### PR TITLE
cic(#1445): pull the channel directory down to refresh

### DIFF
--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -22,9 +22,12 @@
 //   3. CSS CONTRACT (@webkit, iPhone 15): on the real target browser the row
 //      container refuses its own overscroll (so the iOS rubber-band does not
 //      fight the slot at the one scroll position the pull lives at) while
-//      still permitting the browser to pan it. Two POSITIVE assertions, not
-//      one absence: `overscroll-behavior: none` alone would also be satisfied
-//      by a container that had stopped scrolling altogether.
+//      still declaring the ONE axis it can be panned on. Three POSITIVE
+//      assertions, not one absence: `overscroll-behavior: none` alone would
+//      also be satisfied by a container that had stopped scrolling
+//      altogether, and the scroller's own `pan-y` alone would leave the ROW
+//      — the hit-test target across nearly the whole list — still reading
+//      `auto`, which is the shape #913 measured as insufficient.
 //
 // NOT PROVEN ANYWHERE, on purpose rather than by omission:
 //
@@ -201,15 +204,21 @@ test("#1445 — mid-pull the slot moves by the finger's travel, parked offset in
   expect(after - before).toBeCloseTo(travel, 0);
 });
 
-test("@webkit #1445 — the directory list refuses its own overscroll but still pans (iPhone 15)", async ({
+test("@webkit #1445 — the directory list refuses its own overscroll and declares its one pan axis (iPhone 15)", async ({
   page,
 }) => {
   test.slow();
   const { list } = await openDirectory(page, "list-command");
 
   const contract = await list.evaluate((el) => {
+    const row = el.querySelector<HTMLElement>(".directory-row-join");
+    if (row === null) throw new Error("no directory row to hit-test against");
     const s = getComputedStyle(el);
-    return { overscroll: s.overscrollBehaviorY, touchAction: s.touchAction };
+    return {
+      overscroll: s.overscrollBehaviorY,
+      touchAction: s.touchAction,
+      rowTouchAction: getComputedStyle(row).touchAction,
+    };
   });
 
   // `none`, not `contain`: both stop a scroll chaining out of the list, only
@@ -217,9 +226,16 @@ test("@webkit #1445 — the directory list refuses its own overscroll but still 
   // rubber-band that would fight the slot at scrollTop 0, which is the one
   // position the pull exists at.
   expect(contract.overscroll).toBe("none");
-  // And the list must still be pannable. `touch-action: none` here would kill
-  // native scrolling outright, which is why the pull leans on preventDefault
-  // after a claim instead of on a blanket declaration. Asserting the positive
-  // value rather than "not none" so this also fails on a `pan-x` typo.
-  expect(contract.touchAction).toBe("auto");
+  // `pan-y`, not `none` and not `auto`. `none` would kill the native scroll
+  // outright — which is why the pull cancels the pan from JS after a claim
+  // rather than by declaration — and `auto` was still advertising a
+  // horizontal pan and a pinch on a list that `overflow-x: hidden` says
+  // never scrolls sideways.
+  expect(contract.touchAction).toBe("pan-y");
+  // The half that actually decides it. iOS elects the gesture consumer from
+  // the hit-test target's own value and `touch-action` does not inherit, so a
+  // row left at `auto` under a `pan-y` scroller is the exact shape #913
+  // measured as not working. Reverting the descendant rule turns THIS red and
+  // leaves the assertion above green — which is why they are two.
+  expect(contract.rowTouchAction).toBe("pan-y");
 });

--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -1,0 +1,225 @@
+// #1445 — pulling the channel directory's row list down asks for a re-capture,
+// and the spinner slot follows the finger on the way.
+//
+// WHAT THESE PROVE, and what they deliberately do not:
+//
+//   1. THE DOOR (chromium): a synthesized downward drag past the commit
+//      distance puts the Refresh button into its "Refreshing…" state. The
+//      outcome asserted is the visible one, not that a callback fired — and it
+//      is visible precisely BECAUSE the pull goes through the same
+//      `triggerRefresh` the button goes through, so it raises the same store
+//      latch (F1). A gesture wired to a second refresh path would leave the
+//      button reading "Refresh" and turn this red.
+//   2. DISPLACEMENT (chromium): mid-drag, the browser's own computed matrix
+//      says the slot has moved by exactly the finger's travel and by nothing
+//      else. Two things ride on that "and nothing else": the slot rests at
+//      `translateY(-100%)`, which an inline transform REPLACES, so a paint
+//      that forgot to re-state it would read +slotHeight instead of 0 for the
+//      parked term; and the reading is taken mid-gesture, which is only a
+//      stable number because `pull-gesture-active` drops the slot's snap-back
+//      transition — without it getComputedStyle returns wherever the ease
+//      happened to be.
+//   3. CSS CONTRACT (@webkit, iPhone 15): on the real target browser the row
+//      container refuses its own overscroll (so the iOS rubber-band does not
+//      fight the slot at the one scroll position the pull lives at) while
+//      still permitting the browser to pan it. Two POSITIVE assertions, not
+//      one absence: `overscroll-behavior: none` alone would also be satisfied
+//      by a container that had stopped scrolling altogether.
+//
+// NOT PROVEN ANYWHERE, on purpose rather than by omission:
+//
+//   * The FEEL, and with it the whole iOS question. A synthesized TouchEvent
+//     drives no compositor and Playwright's webkit does not reproduce real iOS
+//     scroll physics (feedback_playwright_webkit_not_ios_scroll). Nothing here
+//     says the follow is smooth, that PULL_COMMIT_PX is the right distance, or
+//     — the one that matters most — that iOS elects OUR gesture rather than
+//     its own overscroll in the first place. The binder claims LATE, on a
+//     touchmove, and on a real device the engine may have committed to a pan
+//     before that claim lands. Test 3 asserts the CSS that is supposed to
+//     prevent it; only a phone can say whether it does. That is a vjt call, as
+//     it was for #213 and #1438.
+//   * Interaction with the pane's scroll preservation. A progress ping that
+//     lands WHILE a finger is down rewrites `scrollTop` from a queueMicrotask
+//     (DirectoryPane's entry-count effect). Nothing here holds a finger across
+//     a ping, and nothing here says what happens if one does.
+//   * That the pull is DISCOVERABLE. The gesture is an addition; the button
+//     and the stale CTA remain the discoverable paths, and no assertion here
+//     is about a user finding it.
+//
+// The binder's decision table — which drags claim, which commit, which are
+// left to native scroll — is unit-tested against a bare element in
+// src/__tests__/pullGesture.test.ts, and the pane's wiring in jsdom in
+// src/__tests__/DirectoryPane.test.tsx. These are the end-to-end doors.
+
+import type { Locator, Page } from "@playwright/test";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded here
+// because the e2e tsconfig does not resolve src/ imports; a rename must be
+// propagated by hand, as in every other spec that opens this window.
+const LIST_WINDOW_NAME = "$list";
+
+// PULL_COMMIT_PX from src/lib/pullGesture.ts (SWIPE_MIN_PX * 2). Hardcoded for
+// the same reason — but unlike the window name this copy CHECKS itself: test 2
+// drags half of it and asserts the paint moved by that much, and the paint is
+// capped at the real constant. Lower the real one and this spec reads the cap
+// instead of the drag and goes red, naming the drift.
+const PULL_COMMIT_PX = 80;
+
+// Open the directory pane and hand back its two moving parts.
+//
+// The door is per-layout and there is no layout-agnostic one: on mobile the
+// $list window has NO BottomBar tab and lives behind compose `/list`
+// (issue244's MOBILE arm carries the same note), so `selectChannel` — which is
+// otherwise layout-aware — cannot reach it there. MEASURED, not assumed: the
+// first draft of this spec used it for all three tests and the webkit arm sat
+// 90s on a `.bottom-bar-tab[data-window-name="$list"]` that does not exist.
+//
+// No Refresh click here: `.directory-list` renders inside <Show when={page()}>
+// and the pane's own mount GET is what produces that page, empty snapshot or
+// not. Waiting for the button to read "Refresh" is the load-bearing part — it
+// makes the pane's quiet state the PRE-STATE of every test below, so a
+// "Refreshing…" seen later is the pull's doing and not a capture already in
+// flight from a neighbouring spec.
+async function openDirectory(
+  page: Page,
+  door: "sidebar" | "list-command",
+): Promise<{ list: Locator; refresh: Locator }> {
+  await loginAs(page, specUser());
+  if (door === "sidebar") {
+    await selectChannel(page, NETWORK_SLUG, LIST_WINDOW_NAME);
+  } else {
+    // Focus a channel to get a compose box, then open the directory from it.
+    // expectUnmount: selecting the list window unmounts the ComposeBox (Shell
+    // renders it only for kindHasScrollback kinds), so wait for the unmount
+    // rather than the textarea-empty signal, which races it.
+    const channel = AUTOJOIN_CHANNELS[0];
+    if (channel === undefined) throw new Error("AUTOJOIN_CHANNELS empty");
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+    await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveClass(/selected/, {
+      timeout: 10_000,
+    });
+    await composeSend(page, "/list", { expectUnmount: true });
+  }
+
+  const refresh = page.locator(".directory-refresh");
+  await expect(refresh).toBeVisible({ timeout: 10_000 });
+  const list = page.locator(".directory-list");
+  await expect(list).toBeVisible({ timeout: 30_000 });
+  await expect(refresh).toHaveText("Refresh", { timeout: 60_000 });
+  return { list, refresh };
+}
+
+// One downward drag on the row list, plus the browser's own reading of where
+// the slot sat before and during it. Body inlined in the page rather than
+// passed as a stringified function: `new Function` in page context is eval,
+// and cic serves a CSP with no `unsafe-eval` — the drag would throw where it
+// matters and nowhere else.
+//
+// `dy` is applied in TWO moves because the binder claims LATE: it decides on a
+// touchmove, never on the touchstart. `lift` is optional so a caller can read
+// the paint with the finger still down, which is the only moment it exists.
+async function pullList(
+  list: Locator,
+  dy: number,
+  lift: boolean,
+): Promise<{ before: number; after: number }> {
+  return list.evaluate(
+    (el, opts) => {
+      const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
+      if (slot === null) throw new Error("no pull slot inside the directory list");
+      // The vertical component of the computed matrix — what the browser
+      // actually resolved, not the inline string we wrote.
+      const verticalOffset = (): number =>
+        new DOMMatrixReadOnly(getComputedStyle(slot).transform).f;
+      const at = (y: number): Touch =>
+        new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
+      const fire = (type: string, touch: Touch): void => {
+        const points = type === "touchend" ? [] : [touch];
+        el.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches: points,
+            targetTouches: points,
+            changedTouches: [touch],
+          }),
+        );
+      };
+      // The binder arms only at the top of the scroller, which is where a
+      // freshly opened directory already is. Stated rather than assumed: a
+      // neighbouring assertion that scrolled the list would otherwise turn
+      // this into a silent no-op drag.
+      el.scrollTop = 0;
+      const y0 = 200;
+      const before = verticalOffset();
+      fire("touchstart", at(y0));
+      fire("touchmove", at(y0 + 20));
+      fire("touchmove", at(y0 + opts.dy));
+      const after = verticalOffset();
+      if (opts.lift) fire("touchend", at(y0 + opts.dy));
+      return { before, after };
+    },
+    { dy, lift },
+  );
+}
+
+test("#1445 — a downward pull on the directory asks for the refresh (chromium)", async ({
+  page,
+}) => {
+  test.slow();
+  const { list, refresh } = await openDirectory(page, "sidebar");
+
+  // Comfortably past the commit distance whatever it is exactly, so this spec
+  // asserts the door and not the calibration of a constant it does not own.
+  await pullList(list, PULL_COMMIT_PX * 3, true);
+
+  // The store latch raised by `triggerRefresh` is what makes this immediate
+  // and what makes it evidence: it spans the POST→first-page-GET gap, so the
+  // button flips before any server reply could have arrived. A pull wired
+  // anywhere else would leave it reading "Refresh".
+  await expect(refresh).toHaveText(/^Refreshing/, { timeout: 5_000 });
+  await expect(refresh).toBeDisabled();
+});
+
+test("#1445 — mid-pull the slot moves by the finger's travel, parked offset intact (chromium)", async ({
+  page,
+}) => {
+  test.slow();
+  const { list } = await openDirectory(page, "sidebar");
+
+  // Half the commit distance: under the cap, so a correct paint moves the slot
+  // by exactly what the finger did. The rest position contributes -slotHeight
+  // to this same component, so a paint that dropped it would read
+  // +slotHeight + travel instead. The two failure modes are far apart and the
+  // browser does the arithmetic.
+  const travel = PULL_COMMIT_PX / 2;
+  const { before, after } = await pullList(list, travel, false);
+
+  expect(after - before).toBeCloseTo(travel, 0);
+});
+
+test("@webkit #1445 — the directory list refuses its own overscroll but still pans (iPhone 15)", async ({
+  page,
+}) => {
+  test.slow();
+  const { list } = await openDirectory(page, "list-command");
+
+  const contract = await list.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { overscroll: s.overscrollBehaviorY, touchAction: s.touchAction };
+  });
+
+  // `none`, not `contain`: both stop a scroll chaining out of the list, only
+  // `none` also suppresses the element's OWN overscroll affordance — the iOS
+  // rubber-band that would fight the slot at scrollTop 0, which is the one
+  // position the pull exists at.
+  expect(contract.overscroll).toBe("none");
+  // And the list must still be pannable. `touch-action: none` here would kill
+  // native scrolling outright, which is why the pull leans on preventDefault
+  // after a claim instead of on a blanket declaration. Asserting the positive
+  // value rather than "not none" so this also fails on a `pan-x` typo.
+  expect(contract.touchAction).toBe("auto");
+});

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -17,6 +17,7 @@ import {
 } from "./lib/channelDirectory";
 import { canonicalChannel, channelKey } from "./lib/channelKey";
 import { friendlyApiError } from "./lib/friendlyApiError";
+import { bindPullGesture, PULL_COMMIT_PX } from "./lib/pullGesture";
 import { closeToPreviousWindow, setSelectedChannel } from "./lib/selection";
 import { windowStateByChannel } from "./lib/windowState";
 import { MircBody } from "./MircText";
@@ -62,6 +63,23 @@ import { MircBody } from "./MircText";
 // createEffect on the page's entry COUNT restores it via queueMicrotask so
 // the viewport stays steady while rows update from a progress ping or an
 // append; a REPLACE that shrinks the list snaps back to the top.
+
+// #1445 — the pull slot rests at `translateY(-100%)`, parked one slot-height
+// above the list's top edge and clipped there by the scroller's overflow. An
+// inline transform REPLACES that declaration wholesale, so the pulled paint
+// has to re-state the parked offset or the slot drops into the rows by its own
+// height instead of sliding in from above. Same trap #1438 hit with the media
+// viewer's centering transform, on a different element.
+//
+// Two `translateY` functions rather than one `calc`: they compose to the same
+// matrix, and the resolved form a test can read is `-slotHeight + dy` either
+// way — but this one is legible in an assertion and needs no CSS arithmetic.
+const pulledTransform = (dy: number): string => `translateY(-100%) translateY(${dy}px)`;
+
+// How far the paint is allowed to follow the finger. Past the commit distance
+// the slot stops moving and the gesture is already spent, so more travel would
+// only drag the spinner into the rows it is supposed to sit above.
+const paintedTravel = (dy: number): number => Math.min(dy, PULL_COMMIT_PX);
 
 // Quiet window after the last keystroke before the filter GET fires. Long
 // enough to swallow a burst of typing, short enough that a deliberate pause
@@ -211,6 +229,7 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   // Callback-ref so TypeScript accepts potential undefined (element is inside
   // <Show when={page()}> and only rendered once a page is in the store).
   let containerRef: HTMLDivElement | undefined;
+  let pullSlotRef: HTMLDivElement | undefined;
   let savedScrollTop = 0;
   // The slug currently shown — kept in sync by the effect so onCleanup can
   // reset the right slug without reading props during disposal.
@@ -320,6 +339,50 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
     sentinelObserver.observe(el);
   };
   onCleanup(() => sentinelObserver?.disconnect());
+
+  // #1445 — pull down from the top of the list to ask for a re-capture.
+  //
+  // Painted straight into the DOM rather than through a signal: nothing else
+  // RENDERS from the pulled distance, and a signal here would run the reactive
+  // graph once per touchmove to move one element. Same call MediaViewerModal
+  // makes for the dismiss drag it mirrors.
+  const paintPull = (dy: number): void => {
+    const slot = pullSlotRef;
+    if (slot === undefined) return;
+    const travel = paintedTravel(dy);
+    slot.style.transform = pulledTransform(travel);
+    // The spinner is legible before the commit point, not after it: the ramp
+    // reaches full exactly where the release starts spending a capture, so the
+    // affordance itself says where the line is.
+    slot.style.opacity = String(travel / PULL_COMMIT_PX);
+  };
+
+  const unpaintPull = (): void => {
+    pullSlotRef?.style.removeProperty("transform");
+    pullSlotRef?.style.removeProperty("opacity");
+  };
+
+  // Bound in the ref callback and disposed there too, mirroring
+  // `attachSentinel` above: `.directory-list` lives inside <Show when={page()}>
+  // and can unmount and come back, and Solid does NOT re-invoke a function ref
+  // with undefined at unmount the way React does (#308 landmine 3).
+  let pullDispose: (() => void) | undefined;
+  const attachList = (el: HTMLDivElement): void => {
+    containerRef = el;
+    pullDispose?.();
+    pullDispose = bindPullGesture(el, {
+      // Read LIVE by the binder on every move, never snapshotted: anywhere but
+      // the top of the list the same drag is native scrolling.
+      canPull: () => el.scrollTop === 0,
+      onProgress: paintPull,
+      // THE SAME DOOR the button and the stale CTA use. A second refresh path
+      // would sidestep the store latch that makes those two honest (F1), and
+      // re-open the double-capture this issue closed.
+      onCommit: onRefresh,
+      onRelease: unpaintPull,
+    });
+  };
+  onCleanup(() => pullDispose?.());
 
   const page = () => directoryPage(props.networkSlug);
   const status = () => page()?.status;
@@ -431,14 +494,23 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
               </button>
             </div>
             <div
-              ref={(el) => {
-                containerRef = el;
-              }}
+              ref={attachList}
               class="directory-list"
               onScroll={() => {
                 if (containerRef) savedScrollTop = containerRef.scrollTop;
               }}
             >
+              {/* #1445 — the pulled affordance. Absolutely positioned INSIDE
+                  the scroller: an absolute child is placed against the
+                  scrolled content origin, and the pull exists only at
+                  scrollTop 0, so the two origins coincide by construction —
+                  which buys the plain descendant selector the stylesheet needs
+                  to drop the snap-back transition while a finger is driving.
+                  aria-hidden: the outcome it announces is the Refresh button
+                  going to "Refreshing…", which is already in the a11y tree. */}
+              <div class="directory-pull-slot" aria-hidden="true" ref={pullSlotRef}>
+                <span class="directory-pull-spinner" />
+              </div>
               <ul class="directory-list-inner">
                 <For each={p().entries}>
                   {(entry) => <DirectoryRow entry={entry} networkSlug={props.networkSlug} />}

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -3,6 +3,8 @@ import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DirectoryPage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
+import { PULL_COMMIT_PX } from "../lib/pullGesture";
+import { fireTouch } from "./helpers/touchEvents";
 
 // E3 — DirectoryPane unit suite. Covers:
 //   * mount with undefined page → calls loadDirectory(slug)
@@ -832,6 +834,160 @@ describe("DirectoryPane", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+  // #1445 F3 — the pull gesture on the row list. The binder's own decision
+  // table (what it claims, what it refuses) is covered against a bare element
+  // in pullGesture.test.ts; these are the pane's WIRING: that the pull reaches
+  // the same door the button reaches, that the slot is painted, and that the
+  // listeners die with the pane.
+  //
+  // What jsdom cannot say: whether any of this feels like a pull. A synthetic
+  // touch drives no compositor and jsdom resolves no `touch-action`, so this
+  // pins the transform STRING the pane writes, not that anything tracked a
+  // finger. That half is Playwright's, and the FEEL is a device call.
+  describe("pull to refresh (#1445)", () => {
+    const X = 120;
+    const Y0 = 300;
+
+    const listIn = (container: HTMLElement): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(".directory-list");
+      if (el === null) throw new Error("no directory list rendered");
+      return el;
+    };
+
+    const slotIn = (container: HTMLElement): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(".directory-pull-slot");
+      if (el === null) throw new Error("no pull slot rendered");
+      return el;
+    };
+
+    // Finger down and dragged to `dy`, still on the glass — the mid-pull paint
+    // exists only before the release wipes it. TWO moves because the binder
+    // claims LATE: it decides on a touchmove, never on the touchstart.
+    const pullTo = (target: HTMLElement, dy: number): void => {
+      fireTouch(target, "touchstart", { clientX: X, clientY: Y0 });
+      fireTouch(target, "touchmove", { clientX: X, clientY: Y0 + Math.min(dy, 20) });
+      fireTouch(target, "touchmove", { clientX: X, clientY: Y0 + dy });
+    };
+
+    const pullAndLift = (target: HTMLElement, dy: number): void => {
+      pullTo(target, dy);
+      fireTouch(target, "touchend", { clientX: X, clientY: Y0 + dy });
+    };
+
+    it("a pull past the commit distance asks for the refresh through the SAME door as the button", async () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      pullAndLift(listIn(container), PULL_COMMIT_PX * 3);
+
+      // triggerRefresh, not a second refresh path: the store latch that makes
+      // the button honest (#1445 F1) only guards THAT verb, so a gesture on
+      // any other door would re-open the double-POST this issue closed.
+      await waitFor(() => {
+        expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
+      });
+      expect(triggerRefreshMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("a pull short of the commit distance asks for nothing", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      pullAndLift(listIn(container), Math.round(PULL_COMMIT_PX / 2));
+
+      expect(triggerRefreshMock).not.toHaveBeenCalled();
+      // Positive control: the same pane, pulled far enough, DOES ask. Without
+      // it a binder that never armed at all would pass the assertion above.
+      pullAndLift(listIn(container), PULL_COMMIT_PX * 3);
+      expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
+    });
+
+    it("the slot follows the finger while it is down", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      const travel = Math.round(PULL_COMMIT_PX / 2);
+      pullTo(listIn(container), travel);
+
+      expect(slotIn(container).style.transform).toContain(`translateY(${travel}px)`);
+    });
+
+    it("keeps the slot's parked offset in the pulled transform (an inline transform replaces the rule)", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      pullTo(listIn(container), Math.round(PULL_COMMIT_PX / 2));
+
+      // The slot rests at translateY(-100%), clipped above the list's top
+      // edge. An inline transform REPLACES that declaration wholesale, so a
+      // paint that forgot it would drop the slot into the rows by its own
+      // height instead of sliding it in from above — the #1438 lesson, on a
+      // different element.
+      expect(slotIn(container).style.transform).toContain("translateY(-100%)");
+    });
+
+    it("the paint stops at the commit distance however far the finger goes", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      pullTo(listIn(container), PULL_COMMIT_PX * 4);
+
+      const painted = slotIn(container).style.transform;
+      expect(painted).toContain(`translateY(${PULL_COMMIT_PX}px)`);
+      expect(painted).not.toContain(`translateY(${PULL_COMMIT_PX * 4}px)`);
+    });
+
+    it("the release wipes the paint", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      const list = listIn(container);
+      pullTo(list, Math.round(PULL_COMMIT_PX / 2));
+      expect(slotIn(container).style.transform).not.toBe("");
+
+      fireTouch(list, "touchend", { clientX: X, clientY: Y0 + Math.round(PULL_COMMIT_PX / 2) });
+
+      expect(slotIn(container).style.transform).toBe("");
+    });
+
+    it("a drag that starts scrolled away from the top is left to native scroll", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      const list = listIn(container);
+      list.scrollTop = 200;
+      pullAndLift(list, PULL_COMMIT_PX * 3);
+
+      expect(triggerRefreshMock).not.toHaveBeenCalled();
+      expect(slotIn(container).style.transform).toBe("");
+      // Positive control: the same distance at the top of the list DOES ask,
+      // so this measures the scroll guard and not a dead binder.
+      list.scrollTop = 0;
+      pullAndLift(list, PULL_COMMIT_PX * 3);
+      expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
+    });
+
+    // #308 landmine 3 — Solid does NOT re-invoke a function ref with undefined
+    // at unmount the way React does, so a binder whose disposer is never
+    // called keeps its listeners on a detached element and a stray touch
+    // still spends a server capture.
+    it("unmounting the pane disposes the binder", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container, unmount } = render(() => <DirectoryPane networkSlug={SLUG} />);
+      const list = listIn(container);
+
+      // Pre-state: while mounted, this exact gesture on this exact element
+      // reaches the door. Without it the assertion below cannot tell a
+      // disposed listener from a gesture that never worked.
+      pullAndLift(list, PULL_COMMIT_PX * 3);
+      expect(triggerRefreshMock).toHaveBeenCalledTimes(1);
+
+      unmount();
+      pullAndLift(list, PULL_COMMIT_PX * 3);
+
+      expect(triggerRefreshMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1205,8 +1205,15 @@ html.overlay-open #root > div {
   .login-matrix::before,
   .login-matrix::after,
   .login-spinner,
-  .compose-send-spinner {
+  .compose-send-spinner,
+  .directory-pull-spinner {
     animation: none;
+  }
+  /* #1445 — same call as the swipe-to-reply snap-back below: the slot still
+     follows the finger (that is the gesture's own feedback, not decoration);
+     only the eased return is dropped, so it jumps home. */
+  .directory-pull-slot {
+    transition: none;
   }
   /* #1067 — the swipe-to-reply snap-back. The row still follows the finger
      (that is the gesture's own feedback, not decoration); only the animated
@@ -11732,7 +11739,68 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   overflow-y: auto;
   /* #125 — never scroll horizontally; rows reflow within the viewport. */
   overflow-x: hidden;
-  overscroll-behavior: contain;
+  /* #1445 — `none`, not `contain`. Both stop a scroll chaining out of the
+     list; only `none` also suppresses the element's OWN overscroll affordance,
+     which is the iOS rubber-band that would fight the pulled slot at exactly
+     the position the pull lives — scrollTop 0. Same value and same reason as
+     the body rule (~:492, "kills rubber-band bounce on iOS Safari"). Nothing
+     the `contain` here was protecting is lost: `none` is strictly stronger.
+     NOT accompanied by a `touch-action`: `none` would kill the list's native
+     scroll outright, and the property does not inherit (CSS UI L4), so the
+     `.shell-mobile` blanket never reached this element to begin with.
+     #1445 — `relative` makes the scroller the containing block for the pull
+     slot below. An absolute child is placed against the SCROLLED content
+     origin, and the pull only exists at scrollTop 0, where that origin is the
+     visible top edge. */
+  overscroll-behavior: none;
+  position: relative;
+}
+
+/* #1445 — the pull-to-refresh slot. Parked one slot-height ABOVE the list's
+   top edge, where the scroller's own overflow clips it, and slid into view by
+   the gesture's inline transform (DirectoryPane's `pulledTransform`, which
+   re-states this parked offset because an inline transform replaces the
+   declaration wholesale). `pointer-events: none` so a slot mid-slide never
+   swallows a tap meant for the first row. */
+.directory-pull-slot {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.5rem;
+  opacity: 0;
+  transform: translateY(-100%);
+  transition:
+    transform 150ms ease-out,
+    opacity 150ms ease-out;
+  pointer-events: none;
+}
+
+/* While a finger is driving a CLAIMED pull the binder wears
+   `pull-gesture-active` on the scroller, and the slot must track the finger
+   rather than ease behind it. Reachable as a plain descendant selector only
+   because the slot lives INSIDE the bound element — the reason it is an
+   absolute child rather than a sibling above the list. */
+.directory-list.pull-gesture-active .directory-pull-slot {
+  transition: none;
+}
+
+/* Reuses the `.login-spinner` ring recipe and the shared `login-spin`
+   keyframes, exactly as `.compose-send-spinner` does — a third hand-copied
+   ring is how that recipe would start to drift. In `--accent` like the
+   original: this one sits on the pane background, not on a coloured button. */
+.directory-pull-spinner {
+  box-sizing: border-box;
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border: 2px solid color-mix(in srgb, var(--accent) 25%, transparent);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: login-spin 0.9s linear infinite;
 }
 
 .directory-list-inner {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -11745,15 +11745,41 @@ button.home-pane-network-title:hover .home-pane-network-slug {
      the position the pull lives — scrollTop 0. Same value and same reason as
      the body rule (~:492, "kills rubber-band bounce on iOS Safari"). Nothing
      the `contain` here was protecting is lost: `none` is strictly stronger.
-     NOT accompanied by a `touch-action`: `none` would kill the list's native
-     scroll outright, and the property does not inherit (CSS UI L4), so the
-     `.shell-mobile` blanket never reached this element to begin with.
      #1445 — `relative` makes the scroller the containing block for the pull
      slot below. An absolute child is placed against the SCROLLED content
      origin, and the pull only exists at scrollTop 0, where that origin is the
      visible top edge. */
   overscroll-behavior: none;
   position: relative;
+  /* #1445 — `pan-y`, the value #125 already declared in prose: this list
+     scrolls vertically and `overflow-x: hidden` says it never scrolls
+     sideways, so the horizontal pan and the pinch that `auto` was still
+     advertising were capability the surface does not have. `none` is the
+     value that is wrong here — it would kill the native scroll outright,
+     which is why #1438 can afford it on a modal that does not scroll and
+     this cannot. The pull therefore cancels the pan from JS after a claim
+     (element-level `addEventListener` with `{passive: false}` in
+     `pullGesture.ts`, never a JSX `onTouchMove`: Solid delegates touch to a
+     single PASSIVE document listener where preventDefault silently no-ops). */
+  touch-action: pan-y;
+}
+
+/* #1445 — the DESCENDANT half, and it is the half that does the work. iOS
+   elects the gesture consumer from the HIT-TEST TARGET's own value, and
+   `touch-action` does not inherit (CSS UI L4) — so the row buttons, which are
+   the hit-test target across nearly the whole list, would keep reading `auto`
+   however the scroller above them is declared. #913 measured exactly that:
+   the scroller-only form had shipped for `.members-pane` and did not work,
+   which is why both surviving precedents (`.members-pane *`,
+   `.rail-actions-menu *`) carry the star. This is a third instance of the
+   same shape, not a new idea.
+   NOT verified on a device, and it cannot be from here: neither jsdom nor
+   Playwright's webkit reproduces iOS scroll physics. What IS asserted is the
+   computed value on both elements in the real target engine, which is the
+   deterministic half — the same posture #255 chose, and for the same stated
+   reason. */
+.directory-list * {
+  touch-action: pan-y;
 }
 
 /* #1445 — the pull-to-refresh slot. Parked one slot-height ABOVE the list's

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51865,3 +51865,80 @@ unknown; and nothing here touches the gesture, so none of #1445's
 device-level questions (feel, threshold in px, whether iOS Safari's
 rubber-band at the top of the scroller fights a transform) are answered
 or affected.
+<!-- entry #1445-directory-pull -->
+
+---
+
+## 2026-08-19 — #1445: the pull wired into the pane, and where the CSS decision went
+
+The latch entry above closed the door; this closes the gesture. Three
+things were decided here that the module comments cannot carry on their
+own, because each one is a choice against a plausible alternative.
+
+### The slot lives INSIDE the scroller, and that is a CSS decision
+
+The pulled spinner is an absolutely-positioned FIRST CHILD of
+`.directory-list`, not a sibling above it. An absolute child of a
+scroller is placed against the SCROLLED content origin rather than the
+visible box, which normally makes it the wrong tool — but a pull only
+exists at `scrollTop === 0`, where those two origins are the same point.
+The guarantee is structural, not incidental: the binder refuses to arm
+anywhere else.
+
+What that placement buys is a plain descendant selector. The binder
+wears `pull-gesture-active` on the element it is BOUND to, and the
+stylesheet has to reach the slot from that class to drop its snap-back
+transition while a finger is driving. With the slot as a PRECEDING
+sibling no combinator reaches it at all — `~` only looks forward — and
+the alternative was to put the slot after the list in the DOM and
+position it back to the top, i.e. to reorder the markup to suit a
+selector. The markup would then have lied about what sits above what.
+
+### `overscroll-behavior: contain` -> `none`, and deliberately no `touch-action`
+
+The container's `contain` became `none`. Both values stop a scroll
+chaining out of the list; only `none` also suppresses the element's OWN
+overscroll affordance — the iOS rubber-band, which lives at exactly the
+scroll position the pull lives at and is the one thing on the page that
+would fight the slot. `none` is strictly stronger than what `contain`
+was protecting, so nothing was traded away, and it is the same value and
+the same reason the body rule has carried since iOS-1.
+
+No `touch-action` was added, and that is the deliberate half. `none`
+would kill the list's native scroll outright, which is why #1438 can
+afford it on a modal that does not scroll and this cannot. The property
+does not inherit (CSS UI L4), so the `.shell-mobile` blanket never
+reached this element to begin with — the list has always resolved to
+`auto` and still does. The pull therefore leans on `preventDefault`
+after a claim rather than on a blanket declaration, which is the part
+that cannot be verified off a device: the binder claims LATE, on a
+touchmove, and a real engine may have committed to a pan before the
+claim lands. The webkit e2e arm asserts the CSS that is supposed to
+decide that; it cannot assert that it does.
+
+### Distance only — no flick route, and the asymmetry that chose it
+
+The sibling dismiss binder commits on a short fast flick as well as on
+distance. This one does not, and the reason is a cost asymmetry rather
+than a preference: at the top of a list a flick is the commonest thing a
+finger does, a spurious commit spends an upstream LIST capture and
+disables all three refresh affordances for its whole duration, and a
+spurious spring-back costs one repeated gesture. Adding the flick route
+later is additive; taking it away after it has fired on people is not.
+Standing as a product question with vjt — if it is reversed, it is an
+addition to `bindPullGesture`, not a rewrite of anything here.
+
+### What the tests do and do not settle
+
+The binder's decision table is unit-tested against a bare element, the
+pane's wiring in jsdom, and three doors end-to-end. None of that reaches
+the feel. jsdom drives no compositor and resolves no `touch-action`;
+Playwright's webkit is not iOS. `PULL_COMMIT_PX` is derived from
+`SWIPE_MIN_PX`, not calibrated, and whether it is the right distance —
+like whether the rubber-band actually stands down — is a device call
+that has to be made on a phone with the feature shipped.
+
+One interaction is modelled nowhere: the pane rewrites `scrollTop` from
+a queueMicrotask whenever the entry count changes, so a progress ping
+that lands while a finger is down meets a gesture that assumes it owns
+the scroller. No test holds a finger across a ping.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51904,17 +51904,41 @@ would fight the slot. `none` is strictly stronger than what `contain`
 was protecting, so nothing was traded away, and it is the same value and
 the same reason the body rule has carried since iOS-1.
 
-No `touch-action` was added, and that is the deliberate half. `none`
-would kill the list's native scroll outright, which is why #1438 can
-afford it on a modal that does not scroll and this cannot. The property
-does not inherit (CSS UI L4), so the `.shell-mobile` blanket never
-reached this element to begin with — the list has always resolved to
-`auto` and still does. The pull therefore leans on `preventDefault`
-after a claim rather than on a blanket declaration, which is the part
-that cannot be verified off a device: the binder claims LATE, on a
-touchmove, and a real engine may have committed to a pan before the
-claim lands. The webkit e2e arm asserts the CSS that is supposed to
-decide that; it cannot assert that it does.
+`touch-action` went to `pan-y`, on the scroller AND on its descendants.
+The first draft of this change declared NO `touch-action` at all and
+called that the deliberate half, reasoning that `none` would kill the
+native scroll (true, and why #1438 can afford it on a modal that does
+not scroll) and that the `.shell-mobile` blanket never reached this
+element anyway because the property does not inherit (also true - the
+list has resolved to `auto` since #125). Both facts are correct and
+neither is a defence: they explain why the element is not BROKEN, not
+why leaving it permissive is right. `auto` was still advertising a
+horizontal pan and a pinch on a list whose `overflow-x: hidden` says it
+never scrolls sideways, and this project's standing rule is that a
+touchable surface left at `auto` is a chrome-drag hole on iOS. There was
+no measurement behind the omission, so it was withdrawn rather than
+defended.
+
+The DESCENDANT rule is the half that does the work, and it is a borrowed
+shape rather than a new one. iOS elects the gesture consumer from the
+HIT-TEST TARGET's own value, and `touch-action` does not inherit - so
+the row buttons, which are the hit-test target across nearly the whole
+list, would keep reading `auto` however the scroller above them is
+declared. #913 recorded that exact failure: the scroller-only form had
+already shipped for `.members-pane` and did not work, which is why both
+surviving precedents carry the star. This is the third instance of the
+same shape.
+
+What none of that settles is the claim race. The binder cancels the pan
+from JS after it claims - element-level `addEventListener` with
+`{passive: false}`, never a JSX `onTouchMove`, because Solid delegates
+touch to a single PASSIVE document listener where `preventDefault`
+silently no-ops (#308 landmine 1). But the claim is LATE, on a
+touchmove, and a real engine may have committed to a pan before it
+lands. `pan-y` narrows the axes; it does not make the claim earlier. The
+webkit e2e arm asserts the computed values on both elements - the
+deterministic half, the posture #255 chose for the same stated reason -
+and cannot assert that the gesture wins. That is device-verify.
 
 ### Distance only — no flick route, and the asymmetry that chose it
 


### PR DESCRIPTION
## What this is

F3 of #1445, the last slice: the pull-to-refresh gesture wired into the
channel directory. F1 (the store latch) and F2 (the binder) landed in #1572;
this sits directly on top of it with no divergence, so the diff here is F3
alone.

Four commits: the pane wiring, the end-to-end oracle, the decision log entry,
and a reversal (below) of one call made in the first of them.

## The shape

* `onCommit` goes through `onRefresh` — the **same** `triggerRefresh` the
  Refresh button and the stale CTA use. Not a second refresh path: the pull
  inherits F1's latch instead of re-earning the double-capture #1445 closed.
* The spinner slot is an absolutely-positioned **first child** of
  `.directory-list`. An absolute child of a scroller is placed against the
  scrolled content origin, and a pull only exists at `scrollTop === 0`, where
  that origin *is* the visible top edge — the two agree by construction,
  because the binder refuses to arm anywhere else. What it buys is a plain
  descendant selector: the binder wears its class on the element it is bound
  to, and with the slot as a preceding sibling no combinator reaches it
  (`~` only looks forward). Reordering the DOM to suit a selector would have
  made the markup lie about what sits above what.
* The paint is a direct DOM write, as in `MediaViewerModal`: nothing renders
  from the pulled distance, and a signal would run the reactive graph once per
  touchmove to move one element. It re-states the slot's parked
  `translateY(-100%)` because an inline transform replaces the rule wholesale
  (the #1438 trap, on a different element) and caps at `PULL_COMMIT_PX`.
* Explicit disposer in the ref callback plus `onCleanup`, mirroring
  `attachSentinel`: `.directory-list` lives inside `<Show when={page()}>` and
  can remount, and Solid does not re-invoke a function ref with `undefined`
  at unmount (#308 landmine 3).

## Ratified: distance only, no flick

vjt ruled on this during the session: *a flick that stops short of the
threshold commits nothing and the list springs back; distance is the only
gate, no velocity route.* It was taken here on a cost asymmetry — at the top
of a list a flick is the commonest thing a finger does, a spurious commit
spends an upstream LIST capture and disables all three refresh affordances
for its whole duration, and a spurious spring-back costs one repeated
gesture — and declared reversible at the time. **It is now settled, not
provisional.** Recorded in the decision log so it is not re-opened.

## One call reversed inside this PR

The first commit declared **no** `touch-action` on `.directory-list` and
called that deliberate. The two facts behind it are true — `none` would kill
the native scroll, and the `.shell-mobile` blanket never reached this element
because `touch-action` does not inherit — but they explain why the element is
not broken, not why leaving it permissive is right. `auto` was still
advertising a horizontal pan and a pinch on a list whose `overflow-x: hidden`
has said since #125 that it never scrolls sideways, and a touchable surface
left at `auto` is a chrome-drag hole on iOS. **There was no measurement
behind the omission, so the last commit withdraws it** rather than defending
it: `pan-y` on the scroller and on `.directory-list *`.

The descendant half is the one that does the work. iOS elects the gesture
consumer from the hit-test target's own value, and the row buttons are that
target across nearly the whole list, so a row left at `auto` under a `pan-y`
scroller is exactly the shape #913 recorded as not working — the
scroller-only form had already shipped for `.members-pane` and failed there.
Both surviving precedents carry the star; this is the third.

`overscroll-behavior` also goes `contain` -> `none`. Both stop a scroll
chaining out of the list; only `none` also suppresses the element's own
overscroll affordance, i.e. the iOS rubber-band, which lives at exactly the
scroll position the pull lives at. `none` is strictly stronger than what
`contain` was protecting, and it is the value and the reason the body rule
has carried since iOS-1.

## Also pays a debt from F2

The binder shipped in #1572 without a decision-log entry. The durable part of
it — the no-flick rule and the cost asymmetry that chose it — is recorded
here rather than left in a module comment, where a standing product question
would have been invisible.

## What this pays for in CI

It touches `cicchetto/src/**`, so it pays **five** checks, `integration`
included.

## Gates, measured locally

| gate | result |
| --- | --- |
| `bun run test` (vitest) | 292 files / 5665 tests, rc=0 |
| `bun run check` (biome + tsc) | rc=0, 1060 files, 59 warnings, 6 infos |
| baseline on the parent commit | 1059 files, **59** warnings, 6 infos — zero new |
| `integration.sh` (full) | 758 passed / 1 failed, 29.7m |
| `integration.sh --grep "#1445"` | 3/3 rc=0 |

The test count was pre-registered against the parent's 5657/292 and
reconciles exactly on both axes: +8 tests, no new vitest files (the new spec
is Playwright).

**The one red in the full run was `media-link-modal-viewer.spec.ts:157`, and
it is not this branch's.** It fails inside `loginAs` ->
`waitForUserTopicReady`, a 5s timeout on the WS readiness probe, i.e. before
any code this PR touches has run. Re-running the same test in isolation on
this branch is green in 1.6s. That establishes transient, not whose — it was
not re-run on the base, and no claim is made about that.

**The five e2e specs that click `.directory-refresh` all pass** — the risk F1's
new disabled states carried into this slice. `channel-directory`,
`issue135-visitor-home-landing`, `issue220-link-double-fire` (both arms) and
`issue244-directory-tap-foreground` (all three, including the `@webkit` one).
A full census found six call sites in the suite; none clicks twice and none
asserts the button enabled after a refresh.

## Not measured

* **The last commit's changed webkit assertion has not been run locally.** The
  full-suite and scoped numbers above predate it; the exclusive e2e lane was
  released before the reversal was written, and it was not re-taken. CI is
  the gate for that one assertion.
* **Whether a real iPhone elects this gesture over its own pan.** The binder
  claims LATE, on a touchmove, and an engine may have committed to a scroll
  before the claim lands. `pan-y` narrows the axes; it does not make the claim
  earlier. jsdom resolves no `touch-action` and Playwright's webkit does not
  reproduce iOS scroll physics, so what is asserted is the computed value on
  both elements — the deterministic half, the posture #255 chose for the same
  stated reason. The rest is device-verify.
* **The threshold.** `PULL_COMMIT_PX` is derived from `SWIPE_MIN_PX`, not
  calibrated. Whether 80px is right is a phone call.
* **A progress ping landing while a finger is down.** The pane rewrites
  `scrollTop` from a `queueMicrotask` on every entry-count change, and no test
  holds a finger across a ping. Stated in the decision log and in the spec
  header.
* **Flakiness of the new spec.** Three runs, one red for a reason since fixed.
  Three runs are not a stability measurement.
