### PR TITLE
union(#1571 #1473 #1421 #1601): four disjoint slices on one base, gated together

### DIFF
--- a/cicchetto/scripts/check.ts
+++ b/cicchetto/scripts/check.ts
@@ -34,6 +34,14 @@
 type Stage = { readonly name: string; readonly argv: readonly string[] };
 
 const STAGES: readonly Stage[] = [
+  // First, and cheap: it says whether the three stages below are attributable
+  // at all. #1571 measured a `node_modules` whose biome was three minor
+  // versions off `bun.lock`, and nothing in the tree compared the two — the
+  // only freshness test any script applied was `scripts/bun.sh`'s
+  // `needs_install`, which asks whether the directory is EMPTY. It does not
+  // short-circuit the rest: a stale toolchain and a real type error are
+  // separate facts and #1469's whole point is reporting the union.
+  { name: "lock drift (node_modules vs bun.lock)", argv: ["bun", "scripts/lock-drift.ts"] },
   { name: "biome (src + e2e)", argv: ["biome", "check", "--max-diagnostics=none"] },
   { name: "tsc (src)", argv: ["tsc", "--noEmit"] },
   { name: "tsc (e2e)", argv: ["tsc", "--noEmit", "-p", "e2e/tsconfig.json"] },

--- a/cicchetto/scripts/lock-drift-core.ts
+++ b/cicchetto/scripts/lock-drift-core.ts
@@ -1,0 +1,288 @@
+// #1571 — is what is INSTALLED what `bun.lock` pins?
+//
+// The pure half: no filesystem, no Bun API, no imports. `lock-drift.ts` does
+// the IO and calls in here; `src/__tests__/lockDrift.test.ts` exercises both
+// sides of every rule. Keeping it importable from `src` is also what puts it
+// under `tsc --noEmit` — `cicchetto/scripts/` is outside both the tsconfig
+// `include` and biome's `files.includes`, so a runner-only module would be
+// checked by nothing.
+//
+// WHY THIS EXISTS. A gate verdict is only attributable if the tools that
+// produced it are the ones the lockfile names. #1571 measured a checkout whose
+// biome was three minor versions off the lock, and the failure mode is
+// two-sided: a rule that only fires on the newer version passes locally and
+// fails in CI, and a rule that only fires on the older one fails locally
+// against code CI would accept. Nothing in the tree compared the two — the
+// only freshness test any script applied was `scripts/bun.sh`'s
+// `needs_install`, which asks whether `node_modules` is EMPTY. A populated but
+// stale tree answered "installed" and was never reconciled, and the documented
+// worktree procedure (`cp -Rc` the tree from the main checkout) copied
+// whatever was there into every new worktree.
+//
+// WHY THE COMPARISON IS SCOPED TO THE EXECUTING PLATFORM. Tools like biome and
+// rolldown ship as a JS wrapper plus one binary package per platform
+// (`@biomejs/cli-darwin-arm64`, `@rolldown/binding-linux-arm64-gnu`, …), and
+// `bun install` only ever resolves the optional dependency matching the
+// platform it runs on. Every gate in this repo runs `bun` inside a linux
+// container (`scripts/bun.sh`), so the darwin binaries in a macOS developer's
+// tree cannot be refreshed by any path the project uses — measured on
+// 2026-08-20: `@biomejs/cli-darwin-arm64` at 2.4.13 against a lock pinning
+// 2.5.8, its directory dated three months before its linux siblings. Comparing
+// those would make the gate red on something no gate executes and no
+// documented command can fix. So the question this asks is narrower and
+// truthful: does what will RUN HERE match the lock. The stale foreign-platform
+// binaries are a documented limitation, recorded in docs/TESTING.md.
+
+/** npm `os` / `cpu` fields: a list of allowed values, or `!value` exclusions. */
+export type PlatformConstraint = readonly string[] | null;
+
+export type InstalledPackage = {
+  readonly name: string;
+  readonly version: string;
+  readonly os: PlatformConstraint;
+  readonly cpu: PlatformConstraint;
+};
+
+/** `process.platform` / `process.arch` of whoever is running the gate. */
+export type Platform = { readonly os: string; readonly cpu: string };
+
+export type DriftRow = { readonly name: string; readonly lock: string; readonly installed: string };
+
+export type Report = {
+  /** installed packages whose name the lock resolves, and that run here. */
+  readonly compared: number;
+  readonly drift: readonly DriftRow[];
+  /** installed for a platform that is not this one — deliberately not judged. */
+  readonly skippedPlatform: number;
+  /** installed, runs here, and the lock has no entry for the name. */
+  readonly notInLock: number;
+  /** direct dependencies of package.json that the comparison never reached. */
+  readonly uncovered: readonly string[];
+};
+
+/**
+ * Resolve every `"name@version"` the lockfile carries, keyed by name.
+ *
+ * `bun.lock` is JSONC — it has trailing commas, so `JSON.parse` refuses it.
+ * Rather than hand-roll a JSONC parser, read the one token whose shape is
+ * stable across every lockfile version: each entry's value is an array whose
+ * FIRST element is the canonical `name@version`. Parsing the value rather than
+ * the key also sidesteps bun's nested `parent/child` keys and scoped names in
+ * one rule.
+ *
+ * A name can resolve at several versions (a transitive duplicate), so the map
+ * holds a list and a match against ANY of them is not drift: which one a given
+ * consumer sees is a hoisting decision, not a pin violation.
+ */
+export function parseLockVersions(lockText: string): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const match of lockText.matchAll(/\["([^"\n]+)"/g)) {
+    const token = match[1];
+    if (token === undefined) continue;
+    // Scoped names carry a leading `@`, so split on the LAST one.
+    const at = token.lastIndexOf("@");
+    if (at <= 0) continue;
+    const name = token.slice(0, at);
+    const version = token.slice(at + 1);
+    if (name === "" || version === "") continue;
+    const seen = out.get(name);
+    if (seen === undefined) out.set(name, [version]);
+    else if (!seen.includes(version)) seen.push(version);
+  }
+  return out;
+}
+
+/**
+ * npm platform matching: an empty/absent list matches everything, a list of
+ * `!value` entries excludes, anything else is an allowlist.
+ */
+export function matchesPlatform(constraint: PlatformConstraint, value: string): boolean {
+  if (constraint === null || constraint.length === 0) return true;
+  const negated = constraint.filter((entry) => entry.startsWith("!"));
+  if (negated.length === constraint.length) {
+    return !negated.some((entry) => entry.slice(1) === value);
+  }
+  return constraint.some((entry) => entry === value);
+}
+
+export function runsHere(pkg: InstalledPackage, platform: Platform): boolean {
+  return matchesPlatform(pkg.os, platform.os) && matchesPlatform(pkg.cpu, platform.cpu);
+}
+
+/**
+ * Classify an installed tree against the lock.
+ *
+ * `required` is the direct dependency + devDependency names from package.json.
+ * Any of them the comparison never reached is reported as `uncovered` — the
+ * one completeness check that can be made without guessing: it catches both a
+ * partial install and a parser that silently stopped resolving names, and it
+ * cannot false-positive on the lock's many entries for other platforms.
+ */
+export function classify(
+  installed: readonly InstalledPackage[],
+  lock: ReadonlyMap<string, readonly string[]>,
+  platform: Platform,
+  required: readonly string[],
+): Report {
+  const drift: DriftRow[] = [];
+  const reached = new Set<string>();
+  let compared = 0;
+  let skippedPlatform = 0;
+  let notInLock = 0;
+
+  for (const pkg of installed) {
+    if (!runsHere(pkg, platform)) {
+      skippedPlatform += 1;
+      reached.add(pkg.name);
+      continue;
+    }
+    const versions = lock.get(pkg.name);
+    if (versions === undefined || versions.length === 0) {
+      notInLock += 1;
+      continue;
+    }
+    compared += 1;
+    reached.add(pkg.name);
+    if (!versions.includes(pkg.version)) {
+      drift.push({ name: pkg.name, lock: versions.join(","), installed: pkg.version });
+    }
+  }
+
+  drift.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return {
+    compared,
+    drift,
+    skippedPlatform,
+    notInLock,
+    uncovered: required.filter((name) => !reached.has(name)).sort(),
+  };
+}
+
+/**
+ * The verdict, kept apart from the numbers so a caller cannot read one without
+ * the other. `compared === 0` is a FAILURE, not a clean tree: it is what an
+ * instrument that measured nothing looks like, and it is the shape every
+ * silent zero in this repo's history has taken.
+ */
+export function verdict(report: Report): { ok: boolean; reason: string | null } {
+  if (report.compared === 0) {
+    return { ok: false, reason: "compared 0 packages — the comparison measured nothing" };
+  }
+  if (report.uncovered.length > 0) {
+    return { ok: false, reason: `direct dependencies never compared: ${report.uncovered.join(", ")}` };
+  }
+  if (report.drift.length > 0) {
+    return { ok: false, reason: `${report.drift.length} package(s) installed off-lock` };
+  }
+  return { ok: true, reason: null };
+}
+
+export function formatReport(report: Report): string {
+  const lines = [
+    `compared=${report.compared} drift=${report.drift.length} ` +
+      `skipped_other_platform=${report.skippedPlatform} not_in_lock=${report.notInLock}`,
+  ];
+  for (const row of report.drift) {
+    lines.push(`  DRIFT ${row.name}  lock=${row.lock}  installed=${row.installed}`);
+  }
+  return lines.join("\n");
+}
+
+const LINUX: Platform = { os: "linux", cpu: "arm64" };
+
+function pkg(
+  name: string,
+  version: string,
+  os: PlatformConstraint = null,
+  cpu: PlatformConstraint = null,
+): InstalledPackage {
+  return { name, version, os, cpu };
+}
+
+/**
+ * Known-answer controls, run by the gate BEFORE it reports any real number.
+ * A failed control exits without numbers: a comparator nobody has calibrated
+ * produces a zero indistinguishable from "nothing drifted".
+ *
+ * Returns the failures; empty means every control answered as expected.
+ */
+export function runSelfTest(): string[] {
+  const failures: string[] = [];
+  const expect = (label: string, actual: unknown, wanted: unknown): void => {
+    const a = JSON.stringify(actual);
+    const w = JSON.stringify(wanted);
+    if (a !== w) failures.push(`${label}: expected ${w}, got ${a}`);
+  };
+
+  // 1 — the parser, on a lockfile fragment with the trailing commas that make
+  //     `JSON.parse` refuse the real file, a scoped name, and a duplicate.
+  const parsed = parseLockVersions(`{
+  "packages": {
+    "foo": ["foo@1.0.0", "", {}, "sha512-a=="],
+    "@scope/bar": ["@scope/bar@2.0.0", "", {}, "sha512-b=="],
+    "dup/foo": ["foo@1.2.0", "", {}, "sha512-c=="],
+  }
+}`);
+  expect("parse/plain", parsed.get("foo"), ["1.0.0", "1.2.0"]);
+  expect("parse/scoped", parsed.get("@scope/bar"), ["2.0.0"]);
+  expect("parse/absent", parsed.get("nope"), undefined);
+
+  const lock = new Map<string, string[]>([
+    ["foo", ["1.0.0"]],
+    ["@scope/bar", ["2.0.0"]],
+    ["multi", ["1.1.5", "1.2.1"]],
+    ["@tool/cli-darwin-arm64", ["2.5.8"]],
+  ]);
+
+  // 2 — the positive control: one aligned package, one deliberately off-lock,
+  //     one the lock does not carry. The drifted one must be NAMED.
+  const mixed = classify(
+    [pkg("foo", "1.0.0"), pkg("@scope/bar", "1.9.9"), pkg("orphan", "0.0.1")],
+    lock,
+    LINUX,
+    ["foo", "@scope/bar"],
+  );
+  expect("mixed/compared", mixed.compared, 2);
+  expect("mixed/drift", mixed.drift, [{ name: "@scope/bar", lock: "2.0.0", installed: "1.9.9" }]);
+  expect("mixed/notInLock", mixed.notInLock, 1);
+  expect("mixed/uncovered", mixed.uncovered, []);
+  expect("mixed/verdict", verdict(mixed).ok, false);
+
+  // 3 — a version among a multi-resolution lock entry is not drift.
+  const multi = classify([pkg("multi", "1.2.1")], lock, LINUX, []);
+  expect("multi/drift", multi.drift, []);
+  expect("multi/verdict", verdict(multi).ok, true);
+
+  // 4 — THE PLATFORM RULE, and the reason the darwin binaries are a
+  //     limitation rather than a red: a package that cannot run here is
+  //     skipped, not compared, even though its version is off-lock.
+  const foreign = classify(
+    [pkg("@tool/cli-darwin-arm64", "2.4.13", ["darwin"], ["arm64"]), pkg("foo", "1.0.0")],
+    lock,
+    LINUX,
+    [],
+  );
+  expect("foreign/skipped", foreign.skippedPlatform, 1);
+  expect("foreign/compared", foreign.compared, 1);
+  expect("foreign/drift", foreign.drift, []);
+  //     …and the same package IS judged on the platform it belongs to, or the
+  //     skip would be a blanket exemption instead of a scoping rule.
+  const native = classify(
+    [pkg("@tool/cli-darwin-arm64", "2.4.13", ["darwin"], ["arm64"])],
+    lock,
+    { os: "darwin", cpu: "arm64" },
+    [],
+  );
+  expect("native/drift", native.drift.length, 1);
+
+  // 5 — an empty tree must FAIL, not pass: zero compared is the instrument
+  //     measuring nothing.
+  expect("empty/verdict", verdict(classify([], lock, LINUX, [])).ok, false);
+
+  // 6 — a declared dependency the walk never reached is named.
+  const gap = classify([pkg("foo", "1.0.0")], lock, LINUX, ["foo", "ghost"]);
+  expect("gap/uncovered", gap.uncovered, ["ghost"]);
+  expect("gap/verdict", verdict(gap).ok, false);
+
+  return failures;
+}

--- a/cicchetto/scripts/lock-drift.ts
+++ b/cicchetto/scripts/lock-drift.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+// #1571 — the `bun run check` stage that makes the other stages attributable:
+// it answers whether the tools about to produce a verdict are the ones
+// `bun.lock` pins. The rules, the platform scoping and the reasoning live in
+// `./lock-drift-core.ts`; this file is only the IO around them.
+//
+// Exit codes are distinct on purpose:
+//   0  every package that runs here matches the lock
+//   1  drift, or a declared dependency the comparison never reached
+//   3  a known-answer control failed — NO numbers are printed, because a
+//      comparator that cannot answer a question with a known answer cannot be
+//      believed when it answers one without.
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { classify, formatReport, parseLockVersions, runSelfTest, verdict } from "./lock-drift-core";
+
+const root = process.cwd();
+
+const failures = runSelfTest();
+if (failures.length > 0) {
+  console.error("lock-drift: SELF-TEST FAILED — refusing to report numbers");
+  for (const failure of failures) console.error(`  ${failure}`);
+  process.exit(3);
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function stringList(value: unknown): string[] | null {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === "string");
+  if (typeof value === "string") return [value];
+  return null;
+}
+
+function readInstalled(dir: string, name: string) {
+  const manifest = readJson(join(dir, "package.json"));
+  if (manifest === null || typeof manifest.version !== "string") return null;
+  return {
+    name,
+    version: manifest.version,
+    os: stringList(manifest.os),
+    cpu: stringList(manifest.cpu),
+  };
+}
+
+function walk(modulesDir: string) {
+  const out = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(modulesDir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries.sort()) {
+    if (entry.startsWith(".")) continue;
+    if (entry.startsWith("@")) {
+      let scoped: string[];
+      try {
+        scoped = readdirSync(join(modulesDir, entry));
+      } catch {
+        continue;
+      }
+      for (const inner of scoped.sort()) {
+        const pkg = readInstalled(join(modulesDir, entry, inner), `${entry}/${inner}`);
+        if (pkg !== null) out.push(pkg);
+      }
+      continue;
+    }
+    const pkg = readInstalled(join(modulesDir, entry), entry);
+    if (pkg !== null) out.push(pkg);
+  }
+  return out;
+}
+
+let lockText: string;
+try {
+  lockText = readFileSync(join(root, "bun.lock"), "utf8");
+} catch {
+  console.error(`lock-drift: no bun.lock at ${root} — cannot attribute anything`);
+  process.exit(1);
+}
+
+const manifest = readJson(join(root, "package.json")) ?? {};
+const required = [
+  ...Object.keys((manifest.dependencies as Record<string, string>) ?? {}),
+  ...Object.keys((manifest.devDependencies as Record<string, string>) ?? {}),
+];
+
+const platform = { os: process.platform, cpu: process.arch };
+const report = classify(walk(join(root, "node_modules")), parseLockVersions(lockText), platform, required);
+const result = verdict(report);
+
+console.log(`lock-drift: ${platform.os}/${platform.cpu} — ${formatReport(report)}`);
+
+if (!result.ok) {
+  console.error(`lock-drift: ${result.reason}`);
+  console.error(
+    "lock-drift: the tree does not match bun.lock, so any verdict from the stages below is " +
+      "not attributable to the code. Reconcile with `scripts/bun.sh install --frozen-lockfile`.",
+  );
+  process.exit(1);
+}

--- a/cicchetto/src/__tests__/lockDrift.test.ts
+++ b/cicchetto/src/__tests__/lockDrift.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  classify,
+  type InstalledPackage,
+  matchesPlatform,
+  type Platform,
+  parseLockVersions,
+  runSelfTest,
+  verdict,
+} from "../../scripts/lock-drift-core";
+
+// #1571 — the gate that says whether `node_modules` is what `bun.lock` pins.
+// Every case below is two-sided on purpose: the rule is only worth anything if
+// the red side reddens AND the green side stays green under the same
+// comparator, so a mutation that disables the check cannot pass by making
+// everything green (nor by making everything red).
+
+const LINUX: Platform = { os: "linux", cpu: "arm64" };
+const DARWIN: Platform = { os: "darwin", cpu: "arm64" };
+
+const pkg = (
+  name: string,
+  version: string,
+  os: readonly string[] | null = null,
+  cpu: readonly string[] | null = null,
+): InstalledPackage => ({ name, version, os, cpu });
+
+const LOCK = new Map<string, string[]>([
+  ["biome-ish", ["2.5.8"]],
+  ["@tool/cli-darwin-arm64", ["2.5.8"]],
+  ["@tool/cli-linux-arm64", ["2.5.8"]],
+  ["multi", ["1.1.5", "1.2.1"]],
+]);
+
+describe("lock drift — the installed tree against bun.lock", () => {
+  it("an aligned tree compares its packages and stays green", () => {
+    const report = classify([pkg("biome-ish", "2.5.8")], LOCK, LINUX, ["biome-ish"]);
+
+    expect(report.compared).toBe(1);
+    expect(report.drift).toEqual([]);
+    expect(verdict(report).ok).toBe(true);
+  });
+
+  it("a package installed off-lock reddens and is named with both versions", () => {
+    const report = classify([pkg("biome-ish", "2.4.13")], LOCK, LINUX, ["biome-ish"]);
+
+    expect(report.compared).toBe(1);
+    expect(report.drift).toEqual([{ name: "biome-ish", lock: "2.5.8", installed: "2.4.13" }]);
+    expect(verdict(report).ok).toBe(false);
+  });
+
+  it("a name the lock resolves at several versions matches any of them", () => {
+    // A transitive duplicate is a hoisting outcome, not a pin violation.
+    expect(classify([pkg("multi", "1.1.5")], LOCK, LINUX, []).drift).toEqual([]);
+    expect(classify([pkg("multi", "1.2.1")], LOCK, LINUX, []).drift).toEqual([]);
+    expect(classify([pkg("multi", "1.0.0")], LOCK, LINUX, []).drift).toHaveLength(1);
+  });
+});
+
+describe("lock drift — the platform scoping, which is what makes the darwin binaries a limitation", () => {
+  const darwinBinary = pkg("@tool/cli-darwin-arm64", "2.4.13", ["darwin"], ["arm64"]);
+
+  it("skips a binary that cannot run here, even though its version is off-lock", () => {
+    const report = classify([darwinBinary, pkg("biome-ish", "2.5.8")], LOCK, LINUX, []);
+
+    expect(report.skippedPlatform).toBe(1);
+    expect(report.compared).toBe(1);
+    expect(report.drift).toEqual([]);
+    expect(verdict(report).ok).toBe(true);
+  });
+
+  it("judges the very same package on the platform it belongs to", () => {
+    // Without this side the skip would be a blanket exemption: the rule is
+    // "what runs HERE", not "platform binaries are never checked".
+    const report = classify([darwinBinary], LOCK, DARWIN, []);
+
+    expect(report.skippedPlatform).toBe(0);
+    expect(report.drift).toEqual([
+      { name: "@tool/cli-darwin-arm64", lock: "2.5.8", installed: "2.4.13" },
+    ]);
+  });
+
+  it("reads npm allowlists and negations the way npm does", () => {
+    expect(matchesPlatform(null, "linux")).toBe(true);
+    expect(matchesPlatform([], "linux")).toBe(true);
+    expect(matchesPlatform(["linux", "darwin"], "linux")).toBe(true);
+    expect(matchesPlatform(["darwin"], "linux")).toBe(false);
+    expect(matchesPlatform(["!win32"], "linux")).toBe(true);
+    expect(matchesPlatform(["!win32"], "win32")).toBe(false);
+  });
+});
+
+describe("lock drift — the ways the comparison can measure nothing", () => {
+  it("fails on an empty comparison instead of reporting a clean tree", () => {
+    const report = classify([], LOCK, LINUX, []);
+
+    expect(report.compared).toBe(0);
+    expect(report.drift).toEqual([]);
+    // The dangerous shape: zero drift over zero comparisons. It must not pass.
+    expect(verdict(report).ok).toBe(false);
+    expect(verdict(report).reason).toContain("measured nothing");
+  });
+
+  it("names a declared dependency the walk never reached", () => {
+    const report = classify([pkg("biome-ish", "2.5.8")], LOCK, LINUX, ["biome-ish", "ghost"]);
+
+    expect(report.uncovered).toEqual(["ghost"]);
+    expect(verdict(report).ok).toBe(false);
+  });
+
+  it("counts an installed package the lock does not carry without failing on it", () => {
+    // Not a pin violation: `bun install --cwd e2e` and stray local installs
+    // both land here, and calling them drift would make the gate cry wolf.
+    const report = classify([pkg("biome-ish", "2.5.8"), pkg("stray", "0.0.1")], LOCK, LINUX, []);
+
+    expect(report.notInLock).toBe(1);
+    expect(verdict(report).ok).toBe(true);
+  });
+});
+
+describe("lock drift — the lockfile parser", () => {
+  const text = `{
+  "packages": {
+    "plain": ["plain@1.0.0", "", {}, "sha512-a=="],
+    "@scope/tool": ["@scope/tool@2.5.8", "", { "os": "linux" }, "sha512-b=="],
+    "nested/plain": ["plain@1.2.0", "", {}, "sha512-c=="],
+  }
+}`;
+
+  it("resolves scoped names, and survives the trailing commas JSON.parse refuses", () => {
+    expect(() => JSON.parse(text)).toThrow();
+
+    const lock = parseLockVersions(text);
+    expect(lock.get("@scope/tool")).toEqual(["2.5.8"]);
+    expect(lock.get("plain")).toEqual(["1.0.0", "1.2.0"]);
+    expect(lock.get("absent")).toBeUndefined();
+  });
+});
+
+describe("lock drift — the controls the gate runs on itself", () => {
+  it("answers every known-answer control before it reports a number", () => {
+    // The gate exits 3 without printing numbers when this list is non-empty.
+    expect(runSelfTest()).toEqual([]);
+  });
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53049,3 +53049,96 @@ gates.
 The two historical mentions of these names elsewhere in this file
 (`AdminLiveState`, `AdminVisitorLiveState`) are left untouched: the log
 records what was true when it was written.
+<!-- entry #1571 -->
+
+---
+
+## 2026-08-20 — #1571: the gate now says whether the toolchain is the one the lockfile pins
+
+A `bun run check` is only attributable if the tools that produced the verdict
+are the ones `bun.lock` names. #1571 found a main checkout whose biome was
+three minor versions behind the lock; the re-measurement asked whether that had
+receded, and the answer split in a way worth recording.
+
+**Declared and executed are different packages, and only one of them was ever
+read.** `@biomejs/biome` is a JS wrapper; the binary it runs lives in a
+per-platform optional dependency. Reading the wrapper's `package.json` reports
+the DECLARED version — that reading said 2.5.8, in lock, and was correct about
+what it measured. `biome --version` reports the EXECUTED one. Same tree, two
+answers: **2.5.8 through `scripts/bun.sh` (the container, where every gate
+runs) and 2.4.13 from `cicchetto/node_modules/.bin/biome` on the host.** The
+anchor was part of the instrument, and the wrong anchor closed the issue
+prematurely.
+
+**The mechanism, with evidence.** `bun install` only resolves the optional
+dependency matching the platform it runs on, and every gate here runs bun
+inside a linux container — so the `*-darwin-*` packages in a macOS tree cannot
+be refreshed by any path the project uses. Measured: both drifted packages were
+darwin binaries (`@biomejs/cli-darwin-arm64` 2.4.13 vs 2.5.8,
+`@rolldown/binding-darwin-arm64` 1.0.0-rc.17 vs 1.1.5/1.2.1), both directories
+dated three months before every linux sibling. 2 of 459 compared.
+
+**Closed by the last install, not by construction.** `scripts/bun.sh`'s only
+freshness test is `needs_install`, which asks whether `node_modules` is EMPTY;
+nothing anywhere compared installed versions to the lock; and the documented
+worktree procedure (`cp -Rc` the tree from the main checkout) copies whatever
+is there — reproduced the same day on an hour-old worktree, package for
+package. A future lock bump landing on an already-populated tree re-derives the
+original defect with nothing to say so.
+
+### The cure, and the shape of it
+
+`bun run check` gained a FIRST stage, `cicchetto/scripts/lock-drift.ts`, which
+compares `node_modules` against `bun.lock` and names every package that
+disagrees. It is a stage rather than a preflight in `scripts/bun.sh` because
+`check.ts` already owns the union-of-failures aggregation (#1469) and adding
+one there costs no extra container start; the cost of that choice is stated
+below.
+
+Three properties are deliberate:
+
+- **Scoped to the executing platform.** The question asked is "does what will
+  RUN HERE match the lock", not "is every file in the tree pinned". Judging
+  foreign-platform binaries would make the gate red on something no gate
+  executes and no documented command can fix.
+- **Known-answer controls inside the tool.** `runSelfTest()` runs before any
+  real number is produced and the gate exits **3 printing nothing** when a
+  control fails — a comparator nobody has calibrated produces a zero
+  indistinguishable from "nothing drifted". Measured by mutation: removing the
+  one line that records a drift makes three controls fire and zero numbers
+  print, and reddens the vitest suite at the same time.
+- **`compared === 0` is a failure**, not a clean tree. Measuring nothing is the
+  shape every silent zero in this repo's history has taken, so it gets its own
+  verdict rather than being folded into "no drift found".
+
+Two-sided kill test on the real tree, not on a fixture: putting
+`@biomejs/cli-linux-arm64` at 2.5.6 — the exact version #1571 found in the
+wild — turned `check` red with **one** stage failing and the package named;
+restoring it byte-identical turned all four stages green.
+
+### The darwin binaries are a documented limitation, not a gate that lies
+
+Named explicitly because it is the half that was NOT cured. The stale
+foreign-platform binaries are real and are not judged. What bounds them is
+measured, not assumed: `bun`, `bunx` and `biome` are absent from the host
+PATH, `scripts/check.sh` never invokes bun, no script or workflow runs biome
+outside the container, and the repo carries no editor config or git hook. So
+no documented gate can produce a verdict from them; a direct
+`node_modules/.bin/<tool>` call or an editor integration can, and
+`docs/TESTING.md` now says so and how to check by hand.
+
+### Not covered, deliberately
+
+- **Only `check` carries the stage.** `run test` and `run build` consume the
+  same tree and are not guarded. Guarding every verb means a drift check in
+  `scripts/bun.sh`, which costs one extra container start per invocation; the
+  gate whose attributability #1571 is about is `check`, and a drift surfaced
+  there is a drift the whole tree has.
+- **The missing direction is not checked.** A lock entry with nothing
+  installed is not reported, because the lock legitimately carries packages
+  this platform never installs and the false positives would teach people to
+  ignore the gate. The one completeness check made instead: every direct
+  dependency of `package.json` must have been reached, or the gate fails
+  naming it.
+- **Every number above is one host.** Nothing here says what another
+  developer's tree contains.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53142,3 +53142,108 @@ no documented gate can produce a verdict from them; a direct
   naming it.
 - **Every number above is one host.** Nothing here says what another
   developer's tree contains.
+<!-- entry #1473 -->
+
+---
+
+## 2026-08-20 — #1473: the hand-maintained half of the tracked set, derived
+
+`Grappa.Deploy.Preflight` state-shape-checks only the files behind
+`LongLivedModules.all/0`. That list has two halves. The `@modules` half —
+long-lived `GenServer`s — has been derived-and-gated since #1343. The
+`@state_helpers` half — structs held as FIELDS of one of those processes'
+state — was the half nothing derived; its own moduledoc asked only to "keep
+in sync", and it had drifted three ways.
+
+`Session.Deps` and `Session.DirectoryIngest` arrived with the #1390
+decomposition. `IRC.FakeLag`, a field of `IRC.Client`'s state, was never
+listed at all — it is not in the issue either, which had recorded "no audit
+of the other tracked GenServers' `@type t` blocks was done" as a known
+non-measure. The derivation found it on its first run. **Three, not two.**
+
+Measured through `Preflight.classify/5` on `:jail`, a scratch `defstruct`
+field-add to each classified `{:hot, []}`, while `WindowState` — listed —
+returned `{:cold, [state_shape: [...]]}` from the same harness. A HOT deploy
+carrying such a field-add swaps the beam under a live process still holding
+the old struct; the mismatch surfaces on whatever message next
+pattern-matches it.
+
+### The membership is derivable, and the derivation belongs in the gate
+
+Measured before choosing: walking the `t` typespec of every `@modules` entry
+to a fixpoint and keeping the reachable `:grappa` modules that define a
+struct reproduces **every one of the nine hand-listed helpers** — the
+`listed \ derived` difference is EMPTY. So the list holds nothing the
+derivation cannot reach, and enumerating it by hand buys nothing that
+deriving it does not.
+
+The list stays hand-written anyway, and the derivation became the gate. A
+runtime derivation would feed no Dialyzer union — `@type state_helper` is a
+literal union — and it would fail OPEN at deploy time: a module that fails
+to load simply leaves the set and the preflight silently checks less, which
+is the failure mode the preflight exists to prevent. A hand list with a
+derived gate fails red, in CI, before the deploy. It is also the shape the
+`@modules` half already has, so the two halves stay one pattern rather than
+two. *(The compile-time variant — deriving into the literal at compile time
+— was judged unworkable because `LongLivedModules` would have to read the
+typespecs of modules not yet compiled. That was reasoned, not prototyped.)*
+
+The typespec is read from the BEAM chunk rather than the source: module
+names arrive fully qualified, so there is no alias table to resolve and no
+second parser to keep in step with the compiler.
+
+### The unit of coverage is the FILE, not the module
+
+`extract_state_block/1` reads a source file, so a struct nested inside
+another module's file is covered by listing its PARENT. Measured: a
+field-add to the nested `DirectoryIngest.Run` moves `directory_ingest.ex`'s
+extracted block. Three such nested structs (`LinksAccum.Entry`,
+`ListModeAccum.Entry`, `WhowasAccum.Entry`) were already covered that way
+before this change, which is what makes the rule observed rather than
+assumed.
+
+Listing a nested module instead would be actively harmful:
+`Grappa.Session.DirectoryIngest.Run` implies
+`lib/grappa/session/directory_ingest/run.ex`, which does not exist, and an
+absent file is read as empty at BOTH revs — it compares equal and
+classifies HOT. That is the silent direction the sibling
+"source file sits where its name says" assertion already guards.
+
+So the gate keys on each struct's COMPILE SOURCE, not on module identity,
+and nesting needs no special case.
+
+### What the gate is worth, in both directions
+
+- Add a struct to a long-lived state without listing it: the pre-cure list
+  put `deps.ex`, `directory_ingest.ex` and `fake_lag.ex` in the red set,
+  grouped by file, with `DirectoryIngest.Run` collapsed onto its parent.
+- Remove a listed one: dropping `AwayState` reddens exactly one test,
+  naming `away_state.ex`.
+
+The end-to-end half was then measured through the real `cli/1` with two git
+revisions — the path the issue had recorded as *not established* for these
+modules: a scratch field-add to each of the three, and to the `WindowState`
+control, yields `state_shape: <that file>` and **exit 3**, while a
+comment-only change to a now-listed file yields **exit 0**, which is what
+proves the harness can produce both values rather than always answering 3.
+
+**A measurement trap paid for here.** The first run of that harness returned
+exit 0 for all four, control included. The container's `/app` is the MAIN
+checkout with the worktree's `lib/` bind-mounted over it, so `.git` is
+main's: `HEAD^..HEAD` inside the container resolved to main's last commit,
+not the worktree's scratch one, and every row classified a docs-only diff.
+The verdicts were uniform because the instrument was wrong, not because the
+code agreed. Passing explicit SHAs — the object store IS shared across
+worktrees — fixed it. **A preflight harness must name its revisions
+explicitly; a symbolic ref means the container's repo, not yours.**
+
+### Not established
+
+- **That the three are all of them.** The closure follows `Mod.t()`
+  references inside `t` typespecs. A struct held in a field typed `map()`,
+  `term()` or `any()` is invisible to it, and that gap was not measured.
+- **No production incident is claimed**, unchanged from the issue: what was
+  measured is the classifier's verdict, not the jail's deploy history.
+- **Only `:jail` was classified.** The state-shape stage is
+  substrate-independent in `classify/5`, but `:docker` and `:linux` were
+  read, not run.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53247,3 +53247,141 @@ explicitly; a symbolic ref means the container's repo, not yours.**
 - **Only `:jail` was classified.** The state-shape stage is
   substrate-independent in `classify/5`, but `:docker` and `:linux` were
   read, not run.
+<!-- entry #1421 -->
+
+---
+
+## 2026-08-20 — #1421: a budget that cannot bound the fault it is pointed at
+
+#1420 named this and left it: *"the retry budget cannot fire on the fault it
+exists for"*. This closes the half that can be closed without touching what
+#1420 calls the contested axis. A + B of the option table below shipped;
+C/D/E/H did not, and are vjt's call.
+
+### The mechanism, stated exactly
+
+`BusyRetry`'s budget is a deadline consulted BETWEEN attempts. It cannot
+preempt an attempt already running, because the engine does not own the wait —
+SQLite does. So the reach depends on the FAULT'S OWN latency, and the live
+topologies do not share a regime:
+
+| topology | who owns the wait | latency before the raise | inside the 1500ms budget? |
+|---|---|---|---|
+| pool `queue_timeout` | DBConnection | ~100ms (target 50ms, doubled once, then dropped) | yes |
+| write-lock `busy_locked` | SQLite's busy handler | up to `busy_timeout` = 30_000ms | **no — 20x over** |
+| deferred read->write upgrade | nobody, raises at once | ~0ms | yes, but gated out |
+
+The third row is not live: `Repo.transaction(` appears **0 times** in `lib/`,
+enforced by `Grappa.Repo.TransactionModeGateTest` (#1374). Both live write
+paths are therefore slow-fault paths — the 122 bare `Repo.insert/update/…`
+sites take the write lock in autocommit, and every write transaction goes
+through `immediate_transaction/1`.
+
+So the accurate claim is narrower than "the retry branch is unreachable": it
+is unreachable for the LOCK topology, and stays reachable for the POOL
+topology it was dimensioned for. `config/config.exs` sizes the budget against
+*"the ~1s pool-saturation window the #336 incident measured"* — one number
+dimensioned for one topology, later reused for another. Not a wiring slip.
+
+Chronology, because it explains the order of events and exonerates #524: the
+budget landed 2026-07-19 (`6e99d1c9`, #340); `BEGIN IMMEDIATE` landed nine
+days later (`13edb5f3`, #524), replacing a deferred upgrade that
+`repo.ex:166-170` records as raising *at once*. #524 is correct; it is simply
+the commit after which the write-transaction fault waits `busy_timeout`.
+
+### Why the engine's own suite could not see it
+
+Every pre-existing retry test raises a hand-built `%Exqlite.Error{}` from a
+zero-cost closure. The fault is FREE, so the budget is the only thing bounding
+the loop — the one regime in which the budget appears to work. The new bench
+`Grappa.Repo.BusyRetryBudgetReachTest` provokes a REAL driver `SQLITE_BUSY`
+against a held write lock and varies only `busy_timeout`: above the budget the
+loop collapses to exactly one attempt, below it the loop runs many. Same
+engine, same budget; only the ratio changes, and production's ratio is 20.
+
+The same shape sits in `config/test.exs`: `queue_target: 5_000` (a ~10_000ms
+drop) against `budget_ms: 300`. The test environment reproduces the identical
+incoherence in the OTHER topology, 33x over, and nothing notices — because no
+test pays for its faults.
+
+### What shipped: the line reports the wait it OBSERVED
+
+The terminal warning read `for the full 1500ms retry budget (1 attempts)`
+after waiting 30 067ms. That is CLAUDE.md's log-honesty rule broken by the
+same line #1420 had just corrected for the same reason, so it is a bugfix and
+not a behaviour change: it now reads `for 30067ms across 1 attempts (1500ms
+retry budget)`. The elapsed is the only figure the engine can vouch for; the
+budget stays as context, never as the bound.
+
+Zero behaviour moved. `run/2` carries `started` instead of a precomputed
+deadline and `elapsed_ms < @budget_ms` replaces `monotonic_time < deadline` —
+the same arm at the same boundary, rearranged so one subtraction feeds the
+line. Same retry, same `{:error, :db_unavailable}`, same `fault:` metadata,
+0 of the 71 `BusyRetry.run`/`with_pool_retry` call sites touched.
+
+### The census moved in LOCKSTEP, and its anchor changed on purpose
+
+`scripts/log-gap-scan.awk` counted `saturated` on `/saturated for the full/` —
+the numeric tail this commit rewrites. Left alone it would have reported zero,
+and zero is what a clean run looks like: the #1429 census is the attribution
+instrument for red e2e runs, so blinding it costs the next reader a
+measurement they believe they took.
+
+Both terminal counters are now anchored on the `observed_state/1` phrase
+ALONE (`SQLite pool saturated` / `write lock held by another writer`), which
+is the half that names the topology and the half that does not carry numbers.
+The two known-answer samples in the scanner and the two verbatim pins in
+`test/scripts/log_gap_scan_test.bats` moved in the same commit, plus a new
+bats case that feeds both lines with a DIFFERENT numeric tail — so the
+decoupling is asserted rather than asserted-about.
+
+### What was measured, and what the measurement does NOT license
+
+`log-gap-census` over 50 integration runs (window 2026-08-18T17:02Z ->
+2026-08-20T12:26Z, 600 SUMMARY lines, 1.13-1.17M log lines per run for
+`grappa-test`): `db30`, `idle30`, `dropped`, `saturated` present on 600/600
+and ALL ZERO. The three lock counters are present on **12/600 lines — one run
+of fifty**, since they shipped on 2026-08-20 with #1420-instrument. That is a
+declared non-measure on 49 runs, not a zero.
+
+Positive control, because an all-zero census accuses its own instrument first:
+the single red run's 262MB `grappa-test.log` carries 1 158 475 lines and
+**502 660 `QUERY OK` rows with a `db=` timing**, max 194.2ms, six samples in
+100-1500ms, none above. Half a million timed queries are in the stream, so the
+zeros above are measured rather than an absent logging path.
+
+The regime did fire in a DIFFERENT window (`lock_watch.ex:19-21`, #1420's
+census: `db30=4`, `dropped=2`, `saturated=2`, every gap exactly 30.1s), and
+there the 30s wait bought nothing — four waiters all reached the full timeout
+and two scrollback rows were dropped anyway. That argues FOR lowering
+`busy_timeout`, and it is recorded here even though it favours an option not
+taken. Its weight is six signature hits in one window: not enough to reset a
+global timeout.
+
+Not claimed: that a 30s wait ever SUCCEEDED (the `QUERY OK … db=30064.1ms`
+line in the scanner is a registered known-answer SAMPLE, not an observed line,
+and zero `db=3xxxx` rows appear in the one log materialised — this is the
+single fact that would decide the contested axis, and it is unmeasured); the
+production `queue_timeout` drop latency (read from `db_connection`'s own
+"Queue config", never measured here); the distribution of lock HOLD times
+(both windows are CI, neither is m42); and that lowering `busy_timeout` would
+have saved those two rows (mechanically it cannot — a lock held past 30s
+outlasts every budget under discussion; it would only move the drop earlier).
+
+### Named, not cured — deliberately
+
+Re-dimensioning either number changes retry behaviour under contention, which
+is #1420's contested axis. The options were priced and posted to #1421 for
+vjt: lower `busy_timeout` (turns every lock held between the budget and 30s
+from a slow SUCCESS into a fast drop/503, and re-arms the measured e2e flake
+the 30_000 exists for — `runtime.exs:193-196`); raise `budget_ms` (a 90s HTTP
+hang before the 503, worse for the caller #518 exists to protect); swap the
+roles (~250 / ~30_000: same total wall-clock, ~100 slices, the engine owns the
+wait); or a compile-time coherence gate, which is NOT a middle path — it
+refuses the documented-limitation outcome and forces one of the other three
+without saying so.
+
+The question left open, in one line: **is a 30-second HTTP hang before a 503
+the behaviour we want?** If yes, #1421 closes as a documented limitation and
+the module's contract now says so. If no, the answer is one of the above and
+it is a ruling, not a fix.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53385,3 +53385,104 @@ The question left open, in one line: **is a 30-second HTTP hang before a 503
 the behaviour we want?** If yes, #1421 closes as a documented limitation and
 the module's contract now says so. If no, the answer is one of the above and
 it is a ruling, not a fix.
+<!-- entry #1601 -->
+
+---
+
+## 2026-08-20 — #1601: the Docker hot deploy declared a landing it never compiled
+
+`POST /admin/reload` LOADS beams; it does not make them.
+`Grappa.HotReload.reload_modified/0` md5-walks the app's ebin and reloads what
+changed on disk. On the Docker substrate nothing on the hot path wrote that
+ebin: `substrate_build` opened with `[ "$MODE" = cold ] || return 0` and the
+comment *"the pulled commit is already in the bind-mounted source tree"* —
+true of the SOURCES, silent about the BEAMS. So the reload found the previous
+commit's modules unchanged, answered `reloaded: []` **honestly**, and the
+deploy declared success over code that was never loaded. Measured on staging:
+a manual reload immediately after the ✓ banner found two modules, and the two
+idempotent reloads after that found none — the control that proves the
+deploy's own reload had not loaded them.
+
+### Every step was individually honest; the sum was not
+
+| step | declares | observes |
+|---|---|---|
+| `substrate_build` | "no build needed" | nothing |
+| `substrate_reload` | proceeds on `"failed":[]` | only `failed`; `reloaded` is in the response, logged and never read |
+| `substrate_healthcheck` | "healthy" | a 200 on `/healthz` that the OLD code returns identically |
+| `substrate_write_marker` | "this sha is deployed" | nothing; it writes `NEW_SHA` unconditionally |
+| `done_banner` | "✓ hot-deploy complete" | the sum of the above |
+
+Not one of those lines is a lie on its own. Together they declare "the new
+commit is live" while observing "the old process is up and nothing failed to
+load". That gap is the `Log honesty` rule at deploy scale: **a gate that
+never ran the step cannot report on it, and reporting green anyway is the
+defect** — vjt's "a documented limitation is an acceptable outcome" does not
+extend to a gate that declares a verdict it did not measure.
+
+### The cure ends an exception rather than adding a mechanism
+
+`infra/freebsd/deploy.sh` and `infra/linux/deploy.sh` already build on BOTH
+paths and state the reason: the build *"writes the fresh .beam into the
+daemon's code path that the hot reload POST then loads"*. Docker was the only
+substrate out of line, so the fix is a hot arm in its `substrate_build`, not a
+new step in the shared algorithm.
+
+Placement costs nothing: `deploy_common.sh` calls `substrate_build` **before**
+the hot/cold branch, so a compile there precedes `substrate_reload` by
+construction. Three consequences worth pinning:
+
+- **No `deps.get` beside it.** `mix.lock`/`mix.exs` are COLD triggers
+  (`Preflight.mix_deps?/1`), so a hot deploy cannot bring deps the box has not
+  already fetched. A `deps.get` here would be dead weight on every hot deploy.
+- **`--warnings-as-errors`, matching both release substrates.** Under the
+  consumers' `set -euo pipefail` a failed compile aborts *before* the reload.
+  That is the point of the step: reloading over a tree that would not compile
+  is the same defect with extra ceremony.
+- **Classification is untouched.** `Preflight.classify/5` still decides WHEN a
+  change is hot. This changes what the hot path DOES, never what counts as hot.
+
+### Rejected: re-run the reload after the seed
+
+The issue offered a second shape. `mix grappa.seed_themes` is the one hot-path
+step that compiles today — by accident, as a side effect of being a mix task —
+and `_deploy_hot` runs it AFTER the reload for a documented reason (post-#41
+the reload applies expand migrations, so an earlier seed would meet the
+pre-migration schema). Reloading a second time after it would promote that
+accident into the build step and pay two reloads where one suffices. The
+ordering comment stays correct; what was missing was a compile ahead of it.
+
+### What the test pins, and what it deliberately does not
+
+`test/scripts/deploy_reload_verify_test.bats` already drives `deploy.sh
+--force-hot` against a throwaway clone with `docker` stubbed on PATH, logging
+every argv. The new case asserts a `mix compile` exists in that log **and that
+its line precedes `admin/reload`** — ordering, not presence, because a compile
+after the reload is exactly what the seed already did.
+
+It does NOT assert a non-empty `reloaded` list. A doc-only hot deploy
+legitimately reloads nothing, and pinning that would encode a coincidence; the
+first case in the file already pins the `reloaded: []` shape as valid.
+
+Two mutants, one assertion each, both measured: reinstating `return 0` on the
+hot arm fails the presence assert; moving the compile into `substrate_seed`
+(present, but after the reload) fails the ordering assert and nothing else.
+The second mutant is not optional — the first red never reaches the ordering
+line, so without it that assertion would have shipped unexercised.
+
+### Read from the code, not reproduced
+
+`_deploy_nothing_to_do` exits 0 when `PREV_SHA == NEW_SHA` and `LAST_DEPLOYED
+== NEW_SHA` in auto mode. The marker carries the new sha whether or not
+anything loaded, so an operator who re-runs the deploy to remedy the stale box
+is told "nothing to do". The issue's "self-healing by accident, converges one
+commit later" therefore holds only when a NEW commit arrives — not by
+retrying. Stated as read from `deploy_common.sh`, not reproduced on a box.
+
+### Spun off, not folded in
+
+The same deploy session surfaced a second `Log honesty` fault: the pull's
+`die` reports "the branch diverged" for a refusal it never observed (a
+`branch.<name>.rebase` config turns `git pull --ff-only` into a rebase pull,
+which refuses on any unstaged change with no divergence in sight). Different
+fault, different cure, so it is **#1603** rather than scope creep here.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4751,7 +4751,13 @@ WAL/lock corroboration (mechanism 2, out-of-band): grep prod logs for the
 `db write unavailable` warning — it names WHICH of the two it observed since
 #1420 (`SQLite pool saturated` for a pool `queue_timeout`, `SQLite write lock
 held by another writer` for a `busy_locked`; before that it said "pool" for
-both while its own `fault=` metadata said otherwise) — and busy/locked
+both while its own `fault=` metadata said otherwise). Since **#1421** it also
+names the wall-clock it actually WAITED — `for 30067ms across 1 attempts
+(1500ms retry budget)`. Read the two numbers together: an elapsed far past the
+budget with `1 attempts` is the lock topology, where SQLite's 30 s
+`busy_timeout` sits inside the first attempt and the budget cannot bound
+anything; an elapsed just past the budget with many attempts is the pool
+topology the budget was actually dimensioned for. Also grep busy/locked
 `%Exqlite.Error{}` lines during
 the burst; watch WAL checkpoint pressure via the `runtime/*.db-wal` file size
 (a large, slow-shrinking `-wal` = checkpoints falling behind the write rate).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -637,7 +637,8 @@ on it.
 
 **`.env` and `MIX_ENV` are established for BOTH paths, in
 `establish_deploy_env` (#1377).** They used to live inside
-`substrate_build`, which returns early on hot — so a hot deploy reached
+`substrate_build`, which returned early on hot back then (#1601 has since
+given that hook a hot arm of its own) — so a hot deploy reached
 the theme seed with no `MIX_ENV` in the shell, compose fell back to
 `.env` for the interpolation, and `.env.example` ships `MIX_ENV=dev`:
 cold seeded `grappa_prod.db`, hot seeded `grappa_dev.db` on the same
@@ -647,9 +648,16 @@ flag still reads as a usage error) and before the first side effect.
 Consequence for operators: a box with no `.env` now fails the same way
 on hot as it always did on cold.
 
-**Hot deploys are the normal case.** `git pull` plus `POST
-/admin/reload` swaps modules in the live BEAM with no restart, and
-sessions (`Session.Server`, `IRC.Client`) keep their state. What cannot
+**Hot deploys are the normal case.** `git pull`, then `mix compile`,
+then `POST /admin/reload` swaps modules in the live BEAM with no
+restart, and sessions (`Session.Server`, `IRC.Client`) keep their state.
+**The compile is not optional and not an optimisation (#1601):** the
+reload endpoint only LOADS — it md5-walks the app's ebin — so with
+nothing compiled it answers `reloaded: []` truthfully and the deploy
+declares success over the previous commit's modules. The bind-mount
+puts the pulled SOURCES in the container; it does not put BEAMS in the
+ebin. The jail and systemd substrates have always built on both paths
+for the same reason. What cannot
 be hot-swapped is a change to module *shape* — `mix.lock`/`mix.exs`,
 the `application.ex` supervision tree, a long-lived GenServer's state
 shape — because the reload is accepted and the new code then crashes at

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,7 +34,7 @@ scripts/test.sh --cover                  # coverage
 
 # cic (Solid / TS)
 scripts/bun.sh run test                  # vitest
-scripts/bun.sh run check                 # biome + tsc — src AND e2e (#484); all 3 stages, union of failures (#1469)
+scripts/bun.sh run check                 # lock drift + biome + tsc — src AND e2e (#484); all 4 stages, union of failures (#1469)
 
 # Full CI gate locally
 scripts/check.sh                         # mix ci.check + wireTypes drift gate + bats
@@ -125,8 +125,8 @@ caught.
 told you the FIRST stage failed and nothing about the rest — and formatting,
 the cheapest and most frequent failure, sat first. Measured three times in one
 day, a cosmetic complaint hid two, then three, genuine type errors for as long
-as it lasted. `cicchetto/scripts/check.ts` now runs all three and exits
-non-zero if ANY did, closing with `check summary — 3 stages ran, N failed`.
+as it lasted. `cicchetto/scripts/check.ts` now runs every stage and exits
+non-zero if ANY did, closing with `check summary — N stages ran, M failed`.
 Read that line: it is what tells you the red is complete. It also passes
 `--max-diagnostics=none`, because biome's default ceiling of 20 truncated the
 one real error behind this tree's 59 standing warnings — a red naming no file
@@ -187,6 +187,37 @@ signature above; the guard now tests for CONTENT, and absence and
 emptiness are one state. If you see the self-heal install on a tree that
 looks populated, check whether it holds anything.
 
+**A populated `node_modules` can still be the WRONG one, and `check`'s
+first stage is what says so (#1571).** The self-heal above asks whether the
+tree has content, never whether that content is what `bun.lock` pins — and
+#1571 measured a main checkout whose biome was three minor versions off the
+lock, silently cloned into every worktree by the documented `cp -Rc`
+procedure. A verdict from an unpinned toolchain is unattributable in both
+directions: a rule that only fires on the newer version passes here and
+fails in CI, and one that only fires on the older fails here against code
+CI would accept. The `lock drift (node_modules vs bun.lock)` stage compares
+the two and names every package that disagrees; the cure it prints is
+`scripts/bun.sh install --frozen-lockfile`. It exits **3** without printing
+any number when one of its own known-answer controls fails, so a zero from
+it is never the sound of an instrument that measured nothing.
+
+**Documented limitation: the stage does NOT judge binaries for another
+platform, and those CAN be stale.** biome and rolldown ship a JS wrapper
+plus one binary package per platform, and `bun install` only resolves the
+one matching the platform it runs on. Every gate here runs bun inside a
+LINUX container, so on a macOS host the `*-darwin-*` packages are whatever
+the last host-side install left — measured 2026-08-20:
+`@biomejs/cli-darwin-arm64` at 2.4.13 against a lock pinning 2.5.8, three
+months older than its linux siblings, while the container executed the
+pinned 2.5.8 from the same tree. No gate reaches them (`bun`, `bunx` and
+`biome` are not on the host PATH, and nothing outside the container invokes
+them), and no command the project documents can refresh them, so making the
+gate red on them would be a red nobody could clear. What CAN reach them is
+a direct `cicchetto/node_modules/.bin/<tool>` call or an editor
+integration: if you use one, read its version yourself
+(`./cicchetto/node_modules/.bin/biome --version`) and do not treat its
+verdict as the gate's.
+
 **`scripts/bun.sh run check` counts a biome FORMAT violation as an
 ERROR, and hides which file it came from.** `check` starts with `biome
 check`: a line biome would reflow (a long `foo({ a, b, c })`
@@ -216,7 +247,7 @@ The authoritative source is the comment block at the top of each
 
 * **`scripts/test.sh`** → `scripts/mix.sh --env=test test --warnings-as-errors "$@"`. Forces `MIX_ENV=test` (auto-detect would use the live container's env, usually dev/prod, breaking sandbox).
 * **`scripts/check.sh`** → `scripts/mix.sh --env=dev ci.check` + `mix grappa.gen_wire_types --check` (wireTypes drift gate) + `scripts/bats.sh`. The `ci.check` alias (in `mix.exs`) chains: compile (warnings as errors), format check, credo, deps.audit, hex.audit, sobelow, `cmd env MIX_ENV=test mix doctor`, `cmd env MIX_ENV=test mix test --warnings-as-errors`, dialyzer, docs. Doctor shells out to `:test` since #621: in `:dev` it counts a module's functions from the source AST but reads doc/spec presence from the beam, so every `Mix.env() == :test`-gated helper is scored as undocumented, and `elixirc_paths` omits `test/support` there. `:test` is a strict superset on both axes, and matches the workflow's single `mix doctor` step. The `ci` workflow runs the same gates — including the wireTypes drift check since #767 — but it re-lists them by hand in YAML rather than invoking this script, so the two lists mirror each other only for as long as someone keeps them in step. A gate added here is not in CI until it is added there too; #767 was one instance of that (the drift gate was local-only, and a stale `wireTypes.ts` survived a merge with CI green).
-* **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = biome + tsc over `src` AND `e2e`. `install`, `add`, etc. forward to bun.
+* **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = the lock-drift stage (#1571) + biome + tsc over `src` AND `e2e`. `install`, `add`, etc. forward to bun.
 * **`scripts/bats.sh`** → host-side bats v1.9.0 (submodule at `vendor/bats-core`) against `test/bin/`, `test/infra/` and `test/scripts/`. NOT containerised — bats tests host-side bash (`bin/grappa`, the deploy scripts, the cloud installer). There is no compose involvement in the runner: the container is reached only transitively, when a test exercises a verb that shells out to docker, and those tests stub `docker` on `PATH` rather than touching a real one. So this gate needs no stack up.
 * **`scripts/release-image.sh`** → the RELEASE image (`Dockerfile.release`), not the compose dev stack. `build` buildx-loads it locally; `fresh-boot` wipes the scratch volume and bare-runs it with nothing but `PHX_HOST` (the documented one-liner — the point is that everything else must come from the image and the volume); `warm-boot` does the same on the EXISTING volume; `oneshot <args…>` runs a throwaway container against that volume; `logs` / `down [--volume]` clean up. This is the reproduction for #862 and #867, both of which were found by hand-typing docker commands because no wrapper reached this artifact.
 * **`scripts/smoke-release-image.sh`** → brings a box up from `$GRAPPA_IMAGE` through the real `infra/docker/get.sh` → `deploy.sh` release path (`GRAPPA_RAW_BASE=file://<checkout>`, so get.sh's mirror list is under test too), then probes it over HTTP and tears everything down. Dedicated container/volume names (`grappa-smoke*`), so it cannot eat an operator box. Requires the image to be present locally — **an unavailable image fails the run, it never skips it**. See "The release-image smoke" below.

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -164,13 +164,47 @@ substrate_preflight() {
 }
 
 substrate_build() {
-	# Hot path needs no build — the pulled commit is already in the
-	# bind-mounted source tree (compose.yaml mounts ./:/app). Cold path
-	# rebuilds the toolchain image.
-	[ "$MODE" = cold ] || return 0
+	# BOTH paths must leave fresh .beam in the code path the app boots from
+	# — the same requirement infra/freebsd/deploy.sh and
+	# infra/linux/deploy.sh state for their releases: the build "writes the
+	# fresh .beam into the daemon's code path that the hot reload POST then
+	# loads". POST /admin/reload only LOADS: Grappa.HotReload.reload_modified/0
+	# md5-walks the app's ebin and compiles nothing.
+	#
+	# Nothing on THIS substrate's hot path used to write that ebin, so the
+	# reload honestly answered `reloaded: []` over the PREVIOUS commit's
+	# modules while the banner, the exit code and the completed-deploy marker
+	# all reported success, and the box converged one commit late (#1601).
+	# "The pulled commit is already in the bind-mounted source tree" — the
+	# claim that used to sit here behind a `[ "$MODE" = cold ] || return 0` —
+	# is true of the SOURCES and says nothing about the BEAMS.
+	if [ "$MODE" = cold ]; then
+		# The image is toolchain-only; the beams come from the recreated
+		# container's own `mix phx.server` boot compile, which is why the
+		# cold healthcheck loop is the patient one.
+		echo "Building grappa image..."
+		"${DOCKER_COMPOSE[@]}" --profile prod build grappa
+		return 0
+	fi
 
-	echo "Building grappa image..."
-	"${DOCKER_COMPOSE[@]}" --profile prod build grappa
+	# Hot: a oneshot compiles into the same bind-mounted
+	# `_build/$MIX_ENV/lib/grappa/ebin` the live container booted from, which
+	# is exactly the ebin the reload then walks. Not a new mechanism — `mix
+	# grappa.seed_themes` was already compiling that ebin as a side effect,
+	# one step too LATE (deploy_common.sh `_deploy_hot`: reload, THEN seed).
+	# Doing it here puts it before `substrate_reload`, which deploy_common.sh
+	# guarantees by calling substrate_build ahead of the mode branch.
+	#
+	# No deps.get beside it: `mix.lock`/`mix.exs` are COLD triggers
+	# (Grappa.Deploy.Preflight `mix_deps?/1`), so a hot deploy cannot bring
+	# deps the box has not already fetched. --warnings-as-errors matches both
+	# release substrates, and under the consumers' `set -euo pipefail` a
+	# failed compile aborts BEFORE the reload — which is the point of the
+	# step: reloading over a tree that would not compile is the same defect
+	# with extra steps.
+	echo "Compiling the pulled commit (the reload only LOADS beams)..."
+	"${DOCKER_COMPOSE[@]}" --profile prod run --rm --no-deps grappa \
+		mix compile --warnings-as-errors
 }
 
 substrate_reload() {

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -62,6 +62,28 @@ defmodule Grappa.HotReload.LongLivedModules do
   they are not directly supervised but their shape is part of the
   parent's hot-reload surface.
 
+  **That half is derived and gated too, since GH #1473.** The
+  membership test walks the `t` typespec of every `@modules` entry to
+  a fixpoint, keeps the reachable `:grappa` modules that define a
+  struct, and requires each one's SOURCE FILE to be in the checked
+  set. It was hand-maintained and nothing held it: three structs
+  carrying live `Session.Server` / `IRC.Client` state were absent
+  (`Deps` and `DirectoryIngest` from the #1390 decomposition, plus
+  `IRC.FakeLag`), and a `defstruct` field-add to any of them
+  classified HOT — measured through `Preflight.classify/5`, with
+  `WindowState` as the listed control returning COLD.
+
+  **The unit of coverage is the FILE, not the module**, because
+  `Preflight.extract_state_block/1` reads a source file rather than a
+  module. A struct nested inside another module's file
+  (`LinksAccum.Entry`, `ListModeAccum.Entry`, `WhowasAccum.Entry`,
+  `DirectoryIngest.Run`) is therefore covered by listing its PARENT —
+  measured: a field-add to the nested `Run` moves
+  `directory_ingest.ex`'s extracted block. Such a module must NOT get
+  its own entry: `Grappa.Session.DirectoryIngest.Run` implies
+  `lib/grappa/session/directory_ingest/run.ex`, which does not exist,
+  and an absent file reads equal at both revs — the silent HOT.
+
   A `GenServer` the extractor sees NOTHING in is out of scope, and the
   membership test also refuses a listing it cannot see a shape for — an
   entry that buys no check reads as coverage while providing none. When
@@ -128,8 +150,18 @@ defmodule Grappa.HotReload.LongLivedModules do
   # Helper struct modules whose defstruct is a *field* of one of the
   # `@modules` above. A `defstruct` change here is just as
   # hot-reload-unsafe as a change to the parent's own defstruct.
+  #
+  # Order mirrors `@modules`: the `Session.Server` helpers (alphabetical),
+  # then `IRC.Client`'s, because that is the order their parents appear in.
+  #
+  # #1473 added the last three. List only a module whose CONVENTIONAL PATH
+  # is the file carrying the struct — a struct nested inside another
+  # module's file is covered by listing its parent and must NOT get its own
+  # entry. See the "What goes here" note above.
   @state_helpers [
     Grappa.Session.AwayState,
+    Grappa.Session.Deps,
+    Grappa.Session.DirectoryIngest,
     Grappa.Session.GhostRecovery,
     Grappa.Session.LinksAccum,
     Grappa.Session.ListModeAccum,
@@ -137,7 +169,8 @@ defmodule Grappa.HotReload.LongLivedModules do
     Grappa.Session.RecoverIdentity,
     Grappa.Session.WhoisAccum,
     Grappa.Session.WhowasAccum,
-    Grappa.Session.WindowState
+    Grappa.Session.WindowState,
+    Grappa.IRC.FakeLag
   ]
 
   @typedoc """
@@ -172,6 +205,8 @@ defmodule Grappa.HotReload.LongLivedModules do
   """
   @type state_helper ::
           Grappa.Session.AwayState
+          | Grappa.Session.Deps
+          | Grappa.Session.DirectoryIngest
           | Grappa.Session.GhostRecovery
           | Grappa.Session.LinksAccum
           | Grappa.Session.ListModeAccum
@@ -180,6 +215,7 @@ defmodule Grappa.HotReload.LongLivedModules do
           | Grappa.Session.WhoisAccum
           | Grappa.Session.WhowasAccum
           | Grappa.Session.WindowState
+          | Grappa.IRC.FakeLag
 
   @doc """
   Returns the list of long-lived `GenServer` modules whose state

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -38,6 +38,39 @@ defmodule Grappa.Repo.BusyRetry do
   The retry loop runs over a wall-clock BUDGET, sleeping a linear backoff
   capped per attempt, so a normal write caught behind a burst is ridden
   out; only sustained saturation degrades.
+
+  ## How far the budget REACHES (#1421)
+
+  The budget is a deadline consulted BETWEEN attempts. It cannot preempt an
+  attempt that is already running, because this engine does not own the wait —
+  so its reach depends on the FAULT'S OWN latency, and the two live topologies
+  do not share a regime:
+
+    * a pool `queue_timeout` is dropped by DBConnection near `queue_target`
+      (50ms, doubled once, then dropped — see its "Queue config"), well inside
+      the budget. This is the topology the budget was dimensioned for:
+      `config/config.exs` sizes it against "the ~1s pool-saturation window the
+      #336 incident measured".
+    * a write-lock `busy_locked` fault raises only once SQLite's
+      `busy_timeout` has expired — 30_000ms in every env, 20x the budget. The
+      first attempt has therefore already overshot the deadline by the time it
+      returns, so the loop makes EXACTLY ONE attempt and the linear backoff
+      below never runs.
+
+  A third topology WOULD fall inside the budget — a deferred read->write
+  upgrade raises an immediate `SQLITE_BUSY` that `busy_timeout` does not cover
+  — but it cannot occur here: every write transaction goes through
+  `Grappa.Repo.immediate_transaction/1`, statically enforced by
+  `Grappa.Repo.TransactionModeGateTest` (#1374).
+
+  The second regime is a DOCUMENTED LIMITATION rather than a wiring slip: one
+  number was dimensioned for one topology and later reused for another.
+  Re-dimensioning it changes retry behaviour under contention — #1420's
+  contested axis, and not this module's decision to take. What IS this
+  module's to take is to stop describing a bound it does not have, which is
+  why the terminal line below reports the wait it OBSERVED and never the
+  budget it was handed. Measured in
+  `Grappa.Repo.BusyRetryBudgetReachTest`; the options are priced in #1421.
   """
 
   require Logger
@@ -75,42 +108,43 @@ defmodule Grappa.Repo.BusyRetry do
           {:ok, result} | {:error, error | :db_unavailable}
         when result: var, error: var
   def run(op, opts) when is_function(op, 0) and is_list(opts) do
-    deadline = System.monotonic_time(:millisecond) + @budget_ms
-    loop(op, opts, deadline, 1)
+    # `started` rather than a precomputed deadline: the terminal line has to
+    # report the wall-clock it OBSERVED, and a deadline cannot say how far
+    # past itself the run went (#1421).
+    loop(op, opts, System.monotonic_time(:millisecond), 1)
   end
 
   @spec loop((-> {:ok, result} | {:error, error}), keyword(), integer(), pos_integer()) ::
           {:ok, result} | {:error, error | :db_unavailable}
         when result: var, error: var
-  defp loop(op, opts, deadline, attempt) do
+  defp loop(op, opts, started, attempt) do
     maybe_inject_fault()
     op.()
   rescue
     error in [DBConnection.ConnectionError, Exqlite.Error] ->
+      elapsed_ms = System.monotonic_time(:millisecond) - started
+
       cond do
         not transient_fault?(error) ->
           # Syntax / corruption — retrying spins pointlessly. Re-raise with
           # the original stacktrace so it surfaces as a loud 500, not a 503.
           reraise error, __STACKTRACE__
 
-        System.monotonic_time(:millisecond) < deadline ->
+        # Identical to the pre-#1421 `monotonic_time < started + @budget_ms`,
+        # rearranged so the same subtraction feeds the terminal line. Same
+        # arm, same boundary, no timing change.
+        elapsed_ms < @budget_ms ->
           on_contention(opts, fault_kind(error), attempt, false)
           # The backoff sleep runs after the failed checkout was already
           # released, so it holds no connection — bounded backpressure on the
           # flooding caller, not a held-conn leak (#340).
           Process.sleep(min(@backoff_ms * attempt, @backoff_cap_ms))
-          loop(op, opts, deadline, attempt + 1)
+          loop(op, opts, started, attempt + 1)
 
         true ->
           kind = fault_kind(error)
           on_contention(opts, kind, attempt, true)
-
-          Logger.warning(
-            "db write unavailable: #{observed_state(kind)} for the full " <>
-              "#{@budget_ms}ms retry budget (#{attempt} attempts) — returning :db_unavailable",
-            fault: kind
-          )
-
+          Logger.warning(terminal_message(kind, elapsed_ms, attempt), fault: kind)
           {:error, :db_unavailable}
       end
   end
@@ -129,6 +163,26 @@ defmodule Grappa.Repo.BusyRetry do
   @spec observed_state(fault_kind()) :: String.t()
   defp observed_state(:queue_timeout), do: "SQLite pool saturated"
   defp observed_state(:busy_locked), do: "SQLite write lock held by another writer"
+
+  # The same rule, applied to the NUMBER on that line (#1421). It used to read
+  # "for the full #{@budget_ms}ms retry budget", which is false in the regime
+  # that actually occurs: a `busy_locked` fault waits out SQLite's 30_000ms
+  # `busy_timeout` inside its FIRST attempt, so the line announced a 1500ms
+  # bound for a 30-second wait. The elapsed is the only figure the engine can
+  # vouch for; the budget stays on the line as context, not as the bound.
+  #
+  # 🔴 The #1429 census anchors on this prose, and its bats pins copy it
+  # VERBATIM. Both are anchored on the `observed_state/1` phrase ALONE, so this
+  # numeric tail can move again without blinding the counters — but a change to
+  # the two phrases above still has to move `scripts/log-gap-scan.awk` and
+  # `test/scripts/log_gap_scan_test.bats` in the SAME commit. A census whose
+  # pattern stopped matching reports zero, and zero is what a clean run looks
+  # like.
+  @spec terminal_message(fault_kind(), non_neg_integer(), pos_integer()) :: String.t()
+  defp terminal_message(kind, elapsed_ms, attempt) do
+    "db write unavailable: #{observed_state(kind)} for #{elapsed_ms}ms across " <>
+      "#{attempt} attempts (#{@budget_ms}ms retry budget) — returning :db_unavailable"
+  end
 
   # Invoke the caller's contention observer if one was supplied. Its return is
   # discarded — it is a side-channel (telemetry), not part of the retry result.

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -5,8 +5,9 @@
 #   scripts/bun.sh install
 #   scripts/bun.sh add phoenix
 #   scripts/bun.sh run build
-#   scripts/bun.sh run check                    # biome + tsc over src AND e2e (#484);
-#                                               # all 3 stages run, union of failures (#1469)
+#   scripts/bun.sh run check                    # lock drift (#1571) + biome + tsc over
+#                                               # src AND e2e (#484); every stage runs,
+#                                               # union of failures (#1469)
 #   scripts/bun.sh run test                     # vitest (cic unit tests in jsdom)
 #
 # Canonical "which test runner do I use?" docs: docs/TESTING.md.

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -93,7 +93,12 @@ function count_signatures(line) {
     if (line ~ /db=3[0-9][0-9][0-9][0-9]\./) CNT["db30"]++
     if (line ~ /idle=3[0-9][0-9][0-9][0-9]\./) CNT["idle30"]++
     if (line ~ /scrollback row dropped/) CNT["dropped"]++
-    if (line ~ /saturated for the full/) CNT["saturated"]++
+    # #1421 — anchored on the `observed_state/1` phrase ALONE, no longer on
+    # the numeric tail it used to share with `for the full 1500ms retry
+    # budget`. That tail now carries the OBSERVED elapsed and will move again;
+    # the phrase that names the topology is the stable half, and it is the
+    # half this counter is about.
+    if (line ~ /SQLite pool saturated/) CNT["saturated"]++
 
     # `index` before the three regexes: every lock signature carries the
     # literal "lock", and the stream is ~10^6 lines. The known-answer
@@ -198,11 +203,11 @@ BEGIN {
     sig("idle30", "client #PID<0.700.0> checked out, idle=30062.4ms")
     sig("dropped", "scrollback row dropped for #bofh: :persist_unavailable")
     sig("saturated", \
-        "db write unavailable: SQLite pool saturated for the full 1500ms retry budget" \
-        " (3 attempts) — returning :db_unavailable")
+        "db write unavailable: SQLite pool saturated for 1512ms across 14 attempts" \
+        " (1500ms retry budget) — returning :db_unavailable")
     sig("lockheld", \
-        "db write unavailable: SQLite write lock held by another writer for the full" \
-        " 1500ms retry budget (1 attempts) — returning :db_unavailable")
+        "db write unavailable: SQLite write lock held by another writer for 30067ms" \
+        " across 1 attempts (1500ms retry budget) — returning :db_unavailable")
     sig("lockstall", \
         "db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2" \
         " waiter(s) queued — holder at :gen_server.loop/7, stack: …")

--- a/test/grappa/hot_reload/long_lived_modules_membership_test.exs
+++ b/test/grappa/hot_reload/long_lived_modules_membership_test.exs
@@ -112,6 +112,61 @@ defmodule Grappa.HotReload.LongLivedModulesMembershipTest do
     end
   end
 
+  describe "state-helper membership" do
+    test "the derived state-field struct set is non-vacuous" do
+      # Same guard as the GenServer half: every assertion below is
+      # "for each struct ..." and would pass on an empty set. 26 struct
+      # modules were reachable when this landed; the floor is slack on
+      # purpose — it catches a derivation that stopped walking, not a
+      # headcount.
+      structs = state_field_struct_modules()
+
+      assert length(structs) >= 15,
+             """
+             Only #{length(structs)} struct module(s) reachable from the
+             `t` typespec of a tracked module — the closure is broken and
+             the membership assertion below is vacuous.
+
+             Reached: #{inspect(structs)}
+             """
+    end
+
+    test "every struct held in a tracked module's state has its source file checked" do
+      checked = MapSet.new(Preflight.long_lived_module_files())
+
+      unchecked =
+        state_field_struct_modules()
+        |> Enum.map(&{&1, compile_source(&1)})
+        |> Enum.reject(fn {_, src} -> MapSet.member?(checked, src) end)
+        |> Enum.group_by(fn {_, src} -> src end, fn {mod, _} -> mod end)
+
+      assert unchecked == %{},
+             """
+             Struct(s) whose shape is part of a tracked module's state, in a
+             source file Grappa.Deploy.Preflight does not check:
+
+             #{Enum.map_join(unchecked, "\n", fn {src, mods} -> "  #{src} — #{Enum.map_join(mods, ", ", &inspect/1)}" end)}
+
+             The preflight state-shape-checks only the files behind
+             `LongLivedModules.all/0`, so a `defstruct` field-add to one of
+             these classifies HOT: the swapped beam then pattern-matches the
+             new struct shape against the state a live process already holds.
+
+             Fix: add the module whose CONVENTIONAL PATH is that file to
+             @state_helpers AND to the `state_helper` union in
+             lib/grappa/hot_reload/long_lived_modules.ex.
+
+             Note the unit of coverage is the FILE, not the module: a struct
+             nested inside another module's file (`LinksAccum.Entry`,
+             `ListModeAccum.Entry`, `WhowasAccum.Entry`,
+             `DirectoryIngest.Run`) is covered by listing its PARENT, and
+             must NOT be listed itself — its conventional path does not
+             exist, which Preflight reads as absent at both revs, compares
+             equal, and classifies HOT.
+             """
+    end
+  end
+
   # Every module of the running application that declares the GenServer
   # behaviour and was compiled from `lib/`. `Application.spec/2` is the
   # OTP-level module list — no source parsing, no second enumeration to
@@ -142,6 +197,80 @@ defmodule Grappa.HotReload.LongLivedModulesMembershipTest do
     case mod.module_info(:compile)[:source] do
       source when is_list(source) -> String.contains?(List.to_string(source), "/lib/")
       _ -> false
+    end
+  end
+
+  # Every struct module whose shape is part of a tracked module's state,
+  # reached by walking `t` typespecs to a fixpoint from the tracked
+  # GenServers.
+  #
+  # The typespec comes from the BEAM chunk, not the source: module names
+  # arrive fully qualified, so there is no alias table to resolve and no
+  # second parser to keep in step with the compiler. Staying inside
+  # `Application.spec(:grappa, :modules)` is the same enumeration the
+  # GenServer half derives from, and it is what drops `DateTime` and
+  # `MapSet` — stdlib structs with no source in this repo.
+  #
+  # Transitive on purpose: a helper may hold a struct of its own, and only
+  # the closure sees it. `Grappa.Session.DirectoryIngest.Run` is the live
+  # example.
+  defp state_field_struct_modules do
+    grappa = MapSet.new(Application.spec(:grappa, :modules))
+    seeds = LongLivedModules.modules()
+
+    seeds
+    |> close(MapSet.new(seeds), grappa)
+    |> Enum.filter(&struct_module?/1)
+    |> Enum.sort()
+  end
+
+  defp close([], seen, _), do: seen
+
+  defp close([mod | rest], seen, grappa) do
+    next =
+      mod
+      |> remote_modules_in_t()
+      |> Enum.filter(&(MapSet.member?(grappa, &1) and not MapSet.member?(seen, &1)))
+      |> Enum.uniq()
+
+    close(rest ++ next, MapSet.union(seen, MapSet.new(next)), grappa)
+  end
+
+  defp remote_modules_in_t(mod) do
+    case Code.Typespec.fetch_types(mod) do
+      {:ok, types} ->
+        types
+        |> Enum.filter(fn {kind, {name, _, args}} ->
+          kind in [:type, :opaque] and name == :t and args == []
+        end)
+        |> Enum.flat_map(fn {_, {_, form, _}} -> remote_modules(form, []) end)
+
+      :error ->
+        []
+    end
+  end
+
+  defp remote_modules({:remote_type, _, [{:atom, _, mod}, {:atom, _, _}, args]}, acc),
+    do: Enum.reduce(args, [mod | acc], &remote_modules/2)
+
+  defp remote_modules(tuple, acc) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> Enum.reduce(acc, &remote_modules/2)
+
+  defp remote_modules(list, acc) when is_list(list),
+    do: Enum.reduce(list, acc, &remote_modules/2)
+
+  defp remote_modules(_, acc), do: acc
+
+  defp struct_module?(mod),
+    do: Code.ensure_loaded?(mod) and function_exported?(mod, :__struct__, 0)
+
+  # The file the module was COMPILED from, repo-relative. A nested module
+  # reports its parent's file, which is exactly the unit Preflight checks —
+  # so nesting needs no special case here.
+  defp compile_source(mod) do
+    case mod.module_info(:compile)[:source] do
+      source when is_list(source) -> source |> List.to_string() |> Path.relative_to(File.cwd!())
+      _ -> nil
     end
   end
 

--- a/test/grappa/repo/busy_retry_budget_reach_test.exs
+++ b/test/grappa/repo/busy_retry_budget_reach_test.exs
@@ -1,0 +1,181 @@
+defmodule Grappa.Repo.BusyRetryBudgetReachTest do
+  @moduledoc """
+  #1421 — how far the `Grappa.Repo.BusyRetry` retry BUDGET actually reaches,
+  measured against a REAL driver `SQLITE_BUSY` rather than a hand-built one.
+
+  ## Why the engine's own suite could not see this
+
+  Every other retry test raises a `%Exqlite.Error{}` WE build, from a
+  zero-cost closure. The fault is therefore FREE, and the budget is the only
+  thing bounding the loop — which is exactly the regime in which the budget
+  looks like it works. Reality charges for the fault: a contending write sits
+  inside SQLite's `busy_timeout` before it raises at all.
+
+  The budget is a deadline consulted BETWEEN attempts (`busy_retry.ex`, the
+  `System.monotonic_time(:millisecond) < deadline` arm), so it cannot preempt
+  an attempt that is already running. Whichever of the two numbers is larger
+  decides how many attempts there are — and nothing in the engine can change
+  that, because the engine does not own the wait.
+
+  ## What this file measures
+
+  The SAME engine and the SAME budget, varying ONLY `busy_timeout`, over a
+  real write-lock contention on a private temp repo (the `pool_size: 1`
+  Sandbox cannot contend with itself, which is why the injection seam exists
+  in the first place):
+
+    * `busy_timeout` ABOVE the budget → exactly ONE attempt. Production runs
+      `30_000` against `1_500`, a ratio of 20; this runs 2, and the collapse
+      is a property of the ratio, not of the magnitudes.
+    * `busy_timeout` BELOW the budget → many attempts. This is the regime the
+      budget was dimensioned for (#340, `config/config.exs`: *"comfortably
+      longer than the ~1s pool-saturation window the #336 incident
+      measured"*) — a pool `queue_timeout`, whose drop latency DBConnection
+      caps near `queue_target` (50 ms doubled to 100 ms by default).
+
+  Tests 1 and 2 are a MEASUREMENT of the status quo and pass on unmodified
+  main; they are load-bearing because a mutation of the deadline arm turns
+  them red, not because they started red. Test 3 is the one that starts red:
+  the terminal line reports the budget it was told instead of the wait it
+  observed.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.Repo.BusyRetry
+
+  defmodule TmpRepo do
+    use Ecto.Repo, otp_app: :grappa, adapter: Ecto.Adapters.SQLite3
+  end
+
+  # The very number the engine compiled itself with — never a literal here, or
+  # the bench and the engine can drift apart while both stay green.
+  @budget_ms Application.compile_env(:grappa, [:busy_retry, :budget_ms], 1_500)
+
+  # Runs one genuinely contended write through the engine and reports what was
+  # OBSERVED: the engine's return, the fault kind, the terminal attempt count,
+  # the caller's own wall-clock, and the log it emitted. `busy_timeout` is the
+  # single independent variable.
+  defp measure_contended_write(busy_timeout) do
+    path =
+      Path.join(System.tmp_dir!(), "busy_retry_budget_#{System.unique_integer([:positive])}.db")
+
+    on_exit(fn -> Enum.each(["", "-wal", "-shm"], &File.rm(path <> &1)) end)
+
+    {:ok, repo} =
+      TmpRepo.start_link(
+        database: path,
+        pool_size: 1,
+        busy_timeout: busy_timeout,
+        journal_mode: :wal
+      )
+
+    TmpRepo.query!("CREATE TABLE t(id integer)")
+
+    # A SEPARATE raw connection holds the file write-lock for the WHOLE
+    # measurement, so every attempt the engine makes genuinely contends. Its
+    # own busy_timeout is 0 so setting up the hold can never itself wait.
+    {:ok, holder} = Exqlite.Sqlite3.open(path)
+    :ok = Exqlite.Sqlite3.execute(holder, "PRAGMA busy_timeout=0")
+    :ok = Exqlite.Sqlite3.execute(holder, "BEGIN IMMEDIATE")
+    :ok = Exqlite.Sqlite3.execute(holder, "INSERT INTO t VALUES (1)")
+
+    {:ok, seen} = Agent.start_link(fn -> [] end)
+
+    started = System.monotonic_time(:millisecond)
+
+    {result, log} =
+      with_log(fn ->
+        BusyRetry.run(fn -> {:ok, TmpRepo.query!("INSERT INTO t VALUES (2)")} end,
+          on_contention: fn kind, attempt, terminal? ->
+            Agent.update(seen, &[{kind, attempt, terminal?} | &1])
+          end
+        )
+      end)
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started
+    events = Agent.get(seen, &Enum.reverse(&1))
+
+    # Teardown BEFORE any assertion runs, so a red leaves no repo and no held
+    # write-lock behind for the next test in this serial file.
+    :ok = Exqlite.Sqlite3.close(holder)
+    Supervisor.stop(repo)
+
+    {kind, terminal_attempt, true} = List.last(events)
+
+    %{result: result, kind: kind, attempts: terminal_attempt, elapsed_ms: elapsed_ms, log: log}
+  end
+
+  # The terminal line, isolated from whatever else Logger carried during the
+  # capture.
+  defp terminal_line(log) do
+    log |> String.split("\n") |> Enum.find("", &(&1 =~ "db write unavailable"))
+  end
+
+  # The wall-clock the terminal line CLAIMS, read back out of the line itself.
+  # `nil` when it claims none — which is the state test 3 starts in.
+  defp reported_wait_ms(log) do
+    case Regex.run(~r/db write unavailable:.* for (\d+)ms/, terminal_line(log)) do
+      [_, ms] -> String.to_integer(ms)
+      nil -> nil
+    end
+  end
+
+  describe "the budget's reach against a REAL write-lock contention" do
+    test "a busy_timeout ABOVE the budget collapses the loop to exactly ONE attempt" do
+      busy_timeout = @budget_ms * 2
+
+      observed = measure_contended_write(busy_timeout)
+
+      assert observed.result == {:error, :db_unavailable}
+      assert observed.kind == :busy_locked
+
+      # THE defect #1421 names: at this ratio the linear backoff and every
+      # attempt after the first are unreachable BY CONSTRUCTION.
+      assert observed.attempts == 1
+
+      # ...and the caller waited the busy_timeout, not the budget it was told.
+      assert observed.elapsed_ms >= busy_timeout
+    end
+
+    test "a busy_timeout BELOW the budget makes the retry loop reachable — many attempts" do
+      # The positive control for the loop itself: same engine, same budget,
+      # only the fault got cheap. If THIS one collapsed to a single attempt
+      # too, the finding above would be about the engine and not about the
+      # relationship between the two numbers.
+      observed = measure_contended_write(0)
+
+      assert observed.result == {:error, :db_unavailable}
+      assert observed.kind == :busy_locked
+      assert observed.attempts > 1
+      assert observed.elapsed_ms >= @budget_ms
+    end
+  end
+
+  describe "the terminal line reports the wait it OBSERVED (CLAUDE.md log honesty)" do
+    test "it names the elapsed wall-clock, never a budget that did not bound it" do
+      busy_timeout = @budget_ms * 2
+
+      observed = measure_contended_write(busy_timeout)
+      line = terminal_line(observed.log)
+
+      # The premise of the assertion below: this IS the one-attempt regime.
+      assert observed.attempts == 1
+
+      # The line must carry the wait that happened. `is_integer/1` FIRST and
+      # separately: Elixir's term order puts every atom above every number, so
+      # a `nil >= 600` from a line with no elapsed at all is `true` and the
+      # comparison alone passes vacuously. Measured — the first red run of
+      # this file failed only on the refute below, with `reported_wait_ms/1`
+      # returning nil.
+      reported = reported_wait_ms(observed.log)
+      assert is_integer(reported), "the terminal line carries no elapsed at all: #{line}"
+      assert reported >= busy_timeout
+
+      # ...and must not go on claiming the budget was what ran out, when the
+      # budget was overshot by the first attempt on its own.
+      refute line =~ "for the full #{@budget_ms}ms retry budget"
+    end
+  end
+end

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -135,6 +135,33 @@ run_hot() {
     refute grep -q 'healthz' "$ARGV_LOG"
 }
 
+@test "the hot path COMPILES before it reloads, or the reload loads stale beams (#1601)" {
+    # The Docker hot path skipped the build entirely — "the pulled commit is
+    # already in the bind-mounted source tree" is true of the SOURCES and
+    # false of the BEAMS. POST /admin/reload only LOADS: it md5-walks the
+    # app's ebin. With nothing compiled, it honestly answers `reloaded: []`
+    # and the deploy declares success over the previous commit's modules.
+    #
+    # The freebsd and linux substrates already compile on BOTH paths, and
+    # say why: "it writes the fresh .beam into the daemon's code path that
+    # the hot reload POST then loads". This is that, for docker.
+    #
+    # Ordering, not mere presence: a compile AFTER the reload is what the
+    # seed step already does by accident, and it is what left the box one
+    # commit late.
+    export RELOAD_RESPONSE='{"reloaded":[],"failed":[]}'
+    export HEALTHZ_RC=0
+
+    run_hot
+    [ "$status" -eq 0 ]
+
+    grep -q 'mix compile' "$ARGV_LOG"
+
+    compile_line=$(grep -n 'mix compile' "$ARGV_LOG" | head -1 | cut -d: -f1)
+    reload_line=$(grep -n 'admin/reload' "$ARGV_LOG" | head -1 | cut -d: -f1)
+    [ "$compile_line" -lt "$reload_line" ]
+}
+
 @test "reload ok but healthcheck never returns 200 FAILS the deploy" {
     export RELOAD_RESPONSE='{"reloaded":[],"failed":[]}'
     export HEALTHZ_RC=1

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -27,8 +27,8 @@ setup() {
     #   busy_retry.ex — the two terminal arms, one per fault kind
     LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
-    LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for the full 1500ms retry budget (1 attempts) — returning :db_unavailable'
-    SATURATED_LINE='db write unavailable: SQLite pool saturated for the full 1500ms retry budget (3 attempts) — returning :db_unavailable'
+    LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for 30067ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
+    SATURATED_LINE='db write unavailable: SQLite pool saturated for 1512ms across 14 attempts (1500ms retry budget) — returning :db_unavailable'
 }
 
 # The scanner as integration.sh invokes it: a service label and a
@@ -89,7 +89,7 @@ stamp() {
         stamp '12:00:00.' 'db=30064.1ms query returned'
         stamp '12:00:01.' 'conn idle=30062.4ms checked out'
         stamp '12:00:02.' 'scrollback row dropped for #bofh'
-        stamp '12:00:03.' 'pool saturated for the full 30s'
+        stamp '12:00:03.' "$SATURATED_LINE"
         stamp '12:00:04.' "$LOCKHELD_LINE"
         stamp '12:00:05.' "$LOCKSTALL_LINE"
         stamp '12:00:06.' "$LOCKRESOLVED_LINE"
@@ -158,6 +158,22 @@ stamp() {
     out="$( stamp '12:00:00.' "$SATURATED_LINE" | scan 10 )"
     grep -q 'saturated=1' <<<"$out"
     grep -q 'lockheld=0' <<<"$out"
+}
+
+@test "both terminal counters survive a change to the line's numeric tail" {
+    # #1421 moved that tail: it used to read "for the full 1500ms retry
+    # budget" and now carries the OBSERVED elapsed, which varies per event.
+    # The anchors are the `observed_state/1` phrases alone precisely so the
+    # next number that moves does not blind the census — a pattern that
+    # stopped matching reports zero, and zero is what a clean run looks like.
+    local out
+    out="$( {
+        stamp '12:00:00.' 'db write unavailable: SQLite pool saturated for 9ms across 2 attempts (7ms retry budget) — returning :db_unavailable'
+        stamp '12:00:01.' 'db write unavailable: SQLite write lock held by another writer for 123456ms across 3 attempts (7ms retry budget) — returning :db_unavailable'
+    } | scan 10 )"
+
+    grep -q 'saturated=1' <<<"$out"
+    grep -q 'lockheld=1' <<<"$out"
 }
 
 # --- the scanner's own controls -------------------------------------------


### PR DESCRIPTION
Four already-mergeable PRs, all forked from the same base, combined into one branch so that CI
attests **branch + base + each other** instead of four greens that each attest only branch + base.

Merging them in sequence would cost four rebases and four integration runs, and no single green
would say anything about the other three. This is both cheaper and more honest.

| subsumes | slice | branch | original head |
|---|---|---|---|
| #1600 | #1571 — the cic gate says whether the toolchain matches the lockfile | `w2-1571` | `f20ce48b` |
| #1602 | #1473 — derive the state-helper half of the tracked set | `w1-1473` | `61f23944` |
| #1604 | #1421 — report the wait the retry engine observed, not the budget | `w2-1421` | `18064d28` |
| #1605 | #1601 — compile on the Docker hot path, before the reload | `w1-1601` | `7e0c749f` |

Every head above was re-read from the API at build time, not copied from a briefing.

## Disjointness, measured rather than assumed

All four merge bases resolve to the same commit (`fa2308b9`), and the source-file sets do not
intersect at all. The only shared paths are two documents:

- `docs/DESIGN_NOTES.md` — all four append an entry
- `docs/OPERATIONS.md` — #1421 and #1601, at lines ~4754 and ~640 respectively (three disjoint hunks,
  `19/5` in the union = `7/1` + `12/4`, both additions present in the final file)

The union's changed-file set is byte-identical to the union of the four individual sets: 16 files.

## The union driver actually ran, so the four checks are not vacuous

`docs/DESIGN_NOTES.md` carries `merge=union`, and three of the four cherry-picks reported
`Auto-merging docs/DESIGN_NOTES.md`. That is precisely the machinery #1271 and #1432 exist to catch,
so the recipe was run on the final result:

1. **Numstat, two-sided.** `437 / 0` — additions are exactly the sum of the four slices
   (93 + 105 + 138 + 101) and deletions are zero. Neither direction drifted: nothing was EATEN
   (#1271/#1428) and nothing was RESURRECTED (#1432).
2. **Prefix byte-identical** to `origin/main`'s copy of the file (`head -c 3173423 … | cmp`), which
   subsumes the tail-of-the-previous-entry check for all four boundaries at once.
3. **Boundary shape read on the file, for each of the four** — text line / marker with no blank
   ahead of it / blank / `---` / blank / `##`. Verified at lines 53052 (#1571), 53145 (#1473),
   53250 (#1421), 53388 (#1601). No entry is glued to another and no separator went missing; the
   order follows the pick order, after the base's last entry (#1509).
4. **Four markers, one each, each unique against `origin/main` as it stands now** — the #1428 scope
   that bites, since a marker the base already carries costs four lines instead of three.

`scripts/design-notes-gate.sh` reports `4 new entry heading(s), separator and marker present`, rc=0.

## Content equivalence with the four originals

Cherry-picking rewrites SHAs, so equivalence is shown rather than assumed. The first oracle tried was
`git patch-id --stable`, and it flagged three of the eight commits — all three of the same class (a
DESIGN_NOTES-only commit landing after another one). A uniform failure across one class accuses the
instrument: `patch-id` ignores line numbers but not **context lines**, and each entry necessarily
lands after a different preceding entry here. The instrument was wrong, not the pick.

The right oracle compares the **added and removed lines** of each commit against its twin. Result:
**eight of eight identical, both directions**. The oracle carries its own control — two genuinely
different commits compare as different, so the eight passes are not a blind "everything matches".

| slice | commits | added lines | removed lines |
|---|---|---|---|
| #1571 | 2 | identical | identical |
| #1473 | 2 | identical | identical |
| #1421 | 2 | identical | identical |
| #1601 | 2 | identical | identical |

## On the merit, not just the git

The two slices that touch the hot-reload story are complementary rather than overlapping: #1473
changes *what gets classified cold* (the tracked long-lived-module set), while #1601 changes *what
the hot path does once classified* (it compiles before reloading). Neither moves
`Preflight.classify/5`. Nothing here suggests a slice's premise died in transit.

## Not claimed

No local gate was run on the union — this PR's CI is the gate, deliberately, since a local green
would be a second copy of the same attestation. The four individual PRs' greens are **not** carried
over as evidence for this branch: each of them attests branch + base, which is exactly the gap this
union exists to close.

The four PRs are left OPEN on purpose. Cherry-picking rewrote the SHAs, so GitHub will not close them
on merge; they should be closed by content, naming this union.

Refs #1571, #1473, #1421, #1601.
