### PR TITLE
test(#1098): narrow the ordering oracle to the rows the test created

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52397,3 +52397,74 @@ passed 1/1 when re-run in a warm two-spec subset, and one run per side does
 not attribute anything. **It stays unattributed, and this says so.** Note the
 shape of the trap: the runbook's iso-rerun would have promoted it into a cold
 seat, which is the one triage this very entry documents as blind.
+<!-- entry #1098 -->
+
+---
+
+## 2026-08-20 — #1098: the sandbox answered a different question than the read
+
+The 2026-08-11 entry above lists *"the sort runs across every credential in
+the DB"* under **false, measured**, on the grounds that `DataCase` opens a
+sandbox owner per test. That is correct about what it measured — **rows do not
+PERSIST from one test into another** — and it is not an answer about the
+**SCOPE of the read**. The two are different questions, and only the first was
+put. The read stayed global: `ts` was built from an unfiltered
+`Credentials.list_credentials_for_all_users/0`, so the ordering assertion still
+ranged over every row that query would return, whoever wrote them.
+
+### How wide the residue actually was
+
+Narrower than the issue's phrasing. The query is
+`where: c.connection_state == :connected and not is_nil(c.user_id)`
+(`credentials.ex:1359`), so a foreign row had to be `:connected` — which is the
+column default — **and** user-owned; visitor credentials were out by
+construction. And the failure class had already changed once the oracle became
+a literal: against an exact three-element expected list a foreign row is a
+loud, immediate mismatch, not the subtle ordering flake that passes on rerun.
+
+Latent, then, and with an in-codebase control already standing over it: the
+module has no `setup_all` and no module-level `setup`, the `describe` has none
+of its own, and its first test asserts `list_credentials_for_all_users() == []`
+— the same query, so any leak reddens there first. **Latency is a property of
+today's neighbours, though, not of the assertion**, and the assertion outlives
+them. That is the whole reason for the three lines.
+
+### Filtered by USER, not by the expected PAIRS
+
+The obvious filter is a `MapSet` of the three `{user_id, network_id}` pairs the
+test expects. It is the wrong one: it makes the read a restatement of the
+expected list, so an unexpected row belonging to one of **our own** two users
+would be filtered out rather than reddening. Filtering on the two user ids
+keeps that failure available. Both users are created here with
+`System.unique_integer/1` in their names, so no other row can bear their ids.
+
+**What stops being covered, stated as a scope call and not as a measurement:**
+this test no longer notices a foreign `:connected`, user-owned row entering the
+result set. That property is asserted by both sibling tests in the same
+`describe`, over the same global query — `== []` on an empty DB, and
+`length(creds) == 3` — so the class leaves this test, not the module.
+
+### Two mutants, neither committed
+
+A red was not producible honestly without forcing one. The module is
+`async: false`, so the sandbox is `shared: true` and rolls back: rows written by
+other tests cannot reach this one, and no supervised process writes a
+credential — every `bind_credential/3` caller is request-driven. So the foreign
+row was **injected**, and declared as an injection rather than reported as an
+incidence.
+
+| mutant | before the cure | after |
+|---|---|---|
+| a fourth `:connected`, user-owned row, stamped ahead of `boundary` | RED — 1 failure, this test; the foreign row enters at the HEAD of the list | GREEN |
+| `asc: c.user_id` dropped from the query's `order_by` | — | RED — 1 failure, this test |
+
+The second is the 2026-08-11 entry's own mutant, re-run on the narrowed oracle:
+it still kills exactly this test, which is what says the filter did not weaken
+the ordering it was there to pin.
+
+**Not claimed.** No incidence figure, before or after — structure says a path
+exists, never how often it fires. Nothing here was measured against production
+or a CI runner; the runs are the local module (`117 tests`) plus the full
+`check.sh`. And whether ExUnit can overlap this `async: false` module with an
+`async: true` module that writes credentials was NOT established — the sandbox
+mode was read, the scheduler was not.

--- a/test/grappa/networks_test.exs
+++ b/test/grappa/networks_test.exs
@@ -808,8 +808,20 @@ defmodule Grappa.NetworksTest do
       stamp(hi_user, net_a, next_second)
       stamp(lo_user, net_b, next_second)
 
+      # Narrowed to the two users this test created (their names carry a unique
+      # integer, so no other row can bear their ids): the query is global, and
+      # an ordering oracle that ranges over rows the test did not create reads
+      # a red off someone else's data. Filtering by USER, not by the three
+      # expected PAIRS, keeps the assert able to fail on an unexpected row of
+      # OUR OWN. What it stops covering — that the query returns nothing ELSE —
+      # is what the two sibling tests in this describe assert, and they still
+      # read globally (`== []` above, `length(creds) == 3` above that).
+      ours = [lo_user.id, hi_user.id]
+
       ts =
-        Enum.map(Credentials.list_credentials_for_all_users(), &{&1.user_id, &1.network_id, &1.inserted_at})
+        Credentials.list_credentials_for_all_users()
+        |> Enum.filter(&(&1.user_id in ours))
+        |> Enum.map(&{&1.user_id, &1.network_id, &1.inserted_at})
 
       # Stated outright, never re-derived with `Enum.sort_by/2`: that sorts by
       # Erlang TERM order, and term order on a `%DateTime{}` compares the


### PR DESCRIPTION
Clears the residue left on row #1098 of the #1336 epic. Test-only change plus
its decision-log entry — no production code is touched
(`git diff origin/main..HEAD -- lib/` is empty).

## What was left, and why it is not what the row said

The oracle that produced the recorded red is already gone: the expected list is
a literal and the three timestamps are pinned by `stamp/3`. The recorded red
was never the over-breadth — it was `Enum.sort_by/2` re-deriving the expected
list in Erlang **term order**, which compares a `%DateTime{}`'s map values in
alphabetical KEY order and so weighs `:microsecond` before `:second`. That
disagrees with SQL exactly when two rows straddle a second boundary.

What stayed is the READ. `ts` was still built from an unfiltered
`Credentials.list_credentials_for_all_users/0`, so the ordering assertion
ranged over rows the test did not create.

The 2026-08-11 decision-log entry files *"the sort runs across every credential
in the DB"* under **false, measured**, on the grounds that `DataCase` opens a
sandbox owner per test. That is an answer about **persistence** — rows do not
survive from one test into another — and the row was a claim about **scope**.
Only the first question was put. The entry in this PR records the distinction,
so a later reader does not meet a filter the log says was unnecessary.

## The cure, and the fork inside it

Filtered by **USER**, not by the three expected **PAIRS**. A pair filter makes
the read a restatement of the expected list, so an unexpected row belonging to
one of *our own* two users would be filtered away instead of reddening. Both
users are created here with `System.unique_integer/1` in their names, so no
other row can bear their ids.

**What this stops covering:** that the query returns nothing else. Both sibling
tests in the same `describe` assert exactly that over the same global query
(`== []` on an empty DB, and `length(creds) == 3`), so the class leaves this
test, not the module. That is a scope call, not a measurement, and is labelled
as one in the entry.

## Measured two-sided — both mutants declared, neither committed

A red was not producible honestly without forcing one. The module is
`async: false`, so the sandbox is `shared: true` and rolls back; no supervised
process writes a credential (every `bind_credential/3` caller is
request-driven). The foreign row was therefore **injected**, and is reported as
an injection rather than as an incidence.

| mutant | before the cure | after |
|---|---|---|
| a fourth `:connected`, user-owned row stamped ahead of `boundary` | RED — 1 failure, this test; the foreign row enters at the HEAD of the list | GREEN |
| `asc: c.user_id` dropped from the query's `order_by` | — | RED — 1 failure, this test |

The second is the 2026-08-11 entry's own mutant re-run on the narrowed oracle:
it still kills exactly this test, which is what says the filter did not weaken
the ordering it exists to pin.

## Gate evidence, and its limits

Run locally, on the branch tree:

- `scripts/test.sh test/grappa/networks_test.exs` — **rc=0, 117 tests, 0
  failures**, on a cache cleaned by `mix --env=test compile --force` (rc=0, 345
  files).
- `scripts/design-notes-gate.sh origin/main` — **rc=0**, separator and marker
  present.

**Not measured locally: `scripts/check.sh` in full.** The compile lane was held
by a concurrent session, so format / Credo / Dialyzer / Sobelow / doctor / the
wire-type drift gate / bats were not run here. Per house rule, a contended lane
is gated from this PR's CI instead. Those are *not measured*, not *green*.

**Expect FOUR checks, not five.** `integration.yml` filters `pull_request` on
paths that include neither `test/**` nor `docs/**`, and this branch touches
only those two, so the `e2e` job will not start. Reading a 4/4 as if it were a
5/5 would be reading a workflow that never ran as a pass.
