### PR TITLE
cic(#1393): put 27 of 42 user-topic arms on their generated schemas

### DIFF
--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -71,6 +71,24 @@ function wrongType(value: unknown): unknown {
   return "not-an-object";
 }
 
+// The fourth op, and the one the first three cannot express: a leaf of the
+// RIGHT type carrying a value the schema does not declare.
+//
+// `drop`, `null` and `wrong-type` all move the TYPE, so they leave a closed
+// set (`{e: [...]}`, `{l: "..."}`) and a free `"s"` indistinguishable — both
+// take a string, both refuse a number. But a token a server adds additively
+// IS a well-typed string, and that is precisely the case the wire contract
+// legislates (unknown-is-never-fatal, GH #447): several hand arms accept any
+// string ON PURPOSE where the typespec names a closed set, so that a newer
+// BEAM cannot make an older cic drop a terminal event. A type-only matrix
+// reports those arms at parity and would wave the migration through.
+//
+// Generated for STRING leaves only — on any other leaf it would be
+// `wrong-type` under a second name — and on a free-string field both
+// boundaries accept it, so the row costs a line and says nothing. It is the
+// closed-set fields where it separates them.
+const UNDECLARED_VALUE = "__undeclared_wire_value__";
+
 // Every position in a sample at which a field can be mutated, as a path.
 //
 // The matrix that landed with #1471 mutated TOP-LEVEL fields only, and that
@@ -94,7 +112,11 @@ function paths(value: unknown, prefix: readonly string[] = []): string[][] {
   return [];
 }
 
-function mutateAt(root: unknown, path: readonly string[], op: "drop" | "null" | "wrong-type") {
+type Op = "drop" | "null" | "wrong-type" | "swap";
+
+const OPS = ["drop", "null", "wrong-type", "swap"] as const;
+
+function mutateAt(root: unknown, path: readonly string[], op: Op) {
   const copy = JSON.parse(JSON.stringify(root));
   let parent = copy;
   for (const k of path.slice(0, -1)) parent = parent[k];
@@ -107,10 +129,18 @@ function mutateAt(root: unknown, path: readonly string[], op: "drop" | "null" | 
     else delete parent[leaf];
   } else if (op === "null") {
     parent[leaf] = null;
+  } else if (op === "swap") {
+    parent[leaf] = UNDECLARED_VALUE;
   } else {
     parent[leaf] = wrongType(parent[leaf]);
   }
   return copy;
+}
+
+function valueAt(root: unknown, path: readonly string[]): unknown {
+  let node = root;
+  for (const k of path) node = (node as Record<string, unknown>)[k];
+  return node;
 }
 
 type Mutation = { label: string; payload: unknown };
@@ -122,11 +152,15 @@ function mutations(valid: Record<string, unknown>): Mutation[] {
   return paths(valid)
     .filter((p) => !(p.length === 1 && p[0] === "kind"))
     .flatMap((p) =>
-      (["drop", "null", "wrong-type"] as const).map((op) => ({
+      opsFor(valueAt(valid, p)).map((op) => ({
         label: `${p.join(".")}/${op}`,
         payload: mutateAt(valid, p, op),
       })),
     );
+}
+
+function opsFor(leaf: unknown): readonly Op[] {
+  return typeof leaf === "string" ? OPS : OPS.filter((op) => op !== "swap");
 }
 
 function verdict(narrow: Narrower, payload: unknown): "accept" | "reject" {
@@ -382,15 +416,31 @@ describe("#1393 — user-topic boundary census", () => {
       divergent,
     }).toMatchInlineSnapshot(`
       {
-        "armsAtParity": 33,
+        "armsAtParity": 30,
         "armsCensused": 43,
         "armsWithSchema": 42,
         "brokenOracles": [],
         "divergent": [
           {
+            "arm": "web_session_severed",
+            "handAcceptsSchemaRejects": "-",
+            "mutations": 18,
+            "schema": "S_AdminEventsWireWebSessionSeveredEvent",
+            "schemaAcceptsHandRejects": "subject_id/swap, at/swap",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "web_session_severed",
+            "handAcceptsSchemaRejects": "code/swap",
+            "mutations": 4,
+            "schema": "S_RateLimitWireWebSessionSeveredEvent",
+            "schemaAcceptsHandRejects": "-",
+            "schemaRejectsValid": false,
+          },
+          {
             "arm": "bundle_hash",
             "handAcceptsSchemaRejects": "version/null, version/wrong-type",
-            "mutations": 6,
+            "mutations": 8,
             "schema": "S_CicWireBundleHashPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -398,7 +448,7 @@ describe("#1393 — user-topic boundary census", () => {
           {
             "arm": "connection_state_changed",
             "handAcceptsSchemaRejects": "network.recoverable/drop, network.recoverable/null, network.recoverable/wrong-type",
-            "mutations": 42,
+            "mutations": 53,
             "schema": "S_NetworksWireConnectionStateEvent",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -406,7 +456,7 @@ describe("#1393 — user-topic boundary census", () => {
           {
             "arm": "server_settings_changed",
             "handAcceptsSchemaRejects": "upload.video_max_duration_seconds/drop, upload.video_max_duration_seconds/null, upload.video_max_duration_seconds/wrong-type, http_host_aliases/drop, http_host_aliases/null, http_host_aliases/wrong-type, http_host_aliases.0/null, http_host_aliases.0/wrong-type",
-            "mutations": 30,
+            "mutations": 32,
             "schema": "S_ServerSettingsWireChangedPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -414,15 +464,15 @@ describe("#1393 — user-topic boundary census", () => {
           {
             "arm": "banlist_bundle",
             "handAcceptsSchemaRejects": "mode/drop",
-            "mutations": 24,
+            "mutations": 30,
             "schema": "S_SessionWireBanlistBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
             "arm": "isupport_changed",
-            "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, list_modes_queryable.0/null, list_modes_queryable.0/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, prefix_order.0/null, prefix_order.0/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, chantypes.0/null, chantypes.0/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, maxlist/drop, maxlist/null, maxlist/wrong-type, maxlist.key/null, maxlist.key/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
-            "mutations": 72,
+            "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, list_modes_queryable.0/null, list_modes_queryable.0/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, prefix_order.0/null, prefix_order.0/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, chantypes.0/null, chantypes.0/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, casemapping/swap, maxlist/drop, maxlist/null, maxlist/wrong-type, maxlist.key/null, maxlist.key/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
+            "mutations": 81,
             "schema": "S_SessionWireIsupportChangedPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -430,7 +480,7 @@ describe("#1393 — user-topic boundary census", () => {
           {
             "arm": "links_bundle",
             "handAcceptsSchemaRejects": "mask/drop",
-            "mutations": 24,
+            "mutations": 29,
             "schema": "S_SessionWireLinksBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -438,15 +488,31 @@ describe("#1393 — user-topic boundary census", () => {
           {
             "arm": "lusers_bundle",
             "handAcceptsSchemaRejects": "total_users/drop, total_users/wrong-type, invisible/drop, invisible/wrong-type, servers/drop, servers/wrong-type, operators/drop, operators/wrong-type, unknown_connections/drop, unknown_connections/wrong-type, channels_formed/drop, channels_formed/wrong-type, local_clients/drop, local_clients/wrong-type, local_servers/drop, local_servers/wrong-type, current_local/drop, current_local/wrong-type, max_local/drop, max_local/wrong-type, current_global/drop, current_global/wrong-type, max_global/drop, max_global/wrong-type",
-            "mutations": 39,
+            "mutations": 40,
             "schema": "S_SessionWireLusersBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
+            "arm": "recover_progress",
+            "handAcceptsSchemaRejects": "reason/swap",
+            "mutations": 16,
+            "schema": "S_SessionWireRecoverProgressPayload",
+            "schemaAcceptsHandRejects": "-",
+            "schemaRejectsValid": false,
+          },
+          {
+            "arm": "recover_result",
+            "handAcceptsSchemaRejects": "reason/swap",
+            "mutations": 12,
+            "schema": "S_SessionWireRecoverResultPayload",
+            "schemaAcceptsHandRejects": "-",
+            "schemaRejectsValid": false,
+          },
+          {
             "arm": "whois_bundle",
-            "handAcceptsSchemaRejects": "source/drop, source/null, source/wrong-type, extra_lines/drop",
-            "mutations": 102,
+            "handAcceptsSchemaRejects": "source/drop, source/null, source/wrong-type, source/swap, extra_lines/drop",
+            "mutations": 120,
             "schema": "S_SessionWireWhoisBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -454,7 +520,7 @@ describe("#1393 — user-topic boundary census", () => {
           {
             "arm": "window_invited",
             "handAcceptsSchemaRejects": "inviter/drop, inviter/null, inviter/wrong-type",
-            "mutations": 12,
+            "mutations": 16,
             "schema": "S_SessionWireWindowInvitedPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -622,6 +688,7 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network_slug/drop": "reject",
             "network_slug/null": "reject",
+            "network_slug/swap": "accept",
             "network_slug/wrong-type": "reject",
           },
           "returns": {
@@ -634,9 +701,11 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network_slug/drop": "reject",
             "network_slug/null": "reject",
+            "network_slug/swap": "accept",
             "network_slug/wrong-type": "reject",
             "target/drop": "reject",
             "target/null": "reject",
+            "target/swap": "accept",
             "target/wrong-type": "reject",
           },
           "returns": {
@@ -662,9 +731,11 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "state/drop": "reject",
             "state/null": "reject",
+            "state/swap": "reject",
             "state/wrong-type": "reject",
           },
           "returns": {
@@ -685,9 +756,11 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "state/drop": "reject",
             "state/null": "reject",
+            "state/swap": "reject",
             "state/wrong-type": "reject",
           },
           "returns": {
@@ -701,6 +774,7 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "total/drop": "reject",
             "total/null": "reject",
@@ -717,9 +791,11 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "reason/drop": "reject",
             "reason/null": "reject",
+            "reason/swap": "accept",
             "reason/wrong-type": "reject",
           },
           "returns": {
@@ -736,6 +812,7 @@ describe("#1393 — user-topic boundary census", () => {
             "count/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
           },
           "returns": {
@@ -749,12 +826,15 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "channel/drop": "reject",
             "channel/null": "reject",
+            "channel/swap": "accept",
             "channel/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "peer/drop": "reject",
             "peer/null": "reject",
+            "peer/swap": "accept",
             "peer/wrong-type": "reject",
           },
           "returns": {
@@ -769,18 +849,22 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "channel/drop": "reject",
             "channel/null": "reject",
+            "channel/swap": "accept",
             "channel/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "numeric/drop": "reject",
             "numeric/null": "accept",
             "numeric/wrong-type": "reject",
             "reason/drop": "reject",
             "reason/null": "accept",
+            "reason/swap": "accept",
             "reason/wrong-type": "reject",
             "state/drop": "reject",
             "state/null": "reject",
+            "state/swap": "reject",
             "state/wrong-type": "reject",
           },
           "returns": {
@@ -797,12 +881,15 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "channel/drop": "reject",
             "channel/null": "reject",
+            "channel/swap": "accept",
             "channel/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "state/drop": "reject",
             "state/null": "reject",
+            "state/swap": "reject",
             "state/wrong-type": "reject",
           },
           "returns": {
@@ -817,18 +904,23 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "by/drop": "reject",
             "by/null": "accept",
+            "by/swap": "accept",
             "by/wrong-type": "reject",
             "channel/drop": "reject",
             "channel/null": "reject",
+            "channel/swap": "accept",
             "channel/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "reason/drop": "reject",
             "reason/null": "accept",
+            "reason/swap": "accept",
             "reason/wrong-type": "reject",
             "state/drop": "reject",
             "state/null": "reject",
+            "state/swap": "reject",
             "state/wrong-type": "reject",
           },
           "returns": {
@@ -845,24 +937,31 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "away_ended_at/drop": "reject",
             "away_ended_at/null": "reject",
+            "away_ended_at/swap": "accept",
             "away_ended_at/wrong-type": "reject",
             "away_reason/drop": "reject",
             "away_reason/null": "accept",
+            "away_reason/swap": "accept",
             "away_reason/wrong-type": "reject",
             "away_started_at/drop": "reject",
             "away_started_at/null": "reject",
+            "away_started_at/swap": "accept",
             "away_started_at/wrong-type": "reject",
             "messages.0.body/drop": "reject",
             "messages.0.body/null": "accept",
+            "messages.0.body/swap": "accept",
             "messages.0.body/wrong-type": "reject",
             "messages.0.channel/drop": "reject",
             "messages.0.channel/null": "reject",
+            "messages.0.channel/swap": "accept",
             "messages.0.channel/wrong-type": "reject",
             "messages.0.kind/drop": "reject",
             "messages.0.kind/null": "reject",
+            "messages.0.kind/swap": "reject",
             "messages.0.kind/wrong-type": "reject",
             "messages.0.sender/drop": "reject",
             "messages.0.sender/null": "reject",
+            "messages.0.sender/swap": "accept",
             "messages.0.sender/wrong-type": "reject",
             "messages.0.server_time/drop": "reject",
             "messages.0.server_time/null": "reject",
@@ -875,6 +974,7 @@ describe("#1393 — user-topic boundary census", () => {
             "messages/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
           },
           "returns": {
@@ -899,15 +999,18 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "channel/drop": "reject",
             "channel/null": "reject",
+            "channel/swap": "accept",
             "channel/wrong-type": "reject",
             "members.0.modes.0/drop": "accept",
             "members.0.modes.0/null": "reject",
+            "members.0.modes.0/swap": "accept",
             "members.0.modes.0/wrong-type": "reject",
             "members.0.modes/drop": "reject",
             "members.0.modes/null": "reject",
             "members.0.modes/wrong-type": "reject",
             "members.0.nick/drop": "reject",
             "members.0.nick/null": "reject",
+            "members.0.nick/swap": "accept",
             "members.0.nick/wrong-type": "reject",
             "members.0/drop": "accept",
             "members.0/null": "reject",
@@ -917,6 +1020,7 @@ describe("#1393 — user-topic boundary census", () => {
             "members/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
           },
           "returns": {
@@ -938,12 +1042,14 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "networks.key.0.added_at/drop": "reject",
             "networks.key.0.added_at/null": "reject",
+            "networks.key.0.added_at/swap": "accept",
             "networks.key.0.added_at/wrong-type": "reject",
             "networks.key.0.network_id/drop": "reject",
             "networks.key.0.network_id/null": "reject",
             "networks.key.0.network_id/wrong-type": "reject",
             "networks.key.0.nick/drop": "reject",
             "networks.key.0.nick/null": "reject",
+            "networks.key.0.nick/swap": "accept",
             "networks.key.0.nick/wrong-type": "reject",
             "networks.key.0/drop": "accept",
             "networks.key.0/null": "reject",
@@ -976,6 +1082,7 @@ describe("#1393 — user-topic boundary census", () => {
             "network_id/wrong-type": "reject",
             "nick/drop": "reject",
             "nick/null": "reject",
+            "nick/swap": "accept",
             "nick/wrong-type": "reject",
           },
           "returns": {
@@ -989,12 +1096,15 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "message/drop": "reject",
             "message/null": "reject",
+            "message/swap": "accept",
             "message/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "peer/drop": "reject",
             "peer/null": "reject",
+            "peer/swap": "accept",
             "peer/wrong-type": "reject",
           },
           "returns": {
@@ -1015,15 +1125,19 @@ describe("#1393 — user-topic boundary census", () => {
             "network_id/wrong-type": "reject",
             "nick/drop": "reject",
             "nick/null": "reject",
+            "nick/swap": "accept",
             "nick/wrong-type": "reject",
             "presence/drop": "reject",
             "presence/null": "reject",
+            "presence/swap": "reject",
             "presence/wrong-type": "reject",
             "source/drop": "reject",
             "source/null": "reject",
+            "source/swap": "reject",
             "source/wrong-type": "reject",
             "ts/drop": "reject",
             "ts/null": "reject",
+            "ts/swap": "accept",
             "ts/wrong-type": "reject",
           },
           "returns": {
@@ -1041,12 +1155,14 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "detail/drop": "reject",
             "detail/null": "reject",
+            "detail/swap": "accept",
             "detail/wrong-type": "reject",
             "network_id/drop": "reject",
             "network_id/null": "reject",
             "network_id/wrong-type": "reject",
             "reason/drop": "reject",
             "reason/null": "reject",
+            "reason/swap": "reject",
             "reason/wrong-type": "reject",
           },
           "returns": {
@@ -1064,6 +1180,7 @@ describe("#1393 — user-topic boundary census", () => {
             "network_id/wrong-type": "reject",
             "nicks.key/drop": "accept",
             "nicks.key/null": "reject",
+            "nicks.key/swap": "reject",
             "nicks.key/wrong-type": "reject",
             "nicks/drop": "reject",
             "nicks/null": "reject",
@@ -1085,9 +1202,11 @@ describe("#1393 — user-topic boundary census", () => {
             "windows.key.0.network_id/wrong-type": "reject",
             "windows.key.0.opened_at/drop": "reject",
             "windows.key.0.opened_at/null": "reject",
+            "windows.key.0.opened_at/swap": "accept",
             "windows.key.0.opened_at/wrong-type": "reject",
             "windows.key.0.target_nick/drop": "reject",
             "windows.key.0.target_nick/null": "reject",
+            "windows.key.0.target_nick/swap": "accept",
             "windows.key.0.target_nick/wrong-type": "reject",
             "windows.key.0/drop": "accept",
             "windows.key.0/null": "reject",
@@ -1117,15 +1236,19 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "reason/drop": "reject",
             "reason/null": "accept",
+            "reason/swap": "accept",
             "reason/wrong-type": "reject",
             "status/drop": "reject",
             "status/null": "reject",
+            "status/swap": "reject",
             "status/wrong-type": "reject",
             "step/drop": "reject",
             "step/null": "reject",
+            "step/swap": "reject",
             "step/wrong-type": "reject",
           },
           "returns": {
@@ -1141,12 +1264,15 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "outcome/drop": "reject",
             "outcome/null": "reject",
+            "outcome/swap": "reject",
             "outcome/wrong-type": "reject",
             "reason/drop": "reject",
             "reason/null": "accept",
+            "reason/swap": "accept",
             "reason/wrong-type": "reject",
           },
           "returns": {
@@ -1161,15 +1287,18 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "lines.0/drop": "accept",
             "lines.0/null": "reject",
+            "lines.0/swap": "accept",
             "lines.0/wrong-type": "reject",
             "lines/drop": "reject",
             "lines/null": "reject",
             "lines/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "source/drop": "reject",
             "source/null": "reject",
+            "source/swap": "reject",
             "source/wrong-type": "reject",
           },
           "returns": {
@@ -1186,6 +1315,7 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "account/drop": "reject",
             "account/null": "accept",
+            "account/swap": "accept",
             "account/wrong-type": "reject",
             "identified/drop": "reject",
             "identified/null": "reject",
@@ -1206,6 +1336,7 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "modes.0/drop": "accept",
             "modes.0/null": "reject",
+            "modes.0/swap": "accept",
             "modes.0/wrong-type": "reject",
             "modes/drop": "reject",
             "modes/null": "reject",
@@ -1227,6 +1358,7 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "modes.0/drop": "accept",
             "modes.0/null": "reject",
+            "modes.0/swap": "accept",
             "modes.0/wrong-type": "reject",
             "modes/drop": "reject",
             "modes/null": "reject",
@@ -1248,6 +1380,7 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "code/drop": "reject",
             "code/null": "reject",
+            "code/swap": "accept",
             "code/wrong-type": "reject",
           },
           "returns": {
@@ -1260,33 +1393,42 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "target/drop": "reject",
             "target/null": "reject",
+            "target/swap": "accept",
             "target/wrong-type": "reject",
             "users.0.channel/drop": "reject",
             "users.0.channel/null": "reject",
+            "users.0.channel/swap": "accept",
             "users.0.channel/wrong-type": "reject",
             "users.0.hops/drop": "reject",
             "users.0.hops/null": "accept",
             "users.0.hops/wrong-type": "reject",
             "users.0.host/drop": "reject",
             "users.0.host/null": "reject",
+            "users.0.host/swap": "accept",
             "users.0.host/wrong-type": "reject",
             "users.0.modes/drop": "reject",
             "users.0.modes/null": "reject",
+            "users.0.modes/swap": "accept",
             "users.0.modes/wrong-type": "reject",
             "users.0.nick/drop": "reject",
             "users.0.nick/null": "reject",
+            "users.0.nick/swap": "accept",
             "users.0.nick/wrong-type": "reject",
             "users.0.realname/drop": "reject",
             "users.0.realname/null": "accept",
+            "users.0.realname/swap": "accept",
             "users.0.realname/wrong-type": "reject",
             "users.0.server/drop": "reject",
             "users.0.server/null": "reject",
+            "users.0.server/swap": "accept",
             "users.0.server/wrong-type": "reject",
             "users.0.user/drop": "reject",
             "users.0.user/null": "reject",
+            "users.0.user/swap": "accept",
             "users.0.user/wrong-type": "reject",
             "users.0/drop": "accept",
             "users.0/null": "reject",
@@ -1318,27 +1460,34 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "host/drop": "reject",
             "host/null": "accept",
+            "host/swap": "accept",
             "host/wrong-type": "reject",
             "logoff_time/drop": "reject",
             "logoff_time/null": "accept",
+            "logoff_time/swap": "accept",
             "logoff_time/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "not_found/drop": "reject",
             "not_found/null": "reject",
             "not_found/wrong-type": "reject",
             "realname/drop": "reject",
             "realname/null": "accept",
+            "realname/swap": "accept",
             "realname/wrong-type": "reject",
             "server/drop": "reject",
             "server/null": "accept",
+            "server/swap": "accept",
             "server/wrong-type": "reject",
             "target/drop": "reject",
             "target/null": "reject",
+            "target/swap": "accept",
             "target/wrong-type": "reject",
             "user/drop": "reject",
             "user/null": "accept",
+            "user/swap": "accept",
             "user/wrong-type": "reject",
           },
           "returns": {
@@ -1358,9 +1507,11 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "channel/drop": "reject",
             "channel/null": "reject",
+            "channel/swap": "accept",
             "channel/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
           },
           "returns": {
@@ -1374,12 +1525,15 @@ describe("#1393 — user-topic boundary census", () => {
           "matrix": {
             "channel/drop": "reject",
             "channel/null": "reject",
+            "channel/swap": "accept",
             "channel/wrong-type": "reject",
             "network/drop": "reject",
             "network/null": "reject",
+            "network/swap": "accept",
             "network/wrong-type": "reject",
             "state/drop": "reject",
             "state/null": "reject",
+            "state/swap": "reject",
             "state/wrong-type": "reject",
           },
           "returns": {

--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -85,6 +85,27 @@ function isObjectNode(node: WireNode): node is { o: Record<string, WireNode> } {
   return typeof node !== "string" && "o" in node;
 }
 
+// Key order is not part of the boundary contract, so it must not be part of
+// the comparison: an arm that builds `{kind, network}` and a schema that
+// declares `{network, kind}` hand the dispatcher the same object.
+function canon(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canon);
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([k, v]) => [k, canon(v)]),
+    );
+  }
+  return value;
+}
+
+function keysOf(value: unknown): string[] {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? Object.keys(value as Record<string, unknown>).sort()
+    : [];
+}
+
 // Every generated schema that carries a `kind` literal, indexed by it.
 function schemasByKind(): Map<string, Candidate[]> {
   const out = new Map<string, Candidate[]>();
@@ -386,6 +407,238 @@ describe("#1393 — user-topic boundary census", () => {
           },
         ],
       }
+    `);
+  });
+
+  // The census above measures ACCEPT/REJECT and nothing else, and that is not
+  // the whole boundary. `narrowUserEvent` returns the object the dispatcher
+  // then consumes, and `validate` builds its OWN object from the schema's
+  // declared fields — `wireValidate.ts`'s `walkObject` drops undeclared keys
+  // rather than rejecting them (additive-only, GH #447), exactly as the hand
+  // arms drop them by constructing a fresh literal.
+  //
+  // So two narrowers can agree on every verdict in the matrix above and still
+  // hand the dispatcher DIFFERENT objects, whenever the schema declares a
+  // field the hand arm does not copy out. Swapping one for the other would
+  // ship that difference, and the verdict census cannot see it. "At parity"
+  // therefore needs both axes before an arm is safe to migrate; this measures
+  // the second one.
+  it("censuses the VALUE each boundary returns, not just its verdict", () => {
+    const pairs = ARMS.filter(accepts).flatMap((k) =>
+      candidatesFor(k).map(({ name, node }) => ({ arm: k, schema: name, node })),
+    );
+
+    // A pair is comparable only when BOTH sides produced a value. The
+    // ambiguous `kind` literal leaves some arms carrying a candidate from the
+    // WRONG Wire module, whose sample the hand narrower rightly rejects —
+    // there is no value there to compare, and scoring it as a value
+    // divergence would report the ambiguity as a defect. Skipped pairs are
+    // COUNTED, not dropped, so the arithmetic stays closed.
+    const comparable = pairs.filter(
+      ({ node }) =>
+        verdict(hand, sample(node)) === "accept" &&
+        verdict((raw) => validate(node, raw), sample(node)) === "accept",
+    );
+
+    const divergent = comparable
+      .map(({ arm, schema, node }) => {
+        const valid = sample(node);
+        const byHand = hand(valid);
+        const bySchema = validate(node, valid);
+        const handKeys = keysOf(byHand);
+        const schemaKeys = keysOf(bySchema);
+        return {
+          arm,
+          schema,
+          onlyHand: handKeys.filter((f) => !schemaKeys.includes(f)),
+          onlySchema: schemaKeys.filter((f) => !handKeys.includes(f)),
+          sameValue: JSON.stringify(canon(byHand)) === JSON.stringify(canon(bySchema)),
+        };
+      })
+      .filter((r) => !r.sameValue);
+
+    expect({
+      pairs: pairs.length,
+      comparablePairs: comparable.length,
+      skippedOneSideRejected: pairs.length - comparable.length,
+      armsAtValueParity:
+        new Set(comparable.map((p) => p.arm)).size - new Set(divergent.map((r) => r.arm)).size,
+      divergent,
+    }).toMatchInlineSnapshot(`
+      {
+        "armsAtValueParity": 42,
+        "comparablePairs": 42,
+        "divergent": [],
+        "pairs": 43,
+        "skippedOneSideRejected": 1,
+      }
+    `);
+  });
+
+  // Slice 1 of the migration this file measured.
+  //
+  // The two censuses above compare the hand narrower against the schema. The
+  // moment an arm's `case` calls `validate` with its own generated schema,
+  // both of them compare that schema against ITSELF for that arm and report
+  // parity BY CONSTRUCTION — still printing 34 and 42, still green, and
+  // measuring nothing. A migration that quietly converts its own oracle into
+  // a tautology is a gate that lies, so the property the migration has to
+  // preserve gets an oracle that never consults a schema to JUDGE.
+  //
+  // A schema is still the only available source of a valid payload, so it
+  // generates the inputs; the recorded verdict and returned value are the
+  // narrower's alone. Taken BEFORE the migration this is a record of what the
+  // boundary did, and an unchanged snapshot afterwards is the evidence that
+  // it still does it. A schema edit moves the inputs and therefore the
+  // snapshot — that is a signal, not noise.
+  //
+  // Extend the list with each slice. An arm left off it is migrated with no
+  // oracle at all.
+  const MIGRATED_ARMS = [
+    "away_confirmed",
+    "presence_changed",
+    "presence_error",
+    "session_identity_changed",
+    "umode_changed",
+  ] as const;
+
+  it("pins what the migrated arms accept and return, judged without a schema", () => {
+    const pinned = MIGRATED_ARMS.map((arm) => {
+      const candidates = candidatesFor(arm);
+      // An ambiguous `kind` literal would make `[0]` a coin toss between two
+      // Wire modules. None of slice 1 is ambiguous; a later slice that adds
+      // one has to say which module it means, rather than inherit whichever
+      // the walk happened to see first.
+      if (candidates.length !== 1) {
+        throw new Error(
+          `"${arm}" has ${candidates.length} candidate schemas — pick one explicitly`,
+        );
+      }
+      const node = candidates[0].node;
+      const valid = sample(node) as Record<string, unknown>;
+
+      const matrix: Record<string, string> = {};
+      for (const f of Object.keys(valid).filter((k) => k !== "kind")) {
+        for (const [label, mutated] of [
+          ["drop", without(valid, f)],
+          ["null", { ...valid, [f]: null }],
+          ["wrong-type", { ...valid, [f]: wrongType(valid[f]) }],
+        ] as const) {
+          matrix[`${f}/${label}`] = verdict(hand, mutated);
+        }
+      }
+      return { arm, returns: canon(hand(valid)), matrix };
+    });
+
+    expect(pinned).toMatchInlineSnapshot(`
+      [
+        {
+          "arm": "away_confirmed",
+          "matrix": {
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "state/drop": "reject",
+            "state/null": "reject",
+            "state/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "away_confirmed",
+            "network": "sample",
+            "state": "present",
+          },
+        },
+        {
+          "arm": "presence_changed",
+          "matrix": {
+            "initial/drop": "reject",
+            "initial/null": "reject",
+            "initial/wrong-type": "reject",
+            "network_id/drop": "reject",
+            "network_id/null": "reject",
+            "network_id/wrong-type": "reject",
+            "nick/drop": "reject",
+            "nick/null": "reject",
+            "nick/wrong-type": "reject",
+            "presence/drop": "reject",
+            "presence/null": "reject",
+            "presence/wrong-type": "reject",
+            "source/drop": "reject",
+            "source/null": "reject",
+            "source/wrong-type": "reject",
+            "ts/drop": "reject",
+            "ts/null": "reject",
+            "ts/wrong-type": "reject",
+          },
+          "returns": {
+            "initial": true,
+            "kind": "presence_changed",
+            "network_id": 1,
+            "nick": "sample",
+            "presence": "online",
+            "source": "monitor",
+            "ts": "sample",
+          },
+        },
+        {
+          "arm": "presence_error",
+          "matrix": {
+            "detail/drop": "reject",
+            "detail/null": "reject",
+            "detail/wrong-type": "reject",
+            "network_id/drop": "reject",
+            "network_id/null": "reject",
+            "network_id/wrong-type": "reject",
+            "reason/drop": "reject",
+            "reason/null": "reject",
+            "reason/wrong-type": "reject",
+          },
+          "returns": {
+            "detail": "sample",
+            "kind": "presence_error",
+            "network_id": 1,
+            "reason": "list_full",
+          },
+        },
+        {
+          "arm": "session_identity_changed",
+          "matrix": {
+            "account/drop": "reject",
+            "account/null": "accept",
+            "account/wrong-type": "reject",
+            "identified/drop": "reject",
+            "identified/null": "reject",
+            "identified/wrong-type": "reject",
+            "network_id/drop": "reject",
+            "network_id/null": "reject",
+            "network_id/wrong-type": "reject",
+          },
+          "returns": {
+            "account": "sample",
+            "identified": true,
+            "kind": "session_identity_changed",
+            "network_id": 1,
+          },
+        },
+        {
+          "arm": "umode_changed",
+          "matrix": {
+            "modes/drop": "reject",
+            "modes/null": "reject",
+            "modes/wrong-type": "reject",
+            "network_id/drop": "reject",
+            "network_id/null": "reject",
+            "network_id/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "umode_changed",
+            "modes": [
+              "sample",
+            ],
+            "network_id": 1,
+          },
+        },
+      ]
     `);
   });
 });

--- a/cicchetto/src/__tests__/wireUserBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireUserBoundary.test.ts
@@ -71,10 +71,62 @@ function wrongType(value: unknown): unknown {
   return "not-an-object";
 }
 
-function without(obj: Record<string, unknown>, field: string): Record<string, unknown> {
-  const copy = { ...obj };
-  delete copy[field];
+// Every position in a sample at which a field can be mutated, as a path.
+//
+// The matrix that landed with #1471 mutated TOP-LEVEL fields only, and that
+// cannot see a tolerance nested inside an object field. `connection_state_changed`
+// is the measured instance: its hand arm defaults `network.recoverable` to
+// `false` when the server omits it (#581, additive-field tolerance), while
+// `S_NetworksWireHomeNetworkRow` declares that field REQUIRED. One level down
+// the two boundaries disagree; at the top level they look identical, and the
+// arm was therefore counted among the 34 at parity. So the matrix walks the
+// whole sample instead of its first layer.
+function paths(value: unknown, prefix: readonly string[] = []): string[][] {
+  if (Array.isArray(value)) {
+    return value.flatMap((v, i) => [[...prefix, String(i)], ...paths(v, [...prefix, String(i)])]);
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value as Record<string, unknown>).flatMap(([k, v]) => [
+      [...prefix, k],
+      ...paths(v, [...prefix, k]),
+    ]);
+  }
+  return [];
+}
+
+function mutateAt(root: unknown, path: readonly string[], op: "drop" | "null" | "wrong-type") {
+  const copy = JSON.parse(JSON.stringify(root));
+  let parent = copy;
+  for (const k of path.slice(0, -1)) parent = parent[k];
+  const leaf = path[path.length - 1] as string;
+  if (op === "drop") {
+    // Deleting an array index would leave a hole that reads as `undefined`
+    // rather than a shorter array, which is a third mutation nobody asked
+    // for. Splice keeps "drop" meaning the same thing at every position.
+    if (Array.isArray(parent)) parent.splice(Number(leaf), 1);
+    else delete parent[leaf];
+  } else if (op === "null") {
+    parent[leaf] = null;
+  } else {
+    parent[leaf] = wrongType(parent[leaf]);
+  }
   return copy;
+}
+
+type Mutation = { label: string; payload: unknown };
+
+// `kind` is excluded at the TOP level only — mutating the discriminator tests
+// dispatch, not field validation. A nested `kind` belongs to a nested shape
+// and is an ordinary field there.
+function mutations(valid: Record<string, unknown>): Mutation[] {
+  return paths(valid)
+    .filter((p) => !(p.length === 1 && p[0] === "kind"))
+    .flatMap((p) =>
+      (["drop", "null", "wrong-type"] as const).map((op) => ({
+        label: `${p.join(".")}/${op}`,
+        payload: mutateAt(valid, p, op),
+      })),
+    );
 }
 
 function verdict(narrow: Narrower, payload: unknown): "accept" | "reject" {
@@ -125,7 +177,7 @@ type Candidate = { name: string; node: WireNode };
 type ArmReport = {
   arm: string;
   schema: string;
-  fields: number;
+  mutations: number;
   handAcceptsSchemaRejects: string;
   schemaAcceptsHandRejects: string;
   schemaRejectsValid: boolean;
@@ -134,27 +186,21 @@ type ArmReport = {
 function censusArm(kind: string, schemaName: string, node: WireNode): ArmReport {
   const generated: Narrower = (raw) => validate(node, raw);
   const valid = sample(node) as Record<string, unknown>;
-  const fields = Object.keys(valid).filter((f) => f !== "kind");
+  const matrix = mutations(valid);
 
   const holes: string[] = [];
   const losses: string[] = [];
-  for (const f of fields) {
-    for (const [label, mutated] of [
-      ["drop", without(valid, f)],
-      ["null", { ...valid, [f]: null }],
-      ["wrong-type", { ...valid, [f]: wrongType(valid[f]) }],
-    ] as const) {
-      const byHand = verdict(hand, mutated);
-      const bySchema = verdict(generated, mutated);
-      if (byHand === "accept" && bySchema === "reject") holes.push(`${f}/${label}`);
-      if (bySchema === "accept" && byHand === "reject") losses.push(`${f}/${label}`);
-    }
+  for (const { label, payload } of matrix) {
+    const byHand = verdict(hand, payload);
+    const bySchema = verdict(generated, payload);
+    if (byHand === "accept" && bySchema === "reject") holes.push(label);
+    if (bySchema === "accept" && byHand === "reject") losses.push(label);
   }
 
   return {
     arm: kind,
     schema: schemaName,
-    fields: fields.length,
+    mutations: matrix.length,
     handAcceptsSchemaRejects: holes.length === 0 ? "-" : holes.join(", "),
     schemaAcceptsHandRejects: losses.length === 0 ? "-" : losses.join(", "),
     // The oracle's own sanity check: a schema that rejects its OWN sample
@@ -336,71 +382,79 @@ describe("#1393 — user-topic boundary census", () => {
       divergent,
     }).toMatchInlineSnapshot(`
       {
-        "armsAtParity": 34,
+        "armsAtParity": 33,
         "armsCensused": 43,
         "armsWithSchema": 42,
         "brokenOracles": [],
         "divergent": [
           {
             "arm": "bundle_hash",
-            "fields": 2,
             "handAcceptsSchemaRejects": "version/null, version/wrong-type",
+            "mutations": 6,
             "schema": "S_CicWireBundleHashPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
+            "arm": "connection_state_changed",
+            "handAcceptsSchemaRejects": "network.recoverable/drop, network.recoverable/null, network.recoverable/wrong-type",
+            "mutations": 42,
+            "schema": "S_NetworksWireConnectionStateEvent",
+            "schemaAcceptsHandRejects": "-",
+            "schemaRejectsValid": false,
+          },
+          {
             "arm": "server_settings_changed",
-            "fields": 2,
-            "handAcceptsSchemaRejects": "http_host_aliases/drop, http_host_aliases/null, http_host_aliases/wrong-type",
+            "handAcceptsSchemaRejects": "upload.video_max_duration_seconds/drop, upload.video_max_duration_seconds/null, upload.video_max_duration_seconds/wrong-type, http_host_aliases/drop, http_host_aliases/null, http_host_aliases/wrong-type, http_host_aliases.0/null, http_host_aliases.0/wrong-type",
+            "mutations": 30,
             "schema": "S_ServerSettingsWireChangedPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
             "arm": "banlist_bundle",
-            "fields": 4,
             "handAcceptsSchemaRejects": "mode/drop",
+            "mutations": 24,
             "schema": "S_SessionWireBanlistBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
             "arm": "isupport_changed",
-            "fields": 15,
-            "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, maxlist/drop, maxlist/null, maxlist/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
+            "handAcceptsSchemaRejects": "list_modes_queryable/drop, list_modes_queryable/null, list_modes_queryable/wrong-type, list_modes_queryable.0/null, list_modes_queryable.0/wrong-type, prefix_order/drop, prefix_order/null, prefix_order/wrong-type, prefix_order.0/null, prefix_order.0/wrong-type, chantypes/drop, chantypes/null, chantypes/wrong-type, chantypes.0/null, chantypes.0/wrong-type, casemapping/drop, casemapping/null, casemapping/wrong-type, maxlist/drop, maxlist/null, maxlist/wrong-type, maxlist.key/null, maxlist.key/wrong-type, nicklen/drop, nicklen/wrong-type, channellen/drop, channellen/wrong-type, topiclen/drop, topiclen/wrong-type, frame_budget_base/drop, frame_budget_base/null, frame_budget_base/wrong-type",
+            "mutations": 72,
             "schema": "S_SessionWireIsupportChangedPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
             "arm": "links_bundle",
-            "fields": 3,
             "handAcceptsSchemaRejects": "mask/drop",
+            "mutations": 24,
             "schema": "S_SessionWireLinksBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
             "arm": "lusers_bundle",
-            "fields": 13,
             "handAcceptsSchemaRejects": "total_users/drop, total_users/wrong-type, invisible/drop, invisible/wrong-type, servers/drop, servers/wrong-type, operators/drop, operators/wrong-type, unknown_connections/drop, unknown_connections/wrong-type, channels_formed/drop, channels_formed/wrong-type, local_clients/drop, local_clients/wrong-type, local_servers/drop, local_servers/wrong-type, current_local/drop, current_local/wrong-type, max_local/drop, max_local/wrong-type, current_global/drop, current_global/wrong-type, max_global/drop, max_global/wrong-type",
+            "mutations": 39,
             "schema": "S_SessionWireLusersBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
             "arm": "whois_bundle",
-            "fields": 30,
             "handAcceptsSchemaRejects": "source/drop, source/null, source/wrong-type, extra_lines/drop",
+            "mutations": 102,
             "schema": "S_SessionWireWhoisBundlePayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
           },
           {
             "arm": "window_invited",
-            "fields": 4,
             "handAcceptsSchemaRejects": "inviter/drop, inviter/null, inviter/wrong-type",
+            "mutations": 12,
             "schema": "S_SessionWireWindowInvitedPayload",
             "schemaAcceptsHandRejects": "-",
             "schemaRejectsValid": false,
@@ -495,43 +549,114 @@ describe("#1393 — user-topic boundary census", () => {
   // Extend the list with each slice. An arm left off it is migrated with no
   // oracle at all.
   const MIGRATED_ARMS = [
+    "archive_changed",
+    "archive_purged",
+    "auto_away_debounce_changed",
     "away_confirmed",
+    "channels_changed",
+    "connection_progress",
+    "directory_complete",
+    "directory_failed",
+    "directory_progress",
+    "invite_ack",
+    "join_failed",
+    "joined",
+    "kicked",
+    "mentions_bundle",
+    "names_reply",
+    "notify_list",
+    "own_nick_changed",
+    "peer_away",
     "presence_changed",
     "presence_error",
+    "presence_snapshot",
+    "query_windows_list",
+    "recover_progress",
+    "recover_result",
+    "server_reply",
     "session_identity_changed",
+    "supported_umodes_changed",
     "umode_changed",
+    "web_session_severed",
+    "who_reply",
+    "whowas_bundle",
+    "window_invite_declined",
+    "window_pending",
   ] as const;
 
   it("pins what the migrated arms accept and return, judged without a schema", () => {
     const pinned = MIGRATED_ARMS.map((arm) => {
-      const candidates = candidatesFor(arm);
-      // An ambiguous `kind` literal would make `[0]` a coin toss between two
-      // Wire modules. None of slice 1 is ambiguous; a later slice that adds
-      // one has to say which module it means, rather than inherit whichever
-      // the walk happened to see first.
-      if (candidates.length !== 1) {
+      // An ambiguous `kind` literal must not be resolved by taking `[0]` —
+      // that is a coin toss between two Wire modules, and for
+      // `web_session_severed` the loser is the admin one, whose shape this
+      // topic never carries. Resolve it by MEASUREMENT rather than by a
+      // hard-coded name: the right candidate is the one whose sample the hand
+      // narrower accepts, and exactly one must, or the disambiguation is not
+      // a fact and the pin refuses to guess.
+      const candidates = candidatesFor(arm).filter(
+        ({ node }) => verdict(hand, sample(node)) === "accept",
+      );
+      // `only === undefined` is not defensive noise: a length check does not
+      // narrow an index under `noUncheckedIndexedAccess`, and the two
+      // conditions are the same fact stated where the compiler can see it.
+      const [only] = candidates;
+      if (candidates.length !== 1 || only === undefined) {
         throw new Error(
-          `"${arm}" has ${candidates.length} candidate schemas — pick one explicitly`,
+          `"${arm}": ${candidates.length} candidates produce a sample the hand narrower accepts — expected exactly 1`,
         );
       }
-      const node = candidates[0].node;
+      const node = only.node;
       const valid = sample(node) as Record<string, unknown>;
 
       const matrix: Record<string, string> = {};
-      for (const f of Object.keys(valid).filter((k) => k !== "kind")) {
-        for (const [label, mutated] of [
-          ["drop", without(valid, f)],
-          ["null", { ...valid, [f]: null }],
-          ["wrong-type", { ...valid, [f]: wrongType(valid[f]) }],
-        ] as const) {
-          matrix[`${f}/${label}`] = verdict(hand, mutated);
-        }
+      for (const { label, payload } of mutations(valid)) {
+        matrix[label] = verdict(hand, payload);
       }
       return { arm, returns: canon(hand(valid)), matrix };
     });
 
     expect(pinned).toMatchInlineSnapshot(`
       [
+        {
+          "arm": "archive_changed",
+          "matrix": {
+            "network_slug/drop": "reject",
+            "network_slug/null": "reject",
+            "network_slug/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "archive_changed",
+            "network_slug": "sample",
+          },
+        },
+        {
+          "arm": "archive_purged",
+          "matrix": {
+            "network_slug/drop": "reject",
+            "network_slug/null": "reject",
+            "network_slug/wrong-type": "reject",
+            "target/drop": "reject",
+            "target/null": "reject",
+            "target/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "archive_purged",
+            "network_slug": "sample",
+            "target": "sample",
+          },
+        },
+        {
+          "arm": "auto_away_debounce_changed",
+          "matrix": {
+            "auto_away_debounce_seconds/drop": "reject",
+            "auto_away_debounce_seconds/null": "accept",
+            "auto_away_debounce_seconds/wrong-type": "reject",
+          },
+          "returns": {
+            "auto_away_debounce_seconds": 1,
+            "kind": "auto_away_debounce_changed",
+          },
+        },
         {
           "arm": "away_confirmed",
           "matrix": {
@@ -546,6 +671,337 @@ describe("#1393 — user-topic boundary census", () => {
             "kind": "away_confirmed",
             "network": "sample",
             "state": "present",
+          },
+        },
+        {
+          "arm": "channels_changed",
+          "matrix": {},
+          "returns": {
+            "kind": "channels_changed",
+          },
+        },
+        {
+          "arm": "connection_progress",
+          "matrix": {
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "state/drop": "reject",
+            "state/null": "reject",
+            "state/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "connection_progress",
+            "network": "sample",
+            "state": "connecting",
+          },
+        },
+        {
+          "arm": "directory_complete",
+          "matrix": {
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "total/drop": "reject",
+            "total/null": "reject",
+            "total/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "directory_complete",
+            "network": "sample",
+            "total": 1,
+          },
+        },
+        {
+          "arm": "directory_failed",
+          "matrix": {
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "reason/drop": "reject",
+            "reason/null": "reject",
+            "reason/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "directory_failed",
+            "network": "sample",
+            "reason": "sample",
+          },
+        },
+        {
+          "arm": "directory_progress",
+          "matrix": {
+            "count/drop": "reject",
+            "count/null": "reject",
+            "count/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+          },
+          "returns": {
+            "count": 1,
+            "kind": "directory_progress",
+            "network": "sample",
+          },
+        },
+        {
+          "arm": "invite_ack",
+          "matrix": {
+            "channel/drop": "reject",
+            "channel/null": "reject",
+            "channel/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "peer/drop": "reject",
+            "peer/null": "reject",
+            "peer/wrong-type": "reject",
+          },
+          "returns": {
+            "channel": "sample",
+            "kind": "invite_ack",
+            "network": "sample",
+            "peer": "sample",
+          },
+        },
+        {
+          "arm": "join_failed",
+          "matrix": {
+            "channel/drop": "reject",
+            "channel/null": "reject",
+            "channel/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "numeric/drop": "reject",
+            "numeric/null": "accept",
+            "numeric/wrong-type": "reject",
+            "reason/drop": "reject",
+            "reason/null": "accept",
+            "reason/wrong-type": "reject",
+            "state/drop": "reject",
+            "state/null": "reject",
+            "state/wrong-type": "reject",
+          },
+          "returns": {
+            "channel": "sample",
+            "kind": "join_failed",
+            "network": "sample",
+            "numeric": 1,
+            "reason": "sample",
+            "state": "failed",
+          },
+        },
+        {
+          "arm": "joined",
+          "matrix": {
+            "channel/drop": "reject",
+            "channel/null": "reject",
+            "channel/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "state/drop": "reject",
+            "state/null": "reject",
+            "state/wrong-type": "reject",
+          },
+          "returns": {
+            "channel": "sample",
+            "kind": "joined",
+            "network": "sample",
+            "state": "joined",
+          },
+        },
+        {
+          "arm": "kicked",
+          "matrix": {
+            "by/drop": "reject",
+            "by/null": "accept",
+            "by/wrong-type": "reject",
+            "channel/drop": "reject",
+            "channel/null": "reject",
+            "channel/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "reason/drop": "reject",
+            "reason/null": "accept",
+            "reason/wrong-type": "reject",
+            "state/drop": "reject",
+            "state/null": "reject",
+            "state/wrong-type": "reject",
+          },
+          "returns": {
+            "by": "sample",
+            "channel": "sample",
+            "kind": "kicked",
+            "network": "sample",
+            "reason": "sample",
+            "state": "kicked",
+          },
+        },
+        {
+          "arm": "mentions_bundle",
+          "matrix": {
+            "away_ended_at/drop": "reject",
+            "away_ended_at/null": "reject",
+            "away_ended_at/wrong-type": "reject",
+            "away_reason/drop": "reject",
+            "away_reason/null": "accept",
+            "away_reason/wrong-type": "reject",
+            "away_started_at/drop": "reject",
+            "away_started_at/null": "reject",
+            "away_started_at/wrong-type": "reject",
+            "messages.0.body/drop": "reject",
+            "messages.0.body/null": "accept",
+            "messages.0.body/wrong-type": "reject",
+            "messages.0.channel/drop": "reject",
+            "messages.0.channel/null": "reject",
+            "messages.0.channel/wrong-type": "reject",
+            "messages.0.kind/drop": "reject",
+            "messages.0.kind/null": "reject",
+            "messages.0.kind/wrong-type": "reject",
+            "messages.0.sender/drop": "reject",
+            "messages.0.sender/null": "reject",
+            "messages.0.sender/wrong-type": "reject",
+            "messages.0.server_time/drop": "reject",
+            "messages.0.server_time/null": "reject",
+            "messages.0.server_time/wrong-type": "reject",
+            "messages.0/drop": "accept",
+            "messages.0/null": "reject",
+            "messages.0/wrong-type": "reject",
+            "messages/drop": "reject",
+            "messages/null": "reject",
+            "messages/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+          },
+          "returns": {
+            "away_ended_at": "sample",
+            "away_reason": "sample",
+            "away_started_at": "sample",
+            "kind": "mentions_bundle",
+            "messages": [
+              {
+                "body": "sample",
+                "channel": "sample",
+                "kind": "privmsg",
+                "sender": "sample",
+                "server_time": 1,
+              },
+            ],
+            "network": "sample",
+          },
+        },
+        {
+          "arm": "names_reply",
+          "matrix": {
+            "channel/drop": "reject",
+            "channel/null": "reject",
+            "channel/wrong-type": "reject",
+            "members.0.modes.0/drop": "accept",
+            "members.0.modes.0/null": "reject",
+            "members.0.modes.0/wrong-type": "reject",
+            "members.0.modes/drop": "reject",
+            "members.0.modes/null": "reject",
+            "members.0.modes/wrong-type": "reject",
+            "members.0.nick/drop": "reject",
+            "members.0.nick/null": "reject",
+            "members.0.nick/wrong-type": "reject",
+            "members.0/drop": "accept",
+            "members.0/null": "reject",
+            "members.0/wrong-type": "reject",
+            "members/drop": "reject",
+            "members/null": "reject",
+            "members/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+          },
+          "returns": {
+            "channel": "sample",
+            "kind": "names_reply",
+            "members": [
+              {
+                "modes": [
+                  "sample",
+                ],
+                "nick": "sample",
+              },
+            ],
+            "network": "sample",
+          },
+        },
+        {
+          "arm": "notify_list",
+          "matrix": {
+            "networks.key.0.added_at/drop": "reject",
+            "networks.key.0.added_at/null": "reject",
+            "networks.key.0.added_at/wrong-type": "reject",
+            "networks.key.0.network_id/drop": "reject",
+            "networks.key.0.network_id/null": "reject",
+            "networks.key.0.network_id/wrong-type": "reject",
+            "networks.key.0.nick/drop": "reject",
+            "networks.key.0.nick/null": "reject",
+            "networks.key.0.nick/wrong-type": "reject",
+            "networks.key.0/drop": "accept",
+            "networks.key.0/null": "reject",
+            "networks.key.0/wrong-type": "reject",
+            "networks.key/drop": "accept",
+            "networks.key/null": "reject",
+            "networks.key/wrong-type": "reject",
+            "networks/drop": "reject",
+            "networks/null": "reject",
+            "networks/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "notify_list",
+            "networks": {
+              "key": [
+                {
+                  "added_at": "sample",
+                  "network_id": 1,
+                  "nick": "sample",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "arm": "own_nick_changed",
+          "matrix": {
+            "network_id/drop": "reject",
+            "network_id/null": "reject",
+            "network_id/wrong-type": "reject",
+            "nick/drop": "reject",
+            "nick/null": "reject",
+            "nick/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "own_nick_changed",
+            "network_id": 1,
+            "nick": "sample",
+          },
+        },
+        {
+          "arm": "peer_away",
+          "matrix": {
+            "message/drop": "reject",
+            "message/null": "reject",
+            "message/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "peer/drop": "reject",
+            "peer/null": "reject",
+            "peer/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "peer_away",
+            "message": "sample",
+            "network": "sample",
+            "peer": "sample",
           },
         },
         {
@@ -601,6 +1057,131 @@ describe("#1393 — user-topic boundary census", () => {
           },
         },
         {
+          "arm": "presence_snapshot",
+          "matrix": {
+            "network_id/drop": "reject",
+            "network_id/null": "reject",
+            "network_id/wrong-type": "reject",
+            "nicks.key/drop": "accept",
+            "nicks.key/null": "reject",
+            "nicks.key/wrong-type": "reject",
+            "nicks/drop": "reject",
+            "nicks/null": "reject",
+            "nicks/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "presence_snapshot",
+            "network_id": 1,
+            "nicks": {
+              "key": "online",
+            },
+          },
+        },
+        {
+          "arm": "query_windows_list",
+          "matrix": {
+            "windows.key.0.network_id/drop": "reject",
+            "windows.key.0.network_id/null": "reject",
+            "windows.key.0.network_id/wrong-type": "reject",
+            "windows.key.0.opened_at/drop": "reject",
+            "windows.key.0.opened_at/null": "reject",
+            "windows.key.0.opened_at/wrong-type": "reject",
+            "windows.key.0.target_nick/drop": "reject",
+            "windows.key.0.target_nick/null": "reject",
+            "windows.key.0.target_nick/wrong-type": "reject",
+            "windows.key.0/drop": "accept",
+            "windows.key.0/null": "reject",
+            "windows.key.0/wrong-type": "reject",
+            "windows.key/drop": "accept",
+            "windows.key/null": "reject",
+            "windows.key/wrong-type": "reject",
+            "windows/drop": "reject",
+            "windows/null": "reject",
+            "windows/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "query_windows_list",
+            "windows": {
+              "key": [
+                {
+                  "network_id": 1,
+                  "opened_at": "sample",
+                  "target_nick": "sample",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "arm": "recover_progress",
+          "matrix": {
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "reason/drop": "reject",
+            "reason/null": "accept",
+            "reason/wrong-type": "reject",
+            "status/drop": "reject",
+            "status/null": "reject",
+            "status/wrong-type": "reject",
+            "step/drop": "reject",
+            "step/null": "reject",
+            "step/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "recover_progress",
+            "network": "sample",
+            "reason": "wrong_password",
+            "status": "running",
+            "step": "identify",
+          },
+        },
+        {
+          "arm": "recover_result",
+          "matrix": {
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "outcome/drop": "reject",
+            "outcome/null": "reject",
+            "outcome/wrong-type": "reject",
+            "reason/drop": "reject",
+            "reason/null": "accept",
+            "reason/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "recover_result",
+            "network": "sample",
+            "outcome": "succeeded",
+            "reason": "wrong_password",
+          },
+        },
+        {
+          "arm": "server_reply",
+          "matrix": {
+            "lines.0/drop": "accept",
+            "lines.0/null": "reject",
+            "lines.0/wrong-type": "reject",
+            "lines/drop": "reject",
+            "lines/null": "reject",
+            "lines/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "source/drop": "reject",
+            "source/null": "reject",
+            "source/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "server_reply",
+            "lines": [
+              "sample",
+            ],
+            "network": "sample",
+            "source": "info",
+          },
+        },
+        {
           "arm": "session_identity_changed",
           "matrix": {
             "account/drop": "reject",
@@ -621,8 +1202,32 @@ describe("#1393 — user-topic boundary census", () => {
           },
         },
         {
+          "arm": "supported_umodes_changed",
+          "matrix": {
+            "modes.0/drop": "accept",
+            "modes.0/null": "reject",
+            "modes.0/wrong-type": "reject",
+            "modes/drop": "reject",
+            "modes/null": "reject",
+            "modes/wrong-type": "reject",
+            "network_id/drop": "reject",
+            "network_id/null": "reject",
+            "network_id/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "supported_umodes_changed",
+            "modes": [
+              "sample",
+            ],
+            "network_id": 1,
+          },
+        },
+        {
           "arm": "umode_changed",
           "matrix": {
+            "modes.0/drop": "accept",
+            "modes.0/null": "reject",
+            "modes.0/wrong-type": "reject",
             "modes/drop": "reject",
             "modes/null": "reject",
             "modes/wrong-type": "reject",
@@ -636,6 +1241,152 @@ describe("#1393 — user-topic boundary census", () => {
               "sample",
             ],
             "network_id": 1,
+          },
+        },
+        {
+          "arm": "web_session_severed",
+          "matrix": {
+            "code/drop": "reject",
+            "code/null": "reject",
+            "code/wrong-type": "reject",
+          },
+          "returns": {
+            "code": "rate_limit_flood",
+            "kind": "web_session_severed",
+          },
+        },
+        {
+          "arm": "who_reply",
+          "matrix": {
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "target/drop": "reject",
+            "target/null": "reject",
+            "target/wrong-type": "reject",
+            "users.0.channel/drop": "reject",
+            "users.0.channel/null": "reject",
+            "users.0.channel/wrong-type": "reject",
+            "users.0.hops/drop": "reject",
+            "users.0.hops/null": "accept",
+            "users.0.hops/wrong-type": "reject",
+            "users.0.host/drop": "reject",
+            "users.0.host/null": "reject",
+            "users.0.host/wrong-type": "reject",
+            "users.0.modes/drop": "reject",
+            "users.0.modes/null": "reject",
+            "users.0.modes/wrong-type": "reject",
+            "users.0.nick/drop": "reject",
+            "users.0.nick/null": "reject",
+            "users.0.nick/wrong-type": "reject",
+            "users.0.realname/drop": "reject",
+            "users.0.realname/null": "accept",
+            "users.0.realname/wrong-type": "reject",
+            "users.0.server/drop": "reject",
+            "users.0.server/null": "reject",
+            "users.0.server/wrong-type": "reject",
+            "users.0.user/drop": "reject",
+            "users.0.user/null": "reject",
+            "users.0.user/wrong-type": "reject",
+            "users.0/drop": "accept",
+            "users.0/null": "reject",
+            "users.0/wrong-type": "reject",
+            "users/drop": "reject",
+            "users/null": "reject",
+            "users/wrong-type": "reject",
+          },
+          "returns": {
+            "kind": "who_reply",
+            "network": "sample",
+            "target": "sample",
+            "users": [
+              {
+                "channel": "sample",
+                "hops": 1,
+                "host": "sample",
+                "modes": "sample",
+                "nick": "sample",
+                "realname": "sample",
+                "server": "sample",
+                "user": "sample",
+              },
+            ],
+          },
+        },
+        {
+          "arm": "whowas_bundle",
+          "matrix": {
+            "host/drop": "reject",
+            "host/null": "accept",
+            "host/wrong-type": "reject",
+            "logoff_time/drop": "reject",
+            "logoff_time/null": "accept",
+            "logoff_time/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "not_found/drop": "reject",
+            "not_found/null": "reject",
+            "not_found/wrong-type": "reject",
+            "realname/drop": "reject",
+            "realname/null": "accept",
+            "realname/wrong-type": "reject",
+            "server/drop": "reject",
+            "server/null": "accept",
+            "server/wrong-type": "reject",
+            "target/drop": "reject",
+            "target/null": "reject",
+            "target/wrong-type": "reject",
+            "user/drop": "reject",
+            "user/null": "accept",
+            "user/wrong-type": "reject",
+          },
+          "returns": {
+            "host": "sample",
+            "kind": "whowas_bundle",
+            "logoff_time": "sample",
+            "network": "sample",
+            "not_found": true,
+            "realname": "sample",
+            "server": "sample",
+            "target": "sample",
+            "user": "sample",
+          },
+        },
+        {
+          "arm": "window_invite_declined",
+          "matrix": {
+            "channel/drop": "reject",
+            "channel/null": "reject",
+            "channel/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+          },
+          "returns": {
+            "channel": "sample",
+            "kind": "window_invite_declined",
+            "network": "sample",
+          },
+        },
+        {
+          "arm": "window_pending",
+          "matrix": {
+            "channel/drop": "reject",
+            "channel/null": "reject",
+            "channel/wrong-type": "reject",
+            "network/drop": "reject",
+            "network/null": "reject",
+            "network/wrong-type": "reject",
+            "state/drop": "reject",
+            "state/null": "reject",
+            "state/wrong-type": "reject",
+          },
+          "returns": {
+            "channel": "sample",
+            "kind": "window_pending",
+            "network": "sample",
+            "state": "pending",
           },
         },
       ]

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -769,6 +769,13 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // sets, narrowed strictly (an unknown value drops this ONE presentational
       // ping, not the terminal result). `reason` is a nullable string (cic
       // localizes it in RecoverModal).
+      //
+      // #1393 — and that last sentence is why this arm does NOT move onto
+      // `S_SessionWireRecoverProgressPayload`. The typespec CLOSES `reason`
+      // over four tokens; this boundary takes any string, deliberately, so a
+      // BEAM that adds a fifth cannot make an older cic drop the ping
+      // (unknown-is-never-fatal, #447). The census only sees that once its
+      // matrix swaps a VALUE instead of a type — `reason/swap`.
       if (
         typeof r.network !== "string" ||
         (r.step !== "identify" &&
@@ -792,6 +799,10 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // stays a nullable string (NOT hardened to the known token union) so an
       // additive server reason token can never drop a terminal result event
       // (unknown-is-never-fatal, #447); RecoverModal localizes the known tokens.
+      //
+      // #1393 — so this arm stays hand-written for the same reason as
+      // `recover_progress` above, and here the stakes are a TERMINAL event
+      // rather than a presentational ping.
       if (
         typeof r.network !== "string" ||
         (r.outcome !== "succeeded" && r.outcome !== "failed") ||
@@ -813,6 +824,11 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // on a dead shell holding a revoked bearer. The value is carried
       // verbatim — it selects copy, nothing else. A missing or non-string
       // `code` is malformed rather than additive, and still drops.
+      //
+      // #1393 — `S_RateLimitWireWebSessionSeveredEvent` pins `code` to the
+      // single literal `rate_limit_flood`, so validating against it would
+      // undo #1338 exactly. The arm stays hand-written; `code/swap` in the
+      // census is the row that says so.
       if (typeof r.code !== "string") return null;
       return { kind: "web_session_severed", code: r.code };
     default:

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -73,19 +73,40 @@ import {
   narrowWhoUsers,
   narrowWindowStateEvent,
 } from "./wireNarrow";
-// #1393 slice 1 — the arms below narrow through their GENERATED schema
-// instead of a hand-written field walk. Both are already emitted; the hand
-// copy was the duplicate. Which arms may move is not a judgement call:
-// `wireUserBoundary.test.ts` measured hand and schema to accept and reject
-// the same inputs AND to return the same object, arm by arm, and only arms
-// at parity on both axes are here. The eight measured divergent stay hand-
-// written until each is ruled on individually.
+// #1393 — the arms below narrow through their GENERATED schema instead of a
+// hand-written field walk. Both are already emitted; the hand copy was the
+// duplicate. Which arms may move is not a judgement call:
+// `wireUserBoundary.test.ts` measures hand and schema against the same
+// mutation matrix — drop, null, wrong-type AND a value the schema does not
+// declare — and against the object each one RETURNS, arm by arm. Only arms
+// at parity on both axes are here.
+//
+// Every arm still narrowed by hand below is one the measurement separated,
+// and each carries at its `case` the tolerance the typespec does not: an
+// additive field the server may omit, a token set the wire contract forbids
+// us to close (#447), a per-field degrade that beats dropping the payload.
+// Do not migrate one of those without re-measuring it first.
 import {
+  S_ScrollbackWireArchiveChangedPayload,
+  S_ScrollbackWireArchivePurgedPayload,
   S_SessionWireAwayConfirmedPayload,
+  S_SessionWireChannelsChangedPayload,
+  S_SessionWireConnectionProgressPayload,
+  S_SessionWireDirectoryCompletePayload,
+  S_SessionWireDirectoryFailedPayload,
+  S_SessionWireDirectoryProgressPayload,
+  S_SessionWireInviteAckPayload,
+  S_SessionWireOwnNickChangedPayload,
+  S_SessionWirePeerAwayPayload,
   S_SessionWirePresenceChangedPayload,
   S_SessionWirePresenceErrorPayload,
   S_SessionWireSessionIdentityChangedPayload,
+  S_SessionWireSupportedUmodesChangedPayload,
   S_SessionWireUmodeChangedPayload,
+  S_SessionWireWhowasBundlePayload,
+  S_SessionWireWindowInviteDeclinedPayload,
+  S_SessionWireWindowPendingPayload,
+  S_UserSettingsWireAutoAwayDebounceChangedPayload,
 } from "./wireSchema";
 import type { ServerSettingsWireUploadView, SessionWireServerReplySource } from "./wireTypes";
 // #410 — the connection_state runtime guard derives from the generated const
@@ -386,7 +407,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
   if (typeof r.kind !== "string") return null;
   switch (r.kind) {
     case "channels_changed":
-      return { kind: "channels_changed" };
+      return validate(S_SessionWireChannelsChangedPayload, r);
     case "query_windows_list": {
       // S43 — validate each entry instead of a bare cast.
       const windows = narrowWindowsMap(r.windows);
@@ -415,12 +436,10 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
     case "away_confirmed":
       return validate(S_SessionWireAwayConfirmedPayload, r);
     case "connection_progress":
-      // #100 — transient reconnect badge signal. Closed state set enforced
-      // at the boundary (mirrors away_confirmed) so a malformed value can't
-      // corrupt the reconnectingByNetwork store.
-      if (typeof r.network !== "string" || (r.state !== "connecting" && r.state !== "connected"))
-        return null;
-      return { kind: "connection_progress", network: r.network, state: r.state };
+      // #100 — transient reconnect badge signal. The closed state set is the
+      // schema's own `{e: [...]}`, so a malformed value still cannot corrupt
+      // the reconnectingByNetwork store.
+      return validate(S_SessionWireConnectionProgressPayload, r);
     case "notify_list": {
       // #247 — validate each entry, same strictness as query_windows_list.
       const networks = narrowNotifyMap(r.networks);
@@ -438,8 +457,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       return { kind: "presence_snapshot", network_id: r.network_id, nicks };
     }
     case "own_nick_changed":
-      if (typeof r.network_id !== "number" || typeof r.nick !== "string") return null;
-      return { kind: "own_nick_changed", network_id: r.network_id, nick: r.nick };
+      return validate(S_SessionWireOwnNickChangedPayload, r);
     case "umode_changed":
       // #229 — per-session umode set. `modes` is a string[] (sorted umode
       // letters, sign stripped); any non-string element drops the whole
@@ -449,19 +467,11 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // #388 — the NORMALIZED services-identity verdict. `account` is
       // nullable and display-only; `identified` is the verdict.
       return validate(S_SessionWireSessionIdentityChangedPayload, r);
-    case "supported_umodes_changed": {
-      // #249 — per-session SUPPORTED umode set. User-topic-only, narrowed
-      // inline here (mirror of umode_changed). `modes` must be a string[]
-      // (sorted advertised umode letters); any non-string element drops the
-      // whole payload.
-      if (typeof r.network_id !== "number" || !Array.isArray(r.modes)) return null;
-      if (!r.modes.every((m) => typeof m === "string")) return null;
-      return {
-        kind: "supported_umodes_changed",
-        network_id: r.network_id,
-        modes: r.modes as string[],
-      };
-    }
+    case "supported_umodes_changed":
+      // #249 — per-session SUPPORTED umode set (mirror of umode_changed).
+      // `modes` is the sorted advertised umode letters, and the schema's
+      // `{a: "s"}` already drops the whole payload on a non-string element.
+      return validate(S_SessionWireSupportedUmodesChangedPayload, r);
     case "isupport_changed":
       // #216 — dual-topic event: this is the LIVE 005 edge on the user
       // topic (the per-channel cold-snapshot goes through the identical
@@ -469,14 +479,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // flat CHANMODES/PREFIX shape is validated in exactly one place.
       return narrowIsupportChanged(r);
     case "window_pending":
-      if (typeof r.network !== "string" || typeof r.channel !== "string" || r.state !== "pending")
-        return null;
-      return {
-        kind: "window_pending",
-        network: r.network,
-        channel: r.channel,
-        state: "pending",
-      };
+      return validate(S_SessionWireWindowPendingPayload, r);
     case "window_invited":
       if (typeof r.network !== "string" || typeof r.channel !== "string" || r.state !== "invited")
         return null;
@@ -494,16 +497,11 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         inviter: typeof r.inviter === "string" && r.inviter !== "" ? r.inviter : "*",
       };
     case "window_invite_declined":
-      // #976 — no `state` to validate: a declined invite lands in no window
-      // state, so the payload carries none (see the server's
+      // #976 — no `state` in the schema either: a declined invite lands in no
+      // window state, so the payload carries none (see the server's
       // `window_invite_declined_payload`). Network + channel are the whole
       // contract; a payload missing either names no window and is dropped.
-      if (typeof r.network !== "string" || typeof r.channel !== "string") return null;
-      return {
-        kind: "window_invite_declined",
-        network: r.network,
-        channel: r.channel,
-      };
+      return validate(S_SessionWireWindowInviteDeclinedPayload, r);
     case "connection_state_changed": {
       // REV-J M15: pre-fix this arm carried only the wider transition
       // fields and HomePane patched its row from a separate
@@ -704,18 +702,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // (network, channel, peer); cic appends a synthetic row to the
       // per-network store keyed on target channel and renders inline
       // in the $server window scrollback.
-      if (
-        typeof r.network !== "string" ||
-        typeof r.channel !== "string" ||
-        typeof r.peer !== "string"
-      )
-        return null;
-      return {
-        kind: "invite_ack",
-        network: r.network,
-        channel: r.channel,
-        peer: r.peer,
-      };
+      return validate(S_SessionWireInviteAckPayload, r);
     case "bundle_hash": {
       if (typeof r.hash !== "string" || r.hash === "") return null;
       // #292 — version is optional on the wire (omitted when the deployed
@@ -779,13 +766,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // P-0b — standalone 301 RPL_AWAY. cic dm-listener routes by
       // `peer:` field; banner renders inline at the top of the
       // peer's DM scrollback when that window is selected.
-      if (
-        typeof r.network !== "string" ||
-        typeof r.peer !== "string" ||
-        typeof r.message !== "string"
-      )
-        return null;
-      return { kind: "peer_away", network: r.network, peer: r.peer, message: r.message };
+      return validate(S_SessionWirePeerAwayPayload, r);
     case "lusers_bundle": {
       // P-0d — LUSERS bundle. All counts are integer-or-null (253
       // RPL_LUSERUNKNOWN is optional; defensive nullability covers
@@ -820,28 +801,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // P-0c — WHOWAS bundle. `not_found` discriminates the 406 case;
       // when true, historical fields are nil. cic owns the rendering
       // (single card per network, last-write-wins per /whowas).
-      if (
-        typeof r.network !== "string" ||
-        typeof r.target !== "string" ||
-        typeof r.not_found !== "boolean" ||
-        (r.user !== null && typeof r.user !== "string") ||
-        (r.host !== null && typeof r.host !== "string") ||
-        (r.realname !== null && typeof r.realname !== "string") ||
-        (r.server !== null && typeof r.server !== "string") ||
-        (r.logoff_time !== null && typeof r.logoff_time !== "string")
-      )
-        return null;
-      return {
-        kind: "whowas_bundle",
-        network: r.network,
-        target: r.target,
-        user: r.user as string | null,
-        host: r.host as string | null,
-        realname: r.realname as string | null,
-        server: r.server as string | null,
-        logoff_time: r.logoff_time as string | null,
-        not_found: r.not_found,
-      };
+      return validate(S_SessionWireWhowasBundlePayload, r);
     case "banlist_bundle": {
       // #376/#1251 — channel LIST-MODE bundle. All entries ship (a list mode
       // is a set of rows). cic owns the rendering (single card per network,
@@ -912,16 +872,10 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // → "reuses the verb, not the noun").
       return narrowWindowStateEvent(r);
     case "auto_away_debounce_changed":
-      // #348 — the auto-away preference moved. `null` (no preference)
-      // is a MEANINGFUL value here, not a missing field, so the
-      // narrower admits it explicitly and rejects anything that is
-      // neither null nor a number.
-      if (r.auto_away_debounce_seconds !== null && typeof r.auto_away_debounce_seconds !== "number")
-        return null;
-      return {
-        kind: "auto_away_debounce_changed",
-        auto_away_debounce_seconds: r.auto_away_debounce_seconds,
-      };
+      // #348 — the auto-away preference moved. `null` (no preference) is a
+      // MEANINGFUL value here, not a missing field, and the typespec says so:
+      // `{u: ["i", "z"]}` admits it and rejects anything that is neither.
+      return validate(S_UserSettingsWireAutoAwayDebounceChangedPayload, r);
     case "archive_changed":
       // UX-1 (2026-05-17) — server broadcasts after a successful PART
       // (channel moves into archive list). Single-field envelope: cic
@@ -930,8 +884,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // reconnect replay). For the DESTRUCTIVE
       // `DELETE /networks/:slug/archive/:target` path the server now
       // broadcasts `archive_purged` instead — see below (UX-7-B).
-      if (typeof r.network_slug !== "string") return null;
-      return { kind: "archive_changed", network_slug: r.network_slug };
+      return validate(S_ScrollbackWireArchiveChangedPayload, r);
     case "archive_purged":
       // UX-7-B (2026-05-22) — server broadcasts after a successful
       // DELETE /networks/:slug/archive/:target. Two fields: the slug
@@ -940,17 +893,13 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // target)]` so the pre-delete rows don't ghost in the live Solid
       // store on re-JOIN — refreshScrollback's `?after=cursor` fetch
       // is past every deleted row, masking the gap without the purge).
-      if (typeof r.network_slug !== "string" || typeof r.target !== "string") return null;
-      return { kind: "archive_purged", network_slug: r.network_slug, target: r.target };
+      return validate(S_ScrollbackWireArchivePurgedPayload, r);
     case "directory_progress":
-      if (typeof r.network !== "string" || typeof r.count !== "number") return null;
-      return { kind: "directory_progress", network: r.network, count: r.count };
+      return validate(S_SessionWireDirectoryProgressPayload, r);
     case "directory_complete":
-      if (typeof r.network !== "string" || typeof r.total !== "number") return null;
-      return { kind: "directory_complete", network: r.network, total: r.total };
+      return validate(S_SessionWireDirectoryCompletePayload, r);
     case "directory_failed":
-      if (typeof r.network !== "string" || typeof r.reason !== "string") return null;
-      return { kind: "directory_failed", network: r.network, reason: r.reason };
+      return validate(S_SessionWireDirectoryFailedPayload, r);
     case "recover_progress":
       // #581 — one recovery-step transition. `step` + `status` are closed
       // sets, narrowed strictly (an unknown value drops this ONE presentational

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -73,6 +73,20 @@ import {
   narrowWhoUsers,
   narrowWindowStateEvent,
 } from "./wireNarrow";
+// #1393 slice 1 — the arms below narrow through their GENERATED schema
+// instead of a hand-written field walk. Both are already emitted; the hand
+// copy was the duplicate. Which arms may move is not a judgement call:
+// `wireUserBoundary.test.ts` measured hand and schema to accept and reject
+// the same inputs AND to return the same object, arm by arm, and only arms
+// at parity on both axes are here. The eight measured divergent stay hand-
+// written until each is ruled on individually.
+import {
+  S_SessionWireAwayConfirmedPayload,
+  S_SessionWirePresenceChangedPayload,
+  S_SessionWirePresenceErrorPayload,
+  S_SessionWireSessionIdentityChangedPayload,
+  S_SessionWireUmodeChangedPayload,
+} from "./wireSchema";
 import type { ServerSettingsWireUploadView, SessionWireServerReplySource } from "./wireTypes";
 // #410 — the connection_state runtime guard derives from the generated const
 // (mirror of `Grappa.Networks.Credential.connection_state/0`), single-sourced
@@ -82,6 +96,7 @@ import {
   NETWORKS_CREDENTIAL_CONNECTION_STATE,
   SESSION_WIRE_SERVER_REPLY_SOURCE,
 } from "./wireTypes";
+import { validate } from "./wireValidate";
 
 // Per-user PubSub topic subscriber. Module-singleton side-effect:
 // imports for effect, exports nothing public. `main.tsx` imports this
@@ -398,9 +413,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       };
     }
     case "away_confirmed":
-      if (typeof r.network !== "string" || (r.state !== "present" && r.state !== "away"))
-        return null;
-      return { kind: "away_confirmed", network: r.network, state: r.state };
+      return validate(S_SessionWireAwayConfirmedPayload, r);
     case "connection_progress":
       // #100 — transient reconnect badge signal. Closed state set enforced
       // at the boundary (mirrors away_confirmed) so a malformed value can't
@@ -415,37 +428,9 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       return { kind: "notify_list", networks };
     }
     case "presence_changed":
-      if (
-        typeof r.network_id !== "number" ||
-        typeof r.nick !== "string" ||
-        (r.presence !== "online" && r.presence !== "offline") ||
-        typeof r.initial !== "boolean" ||
-        (r.source !== "monitor" && r.source !== "watch") ||
-        typeof r.ts !== "string"
-      )
-        return null;
-      return {
-        kind: "presence_changed",
-        network_id: r.network_id,
-        nick: r.nick,
-        presence: r.presence,
-        initial: r.initial,
-        source: r.source,
-        ts: r.ts,
-      };
+      return validate(S_SessionWirePresenceChangedPayload, r);
     case "presence_error":
-      if (
-        typeof r.network_id !== "number" ||
-        r.reason !== "list_full" ||
-        typeof r.detail !== "string"
-      )
-        return null;
-      return {
-        kind: "presence_error",
-        network_id: r.network_id,
-        reason: r.reason,
-        detail: r.detail,
-      };
+      return validate(S_SessionWirePresenceErrorPayload, r);
     case "presence_snapshot": {
       if (typeof r.network_id !== "number") return null;
       const nicks = narrowPresenceMap(r.nicks);
@@ -455,28 +440,15 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
     case "own_nick_changed":
       if (typeof r.network_id !== "number" || typeof r.nick !== "string") return null;
       return { kind: "own_nick_changed", network_id: r.network_id, nick: r.nick };
-    case "umode_changed": {
-      // #229 — per-session umode set. User-topic-only (unlike isupport's
-      // dual-topic snapshot), so narrowed inline here. `modes` must be a
-      // string[] (sorted umode letters, sign stripped); any non-string
-      // element drops the whole payload.
-      if (typeof r.network_id !== "number" || !Array.isArray(r.modes)) return null;
-      if (!r.modes.every((m) => typeof m === "string")) return null;
-      return { kind: "umode_changed", network_id: r.network_id, modes: r.modes as string[] };
-    }
-    case "session_identity_changed": {
-      // #388 — the NORMALIZED services-identity verdict. User-topic-only, so
-      // narrowed inline here (mirror of umode_changed). `account` is
-      // nullable and is display data only — `identified` is the verdict.
-      if (typeof r.network_id !== "number" || typeof r.identified !== "boolean") return null;
-      if (r.account !== null && typeof r.account !== "string") return null;
-      return {
-        kind: "session_identity_changed",
-        network_id: r.network_id,
-        identified: r.identified,
-        account: r.account,
-      };
-    }
+    case "umode_changed":
+      // #229 — per-session umode set. `modes` is a string[] (sorted umode
+      // letters, sign stripped); any non-string element drops the whole
+      // payload, which is what the schema's `{a: "s"}` already says.
+      return validate(S_SessionWireUmodeChangedPayload, r);
+    case "session_identity_changed":
+      // #388 — the NORMALIZED services-identity verdict. `account` is
+      // nullable and display-only; `identified` is the verdict.
+      return validate(S_SessionWireSessionIdentityChangedPayload, r);
     case "supported_umodes_changed": {
       // #249 — per-session SUPPORTED umode set. User-topic-only, narrowed
       // inline here (mirror of umode_changed). `modes` must be a string[]

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -6,8 +6,6 @@ import {
   type BanlistEntry,
   type ConnectionState,
   type LinksEntry,
-  type MentionsBundleMessage,
-  type NotifyEntry,
   type QueryWindowEntry,
   type WhoisExtraLine,
   type WireUserEvent,
@@ -67,7 +65,6 @@ import {
   setPending,
 } from "./windowState";
 import {
-  isMessageKind,
   narrowIsupportChanged,
   narrowMembers,
   narrowWhoUsers,
@@ -87,6 +84,8 @@ import {
 // us to close (#447), a per-field degrade that beats dropping the payload.
 // Do not migrate one of those without re-measuring it first.
 import {
+  S_NotifyWireNotifyListPayload,
+  S_QueryWindowsWireWindowsListPayload,
   S_ScrollbackWireArchiveChangedPayload,
   S_ScrollbackWireArchivePurgedPayload,
   S_SessionWireAwayConfirmedPayload,
@@ -96,10 +95,12 @@ import {
   S_SessionWireDirectoryFailedPayload,
   S_SessionWireDirectoryProgressPayload,
   S_SessionWireInviteAckPayload,
+  S_SessionWireMentionsBundlePayload,
   S_SessionWireOwnNickChangedPayload,
   S_SessionWirePeerAwayPayload,
   S_SessionWirePresenceChangedPayload,
   S_SessionWirePresenceErrorPayload,
+  S_SessionWirePresenceSnapshotPayload,
   S_SessionWireSessionIdentityChangedPayload,
   S_SessionWireSupportedUmodesChangedPayload,
   S_SessionWireUmodeChangedPayload,
@@ -213,29 +214,9 @@ function isUploadActiveHost(v: unknown): v is UploadActiveHost {
 // element (server bug, proxy mangling, partial response) would slip
 // through the boundary and crash a downstream renderer that read a
 // missing field. Now each element is narrowed against its wire
-// shape; any failure drops the whole bundle (loud, log-once).
-
-function narrowMentionsBundleMessage(raw: unknown): MentionsBundleMessage | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const r = raw as Record<string, unknown>;
-  if (
-    typeof r.server_time !== "number" ||
-    typeof r.channel !== "string" ||
-    typeof r.sender !== "string" ||
-    (r.body !== null && typeof r.body !== "string") ||
-    // S14 — gate `kind` against the shared `Message.kind()` closed set
-    // (same as `narrowScrollbackMessage`), not a bare `typeof string`.
-    !isMessageKind(r.kind)
-  )
-    return null;
-  return {
-    server_time: r.server_time,
-    channel: r.channel,
-    sender: r.sender,
-    body: r.body as string | null,
-    kind: r.kind,
-  };
-}
+// shape; any failure drops the whole bundle (loud, log-once). The
+// ones below survive because their arm is still hand-narrowed; the
+// rest went with theirs (#1393).
 
 // `whois_bundle.channels` is `string[] | null`. Wire elements arrive
 // as IRC mode-prefixed channel names (`@#italia`, `+#grappa`). Reject
@@ -300,28 +281,6 @@ function narrowLinksEntry(raw: unknown): LinksEntry | null {
   };
 }
 
-// S43 — per-entry narrower for `query_windows_list`. Mirror of
-// `Grappa.QueryWindows.Wire.windows_entry/0` (pinned to the generated
-// `QueryWindowsWireWindowsEntry` by `_Assert_QueryWindowEntry`).
-// Replaces the pre-S43 bare `as Record<string, QueryWindowEntry[]>`
-// cast that admitted any shape — closing the "narrow every WS payload"
-// gap for this arm.
-function narrowQueryWindowEntry(raw: unknown): QueryWindowEntry | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const r = raw as Record<string, unknown>;
-  if (
-    typeof r.network_id !== "number" ||
-    typeof r.target_nick !== "string" ||
-    typeof r.opened_at !== "string"
-  )
-    return null;
-  return {
-    network_id: r.network_id,
-    target_nick: r.target_nick,
-    opened_at: r.opened_at,
-  };
-}
-
 // Maps a per-element narrower across an array; returns the array of
 // narrowed values or null if any element fails. Strict — partial
 // bundles are server bugs, not graceful-degradation cases.
@@ -332,62 +291,6 @@ function narrowArray<T>(raw: unknown, narrow: (el: unknown) => T | null): T[] | 
     const n = narrow(el);
     if (n === null) return null;
     out.push(n);
-  }
-  return out;
-}
-
-// S43 — narrows the `query_windows_list` `windows` map: a
-// network-id-keyed object whose values are arrays of query-window
-// entries. Every entry is validated (`narrowQueryWindowEntry`); a
-// single malformed entry drops the whole map (strict, matching the
-// bundle narrowers). Returns null on a non-object or any bad entry.
-function narrowWindowsMap(raw: unknown): Record<string, QueryWindowEntry[]> | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const out: Record<string, QueryWindowEntry[]> = {};
-  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
-    const entries = narrowArray(val, narrowQueryWindowEntry);
-    if (entries === null) return null;
-    out[key] = entries;
-  }
-  return out;
-}
-
-// #247 — per-entry narrower for `notify_list`. Mirror of
-// `Grappa.Notify.Wire.entry/0` (pinned to the generated
-// `NotifyWireEntry` by `_Assert_NotifyEntry`).
-function narrowNotifyEntry(raw: unknown): NotifyEntry | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const r = raw as Record<string, unknown>;
-  if (
-    typeof r.network_id !== "number" ||
-    typeof r.nick !== "string" ||
-    typeof r.added_at !== "string"
-  )
-    return null;
-  return { network_id: r.network_id, nick: r.nick, added_at: r.added_at };
-}
-
-// #247 — narrows the `notify_list` `networks` map (network-id-keyed
-// object of entry arrays; strict like narrowWindowsMap).
-function narrowNotifyMap(raw: unknown): Record<string, NotifyEntry[]> | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const out: Record<string, NotifyEntry[]> = {};
-  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
-    const entries = narrowArray(val, narrowNotifyEntry);
-    if (entries === null) return null;
-    out[key] = entries;
-  }
-  return out;
-}
-
-// #247 — narrows the `presence_snapshot` folded-nick → state map. A
-// value outside the closed presence set drops the whole map (strict).
-function narrowPresenceMap(raw: unknown): Record<string, "online" | "offline" | "unknown"> | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const out: Record<string, "online" | "offline" | "unknown"> = {};
-  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
-    if (val !== "online" && val !== "offline" && val !== "unknown") return null;
-    out[key] = val;
   }
   return out;
 }
@@ -408,31 +311,17 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
   switch (r.kind) {
     case "channels_changed":
       return validate(S_SessionWireChannelsChangedPayload, r);
-    case "query_windows_list": {
-      // S43 — validate each entry instead of a bare cast.
-      const windows = narrowWindowsMap(r.windows);
-      if (windows === null) return null;
-      return { kind: "query_windows_list", windows };
-    }
-    case "mentions_bundle": {
-      if (
-        typeof r.network !== "string" ||
-        typeof r.away_started_at !== "string" ||
-        typeof r.away_ended_at !== "string" ||
-        (r.away_reason !== null && typeof r.away_reason !== "string")
-      )
-        return null;
-      const messages = narrowArray(r.messages, narrowMentionsBundleMessage);
-      if (messages === null) return null;
-      return {
-        kind: "mentions_bundle",
-        network: r.network,
-        away_started_at: r.away_started_at,
-        away_ended_at: r.away_ended_at,
-        away_reason: r.away_reason as string | null,
-        messages,
-      };
-    }
+    case "query_windows_list":
+      // S43 — every entry is validated, not a bare cast: the schema's
+      // `{r: {a: …}}` rejects the whole map on one malformed entry.
+      return validate(S_QueryWindowsWireWindowsListPayload, r);
+    case "mentions_bundle":
+      // no-silent-drops B6.10 HIGH-11 — the `messages` elements are narrowed
+      // one by one and a malformed element drops the whole bundle, which is
+      // what the schema's `{a: <message>}` says; `kind` inside a message is
+      // gated on the shared `Message.kind()` closed set the same way, now via
+      // the generated `S_ScrollbackMessageKind` rather than a second copy.
+      return validate(S_SessionWireMentionsBundlePayload, r);
     case "away_confirmed":
       return validate(S_SessionWireAwayConfirmedPayload, r);
     case "connection_progress":
@@ -440,22 +329,17 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       // schema's own `{e: [...]}`, so a malformed value still cannot corrupt
       // the reconnectingByNetwork store.
       return validate(S_SessionWireConnectionProgressPayload, r);
-    case "notify_list": {
-      // #247 — validate each entry, same strictness as query_windows_list.
-      const networks = narrowNotifyMap(r.networks);
-      if (networks === null) return null;
-      return { kind: "notify_list", networks };
-    }
+    case "notify_list":
+      // #247 — every entry validated, same strictness as query_windows_list.
+      return validate(S_NotifyWireNotifyListPayload, r);
     case "presence_changed":
       return validate(S_SessionWirePresenceChangedPayload, r);
     case "presence_error":
       return validate(S_SessionWirePresenceErrorPayload, r);
-    case "presence_snapshot": {
-      if (typeof r.network_id !== "number") return null;
-      const nicks = narrowPresenceMap(r.nicks);
-      if (nicks === null) return null;
-      return { kind: "presence_snapshot", network_id: r.network_id, nicks };
-    }
+    case "presence_snapshot":
+      // #247 — a value outside the closed presence set drops the whole map,
+      // which is the schema's `{r: {e: [...]}}`.
+      return validate(S_SessionWirePresenceSnapshotPayload, r);
     case "own_nick_changed":
       return validate(S_SessionWireOwnNickChangedPayload, r);
     case "umode_changed":

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -64,12 +64,7 @@ import {
   setKicked,
   setPending,
 } from "./windowState";
-import {
-  narrowIsupportChanged,
-  narrowMembers,
-  narrowWhoUsers,
-  narrowWindowStateEvent,
-} from "./wireNarrow";
+import { narrowIsupportChanged, narrowWindowStateEvent } from "./wireNarrow";
 // #1393 — the arms below narrow through their GENERATED schema instead of a
 // hand-written field walk. Both are already emitted; the hand copy was the
 // duplicate. Which arms may move is not a judgement call:
@@ -96,28 +91,29 @@ import {
   S_SessionWireDirectoryProgressPayload,
   S_SessionWireInviteAckPayload,
   S_SessionWireMentionsBundlePayload,
+  S_SessionWireNamesReplyPayload,
   S_SessionWireOwnNickChangedPayload,
   S_SessionWirePeerAwayPayload,
   S_SessionWirePresenceChangedPayload,
   S_SessionWirePresenceErrorPayload,
   S_SessionWirePresenceSnapshotPayload,
+  S_SessionWireServerReplyPayload,
   S_SessionWireSessionIdentityChangedPayload,
   S_SessionWireSupportedUmodesChangedPayload,
   S_SessionWireUmodeChangedPayload,
+  S_SessionWireWhoReplyPayload,
   S_SessionWireWhowasBundlePayload,
   S_SessionWireWindowInviteDeclinedPayload,
   S_SessionWireWindowPendingPayload,
   S_UserSettingsWireAutoAwayDebounceChangedPayload,
 } from "./wireSchema";
-import type { ServerSettingsWireUploadView, SessionWireServerReplySource } from "./wireTypes";
+import type { ServerSettingsWireUploadView } from "./wireTypes";
 // #410 — the connection_state runtime guard derives from the generated const
 // (mirror of `Grappa.Networks.Credential.connection_state/0`), single-sourced
-// like the leaf-enum allowlists in wireNarrow.ts. #992 adds the server_reply
-// source set on the same footing.
-import {
-  NETWORKS_CREDENTIAL_CONNECTION_STATE,
-  SESSION_WIRE_SERVER_REPLY_SOURCE,
-} from "./wireTypes";
+// like the leaf-enum allowlists in wireNarrow.ts. #992's server_reply source
+// set was the second reader here until #1393 moved that arm onto its schema,
+// which reaches the same const through `S_SessionWireServerReplySource`.
+import { NETWORKS_CREDENTIAL_CONNECTION_STATE } from "./wireTypes";
 import { validate } from "./wireValidate";
 
 // Per-user PubSub topic subscriber. Module-singleton side-effect:
@@ -541,46 +537,30 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         extra_lines: extraLines,
       };
     }
-    case "names_reply": {
-      // #140 — /names roster bundle. Per-element narrowing on the
-      // members array (shared `narrowMembers` with the channel-topic
-      // members_seeded arm) — a malformed member element drops the whole
-      // payload rather than rendering a half-typed row.
-      if (typeof r.network !== "string" || typeof r.channel !== "string") return null;
-      const members = narrowMembers(r.members);
-      if (members === null) return null;
-      return { kind: "names_reply", network: r.network, channel: r.channel, members };
-    }
-    case "who_reply": {
-      // #169 — /who roster bundle. Per-element narrowing on the users array
-      // (`narrowWhoUsers`) — a malformed row drops the whole payload rather
-      // than rendering a half-typed table.
-      if (typeof r.network !== "string" || typeof r.target !== "string") return null;
-      const users = narrowWhoUsers(r.users);
-      if (users === null) return null;
-      return { kind: "who_reply", network: r.network, target: r.target, users };
-    }
-    case "server_reply": {
-      // #127/#992 — /info, /version, /motd, /admin reply bundle. Validate the
-      // typed `source` discriminant + the raw line array; a malformed payload
-      // drops rather than rendering a half-typed modal.
+    case "names_reply":
+      // #140 — /names roster bundle. A malformed member element drops the
+      // whole payload rather than rendering a half-typed row, which is the
+      // schema's `{a: <member>}`. `narrowMembers` stays in `wireNarrow.ts`:
+      // the per-channel `members_seeded` arm still calls it.
+      return validate(S_SessionWireNamesReplyPayload, r);
+    case "who_reply":
+      // #169 — /who roster bundle. A malformed row drops the whole payload
+      // rather than rendering a half-typed table. Unlike names_reply this
+      // arm was `narrowWhoUsers`'s ONLY caller, so the helper goes with it.
+      return validate(S_SessionWireWhoReplyPayload, r);
+    case "server_reply":
+      // #127/#992 — /info, /version, /motd, /admin reply bundle. A malformed
+      // payload drops rather than rendering a half-typed modal.
       //
-      // #992 — the discriminant is checked against the
-      // SESSION_WIRE_SERVER_REPLY_SOURCE SSOT, not a hand-written `!==`
-      // chain. The chain was a second, silent copy of the closed set: adding
-      // `admin` server-side left it rejecting a legitimate reply as "unknown
-      // source", so the modal never opened and the failure was invisible.
-      if (typeof r.network !== "string") return null;
-      if (!SESSION_WIRE_SERVER_REPLY_SOURCE.includes(r.source as SessionWireServerReplySource))
-        return null;
-      if (!Array.isArray(r.lines) || !r.lines.every((l) => typeof l === "string")) return null;
-      return {
-        kind: "server_reply",
-        network: r.network,
-        source: r.source as SessionWireServerReplySource,
-        lines: r.lines as string[],
-      };
-    }
+      // #992 — the `source` discriminant is checked against the closed set
+      // ONCE, never a hand-written `!==` chain: that chain was a second,
+      // silent copy, and adding `admin` server-side left it rejecting a
+      // legitimate reply as "unknown source" with the modal never opening.
+      // The membership test was already reading the generated
+      // SESSION_WIRE_SERVER_REPLY_SOURCE; the schema's
+      // `S_SessionWireServerReplySource` is that same const, so the SSOT is
+      // unchanged and only the transcription around it is gone.
+      return validate(S_SessionWireServerReplyPayload, r);
     case "invite_ack":
       // P-0e + P-0f — 341 RPL_INVITING ack. Server emits structured
       // (network, channel, peer); cic appends a synthetic row to the

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -2,7 +2,6 @@ import type {
   AdminSnapshotPayload,
   MessageKind,
   ScrollbackMessage,
-  WhoUser,
   WireAdminEvent,
   WireChannelEvent,
 } from "./api";
@@ -315,42 +314,12 @@ export function narrowMembers(raw: unknown): MemberEntry[] | null {
   return out;
 }
 
-// #169 — narrow the `who_reply` per-user rows. Superset of MemberEntry;
-// `modes` is a raw WHO flags STRING (not a prefix list). `hops`/`realname`
-// are nullable (RFC-violating servers may omit the trailing field). A single
-// malformed element drops the whole payload (mirror of narrowMembers) so the
-// modal never renders a half-typed row.
-export function narrowWhoUsers(raw: unknown): WhoUser[] | null {
-  if (!Array.isArray(raw)) return null;
-  const out: WhoUser[] = [];
-  for (const u of raw) {
-    if (typeof u !== "object" || u === null) return null;
-    const e = u as Record<string, unknown>;
-    if (
-      typeof e.nick !== "string" ||
-      typeof e.user !== "string" ||
-      typeof e.host !== "string" ||
-      typeof e.server !== "string" ||
-      typeof e.modes !== "string" ||
-      typeof e.channel !== "string" ||
-      (e.hops !== null && typeof e.hops !== "number") ||
-      (e.realname !== null && typeof e.realname !== "string")
-    ) {
-      return null;
-    }
-    out.push({
-      nick: e.nick,
-      user: e.user,
-      host: e.host,
-      server: e.server,
-      modes: e.modes,
-      hops: e.hops as number | null,
-      realname: e.realname as string | null,
-      channel: e.channel,
-    });
-  }
-  return out;
-}
+// #1393 — `narrowWhoUsers` lived here, next to `narrowMembers`, on the
+// assumption that a `who_reply` row narrower would end up shared the way the
+// member one is. It never was: the user topic was its only caller, and that
+// arm now validates against `S_SessionWireWhoReplyPayload`, whose
+// `{a: <who_user>}` is the same typespec this transcribed. Deleted rather
+// than left exported — an unused export reads as a contract somebody keeps.
 
 // REV-A H1 — shared narrower for the three window-state terminal-event
 // arms (joined / join_failed / kicked). F1 (visitor-parity 2026-05-15)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -56206,3 +56206,93 @@ guessing the owner from the name.
 - **Whether any boundary would now be caught that a source scan would miss.**
   The control proves the mechanism on `Health`; it was not repeated per
   boundary.
+<!-- entry #1393b -->
+
+---
+
+## 2026-08-21 — #1393b: a boundary may be WIDER than its typespec, and only a value swap can see it
+
+The #1393 census mutates every field of every user-topic arm and compares
+the hand narrower against the generated schema. Its verdict authorises the
+migration: an arm at parity on both axes can swap its field walk for
+`validate(S_…, r)` and lose nothing. That verdict was wrong for three arms,
+and the reason it was wrong is a property of the matrix, not of the arms.
+
+### Three ops that all move the same thing
+
+`drop`, `null` and `wrong-type` each change the TYPE of a leaf. None of them
+can tell a closed set apart from a free string: `{e: ["ok", "failed"]}` and
+`"s"` both take a string and both refuse a number, so every mutation the
+matrix could build scored them identically. A token a server adds
+additively, however, is a perfectly well-typed string — and that is exactly
+the case the wire contract legislates (unknown-is-never-fatal, GH #447).
+
+So the matrix gained a fourth op: replace a string leaf with a value no
+schema declares. Generated for string leaves only, because on anything else
+it is `wrong-type` under a second name, and on a free-string field both
+boundaries accept it and the row says nothing.
+
+### What it took
+
+Parity fell from 33 arms to 30.
+
+| arm | field | typespec says | the boundary does | since |
+|---|---|---|---|---|
+| `recover_progress` | `reason` | one of four recovery tokens | any string | #581 |
+| `recover_result` | `reason` | one of four recovery tokens | any string | #581 |
+| `web_session_severed` | `code` | the literal `rate_limit_flood` | any string | #1338 X-S14 |
+
+All three widenings are deliberate and were already argued in the source.
+Migrating them would have closed the set again — silently, under a green
+census — and the consequence is not cosmetic: an unrecognised sever `code`
+would drop a TERMINAL event and strand the client on a dead shell holding a
+revoked bearer, which is the precise failure #1338 removed.
+
+### The rule, stated generally
+
+**The typespec is the server's promise about what it sends; it is not
+automatically the client's rule for what it accepts.** A client that
+deploys independently of its server is entitled to accept more than the
+current typespec describes, and where it does, the codegen schema is
+STRICTER than the boundary and swapping one in is a regression. A migration
+onto generated schemas must therefore measure a VALUE swap, not only a type
+mutation — otherwise every deliberately-open token set reads as parity.
+
+The earlier figures in this log (34 arms at parity, then 33) were not
+mistaken when written; they were measured with a matrix that could not
+express this. Recording the revision rather than editing them is the point
+— what changed is the instrument.
+
+### Where the migration stopped
+
+27 of the 42 arms now narrow through their generated schema. Of the 15 that
+do not, 12 are measured divergent and each carries its issue-numbered
+rationale at the `case` — including the three above, which now name the
+schema they decline and the census row that separates them.
+
+The last three, `joined` / `join_failed` / `kicked`, are at parity and are
+still NOT migrated. Their arm here is already one line delegating to
+`narrowWindowStateEvent`, and every hand line they cost lives in
+`wireNarrow.ts`, where the per-channel cold-snapshot arm keeps calling the
+same helper — so migrating the call site would delete nothing and would
+leave one trio of events narrowed two different ways depending on which
+topic delivered it. That trade belongs to a measurement of the per-channel
+boundary, which has not been made.
+
+### The oracle that survives its own migration
+
+The moment an arm calls `validate` with its own schema, any census that
+judges it with that schema compares the schema to itself and reports parity
+by construction. So the property the migration must preserve is pinned by a
+test that never consults a schema to JUDGE: schemas generate the inputs, the
+recorded verdict and returned value are the hand narrower's alone, and the
+pin was recorded with `userTopic.ts` restored to its pre-migration state.
+An unchanged snapshot afterwards is the evidence. Re-recording it with `-u`
+after a migration would rewrite the evidence into a description of the new
+code — the fourth op is in the pin too, so from here the class is
+machine-checked rather than re-argued.
+
+_Not claimed: that any of the three widened values was ever observed on the
+wire. The finding is an instrument gap, measured in the source. Nothing here
+changes what the server emits, and the per-channel boundary in
+`wireNarrow.ts` has not been censused at all._


### PR DESCRIPTION
**27 of the 42 user-topic arms now narrow through their generated schema.**
Slice 1 (five arms, the form review) is the first three commits; the rest of
the migration, and the measurement that stopped it three arms short of the
list, are the four after it.

## What moved

| commit | what |
|---|---|
| `test` | the schema-free pin — the oracle a schema-migration cannot make tautological |
| `cic` | slice 1: five arms, one per shape |
| `test` | the matrix walks every depth, not just the top layer — finds the 9th divergent |
| `test` | **a fourth mutation op: swap a VALUE, not a type — loses three more arms** |
| `cic` | 15 flat-envelope arms |
| `cic` | 4 collection arms + the 6 helpers they owned |
| `cic` | 3 arms that borrowed a shared narrower |
| `cic` | name, at each of the three arms the swap found, the tolerance that keeps it |
| `docs` | `<!-- entry #1393b -->` |

## Lines

Measured against `origin/main` at `d73c0177`:

| file | + | − |
|---|---|---|
| `cicchetto/src/lib/userTopic.ts` | 147 | 346 |
| `cicchetto/src/lib/wireNarrow.ts` | 6 | 37 |
| `cicchetto/src/__tests__/wireUserBoundary.test.ts` | 1187 | 29 |
| `docs/DESIGN_NOTES.md` | 90 | 0 |

**383 lines of production source out, 153 back — net −230.** Broken down where
I measured it per group, the additions are mostly not arm bodies: the
15-arm group is `+20/−92` on the arms with the rewritten header comment and
import list accounting for `+35/−14` on top; the collection group is `+21/−138`
on arms and helpers with `+4/−3` of imports; the shared-narrower group is
`+32/−52` here and `+6/−37` in `wireNarrow.ts`.

Six file-local helpers died with their arms — `narrowPresenceMap`,
`narrowNotifyMap`, `narrowNotifyEntry`, `narrowWindowsMap`,
`narrowQueryWindowEntry`, `narrowMentionsBundleMessage` — and one exported one,
`narrowWhoUsers`, which turned out to have exactly one caller anywhere in the
tree and no test of its own. `narrowArray` and the four bundle-element
narrowers STAY: `whois_bundle`, `banlist_bundle` and `links_bundle` still call
them and all three are measured divergent.

## Arms migrated (22 this round, 27 total)

**Flat envelopes (15).** `archive_changed`, `archive_purged`,
`auto_away_debounce_changed`, `channels_changed`, `connection_progress`,
`directory_complete`, `directory_failed`, `directory_progress`, `invite_ack`,
`own_nick_changed`, `peer_away`, `supported_umodes_changed`, `whowas_bundle`,
`window_invite_declined`, `window_pending`.

**Collections whose helper died with them (4).** `presence_snapshot`,
`notify_list`, `query_windows_list`, `mentions_bundle`.

**Borrowed a shared narrower (3).** `names_reply`, `who_reply`, `server_reply`.

**Slice 1 (5).** `away_confirmed`, `presence_changed`, `presence_error`,
`session_identity_changed`, `umode_changed`.

## Arms left hand-written (15), and why

**Three the new mutation op took, and the reason it took them.**

`drop`, `null` and `wrong-type` all move the TYPE of a leaf, so none of them can
tell `{e: [...]}` from `"s"` — both take a string, both refuse a number. But a
token a server adds additively **is** a well-typed string, and that is exactly
the case `#447` legislates. So the matrix gained an op that replaces a string
leaf with a value no schema declares. Parity fell **33 → 30**:

| arm | field | typespec | this boundary | since |
|---|---|---|---|---|
| `recover_progress` | `reason` | one of four tokens | any string | #581 |
| `recover_result` | `reason` | one of four tokens | any string | #581 |
| `web_session_severed` | `code` | literal `rate_limit_flood` | any string | #1338 X-S14 |

All three widenings were already deliberate and argued in the source; migrating
them would have closed the set again under a green census. For
`web_session_severed` that is not cosmetic — an unrecognised sever `code` would
drop a TERMINAL event and strand the client on a dead shell holding a revoked
bearer, the precise failure #1338 removed. Each of the three now names, at its
`case`, the schema it declines and the census row that separates them.

**Nine measured divergent before this branch.** `isupport_changed`,
`lusers_bundle`, `whois_bundle`, `banlist_bundle`, `window_invited`,
`server_settings_changed`, `bundle_hash`, `links_bundle`,
`connection_state_changed`.

**Three at parity, left on a scope judgement — `joined`, `join_failed`,
`kicked`.** The handoff lists them and they are clean on both axes. But their
arm here is *already one line*, `return narrowWindowStateEvent(r)`, and every
hand line they cost lives in `wireNarrow.ts`, where the per-channel
cold-snapshot arm keeps calling the same helper. Migrating the call site would
delete **nothing** and would leave one trio of events narrowed two different
ways depending on which topic delivered it. That trade only pays as part of
measuring the per-channel boundary, which this branch has not done.

## The oracle

`wireUserBoundary.test.ts`'s pin judges without ever consulting a schema:
schemas generate the inputs, the recorded verdict and returned value are the
hand narrower's alone. It was recorded with `userTopic.ts` **restored to its
pre-migration state** and has been **byte-identical since**, across every
migration commit — `git diff fdfec43b..HEAD -- <the test file>` is empty, and
`vitest` runs it green without `-u`.

That restore-then-record also answers a question about slice 1: the five arms it
migrated lose nothing on the new axis either. Their pre-migration hand narrowers
used the same closed sets their schemas declare, so the swap rows record parity
for them too — measured, not assumed.

## Gates

- `scripts/bun.sh run check` → `check summary — 4 stages ran, 0 failed`
- `scripts/bun.sh run test` → **5712 passed / 295 files**
- `scripts/design-notes-gate.sh` → `1 new entry heading(s), separator and marker present`
- Rebased onto `origin/main` `d73c0177`; branch contribution `--numstat` pinned
  to a file before and diffed after — identical.
- Run attribution proven, not assumed: the run collected **6 tests** from
  `wireUserBoundary.test.ts` while `origin/main`'s copy declares **4**, so it
  compiled the worktree's source and not main's.

## What I refuse to claim

- **That any of the three widened values was ever seen on the wire.** The
  finding is an instrument gap measured in the source, not an incident. Nothing
  here changes what the server emits.
- **That the swap op is exhaustive.** It swaps STRING leaves only. A closed set
  over non-strings would still read as parity — the current codegen grammar
  emits `{e: [...]}` for strings only, so no such node exists today, but that is
  a property of this emitter and not a proof.
- **That the per-channel boundary is at parity with its schemas.**
  `wireNarrow.ts` / `subscribe.ts` have never been censused. The window-state
  trio is left on exactly that basis, not on a measurement.
- **That the two censuses still measure the 27 migrated arms.** For those they
  now compare a schema against itself and report parity by construction. The pin
  is their only surviving oracle, which is why it must never be re-recorded with
  `-u` on migrated code.
- **Any browser or e2e evidence.** This is a boundary-narrowing change with no UI
  surface; it is gated by vitest, tsc and biome, and no Playwright run was made.
- **CI.** Every number above was measured locally in the worktree under
  `GRAPPA_CACHE_ID=w2-1393`. The CI verdict is the orchestrator's to read.
