### PR TITLE
e2e(#1532): stop the prose naming the channel the subject left

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -676,7 +676,7 @@ export async function reapVisitors(
 
 // Poll GET /networks/:network_slug/channels/:channel/messages for a
 // row matching {sender, body}. Channel id in the URL is the channel
-// NAME (`#bofh`) — grappa's REST surface keys channels by slug-shape,
+// NAME (`#spec-wN`) — grappa's REST surface keys channels by slug-shape,
 // not integer FK (see GrappaWeb.Router scope; ResolveNetwork resolves
 // the network slug, the channel segment is the name). Response is a
 // flat JSON array of `Grappa.Scrollback.Wire.t()` shapes — see
@@ -846,7 +846,7 @@ export async function clearMutedConversations(token: string): Promise<void> {
 // JOIN a channel via REST POST (mirrors `cicchetto/src/lib/api.ts`'s
 // `postJoin`). Used by tests that PART a seeded channel and need to
 // restore it for subsequent specs (M9, in particular — without restore,
-// later specs that assume #bofh is joined fail at selectChannel because
+// later specs that assume #spec-wN is joined fail at selectChannel because
 // the BottomBar tab no longer exists). 200/201/202 = success; the body
 // shape isn't read.
 export async function joinChannel(
@@ -983,7 +983,7 @@ export async function getReadCursor(
 // PART verb (DELETE /networks/.../channels) strips the channel from
 // operator-config autojoin permanently (UX-1, m9-part-x-click,
 // cp15-b6 exercise this); without restoration, every subsequent
-// reset would see an empty autojoin list and the seed `#bofh`
+// reset would see an empty autojoin list and the seed `#spec-wN`
 // would never re-JOIN.
 //
 // `baselineSeed` (network_slug → [{name, seedCount, seedSender}])

--- a/cicchetto/e2e/tests/_smoke.spec.ts
+++ b/cicchetto/e2e/tests/_smoke.spec.ts
@@ -6,7 +6,7 @@
 //
 // Flow:
 //   1. login fixture provided by globalSetup (token seeded)
-//   2. spawn vjt-peer, JOIN #bofh, PRIVMSG, then disconnect
+//   2. spawn vjt-peer, JOIN #spec-wN, PRIVMSG, then disconnect
 //   3. poll grappa's REST messages endpoint until the row appears
 //
 // No cicchetto involvement — the harness signal we want is "grappa's
@@ -22,7 +22,7 @@ const PEER_NICK = "vjt-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MESSAGE_BODY = "smoke-test hello from peer";
 
-test("peer PRIVMSG to #bofh persists in grappa scrollback", async () => {
+test("peer PRIVMSG to #spec-wN persists in grappa scrollback", async () => {
   const vjt = specUser();
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK });

--- a/cicchetto/e2e/tests/archive-desktop-only.spec.ts
+++ b/cicchetto/e2e/tests/archive-desktop-only.spec.ts
@@ -97,7 +97,7 @@ test("desktop — archive modal rows inherit the canonical monospace style", asy
   // to the UA default (system serif). A unit test asserts the JSX class
   // string; here we read the live built DOM's computed value.
 
-  // PART so a channel lands in the archive (the fixture seed leaves #bofh
+  // PART so a channel lands in the archive (the fixture seed leaves #spec-wN
   // joined; partChannel's server-side broadcast moves it into the archive).
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, { timeout: 5_000 });

--- a/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
+++ b/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
@@ -43,7 +43,7 @@ test("B0 — /invite from $server window (no channel context) reaches upstream +
   const vjt = specUser();
   await loginAs(page, vjt);
 
-  // Focus #bofh first to confirm login + ws-ready, then /join the
+  // Focus #spec-wN first to confirm login + ws-ready, then /join the
   // fresh per-spec channel so vjt is the first user and Bahamut
   // grants +o (so /invite has the privileges to send). Same template
   // as p0e-invite-ack.spec.ts:53-60.

--- a/cicchetto/e2e/tests/b2-inbound-invite-cta.spec.ts
+++ b/cicchetto/e2e/tests/b2-inbound-invite-cta.spec.ts
@@ -123,7 +123,7 @@ test("B2 — inbound INVITE raises a banner naming the inviter; its [Join] mount
     // duration of the testnet container. Subsequent specs (notably
     // names-ux N-3) cold-load with `#b2-target` already :joined,
     // and since `Session.list_channels/2` returns alphabetically,
-    // `#b2-target` < `#bofh` ⇒ the auto-select effect picks
+    // `#b2-target` < `#spec-wN` ⇒ the auto-select effect picks
     // `#b2-target` instead. PART here restores pre-test state. The
     // helper swallows 404 (idempotent if test bailed before [Join]
     // click).

--- a/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
@@ -1,7 +1,7 @@
 // BUG7 — own message not visible in scrollback after compose-send on
 // iOS WebKit (the iPhone 15 device emulation surface).
 //
-// Manual matrix: vjt opens cicchetto on a real iPhone, types in #bofh
+// Manual matrix: vjt opens cicchetto on a real iPhone, types in #spec-wN
 // compose box, hits send. Expected the row to appear in scrollback
 // within 2s (same invariant as M3 on chromium). Observed: the row
 // either doesn't appear, appears late, or scrolls out of the visible
@@ -47,7 +47,7 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Per-run unique tag so retries / parallel runs don't strict-mode-collide
-// with persisted prior-run rows in #bofh.
+// with persisted prior-run rows in #spec-wN.
 const MESSAGE_BODY = `BUG7-ios: own-msg visibility @ ${crypto.randomUUID().slice(0, 8)}`;
 
 // Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept

--- a/cicchetto/e2e/tests/bughunt-1-b-archive-mobile-seed.spec.ts
+++ b/cicchetto/e2e/tests/bughunt-1-b-archive-mobile-seed.spec.ts
@@ -37,7 +37,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.afterEach(async () => {
   // Restore the seed-time joined state so later specs that assume
-  // #bofh is joined keep working under retries. Mirror of cp15-b4.
+  // #spec-wN is joined keep working under retries. Mirror of cp15-b4.
   const vjt = specUser();
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL);
 });

--- a/cicchetto/e2e/tests/c2-whois-card-inline-render.spec.ts
+++ b/cicchetto/e2e/tests/c2-whois-card-inline-render.spec.ts
@@ -5,7 +5,7 @@
 // ephemeral (NOT persisted in scrollback) and keyed per network.
 //
 // Pre-conditions:
-//   - vjt logged in, focused on #bofh.
+//   - vjt logged in, focused on #spec-wN.
 //   - IrcPeer "c2-target" connected so the upstream returns real WHOIS
 //     numerics (311 + 312 + 318 minimum from bahamut).
 //

--- a/cicchetto/e2e/tests/c5-member-leftclick-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/c5-member-leftclick-opens-query.spec.ts
@@ -4,14 +4,14 @@
 // one-click variant the spec calls for.
 //
 // Pre-conditions:
-//   - vjt logged in, focused on #bofh (specNick() is the autojoin user;
+//   - vjt logged in, focused on #spec-wN (specNick() is the autojoin user;
 //     IrcPeer "c5-buddy" joins and shows up in members list).
 //
 // Asserts:
 //   - sidebar gains an entry for the buddy nick after click;
 //   - selected window switches to the buddy nick (TopicBar / scrollback
 //     surface keys on it);
-//   - members list still renders #bofh (we left the channel in the
+//   - members list still renders #spec-wN (we left the channel in the
 //     sidebar — close semantics for query windows is unrelated).
 
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";

--- a/cicchetto/e2e/tests/channel-directory.spec.ts
+++ b/cicchetto/e2e/tests/channel-directory.spec.ts
@@ -3,7 +3,7 @@
 // What this spec asserts:
 //   1. The 📇 channels ($list) sidebar row opens DirectoryPane.
 //   2. The server-issued LIST populates the directory; a peer-created
-//      channel (PEER_CHANNEL) and the seeded autojoin channel (#bofh)
+//      channel (PEER_CHANNEL) and the seeded autojoin channel (#spec-wN)
 //      both appear after clicking Refresh.
 //   3. Selecting the $list window fires NO GET /messages request
 //      (grappa-irc#81: kindHasScrollback("list") === false).
@@ -65,7 +65,7 @@ test("channel-directory — browse, no /messages fetch (#81 guard), search filte
 
     await loginAs(page, vjt);
 
-    // Focus #bofh and wait for its scrollback to land so the initial
+    // Focus #spec-wN and wait for its scrollback to land so the initial
     // GET /messages for the autojoin channel has already fired BEFORE
     // we arm the request collector.
     await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], {
@@ -78,7 +78,7 @@ test("channel-directory — browse, no /messages fetch (#81 guard), search filte
     // scrollback for the SELECTED window, i.e. cic's listMessages hits
     // GET .../channels/%24list/messages (encodeURIComponent("$list")).
     // Record ONLY that path: an unrelated forward gap-fill on the live
-    // autojoin #bofh (.../channels/%23bofh/messages?after=...) is legitimate
+    // autojoin #spec-wN (.../channels/%23spec-wN/messages?after=...) is legitimate
     // background activity — a peer is connected and seed traffic is real —
     // NOT the regression, and under full-gate load it can fire inside this
     // window and trip a global-zero collector (the load-only flake).
@@ -143,7 +143,7 @@ test("channel-directory — browse, no /messages fetch (#81 guard), search filte
 
     // (4) Search filter: typing the unique fragment ("e2edir") routes a
     // server-side query re-GET. Only PEER_CHANNEL should match;
-    // AUTOJOIN_CHANNELS[0] (#bofh) should be absent.
+    // AUTOJOIN_CHANNELS[0] (#spec-wN) should be absent.
     await page.locator(".directory-search").fill("e2edir");
     await expect(peerRow).toBeVisible({ timeout: 5_000 });
     await expect(bofhRow).toBeHidden({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
+++ b/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
@@ -24,7 +24,7 @@ test("CP13 S10 — peer's bold-formatted PRIVMSG renders with .scrollback-mirc-b
 }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
-  // awaitWsReady=false: the bootstrap-time JOIN line for #bofh has
+  // awaitWsReady=false: the bootstrap-time JOIN line for #spec-wN has
   // already arrived in the shared grappa session by the time this
   // test runs in full-suite ordering, so the helper's "wait for a
   // fresh JOIN-self line" probe times out. The selectChannel itself
@@ -34,7 +34,7 @@ test("CP13 S10 — peer's bold-formatted PRIVMSG renders with .scrollback-mirc-b
   // Gate the peer.privmsg send on cic having a LIVE per-channel WS
   // subscription, otherwise the server's PubSub broadcast for the
   // boldpeer JOIN+PRIVMSG fires before cic.subscribe.ts joins the
-  // `grappa:user:.../channel:#bofh` Phoenix topic — broadcast lands
+  // `grappa:user:.../channel:#spec-wN` Phoenix topic — broadcast lands
   // in the void, scrollback row never renders, test times out.
   // members-pane rendering vjt-grappa is the cheapest live-WS
   // signal: it requires the after_join snapshot push of

--- a/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
+++ b/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
@@ -81,7 +81,7 @@ test.describe("CP13 server-window cluster", () => {
     // {:server, nil} → persists as a :notice row on $server with
     // meta.numeric=306, severity=:ok. The row arrives on the per-
     // channel WS topic and bumps messagesUnread for $server (the
-    // currently-focused window is #bofh, not $server).
+    // currently-focused window is #spec-wN, not $server).
     //
     // (MOTD lines persist on $server too but they fire DURING session
     // bootstrap, before cicchetto's WS subscription is ready, so they

--- a/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
@@ -29,7 +29,7 @@
 //
 //   Scenario 1 — no unreads → scroll lands at bottom, no marker.
 //     Setup: spec fetches the seeded rows via REST, identifies the
-//     server_time of the last row, writes `rc:bahamut-test:#bofh = T_last`
+//     server_time of the last row, writes `rc:bahamut-test:#spec-wN = T_last`
 //     into localStorage BEFORE page load. cicchetto boots, REST loads
 //     the latest 50 rows, `getReadCursor` returns T_last, the `rows`
 //     createMemo computes `unreadCount = msgs.filter(m => m.server_time > T_last).length = 0`,

--- a/cicchetto/e2e/tests/cp14-b2-scroll-up-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b2-scroll-up-loadmore.spec.ts
@@ -1,6 +1,6 @@
 // CP14 B2 — scroll-up triggers loadMore on the focused channel.
 //
-// Production bug: server has 200 rows for #bofh, cic loads latest 50,
+// Production bug: server has 200 rows for #spec-wN, cic loads latest 50,
 // user scrolls to top, NOTHING happens — the older 150 rows are never
 // fetched. Root cause: `ScrollbackPane.tsx` `onScroll` only updates
 // the `atBottom` signal, never calls `loadMore` (which exists at
@@ -101,7 +101,7 @@ test.describe("CP14 B2 — scroll-up triggers loadMore (no end-of-history bounce
     // `restoreReadCursorToTail` in a fixture that #1078 deleted.
     const seeded = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
     const tail = seeded[seeded.length - 1];
-    if (!tail) throw new Error("cp14-b2: seeded #bofh corpus is empty");
+    if (!tail) throw new Error("cp14-b2: seeded #spec-wN corpus is empty");
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tail.id);
 
     await loginAs(page, vjt);

--- a/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
@@ -75,22 +75,22 @@ test.afterEach(async () => {
   // live. Best-effort reconnect via the same fixture; ignore failure
   // (already-connected returns :not_parked, that's fine).
   //
-  // CRITICAL: also poll the REST surface until #bofh is not merely
+  // CRITICAL: also poll the REST surface until #spec-wN is not merely
   // joined but fully MEMBERS-SEEDED. /connect spawns a fresh
   // Session.Server but autojoin is async — without settling, the next
-  // spec starts before #bofh is back and its loginAs sees a sidebar
+  // spec starts before #spec-wN is back and its loginAs sees a sidebar
   // without the autojoin row. Observed during full integration suite
   // run: skipping this poll cascaded 18 failures across m1-m9 +
   // downstream cp15-b6-* specs because every following spec inherits a
   // half-spawned Session.
   //
   // #522: `joined` is NOT a sufficient settle signal. The channels
-  // endpoint reports `joined: true` the instant #bofh enters
+  // endpoint reports `joined: true` the instant #spec-wN enters
   // `state.members` — the self-JOIN echo (event_router.ex:457) — which
   // lands BEFORE the 353/366 NAMES burst seeds the member list. Return
   // at that point and we leak a mid-stabilization session (autojoin
   // NAMES still in flight) into the immediately-following
-  // cp15-b6-part-archive-rejoin spec (#53): it PARTs #bofh, and the
+  // cp15-b6-part-archive-rejoin spec (#53): it PARTs #spec-wN, and the
   // still-arriving 353/366 races its re-JOIN's members-seeding, flaking
   // the "members pane populates" assert ~60% of the time. Settle
   // deterministically instead — only return once GET /members returns
@@ -162,7 +162,7 @@ test("CP19 T32 — /disconnect parks network + redirects to Home; Reconnect ungr
   // await, so composeSend uses `expectUnmount: true` to wait for the
   // textarea-gone signal instead of textarea-empty (which would race
   // the unmount). Draft IS cleared in the composeByChannel signal
-  // regardless — re-navigating to #bofh later shows an empty compose.
+  // regardless — re-navigating to #spec-wN later shows an empty compose.
   await composeSend(page, `/disconnect ${NETWORK_SLUG} ${PARK_REASON}`, { expectUnmount: true });
 
   // Selection redirected to Home — HomePane renders the parked

--- a/cicchetto/e2e/tests/cp15-b6-part-archive-rejoin.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-part-archive-rejoin.spec.ts
@@ -6,14 +6,14 @@
 // invariant — folded in at the bottom of this spec. b4 deleted.
 //
 // Asserts the full archive lifecycle:
-//   1. PART a joined channel (#bofh, the seeded autojoin) → :parted
+//   1. PART a joined channel (#spec-wN, the seeded autojoin) → :parted
 //      effect → channel leaves active sidebar + appears in Archive.
 //   2. Open the grouped ArchiveModal + expand the network's group →
 //      lazy archive REST fetch → entry visible.
 //   3. Click archive entry → ScrollbackPane opens for the parted
 //      channel (read-only window — TopicBar still shows the name) and
 //      the modal closes.
-//   4. Type `/join #bofh` in compose → state goes pending → joined.
+//   4. Type `/join #spec-wN` in compose → state goes pending → joined.
 //      Sidebar entry returns to the active section (channelsBySlug
 //      branch); the archive entry MUST NOT re-appear in the archive
 //      (BUG-A regression guard — the cic-side `visibleArchiveForNetwork`
@@ -26,7 +26,7 @@
 //      appears there — `Scrollback.list_archive/3` filters $server out
 //      regardless of active_keyset.
 //
-// Cleanup: re-JOIN (assertion path itself) leaves #bofh in the
+// Cleanup: re-JOIN (assertion path itself) leaves #spec-wN in the
 // joined state, matching the seed → no afterEach restoration needed.
 // The PART side-effect on autojoin survives across runs otherwise.
 
@@ -45,7 +45,7 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.afterEach(async () => {
-  // Defensive restore — if the re-join assertion failed, #bofh would
+  // Defensive restore — if the re-join assertion failed, #spec-wN would
   // be left parted and subsequent specs that assume the seed state
   // (M1, BUG7) would fail.
   const vjt = specUser();
@@ -120,9 +120,9 @@ test("CP15 B6 — PART → archive → re-join: row moves from active to archive
   // active_keyset state — Scrollback.list_archive/3 filters $server out
   // unconditionally. Pin the rule here so a future regression in that
   // filter surfaces in e2e too. Verify with a POPULATED group: re-PART
-  // #bofh with the modal still open — the archive_changed broadcast
+  // #spec-wN with the modal still open — the archive_changed broadcast
   // reactively refreshes the already-expanded group (loadArchive re-fires),
-  // so #bofh reappears WITHOUT re-expanding, while $server never does.
+  // so #spec-wN reappears WITHOUT re-expanding, while $server never does.
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, { timeout: 5_000 });
   await expect(regroup.locator(".archive-modal-row", { hasText: CHANNEL })).toHaveCount(1, {

--- a/cicchetto/e2e/tests/freshness-on-activation.spec.ts
+++ b/cicchetto/e2e/tests/freshness-on-activation.spec.ts
@@ -12,7 +12,7 @@
 // rows stayed invisible until a full app reload. Verbatim user report on #159.
 //
 // The gap is opened with `__cic_suppressChannelDeliveryForTests` (subscribe.ts):
-// it silences `phx.on("event")` for #bofh's topic ONLY, leaving the socket and
+// it silences `phx.on("event")` for #spec-wN's topic ONLY, leaving the socket and
 // every other channel live. Both tests assert the RENDERED message row appears
 // after activation (never a fetch spy, never after a reload) — the user-visible
 // contract. RED against pre-fix code (row never appears without reload) → GREEN
@@ -30,7 +30,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // under full-gate load a residual `msg-159-*-during-gap` row persisted by a
 // PRIOR execution of this spec (a Playwright retry, or a slow `_vjtReset`
 // truncate that lost the DB-lock race under #506/#539 contention) can survive
-// into this run's #bofh scrollback and satisfy the `hasText` substring,
+// into this run's #spec-wN scrollback and satisfy the `hasText` substring,
 // reddening the premise before the fix under test ever runs. A per-run UUID
 // makes THIS run's rows un-collidable with any neighbour's, so the premise
 // measures only the delivery gap it means to — never leftover state. Iso is
@@ -95,7 +95,7 @@ test("#159 — tab RE-SELECT after a socket-stays-open gap re-fetches the missed
     peer.privmsg(CHANNEL, before);
     await expect(scrollbackLine(page, "privmsg", before)).toBeVisible();
 
-    // Phase 2 — open the gap for #bofh only; the socket stays "open".
+    // Phase 2 — open the gap for #spec-wN only; the socket stays "open".
     await suppressChannelDelivery(page, NETWORK_SLUG, CHANNEL);
 
     // Phase 3 — peer posts during the gap. Server persists + broadcasts;
@@ -109,7 +109,7 @@ test("#159 — tab RE-SELECT after a socket-stays-open gap re-fetches the missed
     await expect(scrollbackLine(page, "privmsg", during)).toHaveCount(0);
 
     // Phase 4 — re-activate WITHOUT reload: switch to the server window and
-    // back to #bofh. The selection effect fires refreshScrollback for the
+    // back to #spec-wN. The selection effect fires refreshScrollback for the
     // re-activated channel (#159 item 1); loadInitialScrollback is a no-op
     // (load-once gate). The resume cursor is the Phase-1 high-water mark, so
     // `?after=<that id>` fetches the gap row and appends it (id-deduped).

--- a/cicchetto/e2e/tests/i2b-image-upload-litterbox-host.spec.ts
+++ b/cicchetto/e2e/tests/i2b-image-upload-litterbox-host.spec.ts
@@ -13,7 +13,7 @@
 //   2. page.route() stubs the catbox multipart POST — no real
 //      network egress (cic's browser is sandboxed; the stub mirrors
 //      the original I-2 design pre-B2).
-//   3. Operator joined to #bofh, picker → modal (`Upload to
+//   3. Operator joined to #spec-wN, picker → modal (`Upload to
 //      litterbox.catbox.moe`) → Continue → upload completes →
 //      PRIVMSG auto-send → server echo → linkify.
 //   4. afterEach resets the active_host to "embedded" so subsequent

--- a/cicchetto/e2e/tests/ios-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ios-z-cluster-journey.spec.ts
@@ -21,7 +21,7 @@
 //     resolves to 0 here. The assertion confirms the CSS rule didn't
 //     break the layout (top-bar stays in-bounds); the real notch-clearance
 //     evidence is browser-smoke screenshots from a notched iPhone shape.
-//   * iOS-3 bottom-bar close × — open #bofh tab → tap × → tab gone
+//   * iOS-3 bottom-bar close × — open #spec-wN tab → tap × → tab gone
 //     (mirror of `ios-3-bottom-bar-close.spec.ts`).
 //   * iOS-4 font-size — open settings → pick XL → reload → still XL +
 //     `--font-size = 18px` (mirror of `ios-4-font-size.spec.ts`).
@@ -47,12 +47,12 @@ import { joinChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #spec-wN
 
 // GREEN-CI batch 2 — iOS-3 arm below taps the close × which PARTs vjt
-// from #bofh on the bouncer. Without restoration, downstream
+// from #spec-wN on the bouncer. Without restoration, downstream
 // webkit-iphone-15 specs (ux-2-mobile-archive runs next alphabetically)
-// can't selectChannel(#bofh) — the tab is gone, locator times out at
+// can't selectChannel(#spec-wN) — the tab is gone, locator times out at
 // 30s. Re-join via REST in afterEach so the autojoin steady state
 // returns before the next spec.
 test.afterEach(async () => {

--- a/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
@@ -22,7 +22,7 @@
 // that is not currently connected coming back up, surfaced to the user.
 //
 // CLEANUP: afterEach reconnects the network (best-effort) and polls
-// GET /channels until autojoin restores #bofh — same discipline as
+// GET /channels until autojoin restores #spec-wN — same discipline as
 // cp15-b6-parked-disconnect-reconnect so the next spec inherits a live
 // session.
 
@@ -40,7 +40,7 @@ const PARK_REASON = "testing reconnect badge #100";
 test.setTimeout(90_000);
 
 test.afterEach(async () => {
-  // Best-effort reconnect + poll #bofh back to joined so a mid-run
+  // Best-effort reconnect + poll #spec-wN back to joined so a mid-run
   // failure doesn't leave the network parked for the next spec (same
   // rationale as cp15-b6-parked-disconnect-reconnect).
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
@@ -135,7 +135,8 @@ test.describe("#1019 — leaving a far-behind window marks it read", () => {
 
     const lastReadRow = rows[rows.length - UNREAD_TARGET];
     const tailRow = rows[rows.length - 1];
-    if (!lastReadRow || !tailRow) throw new Error("#1019 spec: seeded #bofh rows missing an index");
+    if (!lastReadRow || !tailRow)
+      throw new Error("#1019 spec: seeded #spec-wN rows missing an index");
 
     // Guard the precondition: below this the pane never goes far behind and
     // the spec would pass by testing nothing.
@@ -165,7 +166,7 @@ test.describe("#1019 — leaving a far-behind window marks it read", () => {
     expect(await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL)).toBe(lastReadRow.id);
 
     // THE gesture. The server window shares the `kindHasScrollback` Match with
-    // channels, so the pane stays mounted and the key arm fires with #bofh as
+    // channels, so the pane stays mounted and the key arm fires with #spec-wN as
     // the LEAVING key — a real selection change through the sidebar, not a
     // direct call to the dismiss.
     await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });

--- a/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
+++ b/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
@@ -36,7 +36,7 @@ import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage"
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #spec-wN — the per-spec autojoin channel
 
 test("#1040 — the home rail lays its actions out expanded, in flow, with no launcher", async ({
   page,

--- a/cicchetto/e2e/tests/issue1062-far-behind-float-stack.spec.ts
+++ b/cicchetto/e2e/tests/issue1062-far-behind-float-stack.spec.ts
@@ -86,7 +86,7 @@ test.describe("#1062 — the far-behind gesture is the bar's × and nothing else
     expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
 
     const lastReadRow = rows[rows.length - UNREAD_TARGET];
-    if (!lastReadRow) throw new Error("#1062 spec: seeded #bofh rows missing cursor index");
+    if (!lastReadRow) throw new Error("#1062 spec: seeded #spec-wN rows missing cursor index");
     const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
     // Guard the precondition: below this the pane never goes far behind and
     // the spec would pass by testing nothing.

--- a/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
+++ b/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
@@ -47,8 +47,8 @@
 // scrollTop does NOT change while the content does). The divider's on-screen
 // offset is the pixel the reader actually looks at.
 //
-// Harness mirrors scroll-on-window-switch scenario 3 (warm #bofh in the
-// background, focus $server, then click #bofh — a real key-change SWITCH) and
+// Harness mirrors scroll-on-window-switch scenario 3 (warm #spec-wN in the
+// background, focus $server, then click #spec-wN — a real key-change SWITCH) and
 // the #625 in-page sampler (a rAF loop, because case 2 is one frame wide and any
 // post-hoc snapshot false-greens).
 
@@ -250,7 +250,7 @@ test.describe("issue #1089 — switching into an unread window must not flicker"
     await delayMessageFetches(page, POST_SWITCH_LATENCY_MS);
     await installFlickerProbe(page, SAMPLE_WINDOW_MS);
 
-    // THE SWITCH — a real key-change from $server to #bofh.
+    // THE SWITCH — a real key-change from $server to #spec-wN.
     await sidebarWindow(page, NETWORK_SLUG, CHANNEL).locator(".sidebar-window-btn").click();
 
     await expect
@@ -335,7 +335,7 @@ async function seedMidPageCursor(token: string, channel: string): Promise<void> 
 }
 
 // Warmth gate: cic eagerly refreshes every joined channel on its Phoenix
-// join-ok, so #bofh loads in the background without us focusing it. A cold
+// join-ok, so #spec-wN loads in the background without us focusing it. A cold
 // switch would early-return in `scrollToActivation` (empty pane) and never arm
 // the path under test.
 //
@@ -349,8 +349,8 @@ async function warmUpChannel(page: Page, channel: string): Promise<void> {
   await waitForScrollbackRefreshed(page, NETWORK_SLUG, channel);
 }
 
-// FROM-window: the $server tab mounts ScrollbackPane WITHOUT touching #bofh's
-// read cursor (focusing #bofh first would fire the leave-arm and advance the
+// FROM-window: the $server tab mounts ScrollbackPane WITHOUT touching #spec-wN's
+// read cursor (focusing #spec-wN first would fire the leave-arm and advance the
 // cursor to the tail, erasing the unread under test).
 async function parkOnServerWindow(page: Page): Promise<void> {
   await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });

--- a/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
+++ b/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
@@ -15,7 +15,7 @@
 //
 // e2e shape (per feedback_ux_e2e_mandatory + feedback_cicchetto_browser_smoke
 // — jsdom can't prove the real compose → REST → self-echo → WS → render
-// round-trip): type `/me <tag>` into the focused #bofh composer, then
+// round-trip): type `/me <tag>` into the focused #spec-wN composer, then
 // assert BOTH the REST-persisted kind AND the rendered action row, plus
 // the negative invariant that no privmsg row carries the same tag.
 

--- a/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
+++ b/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
@@ -33,7 +33,7 @@ test("issue142 — QUIT reason renders mIRC bold+color spans (not raw control by
   await selectChannel(page, NETWORK_SLUG, TEST_CHANNEL, { awaitWsReady: false });
 
   // Live per-channel WS gate: the QUIT PubSub broadcast must land after
-  // cic has joined the `grappa:user:.../channel:#bofh` Phoenix topic, or
+  // cic has joined the `grappa:user:.../channel:#spec-wN` Phoenix topic, or
   // the row never renders. members-pane rendering vjt-grappa is the
   // cheapest live-WS signal (see cp13-s10 rationale).
   await expect(page.locator(".members-pane li", { hasText: specNick() })).toBeVisible({

--- a/cicchetto/e2e/tests/issue16-keyed-join-members-seed.spec.ts
+++ b/cicchetto/e2e/tests/issue16-keyed-join-members-seed.spec.ts
@@ -24,7 +24,7 @@
 // directly in `.shell-members .members-pane`, no mobile drawer.
 //
 // CLEANUP: the wrapped `test` fixture auto-resets vjt after every spec
-// (restores autojoin to ["#bofh"], clears last_joined, restarts the
+// (restores autojoin to ["#spec-wN"], clears last_joined, restarts the
 // session) — so the dynamically-joined NEW_CHANNEL is dropped for free.
 // afterEach only tears down the peer.
 

--- a/cicchetto/e2e/tests/issue161-forward-paging.spec.ts
+++ b/cicchetto/e2e/tests/issue161-forward-paging.spec.ts
@@ -49,7 +49,7 @@ import { expect, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-// Re-seed #bofh with a corpus LARGER than the 200-row server cap so the
+// Re-seed #spec-wN with a corpus LARGER than the 200-row server cap so the
 // planted early cursor leaves > 200 unread — the exact condition under which
 // #693 abandons the cursor anchor and lands at the tail instead.
 const LARGE_SEED_COUNT = 260;
@@ -71,7 +71,7 @@ test.describe("#161/#693 — a gap larger than one page opens at the tail, not t
     const vjt = specUser();
     const admin = getSeededAdmin();
 
-    // Re-seed #bofh with > 200 rows. resetSubject truncates then re-seeds
+    // Re-seed #spec-wN with > 200 rows. resetSubject truncates then re-seeds
     // `seedCount` synthetic privmsgs and re-JOINs the channel (own-nick JOIN
     // lands as the max id row after the seed).
     await resetSubject(
@@ -92,7 +92,7 @@ test.describe("#161/#693 — a gap larger than one page opens at the tail, not t
     // one page.
     const cursorIndex = rows.length - 240;
     const lastReadRow = rows[cursorIndex];
-    if (!lastReadRow) throw new Error("#161 spec: seeded #bofh rows missing cursor index");
+    if (!lastReadRow) throw new Error("#161 spec: seeded #spec-wN rows missing cursor index");
     const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
     // Guard the condition under test.
     expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -22,7 +22,7 @@
 //
 // ## What this spec pins
 //
-// Seed a mid-page read cursor on `#bofh` (25 rows from the tail) so an
+// Seed a mid-page read cursor on `#spec-wN` (25 rows from the tail) so an
 // unread divider is present on first focus. Then SEND a line and assert:
 //   (a) the pane is pinned at the BOTTOM (distance-to-tail <= threshold),
 //   (b) the just-sent line is IN the viewport (did NOT jump to the marker),

--- a/cicchetto/e2e/tests/issue188-mentions-panel-polish.spec.ts
+++ b/cicchetto/e2e/tests/issue188-mentions-panel-polish.spec.ts
@@ -2,7 +2,7 @@
 // clear-on-away lifecycle.
 //
 // This drives the REAL server path end to end — no synthetic bundle:
-//   1. operator joins two channels (#bofh autojoin + a fresh #m188)
+//   1. operator joins two channels (#spec-wN autojoin + a fresh #m188)
 //   2. operator goes `/away`
 //   3. a peer PRIVMSGs the operator's nick into BOTH channels while away
 //   4. operator comes back (bare `/away`) → server's
@@ -27,14 +27,14 @@ import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const PEER_NICK = "m188-peer";
-const CHANNEL_A = AUTOJOIN_CHANNELS[0]; // "#bofh" — already joined at login
+const CHANNEL_A = AUTOJOIN_CHANNELS[0]; // "#spec-wN" — already joined at login
 const CHANNEL_B = "#m188"; // fresh channel this operator joins
 const AWAY_REASON = "lunch break";
 // Bodies mention the operator's nick at a word boundary so the server's
 // mention aggregation (own-nick regex) matches them. A per-invocation
 // `runId` suffix is LOAD-BEARING, not cosmetic: `#m188` is NOT in the
 // seeded autojoin set, so the wrapped `test` fixture's `_vjtReset`
-// (which truncates + reseeds only AUTOJOIN_CHANNELS = #bofh) leaves
+// (which truncates + reseeds only AUTOJOIN_CHANNELS = #spec-wN) leaves
 // prior-iteration `ping in m188` rows in #m188's scrollback. With a
 // constant body, the `scrollbackLine(...).first()` wait below would
 // match a STALE row and false-pass WITHOUT the fresh BODY_B having
@@ -70,10 +70,10 @@ test("#188 — away mentions panel: grouped restyle, open-button, close-x, clear
     await peer.join(CHANNEL_A);
     await peer.join(CHANNEL_B);
 
-    // Highlight in #bofh FIRST (focus it so the live push renders, which
+    // Highlight in #spec-wN FIRST (focus it so the live push renders, which
     // confirms the row persisted server-side before we unaway). Ordering
     // A-then-B makes the aggregated bundle deterministic (server_time ASC),
-    // so the groups render #bofh then #m188.
+    // so the groups render #spec-wN then #m188.
     await selectChannel(page, NETWORK_SLUG, CHANNEL_A, { awaitWsReady: false });
     peer.privmsg(CHANNEL_A, bodyA);
     await expect(scrollbackLine(page, "privmsg", `ping in bofh ${runId}`).first()).toBeVisible({
@@ -111,7 +111,7 @@ test("#188 — away mentions panel: grouped restyle, open-button, close-x, clear
     await expect(page.getByTestId("mentions-list")).toBeVisible();
 
     // Rows are clickable and jump to the source channel window (item 3 /
-    // C8.2). Click the #bofh row → panel closes, the #bofh window shows.
+    // C8.2). Click the #spec-wN row → panel closes, the #spec-wN window shows.
     const bofhRow = page
       .getByTestId("mentions-group")
       .filter({ hasText: CHANNEL_A })
@@ -136,7 +136,7 @@ test("#188 — away mentions panel: grouped restyle, open-button, close-x, clear
 
     // Clear-on-away lifecycle (item 7): going /away again drops the bundle,
     // so the Sidebar mentions row (gated on bundle existence) disappears.
-    // We're back on the #bofh window (close-x restored it), which has a
+    // We're back on the #spec-wN window (close-x restored it), which has a
     // compose box.
     await expect(mentionsRow).toBeVisible();
     await composeSend(page, "/away second time");

--- a/cicchetto/e2e/tests/issue195-leave-confirm-modal.spec.ts
+++ b/cicchetto/e2e/tests/issue195-leave-confirm-modal.spec.ts
@@ -19,7 +19,7 @@
 // The channel test uses a DEDICATED non-autojoin channel so it never
 // destabilises the shared seed #bofh; the network test parks the shared
 // network and the afterEach reconnects it (same pattern as
-// cp15-b6-parked-disconnect-reconnect), polling until autojoin restores #bofh.
+// cp15-b6-parked-disconnect-reconnect), polling until autojoin restores #spec-wN.
 
 import {
   confirmModal,
@@ -53,7 +53,7 @@ test.afterEach(async () => {
   // Idempotent cleanup, best-effort (both tolerate already-in-state):
   //   1. Drop the dedicated leave-channel in case a test failed pre-Yes.
   //   2. Reconnect the shared network in case the network test parked it,
-  //      then poll #bofh back to joined so the next serial spec inherits a
+  //      then poll #spec-wN back to joined so the next serial spec inherits a
   //      live session (skipping the poll cascades failures — see cp15-b6).
   await partChannel(vjt.token, NETWORK_SLUG, LEAVE_CHANNEL).catch(() => {});
   await patchNetworkConnectionState(vjt.token, NETWORK_SLUG, {

--- a/cicchetto/e2e/tests/issue196-preview-scroll-live-arrival.spec.ts
+++ b/cicchetto/e2e/tests/issue196-preview-scroll-live-arrival.spec.ts
@@ -4,7 +4,7 @@
 // The original #196 fix (14daadce) snapshots the scroll container's scrollTop on
 // the overlay open edge and re-asserts it on close. Its e2e
 // (issue196-preview-scroll-preserve.spec.ts) opens+closes on a QUIET, fully-read
-// #bofh and passes — because nothing perturbs the scroll while the overlay is up.
+// #spec-wN and passes — because nothing perturbs the scroll while the overlay is up.
 //
 // A LIVE channel does perturb it: a message arriving while the preview is open
 // mutates messages() → rows() recomputes → the ref-keyed <For> RECREATES the
@@ -22,7 +22,7 @@
 //
 // Desktop project only (untagged → chromium): desktop Chrome reproduces desktop
 // scroll physics (feedback_playwright_webkit_not_ios_scroll). Modelled on the
-// #196 + #219-general harness: seeded #bofh (200 lines → tall pane), a live
+// #196 + #219-general harness: seeded #spec-wN (200 lines → tall pane), a live
 // IrcPeer for the in-overlay arrival, deterministic scroll via evaluate, overlay
 // opened by the anchor's OWN real click on a VISIBLE mid-list image.
 

--- a/cicchetto/e2e/tests/issue196-preview-scroll-preserve.spec.ts
+++ b/cicchetto/e2e/tests/issue196-preview-scroll-preserve.spec.ts
@@ -12,7 +12,7 @@
 // scroll physics, unlike webkit-iPhone emulation
 // (feedback_playwright_webkit_not_ios_scroll).
 //
-// Uses the seeded #bofh (200 lines → a genuinely tall, scrollable pane) so no
+// Uses the seeded #spec-wN (200 lines → a genuinely tall, scrollable pane) so no
 // live message flood is needed — a flood risks IRC flood-protection killing the
 // sender AND leaves the pane auto-scrolling, which is what hung the first
 // version. Scroll is driven DETERMINISTICALLY via evaluate to a middle
@@ -38,7 +38,7 @@ test("#196 — opening the image preview keeps the message-list scroll position 
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // Upload an image so the scrollback carries a clickable media link. #bofh is
+  // Upload an image so the scrollback carries a clickable media link. #spec-wN is
   // seeded with 200 lines, so the pane is already tall enough to scroll — the
   // image lands at the tail (its exact position is irrelevant: it's opened via
   // el.click() below, not by scrolling to it).

--- a/cicchetto/e2e/tests/issue200-ws-sub-teardown.spec.ts
+++ b/cicchetto/e2e/tests/issue200-ws-sub-teardown.spec.ts
@@ -56,7 +56,7 @@ const joinedTopicKeys = (page: import("@playwright/test").Page): Promise<string[
   );
 
 test.afterEach(async () => {
-  // Restore the seed state — if the assertion path left #bofh parted,
+  // Restore the seed state — if the assertion path left #spec-wN parted,
   // downstream specs that assume the autojoin seed (M1, BUG7, …) would fail.
   const vjt = specUser();
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
@@ -95,7 +95,7 @@ test("#200 — after own-PART teardown, compose /join re-subscribes AND focuses 
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await expect.poll(() => joinedTopicKeys(page), { timeout: 10_000 }).toContain(TOPIC_KEY);
 
-  // PART #bofh → subscription torn down, channel leaves the sidebar.
+  // PART #spec-wN → subscription torn down, channel leaves the sidebar.
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, { timeout: 10_000 });
   await expect.poll(() => joinedTopicKeys(page), { timeout: 10_000 }).not.toContain(TOPIC_KEY);

--- a/cicchetto/e2e/tests/issue217-timestamp-format.spec.ts
+++ b/cicchetto/e2e/tests/issue217-timestamp-format.spec.ts
@@ -3,7 +3,7 @@
 // open scrollback live (the format is a Solid signal, not a boot-time DOM
 // write), and the choice persists across a reload (localStorage).
 //
-// Desktop project (untagged → chromium). Uses the seeded #bofh scrollback so
+// Desktop project (untagged → chromium). Uses the seeded #spec-wN scrollback so
 // there is always at least one message row carrying a `.scrollback-time` cell.
 
 import {
@@ -34,7 +34,7 @@ test("#217 — timestamp format defaults to seconds, toggles live from Settings,
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // At least one message row is present (seeded #bofh).
+  // At least one message row is present (seeded #spec-wN).
   await expect.poll(async () => await scrollbackLines(page).count()).toBeGreaterThan(0);
 
   // Default (no stored preference) → WITH seconds.

--- a/cicchetto/e2e/tests/issue219-general-overlay-scroll-hold.spec.ts
+++ b/cicchetto/e2e/tests/issue219-general-overlay-scroll-hold.spec.ts
@@ -20,7 +20,7 @@
 // scrollToActivation("tail-only") authority the mobile visualViewport change
 // fires (feedback_playwright_webkit_not_ios_scroll — the real iOS path can't
 // be emulated, but the authority is window-level). Modelled on the #196/#219
-// harness: seeded #bofh (200 lines → tall pane), deterministic mid-list
+// harness: seeded #spec-wN (200 lines → tall pane), deterministic mid-list
 // scroll via evaluate, and the modal driven by the /names command.
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";

--- a/cicchetto/e2e/tests/issue219-overlay-scroll-hold.spec.ts
+++ b/cicchetto/e2e/tests/issue219-overlay-scroll-hold.spec.ts
@@ -23,7 +23,7 @@
 // the mobile visualViewport-change fires — feedback_playwright_webkit_not_ios_
 // scroll means the real iOS path can't be emulated, but the authority is
 // window-level so a plain resize exercises it). Mirrors #196's harness: seeded
-// #bofh (200 lines → tall pane), deterministic mid-list scroll via evaluate, and
+// #spec-wN (200 lines → tall pane), deterministic mid-list scroll via evaluate, and
 // the anchor's OWN click to open the overlay without a Playwright scroll-into-
 // view.
 //
@@ -49,7 +49,7 @@ test("#219 — a resize while the image viewer is open must NOT snap the list to
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // Upload an image so the scrollback carries a clickable media link. #bofh is
+  // Upload an image so the scrollback carries a clickable media link. #spec-wN is
   // seeded with 200 lines → the pane is genuinely tall and scrollable.
   const { slug } = await uploadViaPicker(
     page,

--- a/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
+++ b/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
@@ -5,7 +5,7 @@
 //
 // This e2e is the interactive witness for the per-channel toggle + the
 // render-layer filter + localStorage persistence. It exercises REAL presence
-// events (a peer joins + parts #bofh) — NOT LARGE_CHANNEL_THRESHOLD spawned
+// events (a peer joins + parts #spec-wN) — NOT LARGE_CHANNEL_THRESHOLD spawned
 // peers: that many nicks from one IP risks bahamut flood/autokill
 // (feedback_e2e_multinet_live_needs_distinct_nicks), and there is no
 // window-exposed member-count seam in the e2e harness to inflate membership.
@@ -42,7 +42,7 @@ test("#222 — per-channel toggle hides join/part rows, persists across reload, 
   const channel = AUTOJOIN_CHANNELS[0];
   await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
 
-  // A dedicated peer produces REAL join + part presence events on #bofh.
+  // A dedicated peer produces REAL join + part presence events on #spec-wN.
   // Distinct single nick — no flood risk. try/finally tears it down.
   const peerNick = "pres222peer";
   const peer = await IrcPeer.connect({ nick: peerNick });

--- a/cicchetto/e2e/tests/issue230-mobile-touch-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-mobile-touch-underfill-loadmore.spec.ts
@@ -111,7 +111,7 @@ async function synthTouchDrag(page: Page, startY: number, endY: number): Promise
 async function seedCursorToHead(token: string, channel: string): Promise<void> {
   const asc = await fetchAllMessagesAsc(token, NETWORK_SLUG, channel);
   const head = asc[asc.length - 1];
-  if (!head) throw new Error("#bofh seed corpus empty — cannot seed read cursor to head");
+  if (!head) throw new Error("#spec-wN seed corpus empty — cannot seed read cursor to head");
   await setReadCursorToId(token, NETWORK_SLUG, channel, head.id);
 }
 

--- a/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
@@ -91,7 +91,7 @@ test.describe("issue #230 — wheel-up loads older history when content underfil
     const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const headId = headPage[0]?.id;
-    if (!headId) throw new Error("#bofh seed page empty — cannot seed read cursor to head");
+    if (!headId) throw new Error("#spec-wN seed page empty — cannot seed read cursor to head");
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, headId);
 
     await loginAs(page, vjt);

--- a/cicchetto/e2e/tests/issue231-lusers-current-window.spec.ts
+++ b/cicchetto/e2e/tests/issue231-lusers-current-window.spec.ts
@@ -15,7 +15,7 @@
 // old gated code this fails — the card only exists on kind==="server".
 //
 // Full path exercised:
-//   1. operator focused on a channel window (#bofh, seed-autojoined)
+//   1. operator focused on a channel window (#spec-wN, seed-autojoined)
 //   2. operator issues `/lusers` via composeSend
 //   3. Bahamut replies with the 7-numeric LUSERS sequence; 266
 //      RPL_GLOBALUSERS flushes the `:lusers_bundle` wire event
@@ -41,7 +41,7 @@ test("#231 — /lusers surfaces LusersCard in the CURRENT (channel) window, not 
   const vjt = specUser();
   await loginAs(page, vjt);
 
-  // Focus a CHANNEL window (seed-autojoined #bofh) — deliberately NOT
+  // Focus a CHANNEL window (seed-autojoined #spec-wN) — deliberately NOT
   // the $server window. This is the anti-regression pivot: the old
   // `kind === "server"` gate would leave the card unmounted here.
   const channel = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
+++ b/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
@@ -13,9 +13,9 @@
 //
 // Seeding produces exactly two unread windows on the seeded network:
 //   * a DM (query) window  → TIER 0 (a PM), even though it arrives LAST
-//   * #bofh ordinary line   → TIER 1 (plain channel traffic)
+//   * #spec-wN ordinary line   → TIER 1 (plain channel traffic)
 // so the tier precedence (DM before channel, regardless of arrival
-// order) is the thing under test. One peer drives both: it JOINs #bofh
+// order) is the thing under test. One peer drives both: it JOINs #spec-wN
 // and sends a plain line, then PRIVMSGs the operator's nick to open the
 // DM. Neither window is focused when the activity lands (focus parks on
 // the neutral $server window), so both accrue unread.
@@ -39,8 +39,8 @@ const DM_LINE = "235 direct message";
 const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
 const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
 
-// Drive: read #bofh (clears its baseline unread), park focus on the
-// neutral $server window, then have `peer` produce one tier-1 (#bofh
+// Drive: read #spec-wN (clears its baseline unread), park focus on the
+// neutral $server window, then have `peer` produce one tier-1 (#spec-wN
 // plain line) and one tier-0 (DM) unread window. Returns the connected
 // peer so the caller can disconnect it. Asserts the seeding landed
 // (both windows unread) BEFORE returning, so a seeding failure is
@@ -50,9 +50,9 @@ async function seedTwoTierUnread(
   token: string,
   peerNick: string,
 ): Promise<IrcPeer> {
-  // Clear #bofh's baseline unread by focusing it (cursor baselines to
+  // Clear #spec-wN's baseline unread by focusing it (cursor baselines to
   // tail), then park focus on $server — a window that is NOT in the
-  // channel/query cycle — so #bofh and the DM both stay unfocused.
+  // channel/query cycle — so #spec-wN and the DM both stay unfocused.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
   // The own-nick DM topic must be subscribed before the peer DMs, or

--- a/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
+++ b/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
@@ -51,7 +51,7 @@ const SERVER_WINDOW = "Server";
 const PEER_NICK = "i239peer";
 const WITNESS = "issue-239-visible-witness";
 
-// Cursor was advanced mid-test (open #bofh → read). Restore to tail so
+// Cursor was advanced mid-test (open #spec-wN → read). Restore to tail so
 // downstream specs inherit a clean at-tail cursor (BUGHUNT-3 cascade rule).
 test.afterEach(async () => {
   const vjt = specUser();
@@ -64,12 +64,12 @@ test("#239 — hidden control message does NOT bump the unread badge; reading cl
   const vjt = specUser();
   await loginAs(page, vjt);
 
-  // Focus #bofh first so its per-channel WS topic is subscribed (the badge
+  // Focus #spec-wN first so its per-channel WS topic is subscribed (the badge
   // only updates live for a subscribed channel — see M2). ownNick sync waits
   // for the auto-joined self-JOIN line, proving REST + WS both landed.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // Pin #bofh to HIDE presence via the production toggle (no need to seed
+  // Pin #spec-wN to HIDE presence via the production toggle (no need to seed
   // LARGE_CHANNEL_THRESHOLD members — the size-default math is unit-tested;
   // this is the interactive hide path). #500 folded the denoise toggle behind
   // the rail launcher menu;
@@ -87,7 +87,7 @@ test("#239 — hidden control message does NOT bump the unread badge; reading cl
   // peer traffic we are about to generate.
   await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
 
-  // Defocus to the Server window so #bofh's badges are observable (a focused +
+  // Defocus to the Server window so #spec-wN's badges are observable (a focused +
   // visible window suppresses its own badge — decouple-unread-badge). Server
   // has no compose, so it can't produce client chatter that races the assert.
   await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
@@ -110,7 +110,7 @@ test("#239 — hidden control message does NOT bump the unread badge; reading cl
     //    "1" and could never be cleared by reading (the join never renders).
     await expect(sidebarEventsBadge(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0);
 
-    // 3. Reading clears the counter. Open #bofh — presence stays hidden, so the
+    // 3. Reading clears the counter. Open #spec-wN — presence stays hidden, so the
     //    own-JOIN line is suppressed; wait on the VISIBLE witness privmsg as the
     //    pane-ready signal instead of the (hidden) join line.
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
@@ -121,7 +121,7 @@ test("#239 — hidden control message does NOT bump the unread badge; reading cl
     ).toBeVisible({ timeout: 10_000 });
 
     // Leave the window — the read cursor advances over the visible privmsg the
-    // operator saw. Back on Server, #bofh's badges are observable again.
+    // operator saw. Back on Server, #spec-wN's badges are observable again.
     await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
 
     // 4. Both badges are clear and STAY clear — the message was read, the

--- a/cicchetto/e2e/tests/issue245-scroll-remeasure-on-resize.spec.ts
+++ b/cicchetto/e2e/tests/issue245-scroll-remeasure-on-resize.spec.ts
@@ -46,8 +46,8 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // overflows there) but FEWER than the real device viewport can show (so it
 // does NOT overflow at cold mount). The default 200-row seed overflows even
 // the real viewport, which would make the not-overflowing baseline
-// unreachable — so re-seed #bofh to a small corpus for this spec. The
-// wrapped `test` fixture's afterEach truncates #bofh back to the 200-row
+// unreachable — so re-seed #spec-wN to a small corpus for this spec. The
+// wrapped `test` fixture's afterEach truncates #spec-wN back to the 200-row
 // baseline, so no manual cleanup is needed (same verb issue161 uses).
 // COUPLING: this count MUST stay small enough that the rows do NOT overflow
 // the `webkit-iphone-15` project viewport (393×659) — the not-overflowing
@@ -92,7 +92,7 @@ test("@webkit #245 — .scrollback re-measures overflow (touch-action) on visual
   const admin = getSeededAdmin();
   const vjt = specUser();
 
-  // Re-seed #bofh to a SMALL corpus so it does NOT overflow the real device
+  // Re-seed #spec-wN to a SMALL corpus so it does NOT overflow the real device
   // viewport (the not-overflowing baseline) but WILL overflow a
   // keyboard-shrunk viewport.
   await resetSubject(

--- a/cicchetto/e2e/tests/issue248-lusers-no-auto-surface.spec.ts
+++ b/cicchetto/e2e/tests/issue248-lusers-no-auto-surface.spec.ts
@@ -51,7 +51,7 @@ const PARK_REASON = "testing #248 lusers auto-surface";
 test.setTimeout(90_000);
 
 test.afterEach(async () => {
-  // Best-effort restore: reconnect + poll #bofh back to joined so a
+  // Best-effort restore: reconnect + poll #spec-wN back to joined so a
   // mid-run failure doesn't leave the network parked for the next spec
   // (same discipline as issue100-reconnecting-badge).
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts
+++ b/cicchetto/e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts
@@ -101,7 +101,7 @@ test.describe("#253 — keyboard/viewport resize must not yank a scrolled-up rea
 
     const sc = page.getByTestId("scrollback");
 
-    // #bofh seeds 200 lines → the pane overflows. Park the reader UP in history
+    // #spec-wN seeds 200 lines → the pane overflows. Park the reader UP in history
     // (well above the tail) so `atBottom()` is false — the case the bug yanks.
     //
     // `atBottom` flips false ONLY on a real scroll-UP: production `onScroll`
@@ -119,7 +119,7 @@ test.describe("#253 — keyboard/viewport resize must not yank a scrolled-up rea
         el.dispatchEvent(new Event("scroll"));
         // Park ABOVE the tail (atBottom=false) but BELOW the loadMore-older
         // trigger zone. #268 root cause (proven via a full-suite I253DBG dump):
-        // when #bofh renders SHORT — only the initial ~50-row REST page loaded,
+        // when #spec-wN renders SHORT — only the initial ~50-row REST page loaded,
         // so max ≈ 600px on the iPhone-15 viewport — `Math.floor(max * 0.3)`
         // lands at ~180px, INSIDE `maybeLoadOlder`'s `scrollTop <= 200` gate.
         // The scroll-up then FIRES an infinite-scroll prepend; the browser's

--- a/cicchetto/e2e/tests/issue255-close-x-touch-action.spec.ts
+++ b/cicchetto/e2e/tests/issue255-close-x-touch-action.spec.ts
@@ -39,7 +39,7 @@ import { loginAs, selectChannel, sidebarCloseButton } from "../fixtures/cicchett
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-// #bofh is autojoined → its tab renders a close-× on BOTH layouts.
+// #spec-wN is autojoined → its tab renders a close-× on BOTH layouts.
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // Read the computed `touch-action` off the close × for the given

--- a/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
+++ b/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
@@ -11,15 +11,15 @@
 //
 // Seeding produces exactly two unfocused windows on the seeded network:
 //   * a DM (query) window  → ONE inbound PRIVMSG (content)  → MUST count
-//   * #bofh                 → ONLY a peer JOIN (presence)    → MUST NOT count
-// One peer drives both: it JOINs #bofh (presence-only — deliberately NO
+//   * #spec-wN                 → ONLY a peer JOIN (presence)    → MUST NOT count
+// One peer drives both: it JOINs #spec-wN (presence-only — deliberately NO
 // channel PRIVMSG) then PRIVMSGs the operator's nick to open the DM.
 // Focus parks on the neutral $server window so neither accrues via focus.
 //
 // The event-only window is verified to have ACCRUED its event badge
 // BEFORE the count is asserted — so the RED (gate on the total) fails on
 // the COUNT VALUE ("Expected 1 Received 2"), never on a mis-seeded window
-// or a missing-locator timeout. Under the total gate #bofh's `eventsUnread`
+// or a missing-locator timeout. Under the total gate #spec-wN's `eventsUnread`
 // bumps the count to 2; under the message-scoped gate it contributes 0.
 
 import {
@@ -40,11 +40,11 @@ const DM_LINE = "265 direct message counts";
 const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
 const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
 
-// Drive: read #bofh (baselines its cursor to tail so pre-session unread
+// Drive: read #spec-wN (baselines its cursor to tail so pre-session unread
 // clears), park focus on the neutral $server window, then have `peer`
-// produce ONE event-only window (#bofh: a JOIN, NO channel PRIVMSG) and
+// produce ONE event-only window (#spec-wN: a JOIN, NO channel PRIVMSG) and
 // ONE message window (a DM). Returns the connected peer so the caller can
-// disconnect it. Asserts the seeding landed — the #bofh EVENT badge AND
+// disconnect it. Asserts the seeding landed — the #spec-wN EVENT badge AND
 // the DM MESSAGE badge — BEFORE returning, so a seeding failure is
 // pinpointed here and (crucially) the RED assertion fails on the count
 // value rather than a not-yet-accrued window.
@@ -52,9 +52,9 @@ async function seedEventOnlyAndMessageWindows(
   page: Parameters<typeof loginAs>[0],
   peerNick: string,
 ): Promise<IrcPeer> {
-  // Clear #bofh's baseline unread by focusing it (cursor baselines to
+  // Clear #spec-wN's baseline unread by focusing it (cursor baselines to
   // tail), then park focus on $server — a window that is NOT in the
-  // channel/query cycle — so #bofh and the DM both stay unfocused.
+  // channel/query cycle — so #spec-wN and the DM both stay unfocused.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
   // The own-nick DM topic must be subscribed before the peer DMs, or the
@@ -63,11 +63,11 @@ async function seedEventOnlyAndMessageWindows(
 
   const peer = await IrcPeer.connect({ nick: peerNick });
 
-  // Event-only window — a peer JOIN into #bofh (the operator is in it, so
-  // the JOIN persists + fans out on the per-channel topic while #bofh is
-  // unfocused). #bofh is tiny (< LARGE_CHANNEL_THRESHOLD) so the JOIN is
+  // Event-only window — a peer JOIN into #spec-wN (the operator is in it, so
+  // the JOIN persists + fans out on the per-channel topic while #spec-wN is
+  // unfocused). #spec-wN is tiny (< LARGE_CHANNEL_THRESHOLD) so the JOIN is
   // VISIBLE per the presence filter → accrues `eventsUnread`. Deliberately
-  // NO channel PRIVMSG: #bofh carries ZERO content-unread.
+  // NO channel PRIVMSG: #spec-wN carries ZERO content-unread.
   await peer.join(CHANNEL);
   await expect(sidebarEventsBadge(page, NETWORK_SLUG, CHANNEL)).toBeVisible({ timeout: 10_000 });
 
@@ -89,23 +89,23 @@ test("desktop: #265 next-active count includes the message (DM) window, excludes
 
   const peer = await seedEventOnlyAndMessageWindows(page, peerNick);
   try {
-    // #bofh accrued a presence-only event badge (asserted in the seeder);
+    // #spec-wN accrued a presence-only event badge (asserted in the seeder);
     // the DM accrued a message badge. The activity gate is message-scoped,
     // so ONLY the DM counts → the affordance reports "1", NOT "2".
     //
-    // Pre-#265 (gate on the total) #bofh's event bumps this to "2" and the
+    // Pre-#265 (gate on the total) #spec-wN's event bumps this to "2" and the
     // assertion fails with a clean `Expected "1" Received "2"`.
     await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
 
     // And the ONE active window is the DM — a button jump lands there,
-    // never on the presence-only #bofh.
+    // never on the presence-only #spec-wN.
     await page.locator(NEXT_ACTIVE_BTN).click();
     await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveClass(/selected/, {
       timeout: 10_000,
     });
 
     // The DM is now read → nothing active → the affordance auto-hides
-    // (#bofh's presence-only churn never made it active).
+    // (#spec-wN's presence-only churn never made it active).
     await expect(page.locator(NEXT_ACTIVE_BTN)).toHaveCount(0, { timeout: 10_000 });
   } finally {
     await peer.disconnect("265 desktop done");

--- a/cicchetto/e2e/tests/issue267-mention-server-authoritative.spec.ts
+++ b/cicchetto/e2e/tests/issue267-mention-server-authoritative.spec.ts
@@ -63,20 +63,20 @@ test("#267 — mention landing during a WS gap surfaces from the server count on
   const body = mentionBody(runId);
 
   // Clean baseline: pin the read cursor to the current tail so any
-  // pre-existing unread mention on #bofh drops below the cursor and the
+  // pre-existing unread mention on #spec-wN drops below the cursor and the
   // window's mention count starts at 0. The one mention we send below is
   // then the ONLY row after the cursor → the count is deterministically 1.
   await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
 
   await loginAs(page, vjt);
 
-  // Focus #bofh so its per-channel topic is subscribed (joinChannel fired
+  // Focus #spec-wN so its per-channel topic is subscribed (joinChannel fired
   // + JOIN echoed). Gate on the seeded member list before moving on.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await assertJoinedWithOwnMember(page);
 
   // Defocus to the Server window. The mention badge's focus-zero overlay
-  // renders 0 for the selected+visible window; #bofh must be UNFOCUSED
+  // renders 0 for the selected+visible window; #spec-wN must be UNFOCUSED
   // for its badge to surface. Server has no compose/JOIN so it can't
   // produce chatter that races the assertion.
   await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
@@ -111,7 +111,7 @@ test("#267 — mention landing during a WS gap surfaces from the server count on
       body,
     });
 
-    // Resume the socket. phoenix auto-rejoins #bofh; the join reply
+    // Resume the socket. phoenix auto-rejoins #spec-wN; the join reply
     // carries `window_counts.mentions: 1`, which `applyJoinReplyAndSeed`
     // feeds into `mentions.setServerMention` → the red badge shows "@1".
     // This is the load-bearing proof: cic NEVER saw the PRIVMSG, so the
@@ -145,8 +145,8 @@ test("#267 — mention on an unfocused channel fans out from the server to both 
   await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
 
   // Two independent browser contexts = two devices/tabs of the SAME
-  // operator. Both subscribe to #bofh (autojoin), both defocus to Server
-  // so #bofh's badge is not focus-zero-overlaid in either.
+  // operator. Both subscribe to #spec-wN (autojoin), both defocus to Server
+  // so #spec-wN's badge is not focus-zero-overlaid in either.
   const ctxA = await browser.newContext();
   const ctxB = await browser.newContext();
   const pageA = await ctxA.newPage();
@@ -167,7 +167,7 @@ test("#267 — mention on an unfocused channel fans out from the server to both 
     try {
       await peer.join(CHANNEL);
 
-      // ONE mention. The server pushes `window_counts` on the #bofh topic
+      // ONE mention. The server pushes `window_counts` on the #spec-wN topic
       // to EVERY subscribed socket → both tabs' `setServerMention` fires.
       // A pre-#267 per-tab client bump would compute its count in
       // isolation; here both render the same server-sourced "@1".

--- a/cicchetto/e2e/tests/issue281-account-switch-no-replay.spec.ts
+++ b/cicchetto/e2e/tests/issue281-account-switch-no-replay.spec.ts
@@ -161,7 +161,7 @@ test.describe("issue #281 — account switch replay", () => {
     // `waitForChannelReady` returns while `refreshScrollback` is still in
     // flight: subscribe.ts fires it and stamps the ready seam synchronously
     // right after (the #552 hazard, which is why this twin seam exists). With
-    // `#bofh` seeded at exactly PAGE_LIMIT rows, that backfill gets a FULL
+    // `#spec-wN` seeded at exactly PAGE_LIMIT rows, that backfill gets a FULL
     // page and therefore probes `/messages/count` — measured firing 1.5–75ms
     // before the clear across three fresh stacks, under A's own live bearer,
     // hundreds of ms before any identity purge, at the very `?after=681` the

--- a/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
+++ b/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
@@ -107,9 +107,9 @@ test("@webkit #285 reopen — .scrollback base is fail-open pan-y and the lock g
   const admin = getSeededAdmin();
   const vjt = specUser();
 
-  // Re-seed #bofh to a SMALL corpus so it does NOT overflow the real device
+  // Re-seed #spec-wN to a SMALL corpus so it does NOT overflow the real device
   // viewport (the not-overflowing baseline) but WILL overflow a shrunk one.
-  // The wrapped `test` fixture's afterEach truncates #bofh back to the 200-row
+  // The wrapped `test` fixture's afterEach truncates #spec-wN back to the 200-row
   // baseline (same verb #245 / #161 use), so no manual cleanup is needed.
   await resetSubject(
     admin.token,

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -71,7 +71,7 @@ const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 // REST default page size (Grappa.Web.MessagesController.@default_limit).
 const REST_PAGE_SIZE = 50;
 
-// Shared body: focus an unread #bofh, tap the floating button, assert the cursor
+// Shared body: focus an unread #spec-wN, tap the floating button, assert the cursor
 // persists to the tail AND a subsequent peer line does not snap the view back.
 // `peerNick` is passed distinct per project so the two runs never collide on a
 // bahamut ghost-nick linger window (per-run-unique peer nicks, TESTING.md).
@@ -148,7 +148,7 @@ async function tapButtonPersistsCursorAndHolds(page: Page, peerNick: string): Pr
 }
 
 // The mid-page cursor + the tap advance the shared seeded vjt's cursor across
-// spec boundaries; restore to the tail after EACH run so a downstream #bofh spec
+// spec boundaries; restore to the tail after EACH run so a downstream #spec-wN spec
 // inherits a fully-read channel (cascade hygiene — feedback_cascade_poisoner_pattern).
 test.describe("#310 — scroll-to-bottom button persists the read cursor (desktop)", () => {
   test.use({ viewport: { width: 800, height: 300 } });

--- a/cicchetto/e2e/tests/issue327-bottombar-scroll-into-view.spec.ts
+++ b/cicchetto/e2e/tests/issue327-bottombar-scroll-into-view.spec.ts
@@ -50,7 +50,7 @@ import { expect, specUser, test } from "../fixtures/test";
 
 const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
 const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
-const SEEDED = AUTOJOIN_CHANNELS[0]; // #bofh — the seeded autojoin channel
+const SEEDED = AUTOJOIN_CHANNELS[0]; // #spec-wN — the seeded autojoin channel
 
 // Unique per run so a crashed prior run's residue can't collide on the
 // shared bahamut-test server.

--- a/cicchetto/e2e/tests/issue359-alt0-status-window.spec.ts
+++ b/cicchetto/e2e/tests/issue359-alt0-status-window.spec.ts
@@ -9,9 +9,9 @@
 // This spec drives the USER-VISIBLE OUTCOME from inside a channel, with two
 // independent oracles so a sidebar class flipped without the pane following
 // cannot pass:
-//   1. the sidebar selection moves off #bofh onto the `$server` row, and
+//   1. the sidebar selection moves off #spec-wN onto the `$server` row, and
 //   2. the compose textarea placeholder becomes the server window's
-//      (`message <slug>`, #151) instead of the channel's (`message #bofh`).
+//      (`message <slug>`, #151) instead of the channel's (`message #spec-wN`).
 // Both are asserted in their PRE state first, so the gesture is what moves
 // them. On the unfixed code Alt+0 is an unbound key: the channel stays
 // selected and the placeholder never changes — the spec goes RED.

--- a/cicchetto/e2e/tests/issue38-keyed-tab-dismiss-after-rejoin-fail.spec.ts
+++ b/cicchetto/e2e/tests/issue38-keyed-tab-dismiss-after-rejoin-fail.spec.ts
@@ -23,7 +23,7 @@
 //
 // Repro construction:
 //   1. peer founds NEW_CHANNEL +k (auto-op basis, as cp15-b6).
-//   2. admin PATCH vjt's credential autojoin = [#bofh, NEW_CHANNEL].
+//   2. admin PATCH vjt's credential autojoin = [#spec-wN, NEW_CHANNEL].
 //      An autojoin-only edit is `:left_alone` server-side — a DB write
 //      with NO session restart — so this alone does NOT fire the JOIN.
 //   3. /disconnect + Home Reconnect → a fresh SpawnOrchestrator reads
@@ -38,7 +38,7 @@
 // Runs on chromium desktop (no @webkit tag).
 //
 // CLEANUP: the wrapped `test` fixture auto-resets vjt after every spec
-// (restores autojoin to ["#bofh"] — dropping NEW_CHANNEL even if the ×
+// (restores autojoin to ["#spec-wN"] — dropping NEW_CHANNEL even if the ×
 // failed — clears last_joined, and restarts the session, which drops
 // the failed NEW_CHANNEL window). afterEach only tears down the peer.
 

--- a/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
+++ b/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
@@ -55,7 +55,7 @@ import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — the seeded autojoin channel
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #spec-wN — the seeded autojoin channel
 
 // The rail buttons a NON-admin (vjt) sees on a CHANNEL window, each paired with
 // the `.rail-action-label` text #473 gave it. Order mirrors the render order in
@@ -94,7 +94,7 @@ const RAIL_BUTTONS: ReadonlyArray<{ testid: string; label: string }> = [
 test.setTimeout(60_000);
 
 test.afterEach(async () => {
-  // Tests (c) + (d) PART #bofh into the archive; restore the seed-joined state
+  // Tests (c) + (d) PART #spec-wN into the archive; restore the seed-joined state
   // so downstream specs still find the autojoin channel. Idempotent — a 404 on
   // an already-joined channel is treated as success by joinChannel's caller
   // contract (mirrors ux-1 / ux-2 / cp15-b6).
@@ -245,7 +245,7 @@ test.describe("#473 — RailActions drawer + grouped ArchiveModal", () => {
 
     // PART → archived. Then reach the ONE archive door via the rail (openArchive
     // is viewport-aware: on mobile it opens the drawer then taps the always-on
-    // archive button). Expand the group → the lazy row load surfaces #bofh.
+    // archive button). Expand the group → the lazy row load surfaces #spec-wN.
     await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
     await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, { timeout: 5_000 });
 

--- a/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
@@ -13,7 +13,7 @@
 // Non-destructive on the shared seeded `vjt`: APPLY-AND-RESTORE. The spec
 // changes vjt's per-network nick THROUGH the editor and asserts the change
 // applied LIVE (the /networks row nick flips, the "Identity applied." banner
-// shows, and vjt's own new nick appears in the #bofh members list), THEN
+// shows, and vjt's own new nick appears in the #spec-wN members list), THEN
 // restores `vjt-grappa` in a finally so downstream specs see the seeded
 // baseline. `resetSubject` (the wrapped-test auto-teardown) restores
 // autojoin + scrollback but NOT the nick, so this restore is load-bearing,
@@ -137,7 +137,7 @@ test("issue #476 — a USER edits its per-network identity in settings and it ap
   try {
     // ── GATE: ensure vjt is LIVE under the seeded baseline nick ──
     // Idempotent reconnect (no-op if already connected), then wait for the
-    // session to be connected AND vjt-grappa to be in #bofh members — the
+    // session to be connected AND vjt-grappa to be in #spec-wN members — the
     // real "the editor's starting point is live" precondition.
     await patchNetworkConnectionState(vjt.token, NETWORK_SLUG, {
       connection_state: "connected",
@@ -174,7 +174,7 @@ test("issue #476 — a USER edits its per-network identity in settings and it ap
 
     // HEADLINE — the apply succeeds (the "Identity applied." banner), the
     // /networks row's LIVE nick flips to the new value, and vjt's own new
-    // nick appears in the #bofh members list after the reconnect + autojoin.
+    // nick appears in the #spec-wN members list after the reconnect + autojoin.
     // Three independent witnesses that the USER edit reached upstream.
     await expect(general.getByTestId("settings-identity-ok")).toBeVisible({
       timeout: 20_000,

--- a/cicchetto/e2e/tests/issue500-rail-launcher-overflow.spec.ts
+++ b/cicchetto/e2e/tests/issue500-rail-launcher-overflow.spec.ts
@@ -5,7 +5,7 @@
 // END of the scroll content — below the fold, UNREACHABLE on desktop (vjt's
 // staging report). A three-nick channel would pass against the broken build (no
 // overflow, everything fits) and prove nothing — the trap the issue explicitly
-// calls out. So this spec inflates #bofh with enough peers that the list
+// calls out. So this spec inflates #spec-wN with enough peers that the list
 // genuinely OVERFLOWS a short viewport, then asserts:
 //   (a) the members pane actually overflows (the meaningful precondition),
 //   (b) the launcher is still within the viewport — NOT pushed below the fold,
@@ -27,7 +27,7 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #spec-wN — the per-spec autojoin channel
 // vjt + PEER_COUNT peers. Four extra members overflow the short viewport below
 // with comfortable margin; kept modest so the burst stays well under the
 // testnet's per-IP clone/flood threshold (feedback_integration_bahamut_ip_autokill).
@@ -47,7 +47,7 @@ test.afterEach(async () => {
 test("#500 — an overflowing member list keeps the rail launcher reachable and openable", async ({
   page,
 }) => {
-  // Inflate #bofh so the member list is long enough to overflow. Sequential,
+  // Inflate #spec-wN so the member list is long enough to overflow. Sequential,
   // paced joins — a simultaneous burst risks the testnet fake-lag/split; four is
   // far under the split threshold.
   for (let i = 0; i < PEER_COUNT; i++) {

--- a/cicchetto/e2e/tests/issue511-failed-autojoin-dismiss-durable.spec.ts
+++ b/cicchetto/e2e/tests/issue511-failed-autojoin-dismiss-durable.spec.ts
@@ -46,7 +46,7 @@
 // Runs on chromium desktop (no @webkit tag).
 //
 // CLEANUP: the wrapped `test` fixture auto-resets vjt after every spec
-// (restores autojoin to ["#bofh"], so BOTH staged channels are dropped even if
+// (restores autojoin to ["#spec-wN"], so BOTH staged channels are dropped even if
 // an assertion failed mid-spec, and restarts the session). afterEach only tears
 // down the peer.
 

--- a/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
+++ b/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
@@ -66,7 +66,7 @@ const DM_SECOND = "#532 B: second DM — the unread that the archive badge must 
 
 test.afterEach(async () => {
   const vjt = specUser();
-  // Restore the seed-time joined state (test A parts #bofh) and clear the
+  // Restore the seed-time joined state (test A parts #spec-wN) and clear the
   // DM unread test B leaves behind, so neither poisons a later spec under
   // retries. Both are idempotent / no-ops for the test that didn't touch
   // them, and guarded so a mid-test failure can't cascade.
@@ -88,7 +88,7 @@ test("#532 A — a self-PART leaves NO stale event badge on the archived channel
   await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // PART #bofh. The self-PART persists an own `:part` audit row (id >
+  // PART #spec-wN. The self-PART persists an own `:part` audit row (id >
   // cursor) and drops the channel from the active sidebar into Archive.
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, { timeout: 5_000 });

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -132,14 +132,14 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
 
     // Fully-read channel: seed the cursor to the newest row so NO divider
-    // renders (the auto-reset re-seeds #bofh with fresh-timestamped rows +
+    // renders (the auto-reset re-seeds #spec-wN with fresh-timestamped rows +
     // clears the cursor; without this seed cic would treat them as live-unread
     // and pin a marker to the top — same precondition as scroll-on-window-switch
     // scenario 1).
     const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
-    if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
+    if (!tailId) throw new Error("#spec-wN seed page empty — cannot seed cursor to tail");
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tailId);
 
     await loginAs(page, vjt);
@@ -251,7 +251,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
-    if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
+    if (!tailId) throw new Error("#spec-wN seed page empty — cannot seed cursor to tail");
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tailId);
 
     await loginAs(page, vjt);
@@ -298,7 +298,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const tailId = headPage[0]?.id;
-    if (!tailId) throw new Error("#bofh seed page empty — cannot seed cursor to tail");
+    if (!tailId) throw new Error("#spec-wN seed page empty — cannot seed cursor to tail");
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tailId);
 
     await loginAs(page, vjt);

--- a/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
+++ b/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
@@ -14,7 +14,7 @@
 // asserts the SERVER contract (the REST door of the same domain event,
 // per "one feature, one code path, every door").
 //
-// CLEANUP: afterEach reconnects the network + polls #bofh back to joined,
+// CLEANUP: afterEach reconnects the network + polls #spec-wN back to joined,
 // mirroring issue100-reconnecting-badge, so the next spec on the shared
 // testnet inherits a live session.
 

--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -45,7 +45,7 @@
 // pane has tail-followed the WS echo) so the geometry is deterministic, and
 // asserts on the state the operator actually ends up looking at.
 //
-// Harness mirrors issue168-scroll-authority (DB-seeded 200-row `#bofh`; tiny
+// Harness mirrors issue168-scroll-authority (DB-seeded 200-row `#spec-wN`; tiny
 // 800×300 viewport so the REST page overflows and scroll geometry is
 // measurable; mid-page cursor so cold-mount lands on the marker, above the
 // fold).

--- a/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
+++ b/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
@@ -89,7 +89,7 @@ test("#591 — /ping shows the round-trip time in the source window", async ({ p
     // The reply is CTCP-framed → grappa routes it to $server with typed ctcp
     // meta; cic ALWAYS subscribes to $server, correlates the token back to the
     // pending /ping, and synthesises the round-trip line in the SOURCE window
-    // (#bofh, where /ping was typed). The ms is wall-clock — assert the shape.
+    // (#spec-wN, where /ping was typed). The ms is wall-clock — assert the shape.
     await expect(
       scrollbackLine(page, "notice", new RegExp(`CTCP PING reply from ${peer.nick}: \\d+ ms`)),
     ).toBeVisible({ timeout: 15_000 });

--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -26,7 +26,7 @@
 // first reached the tail means the pane was dragged away — the "too far up"
 // jump.
 //
-// Harness mirrors issue580 (DB-seeded 200-row #bofh; tiny 800×300 viewport so
+// Harness mirrors issue580 (DB-seeded 200-row #spec-wN; tiny 800×300 viewport so
 // the buffer overflows and scroll geometry is measurable).
 
 import type { Page } from "@playwright/test";

--- a/cicchetto/e2e/tests/issue637-service-ping.spec.ts
+++ b/cicchetto/e2e/tests/issue637-service-ping.spec.ts
@@ -35,10 +35,10 @@ test("#637 — /ping NickServ (a real service, token-less echo) renders the roun
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await expect(composeTextarea(page)).toBeVisible();
 
-  // /ping NickServ from #bofh. NickServ echoes a TOKEN-LESS CTCP PING; grappa
+  // /ping NickServ from #spec-wN. NickServ echoes a TOKEN-LESS CTCP PING; grappa
   // routes the CTCP-framed reply to $server; cic's correlation gate falls back
   // to the pending ping by nick and synthesises the RTT row in the source
-  // window (#bofh).
+  // window (#spec-wN).
   await composeSend(page, "/ping NickServ");
 
   await expect(scrollbackLine(page, "notice", /CTCP PING reply from NickServ: \d+ ms/)).toBeVisible(

--- a/cicchetto/e2e/tests/issue66-keyboard-overlap.spec.ts
+++ b/cicchetto/e2e/tests/issue66-keyboard-overlap.spec.ts
@@ -40,7 +40,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // below the iPhone 15 device viewport (393×659) so the shrink is real.
 // Same value names143 uses for the modal-occlusion contract.
 const FAKE_VISIBLE_PX = 300;
-// Per-run unique tag so retries / parallel rows in #bofh don't collide.
+// Per-run unique tag so retries / parallel rows in #spec-wN don't collide.
 const MESSAGE_BODY = `issue66 keyboard-overlap @ ${crypto.randomUUID().slice(0, 8)}`;
 
 test("@webkit issue66 — composer + last message stay inside the keyboard-shrunk viewport", async ({

--- a/cicchetto/e2e/tests/issue71-inc1-sidebar-own-nick.spec.ts
+++ b/cicchetto/e2e/tests/issue71-inc1-sidebar-own-nick.spec.ts
@@ -25,7 +25,7 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.afterEach(async () => {
-  // The rail non-regression test PARTs #bofh to force it into the
+  // The rail non-regression test PARTs #spec-wN to force it into the
   // archive; restore the seed-time joined state so later specs keep
   // working (mirrors archive-desktop-only.spec.ts).
   const vjt = specUser();
@@ -85,7 +85,7 @@ test.describe("#71 INC-1 — sidebar hierarchy", () => {
       )
       .toBe("2px");
 
-    // PART #bofh → it leaves the main network <ul> (no longer a sidebar row)
+    // PART #spec-wN → it leaves the main network <ul> (no longer a sidebar row)
     // and lands in the archive, which is now the grouped ArchiveModal (#473),
     // NOT a sidebar `<details>`.
     await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);

--- a/cicchetto/e2e/tests/issue71-inc2-permanent-rail-desktop.spec.ts
+++ b/cicchetto/e2e/tests/issue71-inc2-permanent-rail-desktop.spec.ts
@@ -40,11 +40,11 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL_A = AUTOJOIN_CHANNELS[0]; // #bofh — seeded autojoin
+const CHANNEL_A = AUTOJOIN_CHANNELS[0]; // #spec-wN — seeded autojoin
 const CHANNEL_B = "#i71inc2"; // fresh channel joined for the away round-trip
 const AWAY_REASON = "inc2 lunch";
 
-// Per-invocation unique mention body suffix (see issue188's comment): `#bofh`
+// Per-invocation unique mention body suffix (see issue188's comment): `#spec-wN`
 // is truncated+reseeded by `_vjtReset` but `#i71inc2` is NOT, so a constant
 // body would let the scrollback-render wait match a STALE prior-iteration row
 // and false-pass. A fresh runId makes each wait a true "the FRESH mention
@@ -55,7 +55,7 @@ const mentionBody = (where: string, runId: string): string =>
 test.setTimeout(90_000);
 
 test.afterEach(async () => {
-  // The guardrail test PARTs #bofh into the archive; restore the seed-joined
+  // The guardrail test PARTs #spec-wN into the archive; restore the seed-joined
   // state so later specs keep working (mirrors issue71-inc1-sidebar-own-nick).
   const vjt = specUser();
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL_A);
@@ -137,7 +137,7 @@ test.describe("#71 INC-2 — permanent right rail (desktop)", () => {
         )
         .toBe("2px");
 
-      // PART #bofh (server-side REST, no compose needed — the mentions window
+      // PART #spec-wN (server-side REST, no compose needed — the mentions window
       // has no ComposeBox) → the channel leaves the main network <ul> and moves
       // into the archive (now the grouped ArchiveModal, #473 — no longer an
       // inline Sidebar `<details class="sidebar-archive">`).

--- a/cicchetto/e2e/tests/issue887-focused-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue887-focused-unread-badge.spec.ts
@@ -87,7 +87,7 @@ test.describe("#887 focused-window unread badge", () => {
     const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(rows.length).toBeGreaterThanOrEqual(UNREAD_DEPTH + 10);
     const lastRead = rows[rows.length - UNREAD_DEPTH];
-    if (!lastRead) throw new Error("#887 spec: seeded #bofh rows missing expected index");
+    if (!lastRead) throw new Error("#887 spec: seeded #spec-wN rows missing expected index");
 
     // Plant the cursor BEFORE login so the channel hydrates already behind.
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, lastRead.id);

--- a/cicchetto/e2e/tests/issue913-rail-menu-safe-area.spec.ts
+++ b/cicchetto/e2e/tests/issue913-rail-menu-safe-area.spec.ts
@@ -32,7 +32,7 @@ import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage"
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #spec-wN — the per-spec autojoin channel
 
 // Short enough that the action rows cannot all fit above the bottom-pinned
 // launcher, so the menu is pinned to its cap rather than to its content height.

--- a/cicchetto/e2e/tests/issue947-unread-divider-count.spec.ts
+++ b/cicchetto/e2e/tests/issue947-unread-divider-count.spec.ts
@@ -86,7 +86,7 @@ test.describe("#947 — the unread divider counts the conversation, not the page
     expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
 
     const lastReadRow = rows[rows.length - UNREAD_TARGET];
-    if (!lastReadRow) throw new Error("#947 spec: seeded #bofh rows missing cursor index");
+    if (!lastReadRow) throw new Error("#947 spec: seeded #spec-wN rows missing cursor index");
     const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
     // Guard the precondition: below this the pane never goes far behind and
     // the spec would pass by testing nothing.

--- a/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
+++ b/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
@@ -47,7 +47,7 @@ const PEER_NICK = "I973Peer";
 const FIRST_DM = "issue-973 first dm";
 const SECOND_DM = "issue-973 second dm";
 
-// The spec focuses #bofh (advancing its cursor on leave). Restore it to tail so
+// The spec focuses #spec-wN (advancing its cursor on leave). Restore it to tail so
 // downstream specs inherit a clean at-tail cursor (BUGHUNT-3 cascade rule).
 test.afterEach(async () => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/links238-modal.spec.ts
+++ b/cicchetto/e2e/tests/links238-modal.spec.ts
@@ -18,7 +18,7 @@
 // connected tree) are the ground-truth witness that the parse order is right.
 //
 // Full path exercised:
-//   1. operator focused on a channel window (#bofh, seed-autojoined)
+//   1. operator focused on a channel window (#spec-wN, seed-autojoined)
 //   2. operator issues `/links` via composeSend
 //   3. grappa primes links_pending + sends LINKS upstream; Bahamut replies
 //      with the 364 burst; 365 RPL_ENDOFLINKS flushes the `links_bundle` event

--- a/cicchetto/e2e/tests/m1-irssi-to-chan-focused.spec.ts
+++ b/cicchetto/e2e/tests/m1-irssi-to-chan-focused.spec.ts
@@ -8,9 +8,9 @@
 //
 // Wiring:
 //   - peer connects via IrcPeer (uses bahamut-test alias → leaf-v4)
-//   - peer JOINs #bofh (cicchetto is autojoined there via the seeder)
+//   - peer JOINs #spec-wN (cicchetto is autojoined there via the seeder)
 //   - cicchetto loginAs() (token + subject pre-seeded into localStorage)
-//   - cicchetto selectChannel(#bofh) — explicit, even though autojoin makes
+//   - cicchetto selectChannel(#spec-wN) — explicit, even though autojoin makes
 //     it the only candidate, so the spec reads as "vjt is focused"
 //   - peer PRIVMSGs the channel
 //   - assert: scrollback has the new line; no msg-unread badge

--- a/cicchetto/e2e/tests/m11-peer-nick-change-row-members.spec.ts
+++ b/cicchetto/e2e/tests/m11-peer-nick-change-row-members.spec.ts
@@ -1,7 +1,7 @@
 // M11 — peer NICK change in a focused channel.
 //
 // Manual matrix: irssi (peer) types `/nick newname` while sitting in
-// #bofh with vjt. Expected:
+// #spec-wN with vjt. Expected:
 //   - server-side persists the rename as kind=:nick_change with
 //     sender=oldNick and meta.new_nick=newNick
 //   - cicchetto scrollback shows `* oldNick is now known as newNick`

--- a/cicchetto/e2e/tests/m2-irssi-to-chan-defocused.spec.ts
+++ b/cicchetto/e2e/tests/m2-irssi-to-chan-defocused.spec.ts
@@ -1,9 +1,9 @@
 // M2 — peer PRIVMSG to a channel cicchetto is NOT focused on.
 //
-// Manual matrix: irssi (peer) sends to #bofh while vjt is viewing a
+// Manual matrix: irssi (peer) sends to #spec-wN while vjt is viewing a
 // different window (Server). Expected:
 //   - the message is persisted server-side
-//   - the #bofh sidebar entry shows a msg-unread badge with "1"
+//   - the #spec-wN sidebar entry shows a msg-unread badge with "1"
 //
 // Cousin of M1, inverse of the focus invariant: M1 proves "focused
 // channel does not bump unread"; M2 proves "defocused channel does
@@ -29,7 +29,7 @@ const MESSAGE_BODY = "M2: defocused-channel inbound";
 test("M2 — peer PRIVMSG to defocused channel bumps msg-unread badge by 1", async ({ page }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
-  // Visit #bofh FIRST with the WS-ready sync so we know the channel
+  // Visit #spec-wN FIRST with the WS-ready sync so we know the channel
   // topic subscription has landed (joinChannel fired + server-side
   // JOIN echoed). THEN defocus by switching to Server. Without this
   // up-front sync, the peer's PRIVMSG races the WS subscribe and the
@@ -39,7 +39,7 @@ test("M2 — peer PRIVMSG to defocused channel bumps msg-unread badge by 1", asy
   // Server window is always present and has no compose, so selecting
   // it can't accidentally produce client-side chatter that would race
   // the unread-bump assertion. WS-ready guard is off here — Server
-  // windows have no JOIN line to wait for and the #bofh topic was
+  // windows have no JOIN line to wait for and the #spec-wN topic was
   // already proven subscribed above.
   await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
 

--- a/cicchetto/e2e/tests/m3-cicchetto-to-chan-own-msg-echo.spec.ts
+++ b/cicchetto/e2e/tests/m3-cicchetto-to-chan-own-msg-echo.spec.ts
@@ -1,7 +1,7 @@
 // M3 — cicchetto-driven PRIVMSG to a channel: type in compose, assert
 // the row renders in scrollback as own-message.
 //
-// Manual matrix: vjt types a message in cicchetto's #bofh compose box.
+// Manual matrix: vjt types a message in cicchetto's #spec-wN compose box.
 // Expected:
 //   - the message persists server-side (round-trip through grappa →
 //     leaf → grappa echo path)

--- a/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
+++ b/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
@@ -7,7 +7,7 @@
 //     re-keys the append from own-nick to sender — see subscribe.ts
 //     "C4.1 / DM live-WS gap" comment)
 //   - msg-unread badge on the auto-opened window shows "1" (cicchetto is
-//     focused on #bofh, not the new DM window)
+//     focused on #spec-wN, not the new DM window)
 //   - clicking the DM window: scrollback renders the body AND the
 //     badge clears (selection.ts isSelected gate)
 //
@@ -40,7 +40,7 @@ const MESSAGE_BODY = "M4: inbound DM to nick";
 test("M4 — inbound DM auto-opens query window with unread, clears on focus", async ({ page }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
-  // Stay focused on #bofh — the DM lands in a NEW window we're NOT
+  // Stay focused on #spec-wN — the DM lands in a NEW window we're NOT
   // looking at, so unread MUST bump. selectChannel here also doubles
   // as the WS-ready sync (own-nick subscribe.ts join for the dm-
   // listener topic happens off the same effect chain).
@@ -82,7 +82,7 @@ test("M4 — inbound DM auto-opens query window with unread, clears on focus", a
     // Sidebar gains exactly one entry for the sender nick.
     await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
-    // Unread badge "1" — cicchetto still on #bofh, query window is
+    // Unread badge "1" — cicchetto still on #spec-wN, query window is
     // unfocused by definition. Asserted BEFORE the click-to-inspect
     // because clicking would clear it (selection.ts isSelected gate).
     await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toHaveText("1", {

--- a/cicchetto/e2e/tests/m6-cicchetto-to-priv-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/m6-cicchetto-to-priv-opens-query.spec.ts
@@ -43,7 +43,7 @@ test("M6 — cicchetto /msg opens query window, focuses, renders own-msg", async
   await loginAs(page, vjt);
   // Start in a real channel so the compose box is visible (Server
   // window has no compose). selectChannel + ownNick syncs WS-ready
-  // for #bofh — same pattern as M1/M2/M7.
+  // for #spec-wN — same pattern as M1/M2/M7.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
   await waitForDmListenerReady(page, NETWORK_SLUG);
 

--- a/cicchetto/e2e/tests/m7-peer-join-no-bouncer-follow.spec.ts
+++ b/cicchetto/e2e/tests/m7-peer-join-no-bouncer-follow.spec.ts
@@ -7,7 +7,7 @@
 //
 // The negative assertion needs a sync point: we have to know that any
 // IRC activity from the peer that COULD have surfaced in cicchetto has had
-// time to propagate. We do that by chaining a second JOIN to #bofh
+// time to propagate. We do that by chaining a second JOIN to #spec-wN
 // (where grappa IS) and waiting for THAT join event to render in cicchetto
 // scrollback. Once that arrives, we know all earlier peer→IRC traffic
 // (including the #other JOIN) has been processed by the leaf and
@@ -30,10 +30,10 @@ const OUTSIDE_CHANNEL = "#m7-outside";
 test("M7 — peer JOIN on unbound channel does NOT add sidebar entry", async ({ page }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
-  // Focus #bofh so the sync-point JOIN line lands in the currently-
+  // Focus #spec-wN so the sync-point JOIN line lands in the currently-
   // visible scrollback (avoids false-negatives where the line is
   // appended to a non-rendered window's store). The WS-ready guard
-  // also pins that the #bofh topic subscription has completed before
+  // also pins that the #spec-wN topic subscription has completed before
   // the peer fires.
   await selectChannel(page, NETWORK_SLUG, BOUND_CHANNEL, { ownNick: specNick() });
 
@@ -42,12 +42,12 @@ test("M7 — peer JOIN on unbound channel does NOT add sidebar entry", async ({ 
     // Peer joins the unbound channel first. Grappa is not a member of
     // OUTSIDE_CHANNEL, so the leaf does not forward this JOIN to grappa.
     await peer.join(OUTSIDE_CHANNEL);
-    // Peer joins #bofh — grappa IS in #bofh, so the leaf forwards this
+    // Peer joins #spec-wN — grappa IS in #spec-wN, so the leaf forwards this
     // JOIN to grappa, which pushes a `join` scrollback row to cicchetto via WS.
     await peer.join(BOUND_CHANNEL);
 
     // Sync point AND user@host render assertion. The peer JOIN row
-    // appearing in #bofh proves grappa has processed all earlier peer
+    // appearing in #spec-wN proves grappa has processed all earlier peer
     // activity in IRC stream order; anything #m7-outside was going to
     // surface in cicchetto would have by now.
     //

--- a/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
+++ b/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
@@ -12,8 +12,8 @@
 //
 // Expected:
 //   - PART row persists server-side (sender = specNick(), kind =
-//     :part, channel = #bofh)
-//   - sidebar entry for #bofh disappears
+//     :part, channel = #spec-wN)
+//   - sidebar entry for #spec-wN disappears
 //   - selectedChannel redirects via UX-4-E picker — with no other
 //     joined channel and the server window not always selectable
 //     in this test fixture's seed shape, lands on home pane
@@ -55,7 +55,7 @@ test.afterEach(async () => {
 test("M9 — sidebar X-button PARTs the channel and dismisses the window", async ({ page }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
-  // Focus #bofh first so the WS subscription sync completes before
+  // Focus #spec-wN first so the WS subscription sync completes before
   // the PART. Without this, the BUG5a self-PART handler might not
   // be installed when the PART echo arrives.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -90,7 +90,7 @@ test("M9 — sidebar X-button PARTs the channel and dismisses the window", async
   // Note: post-PART selection redirection is out of scope for this
   // spec — UX-4-E's MRU-→-server-→-home picker has subtle interactions
   // with the testnet's mid-flight rejoin races (other autojoined users
-  // can briefly re-introduce #bofh into channelsBySlug via concurrent
+  // can briefly re-introduce #spec-wN into channelsBySlug via concurrent
   // JOIN-syncs on the same channel). Sidebar absence + server-side
   // PART persistence are sufficient evidence the X-button worked;
   // selection routing is covered by the dedicated selection.ts

--- a/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
+++ b/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
@@ -10,7 +10,7 @@
 //      session-time, so any peer arrival with `server_time > cursor`
 //      spawns a marker. Cursor only advances on own-msg, so a focused
 //      send-then-reply leaves a "1 unread" mid-page.
-//   4. Switch to a TALL channel (#bofh has 100+ rows).
+//   4. Switch to a TALL channel (#spec-wN has 100+ rows).
 //      Pre-fix: viewport stays at top instead of bottom. Why:
 //      `markerRef` from the prior DM still holds a (now-disposed)
 //      ref; the key createEffect takes the marker branch and calls

--- a/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
+++ b/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
@@ -43,7 +43,7 @@ test("members pane renders @-prefix + full op nick (not clipped)", async ({ page
   const vjt = specUser();
   await loginAs(page, vjt);
 
-  // Focus #bofh first to confirm login + ws-ready, then /join the
+  // Focus #spec-wN first to confirm login + ws-ready, then /join the
   // fresh per-spec channel so vjt is the first user and Bahamut
   // grants +o deterministically.
   await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });

--- a/cicchetto/e2e/tests/nick-follow-query.spec.ts
+++ b/cicchetto/e2e/tests/nick-follow-query.spec.ts
@@ -65,9 +65,9 @@ test("query window follows a peer NICK change — relabels, keeps history, route
     // `channels != []`, i.e. OLD_NICK present in grappa's state.members).
     // `peer.join` above awaits only the peer's OWN join echo from bahamut —
     // NOT grappa's observation of it. Under full-gate load grappa can process
-    // the peer's #bofh JOIN late; a rename that lands first leaves
+    // the peer's #spec-wN JOIN late; a rename that lands first leaves
     // `channels == []` → no peer_nick_renamed → the sidebar never relabels
-    // and STEP 3 fails. Gate on the peer's JOIN line rendering in our #bofh
+    // and STEP 3 fails. Gate on the peer's JOIN line rendering in our #spec-wN
     // scrollback: grappa broadcasts that row from the SAME apply that adds
     // OLD_NICK to state.members, so its presence is the observable proof the
     // shared-membership precondition holds before we drive the rename.

--- a/cicchetto/e2e/tests/p0a-whois-flags.spec.ts
+++ b/cicchetto/e2e/tests/p0a-whois-flags.spec.ts
@@ -4,7 +4,7 @@
 // "registered" tag chip.
 //
 // Pre-conditions:
-//   - vjt logged in, focused on #bofh.
+//   - vjt logged in, focused on #spec-wN.
 //   - Peer "p0a-target" connects to a leaf, REGISTERs with NickServ, then
 //     AUTHs with the emailed code (EMAIL:1 since GH #349) to reach +r.
 //     azzurra-testnet d998d09 added the `U:services.azzurra

--- a/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
+++ b/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
@@ -94,7 +94,7 @@ test("notification_prefs whitelist: messages in allow-list push, messages elsewh
       await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
     }
 
-    // Refocus #bofh — keep both target channels unfocused so neither
+    // Refocus #spec-wN — keep both target channels unfocused so neither
     // can be mistaken for "user is reading this" (irrelevant server-
     // side, but keeps the spec's semantics clean).
     await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });

--- a/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
+++ b/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
@@ -68,7 +68,7 @@ test("channel mention while push-enabled fires Sender → push-catcher receives 
   await loginAs(page, vjt);
 
   // Anchor focus on the autojoin channel so the topic-bar settings
-  // button mounts. We deliberately stay on `#bofh` rather than the
+  // button mounts. We deliberately stay on `#spec-wN` rather than the
   // mention target — we want the mention to land OUT of the focused
   // window so the SW dedup doesn't suppress it. Focused-channel
   // dedup is the dedup spec's concern; this spec asserts the
@@ -94,7 +94,7 @@ test("channel mention while push-enabled fires Sender → push-catcher receives 
     // sends — same race as M1 / b2 specs.
     await selectChannel(page, NETWORK_SLUG, TARGET_CHANNEL, { ownNick: specNick() });
 
-    // Re-focus #bofh so the mention lands UNFOCUSED.
+    // Re-focus #spec-wN so the mention lands UNFOCUSED.
     await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
 
     // #182 — background the device so the server delivers. The server

--- a/cicchetto/e2e/tests/r6-own-action-no-events-badge.spec.ts
+++ b/cicchetto/e2e/tests/r6-own-action-no-events-badge.spec.ts
@@ -23,17 +23,17 @@
 // on the live cursor + scrollback signal flow, which only the real WS
 // + REST + Solid render path exercises):
 //
-//   1. Focus #bofh — initial cold load. The selection.ts cursor-advance
+//   1. Focus #spec-wN — initial cold load. The selection.ts cursor-advance
 //      arm runs against `prev=undefined` here so no advance fires; the
 //      server-side cursor is whatever the bootstrap envelope seeded
 //      (typically null on first session).
-//   2. PART #bofh via REST. The own PART row arrives on the per-channel
+//   2. PART #spec-wN via REST. The own PART row arrives on the per-channel
 //      topic; subscribe.ts's BUG5a own-PART path drops the channel from
 //      the sidebar via setParted AND fires `setSelectedChannel(null)`.
-//      The selection-change effect then fires its leave-arm for #bofh
+//      The selection-change effect then fires its leave-arm for #spec-wN
 //      → `advanceCursorForWindow` → POST advance lands at the row's id.
-//   3. Re-JOIN #bofh via REST. The own JOIN row arrives; subscribe.ts's
-//      BUG4 self-JOIN auto-focus path re-selects #bofh AND
+//   3. Re-JOIN #spec-wN via REST. The own JOIN row arrives; subscribe.ts's
+//      BUG4 self-JOIN auto-focus path re-selects #spec-wN AND
 //      channels_changed broadcasts → channelsBySlug refetches → sidebar
 //      entry returns. ScrollbackPane mounts against the channel key
 //      with the cursor at the post-PART id and sessionTopId at the new
@@ -43,7 +43,7 @@
 //      and no marker renders.
 //   4. Assert the in-pane unread-marker is absent.
 //
-// Cleanup: re-JOIN of #bofh restores the seed state. No afterEach
+// Cleanup: re-JOIN of #spec-wN restores the seed state. No afterEach
 // restoration needed.
 
 import {
@@ -61,7 +61,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // BUGHUNT-3 cascade fix (2026-05-25) — the spec assumes the cursor is
 // at-or-past tail (moduledoc: "typically null on first session").
 // Upstream cursor-writing specs (cp14-b1, BUGHUNT-2 cursor-*,
-// cursor-forward-only) + intervening row arrivals on `#bofh` leave a
+// cursor-forward-only) + intervening row arrivals on `#spec-wN` leave a
 // mid-pane cursor → in-pane unread-marker injects from rows OTHER
 // than the own PART/JOIN under test → the marker assertion fails on
 // rows the predicate fix never controlled. Restore cursor to current
@@ -72,7 +72,7 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  // Defensive restore — if any assertion failed mid-cycle, ensure #bofh
+  // Defensive restore — if any assertion failed mid-cycle, ensure #spec-wN
   // is back in the joined state for subsequent specs.
   const vjt = specUser();
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
@@ -84,28 +84,28 @@ test("CP29 R-6 — operator's own /part → /join cycle does NOT raise an unread
   const vjt = specUser();
   await loginAs(page, vjt);
 
-  // 1. Focus #bofh — initial cold load. The seeded autojoin already
+  // 1. Focus #spec-wN — initial cold load. The seeded autojoin already
   //    placed an own JOIN row on session boot; that row is visible.
   //    selection.ts's leave-arm runs against `prev=undefined` here, so
   //    no cursor advance fires for this initial mount.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  // 2. PART #bofh via REST. The own PART row arrives on the per-channel
+  // 2. PART #spec-wN via REST. The own PART row arrives on the per-channel
   //    topic; subscribe.ts's BUG5a own-PART path drops the channel from
   //    the sidebar via setParted AND fires `setSelectedChannel(null)`.
   //    The selection-change leave-arm then advances the cursor for
-  //    #bofh past the PART row.
+  //    #spec-wN past the PART row.
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, { timeout: 5_000 });
 
-  // 3. Re-JOIN #bofh via REST (an EXTERNAL join — not issued from this
+  // 3. Re-JOIN #spec-wN via REST (an EXTERNAL join — not issued from this
   //    cic). The own JOIN row arrives on the per-channel topic and the
   //    channels_changed broadcast brings the sidebar entry back.
   //
   //    #200 (2026-07-11): an external/cross-device re-JOIN no longer
   //    auto-focuses on this device (ruling b — focus is per-device,
   //    originated at the issuing boundary; the per-channel WS handler no
-  //    longer calls setSelectedChannel). So we explicitly select #bofh to
+  //    longer calls setSelectedChannel). So we explicitly select #spec-wN to
   //    reach the focused state this test needs. The test's actual subject
   //    is the in-pane unread-MARKER + events-badge for own presence rows,
   //    not the focus mechanism — selecting explicitly restores the exact
@@ -121,7 +121,7 @@ test("CP29 R-6 — operator's own /part → /join cycle does NOT raise an unread
   //    the `isOwnPresenceEvent` predicate excludes them and no marker
   //    renders.
   //
-  //    Wait for the new JOIN row to be visible in the focused #bofh
+  //    Wait for the new JOIN row to be visible in the focused #spec-wN
   //    pane before asserting the marker's absence — without the wait, the
   //    marker query could resolve against a still-mounting pane.
   await expect(
@@ -133,10 +133,10 @@ test("CP29 R-6 — operator's own /part → /join cycle does NOT raise an unread
   ).toBeVisible({ timeout: 10_000 });
   await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0);
 
-  // 5. Sibling assertion: the events badge on #bofh's sidebar entry
+  // 5. Sibling assertion: the events badge on #spec-wN's sidebar entry
   //    MUST also be absent. Same predicate, two surfaces; if the badge
   //    rendered, the subscribe.ts bump-gate regressed. Currently
-  //    focused on #bofh (explicit select in step 3, #200), so badges
+  //    focused on #spec-wN (explicit select in step 3, #200), so badges
   //    would clear on focus regardless — but the bump-gate runs BEFORE the
   //    focus check, so a regression at the gate would still leave a badge
   //    when re-checked from the channel's sidebar locator. The

--- a/cicchetto/e2e/tests/refresh-on-join-ws-gap-recovery.spec.ts
+++ b/cicchetto/e2e/tests/refresh-on-join-ws-gap-recovery.spec.ts
@@ -19,7 +19,7 @@
 // the gap.
 //
 // This spec exercises the deterministic path:
-//   1. Operator focuses #bofh; cold REST seeds the pane.
+//   1. Operator focuses #spec-wN; cold REST seeds the pane.
 //   2. Peer privmsg lands live (sets the high-water mark).
 //   3. cic socket dropped via __cic_dropSocketForTests, which HOLDS it
 //      down (phoenix.js's explicit disconnect resets its reconnectTimer —

--- a/cicchetto/e2e/tests/scroll-multi-roundtrip-contamination.spec.ts
+++ b/cicchetto/e2e/tests/scroll-multi-roundtrip-contamination.spec.ts
@@ -116,10 +116,10 @@ test.describe("scroll-multi-roundtrip — N back-and-forths preserve destination
       .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
       .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
 
-    // Loop: scroll-up in #bofh (operator reading history), bounce to
+    // Loop: scroll-up in #spec-wN (operator reading history), bounce to
     // the empty query, return. Pre-fix `atBottom` stays false (the
     // scroll-up set it) and leaks into the empty query's pane mount,
-    // then back into #bofh — the destination length-effect skips the
+    // then back into #spec-wN — the destination length-effect skips the
     // auto-snap because `atBottom()` is stale-false. By round 2-3 the
     // scrollTop is visibly wrong.
     //
@@ -127,7 +127,7 @@ test.describe("scroll-multi-roundtrip — N back-and-forths preserve destination
     // on every transition, so each return lands at-bottom regardless
     // of how the operator scrolled the source.
     for (let i = 0; i < 5; i++) {
-      // Operator scrolls up to mid-history in #bofh.
+      // Operator scrolls up to mid-history in #spec-wN.
       await scrollScrollbackTo(page, 100);
       // Bounce: query → channel.
       await sidebarWindow(page, NETWORK_SLUG, EMPTY_QUERY_PEER)
@@ -139,7 +139,7 @@ test.describe("scroll-multi-roundtrip — N back-and-forths preserve destination
         .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
         .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
 
-      // Contract: every return to #bofh lands at the bottom (no marker
+      // Contract: every return to #spec-wN lands at the bottom (no marker
       // in this scenario — cursor pre-set to tail in beforeEach). Polled
       // because scrollIntoView lands asynchronously vs the layout commit.
       await expect

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -47,8 +47,8 @@
 //     bottom again (no unread → tail). Pre-fix: pinned at scrollTop=0.
 //
 //   Scenario 2 — COLD-MOUNT into channel-with-unreads (#168 completion):
-//     Pre-seed a read cursor for #bofh placing the divider mid-page (25
-//     unreads), then FIRST-focus #bofh straight after login (a cold mount —
+//     Pre-seed a read cursor for #spec-wN placing the divider mid-page (25
+//     unreads), then FIRST-focus #spec-wN straight after login (a cold mount —
 //     the key-effect is `defer`-skipped, so onMount owns the first snap).
 //     Jumps to the MARKER (near the top, distance-to-bottom ABOVE threshold),
 //     NOT the tail — the #46 cold-mount-tail wontfix reversed. A follow-on
@@ -56,9 +56,9 @@
 //     this after a full `page.reload()` (genuine app-startup).
 //
 //   Scenario 3 — SWITCH into channel-with-unreads (#168 regression fix):
-//     Focus the $server window first (mounts ScrollbackPane), let #bofh warm
+//     Focus the $server window first (mounts ScrollbackPane), let #spec-wN warm
 //     in the background (eager join-ok refresh loads all 200 rows), THEN
-//     click #bofh in the sidebar — a real key-change SWITCH. The pane must
+//     click #spec-wN in the sidebar — a real key-change SWITCH. The pane must
 //     jump to the MARKER (marker visible near the top, distance-to-bottom
 //     ABOVE threshold — NOT the tail). Pre-fix (307 race) this stranded at
 //     scrollTop 0 (marker +1048) once the catch-up refresh recreated the DOM;
@@ -139,8 +139,8 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // for. Pre-fix bug: scrollTop stayed at 0 — the operator saw the
     // very first row of history, not the recent context.
     //
-    // Precondition: mark #bofh fully read BEFORE login. The auto-reset
-    // (_vjtReset, fixtures/test.ts) re-seeds #bofh with freshly-
+    // Precondition: mark #spec-wN fully read BEFORE login. The auto-reset
+    // (_vjtReset, fixtures/test.ts) re-seeds #spec-wN with freshly-
     // timestamped rows and clears the read cursor; with no cursor
     // hydrated, cic counts those recent rows as live-unread and pins the
     // unread-marker to the very first row (scrollTop=0). That state is
@@ -156,7 +156,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     const headPage = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(headPage.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const headId = headPage[0]?.id;
-    if (!headId) throw new Error("#bofh seed page empty — cannot seed read cursor to head");
+    if (!headId) throw new Error("#spec-wN seed page empty — cannot seed read cursor to head");
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, headId);
 
     await loginAs(page, vjt);
@@ -223,7 +223,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     const vjt = specUser();
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
 
-    // Pre-seed a cursor 25 rows from the tail of #bofh so the divider injects
+    // Pre-seed a cursor 25 rows from the tail of #spec-wN so the divider injects
     // mid-page. Same shape cp14-b1 scenario 2 uses.
     //
     // #168 completion (2026-07-03b, vjt point-2): the FIRST focus after login
@@ -321,7 +321,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     // The genuine app-startup path: a full PWA reload re-boots the SPA, so the
     // FIRST window focus after the reload cold-mounts the ScrollbackPane fresh
     // (onMount, key-effect defer-skipped) — the same lifecycle as launching the
-    // installed PWA. #bofh is never focused before the reload, so its seeded
+    // installed PWA. #spec-wN is never focused before the reload, so its seeded
     // read cursor is never advanced and the unread divider survives the reboot.
     const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
@@ -330,7 +330,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
 
     await loginAs(page, vjt);
-    // Reboot the app BEFORE any window focus, then focus #bofh — a cold mount
+    // Reboot the app BEFORE any window focus, then focus #spec-wN — a cold mount
     // on a freshly-booted SPA.
     await page.reload();
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -380,7 +380,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
 
     // Seed a cursor 25 rows from the tail so an unread divider injects
     // mid-page (same shape as scenario 2 / issue168), but here we reach
-    // #bofh via a deliberate SWITCH, not a cold mount.
+    // #spec-wN via a deliberate SWITCH, not a cold mount.
     const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
     expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
     const cursorRow = page0[25];
@@ -389,7 +389,7 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
 
     // Deterministic warmth gate: cic eagerly `refreshScrollback`es every
     // joined channel on its Phoenix join-ok (subscribe.ts) — REFRESH_LIMIT
-    // (200) == the seed size, so #bofh loads ALL rows in the background
+    // (200) == the seed size, so #spec-wN loads ALL rows in the background
     // WITHOUT us focusing it. Register the waiter BEFORE loginAs so the
     // post-boot fetch can't slip past us; awaiting it proves the channel is
     // warm (rows in the store) before we switch into it. Without warmth the
@@ -413,17 +413,17 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     await loginAs(page, vjt);
 
     // FROM-window: the always-present $server window mounts ScrollbackPane
-    // WITHOUT touching #bofh's read cursor (focusing #bofh first would fire
+    // WITHOUT touching #spec-wN's read cursor (focusing #spec-wN first would fire
     // the leave-arm on the way out and advance its cursor to the tail,
     // erasing the unread we need). `windowName === NETWORK_SLUG` resolves to
     // the $server tab; awaitWsReady:false — no auto-join echo to wait on.
     await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
     await expect(page.locator('[data-testid="scrollback"]')).toBeVisible({ timeout: 10_000 });
 
-    // #bofh scrollback fetched → warm. Only now is the switch a warm one.
+    // #spec-wN scrollback fetched → warm. Only now is the switch a warm one.
     await channelWarm;
 
-    // THE SWITCH — click #bofh in the sidebar. key() changes $server→#bofh,
+    // THE SWITCH — click #spec-wN in the sidebar. key() changes $server→#spec-wN,
     // firing the channel-switch key-effect (prevKey defined, so NOT the
     // defer-skipped mount run). This is the trigger the #168 collapse
     // over-reached into.

--- a/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
+++ b/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
@@ -71,15 +71,15 @@ test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands
     const vjt = specUser();
     await loginAs(page, vjt);
 
-    // Focus #bofh, confirm the first REST page is in.
+    // Focus #spec-wN, confirm the first REST page is in.
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
     await expect
       .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
       .toBeGreaterThanOrEqual(50);
 
     // Open an empty query (the "other" window) so it exists to switch to,
-    // then return to #bofh. Done up front so the loadMore + tap below all
-    // happen inside #bofh with no intervening switch (avoids racing
+    // then return to #spec-wN. Done up front so the loadMore + tap below all
+    // happen inside #spec-wN with no intervening switch (avoids racing
     // scrollToActivation's re-snap).
     await composeSend(page, `/query ${EMPTY_QUERY_PEER}`);
     await expect(page.locator(".scrollback-empty")).toBeVisible({ timeout: 5_000 });
@@ -117,7 +117,7 @@ test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands
       .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
       .toBeGreaterThanOrEqual(50);
 
-    // Contract: #bofh lands at the bottom after the roundtrip — NOT blank.
+    // Contract: #spec-wN lands at the bottom after the roundtrip — NOT blank.
     await expect
       .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 999, { timeout: 5_000 })
       .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);

--- a/cicchetto/e2e/tests/u-2-admission-split.spec.ts
+++ b/cicchetto/e2e/tests/u-2-admission-split.spec.ts
@@ -69,7 +69,7 @@ async function tryConnect(token: string, slug: string): Promise<Response> {
 
 // Restore vjt to :connected at afterEach in case the test left the
 // credential :parked. Same pattern as cp15-b6-parked-disconnect-reconnect.spec.ts: best
-// effort, fail open if already connected, then poll until #bofh shows
+// effort, fail open if already connected, then poll until #spec-wN shows
 // up as joined so the next spec sees a healthy autojoin baseline.
 async function restoreNetwork(token: string): Promise<void> {
   await patchNetworkConnectionState(token, NETWORK_SLUG, { connection_state: "connected" }).catch(

--- a/cicchetto/e2e/tests/unread-cursor-cluster.spec.ts
+++ b/cicchetto/e2e/tests/unread-cursor-cluster.spec.ts
@@ -59,9 +59,9 @@ function ownNickRows(page: Page, body: string) {
 test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
   // ── Sentinel 1: two-session own-msg-no-bump ─────────────────────────
   //
-  // Two browser contexts, same seeded vjt. Session A focused on #bofh,
+  // Two browser contexts, same seeded vjt. Session A focused on #spec-wN,
   // session B focused on $server. Session A sends a PRIVMSG. Session
-  // B's sidebar/BottomBar badge for #bofh must NOT bump.
+  // B's sidebar/BottomBar badge for #spec-wN must NOT bump.
   //
   // Mechanism (NOT asserted directly — only the behavior is):
   //   - session A's `scrollback.sendMessage` advances local cursor to
@@ -71,15 +71,17 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
   //   - session B's `applyReadCursorSet` (subscribe.ts) folds the new
   //     id into local `readCursors`
   //   - session B's `messagesUnread` memo (bucket B2) recomputes
-  //     `count_after(cursor)` on #bofh → drops the row → badge stays
+  //     `count_after(cursor)` on #spec-wN → drops the row → badge stays
   //     at 0 (or whatever pre-existing count was)
-  test("session A's send in #bofh does NOT bump session B's #bofh badge", async ({ browser }) => {
+  test("session A's send in #spec-wN does NOT bump session B's #spec-wN badge", async ({
+    browser,
+  }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
     const vjt = specUser();
 
     // Restore cursor to tail BEFORE either session loads so both
     // sessions hydrate with a clean (empty) unread state. Prior specs
-    // may have left the seeded vjt's cursor mid-pane on #bofh — bucket
+    // may have left the seeded vjt's cursor mid-pane on #spec-wN — bucket
     // B2's derived memo would otherwise show a stale unread count on
     // session B and the "did not bump" assertion would need to compare
     // deltas instead of absolutes. Clean baseline is simpler + more
@@ -94,13 +96,13 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
       await loginAs(pageA, vjt);
       await loginAs(pageB, vjt);
 
-      // Session A focused on #bofh; session B focused on $server.
+      // Session A focused on #spec-wN; session B focused on $server.
       await selectChannel(pageA, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
       await selectChannel(pageB, NETWORK_SLUG, NETWORK_SLUG, {
         awaitWsReady: false,
       });
 
-      // Snapshot session B's #bofh badge BEFORE the send. With the
+      // Snapshot session B's #spec-wN badge BEFORE the send. With the
       // cursor restored to tail, count_after(cursor) === 0 so the
       // badge element is absent (the production guard hides the
       // badge when count is 0). Use count() as the dispatchable
@@ -133,7 +135,7 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
       // testnet (typically <100ms).
       await pageB.waitForTimeout(POST_SEND_SETTLE_MS);
 
-      // The load-bearing assertion: session B's #bofh badge did NOT
+      // The load-bearing assertion: session B's #spec-wN badge did NOT
       // bump. Either still absent (count === 0) or still at the
       // pre-existing text. A bump would either materialize the badge
       // element (count goes 0 → 1) or grow its number.
@@ -157,9 +159,9 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
 
   // ── Sentinel 2: marker-collapses-on-send-in-focused ─────────────────
   //
-  // Single browser context. Seed `── XX unread ──` marker on #bofh by
+  // Single browser context. Seed `── XX unread ──` marker on #spec-wN by
   // having a peer PRIVMSG while focus is on $server, switch focus to
-  // #bofh to render the marker, then send a message. SEND-RELATCH
+  // #spec-wN to render the marker, then send a message. SEND-RELATCH
   // (2026-06-09, vjt: "marker showing + you send → hide it"): a focused
   // send is an explicit caught-up action and collapses the divider
   // immediately — NO window-switch needed. The freeze contract still
@@ -167,12 +169,12 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
   // an own send fires the `lastOwnSend` re-latch.
   //
   // Mechanism (NOT asserted directly — only the behavior is):
-  //   - peer privmsg lands on #bofh while focus is on $server →
+  //   - peer privmsg lands on #spec-wN while focus is on $server →
   //     server persists row with id > cursor → cic's incoming WS
-  //     fanout to #bofh topic stores the row but DOESN'T touch
+  //     fanout to #spec-wN topic stores the row but DOESN'T touch
   //     cursor (focus on $server, leave-arm on $server doesn't fire
-  //     for #bofh).
-  //   - switch focus to #bofh → key-effect latches `markerCursorId` at
+  //     for #spec-wN).
+  //   - switch focus to #spec-wN → key-effect latches `markerCursorId` at
   //     the pre-peer cursor → rows memo injects `unread-marker` BEFORE
   //     the first row with id > snapshot.
   //   - send a PRIVMSG → `sendMessage` advances the live cursor AND
@@ -190,8 +192,8 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
 
     await loginAs(page, vjt);
 
-    // Focus $server first so the peer's PRIVMSG to #bofh lands while
-    // #bofh is NOT focused — cursor stays put, row stacks past it.
+    // Focus $server first so the peer's PRIVMSG to #spec-wN lands while
+    // #spec-wN is NOT focused — cursor stays put, row stacks past it.
     await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
 
     const peerBody = `unread-cursor Z sentinel2 peer ${crypto.randomUUID().slice(0, 8)}`;
@@ -200,7 +202,7 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
       await peer.join(CHANNEL);
       peer.privmsg(CHANNEL, peerBody);
 
-      // Switch to #bofh — key-effect latches the snapshot at cursor <
+      // Switch to #spec-wN — key-effect latches the snapshot at cursor <
       // peer-row id, rows memo injects the unread-marker. Wait for the
       // peer row + marker to render before the focused send so the
       // pre-condition is visible (otherwise a marker-already-gone state
@@ -215,7 +217,7 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
         timeout: 5_000,
       });
 
-      // Send an own-PRIVMSG in the focused #bofh. `sendMessage` advances
+      // Send an own-PRIVMSG in the focused #spec-wN. `sendMessage` advances
       // the live cursor AND fires `lastOwnSend` → the send-relatch effect
       // hides the marker. No window-switch.
       const ownBody = `unread-cursor Z sentinel2 own ${crypto.randomUUID().slice(0, 8)}`;

--- a/cicchetto/e2e/tests/unread-divider-beyond-window.spec.ts
+++ b/cicchetto/e2e/tests/unread-divider-beyond-window.spec.ts
@@ -20,7 +20,7 @@
 // last-read row is not in the tail page, so neither it nor a correctly-
 // placed marker appears in the DOM.
 //
-// Per BUGHUNT-3 cascade rule: this spec rewinds the seeded vjt's #bofh
+// Per BUGHUNT-3 cascade rule: this spec rewinds the seeded vjt's #spec-wN
 // cursor to an early row, so it MUST restore to tail in afterAll or
 // downstream specs inherit a mid-list cursor → marker injects → scroll
 // lands mid-pane → cascade.
@@ -35,7 +35,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Own-presence kinds excluded from the unread-marker count — mirrors the
 // single source of truth `src/lib/ownPresenceEvent.ts` (`PRESENCE_KINDS`).
 // Used only to DERIVE the expected count from server data (the operator's
-// own auto-JOIN line on #bofh is the one such row after an early cursor);
+// own auto-JOIN line on #spec-wN is the one such row after an early cursor);
 // it is not the behaviour under test.
 const OWN_PRESENCE_KINDS = new Set(["join", "part", "quit", "nick_change", "mode", "kick"]);
 
@@ -67,7 +67,7 @@ test.describe("#156 unread divider with unread beyond the fetch window", () => {
     // not the full history (scroll-up `loadMore` pages further back).
     const readContextRow = rows[cursorIndex - 10];
     if (!lastReadRow || !firstUnreadRow || !readContextRow) {
-      throw new Error("#156 spec: seeded #bofh rows missing expected indices");
+      throw new Error("#156 spec: seeded #spec-wN rows missing expected indices");
     }
 
     // True unread = rows after the cursor MINUS the operator's own

--- a/cicchetto/e2e/tests/unread-off-by-one-on-leave.spec.ts
+++ b/cicchetto/e2e/tests/unread-off-by-one-on-leave.spec.ts
@@ -55,7 +55,7 @@ test.describe("#163 off-by-one unread on leave (pinned to bottom)", () => {
 
     await loginAs(page, vjt);
 
-    // Focus #bofh — the pane loads scrollback and pins to the bottom
+    // Focus #spec-wN — the pane loads scrollback and pins to the bottom
     // (`atBottom` starts true).
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
@@ -79,7 +79,7 @@ test.describe("#163 off-by-one unread on leave (pinned to bottom)", () => {
 
       // LEAVE without reload: focus the always-present $server window
       // (windowName === slug maps to the server tab). This fires the
-      // leave/settle cursor write for #bofh via `lastFullyVisibleRowId`.
+      // leave/settle cursor write for #spec-wN via `lastFullyVisibleRowId`.
       await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, {
         awaitWsReady: false,
       });
@@ -93,7 +93,7 @@ test.describe("#163 off-by-one unread on leave (pinned to bottom)", () => {
         timeout: 5_000,
       });
 
-      // Re-select #bofh. Load-bearing assertion #2: NO `── 1 unread
+      // Re-select #spec-wN. Load-bearing assertion #2: NO `── 1 unread
       // message ──` divider is re-injected. The marker derives from the
       // cursor snapshot on focus; a one-short cursor re-injects it.
       await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });

--- a/cicchetto/e2e/tests/uploads2-video-doc-upload.spec.ts
+++ b/cicchetto/e2e/tests/uploads2-video-doc-upload.spec.ts
@@ -37,7 +37,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const fixture = (name: string): Buffer =>
   readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)));
 
-// Shared preamble: login as the seeded vjt + focus #bofh.
+// Shared preamble: login as the seeded vjt + focus #spec-wN.
 async function openChannel(page: Page): Promise<void> {
   const vjt = specUser();
   await loginAs(page, vjt);

--- a/cicchetto/e2e/tests/ux-1-archive-delete.spec.ts
+++ b/cicchetto/e2e/tests/ux-1-archive-delete.spec.ts
@@ -43,7 +43,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.afterEach(async () => {
   // Restore the seed-time joined state so later specs that assume
-  // #bofh is joined keep working under retries.
+  // #spec-wN is joined keep working under retries.
   const vjt = specUser();
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL);
 });

--- a/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
+++ b/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
@@ -24,7 +24,7 @@
 //      cic re-fetches → entry vanishes from the modal group.
 //   6. Close modal (× in header) → modal closed.
 //
-// Cleanup: re-JOIN the channel in afterEach so later specs see #bofh
+// Cleanup: re-JOIN the channel in afterEach so later specs see #spec-wN
 // joined (mirror of UX-1 / iOS-3 pattern).
 //
 // Per-class parity matrix per `feedback_e2e_user_class_parity_matrix`:

--- a/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
@@ -69,8 +69,8 @@
 //     — this spec runs the registered class only (visitor pathway
 //     blocked), but the members-list-non-empty assertion satisfies
 //     that rule for the registered case.
-//   * K — scroll-on-activate: switch from #bofh → server window →
-//     #bofh; assert scrollback is scrolled to bottom (canonical
+//   * K — scroll-on-activate: switch from #spec-wN → server window →
+//     #spec-wN; assert scrollback is scrolled to bottom (canonical
 //     scrollToActivation routine fired).
 //   * L — settings overhaul: ShellChrome cog is always visible
 //     regardless of selected window kind. Assert cog visible on
@@ -102,7 +102,7 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #spec-wN
 
 type UserClass = {
   name: "registered" | "visitor" | "nickserv";
@@ -432,7 +432,7 @@ test("@webkit UX-4-Z cluster — case-fix + home + sidebar collapse + close-fall
       redirectedToHome > 0 || (selectedTabText !== null && !selectedTabText.includes(CHANNEL)),
     ).toBe(true);
 
-    // Re-join #bofh so the M arm has a settled scrollback (the M
+    // Re-join #spec-wN so the M arm has a settled scrollback (the M
     // arm reloads the page; without the re-join, the first selection
     // post-reload would land in a different state).
     await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});

--- a/cicchetto/e2e/tests/ux-5-bc-park-respawn.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bc-park-respawn.spec.ts
@@ -168,7 +168,7 @@ test("UX-5 BC — park then /connect from the same source IP succeeds (self-excl
   // up + autojoin re-landed). Without this assertion the test would
   // pass on a half-spawned regression where /connect returns 200 but
   // the autojoin loop silently fails. Polls /networks/:slug/channels
-  // until #bofh shows joined.
+  // until #spec-wN shows joined.
   let joined = false;
   for (let attempt = 0; attempt < 60; attempt++) {
     const channels = await fetchChannels(bearer).catch(() => null);

--- a/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
@@ -194,7 +194,7 @@ test("UX-5 BR — Home pane [Reconnect] chip reconnects a parked network", async
   // of a "connected" home row is incidental to the operator goal.
   await expect(parkedRow).toHaveCount(0, { timeout: 30_000 });
 
-  // Autojoin re-lands: poll the channels REST endpoint until #bofh
+  // Autojoin re-lands: poll the channels REST endpoint until #spec-wN
   // re-joins. Without this assertion the test passes on a half-spawned
   // regression where the chip's PATCH succeeds but the spawn dance
   // silently fails. Same pattern as ux-5-bc-park-respawn.

--- a/cicchetto/e2e/tests/ux-5-bu-unread-focus.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bu-unread-focus.spec.ts
@@ -2,7 +2,7 @@
 // transitions and sidebar re-click.
 //
 // Repro flow (vjt 2026-05-19):
-//   1. Channel #bofh is selected and tab is FOCUSED.
+//   1. Channel #spec-wN is selected and tab is FOCUSED.
 //   2. Tab BLURS (visibilitychange → hidden).
 //   3. Peer messages arrive, one mentions the operator.
 //   4. Sidebar: blue ".sidebar-msg-unread" badge AND red ".sidebar-mention"

--- a/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
@@ -25,7 +25,7 @@
 // start, then reverts in afterEach. Reason: admin-vjt has no network bind in
 // the seeder (intentional — m9b-admin-sessions-actions hardcodes session count
 // = 2 and would break if admin-vjt had a bind). vjt has the bind + autojoined
-// #bofh; promoting it temporarily gives the full surface (admin gate + joined
+// #spec-wN; promoting it temporarily gives the full surface (admin gate + joined
 // channel + rail drawer) without ripple-affecting other specs.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";

--- a/cicchetto/e2e/tests/ux-6-e-narrow-server-dedup.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-e-narrow-server-dedup.spec.ts
@@ -1,12 +1,12 @@
 // UX-6-E — narrow-mode (mobile) Server-tab dedup.
 //
 // Pre-fix narrow shape:
-//   [freenode]  [Server]  [#bofh]  ...
+//   [freenode]  [Server]  [#spec-wN]  ...
 //   ^chip span  ^standalone tab     channel tabs
 //
 // Post-fix shape (matches wide mode, where the network header IS the
 // server entry):
-//   [⚙️ freenode]  [×]  [#bofh]  ...
+//   [⚙️ freenode]  [×]  [#spec-wN]  ...
 //   ^clickable header   ^channel tabs
 //
 // The chip + emoji + slug compose the Server-window entry; clicking it

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -49,7 +49,7 @@
 // Seed shape: same as UX-6-C — PATCH the seeded `vjt` user to admin
 // via admin-vjt bearer at test start, revert in afterEach. admin-vjt
 // has no IRC bind (m9b session-count == 2 hardcode); vjt has the bind
-// + autojoined #bofh so it can reach the mobile launcher footer.
+// + autojoined #spec-wN so it can reach the mobile launcher footer.
 
 import type { Page } from "@playwright/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";

--- a/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
@@ -104,7 +104,7 @@ test("UX-6 K — focus-leave on a peer DM window advances the server-side read c
     await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
     // Step 1 — focus the peer window. selection.ts's on(selectedChannel)
-    // effect runs; the leave-arm fires for the OLD selection (#bofh),
+    // effect runs; the leave-arm fires for the OLD selection (#spec-wN),
     // not the new one. No cursor is set for the peer YET (focus
     // alone doesn't set; only LEAVING a window does).
     await selectChannel(page, NETWORK_SLUG, peer.nick, { awaitWsReady: false });

--- a/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
@@ -59,7 +59,7 @@ test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused wind
   // broadcast"; chasing that without console output is masochism.
   forwardPageDiagnostics(page);
   await loginAs(page, vjt);
-  // Stay focused on #bofh — peer DM lands in a NEW window we're NOT
+  // Stay focused on #spec-wN — peer DM lands in a NEW window we're NOT
   // looking at, so beep MUST fire (same focus-rule as the mention
   // gate).
   await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
@@ -123,7 +123,7 @@ test("channel mention fires in-app beep on a non-focused mention target", async 
     await page.locator(".compose-box textarea").press("Enter");
     await selectChannel(page, NETWORK_SLUG, MENTION_CHANNEL, { ownNick: specNick() });
 
-    // Re-focus #bofh so mention lands on a NON-focused window.
+    // Re-focus #spec-wN so mention lands on a NON-focused window.
     await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
 
     const mentionBody = `${specNick()}: you there?`;

--- a/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
@@ -56,7 +56,7 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.afterEach(async () => {
-  // Restore seeded baseline so the next spec sees #bofh joined.
+  // Restore seeded baseline so the next spec sees #spec-wN joined.
   const vjt = specUser();
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL);
 });
@@ -122,7 +122,7 @@ test("@webkit UX-Z cluster — Dynamic Island clearance + RailActions archive + 
 
   // ── UX-2 — archive opened via the always-on RailActions button (#473) ──
   //
-  // The PART above moved #bofh into archive. #473 removed the ShellChrome
+  // The PART above moved #spec-wN into archive. #473 removed the ShellChrome
   // archive button; archive is now reached from the always-on archive button
   // in the RailActions rail drawer, reachable on EVERY window kind (not
   // selection-gated). After the PART bucket E's close-watcher lands selection
@@ -134,7 +134,7 @@ test("@webkit UX-Z cluster — Dynamic Island clearance + RailActions archive + 
   await expect(modal.locator(".archive-modal-header h2")).toHaveText("Archive");
 
   // Expand the seeded network's collapsible group (lazy row load) and find
-  // the archived #bofh row within it.
+  // the archived #spec-wN row within it.
   const group = await expandArchiveGroup(page, NETWORK_SLUG);
   const row = group.locator(".archive-modal-row", { hasText: CHANNEL });
   await expect(row).toHaveCount(1);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54171,3 +54171,112 @@ three unknowns exactly when the comparison between them is the triage.
 - Whether any cross-file cascade actually changes verdict under the new
   grouping is **unknown until the first reds arrive**; the mechanism is
   argued above, the incidence is not.
+<!-- entry #1532 -->
+
+---
+
+## 2026-08-20 — #1532: the e2e prose named a room the subject had left
+
+`#1336` moved the per-spec subject off the shared `#bofh` onto
+`AUTOJOIN_CHANNELS[0]` = `` `#spec-w${TEST_PARALLEL_INDEX}` ``. The 292 callers
+followed the constant without being edited — that was the point of routing
+through a constant — and the prose did not follow anything, because prose has
+no callers. This entry records the census, the rule used to decide each
+occurrence one at a time, and the 66 that were deliberately left.
+
+### The count, because the issue said not to believe its own
+
+The issue filed `~135 files` and warned in the same breath: *"Measure with a
+bare grep before believing any count — a scoped grep in this tree has produced
+false zeros four separate ways."* Measured on `origin/main` `5d695a56`:
+
+| scope | files | lines |
+|---|---|---|
+| bare `git grep -F -i bofh`, whole tree | 195 | 770 |
+| `cicchetto/e2e` only | 138 | 399 |
+
+The `~135` was right about the order of magnitude and named the right tree; it
+is the e2e population, not the repo-wide one. The 399 lines split three ways
+and the split closes exactly — **12 + 355 + 32 = 399**:
+
+- **12** in the six e2e files that drive no per-spec subject at all
+  (`compose.yaml` and five generic fixtures whose `#bofh` is an illustrative
+  example: `` `#bofh` ⊂ `#bofh-test` ``, `` peer.join("#bofh") ``, a
+  `whois-card-channel` DOM sample);
+- **355** carrying the `#bofh` token inside a file that DOES drive the
+  per-spec subject — the domain of this change;
+- **32** carrying only a bare `bofh`: local identifiers (`const bofh`,
+  `bofhRow`, `bofhBadgeB`), the `mentionBody("bofh", runId)` message bodies,
+  `%23bofh`, and the `#BOFH`/`#BoFH` casing spellings.
+
+### The discriminator is measured, not assumed
+
+A file drives the per-spec subject when it reads
+`specUser`/`specNick`/`AUTOJOIN_CHANNELS`/`SEED_CHANNEL`/`specSubject`. **131 of
+the 138 do**; one (`seedData.ts`) legitimately speaks for both, and six speak
+for neither. In the 131, `#bofh` in a comment is false twice over: the subject
+autojoins `#spec-wN`, and `specSubject.ts` re-seeds the SAME 200 `seed-bot`
+rows into that channel, so "the seeded `#bofh` corpus" names the wrong room
+even where the row count is right.
+
+### 289 rewritten, 66 left — and the 66 are the interesting half
+
+Each occurrence was judged for meaning, per the issue's own rule that *"a blind
+`sed` would make the prose more wrong, not less"*. The test applied to each:
+**does replacing the token yield a TRUE sentence?** Where it does not, the line
+stays whole. The 66 fall into eight classes:
+
+| n | class |
+|---|---|
+| 22 | names the compose seeder or the bind of the three long-lived users (`vjt`, `m9b-test`, `m9b-victim`) — that really is `#bofh`, including the `(vjt, bahamut-test, #bofh)` DB-row tuples |
+| 14 | the token is qualified by a SHARING claim that #1336 removed ("the shared `#bofh`", "NOT the shared seeded autojoin") — renaming would assert the per-spec channel is shared, the opposite of what the move bought |
+| 7 | the other half of a sentence whose first half stays `#bofh`; renaming only one half makes one sentence name two rooms |
+| 7 | the `anti-#bofh-pollution` idiom — a named hazard of the shared room, not a channel reference |
+| 6 | a co-resident `+o` / three-way autojoin race, which only exists where co-residents do |
+| 5 | past-tense history ("earlier iterations drove", "used to leave the SHARED cursor") — true as written |
+| 4 | the #1336 comment set itself, which names the shared room on purpose |
+| 1 | `ux-4-z-cluster-journey`'s casing arm — see below |
+
+### Three things the census turned up that the issue did not claim
+
+**The premise "none of them is a value the suite acts on" is true of the 289
+and false of the population.** `issue188-mentions-panel-polish` and
+`issue71-inc2-permanent-rail-desktop` pass `mentionBody("bofh", runId)` and
+assert on the rendered `` `ping in bofh ${runId}` ``: those ARE values, they
+just carry a bare `bofh` rather than `#bofh`, and they were left alone for that
+reason. A future sweep that widens the pattern to bare `bofh` would be editing
+behaviour, not prose.
+
+**`ux-4-z-cluster-journey` bucket A describes an assertion it no longer makes.**
+Its header says *"channel case-insensitivity: `/join #BOFH` routes to the same
+window as `#bofh`"*, and the arm at `:194` focuses the autojoin channel via the
+canonical name and asserts a single tab — there is no uppercase actor anywhere
+in the file. Renaming the channel there would have laundered that divergence
+into a sentence that reads correct, so both lines were left and the divergence
+is recorded here instead. **Not fixed and not filed** — it is a test-content
+question, outside a prose issue.
+
+**A second axis is stale in the same comments, and is deliberately untouched.**
+Many of these lines say `vjt` where the subject is `specUser()`. The code does
+too — `const vjt = specUser()` is the standing spelling — so the name is
+#1078's debt rather than a signal about the room, and treating it as one is
+what would have turned a prose fix into a rename. Consequence, stated so it is
+not read as an oversight: **33 files now carry both spellings**, and that is
+correct by construction, because the two spellings name two different rooms.
+
+### Not established
+
+- **No spec was run.** The gate is `bun run check` (biome + both `tsc`
+  projects) and `bun run test`, both green; the argument that no e2e run is
+  needed is the issue's own — every occurrence touched is a comment, a test
+  title or a thrown message, none of them a value the suite acts on. That is a
+  reason, not a measurement, and it does not cover the two `mentionBody`
+  call sites above, which is why they were left.
+- **The 66 were not re-derived by a second tool.** They come from one pass with
+  an explicit per-line exclusion table; a different reader would move some
+  lines between "left" and "rewritten" at the margin.
+- **`#spec-wN` is a literal, and literals rot.** It replaces the lie without
+  curing the class: name the constant (`AUTOJOIN_CHANNELS[0]`) and the next
+  channel move needs no sweep at all. Rewriting 289 sentences that way was
+  judged a larger change than the issue asked for, and is left as the obvious
+  follow-up if the channel shape ever moves again.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -559,6 +559,45 @@ Do **not** tag a spec on a hunch. A declaration is a claim that the spec
 was measured on both sides of the input; an unmeasured one is a guess
 wearing a gate's clothes, and it will red somebody else's run.
 
+## The cic gate's biome is NOT the one in `node_modules/.bin` (#1532)
+
+**Measured 2026-08-20, in the main checkout and in every worktree at
+once** (they all clone `node_modules` from the same source, so the drift
+propagates):
+
+```
+cicchetto/node_modules/.bin/biome --version   ->  2.4.13
+cicchetto/package.json "@biomejs/biome"       ->  2.5.8
+```
+
+On the same clean tree, `./node_modules/.bin/biome check
+--max-diagnostics=none` reported **7 errors** and `scripts/bun.sh run
+check` reported **0**. Two different binaries, two different verdicts.
+`cicchetto/scripts/check.ts` resolves the pinned version through bun and
+says so in its own comment — *"#1571 measured a `node_modules` whose
+biome was three minor versions behind"*; the `lock drift` stage exists
+for this family and passes anyway, because the `.bin` shim is not what
+it compares.
+
+**So the oracle for any biome number is `scripts/bun.sh run check`, run
+from the ROOT of the worktree — never the binary path.** A count taken
+from `.bin` is not comparable with the gate's, nor with another
+worktree's. When two runs disagree, check `--version` before you go
+looking for the cause in the code: the tree is usually innocent.
+
+Two follow-on tells from the same incident:
+
+- **The gate's biome reports lint and formatter separately, and the
+  errors are the `×` lines.** The `path:line lint/rule` headers above
+  them are frequently WARNINGS in files you never touched; reading those
+  as the failure sends you hunting a `_build`-style contamination that
+  is not there. Scroll to `×` and read what follows it.
+- **A prose edit that LENGTHENS a token can redden the formatter.**
+  #1532 replaced `#bofh` with `#spec-wN` (+3 characters) and pushed
+  exactly two lines past the 100-column `lineWidth`. The fix is to paste
+  the formatter's own printed output, not to shorten the sentence so it
+  fits.
+
 ## Five e2e gate traps that fake a green (or a red)
 
 These five each make a broken run *look* fine — or a fine run look


### PR DESCRIPTION
#1336 moved the per-spec subject off the shared `#bofh` onto
`AUTOJOIN_CHANNELS[0]` = `` `#spec-w${TEST_PARALLEL_INDEX}` ``. The 292
callers followed the constant without being touched. The prose did not
follow anything, because prose has no callers — so what is left is a
comment set naming a channel the subject is no longer in.

**289 occurrences rewritten across 110 files. 66 deliberately left**,
each because renaming it would make the prose *more* wrong.

## The count came first, and the issue was right not to trust its own

The issue says `~135 files` and warns in the same breath: *"Measure with
a bare grep before believing any count — a scoped grep in this tree has
produced false zeros four separate ways."*

| scope | files | lines |
|---|---|---|
| bare `git grep -F -i bofh`, whole tree | 195 | 770 |
| `cicchetto/e2e` only | 138 | 399 |

The `~135` named the right tree and the right order of magnitude. The
399 e2e lines split three ways and the split closes exactly —
**12 + 355 + 32 = 399**:

- **12** in the six e2e files that drive no per-spec subject
  (`compose.yaml`, plus five generic fixtures whose `#bofh` is an
  illustrative example);
- **355** with the `#bofh` token in a file that *does* drive the
  per-spec subject — the domain of this PR;
- **32** with only a bare `bofh`: identifiers (`const bofh`, `bofhRow`,
  `bofhBadgeB`), `mentionBody("bofh", runId)`, `%23bofh`, `#BOFH`.

The domain reconciles too: **289 changed + 66 left = 355**.

## The discriminator is measured, not assumed

A file drives the per-spec subject when it reads
`specUser`/`specNick`/`AUTOJOIN_CHANNELS`/`SEED_CHANNEL`/`specSubject`.
**131 of the 138 do.** In those, `#bofh` in a comment is false twice
over: the subject autojoins `#spec-wN`, and `specSubject.ts` re-seeds
the same 200 `seed-bot` rows into *that* channel — so "the seeded
`#bofh` corpus" names the wrong room even where the row count is right.

## The 66 left whole

Each occurrence was judged for meaning, per the issue's rule that *"a
blind `sed` would make the prose more wrong, not less"*. The test:
**does replacing the token yield a TRUE sentence?**

| n | class |
|---|---|
| 22 | names the compose seeder or the bind of the three long-lived users (`vjt`, `m9b-test`, `m9b-victim`) — that really is `#bofh`, including the `(vjt, bahamut-test, #bofh)` DB-row tuples |
| 14 | qualified by a SHARING claim #1336 removed — renaming would assert the per-spec channel is shared, the opposite of what the move bought |
| 7 | the other half of a sentence whose first half stays `#bofh` |
| 7 | the `anti-#bofh-pollution` idiom — a named hazard, not a channel reference |
| 6 | a co-resident `+o` / three-way autojoin race, which only the shared room has |
| 5 | past-tense history — true as written |
| 4 | the #1336 comment set, which names the shared room on purpose |
| 1 | `ux-4`'s casing arm (below, now #1620) |

## Three things the census turned up that the issue does not claim

**The premise "none of them is a value the suite acts on" is true of the
289 and false of the population.** `issue188-mentions-panel-polish` and
`issue71-inc2-permanent-rail-desktop` pass `mentionBody("bofh", runId)`
and assert on the rendered `` `ping in bofh ${runId}` ``. Those *are*
values — they carry a bare `bofh`, not `#bofh`, and were left alone for
that reason. Widening the pattern to bare `bofh` would be editing
behaviour, not prose.

**`ux-4-z-cluster-journey` bucket A describes an assertion it no longer
makes.** Its header says *"channel case-insensitivity: `/join #BOFH`
routes to the same window as `#bofh`"*; the arm at `:194` focuses the
autojoin channel via the canonical name and asserts a single tab. There
is no uppercase actor in the file. Renaming the channel there would have
laundered that into a sentence that reads correct, so both lines stay.
Filed as #1620 rather than fixed — no cure was measured, and it is a
test-content question, not a prose one.

**33 files now carry BOTH spellings, and that is the correct end state
— not half-finished work.** `#bofh` is still the real room of the three
long-lived seeded users (`vjt`, `m9b-test`, `m9b-victim`), which
`compose.yaml` still binds and seeds; `#spec-wN` is the room the spec
subject is in. The two spellings name two different rooms, so a file
that talks about both carries both. Please do not "finish" this by
sweeping the remainder.

Many of these comments also say `vjt` where the subject is
`specUser()` — but the code says that too (`const vjt = specUser()` is
the standing spelling), so the name is #1078's debt, not a signal about
the room. This PR owns the room. Where a sentence needed both halves to
agree, the whole sentence was left.

## Gates

| gate | result |
|---|---|
| `bun run check` (lock drift, biome src+e2e, tsc src, tsc e2e) | 4 stages, 0 failed |
| `bun run test` | 294 files, 5694 tests, 0 failures |
| `scripts/design-notes-gate.sh` | 1 new entry, separator + marker present |

Two lines needed re-wrapping: `#spec-wN` is three characters longer than
`#bofh` and pushed them past the 100-column formatter limit. Both carry
the formatter's own output rather than a sentence shortened to fit.

**No e2e run, and that is the issue's own reasoning rather than an
omission:** every occurrence touched is a comment, a test title or a
thrown message — *"none of them is a value the suite acts on"*. No CI
job greps a test title for `#bofh` (checked). That is an argument, not a
measurement, and it does not cover the two `mentionBody` call sites,
which is exactly why they were left.

`scripts/union-rebase.sh origin/main` exits 0 with `+109 -0` on
`DESIGN_NOTES` — but it says itself that the run is *"VACUOUS by
construction"* because the branch is already on the tip and the merge
driver never ran. Recorded as a non-measurement, not as a pass.

## Filed and commented, not fixed here

- **#1620** — `ux-4` bucket A's header promises the casing test above.
  Filed rather than fixed: no cure was measured, and it is a
  test-content decision.
- A comment on **#1532** records the false-premise guard-rail, so the
  next sweep does not widen the pattern to bare `bofh` and change
  behaviour by accident.

## One extra commit, deliberately outside the issue

`docs(#1532): put the biome-binary trap where the next runner finds it`
adds a `docs/TESTING.md` section for a trap this work paid for:
`cicchetto/node_modules/.bin/biome` is **2.4.13** while `package.json`
pins **2.5.8**, in main and in every worktree, and on one clean tree the
binary reported 7 errors where `scripts/bun.sh run check` reported 0.
The `lock drift` stage passes regardless — it does not compare the
`.bin` shim. Riding here rather than in its own PR because it is one
paragraph and the incident belongs to this change; say the word and it
moves.

## Not claimed

`#spec-wN` is a literal, and literals rot. It removes the lie without
curing the class — naming the constant (`AUTOJOIN_CHANNELS[0]`) is what
would survive the next channel move. Rewriting 289 sentences that way is
a larger change than this issue asked for; it is written up in the entry
as the follow-up if the shape ever moves again.
