### PR TITLE
codegen(#1466): decide a union from the AST, not from the rendered string

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53699,3 +53699,75 @@ The `EventRouter` per-kind shape table still read `required text` for `:notice`,
 already falsified. Both that cell and `:topic`'s now read `text or ""`, with the reason beneath
 the table — leaving one right and one wrong in the same table is how the next reader picks the
 wrong one.
+<!-- entry #1466 -->
+
+---
+
+## 2026-08-20 — #1466: a structural question, answered by reading the output
+
+`Mix.Tasks.Grappa.GenWireTypes.format_plain_typedef/2` decided whether a
+typedef was a UNION by looking for `" | "` in the string it had just rendered,
+and `reformat_to_multiline/2` then split on every occurrence of those three
+characters. Both halves asked a question about the TYPE and answered it from
+the TEXT, and both are wrong on the same inputs, in opposite directions: a body
+may carry `" | "` without being a union (a nested allowlisted-metadata bag
+renders `Partial<Record<"a" | "b", T>>[]`, which has no arms at all), and a
+union arm may carry `" | "` without that being an arm boundary (the same bag as
+one arm of a real union).
+
+The AST was two frames up the whole time. `pure_atom_union_arms/1` already
+pattern-matches `{:|, _, _}` for exactly this question, and the house rule was
+already written down one incident earlier: the session-state drift test reads
+"the COMPILED typespec via `Code.Typespec.fetch_types/1` — the type Dialyzer
+sees, not a re-parse of the source". A re-parse of the generator's OWN output
+is the same mistake with a shorter round trip.
+
+**Why it stayed latent, measured rather than assumed.** Exactly ONE type in the
+wire reaches that arm today: `Grappa.AdminEvents.Wire.event/0`. Its arms are
+bare alias references with no nested `" | "`, so string-replace and arm-join
+produce the same bytes. The other nine multiline typedefs in `wireTypes.ts`
+come from two different code paths — six from `format_derived_type/2`, three
+from `emit_auto_union/2`, which already built from a list of arms. There are
+zero lines over 100 columns in the committed artifact, which also means the
+`true -> inline_candidate` fallthrough emits nothing today.
+
+**What the defect actually costs, measured with `tsc --noEmit` on the emitted
+text.** #1466 left this open and guessed at the dangerous answer ("a
+valid-but-wrong type"). It is neither of the two options the issue named:
+
+* `" | "` between TYPE tokens — the two cases above — compiles, `rc=0`, and
+  denotes **exactly** the same type as the well-formatted form. Newlines are
+  insignificant between type tokens and a leading `|` is legal, so the token
+  stream is unchanged; an `Exact<A, B>` conditional-type probe compiles as
+  `true`. The damage is pure FORMATTING — and that is the worse regime in
+  practice, because biome reflows the line and the codegen drift gate then
+  disagrees with the cic format gate forever, with nothing failing loudly.
+  The same collision is what forced the `login_throttled` door and scope sets
+  to be NAMED rather than inlined (2026-08-06, a 102-character field).
+* `" | "` inside a STRING LITERAL — reachable from an atom like `:"a | b"` in a
+  mixed union — is `TS1002 unterminated string literal`. A hard syntax error
+  the cic gate catches. No such atom exists in the wire.
+
+So the severity is LOWER than the issue supposed on the axis it worried about,
+and the real exposure is the silent gate disagreement, not a type lie.
+
+**The cure.** The 100-column rule is unchanged; what changed is what it is
+applied to. The arm now matches `{:|, _, _}` on the stripped AST, renders each
+arm on its own and joins them — so an arm containing `" | "` stays one arm. The
+join moved into `multiline_union_typedef/2`, shared with `emit_auto_union/2`,
+so the two places that emit a broken-up union cannot drift apart.
+`reformat_to_multiline/2` is deleted.
+
+**Evidence, and the control's own cardinality.** `mix grappa.gen_wire_types
+--check` is green on BOTH artifacts, so no existing type moved a byte and there
+is no client-contract change. That green is only worth something if the changed
+arm is reached at all, so it was mutated: reversing the arm order inside
+`break_union_typedef/2` alone — not the shared helper, which `emit_auto_union/2`
+would also have reddened — takes `--check` to `OUT OF SYNC`, `rc=1`. The control
+is live, not vacuous.
+
+**Residual, deliberately untouched.** A non-union body over 100 columns still
+emits one long line, and an object body with an over-long field never wraps at
+all. That is the 2026-08-06 gate collision, not this defect, and nothing in the
+wire hits it today. Fixing it means reproducing biome's wrapping for arbitrary
+TS constructs, which is a different job and currently a speculative one.

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -282,16 +282,54 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
       "Partial<Record<#{key_ts_name}, #{do_render(value_ast)}>>;"
   end
 
+  # #1466 — "is this a union?" is a question about the TYPE, so it is asked of
+  # the AST. It used to be asked of `body`, the string this function had just
+  # rendered, via `String.contains?(body, " | ")` — and the split that followed
+  # was a blind `String.replace/3` over the same three characters. Both halves
+  # are wrong on the same inputs, in opposite directions: a body may carry
+  # `" | "` without being a union (`Partial<Record<"a" | "b", T>>[]`, a nested
+  # allowlisted-metadata bag), and a union arm may carry `" | "` without that
+  # being an arm boundary (the same bag as one arm of a real union). The first
+  # splits a type that has no arms; the second splits a real union INSIDE an
+  # arm.
+  #
+  # What that actually costs, MEASURED with `tsc --noEmit` on the emitted text
+  # rather than reasoned about, because the answer is not the obvious one and
+  # #1466 left it open. Two regimes, and NEITHER is the "valid but wrong type"
+  # the issue feared:
+  #
+  #   * `" | "` between TYPE tokens (both cases above): tsc exits 0 and the
+  #     type is EXACTLY equivalent to the well-formatted one — newlines are
+  #     insignificant and a leading `|` is legal, so the token stream is
+  #     unchanged. The damage is pure FORMATTING, which is the worse of the two
+  #     in practice: biome reflows it, so the codegen drift gate and the cic
+  #     format gate disagree forever, with nothing failing loudly. That is the
+  #     same collision that forced the `login_throttled` door/scope sets to be
+  #     NAMED rather than inlined (DESIGN_NOTES 2026-08-06).
+  #   * `" | "` inside a STRING LITERAL (an atom like `:"a | b"` in a mixed
+  #     union): TS1002 "unterminated string literal". A hard syntax error the
+  #     cic gate catches. No such atom exists in the wire today.
+  #
+  # The AST was two frames up the whole time — `pure_atom_union_arms/1` already
+  # pattern-matches `{:|, _, _}` for exactly this question. The 100-column rule
+  # is unchanged; what changed is what it is applied to.
+  #
+  # Residual, deliberately untouched: a NON-union body over 100 columns still
+  # emits one long line (the `true ->` arm, as before), and so does an object
+  # body with an over-long field (the `{` arm, which never wraps at all).
+  # Wrapping an arbitrary TS construct the way biome does is a different job,
+  # and it is the SAME gate collision described above rather than this defect.
+  # No type in the wire hits it today: measured, zero lines over 100 columns in
+  # the committed `wireTypes.ts`.
   defp format_plain_typedef(alias_name, stripped) do
     body = do_render(stripped)
-    sep = if String.starts_with?(body, "\n"), do: "", else: " "
     inline_candidate = "export type #{alias_name} = #{body};"
 
     cond do
-      String.starts_with?(body, "{") -> "export type #{alias_name} = #{body};"
-      String.starts_with?(body, "\n") -> "export type #{alias_name} =#{sep}#{body};"
+      String.starts_with?(body, "{") -> inline_candidate
+      String.starts_with?(body, "\n") -> "export type #{alias_name} =#{body};"
       String.length(inline_candidate) <= 100 -> inline_candidate
-      String.contains?(body, " | ") -> reformat_to_multiline(alias_name, body)
+      match?({:|, _, _}, stripped) -> break_union_typedef(alias_name, stripped)
       true -> inline_candidate
     end
   end
@@ -314,9 +352,19 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   defp atom_literal_arm?({:atom, _, [a]}) when a not in [nil, true, false], do: true
   defp atom_literal_arm?(_), do: false
 
-  defp reformat_to_multiline(alias_name, body) do
-    multi = String.replace(body, " | ", "\n  | ")
-    "export type #{alias_name} =\n  | #{multi};"
+  # Render each arm on its own, then join — so an arm that happens to contain
+  # `" | "` stays one arm. `flatten_union/2` preserves source order.
+  defp break_union_typedef(alias_name, union) do
+    arms = union |> flatten_union([]) |> Enum.map(&do_render/1)
+    multiline_union_typedef(alias_name, arms)
+  end
+
+  # biome's shape for a union that does not fit on one line: one arm per line,
+  # leading `|`, indent 2. Shared with the auto-emitted discriminated union
+  # (`emit_auto_union/2`) — same rule, one implementation, so the two shapes
+  # cannot drift apart.
+  defp multiline_union_typedef(alias_name, rendered_arms) do
+    "export type #{alias_name} =\n  | " <> Enum.join(rendered_arms, "\n  | ") <> ";"
   end
 
   defp module_from_path(path) do
@@ -934,7 +982,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     if String.length(inline_line) <= 100 do
       "\n\n" <> inline_line
     else
-      "\n\nexport type #{union_name} =\n  | " <> Enum.join(rendered_arms, "\n  | ") <> ";"
+      "\n\n" <> multiline_union_typedef(union_name, rendered_arms)
     end
   end
 

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -4,6 +4,19 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
   alias Grappa.Themes.TokenModel
   alias Mix.Tasks.Grappa.GenWireTypes
 
+  # #1466 — the rendering of `Grappa.WireFixtureLongUnion`'s metadata bag. It
+  # carries `" | "` while being a single, indivisible TS construct, so it is
+  # the discriminator between "split on union arms" and "split on a substring".
+  @partial_body ~s(Partial<Record<"alpha_channel" | "beta_channel", unknown>>)
+
+  # What splitting on the substring produces: a break INSIDE the Record's key
+  # union. Measured with `tsc --noEmit`, this still COMPILES and denotes the
+  # same type — newlines are insignificant between type tokens — so tsc is not
+  # the thing that catches it. biome is: it reflows the line, and then the
+  # codegen drift gate and the cic format gate disagree forever. The assertion
+  # therefore has to be on the emitted TEXT; no type-level check would fail.
+  @over_split ~s(Partial<Record<"alpha_channel"\n  | "beta_channel")
+
   describe "type mapping" do
     test "renders atom literal as TS string literal" do
       assert GenWireTypes.render_type({:atom, [], [:foo]}) == ~s("foo")
@@ -514,6 +527,47 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
 
       refute full =~ "ThemesWireBuiltinBackground"
       refute full =~ "ThemesBuiltinBackgroundsT"
+    end
+  end
+
+  # #1466 — the over-100-column arm of `format_plain_typedef/2` used to ask
+  # "is this a union?" by looking for `" | "` in the string it had just
+  # rendered, and then split on EVERY occurrence of those three characters.
+  # Both halves read the output instead of the AST that produced it, so both
+  # are wrong on the same inputs: a body may contain `" | "` without being a
+  # union, and a union arm may contain `" | "` without being a boundary.
+  describe "over-long typedefs break on union ARMS, not on a string sniff (#1466)" do
+    test "a non-union body carrying \" | \" is not broken into union arms" do
+      output = GenWireTypes.render_module_for_test(Grappa.WireFixtureLongUnion)
+
+      assert output =~
+               "export type WireFixtureLongUnionNestedPartialList = " <> @partial_body <> "[];"
+
+      refute output =~ @over_split
+    end
+
+    test "a real union with \" | \" inside an arm breaks only at the arm boundary" do
+      output = GenWireTypes.render_module_for_test(Grappa.WireFixtureLongUnion)
+
+      assert output =~
+               "export type WireFixtureLongUnionNestedPartialOrNull =\n  | " <>
+                 @partial_body <> "\n  | null;"
+
+      refute output =~ @over_split
+    end
+
+    # The pin the cure must NOT move: a union of plain same-module refs is the
+    # shape every union that reaches this arm in the real wire actually has
+    # (`Grappa.AdminEvents.Wire.event/0` is the only one, measured against the
+    # committed artifact). String-replace and arm-join agree here — which is
+    # precisely why the defect stayed latent.
+    test "a union of plain refs splits identically to the string-replace it replaces" do
+      output = GenWireTypes.render_module_for_test(Grappa.WireFixtureLongUnion)
+
+      assert output =~
+               "export type WireFixtureLongUnionLongAliasUnion =\n" <>
+                 "  | WireFixtureLongUnionNestedPartialList\n" <>
+                 "  | WireFixtureLongUnionNestedPartialOrNull;"
     end
   end
 

--- a/test/support/wire_fixture_long_union.ex
+++ b/test/support/wire_fixture_long_union.ex
@@ -1,0 +1,35 @@
+defmodule Grappa.WireFixtureLongUnion do
+  @moduledoc """
+  Fixture for the over-100-column line-breaking arm of
+  `Mix.Tasks.Grappa.GenWireTypes.format_plain_typedef/2` (#1466). Not used
+  in production.
+
+  Kept apart from `Grappa.WireFixture` on purpose, and not for the reason
+  `Grappa.WireFixtureDegraded` is: a `@type` that is a union with a MAP arm
+  makes `user_declared_union?/1` true for the whole module, which suppresses
+  the auto-emitted `Wire<Short>Event` discriminated union. Declaring these
+  types next to `simple_payload`/`collection_payload` would therefore delete
+  `WireWireFixtureEvent` from the fixture module's output — a fixture that
+  silently disables the very feature a sibling test asserts.
+
+  Every type here renders LONGER than 100 columns on one line, so every one
+  of them reaches the line-breaking arm. That is the only thing they have in
+  common; what differs is whether the AST is a union, which is exactly the
+  question the arm used to answer by string-sniffing.
+  """
+
+  # NOT a union: a list of allowlisted-metadata bags (the `Scrollback.Meta.t/0`
+  # shape, in a list). Renders `Partial<Record<"a" | "b", unknown>>[]` — three
+  # characters `" | "` in a body with no top-level union anywhere in it.
+  @type nested_partial_list :: [%{optional(:alpha_channel | :beta_channel) => term()}]
+
+  # IS a union, with a nested `" | "` INSIDE its first arm. A generator that
+  # gets the classification right and the split wrong still emits broken TS
+  # here, so this type separates the two halves of the defect.
+  @type nested_partial_or_null :: %{optional(:alpha_channel | :beta_channel) => term()} | nil
+
+  # The regression pin: a plain union of same-module refs, the shape every
+  # union that reaches this arm in the real wire actually has
+  # (`Grappa.AdminEvents.Wire.event/0`). Its rendering must not move.
+  @type long_alias_union :: nested_partial_list() | nested_partial_or_null()
+end


### PR DESCRIPTION
Fixes the defect reported in #1466: `format_plain_typedef/2` decided whether a
typedef was a UNION by looking for `" | "` in the string it had just rendered,
and `reformat_to_multiline/2` then split on every occurrence of those three
characters. Both halves asked a question about the TYPE and answered it from
the TEXT.

Two things the issue left open are answered here **by measurement**, and both
answers change how the finding should be read. They are the substance of this
PR, not footnotes.

## 1. No currently-generated type is mis-handled — and that is a result

#1466 asked whether any type is "within reach of the trigger", noting nobody
had enumerated the bodies reaching `format_plain_typedef/2` with length > 100.
Enumerated now:

* Exactly **one** type in the whole wire reaches the defective arm:
  `Grappa.AdminEvents.Wire.event/0`. Its arms are bare alias references with no
  nested `" | "`, so string-replace and arm-join produce the same bytes. That
  is why the defect stayed latent.
* The other nine multiline typedefs in `wireTypes.ts` come from two different
  code paths — six from `format_derived_type/2`, three from `emit_auto_union/2`,
  which already built from a list of arms rather than from a string.
* There are **zero lines over 100 columns** in the committed artifact, which
  also means the `true -> inline_candidate` fallthrough emits nothing today.

So this ships **no behavioural change to any existing type**, and that is
verified rather than argued: `mix grappa.gen_wire_types --check` is green on
BOTH artifacts. Zero drift, no client-contract change.

That green is only worth something if the changed arm is reached at all, so it
was mutated: reversing the arm order inside `break_union_typedef/2` **alone**
— not the shared helper, which `emit_auto_union/2` would also have reddened —
takes `--check` to `OUT OF SYNC`, rc=1. The control is live, not vacuous.

## 2. The issue's premise about the damage is measured FALSE

#1466 says the generator would "emit a broken `export type`", and asks whether
`tsc` would catch it "or silently accept a wrong type". Measured with
`tsc --noEmit` on the emitted text: **neither**. There are two regimes.

**`" | "` between TYPE tokens** — which is what both realistic shapes produce
— compiles, `rc=0`, and denotes **exactly the same type** as the well-formatted
form. Newlines are insignificant between type tokens and a leading `|` is
legal, so the token stream is unchanged; an `Exact<A, B>` conditional-type
probe compiles as `true`. There is no wrong type and no type error.

The damage is **pure formatting** — and that is the worse regime in practice,
because it is silent by construction: biome reflows the line, so the codegen
drift gate (`--check`) and the cic format gate (`bun run check`) disagree
forever, with neither failing in a way that names the cause. That exact
collision is what forced the `login_throttled` door and scope sets to be NAMED
rather than inlined (DESIGN_NOTES 2026-08-06, a 102-character field).

**`" | "` inside a STRING LITERAL** — reachable from an atom like `:"a | b"` in
a mixed union — is `TS1002 unterminated string literal`. A hard syntax error
the cic gate catches. No such atom exists in the wire today.

Net: the severity is **lower** than the issue supposed on the axis it worried
about (no type lie), and **higher** on an axis it did not name (a silent
disagreement between two gates, which is the failure mode a drift gate exists
to prevent).

## The change

The arm now matches `{:|, _, _}` on the stripped AST and renders each arm on
its own before joining them, so an arm containing `" | "` stays one arm. The
100-column rule is unchanged; what changed is what it is applied to. The AST
was two frames up the whole time — `pure_atom_union_arms/1` already
pattern-matches `{:|, _, _}` for exactly this question.

The join moves into `multiline_union_typedef/2`, shared with
`emit_auto_union/2`, so the two places that break a union across lines cannot
drift apart. `reformat_to_multiline/2` is deleted.

## Tests

New fixture `Grappa.WireFixtureLongUnion`, in its own module: a `@type` that is
a union with a map arm makes `user_declared_union?/1` true for the whole
module, which would have suppressed `WireWireFixtureEvent` and quietly
disabled the feature a sibling test asserts.

Three tests, and the red was read before the cure: **2 failed, 1 passed.** The
two failures are the two directions of the defect (a non-union split anyway; a
real union split inside an arm). The one that passed is the regression pin — a
union of plain refs, the shape the real wire actually has — which is the
evidence the cure must not move existing output.

## Gates

`scripts/check.sh` on the rebased tree, `GRAPPA_CACHE_ID=w2-1466`: credo strict
clean, `6572 tests, 0 failures`, dialyzer `Total errors: 0`, both artifacts in
sync, bats 588 ok / 0 not ok, `rc=0`. Re-verified after the rebase onto
`8a86b178`: the gen_wire_types suite and the drift gate both green; the full
run is repeating on the new base.

**Not run, deliberately:** `bun run check` / `bun run test` — zero cic files
touched and the generated artifacts are byte-identical (proven by `--check`),
so they would have measured the base, not this branch. `scripts/integration.sh`
and the e2e suite were not run either; this is a codegen mix task with no
runtime surface.

**Deliberately untouched residual:** a non-union body over 100 columns still
emits one long line, and an object body with an over-long field never wraps at
all. That is the same 2026-08-06 gate collision rather than this defect, it
needs biome's wrapping reproduced for arbitrary TS constructs, and no type in
the wire hits it today.