### PR TITLE
test(#1579): discriminate the user-topic barrier reds — the barrier was right

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -70,8 +70,11 @@ import {
 import type { SeededUser } from "./grappaApi";
 import { type ScrollGestureResult, scrollByGesture, waitForScrollRest } from "./scrollGesture";
 import type { TraceEvent } from "./scrollTrace";
+import { describeUserTopicTimeout, watchPageConsole } from "./userTopicDiagnostics";
 
 const SHELL_READY_TIMEOUT_MS = 10_000;
+// #1579 — see `waitForUserTopicReady` for why this number does not move.
+const USER_TOPIC_BARRIER_MS = 5_000;
 const MOBILE_BREAKPOINT_PX = 768;
 
 // Mirror of cicchetto/src/lib/theme.ts isMobile() — viewport width
@@ -111,6 +114,11 @@ export async function expectShellReady(page: Page): Promise<void> {
 // and `getSubject()` reads the subject; doing this via `page.evaluate`
 // AFTER goto would race the SPA's first read.
 async function seedAuthLocalStorage(page: Page, token: string, subjectJson: string): Promise<void> {
+  // #1579 — start recording the page console before the first navigation, so
+  // a later `waitForUserTopicReady` timeout can quote the phoenix-level join
+  // errors instead of leaving them in a container log nobody reads. Costs one
+  // listener; the page is not modified.
+  watchPageConsole(page);
   await page.addInitScript(
     ([t, s]) => {
       localStorage.setItem("grappa-token", t);
@@ -676,16 +684,30 @@ export async function waitForScrollbackRefreshed(
 // Wired into loginAs() universally rather than per-spec because the race
 // affects ANY spec that compose-sends `/join` (or any compose verb that
 // produces a server-side user-topic broadcast) shortly after page-load.
+//
+// #1579 — the budget is deliberately UNCHANGED. Measured over a full 759-test
+// run, 597 satisfied barriers have a median of 18 ms and a maximum of 848 ms,
+// so 5 s is not a tight budget; the three misses in that run sat at 11.1 s,
+// 31.6 s and >65 s, and every one of them was the server failing to complete
+// the WebSocket upgrade at all. A larger number would not have converted them
+// into passes, it would only have moved the red to the next assertion — which
+// is exactly what the same stall did to `loginAs`'s own shell-ready gate in
+// that run. What the barrier lacked was not slack but a voice, so it now
+// reports the state it observed instead of a bare TimeoutError.
 export async function waitForUserTopicReady(page: Page, userName: string): Promise<void> {
-  await page.waitForFunction(
-    (name) => {
-      const set = (window as unknown as { __cic_userTopicReady?: Set<string> })
-        .__cic_userTopicReady;
-      return set?.has(name) === true;
-    },
-    userName,
-    { timeout: 5_000 },
-  );
+  try {
+    await page.waitForFunction(
+      (name) => {
+        const set = (window as unknown as { __cic_userTopicReady?: Set<string> })
+          .__cic_userTopicReady;
+        return set?.has(name) === true;
+      },
+      userName,
+      { timeout: USER_TOPIC_BARRIER_MS },
+    );
+  } catch {
+    throw new Error(await describeUserTopicTimeout(page, userName, USER_TOPIC_BARRIER_MS));
+  }
 }
 
 // #485 — gate on the REAL service worker before a spec mutates any

--- a/cicchetto/e2e/fixtures/userTopicDiagnostics.ts
+++ b/cicchetto/e2e/fixtures/userTopicDiagnostics.ts
@@ -1,0 +1,122 @@
+// #1579 — what the user-topic barrier saw when it gave up.
+//
+// `waitForUserTopicReady` used to throw a bare
+// `TimeoutError: page.waitForFunction: Timeout 5000ms exceeded`, which names
+// the barrier and nothing else. That one line is compatible with at least four
+// different failures, and telling them apart cost a full-suite re-read plus an
+// iso-rerun every time it happened:
+//
+//   * the WS transport never opened, so no JOIN was ever pushed;
+//   * the transport is open and the user-topic JOIN alone is unacknowledged;
+//   * the stamp is present under a DIFFERENT name than the one awaited
+//     (`socketUserName()` disagreeing with the seeded `SeededUser.name`),
+//     which is a harness bug and not a race at all;
+//   * the page went offline / hidden mid-boot.
+//
+// Measured on the 759-test suite (2026-08-20, 597 satisfied barriers): the
+// healthy population sits at a median of 18 ms and a maximum of 848 ms, while
+// the three misses were all the FIRST shape — `state: "connecting"` with a
+// single connect attempt and no error, i.e. the server had not finished the
+// WebSocket upgrade. Nothing about the budget could have told them apart, and
+// nothing about the budget would have saved them; only the state at the
+// deadline does. So the barrier keeps its 5 s and gains a voice.
+//
+// This is diagnosis, never recovery: the timeout still fails the test, at the
+// same moment, for the same reason.
+
+import type { Page } from "@playwright/test";
+
+// Console output per page, captured through Playwright's own listener rather
+// than by patching the page's `console` — the page under test must behave
+// exactly as it does without the harness. `joinUser`/`joinChannel` log the
+// phoenix-level "channel join failed" / "channel join timed out" shapes, which
+// is the difference between "the socket never opened" and "the socket opened
+// and the server refused the topic".
+//
+// A WeakMap so a closed page's buffer is collectable with the page.
+const consoleByPage = new WeakMap<Page, string[]>();
+
+// Cap: a spec that logs in a loop must not turn the buffer into the run's
+// memory profile. The tail is what a post-mortem reads, so the cap drops from
+// the FRONT.
+const CONSOLE_CAP = 200;
+
+// Start recording this page's console. Call before the first navigation —
+// `loginAs`'s seeding door does, which covers every caller of the barrier.
+export function watchPageConsole(page: Page): void {
+  if (consoleByPage.has(page)) return;
+  const buffer: string[] = [];
+  consoleByPage.set(page, buffer);
+  page.on("console", (message) => {
+    buffer.push(`${message.type()}: ${message.text()}`);
+    if (buffer.length > CONSOLE_CAP) buffer.shift();
+  });
+}
+
+type Snapshot = {
+  readyNames: string[];
+  socketHealth: unknown;
+  joinedTopicKeys: string[];
+  onLine: boolean;
+  visibility: string;
+};
+
+// One message naming every state that distinguishes the four failures above.
+// Returns a string rather than throwing so the caller owns the error type, and
+// swallows nothing: a page that can no longer be interrogated says so, because
+// "the page was already gone" is itself one of the answers.
+export async function describeUserTopicTimeout(
+  page: Page,
+  userName: string,
+  budgetMs: number,
+): Promise<string> {
+  const head = `waitForUserTopicReady: '${userName}' was not stamped within ${budgetMs}ms`;
+  let snapshot: Snapshot;
+  try {
+    snapshot = await page.evaluate((): Snapshot => {
+      const w = window as unknown as {
+        __cic_userTopicReady?: Set<string>;
+        __cic_socketHealth?: { state: () => unknown };
+        __cic_joinedTopicKeys?: () => string[];
+      };
+      return {
+        readyNames: Array.from(w.__cic_userTopicReady ?? []),
+        socketHealth: w.__cic_socketHealth?.state() ?? null,
+        joinedTopicKeys: w.__cic_joinedTopicKeys?.() ?? [],
+        onLine: navigator.onLine,
+        visibility: document.visibilityState,
+      };
+    });
+  } catch (err) {
+    return `${head}, and the page could not be interrogated afterwards: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+  }
+
+  const consoleTail = consoleByPage.get(page);
+  return [
+    head,
+    `  stamped names:     ${JSON.stringify(snapshot.readyNames)}`,
+    `  socket health:     ${JSON.stringify(snapshot.socketHealth)}`,
+    `  joined topic keys: ${JSON.stringify(snapshot.joinedTopicKeys)}`,
+    `  navigator.onLine:  ${snapshot.onLine}   visibility: ${snapshot.visibility}`,
+    consoleTail === undefined
+      ? "  page console:      not recorded (watchPageConsole was never called for this page)"
+      : `  page console (last ${Math.min(consoleTail.length, 12)} of ${consoleTail.length}):\n` +
+        (consoleTail.length === 0
+          ? "    (the page logged nothing)"
+          : consoleTail
+              .slice(-12)
+              .map((line) => `    ${line}`)
+              .join("\n")),
+    // The reading a triager should reach for first, spelled out rather than
+    // left to be re-derived. A socket that is still `connecting` on its first
+    // attempt is not a client-side race: the server has not finished the
+    // upgrade, and #1579 measured that as an 11-33 s SQLite write-lock stall
+    // inside `UserSocket.connect/3`.
+    '  If socket health reads state "connecting" with connectAttempts 1 and no',
+    "  error, the WS upgrade never completed server-side — read the grappa",
+    "  container log for `CONNECTED TO GrappaWeb.UserSocket in <N>ms`, not the",
+    "  spec. See #1579.",
+  ].join("\n");
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54171,3 +54171,117 @@ three unknowns exactly when the comparison between them is the triage.
 - Whether any cross-file cascade actually changes verdict under the new
   grouping is **unknown until the first reds arrive**; the mechanism is
   argued above, the incidence is not.
+<!-- entry #1579 -->
+
+---
+
+## 2026-08-20 — #1579: the 5 s user-topic barrier was telling the truth
+
+`waitForUserTopicReady` is the last statement of the canonical `loginAs` that
+333 spec files go through, and a full run had gone red in it three times in
+three different specs. #1579 put three readings on the table and said, in as
+many words, that none of them had been discriminated: (1) the 5 s budget is
+simply too tight under a loaded 29-minute run, (2) the barrier is right and the
+subscribe genuinely never happens, so the reds are product signal, (3)
+run-scoped resource pressure that slows the WS join specifically.
+
+**Reading 2.** The barrier is honest, and the defect is not in the barrier.
+
+### What was measured
+
+One full `scripts/integration.sh` (759 tests, 32.8 min, darwin / Docker
+Desktop, `MIX_ENV=dev`), instrumented so every `waitForUserTopicReady` call
+recorded its satisfaction latency, and so a call that blew the budget kept
+WATCHING for a further 25 s without changing the budget it enforced — the
+enforced 5 s is what fails the test, the extra window only decides whether the
+failure can say "the stamp arrived at 11.2 s" or "it never arrived". 600 calls:
+597 satisfied, 3 missed.
+
+The satisfied population settles reading 1 on its own: median 18 ms, p95
+243 ms, p99 395 ms, max 848 ms. The budget is not tight, it is roughly six
+times the worst healthy case, and the profile is flat across the run (per-tenth
+medians 15–36 ms), which also refuses the monotonic-degradation shape of
+reading 3.
+
+The three misses share one signature, and it is not the one the barrier's own
+moduledoc describes. At the deadline the page reported
+`__cic_socketHealth` = `state: "connecting"`, `connectAttempts: 1`,
+`errorCount: 0` — the WebSocket transport had never opened, so no JOIN had
+been pushed at all, and phoenix.js's own 10 s join timeout had fired for all
+three topics. The stamp then arrived at 11 180 ms in one case and never inside
+30 s in the other two.
+
+### The same event from the server side
+
+The server named itself. On the 11 s case, the transport pid logs
+`ws connect authenticated` at 16:31:44.496, then a single
+`QUERY OK db=11136.6ms` with no source (the `BEGIN IMMEDIATE`), then three
+sub-millisecond `user_settings` statements, a commit, and
+`CONNECTED TO GrappaWeb.UserSocket in 11140ms`. The user-topic
+`JOINED grappa:user:...` that follows took **23 µs**. The client's 11 180 ms and
+the server's 11 140 ms are the same wait, measured from both ends, and none of
+it is the JOIN.
+
+The 31 s case spells out the mechanism in full:
+
+```
+16:28:45.423 ws connect authenticated
+16:29:16.996 QUERY ERROR db=31571.8ms
+16:29:16.999 db write unavailable: SQLite write lock held by another writer
+             for 31572ms across 1 attempts (1500ms retry budget)
+16:29:16.999 record_client_source: db unavailable persisting client prefix
+             for {:user, "270bdc2c-…"} — dropped (best-effort)
+16:29:16.999 CONNECTED TO GrappaWeb.UserSocket in 31575ms
+```
+
+`UserSocket.connect/3` calls `maybe_record_client_source/2` → `Vhosts`
+→ `UserSettings.put_last_client_prefix64/2` → `Repo.immediate_transaction/1`
+**before it returns**, and Phoenix holds the upgrade until it does. The write
+is explicitly best-effort — #523 made it drop on saturation precisely so it
+could never fail a connect — but dropping it costs the full `busy_timeout`
+first, so a sample nobody is allowed to depend on can delay every new
+WebSocket by up to 30 s. Across the run: 682 connects, 680 of them at 56 ms or
+below, two at 11 140 ms and 31 575 ms, and those two are the stalls.
+
+`Grappa.Repo.LockWatch` (#1420) caught three episodes — 11 144 ms, 32 950 ms,
+31 937 ms, each with a waiter queued — and named a `UserSettings.write_data!/2`
+transaction as the holder in two of the three. Twelve queries in the whole run
+exceeded 10 s and all twelve fall inside these episodes, during which the BEAM
+emitted nothing at all despite averaging ~560 log lines a second.
+
+### Why raising the number would be the wrong repair
+
+It cannot reach the numbers: 11.2 s, 31.6 s, and one page that sat through two
+consecutive ~32 s stalls for ~65 s. And it would not remove the reds, only
+relocate them — in the same run the 32.9 s stall took out `loginAs`'s OTHER
+gate, the 10 s `.sidebar-network-header` shell-ready wait in
+`issue591-ctcp-ping`, which is the same stall arriving at a different
+assertion. The barrier is not the thing that is wrong; it is the thing that
+noticed.
+
+So the barrier keeps its 5 s and gains a voice: on timeout it now reports the
+stamped names, the socket-health state, the joined topic keys,
+onLine/visibility, and the tail of the page console — captured through
+Playwright's listener, never by patching the page's `console`. That is the
+measurement #1579 asked for, made permanent. It recovers nothing.
+
+### What this does NOT establish
+
+Why a writer holds the SQLite write lock for 31–33 s. The holder's OWN
+statement is what takes that long (`QUERY OK source="user_settings"
+db=32952.5ms`), so it is not a process sitting idle inside a transaction, and
+one of the three LockWatch stack samples shows the holder blocked inside
+`logger_h_common:log/2` — the Logger's sync-mode back-pressure — rather than
+inside SQLite. Log back-pressure and genuine storage contention are both live,
+and this run cannot separate them: it ran on darwin under Docker Desktop with
+`MIX_ENV=dev` debug query logging (1 114 576 lines), and the same suite on the
+Linux CI runner has not been measured. The measurement that would separate them
+is the same run with the log volume cut, on both substrates.
+
+Also not established: the fifth red of the run
+(`slash-commands-bundle` `/q`, 6.0 s, a window that did not close) is not in
+this class and is not attributed here.
+
+The stall itself is filed separately — the WebSocket upgrade should not be on
+the critical path of a droppable telemetry write, and that is a production
+property, not an e2e one.


### PR DESCRIPTION
Discriminates the three readings #1579 puts on the table and says none of them
had been separated. **Reading 2 wins: the barrier is telling the truth.** The
user-topic subscribe genuinely had not happened, because the server had not
finished the WebSocket upgrade — the two reds in the issue are product signal,
not harness noise.

The budget is deliberately untouched. No timeout was raised, no assertion
weakened, no retry added.

## How it was discriminated

The three readings differ in exactly one observable — what happens AFTER the
5 s deadline — so the harness kept the ENFORCED budget at 5 s and displaced
only the OBSERVATION past it, then recorded the satisfaction latency of every
`waitForUserTopicReady` call in a full run so reading 3 could be judged on the
population instead of on two data points.

One full `scripts/integration.sh` (759 tests, 32.8 min, single worker,
darwin / Docker Desktop, `MIX_ENV=dev`), 600 barrier calls:

* **597 satisfied** — median 18 ms, p95 243 ms, p99 395 ms, **max 848 ms**. The
  5 s budget is ~6× the worst healthy case, so "the budget is simply too tight"
  is refused by its own population. Per-tenth medians are flat (16…36 ms), so
  the monotonic-degradation shape reading 3 needs is not there either.
* **3 missed**, all with one signature: `__cic_socketHealth` reading
  `state: "connecting"`, `connectAttempts: 1`, `errorCount: 0` — the WS
  transport had **never opened**, and phoenix.js's own 10 s join timeout had
  fired for all three topics because the joins were still buffered.

The server agrees, on the pid Phoenix names in its own duration line:
`CONNECTED TO GrappaWeb.UserSocket in 11140ms`, followed by
`JOINED grappa:user:… in 23µs`. Client-side stamp arrived at 11 180 ms. The
same wait from both ends, and none of it is the JOIN. The 31 s case logs its
own mechanism: `db write unavailable: SQLite write lock held by another writer
for 31572ms` inside `record_client_source`, then
`CONNECTED TO GrappaWeb.UserSocket in 31575ms`. Across the run, 682 connects:
680 at ≤ 56 ms and exactly those two above 1 s.

Raising the number would have been the wrong repair twice over: it cannot
reach 11.2 s / 31.6 s / ~65 s, and in the same run the same stall took out
`loginAs`'s OTHER gate (the 10 s shell-ready wait in `issue591-ctcp-ping`), so
a bigger barrier budget just hands the failure to whatever waits next.

## What changed

`waitForUserTopicReady` keeps its 5 s and gains a voice. On timeout it reports
the stamped names, the socket-health state, the joined topic keys,
onLine/visibility, and the tail of the page console — captured through
Playwright's own listener, never by patching the page's `console`. It recovers
nothing; the same timeout fails the same test at the same moment. This is the
measurement #1579 itself asked for ("the barrier currently throws without
reporting what it saw"), made permanent.

Proven by mutation on the committed code, twice — the second run exists only
because the first printed `page console (last 0 of 0)`, which is true but
indistinguishable from a capture that never worked:

```
Error: waitForUserTopicReady: 's92d28457' was not stamped within 5000ms
  stamped names:     ["s92d28457"]
  socket health:     {"state":"open",…,"connectAttempts":1,…}
  joined topic keys: ["bahamut-test s92d28457","bahamut-test $server",…]
  navigator.onLine:  true   visibility: visible
  page console (last 2 of 2):
    error: [w1-probe] a deliberate console.error, to calibrate the capture
    warning: [w1-probe] and a warn
```

## The elsewhere

The stall itself is filed separately: `UserSocket.connect/3` waits a full
`busy_timeout` for a write that #523 already declared droppable, so the
"can never hurt a connect" contract is not actually held — in production, not
only under e2e load.

## What is NOT established

Why a writer holds the SQLite write lock for 31–33 s. The holder's own
statement is what takes that long, and one of three `LockWatch` stack samples
shows it blocked inside `logger_h_common:log/2` rather than inside SQLite, with
the BEAM emitting nothing at all during each episode. Log back-pressure and
storage contention are both live and this run separates neither; the substrate
(darwin/Docker Desktop, `MIX_ENV=dev`, 1 114 576 log lines) is also unshared
with the Linux CI runner. Full list of refusals in the report on the issue.

## Gates

* `scripts/bun.sh run check` — rc=0, 4 stages ran, 0 failed (the only static
  gate over `cicchetto/e2e`, per `docs/TESTING.md`).
* `scripts/design-notes-gate.sh` — rc=0, 1 new entry heading, separator and
  marker present.
* `scripts/union-rebase.sh origin/main` — rc=0,
  `docs/DESIGN_NOTES.md +114 -0 — contribution intact`; boundary shape re-read
  on the real file after the rebase.
* `scripts/integration.sh --project=chromium --grep issue1041` on the shipped
  tree — **6 passed (17.9 s)**, the happy path through the modified login door.
* **Not run, declared:** `scripts/check.sh` (runs no cic gates; the diff is
  `cicchetto/e2e/` + `docs/` only) and the full 759-test suite on the shipped
  tree — the full run I have predates these commits and IS the measurement;
  4 of its 5 reds are the stall class above and pre-date this branch.
