### PR TITLE
#1518 — cic: buy the service-modal arm's ordering invariant

### DIFF
--- a/cicchetto/src/__tests__/serviceModalCommand.test.ts
+++ b/cicchetto/src/__tests__/serviceModalCommand.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { setToken } from "../lib/auth";
+import { channelKey } from "../lib/channelKey";
+import type { CommandContext } from "../lib/commands/context";
+import { serviceModalCommand } from "../lib/commands/services";
+import { appendToScrollback } from "../lib/scrollback";
+import { closeServiceModal, serviceMirrorRows, serviceModalState } from "../lib/serviceModal";
+import { SERVER_WINDOW_NAME } from "../lib/windowKinds";
+
+// #1518 — the `service-modal` arm's statement ORDER, which #290 stated in a
+// comment and nothing bought: swapping the two lines left the whole vitest
+// suite green (measured on 425426f2), because `compose.test.ts` asserts WHICH
+// calls the arm makes and never in what sequence.
+//
+// The order is load-bearing, and the gap is production's own: `sendBodyLines`
+// AWAITS the POST, and the WS handler (`subscribe.ts`, which ingests a NOTICE
+// by calling the same `appendToScrollback` this test calls) runs on that event
+// loop. A service notice that lands while the POST is in flight is a
+// WHILE-OPEN arrival — `openServiceModal` must already have taken the mirror
+// high-water mark, so the notice sits ABOVE it and `ServiceModal.tsx` renders
+// it (`id > sinceId`). Capture the mark after the await instead and that same
+// notice is at or below it: the help wall the modal exists to confine is
+// filtered out of the very view that was opened for it.
+//
+// Only `lib/api`'s `sendMessage` is stubbed, so the await under test is the
+// real one — real `sendBodyLines` → real `scrollback.sendMessage` → the POST —
+// and the notice is delivered through the real ingest verb. `null` is what a
+// `*Serv` target's 202 returns (#1430): the send persists no row of its own.
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, sendMessage: vi.fn() };
+});
+
+const SLUG = "svc-order";
+const SERVICE = "NickServ";
+const PRE_OPEN_ID = 10;
+const IN_FLIGHT_ID = 11;
+
+const notice = (id: number, body: string): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel: SERVER_WINDOW_NAME,
+  server_time: id,
+  kind: "notice",
+  sender: SERVICE,
+  body,
+  meta: {},
+});
+
+// The arm reads `ctx.networkSlug` and nothing else off the record (#1396).
+// Every other member throws rather than returning a plausible value, so a new
+// read shows up as a failure naming the field instead of passing quietly.
+const unread = (field: string): (() => never) => {
+  return () => {
+    throw new Error(`the service-modal arm must not read ctx.${field}`);
+  };
+};
+
+const context = (): CommandContext => ({
+  key: channelKey(SLUG, "#chan"),
+  networkSlug: SLUG,
+  submittedFrom: "#chan",
+  text: "/ns",
+  token: "tok",
+  getActiveChannel: unread("getActiveChannel"),
+  sigils: unread("sigils"),
+  requireChannel: unread("requireChannel"),
+  requireNetworkId: unread("requireNetworkId"),
+  resolveBareWhoisNick: unread("resolveBareWhoisNick"),
+});
+
+describe("service-modal arm (#290/#1518)", () => {
+  beforeEach(() => {
+    // `scrollback.sendMessage` returns early without a bearer, which would
+    // skip the POST and with it the mid-send delivery below.
+    setToken("tok");
+    closeServiceModal();
+  });
+
+  it("captures the mirror high-water mark BEFORE `help` goes out, so a notice landing mid-send stays a while-open arrival", async () => {
+    const key = channelKey(SLUG, SERVER_WINDOW_NAME);
+    appendToScrollback(key, notice(PRE_OPEN_ID, "stale line from a past session"));
+
+    const api = await import("../lib/api");
+    vi.mocked(api.sendMessage).mockImplementation(async () => {
+      appendToScrollback(key, notice(IN_FLIGHT_ID, "***** NickServ Help *****"));
+      return null;
+    });
+
+    await serviceModalCommand({ kind: "service-modal", service: SERVICE }, context());
+
+    // Control — the mid-send notice really did land in the mirror this open
+    // reads. Without it the assertion below would hold for a send that never
+    // fired at all.
+    expect(serviceMirrorRows(SLUG, SERVICE).map((m) => m.id)).toEqual([PRE_OPEN_ID, IN_FLIGHT_ID]);
+    // The invariant: the mark is the PRE-send high-water, so the notice that
+    // arrived during the send is above it and the modal mirrors it.
+    expect(serviceModalState()?.sinceId).toBe(PRE_OPEN_ID);
+  });
+});

--- a/cicchetto/src/lib/commands/services.ts
+++ b/cicchetto/src/lib/commands/services.ts
@@ -12,6 +12,15 @@ import type { CommandHandler } from "./context";
  * command WITH args stays the `msg` arm (inline execute, reply inline) — no
  * unsolicited popup for power users.
  *
+ * #1518 — that ordering is load-bearing, and the gap it guards is this
+ * function's own `await`: `sendBodyLines` suspends on the POST, and the WS
+ * handler delivers the service's reply NOTICEs into the scrollback on the same
+ * event loop. A notice landing while the POST is in flight must count as a
+ * while-open arrival, which it does only if the mark was taken first. Bought by
+ * `serviceModalCommand.test.ts`, and it needed buying: swapping these two lines
+ * used to leave the whole vitest suite green, because the arm's other tests
+ * assert WHICH calls it makes and never in what sequence.
+ *
  * #1396 — it could only move here once #1513 lifted `sendBodyLines` out of the
  * store closure: that import was its whole blocker, and it is the ONLY arm the
  * hoist unblocked. It reads `ctx.networkSlug` and nothing else off the record —

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53699,3 +53699,65 @@ The `EventRouter` per-kind shape table still read `required text` for `:notice`,
 already falsified. Both that cell and `:topic`'s now read `text or ""`, with the reason beneath
 the table — leaving one right and one wrong in the same table is how the next reader picks the
 wrong one.
+<!-- entry #1518 -->
+
+---
+
+## 2026-08-20 — #1518: the services-modal ordering invariant, measured and bought
+
+#290's `service-modal` arm is two statements, and its comment declares the
+order between them: `openServiceModal` captures the mirror high-water mark
+FIRST, `help` goes out SECOND, so the reply notices count as while-open
+arrivals. #1518 measured that nothing enforced it — swap the two lines and the
+suite stays green.
+
+Reproduced before touching anything, on `origin/main` = 425426f2: the whole cic
+vitest suite is 294 files / 5688 cases, and it passes 5688/5688 both with the
+arm as written and with the two statements swapped. Identical totals, `rc=0`
+both times. `compose.test.ts` covers this arm with an `it.each` that asserts
+`openServiceModal` was called and `sendMessage` was called; neither assertion
+can see which ran first.
+
+### The order is real, and the gap is the arm's own `await`
+
+`sendBodyLines` suspends on the POST. The WS handler ingests a NOTICE by
+calling `appendToScrollback` — the same store `openServiceModal` reduces to a
+high-water mark — and it runs on that same event loop. So a service notice that
+lands while the POST is in flight is exactly the arrival the modal exists to
+show, and it is above the mark only if the mark was taken before the await.
+Capture it after and the notice is at or below `sinceId`, which is the one
+predicate `ServiceModal.tsx` filters on: the help wall gets filtered out of the
+view that was opened for it.
+
+That is a race window, not a certainty, which is why it was never observed. The
+ircd's reply usually comes back after the 202 does. The browser e2e
+(`issue290-services-modal.spec.ts`) is blind to it for the same reason: it waits
+for lines to appear with no bound on when they were captured, so it stays green
+under either order.
+
+### What buys it now
+
+`serviceModalCommand.test.ts` drives the real handler with only `lib/api`'s
+`sendMessage` stubbed — the await under test is production's own, through the
+real `sendBodyLines` and the real `scrollback.sendMessage` — and delivers a
+notice through the real ingest verb from inside the in-flight POST. Its
+load-bearing assertion is that `sinceId` is the PRE-send high-water.
+
+Two mutants, one per assertion, each killing exactly one:
+
+* swap the arm's two statements → only the `sinceId` assertion fails
+  (`expected 11 to be 10`); the control passes.
+* drop the mid-send delivery from the fixture → only the control fails
+  (`expected [10] to deeply equal [10, 11]`).
+
+The control is not decoration: without it the invariant assertion holds
+vacuously for a send that never fired at all — `sinceId` would read 10 because
+nothing ever arrived, and the test would be green while measuring nothing.
+
+### What this does not buy
+
+The same order has a second consequence — the modal appears before the send
+rather than after it, so a paced (#666 429-retry) or failing send would leave
+the operator with no modal at all under the swap. The #290 comment does not
+claim it and no test here asserts it. And no e2e was run for this slice: the
+spec above was read, not executed.


### PR DESCRIPTION
#290's `service-modal` arm is two statements, and its comment declares the order
between them: `openServiceModal` takes the mirror high-water mark FIRST, `help`
goes out SECOND, so the reply notices count as while-open arrivals. #1518
measured that nothing enforced it. This slice establishes that the order is
real and buys it with a test that bites.

## The reproduction, before touching anything

On `origin/main` = 425426f2, the whole cic vitest suite is **294 files / 5688
cases**:

| run | arm | result |
|---|---|---|
| R0 | as written | 294/294 files, 5688/5688 tests, `rc=0` |
| R1 | two statements swapped | 294/294 files, 5688/5688 tests, `rc=0` |

Identical totals. `compose.test.ts` covers this arm with an `it.each` asserting
that `openServiceModal` was called and that `sendMessage` was called; neither
assertion can see which ran first.

## Why the order is load-bearing

The gap it guards is the arm's own `await`. `sendBodyLines` suspends on the
POST, and the WS handler ingests a NOTICE by calling `appendToScrollback` — the
same store `openServiceModal` reduces to a high-water mark — on that same event
loop. A service notice landing while the POST is in flight is exactly the
arrival the modal exists to show, and it is above the mark only if the mark was
taken before the await. Capture it after and the notice sits at or below
`sinceId`, the one predicate `ServiceModal.tsx` filters on: the help wall is
filtered out of the view that was opened for it.

It is a race window rather than a certainty, which is why it was never
observed — the ircd's reply usually comes back after the 202 does.

## What buys it now

`serviceModalCommand.test.ts` drives the real handler with only `lib/api`'s
`sendMessage` stubbed, so the await under test is production's own (real
`sendBodyLines` → real `scrollback.sendMessage` → the POST), and delivers a
notice through the real ingest verb from inside the in-flight POST. `null` is
what a `*Serv` target's 202 returns (#1430).

Two mutants, one per assertion, each killing exactly one — `1 failed | 0 other
failures` both times:

| mutant | red line | message |
|---|---|---|
| swap the arm's two statements | the `sinceId` assertion | `expected 11 to be 10` |
| drop the mid-send delivery from the fixture | the control | `expected [ 10 ] to deeply equal [ 10, 11 ]` |

The control is not decoration: without it the invariant assertion holds
vacuously for a send that never fired — `sinceId` would read 10 because nothing
ever arrived, and the test would be green while measuring nothing.

## Gates

Post-rebase onto `ba32aa63`: `bun run test` 295 files / 5695 tests `rc=0`;
`bun run check` 4 stages, 0 failed; `design-notes-gate.sh` `rc=0`;
`union-rebase.sh` `rc=0` with `docs/DESIGN_NOTES.md +62 -0` on both sides, the
preceding entry (#1505, 109 lines) `cmp`-identical against the new base, and
the marker `<!-- entry #1518 -->` absent from `origin/main` and `grep -Fxc` = 1
here.

## What this does not buy

The same order has a second consequence — the modal appears before the send
rather than after it, so a paced (#666 429-retry) or failing send would leave
the operator with no modal at all under the swap. The #290 comment does not
claim it and nothing here asserts it; it is named in the DESIGN_NOTES entry
rather than left implicit.

No e2e ran for this slice. `issue290-services-modal.spec.ts` was read, not
executed: it waits for modal lines with no bound on when they were captured, so
it stays green under either order and would not have bought this either.