### PR TITLE
cic(#1469): run every check stage and fail on the union

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,10 +386,20 @@ jobs:
       - name: Install e2e type dependencies
         run: bun install --cwd e2e
 
-      # `check` is biome check (src + e2e) && tsc --noEmit for both projects —
+      # `check` is biome (src + e2e) plus `tsc --noEmit` for both projects —
       # the same gate the local path runs, so CI and the developer see one rule.
+      # Since #1469 the three stages all RUN and the step fails on the union of
+      # their failures: the old `&&` chain meant a red here reported the first
+      # stage and nothing about the rest, and formatting sat first.
       - name: Biome + typecheck
         run: bun run check
 
+      # #1469 one layer up: two plain steps short-circuit exactly like the `&&`
+      # chain did. Measured on runs 32003821634 and 31355607479 — step "Biome +
+      # typecheck" `failure`, this step `skipped`, so a red job said nothing
+      # about the unit suite. `!cancelled()` (not `always()`, which would also
+      # run through a cancellation) makes the job report the union; a failure in
+      # either step still fails the job.
       - name: Unit tests (vitest)
+        if: ${{ !cancelled() }}
         run: bun run test

--- a/cicchetto/package.json
+++ b/cicchetto/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "check": "biome check && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json",
+    "check": "bun scripts/check.ts",
     "check:fix": "biome check --write",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/cicchetto/scripts/check.ts
+++ b/cicchetto/scripts/check.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+// The cic gate runner (#1469): every stage RUNS, and the verdict is the UNION
+// of their failures.
+//
+// It replaces `"check": "biome check && tsc --noEmit && tsc --noEmit -p
+// e2e/tsconfig.json"`. `&&` stopped at the first non-zero, so a red `check`
+// said "the FIRST stage failed" and nothing at all about the rest — while
+// reading, to a human, as "the gate ran and found a problem". Formatting is
+// the cheapest and most frequent failure and it sat first in the chain, so it
+// was the stage most likely to mask the expensive ones: measured three times
+// in one day, hiding two, then three, genuine type errors for exactly as long
+// as the cosmetic failure lasted.
+//
+// Measured on this branch with one mutant planted per stage — a format-only
+// error, a `tsc` src type error, a `tsc` e2e type error: the old chain exited
+// 1 and printed 456 lines naming NONE of the three broken files. Two because
+// the two `tsc` passes never ran, the third because of the ceiling below.
+//
+// `--max-diagnostics=none`: biome's default is 20 and this tree already
+// carries 59 warnings + 6 infos, so in that same measurement the ONE error was
+// truncated away behind `Diagnostics not shown: 46`. A red that names no file
+// is a red nobody can act on — the same lie one layer down, cured in the same
+// place because it is the same command.
+//
+// Sequential, not parallel: three interleaved tool outputs cost more in
+// attribution than they save in wall clock (biome is sub-second here; the
+// `tsc` passes dominate and are CPU-bound anyway).
+//
+// A new stage is a new entry in STAGES and inherits the aggregation. That is
+// the point of the array — the shape it replaces let a fourth stage be
+// appended with the bug intact, and one forgotten `||` in a hand-rolled shell
+// chain would have been worse still: a silent GREEN over a real failure.
+
+type Stage = { readonly name: string; readonly argv: readonly string[] };
+
+const STAGES: readonly Stage[] = [
+  { name: "biome (src + e2e)", argv: ["biome", "check", "--max-diagnostics=none"] },
+  { name: "tsc (src)", argv: ["tsc", "--noEmit"] },
+  { name: "tsc (e2e)", argv: ["tsc", "--noEmit", "-p", "e2e/tsconfig.json"] },
+];
+
+const results: { name: string; code: number }[] = [];
+
+for (const stage of STAGES) {
+  console.log(`\n━━━ ${stage.name} — ${stage.argv.join(" ")}`);
+  let code: number;
+  try {
+    const proc = Bun.spawn([...stage.argv], { stdout: "inherit", stderr: "inherit" });
+    await proc.exited;
+    // null when the stage died on a signal: a failure, not a pass.
+    code = proc.exitCode ?? 1;
+  } catch (err) {
+    // A stage whose binary is absent must not silently shrink the stage list —
+    // that is the exact class of failure this runner exists to stop.
+    console.error(`cannot run \`${stage.argv.join(" ")}\`: ${err}`);
+    code = 127;
+  }
+  results.push({ name: stage.name, code });
+}
+
+const failed = results.filter((r) => r.code !== 0);
+
+// The count is the honesty payload: "3 stages ran" is what tells a reader the
+// red covers everything. Without it the next regression is invisible again.
+console.log(`\n━━━ check summary — ${results.length} stages ran, ${failed.length} failed`);
+for (const r of results) {
+  console.log(`  ${r.code === 0 ? "ok  " : "FAIL"}  ${r.name}${r.code === 0 ? "" : `  (exit ${r.code})`}`);
+}
+
+process.exit(failed.length === 0 ? 0 : 1);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52568,3 +52568,84 @@ explains PERIODIC drops; if the reported account drops more often than that, thi
 is one cause and not established as the only one, and nothing here looked for the
 rest. Nothing was measured against production or CI — the runs are the local
 module set plus a full `check.sh`.
+<!-- entry #1469 -->
+
+---
+
+## 2026-08-20 — #1469: the gate stopped at the first stage, and truncated the one error it did find
+
+`"check": "biome check && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json"`.
+The `&&` meant a red `check` reported the FIRST stage and nothing about the
+rest, while reading to a human as "the gate ran and found a problem".
+Formatting is the cheapest and most frequent failure and it sat first, so it
+was the stage most likely to mask the expensive ones — three times in one day
+(2026-08-17) a cosmetic complaint hid two, then three, genuine type errors for
+exactly as long as it lasted.
+
+### The measurement found a SECOND lie in the same command
+
+Three independent mutants, one per stage, on a tree whose clean `check` is
+rc=0: a format-only error (`src/lib/zzMutantFmt.ts`), a `tsc` src type error,
+a `tsc` e2e type error. Each was positive-controlled alone — red, and naming
+its own file — and cross-controlled so no mutant bites a stage it does not own.
+
+| on the gate, all three planted | before | after |
+|---|---|---|
+| exit code | 1 | 1 |
+| format error named in the output | **no** | yes |
+| `tsc` src error named | no | yes |
+| `tsc` e2e error named | no | yes |
+| `error TS` lines | 0 | 2 |
+| `Diagnostics not shown` | present | absent |
+| red when exactly ONE stage is red (each of the three) | rc=1 | rc=1 |
+
+The first row of "no" is the known bug: neither `tsc` ran. **The format error
+going unnamed was not predicted.** biome's default `--max-diagnostics` is 20
+and this tree already carries 59 warnings + 6 infos, so the ONE error was
+truncated away under `Diagnostics not shown: 46` while the summary still read
+`Found 1 error.` The gate printed 456 lines that named **none** of the three
+broken files. That is why `--max-diagnostics=none` rides in this change rather
+than a follow-up: same command, same class — a red nobody can act on.
+
+### Why a stage array and not a shell chain
+
+The obvious one-liner is `rc=0; biome … || rc=1; tsc … || rc=1; exit $rc` in
+`package.json`. Rejected: a fourth stage appended without its `|| rc=1` exits
+GREEN over a real failure, which is strictly worse than the bug being fixed
+here. `cicchetto/scripts/check.ts` makes the stage list data, so aggregation
+comes with the entry. It closes on `check summary — N stages ran, M failed`:
+with the fix, "all stages ran" is an invariant, and printing it is what makes
+the next regression visible instead of silent.
+
+### `run build` keeps its `&&` — deliberately
+
+`"build": "tsc --noEmit && vite build"` short-circuits too (measured: with a
+type mutant planted, `vite` produced no output at all). It is **not** the same
+defect. There the two stages are precondition → effect, not two independent
+verdicts: `vite build` WRITES `dist/`, and it is the deploy path
+(`Dockerfile.release`, `infra/packaging/build.sh`, `infra/linux/cic_build.sh`,
+`infra/freebsd/jail_cic_build.sh`, both compose files). Aggregating there would
+mean staging a bundle from code that does not typecheck. Cure the reporting
+gap, not the ordering.
+
+### Measured, not cured
+
+- **The CI job has the same shape one layer up.** `cicchetto (types + lint +
+  unit)` runs `check` and `test` as two plain steps, so a red `check` skips the
+  vitest step outright — observed on runs `32003821634` and `31355607479`:
+  step 7 `failure`, step 8 `skipped`. Fixed here with `if: ${{ !cancelled() }}`
+  on the vitest step, in its own commit.
+- **`cicchetto/scripts/` is outside every lint gate**, so this runner is
+  unlinted and untypechecked — biome's `files.includes` does not reach it
+  (`Checked 0 files`, "these paths were provided but ignored"), `tsconfig.json`
+  is `include: ["src"]`, and `scripts/shellcheck.sh`'s roots are `bin infra
+  scripts` at the REPO root. The same hole `scripts/gen-emoji.ts` already sits
+  in, not one opened here. Adding `"scripts/**"` to biome's includes was
+  measured and is NOT free: it goes red on a standing import-order finding in
+  `scripts/gen-pwa-icons.mjs`, which belongs to whoever widens the gate.
+
+**Not established.** How many past red `check` runs hid a type error later
+fixed incidentally by a reformat — no history was mined, as the issue already
+noted. Nor whether `--max-diagnostics=none` has a pathological output size on
+some future tree; today it is 1323 lines against 456, on a tree with 65
+standing diagnostics.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,7 +34,7 @@ scripts/test.sh --cover                  # coverage
 
 # cic (Solid / TS)
 scripts/bun.sh run test                  # vitest
-scripts/bun.sh run check                 # biome + tsc — src AND e2e (#484)
+scripts/bun.sh run check                 # biome + tsc — src AND e2e (#484); all 3 stages, union of failures (#1469)
 
 # Full CI gate locally
 scripts/check.sh                         # mix ci.check + wireTypes drift gate + bats
@@ -119,6 +119,20 @@ new `error TS`), because it's typechecking main, not your branch. Always
 `cd <worktree-root>` first; verify a run hit the worktree by checking the
 count reflects your additions, or that a deliberate error is actually
 caught.
+
+**A red `run check` covers every stage, and says so (#1469).** It used to be
+`biome check && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json`, so a red
+told you the FIRST stage failed and nothing about the rest — and formatting,
+the cheapest and most frequent failure, sat first. Measured three times in one
+day, a cosmetic complaint hid two, then three, genuine type errors for as long
+as it lasted. `cicchetto/scripts/check.ts` now runs all three and exits
+non-zero if ANY did, closing with `check summary — 3 stages ran, N failed`.
+Read that line: it is what tells you the red is complete. It also passes
+`--max-diagnostics=none`, because biome's default ceiling of 20 truncated the
+one real error behind this tree's 59 standing warnings — a red naming no file
+at all. `run build` still short-circuits on purpose: there `tsc` is a
+precondition for `vite build`, which WRITES `dist/`, so the second stage must
+not run when the first is red.
 
 **`scripts/bun.sh run build`/`run check` can FALSE-PASS a type error in a
 `src/__tests__/*` file.** `tsc`'s incremental `*.tsbuildinfo` cache (under

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -5,7 +5,8 @@
 #   scripts/bun.sh install
 #   scripts/bun.sh add phoenix
 #   scripts/bun.sh run build
-#   scripts/bun.sh run check                    # biome + tsc over src AND e2e (#484)
+#   scripts/bun.sh run check                    # biome + tsc over src AND e2e (#484);
+#                                               # all 3 stages run, union of failures (#1469)
 #   scripts/bun.sh run test                     # vitest (cic unit tests in jsdom)
 #
 # Canonical "which test runner do I use?" docs: docs/TESTING.md.


### PR DESCRIPTION
Fixes the short-circuit in `bun run check` reported in #1469. The measurement
found a **second** lie in the same command that the issue had not predicted.

## The lie, measured two-sided

Three independent mutants, one per stage, on a tree whose clean `check` is
rc=0: a format-only error (`src/lib/zzMutantFmt.ts`), a `tsc` src type error,
a `tsc` e2e type error. Each was positive-controlled **alone** — red, and
naming its own file — and cross-controlled so that no mutant bites a stage it
does not own. Neither mutant nor harness is committed.

| `bun run check`, all three planted | before | after |
|---|---|---|
| exit code | 1 | 1 |
| format error named in the output | **no** | yes |
| `tsc` src error named | no | yes |
| `tsc` e2e error named | no | yes |
| `error TS` lines | 0 | 2 |
| `Diagnostics not shown` notice | present | absent |
| clean tree | rc=0 | rc=0 |
| red when exactly ONE stage is red (A / B / C) | 1 / 1 / 1 | 1 / 1 / 1 |

Before, the gate printed **456 lines that named none of the three broken
files**. Verified with a naked `grep -n zzMutant gate.log` → no match, rc=1.

## The second lie

Two of the three "no"s are the known bug: neither `tsc` ran. **The third was
not predicted.** biome's default `--max-diagnostics` is 20 and this tree
already carries 59 warnings + 6 infos, so the one real error was truncated
away under `Diagnostics not shown: 46` — while the summary still read
`Found 1 error.` A red that names no file is the same lie one layer down, in
the same command, so `--max-diagnostics=none` rides in this change rather than
a follow-up.

## The cure

`cicchetto/scripts/check.ts` runs all three stages, exits non-zero if **any**
did, and closes with `check summary — N stages ran, M failed`.

A shell chain (`rc=0; biome … || rc=1; …; exit $rc`) was rejected: a fourth
stage appended without its `|| rc=1` exits **green** over a real failure, which
is worse than the bug being fixed. With the stage list as data, aggregation
comes with the entry. The summary count is the honesty payload — "all stages
ran" is now an invariant, and printing it is what keeps the next regression
from being silent.

## Is the same lie elsewhere? Measured

- **`bun run build` short-circuits too** — with a type mutant planted, `vite`
  produced no output at all. **Deliberately left alone**: there `tsc` is a
  precondition for `vite build`, which WRITES `dist/` on the deploy path
  (`Dockerfile.release`, `infra/packaging/build.sh`, `infra/linux/cic_build.sh`,
  `infra/freebsd/jail_cic_build.sh`, both compose files). Aggregating would
  stage a bundle from code that does not typecheck. Two stages there are
  precondition → effect, not two independent verdicts.
- **`bun run test` is a single command** (`vitest run`) — nothing to
  short-circuit. Naked enumeration: exactly two `package.json` scripts contain
  `&&`, `build` and `check`.
- **The CI job has the same shape one layer up.** `check` and `test` are two
  plain steps, so a red `check` skips the unit suite. Measured, not deduced —
  runs `32003821634` and `31355607479`: step 7 `failure`, step 8 `skipped`.
  Fixed in its own commit (`!cancelled()`), so it can be dropped alone if the
  CI surface is judged a separate call.

## Measured but NOT cured

`cicchetto/scripts/` is outside every lint gate, so this runner is unlinted and
untypechecked: biome's `files.includes` does not reach it (`Checked 0 files`,
"these paths were provided but ignored"), `tsconfig.json` is `include: ["src"]`,
and `scripts/shellcheck.sh`'s roots are `bin infra scripts` at the **repo**
root. It is the hole `scripts/gen-emoji.ts` already sits in, not one opened
here. Adding `"scripts/**"` to biome's includes was measured and is **not
free** — it goes red on a standing import-order finding in
`scripts/gen-pwa-icons.mjs`, which belongs to whoever widens the gate.

## Gates

| gate | rc | evidence |
|---|---|---|
| `bun.sh run check` | 0 | `3 stages ran, 0 failed` |
| `bun.sh run test` | 0 | 293 files / 5677 tests passed |
| `scripts/shellcheck.sh` | 0 | 76 derived scripts |
| `scripts/bats.sh` | 0 | 566 `ok`, zero `not ok` |
| `scripts/design-notes-gate.sh` | 0 | `1 new entry heading(s), separator and marker present` (non-vacuous — re-run after the commit; before it, it reported "nothing to check") |

Every rc captured to a file, never through a pipe. No Elixir gate was run:
this branch touches no Elixir, and the COMPILE lane belongs to another worker.

## Not established

How many past red `check` runs hid a type error later fixed incidentally by a
reformat — no history mined, as the issue already noted. Nor whether
`--max-diagnostics=none` has a pathological output size on some future tree;
today it is 1323 lines against 456, on a tree with 65 standing diagnostics.