### PR TITLE
arch(#1398): make Session.Backoff a leaf, and let the compiler count

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -56110,3 +56110,99 @@ leaker was identified by CONSTRUCTION (which fixtures return without waiting
 for the session to be dead) and the fix is gated by mutants rather than by a
 red turning green. A green run of the victim suite was never evidence of
 absence, in either direction.
+<!-- entry #1398b -->
+
+---
+
+## 2026-08-21 — #1398b: Session.Backoff becomes a leaf boundary, and the compiler corrects the census that proposed it
+
+#1398 §7 proposed promoting `Grappa.Session.Backoff` to `use Boundary,
+top_level?: true, deps: []` — the pattern #415, #1398 and #1399 set for the
+identity schemas. It is landed here as an annotation change: no module moved,
+no code moved, eight files touched and all of them boundary declarations.
+
+The §7 analysis said plainly what it was: *"nothing outside §1 was compiled"* —
+arithmetic on a hand-built graph, with arcs added and cut by hand. So the
+compiler was run as the gate (Boundary sits in `compilers:`), and it corrected
+the census twice.
+
+### `deps: []` is measured, not assumed
+
+`backoff.ex` makes exactly seven in-app references and all seven are
+`Session.subject()` in a `@spec`/`@typep`. A type name is a module atom in
+metadata, so the xref checker sees no edge — the same rule that lets
+`Networks.Credential` alias three modules and declare none of them. Everything
+the body calls is stdlib: `Application.compile_env`, `Bitwise`, `Enum`,
+`GenServer`, `System`, `:ets`.
+
+### The blast radius: SIX boundaries, not the five the census named
+
+Promote, add nothing, read `compile --force --warnings-as-errors`. Nine
+forbidden references across six boundaries:
+
+| boundary | sites | outcome |
+|---|---|---|
+| `Grappa.Health` | `health.ex:156` | **narrowed** — `Grappa.Session` → `Grappa.Session.Backoff` |
+| `Grappa.AdmissionStateHelpers` | `admission_state_helpers.ex:180` | **narrowed** |
+| `Grappa.Networks` | `networks/session_plan.ex:197` | added; keeps `Session` |
+| `Grappa.SpawnOrchestrator` | `spawn_orchestrator.ex:277,288` | added; keeps `Session` |
+| `Grappa.Visitors` | `visitors.ex:846`, `login.ex:642`, `session_plan.ex:289` | added; keeps `Session` |
+| `Grappa.TestSupport.SubjectReset` | `subject_reset.ex:320` | added; keeps `Session` |
+
+`Grappa.Session` itself moves `Backoff` out of `exports:` and into `deps:` —
+`Session.Server` makes four `Backoff.*` calls, so the leaf it used to contain
+is now a sibling it must declare.
+
+**Correction 1 — the test-support boundary the census could not see.**
+`Grappa.AdmissionStateHelpers` appears in no §7 table. It surfaces ONLY under
+`--env=test`: `MIX_ENV=dev` never compiles `test/support`, so a dev-only run
+under-counts by exactly the test-support boundaries, silently. Both envs were
+run for that reason.
+
+**Correction 2 — `SubjectReset` does NOT reference `Session` through `Backoff`
+alone.** §7 names it as one of the two boundaries that shed their whole
+`X → Session` edge. Measured: `respawn_connected/5` calls
+`Session.stop_session/2` at `subject_reset.ex:339`, so it keeps the context dep
+and merely gains the leaf. Exactly ONE boundary in the repo — `Grappa.Health` —
+loses its session edge in `lib/`, plus `AdmissionStateHelpers` in
+`test/support`.
+
+### What it buys: zero cycles, and §7 said so first
+
+Neither `Health` nor `AdmissionStateHelpers` sits in the SCC, so all 13 runtime
+cycles survive. The gain is shape: a supervised child that shares nothing with
+session orchestration stops being reachable through it, and `Health` now
+declares the one ETS-owning module it names instead of the whole session
+context. §7's own table is the honest counterweight — the highest-leverage
+single arc is `LiveIntrospection → Session` at 6 of 13, and that is not this
+work.
+
+### Positive control, because a green boundary run proves nothing by itself
+
+`def __boundary_control__, do: Grappa.Session.stop_session({:user, 1}, 1)`
+inserted into `Grappa.Health` compiles **RED** after this change
+(`forbidden reference to Grappa.Session ... health.ex:182`) and would have
+compiled **GREEN** before it, when `Health` declared the whole context. The
+narrowing bites. The nine forbidden references the bare promotion produced are
+the matching control for the leaf itself: the checker had a known answer and
+gave it.
+
+### Carve-out, restated because it is a price and not an accident
+
+The leaf keeps the nested name `Grappa.Session.Backoff` while being a SIBLING of
+`Grappa.Session` in the graph. Boundary's docs discourage that mismatch and
+offer a rename; declined on vjt's 2026-08-20 ruling — a rename moves modules and
+beams, which forces a COLD deploy, to buy a naming nicety. The price is a reader
+guessing the owner from the name.
+
+### Not established
+
+- **`Grappa.Session.Control`.** #1398's other half is untouched and out of
+  scope: as written it does not compile, and the version that works moves five
+  boundaries.
+- **Dialyzer.** Not run. The change adds no function, alters no signature and
+  moves no code; a cold PLT on a fresh cache id was judged disproportionate to
+  that. Stated rather than implied.
+- **Whether any boundary would now be caught that a source scan would miss.**
+  The control proves the mechanism on `Health`; it was not repeated per
+  boundary.

--- a/lib/grappa/health.ex
+++ b/lib/grappa/health.ex
@@ -45,7 +45,11 @@ defmodule Grappa.Health do
       # reviewer LOW-1) — single-sourced, so renaming the @table atom in
       # any of them surfaces a Health check failure on next deploy rather
       # than silently diverging here.
-      Grappa.Session,
+      # #1398 §7 — NARROWED, not added: measured, Health's only code reference
+      # into `Grappa.Session` was `Backoff.table_name()` at `:156`. Now that the
+      # leaf is its own boundary, declaring the whole session context would hand
+      # Health every session verb to name one ETS table.
+      Grappa.Session.Backoff,
       Grappa.Admission,
       Grappa.Net.PtrCache
     ]

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -65,6 +65,10 @@ defmodule Grappa.Networks do
       Grappa.Networks.Network,
       Grappa.Networks.Server,
       Grappa.Session,
+      # #1398 §7 — added alongside `Grappa.Session`, not instead of it:
+      # `SessionPlan` reads `Backoff.failure_count/2`, but this boundary makes
+      # nine other references into the session context.
+      Grappa.Session.Backoff,
       Grappa.Subject,
       Grappa.Vault,
       Grappa.Vhosts,

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -90,6 +90,11 @@ defmodule Grappa.Session do
       Grappa.Push,
       Grappa.QueryWindows,
       Grappa.Scrollback,
+      # #1398 §7 — `Backoff` was an EXPORT of this boundary; it is now a leaf
+      # of its own, so `Session.Server`'s four `Backoff.*` calls need it as a
+      # dep like any other sibling. A leaf that leaves `exports:` enters
+      # `deps:` — the same trade #1399 made for the identity schemas.
+      Grappa.Session.Backoff,
       Grappa.SessionLog,
       Grappa.Subject,
       Grappa.Notify,
@@ -102,7 +107,7 @@ defmodule Grappa.Session do
     # secret the on-wire `SET PASSWD` rotates, and both must refuse exactly
     # what Azzurra's services refuse. Sharing the one chain beats a copy that
     # drifts. It is a pure module with no process or state behind it.
-    exports: [Backoff, NSInterceptor, Server, Wire]
+    exports: [NSInterceptor, Server, Wire]
 
   alias Grappa.IRC.{AuthFSM, CTCP, Identifier}
   alias Grappa.Session.{Deps, FloodAllowance, ISupport, Server}

--- a/lib/grappa/session/backoff.ex
+++ b/lib/grappa/session/backoff.ex
@@ -142,6 +142,28 @@ defmodule Grappa.Session.Backoff do
   failure_count}/2`) MUST stay `async: false` so the same constraint
   applies even if `max_cases` is later relaxed for a faster lane.
   """
+  # #1398 §7 — a leaf boundary, on the pattern #415 / #1398 / #1399 set for the
+  # identity schemas. `deps: []` is MEASURED, not assumed: this module's only
+  # in-app references are seven `Session.subject()` typespecs, and a type name
+  # is a module atom in metadata, so the xref checker sees no edge. Everything
+  # it calls at runtime is stdlib (`Application`, `Bitwise`, `Enum`,
+  # `GenServer`, `System`, `:ets`, `:telemetry`).
+  #
+  # The carve-out is the one vjt accepted in #1523: the leaf keeps the nested
+  # name `Grappa.Session.Backoff` while being a SIBLING of `Grappa.Session` in
+  # the graph. Boundary's docs discourage that mismatch and offer a rename; the
+  # rename moves modules and beams, which means a COLD deploy, to buy a naming
+  # nicety. Declined knowingly — the price is a reader guessing the owner from
+  # the name.
+  #
+  # Honest about what it buys: **zero cycles.** A boundary sheds its
+  # `X → Session` edge only if EVERY reference it makes into `Session` is a
+  # `Backoff` one, and only `Grappa.Health` and `Grappa.TestSupport.SubjectReset`
+  # qualify — neither is in the SCC, so all 13 runtime cycles survive. The gain
+  # is shape: a supervised child that shares nothing with the session
+  # orchestration stops being reachable through it.
+  use Boundary, top_level?: true, deps: []
+
   use GenServer
 
   alias Grappa.Session

--- a/lib/grappa/spawn_orchestrator.ex
+++ b/lib/grappa/spawn_orchestrator.ex
@@ -218,7 +218,10 @@ defmodule Grappa.SpawnOrchestrator do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Admission, Grappa.Session]
+    # #1398 §7 — `Grappa.Session` STAYS: `Backoff.reset/2` is two of this
+    # boundary's five references into the session context, so the leaf is an
+    # addition here, not a narrowing.
+    deps: [Grappa.Admission, Grappa.Session, Grappa.Session.Backoff]
 
   alias Grappa.{Admission, Session}
   alias Grappa.Session.Backoff

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -80,6 +80,11 @@ if Mix.env() in [:dev, :test] do
         Grappa.Repo,
         Grappa.Scrollback,
         Grappa.Session,
+        # #1398 §7 — `Grappa.Session` STAYS, correcting the issue's §7 census:
+        # it lists this module as one of the two boundaries whose ONLY session
+        # reference is `Backoff`, but `respawn_connected/5` calls
+        # `Session.stop_session/2` (`:339`). So the leaf is an addition.
+        Grappa.Session.Backoff,
         Grappa.TestSupport.SubjectSession,
         Grappa.Uploads,
         Grappa.UserSettings,

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -72,6 +72,10 @@ defmodule Grappa.Visitors do
       Grappa.Networks.Network,
       Grappa.Repo,
       Grappa.Session,
+      # #1398 §7 — added alongside `Grappa.Session`: three `Backoff` references
+      # (`visitors.ex` forget, `login.ex` reset, `session_plan.ex`
+      # failure_count) against five others into the session context.
+      Grappa.Session.Backoff,
       Grappa.SpawnOrchestrator,
       Grappa.Subject,
       Grappa.Themes,

--- a/test/support/admission_state_helpers.ex
+++ b/test/support/admission_state_helpers.ex
@@ -58,7 +58,13 @@ defmodule Grappa.AdmissionStateHelpers do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Admission, Grappa.AdminEvents, Grappa.Session]
+    # #1398 §7 — NARROWED to the leaf: this helper's only code reference into
+    # `Grappa.Session` is `Backoff` (the `Grappa.Session{Registry,Supervisor}`
+    # names it passes to `Registry`/`DynamicSupervisor` are process names, not
+    # modules of that boundary). It surfaces ONLY under `--env=test`, because
+    # `MIX_ENV=dev` never compiles `test/support` — the issue's §7 census never
+    # saw it.
+    deps: [Grappa.Admission, Grappa.AdminEvents, Grappa.Session.Backoff]
 
   alias Grappa.AdminEvents
   alias Grappa.Admission.NetworkCircuit


### PR DESCRIPTION
#1398 **§7 only**. `Grappa.Session.Control` is deliberately untouched — as
written it does not compile, and the version that works moves five boundaries.

## The change

`Grappa.Session.Backoff` becomes `use Boundary, top_level?: true, deps: []`,
the pattern #415 / #1398 / #1399 set for the identity schemas. No module moves,
no code moves: eight files, every hunk a boundary declaration.

`deps: []` is **measured**. The module makes exactly seven in-app references and
all seven are `Session.subject()` in a `@spec`/`@typep` — a type name is a
module atom in metadata, so the xref checker sees no edge. The body calls only
stdlib (`Application.compile_env`, `Bitwise`, `Enum`, `GenServer`, `System`,
`:ets`).

## The compiler was the gate, and it corrected §7 twice

§7 states its own limit — *"nothing outside §1 was compiled"*, arithmetic on a
hand-built graph. Promote, add nothing, read
`compile --force --warnings-as-errors`: **nine forbidden references across six
boundaries.**

| boundary | sites | outcome |
|---|---|---|
| `Grappa.Health` | `health.ex:156` | **narrowed** — `Grappa.Session` → `Grappa.Session.Backoff` |
| `Grappa.AdmissionStateHelpers` | `admission_state_helpers.ex:180` | **narrowed** |
| `Grappa.Networks` | `networks/session_plan.ex:197` | added; keeps `Session` |
| `Grappa.SpawnOrchestrator` | `spawn_orchestrator.ex:277,288` | added; keeps `Session` |
| `Grappa.Visitors` | `visitors.ex:846`, `login.ex:642`, `session_plan.ex:289` | added; keeps `Session` |
| `Grappa.TestSupport.SubjectReset` | `subject_reset.ex:320` | added; keeps `Session` |

**Correction 1 — six boundaries, not five.** `Grappa.AdmissionStateHelpers`
appears in no §7 table. It lives in `test/support`, which `MIX_ENV=dev` never
compiles, so it surfaces **only** under `--env=test`. Both envs were run for
exactly this reason.

**Correction 2 — `SubjectReset` keeps its `Session` dep.** §7 names it as one of
the two boundaries whose every session reference is a `Backoff` one. Measured:
`respawn_connected/5` calls `Session.stop_session/2` at `subject_reset.ex:339`.
So exactly **one** boundary in `lib/` sheds its session edge — `Grappa.Health` —
plus `AdmissionStateHelpers` in `test/support`.

`Grappa.Session` moves `Backoff` out of `exports:` and into `deps:`:
`Session.Server` makes four `Backoff.*` calls, so the leaf it used to contain is
now a sibling it must declare.

## What it buys: zero cycles — §7 said so first

Neither boundary that sheds the edge is in the SCC, so all 13 runtime cycles
survive. The gain is shape. §7's own table is the honest counterweight: the
highest-leverage single arc is `LiveIntrospection → Session` at 6 of 13, and
that is not this work.

## Positive control

A green boundary run proves nothing by itself, so:

```elixir
def __boundary_control__, do: Grappa.Session.stop_session({:user, 1}, 1)
```

inserted into `Grappa.Health` compiles **RED** after this change
(`forbidden reference to Grappa.Session … health.ex:182`, rc 1) and would have
compiled **GREEN** before it, when `Health` declared the whole context. Reverted
before commit. The nine forbidden references the bare promotion produced are the
matching control for the leaf itself — the checker had a known answer and gave
it.

## Carve-out (a price, not an accident)

The leaf keeps the nested name `Grappa.Session.Backoff` while being a SIBLING of
`Grappa.Session` in the graph. Boundary's docs discourage that and offer a
rename; declined on vjt's 2026-08-20 ruling — a rename moves modules and beams,
forcing a COLD deploy, to buy a naming nicety.

## Gates (fresh `GRAPPA_CACHE_ID=w1-1398`, cold)

| gate | result |
|---|---|
| `compile --force --warnings-as-errors` `--env=dev` | **rc 0**, 0 forbidden references |
| `compile --force --warnings-as-errors` `--env=test` | **rc 0**, 0 forbidden references |
| `scripts/test.sh` | **rc 0** — 8 doctests, 61 properties, **6665 tests, 0 failures** |
| `mix credo --strict` | **rc 0** — 6111 mods/funs, no issues |
| `mix format --check-formatted` | **rc 0** |
| `scripts/design-notes-gate.sh` | **rc 0** — 1 new entry, separator + marker present |
| `scripts/union-rebase.sh` | **rc 0** — `DESIGN_NOTES.md +96 -0`, numstat byte-identical before/after |

**Not run: Dialyzer.** The change adds no function, alters no signature and
moves no code; a cold PLT build on a fresh cache id was judged disproportionate.
Stated rather than implied.

**Baseline caveat, stated:** the `--env=dev` baseline was captured green on the
unmodified tree (rc 0). The `--env=test` baseline run overlapped my edits, so it
is not a clean baseline — but the final `--env=test` compile is green, which
rules out a pre-existing red more directly than a baseline would.