### PR TITLE
ci(#1630): cache deps/ and the dep half of _build/ per shard

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,10 @@ name: integration
 #
 # Stack timing: cold ~6-8 min for the testnet+grappa+nginx images +
 # Playwright base pull; warm with cache it's faster but we don't cache
-# docker layers cross-runs (would need a registry push). The "suite runs
+# docker layers cross-runs (would need a registry push, or buildx
+# `type=gha` — unmeasured). The Elixir dep cache added in #1630 is a
+# DIFFERENT mechanism and reaches a different 97.5s; the step carries the
+# per-phase split of the boot that this line only totals. The "suite runs
 # in ~16s" that stood here was true of the first dozen specs and has not
 # been for a long time: measured 2026-08-20 it is 33.6 min of the 40.5,
 # which is what #1519 shards. The per-shard numbers are on the job below.
@@ -137,6 +140,13 @@ jobs:
     #  ------
     #  40.5 min  total
     #
+    # That 4.6 min line is a BUNDLE, and #1630 is what took it apart: of
+    # the equivalent 5m27s fixed cost on a post-shard run, 105.8s is mix
+    # (2.6 fetch + 94.9 deps + 8.4 app) and the remaining ~3m40s is
+    # submodules, solanum-from-source, the Playwright base pull, seeding
+    # and container health. Only the mix half has a cache step; the split
+    # and what it deliberately does not claim are on that step below.
+    #
     # Only the 33.6 divides. The other 6.8 min is fixed and every shard
     # pays it in full, so four shards land at ~15 min wall clock, not the
     # ~13.4 the issue's arithmetic gave (it counted the in-script boot and
@@ -178,8 +188,9 @@ jobs:
     # 589 of 590 by the cap alone, not by a failure; that must not recur.
     #
     # That raise bought headroom and fixed nothing; the SHARD below is the
-    # fix, and it is one of the three levers #1519 named (the other two —
-    # cache the dep compile, make the suite parallel-safe — are untouched).
+    # fix, and it is one of the three levers #1519 named (the second, cache
+    # the dep compile, landed in #1630; the third, make the suite
+    # parallel-safe, is untouched).
     # 60 stays: a backstop belongs far above the working range, and the
     # working range just fell to ~15 min, so the cap is further from firing
     # than it has ever been. If it is ever the thing tracking the suite's
@@ -241,6 +252,75 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Restore deps/ + the dep half of _build/ (#1630)
+        # The second #1519 lever. Measured off the job LOG of green run
+        # 32411402873 shard 1 (shard 2 agrees to 0.2s), not off the step
+        # summary — the summary bundles the whole boot into one number and
+        # that is what left the split unestablished in the issue:
+        #
+        #     2.6s  `mix deps.get`
+        #    94.9s  compiling the 76 deps, incl. the rebar3 natives (quic
+        #           5.1s, webtransport, hackney) and the exqlite/argon2 NIFs
+        #     8.4s  compiling grappa itself — 326 .ex, one `Compiling` line
+        #   ------
+        #   105.8s  of a 5m27s fixed cost, inside a 12m30s shard
+        #
+        # So 97.5s per shard is reachable from here and 8.4s is not. The
+        # REST of the fixed cost is not reachable either, and is not claimed:
+        # 29.5s recursive submodule checkout, 43.1s solanum built from
+        # source, 30.6s building the Playwright runner image (736 MB base
+        # pull), 32.6s ecto.create + migrate + seed, 21s container health.
+        # Those are docker-layer or network — buildx `type=gha` territory, a
+        # different mechanism, still unmeasured, still unclaimed.
+        #
+        # The seeder runs MIX_ENV=dev inside `elixir:1.19-otp-28-alpine` over
+        # the `../..:/app` bind mount (cicchetto/e2e/compose.yaml), and the
+        # Dockerfile bakes no deps on purpose (its line 43 says so), so deps/
+        # and _build/dev/ are written to the RUNNER's workspace. That is what
+        # makes them reachable by actions/cache at all. ~31 MB compressed,
+        # against a 10 GB per-repo LRU budget.
+        #
+        # WHY THE PATH LIST EXCLUDES `_build/dev/lib/grappa` — this is the
+        # contamination answer, and it is the reason this step is safe.
+        # CLAUDE.md documents the failure class: a `_build` shared between
+        # worktrees produced a red belonging to NO branch (#1170 — a
+        # `Grappa.Version` compiled from another tree's `VERSION`). A CI
+        # cache is that same shape at GitHub scale. The cure is not a
+        # cleverer key, it is to put nothing branch-specific IN the cache:
+        # what is stored is a pure function of files that are themselves in
+        # the key. There is no branch-specific artefact to restore because
+        # none was ever saved.
+        #
+        # And the exclusion is free. `actions/checkout` writes every source
+        # with mtime=now, newer than any restored manifest, so mix recompiles
+        # the app on every run whether or not its beams were restored — the
+        # 8.4s above is paid either way. `VERSION` is deliberately absent
+        # from the key for the same reason: it reaches only the app's beams.
+        #
+        # The `e2e-musl-` namespace is disjoint from ci.yml's
+        # `${{ runner.os }}-mix-` and MUST stay so. These beams are built
+        # under alpine/musl; ci.yml's are built by setup-beam on glibc.
+        # exqlite and argon2_elixir ship NIFs, and mix rebuilds a NIF on
+        # absence, not on ABI — so a crossed restore hands the alpine
+        # container a glibc `.so` it considers built. `restore-keys` carries
+        # the same prefix so prefix matching cannot reach across either.
+        #
+        # A stale key is SLOW, never WRONG: `mix deps.get` reconciles deps/
+        # against mix.lock, and each dep's `.mix/compile.{lock,elixir_scm}`
+        # forces a recompile when its lock entry or the Elixir version moved.
+        # That is the backstop for the floating `1.19-otp-28-alpine` tag,
+        # which `hashFiles('Dockerfile')` cannot see through.
+        id: mix-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            deps
+            _build/dev/lib
+            !_build/dev/lib/grappa
+          key: ${{ runner.os }}-e2e-musl-mix-${{ hashFiles('mix.lock', 'mix.exs', 'Dockerfile', 'config/*.exs') }}
+          restore-keys: |
+            ${{ runner.os }}-e2e-musl-mix-
+
       - name: Run integration suite
         # `bash scripts/integration.sh` boots the stack, runs the
         # Playwright suite, tears the stack down on EXIT trap. Exit
@@ -264,6 +344,34 @@ jobs:
         env:
           COMPOSE_FILE: compose.yaml:compose.ghcr-vjt.yaml
         run: bash scripts/integration.sh --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+
+      - name: Save deps/ + the dep half of _build/ (#1630)
+        # ONE writer. All four shards do byte-identical mix work under one
+        # key, so letting all four save is three redundant uploads racing for
+        # an entry that is immutable once written. Shard 1 writes, the rest
+        # read. The paths are repeated because cache/save takes its own —
+        # they MUST stay identical to the restore step's.
+        #
+        # `success() || failure()` and NOT `always()`: `always()` also fires
+        # on CANCELLED, and this workflow sets `cancel-in-progress: true`, so
+        # a superseded run would freeze a half-compiled tree under the key
+        # and no later run could replace it. A FAILED run's tree is worth
+        # keeping — mix's build is incremental by construction, a partial one
+        # is exactly what any interrupted compile leaves and the next run
+        # finishes it. That also means a red iteration under a NEW key still
+        # warms the cache, which is when warmth is worth most.
+        #
+        # Skipped on an EXACT hit — the entry exists, saving would only log a
+        # collision. A `restore-keys` partial hit is not a hit and DOES save:
+        # that run is the one that just compiled the delta.
+        if: matrix.shard == 1 && steps.mix-cache.outputs.cache-hit != 'true' && (success() || failure())
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            deps
+            _build/dev/lib
+            !_build/dev/lib/grappa
+          key: ${{ steps.mix-cache.outputs.cache-primary-key }}
 
       - name: Upload Playwright traces (on failure)
         # Every artifact name below carries the shard (#1519). Not cosmetic:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55061,3 +55061,148 @@ edge, `from(s in Mod)` does — is quoted from the `--force
 --warnings-as-errors` run recorded in #1521 (`03e7254b`), not re-measured on
 this branch. The one measurement taken here is the absence of
 `find_violations` from `deps/boundary` at 0.10.4._
+<!-- entry #1630 -->
+
+---
+
+## 2026-08-20 — #1630: 97.5s of the e2e boot is cacheable, and the other ~3m40s is not
+
+The second lever of #1519, after the four-way shard. The shard bought ~2.6x
+(39m25-40m10 down to 14m41-15m55, four runs a side) and what it left is
+dominated by a fixed cost that **every shard pays in full**, so a second
+removed there is four seconds of runner time.
+
+### The split, because the issue said it was not established
+
+The workflow's own comment block quoted **4.6 min for `testnet up`: "mix
+deps.get + Elixir compile, solanum built from source, image assembly,
+container health"** — one number over four different mechanisms. The step
+summary cannot take that apart; the job LOG can. Read off green run
+32411402873 shard 1 (`96562423684`), with shard 2 (`96562423519`) as the
+cross-check — the two agree on the mix total to **0.2s**:
+
+| phase | shard 1 |
+|---|---|
+| checkout, `submodules: recursive` | 29.5s |
+| compose plugin + GHCR login | 0.9s |
+| build the `grappa:e2e` toolchain image | 8.7s |
+| seeder container up | 3.1s |
+| **`mix deps.get`** | **2.6s** |
+| **compile the 76 deps** (incl. rebar3 `quic` 5.1s, `webtransport`, `hackney`, and the `exqlite`/`argon2_elixir` NIFs) | **94.9s** |
+| **compile grappa** — 326 `.ex`, one `Compiling` line | **8.4s** |
+| `ecto.create` + migrate + seed | 32.6s |
+| pull the GHCR bahamut/services/nginx/mailpit/bun images | 3.7s |
+| build solanum from source | 43.1s |
+| container create/start/health → `testnet up.` | 21.2s |
+| build the Playwright runner image (736 MB base pull, 22.2s of it) | 30.6s |
+| build push-catcher + start the runner | 22.0s |
+| **the Playwright suite** — 190 tests, one worker | **7m3.5s** |
+| census + tear-down | 20.7s |
+| **job total** | **12m30s** |
+
+So the fixed cost is **5m27s**, of which **105.8s is mix** and 8.4s of that is
+the app. **97.5s per shard is what a host-side `actions/cache` can reach** —
+13% of the shard's wall clock, 30% of its fixed cost.
+
+The premise that makes it reachable at all is the `Dockerfile`'s own rule at
+line 43 (*"Do not add a `mix deps.get` layer here"*): the image is
+toolchain-only and the seeder runs `MIX_ENV=dev` over the `../..:/app` bind
+mount, so `deps/` and `_build/dev/` are written to the **runner's workspace**,
+not into an image layer. Verified in `cicchetto/e2e/compose.yaml` — no named
+volume shadows either path.
+
+### What is NOT claimed
+
+The remaining ~3m40s of fixed cost is **out of `actions/cache`'s reach** and no
+number here should be read as promising it: 29.5s of recursive submodule
+checkout (26.3s of it `submodule update`, most of it `shottino`'s
+`libdatachannel` tree, which this suite never builds), 43.1s of solanum from
+source, 30.6s for the Playwright runner image behind a 736 MB base pull, 32.6s
+of seeding, 21.2s of container health. Those are docker-layer or network —
+buildx `type=gha` territory, a **different mechanism**, still unmeasured, still
+unclaimed, exactly as #1519 already said of it.
+
+Also not measured here, and named so nobody reads its absence as a zero:
+cicchetto/bun and the Playwright browser bundle. Both are inside the container
+builds above, not on the runner's `~/.bun` or `~/.cache/ms-playwright`.
+
+The issue estimated *"~2 min of the fixed cost, so ~15m -> ~13m per shard"*.
+The measurement puts the CEILING at 97.5s, before the cache's own
+download+extract is subtracted — the estimate was in the right family and
+slightly hot.
+
+### Why this is not #1170 at GitHub scale
+
+CLAUDE.md documents the class in the strongest terms available: a `_build`
+shared between worktrees produced **a red that belonged to no branch** — a
+`Grappa.Version` compiled from another tree's `VERSION`. A CI cache of `_build`
+is the same shape with GitHub's fleet behind it: artefacts compiled from
+another commit's source, restored onto yours, making green what is not.
+
+The defence is not a cleverer key. **It is that nothing branch-specific is ever
+written.** The cache holds `deps/` and the deps' beams — both a pure function
+of files that are themselves in the key — and `_build/dev/lib/grappa` is
+excluded from the path list. There is no branch-specific artefact to restore
+because none was ever saved.
+
+And the exclusion is **free**, which is what makes it the right answer rather
+than a sacrifice: `actions/checkout` writes every source with `mtime=now`,
+newer than any restored manifest, so mix recompiles the app on every run
+whether or not its beams came back. The 8.4s is paid either way. `VERSION` is
+deliberately absent from the key for the same reason — it reaches only the
+app's own beams, which are not in the cache.
+
+Three more properties, each load-bearing:
+
+- **`deps/` and `_build` are ONE cache entry, not two.** Split, a re-fetched
+  `deps/` would carry fresh mtimes against an old `_build` manifest and mix
+  would recompile everything — the cache would cost more than it saved. One
+  tarball preserves the relative order.
+- **The `e2e-musl-` namespace is disjoint from `ci.yml`'s `-mix-`, and the
+  `restore-keys` prefix with it.** These beams are built under
+  `elixir:1.19-otp-28-alpine`; ci.yml's are built by `setup-beam` on glibc
+  ubuntu. `exqlite` and `argon2_elixir` ship NIFs, and **mix rebuilds a NIF on
+  ABSENCE, not on ABI** — a crossed restore hands the alpine container a glibc
+  `.so` that mix considers built and will not replace.
+- **A stale key is SLOW, never WRONG.** `mix deps.get` reconciles `deps/`
+  against `mix.lock`, and each dep's `.mix/compile.{lock,elixir_scm}` forces a
+  recompile when its lock entry or the Elixir version moved. That is the
+  backstop for the floating `1.19-otp-28-alpine` tag, which
+  `hashFiles('Dockerfile')` cannot see through — the tag drifting costs a cold
+  run, not a wrong one.
+
+### One writer, and the `always()` trap
+
+Four shards do byte-identical mix work under one key, so `actions/cache` is
+split into `restore` (all four) and `save` (shard 1 only); three concurrent
+uploads racing for an entry that is immutable once written buy nothing.
+
+The save condition is `success() || failure()` and **deliberately not
+`always()`**: `always()` also fires on CANCELLED, and this workflow sets
+`cancel-in-progress: true`, so a superseded run would freeze a half-compiled
+tree under the key and **no later run could replace it**. A FAILED run's tree
+is worth keeping — mix's build is incremental by construction, a partial one is
+what any interrupted compile leaves and the next run finishes it — and that is
+also when warmth is worth most, iterating on a red under a new key.
+
+Size, measured on a local `deps` + dep-half-of-`_build` (a darwin build, so the
+same order rather than the same bytes as the musl one): **~31 MB zstd**,
+against a 10 GB per-repo LRU budget. The key changes only when `mix.lock`,
+`mix.exs`, `Dockerfile` or `config/*.exs` do, so most branches produce main's
+key and write nothing at all.
+
+### What has not been measured, and cannot be from here
+
+**The gain itself.** The first run after this lands is COLD by construction —
+it has no entry to restore and pays the full 105.8s — so its wall clock proves
+nothing, and the honest comparison is the SECOND run on the same key. That
+number does not exist yet and is not asserted anywhere in this entry or in the
+workflow. What is asserted is the 97.5s ceiling the log shows, and the claim
+that the restore cannot make a run wrong.
+
+`test/infra/integration_dep_cache_test.bats` guards the two invariants that
+would rot silently and take nothing red with them: the path list never carrying
+the app's own build dir (with restore and save compared against each other, not
+against a transcribed copy, since `cache/save` takes its own `path:`), and the
+two key namespaces staying disjoint. Its stated limit: it compares the key
+strings as written, `${{ }}` unexpanded.

--- a/test/infra/integration_dep_cache_test.bats
+++ b/test/infra/integration_dep_cache_test.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1630 — the `integration` workflow's Elixir dep cache
+# must never carry a branch-specific build artefact, and must never share a
+# key namespace with `ci.yml`'s.
+#
+# Both invariants are one edit away from being lost, and both fail SILENTLY.
+#
+# 1. CONTAMINATION. CLAUDE.md documents the class: a `_build` shared between
+#    worktrees produced a red that belonged to no branch (#1170 — a
+#    `Grappa.Version` compiled from another tree's `VERSION`). A CI cache is
+#    that same shape at GitHub scale. The step's defence is not a cleverer
+#    key, it is that nothing branch-specific is ever WRITTEN: the cache holds
+#    `deps/` and the deps' beams, both a pure function of files that are
+#    themselves in the key. Widening the path list to a bare `_build` would
+#    restore the whole class, and nothing would go red — a run would just
+#    quietly be judging artefacts compiled from another commit's source.
+#
+# 2. ABI. These beams are built inside `elixir:1.19-otp-28-alpine`; ci.yml's
+#    are built by setup-beam on glibc ubuntu. `exqlite` and `argon2_elixir`
+#    ship NIFs, and mix rebuilds a NIF on ABSENCE, not on ABI — so a restore
+#    that crossed the two would hand the alpine container a glibc `.so` that
+#    mix considers built and will not replace. The namespaces are disjoint by
+#    construction (`-mix-` vs `-e2e-musl-mix-`) and a `restore-keys` prefix
+#    added on either side could quietly bridge them.
+#
+# The path-list checks compare the restore step's list against the save
+# step's rather than against a transcribed copy: `actions/cache/save` takes
+# its own `path:`, so the two can drift apart, and a cache saved over a wider
+# path than it is restored from is exactly how the app's beams would sneak
+# back in.
+#
+# STATED LIMIT of the collision check: it compares the key strings as WRITTEN,
+# with `${{ }}` unexpanded. It therefore catches the namespace being widened
+# or renamed into the other's — the way a collision would actually be
+# introduced — but not two literals that differ in source and coincide only
+# after expansion. Expanding them would need a runner.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    INTEGRATION="$REPO_ROOT/.github/workflows/integration.yml"
+    CI="$REPO_ROOT/.github/workflows/ci.yml"
+}
+
+# Every `path: |` block scalar in a workflow, entries trimmed, blocks
+# separated by a `---` line. The single-line `path:` of the four
+# upload-artifact steps is a different shape and is deliberately not matched.
+path_blocks() {
+    awk '
+        /^[[:space:]]*path:[[:space:]]*\|[[:space:]]*$/ {
+            indent = match($0, /[^ ]/) - 1
+            inblock = 1
+            print "---"
+            next
+        }
+        inblock {
+            if ($0 ~ /^[[:space:]]*$/) { inblock = 0; next }
+            if (match($0, /[^ ]/) - 1 <= indent) { inblock = 0; next }
+            entry = $0
+            sub(/^[[:space:]]+/, "", entry)
+            print entry
+            next
+        }
+    ' "$1"
+}
+
+# Every cache key literal: the `key:` one-liners plus every entry of a
+# `restore-keys: |` block. One per line, leading/trailing space stripped.
+cache_keys() {
+    awk '
+        /^[[:space:]]*key:[[:space:]]/ {
+            entry = $0
+            sub(/^[[:space:]]*key:[[:space:]]*/, "", entry)
+            print entry
+            next
+        }
+        /^[[:space:]]*restore-keys:[[:space:]]*\|[[:space:]]*$/ {
+            indent = match($0, /[^ ]/) - 1
+            inblock = 1
+            next
+        }
+        inblock {
+            if ($0 ~ /^[[:space:]]*$/) { inblock = 0; next }
+            if (match($0, /[^ ]/) - 1 <= indent) { inblock = 0; next }
+            entry = $0
+            sub(/^[[:space:]]+/, "", entry)
+            sub(/[[:space:]]+$/, "", entry)
+            print entry
+            next
+        }
+    ' "$1"
+}
+
+@test "the e2e dep cache restores and saves the SAME path list (#1630)" {
+    blocks="$(path_blocks "$INTEGRATION")"
+
+    # Anti-vacuity: two blocks, no more and no fewer. A third cache step, or
+    # a parser that matched nothing, must not slip past the comparison below.
+    count="$(printf '%s\n' "$blocks" | grep -c '^---$' || true)"
+    [ "$count" -eq 2 ] || {
+        echo "expected exactly 2 'path: |' blocks in integration.yml, found $count:" >&2
+        printf '%s\n' "$blocks" >&2
+        return 1
+    }
+
+    restore="$(printf '%s\n' "$blocks" | awk '/^---$/ { n++; next } n == 1')"
+    save="$(printf '%s\n' "$blocks" | awk '/^---$/ { n++; next } n == 2')"
+
+    [ -n "$restore" ] || { echo "the restore step's path list is empty" >&2; return 1; }
+    [ "$restore" = "$save" ] || {
+        echo "cache/restore and cache/save disagree on 'path:' (#1630)." >&2
+        echo "A save wider than its restore is how the app's own beams get" >&2
+        echo "into the cache without anything going red." >&2
+        echo "--- restore ---" >&2; printf '%s\n' "$restore" >&2
+        echo "--- save ---" >&2;    printf '%s\n' "$save" >&2
+        return 1
+    }
+}
+
+@test "the e2e dep cache never carries grappa's own build dir (#1630)" {
+    # The app's beams are branch-specific — that is the #1170 class. They are
+    # also worthless to cache: `actions/checkout` writes every source with
+    # mtime=now, newer than any restored manifest, so mix recompiles the app
+    # regardless. Excluding them costs nothing and closes the class.
+    restore="$(path_blocks "$INTEGRATION" | awk '/^---$/ { n++; next } n == 1')"
+
+    printf '%s\n' "$restore" | grep -qxF '!_build/dev/lib/grappa' || {
+        echo "the '!_build/dev/lib/grappa' exclusion is gone (#1630):" >&2
+        printf '%s\n' "$restore" >&2
+        return 1
+    }
+
+    # Any UNNEGATED entry that contains the app's build dir reinstates it,
+    # whichever spelling is used to get there.
+    while IFS= read -r entry; do
+        case "$entry" in
+            '!'*) continue ;;
+            _build | _build/ | _build/dev | _build/dev/ | _build/dev/lib/grappa*)
+                echo "cache path '$entry' carries _build/dev/lib/grappa (#1630)." >&2
+                echo "A CI cache of the app's own beams is #1170 at GitHub scale:" >&2
+                echo "artefacts compiled from another commit's source, restored" >&2
+                echo "onto yours, going green for reasons that are not yours." >&2
+                return 1
+                ;;
+        esac
+    done <<<"$restore"
+}
+
+@test "the e2e cache keys cannot collide with ci.yml's glibc ones (#1630)" {
+    e2e_keys="$(cache_keys "$INTEGRATION")"
+    ci_keys="$(cache_keys "$CI")"
+
+    # Anti-vacuity on both sides: ci.yml carries the mix, PLT and bun caches;
+    # integration.yml carries this one. An empty side would pass silently.
+    [ "$(printf '%s\n' "$e2e_keys" | grep -c . || true)" -ge 2 ] || {
+        echo "found no cache keys in integration.yml — the parser is wrong" >&2
+        return 1
+    }
+    [ "$(printf '%s\n' "$ci_keys" | grep -c . || true)" -ge 4 ] || {
+        echo "found <4 cache keys in ci.yml — the parser is wrong:" >&2
+        printf '%s\n' "$ci_keys" >&2
+        return 1
+    }
+
+    # `restore-keys` is PREFIX matching, so the two namespaces collide the
+    # moment either side's key starts with the other side's. Compare both
+    # directions over the full cross product — a one-directional check would
+    # miss a prefix added on the ci.yml side.
+    while IFS= read -r a; do
+        [ -n "$a" ] || continue
+        while IFS= read -r b; do
+            [ -n "$b" ] || continue
+            case "$a" in "$b"*) ;; *) case "$b" in "$a"*) ;; *) continue ;; esac ;; esac
+            echo "cache key namespaces overlap (#1630):" >&2
+            echo "  integration.yml: $a" >&2
+            echo "  ci.yml:          $b" >&2
+            echo "One set of beams is built under alpine/musl and the other" >&2
+            echo "by setup-beam on glibc; exqlite and argon2_elixir ship NIFs" >&2
+            echo "that mix rebuilds on absence, not on ABI." >&2
+            return 1
+        done <<<"$ci_keys"
+    done <<<"$e2e_keys"
+}


### PR DESCRIPTION
Second lever of #1519, after the four-way shard. Refs #1630.

## The measurement came first, and it moved the estimate

The issue asked for the split before anything was built, because the
workflow's own comment quoted **4.6 min for `testnet up`** as one number
over four different mechanisms. Read off the job LOG of green run
`32411402873` shard 1 (`96562423684`), with shard 2 as the cross-check —
the two agree on the mix total to **0.2s**:

| phase | shard 1 |
|---|---|
| `mix deps.get` | **2.6s** |
| compile the 76 deps (rebar3 `quic` 5.1s, `hackney`, the `exqlite`/`argon2` NIFs) | **94.9s** |
| compile grappa — 326 `.ex` | **8.4s** |
| checkout, `submodules: recursive` | 29.5s |
| solanum built from source | 43.1s |
| Playwright runner image (736 MB base pull) | 30.6s |
| `ecto.create` + migrate + seed | 32.6s |
| container create/start/health | 21.2s |
| the Playwright suite (190 tests, one worker) | 7m3.5s |
| **job total** | **12m30s** |

Fixed cost **5m27s**, of which **105.8s is mix**. So **97.5s per shard is
reachable** by `actions/cache` and 8.4s is not — 13% of the shard's wall
clock, 30% of its fixed cost. The issue's `~2 min -> ~13m` was in the
right family and slightly hot.

**Not claimed:** the other ~3m40s is submodules, solanum-from-source, a
736 MB Playwright base pull, seeding and container health — docker-layer
or network, i.e. buildx `type=gha`, a different mechanism, unmeasured.
bun and the Playwright browsers are not measured at all (they live inside
those container builds, not on the runner's caches).

**Also not measured, and deliberately not asserted anywhere: the gain.**
The first run after this lands is COLD by construction, so its wall clock
proves nothing; the honest comparison is the SECOND run on the same key.

## Why this is not #1170 at GitHub scale

CLAUDE.md documents the class: a `_build` shared between worktrees
produced a red that belonged to no branch. A CI cache of `_build` is the
same shape with a fleet behind it.

The defence is not a cleverer key — **nothing branch-specific is ever
written.** The cache holds `deps/` and the deps' beams, both a pure
function of files that are themselves in the key; `_build/dev/lib/grappa`
is excluded. And the exclusion is **free**: `actions/checkout` writes
every source with `mtime=now`, so mix recompiles the app on every run
whether or not its beams came back. `VERSION` is absent from the key for
the same reason.

Three more, each load-bearing:

- **`deps/` and `_build` are ONE entry.** Split, a re-fetched `deps/`
  carries fresh mtimes against an old manifest and mix recompiles
  everything — the cache would cost more than it saved.
- **The `e2e-musl-` namespace is disjoint from `ci.yml`'s `-mix-`**, and
  the `restore-keys` prefix with it. These beams are built under
  `elixir:1.19-otp-28-alpine`; ci.yml's by `setup-beam` on glibc.
  `exqlite` and `argon2_elixir` ship NIFs, and **mix rebuilds a NIF on
  ABSENCE, not on ABI**.
- **A stale key is SLOW, never WRONG.** `deps.get` reconciles against
  `mix.lock`, and each dep's `.mix/compile.{lock,elixir_scm}` forces a
  recompile when its lock entry or the Elixir version moved — the backstop
  for the floating tag `hashFiles('Dockerfile')` cannot see through.

**One writer:** four shards do byte-identical work under one key, so
`restore` runs on all four and `save` on shard 1. The condition is
`success() || failure()` and **not `always()`** — `always()` also fires on
CANCELLED, and this workflow sets `cancel-in-progress`, so a superseded
run would freeze a half-compiled tree under a key no later run could
replace. ~31 MB compressed, against a 10 GB per-repo LRU budget.

## Guard

`test/infra/integration_dep_cache_test.bats` — three cases over the two
invariants that would rot silently: the path list never carrying the app's
own build dir (restore and save compared against **each other**, since
`cache/save` takes its own `path:`), and the key namespaces staying
disjoint. Stated limit: it compares the keys as written, `${{ }}`
unexpanded. Each case was killed by its own mutant, one kill per
assertion.

## Gates

- `scripts/check.sh` → **rc 0** — 8 doctests / 61 properties / 6658 tests,
  0 failures; credo `6096 mods/funs, found no issues`; sobelow
  `Total errors: 0`; dialyzer `done (passed successfully)`; bats `1..615`
- `scripts/bats.sh` (full set) → **615/615, 0 `not ok`**
- `scripts/bun.sh run test` → **295 files / 5708 tests passed**
- `scripts/bun.sh run check` → **4 stages ran, 0 failed**
- `scripts/union-rebase.sh origin/main` → `+145 -0 — contribution intact`

The base moved during the work; the move was **docs only** (CLAUDE.md +
DESIGN_NOTES, 106 insertions, 0 deletions, and nothing under
`.github/workflows/`), so the pre-rebase greens carry — the workflow bats
were re-run on the rebased tree anyway (15/15).

This PR touches `.github/workflows/integration.yml`, which **is** in the
`paths:` filter, so `integration` will run — ~15 min, four shards, and the
first one is cold.