### PR TITLE
fix(#1674): a service or the server naming you is not a mention

### DIFF
--- a/cicchetto/src/__tests__/mentionMatch.test.ts
+++ b/cicchetto/src/__tests__/mentionMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { matchesWatchlist } from "../lib/mentionMatch";
+import { isMentionableSender, matchesWatchlist } from "../lib/mentionMatch";
 
 // #370 — `matchesWatchlist` is the SINGLE client-side match predicate for
 // the in-message visual highlight (ScrollbackPane `.scrollback-mention` /
@@ -57,5 +57,29 @@ describe("matchesWatchlist — own nick ∪ custom highlight patterns (#370)", (
 
   it("is false when both the nick is null and there are no patterns", () => {
     expect(matchesWatchlist("anything at all", null, [])).toBe(false);
+  });
+});
+
+// #1674 — the SENDER half of the mention rule. Mirror of
+// `Grappa.Mentions.mentionable_sender?/1`. Keyed on the sender because
+// neither of the alternatives survives: excluding `:notice` silences a
+// human `/notice`, and excluding `$server` misses the service's own query
+// window, which over-counted identically (measured server-side).
+describe("isMentionableSender — a robot cannot mention you (#1674)", () => {
+  it("excludes services and the server", () => {
+    expect(isMentionableSender("NickServ")).toBe(false);
+    expect(isMentionableSender("chanserv")).toBe(false);
+    expect(isMentionableSender("nightwish.azzurra.chat")).toBe(false);
+  });
+
+  it("keeps every other sender", () => {
+    expect(isMentionableSender("bob")).toBe(true);
+    // Closed allowlist: real ops nicks merely ending in "serv" stay
+    // mentionable (bucket H/S4 regression guard).
+    expect(isMentionableSender("Conserv")).toBe(true);
+  });
+
+  it("only ever subtracts — an unclassifiable sender stays mentionable", () => {
+    expect(isMentionableSender("")).toBe(true);
   });
 });

--- a/cicchetto/src/__tests__/servicesSender.test.ts
+++ b/cicchetto/src/__tests__/servicesSender.test.ts
@@ -5,7 +5,7 @@
 // focus-shift for `/msg <Xserv>` without round-tripping.
 
 import { describe, expect, it } from "vitest";
-import { isServicesSender } from "../lib/servicesSender";
+import { isServerSender, isServicesSender } from "../lib/servicesSender";
 
 describe("isServicesSender", () => {
   it("accepts the eleven well-known services nicks (case-insensitive)", () => {
@@ -46,5 +46,25 @@ describe("isServicesSender", () => {
 
   it("rejects empty string", () => {
     expect(isServicesSender("")).toBe(false);
+  });
+});
+
+// #1674 — the SERVER half. Mirror of `Identifier.server_sender?/1`.
+describe("isServerSender — the other half of the sender classification (#1674)", () => {
+  it("accepts server names (a dot-bearing prefix)", () => {
+    expect(isServerSender("nightwish.azzurra.chat")).toBe(true);
+    expect(isServerSender("irc.libera.chat")).toBe(true);
+  });
+
+  it("rejects every nick, service nicks included", () => {
+    expect(isServerSender("vjt")).toBe(false);
+    expect(isServerSender("NickServ")).toBe(false);
+    // RFC 2812 nick specials carry no dot, so none of them trip the test.
+    expect(isServerSender("foo[bar]")).toBe(false);
+    expect(isServerSender("a|b\\c")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isServerSender("")).toBe(false);
   });
 });

--- a/cicchetto/src/lib/mentionMatch.ts
+++ b/cicchetto/src/lib/mentionMatch.ts
@@ -22,6 +22,8 @@
 // RFC 2812 nick chars include `[`, `]`, `\` etc.; the regex metacharacter
 // escape covers the cases that would otherwise blow up the RegExp constructor.
 
+import { isServerSender, isServicesSender } from "./servicesSender";
+
 const matchesTerm = (body: string | null, term: string | null): boolean => {
   if (!body || !term) return false;
   const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -33,3 +35,15 @@ export const matchesWatchlist = (
   ownNick: string | null,
   patterns: string[],
 ): boolean => [ownNick, ...patterns].some((term) => matchesTerm(body, term));
+
+// #1674 — the SENDER half of the mention rule. Mirror of
+// `Grappa.Mentions.mentionable_sender?/1`: being told something by a robot
+// is not being mentioned by somebody. A NickServ login confirmation and the
+// ircd's connect notices both spell your nick as a matter of routine, and
+// on the server that lit the highest-severity badge grappa has.
+//
+// Keyed on the SENDER, not the kind: a human `/notice` IS conversation and
+// still counts. Biased toward `true` — it only ever SUBTRACTS, so an empty
+// sender stays mentionable and the other conjuncts decide it.
+export const isMentionableSender = (sender: string): boolean =>
+  !isServicesSender(sender) && !isServerSender(sender);

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -25,7 +25,7 @@
 import { type MessageKind, NOTIFY_KINDS } from "./api";
 import { type ChannelKey, canonicalChannel } from "./channelKey";
 import { conversationMuteKey, isConversationMuted } from "./conversationMute";
-import { matchesWatchlist } from "./mentionMatch";
+import { isMentionableSender, matchesWatchlist } from "./mentionMatch";
 import { asciiFold, nickEquals } from "./nickEquals";
 import type { NotificationPrefs } from "./userSettings";
 
@@ -56,7 +56,9 @@ export type ShouldNotifyMessage = {
  *      asciiFold(sender) in private_messages_only (mirrors the
  *      server's `canonical_target(sender) in ...`).
  *   5. channel: channel_messages_all OR canonicalChannel(channel) in
- *      channel_messages_only OR (channel_mentions AND mention).
+ *      channel_messages_only OR (channel_mentions AND mentionable sender
+ *      AND mention). #1674 — a service or the server naming you is not a
+ *      mention, on the MENTION disjunct only.
  */
 export function shouldNotify(
   message: ShouldNotifyMessage,
@@ -158,6 +160,12 @@ function channelMatch(
     // brackets.
     prefs.channel_messages_all ||
     prefs.channel_messages_only.includes(canonicalChannel(message.channel)) ||
-    (prefs.channel_mentions && matchesWatchlist(message.body, ownNick, patterns))
+    // #1674 — the sender half of the mention rule, mirroring the server's
+    // `mention_match?/4`. Only the MENTION disjunct carries it: asking for
+    // ALL channel messages, or whitelisting a window, is an explicit request
+    // that a service reply still honours. A mention is not.
+    (prefs.channel_mentions &&
+      isMentionableSender(message.sender) &&
+      matchesWatchlist(message.body, ownNick, patterns))
   );
 }

--- a/cicchetto/src/lib/servicesSender.ts
+++ b/cicchetto/src/lib/servicesSender.ts
@@ -42,3 +42,13 @@ export function isServicesSender(s: string): boolean {
   if (first === "#" || first === "&" || first === "+" || first === "!") return false;
   return SERVICES.has(s.toLowerCase());
 }
+
+// #1674 — the SERVER half of the sender classification. Mirrors
+// `Grappa.IRC.Identifier.server_sender?/1`.
+//
+// The single `.` is exact rather than heuristic: the server's `@nick_regex`
+// character class has no dot in either position, so a sender carrying one
+// cannot be a nick, and an IRC prefix is one or the other.
+export function isServerSender(s: string): boolean {
+  return s.includes(".");
+}

--- a/cicchetto/src/lib/shouldNotifyTruthTable.json
+++ b/cicchetto/src/lib/shouldNotifyTruthTable.json
@@ -733,5 +733,85 @@
     },
     "patterns": [],
     "expected": true
+  },
+  {
+    "name": "mention (#1674): a services PRIVMSG spelling own nick does NOT notify",
+    "message": {
+      "kind": "privmsg",
+      "channel": "$server",
+      "sender": "MemoServ",
+      "body": "vjt, you have 1 new memo."
+    },
+    "network_slug": "azzurra",
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "mention (#1674): a server-originated PRIVMSG spelling own nick does NOT notify",
+    "message": {
+      "kind": "privmsg",
+      "channel": "$server",
+      "sender": "nightwish.azzurra.chat",
+      "body": "*** Notice -- Client connecting: vjt"
+    },
+    "network_slug": "azzurra",
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "mention (#1674): the exclusion is by SENDER — a peer mention still notifies",
+    "message": {
+      "kind": "privmsg",
+      "channel": "#sniffo",
+      "sender": "Conserv",
+      "body": "vjt: are you there?"
+    },
+    "network_slug": "azzurra",
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "mention (#1674): channel_messages_all still delivers a services row — only the mention disjunct is gated",
+    "message": {
+      "kind": "privmsg",
+      "channel": "$server",
+      "sender": "MemoServ",
+      "body": "vjt, you have 1 new memo."
+    },
+    "network_slug": "azzurra",
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": true,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": true
   }
 ]

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58288,3 +58288,95 @@ argument against one: the defect class is prose, three independent searches here
 each returned a different subset, and the one that wrapped across a line break
 is invisible to the whole technique. A gate that greens on the sentence it cannot
 see is a floor that lies — the same failure the ruling itself was about.
+<!-- entry #1674 -->
+
+---
+
+## 2026-08-22 — #1674: a robot spelling your nick is not a mention
+
+A user reported, with a screen recording, a red `@1` on the server tab that
+"never goes away" — gone while the server window is open, back on the next tab
+switch. Measured read-only on prod (azzurra, `network_id = 1`): row `id
+2957172`, `channel = "$server"`, `kind = :notice`, `sender = "NickServ"`, body
+`Password accepted for <nick>. You are now identified.` The login confirmation
+spells the operator's own nick, and every layer below it then did exactly what
+it was specified to do. The "it comes back" half was the documented focus-zero
+overlay (`cicchetto/src/lib/mentions.ts`) and was never the bug; the badge
+cleared for real only when the read cursor advanced.
+
+### The layers were right; the input was wrong
+
+`Mentions.mentioned?/3` is a predicate on the BODY. `:notice` is in
+`Message.content_kinds/0`, so the row counted as unread content, and nothing
+anywhere asked WHO sent it. So a NickServ confirmation — and equally an ircd
+notice, which routinely names the connecting nick — lit the highest-severity
+badge grappa has, on a window most operators never open, and kept it lit.
+
+### The discriminator is the SENDER, not the kind and not the channel
+
+Two cures were available and only one is right.
+
+Excluding `:notice` wholesale is wrong: a human `/notice vjt ...` IS
+conversation, and the mention it raises is the one the feature exists for.
+That half breaks silently — nothing would have told us.
+
+Excluding the `$server` channel is wrong because the defect is not confined to
+it, which the issue flagged as unmeasured. Measured here, as a failing test
+before the fix: `EventRouter.open_query_or_server/2` (#400, generalised by
+#546) re-keys a services NOTICE onto the SERVICE'S OWN query window whenever
+the operator has one open, and `snapshot/7` on channel `"nickserv"` returned
+`mentions: 1` for the identical row. A channel-shaped cure would have fixed the
+reported window and left the one an operator who `/msg`s NickServ actually
+looks at.
+
+So the rule is on the sender, and it composes the two verbs that already
+answer the same question for message ROUTING:
+`Grappa.Mentions.mentionable_sender?/1` = not `Identifier.services_sender?/1`
+and not `Identifier.server_sender?/1`.
+
+`server_sender?/1` is new only as a name — the single-dot test has been
+routing dot-bearing NOTICE senders to `$server` since the notice matrix
+landed, inline in `EventRouter`. It was promoted rather than restated, and it
+is exact rather than heuristic: `@nick_regex`'s character class has no dot, so
+a sender carrying one cannot be a nick, and an IRC prefix is one or the other.
+`IdentifierTest` pins that disjointness as a property.
+
+The predicate is total and biased toward `true`: it only ever SUBTRACTS, so an
+input it cannot classify stays mentionable and the other conjuncts decide it.
+A fallback clause that silently excluded would be the same defect again.
+
+### One rule, folded at every door
+
+The issue asked for one SSOT so `count_mentions/6` and `count_tail_mentions/3`
+could not diverge. They were already two byte-identical closures, which is
+precisely the shape that made this defect cost four sites instead of one — so
+the fold itself collapsed into `WindowCounts.mention_row?/3` (own-sent, then
+mentionable sender, then body match) and both counting doors now call it.
+
+Two more doors fold the same notion and were closed with it, deliberately
+beyond the issue's text: `aggregate_mentions/6` (the C8 mentions-while-away
+bundle would otherwise still LIST the row whose badge no longer counts) and
+`Push.Triggers.mention_match?/4` (the OS push). The push arm is closed by code
+reading, not by a measured prod arrival: the kind gate already drops every
+`:notice`, so only a services PRIVMSG could reach it, and bahamut's services
+deliver by NOTICE. It is a hole in the door, not an observed leak.
+
+The push mirror `cicchetto/src/lib/pushTriggers.ts` moved in lockstep, with
+four new rows in the shared `shouldNotifyTruthTable.json` that both ports read
+— including one asserting that `channel_messages_all` STILL delivers a service
+row, because only the mention disjunct is gated. Asking for every channel
+message is an explicit request; a mention is an inference.
+
+### What was measured and declined
+
+cic's per-row `.scrollback-mention` was named as needing to move in lockstep.
+It does not: `ScrollbackLine`'s `isMention()` is already gated on
+`kind === "privmsg"`, so it has never highlighted ANY notice, service or human.
+The client is stricter than the server here, in both directions — it also
+misses a peer `/me` and a peer `/notice` that name you — and reconciling that
+axis is a separate question from this one. Untouched, and stated rather than
+quietly assumed.
+
+`aggregate_mentions/6` also does not exclude OWN-sent rows, unlike both badge
+doors: your own line quoting your own nick appears in the away bundle. Real,
+a different axis, left alone.

--- a/lib/grappa/irc/identifier.ex
+++ b/lib/grappa/irc/identifier.ex
@@ -742,6 +742,28 @@ defmodule Grappa.IRC.Identifier do
 
   def services_sender?(_), do: false
 
+  @doc """
+  True iff `s` is a SERVER name rather than a nick — the other half of the
+  sender classification `services_sender?/1` opens.
+
+  The test is a single `.`, and that is exact rather than heuristic:
+  `@nick_regex`'s character class has no dot in either position, so a
+  sender carrying one cannot be a nick and an IRC prefix is one or the
+  other. `IdentifierTest` pins the disjointness as a property.
+
+  `Grappa.Session.EventRouter` has routed a dot-bearing NOTICE sender to
+  the synthetic `"$server"` window since the notice matrix landed; #1674
+  promoted the inline test here so the mention fold
+  (`Grappa.Mentions.mentionable_sender?/1`) could reuse the verb instead
+  of restating it. Two copies of "is this the server" would be the defect
+  of tomorrow — the whole reason #1674 exists is a rule that lived in one
+  door and not the others.
+  """
+  @spec server_sender?(term()) :: boolean()
+  def server_sender?(s) when is_binary(s), do: String.contains?(s, ".")
+
+  def server_sender?(_), do: false
+
   # Channel-membership sigil precedence: op > halfop > voice. Mirrors
   # cic's `memberSigil` (@ > % > +) so server snapshot and client render
   # agree on which glyph a multi-moded member shows.

--- a/lib/grappa/mentions.ex
+++ b/lib/grappa/mentions.ex
@@ -57,14 +57,46 @@ defmodule Grappa.Mentions do
   Mirror of `cicchetto/src/lib/mentionMatch.ts`'s `mentionsUser/2`. A
   regex tweak (e.g. broader Unicode word-boundary support) MUST land
   in both ports together.
+
+  ## `mentionable_sender?/1` — the SENDER half (#1674)
+
+  The body predicate above answers "does this text name me". It cannot
+  answer "did a PERSON name me", and that is the axis #1674 was filed on:
+  a NickServ login confirmation (`Password accepted for <nick>. You are
+  now identified.`) and the ircd's own connect notices both spell the
+  operator's nick as a matter of routine, and both lit the highest-severity
+  badge grappa has on a window almost nobody opens.
+
+  `mentionable_sender?/1` is the second conjunct — a pure sender
+  classification composed from the two `Grappa.IRC.Identifier` verbs that
+  already decide the SAME question for message routing
+  (`services_sender?/1`, `server_sender?/1`). Being told something by a
+  robot is not being mentioned by somebody.
+
+  Deliberately keyed on the SENDER, not the kind and not the channel:
+
+    * NOT the kind — a human `/notice vjt ...` IS conversation and still
+      counts. Excluding `:notice` wholesale would silence it.
+    * NOT the channel — the over-count is not confined to `$server`.
+      `EventRouter.open_query_or_server/2` re-keys a services NOTICE onto
+      the service's own query window when one is open (#400/#546), and
+      that window over-counted identically (measured under #1674).
+
+  Every server-side "is this row a mention" fold composes THIS with
+  `matches?/2`: `Grappa.WindowCounts.mention_row?/3` (the badge, both the
+  per-window and the bulk cold-load door), `aggregate_mentions/6` (the C8
+  mentions-while-away bundle) and `Grappa.Push.Triggers.mention_match?/4`
+  (the OS push). A new mention fold MUST go through it or the badge and
+  the notification start disagreeing again.
   """
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Repo, Grappa.Scrollback]
+    deps: [Grappa.IRC, Grappa.Repo, Grappa.Scrollback]
 
   import Ecto.Query
 
+  alias Grappa.IRC.Identifier
   alias Grappa.Repo
   alias Grappa.Scrollback.Message
 
@@ -85,7 +117,10 @@ defmodule Grappa.Mentions do
   Messages are returned in `server_time ASC` order (chronological).
 
   Non-content-bearing kinds (`:join`, `:part`, `:quit`, etc.) are
-  excluded — they never carry a body to match against.
+  excluded — they never carry a body to match against. Service- and
+  server-originated rows are excluded too (`mentionable_sender?/1`,
+  #1674): a NickServ confirmation naming you is not a mention, and the
+  away bundle must agree with the badge that counted it.
 
   The DB query step uses the `messages_user_id_network_id_channel_server_time_index`
   composite index. The in-memory regex step filters the (typically small)
@@ -120,7 +155,7 @@ defmodule Grappa.Mentions do
     # Compile all pattern regexes once before the loop — avoids
     # re-compilation per row × per pattern.
     compiled = build_matchers([own_nick | watchlist_patterns])
-    Enum.filter(rows, &body_matches?(&1.body, compiled))
+    Enum.filter(rows, &(mentionable_sender?(&1.sender) and body_matches?(&1.body, compiled)))
   end
 
   # ---------------------------------------------------------------------------
@@ -146,6 +181,26 @@ defmodule Grappa.Mentions do
   def mentioned?(body, own_nick, patterns)
       when (is_binary(body) or is_nil(body)) and is_binary(own_nick) and is_list(patterns) do
     matches?(body, matchers(own_nick, patterns))
+  end
+
+  @doc """
+  Returns `true` when a row from `sender` is CAPABLE of mentioning the
+  subject — i.e. `sender` is neither a well-known IRC service nor the
+  server itself (#1674).
+
+  The sender half of the mention rule; pair it with `matches?/2` (or
+  `mentioned?/3`) at every fold. See the moduledoc for WHY this is keyed on
+  the sender rather than on `:notice` or on the `$server` channel.
+
+  Total on `term()` and biased toward `true`: this predicate only ever
+  SUBTRACTS from the mention set, so an input it cannot classify (a `nil`
+  sender, a non-binary) stays mentionable and is decided by the other
+  conjuncts. A second silent exclusion rule hiding in a fallback clause is
+  exactly the shape of the defect this closes.
+  """
+  @spec mentionable_sender?(sender :: term()) :: boolean()
+  def mentionable_sender?(sender) do
+    not (Identifier.services_sender?(sender) or Identifier.server_sender?(sender))
   end
 
   @typedoc """

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -454,8 +454,15 @@ defmodule Grappa.Push.Triggers do
 
   defp channel_in_whitelist?(_, _), do: false
 
-  defp mention_match?(%Message{body: body}, prefs, own_nick, patterns) do
+  defp mention_match?(%Message{body: body, sender: sender}, prefs, own_nick, patterns) do
+    # #1674 — the sender half of the mention rule, the same conjunct the
+    # badge folds (`WindowCounts.mention_row?/3`). The kind gate already
+    # drops every `:notice`, so this closes the arrival it does NOT cover:
+    # a services PRIVMSG (MemoServ delivery) naming the operator, routed to
+    # `$server` and landing in the channel branch below the DM shape test.
+    # Badge and OS notification must never disagree about what a mention is.
     Map.get(prefs, :channel_mentions, false) and
+      Mentions.mentionable_sender?(sender) and
       Mentions.mentioned?(body, own_nick, patterns)
   end
 end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2894,7 +2894,10 @@ defmodule Grappa.Session.EventRouter do
           {String.t(), String.t()}
   defp route_non_channel_notice_non_chanserv(sender, body, state) do
     cond do
-      String.contains?(sender, ".") ->
+      # #1674 — was an inline `String.contains?(sender, ".")`. Promoted to
+      # `Identifier.server_sender?/1` so the mention fold observes the same
+      # "is this the server" rule this routing door does.
+      Identifier.server_sender?(sender) ->
         {"$server", body}
 
       Identifier.valid_nick?(sender) ->

--- a/lib/grappa/window_counts.ex
+++ b/lib/grappa/window_counts.ex
@@ -27,7 +27,10 @@ defmodule Grappa.WindowCounts do
       subject, via the SSOT predicate `Grappa.Mentions.mentioned?/3`
       (own_nick ∪ highlight patterns, word-boundary, case-insensitive).
       Own-sent rows are excluded (you cannot mention yourself), folding
-      `sender` through the ASCII nick SSOT (#121/#525). Bounded by
+      `sender` through the ASCII nick SSOT (#121/#525), and so are
+      service- / server-originated rows (`Mentions.mentionable_sender?/1`,
+      #1674 — a NickServ login confirmation is not a highlight). One
+      row-level rule, `mention_row?/3`, serves BOTH counting doors. Bounded by
       `@mention_scan_cap` — the same bounded-tail strategy
       `Grappa.Push.BadgeCount` uses (SQLite has no `REGEXP`, so the
       match runs in-memory over a capped content tail).
@@ -257,11 +260,31 @@ defmodule Grappa.WindowCounts do
     end
   end
 
-  # Mention count over a pre-fetched capped content tail (#396 bulk path),
-  # IDENTICAL fold to `count_mentions/6`'s per-window Enum.count: exclude
-  # own-sent rows (fold `sender` via the ASCII nick SSOT, #121/#525), then the
-  # `Mentions.mentioned?/3` SSOT predicate. `nil` own_nick → nothing to
-  # match, so no mentions.
+  # The ONE row-level mention rule (#1674). Both counting doors fold THIS —
+  # the per-window `count_mentions/6` and the bulk `count_tail_mentions/3` —
+  # so the badge cannot mean two different things depending on which one
+  # answered. It used to be two byte-identical closures, and #1674 is what a
+  # rule applied per-door instead of per-rule costs: the sender exclusion
+  # would have had to be remembered twice.
+  #
+  # Three conjuncts, each subtractive:
+  #   1. not own-sent — you cannot mention yourself (fold `sender` through
+  #      the ASCII nick SSOT, #121/#525; never a bare downcase);
+  #   2. a sender that CAN mention you — no service, no server (#1674);
+  #   3. the body match itself (`Mentions.matches?/2`, the shared matchers).
+  @spec mention_row?(
+          %{sender: String.t(), body: String.t() | nil},
+          String.t(),
+          Mentions.matchers()
+        ) :: boolean()
+  defp mention_row?(%{sender: sender, body: body}, own_folded, matchers) do
+    Identifier.canonical_target(sender) != own_folded and
+      Mentions.mentionable_sender?(sender) and
+      Mentions.matches?(body, matchers)
+  end
+
+  # Mention count over a pre-fetched capped content tail (#396 bulk path).
+  # `nil` own_nick → nothing to match, so no mentions.
   @spec count_tail_mentions(
           [%{sender: String.t(), body: String.t() | nil}],
           String.t() | nil,
@@ -272,9 +295,7 @@ defmodule Grappa.WindowCounts do
   defp count_tail_mentions(tail, own_nick, matchers) do
     own = Identifier.canonical_target(own_nick)
 
-    Enum.count(tail, fn %{sender: sender, body: body} ->
-      Identifier.canonical_target(sender) != own and Mentions.matches?(body, matchers)
-    end)
+    Enum.count(tail, &mention_row?(&1, own, matchers))
   end
 
   # No configured nick on this network → `count_tail_mentions/3` answers 0
@@ -283,8 +304,8 @@ defmodule Grappa.WindowCounts do
   defp slug_matchers(nil, _), do: []
   defp slug_matchers(own_nick, patterns), do: Mentions.matchers(own_nick, patterns)
 
-  # Counts unread content rows that mention the subject, excluding own-sent
-  # rows (fold via the ASCII nick SSOT, #121/#525). Bounded by the scan cap.
+  # Counts unread content rows that mention the subject, per `mention_row?/3`.
+  # Bounded by the scan cap.
   @spec count_mentions(
           Subject.t(),
           integer(),
@@ -302,9 +323,7 @@ defmodule Grappa.WindowCounts do
 
     subject
     |> Scrollback.unread_content_tail(network_id, channel, after_id, own_nick, @mention_scan_cap)
-    |> Enum.count(fn %{sender: sender, body: body} ->
-      Identifier.canonical_target(sender) != own and Mentions.matches?(body, matchers)
-    end)
+    |> Enum.count(&mention_row?(&1, own, matchers))
   end
 
   # Severity ladder — mention > message > event > none.

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -823,6 +823,41 @@ defmodule Grappa.IRC.IdentifierTest do
     end
   end
 
+  # #1674 — the server-origin half of the sender classification. Promoted
+  # out of `EventRouter.route_non_channel_notice_non_chanserv/3`, which has
+  # routed a dot-bearing sender to `$server` since the notice matrix landed;
+  # the mention fold needs the same verb and must not restate it.
+  describe "server_sender?/1" do
+    test "accepts server names (a dot-bearing prefix)" do
+      assert Identifier.server_sender?("nightwish.azzurra.chat")
+      assert Identifier.server_sender?("irc.libera.chat")
+      assert Identifier.server_sender?("localhost.localdomain")
+    end
+
+    test "rejects every nick, service nicks included" do
+      refute Identifier.server_sender?("vjt")
+      refute Identifier.server_sender?("NickServ")
+      refute Identifier.server_sender?("foo[bar]")
+      refute Identifier.server_sender?("a|b\\c")
+    end
+
+    test "rejects non-binary / empty input" do
+      refute Identifier.server_sender?(nil)
+      refute Identifier.server_sender?(:server)
+      refute Identifier.server_sender?("")
+      refute Identifier.server_sender?(123)
+    end
+
+    property "no valid nick is ever a server sender (the two classes are disjoint)" do
+      # This is the whole justification for the dot test: `@nick_regex`'s
+      # character class has no `.`, so a sender that carries one cannot be
+      # a nick and is therefore the server. Proven, not assumed.
+      check all(s <- StreamData.string(:ascii, min_length: 1, max_length: 20)) do
+        refute Identifier.valid_nick?(s) and Identifier.server_sender?(s)
+      end
+    end
+  end
+
   describe "safe_oper_token?/1 (#20 bundle)" do
     test "accepts non-empty single tokens with no whitespace or control bytes" do
       for s <- ~w(vjt admin-op s3cret hunter2 op_with_underscore) do

--- a/test/grappa/mentions_test.exs
+++ b/test/grappa/mentions_test.exs
@@ -222,6 +222,103 @@ defmodule Grappa.MentionsTest do
   end
 
   # ---------------------------------------------------------------------------
+  # #1674 — service / server senders cannot mention you
+  # ---------------------------------------------------------------------------
+
+  describe "mentionable_sender?/1 — the sender-side SSOT" do
+    test "a service or the server can never mention you" do
+      refute Mentions.mentionable_sender?("NickServ")
+      refute Mentions.mentionable_sender?("chanserv")
+      refute Mentions.mentionable_sender?("nightwish.azzurra.chat")
+    end
+
+    test "every other sender can" do
+      assert Mentions.mentionable_sender?("bob")
+      # Closed allowlist: real ops nicks that merely end in "serv" stay
+      # mentionable (bucket H/S4 regression guard).
+      assert Mentions.mentionable_sender?("Conserv")
+      # A channel-shaped sender is not a real arrival shape, but the
+      # classifier must not silently swallow one either.
+      assert Mentions.mentionable_sender?("#chanserv")
+    end
+
+    test "a non-binary sender is mentionable — this predicate only ever SUBTRACTS" do
+      # The row-level fold's other conjuncts (own-sender fold, body match)
+      # decide those rows; a `nil` here must not become a second, silent
+      # exclusion rule.
+      assert Mentions.mentionable_sender?(nil)
+    end
+  end
+
+  describe "aggregate_mentions/6 — service / server senders (#1674)" do
+    test "a services NOTICE spelling own nick is not aggregated", %{user: u, network: net} do
+      insert!(
+        msg(u, net,
+          channel: "$server",
+          kind: :notice,
+          sender: "NickServ",
+          body: "Password accepted for vjt. You are now identified.",
+          server_time: @away_start + 10
+        )
+      )
+
+      assert Mentions.aggregate_mentions(u.id, net.id, @away_start, @away_end, [], "vjt") == []
+    end
+
+    test "an ircd NOTICE spelling own nick is not aggregated", %{user: u, network: net} do
+      insert!(
+        msg(u, net,
+          channel: "$server",
+          kind: :notice,
+          sender: "nightwish.azzurra.chat",
+          body: "*** Notice -- Client connecting: vjt",
+          server_time: @away_start + 10
+        )
+      )
+
+      assert Mentions.aggregate_mentions(u.id, net.id, @away_start, @away_end, [], "vjt") == []
+    end
+
+    test "a peer's NOTICE spelling own nick IS still aggregated", %{user: u, network: net} do
+      m =
+        insert!(
+          msg(u, net,
+            kind: :notice,
+            sender: "bob",
+            body: "vjt heads up",
+            server_time: @away_start + 10
+          )
+        )
+
+      result = Mentions.aggregate_mentions(u.id, net.id, @away_start, @away_end, [], "vjt")
+      assert Enum.map(result, & &1.id) == [m.id]
+    end
+
+    test "a highlight pattern in a service notice is excluded too", %{user: u, network: net} do
+      # The exclusion is by SENDER, so it covers the /hilight half of the
+      # watchlist and not just the own nick.
+      insert!(
+        msg(u, net,
+          channel: "$server",
+          kind: :notice,
+          sender: "ChanServ",
+          body: "grappa is not registered",
+          server_time: @away_start + 10
+        )
+      )
+
+      assert Mentions.aggregate_mentions(
+               u.id,
+               net.id,
+               @away_start,
+               @away_end,
+               ["grappa"],
+               "nobody"
+             ) == []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Property test: in-memory regex gate matches Elixir Regex directly
   # ---------------------------------------------------------------------------
 

--- a/test/grappa/push/triggers_test.exs
+++ b/test/grappa/push/triggers_test.exs
@@ -254,6 +254,20 @@ defmodule Grappa.Push.TriggersTest do
       m = msg(channel: "#sniffo", body: "vjtbot is paged")
       refute notify?(m, "vjt", prefs(channel_mentions: true), [])
     end
+
+    # #1674 — the mention disjunct folds the same row-level rule the badge
+    # does, so a robot spelling your nick cannot buzz the phone either. The
+    # kind gate already drops every `:notice`; a services PRIVMSG (MemoServ
+    # delivery) is the arrival this closes.
+    test "a services PRIVMSG spelling own nick does NOT notify (#1674)" do
+      m = msg(channel: "$server", sender: "MemoServ", body: "vjt, you have 1 new memo.")
+      refute notify?(m, "vjt", prefs(channel_mentions: true), [])
+    end
+
+    test "a peer PRIVMSG spelling own nick still notifies (#1674)" do
+      m = msg(channel: "#sniffo", sender: "bob", body: "vjt: are you there?")
+      assert notify?(m, "vjt", prefs(channel_mentions: true), [])
+    end
   end
 
   describe "should_notify?/5 — the subject's OWN rows never notify (#532 C)" do

--- a/test/grappa/window_counts_test.exs
+++ b/test/grappa/window_counts_test.exs
@@ -334,6 +334,112 @@ defmodule Grappa.WindowCountsTest do
   end
 
   # ---------------------------------------------------------------------------
+  # #1674 — service / server senders cannot mention you
+  # ---------------------------------------------------------------------------
+
+  test "a services NOTICE spelling own nick is NOT a mention (#1674)" do
+    c = ctx()
+    anchor = insert(c, "$server", st: 1, body: "anchor")
+
+    # The prod row (issue #1674): a NickServ login confirmation naming the
+    # operator lit the highest-severity badge on a window nobody opens.
+    insert(c, "$server",
+      st: 2,
+      kind: :notice,
+      sender: "NickServ",
+      body: "Password accepted for vjt. You are now identified."
+    )
+
+    result = snap(c, "$server", anchor.id, "vjt")
+    # The row stays UNREAD CONTENT — only its mention grade changes, so the
+    # window still asks to be read, just not in red.
+    assert result.messages == 1
+    assert result.mentions == 0
+    assert result.severity == :message
+  end
+
+  test "an ircd NOTICE spelling own nick is NOT a mention (#1674)" do
+    c = ctx()
+    anchor = insert(c, "$server", st: 1, body: "anchor")
+
+    # Not specific to services: the ircd's own notices routinely name the
+    # connecting nick. `sender` is the server name (Message.sender_nick/1
+    # returns the `{:server, name}` prefix verbatim).
+    insert(c, "$server",
+      st: 2,
+      kind: :notice,
+      sender: "nightwish.azzurra.chat",
+      body: "*** Notice -- Client connecting: vjt"
+    )
+
+    result = snap(c, "$server", anchor.id, "vjt")
+    assert result.messages == 1
+    assert result.mentions == 0
+    assert result.severity == :message
+  end
+
+  test "a service NOTICE in the service's OWN query window is not a mention either (#1674)" do
+    c = ctx()
+    anchor = insert(c, "nickserv", st: 1, body: "anchor")
+
+    # The over-count is NOT confined to `$server`: EventRouter's
+    # `open_query_or_server/2` re-keys a services NOTICE onto the service's
+    # query window when the operator has one open (#400/#546), so a
+    # `/msg nickserv identify` reply lands here instead.
+    insert(c, "nickserv",
+      st: 2,
+      kind: :notice,
+      sender: "NickServ",
+      body: "Password accepted for vjt. You are now identified."
+    )
+
+    result = snap(c, "nickserv", anchor.id, "vjt")
+    assert result.messages == 1
+    assert result.mentions == 0
+    assert result.severity == :message
+  end
+
+  test "a services PRIVMSG spelling own nick is NOT a mention (#1674)" do
+    c = ctx()
+    anchor = insert(c, "$server", st: 1, body: "anchor")
+
+    # Sender is the discriminator, not kind: services that PRIVMSG instead of
+    # NOTICE (MemoServ delivery) reach the same fold.
+    insert(c, "$server",
+      st: 2,
+      kind: :privmsg,
+      sender: "MemoServ",
+      body: "vjt, you have 1 new memo."
+    )
+
+    result = snap(c, "$server", anchor.id, "vjt")
+    assert result.mentions == 0
+  end
+
+  test "a PEER's NOTICE spelling own nick STILL counts as a mention (#1674)" do
+    c = ctx()
+    anchor = insert(c, "#chan", st: 1, body: "anchor")
+    # The half that breaks in silence: a human `/notice` IS conversation.
+    # Only service/server senders are excluded — never the kind.
+    insert(c, "#chan", st: 2, kind: :notice, sender: "bob", body: "vjt heads up")
+
+    result = snap(c, "#chan", anchor.id, "vjt")
+    assert result.mentions == 1
+    assert result.severity == :mention
+  end
+
+  test "a nick that merely ENDS in serv still mentions you (closed allowlist, #1674)" do
+    c = ctx()
+    anchor = insert(c, "#chan", st: 1, body: "anchor")
+    # `Conserv` / `Dataserv` / `Reserv` are real ops nicks — the allowlist is
+    # closed on purpose (bucket H/S4). A substring rule would silence them.
+    insert(c, "#chan", st: 2, kind: :privmsg, sender: "Conserv", body: "vjt ping")
+
+    result = snap(c, "#chan", anchor.id, "vjt")
+    assert result.mentions == 1
+  end
+
+  # ---------------------------------------------------------------------------
   # severity ladder
   # ---------------------------------------------------------------------------
 
@@ -440,6 +546,45 @@ defmodule Grappa.WindowCountsTest do
                WindowCounts.snapshot(subject, net.id, "#chan", a.id, own, ["grappa"], false)
 
       assert bulk[net.slug]["#chan"].mentions == 1
+    end
+
+    test "the service/server sender exclusion holds on the bulk path too (#1674)" do
+      user = AuthFixtures.user_fixture()
+      subject = {:user, user.id}
+      net = AuthFixtures.network_fixture()
+      own = "vjt"
+
+      # The bulk path folds `count_tail_mentions/3`, a SECOND fold from the
+      # per-window `count_mentions/6`. Both must see the same rule — this is
+      # the test that fails if the two ever diverge.
+      a = ins(subject, net.id, "$server", st: 1, body: "anchor")
+
+      ins(subject, net.id, "$server",
+        st: 2,
+        kind: :notice,
+        sender: "NickServ",
+        body: "Password accepted for vjt. You are now identified."
+      )
+
+      ins(subject, net.id, "$server",
+        st: 3,
+        kind: :notice,
+        sender: "nightwish.azzurra.chat",
+        body: "*** Notice -- Client connecting: vjt"
+      )
+
+      ins(subject, net.id, "$server", st: 4, kind: :notice, sender: "bob", body: "vjt heads up")
+      cursor(subject, net.id, "$server", a.id)
+
+      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [], %{})
+
+      # Only bob's line is a mention; both robots are excluded.
+      assert bulk[net.slug]["$server"].mentions == 1
+      assert bulk[net.slug]["$server"].messages == 3
+
+      # And the two doors agree row for row.
+      assert bulk[net.slug]["$server"] ==
+               WindowCounts.snapshot(subject, net.id, "$server", a.id, own, [], false)
     end
 
     # #576 self-window carve-out: the own-nick window is the ONE window where


### PR DESCRIPTION
Fixes the over-count reported in #1674: a NickServ login confirmation, or an
ircd connect notice, spells your own nick and so lit the highest-severity badge
grappa has on a window most operators never open.

## The scope question the issue left open, measured

The issue flagged as unmeasured whether the same over-count reaches the service
**query** windows rather than just `$server`. **It does** — and that changes the
cure. Measured as a failing test before the fix:

```
test "a service NOTICE in the service's OWN query window is not a mention"
  code:  assert result.mentions == 0
  left:  1
  right: 0
```

`EventRouter.open_query_or_server/2` (#400, generalised by #546) re-keys a
services NOTICE onto the service's own query window whenever the operator has
one open. A channel-shaped cure would have fixed the reported window and left
the one a `/msg`ing operator actually looks at.

## The discriminator is the SENDER

Both alternatives were tried against the evidence and both fail:

| cure | why it fails |
|---|---|
| by KIND — exclude `:notice` | silences a human `/notice vjt ...`, which IS conversation. Breaks in silence; now pinned by a test. |
| by CHANNEL — exclude `$server` | misses the service query window above. |

So `Grappa.Mentions.mentionable_sender?/1` composes the two `Identifier` verbs
that already answer this question for message ROUTING. It is total and biased
toward `true` — it only ever SUBTRACTS, so an input it cannot classify stays
mentionable and the other conjuncts decide it.

`Identifier.server_sender?/1` is new only as a *name*: the single-dot test has
routed dot-bearing NOTICE senders to `$server` since the notice matrix landed,
inline in `EventRouter`. Promoted rather than restated — a second unnamed copy
of a sibling rule is exactly what #1674 IS. It is exact rather than heuristic
(`@nick_regex` carries no dot in either class), and a property test pins that
disjointness.

## One rule, folded at every door

`count_mentions/6` and `count_tail_mentions/3` were already two byte-identical
closures, which is precisely why this cost four sites instead of one. The fold
collapsed into `WindowCounts.mention_row?/3` and both counting doors call it.

Two further doors are closed with it, **knowingly beyond the issue's text**:

- `aggregate_mentions/6` — otherwise the C8 away bundle still LISTS the row
  whose badge no longer counts.
- `Push.Triggers.mention_match?/4` — closed by code reading, **not** by an
  observed prod arrival: the kind gate already drops every `:notice`, so only a
  services PRIVMSG reaches it and bahamut's services deliver by NOTICE. A hole
  in the door, not a measured leak.

The push mirror `cicchetto/src/lib/pushTriggers.ts` moves in lockstep because
the shared truth table is a drift gate. One of the four new rows fixes the
boundary: `channel_messages_all` STILL delivers a service row — asking for every
channel message is an explicit request, a mention is an inference, and only the
inference is gated.

## Measured and declined

`.scrollback-mention` in `ScrollbackPane` was expected to match the same set and
move in lockstep. It does not: `isMention()` is already gated on
`kind === "privmsg"`, so it has never highlighted ANY notice, service or human.
The client is *stricter* than the server on that axis, in both directions (it
also misses a peer `/me` and a peer `/notice`). Reconciling that is a separate
question. Untouched, and stated rather than quietly assumed.

`aggregate_mentions/6` also does not exclude OWN-sent rows, unlike both badge
doors. Real, a different axis, left alone.

## Proof

- **Red first**: 5 failing tests naming the over-count (`left: 1, right: 0`),
  plus 2 green from the start — a peer's NOTICE and a `Conserv`-style ops nick,
  the half that breaks in silence.
- **Oracle proven by mutation**: with the predicate made permissive again,
  **12 tests die**, covering all four doors — WindowCounts 5 (4 per-window +
  1 bulk), Mentions 4, Triggers 1, and the shared truth-table parity suite 2.
- `scripts/check.sh` — 8 doctests, 62 properties, 6746 tests, 0 failures;
  dialyzer `Total errors: 0`; credo / sobelow / deps.audit / wire_pin / bats
  green.
- `bun run check` 4/4 stages; `bun run test` 299 files / 5841 tests
  (+10 = exactly the cases added); scoped verbose run naming all 10 new cases.
- `design-notes-gate.sh` green; boundary shape read on the real file.

No wire shape changed, so no `protocol_version` bump (`wire_pin --check` green).
