### PR TITLE
db(#1421): report the wait the retry engine observed, not the budget

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53049,3 +53049,141 @@ gates.
 The two historical mentions of these names elsewhere in this file
 (`AdminLiveState`, `AdminVisitorLiveState`) are left untouched: the log
 records what was true when it was written.
+<!-- entry #1421 -->
+
+---
+
+## 2026-08-20 — #1421: a budget that cannot bound the fault it is pointed at
+
+#1420 named this and left it: *"the retry budget cannot fire on the fault it
+exists for"*. This closes the half that can be closed without touching what
+#1420 calls the contested axis. A + B of the option table below shipped;
+C/D/E/H did not, and are vjt's call.
+
+### The mechanism, stated exactly
+
+`BusyRetry`'s budget is a deadline consulted BETWEEN attempts. It cannot
+preempt an attempt already running, because the engine does not own the wait —
+SQLite does. So the reach depends on the FAULT'S OWN latency, and the live
+topologies do not share a regime:
+
+| topology | who owns the wait | latency before the raise | inside the 1500ms budget? |
+|---|---|---|---|
+| pool `queue_timeout` | DBConnection | ~100ms (target 50ms, doubled once, then dropped) | yes |
+| write-lock `busy_locked` | SQLite's busy handler | up to `busy_timeout` = 30_000ms | **no — 20x over** |
+| deferred read->write upgrade | nobody, raises at once | ~0ms | yes, but gated out |
+
+The third row is not live: `Repo.transaction(` appears **0 times** in `lib/`,
+enforced by `Grappa.Repo.TransactionModeGateTest` (#1374). Both live write
+paths are therefore slow-fault paths — the 122 bare `Repo.insert/update/…`
+sites take the write lock in autocommit, and every write transaction goes
+through `immediate_transaction/1`.
+
+So the accurate claim is narrower than "the retry branch is unreachable": it
+is unreachable for the LOCK topology, and stays reachable for the POOL
+topology it was dimensioned for. `config/config.exs` sizes the budget against
+*"the ~1s pool-saturation window the #336 incident measured"* — one number
+dimensioned for one topology, later reused for another. Not a wiring slip.
+
+Chronology, because it explains the order of events and exonerates #524: the
+budget landed 2026-07-19 (`6e99d1c9`, #340); `BEGIN IMMEDIATE` landed nine
+days later (`13edb5f3`, #524), replacing a deferred upgrade that
+`repo.ex:166-170` records as raising *at once*. #524 is correct; it is simply
+the commit after which the write-transaction fault waits `busy_timeout`.
+
+### Why the engine's own suite could not see it
+
+Every pre-existing retry test raises a hand-built `%Exqlite.Error{}` from a
+zero-cost closure. The fault is FREE, so the budget is the only thing bounding
+the loop — the one regime in which the budget appears to work. The new bench
+`Grappa.Repo.BusyRetryBudgetReachTest` provokes a REAL driver `SQLITE_BUSY`
+against a held write lock and varies only `busy_timeout`: above the budget the
+loop collapses to exactly one attempt, below it the loop runs many. Same
+engine, same budget; only the ratio changes, and production's ratio is 20.
+
+The same shape sits in `config/test.exs`: `queue_target: 5_000` (a ~10_000ms
+drop) against `budget_ms: 300`. The test environment reproduces the identical
+incoherence in the OTHER topology, 33x over, and nothing notices — because no
+test pays for its faults.
+
+### What shipped: the line reports the wait it OBSERVED
+
+The terminal warning read `for the full 1500ms retry budget (1 attempts)`
+after waiting 30 067ms. That is CLAUDE.md's log-honesty rule broken by the
+same line #1420 had just corrected for the same reason, so it is a bugfix and
+not a behaviour change: it now reads `for 30067ms across 1 attempts (1500ms
+retry budget)`. The elapsed is the only figure the engine can vouch for; the
+budget stays as context, never as the bound.
+
+Zero behaviour moved. `run/2` carries `started` instead of a precomputed
+deadline and `elapsed_ms < @budget_ms` replaces `monotonic_time < deadline` —
+the same arm at the same boundary, rearranged so one subtraction feeds the
+line. Same retry, same `{:error, :db_unavailable}`, same `fault:` metadata,
+0 of the 71 `BusyRetry.run`/`with_pool_retry` call sites touched.
+
+### The census moved in LOCKSTEP, and its anchor changed on purpose
+
+`scripts/log-gap-scan.awk` counted `saturated` on `/saturated for the full/` —
+the numeric tail this commit rewrites. Left alone it would have reported zero,
+and zero is what a clean run looks like: the #1429 census is the attribution
+instrument for red e2e runs, so blinding it costs the next reader a
+measurement they believe they took.
+
+Both terminal counters are now anchored on the `observed_state/1` phrase
+ALONE (`SQLite pool saturated` / `write lock held by another writer`), which
+is the half that names the topology and the half that does not carry numbers.
+The two known-answer samples in the scanner and the two verbatim pins in
+`test/scripts/log_gap_scan_test.bats` moved in the same commit, plus a new
+bats case that feeds both lines with a DIFFERENT numeric tail — so the
+decoupling is asserted rather than asserted-about.
+
+### What was measured, and what the measurement does NOT license
+
+`log-gap-census` over 50 integration runs (window 2026-08-18T17:02Z ->
+2026-08-20T12:26Z, 600 SUMMARY lines, 1.13-1.17M log lines per run for
+`grappa-test`): `db30`, `idle30`, `dropped`, `saturated` present on 600/600
+and ALL ZERO. The three lock counters are present on **12/600 lines — one run
+of fifty**, since they shipped on 2026-08-20 with #1420-instrument. That is a
+declared non-measure on 49 runs, not a zero.
+
+Positive control, because an all-zero census accuses its own instrument first:
+the single red run's 262MB `grappa-test.log` carries 1 158 475 lines and
+**502 660 `QUERY OK` rows with a `db=` timing**, max 194.2ms, six samples in
+100-1500ms, none above. Half a million timed queries are in the stream, so the
+zeros above are measured rather than an absent logging path.
+
+The regime did fire in a DIFFERENT window (`lock_watch.ex:19-21`, #1420's
+census: `db30=4`, `dropped=2`, `saturated=2`, every gap exactly 30.1s), and
+there the 30s wait bought nothing — four waiters all reached the full timeout
+and two scrollback rows were dropped anyway. That argues FOR lowering
+`busy_timeout`, and it is recorded here even though it favours an option not
+taken. Its weight is six signature hits in one window: not enough to reset a
+global timeout.
+
+Not claimed: that a 30s wait ever SUCCEEDED (the `QUERY OK … db=30064.1ms`
+line in the scanner is a registered known-answer SAMPLE, not an observed line,
+and zero `db=3xxxx` rows appear in the one log materialised — this is the
+single fact that would decide the contested axis, and it is unmeasured); the
+production `queue_timeout` drop latency (read from `db_connection`'s own
+"Queue config", never measured here); the distribution of lock HOLD times
+(both windows are CI, neither is m42); and that lowering `busy_timeout` would
+have saved those two rows (mechanically it cannot — a lock held past 30s
+outlasts every budget under discussion; it would only move the drop earlier).
+
+### Named, not cured — deliberately
+
+Re-dimensioning either number changes retry behaviour under contention, which
+is #1420's contested axis. The options were priced and posted to #1421 for
+vjt: lower `busy_timeout` (turns every lock held between the budget and 30s
+from a slow SUCCESS into a fast drop/503, and re-arms the measured e2e flake
+the 30_000 exists for — `runtime.exs:193-196`); raise `budget_ms` (a 90s HTTP
+hang before the 503, worse for the caller #518 exists to protect); swap the
+roles (~250 / ~30_000: same total wall-clock, ~100 slices, the engine owns the
+wait); or a compile-time coherence gate, which is NOT a middle path — it
+refuses the documented-limitation outcome and forces one of the other three
+without saying so.
+
+The question left open, in one line: **is a 30-second HTTP hang before a 503
+the behaviour we want?** If yes, #1421 closes as a documented limitation and
+the module's contract now says so. If no, the answer is one of the above and
+it is a ruling, not a fix.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4751,7 +4751,13 @@ WAL/lock corroboration (mechanism 2, out-of-band): grep prod logs for the
 `db write unavailable` warning — it names WHICH of the two it observed since
 #1420 (`SQLite pool saturated` for a pool `queue_timeout`, `SQLite write lock
 held by another writer` for a `busy_locked`; before that it said "pool" for
-both while its own `fault=` metadata said otherwise) — and busy/locked
+both while its own `fault=` metadata said otherwise). Since **#1421** it also
+names the wall-clock it actually WAITED — `for 30067ms across 1 attempts
+(1500ms retry budget)`. Read the two numbers together: an elapsed far past the
+budget with `1 attempts` is the lock topology, where SQLite's 30 s
+`busy_timeout` sits inside the first attempt and the budget cannot bound
+anything; an elapsed just past the budget with many attempts is the pool
+topology the budget was actually dimensioned for. Also grep busy/locked
 `%Exqlite.Error{}` lines during
 the burst; watch WAL checkpoint pressure via the `runtime/*.db-wal` file size
 (a large, slow-shrinking `-wal` = checkpoints falling behind the write rate).

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -38,6 +38,39 @@ defmodule Grappa.Repo.BusyRetry do
   The retry loop runs over a wall-clock BUDGET, sleeping a linear backoff
   capped per attempt, so a normal write caught behind a burst is ridden
   out; only sustained saturation degrades.
+
+  ## How far the budget REACHES (#1421)
+
+  The budget is a deadline consulted BETWEEN attempts. It cannot preempt an
+  attempt that is already running, because this engine does not own the wait —
+  so its reach depends on the FAULT'S OWN latency, and the two live topologies
+  do not share a regime:
+
+    * a pool `queue_timeout` is dropped by DBConnection near `queue_target`
+      (50ms, doubled once, then dropped — see its "Queue config"), well inside
+      the budget. This is the topology the budget was dimensioned for:
+      `config/config.exs` sizes it against "the ~1s pool-saturation window the
+      #336 incident measured".
+    * a write-lock `busy_locked` fault raises only once SQLite's
+      `busy_timeout` has expired — 30_000ms in every env, 20x the budget. The
+      first attempt has therefore already overshot the deadline by the time it
+      returns, so the loop makes EXACTLY ONE attempt and the linear backoff
+      below never runs.
+
+  A third topology WOULD fall inside the budget — a deferred read->write
+  upgrade raises an immediate `SQLITE_BUSY` that `busy_timeout` does not cover
+  — but it cannot occur here: every write transaction goes through
+  `Grappa.Repo.immediate_transaction/1`, statically enforced by
+  `Grappa.Repo.TransactionModeGateTest` (#1374).
+
+  The second regime is a DOCUMENTED LIMITATION rather than a wiring slip: one
+  number was dimensioned for one topology and later reused for another.
+  Re-dimensioning it changes retry behaviour under contention — #1420's
+  contested axis, and not this module's decision to take. What IS this
+  module's to take is to stop describing a bound it does not have, which is
+  why the terminal line below reports the wait it OBSERVED and never the
+  budget it was handed. Measured in
+  `Grappa.Repo.BusyRetryBudgetReachTest`; the options are priced in #1421.
   """
 
   require Logger
@@ -75,42 +108,43 @@ defmodule Grappa.Repo.BusyRetry do
           {:ok, result} | {:error, error | :db_unavailable}
         when result: var, error: var
   def run(op, opts) when is_function(op, 0) and is_list(opts) do
-    deadline = System.monotonic_time(:millisecond) + @budget_ms
-    loop(op, opts, deadline, 1)
+    # `started` rather than a precomputed deadline: the terminal line has to
+    # report the wall-clock it OBSERVED, and a deadline cannot say how far
+    # past itself the run went (#1421).
+    loop(op, opts, System.monotonic_time(:millisecond), 1)
   end
 
   @spec loop((-> {:ok, result} | {:error, error}), keyword(), integer(), pos_integer()) ::
           {:ok, result} | {:error, error | :db_unavailable}
         when result: var, error: var
-  defp loop(op, opts, deadline, attempt) do
+  defp loop(op, opts, started, attempt) do
     maybe_inject_fault()
     op.()
   rescue
     error in [DBConnection.ConnectionError, Exqlite.Error] ->
+      elapsed_ms = System.monotonic_time(:millisecond) - started
+
       cond do
         not transient_fault?(error) ->
           # Syntax / corruption — retrying spins pointlessly. Re-raise with
           # the original stacktrace so it surfaces as a loud 500, not a 503.
           reraise error, __STACKTRACE__
 
-        System.monotonic_time(:millisecond) < deadline ->
+        # Identical to the pre-#1421 `monotonic_time < started + @budget_ms`,
+        # rearranged so the same subtraction feeds the terminal line. Same
+        # arm, same boundary, no timing change.
+        elapsed_ms < @budget_ms ->
           on_contention(opts, fault_kind(error), attempt, false)
           # The backoff sleep runs after the failed checkout was already
           # released, so it holds no connection — bounded backpressure on the
           # flooding caller, not a held-conn leak (#340).
           Process.sleep(min(@backoff_ms * attempt, @backoff_cap_ms))
-          loop(op, opts, deadline, attempt + 1)
+          loop(op, opts, started, attempt + 1)
 
         true ->
           kind = fault_kind(error)
           on_contention(opts, kind, attempt, true)
-
-          Logger.warning(
-            "db write unavailable: #{observed_state(kind)} for the full " <>
-              "#{@budget_ms}ms retry budget (#{attempt} attempts) — returning :db_unavailable",
-            fault: kind
-          )
-
+          Logger.warning(terminal_message(kind, elapsed_ms, attempt), fault: kind)
           {:error, :db_unavailable}
       end
   end
@@ -129,6 +163,26 @@ defmodule Grappa.Repo.BusyRetry do
   @spec observed_state(fault_kind()) :: String.t()
   defp observed_state(:queue_timeout), do: "SQLite pool saturated"
   defp observed_state(:busy_locked), do: "SQLite write lock held by another writer"
+
+  # The same rule, applied to the NUMBER on that line (#1421). It used to read
+  # "for the full #{@budget_ms}ms retry budget", which is false in the regime
+  # that actually occurs: a `busy_locked` fault waits out SQLite's 30_000ms
+  # `busy_timeout` inside its FIRST attempt, so the line announced a 1500ms
+  # bound for a 30-second wait. The elapsed is the only figure the engine can
+  # vouch for; the budget stays on the line as context, not as the bound.
+  #
+  # 🔴 The #1429 census anchors on this prose, and its bats pins copy it
+  # VERBATIM. Both are anchored on the `observed_state/1` phrase ALONE, so this
+  # numeric tail can move again without blinding the counters — but a change to
+  # the two phrases above still has to move `scripts/log-gap-scan.awk` and
+  # `test/scripts/log_gap_scan_test.bats` in the SAME commit. A census whose
+  # pattern stopped matching reports zero, and zero is what a clean run looks
+  # like.
+  @spec terminal_message(fault_kind(), non_neg_integer(), pos_integer()) :: String.t()
+  defp terminal_message(kind, elapsed_ms, attempt) do
+    "db write unavailable: #{observed_state(kind)} for #{elapsed_ms}ms across " <>
+      "#{attempt} attempts (#{@budget_ms}ms retry budget) — returning :db_unavailable"
+  end
 
   # Invoke the caller's contention observer if one was supplied. Its return is
   # discarded — it is a side-channel (telemetry), not part of the retry result.

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -93,7 +93,12 @@ function count_signatures(line) {
     if (line ~ /db=3[0-9][0-9][0-9][0-9]\./) CNT["db30"]++
     if (line ~ /idle=3[0-9][0-9][0-9][0-9]\./) CNT["idle30"]++
     if (line ~ /scrollback row dropped/) CNT["dropped"]++
-    if (line ~ /saturated for the full/) CNT["saturated"]++
+    # #1421 — anchored on the `observed_state/1` phrase ALONE, no longer on
+    # the numeric tail it used to share with `for the full 1500ms retry
+    # budget`. That tail now carries the OBSERVED elapsed and will move again;
+    # the phrase that names the topology is the stable half, and it is the
+    # half this counter is about.
+    if (line ~ /SQLite pool saturated/) CNT["saturated"]++
 
     # `index` before the three regexes: every lock signature carries the
     # literal "lock", and the stream is ~10^6 lines. The known-answer
@@ -198,11 +203,11 @@ BEGIN {
     sig("idle30", "client #PID<0.700.0> checked out, idle=30062.4ms")
     sig("dropped", "scrollback row dropped for #bofh: :persist_unavailable")
     sig("saturated", \
-        "db write unavailable: SQLite pool saturated for the full 1500ms retry budget" \
-        " (3 attempts) — returning :db_unavailable")
+        "db write unavailable: SQLite pool saturated for 1512ms across 14 attempts" \
+        " (1500ms retry budget) — returning :db_unavailable")
     sig("lockheld", \
-        "db write unavailable: SQLite write lock held by another writer for the full" \
-        " 1500ms retry budget (1 attempts) — returning :db_unavailable")
+        "db write unavailable: SQLite write lock held by another writer for 30067ms" \
+        " across 1 attempts (1500ms retry budget) — returning :db_unavailable")
     sig("lockstall", \
         "db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2" \
         " waiter(s) queued — holder at :gen_server.loop/7, stack: …")

--- a/test/grappa/repo/busy_retry_budget_reach_test.exs
+++ b/test/grappa/repo/busy_retry_budget_reach_test.exs
@@ -1,0 +1,181 @@
+defmodule Grappa.Repo.BusyRetryBudgetReachTest do
+  @moduledoc """
+  #1421 — how far the `Grappa.Repo.BusyRetry` retry BUDGET actually reaches,
+  measured against a REAL driver `SQLITE_BUSY` rather than a hand-built one.
+
+  ## Why the engine's own suite could not see this
+
+  Every other retry test raises a `%Exqlite.Error{}` WE build, from a
+  zero-cost closure. The fault is therefore FREE, and the budget is the only
+  thing bounding the loop — which is exactly the regime in which the budget
+  looks like it works. Reality charges for the fault: a contending write sits
+  inside SQLite's `busy_timeout` before it raises at all.
+
+  The budget is a deadline consulted BETWEEN attempts (`busy_retry.ex`, the
+  `System.monotonic_time(:millisecond) < deadline` arm), so it cannot preempt
+  an attempt that is already running. Whichever of the two numbers is larger
+  decides how many attempts there are — and nothing in the engine can change
+  that, because the engine does not own the wait.
+
+  ## What this file measures
+
+  The SAME engine and the SAME budget, varying ONLY `busy_timeout`, over a
+  real write-lock contention on a private temp repo (the `pool_size: 1`
+  Sandbox cannot contend with itself, which is why the injection seam exists
+  in the first place):
+
+    * `busy_timeout` ABOVE the budget → exactly ONE attempt. Production runs
+      `30_000` against `1_500`, a ratio of 20; this runs 2, and the collapse
+      is a property of the ratio, not of the magnitudes.
+    * `busy_timeout` BELOW the budget → many attempts. This is the regime the
+      budget was dimensioned for (#340, `config/config.exs`: *"comfortably
+      longer than the ~1s pool-saturation window the #336 incident
+      measured"*) — a pool `queue_timeout`, whose drop latency DBConnection
+      caps near `queue_target` (50 ms doubled to 100 ms by default).
+
+  Tests 1 and 2 are a MEASUREMENT of the status quo and pass on unmodified
+  main; they are load-bearing because a mutation of the deadline arm turns
+  them red, not because they started red. Test 3 is the one that starts red:
+  the terminal line reports the budget it was told instead of the wait it
+  observed.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.Repo.BusyRetry
+
+  defmodule TmpRepo do
+    use Ecto.Repo, otp_app: :grappa, adapter: Ecto.Adapters.SQLite3
+  end
+
+  # The very number the engine compiled itself with — never a literal here, or
+  # the bench and the engine can drift apart while both stay green.
+  @budget_ms Application.compile_env(:grappa, [:busy_retry, :budget_ms], 1_500)
+
+  # Runs one genuinely contended write through the engine and reports what was
+  # OBSERVED: the engine's return, the fault kind, the terminal attempt count,
+  # the caller's own wall-clock, and the log it emitted. `busy_timeout` is the
+  # single independent variable.
+  defp measure_contended_write(busy_timeout) do
+    path =
+      Path.join(System.tmp_dir!(), "busy_retry_budget_#{System.unique_integer([:positive])}.db")
+
+    on_exit(fn -> Enum.each(["", "-wal", "-shm"], &File.rm(path <> &1)) end)
+
+    {:ok, repo} =
+      TmpRepo.start_link(
+        database: path,
+        pool_size: 1,
+        busy_timeout: busy_timeout,
+        journal_mode: :wal
+      )
+
+    TmpRepo.query!("CREATE TABLE t(id integer)")
+
+    # A SEPARATE raw connection holds the file write-lock for the WHOLE
+    # measurement, so every attempt the engine makes genuinely contends. Its
+    # own busy_timeout is 0 so setting up the hold can never itself wait.
+    {:ok, holder} = Exqlite.Sqlite3.open(path)
+    :ok = Exqlite.Sqlite3.execute(holder, "PRAGMA busy_timeout=0")
+    :ok = Exqlite.Sqlite3.execute(holder, "BEGIN IMMEDIATE")
+    :ok = Exqlite.Sqlite3.execute(holder, "INSERT INTO t VALUES (1)")
+
+    {:ok, seen} = Agent.start_link(fn -> [] end)
+
+    started = System.monotonic_time(:millisecond)
+
+    {result, log} =
+      with_log(fn ->
+        BusyRetry.run(fn -> {:ok, TmpRepo.query!("INSERT INTO t VALUES (2)")} end,
+          on_contention: fn kind, attempt, terminal? ->
+            Agent.update(seen, &[{kind, attempt, terminal?} | &1])
+          end
+        )
+      end)
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started
+    events = Agent.get(seen, &Enum.reverse(&1))
+
+    # Teardown BEFORE any assertion runs, so a red leaves no repo and no held
+    # write-lock behind for the next test in this serial file.
+    :ok = Exqlite.Sqlite3.close(holder)
+    Supervisor.stop(repo)
+
+    {kind, terminal_attempt, true} = List.last(events)
+
+    %{result: result, kind: kind, attempts: terminal_attempt, elapsed_ms: elapsed_ms, log: log}
+  end
+
+  # The terminal line, isolated from whatever else Logger carried during the
+  # capture.
+  defp terminal_line(log) do
+    log |> String.split("\n") |> Enum.find("", &(&1 =~ "db write unavailable"))
+  end
+
+  # The wall-clock the terminal line CLAIMS, read back out of the line itself.
+  # `nil` when it claims none — which is the state test 3 starts in.
+  defp reported_wait_ms(log) do
+    case Regex.run(~r/db write unavailable:.* for (\d+)ms/, terminal_line(log)) do
+      [_, ms] -> String.to_integer(ms)
+      nil -> nil
+    end
+  end
+
+  describe "the budget's reach against a REAL write-lock contention" do
+    test "a busy_timeout ABOVE the budget collapses the loop to exactly ONE attempt" do
+      busy_timeout = @budget_ms * 2
+
+      observed = measure_contended_write(busy_timeout)
+
+      assert observed.result == {:error, :db_unavailable}
+      assert observed.kind == :busy_locked
+
+      # THE defect #1421 names: at this ratio the linear backoff and every
+      # attempt after the first are unreachable BY CONSTRUCTION.
+      assert observed.attempts == 1
+
+      # ...and the caller waited the busy_timeout, not the budget it was told.
+      assert observed.elapsed_ms >= busy_timeout
+    end
+
+    test "a busy_timeout BELOW the budget makes the retry loop reachable — many attempts" do
+      # The positive control for the loop itself: same engine, same budget,
+      # only the fault got cheap. If THIS one collapsed to a single attempt
+      # too, the finding above would be about the engine and not about the
+      # relationship between the two numbers.
+      observed = measure_contended_write(0)
+
+      assert observed.result == {:error, :db_unavailable}
+      assert observed.kind == :busy_locked
+      assert observed.attempts > 1
+      assert observed.elapsed_ms >= @budget_ms
+    end
+  end
+
+  describe "the terminal line reports the wait it OBSERVED (CLAUDE.md log honesty)" do
+    test "it names the elapsed wall-clock, never a budget that did not bound it" do
+      busy_timeout = @budget_ms * 2
+
+      observed = measure_contended_write(busy_timeout)
+      line = terminal_line(observed.log)
+
+      # The premise of the assertion below: this IS the one-attempt regime.
+      assert observed.attempts == 1
+
+      # The line must carry the wait that happened. `is_integer/1` FIRST and
+      # separately: Elixir's term order puts every atom above every number, so
+      # a `nil >= 600` from a line with no elapsed at all is `true` and the
+      # comparison alone passes vacuously. Measured — the first red run of
+      # this file failed only on the refute below, with `reported_wait_ms/1`
+      # returning nil.
+      reported = reported_wait_ms(observed.log)
+      assert is_integer(reported), "the terminal line carries no elapsed at all: #{line}"
+      assert reported >= busy_timeout
+
+      # ...and must not go on claiming the budget was what ran out, when the
+      # budget was overshot by the first attempt on its own.
+      refute line =~ "for the full #{@budget_ms}ms retry budget"
+    end
+  end
+end

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -27,8 +27,8 @@ setup() {
     #   busy_retry.ex — the two terminal arms, one per fault kind
     LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
-    LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for the full 1500ms retry budget (1 attempts) — returning :db_unavailable'
-    SATURATED_LINE='db write unavailable: SQLite pool saturated for the full 1500ms retry budget (3 attempts) — returning :db_unavailable'
+    LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for 30067ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
+    SATURATED_LINE='db write unavailable: SQLite pool saturated for 1512ms across 14 attempts (1500ms retry budget) — returning :db_unavailable'
 }
 
 # The scanner as integration.sh invokes it: a service label and a
@@ -89,7 +89,7 @@ stamp() {
         stamp '12:00:00.' 'db=30064.1ms query returned'
         stamp '12:00:01.' 'conn idle=30062.4ms checked out'
         stamp '12:00:02.' 'scrollback row dropped for #bofh'
-        stamp '12:00:03.' 'pool saturated for the full 30s'
+        stamp '12:00:03.' "$SATURATED_LINE"
         stamp '12:00:04.' "$LOCKHELD_LINE"
         stamp '12:00:05.' "$LOCKSTALL_LINE"
         stamp '12:00:06.' "$LOCKRESOLVED_LINE"
@@ -158,6 +158,22 @@ stamp() {
     out="$( stamp '12:00:00.' "$SATURATED_LINE" | scan 10 )"
     grep -q 'saturated=1' <<<"$out"
     grep -q 'lockheld=0' <<<"$out"
+}
+
+@test "both terminal counters survive a change to the line's numeric tail" {
+    # #1421 moved that tail: it used to read "for the full 1500ms retry
+    # budget" and now carries the OBSERVED elapsed, which varies per event.
+    # The anchors are the `observed_state/1` phrases alone precisely so the
+    # next number that moves does not blind the census — a pattern that
+    # stopped matching reports zero, and zero is what a clean run looks like.
+    local out
+    out="$( {
+        stamp '12:00:00.' 'db write unavailable: SQLite pool saturated for 9ms across 2 attempts (7ms retry budget) — returning :db_unavailable'
+        stamp '12:00:01.' 'db write unavailable: SQLite write lock held by another writer for 123456ms across 3 attempts (7ms retry budget) — returning :db_unavailable'
+    } | scan 10 )"
+
+    grep -q 'saturated=1' <<<"$out"
+    grep -q 'lockheld=1' <<<"$out"
 }
 
 # --- the scanner's own controls -------------------------------------------


### PR DESCRIPTION
Closes the half of #1421 that can be closed without touching #1420's
contested axis. A + B of the option table posted on the issue; **C / D / E / H
are deliberately NOT taken** — they change retry behaviour under contention,
which is vjt's ruling to make.

## The defect

`BusyRetry`'s terminal warning read `for the full 1500ms retry budget
(1 attempts)` after waiting 30 067 ms. CLAUDE.md's log-honesty rule says a line
describes the state it OBSERVED, and #1420 had just corrected this same line
for the same reason — so this is a bugfix, not a tuning change.

**Why the number was wrong.** The budget is a deadline consulted BETWEEN
attempts: it cannot preempt an attempt already running, because the engine does
not own the wait. A `busy_locked` fault raises only once SQLite's `busy_timeout`
(30 000 ms) has expired — 20× the budget — so the first attempt has already
overshot the deadline when it returns, and the loop makes exactly one attempt.
The budget was dimensioned in #340 against the POOL topology (`config.exs`: *"the
~1s pool-saturation window the #336 incident measured"*), where DBConnection
drops a checkout near `queue_target` and the retries are real. One number, two
topologies — not a wiring slip.

## What changed

- `run/2` carries `started` instead of a precomputed deadline;
  `elapsed_ms < @budget_ms` replaces `monotonic_time < deadline` — the same arm
  at the same boundary, rearranged so one subtraction feeds the line.
  **Zero behaviour moves**: same retry, same `{:error, :db_unavailable}`, same
  `fault:` metadata, **0 of the 71** wrapped call sites touched.
- The moduledoc now states how far the budget reaches, per topology, and that
  the lock regime is a documented limitation rather than a slip.
- `docs/OPERATIONS.md`: how an operator reads the two numbers together.

## The census moved in LOCKSTEP — the trap this PR had to close

`scripts/log-gap-scan.awk` counted `saturated` on `/saturated for the full/`,
the numeric tail this PR rewrites. Left alone it would have reported **zero**,
and zero is what a clean run looks like: that census is the attribution
instrument for red e2e runs (#1429), so blinding it costs the next reader a
measurement they believe they took.

Both terminal counters now anchor on the `observed_state/1` phrase **alone** —
the half that names the topology and carries no numbers. The scanner's
known-answer samples and the two verbatim bats pins move in the same commit,
plus a new bats case feeding both lines with a **different** numeric tail, so
the decoupling is asserted rather than asserted-about.

## Evidence

The new bench provokes a **real driver `SQLITE_BUSY`** against a held write
lock, instead of the hand-built zero-cost fault every other retry test raises —
which is exactly why the engine's own suite could not see this: with a free
fault the budget IS the only bound, the one regime in which it appears to work.

Red read before green, on unmodified `origin/main` code:

```
db write unavailable: SQLite write lock held by another writer
for the full 300ms retry budget (1 attempts)      <- after a ~600ms wait
```

Two-sided, by mutation of the deadline arm:

| mutant | kills |
|---|---|
| `attempt < 3` | `attempts == 1`, and `elapsed >= budget` with **left = 9 ms** |
| `false` | **only** `attempts > 1` — one mutant, one assertion |

The second is the proof that the *budget* — not an attempt counter — is what
holds the loop for its window: without it the elapsed collapses to 9 ms.

Local gates on the pre-rebase tree: `mix ci.check` + `gen_wire_types --check` +
the full bats set, exit 0 (`_lib.sh` is `set -euo pipefail` and every `ci.check`
step is a halting `mix cmd`, so the bats stage is only reachable on a zero
exit). `test/grappa/repo/` 27/27; `log_gap_scan_test.bats` 19/19.

**Named gap:** those gates ran on `0ea9177c`; this branch is now rebased onto
`fa2308b9`, which touches only `cicchetto/src/lib/api.ts` and
`docs/DESIGN_NOTES.md` — no overlap with anything here except the union-merged
decision log, whose contribution was pinned and re-compared across the rebase
(+138 −0, unchanged; preceding entry byte-identical).