### PR TITLE
#1636: derive the release pre-release marker from the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1242,6 +1242,27 @@ jobs:
             exit 1
           fi
 
+          # #1636 — DERIVE the pre-release marker from the tag being published.
+          # This call used to carry no marker at all, so every candidate was
+          # published as a full release: v1.3.0-rc1 reads as a pre-release only
+          # because a human flipped it after the run, and v1.3.0-rc2 was missed.
+          # GitHub picks "Latest" among the non-draft, non-pre-release releases,
+          # so a green candidate run is the only thing between a release
+          # candidate and the repository's landing page.
+          #
+          # The tag, not the checked-out VERSION: on a #573 (b) repair dispatch
+          # the tree is the DISPATCHED ref while the release object is keyed by
+          # the dispatched tag input, and the two need not agree.
+          #
+          # A tag the script cannot classify STOPS the step. The permissive
+          # answer is the one that publishes, so an unparseable tag must not be
+          # silently treated as a stable release.
+          if ! prerelease_flag="$(infra/packaging/prerelease_flag.sh "${RELEASE_TAG}")"; then
+            echo "::error::cannot classify ${RELEASE_TAG} — refusing to publish a release whose marker was never derived (#1636)"
+            exit 1
+          fi
+          echo "release marker for ${RELEASE_TAG}: ${prerelease_flag}"
+
           # Create the release on first run; on a re-run (or a #573 (b) repair
           # dispatch to an existing release) fall back to uploading with
           # --clobber. BUILD ≠ PUBLISH TO AUR: the PKGBUILD/.SRCINFO ride along
@@ -1250,6 +1271,7 @@ jobs:
                 --repo "${GITHUB_REPOSITORY}" \
                 --title "grappa ${RELEASE_TAG}" \
                 --generate-notes \
+                "${prerelease_flag}" \
                 "${assets[@]}"; then
             gh release upload "${RELEASE_TAG}" \
               --repo "${GITHUB_REPOSITORY}" --clobber \

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55891,6 +55891,34 @@ boot would have taken the candidate. That is what makes this a defect and not
 a label: the marker is what keeps a release candidate out of a fresh
 production install.
 
+### The window was open, for a bounded and measured time
+
+The issue reads the exposure as potential — "no release candidate has ever
+displaced the stable release". Measured NOW that is what the API says. But the
+reading holds only for the state after each hand-edit, and the timestamps say
+there was a state before it.
+
+GitHub documents `GET /releases/latest` as *the most recent non-prerelease,
+non-draft release, sorted by the `created_at` of the underlying git tag*. Both
+candidates were published WITHOUT the marker and both tags are newer than
+`v1.2.0`'s, so by that rule the endpoint answered the candidate until the flag
+was flipped. The API keeps no history, but a release object carries
+`updated_at`, which bounds the flip from above:
+
+    v1.3.0-rc1  published 2026-08-20T10:03:10Z  updated 10:12:38Z   <= 9m28s
+    v1.3.0-rc2  published 2026-08-20T23:40:56Z  updated 23:57:23Z   <= 16m27s
+    v1.2.0      published 2026-08-15T08:55:25Z  updated 08:58:15Z
+
+DERIVED, not observed: nobody polled `releases/latest` during either window,
+and `updated_at` is the LAST edit, so it is an upper bound on when the marker
+was set and not the moment itself. What the derivation does say is that the
+exposure was live rather than hypothetical — and that the two windows differ
+in what they could have cost. rc1 carried ZERO assets, so `latest_deb_url`
+would have found no `grappa_*_amd64.deb` and first-boot would have DIED
+("no grappa_*_amd64.deb asset in the latest release") rather than install
+anything. rc2 carried all eleven. Still no observed damage; the claim being
+declined here is the stronger one, that the window never existed.
+
 ### The tag is the oracle, not the carrier
 
 `infra/packaging/version.sh` reads the repo-root `VERSION` of the CHECKED-OUT

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -55860,3 +55860,137 @@ recorder ever HAS gone blind in CI, only that nothing would have said so. The
 M1 half of slice (1) is untouched — its briefed site is cured, and the live
 residue (`enablePushFromSettings` plus a heuristic ≤7 spec-level barriers)
 needs per-site geometry this pass did not do.
+<!-- entry #1636 -->
+
+---
+
+## 2026-08-21 — #1636: the release marker was a human's memory, so derive it from the tag
+
+`gh release create` in `release.yml`'s `publish` job carried no pre-release
+flag. Not the wrong one — none. So the pipeline's answer for every tag it has
+ever cut was "full release", and the marker on a release candidate existed only
+where somebody remembered to set it afterwards.
+
+Measured on the repository's own release list (GitHub API, 2026-08-21, all 23
+releases): `v1.3.0-rc1` reads `isPrerelease: true` because vjt set it by hand
+after the run; `v1.3.0-rc2` was published `false` and was flipped by hand as
+well. Twenty-one bare `X.Y.Z` releases, two candidates, and the two candidates
+are precisely the two whose marker no machine produced.
+
+The blast radius is worth stating exactly, because it is exposure and not
+damage: GitHub picks *Latest* among the releases that are neither draft nor
+pre-release. `GET /repos/vjt/grappa-irc/releases/latest` still answered
+`v1.2.0`, so no candidate has ever displaced the stable release — but nothing
+in the pipeline was stopping the next green candidate run from doing it.
+
+And that slot has a MACHINE consumer, not only a landing page.
+`infra/cloud/first-boot.sh:54` defaults `GITHUB_API` to
+`.../releases/latest` and installs the `grappa_*_amd64.deb` it finds there
+(`latest_deb_url`, `:110-114`, then `apt-get install`), so every cloud first
+boot would have taken the candidate. That is what makes this a defect and not
+a label: the marker is what keeps a release candidate out of a fresh
+production install.
+
+### The tag is the oracle, not the carrier
+
+`infra/packaging/version.sh` reads the repo-root `VERSION` of the CHECKED-OUT
+tree. That is the wrong source here, and the workflow already says why one step
+above: on the `#573 (b)` repair dispatch the checkout takes the DISPATCHED ref
+while the release object is keyed by the dispatched `tag` input, and an old tag
+"predates this work entirely". The tag is what names the release being marked.
+
+### The rule is semver's, and it was measured
+
+`elixir -e` on the pinned toolchain, `Version.parse/1` — the same parser
+`mix.exs` hands the OTP application vsn to:
+
+    1.3.0          pre: []                        release
+    1.3.0-rc1      pre: ["rc1"]                   pre-release
+    1.3.0-rc.1     pre: ["rc", 1]                 pre-release
+    1.3.0-rc-1     pre: ["rc-1"]                  pre-release
+    1.3.0-1        pre: [1]                       pre-release
+    1.3.0+foo      pre: [],  build: "foo"         release
+    1.3.0+foo-bar  pre: [],  build: "foo-bar"     release
+    1.3.0-rc1+foo  pre: ["rc1"], build: "foo"     pre-release
+    1.3, v1.3.0    :error
+
+A non-empty `pre` is exactly the condition for `--prerelease`. The `+foo-bar`
+row is the one that decides the implementation: semver puts build metadata
+AFTER the pre-release, so a `+` reached before any `-` means the hyphen belongs
+to the build and there is no pre-release at all. Strip the build first, then
+split on the first hyphen.
+
+### Why not reuse either mapper already in that directory — falsified, not judged
+
+`aur/pkgver.sh` (#1591) and the `pkgversion.sh` deb map (#1594) are both
+pre-release-aware, so "did the mapping change the string" looks like a free
+oracle that spells the rule zero extra times. Measured, it is wrong in both
+directions:
+
+    aur/pkgver.sh 1.3.0-1        rc=2, refuses
+    aur/pkgver.sh 1.3.0+foo-bar  -> 1.3.0+foobar    changed, yet pre: []
+    sed 's/-/~/'  1.3.0+foo-bar  -> 1.3.0+foo~bar   changed, yet pre: []
+
+`1.3.0-1` is a legal semver pre-release that `aur/pkgver.sh` refuses on
+purpose, because `1.3.01` would outrank `1.3.0` for pacman — correct there, and
+as an oracle here it would kill the publish step instead of marking the
+release. And both mappers change a string whose `pre` is empty, which would
+publish a stable release as a candidate. They answer "what does this packager
+stamp"; the question here is "does semver call this a pre-release", and the two
+coincide only by accident. Hence a third script rather than a clever reuse —
+but the rule itself is still written exactly once.
+
+### The shape the derivation takes
+
+`infra/packaging/prerelease_flag.sh <tag>` prints `--prerelease=true` or
+`--prerelease=false`, and refuses (exit 2) a tag it cannot classify.
+
+**It always prints a token.** `gh release create` defaults a missing
+`--prerelease` to false, so "no output" and "this is a release" would be the
+same byte string — and a derivation that silently produced nothing would look
+exactly like the bug being closed. `--prerelease=false` was measured as
+accepted by gh 2.93.0: `gh release create --prerelease=false` errors with "tag
+required", not "unknown flag" (an unknown flag was run as the control).
+
+**It refuses rather than answering "release."** The permissive answer is the
+one that publishes — the same posture `release_assets.sh publishable` takes on
+an unknown release state. The workflow reads the refusal explicitly (`if !
+prerelease_flag=…`, `::error::`, `exit 1`) instead of leaning on the runner's
+`-e`.
+
+**The core check is a shape floor, not a second semver parser**, deliberately.
+It rejects a tag that is not `vN.N.N…`; it does not reproduce semver's finer
+refusals (`1.03.0` has a leading zero, `Version.parse/1` says `:error`, this
+answers `--prerelease=false`). Transcribing the grammar here would be a second
+writing of a rule the repo already has one of, which is what #1591, #1594 and
+this issue all are. A number that shape-passes but fails semver cannot reach a
+tag anyway: `VERSION` feeds `mix.exs` and the OTP application vsn.
+
+### What is NOT covered
+
+The flag rides on `gh release create` only. The `--clobber` upload fallback (a
+re-run, or a repair dispatch against an existing release) does not touch the
+marker, and neither does the body-reconciliation `gh release edit` below it. A
+release created before this landed keeps whatever marker it has; rc1 and rc2
+are correct only because they were fixed by hand. Reconciling an existing
+release's marker would mean overwriting a human's deliberate edit, which is a
+different decision from "publish it right in the first place".
+
+`--latest` is untouched. gh documents its default as "automatic based on date
+and version", and a pre-release is excluded from *Latest* by GitHub regardless,
+so the marker alone closes the exposure this entry names.
+
+### The gate, and what it does not exercise
+
+`test/infra/packaging_prerelease_marker_test.bats`, beside the #1591 and #1594
+packaging gates. It pins the derivation row by row against the measured
+`Version.parse/1` table, counts the 23-release corpus (21 bare, 2 candidates)
+so the positive control cannot go vacuous, pins the refusals to exit code 2
+specifically, and asserts that the workflow spells the flag NOWHERE in code —
+a literal in the YAML would be a second writing by definition.
+
+It is a bats proxy, exactly as #1594's is: no real `gh`, no GitHub API, no
+runner. What is proven is that the derivation answers correctly and that the
+publish job splices it into the create call; what is NOT proven is that the
+published release object comes back `isPrerelease: true`. The next candidate
+tag is the only thing that measures that.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4326,6 +4326,14 @@ the repository's landing page. `GET /releases/latest` still answered
 what every cloud first boot would install. The marker is what keeps a
 release candidate out of a fresh production install.
 
+**And the window was open.** GitHub documents `GET /releases/latest` as the
+most recent non-prerelease, non-draft release sorted by the underlying
+tag's `created_at`; both candidates were published unmarked with tags newer
+than `v1.2.0`'s. `updated_at` bounds the hand-edit from above: `v1.3.0-rc1`
+≤ 9m28s after publication, `v1.3.0-rc2` ≤ 16m27s. Derived from the
+documented rule and the measured timestamps, not observed — nobody polled
+the endpoint during either window.
+
 `infra/packaging/prerelease_flag.sh` derives the flag from the TAG:
 
     prerelease_flag.sh v1.3.0      -> --prerelease=false

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4307,6 +4307,71 @@ then creates the release cleanly, which the old order could not do at
 all. An incomplete set against `present` proceeds and marks the release
 partial, unchanged.
 
+### `prerelease_flag.sh` — the release marker, derived from the tag (#1636)
+
+**Every release the pipeline ever cut was published as a full release.**
+`gh release create` carried no pre-release flag at all, so the marker
+depended on a human remembering to flip it afterwards. Measured on the
+repository's own release list (2026-08-21): `v1.3.0-rc1` reads
+`isPrerelease: true` only because it was set BY HAND after the run, and
+`v1.3.0-rc2` was published `false` and flipped by hand as well. GitHub
+picks "Latest" among the releases that are neither draft nor pre-release,
+so a green candidate run is the only thing between a release candidate and
+the repository's landing page. `GET /releases/latest` still answered
+`v1.2.0` when this was written — exposure, not damage.
+
+**That slot has a machine consumer.** `infra/cloud/first-boot.sh` defaults
+`GITHUB_API` to `.../releases/latest` and installs the
+`grappa_*_amd64.deb` it finds there, so a candidate in the "Latest" slot is
+what every cloud first boot would install. The marker is what keeps a
+release candidate out of a fresh production install.
+
+`infra/packaging/prerelease_flag.sh` derives the flag from the TAG:
+
+    prerelease_flag.sh v1.3.0      -> --prerelease=false
+    prerelease_flag.sh v1.3.0-rc2  -> --prerelease=true
+    prerelease_flag.sh v1.3        -> refused, exit 2
+
+**The tag, not `version.sh`.** On the `#573 (b)` repair dispatch the
+checked-out tree is the DISPATCHED ref while the release object is keyed by
+the dispatched `tag` input, and the two need not agree — the tag is what
+names the release being marked.
+
+**The rule is semver's, measured against `Version.parse/1`.** A non-empty
+`pre` is exactly the condition for the flag: `1.3.0-rc1` → `pre: ["rc1"]`,
+`1.3.0-1` → `pre: [1]`, `1.3.0+foo-bar` → `pre: []` with build metadata
+`"foo-bar"`. That last row fixes the implementation order — build metadata
+comes AFTER the pre-release in semver, so a `+` reached before any `-`
+means the hyphen belongs to the build and there is no pre-release.
+
+**Neither mapper next door could serve as the oracle**, and that was
+falsified by measurement rather than by taste. `aur/pkgver.sh 1.3.0-1`
+exits 2 — it refuses a legal semver pre-release, correctly for pacman
+ordering (#1591) — so as an oracle it would kill the publish step instead
+of marking the release; and both `aur/pkgver.sh` and the `pkgversion.sh`
+deb map CHANGE `1.3.0+foo-bar` (to `1.3.0+foobar` and `1.3.0+foo~bar`),
+which would publish a stable release as a candidate. They answer "what does
+this packager stamp", a different question.
+
+**It refuses rather than answering "release".** The permissive answer is
+the one that publishes, so a tag the script cannot classify stops the
+publish step (`::error::`, exit 1) instead of taking the "Latest" slot. The
+core check is a shape floor (`N.N.N`), NOT a second semver parser:
+reproducing the grammar here would be the drift the script exists to
+prevent, and a number that shape-passes but fails semver cannot reach a tag
+anyway (`VERSION` feeds `mix.exs` and the OTP application vsn).
+
+**It always prints a token.** `--prerelease=false` is spelled out rather
+than omitted, so "this is a release" and "the derivation produced nothing"
+are not the same byte string. Gate:
+`test/infra/packaging_prerelease_marker_test.bats`.
+
+**Not reconciled: releases created before this landed, or by hand.** The
+flag rides on `gh release create`. The `--clobber` upload fallback (a re-run
+or a repair dispatch against an existing release) does not touch the
+marker, and neither does the body-reconciliation `gh release edit` below
+it. rc1 and rc2 are already correct because they were fixed by hand.
+
 ### The packaged operator CLI and the migrate path (#419)
 
 **`/usr/bin/grappa` is the only door to the release on a packaged host.**

--- a/infra/packaging/prerelease_flag.sh
+++ b/infra/packaging/prerelease_flag.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# prerelease_flag.sh — echo the `gh release create` pre-release flag that a
+# release TAG calls for, so the marker is DERIVED and never remembered.
+#
+#   prerelease_flag.sh v1.3.0      -> --prerelease=false
+#   prerelease_flag.sh v1.3.0-rc2  -> --prerelease=true
+#   prerelease_flag.sh v1.3        -> refused, exit 2
+#
+# WHY THIS EXISTS (GH #1636). `gh release create` was called with no
+# pre-release flag at all, so the pipeline's answer for every tag it ever cut
+# was "full release". `v1.3.0-rc1` reads `isPrerelease: true` only because a
+# human flipped it after the run; `v1.3.0-rc2` was published `false` and
+# flipped by hand as well. GitHub picks "Latest" among the releases that are
+# neither draft nor pre-release, so a green candidate run was the only thing
+# standing between a release candidate and the repository's landing page —
+# `GET /releases/latest` still answered `v1.2.0`, which makes this exposure
+# rather than damage.
+#
+# WHY THE TAG AND NOT THE CARRIER. `version.sh` reads the repo-root `VERSION`
+# of the CHECKED-OUT tree, and on the `#573 (b)` repair dispatch that tree is
+# the DISPATCHED ref while the release object is keyed by the dispatched
+# `tag` input — `release.yml` says so where it checks out (an old tag "predates
+# this work entirely"). The tag is what names the release being marked, so the
+# tag is what the marker is derived from.
+#
+# WHY NOT REUSE ONE OF THE TWO MAPPERS NEXT DOOR — falsified by measurement,
+# not by taste. `aur/pkgver.sh` and the `pkgversion.sh` deb map are both
+# pre-release-aware, so "did the mapping change the string" looks like a free
+# oracle. Measured, it is wrong in both directions:
+#
+#     aur/pkgver.sh 1.3.0-1        rc=2  — it REFUSES a legal semver
+#                                          pre-release, correctly for pacman
+#                                          (#1591: `1.3.01` would outrank
+#                                          `1.3.0`). As an oracle here it
+#                                          would kill the publish step instead
+#                                          of marking the release.
+#     aur/pkgver.sh 1.3.0+foo-bar  -> 1.3.0+foobar   changed, yet `pre: []`
+#     sed 's/-/~/'  1.3.0+foo-bar  -> 1.3.0+foo~bar  changed, yet `pre: []`
+#
+# Both would publish a stable release as a candidate. They answer "what does
+# this packager stamp"; the question here is "does semver call this a
+# pre-release", and the two only coincide by accident.
+#
+# THE RULE IS SEMVER'S, MEASURED against `Version.parse/1` on the pinned
+# toolchain (the same parser `mix.exs` hands the OTP application vsn to):
+#
+#     1.3.0          pre: []                        release
+#     1.3.0-rc1      pre: ["rc1"]                   pre-release
+#     1.3.0-rc.1     pre: ["rc", 1]                 pre-release
+#     1.3.0-rc-1     pre: ["rc-1"]                  pre-release
+#     1.3.0-1        pre: [1]                       pre-release
+#     1.3.0+foo      pre: [],  build: "foo"         release
+#     1.3.0+foo-bar  pre: [],  build: "foo-bar"     release
+#     1.3.0-rc1+foo  pre: ["rc1"], build: "foo"     pre-release
+#
+# A NON-EMPTY `pre` is exactly the condition for the flag. The `+foo-bar` row
+# is what fixes the ORDER of the two splits below: semver puts build metadata
+# AFTER the pre-release, so a `+` reached before any `-` means the hyphen
+# belongs to the build and there is no pre-release at all.
+#
+# THE CORE CHECK IS A SHAPE FLOOR, NOT A SECOND SEMVER PARSER, deliberately.
+# It rejects a tag that is not `vN.N.N…` so an unclassifiable one stops the
+# publish step; it does NOT reproduce semver's finer refusals (`1.03.0` has a
+# leading zero and `Version.parse/1` returns `:error`, while this answers
+# `--prerelease=false`). Transcribing the whole grammar here would be the
+# second writing of a rule that this repo already has one of, which is the
+# drift #1591/#1594/#1636 all are. A number that shape-passes here and fails
+# semver cannot reach a tag anyway: `VERSION` feeds `mix.exs` and the OTP
+# application vsn, and the release job asserts the tag against it.
+#
+# IT ALWAYS PRINTS A TOKEN, never nothing. `gh release create` defaults a
+# missing `--prerelease` to false, so "no output" and "this is a release"
+# would be the same byte string — and a derivation that silently produced
+# nothing would look exactly like the bug this closes. Measured on gh 2.93.0:
+# `--prerelease=false` parses (`gh release create --prerelease=false` errors
+# with "tag required", not "unknown flag").
+#
+# Caller: the `publish` job of `.github/workflows/release.yml`. Gate:
+# `test/infra/packaging_prerelease_marker_test.bats`.
+#
+# POSIX sh, like its siblings `version.sh` / `pkgversion.sh` / `aur/pkgver.sh`
+# — the derived dash-parse gate (scripts/posix-parse.sh) keys on line 1.
+#
+# Why: docs/OPERATIONS.md § "Packaging (infra/packaging/)".
+set -eu
+
+die() {
+	printf 'prerelease_flag.sh: %s\n' "$1" >&2
+	exit 2
+}
+
+tag="${1:-}"
+
+[ -n "${tag}" ] || die 'no tag given (usage: prerelease_flag.sh vX.Y.Z[-pre][+build])'
+
+# The `v` is the TAG's, not the version's — `Version.parse("v1.3.0")` is
+# `:error`. release.yml fires on a `v*` push, and the repair dispatch's `tag`
+# input is documented as `v0.6.0`, so anything else is a tag nobody can be
+# publishing and must not be guessed at.
+case "${tag}" in
+v?*) version="${tag#v}" ;;
+*) die "tag '${tag}' is not spelled vX.Y.Z — refusing to guess whether it names a pre-release" ;;
+esac
+
+# Build metadata FIRST (see the measured `1.3.0+foo-bar` row above).
+case "${version}" in
+*+*)
+	[ -n "${version#*+}" ] || die "empty build metadata after the '+' in '${tag}'"
+	version="${version%%+*}"
+	;;
+esac
+
+# What is left is `core[-pre]`. The FIRST hyphen is semver's pre-release
+# separator; the pre-release may carry further hyphens of its own.
+case "${version}" in
+*-*)
+	core="${version%%-*}"
+	pre="${version#*-}"
+	[ -n "${pre}" ] || die "empty pre-release after the '-' in '${tag}'"
+	;;
+*)
+	core="${version}"
+	pre=""
+	;;
+esac
+
+# The shape floor: three dot-separated, non-empty, all-digit fields.
+#
+# A `case` and not `grep -E '^…$'`, because a case pattern matches the WHOLE
+# string while grep matches a LINE: a tag carrying a newline would satisfy the
+# anchored expression on its first line and be answered as a release.
+core_ok=no
+case "${core}" in
+*[!0-9.]* | .* | *. | *..* | *.*.*.*) ;;
+*.*.*) core_ok=yes ;;
+esac
+[ "${core_ok}" = yes ] ||
+	die "tag '${tag}' has no X.Y.Z release core — refusing to guess whether it names a pre-release"
+
+if [ -n "${pre}" ]; then
+	printf '%s\n' '--prerelease=true'
+else
+	printf '%s\n' '--prerelease=false'
+fi

--- a/test/infra/packaging_prerelease_marker_test.bats
+++ b/test/infra/packaging_prerelease_marker_test.bats
@@ -1,0 +1,228 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1636 — a release candidate must be PUBLISHED as a
+# pre-release, and the marker must be derived from the tag rather than
+# remembered by a human.
+#
+# `gh release create` was called with no pre-release flag at all, so every
+# release the pipeline has ever cut was published as a full release. Measured
+# on the repository's own release list (GitHub API, 2026-08-21):
+#
+#     v1.3.0-rc1   isPrerelease: true    <- set BY HAND after the run
+#     v1.3.0-rc2   isPrerelease: false   <- nobody remembered; also fixed by hand
+#
+# The blast radius is bounded but real: GitHub picks "Latest" among the
+# releases that are neither draft nor pre-release, so a green candidate run is
+# the only thing between a release candidate and the repository's landing
+# page. `GET /releases/latest` still answered `v1.2.0` when this was written —
+# exposure, not damage.
+#
+# THE ORACLE IS SEMVER, and it was measured rather than argued. `elixir -e`
+# on the pinned toolchain, `Version.parse/1`:
+#
+#     1.3.0          pre: []          <- release
+#     1.3.0-rc1      pre: ["rc1"]     <- pre-release
+#     1.3.0-rc.1     pre: ["rc", 1]   <- pre-release
+#     1.3.0-rc-1     pre: ["rc-1"]    <- pre-release (the pre carries hyphens)
+#     1.3.0-1        pre: [1]         <- pre-release (numeric identifier)
+#     1.3.0+foo      pre: [],  build: "foo"
+#     1.3.0+foo-bar  pre: [],  build: "foo-bar"   <- NOT a pre-release
+#     1.3.0-rc1+foo  pre: ["rc1"], build: "foo"
+#     1.3            :error
+#     v1.3.0         :error           <- the `v` is the TAG's, not the version's
+#
+# A NON-EMPTY `pre` is exactly the condition for the flag. The `+foo-bar` row
+# is the one that decides the implementation: build metadata comes AFTER the
+# pre-release in semver, so a `+` seen before any `-` means the hyphen belongs
+# to the build and there is no pre-release at all.
+#
+# WHY A NEW DERIVATION AND NOT ONE OF THE TWO MAPPERS ALREADY IN THIS
+# DIRECTORY — falsified by measurement, not by taste. Both `aur/pkgver.sh` and
+# the `pkgversion.sh` deb map are pre-release-AWARE, so "did the mapping change
+# the string" looks like a free oracle. It is not:
+#
+#     aur/pkgver.sh 1.3.0-1        rc=2  — REFUSES a legal semver pre-release,
+#                                          because `1.3.01` would outrank
+#                                          `1.3.0` for pacman (#1591). As an
+#                                          oracle it would KILL the publish
+#                                          step instead of marking the release.
+#     aur/pkgver.sh 1.3.0+foo-bar  -> 1.3.0+foobar   (changed, yet pre: [])
+#     sed 's/-/~/'  1.3.0+foo-bar  -> 1.3.0+foo~bar  (changed, yet pre: [])
+#
+# Both would mark a stable release as a candidate. They answer "what does this
+# packager stamp", which is a different question from "does semver call this a
+# pre-release" — and a third writing of the rule is exactly the drift the
+# issue warns about. So the rule is written ONCE, in this suite's subject:
+# `infra/packaging/prerelease_flag.sh`.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    FLAG_SH="$REPO_ROOT/infra/packaging/prerelease_flag.sh"
+    WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+
+    # The FLOOR. Without it every refusal case below is satisfied by a missing
+    # script (127 is non-zero too) and the suite reports green against nothing.
+    [ -x "$FLAG_SH" ]
+}
+
+# The `publish` job of release.yml, from its key to the next top-level job key.
+# Read off the JOB: release.yml also builds deb, rpm, arch and docker, and a
+# whole-file grep would be satisfied by any of their steps.
+publish_job() {
+    awk '/^  publish:/ { f = 1; next } f && /^  [a-z]/ { exit } f' "$WORKFLOW"
+}
+
+# The workflow with its comments stripped, so a gate about what the pipeline
+# DOES is never satisfied — nor broken — by prose about what it does.
+workflow_code() {
+    sed 's/^[[:space:]]*#.*$//; s/[[:space:]]#[[:space:]].*$//' "$WORKFLOW"
+}
+
+# ── The derivation, row by row against the measured Version.parse/1 table ───
+
+@test "#1636 a tag whose version carries a pre-release asks for the marker" {
+    # Every row here has a non-empty `pre` in the measurement above — including
+    # the two spellings the repo has actually cut (rc1, rc2), the dotted and
+    # hyphenated pre-release identifiers, a numeric one, and one carrying build
+    # metadata on top.
+    for tag in v1.3.0-rc1 v1.3.0-rc2 v1.3.0-rc.1 v1.3.0-rc-1 v1.3.0-1 \
+        v1.3.0-RC1 v1.3.0-0a v1.3.0-alpha.1 v1.3.0-rc1+foo v2.0.0-beta; do
+        run "$FLAG_SH" "$tag"
+        [ "$status" -eq 0 ]
+        [ "$output" = "--prerelease=true" ]
+    done
+}
+
+@test "#1636 a bare release tag asks NOT to be marked — explicitly, not by omission" {
+    # The flag is spelled on BOTH sides on purpose. `gh release create` defaults
+    # a missing `--prerelease` to false, so an empty answer would be
+    # indistinguishable from the derivation having silently produced nothing —
+    # which is the failure this whole suite exists to catch. Measured on
+    # gh 2.93.0: `--prerelease=false` parses (`gh release create
+    # --prerelease=false` errors with "tag required", not "unknown flag").
+    for tag in v1.3.0 v0.4.0 v1.2.0 v0.9.11 v10.20.30; do
+        run "$FLAG_SH" "$tag"
+        [ "$status" -eq 0 ]
+        [ "$output" = "--prerelease=false" ]
+    done
+}
+
+@test "#1636 build metadata is not a pre-release, even when it carries a hyphen" {
+    # THE row that decides the implementation. Semver orders the suffixes
+    # pre-release-then-build, so in `1.3.0+foo-bar` the hyphen is INSIDE the
+    # build metadata and `Version.parse/1` reports `pre: []` (measured). An
+    # implementation that splits on the first hyphen without stripping the
+    # build first marks this release as a candidate.
+    for tag in v1.3.0+foo v1.3.0+foo-bar v1.2.0+deadbeef; do
+        run "$FLAG_SH" "$tag"
+        [ "$status" -eq 0 ]
+        [ "$output" = "--prerelease=false" ]
+    done
+}
+
+@test "#1636 the whole published corpus classifies, and only the candidates are marked" {
+    # The positive control, with its cardinality COUNTED rather than eyeballed:
+    # the twenty-three releases this repository has published, read off the
+    # GitHub API on 2026-08-21. Twenty-one are bare and must stay eligible for
+    # "Latest"; the two candidates are the only ones that must not. A
+    # derivation that marked everything would satisfy the first case above and
+    # be caught here.
+    corpus=(v0.4.0 v0.4.1 v0.5.0 v0.6.0 v0.6.1 v0.7.0 v0.8.0 v0.9.0 v0.10.0
+        v0.11.0 v0.12.0 v0.13.0 v0.13.1 v0.13.2 v0.13.3 v0.14.0 v0.15.0
+        v0.16.0 v1.0.0 v1.1.0 v1.2.0 v1.3.0-rc1 v1.3.0-rc2)
+    [ "${#corpus[@]}" -eq 23 ]
+
+    marked=0
+    plain=0
+    for tag in "${corpus[@]}"; do
+        run "$FLAG_SH" "$tag"
+        [ "$status" -eq 0 ]
+        case "$output" in
+            --prerelease=true) marked=$((marked + 1)) ;;
+            --prerelease=false) plain=$((plain + 1)) ;;
+            *) return 1 ;;
+        esac
+    done
+
+    [ "$marked" -eq 2 ]
+    [ "$plain" -eq 21 ]
+}
+
+# ── It refuses rather than answering "stable" ───────────────────────────────
+
+@test "#1636 a tag it cannot classify is REFUSED, never answered as a release" {
+    # The permissive default is the one that publishes — the same posture
+    # `release_assets.sh publishable` takes on an unknown release state. A
+    # classifier that cannot parse its input must stop the step, not shrug and
+    # let a candidate take the "Latest" slot.
+    #
+    # The refusal's OWN exit code, not merely non-zero: 127 (absent script)
+    # would satisfy `-ne 0` while proving nothing. The setup floor guards that
+    # too, belt and braces.
+    for tag in "" 1.3.0 v vfoo v1.3 v1 v1.3.0.4 v1.3.0- v1.3.0+ "v 1.3.0"; do
+        run "$FLAG_SH" "$tag"
+        [ "$status" -eq 2 ]
+        refute grep -qF -- '--prerelease' <<<"$output"
+    done
+
+    # And with no argument at all — a workflow_dispatch that forgot its `tag`
+    # input reaches the publish job with RELEASE_TAG empty.
+    run "$FLAG_SH"
+    [ "$status" -eq 2 ]
+    refute grep -qF -- '--prerelease' <<<"$output"
+
+    # A tag carrying a NEWLINE. Worth its own row because it is the one shape
+    # that separates a whole-string check from a line-anchored regexp: `grep
+    # -E '^[0-9]+\.[0-9]+\.[0-9]+$'` is satisfied by the first line here and
+    # would answer "release" for the rest of it.
+    run "$FLAG_SH" "$(printf 'v1.3.0\nnot-a-tag')"
+    [ "$status" -eq 2 ]
+    refute grep -qF -- '--prerelease' <<<"$output"
+}
+
+# ── The pipeline actually uses it, and spells the rule nowhere else ─────────
+
+@test "#1636 the publish job derives the marker from the tag it is publishing" {
+    # The hole the issue names. `gh release create` carried no marker at all,
+    # so the pipeline's answer was always "full release" and rc1's `true` was a
+    # human's edit after the fact.
+    job="$(publish_job)"
+    [ -n "$job" ]
+    grep -qF 'prerelease_flag.sh' <<<"$job"
+    grep -qF '"${RELEASE_TAG}"' <<<"$job"
+
+    # The refusal is not swallowed. The script exits non-zero on a tag it
+    # cannot classify, and the permissive reading of that — carry on with an
+    # empty flag — is exactly what publishes an unmarked candidate.
+    grep -qF 'if ! prerelease_flag=' <<<"$job"
+
+    # The derived value reaches the CREATE call, which is the irreversible one:
+    # `gh release create` publishes, and deleting the tag afterwards does not
+    # retract it (#1591).
+    create="$(awk '/gh release create/ { f = 1 } f { print } f && /assets\[@\]/ { exit }' <<<"$job")"
+    [ -n "$create" ]
+    grep -qF 'prerelease_flag' <<<"$create"
+}
+
+@test "#1636 the workflow spells the marker nowhere — the rule has one writing" {
+    # Anything that writes the rule twice will drift, which is what #1591 and
+    # #1594 both were. A literal flag in the YAML is a second writing by
+    # definition: it would be a constant where the derivation is a function of
+    # the tag. Comments are stripped first, so the prose above the call may
+    # name the flag while the code may not.
+    refute grep -qF -- '--prerelease' <<<"$(workflow_code)"
+
+    # The stripper must not have eaten the code it is supposed to be reading.
+    grep -qF 'prerelease_flag.sh' <<<"$(workflow_code)"
+    grep -qF 'gh release create' <<<"$(workflow_code)"
+}
+
+@test "#1636 the derivation is POSIX sh, like every sibling under infra/packaging" {
+    # Not a style rule: `scripts/posix-parse.sh` derives its file set from line
+    # 1, so the dialect declaration is what enrols this script in the parse
+    # gate. A bash shebang would silently drop it out of that set.
+    head -1 "$FLAG_SH" | grep -qE '^#!/bin/sh$'
+    "$REPO_ROOT/scripts/posix-parse.sh" --list | grep -qxF 'infra/packaging/prerelease_flag.sh'
+}

--- a/test/infra/packaging_prerelease_marker_test.bats
+++ b/test/infra/packaging_prerelease_marker_test.bats
@@ -201,8 +201,17 @@ workflow_code() {
     # The derived value reaches the CREATE call, which is the irreversible one:
     # `gh release create` publishes, and deleting the tag afterwards does not
     # retract it (#1591).
-    create="$(awk '/gh release create/ { f = 1 } f { print } f && /assets\[@\]/ { exit }' <<<"$job")"
+    #
+    # Anchored on the COMMAND — the `if !` line and its backslash
+    # continuations, to the `; then` that closes it. Not on a mention of
+    # `gh release create`: the #1591 comment block twenty lines above names
+    # the command in prose, and starting there swept the derivation itself
+    # into the "create call", so this assertion held with the flag removed.
+    # Measured — the mutant that drops the splice survived until this line
+    # was anchored.
+    create="$(awk '/^[[:space:]]*if ! gh release create/ { f = 1 } f { print; if (/; then$/) exit }' <<<"$job")"
     [ -n "$create" ]
+    grep -qF 'gh release create' <<<"$create"
     grep -qF 'prerelease_flag' <<<"$create"
 }
 


### PR DESCRIPTION
`gh release create` in `release.yml`'s `publish` job carried no pre-release
flag. Not the wrong one — **none**. So the pipeline's answer for every tag it
has ever cut was "full release", and the marker on a release candidate existed
only where somebody remembered to set it afterwards: `v1.3.0-rc1` reads
`isPrerelease: true` because it was flipped by hand after the run, and
`v1.3.0-rc2` was published `false` and flipped by hand too.

## The radius, stated as measured

GitHub picks *Latest* among the releases that are neither draft nor
pre-release. Two facts sharpen the issue's own reading:

1. **That slot has a machine consumer.** `infra/cloud/first-boot.sh:54`
   defaults `GITHUB_API` to `.../releases/latest` and installs the
   `grappa_*_amd64.deb` it finds there. A candidate in that slot is what every
   cloud first boot would install.
2. **The window was open, bounded.** GitHub documents `GET /releases/latest`
   as the most recent non-prerelease, non-draft release sorted by the
   underlying tag's `created_at`. Both candidates were published unmarked with
   tags newer than `v1.2.0`'s, so by that rule the endpoint answered the
   candidate until the flag was flipped. `updated_at` bounds the flip from
   above: rc1 ≤ 9m28s, rc2 ≤ 16m27s. **Derived, not observed** — nobody polled
   the endpoint. rc1 carried zero assets, so first-boot would have died on the
   missing `.deb`; rc2 carried all eleven.

Still no observed damage. `GET /releases/latest` answers `v1.2.0` today and
both candidates carry the marker.

## The shape

`infra/packaging/prerelease_flag.sh <tag>` → `--prerelease=true` /
`--prerelease=false`, refusing (exit 2) a tag it cannot classify.

* **The tag, not `version.sh`.** On the `#573 (b)` repair dispatch the
  checked-out tree is the DISPATCHED ref while the release object is keyed by
  the dispatched `tag` input.
* **The rule is semver's, measured against `Version.parse/1`** on the pinned
  toolchain. A non-empty `pre` is the condition. The `1.3.0+foo-bar` row
  (`pre: []`, `build: "foo-bar"`) fixes the order of the two splits — build
  metadata comes AFTER the pre-release, so a `+` reached before any `-` means
  the hyphen belongs to the build.
* **Neither mapper next door could be the oracle**, falsified by measurement:
  `aur/pkgver.sh 1.3.0-1` exits 2 (it refuses a legal semver pre-release,
  correctly for pacman ordering, #1591) so as an oracle it would kill the
  publish step; and both it and the `pkgversion.sh` deb map CHANGE
  `1.3.0+foo-bar`, which would publish a stable release as a candidate.
* **It always prints a token.** `gh release create` defaults a missing
  `--prerelease` to false, so "no output" and "this is a release" would be the
  same byte string. Measured on gh 2.93.0 that `--prerelease=false` parses.
* **It refuses rather than answering "release."** The permissive answer is the
  one that publishes. The workflow reads that refusal explicitly rather than
  leaning on the runner's `-e`.

## Gate, proved by mutation

`test/infra/packaging_prerelease_marker_test.bats`, beside the #1591/#1594
packaging gates. Eight cases: the derivation row by row against the measured
table, the 23-release corpus with its cardinality counted (21 bare, 2
candidates) so the positive control cannot go vacuous, the refusals pinned to
exit 2 specifically, and an assertion that the workflow spells the flag
NOWHERE in code.

| # | mutation | NEW (#1636) | #1591 | #1594 |
|---|---|---|---|---|
| M1 | derivation neutered — a pre-release answers `false` | **RED** (2/8) | green | green |
| M2 | derivation inverted | **RED** (4/8) | green | green |
| M3 | build metadata no longer stripped first | **RED** (1/8) | green | green |
| M4 | shape floor fails OPEN | **RED** (1/8) | green | green |
| M5 | wiring removed from `gh release create` | **RED** (1/8) | green | green |
| M6b | `aur/pkgver.sh` joins core and pre with `_` | green | **RED** (2/11) | green |
| M7 | `pkgversion.sh` deb maps EVERY hyphen | green | green | **RED** (1/9) |

No mutant kills two suites. M5 **survived the first run** — the assertion that
the derived flag reaches the create call extracted its region from a *mention*
of `gh release create` in a comment twenty lines above, and so swallowed the
derivation itself. Anchored on the command; that is commit 4 and it is the
reason the matrix exists.

## Declared limits

* Bats **proxy**, exactly as #1594's is: no real `gh`, no GitHub API, no
  runner. Not proven: that the published release object comes back
  `isPrerelease: true`. The next candidate tag is the only thing that measures
  that.
* The flag rides on `gh release create` only. The `--clobber` upload fallback
  and the body-reconciliation `gh release edit` do not touch the marker, so a
  release created before this lands keeps whatever it has. Reconciling one
  would overwrite a human's deliberate edit — a different decision.
* The core check is a **shape floor, not a second semver parser**: `v1.03.0`
  (which `Version.parse/1` rejects for the leading zero) answers
  `--prerelease=false` rather than refusing. Transcribing the grammar here
  would be the drift the script exists to prevent.
* `--latest` untouched.

Refs #1636.