### PR TITLE
union(#1580, #1518, #1513): fuse the three conflicting PRs, gated once and together

### DIFF
--- a/cicchetto/biome.json
+++ b/cicchetto/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noImportCycles": "error"
+      }
     }
   },
   "javascript": {

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -449,7 +449,7 @@ const Shell: Component = () => {
   // `.shell-members` drawer on mobile) a PERMANENT surface reachable from
   // EVERY window kind — the cog lives in it, so it MUST be openable on
   // non-channel windows (home/server/list/mentions/admin). Force-closing it
-  // whenever `isActiveChannelJoined()` is false directly contradicts that. On
+  // whenever `isActiveChannelJoined(...)` is false directly contradicts that. On
   // desktop the effect was already a visual no-op (the members pane is a grid
   // column; `membersOpen`/`.open` have no desktop CSS and the TopicBar
   // hamburger is CSS-hidden there, so membersOpen never toggled). The drawer
@@ -591,7 +591,10 @@ const Shell: Component = () => {
       when={isMobile()}
       fallback={
         // ── Desktop three-pane layout (unchanged from pre-C6) ─────────
-        <div class="shell" classList={{ "shell-no-members": !isActiveChannelJoined() }}>
+        <div
+          class="shell"
+          classList={{ "shell-no-members": !isActiveChannelJoined(selectedChannel()) }}
+        >
           <ErrorBanners />
           <Toasts />
           <PrivacyModal />
@@ -753,11 +756,11 @@ const Shell: Component = () => {
           <aside class="shell-members" classList={{ open: membersOpen() }}>
             {/* UX-5 bucket BS — drag handle on the inner edge of the
                 right (members) sidebar. Mounted unconditionally even
-                when isActiveChannelJoined() is false (the column
+                when isActiveChannelJoined(...) is false (the column
                 narrows via .shell-no-members in CSS); the handle is
                 inside the aside so it's hidden together. */}
             <ResizeHandle side="right" />
-            <Show when={isActiveChannelJoined() && selectedChannel()}>
+            <Show when={isActiveChannelJoined(selectedChannel()) && selectedChannel()}>
               {(sel) => (
                 <MembersPane networkSlug={sel().networkSlug} channelName={sel().channelName} />
               )}
@@ -1088,7 +1091,7 @@ const Shell: Component = () => {
             ONE bottom drawer. The mobile-only `.mobile-panel-actions` footer is
             gone — archive is now a first-class RailActions button. */}
         <aside class="shell-members" classList={{ open: membersOpen() }}>
-          <Show when={isActiveChannelJoined() && selectedChannel()}>
+          <Show when={isActiveChannelJoined(selectedChannel()) && selectedChannel()}>
             {(sel) => (
               <MembersPane
                 networkSlug={sel().networkSlug}

--- a/cicchetto/src/__tests__/serviceModalCommand.test.ts
+++ b/cicchetto/src/__tests__/serviceModalCommand.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { setToken } from "../lib/auth";
+import { channelKey } from "../lib/channelKey";
+import type { CommandContext } from "../lib/commands/context";
+import { serviceModalCommand } from "../lib/commands/services";
+import { appendToScrollback } from "../lib/scrollback";
+import { closeServiceModal, serviceMirrorRows, serviceModalState } from "../lib/serviceModal";
+import { SERVER_WINDOW_NAME } from "../lib/windowKinds";
+
+// #1518 — the `service-modal` arm's statement ORDER, which #290 stated in a
+// comment and nothing bought: swapping the two lines left the whole vitest
+// suite green (measured on 425426f2), because `compose.test.ts` asserts WHICH
+// calls the arm makes and never in what sequence.
+//
+// The order is load-bearing, and the gap is production's own: `sendBodyLines`
+// AWAITS the POST, and the WS handler (`subscribe.ts`, which ingests a NOTICE
+// by calling the same `appendToScrollback` this test calls) runs on that event
+// loop. A service notice that lands while the POST is in flight is a
+// WHILE-OPEN arrival — `openServiceModal` must already have taken the mirror
+// high-water mark, so the notice sits ABOVE it and `ServiceModal.tsx` renders
+// it (`id > sinceId`). Capture the mark after the await instead and that same
+// notice is at or below it: the help wall the modal exists to confine is
+// filtered out of the very view that was opened for it.
+//
+// Only `lib/api`'s `sendMessage` is stubbed, so the await under test is the
+// real one — real `sendBodyLines` → real `scrollback.sendMessage` → the POST —
+// and the notice is delivered through the real ingest verb. `null` is what a
+// `*Serv` target's 202 returns (#1430): the send persists no row of its own.
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, sendMessage: vi.fn() };
+});
+
+const SLUG = "svc-order";
+const SERVICE = "NickServ";
+const PRE_OPEN_ID = 10;
+const IN_FLIGHT_ID = 11;
+
+const notice = (id: number, body: string): ScrollbackMessage => ({
+  id,
+  network: SLUG,
+  channel: SERVER_WINDOW_NAME,
+  server_time: id,
+  kind: "notice",
+  sender: SERVICE,
+  body,
+  meta: {},
+});
+
+// The arm reads `ctx.networkSlug` and nothing else off the record (#1396).
+// Every other member throws rather than returning a plausible value, so a new
+// read shows up as a failure naming the field instead of passing quietly.
+const unread = (field: string): (() => never) => {
+  return () => {
+    throw new Error(`the service-modal arm must not read ctx.${field}`);
+  };
+};
+
+const context = (): CommandContext => ({
+  key: channelKey(SLUG, "#chan"),
+  networkSlug: SLUG,
+  submittedFrom: "#chan",
+  text: "/ns",
+  token: "tok",
+  getActiveChannel: unread("getActiveChannel"),
+  sigils: unread("sigils"),
+  requireChannel: unread("requireChannel"),
+  requireNetworkId: unread("requireNetworkId"),
+  resolveBareWhoisNick: unread("resolveBareWhoisNick"),
+});
+
+describe("service-modal arm (#290/#1518)", () => {
+  beforeEach(() => {
+    // `scrollback.sendMessage` returns early without a bearer, which would
+    // skip the POST and with it the mid-send delivery below.
+    setToken("tok");
+    closeServiceModal();
+  });
+
+  it("captures the mirror high-water mark BEFORE `help` goes out, so a notice landing mid-send stays a while-open arrival", async () => {
+    const key = channelKey(SLUG, SERVER_WINDOW_NAME);
+    appendToScrollback(key, notice(PRE_OPEN_ID, "stale line from a past session"));
+
+    const api = await import("../lib/api");
+    vi.mocked(api.sendMessage).mockImplementation(async () => {
+      appendToScrollback(key, notice(IN_FLIGHT_ID, "***** NickServ Help *****"));
+      return null;
+    });
+
+    await serviceModalCommand({ kind: "service-modal", service: SERVICE }, context());
+
+    // Control — the mid-send notice really did land in the mirror this open
+    // reads. Without it the assertion below would hold for a send that never
+    // fired at all.
+    expect(serviceMirrorRows(SLUG, SERVICE).map((m) => m.id)).toEqual([PRE_OPEN_ID, IN_FLIGHT_ID]);
+    // The invariant: the mark is the PRE-send high-water, so the notice that
+    // arrived during the send is above it and the modal mirrors it.
+    expect(serviceModalState()?.sinceId).toBe(PRE_OPEN_ID);
+  });
+});

--- a/cicchetto/src/__tests__/windowState.test.ts
+++ b/cicchetto/src/__tests__/windowState.test.ts
@@ -395,7 +395,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(true);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(true);
   });
 
   it("returns false when active selection is a channel in pending state", async () => {
@@ -410,7 +410,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is a channel in failed state", async () => {
@@ -425,7 +425,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is a channel in kicked state", async () => {
@@ -440,7 +440,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "channel",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is a query (DM) — no member list possible", async () => {
@@ -452,7 +452,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "query",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is the server window", async () => {
@@ -464,7 +464,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "server",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when active selection is the mentions window", async () => {
@@ -476,7 +476,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
       kind: "mentions",
     });
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 
   it("returns false when no channel is selected", async () => {
@@ -484,7 +484,7 @@ describe("windowState.isActiveChannelJoined (composed: kind=channel AND joined)"
     const selection = await import("../lib/selection");
     selection.setSelectedChannel(null);
 
-    expect(ws.isActiveChannelJoined()).toBe(false);
+    expect(ws.isActiveChannelJoined(selection.selectedChannel())).toBe(false);
   });
 });
 

--- a/cicchetto/src/lib/commands/services.ts
+++ b/cicchetto/src/lib/commands/services.ts
@@ -12,6 +12,15 @@ import type { CommandHandler } from "./context";
  * command WITH args stays the `msg` arm (inline execute, reply inline) — no
  * unsolicited popup for power users.
  *
+ * #1518 — that ordering is load-bearing, and the gap it guards is this
+ * function's own `await`: `sendBodyLines` suspends on the POST, and the WS
+ * handler delivers the service's reply NOTICEs into the scrollback on the same
+ * event loop. A notice landing while the POST is in flight must count as a
+ * while-open arrival, which it does only if the mark was taken first. Bought by
+ * `serviceModalCommand.test.ts`, and it needed buying: swapping these two lines
+ * used to leave the whole vitest suite green, because the arm's other tests
+ * assert WHICH calls it makes and never in what sequence.
+ *
  * #1396 — it could only move here once #1513 lifted `sendBodyLines` out of the
  * store closure: that import was its whole blocker, and it is the ONLY arm the
  * hoist unblocked. It reads `ctx.networkSlug` and nothing else off the record —

--- a/cicchetto/src/lib/windowState.ts
+++ b/cicchetto/src/lib/windowState.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { identityScopedStore } from "./identityScopedStore";
-import { selectedChannel } from "./selection";
+import type { SelectedChannel } from "./selection";
 import type { SessionWireWindowState } from "./wireTypes";
 
 // CP15 B5: cic mirror of the server-side per-(network, channel) window
@@ -276,8 +276,17 @@ export const invitedWindows = (): InvitedWindow[] => {
   return out;
 };
 
-export const isActiveChannelJoined = (): boolean => {
-  const sel = selectedChannel();
+// #1513 — the selection arrives as an ARGUMENT, and that is what lets
+// `noImportCycles` be switched on. This predicate is the only thing this module
+// ever wanted from `selection.ts`, and reading the store here closed the one
+// runtime import cycle cic carried (`selection.ts` reads `windowIsPresent`
+// back). Taking the selection as a parameter leaves the dependency running one
+// way — selection → windowState — and leaves this module a function of its OWN
+// state, which is the honest shape for a store: the caller already holds the
+// selection (Shell.tsx renders both), so nothing is re-derived to pay for it.
+// The residual `import type` is erased by the compiler and cuts no runtime
+// edge, which is exactly why biome's rule ignores type-only imports by default.
+export const isActiveChannelJoined = (sel: SelectedChannel): boolean => {
   if (sel === null) return false;
   if (sel.kind !== "channel") return false;
   return windowIsJoined(channelKey(sel.networkSlug, sel.channelName));

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53877,3 +53877,65 @@ client trace was run, and the unreachability above makes it moot for the one
 caller that exists. That the twelve were the total subject-XOR enforcement
 surface: the DB CHECK constraints are a second layer and were counted, not
 consolidated.
+<!-- entry #1518 -->
+
+---
+
+## 2026-08-20 — #1518: the services-modal ordering invariant, measured and bought
+
+#290's `service-modal` arm is two statements, and its comment declares the
+order between them: `openServiceModal` captures the mirror high-water mark
+FIRST, `help` goes out SECOND, so the reply notices count as while-open
+arrivals. #1518 measured that nothing enforced it — swap the two lines and the
+suite stays green.
+
+Reproduced before touching anything, on `origin/main` = 425426f2: the whole cic
+vitest suite is 294 files / 5688 cases, and it passes 5688/5688 both with the
+arm as written and with the two statements swapped. Identical totals, `rc=0`
+both times. `compose.test.ts` covers this arm with an `it.each` that asserts
+`openServiceModal` was called and `sendMessage` was called; neither assertion
+can see which ran first.
+
+### The order is real, and the gap is the arm's own `await`
+
+`sendBodyLines` suspends on the POST. The WS handler ingests a NOTICE by
+calling `appendToScrollback` — the same store `openServiceModal` reduces to a
+high-water mark — and it runs on that same event loop. So a service notice that
+lands while the POST is in flight is exactly the arrival the modal exists to
+show, and it is above the mark only if the mark was taken before the await.
+Capture it after and the notice is at or below `sinceId`, which is the one
+predicate `ServiceModal.tsx` filters on: the help wall gets filtered out of the
+view that was opened for it.
+
+That is a race window, not a certainty, which is why it was never observed. The
+ircd's reply usually comes back after the 202 does. The browser e2e
+(`issue290-services-modal.spec.ts`) is blind to it for the same reason: it waits
+for lines to appear with no bound on when they were captured, so it stays green
+under either order.
+
+### What buys it now
+
+`serviceModalCommand.test.ts` drives the real handler with only `lib/api`'s
+`sendMessage` stubbed — the await under test is production's own, through the
+real `sendBodyLines` and the real `scrollback.sendMessage` — and delivers a
+notice through the real ingest verb from inside the in-flight POST. Its
+load-bearing assertion is that `sinceId` is the PRE-send high-water.
+
+Two mutants, one per assertion, each killing exactly one:
+
+* swap the arm's two statements → only the `sinceId` assertion fails
+  (`expected 11 to be 10`); the control passes.
+* drop the mid-send delivery from the fixture → only the control fails
+  (`expected [10] to deeply equal [10, 11]`).
+
+The control is not decoration: without it the invariant assertion holds
+vacuously for a send that never fired at all — `sinceId` would read 10 because
+nothing ever arrived, and the test would be green while measuring nothing.
+
+### What this does not buy
+
+The same order has a second consequence — the modal appears before the send
+rather than after it, so a paced (#666 429-retry) or failing send would leave
+the operator with no modal at all under the swap. The #290 comment does not
+claim it and no test here asserts it. And no e2e was run for this slice: the
+spec above was read, not executed.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48617,7 +48617,7 @@ that sentence false.
 
 Ten arms remain inline after this slice, and they are not one class:
 
-* `privmsg`, `me`, `msg`, `ame`, `amsg` — the STORE-coupled arms, held by the
+* `privmsg`, `me`, `msg`, ~~`ame`, `amsg`~~ — the STORE-coupled arms, held by the
   #1513 ruling. Moving them means publishing `claimDrafts`, `writeState` and
   `releaseDrafts` at module scope, and `writeState` is the door that BYPASSES
   the #737 drain lock (`setDraft` refuses a write while a drain owns the
@@ -48629,6 +48629,31 @@ Ten arms remain inline after this slice, and they are not one class:
   time), biome's recommended set has no cycle rule, and a probe that closed
   exactly the `compose.ts` ↔ `commands/*` cycle passed the full vitest suite,
   `tsc --noEmit` and a production `vite build`. The objection is the lock.
+
+  > ⚠️ **Corrected at the source by #1513 (2026-08-20), on two counts.**
+  >
+  > **`ame` and `amsg` are not store-coupled, and they left the switch eight
+  > hours after this entry landed** (`d72e085e`, "move the fan-out pair out of
+  > the switch, at zero new fields" — this entry is `5779c755`, 07:20; that
+  > commit, 15:38). `commands/fanout.ts` says why in its own moduledoc: what
+  > separates it from `privmsg`/`me`/`msg` is that "those close over the
+  > composer's draft store (`sendPacedBody`), this one never touches the
+  > buffer". Struck rather than deleted: the ruling this list belongs to is
+  > about `sendPacedBody`, and the two arms that never touched it were only
+  > ever here by proximity. The three that remain are the ruling, unchanged.
+  >
+  > **The cycle probe is no longer innocuous, because the rule is now ON.**
+  > Every word above stayed true — `noImportCycles` is indeed absent from
+  > biome's recommended set, and the probe did pass vitest, `tsc` and a
+  > `vite build`, none of which look at import graphs. What changed is the
+  > gate: `biome.json` enables `suspicious/noImportCycles` as of the entry at
+  > the end of this file, and re-running that same probe against the shipped
+  > config now emits **7 errors** naming `sendPipeline.ts`, `compose.ts` (×3),
+  > `commands/services.ts` and `commands/fanout.ts`. So an export that closed
+  > that cycle would fail the build today. **This does NOT reopen #737**: the
+  > objection to publishing `writeState` was never the cycle, and this entry
+  > says so in the sentence above — the lock is still the reason, and the
+  > three arms still stay inline.
 * `error` — structural: no red protects it. It returns the parser's own
   message, so a mutant that changes the arm changes nothing a test observes.
   Moving code that no test holds is moving it blind.
@@ -53939,3 +53964,87 @@ rather than after it, so a paced (#666 429-retry) or failing send would leave
 the operator with no modal at all under the swap. The #290 comment does not
 claim it and no test here asserts it. And no e2e was run for this slice: the
 spec above was read, not executed.
+<!-- entry #1513b -->
+
+---
+
+## 2026-08-20 — #1513: the cycle rule goes on, and the one cycle goes away
+
+`noImportCycles` had never been switched on and its cost had never been
+measured — the half of #1513 the issue itself called "cheaper, structural".
+This slice measures it, cuts what it finds, and turns the rule into a build
+error. What it does NOT do is reopen the store half: `privmsg`/`me`/`msg` stay
+inline for the #737 lock, exactly as ruled.
+
+### The number, and why it was believed
+
+`suspicious/noImportCycles` (biome 2.5.8 — not nursery, and off by default),
+enabled and run through the whole `check` chain, which already passes
+`--max-diagnostics=none` so nothing is truncated:
+
+    rule ON, defaults          1064 files    2 errors
+    rule ON, ignoreTypes:false 1064 files   11 errors
+
+The 2 are the two EDGES of ONE runtime cycle, `selection.ts:29` ↔
+`windowState.ts:4` — the same cycle the 2026-08-18 entry above measured at 597
+files, and the file counts differ only in scope (that run was `biome check src`;
+scoped to `src` today the tree is 615 files, against 1064 for `src` + `e2e` +
+root). The other nine belong to three type-only rings (`api` ↔ `wireNarrow`,
+`api` → `channelTopic` → `identityScopedStore` → `auth` → `api`, and `passkeys`
+inside that same ring); `ignoreTypes` defaults to TRUE because the compiler
+erases a type-only import, so it cuts no runtime edge.
+
+A 2 out of 1064 files is the kind of number that could be the tool being blind
+rather than the tree being clean, so it was made to earn belief: closing the
+exact cycle the issue names — a runtime `sendPipeline.ts → compose.ts` import —
+raised **7 new diagnostics** naming `sendPipeline.ts`, `compose.ts` (×3),
+`commands/services.ts` and `commands/fanout.ts`. Probe removed, baseline back to
+the same two edges, byte-identical. The rule polices precisely the class this
+bucket exists to remove.
+
+### Half of what the issue describes had already been built
+
+Measured on the code rather than read off the issue: the extraction landed with
+#1515 and it took the right cut. `sendPipeline.ts` carries `draftLines` and
+`wireBody` WITH the cluster, `compose.ts:82` imports all three back, and compose
+exports neither. Of the six arms the issue calls stuck, `service-modal`
+(#1517), `ame` and `amsg` (`d72e085e`) are already behind the seam; the three
+that remain are the ruled ones. With the rule on, ZERO diagnostics name
+`compose.ts`, `sendPipeline.ts` or `commands/*` — the block-1 cycle the issue
+predicted does not exist, and the probe above proves the rule would say so if it
+did.
+
+### The cut: an argument, not an import
+
+The whole `windowState → selection` edge was ONE function,
+`isActiveChannelJoined()`, five lines composing `selectedChannel()` with
+`windowIsJoined()`. It now takes the selection as a PARAMETER. The reverse edge
+(`selection` reading `windowIsPresent`) stays: the dependency runs one way, and
+`windowState` goes back to being a function of its own state instead of reading
+another store's.
+
+Two cheaper-looking options were rejected and one was ruled against. Moving the
+function into `selection.ts` would have re-homed it out from under four
+`vi.mock("../lib/windowState")` factories that supply it (`Shell.test.tsx`,
+`subscribe.test.ts` ×3) — mocks that would then stop mocking, silently. A
+`biome-ignore` pair would have cost two lines and left the cycle alive,
+permanently, with an issue to remember it by; the ruling (orchestrator,
+2026-08-20) was that eleven mechanical edits to never discuss it again is the
+better trade, and that a suppression is a cycle that stops making noise without
+going away.
+
+Cost against the estimate, since the estimate was made by grep and not by doing
+it: **11 call sites predicted (3 in `Shell.tsx`, 8 in `windowState.test.ts`),
+11 edited.** No mock factory needed a change — both styles are the untyped
+`vi.mock(path, factory)` form, so nothing type-checks against the signature and
+the extra argument is ignored by a zero-arg stub. Full suite 294 files / 5694
+tests green, `check` 4 stages 0 failed.
+
+### What the rule does not catch, stated rather than implied
+
+With the shipped config the count is 0, but `windowState.ts` still carries an
+`import type { SelectedChannel } from "./selection"`, and in `ignoreTypes:false`
+mode the tree still reports 11. The runtime edge is dead; the type edge is not,
+and the strict number did not move. That is the rule's documented default doing
+what it says, not an oversight — but a reader who turns `ignoreTypes` off will
+find the same 11 and should know why.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54040,11 +54040,23 @@ it: **11 call sites predicted (3 in `Shell.tsx`, 8 in `windowState.test.ts`),
 the extra argument is ignored by a zero-arg stub. Full suite 294 files / 5694
 tests green, `check` 4 stages 0 failed.
 
-### What the rule does not catch, stated rather than implied
+### What the rule does not catch, and why that is the decision
 
-With the shipped config the count is 0, but `windowState.ts` still carries an
-`import type { SelectedChannel } from "./selection"`, and in `ignoreTypes:false`
-mode the tree still reports 11. The runtime edge is dead; the type edge is not,
-and the strict number did not move. That is the rule's documented default doing
-what it says, not an oversight — but a reader who turns `ignoreTypes` off will
-find the same 11 and should know why.
+**The rule ships with `ignoreTypes` at its default of TRUE, and the eleven
+type-only diagnostics are deliberately out of scope** (ruling, 2026-08-20).
+
+With the shipped config the count is 0. `windowState.ts` still carries an
+`import type { SelectedChannel } from "./selection"`, and with `ignoreTypes`
+turned off the tree still reports the same 11 across the three rings above — the
+strict number did not move, because this slice converted one runtime edge into a
+type edge and left the other rings alone. The runtime edge is dead; the type
+edges are not.
+
+They stay because a type-only import is ERASED by the compiler: at runtime that
+cycle does not exist, so there is no evaluation-order hazard to guard against and
+nothing for a build error to protect. Chasing them would mean moving TYPES into
+leaf modules to satisfy a knob this repo does not ship — cost with no defect
+underneath it. Recorded here rather than filed as an issue, because "these are
+out of scope and here is why" is the outcome, not a backlog item: a reader who
+flips `ignoreTypes` to false will find exactly 11 and now knows what they are
+looking at.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -53771,3 +53771,109 @@ emits one long line, and an object body with an over-long field never wraps at
 all. That is the 2026-08-06 gate collision, not this defect, and nothing in the
 wire hits it today. Fixing it means reproducing biome's wrapping for arbitrary
 TS constructs, which is a different job and currently a speculative one.
+<!-- entry #1580 -->
+
+---
+
+## 2026-08-20 — #1580: one subject-XOR predicate, and why counting it by name would have lied
+
+`defp validate_subject_xor/1` lived twelve times under `lib/`, once in every
+schema carrying the `user_id` XOR `visitor_id` FK pair. It is now
+`Grappa.Subject.validate_xor/1`, called twelve times.
+
+### Counted by BODY, because a name count is not a duplication count
+
+The issue's "twelve" came from grepping the function NAME. That measures
+declarations, not duplication: a copy that was inlined, renamed, or pasted
+into an anonymous position is invisible to it — measured elsewhere in this
+repo, nineteen named definitions were retired while the same body survived
+INLINE fourteen times across ten files.
+
+So the census re-anchored on the decision body, `case {user_id, visitor_id}
+do … end`, and treated the enclosing function name as a DERIVED column. The
+number held at twelve, and the axes closed on each other: twelve
+`belongs_to :visitor` schemas, twelve decision bodies, twelve
+`<table>_subject_xor` CHECK constraints in migrations, zero schemas with a
+visitor FK and no body, zero `add_error(changeset, :subject, …)` anywhere
+outside those twelve blocks. The wider net — every file naming both columns —
+left ten files, and reading them found no thirteenth XOR in a different
+shape. The nearest miss, `Scrollback.persist_subject/2`, is a telemetry
+labeller that prefers `:user` when both are set: correct for a label, and not
+a validator.
+
+The census script carried its known-answer controls INSIDE it and printed no
+numbers unless all six passed — corpus size, a hand-counted calibration file,
+a real file that must yield zero, a decoy `defp` taking a changeset that must
+NOT be classified as one, a check that the decoy is actually present so the
+control is not vacuous, and an arithmetic cross-check that every subject
+`add_error` in `lib/` falls inside a counted block.
+
+### The mask is what licensed the flattening
+
+Hashing the twelve bodies with the string literals MASKED collapsed them to
+ONE control-flow class. That measurement, not a reading of the code, is what
+makes this a mechanical change: no copy carried behaviour the consolidation
+silently drops. The entire divergence in the family was one message string.
+`uploads/upload.ex` said `"one of user_id or visitor_id is required"`; the
+other eleven said `"must set user_id or visitor_id"`. Nothing pinned the
+variant, and its only production caller cannot reach the arm that emits it —
+`Uploads.create/3` routes the subject through `Subject.put_subject_id/2`,
+whose two clauses both guard `is_binary`, so a subject-less insert raises
+before the changeset runs. A typo the copies let live, not a requirement.
+
+### The comments could not have caught it, by construction
+
+Each copy carried a "Mirror of X" pointer. `accounts/session.ex` →
+`scrollback/message.ex` → `accounts/session.ex` is a cycle, so the graph has
+no root and no copy was the designated original. Every mirror claim was
+therefore unfalsifiable, which is precisely why the drifted copy could keep
+asserting a mirror it no longer was. Copies are not kept honest by comments.
+
+The same class of error appears in the issue's own pointer table, which
+records `networks/credential.ex` as having no pointer at all: it has one,
+spelled `Byte-mirror of`. An anchor that matches one phrasing of a word
+misses the others — the consolidation script hit the identical trap and
+refused the file rather than guessing at it.
+
+### Home, and boundaries
+
+`Grappa.Subject` rather than a new module: it already owns the subject
+discriminator, its moduledoc already states the XOR invariant, and
+`validate_xor/1` is the write-side twin of `put_subject_id/2` — one puts the
+column, the other proves the pair. Ten of the twelve schemas sit inside
+context boundaries that already declared `Grappa.Subject`; only
+`Accounts.Session` and `Networks.Credential` own their boundaries and needed
+the edge. No cycle: `Grappa.Subject` depends on `Accounts.User` and
+`Visitors.Visitor`, neither of which reaches back.
+
+### The pin, and what it is worth
+
+Three of the twelve pinned the missing-subject text; nine did not. A suite
+that guards a quarter of a family and is silent on the copy that is already
+wrong is how the drift shipped. `test/grappa/subject_xor_test.exs` now pins
+all twelve on both error arms and both valid shapes, and guards its own
+coverage: a thirteenth schema declaring `belongs_to :visitor` without a row
+in the table fails the population test.
+
+Written before the consolidation, that table was red exactly once, on
+`Uploads.Upload` — the drift made executable.
+
+### Spun off, not folded in
+
+`check_constraint(:subject, …)` is present in ten of the twelve.
+`accounts/session.ex` and `scrollback/message.ex` lack it although
+`sessions_subject_xor` and `messages_subject_xor` both exist in the DB, so on
+those two tables a violation that reached `Repo` would raise
+`Ecto.ConstraintError` rather than return a changeset error. Reachability is
+thin — the changeset predicate is byte-identical to the CHECK, so nothing
+that passes one fails the other short of a raw write — which is why it is
+recorded here and left to a call rather than folded into a duplication fix.
+
+### Not claimed
+
+That the `{nil, nil}` arm is unreachable in the other eleven: that was traced
+for `uploads` only. That the divergent message was ever user-visible: no
+client trace was run, and the unreachability above makes it moot for the one
+caller that exists. That the twelve were the total subject-XOR enforcement
+surface: the DB CHECK constraints are a second layer and were counted, not
+consolidated.

--- a/lib/grappa/accounts/session.ex
+++ b/lib/grappa/accounts/session.ex
@@ -61,13 +61,19 @@ defmodule Grappa.Accounts.Session do
   listed back — `handle/1` is the public, one-way name a device list
   and an operator log line use instead.
   """
-  use Boundary, top_level?: true, deps: []
+  # `Grappa.Subject` is the one declared dep, and unlike the `belongs_to`
+  # metadata this module's other names arrive as, it is a real call the
+  # checker resolves: `changeset/2` pipes through `Subject.validate_xor/1`
+  # (#1580). No cycle — `Grappa.Subject` depends on `Accounts.User` and
+  # `Visitors.Visitor`, neither of which reaches back here.
+  use Boundary, top_level?: true, deps: [Grappa.Subject]
 
   use Ecto.Schema
 
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @typedoc """
@@ -132,7 +138,7 @@ defmodule Grappa.Accounts.Session do
   Validates that `created_at` and `last_seen_at` are present (the
   other fields — `ip`, `user_agent` — are optional; mix-task callers
   have neither). Exactly one of `user_id` / `visitor_id` must be set —
-  the XOR constraint is enforced by `validate_subject_xor/1` and at
+  the XOR constraint is enforced by `Grappa.Subject.validate_xor/1` and at
   the DB level (CHECK constraint `sessions_subject_xor`).
 
   `assoc_constraint(:user)` and `assoc_constraint(:visitor)` are
@@ -156,7 +162,7 @@ defmodule Grappa.Accounts.Session do
     session
     |> cast(attrs, @cast_fields)
     |> validate_required(@required_fields)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> validate_label_matches_kind()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
@@ -239,28 +245,6 @@ defmodule Grappa.Accounts.Session do
     case DateTime.compare(now, prev) do
       :lt -> add_error(cs, :last_seen_at, "must not move backward (system-clock skew?)")
       _ -> cs
-    end
-  end
-
-  # Mirror of Grappa.Scrollback.Message.validate_subject_xor/1.
-  # Run BEFORE per-field validators so the XOR error surfaces first.
-  #
-  # Errors attach to the synthetic `:subject` key (B5.4 M-pers-2): neither
-  # `user_id` nor `visitor_id` is unambiguously "wrong" in either failure
-  # mode (both-nil = absence-of-either; both-set = pair-conflict), so a
-  # single key keeps client-side error rendering uniform. Pre-B5.4 this
-  # always attached to `:user_id`, which masked which field was the
-  # unexpected addition.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 end

--- a/lib/grappa/channel_directory/entry.ex
+++ b/lib/grappa/channel_directory/entry.ex
@@ -15,7 +15,7 @@ defmodule Grappa.ChannelDirectory.Entry do
   Mirrors `Grappa.QueryWindows.Window`: exactly one of `:user_id` /
   `:visitor_id` is set. Enforced at three layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `channel_directory_subject_xor`.
     * `check_constraint/3` that converts DB violations into changeset
@@ -27,6 +27,7 @@ defmodule Grappa.ChannelDirectory.Entry do
 
   alias Grappa.Accounts.User
   alias Grappa.Networks.Network
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -61,7 +62,7 @@ defmodule Grappa.ChannelDirectory.Entry do
   @doc """
   Builds an insert/update changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors
   to the synthetic `:subject` key). `network_id`, `name`, and
   `user_count` are required at cast time. The `assoc_constraint`s on
   `user`/`visitor`/`network` convert FK violations into changeset
@@ -75,7 +76,7 @@ defmodule Grappa.ChannelDirectory.Entry do
     |> cast(attrs, [:user_id, :visitor_id, :network_id, :name, :topic, :user_count, :captured_at])
     |> validate_required([:network_id, :name, :user_count])
     |> validate_length(:name, min: 1)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -83,19 +84,5 @@ defmodule Grappa.ChannelDirectory.Entry do
       name: :channel_directory_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.QueryWindows.Window.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -28,7 +28,7 @@ defmodule Grappa.Networks.Credential do
   flag; Rule-6 is not triggered by XOR-FK). Enforced at three layers,
   mirroring `Grappa.ReadCursor.Cursor`:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `network_credentials_subject_xor`.
     * Two partial unique indexes — `(user_id, network_id)
@@ -52,19 +52,20 @@ defmodule Grappa.Networks.Credential do
   """
 
   # Its own boundary, like the other three Networks schemas (#1398). Of the
-  # five names this module aliases, only `Grappa.IRC` is declared: the
-  # changeset calls `Identity.sanitize_ident/1` and `Identifier`. `User`,
-  # `Visitor` and `EncryptedBinary` arrive only as `belongs_to` and `field`
-  # arguments, and `Network` only as a `belongs_to` and a typespec — none of
-  # them a reference the checker resolves, so declaring them would state a
+  # six names this module aliases, only `Grappa.IRC` and `Grappa.Subject` are
+  # declared: the changeset calls `Identity.sanitize_ident/1`, `Identifier`,
+  # and — since #1580 — `Subject.validate_xor/1`. `User`, `Visitor` and
+  # `EncryptedBinary` arrive only as `belongs_to` and `field` arguments, and
+  # `Network` only as a `belongs_to` and a typespec — none of them a
+  # reference the checker resolves, so declaring them would state a
   # dependency nothing can verify.
-  use Boundary, top_level?: true, deps: [Grappa.IRC]
+  use Boundary, top_level?: true, deps: [Grappa.IRC, Grappa.Subject]
 
   use Ecto.Schema
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
-  alias Grappa.EncryptedBinary
+  alias Grappa.{EncryptedBinary, Subject}
   alias Grappa.IRC.{AuthFSM, Identifier, Identity}
   alias Grappa.Networks.Network
   alias Grappa.Visitors.Visitor
@@ -313,9 +314,10 @@ defmodule Grappa.Networks.Credential do
     |> validate_required([:network_id, :nick, :auth_method])
     # #211 — subject XOR: exactly one of user_id / visitor_id. Replaces
     # the pre-#211 `validate_required([:user_id])`, which is now
-    # XOR-gated (a visitor credential carries user_id IS NULL). Mirror
-    # of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-    |> validate_subject_xor()
+    # XOR-gated (a visitor credential carries user_id IS NULL). Since
+    # #1580 this is a call into the one shared predicate, not a
+    # hand-copy pointed at a sibling.
+    |> Subject.validate_xor()
     # A8: nick syntax + length is the same `Identifier.valid_nick?/1`
     # rule that `Grappa.Scrollback.Message.changeset/2` and the IRC
     # parser already use — single regex, single source. The local
@@ -400,7 +402,7 @@ defmodule Grappa.Networks.Credential do
     # #211 — DB-level XOR mirror. Maps the CHECK violation to a changeset
     # error on the synthetic `:subject` key (mirror of
     # `Grappa.ReadCursor.Cursor`) so a raw both-set / both-null insert
-    # slipping past `validate_subject_xor/1` still surfaces cleanly.
+    # slipping past `Grappa.Subject.validate_xor/1` still surfaces cleanly.
     |> check_constraint(:subject,
       name: :network_credentials_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
@@ -448,23 +450,6 @@ defmodule Grappa.Networks.Credential do
 
       _ ->
         put_change(changeset, :connection_state_changed_at, DateTime.truncate(DateTime.utc_now(), :second))
-    end
-  end
-
-  # #211 — subject XOR: exactly one of user_id / visitor_id must be set.
-  # Byte-mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`;
-  # errors attach to the synthetic `:subject` key so the client renders
-  # one uniform subject error regardless of which FK column is at fault.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -1172,7 +1172,7 @@ defmodule Grappa.Networks.Credentials do
   `:password` re-encrypts under the same Cloak vault (in-memory the
   loaded value is plaintext), the subject XOR + partial-unique guards
   fire, and `auth_method` validation runs. `:user_id` is never set —
-  the changeset's `validate_subject_xor/1` accepts the visitor-only
+  the changeset's `Grappa.Subject.validate_xor/1` accepts the visitor-only
   shape. Idempotent: identical attrs on an existing row are a no-op
   Repo.update; re-running never creates a duplicate (the
   `(visitor_id, network_id)` partial unique index + the get-or-insert

--- a/lib/grappa/notify/entry.ex
+++ b/lib/grappa/notify/entry.ex
@@ -12,7 +12,7 @@ defmodule Grappa.Notify.Entry do
   exactly one of `:user_id` / `:visitor_id` is set. Enforced at three
   layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `notify_entries_subject_xor`.
     * Two partial unique expression indexes (one per subject branch) on
@@ -32,6 +32,7 @@ defmodule Grappa.Notify.Entry do
   alias Grappa.Accounts.User
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.Network
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -60,7 +61,7 @@ defmodule Grappa.Notify.Entry do
   @doc """
   Builds an insert changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors to
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors to
   the synthetic `:subject` key). `network_id` and `nick` are required;
   `nick` must satisfy `Grappa.IRC.Identifier.valid_nick?/1` — a watch
   entry for a channel-shaped or garbage token would silently never
@@ -74,7 +75,7 @@ defmodule Grappa.Notify.Entry do
     |> cast(attrs, [:user_id, :visitor_id, :network_id, :nick])
     |> validate_required([:network_id, :nick])
     |> validate_nick()
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -96,20 +97,6 @@ defmodule Grappa.Notify.Entry do
         else
           add_error(changeset, :nick, "is not a valid IRC nick")
         end
-    end
-  end
-
-  # Mirror of `Grappa.QueryWindows.Window.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 end

--- a/lib/grappa/push/subscription.ex
+++ b/lib/grappa/push/subscription.ex
@@ -40,7 +40,7 @@ defmodule Grappa.Push.Subscription do
   Mirrors `Grappa.Scrollback.Message` / `Grappa.ReadCursor.Cursor` /
   `Grappa.QueryWindows.Window`: exactly one of `:user_id` /
   `:visitor_id` is set. Enforced at three layers: schema-level
-  `validate_subject_xor/1` (errors attach to the synthetic
+  `Grappa.Subject.validate_xor/1` (errors attach to the synthetic
   `:subject` key), DB CHECK constraint
   `push_subscriptions_subject_xor`, and two partial unique indexes
   (one per subject branch) on `(<subject_id>, endpoint)`. The
@@ -72,6 +72,7 @@ defmodule Grappa.Push.Subscription do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @providers [:webpush, :unifiedpush]
@@ -112,7 +113,7 @@ defmodule Grappa.Push.Subscription do
 
   @required ~w(endpoint p256dh_key auth_key)a
   # Subject FK columns (`:user_id` / `:visitor_id`) are NOT in
-  # `@required` — XOR enforcement runs through `validate_subject_xor/1`,
+  # `@required` — XOR enforcement runs through `Grappa.Subject.validate_xor/1`,
   # which errors on the synthetic `:subject` key instead of either
   # column individually.
   # `last_used_at` is intentionally NOT in the cast allowlist — it's
@@ -182,7 +183,7 @@ defmodule Grappa.Push.Subscription do
     |> validate_length(:p256dh_key, max: 256)
     |> validate_length(:auth_key, max: 64)
     |> validate_length(:user_agent, max: 512)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> unique_constraint([:user_id, :endpoint], error_key: :endpoint)
@@ -191,19 +192,5 @@ defmodule Grappa.Push.Subscription do
       name: :push_subscriptions_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/query_windows/window.ex
+++ b/lib/grappa/query_windows/window.ex
@@ -15,7 +15,7 @@ defmodule Grappa.QueryWindows.Window do
   exactly one of `:user_id` / `:visitor_id` is set. Enforced at three
   layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `query_windows_subject_xor`.
     * Two partial unique expression indexes (one per subject branch) on
@@ -32,6 +32,7 @@ defmodule Grappa.QueryWindows.Window do
 
   alias Grappa.Accounts.User
   alias Grappa.Networks.Network
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -62,7 +63,7 @@ defmodule Grappa.QueryWindows.Window do
   @doc """
   Builds an insert changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors
   to the synthetic `:subject` key). `network_id`, `target_nick` and
   `opened_at` are required at cast time. The `assoc_constraint`s on
   `user`/`visitor`/`network` convert FK violations into changeset
@@ -76,7 +77,7 @@ defmodule Grappa.QueryWindows.Window do
     |> cast(attrs, [:user_id, :visitor_id, :network_id, :target_nick, :opened_at])
     |> validate_required([:network_id, :target_nick, :opened_at])
     |> validate_length(:target_nick, min: 1)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -84,19 +85,5 @@ defmodule Grappa.QueryWindows.Window do
       name: :query_windows_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/read_cursor/cursor.ex
+++ b/lib/grappa/read_cursor/cursor.ex
@@ -14,7 +14,7 @@ defmodule Grappa.ReadCursor.Cursor do
   `:user_id` / `:visitor_id` is set. The XOR is enforced at three
   layers:
 
-    * Schema-level `validate_subject_xor/1` (errors attach to the
+    * Schema-level `Grappa.Subject.validate_xor/1` (errors attach to the
       synthetic `:subject` key for uniform client-side rendering).
     * DB CHECK constraint `read_cursors_subject_xor`.
     * Two partial unique indexes (one per subject branch) that
@@ -37,6 +37,7 @@ defmodule Grappa.ReadCursor.Cursor do
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.Network
   alias Grappa.Scrollback.Message
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -69,7 +70,7 @@ defmodule Grappa.ReadCursor.Cursor do
   Builds an insert / update changeset.
 
   All five fields are required at cast time; subject XOR validation
-  (`validate_subject_xor/1`) attaches to the synthetic `:subject` key.
+  (`Grappa.Subject.validate_xor/1`) attaches to the synthetic `:subject` key.
   `assoc_constraint/2` on each FK converts a missing parent into a
   changeset error (mirrors `Scrollback.Message.changeset/2` +
   `QueryWindows.Window.changeset/2`).
@@ -81,7 +82,7 @@ defmodule Grappa.ReadCursor.Cursor do
     |> canonicalize_channel()
     |> validate_required([:network_id, :channel, :last_read_message_id])
     |> validate_length(:channel, min: 1)
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> assoc_constraint(:network)
@@ -109,20 +110,6 @@ defmodule Grappa.ReadCursor.Cursor do
 
       _ ->
         changeset
-    end
-  end
-
-  # Mirror of Scrollback.Message.validate_subject_xor/1.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 end

--- a/lib/grappa/scrollback/message.ex
+++ b/lib/grappa/scrollback/message.ex
@@ -96,6 +96,7 @@ defmodule Grappa.Scrollback.Message do
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.Network
   alias Grappa.Scrollback.Meta
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @kinds [
@@ -335,7 +336,7 @@ defmodule Grappa.Scrollback.Message do
 
   Exactly one of `:user_id` / `:visitor_id` is required — never both,
   never neither. The XOR constraint is enforced both here (via
-  `validate_subject_xor/1`) and at the DB layer (CHECK constraint
+  `Grappa.Subject.validate_xor/1`) and at the DB layer (CHECK constraint
   `messages_subject_xor`). `:network_id`, `:channel`, `:server_time`,
   `:kind`, `:sender` are universally required.
 
@@ -374,7 +375,7 @@ defmodule Grappa.Scrollback.Message do
     |> cast(attrs, [:body], empty_values: [])
     |> canonicalize_channel()
     |> validate_required([:network_id, :channel, :server_time, :kind, :sender])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> validate_identifier(:channel, &valid_target?/1)
     |> validate_identifier(:sender, &Identifier.valid_sender?/1)
     |> validate_body_for_kind()
@@ -407,27 +408,6 @@ defmodule Grappa.Scrollback.Message do
     case get_change(changeset, :channel) do
       ch when is_binary(ch) -> put_change(changeset, :channel, Identifier.canonical_target(ch))
       _ -> changeset
-    end
-  end
-
-  # Mirror of Grappa.Accounts.Session.validate_subject_xor/1.
-  #
-  # Errors attach to the synthetic `:subject` key (B5.4 M-pers-2): neither
-  # `user_id` nor `visitor_id` is unambiguously "wrong" in either failure
-  # mode (both-nil = absence-of-either; both-set = pair-conflict), so a
-  # single key keeps client-side error rendering uniform. Pre-B5.4 this
-  # always attached to `:user_id`, which masked which field was the
-  # unexpected addition.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
     end
   end
 

--- a/lib/grappa/subject.ex
+++ b/lib/grappa/subject.ex
@@ -32,6 +32,7 @@ defmodule Grappa.Subject do
     top_level?: true,
     deps: [Grappa.Accounts.User, Grappa.Visitors.Visitor]
 
+  import Ecto.Changeset, only: [add_error: 3, get_field: 2]
   import Ecto.Query
 
   alias Grappa.Accounts.User
@@ -71,6 +72,42 @@ defmodule Grappa.Subject do
 
   def put_subject_id(attrs, {:visitor, vid}) when is_map(attrs) and is_binary(vid),
     do: Map.put(attrs, :visitor_id, vid)
+
+  @doc """
+  Enforces the subject XOR on a changeset: exactly one of `:user_id` /
+  `:visitor_id` must be set.
+
+  The write-side twin of `put_subject_id/2` — that one puts the column,
+  this one proves the pair. Errors attach to the synthetic `:subject` key
+  because neither column is individually "wrong"; the fault is in the
+  pair, and one key keeps client-side rendering uniform across both
+  violations and across every XOR-FK schema.
+
+  The DB-level `<table>_subject_xor` CHECK constraint is the substrate
+  twin: this turns a violation into a changeset error, the constraint
+  stops a write that never passed through a changeset at all.
+
+  **The single spelling of this predicate (#1580).** It used to be
+  hand-copied as a private `validate_subject_xor/1` into all twelve
+  XOR-FK schemas, each pointing at a sibling as the "mirror of" — a
+  pointer graph with a cycle in it and therefore no original. By the
+  twelfth copy one had drifted its missing-subject message, three lines
+  under a comment still claiming the mirror held, and nine of the twelve
+  had no test pinning the text. A thirteenth XOR-FK schema calls this;
+  it does not paste it.
+  """
+  @spec validate_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def validate_xor(%Ecto.Changeset{} = changeset) do
+    user_id = get_field(changeset, :user_id)
+    visitor_id = get_field(changeset, :visitor_id)
+
+    case {user_id, visitor_id} do
+      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
+      {_, nil} -> changeset
+      {nil, _} -> changeset
+      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
+    end
+  end
 
   @doc """
   Adds a `WHERE user_id = ?` clause (or its visitor mirror) to

--- a/lib/grappa/themes/theme.ex
+++ b/lib/grappa/themes/theme.ex
@@ -8,7 +8,7 @@ defmodule Grappa.Themes.Theme do
 
   A theme belongs to EITHER a user OR a visitor — never both, never
   neither. Same shape as `user_settings` / `network_credentials`:
-  `user_id` XOR `visitor_id`, enforced at the changeset (`validate_subject_xor/1`)
+  `user_id` XOR `visitor_id`, enforced at the changeset (`Grappa.Subject.validate_xor/1`)
   AND at the DB (the `themes_subject_xor` CHECK). Built-in themes are
   user-owned by the reserved "system" user.
 
@@ -21,6 +21,7 @@ defmodule Grappa.Themes.Theme do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Themes.TokenModel
   alias Grappa.Visitors.Visitor
 
@@ -69,7 +70,7 @@ defmodule Grappa.Themes.Theme do
     theme
     |> cast(attrs, [:name, :user_id, :visitor_id, :payload, :published])
     |> validate_required([:name, :payload])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> validate_length(:name, min: 1, max: 60)
     |> validate_payload()
     |> assoc_constraint(:user)
@@ -80,22 +81,6 @@ defmodule Grappa.Themes.Theme do
       name: :themes_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.UserSettings.Settings.validate_subject_xor/1`: exactly
-  # one subject FK must be set (the DB CHECK is the substrate; this is the
-  # call-site guard).
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 
   # Sanitize-in-place: the sanitized closed-token map replaces whatever the

--- a/lib/grappa/uploads/upload.ex
+++ b/lib/grappa/uploads/upload.ex
@@ -46,6 +46,7 @@ defmodule Grappa.Uploads.Upload do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Uploads.ContentType
   alias Grappa.Visitors.Visitor
 
@@ -108,7 +109,7 @@ defmodule Grappa.Uploads.Upload do
     |> validate_required([:slug, :mime, :bytes])
     |> validate_number(:bytes, greater_than: 0)
     |> sanitize_original_filename()
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> unique_constraint(:slug)
@@ -127,21 +128,6 @@ defmodule Grappa.Uploads.Upload do
   @spec soft_delete_changeset(t(), DateTime.t()) :: Ecto.Changeset.t()
   def soft_delete_changeset(upload, %DateTime{} = now) do
     change(upload, deleted_at: now)
-  end
-
-  # Mirrors `Grappa.ReadCursor.Cursor.validate_subject_xor/1` —
-  # error attaches to the synthetic `:subject` key so the wire shape
-  # matches every other XOR-FK context.
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "one of user_id or visitor_id is required")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 
   # Strip directory separators + leading dots from

--- a/lib/grappa/user_settings/settings.ex
+++ b/lib/grappa/user_settings/settings.ex
@@ -64,6 +64,7 @@ defmodule Grappa.UserSettings.Settings do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Visitors.Visitor
 
   @type t :: %__MODULE__{
@@ -93,7 +94,7 @@ defmodule Grappa.UserSettings.Settings do
   @doc """
   Builds an insert/update changeset.
 
-  Subject XOR is required (`validate_subject_xor/1` attaches errors
+  Subject XOR is required (`Grappa.Subject.validate_xor/1` attaches errors
   to the synthetic `:subject` key); `:data` is required at cast
   time. Shape validation of individual `data` keys is intentionally
   NOT performed here — that is the responsibility of typed accessor
@@ -106,7 +107,7 @@ defmodule Grappa.UserSettings.Settings do
     settings
     |> cast(attrs, [:user_id, :visitor_id, :data])
     |> validate_required([:data])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
     |> unique_constraint(:user_id, name: :user_settings_user_id_index)
@@ -115,19 +116,5 @@ defmodule Grappa.UserSettings.Settings do
       name: :user_settings_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/lib/grappa/vhosts/grant.ex
+++ b/lib/grappa/vhosts/grant.ex
@@ -27,6 +27,7 @@ defmodule Grappa.Vhosts.Grant do
   import Ecto.Changeset
 
   alias Grappa.Accounts.User
+  alias Grappa.Subject
   alias Grappa.Vhosts.Vhost
   alias Grappa.Visitors.Visitor
 
@@ -63,7 +64,7 @@ defmodule Grappa.Vhosts.Grant do
     grant
     |> cast(attrs, [:vhost_id, :user_id, :visitor_id])
     |> validate_required([:vhost_id])
-    |> validate_subject_xor()
+    |> Subject.validate_xor()
     |> assoc_constraint(:vhost)
     |> assoc_constraint(:user)
     |> assoc_constraint(:visitor)
@@ -73,19 +74,5 @@ defmodule Grappa.Vhosts.Grant do
       name: :vhost_grants_subject_xor,
       message: "user_id and visitor_id are mutually exclusive"
     )
-  end
-
-  # Mirror of ReadCursor.Cursor.validate_subject_xor/1.
-  @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp validate_subject_xor(changeset) do
-    user_id = get_field(changeset, :user_id)
-    visitor_id = get_field(changeset, :visitor_id)
-
-    case {user_id, visitor_id} do
-      {nil, nil} -> add_error(changeset, :subject, "must set user_id or visitor_id")
-      {_, nil} -> changeset
-      {nil, _} -> changeset
-      {_, _} -> add_error(changeset, :subject, "user_id and visitor_id are mutually exclusive")
-    end
   end
 end

--- a/test/grappa/subject_xor_test.exs
+++ b/test/grappa/subject_xor_test.exs
@@ -1,0 +1,122 @@
+defmodule Grappa.SubjectXorTest do
+  @moduledoc """
+  One table over EVERY schema carrying the subject XOR-FK pair (#1580).
+
+  The census that opened #1580 measured the population closed at twelve on
+  four independent axes: twelve `belongs_to :visitor` schemas, twelve
+  `case {user_id, visitor_id}` decision bodies (measured by BODY, so an
+  inlined or renamed copy could not hide), twelve `*_subject_xor` DB CHECK
+  constraints, and zero schemas holding a visitor FK without a decision
+  body. Masking the string literals collapsed the twelve bodies to ONE
+  control-flow class: the whole divergence in the family was the
+  missing-subject message text. `uploads/upload.ex` emitted
+  `"one of user_id or visitor_id is required"` where the other eleven
+  emitted `"must set user_id or visitor_id"`, three lines under a comment
+  claiming it mirrored `ReadCursor.Cursor` — which emits the latter.
+
+  Three schemas of the twelve pinned the missing-subject text and nine did
+  not, which is exactly why the drift survived a hand-copy. This table pins
+  all twelve on both arms and both valid shapes, so the next copy that
+  drifts — or the next call site that quietly stops routing through the
+  shared validator — is a red test rather than a silent fork.
+
+  Attrs are deliberately minimal: every assertion reads ONLY the synthetic
+  `:subject` key, so the other required fields of each schema are
+  irrelevant here and are covered by that schema's own test. The two
+  positive assertions (`{nil, nil}` and both-set) are what keeps the pair
+  from passing vacuously — a changeset that stopped calling the validator
+  altogether would fail them, not slip through the two clean-subject ones.
+  """
+  use Grappa.DataCase, async: true
+
+  alias Grappa.Accounts.Session
+  alias Grappa.ChannelDirectory.Entry, as: DirectoryEntry
+  alias Grappa.Networks.Credential
+  alias Grappa.Notify.Entry, as: NotifyEntry
+  alias Grappa.Push.Subscription
+  alias Grappa.QueryWindows.Window
+  alias Grappa.ReadCursor.Cursor
+  alias Grappa.Scrollback.Message
+  alias Grappa.Themes.Theme
+  alias Grappa.Uploads.Upload
+  alias Grappa.UserSettings.Settings
+  alias Grappa.Vhosts.Grant
+
+  @user_id "11111111-1111-4111-8111-111111111111"
+  @visitor_id "22222222-2222-4222-8222-222222222222"
+
+  @missing_subject "must set user_id or visitor_id"
+  @mutually_exclusive "user_id and visitor_id are mutually exclusive"
+
+  # {schema, its subject-bearing changeset}. Eleven spell it `changeset/2`;
+  # `Uploads.Upload` splits insert from soft-delete and only the former
+  # casts the subject FKs.
+  @xor_schemas [
+    {Session, :changeset},
+    {Message, :changeset},
+    {Cursor, :changeset},
+    {Window, :changeset},
+    {DirectoryEntry, :changeset},
+    {NotifyEntry, :changeset},
+    {Subscription, :changeset},
+    {Settings, :changeset},
+    {Grant, :changeset},
+    {Theme, :changeset},
+    {Credential, :changeset},
+    {Upload, :insert_changeset}
+  ]
+
+  describe "the XOR-FK population itself" do
+    test "the table covers every schema that declares a visitor FK" do
+      # Guards the table against bit-rot: a thirteenth XOR-FK schema added
+      # without a row here would otherwise be silently unpinned, which is
+      # the failure mode that produced #1580 in the first place.
+      declared =
+        "lib/grappa/**/*.ex"
+        |> Path.wildcard()
+        |> Enum.filter(fn path ->
+          path |> File.read!() |> String.contains?("belongs_to :visitor,")
+        end)
+
+      assert length(declared) == length(@xor_schemas),
+             """
+             #{length(declared)} schemas declare `belongs_to :visitor`, \
+             but the table pins #{length(@xor_schemas)}. Files:
+             #{Enum.join(declared, "\n")}
+             """
+    end
+  end
+
+  for {schema, fun} <- @xor_schemas do
+    @schema schema
+    @fun fun
+
+    describe "#{inspect(schema)}.#{fun}/2 subject XOR" do
+      test "neither user_id nor visitor_id attaches the shared missing-subject message" do
+        assert @missing_subject in subject_errors(@schema, @fun, %{})
+      end
+
+      test "both user_id and visitor_id attaches the shared mutually-exclusive message" do
+        errors = subject_errors(@schema, @fun, %{user_id: @user_id, visitor_id: @visitor_id})
+
+        assert @mutually_exclusive in errors
+      end
+
+      test "a user-only subject leaves :subject clean" do
+        assert subject_errors(@schema, @fun, %{user_id: @user_id}) == []
+      end
+
+      test "a visitor-only subject leaves :subject clean" do
+        assert subject_errors(@schema, @fun, %{visitor_id: @visitor_id}) == []
+      end
+    end
+  end
+
+  defp subject_errors(schema, fun, attrs) do
+    changeset = apply(schema, fun, [struct(schema), attrs])
+
+    changeset
+    |> errors_on()
+    |> Map.get(:subject, [])
+  end
+end


### PR DESCRIPTION
Union of the three PRs that went `CONFLICTING` when #1466 landed on
`main` (`5d695a56`). Built by cherry-pick onto a fresh branch off that
tip, in the order **#1611 → #1614 → #1615**, so the cycle rule that
#1615 turns on sits *above* the other two and gates their code as well.

Supersedes #1611 (#1580), #1614 (#1518) and #1615 (#1513). Nothing was
re-litigated: the eight commits are the ones already reviewed on those
branches, unchanged.

| absorbed PR | issue | original head | commits |
|---|---|---|---|
| #1611 | #1580 | `51ead1ed` | 2 |
| #1614 | #1518 | `5e92067c` | 2 |
| #1615 | #1513 | `044171d7` | 4 |

**8 of 8 commits applied cleanly — zero conflicts, in any file.**

## Why a union and not three rebases

Three rebases cost three `integration` runs and still leave every
branch never having been compiled against the other two. This matters
concretely here rather than in the abstract: **#1615 turns
`suspicious/noImportCycles` on, and #1614 had never been built with
that rule enabled.** An import cycle introduced by #1614's new
`serviceModalCommand` test and the `commands/services.ts` export it
leans on would have shipped through two separate green runs without
either one asking the question.

Answered: with the rule on, `biome` reports **zero errors** across
1065 files, and there is not one `biome-ignore` for it in `src/`.

To be exact about what this does *not* cover: **#1611 touches zero
files under `cicchetto/`** (its diff is 14 `lib/grappa/*.ex`, one new
test, and DESIGN_NOTES), so the cycle rule has nothing to say about
it and never could have. What #1611 gains from the union is the
single shared `integration` run and a base that is the current tip —
not a cycle check.

## What was measured on the union

| gate | result |
|---|---|
| `bun run check` (lock drift, biome src+e2e, tsc src, tsc e2e) | 4 stages, 0 failed |
| `bun run test` | 295 files, 5695 tests, 0 failures |
| `mix test` (full server suite) | 8 doctests, 61 properties, 6635 tests, **0 failures** |
| `mix compile --warnings-as-errors` | clean, 346 files |
| `mix format --check-formatted` | clean |
| `mix credo --strict` | 6088 mods/funs, no issues |
| `scripts/design-notes-gate.sh` | 3 new entries, separator + marker present |

The server suite was run because this union is *not* cic-only — it
absorbs #1611's `validate_subject_xor` consolidation. It ran on an
isolated build cache (`GRAPPA_CACHE_ID=w2-union`, cold), so the result
is not a shared-`_build` artefact of another worktree.

Not run, and not claimed: **Dialyzer** (a cold PLT for a fresh cache
id, and the union changes no server code relative to #1611's own
green) and the **e2e / integration** suites, which are CI's.

## DESIGN_NOTES

Three entries, `+290 -1`, reconciling exactly against the three
branch pins (`106 + 62 + 122 = 290`; the single deletion is #1615's).
All three markers — `#1580`, `#1518`, `#1513b` — were re-verified
unique against the **current** tip, not against the base they were cut
from; `#1513b` already carried its suffix for that reason.

The one deletion is deliberate and is #1513's correction at the
source: `ame`/`amsg` struck from the store-coupled arm list in the
2026-08-18 entry. Diffing the whole pre-existing portion of the file
against `5d695a56` line by line shows that correction and nothing
else — no merge-driver damage to the preceding entry's tail.

`scripts/union-rebase.sh origin/main` exits `1` here and that red
carries no information, twice over. The script says so itself first
("already on top of `origin/main` — the driver gets no chance to run,
so the comparison below is VACUOUS by construction"), and its verdict
line is the known #1610 defect: it tests `del_after == 0` instead of
`del_before == del_after`. Its own numbers are `additions 290 -> 290,
deletions 1 -> 1` — identical on both sides. The manual check above is
what carries the weight, not that exit code.
