### PR TITLE
cic: pause presence on channels left alone, refetch members on focus (#1680)

### DIFF
--- a/cicchetto/src/__tests__/presenceCooldown.test.ts
+++ b/cicchetto/src/__tests__/presenceCooldown.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { channelKey } from "../lib/channelKey";
+import { createPresenceCooldown, PRESENCE_COOLDOWN_MS } from "../lib/presenceCooldown";
+
+// #1680 — the cooldown that stands between "the user left this channel alone"
+// and "the user flicked past it".
+//
+// The whole point of the window is that the SECOND case must never release a
+// subscription. Every test below is about which of the two a given sequence
+// of focus/blur events is.
+
+const alice = channelKey("azzurra", "#alice");
+const bob = channelKey("azzurra", "#bob");
+
+describe("presenceCooldown (#1680)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("releases a channel the user left alone for the whole cooldown", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+
+    cd.blurred(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith(alice);
+    cd.dispose();
+  });
+
+  it("does not release before the cooldown has fully elapsed", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+
+    cd.blurred(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS - 1);
+
+    expect(release).not.toHaveBeenCalled();
+    cd.dispose();
+  });
+
+  // THE case the cooldown exists for. vjt, 2026-08-22: "a channel the user
+  // flicks through and comes back to should never have left."
+  it("never releases a channel the user came back to inside the window", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+
+    cd.blurred(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+    cd.focused(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 10);
+
+    expect(release).not.toHaveBeenCalled();
+    cd.dispose();
+  });
+
+  // The tour described in the issue: ten channels touched inside the window
+  // hold ten subscriptions. That is the ACCEPTED trade, so it is asserted as
+  // behaviour rather than left implicit — if someone "optimises" it into
+  // one-at-a-time, this test says what was given up.
+  it("holds every channel touched inside one window (the accepted trade)", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+    const tour = Array.from({ length: 10 }, (_, i) => channelKey("azzurra", `#c${i}`));
+
+    for (const key of tour) {
+      cd.focused(key);
+      vi.advanceTimersByTime(1000);
+      cd.blurred(key);
+    }
+
+    expect(release).not.toHaveBeenCalled();
+    expect(cd.pending().length).toBe(10);
+    cd.dispose();
+  });
+
+  it("re-arms a fresh window on each blur instead of stacking timers", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+
+    cd.blurred(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+    cd.blurred(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+
+    // One release, not two: the second blur replaced the first window.
+    expect(release).toHaveBeenCalledTimes(1);
+    cd.dispose();
+  });
+
+  it("tracks each channel on its own window", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+
+    cd.blurred(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+    cd.blurred(bob);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith(alice);
+
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+    expect(release).toHaveBeenCalledWith(bob);
+    cd.dispose();
+  });
+
+  it("focusing a channel with no pending window is a no-op", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+
+    cd.focused(alice);
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 2);
+
+    expect(release).not.toHaveBeenCalled();
+    cd.dispose();
+  });
+
+  it("dispose cancels every pending window (teardown leaks no release)", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, PRESENCE_COOLDOWN_MS);
+
+    cd.blurred(alice);
+    cd.blurred(bob);
+    cd.dispose();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 2);
+
+    expect(release).not.toHaveBeenCalled();
+    expect(cd.pending()).toEqual([]);
+  });
+
+  // THE MUTANT (orchestrator's ask). Zero the cooldown and the flick test
+  // above inverts: the channel the user came straight back to has already
+  // been released. This is what proves the window is load-bearing and not
+  // decoration — if `createPresenceCooldown` ever ignored its cooldownMs,
+  // the flick test would still pass and only this one would fail.
+  it("MUTANT: with a zero cooldown the flicked channel is released anyway", () => {
+    const release = vi.fn();
+    const cd = createPresenceCooldown(release, 0);
+
+    cd.blurred(alice);
+    vi.advanceTimersByTime(0);
+    cd.focused(alice);
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith(alice);
+    cd.dispose();
+  });
+
+  it("the shipped window is two minutes, and it is a chosen number", () => {
+    // Guards the ONE named place. If someone tunes it, they tune it here and
+    // this line is the review surface — not a literal buried in a caller.
+    expect(PRESENCE_COOLDOWN_MS).toBe(120_000);
+  });
+});

--- a/cicchetto/src/__tests__/presencePause.test.ts
+++ b/cicchetto/src/__tests__/presencePause.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { channelKey } from "../lib/channelKey";
+import { PRESENCE_COOLDOWN_MS } from "../lib/presenceCooldown";
+import { SUPPRESSED_PRESENCE_KINDS } from "../lib/presenceFilter";
+import { createPresencePause, PAUSABLE_PRESENCE_KINDS } from "../lib/presencePause";
+
+const alice = channelKey("azzurra", "#alice");
+const bob = channelKey("azzurra", "#bob");
+
+describe("presencePause (#1680)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("what a paused channel is allowed to swallow", () => {
+    // The guard against inheriting a kind by accident. If the server twin
+    // grows a sixth presence kind, `SUPPRESSED_PRESENCE_KINDS` follows it
+    // (it is byte-pinned by presence_filter_test.exs) — and this assertion
+    // keeps that from silently widening what a paused channel drops.
+    it("drops only a strict subset of the presence kinds", () => {
+      for (const kind of PAUSABLE_PRESENCE_KINDS) {
+        expect(SUPPRESSED_PRESENCE_KINDS.has(kind)).toBe(true);
+      }
+      expect(PAUSABLE_PRESENCE_KINDS.size).toBeLessThan(SUPPRESSED_PRESENCE_KINDS.size);
+    });
+
+    // Named individually rather than by set-difference: these two are
+    // excluded for REASONS (the #372/#373 migration, channel-mode state),
+    // and a test that just recomputed the difference would happily follow
+    // someone deleting one of them.
+    it("never drops nick_change — it drives the #372/#373 cache migration", () => {
+      expect(PAUSABLE_PRESENCE_KINDS.has("nick_change")).toBe(false);
+    });
+
+    it("never drops mode", () => {
+      expect(PAUSABLE_PRESENCE_KINDS.has("mode")).toBe(false);
+    });
+  });
+
+  describe("the drop predicate", () => {
+    it("drops a peer join/part/quit once the channel is paused", () => {
+      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      pause.focus(alice);
+      pause.focus(bob);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+
+      expect(pause.isPaused(alice)).toBe(true);
+      for (const kind of ["join", "part", "quit"] as const) {
+        expect(pause.shouldDrop(alice, kind, false)).toBe(true);
+      }
+      pause.dispose();
+    });
+
+    it("drops nothing before the window elapses", () => {
+      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      pause.focus(alice);
+      pause.focus(bob);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS - 1);
+
+      expect(pause.shouldDrop(alice, "join", false)).toBe(false);
+      pause.dispose();
+    });
+
+    it("never drops OUR OWN presence, however long the channel sat paused", () => {
+      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      pause.focus(alice);
+      pause.focus(bob);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 10);
+
+      // An own PART tears the window down (#200); swallowing it would leak
+      // the subscription and strand a dead window.
+      expect(pause.shouldDrop(alice, "part", true)).toBe(false);
+      expect(pause.shouldDrop(alice, "join", true)).toBe(false);
+      pause.dispose();
+    });
+
+    it("never drops a message, whatever the pause state", () => {
+      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      pause.focus(alice);
+      pause.focus(bob);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+
+      // vjt, 2026-08-22: messages must not be lost. Quiet, not blind.
+      for (const kind of ["privmsg", "notice", "action"] as const) {
+        expect(pause.shouldDrop(alice, kind, false)).toBe(false);
+      }
+      pause.dispose();
+    });
+
+    it("never drops on the focused channel", () => {
+      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      pause.focus(alice);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 10);
+
+      expect(pause.shouldDrop(alice, "join", false)).toBe(false);
+      pause.dispose();
+    });
+  });
+
+  describe("the resume seam", () => {
+    it("refetches exactly when presence was actually missed", () => {
+      const onResume = vi.fn();
+      const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+
+      pause.focus(alice);
+      pause.focus(bob);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+      expect(pause.isPaused(alice)).toBe(true);
+
+      pause.focus(alice);
+      expect(onResume).toHaveBeenCalledTimes(1);
+      expect(onResume).toHaveBeenCalledWith(alice);
+      expect(pause.isPaused(alice)).toBe(false);
+      pause.dispose();
+    });
+
+    // The flick again, from the other side: nothing was dropped, so there is
+    // nothing to rebuild and the refetch must NOT fire. A resume that fired
+    // on every re-focus would BE the refetch storm the cooldown exists to
+    // prevent — #1679's failure mode, reintroduced at the other end.
+    it("does not refetch for a channel that was never paused", () => {
+      const onResume = vi.fn();
+      const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+
+      pause.focus(alice);
+      pause.focus(bob);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+      pause.focus(alice);
+
+      expect(onResume).not.toHaveBeenCalled();
+      pause.dispose();
+    });
+
+    it("re-focusing the already-focused channel is a no-op", () => {
+      const onResume = vi.fn();
+      const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+
+      pause.focus(alice);
+      pause.focus(alice);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 2);
+
+      // Still focused, so still never paused — a repeated selection event
+      // must not arm its own window.
+      expect(pause.isPaused(alice)).toBe(false);
+      expect(onResume).not.toHaveBeenCalled();
+      pause.dispose();
+    });
+  });
+
+  describe("selection leaving channel-shaped windows", () => {
+    it("arms the window when selection goes to null", () => {
+      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      pause.focus(alice);
+      pause.focus(null);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+
+      expect(pause.isPaused(alice)).toBe(true);
+      pause.dispose();
+    });
+  });
+
+  it("dispose un-pauses everything and cancels pending windows", () => {
+    const onResume = vi.fn();
+    const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+
+    pause.focus(alice);
+    pause.focus(bob);
+    pause.dispose();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 2);
+
+    expect(pause.paused()).toEqual([]);
+    expect(pause.shouldDrop(alice, "join", false)).toBe(false);
+    expect(onResume).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -4391,3 +4391,211 @@ describe("subscribe — the DM listener releases its own-nick topic on a rename 
     expect(landed).toEqual([channelKey("freenode", "alice")]);
   });
 });
+
+// #1680 — the pause. A 7-network account takes ~30 events/s and 82% of it is
+// join/part/quit for channels nobody is looking at; those are what starve the
+// main thread. These tests pin BOTH halves of the cure: the noise stops for a
+// channel the user left alone, and it keeps flowing for the one they are
+// actually reading.
+//
+// Note what is asserted: `applyPresenceEvent` (the members delta, reached
+// through `routeMessage`). The per-channel Phoenix topic is NOT left — it
+// also carries the messages themselves (`Grappa.Session.Persistor` broadcasts
+// them there), so leaving it would make the window blind rather than quiet.
+describe("subscribe — presence pause on unfocused channels (#1680)", () => {
+  // Solid queues effects on the microtask queue, not on timers, so draining
+  // microtasks flushes the selection effect even with fake timers installed.
+  const flushEffects = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  const focus = (store: Awaited<ReturnType<typeof loadStores>>, channelName: string) =>
+    store.setSelectedChannel({ networkSlug: "freenode", channelName, kind: "channel" });
+
+  it("stops a peer JOIN from touching a channel left alone past the cooldown", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const members = await import("../lib/members");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+    vi.useRealTimers();
+
+    vi.mocked(members.applyPresenceEvent).mockClear();
+    fireMessageEvent("#grappa", { id: 4001, kind: "join", sender: "carol" });
+
+    expect(members.applyPresenceEvent).not.toHaveBeenCalled();
+  });
+
+  // The half that breaks in silence. A pause that also quiets the channel the
+  // user is reading is not a pause, it is a bug — and no counter would catch
+  // it, because "fewer events" is exactly what success looks like.
+  it("keeps presence live on the channel the user is actually reading", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const members = await import("../lib/members");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 5);
+    vi.useRealTimers();
+
+    vi.mocked(members.applyPresenceEvent).mockClear();
+    fireMessageEvent("#grappa", { id: 4002, kind: "join", sender: "carol" });
+
+    expect(members.applyPresenceEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // The flick. Two minutes is chosen precisely so this never releases.
+  it("never pauses a channel the user came back to inside the window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const members = await import("../lib/members");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+    focus(store, "#grappa");
+    await flushEffects();
+    vi.useRealTimers();
+
+    vi.mocked(members.applyPresenceEvent).mockClear();
+    fireMessageEvent("#grappa", { id: 4003, kind: "join", sender: "carol" });
+
+    expect(members.applyPresenceEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // The carve-outs. These kinds ride the same "presence" label but have
+  // consumers that are load-bearing even for a channel nobody is watching:
+  // a peer NICK drives the #372/#373 cache migration, and an own PART tears
+  // the window down. Dropping them with the rest would strand cic's caches
+  // at a dead nick and leak a subscription — silently, in both cases.
+  it("still processes a peer NICK on a paused channel (the #373 migration)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const members = await import("../lib/members");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+    vi.useRealTimers();
+
+    vi.mocked(members.applyPresenceEvent).mockClear();
+    fireMessageEvent("#grappa", {
+      id: 4004,
+      kind: "nick_change",
+      sender: "carol",
+      meta: { new_nick: "carol_" },
+    });
+
+    expect(members.applyPresenceEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("still processes our OWN part on a paused channel (window teardown)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const members = await import("../lib/members");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+    vi.useRealTimers();
+
+    vi.mocked(members.applyPresenceEvent).mockClear();
+    fireMessageEvent("#grappa", { id: 4005, kind: "part", sender: "alice" });
+
+    expect(members.applyPresenceEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // A paused channel must go QUIET, never BLIND. This is the assertion that
+  // encodes vjt's ruling ("messages must not be lost") as a test rather than
+  // as a comment — and the one that fails the moment someone "simplifies"
+  // the pause into a `phx.leave()`.
+  it("still delivers MESSAGES on a paused channel — quiet, not blind", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+    vi.useRealTimers();
+
+    fireMessageEvent("#grappa", { id: 4006, kind: "privmsg", sender: "carol", body: "oi" });
+
+    const rows = store.scrollbackByChannel()[channelKey("freenode", "#grappa")] ?? [];
+    expect(rows.some((r: { id: number }) => r.id === 4006)).toBe(true);
+    expect(mockChannel.leave).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -34,6 +34,7 @@ import {
   narrowCredentialResponse,
   narrowDirectoryPageResponse,
   narrowFeaturedChannelsResponse,
+  narrowMembersIndexResponse,
   narrowMessagePageResponse,
   narrowMessageResponse,
   narrowSessionLogListResponse,
@@ -2606,6 +2607,36 @@ export async function deleteInvite(
 // returns the inner array; the envelope is a stylistic mirror of
 // MembersJSON's `{"members": [...]}` shape.
 export type ArchiveEntry = ScrollbackWireArchiveWireEntry;
+
+// #1680 — `GET /networks/:slug/channels/:name/members`, the snapshot twin of
+// the `members_seeded` event. Both render through `Grappa.Session.Wire.member/1`
+// (bucket D), so this consumes the SAME generated shape rather than a second
+// mirror — and therefore costs no wire change and no protocol bump.
+//
+// `MembersController` was written for this call ("cicchetto refetches on
+// channel-select") but no client ever existed: cic has lived entirely off the
+// broadcast. The pause is what finally needs it, because a paused channel
+// misses the peer join/part/quit deltas and the members map is the one store
+// that goes stale.
+//
+// 🔴 Returns `null`, NOT `[]`, on HTTP 204. The server sends 204 for
+// `{:ok, :uninitialized}` — joined but pre-NAMES, or not joined at all — and
+// collapsing that to an empty array would let a refetch BLANK a good member
+// list at exactly the moment the session is still filling it (CP24 bucket E
+// drew that distinction on purpose; a caller must not undo it).
+export async function listMembers(
+  token: string,
+  networkSlug: string,
+  channel: string,
+): Promise<MemberEntry[] | null> {
+  const res = await fetch(
+    `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channel)}/members`,
+    { headers: buildHeaders(token) },
+  );
+  if (res.status === 204) return null;
+  if (!res.ok) throw await readError(res);
+  return narrowMembersIndexResponse(await res.json()).members;
+}
 
 export async function listArchive(token: string, networkSlug: string): Promise<ArchiveEntry[]> {
   const res = await fetch(`/networks/${encodeURIComponent(networkSlug)}/archive`, {

--- a/cicchetto/src/lib/presenceCooldown.ts
+++ b/cicchetto/src/lib/presenceCooldown.ts
@@ -1,0 +1,111 @@
+// #1680 — the grace window between "the user looked away" and "the user is
+// done with this channel".
+//
+// A 7-network account ingests ~30 events/s, 82% of them join/part/quit for
+// channels nobody is looking at, and the client's main thread is what
+// drowns. The lever is to stop taking presence for channels the user has
+// stopped visiting. The hazard is doing that on every blur: alt-tabbing
+// across ten channels would then become ten releases and ten re-acquisitions
+// — a refetch storm, which is #1679's failure mode wearing a new costume,
+// and it also throws away state that is about to be needed again.
+//
+// So a blur does not release anything; it ARMS a window. Coming back inside
+// the window disarms it. vjt, 2026-08-22: "a channel the user flicks through
+// and comes back to should never have left."
+//
+// WHAT THIS MODULE DELIBERATELY DOES NOT KNOW
+//
+// It does not know what "releasing" a channel means, and it does not know
+// what "focus" is. It owns the WINDOW and nothing else: callers report
+// focused/blurred, and the terminal action arrives as `release`. That is not
+// decoration — the terminal action is the one part of #1680 that is still
+// contested (leaving the per-channel Phoenix topic also stops MESSAGES,
+// because `Grappa.Session.Persistor` broadcasts them on that same topic), so
+// it is held behind an injected callback where changing it costs one line at
+// the wiring site instead of a rewrite here.
+//
+// Mirrors `visibilityHeartbeat.ts`: exported constant + factory over an
+// injected timer effect, so vitest fake timers drive it deterministically.
+
+import type { ChannelKey } from "./channelKey";
+
+// The cooldown, and the ONE place it is named.
+//
+// 🔴 CHOSEN, NOT MEASURED (vjt, 2026-08-22). No on-device timing exists for
+// how long a user dwells away before coming back, so this is a starting
+// value picked to be comfortably longer than a tab-switch and comfortably
+// shorter than a coffee break — not a number any measurement produced.
+//
+// Honest consequence of a window this long: the pause only bites once the
+// user actually STOPS visiting a channel. Someone touring ten channels
+// inside two minutes holds ten subscriptions at once — still far below the
+// 43 seeded channels all held today, but the relief is "the channels you
+// left alone", not "one at a time". That is the accepted trade against
+// re-seeding on every flick, and it is worth re-measuring the event rate
+// with the cooldown live rather than assuming the win.
+export const PRESENCE_COOLDOWN_MS = 120_000;
+
+export interface PresenceCooldown {
+  // The user is looking at this channel: disarm any pending window. Safe to
+  // call for a channel with no window — that is the common case.
+  focused(key: ChannelKey): void;
+  // The user looked away: arm (or re-arm) this channel's window. Never
+  // releases synchronously, and never stacks — a second blur replaces the
+  // first window rather than queueing a second release.
+  blurred(key: ChannelKey): void;
+  // Channels currently inside their window. Diagnostic + test surface; the
+  // production path does not branch on it.
+  pending(): ChannelKey[];
+  // Cancel every pending window (teardown / identity rotation). No release
+  // fires after this.
+  dispose(): void;
+}
+
+// `cooldownMs` is REQUIRED rather than defaulted to PRESENCE_COOLDOWN_MS.
+// A default would let a second call site acquire the window without naming
+// it, and "one named place" is the property the brief actually asked for —
+// so the constant appears at the wiring site, in the open.
+export function createPresenceCooldown(
+  release: (key: ChannelKey) => void,
+  cooldownMs: number,
+): PresenceCooldown {
+  const windows = new Map<ChannelKey, ReturnType<typeof setTimeout>>();
+
+  const disarm = (key: ChannelKey): void => {
+    const id = windows.get(key);
+    if (id !== undefined) {
+      clearTimeout(id);
+      windows.delete(key);
+    }
+  };
+
+  return {
+    focused(key: ChannelKey): void {
+      disarm(key);
+    },
+
+    blurred(key: ChannelKey): void {
+      // Re-arm rather than stack: the window measures time since the LAST
+      // time the user looked away, so a re-blur restarts it.
+      disarm(key);
+      windows.set(
+        key,
+        setTimeout(() => {
+          // Drop the entry BEFORE releasing, so `release` observing
+          // `pending()` (or re-arming the same key) sees a settled map.
+          windows.delete(key);
+          release(key);
+        }, cooldownMs),
+      );
+    },
+
+    pending(): ChannelKey[] {
+      return [...windows.keys()];
+    },
+
+    dispose(): void {
+      for (const id of windows.values()) clearTimeout(id);
+      windows.clear();
+    },
+  };
+}

--- a/cicchetto/src/lib/presencePause.ts
+++ b/cicchetto/src/lib/presencePause.ts
@@ -1,0 +1,122 @@
+// #1680 — which channels are currently paused, and what "paused" is allowed
+// to swallow.
+//
+// Composes `presenceCooldown.ts` (the WINDOW: when does a blurred channel
+// become paused) with the two decisions the window deliberately does not
+// make: which channels are paused right now, and which events a paused
+// channel drops.
+//
+// WHY THIS DROPS AT THE DISPATCH EDGE AND NOT BY LEAVING THE TOPIC
+//
+// The obvious "pause" is to leave the per-channel Phoenix topic. Measured, it
+// is wrong: that topic is not a presence feed, it is the window's whole
+// inbound. `Grappa.Session.Persistor` broadcasts the MESSAGES on it
+// (persistor.ex:107), alongside `WindowCounts.Pusher` (unread/mention),
+// `Session.Broadcaster` (topic/modes/created) and the read-cursor fan-out.
+// `Broadcaster.to_channel/3`'s own moduledoc calls it "the carrier for
+// post-join-handshake events (messages, topic, modes, members)". Leaving it
+// would make a paused channel BLIND, not quiet — and the reported use case is
+// hopping between ACTIVE channels, which is exactly the signal that would be
+// lost. vjt's ruling, 2026-08-22: messages must not be lost.
+//
+// So the subscription stays and the noise is dropped where it arrives.
+//
+// WHY NOT ALL FIVE PRESENCE KINDS
+//
+// `SUPPRESSED_PRESENCE_KINDS` (presenceFilter.ts, byte-pinned to the server
+// twin) has five members, and two of them have consumers that are
+// load-bearing even for a channel nobody is watching:
+//
+//   * `nick_change` drives the #372/#373 client-side identity migration —
+//     renameScrollbackKey / renameReadCursorChannel / renameRailWhois /
+//     followQueryNick. Drop it and cic's caches stay keyed to a nick that no
+//     longer exists, silently, until something forces a refetch.
+//   * `mode` feeds channel-mode state that survives the pause.
+//
+// And regardless of kind, our OWN presence is never noise: an own PART tears
+// the window down (`setParted` + the #200 subscription teardown), so dropping
+// it would leak a subscription and strand a dead window.
+//
+// The three that remain — a PEER joining, parting or quitting — are the 82%.
+// Their only consumer is the members map, and that is precisely what the
+// on-focus refetch rebuilds.
+
+import type { ScrollbackMessage } from "./api";
+import type { ChannelKey } from "./channelKey";
+import { createPresenceCooldown } from "./presenceCooldown";
+
+// The paused-channel drop set: a strict SUBSET of the presence kinds, chosen
+// by "has no consumer other than the members map". Kept as its own literal
+// rather than derived from `SUPPRESSED_PRESENCE_KINDS` because the two answer
+// different questions — that one is "is this presence?" (pinned to the server
+// twin), this one is "is this presence we can afford to miss?". A new kind
+// landing in the server twin must be considered HERE on purpose, not
+// inherited silently; `presencePause.test.ts` asserts the subset relation so
+// the two cannot drift apart unnoticed.
+export const PAUSABLE_PRESENCE_KINDS: ReadonlySet<ScrollbackMessage["kind"]> = new Set([
+  "join",
+  "part",
+  "quit",
+]);
+
+export interface PresencePause {
+  // Selection moved. Pass the newly focused channel, or null when nothing
+  // channel-shaped is selected. Blurs the previously focused key (arming its
+  // window) and resumes the new one, firing `onResume` if it had been paused.
+  focus(key: ChannelKey | null): void;
+  // Is this channel currently swallowing peer presence?
+  isPaused(key: ChannelKey): boolean;
+  // The dispatch-edge predicate. True only for a peer join/part/quit on a
+  // channel that is currently paused.
+  shouldDrop(key: ChannelKey, kind: ScrollbackMessage["kind"], isOwnNick: boolean): boolean;
+  // Currently paused channels. Diagnostic + test surface.
+  paused(): ChannelKey[];
+  // Teardown / identity rotation: cancel windows and un-pause everything.
+  dispose(): void;
+}
+
+// `onResume` fires when a channel that WAS paused regains focus — the seam
+// the members refetch hangs off, because that is the one store the pause let
+// go stale. It does not fire for a channel that was merely blurred and came
+// back inside its window: nothing was dropped, so nothing needs rebuilding.
+export function createPresencePause(
+  onResume: (key: ChannelKey) => void,
+  cooldownMs: number,
+): PresencePause {
+  const pausedKeys = new Set<ChannelKey>();
+  const cooldown = createPresenceCooldown((key) => pausedKeys.add(key), cooldownMs);
+  let focused: ChannelKey | null = null;
+
+  return {
+    focus(key: ChannelKey | null): void {
+      if (key === focused) return;
+      if (focused !== null) cooldown.blurred(focused);
+      focused = key;
+      if (key === null) return;
+      cooldown.focused(key);
+      // `delete` returns whether it was there — so the refetch is ordered
+      // exactly when presence was actually missed, never on a plain re-focus.
+      if (pausedKeys.delete(key)) onResume(key);
+    },
+
+    isPaused(key: ChannelKey): boolean {
+      return pausedKeys.has(key);
+    },
+
+    shouldDrop(key: ChannelKey, kind: ScrollbackMessage["kind"], isOwnNick: boolean): boolean {
+      if (isOwnNick) return false;
+      if (!PAUSABLE_PRESENCE_KINDS.has(kind)) return false;
+      return pausedKeys.has(key);
+    },
+
+    paused(): ChannelKey[] {
+      return [...pausedKeys];
+    },
+
+    dispose(): void {
+      cooldown.dispose();
+      pausedKeys.clear();
+      focused = null;
+    },
+  };
+}

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -1,6 +1,6 @@
 import type { Channel } from "phoenix";
 import { createEffect, on, untrack } from "solid-js";
-import { assertNever, type ChannelEvent, ownNickForNetwork } from "./api";
+import { assertNever, type ChannelEvent, listMembers, ownNickForNetwork } from "./api";
 import { socketUserName, token } from "./auth";
 import { incrementBadge, setBadge } from "./badge";
 import { playBeep } from "./beep";
@@ -26,6 +26,8 @@ import { notificationPrefs } from "./notificationPrefs";
 import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
 import { resolveCtcpReply, resolvePing } from "./pingCorrelation";
+import { PRESENCE_COOLDOWN_MS } from "./presenceCooldown";
+import { createPresencePause } from "./presencePause";
 import { shouldNotify } from "./pushTriggers";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
@@ -143,6 +145,51 @@ moduleRoot(() => {
   // event, doubling presence/unread/mention bumps. N rotations = N+1
   // handlers per channel.
   const joined = new Map<ChannelKey, Channel>();
+  // #1680 — the presence pause. A 7-network account takes ~30 events/s and
+  // 82% of it is peer join/part/quit for channels nobody is reading; that is
+  // what starves the main thread. A channel the user has left alone for
+  // `PRESENCE_COOLDOWN_MS` stops applying those, and regaining focus refetches
+  // the one store the pause let go stale — the members map.
+  //
+  // The subscription itself is NEVER dropped: the per-channel topic also
+  // carries the messages (`Grappa.Session.Persistor` broadcasts them there),
+  // so leaving it would make the window blind rather than quiet. See
+  // `presencePause.ts` for the full argument and the carve-outs.
+  const presencePause = createPresencePause((key) => {
+    const t = untrack(token);
+    if (!t) return;
+    // `decodeChannelKey` is nullable by contract; a key that cannot be
+    // decoded cannot be refetched, and inventing a slug would fetch the
+    // wrong channel. Leave the members map alone.
+    const decoded = decodeChannelKey(key);
+    if (decoded === null) return;
+    const { slug, name } = decoded;
+    // A refetch that throws must not take the handler down with it — the
+    // members map simply stays as it was until the next seed. `null` is the
+    // server's 204 (`:uninitialized`): joined but pre-NAMES, or not joined.
+    // Seeding `[]` there would blank a good list, which is exactly the
+    // distinction CP24 bucket E drew.
+    void listMembers(t, slug, name)
+      .then((members) => {
+        if (members !== null) seedMembers(key, members);
+      })
+      .catch((err: unknown) => {
+        console.warn("[subscribe] members refetch failed on resume", key, err);
+      });
+  }, PRESENCE_COOLDOWN_MS);
+
+  // Selection IS focus, for the pause's purposes — deliberately NOT gated on
+  // `isDocumentVisible()`. A backgrounded tab that comes back must not pay a
+  // refetch for every channel it holds; the cooldown already covers genuine
+  // abandonment, and tab-switching is the flick case the window exists to
+  // absorb. (Issue open question 1, answered this way and recorded as an
+  // assumption rather than a measurement.)
+  createEffect(() => {
+    const sel = selectedChannel();
+    presencePause.focus(
+      sel && sel.kind === "channel" ? channelKey(sel.networkSlug, sel.channelName) : null,
+    );
+  });
   // #254 — coalesce concurrent join callers (the reactive query-windows loop +
   // a compose `/msg` via `ensureQueryTopicJoined`) onto ONE join-ACK promise
   // per query topic, so subscribe-before-send awaits the SAME ack the loop
@@ -582,7 +629,16 @@ moduleRoot(() => {
             if (!windowIsPresent(key)) dropChannelTopicState(key);
           }
 
-          routeMessage(slug, key, name, message, ownNick);
+          // #1680 — the pause bites HERE and nowhere else. `routeMessage` is
+          // what applies the members delta (`applyPresenceEvent`) and the
+          // scrollback append, so guarding this ONE call drops the noise
+          // while every arm around it keeps running: the own-PART teardown
+          // above, the #372/#373 nick migration below, and every non-presence
+          // kind. `shouldDrop` is false for our own nick and for
+          // nick_change/mode by construction.
+          if (!presencePause.shouldDrop(key, message.kind, nickEquals(message.sender, ownNick))) {
+            routeMessage(slug, key, name, message, ownNick);
+          }
 
           // #373: a PEER's NICK migrates that peer's query-window cic-owned
           // caches — the live scrollback under (slug, oldNick) → (slug,

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -29,6 +29,7 @@ import {
   S_SessionLogWireListResult,
   S_SessionLogWireSessionsResult,
   S_SessionLogWireT,
+  S_SessionWireMembersIndexPayload,
   S_ThemesWireActivePair,
   S_ThemesWireIndexPayload,
   S_ThemesWireT,
@@ -55,6 +56,7 @@ import type {
   SessionLogWireListResult,
   SessionLogWireSessionsResult,
   SessionLogWireT,
+  SessionWireMembersIndexPayload,
   ThemesWireActivePair,
   ThemesWireIndexPayload,
   ThemesWireT,
@@ -912,6 +914,18 @@ export function narrowArchiveResponse(raw: unknown): ScrollbackWireArchiveWireIn
 /** `GET /networks/:slug/channels`. */
 export function narrowChannelListResponse(raw: unknown): NetworksWireChannelJson[] {
   return narrowRest({ a: S_NetworksWireChannelJson }, raw, "channel list");
+}
+
+/**
+ * `GET /networks/:slug/channels/:name/members`.
+ *
+ * #1680 — the REST twin of the `members_seeded` event. Both render through
+ * `Grappa.Session.Wire.member/1` on purpose (bucket D), so the per-row shape
+ * is one contract and this narrower reuses the GENERATED schema rather than
+ * a second hand-written mirror.
+ */
+export function narrowMembersIndexResponse(raw: unknown): SessionWireMembersIndexPayload {
+  return narrowRest(S_SessionWireMembersIndexPayload, raw, "members index");
 }
 
 /** `GET /networks/:slug/channels/:name/messages`, both the `before` and `after` pages. */

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58703,3 +58703,104 @@ already supplied every secret. The release-image smoke test supplies only
 command with the password on stdin (never argv) and requires an admin account
 creation. That real image boundary is the regression: a same-process entrypoint
 test cannot model Docker discarding environment mutations for future execs.
+<!-- entry #1680 -->
+
+---
+
+## 2026-08-23 — #1680: pausing presence without going blind, and the two kinds that could not be paused
+
+A 7-network account was dropping clicks. Measured on prod: **26,588 rows in
+15 minutes = 29.5 events/s sustained, of which 21,917 are presence — 82%**.
+The server was demonstrably not the bottleneck (zero 503, zero 4xx, 1655 of
+1718 requests under 100ms, none over 2s); latency produces waiting, not a UI
+that drops clicks. So the client's main thread was being fed ~30 events/s of
+join/part/quit for channels nobody was looking at.
+
+The cure is to stop applying presence for channels the user has stopped
+visiting, and to refetch the member list on return. Three things about it are
+worth keeping.
+
+### The obvious implementation loses messages, and the topic says so
+
+"Pause the channel" reads as "leave the per-channel Phoenix topic", and the
+issue's own first shape said exactly that: client-side only, no server
+change, no protocol move. Taken literally it ships a message-loss bug.
+
+That topic is not a presence feed. It is the window's entire inbound, and
+five broadcasters ride it:
+
+```
+lib/grappa/session/persistor.ex:107      the MESSAGES
+lib/grappa/session/broadcaster.ex:110    topic_changed, channel_created, modes
+lib/grappa/window_counts/pusher.ex:113   unread / mention counters
+lib/grappa/read_cursor.ex:583            read-cursor fan-out
+```
+
+`Persistor.persist_and_broadcast/3` literally hands `Wire.message_payload/1`
+to `Topic.channel/3`, and `Broadcaster.to_channel/3`'s own moduledoc calls the
+topic "the carrier for post-join-handshake events (**messages**, topic, modes,
+members)". Leaving it makes a paused channel **blind, not quiet** — and the
+reported use case is hopping between *active* channels, which is precisely
+the signal that would vanish. Ruling (vjt, 2026-08-22): messages must not be
+lost.
+
+So the subscription stays and the noise is dropped where it arrives, at the
+one `routeMessage` call in `subscribe.ts`. **General rule: before muting a
+transport, enumerate what else rides it.** A per-channel topic that carries
+one obvious thing usually carries four unobvious ones, and the call sites are
+the only honest enumeration — prose about it rots.
+
+### Two of the five "presence" kinds are not noise
+
+`SUPPRESSED_PRESENCE_KINDS` has five members and it is tempting to drop all
+five. Two have consumers that are load-bearing for a channel nobody is
+watching: `nick_change` drives the #372/#373 client-side identity migration
+(`renameScrollbackKey` / `renameReadCursorChannel` / `renameRailWhois` /
+`followQueryNick`), and `mode` feeds channel-mode state. And regardless of
+kind, our OWN presence is never noise — an own PART tears the window down
+(#200), so swallowing it leaks a subscription and strands a dead window.
+
+What remains is a PEER joining, parting or quitting: the 82%, whose only
+consumer is the members map, which is exactly what the on-focus refetch
+rebuilds. `PAUSABLE_PRESENCE_KINDS` is therefore its own literal rather than
+a derivation of the pinned set — the two answer different questions ("is this
+presence?" vs "is this presence we can afford to miss?"), and a sixth kind
+landing in the server twin must be considered here on purpose instead of
+inherited silently. A test asserts the subset relation so they cannot drift.
+
+### The cooldown exists so the cure is not the disease
+
+Releasing on every blur would turn tab-switching into a refetch storm —
+#1679's failure mode in a new costume — and would discard a member list about
+to be needed again. So a blur ARMS a two-minute window and returning disarms
+it: a channel the user flicks through and comes back to never leaves.
+
+**The two minutes are CHOSEN, not measured** (vjt, 2026-08-22). No on-device
+timing exists for how long a user dwells away before returning. The honest
+consequence is that the pause only bites once someone actually stops visiting
+a channel: a tour of ten channels inside the window holds ten subscriptions —
+far below the 43 seeded channels all live today, but the relief is "the
+channels you left alone", not "one at a time". **The event rate is worth
+re-measuring with the cooldown live rather than assuming the win.**
+
+### What this cost, and what it did not
+
+Client-side only and genuinely so: zero Elixir files, `priv/wire/shape.pin`
+untouched, `@protocol_version` unmoved. The members refetch consumes the
+GENERATED `S_SessionWireMembersIndexPayload` because `MembersJSON` and the
+`members_seeded` event already render through `Session.Wire.member/1` — one
+contract, so no wire change. It returns `null` and not `[]` on HTTP 204,
+because 204 is `{:ok, :uninitialized}` and collapsing it would let a refetch
+blank a good member list.
+
+Noted in passing: `MembersController`'s moduledoc has claimed "cicchetto
+refetches on channel-select" since P4-1, and no client function existed —
+cic lived entirely off the broadcast. The claim is true now.
+
+### Left open, deliberately
+
+Issue open question 1 is answered as an ASSUMPTION, not a measurement: focus
+is the selected channel and is NOT gated on `isDocumentVisible()`, because
+gating on tab visibility makes every alt-tab cost a refetch round. Questions 2
+and 3 (what else goes stale while paused; resume ordering against a JOIN
+landing mid-refetch) are narrowed by the carve-outs above rather than closed.


### PR DESCRIPTION
Pauses peer presence for channels the user has stopped visiting, and refetches the member list when they come back. Client-side only: **no server change, no wire change, `@protocol_version` unmoved**.

Addresses #1680.

## Why

Measured on prod (2026-08-22): one 7-network account ingests **26,588 rows in 15 minutes = 29.5 events/s sustained, of which 21,917 are presence — 82%**. The server is demonstrably not the bottleneck: zero 503, zero 4xx, 1655 of 1718 requests under 100ms, none over 2s. Latency produces waiting, not a UI that drops clicks. So the client's main thread is being fed ~30 events/s of join/part/quit for windows nobody is reading.

## The design decision that changed the shape

The obvious implementation is "leave the per-channel Phoenix topic". Taken literally it ships a message-loss bug.

That topic is not a presence feed — it is the window's entire inbound, and four broadcasters ride it besides presence:

```
lib/grappa/session/persistor.ex:107      the MESSAGES themselves
lib/grappa/session/broadcaster.ex:110    topic_changed, channel_created, modes
lib/grappa/window_counts/pusher.ex:113   unread / mention counters
lib/grappa/read_cursor.ex:583            read-cursor fan-out
```

`Persistor.persist_and_broadcast/3` hands `Wire.message_payload/1` straight to `Topic.channel/3`, and `Broadcaster.to_channel/3`'s own moduledoc calls the topic *"the carrier for post-join-handshake events (**messages**, topic, modes, members)"*. Leaving it would make a paused channel **blind, not quiet** — and the reported use case is hopping between *active* channels, which is exactly the signal that would vanish.

So the subscription stays and the noise is dropped where it arrives, at the single `routeMessage` call in `subscribe.ts`.

## Not all five "presence" kinds are noise

`SUPPRESSED_PRESENCE_KINDS` has five members. Two have consumers that are load-bearing even for a channel nobody is watching:

* **`nick_change`** drives the #372/#373 client-side identity migration (`renameScrollbackKey` / `renameReadCursorChannel` / `renameRailWhois` / `followQueryNick`). Drop it and cic's caches stay keyed to a nick that no longer exists.
* **`mode`** feeds channel-mode state.

And regardless of kind, **our own** presence is never noise: an own PART tears the window down (#200), so swallowing it would leak a subscription and strand a dead window.

What remains is a **peer** joining, parting or quitting — the 82% — whose only consumer is the members map, which is precisely what the on-focus refetch rebuilds. `PAUSABLE_PRESENCE_KINDS` is its own literal rather than a derivation of the pinned set: the two answer different questions ("is this presence?" vs "is this presence we can afford to miss?"), so a sixth kind landing in the server twin must be considered on purpose instead of inherited silently. A test asserts the subset relation.

## The cooldown

Releasing on every blur would turn tab-switching into a refetch storm and discard a member list about to be needed again. A blur **arms** a two-minute window; returning inside it **disarms**. A channel the user flicks through and comes back to never leaves.

**The two minutes are a chosen value, not a measured one** — no on-device timing exists for how long a user dwells away before returning. It lives in one named place (`PRESENCE_COOLDOWN_MS`), and `cooldownMs` is a required parameter rather than a default so no second call site can acquire it without naming it.

Honest consequence: the pause only bites once someone actually stops visiting a channel. A tour of ten channels inside the window holds ten subscriptions at once — far below the 43 seeded channels all live today, but the relief is "the channels you left alone", not "one at a time". **The event rate is worth re-measuring with the cooldown live rather than assuming the win.**

## Protocol cost: zero, verified rather than asserted

* no `.ex` / `.exs` file touched
* `priv/wire/shape.pin` untouched; `mix grappa.wire_pin --check` still reports `wire shape and protocol 4 agree`
* the members refetch consumes the **generated** `S_SessionWireMembersIndexPayload`. `MembersJSON` and the `members_seeded` event already render through `Grappa.Session.Wire.member/1` (bucket D), so the per-row shape is one contract and no new wire type was introduced.

Eight files, all under `cicchetto/src/`.

Side note: `MembersController`'s moduledoc has claimed *"cicchetto refetches on channel-select"* since P4-1, and no client function ever existed — cic lived entirely off the broadcast. It is true now. The new `listMembers` returns `null`, not `[]`, on HTTP 204, because 204 is `{:ok, :uninitialized}` and collapsing it would let a refetch blank a good member list.

## How it is proven

**Red first.** The first round of failures was a harness error (a missing token, so no handler was ever installed) — a red that proves nothing, and it was fixed. The genuine red is a single test: *"stops a peer JOIN from touching a channel left alone past the cooldown"*, failing with `expected not to be called, but was called 1 times`. The other five in that block passed before the change: they are the regression guards, and they stayed green after it.

**Two mutation runs**, each reverted with a clean tree afterwards:

1. make the cooldown module blind to `cooldownMs` → **5 of 10 tests red**, including *"never releases a channel the user came back to inside the window"*.
2. make `shouldDrop` always return false → red in `subscribe.test.ts` **and** `presencePause.test.ts`, exactly the two that must fall.

A permanent `MUTANT` test stays in the suite: without it, an implementation that ignored `cooldownMs` entirely would pass every other case.

**The half that breaks in silence is pinned deliberately.** A pause that also quiets the channel being read is not a pause but a bug, and no counter would catch it — "fewer events" is what success looks like. So the suite asserts presence still flows on the focused channel, on a flicked channel, for a peer NICK and for an own PART on a paused channel, and that **messages still arrive while paused**. That last assertion fails the moment someone simplifies this into a `phx.leave()`.

## Gates

* `scripts/check.sh` — 8 doctests, 62 properties, **6786 tests, 0 failures**; dialyzer `Total errors: 0`; credo strict `found no issues`; `gen_wire_types --check` in sync; `wire_pin --check` `protocol 4 agree`; bats `1..657`, zero `not ok`
* `scripts/bun.sh run test` — **301 files, 5870 tests**, all green
* `scripts/bun.sh run check` — lock drift, biome (src + e2e), tsc (src), tsc (e2e), all green
* `scripts/design-notes-gate.sh` — 1 new entry heading, separator and marker present
* integration / e2e — **not run** (shared docker project was occupied)

## What is deliberately not claimed

* **That this fixes the incident.** It reduces main-thread work for channels left alone. On-device profiling was not done, and the issue itself records that as not measured.
* **That two minutes is the right number.** It is chosen. It is in one place so tuning it is a one-line change.
* **That ten flicked channels become one.** Ten stay subscribed.
* **That open questions 2 and 3 are closed.** They are narrowed by the carve-outs above, not resolved — in particular the resume-ordering race (a JOIN landing between refetch and resubscribe) still has its window.
* **That reconnect behaviour under the pause was exercised.** It was not.

Open question 1 is answered as a **stated assumption**, recorded in the code, the commit and DESIGN_NOTES: focus is the selected channel and is *not* gated on `isDocumentVisible()`. Gating on tab visibility would pause every channel the moment the tab backgrounds, and pay a refetch storm on return — the same failure mode in a new costume. Reversing it is one `&&` in one place.
