### PR TITLE
deploy(#1473): derive the state-helper half of the tracked set too

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53049,3 +53049,108 @@ gates.
 The two historical mentions of these names elsewhere in this file
 (`AdminLiveState`, `AdminVisitorLiveState`) are left untouched: the log
 records what was true when it was written.
+<!-- entry #1473 -->
+
+---
+
+## 2026-08-20 — #1473: the hand-maintained half of the tracked set, derived
+
+`Grappa.Deploy.Preflight` state-shape-checks only the files behind
+`LongLivedModules.all/0`. That list has two halves. The `@modules` half —
+long-lived `GenServer`s — has been derived-and-gated since #1343. The
+`@state_helpers` half — structs held as FIELDS of one of those processes'
+state — was the half nothing derived; its own moduledoc asked only to "keep
+in sync", and it had drifted three ways.
+
+`Session.Deps` and `Session.DirectoryIngest` arrived with the #1390
+decomposition. `IRC.FakeLag`, a field of `IRC.Client`'s state, was never
+listed at all — it is not in the issue either, which had recorded "no audit
+of the other tracked GenServers' `@type t` blocks was done" as a known
+non-measure. The derivation found it on its first run. **Three, not two.**
+
+Measured through `Preflight.classify/5` on `:jail`, a scratch `defstruct`
+field-add to each classified `{:hot, []}`, while `WindowState` — listed —
+returned `{:cold, [state_shape: [...]]}` from the same harness. A HOT deploy
+carrying such a field-add swaps the beam under a live process still holding
+the old struct; the mismatch surfaces on whatever message next
+pattern-matches it.
+
+### The membership is derivable, and the derivation belongs in the gate
+
+Measured before choosing: walking the `t` typespec of every `@modules` entry
+to a fixpoint and keeping the reachable `:grappa` modules that define a
+struct reproduces **every one of the nine hand-listed helpers** — the
+`listed \ derived` difference is EMPTY. So the list holds nothing the
+derivation cannot reach, and enumerating it by hand buys nothing that
+deriving it does not.
+
+The list stays hand-written anyway, and the derivation became the gate. A
+runtime derivation would feed no Dialyzer union — `@type state_helper` is a
+literal union — and it would fail OPEN at deploy time: a module that fails
+to load simply leaves the set and the preflight silently checks less, which
+is the failure mode the preflight exists to prevent. A hand list with a
+derived gate fails red, in CI, before the deploy. It is also the shape the
+`@modules` half already has, so the two halves stay one pattern rather than
+two. *(The compile-time variant — deriving into the literal at compile time
+— was judged unworkable because `LongLivedModules` would have to read the
+typespecs of modules not yet compiled. That was reasoned, not prototyped.)*
+
+The typespec is read from the BEAM chunk rather than the source: module
+names arrive fully qualified, so there is no alias table to resolve and no
+second parser to keep in step with the compiler.
+
+### The unit of coverage is the FILE, not the module
+
+`extract_state_block/1` reads a source file, so a struct nested inside
+another module's file is covered by listing its PARENT. Measured: a
+field-add to the nested `DirectoryIngest.Run` moves `directory_ingest.ex`'s
+extracted block. Three such nested structs (`LinksAccum.Entry`,
+`ListModeAccum.Entry`, `WhowasAccum.Entry`) were already covered that way
+before this change, which is what makes the rule observed rather than
+assumed.
+
+Listing a nested module instead would be actively harmful:
+`Grappa.Session.DirectoryIngest.Run` implies
+`lib/grappa/session/directory_ingest/run.ex`, which does not exist, and an
+absent file is read as empty at BOTH revs — it compares equal and
+classifies HOT. That is the silent direction the sibling
+"source file sits where its name says" assertion already guards.
+
+So the gate keys on each struct's COMPILE SOURCE, not on module identity,
+and nesting needs no special case.
+
+### What the gate is worth, in both directions
+
+- Add a struct to a long-lived state without listing it: the pre-cure list
+  put `deps.ex`, `directory_ingest.ex` and `fake_lag.ex` in the red set,
+  grouped by file, with `DirectoryIngest.Run` collapsed onto its parent.
+- Remove a listed one: dropping `AwayState` reddens exactly one test,
+  naming `away_state.ex`.
+
+The end-to-end half was then measured through the real `cli/1` with two git
+revisions — the path the issue had recorded as *not established* for these
+modules: a scratch field-add to each of the three, and to the `WindowState`
+control, yields `state_shape: <that file>` and **exit 3**, while a
+comment-only change to a now-listed file yields **exit 0**, which is what
+proves the harness can produce both values rather than always answering 3.
+
+**A measurement trap paid for here.** The first run of that harness returned
+exit 0 for all four, control included. The container's `/app` is the MAIN
+checkout with the worktree's `lib/` bind-mounted over it, so `.git` is
+main's: `HEAD^..HEAD` inside the container resolved to main's last commit,
+not the worktree's scratch one, and every row classified a docs-only diff.
+The verdicts were uniform because the instrument was wrong, not because the
+code agreed. Passing explicit SHAs — the object store IS shared across
+worktrees — fixed it. **A preflight harness must name its revisions
+explicitly; a symbolic ref means the container's repo, not yours.**
+
+### Not established
+
+- **That the three are all of them.** The closure follows `Mod.t()`
+  references inside `t` typespecs. A struct held in a field typed `map()`,
+  `term()` or `any()` is invisible to it, and that gap was not measured.
+- **No production incident is claimed**, unchanged from the issue: what was
+  measured is the classifier's verdict, not the jail's deploy history.
+- **Only `:jail` was classified.** The state-shape stage is
+  substrate-independent in `classify/5`, but `:docker` and `:linux` were
+  read, not run.

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -62,6 +62,28 @@ defmodule Grappa.HotReload.LongLivedModules do
   they are not directly supervised but their shape is part of the
   parent's hot-reload surface.
 
+  **That half is derived and gated too, since GH #1473.** The
+  membership test walks the `t` typespec of every `@modules` entry to
+  a fixpoint, keeps the reachable `:grappa` modules that define a
+  struct, and requires each one's SOURCE FILE to be in the checked
+  set. It was hand-maintained and nothing held it: three structs
+  carrying live `Session.Server` / `IRC.Client` state were absent
+  (`Deps` and `DirectoryIngest` from the #1390 decomposition, plus
+  `IRC.FakeLag`), and a `defstruct` field-add to any of them
+  classified HOT — measured through `Preflight.classify/5`, with
+  `WindowState` as the listed control returning COLD.
+
+  **The unit of coverage is the FILE, not the module**, because
+  `Preflight.extract_state_block/1` reads a source file rather than a
+  module. A struct nested inside another module's file
+  (`LinksAccum.Entry`, `ListModeAccum.Entry`, `WhowasAccum.Entry`,
+  `DirectoryIngest.Run`) is therefore covered by listing its PARENT —
+  measured: a field-add to the nested `Run` moves
+  `directory_ingest.ex`'s extracted block. Such a module must NOT get
+  its own entry: `Grappa.Session.DirectoryIngest.Run` implies
+  `lib/grappa/session/directory_ingest/run.ex`, which does not exist,
+  and an absent file reads equal at both revs — the silent HOT.
+
   A `GenServer` the extractor sees NOTHING in is out of scope, and the
   membership test also refuses a listing it cannot see a shape for — an
   entry that buys no check reads as coverage while providing none. When
@@ -128,8 +150,18 @@ defmodule Grappa.HotReload.LongLivedModules do
   # Helper struct modules whose defstruct is a *field* of one of the
   # `@modules` above. A `defstruct` change here is just as
   # hot-reload-unsafe as a change to the parent's own defstruct.
+  #
+  # Order mirrors `@modules`: the `Session.Server` helpers (alphabetical),
+  # then `IRC.Client`'s, because that is the order their parents appear in.
+  #
+  # #1473 added the last three. List only a module whose CONVENTIONAL PATH
+  # is the file carrying the struct — a struct nested inside another
+  # module's file is covered by listing its parent and must NOT get its own
+  # entry. See the "What goes here" note above.
   @state_helpers [
     Grappa.Session.AwayState,
+    Grappa.Session.Deps,
+    Grappa.Session.DirectoryIngest,
     Grappa.Session.GhostRecovery,
     Grappa.Session.LinksAccum,
     Grappa.Session.ListModeAccum,
@@ -137,7 +169,8 @@ defmodule Grappa.HotReload.LongLivedModules do
     Grappa.Session.RecoverIdentity,
     Grappa.Session.WhoisAccum,
     Grappa.Session.WhowasAccum,
-    Grappa.Session.WindowState
+    Grappa.Session.WindowState,
+    Grappa.IRC.FakeLag
   ]
 
   @typedoc """
@@ -172,6 +205,8 @@ defmodule Grappa.HotReload.LongLivedModules do
   """
   @type state_helper ::
           Grappa.Session.AwayState
+          | Grappa.Session.Deps
+          | Grappa.Session.DirectoryIngest
           | Grappa.Session.GhostRecovery
           | Grappa.Session.LinksAccum
           | Grappa.Session.ListModeAccum
@@ -180,6 +215,7 @@ defmodule Grappa.HotReload.LongLivedModules do
           | Grappa.Session.WhoisAccum
           | Grappa.Session.WhowasAccum
           | Grappa.Session.WindowState
+          | Grappa.IRC.FakeLag
 
   @doc """
   Returns the list of long-lived `GenServer` modules whose state

--- a/test/grappa/hot_reload/long_lived_modules_membership_test.exs
+++ b/test/grappa/hot_reload/long_lived_modules_membership_test.exs
@@ -112,6 +112,61 @@ defmodule Grappa.HotReload.LongLivedModulesMembershipTest do
     end
   end
 
+  describe "state-helper membership" do
+    test "the derived state-field struct set is non-vacuous" do
+      # Same guard as the GenServer half: every assertion below is
+      # "for each struct ..." and would pass on an empty set. 26 struct
+      # modules were reachable when this landed; the floor is slack on
+      # purpose — it catches a derivation that stopped walking, not a
+      # headcount.
+      structs = state_field_struct_modules()
+
+      assert length(structs) >= 15,
+             """
+             Only #{length(structs)} struct module(s) reachable from the
+             `t` typespec of a tracked module — the closure is broken and
+             the membership assertion below is vacuous.
+
+             Reached: #{inspect(structs)}
+             """
+    end
+
+    test "every struct held in a tracked module's state has its source file checked" do
+      checked = MapSet.new(Preflight.long_lived_module_files())
+
+      unchecked =
+        state_field_struct_modules()
+        |> Enum.map(&{&1, compile_source(&1)})
+        |> Enum.reject(fn {_, src} -> MapSet.member?(checked, src) end)
+        |> Enum.group_by(fn {_, src} -> src end, fn {mod, _} -> mod end)
+
+      assert unchecked == %{},
+             """
+             Struct(s) whose shape is part of a tracked module's state, in a
+             source file Grappa.Deploy.Preflight does not check:
+
+             #{Enum.map_join(unchecked, "\n", fn {src, mods} -> "  #{src} — #{Enum.map_join(mods, ", ", &inspect/1)}" end)}
+
+             The preflight state-shape-checks only the files behind
+             `LongLivedModules.all/0`, so a `defstruct` field-add to one of
+             these classifies HOT: the swapped beam then pattern-matches the
+             new struct shape against the state a live process already holds.
+
+             Fix: add the module whose CONVENTIONAL PATH is that file to
+             @state_helpers AND to the `state_helper` union in
+             lib/grappa/hot_reload/long_lived_modules.ex.
+
+             Note the unit of coverage is the FILE, not the module: a struct
+             nested inside another module's file (`LinksAccum.Entry`,
+             `ListModeAccum.Entry`, `WhowasAccum.Entry`,
+             `DirectoryIngest.Run`) is covered by listing its PARENT, and
+             must NOT be listed itself — its conventional path does not
+             exist, which Preflight reads as absent at both revs, compares
+             equal, and classifies HOT.
+             """
+    end
+  end
+
   # Every module of the running application that declares the GenServer
   # behaviour and was compiled from `lib/`. `Application.spec/2` is the
   # OTP-level module list — no source parsing, no second enumeration to
@@ -142,6 +197,80 @@ defmodule Grappa.HotReload.LongLivedModulesMembershipTest do
     case mod.module_info(:compile)[:source] do
       source when is_list(source) -> String.contains?(List.to_string(source), "/lib/")
       _ -> false
+    end
+  end
+
+  # Every struct module whose shape is part of a tracked module's state,
+  # reached by walking `t` typespecs to a fixpoint from the tracked
+  # GenServers.
+  #
+  # The typespec comes from the BEAM chunk, not the source: module names
+  # arrive fully qualified, so there is no alias table to resolve and no
+  # second parser to keep in step with the compiler. Staying inside
+  # `Application.spec(:grappa, :modules)` is the same enumeration the
+  # GenServer half derives from, and it is what drops `DateTime` and
+  # `MapSet` — stdlib structs with no source in this repo.
+  #
+  # Transitive on purpose: a helper may hold a struct of its own, and only
+  # the closure sees it. `Grappa.Session.DirectoryIngest.Run` is the live
+  # example.
+  defp state_field_struct_modules do
+    grappa = MapSet.new(Application.spec(:grappa, :modules))
+    seeds = LongLivedModules.modules()
+
+    seeds
+    |> close(MapSet.new(seeds), grappa)
+    |> Enum.filter(&struct_module?/1)
+    |> Enum.sort()
+  end
+
+  defp close([], seen, _), do: seen
+
+  defp close([mod | rest], seen, grappa) do
+    next =
+      mod
+      |> remote_modules_in_t()
+      |> Enum.filter(&(MapSet.member?(grappa, &1) and not MapSet.member?(seen, &1)))
+      |> Enum.uniq()
+
+    close(rest ++ next, MapSet.union(seen, MapSet.new(next)), grappa)
+  end
+
+  defp remote_modules_in_t(mod) do
+    case Code.Typespec.fetch_types(mod) do
+      {:ok, types} ->
+        types
+        |> Enum.filter(fn {kind, {name, _, args}} ->
+          kind in [:type, :opaque] and name == :t and args == []
+        end)
+        |> Enum.flat_map(fn {_, {_, form, _}} -> remote_modules(form, []) end)
+
+      :error ->
+        []
+    end
+  end
+
+  defp remote_modules({:remote_type, _, [{:atom, _, mod}, {:atom, _, _}, args]}, acc),
+    do: Enum.reduce(args, [mod | acc], &remote_modules/2)
+
+  defp remote_modules(tuple, acc) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> Enum.reduce(acc, &remote_modules/2)
+
+  defp remote_modules(list, acc) when is_list(list),
+    do: Enum.reduce(list, acc, &remote_modules/2)
+
+  defp remote_modules(_, acc), do: acc
+
+  defp struct_module?(mod),
+    do: Code.ensure_loaded?(mod) and function_exported?(mod, :__struct__, 0)
+
+  # The file the module was COMPILED from, repo-relative. A nested module
+  # reports its parent's file, which is exactly the unit Preflight checks —
+  # so nesting needs no special case here.
+  defp compile_source(mod) do
+    case mod.module_info(:compile)[:source] do
+      source when is_list(source) -> source |> List.to_string() |> Path.relative_to(File.cwd!())
+      _ -> nil
     end
   end
 


### PR DESCRIPTION
Refs #1473.

`Grappa.Deploy.Preflight` state-shape-checks only the files behind
`LongLivedModules.all/0`. That list has two halves. The `@modules` half —
long-lived `GenServer`s — has been derived-and-gated since #1343. The
`@state_helpers` half — structs held as **fields** of one of those processes'
state — was the half nothing derived; its own moduledoc asked only to "keep in
sync", and it had drifted.

## Reproduced before curing

The issue's positive control, re-run through the real CLI on real revisions:

```
$ mix run -e 'Grappa.Deploy.Preflight.cli(["c918c00f^", "c918c00f", "jail"])'
Cold-deploy required:
  → state_shape: lib/grappa/session/window_state.ex
exit 3
```

Then the defect, through `Preflight.classify/5` — which is literally what
`cli/1` delegates to — with a scratch `__pf_scratch__` field added to each
top-level `defstruct`:

| module | in checked set | mutated? | state block differs? | `classify_state_shape` | `classify/5` (`:jail`) |
|---|---|---|---|---|---|
| `Session.Deps` | **false** | ✓ | ✓ | `:cold` | **`{:hot, []}`** |
| `Session.DirectoryIngest` | **false** | ✓ | ✓ | `:cold` | **`{:hot, []}`** |
| `IRC.FakeLag` | **false** | ✓ | ✓ | `:cold` | **`{:hot, []}`** |
| `Session.WindowState` (control) | true | ✓ | ✓ | `:cold` | `{:cold, [state_shape: [...]]}` |

No row is vacuous: the scratch field is genuinely on disk and the extracted
state block genuinely differs on every one. `long_lived_module_files/0`
returned 28 paths.

**`IRC.FakeLag` is a third instance, and it is not in the issue.** It is a
field of `IRC.Client`'s state (`client.ex:171`) and was never listed at all.
The issue had recorded "no audit of the other tracked GenServers' `@type t`
blocks was done" as a known non-measure; the derivation below found it on its
first run. Three, not two.

## The membership is derivable — measured, then still put in the gate

Walking the `t` typespec of every `@modules` entry to a fixpoint and keeping
the reachable `:grappa` modules that define a struct reproduces **every one of
the nine hand-listed helpers**: the `listed \ derived` difference is **empty**.
So the hand list holds nothing the derivation cannot reach.

The list nevertheless stays hand-written, and the derivation became the gate:

- a runtime derivation feeds **no Dialyzer union** — `@type state_helper` is a
  literal union, and computing the list deletes that check;
- it **fails OPEN at deploy time**: a module that fails to load simply leaves
  the set and the preflight silently checks less — the exact failure mode the
  preflight exists to prevent. A hand list with a derived gate fails **red, in
  CI, before** the deploy;
- it keeps **one pattern for one problem**: this is the shape the `@modules`
  half already has.

*(The compile-time variant — deriving into the literal at compile time — was
judged unworkable because `LongLivedModules` would have to read the typespecs
of modules not yet compiled. That was reasoned, not prototyped.)*

The typespec is read from the **BEAM chunk** rather than the source, so module
names arrive fully qualified: no alias table to resolve, no second parser to
keep in step with the compiler.

## The unit of coverage is the FILE, not the module

`extract_state_block/1` reads a source *file*, so a struct nested inside
another module's file is covered by listing its **parent**. Measured: a
field-add to the nested `DirectoryIngest.Run` moves `directory_ingest.ex`'s
extracted block (`classify_state_shape` → `:cold`). Three such nested structs
(`LinksAccum.Entry`, `ListModeAccum.Entry`, `WhowasAccum.Entry`) were already
covered that way before this change, which is what makes the rule observed
rather than assumed.

Listing a nested module instead would be actively harmful:
`Grappa.Session.DirectoryIngest.Run` implies
`lib/grappa/session/directory_ingest/run.ex`, which does not exist, and an
absent file is read as empty at **both** revs — it compares equal and
classifies HOT. So the gate keys on each struct's **compile source**, and
nesting needs no special case.

## What the gate is worth, in both directions

| mutant | expected | measured |
|---|---|---|
| struct in a long-lived state, unlisted | red | red — `deps.ex`, `directory_ingest.ex`, `fake_lag.ex`, grouped by file, `DirectoryIngest.Run` collapsed onto its parent |
| a listed entry removed (`AwayState`) | red | red — **exactly one** test, naming `away_state.ex` |

## Two-sided kill test on the preflight itself

Same harness, before and after the cure:

| module | before | after |
|---|---|---|
| `Session.Deps` | `{:hot, []}` | `{:cold, [state_shape: ["lib/grappa/session/deps.ex"]]}` |
| `Session.DirectoryIngest` | `{:hot, []}` | `{:cold, [state_shape: ["lib/grappa/session/directory_ingest.ex"]]}` |
| `IRC.FakeLag` | `{:hot, []}` | `{:cold, [state_shape: ["lib/grappa/irc/fake_lag.ex"]]}` |
| `WindowState` (negative control) | `{:cold, [state_shape: [...]]}` | **identical to itself** |

Checked paths: **28 → 31**, exactly +3.

The end-to-end half was then measured through the real `cli/1` with two git
revisions — the path the issue recorded as *not established* for these modules
— by committing a scratch field-add and reading the process exit code:

| scratch commit | exit |
|---|---|
| field-add to `deps.ex` | **3**, `state_shape: lib/grappa/session/deps.ex` |
| field-add to `directory_ingest.ex` | **3**, `state_shape: lib/grappa/session/directory_ingest.ex` |
| field-add to `fake_lag.ex` | **3**, `state_shape: lib/grappa/irc/fake_lag.ex` |
| field-add to `window_state.ex` (control) | **3**, `state_shape: lib/grappa/session/window_state.ex` |
| **comment-only** change to `deps.ex` (negative control) | **0** — `no unsafe markers → HOT` |

The negative control is the point: it proves the harness produces both values
in this configuration, so "everything is 3" is a result rather than a stuck
instrument.

### A measurement trap paid for here

The first run of that harness returned **exit 0 for all four cases, control
included**. The container's `/app` is the MAIN checkout with the worktree's
`lib/` bind-mounted over it, so `.git` is main's: `HEAD^..HEAD` *inside the
container* resolved to main's last commit, not the worktree's scratch one, and
every row classified a docs-only diff. The verdicts were uniform because the
instrument was wrong, not because the code agreed. Passing explicit SHAs — the
object store IS shared across worktrees — fixed it. **A preflight harness must
name its revisions explicitly; a symbolic ref means the container's repo, not
yours.**

## Gates

| gate | result |
|---|---|
| `scripts/check.sh` (`mix ci.check` + `scripts/bats.sh`) | **rc=0** |
| ExUnit | 8 doctests, 61 properties, **6571 tests, 0 failures** |
| bats | `1..588` — **588 ok, 0 not ok** |
| Dialyzer | `done (passed successfully)` |
| Credo strict | `found no issues` |
| Sobelow | `Total errors: 0, Skipped: 0` |
| `mix deps.audit` | `No vulnerabilities found.` |
| `scripts/design-notes-gate.sh origin/main` | **rc=0** |

Stage 2 was verified to have actually run — the bats `1..588` plan line is
present, so `ci.check` did not halt stage 1 and leave a downstream green that
never existed.

Rebased onto `origin/main` with `scripts/union-rebase.sh` (its second real
use): `docs/DESIGN_NOTES.md: +105 -0 — contribution intact`, confirmed from a
second source by diffing the contribution numstat pinned to a file before the
rebase. Prefix byte-identical to the base's file — which subsumes the
preceding-entry tail check — boundary shape read on the real file, and the
`<!-- entry #1473 -->` marker unique in the file (`grep -Fxc` = 1) and absent
from the base.

## What this PR does NOT claim

- **That the three are all of them.** The closure follows `Mod.t()` references
  inside `t` typespecs. A struct held in a field typed `map()`, `term()` or
  `any()` is invisible to it, and that gap was **not measured**.
- **No production incident is claimed**, unchanged from the issue: what was
  measured is the classifier's verdict, not the jail's deploy history.
- **Only `:jail` was classified.** The state-shape stage is
  substrate-independent in `classify/5`, but `:docker` and `:linux` were read,
  not run.
- **That the compile-time derivation is impossible.** It was judged wrong for
  the reason above; it was not prototyped.
