### PR TITLE
ci(#1519): split the integration suite across four Playwright shards

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,8 +44,15 @@ name: integration
 #
 # Stack timing: cold ~6-8 min for the testnet+grappa+nginx images +
 # Playwright base pull; warm with cache it's faster but we don't cache
-# docker layers cross-runs (would need a registry push). Suite itself
-# runs in ~16s once everything is up.
+# docker layers cross-runs (would need a registry push). The "suite runs
+# in ~16s" that stood here was true of the first dozen specs and has not
+# been for a long time: measured 2026-08-20 it is 33.6 min of the 40.5,
+# which is what #1519 shards. The per-shard numbers are on the job below.
+#
+# The suite is split across FOUR jobs (#1519), one Playwright `--shard`
+# each, each with its OWN stack — sharding is N separate jobs, and it does
+# NOT touch `workers: 1`, which stays load-bearing inside every shard
+# (three long-lived users still share `#bofh`, see the issue).
 #
 # Failure artifacts: Playwright writes traces (zip), screenshots, and
 # videos to cicchetto/e2e/test-results/ on test failure (configured in
@@ -116,8 +123,44 @@ concurrency:
 
 jobs:
   e2e:
-    name: cicchetto + grappa + azzurra-testnet
+    name: cicchetto + grappa + azzurra-testnet (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    # #1519 — FOUR jobs, each booting its own stack and running a quarter
+    # of the suite. Measured on the green run 32395956800 (2026-08-20),
+    # step timings read off the job log rather than estimated:
+    #
+    #   1.7 min  checkout (submodules) + compose plugin + GHCR login
+    #   4.6 min  `testnet up`: mix deps.get + Elixir compile, solanum
+    #            built from source, image assembly, container health
+    #  33.6 min  the Playwright suite — 759 passed, one worker
+    #   0.5 min  census + tear-down
+    #  ------
+    #  40.5 min  total
+    #
+    # Only the 33.6 divides. The other 6.8 min is fixed and every shard
+    # pays it in full, so four shards land at ~15 min wall clock, not the
+    # ~13.4 the issue's arithmetic gave (it counted the in-script boot and
+    # forgot the checkout and the tear-down). Eight would buy ~4 more
+    # minutes for double the runners; 4 is the knee.
+    #
+    # Paying the boot ONCE was considered and rejected on the numbers: a
+    # build-once job that publishes the images has to FINISH before any
+    # shard starts, so it adds a serial stage the same size as the thing
+    # it removes (~5 min), and 5 + pull + 8.4 is no better than four
+    # parallel 15s. Layer caching (`type=gha`) might shrink the per-shard
+    # build; it is NOT measured, so it is not claimed here.
+    #
+    # NOT measured, and it is the assumption the whole gain rests on: the
+    # account's runner concurrency. If four jobs cannot start together the
+    # arithmetic degrades towards the serial number.
+    strategy:
+      # A red shard must NOT cancel the other three. The suite's triage
+      # runbook (docs/TESTING.md) works by comparing what failed against
+      # what passed — cancelling the rest destroys exactly that evidence
+      # and turns one red into "three unknowns". The default is true.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     # 60, not 45 — third raise (25 -> 30 in 6478ef72, 30 -> 45, now 60),
     # and the reason to stop doing this arithmetic is measured in #1519:
     # across 85 green runs on main between 2026-08-11 and 2026-08-18 the
@@ -134,10 +177,13 @@ jobs:
     # only fire when something is actually wrong. #696 was killed at test
     # 589 of 590 by the cap alone, not by a failure; that must not recur.
     #
-    # This raise buys headroom, it fixes nothing. #1519 holds the
-    # breakdown and the three levers (cache the dep compile, shard the
-    # suite, or make it parallel-safe). If the cap is ever the thing
-    # tracking the suite's growth again, raise the issue, not the number.
+    # That raise bought headroom and fixed nothing; the SHARD below is the
+    # fix, and it is one of the three levers #1519 named (the other two —
+    # cache the dep compile, make the suite parallel-safe — are untouched).
+    # 60 stays: a backstop belongs far above the working range, and the
+    # working range just fell to ~15 min, so the cap is further from firing
+    # than it has ever been. If it is ever the thing tracking the suite's
+    # growth again, raise the issue, not the number.
     timeout-minutes: 60
     # `packages: read` so `docker login ghcr.io` can pull the
     # prebuilt bahamut + services images from `ghcr.io/vjt/*` (see
@@ -208,15 +254,27 @@ jobs:
         # Paths are RELATIVE to the CWD that scripts/{integration,
         # testnet}.sh cd into (cicchetto/e2e/), which is where both
         # compose files live.
+        #
+        # The shard denominator is `strategy.job-total`, NEVER a literal 4:
+        # it is the length of the matrix above, so the two cannot drift into
+        # a filter that silently drops or double-runs tests. Playwright's
+        # `--shard` reaches `npx playwright test` through the script's `"$@"`,
+        # the same door `--grep` uses, so no script change is needed and a
+        # local reproduction of shard 2 is `scripts/integration.sh --shard=2/4`.
         env:
           COMPOSE_FILE: compose.yaml:compose.ghcr-vjt.yaml
-        run: bash scripts/integration.sh
+        run: bash scripts/integration.sh --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Upload Playwright traces (on failure)
+        # Every artifact name below carries the shard (#1519). Not cosmetic:
+        # upload-artifact v4+ REFUSES a name that already exists in the run,
+        # so four shards uploading `playwright-traces` would fail the upload
+        # step of whichever lost the race — a red on top of the red being
+        # triaged, with the evidence missing.
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-traces
+          name: playwright-traces-shard-${{ matrix.shard }}
           path: cicchetto/e2e/test-results/
           # 14d is enough to triage; default 90d wastes storage on
           # a noisy suite during the early CI shakedown phase.
@@ -227,7 +285,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: cicchetto/e2e/playwright-report/
           retention-days: 14
           if-no-files-found: ignore
@@ -240,7 +298,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: container-logs
+          name: container-logs-shard-${{ matrix.shard }}
           path: cicchetto/e2e/container-logs/
           retention-days: 14
           if-no-files-found: ignore
@@ -253,7 +311,42 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: log-gap-census
+          name: log-gap-census-shard-${{ matrix.shard }}
           path: cicchetto/e2e/container-logs/gap-scan.tsv
           retention-days: 14
           if-no-files-found: ignore
+
+  # The one check name that cannot silently miss a shard (#1519).
+  #
+  # `needs.e2e.result` over a MATRIX is the aggregate of every leg: it is
+  # `success` only when all four succeeded, and `failure` as soon as one
+  # fails. So this job is the single place where "the suite passed" is
+  # stated, and it stays true if the matrix grows to eight without anyone
+  # remembering to add a name anywhere.
+  #
+  # `if: always()` is load-bearing and is the whole reason this is not a
+  # bare `needs:`. Without it, a failed shard makes this job SKIPPED — and
+  # a skipped check does not read as a failure to a human scanning the PR
+  # or to a required-check rule. Skipped would be the gate that lies.
+  #
+  # main today has no branch protection and no ruleset (measured, 2026-08-20:
+  # the protection API answers 404 and `/rulesets` is `[]`), so nothing is
+  # "required" by name yet. That is exactly why the stable name is worth
+  # having before it is needed: the day one is required, it is one entry,
+  # not four that a fifth shard would leave behind.
+  e2e-result:
+    name: integration (all shards)
+    if: always()
+    needs: e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail unless every shard succeeded
+        env:
+          SHARDS_RESULT: ${{ needs.e2e.result }}
+        run: |
+          echo "aggregate result of the shard matrix: $SHARDS_RESULT"
+          [ "$SHARDS_RESULT" = success ] || {
+            echo "at least one shard did not succeed — see the per-shard jobs" >&2
+            exit 1
+          }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54060,3 +54060,114 @@ underneath it. Recorded here rather than filed as an issue, because "these are
 out of scope and here is why" is the outcome, not a backlog item: a reader who
 flips `ignoreTypes` to false will find exactly 11 and now knows what they are
 looking at.
+<!-- entry #1519 -->
+
+---
+
+## 2026-08-20 — #1519: four shards, and the three ways a sharded gate lies
+
+`integration` was one job, one stack, one Playwright worker, 40.5 minutes,
+and a daily median climbing +0.42 min/day. vjt's ruling: shard it, "4 or
+even 8 workers". The word "worker" covers two different things and only one
+of them is authorised here — **sharding is N separate JOBS, each with its own
+stack; `workers: 1` inside a shard is untouched**, because the three
+long-lived users (`vjt`, `m9b-test`, `m9b-victim`) still share `#bofh`
+(`compose.yaml:262,286,296`) and #1618 has just measured a 31572 ms SQLite
+write lock in `record_client_source` with the suite running SERIALLY. Shard
+first, shared-state audit after.
+
+### What divides and what does not
+
+Step timings read off the green run `32395956800` (2026-08-20), not
+estimated:
+
+| phase | min |
+|---|---|
+| checkout with submodules + compose plugin + GHCR login | 1.7 |
+| `testnet up` — deps.get, Elixir compile, solanum built from source, images, health | 4.6 |
+| the Playwright suite — 759 passed, one worker | 33.6 |
+| census + tear-down | 0.5 |
+| **total** | **40.5** |
+
+Only the 33.6 divides; the other **6.8 is fixed and every shard pays it in
+full**. Four shards therefore land at ~15 min, not the ~13.4 the issue's
+table gave — that arithmetic used the in-script boot alone and forgot the
+checkout ahead of it and the tear-down behind it. Eight would reach ~11: four
+minutes for double the runners, with the fixed cost dominating. **Four.**
+
+**Paying the boot once was considered and rejected on those numbers.** A
+build-once job that publishes the images has to FINISH before any shard can
+start, so it adds a serial stage the same size as the one it removes (~5
+min), and `5 + pull + 8.4` is no better than four parallel 15s. Layer caching
+(`type=gha`) might shrink the per-shard build; it is **not measured**, so it
+is not claimed.
+
+### The partition is proven, not assumed
+
+A sharded gate that reports green having run fewer tests is worse than a slow
+one. Measured with `playwright test --list` on `bb65f73b`:
+
+| shard | tests |
+|---|---|
+| 1/4 | 190 |
+| 2/4 | 190 |
+| 3/4 | 191 |
+| 4/4 | 188 |
+| **sum** | **759** — the unsharded total, to the test |
+
+Cardinality is the weak form and it was not the one relied on: the four shard
+listings were compared to the full listing as SETS. Tests in the total and in
+no shard: 0. Tests in a shard and not in the total: 0. Tests in two shards: 0.
+The comparator was shown a deliberately altered input and reported the
+difference, so the zeros are measurements rather than a silent parser.
+
+The split granularity is the **(project, file) group**: 447 such groups, and
+not one of them spans two shards. Ordering WITHIN a file is therefore
+preserved exactly as `fullyParallel: false` implies. What is not preserved is
+ordering ACROSS files, and that is a real change to cascade behaviour — the
+set of specs that can pollute a given one is now a quarter of what it was.
+`docs/TESTING.md` carries that warning next to the triage tree.
+
+### The three ways this could have gone quietly wrong
+
+Each is now a bats case (`test/infra/integration_shard_test.bats`), deriving
+its expectation from the workflow rather than transcribing the shard count,
+and each was verified by mutation — six mutants, six kills, one assertion
+each.
+
+1. **The denominator.** `--shard=i/N` with N adrift from the number of jobs
+   silently drops the tail of the suite (too big) or double-runs (too small),
+   and Playwright is content either way: it filters, it does not audit. So the
+   denominator is `${{ strategy.job-total }}` — the matrix's own length, not a
+   literal. That is also why the matrix must stay ONE-dimensional: job-total
+   counts LEGS, so a second axis would double them while the shard values
+   stayed 1..4.
+2. **Artifact names.** `upload-artifact` v4+ refuses a name already present in
+   the run, so four shards uploading `playwright-traces` would fail three
+   uploads — a second red on top of the one being triaged, with the evidence
+   missing. Every name carries `-shard-${{ matrix.shard }}`.
+3. **The aggregate check.** `needs.e2e.result` over a matrix is `success` only
+   if every leg succeeded, which makes `e2e-result` the one name that cannot
+   miss a shard. It carries `if: always()` deliberately: without it a failed
+   shard leaves the aggregate SKIPPED, and a skipped check does not read as a
+   failure to a human or to a required-check rule. `main` has no branch
+   protection and no ruleset today (measured: the protection API answers 404,
+   `/rulesets` is `[]`), so nothing is required by name yet — the stable name
+   exists so that the day one is, it is one entry and not four.
+
+`fail-fast` is explicitly `false` for the opposite reason to the usual one:
+the default cancels the surviving shards, which replaces three results with
+three unknowns exactly when the comparison between them is the triage.
+
+### Not claimed
+
+- **The runner concurrency ceiling was not measured**, and the entire gain
+  rests on it: if four jobs cannot start together, the wall clock degrades
+  towards the serial number. Nothing in this change detects that.
+- The per-shard counts are equal to within three tests; their **durations are
+  not measured**. Wall clock is the slowest shard, so a slice heavy in slow
+  specs sets it, and the ~15 min figure assumes the median holds across the
+  split.
+- Whether any cross-file cascade actually changes verdict under the new
+  grouping is **unknown until the first reds arrive**; the mechanism is
+  argued above, the incidence is not.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,6 +22,14 @@ The CI pipeline runs all three on every push to main. Both `ci.yml`
 (Elixir + lint + audit + cic) and `integration.yml` (Playwright)
 must be green for the commit to count.
 
+`integration.yml` is **four jobs, not one** (#1519): the suite is split
+with Playwright's `--shard`, each leg booting its own stack. Read the
+aggregate off **`integration (all shards)`** — the one check that is red
+whenever any shard is. Per-shard artifacts are suffixed
+(`playwright-traces-shard-2`, `container-logs-shard-2`, …), because
+`upload-artifact` refuses a duplicate name inside a run. Locally nothing
+changes: `scripts/integration.sh` with no argument still runs all 759.
+
 ## Quick reference
 
 ```bash
@@ -65,6 +73,7 @@ scripts/integration.sh                   # full suite, cold bring-up + tear-down
 scripts/integration.sh --grep "UX-6 K"   # one spec or pattern
 scripts/integration.sh --project chromium --grep "UX-6 K"  # one project
 scripts/integration.sh --project chromium --grep "UX-6 K" --repeat-each 3
+scripts/integration.sh --shard=2/4       # exactly what CI's shard 2 runs (#1519)
 KEEP_STACK=1 scripts/integration.sh ...  # leave testnet up after run for iterative debugging
 scripts/testnet.sh up|down|status|logs <svc>|probe|shell <svc>
 ```
@@ -360,9 +369,12 @@ also dumps one log file per container to `cicchetto/e2e/container-logs/`
 trap destroys the containers. The service set is derived from
 `docker compose ps`, so a service added later is covered without editing
 anything. Failure-only: a green run writes nothing. The `integration`
-workflow uploads the directory as the `container-logs` artifact
-alongside the trace + report, so a CI-only red can be read from the
-server side too instead of stopping at the browser.
+workflow uploads the directory as the `container-logs-shard-<N>`
+artifact alongside the trace + report, so a CI-only red can be read from
+the server side too instead of stopping at the browser. The `-shard-<N>`
+suffix names which of the four stacks it came from — a red in shard 3
+carries no evidence about the other three, which is precisely why
+`fail-fast` is off and the other three still run.
 
 **Per-spec subject (#1078).** Every spec gets its OWN throwaway user
 rather than sharing the seeded `vjt`: the `_specSubject` `auto: true`
@@ -397,6 +409,18 @@ anything else.
 ```bash
 scripts/integration.sh --project chromium --grep "<failing spec>" --repeat-each 3
 ```
+
+⚠️ **Sharding changed what "upstream spec" means (#1519).** A cascade is
+state left behind by a spec that ran EARLIER ON THE SAME STACK, and each
+of the four shards is now its own stack with its own quarter of the
+roster. So the set of specs that can pollute a given one is a quarter of
+what it was, and a cascade that used to reproduce can stop reproducing —
+or start — because the two specs landed in different shards. Reproduce
+CI's grouping with `--shard=<N>/4` before concluding anything about
+order; a plain full local run is a fifth grouping, not the one that
+failed. The split is by (project, file) group and it is stable for a
+given roster: measured on `bb65f73b`, no file is split across shards
+within a project.
 
 The decision tree:
 

--- a/test/infra/integration_shard_test.bats
+++ b/test/infra/integration_shard_test.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1519 — the sharded `integration` workflow must not be
+# able to report green while running fewer tests than the suite has.
+#
+# Sharding splits one 40-minute job into four that each run a QUARTER of the
+# Playwright suite. The win is real and measured, but it moves the gate's
+# honesty from "one job ran everything" to "four filters partition
+# everything", and a partition can break in ways that are invisible from a
+# green tick:
+#
+#   WRONG DENOMINATOR   `--shard=i/N` with N != the number of jobs. Too big
+#                       and the tail of the suite is never run by anyone; too
+#                       small and shards overlap. Playwright is happy either
+#                       way — it filters, it does not audit.
+#   NAME COLLISION      four jobs uploading the same artifact name. v4+ of
+#                       upload-artifact REFUSES a duplicate, so the loser's
+#                       step fails and the evidence for the red being triaged
+#                       is the thing that goes missing.
+#   CANCELLED SIBLINGS  `fail-fast` defaults to TRUE: one red shard cancels
+#                       the other three, turning one failure into three
+#                       unknowns and destroying the comparison the triage
+#                       runbook is built on.
+#   SKIPPED AGGREGATE   a `needs:` job without `if: always()` is SKIPPED when
+#                       a dependency fails, and a skipped check reads as
+#                       "nothing to see" rather than as a failure.
+#
+# Every check DERIVES its expectation from the workflow itself — the shard
+# list is read, never transcribed — so raising the shard count is a one-line
+# edit that this suite follows. A hardcoded 4 here would be a second copy of
+# the number, i.e. the very drift being guarded against.
+#
+# The denominator is `${{ strategy.job-total }}` and that is why the
+# single-dimension check below exists: job-total counts matrix LEGS, not
+# `shard` values, so a second dimension (say an `os:` axis) would double the
+# legs while the shard values stayed 1..4, and every test would run twice
+# under a denominator nobody edited.
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+WORKFLOW="$REPO_ROOT/.github/workflows/integration.yml"
+
+# The `matrix:` block's keys, one per line. Two-space-deeper indent than
+# `matrix:` itself, which under `jobs.<id>.strategy` is eight spaces.
+matrix_keys() {
+    awk '
+        /^      matrix:$/ { inmatrix = 1; next }
+        inmatrix && /^        [a-zA-Z_-]+:/ {
+            key = $1; sub(/:$/, "", key); print key; next
+        }
+        inmatrix && /^ {0,7}[a-zA-Z_-]/ { inmatrix = 0 }
+    ' "$WORKFLOW"
+}
+
+# The shard values as a whitespace-separated list, read off the matrix.
+shard_values() {
+    sed -n 's/^        shard: *\[\(.*\)\]$/\1/p' "$WORKFLOW" | tr -d ' ' | tr ',' ' '
+}
+
+# Artifact names: the `name:` that follows each `uses: actions/upload-artifact`.
+artifact_names() {
+    awk '
+        /uses: actions\/upload-artifact/ { pending = 1; next }
+        pending && /^ +name: / {
+            line = $0; sub(/^ +name: /, "", line); print line; pending = 0
+        }
+    ' "$WORKFLOW"
+}
+
+@test "the shard matrix has exactly one dimension (#1519)" {
+    keys="$(matrix_keys)"
+
+    # Vacuity guard: a parser that matched nothing would compare "" to
+    # "shard" and fail loudly, but one that matched everything would pass
+    # this by accident. State the count.
+    count="$(printf '%s\n' "$keys" | grep -c . || true)"
+    [ "$count" -eq 1 ] || {
+        printf 'expected exactly 1 matrix dimension, found %s:\n%s\n' "$count" "$keys" >&2
+        printf 'the shard denominator is ${{ strategy.job-total }}, which counts LEGS.\n' >&2
+        printf 'a second dimension multiplies the legs and the denominator goes stale.\n' >&2
+        return 1
+    }
+    [ "$keys" = "shard" ] || {
+        printf 'the single matrix dimension is %s, expected shard\n' "$keys" >&2
+        return 1
+    }
+}
+
+@test "the shard values are 1..N with no gap and no repeat (#1519)" {
+    values="$(shard_values)"
+
+    n="$(printf '%s\n' $values | grep -c . || true)"
+    [ "$n" -ge 2 ] || {
+        printf 'parsed %s shard value(s) from the matrix — the extractor is wrong or the suite is not sharded:\n%s\n' \
+            "$n" "$values" >&2
+        return 1
+    }
+
+    expected="$(seq 1 "$n" | tr '\n' ' ')"
+    actual="$(printf '%s\n' $values | sort -n | tr '\n' ' ')"
+    [ "$expected" = "$actual" ] || {
+        printf 'shard values are [%s], expected the contiguous [%s]\n' "$actual" "$expected" >&2
+        printf 'Playwright reads i/N positionally: a gap leaves a slice of the suite unrun,\n' >&2
+        printf 'a repeat runs one twice, and both report green.\n' >&2
+        return 1
+    }
+}
+
+@test "the shard denominator is derived from the matrix, never a literal (#1519)" {
+    invocation="$(grep -n -- '--shard=' "$WORKFLOW" || true)"
+
+    [ -n "$invocation" ] || {
+        echo "no --shard= invocation in the workflow at all" >&2
+        return 1
+    }
+
+    printf '%s\n' "$invocation" \
+        | grep -qF -- '--shard=${{ matrix.shard }}/${{ strategy.job-total }}' || {
+        printf 'the --shard invocation does not derive its denominator:\n%s\n' "$invocation" >&2
+        printf 'expected --shard=${{ matrix.shard }}/${{ strategy.job-total }} — a literal N is a\n' >&2
+        printf 'second copy of the matrix length, free to drift away from it silently.\n' >&2
+        return 1
+    }
+}
+
+@test "every uploaded artifact name carries the shard (#1519)" {
+    names="$(artifact_names)"
+
+    count="$(printf '%s\n' "$names" | grep -c . || true)"
+    [ "$count" -ge 4 ] || {
+        printf 'parsed %s artifact name(s) — the extractor is wrong (the job uploads four):\n%s\n' \
+            "$count" "$names" >&2
+        return 1
+    }
+
+    violations="$(printf '%s\n' "$names" | grep -vF '${{ matrix.shard }}' || true)"
+    [ -z "$violations" ] || {
+        printf 'artifact name(s) shared by every shard:\n%s\n' "$violations" >&2
+        printf 'upload-artifact v4+ rejects a duplicate name within a run, so three of the\n' >&2
+        printf 'four uploads fail and the failure being triaged loses its evidence.\n' >&2
+        return 1
+    }
+}
+
+@test "one red shard does not cancel the others (#1519)" {
+    grep -qE '^      fail-fast: false$' "$WORKFLOW" || {
+        printf 'fail-fast is not explicitly false under strategy: — it defaults to TRUE,\n' >&2
+        printf 'which cancels the surviving shards and replaces three results with three\n' >&2
+        printf 'unknowns exactly when the comparison is needed.\n' >&2
+        grep -n -A3 '^    strategy:$' "$WORKFLOW" >&2 || true
+        return 1
+    }
+}
+
+@test "the aggregate job runs even when a shard fails (#1519)" {
+    # `needs:` alone makes the job SKIPPED on a failed dependency, and a
+    # skipped check is not a red one. The pairing is what makes the single
+    # stable check name honest.
+    block="$(awk '/^  e2e-result:$/ { inblock = 1 } inblock { print } inblock && /^      - name: / { exit }' "$WORKFLOW")"
+
+    [ -n "$block" ] || {
+        echo "no e2e-result aggregate job in the workflow" >&2
+        return 1
+    }
+
+    printf '%s\n' "$block" | grep -qE '^    if: always\(\)$' || {
+        printf 'e2e-result lacks `if: always()`:\n%s\n' "$block" >&2
+        return 1
+    }
+    printf '%s\n' "$block" | grep -qE '^    needs: e2e$' || {
+        printf 'e2e-result does not depend on the shard job:\n%s\n' "$block" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
`integration` was one job, one stack, one Playwright worker, 40.5 minutes,
with a daily median climbing +0.42 min/day. vjt's ruling on #1519 authorised
sharding. This is the shard, and nothing else: **`workers: 1` is untouched**,
because the three long-lived users still share `#bofh` and #1618 has just
measured a 31572 ms SQLite write lock with the suite running *serially*. The
shared-state audit is the step after this one.

## Where the 40 minutes go — measured, not estimated

Step timings read off the green run `32395956800` (2026-08-20):

| phase | min |
|---|---|
| checkout with submodules + compose plugin + GHCR login | 1.7 |
| `testnet up` — deps.get, Elixir compile, solanum from source, images, health | 4.6 |
| the Playwright suite — 759 passed, one worker | 33.6 |
| census + tear-down | 0.5 |
| **total** | **40.5** |

Only the 33.6 divides. The other **6.8 min is fixed and every shard pays it
in full**, which puts four shards at **~15 min** — not the ~13.4 the issue's
table gave, which counted the in-script boot alone and forgot the checkout
ahead of it and the tear-down behind it. Eight shards reach ~11: four minutes
for double the runners, with the fixed cost dominating. Hence four.

**Paying the boot once was considered and rejected on the numbers.** A
build-once job has to FINISH before any shard starts, so it adds a serial
stage the same size as the one it removes (~5 min); `5 + pull + 8.4` is no
better than four parallel 15s. Layer caching (`type=gha`) might shrink the
per-shard build — **not measured, so not claimed**.

## The green has to stay TRUE: the partition is proven

Per-shard test counts from `playwright test --list` on `bb65f73b`:

| shard | tests |
|---|---|
| 1/4 | 190 |
| 2/4 | 190 |
| 3/4 | 191 |
| 4/4 | 188 |
| **sum** | **759** — the unsharded total, exactly |

Cardinality is the weak form and it is not what was relied on. The four shard
listings were compared to the full listing as **sets**: in the total and in no
shard → 0; in a shard and not in the total → 0; in two shards → 0. The
comparator was then fed a deliberately altered input and reported the
difference, so those zeros are measurements and not a silent parser.

Granularity is the **(project, file) group** — 447 of them, none spanning two
shards — so ordering *within* a file is preserved exactly as
`fullyParallel: false` implies. Ordering *across* files is not, and that
genuinely changes cascade behaviour; `docs/TESTING.md` now says so next to the
triage tree, with `--shard=N/4` as the way to reproduce CI's grouping.

## The three ways a sharded gate lies quietly

Each is a bats case in `test/infra/integration_shard_test.bats`, deriving its
expectation from the workflow rather than transcribing the shard count.
Verified by mutation: **six mutants, six kills, exactly one assertion each**.

1. **A drifting denominator.** `--shard=i/N` with N adrift from the job count
   drops the tail of the suite or double-runs it, and Playwright is content
   either way — it filters, it does not audit. The denominator is
   `${{ strategy.job-total }}`, the matrix's own length. That is also why the
   matrix must stay one-dimensional: `job-total` counts *legs*.
2. **Colliding artifact names.** `upload-artifact` v4+ refuses a duplicate
   name inside a run, so four shards uploading `playwright-traces` would fail
   three uploads — a second red on top of the one being triaged, evidence
   missing. Every name carries `-shard-${{ matrix.shard }}`.
3. **A skipped aggregate.** `e2e-result` is the one stable check name
   (`needs.e2e.result` is `success` only if every leg was). It carries
   `if: always()` deliberately: without it, a failed shard leaves it
   **skipped**, and a skipped check does not read as a failure.

`fail-fast: false` for the opposite of the usual reason — the default cancels
the surviving shards, replacing three results with three unknowns exactly when
the comparison between them *is* the triage.

## How the red aggregates — measured on real runners, never quoted from the docs

`main` carries no branch protection and no ruleset (measured: the protection
API answers 404, `/rulesets` is `[]`), so no check is required by name today.
Rather than assert the Actions semantics from documentation, a throwaway
branch `w2-1519-probe` ran a matrix with one deliberately failing leg and an
`if: always()` aggregate whose assertion is *inverted* — it passes when the
aggregate reports failure. It cost ~30 s of runner time and it turned up the
thing the documentation would not have put in anyone's face: **without
`if: always()` the aggregate is `skipped`, and `skipped` does not read as
red.** Results are in the comment below; the branch is deleted, the run
outlives it.

## What this PR does NOT claim

- ~~The runner concurrency ceiling was never measured~~ — **it is now, and it
  holds at four.** On this PR's own run
  ([32403458733](https://github.com/vjt/grappa-irc/actions/runs/32403458733))
  the four shards started at **18:29:21Z, 18:29:22Z, 18:29:22Z, 18:29:22Z** —
  within one second of each other, all four `in_progress` together. What is
  still NOT measured is the ceiling under contention: whether EIGHT jobs would
  start together, i.e. this suite sharded four ways while another PR's four
  are already running.
- The per-shard **counts** are equal to within three tests; the per-shard
  **durations** are not measured. Wall clock is the slowest shard.
- Whether any cross-file cascade changes verdict under the new grouping is
  unknown until the first reds arrive. The mechanism is argued; the incidence
  is not measured.

## Gates

- `scripts/bats.sh` full set: **596 ok, 0 failed** (rc captured to a file),
  including the six new cases and the #1408 path-filter suite that parses this
  workflow.
- `scripts/design-notes-gate.sh`: rc=0, one new entry, marker unique against
  the current tip of `origin/main`.
- Workflow YAML parsed independently; push and `pull_request` path filters
  still byte-identical.
- No Elixir and no cic source touched, so `check.sh` / `bun run check` were
  not re-run — stated rather than implied.
- The real verification is **this PR's own `integration` run**, which is the
  first four-shard run in existence.
