### PR TITLE
#1397: remove two duplicated test cases, refuse three, and retire the last e2e login copy

### DIFF
--- a/cicchetto/e2e/tests/issue252-vhost-selector.spec.ts
+++ b/cicchetto/e2e/tests/issue252-vhost-selector.spec.ts
@@ -24,25 +24,15 @@
 // Per feedback_cicchetto_browser_smoke + feedback_ux_e2e_mandatory this
 // exercises the real CSS/DOM render path jsdom can't.
 
-import { expectShellReady, openAdminConsole, openSettingsDrawer } from "../fixtures/cicchettoPage";
+import {
+  adminLogin,
+  loginAs,
+  openAdminConsole,
+  openSettingsDrawer,
+} from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
-
-type Seed = ReturnType<typeof getSeededAdmin>;
-
-async function loginAs(page: import("@playwright/test").Page, seed: Seed): Promise<void> {
-  await page.addInitScript(
-    ([token, subjectJson]) => {
-      localStorage.setItem("grappa-token", token);
-      localStorage.setItem("grappa-subject", subjectJson);
-      localStorage.setItem("cic.installChoice", "browser");
-    },
-    [seed.token, seed.subjectJson] as const,
-  );
-  await page.goto("/");
-  await expectShellReady(page);
-}
 
 async function openVhostsTab(page: import("@playwright/test").Page): Promise<void> {
   await openAdminConsole(page);
@@ -115,7 +105,7 @@ test("#252 admin curates a vhost; a user customizes it via the sub-page and it p
 
   try {
     // --- Admin creates an in-pool, generally-available vhost via the UI ---
-    await loginAs(page, admin);
+    await adminLogin(page, admin);
     await openVhostsTab(page);
 
     await page.getByTestId("vhost-address-select").selectOption(candidate);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52091,3 +52091,108 @@ nor a lower bound, since a site inside a `defp` costs one hash per call and one
 inside a `setup` costs one per test. The before side of the timing is a single
 run against three after runs; the after spread is 1.6s and the gap is 20s, but
 one run is one run.
+<!-- entry #1397-dupe-cases -->
+
+---
+
+## 2026-08-19 — #1397: two duplicated test CASES, two refusals, and the strip-comments regex that ate half of every body
+
+vjt's standing ruling — *"if we have duplicated tests, remove them"* — names a
+population #1397 had never counted. #1397 censuses duplicated helper
+DEFINITIONS (152 over 102 files at filing); a duplicated test CASE is the same
+assertion written twice. The two sets barely intersect, and this entry records
+measuring the second one, removing the two it proves, and refusing three
+candidates it does not.
+
+### The criterion is declared before the count, or the count means nothing
+
+Three criteria, strictest first, over `test "..." do` (ExUnit) and
+`it(...)`/`test(...)` (vitest, Playwright) on `a45428c6`:
+
+  * **D1** — normalised BODY identical (comments stripped, whitespace collapsed,
+    bodies under 40 characters dropped). Names ignored.
+  * **D2** — identical MULTISET of assertion lines (≥ 2), setup ignored.
+  * **D3** — identical test NAME. Weak by construction; carried for completeness.
+
+Calibration, stated with the numbers because a parser nobody calibrated is a
+number nobody can use: 6321 ExUnit blocks against 6346 naked-grep `test "`
+lines (**99.6%**), 5223 vitest cases against the 5665 the suite reports
+(**92.2%** — the gap is tabular `it.each`, declared and not closed), 746
+Playwright cases with no known total to check against.
+
+| criterion | ExUnit | of which cross-file | vitest | e2e |
+| --- | --- | --- | --- | --- |
+| D1 | 4 groups / 8 tests | 3 / 6 | 13 / 32 | 0 |
+| D2 | 131 / 314 | 13 / 36 | — | — |
+| D3 | 126 / 384 | 60 / 223 | 59 / 133 | 0 |
+
+### The first D1 number was 44 groups, and it was the tool
+
+The strip-comments pass was `#[^\n]*`. Every channel in this codebase is
+written `"#chan"`, so the regex cut each body at its first channel literal and
+left the identical prefix behind: four tests in `session_test.exs` that pass
+`"hi\r\nQUIT"`, `"#chan\r\nQUIT"`, `"hi\nbye"` and `"hi\x00bye"` hashed the
+same. Replacing it with a lexer that knows string boundaries takes D1 from
+**44 groups / 107 tests to 4 / 8**.
+
+🥇 The general form: **an all-identical result accuses the oracle exactly as an
+all-red one does.** A plausible count from a broken instrument is the failure
+mode this repo keeps paying for, and the defence is the same either way — one
+naked grep the instrument has to agree with.
+
+### The two that were removed, proven on content
+
+  * `auth_controller_test.exs` held *"captcha_token > 4096 bytes → 400"*
+    (M-web-3) and *"visitor branch — oversize captcha_token also 400 (W3)"*
+    with byte-identical bodies, both inside
+    `describe "POST /auth/login (visitor via nick)"` — so the second's "visitor
+    branch ALSO" names the branch the first already dispatched through. Its
+    non-binary sibling, by contrast, genuinely differs (`[1, 2, 3]` against
+    `42`), which is what marks the oversize pair as a slip rather than a design.
+  * `share_token_controller_test.exs` held a one-assertion describe,
+    `ShareTokens.table_name() == :share_tokens_used`, which is
+    `share_tokens_test.exs`'s own `describe "table_name/0"` verbatim. The
+    function is pure, so neither copy depends on its file's setup.
+
+Measured on the two touched files: **98 tests before, 96 after, 0 failures on
+both sides** — the two-sided run is what attributes the delta to the removals
+rather than to the suite.
+
+### The three that were refused, and why a refusal is worth as much
+
+  * **Setup is content.** `messages_controller_test.exs:543` and
+    `messages_controller_outbound_test.exs:520` both read
+    *"unknown network slug returns 404"* with identical bodies, but their
+    modules' setups differ (one binds a credential, the other starts a session
+    against the fake IRC server) and the second sits beside the *"known slug
+    but no session"* test that closes the probing oracle. Identical bodies
+    under different ambient state are not one test.
+  * **Identical text, different binding.** `wireNarrow.test.ts` has eight
+    `expect(narrowAdminEvent(valid)).toEqual(valid)` bodies; each `describe`
+    declares its own `const valid` for a different admin-event kind. No textual
+    criterion can see that, which is the honest limit of the whole method.
+  * **A name census proposed a fold that content refuses.** The last
+    `credential_fixture` copy outside `test/support` — in
+    `networks/credentials/admin_wire_test.exs` — was in the approved slice on my
+    own proposal. It builds an in-memory `%Credential{}` carrying sentinel
+    secrets (`"decrypted-plaintext-MUST-NEVER-LEAK"`) so the admin-wire test can
+    prove they never reach the JSON; the canonical `credential_fixture/3`
+    INSERTS through `Credentials.bind_credential/3` and cannot carry them.
+    Same name, different verb — the `visitor_fixture` shape again. Folding it
+    would have traded a leak oracle for a database write.
+
+That leaves the server half of bucket H at **zero** true duplicated helper
+copies: four `visitor_fixture` and one `credential_fixture`, all deliberate.
+
+### The last e2e helper copy
+
+`issue252-vhost-selector.spec.ts` defined a local `loginAs` that was
+`adminLogin`'s body under another name. The suite's own idiom decides where each
+call site lands — 20 spec files call `adminLogin` and every one passes an admin
+seed, 333 call `loginAs` — so the admin goes to `adminLogin` (behaviour
+identical to the deleted helper, nothing changes) and the ordinary user to the
+canonical `loginAs`, which additionally waits for the per-network header and for
+`waitForUserTopicReady`. That barrier is the one #1397 was filed over; here it
+was **latent, not live** (the spec composes no `/join`), so the fold buys
+determinism and does not fix a race — a race that was never reproduced is not
+claimed.

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -743,6 +743,11 @@ defmodule GrappaWeb.AuthControllerTest do
     # boundary contract: every shape rejected by validate_captcha_token MUST
     # 400 BEFORE any Login.login/2 work, regardless of which branch
     # IdentifierClassifier dispatches to (visitor included).
+    #
+    # Only the non-binary shape is pinned here. The oversize shape of the
+    # same contract is the M-web-3 test above — same describe, same
+    # `identifier: "vjt"`, so it already dispatches through this visitor
+    # branch. A second copy asserted nothing the first did not (#1397).
     test "visitor branch — non-binary captcha_token also 400 bad_request (W3)",
          %{conn: conn} do
       # `vjt` (no `@`) routes through IdentifierClassifier → :nick →
@@ -751,13 +756,6 @@ defmodule GrappaWeb.AuthControllerTest do
       # captcha_token is passed as an explicit param so the validated
       # value is the only source.
       conn = post(conn, "/auth/login", %{"identifier" => "vjt", "captcha_token" => [1, 2, 3]})
-      assert json_response(conn, 400)["error"] == "bad_request"
-    end
-
-    test "visitor branch — oversize captcha_token also 400 bad_request (W3)",
-         %{conn: conn} do
-      huge = String.duplicate("a", 4097)
-      conn = post(conn, "/auth/login", %{"identifier" => "vjt", "captcha_token" => huge})
       assert json_response(conn, 400)["error"] == "bad_request"
     end
 

--- a/test/grappa_web/controllers/share_token_controller_test.exs
+++ b/test/grappa_web/controllers/share_token_controller_test.exs
@@ -543,12 +543,6 @@ defmodule GrappaWeb.ShareTokenControllerTest do
     end
   end
 
-  describe "ShareTokens module ETS sanity" do
-    test "table_name is reachable from the test harness" do
-      assert ShareTokens.table_name() == :share_tokens_used
-    end
-  end
-
   describe "telemetry" do
     setup do
       handler = "share-token-telemetry-#{System.unique_integer([:positive])}"


### PR DESCRIPTION
Bucket H of the 2026-08-15 architecture review, under vjt's standing ruling
("if we have duplicated tests, remove them"). That ruling names a population
#1397 had never counted: #1397 censuses duplicated helper DEFINITIONS, while a
duplicated test CASE is the same assertion written twice. The two sets barely
intersect, so this PR measures the second one and acts only where the content
proves it.

## The criterion, declared before the count

Three criteria over `test "..." do` (ExUnit) and `it(...)` / `test(...)`
(vitest, Playwright), measured on `a45428c6`:

* **D1** — normalised BODY identical (comments stripped, whitespace collapsed,
  bodies under 40 characters dropped), names ignored;
* **D2** — identical MULTISET of assertion lines (>= 2), setup ignored;
* **D3** — identical test NAME, carried only for completeness.

Parser calibration, published with the numbers: 6321 ExUnit blocks against 6346
naked-grep `test "` lines (**99.6%**), 5223 vitest cases against the suite's own
5665 (**92.2%** — the gap is tabular `it.each`), 746 Playwright cases with no
known total to check against.

| criterion | ExUnit | of which cross-file | vitest | e2e |
| --- | --- | --- | --- | --- |
| D1 | 4 groups / 8 tests | 3 / 6 | 13 / 32 | 0 |
| D2 | 131 / 314 | 13 / 36 | — | — |
| D3 | 126 / 384 | 60 / 223 | 59 / 133 | 0 |

**The first D1 number was 44 groups / 107 tests, and it was the instrument.**
The strip-comments pass was `#[^\n]*`; every channel here is written `"#chan"`,
so the regex cut each body at its first channel literal and hashed the identical
prefixes together — four `session_test.exs` tests passing `"hi\r\nQUIT"`,
`"#chan\r\nQUIT"`, `"hi\nbye"` and `"hi\x00bye"` came out "identical". With a
string-aware lexer: 44 -> 4.

## What is removed (two cases, proven on content)

* `auth_controller_test.exs` — *"captcha_token > 4096 bytes -> 400"* (M-web-3)
  and *"visitor branch — oversize captcha_token also 400 (W3)"* had byte-identical
  bodies inside the SAME `describe "POST /auth/login (visitor via nick)"`, so the
  second's "visitor branch ALSO" names the branch the first already dispatched
  through. Its non-binary sibling genuinely differs (`[1, 2, 3]` vs `42`), which
  is what makes the oversize collision a slip rather than a design. The W3
  comment gains a sentence naming where the oversize shape stays pinned.
* `share_token_controller_test.exs` — a one-assertion describe whose whole body is
  `assert ShareTokens.table_name() == :share_tokens_used`, which is
  `share_tokens_test.exs`'s `describe "table_name/0"` verbatim. Pure function,
  no setup dependency either side.

## What is REFUSED, and why that is half the value

* **Setup is content.** `messages_controller_test.exs:543` and
  `messages_controller_outbound_test.exs:520` both read *"unknown network slug
  returns 404"* with identical bodies, but their modules' setups differ (one binds
  a credential, the other starts a session against the fake IRC server) and the
  second sits beside the *"known slug but no session"* test that closes the
  probing oracle. Not touched.
* **Identical text, different binding.** `wireNarrow.test.ts` has eight
  `expect(narrowAdminEvent(valid)).toEqual(valid)` bodies; each `describe`
  declares its own `const valid` for a different admin-event kind. Eight false
  positives, and the honest limit of any textual criterion. Not touched.
* **A name census proposed a fold the content refuses — and it was my own
  proposal.** The last `credential_fixture` copy outside `test/support` builds an
  in-memory `%Credential{}` carrying sentinel secrets
  (`"decrypted-plaintext-MUST-NEVER-LEAK"`) so the admin-wire test can prove they
  never reach the JSON; the canonical `credential_fixture/3` INSERTS through
  `Credentials.bind_credential/3` and cannot carry them. Same name, different
  verb — the `visitor_fixture` shape again. Retracted, not folded.

With that retraction the server half of bucket H is at **zero** true duplicated
helper copies: four `visitor_fixture` plus one `credential_fixture`, all
deliberate.

## The last e2e helper copy

`issue252-vhost-selector.spec.ts` defined a local `loginAs` that was
`adminLogin`'s body under another name. The suite's own idiom decides the two
call sites — 20 spec files call `adminLogin`, every one with an admin seed; 333
call `loginAs`:

* the admin (`getSeededAdmin()`, no credentials bound) -> `adminLogin`,
  behaviour-identical to the deleted helper;
* the ordinary user (`specUser()`) -> canonical `loginAs`, which additionally
  waits for the per-network header and for `waitForUserTopicReady`.

That barrier is what #1397 was filed over. Here it was **latent, not live** — the
spec composes no `/join` — so the fold buys determinism, not a bug fix.

## Measurement

| gate | result |
| --- | --- |
| scoped `mix test`, the two touched files, BASE | **98 tests, 0 failures** |
| scoped `mix test`, the two touched files, BRANCH | **96 tests, 0 failures** |
| `scripts/check.sh` | rc=0 — 8 doctests, 61 properties, **6560 tests, 0 failures**; dialyzer passed; credo 6060 mods/funs, no issues; sobelow 0 errors; bats green |
| `scripts/bun.sh run check` | rc=0 — 1060 files, 59 warnings, 6 infos (identical to base) |
| `scripts/integration.sh --grep '#252'` | 1 passed (1.9s) |
| `scripts/integration.sh` (full) | **757 passed, 2 failed** in 28.9m |

The two-sided scoped run is what attributes the -2: same two files, base 98 ->
branch 96, zero failures on both sides.

**The two e2e failures are one pre-existing mechanism, not this branch.** Both
died in `waitForUserTopicReady`'s 5s barrier inside the canonical `loginAs`
(`cicchettoPage.ts:680`), in `issue1041-left-edge-sidebar.spec.ts:94` and
`issue173-compose-recall-caret-visible.spec.ts:74` — two specs this branch does
not touch, both of which already called the canonical `loginAs` before it. The
iso-rerun of exactly those two is green in **1.5s and 1.2s** against the 32s
timeouts of the full run. The same mechanism produced the single red of the last
full-suite run recorded on a previous base (`17cd0f77`,
`media-link-modal-viewer.spec.ts:157`, also inside
`loginAs -> waitForUserTopicReady`).

## Not established

* That the two e2e reds cannot recur — they are a timing race under a 29-minute
  single-worker run, and a seeded rerun cannot attribute a timing race in either
  direction. What is established is the mechanism and that it predates this branch.
* The whole-suite base count. 6560 is the branch; the predicted base is 6562 and
  was not run — the attribution rests on the two-sided scoped run instead.
* That D1 = 4 is "the number of duplicated tests". It is the number under one
  textual criterion at 99.6% / 92.2% coverage. Semantic duplication — two tests
  proving the same thing written differently — is invisible to this method.
* The 13 cross-file D2 groups (36 tests) and the 13 vitest D1 groups (32 tests)
  are counted, NOT judged. The counter proposes; the content decides, and that
  reading has not been done.