### PR TITLE
obs(#1420): print the holder's scheduler status in the lock-stall warning

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55456,3 +55456,83 @@ and would have passed on either.
   the outcome here — a broken gate that ships publicly is not a limitation a
   reader can route around — but the partial-release posture itself was neither
   measured nor changed.
+<!-- entry #1420b -->
+
+---
+
+## 2026-08-20 — #1420b: print the holder's scheduler `status`, because the byte that separates the two diagnoses was already sampled and thrown away
+
+`Grappa.Repo.LockWatch` names the write-lock holder and samples its live
+stack. It also samples the holder's scheduler `status` and its
+`message_queue_len` — and the only door that reaches a CI container log,
+the `Logger.warning` in `report/1`, printed neither. This adds `status` to
+that line.
+
+### Why one field is worth an entry
+
+Because for four days the issue could not tell two incompatible diagnoses
+apart, and the discriminator was already in the struct:
+
+| `status` | reading |
+|---|---|
+| `:running` | the holder really is inside the SQLite NIF — the write is slow |
+| `:runnable` | the holder is queued and NOT being scheduled — nothing about SQLite is slow |
+| `:waiting` | the holder is parked in a receive |
+
+Measured, not assumed (2026-08-20, in-container, two arms of one call with
+only the TARGET moving): a process blocked inside
+`Exqlite.Sqlite3NIF.execute/2` on a contended `BEGIN IMMEDIATE` reads
+`:running`; a process parked in a `receive` reads `:waiting`. The same
+measurement killed the fear that made the field look expensive —
+`Process.info/2` on a process executing a **dirty** NIF (every exqlite NIF
+is `ERL_NIF_DIRTY_JOB_IO_BOUND`) returns in **0 ms** and does not block the
+sampler, so nothing about reading `status` can make the watchdog part of
+the incident it is reporting.
+
+Without it, a 33 s hold in an artefact is compatible with "SQLite is slow"
+and with "the runtime stopped", and those have different owners. The three
+holder samples that actually reached a log in the 2026-08-20 field run sat
+at `Sqlite3NIF.execute/2`, `Sqlite3NIF.transaction_status/1` and
+`Sqlite3NIF.columns/2` — the last two are `sqlite3_get_autocommit()` and
+`sqlite3_column_name()`, which do no IO and take no lock, so `status` was
+the missing byte in exactly the cases that mattered.
+
+### Prose, not metadata — and the split is deliberate
+
+`held_ms` and `waiters` are Logger METADATA. `status` is not, and the
+reason is not taste: those two are MEASUREMENTS an operator aggregates,
+while `status` and `current_function` are ONE answer split in half — where
+the holder is, and whether it is running there at all. Putting half of one
+answer in the prose and half in the metadata is what made the reading hard
+in the first place. `message_queue_len` stays off the line entirely: it
+rides the telemetry door, which carries the whole sample into
+`Grappa.DbLatency`'s ring, and the log line stays the two fields that
+answer the question.
+
+### The two verbatim fixtures move with it
+
+`scripts/log-gap-scan.awk`'s own positive control and
+`test/scripts/log_gap_scan_test.bats`'s `LOCKSTALL_LINE` are both declared
+*verbatim from the call site*, so that a pin which drifts from production
+prose fails there instead of reporting a confident zero. Changing the
+message without changing them would make both fixtures lie about the shape
+they claim to mirror. The matcher itself (`/db lock stall: holder /`) is
+unaffected — `status=` lands after it.
+
+### Not established
+
+- **That the log line is the right door at all.** It reaches an artefact
+  only on a RED run; on green only the `#1429` census survives, and the
+  census carries a COUNT, not the field. Dumping `Grappa.DbLatency`'s ring
+  at e2e teardown was considered and NOT done: the e2e `grappa-test`
+  container runs `mix phx.server` with no `--sname` and no
+  `RELEASE_COOKIE`, so `bin/grappa`'s `--rpc-eval` door cannot reach it,
+  and the HTTP door needs an admin bearer minted inside `cleanup()`.
+  Both are larger than this change; neither was built.
+- **That `status` will read `:runnable` in the field.** The three samples
+  on record predate this line, so the field value is unknown until a stall
+  recurs with the field printed. That is the point of shipping it.
+- **`log-gap-scan.awk` still only COUNTS the two episode edges.** Carrying
+  the max `held_ms` or the observed `status` into the census — the summary
+  that survives a green run — is a separate, cheaper change than the ring
+  dump above, and is not made here.

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -82,6 +82,19 @@ defmodule Grappa.Repo.LockWatch do
   folds into a bounded ring — so `GET /admin/db_latency` and
   `bin/grappa db-latency` both inherit the data with no new noun.
 
+  The warning carries the holder's scheduler `status` next to its
+  `current_function`, because the two are one answer and only together do
+  they name a cause. Measured on #1420's own stalls: a holder genuinely
+  blocked inside `Exqlite.Sqlite3NIF.execute/2` on a contended
+  `BEGIN IMMEDIATE` reads `:running` (so the write is slow), one that is
+  merely queued and not being scheduled reads `:runnable` (so nothing about
+  SQLite is slow), and a parked one reads `:waiting`. `sample/2` has always
+  collected the byte; for four days the only door that reaches an artefact
+  threw it away, and the two diagnoses stayed indistinguishable.
+  `message_queue_len` is deliberately NOT in the line — it rides the
+  telemetry door, which carries the whole sample, and the log line stays the
+  two fields that answer the question.
+
   ## Cost and off-switch
 
   On the write path: one `:persistent_term` read, one `:ets.whereis/1`, and
@@ -358,10 +371,15 @@ defmodule Grappa.Repo.LockWatch do
 
     stall = %{holder: holder, waiters: waiter_samples, waiter_count: length(waiter_samples)}
 
+    # `status` rides in the PROSE, next to `current_function`, and not in the
+    # metadata beside `held_ms`/`waiters`: those two are measurements an
+    # operator aggregates, while these two are one answer split in half —
+    # WHERE the holder is, and whether it is running there at all. Separating
+    # them across the message/metadata line is what made the reading hard.
     Logger.warning(
       "db lock stall: holder #{holder.pid} has held RESERVED for #{holder.elapsed_ms}ms " <>
-        "with #{stall.waiter_count} waiter(s) queued — holder at #{holder.current_function}, " <>
-        "stack: #{Enum.join(holder.stacktrace, " <- ")}",
+        "with #{stall.waiter_count} waiter(s) queued — holder status=#{inspect(holder.status)} " <>
+        "at #{holder.current_function}, stack: #{Enum.join(holder.stacktrace, " <- ")}",
       held_ms: holder.elapsed_ms,
       waiters: stall.waiter_count
     )

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -210,7 +210,7 @@ BEGIN {
         " across 1 attempts (1500ms retry budget) — returning :db_unavailable")
     sig("lockstall", \
         "db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2" \
-        " waiter(s) queued — holder at :gen_server.loop/7, stack: …")
+        " waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: …")
     sig("lockstall_resolved", \
         "db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms")
 

--- a/test/grappa/repo/lock_watch_report_test.exs
+++ b/test/grappa/repo/lock_watch_report_test.exs
@@ -1,0 +1,116 @@
+defmodule Grappa.Repo.LockWatchReportTest do
+  @moduledoc """
+  #1420 — what the stall report PRINTS, as opposed to what it detects.
+
+  `Grappa.Repo.LockWatch.sample/2` already collects the holder's scheduler
+  `status`, and until this test the only door that reaches a CI container
+  log — the `Logger.warning` — threw it away. That field is the whole
+  difference between two diagnoses the issue spent days apart on:
+
+    * `:running`  — the holder really is inside the SQLite NIF, so the
+      write itself is slow;
+    * `:runnable` — the holder is queued and NOT being scheduled, so
+      nothing about SQLite is slow and the runtime is the subject;
+    * `:waiting`  — the holder is parked in a receive.
+
+  Measured on the real thing (#1420, 2026-08-20): a process blocked inside
+  `Exqlite.Sqlite3NIF.execute/2` on a contended `BEGIN IMMEDIATE` reads
+  `:running`, and a process parked in a `receive` reads `:waiting`. So the
+  field discriminates, and printing it costs one interpolation.
+
+  ## Why this file exists instead of one more case in `lock_watch_test.exs`
+
+  That file buys REAL `SQLITE_BUSY` contention with a private `TmpRepo` on
+  a temp file, because its claim is that `acquired` fires only once SQLite
+  has granted `RESERVED`. This file's claim is narrower — what the report
+  string carries — and it needs no lock at all, so it drives the
+  production seam (`LockWatch.observe/1`) directly with parked processes.
+
+  **Honest limit, stated rather than implied:** nothing here proves the
+  holder/waiter split is faithful to a real `BEGIN IMMEDIATE`. That is
+  `lock_watch_test.exs`'s job and it is not duplicated here.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.Repo.LockWatch
+
+  setup do
+    LockWatch.put_test_enabled(true)
+    on_exit(fn -> LockWatch.put_test_enabled(false) end)
+    :ok
+  end
+
+  test "the stall warning names the holder's scheduler status, not only where it is" do
+    holder = start_role(:holder)
+    waiter = start_role(:waiter)
+
+    await_roles(holder, waiter)
+
+    log = capture_log(fn -> LockWatch.scan(0) end)
+
+    assert log =~ "db lock stall: holder #{inspect(holder)}"
+
+    # A mutant that drops the field — i.e. the message as it stood before
+    # #1420b — dies here and nowhere else. The value is `:waiting` and not
+    # a wildcard because a parked `receive` is deterministic: a holder that
+    # were still running would read `:running`, which is precisely the
+    # distinction the field exists to draw.
+    assert log =~ "status=:waiting"
+  end
+
+  ## ----- helpers --------------------------------------------------------
+
+  # Both roles go through `LockWatch.observe/1`, production's own wrapper:
+  # a holder is a transactor that calls `acquired`, a waiter is one that
+  # has not called it yet. Re-implementing the edge sequence here would
+  # assert against a copy of the mechanism instead of the mechanism.
+  defp start_role(role) do
+    test_pid = self()
+
+    pid = spawn(fn -> LockWatch.observe(&announce_then_park(role, test_pid, &1)) end)
+
+    # A failed assertion would otherwise leave the process parked inside
+    # `observe/1`, holding a watch-table row that poisons every later test.
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    assert_receive {^role, ^pid}, 5_000
+
+    pid
+  end
+
+  # Split out of `start_role/1` so no body nests deeper than two levels.
+  # A holder is a transactor that has called `acquired`; a waiter is one
+  # that has not.
+  defp announce_then_park(role, test_pid, acquired) do
+    if role == :holder, do: acquired.()
+    send(test_pid, {role, self()})
+    park()
+  end
+
+  defp park do
+    receive do
+      :never -> :ok
+    end
+  end
+
+  # A polled CONDITION, never a sleep: the two `send`s above prove the
+  # processes reached `observe/1`, not that the ETS rows are visible yet.
+  defp await_roles(holder, waiter), do: await_roles(holder, waiter, 300)
+
+  defp await_roles(holder, waiter, 0) do
+    flunk("roles never settled: #{inspect(LockWatch.inspect_lock())} (#{inspect({holder, waiter})})")
+  end
+
+  defp await_roles(holder, waiter, attempts) do
+    %{holders: holders, waiters: waiters} = LockWatch.inspect_lock()
+
+    if Enum.map(holders, & &1.pid) == [inspect(holder)] and Enum.map(waiters, & &1.pid) == [inspect(waiter)] do
+      :ok
+    else
+      Process.sleep(10)
+      await_roles(holder, waiter, attempts - 1)
+    end
+  end
+end

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -25,7 +25,7 @@ setup() {
     # prose fails here rather than reporting a confident zero.
     #   lock_watch.ex — the two edges of one stall episode
     #   busy_retry.ex — the two terminal arms, one per fault kind
-    LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder at :gen_server.loop/7, stack: a <- b'
+    LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
     LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for 30067ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
     SATURATED_LINE='db write unavailable: SQLite pool saturated for 1512ms across 14 attempts (1500ms retry budget) — returning :db_unavailable'


### PR DESCRIPTION
`Grappa.Repo.LockWatch.sample/2` has always collected the holder's
scheduler `status`, and the only door that reaches a CI container log —
the `Logger.warning` in `report/1` — threw it away. This prints it.

That one byte is the whole difference between two incompatible diagnoses
#1420 spent four days unable to separate:

| `status` | reading |
|---|---|
| `:running` | the holder really is inside the SQLite NIF — the write is slow |
| `:runnable` | the holder is queued and NOT being scheduled — nothing about SQLite is slow |
| `:waiting` | the holder is parked in a receive |

Measured before it was written, two arms of one call with only the TARGET
moving: a process blocked inside `Exqlite.Sqlite3NIF.execute/2` on a
contended `BEGIN IMMEDIATE` reads `:running`; a parked one reads
`:waiting`. The same measurement killed the fear that made the field look
expensive — `Process.info/2` on a process executing a **dirty** NIF (every
exqlite NIF is `ERL_NIF_DIRTY_JOB_IO_BOUND`) returns in **0 ms**, so
reading `status` cannot make the watchdog part of the incident it reports.

The three holder samples that reached a log in the 2026-08-20 field run sat
at `Sqlite3NIF.execute/2`, `Sqlite3NIF.transaction_status/1` and
`Sqlite3NIF.columns/2`. The last two are `sqlite3_get_autocommit()` and
`sqlite3_column_name()` — no IO, no lock — so `status` was the missing byte
in exactly the cases that mattered.

## Prose, not metadata

`held_ms` and `waiters` are Logger metadata; `status` is not. Those two are
MEASUREMENTS an operator aggregates, while `status` and `current_function`
are ONE answer split in half — where the holder is, and whether it is
running there at all. `message_queue_len` stays off the line: it rides the
telemetry door, which carries the whole sample into `Grappa.DbLatency`'s
ring.

## The two verbatim fixtures move with it

`scripts/log-gap-scan.awk`'s own positive control and the bats
`LOCKSTALL_LINE` both declare themselves *verbatim from the call site*, so
that a pin which drifts from production prose fails there instead of
reporting a confident zero. Not moving them would make both lie about the
shape they mirror. The matcher `/db lock stall: holder /` is unaffected —
`status=` lands after it.

## The test lives in a new file, on purpose

`lock_watch_test.exs` buys real `SQLITE_BUSY` contention with a private
`TmpRepo` because its claim needs a real `RESERVED`. This claim is only
about what the report string carries, so the new file drives the production
seam `LockWatch.observe/1` directly with parked processes, and says so in
its moduledoc. **`lock_watch_test.exs` is not touched.**

## Recipe — four checks

1. `scripts/check.sh` — green, `CHECK_RC=0` read from the command and not
   from a pipeline: credo strict *found no issues*, **6658 tests /
   0 failures**, dialyzer **Total errors: 0**, bats **1..596** with zero
   `not ok`.
2. The new test is RED before the change and GREEN after — the red reads
   `left: "… queued — holder at Grappa.Repo.LockWatchReportTest.park/0 …"`,
   i.e. the message is otherwise identical and only `status=` is missing.
3. `test/scripts/log_gap_scan_test.bats` still green with the updated
   `LOCKSTALL_LINE`, and the awk's own control (`ok 564 the shipped scanner
   passes its own controls and prints its census`) passes with the updated
   sample.
4. `scripts/design-notes-gate.sh` — *1 new entry heading, separator and
   marker present* (`<!-- entry #1420b -->`, checked unique against the
   base TIP, which already carries `#1420` and `#1420-instrument`).

## Not established

- **That `status` will read `:runnable` in the field.** The three samples
  on record predate this line; the field value is unknown until a stall
  recurs with the field printed. That is the point of shipping it.
- **That the log line is the right door at all.** It reaches an artefact
  only on a RED run. Dumping `Grappa.DbLatency`'s ring at e2e teardown was
  sized and NOT done — the e2e `grappa-test` container runs `mix phx.server`
  with no `--sname` and no `RELEASE_COOKIE`, so `bin/grappa`'s `--rpc-eval`
  door cannot reach it, and the HTTP door needs an admin bearer minted
  inside `cleanup()`.

Instrumentation only. No cure for #1420 is proposed or implied here.