### PR TITLE
test+docs(#1410): the init/1 re-resolve costs nine queries, not three

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55536,3 +55536,97 @@ unaffected — `status=` lands after it.
   the max `held_ms` or the observed `status` into the census — the summary
   that survives a green run — is a separate, cheaper change than the ring
   dump above, and is not made here.
+<!-- entry #1410b -->
+
+---
+
+## 2026-08-21 — #1410: the re-resolve costs nine queries, not three, and five of them nobody had counted
+
+The 2026-08-17 entry above corrected two sentences that denied
+`Grappa.Session.Server.init/1` reads the DB, and closed by declining to quote
+a boot cost: "nothing was executed ... the issue's `N x 3 queries` remains a
+derivation from the call chain, not a measurement". The issue's own "Not
+established" section says the same, and so does the read-only recon on it.
+Three refusals, one number nobody had. This entry is the measurement, and it
+moves the number.
+
+### What was measured, and how
+
+`test/grappa/session/refresh_plan_cost_test.exs` counts `[:grappa, :repo,
+:query]` telemetry events around each door. Telemetry handlers run in the
+process that emits the event, so the handler filters on `self()` and the file
+stays `async: true` — a query from another test runs in that test's process
+and never reaches this mailbox. The events fire synchronously, so the mailbox
+is complete the moment the measured call returns.
+
+The pin is the ORDERED LIST OF TABLES, not a total. A bare count says a number
+changed; the list says which read appeared or vanished, which is what makes it
+usable as a regression guard rather than a tripwire to be re-baselined.
+
+### The numbers
+
+| door | queries | tables |
+|---|---|---|
+| user SPAWN (`Bootstrap`'s own `resolve/1`, network preloaded) | **6** | `users` + the source-resolution five |
+| user RESPAWN (the `refresh_plan` closure `init/1` invokes) | **9** | `network_credentials`, `networks`, `network_servers`, `users` + five |
+| visitor RESPAWN | **9** | `visitors`, `networks`, `network_credentials`, `network_servers` + five |
+
+So `init/1` costs **nine**, and `Bootstrap` pays **fifteen per credential** —
+six in its own resolve, nine in the re-resolve that repeats it. The issue's
+`N x 3` is the right shape and the wrong magnitude, by a factor of three on
+the door it names and five on the loop.
+
+### The five nobody counted, and why the reading missed them
+
+Both the issue and the recon enumerate the same three call sites —
+`get_credential_by_ids/2`, `Repo.preload(network: :servers)`,
+`Accounts.get_user!/1` — and stop there, because that is where the *named*
+reads are. The rest is in the tail of `Networks.SessionPlan.base_plan/7`:
+`addressing_config/0` reads two `server_settings` keys (one `Repo.get_by` each,
+uncached — `ServerSettings` goes straight to the Repo), and
+`Vhosts.effective_source/3` reads `vhost_grants`, `vhosts` and the subject's
+persisted selection from `user_settings`.
+
+That is the general lesson, not an incidental one: **a call-chain reading
+counts the reads the reader is looking for, and a plan builder's tail is not
+where anyone looks.** Reading gives you the STRUCTURE and never the
+MAGNITUDE — the same lesson #1372's corpus work reached from the other end.
+It also explains the symmetry that would otherwise be a coincidence: the
+visitor door costs the same nine as the user door despite reading a different
+first four, because the shared five are paid by both producers on both doors.
+
+`Servers.pick_server!/2` was left open by the recon ("its body was not read").
+It is query-free — pure `Enum` over the already-preloaded `servers` list — and
+the measurement shows no query between the preload and the source resolution,
+which is the same fact from the other side.
+
+### What the magnitude does NOT change
+
+The verdict of the entry above stands, and the measurement was capable of
+overturning it. Both remedies remain blocked for reasons that are structural
+rather than quantitative:
+
+- Moving the reads to `handle_continue` still converts the spawn door's only
+  synchronous "subject no longer viable" signal into a silent death.
+- Skipping the re-resolve on the spawn door still cannot be expressed with a
+  flag, because `DynamicSupervisor` replays the spawn-time child spec on every
+  restart, so "already fresh" would persist into exactly the door that must
+  not trust it.
+
+A third option the fifteen makes worth naming, and which is NOT taken here:
+split `resolve/1` so the closure-construction half (cheap, and the reason
+`Bootstrap` must call it at all) is separable from the data half. That is a
+refactor of the plan producers, not a code-review fix, and it is out of the
+1.3 slice this work sits in.
+
+### Not established
+
+The wall-clock of the boot loop: still unmeasured. So is N on any real
+deployment — this lane has no production DB, so `15 x N` cannot be turned into
+a duration or a total here, and the per-credential factor is the whole of what
+is claimed. The counts hold for the DEFAULT addressing configuration only
+(mode 1, no `vhosts` rows, no grants); mode 2
+(`static_mapping_with_reservations`) walks another branch of
+`effective_source/3` and was not measured. Whether the five source-resolution
+reads are worth caching was not investigated — this entry establishes that
+they exist and are paid twice per boot, not what to do about it.

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -79,7 +79,14 @@ defmodule Grappa.Networks.SessionPlan do
     # `Credentials.list_credentials_for_all_users/0` (network preloaded
     # already) or one fresh from `Credentials.get_credential!/2` (assoc
     # not loaded). Both paths are valid — `Repo.preload` is a no-op on
-    # already-loaded assocs, so no extra query for the Bootstrap path.
+    # an already-loaded assoc, so the Bootstrap path pays nothing here.
+    #
+    # That "nothing" is about the BOOTSTRAP caller and no other (#1410).
+    # The `refresh_plan` closure below reaches this same line with a
+    # credential from `get_credential_by_ids/2`, a bare `Repo.one` with
+    # no preload — so on the respawn door the line costs two queries
+    # (`networks`, `network_servers`), measured, not one. See
+    # `Grappa.Session.RefreshPlanCostTest` for the per-door counts.
     credential = Repo.preload(credential, network: :servers)
     user = Accounts.get_user!(credential.user_id)
     server = Servers.pick_server!(credential.network, attempt)

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -55,8 +55,10 @@ defmodule Grappa.Session do
   `handle_continue` would turn a reported failure into a silent death.
 
   Two consequences stay open. On the SPAWN door the re-resolve
-  duplicates the resolution its caller performed microseconds earlier,
-  and one closure cannot tell the two doors apart. And `Boundary` is
+  duplicates the resolution its caller performed microseconds earlier
+  — measured at nine queries against the caller's six, so Bootstrap
+  pays fifteen per credential where six would do — and one closure
+  cannot tell the two doors apart. And `Boundary` is
   structurally blind to this class: a closure built in `Networks` or
   `Visitors` and invoked here carries no module reference for a
   compile-time checker to see, which is why the deps list below can

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -863,8 +863,17 @@ defmodule Grappa.Session.Server do
   # does pay those queries per credential. Synchronous by necessity —
   # `:ignore` is the spawn door's only synchronous "not viable" signal
   # (see `Grappa.Session`'s A2 section for why `handle_continue` cannot
-  # carry it). The boot cost has never been measured; measure before
-  # quoting a figure for it.
+  # carry it).
+  #
+  # The cost is now measured, and it is NINE queries per `init/1`, not
+  # the three the issue derived from the call chain — the five nobody
+  # counted are `SessionPlan.base_plan/7`'s source resolution
+  # (`server_settings` twice, then `vhost_grants` / `vhosts` /
+  # `user_settings` through `Vhosts.effective_source/3`), uncached and
+  # paid by both plan producers. Bootstrap pays FIFTEEN per credential:
+  # six in its own `resolve/1` plus these nine. Pinned per door in
+  # `Grappa.Session.RefreshPlanCostTest`; #1410. Still unmeasured: the
+  # wall-clock of the loop, and N on any real deployment.
   @impl GenServer
   def init(opts) do
     :ok = Log.set_session_context(opts.subject_label, opts.network_slug)

--- a/test/grappa/session/refresh_plan_cost_test.exs
+++ b/test/grappa/session/refresh_plan_cost_test.exs
@@ -1,0 +1,129 @@
+defmodule Grappa.Session.RefreshPlanCostTest do
+  @moduledoc """
+  #1410 — what the plan re-resolve inside `Grappa.Session.Server.init/1`
+  costs, MEASURED rather than derived.
+
+  The issue quotes "three SQLite round-trips inside `init/1`" and
+  "Bootstrap's spawn loop is serialised on N × 3 queries", and says of
+  itself that the figure is read off the call chain, not executed. So does
+  the 2026-08-17 recon, and so does the #1410 entry in `DESIGN_NOTES`.
+  This file executes it. Measured here: the door costs **nine** queries,
+  not three, and the boot loop pays **fifteen** per credential (six in
+  `Bootstrap`'s own `resolve/1`, nine in the `init/1` re-resolve).
+
+  The five the call-chain reading misses are `Grappa.Networks.SessionPlan`'s
+  `base_plan/7` tail — `addressing_config/0` (two `server_settings` rows,
+  read one `Repo.get_by` each) plus `Grappa.Vhosts.effective_source/3`
+  (`vhost_grants`, `vhosts`, `user_settings`). None is cached:
+  `ServerSettings` reads go straight to `Repo.get_by/2`. They are paid by
+  BOTH plan producers and on BOTH doors, which is why the visitor half
+  costs the same nine as the user half despite reading a different set of
+  rows for the first four.
+
+  The tables are pinned as an ordered list rather than a bare total, so a
+  changed count says WHICH read appeared or vanished. Two doors, one
+  closure: `Bootstrap` resolves a plan and hands it to `start_child`;
+  `init/1` invokes the injected `refresh_plan` and resolves it again. Only
+  the respawn door needs the re-read (the 2026-05-27 `kazamobile` /
+  `kazam02` stale-cached-opts class, plus the #93 ring counter that is
+  authoritative only at restart) and one closure cannot tell the doors
+  apart, so the spawn door pays it too.
+
+  Scope of the measurement: the DEFAULT addressing configuration — mode 1,
+  no `vhosts` rows, no grants. Mode 2 (`static_mapping_with_reservations`)
+  walks a different branch of `effective_source/3` and was not measured.
+
+  The counter runs in the TEST process and the telemetry handler filters on
+  `self()`, which is what makes the file `async: true`-safe: a query
+  emitted by another test runs in that test's process and never reaches
+  this mailbox.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Networks.{Credentials, SessionPlan}
+  alias Grappa.Visitors.SessionPlan, as: VisitorSessionPlan
+
+  @query_event [:grappa, :repo, :query]
+
+  # `base_plan/7`'s source resolution, shared by both producers and both
+  # doors: `addressing_config/0` reads two `server_settings` keys, then
+  # `Vhosts.effective_source/3` reads the grant set, the vhost set and the
+  # subject's persisted selection.
+  @source_resolution ["server_settings", "server_settings", "vhost_grants", "vhosts", "user_settings"]
+
+  describe "the user door" do
+    test "the SPAWN door — Bootstrap's own resolve, network preloaded — costs six queries" do
+      {user, network, _cred} = user_with_credential(6667, %{})
+      credential = Repo.preload(Credentials.get_credential!(user, network), network: :servers)
+
+      {{:ok, _plan}, sources} = measure(fn -> SessionPlan.resolve(credential) end)
+
+      assert sources == ["users"] ++ @source_resolution
+    end
+
+    test "the RESPAWN door — the refresh_plan closure init/1 invokes — costs nine queries" do
+      {user, network, _cred} = user_with_credential(6667, %{})
+      {:ok, plan} = SessionPlan.resolve(Credentials.get_credential!(user, network))
+
+      {{:ok, _fresh}, sources} = measure(plan.refresh_plan)
+
+      assert sources ==
+               ["network_credentials", "networks", "network_servers", "users"] ++
+                 @source_resolution
+    end
+  end
+
+  describe "the visitor door" do
+    test "the RESPAWN door costs nine queries too, on a different first four" do
+      {network, _server} =
+        network_with_server(port: 6667, slug: "vis-#{System.unique_integer([:positive])}")
+
+      visitor = visitor_fixture(network_slug: network.slug)
+      {:ok, plan} = VisitorSessionPlan.resolve(visitor, network)
+
+      {{:ok, _fresh}, sources} = measure(plan.refresh_plan)
+
+      assert sources ==
+               ["visitors", "networks", "network_credentials", "network_servers"] ++
+                 @source_resolution
+    end
+  end
+
+  # Runs `fun` and returns `{result, sources}`, where `sources` is the
+  # ordered list of `metadata.source` values Ecto emitted for the queries
+  # THIS process executed. Telemetry handlers run in the emitting process,
+  # so the `self()` guard is an exact filter, not a heuristic — and the
+  # events are emitted synchronously, so the mailbox is complete the moment
+  # `fun` returns.
+  defp measure(fun) do
+    test_pid = self()
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+
+    :ok = :telemetry.attach(handler_id, @query_event, &__MODULE__.forward_query/4, {test_pid, ref})
+
+    try do
+      result = fun.()
+      {result, drain(ref, [])}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  @doc false
+  @spec forward_query([atom()], map(), map(), {pid(), reference()}) :: :ok
+  def forward_query(_event, _measurements, metadata, {test_pid, ref}) do
+    if self() == test_pid, do: send(test_pid, {ref, Map.get(metadata, :source)})
+    :ok
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, source} -> drain(ref, [source | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/grappa/session/refresh_plan_cost_test.exs
+++ b/test/grappa/session/refresh_plan_cost_test.exs
@@ -55,19 +55,19 @@ defmodule Grappa.Session.RefreshPlanCostTest do
 
   describe "the user door" do
     test "the SPAWN door — Bootstrap's own resolve, network preloaded — costs six queries" do
-      {user, network, _cred} = user_with_credential(6667, %{})
+      {user, network, _} = user_with_credential(6667, %{})
       credential = Repo.preload(Credentials.get_credential!(user, network), network: :servers)
 
-      {{:ok, _plan}, sources} = measure(fn -> SessionPlan.resolve(credential) end)
+      {{:ok, _}, sources} = measure(fn -> SessionPlan.resolve(credential) end)
 
       assert sources == ["users"] ++ @source_resolution
     end
 
     test "the RESPAWN door — the refresh_plan closure init/1 invokes — costs nine queries" do
-      {user, network, _cred} = user_with_credential(6667, %{})
+      {user, network, _} = user_with_credential(6667, %{})
       {:ok, plan} = SessionPlan.resolve(Credentials.get_credential!(user, network))
 
-      {{:ok, _fresh}, sources} = measure(plan.refresh_plan)
+      {{:ok, _}, sources} = measure(plan.refresh_plan)
 
       assert sources ==
                ["network_credentials", "networks", "network_servers", "users"] ++
@@ -77,13 +77,13 @@ defmodule Grappa.Session.RefreshPlanCostTest do
 
   describe "the visitor door" do
     test "the RESPAWN door costs nine queries too, on a different first four" do
-      {network, _server} =
+      {network, _} =
         network_with_server(port: 6667, slug: "vis-#{System.unique_integer([:positive])}")
 
       visitor = visitor_fixture(network_slug: network.slug)
       {:ok, plan} = VisitorSessionPlan.resolve(visitor, network)
 
-      {{:ok, _fresh}, sources} = measure(plan.refresh_plan)
+      {{:ok, _}, sources} = measure(plan.refresh_plan)
 
       assert sources ==
                ["visitors", "networks", "network_credentials", "network_servers"] ++
@@ -114,7 +114,7 @@ defmodule Grappa.Session.RefreshPlanCostTest do
 
   @doc false
   @spec forward_query([atom()], map(), map(), {pid(), reference()}) :: :ok
-  def forward_query(_event, _measurements, metadata, {test_pid, ref}) do
+  def forward_query(_, _, metadata, {test_pid, ref}) do
     if self() == test_pid, do: send(test_pid, {ref, Map.get(metadata, :source)})
     :ok
   end


### PR DESCRIPTION
Ref #1410.

## What was open

Both halves of the issue's option (b) already landed on 2026-08-17
(`b9acdcde`): the A2 parenthetical in `Grappa.Session`'s moduledoc and the
`init/1` comment in `session/server.ex` were corrected, and #1398 was told
its premise moved. What no document supplied is the number. The issue's
"Not established", the read-only recon, and the `#1410` DESIGN_NOTES entry
each decline to quote a boot cost because nothing had been executed.

## What this measures

| door | queries |
|---|---|
| user SPAWN (Bootstrap's own `resolve/1`, network preloaded) | 6 |
| user RESPAWN (the `refresh_plan` closure `init/1` invokes) | 9 |
| visitor RESPAWN | 9 |

`init/1` costs **nine**, not three; Bootstrap pays **fifteen** per credential
because its own resolve is repeated in full. The five nobody counted are in
`SessionPlan.base_plan/7`'s tail: `addressing_config/0` reads two
`server_settings` keys (one `Repo.get_by` each, uncached), then
`Vhosts.effective_source/3` reads `vhost_grants`, `vhosts` and `user_settings`.
Both plan producers pay them on both doors — which is why the visitor door
costs the same nine on a different first four.

## Method

`[:grappa, :repo, :query]` telemetry, handler filtered on `self()` (handlers
run in the emitting process, so the file stays `async: true`). The pin is the
ordered list of TABLES, not a total: a changed count then says which read
appeared or vanished. Three mutants, one assert each — forcing the preload
(spawn door), making the user closure trust its cached credential (this is the
2026-05-27 `kazamobile` zombie bug, so the pin now guards it), making the
visitor closure trust its cached network.

## What changes in production

Nothing. Three comment corrections and one new test file. One of the comments
was false in the same way the two the issue names were false:
`resolve_attempt/2`'s "`Repo.preload` ... no extra query for the Bootstrap
path" holds for Bootstrap and for nothing else — the closure reaches the same
line unpreloaded, at two queries.

## Not established

No wall-clock, no N from any deployment, and the counts hold for the default
addressing mode only (mode 1, no vhost rows). Whether the five source-resolution
reads should be cached was not investigated.

DESIGN_NOTES marker is `#1410b`; `#1410` is already on the base.