### PR TITLE
deploy(#1601): compile on the Docker hot path, before the reload

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53049,3 +53049,104 @@ gates.
 The two historical mentions of these names elsewhere in this file
 (`AdminLiveState`, `AdminVisitorLiveState`) are left untouched: the log
 records what was true when it was written.
+<!-- entry #1601 -->
+
+---
+
+## 2026-08-20 — #1601: the Docker hot deploy declared a landing it never compiled
+
+`POST /admin/reload` LOADS beams; it does not make them.
+`Grappa.HotReload.reload_modified/0` md5-walks the app's ebin and reloads what
+changed on disk. On the Docker substrate nothing on the hot path wrote that
+ebin: `substrate_build` opened with `[ "$MODE" = cold ] || return 0` and the
+comment *"the pulled commit is already in the bind-mounted source tree"* —
+true of the SOURCES, silent about the BEAMS. So the reload found the previous
+commit's modules unchanged, answered `reloaded: []` **honestly**, and the
+deploy declared success over code that was never loaded. Measured on staging:
+a manual reload immediately after the ✓ banner found two modules, and the two
+idempotent reloads after that found none — the control that proves the
+deploy's own reload had not loaded them.
+
+### Every step was individually honest; the sum was not
+
+| step | declares | observes |
+|---|---|---|
+| `substrate_build` | "no build needed" | nothing |
+| `substrate_reload` | proceeds on `"failed":[]` | only `failed`; `reloaded` is in the response, logged and never read |
+| `substrate_healthcheck` | "healthy" | a 200 on `/healthz` that the OLD code returns identically |
+| `substrate_write_marker` | "this sha is deployed" | nothing; it writes `NEW_SHA` unconditionally |
+| `done_banner` | "✓ hot-deploy complete" | the sum of the above |
+
+Not one of those lines is a lie on its own. Together they declare "the new
+commit is live" while observing "the old process is up and nothing failed to
+load". That gap is the `Log honesty` rule at deploy scale: **a gate that
+never ran the step cannot report on it, and reporting green anyway is the
+defect** — vjt's "a documented limitation is an acceptable outcome" does not
+extend to a gate that declares a verdict it did not measure.
+
+### The cure ends an exception rather than adding a mechanism
+
+`infra/freebsd/deploy.sh` and `infra/linux/deploy.sh` already build on BOTH
+paths and state the reason: the build *"writes the fresh .beam into the
+daemon's code path that the hot reload POST then loads"*. Docker was the only
+substrate out of line, so the fix is a hot arm in its `substrate_build`, not a
+new step in the shared algorithm.
+
+Placement costs nothing: `deploy_common.sh` calls `substrate_build` **before**
+the hot/cold branch, so a compile there precedes `substrate_reload` by
+construction. Three consequences worth pinning:
+
+- **No `deps.get` beside it.** `mix.lock`/`mix.exs` are COLD triggers
+  (`Preflight.mix_deps?/1`), so a hot deploy cannot bring deps the box has not
+  already fetched. A `deps.get` here would be dead weight on every hot deploy.
+- **`--warnings-as-errors`, matching both release substrates.** Under the
+  consumers' `set -euo pipefail` a failed compile aborts *before* the reload.
+  That is the point of the step: reloading over a tree that would not compile
+  is the same defect with extra ceremony.
+- **Classification is untouched.** `Preflight.classify/5` still decides WHEN a
+  change is hot. This changes what the hot path DOES, never what counts as hot.
+
+### Rejected: re-run the reload after the seed
+
+The issue offered a second shape. `mix grappa.seed_themes` is the one hot-path
+step that compiles today — by accident, as a side effect of being a mix task —
+and `_deploy_hot` runs it AFTER the reload for a documented reason (post-#41
+the reload applies expand migrations, so an earlier seed would meet the
+pre-migration schema). Reloading a second time after it would promote that
+accident into the build step and pay two reloads where one suffices. The
+ordering comment stays correct; what was missing was a compile ahead of it.
+
+### What the test pins, and what it deliberately does not
+
+`test/scripts/deploy_reload_verify_test.bats` already drives `deploy.sh
+--force-hot` against a throwaway clone with `docker` stubbed on PATH, logging
+every argv. The new case asserts a `mix compile` exists in that log **and that
+its line precedes `admin/reload`** — ordering, not presence, because a compile
+after the reload is exactly what the seed already did.
+
+It does NOT assert a non-empty `reloaded` list. A doc-only hot deploy
+legitimately reloads nothing, and pinning that would encode a coincidence; the
+first case in the file already pins the `reloaded: []` shape as valid.
+
+Two mutants, one assertion each, both measured: reinstating `return 0` on the
+hot arm fails the presence assert; moving the compile into `substrate_seed`
+(present, but after the reload) fails the ordering assert and nothing else.
+The second mutant is not optional — the first red never reaches the ordering
+line, so without it that assertion would have shipped unexercised.
+
+### Read from the code, not reproduced
+
+`_deploy_nothing_to_do` exits 0 when `PREV_SHA == NEW_SHA` and `LAST_DEPLOYED
+== NEW_SHA` in auto mode. The marker carries the new sha whether or not
+anything loaded, so an operator who re-runs the deploy to remedy the stale box
+is told "nothing to do". The issue's "self-healing by accident, converges one
+commit later" therefore holds only when a NEW commit arrives — not by
+retrying. Stated as read from `deploy_common.sh`, not reproduced on a box.
+
+### Spun off, not folded in
+
+The same deploy session surfaced a second `Log honesty` fault: the pull's
+`die` reports "the branch diverged" for a refusal it never observed (a
+`branch.<name>.rebase` config turns `git pull --ff-only` into a rebase pull,
+which refuses on any unstaged change with no divergence in sight). Different
+fault, different cure, so it is **#1603** rather than scope creep here.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -637,7 +637,8 @@ on it.
 
 **`.env` and `MIX_ENV` are established for BOTH paths, in
 `establish_deploy_env` (#1377).** They used to live inside
-`substrate_build`, which returns early on hot — so a hot deploy reached
+`substrate_build`, which returned early on hot back then (#1601 has since
+given that hook a hot arm of its own) — so a hot deploy reached
 the theme seed with no `MIX_ENV` in the shell, compose fell back to
 `.env` for the interpolation, and `.env.example` ships `MIX_ENV=dev`:
 cold seeded `grappa_prod.db`, hot seeded `grappa_dev.db` on the same
@@ -647,9 +648,16 @@ flag still reads as a usage error) and before the first side effect.
 Consequence for operators: a box with no `.env` now fails the same way
 on hot as it always did on cold.
 
-**Hot deploys are the normal case.** `git pull` plus `POST
-/admin/reload` swaps modules in the live BEAM with no restart, and
-sessions (`Session.Server`, `IRC.Client`) keep their state. What cannot
+**Hot deploys are the normal case.** `git pull`, then `mix compile`,
+then `POST /admin/reload` swaps modules in the live BEAM with no
+restart, and sessions (`Session.Server`, `IRC.Client`) keep their state.
+**The compile is not optional and not an optimisation (#1601):** the
+reload endpoint only LOADS — it md5-walks the app's ebin — so with
+nothing compiled it answers `reloaded: []` truthfully and the deploy
+declares success over the previous commit's modules. The bind-mount
+puts the pulled SOURCES in the container; it does not put BEAMS in the
+ebin. The jail and systemd substrates have always built on both paths
+for the same reason. What cannot
 be hot-swapped is a change to module *shape* — `mix.lock`/`mix.exs`,
 the `application.ex` supervision tree, a long-lived GenServer's state
 shape — because the reload is accepted and the new code then crashes at

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -164,13 +164,47 @@ substrate_preflight() {
 }
 
 substrate_build() {
-	# Hot path needs no build — the pulled commit is already in the
-	# bind-mounted source tree (compose.yaml mounts ./:/app). Cold path
-	# rebuilds the toolchain image.
-	[ "$MODE" = cold ] || return 0
+	# BOTH paths must leave fresh .beam in the code path the app boots from
+	# — the same requirement infra/freebsd/deploy.sh and
+	# infra/linux/deploy.sh state for their releases: the build "writes the
+	# fresh .beam into the daemon's code path that the hot reload POST then
+	# loads". POST /admin/reload only LOADS: Grappa.HotReload.reload_modified/0
+	# md5-walks the app's ebin and compiles nothing.
+	#
+	# Nothing on THIS substrate's hot path used to write that ebin, so the
+	# reload honestly answered `reloaded: []` over the PREVIOUS commit's
+	# modules while the banner, the exit code and the completed-deploy marker
+	# all reported success, and the box converged one commit late (#1601).
+	# "The pulled commit is already in the bind-mounted source tree" — the
+	# claim that used to sit here behind a `[ "$MODE" = cold ] || return 0` —
+	# is true of the SOURCES and says nothing about the BEAMS.
+	if [ "$MODE" = cold ]; then
+		# The image is toolchain-only; the beams come from the recreated
+		# container's own `mix phx.server` boot compile, which is why the
+		# cold healthcheck loop is the patient one.
+		echo "Building grappa image..."
+		"${DOCKER_COMPOSE[@]}" --profile prod build grappa
+		return 0
+	fi
 
-	echo "Building grappa image..."
-	"${DOCKER_COMPOSE[@]}" --profile prod build grappa
+	# Hot: a oneshot compiles into the same bind-mounted
+	# `_build/$MIX_ENV/lib/grappa/ebin` the live container booted from, which
+	# is exactly the ebin the reload then walks. Not a new mechanism — `mix
+	# grappa.seed_themes` was already compiling that ebin as a side effect,
+	# one step too LATE (deploy_common.sh `_deploy_hot`: reload, THEN seed).
+	# Doing it here puts it before `substrate_reload`, which deploy_common.sh
+	# guarantees by calling substrate_build ahead of the mode branch.
+	#
+	# No deps.get beside it: `mix.lock`/`mix.exs` are COLD triggers
+	# (Grappa.Deploy.Preflight `mix_deps?/1`), so a hot deploy cannot bring
+	# deps the box has not already fetched. --warnings-as-errors matches both
+	# release substrates, and under the consumers' `set -euo pipefail` a
+	# failed compile aborts BEFORE the reload — which is the point of the
+	# step: reloading over a tree that would not compile is the same defect
+	# with extra steps.
+	echo "Compiling the pulled commit (the reload only LOADS beams)..."
+	"${DOCKER_COMPOSE[@]}" --profile prod run --rm --no-deps grappa \
+		mix compile --warnings-as-errors
 }
 
 substrate_reload() {

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -135,6 +135,33 @@ run_hot() {
     refute grep -q 'healthz' "$ARGV_LOG"
 }
 
+@test "the hot path COMPILES before it reloads, or the reload loads stale beams (#1601)" {
+    # The Docker hot path skipped the build entirely — "the pulled commit is
+    # already in the bind-mounted source tree" is true of the SOURCES and
+    # false of the BEAMS. POST /admin/reload only LOADS: it md5-walks the
+    # app's ebin. With nothing compiled, it honestly answers `reloaded: []`
+    # and the deploy declares success over the previous commit's modules.
+    #
+    # The freebsd and linux substrates already compile on BOTH paths, and
+    # say why: "it writes the fresh .beam into the daemon's code path that
+    # the hot reload POST then loads". This is that, for docker.
+    #
+    # Ordering, not mere presence: a compile AFTER the reload is what the
+    # seed step already does by accident, and it is what left the box one
+    # commit late.
+    export RELOAD_RESPONSE='{"reloaded":[],"failed":[]}'
+    export HEALTHZ_RC=0
+
+    run_hot
+    [ "$status" -eq 0 ]
+
+    grep -q 'mix compile' "$ARGV_LOG"
+
+    compile_line=$(grep -n 'mix compile' "$ARGV_LOG" | head -1 | cut -d: -f1)
+    reload_line=$(grep -n 'admin/reload' "$ARGV_LOG" | head -1 | cut -d: -f1)
+    [ "$compile_line" -lt "$reload_line" ]
+}
+
 @test "reload ok but healthcheck never returns 200 FAILS the deploy" {
     export RELOAD_RESPONSE='{"reloaded":[],"failed":[]}'
     export HEALTHZ_RC=1


### PR DESCRIPTION
On the Docker substrate a hot deploy landed the new code **one deploy late**, while the banner, the
exit code and the completed-deploy marker all reported success.

`POST /admin/reload` only **loads** beams — `Grappa.HotReload.reload_modified/0` md5-walks the app's
ebin and compiles nothing. Nothing on this substrate's hot path wrote that ebin:

```sh
# infra/lib/deploy_docker.sh — substrate_build(), before this PR
# Hot path needs no build — the pulled commit is already in the
# bind-mounted source tree (compose.yaml mounts ./:/app).
[ "$MODE" = cold ] || return 0
```

That claim is true of the **sources** and says nothing about the **beams**. So the reload found the
previous commit's modules unchanged, answered `reloaded: []` honestly, and the deploy declared
success over code that had never been loaded.

## Every step was individually honest; the sum was not

| step | declares | observes |
|---|---|---|
| `substrate_build` | "no build needed" | nothing |
| `substrate_reload` | proceeds on `"failed":[]` | only `failed` — `reloaded` is in the response, logged and never read (verified: zero read sites across the five deploy consumers) |
| `substrate_healthcheck` | "healthy" | a 200 on `/healthz` that the OLD code returns identically |
| `substrate_write_marker` | "this sha is deployed" | nothing; it writes `NEW_SHA` unconditionally |
| `done_banner` | "✓ hot-deploy complete" | the sum of the above |

Not one line is a lie on its own. Together they declare "the new commit is live" while observing
"the old process is up and nothing failed to load". That is the `Log honesty` rule at deploy scale.

## The cure ends an exception rather than adding a mechanism

`infra/freebsd/deploy.sh` and `infra/linux/deploy.sh` already build on **both** paths and state the
reason: the build *"writes the fresh .beam into the daemon's code path that the hot reload POST then
loads"*. Docker was the only substrate out of line, so this adds a hot arm to its `substrate_build`
rather than a step to the shared algorithm.

Placement is free: `deploy_common.sh` calls `substrate_build` **before** the hot/cold branch, so a
compile there precedes `substrate_reload` by construction.

- **No `deps.get` beside it.** `mix.lock`/`mix.exs` are COLD triggers (`Preflight.mix_deps?/1`), so a
  hot deploy cannot bring deps the box has not already fetched.
- **`--warnings-as-errors`, matching both release substrates.** Under the consumers'
  `set -euo pipefail` a failed compile aborts *before* the reload — the point of the step.
- **Classification is untouched.** `Preflight.classify/5` still decides WHEN a change is hot; this
  changes what the hot path DOES.

**Rejected:** re-running the reload after the seed. `mix grappa.seed_themes` is the one hot-path step
that compiles today — by accident, as a side effect of being a mix task — and `_deploy_hot` runs it
after the reload for a documented reason (post-#41 the reload applies expand migrations, so an
earlier seed would meet the pre-migration schema). That shape would promote an accident into the
build step and pay two reloads where one suffices.

## Blast radius, checked across all three hook sets

`infra/lib/deploy_docker.sh` is shared by two entry points since #1384, and a third mode declares its
own hooks:

| consumer | gets the compile? | right? |
|---|---|---|
| `scripts/deploy.sh` (operator door) | yes | yes — checkout with bind-mounted sources |
| `infra/docker/deploy.sh update` → `cmd_update()` | yes, by sourcing the same hook set | yes — same substrate, same defect |
| `infra/docker/deploy.sh` → `cmd_update_release()` | no — declares `substrate_build() { :; }` inside the function and forces cold | yes — a checkout-less box has no sources to compile |

## Evidence

**Red first, and load-bearing by mutation.** The new case asserts a `mix compile` exists in the
stubbed argv log **and that its line precedes `admin/reload`** — ordering, not presence.

| mutant | expected victim | measured |
|---|---|---|
| reinstate `[ "$MODE" = cold ] \|\| return 0` on the hot arm | the presence assert | `not ok`, line 158 |
| move the compile into `substrate_seed` (present, but after the reload) | the ordering assert | `not ok`, line 162 |

The second mutant is not optional: the first red never reaches the ordering line, so without it that
assertion would have shipped unexercised.

The assert is not vacuous — no other argv in the fixture contains `mix compile` (the preflight is
`run --no-start`, the seed is `mix grappa.seed_themes`), and the pre-cure red proves the grep found
nothing.

It deliberately does **not** assert a non-empty `reloaded` list: a doc-only hot deploy legitimately
reloads nothing, and the first case in the file already pins that shape as valid.

**Gates.** `scripts/bats.sh` full: `1..589`, 589 ok, 0 failures. `scripts/shellcheck.sh`: clean over
77 derived scripts, with a positive control (an SC2086 injected into the new hot arm turned it red
and named the file and line, proving the linter reads this worktree's bytes and not the shared main
checkout's). `scripts/posix-parse.sh`: clean, but **vacuous for this change** —
`infra/lib/deploy_docker.sh` declares `shell=bash` and is not in that gate's derived set.
`scripts/check.sh`: `rc=0`. Both stages are evidenced rather than assumed — the upstream
`mix ci.check` left Credo, Sobelow, Dialyzer, doctor and `8 doctests, 61 properties, 6569 tests, 0
failures` in the log, and the bats stage printed its plan line `1..589` with 589 ok and zero
failures. The plan line matters: `check.sh` inherits `set -euo pipefail` from `scripts/_lib.sh`, so a
halting `ci.check` would mean bats never started and "zero failures" would read as "not measured".


## Declined, and named rather than omitted

- **The cold path is left alone.** Its beams still come from the recreated container's own
  `mix phx.server` boot compile, so a compile failure there surfaces as a crash loop plus a
  healthcheck timeout rather than an immediate abort. Pre-existing, and outside this issue: cold
  demonstrably lands (the `v1.3.0-rc1` cut used `--force-cold`).
- **No second test on the standalone door.** #1384 made the two hook sets one function, so a
  duplicate case would exercise the same code twice. The cost, stated: if the hook sets are ever
  re-split, this single test will not catch the second door regressing.
- **Read from the code, not reproduced:** `_deploy_nothing_to_do` exits 0 when
  `PREV_SHA == NEW_SHA` and `LAST_DEPLOYED == NEW_SHA`. The marker carries the new sha whether or not
  anything loaded, so an operator who *re-runs* the deploy to remedy a stale box is told "nothing to
  do". The issue's "self-healing by accident" therefore holds only when a NEW commit arrives, not by
  retrying. No box was available to reproduce this.

## Spun off

The same deploy session surfaced a second `Log honesty` fault — the pull's `die` reports "the branch
diverged" for a refusal it never observed. Different fault, different cure: filed as #1603 rather
than widened into this PR.

Refs #1601.
