### PR TITLE
#1646 slice 2: pin the last 42 mirrored declarations, and one refusal

### DIFF
--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -60,6 +60,7 @@ import {
   refreshScrollback,
   scrollbackByChannel,
 } from "./lib/scrollback";
+import { LOAD_MORE_THRESHOLD_PX, SCROLL_BOTTOM_THRESHOLD_PX } from "./lib/scrollThresholds";
 import { scrollToBottomRequest } from "./lib/scrollToBottomCommand";
 import { setCursorIfAdvances, setSelectedChannel } from "./lib/selection";
 import type { Point } from "./lib/swipe";
@@ -154,8 +155,6 @@ export type Props = {
   kind: WindowKind;
 };
 
-const SCROLL_BOTTOM_THRESHOLD_PX = 50;
-
 // UX-8 (b): scroll-settle debounce — fire the cursor update 500ms after
 // the last scroll event. Resets on every scroll, so iOS momentum
 // scrolling (events fire for 1-2s after finger lift) settles to a
@@ -202,15 +201,6 @@ const SCROLL_KEYS = new Set<string>([
   "ArrowDown",
   " ", // Space — page-down convention
 ]);
-
-// CP14 B2: trigger `loadMore` when the user scrolls within this many
-// pixels of the top. 200px is a standard infinite-scroll threshold —
-// fires before the user actually hits the top so the new rows can
-// land while there's still scroll runway, avoiding the "land at the
-// very top, brief stutter, then content shifts" UX. The verb itself
-// (lib/scrollback.ts loadMore) gates the burst and end-of-history
-// cases; this constant only controls when to *try*.
-const LOAD_MORE_THRESHOLD_PX = 200;
 
 // #285 reopen part (3) — defensive post-mount settle re-measure schedule. The
 // reported cold-iOS-PWA relaunch latch corrects via a viewport settle that

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -1,9 +1,12 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { SHORT_HASH_LEN } from "../lib/bundleHash";
 import { PULL_COMMIT_PX } from "../lib/pullGesture";
+import { PUSH_OPTIN_DECLINED_KEY } from "../lib/pushOptin";
 import { REPLY_QUOTE_BODY_LIMIT, REPLY_QUOTE_TAIL } from "../lib/replyQuote";
 import { UNREAD_RETENTION_CAP } from "../lib/scrollback";
+import { LOAD_MORE_THRESHOLD_PX, SCROLL_BOTTOM_THRESHOLD_PX } from "../lib/scrollThresholds";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "../lib/windowKinds";
 
 // #1646 — the e2e tree hand-copies production constants, and until this file
@@ -32,22 +35,27 @@ import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "../lib/windowKinds";
 // `versionSource.test.ts` — vitest runs from the cicchetto dir, so both `src`
 // and `e2e` are at cwd.
 //
-// ⚠️ SCOPE, and it is narrow. #1646 measured 13 production constants copied
-// into 53 e2e declarations. Pinned here: the 6 whose production side is
-// TypeScript and ALREADY exported — 11 declarations. The other 7 are not
-// pinnable without a decision that is not this file's to take:
-//   - 5 are module-private in production (`SCROLL_BOTTOM_THRESHOLD_PX`,
-//     `LOAD_MORE_THRESHOLD_PX`, `PUSH_OPTIN_DECLINED_KEY`, `SHORT_HASH_LEN`,
-//     `AWAY_SET_LINE`) — 25 declarations, the two largest clusters among them.
-//     Exporting a constant to be testable, or moving it into `lib/`, is a
-//     product call.
-//   - 2 are Elixir module attributes (`MessagesController.@default_limit` and
-//     `@max_http_limit`) — 17 declarations. There is precedent for shipping a
-//     server number to the client mechanically (`mix grappa.gen_wire_types`
-//     with the drift gate in `scripts/check.sh`), and picking it is likewise a
-//     product call.
-// Neither is worked around here. A pin over an exported constant is the part
-// that needed no permission.
+// ⚠️ SCOPE. #1646 measured 13 production constants copied into 53 e2e
+// declarations. Slice 1 pinned the 6 whose production side was TypeScript and
+// ALREADY exported — 11 declarations — and left the other 7 to a product call.
+// Slice 2 took that call (vjt, 2026-08-21) and closed all of them:
+//   - `SCROLL_BOTTOM_THRESHOLD_PX` + `LOAD_MORE_THRESHOLD_PX` (22 declarations)
+//     MOVED out of `ScrollbackPane.tsx` into `src/lib/scrollThresholds.ts`,
+//     which argues its own case. They are `MIRRORS` rows like any other now.
+//   - `PUSH_OPTIN_DECLINED_KEY` + `SHORT_HASH_LEN` (1 each) were already under
+//     `lib/` and only lacked `export`; each declaration says why exporting it
+//     gives away nothing it had.
+//   - `AWAY_SET_NOTICE` (1) stays private, and is pinned by `TEXT_MIRRORS` —
+//     the weaker text-vs-text oracle. See that table for the refusal.
+//   - the 2 Elixir module attributes (17 declarations) are pinned SERVER-SIDE,
+//     in `test/grappa_web/controllers/messages_limit_mirror_test.exs`. They
+//     cannot be pinned from here: `scripts/bun.sh` bind-mounts ONLY
+//     `cicchetto/` at `/app`, so no path from this file reaches `lib/*.ex`.
+//     Do not try — `../lib` RESOLVES inside that container, to the Debian
+//     image's own `/lib`, and only the read fails.
+// `mix grappa.gen_wire_types` was considered for the Elixir pair and declined:
+// it ships wire TYPES, and teaching it to carry arbitrary constants inflates it
+// for two numbers a text read already covers.
 //
 // ⚠️ What this CANNOT do: it cannot find a mirror that has ALREADY drifted.
 // Every declaration below was found because the two sides carry the same
@@ -129,6 +137,104 @@ const MIRRORS: readonly Mirror[] = [
     name: "PULL_COMMIT_PX",
     production: PULL_COMMIT_PX,
     origin: "PULL_COMMIT_PX = SWIPE_MIN_PX * 2 (src/lib/pullGesture.ts)",
+  },
+
+  // The scroll-edge pair (#1646 slice 2). `SCROLL_BOTTOM_THRESHOLD_PX` is the
+  // most-copied constant in the tree by a wide margin — 20 declarations, one
+  // per spec that has to decide "is this pane at its tail".
+  ...[
+    "e2e/fixtures/scrollGesture.test.ts",
+    "e2e/tests/bug7-ios-own-msg-visible.spec.ts",
+    "e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts",
+    "e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts",
+    "e2e/tests/issue1089-switch-into-unread-flicker.spec.ts",
+    "e2e/tests/issue1121-overlay-close-tail-reader.spec.ts",
+    "e2e/tests/issue168-scroll-authority.spec.ts",
+    "e2e/tests/issue196-preview-scroll-live-arrival.spec.ts",
+    "e2e/tests/issue243-tap-active-scroll-bottom.spec.ts",
+    "e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts",
+    "e2e/tests/issue280-button-coexist.spec.ts",
+    "e2e/tests/issue289-float-btn-opacity.spec.ts",
+    "e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts",
+    "e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts",
+    "e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts",
+    "e2e/tests/issue580-send-snap-independent-of-post.spec.ts",
+    "e2e/tests/issue625-single-send-scroll-jump.spec.ts",
+    "e2e/tests/scroll-multi-roundtrip-contamination.spec.ts",
+    "e2e/tests/scroll-on-window-switch.spec.ts",
+    "e2e/tests/scroll-to-bottom-button-contamination.spec.ts",
+  ].map(
+    (file): Mirror => ({
+      file,
+      name: "SCROLL_BOTTOM_THRESHOLD_PX",
+      production: SCROLL_BOTTOM_THRESHOLD_PX,
+      origin: "SCROLL_BOTTOM_THRESHOLD_PX (src/lib/scrollThresholds.ts)",
+    }),
+  ),
+  ...[
+    "e2e/tests/cp14-b2-scroll-up-loadmore.spec.ts",
+    "e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts",
+  ].map(
+    (file): Mirror => ({
+      file,
+      name: "LOAD_MORE_THRESHOLD_PX",
+      production: LOAD_MORE_THRESHOLD_PX,
+      origin: "LOAD_MORE_THRESHOLD_PX (src/lib/scrollThresholds.ts)",
+    }),
+  ),
+
+  {
+    file: "e2e/tests/push-459-optin-banner.spec.ts",
+    name: "PUSH_OPTIN_DECLINED_KEY",
+    production: PUSH_OPTIN_DECLINED_KEY,
+    origin: "PUSH_OPTIN_DECLINED_KEY (src/lib/pushOptin.ts)",
+  },
+  {
+    file: "e2e/tests/issue1063-refresh-visible-feedback.spec.ts",
+    name: "SHORT_HASH_LEN",
+    production: SHORT_HASH_LEN,
+    origin: "SHORT_HASH_LEN (src/lib/bundleHash.ts)",
+  },
+];
+
+/**
+ * A mirror whose production side is read as TEXT rather than imported.
+ *
+ * A WEAKER oracle than `Mirror`, and used only where importing the original
+ * would mean changing production to suit a test. Both sides are read off disk,
+ * so this catches the two copies drifting apart — the defect #1646 names — but
+ * unlike `Mirror` it never observes the value the product actually computes.
+ * Prefer `Mirror`; reach for this when the alternative is moving or exporting a
+ * constant that has no business being moved or exported.
+ */
+type TextMirror = {
+  /** e2e file, relative to the cicchetto dir. */
+  readonly file: string;
+  /** The name the e2e side gives it. */
+  readonly name: string;
+  /** The production file, relative to the cicchetto dir. */
+  readonly originFile: string;
+  /** The production spelling — regularly NOT the e2e spelling. */
+  readonly originName: string;
+};
+
+// `AWAY_SET_NOTICE` stays private in `ComposeBox.tsx` (#1646 slice 2), and this
+// is the pin that costs production nothing to get.
+//
+// It is one half of a PAIR — `AWAY_UNSET_NOTICE` is its twin and has no e2e
+// mirror at all — and its own comment places it in a family kept beside the
+// component that renders it ("Same lowercase-topic register as the other
+// notices"). Moving it to `lib/` would split the pair and make it the only
+// centralised notice string in the tree, to buy a pin on ONE declaration; the
+// scroll-edge pair moved because the concept was already shared, and this one
+// is not. Exporting it in place would be the same trade with a smaller radius.
+// So both sides are read as text instead.
+const TEXT_MIRRORS: readonly TextMirror[] = [
+  {
+    file: "e2e/tests/issue1226-away-seam-feedback.spec.ts",
+    name: "AWAY_SET_LINE",
+    originFile: "src/ComposeBox.tsx",
+    originName: "AWAY_SET_NOTICE",
   },
 ];
 
@@ -276,10 +382,40 @@ describe("e2e mirrors of production constants (#1646)", () => {
     });
   }
 
+  for (const mirror of TEXT_MIRRORS) {
+    it(`${mirror.file} — ${mirror.name} still equals ${mirror.originName} (${mirror.originFile}, read as text)`, () => {
+      // Deliberately the SAME extractor on both sides. The production file is a
+      // `.tsx` component this test must not import — that is the whole reason
+      // the pin is here — so "read the declaration as text" is applied twice
+      // rather than once, and each side must yield exactly one plain literal.
+      const sides = [
+        { label: mirror.originFile, name: mirror.originName },
+        { label: mirror.file, name: mirror.name },
+      ].map((side) => {
+        const declarations = declarationsOf(readFileSync(side.label, "utf8"), side.name);
+        expect(declarations, `no \`${side.name}\` declaration in ${side.label}`).toHaveLength(1);
+
+        const declaration = declarations[0] as Declaration;
+        const value = parseLiteral(declaration.literal);
+        expect(
+          value,
+          `${side.label}:${declaration.line} — \`${declaration.literal}\` is not a plain literal, so this pin no longer reads it`,
+        ).not.toBeNull();
+        return value;
+      });
+
+      expect(
+        sides[1],
+        `${mirror.file} — the copy of ${mirror.originName} (${mirror.originFile}) has drifted`,
+      ).toBe(sides[0]);
+    });
+  }
+
   it("has no mirror outside the table", () => {
     const pinned = new Set(MIRRORS.map((m) => `${m.file}\0${m.name}`));
+    for (const text of TEXT_MIRRORS) pinned.add(`${text.file}\0${text.name}`);
     for (const known of KNOWN_UNPINNED) pinned.add(`${known.file}\0${known.name}`);
-    const names = [...new Set(MIRRORS.map((m) => m.name))];
+    const names = [...new Set([...MIRRORS, ...TEXT_MIRRORS].map((m) => m.name))];
 
     const unlisted: string[] = [];
     for (const file of e2eSourceFiles("e2e")) {

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -277,8 +277,8 @@ describe("e2e mirrors of production constants (#1646)", () => {
   }
 
   it("has no mirror outside the table", () => {
-    const pinned = new Set(MIRRORS.map((m) => `${m.file} ${m.name}`));
-    for (const known of KNOWN_UNPINNED) pinned.add(`${known.file} ${known.name}`);
+    const pinned = new Set(MIRRORS.map((m) => `${m.file}\0${m.name}`));
+    for (const known of KNOWN_UNPINNED) pinned.add(`${known.file}\0${known.name}`);
     const names = [...new Set(MIRRORS.map((m) => m.name))];
 
     const unlisted: string[] = [];
@@ -286,7 +286,7 @@ describe("e2e mirrors of production constants (#1646)", () => {
       const src = readFileSync(file, "utf8");
       for (const name of names) {
         if (declarationsOf(src, name).length === 0) continue;
-        if (!pinned.has(`${file} ${name}`)) unlisted.push(`${file} — ${name}`);
+        if (!pinned.has(`${file}\0${name}`)) unlisted.push(`${file} — ${name}`);
       }
     }
 

--- a/cicchetto/src/lib/bundleHash.ts
+++ b/cicchetto/src/lib/bundleHash.ts
@@ -98,7 +98,12 @@ export function shouldShowRefreshBanner(): boolean {
 // without the hash suffix the two sides would read identically and the
 // signal would go dead. `git`-style 7 chars is a familiar, sufficient
 // content fingerprint.
-const SHORT_HASH_LEN = 7;
+//
+// EXPORTED (#1646): this length is part of the RENDERED string, so the e2e spec
+// that asserts the refresh banner has to reconstruct the same truncation and
+// mirrors the number by hand. It is a display-format rule the assertion side
+// legitimately shares, not an internal of the shortening.
+export const SHORT_HASH_LEN = 7;
 
 function shortHash(hash: string | null): string | null {
   return hash !== null && hash !== "" ? hash.slice(0, SHORT_HASH_LEN) : null;

--- a/cicchetto/src/lib/pushOptin.ts
+++ b/cicchetto/src/lib/pushOptin.ts
@@ -25,7 +25,13 @@ import { enablePush, pushAvailable } from "./push";
 // The PERSISTED × decline. Per-browser is correct: it shadows a per-browser
 // Notification permission, so — unlike #449's move to server-side prefs — this
 // stays in localStorage and does NOT sync across devices.
-const PUSH_OPTIN_DECLINED_KEY = "cic.pushOptinDeclined";
+//
+// EXPORTED (#1646): a localStorage key is already a public contract — the slot
+// is readable and writable by anything sharing the origin — so naming it costs
+// no encapsulation that `localStorage` had not already given away. The e2e spec
+// that seeds a declined state mirrors this string by hand; exporting it lets
+// `src/__tests__/e2eConstantMirrors.test.ts` hold the two copies together.
+export const PUSH_OPTIN_DECLINED_KEY = "cic.pushOptinDeclined";
 
 // SESSION-scoped hide, reactive so the banner drops the instant the user acts
 // (accept or ×) without waiting for another source signal to re-derive the

--- a/cicchetto/src/lib/scrollThresholds.ts
+++ b/cicchetto/src/lib/scrollThresholds.ts
@@ -1,0 +1,47 @@
+// #1646 — the two scroll-edge thresholds, in one place.
+//
+// Both answer the same question at opposite edges of the same scroller: how
+// many pixels from an edge still counts as being AT that edge. They were two
+// module-private constants in `ScrollbackPane.tsx`, and they are here because
+// that is where the concept already lived, not because a test wanted to import
+// them.
+//
+// The case for `lib/` is NOT the importer count — `ScrollbackPane` is still the
+// only one in `src/`. It is that the concept already crosses module boundaries
+// in prose and in signatures:
+//   * `readingAtTail.ts` describes `atBottomNow` as "the geometric 'within
+//     threshold of the tail' measurement" and exists precisely because that
+//     answer has to leave the pane for the badge derivation to use it;
+//   * `e2e/fixtures/scrollTrace.ts` takes `thresholdPx` as an OPTION, "passed
+//     in rather than mirrored so the classifier cannot drift away from the
+//     assertion it explains" — a workaround for the missing shared home this
+//     module now provides.
+// Two places had already reached for the value and had to route around its
+// absence. That is shared vocabulary; the pin is a consequence.
+//
+// They live TOGETHER rather than one per module because they are one concept
+// at two edges, and because the e2e tree already treats them as a pair:
+// `issue253-kbd-resize-scroll-preserve.spec.ts` declares both and passes them
+// in a single `{ bottomThreshold, loadMoreThreshold }` object. Splitting them
+// across `scrollAuthority.ts` (intent arbitration — deliberately DOM-free and
+// geometry-free since #608) and `scrollback.ts` (paging data) would be the
+// half-migration that leaves two patterns for the next reader to choose from.
+
+// Distance from the bottom within which the pane counts as AT THE TAIL.
+//
+// This is the definition of "at the tail" for the whole product, not just for
+// the pane that measures it: the scroll-to-bottom button's visibility (C7.4),
+// the `followMode` re-arm, the read-cursor advance, and the unread-badge
+// suppression in `readingAtTail.ts` all mean this number when they say "at the
+// bottom". 50px absorbs sub-pixel layout and momentum overshoot without
+// letting a genuinely scrolled-up pane claim the tail.
+export const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+// CP14 B2: trigger `loadMore` when the user scrolls within this many
+// pixels of the top. 200px is a standard infinite-scroll threshold —
+// fires before the user actually hits the top so the new rows can
+// land while there's still scroll runway, avoiding the "land at the
+// very top, brief stutter, then content shifts" UX. The verb itself
+// (lib/scrollback.ts loadMore) gates the burst and end-of-history
+// cases; this constant only controls when to *try*.
+export const LOAD_MORE_THRESHOLD_PX = 200;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -56636,3 +56636,118 @@ case — both producers inject it, but the one test site that omits it does so
 deliberately, which is why it is excluded by scope rather than declared safe. No
 boundary was added, removed or re-declared; the graph is byte-for-byte the one
 `2ed5fb51` carried._
+<!-- entry #1646b -->
+
+---
+
+## 2026-08-21 — #1646b: the seven mirrors slice 1 could not take on its own
+
+Slice 1 pinned the 6 e2e-mirrored constants whose production side was already
+exported and left 7 open, each needing a call it was not entitled to make: 5
+were module-private in TypeScript, 2 are Elixir module attributes on
+`GrappaWeb.MessagesController`. vjt ruled both forks on 2026-08-21 — move the
+private ones into `lib/`, pin the Elixir pair by reading the `.ex` as text —
+and this entry records the reasoning, since the pins themselves are mechanics.
+
+### Why `lib/` and not `export`, and why one constant refused both
+
+`SCROLL_BOTTOM_THRESHOLD_PX` (20 copies) and `LOAD_MORE_THRESHOLD_PX` (2) moved
+out of `ScrollbackPane.tsx` into a new `src/lib/scrollThresholds.ts`. The test
+applied was **does this read as shared vocabulary or as one component's private
+detail**, and the answer is not the importer count — `ScrollbackPane` is still
+the only consumer in `src/`. It is that the concept had already escaped the
+component twice, each time by routing around the absent module:
+`readingAtTail.ts` exists because the pane's *"within threshold of the tail"*
+answer has to cross a module boundary for the badge derivation, and
+`e2e/fixtures/scrollTrace.ts` takes `thresholdPx` as an OPTION rather than a
+mirror *"so the classifier cannot drift away from the assertion it explains"*.
+Two workarounds for one missing home is what shared vocabulary looks like
+before someone names it. They live together because they are one concept at two
+edges, and because `issue253-kbd-resize-scroll-preserve.spec.ts` already
+declares both and passes them as a single `{ bottomThreshold, loadMoreThreshold }`
+pair.
+
+`PUSH_OPTIN_DECLINED_KEY` and `SHORT_HASH_LEN` were already under `lib/` and
+only lacked `export`. Neither export concedes anything the module still held: a
+localStorage key names a slot every script on the origin can already read, and
+`pushOptin.ts` ships a `__resetPushOptinForTests()` seam that is a wider hole
+than the key itself; `SHORT_HASH_LEN` is part of the rendered banner string, so
+the assertion side reconstructs that truncation whether or not we name it.
+
+`AWAY_SET_NOTICE` was **refused**, and the refusal is the point of having a
+test rather than an order. It is half a pair — `AWAY_UNSET_NOTICE` has no e2e
+mirror at all — and its own comment places it in a family of notice strings
+kept beside the component that renders them. Moving it to `lib/` would split
+the pair and make it the only centralised notice in the tree, to buy a pin on
+ONE declaration; exporting it in place is the same trade with a smaller radius.
+It is pinned instead by a second, explicitly weaker table (`TEXT_MIRRORS`) that
+reads BOTH sides as text: that still catches the two copies drifting, which is
+the defect #1646 names, while never observing the value the product computes.
+**A constant that lands in `lib/` only to become importable is the same smell
+as exporting one to make it testable** — the move has to be right on its own.
+
+### The Elixir pair moved LANE, not technique
+
+The ruling said "read the `.ex` as text", and the natural home looked like the
+vitest file holding the other eleven. It cannot go there, and the measurement
+that says so is the eighth instance of this repo's plausible false zero — with
+a mechanism none of the previous seven had.
+
+`scripts/bun.sh` bind-mounts **only** `cicchetto/` at `/app` (`-w /app`); the
+script says so itself, which is why `GRAPPA_VERSION` is computed on the host
+and passed as env. Probed from inside that container:
+
+```
+../lib                                  = EXISTS
+../lib/…/messages_controller.ex         = ENOENT
+../VERSION, ../mix.exs                  = ENOENT
+e2e/tests (control)                     = EXISTS
+```
+
+**`../lib` resolves — to the Debian base image's own `/lib`.** An existence
+check on the directory passes, a `readdir` returns `systemd dpkg apt`, and only
+the read of the actual file fails. A guard written to probe-then-skip would
+have reported itself healthy forever over a path that was never the repo's.
+The general rule: *when a container gives you a partial mount, the parent of
+your mount point is not absent — it is the IMAGE's, and it will answer.*
+
+So the pin is server-side, in
+`test/grappa_web/controllers/messages_limit_mirror_test.exs`. No new
+infrastructure was needed: `scripts/_lib.sh` already bind-mounts
+`cicchetto/e2e` read-only into the Elixir test container for exactly this
+purpose, with `Grappa.Infra.KeepaliveIdleOrderingTest` (#1030) as the
+precedent. `mix grappa.gen_wire_types` was considered and declined — it ships
+wire TYPES, and teaching it to carry arbitrary constants inflates it for two
+integers a text read already covers.
+
+The reader must match the DEFINITION and nothing else, because both names also
+appear interpolated inside the controller's own `@doc` (`#{@default_limit}`,
+`#{@max_http_limit}`) and in the body of `parse_limit/1`. Anchoring on
+`^[ \t]*@name[ \t]+` excludes all of them, and that is asserted twice: as a
+predicate test over the interpolated shapes, and by adding a fresh
+`#{@default_limit}` decoy to the real file and observing the pin stay green.
+
+### A raw NUL byte, invisible to every gate
+
+Slice 1's own file carried three literal NUL bytes where the source meant the
+escape `\0` — the composite-key separator in its out-of-table sweep. It was the
+only file in `cicchetto/src` or `cicchetto/e2e` holding a raw control
+character, measured across every `.ts`/`.tsx` in both trees, and nothing could
+have caught it: `git diff --numstat` reports the file as `101 0` rather than
+binary, so three invisible bytes read as ordinary spaces in the diff, in the
+PR and in the editor, and a NUL inside a template literal is valid TypeScript
+that biome and tsc both accept. The separator is a good idea and is kept — NUL
+cannot occur in a path or an identifier — only its spelling changed.
+
+_What this does NOT establish: that 25 and 17 are the true mirror counts. Both
+censuses are NAME-driven, so a copy spelled differently is invisible to them —
+`e2e/fixtures/scrollTrace.test.ts` declares `THRESHOLD = 50` and feeds it to
+the same `thresholdPx` parameter, but `ClassifyOptions` documents that
+threshold as deliberately passed-in rather than mirrored, so whether it mirrors
+production or merely exercises the classifier could not be established and it
+was left unpinned rather than asserted. `MAX_HTTP_LIMIT` is likewise pinned to
+the server attribute alone, though its spec comment claims it mirrors the
+client's unexported `PAGE_LIMIT` too; the two agree at 200 today and could
+diverge. No already-drifted copy was found — but the census that would find one
+compares literals that already match, so that is a statement about names, not
+about values._

--- a/test/grappa_web/controllers/messages_limit_mirror_test.exs
+++ b/test/grappa_web/controllers/messages_limit_mirror_test.exs
@@ -1,0 +1,214 @@
+defmodule GrappaWeb.MessagesLimitMirrorTest do
+  @moduledoc """
+  #1646 — the e2e specs hand-copy `MessagesController`'s two page-size
+  limits, and until this file nothing compared a copy with its original.
+
+  `@default_limit` (the unconfigured-client page size) is re-declared as
+  `REST_PAGE_SIZE` in 13 specs; `@max_http_limit` (the boundary ceiling)
+  as `MAX_HTTP_LIMIT` in 4. Seventeen numbers kept in lockstep by hand,
+  with no witness: change the attribute and every spec keeps asserting
+  the old page size, silently, because a Playwright spec seeds its own
+  fixture and never asks the server what its default is.
+
+  ## Why the pin lives HERE and not in the cic vitest suite
+
+  Its eleven siblings for the TypeScript constants are in
+  `cicchetto/src/__tests__/e2eConstantMirrors.test.ts`, and these two
+  belong with them by subject. They cannot go there.
+  `scripts/bun.sh` bind-mounts ONLY `cicchetto/` at `/app`, so no path
+  from a vitest file reaches `lib/*.ex`.
+
+  The failure mode is worth naming, because it is a false zero wearing a
+  green hat: from inside that container `../lib` RESOLVES — to the
+  Debian base image's own `/lib` — so an existence check on the
+  directory PASSES and only the read of the file ENOENTs. A guard that
+  probed the directory and skipped when absent would have reported
+  itself healthy forever.
+
+  The server test container has no such problem: `scripts/_lib.sh`
+  already bind-mounts `cicchetto/e2e` read-only into it, precisely so a
+  server-side test can read e2e files, and
+  `Grappa.Infra.KeepaliveIdleOrderingTest` (#1030) is the precedent.
+
+  ## Why text, and not codegen
+
+  `mix grappa.gen_wire_types` already ships server facts to the client
+  with a drift gate, and was considered. It ships wire TYPES; teaching
+  it to carry arbitrary constants inflates it for two integers. Reading
+  both sides as text needs no generator, no export, and no new
+  infrastructure — the cost is that this pin compares two FILES and
+  never observes the value `parse_limit/1` actually computes.
+
+  ## What this CANNOT do
+
+  It cannot see a mirror that has already drifted under a name nobody
+  connected to these attributes, and it cannot see a spec that inlines
+  `50` without naming it. Both sides are found by NAME.
+  """
+
+  use ExUnit.Case, async: true
+
+  @controller "lib/grappa_web/controllers/messages_controller.ex"
+  @e2e_glob "cicchetto/e2e/**/*.{ts,tsx}"
+
+  # {e2e spelling, controller attribute, how many copies exist today}.
+  #
+  # The count is pinned, not discovered, for the same reason the vitest
+  # sibling keeps an explicit table: a copy that VANISHES must red just
+  # as loudly as one that drifts, and a new copy is the cheapest way back
+  # to the state #1646 measured. Landing either means changing the number
+  # here, which is the moment someone reads this.
+  @mirrors [
+    {"REST_PAGE_SIZE", "default_limit", 13},
+    {"MAX_HTTP_LIMIT", "max_http_limit", 4}
+  ]
+
+  describe "the extractors (#1646 — the predicates)" do
+    # A guard that only ever runs over a tree it already agrees with
+    # proves nothing about what it would catch, so both predicates are
+    # pinned on their own before either is trusted.
+
+    test "the attribute reader takes a definition" do
+      assert attribute_values("  @default_limit 50\n", "default_limit") == ["50"]
+    end
+
+    test "the attribute reader REFUSES the same name interpolated in a @doc" do
+      # This is the trap the pin exists to avoid. Both names appear inside
+      # the controller's own `@doc` a few dozen lines below the
+      # definitions, and a reader that matched them would compare the
+      # wrong occurrence while looking entirely healthy.
+      doc = """
+        * `limit` — page size (default `\#{@default_limit}`, HTTP ceiling
+          `\#{@max_http_limit}` enforced at the boundary; `Grappa.Scrollback`
+          non-integer, or > `\#{@max_http_limit}`: 400.
+      """
+
+      assert attribute_values(doc, "default_limit") == []
+      assert attribute_values(doc, "max_http_limit") == []
+    end
+
+    test "the attribute reader REFUSES a mid-line use and a comment" do
+      assert attribute_values("  defp parse_limit(nil), do: {:ok, @default_limit}\n", "default_limit") ==
+               []
+
+      assert attribute_values("  # @default_limit 50\n", "default_limit") == []
+      assert attribute_values("  controller's `@default_limit` is the default,\n", "default_limit") == []
+    end
+
+    test "the attribute reader REFUSES a longer name that starts with the one asked for" do
+      assert attribute_values("  @default_limit_ceiling 99\n", "default_limit") == []
+    end
+
+    test "the declaration reader takes a plain e2e declaration" do
+      assert declaration_values("const REST_PAGE_SIZE = 50;\n", "REST_PAGE_SIZE") == ["50"]
+      assert declaration_values("let REST_PAGE_SIZE: number = 50;\n", "REST_PAGE_SIZE") == ["50"]
+    end
+
+    test "the declaration reader REFUSES prose and a longer name" do
+      assert declaration_values("// const REST_PAGE_SIZE = 50;\n", "REST_PAGE_SIZE") == []
+      assert declaration_values("const REST_PAGE_SIZE_MAX = 50;\n", "REST_PAGE_SIZE") == []
+    end
+
+    test "only a plain integer parses; every other shape is refused" do
+      assert parse_integer("50") == 50
+      assert parse_integer("200") == 200
+      assert parse_integer("0x32") == nil
+      assert parse_integer("50 + 0") == nil
+      assert parse_integer("PAGE_LIMIT") == nil
+    end
+  end
+
+  describe "e2e mirrors of the MessagesController limits (#1646)" do
+    setup do
+      %{controller: File.read!(@controller)}
+    end
+
+    for {e2e_name, attribute, expected_count} <- @mirrors do
+      test "#{e2e_name} in #{expected_count} specs still equals @#{attribute}",
+           %{controller: source} do
+        e2e_name = unquote(e2e_name)
+        attribute = unquote(attribute)
+
+        values = attribute_values(source, attribute)
+
+        assert length(values) == 1,
+               "expected exactly one `@#{attribute}` DEFINITION in #{@controller}, " <>
+                 "found #{length(values)}: #{inspect(values)}. Both names also appear " <>
+                 "interpolated in the @doc; if the definition moved into a shape the " <>
+                 "reader cannot see, this pin has stopped reading it."
+
+        expected = parse_integer(hd(values))
+
+        assert expected,
+               "`@#{attribute} #{hd(values)}` is not a plain integer, so this pin no " <>
+                 "longer reads it — teach the reader the new shape or drop the pin."
+
+        copies = e2e_copies(e2e_name)
+
+        # Anti-vacuous. Zero is the failure this exists for as much as a
+        # wrong value is: a pin with nothing left to compare must not pass.
+        assert length(copies) == unquote(expected_count),
+               "expected #{unquote(expected_count)} `#{e2e_name}` declarations under " <>
+                 "cicchetto/e2e, found #{length(copies)}:\n" <>
+                 Enum.map_join(copies, "\n", fn {file, value} -> "  #{file} = #{value}" end)
+
+        for {file, literal} <- copies do
+          actual = parse_integer(literal)
+
+          assert actual,
+                 "#{file}: `#{e2e_name} = #{literal}` is not a plain integer, " <>
+                   "so this pin no longer reads it"
+
+          assert actual == expected,
+                 "#{file}: the copy of `@#{attribute}` has drifted — " <>
+                   "the spec says #{actual}, #{@controller} says #{expected}"
+        end
+      end
+    end
+  end
+
+  # Every `@name <literal>` DEFINITION, as written, and nothing else. The
+  # anchor is what does the work: an interpolation (`\#{@name}`), a
+  # mid-line use and a `#` comment all fail `^[ \t]*@name[ \t]`, and the
+  # trailing `\b`-equivalent (a required space) rejects `@name_longer`.
+  defp attribute_values(source, name) do
+    ~r/^[ \t]*@#{Regex.escape(name)}[ \t]+(\S.*?)[ \t]*$/m
+    |> Regex.scan(source, capture: :all_but_first)
+    |> List.flatten()
+  end
+
+  # The Elixir twin of `declarationsOf` in the vitest sibling: a
+  # single-line `const`/`let NAME = <literal>`, prose excluded.
+  defp declaration_values(source, name) do
+    pattern = ~r/^[ \t]*(?:const|let)[ \t]+#{Regex.escape(name)}[ \t]*(?::[^=]+)?=[ \t]*(.+?);?[ \t]*$/
+
+    source
+    |> String.split("\n")
+    |> Enum.reject(&prose?/1)
+    |> Enum.flat_map(fn line ->
+      case Regex.run(pattern, line, capture: :all_but_first) do
+        [literal] -> [literal]
+        nil -> []
+      end
+    end)
+  end
+
+  defp prose?(line) do
+    trimmed = String.trim_leading(line)
+    String.starts_with?(trimmed, ["//", "*", "/*"])
+  end
+
+  defp e2e_copies(name) do
+    for path <- Path.wildcard(@e2e_glob),
+        not String.contains?(path, "/node_modules/"),
+        literal <- declaration_values(File.read!(path), name),
+        do: {path, literal}
+  end
+
+  defp parse_integer(literal) do
+    case Integer.parse(literal) do
+      {n, ""} -> n
+      _ -> nil
+    end
+  end
+end


### PR DESCRIPTION
Second slice of #1646. Slice 1 pinned the 6 e2e-mirrored constants whose
production side was already exported (11 declarations) and left 7 open,
each needing a call it was not entitled to make. vjt ruled both forks on
2026-08-21; this closes all seven.

## What landed

| constant | disposition | declarations |
|---|---|---|
| `SCROLL_BOTTOM_THRESHOLD_PX` | moved → `src/lib/scrollThresholds.ts` | 20 |
| `LOAD_MORE_THRESHOLD_PX` | moved → `src/lib/scrollThresholds.ts` | 2 |
| `PUSH_OPTIN_DECLINED_KEY` | `export` in place (already in `lib/`) | 1 |
| `SHORT_HASH_LEN` | `export` in place (already in `lib/`) | 1 |
| `AWAY_SET_NOTICE` | **refused** — pinned text-vs-text instead | 1 |
| `@default_limit` | pinned server-side | 13 |
| `@max_http_limit` | pinned server-side | 4 |

## Three things worth reviewing rather than skimming

**The placement argument, not the placement.** The scroll thresholds went
to `lib/` because the concept had already escaped `ScrollbackPane` twice
and each escape routed around the missing module — `readingAtTail.ts`
exists to carry the pane's "within threshold of the tail" answer across a
boundary, and `e2e/fixtures/scrollTrace.ts` takes `thresholdPx` as an
option "so the classifier cannot drift away from the assertion it
explains". Not the importer count, which is still one. A constant that
lands in `lib/` only to become importable is the same smell as exporting
one to make it testable.

**One refusal.** `AWAY_SET_NOTICE` is half a pair whose twin has no
mirror, in a family of notice strings deliberately kept beside their
components. Moving it would split the pair and make it the only
centralised notice in the tree, for one declaration. It gets a second,
explicitly weaker table (`TEXT_MIRRORS`) that reads both sides as text —
catches the drift, never observes the value the product computes, and
says so in its type doc.

**The Elixir pair changed LANE, not technique.** The ruling said "read
the `.ex` as text"; the natural home looked like the vitest file holding
the other pins, and it cannot be. `scripts/bun.sh` bind-mounts only
`cicchetto/` at `/app`. From inside that container `../lib` **resolves**
— to the Debian base image's own `/lib` — so an existence check passes,
`readdir` returns `systemd dpkg apt`, and only the file read ENOENTs. A
probe-then-skip guard would have called itself healthy forever. The pin
is server-side, using the `cicchetto/e2e` read-only mount `_lib.sh`
already provides for this (precedent: #1030). `gen_wire_types` was
declined: it ships wire TYPES, and two integers do not justify inflating
it.

## Evidence

Every pin was seen failing before it was believed, in both directions and
per constant — production mutated (20 / 2 / 1 / 1 red respectively), a
single e2e copy mutated (1 red each), a copy renamed away (the
zero-declaration assert reds rather than passing with nothing to
compare), a copy added (count reds). For the controller pair also: a
fresh interpolation decoy added to the real file leaves the pin GREEN,
proving the reader matches the definition and not the `@doc`
interpolations. Reverting returns to baseline; the e2e tree was verified
pristine after each run.

Counts were re-measured, not inherited: the census reads as 21 *files*
for `SCROLL_BOTTOM_THRESHOLD_PX`, but one names it only in prose — the
declaration count is 20. Both censuses carried known-answer controls and
print nothing if a control fails, after an early false zero of my own (an
unquoted alternation in a zsh `for` list) reported 0 copies of a constant
that has 1.

Gates, from a private `GRAPPA_CACHE_ID`: `scripts/check.sh` exit 0 —
Credo strict 6134 mods/funs no issues, Sobelow no vulnerabilities,
Dialyzer 0 errors, ExUnit 6689 tests 0 failures, bats 0 `not ok`;
`bun run check` 4/4 stages; `bun run build` clean (the gate that catches
an orphaned import after a move); `bun run test` 5759 passed.

## Also in here

`fix(#1646)` removes three literal NUL bytes from slice 1's own file,
where the source meant the escape. Same runtime string; it was the only
file in `cicchetto/src` or `cicchetto/e2e` carrying a raw control
character. Nothing could have caught it — `git diff --numstat` reports
the file as `101 0` rather than binary, so the bytes read as ordinary
spaces in the diff and the PR, and a NUL in a template literal is valid
TypeScript.

## What this does NOT establish

That 25 and 17 are the true mirror counts — both censuses are
name-driven, so a differently-spelled copy is invisible to them.
`e2e/fixtures/scrollTrace.test.ts` declares `THRESHOLD = 50` and feeds it
to the same `thresholdPx` parameter, but `ClassifyOptions` documents that
threshold as deliberately passed-in rather than mirrored, so whether it
mirrors production or merely exercises the classifier could not be
established; it is left unpinned rather than asserted. `MAX_HTTP_LIMIT`
is pinned to the server attribute alone, though its spec comment claims
it also mirrors the client's unexported `PAGE_LIMIT` — the two agree at
200 today and could diverge. No already-drifted copy was found, but the
census that would find one compares literals that already match, so that
is a statement about names, not values.
