### PR TITLE
docs(#1523): register the leaf-promotion rule in CLAUDE.md, with the carve-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -578,6 +578,43 @@ not the surrounding code.**
 - **Contexts at `lib/grappa/<context>.ex`.** Schemas live as
   `lib/grappa/<context>/<name>.ex`. Public API on the context module;
   schemas internal. Boundary library enforces.
+- **A boundary that needs only a SCHEMA declares the schema, not the
+  context — promote the schema to its own boundary (`use Boundary,
+  top_level?: true`, #1398 / #1399).** Declaring `Grappa.<Context>` to
+  name one struct also hands the consumer every exported verb, and the
+  checker then has nothing to say about a call nobody meant to allow —
+  measured, not argued (#1521, `03e7254b`): `Accounts.get_user!/1`
+  inserted into `Grappa.Subject` compiles GREEN while `Subject` declares
+  the whole `Grappa.Accounts`, and RED once it declares
+  `Grappa.Accounts.User` alone. The leaf's OWN `deps:` is measured from
+  ITS outbound edges, not assumed empty — `Accounts.User` is `[]`,
+  `Accounts.Session` is `[Grappa.Subject]`, `Networks.Credential` is
+  `[Grappa.IRC, Grappa.Subject]`. **Second half: often the right move
+  is to declare NOTHING, because the reference carries no edge.**
+  `belongs_to :x, Mod`, `field :x, Mod` and `Mod.t()` in a typespec are
+  module atoms in metadata, so the xref checker never sees them — why
+  `Networks.Credential` aliases `Accounts.User`, `Visitor` and
+  `EncryptedBinary` and declares none of them. `from(s in Mod)` in an
+  Ecto query IS an edge: declare-nothing does not compile there, and
+  that is why `Admission` and `Vhosts` had to narrow to the leaf rather
+  than drop the dep. **Verify with the COMPILER.** Boundary is wired
+  into `compilers:` (`mix.exs`), so `mix compile --force
+  --warnings-as-errors` IS the check and enumerates the blast radius
+  for you; **there is no `mix boundary.find_violations` task in
+  boundary 0.10.4** — don't go looking for one. Measure under
+  `--env=test` as well: `MIX_ENV=dev` never compiles `test/support`, so
+  a dev-only run under-counts by exactly the test-support boundaries,
+  silently. **Carve-out, accepted knowingly (vjt ruling, 2026-08-20):**
+  the promoted leaf keeps its `Grappa.<Context>.<Schema>` name while
+  being a SIBLING of `Grappa.<Context>` in the graph. Boundary's own
+  docs call that namespace/model mismatch discouraged and offer a
+  rename instead; we decline the rename — it moves files and renames
+  modules, which means beams disappearing and a COLD deploy, to buy a
+  naming nicety. Nothing breaks (Boundary still compiles, no runtime
+  effect); the price is a reader guessing the wrong owner from the
+  name. **A promoted identity or FK schema is a deliberate carve-out,
+  not a context internal** — that is the rule, not a smaller count of
+  nested `top_level?: true`.
 - **Controllers thin, contexts thick.** Controller responsibilities:
   parse params, call context, render. Logic lives in the context.
 - **`FallbackController` for `{:error, X}` returns.** Don't `case` on

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -54992,3 +54992,72 @@ is being cut anyway"*); where the 23 came from is not established, and it is
 not restated here. Nothing downstream rests on either number: the identity
 case is pinned by shape ("every tag that predates `v1.3.0-rc1`"), never by a
 count.
+<!-- entry #1523 -->
+
+---
+
+## 2026-08-20 — #1523: the leaf-promotion rule lands in CLAUDE.md, and the caveat it was hedged with names a mix task that does not exist
+
+The rule that #1398 and #1399 established — a boundary needing one schema
+promotes the schema to a leaf and declares that, instead of taking the whole
+context — lived in these entries and in a comment inside
+`networks/credential.ex`, but not in the file that is read as authority.
+#1399's own "not established" says so and hands the edit to vjt. vjt ruled
+on 2026-08-20: **carve-out**. The nesting the promotion creates (a boundary
+named `Grappa.Accounts.User` sitting as a *sibling* of `Grappa.Accounts` in
+the graph) is a price paid knowingly, not a defect to close. So the issue
+ships as documentation only: both halves of the rule plus an explicit
+carve-out sentence, no code.
+
+### The caveat was weaker than it reads, in a direction nobody checked
+
+Both #1399 and #1523 carry the same standing limitation: *`mix
+boundary.find_violations` has never been run on any commit named here.* True
+— and it cannot be made false. **Boundary 0.10.4 has no such task.** The
+string does not occur anywhere in `deps/boundary`, and the tasks it does
+define are `Boundary.Spec`, `Boundary.FindExternalDeps`,
+`Boundary.ExDocGroups`, `Boundary.Visualize{,.Funs,.Mods}` and
+`Mix.Tasks.Compile.Boundary`. The sentence reads as a debt somebody could
+pay in an afternoon; there is nothing to pay.
+
+That does **not** promote the rule to compiler-verified by substitution — a
+named-but-absent task is not evidence that a different mechanism covers the
+same ground, and no such equivalence is claimed here. What it does is move
+the question to the checker that exists: Boundary is wired into `compilers:`
+in `mix.exs`, and `cmd mix compile --warnings-as-errors` is the FIRST step of
+the `ci.check` alias precisely so violations fail the build instead of
+printing as advisory warnings. That compile is what enumerated #1521's blast
+radius (80 forbidden references over 8 boundaries for `User`, 8 over 3 for
+`Session`) and what turned the `Grappa.Subject` mutation from green to red.
+The mechanism claims the CLAUDE.md rule rests on come from that run — which
+also means the correct instruction for a future reader is "run the compiler",
+and the rule now says so rather than pointing at a task they would fail to
+find.
+
+### Two things the rule deliberately does not say
+
+**No census.** The tempting sentences — "the population that declares a whole
+context to name a schema is empty (was 12)", "nested `top_level?: true` goes
+11 → 15 → 17" — are point-in-time counts, and a rule that leans on one is
+false the day an eighth schema is promoted. CLAUDE.md gets the mechanism and
+the price; the counts stay here and in the issues. The carve-out sentence is
+written as a *convention* ("a promoted identity or FK schema is a deliberate
+carve-out, not a context internal") rather than as a budget, for the same
+reason #1399 gave: the thing A7 lacks is an oracle, not a smaller number.
+
+**Not `deps: []`.** Both the issue and the review shorthand the promotion as
+`top_level?: true, deps: []`. Read against the tree that is wrong for four of
+the seven promoted schemas: `Accounts.Session` is `[Grappa.Subject]`,
+`Networks.Network` and `Networks.FeaturedChannel` are `[Grappa.IRC]`,
+`Networks.Credential` is `[Grappa.IRC, Grappa.Subject]`; only
+`Accounts.User`, `Networks.Server` and `Visitors.Visitor` are empty. The code
+wins — the rule describes what is, and says the leaf's own `deps:` is
+measured from its own outbound edges rather than assumed empty. No code was
+changed to match the shorthand.
+
+_Not established: nothing here was compiled. This branch adds prose only, and
+every mechanism claim it repeats — `belongs_to`/`field`/`Mod.t()` carry no
+edge, `from(s in Mod)` does — is quoted from the `--force
+--warnings-as-errors` run recorded in #1521 (`03e7254b`), not re-measured on
+this branch. The one measurement taken here is the absence of
+`find_violations` from `deps/boundary` at 0.10.4._


### PR DESCRIPTION
Documentation only, per vjt's 2026-08-20 ruling on #1523. No code: no annotation, no `deps:` touched, no rename.

## What lands

One bullet in `CLAUDE.md`, next to *"Contexts at `lib/grappa/<context>.ex` … Boundary library enforces"*, carrying both halves of the rule plus the carve-out sentence:

1. **When to promote** — a boundary needing one schema promotes the schema to its own boundary (`use Boundary, top_level?: true`) and declares that, not the context. Why: declaring the whole context also hands the consumer every exported verb, and the checker then has nothing to say about a call nobody meant to allow. The one measurement that exists says it: `Accounts.get_user!/1` inserted into `Grappa.Subject` compiles GREEN while `Subject` declares the whole `Grappa.Accounts`, RED once it declares `Grappa.Accounts.User` alone (#1521, `03e7254b`).
2. **When to declare nothing** — `belongs_to :x, Mod`, `field :x, Mod` and `Mod.t()` in a typespec are module atoms in metadata and carry no edge. `from(s in Mod)` in an Ecto query **is** an edge, which is why `Admission` and `Vhosts` had to narrow to the leaf rather than drop the dep.
3. **Carve-out** — the promoted leaf keeps its `Grappa.<Context>.<Schema>` name while sitting as a *sibling* of `Grappa.<Context>` in the graph. Boundary's own docs call that mismatch discouraged and offer a rename instead; we decline it. Renaming modules is beams disappearing and a cold deploy, bought for a naming nicety. Nothing breaks; the price is a reader guessing the wrong owner.

Plus a DESIGN_NOTES entry (`<!-- entry #1523 -->`) recording the ruling, the two things the rule deliberately does *not* say, and the corrected caveat.

## The standing caveat is corrected, not repeated

#1399 and #1523 both carry *"`mix boundary.find_violations` has never been run."* True — and it cannot be made false. **Boundary 0.10.4 defines no such task.** Zero occurrences of the string in `deps/boundary`; the tasks it does define are `Boundary.Spec`, `Boundary.FindExternalDeps`, `Boundary.ExDocGroups`, `Boundary.Visualize{,.Funs,.Mods}` and `Mix.Tasks.Compile.Boundary`.

That is **not** claimed as equivalence — a named-but-absent task is no evidence that another mechanism covers the same ground. It moves the instruction to the checker that exists: Boundary is wired into `compilers:` in `mix.exs`, and `cmd mix compile --warnings-as-errors` is the *first* step of the `ci.check` alias so violations fail the build. The rule now tells a future reader to run the compiler instead of hunting a task they will not find.

## Two things the rule refuses to say

- **No census.** "The population is empty (was 12)" and "11 → 15 → 17 nested `top_level?: true`" are point-in-time counts; a rule leaning on one outlives it by about one promotion. The mechanism and the price go in `CLAUDE.md`; the counts stay in the issues and the decision log.
- **Not `deps: []`.** The issue's shorthand is wrong for four of the seven promoted schemas — `Accounts.Session` is `[Grappa.Subject]`, `Networks.Network` and `Networks.FeaturedChannel` are `[Grappa.IRC]`, `Networks.Credential` is `[Grappa.IRC, Grappa.Subject]`; only `Accounts.User`, `Networks.Server` and `Visitors.Visitor` are empty. The code wins: the rule says the leaf's `deps:` is measured from its own outbound edges. Nothing was changed to match the shorthand.

## Gates

Rebased onto `efa615d2` after `main` moved mid-flight (#1591 landed), so the union driver actually ran this time — the earlier run against `a10be633` was green but declared vacuous by the gate itself, and is not counted.

- `scripts/union-rebase.sh origin/main` → rc=0. `Successfully rebased`, `docs/DESIGN_NOTES.md: +69 -0 — contribution intact`. Two-sided, numstat pinned to a file on both sides: pre (vs `a10be633`) `37/0 CLAUDE.md, 69/0 DESIGN_NOTES`, post (vs `efa615d2`) identical. Additions unchanged **and** deletions zero — zero deletions is what says the preceding #1591 entry survived, tail included.
- `scripts/design-notes-gate.sh origin/main` → rc=0, *"1 new entry heading(s), separator and marker present."* Marker count 1 in the branch file, 0 on the `origin/main` tip. Boundary shape re-read on the real file after the rebase: full stop / marker / blank / `---` / blank / heading, no blank before the marker.
- No compile was run. This branch adds prose only; every mechanism claim it repeats is quoted from #1521's `--force --warnings-as-errors` run, not re-measured here. The one measurement taken on this branch is the absence of `find_violations` from `deps/boundary` at 0.10.4.

Merge on vjt's order only.