### PR TITLE
#1669 — elastic resistance + a ceiling on the directory pull

### DIFF
--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -20,8 +20,12 @@
 //      `translateY(-100%)` in the stylesheet; what moves it is its ancestor.
 //   2b. THE ROWS FOLLOW THE FINGER, AND THE SPINNER RIDES ABOVE THEM (#1658
 //      point 3, chromium). Two assertions, and the first is the defect vjt
-//      kept reporting: at a travel of 400px the first row's top edge sits 400px
+//      kept reporting: at a travel of 400px the first row's top edge sits well
 //      below the list's top edge — the CONTENT moved, not just the spinner.
+//      #1669 turned that reading from "by exactly 400px" into the pair of
+//      inequalities its own section below sets out (past the commit distance,
+//      short of the finger's 400), because the travel is damped now and an
+//      equality with the finger's distance IS the defect #1669 removes.
 //      Until point 3 only the slot moved, and because rows start at y=0 too,
 //      every position where the spinner was visible was a position where it
 //      covered the first row's top band; the strongest true statement
@@ -42,9 +46,10 @@
 //      clears the paint from `onCommit` — before that fix the spinner stayed
 //      exactly where the finger left it, at full opacity, for the life of the
 //      pane. Point 3 raised the stakes on it: the travel is on the TRACK now,
-//      so the same omission would strand the whole channel list 240px down the
-//      pane, not just a spinner. Both elements are asserted, and so is the
-//      slot's own transform staying empty — the pane must not write one.
+//      so the same omission would strand the whole channel list a hundred-odd
+//      pixels down the pane, not just a spinner. Both elements are asserted,
+//      and so is the slot's own transform staying empty — the pane must not
+//      write one.
 //   3. CSS CONTRACT (@webkit, iPhone 15): on the real target browser the row
 //      container refuses its own overscroll (so the iOS rubber-band does not
 //      fight the slot at the one scroll position the pull lives at) while
@@ -55,7 +60,8 @@
 //      — the hit-test target across nearly the whole list — still reading
 //      `auto`, which is the shape #913 measured as insufficient.
 //   3b. THE INVARIANT, RESOLVED BY THE ENGINE THE BUG CAME FROM (#1658 point
-//      3, @webkit): the track translate the pane writes at full travel is
+//      3, @webkit): a track translate of the SHAPE the pane writes — since
+//      #1669 a fractional px value, see that test's own note — is
 //      applied straight to the track and the engine's own geometry is read
 //      back — did the ROWS move by it, and did the slot's bottom still land on
 //      the first row's top?
@@ -106,12 +112,20 @@
 //     percentage offset such that the invariant holds", a question chromium
 //     cannot answer at all. It does not answer "does it resolve the same way on
 //     vjt's phone", and no assertion here claims it does.
-//   * The TRAVEL DISTANCE, now that #1658 point 3 removed the cap. Nothing here
-//     says 400px of finger should produce 400px of list, only that it DOES and
-//     that the spinner stays off the rows while it happens. Whether the pull
-//     should ease off past the commit point is a feel question that needs a
-//     phone, and the code takes the position that an unbounded follow is the
-//     honest floor to calibrate from rather than an unmeasured damping curve.
+//   * The TWO FEEL NUMBERS #1669 added — the damping factor and the ceiling.
+//     They are declared provisional in `DirectoryPane.tsx` and vjt calibrates
+//     them on a device; nothing in this file names either one, and nothing here
+//     says the resistance feels like an iOS scroller. What test 3 asserts is
+//     the visible PROPERTY: 400px of finger moves the rows by more than the
+//     commit distance and by strictly LESS than 400 — damped, still following.
+//     The curve's own guarantees (strictly increasing, gain never rising,
+//     bounded by the ceiling) are properties of a number and are pinned over a
+//     dense sweep in src/__tests__/DirectoryPane.test.tsx, where changing them
+//     costs no testnet.
+//     🔴 IOS PARITY, which the issue names as the acceptance bar, IS PROVEN
+//     NOWHERE AND IS NOT CLAIMED. Playwright's webkit does not reproduce real
+//     iOS scroll physics (the bullet above), so no reading in this file can
+//     speak to it. That call is vjt's, on the phone.
 //   * The GESTURE on WebKit, by anything here. `new Touch(...)` throws
 //     `Illegal constructor` there, so no test in this file drives the binder
 //     on that project. MEASURED while looking for a way round it, and recorded
@@ -149,17 +163,22 @@ const LIST_WINDOW_NAME = "$list";
 // PULL_COMMIT_PX from src/lib/pullGesture.ts (SWIPE_MIN_PX * 2). Hardcoded for
 // the same reason as the window name above.
 //
-// #1658 — and unlike the window name this copy no longer CHECKS ITSELF. It
-// did: test 2 dragged half of it against a paint capped at the real constant,
-// so lowering the real one made this spec read the cap instead of the drag and
-// go red. Both halves of that are gone. Point 3 removed the cap outright —
-// with the rows carried by the same transform as the spinner there is no
-// collision left to bound — so no drag in this file can read a clamp instead
-// of a follow, at any distance or font size. The only use left is a drag
-// MAGNITUDE (`PULL_COMMIT_PX * 3` in test 1), which reds only if the real
-// constant grows past 240 and says nothing at all if it shrinks. Leaving the
-// old claim here would have left a comment standing where a witness used to
-// be, which is the failure #1393 spent a day removing.
+// #1658 — and unlike the window name this copy stopped CHECKING ITSELF for a
+// while. It used to: test 2 dragged half of it against a paint capped at the
+// real constant, so lowering the real one made this spec read the cap instead
+// of the drag and go red. Point 3 removed that cap outright — with the rows
+// carried by the same transform as the spinner there was no collision left to
+// bound — and the only use left was a drag MAGNITUDE (`PULL_COMMIT_PX * 3` in
+// test 1), which reds only if the real constant grows past 240 and says
+// nothing at all if it shrinks.
+//
+// #1669 gives it a witness again, of a different kind. The commit distance is
+// now the SEAM of the travel curve: below it the finger goes through 1:1,
+// above it the offset is damped. Test 3 reads that the rows moved MORE than
+// this number and LESS than the finger's own 400, so a copy that drifted above
+// the real constant's damped offset reds — a genuine reading, not a magnitude.
+// It is still one-sided (drifting DOWN stays quiet), which is why the static
+// witness below remains the pin that matters.
 //
 // What pins it is #1646's static witness, which needs no testnet:
 // src/__tests__/e2eConstantMirrors.test.ts imports the production constant and
@@ -321,8 +340,8 @@ async function pullInlinePaint(
   });
 }
 
-// One pull driven far past any cap, at a chosen root font size, measured with
-// the finger still down — the only moment the paint exists.
+// One pull driven far past the commit point, at a chosen root font size,
+// measured with the finger still down — the only moment the paint exists.
 //
 // The font size is written as the CSS var on <html>, which is exactly what
 // `lib/fontSize.ts`'s `writeCssVar` does; set here rather than imported to
@@ -376,9 +395,11 @@ async function measureAtFullTravel(
       fire("touchstart", at(y0));
       fire("touchmove", at(y0 + 20));
       // Far past every distance in play — the commit point (80) and the slot
-      // at its largest (50). Whatever stops the pull, it is not the finger
-      // running out, and since point 3 removed the cap nothing else stops it
-      // either: the reading below is the finger's own distance.
+      // at its largest (50). Whatever bounds the pull, it is not the finger
+      // running out. Since #1669 the reading below is NOT the finger's own
+      // distance any more: the travel past the commit point is damped towards
+      // a ceiling, so what comes back is a damped offset and the test asserts
+      // it as one.
       fire("touchmove", at(y0 + opts.travel));
       const slotRect = slot.getBoundingClientRect();
       const rowRect = row.getBoundingClientRect();
@@ -478,7 +499,9 @@ test("#1445 — a downward pull on the directory asks for the refresh (chromium)
   //
   // Point 3 spread the paint over two elements, so this checks both — and the
   // stranded-track case is the worse of the two: not a hung spinner but the
-  // whole channel list sitting 240px down the pane. `slotTransform` is the
+  // whole channel list sitting a hundred-odd pixels down the pane (#1669's
+  // ceiling bounds how far, and does not make it any less stranded).
+  // `slotTransform` is the
   // third reading and it must be empty here for a different reason: the pane
   // never writes one at all, at any point in the gesture.
   expect(await pullInlinePaint(list)).toEqual({
@@ -496,8 +519,14 @@ test("#1445 — mid-pull the track moves by exactly the finger's travel (chromiu
 
   // 20px. It used to be half the commit distance, then a literal 20 chosen to
   // stay under the #1658 slot-height cap at every font size. Point 3 removed
-  // the cap, so no distance can read a clamp any more and the literal survives
-  // only because it keeps this test's arithmetic a small, obvious number.
+  // that cap, and the literal survived only because it kept this test's
+  // arithmetic a small, obvious number.
+  //
+  // 🔴 #1669 makes it load-bearing again, for a THIRD reason: 20 is below the
+  // commit point, which is where the travel is still 1:1. This test's title —
+  // "by EXACTLY the finger's travel" — is now true only in that stretch, and it
+  // is the browser-side witness that #1669 left the deciding stretch alone.
+  // Raise this past `PULL_COMMIT_PX` and the equality is simply false.
   //
   // The track rests at NO transform, so this reading is the whole of the
   // paint: `after - before` is the finger's travel or the paint is wrong. The
@@ -539,14 +568,23 @@ test("#1658 — the rows follow the finger and the slot rides above them, at eve
     expect(transform, `inline transform at --font-size: ${size}`).not.toBe("");
 
     // POINT 3 ITSELF, and the assertion this file did not have: the CONTENT
-    // moved. The first row is 400px below the list's top edge because the
-    // finger dragged it there. Before point 3 this read 0 at every size — the
-    // rows never moved at all, which is the defect vjt kept seeing, and it is
-    // also what proves the travel is UNCAPPED: any cap would read the cap.
-    expect(rowTop - listTop, `rows followed the finger at --font-size: ${size}`).toBeCloseTo(
-      400,
-      0,
+    // moved. Before point 3 this read 0 at every size — the rows never moved
+    // at all, which is the defect vjt kept seeing.
+    //
+    // #1669 turned the reading from an equality into the two inequalities that
+    // bracket it, because the equality was `toBeCloseTo(400, 0)`: the finger's
+    // own distance, going through whole, which is exactly the unbounded 1:1
+    // drag this issue removes. What survives is the pair that says the same
+    // thing without naming a feel number the pane no longer promises:
+    const moved = rowTop - listTop;
+    // Still FOLLOWING, well past the commit point — not the hard cap #1658
+    // deleted, and not a pane that stopped painting.
+    expect(moved, `rows followed the finger at --font-size: ${size}`).toBeGreaterThan(
+      PULL_COMMIT_PX,
     );
+    // And DAMPED: 400px of finger bought strictly less than 400px of list.
+    // This is #1669's visible outcome, read off real layout in a real engine.
+    expect(moved, `travel damped at --font-size: ${size}`).toBeLessThan(FULL_TRAVEL_PX);
 
     // THE STRONG INVARIANT. The slot's bottom edge lands ON the first row's
     // top edge — the spinner sits in the space the rows opened, touching them
@@ -582,8 +620,9 @@ test("@webkit #1658 — WebKit carries the rows AND keeps the slot off them (iPh
     );
     expect(control.gap, `plain-px control at --font-size: ${size}`).toBeCloseTo(20, 0);
 
-    // The declaration the pane actually writes at full travel, resolved by the
-    // engine the bug was reported from — and the two halves fail differently.
+    // A declaration of the shape the pane writes deep into the pull, resolved
+    // by the engine the bug was reported from — and the two halves fail
+    // differently.
     //
     // `gap` is the plain half: WebKit applied the ancestor translate, so the
     // rows moved. `overlap` is the half chromium cannot answer: the slot's own
@@ -599,8 +638,25 @@ test("@webkit #1658 — WebKit carries the rows AND keeps the slot off them (iPh
     // exactly as the CSS-contract test below names `pan-y`. Change the travel's
     // FORM in the pane and this string must move with it — the chromium arm
     // above is what keeps the pane honest about producing it.
-    const full = await resolveTrackTravel(list, size, "translateY(400px)");
-    expect(full.gap, `rows carried at --font-size: ${size} (${full.computed})`).toBeCloseTo(400, 0);
+    //
+    // #1669 changed that form in a way worth probing: the damped offset is
+    // FRACTIONAL (`pulledOffset` divides), where every declaration this file
+    // ever measured was a whole number. An engine that rounds or refuses a
+    // sub-pixel translate would put the spinner back over the first row by half
+    // a pixel and nothing else here would see it — so the probe is fractional
+    // now, and deliberately.
+    //
+    // The VALUE is not a mirror of the ceiling constant and must not become
+    // one: it is a representative translate from the pane's range, chosen so
+    // this stays a pure engine question (does WebKit compose an ancestor px
+    // translate with a descendant percentage) rather than a second, unpinnable
+    // copy of a feel number vjt is expected to retune. The composition is
+    // linear, so any value answers it.
+    const full = await resolveTrackTravel(list, size, "translateY(152.5px)");
+    expect(full.gap, `rows carried at --font-size: ${size} (${full.computed})`).toBeCloseTo(
+      152.5,
+      1,
+    );
     expect(full.overlap, `slot/row overlap at --font-size: ${size}`).toBeCloseTo(0, 0);
   }
 });

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -91,13 +91,82 @@ import { MircBody } from "./MircText";
 //   * The travel used to cap at `min(dy, 100%)`, the slot's own height. That
 //     cap existed for ONE reason — keeping the spinner off rows that stood
 //     still — and with the rows moving there is no collision left to bound.
-//     🔴 Removed rather than retuned, deliberately: any cap makes the list stop
-//     following the finger past it, which is the defect this issue is about, in
-//     smaller print. Where the travel should ease off past the commit distance
-//     is a FEEL question and needs a constant measured on a phone; the honest
-//     floor to calibrate from is the finger's own distance, and damping is
-//     additive afterwards. vjt's call, as `PULL_COMMIT_PX`'s own comment says.
-const pulledTransform = (dy: number): string => `translateY(${dy}px)`;
+//     🔴 Removed rather than retuned, deliberately: any HARD cap makes the list
+//     stop dead under a still-moving finger, which is the defect this issue is
+//     about, in smaller print. What #1669 adds below is not that cap coming
+//     back — an asymptote never stops following, it only ever buys less.
+
+// #1669 — the travel PAST the commit point, and vjt's call on the feel question
+// #1658 left open above ("where the travel should ease off past the commit
+// distance is a FEEL question … damping is additive afterwards"). This is the
+// additive half; the floor it is added to is unchanged.
+//
+// Three properties, and they are what the tests pin — NOT the two numbers,
+// which are provisional. A property survives a recalibration; a number does not.
+//
+//   1. Below the commit point the finger goes through 1:1. That stretch is the
+//      one a user crosses to decide whether to spend a refresh, so it is the
+//      one place the affordance must not lie about distance — and #1658's
+//      geometry (slot bottom ≡ first row top) is an identity at EVERY offset,
+//      so damping it would buy nothing.
+//   2. Past it the gain only ever falls: each further pixel of finger buys
+//      strictly less than the pixel before it. Resistance, not a wall.
+//   3. The offset approaches `PULL_MAX_OFFSET_PX` and never reaches it, while
+//      STILL increasing at every distance. An asymptote, not a clamp — and that
+//      distinction is the whole of why the old cap was deleted rather than
+//      retuned, so it is asserted directly.
+//
+// The curve is the ordinary rubber-band shape (UIScrollView's, and every
+// pull-to-refresh built after it): the slack above the commit point is spent
+// down a reciprocal, so the first pixel past the seam buys `PULL_DAMPING` of
+// itself and the ten-thousandth buys nothing measurable.
+
+// 🔴 A FEEL NUMBER. PROVISIONAL, and NOT MEASURED ON A DEVICE — the same
+// standing rule `PULL_COMMIT_PX` states in its own comment: vjt calibrates on a
+// phone, and nothing here has been near one. No gate in this repo can say this
+// is right, only that it is bounded and monotone: jsdom drives no compositor
+// and Playwright's WebKit does not reproduce real iOS scroll physics (this
+// pane's e2e header says so at length). **iOS parity is claimed nowhere.**
+//
+// Derived rather than picked, so the pull does not grow a second vocabulary for
+// its own distances: the list travels at most twice as far as the finger must
+// go to spend a refresh. Doubling is the defensible default `PULL_COMMIT_PX`
+// itself takes from `SWIPE_MIN_PX`, not a measurement.
+export const PULL_MAX_OFFSET_PX = PULL_COMMIT_PX * 2;
+
+// 🔴 The second feel number, provisional on exactly the same terms.
+//
+// Read it as the gain AT THE SEAM: the share of the finger's next pixel the
+// track still travels the instant it crosses the commit point. Every pixel
+// after that one buys less whatever this is set to — the falling gain is the
+// curve's doing, not this constant's.
+//
+// 1 is the value that leaves NO STEP at the seam: the damped stretch departs at
+// exactly the rate the 1:1 stretch arrives, so resistance builds instead of
+// switching on. It is the honest floor #1658 asked to calibrate FROM. Lower it
+// for a firmer wall right at the threshold. Above 1 the pull would ACCELERATE
+// past the commit point, which is the one direction the property tests refuse.
+const PULL_DAMPING = 1;
+
+/**
+ * The track's offset for a finger that has travelled `dy` downward.
+ *
+ * @spec pulledOffset(number) :: number — the identity below `PULL_COMMIT_PX`;
+ * strictly increasing everywhere; gain non-increasing everywhere; bounded above
+ * by `PULL_MAX_OFFSET_PX`, which it approaches and never reaches.
+ *
+ * Exported for its property tests the way `timeAgo` below is: the three
+ * guarantees are statements about a NUMBER, and asserting them through a
+ * transform string would be asserting them through a parser as well.
+ */
+export function pulledOffset(dy: number): number {
+  if (dy <= PULL_COMMIT_PX) return dy;
+  const slack = PULL_MAX_OFFSET_PX - PULL_COMMIT_PX;
+  const past = dy - PULL_COMMIT_PX;
+  return PULL_COMMIT_PX + slack * (1 - 1 / ((past * PULL_DAMPING) / slack + 1));
+}
+
+const pulledTransform = (dy: number): string => `translateY(${pulledOffset(dy)}px)`;
 
 // The spinner is legible before the commit point, not after it: the ramp
 // reaches full exactly where the release starts spending a capture, so the
@@ -108,6 +177,14 @@ const pulledTransform = (dy: number): string => `translateY(${dy}px)`;
 // ramp to the capped travel would top the spinner out at
 // slotHeight/PULL_COMMIT_PX (0.44 at the default font size) and it would never
 // reach full at the one distance where full is the point.
+//
+// #1669 — which is why this reads the RAW `dy` and not `pulledOffset(dy)`, now
+// that the two differ. What the ramp announces is that the RELEASE will spend a
+// capture, and the binder decides that on the finger's own travel
+// (`swipeDirection(…, PULL_COMMIT_PX)` in pullGesture.ts), which damping does
+// not touch. Ramp the damped offset instead and the spinner reaches full at a
+// distance that does not commit — the affordance lying about the threshold it
+// exists to announce.
 const pulledOpacity = (dy: number): number => Math.min(dy, PULL_COMMIT_PX) / PULL_COMMIT_PX;
 
 // Quiet window after the last keystroke before the filter GET fires. Long

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -157,7 +157,7 @@ const REFRESHING_PAGE: DirectoryPage = {
   status: "refreshing",
 };
 
-import DirectoryPane, { timeAgo } from "../DirectoryPane";
+import DirectoryPane, { PULL_MAX_OFFSET_PX, pulledOffset, timeAgo } from "../DirectoryPane";
 
 describe("DirectoryPane", () => {
   beforeEach(() => {
@@ -871,6 +871,23 @@ describe("DirectoryPane", () => {
       return el;
     };
 
+    // #1669 — the painted travel as a NUMBER, because the damped one is not a
+    // literal any more and an equality against a string would be an equality
+    // against a re-implementation of the curve.
+    //
+    // It THROWS on a shape it cannot read rather than returning NaN: every
+    // caller compares with an inequality, and `NaN < x` is false, so a silent
+    // parse failure would read as a passing bound. An empty transform (the pane
+    // painted nothing) fails here too, which is the point.
+    const trackOffset = (container: HTMLElement): number => {
+      const written = trackIn(container).style.transform;
+      const m = /^translateY\((-?\d+(?:\.\d+)?)px\)$/.exec(written);
+      if (m?.[1] === undefined) {
+        throw new Error(`unreadable track transform: ${JSON.stringify(written)}`);
+      }
+      return Number(m[1]);
+    };
+
     // Finger down and dragged to `dy`, still on the glass — the mid-pull paint
     // exists only before the release wipes it. TWO moves because the binder
     // claims LATE: it decides on a touchmove, never on the touchstart.
@@ -953,22 +970,42 @@ describe("DirectoryPane", () => {
       expect(slotIn(container).style.transform).toBe("");
     });
 
-    // #1658 point 3 — the cap is GONE, and this pins its absence rather than a
-    // new number. It existed only to stop the spinner sinking into rows that
-    // stood still; with the rows carried by the same transform there is no
-    // collision left to bound, so the travel follows the finger the whole way
-    // and where it stops is a question of feel, not of geometry.
+    // #1669 — the pane's WIRING half of the elastic travel: that the damped
+    // number is the one that reaches the DOM. The curve's own guarantees are
+    // properties of a number and are pinned as such, over a sweep, in
+    // "pulledOffset" at the bottom of this file.
     //
-    // Reinstating any clamp — in JS or as a `min()` in the declaration — turns
-    // this string into something other than the raw distance and reds it.
-    it("the travel is UNCAPPED — the finger's distance goes through whole", () => {
+    // This REPLACES #1658 point 3's "the travel is UNCAPPED", which asserted
+    // `translateY(${PULL_COMMIT_PX * 4}px)` — the finger's raw distance, going
+    // through whole. That test pinned the deliberate ABSENCE of the feel
+    // constant #1658 declined to invent; #1669 is vjt making that call, so the
+    // assertion it pinned is now the defect. What survives of it is the part
+    // that was never about the cap: the list must still be MOVING at four times
+    // the commit distance, and it is, which is why the third assertion below is
+    // a strict inequality against the ceiling and not an equality with it.
+    it("the travel past the commit point is damped, and bounded by the ceiling", () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);
       const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
 
+      // Pre-state, and the half that must NOT have changed: below the commit
+      // point the finger still goes through 1:1. Without it every assertion
+      // below is satisfied by a pane that damped the whole gesture to nothing.
+      pullTo(listIn(container), 20);
+      expect(trackOffset(container)).toBe(20);
+
       const far = PULL_COMMIT_PX * 4;
       pullTo(listIn(container), far);
+      const offset = trackOffset(container);
 
-      expect(trackIn(container).style.transform).toBe(`translateY(${far}px)`);
+      // Damped: the visible outcome #1669 asks for. 320px of finger moved the
+      // list by less than 320px.
+      expect(offset).toBeLessThan(far);
+      // Still moving, and past the commit distance — this is what separates
+      // resistance from the hard cap #1658 deleted.
+      expect(offset).toBeGreaterThan(PULL_COMMIT_PX);
+      // Under the ceiling, strictly: it is an asymptote, so no finite finger
+      // ever lands on it.
+      expect(offset).toBeLessThan(PULL_MAX_OFFSET_PX);
     });
 
     // #1658 — the ramp and the travel are INDEPENDENT axes, and the fix for
@@ -1083,6 +1120,103 @@ describe("DirectoryPane", () => {
 
       expect(triggerRefreshMock).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// #1669 — the elastic pull curve, asserted as PROPERTIES and never as the two
+// numbers that shape it. Both are declared provisional feel constants that vjt
+// calibrates on a device; a suite that pinned them would go red on the
+// calibration it exists to permit, and would say nothing about the shape.
+//
+// What jsdom (and Playwright, and this whole repo) cannot say: whether any of
+// this feels like an iOS scroller. No assertion below is about parity, and
+// nothing here has been near a phone.
+//
+// The three properties are each other's controls, which is why they are one
+// sweep and not three unrelated numbers:
+//
+//   * STRICTLY INCREASING alone permits the undamped 1:1 travel (the defect).
+//   * NON-INCREASING GAIN alone permits a hard clamp (gain drops to 0 and
+//     stays there) — the #1658 defect wearing #1669's name.
+//   * BOUNDED alone permits a clamp too.
+//
+// Together only an asymptote satisfies all three, and each of the two mutants
+// above was run and reds — see the DESIGN_NOTES entry for which assertion
+// catches which.
+describe("pulledOffset (#1669 — the elastic pull curve)", () => {
+  // 0…2000px of finger at 1px resolution: past four ceilings, and fine enough
+  // that a gain reversal anywhere in the interesting region lands between two
+  // samples. Whole pixels because that is the resolution a touchmove reports.
+  const SWEEP = Array.from({ length: 2001 }, (_, i) => i);
+  const offsets = SWEEP.map(pulledOffset);
+  // IEEE noise on these magnitudes is ~1e-13. Anything this tolerance hides is
+  // below a millionth of a pixel and cannot be a gain reversal anyone designed.
+  const EPS = 1e-9;
+
+  it("is the identity below the commit point — the deciding stretch is not damped", () => {
+    for (let dy = 0; dy <= PULL_COMMIT_PX; dy++) {
+      expect(pulledOffset(dy), `pulledOffset(${dy})`).toBe(dy);
+    }
+    // The seam is INSIDE the identity, not past it: the commit point itself is
+    // the last undamped pixel, so the ramp and the travel agree exactly at the
+    // one distance the release changes meaning.
+    expect(pulledOffset(PULL_COMMIT_PX)).toBe(PULL_COMMIT_PX);
+  });
+
+  it("never stops following the finger — strictly increasing at every distance", () => {
+    for (let i = 1; i < offsets.length; i++) {
+      expect(
+        offsets[i] as number,
+        `pulledOffset(${SWEEP[i]}) must exceed pulledOffset(${SWEEP[i - 1]})`,
+      ).toBeGreaterThan(offsets[i - 1] as number);
+    }
+  });
+
+  it("resists: every pixel of finger buys no more than the pixel before it", () => {
+    const gain = offsets.slice(1).map((v, i) => v - (offsets[i] as number));
+    for (let i = 1; i < gain.length; i++) {
+      expect(
+        gain[i] as number,
+        `gain over px ${SWEEP[i]}→${SWEEP[i + 1]} must not exceed the one before it`,
+      ).toBeLessThanOrEqual((gain[i - 1] as number) + EPS);
+    }
+    // Not merely NON-increasing: past the seam it actually falls, or "damping"
+    // would be satisfied by the undamped travel, whose gain is a flat 1.
+    const past = SWEEP.findIndex((dy) => dy > PULL_COMMIT_PX);
+    expect(gain[past + 10] as number).toBeLessThan((gain[past] as number) - EPS);
+  });
+
+  it("is bounded by the ceiling, which it approaches and never reaches", () => {
+    for (const [i, v] of offsets.entries()) {
+      expect(v, `pulledOffset(${SWEEP[i]})`).toBeLessThan(PULL_MAX_OFFSET_PX);
+    }
+    // An absurd finger, to read the asymptote rather than a distant sample:
+    // within a hundredth of a pixel of the ceiling and still under it.
+    expect(pulledOffset(1e7)).toBeLessThan(PULL_MAX_OFFSET_PX);
+    expect(pulledOffset(1e7)).toBeGreaterThan(PULL_MAX_OFFSET_PX - 0.01);
+  });
+
+  it("is SPENT well before the arm runs out — the travel still on offer collapses", () => {
+    // The user-facing half of "a ceiling", and the honest way to state it: not
+    // "one more pixel buys nothing" (at any reachable distance it still buys a
+    // pixel or so — MEASURED: 1.35px per 100px of finger at four ceilings out,
+    // which is why the first draft of this assertion was wrong), but "there is
+    // almost nothing LEFT to buy". `PULL_MAX_OFFSET_PX - pulledOffset(dy)` is
+    // everything an arbitrarily long drag could still add, from here to
+    // infinity, and past four ceilings of finger it is under a tenth of the
+    // ceiling.
+    //
+    // Stated as a FRACTION of the ceiling rather than in pixels so it survives
+    // a recalibration of either constant, which is the whole posture of this
+    // block.
+    const far = PULL_MAX_OFFSET_PX * 4;
+    expect(PULL_MAX_OFFSET_PX - pulledOffset(far)).toBeLessThan(PULL_MAX_OFFSET_PX / 10);
+    // Control against vacuity: at the commit point there is still most of the
+    // ceiling to play for. Without it a function that returns the ceiling flat
+    // passes the assertion above.
+    expect(PULL_MAX_OFFSET_PX - pulledOffset(PULL_COMMIT_PX)).toBeGreaterThan(
+      PULL_MAX_OFFSET_PX / 10,
+    );
   });
 });
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -57945,3 +57945,116 @@ Why an explicitly-present `recommended` key enables a domain rule that an
 absent one does not. The delta is measured and reproducible; the mechanism is
 inferred from `biome explain` (a `test`-domain rule gated on a detected
 vitest dependency) and was not proven.
+<!-- entry #1669 -->
+
+---
+
+## 2026-08-22 — #1669: elastic resistance on the directory pull, and why the numbers are not the contract
+
+#1658 point 3 deleted the pull's travel cap and said so in the code: *"any cap
+makes the list stop following the finger past it … where the travel should ease
+off past the commit distance is a FEEL question and needs a constant measured on
+a phone … vjt's call."* #1669 is vjt making that call. The travel past
+`PULL_COMMIT_PX` is now damped towards a ceiling it approaches and never
+reaches.
+
+### The curve, and where it does NOT go
+
+`pulledOffset` in `DirectoryPane.tsx`, the ordinary rubber-band shape: identity
+below the commit point, and above it the remaining slack spent down a
+reciprocal. NOT in `pullGesture.ts` — that binder is deliberately paint-free and
+reports raw travel, and it is the fourth binder over one core, so a paint
+concern parked there becomes four panes' concern. NOT in `PULL_COMMIT_PX`
+either: the commit threshold is a separate decision vjt has explicitly reserved,
+and the binder still gates the commit on the finger's OWN distance
+(`swipeDirection(…, PULL_COMMIT_PX)`), which damping does not touch.
+
+Which forces one non-obvious consequence: **the opacity ramp keeps reading the
+RAW `dy`, not the damped offset.** The ramp announces that the release will
+spend a capture, and the release is decided on finger distance. Ramp the damped
+offset and the spinner reaches full at a distance that does not commit — the
+affordance lying about the one threshold it exists to announce.
+
+### The PROPERTIES are the contract; the two numbers are not
+
+`PULL_MAX_OFFSET_PX` and `PULL_DAMPING` are declared provisional feel constants,
+on the same standing rule `PULL_COMMIT_PX` carries in its own comment. So the
+suite pins the SHAPE and never the values:
+
+1. **Identity below the commit point.** The stretch a user crosses to decide
+   whether to spend a refresh must not lie about distance.
+2. **Strictly increasing at every distance.** An asymptote, not a clamp — this
+   is the property that keeps #1658's deletion intact.
+3. **Gain never rises, and falls past the seam.** Resistance, not a wall.
+4. **Bounded by the ceiling**, which it approaches and never reaches.
+
+They are each other's controls, and that is the point: strictly-increasing alone
+permits the undamped 1:1 travel; non-increasing-gain alone permits a hard clamp;
+bounded alone permits a clamp too. Only an asymptote satisfies all of them.
+
+### Measured by mutation, both mutants, against the shipped oracle
+
+Run through a harness that patches the body, runs, restores, and verifies the
+restored file's digest matches the original — with a known-answer control
+(`the pristine body must appear exactly once`) gating the run, because a patcher
+that silently found nothing reports green.
+
+| mutant | reds |
+| --- | --- |
+| `return dy` (the pre-#1669 linear travel) | 3 — bounded, gain-falls, and the pane-wiring test |
+| `Math.min(dy, PULL_MAX_OFFSET_PX)` (a hard clamp) | 4 — the same three **plus strictly-increasing** |
+
+The second row is why property 2 exists as its own assertion: the clamp is
+bounded and its gain never rises, so it passes everything the issue literally
+asks for while reinstating the defect #1658 removed. Only "still moving at every
+distance" sees it. The linear mutant is the one the brief demanded; it passes
+strictly-increasing and identity-below-the-seam, and dies on the ceiling.
+
+### A wrong assertion, and the honest replacement
+
+The first draft of the ceiling's user-facing test claimed "past four ceilings, a
+further 100px of finger buys under a pixel". **False, measured: it buys 1.35px**,
+and getting under 1px needs roughly 8000px of finger — not a distance a thumb
+reaches. The honest statement of "dragging further adds nothing visible" is not
+about the next pixel but about what is LEFT: `PULL_MAX_OFFSET_PX -
+pulledOffset(dy)` is everything an arbitrarily long drag could still add, and
+past four ceilings it is under a tenth of the ceiling. Stated as a fraction of
+the ceiling, so it survives a recalibration of either constant.
+
+### The e2e assertion that had to go
+
+`issue1445-directory-pull-refresh.spec.ts` asserted `rowTop - listTop` was
+`toBeCloseTo(400, 0)` at three font sizes — the finger's own distance going
+through whole, which #1658 wrote there precisely to pin the ABSENCE of a feel
+constant it declined to invent. That assertion is now the defect, stated. It
+became the two inequalities that bracket it (past the commit distance, short of
+the finger's 400): damped, still following, read off real layout in a real
+engine. The strong invariant it was really guarding — slot bottom ≡ first row
+top — is an identity at every offset and is untouched.
+
+Two smaller consequences in the same file. The `@webkit` engine probe hard-codes
+the declaration it applies, and the damped offset is **fractional** where every
+value that file ever measured was a whole number, so the probe is fractional
+now: an engine that rounded or refused a sub-pixel translate would put the
+spinner back over the first row by half a pixel and nothing else would see it.
+Its value is deliberately NOT a mirror of the ceiling — the composition question
+is linear, so any value answers it, and pinning one would plant an unpinnable
+copy of a number vjt is expected to retune. And the 20px literal in the
+displacement test is load-bearing again for a third reason: 20 is below the
+commit point, which is the only stretch where "moves by EXACTLY the finger's
+travel" is still true.
+
+### Not established, and it is the piece that closes the issue
+
+**The calibration.** Both numbers are guesses with a rationale, not
+measurements: the ceiling is `PULL_COMMIT_PX * 2` (derived so the pull does not
+grow a second vocabulary for its own distances, the same defensible doubling
+`PULL_COMMIT_PX` itself takes from `SWIPE_MIN_PX`), and the damping is 1,
+the value that leaves no step at the seam and is therefore the honest floor
+#1658 asked to calibrate FROM.
+
+**iOS parity — which the issue names as its acceptance bar — is claimed
+nowhere, and cannot be from here.** jsdom drives no compositor and Playwright's
+webkit does not reproduce real iOS scroll physics; every gate in this repo can
+say the travel is bounded and monotone and none of them can say it feels like a
+native scroller. That reading is vjt's, on the phone.


### PR DESCRIPTION
Issue #1669. The directory pull-to-refresh drag was linear and unbounded by
construction (`translateY(${dy}px)`, over a binder that floors travel at 0 and
never caps it). This adds resistance past the commit point and a ceiling the
travel asymptotes to.

## What changed

`pulledOffset` in `DirectoryPane.tsx` — the ordinary rubber-band shape: the
identity below `PULL_COMMIT_PX`, and above it the remaining slack spent down a
reciprocal, so the offset approaches `PULL_MAX_OFFSET_PX` and never reaches it.

In the **pane**, not `pullGesture.ts` — that binder is deliberately paint-free
and reports raw travel, and it is the fourth binder over one core, so a paint
concern parked there becomes four panes' concern. `PULL_COMMIT_PX` is
untouched: it stays the commit THRESHOLD, which is a separate decision.

**Non-obvious consequence, and it is load-bearing:** the opacity ramp keeps
reading the RAW `dy`, not the damped offset. The ramp announces that the
release will spend a capture, and the binder decides that on the finger's own
distance (`swipeDirection(…, PULL_COMMIT_PX)`), which damping does not touch.
Ramp the damped offset instead and the spinner reaches full at a distance that
does not commit — the affordance lying about the one threshold it exists to
announce.

## The tests pin PROPERTIES, never the two numbers

Both new constants are declared provisional feel numbers, on the same standing
rule `PULL_COMMIT_PX` carries in its own comment. A recalibration must not turn
the suite red, so what is asserted over a dense sweep is the shape: the
identity below the seam; strictly increasing at every distance; gain never
rising, and falling past the seam; bounded by the ceiling, which it approaches
and never reaches.

They are each other's controls — measured by mutation against the shipped
oracle, through a harness that patches, runs, restores and verifies the
restored digest matches, gated on a known-answer control so a patcher that
found nothing prints no numbers:

| mutant | reds |
| --- | --- |
| `return dy` (the pre-#1669 linear travel) | 3 — ceiling, gain-falls, and the pane-wiring test |
| `Math.min(dy, PULL_MAX_OFFSET_PX)` (a hard clamp) | 4 — the same three **plus strictly-increasing** |

The second row is the interesting one: a hard clamp passes everything the issue
literally asks for (bounded, gain never rising) while reinstating the defect
#1658 removed. Only "still moving at every distance" sees it.

## An assertion of mine that was wrong, and is recorded as such

The first draft of the ceiling's user-facing test claimed "past four ceilings, a
further 100px of finger buys under a pixel". **False — measured, it buys
1.35px**, and getting under 1px needs roughly 8000px of finger. The honest
statement of "dragging further adds nothing visible" is not about the next pixel
but about what is LEFT to buy (`ceiling − offset`), stated as a fraction of the
ceiling so it survives a recalibration.

## The e2e change was not optional

`issue1445-directory-pull-refresh.spec.ts` asserted `rowTop - listTop` was
`toBeCloseTo(400, 0)` at three font sizes — the finger's raw distance going
through whole, which #1658 put there precisely to pin the ABSENCE of a feel
constant it declined to invent. With that call now made, the equality IS the
defect. It becomes the two inequalities that bracket it (past the commit
distance, short of the finger's 400). The strong invariant it really guards —
slot bottom lands on the first row's top — is an identity at every offset and
is untouched.

The `@webkit` engine probe is fractional now: the damped offset is fractional
where every value that file ever measured was whole, and an engine that rounded
or refused a sub-pixel translate would put the spinner back over the first row
by half a pixel with nothing else there to see it. Its value is deliberately
NOT a mirror of the ceiling — the composition question is linear so any value
answers it, and pinning one would plant an unpinnable copy of a number that is
expected to be retuned.

## Gates (local)

| gate | rc |
| --- | --- |
| `bun.sh run check` (biome + tsc src + tsc e2e) | 0 |
| `bun.sh run test` (vitest, full) | 0 — 299 files, 5831 tests |
| `bun.sh run build` (tsc --noEmit + vite build) | 0 |
| `scripts/design-notes-gate.sh` | 0 |

59 biome warnings are pre-existing and none are in the files this touches
(attributed per file). No Elixir file is touched.

## One design question, named rather than shipped quietly

The ceiling is DERIVED from the commit distance (`PULL_COMMIT_PX * 2`), so the
pull does not grow a second vocabulary for its own distances. But the commit
threshold is separately reported as too small, and with this derivation raising
it also raises the ceiling. If the two should be independent, that is a literal.

## Not claimed

**iOS parity — which the issue names as its acceptance bar — is proven nowhere
and is not claimed.** jsdom drives no compositor and Playwright's webkit does
not reproduce real iOS scroll physics, so no gate in this repo can speak to it.
Both numbers are reasoned guesses that have not been near a phone; the
calibration is the open piece. The e2e suite was NOT run locally (no lane) —
CI is the arbiter here. Known and deliberate gap: changing `PULL_DAMPING`
within (0, 1] reds nothing, because a test that pinned it would be a test of a
constant's existence.