### PR TITLE
#1657: make a lost scrollback row countable, and stop filing pool cancellations as corruption

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57177,3 +57177,100 @@ which imports the production constant and compares it to the literal. A
 comment describing a guarantee that has been removed is worse than no
 comment, because it is the thing a reader consults instead of checking —
 the same class #1393 spent a day deleting.
+<!-- entry #1657 -->
+
+---
+
+## 2026-08-22 — #1657: a lost scrollback row must be countable before it can be prevented
+
+The 1.3.0 cold restart put ~70 sessions through their scrollback restore at
+once, exhausted the SQLite pool, and lost message rows. Two things came out of
+the investigation that outlive the incident, and neither is "raise POOL_SIZE".
+
+### The attribution is NOT establishable, and that is the finding
+
+Three callers were seen in the burst's stacks — `MeController.show/2` →
+`WindowCounts.bulk_snapshot/4` → `ReadCursor.bulk_unread_content_tails/2`,
+`SessionLog`, and `Bootstrap.validate_credential_servers!/1` — with no ranking
+between them. The ranking DID exist: `db_connection` appends the client's
+sampled stack to every checkout-deadline line it logs
+(`connection_pool.ex:196`, `Process.info(pid, :current_stacktrace)`), so the 42
+timeout lines carried 42 attributions. `run_erl`'s log rotation overwrote them
+before anyone grouped them, and the surviving generations all postdate the
+herd. So the ranking is gone, permanently, and the saturation axis is frozen
+rather than guessed at.
+
+`Grappa.DbLatency` cannot substitute, for a reason worth recording because it
+looks like it should: its counters are cumulative-since-boot with only a manual
+`reset/0`, so a burst cannot be windowed out — but more decisively, its
+`[:grappa, :repo, :query]` fold keys on `{source, op}` and never reads
+`metadata.result`. Ecto populates that field for failed queries
+(`ecto_sql/lib/ecto/adapters/sql.ex:1302`, and `db_connection.ex:1695` routes
+checkout errors into the same log callback), so the discriminator reaches the
+sink and the sink discards it. The instrument cannot tell a slow-but-served
+read from one of the 42 victims at any time resolution.
+
+### Counting a loss is a different axis from preventing one
+
+`messages` is the product. A row of it vanishing is a defect on its own terms,
+and it needed no ranking to work on — so it went first.
+
+**The count was a floor by construction.** Of the five
+`Persistor.persist_and_broadcast/3` call sites, only two logged the drop; the
+three outbound doors returned `{:error, _}` and said nothing. The grep that
+produced "ten rows lost" could only ever have seen a subset, and no re-reading
+of the log could have said by how much. The line therefore moved to the door
+rather than to the call sites: `Scrollback.persist_event/1` has exactly one
+production caller, so a census line in `Persistor` covers all five by
+construction and a sixth inherits it. Proven by mutation — removing that one
+line turns all five tests red, not three.
+
+Its wording drops the cause it could not vouch for. The old caller-side text
+asserted "SQLite pool saturated" unconditionally, and the red run printed the
+engine's own verdict for the same drop as "SQLite write lock held by another
+writer". `:persist_unavailable` is one atom over several causes; the cause
+stays on the engine's terminal line, which observed it. The
+`scrollback row dropped` prefix is unchanged, so the #1429 census keeps
+matching.
+
+**And one drop was not contention at all — it was contention misfiled as
+corruption.** `%Exqlite.Error{message: "interrupted"}` is what the pool does to
+its own victim: the checkout deadline fires
+(`db_connection/connection_pool.ex:190`) → `Holder.handle_disconnect/2` →
+`Exqlite.Connection.disconnect/2` → `Sqlite3.cancel/1` → `sqlite3_interrupt()`,
+and the statement in flight returns SQLITE_INTERRUPT. `transient_fault?/1`
+matched only "busy"/"locked", so it called that `:permanent` and re-raised: a
+dropped row in `Scrollback`, a 500 on a stateless web write, and a crash
+anywhere unwrapped — which is how `Bootstrap` died in the incident, on a READ
+(`bootstrap.ex:635`, `Visitors.list_active/0`) that no retry wraps.
+
+It earns a third fault kind rather than borrowing one. #1420 split
+`observed_state/1` in two precisely because a label was worn by a fault it did
+not describe; folding an interrupt into `:busy_locked` would print "write lock
+held by another writer" about a fault that never touched the write lock.
+`:queue_timeout` is nearer but still wrong: that client's checkout was SERVED,
+and then revoked.
+
+### 🔴 What this does NOT fix
+
+Reporting a loss is not preventing one, and the reclassification is not a
+retry. An interrupt arrives only after DBConnection's 15_000ms `:timeout` has
+already blown the 1_500ms budget, so the loop still makes exactly one attempt —
+the same regime #1421 documents for `busy_locked`, for the same reason. What
+changed is the verdict, not the retry count: a 503 instead of a 500, an honest
+drop instead of a corruption alarm, and a counter of its own. Making the budget
+actually reach that regime is #1421's re-dimensioning question and was not
+taken here.
+
+A durable write spool WOULD close the loss axis, and is declined: #340 already
+rejected a serialized writer, and a spool adds ordering against `messages.id`,
+replay-on-boot, and a second durability story for the FK that `read_cursors`
+hangs off — heavier than the problem. `pool_size` is declined for a different
+reason: it lives in `config/runtime.exs`, so it is a COLD deploy that drops
+every IRC session, and admitting more concurrent readers to a single-writer
+file is not obviously a cure for a writer being starved by readers.
+
+Left open, deliberately: whether `Bootstrap` was restarted by its supervisor
+after that crash and re-emitted the spawn plan. The mechanism is verified
+(`use Task, restart: :transient`, `bootstrap.ex:158`); the event was never
+observed, and the log that could have shown it is gone.

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -42,7 +42,8 @@ defmodule Grappa.DbLatency do
           the sender's own `handle_call` queued behind a busy channel's
           synchronous inbound inserts.
         - **mechanism 2 (single-writer contention):** the `contention`
-          row — `queue_timeout` / `busy_locked` counts, and `dropped`
+          row — `queue_timeout` / `busy_locked` / `interrupted` counts (#1657
+          added the third: a checkout the pool served and then revoked), and `dropped`
           (budget-exhausted rows lost).
         - **mechanism 3 (pure insert / index write-amplification):** the
           `persist` row `mean_ms` on its own, watched as the table grows.
@@ -125,6 +126,11 @@ defmodule Grappa.DbLatency do
           n: non_neg_integer(),
           queue_timeout: non_neg_integer(),
           busy_locked: non_neg_integer(),
+          # #1657 — the pool cancelling a checkout it had already served.
+          # Counted apart from `queue_timeout` (never granted) and
+          # `busy_locked` (granted, then blocked on the file lock) because
+          # the three name three different places the write died.
+          interrupted: non_neg_integer(),
           dropped: non_neg_integer()
         }
 
@@ -156,7 +162,7 @@ defmodule Grappa.DbLatency do
   defstruct queries: %{},
             send_privmsg: %{n: 0, total: 0, outcomes: %{}},
             persist: %{n: 0, total: 0, outcomes: %{}},
-            contention: %{n: 0, queue_timeout: 0, busy_locked: 0, dropped: 0},
+            contention: %{n: 0, queue_timeout: 0, busy_locked: 0, interrupted: 0, dropped: 0},
             lock_stalls: []
 
   @type t :: %__MODULE__{
@@ -260,6 +266,7 @@ defmodule Grappa.DbLatency do
     case Map.get(metadata, :fault) do
       :queue_timeout -> %{state | contention: %{counted | queue_timeout: counted.queue_timeout + 1}}
       :busy_locked -> %{state | contention: %{counted | busy_locked: counted.busy_locked + 1}}
+      :interrupted -> %{state | contention: %{counted | interrupted: counted.interrupted + 1}}
       _ -> %{state | contention: counted}
     end
   end

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -21,10 +21,10 @@ defmodule Grappa.Repo.BusyRetry do
       the op. Passed straight through, **never retried** (it is not a
       fault).
     * `{:error, :db_unavailable}` — a TRANSIENT fault
-      (`DBConnection.ConnectionError` / a busy-or-locked `%Exqlite.Error{}`)
-      that persisted for the whole retry budget. A web caller routes this
-      through `FallbackController` to a clean **503** (#518) instead of a
-      500 raise.
+      (`DBConnection.ConnectionError`, or a busy-or-locked / INTERRUPTED
+      `%Exqlite.Error{}` — see `classify/1`) that persisted for the whole
+      retry budget. A web caller routes this through `FallbackController`
+      to a clean **503** (#518) instead of a 500 raise.
 
   A **non-transient** `%Exqlite.Error{}` (syntax / corruption) is NOT
   saturation: retrying only spins. It **re-raises** with its original
@@ -56,6 +56,19 @@ defmodule Grappa.Repo.BusyRetry do
       first attempt has therefore already overshot the deadline by the time it
       returns, so the loop makes EXACTLY ONE attempt and the linear backoff
       below never runs.
+    * an `:interrupted` fault (#1657) shares that second regime, and saying
+      so is the point. It is raised when DBConnection's own `:timeout`
+      (15_000ms by default, 10x the budget) cancels the statement, so the
+      first attempt has ALREADY overshot by the time it returns and the loop
+      makes exactly one attempt here too. 🔴 So do not read #1657's
+      reclassification as "the row now gets retried" — in the live topology
+      it does not. What changed is that a pool-induced cancellation stops
+      being reported as CORRUPTION: it degrades to `{:error, :db_unavailable}`
+      (a 503 on a stateless web write, an honest drop in `Scrollback`)
+      instead of re-raising as a 500, and it is countable as its own state.
+      Making the budget actually REACH this regime is the same
+      re-dimensioning question #1421 prices, and it is not this module's to
+      take unilaterally.
 
   A third topology WOULD fall inside the budget — a deferred read->write
   upgrade raises an immediate `SQLITE_BUSY` that `busy_timeout` does not cover
@@ -79,7 +92,7 @@ defmodule Grappa.Repo.BusyRetry do
   @backoff_ms Application.compile_env(:grappa, [:busy_retry, :backoff_ms], 25)
   @backoff_cap_ms Application.compile_env(:grappa, [:busy_retry, :backoff_cap_ms], 200)
 
-  @type fault_kind :: :queue_timeout | :busy_locked
+  @type fault_kind :: :queue_timeout | :busy_locked | :interrupted
 
   @typedoc """
   Per-contention observer. Called once per RIDDEN-OUT transient attempt with
@@ -160,9 +173,15 @@ defmodule Grappa.Repo.BusyRetry do
   # Prose only: same retry, same `{:error, :db_unavailable}`, same metadata.
   # Splitting it also lets the #1429 census count the two apart
   # (`saturated` / `lockheld` in `scripts/log-gap-scan.awk`).
+  #
+  # #1657 adds the third. Its phrase names what the victim OBSERVED — its
+  # statement was cancelled mid-flight — and not the pool deadline that
+  # caused it, which this frame never sees and which is already the subject
+  # of the timing-out client's own `queue_timeout` line elsewhere in the log.
   @spec observed_state(fault_kind()) :: String.t()
   defp observed_state(:queue_timeout), do: "SQLite pool saturated"
   defp observed_state(:busy_locked), do: "SQLite write lock held by another writer"
+  defp observed_state(:interrupted), do: "SQLite statement cancelled by a pool timeout"
 
   # The same rule, applied to the NUMBER on that line (#1421). It used to read
   # "for the full #{@budget_ms}ms retry budget", which is false in the regime
@@ -198,27 +217,71 @@ defmodule Grappa.Repo.BusyRetry do
 
   @doc """
   Is this caught exception a TRANSIENT write-contention fault (retry) or a
-  permanent one (surface at once)? A pool `queue_timeout` is always
-  transient; for an `%Exqlite.Error{}` the message text ("busy"/"locked")
-  is the only discriminator SQLite gives us. Public so the scrollback
-  wrapper reuses the SAME classifier rather than forking one.
+  permanent one (surface at once)? Derived from `classify/1` so there is
+  exactly ONE table mapping a driver exception to a verdict. Public so the
+  scrollback wrapper reuses the SAME classifier rather than forking one.
   """
   @spec transient_fault?(Exception.t()) :: boolean()
-  def transient_fault?(%DBConnection.ConnectionError{}), do: true
+  def transient_fault?(error), do: classify(error) != :permanent
 
-  def transient_fault?(%Exqlite.Error{message: message}) when is_binary(message) do
+  @doc """
+  The single classifier: driver exception → fault kind, or `:permanent`.
+
+  A pool `queue_timeout` is always transient. For an `%Exqlite.Error{}` the
+  message text is the only discriminator SQLite gives us, and there are two
+  transient shapes, not one:
+
+    * `"interrupted"` — SQLITE_INTERRUPT. **The pool cancelling its own
+      victim (#1657).** Traced through the deps: a checkout deadline fires
+      (`db_connection/connection_pool.ex:190`) → `Holder.handle_disconnect/2`
+      → `Exqlite.Connection.disconnect/2` → `Sqlite3.cancel/1` →
+      `sqlite3_interrupt()`, and the statement in flight returns
+      SQLITE_INTERRUPT. So an interrupt is contention BY CONSTRUCTION —
+      the only way to earn one is for the pool to have run out of time.
+      It was classified `:permanent` until #1657, which meant the one
+      fault the retry budget exists for spent none of it, and — because a
+      permanent fault re-raises — a pool timeout surfaced as a dropped row
+      in `Scrollback`, a 500 on a stateless web write, and a crash
+      anywhere unwrapped (`Grappa.Bootstrap` died exactly this way on the
+      1.3.0 herd).
+    * `"busy"` / `"locked"` — a writer held the file lock past
+      `busy_timeout`.
+
+  Anything else (syntax, corruption) is `:permanent`: retrying only spins.
+
+  🔴 It earns its OWN kind rather than borrowing one. #1420 split
+  `observed_state/1` in two precisely because one label was worn by a fault
+  it did not describe; folding an interrupt into `:busy_locked` would print
+  "write lock held by another writer" about a fault that never touched the
+  write lock — the same defect, re-introduced. `:queue_timeout` is nearer
+  (the pool IS the cause) but still names the wrong observation: that
+  client's checkout was SERVED, and then revoked.
+  """
+  @spec classify(Exception.t()) :: fault_kind() | :permanent
+  def classify(%DBConnection.ConnectionError{}), do: :queue_timeout
+
+  def classify(%Exqlite.Error{message: message}) when is_binary(message) do
     downcased = String.downcase(message)
-    String.contains?(downcased, "busy") or String.contains?(downcased, "locked")
+
+    cond do
+      String.contains?(downcased, "interrupted") -> :interrupted
+      String.contains?(downcased, "busy") or String.contains?(downcased, "locked") -> :busy_locked
+      true -> :permanent
+    end
   end
 
-  def transient_fault?(%Exqlite.Error{}), do: false
+  def classify(%Exqlite.Error{}), do: :permanent
 
-  # Only reached after `transient_fault?/1` returned true, so an
-  # `%Exqlite.Error{}` here is always busy/locked and a `ConnectionError`
-  # always a pool queue_timeout.
+  # Only reached after `transient_fault?/1` returned true, so `classify/1`
+  # cannot answer `:permanent` here — but the clause is explicit rather than
+  # a bare pass-through, so a future transient kind that forgets to teach
+  # `observed_state/1` fails LOUD at the case instead of printing a stray atom.
   @spec fault_kind(DBConnection.ConnectionError.t() | Exqlite.Error.t()) :: fault_kind()
-  defp fault_kind(%DBConnection.ConnectionError{}), do: :queue_timeout
-  defp fault_kind(%Exqlite.Error{}), do: :busy_locked
+  defp fault_kind(error) do
+    case classify(error) do
+      kind when kind in [:queue_timeout, :busy_locked, :interrupted] -> kind
+    end
+  end
 
   ## ----- Test-only fault injection ------------------------------------
   #

--- a/lib/grappa/scrollback/telemetry.ex
+++ b/lib/grappa/scrollback/telemetry.ex
@@ -36,12 +36,16 @@ defmodule Grappa.Scrollback.Telemetry do
 
     * `[:grappa, :scrollback, :persist, :contention]`
       measurements: `%{attempt: pos_integer()}`
-      metadata: `%{fault: :queue_timeout | :busy_locked, dropped: boolean()}`
+      metadata: `%{fault: :queue_timeout | :busy_locked | :interrupted, dropped: boolean()}`
 
       Emitted from `Grappa.Scrollback.with_pool_retry/3` on each transient
       SQLite write-contention fault — mechanism 2 (single-writer contention):
-      `:queue_timeout` (the pool could not serve a checkout) or `:busy_locked`
-      (a slow writer held the single write-lock past `busy_timeout`).
+      `:queue_timeout` (the pool could not serve a checkout), `:busy_locked`
+      (a slow writer held the single write-lock past `busy_timeout`), or
+      `:interrupted` (#1657 — the pool's checkout deadline cancelled a
+      statement it had already served; counted apart because it is the only
+      one of the three that says the connection was TAKEN BACK rather than
+      never granted).
       `dropped: false` = ridden out (a retry follows); `dropped: true` = the
       wall-clock budget was exhausted and the row was dropped — the telemetry
       companion of the existing "SQLite pool saturated" `Logger.warning`, so a
@@ -90,9 +94,10 @@ defmodule Grappa.Scrollback.Telemetry do
   out. Fires ONLY on the contention path — already the slow path — so it adds
   zero cost to an uncontended insert.
   """
-  @spec contention(:queue_timeout | :busy_locked, pos_integer(), boolean()) :: :ok
+  @spec contention(:queue_timeout | :busy_locked | :interrupted, pos_integer(), boolean()) :: :ok
   def contention(fault, attempt, dropped)
-      when fault in [:queue_timeout, :busy_locked] and is_integer(attempt) and attempt > 0 and
+      when fault in [:queue_timeout, :busy_locked, :interrupted] and is_integer(attempt) and
+             attempt > 0 and
              is_boolean(dropped) do
     :telemetry.execute(
       [:grappa, :scrollback, :persist, :contention],

--- a/lib/grappa/session/persistor.ex
+++ b/lib/grappa/session/persistor.ex
@@ -28,14 +28,40 @@ defmodule Grappa.Session.Persistor do
 
   ## Failure ownership
 
-  This module never logs and never crashes the caller on a persist error:
-  it returns `{:error, term()}` so each caller owns its failure-mode
-  message + metadata (the outbound path surfaces it as the HTTP reply; the
-  effect arms log via `log_persist_failure/2` and continue). The `:ok =`
-  match on the broadcast/push is deliberate — those are in-node operations
-  that do not fail on the documented path, and a surprise there is a bug
-  we want loud (CLAUDE.md "no silent-swallow at boundaries").
+  The caller still owns its failure-mode RESPONSE: this module never
+  crashes it, and returns `{:error, term()}` so each site decides what to
+  do (the outbound paths surface it as the HTTP reply; the effect arms log
+  their own context and continue). The `:ok =` match on the broadcast/push
+  is deliberate — those are in-node operations that do not fail on the
+  documented path, and a surprise there is a bug we want loud (CLAUDE.md
+  "no silent-swallow at boundaries").
+
+  ## The census line is OURS, not the caller's (#1657)
+
+  What this module DOES own is the one-line record that a scrollback row
+  died. It used to be the caller's, and the 1.3.0 herd is what that cost:
+  of the five call sites, only two logged it, so the incident's loss was
+  grepped out of the jail log as "ten rows" when three of the five doors
+  had never been able to contribute a single line. The count was a FLOOR
+  by construction and nothing in the log could say by how much.
+
+  A drop is not a per-caller event — it is the same fact at every door
+  (`messages` is the product, and a row of it vanished), and this module
+  is the ONE door: `Grappa.Scrollback.persist_event/1` has no other
+  production caller. Deriving the line here from the attrs we already hold
+  makes the property structural instead of five separate disciplines, and
+  a sixth call site inherits it for free.
+
+  ⚠️ **Reporting a loss is not preventing one.** This line exists so the
+  next herd is COUNTABLE, not so it is survivable — the row is still gone.
+  Prevention is a different axis (`Grappa.Repo.BusyRetry`'s classification
+  and budget); do not read this as the drop being handled.
+
+  A validation failure is NOT a drop and does not log here: the row never
+  had a right to exist, the caller's changeset arm owns that message.
   """
+
+  require Logger
 
   alias Grappa.IRC.Identifier
   alias Grappa.PubSub.Topic
@@ -86,9 +112,41 @@ defmodule Grappa.Session.Persistor do
 
         {:ok, message}
 
+      {:error, :persist_unavailable} = err ->
+        log_row_dropped(attrs, ctx)
+        err
+
       {:error, _} = err ->
         err
     end
+  end
+
+  # #1657 — the census line for a lost scrollback row, emitted at the one
+  # door every persist passes through.
+  #
+  # CLAUDE.md "log honesty": the message names WHAT was observed here (a row
+  # of the product is gone) and NOT why, because this frame cannot know why —
+  # `:persist_unavailable` is a single atom covering a budget-exhausted
+  # transient fault AND the non-transient rescue in
+  # `Scrollback.with_pool_retry/1`. The old caller-side wording asserted
+  # "SQLite pool saturated" unconditionally, and it was measurably wrong: the
+  # engine line printed immediately before it on the same drop reads "SQLite
+  # write lock held by another writer" whenever the fault was `busy_locked`.
+  # The cause belongs to the engine's own terminal line, which observed it.
+  #
+  # 🔴 The `scrollback row dropped` prefix is the #1429 census anchor
+  # (`scripts/log-gap-scan.awk` `CNT["dropped"]`, pinned in
+  # `test/scripts/log_gap_scan_test.bats`). Only the tail may move; changing
+  # the prefix silently zeroes that counter, and zero is what a clean run
+  # looks like.
+  @spec log_row_dropped(map(), session_ctx()) :: :ok
+  defp log_row_dropped(attrs, ctx) do
+    Logger.warning(
+      "scrollback row dropped: persistence unavailable — session continues",
+      channel: Map.get(attrs, :channel),
+      kind: Map.get(attrs, :kind),
+      network: ctx.network_slug
+    )
   end
 
   # Post-persist push obligations, fired only for inbound rows

--- a/lib/grappa/session/persistor.ex
+++ b/lib/grappa/session/persistor.ex
@@ -61,13 +61,13 @@ defmodule Grappa.Session.Persistor do
   had a right to exist, the caller's changeset arm owns that message.
   """
 
-  require Logger
-
   alias Grappa.IRC.Identifier
   alias Grappa.PubSub.Topic
   alias Grappa.Push.Triggers, as: PushTriggers
   alias Grappa.{Scrollback, WindowCounts}
   alias Grappa.Scrollback.Wire
+
+  require Logger
 
   @typedoc """
   The Session.Server state slice this module reads, passed as the full

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -5122,7 +5122,7 @@ defmodule Grappa.Session.Server do
   # double the census. Nothing diagnostic is lost: `Persistor` derives channel,
   # kind and network from the attrs it is holding, and `numeric` rides
   # `attrs.meta` on the one arm that carries it.
-  defp log_persist_failure(:persist_unavailable, _metadata), do: :ok
+  defp log_persist_failure(:persist_unavailable, _), do: :ok
 
   # #422 — a just-persisted DM (query-window) content row ensures its
   # server-side query window exists, next to the persist, so a bouncer

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -5113,9 +5113,16 @@ defmodule Grappa.Session.Server do
     )
   end
 
-  defp log_persist_failure(:persist_unavailable, metadata) do
-    Logger.warning("scrollback row dropped: SQLite pool saturated — session continues", metadata)
-  end
+  # #1657 — the DROP's census line moved to `Persistor.persist_and_broadcast/3`,
+  # the one door every persist passes through, because only two of its five
+  # call sites ever reached this clause: the herd's loss count was a floor by
+  # construction. This arm stays (and stays a no-op) for two reasons — the atom
+  # must still MATCH here or the pre-#336 CaseClauseError this whole helper
+  # exists to prevent comes straight back, and a second line per drop would
+  # double the census. Nothing diagnostic is lost: `Persistor` derives channel,
+  # kind and network from the attrs it is holding, and `numeric` rides
+  # `attrs.meta` on the one arm that carries it.
+  defp log_persist_failure(:persist_unavailable, _metadata), do: :ok
 
   # #422 — a just-persisted DM (query-window) content row ensures its
   # server-side query window exists, next to the persist, so a bouncer

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -99,6 +99,11 @@ function count_signatures(line) {
     # the phrase that names the topology is the stable half, and it is the
     # half this counter is about.
     if (line ~ /SQLite pool saturated/) CNT["saturated"]++
+    # #1657 — the third BusyRetry terminal state. Its own counter, not folded
+    # into `saturated`: a cancelled statement had ALREADY been served a
+    # connection, so counting it as a checkout that never happened would
+    # misreport where the write died.
+    if (line ~ /statement cancelled by a pool timeout/) CNT["interrupted"]++
 
     # `index` before the three regexes: every lock signature carries the
     # literal "lock", and the stream is ~10^6 lines. The known-answer
@@ -119,7 +124,8 @@ function zero_counters(   i) {
 function summary_line(svc, nlines, mg, mat) {
     return sprintf(SUMFMT, svc, nlines, mg, mat, THRESH, ngap, \
         CNT["db30"], CNT["idle30"], CNT["dropped"], CNT["saturated"], \
-        CNT["lockheld"], CNT["lockstall"], CNT["lockstall_resolved"])
+        CNT["interrupted"], CNT["lockheld"], CNT["lockstall"], \
+        CNT["lockstall_resolved"])
 }
 
 function bail(msg) {
@@ -189,7 +195,7 @@ BEGIN {
     }
 
     SUMFMT = "%s\tSUMMARY\tlines=%d\tmaxgap=%.1f\tmaxgap_at=%s\tgaps_ge_%d=%d" \
-        "\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d" \
+        "\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d\tinterrupted=%d" \
         "\tlockheld=%d\tlockstall=%d\tlockstall_resolved=%d\n"
 
     # Samples copied from the emitting call site. Keep them verbatim: a
@@ -197,6 +203,7 @@ BEGIN {
     #   db30 / idle30      — Ecto's own query log (`Grappa.DbLatency`).
     #   dropped            — Grappa.Scrollback, #336 never-crash contract.
     #   saturated          — Repo.BusyRetry, pool queue_timeout arm.
+    #   interrupted        — Repo.BusyRetry, interrupted arm (#1657).
     #   lockheld           — Repo.BusyRetry, busy_locked arm (#1420).
     #   lockstall{,_resolved} — Grappa.Repo.LockWatch's two episode edges.
     sig("db30", "QUERY OK source=\"messages\" db=30064.1ms queue=0.1ms")
@@ -205,6 +212,9 @@ BEGIN {
     sig("saturated", \
         "db write unavailable: SQLite pool saturated for 1512ms across 14 attempts" \
         " (1500ms retry budget) — returning :db_unavailable")
+    sig("interrupted", \
+        "db write unavailable: SQLite statement cancelled by a pool timeout for 15042ms" \
+        " across 1 attempts (1500ms retry budget) — returning :db_unavailable")
     sig("lockheld", \
         "db write unavailable: SQLite write lock held by another writer for 30067ms" \
         " across 1 attempts (1500ms retry budget) — returning :db_unavailable")

--- a/test/grappa/repo/busy_retry_test.exs
+++ b/test/grappa/repo/busy_retry_test.exs
@@ -197,7 +197,7 @@ defmodule Grappa.Repo.BusyRetryTest do
 
     test "the observer sees a distinct :interrupted kind — never :busy_locked" do
       {:ok, observed} = Agent.start_link(fn -> [] end)
-      on_contention = fn kind, _attempt, _terminal? -> Agent.update(observed, &[kind | &1]) end
+      on_contention = fn kind, _, _ -> Agent.update(observed, &[kind | &1]) end
 
       assert {:error, :db_unavailable} =
                BusyRetry.run(fn -> raise_interrupted() end, on_contention: on_contention)

--- a/test/grappa/repo/busy_retry_test.exs
+++ b/test/grappa/repo/busy_retry_test.exs
@@ -41,6 +41,12 @@ defmodule Grappa.Repo.BusyRetryTest do
     raise %Exqlite.Error{message: "near \"SLECT\": syntax error", statement: nil}
   end
 
+  # #1657 — the pool cancelling its own victim's statement at the checkout
+  # deadline. Transient by construction; see the describe block below.
+  defp raise_interrupted do
+    raise %Exqlite.Error{message: "interrupted", statement: nil}
+  end
+
   # Every captured terminal line tagged with this fault kind. The `fault=`
   # metadata is what the prose has to agree with, so it is also what selects
   # the lines to judge.
@@ -114,6 +120,91 @@ defmodule Grappa.Repo.BusyRetryTest do
 
       assert_raise Exqlite.Error, ~r/syntax error/, fn -> BusyRetry.run(op) end
       assert Agent.get(counter, & &1) == 1
+    end
+  end
+
+  describe "SQLITE_INTERRUPT is contention, not corruption (#1657)" do
+    # The 2026-08-21 1.3.0 herd lost scrollback rows to
+    # `%Exqlite.Error{message: "interrupted"}` on ordinary `INSERT INTO
+    # messages`. That string is not a corruption signature — it is what the
+    # POOL does to its own victim, traced through the deps in tree:
+    #
+    #   db_connection/lib/db_connection/connection_pool.ex:190
+    #     the checkout deadline fires -> Holder.handle_disconnect(holder, exc)
+    #   exqlite/lib/exqlite/connection.ex:230
+    #     disconnect/2 -> Sqlite3.cancel(db) -> sqlite3_interrupt()
+    #   -> the statement in flight returns SQLITE_INTERRUPT
+    #
+    # So an interrupt is transient contention BY CONSTRUCTION: the only way
+    # to earn one is for the pool to have run out of time. Classifying it
+    # non-transient spends none of the retry budget on the one fault the
+    # budget exists for, and — because a non-transient re-raises — turns a
+    # 503-shaped degrade into a raise: a dropped row in Scrollback (whose
+    # #336 rescue catches it), a 500 on a stateless web write, and a crash
+    # anywhere unwrapped (`Bootstrap` died exactly this way in the incident).
+    #
+    # It earns its OWN fault kind rather than borrowing one. #1420 split
+    # `observed_state/1` in two precisely because one label was worn by a
+    # fault it did not describe, and folding an interrupt into
+    # `:busy_locked` would make the terminal line read "SQLite write lock
+    # held by another writer" about a fault that never touched the write
+    # lock — the same defect, re-introduced. `:queue_timeout` is nearer
+    # (the pool IS the cause) but still names the wrong observation: that
+    # client's checkout was served, and then revoked.
+    test "transient_fault?/1 classifies an interrupt as TRANSIENT" do
+      assert BusyRetry.transient_fault?(%Exqlite.Error{message: "interrupted", statement: nil})
+    end
+
+    test "an interrupt is RIDDEN OUT — the op that recovers on the third attempt succeeds" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      op = fn ->
+        n = Agent.get_and_update(counter, fn n -> {n, n + 1} end)
+        if n < 2, do: raise_interrupted(), else: {:ok, :served}
+      end
+
+      assert {:ok, :served} = BusyRetry.run(op)
+      assert Agent.get(counter, & &1) == 3
+    end
+
+    test "a persistent interrupt degrades to {:error, :db_unavailable} — it never re-raises" do
+      assert {:error, :db_unavailable} = BusyRetry.run(fn -> raise_interrupted() end)
+    end
+
+    test "a persistent interrupt is no longer one-and-done BY CLASSIFICATION" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      op = fn ->
+        Agent.update(counter, &(&1 + 1))
+        raise_interrupted()
+      end
+
+      assert {:error, :db_unavailable} = BusyRetry.run(op)
+      # The discriminator against the old behaviour: a `:permanent`
+      # classification re-raises after EXACTLY one attempt, whatever the
+      # clock says. Here the loop re-entered, so the single attempt is no
+      # longer forced by the VERDICT.
+      #
+      # ⚠️ What this does NOT claim: that a production interrupt gets
+      # retried. This op raises instantly, so the budget is still intact on
+      # attempt 2; a real one arrives only after DBConnection's 15_000ms
+      # `:timeout` has already blown the 1_500ms budget, so the live regime
+      # is one attempt anyway — for a reason of LATENCY, not of verdict
+      # (moduledoc, "How far the budget REACHES"). This test pins the
+      # verdict; nothing here pins a retry count in prod.
+      assert Agent.get(counter, & &1) > 1
+    end
+
+    test "the observer sees a distinct :interrupted kind — never :busy_locked" do
+      {:ok, observed} = Agent.start_link(fn -> [] end)
+      on_contention = fn kind, _attempt, _terminal? -> Agent.update(observed, &[kind | &1]) end
+
+      assert {:error, :db_unavailable} =
+               BusyRetry.run(fn -> raise_interrupted() end, on_contention: on_contention)
+
+      kinds = Agent.get(observed, & &1)
+      assert kinds != []
+      assert Enum.all?(kinds, &(&1 == :interrupted))
     end
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -13249,4 +13249,132 @@ defmodule Grappa.Session.ServerTest do
       refute Process.alive?(pid)
     end
   end
+
+  # #1657 — the 1.3.0 herd's loss count was taken by grepping `scrollback row
+  # dropped` out of the jail log. That grep could only ever have found a
+  # SUBSET: of the five `Persistor.persist_and_broadcast/3` call sites, only
+  # two reported the loss (the inbound `:persist` effect and `:join_failed`);
+  # the three outbound doors returned `{:error, _}` to their caller and logged
+  # nothing. So the incident's "ten rows" was a FLOOR by construction, and no
+  # re-reading of the log could have said by how much — the evidence for the
+  # other three never existed.
+  #
+  # The describe below pins the property the census depends on: a `messages`
+  # row that dies leaves a line behind, whichever door it died at.
+  #
+  # ⚠️ Reporting the loss is NOT preventing it. Every test there asserts that
+  # a row was lost LOUDLY; none of them assert the row survived.
+
+  # Drive one persist door with every retry loop in the session pid saturated,
+  # and hand back what it logged. `fire_on: 1` faults the persist's own first
+  # attempt (after the handshake the session is idle, so no `BusyRetry.run`
+  # precedes it on this pid); 10_000 armed faults outlast the wall-clock
+  # budget, so the op degrades rather than recovering. Disarmed before the
+  # stop so `terminate/2` runs clean.
+  defp capture_saturated_persist(pid, fun) do
+    Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 1)
+    on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
+
+    log = capture_log(fun)
+
+    Repo.BusyRetry.disarm_faults(pid)
+    log
+  end
+
+  defp session_past_handshake do
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+    {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+    pid = start_session_for(user, network)
+    :ok = IRCServer.await_handshake(server, 1_000)
+    %{server: server, user: user, network: network, pid: pid}
+  end
+
+  describe "a dropped scrollback row is never silent, at EVERY persist door (#1657)" do
+    test "outbound PRIVMSG (persist_and_send_fragments/5) reports the dropped row" do
+      %{user: user, network: network, pid: pid} = session_past_handshake()
+
+      log =
+        capture_saturated_persist(pid, fn ->
+          assert {:error, :persist_unavailable} =
+                   Session.send_privmsg({:user, user.id}, network.id, "#sniffo", "ciao")
+        end)
+
+      assert log =~ "scrollback row dropped"
+      # #336: a lost row degrades the session, it never takes it down.
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "outbound NOTICE (persist_and_send_notice_fragments/5) reports the dropped row" do
+      %{user: user, network: network, pid: pid} = session_past_handshake()
+
+      log =
+        capture_saturated_persist(pid, fn ->
+          assert {:error, :persist_unavailable} =
+                   Session.send_notice({:user, user.id}, network.id, "#sniffo", "carol", "heads up")
+        end)
+
+      assert log =~ "scrollback row dropped"
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "outbound CTCP (handle_ctcp_send/4) reports the dropped row" do
+      %{user: user, network: network, pid: pid} = session_past_handshake()
+
+      log =
+        capture_saturated_persist(pid, fn ->
+          assert {:error, :persist_unavailable} =
+                   Session.send_ctcp({:user, user.id}, network.id, "#sniffo", "carol", "\x01PING 1\x01")
+        end)
+
+      assert log =~ "scrollback row dropped"
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The two doors that ALREADY reported. Green before the change and
+    # after it — they are here because the cure MOVES the line to the one
+    # place every door passes through, and a relocation that drops an
+    # existing report would otherwise be invisible.
+    test "inbound :persist effect still reports the dropped row" do
+      %{server: server, pid: pid} = session_past_handshake()
+
+      log =
+        capture_saturated_persist(pid, fn ->
+          IRCServer.feed(server, ":alice!~a@host PRIVMSG #sniffo :hey there\r\n")
+          # DB-free FIFO barrier: the PONG is answered from the same serial
+          # mailbox, so it proves the PRIVMSG's effects have fully run, and
+          # the armed fault cannot starve it (no Repo call on that path).
+          IRCServer.feed(server, "PING :drop-barrier\r\n")
+          assert {:ok, _} = IRCServer.wait_for_line(server, &String.contains?(&1, "PONG"), 2_000)
+        end)
+
+      assert log =~ "scrollback row dropped"
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test ":join_failed effect still reports the dropped row" do
+      %{server: server, pid: pid} = session_past_handshake()
+
+      log =
+        capture_saturated_persist(pid, fn ->
+          # 474 ERR_BANNEDFROMCHAN — a terminal join failure, so the arm
+          # persists its notice row and that persist is the one that dies.
+          IRCServer.feed(server, ":irc.test 474 vjt #sniffo :Cannot join channel (+b)\r\n")
+          IRCServer.feed(server, "PING :join-failed-barrier\r\n")
+          assert {:ok, _} = IRCServer.wait_for_line(server, &String.contains?(&1, "PONG"), 2_000)
+        end)
+
+      assert log =~ "scrollback row dropped"
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
 end

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -24,11 +24,15 @@ setup() {
     # Verbatim from the call sites, so a pin that drifts from production
     # prose fails here rather than reporting a confident zero.
     #   lock_watch.ex — the two edges of one stall episode
-    #   busy_retry.ex — the two terminal arms, one per fault kind
+    #   busy_retry.ex — the three terminal arms, one per fault kind
     LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
     LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for 30067ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
     SATURATED_LINE='db write unavailable: SQLite pool saturated for 1512ms across 14 attempts (1500ms retry budget) — returning :db_unavailable'
+    # #1657 — the third arm. The elapsed is ~15s because a cancellation is
+    # raised only once DBConnection's own `:timeout` has expired, which is
+    # also why its attempt count is 1 and not 14 like the saturated line.
+    INTERRUPTED_LINE='db write unavailable: SQLite statement cancelled by a pool timeout for 15042ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
 }
 
 # The scanner as integration.sh invokes it: a service label and a
@@ -93,12 +97,15 @@ stamp() {
         stamp '12:00:04.' "$LOCKHELD_LINE"
         stamp '12:00:05.' "$LOCKSTALL_LINE"
         stamp '12:00:06.' "$LOCKRESOLVED_LINE"
+        stamp '12:00:07.' "$INTERRUPTED_LINE"
     } | scan 10 )"
 
     grep -q 'db30=1' <<<"$out"
     grep -q 'idle30=1' <<<"$out"
     grep -q 'dropped=1' <<<"$out"
     grep -q 'saturated=1' <<<"$out"
+    # #1657 — and specifically NOT folded into `saturated`, which stays 1.
+    grep -q 'interrupted=1' <<<"$out"
     grep -q 'lockheld=1' <<<"$out"
     grep -q 'lockstall=1' <<<"$out"
     grep -q 'lockstall_resolved=1' <<<"$out"


### PR DESCRIPTION
Two cures on the **loss** axis of #1657. Neither needs the attribution the
incident log no longer carries; the **saturation** axis is deliberately
untouched.

## What is NOT establishable, and why that is settled

The ranking of the three candidate pool holders is gone. The 42
checkout-deadline lines each carried the client's sampled stack
(`db_connection/connection_pool.ex:196`), and `run_erl`'s circular rotation
overwrote them — every surviving generation postdates the herd.

`Grappa.DbLatency` cannot stand in, and not only because its counters are
cumulative-since-boot: its `[:grappa, :repo, :query]` fold keys on
`{source, op}` and never reads `metadata.result`. Ecto populates that field for
failed queries (`ecto_sql/.../sql.ex:1302`; `db_connection.ex:1695` routes
checkout errors through the same callback), so the discriminator reaches the
sink and the sink discards it. It cannot separate a slow-but-served read from
one of the 42 victims at any time resolution.

## 1. A dropped row is never silent, at every persist door

Of the five `Persistor.persist_and_broadcast/3` call sites, only two reported
the loss; the three outbound doors returned `{:error, _}` and logged nothing.
So the "ten rows lost" figure was a **floor by construction**, and no
re-reading of the log could have said by how much.

The line moved to the door instead of to the call sites:
`Scrollback.persist_event/1` has exactly one production caller, so a census
line in `Persistor` covers all five and a sixth inherits it.

Its wording drops the cause it could not vouch for — the old text asserted
"SQLite pool saturated" unconditionally, and the red run printed the engine's
own verdict for the same drop as "SQLite write lock held by another writer".
The `scrollback row dropped` prefix is unchanged, so the #1429 census keeps
matching with no edit.

## 2. SQLITE_INTERRUPT is contention, not corruption

`%Exqlite.Error{message: "interrupted"}` is the pool cancelling its own victim:
deadline → `Holder.handle_disconnect/2` → `Exqlite.Connection.disconnect/2` →
`Sqlite3.cancel/1` → `sqlite3_interrupt()`. `transient_fault?/1` matched
"busy"/"locked" only, so it re-raised — a dropped row logged as a NON-TRANSIENT
DB error, a 500 instead of a 503 on a web write, and a crash where nothing
wraps it (how `Bootstrap` died, on a READ at `bootstrap.ex:635`).

It gets a third fault kind rather than borrowing one, for #1420's reason: a
label must not be worn by a fault it does not describe. Carried through every
consumer in the same commit — Telemetry guard, `DbLatency` counters, and the
#1429 census plus its bats known-answer control.

## 🔴 What this does NOT fix

- **Reporting a loss is not preventing one.** The row is still gone.
- **The reclassification is not a retry.** An interrupt arrives only after
  DBConnection's 15_000ms `:timeout` has already blown the 1_500ms budget, so
  the loop still makes exactly one attempt — #1421's documented regime. What
  changed is the verdict, not the count.
- **`pool_size` is untouched**, so this is HOT-deployable. If the saturation
  axis is ever taken, that knob lives in `config/runtime.exs` and is a COLD
  deploy.
- **Left open:** whether `Bootstrap` was restarted and re-emitted its spawn
  plan. Mechanism verified (`use Task, restart: :transient`); event never
  observed, and the log that would show it is gone.

## Evidence

| gate | result |
|---|---|
| red, phase 1 | 5 tests, **3 failures** — exactly the three mute doors; the two loquacious ones green |
| mutation, phase 1 | census line removed → **5/5 red** (the property is structural, not five disciplines) |
| red, phase 2 | 20 tests, **5 failures**, each `** (Exqlite.Error) interrupted` re-raised from `busy_retry.ex:122` |
| mutation, phase 2 | `:interrupted` branch removed → **5/20 red** |
| `scripts/check.sh` | **RC=0** |
| `scripts/test.sh` | 8 doctests, 61 properties, **6715 tests, 0 failures** |
| `scripts/bats.sh` | **634 ok, 0 not ok** |

`scripts/integration.sh` NOT run — the stack lane is held by w1.