### PR TITLE
boot: one round trip for the whole boot picture (GET /boot)

### DIFF
--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1,6 +1,6 @@
 // GENERATED FILE — DO NOT EDIT
 // Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
-// Source: lib/grappa/**/*wire.ex + GrappaWeb.AuthJSON + GrappaWeb.ErrorTokens + GrappaWeb.MeJSON
+// Source: lib/grappa/**/*wire.ex + GrappaWeb.AuthJSON + GrappaWeb.BootJSON + GrappaWeb.ErrorTokens + GrappaWeb.MeJSON
 //
 // #429 — the RUNTIME twin of `wireTypes.ts`: the same typespecs, emitted
 // as schema literals `wireValidate.ts` interprets. `wireTypes.ts` is
@@ -1541,6 +1541,23 @@ export const S_AuthJSONVisitorSubjectWire = {
 // GrappaWeb.AuthJSON.subject_wire/0
 export const S_AuthJSONSubjectWire = {
   u: [S_AuthJSONUserSubjectWire, S_AuthJSONVisitorSubjectWire],
+} as const;
+
+// GrappaWeb.BootJSON.channel_tree/0
+export const S_BootJSONChannelTree = { r: { a: S_NetworksWireChannelJson } } as const;
+
+// GrappaWeb.BootJSON.heads/0
+export const S_BootJSONHeads = { r: { r: { a: S_ScrollbackWireT } } } as const;
+
+// GrappaWeb.BootJSON.boot_json/0
+export const S_BootJSONBootJson = {
+  o: {
+    networks: {
+      a: { u: [S_NetworksWireNetworkWithNickJson, S_NetworksWireVisitorNetworkWithNickJson] },
+    },
+    channels: S_BootJSONChannelTree,
+    heads: S_BootJSONHeads,
+  },
 } as const;
 
 // GrappaWeb.ErrorTokens.shared_error_token/0

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1,6 +1,6 @@
 // GENERATED FILE — DO NOT EDIT
 // Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
-// Source: lib/grappa/**/*wire.ex + GrappaWeb.AuthJSON + GrappaWeb.ErrorTokens + GrappaWeb.MeJSON
+// Source: lib/grappa/**/*wire.ex + GrappaWeb.AuthJSON + GrappaWeb.BootJSON + GrappaWeb.ErrorTokens + GrappaWeb.MeJSON
 
 // === External types (referenced by Wire modules) ===
 
@@ -1591,6 +1591,18 @@ export type AuthJSONVisitorSubjectWire = {
 };
 
 export type AuthJSONSubjectWire = AuthJSONUserSubjectWire | AuthJSONVisitorSubjectWire;
+
+// === GrappaWeb.BootJSON ===
+
+export type BootJSONChannelTree = Record<string, NetworksWireChannelJson[]>;
+
+export type BootJSONHeads = Record<string, Record<string, ScrollbackWireT[]>>;
+
+export type BootJSONBootJson = {
+  networks: NetworksWireNetworkWithNickJson | NetworksWireVisitorNetworkWithNickJson[];
+  channels: BootJSONChannelTree;
+  heads: BootJSONHeads;
+};
 
 // === GrappaWeb.ErrorTokens ===
 

--- a/cicchetto/src/service-worker.ts
+++ b/cicchetto/src/service-worker.ts
@@ -95,6 +95,11 @@ const navigationHandler = createHandlerBoundToURL("index.html");
 const navigationRoute = new NavigationRoute(navigationHandler, {
   denylist: [
     /^\/auth/,
+    // #1679 — the one-round-trip boot envelope. A top-level REST path, so
+    // without this entry an explicit navigation to it serves the SPA shell
+    // instead of reaching the controller (REV-G H22). Pinned by
+    // `GrappaWeb.RouterSwDenylistTest`, which is what caught its absence.
+    /^\/boot/,
     /^\/me/,
     /^\/networks/,
     /^\/socket/,

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -443,6 +443,53 @@ Per §2 all of the above is additive: a client that does not recognise the
 `rate_limited` token or the `web_session_severed` frame still degrades
 safely (the 429 status / the socket close remain unambiguous).
 
+### 6a. Cold boot — do NOT fan out; ask `GET /boot` (#1679)
+
+🔴 **The budget above does not protect you here, and the thing that stops
+you is not grappa.** The budget meters write methods only, so a boot — pure
+`GET` — passes it untouched. What a deployment actually puts in front of
+grappa is a reverse proxy with a `limit_req` zone, and that answers **`503`,
+not `429`**, with no `retry_after_ms` and no `Retry-After` to back off on.
+
+This is not hypothetical. A client that fetched the channel list per network
+and then a backlog page per channel presented **81+ requests at once** on a
+seven-network account, and a proxy at `burst=50` rejected 31 of them; the
+user saw a blank window. The same shape had already, on an earlier occasion,
+tripped a `fail2ban` jail and got the client's IP **firewall-banned**. A
+boot whose request count scales with the size of the account will find a
+limiter somewhere, and every operator's is configured differently — so the
+client has to be well-behaved at defaults rather than assume a tuned proxy.
+
+**One request answers the whole picture:**
+
+```
+GET /boot
+→ 200 application/json
+{
+  "networks": [ … ],                          // identical to GET /networks
+  "channels": { "<slug>": [ … ] },            // identical to GET /networks/<slug>/channels
+  "heads":    { "<slug>": { "<chan>": [ … ] } } // newest page per channel
+}
+```
+
+The three values are the SAME shapes the per-request endpoints return — one
+decoder, not two. `channels` carries one key per network you hold; `heads`
+carries one key per channel that HAS history (a channel with none is absent,
+like a missing `read_cursors` key, rather than mapped to `[]`).
+
+Pair it with `GET /me` — which already answers `read_cursors`,
+`unread_counts` and `badge_count` in bulk — and a cold boot is **two
+requests, flat in the size of the account**, however many networks and
+channels it holds.
+
+The per-channel endpoints are unchanged and stay for everything that is not
+boot: paging further back (`?before=`), resuming a gap (`?after=`), and
+measuring one (`/messages/count`). `/boot` replaces the fan-out, not them.
+
+> Note the reconnect path too. A WebSocket resume that re-fetches a backlog
+> page for every channel it re-joins presents the same burst as a cold boot,
+> from the same account size — the limiter cannot tell the two apart.
+
 ---
 
 ## 7. Per-client tokens (#1196)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58635,6 +58635,38 @@ its strongest form here: the moment a client stops fanning out and starts
 REQUIRING `/boot`, it can no longer talk to a server predating it, which is
 the new-client-to-old-server direction the number exists for.
 
+### What the guardrails caught, which prose would not have
+
+Three existing tests failed on the new route, and each was right.
+
+`RouterSwDenylistTest` — a new TOP-LEVEL path must be in cic's
+service-worker navigation denylist or an explicit navigation to it serves
+the SPA shell instead of reaching the controller (REV-G H22).
+`RouterScopeTest` — every route must be classified client-usable or answer
+the scope refusal; `/boot` is client-usable by the same reasoning as
+`GET /me`, and saying so is now a decision on the record rather than a
+default.
+
+The third was a defect, not a registration. A user's channel list is
+`credential.autojoin_channels`; a VISITOR's is
+`credential.last_joined_channels` (#211 phase 4c moved it off the `visitors`
+scalar). Reading the user column for both compiles, passes every user test,
+and hands each visitor an EMPTY channel tree. The column choice now lives in
+`Networks.autojoin_channels/2` — with `Visitors.list_autojoin_channels/2`
+delegating to it — so the two doors cannot pick differently.
+
+### The head is the TAIL, not the unread region
+
+`/boot`'s per-channel head is the newest page, which is what a pane renders
+on selection. It is deliberately NOT what `refreshScrollback` fetches today
+(`?after=<read cursor>`, i.e. the unread region): a subject a thousand rows
+behind gets the most recent page here, not the thousand. The unread
+machinery — counts, the divider, the far-behind affordance — is driven by
+`/me`'s `unread_counts` and `read_cursors`, which do not need the rows;
+anchoring at a cursor stays the per-channel endpoint's job, unchanged. A
+head shaped like the unread region would also be unbounded per channel,
+which is the one thing a single-response envelope cannot afford.
+
 ### Not measured, and named rather than assumed
 
 The RECONNECT path was read off the code, not executed. `subscribe.ts`'s

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58537,3 +58537,110 @@ map forbids. The cure belongs at the call site: `Map.take/2` through a key
 list the callee exports, so the closed type describes what actually crosses
 the boundary. Widening the callee to a catch-all would have made the type
 agree with the leak, and the leak is the thing the closure existed to stop.
+<!-- entry #1679 -->
+
+---
+
+## 2026-08-22 — #1679: a boot that scales with the account, and the tripwire that could not see the cure
+
+cic's cold boot fanned out `GET /me`, `GET /networks`, one
+`GET /networks/:slug/channels` per network, then a `/messages` page per
+channel. The burst therefore scaled with the SIZE OF THE ACCOUNT rather than
+with anything the operator did. On prod it tripped the reverse proxy's
+`limit_req` zone — 31 x `503`, with **zero** `Sent 503` in the application
+log, so nginx rejected them and grappa never saw them. grappa's own inbound
+budget cannot see them either: #630's `RequestBudget` meters write methods
+only, and a boot is pure GET. The operator's proxy is the sole backstop, and
+every operator's is configured differently.
+
+vjt's ruling: a new `/boot` endpoint, and client-side throttling explicitly
+REJECTED — an in-flight cap only staggers the same work and makes boot feel
+slower. It is the request COUNT that has to stop scaling.
+
+### The arithmetic that fixed the scope
+
+The Decision's letter ("one request replaces `1 + N + ...`") and its success
+criterion ("back in the single digits of requests") are not the same
+instruction, and the second is the binding one. Prod: `burst=50` plus 31
+rejections means **at least 81 requests** were presented in the window — a
+floor, since the queue drains as it fills. The account holds seven networks,
+so `me + networks + 7 x channels` is **nine**. The other ~72 are per-channel.
+
+An endpoint that collapsed only `1 + N` would have removed nine of eighty-one
+and the incident would have repeated unchanged. So the per-channel heads are
+in scope, and it is that subtraction — not a preference — that says so.
+
+### Measured, because "must not become an N+1" needs a number
+
+`GrappaWeb.BootCostTest` counts `[:grappa, :repo, :query]` in the test
+process with a `self()` filter (the shape `RefreshPlanCostTest` established:
+handlers run in the emitting process, Ecto emits synchronously, so the filter
+is exact and the mailbox is complete when the request returns).
+
+    today   11 + 5N queries over 2 + N requests   (16/3 at N=1, 46/9 at N=7)
+    /boot    6 queries over 1 request, invariant on BOTH axes
+
+Pinned as an ordered source list — `sessions`, `users`,
+`network_credentials`, `networks`, `user_settings`, `messages` — so a
+regression names WHICH read appeared. `GET /networks` was already constant in
+N before this change; only the per-network channel call scaled.
+
+`GET /me` is deliberately NOT folded in: already an aggregate envelope,
+already constant in account size, and it has non-boot consumers. Boot is
+`/me` + `/boot` — two requests, flat.
+
+### `ROW_NUMBER` per channel, and the two things that keep the query STRING constant
+
+`Scrollback.bulk_heads/4` reuses the shape #396 already proved on the live
+prod indexes: rank ids in a subquery partitioned by `(network_id, channel)`,
+keep the top `limit` per partition, read the rows back.
+
+Two calls, both about SQLite's prepared-statement cache still helping the
+accounts this exists for. The predicate is `network_id IN (...) AND channel
+IN (...)` — two array params — rather than an OR over exact pairs, which
+would grow the query string with the account; the over-read that admits
+(a channel name present on two of the subject's networks) is dropped by
+`Map.take/2`, and `subject_where/2` is applied first so it is never a leak.
+And the #458 presence exclusion is a `kind NOT IN` predicate that hiding and
+showing channels cannot share without a per-pair OR, so targets are
+partitioned: one statement when nothing is hidden, two when something is,
+never N.
+
+### The finding worth more than the endpoint: the wire tripwire was blind
+
+With `/boot` routed, rendered and tested, `mix grappa.wire_pin --check`
+answered `wire shape and protocol 3 agree` at **rc=0**. A whole new
+client-facing endpoint, invisible — because the digested set is a glob over
+`lib/grappa/**/*wire.ex` plus a hand-kept `@extra_modules` list, and a
+controller's `*_json.ex` is in neither.
+
+Adding `GrappaWeb.BootJSON` to that list was necessary and NOT sufficient,
+and the intermediate state is the trap to record: while its only typespec was
+an inline `@spec` on `index/1`, the codegen emitted nothing but a changed
+`Source:` header comment — and that comment moved the digest. A RED gate and
+a version bump earned by a comment rather than by a shape. The generator
+reads `@type` declarations via `Code.Typespec.fetch_types/1` and never looks
+at a `@spec`.
+
+**Rule: a new web-layer envelope must be added to `@extra_modules` AND must
+name its type, in the commit that introduces it.** Either half alone gives a
+number that is wrong in a different direction — silence, or a bump bought
+with a comment. (The false digest was pinned once mid-work; the pin was reset
+to the base and re-taken so the branch carries ONE bump, 3 to 4, against the
+real shape.)
+
+The bump itself is the task's verdict, not a judgement call. Purely additive
+— no existing endpoint changed shape — but the rule since #1393d applies in
+its strongest form here: the moment a client stops fanning out and starts
+REQUIRING `/boot`, it can no longer talk to a server predating it, which is
+the new-client-to-old-server direction the number exists for.
+
+### Not measured, and named rather than assumed
+
+The RECONNECT path was read off the code, not executed. `subscribe.ts`'s
+socket-open effect calls `refetchNetworks()`, `refetchChannels()` and then
+loops `refreshScrollback` over EVERY key in `joined` — and phoenix.js's
+auto-rejoin fires the join-ok refresh for the same keys, which #1593's queue
+deliberately does not drop. So the shape is the same and the count is larger
+than a cold boot's. That is a static reading of an unambiguous loop, not a
+measurement, and it is recorded as such.

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -824,6 +824,31 @@ defmodule Grappa.Networks do
   end
 
   @doc """
+  The persisted channel list a credential contributes to its network's tree —
+  and it is a DIFFERENT COLUMN per subject kind, which is the whole reason
+  this function exists rather than a field access at each call site.
+
+    * a USER declares `autojoin_channels`: an intention, edited by the
+      operator, honoured on every connect.
+    * a VISITOR carries `last_joined_channels`: a per-network SNAPSHOT the
+      live session writes so a returning visitor lands back where it was.
+      (#211 phase 4c moved it off the `visitors` scalar onto the
+      `(visitor_id, network_id)` credential — a multi-network visitor has one
+      per network, and two concurrent sessions would clobber a single one.)
+
+  #1679 — measured, not assumed: reading `autojoin_channels` for BOTH kinds
+  compiles, passes the user tests, and hands every visitor an EMPTY channel
+  tree. The column choice lives here so the boot endpoint and the
+  per-network endpoint cannot answer differently.
+  """
+  @spec autojoin_channels(:user | :visitor, Credential.t()) :: [String.t()]
+  def autojoin_channels(:user, %Credential{autojoin_channels: channels}),
+    do: channels || []
+
+  def autojoin_channels(:visitor, %Credential{last_joined_channels: channels}),
+    do: channels || []
+
+  @doc """
   The live session's channel list for `(subject, network_id)`, or `[]` when no
   session is up — a parked network has an autojoin list and no live joins, and
   that is a normal answer rather than an error.

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -732,6 +732,110 @@ defmodule Grappa.Networks do
     Wire.home_data(pairs, available_slugs)
   end
 
+  @typedoc """
+  One `GET /networks` row before rendering: the network, the LIVE-or-fallback
+  nick, the credential of record, and the live upstream facts (`nil` when no
+  session is up).
+  """
+  @type network_row ::
+          {Network.t(), String.t(), Credential.t(), Session.connection_info() | nil}
+
+  @doc """
+  Every network row the subject can see, tagged with the subject kind the
+  wire discriminator is built from.
+
+  #1679 — extracted from `GrappaWeb.NetworksController.index/2` so the boot
+  endpoint answers with the SAME rows rather than a second assembly that
+  drifts. The two branches were already byte-identical apart from the tag;
+  keeping one copy is what makes "`/boot`'s networks are `GET /networks`'s
+  networks" a fact a test can assert rather than a claim.
+
+  Constant in the number of networks: the credential read preloads
+  `:network`, and both live lookups (`resolve_network_nick/2`,
+  `Session.connection_info/2`) are `Registry`/GenServer reads, not queries.
+  `GrappaWeb.BootCostTest` measures that.
+  """
+  @spec subject_network_rows(Session.subject()) ::
+          {:user, [network_row()]} | {:visitor, [network_row()]}
+  def subject_network_rows({:user, user_id} = subject) when is_binary(user_id) do
+    {:user, rows_for(subject, Credentials.list_credentials_for_user_id(user_id))}
+  end
+
+  def subject_network_rows({:visitor, visitor_id} = subject) when is_binary(visitor_id) do
+    {:visitor, rows_for(subject, Credentials.list_visitor_credentials(visitor_id))}
+  end
+
+  @spec rows_for(Session.subject(), [Credential.t()]) :: [network_row()]
+  defp rows_for(subject, credentials) do
+    Enum.map(credentials, fn cred ->
+      {cred.network, resolve_network_nick(subject, cred), cred, live_connection_info(subject, cred.network_id)}
+    end)
+  end
+
+  # #474 B — the LIVE upstream facts for a row, or `nil` when there is no live
+  # connected session (parked / failed / no pid): the honest "no connection"
+  # the server-window rail renders as an absent card. Same live-vs-DB split as
+  # `resolve_network_nick/2` — these come from the running Session.Server,
+  # never the credential row of record.
+  @spec live_connection_info(Session.subject(), integer()) :: Session.connection_info() | nil
+  defp live_connection_info(subject, network_id) do
+    case Session.connection_info(subject, network_id) do
+      {:ok, info} -> info
+      {:error, _} -> nil
+    end
+  end
+
+  @typedoc "One channel-tree entry: the name, whether we are IN it, and why we know about it."
+  @type channel_entry :: %{name: String.t(), joined: boolean(), source: :autojoin | :joined}
+
+  @doc """
+  The channel tree for one network: the persisted autojoin list unioned with
+  what the LIVE session says it is actually in.
+
+  Q3 pinned: a channel in BOTH is sourced `:autojoin`. Sorted by
+  `{name, source}` for wire-shape stability — name is the primary key and
+  unique under the `MapSet.difference/2` dedup, but tie-breaking on `:source`
+  makes the ordering contract TOTAL, so a future widening that admitted
+  duplicates would still give clients deterministic order instead of
+  source-dependent churn (M-web-4).
+
+  #1679 — lifted out of `GrappaWeb.ChannelsController` so the boot endpoint
+  builds the SAME tree rather than a second copy. The per-network endpoint
+  and the boot endpoint answering different channel lists is precisely the
+  silent half of this change, so there is one function and both doors call
+  it.
+  """
+  @spec merge_channel_sources([String.t()], [String.t()]) :: [channel_entry()]
+  def merge_channel_sources(autojoin, session) when is_list(autojoin) and is_list(session) do
+    autojoin_set = MapSet.new(autojoin)
+    session_set = MapSet.new(session)
+
+    autojoin_entries =
+      Enum.map(autojoin_set, fn name ->
+        %{name: name, joined: MapSet.member?(session_set, name), source: :autojoin}
+      end)
+
+    session_only_entries =
+      session_set
+      |> MapSet.difference(autojoin_set)
+      |> Enum.map(fn name -> %{name: name, joined: true, source: :joined} end)
+
+    Enum.sort_by(autojoin_entries ++ session_only_entries, &{&1.name, &1.source})
+  end
+
+  @doc """
+  The live session's channel list for `(subject, network_id)`, or `[]` when no
+  session is up — a parked network has an autojoin list and no live joins, and
+  that is a normal answer rather than an error.
+  """
+  @spec session_channels(Session.subject(), integer()) :: [String.t()]
+  def session_channels(subject, network_id) when is_integer(network_id) do
+    case Session.list_channels(subject, network_id) do
+      {:ok, list} -> list
+      {:error, :no_session} -> []
+    end
+  end
+
   @doc """
   Resolves the live IRC nick for a `(subject, credential)` pair. Asks
   the running `Session.Server` for its current nick — which may

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -1283,7 +1283,19 @@ defmodule Grappa.Networks.Credentials do
   for display.
   """
   @spec list_credentials_for_user(User.t()) :: [Credential.t()]
-  def list_credentials_for_user(%User{id: user_id}) do
+  def list_credentials_for_user(%User{id: user_id}), do: list_credentials_for_user_id(user_id)
+
+  @doc """
+  The id-keyed twin of `list_credentials_for_user/1`, and the symmetric
+  sibling of `list_visitor_credentials/1` (which has always been id-keyed).
+
+  #1679 — a caller holding a `Session.subject()` tuple has the id and not the
+  struct, and fetching a `%User{}` back out of the DB purely to destructure
+  its `id` would be a query bought for nothing on a path whose whole point is
+  a constant query count.
+  """
+  @spec list_credentials_for_user_id(Ecto.UUID.t()) :: [Credential.t()]
+  def list_credentials_for_user_id(user_id) when is_binary(user_id) do
     query =
       from(c in Credential,
         where: c.user_id == ^user_id,

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -53,7 +53,9 @@ defmodule Grappa.Protocol do
   `min_version/0` is a DIFFERENT axis and does NOT follow: it moves only
   when old clients can no longer be SERVED. An additive field strands
   nobody, so a bump under the new rule leaves the floor where it is —
-  which is why `version/0` is 3 here and `min_version/0` is still 1.
+  which is why `version/0` has moved repeatedly while `min_version/0` has
+  never left 1. (Deliberately not restating either number in prose: this
+  paragraph outlived two bumps naming the old one.)
 
   The rule is written for client authors in `docs/CLIENT_PROTOCOL.md` and
   restated as an invariant in `CLAUDE.md`.
@@ -69,31 +71,41 @@ defmodule Grappa.Protocol do
 
   use Boundary, top_level?: true, deps: [], exports: []
 
-  # Protocol v3 (#1677) — v1 was the initial published contract (#447), v2
-  # the ruling that made the bump unconditional (#1393d). v3 adds
-  # `tls_verify` to `Grappa.Networks.Servers.AdminWire.t`.
+  # Protocol v4 (#1679) — v1 was the initial published contract (#447), v2
+  # the ruling that made the bump unconditional (#1393d), v3 added
+  # `tls_verify` to `Grappa.Networks.Servers.AdminWire.t` (#1677). v4 adds
+  # the `GET /boot` envelope (`GrappaWeb.BootJSON.index/1`): networks, every
+  # network's channel tree, and each channel's head page in one round trip.
   #
-  # An admin-only field no cic surface reads still bumps, and that is the
-  # rule working rather than a cost to route around: the digest spans the
-  # whole generated schema precisely so nobody has to adjudicate which
-  # additions "count" (see `Mix.Tasks.Grappa.WirePin`'s "Cost, accepted
-  # knowingly").
+  # Purely ADDITIVE — no existing endpoint changed shape, and a v3 client
+  # that never calls `/boot` is served exactly as before. It bumps anyway,
+  # which is the rule working rather than a cost to route around: the moment
+  # a client stops fanning out and starts REQUIRING `/boot`, it can no longer
+  # talk to a server predating it, and that break runs new-client → old-server
+  # — the direction the number exists for.
+  #
+  # Not adjudicated by hand: `mix grappa.wire_pin --check` went red on the
+  # digest and named `3 -> 4` (see `Mix.Tasks.Grappa.WirePin`). Worth
+  # recording that it was SILENT until `GrappaWeb.BootJSON` was added to the
+  # codegen's `@extra_modules` — the routed, rendered, tested endpoint agreed
+  # with protocol 3 at rc=0 beforehand, because the digested set is a glob
+  # over `lib/grappa/**` plus a hand-kept list of web-layer envelopes.
   #
   # @min_protocol_version is NOT the same axis and stays at 1: it rises only
   # when old clients can no longer be SERVED, and every client that spoke v1
-  # is still served — v1 clients tolerate what v3 clients require.
-  @protocol_version 3
+  # is still served — v1 clients tolerate what v4 clients require.
+  @protocol_version 4
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
-  # `:: 3` (not `pos_integer()`) so the spec matches the success typing of
+  # A literal (not `pos_integer()`) so the spec matches the success typing of
   # the literal constant under Dialyzer `:underspecs` — the codebase idiom
   # for a constant-returning function (`Grappa.Notify.max_entries/0 :: 64`,
   # `Grappa.IRC.Identifier.max_nick_length/0 :: 30`). A bump edits the spec
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 3
+  @spec version() :: 4
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -617,7 +617,7 @@ defmodule Grappa.Scrollback do
 
   @spec heads_for(subject(), [{integer(), String.t()}], pos_integer(), boolean()) ::
           %{{integer(), String.t()} => [Message.t()]}
-  defp heads_for(_subject, [], _limit, _hide_presence), do: %{}
+  defp heads_for(_, [], _, _), do: %{}
 
   defp heads_for(subject, targets, limit, hide_presence) do
     capped = min(limit, @max_limit)

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -550,6 +550,102 @@ defmodule Grappa.Scrollback do
   end
 
   @doc """
+  #1679 — the newest `limit` rows for EVERY `(network_id, channel)` in
+  `targets`, in a CONSTANT number of queries. Returns
+  `%{{network_id, channel} => [Message.t()]}`, each list ASC by
+  `(server_time, id)` — the order `fetch/7` callers reverse into.
+
+  This is the bulk twin of `fetch/7`, and it exists for one reason: the boot
+  endpoint answers every channel of every network in one round trip, and a
+  round trip that issues one `fetch/7` per channel has moved the thundering
+  herd from the operator's proxy to SQLite. `GrappaWeb.BootCostTest` pins the
+  count as INVARIANT under both account-size axes.
+
+  Same `ROW_NUMBER() OVER (PARTITION BY … )`-filtered-in-the-outer-query
+  shape as `Grappa.ReadCursor.bulk_unread_content_tails/2`, which #396 already
+  proved against the live prod indexes: rank inside a subquery, keep the
+  top-`limit` ids per partition, then read the rows back. Ranking ids rather
+  than whole rows keeps the window pass narrow.
+
+  ## Query COUNT, and why it is one or two rather than one
+
+  `hidden` is the `(network_id, channel)` set whose presence noise this
+  subject suppresses (#458). The exclusion is a `kind NOT IN` predicate, so
+  channels that hide and channels that show cannot share one statement
+  without a per-pair `OR`, which would make the query STRING grow with the
+  account — defeating SQLite's prepared-statement cache for the exact
+  accounts this endpoint exists for. So the targets are partitioned and each
+  half gets one statement: **one query when `hidden` is empty (the common
+  case), two when it is not, never N**. Constant either way, which is what
+  the pin measures.
+
+  ## Over-fetch, bounded and deliberate
+
+  The predicate is `network_id IN (…) AND channel IN (…)` — two array params,
+  a query shape that does NOT vary with account size — rather than an OR over
+  the exact pairs. That admits rows for a `(network, channel)` combination
+  nobody asked for when the same channel name exists on two of the subject's
+  networks; `Map.take/2` drops them. The rows are the subject's own either
+  way (`Subject.subject_where/2` is applied first, as everywhere else), so
+  this is a small over-read, never a leak.
+
+  ## Scope: CHANNELS only
+
+  `targets` carry channel-shaped names (the autojoin ∪ session lists a boot
+  answers with), so the predicate is the plain `channel ==` arm that
+  `channel_or_dm_where/3` resolves those to. DM and self windows are NOT
+  served here — they need that function's OR-shape and its own-nick
+  narrowing, and they are not part of the channel tree a boot renders. A
+  nick-shaped name in `targets` would silently read only its outbound half;
+  callers pass channel lists.
+  """
+  @spec bulk_heads(
+          subject(),
+          [{integer(), String.t()}],
+          pos_integer(),
+          MapSet.t({integer(), String.t()})
+        ) :: %{{integer(), String.t()} => [Message.t()]}
+  def bulk_heads(subject, targets, limit, hidden)
+      when is_list(targets) and is_integer(limit) and limit > 0 do
+    {hiding, showing} = Enum.split_with(targets, &MapSet.member?(hidden, &1))
+
+    Map.merge(
+      heads_for(subject, showing, limit, false),
+      heads_for(subject, hiding, limit, true)
+    )
+  end
+
+  @spec heads_for(subject(), [{integer(), String.t()}], pos_integer(), boolean()) ::
+          %{{integer(), String.t()} => [Message.t()]}
+  defp heads_for(_subject, [], _limit, _hide_presence), do: %{}
+
+  defp heads_for(subject, targets, limit, hide_presence) do
+    capped = min(limit, @max_limit)
+    network_ids = targets |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+    channels = targets |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+
+    ranked =
+      Message
+      |> Subject.subject_where(subject)
+      |> where([m], m.network_id in ^network_ids and m.channel in ^channels)
+      |> maybe_exclude_presence(hide_presence)
+      |> select([m], %{id: m.id, rn: over(row_number(), :w)})
+      |> windows([m],
+        w: [partition_by: [m.network_id, m.channel], order_by: [desc: m.server_time, desc: m.id]]
+      )
+
+    top_ids = from(r in subquery(ranked), where: r.rn <= ^capped, select: r.id)
+
+    Message
+    |> where([m], m.id in subquery(top_ids))
+    |> order_by([m], asc: m.server_time, asc: m.id)
+    |> preload(:network)
+    |> Repo.all()
+    |> Enum.group_by(&{&1.network_id, &1.channel})
+    |> Map.take(targets)
+  end
+
+  @doc """
   Counts rows for `(subject, network_id, channel)` whose `id` is
   strictly greater than `after_id`. Returns an integer.
 

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -931,7 +931,10 @@ defmodule Grappa.Visitors do
   @spec list_autojoin_channels(Visitor.t(), pos_integer()) :: [String.t()]
   def list_autojoin_channels(%Visitor{id: id}, network_id) when is_integer(network_id) do
     case Credentials.get_visitor_credential(id, network_id) do
-      {:ok, %Credential{last_joined_channels: channels}} when is_list(channels) -> channels
+      # #1679 — the COLUMN choice lives in `Networks.autojoin_channels/2`,
+      # next to the user twin it differs from, so the boot endpoint and the
+      # per-network endpoint cannot pick differently.
+      {:ok, %Credential{} = cred} -> Networks.autojoin_channels(:visitor, cred)
       {:error, :not_found} -> []
     end
   end

--- a/lib/grappa_web/controllers/boot_controller.ex
+++ b/lib/grappa_web/controllers/boot_controller.ex
@@ -59,9 +59,8 @@ defmodule GrappaWeb.BootController do
   """
   use GrappaWeb, :controller
 
-  alias Grappa.Networks
+  alias Grappa.{Networks, Scrollback}
   alias Grappa.PresenceFilter.Resolver
-  alias Grappa.Scrollback
   alias GrappaWeb.Subject
 
   # One page, matching `MessagesController`'s `@default_limit`. The head is
@@ -82,7 +81,7 @@ defmodule GrappaWeb.BootController do
     {kind, rows} = Networks.subject_network_rows(subject)
 
     channels =
-      Map.new(rows, fn {network, _nick, cred, _conn} ->
+      Map.new(rows, fn {network, _, cred, _} ->
         {network.slug,
          Networks.merge_channel_sources(
            cred.autojoin_channels,
@@ -108,7 +107,7 @@ defmodule GrappaWeb.BootController do
           [Networks.network_row()],
           %{String.t() => [Networks.channel_entry()]}
         ) :: %{String.t() => %{String.t() => [Scrollback.Message.t()]}}
-  defp heads(_subject, [], _channels), do: %{}
+  defp heads(_, [], _), do: %{}
 
   defp heads(subject, rows, channels) do
     id_by_slug = Map.new(rows, fn {network, _, _, _} -> {network.slug, network.id} end)

--- a/lib/grappa_web/controllers/boot_controller.ex
+++ b/lib/grappa_web/controllers/boot_controller.ex
@@ -84,7 +84,7 @@ defmodule GrappaWeb.BootController do
       Map.new(rows, fn {network, _, cred, _} ->
         {network.slug,
          Networks.merge_channel_sources(
-           cred.autojoin_channels,
+           Networks.autojoin_channels(kind, cred),
            Networks.session_channels(subject, network.id)
          )}
       end)

--- a/lib/grappa_web/controllers/boot_controller.ex
+++ b/lib/grappa_web/controllers/boot_controller.ex
@@ -1,0 +1,156 @@
+defmodule GrappaWeb.BootController do
+  @moduledoc """
+  `GET /boot` — the whole boot picture in ONE round trip (#1679).
+
+  ## Why this exists
+
+  Cic's cold boot used to fan out `GET /me`, `GET /networks`, then one
+  `GET /networks/:slug/channels` PER NETWORK, then one `/messages` fetch PER
+  CHANNEL. The burst therefore scaled with the SIZE OF THE ACCOUNT rather
+  than with anything the operator did, and on prod it tripped the reverse
+  proxy's `limit_req` zone: 31 × `503`, with zero `Sent 503` in the
+  application log — nginx rejected them, grappa never saw them. Grappa's own
+  inbound budget cannot see this either; `#630`'s `RequestBudget` meters only
+  write methods, and a boot is pure GET.
+
+  Throttling the client was considered and REJECTED (#1679 Decision): an
+  in-flight cap staggers the same work and makes boot feel slower. The
+  request COUNT is what had to stop scaling.
+
+  ## What it answers
+
+    * `networks` — byte-identical to `GET /networks`, via the shared
+      `Networks.subject_network_rows/1`.
+    * `channels` — `%{slug => [channel_entry]}`, each list byte-identical to
+      that network's `GET /networks/:slug/channels`, via the shared
+      `Networks.merge_channel_sources/2`.
+    * `heads` — `%{slug => %{channel => [message]}}`, the newest
+      `#{50}` rows per channel, so the pane renders on selection without a
+      second round.
+
+  `GET /me` is deliberately NOT folded in. It is already an aggregate
+  envelope (`read_cursors`, `unread_counts`, `badge_count`, `home_data`),
+  already CONSTANT in account size (measured: seven queries at one network
+  and at four), and it has consumers that are not boot (`refetchUser` after a
+  connect, the BootErrorBoundary retry). Duplicating that envelope here to
+  save one request of a two-request boot would buy a second copy to keep in
+  sync — the exact drift this controller exists to remove elsewhere. Boot is
+  `/me` + `/boot`: two requests, flat in networks and channels.
+
+  ## The N+1 that would undo the whole thing
+
+  Answering in one round trip while issuing one query per network — or worse,
+  per channel — moves the thundering herd from the operator's proxy to
+  SQLite and buys nothing. So every read here is either constant or bulk:
+
+    * the credential set is ONE query with `:network` preloaded;
+    * the per-network live facts (nick, connection info, channel list) are
+      `Registry` / GenServer reads, never queries;
+    * the per-channel heads are `Scrollback.bulk_heads/4` — a single
+      `ROW_NUMBER() OVER (PARTITION BY …)` statement, the shape #396 already
+      proved on the prod indexes;
+    * the presence-filter decision is the BULK
+      `PresenceFilter.Resolver.hidden_channels/3`, the same one `/me` uses.
+
+  `GrappaWeb.BootCostTest` pins that as an INVARIANT under both axes: the
+  query count at one network must equal the count at seven, and the count at
+  two channels must equal the count at twenty. A regression there is the
+  whole fix undone, so it is measured rather than asserted in prose.
+  """
+  use GrappaWeb, :controller
+
+  alias Grappa.Networks
+  alias Grappa.PresenceFilter.Resolver
+  alias Grappa.Scrollback
+  alias GrappaWeb.Subject
+
+  # One page, matching `MessagesController`'s `@default_limit`. The head is
+  # what the pane renders on selection; deeper history is still the
+  # per-channel endpoint's job, which #1679 explicitly leaves unchanged.
+  @head_limit 50
+
+  @doc """
+  `GET /boot` — networks + channel trees + per-channel heads for the caller.
+
+  Both subject kinds, no params. Never 404s on an empty account: a subject
+  with no credentials gets empty collections, which is the honest answer and
+  the one cic's boot chain already handles.
+  """
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _) do
+    subject = Subject.to_session(conn.assigns.current_subject)
+    {kind, rows} = Networks.subject_network_rows(subject)
+
+    channels =
+      Map.new(rows, fn {network, _nick, cred, _conn} ->
+        {network.slug,
+         Networks.merge_channel_sources(
+           cred.autojoin_channels,
+           Networks.session_channels(subject, network.id)
+         )}
+      end)
+
+    render(conn, :index,
+      networks: {kind, rows},
+      channels: channels,
+      heads: heads(subject, rows, channels)
+    )
+  end
+
+  # `%{slug => %{channel => [Message.t()]}}` for every channel in the tree.
+  #
+  # `bulk_heads/4` is keyed by `{network_id, channel}` because that is what
+  # the rows carry; the wire is keyed by SLUG, like every other nested
+  # envelope cic consumes (`read_cursors`, `unread_counts`). The two maps
+  # below translate once rather than at each lookup.
+  @spec heads(
+          Grappa.Session.subject(),
+          [Networks.network_row()],
+          %{String.t() => [Networks.channel_entry()]}
+        ) :: %{String.t() => %{String.t() => [Scrollback.Message.t()]}}
+  defp heads(_subject, [], _channels), do: %{}
+
+  defp heads(subject, rows, channels) do
+    id_by_slug = Map.new(rows, fn {network, _, _, _} -> {network.slug, network.id} end)
+
+    targets =
+      for {slug, entries} <- channels,
+          entry <- entries,
+          do: {Map.fetch!(id_by_slug, slug), entry.name}
+
+    subject
+    |> Scrollback.bulk_heads(targets, @head_limit, hidden_pairs(subject, rows, channels, id_by_slug))
+    |> Enum.group_by(fn {{network_id, _}, _} -> network_id end)
+    |> Map.new(fn {network_id, entries} ->
+      {slug_for(id_by_slug, network_id), Map.new(entries, fn {{_, channel}, messages} -> {channel, messages} end)}
+    end)
+  end
+
+  # The `(network_id, channel)` pairs whose presence noise this subject
+  # suppresses (#458). `hidden_channels/3` is the BULK resolver `/me` already
+  # uses — it takes the window universe as a parameter precisely so a caller
+  # that knows its channel set pays one prefs read instead of one per channel.
+  # Re-keyed from its slug shape to the id shape `bulk_heads/4` partitions on.
+  @spec hidden_pairs(
+          Grappa.Session.subject(),
+          [Networks.network_row()],
+          %{String.t() => [Networks.channel_entry()]},
+          %{String.t() => integer()}
+        ) :: MapSet.t({integer(), String.t()})
+  defp hidden_pairs(subject, rows, channels, id_by_slug) do
+    own_nicks = Map.new(rows, fn {network, nick, _, _} -> {network.slug, {network.id, nick}} end)
+    windows = Map.new(channels, fn {slug, entries} -> {slug, Map.new(entries, &{&1.name, nil})} end)
+
+    subject
+    |> Resolver.hidden_channels(own_nicks, windows)
+    |> Enum.flat_map(fn {slug, set} ->
+      Enum.map(set, fn channel -> {Map.fetch!(id_by_slug, slug), channel} end)
+    end)
+    |> MapSet.new()
+  end
+
+  @spec slug_for(%{String.t() => integer()}, integer()) :: String.t()
+  defp slug_for(id_by_slug, network_id) do
+    Enum.find_value(id_by_slug, fn {slug, id} -> if id == network_id, do: slug end)
+  end
+end

--- a/lib/grappa_web/controllers/boot_json.ex
+++ b/lib/grappa_web/controllers/boot_json.ex
@@ -15,9 +15,8 @@ defmodule GrappaWeb.BootJSON do
   `GrappaWeb.BootCostTest` compares `/boot`'s per-network channel list
   against the live `GET /networks/:slug/channels` response.
   """
-  alias Grappa.Networks
+  alias Grappa.{Networks, Scrollback}
   alias Grappa.Networks.Wire, as: NetworksWire
-  alias Grappa.Scrollback
   alias Grappa.Scrollback.Wire, as: ScrollbackWire
   alias GrappaWeb.NetworksJSON
 

--- a/lib/grappa_web/controllers/boot_json.ex
+++ b/lib/grappa_web/controllers/boot_json.ex
@@ -1,0 +1,92 @@
+defmodule GrappaWeb.BootJSON do
+  @moduledoc """
+  Phoenix view layer for `GrappaWeb.BootController` (#1679).
+
+  Deliberately a COMPOSITION of the three views it replaces rather than a
+  fourth serializer: `networks` delegates to `GrappaWeb.NetworksJSON.index/1`,
+  each channel list to `Grappa.Networks.Wire.channel_to_json/3` (what
+  `ChannelsJSON` does), each message to `Grappa.Scrollback.Wire.to_json/1`
+  (what `MessagesJSON` does).
+
+  That is the point of the endpoint: a boot that answered a DIFFERENT shape
+  from the per-request endpoints would make cic carry two decoders for one
+  concept, and any drift between them would surface as a boot that renders
+  subtly unlike a refetch. The equality is asserted, not just intended —
+  `GrappaWeb.BootCostTest` compares `/boot`'s per-network channel list
+  against the live `GET /networks/:slug/channels` response.
+  """
+  alias Grappa.Networks
+  alias Grappa.Networks.Wire, as: NetworksWire
+  alias Grappa.Scrollback
+  alias Grappa.Scrollback.Wire, as: ScrollbackWire
+  alias GrappaWeb.NetworksJSON
+
+  @typedoc """
+  Per-network channel trees: `%{network_slug => [channel_json]}`, each list
+  byte-identical to that network's `GET /networks/:slug/channels`.
+
+  Slug-keyed, like every other nested envelope cic consumes (`read_cursors`,
+  `unread_counts`) — the integer network id stays REST-internal.
+  """
+  @type channel_tree :: %{String.t() => [NetworksWire.channel_json()]}
+
+  @typedoc """
+  Per-channel head pages: `%{network_slug => %{channel => [message]}}`, the
+  newest page of each channel so the pane renders on selection without a
+  second round trip. Same row shape `GET .../messages` returns.
+
+  A channel with no history is ABSENT rather than mapped to `[]` — the same
+  convention `read_cursors` uses, and the one that keeps the envelope from
+  growing a key per empty window.
+  """
+  @type heads :: %{String.t() => %{String.t() => [ScrollbackWire.t()]}}
+
+  @typedoc """
+  The `GET /boot` envelope (#1679). Three keys, all required, all flat in
+  account size.
+
+  Declared as a NAMED type rather than left inline on `index/1`'s `@spec`
+  because the codegen (`Mix.Tasks.Grappa.GenWireTypes`) reads `@type`
+  declarations via `Code.Typespec.fetch_types/1` and never looks at a
+  `@spec`. Measured: with only the inline spec, adding this module to the
+  codegen's `@extra_modules` emitted NOTHING but a changed `Source:` header
+  comment — and that header alone moved the `wire_pin` digest, i.e. a RED
+  gate and a version bump earned by a comment rather than by a shape. A
+  web-layer envelope has to name its type or it is in the digest without
+  being in the contract.
+  """
+  @type boot_json :: %{
+          networks: [
+            NetworksWire.network_with_nick_json() | NetworksWire.visitor_network_with_nick_json()
+          ],
+          channels: channel_tree(),
+          heads: heads()
+        }
+
+  @doc "Renders the `:index` action — the whole boot envelope."
+  @spec index(%{
+          networks: {:user, [Networks.network_row()]} | {:visitor, [Networks.network_row()]},
+          channels: %{String.t() => [Networks.channel_entry()]},
+          heads: %{String.t() => %{String.t() => [Scrollback.Message.t()]}}
+        }) :: boot_json()
+  def index(%{networks: networks, channels: channels, heads: heads}) do
+    %{
+      networks: NetworksJSON.index(%{networks: networks}),
+      channels: Map.new(channels, fn {slug, entries} -> {slug, channel_list(entries)} end),
+      heads:
+        Map.new(heads, fn {slug, by_channel} ->
+          {slug,
+           Map.new(by_channel, fn {channel, messages} ->
+             {channel, Enum.map(messages, &ScrollbackWire.to_json/1)}
+           end)}
+        end)
+    }
+  end
+
+  @spec channel_list([Networks.channel_entry()]) :: [NetworksWire.channel_json()]
+  defp channel_list(entries) do
+    Enum.map(entries, fn %{name: name, joined: joined, source: source} ->
+      NetworksWire.channel_to_json(name, joined, source)
+    end)
+  end
+end

--- a/lib/grappa_web/controllers/channels_controller.ex
+++ b/lib/grappa_web/controllers/channels_controller.ex
@@ -42,8 +42,8 @@ defmodule GrappaWeb.ChannelsController do
   import GrappaWeb.Validation, only: [validate_channel_name: 1, validate_channel_list: 1]
 
   alias Grappa.Accounts.User
-  alias Grappa.Networks.{Credentials, Network}
   alias Grappa.{Networks, Session, Visitors}
+  alias Grappa.Networks.{Credentials, Network}
   alias GrappaWeb.{BodyLimit, Subject}
 
   @doc """

--- a/lib/grappa_web/controllers/channels_controller.ex
+++ b/lib/grappa_web/controllers/channels_controller.ex
@@ -43,7 +43,7 @@ defmodule GrappaWeb.ChannelsController do
 
   alias Grappa.Accounts.User
   alias Grappa.Networks.{Credentials, Network}
-  alias Grappa.{Session, Visitors}
+  alias Grappa.{Networks, Session, Visitors}
   alias GrappaWeb.{BodyLimit, Subject}
 
   @doc """
@@ -61,13 +61,8 @@ defmodule GrappaWeb.ChannelsController do
     subject = conn.assigns.current_subject
 
     with {:ok, autojoin} <- subject_autojoin(subject, network) do
-      session_channels =
-        case Session.list_channels(Subject.to_session(subject), network.id) do
-          {:ok, list} -> list
-          {:error, :no_session} -> []
-        end
-
-      entries = merge_channel_sources(autojoin, session_channels)
+      session_channels = Networks.session_channels(Subject.to_session(subject), network.id)
+      entries = Networks.merge_channel_sources(autojoin, session_channels)
       render(conn, :index, channels: entries)
     end
   end
@@ -86,33 +81,6 @@ defmodule GrappaWeb.ChannelsController do
     # (`conn.assigns.network`). No credential on this network → empty list
     # (the visitor hasn't attached / joined anything there yet).
     {:ok, Visitors.list_autojoin_channels(visitor, network.id)}
-  end
-
-  # Q3 pinned: when a channel is in both autojoin and session, source
-  # is :autojoin. Sorted alphabetically by `{name, source}` for
-  # wire-shape stability — name is the primary key and (under current
-  # MapSet.difference dedup) is unique, but tie-breaking on `:source`
-  # makes the ordering contract total. If a future refactor ever
-  # widened `merge_channel_sources/2` to accept duplicates, clients
-  # would still see deterministic order across requests instead of
-  # source-dependent churn (M-web-4).
-  @spec merge_channel_sources([String.t()], [String.t()]) ::
-          [%{name: String.t(), joined: boolean(), source: :autojoin | :joined}]
-  defp merge_channel_sources(autojoin, session) do
-    autojoin_set = MapSet.new(autojoin)
-    session_set = MapSet.new(session)
-
-    autojoin_entries =
-      Enum.map(autojoin_set, fn name ->
-        %{name: name, joined: MapSet.member?(session_set, name), source: :autojoin}
-      end)
-
-    session_only_entries =
-      session_set
-      |> MapSet.difference(autojoin_set)
-      |> Enum.map(fn name -> %{name: name, joined: true, source: :joined} end)
-
-    Enum.sort_by(autojoin_entries ++ session_only_entries, &{&1.name, &1.source})
   end
 
   @doc """

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -367,6 +367,23 @@ defmodule GrappaWeb.Router do
 
     get "/me", MeController, :show
 
+    # #1679 — the one-round-trip boot envelope: networks + every network's
+    # channel tree + each channel's head page. Replaces the `1 + N` fan-out
+    # (`GET /networks` then one `GET /networks/:slug/channels` per network)
+    # plus the per-channel `/messages` burst that followed it, which scaled
+    # with the size of the account and tripped the operator's proxy
+    # `limit_req` zone (31 × 503 on prod, none of them grappa's).
+    #
+    # TOP-LEVEL, alongside `/me`, not nested under `/networks`: it is not a
+    # network-scoped resource — it answers ACROSS every network the subject
+    # holds, so `Plugs.ResolveNetwork` (which resolves ONE `:network_id` and
+    # asserts ownership of it) is the wrong pipeline by construction. Subject
+    # scoping is `:authn` plus the subject-keyed reads inside.
+    #
+    # A GET, so `:request_budget` does not meter it (#630 self-gates to write
+    # methods) — the same reason grappa never saw the burst this replaces.
+    get "/boot", BootController, :index
+
     # Per-user settings — push notifications cluster B3 (2026-05-14).
     # Visitor-parity V4 (2026-05-15) lifted the user-only gate; both
     # registered users + visitors hit these endpoints. Persists into

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -100,8 +100,23 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   # delivering zero coverage while looking widened. `error_tokens.ex` only
   # ever worked because it sits directly under `grappa_web/` and camelizes
   # exactly. A module list has no path→name guess to get wrong.
+  # #1679 — `GrappaWeb.BootJSON` joins the list for the same reason `MeJSON`
+  # is on it: it is a top-level ENVELOPE assembled in the web layer, not a
+  # domain `*.Wire` module, so the glob cannot reach it. Its leaf shapes
+  # (network rows, channel entries, message rows) already come from
+  # `Grappa.Networks.Wire` / `Grappa.Scrollback.Wire`; what is new — and what
+  # a client would otherwise hand-write — is how they nest.
+  #
+  # Measured before adding it: with `/boot` routed, rendered and tested,
+  # `mix grappa.wire_pin --check` answered `wire shape and protocol 3 agree`
+  # at rc=0. A whole new client-facing endpoint was invisible to the
+  # tripwire, because the set it digests is a glob over `lib/grappa/**` plus
+  # a hand-kept list. So a new web-layer envelope MUST be added here in the
+  # same commit that introduces it, or the pin green means only "nothing I
+  # was looking at moved".
   @extra_modules [
     GrappaWeb.AuthJSON,
+    GrappaWeb.BootJSON,
     GrappaWeb.ErrorTokens,
     GrappaWeb.MeJSON
   ]

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 3
-shape_digest = sha256:43ef97a8a54ce849af1bfc92969fc60371796d8fd39a745cc514b1ce301117ae
+protocol_version = 4
+shape_digest = sha256:b51b3b6fc9fde697c9fb0a3bfe7b3ecfc8db14ddd1f62493828c31fc28b47a43

--- a/test/grappa_web/controllers/boot_controller_test.exs
+++ b/test/grappa_web/controllers/boot_controller_test.exs
@@ -1,0 +1,151 @@
+defmodule GrappaWeb.BootControllerTest do
+  @moduledoc """
+  #1679 — `GET /boot` behaviour. The COST half (the N+1 pin, the baseline it
+  is measured against) lives in `GrappaWeb.BootCostTest`; this file is about
+  what the envelope says.
+
+  Both subject kinds, because #211 ruling A makes a visitor multi-network
+  with real per-network credentials — a boot endpoint that served only users
+  would leave every visitor on the fan-out this issue exists to remove.
+  """
+  use GrappaWeb.ConnCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.ScrollbackHelpers
+
+  describe "authorization" do
+    test "an unauthenticated caller is refused, and does NOT fall through to the SPA" do
+      conn = get(build_conn(), "/boot")
+
+      # The route sits under `:authn` but BELOW `get "/*path", SpaController`
+      # in the router file, so "refused" has to be asserted as a 401 with a
+      # JSON body — a 200 `text/html` here would mean the request never
+      # reached this controller at all, which is how the catch-all silently
+      # green-lit the cost tests before the route existed.
+      assert json_response(conn, 401)
+    end
+  end
+
+  describe "the user subject" do
+    test "answers the networks, the channel tree and the heads in one envelope" do
+      %{conn: conn, slug: slug, channels: channels} = account_with_history()
+
+      body = json_response(get(conn, "/boot"), 200)
+
+      assert [network] = body["networks"]
+      assert network["slug"] == slug
+      assert network["kind"] == "user"
+
+      assert Enum.map(body["channels"][slug], & &1["name"]) == Enum.sort(channels)
+    end
+
+    test "the head carries the channel's NEWEST rows, oldest-first, and only its own" do
+      %{conn: conn, slug: slug} = account_with_history()
+
+      body = json_response(get(conn, "/boot"), 200)
+
+      head = body["heads"][slug]["#alpha"]
+      assert Enum.map(head, & &1["body"]) == ["alpha 1", "alpha 2", "alpha 3"]
+
+      # A channel's head must not bleed into its sibling's. The partition is
+      # `(network_id, channel)`; a broken one shows up here as one list
+      # holding both channels' rows.
+      assert Enum.map(body["heads"][slug]["#beta"], & &1["body"]) == ["beta 1"]
+    end
+
+    test "a channel with no history is ABSENT from heads, not mapped to an empty list" do
+      %{conn: conn, slug: slug} = account_with_history()
+
+      heads = json_response(get(conn, "/boot"), 200)["heads"][slug]
+
+      # `#quiet` is in the channel tree and has no rows. Absent rather than
+      # `[]` — the `read_cursors` convention, and what keeps the envelope
+      # from growing a key per empty window on a large account.
+      assert Map.has_key?(heads, "#alpha")
+      refute Map.has_key?(heads, "#quiet")
+      assert Enum.any?(json_response(get(conn, "/boot"), 200)["channels"][slug], &(&1["name"] == "#quiet"))
+    end
+
+    test "never leaks another subject's rows into the head" do
+      %{conn: conn, slug: slug, network: network} = account_with_history()
+
+      other = user_fixture(name: "other-#{System.unique_integer([:positive])}")
+      credential_fixture(other, network, %{autojoin_channels: ["#alpha"]})
+      insert_message(other, network, "#alpha", "not yours")
+
+      heads = json_response(get(conn, "/boot"), 200)["heads"][slug]
+
+      refute "not yours" in Enum.map(heads["#alpha"], & &1["body"])
+    end
+
+    test "an account with no networks gets empty collections, not a 404" do
+      user = user_fixture(name: "bare-#{System.unique_integer([:positive])}")
+      conn = put_bearer(build_conn(), session_fixture(user).id)
+
+      body = json_response(get(conn, "/boot"), 200)
+
+      assert body["networks"] == []
+      assert body["channels"] == %{}
+      assert body["heads"] == %{}
+    end
+  end
+
+  describe "the visitor subject" do
+    test "gets the same envelope, discriminated as a visitor" do
+      {network, _} =
+        network_with_server(port: 6667, slug: "vis-#{System.unique_integer([:positive])}")
+
+      {visitor, session} = visitor_and_session_with_credential(network_slug: network.slug)
+      visitor_channel_fixture(visitor, network.slug, "#vis")
+      conn = put_bearer(build_conn(), session.id)
+
+      body = json_response(get(conn, "/boot"), 200)
+
+      assert [row] = body["networks"]
+      assert row["kind"] == "visitor"
+      assert row["slug"] == network.slug
+      assert Enum.map(body["channels"][network.slug], & &1["name"]) == ["#vis"]
+    end
+  end
+
+  # A user on one network with three channels: `#alpha` (three rows),
+  # `#beta` (one), `#quiet` (none).
+  defp account_with_history do
+    user = user_fixture(name: "boot-#{System.unique_integer([:positive])}")
+    session = session_fixture(user)
+
+    {network, _} =
+      network_with_server(port: 6667, slug: "boot-#{System.unique_integer([:positive])}")
+
+    channels = ["#alpha", "#beta", "#quiet"]
+    credential_fixture(user, network, %{autojoin_channels: channels})
+
+    for body <- ["alpha 1", "alpha 2", "alpha 3"],
+        do: insert_message(user, network, "#alpha", body)
+
+    insert_message(user, network, "#beta", "beta 1")
+
+    %{
+      conn: put_bearer(build_conn(), session.id),
+      slug: network.slug,
+      network: network,
+      channels: channels
+    }
+  end
+
+  defp insert_message(user, network, channel, body) do
+    {:ok, message} =
+      ScrollbackHelpers.insert(%{
+        user_id: user.id,
+        network_id: network.id,
+        channel: channel,
+        sender: "peer",
+        kind: :privmsg,
+        body: body,
+        server_time: System.system_time(:millisecond)
+      })
+
+    message
+  end
+end

--- a/test/grappa_web/controllers/boot_cost_test.exs
+++ b/test/grappa_web/controllers/boot_cost_test.exs
@@ -1,0 +1,250 @@
+defmodule GrappaWeb.BootCostTest do
+  @moduledoc """
+  #1679 — what a cold boot costs the DATABASE, measured rather than derived.
+
+  The issue measures the boot burst in HTTP requests (`1 + N + (1..3)·C`) and
+  says of the fix that "the single round trip must not become an N+1
+  underneath". That requirement is only checkable against a number, so this
+  file executes the boot sequence and counts `[:grappa, :repo, :query]`.
+
+  Counted in the TEST process with a `self()` filter, the shape
+  `Grappa.Session.RefreshPlanCostTest` established: telemetry handlers run in
+  the emitting process and Ecto emits synchronously, so the filter is exact
+  and the mailbox is complete the moment the request returns. That is also
+  what makes the file `async: true`-safe.
+
+  Two halves:
+
+    * `the boot sequence as it exists today` — the BASELINE, pinned so the
+      win is a measured delta and not a claim. Measured `11 + 5N` queries
+      over `2 + N` requests.
+    * `GET /boot` — the N+1 pin. The count must be INVARIANT under account
+      size, on BOTH axes (networks and channels). A pinned ordered source
+      list rather than a bare total, so a regression says WHICH read
+      appeared.
+
+  The invariance assertion is the whole point of the file: an endpoint that
+  answers in one round trip while issuing one query per network has moved
+  the thundering herd from the proxy to SQLite and bought nothing.
+  """
+  use GrappaWeb.ConnCase, async: true
+
+  import Grappa.AuthFixtures
+
+  @query_event [:grappa, :repo, :query]
+
+  describe "the boot sequence as it exists today" do
+    test "costs 11 + 5N queries across 2 + N requests — the baseline the fix is measured against" do
+      one = today_boot_cost(1, 3)
+      four = today_boot_cost(4, 3)
+
+      assert one.requests == 3
+      assert four.requests == 6
+
+      # Per-request: /me and /networks are already constant in N; only the
+      # per-network channel call scales, at five queries a network (two of
+      # them the bearer plug's `sessions` + `users`, paid once per request).
+      assert one.me == 7
+      assert four.me == 7
+      assert one.networks == 4
+      assert four.networks == 4
+      assert one.channels_each == [5]
+      assert four.channels_each == [5, 5, 5, 5]
+
+      assert one.total == 16
+      assert four.total == 31
+      assert four.total - one.total == 15
+    end
+  end
+
+  describe "GET /boot" do
+    test "answers the whole boot picture in ONE request" do
+      %{conn: conn, slugs: slugs} = boot_account(3, 4)
+
+      body = json_response(get(conn, "/boot"), 200)
+
+      assert length(body["networks"]) == 3
+
+      for slug <- slugs do
+        assert Enum.any?(body["networks"], &(&1["slug"] == slug))
+        assert length(body["channels"][slug]) == 4
+      end
+    end
+
+    test "carries EVERY channel of EVERY network — the half that breaks in silence" do
+      %{conn: conn, slugs: slugs} = boot_account(3, 4)
+
+      body = json_response(get(conn, "/boot"), 200)
+
+      # The per-network channel lists must be byte-identical to what the
+      # endpoint they replace answers. Anything less is a boot that renders
+      # a short sidebar and looks fine.
+      for slug <- slugs do
+        per_network = json_response(get(conn, "/networks/#{slug}/channels"), 200)
+        assert body["channels"][slug] == per_network
+      end
+    end
+
+    test "costs six queries, and this is WHICH six" do
+      {sources, count} = measure_boot(3, 5)
+
+      # Pinned as an ordered list, not a total: a regression then says which
+      # read appeared or vanished instead of only that something moved.
+      #
+      #   sessions + users     — the bearer plug, once per request
+      #   network_credentials  — the credential set...
+      #   networks             — ...and its `:network` preload
+      #   user_settings        — the presence-filter prefs, read in bulk once
+      #   messages             — the ONE windowed per-channel head statement
+      #
+      # Everything else a boot needs (live nick, connection info, the session
+      # channel list) is a Registry / GenServer read and costs no query — which
+      # is why this list does not grow with the account.
+      assert sources == [
+               "sessions",
+               "users",
+               "network_credentials",
+               "networks",
+               "user_settings",
+               "messages"
+             ]
+
+      assert count == 6
+    end
+
+    test "the query count is INVARIANT under the number of NETWORKS" do
+      {one_src, one} = measure_boot(1, 3)
+      {seven_src, seven} = measure_boot(7, 3)
+
+      assert {one, one_src} == {seven, seven_src},
+             """
+             /boot fans out per network — the HTTP burst became a SQL burst.
+               N=1: #{one} #{inspect(one_src)}
+               N=7: #{seven} #{inspect(seven_src)}
+             """
+    end
+
+    test "the query count is INVARIANT under the number of CHANNELS" do
+      {few_src, few} = measure_boot(2, 2)
+      {many_src, many} = measure_boot(2, 20)
+
+      assert {few, few_src} == {many, many_src},
+             """
+             /boot fans out per channel — the HTTP burst became a SQL burst.
+               C=2:  #{few} #{inspect(few_src)}
+               C=20: #{many} #{inspect(many_src)}
+             """
+    end
+
+    test "the WIN, stated as the delta the issue asked for" do
+      today = today_boot_cost(7, 3)
+      {_, boot} = measure_boot(7, 3)
+
+      # Seven networks is the account the prod incident was measured on.
+      assert today.requests == 9
+      assert today.total == 46
+
+      # `/me` is deliberately not folded in (see BootController's moduledoc),
+      # so a boot is `/me` + `/boot`: two requests, and both flat in account
+      # size. That is the "single digits of requests" the Decision asked for,
+      # and it stays single-digit at seventy networks.
+      assert boot == 6
+      assert today.me + boot == 13
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Harness
+  # ---------------------------------------------------------------------------
+
+  # Runs one `GET /boot` and returns `{sources, count}`.
+  #
+  # The known-answer control is INSIDE the instrument on purpose. `/boot` has
+  # a catch-all above it in the router (`get "/*path", SpaController, :index`)
+  # which answers 200 `text/html` for any unrouted path — so before the route
+  # existed BOTH invariance tests passed, comparing the SPA's query cost
+  # against itself. A count is only evidence once the thing counted is the
+  # thing under test, so the response is proven to be the boot envelope, with
+  # the account it was built for, before its cost is believed.
+  defp measure_boot(n, c) do
+    %{conn: conn, slugs: slugs} = boot_account(n, c)
+    {conn, sources} = measure(fn -> get(conn, "/boot") end)
+
+    body = json_response(conn, 200)
+    assert length(body["networks"]) == n
+    assert map_size(body["channels"]) == n
+    for slug <- slugs, do: assert(length(body["channels"][slug]) == c)
+
+    {sources, length(sources)}
+  end
+
+  defp today_boot_cost(n, c) do
+    %{conn: conn, slugs: slugs} = boot_account(n, c)
+
+    {_, me} = measure(fn -> get(conn, "/me") end)
+    {_, nets} = measure(fn -> get(conn, "/networks") end)
+
+    per_channel =
+      Enum.map(slugs, fn slug ->
+        {_, q} = measure(fn -> get(conn, "/networks/#{slug}/channels") end)
+        length(q)
+      end)
+
+    %{
+      requests: 2 + length(slugs),
+      me: length(me),
+      networks: length(nets),
+      channels_each: per_channel,
+      total: length(me) + length(nets) + Enum.sum(per_channel)
+    }
+  end
+
+  # Builds a user bound to `n` networks, each credential carrying `c`
+  # autojoin channels, and returns a bearer-carrying conn plus the slugs.
+  defp boot_account(n, c) do
+    user = user_fixture(name: "boot-#{System.unique_integer([:positive])}")
+    session = session_fixture(user)
+
+    slugs =
+      for i <- 1..n do
+        {network, _} =
+          network_with_server(port: 6667, slug: "boot-#{System.unique_integer([:positive])}")
+
+        channels = for j <- 1..c, do: "#c#{i}-#{j}"
+        credential_fixture(user, network, %{autojoin_channels: channels})
+        network.slug
+      end
+
+    %{conn: put_bearer(build_conn(), session.id), slugs: slugs}
+  end
+
+  defp measure(fun) do
+    test_pid = self()
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+
+    :ok = :telemetry.attach(handler_id, @query_event, &__MODULE__.forward_query/4, {test_pid, ref})
+
+    try do
+      result = fun.()
+      {result, drain(ref, [])}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  @doc false
+  @spec forward_query([atom()], map(), map(), {pid(), reference()}) :: :ok
+  def forward_query(_, _, metadata, {test_pid, ref}) do
+    if self() == test_pid, do: send(test_pid, {ref, Map.get(metadata, :source)})
+    :ok
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, source} -> drain(ref, [source | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/grappa_web/controllers/boot_cost_test.exs
+++ b/test/grappa_web/controllers/boot_cost_test.exs
@@ -168,9 +168,9 @@ defmodule GrappaWeb.BootCostTest do
   # the account it was built for, before its cost is believed.
   defp measure_boot(n, c) do
     %{conn: conn, slugs: slugs} = boot_account(n, c)
-    {conn, sources} = measure(fn -> get(conn, "/boot") end)
+    {resp, sources} = measure(fn -> get(conn, "/boot") end)
 
-    body = json_response(conn, 200)
+    body = json_response(resp, 200)
     assert length(body["networks"]) == n
     assert map_size(body["channels"]) == n
     for slug <- slugs, do: assert(length(body["channels"][slug]) == c)

--- a/test/grappa_web/router_scope_test.exs
+++ b/test/grappa_web/router_scope_test.exs
@@ -76,6 +76,14 @@ defmodule GrappaWeb.RouterScopeTest do
   # scope refusal.
   @client_usable_routes [
     {"DELETE", "/auth/logout"},
+    # #1679 — the boot envelope. Client-usable by the same reasoning as
+    # `GET /me` and the `/networks` prefix it is assembled from: it is the
+    # read a client performs to know what it is connected to, and refusing
+    # it to a headless client would leave that client on the per-network
+    # fan-out the endpoint exists to remove. It carries no credential and
+    # no setting — networks, channel names, and message rows the same
+    # client can already fetch one at a time.
+    {"GET", "/boot"},
     {"GET", "/me"},
     {"GET", "/me/theme"},
     {"PUT", "/me/theme"},


### PR DESCRIPTION
Addresses #1679.

cic's cold boot fanned out `GET /me`, `GET /networks`, one
`GET /networks/:slug/channels` per network, then a `/messages` page per
channel. The burst scaled with the **size of the account** rather than with
anything the operator did, and on prod it tripped the reverse proxy's
`limit_req` zone: 31 × `503` with **zero** `Sent 503` in the application log
— nginx rejected them and grappa never saw them. grappa's own budget cannot
see them either (#630's `RequestBudget` meters write methods only, and a boot
is pure GET), so the operator's proxy is the sole backstop and every
operator's is configured differently.

Per the issue's Decision, client-side throttling is **not** the fix here: an
in-flight cap staggers the same work and makes boot feel slower. The request
count itself had to stop scaling.

## The arithmetic that set the scope

The Decision's letter ("one request replaces `1 + N + …`") and its success
criterion ("back in the single digits of requests") are not the same
instruction, and the second is the binding one.

`burst=50` plus 31 rejections means **at least 81 requests** were presented
in the window — a floor, since the queue drains as it fills. The account
holds seven networks, so `me + networks + 7 × channels` is **nine**. The
other ~72 are per-channel. An endpoint collapsing only `1 + N` would have
removed nine of eighty-one and the incident would have repeated unchanged.

That subtraction is why the per-channel heads are in scope.

## Measured, because "must not become an N+1" needs a number

`GrappaWeb.BootCostTest` counts `[:grappa, :repo, :query]` in the test
process with a `self()` filter — the shape `RefreshPlanCostTest` established
(handlers run in the emitting process, Ecto emits synchronously, so the
filter is exact and the mailbox is complete when the request returns).

| | today | `/boot` |
|---|---|---|
| queries | `11 + 5N` | **6, invariant** |
| requests | `2 + N` | **1** |
| at N=1 | 16 / 3 | 6 / 1 |
| at N=7 | 46 / 9 | 6 / 1 |

Pinned as an **ordered source list** — `sessions`, `users`,
`network_credentials`, `networks`, `user_settings`, `messages` — not a bare
total, so a regression names *which* read appeared. Invariance is asserted on
**both** axes (1 vs 7 networks, 2 vs 20 channels).

`GET /me` is deliberately **not** folded in: it is already an aggregate
envelope, already constant in account size (measured: seven queries at one
network and at four), and it has non-boot consumers. A boot is `/me` +
`/boot` — two requests, flat in account size.

The per-channel heads are one `ROW_NUMBER() OVER (PARTITION BY (network_id,
channel))` statement, the shape #396 already proved against the live prod
indexes. Two calls keep the query *string* constant so SQLite's
prepared-statement cache still helps the accounts this exists for: an
`IN (…) AND IN (…)` predicate rather than an OR over exact pairs (the
resulting over-read is dropped by `Map.take/2`, and `subject_where/2` is
applied first so it is never a leak), and the #458 presence exclusion
partitions the targets into at most two statements rather than one per pair.

## Two findings worth more than the endpoint

**1. The wire tripwire was blind.** With `/boot` routed, rendered and tested,
`mix grappa.wire_pin --check` answered `wire shape and protocol 3 agree` at
**rc=0**. The digested set is a glob over `lib/grappa/**/*wire.ex` plus a
hand-kept `@extra_modules` list, and a controller's `*_json.ex` is in
neither.

Adding `GrappaWeb.BootJSON` to that list was necessary and **not
sufficient**: while its only typespec was an inline `@spec`, the codegen
emitted nothing but a changed `Source:` header comment — and that comment
moved the digest, i.e. a red gate and a version bump earned by a comment
rather than by a shape. The generator reads `@type` declarations via
`Code.Typespec.fetch_types/1` and never looks at a `@spec`. Both halves are
now required, and stated as a rule.

**2. A visitor's channel tree comes from a different column.** A user
declares `autojoin_channels`; a visitor carries `last_joined_channels` (#211
phase 4c moved it onto the credential). Reading the user column for both
compiles, passes every user test, and hands **every visitor an empty channel
tree**. `Networks.autojoin_channels/2` now owns the choice, with
`Visitors.list_autojoin_channels/2` delegating to it.

Two further guardrails fired and were right: `/boot` needed an entry in cic's
service-worker navigation denylist (else an explicit navigation serves the
SPA shell instead of reaching the controller, REV-G H22), and a classification
in `RouterScopeTest`'s client-usable set — where it belongs by the same
reasoning as `GET /me`.

## Protocol version

⚠️ **Bumped 3 → 4, and `w1-1675` bumps to the same number.** Whichever lands
second must rebase, move to **5**, and re-run `mix grappa.wire_pin --update`.

The bump is the task's verdict rather than a judgement call: `wire_pin
--check` went red on the digest and printed `3 -> 4`. Purely additive — no
existing endpoint changed shape, and a v3 client that never calls `/boot` is
served exactly as before — but the rule since #1393d applies in its strongest
form: the moment a client stops fanning out and starts *requiring* `/boot`,
it can no longer talk to a server predating it, which is the
new-client → old-server direction the number exists for. `min_version` stays
at 1; nobody is stranded.

## Scope, and what is deliberately left out

- **cic is not wired to `/boot` in this PR.** The server answers it; the
  client still fans out, so production behaviour is unchanged until that
  half lands. It is the larger half (`networks.ts`'s resource graph plus
  `scrollback.ts` seeding) and touches the path #281 already broke once.
- **The existing per-channel endpoints are untouched**, per the issue's
  non-goals. `/boot` replaces the fan-out, not them; paging back
  (`?before=`), resuming a gap (`?after=`) and measuring one
  (`/messages/count`) all stay.
- **The head is the channel's newest page, not its unread region.** That is
  what a pane renders on selection; the unread machinery is driven by
  `/me`'s `unread_counts` / `read_cursors`, which do not need the rows. An
  unread-shaped head would also be unbounded per channel, which a
  single-response envelope cannot afford.
- **No rate limits were raised**, in nginx templates or in docs.

## Not measured — stated as such

Whether the **reconnect** path shares the fan-out shape was read off the
code, not executed. `subscribe.ts`'s socket-open effect calls
`refetchNetworks()`, `refetchChannels()`, then loops `refreshScrollback` over
every key in `joined`; phoenix.js's auto-rejoin fires the join-ok refresh for
the same keys, which #1593's queue deliberately does not drop. So the shape
is the same and the count is larger than a cold boot's. That is a static
reading of an unambiguous loop, and it is recorded that way rather than as a
measurement.

## Gates

`scripts/check.sh` **rc=0** — 8 doctests, 62 properties, **6786 tests, 0
failures**; dialyzer `Total errors: 0`; credo strict `found no issues`;
`gen_wire_types --check` in sync; `wire_pin --check` `protocol 4 agree`; bats
`1..657`, zero `not ok`. `scripts/bun.sh run check` and `run test` rc=0 — 299
files, 5841 tests. `scripts/design-notes-gate.sh`: 1 new entry heading,
separator and marker present.

Integration/e2e not run — lane not allocated for this slice.
