### PR TITLE
cic(#682): internet radio — station picker in the rail, live mode in the docked transport

### DIFF
--- a/cicchetto/e2e/fixtures/bytes.ts
+++ b/cicchetto/e2e/fixtures/bytes.ts
@@ -14,3 +14,26 @@
 export const TINY_PNG_HEX =
   "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489" +
   "0000000b49444154789c6360000200000500017a5eab3f0000000049454e44ae426082";
+
+// #682 — a minimal, VALID MPEG-1 Layer III frame sequence, built rather than
+// pasted: 417 bytes per frame at 128 kbps / 44.1 kHz, so a hex constant for
+// even a few frames would be kilobytes of noise in a source file.
+//
+// Header bytes, for the next reader who has to check them against a spec
+// sheet rather than trust a magic number:
+//   FF FB — syncword + MPEG-1 + Layer III + no CRC
+//   90    — 128 kbps, 44100 Hz, no padding
+//   40    — joint stereo, no emphasis
+// Frame size = floor(144 * 128000 / 44100) = 417.
+//
+// The payload is silence (zeroes). Specs use this to satisfy an <audio>
+// element from a `page.route` handler, so that a radio station's stream is
+// served LOCALLY and the suite never reaches a third-party host.
+const MP3_FRAME_HEADER = [0xff, 0xfb, 0x90, 0x40];
+const MP3_FRAME_BYTES = 417;
+
+export function silentMp3(frames: number): Buffer {
+  const frame = Buffer.alloc(MP3_FRAME_BYTES);
+  for (const [i, byte] of MP3_FRAME_HEADER.entries()) frame[i] = byte;
+  return Buffer.concat(Array.from({ length: frames }, () => frame));
+}

--- a/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
+++ b/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
@@ -29,8 +29,11 @@
 // quit are always shown; rooms needs a network context (channel/server window);
 // mentions needs a live bundle for that network; denoise is channel-gated;
 // detach is canDetach()-gated; admin is isAdmin()-gated. vjt is a persistent
-// NON-admin, so on a channel window it sees the EIGHT labelled buttons in
-// RAIL_BUTTONS, with admin ABSENT — the isAdmin() gate's negative arm. The
+// NON-admin, so on a channel window it sees exactly the labelled buttons listed
+// in RAIL_BUTTONS, with admin ABSENT — the isAdmin() gate's negative arm. The
+// count is deliberately NOT restated here: this sentence said "EIGHT" while the
+// array had carried nine since #950, so the number is left where it is derived
+// (`RAIL_BUTTONS.length`) and nowhere else. The
 // admin-present arm is exercised by issue291 / issue299 / ux-6-c, which promote
 // vjt via setAdminFlag; this spec stays on the plain non-admin baseline to keep
 // the shared stack untouched.
@@ -73,6 +76,11 @@ const CHANNEL = AUTOJOIN_CHANNELS[0]; // #spec-wN — the seeded autojoin channe
 const RAIL_BUTTONS: ReadonlyArray<{ testid: string; label: string }> = [
   { testid: "mobile-panel-home", label: "home" },
   { testid: "mobile-panel-list", label: "rooms" },
+  // #682 — the radio picker launcher, added to the CONTRACT rather than
+  // loosening the count it broke: the rail genuinely hosts one more labelled
+  // row now. Ungated — the station table is baked into the bundle, so there is
+  // no capability to gate on and it renders for every subject on both engines.
+  { testid: "rail-action-radio", label: "radio" },
   { testid: "mobile-panel-themes", label: "themes" },
   { testid: "mobile-panel-archive", label: "archive" },
   { testid: "action-cluster-cog", label: "settings" },

--- a/cicchetto/e2e/tests/issue682-rail-radio-picker.spec.ts
+++ b/cicchetto/e2e/tests/issue682-rail-radio-picker.spec.ts
@@ -1,0 +1,103 @@
+// #682 — internet radio: the picker is reachable from the RailActions drawer,
+// picking a station drives the ONE audio element, and both surfaces name it.
+//
+// WHAT THIS SPEC ASSERTS, AND WHY EACH ONE IS AN OUTCOME AND NOT A MIRROR:
+//   (a) the radio launcher is in the rail drawer and opens the picker — the
+//       shape vjt decided, and the only door to the feature;
+//   (b) the picker lists the curated stations;
+//   (c) picking one puts THAT station's stream on the <audio> element and the
+//       browser actually ISSUES the request for it (the route handler counts
+//       the hits) — so this fails if the URL never reaches the element, which
+//       a "the bar appeared" assertion alone would not catch;
+//   (d) the docked transport shows the station's NAME. This is the assertion
+//       that matters most on a phone: the rail carrying the chrome is a
+//       drawer slid off-screen while playing, so the docked bar is the only
+//       surface answering "what am I listening to";
+//   (e) the rail's own station chrome names it too, and the picked row is
+//       marked so the picker is not a blind list.
+//
+// NO THIRD-PARTY NETWORK. Both the stream and the station logos are served by
+// `page.route` from local bytes (fixtures/bytes `silentMp3`), so the suite
+// never depends on somafm.com being up and a station outage cannot turn this
+// red. The route is scoped to the station's real URL, so a change that stops
+// requesting that URL still fails.
+//
+// WHAT THIS SPEC DELIBERATELY DOES NOT ASSERT, and where it IS asserted.
+// The transport's LIVE mode — no seek slider, no download anchor, elapsed
+// shown alone — is not checked here, and the omission is a platform limit
+// rather than a gap left open. Live mode keys off a non-finite
+// `HTMLMediaElement.duration`, and `route.fulfill` must serve a COMPLETE
+// body, which is by definition finite: any stream this spec can serve
+// deterministically reports a finite duration and takes the file branch.
+// Serving a genuinely endless body would mean reaching a real Icecast host
+// and reintroducing the external dependency this spec exists without. So
+// live mode is pinned in `src/__tests__/AudioMiniPlayer.test.tsx`, which
+// drives `duration` (Infinity and NaN) directly on the element. Weakening
+// the assertion here to something a finite body could satisfy would have
+// been a green that proves the opposite of what it claims.
+
+import { silentMp3 } from "../fixtures/bytes";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// The station the spec tunes. Kept as literals rather than imported from
+// `src/lib/radioStations` so that a table edit which silently drops or
+// renames this station fails HERE, loudly, instead of the spec following the
+// rename and asserting nothing about what shipped.
+const STATION_ID = "groovesalad";
+const STATION_TITLE = "Groove Salad";
+const STATION_STREAM = "https://ice.somafm.com/groovesalad-128-mp3";
+
+test.setTimeout(90_000);
+
+test("#682 — the rail picker tunes a station onto the docked transport", async ({ page }) => {
+  let streamRequests = 0;
+
+  // Serve the stream locally. `**` on the host path so a redirect or a query
+  // string cannot slip past the intercept and reach the real host.
+  await page.route("https://ice.somafm.com/**", async (route) => {
+    streamRequests += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "audio/mpeg",
+      body: silentMp3(8),
+    });
+  });
+  // Logos too: an <img> to a third party is still a third-party request.
+  await page.route("https://api.somafm.com/logos/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "image/png", body: Buffer.alloc(0) });
+  });
+
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  // (a) the launcher lives in the ONE rail drawer, on both form factors.
+  await openRailMenu(page);
+  await page.getByTestId("rail-action-radio").click();
+
+  const picker = page.getByTestId("rail-radio-picker");
+  await expect(picker).toBeVisible();
+
+  // (b) and it carries stations, this one among them.
+  const row = page.getByTestId(`rail-radio-station-${STATION_ID}`);
+  await expect(row).toBeVisible();
+
+  await row.click();
+
+  // (c) the station's stream reached the element AND was requested.
+  const audio = page.getByTestId("audio-mini-player-el");
+  await expect(audio).toHaveJSProperty("src", STATION_STREAM);
+  await expect.poll(() => streamRequests, { timeout: 10_000 }).toBeGreaterThan(0);
+
+  // (d) the docked transport names it — the phone's only answer to "what is
+  // playing", since the rail behind it is off-screen while playing.
+  await expect(page.getByTestId("audio-mini-player")).toBeVisible();
+  await expect(page.getByTestId("audio-mini-player-label")).toHaveText(STATION_TITLE);
+
+  // (e) the rail says so too, and marks the row it tuned.
+  await expect(page.getByTestId("rail-radio-now")).toContainText(STATION_TITLE);
+  await expect(row).toHaveAttribute("aria-pressed", "true");
+});

--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -14,6 +14,14 @@ import { activeAudio, closeAudio } from "./lib/audioPlayer";
 // This keeps the `audioEl` ref assigned before the activeAudio effect
 // runs — wrapping the element itself in <Show> would race ref-assignment
 // against the effect on the open transition.
+//
+// #682 — LIVE mode. This bar was written for a FILE, and an internet-radio
+// station is not one: an Icecast stream has no end, so a position slider and
+// a "cur / dur" read are both meaningless against it. Live mode is DERIVED
+// from the element's own `duration` (see `live` below) rather than flagged by
+// the caller — so it is correct for ANY endless source, not just the radio
+// stations that motivated it, and it cannot drift from the element's truth.
+// It is the general rule, not the incident.
 
 const formatTime = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
@@ -49,6 +57,18 @@ const AudioMiniPlayer: Component = () => {
       void audioEl.play().catch(() => {});
     }),
   );
+
+  // Endless source? `duration` starts at 0 — a FINITE number, so a source
+  // whose metadata has not arrived yet keeps today's file chrome and does not
+  // flash a "live" badge at every upload. Only `onLoadedMetadata` writes it
+  // again, and at that point the element is stating what it knows:
+  //   * a file    → a finite length  → scrubbable
+  //   * a stream  → Infinity         → not scrubbable
+  //   * unknown   → NaN              → not scrubbable either, and the reason
+  //                                    is the same one, so the predicate is
+  //                                    "not a finite number" rather than
+  //                                    "=== Infinity".
+  const live = (): boolean => !Number.isFinite(duration());
 
   const togglePlay = (): void => {
     if (audioEl === undefined) return;
@@ -88,33 +108,66 @@ const AudioMiniPlayer: Component = () => {
           >
             {playing() ? "⏸" : "▶"}
           </button>
-          <input
-            type="range"
-            class="audio-mini-player-seek"
-            data-testid="audio-mini-player-seek"
-            min="0"
-            max={duration() || 0}
-            step="any"
-            value={current()}
-            onInput={onSeek}
-            aria-label="seek"
-          />
-          <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
-            {formatTime(current())} / {formatTime(duration())}
-          </span>
-          {/* Same-origin download: the `download` attribute forces a save
-              (overriding the server's `inline` Content-Disposition) and
-              inherits the server-sent filename — cic has no filename on
-              the wire (slug only), so no `download` value is set. */}
-          <a
-            class="audio-mini-player-download"
-            data-testid="audio-mini-player-download"
-            href={activeAudio()?.href}
-            download=""
-            aria-label="download"
+          {/* #682 — the source's name, when it has one. An upload passes
+              null and this renders nothing; a radio station passes its title,
+              which on mobile is the ONLY place naming it (the rail that holds
+              the station chrome is a drawer slid off-screen while playing). */}
+          <Show when={activeAudio()?.label}>
+            {(label) => (
+              <span class="audio-mini-player-label" data-testid="audio-mini-player-label">
+                {label()}
+              </span>
+            )}
+          </Show>
+          <Show
+            when={!live()}
+            fallback={
+              <>
+                <span class="audio-mini-player-live" data-testid="audio-mini-player-live">
+                  live
+                </span>
+                {/* Elapsed since tune-in, NOT a position: there is no total
+                    to divide it by, so it is shown alone rather than as one
+                    half of a "cur / dur" pair with a hollow denominator. */}
+                <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
+                  {formatTime(current())}
+                </span>
+              </>
+            }
           >
-            ⬇
-          </a>
+            <input
+              type="range"
+              class="audio-mini-player-seek"
+              data-testid="audio-mini-player-seek"
+              min="0"
+              max={duration() || 0}
+              step="any"
+              value={current()}
+              onInput={onSeek}
+              aria-label="seek"
+            />
+            <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
+              {formatTime(current())} / {formatTime(duration())}
+            </span>
+            {/* Same-origin download: the `download` attribute forces a save
+                (overriding the server's `inline` Content-Disposition) and
+                inherits the server-sent filename — cic has no filename on
+                the wire (slug only), so no `download` value is set.
+                #682 — gated OFF for a live source, for two independent
+                reasons either of which is sufficient: the resource has no
+                end, so the save never completes; and `download` is ignored
+                outright on a cross-origin href, so the anchor would navigate
+                the operator out of the app instead of saving anything. */}
+            <a
+              class="audio-mini-player-download"
+              data-testid="audio-mini-player-download"
+              href={activeAudio()?.href}
+              download=""
+              aria-label="download"
+            >
+              ⬇
+            </a>
+          </Show>
           <button
             type="button"
             class="audio-mini-player-close"

--- a/cicchetto/src/MircText.tsx
+++ b/cicchetto/src/MircText.tsx
@@ -239,7 +239,10 @@ const renderRun = (
                           // readable while it plays; image/video keep the
                           // full-screen viewer.
                           if (media.kind === "audio") {
-                            playAudio(media.href);
+                            // No label (#682): a pasted media link carries no
+                            // title on the wire — cic sees a slug-only href —
+                            // so there is nothing honest to caption it with.
+                            playAudio(media.href, null);
                           } else {
                             openMediaViewer(media.href, media.kind);
                           }

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -29,6 +29,7 @@ import {
 } from "./lib/notificationPrefs";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { channelPresenceVisible } from "./lib/presenceFilter";
+import { openRadioPicker } from "./lib/radio";
 import { selectedChannel, setSelectedChannel } from "./lib/selection";
 import {
   ADMIN_WINDOW_NAME,
@@ -38,8 +39,8 @@ import {
   LIST_WINDOW_NAME,
 } from "./lib/windowKinds";
 
-// #473 → #500 — RailActions: EVERY rail affordance (home · rooms · themes ·
-// archive · settings · admin · denoise) lives here, mounted unchanged by BOTH
+// #473 → #500 — RailActions: EVERY rail affordance (home · rooms · radio ·
+// themes · archive · settings · admin · denoise) lives here, mounted by BOTH
 // branches of Shell's `isMobile()` split — one component, one place, same
 // buttons on desktop and mobile.
 //
@@ -98,12 +99,14 @@ import {
 // operator flips in place (watching the accent flip, re-toggling), not a
 // navigation away.
 //
-// Buttons, in order: home · rooms · mentions · themes · archive · settings ·
-// admin · refresh · denoise · detach · quit. Each carries its NAME as visible
+// Buttons, in order: home · rooms · mentions · radio · themes · archive ·
+// settings · admin · refresh · denoise · detach · quit. Each carries its NAME as visible
 // text next to the glyph (#473: bare emoji had to be guessed / long-pressed).
 //
 // Gating is CAPABILITY-only — no form-factor gates (#473):
-//   * home / themes / settings / archive / quit — always.
+//   * home / radio / themes / settings / archive / quit — always. The radio
+//     picker's station table is baked in (#682), so there is nothing to gate
+//     it on; it opens RailRadio, which overlays this same rail.
 //   * rooms — needs a network context (`archiveSlugForSelection()`).
 //   * mentions — needs a bundle to re-open for that network context.
 //   * admin — `isAdmin()`.
@@ -431,6 +434,28 @@ const RailActions: Component<Props> = (props) => {
               </button>
             )}
           </Show>
+
+          {/* #682 — radio launcher. Opens the station picker, which overlays
+              this same rail (RailRadio, mounted just above this drawer). It
+              closes the menu like every other launcher: the picker takes over
+              the rail, so leaving this menu live underneath it would stack two
+              overlays on one column. ALWAYS shown — the station table is baked
+              in, so there is no capability to gate on. */}
+          <button
+            type="button"
+            class="shell-chrome-btn rail-action rail-action-radio"
+            aria-label="open radio"
+            data-testid="rail-action-radio"
+            onClick={() => {
+              openRadioPicker();
+              close();
+            }}
+          >
+            <span class="rail-action-icon" aria-hidden="true">
+              {"\u{1F4FB}"}
+            </span>
+            <span class="rail-action-label">radio</span>
+          </button>
 
           {/* #75/#332 — themes launcher: opens the settings drawer on the themes
               sub-page (openThemesPanel deep-links via settingsNav). Always. */}

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -4,6 +4,7 @@ import { refreshInCardHead, refreshSlot } from "./admin/refreshSlot";
 import { archiveSlugForSelection } from "./lib/archiveContext";
 import { type ChannelKey, channelKey } from "./lib/channelKey";
 import { conversationMuteKey, isConversationMuted } from "./lib/conversationMute";
+import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
 import { syncedSetChannelPresencePref } from "./lib/displayPrefs";
 import { canDetach, confirmDetach, confirmQuit } from "./lib/lifecycle";
 import { membersByChannel } from "./lib/members";
@@ -257,16 +258,12 @@ const RailActions: Component<Props> = (props) => {
   // so clicks on the launcher/menu never self-close here — the launcher toggles,
   // the action buttons call close() themselves. Registered only while open; the
   // opening click already fired before the effect runs, so it can't self-close.
+  // #682 — the listener itself moved to `lib/dismissOnOutsidePointer`, where
+  // the second rail popover (the radio picker) shares it. The reasoning above
+  // — non-blocking listener, NOT a scrim — travelled with it and now lives on
+  // the verb; nothing about the behaviour here changed.
   let rootRef: HTMLDivElement | undefined;
-  createEffect(() => {
-    if (!open()) return;
-    const onPointerDown = (e: PointerEvent): void => {
-      const target = e.target as Node | null;
-      if (rootRef && target && !rootRef.contains(target)) close();
-    };
-    document.addEventListener("pointerdown", onPointerDown, true);
-    onCleanup(() => document.removeEventListener("pointerdown", onPointerDown, true));
-  });
+  createDismissOnOutsidePointer(open, () => rootRef, close);
 
   // #588 — the menu opens UPWARD from the launcher (`bottom: 100%`), so its
   // usable height is ONLY the space above `rootRef` (the `.rail-actions`

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -1,0 +1,140 @@
+import { type Component, For, Show } from "solid-js";
+import { closeAudio } from "./lib/audioPlayer";
+import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
+import { createOverlayLock } from "./lib/overlayScrollLock";
+import { closeRadioPicker, radioPickerOpen, tunedStation, tuneStation } from "./lib/radio";
+import { RADIO_STATIONS } from "./lib/radioStations";
+
+// #682 — the rail's internet-radio surface: a station PICKER and, once
+// something is tuned, the station CHROME. Two views of the ONE audio player.
+//
+// WHY THE TRANSPORT IS NOT HERE. Play/pause/elapsed stay on the docked
+// `AudioMiniPlayer` above the compose box, and that split is forced, not
+// stylistic: on mobile `.shell-members` is `position: fixed` with
+// `transform: translateX(100%)`, sliding in only on `.open`
+// (themes/default.css). A transport living only in the rail is therefore
+// UNREACHABLE on a phone while it plays. So the rail gets picking and
+// identity, the docked bar keeps the controls, and there is exactly one
+// <audio> element and one `audioPlayer` store under both.
+//
+// WHY NOT AN ARM OF `RailContext`. That component grafts content BY THE
+// ACTIVE WINDOW'S KIND and renders nothing for kinds it has no arm for, so a
+// radio panel hosted there would vanish the moment the operator switched to a
+// query — the exact opposite of what the docked player already guarantees.
+// This mounts unconditionally inside `.shell-members`, kind-independent, the
+// way `RailActions` does, from BOTH branches of Shell's `isMobile()` split.
+//
+// VERTICAL BUDGET (#500). #500 collapsed the rail actions behind one pinned
+// launcher because an always-expanded column pushed them below the fold on a
+// long nick list. A permanent radio panel would re-charge exactly that cost,
+// so: idle renders NOTHING (no chrome, no picker, zero height), the chrome
+// appears only once the operator has tuned something and is one compact row
+// that takes its space from the scrolling `.members-pane` rather than from
+// the floored `RailActions`, and the picker is an OVERLAY.
+//
+// The picker overlays the whole rail (`position: absolute; inset: 0` against
+// `.shell-members`, which is already `position: relative` for the resize
+// handle) instead of copying the `.rail-actions-menu` popover shape. That is
+// not just simpler, it side-steps the two bugs that shape cost: anchoring a
+// menu at `bottom: 100%` of a bottom-pinned launcher is what made #588 (the
+// cap must be the space ABOVE, not the viewport) and #913 (that space is
+// measured from the physical top under `viewport-fit=cover`) necessary. An
+// inset-0 overlay's height IS the rail, so CSS bounds it with no measurement
+// at all — and `.shell-members` already carries the `min-height: 0` that
+// bounds it to the grid track.
+//
+// Dismiss reuses both shared verbs: `createOverlayLock` for the ordered
+// Escape stack and the refcount scroll-lock that keeps the rail's
+// `touch-action: pan-y` contract intact on mobile, and
+// `createDismissOnOutsidePointer` for the non-blocking outside click.
+//
+// Picking does NOT close the picker. RailActions states the rule already: a
+// launcher that NAVIGATES away is single-shot, a control the operator flips
+// in place and re-flips — `denoise` there — is not. Auditioning stations is
+// the second kind, so the picker stays up and marks the tuned row.
+
+const RailRadio: Component = () => {
+  let rootRef: HTMLDivElement | undefined;
+
+  createOverlayLock(() => radioPickerOpen(), ".rail-radio-picker", closeRadioPicker);
+  createDismissOnOutsidePointer(radioPickerOpen, () => rootRef, closeRadioPicker);
+
+  return (
+    <div class="rail-radio" ref={rootRef}>
+      {/* Station chrome — the rail's answer to "what is playing", present
+          only while something is. The docked transport carries the same name
+          for the phone, where this rail is slid off-screen. */}
+      <Show when={tunedStation()}>
+        {(station) => (
+          <div class="rail-radio-now" data-testid="rail-radio-now">
+            {/* Decorative: the title beside it already names the station, so
+                alt text would be read out twice by a screen reader. */}
+            <img class="rail-radio-now-logo" src={station().logoUrl} alt="" />
+            <div class="rail-radio-now-text">
+              <span class="rail-radio-now-title" data-testid="rail-radio-now-title">
+                {station().title}
+              </span>
+              <span class="rail-radio-now-genres">{station().genres.join(" · ")}</span>
+            </div>
+            {/* `closeAudio` directly: it already IS the stop verb, and the
+                station is derived from the player, so clearing the player is
+                what un-tunes. No radio-flavoured wrapper around it. */}
+            <button
+              type="button"
+              class="rail-radio-stop"
+              data-testid="rail-radio-stop"
+              onClick={closeAudio}
+              aria-label="stop radio"
+            >
+              {"⏹"}
+            </button>
+          </div>
+        )}
+      </Show>
+
+      <Show when={radioPickerOpen()}>
+        <div class="rail-radio-picker" data-testid="rail-radio-picker">
+          <div class="rail-radio-picker-head">
+            {/* Mirrors the MembersPane `<h3>` slot (uppercased by CSS), the
+                established heading shape for rail content. */}
+            <h3 class="rail-radio-heading">radio</h3>
+            <button
+              type="button"
+              class="rail-radio-picker-close"
+              data-testid="rail-radio-picker-close"
+              onClick={closeRadioPicker}
+              aria-label="close radio picker"
+            >
+              {"✕"}
+            </button>
+          </div>
+          <For each={RADIO_STATIONS}>
+            {(station) => (
+              <button
+                type="button"
+                class="rail-radio-station"
+                classList={{ tuned: tunedStation()?.id === station.id }}
+                data-testid={`rail-radio-station-${station.id}`}
+                onClick={() => tuneStation(station)}
+                /* aria-pressed, not aria-selected: these are toggle buttons in
+                   a plain container, not options in a listbox — and it is what
+                   marks the tuned row for a screen reader, matching the visual
+                   `.tuned` class. */
+                aria-pressed={tunedStation()?.id === station.id ? "true" : "false"}
+                title={station.description}
+              >
+                <img class="rail-radio-station-logo" src={station.logoUrl} alt="" />
+                <span class="rail-radio-station-text">
+                  <span class="rail-radio-station-title">{station.title}</span>
+                  <span class="rail-radio-station-genres">{station.genres.join(" · ")}</span>
+                </span>
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default RailRadio;

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -59,6 +59,7 @@ import NextActiveButton from "./NextActiveButton";
 import PrivacyModal from "./PrivacyModal";
 import RailActions from "./RailActions";
 import RailContext from "./RailContext";
+import RailRadio from "./RailRadio";
 import RecoverModal from "./RecoverModal";
 import RegistrationWizardModal from "./RegistrationWizardModal";
 import ResizeHandle from "./ResizeHandle";
@@ -784,6 +785,13 @@ const Shell: Component = () => {
                 now a first-class always-on RailActions button opening the single
                 grouped ArchiveModal (mounted above) — the desktop Sidebar
                 `<details>` and the mobile footer chip it replaced are removed. */}
+            {/* #682 — the radio surface, mounted UNCONDITIONALLY like the drawer
+              below it and deliberately NOT as a `RailContext` arm: that
+              component grafts by the active window's KIND and would drop the
+              panel the moment the operator switched to a query. Idle it renders
+              nothing at all, so #500's vertical budget is untouched until a
+              station is tuned; its picker overlays the whole rail. */}
+            <RailRadio />
             <RailActions setters={{ membersOpen, setMembersOpen, setSettingsOpen }} />
           </aside>
 
@@ -1113,6 +1121,13 @@ const Shell: Component = () => {
               Same component + same handler set the desktop rail mounts (the
               drawer-closing arm of the mobilePanel helpers is meaningful here on
               mobile and a harmless no-op on the permanent desktop rail). */}
+          {/* #682 — the radio surface, mounted UNCONDITIONALLY like the drawer
+              below it and deliberately NOT as a `RailContext` arm: that
+              component grafts by the active window's KIND and would drop the
+              panel the moment the operator switched to a query. Idle it renders
+              nothing at all, so #500's vertical budget is untouched until a
+              station is tuned; its picker overlays the whole rail. */}
+          <RailRadio />
           <RailActions setters={{ membersOpen, setMembersOpen, setSettingsOpen }} />
         </aside>
 

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -32,7 +32,7 @@ describe("AudioMiniPlayer", () => {
 
   it("shows the bar and starts playback when an audio link is played", () => {
     render(() => <AudioMiniPlayer />);
-    playAudio("https://grappa.example/uploads/abc");
+    playAudio("https://grappa.example/uploads/abc", null);
 
     expect(screen.getByTestId("audio-mini-player")).toBeInTheDocument();
     expect(playSpy).toHaveBeenCalled();
@@ -40,7 +40,7 @@ describe("AudioMiniPlayer", () => {
 
   it("close button stops playback and hides the bar", () => {
     render(() => <AudioMiniPlayer />);
-    playAudio("https://grappa.example/uploads/abc");
+    playAudio("https://grappa.example/uploads/abc", null);
 
     screen.getByTestId("audio-mini-player-close").click();
 
@@ -54,7 +54,7 @@ describe("AudioMiniPlayer", () => {
     // real media state jsdom does not implement; that is pinned by the
     // Playwright e2e + iPhone dogfood, not here.
     render(() => <AudioMiniPlayer />);
-    playAudio("https://grappa.example/uploads/abc");
+    playAudio("https://grappa.example/uploads/abc", null);
 
     expect(screen.getByTestId("audio-mini-player-toggle")).toBeInTheDocument();
     expect(screen.getByTestId("audio-mini-player-seek")).toBeInTheDocument();
@@ -66,10 +66,90 @@ describe("AudioMiniPlayer", () => {
     // server's `inline` disposition) and inherits the server's
     // Content-Disposition filename — no value needed.
     render(() => <AudioMiniPlayer />);
-    playAudio("https://grappa.example/uploads/abc");
+    playAudio("https://grappa.example/uploads/abc", null);
 
     const dl = screen.getByTestId("audio-mini-player-download");
     expect(dl).toHaveAttribute("href", "https://grappa.example/uploads/abc");
     expect(dl).toHaveAttribute("download");
+  });
+
+  // #682 — LIVE mode. The transport was written for a FILE: it renders a
+  // position slider and a "cur / dur" read, both meaningless against an
+  // endless Icecast stream. The mode is DERIVED from the element's own
+  // `duration` (non-finite ⇒ nothing to scrub within), not from a flag the
+  // caller sets — so it is right for ANY endless source, not just the radio
+  // stations that motivated it, and cannot drift from the element's truth.
+  //
+  // jsdom implements no media pipeline, so `duration` is stubbed on the
+  // INSTANCE and the metadata event replayed by hand — the same seam the
+  // play/pause spies above use, at the one property the mode reads.
+  const loadMetadataWithDuration = (duration: number): void => {
+    const el = screen.getByTestId("audio-mini-player-el");
+    Object.defineProperty(el, "duration", { configurable: true, value: duration });
+    el.dispatchEvent(new Event("loadedmetadata"));
+  };
+
+  it("a finite duration keeps the seek control and the download link", () => {
+    render(() => <AudioMiniPlayer />);
+    playAudio("https://grappa.example/uploads/abc", null);
+
+    loadMetadataWithDuration(212);
+
+    expect(screen.getByTestId("audio-mini-player-seek")).toBeInTheDocument();
+    expect(screen.getByTestId("audio-mini-player-download")).toBeInTheDocument();
+    expect(screen.queryByTestId("audio-mini-player-live")).toBeNull();
+  });
+
+  it("an endless stream drops the seek control — there is nothing to scrub", () => {
+    render(() => <AudioMiniPlayer />);
+    playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
+
+    loadMetadataWithDuration(Number.POSITIVE_INFINITY);
+
+    expect(screen.queryByTestId("audio-mini-player-seek")).toBeNull();
+    expect(screen.getByTestId("audio-mini-player-live")).toBeInTheDocument();
+  });
+
+  it("an endless stream drops the download link — a save that never completes", () => {
+    // Two independent reasons, either one sufficient: the resource has no
+    // end, so the save never finishes; and `download` is ignored outright on
+    // a cross-origin href, so the anchor would navigate away from the app.
+    render(() => <AudioMiniPlayer />);
+    playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
+
+    loadMetadataWithDuration(Number.POSITIVE_INFINITY);
+
+    expect(screen.queryByTestId("audio-mini-player-download")).toBeNull();
+  });
+
+  it("an unknown (NaN) duration is treated as live, not as a zero-length file", () => {
+    // `duration` is NaN whenever the element cannot state a length. Seeking
+    // is exactly as meaningless there as against Infinity, so the predicate
+    // is "not a finite number" rather than "=== Infinity".
+    render(() => <AudioMiniPlayer />);
+    playAudio("https://ice.somafm.com/dronezone-128-mp3", "Drone Zone");
+
+    loadMetadataWithDuration(Number.NaN);
+
+    expect(screen.queryByTestId("audio-mini-player-seek")).toBeNull();
+    expect(screen.getByTestId("audio-mini-player-live")).toBeInTheDocument();
+  });
+
+  it("shows the source label when one was supplied", () => {
+    // On mobile the right rail is a drawer slid off-screen
+    // (`transform: translateX(100%)`), so while a station plays this docked
+    // bar is the ONLY thing on screen naming it. Without the label the phone
+    // cannot answer "what am I listening to".
+    render(() => <AudioMiniPlayer />);
+    playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
+
+    expect(screen.getByTestId("audio-mini-player-label")).toHaveTextContent("Groove Salad");
+  });
+
+  it("renders no label slot for an unlabelled source", () => {
+    render(() => <AudioMiniPlayer />);
+    playAudio("https://grappa.example/uploads/abc", null);
+
+    expect(screen.queryByTestId("audio-mini-player-label")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -696,6 +696,9 @@ describe("RailActions — detach + quit (#986)", () => {
       "mobile-panel-home",
       "mobile-panel-list",
       "rail-action-mentions",
+      // #682 — the radio picker launcher sits with the navigation set, before
+      // themes: it opens a rail surface, like the entries around it.
+      "rail-action-radio",
       "mobile-panel-themes",
       "mobile-panel-archive",
       "action-cluster-cog",

--- a/cicchetto/src/__tests__/RailRadio.test.tsx
+++ b/cicchetto/src/__tests__/RailRadio.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { activeAudio, closeAudio, playAudio } from "../lib/audioPlayer";
+import { closeRadioPicker, openRadioPicker, radioPickerOpen } from "../lib/radio";
+import { RADIO_STATIONS } from "../lib/radioStations";
+import RailRadio from "../RailRadio";
+
+// #682 — the rail's radio surface. Two views of the ONE audio player: a
+// station picker and, once something is tuned, the station chrome. The
+// transport itself stays docked above compose (AudioMiniPlayer) — see the
+// component header for why the rail cannot host it.
+//
+// The store and the station table are used FOR REAL here (both are pure, and
+// mocking them would leave the wiring these tests exist to check untested);
+// only the media element is stubbed, since jsdom implements no playback.
+
+const station = RADIO_STATIONS[0];
+const other = RADIO_STATIONS[1];
+if (station === undefined || other === undefined) {
+  throw new Error("the curated table must carry at least two stations for these tests");
+}
+
+beforeEach(() => {
+  vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
+  vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+  closeAudio();
+  closeRadioPicker();
+});
+
+afterEach(() => {
+  closeAudio();
+  closeRadioPicker();
+  vi.restoreAllMocks();
+});
+
+describe("RailRadio", () => {
+  it("costs the rail nothing while idle — no chrome, no picker", () => {
+    // #500's budget: a permanently-expanded panel above RailActions re-charges
+    // the vertical cost that issue paid to remove. Nothing tuned and the
+    // picker shut must render neither.
+    render(() => <RailRadio />);
+    expect(screen.queryByTestId("rail-radio-picker")).toBeNull();
+    expect(screen.queryByTestId("rail-radio-now")).toBeNull();
+  });
+
+  it("lists every curated station when the picker is open", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    expect(screen.getByTestId("rail-radio-picker")).toBeInTheDocument();
+    for (const s of RADIO_STATIONS) {
+      expect(
+        screen.getByTestId(`rail-radio-station-${s.id}`),
+        `station ${s.id} missing from the picker`,
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("picking a station hands its stream and title to the one player", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+    expect(activeAudio()).toEqual({ href: station.streamUrl, label: station.title });
+  });
+
+  it("shows the station chrome once something is tuned", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+    expect(screen.getByTestId("rail-radio-now")).toHaveTextContent(station.title);
+  });
+
+  it("marks which station is playing, so the picker is not a blind list", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+    expect(screen.getByTestId(`rail-radio-station-${station.id}`)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId(`rail-radio-station-${other.id}`)).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("stops playback from the rail chrome", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+    screen.getByTestId("rail-radio-stop").click();
+
+    expect(activeAudio()).toBeNull();
+    expect(screen.queryByTestId("rail-radio-now")).toBeNull();
+  });
+
+  it("drops the chrome when an audio upload takes the player over", () => {
+    // One <audio>: a clicked audio link swaps the source out from under the
+    // station. The rail must stop claiming a station is playing — this is the
+    // derived-not-stored contract, seen from the UI.
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+    expect(screen.getByTestId("rail-radio-now")).toBeInTheDocument();
+
+    playAudio("https://grappa.example/uploads/abc", null);
+
+    expect(screen.queryByTestId("rail-radio-now")).toBeNull();
+  });
+
+  it("keeps the picker open after a pick, so stations can be auditioned", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+    expect(screen.getByTestId("rail-radio-picker")).toBeInTheDocument();
+  });
+
+  it("closes the picker from its own dismiss control", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    screen.getByTestId("rail-radio-picker-close").click();
+
+    expect(screen.queryByTestId("rail-radio-picker")).toBeNull();
+    expect(radioPickerOpen()).toBe(false);
+  });
+
+  it("an outside pointerdown closes the picker without tuning anything", () => {
+    // Wiring check for the shared dismiss verb: the click still reaches its
+    // target (non-blocking listener, not a scrim), so a tap on a sidebar
+    // channel selects it in one gesture.
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByTestId("rail-radio-picker")).toBeNull();
+    expect(activeAudio()).toBeNull();
+  });
+
+  it("a pointerdown inside the picker does not dismiss it", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    fireEvent.pointerDown(screen.getByTestId(`rail-radio-station-${station.id}`));
+
+    expect(screen.getByTestId("rail-radio-picker")).toBeInTheDocument();
+  });
+});

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4279,8 +4279,10 @@ describe("ScrollbackPane", () => {
       const ev = new MouseEvent("click", { bubbles: true, cancelable: true });
       link.dispatchEvent(ev);
       // Audio routes to the non-modal docked player; the image/video
-      // viewer modal stays closed.
-      expect(activeAudio()).toEqual({ href });
+      // viewer modal stays closed. `label: null` (#682) is the honest answer
+      // for a pasted link: cic sees a slug-only href and has no title to
+      // caption it with — only a picked radio station carries a name.
+      expect(activeAudio()).toEqual({ href, label: null });
       expect(mediaViewerState()).toBeNull();
     });
 

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -1311,7 +1311,7 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
     });
   });
 
-  it("#473/#986/#950 drawer order: home · rooms · mentions · themes · archive · settings · admin · denoise · mute · quit", async () => {
+  it("#473/#986/#950/#682 drawer order: home · rooms · mentions · radio · themes · archive · settings · admin · denoise · mute · quit", async () => {
     mobileState.value = true;
     userHolder.current = {
       kind: "user",
@@ -1348,6 +1348,7 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
       "mobile-panel-home",
       "mobile-panel-list",
       "rail-action-mentions",
+      "rail-action-radio",
       "mobile-panel-themes",
       "mobile-panel-archive",
       "action-cluster-cog",

--- a/cicchetto/src/__tests__/audioPlayer.test.ts
+++ b/cicchetto/src/__tests__/audioPlayer.test.ts
@@ -17,28 +17,46 @@ describe("audioPlayer store", () => {
   });
 
   it("playAudio sets the active href", () => {
-    playAudio("https://grappa.example/uploads/abc");
-    expect(activeAudio()).toEqual({ href: "https://grappa.example/uploads/abc" });
+    playAudio("https://grappa.example/uploads/abc", null);
+    expect(activeAudio()).toEqual({ href: "https://grappa.example/uploads/abc", label: null });
   });
 
   it("playAudio on a second link swaps the source (one instance, not two)", () => {
-    playAudio("https://grappa.example/uploads/first");
-    playAudio("https://grappa.example/uploads/second");
-    expect(activeAudio()).toEqual({ href: "https://grappa.example/uploads/second" });
+    playAudio("https://grappa.example/uploads/first", null);
+    playAudio("https://grappa.example/uploads/second", null);
+    expect(activeAudio()).toEqual({ href: "https://grappa.example/uploads/second", label: null });
   });
 
   it("closeAudio clears the active audio", () => {
-    playAudio("https://grappa.example/uploads/abc");
+    playAudio("https://grappa.example/uploads/abc", null);
     closeAudio();
     expect(activeAudio()).toBeNull();
   });
 
   it("token rotation closes an open player (identity-scoped)", () => {
     setToken("tokA");
-    playAudio("https://grappa.example/uploads/abc");
+    playAudio("https://grappa.example/uploads/abc", null);
     expect(activeAudio()).not.toBeNull();
 
     setToken("tokB");
     expect(activeAudio()).toBeNull();
+  });
+
+  // #682 — the label rides WITH the href because the two must swap
+  // atomically. A separate signal would let a station's name outlive the
+  // source it named for one render, captioning an upload with the station
+  // that preceded it.
+  it("playAudio carries a label alongside the href", () => {
+    playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
+    expect(activeAudio()).toEqual({
+      href: "https://ice.somafm.com/groovesalad-128-mp3",
+      label: "Groove Salad",
+    });
+  });
+
+  it("swapping a labelled source for an unlabelled one drops the label", () => {
+    playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
+    playAudio("https://grappa.example/uploads/abc", null);
+    expect(activeAudio()).toEqual({ href: "https://grappa.example/uploads/abc", label: null });
   });
 });

--- a/cicchetto/src/__tests__/radio.test.ts
+++ b/cicchetto/src/__tests__/radio.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { activeAudio, closeAudio, playAudio } from "../lib/audioPlayer";
+import { setToken } from "../lib/auth";
+import {
+  closeRadioPicker,
+  radioPickerOpen,
+  toggleRadioPicker,
+  tunedStation,
+  tuneStation,
+} from "../lib/radio";
+import { RADIO_STATIONS } from "../lib/radioStations";
+
+// #682 — the radio store. It owns exactly ONE piece of state (is the picker
+// open) and DERIVES the rest, which is the whole point of these tests: the
+// tuned station is read back out of the single `audioPlayer` store rather
+// than tracked alongside it, so the two cannot disagree.
+
+const station = RADIO_STATIONS[0];
+const other = RADIO_STATIONS[1];
+if (station === undefined || other === undefined) {
+  throw new Error("the curated table must carry at least two stations for these tests");
+}
+
+afterEach(() => {
+  closeAudio();
+  closeRadioPicker();
+  setToken(null);
+});
+
+describe("radio store", () => {
+  it("starts with nothing tuned and the picker shut", () => {
+    expect(tunedStation()).toBeNull();
+    expect(radioPickerOpen()).toBe(false);
+  });
+
+  it("tuning hands the stream and the station name to the one audio player", () => {
+    tuneStation(station);
+    expect(activeAudio()).toEqual({ href: station.streamUrl, label: station.title });
+  });
+
+  it("reads the tuned station back off the player", () => {
+    tuneStation(station);
+    expect(tunedStation()).toEqual(station);
+  });
+
+  it("tuning a second station swaps the first — one player, not two", () => {
+    tuneStation(station);
+    tuneStation(other);
+    expect(tunedStation()).toEqual(other);
+    expect(activeAudio()?.href).toBe(other.streamUrl);
+  });
+
+  it("an audio upload taking over the player un-tunes the station", () => {
+    // The load-bearing case for DERIVING rather than storing. There is one
+    // <audio> element, so a clicked audio link swaps the source out from
+    // under the station. A stored `tuned` signal would keep claiming the
+    // station is playing while the upload plays; a derived one cannot.
+    tuneStation(station);
+    playAudio("https://grappa.example/uploads/abc", null);
+    expect(tunedStation()).toBeNull();
+  });
+
+  it("closing the player un-tunes the station", () => {
+    tuneStation(station);
+    closeAudio();
+    expect(tunedStation()).toBeNull();
+  });
+
+  it("toggles the picker open and shut", () => {
+    toggleRadioPicker();
+    expect(radioPickerOpen()).toBe(true);
+    toggleRadioPicker();
+    expect(radioPickerOpen()).toBe(false);
+  });
+
+  it("keeps the picker open after tuning, so stations can be auditioned", () => {
+    // Follows the rule RailActions already states for `denoise`: a launcher
+    // that NAVIGATES away closes the menu, a control the operator flips in
+    // place and re-flips does not. Tuning is the second kind.
+    toggleRadioPicker();
+    tuneStation(station);
+    expect(radioPickerOpen()).toBe(true);
+  });
+
+  it("token rotation shuts the picker (identity-scoped)", () => {
+    setToken("tokA");
+    toggleRadioPicker();
+    expect(radioPickerOpen()).toBe(true);
+
+    setToken("tokB");
+    expect(radioPickerOpen()).toBe(false);
+  });
+
+  it("token rotation un-tunes, because it stops the player it derives from", () => {
+    setToken("tokA");
+    tuneStation(station);
+    expect(tunedStation()).not.toBeNull();
+
+    setToken("tokB");
+    expect(tunedStation()).toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { RADIO_STATIONS } from "../lib/radioStations";
+
+// #682 — the curated station table. These are SHAPE invariants, and each one
+// exists because breaking it fails SILENTLY in production rather than loudly
+// here.
+//
+// What this file deliberately does NOT assert: that a stream is reachable.
+// That needs the network, and a unit test that hits somafm.com would be a
+// third-party outage detector wired into our gate. Reachability was measured
+// by hand when each entry was added (see the module header for the date and
+// the method) and is re-measured when the list changes — it is not something
+// a test run in CI can honestly stand behind.
+
+describe("RADIO_STATIONS", () => {
+  it("is not empty — an empty table is a picker that opens onto nothing", () => {
+    expect(RADIO_STATIONS.length).toBeGreaterThan(0);
+  });
+
+  it("has a unique id per station", () => {
+    // Ids key the rendered list. A duplicate makes one of the two stations
+    // unreachable in the picker without any error anywhere.
+    const ids = RADIO_STATIONS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("names every station — the title is what the transport shows", () => {
+    // The docked player captions playback with this string; on mobile it is
+    // the only surface naming the station. An empty one is an anonymous bar.
+    for (const s of RADIO_STATIONS) {
+      expect(s.title.trim(), `station ${s.id} has no title`).not.toBe("");
+    }
+  });
+
+  it("serves every stream and logo over https", () => {
+    // The CSP tokens that admit these (`media-src https:`, `img-src https:`)
+    // are scheme-scoped, and an http subresource on an https page is refused
+    // as mixed content regardless. Either way the failure is a station that
+    // silently does not play.
+    for (const s of RADIO_STATIONS) {
+      expect(s.streamUrl, `station ${s.id} stream`).toMatch(/^https:\/\//);
+      expect(s.logoUrl, `station ${s.id} logo`).toMatch(/^https:\/\//);
+    }
+  });
+
+  it("uses SomaFM's stable front door, never a numbered pool host", () => {
+    // Measured 2026-08-23: a channel's `.pls` lists three ROTATING hosts
+    // (ice2 / ice5 / ice6) while the unnumbered `ice.somafm.com` answers for
+    // all of them. Copying a URL straight out of a `.pls` — the obvious way
+    // to add a station — pins one pool member and rots when the pool moves.
+    // Scoped to somafm hosts on purpose: this table is allowed to hold a
+    // station from another provider, and must not be pinned to one vendor.
+    for (const s of RADIO_STATIONS) {
+      const host = new URL(s.streamUrl).host;
+      if (!host.endsWith("somafm.com")) continue;
+      expect(host, `station ${s.id} pins a rotating pool host`).toBe("ice.somafm.com");
+    }
+  });
+});

--- a/cicchetto/src/lib/audioPlayer.ts
+++ b/cicchetto/src/lib/audioPlayer.ts
@@ -20,7 +20,12 @@
 import { createSignal } from "solid-js";
 import { identityScopedStore } from "./identityScopedStore";
 
-export type AudioPlayerState = { href: string };
+export type AudioPlayerState = {
+  href: string;
+  /** Human name for the source, or null when it has none (an upload is
+      identified by its link, not by a title). See `playAudio`. */
+  label: string | null;
+};
 
 const exports_ = identityScopedStore((onIdentityChange) => {
   const [activeAudio, setActiveAudio] = createSignal<AudioPlayerState | null>(null);
@@ -31,8 +36,20 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     activeAudio,
     // Start (or swap to) the audio at `href`. One instance: a second
     // click replaces the source rather than stacking a new player.
-    playAudio(href: string): void {
-      setActiveAudio({ href });
+    //
+    // #682 — `label` rides WITH the href rather than sitting in a sibling
+    // signal, because the two must swap ATOMICALLY: a separate signal lets a
+    // station's name outlive the source it named for one render, captioning
+    // the next upload with the station that preceded it. It is REQUIRED, not
+    // defaulted (CLAUDE.md: no silent-degradation defaults) — a caller with
+    // nothing to say passes `null` and says so.
+    //
+    // Why a label exists at all: on mobile the right rail is a drawer slid
+    // off-screen (`transform: translateX(100%)`), so while a radio station
+    // plays, this docked bar is the only surface naming it. Without the label
+    // the phone cannot answer "what am I listening to".
+    playAudio(href: string, label: string | null): void {
+      setActiveAudio({ href, label });
     },
     closeAudio(): void {
       setActiveAudio(null);

--- a/cicchetto/src/lib/dismissOnOutsidePointer.ts
+++ b/cicchetto/src/lib/dismissOnOutsidePointer.ts
@@ -1,0 +1,39 @@
+import { createEffect, onCleanup } from "solid-js";
+
+// Close-on-click-outside for lightweight rail popovers, as a shared verb.
+//
+// Extracted from `RailActions` (#500) when #682's radio picker became the
+// second surface needing it — two call sites, one implementation, per
+// CLAUDE.md rather than a copy with tweaks.
+//
+// WHY A LISTENER AND NOT A BACKDROP SCRIM. The modal family dismisses by
+// covering the viewport with a click-catching element. That is wrong for a
+// rail popover: the scrim SWALLOWS the click that dismissed it, so selecting
+// a sidebar channel or focusing compose while a popover is open costs two
+// gestures instead of one. A NON-blocking document listener closes the
+// popover AND lets the click reach its target.
+//
+// Capture phase (`true`) on purpose: it must observe the click before a
+// stopPropagation() anywhere in the tree can hide it.
+//
+// Registered only WHILE OPEN, and the opening click has already been
+// dispatched by the time the effect runs, so a popover cannot dismiss itself
+// on the very gesture that opened it. Anything inside `root` is exempt, which
+// is what lets a launcher toggle and lets the popover's own rows be clicked;
+// a row that should dismiss calls `onDismiss` itself.
+export function createDismissOnOutsidePointer(
+  isOpen: () => boolean,
+  root: () => HTMLElement | undefined,
+  onDismiss: () => void,
+): void {
+  createEffect(() => {
+    if (!isOpen()) return;
+    const onPointerDown = (e: PointerEvent): void => {
+      const target = e.target as Node | null;
+      const el = root();
+      if (el && target && !el.contains(target)) onDismiss();
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    onCleanup(() => document.removeEventListener("pointerdown", onPointerDown, true));
+  });
+}

--- a/cicchetto/src/lib/radio.ts
+++ b/cicchetto/src/lib/radio.ts
@@ -1,0 +1,83 @@
+import { createSignal } from "solid-js";
+import { activeAudio, playAudio } from "./audioPlayer";
+import { identityScopedStore } from "./identityScopedStore";
+import { RADIO_STATIONS, type RadioStation } from "./radioStations";
+
+// #682 — internet-radio store. It is deliberately almost empty, and what is
+// NOT here is the design:
+//
+// THE TUNED STATION IS DERIVED, NOT STORED. There is exactly one <audio>
+// element and one `audioPlayer` store behind it (#115), and a station is just
+// another href handed to it. So "which station is playing" is already written
+// down — in `activeAudio()` — and a second signal tracking it would be a
+// parallel structure needing housekeeping that will drift (CLAUDE.md design
+// discipline: derive, don't duplicate). The drift is not hypothetical: click
+// an audio link in scrollback while a station plays and the source swaps
+// under the station. A stored flag would still claim the station is on; the
+// derivation below cannot, and neither can it miss `closeAudio()`, the ✕ on
+// the transport, or the identity-rotation reset that store already performs.
+//
+// So this module owns ONE signal — whether the picker is open — and that one
+// is genuinely local ephemeral UI state, the same kind as Shell's
+// `membersOpen` / `settingsOpen`. cic-never-originates-state governs IRC
+// WINDOW state, not a client-side drawer toggle.
+//
+// There is no `stopStation` verb: `closeAudio()` from the audio store already
+// is that verb, and wrapping it under a radio-flavoured name would be a
+// second noun for one behaviour (CLAUDE.md: reuse the verbs, not the nouns).
+//
+// Identity scoping: the picker resets on rotation like every other cic store.
+// The TUNED station needs no reset of its own — `audioPlayer` clears on
+// rotation and this derives from it, which is one more thing the derivation
+// gets right for free.
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const [radioPickerOpen, setRadioPickerOpen] = createSignal(false);
+
+  // A logout or rotation must not hand the next identity a rail with someone
+  // else's picker hanging open over it.
+  onIdentityChange(() => setRadioPickerOpen(false));
+
+  return {
+    radioPickerOpen,
+    openRadioPicker: (): void => {
+      setRadioPickerOpen(true);
+    },
+    closeRadioPicker: (): void => {
+      setRadioPickerOpen(false);
+    },
+    toggleRadioPicker: (): void => {
+      setRadioPickerOpen((v) => !v);
+    },
+  };
+});
+
+export const { radioPickerOpen, openRadioPicker, closeRadioPicker, toggleRadioPicker } = exports_;
+
+// Start (or swap to) a station. Routes through the ONE player — no second
+// <audio>, no stacking — and hands it the title, which is what the docked
+// transport captions playback with. That caption is not decoration: on mobile
+// the rail holding the station chrome is a drawer slid off-screen while
+// playing, so the docked bar is the only surface naming the station.
+//
+// It deliberately does NOT close the picker. RailActions already states the
+// rule this follows: a launcher that NAVIGATES away closes the menu, while a
+// control the operator flips in place — `denoise` there — does not. Tuning is
+// the second kind: the operator auditions stations and re-picks.
+export function tuneStation(station: RadioStation): void {
+  playAudio(station.streamUrl, station.title);
+}
+
+// Which station, if any, the single player is currently on. Reactive: it
+// tracks `activeAudio`, so it re-reads whenever the source swaps for ANY
+// reason — a second station, an audio upload taking the player over, the
+// transport's ✕, or identity rotation.
+//
+// Matching on the href is what makes it total: an upload's href is in no
+// station's table row, so it answers null without anything having to notice
+// that an upload happened.
+export function tunedStation(): RadioStation | null {
+  const href = activeAudio()?.href;
+  if (href === undefined) return null;
+  return RADIO_STATIONS.find((s) => s.streamUrl === href) ?? null;
+}

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -1,0 +1,170 @@
+// #682 — the curated internet-radio station list.
+//
+// WHY A BAKED-IN TABLE AND NOT A LIVE CATALOGUE. SomaFM publishes its whole
+// catalogue at `https://somafm.com/channels.json` (46 channels, with genre,
+// listener counts and a `lastPlaying` track name), and that endpoint answers
+// `Access-Control-Allow-Origin: *` — measured 2026-08-23. So CORS is NOT what
+// rules it out. OUR OWN CSP is: `connect-src` (GrappaWeb.Plugs.SecurityHeaders)
+// admits `'self'` plus three named third parties, and a `fetch` to somafm.com
+// is not among them. Widening it is a server change and a security-surface
+// decision, so the first cut ships the list as data instead. The same applies
+// to the `.pls` playlists the catalogue points at: fetching one to read the
+// stream URL out of it is a `fetch` too, and falls at the same door.
+//
+// What needs NO server change, and is why this works at all:
+//   * `media-src 'self' blob: https:` already admits the <audio> stream —
+//     #607 widened it for this very mini-player.
+//   * `img-src 'self' data: https:` already admits the logos (#1240), because
+//     an <img> is governed by img-src and not by connect-src.
+//
+// WHY THE STREAM URL IS SAFE TO BAKE. The `.pls` for a channel lists THREE
+// rotating hosts (ice2 / ice5 / ice6), which looks like exactly the kind of
+// detail a hardcoded table gets wrong. Measured, it is not: the UNNUMBERED
+// `ice.somafm.com` also answers, serving `audio/mpeg` with the channel's
+// `icy-name` — it is the stable front door, and ice1..ice6 are the pool
+// behind it. Every entry below was fetched through it and returned real MPEG
+// audio on 2026-08-23; the versionless logo URLs were checked the same way
+// (the catalogue spells them with a `?v=` cache-buster that would rot).
+//
+// The list is CURATED, not user-editable. A user-editable list is user state
+// and would want `lib/displayPrefs.ts` treatment (server-backed + synced,
+// #449) rather than a localStorage list that dies per device — a different
+// piece of work, deliberately out of this one.
+//
+// Fields are stored, not derived from `id`. Deriving the stream URL from the
+// id would template SomaFM's naming convention into the type and break the
+// first entry that is not a SomaFM channel; this is a table of stations, not
+// a table of SomaFM slugs.
+
+/** One tunable station. All URLs must be https — the CSP tokens that admit
+    them (`media-src https:`, `img-src https:`) are scheme-scoped, and an http
+    stream on an https page is refused as mixed content anyway. */
+export type RadioStation = {
+  /** Stable slug. Keys the list and the per-row test ids; never displayed. */
+  readonly id: string;
+  readonly title: string;
+  /** Zero or more genre tags, already split — the catalogue spells them
+      pipe-joined, and a display concern should not have to know that. */
+  readonly genres: readonly string[];
+  readonly description: string;
+  /** The endless audio endpoint handed to `playAudio`. */
+  readonly streamUrl: string;
+  readonly logoUrl: string;
+};
+
+export const RADIO_STATIONS: readonly RadioStation[] = [
+  {
+    id: "groovesalad",
+    title: "Groove Salad",
+    genres: ["ambient", "electronic"],
+    description: "A nicely chilled plate of ambient/downtempo beats and grooves.",
+    streamUrl: "https://ice.somafm.com/groovesalad-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/groovesalad120.png",
+  },
+  {
+    id: "dronezone",
+    title: "Drone Zone",
+    genres: ["ambient"],
+    description:
+      "Served best chilled, safe with most medications. Atmospheric textures with minimal beats.",
+    streamUrl: "https://ice.somafm.com/dronezone-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/dronezone120.png",
+  },
+  {
+    id: "spacestation",
+    title: "Space Station Soma",
+    genres: ["electronic"],
+    description: "Tune in, turn on, space out. Spaced-out ambient and mid-tempo electronica.",
+    streamUrl: "https://ice.somafm.com/spacestation-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/spacestation120.png",
+  },
+  {
+    id: "lush",
+    title: "Lush",
+    genres: ["electronic"],
+    description: "Sensuous and mellow female vocals, many with an electronic influence.",
+    streamUrl: "https://ice.somafm.com/lush-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/lush120.png",
+  },
+  {
+    id: "indiepop",
+    title: "Indie Pop Rocks!",
+    genres: ["alternative", "rock"],
+    description: "New and classic favorite indie pop tracks.",
+    streamUrl: "https://ice.somafm.com/indiepop-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/indiepop120.png",
+  },
+  {
+    id: "u80s",
+    title: "Underground 80s",
+    genres: ["alternative", "electronic"],
+    description: "Early 80s UK Synthpop and a bit of New Wave.",
+    streamUrl: "https://ice.somafm.com/u80s-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/u80s120.png",
+  },
+  {
+    id: "secretagent",
+    title: "Secret Agent",
+    genres: ["lounge"],
+    description:
+      "The soundtrack for your stylish, mysterious, dangerous life. For Spies and PIs too!",
+    streamUrl: "https://ice.somafm.com/secretagent-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/secretagent120.png",
+  },
+  {
+    id: "defcon",
+    title: "DEF CON Radio",
+    genres: ["electronic", "specials"],
+    description: "Music for Hacking. The DEF CON Year-Round Channel.",
+    streamUrl: "https://ice.somafm.com/defcon-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/defcon120.png",
+  },
+  {
+    id: "folkfwd",
+    title: "Folk Forward",
+    genres: ["folk", "alternative"],
+    description: "Indie Folk, Alt-folk and the occasional folk classics. ",
+    streamUrl: "https://ice.somafm.com/folkfwd-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/folkfwd120.png",
+  },
+  {
+    id: "bootliquor",
+    title: "Boot Liquor",
+    genres: ["americana"],
+    description: "Americana Roots music for Cowhands, Cowpokes and Cowtippers",
+    streamUrl: "https://ice.somafm.com/bootliquor-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/bootliquor120.png",
+  },
+  {
+    id: "bossa",
+    title: "Bossa Beyond",
+    genres: ["bossanova", "world"],
+    description: "Silky-smooth, laid-back Brazilian-style rhythms of Bossa Nova, Samba and beyond",
+    streamUrl: "https://ice.somafm.com/bossa-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/bossa120.png",
+  },
+  {
+    id: "reggae",
+    title: "Heavyweight Reggae",
+    genres: ["reggae"],
+    description: "Reggae, Ska, Rocksteady classic and deep tracks.",
+    streamUrl: "https://ice.somafm.com/reggae-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/reggae120.png",
+  },
+  {
+    id: "sonicuniverse",
+    title: "Sonic Universe",
+    genres: ["jazz"],
+    description: "Transcending the world of jazz with eclectic, avant-garde takes on tradition.",
+    streamUrl: "https://ice.somafm.com/sonicuniverse-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/sonicuniverse120.png",
+  },
+  {
+    id: "missioncontrol",
+    title: "Mission Control",
+    genres: ["ambient", "electronic"],
+    description: "Celebrating NASA and Space Explorers everywhere.",
+    streamUrl: "https://ice.somafm.com/missioncontrol-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/missioncontrol120.png",
+  },
+];

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3567,6 +3567,33 @@ html.resize-dragging * {
   text-decoration: none;
 }
 
+/* #682 — the source's name, when it has one (uploads have none and this
+   renders nothing). It takes the free space so a long station title
+   ellipsises rather than pushing the transport controls off the bar: on a
+   phone this row is the whole player, and a control shoved past the right
+   edge is a control the operator cannot reach. In live mode it is also the
+   only element competing for that space — the seek slider is gone. */
+.audio-mini-player-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg);
+}
+
+/* #682 — the "this has no end" badge that stands in for the seek slider.
+   Deliberately a LABEL and not a disabled slider: a greyed-out position bar
+   still draws a scale, and there is no scale — the operator would read a
+   position out of a control that cannot have one. */
+.audio-mini-player-live {
+  flex: none;
+  color: var(--accent, var(--fg));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.85em;
+}
+
 .audio-mini-player-seek {
   flex: 1;
   min-width: 0;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2300,6 +2300,179 @@ html.resize-dragging * {
   color: inherit;
 }
 
+/* #682 — the rail's radio surface, mounted directly above `.rail-actions` in
+   BOTH Shell rail branches. Static position on purpose: the picker below is
+   absolute against `.shell-members` (already `position: relative` for the
+   resize handle), so it overlays the WHOLE rail rather than a slice of it.
+   `flex-shrink: 0` keeps the station chrome from being squeezed by a long
+   nick list — the space it takes comes off the scrolling `.members-pane`
+   above, never off the floored actions drawer below. Idle it has no children
+   at all and so no height: #500's vertical budget is untouched until the
+   operator tunes something. */
+.rail-radio {
+  flex-shrink: 0;
+}
+
+/* The station chrome: one compact row answering "what is playing". Present
+   only while something is — the docked `.audio-mini-player` carries the same
+   name for the phone, where this rail is slid off-screen. */
+.rail-radio-now {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  border-top: 1px solid var(--border);
+  background: var(--bg-alt);
+}
+
+.rail-radio-now-logo {
+  flex: none;
+  width: 2rem;
+  height: 2rem;
+  object-fit: cover;
+}
+
+/* `min-width: 0` is what lets the title ellipsise instead of forcing the row
+   wider than the rail and pushing the stop button out of reach. */
+.rail-radio-now-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 0.1rem;
+}
+
+.rail-radio-now-title,
+.rail-radio-station-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  color: var(--fg);
+}
+
+.rail-radio-now-genres,
+.rail-radio-station-genres {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8em;
+  color: var(--muted);
+}
+
+.rail-radio-stop {
+  flex: none;
+  min-width: 2rem;
+  min-height: 2rem;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+
+/* The picker OVERLAYS the whole rail. Deliberately not the
+   `.rail-actions-menu` popover shape: anchoring at `bottom: 100%` of a
+   bottom-pinned launcher is what made #588 (cap by the space ABOVE, not the
+   viewport) and #913 (that space is measured from the PHYSICAL top under
+   `viewport-fit=cover`) necessary. An `inset: 0` overlay's height IS the
+   rail, so CSS bounds it with no JS measurement to get wrong, and
+   `.shell-members`'s own `min-height: 0` (#500) already bounds that to the
+   grid track. z-index one step above the actions menu so the two cannot
+   argue if both are ever up.
+   `overscroll-behavior: contain` stops the scroll chaining into the nick list
+   behind it, as its sibling menu does. */
+.rail-radio-picker {
+  position: absolute;
+  inset: 0;
+  z-index: 302;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  background: var(--bg-alt);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+}
+
+/* #913's descendant carve-out, for the same reason it exists on
+   `.rail-actions-menu`: `touch-action` does NOT inherit, the station rows ARE
+   the hit-test target across nearly the whole panel, and iOS elects the
+   gesture consumer from the target's OWN value — so a scroller-level `pan-y`
+   alone leaves the pan refused while the list overflows correctly. */
+.rail-radio-picker * {
+  touch-action: pan-y;
+}
+
+.rail-radio-picker-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+/* Matches the `.members-pane h3` / `.rail-query-heading` slot — the
+   established heading shape for rail content. */
+.rail-radio-heading {
+  margin: 0;
+  font-size: var(--font-size);
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.rail-radio-picker-close {
+  flex: none;
+  min-width: 2rem;
+  min-height: 2rem;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+
+/* A station row. The tap floor is the app-wide absolute one, so it does not
+   shrink with the user's font size. */
+.rail-radio-station {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: var(--chrome-tap-min);
+  padding: 0.25rem 0.375rem;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  text-align: start;
+}
+
+.rail-radio-station-logo {
+  flex: none;
+  width: 1.75rem;
+  height: 1.75rem;
+  object-fit: cover;
+}
+
+.rail-radio-station-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 0.1rem;
+}
+
+/* The tuned row, marked the same way the presence toggle marks its active
+   state — accent on both text and border, so it reads without relying on
+   colour alone being noticed (the `aria-pressed` on the button is the
+   non-visual half). */
+.rail-radio-station.tuned {
+  border-color: var(--accent);
+}
+
+.rail-radio-station.tuned .rail-radio-station-title {
+  color: var(--accent);
+}
+
 /* #222/#473 — the denoise (presence-filter) toggle keeps its accent when the
    channel is filtered (rows suppressed), matching the former
    `.action-cluster-presence-toggle` treatment. `flex: none` on the row is not

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59031,3 +59031,135 @@ assertion: 30 s throttle + one rung (~5 s) for `:failing`, and for the
 `[dead, dead, live]` ring 2×30 s + a 5 s rung + a 10 s rung + registration
 before `:connected` returns. The polls are condition-based, not sleeps; the
 numbers are the ladder's, not a safety margin.
+<!-- entry #682 -->
+
+---
+
+## 2026-08-23 — #682: internet radio, and the CORS answer that turned out not to be the question
+
+Wollino asked for an internet-radio player in cicchetto and vjt decided the
+shape in channel: station picker reachable from the RailActions drawer,
+station chrome in the right rail, and the transport staying where it already
+is. Most of the machinery existed — `audioPlayer.ts` (#115) is a one-instance
+store and `AudioMiniPlayer` is a docked, persistent transport, so a station is
+just another href. What this entry records is the three places the obvious
+design was wrong.
+
+### The CORS measurement was necessary and not sufficient
+
+The issue named cross-origin access to `somafm.com/channels.json` as an open
+question, so it was measured first: the catalogue answers
+`Access-Control-Allow-Origin: *`, 46 channels, and so do the `.pls` playlists
+it points at. On that reading a live catalogue was the better design — richer,
+self-updating, and carrying `lastPlaying` as a free partial answer to the
+now-playing question.
+
+That reading was wrong, because the blocking party is not SomaFM. It is our
+own CSP. `GrappaWeb.Plugs.SecurityHeaders` admits `connect-src 'self'` plus
+three named third parties, and a `fetch` to somafm.com is not among them —
+nor is the `.pls` fetch that would resolve a stream URL. Widening it is a
+server change and a security-surface decision, so the first cut ships the
+list as data instead.
+
+Two directives needed no change at all, and they are the reason this works
+without touching the server: `media-src 'self' blob: https:` already admits
+the `<audio>` stream, widened by #607 for this very mini-player, and
+`img-src 'self' data: https:` already admits the station logos (#1240),
+because an `<img>` is governed by `img-src` and not by `connect-src`.
+
+**The general rule, which is what makes this worth recording:** for a
+third-party subresource, CORS answers whether THEY will serve us and the CSP
+answers whether WE will fetch it, and the second question is the one a client
+change can fail on its own. Measuring only the first produces a design that
+looks funded and is not.
+
+### The fragility objection to a baked-in list was refuted by measurement
+
+The argument against hardcoding stream URLs was concrete: a channel's `.pls`
+lists three rotating hosts (`ice2`, `ice5`, `ice6`), so a table pins a pool
+member and rots. Measured, that is false. The UNNUMBERED `ice.somafm.com`
+also answers, serving `audio/mpeg` with the channel's `icy-name` — it is the
+stable front door and the numbered hosts are the pool behind it. All fourteen
+curated entries were fetched through it and returned real MPEG audio, and the
+versionless logo URLs were checked the same way (the catalogue spells them
+with a `?v=` cache-buster that would rot).
+
+The lesson is pinned where it will actually be broken: adding a station by
+pasting a URL out of a `.pls` is the natural way to do it, and a test now
+fails any somafm host that is not the unnumbered one. Scoped to somafm hosts
+deliberately — the table is allowed to hold another provider.
+
+### A source with no end is a transport bug, not a radio feature
+
+`AudioMiniPlayer` was written for a file: a position slider and a `cur / dur`
+read, both meaningless against an endless stream. Live mode is DERIVED from
+the element's own `duration` rather than flagged by the caller, so it is
+right for any endless source and cannot drift from the element's truth. The
+predicate is "not a finite number", not "=== Infinity", because NaN means the
+element cannot state a length and seeking is exactly as meaningless. The
+initial value is `0` — finite — so a source whose metadata has not arrived
+keeps the file chrome instead of flashing a badge at every upload.
+
+In live mode the slider is replaced by a LABEL, not by a disabled slider: a
+greyed-out position bar still draws a scale and there is no scale. The
+download anchor is gated off for two independent reasons, either sufficient —
+the resource has no end, and `download` is ignored outright on a cross-origin
+href, so the anchor would navigate the operator out of the app.
+
+### Where the pieces live, and why the split is forced
+
+`playAudio` grew a REQUIRED label parameter carrying the source's name, riding
+with the href so the two swap atomically (a sibling signal lets a station's
+name outlive the source it named for one render, captioning the next upload).
+It exists because on mobile `.shell-members` is `position: fixed` with
+`transform: translateX(100%)`: a transport living in the rail is UNREACHABLE
+on a phone while it plays. So the rail gets picking and identity, the docked
+bar keeps the controls, and the label is the phone's only answer to "what am
+I listening to".
+
+`RailRadio` is NOT an arm of `RailContext` — that grafts by the active
+window's KIND and would drop the panel on switching to a query. It mounts
+unconditionally inside `.shell-members` from both branches of Shell's
+`isMobile()` split, like `RailActions`.
+
+The tuned station is DERIVED from `activeAudio()`, not stored. One `<audio>`
+means a clicked audio link swaps the source out from under the station; a
+stored flag would keep claiming the station is playing, and the derivation
+also inherits the close button and the identity-rotation reset for free.
+
+### The picker overlays the rail instead of copying the popover that bled
+
+`.rail-actions-menu` anchors at `bottom: 100%` of a bottom-pinned launcher,
+and that geometry is precisely what made #588 (cap by the space ABOVE, not
+the viewport) and #913 (that space is measured from the PHYSICAL top under
+`viewport-fit=cover`) necessary. The picker instead sits `position: absolute;
+inset: 0` against `.shell-members`, which is already relative for the resize
+handle and already carries #500's `min-height: 0`: its height IS the rail, so
+CSS bounds it with no JS measurement to get wrong. #913's descendant
+`touch-action` carve-out IS kept — that one is about which element iOS elects
+as the gesture consumer, and applies unchanged.
+
+#500's vertical budget holds by construction: idle the component renders
+nothing and has no height; the station chrome appears only once the operator
+tunes something and takes its row off the scrolling `.members-pane`, never
+off the floored actions drawer.
+
+Picking does not close the picker, following the rule `RailActions` already
+states for `denoise`: a launcher that NAVIGATES away is single-shot, a control
+the operator flips in place is not. The launcher itself DOES close the actions
+menu, for the opposite reason — the picker takes over the same column.
+
+### Left open, deliberately
+
+Now-playing metadata is out: ICY titles are not exposed to `<audio>`, and
+`lastPlaying` died with the catalogue fetch. A user-editable list is out: that
+is user state and wants `displayPrefs` treatment (server-backed + synced,
+#449) rather than a localStorage list that dies per device. `mediaLink.ts`
+still classifies audio by file EXTENSION and so does not recognise an
+extensionless Icecast endpoint — irrelevant to the rail picker, and it only
+starts to matter if stations may arrive as pasted links. Nothing is persisted
+across reload, which is also why no resume affordance was needed: browsers
+block autoplay without a gesture, and a rail click is one.
+
+Widening `connect-src` for the live catalogue is left as a NON-blocking note
+for vjt rather than taken here.


### PR DESCRIPTION
Internet radio in cicchetto (#682): a station picker in the RailActions drawer, station chrome in the right rail, and the existing docked player as the transport.

cic-only — no server change. Baseline `origin/main` `e935a83a`.

## The measurement that reversed the design

The issue named cross-origin access to SomaFM's catalogue as an open question, so it was measured first, and it came back permissive: `somafm.com/channels.json` answers `Access-Control-Allow-Origin: *` (46 channels), and so do the `.pls` playlists it points at. On that reading a live catalogue was the better design.

That reading was wrong, because the blocking party is not SomaFM — it is **our own CSP**. `GrappaWeb.Plugs.SecurityHeaders` admits `connect-src 'self'` plus three named third parties, and somafm.com is not among them. Both the catalogue and the `.pls` are `fetch`es, so both fall at that door. Widening `connect-src` is a server change and a security-surface decision, and is **not** taken here.

Two directives needed no change at all, which is why this works without touching the server:

| directive | value | consequence |
|---|---|---|
| `media-src` | `'self' blob: https:` | the `<audio>` stream is admitted — #607 widened it for this very mini-player |
| `img-src` | `'self' data: https:` | station logos are admitted (#1240); an `<img>` is governed by `img-src`, not `connect-src` |
| `connect-src` | `'self'` + 3 named hosts | a `fetch` to somafm.com is blocked |

The general rule, recorded in DESIGN_NOTES: **CORS answers whether they will serve us; the CSP answers whether we will fetch it — and only the second is something a client-side change can fail on its own.**

## An objection of mine, refuted by measurement

I argued against baking stream URLs in, because a channel's `.pls` lists three rotating hosts (`ice2` / `ice5` / `ice6`). Measured, that is false: the **unnumbered** `ice.somafm.com` also answers, serving `audio/mpeg` with the channel's `icy-name`. It is the stable front door; the numbered hosts are the pool behind it. All fourteen curated entries were fetched through it and returned real MPEG audio, and the versionless logo URLs were checked the same way (the catalogue spells them with a `?v=` cache-buster that would rot).

The lesson is pinned by a test at the point where it will actually be broken: adding a station by pasting a URL out of a `.pls` is the natural way to do it, and the gate now rejects any somafm host that is not the unnumbered one. Scoped to somafm hosts deliberately — the table may hold another provider.

## What changed

- **A source with no end is a transport bug, not a radio feature.** `AudioMiniPlayer` rendered a position slider and a `cur / dur` read, both meaningless against an endless stream. Live mode is **derived** from the element's own `duration`, not flagged by the caller, so it is right for any endless source and cannot drift from the element's truth. The predicate is "not a finite number" rather than `=== Infinity`, because NaN means the element cannot state a length and seeking is exactly as meaningless. In live mode the slider becomes a **label** (a greyed-out bar still draws a scale, and there is no scale) and the download anchor is gated off — the resource has no end, and `download` is ignored outright on a cross-origin href.
- **`playAudio` grew a required label parameter**, riding with the href so the two swap atomically. It exists because on mobile `.shell-members` is `position: fixed` with `translateX(100%)`: a transport living in the rail is unreachable on a phone while it plays, so the docked bar is the only surface naming the station.
- **`RailRadio` is not an arm of `RailContext`** — that grafts by the active window's KIND and would drop the panel on switching to a query. It mounts unconditionally inside `.shell-members` from both branches of Shell's `isMobile()` split.
- **The tuned station is derived from `activeAudio()`, not stored.** One `<audio>` means a clicked audio link swaps the source out from under the station; a stored flag would keep claiming the station is playing. The derivation inherits the close button and the identity-rotation reset for free.
- **The picker overlays the whole rail** (`position: absolute; inset: 0`) instead of copying `.rail-actions-menu`. Anchoring at `bottom: 100%` of a bottom-pinned launcher is exactly what made #588 and #913 necessary; an inset-0 overlay's height *is* the rail, so CSS bounds it with no JS measurement to get wrong. #913's descendant `touch-action` carve-out is kept — that one is about which element iOS elects as the gesture consumer.
- **#500's vertical budget holds by construction**: idle the component renders nothing and has no height; the station chrome appears only once a station is tuned and takes its row off the scrolling `.members-pane`, never off the floored actions drawer.
- **Close-on-outside-click got one owner** before gaining a second user, rather than being pasted with tweaks.

## Tests

`304 files / 5904 tests` green, up from the `301 / 5870` baseline. Every new behaviour was checked with a mutation bench rather than trusted for being green:

| mutant | result |
|---|---|
| `live()` predicate inverted | 6 failed / 5 passed |
| label gate widened to any active source | 2 failed / 9 passed |
| `tunedStation` ignores the href | 2 failed / 8 passed |
| extracted dismiss verb: `contains()` inverted | 1 failed / 57 passed |
| a station pinned to `ice5` instead of the front door | 1 failed / 4 passed |

The e2e spec drives the real door (rail drawer → radio launcher → picker → station row) and asserts outcomes: the station's stream URL is on the `<audio>` element, the browser **issued** the request for it, the docked transport carries the station's name, the rail chrome names it, and the picked row is marked. Stream and logos are served by `page.route` from local bytes, so no third-party host is reached and a station outage cannot turn it red.

**One thing the e2e deliberately does not assert, and why.** Live mode keys off a non-finite media `duration`, and `route.fulfill` must serve a complete — therefore finite — body, so any stream the spec can serve deterministically takes the file branch. Reaching a genuinely endless Icecast host would reintroduce exactly the external dependency the spec is built without. Live mode is pinned in `AudioMiniPlayer.test.tsx`, which drives `duration` (Infinity and NaN) straight onto the element. Softening the e2e assertion into something a finite body could satisfy would have produced a green that proves the opposite of what it claims.

## Deliberately out

Now-playing metadata (ICY titles are not exposed to `<audio>`, and `lastPlaying` died with the catalogue fetch); a user-editable list (user state, wants `displayPrefs` treatment — server-backed + synced, #449 — not a localStorage list that dies per device); `mediaLink.ts`'s extension-only audio classification, which does not recognise an extensionless Icecast endpoint and only matters if stations may arrive as pasted links; and cross-reload persistence, which is also why no resume affordance was needed — browsers block autoplay without a gesture, and a rail click is one.

Widening `connect-src` for the live catalogue is left as a non-blocking note rather than taken here.
