### PR TITLE
#964 — name a push device, and number the ones you have not named

### DIFF
--- a/cicchetto/e2e/tests/push-964-device-label.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-label.spec.ts
@@ -1,0 +1,147 @@
+// push-964 — naming a device, and the ordinal that names the ones you have not.
+//
+// The sibling spec (`push-964-device-row.spec.ts`) covers the two
+// disambiguators derived from data the row already carried: the activity
+// instant and the "this device" marker. This one covers the two that needed a
+// schema change — the user's own label, and the ordinal that separates the
+// twins nobody has named yet.
+//
+// Four contracts, every one asserted on what a person would SEE:
+//
+//   1. Two devices that parse to the same `Browser on OS` render DIFFERENT
+//      names, numbered oldest-first.
+//   2. Renaming one from its row replaces that name, and demotes the parsed
+//      string to the secondary line instead of dropping it.
+//   3. Naming one twin drops the OTHER's ordinal. This is the assertion a
+//      STORED ordinal would fail: a column written while the pair collided
+//      keeps its `#2` forever, whereas the derived name re-reads the list and
+//      finds the survivor alone in its group.
+//   4. Clearing the label hands the row back to the derived default — the
+//      twins collide again and BOTH are numbered once more.
+//
+// ## Why the rows are POSTed rather than registered from two browsers
+//
+// The contract under test is about two rows whose `user_agent` parses to the
+// same string. The runner has one engine per project, so a second browser
+// would supply the same UA — but also a second push stub, a second SW
+// registration and a second opt-in dance for rows this spec only ever reads.
+// POSTing them is the same insert the server would have performed, and it lets
+// the spec pin the UA, so the expected names are literal (`Firefox on Linux
+// #1`) instead of "whatever this engine calls itself".
+//
+// ## Why there is no page.reload()
+//
+// On boot `installPushResubscribe` renews a subscription the per-document push
+// stub makes look dropped; the renewal POSTs `supersedes`, which DELETES the
+// old row and inserts a fresh one — losing the very label under assertion. The
+// persistence leg therefore reads from a second BrowserContext, which carries
+// no opt-in intent and so renews nothing. Same reasoning as the sibling spec.
+//
+// No @webkit twin: every assertion is on rendered text, so nothing here is
+// engine-dependent.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
+import { resetPushSubscriptions } from "../fixtures/push";
+import { getSeededVjt } from "../fixtures/seedData";
+
+const GRAPPA = "http://grappa-test:4000";
+
+// One UA for both rows: `parseUserAgent` collapses it to "Firefox on Linux",
+// which is precisely the collision Hypnotize reported.
+const TWIN_UA = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
+const TWIN_NAME = "Firefox on Linux";
+
+test("twins carry ordinals, a rename replaces one, and the survivor drops its number", async ({
+  page,
+  browser,
+}) => {
+  const vjt = getSeededVjt();
+  await resetPushSubscriptions(vjt.token);
+
+  // Oldest first — the ordinal is assigned by creation instant, so the order
+  // of these two POSTs is what makes `#1` deterministic.
+  await registerDevice(vjt.token, TWIN_UA, "https://push.example/964-label-older");
+  await registerDevice(vjt.token, TWIN_UA, "https://push.example/964-label-newer");
+
+  await loginAs(page, vjt);
+  await openSettingsSection(page, "push");
+
+  const rows = page.locator('[data-testid="devices-list"] li');
+  await expect(rows).toHaveCount(2);
+
+  // ── 1. Both numbered, and the two names differ.
+  const first = rows.filter({ hasText: `${TWIN_NAME} #1` });
+  const second = rows.filter({ hasText: `${TWIN_NAME} #2` });
+  await expect(first).toHaveCount(1);
+  await expect(second).toHaveCount(1);
+
+  // ── 2. Rename the second one from its row.
+  await second.getByTestId("device-rename").click();
+  const input = page.getByTestId("device-name-input");
+  await expect(input).toBeVisible();
+  await input.fill("il portatile");
+  await page.getByTestId("device-rename-save").click();
+
+  const renamed = rows.filter({ hasText: "il portatile" });
+  await expect(renamed.getByTestId("device-name")).toHaveText("il portatile");
+  // The parsed string is not lost — it demotes to the secondary line.
+  await expect(renamed.getByTestId("device-parsed")).toHaveText(TWIN_NAME);
+
+  // ── 3. The other twin is now alone among the unnamed, so its ordinal is
+  // gone. A stored ordinal would still read "#1" here.
+  const survivor = rows.filter({ hasNotText: "il portatile" });
+  await expect(survivor.getByTestId("device-name")).toHaveText(TWIN_NAME);
+
+  // ── The label lives on the SERVER: a browser that has never seen this
+  // session reads the same name back.
+  const observerCtx = await browser.newContext();
+  try {
+    const observer = await observerCtx.newPage();
+    await loginAs(observer, vjt);
+    await openSettingsSection(observer, "push");
+    await expect(
+      observer.locator('[data-testid="devices-list"] li').filter({ hasText: "il portatile" }),
+    ).toHaveCount(1);
+  } finally {
+    await observerCtx.close();
+  }
+
+  // ── 4. Clearing the label hands the row back to its derived default, and
+  // the twins collide again — both numbered once more.
+  await renamed.getByTestId("device-rename").click();
+  await page.getByTestId("device-name-input").fill("");
+  await page.getByTestId("device-rename-save").click();
+
+  await expect(rows.filter({ hasText: `${TWIN_NAME} #1` })).toHaveCount(1);
+  await expect(rows.filter({ hasText: `${TWIN_NAME} #2` })).toHaveCount(1);
+  await expect(page.getByTestId("device-parsed")).toHaveCount(0);
+});
+
+/**
+ * POSTs a push subscription for `token`'s subject with an explicit UA, so the
+ * spec controls what the row parses to. Keys are the fixture pair the push
+ * helpers use — the changeset's length caps apply to every insert, whoever
+ * makes it.
+ */
+async function registerDevice(token: string, userAgent: string, endpoint: string): Promise<void> {
+  const res = await fetch(`${GRAPPA}/push/subscriptions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": userAgent,
+    },
+    body: JSON.stringify({
+      endpoint,
+      keys: {
+        p256dh:
+          "BCfaYE5dGabdzef68MI0SN24b4Gsf1t_N3ftUlWaFGzkuudjHLor0CRjosM3c7SLZ7PfFufpsFUh8vsO1t8wCHs",
+        auth: "dGVzdC1hdXRoLXNlY3JldDE2Yg",
+      },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`registerDevice: ${res.status} ${await res.text()}`);
+  }
+}

--- a/cicchetto/e2e/tests/push-964-device-label.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-label.spec.ts
@@ -40,10 +40,10 @@
 // No @webkit twin: every assertion is on rendered text, so nothing here is
 // engine-dependent.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
 import { resetPushSubscriptions } from "../fixtures/push";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA = "http://grappa-test:4000";
 

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -25,7 +25,7 @@ import {
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { formatDuration } from "./lib/duration";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
-import { friendlyApiError } from "./lib/friendlyApiError";
+import { errorMessage, friendlyApiError } from "./lib/friendlyApiError";
 import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
 import { deleteAccountBody, updateIdentity, updateNetworkPassword } from "./lib/lifecycle";
 import { networks, user } from "./lib/networks";
@@ -33,6 +33,7 @@ import { mirrorNotificationPrefs, notificationPrefs } from "./lib/notificationPr
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
   deletePushSubscription,
+  deviceRows,
   disablePush,
   type EnablePushResult,
   enablePush,
@@ -40,6 +41,7 @@ import {
   listPushDevices,
   type PushDeviceSummary,
   pushAvailable,
+  renamePushDevice,
   type SubscriptionId,
   subscriptionIdForEndpoint,
 } from "./lib/push";
@@ -123,6 +125,12 @@ const SettingsDrawer: Component<Props> = (props) => {
   // reason this issue exists. `null` = we cannot prove any row is ours (never
   // subscribed here / cleared site data) — then NO row gets the marker.
   const [currentDeviceId, setCurrentDeviceId] = createSignal<SubscriptionId | null>(null);
+  // #964 — inline rename. `renamingId` is the row currently in edit mode
+  // (at most one); the draft lives here rather than in the input so a
+  // re-render from a background refreshDevices cannot discard the typing.
+  const [renamingId, setRenamingId] = createSignal<SubscriptionId | null>(null);
+  const [renameDraft, setRenameDraft] = createSignal("");
+  const [renameError, setRenameError] = createSignal<string | null>(null);
   const [pushEnabled, setPushEnabled] = createSignal(false);
   const [pushBanner, setPushBanner] = createSignal<string | null>(null);
   const [savingPrefs, setSavingPrefs] = createSignal(false);
@@ -667,6 +675,37 @@ const SettingsDrawer: Component<Props> = (props) => {
       setPushEnabled(false);
       setCurrentDeviceId(null);
       await refreshDevices();
+    }
+  };
+
+  // #964 — opens the row's editor. Seeded with the STORED label, never with
+  // the derived default: pre-filling "Firefox on Linux #2" and hitting save
+  // would freeze today's ordinal into a stored label, which is the stale
+  // number the derived design exists to avoid.
+  const startRename = (device: PushDeviceSummary) => {
+    setRenameError(null);
+    setRenameDraft(device.label ?? "");
+    setRenamingId(device.id);
+  };
+
+  const cancelRename = () => {
+    setRenamingId(null);
+    setRenameError(null);
+  };
+
+  // Unlike removeDevice, a failure here is NOT swallowed: a 422 past the
+  // length cap is the user's own input coming back, and silently dropping
+  // it would look like the rename simply did not take.
+  const commitRename = async (id: SubscriptionId) => {
+    const t = token();
+    if (t === null) return;
+    try {
+      await renamePushDevice(t, id, renameDraft());
+      setRenamingId(null);
+      setRenameError(null);
+      await refreshDevices();
+    } catch (err) {
+      setRenameError(errorMessage(err));
     }
   };
 
@@ -1859,8 +1898,9 @@ const SettingsDrawer: Component<Props> = (props) => {
               <Show when={devices().length > 0}>
                 <h3>devices</h3>
                 <ul class="devices-list" data-testid="devices-list">
-                  <For each={devices()}>
-                    {(d) => {
+                  <For each={deviceRows(devices())}>
+                    {(row) => {
+                      const d = row.device;
                       // UX-4 bucket L (2026-05-19) — replace the raw UA
                       // string with `{icon} {Browser} on {OS}`. Title
                       // attribute preserves the full UA so a hover (desktop)
@@ -1875,39 +1915,111 @@ const SettingsDrawer: Component<Props> = (props) => {
                       // "3m ago → 4m ago" would out-freshen its own data.
                       const activity = formatDeviceActivity(d, Date.now());
                       const isCurrent = () => currentDeviceId() === d.id;
+                      const editing = () => renamingId() === d.id;
                       return (
                         <li>
-                          <span class="device-ua" title={d.user_agent ?? "(unknown browser)"}>
-                            <span class="device-ua-icon" aria-hidden="true">
-                              {deviceClassIcon(parsed.deviceClass)}
-                            </span>
-                            <span class="device-ua-text">
-                              <span class="device-ua-title">
-                                <span class="device-ua-name">
-                                  {parsed.browser} on {parsed.os}
-                                </span>
-                                <Show when={isCurrent()}>
-                                  <span class="device-current" data-testid="device-current">
-                                    ● this device
+                          <Show
+                            when={editing()}
+                            fallback={
+                              <>
+                                <span class="device-ua" title={d.user_agent ?? "(unknown browser)"}>
+                                  <span class="device-ua-icon" aria-hidden="true">
+                                    {deviceClassIcon(parsed.deviceClass)}
                                   </span>
-                                </Show>
-                              </span>
-                              <Show when={activity !== null}>
-                                <span class="device-activity" data-testid="device-activity">
-                                  {activity}
+                                  <span class="device-ua-text">
+                                    <span class="device-ua-title">
+                                      <span class="device-ua-name" data-testid="device-name">
+                                        {row.displayName}
+                                      </span>
+                                      <Show when={isCurrent()}>
+                                        <span class="device-current" data-testid="device-current">
+                                          ● this device
+                                        </span>
+                                      </Show>
+                                    </span>
+                                    {/* #964 — the parsed name survives as the
+                                        secondary line ONLY once a label has
+                                        taken its place above; printing it
+                                        twice on an unnamed row says nothing. */}
+                                    <Show when={row.named}>
+                                      <span class="device-activity" data-testid="device-parsed">
+                                        {parsed.browser} on {parsed.os}
+                                      </span>
+                                    </Show>
+                                    <Show when={activity !== null}>
+                                      <span class="device-activity" data-testid="device-activity">
+                                        {activity}
+                                      </span>
+                                    </Show>
+                                  </span>
+                                </span>
+                                <button
+                                  type="button"
+                                  class="device-remove"
+                                  data-testid="device-rename"
+                                  onClick={() => startRename(d)}
+                                >
+                                  rename
+                                </button>
+                                <button
+                                  type="button"
+                                  class="device-remove"
+                                  onClick={() => {
+                                    void removeDevice(d.id);
+                                  }}
+                                >
+                                  remove
+                                </button>
+                              </>
+                            }
+                          >
+                            <span class="device-rename-form">
+                              <input
+                                type="text"
+                                class="device-rename-input"
+                                data-testid="device-name-input"
+                                aria-label="device name"
+                                // Empty draft = no label yet; the placeholder shows
+                                // what the row falls back to, so clearing the field
+                                // is a visible choice rather than a blank row.
+                                placeholder={row.displayName}
+                                value={renameDraft()}
+                                onInput={(e) => setRenameDraft(e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter") {
+                                    e.preventDefault();
+                                    void commitRename(d.id);
+                                  } else if (e.key === "Escape") {
+                                    e.preventDefault();
+                                    cancelRename();
+                                  }
+                                }}
+                              />
+                              <Show when={renameError() !== null}>
+                                <span class="prefs-error" data-testid="device-rename-error">
+                                  {renameError()}
                                 </span>
                               </Show>
                             </span>
-                          </span>
-                          <button
-                            type="button"
-                            class="device-remove"
-                            onClick={() => {
-                              void removeDevice(d.id);
-                            }}
-                          >
-                            remove
-                          </button>
+                            <button
+                              type="button"
+                              class="device-remove"
+                              data-testid="device-rename-save"
+                              onClick={() => {
+                                void commitRename(d.id);
+                              }}
+                            >
+                              save
+                            </button>
+                            <button
+                              type="button"
+                              class="device-remove"
+                              data-testid="device-rename-cancel"
+                              onClick={cancelRename}
+                            >
+                              cancel
+                            </button>
+                          </Show>
                         </li>
                       );
                     }}

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -1907,12 +1907,17 @@ const SettingsDrawer: Component<Props> = (props) => {
                       // can still surface the original for debugging /
                       // device disambiguation across same-browser instances.
                       const parsed = parseUserAgent(d.user_agent);
-                      // #964 — hover is the ONLY disambiguator today and it does
-                      // not exist on touch, which is where the drawer lives. The
-                      // activity instant + the this-device marker are the two
-                      // always-visible ones. Stamped at render, not on a ticking
-                      // clock: the list is refetched on drawer mount, so a live
-                      // "3m ago → 4m ago" would out-freshen its own data.
+                      // #964 — the always-visible disambiguators, in the order
+                      // they take precedence: the user's own label, the derived
+                      // ordinal on unnamed twins (both from `deviceRows`), the
+                      // activity instant, and the this-device marker. Hover on
+                      // the full UA is a fifth, and the only one that does not
+                      // exist on touch — which is where the drawer lives, and
+                      // why it was never enough on its own.
+                      //
+                      // The activity instant is stamped at render, not on a
+                      // ticking clock: the list is refetched on drawer mount, so
+                      // a live "3m ago → 4m ago" would out-freshen its own data.
                       const activity = formatDeviceActivity(d, Date.now());
                       const isCurrent = () => currentDeviceId() === d.id;
                       const editing = () => renamingId() === d.id;

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   deletePushSubscription,
+  deviceRows,
   disablePush,
   enablePush,
   ensurePushSubscription,
@@ -543,6 +544,7 @@ describe("formatDeviceActivity — #964: the row's activity line", () => {
   const device = (over: Partial<PushDeviceSummary>): PushDeviceSummary => ({
     id: "sub-1" as SubscriptionId,
     user_agent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/128.0",
+    label: null,
     created_at: "2026-08-07T11:00:00Z",
     last_used_at: null,
     ...over,
@@ -595,5 +597,149 @@ describe("subscriptionIdForEndpoint — #964: which row is THIS device", () => {
 
   it("returns null when nothing was ever stashed", () => {
     expect(subscriptionIdForEndpoint("https://push.example/ep")).toBeNull();
+  });
+});
+
+// ── #964 — the row's NAME: user label first, derived ordinal otherwise ──
+// The label is the only stored piece; the ordinal is derived on every
+// render precisely so deleting a twin cannot strand a lone "#2".
+
+describe("deviceRows — #964: the name the device row prints", () => {
+  const FIREFOX_LINUX = "Mozilla/5.0 (X11; Linux x86_64) Firefox/128.0";
+  const CHROME_MAC =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
+
+  const dev = (
+    over: Omit<Partial<PushDeviceSummary>, "id"> & { id: string },
+  ): PushDeviceSummary => ({
+    user_agent: FIREFOX_LINUX,
+    label: null,
+    created_at: "2026-08-07T11:00:00Z",
+    last_used_at: null,
+    ...over,
+    id: over.id as SubscriptionId,
+  });
+
+  const nameOf = (rows: ReturnType<typeof deviceRows>, id: string): string | undefined =>
+    rows.find((r) => r.device.id === (id as SubscriptionId))?.displayName;
+
+  it("prints the parsed name, with NO ordinal, for a device alone in its group", () => {
+    const rows = deviceRows([dev({ id: "a" })]);
+    expect(rows.map((r) => r.displayName)).toEqual(["Firefox on Linux"]);
+    expect(rows[0]?.named).toBe(false);
+  });
+
+  it("prints no ordinal when the two devices parse differently", () => {
+    const rows = deviceRows([dev({ id: "a" }), dev({ id: "b", user_agent: CHROME_MAC })]);
+    expect(rows.map((r) => r.displayName)).toEqual(["Firefox on Linux", "Chrome on macOS"]);
+  });
+
+  it("numbers twins oldest-first, regardless of the order the server sent them", () => {
+    // Server order is newest-first, so the NEWER row arrives at index 0 —
+    // if the ordinal followed list position instead of created_at, the
+    // older device would be #2 and the numbers would flip whenever the
+    // list is re-sorted.
+    const rows = deviceRows([
+      dev({ id: "new", created_at: "2026-08-07T11:00:00Z" }),
+      dev({ id: "old", created_at: "2026-08-01T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "old")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "new")).toBe("Firefox on Linux #2");
+  });
+
+  it("keeps existing ordinals stable when a newer twin appears", () => {
+    const older = dev({ id: "old", created_at: "2026-08-01T09:00:00Z" });
+    const newer = dev({ id: "new", created_at: "2026-08-07T11:00:00Z" });
+    const third = dev({ id: "third", created_at: "2026-08-09T09:00:00Z" });
+
+    const before = deviceRows([newer, older]);
+    const after = deviceRows([third, newer, older]);
+
+    expect(nameOf(before, "old")).toBe(nameOf(after, "old"));
+    expect(nameOf(before, "new")).toBe(nameOf(after, "new"));
+    expect(nameOf(after, "third")).toBe("Firefox on Linux #3");
+  });
+
+  it("re-derives after a deletion instead of stranding a lone #2", () => {
+    // THE reason the ordinal is not a column: delete #1 and a stored #2
+    // has nobody to be second to. Derived, the survivor is alone in its
+    // group and drops the suffix entirely.
+    const older = dev({ id: "old", created_at: "2026-08-01T09:00:00Z" });
+    const newer = dev({ id: "new", created_at: "2026-08-07T11:00:00Z" });
+
+    expect(nameOf(deviceRows([newer, older]), "new")).toBe("Firefox on Linux #2");
+    expect(nameOf(deviceRows([newer]), "new")).toBe("Firefox on Linux");
+  });
+
+  it("numbers each colliding group independently", () => {
+    const rows = deviceRows([
+      dev({ id: "f1", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "f2", created_at: "2026-08-02T09:00:00Z" }),
+      dev({ id: "c1", user_agent: CHROME_MAC, created_at: "2026-08-03T09:00:00Z" }),
+      dev({ id: "c2", user_agent: CHROME_MAC, created_at: "2026-08-04T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "f1")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "f2")).toBe("Firefox on Linux #2");
+    expect(nameOf(rows, "c1")).toBe("Chrome on macOS #1");
+    expect(nameOf(rows, "c2")).toBe("Chrome on macOS #2");
+  });
+
+  it("the user's label wins over the derived name", () => {
+    const rows = deviceRows([
+      dev({ id: "a", label: "MacBook del lavoro", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "b", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("MacBook del lavoro");
+    expect(rows.find((r) => r.device.id === ("a" as SubscriptionId))?.named).toBe(true);
+  });
+
+  it("naming one twin leaves the other WITHOUT an orphan ordinal", () => {
+    // The pair is no longer ambiguous on screen, so the survivor must not
+    // keep a "#2" that has nothing to contrast with.
+    const rows = deviceRows([
+      dev({ id: "named", label: "fisso", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "bare", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "bare")).toBe("Firefox on Linux");
+  });
+
+  it("still numbers the two that remain unlabelled among three twins", () => {
+    const rows = deviceRows([
+      dev({ id: "named", label: "fisso", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "x", created_at: "2026-08-02T09:00:00Z" }),
+      dev({ id: "y", created_at: "2026-08-03T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "x")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "y")).toBe("Firefox on Linux #2");
+  });
+
+  it("preserves the server's row order (newest first)", () => {
+    const rows = deviceRows([
+      dev({ id: "new", created_at: "2026-08-07T11:00:00Z" }),
+      dev({ id: "old", created_at: "2026-08-01T09:00:00Z" }),
+    ]);
+    expect(rows.map((r) => r.device.id)).toEqual(["new", "old"]);
+  });
+
+  it("falls back to the id for a total order when created_at does not parse", () => {
+    const rows = deviceRows([
+      dev({ id: "b", created_at: "not-a-date" }),
+      dev({ id: "a", created_at: "not-a-date" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "b")).toBe("Firefox on Linux #2");
+  });
+
+  it("groups two unparseable user agents together rather than splitting them", () => {
+    const rows = deviceRows([
+      dev({ id: "a", user_agent: null, created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "b", user_agent: "", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("Unknown browser on Unknown OS #1");
+    expect(nameOf(rows, "b")).toBe("Unknown browser on Unknown OS #2");
+  });
+
+  it("returns an empty list for an empty device list", () => {
+    expect(deviceRows([])).toEqual([]);
   });
 });

--- a/cicchetto/src/lib/push.ts
+++ b/cicchetto/src/lib/push.ts
@@ -35,6 +35,7 @@
 import { ApiError, readError } from "./api";
 import { formatDurationSince } from "./duration";
 import { isIos, isStandalonePwa } from "./platform";
+import { parseUserAgent } from "./userAgent";
 
 const SUBSCRIBED_VAPID_KEY_STORAGE_KEY = "cic.vapidPublicKey";
 
@@ -168,9 +169,97 @@ export async function deletePushSubscription(token: string, id: SubscriptionId):
 export type PushDeviceSummary = {
   id: SubscriptionId;
   user_agent: string | null;
+  /** #964 — user-set device name. `null` until renamed; see `deviceRows`. */
+  label: string | null;
   created_at: string;
   last_used_at: string | null;
 };
+
+/** A device paired with the name the row should actually print. */
+export type DeviceRow = {
+  device: PushDeviceSummary;
+  /** The user's label when set, else the derived `Browser on OS [#n]`. */
+  displayName: string;
+  /** True when `displayName` is the user's own label rather than the default. */
+  named: boolean;
+};
+
+const parsedDeviceName = (device: PushDeviceSummary): string => {
+  const parsed = parseUserAgent(device.user_agent);
+  return `${parsed.browser} on ${parsed.os}`;
+};
+
+// Oldest first, id as the tiebreak so the ordering is TOTAL — two rows
+// created in the same microsecond (or with an unparseable instant) must
+// still get a stable order, or the ordinals would shuffle between renders.
+const byCreation = (a: PushDeviceSummary, b: PushDeviceSummary): number => {
+  const ta = Date.parse(a.created_at);
+  const tb = Date.parse(b.created_at);
+  const ka = Number.isNaN(ta) ? Number.POSITIVE_INFINITY : ta;
+  const kb = Number.isNaN(tb) ? Number.POSITIVE_INFINITY : tb;
+  if (ka !== kb) return ka < kb ? -1 : 1;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+};
+
+/**
+ * #964 — pairs each device with the name its row prints, preserving the
+ * server's ordering (newest first).
+ *
+ * The user's `label` wins outright. Without one the row falls back to the
+ * parsed `Browser on OS`, which is exactly the string that collides — so
+ * when two or more UNLABELLED devices parse to the same name, each gets an
+ * ordinal (`Firefox on Linux #1`, `#2`) assigned oldest-first. A device
+ * alone in its group takes no suffix: a solitary `#1` is noise.
+ *
+ * Labelled rows are excluded from the grouping, not just from the suffix.
+ * Naming one of two twins already disambiguates the pair, and leaving the
+ * other as a lone `#2` would be the stale-ordinal bug reintroduced by hand.
+ *
+ * ## Why the ordinal is DERIVED here and not a column
+ *
+ * Two independent reasons, and either alone settles it:
+ *
+ *   1. An ordinal is a function of how many rows currently share a parsed
+ *      name. Stored, it goes stale the instant one of them is deleted —
+ *      a `#2` with no `#1` that nothing realigns. Derived, the list
+ *      self-heals on the next render. The LABEL is the stored thing here;
+ *      the ordinal is only the fallback.
+ *   2. The grouping key is the OUTPUT of `parseUserAgent`, which exists
+ *      only in this codebase. Deriving server-side would mean a second UA
+ *      parser in Elixir whose classification could disagree with this one,
+ *      and then the ordinal would number a grouping the user cannot see.
+ */
+export function deviceRows(devices: PushDeviceSummary[]): DeviceRow[] {
+  const unlabelled = devices.filter((d) => (d.label ?? null) === null);
+
+  return devices.map((device) => {
+    const label = device.label ?? null;
+    if (label !== null) return { device, displayName: label, named: true };
+
+    const name = parsedDeviceName(device);
+    const twins = unlabelled.filter((d) => parsedDeviceName(d) === name).sort(byCreation);
+    const displayName =
+      twins.length < 2 ? name : `${name} #${twins.findIndex((d) => d.id === device.id) + 1}`;
+    return { device, displayName, named: false };
+  });
+}
+
+/**
+ * PATCH /push/subscriptions/:id — the #964 inline rename. An empty string
+ * clears the label server-side, so the row falls back to its derived name.
+ */
+export async function renamePushDevice(
+  token: string,
+  id: SubscriptionId,
+  label: string,
+): Promise<void> {
+  const res = await fetch(`/push/subscriptions/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ label }),
+  });
+  if (!res.ok) throw await readError(res);
+}
 
 /**
  * #964 — the device row's activity line.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7171,6 +7171,28 @@ html.resize-dragging * {
   white-space: nowrap;
 }
 
+/* #964 — the row's edit mode. Takes the same flex slot the name occupied
+   so the save/cancel buttons land exactly where remove was, and the list
+   does not reflow when a row is opened for renaming. */
+.settings-drawer .device-rename-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.settings-drawer .device-rename-input {
+  width: 100%;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 0.15rem 0.3rem;
+}
+
 /* #462 — padding + font-size deleted, not rewritten: without them the rule
    stops out-specifying `:where(.settings-drawer) button` and the base's 44px
    floor, 0.4/0.7 padding and --font-size apply. 0.15rem × 0.75rem made this

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54171,3 +54171,169 @@ three unknowns exactly when the comparison between them is the triage.
 - Whether any cross-file cascade actually changes verdict under the new
   grouping is **unknown until the first reds arrive**; the mechanism is
   argued above, the incidence is not.
+<!-- entry #964 -->
+
+---
+
+## 2026-08-20 — #964: naming a push device, and the ordinal for the ones you have not named
+
+Hypnotize reported two rows in the settings drawer both reading `Firefox on
+Linux`, with nothing to tell them apart. `parseUserAgent` collapses a UA to
+`Browser on OS` on purpose, so two instances of the same browser on the same OS
+render byte-identical. The issue proposed three fixes; two of them —
+`formatDeviceActivity` and the `● this device` marker — landed earlier and are
+already in the tree. This entry records the third: a user-set **label**, and the
+**ordinal** that disambiguates the devices nobody has named yet.
+
+The branch that implements it was cut on 2026-08-07, dropped, and revived
+thirteen days later. Rebasing it rather than rewriting it is what surfaced the
+two failures recorded at the end, and both are worth more than the feature.
+
+### The label is the only disambiguator that earns a column
+
+Everything else the row could show is DERIVED from data the server already
+holds: the creation instant, the last-used instant, an ordinal, the PTR of the
+peer address. The label is the only genuinely new information — it is the one
+thing about a device that only its owner knows.
+
+The original ask was "default it to the host". That is not implementable: no web
+API exposes the client machine's hostname, deliberately, and the one historical
+leak (the `.local` name in ICE candidates) was closed in 2019 by mDNS candidate
+obfuscation. Deriving it server-side does not rescue it either — the only
+server-visible name-like thing is the PTR of the peer address, which on a
+residential or NAT'd line is the ISP pool name, identical for every device
+behind it. That reproduces exactly the collision the issue is about.
+
+### The ordinal is DERIVED at render, and is NOT a column
+
+Two independent reasons, either of which settles it:
+
+1. An ordinal is a function of how many rows CURRENTLY share a parsed name.
+   Stored, it goes stale the instant one of them is deleted — a `#2` with no
+   `#1` and nothing to realign it. Derived, the list self-heals on the next
+   render.
+2. The grouping key is the OUTPUT of `parseUserAgent`, which exists only in
+   cicchetto. Deriving server-side would mean a second UA parser in Elixir whose
+   classification could disagree with the client's, and then the ordinal would
+   number a grouping the user cannot see.
+
+`deviceRows/1` (`cicchetto/src/lib/push.ts`) pairs each device with the name its
+row prints. It preserves the server's ordering (newest first) but assigns
+ordinals **oldest-first**, with the id as a tiebreak so the ordering is TOTAL —
+two rows created in the same microsecond, or with an unparseable `created_at`,
+must still get a stable order or the numbers shuffle between renders.
+
+**Labelled rows leave the grouping entirely, not just the suffix.** Naming one of
+two twins already disambiguates the pair, so the survivor must drop its number;
+leaving it as a lone `#2` would be the stale-ordinal bug reintroduced by hand.
+A device alone in its group takes no suffix at all: a solitary `#1` is noise.
+
+### `label`: one storage representation for "cleared"
+
+`label` is nullable with no default and is the ONE user-writable field on a
+subscription. It travels on its own `Subscription.label_changeset/2`, kept off
+the create allowlist for two reasons: it is never knowable at registration time,
+and a separate changeset means a POST body cannot widen the create surface by
+accident.
+
+Blank folds to NULL so "cleared" has exactly ONE representation and the read
+side tests `is_nil/1` and never also `== ""`. That fold is `cast/3`'s own
+default `:empty_values`, which already maps `""` AND a whitespace-only string to
+`nil` — a hand-written blank arm was proven dead by removing it and watching the
+blank/whitespace tests stay green. The trim of a non-blank value is NOT
+something Ecto does, so it lives in the changeset; the 64-**grapheme** cap is
+applied AFTER the trim, so a value that exceeds the cap only by invisible
+padding is accepted rather than rejected on characters the user cannot see.
+
+`PATCH /push/subscriptions/:id` takes `{"label": <string|null>}`. The status
+ladder splits types from values: **400** when `label` is absent or not a
+string/null (a type error is the client's bug, not a value the 422 envelope
+should have to describe), **404** with the uniform body for cross-subject OR
+unknown IDs (the same probing protection `delete/2` has), **422** past the cap.
+`Push.update_label/2` takes the STRUCT, so the caller must already have loaded
+and scoped the row through `get_for_subject/2` — a path parameter cannot reach
+an UPDATE without passing the subject check.
+
+The PATCH renders the SAME `subscription_summary()` an `:index` row carries,
+rather than a bespoke `{id, label}` echo: the rename response IS a row, so the
+client splices it back into the list without a refetch, and there is one place
+to change when a device grows another field. `label` is a new field on an
+existing shape, so per the additive-only wire contract (#447) it costs no
+`protocol_version` bump.
+
+### 🔴 The hand-typed migration stamp was a LIVE collision, not a formality
+
+The branch carried `20260807120000_add_label_to_push_subscriptions.exs`. In the
+thirteen days it sat unproposed, `20260807120000_fold_nickserv_pass_onto_password.exs`
+landed on main — the **same integer version**, a different basename, which git
+fuses without a conflict marker and with nothing to review.
+
+This is the silent regime, and it is the one production hits. Ecto's pending
+filter keys on the integer VERSION, never the filename, and
+`ensure_no_duplication!` only ever sees the PENDING set. On a database that has
+ALREADY applied `20260807120000` — every deployed one — both files drop out of
+pending, `ensure_no_duplication!([])` answers `:ok`, the run reports SUCCESS,
+and NEITHER migration ever executes again. Not a crash, not a warning: a green
+deploy with a column that is not there.
+
+Regenerated with `mix ecto.gen.migration` → `20260820174126`, and checked
+against `origin/main`'s CURRENT latest (`20260816014915`) rather than against
+the August main the branch forked from. That second half is the part a rebase
+makes load-bearing: the correct number is past whatever landed while you were
+out.
+
+The rule was already in CLAUDE.md. What this adds is the demonstration: a
+thirteen-day-old branch was enough for a round stamp to become a real,
+already-applied duplicate.
+
+### 🔴 A clean rebase can reinstall a defect whose premise has evaporated
+
+The same rebase surfaced `validate_subject_xor/1` inside a conflict block in
+`Grappa.Push.Subscription`. #1580 had just collapsed twelve copies of that
+function onto `Grappa.Subject.validate_xor/1`; the #964 commit adds
+`label_changeset/2` immediately above it, so the deleted body came back as
+"context" the resolver is invited to keep.
+
+Nothing about the conflict says the function was deliberately removed. The
+resolution that looks tidy — keep both sides — silently reinstates one of the
+twelve copies #1580 exists to delete, and it would compile, pass and read fine.
+The general rule: on a long-lived branch, a conflict hunk containing code you did
+not write is a question about whether its PREMISE still holds, not a merge
+puzzle. Here it was dropped, and #1580's own `subject_xor_test.exs` runs green
+beside the new label tests.
+
+### Deploy class: HOT, measured, against a moduledoc that claimed COLD
+
+The migration's original moduledoc asserted COLD "because `Preflight` classifies
+every `priv/repo/migrations/*` path as `:migration`". GH #41 ended that:
+`GrappaWeb.AdminController.reload/2` now runs `Ecto.Migrator` in-process BEFORE
+the module reload, so only a CONTRACT migration forces a restart, and
+`classify_migration/1` decides from the `change/0` AST.
+
+Measured on this file rather than asserted: `alter table(:push_subscriptions) do
+add :label, :string end` is an expand — atom column, literal type, nullable, no
+`@disable_ddl_transaction` — so `classify_migration/1` answers `:hot`, and the
+whole changed path set classifies `{:hot, []}` on `:jail`, `:docker` and
+`:linux` alike.
+
+This means the "any migration ⇒ COLD" grep over-triggers exactly the way the
+`^infra/` arm does: it is a path heuristic, and the shipped classifier is the
+thing that actually gates the deploy. It says nothing about the RELEASE that
+ships the feature — a `VERSION` bump is its own cold trigger (`:version`,
+#1287) on the two `mix release` substrates, and is not part of this change.
+
+### Limitations, stated rather than forced
+
+* The ordinal groups on `parseUserAgent`'s output, so two devices the parser
+  cannot classify collapse into one `Unknown browser on Unknown OS` group and
+  are numbered within it. That is the honest answer — they genuinely are
+  indistinguishable to us — but it means an unparseable UA cannot be told apart
+  except by renaming it.
+* `label` is per-subscription, not per-device. A browser that drops and
+  re-registers its push subscription (the #181 supersede path) arrives as a new
+  row with no label. Carrying the label across a supersede would mean trusting
+  the endpoint swap to identify the same physical device, which is exactly the
+  identity claim `subscriptionIdForEndpoint` refuses to make elsewhere.
+* The rename, save and cancel buttons reuse the `.device-remove` class so they
+  inherit the 44 px tap floor #462 restored. Behaviourally right, but the class
+  name is now a misnomer for three buttons that remove nothing.

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -39,6 +39,7 @@ defmodule Grappa.Push do
       subject (sorted by `inserted_at`, most-recent first).
     * `get_for_subject/2` — fetch one by ID, scoped to subject (404
       if cross-subject).
+    * `update_label/2` — rename a device (#964); `nil`/blank clears.
     * `delete/1` — by struct.
     * `delete_dead/1` — by endpoint URL. Used by B2's `Push.Sender`
       when a vendor returns 404/410 for a stale subscription.
@@ -260,6 +261,26 @@ defmodule Grappa.Push do
   """
   @spec delete(Subscription.t()) :: {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
   def delete(%Subscription{} = sub), do: Repo.delete(sub)
+
+  @doc """
+  Renames a subscription (#964). `nil` or a blank string clears the
+  label, and the client falls back to its derived default name.
+
+  Struct-in, for the same reason as `delete/1`: the caller must already
+  have loaded + scoped the row through `get_for_subject/2`, so a path
+  parameter cannot reach an UPDATE without passing the subject check.
+
+  Every normalisation (trim, blank → NULL, length cap) lives in
+  `Subscription.label_changeset/2` — this is user input and it does not
+  reach `Repo` without a changeset.
+  """
+  @spec update_label(Subscription.t(), String.t() | nil) ::
+          {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
+  def update_label(%Subscription{} = sub, label) when is_binary(label) or is_nil(label) do
+    sub
+    |> Subscription.label_changeset(%{label: label})
+    |> Repo.update()
+  end
 
   @doc """
   Deletes any subscription matching the given endpoint URL,

--- a/lib/grappa/push/subscription.ex
+++ b/lib/grappa/push/subscription.ex
@@ -4,9 +4,17 @@ defmodule Grappa.Push.Subscription do
 
   Push notifications cluster B1 (2026-05-14). Stores the three opaque
   fields the W3C Push API hands out (`endpoint`, `p256dh_key`,
-  `auth_key`) plus per-device metadata (`user_agent`, `last_used_at`)
-  that drives the "see + revoke my devices" UX in the cic settings
-  drawer (B3).
+  `auth_key`) plus per-device metadata (`user_agent`, `last_used_at`,
+  `label`) that drives the "see + revoke my devices" UX in the cic
+  settings drawer (B3).
+
+  ## `label` — the only user-writable field (#964)
+
+  Nullable, set through `label_changeset/2` alone. NULL means "no
+  label" and the client falls back to a derived name. The ordinal that
+  disambiguates two same-browser devices is deliberately NOT a column:
+  it is a function of how many rows currently share a parsed name, so a
+  stored copy strands a lone `#2` the moment `#1` is deleted.
 
   ## `:provider` — `:webpush` | `:unifiedpush` (2026-08-13)
 
@@ -90,6 +98,7 @@ defmodule Grappa.Push.Subscription do
           p256dh_key: String.t() | nil,
           auth_key: String.t() | nil,
           user_agent: String.t() | nil,
+          label: String.t() | nil,
           last_used_at: DateTime.t() | nil,
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
@@ -106,6 +115,7 @@ defmodule Grappa.Push.Subscription do
     field :p256dh_key, :string
     field :auth_key, :string
     field :user_agent, :string
+    field :label, :string
     field :last_used_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)
@@ -124,8 +134,18 @@ defmodule Grappa.Push.Subscription do
   # `provider` IS optional — defaults to `"webpush"` (the schema
   # field default) when a caller omits it, so every pre-2026-08-13
   # caller keeps working unchanged.
+  # `label` is likewise absent from the allowlist: it is the ONE
+  # user-writable field, it is never known at registration time (the
+  # browser has nothing to name itself with — see #964 on why the machine
+  # hostname is not reachable from a page), and it travels on its own
+  # `label_changeset/2` so a POST body cannot widen the create surface.
   @optional ~w(provider user_agent)a
   @subject ~w(user_id visitor_id)a
+
+  # Graphemes, not bytes — the cap bounds what the drawer renders, and the
+  # drawer renders characters. Roomy enough for "MacBook del lavoro",
+  # tight enough that the row keeps its ellipsis instead of wrapping.
+  @label_max 64
 
   @doc """
   Insert / update changeset.
@@ -193,4 +213,47 @@ defmodule Grappa.Push.Subscription do
       message: "user_id and visitor_id are mutually exclusive"
     )
   end
+
+  @doc """
+  Rename changeset — the ONE user-writable field on a subscription (#964).
+
+  Separate from `changeset/2` on purpose: `label` is not knowable at
+  registration, so keeping it off the create allowlist means the POST
+  surface cannot grow a field by accident, and this changeset cannot be
+  talked into touching an endpoint or a key.
+
+  The stored contract, and who enforces each half:
+
+    * **blank → NULL**, so "cleared" has exactly ONE representation and
+      the read side tests `is_nil/1` and never also `== ""`. This is what
+      makes clearing the label fall back to the derived
+      `Browser on OS [#n]` default instead of rendering an empty name.
+      Enforced by `cast/3` itself: its default `:empty_values` already
+      folds `""` AND a whitespace-only string to `nil`. Measured, not
+      assumed — a hand-written blank arm here was proven dead by removing
+      it and watching the blank/whitespace tests stay green. The tests
+      pin the CONTRACT, so it survives whoever implements it.
+    * **trim** of a non-blank value — a label is a display string, and
+      invisible padding would make two labels compare unequal. This half
+      Ecto does NOT do, so it lives here.
+    * **cap at #{@label_max} graphemes**, applied AFTER the trim, so a
+      value that only exceeds the cap by padding is accepted rather than
+      rejected on characters the user cannot see.
+
+  A non-string value fails `cast/3` with `"is invalid"`; the controller
+  rejects that shape earlier with a 400 so the 422 envelope stays about
+  values, not types.
+  """
+  @spec label_changeset(t(), map()) :: Ecto.Changeset.t()
+  def label_changeset(%__MODULE__{} = sub, attrs) do
+    sub
+    |> cast(attrs, [:label])
+    |> update_change(:label, &normalize_label/1)
+    |> validate_length(:label, max: @label_max)
+  end
+
+  @spec normalize_label(String.t() | nil) :: String.t() | nil
+  defp normalize_label(nil), do: nil
+
+  defp normalize_label(label) when is_binary(label), do: String.trim(label)
 end

--- a/lib/grappa_web/controllers/push_subscription_controller.ex
+++ b/lib/grappa_web/controllers/push_subscription_controller.ex
@@ -3,7 +3,7 @@ defmodule GrappaWeb.PushSubscriptionController do
   REST surface for `Grappa.Push` subscriptions — push notifications
   cluster B1 (2026-05-14) + visitor-parity V3 (2026-05-15).
 
-  Three endpoints, all behind `[:api, :authn]`:
+  Four endpoints, all behind `[:api, :authn]`:
 
     * `POST /push/subscriptions` — body
       `{"endpoint": <url>, "keys": {"p256dh": <b64>, "auth": <b64>},
@@ -32,11 +32,16 @@ defmodule GrappaWeb.PushSubscriptionController do
       protection — one subject cannot enumerate another's
       subscription IDs).
 
+    * `PATCH /push/subscriptions/:id` — body `{"label": <string|null>}`,
+      the #964 inline rename. 200 with the updated device summary;
+      400 on a missing / non-string `label`; 404 (uniform body) for
+      cross-subject or missing IDs; 422 past the length cap.
+
     * `GET /push/subscriptions` — 200 with
-      `%{subscriptions: [%{id, provider, user_agent, created_at,
-      last_used_at}, ...]}`. Powers the cic settings drawer's
-      per-device list (B3); `provider` lets a client tell a browser
-      subscription apart from a UnifiedPush-registered device.
+      `%{subscriptions: [%{id, provider, user_agent, label,
+      created_at, last_used_at}, ...]}`. Powers the cic settings
+      drawer's per-device list (B3); `provider` lets a client tell a
+      browser subscription apart from a UnifiedPush-registered device.
 
   ## Subject-scoped — V3 (2026-05-15)
 
@@ -152,6 +157,28 @@ defmodule GrappaWeb.PushSubscriptionController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  @doc """
+  `PATCH /push/subscriptions/:id` — rename a device (#964). Body
+  `{"label": <string|null>}`; `null` or a blank string clears the label
+  and the row falls back to its derived name.
+
+  400 when `label` is absent or not a string/null — a type error is the
+  client's bug, not a value the 422 envelope should have to describe.
+  404 (uniform body) for cross-subject OR missing IDs, same probing
+  protection as `delete/2`. 422 when the value exceeds the length cap.
+  """
+  @spec update(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :bad_request | :not_found | Ecto.Changeset.t()}
+  def update(conn, %{"id" => id, "label" => label})
+      when is_binary(id) and (is_binary(label) or is_nil(label)) do
+    with {:ok, sub} <- Push.get_for_subject(Subject.from_assigns(conn.assigns), id),
+         {:ok, renamed} <- Push.update_label(sub, label) do
+      render(conn, :device, subscription: renamed)
+    end
+  end
+
+  def update(_, _), do: {:error, :bad_request}
 
   @doc """
   `GET /push/subscriptions` — list the authenticated subject's

--- a/lib/grappa_web/controllers/push_subscription_json.ex
+++ b/lib/grappa_web/controllers/push_subscription_json.ex
@@ -16,14 +16,21 @@ defmodule GrappaWeb.PushSubscriptionJSON do
       keys are NOT echoed back; cic already has them locally (it just
       sent them).
     * `:index` (GET 200) — `%{subscriptions: [%{id, provider,
-      user_agent, created_at, last_used_at}, ...]}`. Powers cic
+      user_agent, label, created_at, last_used_at}, ...]}`. Powers cic
       settings drawer device list (B3). `last_used_at` is `nil`
       until B2's `Push.Sender` writes the first delivery. `provider`
       (2026-08-13, UnifiedPush) — `"webpush"` or `"unifiedpush"` —
       lets a client's device list show what kind of endpoint each
       row is (a browser tab vs. a UnifiedPush-registered device);
       revocation (`DELETE /push/subscriptions/:id`) works identically
-      for either.
+      for either. `label` is `nil` until the user renames the device
+      (#964), and cic derives a name from `user_agent` while it is.
+    * `:device` (PATCH 200) — one `subscription_summary()`, the same
+      shape an `:index` row carries.
+
+  `label` is a NEW additive field on an existing shape, so per the
+  additive-only wire contract (#447) it costs no `protocol_version`
+  bump: a client that does not know it simply ignores it.
 
   ## Why no endpoint/keys in any list shape
 
@@ -41,6 +48,7 @@ defmodule GrappaWeb.PushSubscriptionJSON do
           id: Ecto.UUID.t(),
           provider: Subscription.provider(),
           user_agent: String.t() | nil,
+          label: String.t() | nil,
           created_at: DateTime.t(),
           last_used_at: DateTime.t() | nil
         }
@@ -60,12 +68,24 @@ defmodule GrappaWeb.PushSubscriptionJSON do
     %{subscriptions: Enum.map(subs, &summary/1)}
   end
 
+  @doc """
+  Renders the `:device` action — the PATCH 200 response shape (#964).
+
+  Deliberately the SAME summary the `:index` rows carry rather than a
+  bespoke `{id, label}` echo: the rename response is a row, so cic can
+  splice it back into the list without a refetch, and there is one place
+  to change when a device grows another field.
+  """
+  @spec device(%{subscription: Subscription.t()}) :: subscription_summary()
+  def device(%{subscription: %Subscription{} = sub}), do: summary(sub)
+
   @spec summary(Subscription.t()) :: subscription_summary()
   defp summary(%Subscription{} = sub) do
     %{
       id: sub.id,
       provider: sub.provider,
       user_agent: sub.user_agent,
+      label: sub.label,
       created_at: sub.inserted_at,
       last_used_at: sub.last_used_at
     }

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -461,6 +461,9 @@ defmodule GrappaWeb.Router do
     # POST here → server stores endpoint+keys for B2's Push.Sender.
     get "/push/subscriptions", PushSubscriptionController, :index
     post "/push/subscriptions", PushSubscriptionController, :create
+    # #964 — inline rename from the device row. The label is the only
+    # user-writable field on a subscription.
+    patch "/push/subscriptions/:id", PushSubscriptionController, :update
     delete "/push/subscriptions/:id", PushSubscriptionController, :delete
 
     # UX-6-B1 (2026-05-20): embedded image uploader — authenticated

--- a/priv/repo/migrations/20260807120000_add_label_to_push_subscriptions.exs
+++ b/priv/repo/migrations/20260807120000_add_label_to_push_subscriptions.exs
@@ -1,0 +1,34 @@
+defmodule Grappa.Repo.Migrations.AddLabelToPushSubscriptions do
+  @moduledoc """
+  #964 — the one thing about a device only its owner knows: what to call it.
+
+  `user_agent` collapses to `Browser on OS` in the settings drawer, so two
+  instances of the same browser on the same OS render byte-identical rows.
+  Every other disambiguator we can synthesise (the activity instant, an
+  ordinal suffix, the PTR of the peer address) is derived from data the
+  server already holds; the label is the only one that is genuinely NEW
+  information, so it is the only one that earns a column.
+
+  Nullable with no default: NULL means "no label", and the row falls back
+  to the derived `Browser on OS [#n]` default. A `""` never reaches storage
+  — `Subscription.label_changeset/2` folds blank to NULL so "cleared" has
+  exactly one representation.
+
+  Deliberately NOT stored: the ordinal. It is a function of how many
+  subscriptions currently share a parsed name, so a stored copy goes stale
+  the moment one of them is deleted — a lone `#2` with no `#1`.
+
+  ## Hot deploy
+
+  COLD. `Grappa.Deploy.Preflight` classifies every `priv/repo/migrations/*`
+  path as `:migration`, substrate-independent, no exceptions for additive
+  nullable columns.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:push_subscriptions) do
+      add :label, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20260820174126_add_label_to_push_subscriptions.exs
+++ b/priv/repo/migrations/20260820174126_add_label_to_push_subscriptions.exs
@@ -18,11 +18,22 @@ defmodule Grappa.Repo.Migrations.AddLabelToPushSubscriptions do
   subscriptions currently share a parsed name, so a stored copy goes stale
   the moment one of them is deleted — a lone `#2` with no `#1`.
 
-  ## Hot deploy
+  ## Hot deploy — HOT, and measured rather than assumed
 
-  COLD. `Grappa.Deploy.Preflight` classifies every `priv/repo/migrations/*`
-  path as `:migration`, substrate-independent, no exceptions for additive
-  nullable columns.
+  An earlier draft of this file asserted COLD "because `Preflight`
+  classifies every `priv/repo/migrations/*` path as `:migration`". That
+  stopped being true with GH #41: `GrappaWeb.AdminController.reload/2` now
+  runs `Ecto.Migrator` in-process BEFORE the module reload, so only a
+  CONTRACT migration still forces a restart, and `classify_migration/1`
+  decides which is which from the `change/0` AST. `add :label, :string` on
+  an existing table is an expand — nullable, literal type, no
+  `@disable_ddl_transaction` — so it reads `:hot`, and the whole changed
+  path set of #964 classifies `{:hot, []}` on `:jail`, `:docker` and
+  `:linux` alike.
+
+  This says nothing about the RELEASE bump that ships it: a `VERSION`
+  change is its own cold trigger (`:version`, #1287) on the two substrates
+  that boot a `mix release`, and it is not part of this diff.
   """
   use Ecto.Migration
 

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -1232,6 +1232,7 @@ defmodule Grappa.Deploy.PreflightTest do
       20260810120000_add_client_tokens_to_sessions
       20260812220753_add_charset_to_uploads
       20260813074128_add_provider_to_push_subscriptions
+      20260820174126_add_label_to_push_subscriptions
     )
 
     test "every migration on disk classifies, and the HOT set is exactly the pinned one" do

--- a/test/grappa/push_test.exs
+++ b/test/grappa/push_test.exs
@@ -303,6 +303,94 @@ defmodule Grappa.PushTest do
     end
   end
 
+  describe "update_label/2 (#964)" do
+    test "a fresh subscription carries no label" do
+      user = user_fixture()
+      assert {:ok, %Subscription{label: nil}} = Push.create({:user, user.id}, valid_attrs())
+    end
+
+    test "create cannot set the label — it is not on the create allowlist" do
+      user = user_fixture()
+      attrs = Map.put(valid_attrs(), :label, "smuggled in at registration")
+      assert {:ok, %Subscription{label: nil}} = Push.create({:user, user.id}, attrs)
+    end
+
+    test "stores the label and the list reads it back" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+
+      assert {:ok, %Subscription{label: "MacBook del lavoro"}} =
+               Push.update_label(sub, "MacBook del lavoro")
+
+      assert [%Subscription{label: "MacBook del lavoro"}] =
+               Push.list_for_subject({:user, user.id})
+    end
+
+    test "trims surrounding whitespace" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      assert {:ok, %Subscription{label: "telefono"}} = Push.update_label(sub, "  telefono \t ")
+    end
+
+    test "a blank string clears the label to NULL, not to an empty string" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, "")
+    end
+
+    test "a whitespace-only string clears the label too" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, "   ")
+    end
+
+    test "nil clears the label" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, nil)
+    end
+
+    test "rejects a label past the 64-grapheme cap" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+
+      assert {:error, %Ecto.Changeset{errors: errors}} =
+               Push.update_label(sub, String.duplicate("a", 65))
+
+      assert {_, opts} = errors[:label]
+      assert opts[:count] == 64
+    end
+
+    test "counts graphemes, not bytes — 64 multi-byte characters fit" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      label = String.duplicate("è", 64)
+      assert {:ok, %Subscription{label: ^label}} = Push.update_label(sub, label)
+    end
+
+    test "the cap applies to the trimmed value, not the padded one" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      padded = "   " <> String.duplicate("a", 64) <> "   "
+      expected = String.duplicate("a", 64)
+      assert {:ok, %Subscription{label: ^expected}} = Push.update_label(sub, padded)
+    end
+
+    test "renaming touches nothing but the label" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, renamed} = Push.update_label(sub, "telefono")
+      assert renamed.endpoint == sub.endpoint
+      assert renamed.p256dh_key == sub.p256dh_key
+      assert renamed.auth_key == sub.auth_key
+      assert renamed.user_agent == sub.user_agent
+      assert renamed.user_id == sub.user_id
+    end
+  end
+
   describe "touch_last_used/1" do
     test "sets last_used_at to a fresh timestamp" do
       user = user_fixture()

--- a/test/grappa_web/controllers/push_subscription_controller_test.exs
+++ b/test/grappa_web/controllers/push_subscription_controller_test.exs
@@ -16,6 +16,10 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
     * DELETE cross-subject → 404 (probing protection).
     * DELETE unknown ID → 404.
     * user_agent header is captured + persisted on POST.
+    * PATCH (#964 rename): 200 + row summary, visitor parity, label
+      visible on the following GET, blank / null clears to NULL, 422
+      past the cap, 400 on a missing or non-string label, 404
+      cross-subject + unknown ID.
   """
   use GrappaWeb.ConnCase, async: true
 
@@ -58,6 +62,20 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
       nil -> body
       value -> Map.put(body, body_key, value)
     end
+  end
+
+  # #964 — a persisted subscription to rename. Carries a real UA so the
+  # renamed row can be checked to keep every field the PATCH must not touch.
+  defp subscription_for(subject, endpoint) do
+    {:ok, sub} =
+      Push.create(subject, %{
+        endpoint: endpoint,
+        p256dh_key: "k",
+        auth_key: "a",
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/124.0"
+      })
+
+    sub
   end
 
   describe "POST /push/subscriptions — auth gating" do
@@ -473,6 +491,165 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
     test "404 on unknown UUID", %{conn: conn} do
       {_, session} = user_and_session()
       conn = conn |> put_bearer(session.id) |> delete("/push/subscriptions/#{Ecto.UUID.generate()}")
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+    end
+  end
+
+  describe "PATCH /push/subscriptions/:id (#964 rename)" do
+    test "401 without bearer", %{conn: conn} do
+      conn = patch(conn, "/push/subscriptions/#{Ecto.UUID.generate()}", %{"label" => "x"})
+      assert json_response(conn, 401)
+    end
+
+    test "200 with the renamed row, and the list reads it back", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/rename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "MacBook del lavoro"})
+
+      body = json_response(conn, 200)
+      assert body["id"] == sub.id
+      assert body["label"] == "MacBook del lavoro"
+      # Same summary shape the list rows carry, so cic can splice it back in.
+      assert body["user_agent"] == sub.user_agent
+      assert Map.has_key?(body, "created_at")
+      assert Map.has_key?(body, "last_used_at")
+      # Credential-grade material stays out of every response shape.
+      refute Map.has_key?(body, "endpoint")
+      refute Map.has_key?(body, "p256dh_key")
+
+      assert [%{label: "MacBook del lavoro"}] = Push.list_for_subject({:user, user.id})
+    end
+
+    test "200 for a visitor subject — V3 parity", %{conn: conn} do
+      {visitor, session} = visitor_and_session()
+      sub = subscription_for({:visitor, visitor.id}, "https://example.com/push/v-rename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "telefono"})
+
+      assert json_response(conn, 200)["label"] == "telefono"
+      assert [%{label: "telefono"}] = Push.list_for_subject({:visitor, visitor.id})
+    end
+
+    test "GET exposes the label after a rename", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/label-index-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "fisso"})
+      |> json_response(200)
+
+      listed =
+        build_conn()
+        |> put_bearer(session.id)
+        |> get("/push/subscriptions")
+        |> json_response(200)
+
+      assert %{"subscriptions" => [only]} = listed
+      assert only["label"] == "fisso"
+    end
+
+    test "a blank label clears the row back to null", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/clear-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "da cancellare"})
+      |> json_response(200)
+
+      cleared =
+        build_conn()
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "   "})
+        |> json_response(200)
+
+      assert cleared["label"] == nil
+    end
+
+    test "an explicit null clears the row too", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/null-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "da cancellare"})
+      |> json_response(200)
+
+      cleared =
+        build_conn()
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => nil})
+        |> json_response(200)
+
+      assert cleared["label"] == nil
+    end
+
+    test "422 past the length cap, and the stored label is untouched", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/toolong-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => String.duplicate("a", 65)})
+
+      assert %{"error" => "validation_failed", "field_errors" => errors} =
+               json_response(conn, 422)
+
+      assert Map.has_key?(errors, "label")
+      assert [%{label: nil}] = Push.list_for_subject({:user, user.id})
+    end
+
+    test "400 when label is absent from the body", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/nolabel-#{uniq()}")
+
+      conn = conn |> put_bearer(session.id) |> patch("/push/subscriptions/#{sub.id}", %{})
+      assert json_response(conn, 400)
+    end
+
+    test "400 when label is not a string", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/badtype-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => %{"nested" => true}})
+
+      assert json_response(conn, 400)
+    end
+
+    test "404 on cross-user rename (probing protection)", %{conn: conn} do
+      {alice, _} = user_and_session()
+      {_, bob_session} = user_and_session()
+      alice_sub = subscription_for({:user, alice.id}, "https://example.com/push/xrename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(bob_session.id)
+        |> patch("/push/subscriptions/#{alice_sub.id}", %{"label" => "mio adesso"})
+
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+      assert [%{label: nil}] = Push.list_for_subject({:user, alice.id})
+    end
+
+    test "404 on unknown UUID", %{conn: conn} do
+      {_, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{Ecto.UUID.generate()}", %{"label" => "x"})
+
       assert json_response(conn, 404) == %{"error" => "not_found"}
     end
   end


### PR DESCRIPTION
Settings: a push device can carry a user-set name, and the ones nobody has
named get an ordinal so two `Firefox on Linux` rows stop being byte-identical.

Issue #964. Not a rewrite: the branch cut on 2026-08-07
(`origin/964-device-label`, never proposed) was rebased forward across 1311
commits of `main`. Everything the branch *decided* survived; two things it
*assumed* did not, and those are the interesting part.

## What ships

* **Schema.** `label`, nullable, no default, off the create allowlist. It
  travels on its own `Subscription.label_changeset/2` (trim, blank → NULL, 64
  **grapheme** cap applied after the trim), so a POST body cannot widen the
  create surface and this changeset cannot be talked into touching an endpoint
  or a key.
* **Context.** `Push.update_label/2` takes the STRUCT, so the caller must
  already have loaded and scoped the row through `get_for_subject/2` — a path
  parameter cannot reach an UPDATE without passing the subject check.
* **REST.** `PATCH /push/subscriptions/:id`, body `{"label": <string|null>}`.
  **200** with the row summary, **400** on an absent or non-string `label`
  (a type error is the client's bug, not something the 422 envelope should
  describe), **404** with the uniform body for cross-subject *or* unknown IDs
  (the probing protection `delete/2` already has), **422** past the cap.
* **View.** The PATCH renders the SAME `subscription_summary()` an `:index` row
  carries, so cic splices the response back into the list instead of refetching.
  `label` is a new field on an existing shape ⇒ additive-only (#447), no
  `protocol_version` bump.
* **cic.** `deviceRows/1` pairs each device with the name its row prints: the
  user's label wins outright; otherwise the parsed `Browser on OS`, with an
  ordinal when two or more UNLABELLED devices parse the same. Labelled rows
  leave the grouping entirely, so naming one twin drops the other's number
  rather than stranding a lone `#2`. Inline rename from the row; the parsed
  string demotes to the secondary line once a label takes its place.
* **e2e.** One spec covering all four contracts, including the one a STORED
  ordinal would fail.

The ordinal is derived at render and is deliberately **not** a column. Two
independent reasons: it is a function of how many rows *currently* share a
parsed name (stored, it strands a `#2` the moment `#1` is deleted), and the
grouping key is `parseUserAgent`'s output, which exists only in cicchetto — a
server-side twin could disagree and then the number would describe a grouping
the user cannot see.

Proposal 3 in the issue (render `last_used_at`) already landed on `main`; this
is proposals 1 and 2.

## The two things the rebase caught

**🔴 The hand-typed migration stamp had become a live duplicate.** The branch
carried `20260807120000_add_label_to_push_subscriptions.exs`;
`20260807120000_fold_nickserv_pass_onto_password.exs` had since landed on `main`
with the same integer version and a different basename, which git fuses without
a conflict marker. That is the silent regime: Ecto's pending filter keys on the
VERSION, `ensure_no_duplication!` only sees the PENDING set, so on a database
that has already applied `20260807120000` — every deployed one — both files drop
out of pending, the run reports SUCCESS, and neither migration ever executes
again. Regenerated with `mix ecto.gen.migration` → `20260820174126`, checked
against `origin/main`'s current latest, not against the August main the branch
forked from.

**🔴 The rebase offered back `validate_subject_xor/1`, which #1580 had just
deleted.** #1580 collapsed twelve copies onto `Grappa.Subject.validate_xor/1`;
this branch adds `label_changeset/2` immediately above the old one, so the
deleted body reappeared inside a conflict hunk as context the resolver is
invited to keep. Dropped. It would have compiled, passed and read fine — a
conflict whose premise had evaporated.

Both are written up in the DESIGN_NOTES entry, because the demonstration is
worth more than the recommendation.

## Deploy class: HOT, measured

The path grep says COLD (`priv/repo/migrations/` matches), but the migration arm
over-triggers the same way the `^infra/` arm does. Since GH #41,
`AdminController.reload/2` runs `Ecto.Migrator` in-process **before** the module
reload, so only a CONTRACT migration forces a restart and `classify_migration/1`
decides from the `change/0` AST.

Measured, not assumed: `classify_migration` answers `:hot` for this file, and
the whole changed path set classifies `{:hot, []}` on `:jail`, `:docker` and
`:linux`. `PreflightTest`'s pinned HOT set — the repo's own oracle — agrees, and
this branch registers the new migration in it.

Independent of #964: a release that bumps `VERSION` is its own cold trigger
(`:version`, #1287) on the two `mix release` substrates.

## Gates

Run from the worktree with `GRAPPA_CACHE_ID=w1-964` (a fresh, cold id — dialyzer
built its PLT from scratch).

| gate | result |
|---|---|
| `mix test --warnings-as-errors` (full) | **8 doctests, 61 properties, 6657 tests, 0 failures** |
| `mix dialyzer` | 0 errors, 0 skipped |
| `mix sobelow --config` | pass (one pre-existing Low in `uploads/reaper.ex`) |
| `mix credo --strict` | 84 checks, 696 files, no issues |
| `mix format --check-formatted` | clean |
| `scripts/bun.sh run test` (vitest) | 295 files, 5708 tests passed |
| `scripts/bun.sh run check` | 4 stages, 0 failed |
| `scripts/design-notes-gate.sh` | 1 entry heading, separator + marker present |
| `scripts/union-rebase.sh origin/main` | `+166 -0 — contribution intact` |
| `scripts/integration.sh` (full e2e) | **755 passed / 5 failed** — see below |

**The five e2e reds are not this diff.** Four of them are
`waitForUserTopicReady` timeouts at `cicchettoPage.ts:680`, the 5 s barrier
#1579 measured and #1618 filed the root cause for (the WebSocket upgrade
serialised behind a DB write lock); the fifth times out on the login-ready
selector, the same failure one observation point earlier. None touch push,
settings or anything this branch edits. Re-run in isolation on this tree, all
five pass (35.4 s). Per the timing-race rule that is **neither guilt nor
absolution** — a seeded or scoped re-run of a temporal race is green from both
sides — so the attribution rests on the mechanism and the untouched surface,
not on the green.

**Not run:** `scripts/bats.sh`, and `scripts/check.sh` end to end.

`origin/964-device-label` still points at the pre-rebase `a9280925` and is
superseded by this branch.
