### PR TITLE
cic(#1571): make the cic gate say whether node_modules matches bun.lock

### DIFF
--- a/cicchetto/scripts/check.ts
+++ b/cicchetto/scripts/check.ts
@@ -34,6 +34,14 @@
 type Stage = { readonly name: string; readonly argv: readonly string[] };
 
 const STAGES: readonly Stage[] = [
+  // First, and cheap: it says whether the three stages below are attributable
+  // at all. #1571 measured a `node_modules` whose biome was three minor
+  // versions off `bun.lock`, and nothing in the tree compared the two — the
+  // only freshness test any script applied was `scripts/bun.sh`'s
+  // `needs_install`, which asks whether the directory is EMPTY. It does not
+  // short-circuit the rest: a stale toolchain and a real type error are
+  // separate facts and #1469's whole point is reporting the union.
+  { name: "lock drift (node_modules vs bun.lock)", argv: ["bun", "scripts/lock-drift.ts"] },
   { name: "biome (src + e2e)", argv: ["biome", "check", "--max-diagnostics=none"] },
   { name: "tsc (src)", argv: ["tsc", "--noEmit"] },
   { name: "tsc (e2e)", argv: ["tsc", "--noEmit", "-p", "e2e/tsconfig.json"] },

--- a/cicchetto/scripts/lock-drift-core.ts
+++ b/cicchetto/scripts/lock-drift-core.ts
@@ -1,0 +1,288 @@
+// #1571 — is what is INSTALLED what `bun.lock` pins?
+//
+// The pure half: no filesystem, no Bun API, no imports. `lock-drift.ts` does
+// the IO and calls in here; `src/__tests__/lockDrift.test.ts` exercises both
+// sides of every rule. Keeping it importable from `src` is also what puts it
+// under `tsc --noEmit` — `cicchetto/scripts/` is outside both the tsconfig
+// `include` and biome's `files.includes`, so a runner-only module would be
+// checked by nothing.
+//
+// WHY THIS EXISTS. A gate verdict is only attributable if the tools that
+// produced it are the ones the lockfile names. #1571 measured a checkout whose
+// biome was three minor versions off the lock, and the failure mode is
+// two-sided: a rule that only fires on the newer version passes locally and
+// fails in CI, and a rule that only fires on the older one fails locally
+// against code CI would accept. Nothing in the tree compared the two — the
+// only freshness test any script applied was `scripts/bun.sh`'s
+// `needs_install`, which asks whether `node_modules` is EMPTY. A populated but
+// stale tree answered "installed" and was never reconciled, and the documented
+// worktree procedure (`cp -Rc` the tree from the main checkout) copied
+// whatever was there into every new worktree.
+//
+// WHY THE COMPARISON IS SCOPED TO THE EXECUTING PLATFORM. Tools like biome and
+// rolldown ship as a JS wrapper plus one binary package per platform
+// (`@biomejs/cli-darwin-arm64`, `@rolldown/binding-linux-arm64-gnu`, …), and
+// `bun install` only ever resolves the optional dependency matching the
+// platform it runs on. Every gate in this repo runs `bun` inside a linux
+// container (`scripts/bun.sh`), so the darwin binaries in a macOS developer's
+// tree cannot be refreshed by any path the project uses — measured on
+// 2026-08-20: `@biomejs/cli-darwin-arm64` at 2.4.13 against a lock pinning
+// 2.5.8, its directory dated three months before its linux siblings. Comparing
+// those would make the gate red on something no gate executes and no
+// documented command can fix. So the question this asks is narrower and
+// truthful: does what will RUN HERE match the lock. The stale foreign-platform
+// binaries are a documented limitation, recorded in docs/TESTING.md.
+
+/** npm `os` / `cpu` fields: a list of allowed values, or `!value` exclusions. */
+export type PlatformConstraint = readonly string[] | null;
+
+export type InstalledPackage = {
+  readonly name: string;
+  readonly version: string;
+  readonly os: PlatformConstraint;
+  readonly cpu: PlatformConstraint;
+};
+
+/** `process.platform` / `process.arch` of whoever is running the gate. */
+export type Platform = { readonly os: string; readonly cpu: string };
+
+export type DriftRow = { readonly name: string; readonly lock: string; readonly installed: string };
+
+export type Report = {
+  /** installed packages whose name the lock resolves, and that run here. */
+  readonly compared: number;
+  readonly drift: readonly DriftRow[];
+  /** installed for a platform that is not this one — deliberately not judged. */
+  readonly skippedPlatform: number;
+  /** installed, runs here, and the lock has no entry for the name. */
+  readonly notInLock: number;
+  /** direct dependencies of package.json that the comparison never reached. */
+  readonly uncovered: readonly string[];
+};
+
+/**
+ * Resolve every `"name@version"` the lockfile carries, keyed by name.
+ *
+ * `bun.lock` is JSONC — it has trailing commas, so `JSON.parse` refuses it.
+ * Rather than hand-roll a JSONC parser, read the one token whose shape is
+ * stable across every lockfile version: each entry's value is an array whose
+ * FIRST element is the canonical `name@version`. Parsing the value rather than
+ * the key also sidesteps bun's nested `parent/child` keys and scoped names in
+ * one rule.
+ *
+ * A name can resolve at several versions (a transitive duplicate), so the map
+ * holds a list and a match against ANY of them is not drift: which one a given
+ * consumer sees is a hoisting decision, not a pin violation.
+ */
+export function parseLockVersions(lockText: string): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const match of lockText.matchAll(/\["([^"\n]+)"/g)) {
+    const token = match[1];
+    if (token === undefined) continue;
+    // Scoped names carry a leading `@`, so split on the LAST one.
+    const at = token.lastIndexOf("@");
+    if (at <= 0) continue;
+    const name = token.slice(0, at);
+    const version = token.slice(at + 1);
+    if (name === "" || version === "") continue;
+    const seen = out.get(name);
+    if (seen === undefined) out.set(name, [version]);
+    else if (!seen.includes(version)) seen.push(version);
+  }
+  return out;
+}
+
+/**
+ * npm platform matching: an empty/absent list matches everything, a list of
+ * `!value` entries excludes, anything else is an allowlist.
+ */
+export function matchesPlatform(constraint: PlatformConstraint, value: string): boolean {
+  if (constraint === null || constraint.length === 0) return true;
+  const negated = constraint.filter((entry) => entry.startsWith("!"));
+  if (negated.length === constraint.length) {
+    return !negated.some((entry) => entry.slice(1) === value);
+  }
+  return constraint.some((entry) => entry === value);
+}
+
+export function runsHere(pkg: InstalledPackage, platform: Platform): boolean {
+  return matchesPlatform(pkg.os, platform.os) && matchesPlatform(pkg.cpu, platform.cpu);
+}
+
+/**
+ * Classify an installed tree against the lock.
+ *
+ * `required` is the direct dependency + devDependency names from package.json.
+ * Any of them the comparison never reached is reported as `uncovered` — the
+ * one completeness check that can be made without guessing: it catches both a
+ * partial install and a parser that silently stopped resolving names, and it
+ * cannot false-positive on the lock's many entries for other platforms.
+ */
+export function classify(
+  installed: readonly InstalledPackage[],
+  lock: ReadonlyMap<string, readonly string[]>,
+  platform: Platform,
+  required: readonly string[],
+): Report {
+  const drift: DriftRow[] = [];
+  const reached = new Set<string>();
+  let compared = 0;
+  let skippedPlatform = 0;
+  let notInLock = 0;
+
+  for (const pkg of installed) {
+    if (!runsHere(pkg, platform)) {
+      skippedPlatform += 1;
+      reached.add(pkg.name);
+      continue;
+    }
+    const versions = lock.get(pkg.name);
+    if (versions === undefined || versions.length === 0) {
+      notInLock += 1;
+      continue;
+    }
+    compared += 1;
+    reached.add(pkg.name);
+    if (!versions.includes(pkg.version)) {
+      drift.push({ name: pkg.name, lock: versions.join(","), installed: pkg.version });
+    }
+  }
+
+  drift.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return {
+    compared,
+    drift,
+    skippedPlatform,
+    notInLock,
+    uncovered: required.filter((name) => !reached.has(name)).sort(),
+  };
+}
+
+/**
+ * The verdict, kept apart from the numbers so a caller cannot read one without
+ * the other. `compared === 0` is a FAILURE, not a clean tree: it is what an
+ * instrument that measured nothing looks like, and it is the shape every
+ * silent zero in this repo's history has taken.
+ */
+export function verdict(report: Report): { ok: boolean; reason: string | null } {
+  if (report.compared === 0) {
+    return { ok: false, reason: "compared 0 packages — the comparison measured nothing" };
+  }
+  if (report.uncovered.length > 0) {
+    return { ok: false, reason: `direct dependencies never compared: ${report.uncovered.join(", ")}` };
+  }
+  if (report.drift.length > 0) {
+    return { ok: false, reason: `${report.drift.length} package(s) installed off-lock` };
+  }
+  return { ok: true, reason: null };
+}
+
+export function formatReport(report: Report): string {
+  const lines = [
+    `compared=${report.compared} drift=${report.drift.length} ` +
+      `skipped_other_platform=${report.skippedPlatform} not_in_lock=${report.notInLock}`,
+  ];
+  for (const row of report.drift) {
+    lines.push(`  DRIFT ${row.name}  lock=${row.lock}  installed=${row.installed}`);
+  }
+  return lines.join("\n");
+}
+
+const LINUX: Platform = { os: "linux", cpu: "arm64" };
+
+function pkg(
+  name: string,
+  version: string,
+  os: PlatformConstraint = null,
+  cpu: PlatformConstraint = null,
+): InstalledPackage {
+  return { name, version, os, cpu };
+}
+
+/**
+ * Known-answer controls, run by the gate BEFORE it reports any real number.
+ * A failed control exits without numbers: a comparator nobody has calibrated
+ * produces a zero indistinguishable from "nothing drifted".
+ *
+ * Returns the failures; empty means every control answered as expected.
+ */
+export function runSelfTest(): string[] {
+  const failures: string[] = [];
+  const expect = (label: string, actual: unknown, wanted: unknown): void => {
+    const a = JSON.stringify(actual);
+    const w = JSON.stringify(wanted);
+    if (a !== w) failures.push(`${label}: expected ${w}, got ${a}`);
+  };
+
+  // 1 — the parser, on a lockfile fragment with the trailing commas that make
+  //     `JSON.parse` refuse the real file, a scoped name, and a duplicate.
+  const parsed = parseLockVersions(`{
+  "packages": {
+    "foo": ["foo@1.0.0", "", {}, "sha512-a=="],
+    "@scope/bar": ["@scope/bar@2.0.0", "", {}, "sha512-b=="],
+    "dup/foo": ["foo@1.2.0", "", {}, "sha512-c=="],
+  }
+}`);
+  expect("parse/plain", parsed.get("foo"), ["1.0.0", "1.2.0"]);
+  expect("parse/scoped", parsed.get("@scope/bar"), ["2.0.0"]);
+  expect("parse/absent", parsed.get("nope"), undefined);
+
+  const lock = new Map<string, string[]>([
+    ["foo", ["1.0.0"]],
+    ["@scope/bar", ["2.0.0"]],
+    ["multi", ["1.1.5", "1.2.1"]],
+    ["@tool/cli-darwin-arm64", ["2.5.8"]],
+  ]);
+
+  // 2 — the positive control: one aligned package, one deliberately off-lock,
+  //     one the lock does not carry. The drifted one must be NAMED.
+  const mixed = classify(
+    [pkg("foo", "1.0.0"), pkg("@scope/bar", "1.9.9"), pkg("orphan", "0.0.1")],
+    lock,
+    LINUX,
+    ["foo", "@scope/bar"],
+  );
+  expect("mixed/compared", mixed.compared, 2);
+  expect("mixed/drift", mixed.drift, [{ name: "@scope/bar", lock: "2.0.0", installed: "1.9.9" }]);
+  expect("mixed/notInLock", mixed.notInLock, 1);
+  expect("mixed/uncovered", mixed.uncovered, []);
+  expect("mixed/verdict", verdict(mixed).ok, false);
+
+  // 3 — a version among a multi-resolution lock entry is not drift.
+  const multi = classify([pkg("multi", "1.2.1")], lock, LINUX, []);
+  expect("multi/drift", multi.drift, []);
+  expect("multi/verdict", verdict(multi).ok, true);
+
+  // 4 — THE PLATFORM RULE, and the reason the darwin binaries are a
+  //     limitation rather than a red: a package that cannot run here is
+  //     skipped, not compared, even though its version is off-lock.
+  const foreign = classify(
+    [pkg("@tool/cli-darwin-arm64", "2.4.13", ["darwin"], ["arm64"]), pkg("foo", "1.0.0")],
+    lock,
+    LINUX,
+    [],
+  );
+  expect("foreign/skipped", foreign.skippedPlatform, 1);
+  expect("foreign/compared", foreign.compared, 1);
+  expect("foreign/drift", foreign.drift, []);
+  //     …and the same package IS judged on the platform it belongs to, or the
+  //     skip would be a blanket exemption instead of a scoping rule.
+  const native = classify(
+    [pkg("@tool/cli-darwin-arm64", "2.4.13", ["darwin"], ["arm64"])],
+    lock,
+    { os: "darwin", cpu: "arm64" },
+    [],
+  );
+  expect("native/drift", native.drift.length, 1);
+
+  // 5 — an empty tree must FAIL, not pass: zero compared is the instrument
+  //     measuring nothing.
+  expect("empty/verdict", verdict(classify([], lock, LINUX, [])).ok, false);
+
+  // 6 — a declared dependency the walk never reached is named.
+  const gap = classify([pkg("foo", "1.0.0")], lock, LINUX, ["foo", "ghost"]);
+  expect("gap/uncovered", gap.uncovered, ["ghost"]);
+  expect("gap/verdict", verdict(gap).ok, false);
+
+  return failures;
+}

--- a/cicchetto/scripts/lock-drift.ts
+++ b/cicchetto/scripts/lock-drift.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+// #1571 — the `bun run check` stage that makes the other stages attributable:
+// it answers whether the tools about to produce a verdict are the ones
+// `bun.lock` pins. The rules, the platform scoping and the reasoning live in
+// `./lock-drift-core.ts`; this file is only the IO around them.
+//
+// Exit codes are distinct on purpose:
+//   0  every package that runs here matches the lock
+//   1  drift, or a declared dependency the comparison never reached
+//   3  a known-answer control failed — NO numbers are printed, because a
+//      comparator that cannot answer a question with a known answer cannot be
+//      believed when it answers one without.
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { classify, formatReport, parseLockVersions, runSelfTest, verdict } from "./lock-drift-core";
+
+const root = process.cwd();
+
+const failures = runSelfTest();
+if (failures.length > 0) {
+  console.error("lock-drift: SELF-TEST FAILED — refusing to report numbers");
+  for (const failure of failures) console.error(`  ${failure}`);
+  process.exit(3);
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function stringList(value: unknown): string[] | null {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === "string");
+  if (typeof value === "string") return [value];
+  return null;
+}
+
+function readInstalled(dir: string, name: string) {
+  const manifest = readJson(join(dir, "package.json"));
+  if (manifest === null || typeof manifest.version !== "string") return null;
+  return {
+    name,
+    version: manifest.version,
+    os: stringList(manifest.os),
+    cpu: stringList(manifest.cpu),
+  };
+}
+
+function walk(modulesDir: string) {
+  const out = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(modulesDir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries.sort()) {
+    if (entry.startsWith(".")) continue;
+    if (entry.startsWith("@")) {
+      let scoped: string[];
+      try {
+        scoped = readdirSync(join(modulesDir, entry));
+      } catch {
+        continue;
+      }
+      for (const inner of scoped.sort()) {
+        const pkg = readInstalled(join(modulesDir, entry, inner), `${entry}/${inner}`);
+        if (pkg !== null) out.push(pkg);
+      }
+      continue;
+    }
+    const pkg = readInstalled(join(modulesDir, entry), entry);
+    if (pkg !== null) out.push(pkg);
+  }
+  return out;
+}
+
+let lockText: string;
+try {
+  lockText = readFileSync(join(root, "bun.lock"), "utf8");
+} catch {
+  console.error(`lock-drift: no bun.lock at ${root} — cannot attribute anything`);
+  process.exit(1);
+}
+
+const manifest = readJson(join(root, "package.json")) ?? {};
+const required = [
+  ...Object.keys((manifest.dependencies as Record<string, string>) ?? {}),
+  ...Object.keys((manifest.devDependencies as Record<string, string>) ?? {}),
+];
+
+const platform = { os: process.platform, cpu: process.arch };
+const report = classify(walk(join(root, "node_modules")), parseLockVersions(lockText), platform, required);
+const result = verdict(report);
+
+console.log(`lock-drift: ${platform.os}/${platform.cpu} — ${formatReport(report)}`);
+
+if (!result.ok) {
+  console.error(`lock-drift: ${result.reason}`);
+  console.error(
+    "lock-drift: the tree does not match bun.lock, so any verdict from the stages below is " +
+      "not attributable to the code. Reconcile with `scripts/bun.sh install --frozen-lockfile`.",
+  );
+  process.exit(1);
+}

--- a/cicchetto/src/__tests__/lockDrift.test.ts
+++ b/cicchetto/src/__tests__/lockDrift.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  classify,
+  type InstalledPackage,
+  matchesPlatform,
+  type Platform,
+  parseLockVersions,
+  runSelfTest,
+  verdict,
+} from "../../scripts/lock-drift-core";
+
+// #1571 — the gate that says whether `node_modules` is what `bun.lock` pins.
+// Every case below is two-sided on purpose: the rule is only worth anything if
+// the red side reddens AND the green side stays green under the same
+// comparator, so a mutation that disables the check cannot pass by making
+// everything green (nor by making everything red).
+
+const LINUX: Platform = { os: "linux", cpu: "arm64" };
+const DARWIN: Platform = { os: "darwin", cpu: "arm64" };
+
+const pkg = (
+  name: string,
+  version: string,
+  os: readonly string[] | null = null,
+  cpu: readonly string[] | null = null,
+): InstalledPackage => ({ name, version, os, cpu });
+
+const LOCK = new Map<string, string[]>([
+  ["biome-ish", ["2.5.8"]],
+  ["@tool/cli-darwin-arm64", ["2.5.8"]],
+  ["@tool/cli-linux-arm64", ["2.5.8"]],
+  ["multi", ["1.1.5", "1.2.1"]],
+]);
+
+describe("lock drift — the installed tree against bun.lock", () => {
+  it("an aligned tree compares its packages and stays green", () => {
+    const report = classify([pkg("biome-ish", "2.5.8")], LOCK, LINUX, ["biome-ish"]);
+
+    expect(report.compared).toBe(1);
+    expect(report.drift).toEqual([]);
+    expect(verdict(report).ok).toBe(true);
+  });
+
+  it("a package installed off-lock reddens and is named with both versions", () => {
+    const report = classify([pkg("biome-ish", "2.4.13")], LOCK, LINUX, ["biome-ish"]);
+
+    expect(report.compared).toBe(1);
+    expect(report.drift).toEqual([{ name: "biome-ish", lock: "2.5.8", installed: "2.4.13" }]);
+    expect(verdict(report).ok).toBe(false);
+  });
+
+  it("a name the lock resolves at several versions matches any of them", () => {
+    // A transitive duplicate is a hoisting outcome, not a pin violation.
+    expect(classify([pkg("multi", "1.1.5")], LOCK, LINUX, []).drift).toEqual([]);
+    expect(classify([pkg("multi", "1.2.1")], LOCK, LINUX, []).drift).toEqual([]);
+    expect(classify([pkg("multi", "1.0.0")], LOCK, LINUX, []).drift).toHaveLength(1);
+  });
+});
+
+describe("lock drift — the platform scoping, which is what makes the darwin binaries a limitation", () => {
+  const darwinBinary = pkg("@tool/cli-darwin-arm64", "2.4.13", ["darwin"], ["arm64"]);
+
+  it("skips a binary that cannot run here, even though its version is off-lock", () => {
+    const report = classify([darwinBinary, pkg("biome-ish", "2.5.8")], LOCK, LINUX, []);
+
+    expect(report.skippedPlatform).toBe(1);
+    expect(report.compared).toBe(1);
+    expect(report.drift).toEqual([]);
+    expect(verdict(report).ok).toBe(true);
+  });
+
+  it("judges the very same package on the platform it belongs to", () => {
+    // Without this side the skip would be a blanket exemption: the rule is
+    // "what runs HERE", not "platform binaries are never checked".
+    const report = classify([darwinBinary], LOCK, DARWIN, []);
+
+    expect(report.skippedPlatform).toBe(0);
+    expect(report.drift).toEqual([
+      { name: "@tool/cli-darwin-arm64", lock: "2.5.8", installed: "2.4.13" },
+    ]);
+  });
+
+  it("reads npm allowlists and negations the way npm does", () => {
+    expect(matchesPlatform(null, "linux")).toBe(true);
+    expect(matchesPlatform([], "linux")).toBe(true);
+    expect(matchesPlatform(["linux", "darwin"], "linux")).toBe(true);
+    expect(matchesPlatform(["darwin"], "linux")).toBe(false);
+    expect(matchesPlatform(["!win32"], "linux")).toBe(true);
+    expect(matchesPlatform(["!win32"], "win32")).toBe(false);
+  });
+});
+
+describe("lock drift — the ways the comparison can measure nothing", () => {
+  it("fails on an empty comparison instead of reporting a clean tree", () => {
+    const report = classify([], LOCK, LINUX, []);
+
+    expect(report.compared).toBe(0);
+    expect(report.drift).toEqual([]);
+    // The dangerous shape: zero drift over zero comparisons. It must not pass.
+    expect(verdict(report).ok).toBe(false);
+    expect(verdict(report).reason).toContain("measured nothing");
+  });
+
+  it("names a declared dependency the walk never reached", () => {
+    const report = classify([pkg("biome-ish", "2.5.8")], LOCK, LINUX, ["biome-ish", "ghost"]);
+
+    expect(report.uncovered).toEqual(["ghost"]);
+    expect(verdict(report).ok).toBe(false);
+  });
+
+  it("counts an installed package the lock does not carry without failing on it", () => {
+    // Not a pin violation: `bun install --cwd e2e` and stray local installs
+    // both land here, and calling them drift would make the gate cry wolf.
+    const report = classify([pkg("biome-ish", "2.5.8"), pkg("stray", "0.0.1")], LOCK, LINUX, []);
+
+    expect(report.notInLock).toBe(1);
+    expect(verdict(report).ok).toBe(true);
+  });
+});
+
+describe("lock drift — the lockfile parser", () => {
+  const text = `{
+  "packages": {
+    "plain": ["plain@1.0.0", "", {}, "sha512-a=="],
+    "@scope/tool": ["@scope/tool@2.5.8", "", { "os": "linux" }, "sha512-b=="],
+    "nested/plain": ["plain@1.2.0", "", {}, "sha512-c=="],
+  }
+}`;
+
+  it("resolves scoped names, and survives the trailing commas JSON.parse refuses", () => {
+    expect(() => JSON.parse(text)).toThrow();
+
+    const lock = parseLockVersions(text);
+    expect(lock.get("@scope/tool")).toEqual(["2.5.8"]);
+    expect(lock.get("plain")).toEqual(["1.0.0", "1.2.0"]);
+    expect(lock.get("absent")).toBeUndefined();
+  });
+});
+
+describe("lock drift — the controls the gate runs on itself", () => {
+  it("answers every known-answer control before it reports a number", () => {
+    // The gate exits 3 without printing numbers when this list is non-empty.
+    expect(runSelfTest()).toEqual([]);
+  });
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53049,3 +53049,96 @@ gates.
 The two historical mentions of these names elsewhere in this file
 (`AdminLiveState`, `AdminVisitorLiveState`) are left untouched: the log
 records what was true when it was written.
+<!-- entry #1571 -->
+
+---
+
+## 2026-08-20 — #1571: the gate now says whether the toolchain is the one the lockfile pins
+
+A `bun run check` is only attributable if the tools that produced the verdict
+are the ones `bun.lock` names. #1571 found a main checkout whose biome was
+three minor versions behind the lock; the re-measurement asked whether that had
+receded, and the answer split in a way worth recording.
+
+**Declared and executed are different packages, and only one of them was ever
+read.** `@biomejs/biome` is a JS wrapper; the binary it runs lives in a
+per-platform optional dependency. Reading the wrapper's `package.json` reports
+the DECLARED version — that reading said 2.5.8, in lock, and was correct about
+what it measured. `biome --version` reports the EXECUTED one. Same tree, two
+answers: **2.5.8 through `scripts/bun.sh` (the container, where every gate
+runs) and 2.4.13 from `cicchetto/node_modules/.bin/biome` on the host.** The
+anchor was part of the instrument, and the wrong anchor closed the issue
+prematurely.
+
+**The mechanism, with evidence.** `bun install` only resolves the optional
+dependency matching the platform it runs on, and every gate here runs bun
+inside a linux container — so the `*-darwin-*` packages in a macOS tree cannot
+be refreshed by any path the project uses. Measured: both drifted packages were
+darwin binaries (`@biomejs/cli-darwin-arm64` 2.4.13 vs 2.5.8,
+`@rolldown/binding-darwin-arm64` 1.0.0-rc.17 vs 1.1.5/1.2.1), both directories
+dated three months before every linux sibling. 2 of 459 compared.
+
+**Closed by the last install, not by construction.** `scripts/bun.sh`'s only
+freshness test is `needs_install`, which asks whether `node_modules` is EMPTY;
+nothing anywhere compared installed versions to the lock; and the documented
+worktree procedure (`cp -Rc` the tree from the main checkout) copies whatever
+is there — reproduced the same day on an hour-old worktree, package for
+package. A future lock bump landing on an already-populated tree re-derives the
+original defect with nothing to say so.
+
+### The cure, and the shape of it
+
+`bun run check` gained a FIRST stage, `cicchetto/scripts/lock-drift.ts`, which
+compares `node_modules` against `bun.lock` and names every package that
+disagrees. It is a stage rather than a preflight in `scripts/bun.sh` because
+`check.ts` already owns the union-of-failures aggregation (#1469) and adding
+one there costs no extra container start; the cost of that choice is stated
+below.
+
+Three properties are deliberate:
+
+- **Scoped to the executing platform.** The question asked is "does what will
+  RUN HERE match the lock", not "is every file in the tree pinned". Judging
+  foreign-platform binaries would make the gate red on something no gate
+  executes and no documented command can fix.
+- **Known-answer controls inside the tool.** `runSelfTest()` runs before any
+  real number is produced and the gate exits **3 printing nothing** when a
+  control fails — a comparator nobody has calibrated produces a zero
+  indistinguishable from "nothing drifted". Measured by mutation: removing the
+  one line that records a drift makes three controls fire and zero numbers
+  print, and reddens the vitest suite at the same time.
+- **`compared === 0` is a failure**, not a clean tree. Measuring nothing is the
+  shape every silent zero in this repo's history has taken, so it gets its own
+  verdict rather than being folded into "no drift found".
+
+Two-sided kill test on the real tree, not on a fixture: putting
+`@biomejs/cli-linux-arm64` at 2.5.6 — the exact version #1571 found in the
+wild — turned `check` red with **one** stage failing and the package named;
+restoring it byte-identical turned all four stages green.
+
+### The darwin binaries are a documented limitation, not a gate that lies
+
+Named explicitly because it is the half that was NOT cured. The stale
+foreign-platform binaries are real and are not judged. What bounds them is
+measured, not assumed: `bun`, `bunx` and `biome` are absent from the host
+PATH, `scripts/check.sh` never invokes bun, no script or workflow runs biome
+outside the container, and the repo carries no editor config or git hook. So
+no documented gate can produce a verdict from them; a direct
+`node_modules/.bin/<tool>` call or an editor integration can, and
+`docs/TESTING.md` now says so and how to check by hand.
+
+### Not covered, deliberately
+
+- **Only `check` carries the stage.** `run test` and `run build` consume the
+  same tree and are not guarded. Guarding every verb means a drift check in
+  `scripts/bun.sh`, which costs one extra container start per invocation; the
+  gate whose attributability #1571 is about is `check`, and a drift surfaced
+  there is a drift the whole tree has.
+- **The missing direction is not checked.** A lock entry with nothing
+  installed is not reported, because the lock legitimately carries packages
+  this platform never installs and the false positives would teach people to
+  ignore the gate. The one completeness check made instead: every direct
+  dependency of `package.json` must have been reached, or the gate fails
+  naming it.
+- **Every number above is one host.** Nothing here says what another
+  developer's tree contains.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,7 +34,7 @@ scripts/test.sh --cover                  # coverage
 
 # cic (Solid / TS)
 scripts/bun.sh run test                  # vitest
-scripts/bun.sh run check                 # biome + tsc — src AND e2e (#484); all 3 stages, union of failures (#1469)
+scripts/bun.sh run check                 # lock drift + biome + tsc — src AND e2e (#484); all 4 stages, union of failures (#1469)
 
 # Full CI gate locally
 scripts/check.sh                         # mix ci.check + wireTypes drift gate + bats
@@ -125,8 +125,8 @@ caught.
 told you the FIRST stage failed and nothing about the rest — and formatting,
 the cheapest and most frequent failure, sat first. Measured three times in one
 day, a cosmetic complaint hid two, then three, genuine type errors for as long
-as it lasted. `cicchetto/scripts/check.ts` now runs all three and exits
-non-zero if ANY did, closing with `check summary — 3 stages ran, N failed`.
+as it lasted. `cicchetto/scripts/check.ts` now runs every stage and exits
+non-zero if ANY did, closing with `check summary — N stages ran, M failed`.
 Read that line: it is what tells you the red is complete. It also passes
 `--max-diagnostics=none`, because biome's default ceiling of 20 truncated the
 one real error behind this tree's 59 standing warnings — a red naming no file
@@ -187,6 +187,37 @@ signature above; the guard now tests for CONTENT, and absence and
 emptiness are one state. If you see the self-heal install on a tree that
 looks populated, check whether it holds anything.
 
+**A populated `node_modules` can still be the WRONG one, and `check`'s
+first stage is what says so (#1571).** The self-heal above asks whether the
+tree has content, never whether that content is what `bun.lock` pins — and
+#1571 measured a main checkout whose biome was three minor versions off the
+lock, silently cloned into every worktree by the documented `cp -Rc`
+procedure. A verdict from an unpinned toolchain is unattributable in both
+directions: a rule that only fires on the newer version passes here and
+fails in CI, and one that only fires on the older fails here against code
+CI would accept. The `lock drift (node_modules vs bun.lock)` stage compares
+the two and names every package that disagrees; the cure it prints is
+`scripts/bun.sh install --frozen-lockfile`. It exits **3** without printing
+any number when one of its own known-answer controls fails, so a zero from
+it is never the sound of an instrument that measured nothing.
+
+**Documented limitation: the stage does NOT judge binaries for another
+platform, and those CAN be stale.** biome and rolldown ship a JS wrapper
+plus one binary package per platform, and `bun install` only resolves the
+one matching the platform it runs on. Every gate here runs bun inside a
+LINUX container, so on a macOS host the `*-darwin-*` packages are whatever
+the last host-side install left — measured 2026-08-20:
+`@biomejs/cli-darwin-arm64` at 2.4.13 against a lock pinning 2.5.8, three
+months older than its linux siblings, while the container executed the
+pinned 2.5.8 from the same tree. No gate reaches them (`bun`, `bunx` and
+`biome` are not on the host PATH, and nothing outside the container invokes
+them), and no command the project documents can refresh them, so making the
+gate red on them would be a red nobody could clear. What CAN reach them is
+a direct `cicchetto/node_modules/.bin/<tool>` call or an editor
+integration: if you use one, read its version yourself
+(`./cicchetto/node_modules/.bin/biome --version`) and do not treat its
+verdict as the gate's.
+
 **`scripts/bun.sh run check` counts a biome FORMAT violation as an
 ERROR, and hides which file it came from.** `check` starts with `biome
 check`: a line biome would reflow (a long `foo({ a, b, c })`
@@ -216,7 +247,7 @@ The authoritative source is the comment block at the top of each
 
 * **`scripts/test.sh`** → `scripts/mix.sh --env=test test --warnings-as-errors "$@"`. Forces `MIX_ENV=test` (auto-detect would use the live container's env, usually dev/prod, breaking sandbox).
 * **`scripts/check.sh`** → `scripts/mix.sh --env=dev ci.check` + `mix grappa.gen_wire_types --check` (wireTypes drift gate) + `scripts/bats.sh`. The `ci.check` alias (in `mix.exs`) chains: compile (warnings as errors), format check, credo, deps.audit, hex.audit, sobelow, `cmd env MIX_ENV=test mix doctor`, `cmd env MIX_ENV=test mix test --warnings-as-errors`, dialyzer, docs. Doctor shells out to `:test` since #621: in `:dev` it counts a module's functions from the source AST but reads doc/spec presence from the beam, so every `Mix.env() == :test`-gated helper is scored as undocumented, and `elixirc_paths` omits `test/support` there. `:test` is a strict superset on both axes, and matches the workflow's single `mix doctor` step. The `ci` workflow runs the same gates — including the wireTypes drift check since #767 — but it re-lists them by hand in YAML rather than invoking this script, so the two lists mirror each other only for as long as someone keeps them in step. A gate added here is not in CI until it is added there too; #767 was one instance of that (the drift gate was local-only, and a stale `wireTypes.ts` survived a merge with CI green).
-* **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = biome + tsc over `src` AND `e2e`. `install`, `add`, etc. forward to bun.
+* **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = the lock-drift stage (#1571) + biome + tsc over `src` AND `e2e`. `install`, `add`, etc. forward to bun.
 * **`scripts/bats.sh`** → host-side bats v1.9.0 (submodule at `vendor/bats-core`) against `test/bin/`, `test/infra/` and `test/scripts/`. NOT containerised — bats tests host-side bash (`bin/grappa`, the deploy scripts, the cloud installer). There is no compose involvement in the runner: the container is reached only transitively, when a test exercises a verb that shells out to docker, and those tests stub `docker` on `PATH` rather than touching a real one. So this gate needs no stack up.
 * **`scripts/release-image.sh`** → the RELEASE image (`Dockerfile.release`), not the compose dev stack. `build` buildx-loads it locally; `fresh-boot` wipes the scratch volume and bare-runs it with nothing but `PHX_HOST` (the documented one-liner — the point is that everything else must come from the image and the volume); `warm-boot` does the same on the EXISTING volume; `oneshot <args…>` runs a throwaway container against that volume; `logs` / `down [--volume]` clean up. This is the reproduction for #862 and #867, both of which were found by hand-typing docker commands because no wrapper reached this artifact.
 * **`scripts/smoke-release-image.sh`** → brings a box up from `$GRAPPA_IMAGE` through the real `infra/docker/get.sh` → `deploy.sh` release path (`GRAPPA_RAW_BASE=file://<checkout>`, so get.sh's mirror list is under test too), then probes it over HTTP and tears everything down. Dedicated container/volume names (`grappa-smoke*`), so it cannot eat an operator box. Requires the image to be present locally — **an unavailable image fails the run, it never skips it**. See "The release-image smoke" below.

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -5,8 +5,9 @@
 #   scripts/bun.sh install
 #   scripts/bun.sh add phoenix
 #   scripts/bun.sh run build
-#   scripts/bun.sh run check                    # biome + tsc over src AND e2e (#484);
-#                                               # all 3 stages run, union of failures (#1469)
+#   scripts/bun.sh run check                    # lock drift (#1571) + biome + tsc over
+#                                               # src AND e2e (#484); every stage runs,
+#                                               # union of failures (#1469)
 #   scripts/bun.sh run test                     # vitest (cic unit tests in jsdom)
 #
 # Canonical "which test runner do I use?" docs: docs/TESTING.md.


### PR DESCRIPTION
## What this cures

The half of #1571 that is a gate telling you nothing: **`node_modules`
could disagree with `bun.lock` and no gate said so.** The only freshness
test any script applied was `scripts/bun.sh`'s `needs_install`, which
asks whether the directory is EMPTY — a populated but stale tree
answered "installed" and was never reconciled, and the documented
worktree procedure (`cp -Rc` from the main checkout) copied whatever was
there into every new worktree.

`bun run check` gains a first stage,
`cicchetto/scripts/lock-drift.ts`, which compares the installed tree
against the lock and names every package that disagrees. A stage rather
than a preflight in `bun.sh`: `check.ts` already owns #1469's
union-of-failures aggregation and adding one there costs no extra
container start.

## The measurement that drove it

Posted in full on the issue. The short version, because it decides the
design: `@biomejs/biome` is a JS wrapper and the binary lives in a
per-platform optional dependency, so the **declared** version and the
**executed** one are different packages. Same tree, two answers —
**2.5.8 in the container** (where every gate runs) and **2.4.13 from
`cicchetto/node_modules/.bin/biome` on the host**. Both drifted packages
were darwin binaries, both directories three months older than every
linux sibling, because `bun install` only ever resolves the optional
dependency for the platform it runs on and every gate here runs bun
inside a linux container.

## Three deliberate properties

* **Scoped to the executing platform.** The question is "does what will
  RUN HERE match the lock". Judging foreign-platform binaries would make
  the gate red on something no gate executes and no documented command
  can fix.
* **Known-answer controls inside the tool.** `runSelfTest()` runs before
  any real number and the gate exits **3 printing nothing** when a
  control fails.
* **`compared === 0` is a failure**, not a clean tree.

## Kill test — two-sided, on the real tree

| tree | `bun run check` |
|---|---|
| `@biomejs/cli-linux-arm64` at **2.5.6** (the version #1571 found in the wild), lock pins 2.5.8 | **rc=1, "4 stages ran, 1 failed"** — only the new stage, naming `DRIFT @biomejs/cli-linux-arm64 lock=2.5.8 installed=2.5.6` |
| same package restored byte-identical | **rc=0, "4 stages ran, 0 failed"** |

Mutation on the instrument itself — delete the one line that records a
drift:

* the gate exits **3**, prints **zero** number lines, and names three
  failing controls (`mixed/drift`, `mixed/verdict`, `native/drift`);
* the vitest suite reddens on the same mutant.

Restored byte-identical (`cmp`) before committing.

## The other half: a documented limitation, and that is my call

The stale darwin binaries are **not** cured, and I am calling them a
limitation rather than a gate that lies. What bounds it is measured, not
assumed: `bun`, `bunx` and `biome` are **absent from the host PATH**,
`scripts/check.sh` never invokes bun, no script or workflow runs biome
outside the container, and the repo carries no editor config and no git
hook. **No documented gate can produce a verdict from those binaries.**
What can reach them is a direct `node_modules/.bin/<tool>` call or an
editor integration — `docs/TESTING.md` now says so, and how to read the
version by hand.

Making the gate red on them would be a red nobody can clear: a linux
container install cannot resolve a darwin optional dependency, so there
is no command in this repo that would turn it green.

## Gates

* `scripts/bun.sh run check` — **rc=0, "4 stages ran, 0 failed"**.
* `scripts/bun.sh run test` — **rc=0, 294 files / 5688 tests**, 11 of
  them the new ones.
* `scripts/design-notes-gate.sh` — **rc=0, "1 new entry heading(s),
  separator and marker present"**.
* DESIGN_NOTES boundary: additions 93 / deletions 0, numstat identical
  across the rebase onto `0ea9177c`, prefix byte-identical, marker
  `grep -Fxc` = 1 here and 0 on `origin/main`.
* No Elixir gate run and none needed: the only non-cic file is a
  comment in `scripts/bun.sh`'s usage header, which
  `test/scripts/bun_self_heal_test.bats` does not read (it drives
  `run check` behaviour through a fixture).

## Not covered, deliberately

* **Only `check` carries the stage.** `run test` and `run build` consume
  the same tree unguarded; covering every verb means a check in
  `scripts/bun.sh` and one extra container start per invocation.
* **The missing direction is not checked** — a lock entry with nothing
  installed. The lock legitimately carries packages this platform never
  installs, and the false positives would teach people to ignore the
  gate. The completeness check made instead: every direct dependency of
  `package.json` must have been reached, or the gate fails naming it.
* **One host.** Nothing here says what another developer's tree holds.
