### PR TITLE
docs: deploy-cic.sh does not update the checkout, and what proves a cic deploy

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -608,6 +608,17 @@ and only then tripped the worktree check — dist swapped, then a
 non-zero exit. `ALLOW_DEPLOY_FROM_BRANCH=1` overrides the branch half
 of the check (a pre-existing knob, for the cases where you mean it).
 
+**The assertion is about WHERE and WHICH BRANCH — never about
+FRESHNESS.** `require_main_checkout` (`scripts/_lib.sh:177`) compares
+`SRC_ROOT` against `REPO_ROOT` and reads `git rev-parse --abbrev-ref
+HEAD`. It does not fetch, and it never compares `HEAD` against
+`origin/main`. So "both deploy scripts assert a checkout on main" is
+true of both and tells you NOTHING about whether that checkout is
+current: a main checkout parked twenty commits behind origin passes the
+guard unchanged. `deploy.sh` closes that gap itself by pulling;
+`deploy-cic.sh` does not close it at all, which is why it carries its
+own pre-flight — see its section below.
+
 ### `scripts/deploy.sh` — the Docker substrate consumer
 
 **It is a thin consumer of `infra/lib/deploy_common.sh` (#503).** The
@@ -714,6 +725,60 @@ copies must not drift apart.
 needs a server restart, and a server deploy never triggers a cic
 refresh. Edit `cicchetto/src/`, run this, and connected browsers see
 the refresh banner within seconds.
+
+**🔴 It does NOT update the checkout — it builds whatever is on disk.**
+Its entire source closure is `scripts/_lib.sh` + `infra/lib/cic_dist.sh`,
+and neither contains a `git pull`, a `git fetch` or a `git checkout`. A
+main checkout sitting behind origin therefore builds and ships an OLD
+bundle, and every signal the run emits stays green while it does.
+Measured 2026-08-21: a staging cic deploy from a checkout at `b1d09c95`
+served a bundle missing already-merged work for a minute, with a clean
+run start to finish. The stale checkout showed up in exactly one place —
+`git rev-parse HEAD`. **So the pre-flight is yours, and it is two
+lines that must match:**
+
+```sh
+# from the main checkout (the script refuses to run anywhere else)
+git fetch origin main
+git rev-parse HEAD           # must equal...
+git rev-parse origin/main    # ...this
+scripts/deploy-cic.sh
+```
+
+**The contrast with `scripts/deploy.sh` is the trap.** That script DOES
+update the checkout — but not in its own body, where the only literal
+`git pull` is a comment. `deploy_main` (`infra/lib/deploy_common.sh:373`)
+calls `substrate_pull`, whose Docker implementation
+(`infra/lib/deploy_docker.sh:106`) records `PREV_SHA`, runs `git pull
+--ff-only` on the current branch, and records `NEW_SHA` — skipped only
+by `NO_PULL=1`, which deploys the working tree as-is on purpose. Prod
+differs again: `scripts/deploy-m42.sh --cic` runs
+`infra/freebsd/jail_deploy_cic.sh`, which pulls inside the jail, and the
+host wrapper refuses to start when local main is ahead of origin.
+**`scripts/deploy-cic.sh` is the one cic path where nobody pulls for
+you.**
+
+**What proves a cic deploy actually happened: the mtime of the SERVED
+artefact**, `ls -l runtime/cicchetto-dist/assets/*.js` (or under
+`CIC_DIST_ROOT` where a packaged install relocated it).
+`cic_dist_promote` (`infra/lib/cic_dist.sh:52`) builds into
+`<served>.next` and swaps with two renames, so every successful deploy
+replaces the served directory with freshly written files — the mtime
+moves even for a byte-identical rebuild. Two things that look like
+proof and are not:
+
+- **The hash.** `Grappa.Cic.Bundle` parses Vite's
+  `/assets/index-<hash>.js`, and that hash is a chunk-CONTENT
+  fingerprint. Identical source rebuilds to an identical hash, so an
+  unchanged hash does not mean the deploy failed — and a changed one
+  does not mean the source was current.
+- **The final `✓ cic dist built + broadcast hash=…` line.** It reports
+  that the build ran and the broadcast fired, never what it was built
+  FROM. It is green on a stale checkout. (The 204 guard below is a
+  different failure: a bundle the server cannot READ.)
+
+The mtime proves the SWAP; the `rev-parse` proves the SOURCE. Neither
+substitutes for the other.
 
 **How the banner fires.** `POST /admin/cic-bundle-changed` makes the
 server re-read the new `index.html` via


### PR DESCRIPTION
Docs-only. No script behaviour changes.

## What this records

`scripts/deploy-cic.sh` **never updates the checkout** — it builds whatever the main checkout holds on disk. Its entire source closure is `scripts/_lib.sh` + `infra/lib/cic_dist.sh`, and neither contains a `git pull`, `git fetch` or `git checkout`.

On 2026-08-21 that shipped a staging cic bundle built at `b1d09c95`, missing already-merged work, for about a minute — with a green run start to finish. The stale checkout surfaced in exactly one place: `git rev-parse HEAD`.

## The correction to the note that circulates

The note "both deploy scripts assert a checkout on main" is **true of both scripts** — and that is precisely the trap, so this PR does not repeat the framing that it is false for `deploy-cic.sh`.

`require_main_checkout` (`scripts/_lib.sh:177`) compares `SRC_ROOT` against `REPO_ROOT` and reads `git rev-parse --abbrev-ref HEAD`. It never fetches and never compares `HEAD` against `origin/main`. A main checkout twenty commits behind origin passes it unchanged. The guard is about WHERE and WHICH BRANCH; freshness is a separate axis that nothing in `deploy-cic.sh` covers.

## Three behaviours behind one word

| entry point | updates the checkout? | where |
|---|---|---|
| `scripts/deploy-cic.sh` | **NO** | nowhere in its closure |
| `scripts/deploy.sh` | yes | `substrate_pull` → `infra/lib/deploy_docker.sh:106`, reached via `deploy_main` (`deploy_common.sh:373`). The only literal `git pull` in `scripts/deploy.sh` itself is a **comment** on line 28. `NO_PULL=1` deliberately skips it. |
| `scripts/deploy-m42.sh --cic` | yes | `infra/freebsd/jail_deploy_cic.sh` pulls inside the jail; the host wrapper also refuses when local main is ahead of origin |

So the gotcha is specific to the Docker/local cic path — **not** to cic deploys in general.

## What proves a cic deploy

- **The mtime of the SERVED artefact** (`runtime/cicchetto-dist/assets/*.js`, or under `CIC_DIST_ROOT`). `cic_dist_promote` (`infra/lib/cic_dist.sh:52`) builds into `<served>.next` and swaps with two renames, so every successful deploy installs a freshly written directory — the mtime moves even for a byte-identical rebuild.
- **NOT the hash.** `Grappa.Cic.Bundle` parses Vite's `/assets/index-<hash>.js`; the moduledoc calls it the chunk-content fingerprint. Identical source rebuilds to an identical hash.
- **NOT the `✓ cic dist built + broadcast hash=…` line.** It reports that the build ran and the broadcast fired, never what it was built FROM. It is green on a stale checkout. (The #526 204-guard is a different failure: a bundle the server cannot READ.)

The mtime proves the SWAP; the `rev-parse` proves the SOURCE. Neither substitutes for the other.

## Scope and non-claims

- **Docs-only**, 65 additions to `docs/OPERATIONS.md`, 0 deletions, no other file.
- **`docs/DESIGN_NOTES.md` deliberately untouched** — a sibling PR is in flight against it. If this warrants a decision-log entry, that is a separate call.
- **No markdown heading added**, so the `## Contents` TOC is unaffected.
- Whether `deploy-cic.sh` *should* pull is a separate question. This records what it does today.
- Gates: `scripts/design-notes-gate.sh` → rc=0 ("this branch adds no entry heading"). The heavy gates (`check.sh`, `bun.sh`) were **not** run — the diff is one markdown file and a fresh cache id would have cost a cold compile plus a PLT build to prove nothing about prose.