### PR TITLE
packaging(#1591): a pre-release VERSION builds the Arch package, and a red leg stops publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1110,6 +1110,10 @@ jobs:
     # withhold the artifacts that built green: the attach step collects whatever
     # actually downloaded and fails loudly only if NOTHING did. The failed leg
     # stays red on its own, so the run is still marked failed and gets fixed.
+    # NARROWED BY #1591: the step still RUNS on a red leg, but it now refuses
+    # to CREATE a release from an incomplete set — that publication cannot be
+    # taken back. Topping up an EXISTING release is unchanged. The gate is in
+    # the attach step, not here, because it needs the downloaded asset set.
     # ALSO skipped on a docker-image dry-run dispatch (its needs are skipped and
     # there is nothing to publish) — else it would fail "no artifacts present".
     if: ${{ !cancelled() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation)) }}
@@ -1139,7 +1143,7 @@ jobs:
         with:
           path: assets
 
-      - name: Attach whatever built, audit the set, mark a partial release
+      - name: Audit the set, refuse to create a partial release, attach what built
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -1162,6 +1166,36 @@ jobs:
             exit 1
           fi
           printf 'attaching: %s\n' "${assets[@]}"
+
+          # #1591 — CREATING a release is irreversible in a way topping one up
+          # is not: `gh release create` publishes, and deleting the tag
+          # afterwards does not retract it. Cutting v1.3.0-rc1 did exactly
+          # that, with a dead Arch leg and a public release object. So the
+          # #504/#573 posture is kept where its reasoning holds — an existing
+          # release still gets whatever built, marked partial — and refused
+          # where it does not: the first run of a fresh tag must be complete.
+          # A re-run after the fix then CREATES the release cleanly, which the
+          # old order could not do at all.
+          #
+          # `gh release view` failing is read as "absent", the conservative
+          # side: a probe that errors for an unrelated reason makes this
+          # refuse, never publish.
+          release_state=absent
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            release_state=present
+          fi
+          if verdict="$(infra/packaging/release_assets.sh publishable assets "$release_state")"; then
+            [ -z "$verdict" ] || printf '%s\n' "$verdict"
+          else
+            printf '%s\n' "$verdict"
+            {
+              echo "## ⛔ Release NOT created"
+              echo
+              printf '%s\n' "$verdict"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::incomplete package set — refusing to create a new release for ${RELEASE_TAG} (#1591)"
+            exit 1
+          fi
 
           # Create the release on first run; on a re-run (or a #573 (b) repair
           # dispatch to an existing release) fall back to uploading with

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -458,6 +458,51 @@ jobs:
           [ "$got" = "$want" ] || {
             echo "::error::the Arch client package is stamped '$got', expected '$want'"; exit 1; }
 
+      # The BOUNCER's own number, which nothing in this workflow used to check
+      # (#1591). Both existing package-version gates — the deb job's and the
+      # rpm job's — compare against the SHOTTINO carrier, so a restamped
+      # grappa version would be seen by nobody. That was an omission while
+      # pkgver was a verbatim copy of VERSION; since #1591 the Arch number is
+      # deliberately TRANSFORMED (makepkg refuses the hyphen a semver
+      # pre-release spells its suffix with), and an unchecked transformation
+      # is the difference between a derivation and a hope.
+      #
+      # `cut -d- -f1` splits off pkgrel and is safe by construction: pkgver.sh
+      # guarantees the value it returns holds no hyphen — that is its job.
+      - name: Prove the derived pkgver reached the built bouncer package
+        run: |
+          want="$(infra/packaging/aur/pkgver.sh "$(infra/packaging/version.sh)")"
+          got="$(pacman -Q grappa | awk '{print $2}' | cut -d- -f1)"
+          echo "bouncer package version: '$got' (want '$want')"
+          [ "$got" = "$want" ] || {
+            echo "::error::the Arch bouncer package is stamped '$got', expected '$want'"; exit 1; }
+
+      # The ordering claim the mapping's SPELLING rests on, re-measured with
+      # the real comparator on a real Arch box. `1.3.0-rc1` maps to
+      # `1.3.0rc1`, which sorts BELOW `1.3.0`; the Arch-conventional
+      # `1.3.0_rc1` sorts ABOVE it and would strand every user who installed
+      # the rc, since pacman would never offer them the release. pkgver.sh
+      # encodes that as a shape rule (its bats suite runs on a host with no
+      # pacman); this is the rule's source of truth, asserted at the only
+      # moment a pre-release can reach a user.
+      #
+      # A no-op on a bare release, and it says so out loud rather than
+      # reporting a green it never computed.
+      - name: Prove a pre-release pkgver sorts BELOW its own release
+        run: |
+          srcv="$(infra/packaging/version.sh)"
+          core="${srcv%%-*}"
+          if [ "$core" = "$srcv" ]; then
+            echo "VERSION is $srcv — no pre-release suffix, nothing to order"
+            exit 0
+          fi
+          pkgver="$(infra/packaging/aur/pkgver.sh "$srcv")"
+          cmp="$(vercmp "$pkgver" "$core")"
+          echo "vercmp $pkgver $core = $cmp (want a negative number)"
+          [ "$cmp" -lt 0 ] || {
+            echo "::error::pkgver '$pkgver' does not sort below '$core' — pacman would never offer the $core upgrade"
+            exit 1; }
+
       - name: Stage Arch artifacts (packages + regenerated recipe metadata)
         run: |
           mkdir -p arch-out

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54832,3 +54832,151 @@ that makes one of them urgent has not happened yet.
 - **Write-side cost of the index changes.** The 2.4x covering index adds one
   b-tree; its INSERT cost was not measured here (#1372 measured that
   widening an existing index is free and that adding new ones is not).
+<!-- entry #1591 -->
+
+---
+
+## 2026-08-20 — #1591: a pre-release `VERSION` could not build the Arch package, and a red leg still published
+
+Cutting `v1.3.0-rc1` — the first pre-release in 23 tags — killed the `arch` job
+of `release.yml` and still produced a **public GitHub Release with `assets=0`**.
+Two defects, one tag. Deleting the tag afterwards does not retract the release,
+which is why this was not closeable with a line of documentation: that question
+was asked first, and the answer is that a doc line cannot stop CI from
+performing an irreversible outward-facing act.
+
+### Why `VERSION` was not the place to fix it
+
+`makepkg` refuses a hyphen in `pkgver`. Reproduced here in
+`menci/archlinuxarm:base-devel` with the issue's own harness shape — a minimal
+PKGBUILD per candidate, driven by the invocation `release.yml` uses, with
+known-answer controls: `1.3.0` rc=0 (positive control), **`1.3.0-rc1` rc=12**
+(`ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or
+whitespace`), `@GRAPPA_VERSION@` rc=0. The lint is
+`[[ $ver = *[[:space:]/:-]* ]]`, in makepkg's own
+`lint_pkgbuild/pkgver.sh` — architecture-independent shell, which is why an
+ARM Arch container is an honest stand-in for the x86_64 runner.
+
+`VERSION` feeds `mix.exs` and the OTP application vsn, and the alternative
+spellings measure badly (`1.3.0rc1` / `1.3.0_rc1` are `:error` from
+`Version.parse/1`; `1.3.0+rc1` parses but compares `:eq` with `1.3.0`, since
+semver build metadata takes no part in precedence). So the number stays semver
+and the transformation happens at the `pkgver` boundary, where makepkg's
+constraint actually lives: `infra/packaging/aur/pkgver.sh`.
+
+### The spelling is a measured constraint, and it reverses the Arch convention
+
+Every candidate BUILDS. Only one ORDERS right. `vercmp <candidate> 1.3.0`,
+pacman 7.1.0, all five at build rc=0:
+
+| `pkgver` | `vercmp` vs `1.3.0` | meaning |
+|---|---|---|
+| **`1.3.0rc1`** | **−1** | **older than its release — correct** |
+| `1.3.0_rc1` | +1 | newer — the Arch-conventional underscore INVERTS it |
+| `1.3.0.rc1` | +1 | |
+| `1.3.0+rc1` | +1 | |
+| `1.3.0~rc1` | +1 | no tilde semantics here, unlike deb |
+
+pacman's comparator explains the split, and the source agrees with the
+measurement rather than being substituted for it: the segment loop is
+`while (*one && *two) { skip separators; … }`, so when the shorter side runs
+out the loop exits **at the condition** and the leftover separator is never
+skipped; the tie-break that follows is `isalpha(*one) ? -1 : 1`
+(`lib/libalpm/version.c`, *"we never want a remaining alpha string to beat an
+empty string"*). **A letter left over means older; a separator left over means
+newer.** Hence: delete the hyphen, join nothing in its place. A future edit
+that "corrects" this to the wiki-conventional `_` would strand every user who
+installed an rc — pacman would never offer them the release.
+
+**This settles a question the issue recorded as NOT MEASURED:** `makepkg` does
+accept `+` in `pkgver` (rc=0). It changes nothing here — the cure does not rest
+on `+`, because `1.3.0+rc1` measures `+1` on the axis that matters.
+
+### Fail closed, not best effort
+
+The same tie-break makes one legal semver shape unmappable. `1.3.0-1` sorts
+below `1.3.0`, but `1.3.01` leaves a DIGIT at the tie-break and measures `+1`.
+No spelling saves it, so `pkgver.sh` refuses to derive (exit 2, naming the
+reason) rather than publish a pre-release that outranks its own release. That
+refusal is why this is a script and not a `sed`.
+
+### `pkgver` stopped being the tag
+
+Once the two can differ, `source=(… v${pkgver}.tar.gz)` names a tag nobody cut.
+The bouncer recipe now carries `_grappaver=@GRAPPA_VERSION@` and spells its
+`source` and `_srcdir` with it — the same shape `aur/shottino/PKGBUILD` has
+carried since #1447, for a neighbouring reason: there `_grappaver` is a
+different NUMBER, here a different SPELLING of the same one. `regen.sh`'s
+`_grappaver` sed, a deliberate no-op on the bouncer's file until now, becomes
+live rather than being added. Both recipes route their `pkgver` through the
+mapper: the client's carrier can grow a pre-release the same way.
+
+### The gate the issue named, closed on the Arch side only
+
+Nothing in the pipeline asserted grappa's own package number — both existing
+package-version gates (`dpkg-deb -f … Version`, `rpm -qp … %{VERSION}`) compare
+against the **shottino** carrier, so a restamp of grappa's number would be seen
+by nobody. That was an omission while `pkgver` was a verbatim copy; with a
+deliberate transformation it is the difference between a derivation and a hope.
+The `arch` job now asserts `pacman -Q grappa` against `pkgver.sh`'s output, and
+— on a pre-release only, saying so out loud otherwise — re-checks the ordering
+with the real `vercmp`.
+
+Both gates were proven by mutating the production they guard, each run
+verbatim (extracted from the workflow, so a paraphrase cannot drift from it)
+against a real Arch box with a genuinely installed `grappa` package. They are
+complementary, not redundant: a **restamped package** kills the first and
+leaves the second green; a **mapper changed to the `_` join, with the package
+rebuilt from it**, leaves the first green — blind by construction, both sides
+moved — and kills the second.
+
+**The deb/rpm half of that hole is deliberately NOT closed here.** Those gates
+live in jobs owned by concurrent work on #1594 (nfpm's own pre-release
+restamping); closing them from this branch would collide with it. Named, not
+fixed.
+
+### `publish` no longer CREATES a partial release — a deliberate behaviour change
+
+`publish` declares `needs: [deb, arch, rpm]` but runs on `if: !cancelled()`,
+and its attach step was named *"mark a partial release"*: a red leg still
+reached `gh release create`. #504/#573 chose that, and the reasoning holds for
+a release that **already exists** — attaching what built is the only way to
+complete one, and it is exactly what the "(b) repair" dispatch does. It does
+not hold for the first run of a fresh tag, where the same rule performs an
+unretractable publication.
+
+So the rule is now completeness **×** does-the-release-exist, expressed as
+`release_assets.sh publishable <dir> <absent|present>` — in that script because
+it is the same expected-kinds table the rest of it owns, and because a
+two-variable rule inlined in YAML is precisely what #573 was filed about. The
+workflow probes with `gh release view` and reads a FAILING probe as `absent`,
+the conservative side. Net effect: an incomplete first run now stops before
+creating anything and a re-run after the fix creates the release cleanly —
+which the old order could not do at all, since the partial already existed.
+
+### Not established
+
+- **The real Arch package was never built.** It needs elixir + bun on x86_64
+  and a real tag tarball. What ran end-to-end is `regen.sh` itself on a real
+  Arch box with `updpkgsums` stubbed (it fetches over the network and is not
+  what is under test): `origin/main` + `1.3.0` → rc=0, `origin/main` +
+  `1.3.0-rc1` → **rc=12**, this branch + `1.3.0` → rc=0 with a `.SRCINFO`
+  identical to the base's, this branch + `1.3.0-rc1` → rc=0 with
+  `pkgver=1.3.0rc1`, `_grappaver=1.3.0-rc1` and the tag URL intact, this branch
+  + `1.3.0-1` → rc=2 before makepkg. The package-version gate ran against a
+  stand-in package genuinely named `grappa` and genuinely installed, not
+  against the bouncer.
+- **Measured on ARM, not on the release runner.** The pkgver lint and `vercmp`
+  are architecture-independent by inspection of their source; that is an
+  argument, not a second measurement.
+- **No `epoch`.** The mapped pre-release sorts below its release, so the Arch
+  escape hatch for inverted pre-release ordering is not needed — and `epoch`
+  is a one-way door that every later release would have to carry. Recorded as
+  the remedy if the mapping ever has to change.
+- **The mapping is not injective**: `1.3.0-rc-1` and `1.3.0-rc1` map onto one
+  `pkgver`. Two pre-releases of one release colliding is a naming annoyance;
+  the ordering property is what breaks an upgrade path, and it is preserved.
+  Accepted, not machinery.
+- **`publishable`'s `present` branch was not exercised against real `gh`.** The
+  five bats cases drive the decision table; the `gh release view` probe that
+  feeds it is inline YAML and untested, like every other `gh` call in that job.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54838,8 +54838,9 @@ that makes one of them urgent has not happened yet.
 
 ## 2026-08-20 — #1591: a pre-release `VERSION` could not build the Arch package, and a red leg still published
 
-Cutting `v1.3.0-rc1` — the first pre-release in 23 tags — killed the `arch` job
-of `release.yml` and still produced a **public GitHub Release with `assets=0`**.
+Cutting `v1.3.0-rc1` — the first and only pre-release among the repository's
+tags — killed the `arch` job of `release.yml` and still produced a **public
+GitHub Release with `assets=0`**.
 Two defects, one tag. Deleting the tag afterwards does not retract the release,
 which is why this was not closeable with a line of documentation: that question
 was asked first, and the answer is that a doc line cannot stop CI from
@@ -54980,3 +54981,14 @@ which the old order could not do at all, since the partial already existed.
 - **`publishable`'s `present` branch was not exercised against real `gh`.** The
   five bats cases drive the decision table; the `gh release view` probe that
   feeds it is inline YAML and untested, like every other `gh` call in that job.
+
+### One line of the issue does not survive measurement
+
+The issue records **"23 tags, zero pre-releases"**. Measured against
+`git ls-remote --tags origin`, the authoritative set: **22** tags matching
+`v*`, of which **one** — `v1.3.0-rc1` — is a pre-release. The zero is a
+sentence the tag it describes overtook (the issue says as much: *"`v1.3.0-rc1`
+is being cut anyway"*); where the 23 came from is not established, and it is
+not restated here. Nothing downstream rests on either number: the identity
+case is pinned by shape ("every tag that predates `v1.3.0-rc1`"), never by a
+count.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4065,7 +4065,9 @@ several other sections point at:
   `nfpm.yaml` interpolates into `version:` for BOTH the `.deb` and the
   `.rpm`.
 - `release.yml`'s Arch job and `aur/regen.sh` run it to fill PKGBUILD's
-  `pkgver=@GRAPPA_VERSION@` sentinel before `makepkg`.
+  `pkgver=@GRAPPA_VERSION@` sentinel before `makepkg` — **through
+  `aur/pkgver.sh`, which is not the identity on a pre-release** (#1591,
+  below).
 - Every cicchetto build entrypoint exports `GRAPPA_VERSION` from it so
   vite can bake `<meta cicchetto-version>`: `scripts/bun.sh`,
   `scripts/deploy.sh`, `scripts/deploy-cic.sh`, `scripts/integration.sh`,
@@ -4082,6 +4084,64 @@ path with no local signal. The `deb` and `arch` release jobs both assert
 `v$tag == $(infra/packaging/version.sh)` before building, and
 `test/grappa/version_single_source_test.exs` fails if the committed
 PKGBUILD stops carrying the sentinel.
+
+#### A pre-release `VERSION` and the Arch `pkgver` (#1591)
+
+**`makepkg` refuses a hyphen in `pkgver`** — measured rc=12, *"pkgver is
+not allowed to contain colons, forward slashes, hyphens or whitespace"*,
+from its own lint (`[[ $ver = *[[:space:]/:-]* ]]`,
+`/usr/share/makepkg/lint_pkgbuild/pkgver.sh`). A semver pre-release
+spells its suffix with exactly that character, so `v1.3.0-rc1` — the
+first pre-release in 23 tags — killed the `arch` job.
+
+**`VERSION` is not the place to fix it.** It feeds `mix.exs` and the OTP
+application vsn, and the alternatives measure badly: `1.3.0rc1` and
+`1.3.0_rc1` are `:error` from `Version.parse/1`, and `1.3.0+rc1` parses
+but `Version.compare("1.3.0+rc1", "1.3.0")` is `:eq` — build metadata
+takes no part in semver precedence, so it would order as the final
+release. The number stays semver and the transformation happens at the
+`pkgver` boundary, in **`infra/packaging/aur/pkgver.sh`**:
+
+    pkgver.sh 1.3.0      -> 1.3.0        identity — every tag cut so far
+    pkgver.sh 1.3.0-rc1  -> 1.3.0rc1
+    pkgver.sh 1.3.0-1    -> refused, exit 2
+
+**The spelling is not free.** Every candidate BUILDS; only one ORDERS
+right. `vercmp <candidate> 1.3.0` on pacman 7.1.0 measures `1.3.0rc1` at
+`-1` (older than its release, correct) and `1.3.0_rc1`, `1.3.0.rc1`,
+`1.3.0+rc1`, `1.3.0~rc1` all at `+1`. **The Arch-conventional underscore
+is the wrong answer here**: a user who installed the rc would never be
+offered the release. pacman's comparator explains it — its segment loop
+is `while (*one && *two) { skip separators; … }`, so when the shorter
+side runs out the loop exits at the condition and the leftover separator
+is never skipped; the tie-break is then `isalpha(*one) ? -1 : 1`
+(`lib/libalpm/version.c`). A **letter** left over means older; a
+separator left over means newer.
+
+That same tie-break is why the mapper **fails closed**: `1.3.0-1` is
+legal semver sorting below `1.3.0`, but `1.3.01` leaves a digit at the
+tie-break and measures `+1`. No spelling saves it, so `pkgver.sh` refuses
+to derive rather than publish a package that outranks its own release.
+
+Consequences to know when touching the Arch recipes:
+
+- **`pkgver` is no longer the tag.** The bouncer recipe's `source` and
+  `_srcdir` now spell it `${_grappaver}`, the second `@GRAPPA_VERSION@`
+  sentinel `regen.sh` fills with the RAW version — `v${pkgver}` would
+  name a tag nobody cut. The client recipe has done this since #1447.
+- **Both recipes map.** The client's carrier can grow a pre-release the
+  same way, so `regen.sh` routes both numbers through `pkgver.sh`.
+- **The `arch` job now asserts its own output**: `pacman -Q grappa` must
+  carry the derived `pkgver`, and on a pre-release `vercmp` must put it
+  below the release core. Before #1591 nothing in the pipeline checked
+  grappa's package number at all — the `deb` and `rpm` version gates
+  both compare against the *shottino* carrier.
+- Pinned by `test/infra/packaging_prerelease_pkgver_test.bats` (the
+  mapping and its refusals, host-side, no pacman needed).
+
+**Publishing an Arch pre-release to the AUR is still a human step**, and
+the ordering above is the reason to think twice before doing it: pacman
+has no `epoch`-free way back if the mapping ever changes.
 
 ### `build.sh` — one throwaway build tree, one format at a time
 
@@ -4225,6 +4285,27 @@ The logic lives in a script rather than inline in `release.yml` precisely
 because the bug lived in untested inline YAML: it is pure filesystem +
 string logic — no docker, no network, no mix — so it runs under bats
 (`test/infra/release_assets_test.bats`).
+
+**`publishable <dir> <absent|present>` — the narrowing #1591 applied.**
+`publish` declares `needs: [deb, arch, rpm]` but runs on
+`if: !cancelled()`, so a red package leg still reached `gh release
+create`. That is #504/#573's deliberate choice and it is right *for a
+release that already exists*: attaching what built is the only way to
+complete one, and it is exactly what the "(b) repair" dispatch does. It
+is **not** right for the first run of a fresh tag, where the same rule
+publishes a partial release — and publication cannot be taken back:
+deleting the tag afterwards does not retract it. Cutting `v1.3.0-rc1`
+produced precisely that, a public release object with `assets=0`.
+
+So the decision is completeness **×** does-the-release-exist, and it
+lives in this script for the same reason the rest does. The workflow
+probes with `gh release view` and reads a FAILING probe as `absent`, the
+conservative side: an errored probe makes publish refuse, never publish.
+An incomplete set against `absent` exits non-zero naming every missing
+kind, and the run stops before creating anything — a re-run after the fix
+then creates the release cleanly, which the old order could not do at
+all. An incomplete set against `present` proceeds and marks the release
+partial, unchanged.
 
 ### The packaged operator CLI and the migrate path (#419)
 

--- a/infra/packaging/README.md
+++ b/infra/packaging/README.md
@@ -95,6 +95,16 @@ carrier, and `_grappaver=@GRAPPA_VERSION@` naming the tag whose tarball
 holds the source. `aur/regen.sh` fills both and regenerates both
 `.SRCINFO`s; `test/grappa/version_single_source_test.exs` pins all of it.
 
+Since #1591 the **bouncer** recipe carries `_grappaver` too, for a
+different reason: `makepkg` refuses the hyphen a semver pre-release spells
+its suffix with, so `aur/pkgver.sh` maps `1.3.0-rc1` onto `1.3.0rc1` and
+`pkgver` stops being the tag. There it is a different SPELLING of the same
+number; in the client recipe it is a different number. Both recipes route
+their `pkgver` through the mapper, which is the identity on a bare
+`X.Y.Z`. Why that spelling and not the Arch-conventional underscore — a
+measured ordering property, not taste — is in `aur/pkgver.sh`'s header and
+`docs/OPERATIONS.md` § "A pre-release `VERSION` and the Arch `pkgver`".
+
 Both halves are pinned by `test/infra/packaging_shottino_pkg_test.bats`,
 and the release audit (`release_assets.sh`) now expects the client's
 packages **by name** — a release that builds the bouncer and loses the

--- a/infra/packaging/aur/PKGBUILD
+++ b/infra/packaging/aur/PKGBUILD
@@ -23,8 +23,21 @@ pkgname=grappa
 # the human AUR publish) fills this from `version.sh` before makepkg. The
 # `@GRAPPA_VERSION@` sentinel is deliberate: makepkg's pkgver lint REFUSES '@',
 # so an underived build fails loudly instead of shipping `grappa-@GRAPPA_VERSION@`.
+#
+# DERIVED ≠ EQUAL, since #1591: makepkg's same lint refuses the hyphen a
+# semver pre-release spells its suffix with, so `regen.sh` fills this through
+# `pkgver.sh`, which maps `1.3.0-rc1` onto `1.3.0rc1` — the only spelling that
+# both builds and `vercmp`s BELOW the release it precedes (the header of that
+# script carries the measurement). On a bare `X.Y.Z` the map is the identity.
 pkgver=@GRAPPA_VERSION@
 pkgrel=1
+# The grappa TAG that carries the source, and a SECOND carrier from pkgver
+# even though both sentinels read `@GRAPPA_VERSION@`: a mapped pre-release
+# makes them differ, and `v${pkgver}` would then name a tag nobody ever cut.
+# The client recipe has carried this for the same reason since #1447 — there
+# because its pkgver is a different NUMBER, here because it is a different
+# SPELLING of the same one. Everything about the source is spelled with it.
+_grappaver=@GRAPPA_VERSION@
 pkgdesc="Always-on IRC bouncer with a REST + Phoenix Channels API and a bundled web PWA (cicchetto)"
 arch=('x86_64')
 url="https://github.com/vjt/grappa-irc"
@@ -58,7 +71,7 @@ optdepends=('shottino: the terminal client, now its own package (#1447)'
             'ffmpeg: strip metadata from video uploads (#39)'
             'nginx: TLS + static reverse proxy (recommended, not required)')
 install="${pkgname}.install"
-source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+source=("${pkgname}-${_grappaver}.tar.gz::${url}/archive/refs/tags/v${_grappaver}.tar.gz")
 # SKIP until the vX.Y.Z tag exists: the release step regenerates this with
 # `updpkgsums` (and .SRCINFO with `makepkg --printsrcinfo`). See README.md.
 sha256sums=('SKIP')
@@ -68,8 +81,9 @@ sha256sums=('SKIP')
 # proven-good .deb payload, which nfpm never strips.
 options=('!strip' '!debug')
 
-# GitHub tag tarballs extract to <repo>-<version>/ = grappa-irc-<pkgver>/.
-_srcdir="grappa-irc-${pkgver}"
+# GitHub tag tarballs extract to <repo>-<version>/ — and the version there is
+# the TAG's, which a mapped pre-release makes different from this package's.
+_srcdir="grappa-irc-${_grappaver}"
 
 build() {
 	cd "${srcdir}/${_srcdir}"

--- a/infra/packaging/aur/README.md
+++ b/infra/packaging/aur/README.md
@@ -123,7 +123,13 @@ concrete publishable recipe by `regen.sh`:
 - `pkgver=@GRAPPA_VERSION@` is a sentinel `makepkg` REFUSES (#538) — an
   underived build fails loudly instead of silently shipping
   `grappa-@GRAPPA_VERSION@`. `regen.sh` fills it from the repo-root `VERSION`
-  file, the single source of truth.
+  file, the single source of truth — **through `pkgver.sh`, which is the
+  identity on a bare `X.Y.Z` and not on a pre-release** (#1591: `makepkg`
+  refuses the hyphen too, so `1.3.0-rc1` becomes `1.3.0rc1`). That is why
+  this recipe also carries `_grappaver=@GRAPPA_VERSION@`, and why every
+  mention of the tag — `source`, `_srcdir` — is spelled with it: once the
+  two can differ, `v${pkgver}` names a tag nobody cut. The spelling is a
+  measured constraint, not a convention — see `pkgver.sh`'s header.
 - `sha256sums=('SKIP')` is a placeholder: the `vX.Y.Z` tarball does not exist
   until the tag is cut, so its real hash cannot be known yet. `regen.sh` runs
   `updpkgsums` to fill it at release.
@@ -140,9 +146,28 @@ copied here too to keep the committed snapshot honest (e.g. #527's
 `test/grappa/version_single_source_test.exs` fails if either carrier stops
 being the `@GRAPPA_VERSION@` sentinel — and, since #1447, if the client
 recipe's `pkgver` stops being `@SHOTTINO_VERSION@` or its `_grappaver` stops
-being `@GRAPPA_VERSION@`. What that guard does NOT do is compare a `PKGBUILD`
-with its `.SRCINFO` field by field: the structural mirroring above stays a
-human discipline, and the only full regeneration is `regen.sh`'s.
+being `@GRAPPA_VERSION@`, and since #1591 if the BOUNCER recipe loses its
+`_grappaver` or goes back to spelling its source `v${pkgver}`. What that
+guard does NOT do is compare a `PKGBUILD` with its `.SRCINFO` field by
+field: the structural mirroring above stays a human discipline, and the
+only full regeneration is `regen.sh`'s.
+
+## Publishing a PRE-RELEASE to the AUR — read this first (#1591)
+
+The release job builds and proves an Arch package for a pre-release tag,
+and `regen.sh` derives a legal `pkgver` for it (`1.3.0-rc1` → `1.3.0rc1`).
+Pushing that to the AUR is still a human decision, and one worth taking
+deliberately:
+
+- The mapped number sorts **below** its own release — measured, `vercmp
+  1.3.0rc1 1.3.0 = -1` — so a user who installs the rc is offered `1.3.0`
+  when it lands. That is the whole reason the hyphen is DELETED rather
+  than replaced with the conventional `_`, which measures `+1` and would
+  strand them. Do not "tidy" that spelling.
+- The AUR has one recipe per package, not a channel per track: publishing
+  a pre-release means every `grappa` AUR user gets it. `optdepends` and
+  `epoch` do not help. If that is not wanted, build it, prove it, and do
+  not push it — the CI leg being green is the deliverable.
 
 ## Version reporting (bare `X.Y.Z`, #419 R3)
 

--- a/infra/packaging/aur/pkgver.sh
+++ b/infra/packaging/aur/pkgver.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# pkgver.sh — map a canonical `VERSION` onto a `pkgver` makepkg accepts.
+#
+#   pkgver.sh 1.3.0        -> 1.3.0        (unchanged — every release so far)
+#   pkgver.sh 1.3.0-rc1    -> 1.3.0rc1
+#   pkgver.sh 1.3.0-1      -> refused, exit 2
+#
+# WHY THIS EXISTS AT ALL (#1591). `makepkg` refuses a hyphen in `pkgver` —
+# measured rc=12, "pkgver is not allowed to contain colons, forward slashes,
+# hyphens or whitespace", from its own lint (`[[ $ver = *[[:space:]/:-]* ]]`,
+# /usr/share/makepkg/lint_pkgbuild/pkgver.sh). A semver pre-release spells its
+# suffix with exactly that character, so cutting `v1.3.0-rc1` killed the Arch
+# leg of the release. The repo-root `VERSION` cannot dodge it: it feeds
+# `mix.exs` and the OTP application vsn, and the alternatives measured
+# `:error` from `Version.parse/1` (`1.3.0rc1`, `1.3.0_rc1`) or, for
+# `1.3.0+rc1`, compared `:eq` with `1.3.0` — build metadata takes no part in
+# semver precedence, so it would order as the final release. The number stays
+# semver; the transformation happens HERE, at the boundary where makepkg's
+# constraint actually lives.
+#
+# WHY THE SPELLING IS "DELETE THE HYPHEN, JOIN NOTHING". Because it is the
+# only one that also ORDERS right. `vercmp <candidate> 1.3.0`, pacman 7.1.0,
+# every candidate building fine (rc=0):
+#
+#     1.3.0rc1   -1   the pre-release is OLDER than its release  ← correct
+#     1.3.0_rc1  +1   NEWER — the Arch-conventional underscore inverts it
+#     1.3.0.rc1  +1
+#     1.3.0+rc1  +1
+#     1.3.0~rc1  +1
+#
+# pacman's own comparator says why. Its segment loop is
+# `while (*one && *two) { skip separators; ... }`, so when the shorter side
+# runs out the loop exits AT THE CONDITION and the leftover separator is never
+# skipped; the tie-break that follows is `isalpha(*one) ? -1 : 1`
+# (lib/libalpm/version.c — "we never want a remaining alpha string to beat an
+# empty string"). A LETTER left over means older. A separator left over means
+# newer. So the hyphen is deleted rather than replaced.
+#
+# WHY IT FAILS CLOSED. That same tie-break is why a numeric-leading
+# pre-release cannot be mapped at all: `1.3.0-1` is legal semver that sorts
+# below `1.3.0`, but `1.3.01` leaves a DIGIT at the tie-break and measures +1
+# — a pre-release package that outranks the release it precedes, so pacman
+# would never offer the upgrade. No spelling saves it, so this refuses to
+# derive a number rather than publish a wrong one. That refusal is the whole
+# reason this is a script and not a `sed`.
+#
+# NOT INJECTIVE, deliberately: a pre-release with an internal hyphen
+# (`1.3.0-rc-1`, legal semver) maps onto the same `pkgver` as `1.3.0-rc1`.
+# Two pre-releases of one release colliding is a naming annoyance; the
+# ordering property above is what actually breaks a user's upgrade path, and
+# it is preserved. Not worth machinery.
+#
+# Callers: `regen.sh` (both recipes) and the `arch` job of
+# `.github/workflows/release.yml` (which asserts the derived number reached
+# the built package, and re-checks the ordering with the real `vercmp`).
+# Takes the version as an ARGUMENT rather than reading a carrier: composing
+# with `version.sh` keeps "which file holds which number" answered in exactly
+# one place.
+#
+# POSIX sh, like its sibling `version.sh` — no bashisms, so the derived
+# dash-parse gate (scripts/posix-parse.sh) covers it.
+#
+# Why: docs/OPERATIONS.md § "Packaging (infra/packaging/)".
+set -eu
+
+die() {
+	printf 'pkgver.sh: %s\n' "$1" >&2
+	exit 2
+}
+
+version="${1:-}"
+
+[ -n "${version}" ] || die 'no version given (usage: pkgver.sh <X.Y.Z[-pre]>)'
+
+# Split on the FIRST hyphen: semver's pre-release separator. Everything before
+# it is the release core, everything after is the pre-release (which may carry
+# further hyphens of its own, and possibly `+build` metadata).
+case "${version}" in
+*-*)
+	core="${version%%-*}"
+	pre="${version#*-}"
+	;;
+*)
+	# No pre-release: byte-for-byte pass-through. Every tag cut so far takes
+	# this path, so the mapping cannot restamp a normal release.
+	printf '%s\n' "${version}"
+	exit 0
+	;;
+esac
+
+[ -n "${core}" ] || die "no release core before the '-' in '${version}'"
+[ -n "${pre}" ] || die "empty pre-release after the '-' in '${version}'"
+
+# THE ordering guard, stated as the shape pacman's tie-break reads: what is
+# left once the release's segments run out must be a LETTER. A digit there
+# makes the pre-release sort NEWER than the release it precedes.
+case "${pre}" in
+[A-Za-z]*) ;;
+*) die "pre-release '${pre}' does not start with a letter — mapping '${version}' would sort NEWER than ${core}, inverting the upgrade path (see the header)" ;;
+esac
+
+# Delete every hyphen; join nothing in its place.
+pkgver="${core}$(printf '%s' "${pre}" | tr -d '\055')"
+
+# makepkg's own refused class, transcribed from its lint. Nothing above can
+# introduce these — VERSION cannot hold them — but a derived value that
+# reaches `makepkg` unchecked is how #1591 happened in the first place.
+case "${pkgver}" in
+*[[:space:]/:-]*) die "derived pkgver '${pkgver}' still carries a character makepkg refuses" ;;
+esac
+
+printf '%s\n' "${pkgver}"

--- a/infra/packaging/aur/regen.sh
+++ b/infra/packaging/aur/regen.sh
@@ -5,8 +5,13 @@
 # TWO recipes since #1447, because they carry TWO version lines:
 #
 #   ./PKGBUILD           the bouncer      pkgver=@GRAPPA_VERSION@
+#                                         _grappaver=@GRAPPA_VERSION@
 #   ./shottino/PKGBUILD  the client       pkgver=@SHOTTINO_VERSION@
 #                                         _grappaver=@GRAPPA_VERSION@
+#
+# Both sentinels read `@GRAPPA_VERSION@` in the bouncer's recipe and are still
+# TWO carriers: since #1591 `pkgver` is the version MAPPED for makepkg and
+# `_grappaver` is the raw tag, and a pre-release makes them differ.
 #
 # A split package could not express that: PKGBUILD(5) does not let a
 # `package_*()` override `pkgver`, so both halves would take the bouncer's
@@ -35,6 +40,18 @@ AUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 version="$("${AUR_DIR}/../version.sh")"
 client_version="$("${AUR_DIR}/../version.sh" shottino)"
 
+# pkgver is NOT the version, and since #1591 that is load-bearing rather than
+# incidental. `makepkg` refuses the hyphen a semver pre-release spells its
+# suffix with, so `pkgver.sh` maps the canonical number onto one makepkg
+# accepts AND `vercmp` orders below the release it precedes — or refuses to
+# derive at all. On a bare `X.Y.Z` (every tag cut so far) it is the identity,
+# so this changes nothing for a normal release. BOTH recipes go through it:
+# the client's carrier can grow a pre-release exactly the way the bouncer's
+# did, and a second recipe that skipped the mapping would die at makepkg, at
+# release time, on a tag.
+pkgver="$("${AUR_DIR}/pkgver.sh" "${version}")"
+client_pkgver="$("${AUR_DIR}/pkgver.sh" "${client_version}")"
+
 # derive <recipe-dir> <pkgver> — fill the sentinels, checksum, regenerate.
 # One function for both recipes: the client's extra `_grappaver` is a no-op
 # sed on the bouncer's, which has no such line, so the two paths cannot drift
@@ -44,7 +61,11 @@ derive() {
 	echo "==> ${dir}: deriving pkgver=${pkgver} (#538/#652 single source)"
 	sed -i -E "s/^pkgver=.*/pkgver=${pkgver}/" "${dir}/PKGBUILD"
 	# The tag that carries the source is ALWAYS the bouncer's version, even in
-	# the recipe whose pkgver is not.
+	# the recipe whose pkgver is not — and, since #1591, even in the recipe
+	# whose pkgver is the bouncer's own MAPPED number. `v${pkgver}` would name
+	# a tag nobody cut the moment a pre-release is mapped, so BOTH recipes now
+	# spell the tag `_grappaver`, and this sed (a deliberate no-op on the
+	# bouncer's file until then) is live on both.
 	sed -i -E "s/^_grappaver=.*/_grappaver=${version}/" "${dir}/PKGBUILD"
 	(
 		cd "${dir}"
@@ -55,6 +76,6 @@ derive() {
 	)
 }
 
-derive "${AUR_DIR}" "${version}"
-derive "${AUR_DIR}/shottino" "${client_version}"
-echo "==> recipes ready: grappa=${version}, shottino=${client_version}"
+derive "${AUR_DIR}" "${pkgver}"
+derive "${AUR_DIR}/shottino" "${client_pkgver}"
+echo "==> recipes ready: grappa=${pkgver}, shottino=${client_pkgver} (tag v${version})"

--- a/infra/packaging/release_assets.sh
+++ b/infra/packaging/release_assets.sh
@@ -13,6 +13,10 @@
 #                     file, one per line. Empty output = complete set.
 #   notice <dir>      nothing if complete; else a sentinel-delimited markdown
 #                     block naming the gap.
+#   publishable <dir> <absent|present>
+#                     exit 0 when publishing may proceed. Refuses (exit 1,
+#                     reason on stdout) for an INCOMPLETE set against a
+#                     release that does not exist yet — see below.
 #   apply-body <dir>  read a release body from STDIN, strip any existing
 #                     sentinel block, and — only if the set is incomplete —
 #                     PREPEND a fresh one. Print the result. Idempotent both
@@ -107,6 +111,57 @@ notice() {
 	notice_block "$dir"
 }
 
+# publishable <dir> <absent|present> — may the publish job proceed?
+#
+# #1591. `publish` runs under `if: !cancelled()`, so a red package leg still
+# reached `gh release create` and PUBLISHED — partial, marked as such, and
+# public. #504/#573 chose that deliberately: a distro breakage must not
+# withhold the artifacts that built green, and the failed leg stays red on its
+# own. That reasoning is sound for a release that ALREADY EXISTS, where
+# attaching what built is the only way to complete it, and it is what the
+# `#573 (b)` repair dispatch is for.
+#
+# It does not survive the FIRST run of a fresh tag. There the same rule turns
+# "one leg failed" into a public artefact, and publication is not an act CI
+# can take back: deleting the tag afterwards does not retract the release.
+# Cutting `v1.3.0-rc1` did exactly this — `assets=0` on a public release
+# object — which is why the axis is completeness × does-the-release-exist,
+# not completeness alone.
+#
+# The state is an ARGUMENT rather than a probe done here: this script is pure
+# filesystem + string logic with no network and no `gh`, and the caller
+# already holds a token. Unknown states are refused rather than defaulted,
+# because the permissive default is the one that publishes.
+publishable() {
+	local dir="$1" state="$2"
+
+	case "$state" in
+		absent | present) ;;
+		*)
+			printf 'unknown release state %s (want: absent | present)\n' "${state:-<empty>}" >&2
+			return 2
+			;;
+	esac
+
+	if is_complete "$dir"; then
+		return 0
+	fi
+
+	# Incomplete against an existing release: top it up (#504/#573).
+	if [ "$state" = present ]; then
+		printf 'release already exists — attaching what built, and marking it partial (#504/#573)\n'
+		return 0
+	fi
+
+	# Incomplete against no release: refuse. Name the gap — the operator's
+	# next move is to fix that leg and re-run, and a bare refusal makes them
+	# go find out which one.
+	printf 'refusing to CREATE a release from an incomplete set — publication cannot be retracted (#1591).\n'
+	printf 'missing:\n'
+	missing "$dir" | while IFS= read -r label; do printf -- '- %s\n' "$label"; done
+	return 1
+}
+
 # strip_block — remove every existing sentinel block (inclusive) from stdin.
 strip_block() {
 	awk -v s="$SENTINEL_START" -v e="$SENTINEL_END" '
@@ -144,6 +199,10 @@ main() {
 			[ "$#" -eq 2 ] || die_usage
 			apply_body "$2"
 			;;
+		publishable)
+			[ "$#" -eq 3 ] || die_usage
+			publishable "$2" "$3"
+			;;
 		*)
 			die_usage
 			;;
@@ -152,6 +211,7 @@ main() {
 
 die_usage() {
 	printf 'usage: %s {found|missing|notice|apply-body} <assets-dir>\n' "${0##*/}" >&2
+	printf '       %s publishable <assets-dir> {absent|present}\n' "${0##*/}" >&2
 	exit 2
 }
 

--- a/test/grappa/version_single_source_test.exs
+++ b/test/grappa/version_single_source_test.exs
@@ -15,7 +15,13 @@ defmodule Grappa.VersionSingleSourceTest do
     * the Arch `pkgver` — `infra/packaging/aur/regen.sh` derives it from the
       same `version.sh` at release time, filling the committed
       `@GRAPPA_VERSION@` sentinel (a value `makepkg` REFUSES, so an
-      underived build fails loudly instead of shipping `grappa-@…@`);
+      underived build fails loudly instead of shipping `grappa-@…@`).
+      DERIVED ≠ EQUAL since #1591: `makepkg` also refuses the hyphen a semver
+      pre-release spells its suffix with, so the value goes through
+      `aur/pkgver.sh` (`1.3.0-rc1` → `1.3.0rc1`, identity on a bare `X.Y.Z`).
+      That is why the same recipe carries a SECOND `@GRAPPA_VERSION@`
+      sentinel, `_grappaver`: `pkgver` is the mapped number, `_grappaver` is
+      the raw tag, and a pre-release makes them differ;
     * the Arch CLIENT recipe (#1447, `aur/shottino/`) — a SECOND pkgbase, and
       therefore a second carrier: `pkgver=@SHOTTINO_VERSION@` derives from
       `frontends/shottino/version.h` (the client's own line, so
@@ -98,6 +104,23 @@ defmodule Grappa.VersionSingleSourceTest do
     test "PKGBUILD pkgver is the @GRAPPA_VERSION@ sentinel (makepkg refuses it → loud)" do
       pkgver = carrier_value("infra/packaging/aur/PKGBUILD", ~r/^pkgver=(.+)$/m)
       assert pkgver == "@GRAPPA_VERSION@"
+    end
+
+    test "the bouncer PKGBUILD names its source TAG through _grappaver (#1591)" do
+      # Same sentinel, second carrier — and the pair is not redundant. Since
+      # #1591 `pkgver` is the version MAPPED for makepkg (which refuses the
+      # hyphen a semver pre-release carries) while `_grappaver` is the raw tag,
+      # so a pre-release makes the two DIFFER. A recipe that went back to
+      # spelling its source `v${pkgver}` would fetch a tag nobody ever cut.
+      pkgbuild = File.read!("infra/packaging/aur/PKGBUILD")
+
+      assert carrier_value("infra/packaging/aur/PKGBUILD", ~r/^_grappaver=(.+)$/m) ==
+               "@GRAPPA_VERSION@"
+
+      assert carrier_value("infra/packaging/aur/PKGBUILD", ~r/^source=\((.+)\)$/m) =~
+               "v${_grappaver}.tar.gz"
+
+      refute pkgbuild =~ ~r/^source=.*v\$\{pkgver\}/m
     end
 
     test ".SRCINFO pkgver is the @GRAPPA_VERSION@ sentinel (regenerated with PKGBUILD)" do

--- a/test/infra/packaging_prerelease_pkgver_test.bats
+++ b/test/infra/packaging_prerelease_pkgver_test.bats
@@ -64,10 +64,10 @@ arch_job() {
 # ── The mapping ─────────────────────────────────────────────────────────────
 
 @test "#1591 a bare X.Y.Z passes through byte-for-byte" {
-    # The identity case is load-bearing, not a formality: every one of the 23
-    # tags cut so far is bare, so a mapper that touched them would restamp the
-    # whole release history's worth of package names for a case that has never
-    # occurred.
+    # The identity case is load-bearing, not a formality: every tag that
+    # predates `v1.3.0-rc1` is bare, so a mapper that touched them would
+    # restamp the whole release history's worth of package names for a case
+    # that had never occurred.
     for v in 0.1.0 1.2.0 1.3.0 10.20.30; do
         run "$PKGVER_SH" "$v"
         [ "$status" -eq 0 ]

--- a/test/infra/packaging_prerelease_pkgver_test.bats
+++ b/test/infra/packaging_prerelease_pkgver_test.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1591 — a pre-release `VERSION` must build the Arch
+# package, and the package it builds must sort BELOW the final release it
+# precedes.
+#
+# `makepkg` refuses a hyphen in `pkgver` (measured: rc=12,
+# "pkgver is not allowed to contain colons, forward slashes, hyphens or
+# whitespace", from its own lint at
+# /usr/share/makepkg/lint_pkgbuild/pkgver.sh — `[[ $ver = *[[:space:]/:-]* ]]`).
+# `VERSION` is semver and feeds mix.exs + the OTP application vsn, so the
+# hyphen cannot be spelled away upstream: the transformation belongs at the
+# `pkgver` boundary, where makepkg's constraint lives. That boundary is
+# `infra/packaging/aur/pkgver.sh`, and this suite is its contract.
+#
+# THE SPELLING IS NOT FREE, and the reason is measured rather than argued.
+# `vercmp <candidate> 1.3.0`, on pacman 7.1.0:
+#
+#     1.3.0rc1   -1   the pre-release is OLDER  ← the only correct one
+#     1.3.0_rc1  +1    "     "         NEWER
+#     1.3.0.rc1  +1
+#     1.3.0+rc1  +1
+#     1.3.0~rc1  +1
+#
+# All five BUILD (rc=0). Only the separator-less one orders right, and
+# pacman's own comparator says why: its segment loop is
+# `while (*one && *two) { skip separators; ... }`, so when the shorter side
+# runs out the loop exits AT THE CONDITION and the separator is never
+# skipped; the tie-break that follows is `isalpha(*one) → -1`
+# (lib/libalpm/version.c, "we never want a remaining alpha string to beat an
+# empty string"). A letter left over means older; a separator left over
+# means newer. Hence: delete the hyphen, join nothing in its place.
+#
+# The same measurement is why the mapping is FAIL-CLOSED rather than
+# best-effort. `1.3.0-1` is legal semver that sorts below `1.3.0`, but its
+# mapping `1.3.01` leaves a DIGIT at the tie-break and measures +1 — it would
+# publish a pre-release that outranks its own release. There is no spelling
+# that saves it, so the mapper refuses it instead of shipping it.
+#
+# Scope: the mapping + its refusals (pure string logic, no Arch needed), and
+# the two structural facts the mapping forces on the recipes — the tag is no
+# longer spelled `${pkgver}`, and the release job now asserts the number it
+# derived actually reached the built package.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    PKG_DIR="$REPO_ROOT/infra/packaging"
+    PKGVER_SH="$PKG_DIR/aur/pkgver.sh"
+    REGEN="$PKG_DIR/aur/regen.sh"
+    PKGBUILD="$PKG_DIR/aur/PKGBUILD"
+    SRCINFO="$PKG_DIR/aur/.SRCINFO"
+    WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+}
+
+# The `arch` job of release.yml, from its key to the next top-level job key.
+# Read off the JOB, never the whole file: release.yml also builds deb, rpm and
+# docker, and a whole-file grep would be satisfied by any of their steps.
+arch_job() {
+    awk '/^  arch:/ { f = 1; next } f && /^  [a-z]/ { exit } f' "$WORKFLOW"
+}
+
+# ── The mapping ─────────────────────────────────────────────────────────────
+
+@test "#1591 a bare X.Y.Z passes through byte-for-byte" {
+    # The identity case is load-bearing, not a formality: every one of the 23
+    # tags cut so far is bare, so a mapper that touched them would restamp the
+    # whole release history's worth of package names for a case that has never
+    # occurred.
+    for v in 0.1.0 1.2.0 1.3.0 10.20.30; do
+        run "$PKGVER_SH" "$v"
+        [ "$status" -eq 0 ]
+        [ "$output" = "$v" ]
+    done
+}
+
+@test "#1591 the hyphen makepkg refuses is deleted, and nothing is put in its place" {
+    run "$PKGVER_SH" 1.3.0-rc1
+    [ "$status" -eq 0 ]
+    [ "$output" = "1.3.0rc1" ]
+}
+
+@test "#1591 no mapped pkgver carries a character makepkg's lint refuses" {
+    # The refused class is makepkg's own bracket expression, transcribed:
+    # `[[ $ver = *[[:space:]/:-]* ]]` in lint_pkgbuild/pkgver.sh.
+    for v in 1.3.0 1.3.0-rc1 1.3.0-rc.1 1.3.0-alpha1 1.3.0-beta.2 1.3.0-rc1+deadbeef; do
+        run "$PKGVER_SH" "$v"
+        [ "$status" -eq 0 ]
+        [ -n "$output" ]
+        refute grep -qE '[[:space:]/:-]' <<<"$output"
+    done
+}
+
+@test "#1591 what is left after the numeric core is a LETTER — the tie-break vercmp reads" {
+    # THE ordering property, expressed as the shape pacman's comparator keys
+    # on rather than as a vercmp call: bats runs on the host, where there is
+    # no pacman. The container measurement behind this rule is in the header;
+    # the release job re-checks it with the real vercmp on a real Arch box.
+    for v in 1.3.0-rc1 1.3.0-rc.1 1.3.0-alpha1 1.3.0-beta.2 1.3.0-rc1+deadbeef; do
+        run "$PKGVER_SH" "$v"
+        [ "$status" -eq 0 ]
+        # Strip the leading numeric core (digits and dots); what remains is
+        # what the comparator is left holding once the final release's
+        # segments run out.
+        rest="$(sed -E 's/^[0-9.]+//' <<<"$output")"
+        [ -n "$rest" ]
+        grep -qE '^[A-Za-z]' <<<"$rest"
+    done
+}
+
+@test "#1591 a numeric-leading pre-release is REFUSED — its mapping would outrank the release" {
+    # `1.3.0-1` is legal semver and sorts BELOW `1.3.0`; `1.3.01` measures +1.
+    # Fail closed: refuse to derive a number rather than publish one that
+    # inverts the upgrade path.
+    for v in 1.3.0-1 1.3.0-0.1 1.3.0-1rc; do
+        run "$PKGVER_SH" "$v"
+        # The refusal's OWN exit code, not merely non-zero: an absent script
+        # exits 127 and would satisfy `-ne 0` while proving nothing.
+        [ "$status" -eq 2 ]
+        grep -qi 'letter' <<<"$output"
+    done
+}
+
+@test "#1591 an empty or missing version is refused, never mapped to the empty string" {
+    # makepkg's lint rejects an empty pkgver too ("is not allowed to be
+    # empty"), but at release time, in CI, on a tag. Refuse here.
+    run "$PKGVER_SH"
+    [ "$status" -eq 2 ]
+
+    run "$PKGVER_SH" ""
+    [ "$status" -eq 2 ]
+}
+
+# ── What the mapping forces on the recipes ─────────────────────────────────
+
+@test "#1591 regen.sh derives BOTH recipes' pkgver through the mapper" {
+    # The client carrier can grow a pre-release exactly the same way the
+    # bouncer's did. One mapper, both numbers — a second recipe that skipped
+    # it would fail at makepkg, at release time, on a tag.
+    grep -qF 'pkgver.sh' "$REGEN"
+    # Two derivations, both mapped: the bouncer's and the client's.
+    [ "$(grep -cF 'pkgver.sh' "$REGEN")" -ge 2 ]
+}
+
+@test "#1591 the bouncer recipe names the TAG through _grappaver, not through pkgver" {
+    # Once pkgver may differ from VERSION, every `v${pkgver}` in the recipe is
+    # a tag that was never cut. The client recipe has carried `_grappaver` for
+    # this reason since #1447; the bouncer needs it for the same reason now,
+    # and `regen.sh`'s `_grappaver` sed — a deliberate no-op on this file until
+    # today — becomes live.
+    grep -qx '_grappaver=@GRAPPA_VERSION@' "$PKGBUILD"
+    grep -qx 'pkgver=@GRAPPA_VERSION@' "$PKGBUILD"
+
+    # The two places a tag is spelled. Read off the declarations, not the
+    # file: the recipe discusses pkgver at length in prose.
+    src_line="$(grep -E '^source=' "$PKGBUILD")"
+    srcdir_line="$(grep -E '^_srcdir=' "$PKGBUILD")"
+    [ -n "$src_line" ]
+    [ -n "$srcdir_line" ]
+    grep -qF '${_grappaver}' <<<"$src_line"
+    grep -qF '${_grappaver}' <<<"$srcdir_line"
+    refute grep -qF 'v${pkgver}' <<<"$src_line"
+    refute grep -qF '${pkgver}' <<<"$srcdir_line"
+}
+
+@test "#1591 the committed bouncer .SRCINFO agrees that the source is the TAG" {
+    # .SRCINFO is regenerated by `makepkg --printsrcinfo`, which does not run
+    # on this host — but the committed template must not claim the tarball is
+    # named after a pkgver that can now differ from the tag.
+    [ -f "$SRCINFO" ]
+    grep -qE '^[[:space:]]*pkgver = @GRAPPA_VERSION@$' "$SRCINFO"
+    grep -qE '^[[:space:]]*source = .*tags/v@GRAPPA_VERSION@\.tar\.gz$' "$SRCINFO"
+}
+
+# ── The hole the issue names: nothing asserted grappa's own package number ──
+
+@test "#1591 the arch job asserts the DERIVED pkgver actually reached the built package" {
+    # The issue's second finding: both existing package-version gates compare
+    # against the SHOTTINO carrier (release.yml's deb and rpm legs), so a
+    # restamp of grappa's number would be seen by nobody. On the Arch side the
+    # number is now deliberately transformed, which makes the missing gate the
+    # difference between a derivation and a hope.
+    job="$(arch_job)"
+    [ -n "$job" ]
+    grep -qF 'pacman -Q grappa' <<<"$job"
+    grep -qF 'pkgver.sh' <<<"$job"
+}
+
+@test "#1591 the arch job re-checks the ordering with the real vercmp" {
+    # The host-side shape rule above is a transcription of a measurement. This
+    # is the measurement itself, on a real Arch box, at the only moment a
+    # pre-release can reach a user: `vercmp <pkgver> <core>` must be negative.
+    job="$(arch_job)"
+    [ -n "$job" ]
+    grep -qF 'vercmp' <<<"$job"
+}

--- a/test/infra/release_assets_test.bats
+++ b/test/infra/release_assets_test.bats
@@ -212,6 +212,76 @@ seed_complete() {
     refute grep -q 'grappa:partial-release' <<<"$output"
 }
 
+# ── publishable: creating a release is irreversible, topping one up is not ──
+#
+# #1591. `publish` runs on `!cancelled()`, so a red package leg still reached
+# `gh release create` and PUBLISHED — a partial release, marked as such, but
+# public. #504/#573 chose that deliberately and for a good reason: a distro
+# breakage must not withhold the artifacts that built green. The reason holds
+# for a release that ALREADY EXISTS, where attaching what built is the only
+# way to complete it. It does not hold for the first run of a fresh tag, where
+# the same rule turns "one leg failed" into a public artefact that deleting
+# the tag does not retract.
+#
+# So the axis is not completeness alone — it is completeness × whether the
+# release object already exists. That decision lives here rather than in YAML
+# because it is the SAME table the rest of this script owns, and because a
+# two-variable rule inlined in a workflow step is exactly what #573 was filed
+# about.
+
+@test "publishable: a complete set may create a brand-new release" {
+    seed_complete
+    run "$SCRIPT" publishable "$ASSETS" absent
+    [ "$status" -eq 0 ]
+}
+
+@test "publishable: a complete set may top up an existing release" {
+    seed_complete
+    run "$SCRIPT" publishable "$ASSETS" present
+    [ "$status" -eq 0 ]
+}
+
+@test "publishable: a PARTIAL set must NOT create a new release (#1591)" {
+    # The irreversible act. `gh release create` publishes; deleting the tag
+    # afterwards does not retract what was published.
+    seed_complete
+    rm "$ASSETS/grappa-arch/grappa-0.8.0-1-x86_64.pkg.tar.zst"
+    run "$SCRIPT" publishable "$ASSETS" absent
+    [ "$status" -ne 0 ]
+    # It must name the gap, not just refuse: the operator's next move is to
+    # fix that leg and re-run, and a bare refusal makes them go find out which.
+    grep -q 'Arch package, bouncer' <<<"$output"
+}
+
+@test "publishable: a PARTIAL set MAY still top up an existing release (#504/#573 preserved)" {
+    # The converse, and the reason this is a two-variable rule rather than a
+    # completeness check: the repair dispatch of #573 (b) exists precisely to
+    # attach a leg that failed the first time, and it runs against a release
+    # that is already public. Refusing here would break the repair path in the
+    # name of protecting a publication that has already happened.
+    seed_complete
+    rm "$ASSETS/grappa-arch/grappa-0.8.0-1-x86_64.pkg.tar.zst"
+    run "$SCRIPT" publishable "$ASSETS" present
+    [ "$status" -eq 0 ]
+}
+
+@test "publishable: an unknown release state is refused, never read as 'present'" {
+    # Fail closed on the permissive side. The workflow computes this from
+    # `gh release view`, and a probe that errors for an unrelated reason (rate
+    # limit, token scope) must not be silently read as "already public,
+    # publish anyway".
+    seed_complete
+    rm "$ASSETS/grappa-arch/grappa-0.8.0-1-x86_64.pkg.tar.zst"
+    for state in "" maybe yes PRESENT; do
+        run "$SCRIPT" publishable "$ASSETS" "$state"
+        [ "$status" -ne 0 ]
+        # Named, so the refusal is distinguishable from the usage error an
+        # absent subcommand produces — otherwise this case is green today,
+        # against a script that has never heard of `publishable`.
+        grep -qi 'release state' <<<"$output"
+    done
+}
+
 @test "usage: an unknown subcommand fails loudly" {
     run "$SCRIPT" frobnicate "$ASSETS"
     [ "$status" -ne 0 ]


### PR DESCRIPTION
## What broke

Cutting `v1.3.0-rc1` did two things at once.

1. **`makepkg` refuses a hyphen in `pkgver`**, and a semver pre-release spells
   its suffix with exactly that character — so the `arch` job died.
2. **`publish` created the GitHub Release anyway.** It declares
   `needs: [deb, arch, rpm]` but runs on `if: !cancelled()`, and its attach step
   was named *"mark a partial release"*. The tag got a public release object
   with `assets=0`, and deleting the tag afterwards does not retract it.

The first question asked was whether a line of documentation closes this. It
does not: a doc line cannot stop CI from performing an irreversible
outward-facing act. Both are fixed here.

## Reproduced first, with known-answer controls

`menci/archlinuxarm:base-devel`, the issue's own harness shape, one minimal
PKGBUILD per candidate, driven by the invocation `release.yml` uses:

| `pkgver` | rc | outcome |
|---|---|---|
| `1.3.0` | 0 | passes — positive control |
| **`1.3.0-rc1`** | **12** | `ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or whitespace` |
| `@GRAPPA_VERSION@` | 0 | passes |

The lint is `[[ $ver = *[[:space:]/:-]* ]]` in makepkg's own
`lint_pkgbuild/pkgver.sh` — architecture-independent shell, which is what makes
an ARM Arch container an honest stand-in for the x86_64 runner.

## The cure: transform at the `pkgver` boundary

`VERSION` stays semver (it feeds `mix.exs` and the OTP application vsn, and
every non-semver spelling either fails `Version.parse/1` or compares `:eq` with
the release). The transformation goes where makepkg's constraint lives, in a
new `infra/packaging/aur/pkgver.sh`:

```
pkgver.sh 1.3.0      -> 1.3.0        identity — every tag before v1.3.0-rc1
pkgver.sh 1.3.0-rc1  -> 1.3.0rc1
pkgver.sh 1.3.0-1    -> refused, exit 2
```

### The spelling reverses the Arch convention, and that is measured

Every candidate BUILDS. Only one ORDERS right. `vercmp <candidate> 1.3.0`,
pacman 7.1.0:

| `pkgver` | `vercmp` vs `1.3.0` | meaning |
|---|---|---|
| **`1.3.0rc1`** | **−1** | **older than its release — correct** |
| `1.3.0_rc1` | +1 | newer — the Arch-conventional underscore INVERTS it |
| `1.3.0.rc1` | +1 | |
| `1.3.0+rc1` | +1 | |
| `1.3.0~rc1` | +1 | no tilde semantics here, unlike deb |

pacman's own comparator agrees with the measurement rather than substituting
for it: the segment loop is `while (*one && *two) { skip separators; … }`, so
when the shorter side runs out the loop exits **at the condition** and the
leftover separator is never skipped; the tie-break is then
`isalpha(*one) ? -1 : 1` (`lib/libalpm/version.c`). A **letter** left over means
older; a **separator** left over means newer. Hence: delete the hyphen, join
nothing in its place. A later "tidy-up" to `_` would strand every user who
installed an rc — pacman would never offer them the release.

**This settles what the issue recorded as NOT MEASURED:** `makepkg` does accept
`+` in `pkgver` (rc=0). It changes nothing — the cure does not rest on `+`,
because `1.3.0+rc1` measures `+1` on the axis that matters.

### Fail closed

The same tie-break makes one legal semver shape unmappable: `1.3.0-1` sorts
below `1.3.0`, but `1.3.01` leaves a DIGIT at the tie-break and measures `+1`.
No spelling saves it, so the mapper refuses (exit 2, naming why) rather than
publish a pre-release that outranks its own release. That refusal is why this
is a script and not a `sed`.

### `pkgver` stopped being the tag

`source=(… v${pkgver}.tar.gz)` would name a tag nobody cut, so the bouncer
recipe now carries `_grappaver` and spells `source` + `_srcdir` with it — the
shape `aur/shottino/PKGBUILD` has had since #1447 (there a different *number*,
here a different *spelling* of the same one). `regen.sh`'s `_grappaver` sed, a
deliberate no-op on that file until now, becomes live rather than being added.
Both recipes route their `pkgver` through the mapper.

## The gate the issue named, closed on the Arch side

Nothing in the pipeline asserted grappa's own package number — both existing
package-version gates compare against the **shottino** carrier. The `arch` job
now asserts `pacman -Q grappa` against the mapper's output, and (on a
pre-release only, saying so out loud otherwise) re-checks the ordering with the
real `vercmp`.

Both were proven by **mutating the production they guard**, each gate extracted
verbatim from the workflow and run against a real Arch box with a genuinely
installed `grappa` package. They are complementary, not redundant:

| mutant | G1 (package == derived) | G2 (vercmp ordering) |
|---|---|---|
| unmutated | green | green |
| package restamped to `1.3.0` | **red** | green |
| mapper joins with `_`, package rebuilt from it | green (blind — both sides moved) | **red** |

The host-side bats suite was mutated too: `_` join kills 2 cases, dropping the
letter guard kills 1, reverting the recipe's tag spelling kills 1.

## `publish` no longer CREATES a partial release

This reverses part of a deliberate decision, so the reasoning is explicit.
#504/#573 chose "attach whatever built" because a distro breakage must not
withhold the artifacts that built green — sound **for a release that already
exists**, and exactly what the "(b) repair" dispatch is for. It does not
survive the first run of a fresh tag.

So the rule is completeness **×** does-the-release-exist, as
`release_assets.sh publishable <dir> <absent|present>` — in that script because
it is the same expected-kinds table the rest of it owns, and because a
two-variable rule inlined in YAML is precisely what #573 was filed about. The
workflow reads a **failing** `gh release view` as `absent`, the conservative
side. Net effect: a broken first run stops before creating anything, and a
re-run after the fix creates the release cleanly — which the old order could
not do at all.

## Boundary

`infra/packaging/nfpm.yaml`, the `deb`/`rpm` jobs and shottino's
`Breaks`/`Obsoletes` are untouched — concurrent work on #1594 owns them. **The
deb/rpm half of the missing-version-gate hole is therefore named and NOT
fixed here.**

## One line of the issue does not survive measurement

The issue records **"23 tags, zero pre-releases"**. `git ls-remote --tags
origin` — the authoritative set — answers **22** matching `v*`, of which
**one** (`v1.3.0-rc1`) is a pre-release. The zero is a sentence its own subject
overtook; where the 23 came from is not established and is not restated.
Nothing rests on either number: the identity case is pinned by shape, never by
a count. Every other line citation in the issue was checked against the branch
base and all seven hold (`regen.sh:45`, `release.yml:389/1070/1097/287/660`,
`nfpm.yaml:17`).

## What I refuse to claim

- **The real Arch package was never built** — it needs elixir + bun on x86_64
  and a real tag tarball. What ran end-to-end is `regen.sh` itself on a real
  Arch box (`updpkgsums` stubbed; it fetches over the network and is not under
  test): base + `1.3.0` → rc=0 · base + `1.3.0-rc1` → **rc=12** · this branch +
  `1.3.0` → rc=0 with a `.SRCINFO` identical to the base's · this branch +
  `1.3.0-rc1` → rc=0, `pkgver=1.3.0rc1`, `_grappaver=1.3.0-rc1`, tag URL intact
  · this branch + `1.3.0-1` → rc=2 before makepkg.
- **The package-version gate ran against a stand-in**, genuinely named `grappa`
  and genuinely installed with pacman — not against the bouncer.
- **Measured on ARM, not on the release runner.** The lint and `vercmp` are
  architecture-independent by inspection of their source. That is an argument,
  not a second measurement.
- **`publishable`'s `gh release view` probe is untested** — inline YAML, like
  every other `gh` call in that job. The five bats cases drive the decision
  table only.
- **The mapping is not injective**: `1.3.0-rc-1` and `1.3.0-rc1` collide.
  Accepted and documented — the ordering property is what breaks an upgrade
  path, and it is preserved.
- **No `epoch`.** Not needed (the mapped pre-release sorts below its release)
  and a one-way door every later release would carry. Recorded as the remedy
  if the mapping ever has to change.

## Gates

**`scripts/check.sh` — rc=0**, from the worktree root on an isolated cold
`GRAPPA_CACHE_ID=w1-1591` (own `_build`/`deps`/PLT, so the
`(grappa 1.3.0-rc1)` in its log is this branch's `VERSION`, not another
worktree's). `ci.check` HALTS on the first red, so the rc alone is not the
claim — each step was checked for a start marker:

| # | step | evidence |
|---|---|---|
| 1 | `compile --warnings-as-errors` | `Compiling 32 files (.ex)` |
| 2 | `format --check-formatted` | **no marker — silent when green.** Inferred from the chain (3–10 ran), and measured separately: `scripts/format.sh --check` rc=0 |
| 3 | `credo --strict` | `Checking 697 source files` |
| 4 | `deps.audit` | `==> mix_audit` |
| 5 | `hex.audit` (advisory) | `Advisories:` / `Found packages with security advisories` |
| 6 | `sobelow --exit Medium` | `==> sobelow` |
| 7 | `doctor` (`MIX_ENV=test`) | `==> doctor` |
| 8 | `test --warnings-as-errors` | `8 doctests, 61 properties, 6658 tests, 0 failures` |
| 9 | `dialyzer` | `done in 0m7.61s` |
| 10 | `docs` | `View html docs at "doc/index.html"` |
| A | wireTypes drift gate | `cicchetto/src/lib/wireTypes.ts is in sync.` |
| B | `bats` | **612 ok, 0 not ok** |

The `** (stop) :tcp_closed` lines in that log are captured GenServer logs
inside the session suites, not a gate failure — the tally above is `0 failures`.

Also green: `scripts/shellcheck.sh` (78 scripts) · `scripts/posix-parse.sh`
(29 sh-dialect scripts — `pkgver.sh` joined the derived set, 28→29) ·
`scripts/design-notes-gate.sh` · `scripts/union-rebase.sh origin/main`
(+160 −0, contribution intact), plus the three checks that script does not do,
re-taken at **each** rebase: marker unique against the CURRENT tip, boundary
shape read on the real file, and the PREVIOUS entry byte-compared against
`origin/main` — identical both times (`#1441` on the first rebase, `#1484` on
the second, after main gained it).

### The gap in that evidence, named rather than papered over

`check.sh` ran against merge-base `fd44e9d8`. Main then gained **one** commit,
`a10be633 docs(#1484)`, touching **only `docs/DESIGN_NOTES.md`** — measured,
not assumed — and the branch was rebased onto it. Of the gates above, the only
one whose input changed is `design-notes-gate.sh`, which was re-run on the new
base (rc=0). The other gates read no file in that delta, so they were not
re-run; that is an argument from the measured file list, not a second
execution.

Worth noting for whoever reads the PR state: it showed `CONFLICTING` between
the two rebases while a **local** trial merge was clean. That is `merge=union`
— GitHub does not apply the repo's merge driver, so a parallel DESIGN_NOTES
append reads as a conflict there and resolves here. Rebasing locally is the
cure, and it is what `union-rebase.sh` exists for.
