### PR TITLE
docs(#1668): retire the comments that still licensed a still protocol_version

### DIFF
--- a/cicchetto/src/__tests__/socket.test.ts
+++ b/cicchetto/src/__tests__/socket.test.ts
@@ -373,9 +373,16 @@ describe("cic declares the client protocol version to the socket (#1379)", () =>
 });
 
 // #1379 — the user-topic join reply carries the server's `protocol_version`
-// and cic dropped it on the floor. It is a diagnostic, not a gate: a
-// difference is legal under the additive-only rule, so the only correct
-// response is to make it visible to whoever is reading a console.
+// and cic dropped it on the floor. What this suite covers is the HANDOVER:
+// joinUser reads the number and hands it to `serverProtocol.ts`, which owns
+// the floor and the comparison (`serverProtocol.test.ts`).
+//
+// This comment used to call the number "a diagnostic, not a gate", because
+// "a difference is legal under the additive-only rule". #1393d withdrew that
+// on 2026-08-21: a server BEHIND cic's floor now raises a banner, not a
+// console line. Only the server-AHEAD direction is still nothing to gate on.
+// The `console.warn` covers both because a bundle/BEAM skew on a
+// service-worker-cached PWA is invisible from every other signal.
 describe("joinUser consumes the join reply's protocol_version (#1379)", () => {
   async function joinAndReply(reply: unknown): Promise<MockInstance> {
     localStorage.setItem("grappa-token", "tok-proto-reply");

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -850,8 +850,11 @@ export function pushRaw(networkId: number, line: string): Promise<void> {
 // #606 — the WHOIS request origin. `"user"` = an operator-issued /whois
 // (renders the single-slot scrollback card); `"rail"` = the query-rail
 // auto-fetch (feeds the per-nick rail cache, never the scrollback card).
-// Add-only wire field, so the server treats an absent/unknown value as
-// "user" and no protocol_version bumps.
+// Add-only wire field: the server treats an absent/unknown value as
+// "user". It landed under protocol v1 with no protocol_version bump —
+// that was the rule of the day, and #1393d withdrew it on 2026-08-21.
+// The server now bumps on EVERY wire-shape change, additive included
+// (docs/CLIENT_PROTOCOL.md §2a), so widening this union is not free.
 export type WhoisOrigin = "user" | "rail";
 
 // /whois [<server>] <nick> → WHOIS — pushes on the user-level channel.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58178,3 +58178,113 @@ stack and was not run for this change. The e2e arithmetic was checked on paper
 instead: at 400px of finger the damped offset is now 256px, so
 `PULL_COMMIT_PX < moved < FULL_TRAVEL_PX` still brackets it — 160 < 256 < 400,
 where it was 80 < 144 < 400.
+<!-- entry #1668 -->
+
+---
+
+## 2026-08-22 — #1668: the comments that still licensed a still version number
+
+vjt's ruling of 2026-08-21 (#1393d) reversed the #447 additive-only rule:
+`Grappa.Protocol.version/0` now bumps on EVERY wire-shape change, additive
+included. `CLAUDE.md`, the `Grappa.Protocol` moduledoc, `docs/CLIENT_PROTOCOL.md`
+and `mix grappa.wire_pin --check` were all moved. Comments in the code were not.
+This entry records the sweep that found them, and three things the sweep taught
+that are worth more than the edit.
+
+### The discriminator, which is what separated 10 defects from ~170 mentions
+
+The tree carries 179 lines matching `additive|add-only` and 484 matching `bump`
+across `lib/`, `cicchetto/src/`, `test/`, `cicchetto/e2e/`, `frontends/` and the
+living docs. Almost none of them are wrong, because **the ruling repealed one
+half of #447 and left the other standing**. Additive-as-emission — the server may
+add a kind or a field, a client MUST ignore what it does not know — is unchanged
+and still true wherever it is written. What fell is the LICENCE that used to be
+drawn from it: *"additive, therefore no `protocol_version` bump"*.
+
+So the test for a defect is not "does it say additive". It is **"does it conclude
+that no bump is needed"**. Ten sites concluded that; every other mention was
+describing tolerance and stays.
+
+### The issue's count was a floor, and the floor was under-stated by 4
+
+#1668 listed six sites and said so explicitly. The sweep found ten. The four the
+issue did not have: `Session.Wire`'s `window_invite_declined` docstring (a new
+event KIND, same "so no `Grappa.Protocol` bump" shape as its `window_invited`
+neighbour twelve lines up), `PushSubscriptionJSON`'s `label` moduledoc,
+`wire_test.exs`'s `window_invited/3` assertion comment, and
+`__tests__/socket.test.ts`, which asserted *"a difference is legal under the
+additive-only rule"* — the withdrawn justification, in a test whose own
+production file (`lib/socket.ts`) had already been rewritten to say the opposite.
+That last one is the interesting shape: **the fix for #1393d moved a module and
+left its test's rationale behind, so the pair now contradicted each other.**
+
+### Why one grep is never the set — twice over, and the second is new
+
+The issue proved this once: its own sweep pattern missed two sites it already
+knew about, because they spell it *"no `protocol_version` bump is needed"*.
+
+It happened again here, one level deeper, and it is the reusable part. The
+positive known-answer control in this sweep's harness was the exact sentence the
+issue quotes from `wire.ex:400`. **It failed.** Not because the site was gone —
+because the sentence WRAPS: line 400 ends `…so no`, line 401 begins
+`` `protocol_version` bump is needed. `` `git grep` is line-oriented, so no
+phrase grep can see it, and the issue's own quotation hides the wrap behind an
+ellipsis. A comment is reflowed to 80 columns by whoever last edited it, which
+means **any phrase long enough to be specific is long enough to have been
+wrapped.** The cure is to build the battery out of single TOKENS (`bump`,
+`additive`, `#447`, `protocol_version`) and pay for it by reading more hits by
+hand — tokens survive reflow, phrases do not.
+
+Third instance, same lesson from a different cause: a first count run under `zsh`
+reported **0 for all five patterns**, because `zsh` does not word-split, so
+`-- $PATHS` reached `git grep` as one pathspec that matches nothing. Zero with
+`rc=0`. A grep that cannot match reports exactly what a clean tree reports, and
+that is true whether the pattern is wrong, the corpus is wrong, or the shell ate
+the argument list. **A sweep without a known-answer control is not evidence.**
+
+### One site had a different cure: the citation was wrong before the ruling too
+
+`Session.Server`'s catch-all clause (#1338 M-S2) and its test both credited "the
+#447 additive-only contract" for letting a publisher add an event type with no
+version bump. But the topics in question — `Topic.ws_presence/1`,
+`Topic.user_settings/1` — resolve to `grappa:ws_presence:…` and
+`grappa:user_settings:…`, INTERNAL PubSub, not the `grappa:user:…` topic cic
+joins. The client-facing wire contract never governed that axis, so the citation
+was a mis-citation before 2026-08-21 and remains one after. Pasting the bump
+obligation there would have been a second wrong answer. The comment now says no
+version numbers that axis at all, which is why the catch-all has to carry it.
+
+### What was deliberately NOT changed
+
+- `CLAUDE.md` and `Grappa.Protocol`'s moduledoc QUOTE the old wording inside the
+  passage that overturns it, as do `docs/CLIENT_PROTOCOL.md` §2 and
+  `UserSocket`'s ceiling comment. Rewriting a quotation deletes the reversal's
+  own reasoning.
+- `Grappa.Push`'s `push_content_encoding` docstring and `FallbackController`'s
+  `{:rate_limited, retry_after}` clause both conclude "no bump", but neither
+  reasons from additivity: the first says an encoding switch is not a shape
+  change, the second says the response body is byte-identical. Both conclusions
+  survive the ruling intact, because the new rule keys on wire-shape change and
+  neither is one.
+- `docs/DESIGN_NOTES.md` is a chronological log. A July entry is not wrong for
+  having been superseded in August; the cure for a log is a new entry, which is
+  this one.
+- `bundle-refresh-banner.spec.ts` is about semver on a rebuild — a different axis.
+
+### Open, not decided: how far "wire-shape change" reaches
+
+`priv/wire/shape.pin` spans the GENERATED artefacts only (`wireTypes.ts` +
+`wireSchema.ts`, from the `*.Wire` typespecs). `PushSubscriptionJSON` is a Phoenix
+JSON view and is not among them, so the gate is silent on a new field there in
+either direction — while `CLAUDE.md` describes `protocol_version` as versioning
+"the client-facing wire contract", which a REST response arguably is. `label`
+itself is moot (it shipped 2026-08-20, one day before the ruling), so nothing is
+retroactively owed. The comment now names the gap rather than resolving it.
+
+### No gate was added, on purpose
+
+The obvious follow-up is a grep gate for the stale phrasing. This sweep is the
+argument against one: the defect class is prose, three independent searches here
+each returned a different subset, and the one that wrapped across a line break
+is invisible to the whole technique. A gate that greens on the sentence it cannot
+see is a floor that lies — the same failure the ruling itself was about.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3598,8 +3598,14 @@ defmodule Grappa.Session.Server do
 
   # #1338 M-S2 — unknown-is-never-fatal, verbatim from `IRC.Client`. This
   # process subscribes to `Topic.ws_presence/1` and `Topic.user_settings/1`,
-  # and the #447 additive-only contract lets a publisher add an event type at
-  # any time with no version bump and no compile error. Without this clause
+  # and a publisher can add an event type on either at any time with no
+  # compile error. This used to cite the #447 additive-only contract as the
+  # licence, which was a mis-citation in both directions: those are INTERNAL
+  # PubSub topics (`grappa:ws_presence:…`, `grappa:user_settings:…`), not the
+  # client-facing wire cic joins (`grappa:user:…`), so neither #447 nor the
+  # #1393d bump obligation that replaced its no-bump half on 2026-08-21
+  # reaches them. No version numbers this axis at all — which is precisely
+  # why the catch-all has to carry it. Without this clause
   # the first such addition takes down EVERY session of that subject with a
   # FunctionClauseError — dropping a live IRC connection over a change made
   # in an unrelated context. Loud, logged, and narrower than it looks: the

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -397,8 +397,14 @@ defmodule Grappa.Session.Wire do
   rule), only the typed source + the raw reply lines.
 
   Additive per the #447 wire contract: a client that does not know
-  `:admin` ignores the frame rather than breaking, so no
-  `protocol_version` bump is needed.
+  `:admin` ignores the frame rather than breaking. That half of #447
+  stands — but it no longer licenses a still version number. Since
+  vjt's ruling (2026-08-21, #1393d) `Grappa.Protocol.version/0` bumps
+  on EVERY wire-shape change, additive included, and this union is in
+  the pinned shape (`SESSION_WIRE_SERVER_REPLY_SOURCE` in the generated
+  `wireTypes.ts`), so a FIFTH source costs a bump and
+  `mix grappa.wire_pin --check` is what says so. `:admin` itself
+  predates the ruling and shipped under v1 without one.
 
   The union is DERIVED from `@server_reply_sources` rather than spelled
   twice. #992 shipped `:admin` into the union but not into the copy of
@@ -558,8 +564,11 @@ defmodule Grappa.Session.Wire do
           target: String.t(),
           # #606 — request origin. `"user"` = operator-issued /whois (the
           # single-slot scrollback card); `"rail"` = query-rail auto-fetch.
-          # Add-only (no protocol_version bump); an old client ignores it and
-          # cic treats an absent value as "user".
+          # Add-only: an old client ignores it and cic treats an absent
+          # value as "user". Add-only is NOT a bump exemption — it shipped
+          # under v1, before the 2026-08-21 ruling (#1393d) made every
+          # wire-shape change bump `Grappa.Protocol.version/0`. Widening
+          # this union today costs one.
           source: :user | :rail,
           user: String.t() | nil,
           host: String.t() | nil,
@@ -1345,9 +1354,12 @@ defmodule Grappa.Session.Wire do
   the user-topic is joined from boot so delivery is guaranteed. Same
   `window_`-namespaced naming convention.
 
-  #902 — carries `inviter`, the nick that sent the INVITE. ADDITIVE field,
-  so no `Grappa.Protocol` version bump (the wire contract is additive-only
-  and a client ignores what it does not know). The greyed tab this event
+  #902 — carries `inviter`, the nick that sent the INVITE. ADDITIVE: a
+  client that does not know it ignores it, and that much of the wire
+  contract is unchanged. It shipped WITHOUT a `Grappa.Protocol` version
+  bump, and `inviter` is one of the five un-bumped additions the ruling
+  cites by name — since 2026-08-21 (#1393d) a field added here bumps
+  `version/0`, additive or not. The greyed tab this event
   used to open is gone; cic now renders a dismissable banner reading
   "<nick> is inviting you to #chan", which needs the nick at event time —
   the persisted INVITE row it used to be read from lives in a channel
@@ -1383,9 +1395,13 @@ defmodule Grappa.Session.Wire do
   window, so absence there is unobservable — this event IS the observation.
   Nothing is sent upstream; IRC has no DECLINE.
 
-  ADDITIVE (a new event kind), so no `Grappa.Protocol` bump: an older client
-  ignores it and simply keeps behaving as it did pre-#976 (the banner returns
-  on ITS next reload; the server-side state is gone either way).
+  ADDITIVE (a new event kind): an older client ignores it and simply keeps
+  behaving as it did pre-#976 (the banner returns on ITS next reload; the
+  server-side state is gone either way). It shipped with no
+  `Grappa.Protocol` bump, under the rule of the day; since 2026-08-21
+  (#1393d) a new event kind bumps `version/0` like any other shape change —
+  the kind is in the pinned shape, so `mix grappa.wire_pin --check` enforces
+  it rather than leaving it to the author to remember.
   """
   @spec window_invite_declined(String.t(), String.t()) :: window_invite_declined_payload()
   def window_invite_declined(network_slug, channel)

--- a/lib/grappa_web/controllers/push_subscription_json.ex
+++ b/lib/grappa_web/controllers/push_subscription_json.ex
@@ -28,9 +28,20 @@ defmodule GrappaWeb.PushSubscriptionJSON do
     * `:device` (PATCH 200) — one `subscription_summary()`, the same
       shape an `:index` row carries.
 
-  `label` is a NEW additive field on an existing shape, so per the
-  additive-only wire contract (#447) it costs no `protocol_version`
-  bump: a client that does not know it simply ignores it.
+  `label` is a NEW additive field on an existing shape: a client that
+  does not know it simply ignores it. It shipped with no
+  `protocol_version` bump, one day before vjt's ruling (2026-08-21,
+  #1393d) made every wire-shape change bump `Grappa.Protocol.version/0`,
+  additive included — so read the absence as a date, not as a standing
+  exemption.
+
+  What the ruling does NOT settle is reach, and this view sits on the
+  unsettled side: `priv/wire/shape.pin` spans the GENERATED artefacts
+  only (`wireTypes.ts` + `wireSchema.ts`, built from the `*.Wire`
+  typespecs), and a REST JSON view is not among them, so the gate is
+  silent here in either direction. A new field on this shape gets the
+  ruling applied by hand, or the scope question asked — not a silent
+  pass because nothing went red.
 
   ## Why no endpoint/keys in any list shape
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -13195,8 +13195,10 @@ defmodule Grappa.Session.ServerTest do
   describe "unmodelled mailbox message (#1338 M-S2)" do
     test "an unrecognised message is logged and the session keeps serving" do
       # The server subscribes to `Topic.ws_presence/1` and
-      # `Topic.user_settings/1` — the settings bridge is a surface the
-      # #447 additive-only contract lets grow WITHOUT a version bump. Before
+      # `Topic.user_settings/1` — INTERNAL PubSub topics, not the
+      # client-facing wire, so no version governs their growth at all (this
+      # used to credit the #447 additive-only contract, which never reached
+      # this axis and whose no-bump half #1393d withdrew anyway). Before
       # #1338 a second tuple published by `Grappa.UserSettings` reached 40
       # clauses and no catch-all: FunctionClauseError, supervisor restart,
       # and the user's IRC connection dropped by an unrelated context.

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -591,9 +591,11 @@ defmodule Grappa.Session.WireTest do
       # window_pending (cic subscribes per-channel after seeing the state).
       #
       # #902 — `inviter` is the nick cic's replacement surface (a banner
-      # reading "<nick> is inviting you to #chan") renders. Additive field:
-      # no protocol bump, and asserting the WHOLE map means a silent drop of
-      # it fails here.
+      # reading "<nick> is inviting you to #chan") renders. It shipped as an
+      # additive field with no protocol bump; #1393d (2026-08-21) withdrew
+      # that exemption, so a field added here now moves
+      # `Grappa.Protocol.version/0` too. Asserting the WHOLE map means a
+      # silent drop of it fails here.
       assert Wire.window_invited("azzurra", "#grappa", "vjt") == %{
                kind: :window_invited,
                network: "azzurra",


### PR DESCRIPTION
Refs #1668.

The 2026-08-21 ruling (#1393d) reversed #447's additive-only rule:
`Grappa.Protocol.version/0` now bumps on EVERY wire-shape change, additive
included. `CLAUDE.md`, the `Grappa.Protocol` moduledoc, `docs/CLIENT_PROTOCOL.md`
and `mix grappa.wire_pin --check` were moved. Comments in the code were not — a
reader adding a field beside one of them was told, in the file they were
editing, that the pin would stay green.

## The discriminator

The tree carries 179 lines matching `additive|add-only` and 484 matching `bump`.
Almost none are wrong, because the ruling repealed **one half** of #447 and left
the other standing. Additive-as-emission — a client ignores what it does not
know — is unchanged. What fell is the licence drawn from it: *"additive,
therefore no bump"*. So the test is not "does it say additive" but **"does it
conclude that no bump is needed"**. Ten sites concluded that.

## The count was a floor, and it was under by 4

#1668 listed six and said so. Four more, none in the issue:

- `Session.Wire:1386` — `window_invite_declined`, same wording as a listed
  sibling twelve lines above
- `PushSubscriptionJSON` — the `label` moduledoc
- `wire_test.exs` — the `window_invited/3` assertion comment
- `__tests__/socket.test.ts` — asserted *"a difference is legal under the
  additive-only rule"*, the withdrawn justification, **in a test whose own
  production file (`lib/socket.ts`) had already been rewritten to say the
  opposite at length**. The #1393d fix moved the module and left its test's
  rationale behind, so the pair contradicted each other.

## Why one grep is never the set — and the new instance

The issue proved this once: its sweep missed two sites it already knew about,
on spelling.

It happened again, one level deeper. The **positive known-answer control** in
this sweep was the exact sentence the issue quotes from `wire.ex:400`. **It
failed** — not because the site was gone, but because the sentence **wraps**:
`:400` ends `…so no`, `:401` begins `` `protocol_version` bump is needed. ``
`git grep` is line-oriented, and the issue's own quotation hides the wrap behind
an ellipsis. Any phrase specific enough to be useful is long enough to have been
reflowed to 80 columns, so the battery has to be built from single **tokens**.

Fourth instance, different cause: a first count under `zsh` reported **0 for all
five patterns**, because `zsh` does not word-split and `-- $PATHS` reached
`git grep` as one pathspec matching nothing. Zero, `rc=0` — indistinguishable
from a clean tree. A sweep without a known-answer control is not evidence.

## One site got a different cure

`Session.Server`'s #1338 catch-all and its test credited "the #447 additive-only
contract" for `Topic.ws_presence/1` / `Topic.user_settings/1`. Those resolve to
`grappa:ws_presence:…` / `grappa:user_settings:…` — **internal PubSub**, not the
`grappa:user:…` topic cic joins. The client wire contract never governed that
axis, so the citation was wrong *before* the ruling and remains wrong after.
Pasting the bump obligation there would have been a second wrong answer. Both
now say no version numbers that axis at all.

## Deliberately not changed

- `CLAUDE.md`, `Grappa.Protocol`'s moduledoc, `CLIENT_PROTOCOL.md` §2 and
  `UserSocket`'s ceiling comment **quote** the old wording inside the passage
  that overturns it.
- `Grappa.Push:132` and `FallbackController:265` conclude "no bump" but do not
  reason from additivity (an encoding switch is not a shape change; the response
  body is byte-identical). Both conclusions survive the ruling.
- `docs/DESIGN_NOTES.md` is chronological — the cure for a log is a new entry.
- `bundle-refresh-banner.spec.ts` is semver on a rebuild, a different axis.

## Open, not decided

`priv/wire/shape.pin` spans the GENERATED artefacts only (`wireTypes.ts` +
`wireSchema.ts`, from the `*.Wire` typespecs). `PushSubscriptionJSON` is a
Phoenix JSON view and is not among them, so the gate is silent on a new field
there either way — while `CLAUDE.md` describes `protocol_version` as versioning
"the client-facing wire contract", which a REST response arguably is. `label`
itself is moot (shipped 2026-08-20, one day before the ruling). The docstring
names the gap rather than resolving it; the scope call is vjt's.

## No gate added, on purpose

The obvious follow-up is a grep gate for the stale phrasing. This sweep is the
argument against one: the class is prose, three independent searches returned
three different subsets, and the site that wrapped is invisible to the whole
technique. A gate that greens on the sentence it cannot see is a floor that
lies — the same failure the ruling was about.

## Gates

| gate | result |
|---|---|
| `bun.sh run check` (lock drift, biome src+e2e, tsc src, tsc e2e) | rc=0, 4/4 stages |
| `bun.sh run test` (vitest) | rc=0, **299/299 files**, 0 failures |
| `scripts/design-notes-gate.sh` | rc=0 — 1 new entry, separator and marker present |
| line length vs Credo (max 120) | max measured 81 |

**Not run, and not claimed:** no Elixir gate at all — `scripts/check.sh` was not
run (no lane). `scripts/integration.sh` not run. No e2e (no e2e file touched).
biome reports 59 warnings tree-wide, **zero in the two cic files touched here**,
measured by grepping the paths.

**Not proven:** that the count is now complete. It is a better floor, not a
ceiling — three searches gave three subsets and I have no argument that a fourth
is the set. And the comments assert that a new field in these unions turns the
pin red; that is **derived** (the pin's coverage line plus the presence of
`SESSION_WIRE_SERVER_REPLY_SOURCE`, `source`, `inviter` and
`window_invite_declined` in the generated `wireTypes.ts`), **not measured** — no
mutation was run, which would need the Elixir toolchain.