### PR TITLE
#1522: the eight bats reds are an ambient GRAPPA_CACHE_ID, not the gate

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52196,3 +52196,79 @@ canonical `loginAs`, which additionally waits for the per-network header and for
 was **latent, not live** (the spec composes no `/join`), so the fold buys
 determinism and does not fix a race — a race that was never reproduced is not
 claimed.
+<!-- entry #1522 -->
+
+---
+
+## 2026-08-20 — #1522: the eight bats reds are an ambient `GRAPPA_CACHE_ID`, not the gate
+
+#1522 reported eight bats cases that fail "only when run through
+`scripts/check.sh`" and pass under `scripts/bats.sh`, identically on a clean
+`origin/main`, and concluded that "the difference that remains is `check.sh`
+itself". **That premise is false, and the correction is the finding.** The
+variable is an ambient `GRAPPA_CACHE_ID` in the caller's shell; `check.sh` is
+merely the command it happened to be attached to.
+
+### Measured by displacement, one variable at a time
+
+On `74a20af1`, from a clean worktree:
+
+| run | result |
+| --- | --- |
+| `scripts/check.sh`, whole gate, no cache id | **rc=0, 564/564 bats green** |
+| the three files alone, no cache id | 14/14 green |
+| the three files alone, `GRAPPA_CACHE_ID=w2probe` | **rc=1, the eight, by name** |
+| full `scripts/bats.sh`, cache id set, after the fix | 566/566 green |
+| full `scripts/bats.sh`, no cache id, after the fix | 566/566 green |
+
+Three intermediate displacements were run first and all came back green, which
+is what excluded the gate: the invocation SHAPE (`cd $REPO_ROOT` then
+`$SRC_ROOT/scripts/bats.sh`, exactly as `check.sh` calls it, with no `mix` at
+all), a preceding `scripts/mix.sh --env=dev compile`, and the whole gate. And
+`git log 259780f3..74a20af1 -- scripts/ test/scripts/ test/infra/ test/bin/
+infra/lib/ mix.exs` is **empty** — 125 commits, none touching the gate or the
+tests — so nothing was repaired in between and the base is not the variable
+either.
+
+### The mechanism, and why nothing under test was wrong
+
+`deploy.sh` refuses to run while the knob is set, by design (#1409): *"only
+'compose run' accepts -v, so the oneshots would use the per-id caches while
+'compose up' boots the container from the shared ones."* The eight cases all
+drive a deploy door, so they die on that refusal — with a message about
+deploying, in a run about something else. The tests are right, the refusal is
+right, and no assertion was weakened to make them pass.
+
+Two of the issue's own details do not survive the measurement either: the four
+`standalone door` cases live in `test/infra/deploy_docker_convergence_test.bats`,
+not in `test/scripts/mix_env_db_test.bats` where the issue files them, and the
+red is a false RED rather than a vacuous green.
+
+### The cure is at the door, because the leak is a class
+
+#1409 already found this leak and cured it **per file** — `unset MIX_ENV
+GRAPPA_CACHE_ID` in `deploy_docker_test.bats`, `unset GRAPPA_CACHE_ID` in
+`deploy_docker_update_test.bats` — in two of the five files that reach a deploy
+door. The other three never got the line, and a sixth file written tomorrow
+would not get it either. The class is "any bats case that reaches a deploy
+door", so `scripts/bats.sh` drops the knob once, **before `_lib.sh` reads it**
+(so no `.caches/<id>` is provisioned and no `MIX_TEST_PARTITION` is derived for
+a door that runs no `mix`), and says so on stderr rather than silently. The two
+per-file `unset`s stay: they also cover a direct `vendor/bats-core/bin/bats`
+invocation, which never passes through the door.
+
+`test/scripts/bats_ambient_cache_id_test.bats` pins it the way the #592 suite
+next door does — a recorder stands in for the bats binary and dumps the
+environment it was handed, with a `GRAPPA_BATS_PROBE=present` control so the
+asserted absence cannot be an empty log. RED before the fix on exactly that
+assertion, green after.
+
+### What is not claimed
+
+The reporter's own table lists a full `scripts/bats.sh` run as green *"with the
+same GRAPPA_CACHE_ID"*; measured here, a full run with the knob set is red on
+those eight (before the fix). Either the standalone runs did not in fact carry
+the id, or something else differed in that session — that cell was not
+reconciled and nothing here depends on it. No claim is made about other
+ambient knobs: `MIX_ENV` was already neutralised per file by the fixtures that
+need it, and no census of the remaining environment surface was run.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52248,9 +52248,14 @@ red is a false RED rather than a vacuous green.
 
 #1409 already found this leak and cured it **per file** — `unset MIX_ENV
 GRAPPA_CACHE_ID` in `deploy_docker_test.bats`, `unset GRAPPA_CACHE_ID` in
-`deploy_docker_update_test.bats` — in two of the five files that reach a deploy
-door. The other three never got the line, and a sixth file written tomorrow
-would not get it either. The class is "any bats case that reaches a deploy
+`deploy_docker_update_test.bats` — in two files. **A first pass here said "two
+of the five files that reach a deploy door" and that number was derived (the
+two cured plus the three red), not censused.** Censused: `git grep -l` for the
+deploy door script names over `test/**/*.bats` returns **twenty** files, of
+which **eighteen** carry no unset. Which of the other fifteen merely never
+reach the guard — the jail and Linux doors do not carry it — was not measured;
+what the census establishes is that the exposed set is far wider than the three
+that happen to go red today, and that a file written tomorrow inherits nothing. The class is "any bats case that reaches a deploy
 door", so `scripts/bats.sh` drops the knob once, **before `_lib.sh` reads it**
 (so no `.caches/<id>` is provisioned and no `MIX_TEST_PARTITION` is derived for
 a door that runs no `mix`), and says so on stderr rather than silently. The two

--- a/scripts/bats.sh
+++ b/scripts/bats.sh
@@ -8,6 +8,29 @@
 # Bats runs ON THE HOST (vendor/bats-core submodule, pinned to v1.9.0),
 # against host-side scripts — no docker compose involvement.
 
+# GRAPPA_CACHE_ID is dropped HERE, before _lib.sh reads it (#1522).
+#
+# The knob (#1263) binds `.caches/<id>` over `_build`, `deps` and
+# `priv/plts` so two workers can run `mix` at once. This door runs no mix —
+# but the Docker deploy scripts REFUSE to start while it is set (#1409:
+# only `compose run` accepts `-v`, so the oneshots would use the per-id
+# caches while `compose up` boots from the shared ones). So every bats case
+# that drives a deploy door dies on that refusal when the caller's shell
+# carries an id: eight cases across three files, failing with a message
+# about deploying that has nothing to do with the code under test.
+#
+# #1409 cured the same leak per-file, in two of the five files that reach a
+# deploy door; the class is "any bats case reaching a deploy door", so the
+# cure belongs at the door, where a case written tomorrow inherits it. The
+# two per-file `unset`s stay: they also cover a direct `vendor/bats-core/
+# bin/bats` invocation, which never passes through here.
+#
+# Dropping a variable the caller set is stated out loud, not silently.
+if [ -n "${GRAPPA_CACHE_ID:-}" ]; then
+    printf 'scripts/bats.sh: ignoring GRAPPA_CACHE_ID=%s — bats runs no mix, and the deploy doors refuse while it is set (#1522).\n' "$GRAPPA_CACHE_ID" >&2
+    unset GRAPPA_CACHE_ID
+fi
+
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 

--- a/scripts/bats.sh
+++ b/scripts/bats.sh
@@ -19,9 +19,10 @@
 # carries an id: eight cases across three files, failing with a message
 # about deploying that has nothing to do with the code under test.
 #
-# #1409 cured the same leak per-file, in two of the five files that reach a
-# deploy door; the class is "any bats case reaching a deploy door", so the
-# cure belongs at the door, where a case written tomorrow inherits it. The
+# #1409 cured the same leak per-file, in two files. Censused after the fact:
+# TWENTY bats files drive a deploy door by name and eighteen carry no unset,
+# so the class is "any bats case reaching a deploy door" and the cure belongs
+# at the door, where a case written tomorrow inherits it. The
 # two per-file `unset`s stay: they also cover a direct `vendor/bats-core/
 # bin/bats` invocation, which never passes through here.
 #

--- a/test/scripts/bats_ambient_cache_id_test.bats
+++ b/test/scripts/bats_ambient_cache_id_test.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+#
+# #1522 — scripts/bats.sh must not hand an ambient GRAPPA_CACHE_ID to the
+# bats process.
+#
+# GRAPPA_CACHE_ID (#1263) is a MIX cache knob: it binds `.caches/<id>` over
+# `_build`, `deps` and `priv/plts` so two workers can compile at once. The
+# bats door runs no mix at all — but scripts/_lib.sh reads the knob, and the
+# Docker deploy doors REFUSE to run while it is set (#1409: only `compose
+# run` accepts `-v`, so the oneshots would use the per-id caches while
+# `compose up` boots from the shared ones). So every bats case that drives a
+# deploy door dies on that refusal when the worker's shell carries an id —
+# eight cases across three files, with a message about deploying that has
+# nothing to do with the code under review. #1522 read that red as a
+# property of scripts/check.sh; it is not, and check.sh is green without the
+# knob.
+#
+# #1409 cured the same leak per-file (`unset GRAPPA_CACHE_ID` in
+# deploy_docker_test.bats and deploy_docker_update_test.bats) and the three
+# other files that drive a deploy door were never given the line. The class
+# is "any bats case reaching a deploy door", so the cure belongs at the
+# door, where a future case inherits it without remembering.
+#
+# Like the #592 suite next door, this asserts on the CONSTRUCTED invocation
+# rather than faking a real run: a recorder stands in for the bats binary
+# and dumps the environment it was handed.
+
+load ../bats_helpers
+
+setup() {
+    BATS_SH="$BATS_TEST_DIRNAME/../../scripts/bats.sh"
+    LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
+
+    # Physical (symlink-resolved) base so _lib.sh's pwd-derived SRC_ROOT and
+    # git's --git-common-dir agree on macOS (/var -> /private/var).
+    TMP="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
+    ENV_LOG="$TMP/env.log"
+    : > "$ENV_LOG"
+
+    MAIN="$TMP/main"
+    git init -q -b main "$MAIN"
+    git -C "$MAIN" config user.email test@grappa.local
+    git -C "$MAIN" config user.name bats
+    mkdir -p "$MAIN/scripts" "$MAIN/lib" "$MAIN/vendor/bats-core/bin" "$MAIN/test"
+    cp "$BATS_SH" "$MAIN/scripts/bats.sh"
+    cp "$LIB_SH" "$MAIN/scripts/_lib.sh"
+    echo base > "$MAIN/lib/base.ex"
+    : > "$MAIN/test/probe.bats"
+    git -C "$MAIN" add -A
+    git -C "$MAIN" commit -qm base
+
+    # Stand-in for the bats binary: records the environment it inherits and
+    # exits 0. Present and executable, so the door's submodule auto-init
+    # branch (#592) never fires and cannot muddy these cases.
+    cat > "$MAIN/vendor/bats-core/bin/bats" <<EOF
+#!/usr/bin/env bash
+env > "$ENV_LOG"
+exit 0
+EOF
+    chmod +x "$MAIN/vendor/bats-core/bin/bats"
+}
+
+@test "an ambient GRAPPA_CACHE_ID never reaches the bats process (#1522)" {
+    cd "$MAIN"
+    GRAPPA_CACHE_ID=w9 GRAPPA_BATS_PROBE=present run "$MAIN/scripts/bats.sh" test/probe.bats
+    [ "$status" -eq 0 ]
+    # Positive control: the recorder ran and captured a real environment, so
+    # the absence asserted below is a refusal and not an empty file.
+    grep -q '^GRAPPA_BATS_PROBE=present$' "$ENV_LOG"
+    refute grep -q '^GRAPPA_CACHE_ID=' "$ENV_LOG"
+    # Dropping a knob the caller set is stated where the caller reads it.
+    [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+}
+
+@test "no ambient GRAPPA_CACHE_ID: the door drops nothing and says nothing (#1522)" {
+    cd "$MAIN"
+    unset GRAPPA_CACHE_ID
+    GRAPPA_BATS_PROBE=present run "$MAIN/scripts/bats.sh" test/probe.bats
+    [ "$status" -eq 0 ]
+    grep -q '^GRAPPA_BATS_PROBE=present$' "$ENV_LOG"
+    refute grep -q '^GRAPPA_CACHE_ID=' "$ENV_LOG"
+    # No knob to drop, so no line about one.
+    [[ "$output" != *"GRAPPA_CACHE_ID"* ]]
+}


### PR DESCRIPTION
Eight bats cases were reported as failing **only** through
`scripts/check.sh`, identically on a clean `origin/main`, with the
conclusion that *"the difference that remains is `check.sh` itself"*.

**That premise is false.** The variable is an ambient `GRAPPA_CACHE_ID`
in the caller's shell; `check.sh` is only the command it happened to be
attached to. The correction is the substance of this PR.

## Established by displacement, one variable at a time

Base `74a20af1`, clean worktree, nothing else moved between rows:

| run | result |
| --- | --- |
| `scripts/check.sh`, whole gate, **no** cache id | **rc=0 — 564/564 bats green** |
| the three files alone, no cache id | 14/14 green |
| the three files alone, `GRAPPA_CACHE_ID=w2probe` | **rc=1 — the eight, by name** |
| full `scripts/bats.sh`, cache id set, after the fix | **566/566 green** |
| full `scripts/bats.sh`, no cache id, after the fix | **566/566 green** |

Three cheaper arms were displaced first and all came back green, which
is what excluded the gate before the knob was even suspected:

1. the **invocation shape** — `cd $REPO_ROOT` then
   `$SRC_ROOT/scripts/bats.sh`, exactly how `check.sh` calls it, with no
   `mix` at all: green;
2. a preceding `scripts/mix.sh --env=dev compile`: green;
3. the **whole gate**: green.

And the base is not the variable either:
`git log 259780f3..74a20af1 -- scripts/ test/scripts/ test/infra/ test/bin/ infra/lib/ mix.exs`
is **empty** — 125 commits, none touching the gate or these tests — so
nothing was quietly repaired between the report and today.

## The mechanism — nothing under test was wrong

`deploy.sh` refuses to run while the knob is set, **by design** (#1409):

```
GRAPPA_CACHE_ID is set ('w2probe') and the Docker deploy substrate cannot
honour it: only 'compose run' accepts -v, so the oneshots would use the
per-id caches while 'compose up' boots the container from the shared ones.
Unset GRAPPA_CACHE_ID to deploy.
```

All eight cases drive a deploy door, so they die on that refusal — with
a message about deploying, inside a run about something else. The tests
are right and the refusal is right. **No assertion was weakened**, and no
test was adjusted to pass inside the gate.

## The cure is at the door, because the leak is a class

#1409 found this same leak and cured it **per file** — `unset MIX_ENV
GRAPPA_CACHE_ID` in `deploy_docker_test.bats`, `unset GRAPPA_CACHE_ID` in
`deploy_docker_update_test.bats` — in two files.

⚠️ **A count I published in the first commit was wrong and is corrected in
`57208f6b`.** It said "two of the five files that reach a deploy door";
five was *derived* (the two cured plus the three red), never censused.
Censused: `git grep -l` for the deploy-door script names over
`test/**/*.bats` returns **twenty** files, **eighteen** with no unset. The
correction argues for the door-level cure harder than the wrong number
did — a per-file line would have to be written eighteen times and
remembered a nineteenth.

So `scripts/bats.sh` drops the knob once, **before `_lib.sh` reads it** —
no `.caches/<id>` provisioned and no `MIX_TEST_PARTITION` derived, for a
door that runs no `mix` — and says so on stderr instead of doing it
silently. The two per-file `unset`s **stay**: they also cover a direct
`vendor/bats-core/bin/bats` invocation, which never passes through the
door.

`test/scripts/bats_ambient_cache_id_test.bats` pins it the way the #592
suite next door does — asserting on the *constructed invocation* rather
than faking a run: a recorder stands in for the bats binary and dumps the
environment it was handed, with a `GRAPPA_BATS_PROBE=present` control so
the asserted absence cannot be an empty log. **RED before the fix on
exactly that assertion, green after**, plus a no-knob arm that pins the
door staying quiet when there is nothing to drop.

## Two details of the issue corrected on the way

* The four `standalone door` cases live in
  `test/infra/deploy_docker_convergence_test.bats`, **not** in
  `test/scripts/mix_env_db_test.bats` where the issue files them (that
  file holds three cases, none of the eight).
* This is a false **RED**, not a vacuous green — the opposite failure
  mode from the bucket it was grouped with.

## Gates

| gate | result |
| --- | --- |
| `scripts/bats.sh` full, no cache id | 566/566, rc=0 |
| `scripts/bats.sh` full, `GRAPPA_CACHE_ID` set | 566/566, rc=0 (was 8 red) |
| `scripts/design-notes-gate.sh origin/main` | rc=0 — `1 new entry heading(s)` |
| `scripts/check.sh` (at `6fe8e4e4`) | **rc=0** — 8 doctests, 61 properties, 6560 tests, 0 failures; dialyzer `Total errors: 0`; credo 6060 mods/funs no issues; sobelow, doctor, bats green |

`57208f6b` is comment- and markdown-only on top of the gated tree
(`git diff 6fe8e4e4..57208f6b -- scripts/` has **zero** non-comment added
lines); full bats was re-run on it — 566/566, rc=0 — and the Elixir
stages of `check.sh` were not, which is stated rather than implied.

## Not established

* The reporter's own table lists a standalone full `scripts/bats.sh` run
  as green *"with the same GRAPPA_CACHE_ID"*; measured here, a full run
  with the knob set is red on those eight before the fix. Either those
  standalone runs did not in fact carry the id, or something else
  differed in that session. **That cell was not reconciled**, and nothing
  in this fix depends on which reading is right.
* Which of the other fifteen exposed files merely never reach the guard
  (the jail and Linux doors do not carry it) versus would go red on a
  different host. Only the eight are established.
* No census of the remaining ambient-environment surface. `MIX_ENV` is
  already neutralised per file by the fixtures that need it; whether any
  other knob leaks the same way was not measured.
* Nothing is claimed about `GRAPPA_CACHE_ID` under CI, which does not set
  one.
* A neighbouring worker's `scripts/integration.sh` was running on this
  host during the gate. The lanes were allocated that way (STACK vs
  COMPILE); no isolation beyond that is claimed.
