### PR TITLE
#1513 — cic: switch noImportCycles on, and cut the one cycle it finds

### DIFF
--- a/cicchetto/biome.json
+++ b/cicchetto/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noImportCycles": "error"
+      }
     }
   },
   "javascript": {

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -449,7 +449,7 @@ const Shell: Component = () => {
   // `.shell-members` drawer on mobile) a PERMANENT surface reachable from
   // EVERY window kind — the cog lives in it, so it MUST be openable on
   // non-channel windows (home/server/list/mentions/admin). Force-closing it
-  // whenever `isActiveChannelJoined()` is false directly contradicts that. On
+  // whenever `isActiveChannelJoined(...)` is false directly contradicts that. On
   // desktop the effect was already a visual no-op (the members pane is a grid
   // column; `membersOpen`/`.open` have no desktop CSS and the TopicBar
   // hamburger is CSS-hidden there, so membersOpen never toggled). The drawer
@@ -591,7 +591,10 @@ const Shell: Component = () => {
       when={isMobile()}
       fallback={
         // ── Desktop three-pane layout (unchanged from pre-C6) ─────────
-        <div class="shell" classList={{ "shell-no-members": !isActiveChannelJoined() }}>
+        <div
+          class="shell"
+          classList={{ "shell-no-members": !isActiveChannelJoined(selectedChannel()) }}
+        >
           <ErrorBanners />
           <Toasts />
           <PrivacyModal />
@@ -753,11 +756,11 @@ const Shell: Component = () => {
           <aside class="shell-members" classList={{ open: membersOpen() }}>
             {/* UX-5 bucket BS — drag handle on the inner edge of the
                 right (members) sidebar. Mounted unconditionally even
-                when isActiveChannelJoined() is false (the column
+                when isActiveChannelJoined(...) is false (the column
                 narrows via .shell-no-members in CSS); the handle is
                 inside the aside so it's hidden together. */}
             <ResizeHandle side="right" />
-            <Show when={isActiveChannelJoined() && selectedChannel()}>
+            <Show when={isActiveChannelJoined(selectedChannel()) && selectedChannel()}>
               {(sel) => (
                 <MembersPane networkSlug={sel().networkSlug} channelName={sel().channelName} />
               )}
@@ -1088,7 +1091,7 @@ const Shell: Component = () => {
             ONE bottom drawer. The mobile-only `.mobile-panel-actions` footer is
             gone — archive is now a first-class RailActions button. */}
         <aside class="shell-members" classList={{ open: membersOpen() }}>
-          <Show when={isActiveChannelJoined() && selectedChannel()}>
+          <Show when={isActiveChannelJoined(selectedChannel()) && selectedChannel()}>
             {(sel) => (
               <MembersPane
                 networkSlug={sel().networkSlug}

--- a/cicchetto/src/__tests__/windowState.test.ts
+++ b/cicchetto/src/__tests__/windowState.test.ts
@@ -395,7 +395,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(true);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(true);
   });
 
   it("returns false when active selection is a channel in pending state", async () => {
@@ -410,7 +410,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is a channel in failed state", async () => {
@@ -425,7 +425,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is a channel in kicked state", async () => {
@@ -440,7 +440,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is a query (DM) — no member list possible", async () => {
@@ -452,7 +452,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "query",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is the server window", async () => {
@@ -464,7 +464,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "server",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is the mentions window", async () => {
@@ -476,7 +476,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "mentions",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when no channel is selected", async () => {
@@ -484,7 +484,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
     const selection = await import("../lib/selection");
     selection.setSelectedChannel(null);
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 });
 

--- a/cicchetto/src/lib/windowState.ts
+++ b/cicchetto/src/lib/windowState.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { identityScopedStore } from "./identityScopedStore";
-import { selectedChannel } from "./selection";
+import type { SelectedChannel } from "./selection";
 import type { SessionWireWindowState } from "./wireTypes";
 
 // CP15 B5: cic mirror of the server-side per-(network, channel) window
@@ -276,8 +276,17 @@ export const invitedWindows = (): InvitedWindow[] => {
   return out;
 };
 
-export const isActiveChannelJoined = (): boolean => {
-  const sel = selectedChannel();
+// #1513 — the selection arrives as an ARGUMENT, and that is what lets
+// `noImportCycles` be switched on. This predicate is the only thing this module
+// ever wanted from `selection.ts`, and reading the store here closed the one
+// runtime import cycle cic carried (`selection.ts` reads `windowIsPresent`
+// back). Taking the selection as a parameter leaves the dependency running one
+// way — selection → windowState — and leaves this module a function of its OWN
+// state, which is the honest shape for a store: the caller already holds the
+// selection (Shell.tsx renders both), so nothing is re-derived to pay for it.
+// The residual `import type` is erased by the compiler and cuts no runtime
+// edge, which is exactly why biome's rule ignores type-only imports by default.
+export const isActiveChannelJoined = (sel: SelectedChannel): boolean => {
   if (sel === null) return false;
   if (sel.kind !== "channel") return false;
   return windowIsJoined(channelKey(sel.networkSlug, sel.channelName));

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48617,7 +48617,7 @@ that sentence false.
 
 Ten arms remain inline after this slice, and they are not one class:
 
-* `privmsg`, `me`, `msg`, `ame`, `amsg` — the STORE-coupled arms, held by the
+* `privmsg`, `me`, `msg`, ~~`ame`, `amsg`~~ — the STORE-coupled arms, held by the
   #1513 ruling. Moving them means publishing `claimDrafts`, `writeState` and
   `releaseDrafts` at module scope, and `writeState` is the door that BYPASSES
   the #737 drain lock (`setDraft` refuses a write while a drain owns the
@@ -48629,6 +48629,31 @@ Ten arms remain inline after this slice, and they are not one class:
   time), biome's recommended set has no cycle rule, and a probe that closed
   exactly the `compose.ts` ↔ `commands/*` cycle passed the full vitest suite,
   `tsc --noEmit` and a production `vite build`. The objection is the lock.
+
+  > ⚠️ **Corrected at the source by #1513 (2026-08-20), on two counts.**
+  >
+  > **`ame` and `amsg` are not store-coupled, and they left the switch eight
+  > hours after this entry landed** (`d72e085e`, "move the fan-out pair out of
+  > the switch, at zero new fields" — this entry is `5779c755`, 07:20; that
+  > commit, 15:38). `commands/fanout.ts` says why in its own moduledoc: what
+  > separates it from `privmsg`/`me`/`msg` is that "those close over the
+  > composer's draft store (`sendPacedBody`), this one never touches the
+  > buffer". Struck rather than deleted: the ruling this list belongs to is
+  > about `sendPacedBody`, and the two arms that never touched it were only
+  > ever here by proximity. The three that remain are the ruling, unchanged.
+  >
+  > **The cycle probe is no longer innocuous, because the rule is now ON.**
+  > Every word above stayed true — `noImportCycles` is indeed absent from
+  > biome's recommended set, and the probe did pass vitest, `tsc` and a
+  > `vite build`, none of which look at import graphs. What changed is the
+  > gate: `biome.json` enables `suspicious/noImportCycles` as of the entry at
+  > the end of this file, and re-running that same probe against the shipped
+  > config now emits **7 errors** naming `sendPipeline.ts`, `compose.ts` (×3),
+  > `commands/services.ts` and `commands/fanout.ts`. So an export that closed
+  > that cycle would fail the build today. **This does NOT reopen #737**: the
+  > objection to publishing `writeState` was never the cycle, and this entry
+  > says so in the sentence above — the lock is still the reason, and the
+  > three arms still stay inline.
 * `error` — structural: no red protects it. It returns the parser's own
   message, so a mutant that changes the arm changes nothing a test observes.
   Moving code that no test holds is moving it blind.
@@ -53699,3 +53724,87 @@ The `EventRouter` per-kind shape table still read `required text` for `:notice`,
 already falsified. Both that cell and `:topic`'s now read `text or ""`, with the reason beneath
 the table — leaving one right and one wrong in the same table is how the next reader picks the
 wrong one.
+<!-- entry #1513b -->
+
+---
+
+## 2026-08-20 — #1513: the cycle rule goes on, and the one cycle goes away
+
+`noImportCycles` had never been switched on and its cost had never been
+measured — the half of #1513 the issue itself called "cheaper, structural".
+This slice measures it, cuts what it finds, and turns the rule into a build
+error. What it does NOT do is reopen the store half: `privmsg`/`me`/`msg` stay
+inline for the #737 lock, exactly as ruled.
+
+### The number, and why it was believed
+
+`suspicious/noImportCycles` (biome 2.5.8 — not nursery, and off by default),
+enabled and run through the whole `check` chain, which already passes
+`--max-diagnostics=none` so nothing is truncated:
+
+    rule ON, defaults          1064 files    2 errors
+    rule ON, ignoreTypes:false 1064 files   11 errors
+
+The 2 are the two EDGES of ONE runtime cycle, `selection.ts:29` ↔
+`windowState.ts:4` — the same cycle the 2026-08-18 entry above measured at 597
+files, and the file counts differ only in scope (that run was `biome check src`;
+scoped to `src` today the tree is 615 files, against 1064 for `src` + `e2e` +
+root). The other nine belong to three type-only rings (`api` ↔ `wireNarrow`,
+`api` → `channelTopic` → `identityScopedStore` → `auth` → `api`, and `passkeys`
+inside that same ring); `ignoreTypes` defaults to TRUE because the compiler
+erases a type-only import, so it cuts no runtime edge.
+
+A 2 out of 1064 files is the kind of number that could be the tool being blind
+rather than the tree being clean, so it was made to earn belief: closing the
+exact cycle the issue names — a runtime `sendPipeline.ts → compose.ts` import —
+raised **7 new diagnostics** naming `sendPipeline.ts`, `compose.ts` (×3),
+`commands/services.ts` and `commands/fanout.ts`. Probe removed, baseline back to
+the same two edges, byte-identical. The rule polices precisely the class this
+bucket exists to remove.
+
+### Half of what the issue describes had already been built
+
+Measured on the code rather than read off the issue: the extraction landed with
+#1515 and it took the right cut. `sendPipeline.ts` carries `draftLines` and
+`wireBody` WITH the cluster, `compose.ts:82` imports all three back, and compose
+exports neither. Of the six arms the issue calls stuck, `service-modal`
+(#1517), `ame` and `amsg` (`d72e085e`) are already behind the seam; the three
+that remain are the ruled ones. With the rule on, ZERO diagnostics name
+`compose.ts`, `sendPipeline.ts` or `commands/*` — the block-1 cycle the issue
+predicted does not exist, and the probe above proves the rule would say so if it
+did.
+
+### The cut: an argument, not an import
+
+The whole `windowState → selection` edge was ONE function,
+`isActiveChannelJoined()`, five lines composing `selectedChannel()` with
+`windowIsJoined()`. It now takes the selection as a PARAMETER. The reverse edge
+(`selection` reading `windowIsPresent`) stays: the dependency runs one way, and
+`windowState` goes back to being a function of its own state instead of reading
+another store's.
+
+Two cheaper-looking options were rejected and one was ruled against. Moving the
+function into `selection.ts` would have re-homed it out from under four
+`vi.mock("../lib/windowState")` factories that supply it (`Shell.test.tsx`,
+`subscribe.test.ts` ×3) — mocks that would then stop mocking, silently. A
+`biome-ignore` pair would have cost two lines and left the cycle alive,
+permanently, with an issue to remember it by; the ruling (orchestrator,
+2026-08-20) was that eleven mechanical edits to never discuss it again is the
+better trade, and that a suppression is a cycle that stops making noise without
+going away.
+
+Cost against the estimate, since the estimate was made by grep and not by doing
+it: **11 call sites predicted (3 in `Shell.tsx`, 8 in `windowState.test.ts`),
+11 edited.** No mock factory needed a change — both styles are the untyped
+`vi.mock(path, factory)` form, so nothing type-checks against the signature and
+the extra argument is ignored by a zero-arg stub. Full suite 294 files / 5694
+tests green, `check` 4 stages 0 failed.
+
+### What the rule does not catch, stated rather than implied
+
+With the shipped config the count is 0, but `windowState.ts` still carries an
+`import type { SelectedChannel } from "./selection"`, and in `ignoreTypes:false`
+mode the tree still reports 11. The runtime edge is dead; the type edge is not,
+and the strict number did not move. That is the rule's documented default doing
+what it says, not an oversight — but a reader who turns `ignoreTypes` off will
+find the same 11 and should know why.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53800,11 +53800,23 @@ it: **11 call sites predicted (3 in `Shell.tsx`, 8 in `windowState.test.ts`),
 the extra argument is ignored by a zero-arg stub. Full suite 294 files / 5694
 tests green, `check` 4 stages 0 failed.
 
-### What the rule does not catch, stated rather than implied
+### What the rule does not catch, and why that is the decision
 
-With the shipped config the count is 0, but `windowState.ts` still carries an
-`import type { SelectedChannel } from "./selection"`, and in `ignoreTypes:false`
-mode the tree still reports 11. The runtime edge is dead; the type edge is not,
-and the strict number did not move. That is the rule's documented default doing
-what it says, not an oversight — but a reader who turns `ignoreTypes` off will
-find the same 11 and should know why.
+**The rule ships with `ignoreTypes` at its default of TRUE, and the eleven
+type-only diagnostics are deliberately out of scope** (ruling, 2026-08-20).
+
+With the shipped config the count is 0. `windowState.ts` still carries an
+`import type { SelectedChannel } from "./selection"`, and with `ignoreTypes`
+turned off the tree still reports the same 11 across the three rings above — the
+strict number did not move, because this slice converted one runtime edge into a
+type edge and left the other rings alone. The runtime edge is dead; the type
+edges are not.
+
+They stay because a type-only import is ERASED by the compiler: at runtime that
+cycle does not exist, so there is no evaluation-order hazard to guard against and
+nothing for a build error to protect. Chasing them would mean moving TYPES into
+leaf modules to satisfy a knob this repo does not ship — cost with no defect
+underneath it. Recorded here rather than filed as an issue, because "these are
+out of scope and here is why" is the outcome, not a backlog item: a reader who
+flips `ignoreTypes` to false will find exactly 11 and now knows what they are
+looking at.


### PR DESCRIPTION
The half of #1513 the issue itself calls "cheaper, structural": measure what
`noImportCycles` costs, cut what it finds, and make a cycle a build error. The
store half is untouched — `privmsg`/`me`/`msg` stay inline for the #737 lock,
exactly as ruled.

## The measurement, before anything moved

`suspicious/noImportCycles` (biome 2.5.8 — not nursery, off by default), run
through the whole `check` chain, which already passes `--max-diagnostics=none`:

| config | files | errors |
|---|---|---|
| rule ON, defaults | 1064 | **2** |
| rule ON, `ignoreTypes: false` | 1064 | **11** |

The 2 are the two EDGES of ONE runtime cycle, `selection.ts:29` ↔
`windowState.ts:4`. It is the same cycle the 2026-08-18 entry measured at 597
files; the counts differ only in scope (that run was `biome check src` — scoped
to `src` the tree is 615 files today, against 1064 for `src` + `e2e` + root).
The other nine are three type-only rings (`api` ↔ `wireNarrow`, `api` →
`channelTopic` → `identityScopedStore` → `auth` → `api`, `passkeys` inside that
same ring). `ignoreTypes` defaults TRUE because the compiler erases a type-only
import, so it cuts no runtime edge.

**A 2 out of 1064 could be blindness, so it was made to earn belief.** Closing
the exact cycle #1513 warns about (a runtime `sendPipeline.ts → compose.ts`
import) raises **7 errors** naming `sendPipeline.ts`, `compose.ts` (×3),
`commands/services.ts`, `commands/fanout.ts`. Probe removed → back to baseline,
byte-identical. Re-run against the SHIPPED config after the cut: 0 → 7 → 0.

## Half of what the issue describes was already built

Measured on the code, not read off the issue: `sendPipeline.ts` already carries
`draftLines` + `wireBody` WITH the cluster and `compose.ts:82` imports all three
back, so the block-1 cycle cannot exist — and with the rule on, zero diagnostics
name `compose.ts`, `sendPipeline.ts` or `commands/*`. Of the six arms, three are
already behind the seam (`service-modal` #1517, `ame`/`amsg` `d72e085e`); the
three that remain are the ruled ones.

## The cut

The whole `windowState → selection` edge was ONE function,
`isActiveChannelJoined()`. It now takes the selection as a parameter; the
reverse edge stays, so the dependency runs one way and `windowState` is a
function of its own state again.

Rejected: moving it into `selection.ts` would have re-homed it out from under
four `vi.mock("../lib/windowState")` factories that supply it — mocks that would
then stop mocking, silently. Also rejected (orchestrator ruling): a
`biome-ignore` pair, two lines that leave the cycle alive permanently with an
issue to remember it by.

**Cost against the grep estimate: 11 call sites predicted (3 `Shell.tsx`, 8
`windowState.test.ts`), 11 edited.** No mock factory needed a change — both are
the untyped `vi.mock(path, factory)` form, so nothing type-checks against the
signature and a zero-arg stub ignores the extra argument.

## Two corrections at the source

In the 2026-08-18 #1513 entry, not as postilles elsewhere:

* `ame`/`amsg` are listed among the STORE-coupled arms. They left the switch
  eight hours after that entry landed (`d72e085e` 15:38 vs `5779c755` 07:20),
  and `commands/fanout.ts` states the distinction itself. Struck, not deleted.
* Its cycle-probe clause is superseded, not false: every word stayed true (the
  rule really is absent from biome's recommended set; the probe really did pass
  vitest, `tsc` and a `vite build` — none of which read import graphs). What
  changed is the gate. Said explicitly that this does **not** reopen #737: the
  objection to publishing `writeState` was the lock, never the cycle.

## Gates

`bun run test` 294 files / 5694 tests `rc=0`; `bun run check` 4 stages, 0 failed
(`biome` now includes the rule); `design-notes-gate.sh` `rc=0`. Branched from
`origin/main` = `ba32aa63` and still a descendant of it, so no rebase ran.

## What this does not buy

`windowState.ts` still carries an `import type { SelectedChannel }`, and the
`ignoreTypes:false` reading of the tree is still 11 — the runtime edge is dead,
the type edge is not, and the strict number did not move. That is the rule's
documented default, stated here rather than left for someone to rediscover.