### PR TITLE
test(#1646): pin the e2e mirrors of six exported production constants

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -576,11 +576,17 @@ export async function waitForQueryWindowReady(
   );
 }
 
-// Mirror of `cicchetto/src/lib/channelKey.ts:canonicalChannel` — the e2e
-// tree MIRRORS src, never imports it (separate build context; see
-// fixtures/push.ts). MUST stay byte-identical to the src twin, or the
-// composite key this rebuilds won't match the one subscribe.ts stamped
-// into `__cic_channelReady`.
+// Mirror of `cicchetto/src/lib/channelKey.ts:canonicalChannel` — the e2e tree
+// MIRRORS src rather than importing its VALUES, to keep the runner's runtime
+// graph free of the app's (see the header of fixtures/grappaApi.ts, and
+// fixtures/push.ts). "Never imports it" is what this comment said until #1646
+// and it is not true: grappaApi.ts type-imports from `src/lib/wireTypes`, a
+// plain relative import that resolves and typechecks under e2e/tsconfig.json.
+// MUST stay byte-identical to the src twin, or the composite key this rebuilds
+// won't match the one subscribe.ts stamped into `__cic_channelReady`.
+//
+// This one is a FUNCTION, so #1646's constant pin cannot watch it — the drift
+// below was found by hand, and would be again.
 //
 // #973 — this mirror had drifted two ways and was silently rebuilding keys
 // nothing had stamped. It was still the PRE-#537 shape: sigil-gated (a nick

--- a/cicchetto/e2e/fixtures/push.ts
+++ b/cicchetto/e2e/fixtures/push.ts
@@ -194,9 +194,12 @@ export async function resetPushCatcher(): Promise<void> {
  * `Grappa.UserSettings.default_notification_prefs/0` AND
  * `cicchetto/src/lib/userSettings.ts:DEFAULT_NOTIFICATION_PREFS`.
  *
- * Re-importing from `cicchetto/src/lib/userSettings.ts` would require
- * a path alias in `cicchetto/e2e/tsconfig.json` and a transitive
- * import of solid-router types — heavier than this small literal.
+ * Re-importing from `cicchetto/src/lib/userSettings.ts` would pull in a
+ * transitive import of solid-router types — heavier than this small literal.
+ * (It would NOT need "a path alias in `cicchetto/e2e/tsconfig.json`", which is
+ * what this comment claimed until #1646: `grappaApi.ts` reaches `src` with a
+ * plain relative import and no alias. The dependency graph is the reason; the
+ * module resolution never was.)
  * The drift class is real but bounded: a new pref key would silently
  * keep writing the old shape AND break cic's TypeScript at the same
  * time; the latter is the loud failure mode.

--- a/cicchetto/e2e/tests/channel-directory.spec.ts
+++ b/cicchetto/e2e/tests/channel-directory.spec.ts
@@ -32,9 +32,13 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded
-// here because the e2e tsconfig does not resolve src/ imports. A
-// rename of the constant must be propagated to this file manually.
+// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts, mirrored rather than
+// imported to keep src VALUES out of the e2e runtime graph (see the header of
+// fixtures/grappaApi.ts). NOT because "the e2e tsconfig does not resolve src/
+// imports", which is what this comment said until #1646 and is false: that same
+// fixture type-imports from src and `tsc -p e2e/tsconfig.json` is green.
+// The copy is pinned — src/__tests__/e2eConstantMirrors.test.ts fails if either
+// side moves.
 const LIST_WINDOW_NAME = "$list";
 
 // Unique channel per run: avoids persistent state bleed across

--- a/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
@@ -61,8 +61,13 @@ const FILLER =
 // measured is unchanged: the caret's geometry after an append.
 //
 // Hardcoded in lockstep with `REPLY_QUOTE_BODY_LIMIT` / `REPLY_QUOTE_ELLIPSIS`
-// in `src/lib/replyQuote.ts` — the e2e package does not import from `src`, and
-// the house convention here is a mirrored constant with a lockstep comment.
+// in `src/lib/replyQuote.ts`: the house convention is a mirrored constant, so
+// that src VALUES stay out of the e2e runtime graph (fixtures/grappaApi.ts).
+// The e2e package DOES import from `src` — one type-only import, in that same
+// fixture — so "does not import from src", which this comment said until #1646,
+// was false. `QUOTED_BODY_LIMIT` is pinned to the production constant by
+// src/__tests__/e2eConstantMirrors.test.ts; `REPLY_QUOTE_ELLIPSIS` is not
+// mirrored here as a constant and so is not pinned.
 const QUOTED_BODY_LIMIT = 100;
 const QUOTED_ELLIPSIS = "...";
 const REPLIES = 3;
@@ -74,10 +79,11 @@ function cappedQuotedBody(body: string): string {
     : chars.slice(0, QUOTED_BODY_LIMIT).join("") + QUOTED_ELLIPSIS;
 }
 
-// Hardcoded in lockstep with `REPLY_QUOTE_TAIL` in `src/lib/replyQuote.ts`,
-// the same convention as the two constants above and for the same reason:
-// `e2e/tsconfig.json` spans `e2e/` only, so no spec in this suite imports from
-// `src`.
+// Hardcoded in lockstep with `REPLY_QUOTE_TAIL` in `src/lib/replyQuote.ts`, the
+// same convention as the two constants above and for the same reason. The reason
+// is the runtime graph, not the tsconfig: `e2e/tsconfig.json` spans `e2e/` only,
+// but a relative import out of it resolves and typechecks all the same (#1646).
+// Pinned by src/__tests__/e2eConstantMirrors.test.ts.
 const REPLY_QUOTE_TAIL = " << ";
 
 // What the draft holds after `replies` swipes on the same row. #1357: vjt

--- a/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
+++ b/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
@@ -97,6 +97,10 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // `isFarBehind` already draws the line at. Mirrored rather than imported: the
 // e2e bundle is the built app, and a spec that imported the source constant
 // would keep passing if the shipped bundle disagreed with it.
+//
+// #1646 — src/__tests__/e2eConstantMirrors.test.ts pins this copy to the
+// production constant, which is DERIVED (`= PAGE_LIMIT`): the number can move
+// from a module this comment does not name, and until that pin nothing noticed.
 const UNREAD_BOUND = 200;
 
 // Enough history that the pane has a read context to be scrolled up INTO,

--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -59,9 +59,10 @@ import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded here
-// because the e2e tsconfig does not resolve src/ imports; a rename must be
-// propagated by hand, as in every other spec that opens this window.
+// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts, mirrored rather than
+// imported to keep src VALUES out of the e2e runtime graph (fixtures/grappaApi.ts).
+// NOT because the e2e tsconfig cannot resolve src/ — it can, and that fixture
+// proves it (#1646). Pinned by src/__tests__/e2eConstantMirrors.test.ts.
 const LIST_WINDOW_NAME = "$list";
 
 // PULL_COMMIT_PX from src/lib/pullGesture.ts (SWIPE_MIN_PX * 2). Hardcoded for
@@ -69,6 +70,10 @@ const LIST_WINDOW_NAME = "$list";
 // drags half of it and asserts the paint moved by that much, and the paint is
 // capped at the real constant. Lower the real one and this spec reads the cap
 // instead of the drag and goes red, naming the drift.
+//
+// #1646 adds a static second witness that needs no testnet, and it watches the
+// number this comment does NOT name: the production side is DERIVED, so moving
+// `SWIPE_MIN_PX` in src/lib/swipe.ts moves the cap while leaving 80 here.
 const PULL_COMMIT_PX = 80;
 
 // Open the directory pane and hand back its two moving parts.

--- a/cicchetto/e2e/tests/issue220-link-double-fire.spec.ts
+++ b/cicchetto/e2e/tests/issue220-link-double-fire.spec.ts
@@ -30,8 +30,10 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded
-// here because the e2e tsconfig does not resolve src/ imports.
+// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts, mirrored rather than
+// imported to keep src VALUES out of the e2e runtime graph (fixtures/grappaApi.ts).
+// NOT because the e2e tsconfig cannot resolve src/ — it can, and that fixture
+// proves it (#1646). Pinned by src/__tests__/e2eConstantMirrors.test.ts.
 const LIST_WINDOW_NAME = "$list";
 
 // A cross-host URL the linkifier turns into an <a>. Stubbed via a context

--- a/cicchetto/e2e/tests/issue244-directory-tap-foreground.spec.ts
+++ b/cicchetto/e2e/tests/issue244-directory-tap-foreground.spec.ts
@@ -27,9 +27,10 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded here
-// because the e2e tsconfig does not resolve src/ imports. A rename of the
-// constant must be propagated to this file manually.
+// "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts, mirrored rather than
+// imported to keep src VALUES out of the e2e runtime graph (fixtures/grappaApi.ts).
+// NOT because the e2e tsconfig cannot resolve src/ — it can, and that fixture
+// proves it (#1646). Pinned by src/__tests__/e2eConstantMirrors.test.ts.
 const LIST_WINDOW_NAME = "$list";
 
 test.describe("#244 directory tap foregrounds the joined window", () => {

--- a/cicchetto/e2e/tests/issue276-away-emoji-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue276-away-emoji-badge.spec.ts
@@ -33,6 +33,11 @@ import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// `SERVER_WINDOW_NAME` in src/lib/windowKinds.ts, mirrored rather than imported
+// to keep src VALUES out of the e2e runtime graph (fixtures/grappaApi.ts).
+// Pinned by src/__tests__/e2eConstantMirrors.test.ts (#1646) — it carried no
+// note at all until then, which is how a copy stops being recognised as one.
 const SERVER_WINDOW = "$server";
 
 // 60s — login + channel seed + two AWAY round-trips against the real

--- a/cicchetto/e2e/tests/issue677-directory-pagination.spec.ts
+++ b/cicchetto/e2e/tests/issue677-directory-pagination.spec.ts
@@ -24,8 +24,10 @@ import { loginAs, sidebarWindow } from "../fixtures/cicchettoPage";
 import { NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-// LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded — the e2e
-// tsconfig does not resolve src/ imports; a rename must be mirrored here.
+// LIST_WINDOW_NAME from src/lib/windowKinds.ts, mirrored rather than imported to
+// keep src VALUES out of the e2e runtime graph (fixtures/grappaApi.ts). NOT
+// because the e2e tsconfig cannot resolve src/ — it can, and that fixture proves
+// it (#1646). Pinned by src/__tests__/e2eConstantMirrors.test.ts.
 const LIST_WINDOW_NAME = "$list";
 
 const CAPTURED_AT = "2026-08-02T12:00:00Z";

--- a/cicchetto/e2e/tests/m12-motd-server-window-routes-notice.spec.ts
+++ b/cicchetto/e2e/tests/m12-motd-server-window-routes-notice.spec.ts
@@ -28,6 +28,10 @@ import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
+// `SERVER_WINDOW_NAME` in src/lib/windowKinds.ts, mirrored rather than imported
+// to keep src VALUES out of the e2e runtime graph (fixtures/grappaApi.ts).
+// Pinned by src/__tests__/e2eConstantMirrors.test.ts (#1646) — it carried no
+// note at all until then, which is how a copy stops being recognised as one.
 const SERVER_CHANNEL = "$server";
 
 // Match the testnet's leaf hostnames — leaf4.azzurra.chat | leaf6.azzurra.chat

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -1,0 +1,299 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PULL_COMMIT_PX } from "../lib/pullGesture";
+import { REPLY_QUOTE_BODY_LIMIT, REPLY_QUOTE_TAIL } from "../lib/replyQuote";
+import { UNREAD_RETENTION_CAP } from "../lib/scrollback";
+import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "../lib/windowKinds";
+
+// #1646 — the e2e tree hand-copies production constants, and until this file
+// nothing compared a copy with its original.
+//
+// The copies are deliberate: `e2e/` is its own package (`e2e/package.json`,
+// playwright-only) and `fixtures/grappaApi.ts` spells out why the ONE import it
+// allows itself is type-only — a value import would reach the solid-js
+// dependency graph that keeps the runner image a pure REST/IRC client. The
+// mirroring is not the defect. The defect is that "kept in lockstep by hand"
+// had no witness: every one of the declarations below could be edited, or its
+// original could move, and every gate in the repo stayed green.
+//
+// So the pin reads the e2e declaration as TEXT and compares it with the
+// production constant IMPORTED here. The two sides come from genuinely
+// different places — a module import and a file the test never imports — which
+// is what makes the comparison able to fail. It fails in both directions:
+// change production and the import moves while the text does not; change the
+// copy and the text moves while the import does not.
+//
+// This lives in `src/__tests__/` rather than in `e2e/fixtures/` (which the
+// vitest lane also collects) precisely BECAUSE of the rule it is guarding: a
+// pin in `e2e/` would have to import src values, which is the edge the e2e
+// package refuses. Reading the spec files as text creates no import edge at
+// all. Sibling of `biomePin.test.ts` / `moduleRootGuard.test.ts` /
+// `versionSource.test.ts` — vitest runs from the cicchetto dir, so both `src`
+// and `e2e` are at cwd.
+//
+// ⚠️ SCOPE, and it is narrow. #1646 measured 13 production constants copied
+// into 53 e2e declarations. Pinned here: the 6 whose production side is
+// TypeScript and ALREADY exported — 11 declarations. The other 7 are not
+// pinnable without a decision that is not this file's to take:
+//   - 5 are module-private in production (`SCROLL_BOTTOM_THRESHOLD_PX`,
+//     `LOAD_MORE_THRESHOLD_PX`, `PUSH_OPTIN_DECLINED_KEY`, `SHORT_HASH_LEN`,
+//     `AWAY_SET_LINE`) — 25 declarations, the two largest clusters among them.
+//     Exporting a constant to be testable, or moving it into `lib/`, is a
+//     product call.
+//   - 2 are Elixir module attributes (`MessagesController.@default_limit` and
+//     `@max_http_limit`) — 17 declarations. There is precedent for shipping a
+//     server number to the client mechanically (`mix grappa.gen_wire_types`
+//     with the drift gate in `scripts/check.sh`), and picking it is likewise a
+//     product call.
+// Neither is worked around here. A pin over an exported constant is the part
+// that needed no permission.
+//
+// ⚠️ What this CANNOT do: it cannot find a mirror that has ALREADY drifted.
+// Every declaration below was found because the two sides carry the same
+// literal today. A copy that already disagrees with production is invisible to
+// the census that produced this table, and adding it here is the only way it
+// enters. `KNOWN_UNPINNED` names the one set where that question is open.
+
+/** A hand-copied e2e declaration and the production constant it mirrors. */
+type Mirror = {
+  /** e2e file, relative to the cicchetto dir. */
+  readonly file: string;
+  /** The name the e2e side gives it — often NOT the production spelling. */
+  readonly name: string;
+  /** The production value, imported. Derived values arrive already computed. */
+  readonly production: string | number;
+  /** Where production defines it, for the failure message. */
+  readonly origin: string;
+};
+
+const MIRRORS: readonly Mirror[] = [
+  // `$list` — the channel-directory pseudo-window (#84).
+  ...[
+    "e2e/tests/channel-directory.spec.ts",
+    "e2e/tests/issue1445-directory-pull-refresh.spec.ts",
+    "e2e/tests/issue220-link-double-fire.spec.ts",
+    "e2e/tests/issue244-directory-tap-foreground.spec.ts",
+    "e2e/tests/issue677-directory-pagination.spec.ts",
+  ].map(
+    (file): Mirror => ({
+      file,
+      name: "LIST_WINDOW_NAME",
+      production: LIST_WINDOW_NAME,
+      origin: "LIST_WINDOW_NAME (src/lib/windowKinds.ts)",
+    }),
+  ),
+
+  // `$server` — the synthetic per-network server window. Two spellings on the
+  // e2e side for one production constant, which is itself part of why the
+  // lockstep needs a machine: a grep for the production NAME finds neither.
+  {
+    file: "e2e/tests/issue276-away-emoji-badge.spec.ts",
+    name: "SERVER_WINDOW",
+    production: SERVER_WINDOW_NAME,
+    origin: "SERVER_WINDOW_NAME (src/lib/windowKinds.ts)",
+  },
+  {
+    file: "e2e/tests/m12-motd-server-window-routes-notice.spec.ts",
+    name: "SERVER_CHANNEL",
+    production: SERVER_WINDOW_NAME,
+    origin: "SERVER_WINDOW_NAME (src/lib/windowKinds.ts)",
+  },
+
+  {
+    file: "e2e/tests/issue1105-reply-quote-caret-visible.spec.ts",
+    name: "REPLY_QUOTE_TAIL",
+    production: REPLY_QUOTE_TAIL,
+    origin: "REPLY_QUOTE_TAIL (src/lib/replyQuote.ts)",
+  },
+  {
+    file: "e2e/tests/issue1105-reply-quote-caret-visible.spec.ts",
+    name: "QUOTED_BODY_LIMIT",
+    production: REPLY_QUOTE_BODY_LIMIT,
+    origin: "REPLY_QUOTE_BODY_LIMIT (src/lib/replyQuote.ts)",
+  },
+
+  // The two DERIVED ones, and the reason a value pin beats a name pin. Neither
+  // production side is a literal — `UNREAD_RETENTION_CAP = PAGE_LIMIT` and
+  // `PULL_COMMIT_PX = SWIPE_MIN_PX * 2` — so the number the e2e copy froze can
+  // be moved from a module the copy does not even name. Importing the constant
+  // pins the computed value, which is the one the product uses.
+  {
+    file: "e2e/tests/issue1229-unread-retention-bound.spec.ts",
+    name: "UNREAD_BOUND",
+    production: UNREAD_RETENTION_CAP,
+    origin: "UNREAD_RETENTION_CAP = PAGE_LIMIT (src/lib/scrollback.ts)",
+  },
+  {
+    file: "e2e/tests/issue1445-directory-pull-refresh.spec.ts",
+    name: "PULL_COMMIT_PX",
+    production: PULL_COMMIT_PX,
+    origin: "PULL_COMMIT_PX = SWIPE_MIN_PX * 2 (src/lib/pullGesture.ts)",
+  },
+];
+
+// Declarations that carry a PINNED NAME but no pin, each with the reason.
+//
+// `SERVER_WINDOW = "Server"` — six specs use the literal `"Server"` as a
+// window/channel name under the same identifier two specs give `"$server"`.
+// #1646 could not establish whether those six mirror a live production string,
+// a retired one, or nothing at all: the src side records the `"Server"` LABEL
+// as gone (`BottomBar.tsx`, `__tests__/Sidebar.test.tsx`) while
+// `__tests__/subscribe.test.ts` still passes it as a `channelName`. Pinning
+// them to `SERVER_WINDOW_NAME` would assert a fact nobody has measured, and
+// deleting them from the sweep silently would hide the question. They are
+// listed, so a SEVENTH one cannot appear without someone reading this.
+const KNOWN_UNPINNED: readonly { readonly file: string; readonly name: string }[] = [
+  { file: "e2e/tests/issue239-hidden-msg-unread.spec.ts", name: "SERVER_WINDOW" },
+  { file: "e2e/tests/issue267-mention-server-authoritative.spec.ts", name: "SERVER_WINDOW" },
+  { file: "e2e/tests/issue498-badge-follows-live-nick.spec.ts", name: "SERVER_WINDOW" },
+  { file: "e2e/tests/issue973-query-unread-badge-clears.spec.ts", name: "SERVER_WINDOW" },
+  { file: "e2e/tests/issue981-no-badge-at-tail.spec.ts", name: "SERVER_WINDOW" },
+  { file: "e2e/tests/m2-irssi-to-chan-defocused.spec.ts", name: "SERVER_WINDOW" },
+];
+
+/** A single-line `const`/`let NAME = <literal>` declaration, as written. */
+type Declaration = { readonly line: number; readonly literal: string };
+
+// Prose carries the history, and several comments quote the very declarations
+// this file reads. Same guard as `moduleRootGuard.test.ts`.
+const isProse = (line: string): boolean => {
+  const trimmed = line.trim();
+  return trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*");
+};
+
+/**
+ * Every single-line declaration of `name` in `src`, literal text unparsed.
+ *
+ * @spec declarationsOf(string, string) :: Declaration[] — empty when absent,
+ * which every caller treats as a failure rather than a pass.
+ */
+function declarationsOf(src: string, name: string): Declaration[] {
+  const pattern = new RegExp(`^\\s*(?:const|let)\\s+${name}\\s*(?::[^=]+)?=\\s*(.+?);?\\s*$`);
+  const found: Declaration[] = [];
+  src.split("\n").forEach((line, i) => {
+    if (isProse(line)) return;
+    const m = pattern.exec(line);
+    if (m?.[1] !== undefined) found.push({ line: i + 1, literal: m[1] });
+  });
+  return found;
+}
+
+/**
+ * The value of a mirror's literal.
+ *
+ * @spec parseLiteral(string) :: string | number | null — null for anything
+ * that is not a plain double-quoted string or a plain number. A mirror written
+ * as a template literal, an expression or a concatenation is NOT silently
+ * accepted: the caller fails and names the line, because a pin that shrugs at
+ * a shape it cannot read is a pin that stops covering a declaration the day
+ * someone reformats it.
+ */
+function parseLiteral(literal: string): string | number | null {
+  if (/^"(?:[^"\\]|\\.)*"$/.test(literal)) return JSON.parse(literal) as string;
+  if (/^-?\d+(?:\.\d+)?$/.test(literal)) return Number(literal);
+  return null;
+}
+
+function e2eSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    // `e2e/node_modules` is the runner's own install; `test-results` and
+    // `playwright-report` are run output. None of them is a hand-written
+    // mirror, and walking them costs seconds.
+    if (entry === "node_modules" || entry === "test-results" || entry === "playwright-report") {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...e2eSourceFiles(full));
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe("the extractor (#1646 — the predicate)", () => {
+  // A guard that only ever runs over a tree it already agrees with proves
+  // nothing about what it would catch, so the predicate is pinned on its own.
+  it("reads a plain declaration", () => {
+    expect(declarationsOf(`const FOO = "$list";`, "FOO")).toEqual([
+      { line: 1, literal: `"$list"` },
+    ]);
+  });
+
+  it("reads a typed declaration and a `let`", () => {
+    expect(declarationsOf(`const FOO: string = "x";`, "FOO")).toEqual([
+      { line: 1, literal: `"x"` },
+    ]);
+    expect(declarationsOf(`let FOO = 50;`, "FOO")).toEqual([{ line: 1, literal: "50" }]);
+  });
+
+  it("does not read a comment that quotes the declaration", () => {
+    expect(declarationsOf(`// const FOO = "$list";`, "FOO")).toEqual([]);
+  });
+
+  it("does not read a DIFFERENT name that ends with the one asked for", () => {
+    expect(declarationsOf(`const NOT_FOO = 1;`, "FOO")).toEqual([]);
+  });
+
+  it("finds every occurrence, with its line", () => {
+    expect(declarationsOf(`const FOO = 1;\nconst BAR = 2;\nconst FOO = 3;`, "FOO")).toEqual([
+      { line: 1, literal: "1" },
+      { line: 3, literal: "3" },
+    ]);
+  });
+
+  it("parses the two shapes a mirror may take, and refuses the rest", () => {
+    expect(parseLiteral(`" << "`)).toBe(" << ");
+    expect(parseLiteral("200")).toBe(200);
+    expect(parseLiteral("-1")).toBe(-1);
+    expect(parseLiteral("`$list`")).toBeNull();
+    expect(parseLiteral(`"$" + "list"`)).toBeNull();
+    expect(parseLiteral("SWIPE_MIN_PX * 2")).toBeNull();
+  });
+});
+
+describe("e2e mirrors of production constants (#1646)", () => {
+  for (const mirror of MIRRORS) {
+    it(`${mirror.file} — ${mirror.name} still equals ${mirror.origin}`, () => {
+      const declarations = declarationsOf(readFileSync(mirror.file, "utf8"), mirror.name);
+
+      // Zero is the failure this assertion exists for as much as a wrong value
+      // is: a renamed or deleted mirror must not make the pin pass by having
+      // nothing left to compare. More than one means the table stopped
+      // describing the file.
+      expect(declarations, `no \`${mirror.name}\` declaration in ${mirror.file}`).toHaveLength(1);
+
+      const declaration = declarations[0] as Declaration;
+      const value = parseLiteral(declaration.literal);
+      expect(
+        value,
+        `${mirror.file}:${declaration.line} — \`${declaration.literal}\` is not a plain literal, so this pin no longer reads it`,
+      ).not.toBeNull();
+      expect(
+        value,
+        `${mirror.file}:${declaration.line} — the copy of ${mirror.origin} has drifted`,
+      ).toBe(mirror.production);
+    });
+  }
+
+  it("has no mirror outside the table", () => {
+    const pinned = new Set(MIRRORS.map((m) => `${m.file} ${m.name}`));
+    for (const known of KNOWN_UNPINNED) pinned.add(`${known.file} ${known.name}`);
+    const names = [...new Set(MIRRORS.map((m) => m.name))];
+
+    const unlisted: string[] = [];
+    for (const file of e2eSourceFiles("e2e")) {
+      const src = readFileSync(file, "utf8");
+      for (const name of names) {
+        if (declarationsOf(src, name).length === 0) continue;
+        if (!pinned.has(`${file} ${name}`)) unlisted.push(`${file} — ${name}`);
+      }
+    }
+
+    // A new copy of an already-copied constant is the cheapest way back to the
+    // state #1646 measured, and it is the one case a table-driven pin can see
+    // coming. Landing one means adding it to MIRRORS (or, if its value is a
+    // question rather than a copy, to KNOWN_UNPINNED with the reason).
+    expect(unlisted).toEqual([]);
+  });
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -56296,3 +56296,82 @@ _Not claimed: that any of the three widened values was ever observed on the
 wire. The finding is an instrument gap, measured in the source. Nothing here
 changes what the server emits, and the per-channel boundary in
 `wireNarrow.ts` has not been censused at all._
+<!-- entry #1646 -->
+
+---
+
+## 2026-08-21 — #1646: the e2e mirrors get a witness, and the reason they exist gets corrected
+
+The e2e tree hand-copies 13 production constants into 53 declarations and
+nothing compared a copy with its original. The copies are deliberate and their
+comments say so — *"kept in lockstep by hand"* — but the hand had no witness:
+every one of them could be edited, or its original could move, and every gate
+in the repo stayed green.
+
+### The reason those comments gave was false
+
+Nine of them explained the mirror with module resolution: *"the e2e tsconfig
+does not resolve src/ imports"*, *"the e2e package does not import from src"*,
+*"the e2e tree never imports it"*, and in `fixtures/push.ts` *"would require a
+path alias in `cicchetto/e2e/tsconfig.json`"*. `fixtures/grappaApi.ts:25`
+type-imports `../../src/lib/wireTypes` with a plain relative import and no
+alias, and `tsc --noEmit -p e2e/tsconfig.json` is green. Resolution was never
+the obstacle.
+
+The true reason is the one `grappaApi.ts` states in its own header and
+`push.ts` in its second half: the runner keeps src **values** out of its
+runtime graph, because a value import reaches solid-js / solid-router. Only
+the false half was replaced.
+
+This is not tidiness. A wrong reason is what makes a copy look unavoidable:
+reading *"the tsconfig cannot resolve src/"*, nobody re-examines the mirror.
+53 declarations grew under that sentence.
+
+### The pin, and why it reads text
+
+`src/__tests__/e2eConstantMirrors.test.ts` reads the e2e declaration as TEXT
+and compares it with the production constant IMPORTED. The two sides come from
+different places — a module import and a file the test never imports — which is
+what makes the comparison able to fail, in both directions.
+
+It lives in `src/__tests__/` rather than `e2e/fixtures/` (which the vitest lane
+also collects) precisely BECAUSE of the rule it guards: a pin inside `e2e/`
+would need a src value import, the edge that package refuses. Reading the specs
+as text creates no import edge at all.
+
+Two of the six pinned constants are DERIVED in production
+(`UNREAD_RETENTION_CAP = PAGE_LIMIT`, `PULL_COMMIT_PX = SWIPE_MIN_PX * 2`) —
+the case where the copy freezes a number that can be moved from a module the
+copy does not even name. Importing the constant pins the computed value, and
+the mutants confirm it: `PAGE_LIMIT` 200→199 and `SWIPE_MIN_PX` 40→41 each kill
+exactly their arm.
+
+### Scope: six of thirteen, and the rest is a product call
+
+Pinned: the 6 constants whose production side is TypeScript and ALREADY
+exported — 11 of the 53 declarations. NOT pinned, deliberately: 5 are
+module-private in production (25 declarations) and 2 are Elixir module
+attributes (17 declarations). Exporting a constant to be testable, moving it
+to `lib/`, or extending `mix grappa.gen_wire_types` with its drift gate are
+product decisions, and this work does not take them.
+
+A pin over an exported constant is the part that needed no permission.
+
+_Not claimed: that a value import from `src` survives the **playwright**
+transform. The pin's import runs under vitest, from `src/`. What is measured
+is that a relative `src/` import resolves and typechecks under
+`e2e/tsconfig.json` — which is what falsifies the comments — not that a spec
+could import one at runtime. That question is what decides "export and import"
+versus "export and pin", and it stays open._
+
+_Not fixed: a mirror that has ALREADY drifted is invisible here. Every row of
+#1646's census was found because the two sides carry the same literal today; a
+copy that already disagrees cannot be found that way, and this pin inherits the
+same blind spot — it can only watch the pairs the census listed. The six
+`SERVER_WINDOW = "Server"` declarations are the one place that gap is named
+rather than papered over: whether they mirror a live production string, a
+retired one, or nothing was not established, so they are listed as unpinned
+with the reason instead of being asserted against `SERVER_WINDOW_NAME`._
+
+_Not watched: `canonicalChannel`'s mirror in `fixtures/cicchettoPage.ts` is a
+FUNCTION. It drifted twice before (#973) and a constant pin cannot see it._


### PR DESCRIPTION
Slice 1 of #1646, and deliberately only slice 1.

The e2e tree hand-copies **13 production constants into 53 declarations** and
nothing in the repo compared a copy with its original. This pins the part that
needed no product decision: the **6 constants whose production side is
TypeScript and already exported — 11 of the 53 declarations**. It also corrects
the reason those copies give for existing, which is measurably false.

## The pin

`cicchetto/src/__tests__/e2eConstantMirrors.test.ts` reads the e2e declaration
as TEXT and compares it with the production constant IMPORTED. The two sides
come from genuinely different places — a module import and a file the test
never imports — so the comparison can fail in both directions.

It lives in `src/__tests__/` rather than `e2e/fixtures/` (which the vitest lane
also collects) precisely BECAUSE of the rule it guards: a pin inside `e2e/`
would need a src VALUE import, the edge that package refuses since it drags the
solid-js graph into the runner. Reading the specs as text creates no import
edge at all. Sibling of `biomePin.test.ts` / `moduleRootGuard.test.ts`.

| pinned | production | e2e decls |
|---|---|---|
| `LIST_WINDOW_NAME` | `src/lib/windowKinds.ts` | 5 |
| `SERVER_WINDOW` / `SERVER_CHANNEL` | `SERVER_WINDOW_NAME`, same module | 2 |
| `REPLY_QUOTE_TAIL` | `src/lib/replyQuote.ts` | 1 |
| `QUOTED_BODY_LIMIT` | `REPLY_QUOTE_BODY_LIMIT`, same module | 1 |
| `UNREAD_BOUND` | `UNREAD_RETENTION_CAP = PAGE_LIMIT` (**derived**) | 1 |
| `PULL_COMMIT_PX` | `PULL_COMMIT_PX = SWIPE_MIN_PX * 2` (**derived**) | 1 |

The two derived ones are the case the census called out: production computes
the number, so it can move from a module the copy does not even name.
Importing the constant pins the computed value.

## Proven by mutation, not by being green

Six mutants, each run against the pin alone, each killing exactly the arms it
should and no others (18 tests total):

| mutant | dead arms |
|---|---|
| prod `LIST_WINDOW_NAME` `"$list"` → `"$listing"` | the 5 `LIST_WINDOW_NAME` arms |
| prod `PAGE_LIMIT` 200 → 199 (**derived source**) | `UNREAD_BOUND` — `expected 200 to be 199` |
| prod `SWIPE_MIN_PX` 40 → 41 (**derived source**) | `PULL_COMMIT_PX` — `expected 80 to be 82` |
| e2e copy `REPLY_QUOTE_TAIL` `" << "` → `" <<< "` | that arm — `expected ' <<< ' to be ' << '` |
| e2e copy of `UNREAD_BOUND` commented out | that arm — `no UNREAD_BOUND declaration in …` |
| a NEW unlisted copy appended to another spec | the sweep — names the file and the constant |

The fifth is the vacuity control: a renamed or deleted mirror fails rather than
passing with nothing left to compare. The extractor is also pinned on its own
fixtures (typed decl, `let`, a comment that quotes a declaration, a name that
merely ends with the one asked for, and the literal shapes it refuses).

## The comment that was already false

Nine comments explained the copies with module resolution — *"the e2e tsconfig
does not resolve src/ imports"*, *"the e2e package does not import from src"*,
*"the e2e tree never imports it"*, and in `fixtures/push.ts` *"would require a
path alias in e2e/tsconfig.json"*. `fixtures/grappaApi.ts:25` type-imports
`../../src/lib/wireTypes` with a plain relative import and no alias, and
`tsc --noEmit -p e2e/tsconfig.json` is green. Resolution was never the
obstacle; the runtime dependency graph is, which is what `grappaApi.ts` says in
its own header and `push.ts` in its second half. Only the false half is
replaced.

`push.ts`'s `DEFAULT_NOTIFICATION_PREFS` is not in the census (an object
literal, not a single-line const) and is not pinned — its comment carried the
same false claim, so the claim was corrected there too and nothing else.

## What this does NOT do

- **Nothing is exported to make it testable, and no Elixir attribute is
  shipped.** 5 of the 13 are module-private in production (25 declarations) and
  2 are `MessagesController` module attributes (17 declarations). Exporting,
  moving to `lib/`, or extending `mix grappa.gen_wire_types` with its drift
  gate are product calls. They are named in the test header and in DESIGN_NOTES,
  not worked around.
- **It cannot find a mirror that has ALREADY drifted.** Every row of the census
  was found *because* the two sides carry the same literal today; a copy that
  already disagrees with production is invisible to that method, and this pin
  inherits the blind spot exactly — it watches the pairs the census listed and
  no others. The `has no mirror outside the table` sweep narrows the future
  case (a NEW copy of an already-copied name) but does nothing for the past one.
- **The six `SERVER_WINDOW = "Server"` declarations are listed as unpinned,
  with the reason.** Whether they mirror a live production string, a retired
  one, or nothing was never established — asserting them against
  `SERVER_WINDOW_NAME` would encode an unmeasured fact, and dropping them from
  the sweep would hide the question.
- **`canonicalChannel`'s mirror in `cicchettoPage.ts` is a FUNCTION** and no
  constant pin can watch it. It drifted twice before (#973); its comment now
  says so.
- **Not measured: whether a value import survives the playwright transform.**
  The pin's import runs under vitest. What is measured — and what falsifies the
  comments — is that a relative `src/` import resolves and typechecks under
  `e2e/tsconfig.json`. That is the weaker claim, and it is the one made. The
  stronger one decides "export and import" vs "export and pin", and stays open.

## Gates

Run from the worktree with `GRAPPA_CACHE_ID=w1-1646`, after reconciling the
cloned `node_modules` against this branch's `bun.lock`:

- `scripts/bun.sh run check` — `4 stages ran, 0 failed` (lock drift, biome
  src+e2e, tsc src, tsc e2e). Same 4/4 on the untouched base first.
- `scripts/bun.sh run test` — **296 files, 5730 tests passed**.
- `scripts/design-notes-gate.sh` — `1 new entry heading(s), separator and
  marker present`.

No spec was executed: this slice adds no playwright coverage and changes no
product code, so the integration shards are expected to be a no-op on it.