### PR TITLE
ws(#1416): say what the connect boundary made of client_proto

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -700,7 +700,17 @@ config :logger, :console,
     # entry indistinguishable from a page that reported hidden, so the
     # `/admin/ws_presence` snapshot can no longer show it; this line is
     # where that age survives.
-    :silent_for_ms
+    :silent_for_ms,
+    # #1416 — what `GrappaWeb.UserSocket.connect/3` made of the client's
+    # `client_proto` declaration (`:absent | :declared | :unreadable`).
+    # A value the server cannot read is served as CURRENT by design
+    # (#447, unknown-is-never-fatal), so the connect result is identical
+    # either way and this key is the only place the difference exists.
+    # Declared here because an UNDECLARED key is dropped at FORMAT time:
+    # without this line the call site compiles, the telemetry twin still
+    # fires, and the operator reads the same bare string as before —
+    # which is precisely the defect #1416 was filed about.
+    :client_proto
   ]
 
 # #1075 — os_mon is loaded for `:cpu_sup.avg1/0` alone (the admin top bar's

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -119,8 +119,8 @@ URL. This keeps the credential out of access logs. The phoenix.js client
 does this for you via `new Socket(url, {authToken: token})`; a raw client
 sends the bearer subprotocol alongside `"phoenix"`. A missing/invalid
 bearer is rejected with **403**. Source:
-`lib/grappa_web/channels/user_socket.ex` (`connect/3:101`, `extract_token`)
-+ `lib/grappa_web/endpoint.ex:87` (`auth_token: true`).
+`lib/grappa_web/channels/user_socket.ex` (`connect/3`, `extract_token/1`)
++ `lib/grappa_web/endpoint.ex` (`auth_token: true`).
 
 ### 3b. Protocol version — the `client_proto` query param
 
@@ -145,16 +145,30 @@ wss://host/socket/websocket?client_proto=1&vsn=2.0.0
 - If you **omit** `client_proto` entirely, you are treated as **current**
   (the server sends you nothing new). This is the zero-friction path and
   is exactly what our own clients do until they need to negotiate.
+- If you send a value the server **cannot read as an integer** — a stray
+  suffix (`1/websocket`), a non-numeric string, or an array form
+  (`?client_proto[]=1`) — you are ALSO treated as current, and the connect
+  succeeds. Your declaration is discarded, so you get none of the
+  negotiation you asked for: **an accepted socket is not evidence that your
+  version was understood.** Since #1416 the server records which of the
+  three it saw (`client_proto=absent|declared|unreadable` on the connect
+  log line and in the `[:grappa, :ws, :connect]` telemetry metadata), so
+  ask your operator to grep that key if a declaration is not taking
+  effect. This is the trap that bit our own reference client: phoenix.js
+  concatenates the transport path onto the endpoint string, so a query
+  baked into the endpoint URL becomes part of a parameter VALUE — put the
+  version in the Socket's `params`, not in the endpoint.
 - There is **no upper bound**: declaring a version higher than the server
   speaks is fine (additive-only — a newer client tolerates an older
   server).
 
-Source: `lib/grappa_web/channels/user_socket.ex:135`
+Source: `lib/grappa_web/channels/user_socket.ex`
 (`check_protocol_version/1`) → returns `{:error, :upgrade_required}`,
 which the endpoint's `error_handler`
-(`user_socket.ex:166` `handle_ws_error/2`, wired at
-`endpoint.ex:90`) turns into the 426. The version check runs **before**
-auth, so a too-old client is refused regardless of its credential.
+(`user_socket.ex` `handle_ws_error/2`, wired on the `socket "/socket"`
+declaration in `endpoint.ex`) turns into the 426. The version check runs
+**before** auth, so a too-old client is refused regardless of its
+credential.
 
 ### 3c. The initial payload
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53486,3 +53486,85 @@ The same deploy session surfaced a second `Log honesty` fault: the pull's
 `branch.<name>.rebase` config turns `git pull --ff-only` into a rebase pull,
 which refuses on any unstaged change with no divergence in sight). Different
 fault, different cure, so it is **#1603** rather than scope creep here.
+<!-- entry #1416 -->
+
+---
+
+## 2026-08-20 — #1416: the WS version gate now says what it read
+
+#447 made three different readings of `client_proto` share one answer. A
+declaration at or above the floor, a declaration the server cannot parse, and
+no declaration at all are all served as CURRENT — deliberately, and that part
+does not change here: unknown-is-never-fatal runs in both directions and
+existing clients must keep working untouched.
+
+What did change is that the three used to be indistinguishable in every
+output. `check_protocol_version/1` answered a bare `:ok` and the two connect
+emissions of `user_socket.ex` were a metadata-free `Logger.info("ws connect
+authenticated")` and a `[:grappa, :ws, :connect]` counter whose metadata #202
+had emptied. So a client that shipped a value the server could never honour
+produced, byte for byte, the connect of a client that negotiated correctly.
+
+That is not hypothetical. It is what let #1379 run for a release: cicchetto
+baked the query into the endpoint string, phoenix.js concatenated
+`/websocket` onto it, and the server received `client_proto=1/websocket`,
+which `Integer.parse/1` reads as `{1, "/websocket"}` — parseable head,
+unconsumed tail, straight into the silent arm. Every WebSocket in the
+application was broken and the version seam, the one component that had
+actually observed the malformed declaration, said nothing.
+
+The gate now returns a closed `:absent | :declared | :unreadable` and both
+emissions carry it. The Logger MESSAGE is byte-unchanged so #95's greppable
+line keeps working; the reading rides the metadata prefix beside it.
+
+### Presence, not parseability, is what separates absent from unreadable
+
+The catch-all clause was split in two. `?client_proto[]=1` decodes to a LIST,
+so it never reached the `is_binary(raw)` head and fell through to the same arm
+as a client that declared nothing. Reporting that as `:absent` would have been
+the same lie in a second costume — the client DID declare, and the server
+could not read it — so the key's presence alone now decides which of the two
+it is. The accept is identical either way; only the report differs.
+
+### The declared value is not repeated on our line, and the reason is measured
+
+Phoenix's own `[:phoenix, :socket_connected]` handler already prints
+`Parameters: <inspect>` (`deps/phoenix/lib/phoenix/logger.ex:363`) at a level
+that defaults to `:info` (`socket.ex:524`) which `endpoint.ex` does not
+override and which prod runs at. It comes out of the same transport process,
+and `:pid` is in the Logger metadata allowlist, so the two lines correlate
+exactly. Repeating the value would add a second unbounded
+attacker-controlled-text log site for a fact the operator already has one line
+away. What was missing was never the value — it was the server's READING of
+it.
+
+**Not pinned, and named as such.** No test in this repo can witness that
+phoenix line's production configuration. `Phoenix.ChannelTest.__connect__/4`
+synthesises its own socket options and never passes the endpoint's, so `log:`
+is hardcoded `:info` in every ChannelTest connect. Measured rather than
+assumed: injecting `log: false` into the endpoint's socket declaration killed
+ZERO of the 37 tests, which is how a first cut of this work — a test asserting
+the value on the captured log, written as a tripwire for exactly this
+dependency — was found to be a mirror and deleted. A future `log: false` would
+take the value away with no gate firing. The comment at the emission site
+carries that gap rather than leaving it implicit.
+
+### The allowlist is half the fix
+
+`:client_proto` goes into `config/config.exs`'s `:metadata` in the same
+commit, because an undeclared key is dropped at FORMAT time. Without that
+line the call site compiles, the telemetry twin fires, the telemetry tests
+pass — and the operator reads the same bare string as before. Deleting the key
+kills the three log tests and none of the telemetry ones, which is the
+evidence that those two halves measure different things rather than one thing
+twice.
+
+### What this does not establish
+
+No connect was observed against a running BEAM and no e2e ran; the signals are
+proven in-process through `Phoenix.ChannelTest`. The distinction is asserted on
+the emitted signal and not on the return value, because the return value is
+identical in both cases by design — that is the issue, not an omission. And
+nothing in `lib/` attaches to `[:grappa, :ws, :connect]` today, so the
+telemetry half remains a hook for a future exporter; the Logger line is what
+an operator can actually read now.

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -47,12 +47,24 @@ defmodule GrappaWeb.UserSocket do
   failure gets. Absent or unparseable → treated as current, so existing
   clients keep working untouched.
 
+  **The gate REPORTS its reading (#1416).** Because absent and unparseable
+  land on the same accept, the connect RESULT cannot distinguish a client
+  that negotiated from one whose declaration the server could not read —
+  and until #1416 nothing else could either, which is how #1379 shipped a
+  cicchetto dialling `client_proto=1/websocket` for a whole release with no
+  operator-visible signal. `check_protocol_version/1` therefore returns a
+  closed `t:declaration/0` and both connect emissions carry it. The
+  decision is untouched; only the observability is new.
+
   Every authenticated connect emits a `[:grappa, :ws, :connect]`
-  telemetry counter (`%{count: 1}`, empty metadata) + a greppable Logger
-  line — a cheap ops signal for connect churn. Neither carries the token
-  value (the raw bearer IS the session credential — S9). #95's
-  `auth_method` tag is gone (#202): once the query-string fallback was
-  removed it collapsed to a constant `:subprotocol`.
+  telemetry counter (`%{count: 1}`, metadata `%{client_proto:
+  declaration}`) + a greppable Logger line carrying the same key — a cheap
+  ops signal for connect churn and for declarations the server could not
+  read. Neither carries the token value (the raw bearer IS the session
+  credential — S9). #95's `auth_method` tag is gone (#202): once the
+  query-string fallback was removed it collapsed to a constant
+  `:subprotocol`; #1416 refilled the metadata with a key that does carry
+  information.
 
   The authenticated `Session` row carries an XOR FK (`user_id` xor
   `visitor_id`, per Q-A). `connect/3` dispatches on that XOR:

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -102,6 +102,23 @@ defmodule GrappaWeb.UserSocket do
   channel "grappa:user:*", GrappaWeb.GrappaChannel
   channel "grappa:admin:events", GrappaWeb.AdminChannel
 
+  @typedoc """
+  What the connect boundary made of the client's `client_proto`
+  declaration (#1416) — a closed set, ridden verbatim by both connect
+  signals.
+
+    * `:absent` — no `client_proto` at all. The deliberate zero-friction
+      path (#447): served as current.
+    * `:declared` — read as an integer at or above
+      `Grappa.Protocol.min_version/0`. (A readable value BELOW the floor
+      never becomes a declaration: it returns `{:error, :upgrade_required}`
+      and there is no connect to report on.)
+    * `:unreadable` — present and not readable as a version. Served as
+      current, exactly like `:absent`, and that is the point: the two are
+      indistinguishable in the RESULT, so they must not be in the SIGNAL.
+  """
+  @type declaration :: :absent | :declared | :unreadable
+
   @impl Phoenix.Socket
   def connect(params, socket, connect_info) do
     # #447 — the protocol-version gate runs BEFORE auth: a client that
@@ -112,9 +129,9 @@ defmodule GrappaWeb.UserSocket do
     # (`handle_ws_error/2`) sends a clean 426; a bare `:error` (missing /
     # bad token, or an absent-but-fine version) still gets the transport's
     # own 403. The two failures stay distinct on the wire (426 vs 403).
-    with :ok <- check_protocol_version(params),
+    with {:ok, declaration} <- check_protocol_version(params),
          {:ok, token} <- extract_token(connect_info),
-         {:ok, socket} <- authenticate_and_assign(token, socket) do
+         {:ok, socket} <- authenticate_and_assign(token, socket, declaration) do
       maybe_record_client_source(socket, connect_info)
       {:ok, socket}
     end
@@ -181,25 +198,41 @@ defmodule GrappaWeb.UserSocket do
   # server speaks is still accepted: additive-only means a newer client
   # tolerates an older server (unknown-is-never-fatal), so there is no
   # upper bound.
-  @spec check_protocol_version(map()) :: :ok | {:error, :upgrade_required}
+  # #1416 — the gate also REPORTS what it made of the declaration, because
+  # the accept/reject answer alone cannot: `:declared` and `:unreadable`
+  # are the same `{:ok, _}` by design, so a client bug that discards the
+  # whole negotiation used to be byte-identical, in every emission of this
+  # module, to a client that negotiated correctly. That is the shape that
+  # hid #1379 for a full release. The decision is unchanged — this is a
+  # signal, not a policy.
+  @spec check_protocol_version(map()) ::
+          {:ok, declaration()} | {:error, :upgrade_required}
   defp check_protocol_version(%{"client_proto" => raw}) when is_binary(raw) do
     case Integer.parse(raw) do
       {version, ""} ->
         if version < Grappa.Protocol.min_version() do
           {:error, :upgrade_required}
         else
-          :ok
+          {:ok, :declared}
         end
 
       _ ->
         # Unparseable `client_proto` — a client bug, not a reason to refuse
         # a socket that might otherwise work. Treat as current (silent),
-        # same as absent (unknown-is-never-fatal).
-        :ok
+        # same as absent (unknown-is-never-fatal) — but SAY SO.
+        {:ok, :unreadable}
     end
   end
 
-  defp check_protocol_version(_), do: :ok
+  # A `client_proto` that is present but not a binary — `?client_proto[]=1`
+  # decodes to a list, `?client_proto[a]=1` to a map. Same class as an
+  # unparseable string and NOT the same as absent: the client declared
+  # something and the server could not read it. Folding this into the
+  # absent clause would reinstate the exact lie #1416 removes, one costume
+  # over.
+  defp check_protocol_version(%{"client_proto" => _}), do: {:ok, :unreadable}
+
+  defp check_protocol_version(_), do: {:ok, :absent}
 
   @doc false
   # #447 — custom WS error_handler wired in `endpoint.ex`'s `socket`
@@ -246,9 +279,9 @@ defmodule GrappaWeb.UserSocket do
     end
   end
 
-  @spec authenticate_and_assign(String.t(), Phoenix.Socket.t()) ::
+  @spec authenticate_and_assign(String.t(), Phoenix.Socket.t(), declaration()) ::
           {:ok, Phoenix.Socket.t()} | :error
-  defp authenticate_and_assign(token, socket) do
+  defp authenticate_and_assign(token, socket, declaration) do
     with {:ok, session} <- Accounts.authenticate(token),
          {:ok, socket} <- assign_subject(socket, session) do
       socket =
@@ -336,9 +369,34 @@ defmodule GrappaWeb.UserSocket do
       # constant `:subprotocol` once the query-string fallback was
       # removed, so it carried no information. The token VALUE is never
       # logged or emitted — the raw bearer IS the session credential (S9).
-      Logger.info("ws connect authenticated")
+      #
+      # #1416 — both carry the ONE thing the connect result cannot say:
+      # what this boundary made of the client's `client_proto`. The
+      # MESSAGE stays byte-identical so #95's grep keeps working and the
+      # new fact rides the metadata prefix.
+      #
+      # The declared VALUE is deliberately NOT repeated here. Phoenix's
+      # own `[:phoenix, :socket_connected]` handler already prints
+      # `Parameters: <inspect>` from this same transport process at
+      # `log: :info` (`deps/phoenix/lib/phoenix/logger.ex:363`; the
+      # default is set at `socket.ex:524`, `endpoint.ex` overrides
+      # nothing, and prod runs at `:info`), and `:pid` is in the Logger
+      # metadata allowlist, so the value is one correlated line away.
+      # Repeating it would put unbounded attacker-controlled text into a
+      # second log site for no fact the operator does not already have.
+      #
+      # What did NOT exist anywhere, and is what these two now state, is
+      # the server's READING of that value. That half is pinned by tests.
+      # The other half is not: no test in this repo can witness the
+      # phoenix line's production configuration, because
+      # `Phoenix.ChannelTest.__connect__/4` synthesises its own socket
+      # options and never passes the endpoint's. So a future `log: false`
+      # here would silently take the value away with no gate firing —
+      # a known, declared gap, and the reason this comment names the
+      # dependency instead of leaving it implicit.
+      Logger.info("ws connect authenticated", client_proto: declaration)
 
-      :telemetry.execute([:grappa, :ws, :connect], %{count: 1}, %{})
+      :telemetry.execute([:grappa, :ws, :connect], %{count: 1}, %{client_proto: declaration})
 
       {:ok, socket}
     else

--- a/test/grappa_web/channels/user_socket_test.exs
+++ b/test/grappa_web/channels/user_socket_test.exs
@@ -32,6 +32,7 @@ defmodule GrappaWeb.UserSocketTest do
   """
   use GrappaWeb.ChannelCase, async: false
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
   alias Grappa.{Accounts, Protocol, PubSub.Topic}
@@ -63,6 +64,14 @@ defmodule GrappaWeb.UserSocketTest do
   defp connect_with_proto_no_token(client_proto) do
     Phoenix.ChannelTest.connect(UserSocket, %{"client_proto" => client_proto}, connect_info: %{})
   end
+
+  # #1416 — the VALUE cicchetto actually shipped on the wire when
+  # `socketEndpoint` baked the query into the endpoint string and
+  # phoenix.js concatenated `/websocket` onto it (DESIGN_NOTES 2026-08-16,
+  # "the hop this entry named as unmeasured was the bug"). `Integer.parse/1`
+  # answers `{1, "/websocket"}` — parseable head, unconsumed tail — which is
+  # the exact shape the `_ -> :ok` arm swallowed in silence.
+  @shipped_unreadable "1/websocket"
 
   describe "connect/3" do
     test "returns :error when no token is given" do
@@ -174,6 +183,20 @@ defmodule GrappaWeb.UserSocketTest do
 
       assert {:ok, _} = connect_with_proto("garbage", session.id)
     end
+
+    # #1416 — `?client_proto[]=1` decodes to a LIST, not a binary, so it
+    # misses the `is_binary(raw)` head and lands on the catch-all clause.
+    # The DECISION is unchanged (served as current, same as any other
+    # value the server cannot read); this pins that the new clause added
+    # for the signal did not smuggle in a refusal.
+    test "a present-but-non-binary client_proto still connects (decision unchanged)" do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+
+      assert {:ok, _} =
+               Phoenix.ChannelTest.connect(UserSocket, %{"client_proto" => ["1"]},
+                 connect_info: %{auth_token: session.id}
+               )
+    end
   end
 
   # #447 — the custom error_handler wired into the endpoint's `websocket:`
@@ -195,11 +218,15 @@ defmodule GrappaWeb.UserSocketTest do
   # #95 + #202 — connect observability: connect/3 emits a
   # [:grappa, :ws, :connect] counter on every authenticated connect. #202
   # dropped the `auth_method` metadata tag — it had collapsed to a
-  # constant `:subprotocol` once the query-string fallback was removed —
-  # leaving a bare `%{count: 1}` measurement with EMPTY metadata. The
-  # token value is NEVER emitted (the raw bearer IS the session
-  # credential — S9).
-  describe "connect telemetry (#95 / #202)" do
+  # constant `:subprotocol` once the query-string fallback was removed.
+  #
+  # #1416 re-populates the metadata with ONE bounded key: what the connect
+  # boundary could make of the client's `client_proto` declaration. Before
+  # it, a declaration the server could not read was byte-identical in every
+  # observable output to one it read — the counter carried `%{}` and the
+  # Logger line was a bare string. The token value is still NEVER emitted
+  # (the raw bearer IS the session credential — S9).
+  describe "connect telemetry (#95 / #202 / #1416)" do
     setup do
       ref = make_ref()
       handler_id = "ws-connect-test-#{System.unique_integer([:positive])}"
@@ -218,19 +245,135 @@ defmodule GrappaWeb.UserSocketTest do
       %{ref: ref}
     end
 
-    test "emits the connect counter with empty metadata on an authenticated connect", %{ref: ref} do
+    # #202 asserted `metadata == %{}` here. #1416 supersedes that: the
+    # empty map was the defect, not the contract — it is what made an
+    # unreadable declaration indistinguishable from a read one. The
+    # measurement is untouched.
+    test "an absent declaration is reported as :absent, not as nothing", %{ref: ref} do
       {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
 
       assert {:ok, _} = connect_via_subprotocol(session.id)
       assert_receive {^ref, measurements, metadata}
       assert measurements == %{count: 1}
-      assert metadata == %{}
+      assert metadata == %{client_proto: :absent}
+    end
+
+    test "a readable declaration is reported as :declared", %{ref: ref} do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+
+      assert {:ok, _} =
+               connect_with_proto(Integer.to_string(Protocol.min_version()), session.id)
+
+      assert_receive {^ref, _, metadata}
+      assert metadata == %{client_proto: :declared}
+    end
+
+    # THE issue. Same return value as the test above by design — the
+    # distinction can only live in the emitted signal, so that is where
+    # it is asserted.
+    test "a declaration the server could not read is reported as :unreadable", %{ref: ref} do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+
+      assert {:ok, _} = connect_with_proto(@shipped_unreadable, session.id)
+
+      assert_receive {^ref, _, metadata}
+      assert metadata == %{client_proto: :unreadable}
+    end
+
+    # A present-but-non-binary value (`?client_proto[]=1`) is a client that
+    # DECLARED something the server could not read — reporting it as
+    # `:absent` would be the same lie in a second costume, so the catch-all
+    # clause splits on whether the key is there at all.
+    test "a present-but-non-binary declaration is :unreadable, not :absent", %{ref: ref} do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+
+      assert {:ok, _} =
+               Phoenix.ChannelTest.connect(UserSocket, %{"client_proto" => ["1"]},
+                 connect_info: %{auth_token: session.id}
+               )
+
+      assert_receive {^ref, _, metadata}
+      assert metadata == %{client_proto: :unreadable}
     end
 
     test "emits NO connect event on an auth failure (counter is post-auth)", %{ref: ref} do
       assert :error = connect_via_subprotocol(Ecto.UUID.generate())
       refute_receive {^ref, _, _}
     end
+  end
+
+  # #1416 — the Logger half of the same signal, and the half that has an
+  # operator behind it: nothing in `lib/` attaches to
+  # `[:grappa, :ws, :connect]`, so the counter above is a hook for a future
+  # exporter while the log line is what a 2am grep actually reads.
+  #
+  # This describe pins the `config/config.exs` `:metadata` allowlist as
+  # much as the code: an undeclared key is dropped at FORMAT time, so the
+  # call site would compile, the telemetry tests above would pass, and the
+  # operator would still read a bare line. Only a capture of the RENDERED
+  # output can tell those apart.
+  #
+  # `Logger.configure(level: :info)` because the test env runs at
+  # :warning — same rationale (and same `async: false` requirement) as
+  # `Grappa.IRC.ClientOutboundCostTest`.
+  describe "connect log line (#1416)" do
+    setup do
+      original = Logger.level()
+      Logger.configure(level: :info)
+      on_exit(fn -> Logger.configure(level: original) end)
+      :ok
+    end
+
+    defp capture_connect(fun) do
+      capture_log(fn ->
+        assert {:ok, _} = fun.()
+        Logger.flush()
+      end)
+    end
+
+    test "an unreadable declaration is named as unreadable" do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+
+      log = capture_connect(fn -> connect_with_proto(@shipped_unreadable, session.id) end)
+
+      # The message is byte-unchanged — #95's greppable line keeps working
+      # and the new fact rides the metadata prefix beside it.
+      assert log =~ "ws connect authenticated"
+      assert log =~ "client_proto=unreadable"
+    end
+
+    test "a readable declaration is named as declared" do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+
+      log =
+        capture_connect(fn ->
+          connect_with_proto(Integer.to_string(Protocol.min_version()), session.id)
+        end)
+
+      assert log =~ "ws connect authenticated"
+      assert log =~ "client_proto=declared"
+    end
+
+    test "an absent declaration is named as absent" do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+
+      log = capture_connect(fn -> connect_via_subprotocol(session.id) end)
+
+      assert log =~ "client_proto=absent"
+    end
+
+    # NOT ASSERTED HERE, deliberately: that the declared VALUE is also
+    # observable. It is — phoenix's own `[:phoenix, :socket_connected]`
+    # handler prints `Parameters: <inspect>` from this same process
+    # (`deps/phoenix/lib/phoenix/logger.ex:363`, level defaulting to
+    # `:info` at `socket.ex:524`, and prod runs at `:info`) — but no test
+    # in this file can witness it, because `Phoenix.ChannelTest.__connect__/4`
+    # synthesises its own socket options (`channel_test.ex:337-343`) and
+    # never passes the endpoint's, so `log:` is hardcoded `:info` in every
+    # ChannelTest connect. Measured, not assumed: injecting `log: false`
+    # into `endpoint.ex`'s socket declaration killed ZERO tests. An
+    # assertion on that line would measure the harness and pass forever.
+    # See `UserSocket`'s emission comment for what this leaves unpinned.
   end
 
   describe "id/1" do


### PR DESCRIPTION
Refs #1416.

## What changes, and what deliberately does not

The accept/reject decision is **unchanged**, and stays unchanged on
purpose. Per #447 an absent or unreadable `client_proto` is served as
current (unknown-is-never-fatal), and the issue is explicit that the
`_ -> :ok` arm stays `:ok`. What changes is that the gate now **reports
its reading**.

`check_protocol_version/1` used to answer a bare `:ok` for three
different readings. It now returns a closed
`:absent | :declared | :unreadable`, and the two connect emissions that
already existed carry it:

- `Logger.info("ws connect authenticated", client_proto: declaration)` —
  the **message is byte-identical**, so #95's greppable line keeps
  working and the new fact rides the metadata prefix.
- `:telemetry.execute([:grappa, :ws, :connect], %{count: 1}, %{client_proto: declaration})`
  — refilling the `%{}` that #202 left behind.

`:client_proto` is added to the `config/config.exs` `:metadata`
allowlist **in the same commit**: an undeclared key is dropped at FORMAT
time, so without it the call site compiles, the telemetry twin fires,
and the operator reads the same bare string — the defect, reintroduced
by omission.

## The catch-all clause is split (class, not example)

`?client_proto[]=1` decodes to a **list**, so it never reached the
`is_binary(raw)` head and fell through to the same arm as a client that
declared nothing. Reporting that as `:absent` would be the same lie in a
second costume — the client *did* declare and the server could not read
it — so the key's **presence** now decides, not its parseability. The
decision is identical either way, and a test pins that the newly
classified shape still **connects**.

## A correction to the issue's premise, measured

The issue says a malformed declaration is "byte-identical, in every
observable output, to a valid one". That is true of *this module's*
emissions (which the issue scopes to) and **false of a connect's
observable output as a whole**: phoenix's own
`[:phoenix, :socket_connected]` handler already prints
`Parameters: <inspect>` from the same transport process
(`deps/phoenix/lib/phoenix/logger.ex:363`, level defaulting to `:info`
at `socket.ex:524`, `endpoint.ex` overriding nothing, prod at `:info`),
and `:pid` is in the metadata allowlist so the two lines correlate.

So the declared **value** is deliberately not repeated on our line —
that would duplicate state one line away and open a second
attacker-controlled-text log site for no new fact. What did not exist
anywhere is the server's **reading**, which is what this adds.

**Not pinned, and named as such.** No test here can witness that
phoenix line's production configuration:
`Phoenix.ChannelTest.__connect__/4` synthesises its own socket options
and never passes the endpoint's, so `log:` is hardcoded `:info` in every
ChannelTest connect. Measured, not assumed — injecting `log: false` into
the endpoint's socket declaration killed **zero of 38** tests, which is
how a first cut of this work (a tripwire test for exactly that
dependency) was found to be a mirror and deleted. The emission-site
comment and the decision-log entry carry the gap rather than leaving it
implicit.

## Mutation map (baseline 37 green, each mutant reverted)

| mutant | kills |
|---|---|
| unreadable arm returns `:declared` | 2 — telemetry `:unreadable` + its log line |
| present-but-non-binary clause deleted | 1 — exactly the `:unreadable`-not-`:absent` test |
| `:client_proto` out of the allowlist | 3 — **all and only** the log tests, zero telemetry |
| absent arm returns `:declared` | 2 — log `:absent` + telemetry `:absent` |

The third is the one that matters beyond the obvious: that it kills the
log tests and none of the telemetry ones is the evidence the two halves
measure different things rather than one thing twice.

## Gates

`scripts/check.sh` **rc=0**, read stage by stage rather than off the
tail: compile `--warnings-as-errors` (Boundary included), `format
--check-formatted`, credo `--strict` (6079 mods/funs, no issues),
`deps.audit` (no vulnerabilities), sobelow (17 findings, all Low
Confidence, zero Medium+), doctor, ExUnit (8 doctests, 61 properties,
**6576 tests, 0 failures**), dialyzer (`Total errors: 0`), bats (plan
`1..588` declared, 588 `ok`, 0 `not ok` — plan complete *and*
satisfied).

`scripts/design-notes-gate.sh`: 1 new entry heading, separator and
marker present.

**Rebase onto the post-#1606 main (`8a86b178`), full recipe:**
`scripts/union-rebase.sh` → `+82 -0` contribution intact; numstat
two-sided identical across all 5 files; the preceding entry
(`<!-- entry #1601 -->`, 101 lines) **re-captured from the new main and
`cmp`-identical** byte for byte; boundary shape read on the file (full
stop / marker with no blank before it / blank / `---` / blank /
heading); totals 53488+82=53570 lines, 150+1=151 markers, `_Deploy:`
unchanged at 66; `<!-- entry #1416 -->` unique against the new main's
tip (`grep -Fxc` = 0).

## What this does not establish

- The gate above was measured on base `fa2308b9`. Post-rebase the code
  is byte-identical and the only file the four landed PRs and this
  branch both touch is `DESIGN_NOTES.md` (verified byte-exact above) —
  but **the union of this change and the new base has not been gated
  together locally**. CI on this PR is what closes that.
- No connect was observed against a running BEAM; no e2e ran. The
  signals are proven in-process via `Phoenix.ChannelTest`.
- The distinction is asserted on the **emitted signal**, never on the
  return value — the return value is identical in both cases by design.
- Nothing in `lib/` attaches to `[:grappa, :ws, :connect]`, so the
  telemetry half is a hook for a future exporter; the Logger line is
  what an operator can read today.
- An unauthenticated connect with a malformed declaration is still
  invisible in *our* emissions — both are post-auth, as before.