### PR TITLE
refactor(#1580): one subject-XOR predicate instead of twelve hand-copies

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53699,3 +53699,109 @@ The `EventRouter` per-kind shape table still read `required text` for `:notice`,
 already falsified. Both that cell and `:topic`'s now read `text or ""`, with the reason beneath
 the table — leaving one right and one wrong in the same table is how the next reader picks the
 wrong one.
+<!-- entry #1580 -->
+
+---
+
+## 2026-08-20 — #1580: one subject-XOR predicate, and why counting it by name would have lied
+
+`defp validate_subject_xor/1` lived twelve times under `lib/`, once in every
+schema carrying the `user_id` XOR `visitor_id` FK pair. It is now
+`Grappa.Subject.validate_xor/1`, called twelve times.
+
+### Counted by BODY, because a name count is not a duplication count
+
+The issue's "twelve" came from grepping the function NAME. That measures
+declarations, not duplication: a copy that was inlined, renamed, or pasted
+into an anonymous position is invisible to it — measured elsewhere in this
+repo, nineteen named definitions were retired while the same body survived
+INLINE fourteen times across ten files.
+
+So the census re-anchored on the decision body, `case {user_id, visitor_id}
+do … end`, and treated the enclosing function name as a DERIVED column. The
+number held at twelve, and the axes closed on each other: twelve
+`belongs_to :visitor` schemas, twelve decision bodies, twelve
+`<table>_subject_xor` CHECK constraints in migrations, zero schemas with a
+visitor FK and no body, zero `add_error(changeset, :subject, …)` anywhere
+outside those twelve blocks. The wider net — every file naming both columns —
+left ten files, and reading them found no thirteenth XOR in a different
+shape. The nearest miss, `Scrollback.persist_subject/2`, is a telemetry
+labeller that prefers `:user` when both are set: correct for a label, and not
+a validator.
+
+The census script carried its known-answer controls INSIDE it and printed no
+numbers unless all six passed — corpus size, a hand-counted calibration file,
+a real file that must yield zero, a decoy `defp` taking a changeset that must
+NOT be classified as one, a check that the decoy is actually present so the
+control is not vacuous, and an arithmetic cross-check that every subject
+`add_error` in `lib/` falls inside a counted block.
+
+### The mask is what licensed the flattening
+
+Hashing the twelve bodies with the string literals MASKED collapsed them to
+ONE control-flow class. That measurement, not a reading of the code, is what
+makes this a mechanical change: no copy carried behaviour the consolidation
+silently drops. The entire divergence in the family was one message string.
+`uploads/upload.ex` said `"one of user_id or visitor_id is required"`; the
+other eleven said `"must set user_id or visitor_id"`. Nothing pinned the
+variant, and its only production caller cannot reach the arm that emits it —
+`Uploads.create/3` routes the subject through `Subject.put_subject_id/2`,
+whose two clauses both guard `is_binary`, so a subject-less insert raises
+before the changeset runs. A typo the copies let live, not a requirement.
+
+### The comments could not have caught it, by construction
+
+Each copy carried a "Mirror of X" pointer. `accounts/session.ex` →
+`scrollback/message.ex` → `accounts/session.ex` is a cycle, so the graph has
+no root and no copy was the designated original. Every mirror claim was
+therefore unfalsifiable, which is precisely why the drifted copy could keep
+asserting a mirror it no longer was. Copies are not kept honest by comments.
+
+The same class of error appears in the issue's own pointer table, which
+records `networks/credential.ex` as having no pointer at all: it has one,
+spelled `Byte-mirror of`. An anchor that matches one phrasing of a word
+misses the others — the consolidation script hit the identical trap and
+refused the file rather than guessing at it.
+
+### Home, and boundaries
+
+`Grappa.Subject` rather than a new module: it already owns the subject
+discriminator, its moduledoc already states the XOR invariant, and
+`validate_xor/1` is the write-side twin of `put_subject_id/2` — one puts the
+column, the other proves the pair. Ten of the twelve schemas sit inside
+context boundaries that already declared `Grappa.Subject`; only
+`Accounts.Session` and `Networks.Credential` own their boundaries and needed
+the edge. No cycle: `Grappa.Subject` depends on `Accounts.User` and
+`Visitors.Visitor`, neither of which reaches back.
+
+### The pin, and what it is worth
+
+Three of the twelve pinned the missing-subject text; nine did not. A suite
+that guards a quarter of a family and is silent on the copy that is already
+wrong is how the drift shipped. `test/grappa/subject_xor_test.exs` now pins
+all twelve on both error arms and both valid shapes, and guards its own
+coverage: a thirteenth schema declaring `belongs_to :visitor` without a row
+in the table fails the population test.
+
+Written before the consolidation, that table was red exactly once, on
+`Uploads.Upload` — the drift made executable.
+
+### Spun off, not folded in
+
+`check_constraint(:subject, …)` is present in ten of the twelve.
+`accounts/session.ex` and `scrollback/message.ex` lack it although
+`sessions_subject_xor` and `messages_subject_xor` both exist in the DB, so on
+those two tables a violation that reached `Repo` would raise
+`Ecto.ConstraintError` rather than return a changeset error. Reachability is
+thin — the changeset predicate is byte-identical to the CHECK, so nothing
+that passes one fails the other short of a raw write — which is why it is
+recorded here and left to a call rather than folded into a duplication fix.
+
+### Not claimed
+
+That the `{nil, nil}` arm is unreachable in the other eleven: that was traced
+for `uploads` only. That the divergent message was ever user-visible: no
+client trace was run, and the unreachability above makes it moot for the one
+caller that exists. That the twelve were the total subject-XOR enforcement
+surface: the DB CHECK constraints are a second layer and were counted, not
+consolidated.

--- a/lib/grappa/accounts/session.ex
+++ b/lib/grappa/accounts/session.ex
@@ -61,13 +61,19 @@ defmodule Grappa.Accounts.Session do
   listed back — `handle/1` is the public, one-way name a device list
   and an operator log line use instead.
   """
-  use Boundary, top_level?: true, deps: []
+  # `Grappa.Subject` is the one declared dep, and unlike the `belongs_to`
+  # metadata this module's other names arrive as, it is a real call the
+  # checker resolves: `changeset/2` pipes through `Subject.validate_xor/1`
+  # (#1580). No cycle — `Grappa.Subject` depends on `Accounts.User` and
+  # `Visitors.Visitor`, neither of which reaches back here.
+  use Boundary, top_level?: true, deps: [Grappa.Subject]
 
   use Ecto.Schema
 
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @typedoc """
@@ -132,7 +138,7 @@ defmodule Grappa.Accounts.Session do
   Validates that `created_at` and `last_seen_at` are present (the
   other fields — `ip`, `user_agent` — are optional; mix-task callers
   have neither). Exactly one of `user_id` / `visitor_id` must be set —
-  the XOR constraint is enforced by `validate_subject_xor/1` and at
+  the XOR constraint is enforced by `Grappa.Subject.validate_xor/1` and at
   the DB level (CHECK constraint `sessions_subject_xor`).
 
   `assoc_constraint(:user)` and `assoc_constraint(:visitor)` are
@@ -156,7 +162,7 @@ defmodule Grappa.Accounts.Session do
     session
     |> cast(attrs, @cast_fields)
     |> validate_required(@required_fields)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> validate_label_matches_kind()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
@@ -239,28 +245,6 @@ defmodule Grappa.Accounts.Session do
     case DateTime.compare(now, prev) do
       :lt -> add_error(cs, :last_seen_at, "must not move backward (system-clock skew?)")
       _ -> cs
-    end
-  end
-
-  # Mirror of Grappa.Scrollback.Message.validate_subject_xor/1.
-  # Run BEFORE per-field validators so the XOR error surfaces first.
-  #
-  # Errors attach to the synthetic `:subject` key (B5.4 M-pers-2): neither
-  # `user_id` nor `visitor_id` is unambiguously "wrong" in either failure
-  # mode (both-nil = absence-of-either; both-set = pair-conflict), so a
-  # single key keeps client-side error rendering uniform. Pre-B5.4 this
-  # always attached to `:user_id`, which masked which field was the
-  # unexpected addition.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 end

--- a/lib/grappa/channel_directory/entry.ex
+++ b/lib/grappa/channel_directory/entry.ex
@@ -15,7 +15,7 @@ defmodule Grappa.ChannelDirectory.Entry do
   Mirrors `Grappa.QueryWindows.Window`: exactly one of `:user_id` /
   `:visitor_id` is set. Enforced at three layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `channel_directory_subject_xor`.
     * `check_constraint/3` that converts DB violations into changeset
@@ -27,6 +27,7 @@ defmodule Grappa.ChannelDirectory.Entry do
 
   alias Grappa.Accounts.User
   alias Grappa.Networks.Network
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -61,7 +62,7 @@ defmodule Grappa.ChannelDirectory.Entry do
   @doc """
   Builds an insert/update changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors
   to the synthetic `:subject` key). `network_id`, `name`, and
   `user_count` are required at cast time. The `assoc_constraint`s on
   `user`/`visitor`/`network` convert FK violations into changeset
@@ -75,7 +76,7 @@ defmodule Grappa.ChannelDirectory.Entry do
     |> cast(attrs, [:user_id, :visitor_id, :network_id, :name, :topic, :user_count, :captured_at])
     |> validate_required([:network_id, :name, :user_count])
     |> validate_length(:name, min: 1)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -83,19 +84,5 @@ defmodule Grappa.ChannelDirectory.Entry do
       name: :channel_directory_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.QueryWindows.Window.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -28,7 +28,7 @@ defmodule Grappa.Networks.Credential do
   flag; Rule-6 is not triggered by XOR-FK). Enforced at three layers,
   mirroring `Grappa.ReadCursor.Cursor`:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `network_credentials_subject_xor`.
     * Two partial unique indexes — `(user_id, network_id)
@@ -52,19 +52,20 @@ defmodule Grappa.Networks.Credential do
   """
 
   # Its own boundary, like the other three Networks schemas (#1398). Of the
-  # five names this module aliases, only `Grappa.IRC` is declared: the
-  # changeset calls `Identity.sanitize_ident/1` and `Identifier`. `User`,
-  # `Visitor` and `EncryptedBinary` arrive only as `belongs_to` and `field`
-  # arguments, and `Network` only as a `belongs_to` and a typespec — none of
-  # them a reference the checker resolves, so declaring them would state a
+  # six names this module aliases, only `Grappa.IRC` and `Grappa.Subject` are
+  # declared: the changeset calls `Identity.sanitize_ident/1`, `Identifier`,
+  # and — since #1580 — `Subject.validate_xor/1`. `User`, `Visitor` and
+  # `EncryptedBinary` arrive only as `belongs_to` and `field` arguments, and
+  # `Network` only as a `belongs_to` and a typespec — none of them a
+  # reference the checker resolves, so declaring them would state a
   # dependency nothing can verify.
-  use Boundary, top_level?: true, deps: [Grappa.IRC]
+  use Boundary, top_level?: true, deps: [Grappa.IRC, Grappa.Subject]
 
   use Ecto.Schema
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
-  alias Grappa.EncryptedBinary
+  alias Grappa.{EncryptedBinary, Subject}
   alias Grappa.IRC.{AuthFSM, Identifier, Identity}
   alias Grappa.Networks.Network
   alias Grappa.Visitors.Visitor
@@ -313,9 +314,10 @@ defmodule Grappa.Networks.Credential do
     |> validate_required([:network_id, :nick, :auth_method])
     # #211 — subject XOR: exactly one of user_id / visitor_id. Replaces
     # the pre-#211 `validate_required([:user_id])`, which is now
-    # XOR-gated (a visitor credential carries user_id IS NULL). Mirror
-    # of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-    |> validate_subject_xor()
+    # XOR-gated (a visitor credential carries user_id IS NULL). Since
+    # #1580 this is a call into the one shared predicate, not a
+    # hand-copy pointed at a sibling.
+    |> Subject.validate_xor()
     # A8: nick syntax + length is the same `Identifier.valid_nick?/1`
     # rule that `Grappa.Scrollback.Message.changeset/2` and the IRC
     # parser already use — single regex, single source. The local
@@ -400,7 +402,7 @@ defmodule Grappa.Networks.Credential do
     # #211 — DB-level XOR mirror. Maps the CHECK violation to a changeset
     # error on the synthetic `:subject` key (mirror of
     # `Grappa.ReadCursor.Cursor`) so a raw both-set / both-null insert
-    # slipping past `validate_subject_xor/1` still surfaces cleanly.
+    # slipping past `Grappa.Subject.validate_xor/1` still surfaces cleanly.
     |> check_constraint(:subject,
       name: :network_credentials_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
@@ -448,23 +450,6 @@ defmodule Grappa.Networks.Credential do
 
       _ ->
         put_change(changeset, :connection_state_changed_at, DateTime.truncate(DateTime.utc_now(), :second))
-    end
-  end
-
-  # #211 — subject XOR: exactly one of user_id / visitor_id must be set.
-  # Byte-mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`;
-  # errors attach to the synthetic `:subject` key so the client renders
-  # one uniform subject error regardless of which FK column is at fault.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -1172,7 +1172,7 @@ defmodule Grappa.Networks.Credentials do
   `:password` re-encrypts under the same Cloak vault (in-memory the
   loaded value is plaintext), the subject XOR + partial-unique guards
   fire, and `auth_method` validation runs. `:user_id` is never set —
-  the changeset's `validate_subject_xor/1` accepts the visitor-only
+  the changeset's `Grappa.Subject.validate_xor/1` accepts the visitor-only
   shape. Idempotent: identical attrs on an existing row are a no-op
   Repo.update; re-running never creates a duplicate (the
   `(visitor_id, network_id)` partial unique index + the get-or-insert

--- a/lib/grappa/notify/entry.ex
+++ b/lib/grappa/notify/entry.ex
@@ -12,7 +12,7 @@ defmodule Grappa.Notify.Entry do
   exactly one of `:user_id` / `:visitor_id` is set. Enforced at three
   layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `notify_entries_subject_xor`.
     * Two partial unique expression indexes (one per subject branch) on
@@ -32,6 +32,7 @@ defmodule Grappa.Notify.Entry do
   alias Grappa.Accounts.User
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.Network
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -60,7 +61,7 @@ defmodule Grappa.Notify.Entry do
   @doc """
   Builds an insert changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors to
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors to
   the synthetic `:subject` key). `network_id` and `nick` are required;
   `nick` must satisfy `Grappa.IRC.Identifier.valid_nick?/1` — a watch
   entry for a channel-shaped or garbage token would silently never
@@ -74,7 +75,7 @@ defmodule Grappa.Notify.Entry do
     |> cast(attrs, [:user_id, :visitor_id, :network_id, :nick])
     |> validate_required([:network_id, :nick])
     |> validate_nick()
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -96,20 +97,6 @@ defmodule Grappa.Notify.Entry do
         else
           add_error(changeset, :nick, "is not a valid IRC nick")
         end
-    end
-  end
-
-  # Mirror of `Grappa.QueryWindows.Window.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 end

--- a/lib/grappa/push/subscription.ex
+++ b/lib/grappa/push/subscription.ex
@@ -40,7 +40,7 @@ defmodule Grappa.Push.Subscription do
   Mirrors `Grappa.Scrollback.Message` / `Grappa.ReadCursor.Cursor` /
   `Grappa.QueryWindows.Window`: exactly one of `:user_id` /
   `:visitor_id` is set. Enforced at three layers: schema-level
-  `validate_subject_xor/1` (errors attach to the synthetic
+  `Grappa.Subject.validate_xor/1` (errors attach to the synthetic
   `:subject` key), DB CHECK constraint
   `push_subscriptions_subject_xor`, and two partial unique indexes
   (one per subject branch) on `(<subject_id>, endpoint)`. The
@@ -72,6 +72,7 @@ defmodule Grappa.Push.Subscription do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @providers [:webpush, :unifiedpush]
@@ -112,7 +113,7 @@ defmodule Grappa.Push.Subscription do
 
   @required ~w(endpoint p256dh_key auth_key)a
   # Subject FK columns (`:user_id` / `:visitor_id`) are NOT in
-  # `@required` — XOR enforcement runs through `validate_subject_xor/1`,
+  # `@required` — XOR enforcement runs through `Grappa.Subject.validate_xor/1`,
   # which errors on the synthetic `:subject` key instead of either
   # column individually.
   # `last_used_at` is intentionally NOT in the cast allowlist — it's
@@ -182,7 +183,7 @@ defmodule Grappa.Push.Subscription do
     |> validate_length(:p256dh_key, max: 256)
     |> validate_length(:auth_key, max: 64)
     |> validate_length(:user_agent, max: 512)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> unique_constraint([:user_id, :endpoint], error_key: :endpoint)
@@ -191,19 +192,5 @@ defmodule Grappa.Push.Subscription do
       name: :push_subscriptions_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/query_windows/window.ex
+++ b/lib/grappa/query_windows/window.ex
@@ -15,7 +15,7 @@ defmodule Grappa.QueryWindows.Window do
   exactly one of `:user_id` / `:visitor_id` is set. Enforced at three
   layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `query_windows_subject_xor`.
     * Two partial unique expression indexes (one per subject branch) on
@@ -32,6 +32,7 @@ defmodule Grappa.QueryWindows.Window do
 
   alias Grappa.Accounts.User
   alias Grappa.Networks.Network
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -62,7 +63,7 @@ defmodule Grappa.QueryWindows.Window do
   @doc """
   Builds an insert changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors
   to the synthetic `:subject` key). `network_id`, `target_nick` and
   `opened_at` are required at cast time. The `assoc_constraint`s on
   `user`/`visitor`/`network` convert FK violations into changeset
@@ -76,7 +77,7 @@ defmodule Grappa.QueryWindows.Window do
     |> cast(attrs, [:user_id, :visitor_id, :network_id, :target_nick, :opened_at])
     |> validate_required([:network_id, :target_nick, :opened_at])
     |> validate_length(:target_nick, min: 1)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -84,19 +85,5 @@ defmodule Grappa.QueryWindows.Window do
       name: :query_windows_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/read_cursor/cursor.ex
+++ b/lib/grappa/read_cursor/cursor.ex
@@ -14,7 +14,7 @@ defmodule Grappa.ReadCursor.Cursor do
   `:user_id` / `:visitor_id` is set. The XOR is enforced at three
   layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `read_cursors_subject_xor`.
     * Two partial unique indexes (one per subject branch) that
@@ -37,6 +37,7 @@ defmodule Grappa.ReadCursor.Cursor do
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.Network
   alias Grappa.Scrollback.Message
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -69,7 +70,7 @@ defmodule Grappa.ReadCursor.Cursor do
   Builds an insert / update changeset.
 
   All five fields are required at cast time; subject XOR validation
-  (`validate_subject_xor/1`) attaches to the synthetic `:subject` key.
+  (`Grappa.Subject.validate_xor/1`) attaches to the synthetic `:subject` key.
   `assoc_constraint/2` on each FK converts a missing parent into a
   changeset error (mirrors `Scrollback.Message.changeset/2` +
   `QueryWindows.Window.changeset/2`).
@@ -81,7 +82,7 @@ defmodule Grappa.ReadCursor.Cursor do
     |> canonicalize_channel()
     |> validate_required([:network_id, :channel, :last_read_message_id])
     |> validate_length(:channel, min: 1)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -109,20 +110,6 @@ defmodule Grappa.ReadCursor.Cursor do
 
       _ ->
         changeset
-    end
-  end
-
-  # Mirror of Scrollback.Message.validate_subject_xor/1.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 end

--- a/lib/grappa/scrollback/message.ex
+++ b/lib/grappa/scrollback/message.ex
@@ -96,6 +96,7 @@ defmodule Grappa.Scrollback.Message do
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.Network
   alias Grappa.Scrollback.Meta
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @kinds [
@@ -335,7 +336,7 @@ defmodule Grappa.Scrollback.Message do
 
   Exactly one of `:user_id` / `:visitor_id` is required — never both,
   never neither. The XOR constraint is enforced both here (via
-  `validate_subject_xor/1`) and at the DB layer (CHECK constraint
+  `Grappa.Subject.validate_xor/1`) and at the DB layer (CHECK constraint
   `messages_subject_xor`). `:network_id`, `:channel`, `:server_time`,
   `:kind`, `:sender` are universally required.
 
@@ -374,7 +375,7 @@ defmodule Grappa.Scrollback.Message do
     |> cast(attrs, [:body], empty_values: [])
     |> canonicalize_channel()
     |> validate_required([:network_id, :channel, :server_time, :kind, :sender])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> validate_identifier(:channel, &valid_target?/1)
     |> validate_identifier(:sender, &Identifier.valid_sender?/1)
     |> validate_body_for_kind()
@@ -407,27 +408,6 @@ defmodule Grappa.Scrollback.Message do
     case get_change(changeset, :channel) do
       ch when is_binary(ch) -> put_change(changeset, :channel, Identifier.canonical_target(ch))
       _ -> changeset
-    end
-  end
-
-  # Mirror of Grappa.Accounts.Session.validate_subject_xor/1.
-  #
-  # Errors attach to the synthetic `:subject` key (B5.4 M-pers-2): neither
-  # `user_id` nor `visitor_id` is unambiguously "wrong" in either failure
-  # mode (both-nil = absence-of-either; both-set = pair-conflict), so a
-  # single key keeps client-side error rendering uniform. Pre-B5.4 this
-  # always attached to `:user_id`, which masked which field was the
-  # unexpected addition.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 

--- a/lib/grappa/subject.ex
+++ b/lib/grappa/subject.ex
@@ -32,6 +32,7 @@ defmodule Grappa.Subject do
     top_level?: true,
     deps: [Grappa.Accounts.User, Grappa.Visitors.Visitor]
 
+  import Ecto.Changeset, only: [add_error: 3, get_field: 2]
   import Ecto.Query
 
   alias Grappa.Accounts.User
@@ -71,6 +72,42 @@ defmodule Grappa.Subject do
 
   def put_subject_id(attrs, {:visitor, vid}) when is_map(attrs) and is_binary(vid),
     do: Map.put(attrs, :visitor_id, vid)
+
+  @doc """
+  Enforces the subject XOR on a changeset: exactly one of `:user_id` /
+  `:visitor_id` must be set.
+
+  The write-side twin of `put_subject_id/2` — that one puts the column,
+  this one proves the pair. Errors attach to the synthetic `:subject` key
+  because neither column is individually "wrong"; the fault is in the
+  pair, and one key keeps client-side rendering uniform across both
+  violations and across every XOR-FK schema.
+
+  The DB-level `<table>_subject_xor` CHECK constraint is the substrate
+  twin: this turns a violation into a changeset error, the constraint
+  stops a write that never passed through a changeset at all.
+
+  **The single spelling of this predicate (#1580).** It used to be
+  hand-copied as a private `validate_subject_xor/1` into all twelve
+  XOR-FK schemas, each pointing at a sibling as the "mirror of" — a
+  pointer graph with a cycle in it and therefore no original. By the
+  twelfth copy one had drifted its missing-subject message, three lines
+  under a comment still claiming the mirror held, and nine of the twelve
+  had no test pinning the text. A thirteenth XOR-FK schema calls this;
+  it does not paste it.
+  """
+  @spec validate_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def validate_xor(%Ecto.Changeset{} = changeset) do
+    user_id = get_field(changeset, :user_id)
+    visitor_id = get_field(changeset, :visitor_id)
+
+    case {user_id, visitor_id} do
+      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
+      {_, nil} -> changeset
+      {nil, _} -> changeset
+      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
+    end
+  end
 
   @doc """
   Adds a `WHERE user_id = ?` clause (or its visitor mirror) to

--- a/lib/grappa/themes/theme.ex
+++ b/lib/grappa/themes/theme.ex
@@ -8,7 +8,7 @@ defmodule Grappa.Themes.Theme do
 
   A theme belongs to EITHER a user OR a visitor — never both, never
   neither. Same shape as `user_settings` / `network_credentials`:
-  `user_id` XOR `visitor_id`, enforced at the changeset (`validate_subject_xor/1`)
+  `user_id` XOR `visitor_id`, enforced at the changeset (`Grappa.Subject.validate_xor/1`)
   AND at the DB (the `themes_subject_xor` CHECK). Built-in themes are
   user-owned by the reserved "system" user.
 
@@ -21,6 +21,7 @@ defmodule Grappa.Themes.Theme do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Themes.TokenModel
   alias Grappa.Visitors.Visitor
 
@@ -69,7 +70,7 @@ defmodule Grappa.Themes.Theme do
     theme
     |> cast(attrs, [:name, :user_id, :visitor_id, :payload, :published])
     |> validate_required([:name, :payload])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> validate_length(:name, min: 1, max: 60)
     |> validate_payload()
     |> assoc_constraint(:user)
@@ -80,22 +81,6 @@ defmodule Grappa.Themes.Theme do
       name: :themes_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.UserSettings.Settings.validate_subject_xor/1`: exactly
-  # one subject FK must be set (the DB CHECK is the substrate; this is the
-  # call-site guard).
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 
   # Sanitize-in-place: the sanitized closed-token map replaces whatever the

--- a/lib/grappa/uploads/upload.ex
+++ b/lib/grappa/uploads/upload.ex
@@ -46,6 +46,7 @@ defmodule Grappa.Uploads.Upload do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Uploads.ContentType
   alias Grappa.Visitors.Visitor
 
@@ -108,7 +109,7 @@ defmodule Grappa.Uploads.Upload do
     |> validate_required([:slug, :mime, :bytes])
     |> validate_number(:bytes, greater_than: 0)
     |> sanitize_original_filename()
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> unique_constraint(:slug)
@@ -127,21 +128,6 @@ defmodule Grappa.Uploads.Upload do
   @spec soft_delete_changeset(t(), DateTime.t()) :: Ecto.Changeset.t()
   def soft_delete_changeset(upload, %DateTime{} = now) do
     change(upload, deleted_at: now)
-  end
-
-  # Mirrors `Grappa.ReadCursor.Cursor.validate_subject_xor/1` —
-  # error attaches to the synthetic `:subject` key so the wire shape
-  # matches every other XOR-FK context.
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "one of user_id or visitor_id is required")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 
   # Strip directory separators + leading dots from

--- a/lib/grappa/user_settings/settings.ex
+++ b/lib/grappa/user_settings/settings.ex
@@ -64,6 +64,7 @@ defmodule Grappa.UserSettings.Settings do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -93,7 +94,7 @@ defmodule Grappa.UserSettings.Settings do
   @doc """
   Builds an insert/update changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors
   to the synthetic `:subject` key); `:data` is required at cast
   time. Shape validation of individual `data` keys is intentionally
   NOT performed here — that is the responsibility of typed accessor
@@ -106,7 +107,7 @@ defmodule Grappa.UserSettings.Settings do
     settings
     |> cast(attrs, [:user_id, :visitor_id, :data])
     |> validate_required([:data])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> unique_constraint(:user_id, name: :user_settings_user_id_index)
@@ -115,19 +116,5 @@ defmodule Grappa.UserSettings.Settings do
       name: :user_settings_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/vhosts/grant.ex
+++ b/lib/grappa/vhosts/grant.ex
@@ -27,6 +27,7 @@ defmodule Grappa.Vhosts.Grant do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Vhosts.Vhost
   alias Grappa.Visitors.Visitor
 
@@ -63,7 +64,7 @@ defmodule Grappa.Vhosts.Grant do
     grant
     |> cast(attrs, [:vhost_id, :user_id, :visitor_id])
     |> validate_required([:vhost_id])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:vhost)
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
@@ -73,19 +74,5 @@ defmodule Grappa.Vhosts.Grant do
       name: :vhost_grants_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of ReadCursor.Cursor.validate_subject_xor/1.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/test/grappa/subject_xor_test.exs
+++ b/test/grappa/subject_xor_test.exs
@@ -1,0 +1,122 @@
+defmodule Grappa.SubjectXorTest do
+  @moduledoc """
+  One table over EVERY schema carrying the subject XOR-FK pair (#1580).
+
+  The census that opened #1580 measured the population closed at twelve on
+  four independent axes: twelve `belongs_to :visitor` schemas, twelve
+  `case {user_id, visitor_id}` decision bodies (measured by BODY, so an
+  inlined or renamed copy could not hide), twelve `*_subject_xor` DB CHECK
+  constraints, and zero schemas holding a visitor FK without a decision
+  body. Masking the string literals collapsed the twelve bodies to ONE
+  control-flow class: the whole divergence in the family was the
+  missing-subject message text. `uploads/upload.ex` emitted
+  `"one of user_id or visitor_id is required"` where the other eleven
+  emitted `"must set user_id or visitor_id"`, three lines under a comment
+  claiming it mirrored `ReadCursor.Cursor` — which emits the latter.
+
+  Three schemas of the twelve pinned the missing-subject text and nine did
+  not, which is exactly why the drift survived a hand-copy. This table pins
+  all twelve on both arms and both valid shapes, so the next copy that
+  drifts — or the next call site that quietly stops routing through the
+  shared validator — is a red test rather than a silent fork.
+
+  Attrs are deliberately minimal: every assertion reads ONLY the synthetic
+  `:subject` key, so the other required fields of each schema are
+  irrelevant here and are covered by that schema's own test. The two
+  positive assertions (`{nil, nil}` and both-set) are what keeps the pair
+  from passing vacuously — a changeset that stopped calling the validator
+  altogether would fail them, not slip through the two clean-subject ones.
+  """
+  use Grappa.DataCase, async: true
+
+  alias Grappa.Accounts.Session
+  alias Grappa.ChannelDirectory.Entry, as: DirectoryEntry
+  alias Grappa.Networks.Credential
+  alias Grappa.Notify.Entry, as: NotifyEntry
+  alias Grappa.Push.Subscription
+  alias Grappa.QueryWindows.Window
+  alias Grappa.ReadCursor.Cursor
+  alias Grappa.Scrollback.Message
+  alias Grappa.Themes.Theme
+  alias Grappa.Uploads.Upload
+  alias Grappa.UserSettings.Settings
+  alias Grappa.Vhosts.Grant
+
+  @user_id "11111111-1111-4111-8111-111111111111"
+  @visitor_id "22222222-2222-4222-8222-222222222222"
+
+  @missing_subject "must set user_id or visitor_id"
+  @mutually_exclusive "user_id and visitor_id are mutually exclusive"
+
+  # {schema, its subject-bearing changeset}. Eleven spell it `changeset/2`;
+  # `Uploads.Upload` splits insert from soft-delete and only the former
+  # casts the subject FKs.
+  @xor_schemas [
+    {Session, :changeset},
+    {Message, :changeset},
+    {Cursor, :changeset},
+    {Window, :changeset},
+    {DirectoryEntry, :changeset},
+    {NotifyEntry, :changeset},
+    {Subscription, :changeset},
+    {Settings, :changeset},
+    {Grant, :changeset},
+    {Theme, :changeset},
+    {Credential, :changeset},
+    {Upload, :insert_changeset}
+  ]
+
+  describe "the XOR-FK population itself" do
+    test "the table covers every schema that declares a visitor FK" do
+      # Guards the table against bit-rot: a thirteenth XOR-FK schema added
+      # without a row here would otherwise be silently unpinned, which is
+      # the failure mode that produced #1580 in the first place.
+      declared =
+        "lib/grappa/**/*.ex"
+        |> Path.wildcard()
+        |> Enum.filter(fn path ->
+          path |> File.read!() |> String.contains?("belongs_to :visitor,")
+        end)
+
+      assert length(declared) == length(@xor_schemas),
+             """
+             #{length(declared)} schemas declare `belongs_to :visitor`, \
+             but the table pins #{length(@xor_schemas)}. Files:
+             #{Enum.join(declared, "\n")}
+             """
+    end
+  end
+
+  for {schema, fun} <- @xor_schemas do
+    @schema schema
+    @fun fun
+
+    describe "#{inspect(schema)}.#{fun}/2 subject XOR" do
+      test "neither user_id nor visitor_id attaches the shared missing-subject message" do
+        assert @missing_subject in subject_errors(@schema, @fun, %{})
+      end
+
+      test "both user_id and visitor_id attaches the shared mutually-exclusive message" do
+        errors = subject_errors(@schema, @fun, %{user_id: @user_id, visitor_id: @visitor_id})
+
+        assert @mutually_exclusive in errors
+      end
+
+      test "a user-only subject leaves :subject clean" do
+        assert subject_errors(@schema, @fun, %{user_id: @user_id}) == []
+      end
+
+      test "a visitor-only subject leaves :subject clean" do
+        assert subject_errors(@schema, @fun, %{visitor_id: @visitor_id}) == []
+      end
+    end
+  end
+
+  defp subject_errors(schema, fun, attrs) do
+    changeset = apply(schema, fun, [struct(schema), attrs])
+
+    changeset
+    |> errors_on()
+    |> Map.get(:subject, [])
+  end
+end


### PR DESCRIPTION
Consolidates the twelve hand-copied `defp validate_subject_xor/1` bodies into
one `Grappa.Subject.validate_xor/1`, and pins the contract on all twelve
schemas. Refs #1580.

## The number was re-measured before it was trusted

#1580's "twelve" came from grepping the function NAME, which counts
declarations rather than duplication — an inlined, renamed or anonymous copy
is invisible to it. Re-anchored on the **decision body**,
`case {user_id, visitor_id} do … end`, with the enclosing name demoted to a
derived column:

| axis | count |
|---|---|
| XOR decision bodies in `lib/` | **12** |
| distinct enclosing names | 1 — no inlined or renamed copy |
| schemas declaring `belongs_to :visitor` | 12 |
| `<table>_subject_xor` CHECK constraints in migrations | 12 |
| visitor FK but **no** decision body | 0 |
| subject `add_error` outside a counted body | 0 |

The number holds and the population is closed on four independent axes. The
census script carried six known-answer controls **inside** it — including a
decoy `defp` that takes a changeset but is not an XOR, plus a check that the
decoy is actually present so the control is not vacuous — and printed no
numbers unless all six passed. No `git grep -E` was used for counting: POSIX
ERE has no `\s` and no `\b`.

The "no copy in a different shape" zero was earned, not assumed: the ten
files naming both columns but holding no body were all read. Nearest miss is
`Scrollback.persist_subject/2`, a telemetry labeller — not a validator.

## Why flattening is safe, measured rather than argued

Hashing each body twice — literals included, then literals masked — gives
**2 classes by text** (11 + 1) but **1 class by control flow** (12). The
entire divergence in the family is the missing-subject message, so no copy
carried behaviour this change drops.

`uploads/upload.ex` said `"one of user_id or visitor_id is required"` where
the eleven said `"must set user_id or visitor_id"`. Classified as a typo, not
a requirement, on four measurements: identical control flow; its own comment
claims to mirror `ReadCursor.Cursor`, which emits the other string; zero test
pins on the variant; and **the arm is unreachable through its only production
caller** — `Uploads.create/3` routes the subject through
`Subject.put_subject_id/2`, whose clauses both guard `is_binary`.

That last one downgrades the issue's framing: the drift is real and measured,
but it is a latent inconsistency, **not an observable defect**.

## The root cause the issue described but did not name

`accounts/session.ex` → `scrollback/message.ex` → `accounts/session.ex` is a
cycle. The pointer graph has no root, so no copy was the designated original
and every "mirror of" claim was unfalsifiable by construction. A comment could
not have caught this. Copies are not kept honest by comments; the fix is to
have one.

## Home

`Grappa.Subject` rather than a new module: it already owns the subject
discriminator, its moduledoc already states the XOR invariant, and this is the
write-side twin of `put_subject_id/2` — one puts the column, the other proves
the pair. Ten of the twelve schemas sit in context boundaries that already
declared `Grappa.Subject`; only `Accounts.Session` and `Networks.Credential`
own their boundaries and needed the edge. No cycle.

`lib/` net **+94 / −228** over 14 files; 17 stale doc citations repointed.

## The red came first, and it was the drift

`test/grappa/subject_xor_test.exs` — one table over all twelve schemas, four
cases each, plus a population guard. Run before any production change:

```
49 tests, 1 failure

1) Grappa.Uploads.Upload.insert_changeset/2 subject XOR
   neither user_id nor visitor_id attaches the shared missing-subject message
   left:  "must set user_id or visitor_id"
   right: ["one of user_id or visitor_id is required"]
```

Reproducible from the base:

```sh
git checkout 8a86b178
git checkout w1-1580 -- test/grappa/subject_xor_test.exs
scripts/test.sh test/grappa/subject_xor_test.exs   # 49 tests, 1 failure
```

Every commit on the branch is green, so a bisect never lands on a broken tree.
Before this the suite pinned the text in 3 of 12 schemas and was silent on the
other nine, including the one already wrong.

## The pin is load-bearing — 7 mutants, 0 survivors

M0 is a calibration run: the hand-written parser must read the known baseline
(49/0) off an unmutated tree or the harness aborts. Every injection asserts
its predicate matches **exactly once** before writing.

| mutant | killed | arms hit |
|---|---|---|
| M1 reinstates the exact #1580 drift in the single function | 12/49 | missing-subject ×12 |
| M2 changes the both-set message | 12/49 | mutually-exclusive ×12 |
| M3 rejects a user-only subject | 12/49 | user-only-valid ×12 |
| M4 rejects a visitor-only subject | 12/49 | visitor-only-valid ×12 |
| M5 accepts both-set (drops the XOR) | 12/49 | mutually-exclusive ×12 |
| M6 one call site stops routing through the validator | **2/49** | uploads only |
| M7 a schema drops out of the table | **1/45** | population-guard ×1 |

**M1 is the requirement discharged**: the single function gets one case wrong
— precisely the case one copy treated differently — and 12 assertions die;
before consolidation the same mistake killed 3. Each mutant hits exactly one
arm, so the assertions discriminate rather than being one blanket check
wearing four names. **M6 kills exactly one schema's two rows**: a *partial*
consolidation, the likeliest future regression, is caught and localised. M7 is
the only mutant that moves the denominator (49 → 45), which is itself the
evidence the guard measures coverage.

## Gates

`scripts/check.sh` **rc=0** on the rebased head, every stage confirmed to have
run: credo 696 files 0 issues · `deps.audit` clean · sobelow Low-only (gate is
Medium+) · **6630 tests / 8 doctests / 61 properties / 0 failures** · dialyzer
**0 errors** · bats **590/590**. Plus `format.sh --check` rc=0,
`design-notes-gate.sh` ok, and `union-rebase.sh` reporting
`docs/DESIGN_NOTES.md +106 −0 — contribution intact` with the boundary shape
read on the real file afterwards.

An earlier `check.sh` **halted at credo** on an issue that was mine
(`credential.ex` ended up with two single `Grappa.*` aliases where the repo
uses the multi form). Fixed, folded into the refactor commit, whole gate
re-run from scratch — tests, dialyzer, sobelow and bats never ran on the
halted invocation, so that run is reported as *not measured*, never as zero.

## Two findings left OUT of this PR, deliberately

1. **`check_constraint(:subject, …)` is in 10 of 12.** `accounts/session.ex`
   and `scrollback/message.ex` lack it although `sessions_subject_xor` and
   `messages_subject_xor` both exist in the DB, so a violation reaching `Repo`
   there raises `Ecto.ConstraintError` instead of returning a changeset error.
   A different axis from the copied predicate, and reachability is thin (the
   changeset predicate is byte-identical to the CHECK). **A call for @vjt** —
   defence-in-depth, deliberate-and-wants-a-comment, or not worth it.
2. **#1580's pointer table records `networks/credential.ex` as having no
   pointer.** It has one, spelled `Byte-mirror of`. An anchor matching
   `Mirror of` misses it. The *inbound* claim in the issue still stands. The
   consolidation script hit the identical trap and refused the file rather
   than guessing, which is how it was caught.

## Not claimed

Eleven declared non-measures are enumerated in the report, each marked
closable or structural. The load-bearing ones: `{nil, nil}` reachability was
traced for `uploads` only; no client trace was run, so no claim that the
divergent message was ever user-visible; the twelve bodies were proven
equivalent *structurally* (normalised-body hash) plus the post-hoc table, not
by a pre-consolidation differential run; the `ConstraintError` consequence in
finding 1 is read from Ecto semantics, not reproduced; and **e2e /
`scripts/integration.sh` was not run** — the change is server-side Elixir with
no cic or wire surface, but that is an argument, not a measurement, and per
CLAUDE.md the full integration suite green is the ship gate.
