### PR TITLE
ci(#1428): check an added DESIGN_NOTES marker against the base, not only the file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,6 +451,17 @@ not the surrounding code.**
   Enforced by `scripts/design-notes-gate.sh` over the entries a branch ADDS,
   in CI and in `scripts/bats.sh`; the same gate treats an added `^## ` as an
   ENTRY heading, so a subsection inside an entry must be `###` or deeper.
+  **UNIQUE has two scopes, and the second is the one that bites (#1428):
+  unique in your file, AND unique against what `origin/main` carries NOW.**
+  One issue producing several entries needs distinct suffixes (`#1404a`,
+  `#1404b`, …) — and the suffix must be chosen against the base's CURRENT
+  content, not the base you branched from, because **a rebase is exactly when
+  a previously-unique marker stops being unique**. A marker the base already
+  carries restores the identical prefix the convention exists to destroy, and
+  costs **FOUR** lines instead of three — one MORE than no marker at all,
+  since the marker collapses together with the separator block it was added
+  to protect. The gate checks this against the base ref's TIP; the collision
+  does not exist at the merge base, so checking there sees nothing.
 - **Log honesty**: when a fast path skips work, the log message must
   describe the state it OBSERVED, not the absence of work. Example:
   `bootstrap: no credentials bound — running web-only` lies when N

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52649,3 +52649,82 @@ fixed incidentally by a reformat — no history was mined, as the issue already
 noted. Nor whether `--max-diagnostics=none` has a pathological output size on
 some future tree; today it is 1323 lines against 456, on a tree with 65
 standing diagnostics.
+<!-- entry #1428 -->
+
+---
+
+## 2026-08-20 — #1428: the marker that defeats `merge=union` has two scopes of uniqueness, and the gate only closed one
+
+#1271 cured a silent three-line loss by giving every DESIGN_NOTES entry a
+`<!-- entry #NNNN -->` opening line. The mechanism is DIFFERENCE, not the
+marker: the old identical prefix (blank / `---` / blank) is what the merge
+machinery aligns as a common addition, and a line that differs between the two
+sides leaves nothing to collapse. #1428 is the regime in which that cure does
+not cure — the marker on the branch is one the BASE already carries.
+
+### Measured, on the scratch repo the bats suite builds
+
+The oracle is a real `merge=union` attribute and a real `git rebase`, not a
+hand-written broken file. Same harness, four regimes, additions of the
+branch's own contribution before → after:
+
+| markers (branch / main) | rebase | additions | gate BEFORE | gate AFTER |
+|---|---|---|---|---|
+| none / none (#1271) | rc=0, del=0 | 6 → 3 (**-3**) | 1 | 1 |
+| distinct | rc=0, del=0 | 7 → 7 | 0 | 0 |
+| **same / same (#1428)** | **rc=0, del=0** | **7 → 3 (-4)** | **0** | 1 |
+| none / distinct | rc=0, del=0 | 6 → 6 | 1 | 1 |
+
+Two things in that third row. A duplicated marker costs **four** lines, one
+MORE than carrying no marker at all, because the marker collapses together
+with the separator block it was added to protect. And the gate was **green
+before the rebase** — the only moment at which the loss was still preventable.
+
+### Why the file-wide uniqueness check could not see it
+
+The gate already counted duplicate markers in the file. That closes the
+copy-paste-within-one-branch case and nothing else. Here the branch's own file
+carries the marker exactly ONCE and the base carries the other, so nothing
+local is duplicated. And the collapse destroys the evidence on its way past:
+afterwards a single marker is left to count, so the check cannot retro-detect
+either. It is blind in both directions, by construction.
+
+What catches the damage today is the SEPARATOR check — the detector, not the
+prevention — and it fires only after the four lines are gone. The repair loop
+was measured too: restoring the separator while keeping the marker puts two
+identical markers in one file, which the existing count then does catch, so
+the loop terminates. It terminates one full round-trip late.
+
+### The cure, and the one line of it that is load-bearing
+
+Every marker the branch ADDS is compared against the markers in
+`$BASE_REF:docs/DESIGN_NOTES.md`. **The reference is the base ref's TIP, not
+the merge base**, and that is the whole finding rather than an implementation
+detail: the colliding entry landed on main AFTER the branch was cut — that is
+what "a rebase is when a previously-unique marker stops being unique" means.
+At the merge base the marker is not there yet. Pinned by a mutant: swapping
+`$BASE_REF` for `$base` reddens exactly one case and leaves the negative
+control green.
+
+Checks 1 and 2 stay diff-scoped against the merge base because they judge the
+SHAPE of what the branch wrote; check 3 judges a COLLISION with what the branch
+is about to land on. Different question, different reference.
+
+### Not covered, deliberately
+
+A marker added to an EXISTING entry without adding a heading — a retrofit —
+exits at the "adds no entry heading" fast path before check 3 runs. Out of
+convention (old entries need no retrofit) and left uncovered rather than
+silently half-covered; widening it would also make that fast path's message
+untrue.
+
+### Its sibling is a different defect, measured side by side
+
+#1432 (`merge=union` resurrects deliberately-deleted text) reproduces in the
+same harness with the opposite sign: additions **7 → 9**, deletions 0, the
+removed lines back in the file, and the gate **rc=0 — fully blind**. Opposite
+direction, opposite verdict from the current gate, so not one defect with two
+symptoms. The overlap is in the CURE, not the defect: a two-sided
+numstat-invariance check would detect both. It can only ever be a DETECTOR
+though — it needs a before and an after — whereas the marker check is a
+PREVENTER that runs on a single state. That is the argument for keeping both.

--- a/scripts/design-notes-gate.sh
+++ b/scripts/design-notes-gate.sh
@@ -28,7 +28,7 @@
 # 12 of those headings are not entry headings at all (7 document sections, and
 # 5 mis-levelled subsections inside the 2026-08-08 #1038 entry).
 #
-# THE TWO CHECKS, and why both
+# THE CHECKS, and why each
 #
 #   1. every ADDED `## ` heading is preceded by `---` — the detector. It sees
 #      whatever the merge machinery does next, including a mechanism nobody has
@@ -40,6 +40,26 @@
 #      directions, so adoption is incremental. Uniqueness is the mechanism, not
 #      decoration: a copy-pasted marker restores the collapsible prefix and the
 #      bug with it, silently.
+#   3. uniqueness has TWO scopes, and check 2's file-wide count only closes one
+#      of them (#1428). Two copies in one file it can see. A copy the BASE
+#      already carries it cannot: the branch's own file holds the marker
+#      exactly ONCE, nothing local is duplicated, and the collision only
+#      becomes real at the rebase — which is also when it stops being
+#      detectable, because the collapse leaves a single marker behind to count.
+#      So the added markers are compared against the base as well. Measured on
+#      the scratch repo the bats suite builds: that rebase reports rc=0, zero
+#      deletions, and takes FOUR lines — one MORE than carrying no marker at
+#      all, because the duplicated marker collapses together with the separator
+#      block it was added to protect.
+#
+# THE REFERENCE FOR CHECK 3 IS THE BASE REF'S TIP, NOT THE MERGE BASE. This is
+# the whole finding and it is easy to undo by tidying: the colliding entry
+# landed on main AFTER the branch was cut — that is what "a rebase is when a
+# previously-unique marker stops being unique" means. At the merge base the
+# marker is not there yet, so a check written against `$base` measures nothing
+# and passes every real occurrence. Checks 1 and 2 stay diff-scoped against the
+# merge base, because they judge the SHAPE of what the branch wrote; check 3
+# judges a COLLISION with what the branch is about to land on.
 #
 # A convention that is only written down depends on somebody remembering it
 # across sessions — which is the very property that made this bug survive four
@@ -138,6 +158,36 @@ if [ -n "$duplicates" ]; then
 	{
 		printf 'design-notes-gate: duplicate entry marker(s) — each must be unique:\n'
 		printf '%s\n' "$duplicates"
+	} >&2
+fi
+
+# The other scope of the same uniqueness (#1428): a marker the BASE already
+# carries. Both sets are matched as WHOLE lines (`-x`): a marker collides only
+# with a byte-identical one, since only a byte-identical prefix is what the
+# merge machinery collapses. No reachable substring pair is known — `-x` states
+# the contract rather than closing a measured hole.
+added_markers="$(git diff "$base" HEAD -- "$FILE" | sed -n 's/^+\(<!-- entry .* -->\)$/\1/p' | sort -u)"
+base_markers="$(git show "$BASE_REF:$FILE" 2>/dev/null | grep '^<!-- entry .* -->$' || true)"
+
+collisions=""
+if [ -n "$added_markers" ] && [ -n "$base_markers" ]; then
+	collisions="$(printf '%s\n' "$added_markers" \
+		| grep -Fxf <(printf '%s\n' "$base_markers") || true)"
+fi
+
+if [ -n "$collisions" ]; then
+	status=1
+	{
+		printf 'design-notes-gate: entry marker(s) already carried by %s — pick a fresh one:\n' "$BASE_REF"
+		printf '%s\n' "$collisions"
+		printf '\nA marker defeats merge=union only because it DIFFERS between the two\n'
+		printf 'sides. One the base already carries restores the identical prefix the\n'
+		printf 'convention exists to destroy, and the rebase then eats FOUR lines with\n'
+		printf 'rc=0 and zero deletions — the separator block plus the marker itself,\n'
+		printf 'one MORE than carrying no marker at all.\n\n'
+		printf 'Rename yours. One issue producing several entries needs distinct\n'
+		printf 'suffixes (#1404a, #1404b, ...), chosen against what the base carries\n'
+		printf 'NOW rather than when the branch was cut.\n'
 	} >&2
 fi
 

--- a/test/scripts/design_notes_gate_test.bats
+++ b/test/scripts/design_notes_gate_test.bats
@@ -202,6 +202,61 @@ contribution() {
     refute grep -q "NOT preceded by" <<<"$output"
 }
 
+# ── The prevention window: a marker the BASE already carries (#1428) ─────────
+#
+# The regime in which #1271's cure does not cure. The case above needs both
+# copies in ONE file to be seen; here the branch's file carries the marker
+# exactly ONCE and the base carries the other. Nothing local is duplicated, so
+# the file-wide count is blind, and the collision only becomes real at the
+# rebase — by which point the four lines are already gone.
+
+@test "a marker the base already carries is rejected BEFORE the rebase (#1428)" {
+    # `scratch C C` puts the SAME marker on both sides, and main's copy landed
+    # AFTER the branch was cut. That is the reachable path: a rebase is exactly
+    # when a previously-unique marker stops being unique.
+    #
+    # This case also PINS the reference. The collision does not exist at the
+    # merge base — only at the base REF's tip — so a check written against the
+    # merge base measures nothing and this case goes red.
+    scratch C C
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"already carried by"* ]]
+    [[ "$output" == *"<!-- entry #C -->"* ]]
+}
+
+@test "the pre-rebase gate is the only window: the rebase itself is silent (#1428)" {
+    # What the check above is standing in front of, measured rather than
+    # asserted. Left ungated, this rebase reports success, deletes nothing, and
+    # takes FOUR lines — one more than carrying no marker at all, because the
+    # duplicated marker collapses together with the separator block it was
+    # added to protect.
+    scratch C C
+
+    local add_before add_after del_after
+    add_before="$(contribution 1)"
+
+    run git rebase main
+    [ "$status" -eq 0 ]
+
+    add_after="$(contribution 1)"
+    del_after="$(contribution 2)"
+
+    [ "$del_after" -eq 0 ]
+    [ "$add_after" -eq $((add_before - 4)) ]
+}
+
+@test "a marker absent from the base passes the pre-rebase check (#1428)" {
+    # The negative control for the two cases above: same shape, distinct
+    # markers, no rebase. Without it, a check that simply failed every branch
+    # carrying a marker would satisfy them both.
+    scratch B C
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 0 ]
+}
+
 # ── Fail-closed, and the fast path that must stay honest ────────────────────
 
 @test "an unresolvable base ref FAILS the gate, it does not skip it" {


### PR DESCRIPTION
Refs #1428.

#1271 cured a silent three-line loss by opening every DESIGN_NOTES entry with a
`<!-- entry #NNNN -->` line. The mechanism is DIFFERENCE, not the marker: the old
identical prefix (blank / `---` / blank) is what the merge machinery aligns as a
common addition, and a line that differs between the two sides leaves nothing to
collapse.

This is the regime in which that cure does not cure — the marker on the branch is
one the **base already carries**.

## The regime, reproduced and counted

The oracle is a scratch repository with a real `merge=union` attribute and a real
`git rebase`, not a hand-written broken file — the same shape the existing bats
suite uses. Additions of the branch's own contribution, before → after:

| markers (branch / main) | rebase | additions | gate BEFORE | gate AFTER |
|---|---|---|---|---|
| none / none (#1271) | rc=0, del=0 | 6 → 3 (**-3**) | 1 | 1 |
| distinct | rc=0, del=0 | 7 → 7 | 0 | 0 |
| **same / same (#1428)** | **rc=0, del=0** | **7 → 3 (-4)** | **0** | 1 |
| none / distinct | rc=0, del=0 | 6 → 6 | 1 | 1 |

Rows 1–3 reproduce the numbers already pinned in the bats suite (3, 0, 4), so the
harness is calibrated on known answers before any of its new readings were
believed.

**The headline is the `gate BEFORE` column: 0.** Green right up to the rebase,
which was the only moment the loss was still preventable. And the loss is FOUR
lines, one MORE than carrying no marker at all, because the duplicated marker
collapses together with the separator block it was added to protect.

Hardened against seven further placements (collision first vs last on either side,
two entries per side, merge instead of rebase): all still detected post-hoc, none
detected pre-hoc.

## Why the existing file-wide count could not see it

It closes copy-paste-within-one-branch and nothing else. Here the branch's own file
holds the marker exactly ONCE and the base holds the other, so nothing local is
duplicated. And the collapse destroys the evidence on its way past — a single
marker is left behind to count — so it cannot retro-detect either. Blind in both
directions, by construction.

The repair loop was measured too: restoring the separator while keeping the marker
puts two identical markers in one file, which the old count *does* catch. So it
terminates — one full round-trip after the lines were already lost.

## The cure

Every marker the branch ADDS is compared against `$BASE_REF:docs/DESIGN_NOTES.md`.

**The reference is the base ref's TIP, deliberately not the merge base.** That is
the whole finding rather than an implementation detail: the colliding entry landed
on main AFTER the branch was cut — which is what "a rebase is exactly when a
previously-unique marker stops being unique" means. At the merge base the marker is
not there yet, so a check written against `$base` measures nothing and passes every
real occurrence.

Checks 1 and 2 stay diff-scoped against the merge base because they judge the SHAPE
of what the branch wrote; this one judges a COLLISION with what the branch is about
to land on. Different question, different reference.

`CLAUDE.md`'s #1271 rule is changed alongside it. The rule was not wrong, it was
**incomplete**: it said UNIQUE without saying unique against *what* and *when*, so
"unique in my own file" reads as compliant — which is the exact state every
occurrence was in. Changing the gate without the rule would leave the convention
unrestatable; changing the rule without the gate is what already failed.

## Two-sided kill test

A guard that has not been seen to fail is not a guard — which is literally the
subject of this issue.

- **Before the cure:** `not ok 7 a marker the base already carries is rejected
  BEFORE the rebase (#1428)`, failing on `[ "$status" -eq 1 ]` — the gate answered
  0. Read, not assumed.
- **After:** 13/13.
- **Mutant** `$BASE_REF` → `$base`: reddens **exactly** case 7 and leaves the
  negative control (case 9) green. The tip-vs-merge-base choice is pinned by a
  test, not only by a comment.
- **End-to-end on the real 3.1 MB `docs/DESIGN_NOTES.md`, in the true behind-main
  regime:** a detached worktree at `26ed40c6` appending an entry that re-uses
  `<!-- entry #1469 -->`, which landed later in `d54d5fab`. One copy in that file,
  so the old count is blind; the new check fires, rc=1. Same worktree with a fresh
  marker: rc=0.

Three new cases: the rejection before the rebase, the four lines it stands in front
of, and a distinct marker that still passes. The middle one measures the *driver*
rather than the gate, on purpose — without it, the number in the failure message is
a claim.

## Gates

- `scripts/bats.sh`, **FULL set: 569 ok, 0 not ok, rc=0** (not only the touched file).
- `shellcheck -x scripts/design-notes-gate.sh`: rc=0.
- `scripts/design-notes-gate.sh origin/main` on this branch: rc=0.
- The DESIGN_NOTES recipe applied to this branch's own entry: prefix byte-identical
  to main's file, marker unique on the whole line (`grep -Fxc` = 1), boundary shape
  read on the file.
- **The two-sided numstat pin is VACUOUS here, and that is stated rather than
  reported as a pass:** the branch sits directly on `d54d5fab` and no rebase
  happened, so the union driver never had an opportunity.
- **`scripts/check.sh` not run:** nothing here compiles — one shell script, one bats
  file, two docs.

## What I refuse to assert

- **That the post-rebase detector was ever absent.** #1428 says "Nothing in the
  tooling flagged it" (2026-08-16). In every rebase regime probed here, the
  SEPARATOR check fires post-hoc with rc=1. Whether the gate existed or ran on that
  branch at that date was not established, so what is fixed here is the gap that was
  *measured* — no PREVENTION — not the one that sentence claims.
- **That the collision always lands on the branch's own entry.** Structurally it
  should (union emits the shared prefix once, ahead of the upstream body), but seven
  placements were probed, which is not a proof. If it can ever land on main's entry,
  the diff-scoped gate would be blind post-hoc as well. Unmeasured.
- **That `-x` on the marker match closes a reachable hole.** The comment first
  carried a `#1404b` / `#1404` example; it was then falsified — the trailing ` -->`
  makes that pair impossible as a substring. The comment now says `-x` states the
  contract rather than closing a measured hole. No reachable substring pair is known.
- **Coverage of a retrofitted marker** — one added to an existing entry with no new
  heading. It exits at the "adds no entry heading" fast path before this check runs.
  Left uncovered deliberately: it is out of convention (old entries need no
  retrofit), and widening it would make that fast path's message untrue. Named in the
  gate header, the commit and the decision-log entry rather than left silent.

## On the sibling, #1432

Measured side by side in the same harness and it is **a different defect**, not a
second symptom: additions **7 → 9**, deletions 0, the deliberately-deleted lines back
in the file, and the gate **rc=0 — fully blind**. Opposite sign, opposite verdict
from the current gate.

The overlap is in the *cure*, not the defect: a two-sided numstat-invariance check
would detect both. But it can only ever be a **detector** — it needs a before and an
after — whereas the marker check is a **preventer** that runs on a single state. That
is the argument for keeping both. Nothing here touches #1432.
