### PR TITLE
test(#1441): one media-viewer door — thirteen sites, not ten copies

### DIFF
--- a/cicchetto/e2e/fixtures/mediaViewer.ts
+++ b/cicchetto/e2e/fixtures/mediaViewer.ts
@@ -1,0 +1,139 @@
+// The media-viewer door (#1441): one place that knows how the viewer is
+// named, opened and closed.
+//
+// ## What was measured before the lift (on 5ec44475)
+//
+// THIRTEEN opening call sites across TEN spec files — not "ten copies". The
+// issue's ten is right at FILE granularity and low at call-site granularity:
+// media-link-modal-viewer.spec.ts alone opened it three times and
+// media-link-cross-host-modal.spec.ts twice.
+//
+// They were NOT byte-identical, a claim the issue explicitly refused to make.
+// Counting raw bytes there were FIVE distinct bodies (indentation splits them:
+// the two sites inside a `test.describe` are indented one level deeper);
+// normalising indentation and comments away leaves THREE, and the third is
+// only "shorter because the dialog was already bound above". So the real
+// divergence is ONE axis, below.
+//
+// ## The one axis that genuinely diverges, and why it gets two verbs
+//
+// Nine sites clicked with `link.click()` — Playwright's click, which scrolls
+// the anchor into view first. Four clicked with
+// `link.evaluate((el) => (el as HTMLElement).click())` — the anchor's OWN
+// click, dispatched where it sits. That is not drift. Those four
+// (#196-preserve, #219, #213, #1438) MEASURE the scrollback's scroll position
+// across the open, and Playwright's scroll-into-view would move the very thing
+// under test before the gesture it is testing ever fires.
+//
+// So this module exports two verbs rather than one verb with a `scroll: bool`.
+// A boolean at thirteen call sites is a coin flip a reviewer cannot check; two
+// names are two things a reviewer can read. `openMediaViewerInPlace` says what
+// it protects in its name, which is the whole reason those four specs are
+// green.
+//
+// ## Wait conditions: from the strictest copy, and then frozen
+//
+// All thirteen waited `toBeVisible({ timeout: 5_000 })` on the dialog, so the
+// strictest and the uniform value are the same 5_000 — kept, not raised.
+// It is a module constant and NOT a per-call-site parameter, deliberately
+// against `uploadJourney.ts`'s opposite rule: there the image and video budgets
+// genuinely differ 6×, here every caller wants the same answer to the same
+// question, and a parameter would re-open the drift axis this module exists to
+// close. A future viewer that needs longer changes it here, for everyone, on
+// purpose.
+//
+// #213 additionally waited for `.media-viewer-media--zoomable` to be visible.
+// That barrier stays in #213: it is image-and-zoom specific (the cross-host
+// video case has no zoomable element at all), and it is also the locator that
+// spec goes on to drive. Strictest COMMON wait, not strictest anywhere.
+//
+// ## Not in scope here
+//
+// `media-link-cross-host-modal.spec.ts` and `media-link-alias-modal.spec.ts`
+// produce their anchor by composing a URL rather than by uploading, so they
+// use the openers but not `uploadImageAndGetLink`. That is the domain
+// boundary, not a gap: the thing they share is the DOOR, and they use it.
+
+import { expect, type Locator, type Page } from "@playwright/test";
+import { TINY_PNG_HEX } from "./bytes";
+import { mediaScrollbackRow, uploadViaPicker } from "./uploadJourney";
+
+// The accessible name MediaViewerModal renders (role=dialog + aria-label), and
+// its close control. Ten spec files used to spell these out, so renaming the
+// label meant finding ten call sites by hand and the eleventh by CI.
+const DIALOG_NAME = "Media viewer";
+const CLOSE_BUTTON_NAME = "Close media viewer";
+
+// Measured uniform across all thirteen pre-lift call sites. See the header for
+// why it is a constant and not a parameter.
+const VIEWER_SETTLE_MS = 5_000;
+
+// The upload budget for the IMAGE path only — uniform across the eight upload
+// preambles. `uploadJourney.uploadViaPicker` deliberately demands this per call
+// site because the video path needs 6× as long; `uploadImageAndGetLink` is
+// image-only, so the budget is intrinsic to the verb. A video caller keeps
+// using `uploadViaPicker` directly and keeps choosing its own.
+const IMAGE_POST_TIMEOUT_MS = 10_000;
+
+// The viewer dialog, open or not. Exported so a NEGATIVE assertion (the audio
+// path must NOT open the modal) reads the same locator the positive ones do.
+export function mediaViewer(page: Page): Locator {
+  return page.getByRole("dialog", { name: DIALOG_NAME });
+}
+
+// Open by a real user click. Playwright scrolls the anchor into view first,
+// which is correct everywhere the scroll position is not itself the subject.
+export async function openMediaViewer(page: Page, link: Locator): Promise<Locator> {
+  await link.click();
+  return settled(page);
+}
+
+// Open WITHOUT moving the pane: dispatch the anchor's own click where it sits.
+// The four scroll-position specs need this — Playwright's click would scroll
+// the container they are about to measure.
+export async function openMediaViewerInPlace(page: Page, link: Locator): Promise<Locator> {
+  await link.evaluate((el) => (el as HTMLElement).click());
+  return settled(page);
+}
+
+// Close by the X, and wait for the dialog to actually go. Every caller wants
+// the barrier — a close that is only issued races whatever the spec asserts
+// next about the pane underneath.
+export async function closeMediaViewer(viewer: Locator): Promise<void> {
+  await viewer.getByRole("button", { name: CLOSE_BUTTON_NAME }).click();
+  await expect(viewer).toBeHidden({ timeout: VIEWER_SETTLE_MS });
+}
+
+async function settled(page: Page): Promise<Locator> {
+  const viewer = mediaViewer(page);
+  await expect(viewer).toBeVisible({ timeout: VIEWER_SETTLE_MS });
+  return viewer;
+}
+
+// The eight-copy preamble: upload a tiny PNG through the real picker, wait for
+// the 📸 row the IRC echo brings back, and hand over its anchor.
+//
+// `fileName` stays a parameter: it lands in the upload and names the spec that
+// made it, which is how a leftover in the store is attributed.
+//
+// The media-class assertion is HERE rather than at the call sites. Six of the
+// eight preambles made it and two (#213, #1438) did not — strictest wins, so
+// the two gain a precondition they were relying on silently. Without the class
+// the anchor never opens the viewer, and the failure used to surface as a
+// five-second timeout on the dialog instead of naming the classifier.
+// `uploadJourney.mediaScrollbackRow` deliberately does NOT assert it (it serves
+// 📄 documents too, which carry no media class); this verb is image-only, so
+// here it is a fact and not an assumption.
+export async function uploadImageAndGetLink(
+  page: Page,
+  fileName: string,
+): Promise<{ slug: string; url: string; row: Locator; link: Locator }> {
+  const { slug, url } = await uploadViaPicker(
+    page,
+    { name: fileName, mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
+    { postTimeout: IMAGE_POST_TIMEOUT_MS },
+  );
+  const { row, link } = await mediaScrollbackRow(page, "📸", slug);
+  await expect(link).toHaveClass(/scrollback-media-link/);
+  return { slug, url, row, link };
+}

--- a/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
+++ b/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
@@ -31,12 +31,11 @@
 // Desktop project only (untagged → chromium), like its #196 twin: desktop Chrome
 // reproduces desktop scroll physics (feedback_playwright_webkit_not_ios_scroll).
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
+import { closeMediaViewer, openMediaViewer, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "arr1121-peer";
@@ -64,13 +63,7 @@ test.describe("#1121 — closing an overlay over a tail reader must not strand t
 
     // Upload an image → a clickable media link lands at the tail, where our
     // reader already is. No scroll-up here: being AT the tail IS the precondition.
-    const { slug } = await uploadViaPicker(
-      page,
-      { name: "arr1121.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-      { postTimeout: 10_000 },
-    );
-    const { link } = await mediaScrollbackRow(page, "📸", slug);
-    await expect(link).toHaveClass(/scrollback-media-link/);
+    const { link } = await uploadImageAndGetLink(page, "arr1121.png");
 
     const sc = page.getByTestId("scrollback");
     const scrollButton = page.locator('[data-testid="scroll-to-bottom"]');
@@ -109,9 +102,7 @@ test.describe("#1121 — closing an overlay over a tail reader must not strand t
       await expect(scrollButton).toBeHidden({ timeout: 5_000 });
 
       // Open the preview via a REAL click on the image at the tail.
-      await link.click();
-      const viewer = page.getByRole("dialog", { name: "Media viewer" });
-      await expect(viewer).toBeVisible({ timeout: 5_000 });
+      const viewer = await openMediaViewer(page, link);
 
       // Three lines land underneath the open overlay — the reporter's exact
       // gesture. They must NOT move the frozen pane (that is #196's contract,
@@ -128,8 +119,7 @@ test.describe("#1121 — closing an overlay over a tail reader must not strand t
       expect(Math.abs(during - before.top)).toBeLessThanOrEqual(5);
 
       // Close it. The reader is now genuinely parked above a tail that moved.
-      await viewer.getByRole("button", { name: "Close media viewer" }).click();
-      await expect(viewer).toBeHidden({ timeout: 5_000 });
+      await closeMediaViewer(viewer);
       await page.waitForTimeout(400);
 
       // OBSERVABLE 1 — the geometry was republished, so the pane admits there is

--- a/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
@@ -38,35 +38,27 @@
 // src/__tests__/mediaViewerGesture.test.ts. These are the end-to-end doors.
 
 import type { Locator, Page } from "@playwright/test";
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { openMediaViewerInPlace, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // Upload a tiny image and open it in the media viewer, mirroring #213's
 // harness: the anchor's OWN click opens the overlay (no Playwright
-// scroll-into-view). Every spec that opens this viewer carries its own copy of
-// these six lines — a pre-existing duplication across nine files, not one this
-// change introduces, and not one it is in scope to sweep.
+// scroll-into-view).
+//
+// The duplication this used to carry — "these six lines across nine files",
+// out of scope when #1438 landed — is now fixtures/mediaViewer.ts (#1441). What
+// is left here is the login + channel selection this spec's three tests share.
 async function openImageViewer(page: Page): Promise<{ viewer: Locator }> {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
   await loginAs(page, specUser());
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x1438.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await link.evaluate((el) => (el as HTMLElement).click());
-
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
-  return { viewer };
+  const { link } = await uploadImageAndGetLink(page, "x1438.png");
+  return { viewer: await openMediaViewerInPlace(page, link) };
 }
 
 // One vertical drag on the modal, plus the browser's own reading of where the

--- a/cicchetto/e2e/tests/issue196-preview-scroll-live-arrival.spec.ts
+++ b/cicchetto/e2e/tests/issue196-preview-scroll-live-arrival.spec.ts
@@ -26,13 +26,12 @@
 // IrcPeer for the in-overlay arrival, deterministic scroll via evaluate, overlay
 // opened by the anchor's OWN real click on a VISIBLE mid-list image.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
+import { closeMediaViewer, openMediaViewer, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "arr196-peer";
@@ -65,13 +64,7 @@ test.describe("#196 — preview overlay holds scroll across a live message arriv
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
     // Upload an image → a clickable media link lands at the tail.
-    const { slug } = await uploadViaPicker(
-      page,
-      { name: "arr196.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-      { postTimeout: 10_000 },
-    );
-    const { link } = await mediaScrollbackRow(page, "📸", slug);
-    await expect(link).toHaveClass(/scrollback-media-link/);
+    const { link } = await uploadImageAndGetLink(page, "arr196.png");
 
     const peer = await IrcPeer.connect({ nick: PEER_NICK });
     try {
@@ -110,9 +103,7 @@ test.describe("#196 — preview overlay holds scroll across a live message arriv
       expect(before.rowVisible).toBe(true);
 
       // Open the preview via a REAL click on the visible image.
-      await link.click();
-      const viewer = page.getByRole("dialog", { name: "Media viewer" });
-      await expect(viewer).toBeVisible({ timeout: 5_000 });
+      const viewer = await openMediaViewer(page, link);
 
       // Opening the overlay must not move the list.
       const onOpen = await sc.evaluate((el) => el.scrollTop);
@@ -132,8 +123,7 @@ test.describe("#196 — preview overlay holds scroll across a live message arriv
       expect(Math.abs(during - before.top)).toBeLessThanOrEqual(5);
 
       // Close the preview — the position must STILL be where the reader left it.
-      await viewer.getByRole("button", { name: "Close media viewer" }).click();
-      await expect(viewer).toBeHidden({ timeout: 5_000 });
+      await closeMediaViewer(viewer);
       await page.waitForTimeout(400);
       const after = await sc.evaluate((el) => el.scrollTop);
       expect(Math.abs(after - before.top)).toBeLessThanOrEqual(5);

--- a/cicchetto/e2e/tests/issue196-preview-scroll-preserve.spec.ts
+++ b/cicchetto/e2e/tests/issue196-preview-scroll-preserve.spec.ts
@@ -21,11 +21,14 @@
 // (off-screen), and this test is about OPENING the overlay not moving the list,
 // NOT about the click's own scroll-into-view.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  closeMediaViewer,
+  openMediaViewerInPlace,
+  uploadImageAndGetLink,
+} from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -42,13 +45,7 @@ test("#196 — opening the image preview keeps the message-list scroll position 
   // seeded with 200 lines, so the pane is already tall enough to scroll — the
   // image lands at the tail (its exact position is irrelevant: it's opened via
   // el.click() below, not by scrolling to it).
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x196.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
+  const { link } = await uploadImageAndGetLink(page, "x196.png");
 
   const sc = page.getByTestId("scrollback");
   // Scroll to a deterministic MIDDLE position (away from both top and bottom).
@@ -65,18 +62,16 @@ test("#196 — opening the image preview keeps the message-list scroll position 
   expect(before.top).toBeLessThan(before.max - 5);
 
   // Open the preview via the anchor's OWN click — fires the onClick
-  // (preventDefault + openMediaViewer) with NO Playwright scroll-into-view.
-  await link.evaluate((el) => (el as HTMLElement).click());
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  // (preventDefault + the app's src/lib/mediaViewer) with NO Playwright
+  // scroll-into-view, which would move the very position under test.
+  const viewer = await openMediaViewerInPlace(page, link);
 
   // The scroll position must NOT have moved when the overlay opened.
   const during = await sc.evaluate((el) => el.scrollTop);
   expect(Math.abs(during - before.top)).toBeLessThanOrEqual(3);
 
   // Close the overlay — the position must STILL be where the reader left it.
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   const after = await sc.evaluate((el) => el.scrollTop);
   expect(Math.abs(after - before.top)).toBeLessThanOrEqual(3);
 });

--- a/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
+++ b/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
@@ -32,33 +32,32 @@
 // scale ratio) is covered by the pinchZoom.ts unit tests (jsdom); these e2es
 // guard the DOM wiring + the CSS contract, not the physics.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
+import type { Page } from "@playwright/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { openMediaViewerInPlace, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-// Upload a tiny image and open it in the media viewer. Returns the viewer
-// dialog + the zoomable <img> locator. Mirrors #219's harness: the anchor's OWN
-// click opens the overlay (no Playwright scroll-into-view).
-async function openImageViewer(page: import("@playwright/test").Page) {
+// Upload a tiny image and open it in the media viewer, then narrow to the
+// ZOOMABLE <img> — the element these three tests actually drive.
+//
+// The door itself (upload → anchor → in-place click → dialog visible) is
+// fixtures/mediaViewer.ts since #1441. The extra barrier below stays here: it
+// is image-and-zoom specific, and it is also the locator this spec returns.
+// `openMediaViewerInPlace` and not the plain opener because #219's harness
+// (which this mirrors) needs the anchor's OWN click, with no Playwright
+// scroll-into-view.
+async function openImageViewer(page: Page) {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
   const vjt = specUser();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x213.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await link.evaluate((el) => (el as HTMLElement).click());
+  const { link } = await uploadImageAndGetLink(page, "x213.png");
+  const viewer = await openMediaViewerInPlace(page, link);
 
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
   const img = viewer.locator(".media-viewer-media--zoomable");
   await expect(img).toBeVisible({ timeout: 5_000 });
   return { viewer, img };

--- a/cicchetto/e2e/tests/issue219-overlay-scroll-hold.spec.ts
+++ b/cicchetto/e2e/tests/issue219-overlay-scroll-hold.spec.ts
@@ -32,11 +32,14 @@
 // stays there on close. GREEN post-fix: the position is HELD across the resize
 // and the close.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  closeMediaViewer,
+  openMediaViewerInPlace,
+  uploadImageAndGetLink,
+} from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -51,13 +54,7 @@ test("#219 — a resize while the image viewer is open must NOT snap the list to
 
   // Upload an image so the scrollback carries a clickable media link. #spec-wN is
   // seeded with 200 lines → the pane is genuinely tall and scrollable.
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x219.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
+  const { link } = await uploadImageAndGetLink(page, "x219.png");
 
   const sc = page.getByTestId("scrollback");
   // Scroll to a deterministic MIDDLE position (away from both top and bottom).
@@ -72,9 +69,7 @@ test("#219 — a resize while the image viewer is open must NOT snap the list to
   expect(before.top).toBeLessThan(before.max - 5);
 
   // Open the preview via the anchor's OWN click (no Playwright scroll-into-view).
-  await link.evaluate((el) => (el as HTMLElement).click());
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewerInPlace(page, link);
 
   // #196 covers the open EDGE — position is preserved right after open.
   const afterOpen = await sc.evaluate((el) => el.scrollTop);
@@ -98,8 +93,7 @@ test("#219 — a resize while the image viewer is open must NOT snap the list to
   expect(Math.abs(during - before.top)).toBeLessThanOrEqual(10);
 
   // Close — the position must STILL be where the reader left it.
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   await page.waitForTimeout(300);
   const after = await sc.evaluate((el) => el.scrollTop);
   expect(Math.abs(after - before.top)).toBeLessThanOrEqual(10);

--- a/cicchetto/e2e/tests/issue418-upload-url-extension.spec.ts
+++ b/cicchetto/e2e/tests/issue418-upload-url-extension.spec.ts
@@ -26,8 +26,8 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Page } from "@playwright/test";
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { closeMediaViewer, openMediaViewer, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
@@ -48,28 +48,20 @@ test("image: server mints /uploads/<slug>.png and the extensioned URL opens the 
 }) => {
   await openChannel(page);
 
-  const { slug, url } = await uploadViaPicker(
-    page,
-    { name: "issue418.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-
-  // #418 server half: the minted URL carries the faithful type extension.
-  expect(url).toMatch(new RegExp(`/uploads/${slug}\\.png$`));
-
   // Real IRC echo → the 📸 row. The link classifies by the EXTENSION now
   // (the URL is `/uploads/<slug>.png`, which no longer matches the
   // extensionless UPLOADS_PATH_RE → mediaLink rule 3), and the anchor
-  // href IS the extensioned URL — the type signal reached cic intact.
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
+  // href IS the extensioned URL — the type signal reached cic intact. The
+  // media-class assertion is inside `uploadImageAndGetLink` (#1441).
+  const { slug, url, link } = await uploadImageAndGetLink(page, "issue418.png");
+
+  // #418 server half: the minted URL carries the faithful type extension.
+  expect(url).toMatch(new RegExp(`/uploads/${slug}\\.png$`));
   await expect(link).toHaveAttribute("href", url);
 
   // Click → in-app image viewer opens, no navigation.
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   expect(page.url()).toBe(cicUrl);
 
   // The <img> fetched the bytes from the EXTENSIONED URL through nginx,
@@ -79,8 +71,7 @@ test("image: server mints /uploads/<slug>.png and the extensioned URL opens the 
   await expect(img).toHaveJSProperty("complete", true, { timeout: 10_000 });
   expect(await img.evaluate((el) => (el as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
 
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   expect(page.url()).toBe(cicUrl);
 });
 

--- a/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
@@ -31,6 +31,7 @@
 import type { Page } from "@playwright/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { closeMediaViewer, openMediaViewer } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
@@ -72,9 +73,7 @@ async function aliasModalJourney(page: Page): Promise<void> {
   await expect(link).toHaveAttribute("href", aliasUrl);
 
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   // No navigation — the modal opened in place.
   expect(page.url()).toBe(cicUrl);
 
@@ -90,8 +89,7 @@ async function aliasModalJourney(page: Page): Promise<void> {
   const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
   expect(naturalWidth).toBeGreaterThan(0);
 
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
 
   // Negative: a genuinely third-party host (NOT in the alias set) with
   // the same emoji + EXTENSIONLESS uploads shape must still be rejected —

--- a/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
@@ -43,6 +43,7 @@ import { fileURLToPath } from "node:url";
 import type { Page } from "@playwright/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { closeMediaViewer, openMediaViewer } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -126,9 +127,7 @@ test("cross-host https image link opens the media viewer, href unchanged, bytes 
   await expect(link).toHaveAttribute("href", IMAGE_URL);
 
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   // No navigation — the modal opened in place.
   expect(page.url()).toBe(cicUrl);
 
@@ -141,8 +140,7 @@ test("cross-host https image link opens the media viewer, href unchanged, bytes 
   const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
   expect(naturalWidth, "cross-host image must decode under the prod CSP").toBeGreaterThan(0);
 
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
 
   // Negative: same host, same extension, http → plain anchor.
   const insecure = await foreignLink(page, INSECURE_IMAGE_URL);
@@ -161,9 +159,7 @@ test("cross-host https video link opens the media viewer, href unchanged, metada
   await expect(link).toHaveAttribute("href", VIDEO_URL);
 
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   expect(page.url()).toBe(cicUrl);
 
   const video = viewer.locator("video.media-viewer-media");

--- a/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
+++ b/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
@@ -29,52 +29,29 @@
 // anyway (feedback_playwright_webkit_not_ios_scroll, same class).
 // Unit tests pin the rewrite; device dogfood is the final word.
 
-import type { Locator, Page } from "@playwright/test";
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  closeMediaViewer,
+  mediaViewer,
+  openMediaViewer,
+  uploadImageAndGetLink,
+} from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-// UX-6-B embedded-upload journey (shared fixtures/uploadJourney.ts):
-// real PNG through the picker, real POST /api/uploads, real IRC echo.
-// Returns the scrollback media link ready to click.
-async function uploadPngAndGetLink(page: Page): Promise<{
-  slug: string;
-  url: string;
-  row: Locator;
-  link: Locator;
-}> {
-  const { slug, url } = await uploadViaPicker(
-    page,
-    {
-      name: "media-viewer.png",
-      mimeType: "image/png",
-      buffer: Buffer.from(TINY_PNG_HEX, "hex"),
-    },
-    { postTimeout: 10_000 },
-  );
-
-  // 📸 PRIVMSG echoes back; the anchor carries the media-link class.
-  const { row, link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
-  return { slug, url, row, link };
-}
-
 test("📸 upload link click opens the in-app viewer instead of navigating", async ({ page }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { url, row, link } = await uploadPngAndGetLink(page);
+  const { url, row, link } = await uploadImageAndGetLink(page, "media-viewer.png");
 
   // Click → in-app viewer, NO navigation.
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   expect(page.url()).toBe(cicUrl);
 
   // The <img> actually loaded the bytes through nginx (naturalWidth 0
@@ -93,8 +70,7 @@ test("📸 upload link click opens the in-app viewer instead of navigating", asy
   await expect(external).toHaveAttribute("target", "_blank");
 
   // X closes; cic still on the channel, scrollback intact.
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   await expect(row.first()).toBeVisible();
   expect(page.url()).toBe(cicUrl);
 });
@@ -132,7 +108,7 @@ test("🎵 upload link click opens the docked mini-player, NOT the modal (GH #11
   // The docked bar appears; the media viewer modal stays closed.
   const player = page.getByTestId("audio-mini-player");
   await expect(player).toBeVisible({ timeout: 5_000 });
-  await expect(page.getByRole("dialog", { name: "Media viewer" })).toBeHidden();
+  await expect(mediaViewer(page)).toBeHidden();
   expect(page.url()).toBe(cicUrl);
 
   // The single <audio> element points at the served bytes (same-origin,
@@ -166,17 +142,14 @@ test("viewer load states: failure text on unfetchable media, spinner until bytes
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { slug, link } = await uploadPngAndGetLink(page);
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
+  const { slug, link } = await uploadImageAndGetLink(page, "media-viewer.png");
 
   // Phase 1 — unfetchable media: failure text, no forever-spinner.
   await page.route(`**/uploads/${slug}*`, (route) => route.abort());
-  await link.click();
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   await expect(viewer.getByText(/failed to load/i)).toBeVisible({ timeout: 5_000 });
   await expect(viewer.getByRole("status")).toBeHidden();
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   await page.unroute(`**/uploads/${slug}*`);
 
   // Phase 2 — hold the media response open until the spinner has been
@@ -191,8 +164,7 @@ test("viewer load states: failure text on unfetchable media, spinner until bytes
     await route.continue();
   });
 
-  await link.click();
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  await openMediaViewer(page, link);
   const spinner = viewer.getByRole("status", { name: /loading/i });
   await expect(spinner).toBeVisible();
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54280,3 +54280,114 @@ correct by construction, because the two spellings name two different rooms.
   channel move needs no sweep at all. Rewriting 289 sentences that way was
   judged a larger change than the issue asked for, and is left as the obvious
   follow-up if the channel shape ever moves again.
+<!-- entry #1441 -->
+
+---
+
+## 2026-08-20 — #1441: the media-viewer opener was thirteen sites, not ten copies, and never byte-identical
+
+The issue asked for one fixture-level opener for "ten specs", and was explicit
+that neither the byte-identity of the copies nor the completeness of the ten
+had been measured. Both were measured first, and both moved.
+
+### The census
+
+`cicchetto/e2e/fixtures/mediaViewer.ts` now owns the door. Before it, on
+`5ec44475`:
+
+| measured | value |
+|---|---|
+| spec FILES that open the viewer | **10** |
+| opening CALL SITES | **13** |
+| distinct glue bodies, raw bytes | **5** |
+| distinct glue bodies, indentation + comments normalised away | **3** |
+| `link.click()` (Playwright, scrolls into view) | 9 |
+| `link.evaluate((el) => el.click())` (in place) | 4 |
+| dialog-constructing files with no opening click | **0** |
+
+So the issue's ten is right at FILE granularity and low at call-site
+granularity — `media-link-modal-viewer.spec.ts` opened it three times and
+`media-link-cross-host-modal.spec.ts` twice. "Byte-identical" was never true:
+indentation alone splits the thirteen into five bodies, because two of them sit
+inside a `test.describe`.
+
+**The extractor lied first, and the scalar control did not catch it.** Version
+one pinned `media-link-modal-viewer.spec.ts == 3 open sites` and PASSED while
+finding the wrong three (75/175/176 instead of 75/174/194): a `toBeVisible`
+quoted inside a prose comment counted as a barrier, and a site whose dialog
+binding sat outside the lookback window was missed. Two errors of opposite sign
+summed to the expected total. The controls are pinned to LINE NUMBERS since —
+a count cannot see a compensating pair, and a hand-written parser gets exactly
+one chance to be calibrated against something a human read off the file. The
+negative control is `issue219-general-overlay-scroll-hold.spec.ts`, which says
+"media-viewer" three times in prose and opens the `/names` modal.
+
+### Two verbs, not one verb with a flag
+
+Nine sites clicked through Playwright, four dispatched the anchor's own click.
+That is not drift: #196-preserve, #219, #213 and #1438 MEASURE the scrollback's
+scroll position across the open, and Playwright's scroll-into-view would move
+the very thing under test. So the fixture exports `openMediaViewer` and
+`openMediaViewerInPlace` rather than one opener with `scroll: boolean`. A
+boolean at thirteen call sites is a coin flip a reviewer cannot check; the
+second name says in the call site what it is protecting.
+
+`closeMediaViewer` rides in for the same reason at the other edge (nine
+copies of the close click plus its `toBeHidden` barrier), and `mediaViewer`
+exports the locator so the one NEGATIVE use — the audio path must not open the
+modal — reads the same accessible name the positive ones do. The strings
+`"Media viewer"` and `"Close media viewer"` now appear once each in the tree.
+
+### Wait conditions: strictest, and then frozen
+
+All thirteen waited `toBeVisible({ timeout: 5_000 })`, so strictest and uniform
+coincide; 5_000 is kept, never raised. It is a module constant and NOT a
+per-call-site parameter — deliberately the opposite of `uploadJourney.ts`,
+where the image and video budgets genuinely differ 6×. Here every caller asks
+the same question, and a parameter would re-open the drift axis the lift exists
+to close.
+
+#213's extra wait on `.media-viewer-media--zoomable` stays in #213: it is
+image-and-zoom specific (the cross-host VIDEO case has no zoomable element at
+all) and it is the locator that spec goes on to drive. Strictest COMMON wait,
+not strictest anywhere.
+
+The media-class assertion moved INTO `uploadImageAndGetLink`, where six of the
+eight upload preambles already had it. #213 and #1438 gain it: without the
+class the anchor never opens the viewer, and the failure used to surface as a
+five-second timeout on the dialog instead of naming the classifier.
+
+### The +0, from Playwright's own collector
+
+`playwright test --list` on the base and on the branch: **759 tests in 411
+files** both sides, and the full 759-line title list diffs empty (line numbers
+stripped — those legitimately move). No spec disappeared, no title changed.
+
+Source `expect(` tokens fall 4189 → 4164, and that drop is what deduplication
+IS, so the arithmetic is reconciled exactly rather than waved at: 13
+`toBeVisible` + 9 `toBeHidden` + 6 `toHaveClass` removed from the specs = 28;
+3 added in the fixture. Executed assertions per path are unchanged at eleven of
+the thirteen sites and +1 at the two that gained the class check, so no path
+lost coverage.
+
+### Not established
+
+- **No e2e spec was RUN.** The stack lane was not requested for this change.
+  The gates are `bun run check` (all four stages green, including
+  `tsc -p e2e/tsconfig.json`) and `bun run test` (295 files, 5695 tests), plus
+  the `--list` equality above. That is a static argument and a collection
+  argument; it is not a green suite, and it does not rule out a runtime
+  difference the type system cannot see.
+- **No unit test covers the opener.** `whoisWait.ts` and `privmsgWait.ts` are
+  unit-testable because they carry a DECISION; these four functions are driver
+  calls around an imported `expect`, and the only way to fake that barrier is
+  to inject it — a seam invented for the test, over a verb the `tsc` and e2e
+  gates already cover.
+- **The population is "everything that names the dialog".** Two independent
+  shapes agree on the same ten files, and every file that constructs the dialog
+  has an opening click. A spec that opened the viewer and never asserted on it
+  would be invisible to both — and would also not be an opener worth sharing.
+- **`cicchetto/e2e` IS gated by `bun run check`**, correcting a briefing that
+  said otherwise: `cicchetto/scripts/check.ts` runs four stages and the fourth
+  is `tsc --noEmit -p e2e/tsconfig.json`, with `biome.json` including `e2e/**`
+  (#484, #1469).


### PR DESCRIPTION
One fixture-level door for the media viewer (#1441), and the census the issue
asked for — which moved both of its numbers.

## The census, first

Measured on the branch base before anything moved, by a script whose
known-answer controls run before it prints a single number:

| measured | value |
|---|---|
| spec FILES that open the viewer | **10** |
| opening CALL SITES | **13** |
| distinct glue bodies, raw bytes | **5** |
| distinct glue bodies, indentation + comments normalised away | **3** |
| `link.click()` (Playwright, scrolls into view) | 9 |
| `link.evaluate((el) => el.click())` (in place) | 4 |
| dialog-constructing files with no opening click | **0** |

The issue's **ten is right per FILE and low per call site** —
`media-link-modal-viewer.spec.ts` opens it three times,
`media-link-cross-host-modal.spec.ts` twice. **"Byte-identical" was never
true**, exactly as the issue suspected: indentation alone splits the thirteen
into five bodies, because two sit inside a `test.describe`.

**The extractor lied first and a scalar control did not catch it.** Version one
pinned `media-link-modal-viewer.spec.ts == 3 open sites` and PASSED while
finding the wrong three — 75/175/176 instead of 75/174/194 — because a
`toBeVisible` quoted inside a prose comment counted as a barrier and a site
whose dialog binding sat outside the lookback was missed. Two errors of
opposite sign summed to the expected total. Controls are pinned to LINE NUMBERS
since. The negative control is `issue219-general-overlay-scroll-hold.spec.ts`,
which names "media-viewer" three times in prose and opens the `/names` modal.

## Two verbs, not one verb with a flag

Nine sites clicked through Playwright, four dispatched the anchor's own click.
That divergence is **load-bearing, not drift**: #196-preserve, #219, #213 and
#1438 measure the scrollback's scroll position ACROSS the open, and Playwright's
scroll-into-view would move the very thing under test. So the fixture exports
`openMediaViewer` and `openMediaViewerInPlace` rather than one opener with
`scroll: boolean` — a boolean at thirteen call sites is a coin flip a reviewer
cannot check.

`closeMediaViewer` rides in for the same drift at the other edge (nine copies of
the close click plus its `toBeHidden`), and `mediaViewer` exports the locator so
the one NEGATIVE use — the audio path must not open the modal — reads the same
accessible name the positive ones do. `"Media viewer"` and
`"Close media viewer"` now appear once each in the tree.

## Wait conditions: strictest, then frozen

All thirteen waited `toBeVisible({ timeout: 5_000 })`, so strictest and uniform
coincide — kept, never raised. A module constant and deliberately NOT a
per-call-site parameter, the opposite of `uploadJourney.ts`'s rule: there the
image and video budgets genuinely differ 6x, here every caller asks the same
question and a parameter would re-open the axis this closes.

#213's extra wait on `.media-viewer-media--zoomable` **stays in #213** — it is
image-and-zoom specific (the cross-host VIDEO case has no zoomable element) and
it is the locator that spec drives. Strictest COMMON wait, not strictest
anywhere.

The media-class assertion moved into `uploadImageAndGetLink`, where six of the
eight upload preambles already had it; #213 and #1438 gain it. Without the class
the anchor never opens the viewer, and that used to surface as a five-second
timeout on the dialog instead of naming the classifier.

## The +0

From Playwright's own collector rather than a grep: `playwright test --list`
reports **759 tests in 411 files** on the base and on this branch, and the full
759-line title list **diffs empty** (line numbers stripped — those legitimately
move). Re-measured after the rebase, against the new base `9be1b40a`.

Source `expect(` tokens fall 4189 -> 4164. That drop is what deduplication IS,
and it reconciles exactly: 13 `toBeVisible` + 9 `toBeHidden` + 6 `toHaveClass`
removed from the specs = 28; 3 added in the fixture. **Executed** assertions are
unchanged at eleven of the thirteen sites and +1 at the two that gained the
class check, so no path lost coverage.

## Gates

- `bun run check` — 4 stages, 0 failed, both before and after the rebase.
- `bun run test` — 295 files, 5695 tests, green.
- `scripts/design-notes-gate.sh origin/main` — rc=0.
- `scripts/union-rebase.sh origin/main` — contribution intact (`+111 -0`);
  the four-check ritual after it: numstat identical on every path, previous
  entry (#1532) byte-identical at 6343 bytes, boundary shape read on the file
  (marker / blank / `---` / blank / `## `), marker unique in the file and
  against the `origin/main` tip.

## What this does NOT claim

- **No e2e spec was run** — no stack lane was requested for this change. The
  argument is static (`tsc -p e2e/tsconfig.json`) plus collection equality; it
  is not a green suite.
- **No unit test covers the opener.** `whoisWait.ts` and `privmsgWait.ts` are
  unit-testable because they carry a decision; these four functions are driver
  calls around an imported `expect`, and faking that barrier would mean
  injecting a seam invented for the test over a verb the existing gates cover.
- **The population is "everything that names the dialog".** Two independent
  grep shapes agree on the same ten files and every dialog-constructing file
  has an opening click, but a spec that opened the viewer and never asserted on
  it would be invisible to both.

## One correction to the record

`bun run check` **does** gate `cicchetto/e2e/`. `cicchetto/scripts/check.ts`
runs four stages and the fourth is `tsc --noEmit -p e2e/tsconfig.json`, with
`biome.json` including `e2e/**` (#484, #1469). Any brief saying it is
src-scoped is stale.
