### PR TITLE
deploy(#1656): a failed healthcheck must not be able to hide a dead node

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57274,3 +57274,124 @@ Left open, deliberately: whether `Bootstrap` was restarted by its supervisor
 after that crash and re-emitted the spawn plan. The mechanism is verified
 (`use Task, restart: :transient`, `bootstrap.ex:158`); the event was never
 observed, and the log that could have shown it is gone.
+<!-- entry #1656 -->
+
+---
+
+## 2026-08-22 — #1656: a failed healthcheck must never be able to hide a dead node
+
+The v1.3.0 cold deploy on m42 (2026-08-21 ~21:20 CEST, `--force-cold`)
+worked — migrations, seed, stop+start, users reconnected and were served —
+and then the healthcheck loop burned its 30×2s budget (first probes `503`,
+later `Connection refused`), exited `healthcheck never returned 200 after
+60s`, and production was down until a manual `service grappa start`.
+
+### The issue's causal order is inverted by its own evidence
+
+The issue reads *healthcheck fails → script exits → node dies*. But the
+teardown stops children in REVERSE start order, so `GrappaWeb.Endpoint`
+goes down BEFORE `Grappa.SessionSupervisor` finishes draining. A `503`
+therefore means the Endpoint is UP, and `Connection refused` means it is
+already gone — and both happened INSIDE the loop, before the script
+exited. `21:24:37` is not when the node died; it is when a long drain
+FINISHED. Nothing links the script's exit to the death, which is why the
+"what does the script leak into the daemon" hunt (ssh process group,
+`run_erl` detachment) had nothing to find.
+
+### F1 — what each way of killing this release actually logs (measured)
+
+Measured on a real `mix release` (`scripts/release-image.sh`, ERTS
+16.4.0.5, `start_permanent: Mix.env() == :prod`), one fresh boot per row:
+
+| death | log line | node | crash dump |
+|---|---|---|---|
+| `bin/grappa stop` | **nothing at all** | dies, exit 0 | no |
+| `SIGTERM` | `[notice] SIGTERM received - shutting down` | dies, exit 0 | no |
+| top supervisor gives up | `[notice] Application grappa exited: shutdown` + `Kernel pid terminated (application_controller) ("{application_terminated,grappa,shutdown}")` | dies, exit 1 | **yes** |
+| `Application.stop(:grappa)` | `Application grappa exited: :stopped` | **stays up** | no |
+
+The line the incident reported matches the third row and only the third
+row, down to the rendering: `shutdown` bare, where an `Application.stop`
+renders `:stopped` with the colon. So **nobody stopped that node** — not
+an operator stop (silent), not a signal (which announces itself). Its own
+top supervisor gave up, and because a release's own application is
+`:permanent`, that takes the whole runtime with it, orderly.
+
+This also settles a reasoning objection raised during triage: "an orderly
+shutdown is what SIGTERM produces, so *no signal in the log* proves
+nothing." Measured, that is wrong — OTP logs the signal explicitly. The
+issue's exclusion was sound.
+
+`Grappa.Supervisor` is started with no `max_restarts`, so it inherits
+**3 restarts in 5 seconds** — against `Grappa.SessionSupervisor`'s
+explicit `10_000/60`. A permanent child crash-looping past that ladder is
+sufficient to produce every observation: users served, sessions logging
+`reason=:shutdown clean=true`, Endpoint gone mid-loop, no SIGTERM.
+
+### What is NOT established
+
+The cause is still **unknown**, deliberately. F1 identifies the SHAPE of
+the death, not which child failed nor why. Two things keep it open:
+
+- **The crash dump.** The third row writes one (into the BEAM's CWD —
+  measured `/app` in the image, i.e. the release root on the jail), and
+  `ERL_CRASH_DUMP*` is set nowhere in this repo, so dumping is enabled.
+  The issue reports no dump. Either it landed where nobody looked, or the
+  mechanism is a fifth one not reproduced here.
+- **Why `/healthz` answered 503 while the box served users.** `mark_ready/0`
+  runs the instant `Supervisor.start_link` returns and `Grappa.Bootstrap`
+  is a `Task` that returns immediately, so a live session implies
+  `ready?` was already `true` — which leaves the `repo` or `ets` check as
+  the only thing that can 503 a serving node. That is inference from
+  code, not evidence: the run's logs had already rotated away.
+
+### The three cures, none of which need the cause
+
+**1. The failure arm reports liveness (`substrate_service_alive`).**
+A new hook in `infra/lib/deploy_common.sh`, correctness-posture (default
+ON, no fallback, like the #440 seed) so every substrate must answer it.
+"Healthcheck failed" and "production is DOWN" are different emergencies
+and printed the same sentence. A consumer that predates the hook reports
+**UNKNOWN**, never DOWN: an undefined function returns 127, and reading
+that as "dead" would fire the loudest alarm we own on no evidence —
+reachable, because `infra/docker/get.sh` mirrors the lib and the consumer
+as separate files.
+
+**It reports; it never acts.** Restarting production is the operator's
+decision, and a deploy that restarts what it just failed to health-check
+can drive a crash-loop straight back into the outage it is standing in.
+
+**2. The 503 body is no longer discarded.** `/healthz` answers a non-200
+with a body naming the failing check (`ready` / `repo` / `ets`) and its
+reason — and every substrate probed with `curl -fsS -o /dev/null`, where
+`-f` is simultaneously what makes a non-2xx an error and what throws the
+body away. The deploy held the diagnosis thirty times and dropped it each
+time. Each hook now re-asks WITHOUT `-f` on a red probe only (a healthy
+deploy still makes exactly one request) and the loop prints the last
+answer once, in the failure arm. `--fail-with-body` would be one flag
+instead of two requests; it was declined as a portability bet against a
+FreeBSD curl this branch cannot measure.
+
+**3. The run_erl log ring holds a week instead of an hour.** On the jail
+that circular ring is the node's ONLY history — no journald, no
+`docker logs` — and it ships at run_erl's stock 5 × 100 KB. Measured on
+the jail 2026-08-22: the four surviving `erlang.log.*` spanned 22:52 →
+00:32, one hundred minutes, with the generation between them already
+overwritten. **Two incidents lost their evidence to that ring in a single
+night** (#1656 and #1657, whose 42 queue timeouts appear zero times in
+what survived), and both had to be filed cause-unknown because of it.
+`grappa_log_generations=20` × `grappa_log_maxsize=2 MB` = a 40 MB hard
+ceiling, ~7 days at the measured ~240 KB/h, still circular and still
+bounded. The variable names were read out of the shipped `run_erl` binary,
+not remembered.
+
+**Deploy class: COLD.** `RUN_ERL_LOG_*` are read by `run_erl(1)` when it
+spawns, so the new ring only exists on a BEAM started after the change —
+and `jail_install_rcd.sh`, which installs the wrapper carrying it, runs
+only on the cold path's `substrate_restart`. A hot deploy neither installs
+the new wrapper nor restarts the daemon, so it changes nothing here.
+
+The jail rc.d is the only shipped service definition that spawns
+`run_erl`; systemd and both images run `bin/grappa start` in the
+foreground. A test holds that set, so a future substrate that adopts
+`daemon` cannot inherit the 500 KB ring in silence.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57395,3 +57395,35 @@ The jail rc.d is the only shipped service definition that spawns
 `run_erl`; systemd and both images run `bin/grappa start` in the
 foreground. A test holds that set, so a future substrate that adopts
 `daemon` cannot inherit the 500 KB ring in silence.
+
+### The mutation bench broke, and how it announced itself
+
+The oracles above were proven by mutation, and one round of that battery
+was invalid. The loop saved each production file before mutating it with
+`cp "$f" /tmp/w1-$(basename "$f").orig` — and this repo has **five files
+named `deploy.sh`** (`infra/linux/`, `infra/docker/`, `infra/freebsd/`,
+`scripts/`, plus the mirrored copies). Two of them collapsed onto one
+backup, so the restore wrote the docker driver into
+`infra/linux/deploy.sh`, and the next mutant ran against a file that was
+not the file under test.
+
+**It announced itself in the shape of the result: a mutation aimed at one
+hook lit up 22 reds across the whole linux suite instead of the 1 it was
+built to kill.** That reads like a discovery — "my change breaks
+everything" — and it is the opposite: nothing was measured at all.
+
+**A targeted mutant that lights up reds everywhere is not a powerful
+mutant, it is the wrong bench.** A mutant is a scalpel; its result is
+only evidence when the blast radius matches the aim. One red where you
+predicted one red is a measurement. Twenty-two reds where you predicted
+one is a bench report, and the only correct next move is to throw the
+round away and rebuild the bench — which is what happened here: the round
+was rerun after restoring from git, and it then killed exactly its one
+intended case.
+
+Restore from `git checkout -- <file>` rather than from a copy. The
+production files are committed before the battery starts, so git is the
+authoritative backup and it cannot collide with itself; and
+`git status --porcelain` after each restore names any file the mutant
+never touched, which is the cheap check that would have caught this on
+the first round instead of the second.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -3316,6 +3316,25 @@ Both hooks therefore run every deploy, forever, and both MUST be
 idempotent. "Hot vs cold deploy" above carries the per-substrate seed
 doors and the schema-then-data ordering.
 
+**A failed healthcheck says WHICH emergency it is (#1656).** When the
+budget runs out, the loop no longer stops at `healthcheck never returned
+200`. It prints the last `/healthz` answer, then asks
+`substrate_service_alive` and says one of three things: the daemon is
+**still RUNNING** (up but unhealthy — production is serving, read the
+answer before touching anything), the daemon is **GONE** (production is
+DOWN — that is the emergency, the healthcheck line was the symptom), or
+liveness is **UNKNOWN** (a consumer older than the hook; check by hand).
+It never restarts anything: that is the operator's decision, and a deploy
+that restarts what it just failed to health-check can drive a crash-loop
+back into the outage. `DEPLOY_RESTART_HINT` carries the per-substrate
+command to type.
+
+The probe itself changed shape for the same reason. `/healthz` answers a
+non-200 with a body naming the failing check (`ready` / `repo` / `ets`),
+and `curl -f` is both what turns a non-2xx into an error and what discards
+that body — so every `substrate_healthcheck` now re-asks WITHOUT `-f` on a
+red probe only. A healthy deploy still makes exactly one request.
+
 **A failed seed is non-fatal, and that is not a silent swallow.** On
 the cold path the seed runs after the migration and before the restart,
 so aborting there would leave a migrated DB, the old daemon still up,
@@ -4826,7 +4845,17 @@ it.
   the daemon), driven by `RELEASE_TMP=runtime` exported by
   `infra/freebsd/rc.d/grappa`. The rotation set survives
   `mix release --overwrite` (which would otherwise blow away
-  `_build/.../tmp/log/`). On the Linux/systemd substrate, `bin/grappa
+  `_build/.../tmp/log/`).
+  **The ring is CIRCULAR and it is the jail's only log history**, so its
+  size decides how far back an incident can be read. run_erl ships 5
+  files × 100 KB, which measured out at roughly two hours and cost #1656
+  and #1657 their evidence in one night; the rc.d now exports
+  `RUN_ERL_LOG_GENERATIONS` / `RUN_ERL_LOG_MAXSIZE` from
+  `grappa_log_generations` (20) and `grappa_log_maxsize` (2000000) —
+  a 40 MB ceiling, about a week. Retune per jail in
+  `/etc/rc.conf.d/grappa`; **a new value only takes effect on the next
+  COLD deploy**, because `run_erl` reads them when it spawns.
+  On the Linux/systemd substrate, `bin/grappa
   start` runs in the foreground (no `run_erl`), so logs go to
   `journalctl -u grappa` instead — no `runtime/log/` file story there.
 - **Config**: DB-driven (Phase 2 sub-task 2j replaced the TOML loader).

--- a/infra/docker/deploy.sh
+++ b/infra/docker/deploy.sh
@@ -618,6 +618,7 @@ cmd_update() {
 	DEPLOY_FEATURE_MARKER=1
 	DEPLOY_FEATURE_PREV_SHA_CARRY=1
 	DEPLOY_SEED_RETRY_HINT="${COMPOSE[*]} --profile prod run --rm grappa mix grappa.seed_themes"
+	DEPLOY_RESTART_HINT="${COMPOSE[*]} --profile prod up -d grappa"
 	# ---- substrate hooks --------------------------------------------
 	# ONE hook set for this substrate, shared with `scripts/deploy.sh`
 	# (#1384). The healthcheck knobs come with it: two doors onto one
@@ -879,6 +880,7 @@ cmd_update_release() {
 	DEPLOY_FEATURE_MARKER=0
 	DEPLOY_FEATURE_PREV_SHA_CARRY=0
 	DEPLOY_SEED_RETRY_HINT="docker run --rm --env-file $ENV_FILE -v ${GRAPPA_DATA_VOLUME}:/data $GRAPPA_IMAGE eval 'Grappa.Release.seed_themes()'"
+	DEPLOY_RESTART_HINT="infra/docker/deploy.sh start"
 	COLD_HEALTHCHECK_RETRIES="${COLD_HEALTHCHECK_RETRIES:-120}"
 	COLD_HEALTHCHECK_SLEEP="${COLD_HEALTHCHECK_SLEEP:-2}"
 
@@ -910,7 +912,17 @@ cmd_update_release() {
 		release_start_container
 	}
 	substrate_healthcheck() {
-		docker exec "$GRAPPA_CONTAINER" curl -fsS -o /dev/null http://localhost:4000/healthz
+		# On a red probe re-ask WITHOUT `-f` so the 503 body (which names the
+		# failing check) reaches the loop instead of /dev/null — see #1656 and
+		# the hook contract in infra/lib/deploy_common.sh.
+		docker exec "$GRAPPA_CONTAINER" curl -fsS -o /dev/null http://localhost:4000/healthz && return 0
+		docker exec "$GRAPPA_CONTAINER" curl -sS http://localhost:4000/healthz 2>&1
+		return 1
+	}
+	substrate_service_alive() {
+		# Existence is not liveness: release_container_exists answers yes for a
+		# container that has already exited.
+		[ "$(docker inspect -f '{{.State.Running}}' "$GRAPPA_CONTAINER" 2>/dev/null)" = "true" ]
 	}
 	substrate_done_banner() {
 		say "grappa updated — cold (image pulled + container recreated) 🎉"

--- a/infra/freebsd/deploy.sh
+++ b/infra/freebsd/deploy.sh
@@ -53,6 +53,9 @@ DEPLOY_FEATURE_MARKER=1
 DEPLOY_FEATURE_PREV_SHA_CARRY=1
 DEPLOY_FEATURE_RECONCILE=1
 DEPLOY_SEED_RETRY_HINT="sudo bastille cmd grappa ${REPO_ROOT}/infra/freebsd/jail_release.sh eval 'Grappa.Release.seed_themes()'"
+# Host-side spelling, like the seed hint above: what the operator types, not
+# what this script (already inside the jail) would run.
+DEPLOY_RESTART_HINT="sudo bastille cmd grappa service grappa start"
 
 # Run one build step as the grappa user. `su -l` strips the environment,
 # so PATH/MIX_ENV/MIX_OS_CONCURRENCY_LOCK are re-set inside every
@@ -191,7 +194,21 @@ substrate_restart() {
 }
 
 substrate_healthcheck() {
-	curl -fsS -o /dev/null "${HEALTHCHECK_URL}"
+	# `-f` is what turns a non-2xx into a non-zero exit — and it is also what
+	# throws the BODY away. /healthz answers 503 with a body naming the failing
+	# check (`ready` / `repo` / `ets`) and its reason, so on a red probe ask
+	# again WITHOUT `-f` and hand that answer up. Two requests happen only on
+	# a probe that already failed; a healthy deploy still makes exactly one.
+	# Why: the #1656 cold deploy discarded that answer 30 times.
+	curl -fsS -o /dev/null "${HEALTHCHECK_URL}" && return 0
+	curl -sS "${HEALTHCHECK_URL}" 2>&1
+	return 1
+}
+
+substrate_service_alive() {
+	# rc.subr's status_cmd → `bin/grappa pid` RPC against the live node. Same
+	# probe grappa_start polls, so "alive" means the same thing to both.
+	service grappa status >/dev/null 2>&1
 }
 
 substrate_done_banner() {

--- a/infra/freebsd/rc.d/grappa
+++ b/infra/freebsd/rc.d/grappa
@@ -62,6 +62,23 @@ load_rc_config "$name"
 # because run_erl always creates its own `log/` subdir under
 # RELEASE_TMP. Operator override via /etc/rc.conf.d/grappa.
 : ${grappa_runtime_tmp:="/home/grappa/grappa/runtime"}
+# run_erl's CIRCULAR log ring — the node's only stdout/stderr history, and
+# the sole place an incident's evidence lives on this substrate.
+#
+# 🔴 The stock ring is 5 files x 100 KB = 500 KB, and it is too small to
+# survive one night. MEASURED on the jail 2026-08-22: the four surviving
+# `erlang.log.*` covered 22:52 -> 00:32, exactly 100 minutes, and the
+# generation in between had already been overwritten. TWO separate incidents
+# lost their evidence to that ring inside a single night — #1656 (the v1.3.0
+# cold deploy that ended with the node gone) and #1657 (42 queue timeouts, of
+# which the surviving files hold zero) — and both had to be filed with the
+# cause DELIBERATELY UNKNOWN because the log was already gone by morning.
+#
+# Sized from that measurement: ~400 KB per 100 min is ~240 KB/h, so
+# 20 x 2 MB = 40 MB holds roughly a week. The ring stays CIRCULAR and the
+# ceiling is hard — this buys retention, never unbounded growth.
+: ${grappa_log_generations:="20"}
+: ${grappa_log_maxsize:="2000000"}
 # Stop/start synchronization (defect #9, 2026-06-11 outage: `service
 # grappa restart` started the new BEAM while the old node was still
 # draining WS connections → "name grappa@grappa seems to be in use" →
@@ -126,7 +143,11 @@ grappa_runas() {
 	# and Dockerfile.release. An LC_ALL/LC_CTYPE inherited from root still
 	# outranks LANG (measured) — this pins the default, it does not fight an
 	# override.
-	su -m "${grappa_user}" -c "export RELEASE_TMP='${grappa_runtime_tmp}'; export LANG=C.UTF-8; export PATH=\"/usr/local/bin:/usr/local/sbin:\${PATH}\"; ${envsrc}${command} ${subcmd}"
+	# RUN_ERL_LOG_* are read by run_erl(1) from the environment of the process
+	# that spawns it, i.e. exactly here, on the `daemon` subcommand. They ride
+	# with the other exports because this is the one door every subcommand
+	# goes through; the other verbs simply never spawn a run_erl.
+	su -m "${grappa_user}" -c "export RELEASE_TMP='${grappa_runtime_tmp}'; export LANG=C.UTF-8; export RUN_ERL_LOG_GENERATIONS='${grappa_log_generations}'; export RUN_ERL_LOG_MAXSIZE='${grappa_log_maxsize}'; export PATH=\"/usr/local/bin:/usr/local/sbin:\${PATH}\"; ${envsrc}${command} ${subcmd}"
 }
 
 grappa_start() {

--- a/infra/lib/deploy_common.sh
+++ b/infra/lib/deploy_common.sh
@@ -42,7 +42,13 @@
 #   substrate_cic             cic bundle build (cold only)
 #   substrate_migrate         ecto migrate (cold only)
 #   substrate_restart         stop/start the daemon (cold only; may exit on defer)
-#   substrate_healthcheck     one /healthz probe; 0=200, nonzero=not yet
+#   substrate_healthcheck     one /healthz probe; 0=200, nonzero=not yet AND
+#                             stdout carries whatever the substrate could learn
+#                             about WHY (the 503 body, the curl error) — see
+#                             _deploy_healthcheck_loop
+#   substrate_service_alive   0 iff the daemon/container/unit is running RIGHT
+#                             NOW; asked only when the healthcheck budget ran
+#                             out (#1656)
 #   substrate_done_banner N   print the success line (N = retries taken);
 #                             the wording is substrate-specific
 #
@@ -251,13 +257,21 @@ _deploy_resolve_mode() {
 # $1 retries, $2 sleep. Writes the completed-deploy marker on the first
 # 200 (gated on the MARKER feature) — the marker is the "deploy fully
 # applied" barrier, so it is written LAST, after the app answers.
+#
+# The probe's output is CAPTURED, not discarded (#1656). /healthz answers a
+# non-200 with a body naming the failing check (`ready` / `repo` / `ets`) and
+# its reason, and a connection error carries curl's own diagnosis — that is
+# the only evidence of WHY a deploy went red, and it used to go to
+# /dev/null 30 times in a row. The last answer is printed once, in the
+# failure arm, where the operator is already reading.
 _deploy_healthcheck_loop() {
 	retries="$1"
 	sleep_s="$2"
 	deploy_log "healthcheck loop ($retries x ${sleep_s}s)"
 	i=0
+	hc_answer=""
 	while [ "$i" -lt "$retries" ]; do
-		if substrate_healthcheck; then
+		if hc_answer=$(substrate_healthcheck 2>&1); then
 			if [ "$DEPLOY_FEATURE_MARKER" = 1 ]; then
 				substrate_write_marker
 			fi
@@ -269,7 +283,41 @@ _deploy_healthcheck_loop() {
 		sleep "$sleep_s"
 	done
 	deploy_error "healthcheck never returned 200 after $((retries * sleep_s))s"
+	if [ -n "$hc_answer" ]; then
+		printf '[deploy]   last /healthz answer: %s\n' "$hc_answer" >&2
+	fi
+	_deploy_report_liveness
 	exit 1
+}
+
+# ---- liveness report on an exhausted healthcheck budget (#1656) ------
+# "The healthcheck failed" and "production is DOWN" are different
+# emergencies, and until now they printed the same sentence. Measured: the
+# v1.3.0 cold deploy on m42 (2026-08-21) exited `healthcheck never returned
+# 200 after 60s` while the node had already terminated — an operator who did
+# not go and look at the jail was holding a message about the wrong problem.
+#
+# This REPORTS, it never acts. Restarting production is the operator's
+# decision: a deploy that restarts what it just failed to health-check can
+# drive a crash-loop straight back into the outage it is standing in.
+: "${DEPLOY_RESTART_HINT:=the service manager on this substrate}"
+
+_deploy_report_liveness() {
+	# A consumer that predates this hook must not be read as "the daemon is
+	# dead" — an undefined function returns 127, which would fire the loudest
+	# alarm we own on no evidence at all. `infra/docker/get.sh` mirrors the lib
+	# and the consumer separately, so old-consumer/new-lib is reachable.
+	if ! command -v substrate_service_alive >/dev/null 2>&1; then
+		deploy_error "this substrate defines no substrate_service_alive hook — whether the daemon survived is UNKNOWN. Check it by hand before walking away."
+		return 0
+	fi
+
+	if substrate_service_alive; then
+		deploy_error "the daemon is still RUNNING — it is up but not answering a healthy /healthz. Production is serving; read the answer above before touching anything."
+	else
+		deploy_error "the daemon is GONE — PRODUCTION IS DOWN. The healthcheck failure above is the symptom; this is the emergency."
+		printf '[deploy]   nothing was restarted — that is your call, not the deploy'"'"'s. Bring it back with: %s\n' "${DEPLOY_RESTART_HINT}" >&2
+	fi
 }
 
 # ---- seed (versioned built-in data) ---------------------------------

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -290,6 +290,19 @@ substrate_restart() {
 
 substrate_healthcheck() {
 	# Probe /healthz from INSIDE the container so the check is independent of
-	# host port binding.
-	"${DOCKER_COMPOSE[@]}" exec -T grappa curl -fsS -o /dev/null http://localhost:4000/healthz
+	# host port binding. On a red probe re-ask WITHOUT `-f` so the 503 body
+	# (which names the failing check) reaches the loop instead of /dev/null —
+	# see #1656 and the hook contract in infra/lib/deploy_common.sh.
+	"${DOCKER_COMPOSE[@]}" exec -T grappa curl -fsS -o /dev/null http://localhost:4000/healthz && return 0
+	"${DOCKER_COMPOSE[@]}" exec -T grappa curl -sS http://localhost:4000/healthz 2>&1
+	return 1
+}
+
+substrate_service_alive() {
+	# `compose ps -q` names the container whether or not it runs, so ask docker
+	# for the actual state rather than reading existence as liveness.
+	local cid
+	cid="$("${DOCKER_COMPOSE[@]}" ps -q grappa 2>/dev/null | head -1)"
+	[ -n "$cid" ] || return 1
+	[ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null)" = "true" ]
 }

--- a/infra/linux/deploy.sh
+++ b/infra/linux/deploy.sh
@@ -46,6 +46,7 @@ DEPLOY_FEATURE_REEXEC=1
 DEPLOY_FEATURE_MARKER=1
 DEPLOY_FEATURE_PREV_SHA_CARRY=1
 DEPLOY_SEED_RETRY_HINT="sudo -u ${GRAPPA_USER} -H bash -c \"cd ${REPO_ROOT} && set -a; . ${ENV_FILE}; set +a; MIX_ENV=prod mix grappa.seed_themes\""
+DEPLOY_RESTART_HINT="sudo systemctl start grappa"
 
 run_as_grappa() {
 	sudo -u "${GRAPPA_USER}" -H bash -c "
@@ -173,7 +174,16 @@ substrate_restart() {
 }
 
 substrate_healthcheck() {
-	curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/healthz"
+	# On a red probe re-ask WITHOUT `-f` so the 503 body (which names the
+	# failing check) reaches the loop instead of /dev/null — see #1656 and the
+	# hook contract in infra/lib/deploy_common.sh.
+	curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/healthz" && return 0
+	curl -sS "http://127.0.0.1:${PORT}/healthz" 2>&1
+	return 1
+}
+
+substrate_service_alive() {
+	systemctl is-active --quiet grappa
 }
 
 substrate_done_banner() {

--- a/scripts/deploy-m42.sh
+++ b/scripts/deploy-m42.sh
@@ -118,7 +118,28 @@ if [ "$full_restart" -eq 1 ]; then
     sleep "$FULL_RESTART_HC_SLEEP"
   done
   if [ "$hc_ok" -ne 1 ]; then
-    die "healthcheck never returned 200 after $((FULL_RESTART_HC_RETRIES * FULL_RESTART_HC_SLEEP))s — jail may be unhealthy; marker NOT written, fix and rerun"
+    # "The healthcheck failed" and "production is DOWN" are different
+    # emergencies, and this arm used to print one sentence for both (#1656 —
+    # the v1.3.0 cold deploy exited on the healthcheck budget while the node
+    # had already terminated). Same policy as the in-jail loop in
+    # infra/lib/deploy_common.sh; the mechanism differs because this door only
+    # reaches the jail over ssh, so it cannot share that hook.
+    echo "deploy-m42: ERROR: healthcheck never returned 200 after $((FULL_RESTART_HC_RETRIES * FULL_RESTART_HC_SLEEP))s — marker NOT written" >&2
+
+    # The probe above runs `curl -fsS`, and `-f` discards the body. /healthz
+    # answers a non-200 with a body naming the failing check — ask once more
+    # WITHOUT `-f` so that answer reaches the operator instead of /dev/null.
+    echo "deploy-m42: last /healthz answer:" >&2
+    # shellcheck disable=SC2029  # intentional client-side expansion of vars
+    ssh "$M42_HOST" "sudo bastille cmd ${JAIL} curl -sS ${FULL_RESTART_HC_URL}" >&2 || true
+    echo >&2
+
+    # shellcheck disable=SC2029  # intentional client-side expansion of vars
+    if ssh "$M42_HOST" "sudo bastille cmd ${JAIL} service grappa status" >/dev/null 2>&1; then
+      die "the daemon is still RUNNING — up but not answering a healthy /healthz. The jail is serving; read the answer above before touching it, then fix and rerun"
+    fi
+    echo "deploy-m42: nothing was restarted — that is your call, not the deploy's." >&2
+    die "the daemon is GONE — PRODUCTION IS DOWN. Bring it back with: ssh ${M42_HOST} sudo bastille cmd ${JAIL} service grappa start"
   fi
 
   # Write the marker INSIDE the jail (deploy.sh reads it as the

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,6 +41,7 @@ DEPLOY_FEATURE_REEXEC=1
 DEPLOY_FEATURE_MARKER=1
 DEPLOY_FEATURE_PREV_SHA_CARRY=1
 DEPLOY_SEED_RETRY_HINT="scripts/mix.sh grappa.seed_themes"
+DEPLOY_RESTART_HINT="scripts/deploy.sh --force-cold"
 
 # ---- substrate hooks ------------------------------------------------
 # ONE hook set for this substrate, shared with `infra/docker/deploy.sh

--- a/test/infra/deploy_docker_release_image_test.bats
+++ b/test/infra/deploy_docker_release_image_test.bats
@@ -53,6 +53,22 @@ printf 'docker %s\n' "$*" >> "$ARGV_LOG"
 case "$1" in
   inspect)
     [ -n "${FAKE_CONTAINER_EXISTS:-}" ] || exit 1
+    # #1656 — liveness asks for the STATE, not for existence.
+    case "$*" in
+      *"{{.State.Running}}"*) printf '%s' "${FAKE_CONTAINER_RUNNING:-true}" ;;
+    esac
+    exit 0 ;;
+  exec)
+    # #1656 — /healthz, modelled as real curl: `-f` discards the body and
+    # exits non-zero on a non-2xx; without it curl exits 0 and PRINTS it.
+    case "$*" in
+      *healthz*)
+        case "$*" in
+          *"curl -fsS"*) [ "${HEALTHZ_STATUS:-200}" = 200 ] || exit 22 ;;
+          *)             printf '%s' "${HEALTHZ_BODY:-}" ;;
+        esac
+        ;;
+    esac
     exit 0 ;;
 esac
 exit 0
@@ -300,4 +316,32 @@ EOF
     run "$DEPLOY"
     [ "$status" -eq 0 ]
     grep -q "pull ghcr.io/vjt/grappa:latest" "$ARGV_LOG"
+}
+
+# --- #1656: the release-image arm defines its OWN hook set, so it needs its
+# own proof that the failed-healthcheck arm tells the truth.
+
+@test "#1656 update: healthcheck red + container gone shouts PRODUCTION IS DOWN" {
+    seed_env_file
+    export FAKE_CONTAINER_EXISTS=1 FAKE_CONTAINER_RUNNING=false
+    # this arm's cold budget is 120x2s — a red probe would burn four minutes
+    export HEALTHZ_STATUS=503 COLD_HEALTHCHECK_RETRIES=2 COLD_HEALTHCHECK_SLEEP=0
+    export HEALTHZ_BODY='{"status":"fail","checks":[{"name":"repo","reason":"Repo.query failed"}]}'
+
+    run "$DEPLOY" update
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Repo.query failed"* ]]
+    [[ "$output" == *"PRODUCTION IS DOWN"* ]]
+}
+
+@test "#1656 update: healthcheck red + container running says it is still RUNNING" {
+    seed_env_file
+    export FAKE_CONTAINER_EXISTS=1 FAKE_CONTAINER_RUNNING=true
+    # this arm's cold budget is 120x2s — a red probe would burn four minutes
+    export HEALTHZ_STATUS=503 COLD_HEALTHCHECK_RETRIES=2 COLD_HEALTHCHECK_SLEEP=0
+
+    run "$DEPLOY" update
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"still RUNNING"* ]]
+    refute grep -q "PRODUCTION IS DOWN" <<<"$output"
 }

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -134,6 +134,19 @@ case "$*" in
             printf '{"loaded":[],"failed":[]}'
         fi
         ;;
+    # #1656 — /healthz, modelled as real curl behaves: `-f` discards the body
+    # and exits non-zero on a non-2xx; without `-f` it exits 0 and PRINTS it.
+    *"exec -T grappa curl"*healthz*)
+        # NB: `*-f*` would also match compose's own `-f <file>`, so key on the
+        # curl flags themselves.
+        case "$*" in
+            *"curl -fsS"*) [ "${HEALTHZ_STATUS:-200}" = 200 ] || exit 22 ;;
+            *)             printf '%s' "${HEALTHZ_BODY:-}" ;;
+        esac
+        ;;
+    # #1656 — container liveness. Existence is not liveness, so the stub
+    # answers the state knob rather than the id.
+    "inspect -f {{.State.Running}} "*) printf '%s' "${CONTAINER_RUNNING:-true}" ;;
 esac
 exit 0
 EOF
@@ -453,4 +466,34 @@ seed_mix_env() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"GRAPPA_CACHE_ID"* ]]
+}
+
+# --- #1656: the failed-healthcheck arm is the shared lib's, so the compose
+# substrate inherits it — but only if this consumer actually wires the hook.
+
+@test "#1656: healthcheck red + container gone shouts PRODUCTION IS DOWN" {
+    export HEALTHZ_STATUS=503 CONTAINER_RUNNING=false
+    # the cold budget is 120x2s by default — a red probe would burn 4 minutes
+    export COLD_HEALTHCHECK_RETRIES=2 COLD_HEALTHCHECK_SLEEP=0
+    export HEALTHZ_BODY='{"status":"fail","checks":[{"name":"ets","reason":"ETS table missing"}]}'
+    make_env
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ETS table missing"* ]]
+    [[ "$output" == *"PRODUCTION IS DOWN"* ]]
+}
+
+@test "#1656: healthcheck red + container running reports it is still RUNNING" {
+    export HEALTHZ_STATUS=503 CONTAINER_RUNNING=true
+    # the cold budget is 120x2s by default — a red probe would burn 4 minutes
+    export COLD_HEALTHCHECK_RETRIES=2 COLD_HEALTHCHECK_SLEEP=0
+    make_env
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"still RUNNING"* ]]
+    refute grep -q "PRODUCTION IS DOWN" <<<"$output"
 }

--- a/test/infra/deploy_jail_test.bats
+++ b/test/infra/deploy_jail_test.bats
@@ -115,19 +115,39 @@ esac
 exit 0
 EOF
 
-    # curl: reload POST answers a clean reload; healthcheck answers 200.
+    # curl: reload POST answers a clean reload; healthcheck answers
+    # $HEALTHZ_STATUS (200 by default).
+    #
+    # #1656: the /healthz probe is modelled as REAL curl behaves, because the
+    # whole point of the fix is which invocation keeps the body. `-f` discards
+    # the response body and exits 22 on a non-2xx; the same URL without `-f`
+    # exits 0 and PRINTS the body. A stub that failed both ways would let a
+    # cure that never re-asks pass.
     cat > "$FAKE_DIR/curl" <<'EOF'
 #!/bin/sh
 printf 'curl %s\n' "$*" >> "$ARGV_LOG"
 case "$*" in
-    *"-X POST"*reload*) printf '{"loaded":[],"failed":[]}' ;;
+    *"-X POST"*reload*) printf '{"loaded":[],"failed":[]}'; exit 0 ;;
+esac
+case "$*" in
+    *-f*)
+        [ "${HEALTHZ_STATUS:-200}" = 200 ] || exit 22
+        ;;
+    *)
+        printf '%s' "${HEALTHZ_BODY:-}"
+        ;;
 esac
 exit 0
 EOF
 
+    # service: every verb succeeds except `status`, which answers
+    # $SERVICE_STATUS_RC (0 = running, like rc.subr's status_cmd).
     cat > "$FAKE_DIR/service" <<'EOF'
 #!/bin/sh
 printf 'service %s\n' "$*" >> "$ARGV_LOG"
+case "$*" in
+    *status*) exit "${SERVICE_STATUS_RC:-0}" ;;
+esac
 exit 0
 EOF
 
@@ -525,4 +545,103 @@ EOF
     # mutation until the second refute was added.
     refute grep -q "NOT materialised" <<<"$output"
     refute grep -q "reminder:" <<<"$output"
+}
+
+# --- #1656: a failed healthcheck must not hide a dead node -------------------
+#
+# The 2026-08-21 v1.3.0 cold deploy exhausted the healthcheck budget and exited
+# saying "healthcheck never returned 200". The fact on the ground was that the
+# BEAM was GONE and production was down. Those are different emergencies and
+# the script rendered them identical.
+#
+# The probes also HAD the diagnosis and threw it away: `/healthz` answers 503
+# with a body naming the failing check (ready/repo/ets), and `curl -f` discards
+# a non-2xx body.
+
+@test "#1656: a failed healthcheck reports the last /healthz answer" {
+    export HEALTHZ_STATUS=503
+    export HEALTHZ_BODY='{"status":"fail","checks":[{"name":"repo","reason":"Repo.query failed: database is locked"}]}'
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"never returned 200"* ]]
+    [[ "$output" == *"database is locked"* ]]
+}
+
+@test "#1656: healthcheck red + daemon alive reports the daemon is still RUNNING" {
+    export HEALTHZ_STATUS=503 SERVICE_STATUS_RC=0
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"still RUNNING"* ]]
+    refute grep -q "PRODUCTION IS DOWN" <<<"$output"
+}
+
+@test "#1656: healthcheck red + daemon gone shouts that production is DOWN" {
+    export HEALTHZ_STATUS=503 SERVICE_STATUS_RC=1
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"PRODUCTION IS DOWN"* ]]
+    refute grep -q "still RUNNING" <<<"$output"
+}
+
+@test "#1656: the failure arm asks the service manager, it does not infer" {
+    export HEALTHZ_STATUS=503 SERVICE_STATUS_RC=1
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    grep -q "service grappa status" "$ARGV_LOG"
+}
+
+@test "#1656: a dead daemon is NOT restarted by the deploy — that is a decision" {
+    export HEALTHZ_STATUS=503 SERVICE_STATUS_RC=1
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    # Exactly one `service grappa start`: the cold path's own. A second one
+    # would mean the failure arm took the operator's decision for them.
+    [ "$(grep -c 'service grappa start' "$ARGV_LOG")" -eq 1 ]
+}
+
+@test "#1656: the HOT path inherits the same liveness report" {
+    # The loop is shared. If the report lived in the cold hook instead of the
+    # loop, a hot deploy would keep telling the old half-truth.
+    export HEALTHZ_STATUS=503 SERVICE_STATUS_RC=1
+    export PREFLIGHT_RC=0
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-hot
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"PRODUCTION IS DOWN"* ]]
+}
+
+@test "#1656: a healthy deploy says nothing about liveness" {
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 0 ]
+    refute grep -q "PRODUCTION IS DOWN" <<<"$output"
+    refute grep -q "still RUNNING" <<<"$output"
+}
+
+@test "#1656: a consumer with no liveness hook reports UNKNOWN, never DOWN" {
+    # infra/docker/get.sh mirrors the lib and the consumer as separate files,
+    # so new-lib/old-consumer is reachable on an operator's box. An undefined
+    # function returns 127, and reading that as "dead" would fire the loudest
+    # alarm we own on no evidence at all.
+    run bash -c '
+        set -eu
+        . "'"$BATS_TEST_DIRNAME"'/../../infra/lib/deploy_common.sh"
+        _deploy_report_liveness
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"UNKNOWN"* ]]
+    refute grep -q "PRODUCTION IS DOWN" <<<"$output"
+    refute grep -q "still RUNNING" <<<"$output"
 }

--- a/test/infra/deploy_linux_test.bats
+++ b/test/infra/deploy_linux_test.bats
@@ -153,12 +153,26 @@ case "$*" in
         fi
         ;;
 esac
+# #1656 — the /healthz probe, modelled as real curl behaves: `-f` discards the
+# body and exits non-zero on a non-2xx, the same URL without `-f` exits 0 and
+# PRINTS it.
+case "$*" in
+    *-f*)
+        [ "${HEALTHZ_STATUS:-200}" = 200 ] || exit 22
+        ;;
+    *healthz*)
+        printf '%s' "${HEALTHZ_BODY:-}"
+        ;;
+esac
 exit 0
 EOF
 
     cat > "$FAKE_DIR/systemctl" <<'EOF'
 #!/bin/sh
 printf 'systemctl %s\n' "$*" >> "$ARGV_LOG"
+case "$*" in
+    *is-active*) exit "${SYSTEMCTL_ACTIVE_RC:-0}" ;;
+esac
 exit 0
 EOF
 
@@ -505,4 +519,30 @@ run_deploy() {
     # mutation until the second refute was added.
     refute grep -q "NOT materialised" <<<"$output"
     refute grep -q "reminder:" <<<"$output"
+}
+
+# --- #1656: the failed-healthcheck arm is the shared lib's, so systemd
+# inherits it — but only if this substrate actually wires the hook.
+
+@test "#1656: healthcheck red + unit dead shouts PRODUCTION IS DOWN and names the restart" {
+    export HEALTHZ_STATUS=503 SYSTEMCTL_ACTIVE_RC=3
+    export HEALTHZ_BODY='{"status":"fail","checks":[{"name":"repo","reason":"Repo.query failed"}]}'
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Repo.query failed"* ]]
+    [[ "$output" == *"PRODUCTION IS DOWN"* ]]
+    [[ "$output" == *"systemctl start grappa"* ]]
+    grep -q "systemctl is-active" "$ARGV_LOG"
+}
+
+@test "#1656: healthcheck red + unit active reports the daemon is still RUNNING" {
+    export HEALTHZ_STATUS=503 SYSTEMCTL_ACTIVE_RC=0
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy --force-cold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"still RUNNING"* ]]
+    refute grep -q "PRODUCTION IS DOWN" <<<"$output"
 }

--- a/test/infra/deploy_m42_test.bats
+++ b/test/infra/deploy_m42_test.bats
@@ -32,7 +32,11 @@ setup() {
 #!/bin/sh
 printf 'ssh %s\n' "$*" >> "$SSH_LOG"
 case "$*" in
-    *curl*healthz*) exit "${HEALTH_RC:-0}" ;;
+    # #1656 — `-fsS` is the PROBE (body discarded, non-zero on non-2xx); the
+    # same URL without it is the diagnostic re-ask that PRINTS the body.
+    *"curl -fsS"*healthz*) exit "${HEALTH_RC:-0}" ;;
+    *curl*healthz*)        printf '%s' "${HEALTHZ_BODY:-}"; exit 0 ;;
+    *"service grappa status"*) exit "${SERVICE_STATUS_RC:-0}" ;;
     *) exit 0 ;;
 esac
 EOF
@@ -148,4 +152,39 @@ EOF
 @test "unknown flag is a usage error (64)" {
     run_m42 --bogus
     [ "$status" -eq 64 ]
+}
+
+# --- #1656: the host-side --full-restart loop told the same half-truth -------
+
+@test "#1656 --full-restart: a failed healthcheck reports what /healthz said" {
+    export HEALTH_RC=1
+    export HEALTHZ_BODY='{"status":"fail","checks":[{"name":"ready","reason":"supervision tree boot not complete"}]}'
+    run_m42 --full-restart
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"supervision tree boot not complete"* ]]
+}
+
+@test "#1656 --full-restart: healthcheck red + daemon gone shouts PRODUCTION IS DOWN" {
+    export HEALTH_RC=1 SERVICE_STATUS_RC=1
+    run_m42 --full-restart
+    [ "$status" -ne 0 ]
+    grep -q "service grappa status" "$SSH_LOG"
+    [[ "$output" == *"PRODUCTION IS DOWN"* ]]
+    refute grep -q "last-deployed-sha" "$SSH_LOG"
+}
+
+@test "#1656 --full-restart: healthcheck red + daemon alive says it is still RUNNING" {
+    export HEALTH_RC=1 SERVICE_STATUS_RC=0
+    run_m42 --full-restart
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"still RUNNING"* ]]
+    refute grep -q "PRODUCTION IS DOWN" <<<"$output"
+}
+
+@test "#1656 --full-restart: a dead jail is never restarted for you" {
+    export HEALTH_RC=1 SERVICE_STATUS_RC=1
+    run_m42 --full-restart
+    [ "$status" -ne 0 ]
+    refute grep -q "service grappa start" "$SSH_LOG"
+    refute grep -q "bastille start" "$SSH_LOG"
 }

--- a/test/infra/run_erl_log_retention_test.bats
+++ b/test/infra/run_erl_log_retention_test.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+#
+# Bats suite for #1656 — the FreeBSD jail's run_erl log ring must outlive an
+# incident.
+#
+# run_erl(1) keeps the node's stdout/stderr in a CIRCULAR set of
+# `RUN_ERL_LOG_GENERATIONS` files of `RUN_ERL_LOG_MAXSIZE` bytes each, and the
+# stock ring is 5 x 100 KB = 500 KB. On this substrate that ring is the ONLY
+# history the BEAM leaves behind: there is no journald, no docker logs.
+#
+# MEASURED on the jail 2026-08-22: the four surviving `erlang.log.*` spanned
+# 22:52 -> 00:32 — one hundred minutes, with the generation in between already
+# overwritten. Two separate incidents lost their evidence to that ring in a
+# single night (#1656, #1657) and both were filed cause-unknown as a result.
+#
+# The variable NAMES are not folklore: they were read out of the shipped
+# run_erl binary (`strings .../erts-16.4.0.5/bin/run_erl | grep ^RUN_ERL`),
+# which lists RUN_ERL_LOG_GENERATIONS and RUN_ERL_LOG_MAXSIZE among others.
+#
+# Every assertion here is about the CEILING the ring buys, never about the
+# literal numbers — an operator is free to tune them in /etc/rc.conf.d/grappa,
+# and a future edit is free to pick different ones, as long as the ring still
+# survives the night that #1656 did not.
+
+load ../bats_helpers
+
+REPO_SRC="$BATS_TEST_DIRNAME/../.."
+RCD="$REPO_SRC/infra/freebsd/rc.d/grappa"
+
+# run_erl(1)'s own defaults — the bar the pin has to clear to mean anything.
+STOCK_GENERATIONS=5
+STOCK_MAXSIZE=100000
+
+# ~240 KB/h, from the measurement in the header (400 KB over 100 minutes).
+MEASURED_BYTES_PER_HOUR=245760
+
+# Echo the rc.conf-overridable default assigned to $1, e.g.
+#   : ${grappa_log_generations:="20"}   ->   20
+rcd_default() {
+    sed -n "s/^: \${$1:=\"\([0-9]*\)\"}.*/\1/p" "$RCD"
+}
+
+
+# Shipped service definitions (same SET as service_locale_pin_test.bats) that
+# INVOKE the `daemon` subcommand. Comment lines are stripped first: three of
+# these files discuss `daemon(8)` or run_erl in prose, and prose is not a spawn.
+daemon_spawning_definitions() {
+    local rel
+    git -C "$REPO_SRC" ls-files -- infra | while IFS= read -r rel; do
+        case "$rel" in
+            *.service | */rc.d/*) ;;
+            *) continue ;;
+        esac
+        grep -v '^[[:space:]]*#' "$REPO_SRC/$rel" | grep -q 'daemon' || continue
+        printf '%s\n' "$rel"
+    done
+}
+
+@test "the rc.d exports both run_erl retention variables into the release" {
+    grep -q 'export RUN_ERL_LOG_GENERATIONS=' "$RCD"
+    grep -q 'export RUN_ERL_LOG_MAXSIZE=' "$RCD"
+}
+
+@test "both retention variables are rc.conf-overridable, not hardcoded" {
+    # The rc.subr idiom is what lets an operator retune a jail without
+    # patching a tracked file. A literal baked into the `su` line would be a
+    # pin nobody on the box can move.
+    [ -n "$(rcd_default grappa_log_generations)" ]
+    [ -n "$(rcd_default grappa_log_maxsize)" ]
+    grep -q 'export RUN_ERL_LOG_GENERATIONS=.\${grappa_log_generations}' "$RCD"
+    grep -q 'export RUN_ERL_LOG_MAXSIZE=.\${grappa_log_maxsize}' "$RCD"
+}
+
+@test "the ring is bigger than the stock one on BOTH axes" {
+    # Either axis left at stock silently halves (or worse) the retention the
+    # other one buys, and the product assertion below would still pass on a
+    # 1-generation ring of one enormous file — which loses the OLDEST evidence
+    # first, the opposite of what an incident needs.
+    [ "$(rcd_default grappa_log_generations)" -gt "$STOCK_GENERATIONS" ]
+    [ "$(rcd_default grappa_log_maxsize)" -gt "$STOCK_MAXSIZE" ]
+}
+
+@test "the ring holds at least 24h of logs at the measured rate" {
+    # The property that matters, stated as the incident states it: an operator
+    # who reads the log the morning after must still find the night in it. The
+    # stock 500 KB ring buys about two hours and is what lost #1656 and #1657.
+    total=$(( $(rcd_default grappa_log_generations) * $(rcd_default grappa_log_maxsize) ))
+    [ "$total" -ge $(( MEASURED_BYTES_PER_HOUR * 24 )) ]
+}
+
+@test "the jail rc.d is the only shipped service definition that spawns run_erl" {
+    # systemd and both container images run `bin/grappa start` in the
+    # FOREGROUND, so their logs go to journald / docker and no run_erl ring
+    # exists to size. A future substrate that adopts `daemon` inherits the
+    # 500 KB ring silently — this is the case that will notice.
+    run daemon_spawning_definitions
+    [ "$status" -eq 0 ]
+    [ "$output" = "infra/freebsd/rc.d/grappa" ]
+}


### PR DESCRIPTION
## What this is

#1656: the v1.3.0 cold deploy on m42 ended with production down while the
script's last word was `healthcheck never returned 200 after 60s`.

The cause of the node's death is **still unknown, deliberately**. What is
established is the SHAPE of that death, plus three defects that stand on
their own without it.

## F1 — measured, not argued

Four ways of killing this release, one fresh boot each, on a real
`mix release` (`scripts/release-image.sh`, ERTS 16.4.0.5,
`start_permanent: Mix.env() == :prod`):

| death | log line | node | crash dump |
|---|---|---|---|
| `bin/grappa stop` | **nothing at all** | dies, exit 0 | no |
| `SIGTERM` | `[notice] SIGTERM received - shutting down` | dies, exit 0 | no |
| top supervisor gives up | `[notice] Application grappa exited: shutdown` + `Kernel pid terminated (application_controller)` | dies, exit 1 | **yes** |
| `Application.stop(:grappa)` | `Application grappa exited: :stopped` | **stays up** | no |

The incident's line matches the third row and only the third row, down to
`shutdown` rendering bare where an `Application.stop` renders `:stopped`.
**Nobody stopped that node** — not an operator stop (silent), not a signal
(which announces itself). Its own top supervisor gave up, and a release's
application is `:permanent`, so that takes the runtime with it.

`Grappa.Supervisor` carries no `max_restarts`, so it inherits **3 in 5s**,
against `SessionSupervisor`'s explicit `10_000/60`.

The issue's causal order is also inverted by its own evidence: teardown
stops children in reverse, so the Endpoint dies before the sessions finish
draining — `503`-then-`Connection refused` inside the loop means the
teardown began BEFORE the script exited, and `21:24:37` is the end of a
long drain, not the moment of death.

## What is NOT claimed

- **The cause.** F1 gives the shape, not which child failed or why.
- **The crash dump.** Row three writes one (into the BEAM's CWD — measured
  `/app` in the image, the release root on the jail) and `ERL_CRASH_DUMP*`
  is set nowhere in this repo, so dumping is on. The issue reports none.
  Either it landed where nobody looked, or the mechanism is a fifth one.
- **Why `/healthz` answered 503 while the box served users.** Inference
  from code (`mark_ready/0` runs the moment `start_link` returns, and
  `Bootstrap` is a `Task` that returns immediately, so a live session
  implies `ready?` was true — leaving `repo`/`ets` as the only 503 left).
  Not evidence: that run's logs had rotated away.
- Nothing was run against production, and nothing here restarts anything.

## The three cures

**1. The failure arm names the emergency.** New `substrate_service_alive`
hook (correctness posture: default ON, no fallback, like the #440 seed).
Three states: daemon **still RUNNING**, daemon **GONE / PRODUCTION IS
DOWN**, or **UNKNOWN** — the third because an undefined shell function
returns 127 and reading that as "dead" would fire the loudest alarm we own
on no evidence (reachable: `get.sh` mirrors lib and consumer separately).
It reports, never acts.

**2. The 503 body stops going to `/dev/null`.** `/healthz` names the
failing check (`ready`/`repo`/`ets`) in the body, and `curl -f` is both
what makes a non-2xx an error and what discards it. All five `deploy_main`
consumers now re-ask without `-f` on a red probe only.

**3. The jail's run_erl ring holds a week, not an hour.** Stock 5×100 KB
measured out at ~100 minutes and cost **two incidents their evidence in one
night** (#1656 and #1657). Now 20 × 2 MB — a 40 MB hard ceiling, still
circular, rc.conf-overridable. Variable names read out of the shipped
binary. **Deploy class: COLD** (run_erl reads them when it spawns, and the
wrapper ships via `jail_install_rcd.sh`, cold path only).

## Gates

- `scripts/bats.sh` full suite: **657/657, zero red** on the shipping tree.
- `scripts/posix-parse.sh` (31 sh-dialect scripts) and `scripts/shellcheck.sh`
  (80 scripts): both rc=0.
- `scripts/design-notes-gate.sh`: green.
- No Elixir touched, so no `scripts/check.sh`.
- Every new oracle proven by MUTATION (mutants applied then withdrawn):
  reverting each probe to `-o /dev/null` kills the body case; forcing
  liveness to always-alive / always-dead kills the matching case; removing
  the hook-absent guard kills the UNKNOWN case; dropping the run_erl exports
  or leaving either axis at stock kills the retention cases.