### PR TITLE
cic(#1509): delete the four dead admin live_state aliases

### DIFF
--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -50,7 +50,6 @@ import type {
   ChannelDirectoryStatus,
   ChannelDirectoryWireEntry,
   ChannelDirectoryWireIndexPayload,
-  LiveIntrospectionAdminWireLiveStateJson,
   LiveIntrospectionAdminWireT,
   NetworksAdminWireT,
   NetworksCredentialConnectionState,
@@ -1821,16 +1820,28 @@ async function fetchMe(token: string): Promise<MeResponse> {
 // M-8 doesn't render individual values (those land in M-9 Sessions
 // tab's per-row detail surface); a non-empty array implies the live
 // state values may be stale.
-// M-cluster M-8 / M-9b — shared live-introspection wire shape.
-// Mirror of `Grappa.LiveIntrospection.AdminWire.live_state_json/0`.
-// Same physical struct surfaces under `/admin/visitors[].live_state`
-// (where it's `| null` per U-0 honesty) AND every
-// `/admin/sessions[].live_state` (non-null since the latter is
-// registry-driven). Single source per "Implement once, reuse
-// everywhere".
-export type AdminLiveState = LiveIntrospectionAdminWireLiveStateJson;
 
-export type AdminVisitorLiveState = AdminLiveState;
+// M-cluster M-8 / M-9b — admin `live_state` is THREE shapes, by scope, and
+// there is deliberately no cic-side alias for it. Take each one from the
+// generated type of the endpoint that OWNS it, the way `adminSubjectRows.ts`
+// already does — `AdminVisitorNetwork["live_state"]` for a visitor row,
+// `AdminSession["live_state"]` for a session row.
+//
+// #550 scoped the upstream peer triple (`peer_address` / `peer_port` /
+// `peer_name`) to the Sessions tab, the netsplit-triage door:
+// `LiveIntrospectionAdminWireLiveStateJson` carries 10 keys,
+// `VisitorsAdminWireLiveStateJson` and
+// `NetworksCredentialsAdminWireLiveStateJson` the 7-key subset. That is a
+// recorded scoping decision, not drift — `peer_name` is not a `SessionEntry`
+// field at all (the Sessions controller resolves it through `Net.PtrCache`,
+// #252), so the other two wires would have to synthesise it.
+//
+// #1509 deleted four aliases that flattened all three onto the widest. Two of
+// them promised the peer triple on endpoints that never send it: measured,
+// a consumer typed with the visitor alias could read `.peer_address` with
+// `tsc` green and get `undefined` at runtime. Nothing consumed them — the
+// renderers already went through the generated types — so the whole cost was
+// the sentence that used to stand here claiming one struct was correct.
 
 // #211 phase 7 — per-network entry inside an AdminVisitor. A visitor is
 // multi-network; each attached network carries its own nick +
@@ -1872,8 +1883,6 @@ export async function adminDeleteVisitor(token: string, id: string): Promise<voi
 // string per the M-9a controller contract; cic constructs it
 // client-side. Cic must NEVER round-trip `pid_inspect` back to the
 // server — it's a human-readable label only.
-export type AdminSessionLiveState = AdminLiveState;
-
 export type AdminSession = LiveIntrospectionAdminWireT;
 
 // Composite session id constructor — single source for the wire
@@ -3083,8 +3092,6 @@ export async function adminDeleteFeaturedChannel(
 
 // Bucket 3 — Credential CRUD. URL composite (`:user_id/:network_id`)
 // reflects the schema's composite primary key (no surrogate id).
-
-export type AdminCredentialLiveState = AdminLiveState;
 
 export type AdminCredential = NetworksCredentialsAdminWireT & {
   // Present on PUT responses only; index/GET shape excludes it.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52976,3 +52976,76 @@ census count the two apart.
   own implicit transaction and registering nothing. A seam on all of them is
   not a reflex-sized change.
 - **Who holds the lock is still unnamed**, and nothing here narrows it.
+<!-- entry #1509 -->
+
+---
+
+## 2026-08-20 — #1509: three admin `live_state` shapes, and four cic aliases that promised one
+
+`cicchetto/src/lib/api.ts` carried a four-link alias chain —
+`AdminLiveState` → `AdminVisitorLiveState` / `AdminSessionLiveState` /
+`AdminCredentialLiveState` — all resolving to
+`LiveIntrospectionAdminWireLiveStateJson`, with a comment above it stating
+that one physical struct surfaces on both `/admin/visitors` and
+`/admin/sessions`. The codegen has said otherwise per owner since #550:
+`LiveIntrospectionAdminWireLiveStateJson` carries 10 keys,
+`VisitorsAdminWireLiveStateJson` and
+`NetworksCredentialsAdminWireLiveStateJson` carry the 7-key subset.
+
+**The server split is not the defect.** #550 scoped the upstream peer triple
+(`peer_address` / `peer_port` / `peer_name`) to the Sessions tab — the
+netsplit-triage door — and left the visitors/credentials tabs on the existing
+subset. Aligning the three would also be wrong on its own terms: `peer_name`
+is not a `SessionEntry` field, the Sessions controller resolves it through
+`Net.PtrCache` (#252), so the other two wires would have to synthesise it.
+The client declaring ONE shape where the ruling records THREE is the whole
+defect.
+
+**Measured before deciding**, on a scratch probe compiled by the tree's own
+`tsc` (deleted before the commit; baseline without it was rc=0, zero
+diagnostics):
+
+- `Equal<alias, owner's generated type>` is FALSE for the visitor and the
+  credential alias, TRUE for the session and the base alias. So **two of the
+  four misrepresented the shape; the other two were merely dead** — the
+  issue's "four aliases flatten three onto one" is true of the chain, not of
+  each name, and the instrument was not uniformly red.
+- The trap was measured OPEN, not predicted: `v.peer_address` on a value
+  typed `AdminVisitorLiveState` compiled GREEN. A renderer written that way
+  would read `undefined` from an endpoint that never sends the field. After
+  the deletion the same probe fails at the import (TS2305) — the name is
+  gone, so the trap cannot be entered.
+- Calibration that must not move across the fix: `peer_address` on
+  `VisitorsAdminWireLiveStateJson` is RED on both sides (the server shape
+  genuinely lacks it) and `.nick` GREEN on both.
+- Zero consumers: `git grep -w` over the four names outside `node_modules`
+  returns only the definitions themselves plus two historical mentions in
+  this file and a 2026-05-22 review draft. Positive control on the same
+  grep: `AdminSession`, a name that IS consumed, returns 20.
+
+**Deleted rather than repointed-and-pinned.** Repointing each alias at its
+owner and adding three `wireTypesAssert` entries was fully specified and buys
+a red; it also installs a standing gate over four names no consumer wants,
+which preserves the thing whose only defect is existing. The knowledge — three
+shapes, by scope, and why — is what needed to survive, and a comment carries
+it where a dead alias never did. Consumers were already correct
+(`adminSubjectRows.ts` takes `live_state` from the owner's generated type),
+which is why the lie stayed inert.
+
+**Accepted consequence, stated rather than dressed up:** the deletion is
+bought by a reading plus a green gate, not by a standing red. You cannot pin a
+type you removed. What guards the class going forward is that no cic-side
+`live_state` name exists to be pointed at the wrong owner, plus the
+`wireTypesAssert` golden shapes from #1510, which redden on a mis-pointed
+alias only when the two shapes differ.
+
+**Not done here, deliberately:** the moduledoc of
+`lib/grappa/networks/credentials/admin_wire.ex` disambiguates `session_ip`
+against `live_state.peer_address` — a field that particular wire never emits,
+the same lie one layer down. It is a comment-only fix on the server side and
+this branch is cic-only; it is left for a branch that can run the Elixir
+gates.
+
+The two historical mentions of these names elsewhere in this file
+(`AdminLiveState`, `AdminVisitorLiveState`) are left untouched: the log
+records what was true when it was written.


### PR DESCRIPTION
## What this does

Ships fix **(a)** from #1509 as ruled: delete the four dead
`live_state` aliases in `cicchetto/src/lib/api.ts` and replace the
comment above them with the #550 ruling — three shapes, by scope, and
why.

The server side is untouched. The three-way split is a recorded
scoping decision (#550: the upstream peer triple belongs to the
netsplit-triage door), and `peer_name` is not a `SessionEntry` field
at all — the Sessions controller resolves it via `Net.PtrCache`
(#252), so the other two wires would have to synthesise it.

## What was measured

Harness: the tree's own `tsc` (`scripts/bun.sh x tsc --noEmit`,
typescript 7). Baseline without the probes: **rc=0, zero
diagnostics**. The probe files were deleted before the commit.

| probe | pre-fix | post-fix |
|---|---|---|
| `Equal<AdminVisitorLiveState, VisitorsAdminWireLiveStateJson>` | **RED** | name gone (TS2305) |
| `Equal<AdminCredentialLiveState, NetworksCredentialsAdminWireLiveStateJson>` | **RED** | name gone (TS2724) |
| `Equal<AdminSessionLiveState, LiveIntrospectionAdminWireLiveStateJson>` | GREEN — control | name gone |
| `Equal<AdminLiveState, LiveIntrospectionAdminWireLiveStateJson>` | GREEN — control | name gone |
| `v.peer_address` where `v: AdminVisitorLiveState` | **GREEN — the trap, open** | **RED at the import** |
| `v.nick` | GREEN — control | RED (same import) |
| `v.no_such_field_1509` | RED — negative control fires | (file dies at the import) |
| `g.peer_address` where `g: VisitorsAdminWireLiveStateJson` | RED | RED — invariant across the fix |
| `g.nick` | GREEN | GREEN — invariant across the fix |

Two readings this buys that the issue did not have:

* **Two of the four aliases misrepresented the shape; the other two
  were merely dead.** The instrument was not uniformly red, so it
  discriminates.
* **The trap was measured open, not predicted.** A consumer typed with
  the visitor alias could read `.peer_address` with `tsc` green and
  get `undefined` from an endpoint that never sends the field. The
  calibration on the generated side (RED on both sides of the fix)
  is what makes that a measurement rather than an assumption.

Zero consumers, re-measured on `d33852c0`: `git grep -w` over the four
names outside `node_modules` returns only the definitions plus two
historical doc mentions (`docs/DESIGN_NOTES.md`, a 2026-05-22 review
draft). Positive control on the same grep: `AdminSession`, a name that
IS consumed, returns 20 hits.

## Gates

* `scripts/bun.sh run check` — **rc=0, "3 stages ran, 0 failed"**
  (biome, tsc src, tsc e2e).
* `scripts/bun.sh run test` — **rc=0, 293/293 test files passed**.
* `scripts/design-notes-gate.sh` — **rc=0, "1 new entry heading(s),
  separator and marker present"**. Note the first run of this gate
  reported *"adds no entry heading — nothing to check"* because the
  branch was uncommitted; that rc=0 measured nothing and was re-run
  after the commit.
* DESIGN_NOTES boundary: additions 73 / deletions 0, prefix
  byte-identical to `origin/main`'s copy, marker `grep -Fxc` = 1 here
  and 0 on `origin/main`.
* Elixir gates: **not run** — this branch touches no `.ex` file and
  the compile lane belongs to another worker.

## What I refuse to claim

* **This is not bought by a standing red.** You cannot pin a type you
  removed. The deletion is bought by a reading plus a green gate; the
  reds above prove the defect existed, not that a future regression
  would be caught. What guards the class going forward is that no
  cic-side `live_state` name exists to be pointed at the wrong owner.
* I did not measure whether the `wireTypesAssert.ts` coverage gap is
  broader than these four — the issue flags that as unmeasured and it
  stays unmeasured here.
* Nothing about runtime behaviour: no rendering path read these
  aliases before this change, so nothing user-visible moves.

## Left out, deliberately

* The server-side twin: the moduledoc of
  `lib/grappa/networks/credentials/admin_wire.ex` disambiguates
  `session_ip` against `live_state.peer_address`, naming a field that
  particular wire never emits. Same lie one layer down, comment-only
  fix — left for a branch that can run the Elixir gates.
* The two historical mentions of the deleted names in
  `docs/DESIGN_NOTES.md` and in the 2026-05-22 review draft: the log
  records what was true when it was written.

## Correction to the issue text

The issue quotes `wireTypesAssert.ts`'s maintenance rule as *"add an
assert for every api.ts type that has a wireTypes.ts counterpart"* and
argues the rule is unmet for these four. **#1510 rewrote that rule**
(the second side is now picked by how the cic side is declared, and
pinning an alias against its own right-hand side is named there as the
vacuous form). The load-bearing observation still holds — none of the
pins names these four — but the quoted sentence is no longer in the
file.
