### PR TITLE
#1657b: the census over-reported, and which wait actually ends a contended write

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57562,9 +57562,23 @@ its private repo with `busy_timeout: 30_000` and says in a comment that the
 number is generous *"on purpose: the waiter must still be WAITING when the
 scan runs"*. Neither writer passes `:timeout`, so both inherit Ecto's
 default 15_000, which DBConnection arms as a checkout deadline over the
-WHOLE transaction — queue, statements, and the holder's park alike. The
-wait that file believed it had configured was `min(15_000, 30_000)`, and
-the number that actually governs was written down nowhere.
+WHOLE transaction — queue, statements, and the holder's park alike.
+
+🔴 **The bench declared 30 000 on purpose and got 15 000.** That sentence is
+the whole defect. The wait it believed it had configured was
+`min(15_000, 30_000)`, the smaller number came from a library default nobody
+wrote down, and no line in the file names it — so the red, when it finally
+came, pointed at an assertion instead of at the number that broke it.
+
+The route to this was itself instructive and is worth keeping. The first
+hypothesis was interference: a NEW test that also builds a real lock
+contention, running alongside the old one. It is false BY CONSTRUCTION —
+both modules are `async: false`, and ExUnit runs sync modules one at a time
+after the async ones are exhausted, so the two contentions cannot overlap.
+Checking the structural claim before believing the plausible one is what
+turned a suspicion about this branch into a defect that was already there.
+Proving it by mutating **main** rather than the branch is what established
+the second half: latent, not introduced.
 
 Measured on `29bea21d` (origin/main, none of this branch's code present) by
 injecting a 16s delay between the waiter's `BEGIN IMMEDIATE` and the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57427,3 +57427,149 @@ authoritative backup and it cannot collide with itself; and
 `git status --porcelain` after each restore names any file the mutant
 never touched, which is the cheap check that would have caught this on
 the first round instead of the second.
+<!-- entry #1657b -->
+
+---
+
+## 2026-08-22 — #1657b: the instrument that over-reported, and which wait actually ends a contended write
+
+#1657 landed the night before and this is a review of it, not of a diff.
+Two of the three findings below are corrections to that landed work, and
+one of them is a defect it introduced the coverage for.
+
+### The census over-reported, and that is worse than the floor it fixed
+
+#1657's whole argument was that `scrollback row dropped` had been a
+count taken from two of five doors, so "ten rows lost" was a FLOOR by
+construction. It moved the line to the one door every persist passes
+through. It did not check the opposite direction.
+
+`Scrollback.persist_row/1` ran TWO retry-wrapped ops: the insert, then
+`Repo.preload(message, :network)`. A failure of the SECOND returned the
+same `:persist_unavailable` as a row that never landed, so `Persistor`
+logged the drop for a row sitting durably in the table. The code knew —
+the comment read *"the row IS durably written [...] the live broadcast
+is what's lost"* — and returned the drop atom anyway.
+
+**So the corrected reading of #1657's own note is that the count was
+neither a floor nor a ceiling.** A floor is still a usable number; a
+figure that can err in EITHER direction, with nothing on the line saying
+which arm produced it, is not. An instrument that lies in our favour
+("we lost more than we did") is exactly as dangerous as one that lies
+against us, and this is the same class #1657 spent its night removing.
+
+### Cured at the root: the write path had a round-trip it did not need
+
+The preload existed to fetch ONE value for the wire payload — the
+network slug. The only production caller already holds it:
+`Session.Persistor` uses `ctx.network_slug` on the adjacent line to
+build the broadcast topic. So the hot write path was spending a second
+pool checkout, with its own DBConnection deadline, on the path that
+loses rows under saturation, to re-derive a value in the caller's hand.
+
+`Wire.to_json/2` and `message_payload/2` now take the slug;
+`to_json/1` remains as the READ-path entrance, deriving it from the
+assoc a fetch already preloaded, and delegating to the same body. Which
+door a caller uses follows from what it holds: a render function handed
+nothing but rows has no slug, a broadcast always does. There is
+deliberately no `message_payload/1`.
+
+Two consequences beyond the honesty fix: one pool checkout per persisted
+row instead of two, and `:persist_unavailable` at that door now has
+exactly one meaning. Pinned in both directions by
+`Grappa.Session.PersistorTest` — a durable row must produce no census
+line, a lost row must produce one — because the lazy way to green the
+first is to delete the line. Oracle proven by mutation: restoring the
+preload turns the first test red and nothing else.
+
+Declined as too wide for this branch: the four READ-path
+`preload(:network)` sites (`scrollback.ex` 435/513/868/876). Same
+"derive what you already have" shape, different callers, and they are
+separate queries rather than a second op behind a committed row.
+
+### Which wait ends a contended write — the prediction was refuted
+
+The analysis that opened this branch predicted that DBConnection's
+checkout deadline (15_000ms, Ecto's default, overridden nowhere) always
+cuts a lock wait before `busy_timeout` (30_000ms) can expire, and that
+the caller therefore sees `:interrupted`. Half right, and the wrong half
+is the useful one.
+
+`Grappa.Repo.CheckoutDeadlineReachTest` varies ONE thing — which of the
+two numbers is smaller — against a real held write lock, ratio preserved
+and magnitudes scaled (300 : 600), classified by production's own
+`BusyRetry.classify/1`. The pool DOES cut the wait: it logs the checkout
+timeout and disconnects the holder. But the class is `:busy_locked` in
+BOTH orderings, 12/12 samples each. exqlite installs a custom busy
+handler that polls `conn->cancelled` and **returns 0** on cancellation
+(`c_src/sqlite3_nif.c`), and a busy handler returning 0 makes SQLite
+give up with SQLITE_BUSY rather than SQLITE_INTERRUPT.
+
+**A write cancelled while WAITING for the lock is indistinguishable, by
+fault kind, from one that exhausted `busy_timeout`. Only the clock
+separates them.** `observed_state(:busy_locked)` — "SQLite write lock
+held by another writer" — stays honest under both, so no census phrase
+moved and `scripts/log-gap-scan.awk` is untouched.
+
+This re-prices #1421's option table. Its lock row reads *"up to
+`busy_timeout` = 30_000ms"*; the real latency is
+`min(busy_timeout, checkout deadline)`, i.e. 15_000 in production, so
+the ratio against the 1_500 budget is 10 and not 20. #1421's CONCLUSION
+is unchanged — the loop still collapses to one attempt — but three of
+its four priced options are argued against a number that never governs a
+lock-contended write. Reported up rather than edited there: #1421 is not
+this branch's to cure.
+
+It also names the discriminator. `:interrupted` is not the lock-wait
+verdict at all — it is what a cancellation yields when the statement is
+EXECUTING rather than queued behind the lock. That is exactly why
+#1657's `Bootstrap` casualty was an interrupt on a READ
+(`Visitors.list_active/0`): a read never enters the busy handler.
+
+### 🔴 A gap found by that measurement, named and not fixed
+
+The executing-statement case is BIMODAL. Over 63 samples across two
+statement shapes, a cancelled statement raised
+`%Exqlite.Error{message: "interrupted"}` ~57% of the time and
+`%Exqlite.Error{message: "out of memory"}` ~43% — and `classify/1` calls
+the latter `:permanent`, so `BusyRetry` RE-RAISES it. That is precisely
+the failure mode #1657 exists to remove (a 500 instead of a 503, a crash
+where nothing wraps it, a "non-transient DB error" in the log), still
+live for roughly half of its own cases, and wearing a message that tells
+the operator they ran out of memory.
+
+Not a harness artifact: the control is a streaming cross join whose
+memory is O(1) by construction, and it splits the same way a recursive
+CTE did.
+
+Not fixed here, and not asserted in the test either. The split is
+roughly even so pinning it would be flaky, and asserting that
+`:permanent` is an acceptable outcome would be asserting a bug. Widening
+the transient set to cover `"out of memory"` carries a real cost — a
+genuine SQLITE_NOMEM would then be retried and degraded to a 503 instead
+of surfacing loudly — so it is a policy call that goes up with its
+numbers, the same treatment `pool_size` got.
+
+### What is NOT claimed
+
+- **No production substrate was measured.** Both new benches run on
+  private temp repos. The prevention axis is untouched: a contended
+  insert still drops its row. What this branch removed is a loss
+  CHANNEL (a durable row whose broadcast died) and a hot-path round-trip.
+- **The C-level cause of the `"out of memory"` reading is not
+  established.** The likely mechanism is `sqlite3_errmsg` read against a
+  handle the concurrent disconnect is already tearing down, but that was
+  not confirmed in the C source, and the reading has never been seen
+  outside that test file.
+- **The #1420 contradiction is NOT resolved.** That census measured gaps
+  of exactly 30.1s (`lock_watch.ex:19-21`) — `busy_timeout` expiring in
+  full, which needs a deadline that did not fire. The mechanism
+  established here says that cannot happen while a 15_000 deadline is in
+  play, so the two readings still disagree. The disagreement is sharper,
+  not closed: it now points at WHICH POOL was in that window, since the
+  SQL Sandbox runs `DBConnection.Ownership` rather than
+  `ConnectionPool`, and #1421 records that both its windows are CI and
+  neither is m42. Left open, written as open.
+- **The 1.3.0 herd's attribution stays closed as non-establishable**
+  (#1657): the 42 stack-carrying deadline lines were overwritten by
+  `run_erl` rotation. Nothing here reopens it.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57550,8 +57550,62 @@ genuine SQLITE_NOMEM would then be retried and degraded to a 503 instead
 of surfacing loudly — so it is a policy call that goes up with its
 numbers, the same treatment `pool_size` got.
 
+### Coda: CI found the same cap had already broken a test nobody linked to it
+
+`Grappa.Repo.LockWatchTest` went red on this branch's first CI run, on an
+assertion the branch does not touch, in a file the branch does not touch.
+Its blocked writer died `%Exqlite.Error{message: "database is locked",
+statement: "BEGIN IMMEDIATE TRANSACTION"}` instead of exiting `:normal`.
+
+It is the finding above arriving from the other direction. That file starts
+its private repo with `busy_timeout: 30_000` and says in a comment that the
+number is generous *"on purpose: the waiter must still be WAITING when the
+scan runs"*. Neither writer passes `:timeout`, so both inherit Ecto's
+default 15_000, which DBConnection arms as a checkout deadline over the
+WHOLE transaction — queue, statements, and the holder's park alike. The
+wait that file believed it had configured was `min(15_000, 30_000)`, and
+the number that actually governs was written down nowhere.
+
+Measured on `29bea21d` (origin/main, none of this branch's code present) by
+injecting a 16s delay between the waiter's `BEGIN IMMEDIATE` and the
+holder's release — a slow runner, made deterministic:
+
+| bench | outcome |
+|---|---|
+| main + delay | the pool disconnects BOTH connections at 15 000ms; the waiter dies `database is locked`; the waiter-DOWN assertion fails and the holder-DOWN one passes |
+| main + delay + `timeout: :infinity` | 4 tests, 0 failures, assertions byte-identical |
+
+The holder passing while the waiter fails is the same asymmetry CI showed,
+and it is not luck: a commit on a disconnected connection RETURNS
+`{:error, :rollback}` through Ecto, while a cancelled `BEGIN IMMEDIATE`
+RAISES — because exqlite's busy handler answers the cancellation with a
+plain SQLITE_BUSY, the mechanism measured above. The deadline kills both
+writers; only one of them says so.
+
+The cure is `timeout: :infinity` on both writers. It weakens no assertion:
+it deletes an unstated fourth wait and leaves `busy_timeout` as the only
+bound, which is what the file already claimed to be doing. The bound stays
+finite — 30 000ms, under ExUnit's own per-test timeout.
+
+Scope of the class, checked rather than assumed: of the four private-repo
+benches, only this one holds the write lock inside a POOLED Ecto
+transaction and parks it for an unbounded time.
+`Grappa.Repo.BusyRetryFidelityTest` and `Grappa.Repo.BusyRetryBudgetReachTest`
+hold theirs on a RAW `Exqlite.Sqlite3` connection with a `busy_timeout` of 0
+and 3 000, and `Grappa.Repo.CheckoutDeadlineReachTest` states `:timeout`
+explicitly because that number is its independent variable. **Rule for the
+next one: a bench whose `busy_timeout` exceeds 15 000, or that parks a
+pooled transaction for an unbounded time, must state `:timeout` — otherwise
+the smaller, invisible deadline is what it is really measuring.**
+
 ### What is NOT claimed
 
+- **It is NOT established that this branch made that red more likely.**
+  Both files are `async: false`, so ExUnit never runs them concurrently,
+  and the pair reran green four times locally (7 tests each). What IS
+  established is that the defect belongs to `origin/main` and reproduces
+  with none of this branch's code present. WHY the CI runner spent more
+  than 15s inside that window was not measured.
 - **No production substrate was measured.** Both new benches run on
   private temp repos. The prevention axis is untouched: a contended
   insert still drops its row. What this branch removed is a loss

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4920,7 +4920,7 @@ mechanism is provable before any fix (Deliverable 2, deferred). Four signals,
 mapped to the three mechanisms the issue traced:
 
 - **`[:grappa, :scrollback, :persist, :start | :stop]`** — a `:telemetry.span`
-  around every `messages` insert+preload, **tagged by `channel`** (also
+  around every `messages` insert, **tagged by `channel`** (also
   `kind`, `network_id`, `subject`, and `outcome`). `:stop` `duration` is the
   **pure insert** time (mechanism 3: index write-amplification grows it as the
   table grows). Correlate a channel's `:stop` durations against its inbound
@@ -4932,8 +4932,11 @@ mapped to the three mechanisms the issue traced:
   duration` = head-of-line blocking (mechanism 1)** — the user's own send
   queued behind a busy channel's synchronous inbound inserts.
 - **`[:grappa, :scrollback, :persist, :contention]`** — fires per transient
-  SQLite write-contention fault in `with_pool_retry/3` (mechanism 2:
-  single-writer contention). Metadata `fault: :queue_timeout | :busy_locked`,
+  SQLite write-contention fault in `with_pool_retry/1` (mechanism 2:
+  single-writer contention). Metadata
+  `fault: :queue_timeout | :busy_locked | :interrupted` (`:interrupted` since
+  #1657 — the pool's checkout deadline cancelled a statement it had already
+  served, i.e. the connection was taken BACK rather than never granted),
   `dropped: false` (ridden out) / `true` (budget exhausted, row lost — the
   telemetry twin of the `scrollback persist unavailable: SQLite pool
   saturated` `Logger.warning`).

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -332,11 +332,14 @@ defmodule Grappa.Repo.BusyRetry do
     # `maybe_inject_fault/0` at the top of a `BusyRetry.run/1` attempt — NOT a
     # raw `Repo` call and NOT an operation. `fire_on: 1` fires on the VERY NEXT
     # check (channel / reaper immediate case); a higher value is how #594 pins
-    # the query-window auto-open terminal — persist + its preload each make one
-    # wrapped call BEFORE the open, so a single per-pid counter cannot otherwise
+    # the query-window auto-open terminal — the persist makes its own wrapped
+    # call BEFORE the open, so a single per-pid counter cannot otherwise
     # distinguish "fault the open" from "fault the persist". The exact `fire_on`
     # is DETERMINED EMPIRICALLY per flow (see the #594 session test); a change in
-    # how many `BusyRetry.run` calls precede the open is MEANT to break it.
+    # how many `BusyRetry.run` calls precede the open is MEANT to break it — and
+    # it has: #1657b deleted the persist's `Repo.preload` round-trip, so one
+    # check disappeared and that pin moved from `fire_on: 3` to `fire_on: 2`.
+    # The break was the contract working, not a regression.
     #
     # Callers MUST `on_exit` a `disarm_faults/1` — a fault left armed on a pid
     # that outlives the test is a failure-at-a-distance (the worst kind to

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -65,7 +65,7 @@ defmodule Grappa.Scrollback do
   @max_limit 500
 
   # #336 / #340 — SQLite is single-writer; a write burst saturates the
-  # connection pool (`Repo.insert`/`Repo.preload` RAISE
+  # connection pool (`Repo.insert` RAISES
   # `DBConnection.ConnectionError`, reason: :queue_timeout) OR, when a slow
   # writer holds the lock past `busy_timeout`, raises `%Exqlite.Error{}`
   # with a "busy"/"locked" message. Both are TRANSIENT contention, not a
@@ -91,8 +91,17 @@ defmodule Grappa.Scrollback do
 
   # Closed error set for the write path. A validation failure returns the
   # changeset (caller inspects `.errors`); a pool-saturation drop returns
-  # the bare atom (nothing to inspect — the row never reached the DB, or
-  # the insert landed but the wire-shape preload could not).
+  # the bare atom, and since #1657b that atom means EXACTLY ONE thing:
+  # the row never reached the DB.
+  #
+  # 🔴 It has to keep meaning exactly that. It used to cover a second case
+  # as well — insert landed, wire-shape preload did not — and one atom over
+  # two outcomes is what let `Persistor` log `scrollback row dropped` for a
+  # row sitting durably in the table (#1429 census, over-counting). Any
+  # retried op added AFTER the insert in `persist_row/1` re-opens the
+  # ambiguity, because both arms collapse onto this one value and no caller
+  # downstream can tell them apart. Add one and you must widen the type
+  # first, not the function.
   @type persist_error :: Ecto.Changeset.t() | :persist_unavailable
 
   # Content-bearing kinds: the ones that carry a notification meaning.
@@ -169,7 +178,7 @@ defmodule Grappa.Scrollback do
   def persist_event(%{kind: kind} = attrs) when is_atom(kind) do
     changeset = Message.changeset(%Message{}, attrs)
 
-    # #357 D1 — the insert+preload is wrapped in the `[:grappa, :scrollback,
+    # #357 D1 — the insert is wrapped in the `[:grappa, :scrollback,
     # :persist, …]` span (channel-tagged) so per-channel write latency
     # (mechanism 3) is measurable, and it is the "pure insert" half of the
     # split-span pair vs the send-path total (mechanism 1). The span returns
@@ -208,9 +217,10 @@ defmodule Grappa.Scrollback do
   # `Grappa.Session.PersistorTest`, whose two tests fail in opposite directions.
   #
   # What remains is a single op whose failure means exactly one thing: the row
-  # did not land. The `with` still carries a plain `{:error, %Changeset{}}`
-  # validation failure straight through (that op returns, never raises, so it
-  # is not retried). Kept as a named function rather than inlined to hold
+  # did not land. `with_pool_retry/1` still carries a plain
+  # `{:error, %Changeset{}}` validation failure straight through (a changeset
+  # error is RETURNED, never raised, so it is not retried). Kept as a named
+  # function rather than inlined to hold
   # `persist_event/1`'s nesting ≤ 2 (Credo).
   @spec persist_row(Ecto.Changeset.t()) :: {:ok, Message.t()} | {:error, persist_error()}
   defp persist_row(changeset) do
@@ -272,9 +282,16 @@ defmodule Grappa.Scrollback do
   rescue is the ONE place the scrollback posture diverges from a stateless
   web write, which instead lets the engine's raise surface as a 500.
 
-  Public because `persist_event/1` runs BOTH its insert and its preload
-  through it, and the retry/degrade contract is unit-tested here directly
-  (the sandbox pool cannot reproduce a real `queue_timeout`).
+  Public for two reasons, and `persist_event/1` is no longer either of them:
+  since #1657b it makes exactly ONE wrapped call, from inside this module.
+  (1) The retry/degrade contract is unit-tested here directly — the sandbox
+  pool cannot reproduce a real `queue_timeout`, so the tests hand this
+  function a raising op. (2) It is the named reference posture two siblings
+  are documented AGAINST: `Grappa.Repo.BusyRetry`'s moduledoc cites it as
+  the deliberate divergence (the engine re-raises a non-transient fault
+  where this one rescues it), and `Grappa.Notify.degrade_on_db_fault/1`
+  says it mirrors this test posture. Un-publishing it is a surface change,
+  not a comment fix, and it would take both citations with it.
   """
   @spec with_pool_retry((-> {:ok, result} | {:error, Ecto.Changeset.t()})) ::
           {:ok, result} | {:error, persist_error()}

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -131,9 +131,12 @@ defmodule Grappa.Scrollback do
   is responsible for `:server_time` (epoch ms) and `:meta` (`%{}` for
   kinds without event-specific payload).
 
-  The returned row has `:network` preloaded so callers can hand it
-  straight to `Grappa.Scrollback.Wire.message_payload/1` (which
-  pattern-matches on `%Network{slug: _}` and crashes on unloaded assoc).
+  🔴 The returned row does **NOT** have `:network` preloaded (#1657b,
+  reversing the original contract). Pass the slug you already have to
+  `Grappa.Scrollback.Wire.message_payload/2` instead — every caller of
+  this function knows its own network, and preloading here cost a
+  second pool checkout per row on the hot write path plus a failure arm
+  that reported a durable row as dropped. See `persist_row/1`.
   Single source for the wire-shape contract — every door (REST,
   PubSub, future Phase 6 listener) goes through here.
 
@@ -183,20 +186,35 @@ defmodule Grappa.Scrollback do
     end)
   end
 
-  # Insert and preload each run through `with_pool_retry/1` so a pool
-  # saturation raise on EITHER step degrades to `{:error, :persist_unavailable}`
-  # instead of escaping. The `with` also carries a plain `{:error, %Changeset{}}`
-  # validation failure straight through (that op returns, never raises, so it's
-  # not retried). On a preload-only failure the row IS durably written but has
-  # no `:network` assoc for the wire payload — degrading is correct: the row
-  # surfaces on the next `fetch/5`, the live broadcast is what's lost. Extracted
-  # from the span closure to keep `persist_event/1`'s nesting ≤ 2 (Credo).
+  # ONE retry-wrapped DB op, and the count is the point (#1657b).
+  #
+  # This used to be two: the insert, then `Repo.preload(message, :network)` so
+  # the row came back wire-shape-ready. The preload was a second SELECT, with
+  # its own pool checkout and its own DBConnection deadline, issued on the
+  # hot write path to fetch ONE value — the network slug — that the only
+  # production caller already holds (`Persistor`'s `ctx.network_slug`, which
+  # it uses on the adjacent line to build the broadcast topic). Deriving what
+  # you already have, at the cost of a round-trip, on the path that loses rows
+  # under saturation.
+  #
+  # 🔴 It also made the #1429 census LIE, and that is why it went rather than
+  # being merely optimised. A preload-only failure returned the same
+  # `:persist_unavailable` as a row that never landed, so `Persistor` logged
+  # `scrollback row dropped` for a row sitting durably in the table. The old
+  # comment here knew it — "the row IS durably written [...] the live broadcast
+  # is what's lost" — and returned the drop atom anyway. #1657 made the count
+  # stop being a floor; this arm made it not a ceiling either, which is worse,
+  # because nothing on the line said which arm produced it. Pinned by
+  # `Grappa.Session.PersistorTest`, whose two tests fail in opposite directions.
+  #
+  # What remains is a single op whose failure means exactly one thing: the row
+  # did not land. The `with` still carries a plain `{:error, %Changeset{}}`
+  # validation failure straight through (that op returns, never raises, so it
+  # is not retried). Kept as a named function rather than inlined to hold
+  # `persist_event/1`'s nesting ≤ 2 (Credo).
   @spec persist_row(Ecto.Changeset.t()) :: {:ok, Message.t()} | {:error, persist_error()}
   defp persist_row(changeset) do
-    with {:ok, message} <- with_pool_retry(fn -> Repo.insert(changeset) end),
-         {:ok, preloaded} <- with_pool_retry(fn -> {:ok, Repo.preload(message, :network)} end) do
-      {:ok, preloaded}
-    end
+    with_pool_retry(fn -> Repo.insert(changeset) end)
   end
 
   # #357 D1 — span metadata. `channel`/`network_id` via `Map.get` (nil on a

--- a/lib/grappa/scrollback/telemetry.ex
+++ b/lib/grappa/scrollback/telemetry.ex
@@ -17,7 +17,7 @@ defmodule Grappa.Scrollback.Telemetry do
       metadata: start-metadata + `%{outcome: :ok | :validation_error | :unavailable}`
 
       The STOP half of the `:telemetry.span` wrapping
-      `Grappa.Scrollback.persist_event/1`'s insert+preload. `duration` is the
+      `Grappa.Scrollback.persist_event/1`'s insert. `duration` is the
       pure DB-write time — mechanism 3 (index write-amplification grows it as
       the table grows) — and is `channel`-tagged so it correlates against a
       channel's inbound msg/s (proving the RATE, not member-count,
@@ -38,7 +38,7 @@ defmodule Grappa.Scrollback.Telemetry do
       measurements: `%{attempt: pos_integer()}`
       metadata: `%{fault: :queue_timeout | :busy_locked | :interrupted, dropped: boolean()}`
 
-      Emitted from `Grappa.Scrollback.with_pool_retry/3` on each transient
+      Emitted from `Grappa.Scrollback.with_pool_retry/1` on each transient
       SQLite write-contention fault — mechanism 2 (single-writer contention):
       `:queue_timeout` (the pool could not serve a checkout), `:busy_locked`
       (a slow writer held the single write-lock past `busy_timeout`), or
@@ -66,7 +66,7 @@ defmodule Grappa.Scrollback.Telemetry do
         }
 
   @doc """
-  Wrap `fun` (the insert+preload) in the `[:grappa, :scrollback, :persist, …]`
+  Wrap `fun` (the insert) in the `[:grappa, :scrollback, :persist, …]`
   span. `fun` returns `{result, %{outcome: persist_outcome()}}`; the raw
   `result` is returned unchanged so `persist_event/1`'s contract is untouched.
 
@@ -88,7 +88,7 @@ defmodule Grappa.Scrollback.Telemetry do
 
   @doc """
   Emit `[:grappa, :scrollback, :persist, :contention]` for ONE transient
-  write-contention fault caught in `with_pool_retry/3`. `attempt` is the
+  write-contention fault caught in `with_pool_retry/1`. `attempt` is the
   1-based retry attempt; `dropped` is `true` only on the budget-exhausted
   final attempt (the row is lost), `false` while the loop is still riding it
   out. Fires ONLY on the contention path — already the slow path — so it adds

--- a/lib/grappa/scrollback/wire.ex
+++ b/lib/grappa/scrollback/wire.ex
@@ -10,16 +10,39 @@ defmodule Grappa.Scrollback.Wire do
   Phase 6 IRCv3 `CHATHISTORY` listener will be the fourth — different
   serializer (IRC bytes, not JSON) but same domain event. Centralising
   the shape here separates "data" (`Scrollback.Message` schema) from
-  "verb" (this module's `to_json/1` and `message_payload/1`).
+  "verb" (this module's `to_json/1,2` and `message_payload/2`).
+
+  ## Where the slug comes from, and why there are two doors (#1657b)
+
+  The wire's `:network` is a **slug**, and a caller reaches it one of
+  two ways. `to_json/2` TAKES it; `to_json/1` DERIVES it from a
+  preloaded `:network` assoc. One body, two entrances — not two
+  shapes.
+
+  Which door a caller uses is decided by what it already holds, and
+  that is not a style choice:
+
+    * A **read** path (`MessagesJSON`) receives rows out of a query
+      that preloaded `:network` as part of the same fetch, and its
+      render function is handed nothing but the rows. It has no slug
+      of its own, so it uses `to_json/1`.
+    * A **broadcast** path always knows the slug already — it is in
+      the topic it is about to publish on. `Persistor` computes
+      `Topic.channel(…, ctx.network_slug, …)` on the line above the
+      payload. So `message_payload/2` takes it, and there is no
+      1-arity: making the write path re-derive a value sitting in the
+      adjacent expression cost `Scrollback.persist_event/1` a whole
+      extra DB round-trip per row, and cost the #1429 census its
+      honesty when that round-trip failed (see `Scrollback.persist_row/1`).
+
+  `to_json/1` pattern-matches and crashes loudly if the assoc is
+  unloaded — invariant violation worth crashing on, per CLAUDE.md
+  "let it crash." That is the read-path contract, unchanged.
 
   ## Phase 2 sub-task 2e — wire-shape changes
 
     * The wire emits the network **slug** (string) under key
-      `:network`, NOT the integer `network_id` FK. Callers must
-      preload `:network` on the message before calling `to_json/1`;
-      the function pattern-matches and crashes loudly if the assoc
-      is unloaded — invariant violation worth crashing on, per
-      CLAUDE.md "let it crash."
+      `:network`, NOT the integer `network_id` FK.
     * The wire does NOT carry `user_id` (decision G3). The user
       identity is a topic discriminator (in the PubSub topic string
       and the channel join URL), not a payload field — the client
@@ -100,7 +123,18 @@ defmodule Grappa.Scrollback.Wire do
   literal union rather than a bare `string`.
   """
   @spec to_json(Message.t()) :: t()
-  def to_json(%Message{network: %Network{slug: slug}, kind: kind} = m) when kind != nil do
+  def to_json(%Message{network: %Network{slug: slug}} = m), do: to_json(m, slug)
+
+  @doc """
+  As `to_json/1`, with the network slug supplied by the caller instead
+  of read off a preloaded `:network` assoc.
+
+  This is the body both doors share; `to_json/1` is the read-path
+  entrance that derives `slug` and delegates here. See the moduledoc
+  for which caller owes which.
+  """
+  @spec to_json(Message.t(), String.t()) :: t()
+  def to_json(%Message{kind: kind} = m, slug) when kind != nil and is_binary(slug) do
     %{
       id: m.id,
       network: slug,
@@ -120,18 +154,22 @@ defmodule Grappa.Scrollback.Wire do
 
   Use this with `Grappa.PubSub.broadcast_event/2`:
 
-      Grappa.PubSub.broadcast_event(topic, Wire.message_payload(message))
+      Grappa.PubSub.broadcast_event(topic, Wire.message_payload(message, slug))
 
-  The caller is responsible for preloading `:network` before calling.
+  The caller supplies the network slug. There is deliberately **no
+  1-arity form** (#1657b): every broadcast door already holds the slug
+  — it is in the topic it is publishing on — so a variant that read it
+  back off a preloaded assoc would only re-create the extra DB
+  round-trip this removed. See the moduledoc.
 
   Renamed from `message_event/1` (which returned the legacy `{:event,
   payload}` tuple shape used with raw `Phoenix.PubSub.broadcast/3`)
   when BUG 6 forced a switch to the framework-native fastlane path.
   See `Grappa.PubSub.broadcast_event/2` for the new broadcast surface.
   """
-  @spec message_payload(Message.t()) :: event()
-  def message_payload(%Message{} = m) do
-    %{kind: :message, message: to_json(m)}
+  @spec message_payload(Message.t(), String.t()) :: event()
+  def message_payload(%Message{} = m, network_slug) when is_binary(network_slug) do
+    %{kind: :message, message: to_json(m, network_slug)}
   end
 
   @doc """

--- a/lib/grappa/session/persistor.ex
+++ b/lib/grappa/session/persistor.ex
@@ -6,7 +6,7 @@ defmodule Grappa.Session.Persistor do
   Three sites in the Server hand-rolled the same delivery shape — the
   inbound `:persist` effect, the outbound `persist_and_send_fragments`
   loop, and the `:join_failed` effect — each persisting a `Scrollback`
-  row and broadcasting `Scrollback.Wire.message_payload/1` on the row's
+  row and broadcasting `Scrollback.Wire.message_payload/2` on the row's
   per-channel topic. But only the inbound arm carried the #267
   `WindowCounts.PushSource.push` obligation. The 2026-04-27 A20 deferral
   predicted this drift; the 2026-07-20 architecture review (#369 A3)
@@ -59,6 +59,22 @@ defmodule Grappa.Session.Persistor do
 
   A validation failure is NOT a drop and does not log here: the row never
   had a right to exist, the caller's changeset arm owns that message.
+
+  ## The line may only fire when the row is actually gone (#1657b)
+
+  #1657 fixed the direction where the census UNDER-counted. It left the
+  other one: `Scrollback.persist_row/1` ran a second retry-wrapped op
+  after the insert had already committed, and its failure returned the
+  same `:persist_unavailable`, so this line fired for a row durably in
+  the table. A count that is neither a floor nor a ceiling is worse than
+  one known to be a floor — nothing on the line says which arm made it.
+
+  The cure is structural rather than a smarter predicate here: the second
+  op is gone, so `:persist_unavailable` now has exactly one meaning at
+  this door. **A future op added to the persist path AFTER the insert
+  re-opens this defect** — if one is ever needed, its failure must not
+  reach `log_row_dropped/2`. Pinned in both directions by
+  `Grappa.Session.PersistorTest`.
   """
 
   alias Grappa.IRC.Identifier
@@ -102,10 +118,14 @@ defmodule Grappa.Session.Persistor do
   def persist_and_broadcast(attrs, ctx, opts) do
     case Scrollback.persist_event(attrs) do
       {:ok, message} ->
+        # Both the topic and the payload take `ctx.network_slug` — the same
+        # value, from the same place, on two adjacent lines. It used to reach
+        # the payload the long way round, off a `:network` assoc that
+        # `persist_event/1` fetched with a second query (#1657b).
         :ok =
           Grappa.PubSub.broadcast_event(
             Topic.channel(ctx.subject_label, ctx.network_slug, attrs.channel),
-            Wire.message_payload(message)
+            Wire.message_payload(message, ctx.network_slug)
           )
 
         if Keyword.get(opts, :push, false), do: dispatch_push(message, ctx)

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -58,7 +58,7 @@ defmodule Grappa.Session.Server do
 
   ## Wire shape (broadcast contract)
 
-  PRIVMSG broadcasts emit `Grappa.Scrollback.Wire.message_payload/1`
+  PRIVMSG broadcasts emit `Grappa.Scrollback.Wire.message_payload/2`
   via `Grappa.PubSub.broadcast_event/2` on the per-(subject, network,
   channel) topic built via `Grappa.PubSub.Topic.channel/3`.
   `state.subject_label` is the first segment (sub-task 2h, generalized

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -157,7 +157,7 @@ defmodule GrappaWeb.GrappaChannel do
   dispatcher and the per-socket fastlane — a single WS frame per
   connected socket on the topic. The wire-shape contract lives at the
   broadcasting boundary (`Grappa.Session.Server` via
-  `Grappa.Scrollback.Wire.message_payload/1`). For the channel's own
+  `Grappa.Scrollback.Wire.message_payload/2`). For the channel's own
   topic the fastlane bypasses `handle_info/2` entirely; the ONE
   `handle_info(%Phoenix.Socket.Broadcast{}, _)` clause here serves
   #1088's foreign per-connection topic, which has no fastlane.

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -279,7 +279,7 @@ defmodule GrappaWeb.MessagesController do
          :ok <- validate_wire_recipient_name(ctcp_target, Session.statusmsg(subject, network.id)),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_ctcp(subject, network.id, channel, ctcp_target, body) do
-      render_send_result(conn, result)
+      render_send_result(conn, result, network.slug)
     end
   end
 
@@ -302,7 +302,7 @@ defmodule GrappaWeb.MessagesController do
            validate_wire_recipient_name(notice_target, Session.statusmsg(subject, network.id)),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_notice(subject, network.id, channel, notice_target, body) do
-      render_send_result(conn, result)
+      render_send_result(conn, result, network.slug)
     end
   end
 
@@ -327,7 +327,7 @@ defmodule GrappaWeb.MessagesController do
          :ok <- validate_post_target_name(channel),
          :ok <- take_send_token(subject, network.id),
          {:ok, result} <- Session.send_privmsg(subject, network.id, channel, body) do
-      render_send_result(conn, result)
+      render_send_result(conn, result, network.slug)
     end
   end
 
@@ -423,13 +423,18 @@ defmodule GrappaWeb.MessagesController do
   # clause, and Phoenix raised on the unsent conn → 500. Split into
   # two arms here so the type contract is honored without a discriminator
   # leak into the `with` chain.
-  defp render_send_result(conn, %Scrollback.Message{} = message) do
+  #
+  # `network_slug` is passed rather than read off the row: since #1657b the
+  # persist boundary no longer preloads `:network` (it was a second pool
+  # checkout per row on the hot write path), and this controller already
+  # resolved the network from the URL.
+  defp render_send_result(conn, %Scrollback.Message{} = message, network_slug) do
     conn
     |> put_status(:created)
-    |> render(:show, message: message)
+    |> render(:show, message: message, network_slug: network_slug)
   end
 
-  defp render_send_result(conn, :no_persist) do
+  defp render_send_result(conn, :no_persist, _) do
     conn
     |> put_status(:accepted)
     |> json(%{ok: true})

--- a/lib/grappa_web/controllers/messages_json.ex
+++ b/lib/grappa_web/controllers/messages_json.ex
@@ -20,9 +20,16 @@ defmodule GrappaWeb.MessagesJSON do
   @spec index(%{messages: [Message.t()]}) :: [Wire.t()]
   def index(%{messages: messages}), do: Enum.map(messages, &Wire.to_json/1)
 
-  @doc "Renders the `:show` action — a single serialized message map."
-  @spec show(%{message: Message.t()}) :: Wire.t()
-  def show(%{message: message}), do: Wire.to_json(message)
+  @doc """
+  Renders the `:show` action — a single serialized message map.
+
+  Takes the network slug explicitly (#1657b). `:show` renders a row that
+  was JUST persisted, and the persist boundary no longer preloads
+  `:network` — so this is `to_json/2`, while `index/1` above stays on
+  `to_json/1` because its rows come out of a query that preloaded.
+  """
+  @spec show(%{message: Message.t(), network_slug: String.t()}) :: Wire.t()
+  def show(%{message: message, network_slug: slug}), do: Wire.to_json(message, slug)
 
   @doc """
   Renders the `:count` action (#693) — the uncapped row count after an

--- a/test/grappa/repo/checkout_deadline_reach_test.exs
+++ b/test/grappa/repo/checkout_deadline_reach_test.exs
@@ -1,0 +1,222 @@
+defmodule Grappa.Repo.CheckoutDeadlineReachTest do
+  @moduledoc """
+  #1657b — which of the waits around a contended write actually ends it:
+  SQLite's `busy_timeout`, or DBConnection's checkout deadline?
+
+  ## Why the question is load-bearing
+
+  Production stacks THREE waits on one write, and nothing had ever
+  checked them against each other:
+
+      busy_retry budget   1_500ms   config/config.exs
+      checkout deadline  15_000ms   Ecto's default `:timeout`, not overridden anywhere
+      busy_timeout       30_000ms   config/runtime.exs
+
+  #1421 priced its options against a two-row table whose lock row waits
+  *"up to `busy_timeout` = 30_000ms"*. #1657 then added a third fault
+  kind, `:interrupted`, and named its cause: the checkout deadline
+  firing, which disconnects the holder (`db_connection`'s
+  `ConnectionPool.handle_info({:timeout, …})` → `Holder.handle_disconnect/2`)
+  and cancels the statement. That deadline sits BETWEEN the other two
+  numbers, so which one governs is not a detail.
+
+  ## Method
+
+  ONE independent variable per test: **which of the two numbers is
+  smaller.** Same engine, same real held write lock, same statement; the
+  verdict is named by production's own `BusyRetry.classify/1`, never by a
+  literal here. Magnitudes are scaled down with the RATIO preserved
+  (production is 15_000 : 30_000, i.e. 1:2; this runs 300 : 600) — the
+  same methodology `Grappa.Repo.BusyRetryBudgetReachTest` justifies for
+  the budget, and it keeps the file under two seconds.
+
+  ## What was measured, and what it overturned
+
+  🔴 **The prediction this file was written to confirm was REFUTED, and
+  the refutation is the finding.** The expectation was that the deadline,
+  being smaller, would cut the wait and surface as `:interrupted`. It
+  does cut the wait — the pool logs the checkout timeout and disconnects
+  — but the caller sees `:busy_locked` either way:
+
+    * `busy_timeout` smaller → `busy_locked`, 12/12 samples
+    * deadline smaller → `busy_locked`, 12/12 samples
+
+  exqlite installs a CUSTOM busy handler that polls `conn->cancelled` and
+  **returns 0** when the pool cancels (`c_src/sqlite3_nif.c`); a busy
+  handler returning 0 makes SQLite give up with SQLITE_BUSY. So a write
+  cancelled while WAITING for the lock is indistinguishable BY CLASS from
+  one that exhausted `busy_timeout`. Only the clock separates them.
+
+  Consequence for #1421's table, which is why this was worth measuring:
+  the lock row's latency is not `busy_timeout`, it is
+  `min(busy_timeout, checkout deadline)`. In production that is 15_000,
+  not 30_000, so the ratio against the 1_500 budget is 10 rather than 20.
+  The conclusion #1421 drew (the loop collapses to one attempt) is
+  unchanged; the number it drew it from is not, and `busy_timeout:
+  30_000` never governs a lock-contended write while the deadline is
+  smaller.
+
+  ## The discriminator, and a gap it exposes
+
+  `:interrupted` is NOT the lock-wait verdict — it is what a cancellation
+  produces when the statement is EXECUTING rather than queued behind the
+  lock. That is why #1657's `Bootstrap` casualty was `:interrupted` on a
+  READ (`Visitors.list_active/0`): a read never enters the busy handler.
+
+  🔴 **Measured and unfixed: that case is BIMODAL.** Across 63 samples
+  over two statement shapes, a cancelled executing statement raised
+  `%Exqlite.Error{message: "interrupted"}` ~57% of the time and
+  `%Exqlite.Error{message: "out of memory"}` ~43% — and `classify/1`
+  calls the latter `:permanent`, so `BusyRetry` RE-RAISES it. That is the
+  exact failure mode #1657 exists to remove (a 500 instead of a 503, a
+  crash where nothing wraps, a "non-transient DB error" in the log),
+  still live for roughly half of its own cases, wearing a message that
+  tells the operator they ran out of memory.
+
+  Not an artifact of the harness: the control below uses a streaming
+  cross join that allocates nothing which grows, and it splits the same
+  way as a recursive CTE did. The C-level cause is NOT established — most
+  likely `sqlite3_errmsg` read against a handle the concurrent disconnect
+  is already tearing down — and it is NOT observed in production; the
+  1.3.0 herd's evidence is `interrupted`, the other half has never been
+  seen outside this file.
+
+  Deliberately NOT pinned by an assertion below. The split is roughly
+  even, so asserting it would be flaky, and asserting that `:permanent`
+  is an acceptable outcome would be asserting a bug. Widening the
+  transient set to cover `"out of memory"` is a policy call with a real
+  cost — a genuine SQLITE_NOMEM would then be retried and degraded to a
+  503 instead of surfacing — so it goes up with the numbers, like
+  `pool_size` did, and not into this branch.
+
+  ## What this does NOT resolve
+
+  The #1420 census measured gaps of exactly 30.1s (`lock_watch.ex:19-21`)
+  — `busy_timeout` expiring IN FULL, which requires a deadline that did
+  not fire. The mechanism established here says that cannot happen while
+  a 15_000 deadline is in play, so the two readings still disagree, and
+  the disagreement is now sharper rather than resolved: it points at
+  WHICH POOL was in that window (#1421 records that both its windows are
+  CI and neither is m42; the SQL Sandbox runs `DBConnection.Ownership`,
+  not `ConnectionPool`). This file establishes the mechanism on a private
+  repo of its own making. It measures no production substrate.
+  """
+  use ExUnit.Case, async: false
+
+  alias Grappa.Repo.BusyRetry
+
+  defmodule TmpRepo do
+    use Ecto.Repo, otp_app: :grappa, adapter: Ecto.Adapters.SQLite3
+  end
+
+  # Production's ordering is deadline : busy_timeout = 15_000 : 30_000.
+  @short_ms 300
+  @long_ms 600
+
+  defp tmp_repo!(prefix, busy_timeout) do
+    path = Path.join(System.tmp_dir!(), "#{prefix}_#{System.unique_integer([:positive])}.db")
+    on_exit(fn -> Enum.each(["", "-wal", "-shm"], &File.rm(path <> &1)) end)
+
+    {:ok, repo} =
+      TmpRepo.start_link(
+        database: path,
+        pool_size: 1,
+        busy_timeout: busy_timeout,
+        journal_mode: :wal
+      )
+
+    {repo, path}
+  end
+
+  # Runs `sql` and reports the production verdict plus the wall-clock.
+  # `query_timeout` is the per-query `:timeout` DBConnection turns into the
+  # checkout deadline (`Holder.abs_timeout/2` — the timer covers queue AND
+  # execution, armed from the moment the checkout is requested).
+  defp observe(repo, sql, query_timeout) do
+    started = System.monotonic_time(:millisecond)
+
+    class =
+      try do
+        TmpRepo.query!(sql, [], timeout: query_timeout)
+        :no_fault
+      rescue
+        error in [DBConnection.ConnectionError, Exqlite.Error] -> BusyRetry.classify(error)
+      end
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started
+
+    # Teardown BEFORE any assertion, so a red leaves no repo and no held
+    # write-lock behind for the next test in this serial file.
+    Supervisor.stop(repo)
+
+    %{class: class, elapsed_ms: elapsed_ms}
+  end
+
+  # A write that must WAIT: a separate raw connection holds the file
+  # write-lock for the whole measurement. Its own busy_timeout is 0 so
+  # taking the hold can never itself wait.
+  defp observe_contended_write(busy_timeout, query_timeout) do
+    {repo, path} = tmp_repo!("checkout_deadline_w", busy_timeout)
+    TmpRepo.query!("CREATE TABLE t(id integer)")
+
+    {:ok, holder} = Exqlite.Sqlite3.open(path)
+    :ok = Exqlite.Sqlite3.execute(holder, "PRAGMA busy_timeout=0")
+    :ok = Exqlite.Sqlite3.execute(holder, "BEGIN IMMEDIATE")
+    :ok = Exqlite.Sqlite3.execute(holder, "INSERT INTO t VALUES (1)")
+
+    observed = observe(repo, "INSERT INTO t VALUES (2)", query_timeout)
+
+    :ok = Exqlite.Sqlite3.close(holder)
+    observed
+  end
+
+  # A statement that is EXECUTING rather than waiting: a streaming cross
+  # join, 1000^3 row combinations counted one at a time. O(1) memory by
+  # construction, which is what makes it the control for the "out of
+  # memory" reading in the moduledoc — a recursive CTE could plausibly
+  # exhaust memory on its own; this cannot.
+  defp observe_cancelled_execution(query_timeout) do
+    {repo, _path} = tmp_repo!("checkout_deadline_x", 0)
+    TmpRepo.query!("CREATE TABLE s(x integer)")
+
+    TmpRepo.query!(
+      "WITH RECURSIVE g(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM g WHERE i < 1000) " <>
+        "INSERT INTO s SELECT i FROM g"
+    )
+
+    observe(repo, "SELECT count(*) FROM s a, s b, s c", query_timeout)
+  end
+
+  describe "which wait ends a lock-contended write (#1657b)" do
+    test "busy_timeout smaller: SQLite's own handler ends it" do
+      observed = observe_contended_write(@short_ms, @long_ms)
+
+      assert observed.class == :busy_locked
+      assert observed.elapsed_ms < @long_ms
+    end
+
+    test "deadline smaller: the POOL ends it — sooner, under the SAME class" do
+      observed = observe_contended_write(@long_ms, @short_ms)
+
+      # The class is blind to which wait ran out (see moduledoc: exqlite's
+      # busy handler converts the cancellation into a plain SQLITE_BUSY)...
+      assert observed.class == :busy_locked
+
+      # ...so the CLOCK is the only witness, and it says `busy_timeout` did
+      # not bound this. In production that is the 15_000 deadline capping a
+      # 30_000 busy_timeout, which is why the 30_000 never governs here.
+      assert observed.elapsed_ms < @long_ms
+    end
+
+    test "a cancelled statement that is EXECUTING is never the lock-wait verdict" do
+      observed = observe_cancelled_execution(@short_ms)
+
+      # The discriminator is WHERE the cancellation lands, not that one
+      # happened. Only the negative is asserted: the positive is bimodal
+      # (~57% :interrupted, ~43% :permanent — the unfixed gap in the
+      # moduledoc), so pinning it would be flaky AND would encode a bug.
+      refute observed.class == :busy_locked
+      assert observed.elapsed_ms < @long_ms
+    end
+  end
+end

--- a/test/grappa/repo/checkout_deadline_reach_test.exs
+++ b/test/grappa/repo/checkout_deadline_reach_test.exs
@@ -176,7 +176,7 @@ defmodule Grappa.Repo.CheckoutDeadlineReachTest do
   # memory" reading in the moduledoc — a recursive CTE could plausibly
   # exhaust memory on its own; this cannot.
   defp observe_cancelled_execution(query_timeout) do
-    {repo, _path} = tmp_repo!("checkout_deadline_x", 0)
+    {repo, _} = tmp_repo!("checkout_deadline_x", 0)
     TmpRepo.query!("CREATE TABLE s(x integer)")
 
     TmpRepo.query!(

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -184,6 +184,9 @@ defmodule Grappa.Repo.LockWatchTest do
     # busy_timeout is generous on purpose: the waiter must still be WAITING
     # when the scan runs. A short timeout would turn it into an error path
     # and measure `BusyRetry` instead of this module.
+    #
+    # It is NOT the only wait on that writer, and on its own it does not
+    # govern — see `observed_write/3`.
     {:ok, repo} =
       TmpRepo.start_link(database: path, pool_size: 2, busy_timeout: 30_000, journal_mode: :wal)
 
@@ -211,10 +214,34 @@ defmodule Grappa.Repo.LockWatchTest do
   # Split out of `start_writer/2` so no body nests deeper than two levels.
   # `observe/1` is production's own wrapper — the point is that the test
   # drives the real edge sequence rather than a hand-written copy of it.
+  #
+  # 🔴 `timeout: :infinity` is load-bearing, and it is what makes
+  # `start_tmp_repo/0`'s `busy_timeout: 30_000` mean what that comment says
+  # it means. Without it both writers inherit Ecto's DEFAULT `:timeout` of
+  # 15_000 (`ecto_sql/lib/ecto/adapters/sql.ex`), which DBConnection arms as
+  # a checkout deadline covering the WHOLE transaction — queue, statements
+  # and the holder's park alike. So the real wait was `min(15_000, 30_000)`,
+  # the smaller number was never written down anywhere, and once a loaded
+  # runner pushed the window past 15s the pool disconnected BOTH
+  # connections: the parked holder mid-park, and the waiter mid-`BEGIN
+  # IMMEDIATE`. exqlite's busy handler answers a cancellation with plain
+  # SQLITE_BUSY, so the waiter died `%Exqlite.Error{message: "database is
+  # locked"}` instead of exiting `:normal` — a red naming this file's
+  # waiter assertion, on a machine slow enough, with nothing in the source
+  # to point at. #1657b measured that ordering (deadline caps busy_timeout,
+  # and the cap is invisible by error CLASS); this is the same finding
+  # landing on the harness that assumed otherwise.
+  #
+  # Measured, on `29bea21d` with a 16s delay injected before the release:
+  # without this option the waiter dies `database is locked` and the
+  # waiter-DOWN assertion fails; with it, 4 tests / 0 failures, assertions
+  # untouched. `busy_timeout` is now the only wait bounding the waiter,
+  # which is what this file was always documented to be testing.
   defp observed_write(id, after_insert, test_pid) do
     LockWatch.observe(fn acquired ->
       TmpRepo.transaction(fn -> insert_then(id, after_insert, test_pid, acquired) end,
-        mode: :immediate
+        mode: :immediate,
+        timeout: :infinity
       )
     end)
   end

--- a/test/grappa/scrollback/wire_test.exs
+++ b/test/grappa/scrollback/wire_test.exs
@@ -92,14 +92,16 @@ defmodule Grappa.Scrollback.WireTest do
     end
   end
 
-  describe "message_payload/1" do
+  describe "message_payload/2" do
     test "wraps a row in %{kind: \"message\", message: wire}",
          %{user: user, network: network} do
       {:ok, msg} = ScrollbackHelpers.insert(sample(user, network, 1))
-      preloaded = Repo.preload(msg, :network)
 
-      assert %{kind: :message, message: wire} = Wire.message_payload(preloaded)
-      assert wire == Wire.to_json(preloaded)
+      # #1657b — the broadcast door takes the slug; no preload. The equality
+      # against the read-path door on the SAME row is what keeps "one body,
+      # two entrances" a fact rather than a claim.
+      assert %{kind: :message, message: wire} = Wire.message_payload(msg, network.slug)
+      assert wire == Wire.to_json(Repo.preload(msg, :network))
     end
   end
 

--- a/test/grappa/scrollback_telemetry_test.exs
+++ b/test/grappa/scrollback_telemetry_test.exs
@@ -5,7 +5,7 @@ defmodule Grappa.ScrollbackTelemetryTest do
   Two signals, both proving the mechanisms the issue traced:
 
     * `[:grappa, :scrollback, :persist, :start | :stop]` — a `:telemetry.span`
-      around `persist_event/1`'s insert+preload, tagged by `channel` so the
+      around `persist_event/1`'s insert, tagged by `channel` so the
       per-channel insert latency (mechanism 3, index write-amplification) is
       correlatable against a channel's inbound msg/s. This is ALSO the "pure
       insert" half of the split-span pair (the other half is the send-path
@@ -13,7 +13,7 @@ defmodule Grappa.ScrollbackTelemetryTest do
       the mailbox head-of-line blocking (mechanism 1).
 
     * `[:grappa, :scrollback, :persist, :contention]` — emitted from
-      `with_pool_retry/3` on each transient busy/locked/queue_timeout fault,
+      `with_pool_retry/1` on each transient busy/locked/queue_timeout fault,
       surfacing SQLite single-writer contention (mechanism 2) as telemetry
       rather than only a log grep.
 
@@ -112,7 +112,7 @@ defmodule Grappa.ScrollbackTelemetryTest do
     end
   end
 
-  describe "with_pool_retry/3 contention — [:grappa, :scrollback, :persist, :contention]" do
+  describe "with_pool_retry/1 contention — [:grappa, :scrollback, :persist, :contention]" do
     defp raise_busy, do: raise(%Exqlite.Error{message: "database is locked", statement: nil})
 
     defp raise_queue_timeout do

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -254,17 +254,23 @@ defmodule Grappa.ScrollbackTest do
     end
   end
 
-  describe "persist_event/1 — :network preloading (was persist_privmsg/5)" do
-    test "returns the row with :network preloaded so Wire.to_json/1 doesn't need to",
-         %{user: user, network: net} do
-      # Wire.to_json/1 pattern-matches on `%Network{slug: slug}` and
-      # crashes on unloaded assoc. Both callers (Session.Server's
-      # persist_and_broadcast → Wire.message_payload, and the REST POST
-      # controller → Scrollback.Wire.to_json) used to re-issue a
-      # `Repo.preload(message, :network)` after the boundary returned.
-      # Pushing the preload into the Scrollback boundary collapses the
-      # two parallel preload sites into one — the contract is now "the
-      # row I hand back is wire-shape-ready".
+  # #1657b REVERSES the contract this describe used to pin. It read
+  # "returns the row with :network preloaded so Wire.to_json/1 doesn't need
+  # to", and that preload was a SECOND pool checkout per persisted row,
+  # issued on the hot write path to fetch the network slug — a value the one
+  # production caller (`Session.Persistor`) already holds as
+  # `ctx.network_slug` and uses on the adjacent line to build the broadcast
+  # topic.
+  #
+  # It was not merely wasteful. Its failure returned the same
+  # `:persist_unavailable` as a row that never landed, so the #1429 census
+  # logged `scrollback row dropped` for a row durably in the table. The
+  # honesty half is pinned in `Grappa.Session.PersistorTest`; what is pinned
+  # HERE is the mechanical fact that makes it true — the boundary issues no
+  # query after the insert, so there is nothing left that can fail behind a
+  # committed row.
+  describe "persist_event/1 — one DB op, no wire-shape preload (#1657b)" do
+    test "hands back the row WITHOUT :network preloaded", %{user: user, network: net} do
       attrs = %{
         user_id: user.id,
         network_id: net.id,
@@ -278,9 +284,34 @@ defmodule Grappa.ScrollbackTest do
 
       assert {:ok, %Message{} = m} = Scrollback.persist_event(attrs)
 
-      assert %Network{id: id, slug: slug} = m.network
-      assert id == net.id
-      assert slug == net.slug
+      # The FK is what the row carries; the slug is the caller's to supply.
+      assert m.network_id == net.id
+      assert %Ecto.Association.NotLoaded{} = m.network
+    end
+
+    test "the wire payload is built from the caller's slug, not from the row",
+         %{user: user, network: net} do
+      # The two doors must agree byte-for-byte on the same row, or "one body,
+      # two entrances" is a claim rather than a fact — and the write path
+      # would be emitting a shape nothing else validates.
+      attrs = %{
+        user_id: user.id,
+        network_id: net.id,
+        channel: "#sniffo",
+        server_time: System.system_time(:millisecond),
+        kind: :privmsg,
+        sender: "vjt",
+        body: "ciao",
+        meta: %{}
+      }
+
+      assert {:ok, %Message{} = m} = Scrollback.persist_event(attrs)
+
+      from_caller = Wire.to_json(m, net.slug)
+      from_assoc = m |> Repo.preload(:network) |> Wire.to_json()
+
+      assert from_caller == from_assoc
+      assert from_caller.network == net.slug
     end
   end
 
@@ -399,7 +430,7 @@ defmodule Grappa.ScrollbackTest do
   end
 
   describe "persist_event/1" do
-    test "persists :privmsg with body+meta and preloads :network", %{user: user, network: net} do
+    test "persists :privmsg with body+meta", %{user: user, network: net} do
       attrs = %{
         user_id: user.id,
         network_id: net.id,
@@ -411,8 +442,9 @@ defmodule Grappa.ScrollbackTest do
         meta: %{}
       }
 
-      assert {:ok, %Message{kind: :privmsg, body: "ciao", network: %Network{slug: _}} = m} =
-               Scrollback.persist_event(attrs)
+      # #1657b — the row comes back with the network FK and no preloaded
+      # assoc; the wire slug is the caller's to supply.
+      assert {:ok, %Message{kind: :privmsg, body: "ciao"} = m} = Scrollback.persist_event(attrs)
 
       assert m.user_id == user.id
       assert m.network_id == net.id
@@ -430,7 +462,7 @@ defmodule Grappa.ScrollbackTest do
         meta: %{}
       }
 
-      assert {:ok, %Message{kind: :join, body: nil, network: %Network{slug: _}}} =
+      assert {:ok, %Message{kind: :join, body: nil}} =
                Scrollback.persist_event(attrs)
     end
 

--- a/test/grappa/session/persistor_test.exs
+++ b/test/grappa/session/persistor_test.exs
@@ -70,10 +70,8 @@ defmodule Grappa.Session.PersistorTest do
   end
 
   defp rows_in(network, channel) do
-    Repo.aggregate(
-      from(m in Message, where: m.network_id == ^network.id and m.channel == ^channel),
-      :count
-    )
+    query = from(m in Message, where: m.network_id == ^network.id and m.channel == ^channel)
+    Repo.aggregate(query, :count)
   end
 
   # Arm the retry engine against THIS process and hand back what the door

--- a/test/grappa/session/persistor_test.exs
+++ b/test/grappa/session/persistor_test.exs
@@ -1,0 +1,136 @@
+defmodule Grappa.Session.PersistorTest do
+  @moduledoc """
+  #1657b — the census line and the row's existence must never disagree.
+
+  #1657 moved the `scrollback row dropped` line to the one door every
+  persist passes through, so the #1429 count stopped being a floor taken
+  from two of five call sites. It did NOT check the other direction: the
+  line asserts a row is GONE, and the write path had an arm where the row
+  was durably written and the line fired anyway.
+
+  That arm was the second retry-wrapped op in `Scrollback.persist_row/1` —
+  `Repo.preload(message, :network)`, run AFTER the insert had committed.
+  `scrollback.ex` knew it ("the row IS durably written but has no
+  `:network` assoc for the wire payload") and returned the same
+  `:persist_unavailable` atom as a row that never landed, so `Persistor`
+  logged the drop for a row sitting in the table.
+
+  An instrument that over-reports a loss is the same defect class #1657
+  spent its night removing, only pointed the other way. A count that is
+  neither a floor nor a ceiling is worse than one known to be a floor,
+  because nothing on the line says which arm produced it.
+
+  The pair below pins BOTH directions, and it has to be a pair: the lazy
+  way to make the first test green is to delete the line, and the second
+  test is what makes that cost visible.
+  """
+  use Grappa.DataCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.{Accounts, Networks, Repo}
+  alias Grappa.Repo.BusyRetry
+  alias Grappa.Scrollback.Message
+  alias Grappa.Session.Persistor
+
+  @census_prefix "scrollback row dropped"
+
+  setup do
+    {:ok, user} =
+      Accounts.create_user(%{name: "vjt-#{uniq()}", password: "correct horse battery"})
+
+    {:ok, network} = Networks.find_or_create_network(%{slug: "azzurra-#{uniq()}"})
+
+    %{user: user, network: network}
+  end
+
+  defp uniq, do: System.unique_integer([:positive])
+
+  defp attrs(user, network, channel) do
+    %{
+      user_id: user.id,
+      network_id: network.id,
+      channel: channel,
+      server_time: System.system_time(:millisecond),
+      kind: :privmsg,
+      sender: "alice",
+      body: "ciao",
+      meta: %{}
+    }
+  end
+
+  defp ctx(user, network) do
+    %{
+      subject: {:user, user.id},
+      subject_label: user.name,
+      network_slug: network.slug,
+      network_id: network.id,
+      nick: "vjt"
+    }
+  end
+
+  defp rows_in(network, channel) do
+    Repo.aggregate(
+      from(m in Message, where: m.network_id == ^network.id and m.channel == ^channel),
+      :count
+    )
+  end
+
+  # Arm the retry engine against THIS process and hand back what the door
+  # logged. `fire_on` is 1-indexed over `BusyRetry.run/2` fault CHECKS on this
+  # pid, and the whole point of the pair below is which check gets faulted:
+  # the persist's FIRST retry-wrapped op, or a LATER one that can only run
+  # once the insert has already committed. 10_000 armed faults outlast the
+  # wall-clock budget, so the op degrades instead of recovering.
+  defp capture_faulted_persist(fire_on, fun) do
+    BusyRetry.arm_faults(self(), 10_000, fire_on: fire_on)
+    on_exit(fn -> BusyRetry.disarm_faults(self()) end)
+
+    log = capture_log(fun)
+
+    BusyRetry.disarm_faults(self())
+    log
+  end
+
+  describe "the census line never claims a drop for a row that is in the table (#1657b)" do
+    test "a durably-written row is not reported as dropped", %{user: user, network: net} do
+      channel = "#durable-#{uniq()}"
+
+      # `fire_on: 2` rides out the persist's FIRST retry-wrapped op and faults
+      # from the second on. The insert therefore commits, and only whatever
+      # runs after it can fail — which is exactly the arm that used to report
+      # a loss that had not happened.
+      log =
+        capture_faulted_persist(2, fn ->
+          Persistor.persist_and_broadcast(attrs(user, net, channel), ctx(user, net), push: false)
+        end)
+
+      # The row is the product, and it is THERE. Asserted first and
+      # unconditionally: without it the refute below could pass on a path that
+      # simply never wrote anything.
+      assert rows_in(net, channel) == 1
+
+      refute log =~ @census_prefix
+    end
+
+    test "a row that never landed IS reported as dropped", %{user: user, network: net} do
+      channel = "#lost-#{uniq()}"
+
+      # `fire_on: 1` faults the persist's own first attempt, so nothing ever
+      # commits. This is the #1657 property, restated here as the guard that
+      # stops the test above from being satisfied by deleting the line.
+      log =
+        capture_faulted_persist(1, fn ->
+          assert {:error, :persist_unavailable} =
+                   Persistor.persist_and_broadcast(
+                     attrs(user, net, channel),
+                     ctx(user, net),
+                     push: false
+                   )
+        end)
+
+      assert rows_in(net, channel) == 0
+      assert log =~ @census_prefix
+    end
+  end
+end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3196,21 +3196,25 @@ defmodule Grappa.Session.ServerTest do
 
       # Arm the fault on the SESSION pid, firing on the auto-open's
       # `BusyRetry.run` — NOT the persist's. The session-pid fault-CHECKS that
-      # precede the open are: persist insert (1) + persist preload (2). The
-      # `push: true` obligations (`Push.Triggers` + `WindowCounts`) each run in
-      # their OWN Task, so they add NO checks to this pid — the open's insert is
-      # the 3rd check, hence `fire_on: 3`. A wrong value fails LOUD, never
-      # silently passes: too low faults the persist (the message never lands →
-      # `assert_message_event` below times out); too high lets the open succeed
-      # (the terminal log is absent → the `log =~` assertion fails). So a change
-      # in how many `BusyRetry.run` calls precede the open BREAKS this test.
-      Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 3)
+      # precede the open are: persist insert (1). The `push: true` obligations
+      # (`Push.Triggers` + `WindowCounts`) each run in their OWN Task, so they
+      # add NO checks to this pid — the open's insert is the 2nd check, hence
+      # `fire_on: 2`. A wrong value fails LOUD, never silently passes: too low
+      # faults the persist (the message never lands → `assert_message_event`
+      # below times out); too high lets the open succeed (the terminal log is
+      # absent → the `log =~` assertion fails). So a change in how many
+      # `BusyRetry.run` calls precede the open BREAKS this test.
+      #
+      # It WAS `fire_on: 3`, and #1657b is exactly the change this guard was
+      # written to catch: removing the persist's `Repo.preload` round-trip
+      # deleted check (2), so the open moved up by one. The break was designed.
+      Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 2)
       on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
 
       log =
         capture_log(fn ->
           IRCServer.feed(server, ":alice!~a@host PRIVMSG vjt :hey there\r\n")
-          # persist rode out checks 1-2 + broadcast the message…
+          # persist rode out check 1 + broadcast the message…
           assert_message_event(sender: "alice", body: "hey there")
           # …then drain the handle_info that also ran the dropped open.
           _ = :sys.get_state(pid)
@@ -13264,6 +13268,12 @@ defmodule Grappa.Session.ServerTest do
   #
   # ⚠️ Reporting the loss is NOT preventing it. Every test there asserts that
   # a row was lost LOUDLY; none of them assert the row survived.
+  #
+  # #1657b adds the OTHER direction, and it lives in
+  # `Grappa.Session.PersistorTest` rather than here: a row that IS in the
+  # table must produce no census line. Together the two files bound the
+  # count from both sides — without the second, `scrollback row dropped`
+  # was neither a floor nor a ceiling.
 
   # Drive one persist door with every retry loop in the session pid saturated,
   # and hand back what it logged. `fire_on: 1` faults the persist's own first

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -249,8 +249,9 @@ defmodule GrappaWeb.GrappaChannelTest do
           body: "ciao raga"
         })
 
-      preloaded = Repo.preload(message, :network)
-      payload = Wire.message_payload(preloaded)
+      # #1657b — the broadcast door takes the slug it is publishing under; no
+      # preload, mirroring what `Session.Persistor` does in production.
+      payload = Wire.message_payload(message, network.slug)
 
       Grappa.PubSub.broadcast_event(topic, payload)
 

--- a/test/support/message_event_assertions.ex
+++ b/test/support/message_event_assertions.ex
@@ -2,7 +2,7 @@ defmodule Grappa.MessageEventAssertions do
   @moduledoc """
   Test assertions for the canonical PubSub broadcast event payload
   `%{kind: :message, message: wire_shape}` produced by
-  `Grappa.Scrollback.Wire.message_payload/1` and broadcast via
+  `Grappa.Scrollback.Wire.message_payload/2` and broadcast via
   `Grappa.PubSub.broadcast_event/2`.
 
   Test processes that subscribe with `Phoenix.PubSub.subscribe(Grappa.PubSub,


### PR DESCRIPTION
Follow-up to #1657 (leg 2). **#1657 stays open.** Three deliverables, ordered as the review found them.

## 1. The census could over-report — found in my own landed work

#1657's argument was that `scrollback row dropped` had been taken from two of five doors, so "ten rows lost" was a **floor by construction**. It never checked the other direction.

`Scrollback.persist_row/1` ran **two** retry-wrapped ops: the insert, then `Repo.preload(message, :network)`. A failure of the second returned the same `:persist_unavailable` as a row that never landed — so `Persistor` logged the drop for a row sitting **durably in the table**. The code knew: *"the row IS durably written [...] the live broadcast is what's lost"*, and returned the drop atom anyway.

**Corrected reading of #1657's own note: the count was neither a floor nor a ceiling.** A floor is still usable. A figure that can err in either direction, with nothing on the line saying which arm produced it, is not — and an instrument that lies *in our favour* is exactly as dangerous as one that lies against us.

## 2. Cured at the root: the write path had a round-trip it did not need

The preload fetched **one** value for the wire payload, the network slug — which the only production caller already holds (`Persistor`'s `ctx.network_slug`, used on the adjacent line to build the broadcast topic). So the hot write path spent a second pool checkout, with its own DBConnection deadline, on the path that loses rows under saturation, to re-derive a value in the caller's hand.

`Wire.to_json/2` + `message_payload/2` take the slug; `to_json/1` stays as the READ-path entrance and delegates to the same body. **One pool checkout per persisted row instead of two**, and `:persist_unavailable` at that door now means exactly one thing.

Pinned in **both** directions by `Grappa.Session.PersistorTest` — a durable row must produce no line, a lost row must produce one — because the lazy way to green the first is to delete the line. Oracle proven by mutation: restoring the preload reddens test 1 and nothing else.

## 3. The measurement — and it refuted the prediction it was written to confirm

`Grappa.Repo.CheckoutDeadlineReachTest` varies one thing: which of `busy_timeout` / the DBConnection checkout deadline is smaller, against a real held write lock, classified by production's own `BusyRetry.classify/1`.

The pool **does** cut the wait (it logs the checkout timeout and disconnects the holder) — but the class is `:busy_locked` in **both** orderings, 12/12 samples each. exqlite's custom busy handler returns `0` on cancellation (`c_src/sqlite3_nif.c`), and a busy handler returning 0 makes SQLite give up with `SQLITE_BUSY`, not `SQLITE_INTERRUPT`.

**A write cancelled while waiting for the lock is indistinguishable, by fault kind, from one that exhausted `busy_timeout`. Only the clock separates them.** `observed_state/1`'s phrases stay honest under both, so no census phrase moved and `scripts/log-gap-scan.awk` is untouched.

**This re-prices #1421's table**: its lock row reads *"up to `busy_timeout` = 30_000ms"*; the real latency is `min(busy_timeout, checkout deadline)` = **15_000** in prod, so the ratio against the 1_500 budget is **10, not 20**. #1421's conclusion is unchanged; the number it was drawn from is not. **Reported, not edited — #1421 is not this branch's to touch.**

It also names the discriminator: `:interrupted` is what a cancellation yields when the statement is **executing**, not queued behind the lock — which is exactly why #1657's `Bootstrap` casualty was an interrupt on a READ.

### 🔴 A gap that measurement exposed, named and NOT fixed

The executing-statement case is **bimodal**: over 63 samples across two statement shapes, ~57% raise `%Exqlite.Error{message: "interrupted"}` and **~43% raise `"out of memory"`**, which `classify/1` calls `:permanent` — so `BusyRetry` **re-raises**. That is the failure mode #1657 exists to remove, live for roughly half of its own cases, wearing a message that tells the operator they ran out of memory.

Not a harness artifact: the control is a streaming cross join with O(1) memory and it splits the same way.

Not fixed, and not asserted (the split is ~even, so pinning would be flaky; asserting `:permanent` is acceptable would be asserting a bug). Widening the transient set to cover `"out of memory"` has a real cost — a genuine `SQLITE_NOMEM` would then be retried into a 503 instead of surfacing — so it goes up with its numbers for a ruling, like `pool_size` did.

## Gates

`scripts/check.sh` **RC=0** · `scripts/test.sh` **6721 tests, 0 failures** · `design-notes-gate.sh` green · rebased onto `origin/main` via `scripts/union-rebase.sh` (`docs/DESIGN_NOTES.md` +146 −0, contribution intact, boundary shape verified on the file).

`scripts/integration.sh` **NOT run** — the STACK lane was not taken.

## What is NOT claimed

- **No production substrate was measured.** Both new benches run on private temp repos.
- **This does not prevent a row loss under saturation.** A contended insert still drops. What went is a loss *channel* (a durable row whose broadcast died) and a hot-path round-trip.
- **The C-level cause of the `"out of memory"` reading is unestablished**, and it has never been seen outside that test file.
- **The #1420 contradiction is NOT resolved.** Its census measured gaps of exactly 30.1s — `busy_timeout` expiring in full, needing a deadline that did not fire. The mechanism measured here says that cannot happen while a 15_000 deadline is in play. The disagreement is now *sharper* (it points at which pool was in that window; the SQL Sandbox runs `DBConnection.Ownership`, not `ConnectionPool`) but it is open, and written as open.
- **The 1.3.0 herd's attribution stays closed as non-establishable.** Nothing here reopens it.
- **`pool_size` untouched** — `config/*.exs`, COLD deploy, not a PR's call.