### PR TITLE
e2e(#1584): publish the cold-start input, and fail a run measured on the wrong side of it

### DIFF
--- a/cicchetto/e2e/playwright.config.ts
+++ b/cicchetto/e2e/playwright.config.ts
@@ -32,7 +32,16 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 0,
   workers: 1,
-  reporter: [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
+  // `./reporters/coldStart.ts` (#1584) — LAST on purpose, so its census
+  // prints under the list summary rather than above the first test line.
+  // A reporter, not a fixture: it is the only place that sees every test's
+  // true worker and true order, including the 29 spec files that import
+  // `test` from `@playwright/test` and so are invisible to `fixtures/test`.
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+    ["./reporters/coldStart.ts"],
+  ],
   use: {
     baseURL,
     // Self-signed nginx-test cert — accepted across every spec.

--- a/cicchetto/e2e/reporters/coldStart.ts
+++ b/cicchetto/e2e/reporters/coldStart.ts
@@ -53,7 +53,11 @@ function renderCensus(census: readonly CensusRow[]): string {
     "\n#1584 cold-start census — the first test each Playwright worker began.\n" +
     "  That test paid the browser launch; every later test in the same worker\n" +
     "  ran against an already-running browser. Position is an input to every\n" +
-    "  spec in this suite, and these are its values for this run.\n";
+    "  spec in this suite, and these are its values for this run.\n" +
+    "  More rows than projects means workers were RESTARTED: Playwright\n" +
+    "  discards a worker after a failed test, so every red mints a fresh cold\n" +
+    "  seat for whatever ran next. Measured on the 759-test suite: 4 failures\n" +
+    "  turned the expected 2 cold seats into 6.\n";
 
   if (census.length === 0) return `${header}  (no test reached a worker)\n`;
 

--- a/cicchetto/e2e/reporters/coldStart.ts
+++ b/cicchetto/e2e/reporters/coldStart.ts
@@ -1,0 +1,71 @@
+// #1584 — the driver half of the cold-start cure. Everything that is a
+// DECISION lives in `coldStartLedger.ts` and is proven by vitest; this file
+// only turns Playwright's reporter callbacks into that decision's input, and
+// its answer into stdout plus a run status.
+//
+// Registered in `playwright.config.ts`, so it runs on EVERY invocation —
+// full suite, `--grep`, single file, iso-rerun. That is the point: the
+// invocations that silently change the input are exactly the scoped ones.
+
+import { basename } from "node:path";
+import type { FullResult, Reporter, TestCase, TestResult } from "@playwright/test/reporter";
+import { type CensusRow, judgeRun, type TestStart } from "./coldStartLedger";
+
+class ColdStartReporter implements Reporter {
+  private readonly starts: TestStart[] = [];
+
+  onTestBegin(test: TestCase, result: TestResult): void {
+    this.starts.push({
+      // `parent` is the innermost suite; `project()` walks up to the project
+      // suite, and is undefined only for the root.
+      project: test.parent.project()?.name ?? "<no project>",
+      workerIndex: result.workerIndex,
+      title: `${basename(test.location.file)} > ${test.title}`,
+      tags: test.tags,
+    });
+  }
+
+  // `async` is load-bearing, not decoration: Reporter.onEnd's synchronous
+  // branch is typed `void`, so only the Promise branch may carry a status
+  // override back to Playwright.
+  async onEnd(_result: FullResult): Promise<{ status: FullResult["status"] } | undefined> {
+    const { census, violations } = judgeRun(this.starts);
+    process.stdout.write(renderCensus(census));
+
+    if (violations.length === 0) return undefined;
+
+    process.stdout.write(
+      `\n#1584 cold-start violations — ${violations.length} declared start ` +
+        `temperature(s) did not match this run:\n` +
+        violations.map((violation) => `  - ${violation}\n`).join("") +
+        "\n  The run is failed on this alone. Nothing above is a product " +
+        "verdict:\n  a result measured on the wrong side of this input is not a " +
+        "result.\n",
+    );
+    return { status: "failed" };
+  }
+}
+
+// Printed on EVERY run, green included. A census only a red run prints is a
+// census the reader never sees on the runs where the misreading happens.
+function renderCensus(census: readonly CensusRow[]): string {
+  const header =
+    "\n#1584 cold-start census — the first test each Playwright worker began.\n" +
+    "  That test paid the browser launch; every later test in the same worker\n" +
+    "  ran against an already-running browser. Position is an input to every\n" +
+    "  spec in this suite, and these are its values for this run.\n";
+
+  if (census.length === 0) return `${header}  (no test reached a worker)\n`;
+
+  return (
+    header +
+    census
+      .map(
+        (row) =>
+          `  ${row.project} / worker ${row.workerIndex}: ${row.title} [${row.declaration}]\n`,
+      )
+      .join("")
+  );
+}
+
+export default ColdStartReporter;

--- a/cicchetto/e2e/reporters/coldStartLedger.test.ts
+++ b/cicchetto/e2e/reporters/coldStartLedger.test.ts
@@ -1,0 +1,172 @@
+// #1584 — the ledger IS the cure, so it has to be able to fail for the right
+// reason, and only for that reason. Runs under the cic vitest project (same
+// reason and same shape as `fixtures/pushAbsence.test.ts`): the logic is
+// deliberately free of any Playwright import, so it is provable without a
+// testnet and without a browser.
+//
+// The case that matters is the one MEASURED on #1543: a spec whose outcome
+// depends on paying the cold browser launch goes GREEN the moment any other
+// spec sorts before it in the same project, and nothing in the report says
+// the condition changed. A green like that is indistinguishable, to a reader,
+// from a green that means the contract holds.
+
+import { describe, expect, it } from "vitest";
+import {
+  COLD_START_TAG,
+  declarationOf,
+  judgeRun,
+  type TestStart,
+  WARM_START_TAG,
+} from "./coldStartLedger";
+
+function start(overrides: Partial<TestStart> & Pick<TestStart, "title">): TestStart {
+  return {
+    project: "webkit-iphone-15",
+    workerIndex: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("declarationOf", () => {
+  it("reads @coldstart as a declared dependency on the cold start", () => {
+    expect(declarationOf([COLD_START_TAG])).toBe("cold");
+  });
+
+  it("reads @warmstart as a declared dependency on NOT paying the cold start", () => {
+    expect(declarationOf([WARM_START_TAG])).toBe("warm");
+  });
+
+  it("reads an unrelated tag as undeclared", () => {
+    expect(declarationOf(["@webkit"])).toBe("undeclared");
+  });
+
+  it("reads both tags together as contradictory rather than picking one", () => {
+    expect(declarationOf([WARM_START_TAG, COLD_START_TAG])).toBe("contradictory");
+  });
+});
+
+describe("judgeRun census", () => {
+  it("names the first test each worker began, which is the one that paid the launch", () => {
+    const judgement = judgeRun([
+      start({ title: "first here", workerIndex: 0 }),
+      start({ title: "second here", workerIndex: 0 }),
+    ]);
+
+    expect(judgement.census).toEqual([
+      {
+        project: "webkit-iphone-15",
+        workerIndex: 0,
+        title: "first here",
+        declaration: "undeclared",
+      },
+    ]);
+  });
+
+  it("keeps one row per worker, so a second project does not overwrite the first", () => {
+    const judgement = judgeRun([
+      start({ title: "chromium head", project: "chromium", workerIndex: 0 }),
+      start({ title: "webkit head", project: "webkit-iphone-15", workerIndex: 1 }),
+      start({ title: "webkit tail", project: "webkit-iphone-15", workerIndex: 1 }),
+    ]);
+
+    expect(judgement.census.map((row) => row.title)).toEqual(["chromium head", "webkit head"]);
+  });
+
+  it("ignores a test that never reached a worker, so it cannot be read as the payer", () => {
+    // Playwright reports workerIndex -1 for a test interrupted before it ran
+    // (testReporter.d.ts). Such a test launched nothing.
+    const judgement = judgeRun([
+      start({ title: "interrupted", workerIndex: -1 }),
+      start({ title: "really ran", workerIndex: 0 }),
+    ]);
+
+    expect(judgement.census.map((row) => row.title)).toEqual(["really ran"]);
+  });
+
+  it("reports an empty census for a run that began no test", () => {
+    expect(judgeRun([])).toEqual({ census: [], violations: [] });
+  });
+});
+
+describe("judgeRun violations", () => {
+  it("fails a @coldstart test that another test preceded in its worker", () => {
+    const judgement = judgeRun([
+      start({ title: "unrelated spec" }),
+      start({ title: "needs the cold start", tags: [COLD_START_TAG] }),
+    ]);
+
+    expect(judgement.violations).toHaveLength(1);
+    expect(judgement.violations[0]).toContain("needs the cold start");
+    expect(judgement.violations[0]).toContain(COLD_START_TAG);
+    // The payer is named: without it the reader cannot tell WHAT silenced it.
+    expect(judgement.violations[0]).toContain("unrelated spec");
+  });
+
+  it("passes a @coldstart test that its worker began with", () => {
+    const judgement = judgeRun([
+      start({ title: "needs the cold start", tags: [COLD_START_TAG] }),
+      start({ title: "unrelated spec" }),
+    ]);
+
+    expect(judgement.violations).toEqual([]);
+  });
+
+  it("fails a @warmstart test the invocation promoted to its worker's first", () => {
+    const judgement = judgeRun([
+      start({ title: "only evidence when warm", tags: [WARM_START_TAG] }),
+      start({ title: "unrelated spec" }),
+    ]);
+
+    expect(judgement.violations).toHaveLength(1);
+    expect(judgement.violations[0]).toContain("only evidence when warm");
+    expect(judgement.violations[0]).toContain(WARM_START_TAG);
+  });
+
+  it("passes a @warmstart test that ran behind another test in its worker", () => {
+    const judgement = judgeRun([
+      start({ title: "unrelated spec" }),
+      start({ title: "only evidence when warm", tags: [WARM_START_TAG] }),
+    ]);
+
+    expect(judgement.violations).toEqual([]);
+  });
+
+  it("judges each worker on its own head, not on the run's first test", () => {
+    // Worker 0 ran two tests already; that says nothing about worker 1, which
+    // launched its own browser. A per-run counter would pass this wrongly.
+    const judgement = judgeRun([
+      start({ title: "chromium head", project: "chromium", workerIndex: 0 }),
+      start({ title: "chromium tail", project: "chromium", workerIndex: 0 }),
+      start({
+        title: "only evidence when warm",
+        project: "webkit-iphone-15",
+        workerIndex: 1,
+        tags: [WARM_START_TAG],
+      }),
+    ]);
+
+    expect(judgement.violations).toHaveLength(1);
+    expect(judgement.violations[0]).toContain("only evidence when warm");
+  });
+
+  it("fails a contradictory declaration wherever it ran", () => {
+    const judgement = judgeRun([
+      start({ title: "unrelated spec" }),
+      start({ title: "says both", tags: [COLD_START_TAG, WARM_START_TAG] }),
+    ]);
+
+    expect(judgement.violations).toHaveLength(1);
+    expect(judgement.violations[0]).toContain("says both");
+    expect(judgement.violations[0]).toContain("both");
+  });
+
+  it("stays silent on a run where nothing declared a temperature", () => {
+    const judgement = judgeRun([
+      start({ title: "unrelated spec" }),
+      start({ title: "another one", tags: ["@webkit"] }),
+    ]);
+
+    expect(judgement.violations).toEqual([]);
+  });
+});

--- a/cicchetto/e2e/reporters/coldStartLedger.ts
+++ b/cicchetto/e2e/reporters/coldStartLedger.ts
@@ -1,0 +1,165 @@
+// #1584 — the decision half of the cold-start reporter, kept free of any
+// Playwright import so `coldStartLedger.test.ts` can prove it without a
+// testnet and without a browser.
+//
+// ## What lies, and why documenting it would not have been enough
+//
+// The suite runs `workers: 1`, `fullyParallel: false`, two projects. Exactly
+// one test per worker pays the browser launch; every later test in that
+// worker runs against an already-running browser. So "did this test pay the
+// cold start?" is an INPUT to the test — decided by filename sort order plus
+// which files the invocation collected — and until now it appeared nowhere in
+// the result.
+//
+// Measured on #1543: `issue310-scroll-to-bottom-btn-cursor.spec.ts`'s @webkit
+// test is RED 4/4 as the first `@webkit` test collected, and GREEN the moment
+// one other `@webkit` spec sorts before it. A bare open with no assertions is
+// red on the same seat. In the full 759-test suite it passes, behind dozens of
+// earlier files. Nothing in either report says which side it was measured on.
+//
+// A green like that cannot be told apart from a green that means the contract
+// holds, and a red like that reads as a regression in the branch when it is a
+// property of the collected subset. Writing that down in a doc moves the
+// problem to a file nobody opens while reading a tick.
+//
+// ## What this measures, and what it infers
+//
+// MEASURED: the first test each Playwright worker began, from the reporter's
+// own `onTestBegin` stream — which sees every test, including the 29 spec
+// files that import `test` from `@playwright/test` instead of the wrapped
+// `fixtures/test`. A per-worker counter inside a fixture cannot see those, so
+// a subset that puts one of them first would make the next wrapped test read
+// as cold when it is not. That false reading is the reason the cure is a
+// reporter and not a fixture.
+//
+// INFERRED: that the worker's first test is the one that paid the browser
+// launch. Playwright launches the browser lazily, when a test first asks for
+// it, so a hypothetical browser-less first test would push the launch onto its
+// successor. No such spec exists today; the inference is named here rather
+// than hidden, and the census wording states the measured fact.
+//
+// ## The two declarations
+//
+// A spec that knows its outcome depends on this input says so with a tag, and
+// the run FAILS when the input does not match the declaration. Undeclared
+// specs are never failed by this ledger — they get the census, which is the
+// value of the input published next to their result.
+
+/** A spec whose contract is only exercised on its worker's first test. */
+export const COLD_START_TAG = "@coldstart";
+
+/** A spec whose outcome is only meaningful when it did NOT pay the launch. */
+export const WARM_START_TAG = "@warmstart";
+
+export type StartDeclaration = "cold" | "warm" | "undeclared" | "contradictory";
+
+/** One `onTestBegin`, reduced to the four facts the judgement needs. */
+export interface TestStart {
+  readonly project: string;
+  /** Playwright reports -1 for a test interrupted before it reached a worker. */
+  readonly workerIndex: number;
+  readonly title: string;
+  readonly tags: readonly string[];
+}
+
+/** The test a worker began with — the published value of the hidden input. */
+export interface CensusRow {
+  readonly project: string;
+  readonly workerIndex: number;
+  readonly title: string;
+  readonly declaration: StartDeclaration;
+}
+
+export interface RunJudgement {
+  readonly census: readonly CensusRow[];
+  readonly violations: readonly string[];
+}
+
+/**
+ * Read a test's declared start temperature off its Playwright tags.
+ *
+ * Both tags at once is a contradiction, not a precedence puzzle: answering
+ * "cold" or "warm" there would pick one silently, which is the same class of
+ * quiet wrong answer this whole ledger exists to end.
+ */
+export function declarationOf(tags: readonly string[]): StartDeclaration {
+  const cold = tags.includes(COLD_START_TAG);
+  const warm = tags.includes(WARM_START_TAG);
+  if (cold && warm) return "contradictory";
+  if (cold) return "cold";
+  if (warm) return "warm";
+  return "undeclared";
+}
+
+/**
+ * Judge a whole run from its `onTestBegin` stream, in arrival order.
+ *
+ * Per WORKER, not per run: worker 1 launches its own browser however many
+ * tests worker 0 has already run, so a run-wide counter would clear a promoted
+ * spec in the second project.
+ */
+export function judgeRun(starts: readonly TestStart[]): RunJudgement {
+  const heads = new Map<number, TestStart>();
+  const violations: string[] = [];
+
+  for (const started of starts) {
+    // A test that never reached a worker launched nothing, and must not be
+    // recorded as the payer — the next test in that worker is the real one.
+    if (started.workerIndex < 0) continue;
+
+    const head = heads.get(started.workerIndex);
+    const paidColdStart = head === undefined;
+    if (paidColdStart) heads.set(started.workerIndex, started);
+
+    const violation = violationOf(started, paidColdStart, head);
+    if (violation) violations.push(violation);
+  }
+
+  const census = [...heads.values()].map(
+    (head): CensusRow => ({
+      project: head.project,
+      workerIndex: head.workerIndex,
+      title: head.title,
+      declaration: declarationOf(head.tags),
+    }),
+  );
+
+  return { census, violations };
+}
+
+function violationOf(
+  started: TestStart,
+  paidColdStart: boolean,
+  head: TestStart | undefined,
+): string | null {
+  const where = `project ${started.project}, worker ${started.workerIndex}`;
+
+  switch (declarationOf(started.tags)) {
+    case "contradictory":
+      return (
+        `${started.title} carries both ${COLD_START_TAG} and ${WARM_START_TAG}. ` +
+        "A test declares one start temperature or none (#1584)."
+      );
+
+    case "cold":
+      if (paidColdStart) return null;
+      return (
+        `${started.title} declares ${COLD_START_TAG} but did not pay the cold start. ` +
+        `${where} began with: ${head?.title}. The contract this spec names is only ` +
+        "exercised on the worker's first test, so a green here would not be evidence " +
+        "that it holds (#1584)."
+      );
+
+    case "warm":
+      if (!paidColdStart) return null;
+      return (
+        `${started.title} declares ${WARM_START_TAG} but paid the cold start. ` +
+        `${where} began with it, so it took the browser launch it does not take in ` +
+        "the full suite. Its outcome here is a property of the collected subset, not " +
+        "of the branch under test (#1584, #1543)."
+      );
+
+    case "undeclared":
+      return null;
+  }
+}

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -61,6 +61,7 @@ import {
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
+import { WARM_START_TAG } from "../reporters/coldStartLedger";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -172,9 +173,24 @@ test.describe("#310 — scroll-to-bottom button persists the read cursor (mobile
     await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
   });
 
-  test("@webkit tapping the button advances the cursor to the tail and does not snap back", async ({
-    page,
-  }) => {
+  // `@warmstart` (#1584) — MEASURED on #1543: this test is red 4/4 as the
+  // first `@webkit` test an invocation collects, and green behind any other
+  // one; a bare open with no assertions is red on the same seat. So its red,
+  // when it is the head of its worker, is a property of what the invocation
+  // collected and not of the branch under test — which is how #1543 came to
+  // be filed against the code. The tag makes that invocation fail with the
+  // reason spelled out instead of handing back a regression-shaped red.
+  //
+  // The tag is on the mobile arm ONLY: the desktop arm above was not measured
+  // on either side of the input, and an unmeasured declaration would be a
+  // guess wearing a gate's clothes.
+  //
+  // Declared through the `{ tag }` option rather than in the title, so the
+  // title stays greppable exactly as `docs/TESTING.md` and #1543 spell it
+  // (`--grep` matches tags too).
+  test("@webkit tapping the button advances the cursor to the tail and does not snap back", {
+    tag: WARM_START_TAG,
+  }, async ({ page }) => {
     await tapButtonPersistsCursorAndHolds(page, `btn310-w${Date.now() % 100000}`);
   });
 });

--- a/cicchetto/vitest.config.ts
+++ b/cicchetto/vitest.config.ts
@@ -21,7 +21,17 @@ export default defineConfig({
     // worth testing here (#806). Matched on `.test.ts` alone, never
     // `.spec.ts`: `e2e/tests/*.spec.ts` are playwright specs and must not
     // be picked up by vitest.
-    include: ["src/**/*.{test,spec}.{ts,tsx}", "e2e/fixtures/**/*.test.ts"],
+    //
+    // `e2e/reporters/**/*.test.ts` — same argument one directory over
+    // (#1584): a playwright REPORTER is the only place that sees every
+    // test's true worker and true order, so the cure for the
+    // first-in-project class lives there, and the part of it that is a
+    // decision rather than a driver call is proven here.
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      "e2e/fixtures/**/*.test.ts",
+      "e2e/reporters/**/*.test.ts",
+    ],
   },
   resolve: {
     conditions: ["development", "browser"],

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52277,3 +52277,93 @@ the id, or something else differed in that session — that cell was not
 reconciled and nothing here depends on it. No claim is made about other
 ambient knobs: `MIX_ENV` was already neutralised per file by the fixtures that
 need it, and no census of the remaining environment surface was run.
+<!-- entry #1584 -->
+
+---
+
+## 2026-08-20 — #1584: position in the Playwright project is an INPUT, and it now appears in the result
+
+`cicchetto/e2e` runs `workers: 1`, `fullyParallel: false`, two projects, so
+exactly one test per worker pays the browser launch and every later test in
+that worker runs against an already-running browser. Whether a given spec sits
+in that seat is decided by filename sort order plus which files the invocation
+collected. It was, until this entry, invisible in the result.
+
+Measured on #1543: the `@webkit` arm of
+`issue310-scroll-to-bottom-btn-cursor.spec.ts` is red 4/4 as the first
+`@webkit` test collected and green behind any other one; a bare open with no
+assertions is red in the same seat. In the 759-test suite it passes, dozens of
+files deep. So a green from it could mean "the contract holds" or "something
+else was collected first", and its red reads as a branch regression when it is
+a property of the subset — which is how #1543 came to be filed against the
+code.
+
+### Why a reporter and not a fixture
+
+The obvious shape is a per-worker counter in `fixtures/test.ts`, next to
+`_cspGuard` and the `#1152` nick guard. It cannot be right: **29 of the 411
+spec files import `test` from `@playwright/test`** rather than the wrapped
+fixture, so a subset that puts one of those first would make the next wrapped
+test read as cold when it is not. `_cspGuard` can carry that same blind spot
+because an unguarded spec there is merely unguarded; here the blind spot makes
+the instrument WRONG about its own input, and a guard that can be wrong about
+its input is the defect this issue names, not the cure for it.
+
+`onTestBegin` sees every test with its true worker and true order, and `onEnd`
+may return `{ status: "failed" }`. So the cure is
+`e2e/reporters/coldStart.ts`, with the decision half in a Playwright-free
+`coldStartLedger.ts` proven by 15 vitest cases — the `fixtures/pushAbsence.test.ts`
+split, one directory over.
+
+### What it does, and why the census is unconditional
+
+Every run prints which test each worker began with, green runs included. A
+census only a red run prints is a census absent from exactly the runs where
+the misreading happens. Two tags let a spec declare which side it needs —
+`@warmstart` fails the run when the invocation promoted the spec to its
+worker's head, `@coldstart` fails when anything preceded it — and the failure
+is deliberately run-level: the offending test is often GREEN, and that green
+is the thing being reported.
+
+Judged per WORKER, not per run: the second project launches its own browser
+however many tests the first has run, so a run-wide counter would clear a
+promoted spec in the second project. Both tags on one test is a hard
+violation rather than a precedence rule, because picking one silently is the
+same class of quiet wrong answer.
+
+MEASURED is "the first test the worker began"; INFERRED is that it paid the
+launch (Playwright launches lazily, so a browser-less first test would push
+the launch onto its successor — no such spec exists today). The census wording
+states the measured fact and this entry names the inference.
+
+### What was proved, and what was not
+
+Five arms on the two-spec `webkit-iphone-15` subset, `origin/main` at
+`74a20af1`:
+
+| arm | tree | subset | the spec | run rc |
+|---|---|---|---|---|
+| A | base | issue310 alone | RED 10.3 s | 1 |
+| B | base | bug7 then issue310 | GREEN 3.0 s | 0 |
+| C | cure, tag mutated to `@coldstart` | bug7 then issue310 | GREEN 2.8 s | **1** |
+| D | cure as shipped (`@warmstart`) | bug7 then issue310 | GREEN 2.7 s | 0 |
+| E | cure as shipped | issue310 alone | RED 10.2 s | 1 |
+
+B → C is the mutation the cure has to survive: identical subset, the spec
+green on both sides, the RUN flipping 0 → 1 with the payer named. D is the
+control that the gate is not a blanket red. A → E is the same red gaining its
+explanation.
+
+The only declared adopter is the arm that was measured. The desktop arm of the
+same spec carries nothing, because it was measured on neither side.
+`@coldstart` ships with **no adopter at all**: under `workers: 1` a spec that
+truly needs the cold seat cannot get it at CI's position, and #1543 already
+concluded that a cold contract belongs in a vitest pin. It is shipped because
+the issue's headline case is that direction, and a mechanism that cannot
+express it would leave the headline unaddressed.
+
+Not established: how many other specs are exposed. Zero were surveyed. A grep
+for `@webkit` inside a `test(...)`/`describe(...)` title finds 85 files where
+`grep -l @webkit` finds 103 — the difference is comment matches, and the
+issue's own "103 files" figure carries that inflation. Neither number is
+Playwright's collector.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52367,3 +52367,33 @@ for `@webkit` inside a `test(...)`/`describe(...)` title finds 85 files where
 `grep -l @webkit` finds 103 — the difference is comment matches, and the
 issue's own "103 files" figure carries that inflation. Neither number is
 Playwright's collector.
+
+### What the first full run found: the seat recurs, and a red mints one
+
+The issue's model — and this entry's first draft — said "exactly one test per
+project pays it", so two cold seats per run. The first full
+`scripts/integration.sh` under the census printed **six**: `chromium` workers
+0–3 and `webkit-iphone-15` workers 4–5, on a run with 755 passed and 4 failed.
+
+The arithmetic closes exactly: Playwright discards a worker after a failed
+test, so 4 failures plus 1 project change account for all 5 restarts, and each
+census head is the roster's next test after a red. **Every failure therefore
+mints a fresh cold seat for whatever runs next**, which makes the exposure
+proportional to how red the run already is — worst precisely when a reader is
+triaging. `docs/TESTING.md` calls this out beside the cascade tree: the tree's
+"state pollution" carrier has a sibling nobody had named, and it is not state,
+it is a cold browser.
+
+The census was not written to find this. It found it on its first full run,
+which is the argument for printing it on green runs too.
+
+The same run's 4 reds are not this branch's, and the evidence is uneven, so it
+is split rather than averaged. Three chromium reds (33.0 s, 33.5 s, 33.9 s)
+sit on top of three grappa-test stalls of 32.5 s, 33.0 s and 33.3 s with
+`db30=7` and `saturated=3` in the #1429 census — gap plus damage signature,
+which the house rule reads as environment. The fourth,
+`issue1445-directory-pull-refresh` on webkit, has no gap anywhere near it: it
+passed 1/1 when re-run in a warm two-spec subset, and one run per side does
+not attribute anything. **It stays unattributed, and this says so.** Note the
+shape of the trap: the runbook's iso-rerun would have promoted it into a cold
+seat, which is the one triage this very entry documents as blind.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -471,6 +471,21 @@ tests/bug7-ios-own-msg-visible.spec.ts tests/<yours>.spec.ts`) or in the
 full suite. `--repeat-each` does not help: every repeat sits in the same
 promoted seat.
 
+🔴 **`@coldstart` cannot be satisfied at CI's position, and that is a
+documented limit, not an oversight.** With `workers: 1` only the roster's
+first test in each project holds a cold seat, so any spec that genuinely
+needs one — anywhere but position 1 — makes the full suite fail by
+declaration. **No spec carries the tag today** and none should acquire
+one without first moving the contract somewhere the seat is not an
+input: for the #1543 case that is a `vitest` pin over the component,
+which is what that issue itself concluded. The tag exists so the claim
+can be *stated and checked* rather than assumed, and so a run that
+believes it has cold coverage finds out it does not.
+
+(The seats a failure mints are not an escape hatch either: they are
+minted by whichever test happens to be next after a red, so they are
+not a position anybody can ask for.)
+
 Do **not** tag a spec on a hunch. A declaration is a claim that the spec
 was measured on both sides of the input; an unmeasured one is a guess
 wearing a gate's clothes, and it will red somebody else's run.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -374,6 +374,11 @@ The decision tree:
                 no fixes without it). Read the Playwright trace +
                 screenshot + error-context.md in test-results/ before
                 touching code.
+                🔴 EXCEPT when the run printed a #1584 cold-start
+                violation: an iso-rerun is the MOST first-in-project a
+                spec can be, so for a boot-timing-sensitive spec it
+                manufactures the red it is supposed to be diagnosing.
+                Read the next section before believing branch 3.
 ```
 
 **Common cascade signatures:**
@@ -410,6 +415,57 @@ The decision tree:
 **Never** `gh run rerun --failed`. First run IS the truth — see
 `feedback_no_ci_retries_on_first_failure`. Reproduce locally with
 `--repeat-each` instead.
+
+## The cold-start census: position in the project is an INPUT (#1584)
+
+`workers: 1`, `fullyParallel: false`, two projects — so **exactly one
+test per worker pays the browser launch**, and every later test in that
+worker runs against an already-running browser. Which test that is comes
+from filename sort order plus *which files the invocation collected*, so
+**it changes when you scope a run and it changes when somebody adds an
+earlier-sorting spec**, with no edit to the affected spec and no line in
+any diff pointing at it.
+
+Measured on #1543: the `@webkit` arm of
+`issue310-scroll-to-bottom-btn-cursor.spec.ts` is red 4/4 in that seat
+and green 3/3 behind any other `@webkit` test — and a bare open with no
+assertions is red in the same seat. In the full suite it passes, dozens
+of files deep.
+
+**Every run now prints the value of that input**, green runs included:
+
+```
+#1584 cold-start census — the first test each Playwright worker began.
+  webkit-iphone-15 / worker 0: bug7-ios-own-msg-visible.spec.ts > ... [undeclared]
+```
+
+Read it before reading a result you are about to act on. If your spec is
+NOT in that list, it ran warm.
+
+**Two tags let a spec declare which side it needs.** Both come from
+`e2e/reporters/coldStartLedger.ts` — import the constant, never retype
+the string — and both are declared through Playwright's `{ tag }`
+option so the title stays greppable:
+
+| tag | means | the run FAILS when |
+|---|---|---|
+| `@warmstart` | only meaningful behind another test | the invocation promoted it to its worker's head |
+| `@coldstart` | only exercised on the worker's first test | anything preceded it in that worker |
+
+The failure is a **run-level** red printed by the reporter, not a test
+red: the offending test may well be green, and that green is the
+problem. Nothing above the violation block is a product verdict.
+
+A `@warmstart` spec therefore **cannot be run alone** — that is the
+point, not a limitation to work around. Run it behind another spec of
+the same project (`scripts/integration.sh --project=webkit-iphone-15
+tests/bug7-ios-own-msg-visible.spec.ts tests/<yours>.spec.ts`) or in the
+full suite. `--repeat-each` does not help: every repeat sits in the same
+promoted seat.
+
+Do **not** tag a spec on a hunch. A declaration is a claim that the spec
+was measured on both sides of the input; an unmeasured one is a guess
+wearing a gate's clothes, and it will red somebody else's run.
 
 ## Five e2e gate traps that fake a green (or a red)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -442,6 +442,14 @@ of files deep.
 Read it before reading a result you are about to act on. If your spec is
 NOT in that list, it ran warm.
 
+**More rows than projects means workers were restarted.** Playwright
+discards a worker after a failed test, so **every red mints a fresh cold
+seat for whatever ran next** — measured on the 759-test suite, 4 failures
+turned the expected 2 cold seats into 6, and in each case the spec that
+inherited the seat was simply the next one in the roster. That is the
+cascade mechanism the tree above calls "state pollution", with a second
+carrier nobody had named: not shared state, but a cold browser.
+
 **Two tags let a spec declare which side it needs.** Both come from
 `e2e/reporters/coldStartLedger.ts` — import the constant, never retype
 the string — and both are declared through Playwright's `{ tag }`


### PR DESCRIPTION
Fixes the lying gate in #1584.

## The lie

`cicchetto/e2e` runs `workers: 1`, `fullyParallel: false`, two projects, so
exactly one test per worker pays the browser launch and every later test in
that worker runs warm. Which test sits in that seat comes from filename sort
order plus which files the invocation collected — and it appeared nowhere in
the result.

Measured on #1543: the `@webkit` arm of
`issue310-scroll-to-bottom-btn-cursor.spec.ts` is red 4/4 in that seat and
green behind any other `@webkit` test; a bare open with no assertions is red
in the same seat. In the 759-test suite it passes, dozens of files deep. So
its green could mean "the contract holds" or "something else was collected
first", and its red reads as a branch regression when it is a property of the
subset — which is how #1543 came to be filed against the code.

## The cure

* **Every run prints the value of the input**, green runs included:
  `#1584 cold-start census — the first test each Playwright worker began`.
* **Two tags let a spec declare which side it needs**, and the run FAILS on a
  mismatch. `@warmstart` fails when the invocation promoted the spec to its
  worker's head; `@coldstart` fails when anything preceded it. The failure is
  run-level on purpose: the offending test is often GREEN, and that green is
  what is being reported.
* A **reporter**, not a fixture. 29 of the 411 spec files import `test` from
  `@playwright/test` rather than the wrapped `fixtures/test`, so a per-worker
  counter in the fixture would read the next wrapped test as cold when a bare
  one had already run — a guard that can be wrong about its own input is the
  defect in this issue, not the cure for it. `onTestBegin` sees every test with
  its true worker and true order; `onEnd` can fail the run.
* Decision half in a Playwright-free module under vitest (15 cases, the
  `fixtures/pushAbsence.test.ts` split); the reporter is the driver adapter.

## Proof: the mutation the cure had to survive

Five arms on the same two-spec `webkit-iphone-15` subset, base `74a20af1`:

| arm | tree | subset | the spec | run rc |
|---|---|---|---|---|
| A | base | issue310 alone | RED 10.3 s | 1 |
| B | base | bug7 then issue310 | GREEN 3.0 s | 0 |
| C | cure, tag mutated to `@coldstart` | bug7 then issue310 | GREEN 2.8 s | **1** |
| D | cure as shipped (`@warmstart`) | bug7 then issue310 | GREEN 2.7 s | 0 |
| E | cure as shipped | issue310 alone | RED 10.2 s | 1 |

B to C is the mutation: identical subset, the spec green on both sides, the
RUN flipping 0 to 1 with the payer named. D is the control that this is not a
blanket red. A to E is the same red gaining its explanation.

## What the first full run found

`scripts/integration.sh`: **755 passed, 4 failed, 29.1 min**, no #1584
violation. The census printed **six** cold seats, not two — Playwright discards
a worker after a failed test, so 4 failures plus 1 project change account for
all five restarts, and every census head is the roster's next test after a
red. **A red mints a fresh cold seat for whatever runs next**, so the exposure
grows with how red a run already is, worst while somebody is triaging. Nothing
looked for this; the census printed it on a run it was not asked to explain,
which is the argument for printing it on green runs too.

The 4 reds are not this branch's, and the evidence is uneven, so it is split:
three chromium reds (33.0 / 33.5 / 33.9 s) sit on three grappa-test stalls of
32.5 / 33.0 / 33.3 s with `db30=7`, `saturated=3` in the #1429 census — gap
plus damage signature, which the house rule reads as environment. The fourth,
`issue1445-directory-pull-refresh` on webkit, has no gap near it; it passed
1/1 re-run in a warm two-spec subset, and one run per side attributes nothing.
**It stays unattributed.** Note the shape: the runbook's iso-rerun would have
promoted it into a cold seat, the one triage this PR documents as blind.

## What I do not claim

* Not a census of exposed specs — **zero surveyed**. The class is stated from
  one measured instance. (A grep for `@webkit` inside a title finds 85 files
  where `grep -l` finds 103; the issue's 103 includes comment matches, and
  neither number is Playwright's collector.)
* `@coldstart` ships with **no adopter**. Under `workers: 1` a spec that truly
  needs the cold seat cannot get it at CI's position, and #1543 already
  concluded a cold contract belongs in a vitest pin. It ships because the
  issue's headline case is that direction.
* The desktop arm of the same spec carries no tag: it was measured on neither
  side, and an unmeasured declaration is a guess wearing a gate's clothes.
* MEASURED is "the first test the worker began"; INFERRED is that it paid the
  launch — Playwright launches lazily, so a browser-less first test would push
  the launch onto its successor. No such spec exists today.
* This does not fix #1543's underlying red, and does not claim to.
* The cic gates (`bun run check`, 5677 vitest) were run before the rebase onto
  `57208f6b`; those three commits touch only `docs/`, `scripts/bats.sh` and one
  bats file, so no cic input changed. Not re-run, and said rather than implied.
* Server-side gates were not run: nothing outside `cicchetto/` and `docs/` is
  touched.

Gates: `bun run check` green (biome + tsc over src and e2e), vitest
**293 files / 5677 tests** green, `scripts/design-notes-gate.sh` green,
full `scripts/integration.sh` as above. DESIGN_NOTES contribution proven
append-only: the branch's file is byte-identical to `origin/main`'s for its
first 52279 lines, plus 120 appended.