### PR TITLE
#1671 — double the pull-to-refresh commit distance (vjt on-device: 80px -> 160px)

### DIFF
--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -160,8 +160,8 @@ import { expect, specNick, specUser, test } from "../fixtures/test";
 // proves it (#1646). Pinned by src/__tests__/e2eConstantMirrors.test.ts.
 const LIST_WINDOW_NAME = "$list";
 
-// PULL_COMMIT_PX from src/lib/pullGesture.ts (SWIPE_MIN_PX * 2). Hardcoded for
-// the same reason as the window name above.
+// PULL_COMMIT_PX from src/lib/pullGesture.ts. Hardcoded for the same reason as
+// the window name above.
 //
 // #1658 — and unlike the window name this copy stopped CHECKING ITSELF for a
 // while. It used to: test 2 dragged half of it against a paint capped at the
@@ -182,10 +182,13 @@ const LIST_WINDOW_NAME = "$list";
 //
 // What pins it is #1646's static witness, which needs no testnet:
 // src/__tests__/e2eConstantMirrors.test.ts imports the production constant and
-// compares it to this literal. It watches the number this file does NOT name —
-// the production side is DERIVED, so moving `SWIPE_MIN_PX` in src/lib/swipe.ts
-// moves the commit distance while leaving 80 sitting here.
-const PULL_COMMIT_PX = 80;
+// compares it to this literal. #1671 measured this distance on a phone and
+// doubled it, and that pin is exactly what caught this copy sitting at the old
+// 80 — a red naming this line, not a silent drift. What the pin no longer
+// watches is a THIRD module: production stopped being `SWIPE_MIN_PX * 2` in the
+// same change, deliberately, so moving the swipe floor no longer moves the
+// commit distance and there is nothing left here to be moved from behind.
+const PULL_COMMIT_PX = 160;
 
 // Open the directory pane and hand back its two moving parts.
 //
@@ -394,8 +397,9 @@ async function measureAtFullTravel(
       const y0 = 200;
       fire("touchstart", at(y0));
       fire("touchmove", at(y0 + 20));
-      // Far past every distance in play — the commit point (80) and the slot
-      // at its largest (50). Whatever bounds the pull, it is not the finger
+      // Far past every distance in play — the commit point (160 since #1671)
+      // and the slot at its largest (50). Whatever bounds the pull, it is not
+      // the finger
       // running out. Since #1669 the reading below is NOT the finger's own
       // distance any more: the travel past the commit point is damped towards
       // a ceiling, so what comes back is a damped offset and the test asserts

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -121,17 +121,22 @@ import { MircBody } from "./MircText";
 // down a reciprocal, so the first pixel past the seam buys `PULL_DAMPING` of
 // itself and the ten-thousandth buys nothing measurable.
 
-// 🔴 A FEEL NUMBER. PROVISIONAL, and NOT MEASURED ON A DEVICE — the same
-// standing rule `PULL_COMMIT_PX` states in its own comment: vjt calibrates on a
-// phone, and nothing here has been near one. No gate in this repo can say this
-// is right, only that it is bounded and monotone: jsdom drives no compositor
+// 🔴 A FEEL NUMBER. PROVISIONAL, and NOT MEASURED ON A DEVICE. It no longer
+// shares that standing with `PULL_COMMIT_PX`, which vjt measured on a phone in
+// #1671 — this one has still never been near one. No gate in this repo can say
+// it is right, only that it is bounded and monotone: jsdom drives no compositor
 // and Playwright's WebKit does not reproduce real iOS scroll physics (this
 // pane's e2e header says so at length). **iOS parity is claimed nowhere.**
 //
-// Derived rather than picked, so the pull does not grow a second vocabulary for
-// its own distances: the list travels at most twice as far as the finger must
-// go to spend a refresh. Doubling is the defensible default `PULL_COMMIT_PX`
-// itself takes from `SWIPE_MIN_PX`, not a measurement.
+// STILL DERIVED, deliberately, even though its base stopped being derived. What
+// #1671 approved on the device is the commit DISTANCE; what is approved here is
+// the RATIO — the list travels at most twice as far as the finger must go to
+// spend a refresh — so the ceiling follows the commit point and the elastic
+// keeps the shape vjt has just signed off. Freezing a literal here would pin
+// that shape against the next recalibration instead of tracking it. That is the
+// whole of the rule `PULL_COMMIT_PX` now states at its own declaration: derive
+// the ratio, write the measured distance. If the doubled 320px turns out to be
+// too much travel on the device, that is its own measurement and its own issue.
 export const PULL_MAX_OFFSET_PX = PULL_COMMIT_PX * 2;
 
 // 🔴 The second feel number, provisional on exactly the same terms.
@@ -175,8 +180,9 @@ const pulledTransform = (dy: number): string => `translateY(${pulledOffset(dy)}p
 // #1658 — a DIFFERENT axis from the travel above and it keeps its own
 // distance. The travel is the placement, the ramp is the affordance; tying the
 // ramp to the capped travel would top the spinner out at
-// slotHeight/PULL_COMMIT_PX (0.44 at the default font size) and it would never
-// reach full at the one distance where full is the point.
+// slotHeight/PULL_COMMIT_PX (0.22 at the default font size, halved from 0.44 by
+// #1671's doubling) and it would never reach full at the one distance where
+// full is the point.
 //
 // #1669 — which is why this reads the RAW `dy` and not `pulledOffset(dy)`, now
 // that the two differ. What the ramp announces is that the RELEASE will spend a

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -1011,8 +1011,9 @@ describe("DirectoryPane", () => {
     // #1658 — the ramp and the travel are INDEPENDENT axes, and the fix for
     // the travel is what puts the ramp at risk: computing opacity from the
     // capped travel would top the spinner out at slotHeight/PULL_COMMIT_PX —
-    // 0.44 at the default font size — so it would never reach full at the one
-    // distance where reaching full is the whole point. The ramp says where the
+    // 0.22 at the default font size, halved from 0.44 when #1671 doubled the
+    // commit distance — so it would never reach full at the one distance where
+    // reaching full is the whole point. The ramp says where the
     // release starts spending a capture; the travel says where the slot sits.
     //
     // Green before this issue and green after it, deliberately: its oracle is

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -121,22 +121,30 @@ const MIRRORS: readonly Mirror[] = [
     origin: "REPLY_QUOTE_BODY_LIMIT (src/lib/replyQuote.ts)",
   },
 
-  // The two DERIVED ones, and the reason a value pin beats a name pin. Neither
-  // production side is a literal — `UNREAD_RETENTION_CAP = PAGE_LIMIT` and
-  // `PULL_COMMIT_PX = SWIPE_MIN_PX * 2` — so the number the e2e copy froze can
-  // be moved from a module the copy does not even name. Importing the constant
-  // pins the computed value, which is the one the product uses.
+  // The DERIVED one, and the reason a value pin beats a name pin. Its
+  // production side is not a literal — `UNREAD_RETENTION_CAP = PAGE_LIMIT` — so
+  // the number the e2e copy froze can be moved from a module the copy does not
+  // even name. Importing the constant pins the computed value, which is the one
+  // the product uses.
   {
     file: "e2e/tests/issue1229-unread-retention-bound.spec.ts",
     name: "UNREAD_BOUND",
     production: UNREAD_RETENTION_CAP,
     origin: "UNREAD_RETENTION_CAP = PAGE_LIMIT (src/lib/scrollback.ts)",
   },
+
+  // Was the SECOND derived one until #1671: `PULL_COMMIT_PX = SWIPE_MIN_PX * 2`
+  // became a plain 160 when vjt measured the distance on a phone, because a
+  // measurement is not a multiple of the swipe floor. The pin is unchanged and
+  // it is the reason that landed cleanly — it went red on this very row,
+  // naming the e2e line still holding 80. What it stopped covering went with
+  // the derivation and not with the pin: there is no third module left whose
+  // edit could move this value.
   {
     file: "e2e/tests/issue1445-directory-pull-refresh.spec.ts",
     name: "PULL_COMMIT_PX",
     production: PULL_COMMIT_PX,
-    origin: "PULL_COMMIT_PX = SWIPE_MIN_PX * 2 (src/lib/pullGesture.ts)",
+    origin: "PULL_COMMIT_PX (src/lib/pullGesture.ts)",
   },
 
   // The scroll-edge pair (#1646 slice 2). `SCROLL_BOTTOM_THRESHOLD_PX` is the

--- a/cicchetto/src/lib/pullGesture.ts
+++ b/cicchetto/src/lib/pullGesture.ts
@@ -18,19 +18,36 @@
 // Like `bindDismissGesture` it reports PROGRESS and writes no paint of its own:
 // the pulled slot, its cap and its spinner belong to the pane, and a binder
 // that knew about them would be a binder that knew about the directory.
-import { type Point, SWIPE_MIN_PX, swipeDirection } from "./swipe";
+import { type Point, swipeDirection } from "./swipe";
 import { soleTouch, verticalClaim } from "./touchGesture";
 
 // How far down the finger must travel for the release to spend a refresh.
 //
-// Derived from `SWIPE_MIN_PX` rather than picked, so this does not become a
-// second vocabulary for the same physical gesture. It is deliberately STRICTER
-// than that floor: 40px answers "was this a gesture at all", while this answers
-// "did they mean to spend a server round-trip and a disabled button for the
-// length of a capture". Doubling is a defensible default, NOT a measurement —
-// the same standing `DISMISS_COMMIT_FRACTION` carries in the sibling binder.
-// vjt calibrates on-device; nothing here was verified on a phone.
-export const PULL_COMMIT_PX = SWIPE_MIN_PX * 2;
+// 🔴 MEASURED ON A DEVICE — vjt, 2026-08-22 (#1671), on a phone against the
+// staging build of `1.3.1-c6f46686`. This comment used to say the opposite in
+// as many words ("Doubling is a defensible default, NOT a measurement … vjt
+// calibrates on-device; nothing here was verified on a phone") and the value
+// was half of this, reached by doubling `SWIPE_MIN_PX`. The calibration it
+// asked for has now happened and it says 160.
+//
+// WRITTEN AS A LITERAL, which is the substantive half of the change. The
+// derivation `SWIPE_MIN_PX * 4` reaches the same number today and was the
+// recommendation on the issue; it is declined because it would assert a
+// causality that has stopped being true. 40px answers a DIFFERENT question
+// ("was this a gesture at all") for four binders, and recalibrating that floor
+// must not silently drag a distance somebody measured with a thumb. The lattice
+// bites the other way too: the next on-device call need not land on a multiple
+// of 40, and a constant spellable only in 40px steps invites rounding the
+// measurement to fit the multiplier.
+//
+// The one guarantee the derivation gave for free — that this stays STRICTER
+// than the swipe floor — is asserted rather than assumed: `BETWEEN_FLOOR_AND_
+// COMMIT` in `pullGesture.test.ts` sits between the two and reds the moment
+// they cross. The general rule, and why `PULL_MAX_OFFSET_PX` in
+// `DirectoryPane.tsx` STAYS derived from this constant in the same change:
+// derive when the approved thing is a RATIO, write the literal when the
+// measured thing is a DISTANCE.
+export const PULL_COMMIT_PX = 160;
 
 // Worn by the bound element for exactly as long as the finger is driving a
 // CLAIMED pull, so the stylesheet can drop its snap-back transition and let the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58058,3 +58058,123 @@ nowhere, and cannot be from here.** jsdom drives no compositor and Playwright's
 webkit does not reproduce real iOS scroll physics; every gate in this repo can
 say the travel is bounded and monotone and none of them can say it feels like a
 native scroller. That reading is vjt's, on the phone.
+<!-- entry #1671 -->
+
+---
+
+## 2026-08-22 — #1671: the pull distance stops being a default and becomes a measurement
+
+The entry directly above this one ends on a sentence that was still an IOU:
+*"That reading is vjt's, on the phone."* This is that reading arriving. vjt
+pulled the channel directory on a real device against the staging build of
+`1.3.1-c6f46686` and called it: the travel needed to trigger the refresh
+doubles, 80px → 160px. `PULL_COMMIT_PX` had asked for exactly this since #1445
+wrote it — *"Doubling is a defensible default, NOT a measurement […] vjt
+calibrates on-device; nothing here was verified on a phone."* The number is now
+a datum, and the sentence calling it a default is the part that became false.
+
+### The rule the change is really about: derive a ratio, write a distance
+
+Two spellings reach 160 and the issue recommended the first: `SWIPE_MIN_PX * 4`,
+keeping the derivation, versus a plain literal. It is not an orthography
+question and the literal was taken.
+
+`SWIPE_MIN_PX = 40` answers a DIFFERENT question — *was this a gesture at all* —
+for four binders. Spelling a measured distance as a multiple of it asserts a
+causality that has stopped being true, and the harm is directional: whoever
+recalibrates the swipe floor on a device next would silently drag a distance
+somebody else measured with a thumb, and nothing in the resulting red would say
+so. The lattice bites the other way too. The next on-device call need not land
+on a multiple of 40; a constant spellable only in 40px steps invites rounding
+the measurement to fit the multiplier, or an `* 4.5` that is a lie with a
+decimal point in it.
+
+So the pair now states one rule at both declarations. **Derive when the approved
+thing is a RATIO; write the literal when the measured thing is a DISTANCE.**
+That is why `PULL_MAX_OFFSET_PX = PULL_COMMIT_PX * 2` STAYS derived in the same
+commit and follows to 320px on its own: what vjt approved there is the elastic's
+shape relative to the commit point, and freezing a literal would pin that shape
+against the next recalibration instead of tracking it. Whether 320px is now too
+much travel is its own measurement and its own issue.
+
+### What the derivation was doing, and where each job went
+
+Two jobs, and they separated cleanly.
+
+The ordering guarantee — the commit distance staying STRICTER than the swipe
+floor — was structural and is now asserted: `BETWEEN_FLOOR_AND_COMMIT` in
+`pullGesture.test.ts` is `(SWIPE_MIN_PX + PULL_COMMIT_PX) / 2` and reds the
+moment the two cross. It already existed, written for a #1445 mutant; nothing
+was added for this.
+
+The second job is knowingly given up. #1646's mirror pin listed
+`PULL_COMMIT_PX` as one of TWO DERIVED arms, the interesting case where *"the
+copy freezes a number that can be moved from a module the copy does not even
+name"*. There is one such arm now (`UNREAD_RETENTION_CAP = PAGE_LIMIT`). That
+loss is the point rather than a regression: the pin faithfully tracked a
+coupling this change exists to cut, so the reach it loses is reach it should no
+longer have. Three prose sites arguing for that reach are corrected rather than
+left to rot.
+
+The pin itself is untouched, and it is what made this land cleanly. Changing
+production alone turned it red on its own row — `expected 80 to be 160`, naming
+`issue1445-directory-pull-refresh.spec.ts:188`. A frozen copy left behind is a
+red that names its line, which is exactly what #1646 was built to buy.
+
+### The derived figure, recomputed rather than copied
+
+`0.44` is not a constant anywhere; it is `slotHeight / PULL_COMMIT_PX` quoted in
+prose in three places as the opacity the spinner would top out at under the
+naive fix #1658 refused. The slot is `2.5rem` against a default
+`--font-size: 14px` = 35px, so it halves with the commit distance: 35/160 =
+**0.22**, where it was 35/80 = 0.44. Both live comment sites now carry 0.22 and
+say what halved them.
+
+A nude grep for `80` and `0.44` across `cicchetto/src`, `cicchetto/e2e` and
+`docs` is what closed the census, and it earned its keep: it found a site no
+issue listed — `measureAtFullTravel`'s comment calling the commit point 80 while
+its own drag is 400.
+
+### 🔴 The historical entries above are NOT rewritten, and that is deliberate
+
+Both the issue and the briefing asked for the several places in this file that
+say *"80px, `SWIPE_MIN_PX * 2`"* and *"0.44 at the default size"* to be updated.
+That was declined, and the refusal is the durable part.
+
+This file is the chronological decision log. An entry dated when `PULL_COMMIT_PX`
+was 80 and derived is a TRUE statement about that date, and editing the number
+inside it would make the log lie about its own history — destroying the very
+evidence that a recalibration happened, which is the thing a decision log exists
+to hold. Several of those passages are load-bearing arguments that would go
+incoherent under a find-and-replace: #1658's entry reasons *"the alternative
+worth having is damping past the commit point; that needs a constant measured on
+a device, and `PULL_COMMIT_PX`'s own comment already records that nothing about
+this gesture was verified on a phone"*, and #1669's ends by naming this
+calibration as the thing it could not establish. Those sentences are worth MORE
+now that the measurement exists, not less.
+
+The general rule, which is not specific to this constant: **a stale number in a
+DATED entry is history and stays; a stale number in a MODULE comment is a claim
+about the present and must move.** Code comments are read as the current rule by
+whoever opens the file — that is why every one of them changed here — and a
+chronological entry is read as a record of a moment. Fixing a documentation
+citation means fixing the CLASS, and for this file the class fix is a new entry,
+which is this one.
+
+### Not established
+
+**iOS parity, still, and this change does not touch that.** The distance is now
+a device measurement but the FEEL around it is not: jsdom drives no compositor
+and Playwright's WebKit does not reproduce real iOS scroll physics. What is
+claimed is that the trigger travel is the one vjt asked for.
+
+**The doubled ceiling has not been on a phone.** `PULL_MAX_OFFSET_PX` follows to
+320px by derivation and is still a provisional feel number; preserving the ratio
+preserves the shape vjt approved, which is an argument and not a measurement.
+
+**Nothing here was run in a browser.** The vitest suite is green (299 files,
+5831 tests) and so is the cic `check` gate, but the e2e lane needs the shared
+stack and was not run for this change. The e2e arithmetic was checked on paper
+instead: at 400px of finger the damped offset is now 256px, so
+`PULL_COMMIT_PX < moved < FULL_TRAVEL_PX` still brackets it — 160 < 256 < 400,
+where it was 80 < 144 < 400.


### PR DESCRIPTION
Closes out the on-device calibration in #1671: the travel needed to trigger the channel-directory pull-to-refresh doubles, 80px → 160px.

vjt measured it on a real phone against the staging build of `1.3.1-c6f46686`. The constant's own comment had been asking for exactly this since #1445 wrote it — *"Doubling is a defensible default, NOT a measurement […] vjt calibrates on-device; nothing here was verified on a phone."* The measurement has now been taken, so the number is a datum and the sentence calling it a default is the part that became false.

## The one decision worth reviewing: literal, not `SWIPE_MIN_PX * 4`

Both spellings reach 160 today. The issue recommended keeping the derivation; **the literal was taken instead**, and the reasoning is in the commit and in the DESIGN_NOTES entry. In short:

- `SWIPE_MIN_PX = 40` answers a **different** question (*was this a gesture at all*) for four binders. Spelling a measured distance as a multiple of it asserts a causality that has stopped being true, and the harm is directional — whoever recalibrates the swipe floor next would silently drag a distance somebody measured with a thumb, and nothing in the resulting red would say so.
- The lattice bites the other way too: the next on-device call need not land on a multiple of 40, and a constant spellable only in 40px steps invites rounding the measurement to fit the multiplier.

The rule both declarations now state: **derive when the approved thing is a RATIO, write the literal when the measured thing is a DISTANCE.** That is why `PULL_MAX_OFFSET_PX = PULL_COMMIT_PX * 2` **stays derived** in the same commit and follows to 320px on its own — the elastic's shape relative to the commit point is what was approved there. `SWIPE_MIN_PX` is untouched.

This is a one-line revert if vjt prefers the derivation.

## What moved

| Site | Change |
|---|---|
| `src/lib/pullGesture.ts` | `PULL_COMMIT_PX = SWIPE_MIN_PX * 2` → `160`; comment rewritten, `SWIPE_MIN_PX` import dropped |
| `src/DirectoryPane.tsx` | `PULL_MAX_OFFSET_PX` comment: stops borrowing a disclaimer that no longer holds, states why it stays derived |
| `src/DirectoryPane.tsx` + `__tests__/DirectoryPane.test.tsx` | spinner-ramp figure recomputed, `0.44` → `0.22` |
| `e2e/tests/issue1445-directory-pull-refresh.spec.ts` | frozen copy `80` → `160`, plus a comment the issue did not list |
| `src/__tests__/e2eConstantMirrors.test.ts` | `origin` string and the "two DERIVED arms" prose |
| `docs/DESIGN_NOTES.md` | new entry |

`0.22` is recomputed, not copied: the slot is `2.5rem` against a default `--font-size: 14px` = 35px, so 35/160 = 0.22 where it was 35/80 = 0.44.

## The pin did its job

Changing production alone turned `e2eConstantMirrors` red on its own row — `expected 80 to be 160`, naming `issue1445-directory-pull-refresh.spec.ts:188`. That red is the RED-first oracle for this change, captured before the copy was updated.

Knowingly paid: the pin loses its second **DERIVED** arm (it no longer watches a third module). That reach was tracking the coupling this change exists to cut, so losing it is the point rather than a regression. Three prose sites arguing for it are corrected rather than left to rot.

## The historical DESIGN_NOTES numbers are NOT rewritten

The issue asked for the dated entries quoting *"80px, `SWIPE_MIN_PX * 2`"* and *"0.44"* to be updated in place. **Declined.** This file is the chronological decision log; those statements were true on their dates, and a find-and-replace would destroy the evidence that a recalibration happened while leaving #1658's and #1669's reasoning incoherent — both argue **from** the fact that nothing had been measured.

The rule is written into the new entry: *a stale number in a DATED entry is history and stays; a stale number in a MODULE comment is a claim about the present and moves.* Every module comment moved.

## Gates

- `bun.sh run test` — **299 files, 5831 tests, green** (rc=0)
- `bun.sh run check` — **4 stages, 0 failed** (rc=0): lock drift, biome, tsc src, tsc e2e
- `scripts/design-notes-gate.sh` — green, marker + separator present
- A **nude grep** for `80` and `0.44` across `cicchetto/src`, `cicchetto/e2e` and `docs` closed the census and found one site no issue listed (`measureAtFullTravel`'s comment calling the commit point 80 while its own drag is 400).

**The #1669 property tests are green UNCHANGED** — the only edit inside a test body in this branch is prose. That is what they were written for: a property survives a recalibration, a number does not.

## Not established

- **The e2e lane was not run** (it needs the shared stack). Its arithmetic was checked on paper instead: at 400px of finger the damped offset is now 256px, so `PULL_COMMIT_PX < moved < FULL_TRAVEL_PX` still brackets it — 160 < 256 < 400, where it was 80 < 144 < 400.
- **iOS parity**, as always here, is claimed nowhere: jsdom drives no compositor and Playwright's WebKit does not reproduce real iOS scroll physics.
- **The doubled 320px ceiling has not been on a phone.** It follows by derivation and preserving the ratio preserves the approved shape — an argument, not a measurement. If it is too much travel, that is its own issue.
