### PR TITLE
test(#1645): buy pkgver.sh's hyphen deletion the assertion it never had

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -56375,3 +56375,63 @@ with the reason instead of being asserted against `SERVER_WINDOW_NAME`._
 
 _Not watched: `canonicalChannel`'s mirror in `fixtures/cicchettoPage.ts` is a
 FUNCTION. It drifted twice before (#973) and a constant pin cannot see it._
+<!-- entry #1645 -->
+
+---
+
+## 2026-08-21 — #1645: a case named for a line can leave that line untested
+
+`infra/packaging/aur/pkgver.sh:103` is the line the whole mapper is named
+for — `pkgver="${core}$(printf '%s' "${pre}" | tr -d '\055')"`, the hyphen
+deletion #1591 measured against pacman's comparator. The suite carried a case
+called *"the hyphen makepkg refuses is deleted, and nothing is put in its
+place"*. That case never reached the line.
+
+The hyphen a semver pre-release is named for is removed by the **split**
+(`core="${version%%-*}"`, `pre="${version#*-}"`, then concatenated), not by
+the `tr`. On `1.3.0-rc1` the `tr` is handed `rc1` and does nothing. It fires
+only on a pre-release carrying a hyphen of its **own** — a version with two
+or more hyphens. Census of every literal the suite feeds the script: 21
+invocations, 19 with a value, 12 distinct, **0** with a second hyphen.
+
+Measured on `origin/main` b1d09c95, in a detached worktree, with a one-shot
+injector that refuses unless the needle occurs exactly once:
+
+| tree | rc | plan | ok | not ok |
+|---|---|---|---|---|
+| unmutated | 0 | 633 | 633 | 0 |
+| M6a (`tr '\055' '_'`) | 0 | 633 | 633 | 0 |
+
+The two TAP transcripts are byte-identical — same md5, `cmp` silent. Not an
+equivalent mutant, though: over the suite's own 12 literals the two scripts
+agree 12/12, and on three untested witnesses they differ 3/3 (`1.3.0-rc-1` →
+`1.3.0rc1` vs `1.3.0rc_1`).
+
+The cure is one case, and it was proven as an oracle rather than assumed:
+with M6a applied the suite reports rc=1, 11 ok, 1 not ok, and the failure is
+the new case and only it; with M6a reverted, rc=0, 12 ok, 0 not ok. One
+mutant, one assertion.
+
+The input chosen is not arbitrary. `pkgver.sh`'s header (`:47-51`) declares
+the mapping **NOT INJECTIVE, deliberately** — `1.3.0-rc-1` lands on the same
+`pkgver` as `1.3.0-rc1`. Under M6a that documented collision quietly stops
+holding while **both of the script's own guards still pass**: `_` is not in
+makepkg's refused class `[[:space:]/:-]`, and the tie-break character is
+still the letter `r`. Neither the script nor the suite would report it; only
+the published package name would differ. Pinning a documented decision beats
+pinning a magic string.
+
+**The transferable rule: a test named after a line is not evidence that the
+line runs.** When a mapper composes several transformations, ask which of
+them each input actually reaches — the split can be doing the work the
+assertion credits to the substitution. Mutating one clause and reading which
+named tests redden answers it; a green count does not.
+
+_Not claimed: that the input can occur in this project. 23 `v*` tags, 2
+pre-releases, 0 with two hyphens, and `VERSION` has held 16 distinct values
+with the same split — the uncovered branch has never been taken. That bears
+on priority, not on coverage. Also not measured here: `vercmp 1.3.0rc_1
+1.3.0` (no pacman on the host), the `arch` job's own gates (they compare the
+mapper against itself), and the coverage of the rest of `pkgver.sh` — one
+mutant, one line. The pre-existing `bats #44` red the briefing warned about
+did not appear on this base: test 44 is green in all runs above._

--- a/test/infra/packaging_prerelease_pkgver_test.bats
+++ b/test/infra/packaging_prerelease_pkgver_test.bats
@@ -81,6 +81,30 @@ arch_job() {
     [ "$output" = "1.3.0rc1" ]
 }
 
+@test "#1645 a pre-release carrying its OWN hyphen loses that one too" {
+    # The case above does NOT exercise the line it reads like it does. The
+    # hyphen a semver pre-release is named for is removed by the SPLIT
+    # (`core=${version%%-*}`, `pre=${version#*-}`, then concatenated), never by
+    # the `tr`. The `tr` fires only on a pre-release that carries a hyphen of
+    # its OWN — i.e. on a version with two or more hyphens — and #1645 censused
+    # every literal this suite feeds the script: 21 invocations, 19 with a
+    # value, 12 distinct, and ZERO with a second hyphen. So the deletion had no
+    # test, and a mutant that turns it into a substitution (`tr '\055' '_'`)
+    # left the whole host bats set byte-identically green: 633 ok, 0 not ok,
+    # same md5 as the unmutated transcript.
+    #
+    # This input is also the mapper's documented NOT-INJECTIVE decision (see
+    # the header, `pkgver.sh:47-51`): `1.3.0-rc-1` is legal semver and lands on
+    # the same pkgver as `1.3.0-rc1`, deliberately. Under the substitution it
+    # becomes `1.3.0rc_1` — a different published package name — while both of
+    # the script's own guards still pass: `_` is not in makepkg's refused class
+    # `[[:space:]/:-]`, and the tie-break character is still the letter `r`.
+    # Nothing but this assertion would notice the line changing.
+    run "$PKGVER_SH" 1.3.0-rc-1
+    [ "$status" -eq 0 ]
+    [ "$output" = "1.3.0rc1" ]
+}
+
 @test "#1591 no mapped pkgver carries a character makepkg's lint refuses" {
     # The refused class is makepkg's own bracket expression, transcribed:
     # `[[ $ver = *[[:space:]/:-]* ]]` in lint_pkgbuild/pkgver.sh.


### PR DESCRIPTION
Closes the coverage hole GH #1645 measured: `infra/packaging/aur/pkgver.sh:103`
— the hyphen deletion the whole mapper is named for — had no test, and a mutant
of it was zero-kill.

## The premise, re-verified rather than inherited

- `origin/main` at start: `b1d09c95`. `git log origin/main --grep '#1645'`: zero.
- The line is still live: `grep -cF "tr -d '\055'"` → **1** occurrence.
- The issue measured at `d73c0177`. `git diff d73c0177 b1d09c95 -- infra/packaging/
  test/infra/packaging_prerelease_pkgver_test.bats` is **empty**, so the subject is
  byte-identical to the one the issue read.

## The hole, reproduced on this base

M6a = the deletion turned into a substitution (`tr -d '\055'` → `tr '\055' '_'`).

| tree | rc | plan | ok | not ok |
|---|---|---|---|---|
| unmutated | 0 | 633 | 633 | 0 |
| **M6a applied** | **0** | **633** | **633** | **0** |

The two TAP transcripts are **byte-identical** — same md5
(`4f7dae3dd14241f1c3e969d95fe60a22`), and `cmp` is silent. Whole host bats set
(`test/bin/ test/infra/ test/scripts/`), not a subset.

**Not an equivalent mutant.** Differential over the suite's own census plus three
untested witnesses:

| | identical | different |
|---|---|---|
| the 12 literals any test feeds | **12** | 0 |
| three untested witnesses | 0 | **3** |

```
1.3.0-rc-1           orig 1.3.0rc1          m6a 1.3.0rc_1
1.3.0-alpha-beta     orig 1.3.0alphabeta    m6a 1.3.0alpha_beta
1.3.0-rc1+build-meta orig 1.3.0rc1+buildmeta m6a 1.3.0rc1+build_meta
```

## Why the existing case does not reach the line

The hyphen a semver pre-release is named for is removed by the **split**
(`core="${version%%-*}"`, `pre="${version#*-}"`, then concatenated), never by the
`tr`. On `1.3.0-rc1` the `tr` is handed `rc1` and does nothing. It fires only on a
pre-release carrying a hyphen of its **own**. The case named *"the hyphen makepkg
refuses is deleted"* therefore passes without exercising the deletion.

## The cure, proven as an oracle in both directions

One case added, on the input that is the mapper's own documented NOT-INJECTIVE
decision (`pkgver.sh:47-51`), so the assertion pins a decision rather than a magic
string:

| suite | tree | rc | result |
|---|---|---|---|
| with the case | unmutated | 0 | 12 ok, 0 not ok |
| with the case | **M6a** | **1** | **11 ok, 1 not ok** |

The one that fails is the new case **and only it** — one mutant, one assertion.

Under M6a the documented collision silently stops holding while **both of the
script's own guards still pass**: `_` is not in makepkg's refused class
`[[:space:]/:-]`, and the tie-break character is still the letter `r`. Only the
published package name would have changed.

## Ship gate

`scripts/bats.sh` (full host set) on the branch tip: **rc=0, plan 634, 634 ok, 0
not ok**, working tree clean. Baseline was 633 — the delta is exactly this case,
and it is present in the transcript as `ok 373`. `scripts/design-notes-gate.sh
origin/main`: *"1 new entry heading(s), separator and marker present"* — a
non-empty verdict, not a "nothing to check".

## Method

- Detached-from-`origin/main` worktree, `GRAPPA_CACHE_ID=w2-1645` (which
  `scripts/bats.sh` drops out loud by design — #1522 — since bats runs no mix).
- Injector: exact one-shot substitution, ABORTs unless the needle occurs exactly
  once and the file actually changes; reverts by the **inverse edit**, never
  `git checkout --`; `git status --porcelain` proven empty after every mutant.
- The fix was committed **before** any further mutation run.

## What I do NOT claim

- **That the input can occur here.** Carried from the issue, not re-measured: 23
  `v*` tags, 2 pre-releases, 0 with two hyphens. That bears on priority, not on
  coverage.
- **The ordering of the mutant's output.** `vercmp 1.3.0rc_1 1.3.0` was not run —
  no pacman on this host.
- **The M6b positive control.** Measured by the issue, not re-run here; the
  two-sided oracle above is this PR's own control and it is not empty.
- **Any coverage claim about the rest of `pkgver.sh`.** One mutant, one line.
- **The pre-existing `bats #44` red the briefing warned about.** It did **not**
  appear on this base: test 44 (`runtime newer than build passes`) is `ok` in the
  baseline, the M6a run, and the final run. I did not reproduce it, so I neither
  fixed it nor attribute it.
- **CI.** Not polled — per the order, it is watched elsewhere.