### PR TITLE
cic(#1510): give the eleven vacuous wire pins a second source

### DIFF
--- a/cicchetto/src/lib/wireTypesAssert.ts
+++ b/cicchetto/src/lib/wireTypesAssert.ts
@@ -1,5 +1,6 @@
-// Structural-equivalence asserts between hand-rolled cic types in
-// `./api.ts` and codegen-emitted types in `./wireTypes.ts`.
+// Structural-equivalence asserts between the cic-facing wire types
+// (`./api.ts` and its store-side siblings) and codegen-emitted types
+// in `./wireTypes.ts`.
 //
 // Why this file exists:
 //
@@ -17,38 +18,82 @@
 //     "./wireTypes"` is risky in one go (the cic-side type unions
 //     are richer than the server-side typespecs in places — REST-
 //     aggregate, discriminator-narrowed). Instead, this file asserts
-//     STRUCTURAL EQUIVALENCE between each api.ts type and its
-//     wireTypes.ts counterpart. The `_Assert_*` type aliases evaluate
-//     to `true` when shapes match, `never` when they drift. The
-//     `assertExtends/2` helpers further enforce bi-directional
-//     subtype-ness at compile time. `bun run check` fails on `never`
-//     — closing the drift class at TS compile rather than waiting
-//     for a runtime narrower mismatch.
+//     STRUCTURAL EQUIVALENCE between each cic-facing type and the
+//     shape the server promises. The `_Assert_*` type aliases evaluate
+//     to `true` when the shapes match and to `false` (or, for the
+//     walks, a named-arm object) when they drift; `bun run check`
+//     fails on that — closing the drift class at TS compile rather
+//     than waiting for a runtime narrower mismatch.
 //
 //   * The CI-time loop is: typespec change → codegen regen → drift
 //     gate (D) catches stale committed file → operator runs codegen
 //     → wireTypes.ts updates → this file's asserts fail at `bun run
-//     check` if the api.ts hand-roll doesn't match the new shape →
-//     operator fixes api.ts to match → CI green.
+//     check` → operator reconciles the cic side → CI green.
+//
+//   * WHAT MAKES A PIN ABLE TO FAIL (#1510). A pin needs TWO
+//     INDEPENDENT declarations of the shape. Since #410 most api.ts
+//     types are DIRECT ALIASES of their generated counterpart, so
+//     `Equal<X, Gen>` where `type X = Gen` compares a type with
+//     itself: `true` by construction, and no server-side change can
+//     ever redden it — the alias follows the codegen silently, and so
+//     does the pin. Eleven of the fourteen full-shape pins were in
+//     that state and were MEASURED vacuous (an optional probe field
+//     added to the generated type left `bun run check` green on every
+//     one of them, while the same probe on `SessionWireMember` —
+//     whose cic side is hand-written — reddened). Those eleven now
+//     carry an INLINE GOLDEN SHAPE as their second side: the field
+//     roster written out by hand here, which no alias can follow. A
+//     server-side rename, retype, add or removal now reaches a human
+//     instead of regenerating in silence.
 //
 // Maintenance:
 //
-//   * Add an assert for every api.ts type that has a wireTypes.ts
-//     counterpart. When server-side adds a new Wire module + type,
-//     the codegen emits it; if a cic consumer needs the new shape,
-//     add the assert + the api.ts mirror. EXCEPT for UNION ARMS, which
-//     are walked rather than listed (#1406): a `WireSessionEvent` arm
-//     needs nothing at all, and a cross-module arm needs one line in the
-//     `CrossModuleArm` registry naming its generated counterpart. Neither
-//     buys the silence a forgotten assert line used to.
+//   * Add a pin for every cic-facing type that has a wireTypes.ts
+//     counterpart, and pick its SECOND SIDE by how the cic side is
+//     declared:
+//       - cic side HAND-WRITTEN (today `MemberEntry`, `TopicEntry`,
+//         `ModesEntry`, all outside api.ts): pin it against the
+//         GENERATED type. Two independent declarations already exist.
+//       - cic side a DIRECT ALIAS of the generated type (everything
+//         pinned out of api.ts): pin it against an inline golden
+//         shape. NEVER against the alias's own right-hand side — that
+//         is the vacuous form #1510 found eleven times, and the rule
+//         this file used to state ("add an assert for every api.ts
+//         type that has a counterpart") manufactured it once api.ts
+//         had migrated to aliases.
+//     EXCEPT for UNION ARMS, which are walked rather than listed
+//     (#1406): a `WireSessionEvent` arm needs nothing at all, and a
+//     cross-module arm needs one line in the `CrossModuleArm` registry
+//     naming its generated counterpart. Neither buys the silence a
+//     forgotten assert line used to.
 //
-//   * If an assert fails (`Type 'true' is not assignable to type
-//     'never'` at the `: true = true` lines), the api.ts mirror has
-//     drifted from the server typespec. The fix is on the cic side —
-//     update api.ts to match wireTypes.ts (server is the source of
-//     truth per CLAUDE.md "Implement once, reuse everywhere").
+//   * A golden shape names a field's type BY REFERENCE when the
+//     referenced type carries its own pin (`HomeNetworkRow` inside
+//     `HomeData`), so one server-side change reddens one pin. Where
+//     the reference is a leaf the codegen emits and nothing here pins
+//     — `MessageKind`, `ScrollbackMetaT`, `ConnectionState`,
+//     `NetworksCredentialAuthMethod`, `AvailableNetworkRow` — the pin
+//     is blind to changes INSIDE it, by construction. #410 dropped the
+//     leaf-enum pins on the same alias argument #1510 overturns;
+//     restoring them is outside #1510's perimeter and is recorded here
+//     rather than cured.
+//
+//   * When a GOLDEN-SHAPE pin fails, the server changed the shape:
+//     read the codegen diff, check cic's consumers, then update the
+//     literal here — updating it IS the acknowledgement the pin exists
+//     to force. When a HAND-WRITTEN-side pin fails, the cic mirror has
+//     drifted; the fix is on the cic side — update it to match
+//     wireTypes.ts (server is the source of truth per CLAUDE.md
+//     "Implement once, reuse everywhere").
+//
+//   * Residual, named rather than cured: a golden shape also reddens
+//     when an alias is re-pointed at the WRONG generated type (#1509's
+//     class) — but only when the two shapes differ. Structural
+//     coincidence still passes.
 
 import type {
+  AvailableNetworkRow,
+  ConnectionState,
   CredentialJson,
   DirectoryEntry,
   FeaturedChannelLink,
@@ -57,6 +102,7 @@ import type {
   LinksEntry,
   MentionsBundleMessage,
   MeResponse,
+  MessageKind,
   NotifyEntry,
   QueryWindowEntry,
   ScrollbackMessage,
@@ -69,31 +115,22 @@ import type { ModesEntry, TopicEntry } from "./channelTopic";
 import type { MemberEntry } from "./memberTypes";
 import type {
   AuthJSONSubjectWire,
-  ChannelDirectoryWireEntry,
   CicWireBundleHashPayload,
   MeJSONMeJson,
-  NetworksFeaturedChannelsWireLink,
+  NetworksCredentialAuthMethod,
   NetworksWireConnectionStateEvent,
-  NetworksWireCredentialJson,
-  NetworksWireHomeData,
-  NetworksWireHomeNetworkRow,
-  NotifyWireEntry,
   NotifyWireNotifyListPayload,
-  QueryWindowsWireWindowsEntry,
   QueryWindowsWireWindowsListPayload,
   RateLimitWireWebSessionSeveredEvent,
   ReadCursorWireReadCursorSet,
+  ScrollbackMetaT,
   ScrollbackWireArchiveChangedPayload,
   ScrollbackWireArchivePurgedPayload,
   ScrollbackWireEvent,
-  ScrollbackWireT,
   ServerSettingsWireChangedPayload,
   SessionWireChannelModesWire,
-  SessionWireLinksEntry,
   SessionWireMember,
-  SessionWireMentionsBundleMessage,
   SessionWireTopicEntryWire,
-  SessionWireWhoUser,
   UserSettingsWireAutoAwayDebounceChangedPayload,
   WindowCountsWireEvent,
   WireSessionEvent,
@@ -108,11 +145,27 @@ type Assert<T extends true> = T;
 
 // === #85 — Featured channels ===
 // Public delivery link (HomePane) + the /list directory entry's new
-// `featured` flag, pinned to their codegen counterparts.
+// `featured` flag, pinned to the shape the server promises.
 export type _Assert_FeaturedChannelLink = Assert<
-  Equal<FeaturedChannelLink, NetworksFeaturedChannelsWireLink>
+  Equal<
+    FeaturedChannelLink,
+    {
+      name: string;
+      description: string | null;
+    }
+  >
 >;
-export type _Assert_DirectoryEntry = Assert<Equal<DirectoryEntry, ChannelDirectoryWireEntry>>;
+export type _Assert_DirectoryEntry = Assert<
+  Equal<
+    DirectoryEntry,
+    {
+      name: string;
+      topic: string | null;
+      user_count: number;
+      featured: boolean;
+    }
+  >
+>;
 
 // === S3 (2026-07-08 review) — end-to-end gate for the flat wire mirrors ===
 // Every hand-rolled `api.ts` type below has a structurally-identical
@@ -124,32 +177,131 @@ export type _Assert_DirectoryEntry = Assert<Equal<DirectoryEntry, ChannelDirecto
 // window (S43), the /who + /topic + /modes + members payloads, the
 // home rows, and the credential JSON (S3 caught `auth_method` drift).
 //
-// #410 — the leaf ENUM types (MessageKind, ConnectionState, ServicesFlavor,
-// DirectoryStatus, ServerReplySource) are no longer asserted here: they are
-// now single-sourced in api.ts as `export type X = <generated>` aliases, so
-// equality with the codegen type holds BY CONSTRUCTION (an alias can't
-// drift). Only the STRUCT mirrors below still need a pin.
+// #410 dropped the leaf ENUM pins (MessageKind, ConnectionState,
+// ServicesFlavor, DirectoryStatus, ServerReplySource) on the argument that
+// an alias "can't drift", so equality with the codegen type holds BY
+// CONSTRUCTION. #1510 measured what that argument actually buys: holding by
+// construction is exactly what makes a pin unable to redden, and the STRUCT
+// mirrors below had migrated to aliases too — so nine of them had quietly
+// joined the enums. They are pinned against an inline golden shape now. The
+// leaf enums are NOT (outside #1510's perimeter, recorded in the header).
 //
 // Enriched / discriminated types (`WireUserEvent`, `WireChannelEvent`,
 // `WireAdminEvent`, `MeResponse`, `Network`) carry cic-side
 // consumer enrichments and are validated via their runtime narrowers +
 // `assertNever`; their per-arm PAYLOADS that have a flat counterpart
 // are pinned below (e.g. `ScrollbackMessage`, `MentionsBundleMessage`).
-export type _Assert_ScrollbackMessage = Assert<Equal<ScrollbackMessage, ScrollbackWireT>>;
-export type _Assert_MentionsBundleMessage = Assert<
-  Equal<MentionsBundleMessage, SessionWireMentionsBundleMessage>
+export type _Assert_ScrollbackMessage = Assert<
+  Equal<
+    ScrollbackMessage,
+    {
+      id: number;
+      network: string;
+      channel: string;
+      server_time: number;
+      kind: MessageKind;
+      sender: string;
+      body: string | null;
+      meta: ScrollbackMetaT;
+    }
+  >
 >;
-export type _Assert_WhoUser = Assert<Equal<WhoUser, SessionWireWhoUser>>;
+export type _Assert_MentionsBundleMessage = Assert<
+  Equal<
+    MentionsBundleMessage,
+    {
+      server_time: number;
+      channel: string;
+      sender: string;
+      body: string | null;
+      kind: MessageKind;
+    }
+  >
+>;
+export type _Assert_WhoUser = Assert<
+  Equal<
+    WhoUser,
+    {
+      nick: string;
+      user: string;
+      host: string;
+      server: string;
+      modes: string;
+      hops: number | null;
+      realname: string | null;
+      channel: string;
+    }
+  >
+>;
+// The three pins whose cic side is an independent HAND-WRITTEN declaration
+// (all outside api.ts, in the stores that own the shape). Those need no
+// golden literal — the hand-roll IS the second source, and #1510 measured
+// all three reddening under a probe field added to the generated type.
 export type _Assert_MemberEntry = Assert<Equal<MemberEntry, SessionWireMember>>;
 export type _Assert_TopicEntry = Assert<Equal<TopicEntry, SessionWireTopicEntryWire>>;
 export type _Assert_ModesEntry = Assert<Equal<ModesEntry, SessionWireChannelModesWire>>;
 export type _Assert_QueryWindowEntry = Assert<
-  Equal<QueryWindowEntry, QueryWindowsWireWindowsEntry>
+  Equal<
+    QueryWindowEntry,
+    {
+      network_id: number;
+      target_nick: string;
+      opened_at: string;
+    }
+  >
 >;
-export type _Assert_NotifyEntry = Assert<Equal<NotifyEntry, NotifyWireEntry>>;
-export type _Assert_HomeNetworkRow = Assert<Equal<HomeNetworkRow, NetworksWireHomeNetworkRow>>;
-export type _Assert_HomeData = Assert<Equal<HomeData, NetworksWireHomeData>>;
-export type _Assert_CredentialJson = Assert<Equal<CredentialJson, NetworksWireCredentialJson>>;
+export type _Assert_NotifyEntry = Assert<
+  Equal<
+    NotifyEntry,
+    {
+      network_id: number;
+      nick: string;
+      added_at: string;
+    }
+  >
+>;
+export type _Assert_HomeNetworkRow = Assert<
+  Equal<
+    HomeNetworkRow,
+    {
+      slug: string;
+      nick: string;
+      connection_state: ConnectionState;
+      connection_state_reason: string | null;
+      connection_state_changed_at: string | null;
+      recoverable: boolean;
+    }
+  >
+>;
+export type _Assert_HomeData = Assert<
+  Equal<
+    HomeData,
+    {
+      networks: HomeNetworkRow[];
+      available_networks: AvailableNetworkRow[];
+    }
+  >
+>;
+export type _Assert_CredentialJson = Assert<
+  Equal<
+    CredentialJson,
+    {
+      network: string;
+      nick: string;
+      ident: string | null;
+      realname: string | null;
+      sasl_user: string | null;
+      auth_method: NetworksCredentialAuthMethod;
+      auth_command_template: string | null;
+      autojoin_channels: string[];
+      connection_state: ConnectionState;
+      connection_state_reason: string | null;
+      connection_state_changed_at: string | null;
+      inserted_at: string;
+      updated_at: string;
+    }
+  >
+>;
 
 // === cross-surface S7 (2026-07-19 review) — the biggest boundary payloads ===
 // S7 pinned the largest payloads on the wire — WhoisBundle (28 fields, grown
@@ -164,7 +316,17 @@ export type _Assert_CredentialJson = Assert<Equal<CredentialJson, NetworksWireCr
 // for the whole 37-arm population. What survives here is the ELEMENT type
 // nested inside an arm, which the walk covers only through its container
 // and which cic also reuses standalone in its stores.
-export type _Assert_LinksEntry = Assert<Equal<LinksEntry, SessionWireLinksEntry>>;
+export type _Assert_LinksEntry = Assert<
+  Equal<
+    LinksEntry,
+    {
+      server: string;
+      linked_to: string | null;
+      hopcount: number | null;
+      description: string | null;
+    }
+  >
+>;
 
 // === #1406 X-S1 — the cross-module arms, as DATA rather than asserts ===
 // cic's two hand-rolled unions fan IN from many `Grappa.*.Wire` modules;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52728,3 +52728,75 @@ symptoms. The overlap is in the CURE, not the defect: a two-sided
 numstat-invariance check would detect both. It can only ever be a DETECTOR
 though — it needs a before and an after — whereas the marker check is a
 PREVENTER that runs on a single state. That is the argument for keeping both.
+<!-- entry #1510 -->
+
+---
+
+## 2026-08-20 — #1510: a pin needs two independent declarations, and an alias is only one
+
+`cicchetto/src/lib/wireTypesAssert.ts` presented fourteen full-shape pins
+between the cic-facing wire types and the codegen-emitted `wireTypes.ts`.
+Eleven compared a type with itself: since #410 the api.ts side is a DIRECT
+ALIAS of its generated counterpart, so `Equal<X, Gen>` with `type X = Gen` is
+`true` by construction and no server-side change can redden it — the alias
+follows the codegen, and so does the pin. Measured before the cure, all
+fourteen: one optional probe field added to the generated type left `bun run
+check` green on the eleven and reddened the three whose cic side is
+hand-written (`MemberEntry`, `TopicEntry`, `ModesEntry`). That positive
+control is what makes the greens mean "this pin cannot fail" rather than "the
+gate never ran".
+
+**The rule is what produced them.** The file asked for "an assert for every
+api.ts type that has a wireTypes.ts counterpart". Once api.ts had migrated to
+aliases, that rule MANUFACTURES vacuous pins — applied literally today it
+produces more of exactly this. It is now keyed on how the cic side is
+DECLARED, not on whether a counterpart exists: a hand-written cic side pins
+against the generated type (two independent declarations already exist); an
+alias pins against an INLINE GOLDEN SHAPE written out by hand in this file,
+never against the alias's own right-hand side.
+
+**Why golden shapes rather than deletion.** Deletion was the cure the issue
+body proposed, on the argument that an alias cannot structurally drift from
+the type it aliases, so there is nothing to protect. True — on the
+cic-vs-codegen axis. The gate's subject is cic-vs-SERVER, and the alias is
+precisely what lets a server-side shape change reach cic with nobody
+acknowledging it. The mutant that settles it is the one measured on the issue:
+renaming `sender` in `SessionWireMentionsBundleMessage` produced ZERO
+occurrences of `wireTypesAssert` in the log and was caught only by the
+hand-written `MentionsBundle` mirror in `userTopic.ts` — the mirror
+architecture-review A4 proposes to retire, whose removal would open a blind
+window. The same rename against the cured file reddens
+`_Assert_MentionsBundleMessage` (plus the two `userTopic.ts` sites, still
+there today). A deleted pin cannot do that, so the A4 ordering constraint is
+discharged here rather than carried.
+
+**Two-sided kill test, all fourteen.** With the cure in place, one optional
+probe field injected into each generated counterpart — anchor verified to
+match exactly once, injection verified to add exactly one probe, restore
+verified byte-identical — all fourteen go red, `rc=1`, against a green
+baseline. The eleven repaired pins are SURGICAL: one mutant, exactly one
+reddened assertion, zero other TS errors. The three hand-written ones each
+also redden `_Assert_NoChannelArmDrift`, reproducing what the issue measured —
+their generated types feed channel arms, so the #1406 walk catches them
+independently.
+
+### Measured, not cured
+
+- **A golden shape is blind INSIDE a type it names by reference.** Naming
+  `HomeNetworkRow` inside `HomeData`'s literal is deliberate — it is what
+  keeps one server-side change to one reddened pin — and the cost is measured:
+  a probe field on `NetworksWireAvailableNetworkRow`, which `HomeData` names
+  and nothing pins, leaves the whole gate green.
+- **The leaf enums #410 unpinned are not silent.** Appending an arm to the
+  generated `SCROLLBACK_MESSAGE_KIND` const gives ZERO `wireTypesAssert`
+  occurrences and two reds elsewhere — `ScrollbackPane.tsx` and `members.ts`,
+  both exhaustive switches. The guard there is the consumers, not a pin.
+  Restoring the enum pins is outside this issue's perimeter.
+- **#1509's class is now partly reachable.** A golden shape also reddens when
+  an alias is re-pointed at the WRONG generated type, but only when the two
+  shapes differ; structural coincidence still passes. Not a substitute for the
+  mechanical alias-target guard #1510 left as a separate design call.
+
+**Not evaluated**, unchanged from the issue: the two narrow `["kind"]` pins
+(`_Assert_MeResponseKind`, `_Assert_LoginSubjectKind`) and seven of the eight
+#1406 arm-walking asserts.


### PR DESCRIPTION
## What this is

`wireTypesAssert.ts` presented **fourteen** full-shape pins between the
cic-facing wire types and the codegen-emitted `wireTypes.ts`. **Eleven
compared a type with itself.** Since #410 the `api.ts` side of those pins is a
direct alias of its generated counterpart, so `Equal<X, Gen>` with
`type X = Gen` is `true` by construction: the alias follows the codegen, the
pin follows the alias, and no server-side change can ever redden it.

A pin needs **two independent declarations** of the shape. The eleven now
carry an **inline golden shape** as their second side — the field roster
written out by hand in this file, which no alias can follow.

## Why golden shapes and not deletion

Deletion is what the issue body proposed, on the argument that an alias cannot
structurally drift from the type it aliases, so there is nothing to protect.
That holds on the *cic-vs-codegen* axis. The gate's subject is *cic-vs-SERVER*,
and the alias is precisely what lets a server-side shape change reach cic with
nobody acknowledging it.

The mutant that settles it is the one measured in the issue's last comment:
renaming `sender` in `SessionWireMentionsBundleMessage` produced **zero**
occurrences of `wireTypesAssert` in the log and was caught only by the
hand-written `MentionsBundle` mirror in `userTopic.ts` — the mirror
architecture-review **A4** proposes to retire, whose removal opens a blind
window. Re-run against this branch, the same rename reddens
`_Assert_MentionsBundleMessage`:

```
=== rename SessionWireMentionsBundleMessage sender rc=1
--- wireTypesAssert occurrences: 1
    _Assert_MentionsBundleMessage  <- src/lib/wireTypesAssert.ts(210,3): error TS2344
```

A deleted pin cannot do that, so the A4 ordering constraint is discharged here
rather than carried forward.

## The rule is rekeyed, not just the pins

The file asked for *"an assert for every api.ts type that has a wireTypes.ts
counterpart"*. After the alias migration that rule **manufactures** vacuous
pins. It now keys on how the cic side is **declared**:

* cic side **hand-written** (`MemberEntry`, `TopicEntry`, `ModesEntry`, all
  outside `api.ts`) → pin against the **generated type**; two independent
  declarations already exist.
* cic side a **direct alias** → pin against an **inline golden shape**, never
  against the alias's own right-hand side.

## Two-sided kill test — all fourteen, measured

Harness: one optional probe field (`__probe_v?: string;`) injected immediately
after the generated type's `export type X = {` line, `bun run check`, restore.
Controls in the harness itself: the anchor must match **exactly once**, the
injection must add **exactly one** probe, the restore must be **byte-identical**
(`cmp`). Baseline unmutated = **green, rc=0**.

| generated type mutated | pin expected | rc | reddened pins | other TS errors |
|---|---|---|---|---|
| `NetworksFeaturedChannelsWireLink` | `_Assert_FeaturedChannelLink` | 1 | `_Assert_FeaturedChannelLink` | 0 |
| `ChannelDirectoryWireEntry` | `_Assert_DirectoryEntry` | 1 | `_Assert_DirectoryEntry` | 0 |
| `ScrollbackWireT` | `_Assert_ScrollbackMessage` | 1 | `_Assert_ScrollbackMessage` | 0 |
| `SessionWireMentionsBundleMessage` | `_Assert_MentionsBundleMessage` | 1 | `_Assert_MentionsBundleMessage` | 0 |
| `SessionWireWhoUser` | `_Assert_WhoUser` | 1 | `_Assert_WhoUser` | 0 |
| `QueryWindowsWireWindowsEntry` | `_Assert_QueryWindowEntry` | 1 | `_Assert_QueryWindowEntry` | 0 |
| `NotifyWireEntry` | `_Assert_NotifyEntry` | 1 | `_Assert_NotifyEntry` | 0 |
| `NetworksWireHomeNetworkRow` | `_Assert_HomeNetworkRow` | 1 | `_Assert_HomeNetworkRow` | 0 |
| `NetworksWireHomeData` | `_Assert_HomeData` | 1 | `_Assert_HomeData` | 0 |
| `NetworksWireCredentialJson` | `_Assert_CredentialJson` | 1 | `_Assert_CredentialJson` | 0 |
| `SessionWireLinksEntry` | `_Assert_LinksEntry` | 1 | `_Assert_LinksEntry` | 0 |
| `SessionWireMember` | `_Assert_MemberEntry` | 1 | `_Assert_MemberEntry` + `_Assert_NoChannelArmDrift` | 0 |
| `SessionWireTopicEntryWire` | `_Assert_TopicEntry` | 1 | `_Assert_TopicEntry` + `_Assert_NoChannelArmDrift` | 0 |
| `SessionWireChannelModesWire` | `_Assert_ModesEntry` | 1 | `_Assert_ModesEntry` + `_Assert_NoChannelArmDrift` | 0 |

**The eleven repaired pins are surgical**: one mutant, exactly one reddened
assertion. The three hand-written ones each also redden
`_Assert_NoChannelArmDrift`, reproducing exactly what the issue measured —
their generated types feed channel arms, so the #1406 walk catches them
independently.

The pre-cure state was re-measured on this same tree before the change, with
its positive control in the same harness: `NotifyWireEntry` → **green, 0
reddened pins**; `SessionWireMember` → **red at `_Assert_MemberEntry` +
`_Assert_NoChannelArmDrift`**. So the eleven greens meant "cannot fail", not
"gate did not run".

## Measured, not cured

* **A golden shape is blind INSIDE a type it names by reference.** Naming
  `HomeNetworkRow` inside `HomeData`'s literal is deliberate — it is what keeps
  one server-side change to one reddened pin — and the cost is measured: a
  probe on `NetworksWireAvailableNetworkRow`, which `HomeData` names and
  nothing pins, leaves the whole gate **green (rc=0, 0 reddened pins)**.
* **The leaf enums #410 unpinned are not silent.** Appending an arm to the
  generated `SCROLLBACK_MESSAGE_KIND` const gives **0** `wireTypesAssert`
  occurrences and two reds elsewhere — `ScrollbackPane.tsx(1015,13)` and
  `members.ts(100,17)`, both exhaustive switches. The guard there is the
  consumers, not a pin. Restoring the enum pins is outside this issue's
  perimeter and is named rather than cured.
* **#1509's class is now partly reachable**: a golden shape reddens when an
  alias is re-pointed at the wrong generated type, *but only when the two
  shapes differ*. Structural coincidence still passes. Not a substitute for the
  mechanical alias-target guard the issue left as a separate design call.

## Not evaluated

Unchanged from the issue, named so silence is not read as a clean result: the
two narrow `["kind"]` pins (`_Assert_MeResponseKind`, `_Assert_LoginSubjectKind`)
and seven of the eight #1406 arm-walking asserts. Mutation shapes beyond
"add an optional field" and "rename a field" remain untried.

## Gates

* `scripts/bun.sh run check` — **green**, 3 stages ran, 0 failed (biome, tsc src, tsc e2e).
* `scripts/bun.sh run test` — **green**, 293 test files, rc=0.
* `scripts/design-notes-gate.sh` — **rc=0**, 1 new entry heading, separator and marker present; `grep -Fxc '<!-- entry #1510 -->'` = 1.
* **COMPILE lane not taken and not needed**: no `.ex` file is touched, `wireTypes.ts` is byte-identical to `origin/main` (every mutation restored and `cmp`-verified), so the codegen drift gate has nothing to see.

## Deploy

Neither HOT nor COLD — cic bundle only, and in fact nothing reaches the bundle:
`tsc` erases every one of these type aliases.

Refs #1510.
