### PR TITLE
#1420: put the LockWatch verdict where green runs keep it, and stop the terminal line naming the wrong subsystem

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52892,3 +52892,87 @@ does **not** have that geometry: the deleted region sits ~59 lines before the
 file's end and `git blame` puts those 59 lines in the same commit as the
 deleted text. The adjacency threshold is A path to resurrection; that it is THE
 path is not established, and the tool promises no threshold.
+<!-- entry #1420-instrument -->
+
+---
+
+## 2026-08-20 — #1420: the instrument's verdict, and the line that named the wrong subsystem
+
+Two instrument-side slices of #1420. Neither touches the contested cure —
+narrowing `BEGIN IMMEDIATE` is a ruling about what we accept to lose, and it
+conflicts with why #1374/#1375 exist.
+
+### The census now carries the LockWatch verdict on a GREEN run
+
+`log-gap-census` uploads with `if: always()`; `container-logs` only on
+failure. Measured over a 3-day window: 161 attempts, 12 of them stalled, 9
+with `LockWatch` compiled in — and of those 9, **6 (5 green, 1 cancelled)
+uploaded no bytes at all**, so the instrument's answer was discarded BY
+CONSTRUCTION on two thirds of the attempts that armed it. The verdict cost a
+few bytes and it was already being computed; it just was not in the artefact
+that survives.
+
+`scripts/log-gap-scan.awk` now counts three more signatures beside `db30 /
+idle30 / dropped / saturated`: `lockstall` and `lockstall_resolved` (the two
+edges of a `LockWatch` episode) and `lockheld` (a `BusyRetry` budget exhausted
+against a held write lock — see below). Two counters for the episode, not one,
+because the RESOLVED line CONTAINS the phrase `db lock stall`: a counter
+anchored there reports an episode that never opened, and reports a resolved
+stall as an unresolved one. `lockstall` therefore anchors on `db lock stall:
+holder ` — the colon is load-bearing.
+
+Nothing about RETENTION changed: the triggers are still a service gap and a
+dropped row. Making a detected stall keep the 275 MB is a defensible next
+move and is deliberately not taken here — it is a policy change, and this
+slice is an instrument change.
+
+### The controls live INSIDE the scanner
+
+A census is read as evidence months later, and a zero from a pattern that
+stopped matching is indistinguishable from a zero that means "clean". So the
+scanner registers each signature with a known-answer sample copied from the
+call site that emits it, and BEGIN pushes those samples through the REAL
+counting path before one input line is read:
+
+* **known answer** — each sample raises ITS counter exactly once and no
+  other. This is the arm that catches the `db lock stall` substring trap:
+  loosen `lockstall` to that phrase and the control names both signatures.
+* **invented line** — a line no signature describes raises nothing, so a
+  pattern that degenerated to match-anything cannot pass the arm above.
+* **complete set** — every registered signature reaches the SUMMARY with its
+  known answer, and the SUMMARY declares no `key=` field nothing registers.
+
+A failed control exits 3 having printed **no numbers**. The format is scanned
+BEFORE it is rendered on purpose: an unbacked `%d` makes `sprintf` die with
+"not enough args" on BSD awk and pass silently on gawk/mawk, so rendering
+first would make the control's verdict depend on which awk the runner has.
+Each control is exercised in `test/scripts/log_gap_scan_test.bats` by
+corrupting a COPY of the scanner — a control nobody has watched fire is not
+shipped as one.
+
+### The terminal line named the wrong subsystem
+
+`Repo.BusyRetry`'s budget-exhaustion warning read `SQLite pool saturated` for
+BOTH fault kinds while its own `fault:` metadata on the SAME line said which.
+Measured across three stalled CI runs: **4 terminal observations, all four
+`fault=busy_locked`, zero `queue_timeout`** — every one a write-lock
+contention wearing a pool label, on the exact axis (pool vs lock) this issue
+exists to separate. CLAUDE.md's log-honesty rule says the line describes the
+state OBSERVED, so the prose splits per fault kind. Prose only: same retry,
+same `{:error, :db_unavailable}`, same metadata. It is also what lets the
+census count the two apart.
+
+### Named, not cured
+
+- **The retry budget cannot fire on the fault it exists for.**
+  `busy_timeout: 30_000` against `budget_ms: 1_500` means the first attempt
+  overruns the budget by 20×, so the `monotonic_time < deadline` arm is
+  unreachable for a `busy_locked` fault — observed 4/4 as `(1 attempts)`.
+  Real, measured, and deliberately NOT fixed here: changing it changes retry
+  behaviour under contention, which is the contested axis.
+- **`LockWatch` is blind to bare writes.** Both its sets are populated only by
+  `Repo.immediate_transaction/1`, and there are ~130 bare
+  `Repo.insert/update/delete/*_all` call sites, each taking `RESERVED` for its
+  own implicit transaction and registering nothing. A seam on all of them is
+  not a reflex-sized change.
+- **Who holds the lock is still unnamed**, and nothing here narrows it.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -925,7 +925,13 @@ So the trap now streams each service's log through
 measured: the largest silence between consecutive lines, every silence
 at or over `GAP_THRESHOLD` (10 s — above the 5 s healthcheck cadence,
 below the 30 s `busy_timeout`), and counts of the damage signatures
-(`db=3xxxx`, `idle=3xxxx`, a dropped scrollback row, a saturated pool).
+(`db=3xxxx`, `idle=3xxxx`, a dropped scrollback row, a saturated pool, a
+retry budget exhausted against a held write lock, and — since #1420 — both
+edges of a `LockWatch` stall episode, `lockstall` / `lockstall_resolved`).
+Those last three are why the census is where the LockWatch verdict lives:
+`container-logs` uploads on failure only, and of the 9 stalled attempts that
+had LockWatch compiled in, 6 (5 green, 1 cancelled) uploaded no bytes at all,
+so the instrument's answer was discarded by construction.
 That lands in `container-logs/gap-scan.tsv`, a few KB, and on stdout as
 well — on a green CI run the job log is the copy that survives without
 an artifact. `tee` is the mechanism: the stream reaches the scanner
@@ -1031,6 +1037,15 @@ without touching the script that implements it — which is why
 `test/scripts/log_gap_scan_test.bats` (threshold boundary from both
 sides, arithmetic, midnight rollover, one case per damage signature,
 and the refusal to default a missing threshold).
+
+The scanner also carries its own controls, in BEGIN, before a single input
+line is read: each signature's known-answer sample must raise ITS counter and
+no other, an invented line must raise nothing, and every registered signature
+must reach the SUMMARY. A failed control exits 3 having printed no numbers —
+because a zero from a broken pattern is indistinguishable from a zero that
+means "clean", and this census is read as evidence months later. The bats file
+exercises each control by corrupting a COPY of the scanner, so a control
+nobody has watched fire is not shipped as one.
 
 This is evidence collection, not a gate: no branch of the trap touches
 the exit code, and a green run stays green.
@@ -4733,7 +4748,11 @@ baseline table, never a summary number**:
   row `mean_ms`, watched as the table grows.
 
 WAL/lock corroboration (mechanism 2, out-of-band): grep prod logs for the
-`SQLite pool saturated` warning and busy/locked `%Exqlite.Error{}` lines during
+`db write unavailable` warning — it names WHICH of the two it observed since
+#1420 (`SQLite pool saturated` for a pool `queue_timeout`, `SQLite write lock
+held by another writer` for a `busy_locked`; before that it said "pool" for
+both while its own `fault=` metadata said otherwise) — and busy/locked
+`%Exqlite.Error{}` lines during
 the burst; watch WAL checkpoint pressure via the `runtime/*.db-wal` file size
 (a large, slow-shrinking `-wal` = checkpoints falling behind the write rate).
 

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -102,17 +102,33 @@ defmodule Grappa.Repo.BusyRetry do
           loop(op, opts, deadline, attempt + 1)
 
         true ->
-          on_contention(opts, fault_kind(error), attempt, true)
+          kind = fault_kind(error)
+          on_contention(opts, kind, attempt, true)
 
           Logger.warning(
-            "db write unavailable: SQLite pool saturated for the full " <>
+            "db write unavailable: #{observed_state(kind)} for the full " <>
               "#{@budget_ms}ms retry budget (#{attempt} attempts) — returning :db_unavailable",
-            fault: fault_kind(error)
+            fault: kind
           )
 
           {:error, :db_unavailable}
       end
   end
+
+  # CLAUDE.md "Log honesty": the line describes the state it OBSERVED, not a
+  # plausible one. It used to say "SQLite pool saturated" for BOTH fault kinds
+  # while its own `fault:` metadata on the same line said which — and #1420
+  # measured 4 terminal observations across three stalled CI runs, all four
+  # `fault=busy_locked` and none `queue_timeout`. Every one was a write-lock
+  # contention wearing a pool label, which is a plausible reason the two
+  # topologies stayed conflated for as long as they did.
+  #
+  # Prose only: same retry, same `{:error, :db_unavailable}`, same metadata.
+  # Splitting it also lets the #1429 census count the two apart
+  # (`saturated` / `lockheld` in `scripts/log-gap-scan.awk`).
+  @spec observed_state(fault_kind()) :: String.t()
+  defp observed_state(:queue_timeout), do: "SQLite pool saturated"
+  defp observed_state(:busy_locked), do: "SQLite write lock held by another writer"
 
   # Invoke the caller's contention observer if one was supplied. Its return is
   # discarded — it is a side-channel (telemetry), not part of the retry result.

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -21,7 +21,8 @@
 # 14:40:14, silence 14:40:15.008 -> 14:40:31.720, failure 14:40:32), with
 # every damage counter at zero, and that spec passing 3/3 in isolation.
 #
-#   gap + a DAMAGE SIGNATURE (db30 / idle30 / dropped / saturated)
+#   gap + a DAMAGE SIGNATURE (db30 / idle30 / dropped / saturated /
+#       lockheld / lockstall / lockstall_resolved)
 #       => a stall. The environment is implicated, the spec is not.
 #   BARE gap (every damage counter zero)
 #       => attributes NOTHING. Traffic drought and a stalled process
@@ -31,6 +32,15 @@
 # in a separate report: the gap alone is not a verdict, and separating
 # them invites reading it as one.
 #
+# 🔴 WHY THE LOCK COUNTERS ARE HERE (#1420). `container-logs` uploads on
+# failure only; this census uploads on EVERY run. #1420 measured 12
+# stalled attempts, 9 of them with `LockWatch` compiled in — and only 3
+# were readable, because the other 6 (5 green, 1 cancelled) never
+# uploaded any bytes. The instrument's own verdict was thrown away BY
+# CONSTRUCTION on the majority of the attempts that armed it. Counting
+# `LockWatch`'s two episode edges here puts that verdict in the artefact
+# that survives a green run.
+#
 # What it reports, per service:
 #   - the largest silence between consecutive timestamped lines, and when
 #     it started. A quiet stack still logs its 5 s healthcheck cadence, so
@@ -38,13 +48,133 @@
 #   - every silence at or over THRESH seconds, individually.
 #   - counts of the damage signatures that accompany the regime: a
 #     statement or a checked-out connection held for 30-something seconds
-#     (db=3xxxx / idle=3xxxx), a dropped scrollback row, a saturated pool.
+#     (db=3xxxx / idle=3xxxx), a dropped scrollback row, a saturated pool,
+#     a retry budget exhausted against a held write lock, and the two
+#     edges of a `LockWatch` stall episode.
 #
 # Usage: awk -v SVC=<service> -v THRESH=<seconds> -f log-gap-scan.awk
 #
 # THRESH is REQUIRED. A defaulted threshold would let a caller that forgot
 # it report a plausible-looking census measured against something other
 # than what the caller meant.
+#
+# 🔴 THE CONTROLS ARE INSIDE THE INSTRUMENT, NOT BESIDE IT. Every damage
+# signature is registered with a KNOWN-ANSWER sample copied from the call
+# site that produces it, and BEGIN pushes those samples through the REAL
+# counting path before a single input line is read:
+#
+#   * known answer — each sample raises its OWN counter exactly once, and
+#     no other (so a pattern that swallows a sibling's line is caught:
+#     `db lock stall` matches the RESOLVED line too, which is the exact
+#     trap these three counters walked into).
+#   * invented line — a line no signature describes raises nothing.
+#   * complete set — every registered signature reaches the SUMMARY line
+#     with its known answer, and the SUMMARY declares no `key=` field that
+#     is neither registered nor structural.
+#
+# A failed control exits 3 having printed NO numbers: a census that cannot
+# vouch for its own counters must not publish any, because a zero from a
+# broken pattern is indistinguishable from a zero that means "clean".
+
+# Register a damage signature: its counter name, and one line copied
+# VERBATIM from the call site that emits it. The pattern itself lives in
+# `count_signatures` — the samples are pushed through that function, so
+# the control tests the shipped counting path and not a parallel table.
+function sig(name, sample) {
+    nsig++
+    NAME[nsig] = name
+    SAMPLE[nsig] = sample
+    REGISTERED[name] = 1
+}
+
+# The only place a damage signature is recognised. Both the live stream
+# and the BEGIN controls go through here.
+function count_signatures(line) {
+    if (line ~ /db=3[0-9][0-9][0-9][0-9]\./) CNT["db30"]++
+    if (line ~ /idle=3[0-9][0-9][0-9][0-9]\./) CNT["idle30"]++
+    if (line ~ /scrollback row dropped/) CNT["dropped"]++
+    if (line ~ /saturated for the full/) CNT["saturated"]++
+
+    # `index` before the three regexes: every lock signature carries the
+    # literal "lock", and the stream is ~10^6 lines. The known-answer
+    # control below is what proves the guard lets them through.
+    if (index(line, "lock") > 0) {
+        if (line ~ /write lock held by another writer/) CNT["lockheld"]++
+        if (line ~ /db lock stall: holder /) CNT["lockstall"]++
+        if (line ~ /db lock stall RESOLVED/) CNT["lockstall_resolved"]++
+    }
+}
+
+function zero_counters(   i) {
+    for (i = 1; i <= nsig; i++) CNT[NAME[i]] = 0
+}
+
+# One definition of the SUMMARY line, used by the END emit AND by the
+# completeness control, so the control cannot drift from what ships.
+function summary_line(svc, nlines, mg, mat) {
+    return sprintf(SUMFMT, svc, nlines, mg, mat, THRESH, ngap, \
+        CNT["db30"], CNT["idle30"], CNT["dropped"], CNT["saturated"], \
+        CNT["lockheld"], CNT["lockstall"], CNT["lockstall_resolved"])
+}
+
+function bail(msg) {
+    print "log-gap-scan.awk: CONTROL FAILED — " msg >"/dev/stderr"
+    print "log-gap-scan.awk: refusing to print a census it cannot vouch for" >"/dev/stderr"
+    abort_rc = 3
+    exit 3
+}
+
+# known answer + no cross-talk: each sample raises its own counter, once.
+function control_known_answer(   i, j) {
+    for (i = 1; i <= nsig; i++) {
+        zero_counters()
+        count_signatures(SAMPLE[i])
+        if (CNT[NAME[i]] != 1)
+            bail("the known-answer sample for " NAME[i] " raised it " CNT[NAME[i]] " times, want 1")
+        for (j = 1; j <= nsig; j++)
+            if (j != i && CNT[NAME[j]] != 0)
+                bail(NAME[i] "'s sample also raised " NAME[j] " — the two patterns do not discriminate")
+    }
+}
+
+# invented line: a plausible log line no signature describes must raise
+# nothing. Without it a pattern that degenerated to "match anything" would
+# pass every known-answer check above.
+function control_invented_line(   i) {
+    zero_counters()
+    count_signatures(NEG)
+    for (i = 1; i <= nsig; i++)
+        if (CNT[NAME[i]] != 0)
+            bail("the invented line raised " NAME[i] " — that pattern matches lines it does not describe")
+}
+
+# complete set, both directions: every registered signature reaches the
+# SUMMARY with its known answer, and the SUMMARY declares no `key=` field
+# that is neither registered nor structural.
+# The format is scanned BEFORE it is rendered: an unbacked `%d` field makes
+# `sprintf` die with "not enough args" on a strict awk (BSD) and pass
+# silently on a lenient one (gawk/mawk), so leaving the render first would
+# make the control's own verdict depend on which awk the runner has.
+function control_complete_set(   i, probe, n, parts, p, k) {
+    n = split(SUMFMT, parts, "\t")
+    for (i = 1; i <= n; i++) {
+        p = index(parts[i], "=")
+        if (p == 0) continue
+        k = substr(parts[i], 1, p - 1)
+        if (k == "lines" || k == "maxgap" || k == "maxgap_at") continue
+        if (k ~ /^gaps_ge_/) continue
+        if (!(k in REGISTERED))
+            bail("the SUMMARY declares '" k "=' but nothing registers that signature")
+    }
+
+    zero_counters()
+    for (i = 1; i <= nsig; i++) count_signatures(SAMPLE[i])
+    probe = summary_line("selftest", 0, 0, "")
+    for (i = 1; i <= nsig; i++)
+        if (index(probe, "\t" NAME[i] "=1") == 0)
+            bail("signature " NAME[i] " does not reach the SUMMARY line with its known answer")
+    zero_counters()
+}
 
 BEGIN {
     if (THRESH + 0 <= 0) {
@@ -52,14 +182,46 @@ BEGIN {
         missing_thresh = 1
         exit 2
     }
+
+    SUMFMT = "%s\tSUMMARY\tlines=%d\tmaxgap=%.1f\tmaxgap_at=%s\tgaps_ge_%d=%d" \
+        "\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d" \
+        "\tlockheld=%d\tlockstall=%d\tlockstall_resolved=%d\n"
+
+    # Samples copied from the emitting call site. Keep them verbatim: a
+    # sample edited to fit the pattern turns the control into a mirror.
+    #   db30 / idle30      — Ecto's own query log (`Grappa.DbLatency`).
+    #   dropped            — Grappa.Scrollback, #336 never-crash contract.
+    #   saturated          — Repo.BusyRetry, pool queue_timeout arm.
+    #   lockheld           — Repo.BusyRetry, busy_locked arm (#1420).
+    #   lockstall{,_resolved} — Grappa.Repo.LockWatch's two episode edges.
+    sig("db30", "QUERY OK source=\"messages\" db=30064.1ms queue=0.1ms")
+    sig("idle30", "client #PID<0.700.0> checked out, idle=30062.4ms")
+    sig("dropped", "scrollback row dropped for #bofh: :persist_unavailable")
+    sig("saturated", \
+        "db write unavailable: SQLite pool saturated for the full 1500ms retry budget" \
+        " (3 attempts) — returning :db_unavailable")
+    sig("lockheld", \
+        "db write unavailable: SQLite write lock held by another writer for the full" \
+        " 1500ms retry budget (1 attempts) — returning :db_unavailable")
+    sig("lockstall", \
+        "db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2" \
+        " waiter(s) queued — holder at :gen_server.loop/7, stack: …")
+    sig("lockstall_resolved", \
+        "db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms")
+
+    # Deliberately ordinary: a real line from the same stream that names
+    # none of the signatures. It DOES carry the word "lock" so the
+    # index-guard above cannot be what makes it pass.
+    NEG = "GET /healthz — 200 in 412µs (db lock unrelated prose, no signature here)"
+
+    control_known_answer()
+    control_invented_line()
+    control_complete_set()
+
     prev = -1
     maxgap = 0
     maxat = ""
     ngap = 0
-    db30 = 0
-    idle30 = 0
-    dropped = 0
-    saturated = 0
     lines = 0
 }
 
@@ -83,14 +245,11 @@ BEGIN {
         prevstamp = substr($0, 12, 12)
     }
 
-    if ($0 ~ /db=3[0-9][0-9][0-9][0-9]\./) db30++
-    if ($0 ~ /idle=3[0-9][0-9][0-9][0-9]\./) idle30++
-    if ($0 ~ /scrollback row dropped/) dropped++
-    if ($0 ~ /saturated for the full/) saturated++
+    count_signatures($0)
 }
 
 END {
     if (missing_thresh) exit 2
-    printf "%s\tSUMMARY\tlines=%d\tmaxgap=%.1f\tmaxgap_at=%s\tgaps_ge_%d=%d\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d\n", \
-        SVC, lines, maxgap, maxat, THRESH, ngap, db30, idle30, dropped, saturated
+    if (abort_rc) exit abort_rc
+    printf "%s", summary_line(SVC, lines, maxgap, maxat)
 }

--- a/test/grappa/repo/busy_retry_test.exs
+++ b/test/grappa/repo/busy_retry_test.exs
@@ -21,6 +21,8 @@ defmodule Grappa.Repo.BusyRetryTest do
   """
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Grappa.Repo.BusyRetry
 
   # A pool checkout that could not be served — always transient (retry).
@@ -37,6 +39,15 @@ defmodule Grappa.Repo.BusyRetryTest do
   # Syntax / corruption — NON-transient: retrying only spins.
   defp raise_syntax do
     raise %Exqlite.Error{message: "near \"SLECT\": syntax error", statement: nil}
+  end
+
+  # Every captured terminal line tagged with this fault kind. The `fault=`
+  # metadata is what the prose has to agree with, so it is also what selects
+  # the lines to judge.
+  defp terminal_lines(log, fault) do
+    log
+    |> String.split("\n")
+    |> Enum.filter(&(&1 =~ "db write unavailable" and &1 =~ "fault=#{fault}"))
   end
 
   describe "run/1 happy + validation paths" do
@@ -103,6 +114,40 @@ defmodule Grappa.Repo.BusyRetryTest do
 
       assert_raise Exqlite.Error, ~r/syntax error/, fn -> BusyRetry.run(op) end
       assert Agent.get(counter, & &1) == 1
+    end
+  end
+
+  # #1420 — CLAUDE.md "Log honesty": the line must describe the state it
+  # OBSERVED. This one read `SQLite pool saturated` for BOTH fault kinds while
+  # its own `fault:` metadata on the SAME line said which one it was. Measured
+  # in CI over three stalled integration runs: 4 terminal observations, all
+  # four `fault=busy_locked` and none `fault=queue_timeout` — so every one of
+  # them was a write-lock contention wearing a pool label, and the two
+  # topologies this whole issue is about stayed conflated in the prose that
+  # names them.
+  #
+  # Asserted over the SET of terminal lines carrying a given `fault=`, never
+  # over the whole capture: `capture_log/1` sees Logger output from every
+  # concurrently-running async file, and several of them drive this same
+  # terminal arm. "Every terminal line tagged X names X" is the invariant, and
+  # a leaked line from a sibling file satisfies it too.
+  describe "terminal log line — the fault it names is the fault it observed" do
+    test "a busy_locked exhaustion names the write LOCK, never the pool" do
+      log = capture_log(fn -> assert {:error, :db_unavailable} = BusyRetry.run(&raise_busy/0) end)
+
+      lines = terminal_lines(log, :busy_locked)
+      assert lines != []
+      assert Enum.all?(lines, &(&1 =~ "SQLite write lock held by another writer"))
+      refute Enum.any?(lines, &(&1 =~ "pool saturated"))
+    end
+
+    test "a queue_timeout exhaustion still names the POOL, never the lock" do
+      log = capture_log(fn -> assert {:error, :db_unavailable} = BusyRetry.run(&raise_queue_timeout/0) end)
+
+      lines = terminal_lines(log, :queue_timeout)
+      assert lines != []
+      assert Enum.all?(lines, &(&1 =~ "SQLite pool saturated"))
+      refute Enum.any?(lines, &(&1 =~ "write lock held"))
     end
   end
 

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -20,6 +20,15 @@ load ../bats_helpers
 setup() {
     SCANNER="$BATS_TEST_DIRNAME/../../scripts/log-gap-scan.awk"
     [ -f "$SCANNER" ]
+
+    # Verbatim from the call sites, so a pin that drifts from production
+    # prose fails here rather than reporting a confident zero.
+    #   lock_watch.ex — the two edges of one stall episode
+    #   busy_retry.ex — the two terminal arms, one per fault kind
+    LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder at :gen_server.loop/7, stack: a <- b'
+    LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
+    LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for the full 1500ms retry budget (1 attempts) — returning :db_unavailable'
+    SATURATED_LINE='db write unavailable: SQLite pool saturated for the full 1500ms retry budget (3 attempts) — returning :db_unavailable'
 }
 
 # The scanner as integration.sh invokes it: a service label and a
@@ -81,12 +90,164 @@ stamp() {
         stamp '12:00:01.' 'conn idle=30062.4ms checked out'
         stamp '12:00:02.' 'scrollback row dropped for #bofh'
         stamp '12:00:03.' 'pool saturated for the full 30s'
+        stamp '12:00:04.' "$LOCKHELD_LINE"
+        stamp '12:00:05.' "$LOCKSTALL_LINE"
+        stamp '12:00:06.' "$LOCKRESOLVED_LINE"
     } | scan 10 )"
 
     grep -q 'db30=1' <<<"$out"
     grep -q 'idle30=1' <<<"$out"
     grep -q 'dropped=1' <<<"$out"
     grep -q 'saturated=1' <<<"$out"
+    grep -q 'lockheld=1' <<<"$out"
+    grep -q 'lockstall=1' <<<"$out"
+    grep -q 'lockstall_resolved=1' <<<"$out"
+}
+
+# --- #1420: the LockWatch verdict has to reach a GREEN run's artefact ------
+#
+# `container-logs` uploads on failure only; this census uploads always. #1420
+# measured 9 stalled attempts with LockWatch compiled in and only 3 readable —
+# the other 6 (5 green, 1 cancelled) threw the instrument's verdict away by
+# construction. These two counters are what puts it in the artefact that
+# survives.
+
+@test "a LockWatch stall episode is counted at BOTH edges" {
+    local out
+    out="$( {
+        stamp '12:00:00.' "$LOCKSTALL_LINE"
+        stamp '12:00:30.' "$LOCKRESOLVED_LINE"
+    } | scan 60 )"
+
+    grep -q 'lockstall=1' <<<"$out"
+    grep -q 'lockstall_resolved=1' <<<"$out"
+}
+
+@test "the RESOLVED edge alone does not score as a DETECTION" {
+    # The substring trap, and the reason these are two counters rather than
+    # one `db lock stall`: the RESOLVED line CONTAINS that phrase, so a
+    # counter anchored on it would report an episode that never opened —
+    # and, worse, report a resolved stall as an unresolved one.
+    local out
+    out="$( stamp '12:00:00.' "$LOCKRESOLVED_LINE" | scan 10 )"
+
+    grep -q 'lockstall=0' <<<"$out"
+    grep -q 'lockstall_resolved=1' <<<"$out"
+}
+
+@test "a DETECTION alone does not score as RESOLVED" {
+    # The other side, and the one that matters most in a census: an episode
+    # that never closed is the stall still running when the run ended.
+    local out
+    out="$( stamp '12:00:00.' "$LOCKSTALL_LINE" | scan 10 )"
+
+    grep -q 'lockstall=1' <<<"$out"
+    grep -q 'lockstall_resolved=0' <<<"$out"
+}
+
+@test "a retry budget exhausted on the write LOCK is counted apart from a saturated POOL" {
+    # #1420 measured 4 terminal BusyRetry observations in CI, all four
+    # `fault=busy_locked` — i.e. lock contention wearing a pool label. The
+    # prose split at the call site is worth nothing if the census re-merges
+    # them here.
+    local out
+    out="$( stamp '12:00:00.' "$LOCKHELD_LINE" | scan 10 )"
+    grep -q 'lockheld=1' <<<"$out"
+    grep -q 'saturated=0' <<<"$out"
+
+    out="$( stamp '12:00:00.' "$SATURATED_LINE" | scan 10 )"
+    grep -q 'saturated=1' <<<"$out"
+    grep -q 'lockheld=0' <<<"$out"
+}
+
+# --- the scanner's own controls -------------------------------------------
+#
+# The counters above are only worth their numbers if a broken pattern is
+# LOUD rather than zero. The scanner carries three controls in BEGIN —
+# known answer, invented line, complete set — and refuses to print a census
+# when one fails. A control nobody has seen fire is not a control, so each is
+# exercised by corrupting a COPY (the complete-set one in both directions).
+
+# A copy of the scanner with one sed applied. The edit must actually change
+# something, or the test would pass against an untouched script.
+corrupted_scanner() {
+    local out="$BATS_TEST_TMPDIR/scanner.awk"
+    sed "$1" "$SCANNER" >"$out"
+    refute cmp -s "$out" "$SCANNER"
+    printf '%s' "$out"
+}
+
+@test "the shipped scanner passes its own controls and prints its census" {
+    # The positive side. Without it the three corruption tests below could
+    # all be passing because the scanner never runs at all.
+    run awk -v SVC=svc -v THRESH=10 -f "$SCANNER" </dev/null
+    [ "$status" -eq 0 ]
+    grep -q 'svc	SUMMARY	lines=0' <<<"$output"
+    refute grep -q 'CONTROL FAILED' <<<"$output"
+}
+
+@test "a known-answer control failure prints NO numbers" {
+    # A pattern that stopped matching the line it exists for reports zero,
+    # and a zero is what a clean run looks like. Break the db30 sample so it
+    # no longer raises its counter.
+    local mutated
+    mutated="$(corrupted_scanner 's/db=30064\.1ms/db=1.1ms/')"
+
+    run awk -v SVC=svc -v THRESH=10 -f "$mutated" </dev/null
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"db30"* ]]
+    refute grep -q $'\tSUMMARY\t' <<<"$output"
+}
+
+@test "two patterns that do not discriminate print NO numbers" {
+    # The trap this slice exists for, as a mutant: loosen the DETECTION
+    # anchor to the bare phrase and it swallows the RESOLVED line too. The
+    # known-answer control's cross-talk arm is what names both signatures
+    # instead of quietly reporting an episode that never opened.
+    local mutated
+    mutated="$(corrupted_scanner 's|/db lock stall: holder /|/db lock stall/|')"
+
+    run awk -v SVC=svc -v THRESH=10 -f "$mutated" </dev/null
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"lockstall_resolved's sample also raised lockstall"* ]]
+    refute grep -q $'\tSUMMARY\t' <<<"$output"
+}
+
+@test "a pattern that matches lines it does not describe prints NO numbers" {
+    # The invented-line control. Make the negative sample carry a real
+    # signature: the `dropped` pattern then matches a line no signature
+    # describes, which is how a degenerate pattern would look.
+    local mutated
+    mutated="$(corrupted_scanner 's/no signature here/scrollback row dropped/')"
+
+    run awk -v SVC=svc -v THRESH=10 -f "$mutated" </dev/null
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"dropped"* ]]
+    refute grep -q $'\tSUMMARY\t' <<<"$output"
+}
+
+@test "a registered signature missing from the SUMMARY prints NO numbers" {
+    # The complete-set control, counted direction: a counter that is raised
+    # but never emitted is a measurement nobody can read.
+    local mutated
+    mutated="$(corrupted_scanner 's/\\tdropped=%d//')"
+
+    run awk -v SVC=svc -v THRESH=10 -f "$mutated" </dev/null
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"dropped"* ]]
+    refute grep -q $'\tSUMMARY\t' <<<"$output"
+}
+
+@test "a SUMMARY field nothing registers prints NO numbers" {
+    # The complete-set control, emitted direction: a field in the census
+    # that no signature backs reports a number that means nothing.
+    local mutated
+    mutated="$(corrupted_scanner 's/\\tsaturated=%d/\\tsaturated=%d\\tbogus=%d/')"
+
+    run awk -v SVC=svc -v THRESH=10 -f "$mutated" </dev/null
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"bogus"* ]]
+    refute grep -q $'\tSUMMARY\t' <<<"$output"
 }
 
 @test "a sub-30s duration does not score as a 30-something hold" {


### PR DESCRIPTION
Two instrument-side slices of #1420. **Neither touches the contested cure** —
narrowing `BEGIN IMMEDIATE` is a ruling about what we accept to lose, and it
conflicts with why #1374/#1375 exist.

## A — the census now carries the LockWatch verdict on a GREEN run

`log-gap-census` uploads with `if: always()`; `container-logs` only on failure.
Measured over a 3-day window: **161 attempts, 12 stalled, 9 with `LockWatch`
compiled in — and 6 of those 9 (5 green, 1 cancelled) uploaded no bytes at
all.** The instrument's answer was discarded BY CONSTRUCTION on two thirds of
the attempts that armed it, while the census that survives every run was
already streaming the same bytes.

`scripts/log-gap-scan.awk` gains three signatures beside `db30 / idle30 /
dropped / saturated`:

| counter | emitter | what it means |
|---|---|---|
| `lockstall` | `lock_watch.ex` DETECTED edge | an episode opened |
| `lockstall_resolved` | `lock_watch.ex` RESOLVED edge | it closed |
| `lockheld` | `busy_retry.ex` `busy_locked` arm | a retry budget died against a held write lock |

**Two counters for the episode, not one.** The RESOLVED line CONTAINS the
phrase `db lock stall`, so a counter anchored there reports an episode that
never opened and reports a resolved stall as an unresolved one. `lockstall`
anchors on `db lock stall: holder ` — the colon is load-bearing.

**The third counter the issue comment asked for does not exist.** `has held
RESERVED` is not a distinct signature: `git grep` finds exactly one emitter,
`lock_watch.ex:362`, which IS the DETECTED line. Two counters cover the whole
population.

## The controls are INSIDE the scanner

A census is read as evidence months later, and a zero from a pattern that
stopped matching is indistinguishable from a zero that means "clean". So each
signature is registered with a known-answer sample copied from its call site,
and BEGIN pushes those samples through the **real** counting path before one
input line is read:

* **known answer** — each sample raises ITS counter exactly once and no other.
* **invented line** — a line no signature describes raises nothing.
* **complete set** — every registered signature reaches the SUMMARY, and the
  SUMMARY declares no `key=` field nothing registers.

A failed control **exits 3 having printed no numbers**.

## Two-sided kill tests — A

Base scanner (`d54d5fab`), fed three genuine LockWatch/BusyRetry lines:

```
svc  SUMMARY  lines=3  maxgap=30.0  ...  db30=0 idle30=0 dropped=0 saturated=0
```

— the census reports nothing; the fields do not exist. **RED.**

Cured scanner, same stream: `lockheld=1 lockstall=1 lockstall_resolved=1`.
Then, one line at a time:

| stream | result |
|---|---|
| RESOLVED alone | `lockstall=0`, `lockstall_resolved=1` |
| DETECTED alone | `lockstall=1`, `lockstall_resolved=0` |
| `lockheld` line alone | `lockheld=1`, `saturated=0` |
| `saturated` line alone | `saturated=1`, `lockheld=0` |
| empty stream | every counter 0, rc=0 |

**Five control mutants, each watched firing** (corrupted COPY of the scanner;
each `sed` verified non-no-op):

| mutant | rc | census lines printed | message |
|---|---|---|---|
| `db30` sample broken | 3 | 0 | known-answer sample for db30 raised it 0 times |
| `lockstall` loosened to the bare phrase | 3 | 0 | `lockstall_resolved`'s sample also raised `lockstall` |
| invented line given a real signature | 3 | 0 | the invented line raised `dropped` |
| `dropped=%d` removed from the SUMMARY | 3 | 0 | signature `dropped` does not reach the SUMMARY |
| unbacked `bogus=%d` added to the SUMMARY | 3 | 0 | the SUMMARY declares `bogus=` but nothing registers it |

Positive control: the shipped scanner, rc=0, census printed.

### Portability, measured — and it found a real defect

Run under **mawk 1.3.4** (what Ubuntu CI's `awk` is), **gawk 5.2.1** and BSD
awk 20200816: census output **byte-identical**, all mutants rc=3.

In the first draft the last mutant died **rc=2 on BSD awk** (`sprintf`: not
enough args) and would have **passed silently on mawk/gawk**. The format is
now scanned BEFORE it is rendered, so the control's verdict does not depend on
which awk the runner has.

## B — the terminal line named the wrong subsystem

`Repo.BusyRetry`'s budget-exhaustion warning read `SQLite pool saturated` for
BOTH fault kinds while its own `fault:` metadata on the SAME line said which.
Measured across three stalled CI runs: **4 terminal observations, all four
`fault=busy_locked`, zero `queue_timeout`** — every one a write-lock
contention wearing a pool label, on the exact axis this issue exists to
separate.

TDD, both sides run:

**RED** (cure reverted to `origin/main`'s version, test file unchanged) — one
failure, and its output is the defect verbatim:

```
1) test ... a busy_locked exhaustion names the write LOCK, never the pool
   ["11:04:00.708 fault=busy_locked pid=<0.873.0> [warning] db write unavailable:
     SQLite pool saturated for the full 300ms retry budget (26 attempts) ..."]
15 tests, 1 failure
```

The `queue_timeout` case stayed green throughout — pre-cure the pool prose is
correct for that fault, so the mutant kills exactly the one assertion it
should.

**GREEN** (cure restored): `15 tests, 0 failures`, rc=0.

Behaviour is untouched: same retry, same `{:error, :db_unavailable}`, same
metadata, same telemetry. Prose only.

The test asserts over the **set** of terminal lines carrying a given `fault=`,
never over the whole capture: `capture_log/1` sees output from every
concurrently-running async file and several drive this same arm, so "every
terminal line tagged X names X" is the invariant a leaked sibling line
satisfies too.

## Named, NOT cured

* **The retry budget cannot fire on the fault it exists for.** `busy_timeout:
  30_000` against `budget_ms: 1_500` — the first attempt overruns the budget by
  20×, so the `monotonic_time < deadline` arm is unreachable for a
  `busy_locked` fault (observed 4/4 as `(1 attempts)`). Real and measured, and
  deliberately left alone: fixing it changes retry behaviour under contention,
  which is the contested axis.
* **`LockWatch` is blind to bare writes** — both its sets are populated only by
  `Repo.immediate_transaction/1`, against ~130 bare `Repo.insert/update/delete`
  call sites.
* **A detected stall is NOT a retention trigger.** Defensible next move,
  deliberately not taken: retention is a policy, this slice is an instrument.
  The triggers are still a service gap and a dropped row.
* **Who holds the lock is still unnamed**, and nothing here narrows it.

## Gates

* `scripts/check.sh` — **rc=0**. 8 doctests, 61 properties, **6569 tests, 0
  failures**; dialyzer `Total errors: 0`; credo, sobelow, doctor, and the
  wire-types drift gate all ran.
* `scripts/bats.sh` — **rc=0**, full set: **579 ok, 0 not ok**, including the
  11 new/extended `log_gap_scan_test.bats` cases.
* `scripts/design-notes-gate.sh` — **rc=0**; marker `grep -Fxc` = 1, unique
  file-wide and against the base tip; boundary shape read on the real file.
* Both gates were run on base `9771ac8f`; the branch was then rebased onto
  `d33852c0`. The delta is #1510, which touches `cicchetto/src/lib/
  wireTypesAssert.ts` and `docs/DESIGN_NOTES.md` — measured file intersection
  with this branch is `docs/DESIGN_NOTES.md` alone, a pure append whose prefix
  is byte-identical to main's copy. **Transferred by measurement, not re-run.**

Refs #1420.
