### PR TITLE
fix(#1593): queue a mid-flight scrollback refresh instead of dropping it

### DIFF
--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -1186,7 +1186,10 @@ describe("refreshScrollback (CP29 R-5)", () => {
     expect(list[0]?.body).toBe("live");
   });
 
-  it("guards against overlapping in-flight refreshes on the same topic", async () => {
+  it("never runs two refreshes CONCURRENTLY on the same topic", async () => {
+    // The in-flight guard's surviving job after #1593: no two `?after=`
+    // fetches for one key on the wire at the same time. What it must NOT do
+    // is DROP the second caller — that is the next test.
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     const scrollback = await import("../lib/scrollback");
@@ -1196,6 +1199,9 @@ describe("refreshScrollback (CP29 R-5)", () => {
     const firstPromise = new Promise<ScrollbackMessage[]>((res) => {
       resolveFirst = res;
     });
+    // Persistent (not `…Once`): the queued re-run consumes it, and an
+    // unconsumed `…Once` would leak its queue into the next test in the file.
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([]);
     vi.mocked(api.listMessagesAfter).mockReturnValueOnce(firstPromise);
 
     const a = scrollback.refreshScrollback("freenode", "#grappa");
@@ -1205,6 +1211,98 @@ describe("refreshScrollback (CP29 R-5)", () => {
 
     resolveFirst([]);
     await Promise.all([a, b]);
+  });
+
+  it("re-runs once after the in-flight refresh settles, ingesting the row written in between (#1593)", async () => {
+    // #1593 — the reconnect fires TWO refreshes per already-joined key, and
+    // only the SECOND one can close the gap:
+    //
+    //   * the socket-open sweep (subscribe.ts, `socketHealth().state` → open)
+    //     runs over `joined.keys()` BEFORE any per-channel topic has rejoined;
+    //   * the per-channel join-ok refresh runs AFTER that topic's subscription
+    //     is live.
+    //
+    // Measured on CI run 32351074283 (`0-trace.network`, the failing
+    // `issue254-own-echo-live.spec.ts:235` trace): the sweep's GET for
+    // `#spec-w0` was on the wire 09:08:32.727 → .756; the row was written at
+    // .751 (after the sweep's query) and the topic's join completed at .754
+    // (inside the sweep's window). The join-ok refresh — the only one that
+    // could have seen 53749 — hit `refreshInFlight` and returned. The trace
+    // carries no further `?after=` request for that key, ever.
+    //
+    // A refresh requested while one is in flight therefore must be QUEUED,
+    // not dropped: it was asked for AFTER the in-flight fetch issued its
+    // query, so it is the only caller that can observe rows written since.
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    mockGetResumeCursor.mockReturnValue(5);
+
+    let resolveSweep: (v: ScrollbackMessage[]) => void = () => {};
+    const sweepPage = new Promise<ScrollbackMessage[]>((res) => {
+      resolveSweep = res;
+    });
+    // The row lands on the server while the sweep's GET is still on the wire,
+    // so only a fetch issued AFTER that GET can see it. Persistent, so an
+    // unconsumed `…Once` cannot leak into the next test in the file.
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([sample(6, "written-mid-flight")]);
+    // The sweep itself queried before the row existed: it comes back empty.
+    vi.mocked(api.listMessagesAfter).mockReturnValueOnce(sweepPage);
+
+    const sweep = scrollback.refreshScrollback("freenode", "#grappa");
+    const joinOk = scrollback.refreshScrollback("freenode", "#grappa");
+
+    resolveSweep([]);
+    await Promise.all([sweep, joinOk]);
+
+    await vi.waitFor(() => {
+      expect(scrollback.scrollbackByChannel()[key]?.map((m) => m.id)).toEqual([6]);
+    });
+  });
+
+  it("withholds the #552 completion seam until the queued re-run settles (#1593)", async () => {
+    // `__cic_scrollbackRefreshed` means "no backfill is in flight for this
+    // key, and none is about to start". Stamping it when the LEADING run
+    // finishes while a queued re-run is still owed would hand
+    // `waitForScrollbackRefreshed` a false all-clear — the very race #552
+    // added the seam to remove.
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    mockGetResumeCursor.mockReturnValue(5);
+    // The seam lives on `window`, which `vi.resetModules()` does not clear —
+    // an earlier test in this file may already have stamped this key. Read it
+    // through a getter so clearing it here doesn't narrow the type to `never`
+    // for the assertions below.
+    const seamKeys = (): Set<string> | undefined =>
+      (window as unknown as { __cic_scrollbackRefreshed?: Set<string> }).__cic_scrollbackRefreshed;
+    (window as unknown as { __cic_scrollbackRefreshed?: Set<string> }).__cic_scrollbackRefreshed =
+      undefined;
+
+    let resolveSweep: (v: ScrollbackMessage[]) => void = () => {};
+    const sweepPage = new Promise<ScrollbackMessage[]>((res) => {
+      resolveSweep = res;
+    });
+    let resolveTrailing: (v: ScrollbackMessage[]) => void = () => {};
+    const trailingPage = new Promise<ScrollbackMessage[]>((res) => {
+      resolveTrailing = res;
+    });
+    vi.mocked(api.listMessagesAfter).mockReturnValue(trailingPage);
+    vi.mocked(api.listMessagesAfter).mockReturnValueOnce(sweepPage);
+
+    const sweep = scrollback.refreshScrollback("freenode", "#grappa");
+    const joinOk = scrollback.refreshScrollback("freenode", "#grappa");
+
+    resolveSweep([]);
+    await Promise.all([sweep, joinOk]);
+    expect(seamKeys()?.has(key) ?? false).toBe(false);
+
+    resolveTrailing([]);
+    await vi.waitFor(() => {
+      expect(seamKeys()?.has(key) ?? false).toBe(true);
+    });
   });
 
   it("releases the in-flight guard on REST error — subsequent refreshes can retry", async () => {

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -35,8 +35,9 @@ import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 // overlap in a small race window — the same row would otherwise
 // appear twice. `id` is monotonic per the schema's auto-increment column.
 //
-// Identity-scoped state via identityScopedStore (dup-A3 close): eleven resets
-// registered (see the registration block below). The factory preserves the A1
+// Identity-scoped state via identityScopedStore (dup-A3 close): thirteen
+// resets registered (see the registration block below, which is the SSOT for
+// the count — this line has been stale before). The factory preserves the A1
 // invariant — registration runs before any verb fires, so no rotation can be
 // missed for want of a registered reset.
 //
@@ -436,10 +437,11 @@ const exports = identityScopedStore((onIdentityChange) => {
   });
 
   // Identity-transition cleanup, and the SSOT for what an identity transition
-  // clears. Twelve registered resets fired by the factory's
-  // createEffect(on(token, ...)) — seven Set.clear() (loadedChannels +
+  // clears. Thirteen registered resets fired by the factory's
+  // createEffect(on(token, ...)) — eight Set.clear() (loadedChannels +
   // loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161 +
-  // refreshInFlight + jumpInFlight, #788) + five signal flushes
+  // refreshInFlight + refreshQueued, #1593 + jumpInFlight, #788) + five
+  // signal flushes
   // (scrollbackByChannel + lastOwnSend + ownSendSubmitted, #580 +
   // farBehindByChannel, #693 + measuredUnreadByChannel, #947). Order matches
   // the pre-A3 inline shape.
@@ -466,6 +468,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => loadNewerInFlight.clear());
   onIdentityChange(() => loadNewerExhausted.clear());
   onIdentityChange(() => refreshInFlight.clear());
+  onIdentityChange(() => refreshQueued.clear());
   onIdentityChange(() => jumpInFlight.clear());
   onIdentityChange(() => setScrollbackByChannel({}));
   onIdentityChange(() => setLastOwnSend(null));
@@ -1225,17 +1228,51 @@ const exports = identityScopedStore((onIdentityChange) => {
   //      capped at 200 server-side so this is bounded even on a busy
   //      channel.
   //
-  // In-flight guard: per-key Set prevents double-fetch under bursty
-  // rejoin sequences (phoenix.js's `Push.resend()` can fire
-  // `.receive("ok")` twice for stale outbound pushes that succeed
-  // post-rejoin — see socket.ts moduledoc). Released in `finally` so a
-  // transient REST error doesn't latch out future retries.
+  // In-flight guard: per-key Set prevents two `?after=` fetches for the same
+  // key being on the wire CONCURRENTLY under bursty rejoin sequences
+  // (phoenix.js's `Push.resend()` can fire `.receive("ok")` twice for stale
+  // outbound pushes that succeed post-rejoin — see socket.ts moduledoc).
+  // Released in `finally` so a transient REST error doesn't latch out future
+  // retries.
+  //
+  // #1593 — the guard QUEUES the loser, it does not DROP it. A caller that
+  // arrives mid-flight asked AFTER the running fetch issued its query, so it
+  // is the only one that can observe rows written since; dropping it throws
+  // away the observation and nothing ever goes back for those rows. That is
+  // not hypothetical — it is the reconnect's normal shape, because
+  // `subscribe.ts` fires TWO refreshes per already-joined key and they
+  // reliably overlap:
+  //
+  //   * the socket-open sweep (`socketHealth().state` → "open", #159 item 3)
+  //     runs over `joined.keys()` the moment the transport is back — BEFORE
+  //     any per-channel topic has rejoined, so by construction it cannot
+  //     cover rows written after its own query;
+  //   * the per-channel join-ok refresh (CP29 R-5) runs once that topic's
+  //     subscription is live, and is the only one whose fetch is ordered
+  //     after the subscription that will carry everything later.
+  //
+  // Measured on CI run 32351074283 (`0-trace.network` of the failing
+  // `issue254-own-echo-live.spec.ts:235`): the sweep put three GETs on the
+  // wire at 09:08:32.725/.726/.727, each still unresolved when its own
+  // topic's join completed (.737, .749, .754 server-side) — all three join-ok
+  // refreshes were dropped, and the row persisted at .751 into a topic that
+  // had no subscriber was never fetched again by any later request in the
+  // whole trace.
+  //
+  // The re-run closes the hole rather than narrowing it: it is triggered BY
+  // the post-subscription caller, so its response covers the server up to a
+  // point after the subscription went live, and everything past that arrives
+  // over the WS. Cost is at most one extra short `?after=` per in-flight
+  // window per key — and a caller arriving during the re-run coalesces into
+  // the same single slot, so the chain is bounded by the arrival of new
+  // events, not by the number of callers.
   //
   // High-water mark rolls forward as we ingest so a SECOND disconnect
   // mid-refresh resumes from the new highest id rather than the
   // original cursor — same property the pre-CP29-R5 reconnectBackfill
   // ran inside `runBackfill`, preserved here for the same reason.
   const refreshInFlight = new Set<ChannelKey>();
+  const refreshQueued = new Set<ChannelKey>();
 
   // #552 — pure test seam: stamp `__cic_scrollbackRefreshed` (a Set of the
   // module composite key) when a refreshScrollback COMPLETES for a key.
@@ -1259,7 +1296,11 @@ const exports = identityScopedStore((onIdentityChange) => {
     const t = token();
     if (!t) return;
     const key = channelKey(slug, name);
-    if (refreshInFlight.has(key)) return;
+    if (refreshInFlight.has(key)) {
+      // #1593 — queue, never drop. See the `refreshQueued` declaration.
+      refreshQueued.add(key);
+      return;
+    }
     let cursor = getResumeCursor(slug, name);
     if (cursor === null) {
       // Local-pane fallback (cp13-S5 race shape). The REST seed has
@@ -1326,9 +1367,24 @@ const exports = identityScopedStore((onIdentityChange) => {
     } finally {
       if (!identityMoved(t)) {
         refreshInFlight.delete(key);
-        // #552 — mark this backfill DONE (success or error): no more in-flight
-        // DOM recreation for this key, so a spec awaiting it can safely proceed.
-        stampScrollbackRefreshed(key);
+        if (refreshQueued.delete(key)) {
+          // #1593 — a caller landed while this fetch was on the wire. Run it
+          // now, from a freshly resolved resume cursor (the page we just
+          // ingested has already rolled the high-water mark forward, so this
+          // asks only for what is still missing). Fire-and-forget: the
+          // re-run owns its own errors, and awaiting it here would make the
+          // LEADING caller's promise mean something different from every
+          // other caller's.
+          void refreshScrollback(slug, name);
+        } else {
+          // #552 — mark this backfill DONE (success or error): no more
+          // in-flight DOM recreation for this key, so a spec awaiting it can
+          // safely proceed. Deliberately NOT stamped when a re-run is owed —
+          // the seam means "and none is about to start", so stamping here
+          // would hand `waitForScrollbackRefreshed` the false all-clear the
+          // seam exists to remove.
+          stampScrollbackRefreshed(key);
+        }
       }
     }
   };

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -921,9 +921,12 @@ moduleRoot(() => {
         const phx = joinChannel(name, slug, ch.name, (reply) => {
           applyJoinReplyAndSeed(slug, ch.name, reply);
           // CP29 R-5: refresh on EVERY successful join (initial + every
-          // auto-rejoin). The per-key in-flight guard inside
-          // refreshScrollback dedupes bursty rejoins; the resume-cursor
-          // heuristic short-circuits when there's nothing to fetch.
+          // auto-rejoin). This is the ONLY refresh ordered after the
+          // subscription is live, so it is the one that closes the
+          // subscribe-vs-backfill gap (#1593); the socket-open sweep cannot.
+          // The per-key guard inside refreshScrollback keeps bursty rejoins
+          // off the wire concurrently and QUEUES the loser (never drops it);
+          // the resume-cursor heuristic keeps the fetch short.
           void refreshScrollback(slug, ch.name);
           // #79: this callback fires on the join ACK (subscribed), NOT the
           // `joined.set(key, phx)` below which fires on join-ATTEMPT. Stamp
@@ -1255,9 +1258,16 @@ moduleRoot(() => {
         // per-channel fan-out severed without a socket close) leaves the
         // gap unhealed until a full reload. Drive `refreshScrollback` for
         // EVERY already-joined key directly so reconnect recovery no
-        // longer depends on the per-channel rejoin completing. The verb's
-        // per-key in-flight guard + id-dedupe make it safe to overlap with
-        // a rejoin's own join-ok refresh.
+        // longer depends on the per-channel rejoin completing.
+        //
+        // #1593 — this sweep is a FLOOR, never the whole recovery: it runs
+        // before any per-channel topic has rejoined, so rows written after
+        // its own query and before that subscription goes live are outside
+        // it by construction. The join-ok refresh is what covers that span,
+        // and on CI the two are ~30 ms apart — i.e. they reliably overlap on
+        // the wire. What keeps the later one alive is `refreshScrollback`'s
+        // QUEUE, not its in-flight guard: the guard used to DROP it, which is
+        // exactly how #1593's row was lost. Do not "optimise" the queue away.
         for (const joinedKey of joined.keys()) {
           const decoded = decodeChannelKey(joinedKey);
           if (decoded !== null) {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55630,3 +55630,116 @@ is claimed. The counts hold for the DEFAULT addressing configuration only
 `effective_source/3` and was not measured. Whether the five source-resolution
 reads are worth caching was not investigated — this entry establishes that
 they exist and are paid twice per boot, not what to do about it.
+<!-- entry #1593 -->
+
+---
+
+## 2026-08-21 — #1593: the reconnect fires two backfills and drops the only one that could work
+
+A message written by the server between a reconnect's backfill and that
+reconnect's subscription going live was never delivered and never reconciled.
+cic kept the row's id — it advanced the read cursor to it, off the `POST
+/messages` 201 body — but the row never rendered, and no later fetch went back
+for it. Reproduced in the field on the Android PWA (a ~60 s blind window, then
+eight lines landing at once) and caught once on CI, as the single red
+`integration` run 32351074283 on main `41190db8`
+(`issue254-own-echo-live.spec.ts:235`).
+
+### The mechanism, and how it was settled
+
+The issue stopped at two readings: **(A)** the subscription was not yet useful
+when the broadcast fired, or **(B)** it was live and the echo was lost
+downstream. (B) was already falsified from the server log (the per-channel
+`JOINED` for `#spec-w0` completed 16 ms *after* the backfill fetch, so the
+backfill cannot have been triggered by the join ACK).
+
+What settled the rest was an instrument nobody had opened: **`0-trace.network`
+inside the `playwright-traces` artefact** — the client-side HTTP request log,
+with `startedDateTime` in wall-clock UTC and a per-request duration. The issue
+had established that the Playwright trace carries no WebSocket frames, which is
+true, and concluded the trace "does not contain the information". It contains a
+different piece of it, and that piece is decisive:
+
+| key | the sweep's `?after=` GET, on the wire | that topic's `JOINED` (server log) |
+|---|---|---|
+| `s45dcf513` | 09:08:32.725 → .752 | 09:08:32.737 — 15 ms inside |
+| `$server` | 09:08:32.726 → .759 | 09:08:32.749 — 10 ms inside |
+| `#spec-w0` | 09:08:32.727 → .756 | 09:08:32.754 — 2 ms inside |
+
+Those three GETs are the signature of one code path: `subscribe.ts`'s
+socket-open effect, which on `socketHealth().state` → `"open"` calls
+`refetchNetworks()` (`/networks`, .722), `refetchChannels()`
+(`/…/channels`, .724) and then sweeps `refreshScrollback` over every
+`joined.keys()` (.725/.726/.727). That sweep runs **before any per-channel
+topic has rejoined**, so by construction it cannot cover rows written after its
+own query.
+
+The refresh that *can* is the per-channel join-ok one (CP29 R-5). All three of
+them landed inside their own key's in-flight window and hit
+`refreshScrollback`'s guard, which **returned**. Row 53749 was persisted at
+.751 — after the sweep's query, into a topic that had no subscriber — and the
+trace carries no further `?after=` request for any of those keys, ever, while
+the same client kept issuing HTTP at .774, .779 (×2) and .874. That last row is
+the positive control: the absence is an absence, not a gap in capture.
+
+So the answer is (A), but the actionable half is not the ordering. The ordering
+hole is inherent and cic already owns the verb that closes it. The defect is
+that **the verb was being thrown away by a guard whose comment claimed the
+overlap was safe** ("the per-key in-flight guard + id-dedupe make it safe to
+overlap with a rejoin's own join-ok refresh").
+
+### The rule
+
+**A coalescing guard must not DROP the caller that loses the race.** The two
+callers are not interchangeable: the one that arrives mid-flight asked *after*
+the running fetch issued its query, so it is the only one that can observe
+anything written since. Dropping it discards the observation, and — because
+nothing else ever re-asks — permanently.
+
+`refreshScrollback` therefore queues the loser (`refreshQueued`, a sibling Set
+to `refreshInFlight`, reset on identity transition like every other lock in
+that block) and re-runs once when the leading fetch settles. The guard keeps
+its real job: never two `?after=` for one key on the wire at once.
+
+This closes the hole rather than narrowing it. The re-run is triggered *by* the
+post-subscription caller, so its response covers the server past the point the
+subscription went live, and everything after that arrives over the WS. Cost is
+at most one extra short `?after=` per in-flight window per key; a caller
+arriving during the re-run coalesces into the same slot, so the chain is
+bounded by event arrivals, not by caller count.
+
+The #552 completion seam (`__cic_scrollbackRefreshed`) is withheld while a
+re-run is owed. The seam means "nothing in flight *and* nothing about to
+start"; stamping it when the leading run finishes would hand
+`waitForScrollbackRefreshed` precisely the false all-clear it was added to
+remove.
+
+### What is deliberately left standing
+
+- **The read cursor can still advance past a row that never rendered.**
+  `sendMessage` advances it off the 201 body, gated on "the pane holds some
+  rendered row" (the #50 anti-poison gate), not on "this row rendered". With
+  this change the row does get fetched and rendered, so in the #1593 shape the
+  advance becomes retroactively honest — but the ordering is unchanged, and a
+  cure for it would be a separate change.
+- **No polling.** A periodic reconcile of any topic whose high-water mark
+  trails the server was the general cure on the table and is rejected: it is
+  polling REST from a connected client, which CLAUDE.md rules out.
+- **No client-originated state.** The cure re-asks for a range; it never
+  invents a row.
+
+### What was not measured
+
+- **The Android field incident was not discriminated directly.** The instrument
+  vjt named for it is the server log of that one-minute window, and prod (the
+  m42 jail) is unreachable from the worker sandbox — the ssh identity is
+  blocked, `Permission denied (publickey)`. The field report is *consistent*
+  with this mechanism (any reconnect fires the same sweep-then-join sequence),
+  but n=1 on CI is what is measured, and the field case is argued, not proven.
+- **Incidence.** Still n=1. The `:235` spec ran 474 times on main over the
+  preceding 30 days with this as its only failure; nothing here changes that
+  number or explains why the webkit twin `:244` passed in the same run.
+- **The 2 ms margin on `#spec-w0` alone.** The join reply's client-side arrival
+  is not timestamped anywhere; that key's overlap is established by the total
+  absence of a later `?after=` GET, and by the 15 ms and 10 ms margins on the
+  two sibling keys in the same reconnect, not by the 2 ms figure on its own.


### PR DESCRIPTION
Issue #1593.

## What was undecided, and what settled it

The issue stopped at two candidate mechanisms and said so: **(A)** the
subscription was not yet useful when the broadcast fired, or **(B)** it was
live and the echo was lost downstream. vjt's first comment already falsified
(B) from the server log — the per-channel `JOINED` for `#spec-w0` completed
**16 ms after** the backfill fetch, so the backfill was not join-driven.

The rest was settled by an artefact of the same run that nobody had opened:
**`0-trace.network`**, inside the `playwright-traces` artefact of CI run
`32351074283`. The issue concluded "the trace does not contain the
information" from a true observation — there are no `webSocket*` events in
`0-trace.trace` — but the network file is a separate stream, and it is the
client-side HTTP request log with wall-clock `startedDateTime` and a per-request
duration.

Cross-referenced against the `JOINED` lines vjt published:

| key | the sweep's `?after=` GET, on the wire | that topic's `JOINED` (server) |
|---|---|---|
| `s45dcf513` | 09:08:32.725 → .752 | 09:08:32.737 — **15 ms inside** |
| `$server`   | 09:08:32.726 → .759 | 09:08:32.749 — **10 ms inside** |
| `#spec-w0`  | 09:08:32.727 → .756 | 09:08:32.754 — **2 ms inside** |

Those three GETs, preceded by `/networks` at .722 and `/…/channels` at .724,
are the exact signature of one code path: `subscribe.ts`'s socket-open effect
(`socketHealth().state` → `"open"` → `refetchNetworks()`, `refetchChannels()`,
then a `refreshScrollback` sweep over every `joined.keys()`). That sweep runs
**before any per-channel topic has rejoined**.

So this is (A) — but the actionable half is not the ordering. The ordering hole
is inherent and cic already owns the verb that closes it: the per-channel
join-ok `refreshScrollback`, the only refresh ordered *after* the subscription
is live. **All three join-ok refreshes landed inside their own key's in-flight
window and were dropped by `refreshScrollback`'s guard.** Row 53749 was
persisted at .751 — after the sweep's query, into a topic with no subscriber —
and the trace carries no further `?after=` request for any of those keys, ever,
while the same client kept issuing HTTP at .774, .779 (×2) and .874 (positive
control: the absence is an absence, not a capture gap).

The comment that authorised it said the opposite: *"the per-key in-flight guard
+ id-dedupe make it safe to overlap with a rejoin's own join-ok refresh."*

## The fix

**A coalescing guard must not DROP the caller that loses the race.** The two
callers are not interchangeable — the mid-flight one asked *after* the running
fetch issued its query, so it is the only one that can observe anything written
since. `refreshScrollback` now queues it (`refreshQueued`, sibling Set to
`refreshInFlight`, reset on identity transition like every other lock in that
block) and re-runs once when the leading fetch settles. The guard keeps its
real job: never two `?after=` for one key on the wire at once.

This **closes** the hole rather than narrowing it: the re-run is triggered *by*
the post-subscription caller, so its response covers the server past the point
the subscription went live, and everything later arrives over the WS. Cost is
at most one extra short `?after=` per in-flight window per key; a caller
arriving during the re-run coalesces into the same slot.

The #552 completion seam is withheld while a re-run is owed — it means "nothing
in flight **and** nothing about to start", and stamping it early would hand
`waitForScrollbackRefreshed` the false all-clear it was added to remove.

## Evidence

Red first: 2 failed / 65 passed on the pre-fix tree (`expected undefined to
deeply equal [ 6 ]`, `expected true to be false`), 67/67 after.

Mutants, one axis each:

| mutant | red |
|---|---|
| queue → drop (revert the cure) | the re-run test **and** the seam test |
| stamp the #552 seam unconditionally | the seam test **only** |
| remove the in-flight guard entirely | the concurrency test (+ seam, collaterally) |

Gates, from this branch rebased onto `origin/main` `5e8ff209`:
`scripts/bun.sh run test` **5710/5710 (295 files)**;
`scripts/bun.sh run check` **4/4 stages ok**;
`scripts/design-notes-gate.sh` ok; `scripts/union-rebase.sh` ok
(`docs/DESIGN_NOTES.md: +113 -0 — contribution intact`).

## Left standing, deliberately

- **The read cursor can still advance past a row that never rendered.**
  `sendMessage` advances it off the 201 body, gated on "the pane holds some
  rendered row" (#50's anti-poison gate), not on "this row rendered". With this
  change the row does get fetched and rendered, so in the #1593 shape the
  advance becomes retroactively honest — the ordering is unchanged, and a cure
  for it is a separate change.
- **No polling** (a periodic reconcile of trailing topics is rejected: CLAUDE.md
  rules out polling REST from a connected client) and **no client-originated
  state** — the cure re-asks for a range, it never invents a row.

## Not measured

- **The Android field incident was not discriminated directly.** The instrument
  vjt named is the server log of that one-minute window; prod (m42) is
  unreachable from the worker sandbox (`Permission denied (publickey)`, the ssh
  identity is blocked). The field report is *consistent* with this mechanism —
  any reconnect fires the same sweep-then-join sequence — but that is argued,
  not proven.
- **Incidence.** Still n=1 on CI. Nothing here explains why the webkit twin
  `:244` passed in the same run.
- **No e2e was run.** The stack is held by another worker; `issue254-own-echo-live.spec.ts:235`
  is the existing detector and is untouched.
- **The 2 ms margin on `#spec-w0` alone.** The join reply's client-side arrival
  is not timestamped anywhere. That key's overlap rests on the total absence of
  a later `?after=` GET plus the 15 ms and 10 ms margins on its two siblings in
  the same reconnect — not on the 2 ms figure by itself.