### PR TITLE
docs(#1632): picking becomes absolute FIFO, and status:soon dies

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -210,10 +210,11 @@ is DELETE-then-write, never append-only:
 - **BATCH ALL DEPLOYS — never deploy per-issue (vjt STANDING ORDER 2026-07-17).** A per-issue
   `--cic` bundle deploy (OR cold restart) spams live users with a BundleRefreshBanner every
   ~20min. So: as each issue completes, worker MERGES + pushes to origin/main (the CI-green
-  gate still gates the merge) — but does **NOT** deploy. Accumulate in `soon`. Ship ONE batched
+  gate still gates the merge) — but does **NOT** deploy. **The issue CLOSES at that merge**
+  (#1632); the merged-and-closed issues then accumulate as the pending deploy batch. Ship ONE batched
   deploy only when **~4–5 issues are resolved (merged, awaiting deploy)**, carrying all of them in
-  a single bundle broadcast, then ONE announce covering the batch + close all + strip their
-  `status:soon`. Merge ≠ deploy: the m42 jail only pulls origin/main when `deploy-m42` runs, so
+  a single bundle broadcast, then ONE announce covering the batch — **nothing left to close or
+  unlabel at that point.** Merge ≠ deploy: the m42 jail only pulls origin/main when `deploy-m42` runs, so
   merging freely does not touch prod. This SUPERSEDES per-issue ship-on-green in dispatch briefs —
   tell the worker to merge+HOLD, not deploy. Deploy rules stack: this batching gate + the **CI-green-before-ship** gate
   (`integration` must be green before ANY merge/ship) + the **night-cold-deploy** window (cold-
@@ -227,12 +228,21 @@ is DELETE-then-write, never append-only:
   banner), just never HOLD a hot-ready batch for a cold restart it does not need. When the two
   rules pull against each other, the tiebreak is **users see one banner per batch, and no work
   sits waiting on a restart it does not require**.
-- 🔴 **EVERY ISSUE CLOSED AT A RELEASE GETS A COMMENT NAMING THAT RELEASE (vjt STANDING ORDER 2026-08-04).**
-  Closing is not enough: the closing comment must say **which release the work shipped in** (e.g. *"shipped in
-  v0.11.1"*), because a self-hoster reading the issue needs to know **which tag to pull** — that is the same
-  reason `soon` ends at the release and not at our deploy. **And strip `status:soon` from everything that
-  goes into the release, in the same pass.** Close + release-comment + label-strip are ONE action, never
-  three chores to remember separately. Do it for every issue in the batch, not just the headline ones.
+- 🔴 **"WHICH TAG DO I PULL" IS ANSWERED AT THE RELEASE CUT — NOT BY A CLOSING COMMENT, AND NOT BY THE
+  MILESTONE (vjt STANDING ORDER 2026-08-04, REWORDED 2026-08-20/21 by #1632).** The original order said
+  every issue closed at a release gets a closing comment **naming that release**, because a self-hoster
+  reading the issue needs to know **which tag to pull**. Closing now happens at the MERGE, when no tag
+  exists yet. **The obligation survives; its carrier is the RELEASE CUT** — the tag plus its release
+  notes — and the final `vX.Y.0` cut is vjt's. So: **no release-time closing comment, no release-time
+  close pass, no label to strip.**
+  ⚠️ **The MILESTONE does NOT carry it (vjt, 2026-08-21).** A milestone is a **PLANNING** label: which
+  release the work is **INTENDED** to go out in, an intention that can still change because he
+  **dogfoods on staging before committing to a release**. It is not a promise about which tag contains
+  the code. **Never cite a milestone as evidence that something shipped.**
+  🔴 **Accepted price, say it out loud:** a merge-closed issue **names no release**. That is deliberate,
+  not a gap to paper over with an invented comment.
+  ℹ️ **WHEN a milestone is assigned or moved is NOT specified** — vjt has not given that rule, and this
+  file does not invent one.
 - **RELEASE-CUTTING + NEWS.JSON (vjt STANDING ORDERS 2026-07-24).** After a batch DEPLOYS to
   Azzurra + verifies healthy: cut a GitHub **release + tag** (tag ≡ CTCP VERSION exactly, #391),
   THEN produce the site's **News/Releases `news.json` entry** — bilingual, curated by vjt, and
@@ -251,36 +261,48 @@ is DELETE-then-write, never append-only:
   worker to remove its worktree after merging. NEVER force-remove an UNmerged or DIRTY worktree — it belongs to a
   concurrent session's in-flight work (also the source of the "sibling stashed my changes" pitfall). Codified in
   CLAUDE.md Development Cycle too.
-- **`status:*` label discipline (WIP board — grappa-irc #258, mandatory 2026-07-15).** The
-  grappa.chat WIP board renders directly from three mutually-exclusive grappa-irc labels —
-  `status:queued` (accepted, in build queue, not started), `status:cooking` (worker STILL ON IT —
+- **`status:*` label discipline (WIP board — grappa-irc #258, mandatory 2026-07-15; cut to TWO
+  labels 2026-08-20 by #1632).** There are **two** mutually-exclusive grappa-irc labels —
+  `status:queued` (accepted, in build queue, not started) and `status:cooking` (worker STILL ON IT —
   building, in code-review, waiting on CI **including post-merge CI polling**, addressing findings:
-  ANY active worker attention on the issue), `status:soon` (worker FULLY DONE + handed off, no
-  active work and NO CI-wait remaining, **awaiting a RELEASE**). The board's two
+  ANY active worker attention on the issue). **A closed issue carries neither.** The board's two
   plain-link columns are derived: **backlog = open issues with NO `status:*` label** (shown
-  before Queued), **closed = closed issues** (after Soon) — both exclude `status:*`. The
+  before Queued), **closed = closed issues** — both exclude `status:*`. The
   orchestrator OWNS keeping these labels truthful, or the board drifts from reality:
-  - **`cooking → soon` fires ONLY at the worker's HAND-OFF, NEVER at merge (vjt order 2026-07-18).**
-    Waiting on CI — PR checks OR post-merge main CI — is STILL cooking, not soon. A merged issue
-    whose worker is still polling its post-merge run stays `cooking`. The ORCHESTRATOR flips it to
-    `soon` in the SAME turn it processes the worker's DONE hand-back (worker idle, CI settled, moved
-    on) — the worker does NOT self-flip to soon at merge. (Prior rule "worker merge+soon" flipped
-    prematurely during CI-wait → the exact drift vjt caught. Worker now: merge+HOLD, STAYS cooking.)
+  - 🔴 **`status:soon` is DEAD (#1632) — the state machine is `queued → cooking → closed`.** It
+    meant "merged, awaiting release". Measured before it was retired: **75 open `status:soon`
+    issues, 71 already in milestone 1.3, and zero `status:soon` issues ever closed** in the repo's
+    history. The label still EXISTS on GitHub (deleting it is a separate, irreversible call for vjt)
+    but **nothing sets it**: an issue carrying one is drift.
+    ⚠️ The grappa.chat board's Soon column follows in the OTHER repo — filed as **vjt/grappa-www#6**,
+    routing is vjt's. **Do not "fix" the board from here.**
+  - **`cooking → closed` fires ONLY at the worker's HAND-OFF, NEVER mid-CI (the 2026-07-18 order,
+    carried over from `cooking → soon`).** Waiting on CI — PR checks OR post-merge main CI — is
+    STILL cooking. A merged issue whose worker is still polling its post-merge run stays `cooking`.
+    The ORCHESTRATOR closes it in the SAME turn it processes the worker's DONE hand-back (worker
+    idle, CI settled, moved on) — the worker does NOT self-close at merge. (Prior rule "worker
+    merge+advance" flipped prematurely during CI-wait → the exact drift vjt caught. Worker now:
+    merge+HOLD, STAYS cooking.)
+  - 🔴 **A merge that covers only ONE LEG of a multi-part issue does NOT close it.** #96 shipped one
+    leg of three and vjt said explicitly the rest stays open. Epics and multi-leg issues close **leg
+    by leg, when the last leg lands** — check each one. (Was a release-cut caveat in
+    `docs/OPERATIONS.md`; closing moved to merge, so it moved too.)
   - **Enqueue (`→ status:queued`) is done by the ircbot or vjt, NOT you** — that label is how
     work enters the queue (the ircbot no longer pings you to hand issues over; the label IS the
     handover). Your first touch is `status:queued → status:cooking` when the worker starts
     building. Move, don't add — mutually exclusive
     (`gh issue edit N --remove-label status:X --add-label status:Y`).
-  - 🔴 **`soon` ENDS AT THE RELEASE, NOT AT THE DEPLOY (vjt, #grappa 2026-08-03 13:1x — this SUPERSEDES
-    the old deploy-ends-soon rule and the "se son deployate son chiuse" ruling).** His reason, and it is
-    the whole point: **we are not the only deployment.** Self-hosters exist (Mezmerize's instance, the
-    #503 one-click AWS installer, the docker path), so "deployed" describes only what the m42 jail
-    pulled — for every other operator the work exists when **there is a tag to pull**. So:
-    **`gh issue close` + strip `status:*` both fire at the RELEASE CUT**, not when m42 deploys.
-    A deploy to m42 is an internal event that changes NO label and closes NO issue.
-    ⚠️ Consequence to keep in mind: the board's **Soon column will hold code that is already LIVE on
-    m42** — it means "shipped, not yet in a named release", not "not yet running". If that reads wrong
-    on grappa.chat, the column name is vjt's call, not a reason to bend the label.
+  - 🔴 **CLOSING FIRES AT THE MERGE, NOT AT THE DEPLOY AND NOT AT THE RELEASE (vjt, #grappa
+    2026-08-20: *"si chiudiamo al merge"* — #1632; SUPERSEDES the 2026-08-03 `soon`-ends-at-the-
+    release rule, the older deploy-ends-soon rule, and the "se son deployate son chiuse" ruling).**
+    What survives from 2026-08-03 is its REASON: **we are not the only deployment.** Self-hosters
+    exist (Mezmerize's instance, the #503 one-click AWS installer, the docker path), so "deployed"
+    describes only what the m42 jail pulled — for every other operator the work exists when **there
+    is a tag to pull**. That reader still has to be told which tag, and **the RELEASE CUT is what
+    tells them** (tag + release notes), since the close now happens before any tag exists — NOT the
+    milestone, which is a planning label only. So:
+    **`gh issue close` + strip `status:*` both fire at the MERGE.**
+    A deploy to m42 changes NO label and closes NO issue; neither does a release cut.
   - A newly-filed backlog issue gets NO `status:*` label (it lives under the backlog link until
     triaged into the queue). The board is a shared artifact — keep it honest every transition.
   - **ANTI-DRIFT (vjt caught two misses 2026-07-16 — stale `cooking` on closed #268; forgotten
@@ -289,10 +311,12 @@ is DELETE-then-write, never append-only:
     - The `queued→cooking` edit goes in the **SAME Bash block as the clear-and-dispatch send-keys**
       (dispatch and label move as one tool call — you cannot dispatch without moving the label).
     - The `strip status:*` edit goes in the **SAME handling turn as processing the worker's
-      shipped/closed report** (alongside `gh issue close` + the announce brief).
+      merged/DONE report** (alongside the `gh issue close` that turn now also carries — the
+      announce comes later, with the batched deploy).
     - **`lib/board-check.sh [--cooking N]` is the STANDING GUARD.** Run it at EVERY handoff-flush
       and EVERY `/orchestrate` resume (Step 0). It fails (exit 1) on: a CLOSED issue with a
-      `status:*` label, any issue with >1 status label, or (with `--cooking N`) a cooking set that
+      `status:*` label, any issue with >1 status label, an OPEN issue still carrying the RETIRED
+      `status:soon` (#1632), or (with `--cooking N`) a cooking set that
       doesn't match the in-flight issue you believe is building. It bakes in `--limit 300` — plain
       `gh issue list` defaults to 30 and silently truncates older issues (that truncation masked
       the drift twice). If it prints DRIFT, fix it BEFORE doing anything else.
@@ -300,8 +324,11 @@ is DELETE-then-write, never append-only:
   execution queue — there is no hand-managed list. When the worker is free and nothing is in
   flight, read the open queued set (`gh issue list --state open --label status:queued --json
   number,title,labels`) and dispatch the next per the placement rules in
-  `/srv/grappa/docs/ISSUE_PIPELINE.md` (P0 first / never preempt in-flight, then
-  similarity-group, else lowest number), moving it `status:queued → status:cooking`. This
+  `/srv/grappa/docs/ISSUE_PIPELINE.md` — **P0 first / never preempt in-flight, otherwise the
+  LOWEST-NUMBERED queued issue, absolute FIFO, no exceptions.** (The old
+  "similarity → group" tier was deleted 2026-08-20, #1632: it legitimised jumping the queue
+  whenever the next issue looked adjacent to what just shipped.) Move it
+  `status:queued → status:cooking`. This
   REPLACES waiting for an ircbot handover. Only when the queued set is **EMPTY** do you ping
   vjt "what next?" — don't invent work.
 - **Auto-clearer**: `lib/auto-clear-watch.sh start|status grappa-orch` runs an external
@@ -590,8 +617,8 @@ local artefact the container NEVER serves — do not read deploy state from it.*
 exactly like a broken deploy; one `ls -l` on the served path ended it.
 ℹ️ A `✓ built in 70ms` line is the **service-worker sub-build**, not the bundle — read the whole log before
 calling a build suspiciously fast.
-Worker MERGES + pushes, **never deploys**; stays `cooking` until its DONE hand-off; ORCH flips to `soon`.
-ONE batched deploy (~4–5 issues), ONE dual-net announce, then close all + strip labels.
+Worker MERGES + pushes, **never deploys**; stays `cooking` until its DONE hand-off; ORCH then CLOSES it
+at that merge (#1632). ONE batched deploy (~4–5 already-closed issues), ONE dual-net announce.
 - **COLD:** `/srv/grappa/scripts/deploy-m42.sh --force-cold` · **HOT:** `--force-hot` **THEN `--cic`** — a HOT deploy is
   TWO runs; one alone ships half the range. ABSOLUTE path, **redirect to a file** (a pipe SIGPIPEs the remote deploy).
 - 🔴 **RUN DEPLOYS DETACHED** (`nohup` + `disown`). Tonight the `--cic` run was **HARNESS-REAPED mid-`vite build`**
@@ -674,7 +701,8 @@ clearing on unverified edits leaves the next session unable to tell whether they
 ## 🏷️ LABEL DISCIPLINE
 `lib/board-check.sh [--cooking "N M"]` at EVERY flush + resume. Moves are ATOMIC: `queued→cooking` rides the SAME Bash
 block as the dispatch send-keys; `strip status:*` rides the SAME turn as processing the shipped report.
-**`cooking→soon` only at the worker's DONE hand-off — CI-wait is still cooking.** A closed issue carries NO `status:*`.
+**`cooking→closed` only at the worker's DONE hand-off — CI-wait is still cooking.** A closed issue carries NO
+`status:*` and `status:soon` is DEAD (#1632). **A milestone is PLANNING, never proof that code is in a tag.**
 **Enqueue is vjt's or the ircbot's** — except when he says "fix it" in conversation: that IS the enqueue (#526, #522).
 
 ## 🔀 PR / MERGE / GATING MECHANICS (learned the hard way 2026-08-01 — permanent)

--- a/.claude/skills/orchestrate/lib/board-check.sh
+++ b/.claude/skills/orchestrate/lib/board-check.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # board-check.sh — orchestrator label drift-guard for the grappa.chat WIP board.
 #
-# WHY: the board renders from three mutually-exclusive status:* labels on
-# vjt/grappa-irc (queued / cooking / soon). The orchestrator OWNS keeping them
+# WHY: the board renders from the mutually-exclusive status:* labels on
+# vjt/grappa-irc. Since #1632 (vjt, 2026-08-20) there are TWO — queued / cooking
+# — and the machine is `queued → cooking → closed at the MERGE`. A milestone is a
+# PLANNING label (which release the work is INTENDED for), never proof that code
+# is in a tag, so this script does not audit milestones. `status:soon` is RETIRED:
+# the label still exists on GitHub (deleting it is vjt's call) but nothing sets
+# it, so an issue still carrying one is drift and check 3 below fails on it.
+# The orchestrator OWNS keeping these labels
 # truthful, but the transitions are manual side-effects that are easy to forget
 # (missed queued→cooking on a #273 dispatch; left status:cooking on the closed
 # #268 — both caught by vjt, 2026-07-16). This script is the STANDING GUARD:
@@ -59,18 +65,28 @@ if [ -n "$multi" ]; then
   drift=1
 fi
 
-# 3) Board snapshot (OPEN only — the three live columns).
-cooking=$(gh issue list --repo "$REPO" --state open --limit "$LIMIT" --label status:cooking \
+# 3) HARD DRIFT: status:soon is RETIRED (#1632) — nothing sets it any more, so an
+#    OPEN issue still carrying it was left behind by the old four-state machine.
+#    Closed ones are already caught by check 1, so this looks at OPEN only.
+retired=$(gh issue list --repo "$REPO" --state open --limit "$LIMIT" --label status:soon \
   --json number -q '[.[].number] | sort | map("#"+(tostring)) | join(" ")')
-soon=$(gh issue list --repo "$REPO" --state open --limit "$LIMIT" --label status:soon \
+if [ -n "$retired" ]; then
+  echo "✗ DRIFT — OPEN issue carrying the RETIRED status:soon label (#1632):"
+  echo "    $retired"
+  echo "    → the machine is queued→cooking→closed-at-merge; close it if its work"
+  echo "      merged, else move it back to status:queued. Never re-add soon."
+  drift=1
+fi
+
+# 4) Board snapshot (OPEN only — the two live columns).
+cooking=$(gh issue list --repo "$REPO" --state open --limit "$LIMIT" --label status:cooking \
   --json number -q '[.[].number] | sort | map("#"+(tostring)) | join(" ")')
 queued=$(gh issue list --repo "$REPO" --state open --limit "$LIMIT" --label status:queued \
   --json number -q '[.[].number] | sort | map("#"+(tostring)) | join(" ")')
 echo "  cooking: ${cooking:-<none>}"
-echo "  soon   : ${soon:-<none>}"
 echo "  queued : ${queued:-<none>}"
 
-# 4) Optional: assert cooking matches what the orchestrator believes is in-flight.
+# 5) Optional: assert cooking matches what the orchestrator believes is in-flight.
 if [ -n "$expect_cooking" ]; then
   want=$(norm "$expect_cooking")
   got=$(norm "$cooking")

--- a/docs/ISSUE_PIPELINE.md
+++ b/docs/ISSUE_PIPELINE.md
@@ -19,8 +19,8 @@ as a **continuous stream**, triaged and executed continuously.
   nothing in flight) **pulls the open `status:queued` set directly from GitHub**,
   picks the next issue per the placement rules below, moves it
   `status:queued → status:cooking`, and drives the worker through it end-to-end
-  (ship + announce + close, removing the `status:*` label on close). Does NOT
-  implement. The `status:queued` set IS the queue — there is no separate
+  (close at the merge + ship + announce, removing the `status:*` label on close).
+  Does NOT implement. The `status:queued` set IS the queue — there is no separate
   hand-managed list, so the grappa.chat WIP board and the queue are one artifact.
 - **worker** ("grappa-worker") — the sibling Claude that implements ONE issue at
   a time in a git worktree, under the orchestrator's direction.
@@ -34,11 +34,16 @@ and picks ONE to dispatch:
 1. **Critical bug → first, but never preempt.** A `P0` bug in the queued set is
    dispatched next — but it **never interrupts work already in flight**. The
    in-flight issue always finishes first.
-2. **Similarity → group.** Prefer a queued issue that touches the same surface as
-   what just shipped / is adjacent in flight, so related changes reuse context.
-3. **Otherwise → oldest first (FIFO).** Absent a P0 or a similarity match, take the
-   lowest-numbered queued issue.
-4. The orchestrator applies these itself. It escalates to vjt only for genuine
+2. **Otherwise → oldest first (FIFO).** Absent a P0, take the lowest-numbered
+   queued issue. **No exceptions.**
+   🔴 There used to be a *"similarity → group"* rule above this one, preferring a
+   queued issue adjacent to what just shipped so related changes reuse context.
+   vjt deleted it on 2026-08-20 (#1632): it legitimised skipping the queue
+   whenever the next issue *looked* adjacent, and that is the hole through which
+   recent issues got picked ahead of old ones. **Picking is absolute FIFO** —
+   adjacency is not a reason to jump the queue, and "these two touch the same
+   file" is not a placement rule.
+3. The orchestrator applies these itself. It escalates to vjt only for genuine
    ambiguity / design forks / scope questions — not for routine placement. When the
    `status:queued` set is **empty**, it goes idle / asks vjt "what next?" rather
    than inventing work.
@@ -48,29 +53,54 @@ transitions ARE the queue's state, so the WIP board always reflects the real que
 
 ## Label state machine (the ONLY legal transitions)
 
-vjt, 2026-08-07: *"non ci inventiamo le transizioni allucinate"*. There are four
-states and three transitions. Nothing else exists.
+vjt, 2026-08-07: *"non ci inventiamo le transizioni allucinate"*. There are three
+states and two transitions. Nothing else exists.
 
 ```
-status:queued  ──▶  status:cooking  ──▶  status:soon  ──▶  closed
-   (ircbot          (orchestrator        (PR MERGED,        (RELEASED)
-    enqueues)        dispatches)          awaiting release)
+status:queued  ──▶  status:cooking  ──▶  closed
+   (ircbot          (orchestrator        (MERGED to origin/main)
+    enqueues)        dispatches)
 ```
 
 - **`status:queued`** — triaged and enqueued by the ircbot. Nobody is working on it.
 - **`status:cooking`** — a worker holds it. It is in flight *right now*.
-- **`status:soon`** — **the work is MERGED** and is waiting for a release. It does
-  NOT mean "coming soon" / "planned". An issue sitting at `cooking` whose change is
-  already merged is a **stale label**, not work in progress — advance it.
-- **closed** — shipped in a release.
+- **closed** — **the work is MERGED to `origin/main`.** Not deployed, not
+  released: merged. vjt, 2026-08-20: *"si chiudiamo al merge"* (#1632).
+
+🔴 **`status:soon` is DEAD (#1632).** It was the fourth state — "merged, awaiting
+release" — and nothing sets it any more. Measured at its removal: 75 open
+`status:soon` issues, **71 of them already in milestone 1.3**, and **zero
+`status:soon` issues had ever been closed** in the whole history of the repo.
+The label still exists on GitHub (deleting it is a separate, irreversible call
+for vjt) but an issue carrying it is drift.
+
+⚠️ **The MILESTONE is a PLANNING label, not a shipping record (vjt, 2026-08-21).**
+It says which release the work is **INTENDED** to go out in — an intention that
+may still change, because vjt dogfoods on staging before committing to a release.
+It is **NOT** a promise about which tag contains the code, and reading it as one
+is exactly the mistake this note exists to prevent.
+
+🔴 **A merge-closed issue therefore NAMES NO RELEASE, and that is an accepted
+price, not an oversight.** At the merge the tag does not exist yet. The duty to
+tell a reader **which tag to pull** is not discharged here, and the milestone does
+not discharge it either: it is discharged **at the release cut**, by the tag and
+its release notes — a later moment, and the final `vX.Y.0` cut is vjt's.
+
+ℹ️ **Deliberately unspecified:** WHEN a milestone is assigned, and when it may be
+moved. vjt has not given that rule, so this doc does not invent one.
 
 Rules:
 
 - The **orchestrator owns every transition**. The ircbot only sets `status:queued`
   at intake, and otherwise measures and reports drift — it does not relabel.
-- **Advance the label in the same step that causes it.** Merging without moving
-  `cooking → soon` makes the board lie; a board audit on 2026-08-07 found nine
-  issues stuck at `cooking` with their change already merged.
+- **Advance the label in the same step that causes it.** Merging without closing
+  makes the board lie; a board audit on 2026-08-07 found nine issues stuck at
+  `cooking` with their change already merged.
+- 🔴 **A merge that covers only ONE LEG of a multi-part issue does NOT close it.**
+  #96 shipped one leg of three and vjt said explicitly the rest stays open. Epics
+  and multi-leg issues close **leg by leg, when the last leg lands** — check each
+  one before closing. (This caveat used to live at release-cut time in
+  `docs/OPERATIONS.md`; closing moved to merge, so the caveat moved with it.)
 - **Do not invent intermediate states.** No `status:review`, no `status:blocked`
   improvised on the spot; if a real new state is needed it goes in this doc first.
 
@@ -82,9 +112,9 @@ worktree (branch off local main)
   → gates green (ONE check.sh — never concurrent runs; if waiting on a bg run use a
                  log-pattern Monitor WITH a timeout, never a self-matching pgrep loop)
   → rebase onto main → merge to main → push origin main
+  → gh issue close  (AT THE MERGE — multi-leg issues wait for their last leg)
   → deploy m42 (auto hot/cold; add --cic when cic was touched)
   → announce #grappa (fire-and-forget via the ircbot — brief once, move on)
-  → gh issue close
 ```
 
 - **No PRs.** Worktree + merge + push + deploy. ("No commit *directly* to master"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1625,14 +1625,25 @@ sequence:
    **Division of labor:** ORCHESTRATOR = create the GH release + ping vjt with
    (tag, URL, 2-line highlight), and write + push the news entry whenever he
    hands that lane over. vjt = the call on whether he writes the copy himself.
-5. **Dual-net announce** (#grappa on Azzurra + Libera via the ircbot) + `gh issue
-   close` the closed-at-release issues + strip their `status:soon`.
+5. **Dual-net announce** (#grappa on Azzurra + Libera via the ircbot).
+   **There is no issue-closing pass at the release** (#1632, vjt 2026-08-20:
+   *"si chiudiamo al merge"*): every issue in the cut was already closed when its
+   change merged. So there is no `gh issue close` sweep, no `status:soon` to
+   strip, and **no closing comment naming the release** — at the merge the tag did
+   not exist yet, so a merge-closed issue names no release at all. That is an
+   accepted price, not an oversight.
+   🔴 **This step is where the duty survives.** The 2026-08-04 standing order was
+   *reworded, not repealed*: a self-hoster still has to be told **which tag to
+   pull**, and now **the tag and its release notes are what tell them** — this
+   cut, not a per-issue comment. ⚠️ **The milestone does NOT carry that** (vjt,
+   2026-08-21): it is a **PLANNING** label saying which release the work is
+   *intended* for, an intention that can still change because he dogfoods on
+   staging first. Never quote a milestone as evidence that code is in a tag.
+   The multi-leg caveat (#96: one leg of three shipped, the issue stays open)
+   moved with the close, to `docs/ISSUE_PIPELINE.md` → *Label state machine*.
    ⚠️ **A TAG-ONLY release (no deploy) does NOT get the "we shipped" announce** —
    nothing changed for a user of the hosted instance, and saying otherwise is
    simply false. What is worth one line is that self-hosters have a tag to pull.
-   🔴 **Not every `status:soon` issue is DONE.** #96 shipped one leg of three in
-   v0.12.0 and vjt said explicitly the rest stays open: at the sweep it got the
-   release comment and its label stripped, but was NOT closed. Check each one.
 
 ### The published release image (ghcr.io) — #503 unit C
 


### PR DESCRIPTION
Applies vjt's two #1632 rulings, plus the 2026-08-21 correction to what a
milestone means. Docs + the orchestrate skill only — no code.

## Ruling 1 — picking is absolute FIFO

`2. Similarity → group` sat ABOVE the FIFO rule in `docs/ISSUE_PIPELINE.md` and
legitimised skipping the queue whenever the next issue looked adjacent to what
just shipped. Deleted; survivors renumbered; the deletion recorded in place so
the rule does not grow back. The `orchestrator applies these itself / escalates
only for genuine ambiguity` clause is unchanged.

`.claude/skills/orchestrate/SKILL.md` restated the same three tiers from memory
(`P0 first / … then similarity-group, else lowest number`). Corrected too —
otherwise the documentation would be new and the behaviour old.

## Ruling 2 — `status:soon` dies, issues close at MERGE

Four states become three: `queued → cooking → closed at the MERGE`. Measured at
the label's removal: 75 open `status:soon` issues, 71 already in milestone 1.3,
zero ever closed in the repo's history.

**What a milestone is, stated carefully.** It is a **PLANNING** label — which
release the work is *intended* for, an intention that can still change because
vjt dogfoods on staging before committing to a release. It is **not** evidence
that code is in a tag. So the 2026-08-04 standing order (every issue closed at a
release names that release, so a self-hoster knows which tag to pull) is
**reworded, not repealed**: the duty now lands at the **release cut**, on the tag
and its release notes.

The honest corollary is written down rather than hidden: **a merge-closed issue
names no release**, because at the merge no tag exists yet. Accepted price.

**Deliberately left unspecified:** when a milestone is assigned, and when it may
be moved. vjt has not given that rule, so nothing here invents one.

The #96 caveat is not repealed either — it **moves** with the close. A merge
covering one leg of a multi-part issue does not close it; epics close leg by leg.
It now sits beside the state machine instead of at release-cut time in
`OPERATIONS.md`.

## Four files, not three

The issue's table lists three. A grep for the machine found a fourth:
`.claude/skills/orchestrate/lib/board-check.sh` — the drift guard the
orchestrator runs at every resume — still queried `status:soon`. Its snapshot
column becomes a **drift check**: nothing sets that label now, so an OPEN issue
still carrying one is drift.

## Deliberately NOT touched

- The grappa.chat WIP board — other repo, filed as `vjt/grappa-www#6`.
- The `status:soon` label on GitHub — deleting it is an irreversible action on
  the public repo, and vjt's call.
- Milestone re-labelling on any issue, open or closed.
- Merge ≠ deploy: the deploy-batching gate, the CI-green-before-ship gate and the
  night-cold-deploy window are all untouched.
- Historic `docs/DESIGN_NOTES.md` entries that mention `cooking → soon` — the
  decision log is a chronological record of what was true then.

## Gates

- `scripts/bats.sh` — **633/633 ok, 0 `not ok`, rc 0** (plan line `1..633`
  agrees; no skips).
- `shellcheck -x` on the modified script: 4 findings, all pre-existing (lines 42,
  53, 60, 64), none in the added block. Note that `scripts/shellcheck.sh` derives
  its set from `bin/ infra/ scripts/` only, so `.claude/**` scripts are outside
  the lint gate entirely.
- No Elixir and no cic touched, so `mix ci.check` and the wire-types drift gate
  have nothing to say here.
- ⚠️ **This PR will get FEWER checks than a code PR.** Verified against
  `.github/workflows/integration.yml`: its `paths:` filter lists `lib/**`,
  `cicchetto/src/**`, `config/**`, `priv/**`, three named scripts, the manifests,
  `Dockerfile`, `compose.yaml`, `VERSION` — and matches neither `docs/**` nor
  `.claude/**`. `integration` will not run. `ci.yml` has no `paths:` filter and
  will. Do not read a green here as equivalent to a code PR's green.