### PR TITLE
#1594: a pre-release crossed its own takeover boundary — and no gate was watching the number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,24 @@ jobs:
             exit 1
           fi
 
+      # A DIFFERENT claim from the step above, and #1594's whole point. That
+      # one reads the number the BEAM reports; this one reads the number the
+      # PACKAGE is stamped with, which nfpm derives and can therefore restamp.
+      # It did: `1.3.0-rc1` reached apt as `1.3.0~rc1`, and no assertion in
+      # this pipeline was looking at that field — the two version proofs it
+      # had both compared the CLIENT package against the CLIENT's carrier.
+      # `pkgversion.sh` is the shared oracle; its map is measured against the
+      # pinned nfpm, not read off nfpm's source.
+      - name: Prove the bouncer .deb is stamped with the version nfpm derives from VERSION
+        run: |
+          deb="$(find dist -name 'grappa_*.deb' -print -quit)"
+          [ -n "$deb" ] || { echo "::error::no bouncer .deb in dist/"; exit 1; }
+          want="$(infra/packaging/pkgversion.sh deb grappa)"
+          got="$(dpkg-deb -f "$deb" Version)"
+          echo "bouncer package version: '$got' (want '$want')"
+          [ "$got" = "$want" ] || {
+            echo "::error::the bouncer .deb is stamped '$got', expected '$want'"; exit 1; }
+
       # Same proof discipline as the migrate + version checks above: assert
       # on the INSTALLED artifact, not on the build tree. `--help` exits 0
       # without a server, a terminal or config, so it exercises the real
@@ -285,8 +303,10 @@ jobs:
             echo "::error::Replaces: is not the literal grappa (<< 1.3.0~)"
             dpkg-deb -f "$deb" Replaces; exit 1; }
 
-          # Its own version line, not the bouncer's.
-          want="$(infra/packaging/version.sh shottino)"
+          # Its own version line, not the bouncer's — through the same nfpm
+          # map the bouncer's proof uses, so a pre-release on the client's
+          # cadence is covered the day it appears rather than the day it fails.
+          want="$(infra/packaging/pkgversion.sh deb shottino)"
           got="$(dpkg-deb -f "$deb" Version)"
           echo "client version: '$got' (want '$want')"
           [ "$got" = "$want" ] || {
@@ -662,6 +682,26 @@ jobs:
             exit 1
           fi
 
+      # The rpm twin of the deb job's stamped-version gate (#1594). Two fields
+      # here, not one: nfpm could in principle split a pre-release out into
+      # `Release`, and measured against the pinned 2.43.0 it does NOT — every
+      # shape lands wholly in `Version` with `Release` left at the default 1.
+      # Asserting both is what makes "the number was not restamped" a closed
+      # claim rather than a claim about one field.
+      - name: Prove the bouncer .rpm is stamped with the version nfpm derives from VERSION
+        run: |
+          pkg="$(find dist -name 'grappa-*.rpm' -print -quit)"
+          [ -n "$pkg" ] || { echo "::error::no bouncer .rpm in dist/"; exit 1; }
+          want="$(infra/packaging/pkgversion.sh rpm grappa)"
+          got="$(rpm -qp --queryformat '%{VERSION}' "$pkg")"
+          rel="$(rpm -qp --queryformat '%{RELEASE}' "$pkg")"
+          echo "bouncer package NEVRA: $(rpm -qp --queryformat '%{NEVRA}' "$pkg")"
+          echo "bouncer package version: '$got' (want '$want'), release: '$rel'"
+          [ "$got" = "$want" ] || {
+            echo "::error::the bouncer .rpm is stamped '$got', expected '$want'"; exit 1; }
+          [ "$rel" = "1" ] || {
+            echo "::error::Release is '$rel', not nfpm's default 1 — a release: key was added and this gate has not measured it"; exit 1; }
+
       # Same proof discipline as the .deb, both directions — the file must be
       # ABSENT from the bouncer's payload and delivered by the client package.
       # Like the arch source build, this also confirms shottino compiled on
@@ -706,7 +746,7 @@ jobs:
             echo "::error::Obsoletes: is not the literal grappa < 1.3.0~"
             rpm -qp --obsoletes "$pkg"; exit 1; }
 
-          want="$(infra/packaging/version.sh shottino)"
+          want="$(infra/packaging/pkgversion.sh rpm shottino)"
           got="$(rpm -qp --queryformat '%{VERSION}' "$pkg")"
           echo "client version: '$got' (want '$want')"
           [ "$got" = "$want" ] || {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,12 +275,14 @@ jobs:
 
           # The takeover metadata reached the control file intact — an
           # unexpanded ${VAR} would show up here verbatim (nfpm does not
-          # expand deb.breaks).
-          dpkg-deb -f "$deb" Breaks | grep -qF 'grappa (<< 1.3.0)' || {
-            echo "::error::Breaks: is not the literal grappa (<< 1.3.0)"
+          # expand deb.breaks). The trailing `~` is #1594's pre-release
+          # epsilon and is part of the boundary VALUE: without it the relation
+          # captures grappa's own `1.3.0~rc1` and the pair stops installing.
+          dpkg-deb -f "$deb" Breaks | grep -qF 'grappa (<< 1.3.0~)' || {
+            echo "::error::Breaks: is not the literal grappa (<< 1.3.0~)"
             dpkg-deb -f "$deb" Breaks; exit 1; }
-          dpkg-deb -f "$deb" Replaces | grep -qF 'grappa (<< 1.3.0)' || {
-            echo "::error::Replaces: is not the literal grappa (<< 1.3.0)"
+          dpkg-deb -f "$deb" Replaces | grep -qF 'grappa (<< 1.3.0~)' || {
+            echo "::error::Replaces: is not the literal grappa (<< 1.3.0~)"
             dpkg-deb -f "$deb" Replaces; exit 1; }
 
           # Its own version line, not the bouncer's.
@@ -696,9 +698,12 @@ jobs:
             echo "::error::expected exactly /usr/bin/shottino, got: $files"; exit 1; }
 
           # nfpm maps `replaces:` to Obsoletes: on rpm (rpm/rpm.go), so this is
-          # the same declaration the .deb spells as Replaces:.
-          rpm -qp --obsoletes "$pkg" | grep -qF 'grappa < 1.3.0' || {
-            echo "::error::Obsoletes: is not the literal grappa < 1.3.0"
+          # the same declaration the .deb spells as Replaces:. Anchored on the
+          # end of line: `grappa < 1.3.0` is a PREFIX of the cured
+          # `grappa < 1.3.0~`, so an unanchored fixed-string match cannot tell
+          # the pre-#1594 boundary from this one and would pass on either.
+          rpm -qp --obsoletes "$pkg" | grep -qE '^grappa < 1\.3\.0~$' || {
+            echo "::error::Obsoletes: is not the literal grappa < 1.3.0~"
             rpm -qp --obsoletes "$pkg"; exit 1; }
 
           want="$(infra/packaging/version.sh shottino)"

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55310,3 +55310,149 @@ persist/retention axis remains unmeasured for `networks_controller_test.exs`.
 Whether `terminate/2`'s badmatch is reachable in production is #1613's
 question, not this one's — the cascade amplifier is still there, this fix
 removes the thing that fed it.
+<!-- entry #1594 -->
+
+---
+
+## 2026-08-20 — #1594: a pre-release crossed its own takeover boundary, and nothing was watching the number
+
+Cutting `v1.3.0-rc1` killed the `deb` and the `rpm` release jobs at the same
+step — *Install BOTH packages*, apt exit 100, dnf exit 1. Both packages BUILT
+correctly and their metadata was exactly what CI asked for. They were simply
+**mutually uninstallable**, and the reason is one character.
+
+### Two facts meeting
+
+**nfpm restamps a pre-release.** `build.sh` passes the VERSION string through
+untouched, and nfpm parses it as semver and re-spells the pre-release with a
+tilde, because `~` is how dpkg and rpm both say "sorts below the release it
+precedes". So `1.3.0-rc1` reached the resolvers as `1.3.0~rc1`.
+
+**`shottino` declared its takeover boundary at exactly `1.3.0`** — the first
+release that stops shipping `/usr/bin/shottino`, written as a constant on
+purpose (#1447, vjt 2026-08-17). And `~` sorts BELOW the empty string, so
+`1.3.0~rc1 < 1.3.0` is true and the boundary captured **the release candidate
+of the very release that defines the boundary**. shottino asserted that a
+grappa which does not own the path still owns it.
+
+The yaml comment had argued the constant at length against a *future* bump
+claiming too much. The hole came from the other direction, which the comment
+did not consider: the pre-release of the boundary version itself, falling
+below its own boundary.
+
+### The nfpm map, measured
+
+nfpm 2.43.0 — the version `build.sh` pins — against a minimal config, one
+package built per row, the field read off the ARTEFACT (`dpkg-deb -f`,
+`rpm -qp --queryformat`), on `ubuntu:24.04` and `fedora:43`, the two images the
+release jobs use. `1.3.0` is the positive control:
+
+| VERSION file | deb `Version` | rpm `Version` | rpm `Release` |
+|---|---|---|---|
+| `1.3.0` | `1.3.0` | `1.3.0` | `1` |
+| `1.3.0-rc1` | `1.3.0~rc1` | `1.3.0~rc1` | `1` |
+| `1.3.0-rc.1` | `1.3.0~rc.1` | `1.3.0~rc.1` | `1` |
+| `1.3.0-rc-1` | `1.3.0~rc-1` | `1.3.0~rc_1` | `1` |
+| `1.3.0+foo` | `1.3.0+foo` | `1.3.0+foo` | `1` |
+| `1.3.0-rc1+foo` | `1.3.0~rc1+foo` | `1.3.0~rc1+foo` | `1` |
+
+The rule: the FIRST `-` becomes `~` in both formats, and on rpm every FURTHER
+`-` becomes `_` (rpm reserves `-` as the Version/Release separator). A
+pre-release is **not** split out into `Release`, which stays nfpm's default
+`1` in every row. This closes the "rpm/deb side" non-measure #1591 declared.
+
+### The resolvers' verdict, measured — not the control file's contents
+
+A `Breaks` that *can* capture is not a `Breaks` that *has* captured, so the
+boundary was measured by building fixture packages and asking apt and dnf to
+install the pair. Two boundaries × four grappa versions, both formats,
+identical results:
+
+| grappa | `<< 1.3.0` (before) | `<< 1.3.0~` (after) |
+|---|---|---|
+| `1.2.0` | REFUSES | REFUSES |
+| `1.2.9` | REFUSES | REFUSES |
+| `1.3.0-rc1` → `1.3.0~rc1` | **REFUSES** | **INSTALLS** |
+| `1.3.0` | INSTALLS | INSTALLS |
+
+**Exactly one cell moves.** The guard is relocated, not disarmed — which is
+the row a `<< 0` "fix" would also have produced for rc1 and would have failed
+for 1.2.x. The pre-cure refusals reproduce the CI logs verbatim:
+`shottino : Breaks: grappa (< 1.3.0) but 1.3.0~rc1 is to be installed` and
+`package shottino-0.3.0-1.x86_64 from @commandline obsoletes grappa < 1.3.0
+provided by grappa-1.3.0~rc1-1.x86_64 from @commandline`.
+
+**The bare `1.3.0` row is the decision-relevant one, and it is green on both
+sides.** #1591 named it "the single most decision-relevant open question" and
+derived it from the ordering rule; measured, the derivation holds. Cutting
+1.3.0 FINAL was never blocked. Only pre-releases were — which is why this is
+a fix for the next tag and not a reason to touch the published `v1.3.0-rc1`.
+
+### The cure, and the class
+
+The three relations become `grappa (<< 1.3.0~)` (deb `breaks` +
+`overrides.deb.replaces`) and `grappa < 1.3.0~` (`overrides.rpm.replaces`,
+rendered `Obsoletes:`). `X.Y.Z~` is the spelling of "everything strictly
+before X.Y.Z, its own pre-releases excluded".
+
+**The general rule, and it is a class rather than this incident: a hard-coded
+lower-bound version constant in package metadata is crossed by the
+pre-release of that very version**, on both dpkg and rpm. Any future boundary
+written as a constant is written `X.Y.Z~` unless someone wants to capture that
+version's pre-releases deliberately.
+
+### The other half: the number itself had no gate
+
+The issue named a second hole worth as much as the cure. The release pipeline
+carried two package-version proofs, and **both compared against
+`version.sh shottino`** — the CLIENT's carrier, `frontends/shottino/version.h`,
+which a grappa bump does not touch. So the BOUNCER package's stamped number
+was unasserted in both formats: nfpm restamped it and nothing in the pipeline
+could have noticed. The `grappa eval` proof next door is a different claim —
+it reads the number the BEAM reports, which nfpm never touches.
+
+`infra/packaging/pkgversion.sh <deb|rpm> <component>` is the shared oracle for
+the measured map, and all four packages (bouncer + client, deb + rpm) now
+assert their stamped field against it. It is a SIBLING of `version.sh`, not a
+flag on it: `version.sh` answers *which file carries the number* and is the
+source of truth; this one answers *what the packager writes down*, and the two
+answers diverge the moment the number carries a pre-release. It takes the
+format explicitly and refuses on a missing or unknown one — an oracle that
+guessed would compare a `.rpm` against the deb spelling and agree on every
+version without a hyphen, which is every version this repo has ever cut but
+one.
+
+The `arch` job keeps reading `version.sh shottino` on purpose: makepkg
+REFUSES a hyphen in `pkgver` rather than re-spelling it (#1591), so routing it
+through an nfpm-shaped map would assert a transform pacman never performs.
+
+Two greps also had to be anchored, and the reason is the cure itself:
+`grappa < 1.3.0` is a PREFIX of `grappa < 1.3.0~`, so the rpm `Obsoletes`
+proof and the bats count could not have told the old boundary from the new one
+and would have passed on either.
+
+### Not established
+
+- **Nothing was run at a real tag.** Every measurement is fixture packages
+  built by the pinned nfpm from a minimal config, not the real 37 MB bouncer
+  package with its ERTS payload and maintainer scripts. The metadata fields
+  and the resolver decisions do not depend on the payload, but the claim here
+  is about the version relation, not about the release building.
+- **The new CI gates have not run in CI.** They are proven locally: each new
+  assertion was mutated back to the pre-cure tree and observed RED.
+- **amd64 only, on those two images.** Measured with
+  `--platform linux/amd64` on `ubuntu:24.04` and `fedora:43`; the deb job runs
+  on the `ubuntu-latest` runner rather than in that container, and arm64 was
+  not measured. Version ordering and nfpm's map are architecture-independent
+  by construction, but that is an argument, not a measurement.
+- **`Release` beyond the default.** Every row measured leaves it at `1` because
+  `nfpm.yaml` declares no `release:` key. What nfpm would do with one is not
+  measured — the rpm gate refuses a non-`1` value rather than guessing.
+- **The Arch leg.** Untouched here and unfixed; it is #1591's, and its defect
+  is a different mechanism (makepkg rejects the hyphen outright).
+- **Whether a partial release is the right failure mode.** #1591 recorded that
+  `publish` runs under `if: !cancelled()` and marks a partial release rather
+  than failing the cut. That is why "a documented limitation" was rejected as
+  the outcome here — a broken gate that ships publicly is not a limitation a
+  reader can route around — but the partial-release posture itself was neither
+  measured nor changed.

--- a/infra/packaging/README.md
+++ b/infra/packaging/README.md
@@ -59,12 +59,32 @@ cadences: `shottino --version` and the package version agree, which they
 could not if the package were stamped with a bouncer release number.
 
 Its metadata takes `/usr/bin/shottino` over from the bouncer with
-`Replaces:` / `Breaks: grappa (<< 1.3.0)` (nfpm maps `replaces` to RPM's
+`Replaces:` / `Breaks: grappa (<< 1.3.0~)` (nfpm maps `replaces` to RPM's
 `Obsoletes`). That boundary is historical — the first release that stops
 shipping the file — so it is written as a constant and must not become
 `${GRAPPA_VERSION}`: at 1.4.0 that would assert grappa 1.3.0 shipped a file
 it did not. `deb.breaks` is also absent from nfpm's env-expansion list, so
 an interpolation there reaches the control file verbatim.
+
+**The trailing `~` is part of the boundary, not punctuation (#1594).** nfpm
+stamps a `1.3.0-rc1` VERSION file as `1.3.0~rc1`, and `~` sorts below the
+empty string in both dpkg and rpm ordering — so a bare `1.3.0` boundary
+captures 1.3.0's own release candidate, and cutting `v1.3.0-rc1` made the
+two packages mutually uninstallable (apt 100, dnf 1). `1.3.0~` means
+"everything strictly before 1.3.0, its pre-releases excluded". Any future
+`X.Y.Z` boundary written as a constant has the same hole and is written
+`X.Y.Z~`.
+
+### `pkgversion.sh` — the version nfpm stamps
+
+`version.sh <component>` answers *which file carries the number*.
+`pkgversion.sh <deb|rpm> <component>` answers *what the packager writes
+down*, and the two differ for any pre-release. The release workflow asserts
+all four packages (bouncer + client, deb + rpm) against it; before #1594 the
+bouncer's stamped number had no assertion in either format, so a restamp was
+invisible. The map (first `-` → `~`, and on rpm every further `-` → `_`) is
+measured against the pinned nfpm 2.43.0 — the table is in the script header
+and in `docs/DESIGN_NOTES.md` under #1594.
 
 **Where the split stands.** Done, in both halves at once. The bouncer
 package no longer ships `/usr/bin/shottino` — it is out of `nfpm.yaml`'s

--- a/infra/packaging/nfpm-shottino.yaml
+++ b/infra/packaging/nfpm-shottino.yaml
@@ -46,8 +46,31 @@ description: |
 # the file — so it is written as a constant. It must NOT become
 # `${GRAPPA_VERSION}`: at 1.4.0 that would claim every grappa older than 1.4.0
 # shipped the file, which is false for 1.3.0, and a false statement in package
-# metadata is worse than an inconvenient one. Two further reasons, measured in
-# nfpm v2.43.0 (the version build.sh pins) rather than assumed:
+# metadata is worse than an inconvenient one.
+#
+# 🔴 THE TRAILING `~` IS LOAD-BEARING (GH #1594), and it is not decoration on
+# the constant — it is part of the boundary's VALUE. `~` sorts BELOW the empty
+# string in dpkg and in rpm version ordering, and nfpm stamps a `1.3.0-rc1`
+# VERSION file as `1.3.0~rc1`. So a bare `1.3.0` boundary is strictly GREATER
+# than the release candidate of 1.3.0 itself: cutting v1.3.0-rc1 made these two
+# packages mutually uninstallable — apt exit 100, dnf exit 1, both at the
+# *Install BOTH packages* step — because shottino asserted that a grappa which
+# does not own /usr/bin/shottino still owns it. `1.3.0~` spells "everything
+# strictly before 1.3.0, its own pre-releases NOT included", which is the
+# statement that was always meant.
+#
+# Measured through the RESOLVERS, not derived from the ordering rule: with the
+# bare boundary, apt and dnf both REFUSE a `1.3.0~rc1` pair and both accept a
+# bare `1.3.0` one; with this boundary the rc1 pair installs, and 1.2.0 / 1.2.9
+# keep being refused on both formats. Exactly one cell of that matrix moves —
+# the guard is relocated, not disarmed. Full table: DESIGN_NOTES #1594.
+#
+# The same hole exists for ANY future `X.Y.Z` boundary written as a constant,
+# so a new one is written `X.Y.Z~` unless someone has a reason to capture that
+# version's pre-releases on purpose.
+#
+# Two further reasons the constant stays a constant, measured in nfpm v2.43.0
+# (the version build.sh pins) rather than assumed:
 #
 #   * `deb.breaks` is NOT env-expanded. nfpm expands ${VARS} in depends /
 #     replaces / recommends / provides / suggests / conflicts (nfpm.go:214-227)
@@ -68,7 +91,7 @@ description: |
 # inferred from the syntax.
 deb:
   breaks:
-    - grappa (<< 1.3.0)
+    - grappa (<< 1.3.0~)
 
 # Runtime deps are per-format (disjoint package names across distro families).
 # NOT the bouncer's list: no ERTS here, so libncurses6 (the NARROW build ERTS
@@ -98,7 +121,7 @@ overrides:
       - ca-certificates
     # Debian relation syntax: parenthesised, `<<` for strictly-less.
     replaces:
-      - grappa (<< 1.3.0)
+      - grappa (<< 1.3.0~)
   rpm:
     depends:
       - ncurses-libs
@@ -108,7 +131,7 @@ overrides:
     # `Obsoletes:`. See the comment above the `deb:` block for what happens if
     # the Debian spelling reaches this list instead.
     replaces:
-      - grappa < 1.3.0
+      - grappa < 1.3.0~
 
 contents:
   - src: ./staging-shottino/usr/bin/shottino

--- a/infra/packaging/pkgversion.sh
+++ b/infra/packaging/pkgversion.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# pkgversion.sh — echo the version field nfpm STAMPS into a package, for one
+# component in one format.
+#
+#   pkgversion.sh deb grappa     the .deb `Version:` of the bouncer package
+#   pkgversion.sh rpm grappa     the .rpm `Version` of its NEVRA
+#   pkgversion.sh deb shottino   ditto for the standalone client package
+#   pkgversion.sh rpm shottino
+#
+# WHY THIS IS NOT version.sh (GH #1594). `version.sh` answers "which file
+# carries this component's number", and it is the SOURCE of truth. This script
+# answers a different question — "what does the packager write down" — and the
+# two answers DIFFER the moment the number carries a pre-release. nfpm does not
+# ship the string it is given: it parses it as semver and re-spells the
+# pre-release with a tilde, because `~` is how both dpkg and rpm express
+# "sorts below the release it precedes".
+#
+# Cutting v1.3.0-rc1 is where that mattered. `1.3.0-rc1` reached the resolvers
+# as `1.3.0~rc1`, which is strictly less than `1.3.0`, so shottino's takeover
+# boundary captured the release candidate of the very release that defines the
+# boundary and the two packages became mutually uninstallable. Nothing in the
+# pipeline noticed, because the only version proofs it had compared the CLIENT
+# package against the CLIENT's own carrier — the bouncer's stamped number was
+# unasserted in both formats. This script is the shared oracle those four
+# proofs now use.
+#
+# THE MAP IS MEASURED, not derived from nfpm's source or from semver's text.
+# nfpm 2.43.0 (the version build.sh pins), minimal config, one package built
+# per row, field read off the artefact with `dpkg-deb -f`/`rpm -qp`:
+#
+#   VERSION file      deb Version      rpm Version      rpm Release
+#   1.3.0             1.3.0            1.3.0            1
+#   1.3.0-rc1         1.3.0~rc1        1.3.0~rc1        1
+#   1.3.0-rc.1        1.3.0~rc.1       1.3.0~rc.1       1
+#   1.3.0-rc-1        1.3.0~rc-1       1.3.0~rc_1       1
+#   1.3.0+foo         1.3.0+foo        1.3.0+foo        1
+#   1.3.0-rc1+foo     1.3.0~rc1+foo    1.3.0~rc1+foo    1
+#
+# So: the FIRST `-` becomes `~` in both formats, and on rpm every FURTHER `-`
+# becomes `_` — rpm reserves `-` as the Version/Release separator and cannot
+# carry one inside Version. That single divergent row is why this takes a
+# format argument instead of answering once. `Release` is nfpm's default `1`
+# in every row; a pre-release is NOT split out into it.
+#
+# NO DEFAULT ARGUMENTS, unlike version.sh's load-bearing bare form. An oracle
+# that guesses the format would compare a .rpm against the deb spelling and
+# agree on every version without a hyphen — which is every version this repo
+# has ever cut but one. It must refuse instead.
+#
+# POSIX sh, same dialect as its sibling: it is reached from CI shell and from
+# the bats suite, and the derived POSIX-parse gate covers it by line 1.
+set -eu
+
+# shellcheck disable=SC1007
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+
+if [ "$#" -ne 2 ]; then
+	printf 'pkgversion.sh: usage: pkgversion.sh <deb|rpm> <grappa|shottino>\n' >&2
+	exit 2
+fi
+
+format="$1"
+component="$2"
+
+case "${format}" in
+deb | rpm) ;;
+*)
+	printf 'pkgversion.sh: unknown format %s (want: deb | rpm)\n' "${format}" >&2
+	exit 2
+	;;
+esac
+
+# The component name is validated by version.sh, which exits 2 on an unknown
+# one — no second allowlist to drift out of step with it.
+source_version="$("${SCRIPT_DIR}/version.sh" "${component}")"
+
+case "${format}" in
+deb)
+	# First `-` only: `s///` without `g`.
+	printf '%s\n' "${source_version}" | sed 's/-/~/'
+	;;
+rpm)
+	printf '%s\n' "${source_version}" | sed 's/-/~/; s/-/_/g'
+	;;
+esac

--- a/test/infra/packaging_pkgversion_test.bats
+++ b/test/infra/packaging_pkgversion_test.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1594 — the package VERSION field is nfpm's, not ours, and
+# the release pipeline never checked it.
+#
+# TWO properties, one root. Cutting `v1.3.0-rc1` made both visible at once.
+#
+#   1. nfpm RESTAMPS a pre-release. `1.3.0-rc1` in the VERSION file becomes
+#      `1.3.0~rc1` in the .deb `Version:` field and in the .rpm `Version` of
+#      the NEVRA. The string the resolvers compare is therefore NOT the string
+#      the repo carries, and `~` sorts BELOW the empty string in both dpkg and
+#      rpm ordering.
+#   2. NOTHING in the pipeline noticed. Both existing version proofs
+#      (`release.yml` deb + rpm) compared against `version.sh shottino` — the
+#      CLIENT's carrier, `frontends/shottino/version.h`, which a grappa bump
+#      does not touch. The bouncer package's stamped number had no assertion
+#      at all, in either format.
+#
+# So `pkgversion.sh` exists to answer, in ONE place, "what does nfpm stamp for
+# this component in this format", and both jobs assert every package against
+# it. The map is MEASURED, not derived — see docs/DESIGN_NOTES.md #1594 for
+# the nfpm 2.43.0 table these rows reproduce. This suite pins the transform;
+# the measurement is what says the transform is the right one.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    PKG_DIR="$REPO_ROOT/infra/packaging"
+    PKGVERSION="$PKG_DIR/pkgversion.sh"
+    WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+
+    # A sandbox repo carrying BOTH version carriers, so a case can set the
+    # version to any shape in the measured table without touching the real
+    # tree. pkgversion.sh delegates to version.sh, and version.sh derives the
+    # repo root from its own $0 — so the copies must sit at the same relative
+    # depth as the originals.
+    SANDBOX="$BATS_TEST_TMPDIR/sandbox"
+    mkdir -p "$SANDBOX/infra/packaging" "$SANDBOX/frontends/shottino"
+    cp "$PKG_DIR/version.sh" "$PKGVERSION" "$SANDBOX/infra/packaging/"
+    chmod +x "$SANDBOX/infra/packaging/"*.sh
+    SANDBOX_PKGVERSION="$SANDBOX/infra/packaging/pkgversion.sh"
+    # The FLOOR. Without it the two refusal cases below are satisfied by a
+    # missing script (exit 127 is also non-zero), and would report green
+    # against a sandbox that holds nothing.
+    [ -x "$SANDBOX_PKGVERSION" ]
+}
+
+# Set the sandbox's bouncer version and echo what pkgversion.sh makes of it.
+sandbox_maps() { # $1 = VERSION file content, $2 = format
+    printf '%s\n' "$1" > "$SANDBOX/VERSION"
+    "$SANDBOX_PKGVERSION" "$2" grappa
+}
+
+# ── The map, row by row against the measured nfpm 2.43.0 table ─────────────
+
+@test "#1594 deb: the first hyphen becomes a tilde, and nothing else moves" {
+    # Measured with the pinned nfpm 2.43.0 (the version build.sh downloads)
+    # against a minimal config, reading `dpkg-deb -f <pkg> Version` off the
+    # artefact. Every row here is one row of that table.
+    [ "$(sandbox_maps '1.3.0-rc1' deb)" = '1.3.0~rc1' ]
+    [ "$(sandbox_maps '1.3.0-rc.1' deb)" = '1.3.0~rc.1' ]
+    [ "$(sandbox_maps '1.3.0-rc-1' deb)" = '1.3.0~rc-1' ]
+    [ "$(sandbox_maps '1.3.0+foo' deb)" = '1.3.0+foo' ]
+    [ "$(sandbox_maps '1.3.0-rc1+foo' deb)" = '1.3.0~rc1+foo' ]
+}
+
+@test "#1594 rpm: same tilde, and every FURTHER hyphen becomes an underscore" {
+    # The one row where the two formats disagree, and the reason the script
+    # takes a format rather than answering once: rpm forbids `-` in Version
+    # (it is the Version/Release separator), so nfpm rewrites the leftovers.
+    # `1.3.0-rc-1` -> deb `1.3.0~rc-1`, rpm `1.3.0~rc_1`. Measured, not read.
+    [ "$(sandbox_maps '1.3.0-rc1' rpm)" = '1.3.0~rc1' ]
+    [ "$(sandbox_maps '1.3.0-rc.1' rpm)" = '1.3.0~rc.1' ]
+    [ "$(sandbox_maps '1.3.0-rc-1' rpm)" = '1.3.0~rc_1' ]
+    [ "$(sandbox_maps '1.3.0+foo' rpm)" = '1.3.0+foo' ]
+    [ "$(sandbox_maps '1.3.0-rc1+foo' rpm)" = '1.3.0~rc1+foo' ]
+}
+
+@test "#1594 a bare X.Y.Z passes through untouched, in both formats" {
+    # The POSITIVE CONTROL of the whole issue. Every tag before v1.3.0-rc1 was
+    # a bare release, so if this row moved, the map would be rewriting history
+    # that nfpm never rewrote — and the gate built on it would fail every
+    # ordinary cut.
+    [ "$(sandbox_maps '1.3.0' deb)" = '1.3.0' ]
+    [ "$(sandbox_maps '1.3.0' rpm)" = '1.3.0' ]
+    [ "$(sandbox_maps '0.9.11' deb)" = '0.9.11' ]
+    [ "$(sandbox_maps '0.9.11' rpm)" = '0.9.11' ]
+}
+
+@test "#1594 the client component reads its OWN carrier, mapped the same way" {
+    # Two artifacts, two cadences (#1447). The mapping is a property of nfpm,
+    # not of which file the number came from, so the client goes through the
+    # same door — today its line is bare and the map is the identity, which is
+    # exactly why routing it here now costs nothing and covers it later.
+    printf '1.3.0\n' > "$SANDBOX/VERSION"
+    printf '#define SHOTTINO_VERSION "0.4.0-rc2"\n' > "$SANDBOX/frontends/shottino/version.h"
+
+    [ "$("$SANDBOX_PKGVERSION" deb shottino)" = '0.4.0~rc2' ]
+    [ "$("$SANDBOX_PKGVERSION" rpm shottino)" = '0.4.0~rc2' ]
+}
+
+# ── It refuses rather than guessing ────────────────────────────────────────
+
+@test "#1594 an unknown format, an unknown component or a missing argument refuses" {
+    # No defaulting. A gate whose oracle silently answers for the wrong format
+    # is worse than no gate: it would compare a .rpm against the deb spelling
+    # and pass on every version that has no hyphen — which is every version
+    # the repo has ever cut except one.
+    printf '1.3.0\n' > "$SANDBOX/VERSION"
+
+    run "$SANDBOX_PKGVERSION" apk grappa
+    [ "$status" -ne 0 ]
+
+    run "$SANDBOX_PKGVERSION" deb cicchetto
+    [ "$status" -ne 0 ]
+
+    run "$SANDBOX_PKGVERSION" deb
+    [ "$status" -ne 0 ]
+
+    run "$SANDBOX_PKGVERSION"
+    [ "$status" -ne 0 ]
+}
+
+@test "#1594 an unreadable carrier fails loudly instead of echoing an empty version" {
+    # An empty expected value would make the CI comparison pass against an
+    # equally empty `dpkg-deb -f` on a missing file — two silences agreeing.
+    rm -f "$SANDBOX/VERSION"
+
+    run "$SANDBOX_PKGVERSION" deb grappa
+    [ "$status" -ne 0 ]
+    # And it prints no version-shaped line a caller could mistake for one.
+    refute grep -qE '^[0-9]+\.[0-9]+\.[0-9]+' <<<"$output"
+}
+
+# ── The pipeline actually uses it, for BOTH packages, in BOTH jobs ─────────
+
+@test "#1594 every package-version proof in the release workflow goes through pkgversion.sh" {
+    # The buco this issue names: before it, the two version proofs that existed
+    # both read `version.sh shottino`, so a restamp of the BOUNCER's number was
+    # unobservable. Four proofs now — bouncer and client, deb and rpm — and
+    # each one derives its expected value here.
+    [ "$(grep -cF 'pkgversion.sh deb grappa' "$WORKFLOW")" -eq 1 ]
+    [ "$(grep -cF 'pkgversion.sh rpm grappa' "$WORKFLOW")" -eq 1 ]
+    [ "$(grep -cF 'pkgversion.sh deb shottino' "$WORKFLOW")" -eq 1 ]
+    [ "$(grep -cF 'pkgversion.sh rpm shottino' "$WORKFLOW")" -eq 1 ]
+}
+
+@test "#1594 the only surviving raw-carrier proof is the Arch one, whose map is not nfpm's" {
+    # `version.sh shottino` was the OLD oracle for BOTH nfpm proofs. It answers
+    # "what does version.h say" and not "what did nfpm stamp"; leaving one
+    # behind would restore the gap for that format only, which is the shape
+    # that hid it for three releases.
+    #
+    # The `arch` job keeps it, and that is not an oversight: makepkg has its
+    # own `pkgver` rules — it REFUSES a hyphen outright rather than re-spelling
+    # it (#1591) — so routing it through an nfpm-shaped map would assert a
+    # transform pacman never performs. Derived, not asserted by eye: the one
+    # remaining call is inside the arch job's line range.
+    hits="$(grep -nE 'packaging/version\.sh (grappa|shottino)' "$WORKFLOW" | cut -d: -f1)"
+    [ "$(printf '%s\n' "$hits" | grep -c .)" -eq 1 ]
+
+    arch_start="$(grep -n '^  arch:$' "$WORKFLOW" | cut -d: -f1)"
+    [ -n "$arch_start" ]
+    # The next top-level job key after `arch:` bounds the block.
+    arch_end="$(awk -v s="$arch_start" 'NR > s && /^  [a-z][a-z0-9_-]*:$/ { print NR; exit }' "$WORKFLOW")"
+    [ -n "$arch_end" ]
+
+    [ "$hits" -gt "$arch_start" ]
+    [ "$hits" -lt "$arch_end" ]
+}
+
+@test "#1594 the bouncer package's stamped version is read off the ARTEFACT, per format" {
+    # Same discipline as every other proof in those jobs: assert on the built
+    # package, not on the tree that produced it. `Grappa.Version.current()` is
+    # already proved elsewhere and is a DIFFERENT claim — it is the number the
+    # BEAM reports, which nfpm never touches.
+    grep -qF 'dpkg-deb -f "$deb" Version' "$WORKFLOW"
+    grep -qF "rpm -qp --queryformat '%{VERSION}'" "$WORKFLOW"
+}

--- a/test/infra/packaging_shottino_pkg_test.bats
+++ b/test/infra/packaging_shottino_pkg_test.bats
@@ -282,9 +282,36 @@ upload_dirs() {
     # Deb and RPM SPELL a relation differently and `replaces` reaches both, so
     # it is written per-format. The Debian spelling is what deb.breaks and
     # overrides.deb.replaces carry; overrides.rpm.replaces carries the rpm one.
-    [ "$(grep -cF -- '- grappa (<< 1.3.0)' "$NFPM_CLIENT")" -eq 2 ]
-    [ "$(grep -cF -- '- grappa < 1.3.0' "$NFPM_CLIENT")" -eq 1 ]
+    #
+    # The trailing `~` is #1594's — see the case below for what it buys. The
+    # rpm row is anchored on the end of line because `- grappa < 1.3.0` is a
+    # PREFIX of `- grappa < 1.3.0~`: an unanchored fixed-string count cannot
+    # tell the pre-#1594 spelling from the cured one and would pass either way.
+    [ "$(grep -cF -- '- grappa (<< 1.3.0~)' "$NFPM_CLIENT")" -eq 2 ]
+    [ "$(grep -cE -- '^[[:space:]]+- grappa < 1\.3\.0~$' "$NFPM_CLIENT")" -eq 1 ]
     grep -q '^  breaks:$' "$NFPM_CLIENT"
+}
+
+@test "#1594 the boundary carries the pre-release epsilon, or it captures its own rc" {
+    # `~` sorts BELOW the empty string in dpkg AND in rpm version ordering, so
+    # a bare `1.3.0` boundary is strictly greater than `1.3.0~rc1` — which is
+    # exactly what nfpm stamps for a `1.3.0-rc1` VERSION file. Cutting
+    # v1.3.0-rc1 therefore made the two packages mutually uninstallable: apt
+    # exit 100, dnf exit 1, both at the *Install BOTH packages* step.
+    #
+    # `1.3.0~` is the boundary that means "everything before 1.3.0, its own
+    # pre-releases NOT included". Measured through the resolvers, not derived
+    # from the ordering rule: with the bare boundary a 1.3.0~rc1 pair REFUSES
+    # and with this one it INSTALLS, while 1.2.0 and 1.2.9 keep REFUSING on
+    # both — the guard is moved, not disarmed. See DESIGN_NOTES #1594.
+    #
+    # This case is deliberately separate from the syntax case above: that one
+    # is about each format's spelling, this one is about the boundary VALUE.
+    refute grep -qE -- '- grappa \(<< 1\.3\.0\)[[:space:]]*$' "$NFPM_CLIENT"
+    refute grep -qE -- '- grappa < 1\.3\.0[[:space:]]*$' "$NFPM_CLIENT"
+    # Every relation naming grappa ends at the epsilon — no third spelling
+    # crept in under one of the three keys.
+    [ "$(grep -cE -- '^[[:space:]]+- grappa ?[(<].*1\.3\.0~\)?$' "$NFPM_CLIENT")" -eq 3 ]
 }
 
 @test "#1447 no Debian-spelled relation is offered to the rpm renderer" {


### PR DESCRIPTION
Fixes the deb + rpm half of the `v1.3.0-rc1` release failure (#1594). The
arch half (#1591) is untouched — different file, different mechanism, no line
overlap.

## First, the question the paletti demand be asked out loud

**Does this close with one line of documentation?** No, and the reason is
specific rather than reflexive: #1591 measured that `publish` runs under
`if: !cancelled()` and *marks a partial release* rather than failing the cut,
so the failure mode is a **public, partial GitHub Release**, not an error a
reader can route around. A documented "do not install both packages at a
pre-release" would be documenting a broken product. The cure is three
characters in a constant.

## The defect

nfpm re-spells a semver pre-release with a tilde, so `1.3.0-rc1` reached the
resolvers as `1.3.0~rc1`. `~` sorts BELOW the empty string in both dpkg and
rpm ordering. shottino's takeover boundary was the bare constant `1.3.0`, so
it captured **the release candidate of the very release that defines the
boundary** — shottino asserting that a grappa which does not own
`/usr/bin/shottino` still owns it. apt exit 100, dnf exit 1, both at
*Install BOTH packages*.

## Measured, not derived

Everything below is a measurement on the images the release jobs use
(`ubuntu:24.04`, `fedora:43`, `--platform linux/amd64`) with the **pinned
nfpm 2.43.0** `build.sh` downloads, reading fields off the **artefact**.

**The nfpm map** — six shapes, `1.3.0` as the positive control:

| VERSION file | deb `Version` | rpm `Version` | rpm `Release` |
|---|---|---|---|
| `1.3.0` | `1.3.0` | `1.3.0` | `1` |
| `1.3.0-rc1` | `1.3.0~rc1` | `1.3.0~rc1` | `1` |
| `1.3.0-rc.1` | `1.3.0~rc.1` | `1.3.0~rc.1` | `1` |
| `1.3.0-rc-1` | `1.3.0~rc-1` | `1.3.0~rc_1` | `1` |
| `1.3.0+foo` | `1.3.0+foo` | `1.3.0+foo` | `1` |
| `1.3.0-rc1+foo` | `1.3.0~rc1+foo` | `1.3.0~rc1+foo` | `1` |

First `-` → `~` in both formats; on rpm every further `-` → `_`; a pre-release
is never split into `Release`. This closes the "rpm/deb side" non-measure
#1591 declared.

**The resolvers' verdict** — a `Breaks` that *can* capture is not one that
*has* captured, so the boundary was proven by asking apt and dnf to install
the pair. Identical on both formats:

| grappa | `<< 1.3.0` (before) | `<< 1.3.0~` (after) |
|---|---|---|
| `1.2.0` | REFUSES | REFUSES |
| `1.2.9` | REFUSES | REFUSES |
| `1.3.0-rc1` → `1.3.0~rc1` | **REFUSES** | **INSTALLS** |
| `1.3.0` | INSTALLS | INSTALLS |

**Exactly one cell moves** — the guard is relocated, not disarmed, which is
the row a `<< 0` "fix" would have got wrong. The pre-cure refusals reproduce
the CI logs verbatim (`Breaks: grappa (< 1.3.0) but 1.3.0~rc1 is to be
installed`; `obsoletes grappa < 1.3.0 provided by grappa-1.3.0~rc1-1.x86_64`).

**And the decision-relevant row: a bare `1.3.0` installs cleanly on both
sides.** #1591 called that "the single most decision-relevant open question"
and derived it; measured, the derivation holds. **Cutting 1.3.0 FINAL was
never blocked.** This is a fix for the next pre-release, and `v1.3.0-rc1`
stays untouched.

## The other half — the hole the issue names, and it is the bigger one

Both existing package-version proofs compared against `version.sh shottino`,
the **client's** carrier, which a grappa bump does not touch. The bouncer
package's stamped number was unasserted in both formats: nfpm restamped it
and nothing could have noticed. (`grappa eval` next door is a different
claim — the number the BEAM reports, which nfpm never touches.)

`infra/packaging/pkgversion.sh <deb|rpm> <component>` is the shared oracle for
the measured map, and all four packages now assert against it. A **sibling**
of `version.sh`, not a flag on it: one answers *which file carries the
number*, the other *what the packager writes down*. It refuses on a missing
or unknown format — an oracle that guessed would compare a `.rpm` against the
deb spelling and agree on every version without a hyphen, i.e. every version
this repo has cut but one.

The `arch` job keeps `version.sh shottino` on purpose, and the suite *derives*
that rather than trusting it (the call must sit inside the arch job's line
range): makepkg refuses a hyphen in `pkgver` instead of re-spelling it
(#1591), so an nfpm-shaped map there would assert a transform pacman never
performs.

## Every new assertion was mutated red

| mutant | killed |
|---|---|
| all three relations back to bare `1.3.0` | both boundary cases |
| **only** the rpm relation back to bare | both — and on the same mutant the PRE-#1594 unanchored `grep -cF` still answers **1** while the new anchored one answers **0**, which is the measured reason the anchor exists (`grappa < 1.3.0` is a PREFIX of `grappa < 1.3.0~`) |
| `pkgversion.sh deb grappa` → `version.sh grappa` in the workflow | the two workflow-wiring cases, and only those |
| rpm map loses its further-hyphen pass | the rpm map case, and only that one — deb and the bare control stay green |

And the CI gate itself, run for real against nfpm artefacts rather than
through bats: with the shipped oracle it PASSES on `1.3.0~rc1`, with the
pre-cure oracle it FAILS on the same artefact. On a bare version **both**
pass — which is precisely why the hole survived 23 tags.

## Not established

- Nothing ran at a real tag; the measurements use fixture packages, not the
  37 MB bouncer with its ERTS payload.
- The new CI gates have not run **in** CI. They are proven locally, above.
- amd64 only, on those two images.
- `Release` beyond nfpm's default `1` is unmeasured — the rpm gate refuses a
  non-`1` value rather than guessing.
- The partial-release posture (`publish` under `if: !cancelled()`) was neither
  measured nor changed here.
- The Arch leg stays broken; it is #1591's.
