### PR TITLE
arch(#1398): make the injected closure set a function of the subject tag

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -56529,3 +56529,110 @@ SERVER, which this census has never compared — it compares two client-side
 boundaries. No narrower was touched: the diff is 461 added lines and zero
 deleted, so the census the previous slice landed still reads byte for byte the
 same._
+<!-- entry #1398c -->
+
+---
+
+## 2026-08-21 — #1398c: `nil` was never a default on `Session.Deps`, it was a function of the subject tag
+
+Bucket **I dependency-inversion** of the 2026-08-15 architecture review had two
+halves. The first — five `dirty_xrefs` waivers manufacturing an acyclic Boundary
+graph, and the 31 elementary cycles over 12 boundaries they hid — was already
+dead when this landed: #1399's schema-owns-itself work removed every active
+waiver, so the cycles are gone rather than waived, and the `Grappa.Session.Control`
+extraction the review proposed would have broken none of them (it needs `Server`,
+so it cannot be the leaf the review wanted). §7, `Grappa.Session.Backoff` as a
+leaf, landed separately as `ae4c52be`.
+
+This entry is the remaining half: the ten closures injected into `Session.Server`,
+which no compile-time checker can see. **A closure carries no module reference**,
+so Boundary cannot follow the edge. Built with `Map.get(opts, :key)`, an omitted
+injection was not a compile error, not a crash and not a log line — it was a `nil`
+field, and the first path that reached for it simply did not persist. Silently, for
+as long as nobody compared the DB against the live session.
+
+### The measurement that gives the design
+
+`nil` could not just be banned: it is correct half the time. There are **exactly
+two producers and they inject disjoint sets** —
+`Grappa.Networks.SessionPlan` (registered users) and
+`Grappa.Visitors.SessionPlan` (visitors). Measured against the live output of
+both: two shared (`credential_failer`, `last_joined_persister`), three user-only
+(`away_persister`, `credential_committer`, `registration_committer`), four
+visitor-only (`recover_source`, `visitor_committer`, `visitor_nick_persister`,
+`visitor_password_rotator`).
+
+So an absent `away_persister` on a **user** session is a bug and the same absence
+on a **visitor** session is correct by construction, and before this change the two
+were indistinguishable. `Deps` is therefore not one struct with ten optional
+fields: it is **two variants discriminated by the subject tag**, which
+`Grappa.Subject` already carries.
+
+`Deps.from_opts/2` takes the subject and validates the set due for that tag,
+raising `Grappa.Session.DepsInjectionError` naming the offending keys.
+`Deps.required_injections/1` is the single source of truth for the two sets, and
+it carries **arity as well as presence** — a closure of the wrong shape fails at
+the call site, deep inside a running session on the rare path that reaches it,
+which is the same late-and-silent failure the presence check exists to end. An
+**explicit `nil` counts as missing**: that is the exact shape the old `Map.get/2`
+door swallowed. A key due for the *other* tag is refused as alien.
+
+Neither producer can name `Deps` — both their boundaries already dep
+`Grappa.Session`, so the reverse edge would close the very cycle the closures
+exist to dodge. The two sides are held in step by `Grappa.Session.DepsTest`, which
+measures each producer's real resolved plan against the table, in both directions:
+a closure added to a plan with no table entry is red, and so is a table entry no
+plan injects.
+
+### Why raising is safe under a `:transient` child
+
+The raise happens in `do_init/1`, before registration and before the upstream
+socket. `start_link/1` then returns `{:error, {exception, _}}` and
+`DynamicSupervisor.start_child/2` propagates it — a child that never started is
+not restarted, so a mis-wired plan fails loudly and **once** instead of entering a
+respawn loop. A later respawn cannot reach the state either: the supervisor
+replays the cached child spec, and `refresh_plan`'s `Map.merge/2` can only add
+keys. The `{:hold, _}` arm of `init_or_hold/1` returns `:ignore` before any state
+is built, so held sessions never pay the check.
+
+### Two counts that do not match, and why
+
+The review's "ten closures" and the ten fields of the `Deps` struct are **different
+sets overlapping in nine**. The review's ten is the union of what the two producers
+inject, which includes `refresh_plan`; the struct's ten replaces it with
+`query_window_open?`, which neither producer injects. Both stay outside the guard,
+for different reasons:
+
+* `query_window_open?` is due on neither tag. It has a real production default
+  (`&QueryWindows.open?/3`) and the injection point exists so a test can keep
+  `EventRouter` a sandbox-free classifier. Accepted on both tags, required on
+  neither.
+* `refresh_plan` is not a `Deps` field at all, though both producers inject it and
+  it shares the silent-absence class. `Server.init/1` consumes it from the raw opts
+  *before* `do_init/1` builds the struct, because its return value replaces the
+  opts the struct would be built from. **It stays unguarded — a documented
+  limitation of this guard, not an oversight.**
+
+### What the guard found on its way in
+
+Three test sites built a partial plan on purpose, and the strict door is what
+surfaced them. `server_test.exs`'s `derived_alias_opts/4` hand-built a full user
+connect plan carrying none of the five user closures; it now resolves the real plan
+and **drops `refresh_plan` by name**, so the one exclusion the test genuinely needs
+(the DB-wins closure would re-resolve its two overrides away) is a line of code
+instead of a silence. Two hand-built visitor plans now come from
+`Visitors.SessionPlan.resolve/2`.
+
+One of those two carried a **false premise in its comment**: "no
+`credential_failer` — visitor plans don't include it". `Visitors.SessionPlan` has
+injected one since CP24 bucket E — it calls `Visitors.mark_failed/2`, expiring the
+visitor row so Bootstrap stops respawning. The hand-built plan is what kept the lie
+invisible; the guard is what made it fail.
+
+_Not claimed. That an omitted injection has ever fired in production: the failure
+mode is silent by construction, so the absence of reports is not evidence either
+way, and nothing here measured it. That `refresh_plan` has no legitimate absent
+case — both producers inject it, but the one test site that omits it does so
+deliberately, which is why it is excluded by scope rather than declared safe. No
+boundary was added, removed or re-declared; the graph is byte-for-byte the one
+`2ed5fb51` carried._

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -109,6 +109,18 @@ defmodule Grappa.Networks.SessionPlan do
         cred.nick
       )
 
+    # #1398 — the closures below are the USER half of a two-variant
+    # contract. `Grappa.Session.Deps.required_injections({:user, _})` is
+    # its single source of truth, and `Grappa.Session.Deps.from_opts/2`
+    # raises at spawn if this map does not match it, key for key and
+    # arity for arity. This module cannot name that one (Session is
+    # already a dep of Networks, so the reverse edge would close the very
+    # Boundary cycle these closures exist to dodge) — the two are held in
+    # step by `Grappa.Session.DepsTest`, which measures THIS function's
+    # output against the table. Adding a closure here without adding it
+    # there is red; so is the reverse. `refresh_plan` is the one below
+    # that is NOT part of that set: `Server.init/1` consumes it from the
+    # raw opts before the struct is built.
     Map.merge(base, %{
       # Opaque callback injected so Session.Server can transition the
       # credential to :failed on hard upstream errors (k-line, permanent

--- a/lib/grappa/session/deps.ex
+++ b/lib/grappa/session/deps.ex
@@ -15,13 +15,54 @@ defmodule Grappa.Session.Deps do
   contract stops carrying a bare closure among fields that are genuinely
   state: what it sees now is one typed field it can project as a whole.
 
-  The struct is built by `from_opts/1` from the SAME `start_link/1` keyword
-  API as before — the ten option keys are unchanged, so no producer of a
+  The struct is built by `from_opts/2` from the SAME `start_link/1` keyword
+  API as before — the option keys are unchanged, so no producer of a
   session plan had to move.
+
+  ## Why the door takes the subject (#1398)
+
+  A closure carries no module reference, so `Boundary` cannot follow the
+  edge and nothing at compile time can see these ten. Built with
+  `Map.get/2`, an omitted injection produced a `nil` field, and a `nil`
+  field is a persist that silently does not happen — not a compile error,
+  not a crash, not a log line.
+
+  `nil` could not simply be banned, because it is correct half the time.
+  There are exactly TWO producers and they inject DISJOINT sets:
+
+  * `Grappa.Networks.SessionPlan` (registered users) —
+    `away_persister`, `credential_committer`, `credential_failer`,
+    `last_joined_persister`, `registration_committer`;
+  * `Grappa.Visitors.SessionPlan` (visitors) — `credential_failer`,
+    `last_joined_persister`, `recover_source`, `visitor_committer`,
+    `visitor_nick_persister`, `visitor_password_rotator`.
+
+  Two shared, three user-only, four visitor-only. So `nil` is not a
+  default at all: it is a function of the SUBJECT TAG, which
+  `Grappa.Subject` already carries. `from_opts/2` validates the set due
+  for that tag and raises `Grappa.Session.DepsInjectionError` naming the
+  offending keys — the failure moves to spawn, loud, instead of surfacing
+  as a missing row weeks later. `required_injections/1` is the single
+  source of truth for the two sets; `Grappa.Session.DepsTest` pins it
+  against the live output of both producers, since neither can reference
+  this module (both their boundaries already dep `Grappa.Session`, so the
+  reverse edge would close a cycle — the same reason these are closures).
+
+  Two keys sit outside that rule, both measured:
+
+  * `query_window_open?` is due on NEITHER tag. Neither producer injects
+    it, it carries a real production default, and it exists as a seam so
+    a test can keep `EventRouter` sandbox-free. Accepted on both tags,
+    required on neither.
+  * `refresh_plan` is not a field here at all, though both producers
+    inject it and it shares the silent-absence class. `Server.init/1`
+    consumes it from the raw opts BEFORE `do_init/1` builds this struct,
+    because its return value REPLACES the opts the struct is built from.
+    It is outside this struct's authority and stays unguarded.
   """
 
   alias Grappa.QueryWindows
-  alias Grappa.Session.EventRouter
+  alias Grappa.Session.{DepsInjectionError, EventRouter}
 
   @typedoc """
   Optional opaque callback the visitor-side `SessionPlan` injects into
@@ -187,9 +228,14 @@ defmodule Grappa.Session.Deps do
   @type away_persister :: (String.t() | nil, DateTime.t() | nil -> :ok | {:error, term()})
 
   @typedoc """
-  The ten injected callbacks. Nine default to `nil` — a plan that does not
-  supply one is declaring the session cannot do that thing (a user session
-  has no `recover_source`; a visitor session has no `away_persister`).
+  The ten injected callbacks. Nine field defaults are `nil`, and a `nil`
+  on a LIVE session still means "this session cannot do that thing" (a
+  user session has no `recover_source`; a visitor session has no
+  `away_persister`) — but which nils are legitimate is decided at the
+  door by `from_opts/2`, per subject tag, not by this struct. The
+  defaults remain so `%__MODULE__{}` stays constructible for the
+  hot-deploy fallback in `Session.Server` (a pre-#1390 live process has
+  no `:deps` key at all).
 
   `query_window_open?` is the exception and does NOT default to `nil`: it
   has a real production default, `&QueryWindows.open?/3`. A session always
@@ -221,14 +267,103 @@ defmodule Grappa.Session.Deps do
             away_persister: nil,
             query_window_open?: &QueryWindows.open?/3
 
-  @doc """
-  Reads the ten callbacks out of a resolved `Grappa.Session.start_opts/0`.
+  # The two due sets, key => the arity the consumer calls the closure at.
+  # Arity is part of the contract, not decoration: a closure of the wrong
+  # shape fails at the call site — deep inside a running session, on the
+  # rare path that reaches for it — which is the same silent-until-late
+  # failure the presence check exists to end.
+  @user_injections %{
+    away_persister: 2,
+    credential_committer: 1,
+    credential_failer: 1,
+    last_joined_persister: 2,
+    registration_committer: 1
+  }
 
-  Absent keys take the struct defaults, which is the same rule `init/1`
-  applied when these lived as ten separate `Map.get(opts, :key)` lines.
+  @visitor_injections %{
+    credential_failer: 1,
+    last_joined_persister: 2,
+    recover_source: 0,
+    visitor_committer: 3,
+    visitor_nick_persister: 2,
+    visitor_password_rotator: 2
+  }
+
+  # Derived, never listed twice: the alien check needs the union, and a
+  # union computed from the two tables cannot drift away from them.
+  @injectable_keys Enum.sort(Enum.uniq(Map.keys(@user_injections) ++ Map.keys(@visitor_injections)))
+
+  @typedoc """
+  The closed set of injectable closure keys — NINE, not ten.
+
+  Nine and not ten because the review's ten is the UNION OF WHAT THE TWO
+  PRODUCERS INJECT, and one member of that union is `refresh_plan`, which
+  this struct does not carry. Measured, not assumed:
+
+  * it is absent from `defstruct` above and always has been;
+  * `Server.init/1` reads it with its own `Map.get(opts, :refresh_plan)`
+    and, on `{:ok, fresh_plan}`, calls `init_or_hold(Map.merge(opts,
+    fresh_plan))`. So it is consumed BEFORE `do_init/1` and its return
+    value REPLACES the opts this struct is then built from — a check here
+    would run after the fact, on a map that already reflects the closure's
+    own output.
+
+  Excluded by that structure, therefore, not by oversight and not because
+  its absence is safe: both producers inject it, so it belongs to the same
+  silent-absence class as these nine, and it stays UNGUARDED. That is the
+  documented limitation of this door. `query_window_open?` is the tenth
+  STRUCT field and is likewise not here, for the opposite reason — no
+  producer injects it and it has a real production default.
   """
-  @spec from_opts(map()) :: t()
-  def from_opts(opts) when is_map(opts) do
+  @type injectable ::
+          :away_persister
+          | :credential_committer
+          | :credential_failer
+          | :last_joined_persister
+          | :recover_source
+          | :registration_committer
+          | :visitor_committer
+          | :visitor_nick_persister
+          | :visitor_password_rotator
+
+  @doc """
+  The closures due for `subject`'s tag, as `%{key => arity}`.
+
+  The single source of truth for both sets. `Grappa.Session.DepsTest`
+  pins it against the live output of `Grappa.Networks.SessionPlan` and
+  `Grappa.Visitors.SessionPlan`, so a closure added to a producer without
+  an entry here — or an entry no producer injects — is red.
+  """
+  @spec required_injections(Grappa.Session.subject()) :: %{injectable() => arity()}
+  def required_injections({:user, _}), do: @user_injections
+  def required_injections({:visitor, _}), do: @visitor_injections
+
+  @doc """
+  Every key either producer may inject — the union of the two due sets,
+  and never empty.
+
+  A key in this list that is not due for the session's tag is ALIEN: a
+  visitor closure on a user session is a mis-wired plan, not a spare
+  capability, and `from_opts/2` refuses it. See `t:injectable/0` for why
+  the list holds nine keys and not the review's ten.
+  """
+  @spec injectable_keys() :: [injectable(), ...]
+  def injectable_keys, do: @injectable_keys
+
+  @doc """
+  Builds the struct from a resolved `Grappa.Session.start_opts/0`,
+  validating the injected set against `subject`'s tag.
+
+  Raises `Grappa.Session.DepsInjectionError` when a due key is absent, is
+  present as `nil` (the shape the old `Map.get/2` door swallowed), is
+  present at the wrong arity, or when a key due for the OTHER tag is
+  present. Never returns a partially-injected struct: the plan is either
+  complete for its subject or the spawn fails naming what is wrong.
+  """
+  @spec from_opts(Grappa.Session.subject(), map()) :: t()
+  def from_opts(subject, opts) when is_map(opts) do
+    :ok = validate!(subject, opts)
+
     %__MODULE__{
       visitor_committer: Map.get(opts, :visitor_committer),
       visitor_password_rotator: Map.get(opts, :visitor_password_rotator),
@@ -241,5 +376,46 @@ defmodule Grappa.Session.Deps do
       away_persister: Map.get(opts, :away_persister),
       query_window_open?: Map.get(opts, :query_window_open?, &QueryWindows.open?/3)
     }
+  end
+
+  defp validate!(subject, opts) do
+    due = required_injections(subject)
+    {missing, wrong_arity} = due_faults(due, opts)
+    alien = Enum.filter(@injectable_keys -- Map.keys(due), &(Map.get(opts, &1) != nil))
+
+    if missing == [] and wrong_arity == [] and alien == [] do
+      :ok
+    else
+      raise DepsInjectionError,
+        subject_tag: elem(subject, 0),
+        missing: missing,
+        alien: alien,
+        wrong_arity: wrong_arity
+    end
+  end
+
+  # One pass over the due set, splitting it into "not supplied at all" and
+  # "supplied at the wrong shape". Sorted input (a map's key order is
+  # already sorted for atoms) keeps the message stable across runs.
+  defp due_faults(due, opts) do
+    {missing, wrong_arity} =
+      Enum.reduce(due, {[], []}, fn {key, arity}, {missing, wrong_arity} ->
+        case Map.get(opts, key) do
+          fun when is_function(fun, arity) ->
+            {missing, wrong_arity}
+
+          fun when is_function(fun) ->
+            {:arity, got} = Function.info(fun, :arity)
+            {missing, [{key, arity, got} | wrong_arity]}
+
+          # Absent, or present as something that is not a function at all —
+          # `nil` included, which is the exact value the old `Map.get/2`
+          # door accepted in silence. Both are MISSING, not "supplied".
+          _ ->
+            {[key | missing], wrong_arity}
+        end
+      end)
+
+    {Enum.reverse(missing), Enum.reverse(wrong_arity)}
   end
 end

--- a/lib/grappa/session/deps_injection_error.ex
+++ b/lib/grappa/session/deps_injection_error.ex
@@ -1,0 +1,59 @@
+defmodule Grappa.Session.DepsInjectionError do
+  @moduledoc """
+  Raised by `Grappa.Session.Deps.from_opts/2` when a session plan's set of
+  injected closures does not match the set due for its subject tag.
+
+  #1398 — the failure this exception exists to relocate. An injected
+  callback is a bare closure, so it carries no module reference and
+  `Boundary` cannot follow the edge: before this door, an omitted
+  injection was not a compile error, not a crash and not a log line. It
+  was a `nil` on the struct, and the first time anything reached for it
+  the effect — an away snapshot, a credential commit, a rejoin snapshot —
+  simply did not happen. Silently, in production, for as long as nobody
+  compared the DB against the live session.
+
+  `nil` could not be rejected wholesale because it is legitimate half the
+  time: the two producers inject DISJOINT sets, so an absent
+  `away_persister` is a bug on a user session and correct by construction
+  on a visitor one. The subject tag is what tells the two apart, which is
+  why the door takes it and why this exception reports it.
+
+  Raised from `Server.init/1`'s `do_init/1`, i.e. at spawn, BEFORE the
+  session is registered or the upstream socket is opened. A raise there
+  makes `start_link/1` return `{:error, {exception, _stacktrace}}` and
+  `DynamicSupervisor.start_child/2` propagate it: a child that never
+  started is not restarted, so a mis-wired plan fails loudly and once
+  instead of entering the `:transient` respawn loop. A LATER respawn
+  cannot reach this state either — the supervisor replays the cached
+  child spec and `refresh_plan`'s `Map.merge/2` can only add keys.
+  """
+  defexception [:subject_tag, :missing, :alien, :wrong_arity]
+
+  @type t :: %__MODULE__{
+          subject_tag: atom(),
+          missing: [atom()],
+          alien: [atom()],
+          wrong_arity: [{atom(), non_neg_integer(), non_neg_integer()}]
+        }
+
+  @impl Exception
+  def message(%__MODULE__{subject_tag: tag} = error) do
+    "session plan for a :#{tag} subject carries a bad injected-closure set — " <>
+      Enum.map_join(faults(error), "; ", fn {label, text} -> "#{label}: #{text}" end)
+  end
+
+  # Only the offending keys are named. An enumeration of the whole
+  # expected set would read the same on every failure and would make a
+  # test that asserts "names the missing key" pass vacuously.
+  defp faults(%__MODULE__{missing: missing, alien: alien, wrong_arity: wrong_arity}) do
+    sections = [
+      {"missing", Enum.join(missing, ", ")},
+      {"not due on this tag", Enum.join(alien, ", ")},
+      {"wrong arity", Enum.map_join(wrong_arity, ", ", &arity_fault/1)}
+    ]
+
+    Enum.reject(sections, fn {_, text} -> text == "" end)
+  end
+
+  defp arity_fault({key, expected, got}), do: "#{key} (expected #{expected}, got #{got})"
+end

--- a/lib/grappa/session/directory_ingest.ex
+++ b/lib/grappa/session/directory_ingest.ex
@@ -111,8 +111,10 @@ defmodule Grappa.Session.DirectoryIngest do
   struct's config defaults for anything the caller does not pin.
 
   Same shape and same opt-key spelling as before the extraction, so a test
-  that pinned `:directory_ingest_batch` keeps working. Mirrors its slice-1
-  sibling `Deps.from_opts/1`.
+  that pinned `:directory_ingest_batch` keeps working. Shaped after its
+  slice-1 sibling `Deps.from_opts/2`, but deliberately NOT strict like it:
+  these are numeric tuning knobs with real production defaults, not
+  injected capabilities whose absence is a silent no-op (#1398).
   """
   @spec from_opts(map()) :: t()
   def from_opts(opts) when is_map(opts) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1050,7 +1050,12 @@ defmodule Grappa.Session.Server do
       pending_password: pending_password_from_opts(opts),
       perform_list: Map.get(opts, :perform_list),
       oper_pass: Map.get(opts, :oper_pass),
-      deps: Deps.from_opts(opts),
+      # #1398 — the subject tag decides WHICH closures are due, so the
+      # door takes it: a user plan missing `away_persister` raises here,
+      # a visitor plan without one is correct by construction. Reached
+      # only from `do_init/1`, so the `{:hold, _}` arm above (which
+      # `:ignore`s before any state is built) never pays the check.
+      deps: Deps.from_opts(opts.subject, opts),
       ghost_recovery: nil,
       ghost_timer: nil,
       parked_nick_fallback: nil,

--- a/lib/grappa/visitors/session_plan.ex
+++ b/lib/grappa/visitors/session_plan.ex
@@ -166,6 +166,17 @@ defmodule Grappa.Visitors.SessionPlan do
         "Grappa Visitor"
       )
 
+    # #1398 — the closures below are the VISITOR half of a two-variant
+    # contract, disjoint from the user half on all but `credential_failer`
+    # and `last_joined_persister`.
+    # `Grappa.Session.Deps.required_injections({:visitor, _})` is its
+    # single source of truth and `Grappa.Session.Deps.from_opts/2` raises
+    # at spawn if this map does not match it. Same reason this module
+    # cannot name that one (Visitors deps Session via Login), same keeper:
+    # `Grappa.Session.DepsTest` measures THIS function's output against
+    # the table, so a closure added on either side alone is red.
+    # `refresh_plan` is outside that set — `Server.init/1` consumes it
+    # from the raw opts before the struct exists.
     Map.merge(base, %{
       # Task 15 / #561: opaque function-reference indirection. Session.Server
       # cannot statically alias Grappa.Visitors (closes a Boundary

--- a/test/grappa/session/deps_test.exs
+++ b/test/grappa/session/deps_test.exs
@@ -1,0 +1,243 @@
+defmodule Grappa.Session.DepsTest do
+  @moduledoc """
+  #1398 — the injected-closure half of bucket I, the half no compile-time
+  checker can see.
+
+  A closure carries no module reference, so `Boundary` cannot follow the
+  edge: an omitted injection is not a compile error, not a crash and not a
+  log line. It is a persist that silently does not happen. The two
+  producers are `Grappa.Networks.SessionPlan` (registered users) and
+  `Grappa.Visitors.SessionPlan` (visitors), and they inject DISJOINT sets —
+  so `nil` is not a legitimate default, it is a function of the SUBJECT
+  TAG. An absent `away_persister` on a user session is a bug; the same
+  absence on a visitor session is correct by construction. Before
+  `from_opts/2` the two were indistinguishable.
+
+  What this file pins:
+
+  * the per-tag due set AND its arities, against the LIVE output of both
+    producers — a closure added to a plan without a table entry, or a
+    table entry no plan injects, or an arity change on either side, is red;
+  * that a missing due key raises and NAMES the key (and does not name the
+    keys that were supplied);
+  * that an alien key — a visitor closure on a user session — raises;
+  * that an explicit `nil`, the exact shape the old `Map.get/2` door
+    accepted in silence, counts as MISSING and not as supplied.
+
+  Out of scope, measured and deliberate:
+
+  * `query_window_open?` is the tenth struct field and is due on NEITHER
+    tag. Neither `SessionPlan` injects it, it carries a real production
+    default (`&Grappa.QueryWindows.open?/3`), and the injection point
+    exists so a test can keep `EventRouter` a sandbox-free classifier. So
+    it is accepted on both tags and required on neither.
+  * `refresh_plan` is NOT a `Deps` field, though both plans inject it and
+    it belongs to the same silent class. `Server.init/1` reads it from the
+    raw opts BEFORE `do_init/1` builds this struct, because its return
+    value REPLACES the opts the struct would be built from. It is outside
+    this struct's authority and stays unguarded — the documented
+    limitation of this guard, not an oversight.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Networks.{Credentials, SessionPlan}
+  alias Grappa.QueryWindows
+  alias Grappa.Session.{Deps, DepsInjectionError}
+  alias Grappa.Visitors.SessionPlan, as: VisitorSessionPlan
+
+  describe "the due set, measured against the live producers" do
+    test "the user plan injects exactly the user-due set, at the declared arities" do
+      {user, network, _} = user_with_credential(6667, %{})
+      {:ok, plan} = SessionPlan.resolve(Credentials.get_credential!(user, network))
+
+      assert injected_arities(plan) == Deps.required_injections({:user, user.id})
+    end
+
+    test "the visitor plan injects exactly the visitor-due set, at the declared arities" do
+      {visitor, network} = visitor_with_network(6667)
+      {:ok, plan} = VisitorSessionPlan.resolve(visitor, network)
+
+      assert injected_arities(plan) == Deps.required_injections({:visitor, visitor.id})
+    end
+
+    test "the two due sets are disjoint on all but the two shared persisters" do
+      user_keys = {:user, "u"} |> Deps.required_injections() |> Map.keys() |> MapSet.new()
+      visitor_keys = {:visitor, "v"} |> Deps.required_injections() |> Map.keys() |> MapSet.new()
+
+      assert MapSet.intersection(user_keys, visitor_keys) ==
+               MapSet.new([:credential_failer, :last_joined_persister])
+    end
+
+    test "injectable_keys/0 is exactly the union of the two due sets" do
+      union =
+        [{:user, "u"}, {:visitor, "v"}]
+        |> Enum.flat_map(&Map.keys(Deps.required_injections(&1)))
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert Deps.injectable_keys() == union
+    end
+  end
+
+  describe "from_opts/2 on a complete plan" do
+    test "a resolved user plan builds a struct with the user five set and the visitor four nil" do
+      {user, network, _} = user_with_credential(6667, %{})
+      subject = {:user, user.id}
+      {:ok, plan} = SessionPlan.resolve(Credentials.get_credential!(user, network))
+
+      deps = Deps.from_opts(subject, plan)
+
+      assert is_function(deps.away_persister, 2)
+      assert is_function(deps.credential_committer, 1)
+      assert is_function(deps.credential_failer, 1)
+      assert is_function(deps.last_joined_persister, 2)
+      assert is_function(deps.registration_committer, 1)
+
+      assert deps.recover_source == nil
+      assert deps.visitor_committer == nil
+      assert deps.visitor_nick_persister == nil
+      assert deps.visitor_password_rotator == nil
+    end
+
+    test "a resolved visitor plan builds a struct with the visitor six set and the user three nil" do
+      {visitor, network} = visitor_with_network(6667)
+      subject = {:visitor, visitor.id}
+      {:ok, plan} = VisitorSessionPlan.resolve(visitor, network)
+
+      deps = Deps.from_opts(subject, plan)
+
+      assert is_function(deps.credential_failer, 1)
+      assert is_function(deps.last_joined_persister, 2)
+      assert is_function(deps.recover_source, 0)
+      assert is_function(deps.visitor_committer, 3)
+      assert is_function(deps.visitor_nick_persister, 2)
+      assert is_function(deps.visitor_password_rotator, 2)
+
+      assert deps.away_persister == nil
+      assert deps.credential_committer == nil
+      assert deps.registration_committer == nil
+    end
+
+    test "query_window_open? falls back to the production default and an override wins" do
+      subject = {:user, "u"}
+      opts = complete_opts(subject)
+      fake = fn _, _, _ -> true end
+
+      assert Deps.from_opts(subject, opts).query_window_open? == (&QueryWindows.open?/3)
+
+      assert Deps.from_opts(subject, Map.put(opts, :query_window_open?, fake)).query_window_open? ==
+               fake
+    end
+
+    test "query_window_open? is accepted on the visitor tag too, and is due on neither" do
+      subject = {:visitor, "v"}
+      fake = fn _, _, _ -> true end
+
+      refute Map.has_key?(Deps.required_injections(subject), :query_window_open?)
+
+      assert %Deps{} =
+               Deps.from_opts(subject, Map.put(complete_opts(subject), :query_window_open?, fake))
+    end
+  end
+
+  describe "from_opts/2 refuses a set that does not match the tag" do
+    test "a user plan missing away_persister raises and names ONLY the missing key" do
+      subject = {:user, "u"}
+      opts = Map.delete(complete_opts(subject), :away_persister)
+
+      message = raise_message(subject, opts)
+
+      assert message =~ "away_persister"
+      refute message =~ "credential_failer"
+      refute message =~ "last_joined_persister"
+    end
+
+    test "a plan missing several due keys names all of them" do
+      subject = {:visitor, "v"}
+      opts = Map.drop(complete_opts(subject), [:recover_source, :visitor_nick_persister])
+
+      message = raise_message(subject, opts)
+
+      assert message =~ "recover_source"
+      assert message =~ "visitor_nick_persister"
+      refute message =~ "visitor_committer"
+    end
+
+    test "an explicit nil is MISSING, not supplied — the silent shape the old door accepted" do
+      subject = {:user, "u"}
+      opts = Map.put(complete_opts(subject), :credential_failer, nil)
+
+      assert raise_message(subject, opts) =~ "credential_failer"
+    end
+
+    test "a visitor closure on a user session raises as ALIEN, not as missing" do
+      subject = {:user, "u"}
+      opts = Map.put(complete_opts(subject), :visitor_committer, fn _, _, _ -> :ok end)
+
+      message = raise_message(subject, opts)
+
+      assert message =~ "visitor_committer"
+      assert message =~ "not due"
+      refute message =~ "away_persister"
+    end
+
+    test "a user closure on a visitor session raises as ALIEN too" do
+      subject = {:visitor, "v"}
+      opts = Map.put(complete_opts(subject), :away_persister, fn _, _ -> :ok end)
+
+      message = raise_message(subject, opts)
+
+      assert message =~ "away_persister"
+      assert message =~ "not due"
+    end
+
+    test "a due key supplied at the wrong arity raises and reports both arities" do
+      subject = {:user, "u"}
+      opts = Map.put(complete_opts(subject), :last_joined_persister, fn _ -> :ok end)
+
+      message = raise_message(subject, opts)
+
+      assert message =~ "last_joined_persister"
+      assert message =~ "expected 2"
+      assert message =~ "got 1"
+    end
+
+    test "the subject tag is named, so the message says which set was expected" do
+      subject = {:visitor, "v"}
+      opts = Map.delete(complete_opts(subject), :recover_source)
+
+      assert raise_message(subject, opts) =~ ":visitor"
+    end
+  end
+
+  # The arity-correct injection set for `subject`, built FROM the SSOT so a
+  # new due key cannot be silently forgotten here — the helper grows with
+  # the table, and the drift tests above keep the table honest against the
+  # two real producers.
+  defp complete_opts(subject) do
+    subject
+    |> Deps.required_injections()
+    |> Map.new(fn {key, arity} -> {key, inert(arity)} end)
+  end
+
+  defp inert(0), do: fn -> {:error, :nothing_to_recover} end
+  defp inert(1), do: fn _ -> :ok end
+  defp inert(2), do: fn _, _ -> :ok end
+  defp inert(3), do: fn _, _, _ -> {:error, :not_found} end
+
+  # Every injectable key the plan actually carries, mapped to the arity it
+  # carries it at. Scoped to `injectable_keys/0` rather than to the tag's
+  # own due set on purpose: an EXTRA closure (a visitor callback leaking
+  # into the user plan) must show up as a surplus key, not be filtered out.
+  defp injected_arities(plan) do
+    plan
+    |> Map.take(Deps.injectable_keys())
+    |> Map.new(fn {key, fun} -> {key, elem(Function.info(fun, :arity), 1)} end)
+  end
+
+  defp raise_message(subject, opts) do
+    Exception.message(assert_raise(DepsInjectionError, fn -> Deps.from_opts(subject, opts) end))
+  end
+end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -48,6 +48,7 @@ defmodule Grappa.Session.ServerTest do
   }
 
   alias Grappa.SessionStateHelpers
+  alias Grappa.Visitors.SessionPlan, as: VisitorSessionPlan
   alias Grappa.WindowCounts.PushSource
 
   # #543 INC-6 — the armed static-mapping prefix the test alias-manager binds
@@ -101,31 +102,27 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
-  # #543 INC-6 — a full synthetic connect plan (no `refresh_plan`, so the
-  # injected `managed_source_alias` isn't re-resolved away by the DB-wins
-  # closure) pointing at the in-process `IRCServer` fake. `source_address` is
-  # `nil` so the loopback connect actually binds: INC-6 acquire/release keys on
-  # `managed_source_alias`, which the plan sets equal to `source_address` in
-  # prod (asserted at the SessionPlan layer) but which we decouple here to
-  # isolate the alias-lifecycle from the orthogonal socket-bind concern.
-  defp derived_alias_opts(user, network, port, managed_alias) do
-    %{
-      subject: {:user, user.id},
-      subject_label: Grappa.Subject.label({:user, user.name}),
-      network_slug: network.slug,
-      nick: "vjt",
-      ident: "vjt",
-      realname: "vjt",
-      sasl_user: "vjt",
-      auth_method: :none,
-      password: nil,
-      autojoin_channels: [],
-      host: "127.0.0.1",
-      port: port,
-      tls: false,
-      source_address: nil,
-      managed_source_alias: managed_alias
-    }
+  # #543 INC-6 — the connect plan production builds, with two keys
+  # overridden. `source_address` is `nil` so the loopback connect actually
+  # binds: INC-6 acquire/release keys on `managed_source_alias`, which the
+  # plan sets equal to `source_address` in prod (asserted at the
+  # SessionPlan layer) but which we decouple here to isolate the
+  # alias-lifecycle from the orthogonal socket-bind concern.
+  #
+  # `refresh_plan` is dropped EXPLICITLY, because it is the DB-wins closure
+  # and would re-resolve both overrides away inside `init/1`. It used to be
+  # absent by virtue of the whole plan being hand-built — a synthetic map
+  # that also carried none of the five USER closures, which #1398 turned
+  # from an invisible omission into a spawn-time raise
+  # (`Grappa.Session.Deps.from_opts/2`). Resolving the real plan and
+  # naming the one key this test must NOT have is the honest shape: the
+  # exclusion is now a line of code instead of a silence.
+  defp derived_alias_opts(user, network, managed_alias) do
+    {:ok, plan} = SessionPlan.resolve(Credentials.get_credential!(user, network))
+
+    plan
+    |> Map.drop([:refresh_plan])
+    |> Map.merge(%{source_address: nil, managed_source_alias: managed_alias})
   end
 
   # #211 phase 7 — the visitor nick lives on its per-network credential now
@@ -829,7 +826,7 @@ defmodule Grappa.Session.ServerTest do
       expect(Grappa.Net.SourceAliasMock, :release_source, fn ^addr, @inc6_prefix -> :ok end)
 
       {:ok, pid} =
-        Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, addr))
+        Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, addr))
 
       IRCServer.await_handshake(server, 1_000)
 
@@ -853,7 +850,7 @@ defmodule Grappa.Session.ServerTest do
       expect(Grappa.Net.SourceAliasMock, :release_source, fn ^addr, @inc6_prefix -> :ok end)
 
       {:ok, pid} =
-        Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, addr))
+        Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, addr))
 
       IRCServer.await_handshake(server, 1_000)
       :ok = GenServer.stop(pid, :normal, 1_000)
@@ -873,10 +870,10 @@ defmodule Grappa.Session.ServerTest do
       expect(Grappa.Net.SourceAliasMock, :release_source, fn ^addr, @inc6_prefix -> :ok end)
 
       {:ok, pid1} =
-        Session.start_session({:user, user1.id}, net1.id, derived_alias_opts(user1, net1, port1, addr))
+        Session.start_session({:user, user1.id}, net1.id, derived_alias_opts(user1, net1, addr))
 
       {:ok, pid2} =
-        Session.start_session({:user, user2.id}, net2.id, derived_alias_opts(user2, net2, port2, addr))
+        Session.start_session({:user, user2.id}, net2.id, derived_alias_opts(user2, net2, addr))
 
       IRCServer.await_handshake(server1, 1_000)
       IRCServer.await_handshake(server2, 1_000)
@@ -897,7 +894,7 @@ defmodule Grappa.Session.ServerTest do
       # managed_source_alias nil → NO ensure_source (no expect set — an
       # unexpected call fails verify_on_exit!), and no holder registration.
       {:ok, pid} =
-        Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, port, nil))
+        Session.start_session({:user, user.id}, network.id, derived_alias_opts(user, network, nil))
 
       IRCServer.await_handshake(server, 1_000)
 
@@ -924,7 +921,7 @@ defmodule Grappa.Session.ServerTest do
 
       opts =
         user
-        |> derived_alias_opts(network, port, addr)
+        |> derived_alias_opts(network, addr)
         |> Map.put(:network_id, network.id)
 
       Process.flag(:trap_exit, true)
@@ -987,32 +984,23 @@ defmodule Grappa.Session.ServerTest do
       # Task 6.5 isolation guarantee. The registry key is
       # `{:session, subject, network_id}` — different first-tuple-element
       # discriminates user from visitor even when the underlying UUID
-      # happens to coincide. Visitor.SessionPlan + visitor wiring land
-      # in Task 7+; this test hand-crafts the visitor opts to isolate
-      # the subject-tuple registry behavior at the Session boundary.
+      # happens to coincide. Both subjects are spawned from the plan their
+      # own producer builds — this used to hand-craft the visitor opts
+      # ("Visitor.SessionPlan lands in Task 7+"), which by now means a map
+      # carrying none of the six visitor closures; #1398's spawn-time guard
+      # refuses that, and the producer has existed since Task 7 anyway.
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port)
       user_pid = start_session_for(user, network)
 
-      visitor_id = Ecto.UUID.generate()
-      visitor_subject = {:visitor, visitor_id}
+      visitor =
+        visitor_fixture(
+          nick: "vsh-#{System.unique_integer([:positive])}",
+          network_slug: network.slug
+        )
 
-      visitor_plan = %{
-        subject: visitor_subject,
-        subject_label: "visitor:" <> visitor_id,
-        network_slug: network.slug,
-        nick: "vsh",
-        ident: "vsh",
-        realname: "Grappa Visitor",
-        sasl_user: "vsh",
-        auth_method: :none,
-        password: nil,
-        autojoin_channels: [],
-        host: "127.0.0.1",
-        port: port,
-        tls: false,
-        source_address: nil
-      }
+      visitor_subject = {:visitor, visitor.id}
+      {:ok, visitor_plan} = VisitorSessionPlan.resolve(visitor, network)
 
       Process.flag(:trap_exit, true)
       {:ok, visitor_pid} = Session.start_session(visitor_subject, network.id, visitor_plan)
@@ -8920,32 +8908,27 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "visitor session: 465 terminates cleanly with :normal (no credential row to mark)" do
-      # Visitors have ephemeral credentials — connection_state is irrelevant
-      # and there is no credential_failer in the plan. The session simply
-      # exits :normal without attempting any DB write.
+      # Visitors have ephemeral credentials, so no `network_credentials`
+      # row transitions to `:failed` here the way the user arm's does.
+      #
+      # The note that used to stand here — "no credential_failer — visitor
+      # plans don't include it" — was FALSE, and the hand-built plan below
+      # it was what kept the lie invisible: `Visitors.SessionPlan` has
+      # injected a `credential_failer` since CP24 bucket E (it calls
+      # `Visitors.mark_failed/2`, expiring the visitor ROW so Bootstrap
+      # stops respawning). #1398's spawn-time guard refuses a visitor plan
+      # missing it, which is how the false premise surfaced. The real plan
+      # is used now; the failer runs detached under `Grappa.TaskSupervisor`
+      # and this test deliberately pins only the exit reason, not that
+      # asynchronous effect.
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
-      visitor_id = Ecto.UUID.generate()
-      visitor_subject = {:visitor, visitor_id}
-
       {_, network, _} = setup_user_and_network(port)
 
-      visitor_plan = %{
-        subject: visitor_subject,
-        subject_label: "visitor:" <> visitor_id,
-        network_slug: "test-visitor-#{System.unique_integer([:positive])}",
-        nick: "visitor-test",
-        ident: "visitor-test",
-        realname: "Visitor",
-        sasl_user: "visitor-test",
-        auth_method: :none,
-        password: nil,
-        autojoin_channels: [],
-        host: "127.0.0.1",
-        port: port,
-        tls: false,
-        source_address: nil
-        # Note: no credential_failer — visitor plans don't include it
-      }
+      visitor =
+        visitor_fixture(nick: "visitor-test", network_slug: network.slug)
+
+      visitor_subject = {:visitor, visitor.id}
+      {:ok, visitor_plan} = VisitorSessionPlan.resolve(visitor, network)
 
       {:ok, visitor_pid} = Grappa.Session.start_session(visitor_subject, network.id, visitor_plan)
       ref = Process.monitor(visitor_pid)


### PR DESCRIPTION
Bucket **I dependency-inversion** of the 2026-08-15 architecture review — the half that survives. Issue #1398.

Half the finding was already dead: #1399 removed every active `dirty_xrefs`, so the 31 cycles are gone rather than waived, and the proposed `Session.Control` extraction would have broken none of them (it needs `Server`, so it cannot be the leaf the review wanted). §7 landed separately as `ae4c52be`. **No boundary is added, removed or re-declared here.**

## The problem

Ten closures are injected into `Session.Server`. A closure carries no module reference, so Boundary cannot follow the edge. Built with `Map.get(opts, :key)`, an omitted injection was not a compile error, not a crash and not a log line — it was a `nil` field, and the first path that reached for it simply did not persist.

`nil` could not just be banned, because it is correct half the time.

## The measurement that gives the design

There are exactly **two producers and they inject disjoint sets**, measured against the live output of `Networks.SessionPlan` and `Visitors.SessionPlan` rather than read off the review:

| | keys |
|---|---|
| shared (2) | `credential_failer`, `last_joined_persister` |
| user-only (3) | `away_persister`, `credential_committer`, `registration_committer` |
| visitor-only (4) | `recover_source`, `visitor_committer`, `visitor_nick_persister`, `visitor_password_rotator` |

So an absent `away_persister` is a bug on a user session and correct by construction on a visitor one. `nil` is not a default — it is a function of the **subject tag**, which `Grappa.Subject` already carries.

## What lands

`Deps.from_opts/2` takes the subject and validates the set due for that tag, raising `Grappa.Session.DepsInjectionError` naming **only** the offending keys. Four previously-silent ways to be wrong:

- a due key absent;
- a due key present as `nil` — the exact value the old door swallowed;
- a due key at the wrong **arity** (a wrong-shaped closure otherwise fails at the call site, deep inside a running session on the rare path that reaches it — the same late-and-silent failure);
- a key due for the **other** tag.

`required_injections/1` is the single source of truth. Neither producer can name it (both boundaries already dep `Grappa.Session`, so the reverse edge closes the very cycle these closures exist to dodge), so `Grappa.Session.DepsTest` keeps the two sides in step by measuring each producer's **real resolved plan** against the table, in both directions — a closure added to a plan with no table entry is red, and so is a table entry no plan injects.

### Why raising is safe under a `:transient` child

It happens in `do_init/1`, before registration and before the socket, so `start_link/1` returns `{:error, _}` and `DynamicSupervisor` propagates it. A child that never started is not restarted. A later respawn cannot reach the state either: the supervisor replays the cached spec and `refresh_plan`'s `Map.merge/2` can only add keys. The `{:hold, _}` arm `:ignore`s earlier still.

### Nine keys, not the review's ten — and the limitation

The review's ten is the union of what the producers inject and includes `refresh_plan`, which is **not a field on this struct**. `Server.init/1` consumes it before `do_init/1`, and its return value *replaces* the opts the struct is then built from, so a check here would run after the fact. It stays **unguarded** — a documented limitation carried in `t:injectable/0`, not a claim that its absence is safe. `query_window_open?` is the tenth *struct* field and is out for the opposite reason: no producer injects it and it has a real production default.

## What the guard found on its way in

Three test sites built partial plans on purpose; they now come from their producers, with the one load-bearing exclusion spelled `Map.drop([:refresh_plan])` instead of expressed as a silence. One of them carried a **false premise**: "no `credential_failer` — visitor plans don't include it". `Visitors.SessionPlan` has injected one since CP24 bucket E (it calls `Visitors.mark_failed/2`, expiring the visitor row so Bootstrap stops respawning). The hand-built plan is what kept that claim from ever being contradicted.

## Gates

Measured on base `2ed5fb51` under `GRAPPA_CACHE_ID=w2-1398`:

- **RED observed first**: 15/15 failures, `rc=3`. Content proof the run saw the worktree — it executed `deps_test.exs`, a file that does not exist on `main`.
- `scripts/check.sh` → `rc=0`: credo strict *"6128 mods/funs, found no issues"*, dialyzer *"Total errors: 0"*, sobelow, bats, and the embedded suite at **6680 tests, 0 failures**.
- `scripts/test.sh` standalone → `rc=0`, same 6680/0.
- Rebased onto `413d07fa` with `scripts/union-rebase.sh`: *"docs/DESIGN_NOTES.md: +107 -0 — contribution intact"*, and the entry boundary re-read on the real file (full stop / marker / blank / `---` / blank / heading). Marker `#1398c` unique (`grep -Fxc` = 1).

**Not claimed.** That an omitted injection has ever fired in production — the failure mode is silent by construction, so the absence of reports is not evidence either way, and nothing here measured it. That `refresh_plan` has no legitimate absent case: it is excluded by structure, not absolved.

**Post-rebase re-run, now landed.** `scripts/check.sh` on `578b04a7` — the exact head of this PR, working tree clean — `rc=0`: credo *"6128 mods/funs, found no issues"*, dialyzer *"Total errors: 0"*, suite **6680 tests, 0 failures**. This closes the gap an earlier revision of this body declared: the green is no longer only on `2ed5fb51`.
