### PR TITLE
fix(#1505): an empty TOPIC is a cleared topic — persist it, and say so on both surfaces

### DIFF
--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -15,7 +15,7 @@ import { isContentKind, ownNickForNetwork, type ScrollbackMessage } from "./lib/
 import { acceptInvite, confirmJoinChannel } from "./lib/channelJoin";
 import { channelKey, decodeChannelKey } from "./lib/channelKey";
 import { statusmsgDescription } from "./lib/channelModes";
-import { type TopicJoinLine, topicByChannel, topicJoinLine } from "./lib/channelTopic";
+import { hasNoTopic, type TopicJoinLine, topicByChannel, topicJoinLine } from "./lib/channelTopic";
 import { isChannelName } from "./lib/chantypes";
 import { stripCtcpAction } from "./lib/ctcpAction";
 import { isDocumentVisible } from "./lib/documentVisibility";
@@ -975,6 +975,21 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       );
     }
     case "topic":
+      // #1505 — `TOPIC #chan :` (empty trailing) is how an operator CLEARS a
+      // topic, and the server persists it verbatim as `body: ""` (#1500's
+      // ruling: the wire carried an empty string, not an absence). The
+      // generic arm below would emit `* alice changed topic:` and stop —
+      // `parseMircFormat("")` yields zero runs, so `<MircBody>` renders
+      // nothing. That asserts *changed* and then shows a blank, which reads
+      // as a truncated line rather than as the event that happened. `null` is
+      // folded in by the same predicate: absence and emptiness both mean the
+      // channel has no topic, and a renderer arm that says so cannot be
+      // reached with an "undefined" to print.
+      if (hasNoTopic(msg.body)) {
+        return (
+          <span class="scrollback-body">* {bareSenderSpan(msg.sender)} cleared the topic</span>
+        );
+      }
       return (
         <span class="scrollback-body">
           * {bareSenderSpan(msg.sender)} changed topic: <MircBody body={msg.body ?? ""} emphasis />

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -6,6 +6,7 @@ import { channelKey } from "./lib/channelKey";
 import {
   compactModeString,
   flattenTopicNewlines,
+  hasNoTopic,
   modesByChannel,
   topicByChannel,
 } from "./lib/channelTopic";
@@ -106,6 +107,12 @@ const TopicBar: Component<Props> = (props) => {
 
   const topicEntry = () => topicByChannel()[key()] ?? null;
   const topicText = () => topicEntry()?.text ?? null;
+  // #1505 — the placeholder gate. `hasNoTopic` and not `text !== null`: a
+  // CLEARED topic arrives as `""` (the empty trailing the wire carried), and
+  // the old gate let it through to `MircBody`, which emits zero runs for an
+  // empty body. The strip then painted an EMPTY box and the tooltip an empty
+  // string — a blank rectangle where "(no topic set)" belongs.
+  const topicMissing = () => hasNoTopic(topicText());
   // #142: the `title` tooltip + the rendered strip both come from the same
   // topic. The strip routes the raw text through `MircBody` (formatting
   // renders); the tooltip is a plain-text-only attribute surface, so it
@@ -113,7 +120,7 @@ const TopicBar: Component<Props> = (props) => {
   // the ONE parser, never leaked raw into the attribute.
   const topicTitle = () => {
     const t = topicText();
-    return t !== null ? mircPlainText(t) : "(no topic set)";
+    return topicMissing() ? "(no topic set)" : mircPlainText(t ?? "");
   };
   const modesEntry = () => modesByChannel()[key()] ?? null;
   const modeStr = () => {
@@ -180,7 +187,7 @@ const TopicBar: Component<Props> = (props) => {
     // Empty submit with nothing to clear → nothing to send: revert to read-only
     // (modal stays open), like cancel. Done BEFORE `setSaving(true)` so the
     // (saving-guarded) `cancelEdit` reverts cleanly.
-    if (trimmed === "" && (topicText() === null || topicText() === "")) {
+    if (trimmed === "" && topicMissing()) {
       cancelEdit();
       return;
     }
@@ -349,7 +356,7 @@ const TopicBar: Component<Props> = (props) => {
             reimplementation is needed. MircBody emits its runs with no block
             wrapper, so they land as the span's direct line-box content. */}
           <span class="topic-bar-topic-text">
-            <Show when={topicText() !== null} fallback={"(no topic set)"}>
+            <Show when={!topicMissing()} fallback={"(no topic set)"}>
               {/* #220 — the bar NEVER navigates a link directly; a tap on a
                 link "surface-wins" (suppresses navigation) and bubbles to
                 the strip's onClick, which opens the modal. */}
@@ -384,7 +391,7 @@ const TopicBar: Component<Props> = (props) => {
               fallback={
                 <>
                   <p class="topic-modal-text">
-                    <Show when={topicText() !== null} fallback={"(no topic set)"}>
+                    <Show when={!topicMissing()} fallback={"(no topic set)"}>
                       <MircBody body={topicText() ?? ""} emphasis />
                     </Show>
                   </p>

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1106,6 +1106,58 @@ describe("ScrollbackPane", () => {
     expect(document.querySelector("form.compose")).toBeNull();
   });
 
+  // #1505 — `TOPIC #chan :` (empty trailing) is how an operator CLEARS a
+  // topic. The server persists the row with `body: ""` (the empty string the
+  // wire carried; #1500 pinned "" over NULL). The generic arm renders
+  // `changed topic: ` + `<MircBody body="">`, and `parseMircFormat("")`
+  // returns zero runs — so the line asserts "changed" and then shows nothing,
+  // which reads as a truncated render rather than as a cleared topic.
+  describe("#1505 — an empty topic body renders as CLEARED, not as a truncation", () => {
+    const topicRow = (body: string | null) => ({
+      id: 1,
+      network: "freenode",
+      channel: "#a",
+      server_time: 100,
+      kind: "topic" as const,
+      sender: "alice",
+      body,
+      meta: {},
+    });
+
+    it("says the topic was cleared and never claims it was 'changed'", () => {
+      setScrollback({ "freenode #a": [topicRow("")] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#a" kind="channel" />);
+      const line = screen.getAllByTestId("scrollback-line")[0];
+      expect(line).toHaveTextContent("* alice cleared the topic");
+      expect(line).not.toHaveTextContent("changed topic");
+    });
+
+    // The `body: null` shape is not produced by the TOPIC path (the row is
+    // body-required-relaxed, not body-dropped), but the renderer's own `??`
+    // makes it reachable from any cold-deploy backfill row. Absence and
+    // emptiness both mean "there is no topic", so they render the same.
+    it("renders the cleared wording for a null body too", () => {
+      setScrollback({ "freenode #a": [topicRow(null)] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#a" kind="channel" />);
+      expect(screen.getAllByTestId("scrollback-line")[0]).toHaveTextContent(
+        "* alice cleared the topic",
+      );
+    });
+
+    // The non-empty arm is the control: the cleared branch must not swallow a
+    // real topic change. A whitespace-only topic is NOT cleared — it is a
+    // topic made of spaces, which the wire carried and which `topicJoinLine`
+    // separately declines to PRINT; the row still reports the change.
+    it("still reports a real change, including a whitespace-only topic", () => {
+      setScrollback({ "freenode #a": [topicRow("new topic"), { ...topicRow(" "), id: 2 }] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#a" kind="channel" />);
+      const lines = screen.getAllByTestId("scrollback-line");
+      expect(lines[0]).toHaveTextContent("* alice changed topic: new topic");
+      expect(lines[1]).toHaveTextContent("changed topic");
+      expect(lines[1]).not.toHaveTextContent("cleared the topic");
+    });
+  });
+
   describe("mention highlight (P4-1)", () => {
     it("adds .scrollback-mention to lines that mention the user's nick", () => {
       setUserNick("vjt");

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -209,10 +209,18 @@ vi.mock("../lib/members", () => ({
   sortMembers: <T,>(list: T[]) => list,
 }));
 
-vi.mock("../lib/channelTopic", () => ({
+// Only the STORE half is faked; the pure helpers come through
+// `importOriginal` (CLAUDE.md: use production code in tests, never
+// re-implement logic — the same shape TopicBar.test.tsx uses). A literal
+// factory here was a partial that LIED about the module's surface: every
+// helper TopicBar picks up later arrives `undefined` and takes the whole
+// Shell tree down at render, which is how #1505's `hasNoTopic` broke 29
+// tests in a file that has nothing to do with topics. `compactModeString`
+// was already being re-implemented inline for the same reason.
+vi.mock("../lib/channelTopic", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/channelTopic")>()),
   topicByChannel: () => ({}),
   modesByChannel: () => ({}),
-  compactModeString: (modes: string[]) => (modes.length > 0 ? `+${modes.join("")}` : ""),
   seedTopic: vi.fn(),
   seedModes: vi.fn(),
   dropChannelTopicState: vi.fn(),

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -175,6 +175,44 @@ describe("TopicBar", () => {
     expect(screen.getByText("(no topic set)")).toBeInTheDocument();
   });
 
+  // #1505 — an operator who CLEARS the topic (`TOPIC #chan :`) makes the
+  // server cache `text: ""`, not `text: null`: `null` is the 331 RPL_NOTOPIC
+  // / not-yet-arrived shape, `""` is what the wire carried. Both mean "this
+  // channel has no topic", so both MUST reach the placeholder — gating on
+  // `!== null` alone paints an empty strip, a blank rectangle rather than a
+  // statement. `topicJoinLine` already treats `""` as no-topic; the bar was
+  // the surface that disagreed.
+  it("#1505 shows placeholder when the topic was CLEARED (empty text)", () => {
+    mockTopicByChannel.mockReturnValue({
+      "freenode #italia": { text: "", set_by: "vjt", set_at: null },
+    });
+    render(() => <TopicBar {...baseProps()} />);
+    expect(screen.getByText("(no topic set)")).toBeInTheDocument();
+  });
+
+  // The modal reads the same entry through the same gate, so it carries the
+  // same defect and the same cure.
+  it("#1505 shows placeholder in the modal when the topic was CLEARED", () => {
+    mockTopicByChannel.mockReturnValue({
+      "freenode #italia": { text: "", set_by: "vjt", set_at: "2026-05-04T10:00:00Z" },
+    });
+    render(() => <TopicBar {...baseProps()} />);
+    fireEvent.click(screen.getByTestId("topic-strip"));
+    const modal = screen.getByRole("dialog");
+    expect(modal.querySelector(".topic-modal-text")).toHaveTextContent("(no topic set)");
+  });
+
+  // Control: a whitespace-only topic is a topic the wire carried, not an
+  // absence. It must NOT collapse into the placeholder — otherwise the cure
+  // would be `trim()`-shaped and would erase a real (if silly) topic.
+  it("#1505 does NOT show the placeholder for a whitespace-only topic", () => {
+    mockTopicByChannel.mockReturnValue({
+      "freenode #italia": { text: " ", set_by: "vjt", set_at: null },
+    });
+    render(() => <TopicBar {...baseProps()} />);
+    expect(screen.queryByText("(no topic set)")).toBeNull();
+  });
+
   // #263 — tapping the strip ALWAYS opens the read-only modal, for EVERYONE
   // (the #74 inline in-place editor is gone). The modal shows the full topic,
   // setter + timestamp. An op additionally sees a ✏️ toggle (tested in the

--- a/cicchetto/src/lib/channelTopic.ts
+++ b/cicchetto/src/lib/channelTopic.ts
@@ -48,6 +48,29 @@ export type ModesEntry = {
   params: Record<string, string | null>;
 };
 
+/**
+ * #1505 — "this channel has no topic", the ONE predicate every surface asks.
+ *
+ * The server publishes that fact in TWO shapes and both are truthful:
+ * `null` is 331 RPL_NOTOPIC (or a topic that has not arrived yet), `""` is
+ * what an operator's `TOPIC #chan :` actually put on the wire — the same
+ * empty trailing `Client.send_topic_clear/2` writes for our own
+ * `/topic -delete`. #1500 pinned `""` over `NULL` for the stored body on the
+ * rule that the wire carried an empty string, not an absence; the server
+ * therefore does NOT normalise the two into one, and the READ side is where
+ * they converge.
+ *
+ * Whitespace is deliberately NOT trimmed: a topic of spaces is a topic the
+ * wire carried, so `" "` is present, not absent. `topicJoinLine` is stricter
+ * on purpose and that divergence is presentational, not a second answer to
+ * this question — it decides whether to PRINT a join-time line at all, and a
+ * line that would render blank is worth nothing there. The bar has no such
+ * option: it occupies its strip either way, so it must say something true.
+ */
+export function hasNoTopic(text: string | null | undefined): boolean {
+  return text === null || text === undefined || text === "";
+}
+
 const exports_ = identityScopedStore((onIdentityChange) => {
   const [topicByChannel, setTopicByChannel] = createSignal<Record<ChannelKey, TopicEntry>>({});
   const [modesByChannel, setModesByChannel] = createSignal<Record<ChannelKey, ModesEntry>>({});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47915,8 +47915,30 @@ decided semantics, and widening past the measured case is how a rule stops meani
 **`:topic` is the known next candidate, it is the SAME defect, and it is still deliberately
 not taken here — for a measured reason, not a scoping one.** `TOPIC #chan :` is how an
 operator CLEARS a topic; it produces `body: ""`, and today the row drops and error-logs
-exactly as the NOTICE did (the `{:topic_changed, …}` effect still fires, so the topic bar
-clears correctly and only the HISTORY is lost). Server-side the extension really would be
+exactly as the NOTICE did (the `{:topic_changed, …}` effect still fires, so ~~the topic bar
+clears correctly and only the HISTORY is lost~~).
+
+> ⚠️ **Corrected at the source by #1505 (2026-08-20): "the topic bar clears correctly and
+> only the HISTORY is lost" was MEASURED FALSE.** It was inferred from the effect FIRING and
+> never checked at the bar. `EventRouter`'s TOPIC arm caches `entry = %{text: body, …}`, so a
+> clear caches `text: ""` — a different value from the `nil` that 331 RPL_NOTOPIC produces —
+> while `TopicBar` gated its "(no topic set)" placeholder on `topicText() !== null` at all
+> three of its sites (strip, `title` tooltip, read-only modal). `"" !== null`, so the value
+> reached `MircBody`, and this entry's own next bullet says what happens then:
+> `parseMircFormat("")` returns zero runs. The vitest red printed the DOM —
+> `<span class="topic-bar-topic-text" />`, an EMPTY box where the placeholder belongs, and
+> `title=""` on the button. So the HISTORY was not the only casualty: the bar carried the
+> SAME defect, on the surface that is permanently on screen, and it did so for the same
+> reason the scrollback row would have. Struck rather than deleted — the log records what was
+> claimed, and a claim this entry used to justify a scope boundary has to stay legible beside
+> its refutation. Cured in the #1505 entry at the end of this file (one `hasNoTopic`
+> predicate over `null` / `undefined` / `""`, shared by the bar and the new renderer arm).
+>
+> Nothing else in this entry moves. The reasoning it used to hold `:topic` back — that an
+> empty row would render as `* alice changed topic:` — was re-measured and reproduced
+> verbatim before #1505 changed a line.
+
+Server-side the extension really would be
 free — the same atom out of the same list, already covered by the same re-cast. The blocker
 is on the client, and it was read rather than assumed:
 
@@ -53622,6 +53644,15 @@ a topic.
 `topicJoinLine` in the same module already got this right (`text.trim() === "" → null`), which
 is what makes the bar the outlier rather than the convention. One module, two answers to one
 question, is the "half-migrated creates two patterns" failure CLAUDE.md names.
+
+**The #1500 entry is corrected AT THE SOURCE, not only here** (vjt's ruling, 2026-08-20): a
+decision log whose earlier entry states something a later measurement falsified will keep being
+read forwards, and a correction that lives only at the far end of the file is a correction
+nobody reaching for the original claim will meet. The false clause is struck in place with the
+measurement and this entry named beside it — struck rather than deleted, because that clause is
+what justified #1500's scope boundary and the boundary only reads honestly next to its
+refutation. The rest of that entry stands: its prediction about the scrollback render was
+re-measured and reproduced verbatim.
 
 ### One predicate, and the whitespace line it deliberately does not cross
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53568,3 +53568,103 @@ identical in both cases by design — that is the issue, not an omission. And
 nothing in `lib/` attaches to `[:grappa, :ws, :connect]` today, so the
 telemetry half remains a hook for a future exporter; the Logger line is what
 an operator can actually read now.
+<!-- entry #1505 -->
+
+---
+
+## 2026-08-20 — #1505: an empty topic is not an absent one, and three surfaces disagreed about it
+
+`TOPIC #chan :` is how an operator CLEARS a topic. It is also the exact line
+`IRC.Client.send_topic_clear/2` writes for our own `/topic -delete`, so the defect ate our
+own echo as well as anyone else's. #1500 fixed the identical mechanism for `:notice`, measured
+the `:topic` extension as free on the server, and deliberately held it back for one reason: the
+renderer had no honest arm and would have printed `* alice changed topic:` — a label, a colon,
+and nothing. That reasoning is confirmed, not revised: the red reproduced that exact string,
+`00:00:00 * alice changed topic:`, before a line of it was changed.
+
+### The two halves are not in tension, and the issue title's "and" is the fix
+
+The title reads as a dilemma — dropped if we do nothing, truncated if we persist. It is not one.
+"Would render as a truncated line" is a statement about a renderer that has one arm; the cure is
+the second arm, and the halves are sequential rather than opposed. So: `:topic` leaves
+`@body_required_kinds` (which is now `[:privmsg, :action]`), and `ScrollbackPane.tsx`'s
+`case "topic"` grows a cleared branch. Neither is shippable alone, which is what #1500 meant by
+"taken together or not at all".
+
+`:privmsg` and `:action` stay required. An empty one of those still has no reported arrival and
+no decided semantics.
+
+### The wording is "cleared the topic", and why not the sender's own words
+
+irssi prints `-!- Topic unset by alice on #chan` for this event and a different line for a
+change, so a distinct sentence — not a change-line with an empty tail — is the least surprising
+shape. cic's register is its own (`* alice changed topic: …`, no "of #chan", no "to:"), so the
+sibling reads `* alice cleared the topic`. This is the one product call in the change and it is
+one string plus two assertions to revise if vjt wants different words.
+
+Rejected: synthesising a body server-side (e.g. `"(cleared)"`). It would store a sentence the
+wire never carried, and Phase 6's `CHATHISTORY` facade would replay grappa's prose to a
+third-party client as though the operator had typed it.
+
+### The premise the issue left open was false: the topic BAR was broken too
+
+The issue closed with "the topic bar and `channelTopic.ts` were not checked", and #1500's entry
+had asserted in passing that "the topic bar clears correctly and only the HISTORY is lost".
+Measured, that is wrong. The `:topic` route caches `text: body`, so a clear caches `text: ""`,
+while `TopicBar` gated its placeholder on `topicText() !== null`. An empty string is not null,
+so the gate passed the value to `MircBody`, `parseMircFormat("")` yielded zero runs, and the
+strip rendered `<span class="topic-bar-topic-text" />` — an EMPTY box where "(no topic set)"
+belongs. The tooltip went the same way (`title=""`), and the read-only modal shares the gate.
+So the cleared topic was mis-rendered on the bar for exactly the same reason it would have been
+mis-rendered in the scrollback: `""` treated as a string to print rather than as the absence of
+a topic.
+
+`topicJoinLine` in the same module already got this right (`text.trim() === "" → null`), which
+is what makes the bar the outlier rather than the convention. One module, two answers to one
+question, is the "half-migrated creates two patterns" failure CLAUDE.md names.
+
+### One predicate, and the whitespace line it deliberately does not cross
+
+`hasNoTopic(text)` in `lib/channelTopic.ts` is now the single answer to "does this channel have
+a topic", consumed by the bar's three gates (strip, tooltip, modal) and by the scrollback arm.
+It folds `null`, `undefined` and `""` together and stops there.
+
+Whitespace is NOT trimmed. `TOPIC #chan : ` sets the topic to a space: the wire carried it, the
+ircd stores it, RPL_TOPIC returns it. Rendering "(no topic set)" over it would be a lie, and a
+`trim()`-shaped cure would erase a real if silly topic. `topicJoinLine` is stricter on purpose
+and that is not a second answer to the same question — it decides whether to PRINT a join-time
+line at all, and a line that would render blank is worth nothing there. The bar has no such
+option: it occupies its strip either way, so it must say something true. Both directions are
+pinned by control tests.
+
+Rejected: normalising `text: ""` to `nil` server-side so the wire carries one shape. It would
+publish something other than what the wire carried (against #1500's ruling on the sibling
+field), it would change the value an existing wire field takes for every client, and it would
+leave `topicJoinLine`'s `""` branch dead. The read side is the cheaper and more honest place for
+two truthful shapes to converge.
+
+### Why `nil` is accepted too, and what the changeset stopped guaranteeing
+
+Relaxing `:topic` the way `:notice` was relaxed also lets `body: nil` through. No producer
+writes it — the router's TOPIC arm is guarded `is_binary(body)` — but the renderer folds it into
+the same cleared arm, so the shape that can arrive from a cold-deploy backfill row has a
+destination that says something true rather than an `undefined` to print. The test that asserted
+`:topic` REJECTS a blank body is now its inverse; assertions of a validation that no longer
+exists are worse than none.
+
+### The mock that lied, and the 29 tests it took down
+
+`Shell.test.tsx` mocked `../lib/channelTopic` with a literal factory listing five of the
+module's exports, so `hasNoTopic` arrived `undefined` and every Shell render that mounts
+TopicBar threw — 29 failures in a file with nothing to do with topics. The mock had already been
+re-implementing `compactModeString` inline for the same reason. Replaced with the
+`importOriginal` spread `TopicBar.test.tsx` already uses, so only the STORE half is faked and
+every pure helper is production code. A partial mock of a growing module is a fixture that lies
+about the shape, and it fails far from the edit that caused it.
+
+### Also corrected in passing
+
+The `EventRouter` per-kind shape table still read `required text` for `:notice`, which #1500 had
+already falsified. Both that cell and `:topic`'s now read `text or ""`, with the reason beneath
+the table — leaving one right and one wrong in the same table is how the next reader picks the
+wrong one.

--- a/lib/grappa/scrollback/message.ex
+++ b/lib/grappa/scrollback/message.ex
@@ -35,8 +35,10 @@ defmodule Grappa.Scrollback.Message do
 
   The column is nullable because not all event types carry text content:
   `:join` and `:part` and `:nick_change` and `:mode` have no body;
-  `:privmsg`, `:notice`, `:action`, `:topic` do. The changeset
-  enforces presence per-kind. This is a deliberate split from
+  `:privmsg` and `:action` do, and the changeset enforces presence for
+  exactly those two. `:notice` (#1500) and `:topic` (#1505) are content
+  kinds whose body may legitimately be the EMPTY STRING the wire carried —
+  see `@body_required_kinds`. This is a deliberate split from
   CLAUDE.md "Total consistency or nothing" — but the cases ARE
   semantically distinct: PRIVMSG with no body is a malformed message,
   while JOIN with a body is a malformed event. The validation rule
@@ -113,11 +115,22 @@ defmodule Grappa.Scrollback.Message do
   # #1500 — `:notice` is NOT here. A NOTICE with an empty trailing is legal
   # (RFC 1459 §2.3.1: `:` followed by nothing is a valid, empty last param),
   # and the empty body is itself the diagnosable event. Requiring a body
-  # dropped the row AND error-logged the drop on every arrival. The other
-  # three stay: an empty PRIVMSG/ACTION/TOPIC has no reported arrival and no
-  # decided semantics, and widening past the measured case is how a rule
-  # stops meaning anything.
-  @body_required_kinds [:privmsg, :action, :topic]
+  # dropped the row AND error-logged the drop on every arrival.
+  #
+  # #1505 — `:topic` left too, and it is the SAME defect, not a widening.
+  # `TOPIC #chan :` is how an operator CLEARS a topic; it is also the exact
+  # line `IRC.Client.send_topic_clear/2` writes for our own `/topic -delete`,
+  # so the drop ate our own echo. #1500 measured the server relaxation as free
+  # and held it back for one reason only — the renderer had no honest arm and
+  # would have printed `* alice changed topic:`, a label and a colon. That arm
+  # now exists (`ScrollbackPane.tsx`'s `case "topic"` → "cleared the topic",
+  # gated by `hasNoTopic`), so the two halves land together as that issue
+  # required.
+  #
+  # `:privmsg` and `:action` stay: an empty one of those has no reported
+  # arrival and no decided semantics, and widening past the measured case is
+  # how a rule stops meaning anything.
+  @body_required_kinds [:privmsg, :action]
 
   # S17 (2026-07-08 review) / #395 — the human-content kinds and their
   # unread PROJECTION, declared ONCE. Each content kind maps to whether it
@@ -326,11 +339,12 @@ defmodule Grappa.Scrollback.Message do
   `messages_subject_xor`). `:network_id`, `:channel`, `:server_time`,
   `:kind`, `:sender` are universally required.
 
-  `:body` is required only for content-bearing kinds
-  (`:privmsg`, `:notice`, `:action`, `:topic`). Presence-event kinds
-  (`:join`, `:part`, etc.) accept `body: nil`. Per-kind validation
-  encodes the domain truth that PRIVMSG with no body is malformed
-  while JOIN with a body is malformed; see moduledoc.
+  `:body` is required only for `:privmsg` and `:action`. Presence-event
+  kinds (`:join`, `:part`, etc.) accept `body: nil`, and so do the two
+  content kinds whose empty body is a real wire value — `:notice` (#1500)
+  and `:topic` (#1505). Per-kind validation encodes the domain truth that
+  PRIVMSG with no body is malformed while JOIN with a body is malformed;
+  see moduledoc.
 
   `:meta` defaults to `%{}` via the schema-level field default —
   callers may omit it for kinds that have no event-specific payload.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -47,15 +47,21 @@ defmodule Grappa.Session.EventRouter do
       | Kind          | Body           | Meta                                    | members delta              |
       |---------------|----------------|-----------------------------------------|----------------------------|
       | :privmsg      | required text  | %{}                                     | (none)                     |
-      | :notice       | required text  | %{}                                     | (none)                     |
+      | :notice       | text or ""     | %{}                                     | (none)                     |
       | :action       | required text  | %{}                                     | (none)                     |
       | :join         | nil            | %{}                                     | add (or reset+add if self) |
       | :part         | reason \\| nil | %{}                                     | remove                     |
       | :quit         | reason \\| nil | %{}                                     | remove (fan-out)           |
       | :nick_change  | nil            | %{new_nick: String.t()}                 | rename (fan-out)           |
       | :mode         | nil            | %{modes: String.t(), args: [String.t()]} | per-arg add/remove modes   |
-      | :topic        | required text  | %{}                                     | (none)                     |
+      | :topic        | text or ""     | %{}                                     | (none)                     |
       | :kick         | reason \\| nil | %{target: String.t()}                   | remove                     |
+
+  `text or ""` on `:notice` (#1500) and `:topic` (#1505) is not slack: an
+  empty trailing is legal (RFC 1459 §2.3.1) and, on TOPIC, it IS the
+  topic-cleared event. Both persist the `""` verbatim rather than a `nil`,
+  which would claim the row has no body at all — the thing a `:join` row
+  means. See `Grappa.Scrollback.Message`'s `@body_required_kinds`.
 
   Q2-pinned: NICK + QUIT are server-level events that fan out to one
   scrollback row per channel where the nick was in `state.members`.

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -73,10 +73,12 @@ defmodule Grappa.ScrollbackTest do
   # `@suppressed_presence_kinds` must break the count assertions by CHANGING
   # THE NUMBERS, not silently agree with a hand-copied list.
   # Every row carries a body, including the presence kinds that would
-  # normally persist `body: nil`. `Message.@body_required_kinds` is
-  # `content_kinds ∪ [:topic]`, and restating that here would be a second
-  # copy of a production list — while the changeset ACCEPTS a body on every
-  # kind, and these tests bucket rows by KIND and never read a body. So the
+  # normally persist `body: nil`. Which kinds actually REQUIRE one is
+  # `Message.@body_required_kinds`, and restating it here would be a second
+  # copy of a production list that drifts the moment the real one moves (it
+  # did: this comment claimed `content_kinds ∪ [:topic]`, which #1500 and
+  # #1505 have both since falsified). The changeset ACCEPTS a body on every
+  # kind, and these tests bucket rows by KIND and never read a body — so the
   # uniform body is the choice that keeps the helper from forking an SSOT.
   defp seed_one_row_per_kind(user, net) do
     Message.kinds()
@@ -690,11 +692,26 @@ defmodule Grappa.ScrollbackTest do
       assert "can't be blank" in errors_on(cs).body
     end
 
-    test "rejects :topic without body (per-kind body required)", %{user: user, network: net} do
-      assert {:error, %Ecto.Changeset{} = cs} =
-               ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :topic, sender: "ChanServ", body: nil}))
+    # #1505 — `:topic` LEFT `@body_required_kinds`, so this is the inverse of
+    # the assertion that stood here. `TOPIC #chan :` clears a topic and is
+    # legal input, so the empty body must round-trip as the `""` the wire
+    # carried — never as `nil`, which would claim the row has no body at all
+    # (the thing a `:join` row means, and the shape #1400 exists to keep out
+    # of a renderer). `nil` is accepted by the relaxed validator too and
+    # pinned here for the same reason #1500 pinned it on `:notice`: it is the
+    # shape a cold-deploy backfill row can carry, and the renderer treats it
+    # as the same "no topic" event.
+    test "accepts :topic with an EMPTY body and stores the empty string", %{user: user, network: net} do
+      assert {:ok, %Message{kind: :topic, body: ""}} =
+               ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :topic, sender: "ChanServ", body: ""}))
 
-      assert "can't be blank" in errors_on(cs).body
+      assert [%Message{kind: :topic, body: ""}] =
+               Scrollback.fetch({:user, user.id}, net.id, "#sniffo", nil, 10, nil, false)
+    end
+
+    test "accepts :topic with a nil body", %{user: user, network: net} do
+      assert {:ok, %Message{kind: :topic, body: nil}} =
+               ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :topic, sender: "ChanServ", body: nil}))
     end
 
     test "accepts all 10 extended kinds with appropriate body/meta shape",
@@ -1534,9 +1551,10 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :join, body: nil}))
       {:ok, m1} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :privmsg}))
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :part, body: nil}))
-      # `:topic` is body-required (`Message.@body_required_kinds`) — it is a
-      # CONTROL row that carries text, which is exactly why it must survive
-      # the hide: the pane renders it.
+      # `:topic` is a CONTROL row that carries text, which is exactly why it
+      # must survive the hide: the pane renders it. (Since #1505 the text may
+      # legitimately be `""` — a cleared topic — but this case is about the
+      # presence filter, so it uses the ordinary non-empty shape.)
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 3, %{kind: :topic, body: "new topic"}))
 
       assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", m1.id, nil, false) ==

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2952,6 +2952,52 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #1505 — the same defect on `:topic`, which #1500 deliberately left in
+    # `@body_required_kinds` because the renderer had no honest arm for an
+    # empty body. `TOPIC #chan :` is how an operator CLEARS a topic — it is
+    # also the exact line `Client.send_topic_clear/2` writes for our OWN
+    # `/topic -delete`, so the drop hit our own echo too.
+    #
+    # Same two-part oracle as #1500 and the same order: the row must ARRIVE
+    # first, or `refute log =~` passes on a session that never processed the
+    # line. `""` is asserted on the STORED value, not just the broadcast one —
+    # `nil` would claim the row has no body at all, which is what a `:join`
+    # row means.
+    test "#1505 a TOPIC with an empty trailing persists and logs no error" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "#italia")
+        )
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      log =
+        capture_log(fn ->
+          IRCServer.feed(server, ":alice!~a@host TOPIC #italia :\r\n")
+
+          assert_receive %Phoenix.Socket.Broadcast{
+                           event: "event",
+                           payload: %{
+                             kind: :message,
+                             message: %{kind: :topic, channel: "#italia", sender: "alice", body: ""}
+                           }
+                         },
+                         2_000
+        end)
+
+      assert [%{kind: :topic, body: ""}] =
+               Scrollback.fetch({:user, user.id}, network.id, "#italia", nil, 10, nil, false)
+
+      refute log =~ "scrollback insert failed"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     # #546 regression the issue called out as the one concrete casualty: the
     # "CTCP VERSION query → grappa X" visibility row. It does NOT ride the
     # NOTICE door at all — it is emitted by the inbound-PRIVMSG CTCP arm,


### PR DESCRIPTION
Fixes the empty-TOPIC drop reported in #1505, both halves, plus the surface that issue left
unchecked — and corrects the claim in the #1500 decision-log entry that this work measured
false.

## The tension in the title is not a conflict

*"dropped from scrollback — **and** persisting it would render as a truncated line."* The second
half is a statement about a renderer that has exactly one arm. The cure **is** the second arm.
The halves are sequential, not opposed — which is what #1500 meant by *"the whole case — server
relaxation plus the renderer arm, taken together or not at all"*.

Measured cost of the resolution: **one atom** out of `@body_required_kinds`, **one renderer
branch**, **one predicate**. No wire change, no migration, no new field.

## What changed

**Server** — `:topic` leaves `@body_required_kinds` (now `[:privmsg, :action]`), so
`TOPIC #chan :` persists as the `""` the wire carried. Not `nil`: that would claim the row has
no body at all — what a `:join` row means — and `wireValidate` passes it, so it would reach a
renderer as the undefined-shape #1400 exists to remove. `:privmsg` / `:action` stay required.

The empty trailing is also the exact line `IRC.Client.send_topic_clear/2` writes for our own
`/topic -delete`, so the drop ate our own echo, not just a peer's.

**Scrollback renderer** — `case "topic"` grows a cleared branch: `* alice cleared the topic`.
irssi prints a distinct sentence for an unset topic rather than a change-line with an empty
tail, and cic's register is its own, so the sibling is worded in that register.

**Topic bar** — the issue's *"Not established"* section turned out to hold a real defect. See
below.

**One predicate** — `hasNoTopic(text)` in `lib/channelTopic.ts` folds `null` / `undefined` /
`""` and stops there. Consumed by the renderer arm and by the bar's three gates (strip, tooltip,
modal) and its save-guard.

## A premise fell, and it was measured

`EventRouter`'s TOPIC arm caches `entry = %{text: body, …}`, so a clear caches `text: ""` — a
different value from the `nil` that 331 RPL_NOTOPIC produces. `TopicBar` gated its
`(no topic set)` placeholder on `topicText() !== null`. `"" !== null`, so the value reached
`MircBody`, `parseMircFormat("")` returned zero runs, and the red printed the DOM:

    <span class="topic-bar-topic-text" />

An empty box where the placeholder belongs, plus `title=""` on the button. The read-only modal
shares the gate.

So the HISTORY was not the only casualty. The bar carried the **same** defect, for the **same**
reason, on the surface that is permanently on screen. `topicJoinLine` in the same module already
treated `""` as no-topic, which makes the bar the outlier rather than a scope extension.

**The #1500 entry is corrected at the source** (commit 4), not only in the new entry: it had
asserted *"the topic bar clears correctly and only the HISTORY is lost"*, inferred from the
effect firing and never checked at the bar. The clause is **struck, not deleted** — it is what
justified #1500's scope boundary, and the boundary only reads honestly beside its refutation.
Everything else in that entry stands: its prediction about the scrollback render was re-measured
and reproduced verbatim.

## Whitespace is deliberately not trimmed

`TOPIC #chan : ` sets the topic to a space. The wire carried it, the ircd stores it, RPL_TOPIC
returns it. Rendering `(no topic set)` over it would be a lie, and a `trim()`-shaped cure would
erase a real if silly topic. `topicJoinLine` keeps its stricter trim because it decides whether
to **print a line at all**; the bar has no such option and must say something true. Both
directions are pinned by control tests.

## Rejected

| Rejected | Why |
|---|---|
| Synthesise a body server-side (`"(cleared)"`) | Stores a sentence the wire never carried; Phase 6's `CHATHISTORY` facade would replay grappa's prose as though the operator typed it. |
| Store `body: nil` | #1500's ruling on the sibling field; `wireValidate` passes it, so it is the *more* dangerous shape. |
| Normalise `text: "" → nil` server-side | Publishes something other than what the wire carried, changes the value an existing wire field takes for every client, and leaves `topicJoinLine`'s `""` branch dead. |
| `trim()` inside the shared predicate | See above. |

## The reds, read before the greens

| Oracle | Red |
|---|---|
| Scrollback row, `body: ""` | `00:00:00 * alice changed topic:` — the issue's predicted string, verbatim |
| Bar strip, `text: ""` | `<span class="topic-bar-topic-text" />`, `title=""` |
| Bar modal, `text: ""` | `.topic-modal-text` empty |
| Server: `:alice TOPIC #italia :` persists, no error log | **NOT MEASURED** — see gates |

Collateral: `Shell.test.tsx` mocked `lib/channelTopic` with a literal factory listing five
exports, so `hasNoTopic` arrived `undefined` and **29 tests failed in a file with nothing to do
with topics**. That mock was already re-implementing `compactModeString` inline for the same
reason. Replaced with the `importOriginal` spread `TopicBar.test.tsx` already uses — only the
store half is faked, every pure helper is production code.

## Gates

**Ran, green:**

* `scripts/bun.sh run test` — **5683 passed / 293 files, 0 failed** (full suite)
* `scripts/bun.sh run check` — biome (src + e2e), tsc (src), tsc (e2e)
* `scripts/design-notes-gate.sh` — `1 new entry heading(s), separator and marker present`;
  marker `<!-- entry #1505 -->` verified absent from `origin/main`

**NOT MEASURED — no COMPILE lane at the time of opening** (held elsewhere; requested, not
self-served). This is a declared non-measure, not a silence:

* `scripts/test.sh` — including the new `server_test.exs` case (oracle D) and the two rewritten
  `scrollback_test.exs` cases
* `mix format`, Credo strict, Dialyzer, Sobelow, `scripts/check.sh`
* `scripts/integration.sh` and e2e — neither lane is mine

Nothing about the Elixir half should be read as verified until CI says so.

## Not established / not claimed

* That the upstream ircd always emits an empty trailing for a clear — read from our own
  `send_topic_clear/2` and RFC 1459 §2.3.1 framing, not from a live capture.
* That no e2e spec is affected: I checked the six specs touching `.topic-bar-topic*` and all set
  a **non-empty** topic first, so none exercises the changed gate, and `grep` for the old
  wording over `cicchetto/e2e/` returns one *comment*. I did not run the lane.
* `/topic` (bare) is unaffected — `topicShowCommand` is a stub that never reads the cache.

## Also corrected in passing

`EventRouter`'s per-kind shape table still read `required text` for `:notice`, which #1500 had
already falsified; both that cell and `:topic`'s now read `text or ""`. And
`scrollback_test.exs`'s helper comment claimed `@body_required_kinds` is `content_kinds ∪
[:topic]` — false since #1500 — rewritten to stop restating the production list.
