### PR TITLE
test(#1397): drop three vitest cases a mutant cannot tell from their twin

### DIFF
--- a/cicchetto/src/__tests__/linkify.test.ts
+++ b/cicchetto/src/__tests__/linkify.test.ts
@@ -229,12 +229,6 @@ describe("linkify", () => {
     it("empty string returns single empty text segment", () => {
       expect(linkify("")).toEqual([{ type: "text", value: "" }]);
     });
-
-    it("text without protocol prefix is not a URL", () => {
-      expect(linkify("just example.com no scheme")).toEqual([
-        { type: "text", value: "just example.com no scheme" },
-      ]);
-    });
   });
 
   describe("IDN pass-through", () => {

--- a/cicchetto/src/__tests__/pushDedup.test.ts
+++ b/cicchetto/src/__tests__/pushDedup.test.ts
@@ -40,12 +40,4 @@ describe("shouldSuppressPush", () => {
   it("does NOT suppress when there are no windows (PWA closed)", () => {
     expect(shouldSuppressPush([])).toBe(false);
   });
-
-  it("ignores URL — visible window suppresses regardless of pathname", () => {
-    // Pre-L the gate compared client.url to payload.url. L drops the
-    // URL match entirely — once cic is foreground the in-app beep
-    // covers the alert, regardless of which channel/window is on top.
-    const clients: ClientLike[] = [{ visibilityState: "visible" }];
-    expect(shouldSuppressPush(clients)).toBe(true);
-  });
 });

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1305,7 +1305,10 @@ describe("parseSlash — /notify + /watch presence (#356: irssi-direct, bare →
 
 describe("#385 — expandAlias grammar", () => {
   it("positional $1 substitution (whois-with-idle motivating example)", () => {
-    // /wii foo → whois foo foo
+    // /wii foo → whois foo foo. This also pins the NO-implicit-append half of
+    // the rule: the expansion carries a placeholder, so the raw rest is not
+    // appended on top of it — that would read `foo foo foo`. The sibling case
+    // below pins the other half, the append when there is no placeholder.
     expect(expandAlias("wii", "foo", { wii: "whois $1 $1" })).toEqual({
       verb: "whois",
       rest: "foo foo",
@@ -1317,14 +1320,6 @@ describe("#385 — expandAlias grammar", () => {
     expect(expandAlias("w2", "foo bar", { w2: "whois" })).toEqual({
       verb: "whois",
       rest: "foo bar",
-    });
-  });
-
-  it("no implicit append when a placeholder is present (no triple-arg)", () => {
-    // alias wii whois $1 $1 + /wii foo → whois foo foo (NOT foo foo foo)
-    expect(expandAlias("wii", "foo", { wii: "whois $1 $1" })).toEqual({
-      verb: "whois",
-      rest: "foo foo",
     });
   });
 


### PR DESCRIPTION
Thirteen candidate duplicate groups in `cicchetto/src/__tests__/**` were
judged one by one, re-derived on `51eaa6c1`. Three tests go; ten groups
stay, each for a stated reason.

## The criterion

A group is a real duplicate when the two tests call the same function on
the same input with the same oracle **and the same setup**. That is
decidable rather than aesthetic: when it holds, no change to the code
under test can fail one and pass the other, so the second copy adds no
coverage — only a second site to keep in step.

Seven groups met it. Three of those seven also had a reason to be the
copy that goes:

| removed | why this one |
| --- | --- |
| `linkify.test.ts` "text without protocol prefix is not a URL" | repeats the #212 guard "does NOT linkify a bare domain with no path", and the name is stale: since #212, text without a protocol prefix *is* linkified when it carries a path — asserted twelve lines above it |
| `pushDedup.test.ts` "ignores URL — visible window suppresses regardless of pathname" | `shouldSuppressPush` takes only the client list, so there is no URL for it to ignore; it re-ran the first case of its own describe. The rationale it carried is already in the file header |
| `slashCommands.test.ts` "no implicit append when a placeholder is present (no triple-arg)" | same `expandAlias` call as the motivating example sixteen lines above, same describe. The property it named is real, so it moves into that test's comment |

The other four execution-identical groups stay: they sit at a second
feature's site as deliberate cross-guards (a `/notice` alias-collision
pin, a #418 legacy-fallback pin, a #385 default-arg pin, and the
`src/__tests__` ÷ `src/lib/__tests__` split on `customTheme`).

## The six that were never duplicates

Four fail the criterion on **setup**: a `beforeEach` seeding a visitor
subject, a nested `beforeEach` deleting `crypto.randomUUID`, and eight
`narrowAdminEvent` arms that each declare their own `valid` for a
different event kind.

Two more are **positive controls**: `api.test.ts:990` is literally named
"— the control" and is the only proof that five neighbouring
`not.toHaveBeenCalled()` assertions can fail at all; `replyQuote.test.ts:299`
is the old-spelling arm of a both-spellings pair. Deleting either leaves
a live assertion unable to fail.

## Gates

* `scripts/bun.sh run test` — rc=0, 292 files, 5662 tests.
* `scripts/bun.sh run check` — rc=0 (biome 2.5.8, the declared version).
* Effect measured on both sides by the runner, scoped to the three
  files: 312 → 309 tests, green before and after; per file 5→4, 51→50,
  256→255.

Touches `cicchetto/**` only.