### PR TITLE
#1658 point 3 — the rows follow the finger, and the hover fill stops latching on touch

### DIFF
--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -212,6 +212,33 @@ async function openDirectory(
   return { list, refresh };
 }
 
+// A row to measure against, MADE rather than waited for.
+//
+// 🔴 MEASURED, not reasoned from the source: with only this spec in the run the
+// directory renders "0 channels", "never", and an EMPTY `<ul>` — the Playwright
+// failure snapshot says exactly that. No capture has ever happened on the
+// network, and `openDirectory` names that state in its own comment ("the pane's
+// own mount GET is what produces that page, EMPTY SNAPSHOT OR NOT"). So no
+// timeout and no polling can help: waiting longer for a row that nothing is
+// producing waits forever.
+//
+// What made this pass in CI at all is shard ORDER — the directory snapshot is
+// SERVER-side and per-network, so any earlier spec that captured one leaves it
+// populated for everything after. That is the flake, and the cure is to stop
+// depending on a neighbour: force the capture here, through the same door
+// `channel-directory.spec.ts` uses.
+//
+// The 15s is that spec's number and it is a ROUND-TRIP BUDGET, not a guess at a
+// slow machine: LIST → the session's 322 capture → 323 → progress ping → cic's
+// re-GET. Settling the button back to "Refresh" afterwards restores the quiet
+// pre-state `openDirectory` establishes, so a "Refreshing…" seen later is the
+// pull's doing and not this capture still in flight.
+async function seedOneRow(page: Page, refresh: Locator): Promise<void> {
+  await refresh.click();
+  await expect(page.locator(".directory-row-join").first()).toBeVisible({ timeout: 15_000 });
+  await expect(refresh).toHaveText("Refresh", { timeout: 15_000 });
+}
+
 // One downward drag on the row list, plus the browser's own reading of where
 // the slot sat before and during it. Body inlined in the page rather than
 // passed as a stringified function: `new Function` in page context is eval,
@@ -328,7 +355,7 @@ async function measureAtFullTravel(
       if (slot === null) throw new Error("no pull slot inside the directory list");
       const track = el.querySelector<HTMLElement>(".directory-pull-track");
       if (track === null) throw new Error("no pull track inside the directory list");
-      const row = el.querySelector<HTMLElement>(".directory-row");
+      const row = el.querySelector<HTMLElement>(".directory-row-join");
       if (row === null) throw new Error("no directory row to measure the gap against");
       const at = (y: number): Touch =>
         new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
@@ -409,7 +436,7 @@ async function resolveTrackTravel(
       if (slot === null) throw new Error("no pull slot inside the directory list");
       const track = el.querySelector<HTMLElement>(".directory-pull-track");
       if (track === null) throw new Error("no pull track inside the directory list");
-      const row = el.querySelector<HTMLElement>(".directory-row");
+      const row = el.querySelector<HTMLElement>(".directory-row-join");
       if (row === null) throw new Error("no directory row to measure the gap against");
       el.classList.add("pull-gesture-active");
       track.style.transform = opts.declaration;
@@ -486,7 +513,10 @@ test("#1658 — the rows follow the finger and the slot rides above them, at eve
   page,
 }) => {
   test.slow();
-  const { list } = await openDirectory(page, "sidebar");
+  const { list, refresh } = await openDirectory(page, "sidebar");
+  // A row must EXIST to measure the gap against it, and nothing else in this
+  // run produces one — see `seedOneRow`.
+  await seedOneRow(page, refresh);
 
   // S, M (the default) and XXL — three DIFFERENT slot heights, and that is the
   // point: the invariant is an identity only if it survives all three. A
@@ -535,7 +565,8 @@ test("@webkit #1658 — WebKit carries the rows AND keeps the slot off them (iPh
   test.slow();
   // The mobile door, for the reason `openDirectory` states: the $list window
   // has no BottomBar tab, so `selectChannel` cannot reach it on this layout.
-  const { list } = await openDirectory(page, "list-command");
+  const { list, refresh } = await openDirectory(page, "list-command");
+  await seedOneRow(page, refresh);
 
   for (const [size, expectedSlotHeight] of FONT_SIZES) {
     // The ARITHMETIC CONTROL, and it runs first because everything below is
@@ -578,7 +609,13 @@ test("@webkit #1445 — the directory list refuses its own overscroll and declar
   page,
 }) => {
   test.slow();
-  const { list } = await openDirectory(page, "list-command");
+  const { list, refresh } = await openDirectory(page, "list-command");
+  // NOT this test's defect, but the same latent one: it hit-tests a row and
+  // has only ever found one because some earlier spec in the shard left a
+  // server-side snapshot behind. Seeded here too — leaving one call site
+  // order-dependent while curing its two neighbours would put two patterns in
+  // one file.
+  await seedOneRow(page, refresh);
 
   const contract = await list.evaluate((el) => {
     const row = el.querySelector<HTMLElement>(".directory-row-join");

--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -11,34 +11,40 @@
 //      latch (F1). A gesture wired to a second refresh path would leave the
 //      button reading "Refresh" and turn this red.
 //   2. DISPLACEMENT (chromium): mid-drag, the browser's own computed matrix
-//      says the slot has moved by exactly the finger's travel and by nothing
-//      else. Two things ride on that "and nothing else": the slot rests at
-//      `translateY(-100%)`, which an inline transform REPLACES, so a paint
-//      that forgot to re-state it would read +slotHeight instead of 0 for the
-//      parked term; and the reading is taken mid-gesture, which is only a
-//      stable number because `pull-gesture-active` drops the slot's snap-back
-//      transition — without it getComputedStyle returns wherever the ease
-//      happened to be.
-//   2b. THE FLUSH LINE (#1658, chromium): at a travel far past any cap the
-//      slot's top edge lands exactly ON the list's top edge — it stops flush
-//      instead of sinking into the rows, which is what it did on 1.3.0 (the
-//      cap was `PULL_COMMIT_PX`, larger than the slot at every font size, so
-//      the spinner parked 30-50px inside the list). Asserted at THREE root
-//      font sizes because the slot is `2.5rem` against a size the user picks,
-//      and the reading is 0 at all three only if the cap is the slot's own
-//      height: a hardcoded 35 would read +5 at S and -15 at XXL. The slot
-//      height is asserted alongside it, so a `--font-size` write that silently
-//      failed cannot make three identical measurements look like three sizes.
-//      What this does NOT say is that the slot never covers a row: it is
-//      `position: absolute; top: 0` over rows that start at y=0, so every
-//      visible position overlaps the first row's top band. Only moving the
-//      rows fixes that (#1658 point 3, not started) — the flush line is the
-//      strongest TRUE statement available here.
+//      says the TRACK has moved by exactly the finger's travel and by nothing
+//      else. The reading is taken mid-gesture, which is only a stable number
+//      because `pull-gesture-active` drops the snap-back transition — without
+//      it getComputedStyle returns wherever the ease happened to be.
+//      #1658 point 3 moved this reading off the slot and onto the track. The
+//      slot no longer carries a transform of its own beyond the parked
+//      `translateY(-100%)` in the stylesheet; what moves it is its ancestor.
+//   2b. THE ROWS FOLLOW THE FINGER, AND THE SPINNER RIDES ABOVE THEM (#1658
+//      point 3, chromium). Two assertions, and the first is the defect vjt
+//      kept reporting: at a travel of 400px the first row's top edge sits 400px
+//      below the list's top edge — the CONTENT moved, not just the spinner.
+//      Until point 3 only the slot moved, and because rows start at y=0 too,
+//      every position where the spinner was visible was a position where it
+//      covered the first row's top band; the strongest true statement
+//      available then was the weaker "the slot never travels PAST the top
+//      edge", and this file used to assert exactly that.
+//      The second is the STRONG invariant that replaces it: the slot's bottom
+//      edge lands ON the first row's top edge, never below it. It holds because
+//      the two are one rigid body under one transform — an identity, not a
+//      bound — so what this measures is that the ENGINE agrees with that
+//      geometry once real layout exists, which jsdom cannot say.
+//      Asserted at THREE root font sizes, with the slot height read alongside:
+//      the slot is `2.5rem` against a size the user picks, and without the
+//      height control three identical readings from a `--font-size` write that
+//      silently failed would look like proof.
 //   2c. NO PAINT AFTER THE COMMIT (#1658, chromium): the committing release
-//      leaves no inline transform and no inline opacity on the slot. The
-//      binder does not call `onRelease` on that path, so the pane clears the
-//      paint from `onCommit` — before the fix the spinner stayed exactly where
-//      the finger left it, at full opacity, for the life of the pane.
+//      leaves no inline transform on the track and no inline opacity on the
+//      slot. The binder does not call `onRelease` on that path, so the pane
+//      clears the paint from `onCommit` — before that fix the spinner stayed
+//      exactly where the finger left it, at full opacity, for the life of the
+//      pane. Point 3 raised the stakes on it: the travel is on the TRACK now,
+//      so the same omission would strand the whole channel list 240px down the
+//      pane, not just a spinner. Both elements are asserted, and so is the
+//      slot's own transform staying empty — the pane must not write one.
 //   3. CSS CONTRACT (@webkit, iPhone 15): on the real target browser the row
 //      container refuses its own overscroll (so the iOS rubber-band does not
 //      fight the slot at the one scroll position the pull lives at) while
@@ -48,17 +54,26 @@
 //      altogether, and the scroller's own `pan-y` alone would leave the ROW
 //      — the hit-test target across nearly the whole list — still reading
 //      `auto`, which is the shape #913 measured as insufficient.
-//   3b. THE CAP, RESOLVED BY THE ENGINE THE BUG CAME FROM (#1658, @webkit):
-//      the declaration the pane writes at full travel is applied straight to
-//      the slot and the engine's own geometry is read back. vjt reported this
-//      from iOS Safari, and the cap is `translateY(min(<px>, 100%))` — a CSS
-//      math function over MIXED UNITS inside a transform. Chromium resolving
-//      it says nothing about WebKit, and a WebKit that did not resolve it
-//      would leave the slot parked out of sight: not "the cap is a few px
-//      off" but the pull no longer following the finger, on the only engine
-//      the reporter has, with 2b and every other gate here GREEN. That is the
-//      empty-green class — a gate that passes because it does not look where
-//      the defect lives — and this is the assertion that closes it.
+//   3b. THE INVARIANT, RESOLVED BY THE ENGINE THE BUG CAME FROM (#1658 point
+//      3, @webkit): the track translate the pane writes at full travel is
+//      applied straight to the track and the engine's own geometry is read
+//      back — did the ROWS move by it, and did the slot's bottom still land on
+//      the first row's top?
+//      The question is not the same one chromium answers, and that is why the
+//      arm exists. The invariant is an identity only if the engine composes an
+//      ancestor's px translate with the slot's OWN `translateY(-100%)` — a
+//      PERCENTAGE that resolves against the slot's own height, not the
+//      track's. Chromium composing it correctly says nothing about WebKit, and
+//      a WebKit that resolved that percentage against the wrong box would put
+//      the spinner back on top of the first row: the exact defect, on the only
+//      engine the reporter has, with every chromium gate here GREEN. That is
+//      the empty-green class — a gate that passes because it does not look
+//      where the defect lives.
+//      It used to ask a different question — whether WebKit resolved
+//      `translateY(min(<px>, 100%))`, the mixed-unit cap. Point 3 deleted that
+//      declaration from production, so the test was re-aimed rather than
+//      dropped: the engine half is still worth a witness, only the geometry it
+//      witnesses changed.
 //      NO GESTURE, deliberately and not for convenience: `new Touch(...)` is
 //      an `Illegal constructor` on Playwright's WebKit (measured; issue230's
 //      header records the same limit for its own drag), so the production
@@ -66,8 +81,8 @@
 //      the ENGINE half; the PANE half — that the pane writes this declaration
 //      from a real finger — is 2b's, on chromium. Each is honest about which
 //      half it owns, and neither pretends to the other.
-//      It carries a plain-px ARITHMETIC CONTROL ahead of the capped reading,
-//      because the first draft of it had none and measured the slot's 150ms
+//      It carries a plain-px ARITHMETIC CONTROL ahead of the real reading,
+//      because the first draft of it had none and measured the 150ms
 //      snap-back transition instead of the resolved transform: every
 //      declaration read as "parked" on BOTH engines and it looked like a
 //      total WebKit failure. The control fails loudly in that state.
@@ -87,9 +102,16 @@
 //   * That Playwright's WebKit IS iOS Safari. Test 3b measures the same engine
 //     family under a phone viewport, which is the closest thing reachable from
 //     CI and strictly more than a chromium-only reading — it answers "does
-//     WebKit resolve a mixed-unit `min()` inside a transform", a question
-//     chromium cannot answer at all. It does not answer "does it resolve the
-//     same way on vjt's phone", and no assertion here claims it does.
+//     WebKit compose an ancestor's px translate with a descendant's own
+//     percentage offset such that the invariant holds", a question chromium
+//     cannot answer at all. It does not answer "does it resolve the same way on
+//     vjt's phone", and no assertion here claims it does.
+//   * The TRAVEL DISTANCE, now that #1658 point 3 removed the cap. Nothing here
+//     says 400px of finger should produce 400px of list, only that it DOES and
+//     that the spinner stays off the rows while it happens. Whether the pull
+//     should ease off past the commit point is a feel question that needs a
+//     phone, and the code takes the position that an unbounded follow is the
+//     honest floor to calibrate from rather than an unmeasured damping curve.
 //   * The GESTURE on WebKit, by anything here. `new Touch(...)` throws
 //     `Illegal constructor` there, so no test in this file drives the binder
 //     on that project. MEASURED while looking for a way round it, and recorded
@@ -130,13 +152,14 @@ const LIST_WINDOW_NAME = "$list";
 // #1658 — and unlike the window name this copy no longer CHECKS ITSELF. It
 // did: test 2 dragged half of it against a paint capped at the real constant,
 // so lowering the real one made this spec read the cap instead of the drag and
-// go red. Both halves of that are gone — the travel caps at the slot's own
-// height now, and test 2 drags a literal 20 to stay under it at every font
-// size. The only use left is a drag MAGNITUDE (`PULL_COMMIT_PX * 3` in test
-// 1), which reds only if the real constant grows past 240 and says nothing at
-// all if it shrinks. Leaving the old claim here would have left a comment
-// standing where a witness used to be, which is the failure #1393 spent a day
-// removing.
+// go red. Both halves of that are gone. Point 3 removed the cap outright —
+// with the rows carried by the same transform as the spinner there is no
+// collision left to bound — so no drag in this file can read a clamp instead
+// of a follow, at any distance or font size. The only use left is a drag
+// MAGNITUDE (`PULL_COMMIT_PX * 3` in test 1), which reds only if the real
+// constant grows past 240 and says nothing at all if it shrinks. Leaving the
+// old claim here would have left a comment standing where a witness used to
+// be, which is the failure #1393 spent a day removing.
 //
 // What pins it is #1646's static witness, which needs no testnet:
 // src/__tests__/e2eConstantMirrors.test.ts imports the production constant and
@@ -205,12 +228,16 @@ async function pullList(
 ): Promise<{ before: number; after: number }> {
   return list.evaluate(
     (el, opts) => {
-      const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
-      if (slot === null) throw new Error("no pull slot inside the directory list");
+      // #1658 point 3 — the TRACK, not the slot. The travel is painted on the
+      // element that carries both the spinner and the rows; the slot's own
+      // computed transform is the constant parked `translateY(-100%)` and
+      // would read the same at every distance.
+      const track = el.querySelector<HTMLElement>(".directory-pull-track");
+      if (track === null) throw new Error("no pull track inside the directory list");
       // The vertical component of the computed matrix — what the browser
       // actually resolved, not the inline string we wrote.
       const verticalOffset = (): number =>
-        new DOMMatrixReadOnly(getComputedStyle(slot).transform).f;
+        new DOMMatrixReadOnly(getComputedStyle(track).transform).f;
       const at = (y: number): Touch =>
         new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
       const fire = (type: string, touch: Touch): void => {
@@ -243,15 +270,27 @@ async function pullList(
   );
 }
 
-// The slot's inline style, which is the whole of the paint: the rule in
-// default.css sets the parked transform and `opacity: 0`, and the gesture
-// writes over both. Empty strings mean the pane handed the slot back to the
-// stylesheet.
-async function slotInlinePaint(list: Locator): Promise<{ transform: string; opacity: string }> {
+// The whole of the paint, which since #1658 point 3 spans TWO elements on two
+// axes: the TRACK carries the travel, the SLOT carries the opacity ramp.
+// Empty strings mean the pane handed both back to the stylesheet.
+//
+// `slotTransform` is read as well and must ALWAYS be empty, at rest and
+// mid-pull alike: the parked `translateY(-100%)` lives in default.css and the
+// pane writes no transform on that element at any point. A non-empty reading
+// is the #1438 trap coming back — an inline transform replacing the rule.
+async function pullInlinePaint(
+  list: Locator,
+): Promise<{ trackTransform: string; slotOpacity: string; slotTransform: string }> {
   return list.evaluate((el) => {
+    const track = el.querySelector<HTMLElement>(".directory-pull-track");
+    if (track === null) throw new Error("no pull track inside the directory list");
     const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
     if (slot === null) throw new Error("no pull slot inside the directory list");
-    return { transform: slot.style.transform, opacity: slot.style.opacity };
+    return {
+      trackTransform: track.style.transform,
+      slotOpacity: slot.style.opacity,
+      slotTransform: slot.style.transform,
+    };
   });
 }
 
@@ -265,52 +304,70 @@ async function slotInlinePaint(list: Locator): Promise<{ transform: string; opac
 // cancel puts the slot back without committing, so measuring three sizes in
 // one test does not spend three upstream LIST captures.
 //
-// `transform` comes back as the INLINE string, not a computed one, and it is
-// the discriminator #1658's webkit arm needs: setting an unparseable value on
-// a CSSStyleDeclaration is a silent no-op, so an engine that refuses
-// `min(<px>, 100%)` inside `translateY` leaves this empty while the geometry
-// merely reads "parked". Empty means the declaration was refused; non-empty
-// with a non-zero offset means it was accepted and resolved elsewhere.
+// `transform` comes back as the INLINE string, not a computed one: setting an
+// unparseable value on a CSSStyleDeclaration is a silent no-op, so an engine
+// that refused the declaration leaves this empty while the geometry merely
+// reads "parked". Empty means refused; non-empty with a moved row means
+// accepted and resolved.
+const FULL_TRAVEL_PX = 400;
+
 async function measureAtFullTravel(
   list: Locator,
   rootFontSize: string,
-): Promise<{ slotTop: number; listTop: number; slotHeight: number; transform: string }> {
-  return list.evaluate((el, size) => {
-    document.documentElement.style.setProperty("--font-size", size);
-    const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
-    if (slot === null) throw new Error("no pull slot inside the directory list");
-    const at = (y: number): Touch =>
-      new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
-    const fire = (type: string, touch: Touch): void => {
-      const points = type === "touchend" || type === "touchcancel" ? [] : [touch];
-      el.dispatchEvent(
-        new TouchEvent(type, {
-          bubbles: true,
-          cancelable: true,
-          touches: points,
-          targetTouches: points,
-          changedTouches: [touch],
-        }),
-      );
-    };
-    el.scrollTop = 0;
-    const y0 = 200;
-    fire("touchstart", at(y0));
-    fire("touchmove", at(y0 + 20));
-    // Far past every cap in play — the old one (80), the slot at its largest
-    // (50). Whatever stops the slot, it is not the finger running out.
-    fire("touchmove", at(y0 + 400));
-    const slotRect = slot.getBoundingClientRect();
-    const listRect = el.getBoundingClientRect();
-    const transform = slot.style.transform;
-    fire("touchcancel", at(y0 + 400));
-    return {
-      slotTop: slotRect.top,
-      listTop: listRect.top,
-      slotHeight: slotRect.height,
-      transform,
-    };
-  }, rootFontSize);
+): Promise<{
+  slotBottom: number;
+  rowTop: number;
+  listTop: number;
+  slotHeight: number;
+  transform: string;
+}> {
+  return list.evaluate(
+    (el, opts) => {
+      document.documentElement.style.setProperty("--font-size", opts.size);
+      const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
+      if (slot === null) throw new Error("no pull slot inside the directory list");
+      const track = el.querySelector<HTMLElement>(".directory-pull-track");
+      if (track === null) throw new Error("no pull track inside the directory list");
+      const row = el.querySelector<HTMLElement>(".directory-row");
+      if (row === null) throw new Error("no directory row to measure the gap against");
+      const at = (y: number): Touch =>
+        new Touch({ identifier: 1, target: el, clientX: 200, clientY: y });
+      const fire = (type: string, touch: Touch): void => {
+        const points = type === "touchend" || type === "touchcancel" ? [] : [touch];
+        el.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches: points,
+            targetTouches: points,
+            changedTouches: [touch],
+          }),
+        );
+      };
+      el.scrollTop = 0;
+      const y0 = 200;
+      fire("touchstart", at(y0));
+      fire("touchmove", at(y0 + 20));
+      // Far past every distance in play — the commit point (80) and the slot
+      // at its largest (50). Whatever stops the pull, it is not the finger
+      // running out, and since point 3 removed the cap nothing else stops it
+      // either: the reading below is the finger's own distance.
+      fire("touchmove", at(y0 + opts.travel));
+      const slotRect = slot.getBoundingClientRect();
+      const rowRect = row.getBoundingClientRect();
+      const listRect = el.getBoundingClientRect();
+      const transform = track.style.transform;
+      fire("touchcancel", at(y0 + opts.travel));
+      return {
+        slotBottom: slotRect.bottom,
+        rowTop: rowRect.top,
+        listTop: listRect.top,
+        slotHeight: slotRect.height,
+        transform,
+      };
+    },
+    { size: rootFontSize, travel: FULL_TRAVEL_PX },
+  );
 }
 
 // The three root font sizes that bracket cic's range, and the slot height each
@@ -321,38 +378,48 @@ const FONT_SIZES = [
   ["20px", 50],
 ] as const;
 
-// One paint applied DIRECTLY to the slot, with no gesture in front of it, and
+// One paint applied DIRECTLY to the track, with no gesture in front of it, and
 // the geometry the engine resolves it to. This is how the @webkit arm reaches
-// the cap at all: `new Touch(...)` is an `Illegal constructor` on Playwright's
-// WebKit (measured, and issue230's header records the same for its own drag),
-// so the production gesture cannot be synthesized there and the question
-// "does THIS ENGINE resolve THIS DECLARATION" has to be asked directly.
+// the invariant at all: `new Touch(...)` is an `Illegal constructor` on
+// Playwright's WebKit (measured, and issue230's header records the same for
+// its own drag), so the production gesture cannot be synthesized there and the
+// question "does THIS ENGINE resolve THIS GEOMETRY" has to be asked directly.
 //
-// 🔴 `pull-gesture-active` is not decoration. The slot carries
+// It returns both halves of the invariant because they fail differently: `gap`
+// is how far the ROWS moved (the engine applied the ancestor translate at all)
+// and `overlap` is slot-bottom minus row-top (the engine composed that
+// translate with the slot's own PERCENTAGE offset against the right box).
+//
+// 🔴 `pull-gesture-active` is not decoration. The track carries
 // `transition: transform 150ms ease-out`, which production drops through that
 // exact class for the length of a claimed pull. Without it every reading here
-// is the ease at t=0 — MEASURED: all eight candidate declarations, on BOTH
-// engines, read as the parked position and the table looked like a total
-// engine failure. Killing the transition the way production kills it is what
-// turned that into a table with two distinct answers in it.
-async function resolveTransform(
+// is the ease at t=0 — MEASURED on the cap this test used to check: all eight
+// candidate declarations, on BOTH engines, read as the parked position and the
+// table looked like a total engine failure. Killing the transition the way
+// production kills it is what turned that into a table with distinct answers.
+async function resolveTrackTravel(
   list: Locator,
   rootFontSize: string,
   declaration: string,
-): Promise<{ offset: number; slotHeight: number; computed: string }> {
+): Promise<{ gap: number; overlap: number; slotHeight: number; computed: string }> {
   return list.evaluate(
     (el, opts) => {
       document.documentElement.style.setProperty("--font-size", opts.rootFontSize);
       const slot = el.querySelector<HTMLElement>(".directory-pull-slot");
       if (slot === null) throw new Error("no pull slot inside the directory list");
+      const track = el.querySelector<HTMLElement>(".directory-pull-track");
+      if (track === null) throw new Error("no pull track inside the directory list");
+      const row = el.querySelector<HTMLElement>(".directory-row");
+      if (row === null) throw new Error("no directory row to measure the gap against");
       el.classList.add("pull-gesture-active");
-      slot.style.transform = opts.declaration;
-      const computed = getComputedStyle(slot).transform;
+      track.style.transform = opts.declaration;
+      const computed = getComputedStyle(track).transform;
       const slotRect = slot.getBoundingClientRect();
-      const offset = slotRect.top - el.getBoundingClientRect().top;
-      slot.style.removeProperty("transform");
+      const rowRect = row.getBoundingClientRect();
+      const gap = rowRect.top - el.getBoundingClientRect().top;
+      track.style.removeProperty("transform");
       el.classList.remove("pull-gesture-active");
-      return { offset, slotHeight: slotRect.height, computed };
+      return { gap, overlap: slotRect.bottom - rowRect.top, slotHeight: slotRect.height, computed };
     },
     { rootFontSize, declaration },
   );
@@ -378,65 +445,91 @@ test("#1445 — a downward pull on the directory asks for the refresh (chromium)
   // #1658 — and the committing release cleaned up after itself. The binder
   // reports a commit through `onCommit` and returns WITHOUT calling
   // `onRelease`, so a pane that hangs its cleanup off `onRelease` alone leaves
-  // the slot painted where the finger left it, at full opacity, forever. The
-  // two assertions above are the pre-state that makes this one evidence: the
-  // gesture really did take the committing path.
-  expect(await slotInlinePaint(list)).toEqual({ transform: "", opacity: "" });
+  // the paint where the finger left it, forever. The two assertions above are
+  // the pre-state that makes this one evidence: the gesture really did take
+  // the committing path.
+  //
+  // Point 3 spread the paint over two elements, so this checks both — and the
+  // stranded-track case is the worse of the two: not a hung spinner but the
+  // whole channel list sitting 240px down the pane. `slotTransform` is the
+  // third reading and it must be empty here for a different reason: the pane
+  // never writes one at all, at any point in the gesture.
+  expect(await pullInlinePaint(list)).toEqual({
+    trackTransform: "",
+    slotOpacity: "",
+    slotTransform: "",
+  });
 });
 
-test("#1445 — mid-pull the slot moves by the finger's travel, parked offset intact (chromium)", async ({
+test("#1445 — mid-pull the track moves by exactly the finger's travel (chromium)", async ({
   page,
 }) => {
   test.slow();
   const { list } = await openDirectory(page, "sidebar");
 
-  // 20px, and it used to be half the commit distance. #1658 capped the travel
-  // at the slot's OWN height — `2.5rem`, so 30px at the smallest root font
-  // size cic offers — and 40px is over that cap at three of the five sizes,
-  // which would make this read the clamp instead of the follow. 20px is under
-  // it at all five. The cap has its own test below.
+  // 20px. It used to be half the commit distance, then a literal 20 chosen to
+  // stay under the #1658 slot-height cap at every font size. Point 3 removed
+  // the cap, so no distance can read a clamp any more and the literal survives
+  // only because it keeps this test's arithmetic a small, obvious number.
   //
-  // Under the cap a correct paint moves the slot by exactly what the finger
-  // did. The rest position contributes -slotHeight to this same component, so
-  // a paint that dropped it would read +slotHeight + travel instead. The two
-  // failure modes are far apart and the browser does the arithmetic.
+  // The track rests at NO transform, so this reading is the whole of the
+  // paint: `after - before` is the finger's travel or the paint is wrong. The
+  // parked offset that used to complicate it belongs to the slot and stays in
+  // the stylesheet, on an element this no longer reads.
   const travel = 20;
   const { before, after } = await pullList(list, travel, false);
 
   expect(after - before).toBeCloseTo(travel, 0);
 });
 
-test("#1658 — at full travel the slot stops flush with the list's top edge, at every font size (chromium)", async ({
+test("#1658 — the rows follow the finger and the slot rides above them, at every font size (chromium)", async ({
   page,
 }) => {
   test.slow();
   const { list } = await openDirectory(page, "sidebar");
 
   // S, M (the default) and XXL — three DIFFERENT slot heights, and that is the
-  // point: the cap is only the slot's own height if the flush reading survives
-  // all three. A hardcoded 35 reads +5 at S and -15 at XXL; the old
-  // `PULL_COMMIT_PX` cap reads +50, +45 and +30.
+  // point: the invariant is an identity only if it survives all three. A
+  // spinner placed by any arithmetic on the slot's height instead of by being
+  // carried in the same box would read three different overlaps here.
   for (const [size, expectedSlotHeight] of FONT_SIZES) {
-    const { slotTop, listTop, slotHeight, transform } = await measureAtFullTravel(list, size);
+    const { slotBottom, rowTop, listTop, slotHeight, transform } = await measureAtFullTravel(
+      list,
+      size,
+    );
 
     // Known-answer control, and without it this whole test is theatre: if the
     // `--font-size` write did not take, all three iterations would measure the
     // same slot and three identical readings would look like proof.
     expect(slotHeight, `slot height at --font-size: ${size}`).toBeCloseTo(expectedSlotHeight, 0);
-    // Read this one FIRST when the pair goes red: an EMPTY inline transform is
+    // Read this one FIRST when the rest goes red: an EMPTY inline transform is
     // the engine refusing the declaration outright (the CSSOM setter drops an
     // unparseable value silently), which is a different defect and a different
     // fix from an engine that accepted it and resolved it somewhere else.
     expect(transform, `inline transform at --font-size: ${size}`).not.toBe("");
-    // The flush line. NOT "the slot clears the first row" — it cannot, it is
-    // absolutely positioned over rows that start at the same y — but it never
-    // travels PAST the edge, which is the whole of what #1658 point 2 can buy
-    // before the rows themselves move (point 3, not started).
-    expect(slotTop - listTop, `flush offset at --font-size: ${size}`).toBeCloseTo(0, 0);
+
+    // POINT 3 ITSELF, and the assertion this file did not have: the CONTENT
+    // moved. The first row is 400px below the list's top edge because the
+    // finger dragged it there. Before point 3 this read 0 at every size — the
+    // rows never moved at all, which is the defect vjt kept seeing, and it is
+    // also what proves the travel is UNCAPPED: any cap would read the cap.
+    expect(rowTop - listTop, `rows followed the finger at --font-size: ${size}`).toBeCloseTo(
+      400,
+      0,
+    );
+
+    // THE STRONG INVARIANT. The slot's bottom edge lands ON the first row's
+    // top edge — the spinner sits in the space the rows opened, touching them
+    // and never over them. A positive number here is the spinner back on top
+    // of the row, which is exactly the 1.3.0 defect.
+    expect(slotBottom - rowTop, `slot/row overlap at --font-size: ${size}`).toBeCloseTo(0, 0);
+    expect(slotBottom, `slot bottom must not pass the first row at ${size}`).toBeLessThanOrEqual(
+      rowTop + 0.5,
+    );
   }
 });
 
-test("@webkit #1658 — WebKit resolves the travel cap against the slot's own height (iPhone 15)", async ({
+test("@webkit #1658 — WebKit carries the rows AND keeps the slot off them (iPhone 15)", async ({
   page,
 }) => {
   test.slow();
@@ -446,44 +539,38 @@ test("@webkit #1658 — WebKit resolves the travel cap against the slot's own he
 
   for (const [size, expectedSlotHeight] of FONT_SIZES) {
     // The ARITHMETIC CONTROL, and it runs first because everything below is
-    // worthless without it. A plain px translate under the cap must move the
-    // slot by exactly that much from its parked -100%. If this reads the
-    // parked position instead, the harness is measuring a transition or a
-    // stale layout and the capped reading beneath it means nothing — which is
-    // the exact hole the first draft of this test fell into.
-    const control = await resolveTransform(list, size, "translateY(-100%) translateY(20px)");
+    // worthless without it. A small plain-px translate on the track must move
+    // the first row by exactly that much. If this reads 0 instead, the harness
+    // is measuring a transition or a stale layout and the reading beneath it
+    // means nothing — which is the exact hole the first draft of this test
+    // fell into, back when it measured a cap.
+    const control = await resolveTrackTravel(list, size, "translateY(20px)");
     expect(control.slotHeight, `slot height at --font-size: ${size}`).toBeCloseTo(
       expectedSlotHeight,
       0,
     );
-    expect(control.offset, `plain-px control at --font-size: ${size}`).toBeCloseTo(
-      20 - expectedSlotHeight,
-      0,
-    );
+    expect(control.gap, `plain-px control at --font-size: ${size}`).toBeCloseTo(20, 0);
 
     // The declaration the pane actually writes at full travel, resolved by the
-    // engine the bug was reported from. `min(<px>, 100%)` is a CSS math
-    // function over MIXED UNITS inside a transform: chromium resolving it says
-    // nothing about WebKit, and if WebKit did not resolve it the slot would
-    // stay parked out of sight — not "the cap is off by a few px" but the pull
-    // no longer following the finger at all, on the only engine vjt has, with
-    // every other gate in this repo green. That is the empty-green class, and
-    // this line is what closes it.
+    // engine the bug was reported from — and the two halves fail differently.
+    //
+    // `gap` is the plain half: WebKit applied the ancestor translate, so the
+    // rows moved. `overlap` is the half chromium cannot answer: the slot's own
+    // parked offset is a PERCENTAGE (`translateY(-100%)`) that resolves against
+    // the SLOT's box, not the track's, and the invariant is an identity only if
+    // the engine composes those two correctly. An engine that resolved the
+    // percentage against the wrong box puts the spinner straight back on top of
+    // the first row — the 1.3.0 defect, on the only engine vjt has, with every
+    // chromium gate in this repo green. That is the empty-green class.
     //
     // Coupled BY HAND to `pulledTransform` in src/DirectoryPane.tsx: this is an
     // ENGINE contract, so it names the declaration rather than importing it,
-    // exactly as the CSS-contract test below names `pan-y`. Change the cap's
+    // exactly as the CSS-contract test below names `pan-y`. Change the travel's
     // FORM in the pane and this string must move with it — the chromium arm
     // above is what keeps the pane honest about producing it.
-    const capped = await resolveTransform(
-      list,
-      size,
-      "translateY(-100%) translateY(min(400px, 100%))",
-    );
-    expect(capped.offset, `capped travel at --font-size: ${size} (${capped.computed})`).toBeCloseTo(
-      0,
-      0,
-    );
+    const full = await resolveTrackTravel(list, size, "translateY(400px)");
+    expect(full.gap, `rows carried at --font-size: ${size} (${full.computed})`).toBeCloseTo(400, 0);
+    expect(full.overlap, `slot/row overlap at --font-size: ${size}`).toBeCloseTo(0, 0);
   }
 });
 

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -64,41 +64,40 @@ import { MircBody } from "./MircText";
 // the viewport stays steady while rows update from a progress ping or an
 // append; a REPLACE that shrinks the list snaps back to the top.
 
-// #1445 — the pull slot rests at `translateY(-100%)`, parked one slot-height
-// above the list's top edge and clipped there by the scroller's overflow. An
-// inline transform REPLACES that declaration wholesale, so the pulled paint
-// has to re-state the parked offset or the slot drops into the rows by its own
-// height instead of sliding in from above. Same trap #1438 hit with the media
-// viewer's centering transform, on a different element.
+// #1658 point 3 — the pull moves the TRACK, and the track carries everything:
+// the parked slot AND the rows. That is the whole design, and it is worth
+// stating as geometry because the geometry is what makes the strong invariant
+// free.
 //
-// Two `translateY` functions rather than one `calc`: they compose to the same
-// matrix, and the resolved form a test can read is `-slotHeight + dy` either
-// way — but this one is legible in an assertion and needs no CSS arithmetic.
+// Inside the track the slot occupies `[-slotHeight, 0]` (its own
+// `translateY(-100%)`, which lives in the stylesheet) and the rows start at 0.
+// Translate the track by `dy` and the slot's bottom edge lands on `dy` — which
+// is exactly where the first row's top edge lands. So:
 //
-// #1658 — the travel caps at `100%`, the slot's OWN height, and the cap lives
-// in the CSS rather than in JS because there is no number to put in JS. The
-// slot is `2.5rem` and cic's root font-size is a USER PREFERENCE
-// (`lib/fontSize.ts` writes `--font-size` on <html>: S=12px … XXL=20px), so
-// the slot is anywhere from 30px to 50px and can change while this pane is
-// open. A px constant would be right for one of the five sizes; a percentage
-// in `translateY` resolves against the element's own height, so the cap and
-// the parked offset are the same unit, the same fact, and read live.
+//   slot bottom ≡ first row top, at EVERY dy
 //
-// It used to cap at `PULL_COMMIT_PX` (80), which is more than the slot at
-// every size: at full travel the slot sat 30-50px BELOW the list's top edge —
-// a whole spinner parked inside the rows, which is the overlap vjt reported
-// on 1.3.0. The old comment claimed the cap existed to stop exactly that.
+// Not a bound that holds at the distances a test happens to sample: an
+// identity, because the two are one rigid body under one transform. The
+// spinner rides in the space the rows open and cannot be made to overlap them
+// by any later edit to either one — there is no second number to keep in step.
 //
-// 🔴 What this buys is the WEAKER of the two invariants available, on purpose:
-// the slot never travels PAST the list's top edge. It does not buy "the slot
-// never overlaps a row", and that one is not on offer here — the slot is
-// `position: absolute; top: 0` inside a scroller whose rows also start at
-// y=0, so every position where the spinner is visible at all is a position
-// where it covers the top band of the first row. Making the rows move out of
-// its way is a different change (#1658 point 3, not started), and until it
-// lands the honest statement is the flush line. Asserting the strong one here
-// would be asserting something false.
-const pulledTransform = (dy: number): string => `translateY(-100%) translateY(min(${dy}px, 100%))`;
+// What this REPLACED, and why none of it is a loss:
+//
+//   * The paint used to go on the slot as `translateY(-100%) translateY(...)`,
+//     re-stating the parked offset because an inline transform replaces the
+//     rule wholesale (the #1438 trap). The pane writes no transform to the slot
+//     at all now, so the parked offset stays in the stylesheet where nothing
+//     can replace it and the trap is gone rather than guarded.
+//   * The travel used to cap at `min(dy, 100%)`, the slot's own height. That
+//     cap existed for ONE reason — keeping the spinner off rows that stood
+//     still — and with the rows moving there is no collision left to bound.
+//     🔴 Removed rather than retuned, deliberately: any cap makes the list stop
+//     following the finger past it, which is the defect this issue is about, in
+//     smaller print. Where the travel should ease off past the commit distance
+//     is a FEEL question and needs a constant measured on a phone; the honest
+//     floor to calibrate from is the finger's own distance, and damping is
+//     additive afterwards. vjt's call, as `PULL_COMMIT_PX`'s own comment says.
+const pulledTransform = (dy: number): string => `translateY(${dy}px)`;
 
 // The spinner is legible before the commit point, not after it: the ramp
 // reaches full exactly where the release starts spending a capture, so the
@@ -260,6 +259,7 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   // <Show when={page()}> and only rendered once a page is in the store).
   let containerRef: HTMLDivElement | undefined;
   let pullSlotRef: HTMLDivElement | undefined;
+  let pullTrackRef: HTMLDivElement | undefined;
   let savedScrollTop = 0;
   // The slug currently shown — kept in sync by the effect so onCleanup can
   // reset the right slug without reading props during disposal.
@@ -376,15 +376,25 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   // RENDERS from the pulled distance, and a signal here would run the reactive
   // graph once per touchmove to move one element. Same call MediaViewerModal
   // makes for the dismiss drag it mirrors.
+  // #1658 point 3 — TWO elements, one per axis, and the split is the point.
+  // The TRACK carries the placement (slot + rows together, so they cannot
+  // disagree); the SLOT carries the ramp, which is a different axis with a
+  // different distance and must not be recomputed from the travel.
   const paintPull = (dy: number): void => {
+    const track = pullTrackRef;
     const slot = pullSlotRef;
-    if (slot === undefined) return;
-    slot.style.transform = pulledTransform(dy);
+    if (track === undefined || slot === undefined) return;
+    track.style.transform = pulledTransform(dy);
     slot.style.opacity = String(pulledOpacity(dy));
   };
 
+  // Both, always. The travel and the ramp are painted on different elements
+  // now, so a cleanup that clears one and forgets the other does not leave a
+  // hung spinner — it leaves the whole channel list parked down the pane for
+  // as long as it lives, which is a louder version of the bug `onCommit` was
+  // taught to clear.
   const unpaintPull = (): void => {
-    pullSlotRef?.style.removeProperty("transform");
+    pullTrackRef?.style.removeProperty("transform");
     pullSlotRef?.style.removeProperty("opacity");
   };
 
@@ -538,33 +548,52 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
                 if (containerRef) savedScrollTop = containerRef.scrollTop;
               }}
             >
-              {/* #1445 — the pulled affordance. Absolutely positioned INSIDE
-                  the scroller: an absolute child is placed against the
-                  scrolled content origin, and the pull exists only at
-                  scrollTop 0, so the two origins coincide by construction —
-                  which buys the plain descendant selector the stylesheet needs
-                  to drop the snap-back transition while a finger is driving.
-                  aria-hidden: the outcome it announces is the Refresh button
-                  going to "Refreshing…", which is already in the a11y tree. */}
-              <div class="directory-pull-slot" aria-hidden="true" ref={pullSlotRef}>
-                <span class="directory-pull-spinner" />
-              </div>
-              <ul class="directory-list-inner">
-                <For each={p().entries}>
-                  {(entry) => <DirectoryRow entry={entry} networkSlug={props.networkSlug} />}
-                </For>
-              </ul>
-              {/* #677 — load-more sentinel: present only while the server
-                  reports another page (next_cursor). IntersectionObserver on
-                  it drives loadMore; it unmounts when the list is exhausted. */}
-              <Show when={p().next_cursor !== null}>
-                <div class="directory-sentinel" aria-hidden="true" ref={attachSentinel} />
-              </Show>
-              <Show when={isLoadingMore(props.networkSlug)}>
-                <div class="directory-loading-more muted" role="status">
-                  Loading more…
+              {/* #1658 point 3 — the pull TRACK: everything the finger drags,
+                  in one box, moved by one transform. It wraps the slot AND the
+                  rows on purpose — that is what makes "the spinner never
+                  covers a row" a property of the markup instead of an
+                  arithmetic relation between two paints that a later edit
+                  could break. It is the containing block for the absolutely
+                  positioned slot below (`position: relative` in the
+                  stylesheet), which puts the slot's origin at the top of the
+                  content — the same place `.directory-list` put it before, so
+                  nothing moves at rest.
+                  A wrapper level is safe here, checked rather than assumed: no
+                  rule in default.css selects a DIRECT child of
+                  `.directory-list`, `attachSentinel` reaches its observer root
+                  through `closest()`, and a transform does not touch layout,
+                  so scrollHeight and the pane's scroll-preservation effect are
+                  untouched. */}
+              <div class="directory-pull-track" ref={pullTrackRef}>
+                {/* #1445 — the pulled affordance. Absolutely positioned, and
+                    it keeps its parked `translateY(-100%)` in the STYLESHEET:
+                    the pane no longer writes a transform here, so the #1438
+                    trap (an inline transform replacing the rule wholesale) has
+                    nothing left to catch. Only the opacity ramp is painted
+                    inline. aria-hidden: the outcome it announces is the
+                    Refresh button going to "Refreshing…", which is already in
+                    the a11y tree. */}
+                <div class="directory-pull-slot" aria-hidden="true" ref={pullSlotRef}>
+                  <span class="directory-pull-spinner" />
                 </div>
-              </Show>
+                <ul class="directory-list-inner">
+                  <For each={p().entries}>
+                    {(entry) => <DirectoryRow entry={entry} networkSlug={props.networkSlug} />}
+                  </For>
+                </ul>
+                {/* #677 — load-more sentinel: present only while the server
+                    reports another page (next_cursor). IntersectionObserver on
+                    it drives loadMore; it unmounts when the list is
+                    exhausted. */}
+                <Show when={p().next_cursor !== null}>
+                  <div class="directory-sentinel" aria-hidden="true" ref={attachSentinel} />
+                </Show>
+                <Show when={isLoadingMore(props.networkSlug)}>
+                  <div class="directory-loading-more muted" role="status">
+                    Loading more…
+                  </div>
+                </Show>
+              </div>
             </div>
           </>
         )}

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -862,6 +862,15 @@ describe("DirectoryPane", () => {
       return el;
     };
 
+    // #1658 point 3 — the one element the pull moves. The slot and the rows
+    // live INSIDE it, so the single transform written here carries both and
+    // they cannot drift apart.
+    const trackIn = (container: HTMLElement): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(".directory-pull-track");
+      if (el === null) throw new Error("no pull track rendered");
+      return el;
+    };
+
     // Finger down and dragged to `dy`, still on the glass — the mid-pull paint
     // exists only before the release wipes it. TWO moves because the binder
     // claims LATE: it decides on a touchmove, never on the touchstart.
@@ -904,58 +913,62 @@ describe("DirectoryPane", () => {
       expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
     });
 
-    // #1658 — 20px, not half the commit distance as this drag used to be. The
-    // travel now caps at the slot's OWN height, and the slot is `2.5rem`
-    // against a root font-size the user picks (`lib/fontSize.ts`: S=12px …
-    // XXL=20px ⇒ 30px … 50px). 40px is over that cap at three of the five
-    // sizes; 20px is under it at all five, so this reads the follow and not
-    // the clamp. The clamp has its own test below.
-    it("the slot follows the finger while it is down", () => {
+    // #1658 point 3 — the whole of the defect vjt kept seeing: only the
+    // spinner moved. What the finger drags now is the TRACK, and the rows are
+    // inside it, so "the list follows the finger" is the same statement as
+    // "the paint happened".
+    it("the list's CONTENT follows the finger, not just the slot", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
 
       pullTo(listIn(container), 20);
 
-      expect(slotIn(container).style.transform).toContain("translateY(min(20px, 100%))");
+      const track = trackIn(container);
+      expect(track.style.transform).toBe("translateY(20px)");
+      // The rows are INSIDE the element that moved. Without this the assertion
+      // above is satisfied by a track that translates an empty box beside a
+      // list standing still — which is the defect, wearing the fix's name.
+      expect(track.querySelector(".directory-list-inner")).not.toBeNull();
+      // And so is the slot: ONE transform carries both, which is why the
+      // spinner cannot land on top of a row. The geometry that follows from it
+      // is asserted in the browser (e2e), where there is layout to measure.
+      expect(track.querySelector(".directory-pull-slot")).not.toBeNull();
     });
 
-    it("keeps the slot's parked offset in the pulled transform (an inline transform replaces the rule)", () => {
+    // #1658 point 3 — the inverse of the test this replaces. The pane used to
+    // write `translateY(-100%) translateY(min(dy, 100%))` onto the SLOT: the
+    // parked offset had to be re-stated because an inline transform replaces
+    // the rule wholesale (the #1438 lesson), and the `min(…, 100%)` capped the
+    // travel at the slot's own height to keep the spinner off the rows.
+    //
+    // Both are gone, and neither is a loss. The slot is carried by its
+    // ancestor now, so the parked `translateY(-100%)` stays in the stylesheet
+    // where nothing can replace it, and the cap has nothing left to prevent.
+    it("writes no inline transform to the slot — the parked offset stays in the stylesheet", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
 
       pullTo(listIn(container), Math.round(PULL_COMMIT_PX / 2));
 
-      // The slot rests at translateY(-100%), clipped above the list's top
-      // edge. An inline transform REPLACES that declaration wholesale, so a
-      // paint that forgot it would drop the slot into the rows by its own
-      // height instead of sliding it in from above — the #1438 lesson, on a
-      // different element.
-      expect(slotIn(container).style.transform).toContain("translateY(-100%)");
+      expect(slotIn(container).style.transform).toBe("");
     });
 
-    // #1658 — the cap used to be `PULL_COMMIT_PX`, which is TWICE the slot at
-    // the default font size: the paint drove the slot a whole extra
-    // slot-height past the list's top edge and parked the spinner inside the
-    // rows. What this pins is not a smaller number but the ABSENCE of a
-    // number: the finger's distance goes through unclamped and the clamp is
-    // `100%` — the slot's own height, resolved by the engine against whatever
-    // the root font-size currently is. Reinstating any JS clamp turns the
-    // received string into a bare `translateY(<n>px)` and this red.
+    // #1658 point 3 — the cap is GONE, and this pins its absence rather than a
+    // new number. It existed only to stop the spinner sinking into rows that
+    // stood still; with the rows carried by the same transform there is no
+    // collision left to bound, so the travel follows the finger the whole way
+    // and where it stops is a question of feel, not of geometry.
     //
-    // jsdom resolves no layout, so this is the CONTRACT and not the geometry.
-    // That the slot actually stops flush with the list's top edge — at three
-    // font sizes, which is what proves the cap is slot-relative and not a 35
-    // in disguise — is asserted in the browser, in
-    // e2e/tests/issue1445-directory-pull-refresh.spec.ts.
-    it("the paint is capped by the slot's OWN height, not by the commit distance", () => {
+    // Reinstating any clamp — in JS or as a `min()` in the declaration — turns
+    // this string into something other than the raw distance and reds it.
+    it("the travel is UNCAPPED — the finger's distance goes through whole", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
 
       const far = PULL_COMMIT_PX * 4;
       pullTo(listIn(container), far);
 
-      const painted = slotIn(container).style.transform;
-      expect(painted).toBe(`translateY(-100%) translateY(min(${far}px, 100%))`);
+      expect(trackIn(container).style.transform).toBe(`translateY(${far}px)`);
     });
 
     // #1658 — the ramp and the travel are INDEPENDENT axes, and the fix for
@@ -989,11 +1002,11 @@ describe("DirectoryPane", () => {
 
       const list = listIn(container);
       pullTo(list, Math.round(PULL_COMMIT_PX / 2));
-      expect(slotIn(container).style.transform).not.toBe("");
+      expect(trackIn(container).style.transform).not.toBe("");
 
       fireTouch(list, "touchend", { clientX: X, clientY: Y0 + Math.round(PULL_COMMIT_PX / 2) });
 
-      expect(slotIn(container).style.transform).toBe("");
+      expect(trackIn(container).style.transform).toBe("");
     });
 
     // #1658 — the release that COMMITS is a terminal too, and the pane hangs
@@ -1006,6 +1019,12 @@ describe("DirectoryPane", () => {
     // A separate test from "the release wipes the paint" above rather than a
     // widening of it: that one lifts SHORT of the commit distance, which is
     // precisely why it stayed green through the whole defect.
+    //
+    // #1658 point 3 — and the guarantee now spans TWO elements. The travel
+    // moved to the track while the ramp stayed on the slot, so a cleanup that
+    // clears one and forgets the other leaves the list itself parked 240px
+    // down the pane for the rest of its life: a worse version of the hung
+    // spinner this test was written for. Both are asserted, separately.
     it("a release that COMMITS wipes the paint too", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
@@ -1015,7 +1034,7 @@ describe("DirectoryPane", () => {
       // Pre-state, not decoration: without it a binder that never armed would
       // satisfy both assertions below by having painted nothing at all.
       expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
-      expect(slotIn(container).style.transform).toBe("");
+      expect(trackIn(container).style.transform).toBe("");
       expect(slotIn(container).style.opacity).toBe("");
     });
 

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -1036,6 +1036,14 @@ describe("DirectoryPane", () => {
       expect(triggerRefreshMock).toHaveBeenCalledWith(SLUG);
       expect(trackIn(container).style.transform).toBe("");
       expect(slotIn(container).style.opacity).toBe("");
+      // The third reading, and a MUTANT found the hole it fills: paint the
+      // travel onto the slot instead of the track — the pre-point-3 defect,
+      // exactly — and the two assertions above stay GREEN, because the track
+      // is trivially unpainted and the ramp is still cleared. This one is the
+      // one that sees it. The pane must write no transform to this element at
+      // any point, so "" here is the same statement at rest and after a
+      // commit.
+      expect(slotIn(container).style.transform).toBe("");
     });
 
     it("a drag that starts scrolled away from the top is left to native scroll", () => {

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -63,6 +63,41 @@ export function nestedRuleBodies(selector: string): string[] {
   return out;
 }
 
+/**
+ * The body of every `@media (hover: hover)` block, brace-MATCHED rather than
+ * regex-captured: such a block contains whole rules, and the `[^{}]` classes
+ * the helpers above rely on cannot span a nested brace. Comments stripped,
+ * same as the rest of this module, so prose naming a selector can neither
+ * satisfy nor trip an assertion about it.
+ *
+ * Throws when the sheet carries no such gate at all, for the same reason
+ * `ruleBody` throws on an absent rule: a test asking "is this rule gated?"
+ * must not pass because the GATE vanished.
+ */
+export function hoverGatedBlocks(): string[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const opener = /@media\s*\(\s*hover\s*:\s*hover\s*\)\s*\{/g;
+  const out: string[] = [];
+  let match = opener.exec(stripped);
+  while (match !== null) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let i = start;
+    while (i < stripped.length && depth > 0) {
+      const ch = stripped[i];
+      if (ch === "{") depth += 1;
+      else if (ch === "}") depth -= 1;
+      i += 1;
+    }
+    if (depth !== 0) throw new Error("unbalanced @media (hover: hover) block in default.css");
+    out.push(stripped.slice(start, i - 1));
+    opener.lastIndex = i;
+    match = opener.exec(stripped);
+  }
+  if (out.length === 0) throw new Error("no @media (hover: hover) gate found in default.css");
+  return out;
+}
+
 export function ruleBody(selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, "m");

--- a/cicchetto/src/__tests__/hoverGate.test.ts
+++ b/cicchetto/src/__tests__/hoverGate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { hoverGatedBlocks, themeCss } from "./helpers/themeCss";
+
+// #1658 second defect — a scroll must not light up the row under the finger.
+//
+// A touch browser SYNTHESIZES `:hover` on the element the finger lands on and
+// LATCHES it: put a finger down to scroll the channel directory — or to pull it
+// for a refresh, which is the whole of #1658's first defect — and the row under
+// it paints, and STAYS painted after the finger leaves. This sheet already
+// knows the cure and carries it at three other sites; `.directory-row-join` was
+// left out.
+//
+// WHY A SOURCE-LEVEL TEST AND NOT A BEHAVIOURAL ONE. The behaviour needs a
+// browser that reports `(hover: none)`, and Playwright cannot emulate that:
+// `page.emulateMedia()` covers `media`, `colorScheme`, `reducedMotion`,
+// `forcedColors` and `contrast` — there is no `hover` key, so no project in
+// this repo can put the media query into its false branch on purpose. Nor does
+// jsdom apply a stylesheet. What IS deterministic is what the cascade is ASKED
+// to do, and that is what these read. They say nothing about what any engine
+// paints; vjt's phone is the only witness for that half.
+const SELECTOR = ".directory-row-join:hover";
+
+// Comments stripped for the same reason `themeCss`'s helpers strip them: the
+// gate's own why-comment names the selector, and prose must not be able to
+// stand in for a rule.
+const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("#1658 — the directory row's hover fill is gated on hover-capable input", () => {
+  // The CONTROL, and it runs first because the assertion below passes just as
+  // well against a sheet that deleted the rule outright. Gating an affordance
+  // and removing it are different changes and only one of them was asked for.
+  it("still declares the fill it always declared", () => {
+    expect(occurrences(stripped, SELECTOR), `${SELECTOR} rules in default.css`).toBe(1);
+    expect(stripped).toMatch(/\.directory-row-join:hover\s*\{[^}]*background:\s*var\(--border\)/);
+  });
+
+  // The discriminator. Counted rather than "at least one is gated": a second,
+  // ungated copy added later would satisfy an existence check while restoring
+  // the exact defect. Every declaration of it must be behind the query, or none
+  // of them is.
+  it("declares it ONLY inside a (hover: hover) gate", () => {
+    const total = occurrences(stripped, SELECTOR);
+    const gated = occurrences(hoverGatedBlocks().join("\n"), SELECTOR);
+
+    expect(gated, `${SELECTOR} declarations inside @media (hover: hover)`).toBe(total);
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1209,9 +1209,14 @@ html.overlay-open #root > div {
   .directory-pull-spinner {
     animation: none;
   }
-  /* #1445 — same call as the swipe-to-reply snap-back below: the slot still
+  /* #1445 — same call as the swipe-to-reply snap-back below: the pull still
      follows the finger (that is the gesture's own feedback, not decoration);
-     only the eased return is dropped, so it jumps home. */
+     only the eased return is dropped, so it jumps home.
+     #1658 point 3 — the track joined the slot here because the TRAVEL moved
+     onto it. Leaving it out would have kept a 150ms eased return on the whole
+     channel list for a user who asked for no motion — the one animation in
+     this pair that is actually large. */
+  .directory-pull-track,
   .directory-pull-slot {
     transition: none;
   }
@@ -11804,12 +11809,32 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   touch-action: pan-y;
 }
 
-/* #1445 — the pull-to-refresh slot. Parked one slot-height ABOVE the list's
-   top edge, where the scroller's own overflow clips it, and slid into view by
-   the gesture's inline transform (DirectoryPane's `pulledTransform`, which
-   re-states this parked offset because an inline transform replaces the
-   declaration wholesale). `pointer-events: none` so a slot mid-slide never
-   swallows a tap meant for the first row. */
+/* #1658 point 3 — the pull TRACK: everything the finger drags, moved as one
+   body. The slot and the rows are both inside it, so the single transform
+   DirectoryPane writes here places both and the spinner rides in the space the
+   rows open rather than sliding over them.
+   `position: relative` makes it the containing block for the absolutely
+   positioned slot below. That puts the slot's origin at the top of the
+   content, which is where `.directory-list` (also `relative`, and a scroller,
+   so its absolute children are placed against the SCROLLED content origin) put
+   it before — nothing moves at rest.
+   The eased snap-back lives here now, on the transform, because the transform
+   moved here; the slot below keeps only its own opacity ease. */
+.directory-pull-track {
+  position: relative;
+  transition: transform 150ms ease-out;
+}
+
+/* #1445 — the pull-to-refresh slot. Parked one slot-height ABOVE the track's
+   top edge, where the scroller's own overflow clips it, and carried into view
+   by the TRACK's transform — not by one of its own.
+   🔴 #1658 point 3 — this `translateY(-100%)` is no longer re-stated by any
+   inline paint, and that is deliberate: an inline transform replaces the
+   declaration wholesale (the #1438 trap), so keeping the parked offset in the
+   stylesheet and moving the ancestor instead removes the trap rather than
+   guarding against it. Nothing writes `transform` on this element.
+   `pointer-events: none` so a slot mid-slide never swallows a tap meant for
+   the first row. */
 .directory-pull-slot {
   position: absolute;
   top: 0;
@@ -11821,17 +11846,17 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   height: 2.5rem;
   opacity: 0;
   transform: translateY(-100%);
-  transition:
-    transform 150ms ease-out,
-    opacity 150ms ease-out;
+  transition: opacity 150ms ease-out;
   pointer-events: none;
 }
 
 /* While a finger is driving a CLAIMED pull the binder wears
-   `pull-gesture-active` on the scroller, and the slot must track the finger
-   rather than ease behind it. Reachable as a plain descendant selector only
-   because the slot lives INSIDE the bound element — the reason it is an
-   absolute child rather than a sibling above the list. */
+   `pull-gesture-active` on the scroller, and BOTH painted axes must track the
+   finger rather than ease behind it — the track's travel and the slot's ramp.
+   Reachable as plain descendant selectors only because both live INSIDE the
+   bound element, which is why the slot is an absolute child rather than a
+   sibling above the list. */
+.directory-list.pull-gesture-active .directory-pull-track,
 .directory-list.pull-gesture-active .directory-pull-slot {
   transition: none;
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -11906,8 +11906,24 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   cursor: pointer;
 }
 
-.directory-row-join:hover {
-  background: var(--border);
+/* #1658 — gate the row fill on hover-capable input. A touch browser
+   SYNTHESIZES `:hover` on the element under the finger and LATCHES it, so a
+   finger put down to scroll this list — or to pull it for a refresh, which is
+   the other half of #1658 — painted the row it landed on and left it painted
+   after the lift. vjt reported it from a phone on 1.3.0.
+   The FOURTH instance of a cure this sheet already carries at
+   `.scroll-to-bottom-btn`, `.members-pane li .member-name` and
+   `.next-active-btn` — three, not the eight the issue claims (measured). Named
+   by selector rather than by line number so the citation cannot rot.
+   `(hover: hover)` tests the PRIMARY input, so touch-only and touch-primary
+   devices skip the rule cleanly while a hybrid (Surface, iPad+trackpad)
+   honours it.
+   A PRESSED affordance on touch would be `:active` and is a SEPARATE
+   decision — deliberately not smuggled in here (#1658 says so outright). */
+@media (hover: hover) {
+  .directory-row-join:hover {
+    background: var(--border);
+  }
 }
 
 /* Name + featured + joined labels. Mobile: a wrapping flex ROW so the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57641,3 +57641,116 @@ the smaller, invisible deadline is what it is really measuring.**
 - **The 1.3.0 herd's attribution stays closed as non-establishable**
   (#1657): the 42 stack-carrying deadline lines were overwritten by
   `run_erl` rotation. Nothing here reopens it.
+<!-- entry #1658b -->
+
+---
+
+## 2026-08-22 — #1658b: the rows follow the finger, and what that lets the code delete
+
+Point 3 of #1658, the half vjt kept seeing on a phone after the other two
+landed: pulling the channel directory moved only the spinner. The slot is
+`position: absolute; top: 0` inside the scroller and the rows start at `y=0`
+too, so **every position where the spinner was visible was a position where it
+covered the first row's top band**. The code said so itself — the comment on
+`pulledTransform` declined to assert the strong invariant on the grounds that
+it was false, and asserted the flush line instead ("the slot never travels
+PAST the top edge"). That was the honest ceiling while the rows stood still.
+
+**The design: one rigid track, one transform.** Everything the finger drags —
+the parked slot AND the rows — now lives in a single `.directory-pull-track`,
+and the pull writes one `translateY(dy)` onto it. Inside the track the slot
+occupies `[-slotHeight, 0]` and the rows start at `0`, so translating by `dy`
+puts the slot's bottom edge and the first row's top edge both at `dy`:
+
+    slot bottom ≡ first row top, at EVERY dy
+
+**That is an identity, not a bound**, and the distinction is the whole reason
+this shape was chosen over the obvious one (translate the rows, keep capping
+the slot). Two separately-painted elements would satisfy the invariant by
+arithmetic that a later edit to either one could get wrong; one rigid body
+under one transform has no second number to keep in step. The invariant stops
+being something the tests check and becomes something the markup cannot
+violate.
+
+🔴 **The travel cap is REMOVED, and that was the decision the issue asked to
+have named.** `min(dy, 100%)` (#1658 point 2, `c7cb048e`) existed for exactly
+one reason: keeping the spinner off rows that stood still. With the rows
+carried there is no collision left to bound, so the question stops being
+geometry and becomes feel. It was removed rather than retuned because **any
+cap makes the list stop following the finger past it** — the reported defect
+in smaller print, arriving at the moment the gesture is most committed. The
+alternative worth having is damping past the commit point; that needs a
+constant measured on a device, and `PULL_COMMIT_PX`'s own comment already
+records that nothing about this gesture was verified on a phone. An unbounded
+linear follow is the honest floor to calibrate FROM, and damping is additive
+afterwards. The other coherent look — the slot settling at the top edge while
+the gap keeps growing beneath it — is deliberately not taken: it satisfies the
+invariant too, but by hand-maintained arithmetic across two transforms.
+
+**Two things fall out for free.** The pane writes no transform to the slot at
+all, so the parked `translateY(-100%)` stays in the stylesheet and the #1438
+trap (an inline transform replacing the declaration wholesale) is *gone*
+rather than guarded against. And the opacity ramp keeps its own axis
+untouched — painted on the slot, computed from the commit distance, never
+recomputed from the travel, which is what makes it reach full at the one
+distance where full is the point.
+
+**The `a2dacafa` guarantee now spans two elements, which raises its stakes.**
+A commit-path cleanup that clears one and forgets the other no longer leaves a
+hung spinner but the whole channel list parked a few hundred pixels down the
+pane. Both are cleared and both are asserted, separately.
+
+**A mutant found a hole in the oracle and it is worth recording as a
+pattern.** Mutating the paint to write the travel onto the slot instead of the
+track — which is precisely the pre-point-3 defect, not an invented mutation —
+left "a release that COMMITS wipes the paint too" GREEN: under that mutant the
+track is trivially unpainted and the ramp is still cleared, so both of its
+assertions passed while a stale transform sat on the slot. **A cleanup test
+that only reads the elements the CURRENT code paints cannot see paint that
+went to the wrong element.** The third assertion (the slot's transform is
+empty, at rest and after a commit alike) is what distinguishes "nothing was
+painted here" from "the paint landed elsewhere".
+
+**The webkit arm was re-aimed, not dropped.** It used to ask whether WebKit
+resolved `translateY(min(<px>, 100%))`, a mixed-unit CSS math function inside
+a transform; point 3 deleted that declaration from production. The engine
+question that survives is sharper: the invariant is an identity only if the
+engine composes the track's px translate with the slot's own PERCENTAGE
+offset, which resolves against the slot's box and not the track's. An engine
+getting that wrong puts the spinner straight back on the first row with every
+chromium gate green — the empty-green class. The division of labour stands:
+chromium owns the PANE half (the declaration comes from a real finger), webkit
+owns the ENGINE half (`new Touch(...)` is an `Illegal constructor` there, so
+no gesture is synthesizable on that project).
+
+**Second defect, same pane: a scroll must not light up the row under the
+finger.** `.directory-row-join:hover { background: var(--border) }` was
+ungated, and a touch browser SYNTHESIZES `:hover` on the element under the
+finger and LATCHES it — so putting a finger down to scroll, or to drive the
+pull above, painted the row it landed on and left it painted after the lift.
+Gated behind `@media (hover: hover)`, which tests the PRIMARY input.
+**Measured correction to the issue text: this stylesheet applies that cure
+THREE times, not eight** (`.scroll-to-bottom-btn`,
+`.members-pane li .member-name`, `.next-active-btn`, brace-matched over the
+three gate blocks); the new one is the fourth. `:active` was NOT smuggled in —
+a pressed affordance on touch is a separate decision.
+
+**The hover guard is source-level and that is not a shortcut.** The behaviour
+needs a browser reporting `(hover: none)`, and Playwright cannot emulate one:
+`page.emulateMedia()` accepts `colorScheme`, `contrast`, `forcedColors`,
+`media` and `reducedMotion` — there is no `hover` key (verified against the
+installed `playwright-core` types), so no project in this repo can put the
+query into its false branch on purpose, and jsdom applies no stylesheet at
+all. What is deterministic is what the cascade is ASKED to do. The test
+COUNTS: every declaration of the selector must sit inside a hover gate, so a
+second ungated copy added later reds it where an existence check would pass,
+and a control ahead of it pins that the fill still exists — "gate it" and
+"delete it" are different changes.
+
+**Not established here, and left open on purpose.** The FEEL, and with it the
+whole iOS question: whether the follow is smooth, whether an uncapped travel
+is the right sensation, and above all whether iOS elects our gesture rather
+than its own overscroll — the binder claims LATE, on a touchmove, and a real
+device may have committed to a pan before that claim lands. Playwright's
+WebKit is not vjt's phone. The assertions here are DOM facts; the calibration
+is a device call, as it was for #213 and #1438.


### PR DESCRIPTION
Closes nothing by keyword — deliberately, per house rule. This is issue #1658,
points 3 and the second defect reported alongside it.

## What was wrong

**Point 3.** Pulling the channel directory moved only the spinner. The slot is
`position: absolute; top: 0` inside the scroller and the rows start at `y = 0`
too, so every position where the spinner was visible at all was a position
where it covered the first row's top band. The code said so itself: the
comment on `pulledTransform` declined to assert the strong invariant on the
grounds that it was false, and asserted the flush line instead. That was the
honest ceiling while the rows stood still.

**Second defect.** `.directory-row-join:hover { background: var(--border) }`
was ungated. A touch browser synthesizes `:hover` on the element under the
finger and LATCHES it, so putting a finger down to scroll the list — or to
drive the pull above — painted the row it landed on and left it painted after
the lift.

## The design, and why this shape

Everything the finger drags — the parked slot AND the rows — now lives in one
`.directory-pull-track`, moved by ONE transform. Inside the track the slot
occupies `[-slotHeight, 0]` and the rows start at `0`, so translating by `dy`
lands the slot's bottom edge and the first row's top edge both on `dy`:

    slot bottom ≡ first row top, at EVERY dy

**That is an identity, not a bound.** The obvious alternative — translate the
rows, keep capping the slot — satisfies the invariant too, but by arithmetic
across two independently painted elements that a later edit to either one can
get wrong. One rigid body under one transform has no second number to keep in
step, so the invariant stops being something the tests check and becomes
something the markup cannot violate.

## The cap is REMOVED, and naming that was part of the ask

`min(dy, 100%)` existed for exactly one reason: keeping the spinner off rows
that stood still. With the rows carried there is no collision left to bound,
so the question stops being geometry and becomes feel.

Removed rather than retuned because **any cap makes the list stop following
the finger past it** — the reported defect in smaller print, arriving at the
moment the gesture is most committed. Damping past the commit point is the
alternative worth having, and it needs a constant measured on a device;
`PULL_COMMIT_PX`'s own comment already records that nothing about this gesture
was verified on a phone. An unbounded linear follow is the honest floor to
calibrate FROM, and damping is additive afterwards. The other coherent look —
the slot settling at the top edge while the gap grows beneath it — is named in
DESIGN_NOTES so it can be asked for after the feel is judged on a phone.

Two things fall out for free: the pane writes no transform to the slot at all,
so the parked `translateY(-100%)` stays in the stylesheet and the #1438 trap
(an inline transform replacing the declaration wholesale) is *gone* rather
than guarded; and the opacity ramp keeps its own axis, untouched.

The `a2dacafa` guarantee now spans two elements, which raises its stakes: a
commit-path cleanup that clears one and forgets the other strands the whole
channel list down the pane rather than just a spinner. Both are cleared, both
asserted.

## A mutant found a hole in the oracle

Mutating the paint to write the travel onto the SLOT instead of the track —
which is precisely the pre-point-3 defect, not an invented mutation — left "a
release that COMMITS wipes the paint too" GREEN: the track is trivially
unpainted under that mutant and the ramp is still cleared, so both assertions
passed while a stale transform sat on the slot. **A cleanup test that only
reads the elements the CURRENT code paints cannot see paint that went to the
wrong element.** Third assertion added; the pull group goes 4 red → 5 under
the mutant, and the 5th is that one. Recorded in DESIGN_NOTES as a pattern.

## The webkit arm was re-aimed, not dropped

It used to ask whether WebKit resolved `translateY(min(<px>, 100%))`; that
declaration no longer exists in production. The surviving engine question is
sharper: the invariant is an identity only if the engine composes the track's
px translate with the slot's own PERCENTAGE offset, which resolves against the
slot's box and not the track's. An engine getting that wrong puts the spinner
back on the first row with every chromium gate green — the empty-green class.
The division stands: chromium owns the PANE half (the declaration comes from a
real finger), webkit owns the ENGINE half (`new Touch(...)` is an
`Illegal constructor` there, so no gesture is synthesizable on that project).

## Measured corrections to the issue text

* The stylesheet applies the `@media (hover: hover)` cure **THREE** times, not
  eight — `.scroll-to-bottom-btn`, `.members-pane li .member-name`,
  `.next-active-btn`, brace-matched over the three gate blocks. The new one is
  the fourth. The gate's why-comment names them by SELECTOR rather than line
  number, so the citation cannot rot.
* `:active` was NOT smuggled in. A pressed affordance on touch is a separate
  decision.

## Why the hover guard is source-level

Not a shortcut: the behaviour needs a browser reporting `(hover: none)`, and
Playwright cannot emulate one. `page.emulateMedia()` accepts `colorScheme`,
`contrast`, `forcedColors`, `media` and `reducedMotion` — there is no `hover`
key (verified against the installed `playwright-core` types), so no project in
this repo can put the query into its false branch on purpose, and jsdom
applies no stylesheet at all. What is deterministic is what the cascade is
ASKED to do. The test COUNTS every declaration of the selector rather than
checking one exists, so a second ungated copy added later reds it; a control
ahead of it pins that the fill still exists, because "gate it" and "delete it"
are different changes.

## Gates run locally

* `bun run check` — 4/4 stages, including lock drift (so the tree is
  attributable), biome, tsc src and tsc e2e
* `bun run build`
* vitest — **5826 passed / 299 files**
* `scripts/design-notes-gate.sh origin/main` — 1 new entry heading, separator
  and marker present

## 🔴 NOT established, on purpose rather than by omission

* **The e2e arms have never been run.** They compile, and that is the whole of
  what can be said until they get a lane. Until then point 3 is proven as a
  CONTRACT in jsdom, not as geometry in a browser: the three geometric
  assertions (rows carried 400px, overlap 0, slot-height control at three root
  font sizes) are derived, not measured.
* **The FEEL, and with it the whole iOS question** — whether the follow is
  smooth, whether an uncapped travel is the right sensation, and above all
  whether iOS elects our gesture rather than its own overscroll. The binder
  claims LATE, on a touchmove, and a real device may have committed to a pan
  before that claim lands. Playwright's WebKit is not the reporter's phone.
* The hover fix is proven at the level of the cascade, not of behaviour, for
  the reason given above.