### PR TITLE
union(#1579 + #964 + #1441): gate the three-slice union, not three greens against two bases

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -70,8 +70,11 @@ import {
 import type { SeededUser } from "./grappaApi";
 import { type ScrollGestureResult, scrollByGesture, waitForScrollRest } from "./scrollGesture";
 import type { TraceEvent } from "./scrollTrace";
+import { describeUserTopicTimeout, watchPageConsole } from "./userTopicDiagnostics";
 
 const SHELL_READY_TIMEOUT_MS = 10_000;
+// #1579 — see `waitForUserTopicReady` for why this number does not move.
+const USER_TOPIC_BARRIER_MS = 5_000;
 const MOBILE_BREAKPOINT_PX = 768;
 
 // Mirror of cicchetto/src/lib/theme.ts isMobile() — viewport width
@@ -111,6 +114,11 @@ export async function expectShellReady(page: Page): Promise<void> {
 // and `getSubject()` reads the subject; doing this via `page.evaluate`
 // AFTER goto would race the SPA's first read.
 async function seedAuthLocalStorage(page: Page, token: string, subjectJson: string): Promise<void> {
+  // #1579 — start recording the page console before the first navigation, so
+  // a later `waitForUserTopicReady` timeout can quote the phoenix-level join
+  // errors instead of leaving them in a container log nobody reads. Costs one
+  // listener; the page is not modified.
+  watchPageConsole(page);
   await page.addInitScript(
     ([t, s]) => {
       localStorage.setItem("grappa-token", t);
@@ -676,16 +684,30 @@ export async function waitForScrollbackRefreshed(
 // Wired into loginAs() universally rather than per-spec because the race
 // affects ANY spec that compose-sends `/join` (or any compose verb that
 // produces a server-side user-topic broadcast) shortly after page-load.
+//
+// #1579 — the budget is deliberately UNCHANGED. Measured over a full 759-test
+// run, 597 satisfied barriers have a median of 18 ms and a maximum of 848 ms,
+// so 5 s is not a tight budget; the three misses in that run sat at 11.1 s,
+// 31.6 s and >65 s, and every one of them was the server failing to complete
+// the WebSocket upgrade at all. A larger number would not have converted them
+// into passes, it would only have moved the red to the next assertion — which
+// is exactly what the same stall did to `loginAs`'s own shell-ready gate in
+// that run. What the barrier lacked was not slack but a voice, so it now
+// reports the state it observed instead of a bare TimeoutError.
 export async function waitForUserTopicReady(page: Page, userName: string): Promise<void> {
-  await page.waitForFunction(
-    (name) => {
-      const set = (window as unknown as { __cic_userTopicReady?: Set<string> })
-        .__cic_userTopicReady;
-      return set?.has(name) === true;
-    },
-    userName,
-    { timeout: 5_000 },
-  );
+  try {
+    await page.waitForFunction(
+      (name) => {
+        const set = (window as unknown as { __cic_userTopicReady?: Set<string> })
+          .__cic_userTopicReady;
+        return set?.has(name) === true;
+      },
+      userName,
+      { timeout: USER_TOPIC_BARRIER_MS },
+    );
+  } catch {
+    throw new Error(await describeUserTopicTimeout(page, userName, USER_TOPIC_BARRIER_MS));
+  }
 }
 
 // #485 — gate on the REAL service worker before a spec mutates any

--- a/cicchetto/e2e/fixtures/mediaViewer.ts
+++ b/cicchetto/e2e/fixtures/mediaViewer.ts
@@ -1,0 +1,139 @@
+// The media-viewer door (#1441): one place that knows how the viewer is
+// named, opened and closed.
+//
+// ## What was measured before the lift (on 5ec44475)
+//
+// THIRTEEN opening call sites across TEN spec files — not "ten copies". The
+// issue's ten is right at FILE granularity and low at call-site granularity:
+// media-link-modal-viewer.spec.ts alone opened it three times and
+// media-link-cross-host-modal.spec.ts twice.
+//
+// They were NOT byte-identical, a claim the issue explicitly refused to make.
+// Counting raw bytes there were FIVE distinct bodies (indentation splits them:
+// the two sites inside a `test.describe` are indented one level deeper);
+// normalising indentation and comments away leaves THREE, and the third is
+// only "shorter because the dialog was already bound above". So the real
+// divergence is ONE axis, below.
+//
+// ## The one axis that genuinely diverges, and why it gets two verbs
+//
+// Nine sites clicked with `link.click()` — Playwright's click, which scrolls
+// the anchor into view first. Four clicked with
+// `link.evaluate((el) => (el as HTMLElement).click())` — the anchor's OWN
+// click, dispatched where it sits. That is not drift. Those four
+// (#196-preserve, #219, #213, #1438) MEASURE the scrollback's scroll position
+// across the open, and Playwright's scroll-into-view would move the very thing
+// under test before the gesture it is testing ever fires.
+//
+// So this module exports two verbs rather than one verb with a `scroll: bool`.
+// A boolean at thirteen call sites is a coin flip a reviewer cannot check; two
+// names are two things a reviewer can read. `openMediaViewerInPlace` says what
+// it protects in its name, which is the whole reason those four specs are
+// green.
+//
+// ## Wait conditions: from the strictest copy, and then frozen
+//
+// All thirteen waited `toBeVisible({ timeout: 5_000 })` on the dialog, so the
+// strictest and the uniform value are the same 5_000 — kept, not raised.
+// It is a module constant and NOT a per-call-site parameter, deliberately
+// against `uploadJourney.ts`'s opposite rule: there the image and video budgets
+// genuinely differ 6×, here every caller wants the same answer to the same
+// question, and a parameter would re-open the drift axis this module exists to
+// close. A future viewer that needs longer changes it here, for everyone, on
+// purpose.
+//
+// #213 additionally waited for `.media-viewer-media--zoomable` to be visible.
+// That barrier stays in #213: it is image-and-zoom specific (the cross-host
+// video case has no zoomable element at all), and it is also the locator that
+// spec goes on to drive. Strictest COMMON wait, not strictest anywhere.
+//
+// ## Not in scope here
+//
+// `media-link-cross-host-modal.spec.ts` and `media-link-alias-modal.spec.ts`
+// produce their anchor by composing a URL rather than by uploading, so they
+// use the openers but not `uploadImageAndGetLink`. That is the domain
+// boundary, not a gap: the thing they share is the DOOR, and they use it.
+
+import { expect, type Locator, type Page } from "@playwright/test";
+import { TINY_PNG_HEX } from "./bytes";
+import { mediaScrollbackRow, uploadViaPicker } from "./uploadJourney";
+
+// The accessible name MediaViewerModal renders (role=dialog + aria-label), and
+// its close control. Ten spec files used to spell these out, so renaming the
+// label meant finding ten call sites by hand and the eleventh by CI.
+const DIALOG_NAME = "Media viewer";
+const CLOSE_BUTTON_NAME = "Close media viewer";
+
+// Measured uniform across all thirteen pre-lift call sites. See the header for
+// why it is a constant and not a parameter.
+const VIEWER_SETTLE_MS = 5_000;
+
+// The upload budget for the IMAGE path only — uniform across the eight upload
+// preambles. `uploadJourney.uploadViaPicker` deliberately demands this per call
+// site because the video path needs 6× as long; `uploadImageAndGetLink` is
+// image-only, so the budget is intrinsic to the verb. A video caller keeps
+// using `uploadViaPicker` directly and keeps choosing its own.
+const IMAGE_POST_TIMEOUT_MS = 10_000;
+
+// The viewer dialog, open or not. Exported so a NEGATIVE assertion (the audio
+// path must NOT open the modal) reads the same locator the positive ones do.
+export function mediaViewer(page: Page): Locator {
+  return page.getByRole("dialog", { name: DIALOG_NAME });
+}
+
+// Open by a real user click. Playwright scrolls the anchor into view first,
+// which is correct everywhere the scroll position is not itself the subject.
+export async function openMediaViewer(page: Page, link: Locator): Promise<Locator> {
+  await link.click();
+  return settled(page);
+}
+
+// Open WITHOUT moving the pane: dispatch the anchor's own click where it sits.
+// The four scroll-position specs need this — Playwright's click would scroll
+// the container they are about to measure.
+export async function openMediaViewerInPlace(page: Page, link: Locator): Promise<Locator> {
+  await link.evaluate((el) => (el as HTMLElement).click());
+  return settled(page);
+}
+
+// Close by the X, and wait for the dialog to actually go. Every caller wants
+// the barrier — a close that is only issued races whatever the spec asserts
+// next about the pane underneath.
+export async function closeMediaViewer(viewer: Locator): Promise<void> {
+  await viewer.getByRole("button", { name: CLOSE_BUTTON_NAME }).click();
+  await expect(viewer).toBeHidden({ timeout: VIEWER_SETTLE_MS });
+}
+
+async function settled(page: Page): Promise<Locator> {
+  const viewer = mediaViewer(page);
+  await expect(viewer).toBeVisible({ timeout: VIEWER_SETTLE_MS });
+  return viewer;
+}
+
+// The eight-copy preamble: upload a tiny PNG through the real picker, wait for
+// the 📸 row the IRC echo brings back, and hand over its anchor.
+//
+// `fileName` stays a parameter: it lands in the upload and names the spec that
+// made it, which is how a leftover in the store is attributed.
+//
+// The media-class assertion is HERE rather than at the call sites. Six of the
+// eight preambles made it and two (#213, #1438) did not — strictest wins, so
+// the two gain a precondition they were relying on silently. Without the class
+// the anchor never opens the viewer, and the failure used to surface as a
+// five-second timeout on the dialog instead of naming the classifier.
+// `uploadJourney.mediaScrollbackRow` deliberately does NOT assert it (it serves
+// 📄 documents too, which carry no media class); this verb is image-only, so
+// here it is a fact and not an assumption.
+export async function uploadImageAndGetLink(
+  page: Page,
+  fileName: string,
+): Promise<{ slug: string; url: string; row: Locator; link: Locator }> {
+  const { slug, url } = await uploadViaPicker(
+    page,
+    { name: fileName, mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
+    { postTimeout: IMAGE_POST_TIMEOUT_MS },
+  );
+  const { row, link } = await mediaScrollbackRow(page, "📸", slug);
+  await expect(link).toHaveClass(/scrollback-media-link/);
+  return { slug, url, row, link };
+}

--- a/cicchetto/e2e/fixtures/userTopicDiagnostics.ts
+++ b/cicchetto/e2e/fixtures/userTopicDiagnostics.ts
@@ -1,0 +1,122 @@
+// #1579 — what the user-topic barrier saw when it gave up.
+//
+// `waitForUserTopicReady` used to throw a bare
+// `TimeoutError: page.waitForFunction: Timeout 5000ms exceeded`, which names
+// the barrier and nothing else. That one line is compatible with at least four
+// different failures, and telling them apart cost a full-suite re-read plus an
+// iso-rerun every time it happened:
+//
+//   * the WS transport never opened, so no JOIN was ever pushed;
+//   * the transport is open and the user-topic JOIN alone is unacknowledged;
+//   * the stamp is present under a DIFFERENT name than the one awaited
+//     (`socketUserName()` disagreeing with the seeded `SeededUser.name`),
+//     which is a harness bug and not a race at all;
+//   * the page went offline / hidden mid-boot.
+//
+// Measured on the 759-test suite (2026-08-20, 597 satisfied barriers): the
+// healthy population sits at a median of 18 ms and a maximum of 848 ms, while
+// the three misses were all the FIRST shape — `state: "connecting"` with a
+// single connect attempt and no error, i.e. the server had not finished the
+// WebSocket upgrade. Nothing about the budget could have told them apart, and
+// nothing about the budget would have saved them; only the state at the
+// deadline does. So the barrier keeps its 5 s and gains a voice.
+//
+// This is diagnosis, never recovery: the timeout still fails the test, at the
+// same moment, for the same reason.
+
+import type { Page } from "@playwright/test";
+
+// Console output per page, captured through Playwright's own listener rather
+// than by patching the page's `console` — the page under test must behave
+// exactly as it does without the harness. `joinUser`/`joinChannel` log the
+// phoenix-level "channel join failed" / "channel join timed out" shapes, which
+// is the difference between "the socket never opened" and "the socket opened
+// and the server refused the topic".
+//
+// A WeakMap so a closed page's buffer is collectable with the page.
+const consoleByPage = new WeakMap<Page, string[]>();
+
+// Cap: a spec that logs in a loop must not turn the buffer into the run's
+// memory profile. The tail is what a post-mortem reads, so the cap drops from
+// the FRONT.
+const CONSOLE_CAP = 200;
+
+// Start recording this page's console. Call before the first navigation —
+// `loginAs`'s seeding door does, which covers every caller of the barrier.
+export function watchPageConsole(page: Page): void {
+  if (consoleByPage.has(page)) return;
+  const buffer: string[] = [];
+  consoleByPage.set(page, buffer);
+  page.on("console", (message) => {
+    buffer.push(`${message.type()}: ${message.text()}`);
+    if (buffer.length > CONSOLE_CAP) buffer.shift();
+  });
+}
+
+type Snapshot = {
+  readyNames: string[];
+  socketHealth: unknown;
+  joinedTopicKeys: string[];
+  onLine: boolean;
+  visibility: string;
+};
+
+// One message naming every state that distinguishes the four failures above.
+// Returns a string rather than throwing so the caller owns the error type, and
+// swallows nothing: a page that can no longer be interrogated says so, because
+// "the page was already gone" is itself one of the answers.
+export async function describeUserTopicTimeout(
+  page: Page,
+  userName: string,
+  budgetMs: number,
+): Promise<string> {
+  const head = `waitForUserTopicReady: '${userName}' was not stamped within ${budgetMs}ms`;
+  let snapshot: Snapshot;
+  try {
+    snapshot = await page.evaluate((): Snapshot => {
+      const w = window as unknown as {
+        __cic_userTopicReady?: Set<string>;
+        __cic_socketHealth?: { state: () => unknown };
+        __cic_joinedTopicKeys?: () => string[];
+      };
+      return {
+        readyNames: Array.from(w.__cic_userTopicReady ?? []),
+        socketHealth: w.__cic_socketHealth?.state() ?? null,
+        joinedTopicKeys: w.__cic_joinedTopicKeys?.() ?? [],
+        onLine: navigator.onLine,
+        visibility: document.visibilityState,
+      };
+    });
+  } catch (err) {
+    return `${head}, and the page could not be interrogated afterwards: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+  }
+
+  const consoleTail = consoleByPage.get(page);
+  return [
+    head,
+    `  stamped names:     ${JSON.stringify(snapshot.readyNames)}`,
+    `  socket health:     ${JSON.stringify(snapshot.socketHealth)}`,
+    `  joined topic keys: ${JSON.stringify(snapshot.joinedTopicKeys)}`,
+    `  navigator.onLine:  ${snapshot.onLine}   visibility: ${snapshot.visibility}`,
+    consoleTail === undefined
+      ? "  page console:      not recorded (watchPageConsole was never called for this page)"
+      : `  page console (last ${Math.min(consoleTail.length, 12)} of ${consoleTail.length}):\n` +
+        (consoleTail.length === 0
+          ? "    (the page logged nothing)"
+          : consoleTail
+              .slice(-12)
+              .map((line) => `    ${line}`)
+              .join("\n")),
+    // The reading a triager should reach for first, spelled out rather than
+    // left to be re-derived. A socket that is still `connecting` on its first
+    // attempt is not a client-side race: the server has not finished the
+    // upgrade, and #1579 measured that as an 11-33 s SQLite write-lock stall
+    // inside `UserSocket.connect/3`.
+    '  If socket health reads state "connecting" with connectAttempts 1 and no',
+    "  error, the WS upgrade never completed server-side — read the grappa",
+    "  container log for `CONNECTED TO GrappaWeb.UserSocket in <N>ms`, not the",
+    "  spec. See #1579.",
+  ].join("\n");
+}

--- a/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
+++ b/cicchetto/e2e/tests/issue1121-overlay-close-tail-reader.spec.ts
@@ -31,12 +31,11 @@
 // Desktop project only (untagged → chromium), like its #196 twin: desktop Chrome
 // reproduces desktop scroll physics (feedback_playwright_webkit_not_ios_scroll).
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
+import { closeMediaViewer, openMediaViewer, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "arr1121-peer";
@@ -64,13 +63,7 @@ test.describe("#1121 — closing an overlay over a tail reader must not strand t
 
     // Upload an image → a clickable media link lands at the tail, where our
     // reader already is. No scroll-up here: being AT the tail IS the precondition.
-    const { slug } = await uploadViaPicker(
-      page,
-      { name: "arr1121.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-      { postTimeout: 10_000 },
-    );
-    const { link } = await mediaScrollbackRow(page, "📸", slug);
-    await expect(link).toHaveClass(/scrollback-media-link/);
+    const { link } = await uploadImageAndGetLink(page, "arr1121.png");
 
     const sc = page.getByTestId("scrollback");
     const scrollButton = page.locator('[data-testid="scroll-to-bottom"]');
@@ -109,9 +102,7 @@ test.describe("#1121 — closing an overlay over a tail reader must not strand t
       await expect(scrollButton).toBeHidden({ timeout: 5_000 });
 
       // Open the preview via a REAL click on the image at the tail.
-      await link.click();
-      const viewer = page.getByRole("dialog", { name: "Media viewer" });
-      await expect(viewer).toBeVisible({ timeout: 5_000 });
+      const viewer = await openMediaViewer(page, link);
 
       // Three lines land underneath the open overlay — the reporter's exact
       // gesture. They must NOT move the frozen pane (that is #196's contract,
@@ -128,8 +119,7 @@ test.describe("#1121 — closing an overlay over a tail reader must not strand t
       expect(Math.abs(during - before.top)).toBeLessThanOrEqual(5);
 
       // Close it. The reader is now genuinely parked above a tail that moved.
-      await viewer.getByRole("button", { name: "Close media viewer" }).click();
-      await expect(viewer).toBeHidden({ timeout: 5_000 });
+      await closeMediaViewer(viewer);
       await page.waitForTimeout(400);
 
       // OBSERVABLE 1 — the geometry was republished, so the pane admits there is

--- a/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
@@ -38,35 +38,27 @@
 // src/__tests__/mediaViewerGesture.test.ts. These are the end-to-end doors.
 
 import type { Locator, Page } from "@playwright/test";
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { openMediaViewerInPlace, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // Upload a tiny image and open it in the media viewer, mirroring #213's
 // harness: the anchor's OWN click opens the overlay (no Playwright
-// scroll-into-view). Every spec that opens this viewer carries its own copy of
-// these six lines — a pre-existing duplication across nine files, not one this
-// change introduces, and not one it is in scope to sweep.
+// scroll-into-view).
+//
+// The duplication this used to carry — "these six lines across nine files",
+// out of scope when #1438 landed — is now fixtures/mediaViewer.ts (#1441). What
+// is left here is the login + channel selection this spec's three tests share.
 async function openImageViewer(page: Page): Promise<{ viewer: Locator }> {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
   await loginAs(page, specUser());
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x1438.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await link.evaluate((el) => (el as HTMLElement).click());
-
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
-  return { viewer };
+  const { link } = await uploadImageAndGetLink(page, "x1438.png");
+  return { viewer: await openMediaViewerInPlace(page, link) };
 }
 
 // One vertical drag on the modal, plus the browser's own reading of where the

--- a/cicchetto/e2e/tests/issue196-preview-scroll-live-arrival.spec.ts
+++ b/cicchetto/e2e/tests/issue196-preview-scroll-live-arrival.spec.ts
@@ -26,13 +26,12 @@
 // IrcPeer for the in-overlay arrival, deterministic scroll via evaluate, overlay
 // opened by the anchor's OWN real click on a VISIBLE mid-list image.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
+import { closeMediaViewer, openMediaViewer, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "arr196-peer";
@@ -65,13 +64,7 @@ test.describe("#196 — preview overlay holds scroll across a live message arriv
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
     // Upload an image → a clickable media link lands at the tail.
-    const { slug } = await uploadViaPicker(
-      page,
-      { name: "arr196.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-      { postTimeout: 10_000 },
-    );
-    const { link } = await mediaScrollbackRow(page, "📸", slug);
-    await expect(link).toHaveClass(/scrollback-media-link/);
+    const { link } = await uploadImageAndGetLink(page, "arr196.png");
 
     const peer = await IrcPeer.connect({ nick: PEER_NICK });
     try {
@@ -110,9 +103,7 @@ test.describe("#196 — preview overlay holds scroll across a live message arriv
       expect(before.rowVisible).toBe(true);
 
       // Open the preview via a REAL click on the visible image.
-      await link.click();
-      const viewer = page.getByRole("dialog", { name: "Media viewer" });
-      await expect(viewer).toBeVisible({ timeout: 5_000 });
+      const viewer = await openMediaViewer(page, link);
 
       // Opening the overlay must not move the list.
       const onOpen = await sc.evaluate((el) => el.scrollTop);
@@ -132,8 +123,7 @@ test.describe("#196 — preview overlay holds scroll across a live message arriv
       expect(Math.abs(during - before.top)).toBeLessThanOrEqual(5);
 
       // Close the preview — the position must STILL be where the reader left it.
-      await viewer.getByRole("button", { name: "Close media viewer" }).click();
-      await expect(viewer).toBeHidden({ timeout: 5_000 });
+      await closeMediaViewer(viewer);
       await page.waitForTimeout(400);
       const after = await sc.evaluate((el) => el.scrollTop);
       expect(Math.abs(after - before.top)).toBeLessThanOrEqual(5);

--- a/cicchetto/e2e/tests/issue196-preview-scroll-preserve.spec.ts
+++ b/cicchetto/e2e/tests/issue196-preview-scroll-preserve.spec.ts
@@ -21,11 +21,14 @@
 // (off-screen), and this test is about OPENING the overlay not moving the list,
 // NOT about the click's own scroll-into-view.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  closeMediaViewer,
+  openMediaViewerInPlace,
+  uploadImageAndGetLink,
+} from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -42,13 +45,7 @@ test("#196 — opening the image preview keeps the message-list scroll position 
   // seeded with 200 lines, so the pane is already tall enough to scroll — the
   // image lands at the tail (its exact position is irrelevant: it's opened via
   // el.click() below, not by scrolling to it).
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x196.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
+  const { link } = await uploadImageAndGetLink(page, "x196.png");
 
   const sc = page.getByTestId("scrollback");
   // Scroll to a deterministic MIDDLE position (away from both top and bottom).
@@ -65,18 +62,16 @@ test("#196 — opening the image preview keeps the message-list scroll position 
   expect(before.top).toBeLessThan(before.max - 5);
 
   // Open the preview via the anchor's OWN click — fires the onClick
-  // (preventDefault + openMediaViewer) with NO Playwright scroll-into-view.
-  await link.evaluate((el) => (el as HTMLElement).click());
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  // (preventDefault + the app's src/lib/mediaViewer) with NO Playwright
+  // scroll-into-view, which would move the very position under test.
+  const viewer = await openMediaViewerInPlace(page, link);
 
   // The scroll position must NOT have moved when the overlay opened.
   const during = await sc.evaluate((el) => el.scrollTop);
   expect(Math.abs(during - before.top)).toBeLessThanOrEqual(3);
 
   // Close the overlay — the position must STILL be where the reader left it.
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   const after = await sc.evaluate((el) => el.scrollTop);
   expect(Math.abs(after - before.top)).toBeLessThanOrEqual(3);
 });

--- a/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
+++ b/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
@@ -32,33 +32,32 @@
 // scale ratio) is covered by the pinchZoom.ts unit tests (jsdom); these e2es
 // guard the DOM wiring + the CSS contract, not the physics.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
+import type { Page } from "@playwright/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { openMediaViewerInPlace, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-// Upload a tiny image and open it in the media viewer. Returns the viewer
-// dialog + the zoomable <img> locator. Mirrors #219's harness: the anchor's OWN
-// click opens the overlay (no Playwright scroll-into-view).
-async function openImageViewer(page: import("@playwright/test").Page) {
+// Upload a tiny image and open it in the media viewer, then narrow to the
+// ZOOMABLE <img> — the element these three tests actually drive.
+//
+// The door itself (upload → anchor → in-place click → dialog visible) is
+// fixtures/mediaViewer.ts since #1441. The extra barrier below stays here: it
+// is image-and-zoom specific, and it is also the locator this spec returns.
+// `openMediaViewerInPlace` and not the plain opener because #219's harness
+// (which this mirrors) needs the anchor's OWN click, with no Playwright
+// scroll-into-view.
+async function openImageViewer(page: Page) {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
   const vjt = specUser();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x213.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await link.evaluate((el) => (el as HTMLElement).click());
+  const { link } = await uploadImageAndGetLink(page, "x213.png");
+  const viewer = await openMediaViewerInPlace(page, link);
 
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
   const img = viewer.locator(".media-viewer-media--zoomable");
   await expect(img).toBeVisible({ timeout: 5_000 });
   return { viewer, img };

--- a/cicchetto/e2e/tests/issue219-overlay-scroll-hold.spec.ts
+++ b/cicchetto/e2e/tests/issue219-overlay-scroll-hold.spec.ts
@@ -32,11 +32,14 @@
 // stays there on close. GREEN post-fix: the position is HELD across the resize
 // and the close.
 
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  closeMediaViewer,
+  openMediaViewerInPlace,
+  uploadImageAndGetLink,
+} from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
-import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -51,13 +54,7 @@ test("#219 — a resize while the image viewer is open must NOT snap the list to
 
   // Upload an image so the scrollback carries a clickable media link. #spec-wN is
   // seeded with 200 lines → the pane is genuinely tall and scrollable.
-  const { slug } = await uploadViaPicker(
-    page,
-    { name: "x219.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
+  const { link } = await uploadImageAndGetLink(page, "x219.png");
 
   const sc = page.getByTestId("scrollback");
   // Scroll to a deterministic MIDDLE position (away from both top and bottom).
@@ -72,9 +69,7 @@ test("#219 — a resize while the image viewer is open must NOT snap the list to
   expect(before.top).toBeLessThan(before.max - 5);
 
   // Open the preview via the anchor's OWN click (no Playwright scroll-into-view).
-  await link.evaluate((el) => (el as HTMLElement).click());
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewerInPlace(page, link);
 
   // #196 covers the open EDGE — position is preserved right after open.
   const afterOpen = await sc.evaluate((el) => el.scrollTop);
@@ -98,8 +93,7 @@ test("#219 — a resize while the image viewer is open must NOT snap the list to
   expect(Math.abs(during - before.top)).toBeLessThanOrEqual(10);
 
   // Close — the position must STILL be where the reader left it.
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   await page.waitForTimeout(300);
   const after = await sc.evaluate((el) => el.scrollTop);
   expect(Math.abs(after - before.top)).toBeLessThanOrEqual(10);

--- a/cicchetto/e2e/tests/issue418-upload-url-extension.spec.ts
+++ b/cicchetto/e2e/tests/issue418-upload-url-extension.spec.ts
@@ -26,8 +26,8 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Page } from "@playwright/test";
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { closeMediaViewer, openMediaViewer, uploadImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
@@ -48,28 +48,20 @@ test("image: server mints /uploads/<slug>.png and the extensioned URL opens the 
 }) => {
   await openChannel(page);
 
-  const { slug, url } = await uploadViaPicker(
-    page,
-    { name: "issue418.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
-    { postTimeout: 10_000 },
-  );
-
-  // #418 server half: the minted URL carries the faithful type extension.
-  expect(url).toMatch(new RegExp(`/uploads/${slug}\\.png$`));
-
   // Real IRC echo → the 📸 row. The link classifies by the EXTENSION now
   // (the URL is `/uploads/<slug>.png`, which no longer matches the
   // extensionless UPLOADS_PATH_RE → mediaLink rule 3), and the anchor
-  // href IS the extensioned URL — the type signal reached cic intact.
-  const { link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
+  // href IS the extensioned URL — the type signal reached cic intact. The
+  // media-class assertion is inside `uploadImageAndGetLink` (#1441).
+  const { slug, url, link } = await uploadImageAndGetLink(page, "issue418.png");
+
+  // #418 server half: the minted URL carries the faithful type extension.
+  expect(url).toMatch(new RegExp(`/uploads/${slug}\\.png$`));
   await expect(link).toHaveAttribute("href", url);
 
   // Click → in-app image viewer opens, no navigation.
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   expect(page.url()).toBe(cicUrl);
 
   // The <img> fetched the bytes from the EXTENSIONED URL through nginx,
@@ -79,8 +71,7 @@ test("image: server mints /uploads/<slug>.png and the extensioned URL opens the 
   await expect(img).toHaveJSProperty("complete", true, { timeout: 10_000 });
   expect(await img.evaluate((el) => (el as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
 
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   expect(page.url()).toBe(cicUrl);
 });
 

--- a/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
@@ -31,6 +31,7 @@
 import type { Page } from "@playwright/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { closeMediaViewer, openMediaViewer } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
@@ -72,9 +73,7 @@ async function aliasModalJourney(page: Page): Promise<void> {
   await expect(link).toHaveAttribute("href", aliasUrl);
 
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   // No navigation — the modal opened in place.
   expect(page.url()).toBe(cicUrl);
 
@@ -90,8 +89,7 @@ async function aliasModalJourney(page: Page): Promise<void> {
   const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
   expect(naturalWidth).toBeGreaterThan(0);
 
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
 
   // Negative: a genuinely third-party host (NOT in the alias set) with
   // the same emoji + EXTENSIONLESS uploads shape must still be rejected —

--- a/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
@@ -43,6 +43,7 @@ import { fileURLToPath } from "node:url";
 import type { Page } from "@playwright/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { closeMediaViewer, openMediaViewer } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -126,9 +127,7 @@ test("cross-host https image link opens the media viewer, href unchanged, bytes 
   await expect(link).toHaveAttribute("href", IMAGE_URL);
 
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   // No navigation — the modal opened in place.
   expect(page.url()).toBe(cicUrl);
 
@@ -141,8 +140,7 @@ test("cross-host https image link opens the media viewer, href unchanged, bytes 
   const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
   expect(naturalWidth, "cross-host image must decode under the prod CSP").toBeGreaterThan(0);
 
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
 
   // Negative: same host, same extension, http → plain anchor.
   const insecure = await foreignLink(page, INSECURE_IMAGE_URL);
@@ -161,9 +159,7 @@ test("cross-host https video link opens the media viewer, href unchanged, metada
   await expect(link).toHaveAttribute("href", VIDEO_URL);
 
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   expect(page.url()).toBe(cicUrl);
 
   const video = viewer.locator("video.media-viewer-media");

--- a/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
+++ b/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
@@ -29,52 +29,29 @@
 // anyway (feedback_playwright_webkit_not_ios_scroll, same class).
 // Unit tests pin the rewrite; device dogfood is the final word.
 
-import type { Locator, Page } from "@playwright/test";
-import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  closeMediaViewer,
+  mediaViewer,
+  openMediaViewer,
+  uploadImageAndGetLink,
+} from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-// UX-6-B embedded-upload journey (shared fixtures/uploadJourney.ts):
-// real PNG through the picker, real POST /api/uploads, real IRC echo.
-// Returns the scrollback media link ready to click.
-async function uploadPngAndGetLink(page: Page): Promise<{
-  slug: string;
-  url: string;
-  row: Locator;
-  link: Locator;
-}> {
-  const { slug, url } = await uploadViaPicker(
-    page,
-    {
-      name: "media-viewer.png",
-      mimeType: "image/png",
-      buffer: Buffer.from(TINY_PNG_HEX, "hex"),
-    },
-    { postTimeout: 10_000 },
-  );
-
-  // 📸 PRIVMSG echoes back; the anchor carries the media-link class.
-  const { row, link } = await mediaScrollbackRow(page, "📸", slug);
-  await expect(link).toHaveClass(/scrollback-media-link/);
-  return { slug, url, row, link };
-}
-
 test("📸 upload link click opens the in-app viewer instead of navigating", async ({ page }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { url, row, link } = await uploadPngAndGetLink(page);
+  const { url, row, link } = await uploadImageAndGetLink(page, "media-viewer.png");
 
   // Click → in-app viewer, NO navigation.
   const cicUrl = page.url();
-  await link.click();
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   expect(page.url()).toBe(cicUrl);
 
   // The <img> actually loaded the bytes through nginx (naturalWidth 0
@@ -93,8 +70,7 @@ test("📸 upload link click opens the in-app viewer instead of navigating", asy
   await expect(external).toHaveAttribute("target", "_blank");
 
   // X closes; cic still on the channel, scrollback intact.
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   await expect(row.first()).toBeVisible();
   expect(page.url()).toBe(cicUrl);
 });
@@ -132,7 +108,7 @@ test("🎵 upload link click opens the docked mini-player, NOT the modal (GH #11
   // The docked bar appears; the media viewer modal stays closed.
   const player = page.getByTestId("audio-mini-player");
   await expect(player).toBeVisible({ timeout: 5_000 });
-  await expect(page.getByRole("dialog", { name: "Media viewer" })).toBeHidden();
+  await expect(mediaViewer(page)).toBeHidden();
   expect(page.url()).toBe(cicUrl);
 
   // The single <audio> element points at the served bytes (same-origin,
@@ -166,17 +142,14 @@ test("viewer load states: failure text on unfetchable media, spinner until bytes
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { slug, link } = await uploadPngAndGetLink(page);
-  const viewer = page.getByRole("dialog", { name: "Media viewer" });
+  const { slug, link } = await uploadImageAndGetLink(page, "media-viewer.png");
 
   // Phase 1 — unfetchable media: failure text, no forever-spinner.
   await page.route(`**/uploads/${slug}*`, (route) => route.abort());
-  await link.click();
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  const viewer = await openMediaViewer(page, link);
   await expect(viewer.getByText(/failed to load/i)).toBeVisible({ timeout: 5_000 });
   await expect(viewer.getByRole("status")).toBeHidden();
-  await viewer.getByRole("button", { name: "Close media viewer" }).click();
-  await expect(viewer).toBeHidden({ timeout: 5_000 });
+  await closeMediaViewer(viewer);
   await page.unroute(`**/uploads/${slug}*`);
 
   // Phase 2 — hold the media response open until the spinner has been
@@ -191,8 +164,7 @@ test("viewer load states: failure text on unfetchable media, spinner until bytes
     await route.continue();
   });
 
-  await link.click();
-  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  await openMediaViewer(page, link);
   const spinner = viewer.getByRole("status", { name: /loading/i });
   await expect(spinner).toBeVisible();
 

--- a/cicchetto/e2e/tests/push-964-device-label.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-label.spec.ts
@@ -1,0 +1,147 @@
+// push-964 — naming a device, and the ordinal that names the ones you have not.
+//
+// The sibling spec (`push-964-device-row.spec.ts`) covers the two
+// disambiguators derived from data the row already carried: the activity
+// instant and the "this device" marker. This one covers the two that needed a
+// schema change — the user's own label, and the ordinal that separates the
+// twins nobody has named yet.
+//
+// Four contracts, every one asserted on what a person would SEE:
+//
+//   1. Two devices that parse to the same `Browser on OS` render DIFFERENT
+//      names, numbered oldest-first.
+//   2. Renaming one from its row replaces that name, and demotes the parsed
+//      string to the secondary line instead of dropping it.
+//   3. Naming one twin drops the OTHER's ordinal. This is the assertion a
+//      STORED ordinal would fail: a column written while the pair collided
+//      keeps its `#2` forever, whereas the derived name re-reads the list and
+//      finds the survivor alone in its group.
+//   4. Clearing the label hands the row back to the derived default — the
+//      twins collide again and BOTH are numbered once more.
+//
+// ## Why the rows are POSTed rather than registered from two browsers
+//
+// The contract under test is about two rows whose `user_agent` parses to the
+// same string. The runner has one engine per project, so a second browser
+// would supply the same UA — but also a second push stub, a second SW
+// registration and a second opt-in dance for rows this spec only ever reads.
+// POSTing them is the same insert the server would have performed, and it lets
+// the spec pin the UA, so the expected names are literal (`Firefox on Linux
+// #1`) instead of "whatever this engine calls itself".
+//
+// ## Why there is no page.reload()
+//
+// On boot `installPushResubscribe` renews a subscription the per-document push
+// stub makes look dropped; the renewal POSTs `supersedes`, which DELETES the
+// old row and inserts a fresh one — losing the very label under assertion. The
+// persistence leg therefore reads from a second BrowserContext, which carries
+// no opt-in intent and so renews nothing. Same reasoning as the sibling spec.
+//
+// No @webkit twin: every assertion is on rendered text, so nothing here is
+// engine-dependent.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
+import { resetPushSubscriptions } from "../fixtures/push";
+import { getSeededVjt } from "../fixtures/seedData";
+
+const GRAPPA = "http://grappa-test:4000";
+
+// One UA for both rows: `parseUserAgent` collapses it to "Firefox on Linux",
+// which is precisely the collision Hypnotize reported.
+const TWIN_UA = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
+const TWIN_NAME = "Firefox on Linux";
+
+test("twins carry ordinals, a rename replaces one, and the survivor drops its number", async ({
+  page,
+  browser,
+}) => {
+  const vjt = getSeededVjt();
+  await resetPushSubscriptions(vjt.token);
+
+  // Oldest first — the ordinal is assigned by creation instant, so the order
+  // of these two POSTs is what makes `#1` deterministic.
+  await registerDevice(vjt.token, TWIN_UA, "https://push.example/964-label-older");
+  await registerDevice(vjt.token, TWIN_UA, "https://push.example/964-label-newer");
+
+  await loginAs(page, vjt);
+  await openSettingsSection(page, "push");
+
+  const rows = page.locator('[data-testid="devices-list"] li');
+  await expect(rows).toHaveCount(2);
+
+  // ── 1. Both numbered, and the two names differ.
+  const first = rows.filter({ hasText: `${TWIN_NAME} #1` });
+  const second = rows.filter({ hasText: `${TWIN_NAME} #2` });
+  await expect(first).toHaveCount(1);
+  await expect(second).toHaveCount(1);
+
+  // ── 2. Rename the second one from its row.
+  await second.getByTestId("device-rename").click();
+  const input = page.getByTestId("device-name-input");
+  await expect(input).toBeVisible();
+  await input.fill("il portatile");
+  await page.getByTestId("device-rename-save").click();
+
+  const renamed = rows.filter({ hasText: "il portatile" });
+  await expect(renamed.getByTestId("device-name")).toHaveText("il portatile");
+  // The parsed string is not lost — it demotes to the secondary line.
+  await expect(renamed.getByTestId("device-parsed")).toHaveText(TWIN_NAME);
+
+  // ── 3. The other twin is now alone among the unnamed, so its ordinal is
+  // gone. A stored ordinal would still read "#1" here.
+  const survivor = rows.filter({ hasNotText: "il portatile" });
+  await expect(survivor.getByTestId("device-name")).toHaveText(TWIN_NAME);
+
+  // ── The label lives on the SERVER: a browser that has never seen this
+  // session reads the same name back.
+  const observerCtx = await browser.newContext();
+  try {
+    const observer = await observerCtx.newPage();
+    await loginAs(observer, vjt);
+    await openSettingsSection(observer, "push");
+    await expect(
+      observer.locator('[data-testid="devices-list"] li').filter({ hasText: "il portatile" }),
+    ).toHaveCount(1);
+  } finally {
+    await observerCtx.close();
+  }
+
+  // ── 4. Clearing the label hands the row back to its derived default, and
+  // the twins collide again — both numbered once more.
+  await renamed.getByTestId("device-rename").click();
+  await page.getByTestId("device-name-input").fill("");
+  await page.getByTestId("device-rename-save").click();
+
+  await expect(rows.filter({ hasText: `${TWIN_NAME} #1` })).toHaveCount(1);
+  await expect(rows.filter({ hasText: `${TWIN_NAME} #2` })).toHaveCount(1);
+  await expect(page.getByTestId("device-parsed")).toHaveCount(0);
+});
+
+/**
+ * POSTs a push subscription for `token`'s subject with an explicit UA, so the
+ * spec controls what the row parses to. Keys are the fixture pair the push
+ * helpers use — the changeset's length caps apply to every insert, whoever
+ * makes it.
+ */
+async function registerDevice(token: string, userAgent: string, endpoint: string): Promise<void> {
+  const res = await fetch(`${GRAPPA}/push/subscriptions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": userAgent,
+    },
+    body: JSON.stringify({
+      endpoint,
+      keys: {
+        p256dh:
+          "BCfaYE5dGabdzef68MI0SN24b4Gsf1t_N3ftUlWaFGzkuudjHLor0CRjosM3c7SLZ7PfFufpsFUh8vsO1t8wCHs",
+        auth: "dGVzdC1hdXRoLXNlY3JldDE2Yg",
+      },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`registerDevice: ${res.status} ${await res.text()}`);
+  }
+}

--- a/cicchetto/e2e/tests/push-964-device-label.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-label.spec.ts
@@ -40,10 +40,10 @@
 // No @webkit twin: every assertion is on rendered text, so nothing here is
 // engine-dependent.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
 import { resetPushSubscriptions } from "../fixtures/push";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA = "http://grappa-test:4000";
 

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -25,7 +25,7 @@ import {
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { formatDuration } from "./lib/duration";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
-import { friendlyApiError } from "./lib/friendlyApiError";
+import { errorMessage, friendlyApiError } from "./lib/friendlyApiError";
 import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
 import { deleteAccountBody, updateIdentity, updateNetworkPassword } from "./lib/lifecycle";
 import { networks, user } from "./lib/networks";
@@ -33,6 +33,7 @@ import { mirrorNotificationPrefs, notificationPrefs } from "./lib/notificationPr
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
   deletePushSubscription,
+  deviceRows,
   disablePush,
   type EnablePushResult,
   enablePush,
@@ -40,6 +41,7 @@ import {
   listPushDevices,
   type PushDeviceSummary,
   pushAvailable,
+  renamePushDevice,
   type SubscriptionId,
   subscriptionIdForEndpoint,
 } from "./lib/push";
@@ -123,6 +125,12 @@ const SettingsDrawer: Component<Props> = (props) => {
   // reason this issue exists. `null` = we cannot prove any row is ours (never
   // subscribed here / cleared site data) — then NO row gets the marker.
   const [currentDeviceId, setCurrentDeviceId] = createSignal<SubscriptionId | null>(null);
+  // #964 — inline rename. `renamingId` is the row currently in edit mode
+  // (at most one); the draft lives here rather than in the input so a
+  // re-render from a background refreshDevices cannot discard the typing.
+  const [renamingId, setRenamingId] = createSignal<SubscriptionId | null>(null);
+  const [renameDraft, setRenameDraft] = createSignal("");
+  const [renameError, setRenameError] = createSignal<string | null>(null);
   const [pushEnabled, setPushEnabled] = createSignal(false);
   const [pushBanner, setPushBanner] = createSignal<string | null>(null);
   const [savingPrefs, setSavingPrefs] = createSignal(false);
@@ -667,6 +675,37 @@ const SettingsDrawer: Component<Props> = (props) => {
       setPushEnabled(false);
       setCurrentDeviceId(null);
       await refreshDevices();
+    }
+  };
+
+  // #964 — opens the row's editor. Seeded with the STORED label, never with
+  // the derived default: pre-filling "Firefox on Linux #2" and hitting save
+  // would freeze today's ordinal into a stored label, which is the stale
+  // number the derived design exists to avoid.
+  const startRename = (device: PushDeviceSummary) => {
+    setRenameError(null);
+    setRenameDraft(device.label ?? "");
+    setRenamingId(device.id);
+  };
+
+  const cancelRename = () => {
+    setRenamingId(null);
+    setRenameError(null);
+  };
+
+  // Unlike removeDevice, a failure here is NOT swallowed: a 422 past the
+  // length cap is the user's own input coming back, and silently dropping
+  // it would look like the rename simply did not take.
+  const commitRename = async (id: SubscriptionId) => {
+    const t = token();
+    if (t === null) return;
+    try {
+      await renamePushDevice(t, id, renameDraft());
+      setRenamingId(null);
+      setRenameError(null);
+      await refreshDevices();
+    } catch (err) {
+      setRenameError(errorMessage(err));
     }
   };
 
@@ -1859,8 +1898,9 @@ const SettingsDrawer: Component<Props> = (props) => {
               <Show when={devices().length > 0}>
                 <h3>devices</h3>
                 <ul class="devices-list" data-testid="devices-list">
-                  <For each={devices()}>
-                    {(d) => {
+                  <For each={deviceRows(devices())}>
+                    {(row) => {
+                      const d = row.device;
                       // UX-4 bucket L (2026-05-19) — replace the raw UA
                       // string with `{icon} {Browser} on {OS}`. Title
                       // attribute preserves the full UA so a hover (desktop)
@@ -1875,39 +1915,111 @@ const SettingsDrawer: Component<Props> = (props) => {
                       // "3m ago → 4m ago" would out-freshen its own data.
                       const activity = formatDeviceActivity(d, Date.now());
                       const isCurrent = () => currentDeviceId() === d.id;
+                      const editing = () => renamingId() === d.id;
                       return (
                         <li>
-                          <span class="device-ua" title={d.user_agent ?? "(unknown browser)"}>
-                            <span class="device-ua-icon" aria-hidden="true">
-                              {deviceClassIcon(parsed.deviceClass)}
-                            </span>
-                            <span class="device-ua-text">
-                              <span class="device-ua-title">
-                                <span class="device-ua-name">
-                                  {parsed.browser} on {parsed.os}
-                                </span>
-                                <Show when={isCurrent()}>
-                                  <span class="device-current" data-testid="device-current">
-                                    ● this device
+                          <Show
+                            when={editing()}
+                            fallback={
+                              <>
+                                <span class="device-ua" title={d.user_agent ?? "(unknown browser)"}>
+                                  <span class="device-ua-icon" aria-hidden="true">
+                                    {deviceClassIcon(parsed.deviceClass)}
                                   </span>
-                                </Show>
-                              </span>
-                              <Show when={activity !== null}>
-                                <span class="device-activity" data-testid="device-activity">
-                                  {activity}
+                                  <span class="device-ua-text">
+                                    <span class="device-ua-title">
+                                      <span class="device-ua-name" data-testid="device-name">
+                                        {row.displayName}
+                                      </span>
+                                      <Show when={isCurrent()}>
+                                        <span class="device-current" data-testid="device-current">
+                                          ● this device
+                                        </span>
+                                      </Show>
+                                    </span>
+                                    {/* #964 — the parsed name survives as the
+                                        secondary line ONLY once a label has
+                                        taken its place above; printing it
+                                        twice on an unnamed row says nothing. */}
+                                    <Show when={row.named}>
+                                      <span class="device-activity" data-testid="device-parsed">
+                                        {parsed.browser} on {parsed.os}
+                                      </span>
+                                    </Show>
+                                    <Show when={activity !== null}>
+                                      <span class="device-activity" data-testid="device-activity">
+                                        {activity}
+                                      </span>
+                                    </Show>
+                                  </span>
+                                </span>
+                                <button
+                                  type="button"
+                                  class="device-remove"
+                                  data-testid="device-rename"
+                                  onClick={() => startRename(d)}
+                                >
+                                  rename
+                                </button>
+                                <button
+                                  type="button"
+                                  class="device-remove"
+                                  onClick={() => {
+                                    void removeDevice(d.id);
+                                  }}
+                                >
+                                  remove
+                                </button>
+                              </>
+                            }
+                          >
+                            <span class="device-rename-form">
+                              <input
+                                type="text"
+                                class="device-rename-input"
+                                data-testid="device-name-input"
+                                aria-label="device name"
+                                // Empty draft = no label yet; the placeholder shows
+                                // what the row falls back to, so clearing the field
+                                // is a visible choice rather than a blank row.
+                                placeholder={row.displayName}
+                                value={renameDraft()}
+                                onInput={(e) => setRenameDraft(e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter") {
+                                    e.preventDefault();
+                                    void commitRename(d.id);
+                                  } else if (e.key === "Escape") {
+                                    e.preventDefault();
+                                    cancelRename();
+                                  }
+                                }}
+                              />
+                              <Show when={renameError() !== null}>
+                                <span class="prefs-error" data-testid="device-rename-error">
+                                  {renameError()}
                                 </span>
                               </Show>
                             </span>
-                          </span>
-                          <button
-                            type="button"
-                            class="device-remove"
-                            onClick={() => {
-                              void removeDevice(d.id);
-                            }}
-                          >
-                            remove
-                          </button>
+                            <button
+                              type="button"
+                              class="device-remove"
+                              data-testid="device-rename-save"
+                              onClick={() => {
+                                void commitRename(d.id);
+                              }}
+                            >
+                              save
+                            </button>
+                            <button
+                              type="button"
+                              class="device-remove"
+                              data-testid="device-rename-cancel"
+                              onClick={cancelRename}
+                            >
+                              cancel
+                            </button>
+                          </Show>
                         </li>
                       );
                     }}

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -1907,12 +1907,17 @@ const SettingsDrawer: Component<Props> = (props) => {
                       // can still surface the original for debugging /
                       // device disambiguation across same-browser instances.
                       const parsed = parseUserAgent(d.user_agent);
-                      // #964 — hover is the ONLY disambiguator today and it does
-                      // not exist on touch, which is where the drawer lives. The
-                      // activity instant + the this-device marker are the two
-                      // always-visible ones. Stamped at render, not on a ticking
-                      // clock: the list is refetched on drawer mount, so a live
-                      // "3m ago → 4m ago" would out-freshen its own data.
+                      // #964 — the always-visible disambiguators, in the order
+                      // they take precedence: the user's own label, the derived
+                      // ordinal on unnamed twins (both from `deviceRows`), the
+                      // activity instant, and the this-device marker. Hover on
+                      // the full UA is a fifth, and the only one that does not
+                      // exist on touch — which is where the drawer lives, and
+                      // why it was never enough on its own.
+                      //
+                      // The activity instant is stamped at render, not on a
+                      // ticking clock: the list is refetched on drawer mount, so
+                      // a live "3m ago → 4m ago" would out-freshen its own data.
                       const activity = formatDeviceActivity(d, Date.now());
                       const isCurrent = () => currentDeviceId() === d.id;
                       const editing = () => renamingId() === d.id;

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   deletePushSubscription,
+  deviceRows,
   disablePush,
   enablePush,
   ensurePushSubscription,
@@ -543,6 +544,7 @@ describe("formatDeviceActivity — #964: the row's activity line", () => {
   const device = (over: Partial<PushDeviceSummary>): PushDeviceSummary => ({
     id: "sub-1" as SubscriptionId,
     user_agent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/128.0",
+    label: null,
     created_at: "2026-08-07T11:00:00Z",
     last_used_at: null,
     ...over,
@@ -595,5 +597,149 @@ describe("subscriptionIdForEndpoint — #964: which row is THIS device", () => {
 
   it("returns null when nothing was ever stashed", () => {
     expect(subscriptionIdForEndpoint("https://push.example/ep")).toBeNull();
+  });
+});
+
+// ── #964 — the row's NAME: user label first, derived ordinal otherwise ──
+// The label is the only stored piece; the ordinal is derived on every
+// render precisely so deleting a twin cannot strand a lone "#2".
+
+describe("deviceRows — #964: the name the device row prints", () => {
+  const FIREFOX_LINUX = "Mozilla/5.0 (X11; Linux x86_64) Firefox/128.0";
+  const CHROME_MAC =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
+
+  const dev = (
+    over: Omit<Partial<PushDeviceSummary>, "id"> & { id: string },
+  ): PushDeviceSummary => ({
+    user_agent: FIREFOX_LINUX,
+    label: null,
+    created_at: "2026-08-07T11:00:00Z",
+    last_used_at: null,
+    ...over,
+    id: over.id as SubscriptionId,
+  });
+
+  const nameOf = (rows: ReturnType<typeof deviceRows>, id: string): string | undefined =>
+    rows.find((r) => r.device.id === (id as SubscriptionId))?.displayName;
+
+  it("prints the parsed name, with NO ordinal, for a device alone in its group", () => {
+    const rows = deviceRows([dev({ id: "a" })]);
+    expect(rows.map((r) => r.displayName)).toEqual(["Firefox on Linux"]);
+    expect(rows[0]?.named).toBe(false);
+  });
+
+  it("prints no ordinal when the two devices parse differently", () => {
+    const rows = deviceRows([dev({ id: "a" }), dev({ id: "b", user_agent: CHROME_MAC })]);
+    expect(rows.map((r) => r.displayName)).toEqual(["Firefox on Linux", "Chrome on macOS"]);
+  });
+
+  it("numbers twins oldest-first, regardless of the order the server sent them", () => {
+    // Server order is newest-first, so the NEWER row arrives at index 0 —
+    // if the ordinal followed list position instead of created_at, the
+    // older device would be #2 and the numbers would flip whenever the
+    // list is re-sorted.
+    const rows = deviceRows([
+      dev({ id: "new", created_at: "2026-08-07T11:00:00Z" }),
+      dev({ id: "old", created_at: "2026-08-01T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "old")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "new")).toBe("Firefox on Linux #2");
+  });
+
+  it("keeps existing ordinals stable when a newer twin appears", () => {
+    const older = dev({ id: "old", created_at: "2026-08-01T09:00:00Z" });
+    const newer = dev({ id: "new", created_at: "2026-08-07T11:00:00Z" });
+    const third = dev({ id: "third", created_at: "2026-08-09T09:00:00Z" });
+
+    const before = deviceRows([newer, older]);
+    const after = deviceRows([third, newer, older]);
+
+    expect(nameOf(before, "old")).toBe(nameOf(after, "old"));
+    expect(nameOf(before, "new")).toBe(nameOf(after, "new"));
+    expect(nameOf(after, "third")).toBe("Firefox on Linux #3");
+  });
+
+  it("re-derives after a deletion instead of stranding a lone #2", () => {
+    // THE reason the ordinal is not a column: delete #1 and a stored #2
+    // has nobody to be second to. Derived, the survivor is alone in its
+    // group and drops the suffix entirely.
+    const older = dev({ id: "old", created_at: "2026-08-01T09:00:00Z" });
+    const newer = dev({ id: "new", created_at: "2026-08-07T11:00:00Z" });
+
+    expect(nameOf(deviceRows([newer, older]), "new")).toBe("Firefox on Linux #2");
+    expect(nameOf(deviceRows([newer]), "new")).toBe("Firefox on Linux");
+  });
+
+  it("numbers each colliding group independently", () => {
+    const rows = deviceRows([
+      dev({ id: "f1", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "f2", created_at: "2026-08-02T09:00:00Z" }),
+      dev({ id: "c1", user_agent: CHROME_MAC, created_at: "2026-08-03T09:00:00Z" }),
+      dev({ id: "c2", user_agent: CHROME_MAC, created_at: "2026-08-04T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "f1")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "f2")).toBe("Firefox on Linux #2");
+    expect(nameOf(rows, "c1")).toBe("Chrome on macOS #1");
+    expect(nameOf(rows, "c2")).toBe("Chrome on macOS #2");
+  });
+
+  it("the user's label wins over the derived name", () => {
+    const rows = deviceRows([
+      dev({ id: "a", label: "MacBook del lavoro", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "b", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("MacBook del lavoro");
+    expect(rows.find((r) => r.device.id === ("a" as SubscriptionId))?.named).toBe(true);
+  });
+
+  it("naming one twin leaves the other WITHOUT an orphan ordinal", () => {
+    // The pair is no longer ambiguous on screen, so the survivor must not
+    // keep a "#2" that has nothing to contrast with.
+    const rows = deviceRows([
+      dev({ id: "named", label: "fisso", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "bare", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "bare")).toBe("Firefox on Linux");
+  });
+
+  it("still numbers the two that remain unlabelled among three twins", () => {
+    const rows = deviceRows([
+      dev({ id: "named", label: "fisso", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "x", created_at: "2026-08-02T09:00:00Z" }),
+      dev({ id: "y", created_at: "2026-08-03T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "x")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "y")).toBe("Firefox on Linux #2");
+  });
+
+  it("preserves the server's row order (newest first)", () => {
+    const rows = deviceRows([
+      dev({ id: "new", created_at: "2026-08-07T11:00:00Z" }),
+      dev({ id: "old", created_at: "2026-08-01T09:00:00Z" }),
+    ]);
+    expect(rows.map((r) => r.device.id)).toEqual(["new", "old"]);
+  });
+
+  it("falls back to the id for a total order when created_at does not parse", () => {
+    const rows = deviceRows([
+      dev({ id: "b", created_at: "not-a-date" }),
+      dev({ id: "a", created_at: "not-a-date" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "b")).toBe("Firefox on Linux #2");
+  });
+
+  it("groups two unparseable user agents together rather than splitting them", () => {
+    const rows = deviceRows([
+      dev({ id: "a", user_agent: null, created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "b", user_agent: "", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("Unknown browser on Unknown OS #1");
+    expect(nameOf(rows, "b")).toBe("Unknown browser on Unknown OS #2");
+  });
+
+  it("returns an empty list for an empty device list", () => {
+    expect(deviceRows([])).toEqual([]);
   });
 });

--- a/cicchetto/src/lib/push.ts
+++ b/cicchetto/src/lib/push.ts
@@ -35,6 +35,7 @@
 import { ApiError, readError } from "./api";
 import { formatDurationSince } from "./duration";
 import { isIos, isStandalonePwa } from "./platform";
+import { parseUserAgent } from "./userAgent";
 
 const SUBSCRIBED_VAPID_KEY_STORAGE_KEY = "cic.vapidPublicKey";
 
@@ -168,9 +169,97 @@ export async function deletePushSubscription(token: string, id: SubscriptionId):
 export type PushDeviceSummary = {
   id: SubscriptionId;
   user_agent: string | null;
+  /** #964 — user-set device name. `null` until renamed; see `deviceRows`. */
+  label: string | null;
   created_at: string;
   last_used_at: string | null;
 };
+
+/** A device paired with the name the row should actually print. */
+export type DeviceRow = {
+  device: PushDeviceSummary;
+  /** The user's label when set, else the derived `Browser on OS [#n]`. */
+  displayName: string;
+  /** True when `displayName` is the user's own label rather than the default. */
+  named: boolean;
+};
+
+const parsedDeviceName = (device: PushDeviceSummary): string => {
+  const parsed = parseUserAgent(device.user_agent);
+  return `${parsed.browser} on ${parsed.os}`;
+};
+
+// Oldest first, id as the tiebreak so the ordering is TOTAL — two rows
+// created in the same microsecond (or with an unparseable instant) must
+// still get a stable order, or the ordinals would shuffle between renders.
+const byCreation = (a: PushDeviceSummary, b: PushDeviceSummary): number => {
+  const ta = Date.parse(a.created_at);
+  const tb = Date.parse(b.created_at);
+  const ka = Number.isNaN(ta) ? Number.POSITIVE_INFINITY : ta;
+  const kb = Number.isNaN(tb) ? Number.POSITIVE_INFINITY : tb;
+  if (ka !== kb) return ka < kb ? -1 : 1;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+};
+
+/**
+ * #964 — pairs each device with the name its row prints, preserving the
+ * server's ordering (newest first).
+ *
+ * The user's `label` wins outright. Without one the row falls back to the
+ * parsed `Browser on OS`, which is exactly the string that collides — so
+ * when two or more UNLABELLED devices parse to the same name, each gets an
+ * ordinal (`Firefox on Linux #1`, `#2`) assigned oldest-first. A device
+ * alone in its group takes no suffix: a solitary `#1` is noise.
+ *
+ * Labelled rows are excluded from the grouping, not just from the suffix.
+ * Naming one of two twins already disambiguates the pair, and leaving the
+ * other as a lone `#2` would be the stale-ordinal bug reintroduced by hand.
+ *
+ * ## Why the ordinal is DERIVED here and not a column
+ *
+ * Two independent reasons, and either alone settles it:
+ *
+ *   1. An ordinal is a function of how many rows currently share a parsed
+ *      name. Stored, it goes stale the instant one of them is deleted —
+ *      a `#2` with no `#1` that nothing realigns. Derived, the list
+ *      self-heals on the next render. The LABEL is the stored thing here;
+ *      the ordinal is only the fallback.
+ *   2. The grouping key is the OUTPUT of `parseUserAgent`, which exists
+ *      only in this codebase. Deriving server-side would mean a second UA
+ *      parser in Elixir whose classification could disagree with this one,
+ *      and then the ordinal would number a grouping the user cannot see.
+ */
+export function deviceRows(devices: PushDeviceSummary[]): DeviceRow[] {
+  const unlabelled = devices.filter((d) => (d.label ?? null) === null);
+
+  return devices.map((device) => {
+    const label = device.label ?? null;
+    if (label !== null) return { device, displayName: label, named: true };
+
+    const name = parsedDeviceName(device);
+    const twins = unlabelled.filter((d) => parsedDeviceName(d) === name).sort(byCreation);
+    const displayName =
+      twins.length < 2 ? name : `${name} #${twins.findIndex((d) => d.id === device.id) + 1}`;
+    return { device, displayName, named: false };
+  });
+}
+
+/**
+ * PATCH /push/subscriptions/:id — the #964 inline rename. An empty string
+ * clears the label server-side, so the row falls back to its derived name.
+ */
+export async function renamePushDevice(
+  token: string,
+  id: SubscriptionId,
+  label: string,
+): Promise<void> {
+  const res = await fetch(`/push/subscriptions/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ label }),
+  });
+  if (!res.ok) throw await readError(res);
+}
 
 /**
  * #964 — the device row's activity line.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7171,6 +7171,28 @@ html.resize-dragging * {
   white-space: nowrap;
 }
 
+/* #964 — the row's edit mode. Takes the same flex slot the name occupied
+   so the save/cancel buttons land exactly where remove was, and the list
+   does not reflow when a row is opened for renaming. */
+.settings-drawer .device-rename-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.settings-drawer .device-rename-input {
+  width: 100%;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 0.15rem 0.3rem;
+}
+
 /* #462 — padding + font-size deleted, not rewritten: without them the rule
    stops out-specifying `:where(.settings-drawer) button` and the base's 44px
    floor, 0.4/0.7 padding and --font-size apply. 0.15rem × 0.75rem made this

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54394,3 +54394,169 @@ this class and is not attributed here.
 The stall itself is filed separately — the WebSocket upgrade should not be on
 the critical path of a droppable telemetry write, and that is a production
 property, not an e2e one.
+<!-- entry #964 -->
+
+---
+
+## 2026-08-20 — #964: naming a push device, and the ordinal for the ones you have not named
+
+Hypnotize reported two rows in the settings drawer both reading `Firefox on
+Linux`, with nothing to tell them apart. `parseUserAgent` collapses a UA to
+`Browser on OS` on purpose, so two instances of the same browser on the same OS
+render byte-identical. The issue proposed three fixes; two of them —
+`formatDeviceActivity` and the `● this device` marker — landed earlier and are
+already in the tree. This entry records the third: a user-set **label**, and the
+**ordinal** that disambiguates the devices nobody has named yet.
+
+The branch that implements it was cut on 2026-08-07, dropped, and revived
+thirteen days later. Rebasing it rather than rewriting it is what surfaced the
+two failures recorded at the end, and both are worth more than the feature.
+
+### The label is the only disambiguator that earns a column
+
+Everything else the row could show is DERIVED from data the server already
+holds: the creation instant, the last-used instant, an ordinal, the PTR of the
+peer address. The label is the only genuinely new information — it is the one
+thing about a device that only its owner knows.
+
+The original ask was "default it to the host". That is not implementable: no web
+API exposes the client machine's hostname, deliberately, and the one historical
+leak (the `.local` name in ICE candidates) was closed in 2019 by mDNS candidate
+obfuscation. Deriving it server-side does not rescue it either — the only
+server-visible name-like thing is the PTR of the peer address, which on a
+residential or NAT'd line is the ISP pool name, identical for every device
+behind it. That reproduces exactly the collision the issue is about.
+
+### The ordinal is DERIVED at render, and is NOT a column
+
+Two independent reasons, either of which settles it:
+
+1. An ordinal is a function of how many rows CURRENTLY share a parsed name.
+   Stored, it goes stale the instant one of them is deleted — a `#2` with no
+   `#1` and nothing to realign it. Derived, the list self-heals on the next
+   render.
+2. The grouping key is the OUTPUT of `parseUserAgent`, which exists only in
+   cicchetto. Deriving server-side would mean a second UA parser in Elixir whose
+   classification could disagree with the client's, and then the ordinal would
+   number a grouping the user cannot see.
+
+`deviceRows/1` (`cicchetto/src/lib/push.ts`) pairs each device with the name its
+row prints. It preserves the server's ordering (newest first) but assigns
+ordinals **oldest-first**, with the id as a tiebreak so the ordering is TOTAL —
+two rows created in the same microsecond, or with an unparseable `created_at`,
+must still get a stable order or the numbers shuffle between renders.
+
+**Labelled rows leave the grouping entirely, not just the suffix.** Naming one of
+two twins already disambiguates the pair, so the survivor must drop its number;
+leaving it as a lone `#2` would be the stale-ordinal bug reintroduced by hand.
+A device alone in its group takes no suffix at all: a solitary `#1` is noise.
+
+### `label`: one storage representation for "cleared"
+
+`label` is nullable with no default and is the ONE user-writable field on a
+subscription. It travels on its own `Subscription.label_changeset/2`, kept off
+the create allowlist for two reasons: it is never knowable at registration time,
+and a separate changeset means a POST body cannot widen the create surface by
+accident.
+
+Blank folds to NULL so "cleared" has exactly ONE representation and the read
+side tests `is_nil/1` and never also `== ""`. That fold is `cast/3`'s own
+default `:empty_values`, which already maps `""` AND a whitespace-only string to
+`nil` — a hand-written blank arm was proven dead by removing it and watching the
+blank/whitespace tests stay green. The trim of a non-blank value is NOT
+something Ecto does, so it lives in the changeset; the 64-**grapheme** cap is
+applied AFTER the trim, so a value that exceeds the cap only by invisible
+padding is accepted rather than rejected on characters the user cannot see.
+
+`PATCH /push/subscriptions/:id` takes `{"label": <string|null>}`. The status
+ladder splits types from values: **400** when `label` is absent or not a
+string/null (a type error is the client's bug, not a value the 422 envelope
+should have to describe), **404** with the uniform body for cross-subject OR
+unknown IDs (the same probing protection `delete/2` has), **422** past the cap.
+`Push.update_label/2` takes the STRUCT, so the caller must already have loaded
+and scoped the row through `get_for_subject/2` — a path parameter cannot reach
+an UPDATE without passing the subject check.
+
+The PATCH renders the SAME `subscription_summary()` an `:index` row carries,
+rather than a bespoke `{id, label}` echo: the rename response IS a row, so the
+client splices it back into the list without a refetch, and there is one place
+to change when a device grows another field. `label` is a new field on an
+existing shape, so per the additive-only wire contract (#447) it costs no
+`protocol_version` bump.
+
+### 🔴 The hand-typed migration stamp was a LIVE collision, not a formality
+
+The branch carried `20260807120000_add_label_to_push_subscriptions.exs`. In the
+thirteen days it sat unproposed, `20260807120000_fold_nickserv_pass_onto_password.exs`
+landed on main — the **same integer version**, a different basename, which git
+fuses without a conflict marker and with nothing to review.
+
+This is the silent regime, and it is the one production hits. Ecto's pending
+filter keys on the integer VERSION, never the filename, and
+`ensure_no_duplication!` only ever sees the PENDING set. On a database that has
+ALREADY applied `20260807120000` — every deployed one — both files drop out of
+pending, `ensure_no_duplication!([])` answers `:ok`, the run reports SUCCESS,
+and NEITHER migration ever executes again. Not a crash, not a warning: a green
+deploy with a column that is not there.
+
+Regenerated with `mix ecto.gen.migration` → `20260820174126`, and checked
+against `origin/main`'s CURRENT latest (`20260816014915`) rather than against
+the August main the branch forked from. That second half is the part a rebase
+makes load-bearing: the correct number is past whatever landed while you were
+out.
+
+The rule was already in CLAUDE.md. What this adds is the demonstration: a
+thirteen-day-old branch was enough for a round stamp to become a real,
+already-applied duplicate.
+
+### 🔴 A clean rebase can reinstall a defect whose premise has evaporated
+
+The same rebase surfaced `validate_subject_xor/1` inside a conflict block in
+`Grappa.Push.Subscription`. #1580 had just collapsed twelve copies of that
+function onto `Grappa.Subject.validate_xor/1`; the #964 commit adds
+`label_changeset/2` immediately above it, so the deleted body came back as
+"context" the resolver is invited to keep.
+
+Nothing about the conflict says the function was deliberately removed. The
+resolution that looks tidy — keep both sides — silently reinstates one of the
+twelve copies #1580 exists to delete, and it would compile, pass and read fine.
+The general rule: on a long-lived branch, a conflict hunk containing code you did
+not write is a question about whether its PREMISE still holds, not a merge
+puzzle. Here it was dropped, and #1580's own `subject_xor_test.exs` runs green
+beside the new label tests.
+
+### Deploy class: HOT, measured, against a moduledoc that claimed COLD
+
+The migration's original moduledoc asserted COLD "because `Preflight` classifies
+every `priv/repo/migrations/*` path as `:migration`". GH #41 ended that:
+`GrappaWeb.AdminController.reload/2` now runs `Ecto.Migrator` in-process BEFORE
+the module reload, so only a CONTRACT migration forces a restart, and
+`classify_migration/1` decides from the `change/0` AST.
+
+Measured on this file rather than asserted: `alter table(:push_subscriptions) do
+add :label, :string end` is an expand — atom column, literal type, nullable, no
+`@disable_ddl_transaction` — so `classify_migration/1` answers `:hot`, and the
+whole changed path set classifies `{:hot, []}` on `:jail`, `:docker` and
+`:linux` alike.
+
+This means the "any migration ⇒ COLD" grep over-triggers exactly the way the
+`^infra/` arm does: it is a path heuristic, and the shipped classifier is the
+thing that actually gates the deploy. It says nothing about the RELEASE that
+ships the feature — a `VERSION` bump is its own cold trigger (`:version`,
+#1287) on the two `mix release` substrates, and is not part of this change.
+
+### Limitations, stated rather than forced
+
+* The ordinal groups on `parseUserAgent`'s output, so two devices the parser
+  cannot classify collapse into one `Unknown browser on Unknown OS` group and
+  are numbered within it. That is the honest answer — they genuinely are
+  indistinguishable to us — but it means an unparseable UA cannot be told apart
+  except by renaming it.
+* `label` is per-subscription, not per-device. A browser that drops and
+  re-registers its push subscription (the #181 supersede path) arrives as a new
+  row with no label. Carrying the label across a supersede would mean trusting
+  the endpoint swap to identify the same physical device, which is exactly the
+  identity claim `subscriptionIdForEndpoint` refuses to make elsewhere.
+* The rename, save and cancel buttons reuse the `.device-remove` class so they
+  inherit the 44 px tap floor #462 restored. Behaviourally right, but the class
+  name is now a misnomer for three buttons that remove nothing.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54560,3 +54560,114 @@ ships the feature — a `VERSION` bump is its own cold trigger (`:version`,
 * The rename, save and cancel buttons reuse the `.device-remove` class so they
   inherit the 44 px tap floor #462 restored. Behaviourally right, but the class
   name is now a misnomer for three buttons that remove nothing.
+<!-- entry #1441 -->
+
+---
+
+## 2026-08-20 — #1441: the media-viewer opener was thirteen sites, not ten copies, and never byte-identical
+
+The issue asked for one fixture-level opener for "ten specs", and was explicit
+that neither the byte-identity of the copies nor the completeness of the ten
+had been measured. Both were measured first, and both moved.
+
+### The census
+
+`cicchetto/e2e/fixtures/mediaViewer.ts` now owns the door. Before it, on
+`5ec44475`:
+
+| measured | value |
+|---|---|
+| spec FILES that open the viewer | **10** |
+| opening CALL SITES | **13** |
+| distinct glue bodies, raw bytes | **5** |
+| distinct glue bodies, indentation + comments normalised away | **3** |
+| `link.click()` (Playwright, scrolls into view) | 9 |
+| `link.evaluate((el) => el.click())` (in place) | 4 |
+| dialog-constructing files with no opening click | **0** |
+
+So the issue's ten is right at FILE granularity and low at call-site
+granularity — `media-link-modal-viewer.spec.ts` opened it three times and
+`media-link-cross-host-modal.spec.ts` twice. "Byte-identical" was never true:
+indentation alone splits the thirteen into five bodies, because two of them sit
+inside a `test.describe`.
+
+**The extractor lied first, and the scalar control did not catch it.** Version
+one pinned `media-link-modal-viewer.spec.ts == 3 open sites` and PASSED while
+finding the wrong three (75/175/176 instead of 75/174/194): a `toBeVisible`
+quoted inside a prose comment counted as a barrier, and a site whose dialog
+binding sat outside the lookback window was missed. Two errors of opposite sign
+summed to the expected total. The controls are pinned to LINE NUMBERS since —
+a count cannot see a compensating pair, and a hand-written parser gets exactly
+one chance to be calibrated against something a human read off the file. The
+negative control is `issue219-general-overlay-scroll-hold.spec.ts`, which says
+"media-viewer" three times in prose and opens the `/names` modal.
+
+### Two verbs, not one verb with a flag
+
+Nine sites clicked through Playwright, four dispatched the anchor's own click.
+That is not drift: #196-preserve, #219, #213 and #1438 MEASURE the scrollback's
+scroll position across the open, and Playwright's scroll-into-view would move
+the very thing under test. So the fixture exports `openMediaViewer` and
+`openMediaViewerInPlace` rather than one opener with `scroll: boolean`. A
+boolean at thirteen call sites is a coin flip a reviewer cannot check; the
+second name says in the call site what it is protecting.
+
+`closeMediaViewer` rides in for the same reason at the other edge (nine
+copies of the close click plus its `toBeHidden` barrier), and `mediaViewer`
+exports the locator so the one NEGATIVE use — the audio path must not open the
+modal — reads the same accessible name the positive ones do. The strings
+`"Media viewer"` and `"Close media viewer"` now appear once each in the tree.
+
+### Wait conditions: strictest, and then frozen
+
+All thirteen waited `toBeVisible({ timeout: 5_000 })`, so strictest and uniform
+coincide; 5_000 is kept, never raised. It is a module constant and NOT a
+per-call-site parameter — deliberately the opposite of `uploadJourney.ts`,
+where the image and video budgets genuinely differ 6×. Here every caller asks
+the same question, and a parameter would re-open the drift axis the lift exists
+to close.
+
+#213's extra wait on `.media-viewer-media--zoomable` stays in #213: it is
+image-and-zoom specific (the cross-host VIDEO case has no zoomable element at
+all) and it is the locator that spec goes on to drive. Strictest COMMON wait,
+not strictest anywhere.
+
+The media-class assertion moved INTO `uploadImageAndGetLink`, where six of the
+eight upload preambles already had it. #213 and #1438 gain it: without the
+class the anchor never opens the viewer, and the failure used to surface as a
+five-second timeout on the dialog instead of naming the classifier.
+
+### The +0, from Playwright's own collector
+
+`playwright test --list` on the base and on the branch: **759 tests in 411
+files** both sides, and the full 759-line title list diffs empty (line numbers
+stripped — those legitimately move). No spec disappeared, no title changed.
+
+Source `expect(` tokens fall 4189 → 4164, and that drop is what deduplication
+IS, so the arithmetic is reconciled exactly rather than waved at: 13
+`toBeVisible` + 9 `toBeHidden` + 6 `toHaveClass` removed from the specs = 28;
+3 added in the fixture. Executed assertions per path are unchanged at eleven of
+the thirteen sites and +1 at the two that gained the class check, so no path
+lost coverage.
+
+### Not established
+
+- **No e2e spec was RUN.** The stack lane was not requested for this change.
+  The gates are `bun run check` (all four stages green, including
+  `tsc -p e2e/tsconfig.json`) and `bun run test` (295 files, 5695 tests), plus
+  the `--list` equality above. That is a static argument and a collection
+  argument; it is not a green suite, and it does not rule out a runtime
+  difference the type system cannot see.
+- **No unit test covers the opener.** `whoisWait.ts` and `privmsgWait.ts` are
+  unit-testable because they carry a DECISION; these four functions are driver
+  calls around an imported `expect`, and the only way to fake that barrier is
+  to inject it — a seam invented for the test, over a verb the `tsc` and e2e
+  gates already cover.
+- **The population is "everything that names the dialog".** Two independent
+  shapes agree on the same ten files, and every file that constructs the dialog
+  has an opening click. A spec that opened the viewer and never asserted on it
+  would be invisible to both — and would also not be an opener worth sharing.
+- **`cicchetto/e2e` IS gated by `bun run check`**, correcting a briefing that
+  said otherwise: `cicchetto/scripts/check.ts` runs four stages and the fourth
+  is `tsc --noEmit -p e2e/tsconfig.json`, with `biome.json` including `e2e/**`
+  (#484, #1469).

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54280,3 +54280,117 @@ correct by construction, because the two spellings name two different rooms.
   channel move needs no sweep at all. Rewriting 289 sentences that way was
   judged a larger change than the issue asked for, and is left as the obvious
   follow-up if the channel shape ever moves again.
+<!-- entry #1579 -->
+
+---
+
+## 2026-08-20 — #1579: the 5 s user-topic barrier was telling the truth
+
+`waitForUserTopicReady` is the last statement of the canonical `loginAs` that
+333 spec files go through, and a full run had gone red in it three times in
+three different specs. #1579 put three readings on the table and said, in as
+many words, that none of them had been discriminated: (1) the 5 s budget is
+simply too tight under a loaded 29-minute run, (2) the barrier is right and the
+subscribe genuinely never happens, so the reds are product signal, (3)
+run-scoped resource pressure that slows the WS join specifically.
+
+**Reading 2.** The barrier is honest, and the defect is not in the barrier.
+
+### What was measured
+
+One full `scripts/integration.sh` (759 tests, 32.8 min, darwin / Docker
+Desktop, `MIX_ENV=dev`), instrumented so every `waitForUserTopicReady` call
+recorded its satisfaction latency, and so a call that blew the budget kept
+WATCHING for a further 25 s without changing the budget it enforced — the
+enforced 5 s is what fails the test, the extra window only decides whether the
+failure can say "the stamp arrived at 11.2 s" or "it never arrived". 600 calls:
+597 satisfied, 3 missed.
+
+The satisfied population settles reading 1 on its own: median 18 ms, p95
+243 ms, p99 395 ms, max 848 ms. The budget is not tight, it is roughly six
+times the worst healthy case, and the profile is flat across the run (per-tenth
+medians 15–36 ms), which also refuses the monotonic-degradation shape of
+reading 3.
+
+The three misses share one signature, and it is not the one the barrier's own
+moduledoc describes. At the deadline the page reported
+`__cic_socketHealth` = `state: "connecting"`, `connectAttempts: 1`,
+`errorCount: 0` — the WebSocket transport had never opened, so no JOIN had
+been pushed at all, and phoenix.js's own 10 s join timeout had fired for all
+three topics. The stamp then arrived at 11 180 ms in one case and never inside
+30 s in the other two.
+
+### The same event from the server side
+
+The server named itself. On the 11 s case, the transport pid logs
+`ws connect authenticated` at 16:31:44.496, then a single
+`QUERY OK db=11136.6ms` with no source (the `BEGIN IMMEDIATE`), then three
+sub-millisecond `user_settings` statements, a commit, and
+`CONNECTED TO GrappaWeb.UserSocket in 11140ms`. The user-topic
+`JOINED grappa:user:...` that follows took **23 µs**. The client's 11 180 ms and
+the server's 11 140 ms are the same wait, measured from both ends, and none of
+it is the JOIN.
+
+The 31 s case spells out the mechanism in full:
+
+```
+16:28:45.423 ws connect authenticated
+16:29:16.996 QUERY ERROR db=31571.8ms
+16:29:16.999 db write unavailable: SQLite write lock held by another writer
+             for 31572ms across 1 attempts (1500ms retry budget)
+16:29:16.999 record_client_source: db unavailable persisting client prefix
+             for {:user, "270bdc2c-…"} — dropped (best-effort)
+16:29:16.999 CONNECTED TO GrappaWeb.UserSocket in 31575ms
+```
+
+`UserSocket.connect/3` calls `maybe_record_client_source/2` → `Vhosts`
+→ `UserSettings.put_last_client_prefix64/2` → `Repo.immediate_transaction/1`
+**before it returns**, and Phoenix holds the upgrade until it does. The write
+is explicitly best-effort — #523 made it drop on saturation precisely so it
+could never fail a connect — but dropping it costs the full `busy_timeout`
+first, so a sample nobody is allowed to depend on can delay every new
+WebSocket by up to 30 s. Across the run: 682 connects, 680 of them at 56 ms or
+below, two at 11 140 ms and 31 575 ms, and those two are the stalls.
+
+`Grappa.Repo.LockWatch` (#1420) caught three episodes — 11 144 ms, 32 950 ms,
+31 937 ms, each with a waiter queued — and named a `UserSettings.write_data!/2`
+transaction as the holder in two of the three. Twelve queries in the whole run
+exceeded 10 s and all twelve fall inside these episodes, during which the BEAM
+emitted nothing at all despite averaging ~560 log lines a second.
+
+### Why raising the number would be the wrong repair
+
+It cannot reach the numbers: 11.2 s, 31.6 s, and one page that sat through two
+consecutive ~32 s stalls for ~65 s. And it would not remove the reds, only
+relocate them — in the same run the 32.9 s stall took out `loginAs`'s OTHER
+gate, the 10 s `.sidebar-network-header` shell-ready wait in
+`issue591-ctcp-ping`, which is the same stall arriving at a different
+assertion. The barrier is not the thing that is wrong; it is the thing that
+noticed.
+
+So the barrier keeps its 5 s and gains a voice: on timeout it now reports the
+stamped names, the socket-health state, the joined topic keys,
+onLine/visibility, and the tail of the page console — captured through
+Playwright's listener, never by patching the page's `console`. That is the
+measurement #1579 asked for, made permanent. It recovers nothing.
+
+### What this does NOT establish
+
+Why a writer holds the SQLite write lock for 31–33 s. The holder's OWN
+statement is what takes that long (`QUERY OK source="user_settings"
+db=32952.5ms`), so it is not a process sitting idle inside a transaction, and
+one of the three LockWatch stack samples shows the holder blocked inside
+`logger_h_common:log/2` — the Logger's sync-mode back-pressure — rather than
+inside SQLite. Log back-pressure and genuine storage contention are both live,
+and this run cannot separate them: it ran on darwin under Docker Desktop with
+`MIX_ENV=dev` debug query logging (1 114 576 lines), and the same suite on the
+Linux CI runner has not been measured. The measurement that would separate them
+is the same run with the log volume cut, on both substrates.
+
+Also not established: the fifth red of the run
+(`slash-commands-bundle` `/q`, 6.0 s, a window that did not close) is not in
+this class and is not attributed here.
+
+The stall itself is filed separately — the WebSocket upgrade should not be on
+the critical path of a droppable telemetry write, and that is a production
+property, not an e2e one.

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -39,6 +39,7 @@ defmodule Grappa.Push do
       subject (sorted by `inserted_at`, most-recent first).
     * `get_for_subject/2` — fetch one by ID, scoped to subject (404
       if cross-subject).
+    * `update_label/2` — rename a device (#964); `nil`/blank clears.
     * `delete/1` — by struct.
     * `delete_dead/1` — by endpoint URL. Used by B2's `Push.Sender`
       when a vendor returns 404/410 for a stale subscription.
@@ -260,6 +261,26 @@ defmodule Grappa.Push do
   """
   @spec delete(Subscription.t()) :: {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
   def delete(%Subscription{} = sub), do: Repo.delete(sub)
+
+  @doc """
+  Renames a subscription (#964). `nil` or a blank string clears the
+  label, and the client falls back to its derived default name.
+
+  Struct-in, for the same reason as `delete/1`: the caller must already
+  have loaded + scoped the row through `get_for_subject/2`, so a path
+  parameter cannot reach an UPDATE without passing the subject check.
+
+  Every normalisation (trim, blank → NULL, length cap) lives in
+  `Subscription.label_changeset/2` — this is user input and it does not
+  reach `Repo` without a changeset.
+  """
+  @spec update_label(Subscription.t(), String.t() | nil) ::
+          {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
+  def update_label(%Subscription{} = sub, label) when is_binary(label) or is_nil(label) do
+    sub
+    |> Subscription.label_changeset(%{label: label})
+    |> Repo.update()
+  end
 
   @doc """
   Deletes any subscription matching the given endpoint URL,

--- a/lib/grappa/push/subscription.ex
+++ b/lib/grappa/push/subscription.ex
@@ -4,9 +4,17 @@ defmodule Grappa.Push.Subscription do
 
   Push notifications cluster B1 (2026-05-14). Stores the three opaque
   fields the W3C Push API hands out (`endpoint`, `p256dh_key`,
-  `auth_key`) plus per-device metadata (`user_agent`, `last_used_at`)
-  that drives the "see + revoke my devices" UX in the cic settings
-  drawer (B3).
+  `auth_key`) plus per-device metadata (`user_agent`, `last_used_at`,
+  `label`) that drives the "see + revoke my devices" UX in the cic
+  settings drawer (B3).
+
+  ## `label` — the only user-writable field (#964)
+
+  Nullable, set through `label_changeset/2` alone. NULL means "no
+  label" and the client falls back to a derived name. The ordinal that
+  disambiguates two same-browser devices is deliberately NOT a column:
+  it is a function of how many rows currently share a parsed name, so a
+  stored copy strands a lone `#2` the moment `#1` is deleted.
 
   ## `:provider` — `:webpush` | `:unifiedpush` (2026-08-13)
 
@@ -90,6 +98,7 @@ defmodule Grappa.Push.Subscription do
           p256dh_key: String.t() | nil,
           auth_key: String.t() | nil,
           user_agent: String.t() | nil,
+          label: String.t() | nil,
           last_used_at: DateTime.t() | nil,
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
@@ -106,6 +115,7 @@ defmodule Grappa.Push.Subscription do
     field :p256dh_key, :string
     field :auth_key, :string
     field :user_agent, :string
+    field :label, :string
     field :last_used_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)
@@ -124,8 +134,18 @@ defmodule Grappa.Push.Subscription do
   # `provider` IS optional — defaults to `"webpush"` (the schema
   # field default) when a caller omits it, so every pre-2026-08-13
   # caller keeps working unchanged.
+  # `label` is likewise absent from the allowlist: it is the ONE
+  # user-writable field, it is never known at registration time (the
+  # browser has nothing to name itself with — see #964 on why the machine
+  # hostname is not reachable from a page), and it travels on its own
+  # `label_changeset/2` so a POST body cannot widen the create surface.
   @optional ~w(provider user_agent)a
   @subject ~w(user_id visitor_id)a
+
+  # Graphemes, not bytes — the cap bounds what the drawer renders, and the
+  # drawer renders characters. Roomy enough for "MacBook del lavoro",
+  # tight enough that the row keeps its ellipsis instead of wrapping.
+  @label_max 64
 
   @doc """
   Insert / update changeset.
@@ -193,4 +213,47 @@ defmodule Grappa.Push.Subscription do
       message: "user_id and visitor_id are mutually exclusive"
     )
   end
+
+  @doc """
+  Rename changeset — the ONE user-writable field on a subscription (#964).
+
+  Separate from `changeset/2` on purpose: `label` is not knowable at
+  registration, so keeping it off the create allowlist means the POST
+  surface cannot grow a field by accident, and this changeset cannot be
+  talked into touching an endpoint or a key.
+
+  The stored contract, and who enforces each half:
+
+    * **blank → NULL**, so "cleared" has exactly ONE representation and
+      the read side tests `is_nil/1` and never also `== ""`. This is what
+      makes clearing the label fall back to the derived
+      `Browser on OS [#n]` default instead of rendering an empty name.
+      Enforced by `cast/3` itself: its default `:empty_values` already
+      folds `""` AND a whitespace-only string to `nil`. Measured, not
+      assumed — a hand-written blank arm here was proven dead by removing
+      it and watching the blank/whitespace tests stay green. The tests
+      pin the CONTRACT, so it survives whoever implements it.
+    * **trim** of a non-blank value — a label is a display string, and
+      invisible padding would make two labels compare unequal. This half
+      Ecto does NOT do, so it lives here.
+    * **cap at #{@label_max} graphemes**, applied AFTER the trim, so a
+      value that only exceeds the cap by padding is accepted rather than
+      rejected on characters the user cannot see.
+
+  A non-string value fails `cast/3` with `"is invalid"`; the controller
+  rejects that shape earlier with a 400 so the 422 envelope stays about
+  values, not types.
+  """
+  @spec label_changeset(t(), map()) :: Ecto.Changeset.t()
+  def label_changeset(%__MODULE__{} = sub, attrs) do
+    sub
+    |> cast(attrs, [:label])
+    |> update_change(:label, &normalize_label/1)
+    |> validate_length(:label, max: @label_max)
+  end
+
+  @spec normalize_label(String.t() | nil) :: String.t() | nil
+  defp normalize_label(nil), do: nil
+
+  defp normalize_label(label) when is_binary(label), do: String.trim(label)
 end

--- a/lib/grappa_web/controllers/push_subscription_controller.ex
+++ b/lib/grappa_web/controllers/push_subscription_controller.ex
@@ -3,7 +3,7 @@ defmodule GrappaWeb.PushSubscriptionController do
   REST surface for `Grappa.Push` subscriptions — push notifications
   cluster B1 (2026-05-14) + visitor-parity V3 (2026-05-15).
 
-  Three endpoints, all behind `[:api, :authn]`:
+  Four endpoints, all behind `[:api, :authn]`:
 
     * `POST /push/subscriptions` — body
       `{"endpoint": <url>, "keys": {"p256dh": <b64>, "auth": <b64>},
@@ -32,11 +32,16 @@ defmodule GrappaWeb.PushSubscriptionController do
       protection — one subject cannot enumerate another's
       subscription IDs).
 
+    * `PATCH /push/subscriptions/:id` — body `{"label": <string|null>}`,
+      the #964 inline rename. 200 with the updated device summary;
+      400 on a missing / non-string `label`; 404 (uniform body) for
+      cross-subject or missing IDs; 422 past the length cap.
+
     * `GET /push/subscriptions` — 200 with
-      `%{subscriptions: [%{id, provider, user_agent, created_at,
-      last_used_at}, ...]}`. Powers the cic settings drawer's
-      per-device list (B3); `provider` lets a client tell a browser
-      subscription apart from a UnifiedPush-registered device.
+      `%{subscriptions: [%{id, provider, user_agent, label,
+      created_at, last_used_at}, ...]}`. Powers the cic settings
+      drawer's per-device list (B3); `provider` lets a client tell a
+      browser subscription apart from a UnifiedPush-registered device.
 
   ## Subject-scoped — V3 (2026-05-15)
 
@@ -152,6 +157,28 @@ defmodule GrappaWeb.PushSubscriptionController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  @doc """
+  `PATCH /push/subscriptions/:id` — rename a device (#964). Body
+  `{"label": <string|null>}`; `null` or a blank string clears the label
+  and the row falls back to its derived name.
+
+  400 when `label` is absent or not a string/null — a type error is the
+  client's bug, not a value the 422 envelope should have to describe.
+  404 (uniform body) for cross-subject OR missing IDs, same probing
+  protection as `delete/2`. 422 when the value exceeds the length cap.
+  """
+  @spec update(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :bad_request | :not_found | Ecto.Changeset.t()}
+  def update(conn, %{"id" => id, "label" => label})
+      when is_binary(id) and (is_binary(label) or is_nil(label)) do
+    with {:ok, sub} <- Push.get_for_subject(Subject.from_assigns(conn.assigns), id),
+         {:ok, renamed} <- Push.update_label(sub, label) do
+      render(conn, :device, subscription: renamed)
+    end
+  end
+
+  def update(_, _), do: {:error, :bad_request}
 
   @doc """
   `GET /push/subscriptions` — list the authenticated subject's

--- a/lib/grappa_web/controllers/push_subscription_json.ex
+++ b/lib/grappa_web/controllers/push_subscription_json.ex
@@ -16,14 +16,21 @@ defmodule GrappaWeb.PushSubscriptionJSON do
       keys are NOT echoed back; cic already has them locally (it just
       sent them).
     * `:index` (GET 200) — `%{subscriptions: [%{id, provider,
-      user_agent, created_at, last_used_at}, ...]}`. Powers cic
+      user_agent, label, created_at, last_used_at}, ...]}`. Powers cic
       settings drawer device list (B3). `last_used_at` is `nil`
       until B2's `Push.Sender` writes the first delivery. `provider`
       (2026-08-13, UnifiedPush) — `"webpush"` or `"unifiedpush"` —
       lets a client's device list show what kind of endpoint each
       row is (a browser tab vs. a UnifiedPush-registered device);
       revocation (`DELETE /push/subscriptions/:id`) works identically
-      for either.
+      for either. `label` is `nil` until the user renames the device
+      (#964), and cic derives a name from `user_agent` while it is.
+    * `:device` (PATCH 200) — one `subscription_summary()`, the same
+      shape an `:index` row carries.
+
+  `label` is a NEW additive field on an existing shape, so per the
+  additive-only wire contract (#447) it costs no `protocol_version`
+  bump: a client that does not know it simply ignores it.
 
   ## Why no endpoint/keys in any list shape
 
@@ -41,6 +48,7 @@ defmodule GrappaWeb.PushSubscriptionJSON do
           id: Ecto.UUID.t(),
           provider: Subscription.provider(),
           user_agent: String.t() | nil,
+          label: String.t() | nil,
           created_at: DateTime.t(),
           last_used_at: DateTime.t() | nil
         }
@@ -60,12 +68,24 @@ defmodule GrappaWeb.PushSubscriptionJSON do
     %{subscriptions: Enum.map(subs, &summary/1)}
   end
 
+  @doc """
+  Renders the `:device` action — the PATCH 200 response shape (#964).
+
+  Deliberately the SAME summary the `:index` rows carry rather than a
+  bespoke `{id, label}` echo: the rename response is a row, so cic can
+  splice it back into the list without a refetch, and there is one place
+  to change when a device grows another field.
+  """
+  @spec device(%{subscription: Subscription.t()}) :: subscription_summary()
+  def device(%{subscription: %Subscription{} = sub}), do: summary(sub)
+
   @spec summary(Subscription.t()) :: subscription_summary()
   defp summary(%Subscription{} = sub) do
     %{
       id: sub.id,
       provider: sub.provider,
       user_agent: sub.user_agent,
+      label: sub.label,
       created_at: sub.inserted_at,
       last_used_at: sub.last_used_at
     }

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -461,6 +461,9 @@ defmodule GrappaWeb.Router do
     # POST here → server stores endpoint+keys for B2's Push.Sender.
     get "/push/subscriptions", PushSubscriptionController, :index
     post "/push/subscriptions", PushSubscriptionController, :create
+    # #964 — inline rename from the device row. The label is the only
+    # user-writable field on a subscription.
+    patch "/push/subscriptions/:id", PushSubscriptionController, :update
     delete "/push/subscriptions/:id", PushSubscriptionController, :delete
 
     # UX-6-B1 (2026-05-20): embedded image uploader — authenticated

--- a/priv/repo/migrations/20260807120000_add_label_to_push_subscriptions.exs
+++ b/priv/repo/migrations/20260807120000_add_label_to_push_subscriptions.exs
@@ -1,0 +1,34 @@
+defmodule Grappa.Repo.Migrations.AddLabelToPushSubscriptions do
+  @moduledoc """
+  #964 — the one thing about a device only its owner knows: what to call it.
+
+  `user_agent` collapses to `Browser on OS` in the settings drawer, so two
+  instances of the same browser on the same OS render byte-identical rows.
+  Every other disambiguator we can synthesise (the activity instant, an
+  ordinal suffix, the PTR of the peer address) is derived from data the
+  server already holds; the label is the only one that is genuinely NEW
+  information, so it is the only one that earns a column.
+
+  Nullable with no default: NULL means "no label", and the row falls back
+  to the derived `Browser on OS [#n]` default. A `""` never reaches storage
+  — `Subscription.label_changeset/2` folds blank to NULL so "cleared" has
+  exactly one representation.
+
+  Deliberately NOT stored: the ordinal. It is a function of how many
+  subscriptions currently share a parsed name, so a stored copy goes stale
+  the moment one of them is deleted — a lone `#2` with no `#1`.
+
+  ## Hot deploy
+
+  COLD. `Grappa.Deploy.Preflight` classifies every `priv/repo/migrations/*`
+  path as `:migration`, substrate-independent, no exceptions for additive
+  nullable columns.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:push_subscriptions) do
+      add :label, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20260820174126_add_label_to_push_subscriptions.exs
+++ b/priv/repo/migrations/20260820174126_add_label_to_push_subscriptions.exs
@@ -18,11 +18,22 @@ defmodule Grappa.Repo.Migrations.AddLabelToPushSubscriptions do
   subscriptions currently share a parsed name, so a stored copy goes stale
   the moment one of them is deleted — a lone `#2` with no `#1`.
 
-  ## Hot deploy
+  ## Hot deploy — HOT, and measured rather than assumed
 
-  COLD. `Grappa.Deploy.Preflight` classifies every `priv/repo/migrations/*`
-  path as `:migration`, substrate-independent, no exceptions for additive
-  nullable columns.
+  An earlier draft of this file asserted COLD "because `Preflight`
+  classifies every `priv/repo/migrations/*` path as `:migration`". That
+  stopped being true with GH #41: `GrappaWeb.AdminController.reload/2` now
+  runs `Ecto.Migrator` in-process BEFORE the module reload, so only a
+  CONTRACT migration still forces a restart, and `classify_migration/1`
+  decides which is which from the `change/0` AST. `add :label, :string` on
+  an existing table is an expand — nullable, literal type, no
+  `@disable_ddl_transaction` — so it reads `:hot`, and the whole changed
+  path set of #964 classifies `{:hot, []}` on `:jail`, `:docker` and
+  `:linux` alike.
+
+  This says nothing about the RELEASE bump that ships it: a `VERSION`
+  change is its own cold trigger (`:version`, #1287) on the two substrates
+  that boot a `mix release`, and it is not part of this diff.
   """
   use Ecto.Migration
 

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -1232,6 +1232,7 @@ defmodule Grappa.Deploy.PreflightTest do
       20260810120000_add_client_tokens_to_sessions
       20260812220753_add_charset_to_uploads
       20260813074128_add_provider_to_push_subscriptions
+      20260820174126_add_label_to_push_subscriptions
     )
 
     test "every migration on disk classifies, and the HOT set is exactly the pinned one" do

--- a/test/grappa/push_test.exs
+++ b/test/grappa/push_test.exs
@@ -303,6 +303,94 @@ defmodule Grappa.PushTest do
     end
   end
 
+  describe "update_label/2 (#964)" do
+    test "a fresh subscription carries no label" do
+      user = user_fixture()
+      assert {:ok, %Subscription{label: nil}} = Push.create({:user, user.id}, valid_attrs())
+    end
+
+    test "create cannot set the label — it is not on the create allowlist" do
+      user = user_fixture()
+      attrs = Map.put(valid_attrs(), :label, "smuggled in at registration")
+      assert {:ok, %Subscription{label: nil}} = Push.create({:user, user.id}, attrs)
+    end
+
+    test "stores the label and the list reads it back" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+
+      assert {:ok, %Subscription{label: "MacBook del lavoro"}} =
+               Push.update_label(sub, "MacBook del lavoro")
+
+      assert [%Subscription{label: "MacBook del lavoro"}] =
+               Push.list_for_subject({:user, user.id})
+    end
+
+    test "trims surrounding whitespace" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      assert {:ok, %Subscription{label: "telefono"}} = Push.update_label(sub, "  telefono \t ")
+    end
+
+    test "a blank string clears the label to NULL, not to an empty string" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, "")
+    end
+
+    test "a whitespace-only string clears the label too" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, "   ")
+    end
+
+    test "nil clears the label" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, nil)
+    end
+
+    test "rejects a label past the 64-grapheme cap" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+
+      assert {:error, %Ecto.Changeset{errors: errors}} =
+               Push.update_label(sub, String.duplicate("a", 65))
+
+      assert {_, opts} = errors[:label]
+      assert opts[:count] == 64
+    end
+
+    test "counts graphemes, not bytes — 64 multi-byte characters fit" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      label = String.duplicate("è", 64)
+      assert {:ok, %Subscription{label: ^label}} = Push.update_label(sub, label)
+    end
+
+    test "the cap applies to the trimmed value, not the padded one" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      padded = "   " <> String.duplicate("a", 64) <> "   "
+      expected = String.duplicate("a", 64)
+      assert {:ok, %Subscription{label: ^expected}} = Push.update_label(sub, padded)
+    end
+
+    test "renaming touches nothing but the label" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, renamed} = Push.update_label(sub, "telefono")
+      assert renamed.endpoint == sub.endpoint
+      assert renamed.p256dh_key == sub.p256dh_key
+      assert renamed.auth_key == sub.auth_key
+      assert renamed.user_agent == sub.user_agent
+      assert renamed.user_id == sub.user_id
+    end
+  end
+
   describe "touch_last_used/1" do
     test "sets last_used_at to a fresh timestamp" do
       user = user_fixture()

--- a/test/grappa_web/controllers/push_subscription_controller_test.exs
+++ b/test/grappa_web/controllers/push_subscription_controller_test.exs
@@ -16,6 +16,10 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
     * DELETE cross-subject → 404 (probing protection).
     * DELETE unknown ID → 404.
     * user_agent header is captured + persisted on POST.
+    * PATCH (#964 rename): 200 + row summary, visitor parity, label
+      visible on the following GET, blank / null clears to NULL, 422
+      past the cap, 400 on a missing or non-string label, 404
+      cross-subject + unknown ID.
   """
   use GrappaWeb.ConnCase, async: true
 
@@ -58,6 +62,20 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
       nil -> body
       value -> Map.put(body, body_key, value)
     end
+  end
+
+  # #964 — a persisted subscription to rename. Carries a real UA so the
+  # renamed row can be checked to keep every field the PATCH must not touch.
+  defp subscription_for(subject, endpoint) do
+    {:ok, sub} =
+      Push.create(subject, %{
+        endpoint: endpoint,
+        p256dh_key: "k",
+        auth_key: "a",
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/124.0"
+      })
+
+    sub
   end
 
   describe "POST /push/subscriptions — auth gating" do
@@ -473,6 +491,165 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
     test "404 on unknown UUID", %{conn: conn} do
       {_, session} = user_and_session()
       conn = conn |> put_bearer(session.id) |> delete("/push/subscriptions/#{Ecto.UUID.generate()}")
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+    end
+  end
+
+  describe "PATCH /push/subscriptions/:id (#964 rename)" do
+    test "401 without bearer", %{conn: conn} do
+      conn = patch(conn, "/push/subscriptions/#{Ecto.UUID.generate()}", %{"label" => "x"})
+      assert json_response(conn, 401)
+    end
+
+    test "200 with the renamed row, and the list reads it back", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/rename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "MacBook del lavoro"})
+
+      body = json_response(conn, 200)
+      assert body["id"] == sub.id
+      assert body["label"] == "MacBook del lavoro"
+      # Same summary shape the list rows carry, so cic can splice it back in.
+      assert body["user_agent"] == sub.user_agent
+      assert Map.has_key?(body, "created_at")
+      assert Map.has_key?(body, "last_used_at")
+      # Credential-grade material stays out of every response shape.
+      refute Map.has_key?(body, "endpoint")
+      refute Map.has_key?(body, "p256dh_key")
+
+      assert [%{label: "MacBook del lavoro"}] = Push.list_for_subject({:user, user.id})
+    end
+
+    test "200 for a visitor subject — V3 parity", %{conn: conn} do
+      {visitor, session} = visitor_and_session()
+      sub = subscription_for({:visitor, visitor.id}, "https://example.com/push/v-rename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "telefono"})
+
+      assert json_response(conn, 200)["label"] == "telefono"
+      assert [%{label: "telefono"}] = Push.list_for_subject({:visitor, visitor.id})
+    end
+
+    test "GET exposes the label after a rename", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/label-index-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "fisso"})
+      |> json_response(200)
+
+      listed =
+        build_conn()
+        |> put_bearer(session.id)
+        |> get("/push/subscriptions")
+        |> json_response(200)
+
+      assert %{"subscriptions" => [only]} = listed
+      assert only["label"] == "fisso"
+    end
+
+    test "a blank label clears the row back to null", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/clear-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "da cancellare"})
+      |> json_response(200)
+
+      cleared =
+        build_conn()
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "   "})
+        |> json_response(200)
+
+      assert cleared["label"] == nil
+    end
+
+    test "an explicit null clears the row too", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/null-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "da cancellare"})
+      |> json_response(200)
+
+      cleared =
+        build_conn()
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => nil})
+        |> json_response(200)
+
+      assert cleared["label"] == nil
+    end
+
+    test "422 past the length cap, and the stored label is untouched", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/toolong-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => String.duplicate("a", 65)})
+
+      assert %{"error" => "validation_failed", "field_errors" => errors} =
+               json_response(conn, 422)
+
+      assert Map.has_key?(errors, "label")
+      assert [%{label: nil}] = Push.list_for_subject({:user, user.id})
+    end
+
+    test "400 when label is absent from the body", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/nolabel-#{uniq()}")
+
+      conn = conn |> put_bearer(session.id) |> patch("/push/subscriptions/#{sub.id}", %{})
+      assert json_response(conn, 400)
+    end
+
+    test "400 when label is not a string", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/badtype-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => %{"nested" => true}})
+
+      assert json_response(conn, 400)
+    end
+
+    test "404 on cross-user rename (probing protection)", %{conn: conn} do
+      {alice, _} = user_and_session()
+      {_, bob_session} = user_and_session()
+      alice_sub = subscription_for({:user, alice.id}, "https://example.com/push/xrename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(bob_session.id)
+        |> patch("/push/subscriptions/#{alice_sub.id}", %{"label" => "mio adesso"})
+
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+      assert [%{label: nil}] = Push.list_for_subject({:user, alice.id})
+    end
+
+    test "404 on unknown UUID", %{conn: conn} do
+      {_, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{Ecto.UUID.generate()}", %{"label" => "x"})
+
       assert json_response(conn, 404) == %{"error" => "not_found"}
     end
   end


### PR DESCRIPTION
Union of three slices that have never been seen together: **#1579** (test-only), **#964** (feature), **#1441** (e2e refactor). Cherry-picked onto `origin/main` = `571e3ebe`, in that order.

## Why a union and not three PRs

#1617 and #1623 were both green 8/8, but **both against `5ec44475`**, and `main` has moved 114 files since. #1625 is green against `9be1b40a`. N greens earned against a base attest N pairwise merges, never the N-way union — and **all three touch `cicchetto/e2e`**. That is the exact configuration that reddened `main` for twelve hours on 2026-08-03/04: five PRs, each green against one base, the union gated by nothing.

Three separate gates would cost three `integration` runs plus chained rebases. This costs one, and it asks the question no separate gate poses.

## What is in it

| slice | head | commits | contribution |
|---|---|---|---|
| #1579 — user-topic barrier diagnostics | `0794280d` | 2 | 3 files |
| #964 — push device label + derived ordinal | `b417bbfa` | 8 | 15 files (9 server) |
| #1441 — the media-viewer door | `10861cd5` | 2 | 12 files |

Zero conflicts. **The only file any two slices share is `docs/DESIGN_NOTES.md`** (`comm -12` on all three pairs, oracle positive-controlled against itself = 3).

## Measurements

**Every slice arrives byte-identical.** For each slice, its non-`DESIGN_NOTES` files diffed against its own head: empty, all three. The oracle is not vacuous — the same comparison against the base reports 14 files / 1012 insertions.

**`DESIGN_NOTES.md`, the four-check recipe** (the union path, `merge=union`):

- numstat two-sided: **+391 -0**, exactly 114 + 166 + 111. Additions unchanged, deletions zero.
- totals: 54282 → **54673** lines (= base + 391), 158 → **161** markers, `_Deploy:` steady at 66.
- markers `#1579` / `#964` / `#1441` each `grep -Fxc` = **1** on the union and **0** on the tip, re-verified against `571e3ebe` immediately before pushing. Positive control `#1519` = 1 against an 158-marker universe; negative `#999999` = 0. No duplicate among all 161.
- boundary shape read **on the file** at all three new boundaries: last line of the previous entry / marker with no blank ahead of it / blank / `---` / blank / `## `.
- **the tail check, which is the one that catches the mode the marker does not cover:** entry `#1532` — the one preceding the first graft — is byte-identical at 109 lines, `md5 e980004d…`. All three grafted entries likewise `cmp`-identical to their source (114 / 166 / 111 lines).

`scripts/design-notes-gate.sh` green: 3 new entry headings, separator and marker present.

**`#964`'s migration stamp** was regenerated against `5ec44475`; re-checked here against `571e3ebe`. `20260820174126` is posterior to main's latest `20260816014915`, and no version is duplicated among the union's 91 migrations. This matters because a duplicate version on a DB that already applied it drops **both** files out of pending and reports success while neither runs.

**The duplication the union was supposed to expose: measured, not there.** #1441 lifts thirteen media-viewer opening sites into one door; the count on the base is **13** across 10 files, and on the union it is **1** — the door itself. Neither #1579 nor #964 adds a single line naming the viewer (0 and 0). No conflict touched the subject of any slice, so no premise needed re-deriving.

## Declared non-measures

- **`scripts/union-rebase.sh origin/main` exits 0, and that 0 means nothing here.** The tool says so itself: *"already on top of origin/main — the driver gets no chance to run, so the comparison below is VACUOUS by construction, not a pass."* A branch cherry-picked from the tip is precisely that condition. The four checks above carry the load; the tool's rc does not.
- **No local suite or e2e was run** on this branch, by instruction. CI is the gate.
- **#1441 shipped without a single e2e spec having been RUN** (its own entry says so: the lane was not requested, the argument is `tsc` + `bun run test` + `playwright test --list` equality). It rewrites eleven spec files. **This union's e2e job is the first execution of that refactor**, and it is the risk worth watching.
- Each slice's own files are unchanged, and no slice's files were touched by main since its base — but main moved 114 other files under #1579 and #964. Semantic interaction with those is exactly what this run is for, and nothing local attests it.

## The #1441 census

Worth not losing. The issue asked for one opener for "ten specs" and was explicit that neither the byte-identity of the copies nor the completeness of the ten had been measured. Both were measured, and both moved: **10 files but 13 call sites**, and never byte-identical — **5 distinct bodies** raw, **3** with indentation and comments normalised away.

**The extractor lied first, and the scalar control did not catch it.** Version one pinned `media-link-modal-viewer.spec.ts == 3 open sites` and PASSED while finding the wrong three (75/175/176 instead of 75/174/194): a `toBeVisible` quoted inside a prose comment counted as a barrier, and a site whose dialog binding sat outside the lookback window was missed. **Two errors of opposite sign summed to the expected total.** Controls are pinned to line numbers since — a count cannot see a compensating pair.

The one axis that genuinely diverges gets two verbs rather than a boolean: nine sites click through Playwright, four dispatch the anchor's own click because they measure the scrollback's scroll position across the open, and scroll-into-view would move the thing under test.

## Supersession

This supersedes **#1617**, **#1623** and **#1625**. Cherry-picking rewrites the SHAs, so **GitHub cannot auto-close any of them** — they close by content at merge. The source branches are untouched and unpushed.
