### PR TITLE
ci(#1432): prove the union driver rewrote nothing, in both directions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,20 @@ not the surrounding code.**
   the BOUNDARY SHAPE on the real file** (full stop / blank / `---` / blank /
   heading), because an identical numstat proves nothing when the pre-rebase
   state was already broken.
+  **🔴 TWO-SIDED means BOTH directions are failures, not just loss (#1432).**
+  Additions going **DOWN** is the driver EATING a separator; additions going
+  **UP** is it RESURRECTING text the base deliberately deleted — `merge=union`
+  takes the additions from both sides and never the deletions, so a branch
+  that predates a removal gets it back, glued wherever it lands. Measured:
+  **131 of 1001** DESIGN_NOTES commits on main delete text, and for **30 of
+  those 131 (22.9%)** a tail-appending branch forked just before would
+  resurrect it. Both modes report `rc=0`, zero conflicts and zero deletions.
+  `scripts/union-rebase.sh` is that ritual automated — it pins, rebases,
+  re-pins and compares. **It is a VERB and not a check in
+  `design-notes-gate.sh` on purpose:** after a rebase the merge base collapses
+  onto the base ref and the only state recording that a line was ever deleted
+  is gone (measured: 2 such lines visible pre-rebase, 0 post), so the detector
+  needs a BEFORE and an AFTER and the gate has neither.
 - **🔴 Open every new DESIGN_NOTES entry with a UNIQUE `<!-- entry #NNNN -->`
   line, as its FIRST appended line (#1271).** Exact shape: marker / blank /
   `---` / blank / `## <date> — #NNNN: …`, with NO blank before the marker.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -52800,3 +52800,95 @@ independently.
 **Not evaluated**, unchanged from the issue: the two narrow `["kind"]` pins
 (`_Assert_MeResponseKind`, `_Assert_LoginSubjectKind`) and seven of the eight
 #1406 arm-walking asserts.
+<!-- entry #1432 -->
+
+---
+
+## 2026-08-20 — #1432: the union driver fails in two directions, and only one of them can live in a gate
+
+`merge=union` takes the additions from BOTH sides and NEVER the deletions. That
+gives two silent failures with OPPOSITE signs, both at `rc=0`, zero conflicts
+and zero deletions:
+
+- **EATEN** (#1271/#1428) — an identical leading prefix is collapsed and an
+  entry loses its separator. Additions go **DOWN**.
+- **RESURRECTED** (#1432) — a branch that predates a commit which deliberately
+  removed text gets that text back. Additions go **UP**.
+
+A check that only asks "did we lose lines?" passes the second one cleanly. The
+invariant is therefore two-sided: **additions unchanged AND deletions zero.**
+
+### How often it can bite, measured
+
+Census over the **1001** commits touching the file on main's first-parent line,
+with known-answer controls inside the tool (`64914b6d` must classify as a
+rewrite, `9771ac8f` as an append; both passed, and the tool exits without
+printing numbers if either fails):
+
+| | count | share |
+|---|---|---|
+| pure append | 716 | 71.5% |
+| non-append | 284 | 28.4% |
+| — of those, actually DELETING | 131 | 13.1% of all |
+
+Then the unbiased question, asked of the driver rather than of the authors: for
+each of those 131 real deletions, replay a hypothetical branch that forked
+immediately before it and appended an entry at the tail. **30 of 131 (22.9%)
+resurrect.** So roughly one DESIGN_NOTES commit in eight deletes, and about
+one deletion in five is a live resurrection hazard for the branch shape this
+repo actually uses.
+
+### Why the detector could not be a check in the gate
+
+`scripts/design-notes-gate.sh` can read three states: HEAD's file, the base
+ref's file, and their merge base. Measured in the resurrection regime:
+
+| moment | merge base == base ref? | lines the base deleted, visible |
+|---|---|---|
+| PRE-rebase | no | **2** |
+| POST-rebase | **yes** | **0** |
+
+After the rebase the merge base collapses onto the base ref, and with it the
+only state that records that a line was ever deleted. A resurrected line and a
+deliberately re-added line are then the same bytes in the same three states.
+The scope's "compare against the merge base AND against main" is therefore
+**not expressible inside the gate** — it needs a BEFORE and an AFTER.
+
+So the detector is a VERB, `scripts/union-rebase.sh`: pin, rebase, re-pin,
+compare. It watches every path `.gitattributes` marks `merge=union` (derived,
+not hard-coded), refuses a dirty tree, refuses an unresolvable ref, refuses
+outright when no union path exists rather than reporting a rebase it did not
+verify, says out loud when the comparison is VACUOUS because the branch was
+already on top, and — because `git rebase --abort` is gone by the time drift is
+visible — hands back the pre-rebase HEAD.
+
+The gate keeps its role unchanged: a PREVENTER that runs on a single state.
+The verb is the DETECTOR. Both are needed and neither replaces the other.
+
+### Two measurement traps, recorded because they cost real time
+
+- **A merged-PR sweep cannot measure this.** The first attempt replayed the
+  last 60 merged PRs. That population is exactly the one resurrections have
+  been removed from by hand — #1432's own occurrence was caught by the author's
+  numstat pin and the file rebuilt before landing. Survivorship bias,
+  structural rather than a sample-size problem. It also came back all-zero for
+  a second reason worth knowing: **11 of the first 20 branches had a fork proxy
+  equal to the merge point**, i.e. zero BY CONSTRUCTION, not zero measured.
+- **BSD `seq 1 0` counts DOWN**, printing `1\n0\n` where GNU prints nothing. A
+  scratch harness padded with it shifted every reading by two lines and
+  produced an all-green sample. Anyone writing a measurement harness on macOS
+  will meet this.
+
+Both are instances of the same rule: a uniform result accuses the instrument
+before the data.
+
+### What is deliberately not claimed
+
+The verb compares **numstat, never geometry**. In a scratch fixture the
+resurrection reproduces only when the deleted block is immediately adjacent to
+the branch's own append — one line of separation and the 3-way merge sees two
+non-overlapping hunks and applies cleanly. But the real 2026-08-16 occurrence
+does **not** have that geometry: the deleted region sits ~59 lines before the
+file's end and `git blame` puts those 59 lines in the same commit as the
+deleted text. The adjacency threshold is A path to resurrection; that it is THE
+path is not established, and the tool promises no threshold.

--- a/scripts/union-rebase.sh
+++ b/scripts/union-rebase.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# scripts/union-rebase.sh — rebase, and PROVE the union driver rewrote nothing
+# (#1432).
+#
+# Usage:
+#   scripts/union-rebase.sh              # rebase onto origin/main
+#   scripts/union-rebase.sh <onto-ref>   # rebase onto another ref
+#
+# WHAT IT GUARDS
+#
+# `docs/DESIGN_NOTES.md` carries `merge=union` (#114) so concurrent appends
+# auto-resolve. The driver takes the additions from BOTH sides and NEVER the
+# deletions, and it rewrites the boundary between entries. That gives two
+# failure modes with OPPOSITE signs, both silent:
+#
+#   EATEN (#1271/#1428)   the identical leading prefix of two entries is
+#                         aligned as a common addition and emitted once, so one
+#                         entry loses its separator. Additions go DOWN.
+#   RESURRECTED (#1432)   a branch that predates a commit which deliberately
+#                         REMOVED text gets that text put back, glued wherever
+#                         the driver lands it. Additions go UP.
+#
+# Both report `rc=0`, zero conflicts and zero deletions. A check that only asks
+# "did we lose lines?" passes the second one cleanly, which is why the
+# invariant is TWO-SIDED: additions UNCHANGED **and** deletions ZERO. Any drift
+# in EITHER direction means the driver rewrote something nobody asked it to.
+#
+# WHY THIS IS A VERB AND NOT A CHECK IN design-notes-gate.sh
+#
+# The gate can read three states: HEAD's file, the base ref's file, and their
+# merge base. Measured, in the resurrection regime:
+#
+#   PRE-rebase    merge base != base ref   lines the base deleted: 2
+#   POST-rebase   merge base == base ref   lines the base deleted: 0
+#
+# After the rebase the merge base collapses onto the base ref, and with it the
+# only state that records that a line was ever deleted. A resurrected line and
+# a deliberately re-added line are then the same bytes in the same three
+# states — nothing is left to tell them apart. So the detector cannot live in
+# the gate: it needs a BEFORE and an AFTER, and this wrapper is the only place
+# that has both. The gate stays what it is, a preventer that runs on one state.
+#
+# WHAT IT DOES NOT CLAIM
+#
+# It compares NUMSTAT, never geometry. In a scratch fixture the resurrection
+# reproduces only when the deleted block is immediately adjacent to the
+# branch's own append (gap=0; one line of separation and the 3-way merge sees
+# two non-overlapping hunks). But the real 2026-08-16 occurrence does NOT have
+# that geometry — there the deleted region sits ~59 lines before the file's
+# end, and `git blame` puts those 59 lines in the same commit as the deleted
+# text. So the adjacency threshold is A path to resurrection, not established
+# as THE one. This tool therefore promises no threshold: it pins the numbers
+# and compares them.
+#
+# The paths it watches are DERIVED from `.gitattributes` (`merge=union`), not
+# hard-coded, so a future union-attributed file inherits this for free.
+#
+# Exit 0 = the rebase ran and every union-attributed path came through with its
+#          contribution intact.
+# Exit 1 = drift in either direction, a refused precondition, or a rebase that
+#          stopped. A tool that cannot measure FAILS; it never passes vacuously.
+
+set -euo pipefail
+
+ONTO="${1:-origin/main}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+die() {
+	printf 'union-rebase: %s\n' "$*" >&2
+	exit 1
+}
+
+say() { printf 'union-rebase: %s\n' "$*"; }
+
+# ── preconditions ───────────────────────────────────────────────────────────
+
+git rev-parse --verify --quiet "${ONTO}^{commit}" >/dev/null \
+	|| die "'$ONTO' does not resolve. If this is CI, the checkout is shallow — actions/checkout needs fetch-depth: 0."
+
+[ -z "$(git status --porcelain)" ] \
+	|| die "working tree is not clean. A rebase would refuse anyway, and a pin taken over uncommitted work measures the wrong thing."
+
+git rev-parse --verify --quiet HEAD >/dev/null || die "HEAD does not resolve"
+
+# ── the paths this file's own attributes put under the union driver ─────────
+
+mapfile -t UNION_PATHS < <(
+	git ls-files | git check-attr --stdin merge \
+		| sed -n 's/^\(.*\): merge: union$/\1/p'
+)
+
+if [ "${#UNION_PATHS[@]}" -eq 0 ]; then
+	die "no path carries merge=union — this tool would measure nothing, so it refuses rather than report a clean rebase it did not verify."
+fi
+
+# ── the pin ─────────────────────────────────────────────────────────────────
+
+# Additions and deletions of the branch's own contribution for one path, as
+# "<add> <del>". An untouched path is a real 0 0, not an absence.
+pin() {
+	local base="$1" head="$2" path="$3" out
+	out="$(git diff --numstat "$base" "$head" -- "$path" | cut -f1,2 | tr '\t' ' ')"
+	[ -n "$out" ] || out="0 0"
+	printf '%s\n' "$out"
+}
+
+# Known-answer control, INSIDE the tool. A diff of a commit against itself is
+# 0 0 by definition; if the parser cannot produce that, it is reading the wrong
+# columns and every number below would be furniture. Exit WITHOUT a verdict.
+control="$(pin HEAD HEAD "${UNION_PATHS[0]}")"
+[ "$control" = "0 0" ] || die "CONTROL FAILED: pinning HEAD against itself gave '$control', expected '0 0' — the numstat parser is wrong, no verdict printed."
+
+base_before="$(git merge-base "$ONTO" HEAD)" || die "no merge base between '$ONTO' and HEAD"
+pre_head="$(git rev-parse HEAD)"
+
+if [ "$base_before" = "$(git rev-parse "$ONTO")" ]; then
+	say "already on top of $ONTO — the driver gets no chance to run, so the comparison below is VACUOUS by construction, not a pass."
+fi
+
+declare -a BEFORE
+for i in "${!UNION_PATHS[@]}"; do
+	BEFORE[i]="$(pin "$base_before" HEAD "${UNION_PATHS[i]}")"
+done
+
+say "pinned ${#UNION_PATHS[@]} union path(s) against $base_before; pre-rebase HEAD is $pre_head"
+
+# ── the rebase ──────────────────────────────────────────────────────────────
+
+if ! git rebase "$ONTO"; then
+	{
+		printf 'union-rebase: the rebase stopped — resolve it, then re-run this tool.\n'
+		printf 'No verdict is given: the pin taken before is meaningless against a\n'
+		printf 'half-applied state. Your pre-rebase HEAD was %s.\n' "$pre_head"
+	} >&2
+	exit 1
+fi
+
+# ── the comparison ──────────────────────────────────────────────────────────
+
+base_after="$(git merge-base "$ONTO" HEAD)" || die "no merge base after the rebase"
+
+status=0
+for i in "${!UNION_PATHS[@]}"; do
+	path="${UNION_PATHS[i]}"
+	read -r add_before del_before <<<"${BEFORE[i]}"
+	read -r add_after del_after <<<"$(pin "$base_after" HEAD "$path")"
+
+	if [ "$add_before" -eq "$add_after" ] && [ "$del_after" -eq 0 ]; then
+		say "$path: +$add_after -$del_after — contribution intact"
+		continue
+	fi
+
+	status=1
+	{
+		printf 'union-rebase: %s was REWRITTEN by the merge driver.\n' "$path"
+		printf '  additions %s -> %s   deletions %s -> %s\n' \
+			"$add_before" "$add_after" "$del_before" "$del_after"
+		if [ "$add_after" -lt "$add_before" ]; then
+			printf '  additions went DOWN: the driver ATE %s line(s) (#1271/#1428).\n' \
+				"$((add_before - add_after))"
+			printf '  Usually the separator block of an entry whose leading prefix was\n'
+			printf '  identical to the one that landed next to it. Restore it IN the commit\n'
+			printf '  that carries the entry, never as a separator-only commit, and give the\n'
+			printf '  entry a marker no other entry and no entry on %s carries.\n' "$ONTO"
+		elif [ "$add_after" -gt "$add_before" ]; then
+			printf '  additions went UP: the driver RESURRECTED %s line(s) (#1432).\n' \
+				"$((add_after - add_before))"
+			printf '  union takes the additions from both sides and never the deletions, so\n'
+			printf '  text %s deliberately removed is back, glued wherever it landed.\n' "$ONTO"
+		fi
+		if [ "$del_after" -ne 0 ]; then
+			printf '  deletions are %s, not zero: this branch now removes lines from %s.\n' \
+				"$del_after" "$ONTO"
+		fi
+		printf '\n  Read the BOUNDARY SHAPE on the file before trusting any repair — an\n'
+		printf '  identical numstat proves nothing if the pre-rebase state was already\n'
+		printf '  broken. Your pre-rebase HEAD was %s:\n' "$pre_head"
+		printf '      git reset --hard %s\n' "$pre_head"
+	} >&2
+done
+
+if [ "$status" -ne 0 ]; then
+	exit 1
+fi
+
+say "rebased onto $ONTO; every union path came through unchanged."

--- a/test/scripts/union_rebase_test.bats
+++ b/test/scripts/union_rebase_test.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+#
+# scripts/union-rebase.sh — the two-sided union-drift detector (#1432).
+#
+# `merge=union` fails in two directions with OPPOSITE signs, both at rc=0 with
+# zero conflicts and zero deletions:
+#
+#   EATEN (#1271/#1428)   a separator block is collapsed, additions go DOWN
+#   RESURRECTED (#1432)   text the base deleted is put back, additions go UP
+#
+# A check that only asks "did we lose lines?" passes the second one cleanly, so
+# this suite's job is to prove the tool goes red in BOTH directions and stays
+# green on a rebase that behaved. A detector nobody has watched fail is not a
+# detector — which is the whole subject of the issue.
+#
+# The oracle is never a hand-written broken file: every case builds a scratch
+# repository with the real `merge=union` attribute and runs a real `git rebase`,
+# so what the tool is judged against is what the merge machinery produced.
+
+load ../bats_helpers
+
+setup() {
+    TOOL_SRC="$BATS_TEST_DIRNAME/../../scripts/union-rebase.sh"
+}
+
+# A scratch repo carrying the union attribute, `main` one commit ahead, `feat`
+# with its own appended entry, NOT yet rebased.
+#
+#   scratch_eaten        two entries, neither with a marker -> the #1271 shape
+#   scratch_resurrected  base text that main deletes, adjacent to feat's append
+#   scratch_clean        distinct markers, main deletes nothing
+scratch_init() {
+    REPO="$BATS_TEST_TMPDIR/repo"
+    rm -rf "$REPO"
+    mkdir -p "$REPO/docs" "$REPO/scripts"
+    cp "$TOOL_SRC" "$REPO/scripts/union-rebase.sh"
+    chmod 0755 "$REPO/scripts/union-rebase.sh"
+    cd "$REPO"
+    git -c init.defaultBranch=main init -q .
+    git config user.email bats@example.invalid
+    git config user.name bats
+    printf 'docs/DESIGN_NOTES.md merge=union\n' > .gitattributes
+}
+
+scratch_eaten() {
+    scratch_init
+    printf 'INTRO\n\n---\n\n## 2026-01-01 — entry A\n\nbody A\n' > docs/DESIGN_NOTES.md
+    git add -A && git commit -qm base
+    git branch feat
+    printf '\n---\n\n## 2026-01-02 — entry C\n\nbody C\n' >> docs/DESIGN_NOTES.md
+    git commit -qam 'main C'
+    git checkout -q feat
+    printf '\n---\n\n## 2026-01-02 — entry B\n\nbody B\n' >> docs/DESIGN_NOTES.md
+    git commit -qam 'feat B'
+}
+
+scratch_resurrected() {
+    scratch_init
+    # The COST block sits at the very tail, so feat's append is adjacent to
+    # what main is about to delete. Measured: that is a geometry in which the
+    # driver resurrects. The tool does NOT depend on the geometry — it compares
+    # numstat — but the fixture needs one that actually reproduces.
+    printf 'INTRO\n\n<!-- entry #A -->\n\n---\n\n## 2026-01-01 — entry A\n\nbody A\nCOST line 1\nCOST line 2\n' \
+        > docs/DESIGN_NOTES.md
+    git add -A && git commit -qm base
+    git branch feat
+    printf 'INTRO\n\n<!-- entry #A -->\n\n---\n\n## 2026-01-01 — entry A\n\nbody A\n' \
+        > docs/DESIGN_NOTES.md
+    git commit -qam 'main: supersede the accepted cost'
+    git checkout -q feat
+    printf '<!-- entry #B -->\n\n---\n\n## 2026-01-02 — entry B\n\nbody B\n' \
+        >> docs/DESIGN_NOTES.md
+    git commit -qam 'feat B'
+}
+
+scratch_clean() {
+    scratch_init
+    printf 'INTRO\n\n<!-- entry #A -->\n\n---\n\n## 2026-01-01 — entry A\n\nbody A\n' \
+        > docs/DESIGN_NOTES.md
+    git add -A && git commit -qm base
+    git branch feat
+    printf '<!-- entry #C -->\n\n---\n\n## 2026-01-02 — entry C\n\nbody C\n' \
+        >> docs/DESIGN_NOTES.md
+    git commit -qam 'main C'
+    git checkout -q feat
+    printf '<!-- entry #B -->\n\n---\n\n## 2026-01-02 — entry B\n\nbody B\n' \
+        >> docs/DESIGN_NOTES.md
+    git commit -qam 'feat B'
+}
+
+# ── the two directions ──────────────────────────────────────────────────────
+
+@test "additions going UP is a failure: the driver RESURRECTED text (#1432)" {
+    # The direction a loss-only check passes cleanly. This is the case the
+    # whole tool exists for.
+    scratch_resurrected
+
+    run scripts/union-rebase.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"RESURRECTED"* ]]
+    [[ "$output" == *"docs/DESIGN_NOTES.md"* ]]
+    # Anchored on the phrase, not on "ATE": a bare substring match would be
+    # satisfied by any future wording that happens to contain those letters.
+    refute grep -q "driver ATE" <<<"$output"
+}
+
+@test "additions going DOWN is a failure: the driver ATE a separator (#1271)" {
+    scratch_eaten
+
+    run scripts/union-rebase.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ATE"* ]]
+    refute grep -q "RESURRECTED" <<<"$output"
+}
+
+@test "a rebase that behaved passes, so the two above are not a tool that always fails" {
+    scratch_clean
+
+    run scripts/union-rebase.sh main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"came through unchanged"* ]]
+}
+
+# ── the numbers, measured rather than asserted ──────────────────────────────
+
+@test "the report carries the drift it measured, in both directions" {
+    # Without this the words RESURRECTED and ATE are labels the tool could
+    # print on anything. The counts come from the driver.
+    scratch_resurrected
+    run scripts/union-rebase.sh main
+    [[ "$output" == *"additions 7 -> 9"* ]]
+
+    scratch_eaten
+    run scripts/union-rebase.sh main
+    [[ "$output" == *"additions 6 -> 3"* ]]
+}
+
+@test "a failure hands back the pre-rebase HEAD, because the rebase already ran" {
+    # `git rebase --abort` is gone by the time the drift is visible, so the only
+    # way back is the sha the tool pinned before starting. A detector that
+    # reports damage and strands you is half a tool.
+    scratch_resurrected
+    local pre
+    pre="$(git rev-parse HEAD)"
+
+    run scripts/union-rebase.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"git reset --hard $pre"* ]]
+}
+
+# ── fail-closed, and the fast paths that must stay honest ───────────────────
+
+@test "no merge=union path anywhere makes the tool REFUSE, not report a clean rebase" {
+    # Passing here would report a verified rebase against nothing at all — the
+    # shape of every guard that fails open.
+    scratch_clean
+    printf '# nothing under the union driver\n' > .gitattributes
+    git commit -qam 'drop the union attribute'
+
+    run scripts/union-rebase.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"would measure nothing"* ]]
+}
+
+@test "an unresolvable onto ref FAILS the tool, it does not skip it" {
+    scratch_clean
+
+    run scripts/union-rebase.sh no/such/ref
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not resolve"* ]]
+    [[ "$output" == *"fetch-depth"* ]]
+}
+
+@test "a dirty tree is refused before anything is pinned" {
+    scratch_clean
+    printf 'uncommitted\n' >> docs/DESIGN_NOTES.md
+
+    run scripts/union-rebase.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not clean"* ]]
+}
+
+@test "already on top of the onto ref says the comparison is VACUOUS, not a pass" {
+    # The driver never runs, so there is nothing to have rewritten. Reporting
+    # that as a verified rebase is the log-honesty failure: a fast path must
+    # state what it observed, not what it skipped.
+    scratch_clean
+    git checkout -q main
+
+    run scripts/union-rebase.sh main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"VACUOUS"* ]]
+}


### PR DESCRIPTION
Refs #1432.

`merge=union` takes the additions from BOTH sides and NEVER the deletions. That gives
two silent failure modes with **opposite signs**, both landing at `rc=0` with zero
conflicts and zero deletions:

| mode | what happens | additions |
|---|---|---|
| **EATEN** (#1271/#1428) | the identical leading prefix of two entries is aligned as a common addition and emitted once, so one entry loses its separator | go **DOWN** |
| **RESURRECTED** (#1432) | a branch that predates a commit which deliberately REMOVED text gets that text put back, glued wherever the driver lands it | go **UP** |

The ritual documented in `CLAUDE.md` only ever asked *"did we lose lines?"*, which the
second mode passes cleanly. This PR makes the invariant **two-sided** — additions
UNCHANGED **and** deletions ZERO — and automates it.

## What lands

`scripts/union-rebase.sh [<onto>]` (default `origin/main`): pins the branch's own
contribution numstat for every `merge=union` path, rebases, re-pins, compares. Drift in
either direction is a failure, named `ATE` or `RESURRECTED` with the line count.

- **Paths are DERIVED from `.gitattributes`**, not hard-coded, so a future
  union-attributed file inherits the guard for free.
- **Refuses rather than passing vacuously:** dirty tree, unresolvable onto ref, and —
  deliberately — a repo where *no* path carries `merge=union`. Reporting a verified
  rebase against nothing is the shape of every guard that fails open.
- **Says VACUOUS out loud** when the branch is already on top of the onto ref: the
  driver never runs, so there is nothing it could have rewritten.
- **Hands back the pre-rebase HEAD** on failure. `git rebase --abort` is gone by the
  time the drift is visible, so the sha pinned before starting is the only way back.
- **Known-answer control inside the tool:** pinning HEAD against itself must yield
  `0 0`. If the parser cannot produce that it is reading the wrong columns, and the
  tool exits **without printing a verdict**.

### Why a verb and not a check in `design-notes-gate.sh`

The gate can read three states: HEAD's file, the base ref's file, and their merge base.
Measured in the resurrection regime:

| | merge base | lines the base deleted |
|---|---|---|
| PRE-rebase | `!=` base ref | **2** |
| POST-rebase | `==` base ref | **0** |

After the rebase the merge base collapses onto the base ref, and with it the only state
recording that a line was ever deleted. A resurrected line and a deliberately re-added
line are then the same bytes in the same three states. The detector needs a BEFORE and
an AFTER; the gate has neither. The header says so, so nobody "tidies" it into the gate.

## Why this is worth a tool: the driver measured on real history

Over the **1001** commits touching `docs/DESIGN_NOTES.md` on main:

- **131 (13.1%)** delete text.
- For **30 of those 131 (22.9%)**, replaying a branch that forked immediately before and
  appends at the tail **resurrects the deleted text**.

Two measurement traps paid for along the way, recorded so the next reader does not
re-pay them:

- **A merged-PR sweep cannot measure this, structurally.** The merged population is
  exactly the one resurrections have been removed from by hand — #1432's own occurrence
  was caught by the author's numstat pin and the file rebuilt before landing. Replaying
  landed branches replays the repaired ones. Survivorship bias, not sample size.
  Additionally, 11 of the first 20 branches had fork proxy == merge point, i.e. zero
  **by construction**.
- **BSD `seq 1 0` counts DOWN** (prints `1\n0\n` where GNU prints nothing), shifting
  every reading by two lines and producing an all-green. A uniform result accuses the
  instrument before the data.

## Tests: the two-sidedness is pinned by DISJOINT assertions

`test/scripts/union_rebase_test.bats`, 9 tests over three scratch-repo fixtures
(`scratch_eaten`, `scratch_resurrected`, `scratch_clean`). Expectations were taken by
replicating the fixtures with plain git and READING the numbers, not by guessing them.

One mutant only proves one direction, and the claim on trial is that there are two — so
**both** one-sided comparisons were run against the suite. Line 150 is the success
condition; the original is
`[ "$add_before" -eq "$add_after" ] && [ "$del_after" -eq 0 ]`.

| mutant | line 150 becomes | tolerates | tests killed |
|---|---|---|---|
| **A** loss-only detector | `[ "$add_after" -ge "$add_before" ]` | gains | **1, 4, 5** |
| **B** gain-only detector | `[ "$add_after" -le "$add_before" ]` | losses | **2, 4** |

Mapped against the fixture each test drives:

- **A kills exactly the tests driving `scratch_resurrected`** — test 1 (the UP
  direction), test 5 (pre-rebase HEAD handback, which uses that fixture), and the
  resurrected half of test 4. Everything on `scratch_eaten` and `scratch_clean` survives.
- **B kills exactly the tests driving `scratch_eaten`** — test 2 and the eaten half of
  test 4. Tests 1 and 5 survive.
- The kill sets **intersect only in test 4**, which is by name the both-directions
  assertion. Otherwise **disjoint**.

Neither one-sided comparison can pass this suite, and each direction is defended by
assertions the *other* mutant leaves untouched. The tool was restored from backup
afterwards (md5 identical, tree clean, suite re-run 9/9).

## Gates

| gate | result |
|---|---|
| `scripts/bats.sh` full set, on the post-rebase tree | `1..578` — **578 ok, 0 not ok, rc=0** (these 9 at 570–578) |
| `test/scripts/union_rebase_test.bats` | `1..9` — **9 ok, 0 not ok, rc=0** |
| `scripts/design-notes-gate.sh origin/main` | **rc=0**, against the current tip |
| `scripts/shellcheck.sh`, on the post-rebase tree | **rc=0**, 77 scripts, this one included |

Every row above was measured on the same post-rebase tree, `3e01f0a6`.

`origin/main` advanced to `d33852c0` mid-run, which invalidated the design-notes gate
reading (its #1428 check compares an added marker against the base ref's **TIP**) and
the byte-identical-prefix check. Both were redone against the new tip, and the full bats
set was re-run on the post-rebase union rather than on the pre-rebase tree.

That move also made this branch the tool's **first non-vacuous use**: it rebased itself,
reporting `docs/DESIGN_NOTES.md: +92 -0 — contribution intact`. Confirmed from a second
source rather than the tool's own verdict — the contribution numstat was pinned to a
file before the rebase and `diff`ed against the post-rebase one. The prefix of
`docs/DESIGN_NOTES.md` is byte-identical to the base's, which subsumes the
preceding-entry tail check; the boundary shape was read on the real file; the
`<!-- entry #1432 -->` marker is unique in the file (`grep -Fxc` = 1) and absent from
the base.

## What this PR does NOT claim

- **That the adjacency threshold explains the real occurrence.** The resurrection
  reproduces in a fixture only at gap=0, but the real 2026-08-16 occurrence does not have
  that geometry — the deleted region sits ~59 lines before the file's end, and
  `git blame` puts those 59 lines in the same commit as the deleted text. So gap=0 is
  **a** path to resurrection, not established as **the** one. The tool compares NUMSTAT
  and never geometry, precisely so it does not inherit the claim.
- **That 22.9% is the risk a real branch faces.** It is the rate **per deletion** for a
  hypothetical tail-appending branch forked immediately before it. A real branch must
  also be open across that deletion; that joint probability is **unmeasured**.
- **That the self-rebase above was an adversarial test of the detector.** It came through
  clean, so it exercised the plumbing on a real branch — it did not present the tool with
  drift to catch. Only the fixtures have shown it firing.
- **That the two mutants prove the suite complete.** They sample the comparison line.
  They say nothing about the refusal paths (tests 6–9), which no mutant here touched.
- **That the verb is discoverable.** It is in neither `docs/OPERATIONS.md` nor
  `docs/TESTING.md` — and neither is `design-notes-gate.sh`, a pre-existing catalogue gap
  the 2026-08-15 codebase review already filed. This branch was not widened to close it.
