### PR TITLE
e2e(#1336): close M2 — five absence assertions that could not fail

### DIFF
--- a/cicchetto/e2e/fixtures/test.ts
+++ b/cicchetto/e2e/fixtures/test.ts
@@ -58,7 +58,18 @@ import {
 //     (admin-*, m9b-*) skip the guard, same as they get no per-spec
 //     subject. The media/upload surfaces that motivated this all
 //     import the wrapped `test`.
-interface CspViolation {
+//   - and the zero it asserts was, until #1336, unfalsifiable: a
+//     collector that never receives reads exactly like a CSP nobody
+//     violated. Renaming the binding, an init script that lands after
+//     the document listens, an event this engine spells differently —
+//     each leaves `violations` empty for 759 tests and the whole guard
+//     silently guards nothing. The array is therefore EXPOSED as the
+//     `cspViolations` fixture and `issue1336-csp-guard-control.spec.ts`
+//     provokes a real block through it, so a dead collector reds one
+//     spec instead of quietly passing all of them. That control is the
+//     apparatus's, not each test's: it proves this wiring is live once
+//     per run, and does NOT prove it re-armed for some particular test.
+export interface CspViolation {
   blockedURI: string;
   violatedDirective: string;
   documentURI: string;
@@ -72,6 +83,7 @@ interface CspViolation {
 // biome-ignore-start lint/suspicious/noConfusingVoidType: Playwright's auto-fixture declaration shape
 export const test = base.extend<{
   _specSubject: void;
+  cspViolations: CspViolation[];
   _cspGuard: void;
   _unrouteGuard: void;
 }>({
@@ -145,9 +157,18 @@ export const test = base.extend<{
     },
     { auto: true },
   ],
+  // The guard's collector, hoisted out of `_cspGuard`'s closure so the
+  // positive control can read it. Only ONE spec is expected to touch it
+  // (`issue1336-csp-guard-control`), which drains what it deliberately
+  // provoked; every other spec should ignore it and let the teardown
+  // below do the asserting.
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture-dependency declaration
+  cspViolations: async ({}, use) => {
+    await use([]);
+  },
   _cspGuard: [
-    async ({ context }, use) => {
-      const violations: CspViolation[] = [];
+    async ({ context, cspViolations }, use) => {
+      const violations = cspViolations;
       await context.exposeBinding("__grappaCspViolation", (_source, violation: CspViolation) => {
         violations.push(violation);
       });

--- a/cicchetto/e2e/tests/i2b-image-upload-litterbox-host.spec.ts
+++ b/cicchetto/e2e/tests/i2b-image-upload-litterbox-host.spec.ts
@@ -151,5 +151,28 @@ test.describe("I-2 litterbox path (admin-pinned host)", () => {
 
     await page.waitForTimeout(500);
     expect(routeHits).toBe(0);
+
+    // Positive control (#1117 / #1336). `routeHits` is only evidence of a
+    // suppressed upload if the route can fire at all — a URL the host
+    // moved, a pattern that stopped matching, or an active_host that
+    // never hydrated to `litterbox` all leave the counter at 0 while the
+    // Cancel button does nothing of the sort. The sibling happy-path test
+    // proves the pattern in ITS test; nothing proved it in THIS one, and
+    // a per-test route registration is a per-test apparatus.
+    //
+    // Same picker, same modal, Continue instead of Cancel: the stub is
+    // hit through the very registration asserted silent above.
+    const controlModal = await pickFile(
+      page,
+      {
+        name: "screenshot-control.png",
+        mimeType: "image/png",
+        buffer: Buffer.from(TINY_PNG_HEX, "hex"),
+      },
+      LITTERBOX_MODAL_HEADING,
+    );
+    await controlModal.locator("button", { hasText: /continue/i }).click();
+    await expect(controlModal).toBeHidden({ timeout: 5_000 });
+    await expect.poll(() => routeHits, { timeout: 10_000 }).toBeGreaterThan(0);
   });
 });

--- a/cicchetto/e2e/tests/issue1336-csp-guard-control.spec.ts
+++ b/cicchetto/e2e/tests/issue1336-csp-guard-control.spec.ts
@@ -1,0 +1,85 @@
+// #1336 (M2, from #1117) — the positive control for the suite-wide CSP guard.
+//
+// `fixtures/test.ts`'s `_cspGuard` asserts, at the teardown of EVERY spec that
+// imports the wrapped `test`, that zero `securitypolicyviolation` events were
+// collected. That zero is the normal outcome, which is exactly what makes it
+// dangerous: a collector that never receives produces the same empty array as
+// a CSP nobody violated. Rename the exposed binding, land the init script
+// after the document has already listened, or meet an engine that spells the
+// event differently, and ~750 assertions go quiet together with nothing to
+// show for it — the #1117 shape at its largest blast radius.
+//
+// So this spec provokes a REAL enforced block against the REAL header
+// (`GrappaWeb.Plugs.SecurityHeaders`) and asserts the guard's own collector
+// caught it, through the same binding, the same init script and the same
+// array the teardown reads. It then drains what it provoked, so the guard's
+// own assertion still sees the empty array it is entitled to.
+//
+// Placement, deliberate: ONE control per APPARATUS, not one per test. The
+// wiring is a single fixture shared by every spec, so proving it live once
+// per run is what a positive control on it can mean. It does NOT establish
+// that the listener re-armed inside some other spec's context — a per-test
+// control would cost a provoked violation in all ~750 of them, and any page
+// with no enforced CSP (a bare `about:blank`, a document served by something
+// other than the BEAM) would then fail for the harness's reasons rather than
+// the product's.
+//
+// The stimulus is a `connect-src` violation: the CSP allowlist is `'self'`
+// plus three named https hosts, so a fetch to a reserved-TLD host
+// (RFC 2606 `.invalid`, which by construction never resolves) is refused by
+// the policy before any network I/O — deterministic, side-effect free, and
+// nothing in the app observes it. `.catch()` swallows the resulting
+// TypeError: the rejected promise is the block working, not a failure.
+
+import { expect, test } from "../fixtures/test";
+
+// Reserved TLD (RFC 2606) — cannot resolve, so a violation here can only be
+// the policy refusing it, never a network round trip that happened to fail.
+const BLOCKED_URL = "https://csp-control.invalid/probe";
+
+test("#1336 the suite-wide CSP guard's collector actually collects", async ({
+  page,
+  cspViolations,
+}) => {
+  // Any same-origin document carries the header — the plug registers the
+  // response headers for every response, static included. The login screen
+  // needs no subject state and is the cheapest one to reach.
+  await page.goto("/login");
+  await expect(page.getByLabel(/nick or email/i)).toBeVisible({ timeout: 10_000 });
+
+  // Pre-state: the guard has collected nothing yet, so the assertion below
+  // cannot be satisfied by something that arrived before the stimulus.
+  expect(
+    cspViolations,
+    "the guard must start empty — a violation before the stimulus would make the control meaningless",
+  ).toEqual([]);
+
+  await page.evaluate(async (url) => {
+    await fetch(url).catch(() => undefined);
+  }, BLOCKED_URL);
+
+  await expect
+    .poll(() => cspViolations.filter((v) => v.blockedURI.includes("csp-control.invalid")).length, {
+      timeout: 10_000,
+      message:
+        "the CSP guard collected nothing for a request its own policy blocks — " +
+        "the binding, the init script or the event plumbing in fixtures/test.ts is dead, " +
+        "and every `toEqual([])` that guard makes is vacuous",
+    })
+    .toBeGreaterThan(0);
+
+  // The payload the guard forwards must be the violation's, not a husk: the
+  // teardown message points an operator at a DIRECTIVE, so the directive has
+  // to survive the hop through `exposeBinding`.
+  const provoked = cspViolations.find((v) => v.blockedURI.includes("csp-control.invalid"));
+  expect(provoked?.violatedDirective, "the forwarded payload must name the directive").toContain(
+    "connect-src",
+  );
+
+  // Drain what this test provoked — the guard's teardown asserts the array is
+  // empty, and it is right to. Only the provoked entries go; anything else the
+  // page produced is a real finding and must still red the teardown.
+  const kept = cspViolations.filter((v) => !v.blockedURI.includes("csp-control.invalid"));
+  cspViolations.length = 0;
+  cspViolations.push(...kept);
+});

--- a/cicchetto/e2e/tests/issue220-link-double-fire.spec.ts
+++ b/cicchetto/e2e/tests/issue220-link-double-fire.spec.ts
@@ -166,7 +166,6 @@ test.describe("#220 link-bearing surfaces double-fire", () => {
 
       // Give a (buggy) navigation a window to fire before asserting none.
       await page.waitForTimeout(1_000);
-      context.off("page", onPage);
       expect(popupOpened, "topic-bar link must NOT navigate — the bar opens the modal").toBe(false);
 
       // Inside the modal the link is a working anchor (default policy):
@@ -174,6 +173,20 @@ test.describe("#220 link-bearing surfaces double-fire", () => {
       const modalLink = dialog.locator(".scrollback-link");
       await expect(modalLink).toHaveAttribute("href", LINK_URL);
       await expect(modalLink).toHaveAttribute("target", "_blank");
+
+      // Positive control (#1117 / #1336) for the `false` above, and the
+      // reason `context.off` moved BELOW it: a listener that was never
+      // reached — detached early, registered on another context, or
+      // watching an event this build no longer emits — leaves the flag
+      // false for a reason that has nothing to do with the topic bar, and
+      // the assertion cannot tell the two apart. The modal's own anchor
+      // IS a target=_blank navigation, so clicking it must produce the
+      // very `page` event the flag says never came.
+      const controlPopup = context.waitForEvent("page", { timeout: 5_000 });
+      await modalLink.click();
+      await (await controlPopup).close();
+      await expect.poll(() => popupOpened, { timeout: 5_000 }).toBe(true);
+      context.off("page", onPage);
     } finally {
       await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
     }

--- a/cicchetto/e2e/tests/login-alt-auth-entry-points.spec.ts
+++ b/cicchetto/e2e/tests/login-alt-auth-entry-points.spec.ts
@@ -143,6 +143,19 @@ test.describe("login alt-auth entry points — 390x480 (shortest supported viewp
     await passkeyButton(page).click();
     await expect(page.getByRole("alert")).toHaveText(/account name or email/i);
     expect(requested).toBe(false);
+
+    // Positive control (#1117 / #1336). `requested` stays false both when
+    // the client-side validator blocks the ceremony — what this test is
+    // for — and when the route glob stopped matching the passkey
+    // endpoints, which is a broken instrument reading as a pass. The
+    // sibling test below fires the ceremony, but it registers its own
+    // waiter: nothing in THIS test proves THIS registration is live.
+    // Fill the identifier the validator was missing and click again — the
+    // options POST then travels through the same `**/auth/passkeys/**`
+    // handler asserted silent above.
+    await page.getByLabel(/nick or email/i).fill(probeIdentifier());
+    await passkeyButton(page).click();
+    await expect.poll(() => requested, { timeout: 10_000 }).toBe(true);
   });
 
   test("Passkey with an identifier fires the ceremony request and reports the refusal", async ({

--- a/cicchetto/e2e/tests/ux-6-b-embedded-upload.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-b-embedded-upload.spec.ts
@@ -125,4 +125,26 @@ test("UX-6-B — privacy modal Cancel does NOT trigger upload (folded from i2 20
   // Give the orchestrator a moment to (not) fire the POST.
   await page.waitForTimeout(500);
   expect(uploadHits).toBe(0);
+
+  // Positive control (#1117 / #1336). The zero above is only evidence if
+  // this counter can count: a mistyped path, a `.endsWith` that stopped
+  // matching after a route change, or a listener attached to the wrong
+  // page all leave `uploadHits` at 0 with the guard broken, and the test
+  // is green in both worlds. Drive the SAME journey to Continue instead
+  // of Cancel — the real POST goes through the very predicate asserted
+  // empty, so a blind counter reds here.
+  //
+  // Deliberately AFTER the zero: a control placed first would leave a
+  // non-zero baseline the assertion above would have to subtract, and an
+  // off-by-one in that subtraction is exactly the silence being cured.
+  await uploadViaPicker(
+    page,
+    {
+      name: "ux-6-b-cancel-control.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(TINY_PNG_HEX, "hex"),
+    },
+    { postTimeout: 10_000 },
+  );
+  await expect.poll(() => uploadHits, { timeout: 5_000 }).toBeGreaterThan(0);
 });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55743,3 +55743,120 @@ remove.
   is not timestamped anywhere; that key's overlap is established by the total
   absence of a later `?after=` GET, and by the 15 ms and 10 ms margins on the
   two sibling keys in the same reconnect, not by the 2 ms figure on its own.
+<!-- entry #1336-m2-controls -->
+
+---
+
+## 2026-08-21 — #1336: M2 closed by census, and the guard that guarded nothing
+
+Slice (1) of the instruments epic named two mechanisms: M1, a barrier that
+awaits the CLASS instead of the effect, and M2, an assertion of absence that
+an empty recorder satisfies. **Both of M2's briefed populations are dead** —
+`#1117`'s three sites were cured by `038a33ca` and `#1152`'s seven by
+`36ea566b` + `ba1bdc20`, all ancestors of `origin/main` at `3b62059a`
+(oracle calibrated both ways: a cure sha answers yes, an unmerged branch tip
+answers no). What was NOT dead is the rest of the mechanism, which nobody had
+enumerated. This entry closes that remainder and records how its edge was
+drawn.
+
+### The population, and why it is closed
+
+An **apparatus** is a variable mutated by a callback registered on an
+asynchronous event source in the e2e harness — `page.on`, `context.on`,
+`ws.on`, `page.route`, `context.route`, `context.exposeBinding`. A **site**
+is an absence assertion read off one. A site is **controlled** iff the same
+apparatus is shown, in the same test, to yield at least one element.
+
+That edge is drawn where it is because an event collector's silence is not
+observable from inside the test, while a synchronous read's is: the two
+nearest neighbours — `issue184`'s `expect(rows).toHaveLength(0)` over a REST
+body and `issue276`'s filter of a `$server` fetch — are absences over a
+SERVER QUERY, whose apparatus reports its own success (`res.ok`) and which
+this pass deliberately did not touch. Neither did it touch `toHaveCount(0)`
+over a DOM locator, several hundred sites whose vacuity is a selector
+question, not a recorder one. Both exclusions are choices, not oversights.
+
+Measured on `3b62059a` by a census that refuses to print a number unless four
+known-answer controls pass (a known value: `issue160` must read controlled and
+by a `toBeGreaterThan`; a complete set: its file list must equal a NAKED
+`git grep -lE` intersection, plus one declared multi-line site the one-line
+grep cannot see; an invented file and identifier must be absent; the
+positive/absence classifier must be right in both directions):
+
+**17 apparatuses carry an absence assertion. 12 were controlled. 5 were not.**
+
+Two traps the census hit, both worth the next reader's time. A naive
+comment-stripper eats the rest of a file from the `/*` inside
+`page.route("**/*", …)` — 14 statements survived a 350-line spec before the
+scanner was made string-aware. And `git grep -E` is POSIX ERE with no `\s`
+or `\b`, so a matcher wrapped across lines (`).toBe(\n  false,\n)` in
+`issue375`) is invisible to it: that site is declared in the census rather
+than silently missing from it.
+
+### The five, and their cures
+
+| apparatus | the absence | the control now proving it can fire |
+|---|---|---|
+| `ux-6-b-embedded-upload` `uploadHits` | `toBe(0)` after modal Cancel | the real `uploadViaPicker` journey, after the zero |
+| `i2b-litterbox` `routeHits` | `toBe(0)` after modal Cancel | the same picker driven to Continue, hitting the stub |
+| `issue220` `popupOpened` | `toBe(false)` for the topic-bar link | clicking the modal's own `target=_blank` anchor |
+| `login-alt-auth` `requested` | `toBe(false)` for an empty identifier | filling the identifier and clicking Passkey again |
+| `fixtures/test.ts` `cspViolations` | `toEqual([])` in EVERY spec's teardown | one spec provoking a real `connect-src` block |
+
+Each control is a REAL production stimulus through the SAME predicate, never a
+synthetic probe, and each is placed AFTER the zero it certifies: armed first,
+it would leave a baseline the assertion has to subtract, and an off-by-one in
+that subtraction is the same silence wearing a different hat.
+
+### The CSP guard is the one that mattered
+
+`_cspGuard` asserts zero `securitypolicyviolation` events at the teardown of
+every spec importing the wrapped `test` — roughly 750 assertions off ONE
+apparatus, where the empty array is the NORMAL outcome. Rename the exposed
+binding, land the init script after the document has already listened, or meet
+an engine that reports the event differently, and all of them go quiet
+together. Nothing in the suite could tell that world from a clean one.
+
+The collector is now the `cspViolations` fixture, and
+`issue1336-csp-guard-control.spec.ts` provokes a fetch to a reserved-TLD host
+(RFC 2606 `.invalid`) that `connect-src` refuses before any network I/O, then
+asserts the guard's own array caught it and that the forwarded payload still
+names the directive. It drains only what it provoked; anything else the page
+produced still reds the teardown.
+
+**ONE control per APPARATUS, not per test** — the distinction is deliberate
+and is stated in the spec. The wiring is a single shared fixture, so proving
+it live once per run is what a control on it can honestly mean. A per-test
+control would cost a provoked violation in all ~750 and would fail, for the
+harness's reasons rather than the product's, on any page with no enforced CSP.
+What remains uncovered is a context that armed here and not there; that gap is
+narrower than the one it replaces, and named rather than papered over.
+
+### The measurement, two-sided
+
+Five mutants, one per apparatus, each breaking the RECORDER and touching no
+assertion, applied by an injector that refuses to run unless every needle
+occurs exactly once. `M-B` is `routeHits += 0` rather than a broken URL on
+purpose: breaking the glob also disables the stub, so the upload would hang
+and red a DIFFERENT assertion — one mutant, one assert.
+
+| round | tree | mutants | result |
+|---|---|---|---|
+| 1 | `3b62059a` (pre-fix) | none | 4 passed — baseline |
+| 2 | `3b62059a` (pre-fix) | all 5 | **5 passed** — the defect |
+| 3 | cured | all 5 | **5 failed**, each on its own control |
+| 4 | cured | none | 5 passed |
+
+Round 2 is the finding: on `origin/main` today, breaking five recorders
+outright changes nothing that any test can see. Round 3 is the claim: after
+the cure the same five breakages are five reds.
+
+### Not established
+
+The four spec-level controls prove their own test's apparatus, per test. The
+CSP control proves the fixture's wiring once per run, NOT per context. No
+rate or reproduction is claimed for any of the five: nothing here says a
+recorder ever HAS gone blind in CI, only that nothing would have said so. The
+M1 half of slice (1) is untouched — its briefed site is cured, and the live
+residue (`enablePushFromSettings` plus a heuristic ≤7 spec-level barriers)
+needs per-site geometry this pass did not do.


### PR DESCRIPTION
Slice (1) of #1336, M2 half: **an assertion of absence that an empty recorder satisfies**.

## What the measurement says, before the code

Both of M2's *briefed* populations are already dead on `origin/main` — `#1117`'s three
sites (`038a33ca`) and `#1152`'s seven (`36ea566b` + `ba1bdc20`), each verified with
`git merge-base --is-ancestor` against an oracle calibrated **both** ways (a cure sha
answers yes, an unmerged branch tip answers no; the first control ref I picked was a
false negative — already merged — and was replaced rather than reported).

What was alive is the rest of the mechanism, which nobody had enumerated. A census with
four known-answer controls that refuse to print a number if any fails (known value,
complete set vs a NAKED `git grep -lE`, invented row absent, classifier right in both
directions) measured, at `3b62059a`:

**17 apparatuses carry an absence assertion. 12 controlled. 5 blind.**

| apparatus | the absence | the control added |
|---|---|---|
| `ux-6-b-embedded-upload` `uploadHits` | `toBe(0)` after modal Cancel | the real `uploadViaPicker` journey |
| `i2b-litterbox` `routeHits` | `toBe(0)` after modal Cancel | the same picker driven to Continue |
| `issue220` `popupOpened` | `toBe(false)` for the topic-bar link | clicking the modal's own `target=_blank` anchor |
| `login-alt-auth` `requested` | `toBe(false)` for an empty identifier | filling the identifier and clicking Passkey again |
| `fixtures/test.ts` `cspViolations` | `toEqual([])` in **every** spec's teardown | one spec provoking a real `connect-src` block |

## The one that mattered

`_cspGuard` makes ~750 assertions off ONE apparatus, and the empty array is the NORMAL
outcome. Rename the binding, land the init script late, meet an engine that spells the
event differently — all of them go quiet together and nothing in the suite could tell.
The collector is now a fixture and one spec provokes a real enforced block through it.
**One control per apparatus, not per test** — stated in the code, with the residual gap
(a context that armed here and not there) named rather than papered over.

## Two-sided, with a mutant per apparatus

Five mutants, each breaking a RECORDER and touching no assertion, applied by an injector
that refuses to run unless every needle occurs exactly once.

| round | tree | mutants | result |
|---|---|---|---|
| 1 | `3b62059a` | none | 4 passed (baseline) |
| 2 | `3b62059a` | all 5 | **5 passed** ← the defect |
| 3 | this branch | all 5 | **5 failed**, each on its own control line |
| 4 | this branch | none | 5 passed |

Round 2 is the finding: on main today, breaking five recorders outright changes nothing
any test can see.

## Gates

`bun run check` rc=0 (4 stages) · `bun run test` rc=0 (295 files) · design-notes gate
rc=0 · full `scripts/integration.sh` on this branch: **758 passed, 3 failed** — three
DISTINCT specs, none in a file this branch touches (`issue356` on the #1579
WS-upgrade-incomplete shape, `issue1445` on an empty /LIST, `issue260` on a 30 s
`_specSubject` setup coinciding with a 33.3 s `grappa-test` gap, the #1420 damage
signature). All three pass in an iso-rerun on this branch, which says cascade-not-real,
NOT whose fault; no attribution is claimed for them. All five target tests are green
under full-suite load.

Decision log: `docs/DESIGN_NOTES.md`, entry `#1336-m2-controls` — including the two
census traps (a comment-stripper eating a file from the `/*` inside
`page.route("**/*")`, and ERE being unable to see a matcher wrapped across lines) and
the exclusions drawn on purpose (server-query absences, DOM `toHaveCount(0)`).

Refs #1336.