### PR TITLE
#1658 — the pull-to-refresh paint: it outlived the gesture, and its cap was a number that cannot exist

### DIFF
--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -19,6 +19,26 @@
 //      stable number because `pull-gesture-active` drops the slot's snap-back
 //      transition — without it getComputedStyle returns wherever the ease
 //      happened to be.
+//   2b. THE FLUSH LINE (#1658, chromium): at a travel far past any cap the
+//      slot's top edge lands exactly ON the list's top edge — it stops flush
+//      instead of sinking into the rows, which is what it did on 1.3.0 (the
+//      cap was `PULL_COMMIT_PX`, larger than the slot at every font size, so
+//      the spinner parked 30-50px inside the list). Asserted at THREE root
+//      font sizes because the slot is `2.5rem` against a size the user picks,
+//      and the reading is 0 at all three only if the cap is the slot's own
+//      height: a hardcoded 35 would read +5 at S and -15 at XXL. The slot
+//      height is asserted alongside it, so a `--font-size` write that silently
+//      failed cannot make three identical measurements look like three sizes.
+//      What this does NOT say is that the slot never covers a row: it is
+//      `position: absolute; top: 0` over rows that start at y=0, so every
+//      visible position overlaps the first row's top band. Only moving the
+//      rows fixes that (#1658 point 3, not started) — the flush line is the
+//      strongest TRUE statement available here.
+//   2c. NO PAINT AFTER THE COMMIT (#1658, chromium): the committing release
+//      leaves no inline transform and no inline opacity on the slot. The
+//      binder does not call `onRelease` on that path, so the pane clears the
+//      paint from `onCommit` — before the fix the spinner stayed exactly where
+//      the finger left it, at full opacity, for the life of the pane.
 //   3. CSS CONTRACT (@webkit, iPhone 15): on the real target browser the row
 //      container refuses its own overscroll (so the iOS rubber-band does not
 //      fight the slot at the one scroll position the pull lives at) while
@@ -174,6 +194,63 @@ async function pullList(
   );
 }
 
+// The slot's inline style, which is the whole of the paint: the rule in
+// default.css sets the parked transform and `opacity: 0`, and the gesture
+// writes over both. Empty strings mean the pane handed the slot back to the
+// stylesheet.
+async function slotInlinePaint(list: Locator): Promise<{ transform: string; opacity: string }> {
+  return list.evaluate((el) => {
+    const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
+    if (slot === null) throw new Error("no pull slot inside the directory list");
+    return { transform: slot.style.transform, opacity: slot.style.opacity };
+  });
+}
+
+// One pull driven far past any cap, at a chosen root font size, measured with
+// the finger still down — the only moment the paint exists.
+//
+// The font size is written as the CSS var on <html>, which is exactly what
+// `lib/fontSize.ts`'s `writeCssVar` does; set here rather than imported to
+// keep src VALUES out of the e2e runtime graph, the same call as
+// LIST_WINDOW_NAME above. The gesture ends on a touchCANCEL, not a touchend:
+// cancel puts the slot back without committing, so measuring three sizes in
+// one test does not spend three upstream LIST captures.
+async function measureAtFullTravel(
+  list: Locator,
+  rootFontSize: string,
+): Promise<{ slotTop: number; listTop: number; slotHeight: number }> {
+  return list.evaluate((el, size) => {
+    document.documentElement.style.setProperty("--font-size", size);
+    const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
+    if (slot === null) throw new Error("no pull slot inside the directory list");
+    const at = (y: number): Touch =>
+      new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
+    const fire = (type: string, touch: Touch): void => {
+      const points = type === "touchend" || type === "touchcancel" ? [] : [touch];
+      el.dispatchEvent(
+        new TouchEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          touches: points,
+          targetTouches: points,
+          changedTouches: [touch],
+        }),
+      );
+    };
+    el.scrollTop = 0;
+    const y0 = 200;
+    fire("touchstart", at(y0));
+    fire("touchmove", at(y0 + 20));
+    // Far past every cap in play — the old one (80), the slot at its largest
+    // (50). Whatever stops the slot, it is not the finger running out.
+    fire("touchmove", at(y0 + 400));
+    const slotRect = slot.getBoundingClientRect();
+    const listRect = el.getBoundingClientRect();
+    fire("touchcancel", at(y0 + 400));
+    return { slotTop: slotRect.top, listTop: listRect.top, slotHeight: slotRect.height };
+  }, rootFontSize);
+}
+
 test("#1445 — a downward pull on the directory asks for the refresh (chromium)", async ({
   page,
 }) => {
@@ -190,6 +267,14 @@ test("#1445 — a downward pull on the directory asks for the refresh (chromium)
   // anywhere else would leave it reading "Refresh".
   await expect(refresh).toHaveText(/^Refreshing/, { timeout: 5_000 });
   await expect(refresh).toBeDisabled();
+
+  // #1658 — and the committing release cleaned up after itself. The binder
+  // reports a commit through `onCommit` and returns WITHOUT calling
+  // `onRelease`, so a pane that hangs its cleanup off `onRelease` alone leaves
+  // the slot painted where the finger left it, at full opacity, forever. The
+  // two assertions above are the pre-state that makes this one evidence: the
+  // gesture really did take the committing path.
+  expect(await slotInlinePaint(list)).toEqual({ transform: "", opacity: "" });
 });
 
 test("#1445 — mid-pull the slot moves by the finger's travel, parked offset intact (chromium)", async ({
@@ -198,15 +283,50 @@ test("#1445 — mid-pull the slot moves by the finger's travel, parked offset in
   test.slow();
   const { list } = await openDirectory(page, "sidebar");
 
-  // Half the commit distance: under the cap, so a correct paint moves the slot
-  // by exactly what the finger did. The rest position contributes -slotHeight
-  // to this same component, so a paint that dropped it would read
-  // +slotHeight + travel instead. The two failure modes are far apart and the
-  // browser does the arithmetic.
-  const travel = PULL_COMMIT_PX / 2;
+  // 20px, and it used to be half the commit distance. #1658 capped the travel
+  // at the slot's OWN height — `2.5rem`, so 30px at the smallest root font
+  // size cic offers — and 40px is over that cap at three of the five sizes,
+  // which would make this read the clamp instead of the follow. 20px is under
+  // it at all five. The cap has its own test below.
+  //
+  // Under the cap a correct paint moves the slot by exactly what the finger
+  // did. The rest position contributes -slotHeight to this same component, so
+  // a paint that dropped it would read +slotHeight + travel instead. The two
+  // failure modes are far apart and the browser does the arithmetic.
+  const travel = 20;
   const { before, after } = await pullList(list, travel, false);
 
   expect(after - before).toBeCloseTo(travel, 0);
+});
+
+test("#1658 — at full travel the slot stops flush with the list's top edge, at every font size (chromium)", async ({
+  page,
+}) => {
+  test.slow();
+  const { list } = await openDirectory(page, "sidebar");
+
+  // S, M (the default) and XXL, from lib/fontSize.ts's SIZES. The slot is
+  // `2.5rem`, so these are three DIFFERENT slot heights — 30, 35 and 50px —
+  // and that is the point: the cap is only the slot's own height if the
+  // flush reading survives all three. A hardcoded 35 reads +5 here and -15
+  // there; the old `PULL_COMMIT_PX` cap reads +50, +45 and +30.
+  for (const [size, expectedSlotHeight] of [
+    ["12px", 30],
+    ["14px", 35],
+    ["20px", 50],
+  ] as const) {
+    const { slotTop, listTop, slotHeight } = await measureAtFullTravel(list, size);
+
+    // Known-answer control, and without it this whole test is theatre: if the
+    // `--font-size` write did not take, all three iterations would measure the
+    // same slot and three identical readings would look like proof.
+    expect(slotHeight, `slot height at --font-size: ${size}`).toBeCloseTo(expectedSlotHeight, 0);
+    // The flush line. NOT "the slot clears the first row" — it cannot, it is
+    // absolutely positioned over rows that start at the same y — but it never
+    // travels PAST the edge, which is the whole of what #1658 point 2 can buy
+    // before the rows themselves move (point 3, not started).
+    expect(slotTop - listTop, `flush offset at --font-size: ${size}`).toBeCloseTo(0, 0);
+  }
 });
 
 test("@webkit #1445 — the directory list refuses its own overscroll and declares its one pan axis (iPhone 15)", async ({

--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -48,6 +48,29 @@
 //      altogether, and the scroller's own `pan-y` alone would leave the ROW
 //      — the hit-test target across nearly the whole list — still reading
 //      `auto`, which is the shape #913 measured as insufficient.
+//   3b. THE CAP, RESOLVED BY THE ENGINE THE BUG CAME FROM (#1658, @webkit):
+//      the declaration the pane writes at full travel is applied straight to
+//      the slot and the engine's own geometry is read back. vjt reported this
+//      from iOS Safari, and the cap is `translateY(min(<px>, 100%))` — a CSS
+//      math function over MIXED UNITS inside a transform. Chromium resolving
+//      it says nothing about WebKit, and a WebKit that did not resolve it
+//      would leave the slot parked out of sight: not "the cap is a few px
+//      off" but the pull no longer following the finger, on the only engine
+//      the reporter has, with 2b and every other gate here GREEN. That is the
+//      empty-green class — a gate that passes because it does not look where
+//      the defect lives — and this is the assertion that closes it.
+//      NO GESTURE, deliberately and not for convenience: `new Touch(...)` is
+//      an `Illegal constructor` on Playwright's WebKit (measured; issue230's
+//      header records the same limit for its own drag), so the production
+//      gesture cannot be synthesized on that project at all. What 3b buys is
+//      the ENGINE half; the PANE half — that the pane writes this declaration
+//      from a real finger — is 2b's, on chromium. Each is honest about which
+//      half it owns, and neither pretends to the other.
+//      It carries a plain-px ARITHMETIC CONTROL ahead of the capped reading,
+//      because the first draft of it had none and measured the slot's 150ms
+//      snap-back transition instead of the resolved transform: every
+//      declaration read as "parked" on BOTH engines and it looked like a
+//      total WebKit failure. The control fails loudly in that state.
 //
 // NOT PROVEN ANYWHERE, on purpose rather than by omission:
 //
@@ -61,6 +84,22 @@
 //     before that claim lands. Test 3 asserts the CSS that is supposed to
 //     prevent it; only a phone can say whether it does. That is a vjt call, as
 //     it was for #213 and #1438.
+//   * That Playwright's WebKit IS iOS Safari. Test 3b measures the same engine
+//     family under a phone viewport, which is the closest thing reachable from
+//     CI and strictly more than a chromium-only reading — it answers "does
+//     WebKit resolve a mixed-unit `min()` inside a transform", a question
+//     chromium cannot answer at all. It does not answer "does it resolve the
+//     same way on vjt's phone", and no assertion here claims it does.
+//   * The GESTURE on WebKit, by anything here. `new Touch(...)` throws
+//     `Illegal constructor` there, so no test in this file drives the binder
+//     on that project. MEASURED while looking for a way round it, and recorded
+//     because the next person will look too: `document.createTouch` DOES
+//     exist and returns a usable Touch, `document.createEvent("TouchEvent")`
+//     succeeds but has no `initTouchEvent`, and `new TouchEvent(type, {...})`
+//     accepts a `document.createTouchList(...)` for its touch sequences while
+//     rejecting a plain array with `TypeError: Type error`. So a WebKit drag
+//     is reachable — nobody has built it, and whether the wiring half is worth
+//     proving twice is a product call, not this file's.
 //   * Interaction with the pane's scroll preservation. A progress ping that
 //     lands WHILE a finger is down rewrites `scrollTop` from a queueMicrotask
 //     (DirectoryPane's entry-count effect). Nothing here holds a finger across
@@ -86,14 +125,24 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 const LIST_WINDOW_NAME = "$list";
 
 // PULL_COMMIT_PX from src/lib/pullGesture.ts (SWIPE_MIN_PX * 2). Hardcoded for
-// the same reason — but unlike the window name this copy CHECKS itself: test 2
-// drags half of it and asserts the paint moved by that much, and the paint is
-// capped at the real constant. Lower the real one and this spec reads the cap
-// instead of the drag and goes red, naming the drift.
+// the same reason as the window name above.
 //
-// #1646 adds a static second witness that needs no testnet, and it watches the
-// number this comment does NOT name: the production side is DERIVED, so moving
-// `SWIPE_MIN_PX` in src/lib/swipe.ts moves the cap while leaving 80 here.
+// #1658 — and unlike the window name this copy no longer CHECKS ITSELF. It
+// did: test 2 dragged half of it against a paint capped at the real constant,
+// so lowering the real one made this spec read the cap instead of the drag and
+// go red. Both halves of that are gone — the travel caps at the slot's own
+// height now, and test 2 drags a literal 20 to stay under it at every font
+// size. The only use left is a drag MAGNITUDE (`PULL_COMMIT_PX * 3` in test
+// 1), which reds only if the real constant grows past 240 and says nothing at
+// all if it shrinks. Leaving the old claim here would have left a comment
+// standing where a witness used to be, which is the failure #1393 spent a day
+// removing.
+//
+// What pins it is #1646's static witness, which needs no testnet:
+// src/__tests__/e2eConstantMirrors.test.ts imports the production constant and
+// compares it to this literal. It watches the number this file does NOT name —
+// the production side is DERIVED, so moving `SWIPE_MIN_PX` in src/lib/swipe.ts
+// moves the commit distance while leaving 80 sitting here.
 const PULL_COMMIT_PX = 80;
 
 // Open the directory pane and hand back its two moving parts.
@@ -215,10 +264,17 @@ async function slotInlinePaint(list: Locator): Promise<{ transform: string; opac
 // LIST_WINDOW_NAME above. The gesture ends on a touchCANCEL, not a touchend:
 // cancel puts the slot back without committing, so measuring three sizes in
 // one test does not spend three upstream LIST captures.
+//
+// `transform` comes back as the INLINE string, not a computed one, and it is
+// the discriminator #1658's webkit arm needs: setting an unparseable value on
+// a CSSStyleDeclaration is a silent no-op, so an engine that refuses
+// `min(<px>, 100%)` inside `translateY` leaves this empty while the geometry
+// merely reads "parked". Empty means the declaration was refused; non-empty
+// with a non-zero offset means it was accepted and resolved elsewhere.
 async function measureAtFullTravel(
   list: Locator,
   rootFontSize: string,
-): Promise<{ slotTop: number; listTop: number; slotHeight: number }> {
+): Promise<{ slotTop: number; listTop: number; slotHeight: number; transform: string }> {
   return list.evaluate((el, size) => {
     document.documentElement.style.setProperty("--font-size", size);
     const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
@@ -246,9 +302,60 @@ async function measureAtFullTravel(
     fire("touchmove", at(y0 + 400));
     const slotRect = slot.getBoundingClientRect();
     const listRect = el.getBoundingClientRect();
+    const transform = slot.style.transform;
     fire("touchcancel", at(y0 + 400));
-    return { slotTop: slotRect.top, listTop: listRect.top, slotHeight: slotRect.height };
+    return {
+      slotTop: slotRect.top,
+      listTop: listRect.top,
+      slotHeight: slotRect.height,
+      transform,
+    };
   }, rootFontSize);
+}
+
+// The three root font sizes that bracket cic's range, and the slot height each
+// produces. From lib/fontSize.ts's SIZES; the slot is `2.5rem`.
+const FONT_SIZES = [
+  ["12px", 30],
+  ["14px", 35],
+  ["20px", 50],
+] as const;
+
+// One paint applied DIRECTLY to the slot, with no gesture in front of it, and
+// the geometry the engine resolves it to. This is how the @webkit arm reaches
+// the cap at all: `new Touch(...)` is an `Illegal constructor` on Playwright's
+// WebKit (measured, and issue230's header records the same for its own drag),
+// so the production gesture cannot be synthesized there and the question
+// "does THIS ENGINE resolve THIS DECLARATION" has to be asked directly.
+//
+// 🔴 `pull-gesture-active` is not decoration. The slot carries
+// `transition: transform 150ms ease-out`, which production drops through that
+// exact class for the length of a claimed pull. Without it every reading here
+// is the ease at t=0 — MEASURED: all eight candidate declarations, on BOTH
+// engines, read as the parked position and the table looked like a total
+// engine failure. Killing the transition the way production kills it is what
+// turned that into a table with two distinct answers in it.
+async function resolveTransform(
+  list: Locator,
+  rootFontSize: string,
+  declaration: string,
+): Promise<{ offset: number; slotHeight: number; computed: string }> {
+  return list.evaluate(
+    (el, opts) => {
+      document.documentElement.style.setProperty("--font-size", opts.rootFontSize);
+      const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
+      if (slot === null) throw new Error("no pull slot inside the directory list");
+      el.classList.add("pull-gesture-active");
+      slot.style.transform = opts.declaration;
+      const computed = getComputedStyle(slot).transform;
+      const slotRect = slot.getBoundingClientRect();
+      const offset = slotRect.top - el.getBoundingClientRect().top;
+      slot.style.removeProperty("transform");
+      el.classList.remove("pull-gesture-active");
+      return { offset, slotHeight: slotRect.height, computed };
+    },
+    { rootFontSize, declaration },
+  );
 }
 
 test("#1445 — a downward pull on the directory asks for the refresh (chromium)", async ({
@@ -305,27 +412,78 @@ test("#1658 — at full travel the slot stops flush with the list's top edge, at
   test.slow();
   const { list } = await openDirectory(page, "sidebar");
 
-  // S, M (the default) and XXL, from lib/fontSize.ts's SIZES. The slot is
-  // `2.5rem`, so these are three DIFFERENT slot heights — 30, 35 and 50px —
-  // and that is the point: the cap is only the slot's own height if the
-  // flush reading survives all three. A hardcoded 35 reads +5 here and -15
-  // there; the old `PULL_COMMIT_PX` cap reads +50, +45 and +30.
-  for (const [size, expectedSlotHeight] of [
-    ["12px", 30],
-    ["14px", 35],
-    ["20px", 50],
-  ] as const) {
-    const { slotTop, listTop, slotHeight } = await measureAtFullTravel(list, size);
+  // S, M (the default) and XXL — three DIFFERENT slot heights, and that is the
+  // point: the cap is only the slot's own height if the flush reading survives
+  // all three. A hardcoded 35 reads +5 at S and -15 at XXL; the old
+  // `PULL_COMMIT_PX` cap reads +50, +45 and +30.
+  for (const [size, expectedSlotHeight] of FONT_SIZES) {
+    const { slotTop, listTop, slotHeight, transform } = await measureAtFullTravel(list, size);
 
     // Known-answer control, and without it this whole test is theatre: if the
     // `--font-size` write did not take, all three iterations would measure the
     // same slot and three identical readings would look like proof.
     expect(slotHeight, `slot height at --font-size: ${size}`).toBeCloseTo(expectedSlotHeight, 0);
+    // Read this one FIRST when the pair goes red: an EMPTY inline transform is
+    // the engine refusing the declaration outright (the CSSOM setter drops an
+    // unparseable value silently), which is a different defect and a different
+    // fix from an engine that accepted it and resolved it somewhere else.
+    expect(transform, `inline transform at --font-size: ${size}`).not.toBe("");
     // The flush line. NOT "the slot clears the first row" — it cannot, it is
     // absolutely positioned over rows that start at the same y — but it never
     // travels PAST the edge, which is the whole of what #1658 point 2 can buy
     // before the rows themselves move (point 3, not started).
     expect(slotTop - listTop, `flush offset at --font-size: ${size}`).toBeCloseTo(0, 0);
+  }
+});
+
+test("@webkit #1658 — WebKit resolves the travel cap against the slot's own height (iPhone 15)", async ({
+  page,
+}) => {
+  test.slow();
+  // The mobile door, for the reason `openDirectory` states: the $list window
+  // has no BottomBar tab, so `selectChannel` cannot reach it on this layout.
+  const { list } = await openDirectory(page, "list-command");
+
+  for (const [size, expectedSlotHeight] of FONT_SIZES) {
+    // The ARITHMETIC CONTROL, and it runs first because everything below is
+    // worthless without it. A plain px translate under the cap must move the
+    // slot by exactly that much from its parked -100%. If this reads the
+    // parked position instead, the harness is measuring a transition or a
+    // stale layout and the capped reading beneath it means nothing — which is
+    // the exact hole the first draft of this test fell into.
+    const control = await resolveTransform(list, size, "translateY(-100%) translateY(20px)");
+    expect(control.slotHeight, `slot height at --font-size: ${size}`).toBeCloseTo(
+      expectedSlotHeight,
+      0,
+    );
+    expect(control.offset, `plain-px control at --font-size: ${size}`).toBeCloseTo(
+      20 - expectedSlotHeight,
+      0,
+    );
+
+    // The declaration the pane actually writes at full travel, resolved by the
+    // engine the bug was reported from. `min(<px>, 100%)` is a CSS math
+    // function over MIXED UNITS inside a transform: chromium resolving it says
+    // nothing about WebKit, and if WebKit did not resolve it the slot would
+    // stay parked out of sight — not "the cap is off by a few px" but the pull
+    // no longer following the finger at all, on the only engine vjt has, with
+    // every other gate in this repo green. That is the empty-green class, and
+    // this line is what closes it.
+    //
+    // Coupled BY HAND to `pulledTransform` in src/DirectoryPane.tsx: this is an
+    // ENGINE contract, so it names the declaration rather than importing it,
+    // exactly as the CSS-contract test below names `pan-y`. Change the cap's
+    // FORM in the pane and this string must move with it — the chromium arm
+    // above is what keeps the pane honest about producing it.
+    const capped = await resolveTransform(
+      list,
+      size,
+      "translateY(-100%) translateY(min(400px, 100%))",
+    );
+    expect(capped.offset, `capped travel at --font-size: ${size} (${capped.computed})`).toBeCloseTo(
+      0,
+      0,
+    );
   }
 });
 

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -378,7 +378,19 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
       // THE SAME DOOR the button and the stale CTA use. A second refresh path
       // would sidestep the store latch that makes those two honest (F1), and
       // re-open the double-capture this issue closed.
-      onCommit: onRefresh,
+      //
+      // #1658 — and it unpaints FIRST, because a committing release is a
+      // terminal the binder does not report through `onRelease`: it calls
+      // `onCommit()` and returns. `onRelease: unpaintPull` alone therefore
+      // cleared the paint on every path EXCEPT the one the user takes when the
+      // gesture works, and the slot kept the last touchmove's transform and
+      // full opacity for as long as the pane lived — vjt's hung spinner on
+      // 1.3.0. The paint belongs to this pane (the binder writes none of its
+      // own), so ending it on both terminals belongs here too.
+      onCommit: () => {
+        unpaintPull();
+        onRefresh();
+      },
       onRelease: unpaintPull,
     });
   };

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -74,12 +74,42 @@ import { MircBody } from "./MircText";
 // Two `translateY` functions rather than one `calc`: they compose to the same
 // matrix, and the resolved form a test can read is `-slotHeight + dy` either
 // way — but this one is legible in an assertion and needs no CSS arithmetic.
-const pulledTransform = (dy: number): string => `translateY(-100%) translateY(${dy}px)`;
+//
+// #1658 — the travel caps at `100%`, the slot's OWN height, and the cap lives
+// in the CSS rather than in JS because there is no number to put in JS. The
+// slot is `2.5rem` and cic's root font-size is a USER PREFERENCE
+// (`lib/fontSize.ts` writes `--font-size` on <html>: S=12px … XXL=20px), so
+// the slot is anywhere from 30px to 50px and can change while this pane is
+// open. A px constant would be right for one of the five sizes; a percentage
+// in `translateY` resolves against the element's own height, so the cap and
+// the parked offset are the same unit, the same fact, and read live.
+//
+// It used to cap at `PULL_COMMIT_PX` (80), which is more than the slot at
+// every size: at full travel the slot sat 30-50px BELOW the list's top edge —
+// a whole spinner parked inside the rows, which is the overlap vjt reported
+// on 1.3.0. The old comment claimed the cap existed to stop exactly that.
+//
+// 🔴 What this buys is the WEAKER of the two invariants available, on purpose:
+// the slot never travels PAST the list's top edge. It does not buy "the slot
+// never overlaps a row", and that one is not on offer here — the slot is
+// `position: absolute; top: 0` inside a scroller whose rows also start at
+// y=0, so every position where the spinner is visible at all is a position
+// where it covers the top band of the first row. Making the rows move out of
+// its way is a different change (#1658 point 3, not started), and until it
+// lands the honest statement is the flush line. Asserting the strong one here
+// would be asserting something false.
+const pulledTransform = (dy: number): string => `translateY(-100%) translateY(min(${dy}px, 100%))`;
 
-// How far the paint is allowed to follow the finger. Past the commit distance
-// the slot stops moving and the gesture is already spent, so more travel would
-// only drag the spinner into the rows it is supposed to sit above.
-const paintedTravel = (dy: number): number => Math.min(dy, PULL_COMMIT_PX);
+// The spinner is legible before the commit point, not after it: the ramp
+// reaches full exactly where the release starts spending a capture, so the
+// affordance itself says where the line is.
+//
+// #1658 — a DIFFERENT axis from the travel above and it keeps its own
+// distance. The travel is the placement, the ramp is the affordance; tying the
+// ramp to the capped travel would top the spinner out at
+// slotHeight/PULL_COMMIT_PX (0.44 at the default font size) and it would never
+// reach full at the one distance where full is the point.
+const pulledOpacity = (dy: number): number => Math.min(dy, PULL_COMMIT_PX) / PULL_COMMIT_PX;
 
 // Quiet window after the last keystroke before the filter GET fires. Long
 // enough to swallow a burst of typing, short enough that a deliberate pause
@@ -349,12 +379,8 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   const paintPull = (dy: number): void => {
     const slot = pullSlotRef;
     if (slot === undefined) return;
-    const travel = paintedTravel(dy);
-    slot.style.transform = pulledTransform(travel);
-    // The spinner is legible before the commit point, not after it: the ramp
-    // reaches full exactly where the release starts spending a capture, so the
-    // affordance itself says where the line is.
-    slot.style.opacity = String(travel / PULL_COMMIT_PX);
+    slot.style.transform = pulledTransform(dy);
+    slot.style.opacity = String(pulledOpacity(dy));
   };
 
   const unpaintPull = (): void => {

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -904,14 +904,19 @@ describe("DirectoryPane", () => {
       expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
     });
 
+    // #1658 — 20px, not half the commit distance as this drag used to be. The
+    // travel now caps at the slot's OWN height, and the slot is `2.5rem`
+    // against a root font-size the user picks (`lib/fontSize.ts`: S=12px …
+    // XXL=20px ⇒ 30px … 50px). 40px is over that cap at three of the five
+    // sizes; 20px is under it at all five, so this reads the follow and not
+    // the clamp. The clamp has its own test below.
     it("the slot follows the finger while it is down", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
 
-      const travel = Math.round(PULL_COMMIT_PX / 2);
-      pullTo(listIn(container), travel);
+      pullTo(listIn(container), 20);
 
-      expect(slotIn(container).style.transform).toContain(`translateY(${travel}px)`);
+      expect(slotIn(container).style.transform).toContain("translateY(min(20px, 100%))");
     });
 
     it("keeps the slot's parked offset in the pulled transform (an inline transform replaces the rule)", () => {
@@ -928,15 +933,54 @@ describe("DirectoryPane", () => {
       expect(slotIn(container).style.transform).toContain("translateY(-100%)");
     });
 
-    it("the paint stops at the commit distance however far the finger goes", () => {
+    // #1658 — the cap used to be `PULL_COMMIT_PX`, which is TWICE the slot at
+    // the default font size: the paint drove the slot a whole extra
+    // slot-height past the list's top edge and parked the spinner inside the
+    // rows. What this pins is not a smaller number but the ABSENCE of a
+    // number: the finger's distance goes through unclamped and the clamp is
+    // `100%` — the slot's own height, resolved by the engine against whatever
+    // the root font-size currently is. Reinstating any JS clamp turns the
+    // received string into a bare `translateY(<n>px)` and this red.
+    //
+    // jsdom resolves no layout, so this is the CONTRACT and not the geometry.
+    // That the slot actually stops flush with the list's top edge — at three
+    // font sizes, which is what proves the cap is slot-relative and not a 35
+    // in disguise — is asserted in the browser, in
+    // e2e/tests/issue1445-directory-pull-refresh.spec.ts.
+    it("the paint is capped by the slot's OWN height, not by the commit distance", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
 
-      pullTo(listIn(container), PULL_COMMIT_PX * 4);
+      const far = PULL_COMMIT_PX * 4;
+      pullTo(listIn(container), far);
 
       const painted = slotIn(container).style.transform;
-      expect(painted).toContain(`translateY(${PULL_COMMIT_PX}px)`);
-      expect(painted).not.toContain(`translateY(${PULL_COMMIT_PX * 4}px)`);
+      expect(painted).toBe(`translateY(-100%) translateY(min(${far}px, 100%))`);
+    });
+
+    // #1658 — the ramp and the travel are INDEPENDENT axes, and the fix for
+    // the travel is what puts the ramp at risk: computing opacity from the
+    // capped travel would top the spinner out at slotHeight/PULL_COMMIT_PX —
+    // 0.44 at the default font size — so it would never reach full at the one
+    // distance where reaching full is the whole point. The ramp says where the
+    // release starts spending a capture; the travel says where the slot sits.
+    //
+    // Green before this issue and green after it, deliberately: its oracle is
+    // the naive fix, not the defect. Compute the opacity from the capped
+    // travel and it goes red on the last two assertions.
+    it("the opacity ramp still reaches full at the commit distance", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      const list = listIn(container);
+      pullTo(list, Math.round(PULL_COMMIT_PX / 2));
+      expect(slotIn(container).style.opacity).toBe("0.5");
+
+      pullTo(list, PULL_COMMIT_PX);
+      expect(slotIn(container).style.opacity).toBe("1");
+
+      pullTo(list, PULL_COMMIT_PX * 4);
+      expect(slotIn(container).style.opacity).toBe("1");
     });
 
     it("the release wipes the paint", () => {

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -952,6 +952,29 @@ describe("DirectoryPane", () => {
       expect(slotIn(container).style.transform).toBe("");
     });
 
+    // #1658 — the release that COMMITS is a terminal too, and the pane hangs
+    // `unpaintPull` off `onRelease` alone, which the binder skips on exactly
+    // that path (`onCommit()` then `return`). The slot keeps the inline
+    // transform and opacity the last touchmove wrote, at full opacity, for as
+    // long as the pane lives — the spinner vjt saw hung after the refresh on
+    // 1.3.0.
+    //
+    // A separate test from "the release wipes the paint" above rather than a
+    // widening of it: that one lifts SHORT of the commit distance, which is
+    // precisely why it stayed green through the whole defect.
+    it("a release that COMMITS wipes the paint too", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      pullAndLift(listIn(container), PULL_COMMIT_PX * 3);
+
+      // Pre-state, not decoration: without it a binder that never armed would
+      // satisfy both assertions below by having painted nothing at all.
+      expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
+      expect(slotIn(container).style.transform).toBe("");
+      expect(slotIn(container).style.opacity).toBe("");
+    });
+
     it("a drag that starts scrolled away from the top is left to native scroll", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);

--- a/cicchetto/src/lib/mediaViewerGesture.ts
+++ b/cicchetto/src/lib/mediaViewerGesture.ts
@@ -54,8 +54,16 @@ export type DismissGestureParams = {
   // Past the distance or the velocity: close, through the caller's normal
   // close path (#1121 / #535 — a dismiss that bypassed it would strand the
   // reader exactly the way those two issues closed).
+  //
+  // 🔴 TERMINAL, and `onRelease` does NOT also fire on this path — exactly one
+  // of the two runs. This viewer gets away with painting and never clearing
+  // because committing UNMOUNTS the element it painted; a consumer whose
+  // painted element survives the commit must clear it here. Stated because it
+  // was implicit and cost #1658 in the sibling binder (`pullGesture.ts`),
+  // whose slot does survive: it hung at full opacity for the life of the pane.
   onCommit: () => void;
-  // Claimed but not committed, or cancelled: put it back.
+  // Claimed but not committed, or cancelled: put it back. NOT the sole cleanup
+  // hook — see `onCommit`.
   onRelease: () => void;
 };
 

--- a/cicchetto/src/lib/pullGesture.ts
+++ b/cicchetto/src/lib/pullGesture.ts
@@ -54,8 +54,22 @@ export type PullGestureParams = {
   // read as "no pull", never as an upward paint.
   onProgress: (dy: number) => void;
   // Released past the commit distance: ask for the refresh.
+  //
+  // 🔴 TERMINAL, and `onRelease` does NOT also fire on this path: the two are
+  // the ends of a claimed gesture and exactly one of them runs. So if the
+  // element `onProgress` painted OUTLIVES the commit, clear the paint HERE
+  // yourself — the binder writes no paint and cannot clear one.
+  //
+  // Measured (#1658): the channel directory's slot does outlive it, and it
+  // kept the last touchmove's transform at full opacity for the life of the
+  // pane. `bindDismissGesture` (mediaViewerGesture.ts) has the same terminal
+  // shape and never showed the bug, because its commit CLOSES the modal it
+  // painted — so the requirement stayed implicit until the first consumer
+  // whose element survived a commit paid for it. Written down here, where the
+  // fifth binder over this core will read it.
   onCommit: () => void;
-  // Claimed but not committed, or cancelled: put the slot back.
+  // Claimed but not committed, or cancelled: put the slot back. NOT the sole
+  // cleanup hook — see `onCommit`.
   onRelease: () => void;
 };
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57099,3 +57099,81 @@ root font sizes, with the slot height asserted alongside each so that a
 `--font-size` write that silently failed cannot pass three identical
 measurements off as three sizes. Whether any of it feels like a pull is a
 device call and stays vjt's.
+
+### The cap is a CSS math function, and chromium could not vouch for it
+
+The cure above puts the cap in the CSS — `translateY(min(<px>, 100%))` —
+and every assertion behind it ran on chromium. The bug was reported from
+iOS Safari. `min()` over MIXED UNITS inside a transform is exactly the
+kind of declaration an engine can accept syntactically and then resolve to
+nothing, and had WebKit done that the slot would have stayed parked out of
+sight: not a cap a few pixels off, but the pull no longer following the
+finger at all — the first defect of this issue restored, on the only
+engine the reporter has, with every gate in this repo green. That is the
+empty-green class, and a fix for an iOS bug whose mechanism is unmeasured
+on WebKit has not been measured at all.
+
+MEASURED, on Playwright's `webkit-iphone-15` (WebKit 605.1.15,
+Version/26.4) against chromium 147, reading the resolved geometry off the
+real slot:
+
+| declaration | chromium | webkit |
+|---|---|---|
+| `translateY(-100%) translateY(20px)` | `off=-15` | `off=-15` |
+| `translateY(-100%) translateY(min(400px, 100%))` | `off=0` | `off=0` |
+
+Identical, row for row. **`min()` holds on WebKit**; the feared hole is
+not there. The first row is the arithmetic control and it earns its place
+below.
+
+### The measurement that lied first, and what makes it honest
+
+The first pass of that table read "parked" for every candidate on BOTH
+engines and looked like a total WebKit failure. It was the harness: the
+slot carries `transition: transform 150ms ease-out`, and production drops
+it through the `pull-gesture-active` class for exactly as long as a
+claimed pull runs. A reading taken without that class is the ease at t=0,
+which is the parked position, for every declaration ever written. The fix
+is to kill the transition the way production kills it, and the guard
+against believing the lie again is the plain-px control row: it must read
+`20 - slotHeight`, and it reads the parked position under precisely the
+harness fault that produced the false table. A cross-engine claim with no
+control in it is a claim about the harness.
+
+### Why the WebKit arm asserts CSS and not the gesture
+
+It sets the declaration on the slot directly. Not for convenience:
+`new Touch(...)` throws `Illegal constructor` on Playwright's WebKit, so
+the production gesture cannot be synthesized on that project at all —
+`issue230`'s header had already recorded the same limit for its own drag,
+as prose, without a measurement next to it. So the two arms own two
+halves and each says which: chromium proves the PANE writes this
+declaration from a real finger; WebKit proves the ENGINE resolves it.
+Neither pretends to the other, and the pair is what closes the hole.
+
+Recorded for whoever tries again, because they will: `document.createTouch`
+DOES exist there and returns a usable Touch;
+`document.createEvent("TouchEvent")` succeeds but carries no
+`initTouchEvent`; and `new TouchEvent(type, {…})` accepts a
+`document.createTouchList(…)` for its touch sequences while rejecting a
+plain array with `TypeError: Type error`. A WebKit drag is therefore
+reachable. Nobody has built one, and whether the wiring half is worth
+proving on a second engine is a product call, not a gap this change left
+open by accident.
+
+### A comment that outlived its witness
+
+The e2e copy of `PULL_COMMIT_PX` carried a paragraph claiming it checked
+itself: the displacement test dragged half the constant against a paint
+capped at the real one, so lowering the real one made the spec read the
+cap instead of the drag. Both halves of that died in this change — the
+travel caps at the slot's own height now, and the displacement test drags
+a literal 20 to stay under the cap at every font size. The only use left
+is a drag magnitude, which reds if the constant grows past 240 and says
+nothing at all if it shrinks.
+
+The comment is now what it is: a copy pinned by #1646's static witness,
+which imports the production constant and compares it to the literal. A
+comment describing a guarantee that has been removed is worse than no
+comment, because it is the thing a reader consults instead of checking —
+the same class #1393 spent a day deleting.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -56996,3 +56996,106 @@ unmeasured mechanism shipped under deadline, which is the failure mode this
 entry spends its length arguing against. Recorded here as debt with a name,
 not as a detail — an unenforced obligation that nobody wrote down is
 indistinguishable from one that does not exist.
+<!-- entry #1658 -->
+
+---
+
+## 2026-08-21 — #1658: the pull affordance's two ends, and the cap that could not be a number
+
+vjt pulled the channel directory down on a phone against 1.3.0 and
+reported three things: the list does not follow the finger, the spinner
+overlaps the first row, and the spinner stays hung after the refresh. Two
+are defects and are fixed here; the third is a change of behaviour and is
+not started, awaiting vjt's own word rather than a relay of it.
+
+### The paint outlived the gesture
+
+`unpaintPull` is the only thing that removes the inline `transform` and
+`opacity` the pull writes onto the slot, and it was bound to `onRelease`
+alone. `bindPullGesture` does not report a COMMITTING release through
+`onRelease`: it calls `onCommit()` and returns. The paint was therefore
+cleared on every terminal except the one a working gesture takes, and the
+slot kept the last touchmove's transform at full opacity for the life of
+the pane.
+
+The fix is in the pane — `onCommit` unpaints before it refreshes — because
+the binder writes no paint of its own by design, and that is the entire
+reason it reports progress instead of moving anything.
+
+The interesting part is the class, not the instance. `bindDismissGesture`
+(`mediaViewerGesture.ts`) has the IDENTICAL terminal shape and has never
+shown this bug, because its commit CLOSES the modal it painted: the
+element carrying the stale paint stops existing in the same tick. So the
+requirement — *a consumer whose painted element SURVIVES a commit must
+clear the paint itself* — was true from the first binder and written down
+nowhere, and `pullGesture`, the fourth binder over that core, inherited a
+shape that was only ever safe by accident of its first consumer's
+lifecycle. Both `onCommit` docs now state it. The pattern is what
+propagates in this codebase; an implicit precondition attached to a
+pattern propagates with it, silently, until it meets a consumer that
+violates it.
+
+### The cap was a number where no number exists
+
+The paint followed the finger up to `PULL_COMMIT_PX` (80px, `SWIPE_MIN_PX
+* 2`), while the slot is parked one slot-height above the list's top edge.
+At full travel the slot therefore sat `80 - slotHeight` PAST that edge —
+a whole spinner inside the rows. The comment above the cap said it existed
+so that extra travel would not "drag the spinner into the rows it is
+supposed to sit above". The prose was right and the number contradicted it.
+
+The issue reported the overlap as 40px, from `2.5rem = 40px`. Measured, it
+is not: `html { font-size: var(--font-size) }` with `--font-size: 14px`
+(`default.css`), so 1rem is 14px here and the slot is 35px. Two comments
+in that same stylesheet already warn about exactly this trap, which is why
+`--chrome-tap-min` and `--tap-min` are absolute px.
+
+The load-bearing correction is the next one. `--font-size` is a USER
+PREFERENCE: `lib/fontSize.ts` writes it on `<html>` from a five-value set,
+S=12px through XXL=20px. The slot is therefore 30px…50px, changeable while
+the pane is open, and the overlap was 50/45/40/35/30px depending on a
+setting. There is no px constant to write in TS that is right for more
+than one of the five, so the cap moved into the CSS as `min(dy, 100%)`: a
+percentage in `translateY` resolves against the element's own height, so
+the cap and the parked `-100%` become the same unit and the same fact,
+resolved live by the engine. A defect whose magnitude is a user preference
+cannot be fixed by a better constant — only by removing the constant.
+
+The opacity ramp deliberately did not follow the travel down. They are
+independent axes: the travel is the placement, the ramp is the affordance
+that says where the release starts spending a capture. Driving opacity
+from the capped travel would top the spinner out at
+`slotHeight / PULL_COMMIT_PX` — 0.44 at the default size — so it would
+never reach full where full is the whole point. That is the likeliest
+wrong fix, so it has a test whose oracle is the wrong fix rather than the
+defect: the test is green before this change and after it, and red only
+under the mistake.
+
+### The invariant we can state, and the one we cannot
+
+Capping at the slot's own height does NOT stop the spinner covering a row,
+and the code and the specs both say so. The slot is `position: absolute;
+top: 0` inside a scroller whose rows also start at y=0, so every position
+where the spinner is visible at all is a position where it covers the top
+band of the first row; the only non-overlapping position is the invisible
+one. What the cap buys is the weaker, true statement: **the slot never
+travels past the list's top edge**. The strong statement becomes available
+only when the rows move with the finger, which is the third report and a
+separate change.
+
+Stating the weaker invariant and naming why the stronger one is
+unavailable is the point, not a hedge. A comment or a test asserting "no
+overlap" would have been asserting something false about code that had
+just been changed to make it look true.
+
+### What is not proven
+
+The FEEL, as ever: a synthesized TouchEvent drives no compositor and
+Playwright's webkit does not reproduce iOS scroll physics, so nothing here
+says the follow is smooth or that 80px is the right commit distance. The
+browser assertions are DOM facts — the inline paint is gone after a
+commit, and the slot's top edge lands on the list's at three different
+root font sizes, with the slot height asserted alongside each so that a
+`--font-size` write that silently failed cannot pass three identical
+measurements off as three sizes. Whether any of it feels like a pull is a
+device call and stays vjt's.


### PR DESCRIPTION
Fixes the two defects in #1658 (points 1 and 2). Point 3 — the rows following the finger — is **not** in here: it is a change of behaviour, not a defect, and it is waiting on vjt.

Branched off `4eb41d63` (`v1.3.0`, the release the report came from).

## 1. The paint outlived the gesture

`unpaintPull` is the only thing that removes the inline `transform`/`opacity` the pull writes onto the slot, and it hung off `onRelease`. `bindPullGesture` does not report a COMMITTING release through `onRelease` — it calls `onCommit()` and returns — so the paint was cleared on every terminal *except* the one a working gesture takes. The slot kept the last touchmove's transform at full opacity for the life of the pane.

Fixed in the pane (`onCommit` unpaints, then refreshes), not in the binder: the binder writes no paint of its own by design.

**The class is wider than the instance.** `bindDismissGesture` (`mediaViewerGesture.ts`) has the identical terminal shape and has never shown this bug, because its commit CLOSES the modal it painted. The requirement — *a consumer whose painted element survives a commit must clear the paint itself* — was true from the first binder and written down nowhere, so the fourth binder over that core inherited a shape that was only safe by accident of its first consumer's lifecycle. Both `onCommit` docs now say it.

## 2. The cap was a number where no number exists

The paint followed the finger to `PULL_COMMIT_PX` (80px) while the slot is parked one slot-height above the list's top edge, so at full travel it sat `80 − slotHeight` PAST that edge. The comment above the cap claimed it existed to stop exactly that.

Two corrections to the reported arithmetic, both measured:

* `html { font-size: var(--font-size) }` with `--font-size: 14px`, so **1rem is 14px here and the slot is 35px, not 40**. (`default.css` already carries two warnings about this trap, which is why `--chrome-tap-min` and `--tap-min` are absolute px.)
* **`--font-size` is a user preference.** `lib/fontSize.ts` writes it on `<html>` from S=12px … XXL=20px, so the slot is 30…50px and the overlap was 50/45/40/35/30px depending on a setting — changeable while the pane is open.

So the cap moved into the CSS as `min(dy, 100%)`: a percentage in `translateY` resolves against the element's own height, making the cap and the parked `-100%` the same unit and the same fact, resolved live. A defect whose magnitude is a user preference cannot be fixed with a better constant.

The opacity ramp keeps its own `PULL_COMMIT_PX` clamp — independent axes, and driving it from the capped travel would top the spinner out at 0.44 at the default font size.

## What this does NOT claim

**It does not stop the spinner covering a row.** The slot is `position: absolute; top: 0` over rows that start at the same y, so every position where the spinner is visible overlaps the first row's top band; the only non-overlapping position is the invisible one. The invariant asserted is the weaker true one — **the slot never travels past the list's top edge** — and the code, the specs and the decision-log entry all say why the strong one is unavailable until the rows move (point 3).

## Tests

Red before, green after, and each oracle proved by mutation (reinstate the defect ⇒ those tests go red, and **only** those):

* `a release that COMMITS wipes the paint too` — the existing sibling stayed green through the whole defect because it lifts SHORT of the commit distance.
* `the paint is capped by the slot's OWN height, not by the commit distance` — pins the absence of a JS clamp.
* `the opacity ramp still reaches full at the commit distance` — green before AND after; its oracle is the likeliest wrong fix, not the defect.
* e2e: the post-commit inline paint is empty, and at full travel the slot's top edge lands on the list's **at three root font sizes** (S/M/XXL). One size would not distinguish this from a hardcoded 35 (which reads +5 at S and −15 at XXL). The slot height is asserted alongside each offset, so a `--font-size` write that silently failed cannot pass three identical measurements off as three sizes.
* Two existing assertions moved off a distance the fix redefined: 40px is over the new cap at three of the five font sizes, so they now drag 20px, which is under it at all five.

## Gates

| gate | result |
| --- | --- |
| `bun run check` (lock drift, biome src+e2e, tsc src, tsc e2e) | 4 stages, 0 failed |
| `bun run test` (vitest) | 298 files / 5824 tests, rc=0 |
| `bun run build` (tsc --noEmit && vite build) | ok |
| `scripts/design-notes-gate.sh` | 1 new entry, separator and marker present |

biome: **0 errors**; the standing 59 warnings / 4 infos are the pre-existing baseline (identical count on `da5e47c2` at the same scope), and the five files this branch touches produce zero diagnostics.

**NOT run: the e2e suite** — it needs the stack lane. The three browser assertions above are written and type-check, but no one has watched them go red or green.
