### PR TITLE
test(#1654): pin cic server floor to what the server speaks — half-measure, not the gate

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57754,3 +57754,94 @@ than its own overscroll — the binder claims LATE, on a touchmove, and a real
 device may have committed to a pan before that claim lands. Playwright's
 WebKit is not vjt's phone. The assertions here are DOM facts; the calibration
 is a device call, as it was for #213 and #1438.
+<!-- entry #1654 -->
+
+---
+
+## 2026-08-22 — #1654: a pin for cic's server floor, and the measured price of the gate it is not
+
+#1393d gave cic a floor for the SERVER it talks to
+(`MIN_SERVER_PROTOCOL_VERSION = 2`, `cicchetto/src/lib/serverProtocol.ts`)
+and shipped, knowingly, with nothing enforcing it. The obligation it
+carries is that narrowing any client guard to REQUIRE a field introduced
+by protocol version N obliges raising the floor to N in the same change.
+The module says so in prose beside the constant, and #1393d's own note
+concedes a sentence is not a gate.
+
+### What shipped here, and what it deliberately is not
+
+Two assertions in `test/grappa/protocol_test.exs`, next to #1379's
+`CLIENT_PROTOCOL_VERSION >= Protocol.min_version()` and reading cic's
+source the same way (`cicchetto/src` is mounted into the Elixir test
+container): the constant exists, and
+`MIN_SERVER_PROTOCOL_VERSION <= Protocol.version()`.
+
+That catches a floor raised ABOVE every server that can exist — a bundle
+that banners "server outdated" on a fully current deploy. It does **not**
+catch the defect the issue is about, which is forgetting to RAISE the
+floor: tighten a narrower onto a v5 field, leave the floor at 2, and
+`2 <= 5` still holds. The test is labelled as a half-measure in its own
+describe name so no later reader mistakes a green for coverage. The wire
+pin cannot host the real check either — `mix grappa.wire_pin`'s digest
+spans the SERVER's two generated artefacts, so a `wireNarrow.ts` edit
+moves nothing it covers.
+
+The oracle was proven by mutation, not by inspection: floor to 3 fails
+`left: 3 / right: 2`; renaming the constant fails BOTH tests with the
+named message rather than passing vacuously (Elixir's term order puts
+every atom above every integer, so a `nil` return would satisfy a `>=`
+comparison — the reason #1379's reader flunks, and the reason this one
+shares it rather than copying it).
+
+### The price of the real gate, measured
+
+A field to version-that-introduced-it ledger is the only thing that
+catches the forgotten raise. Counted by IMPORTING the generated runtime
+schema rather than grepping it (`cicchetto/src/lib/wireSchema.ts` is a
+deterministic projection of the `@type` declarations, so one slot there
+is one field a human would have to stamp):
+
+- **768 field slots** across **185** schema consts, **253** distinct
+  field names — every one of them unstamped today.
+- **169** `@type` declarations in the codegen's source set, spread over
+  **29** `lib/grappa/**/*wire.ex` modules plus three web modules
+  (`GrappaWeb.AuthJSON`, `GrappaWeb.MeJSON`, `GrappaWeb.ErrorTokens`) the
+  generated header names.
+- **0** per-field version stamps anywhere in `lib/` — a naked
+  case-insensitive grep for `@since|@wire_version|@introduced|@added_in|
+  @proto_version|@first_seen_in`, with planted positives proving the
+  pattern can match. The word `version` DOES occur 29 times in that
+  source set, so the zero is an absence of stamps, not of the search.
+
+Two findings widen the "where", and both were forced by a control that
+fired rather than by inspection. The census first claimed 185 consts
+against 169 `@type`s, which is impossible if the mapping is one-to-one:
+
+- **The stamp surface is not the wire modules.** The 16 extra consts are
+  types declared in DOMAIN modules and pulled in by reference from a wire
+  typespec — `Grappa.Admission.flow/0`, `Grappa.IRC.Identifier.casemapping/0`,
+  `Grappa.Networks.Credential.connection_state/0`,
+  `Grappa.Scrollback.Message.kind/0` and twelve more. A ledger stamped
+  only in `*wire.ex` would silently miss whatever they later grow.
+  (Cross-checked by generating the expected const name for all 169 from
+  the codegen's own rule — `S_` + `Module.split |> tl |> join` + camelize
+  — and diffing: 169 matched, 0 orphans, 16 external.)
+- **One type cannot be stamped at all.** `Grappa.Scrollback.Meta.t/0`
+  emits `{ r: "x" }` — a bare `map()`, `Record<string, unknown>`, the
+  escape hatch the codegen's own moduledoc warns defeats its purpose. Its
+  fields are declared nowhere, so no ledger can date them.
+
+**The choice is not made here.** Whether to build the ledger, adopt a
+review-time convention, or accept the half-measure is vjt's, and the
+numbers above are the input to it, not an argument for one arm.
+
+### Found in passing, not fixed
+
+Three comments in `lib/grappa/session/wire.ex` (around the
+`whois_bundle_payload` `source` field, the `window_invited` `inviter`
+field, and the `server_reply` source union) still state the pre-ruling
+rule — "additive, so no `protocol_version` bump is needed". vjt's ruling
+of 2026-08-21 reversed exactly that, and `Grappa.Protocol`'s moduledoc
+plus CLAUDE.md now say the opposite. These are module comments, not a
+chronological log, so a reader takes them as the current rule. Left for
+its own slice.

--- a/test/grappa/protocol_test.exs
+++ b/test/grappa/protocol_test.exs
@@ -10,15 +10,17 @@ defmodule Grappa.ProtocolTest do
   is exercised: `GET /api/config` (`config_controller_test.exs`) and the WS
   handshake 426 (`user_socket_test.exs`).
 
-  The last describe is the odd one out and deliberately so: it reads cic's
-  source. #1379 made cicchetto DECLARE its protocol version, which turns the
-  426 refusal from unreachable-against-cic into live-against-cic — so raising
-  `min_version/0` now bricks every un-updated bundle at the handshake. That
-  consequence has to be visible at the commit that raises the floor, and only
-  a test spanning both sides can show it. `cicchetto/src` is mounted into the
-  Elixir test container (`scripts/_lib.sh`), so this reads the change under
-  test, not main's copy — the same reasoning that put the version carrier's
-  cic half on the cic side (`version_single_source_test.exs`).
+  The last two describes are the odd ones out and deliberately so: they read
+  cic's source. #1379 made cicchetto DECLARE its protocol version, which turns
+  the 426 refusal from unreachable-against-cic into live-against-cic — so
+  raising `min_version/0` now bricks every un-updated bundle at the handshake.
+  That consequence has to be visible at the commit that raises the floor, and
+  only a test spanning both sides can show it. #1393d added the mirror-image
+  constant on cic's side and #1654 pins it here for the same reason.
+  `cicchetto/src` is mounted into the Elixir test container
+  (`scripts/_lib.sh`), so this reads the change under test, not main's copy —
+  the same reasoning that put the version carrier's cic half on the cic side
+  (`version_single_source_test.exs`).
   """
   use ExUnit.Case, async: true
 
@@ -56,18 +58,70 @@ defmodule Grappa.ProtocolTest do
     end
   end
 
-  # The integer literal cicchetto declares. Source text, not a build artifact:
+  # 🔴 THIS IS NOT THE GATE #1654 ASKS FOR. It is the half of it that can be
+  # written against facts the repo holds today, shipped as such.
+  #
+  # #1393d gave cic a floor for the SERVER it is talking to
+  # (`MIN_SERVER_PROTOCOL_VERSION`, `cicchetto/src/lib/serverProtocol.ts`):
+  # below it, a "server outdated" banner instead of envelopes silently
+  # dropped by a narrower. The obligation that comes with it is that
+  # narrowing any client guard to REQUIRE a field introduced by protocol
+  # version N obliges raising the floor to N in the same change.
+  #
+  # What these two tests catch: the floor pointing ABOVE every server that
+  # can exist — say `MIN_SERVER_PROTOCOL_VERSION = 5` while `version/0` is 2,
+  # which banners "server outdated" at every operator on a fully current
+  # deploy — and the constant vanishing altogether.
+  #
+  # 🔴 What they do NOT catch, which is precisely the defect #1654 is about:
+  # forgetting to RAISE the floor. Tighten a narrower onto a v5 field and
+  # leave the floor at 2, and `2 <= 5` still holds — this stays GREEN through
+  # exactly the edit that reintroduces the silent mode. Nor does the wire pin
+  # span it: `mix grappa.wire_pin`'s digest is taken over the SERVER's two
+  # generated artefacts, so a `wireNarrow.ts` edit moves nothing it covers.
+  #
+  # Catching the real defect needs a fact this repo does not hold — WHICH
+  # protocol version introduced each field. `priv/wire/shape.pin` is a digest
+  # of the CURRENT shape beside the CURRENT number, not a history. Building
+  # that ledger is the open half of #1654 and a design decision, not a test.
+  describe "the SERVER floor cicchetto declares (#1654) — half-measure, not the gate" do
+    @cic_server_protocol "cicchetto/src/lib/serverProtocol.ts"
+
+    test "cicchetto declares a MIN_SERVER_PROTOCOL_VERSION at all" do
+      # The carrier. Deleting or renaming the constant is how the floor
+      # silently reverts to the pre-#1393d posture where cic accepts any
+      # server and shows no banner for one too old to serve it.
+      assert is_integer(cic_min_server_protocol_version())
+    end
+
+    test "cic's server floor is at or below the protocol the server speaks" do
+      # Fails on a floor raised past `version/0` — a bundle that banners
+      # "server outdated" against the newest server that exists, which is
+      # unshippable and otherwise reaches an operator before it reaches a
+      # test. It does NOT fail on a floor left too low; see above.
+      assert cic_min_server_protocol_version() <= Protocol.version()
+    end
+  end
+
+  # An integer literal cicchetto declares. Source text, not a build artifact:
   # the point is to catch the edit, and nothing in the Elixir test container
   # can execute the bundle.
   #
   # A missing constant FLUNKS rather than returning nil, because Elixir's term
   # order puts every atom above every integer: `nil >= Protocol.min_version()`
-  # is `true`, so the floor comparison below would pass vacuously on exactly
-  # the edit it exists to catch.
-  defp cic_protocol_version do
-    case Regex.run(~r/^export const CLIENT_PROTOCOL_VERSION = (\d+);$/m, File.read!(@cic_socket)) do
+  # and `nil <= Protocol.version()` are `true` and `false` respectively — the
+  # first passes vacuously on exactly the edit it exists to catch, and neither
+  # names what actually went wrong. Both readers below compare, so both need
+  # the flunk; that shared need is why this is one function and not two.
+  defp cic_integer_constant(path, name) do
+    case Regex.run(~r/^export const #{Regex.escape(name)} = (\d+);$/m, File.read!(path)) do
       [_, digits] -> String.to_integer(digits)
-      nil -> flunk("no `export const CLIENT_PROTOCOL_VERSION = <int>;` in #{@cic_socket}")
+      nil -> flunk("no `export const #{name} = <int>;` in #{path}")
     end
   end
+
+  defp cic_protocol_version, do: cic_integer_constant(@cic_socket, "CLIENT_PROTOCOL_VERSION")
+
+  defp cic_min_server_protocol_version,
+    do: cic_integer_constant(@cic_server_protocol, "MIN_SERVER_PROTOCOL_VERSION")
 end


### PR DESCRIPTION
Ref #1654. Ships only the "cheap half-measure" the issue itself calls worth
having, and labels it as not the gate in three places: the describe name, a
comment block above it, and the commit body.

## What lands

`test/grappa/protocol_test.exs`, next to #1379's cross-language assertion:

- `MIN_SERVER_PROTOCOL_VERSION` exists at all;
- `MIN_SERVER_PROTOCOL_VERSION <= Protocol.version()`.

**Catches** a floor raised above every server that can exist — a bundle
that banners "server outdated" on a fully current deploy.

**Does not catch** the defect #1654 is about: forgetting to *raise* the
floor. Tighten a narrower onto a v5 field, leave the floor at 2, and
`2 <= 5` still holds, so this stays green through exactly the edit that
reintroduces the silent mode. The wire pin cannot host the real check
either — its digest spans the server's two generated artefacts, so a
`wireNarrow.ts` edit moves nothing it covers.

The two readers share one `cic_integer_constant/2` rather than being
copy-pasted with the constant name swapped. Both need the flunk-not-nil
behaviour for the same reason (Elixir term order puts every atom above
every integer, so a `nil` return satisfies a `>=` comparison), which is
what makes it one function and not two.

## Oracle, proven by mutation

| mutation | result |
|---|---|
| floor `2 -> 3` | RED, `left: 3 / right: 2` |
| constant renamed | RED on **both** tests, with the named message — not a vacuous pass |
| reverted | GREEN, 6 tests 0 failures |

## The ledger is measured, not built

The real gate needs a field to version-that-introduced-it history the repo
does not hold. Measured by importing the generated runtime schema rather
than grepping it: **768 field slots**, 185 consts, 253 distinct names,
**0 stamped**, across 169 `@type` in 29 `*wire.ex` plus 3 web modules.

Two findings a control-that-fired forced out, both recorded in DESIGN_NOTES:
the stamp surface is **not** the wire modules (16 types are pulled in by
reference from domain modules), and `Grappa.Scrollback.Meta.t/0` emits a
bare `map()` whose fields are declared nowhere, so no ledger can date them.

**Whether to build the ledger is not decided here.** Those numbers are its
input, not an argument for one arm.

## Gates

- `scripts/check.sh` rc=0 — Dialyzer 0 errors, 6723 tests 0 failures, 657 bats 0 not-ok
- `scripts/design-notes-gate.sh` rc=0
- `scripts/bun.sh run check` rc=0 — 4/4 stages, lock drift included
