### PR TITLE
test(#1546): close the AdminEvents persist/retention leak at its root

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55206,3 +55206,107 @@ the app's own build dir (with restore and save compared against each other, not
 against a transcribed copy, since `cache/save` takes its own `path:`), and the
 two key namespaces staying disjoint. Its stated limit: it compares the key
 strings as written, `${{ }}` unexpanded.
+<!-- entry #1546 -->
+
+---
+
+## 2026-08-21 — #1546: cleanup that only runs when the test passes is not cleanup
+
+`Grappa.AdminEvents` is a singleton started by `Grappa.Application`. It
+outlives every sandbox checkout, so anything a test writes into its state is
+still there for the next test — and for the next FILE. Seven test files opened
+their `setup` by resetting it; #1397 gave those seven one shared verb,
+`AdmissionStateHelpers.reset_admin_events/0`, and a no-op mutant on that verb
+reddened 14–16 of 177, which is how #1546 got filed.
+
+The number was never the finding. `reset_admin_events/0` does **two** things —
+it empties the ring, and it rebuilds the struct, so `persist` and `retention`
+go back to their `defstruct` defaults — and a mutant that removes the whole
+function removes both at once. Separating the two axes is what changed the
+answer, and the second axis is the one the original ticket does not name.
+
+### The leak, and why it is not cosmetic
+
+`admin_events_test.exs` is the only file in all of `test/` that writes
+`persist` / `retention`. It restored them with straight-line statements in the
+test BODIES. A failing assertion above such a statement skips it: two windows,
+both requiring another test to have already failed.
+
+What escapes is not a stale flag. `persist: true` makes the singleton write to
+the Repo from its own pid, which is `Sandbox.allow`ed only inside that one
+file, so it dies inside some unrelated file's `setup`. The failure then names a
+file that did nothing wrong and the real one is already off screen (#1613 is
+the sibling defect that erases the reason on the way out). **That cascade is
+what the "not load-bearing" resets on the two zero-read files were actually
+suppressing** — which is why they could not simply be deleted: removing them
+without closing the leak first *introduces* the noise, it does not remove a
+redundancy.
+
+### The fix is a placement, not a verb
+
+One `on_exit(&AdmissionStateHelpers.reset_admin_events/0)` in the setup of the
+one file that dirties. Cleanup registered as a callback is off the happy path
+by construction — it runs on pass, on failure and on raise alike — so the two
+censused windows close and no future window can open in that file either,
+including in tests nobody has written yet. `session_log_persistence_test.exs`
+already had this shape; the general rule it embodies is worth stating plainly:
+**a restore belongs in `on_exit`, never in a test body.** A restore in the body
+is exactly as reliable as the assertions above it.
+
+`reset_admin_events/0` itself was deliberately not touched. The defect was
+where the restore sat, not what it did.
+
+### Gating an `on_exit` needs no seam
+
+The witness is a tag-gated test that dirties and deliberately never restores —
+the failing-assert path minus the failure. Its verdict is another `on_exit`,
+registered FIRST, because ExUnit runs the callbacks in reverse registration
+order: registered first means run last, which is the only position from which
+one callback can read what another left. A `raise` there reddens the test and
+the stacktrace names `ExUnit.OnExitHandler.exec_callback/1`. No exported seam,
+no test-only production API.
+
+Tag-gating is not decoration. An always-on watcher would have made one mutant
+redden the whole file; gated, dropping the restore kills exactly one assertion.
+
+### The pin is what keeps the argument true
+
+"The one file that writes those fields" is the load-bearing clause of the whole
+fix, and it was a hand-run grep. `admin_events_dirt_sources_test.exs` freezes
+it as a derived census: glob `test/`, count the sites reaching the singleton's
+state through `:sys`, require the set to equal the two known ones. It also
+asserts those two are non-empty — an anchor that drifted would otherwise turn
+the pin green by matching nothing, which is the vacuous green a positive
+control exists to refuse. Both halves were measured against mutants, not
+assumed. What the anchor cannot see is stated in its moduledoc: a `:sys` call
+through a pid bound earlier. It is a tripwire on the common shape, not a proof
+of impossibility.
+
+### Two of the three resets fell; the third did not, and that is the result
+
+With the leak closed, `users_controller_test.exs` and
+`credentials_controller_test.exs` lost their last function and went. Neither
+contains an `AdminEvents.*` call, so the ring they emptied is unobservable from
+inside them under any ordering; what they observe is the PubSub broadcast, and
+a broadcast is never re-emitted by a stale ring. The control that makes that
+green mean something: with `record/1` swallowing every synthetic event those
+two files fail 8 tests — 5 and 3, 100% of each file's emission describe.
+
+`networks_controller_test.exs` **keeps** its reset. It reads the ring, and the
+reset is protection against a false PASS: break the emission and a stale
+`:network_caps_updated` at the head still satisfies `[head | _]`, so the
+assertions pass on the wrong row. That is the ring axis, which this fix does
+not touch. A root fix that made all three fall would have been the tidier
+story; the third one staying is the evidence that the two axes are genuinely
+two, and the comment there now records which future change re-arms the trap
+(dropping the cap assertion, or adding a sibling that PATCHes user cap to 4).
+
+### Not established
+
+The 14/16 was never re-run and is not a target — it is seed-dependent and does
+not exist as a fixed quantity, which the ticket already said of its own
+numbers. Only the eight admin files were run, never the full suite. The
+persist/retention axis remains unmeasured for `networks_controller_test.exs`.
+Whether `terminate/2`'s badmatch is reachable in production is #1613's
+question, not this one's — the cascade amplifier is still there, this fix
+removes the thing that fed it.

--- a/test/grappa/admin_events_dirt_sources_test.exs
+++ b/test/grappa/admin_events_dirt_sources_test.exs
@@ -60,7 +60,7 @@ defmodule Grappa.AdminEventsDirtSourcesTest do
   test "only the censused files write the AdminEvents singleton's state" do
     by_file = writers()
 
-    assert Map.keys(by_file) |> Enum.sort() == Enum.sort(@allowed),
+    assert Enum.sort(Map.keys(by_file)) == Enum.sort(@allowed),
            """
            A file outside the #1546 census writes `Grappa.AdminEvents`'
            singleton state via :sys.

--- a/test/grappa/admin_events_dirt_sources_test.exs
+++ b/test/grappa/admin_events_dirt_sources_test.exs
@@ -1,0 +1,98 @@
+defmodule Grappa.AdminEventsDirtSourcesTest do
+  @moduledoc """
+  Census pin for who may write `Grappa.AdminEvents`' singleton state
+  from a test (#1546).
+
+  `Grappa.AdminEvents` is started by `Grappa.Application` and outlives
+  every sandbox checkout, so `persist` / `retention` written by one test
+  are still there for the next FILE. `persist: true` escaping is not a
+  cosmetic leak: the singleton then writes to the Repo from its own pid,
+  which is `Sandbox.allow`ed only inside `admin_events_test.exs`, so it
+  dies inside some unrelated file's `setup` — a cascade whose failure
+  text names a file that did nothing wrong (#1613 is the sibling defect
+  that erases the reason).
+
+  The root fix for that is a restore registered as an `on_exit`, off the
+  test's happy path, in the ONE file that writes those fields. That
+  argument only holds while "the ONE file" stays true — which is exactly
+  what this pin measures. A new file that starts writing the singleton's
+  state has re-opened the class and needs its own `on_exit`.
+
+  DERIVED, not manifested (CLAUDE.md — derive, don't duplicate): the
+  writer set is grepped out of `test/` rather than hand-listed, so a new
+  file is caught by the glob and not by anyone remembering to update a
+  list. The allowed sites are asserted NON-EMPTY too — a rename that
+  made the anchor stop matching would otherwise turn this pin green by
+  matching nothing at all.
+
+  ## What the anchor cannot see
+
+  `:sys.replace_state/2` reached through a pid bound earlier (e.g.
+  `pid = Process.whereis(AdminEvents)`) is invisible to a textual
+  anchor. No such site exists today (the two allowed files both name
+  the module inline); the pin is a tripwire on the cheap, common shape,
+  not a proof of impossibility.
+  """
+
+  # async: true — pure file reads, no global state.
+  use ExUnit.Case, async: true
+
+  @test_glob "test/**/*.{ex,exs}"
+
+  # Written by hand rather than derived: this IS the census the pin
+  # freezes. Adding a path here is the review moment the pin exists to
+  # force.
+  @allowed [
+    # The shared reset verb itself — the sanctioned way back to a
+    # booted struct.
+    "test/support/admission_state_helpers.ex",
+    # The only file that dirties `persist` / `retention`, and the one
+    # whose setup registers the file-wide `on_exit` restore.
+    "test/grappa/admin_events_test.exs"
+  ]
+
+  # This file spells the anchor in its own source (in prose, and in the
+  # pattern below). It writes nothing.
+  @self "test/grappa/admin_events_dirt_sources_test.exs"
+
+  @anchor ~r/:sys\.replace_state\(\s*(?:Grappa\.)?AdminEvents\b/
+
+  test "only the censused files write the AdminEvents singleton's state" do
+    by_file = writers()
+
+    assert Map.keys(by_file) |> Enum.sort() == Enum.sort(@allowed),
+           """
+           A file outside the #1546 census writes `Grappa.AdminEvents`'
+           singleton state via :sys.
+
+           found:   #{inspect(Enum.sort(Map.keys(by_file)))}
+           allowed: #{inspect(Enum.sort(@allowed))}
+
+           If the new file dirties `persist` or `retention`, register a
+           restore as an `on_exit` (never a straight-line statement in
+           the test body — a failing assertion above it skips it) and
+           add the path to @allowed. If it only empties the ring, call
+           `AdmissionStateHelpers.reset_admin_events/0` instead.
+           """
+  end
+
+  test "each censused file still writes it — the pin is not matching nothing" do
+    by_file = writers()
+
+    for path <- @allowed do
+      assert Map.get(by_file, path, 0) > 0,
+             "#{path} no longer writes the AdminEvents singleton via :sys — " <>
+               "either the anchor drifted (this pin now proves nothing) or the " <>
+               "path belongs out of @allowed."
+    end
+  end
+
+  defp writers do
+    @test_glob
+    |> Path.wildcard()
+    |> Enum.reject(&(&1 == @self))
+    |> Enum.map(fn path -> {path, length(Regex.scan(@anchor, File.read!(path)))} end)
+    |> Enum.reject(fn {_, count} -> count == 0 end)
+    |> Map.new()
+  end
+end

--- a/test/grappa/admin_events_test.exs
+++ b/test/grappa/admin_events_test.exs
@@ -26,7 +26,13 @@ defmodule Grappa.AdminEventsTest do
     [:grappa, :session, :lifecycle, :terminated]
   ]
 
-  setup do
+  setup context do
+    # #1546 — registered FIRST so ExUnit's reverse-registration (LIFO)
+    # order runs it LAST: it reads the state the restore below left
+    # behind. Registering it any later would observe the singleton
+    # BEFORE the restore and prove nothing.
+    maybe_watch_for_escaping_dirt(context)
+
     # Drain stale `{:session, _, _}` entries left by prior tests.
     # `AdmissionStateHelpers.reset_session_supervisor/0` is the canonical
     # purge — it walks `DynamicSupervisor.which_children/1` and calls
@@ -55,6 +61,16 @@ defmodule Grappa.AdminEventsTest do
     # sandbox checkout, so the ring goes back to a booted struct per test.
     AdmissionStateHelpers.reset_admin_events()
 
+    # #1546 — and back to a booted struct AFTERWARDS too. This file is
+    # the only writer of the singleton's `persist` / `retention` in all
+    # of `test/`, so this one registration is what makes the dirt
+    # unable to reach any other file. As an `on_exit` it is off the
+    # happy path: a test that fails before its own inline restore
+    # (two such windows were censused on #1546) still leaves the
+    # singleton clean. Cleanup belongs in `on_exit`, never in a test
+    # body — same shape as `session_log_persistence_test.exs:90`.
+    on_exit(&AdmissionStateHelpers.reset_admin_events/0)
+
     # M-11: AdminEvents boots with `attach_telemetry: false` under
     # `config :grappa, :attach_admin_telemetry, false` in test env
     # (see `config/test.exs` rationale). Telemetry-adapter tests
@@ -71,6 +87,31 @@ defmodule Grappa.AdminEventsTest do
     Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), Process.whereis(AdminEvents))
 
     on_exit(fn -> :telemetry.detach(@telemetry_handler_id) end)
+
+    :ok
+  end
+
+  # #1546 — the leak witness. Only armed for `@tag :dirt_probe`, so one
+  # mutant (dropping the restore) kills exactly one assertion instead of
+  # reddening every test in the file.
+  #
+  # A `raise` inside an `on_exit` callback reddens the test it belongs
+  # to (ExUnit.OnExitHandler.exec_callback/1) — that is the observation
+  # point, and the stacktrace names it.
+  defp maybe_watch_for_escaping_dirt(context) do
+    if context[:dirt_probe] do
+      on_exit(fn ->
+        defaults = %AdminEvents{}
+        left = :sys.get_state(AdminEvents)
+
+        if {left.persist, left.retention} != {defaults.persist, defaults.retention} do
+          raise "AdminEvents config dirt escaped the test: " <>
+                  "persist=#{inspect(left.persist)} retention=#{inspect(left.retention)} " <>
+                  "(defaults persist=#{inspect(defaults.persist)} " <>
+                  "retention=#{inspect(defaults.retention)})"
+        end
+      end)
+    end
 
     :ok
   end
@@ -174,6 +215,44 @@ defmodule Grappa.AdminEventsTest do
     end
   end
 
+  describe "config dirt cannot outlive the test that made it (#1546)" do
+    # `Grappa.AdminEvents` is a singleton started by `Grappa.Application`;
+    # it outlives every sandbox checkout, so `persist` / `retention`
+    # written by one test are still there for the next FILE unless
+    # something puts them back. This file is the only place in `test/`
+    # that writes them (pinned by `AdminEventsDirtSourcesTest`).
+    #
+    # Before #1546 the restores were straight-line statements in the test
+    # bodies, so a failing assertion ABOVE one skipped it. Two such
+    # windows were censused. `persist: true` escaping makes the singleton
+    # write to the Repo from its own pid, which is not `Sandbox.allow`ed
+    # outside this file — the singleton then dies inside an unrelated
+    # file's setup, which is a cascade with no relation to the real
+    # failure.
+    #
+    # The cure is that the restore is an `on_exit`, registered in setup,
+    # so it is off the happy path entirely: it runs on pass, on failure
+    # and on raise alike. This test IS the failing-assert path minus the
+    # failure — it dirties and deliberately never restores.
+    @tag :dirt_probe
+    test "a test that dirties persist/retention and never restores leaves the singleton clean" do
+      defaults = %AdminEvents{}
+
+      :sys.replace_state(AdminEvents, fn s ->
+        %{s | persist: not defaults.persist, retention: defaults.retention + 1}
+      end)
+
+      # Assert the pre-state, or the watcher's verdict is about a
+      # singleton that was never dirtied in the first place.
+      dirty = :sys.get_state(AdminEvents)
+      assert dirty.persist != defaults.persist
+      assert dirty.retention != defaults.retention
+
+      # NO inline restore. The verdict is `maybe_watch_for_escaping_dirt/1`'s
+      # `on_exit`, which runs after this body returns.
+    end
+  end
+
   describe "disk-backing (#215 Option B)" do
     # The singleton boots persist:false in test env (config); flip it on +
     # rely on the setup's Sandbox.allow so the pid's Repo writes land in
@@ -183,12 +262,11 @@ defmodule Grappa.AdminEventsTest do
       Repo.delete_all(Event)
       :sys.replace_state(AdminEvents, fn s -> %{s | persist: true, retention: 200} end)
 
-      on_exit(fn ->
-        # Restore the in-memory-only steady state (incl. retention) so no
-        # later suite sees a leaked persist flag / shrunk retention.
-        :sys.replace_state(AdminEvents, fn s -> %{s | persist: false, buffer: [], retention: 200} end)
-      end)
-
+      # #1546 — no restore here. The file-wide `on_exit` in the outer
+      # setup lands the identical state (`%AdminEvents{buffer: []}` IS
+      # `persist: false, retention: 200, buffer: []`), and one restore
+      # for one invariant is the point of the fix: a second copy is the
+      # duplication that drifts.
       :ok
     end
 

--- a/test/grappa/admin_events_test.exs
+++ b/test/grappa/admin_events_test.exs
@@ -99,18 +99,20 @@ defmodule Grappa.AdminEventsTest do
   # to (ExUnit.OnExitHandler.exec_callback/1) — that is the observation
   # point, and the stacktrace names it.
   defp maybe_watch_for_escaping_dirt(context) do
-    if context[:dirt_probe] do
-      on_exit(fn ->
-        defaults = %AdminEvents{}
-        left = :sys.get_state(AdminEvents)
+    if context[:dirt_probe], do: on_exit(&refute_escaping_dirt/0)
 
-        if {left.persist, left.retention} != {defaults.persist, defaults.retention} do
-          raise "AdminEvents config dirt escaped the test: " <>
-                  "persist=#{inspect(left.persist)} retention=#{inspect(left.retention)} " <>
-                  "(defaults persist=#{inspect(defaults.persist)} " <>
-                  "retention=#{inspect(defaults.retention)})"
-        end
-      end)
+    :ok
+  end
+
+  defp refute_escaping_dirt do
+    defaults = %AdminEvents{}
+    left = :sys.get_state(AdminEvents)
+
+    if {left.persist, left.retention} != {defaults.persist, defaults.retention} do
+      raise "AdminEvents config dirt escaped the test: " <>
+              "persist=#{inspect(left.persist)} retention=#{inspect(left.retention)} " <>
+              "(defaults persist=#{inspect(defaults.persist)} " <>
+              "retention=#{inspect(defaults.retention)})"
     end
 
     :ok

--- a/test/grappa_web/controllers/admin/credentials_controller_test.exs
+++ b/test/grappa_web/controllers/admin/credentials_controller_test.exs
@@ -29,7 +29,6 @@ defmodule GrappaWeb.Admin.CredentialsControllerTest do
 
   setup do
     AdmissionStateHelpers.reset_all()
-    AdmissionStateHelpers.reset_admin_events()
     :ok
   end
 

--- a/test/grappa_web/controllers/admin/networks_controller_test.exs
+++ b/test/grappa_web/controllers/admin/networks_controller_test.exs
@@ -36,6 +36,17 @@ defmodule GrappaWeb.Admin.NetworksControllerTest do
     # MED-1: PATCH emits :network_caps_updated via AdminEvents.record/1,
     # so the ring has to start empty or a prior test's event pollutes the
     # head-of-buffer assertion.
+    #
+    # #1546 removed this line from the two sibling admin controller tests
+    # and deliberately KEPT it here: those two never read the ring, this
+    # one does (`[head | _] = AdminEvents.snapshot()` below). What it buys
+    # is protection against a false PASS — with the ring broken, a stale
+    # `:network_caps_updated` at the head satisfies the match and the
+    # assertions pass on the wrong row. Measured on #1546: red with this
+    # reset intact, green with a crafted stale head. The cap assertion is
+    # what makes that head unproducible by today's suite; drop it, or add
+    # a sibling that PATCHes user cap to 4, and this line is the only
+    # thing left.
     AdmissionStateHelpers.reset_admin_events()
     :ok
   end

--- a/test/grappa_web/controllers/admin/users_controller_test.exs
+++ b/test/grappa_web/controllers/admin/users_controller_test.exs
@@ -32,9 +32,6 @@ defmodule GrappaWeb.Admin.UsersControllerTest do
 
   setup do
     AdmissionStateHelpers.reset_session_supervisor()
-    # Bucket 4: the head-of-buffer assertions need the ring to start
-    # empty, or a prior test's event sits where this test's should.
-    AdmissionStateHelpers.reset_admin_events()
     :ok
   end
 


### PR DESCRIPTION
Root cause for #1546, widened by ruling from "should three setup resets be
deleted" to "make it impossible for `Grappa.AdminEvents`' `persist` /
`retention` to leak between tests".

## Why the resets could not just be deleted

`reset_admin_events/0` does two things — empties the ring, and rebuilds the
struct, so `persist` / `retention` go back to their `defstruct` defaults. The
no-op mutant that produced the ticket removes both at once, so its numbers
cannot say which half carries the weight. Split on the two axes, the answers
differ.

On the config axis, `admin_events_test.exs` is the only file in `test/` that
writes those two fields, and it restored them with straight-line statements in
the test bodies — which a failing assertion above them skips. `persist: true`
escaping makes the singleton write to the Repo from a pid `Sandbox.allow`ed
only in that file, so it dies inside an unrelated file's `setup` and the
reported failure names a file that did nothing wrong. **That cascade is what
the "not load-bearing" resets were suppressing**, which is why removing them
first would have added noise rather than removed redundancy.

## What this does

1. **A census pin** over `test/`, derived not hand-listed, freezing the
   "one file writes those fields" clause the whole fix rests on — with a
   non-empty assertion on the allowed sites so a drifting anchor cannot turn
   it green by matching nothing.
2. **The restore moves to `on_exit`**, registered in that one file's setup.
   Cleanup registered as a callback is off the happy path by construction: it
   runs on pass, on failure and on raise alike, so the two censused windows
   close and no future window can open in that file either. Same shape as
   `session_log_persistence_test.exs:90`. The disk-backing describe's own
   restore goes — the file-wide one lands the identical state and one restore
   per invariant is the point.
3. **Two of the three resets fall.** `users` and `credentials` contain no
   `AdminEvents.*` call at all; what they observe is the PubSub broadcast, and
   a broadcast is never re-emitted by a stale ring.
4. **`networks` keeps its reset, and that is a result rather than a
   leftover.** It reads the ring, and the reset is what stands between an
   honest red and a lying green if the emission ever breaks. Different axis;
   this fix does not touch it. Its comment now records what keeps the false
   pass unproducible today, so the next reader knows which change re-arms it.

`AdmissionStateHelpers.reset_admin_events/0` is deliberately unchanged. The
defect was where the restore sat, not what it did.

## Measured, not reasoned

- The witness was written **before** the fix and is red on that tree
  (`dirt escaped the test: persist=true retention=201`, raised from
  `ExUnit.OnExitHandler.exec_callback/1`), green after; re-measured after a
  Credo refactor rather than assumed unchanged.
- Deleting the disk-backing restore was measured too: tagging one of its
  tests with the probe is green with the file-wide `on_exit` and red without
  it — which also proves the probe was armed there.
- The pin has teeth both ways: injecting a write into a third file reddens
  the set assertion and names the intruder; drifting the anchor reddens the
  non-empty assertion.
- The teeth control for the deletion: with `record/1` swallowing every
  synthetic event, `users` and `credentials` fail 8 tests (5 and 3), 100% of
  each file's emission describe.

## Not established

The mutant's failure count was never re-run and is not a target — it is
seed-dependent and does not exist as a fixed quantity. The `persist` /
`retention` axis remains unmeasured for `networks_controller_test.exs`. The
pin is a tripwire on the textual shape: a `:sys` call through a pid bound
earlier is invisible to it (measured absent today, not made impossible).
ExUnit's reverse-registration order for `on_exit` is established empirically
on ex_unit 1.19.5, not from documentation. #1613 (the cascade amplifier) is
untouched and stays open.

## Gates

`scripts/check.sh` rc=0 at base `1893ee9d`: Credo strict found no issues,
`deps.audit` no vulnerabilities, Sobelow clean at the gate threshold,
dialyzer passed, full suite **6661 tests, 0 failures**, bats 0 `not ok`.
Rebased onto `6af40628` with `scripts/union-rebase.sh` (`+104 -0 —
contribution intact`). The base delta is three non-Elixir paths and no ExUnit
test reads any of them, so only bats could shift: the full set was re-run
after the rebase — **615 ok, 0 not ok**, design-notes gate green.
