### PR TITLE
#1499: narrow the idle-session reaper to the rows it actually reaped

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52468,3 +52468,103 @@ or a CI runner; the runs are the local module (`117 tests`) plus the full
 `check.sh`. And whether ExUnit can overlap this `async: false` module with an
 `async: true` module that writes credentials was NOT established — the sandbox
 mode was read, the scheduler was not.
+<!-- entry #1499 -->
+
+---
+
+## 2026-08-20 — #1499: a socket outlives its row, so the reaper must fire — narrowly
+
+The idle-session reaper deleted rows past the 7-day window and announced
+`Revocations.announce({:user, name})` per distinct owner. On h-irc, 2026-08-17
+18:00:30, one week-old row of an active account crossed the window; the account's
+`bicchierino` IRC bridge lost its WebSocket and the weechat behind it rejoined 14
+channels. The bridge's own bearer had never expired.
+
+### The conflict, and which side the measurement took
+
+#1499's body proposes dropping the announcement outright: the rows are already
+dead at read-time, `authenticate/1` returns `{:error, :expired}` for anything past
+the window, so no live socket can be resting on one. That reading is about the
+ROW. The question is about the SOCKET, and the two coincide only if an open socket
+re-authenticates.
+
+It does not, and this was measured rather than reasoned. `Accounts.authenticate/1`
+has three call sites — REST `Plugs.Authn`, the visitor login, and
+`GrappaWeb.UserSocket`, which reaches it once, at connect — and
+`Session.touch_changeset/2`, driven from that one function, is the only writer of
+`last_seen_at`. A client that speaks only over the WebSocket therefore never
+refreshes its row, which ages out under a connection that is still serving.
+`GrappaWeb.SocketLivenessVsSessionRowTest` pins it and passes on `98c180ac`
+unchanged. **So the announcement is load-bearing: removing it strands a live
+socket on a deleted row.** The body's smallest-first option is dead, and the
+house rule applied — where an issue's text disagrees with measured code, the code
+wins.
+
+What remained was the granularity, and the reaper is where per-subject stops being
+defensible. `Revocations`' "over-firing is the safe direction" was argued for doors
+the account holder had just walked through, where a reconnect is expected and
+`phoenix.js` handles it. The reaper fires on a 60s timer with no request and no
+operator behind it, so its blast lands on whoever happened to be connected, and it
+lands in a downstream IRC client as a server disconnect plus a rejoin storm.
+
+### The shape: additive, not a re-key
+
+`UserSocket.id/1` stays keyed by subject; every authenticated transport now ALSO
+subscribes to `UserSocket.id_for_session/1` at connect, and
+`Revocations.announce_session/1` → `UserSocket.disconnect_session/1` addresses it.
+`Phoenix.Socket.__info__/2` stops a transport on a `"disconnect"` broadcast
+whatever topic carried it, so both addresses reuse the one teardown path.
+
+Re-keying `id/1` onto `session_id` — the option the issue body names, together
+with teaching `WSPresence` to carry it — was rejected: `id/1` yields ONE topic, so
+the five account-wide doors would lose their address for a subject entirely and
+have to enumerate live sessions to rebuild one. Under-firing a revoke is the
+failure `Revocations` exists to prevent.
+
+The two topics cannot collide, and not by luck: a user name matches
+`~r/^[a-zA-Z][a-zA-Z0-9_\-]*$/` so it can never contain a `:`, which is the same
+argument the pre-existing `"user_socket:visitor:" <> id` already rests on.
+
+The subscribe sits in `connect/3` rather than `init/1` because `use Phoenix.Socket`
+generates `init/1` non-overridably. It leans on the same guarantee
+`WSPresence.register/2` two lines above has leaned on since #182 — that `connect/3`
+runs in the process that will own the socket. That is a dependency on Phoenix's
+transport shape, stated here rather than guarded, because no test in a
+`server: false` suite can distinguish it.
+
+### The oracle
+
+`GrappaWeb.ReaperSocketBlastRadiusTest` stands up one transport process per socket
+and drives the production `Phoenix.Socket.Transport` callbacks — the harness is a
+stand-in for the WebSock adapter, not for the socket, and holds no view of its own
+on what closes a connection. Two transports in one process could not have shown
+the defect: both the subscription and the teardown are per-process.
+
+| state | the reaped session's socket | the other socket of the same user |
+|---|---|---|
+| `98c180ac`, before the cure | down (positive control, passes) | **down — RED** |
+| after the cure | down | serving |
+
+The positive control passes on both sides, so the survival claim is not a teardown
+path that had quietly stopped working. `session_revocation_listener_test.exs`
+asserts the narrowing in both directions — a session announcement must not reach
+the subject topic, and a subject announcement must not be narrowed onto a session
+topic — so neither granularity can absorb the other.
+
+### Option (b), priced and not taken
+
+The alternative cure was to keep the row fresh while its socket is alive, so it
+never becomes a reap candidate. Rejected on meaning, not on cost: `last_seen_at`
+is what `authenticate/1` gates on, so bumping it from a connection would redefine
+"idle" from *nobody has used this credential* to *nobody has closed this tab*, and
+an abandoned logged-in browser would then hold a bearer open indefinitely. It is
+also the larger change — a new writer on the auth-gate column, on a cadence, from
+the WS layer.
+
+### Not claimed
+
+No incidence. The reaper only bites rows past 7 days of idleness, so #1499
+explains PERIODIC drops; if the reported account drops more often than that, this
+is one cause and not established as the only one, and nothing here looked for the
+rest. Nothing was measured against production or CI — the runs are the local
+module set plus a full `check.sh`.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -1232,6 +1232,15 @@ defmodule Grappa.Accounts do
   Returns `{:ok, count}` with the number of rows removed; the count
   rides the audit log so a no-op sweep stays distinguishable from a
   productive one.
+
+  Announces one `Revocations.announce_session/1` per row swept, NOT a
+  `{:user, name}` for each owner (#1499). "Already un-reusable" above is
+  a claim about the ROW, and the socket is a separate object: a WebSocket
+  authenticates once, at connect, so a live one goes on serving over a
+  row that ages out beneath it. Both halves follow from that — the
+  announcement has to happen (or the socket outlives its bearer), and it
+  has to be narrow (or it takes down the account's other, valid sockets
+  with it, which is the production incident #1499 reports).
   """
   @spec delete_expired_sessions() :: {:ok, non_neg_integer()} | {:error, :db_unavailable}
   def delete_expired_sessions do
@@ -1251,8 +1260,8 @@ defmodule Grappa.Accounts do
     # owns the best-effort-DROP terminal — NO 503 (no web caller). Wrap the
     # `delete_all` in an `{:ok, _}` so it honours the `BusyRetry.run/1`
     # contract.
-    case Repo.BusyRetry.run(fn -> {:ok, {expired_user_names(query), Repo.delete_all(query)}} end) do
-      {:ok, {names, {deleted, _}}} ->
+    case Repo.BusyRetry.run(fn -> {:ok, {expired_session_ids(query), Repo.delete_all(query)}} end) do
+      {:ok, {ids, {deleted, _}}} ->
         # Suppressed on count=0: the reaper calls this every 60s, so an
         # unconditional line would flood the log with 1440 idle "reaped 0"
         # entries/day. A productive sweep logs once so the lifecycle stays
@@ -1261,7 +1270,26 @@ defmodule Grappa.Accounts do
         # was observed — N rows past the idle window — not merely "ran".)
         if deleted > 0, do: Logger.info("expired sessions reaped", affected: deleted)
 
-        Enum.each(names, &Revocations.announce({:user, &1}))
+        # #1499 — announced per SESSION, not per owner. This door deletes
+        # ONE row of an account that may have a dozen live sockets on
+        # other, perfectly valid bearers, and a `{:user, name}`
+        # announcement closes all of them: measured in production on
+        # 2026-08-17, where a week-old row of an active account crossed
+        # the window and dropped that account's IRC bridge, costing a
+        # full channel-rejoin storm downstream. Nothing here justifies
+        # the wide address — the sweep's own claim is exactly "these
+        # bearers are gone", never "this account is".
+        #
+        # The announcement is NOT optional, which is the other half of
+        # #1499 and the opposite of what its body proposed. The rows are
+        # dead in law the moment they cross the window, but a WebSocket
+        # authenticates once and never again (`authenticate/1` has three
+        # call sites and the WS one runs at connect), so `last_seen_at`
+        # freezes under a socket that is still serving and the row ages
+        # out beneath it. Dropping the announcement would leave that
+        # socket open on a row that no longer exists — pinned by
+        # `GrappaWeb.SocketLivenessVsSessionRowTest`.
+        Enum.each(ids, &Revocations.announce_session/1)
 
         {:ok, deleted}
 
@@ -1270,22 +1298,15 @@ defmodule Grappa.Accounts do
     end
   end
 
-  # The distinct owners of the rows `delete_expired_sessions/0` is about to
-  # remove, as socket id-topic labels. Read BEFORE the DELETE: the user rows
-  # survive the sweep, but the sessions that name them do not, so afterwards
-  # there is nothing left to join.
+  # The ids of the rows `delete_expired_sessions/0` is about to remove, as
+  # socket teardown addresses. Read BEFORE the DELETE, for the obvious
+  # reason that afterwards there is nothing left to read.
   #
   # A second statement on a 60s timer whose usual result is the empty list.
   # `delete_all(returning: …)` would avoid it, but the sweep is the reaper's
   # whole tick — there is no hot path to protect here.
-  @spec expired_user_names(Ecto.Query.t()) :: [String.t()]
-  defp expired_user_names(query) do
-    query
-    |> join(:inner, [s], u in User, on: u.id == s.user_id)
-    |> distinct(true)
-    |> select([_s, u], u.name)
-    |> Repo.all()
-  end
+  @spec expired_session_ids(Ecto.Query.t()) :: [Ecto.UUID.t()]
+  defp expired_session_ids(query), do: query |> select([s], s.id) |> Repo.all()
 
   # #1196 — a client token does not age out. The whole failure this
   # feature exists to remove is an unattended client coming back after a

--- a/lib/grappa/accounts/reaper.ex
+++ b/lib/grappa/accounts/reaper.ex
@@ -25,11 +25,27 @@ defmodule Grappa.Accounts.Reaper do
   `Accounts.delete_expired_sessions/0` — a single set-based
   `Repo.delete_all` over USER sessions whose `last_seen_at` is older
   than the 7-day idle window (`Accounts.@idle_timeout_seconds`, the
-  same constant `authenticate/1` gates on). The rows removed are
-  already un-authenticatable at read-time, so the GC only reclaims
-  dead material; it changes no liveness semantics. Visitor sessions
-  are deliberately out of scope — they CASCADE from the visitor row
-  via `Grappa.Visitors.Reaper`.
+  same constant `authenticate/1` gates on). Visitor sessions are
+  deliberately out of scope — they CASCADE from the visitor row via
+  `Grappa.Visitors.Reaper`.
+
+  ## It DOES change liveness (#1499)
+
+  This moduledoc used to claim the sweep "only reclaims dead material;
+  it changes no liveness semantics", on the reading that a row past the
+  window can no longer authenticate so nothing can be resting on it.
+  That is true of the ROW and false of the SOCKET, and the distinction
+  is the whole of #1499: `GrappaWeb.UserSocket` calls
+  `Accounts.authenticate/1` once, at connect, and never again, so a
+  client that speaks only over the WebSocket never refreshes
+  `last_seen_at` and its row ages out underneath a connection that is
+  still serving. `GrappaWeb.SocketLivenessVsSessionRowTest` pins it.
+
+  So the sweep genuinely closes live sockets, and must: leaving one open
+  on a row it has just deleted is worse. What it must NOT do is close
+  the account's OTHER sockets, which is what a per-subject announcement
+  did until #1499 re-keyed it to `Revocations.announce_session/1` — one
+  announcement per row swept, addressed at that bearer alone.
 
   ## No AdminEvent
 

--- a/lib/grappa/accounts/revocations.ex
+++ b/lib/grappa/accounts/revocations.ex
@@ -34,16 +34,37 @@ defmodule Grappa.Accounts.Revocations do
   single hard-delete mechanic for visitor rows). A new door inherits the
   teardown by construction.
 
-  ## Granularity: per-subject, deliberately
+  ## Two granularities: per-subject and per-session (#1499)
 
-  `UserSocket.id/1` is keyed by subject, not by session, so the teardown
-  closes EVERY socket of the subject. On the "revoke all the OTHER
-  sessions" paths (TOTP enrolment/disable, passkey mode change) the
-  device that performed the operation is disconnected too. Its bearer is
-  still valid, so `phoenix.js` reconnects on its own: the cost is a blip.
-  Per-session granularity would require re-keying `UserSocket.id/1` and
-  teaching `Grappa.WSPresence` to carry `session_id`; it stays an open,
-  strictly additive question.
+  `announce/1` names a SUBJECT and closes every socket that subject has;
+  `announce_session/1` names ONE bearer session and closes only the
+  sockets carrying it. A door picks by what it actually killed.
+
+  Per-subject is right wherever the account itself changed hands or shape
+  — `delete_user/1`, `revoke_sessions_for_user/1`, the visitor destroy —
+  and on the "revoke all the OTHER sessions" paths (TOTP
+  enrolment/disable, passkey mode change), where the acting device is
+  disconnected too although its bearer survives. That one IS a blip:
+  `phoenix.js` reconnects on its own, and the operation was something the
+  account holder had just performed, so a reconnect is expected.
+
+  Per-subject was WRONG for the idle-session reaper, which is what #1499
+  reported. That door kills one stale row on a 60s timer with no request
+  and no operator behind it, so the sockets it took down belonged to
+  whoever happened to be connected — measured in production on
+  2026-08-17, where reaping a week-old row of an active account dropped
+  that account's IRC bridge and cost a full channel-rejoin storm on a
+  bearer that had never expired. Nothing about that is a blip, and
+  nothing about it was the account holder's doing.
+
+  The finer address is ADDITIVE: `UserSocket.id/1` stays keyed by
+  subject and every transport ALSO subscribes to
+  `UserSocket.id_for_session/1` at connect. Re-keying `id/1` onto the
+  session (the option #1499's body names, alongside teaching
+  `Grappa.WSPresence` to carry `session_id`) was rejected — `id/1` yields
+  ONE topic, so the account-wide doors would lose their address entirely
+  and have to enumerate live sessions to rebuild it. Under-firing is
+  still the failure that matters; a door in doubt announces the subject.
 
   ## Over-firing is the safe direction
 
@@ -78,8 +99,16 @@ defmodule Grappa.Accounts.Revocations do
   """
   @type subject :: {:user, String.t()} | {:visitor, String.t()}
 
-  @typedoc "The message a subscriber receives."
-  @type event :: {:sessions_revoked, subject()}
+  @typedoc """
+  The messages a subscriber receives.
+
+  Plural vs singular is the whole distinction and it is load-bearing:
+  `:sessions_revoked` carries a SUBJECT and means every bearer it has is
+  dead, `:session_revoked` carries ONE session id and means only that
+  one is. A listener that handles the plural shape must not be assumed
+  to handle the singular — they close different sets of sockets.
+  """
+  @type event :: {:sessions_revoked, subject()} | {:session_revoked, Ecto.UUID.t()}
 
   @doc """
   Subscribes the calling process to the revocation stream.
@@ -109,11 +138,7 @@ defmodule Grappa.Accounts.Revocations do
   """
   @spec announce(subject()) :: :ok
   def announce({tag, label} = subject) when tag in [:user, :visitor] and is_binary(label) do
-    case Phoenix.PubSub.broadcast(
-           Grappa.PubSub,
-           Topic.session_revocations(),
-           {:sessions_revoked, subject}
-         ) do
+    case broadcast({:sessions_revoked, subject}) do
       :ok ->
         :ok
 
@@ -126,4 +151,48 @@ defmodule Grappa.Accounts.Revocations do
         :ok
     end
   end
+
+  @doc """
+  Announces that ONE bearer session is dead (#1499).
+
+  The narrow twin of `announce/1`, for a door that killed a single row
+  rather than an account: `GrappaWeb.SessionRevocationListener` turns it
+  into `GrappaWeb.UserSocket.disconnect_session/1`, which closes the
+  sockets carrying that bearer and leaves the subject's other sockets
+  serving.
+
+  Use it only where the narrow claim is actually true. Announcing one
+  session where the account died would under-fire, and under-firing is
+  the failure this module exists to prevent — see the granularity
+  section above.
+
+  Fire-and-forget on the same terms as `announce/1`.
+  """
+  @spec announce_session(Ecto.UUID.t()) :: :ok
+  def announce_session(session_id) when is_binary(session_id) do
+    case broadcast({:session_revoked, session_id}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        # No id on the line, and no `:subject_kind` either. The id is the
+        # bearer token itself (S9 — `accounts_sessions.id` is what the
+        # client presents), and `Grappa.Accounts.Session.handle/1`, which
+        # exists to make one greppable without printing it, is on the far
+        # side of this boundary's `deps`. `:subject_kind` is documented in
+        # `config/config.exs` as `:user | :visitor`, where anything else
+        # reads as an unknown-shape drop worth investigating — so a
+        # `:session` value there would send an operator hunting a bug that
+        # is not one. The distinct message carries the distinction instead.
+        Logger.warning("single-session revocation announce failed", reason: inspect(reason))
+
+        :ok
+    end
+  end
+
+  # The one publish. Both granularities ride the same topic and the same
+  # single subscriber; only the event shape and the failure line differ.
+  @spec broadcast(event()) :: :ok | {:error, term()}
+  defp broadcast(event),
+    do: Phoenix.PubSub.broadcast(Grappa.PubSub, Topic.session_revocations(), event)
 end

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -300,6 +300,35 @@ defmodule GrappaWeb.UserSocket do
       #     with long-lived tabs never saw the refresh banner trigger.
       :ok = WSPresence.register(socket.assigns.user_name, self())
 
+      # #1499 — a SECOND teardown address for this transport, keyed by
+      # SESSION, alongside the per-SUBJECT one Phoenix subscribes us to
+      # from the `id/1` callback. Both are plain id-topics carrying the
+      # same `"disconnect"` event, and `Phoenix.Socket.__info__/2` stops
+      # the transport on that event whatever topic it arrived on — so a
+      # door that wants ONE bearer's socket closed now has an address for
+      # it, and the doors that want the whole account off every device
+      # keep using the subject topic untouched.
+      #
+      # Strictly additive on purpose. Re-keying `id/1` itself was the
+      # other way to get per-session granularity (it is the one #1499's
+      # body names), and it is the wrong one: `id/1` yields ONE topic, so
+      # moving it to the session would leave the five account-wide doors
+      # — `delete_user/1`, `revoke_sessions_for_user/1`, the two
+      # `revoke_other_sessions_*`, the visitor destroy — with no address
+      # for a subject at all, and they would have to enumerate live
+      # sessions to rebuild one. Under-firing a revoke is the failure
+      # that matters (see `Grappa.Accounts.Revocations`), so the coarse
+      # address stays and the fine one is added beside it.
+      #
+      # Subscribed HERE rather than in `init/1` because `init/1` is
+      # generated non-overridably by `use Phoenix.Socket`. That makes
+      # this rest on the same guarantee `WSPresence.register/2` above
+      # already rests on — that `connect/3` runs in the process that will
+      # own the WebSocket. It holds for both transports Phoenix ships
+      # (the upgrade keeps the request process), and auto-away has been
+      # riding it in production since #182.
+      :ok = GrappaWeb.Endpoint.subscribe(id_for_session(session.id))
+
       # #95 + #202 — connect observability (NEVER the token). The Logger
       # line is greppable; the `[:grappa, :ws, :connect]` counter is a
       # cheap ops signal (a Phase-5 exporter can aggregate connect churn).
@@ -345,6 +374,23 @@ defmodule GrappaWeb.UserSocket do
   def id_for_subject(subject), do: id_for_user_name(Subject.topic_label(subject))
 
   @doc """
+  #1499: the teardown topic of ONE bearer session, as opposed to
+  `id_for_subject/1`'s topic for every socket of a subject.
+
+  Every authenticated transport subscribes to this at connect
+  (`authenticate_and_assign/2`), user and visitor alike — the session id
+  is the one identifier both branches always have.
+
+  It cannot collide with a subject topic, and not by luck: a user name
+  matches `~r/^[a-zA-Z][a-zA-Z0-9_\\-]*$/` (`Grappa.Accounts.User`) so it
+  can never contain a `:`, which is the same argument the pre-existing
+  `"user_socket:visitor:" <> id` shape already rests on.
+  """
+  @spec id_for_session(Ecto.UUID.t()) :: String.t()
+  def id_for_session(session_id) when is_binary(session_id),
+    do: id_for_user_name("session:" <> session_id)
+
+  @doc """
   Close the live WebSocket for `subject` by broadcasting `"disconnect"`
   to its id-topic (the topic the transport process subscribes to at
   connect time). Phoenix's socket `__info__` catch-all maps the event to
@@ -379,9 +425,36 @@ defmodule GrappaWeb.UserSocket do
   rejected on its next connect anyway).
   """
   @spec disconnect_user_name(String.t()) :: :ok
-  def disconnect_user_name(user_name) when is_binary(user_name) do
-    socket_id = id_for_user_name(user_name)
+  def disconnect_user_name(user_name) when is_binary(user_name),
+    do: user_name |> id_for_user_name() |> push_disconnect()
 
+  @doc """
+  Close the live WebSocket(s) carrying ONE bearer session, leaving every
+  other socket of the same subject serving (#1499).
+
+  The narrow twin of `disconnect_user_name/1`, for the doors that kill a
+  single row rather than an account: the idle-session reaper is the
+  first, and it is the one that made the difference visible, because it
+  fires on a timer with nobody behind it. Same id-topic broadcast, a
+  different address — one teardown code path, two granularities.
+
+  Usually one socket, not necessarily: two transports opened with the
+  same bearer share the session and both go down, which is correct —
+  the row under them is what died.
+
+  Fire-and-forget on the same terms as `disconnect_user_name/1`.
+  """
+  @spec disconnect_session(Ecto.UUID.t()) :: :ok
+  def disconnect_session(session_id) when is_binary(session_id),
+    do: session_id |> id_for_session() |> push_disconnect()
+
+  # The ONE socket-teardown broadcast, shared by both granularities. A
+  # PubSub-unreachable `{:error, _}` is logged and swallowed: the caller
+  # has already revoked or deleted the row, so the socket is refused at
+  # its next connect regardless, and a failed accelerator must never turn
+  # a completed revocation into a failed one.
+  @spec push_disconnect(String.t()) :: :ok
+  defp push_disconnect(socket_id) do
     case GrappaWeb.Endpoint.broadcast(socket_id, "disconnect", %{}) do
       :ok ->
         :ok

--- a/lib/grappa_web/session_revocation_listener.ex
+++ b/lib/grappa_web/session_revocation_listener.ex
@@ -3,12 +3,18 @@ defmodule GrappaWeb.SessionRevocationListener do
   Translates the `Grappa.Accounts.Revocations` domain event into the
   existing socket teardown.
 
-  The whole web-side half of the fix: the contexts announce that a
-  subject's bearer sessions are dead, this process turns that into
-  `GrappaWeb.UserSocket.disconnect_user_name/1`. It exists so the kill
-  sites do not have to reach into the web layer — a context → web
-  dependency `Boundary` refuses, and rightly: `Grappa.Accounts` has no
-  business knowing that a WebSocket is what dies.
+  The whole web-side half of the fix: the contexts announce that bearer
+  sessions are dead, this process turns that into the matching socket
+  teardown — `GrappaWeb.UserSocket.disconnect_user_name/1` for a whole
+  subject, `disconnect_session/1` for one bearer (#1499). It exists so
+  the kill sites do not have to reach into the web layer — a context →
+  web dependency `Boundary` refuses, and rightly: `Grappa.Accounts` has
+  no business knowing that a WebSocket is what dies.
+
+  The granularity is chosen by the ANNOUNCER, not here: a door knows
+  what it killed and this process does not. Both events ride one topic
+  and one subscriber, so there is still exactly one place where a
+  revocation becomes a closed socket.
 
   Stateless and single-subscriber. It holds no socket registry of its
   own: the id-topic broadcast is addressed by label, and Phoenix's
@@ -65,6 +71,16 @@ defmodule GrappaWeb.SessionRevocationListener do
   @impl GenServer
   def handle_info({:sessions_revoked, subject}, state) do
     :ok = subject |> Subject.label() |> UserSocket.disconnect_user_name()
+    {:noreply, state}
+  end
+
+  # #1499 — the narrow half. Plural above closes every socket of a
+  # subject; singular here closes only the sockets carrying one bearer.
+  # Two clauses rather than one with a branch, because they are two
+  # different claims about what died and the pattern is where that is
+  # stated. The catch-all below still covers a shape neither models.
+  def handle_info({:session_revoked, session_id}, state) do
+    :ok = UserSocket.disconnect_session(session_id)
     {:noreply, state}
   end
 

--- a/test/grappa/session_revocation_test.exs
+++ b/test/grappa/session_revocation_test.exs
@@ -135,21 +135,46 @@ defmodule Grappa.SessionRevocationTest do
       assert name == user.name
     end
 
-    test "delete_expired_sessions/0 announces every owner it swept" do
-      first = stale_session_owner()
-      second = stale_session_owner()
+    # #1499 — one announcement per ROW, naming the row. This used to
+    # announce `{:user, name}` per distinct owner, and that is the defect:
+    # the sweep's claim is "these bearers are gone", never "these accounts
+    # are", and the wide announcement closed every socket of each owner.
+    test "delete_expired_sessions/0 announces every session it swept, not their owners" do
+      first = stale_session()
+      second = stale_session()
 
       assert {:ok, 2} = Accounts.delete_expired_sessions()
 
-      assert_receive {:sessions_revoked, {:user, one}}
-      assert_receive {:sessions_revoked, {:user, two}}
-      assert Enum.sort([one, two]) == Enum.sort([first.name, second.name])
+      assert_receive {:session_revoked, one}
+      assert_receive {:session_revoked, two}
+      assert Enum.sort([one, two]) == Enum.sort([first.id, second.id])
+
+      # The absence is half the contract: a subject-wide announcement here
+      # is precisely what took the bystander sockets down.
+      refute_receive {:sessions_revoked, _}, 100
+    end
+
+    # The narrowing, stated at the door. `ReaperSocketBlastRadiusTest` is
+    # the same claim measured on live transports; this one keeps it
+    # falsifiable without standing any up, so a regression is attributed
+    # to the announcement rather than to the socket layer.
+    test "delete_expired_sessions/0 says nothing about the owner's surviving sessions" do
+      user = user_fixture()
+      stale_id = age_out(session_fixture(user)).id
+      fresh_id = session_fixture(user).id
+
+      assert {:ok, 1} = Accounts.delete_expired_sessions()
+
+      assert_receive {:session_revoked, ^stale_id}
+      refute_receive {:session_revoked, ^fresh_id}, 100
+      refute_receive {:sessions_revoked, _}, 100
     end
 
     test "delete_expired_sessions/0 announces nothing on an idle sweep" do
       assert {:ok, 0} = Accounts.delete_expired_sessions()
 
       refute_receive {:sessions_revoked, _}, 100
+      refute_receive {:session_revoked, _}, 100
     end
 
     test "Visitors.delete/1 announces the visitor" do
@@ -194,11 +219,17 @@ defmodule Grappa.SessionRevocationTest do
     :ok
   end
 
-  defp stale_session_owner do
-    {user, session} = user_and_session()
+  defp stale_session do
+    {_user, session} = user_and_session()
+    age_out(session)
+  end
+
+  # Backdates the row past the idle window and hands it back, so a caller
+  # can name the session the sweep is about to take.
+  defp age_out(%Session{} = session) do
     when_seen = DateTime.add(DateTime.utc_now(), -(@idle_seconds + 3600), :second)
     query = from(s in Session, where: s.id == ^session.id)
     {1, _} = Repo.update_all(query, set: [last_seen_at: when_seen])
-    user
+    session
   end
 end

--- a/test/grappa/session_revocation_test.exs
+++ b/test/grappa/session_revocation_test.exs
@@ -220,7 +220,7 @@ defmodule Grappa.SessionRevocationTest do
   end
 
   defp stale_session do
-    {_user, session} = user_and_session()
+    {_, session} = user_and_session()
     age_out(session)
   end
 

--- a/test/grappa_web/reaper_socket_blast_radius_test.exs
+++ b/test/grappa_web/reaper_socket_blast_radius_test.exs
@@ -1,0 +1,188 @@
+defmodule GrappaWeb.ReaperSocketBlastRadiusTest do
+  @moduledoc """
+  #1499 — the BLAST RADIUS of the idle-session reaper, measured on live
+  transports rather than on the announcement.
+
+  `Grappa.SessionRevocationTest` asserts that the reaper announces, and
+  `GrappaWeb.SessionRevocationListenerTest` asserts that an announcement
+  reaches an id-topic. Neither can see the defect, because both are
+  written from the point of view of ONE subject: the reaper's
+  announcement is keyed by `{:user, name}`, so a test that expects a
+  teardown for that user gets one and is satisfied. The question #1499
+  asks is how many OTHER sockets went down with it, and that is only
+  visible with two live transports of the same user in the same test.
+
+  Reaping is the door where this matters most: it fires on a 60s timer
+  with no request and no operator behind it, so the socket it takes down
+  belongs to whoever happened to be connected.
+
+  ## Why a transport process per socket
+
+  Both halves of the mechanism under test are per-PROCESS. The id-topic
+  subscription is made by `Phoenix.Socket.__init__/1` in the process that
+  connects, and the teardown is that same process receiving a
+  `"disconnect"` broadcast. Two sockets assembled in the test process
+  would share one mailbox and one subscription set — exactly the
+  distinction the measurement needs.
+
+  `start_transport!/1` is therefore a stand-in for the WebSock adapter,
+  NOT for the socket: it drives the production `Phoenix.Socket.Transport`
+  callbacks `GrappaWeb.UserSocket` generates (`connect/1`, `init/1`,
+  `handle_info/2`) and holds no opinion of its own about what should
+  close a connection. `init/1` establishes the real subscription set;
+  `handle_info/2` is what turns a `"disconnect"` broadcast into
+  `{:stop, …}`. The loop only obeys the verdict it is handed, so a
+  passing test here cannot be an artefact of the harness agreeing with
+  itself.
+  """
+  use GrappaWeb.ChannelCase, async: false
+
+  import Ecto.Query
+  import Grappa.AuthFixtures
+
+  alias Grappa.{Accounts, Repo}
+  alias Grappa.Accounts.{Reaper, Session}
+  alias GrappaWeb.UserSocket
+
+  @idle_seconds 7 * 24 * 3600
+
+  describe "the idle-session reaper" do
+    test "reaping one session leaves the same user's other socket serving" do
+      user = user_fixture()
+      stale = session_fixture(user)
+      fresh = session_fixture(user)
+
+      # Both sockets connect while both bearers are still good — the
+      # ageing comes after, because `authenticate/1` refuses an expired
+      # row at the door and bumps `last_seen_at` when it admits one.
+      # This is the order the incident had: a bridge that connected days
+      # before an unrelated row of the same account crossed the window.
+      stale_ws = start_transport!(stale.id)
+      fresh_ws = start_transport!(fresh.id)
+
+      stale_ref = Process.monitor(stale_ws)
+      fresh_ref = Process.monitor(fresh_ws)
+
+      :ok = age_past_idle_window(stale.id)
+
+      # The pre-state, so a socket that never came up cannot be mistaken
+      # for one the sweep took down.
+      assert Process.alive?(stale_ws)
+      assert Process.alive?(fresh_ws)
+
+      # Exactly one row is reaped. Asserted, not assumed: a sweep that
+      # found nothing would satisfy every survival claim below while
+      # measuring nothing at all.
+      assert {:ok, 1} = Reaper.sweep()
+
+      # Positive control — the reaped session's own socket DOES go down.
+      # Without it, the survival assertion could pass on a teardown path
+      # that had simply stopped working.
+      assert_receive {:DOWN, ^stale_ref, :process, ^stale_ws, _}, 1_000
+
+      # The defect. Both transports subscribe to the SUBJECT id-topic, so
+      # the per-user announcement closes this one too, though its bearer
+      # is untouched and its row was never a reap candidate.
+      refute_receive {:DOWN, ^fresh_ref, :process, ^fresh_ws, _}, 200
+      assert Process.alive?(fresh_ws)
+
+      # …and it was never dead in law either, which is what makes the
+      # teardown a defect rather than a rounding error.
+      assert {:ok, _} = Accounts.authenticate(fresh.id)
+    end
+
+    # The counterweight. Narrowing the reaper must not narrow the doors
+    # whose whole job is to take the account off every device it is on:
+    # `revoke_sessions_for_user/1` is operator recovery, and a survivor
+    # there is a security failure, not a blip.
+    test "an account-wide revoke still takes down every socket of the user" do
+      user = user_fixture()
+      one = session_fixture(user)
+      two = session_fixture(user)
+
+      one_ws = start_transport!(one.id)
+      two_ws = start_transport!(two.id)
+
+      one_ref = Process.monitor(one_ws)
+      two_ref = Process.monitor(two_ws)
+
+      assert :ok = Accounts.revoke_sessions_for_user(user)
+
+      assert_receive {:DOWN, ^one_ref, :process, ^one_ws, _}, 1_000
+      assert_receive {:DOWN, ^two_ref, :process, ^two_ws, _}, 1_000
+    end
+  end
+
+  # Seven days and an hour of silence on the row, leaving the socket
+  # untouched. `last_seen_at` is bumped by `Accounts.authenticate/1`
+  # alone, which the WS path reaches once, at connect — so this is not a
+  # contrived state, it is what any WS-only client's row does on its own.
+  @spec age_past_idle_window(Ecto.UUID.t()) :: :ok
+  defp age_past_idle_window(session_id) do
+    when_seen = DateTime.add(DateTime.utc_now(), -(@idle_seconds + 3600), :second)
+    query = from(s in Session, where: s.id == ^session_id)
+    {1, _} = Repo.update_all(query, set: [last_seen_at: when_seen])
+    :ok
+  end
+
+  # Brings up one transport process per socket and returns its pid, or
+  # fails the test naming what `UserSocket` did instead. The connect map
+  # mirrors the one `Phoenix.ChannelTest.__connect__/4` builds — that
+  # helper discards the transport state, and the state is what
+  # `handle_info/2` needs.
+  @spec start_transport!(String.t()) :: pid()
+  defp start_transport!(token) do
+    parent = self()
+
+    connect_map = %{
+      endpoint: GrappaWeb.Endpoint,
+      transport: :websocket,
+      options: [serializer: [{Phoenix.ChannelTest.NoopSerializer, "~> 1.0.0"}]],
+      params: %{},
+      connect_info: %{auth_token: token}
+    }
+
+    pid =
+      spawn(fn ->
+        case UserSocket.connect(connect_map) do
+          {:ok, state} ->
+            {:ok, state} = UserSocket.init(state)
+            send(parent, {:transport_up, self()})
+            serve(state)
+
+          refused ->
+            send(parent, {:transport_refused, self(), refused})
+        end
+      end)
+
+    # Registered before the wait: a transport that comes up and is never
+    # torn down would outlive the sandbox owner and keep speaking to a
+    # checked-in connection. `on_exit` runs LIFO, so this fires before
+    # `ChannelCase`'s `stop_owner`.
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    receive do
+      {:transport_up, ^pid} -> pid
+      {:transport_refused, ^pid, refused} -> flunk("UserSocket refused the bearer: #{inspect(refused)}")
+    after
+      1_000 -> flunk("transport process never reported in")
+    end
+  end
+
+  # The adapter's loop, with the adapter's opinions left out: every
+  # message is handed to the production `handle_info/2` and the return
+  # value decides. `{:stop, …}` ends the process, which is what
+  # `Process.alive?/1` and the monitor above read as "the socket closed".
+  @spec serve(term()) :: :ok
+  defp serve(state) do
+    receive do
+      message ->
+        case UserSocket.handle_info(message, state) do
+          {:ok, state} -> serve(state)
+          {:push, _reply, state} -> serve(state)
+          {:stop, _reason, _code, _state} -> :ok
+          {:stop, _reason, _state} -> :ok
+        end
+    end
+  end
+end

--- a/test/grappa_web/reaper_socket_blast_radius_test.exs
+++ b/test/grappa_web/reaper_socket_blast_radius_test.exs
@@ -179,9 +179,9 @@ defmodule GrappaWeb.ReaperSocketBlastRadiusTest do
       message ->
         case UserSocket.handle_info(message, state) do
           {:ok, state} -> serve(state)
-          {:push, _reply, state} -> serve(state)
-          {:stop, _reason, _code, _state} -> :ok
-          {:stop, _reason, _state} -> :ok
+          {:push, _, state} -> serve(state)
+          {:stop, _, _, _} -> :ok
+          {:stop, _, _} -> :ok
         end
     end
   end

--- a/test/grappa_web/session_revocation_listener_test.exs
+++ b/test/grappa_web/session_revocation_listener_test.exs
@@ -41,6 +41,37 @@ defmodule GrappaWeb.SessionRevocationListenerTest do
     assert_receive %Phoenix.Socket.Broadcast{topic: ^socket_id, event: "disconnect"}
   end
 
+  # #1499 — the narrow half of the contract, asserted on both topics at
+  # once. Checking only that the session topic fires would still pass if
+  # the listener had kept announcing the subject as well, which is the
+  # exact behaviour the issue reports.
+  test "a session announcement pushes disconnect on that session's topic and no other" do
+    session_id = Ecto.UUID.generate()
+    session_topic = UserSocket.id_for_session(session_id)
+    name = "owner-#{System.unique_integer([:positive])}"
+    subject_topic = UserSocket.id_for_subject({:user, %User{name: name}})
+
+    :ok = Endpoint.subscribe(session_topic)
+    :ok = Endpoint.subscribe(subject_topic)
+
+    :ok = Revocations.announce_session(session_id)
+
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^session_topic, event: "disconnect"}
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^subject_topic}, 100
+  end
+
+  # The converse, so neither granularity can quietly absorb the other: a
+  # subject-wide revoke must NOT be narrowed into a per-session one, or
+  # the account-recovery doors would start leaving sockets up.
+  test "a subject announcement does not reach an unrelated session's topic" do
+    session_topic = UserSocket.id_for_session(Ecto.UUID.generate())
+    :ok = Endpoint.subscribe(session_topic)
+
+    :ok = Revocations.announce({:user, "revoked-#{System.unique_integer([:positive])}"})
+
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^session_topic}, 100
+  end
+
   test "an announcement for one subject leaves another subject's socket alone" do
     bystander = "bystander-#{System.unique_integer([:positive])}"
     socket_id = UserSocket.id_for_subject({:user, %User{name: bystander}})

--- a/test/grappa_web/socket_liveness_vs_session_row_test.exs
+++ b/test/grappa_web/socket_liveness_vs_session_row_test.exs
@@ -1,0 +1,79 @@
+defmodule GrappaWeb.SocketLivenessVsSessionRowTest do
+  @moduledoc """
+  Pins the premise the whole `Grappa.Accounts.Revocations` design rests
+  on: **an open WebSocket's liveness is independent of its `sessions`
+  row.**
+
+  `Revocations`' moduledoc states it ("`GrappaWeb.UserSocket`
+  authenticates once, at connect, and holds no further tie to the row —
+  so the teardown has to be pushed"), and #1499 proposed removing the
+  reaper's announcement on the opposite reading: that a reaped row can
+  never carry a live socket, because `authenticate/1` refuses it. The
+  two readings differ on whether an ALREADY-OPEN socket re-authenticates.
+  It does not, and nothing here is arguable from the call graph alone —
+  hence a test rather than a comment.
+
+  What follows is therefore a characterization gate, not a regression
+  guard for a fix: it is the measurement that says which cures for #1499
+  are admissible. Should a future change give a live socket any tie back
+  to its row (a periodic re-auth, a `last_seen_at` bump from the WS
+  path), the first test here goes red and the reasoning above must be
+  re-derived before it is edited.
+  """
+  use GrappaWeb.ChannelCase, async: false
+
+  import Ecto.Query
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+  alias Grappa.Accounts.{Reaper, Session}
+  alias Grappa.PubSub.Topic
+  alias Grappa.Repo
+  alias GrappaWeb.{GrappaChannel, UserSocket}
+
+  @idle_seconds 7 * 24 * 3600
+
+  # Seven days of an open socket that spoke only over the WebSocket.
+  # `last_seen_at` is bumped by `authenticate/1` alone, and the WS path
+  # reaches it exactly once, at connect — so time passing on a live
+  # socket looks identical to time passing on an abandoned one.
+  defp age_past_idle_window(session_id) do
+    when_seen = DateTime.add(DateTime.utc_now(), -(@idle_seconds + 3600), :second)
+    {1, _} = Repo.update_all(from(s in Session, where: s.id == ^session_id), set: [last_seen_at: when_seen])
+    :ok
+  end
+
+  defp connect_socket(token) do
+    Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{auth_token: token})
+  end
+
+  test "an open socket keeps serving after its own row crosses the idle window" do
+    {user, session} = user_and_session()
+
+    assert {:ok, socket} = connect_socket(session.id)
+
+    :ok = age_past_idle_window(session.id)
+
+    # Dead in law: no door would let this bearer in again.
+    assert {:error, :expired} = Accounts.authenticate(session.id)
+
+    # Alive in fact: the socket joins and is served with no further
+    # contact with the row it was born from.
+    assert {:ok, _reply, chan} = subscribe_and_join(socket, GrappaChannel, Topic.user(user.name))
+    assert Process.alive?(chan.channel_pid)
+  end
+
+  test "the reaper's announcement is the only thing that closes that socket" do
+    {user, session} = user_and_session()
+
+    assert {:ok, _socket} = connect_socket(session.id)
+
+    :ok = age_past_idle_window(session.id)
+
+    GrappaWeb.Endpoint.subscribe(UserSocket.id_for_subject({:user, user}))
+
+    assert {:ok, 1} = Reaper.sweep()
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}, 1_000
+  end
+end

--- a/test/grappa_web/socket_liveness_vs_session_row_test.exs
+++ b/test/grappa_web/socket_liveness_vs_session_row_test.exs
@@ -25,10 +25,9 @@ defmodule GrappaWeb.SocketLivenessVsSessionRowTest do
   import Ecto.Query
   import Grappa.AuthFixtures
 
-  alias Grappa.Accounts
+  alias Grappa.{Accounts, Repo}
   alias Grappa.Accounts.{Reaper, Session}
   alias Grappa.PubSub.Topic
-  alias Grappa.Repo
   alias GrappaWeb.{GrappaChannel, UserSocket}
 
   @idle_seconds 7 * 24 * 3600
@@ -39,7 +38,8 @@ defmodule GrappaWeb.SocketLivenessVsSessionRowTest do
   # socket looks identical to time passing on an abandoned one.
   defp age_past_idle_window(session_id) do
     when_seen = DateTime.add(DateTime.utc_now(), -(@idle_seconds + 3600), :second)
-    {1, _} = Repo.update_all(from(s in Session, where: s.id == ^session_id), set: [last_seen_at: when_seen])
+    query = from(s in Session, where: s.id == ^session_id)
+    {1, _} = Repo.update_all(query, set: [last_seen_at: when_seen])
     :ok
   end
 
@@ -59,14 +59,14 @@ defmodule GrappaWeb.SocketLivenessVsSessionRowTest do
 
     # Alive in fact: the socket joins and is served with no further
     # contact with the row it was born from.
-    assert {:ok, _reply, chan} = subscribe_and_join(socket, GrappaChannel, Topic.user(user.name))
+    assert {:ok, _, chan} = subscribe_and_join(socket, GrappaChannel, Topic.user(user.name))
     assert Process.alive?(chan.channel_pid)
   end
 
   test "the reaper's announcement is the only thing that closes that socket" do
     {user, session} = user_and_session()
 
-    assert {:ok, _socket} = connect_socket(session.id)
+    assert {:ok, _} = connect_socket(session.id)
 
     :ok = age_past_idle_window(session.id)
 

--- a/test/grappa_web/socket_liveness_vs_session_row_test.exs
+++ b/test/grappa_web/socket_liveness_vs_session_row_test.exs
@@ -63,6 +63,12 @@ defmodule GrappaWeb.SocketLivenessVsSessionRowTest do
     assert Process.alive?(chan.channel_pid)
   end
 
+  # The claim is unchanged from when this was written: nothing but the
+  # sweep's announcement closes a socket whose row has aged out under it.
+  # The ADDRESS changed with #1499 — the reaper now announces the session
+  # rather than its owner, so the teardown arrives on the per-session
+  # id-topic. Subscribing to the subject topic here would pass vacuously
+  # by never seeing anything either way, so the test follows the address.
   test "the reaper's announcement is the only thing that closes that socket" do
     {user, session} = user_and_session()
 
@@ -70,10 +76,15 @@ defmodule GrappaWeb.SocketLivenessVsSessionRowTest do
 
     :ok = age_past_idle_window(session.id)
 
+    GrappaWeb.Endpoint.subscribe(UserSocket.id_for_session(session.id))
     GrappaWeb.Endpoint.subscribe(UserSocket.id_for_subject({:user, user}))
 
     assert {:ok, 1} = Reaper.sweep()
 
-    assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}, 1_000
+    session_topic = UserSocket.id_for_session(session.id)
+    assert_receive %Phoenix.Socket.Broadcast{topic: ^session_topic, event: "disconnect"}, 1_000
+
+    subject_topic = UserSocket.id_for_subject({:user, user})
+    refute_receive %Phoenix.Socket.Broadcast{topic: ^subject_topic}, 100
   end
 end


### PR DESCRIPTION
Refs #1499.

The idle-session reaper announced `Revocations.announce({:user, name})` per distinct owner of a swept row, so deleting one stale session took down **every** socket that account had. Measured on h-irc 2026-08-17 18:00:30: a week-old row of an active account crossed the 7-day window, the `bicchierino` IRC bridge lost its WebSocket, and the weechat behind it saw a server disconnect plus 14 channel rejoins. The bridge's own bearer had never expired.

## The conflict in the issue, settled by measurement

#1499's body proposes the smallest fix first — drop the announcement entirely, because the rows are already dead at read-time and so "no live socket can be resting on a row this sweep removes".

**That road is dead, and this was measured rather than read.** `Accounts.authenticate/1` has exactly three call sites — REST `Plugs.Authn`, the visitor login, and `GrappaWeb.UserSocket`, which reaches it *once*, at connect — and `Session.touch_changeset/2`, driven from that one function, is the only writer of `last_seen_at`. A client that speaks only over the WebSocket therefore never refreshes its row, which ages out *underneath a connection that is still serving*. The claim is about the ROW; the question is about the SOCKET.

So the announcement is load-bearing: removing it strands a live socket on a deleted row. What was wrong was its **width**, not its existence.

Two cherry-picked commits from another worker's local branch carry that measurement (`SocketLivenessVsSessionRowTest`); both pass unchanged on `98c180ac`.

## The red, before the cure

`GrappaWeb.ReaperSocketBlastRadiusTest` stands up one transport process per socket and drives the production `Phoenix.Socket.Transport` callbacks — the harness stands in for the WebSock adapter, not for the socket, so it holds no opinion of its own about what closes a connection.

```
1) test the idle-session reaper reaping one session leaves the same user's
   other socket serving (GrappaWeb.ReaperSocketBlastRadiusTest)
   Unexpectedly received message {:DOWN, #Reference<...>, :process,
                                  #PID<0.884.0>, :normal}
   code: refute_receive {:DOWN, ^fresh_ref, :process, ^fresh_ws, _}, 200
```

| state | reaped session's socket | the same user's other socket |
|---|---|---|
| `98c180ac` | down (positive control, **passes**) | **down — RED** |
| after the cure | down | serving |

The positive control passes on both sides, so the survival claim is not a teardown path that had simply stopped working.

## The shape

Additive, not a re-key. `UserSocket.id/1` stays keyed by subject; every authenticated transport now **also** subscribes to `UserSocket.id_for_session/1` at connect, and `Revocations.announce_session/1` → `UserSocket.disconnect_session/1` addresses it. `Phoenix.Socket.__info__/2` stops a transport on a `"disconnect"` broadcast whatever topic carried it, so both addresses reuse the one existing teardown path.

Re-keying `id/1` onto `session_id` (the option the issue body names) was rejected: `id/1` yields ONE topic, so the five account-wide doors would lose their address for a subject entirely and have to enumerate live sessions to rebuild one. Under-firing a revoke is the failure `Revocations` exists to prevent.

Only the reaper adopts the narrow address. The other six announce sites are untouched, and a test asserts an account-wide revoke still takes down every socket of the user — so neither granularity can quietly absorb the other.

## Gate

`scripts/check.sh` **entire**, rc read from a file, on `41190db8` with `origin/main` at `98c180ac` (unchanged before and after the run):

- Credo strict — `6074 mods/funs, found no issues`
- Sobelow, `deps.audit`, wire-types drift gate — clean
- Doctor — passed, 355 modules
- ExUnit — `8 doctests, 61 properties, 6567 tests, 0 failures`
- Dialyzer — `done (passed successfully)`, `Total errors: 0`
- bats — 566 assertions, 0 `not ok`

An earlier run halted at Credo on seven unused-variable nits in the new tests; nothing downstream of that halt was measured on that run, and the numbers above are from the clean re-run.

## Not claimed

The reaper only bites rows past **7 days** of idleness, so #1499 explains **periodic** drops. If the reported account drops more often than that, this is one cause and was **not** established as the only one — nothing here went looking for the rest.

No incidence figure, before or after. Nothing was measured against production or CI.