### PR TITLE
#1675 — a fourth connection_state, because `connected` was reporting the spawn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,9 +520,35 @@ not the surrounding code.**
   a row STILL reading `:connected` whose process is already in
   `terminate/2`, because `Networks.disconnect/2` and `mark_failed/2`
   both stop the session BEFORE writing the transition. The closed set
-  is `[:connected, :parked, :failed]` — there is no `:disconnected`
-  state (the `:disconnected` in `session_log_events` is a lifecycle
-  EVENT, a different axis).
+  is `[:connected, :parked, :failing, :failed]` (#1675) — there is no
+  `:disconnected` state (the `:disconnected` in `session_log_events` is
+  a lifecycle EVENT, a different axis).
+  **🔴 `:connected` means REGISTERED UPSTREAM, not "a session process is
+  alive" (#1675).** Until then it meant the latter, and that is exactly
+  the lie: `Networks.connect/1` writes `:connected` on SPAWN success (the
+  U-0 ordering, correct as far as it goes — see #642), and three prod
+  networks that never completed registration read `connected` for hours
+  because nothing walked the row back. `:failing` is that missing state —
+  "the session process is alive and the reconnect backoff is running, but
+  the upstream link is not registered" — written by the NON-terminal
+  `Networks.mark_failing/2` with the actual cause in
+  `connection_state_reason` (`IRC.Client.describe_connect_failure/1`, never
+  a category label), reversed by `mark_registered/1` on 001 RPL_WELCOME,
+  and reached from `Session.Server` only through the injected
+  `link_state_reporter` closure → `Networks.report_link_state/3` (the ONE
+  subject-polymorphic door; the drift has no subject branch, so visitors
+  are in scope by construction). `:failed` stays TERMINAL and unchanged:
+  `mark_failed/2` stops the session BEFORE the transition, so a
+  `:failed → :connected` edge on 001 can never fire — which is WHY this is
+  a fourth value and not a reason string on `:failed`. Boot resumes
+  `:failing` and still skips `:failed`
+  (`Credentials.list_credentials_for_all_users/0`), else a reboot inside a
+  backoff window drops the network permanently. **Known gap, not a bug to
+  rediscover:** a socket that CONNECTS but never registers (blocked rDNS,
+  ident hang) emits no `irc_connect_failed`, so it still reads
+  `:connected` — there is no registration watchdog, deliberately. A new
+  reader of `connection_state` MUST decide which fact it wants and say so;
+  a liveness check is `Grappa.Session.whereis/2`, not this column.
   `AdminSessionsTab` surfaces BOTH columns and shows an explicit
   `null` when the live pid is gone — diagnostic value beats false
   uniformity. When adding a new admin listing, return both

--- a/cicchetto/e2e/tests/issue1675-failing-link-state.spec.ts
+++ b/cicchetto/e2e/tests/issue1675-failing-link-state.spec.ts
@@ -40,10 +40,40 @@
 //      not a park→connect cycle (which would re-write `:connected` from
 //      `Networks.connect/1` before any registration and assert nothing).
 //
-// The two dead leaves in test 2 are not padding: the ladder is 5s then 10s
-// (`config/config.exs` `session_backoff`, base 5_000 — dev is what the e2e
-// stack boots), so they buy a ~15s window in which the row is observably
-// `:failing` rather than the ~5s a single dead leaf would leave.
+// The two dead leaves in test 2 are not padding — see the ladder below.
+//
+// 🔴 THE LADDER, AND WHY THE BUDGETS ARE WHAT THEY ARE. These numbers are
+// measured, not padding, and the first run of this spec was red for exactly
+// this reason (polled 20s, needed ~35s).
+//
+// The FIRST connect failure never marks the row. Every operator-initiated
+// connect spawns BEFORE it writes `:connected` (`resolve → spawn →
+// Networks.connect/1`, which is #642's cure), so the row still reads
+// `:parked` when an instantly-refusing upstream reports back, and
+// `mark_failing/2` rejects `:parked` by design. Measured on the integration
+// stack 2026-08-22 — `credential_bound` at 21:49:35.464, `report_link_state:
+// {:failing, "connection refused"} declined (user_parked)` at .466, two
+// milliseconds later. See `Networks.mark_failing/2`'s "KNOWN HOLE" section
+// and DESIGN_NOTES 2026-08-22 #1675; it is a real bounded window, not a test
+// artefact, and it is deliberately NOT cured in this slice.
+//
+// So the row can only reach `:failing` on attempt 2, which lands at
+// `@connect_failure_sleep_ms` (30_000, `config/config.exs`; the e2e stack
+// boots MIX_ENV=dev) + one backoff rung (5_000 ±25% jitter,
+// `:session_backoff`) ≈ 35s. Test 2's ring then needs one more full rung
+// before the live leaf: 2×30s + a 5s rung + a 10s rung + registration ≈ 95s.
+//
+// Shrinking the throttle in `config/dev.exs` was considered FIRST (the house
+// rule is deterministic setup over a raised timeout, and #671 already does
+// exactly that for the auto-away debounce) and declined on two grounds: it
+// changes the retry cadence of every session in a 760-test suite to save 30s
+// in one spec, and it would not buy determinism anyway — the wait exists
+// because of the `:parked` window, not because of the throttle. There is no
+// operator verb that provokes a connect failure on a row that is ALREADY
+// `:connected`, so the wait cannot be removed from the test side.
+//
+// The polls below are therefore condition-based (poll until the state, never
+// sleep-then-assert) with ceilings taken from that ladder.
 //
 // NOT COVERED HERE, deliberately: the reboot arm of the ruling (a
 // `:failing` row is resumed by Bootstrap, not skipped). Restarting the
@@ -199,9 +229,9 @@ function ephemeralNames(tag: string): { slug: string; nick: string } {
 test("#1675 — a network whose upstream refuses every connect reads `failing`, and cic names the cause", async ({
   page,
 }) => {
-  // Bind + first failed attempt (~instant) + shell boot, with margin for a
-  // loaded testnet.
-  test.setTimeout(60_000);
+  // ~35s to attempt 2 (the first one is eaten — see the ladder above), then
+  // the shell boot, with margin for a loaded testnet.
+  test.setTimeout(180_000);
 
   const admin = getSeededAdmin();
   const adminUserId = userIdFromSubject(admin.subjectJson);
@@ -214,12 +244,14 @@ test("#1675 — a network whose upstream refuses every connect reads `failing`, 
     await bindCredential(admin.token, adminUserId, networkId, nick);
 
     // The row of record. One dead leaf means every rung of the ladder
-    // refuses, so this state is stable, not a flash.
+    // refuses, so once it arrives this state is stable, not a flash — but
+    // it arrives on attempt 2, at 30s throttle + a ~5s rung. 75s is that
+    // ladder with the jitter, not a safety margin.
     const failing = await waitForNetworkRow(
       admin.token,
       slug,
       (r) => r.connection_state === "failing",
-      20_000,
+      75_000,
       "failing",
     );
 
@@ -252,9 +284,10 @@ test("#1675 — a network whose upstream refuses every connect reads `failing`, 
 });
 
 test("#1675 — a failing row returns to `connected` with the reason cleared once a leaf registers", async () => {
-  // Two dead rungs (5s + 10s of backoff) then the live leaf's connect +
-  // registration, with margin for jitter and a loaded ircd.
-  test.setTimeout(150_000);
+  // Attempt 1 marks `:failing` at ~35s, attempt 2 reaches the live leaf at
+  // ~80s (2×30s throttle + a 5s and a 10s rung), then registration. ~95s of
+  // ladder; the ceiling carries the jitter and a loaded ircd.
+  test.setTimeout(300_000);
 
   const admin = getSeededAdmin();
   const adminUserId = userIdFromSubject(admin.subjectJson);
@@ -268,11 +301,14 @@ test("#1675 — a failing row returns to `connected` with the reason cleared onc
     await addServer(admin.token, networkId, LIVE_HOST, LIVE_PORT, 2);
     await bindCredential(admin.token, adminUserId, networkId, nick);
 
+    // Attempt 1 (attempt 0's failure is eaten by the `:parked` window) hits
+    // the SECOND dead leaf while the row already reads `:connected`, so this
+    // is where `:failing` is finally written. ~35s of ladder.
     const failing = await waitForNetworkRow(
       admin.token,
       slug,
       (r) => r.connection_state === "failing",
-      20_000,
+      75_000,
       "failing",
     );
     expect(failing.connection_state_reason ?? "").toMatch(/connection refused/i);
@@ -286,7 +322,7 @@ test("#1675 — a failing row returns to `connected` with the reason cleared onc
       admin.token,
       slug,
       (r) => r.connection_state === "connected" && r.connection?.registered === true,
-      120_000,
+      180_000,
       "connected + registered",
     );
     expect(recovered.connection_state_reason).toBeNull();

--- a/cicchetto/e2e/tests/issue1675-failing-link-state.spec.ts
+++ b/cicchetto/e2e/tests/issue1675-failing-link-state.spec.ts
@@ -103,11 +103,17 @@ const DEAD_PORT_B = 2;
 const LIVE_HOST = "bahamut-test2";
 const LIVE_PORT = 6667;
 
+// Deliberately NARROW — the wire carries more, and these tests read exactly
+// this. `connection` is the LIVE projection: null when there is no session or
+// no peer. `registered` is on that wire and is NOT declared here on purpose:
+// it is the #388 NickServ IDENTIFIED verdict, not an IRC-registration
+// witness, and leaving it out of the type keeps the next reader from
+// reaching for it the way this spec once did.
 type NetworkRow = {
   slug: string;
   connection_state: string;
   connection_state_reason: string | null;
-  connection: { registered: boolean } | null;
+  connection: { port: number } | null;
 };
 
 function userIdFromSubject(subjectJson: string): string {
@@ -261,8 +267,13 @@ test("#1675 — a network whose upstream refuses every connect reads `failing`, 
     expect(reason).not.toBe("");
     expect(reason).toMatch(/connection refused/i);
 
-    // Pre-state for the sibling test's recovery oracle: nothing registered.
-    expect(failing.connection?.registered ?? false).toBe(false);
+    // The pre-state that IS the issue: a row that names a state, with no
+    // live link behind it. `connection` is the live projection and it is
+    // null here — either the session is between rungs of the backoff
+    // ladder, or it is up with no peer; both answer `no_peer`/`no_session`.
+    // (NOT asserted via `connection.registered`: that field is the #388
+    // NickServ IDENTIFIED verdict, not an IRC-registration witness.)
+    expect(failing.connection).toBeNull();
 
     // …and now the half an API assertion cannot discharge. Log in and read
     // the row the way the operator does.
@@ -313,19 +324,39 @@ test("#1675 — a failing row returns to `connected` with the reason cleared onc
     );
     expect(failing.connection_state_reason ?? "").toMatch(/connection refused/i);
 
-    // `registered === true` is the load-bearing conjunct. `:connected`
-    // alone would be a vacuous oracle — `Networks.connect/1` writes it on
-    // spawn success — whereas the live `connection` projection only reports
-    // registered once 001 RPL_WELCOME landed, which is the event
-    // `mark_registered/1` hangs off.
+    // 🔴 THE ORACLE, and why it is not vacuous — this cost a full-suite run
+    // to get right, so the reasoning is written down rather than trusted.
+    //
+    // `connection_state === "connected"` on its OWN would be vacuous:
+    // `Networks.connect/1` writes exactly that on spawn success. But the
+    // poll above has ALREADY observed `failing`, and from `:failing` the
+    // only writer that reaches `connected` with a NULL reason is
+    // `Networks.mark_registered/1` — `connect/1` from `:failing` is a
+    // measured NO-OP (`when state in [:connected, :failing]` returns the
+    // credential untouched: no transition, no broadcast), and this test
+    // issues neither a park nor a connect PATCH. `mark_registered/1`'s only
+    // caller is the 001 RPL_WELCOME arm of `Session.Server`. So the
+    // SEQUENCE failing → connected+null IS the proof of registration; no
+    // single-state assertion could be.
+    //
+    // What is NOT the witness, measured the hard way: the live projection's
+    // `connection.registered`. Despite the name it is
+    // `IdentityState.identified?/1` — the #388 NickServ IDENTIFIED verdict,
+    // not "registered with the ircd". This credential is `auth_method:
+    // none` with no services account, so that field is `false` forever and
+    // asserting it hung this test for 180s against a link that had
+    // registered perfectly.
     const recovered = await waitForNetworkRow(
       admin.token,
       slug,
-      (r) => r.connection_state === "connected" && r.connection?.registered === true,
+      (r) => r.connection_state === "connected" && r.connection_state_reason === null,
       180_000,
-      "connected + registered",
+      "connected with the reason cleared",
     );
-    expect(recovered.connection_state_reason).toBeNull();
+
+    // …and it is the LIVE leaf it came back on, not merely a row that says
+    // connected: the ring rotated off the two dead endpoints onto this one.
+    expect(recovered.connection?.port).toBe(LIVE_PORT);
 
     // The failure also had to reach the `$server` window — the issue's last
     // line, and the durable half: a row survives the recovery that cleared

--- a/cicchetto/e2e/tests/issue1675-failing-link-state.spec.ts
+++ b/cicchetto/e2e/tests/issue1675-failing-link-state.spec.ts
@@ -1,0 +1,309 @@
+// #1675 — `connection_state: "failing"`, the fourth state.
+//
+// The defect: `Networks.connect/1` writes `:connected` when the SPAWN
+// succeeds, and nothing walked the row back when the upstream TCP/TLS/
+// registration then failed. Three networks added on prod on 2026-08-22
+// showed as connected in cicchetto while none of them ever registered.
+// vjt's ruling made e2e coverage mandatory *because every part of it that
+// failed on prod failed BETWEEN the layers* — an API-only assertion does
+// not discharge the requirement, so the second half of test 1 asserts what
+// the operator actually sees.
+//
+// SUBJECT: `admin-vjt`, the ONE seeded user with no network bind
+// (compose.yaml: "admin-vjt has no bind"). Its HomePane therefore renders
+// exactly the ephemeral network these tests provision and nothing else, so
+// neither test can disturb — or be disturbed by — the seeded sessions every
+// other spec depends on. The seeded networks are load-bearing and are never
+// touched here (same discipline as admin-network-crud.spec.ts).
+//
+// DRIVER: a `network_servers` row pointed at a CLOSED port. `connect/2`
+// returns `:econnrefused` immediately, `Session.Server`'s
+// `{:irc_connect_failed, _}` arm reports `{:failing, "connection refused"}`
+// through the injected `link_state_reporter`, and the row lands on
+// `:failing` with the cause in `connection_state_reason`. Deterministic and
+// instant — unlike the three real prod causes (a TLS hostname mismatch, an
+// A-only host against a v6 source, a 30s connect timeout), which the
+// harness cannot reproduce without a second ircd and a wall-clock wait.
+//
+// WHY TWO TESTS. The two halves of the ruling want opposite topologies:
+//
+//   1. `:failing` + the cic display want a PERMANENT failing row — one
+//      dead server, so every attempt on the backoff ladder fails and the
+//      state is stable for as long as the assertions take.
+//   2. The recovery edge wants the row to LEAVE `:failing` on its own.
+//      `SessionPlan`'s `refresh_plan` closure re-resolves the endpoint at
+//      `Backoff.failure_count` on every `:transient` respawn, and
+//      `Servers.pick_server!/2` indexes the enabled ring by that ordinal
+//      (`rem(attempt, length(ring))`) — so a ring of [dead, dead, live]
+//      walks itself onto the live leaf at attempt 2 and registers. That is
+//      the REAL `mark_failing → mark_registered` pair on one credential,
+//      not a park→connect cycle (which would re-write `:connected` from
+//      `Networks.connect/1` before any registration and assert nothing).
+//
+// The two dead leaves in test 2 are not padding: the ladder is 5s then 10s
+// (`config/config.exs` `session_backoff`, base 5_000 — dev is what the e2e
+// stack boots), so they buy a ~15s window in which the row is observably
+// `:failing` rather than the ~5s a single dead leaf would leave.
+//
+// NOT COVERED HERE, deliberately: the reboot arm of the ruling (a
+// `:failing` row is resumed by Bootstrap, not skipped). Restarting the
+// container mid-suite is heavy and flaky; that arm runs the real
+// `Bootstrap.run/0` against a real socket in
+// `test/grappa/bootstrap_test.exs` ("#1675 — resumes a :failing
+// credential").
+
+import { adminLogin } from "../fixtures/cicchettoPage";
+import { fetchAllMessagesAsc, GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// Loopback + a port nothing can be listening on: connect(2) from inside the
+// grappa container returns ECONNREFUSED with no DNS lookup, no route, and no
+// wait. Ports 1 and 2 are unbindable without privileges, which is exactly
+// why they are safe to dial.
+const DEAD_HOST = "127.0.0.1";
+const DEAD_PORT_A = 1;
+const DEAD_PORT_B = 2;
+
+// The recovery leaf. `solanum-test2` (aliased `bahamut-test2`) rather than
+// the main `bahamut-test`: the latter serves every seeded session from the
+// same container IP and has a per-IP clone posture the suite already trips
+// over. This ircd carries only the azzurra2 seed, so one more registration
+// costs nothing anybody else is waiting on.
+const LIVE_HOST = "bahamut-test2";
+const LIVE_PORT = 6667;
+
+type NetworkRow = {
+  slug: string;
+  connection_state: string;
+  connection_state_reason: string | null;
+  connection: { registered: boolean } | null;
+};
+
+function userIdFromSubject(subjectJson: string): string {
+  const subj = JSON.parse(subjectJson) as { kind: string; id: string };
+  return subj.id;
+}
+
+async function createNetwork(token: string, slug: string): Promise<number> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ slug }),
+  });
+  if (!res.ok) throw new Error(`createNetwork: ${slug} → ${res.status} ${await res.text()}`);
+  const body = (await res.json()) as { id: number };
+  return body.id;
+}
+
+async function addServer(
+  token: string,
+  networkId: number,
+  host: string,
+  port: number,
+  priority: number,
+): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}/servers`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ host, port, tls: false, priority }),
+  });
+  if (!res.ok) {
+    throw new Error(`addServer: ${host}:${port} → ${res.status} ${await res.text()}`);
+  }
+}
+
+// The bind is also the SPAWN (#1163 wired the admin bind dial through
+// `Operator.connect_credential/1`), so this call is what starts the doomed
+// connect attempt — there is no separate PATCH to make.
+async function bindCredential(
+  token: string,
+  userId: string,
+  networkId: number,
+  nick: string,
+): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/credentials`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ user_id: userId, network_id: networkId, nick, auth_method: "none" }),
+  });
+  if (!res.ok) throw new Error(`bindCredential: ${nick} → ${res.status} ${await res.text()}`);
+}
+
+async function unbindCredentialBestEffort(
+  token: string,
+  userId: string,
+  networkId: number,
+): Promise<void> {
+  try {
+    await fetch(`${GRAPPA_BASE_URL}/admin/credentials/${userId}/${networkId}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+async function deleteNetworkBestEffort(token: string, networkId: number): Promise<void> {
+  try {
+    await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+// `GET /networks` is the row cic itself reads (`Networks.Wire
+// .network_with_nick_to_json/4`): `connection_state`,
+// `connection_state_reason` and the LIVE `connection` projection in one
+// shape. Polling it rather than the admin listing keeps the oracle on the
+// same door the UI uses.
+async function fetchNetworkRow(token: string, slug: string): Promise<NetworkRow | undefined> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/networks`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return undefined;
+  const rows = (await res.json()) as NetworkRow[];
+  return rows.find((r) => r.slug === slug);
+}
+
+async function waitForNetworkRow(
+  token: string,
+  slug: string,
+  predicate: (row: NetworkRow) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<NetworkRow> {
+  const deadline = Date.now() + timeoutMs;
+  let last: NetworkRow | undefined;
+  while (Date.now() < deadline) {
+    last = await fetchNetworkRow(token, slug).catch(() => undefined);
+    if (last !== undefined && predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(
+    `waitForNetworkRow: ${slug} never reached "${label}" in ${timeoutMs}ms — last row ${JSON.stringify(last)}`,
+  );
+}
+
+// Unique per invocation so the spec survives `--repeat-each` and so a
+// leftover row from a crashed run can never be mistaken for this one's.
+function ephemeralNames(tag: string): { slug: string; nick: string } {
+  const stamp = Date.now();
+  return { slug: `e2e1675-${tag}-${stamp}`, nick: `f${stamp % 1_000_000}` };
+}
+
+test("#1675 — a network whose upstream refuses every connect reads `failing`, and cic names the cause", async ({
+  page,
+}) => {
+  // Bind + first failed attempt (~instant) + shell boot, with margin for a
+  // loaded testnet.
+  test.setTimeout(60_000);
+
+  const admin = getSeededAdmin();
+  const adminUserId = userIdFromSubject(admin.subjectJson);
+  const { slug, nick } = ephemeralNames("dead");
+  let networkId: number | null = null;
+
+  try {
+    networkId = await createNetwork(admin.token, slug);
+    await addServer(admin.token, networkId, DEAD_HOST, DEAD_PORT_A, 0);
+    await bindCredential(admin.token, adminUserId, networkId, nick);
+
+    // The row of record. One dead leaf means every rung of the ladder
+    // refuses, so this state is stable, not a flash.
+    const failing = await waitForNetworkRow(
+      admin.token,
+      slug,
+      (r) => r.connection_state === "failing",
+      20_000,
+      "failing",
+    );
+
+    // The reason is the half the operator had no way to see: it must be
+    // written AND it must name the actual cause, not a category label.
+    const reason = failing.connection_state_reason ?? "";
+    expect(reason).not.toBe("");
+    expect(reason).toMatch(/connection refused/i);
+
+    // Pre-state for the sibling test's recovery oracle: nothing registered.
+    expect(failing.connection?.registered ?? false).toBe(false);
+
+    // …and now the half an API assertion cannot discharge. Log in and read
+    // the row the way the operator does.
+    await adminLogin(page, admin);
+
+    const row = page.locator(".home-pane-network-row-failing", {
+      has: page.locator(".home-pane-network-slug", { hasText: slug }),
+    });
+    await expect(row).toHaveCount(1, { timeout: 15_000 });
+    await expect(row.locator(".home-pane-network-state")).toHaveText("failing");
+    // The SAME string the API returned — the display is not a paraphrase.
+    await expect(row.locator(".home-pane-network-reason")).toHaveText(reason);
+  } finally {
+    if (networkId !== null) {
+      await unbindCredentialBestEffort(admin.token, adminUserId, networkId);
+      await deleteNetworkBestEffort(admin.token, networkId);
+    }
+  }
+});
+
+test("#1675 — a failing row returns to `connected` with the reason cleared once a leaf registers", async () => {
+  // Two dead rungs (5s + 10s of backoff) then the live leaf's connect +
+  // registration, with margin for jitter and a loaded ircd.
+  test.setTimeout(150_000);
+
+  const admin = getSeededAdmin();
+  const adminUserId = userIdFromSubject(admin.subjectJson);
+  const { slug, nick } = ephemeralNames("heal");
+  let networkId: number | null = null;
+
+  try {
+    networkId = await createNetwork(admin.token, slug);
+    await addServer(admin.token, networkId, DEAD_HOST, DEAD_PORT_A, 0);
+    await addServer(admin.token, networkId, DEAD_HOST, DEAD_PORT_B, 1);
+    await addServer(admin.token, networkId, LIVE_HOST, LIVE_PORT, 2);
+    await bindCredential(admin.token, adminUserId, networkId, nick);
+
+    const failing = await waitForNetworkRow(
+      admin.token,
+      slug,
+      (r) => r.connection_state === "failing",
+      20_000,
+      "failing",
+    );
+    expect(failing.connection_state_reason ?? "").toMatch(/connection refused/i);
+
+    // `registered === true` is the load-bearing conjunct. `:connected`
+    // alone would be a vacuous oracle — `Networks.connect/1` writes it on
+    // spawn success — whereas the live `connection` projection only reports
+    // registered once 001 RPL_WELCOME landed, which is the event
+    // `mark_registered/1` hangs off.
+    const recovered = await waitForNetworkRow(
+      admin.token,
+      slug,
+      (r) => r.connection_state === "connected" && r.connection?.registered === true,
+      120_000,
+      "connected + registered",
+    );
+    expect(recovered.connection_state_reason).toBeNull();
+
+    // The failure also had to reach the `$server` window — the issue's last
+    // line, and the durable half: a row survives the recovery that cleared
+    // `connection_state_reason`, so the operator can still see WHY the
+    // network was down after it came back.
+    const serverRows = await fetchAllMessagesAsc(admin.token, slug, "$server");
+    const causes = serverRows.filter((m) =>
+      /upstream connect failed: connection refused/.test(m.body ?? ""),
+    );
+    expect(causes.length).toBeGreaterThan(0);
+  } finally {
+    if (networkId !== null) {
+      await unbindCredentialBestEffort(admin.token, adminUserId, networkId);
+      await deleteNetworkBestEffort(admin.token, networkId);
+    }
+  }
+});

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -110,6 +110,12 @@ export type Props = {
 // it is not on screen while composing normally.
 const COUNTDOWN_FROM = 10;
 
+// #1675 — `failing` is deliberately NOT in this set. Greyed means "no
+// live session; the way back is a reconnect action", and a failing
+// network HAS one, retrying on its own — greying it would disable the
+// compose box on every network that blinks. The state is still visible:
+// HomePane routes anything that is not `connected` to the disconnected
+// row, which renders the word AND `connection_state_reason`.
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
 // #356 — how long a green success/notice stays up before self-clearing.

--- a/cicchetto/src/HomePane.tsx
+++ b/cicchetto/src/HomePane.tsx
@@ -437,6 +437,11 @@ const DisconnectedRow: Component<{ row: HomeRow }> = (props) => {
       classList={{
         "home-pane-network-row-parked": props.row.connection_state === "parked",
         "home-pane-network-row-failed": props.row.connection_state === "failed",
+        // #1675 — a `failing` network lands on this row by the same rule
+        // as the other two (anything that is not `connected`), so the
+        // state word and the reason render with no change; the modifier
+        // exists so it does not wear the styling of a state it is not.
+        "home-pane-network-row-failing": props.row.connection_state === "failing",
       }}
     >
       {/* #529 — same heading/separator shape as ConnectedRow: a horizontal

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -88,6 +88,12 @@ import WindowBadges from "./WindowBadges";
 //   per-window `:parked` events from `Session.Server.terminate/2`; cic
 //   derives the cascade from the network-level state.
 
+// #1675 — `failing` is deliberately NOT in this set. Greyed means "no
+// live session; the way back is a reconnect action", and a failing
+// network HAS one, retrying on its own — greying it would disable the
+// compose box on every network that blinks. The state is still visible:
+// HomePane routes anything that is not `connected` to the disconnected
+// row, which renders the word AND `connection_state_reason`.
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
 // #96 — a row's state, spoken. Every non-live sidebar row is rendered muted +

--- a/cicchetto/src/admin/connectionTone.ts
+++ b/cicchetto/src/admin/connectionTone.ts
@@ -24,6 +24,13 @@ import type { Tone } from "./AdminBadge";
 // danger.
 const BY_LABEL: Record<string, Tone> = {
   connected: "ok",
+  // #1675 — `failing` is danger and not warn, on the same
+  // meaning-not-severity reading: it is a genuine outage the operator
+  // may have to fix (a wrong endpoint, an unverifiable certificate),
+  // whereas `parked` is somebody choosing to pause. That the bouncer
+  // keeps retrying does not make it less broken, and pairing it with
+  // the deliberate pause would say it is.
+  failing: "danger",
   parked: "warn",
   failed: "danger",
   unknown: "neutral",

--- a/cicchetto/src/lib/__tests__/connectionStateEmoji.test.ts
+++ b/cicchetto/src/lib/__tests__/connectionStateEmoji.test.ts
@@ -5,8 +5,8 @@ import { connectionStateEmoji } from "../connectionStateEmoji";
 // ADMIN-LAYOUT-FIX (2026-07-12) — pure table test for the DB-canonical
 // `connection_state` → glyph map rendered in AdminVisitorsTab. Mirrors
 // the timeFormat.ts (#217) closed-set→value pattern: the closed set is
-// `Grappa.Networks.Credential.connection_state()` = :connected | :parked
-// | :failed (credential.ex:86), encoded over JSON as the string
+// `Grappa.Networks.Credential.connection_state()` = :connected |
+// :failing | :parked | :failed, encoded over JSON as the string
 // discriminator, plus a defensive `null`/unrecognised → ⚪ fallback (the
 // wire field is non-nullable per api.ts, so the null arm is belt-and-
 // braces, not a live signal). Every real state + the fallback maps to a
@@ -20,6 +20,10 @@ import { connectionStateEmoji } from "../connectionStateEmoji";
 // to the ⚪ fallback.
 const STATES: ReadonlyArray<[ConnectionState, string]> = [
   ["connected", "connected"],
+  // #1675 — the fourth value. `failing` and `failed` are different
+  // facts (retrying vs terminal) and the "DISTINCT glyph" case below is
+  // what keeps them from rendering as the same picture.
+  ["failing", "failing"],
   ["parked", "parked"],
   ["failed", "failed"],
 ];

--- a/cicchetto/src/lib/connectionStateEmoji.ts
+++ b/cicchetto/src/lib/connectionStateEmoji.ts
@@ -8,13 +8,16 @@ import type { ConnectionState } from "./api";
 // ## The closed set is the server's, not ours
 //
 // The states are `Grappa.Networks.Credential.connection_state()` =
-// `:connected | :parked | :failed` (credential.ex:86), encoded over JSON
-// as the string discriminator and typed in api.ts as `ConnectionState`.
-// There is NO `:disconnected` / `:connecting` / `:reconnecting` at the DB
-// level — those transient runtime sub-states live in Session.Server
-// GenServer state and never reach this wire field (credential.ex:72-79).
-// So the map keys are EXACTLY the three real values; anything else
-// degrades to the neutral ⚪ fallback — visibly, never a throw. Note
+// `:connected | :failing | :parked | :failed`, encoded over JSON as the
+// string discriminator and typed in api.ts as `ConnectionState` (a
+// re-export of the GENERATED union, so the server's set is the only
+// source and this map is exhaustive by tsc rather than by vigilance).
+// There is still NO `:disconnected` / `:connecting` at the DB level —
+// those transient runtime sub-states live in Session.Server GenServer
+// state and reach cic as the #100 `connection_progress` overlay, never
+// as this wire field. So the map keys are EXACTLY the four real values;
+// anything else degrades to the neutral ⚪ fallback — visibly, never a
+// throw. Note
 // `AdminVisitorNetwork.connection_state` is NON-nullable (api.ts), so the
 // `null` arm below is defensive only; the U-0 honesty signal is carried by
 // `net.live_state` (nullable), a SEPARATE field the LiveBadge renders.
@@ -39,11 +42,17 @@ export type ConnectionStateGlyph = {
   label: string;
 };
 
-// 🟢 connected — live binding (or continuous reconnect/backoff).
+// 🟢 connected — registered upstream (001 RPL_WELCOME seen).
+// ⚠️  failing   — #1675: the session is alive and retrying, but the link
+//                is NOT registered (refused / timed out / TLS unusable).
+//                Distinct from 🔴: this one is coming back on its own if
+//                the upstream lets it, and the row carries the cause in
+//                `connection_state_reason`.
 // ⏸️  parked    — user-driven /disconnect or /quit; paused, not an error.
 // 🔴 failed     — server-set permanent error (k-line 465 / SASL 904/906).
 const GLYPHS: Record<ConnectionState, ConnectionStateGlyph> = {
   connected: { glyph: "🟢", label: "connected" },
+  failing: { glyph: "⚠️", label: "failing" },
   parked: { glyph: "⏸️", label: "parked" },
   failed: { glyph: "🔴", label: "failed" },
 };

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -39,7 +39,12 @@ export type LiveIntrospectionSessionEntryDegradedField =
 
 export type NetworksCredentialAuthMethod = IRCAuthFSMAuthMethod;
 
-export const NETWORKS_CREDENTIAL_CONNECTION_STATE = ["connected", "parked", "failed"] as const;
+export const NETWORKS_CREDENTIAL_CONNECTION_STATE = [
+  "connected",
+  "failing",
+  "parked",
+  "failed",
+] as const;
 export type NetworksCredentialConnectionState =
   (typeof NETWORKS_CREDENTIAL_CONNECTION_STATE)[number];
 
@@ -85,6 +90,7 @@ export const SCROLLBACK_META_TKEY = [
   "notice_target",
   "statusmsg",
   "nick_fallback",
+  "link_failure",
 ] as const;
 export type ScrollbackMetaTKey = (typeof SCROLLBACK_META_TKEY)[number];
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -12151,7 +12151,16 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   color: #d04040;
 }
 
+/* #1675 — `failing` is an outage in progress: amber, not the terminal
+   red of `failed` and not the muted grey of a deliberate park. The row
+   below it carries `connection_state_reason`, which is the actual
+   diagnosis and the half the operator had no way to see. */
+.home-pane-network-row-failing .home-pane-network-state {
+  color: #d08a20;
+}
+
 .home-pane-network-row-parked .home-pane-network-title-static,
+.home-pane-network-row-failing .home-pane-network-title-static,
 .home-pane-network-row-failed .home-pane-network-title-static {
   opacity: 0.85;
 }

--- a/config/config.exs
+++ b/config/config.exs
@@ -470,6 +470,11 @@ config :logger, :console,
     # sync test even though no Logger call carries it today.
     :statusmsg,
     :nick_fallback,
+    # #1675 — the upstream-connect failure carried structured on the
+    # `$server` row (the human spelling is the body). In the allowlist to
+    # satisfy the known_keys↔metadata sync test even though no Logger
+    # call carries it today.
+    :link_failure,
     # Auth context (Phase 2): bearer-token session lifecycle. `session_ref`
     # is a non-reversible SHA-256 handle of the session-id (S9: the raw id
     # IS the bearer token, so it must NEVER hit the log stream) — it rides

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -138,8 +138,10 @@ number told nobody anything.
 **`min_protocol_version` is a different axis and does NOT follow.** It
 rises only when old clients can no longer be *served*. An additive field
 strands nobody, so the ordinary bump leaves the floor exactly where it
-is: at the time of writing `protocol_version` is `2` and
-`min_protocol_version` is still `1`.
+is: `protocol_version` has moved several times under this rule while
+`min_protocol_version` has never left `1`. (The current pair is not
+written here on purpose — see the note under `GET /api/config`; the
+moving number is stale the moment it is typed, and it has been, twice.)
 
 ### 2b. What this means for you, as a client author
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58955,3 +58955,79 @@ disturb the seeded sessions the rest of the suite depends on.
 Restarting the container mid-suite is heavy and flaky. It is covered by
 `bootstrap_test.exs` ("#1675 — resumes a :failing credential"), which runs
 the real `Bootstrap.run/0` against a real socket.
+
+### The `:parked` rejection also eats the FIRST failure — measured, and left open
+
+Writing the e2e surfaced a hole in the cure itself, and it is recorded here
+rather than fixed because the fix is somebody's decision, not a detail.
+
+Every operator-initiated connect SPAWNS BEFORE it writes `:connected`.
+`Operator.connect_credential/1` is `resolve → spawn → Networks.connect/1`, and
+the post-U-0 `NetworksController` order is the same — deliberately, because
+that IS #642's cure: a refused spawn must not report success. So between the
+spawn and that write the row still reads `:parked`, and `mark_failing/2`
+rejects `:parked` by design.
+
+An upstream that refuses instantly closes inside that window. From the
+integration stack on 2026-08-22, a network bound to a closed loopback port:
+
+```
+21:49:35.464  credential_bound
+21:49:35.466  report_link_state: {:failing, "connection refused"}
+              declined (user_parked)              <- 2 ms after the bind
+21:49:35.470  INSERT INTO "messages"              <- the $server row DOES land
+```
+
+and `GET /networks` twenty seconds later still answered
+`connection_state: "connected"`, `connection_state_reason: null`,
+`connection: null`.
+
+Three things are wrong at once, and they are worth separating. The
+`user_parked` **diagnosis is false** — nobody parked the row, the writer had
+not committed — so the log lies about why, which is the exact failure the
+log-honesty rule names. The **two surfaces disagree**: the `$server`
+scrollback says the connect was refused while the network row says connected.
+And the row **self-corrects only on the next attempt**, i.e. after
+`@connect_failure_sleep_ms` (30 s) plus one backoff rung (~5 s) — about
+**35 seconds of exactly the lie this issue exists to remove**, bounded but
+real, and reachable in production by the commonest misconfiguration there is.
+
+It did not show on the 2026-08-22 incident because all three real causes were
+SLOW (a TLS handshake, four connect timeouts, a refusal computed before the
+SYN), so the microsecond write always won. `:econnrefused` is the case that
+loses, and it is the case an operator hits by typing the wrong port.
+
+Not fixed in this slice: the cure is an ordering change to the U-0 sequence
+#642 established, and re-ordering it naively reinstates #642. Recorded so the
+next reader does not have to re-derive it from a log line that lies.
+
+### Why the e2e budgets are what they are, and why the throttle was NOT shrunk
+
+The first e2e run was red for this reason and not for a defect in the cure:
+the spec polled 20 s for `:failing`, and with the first failure eaten the row
+cannot reach it before attempt 2 at ~35 s.
+
+The house rule is to cure a red by making the SETUP deterministic rather than
+by raising a timeout, so that was tried first and it does not exist here.
+`irc_client_connect_failure_sleep_ms` is `Application.compile_env` and
+`config/dev.exs` is the established door for shortening an integration-env
+constant (#671 does exactly that for the auto-away debounce). It was still
+declined, on two measurements. It changes the retry cadence of every session
+in a 760-test suite, including the failure paths of the known per-IP autokill
+flake, to save thirty seconds in one spec. **And it would not buy determinism
+anyway:** the spec would still be waiting on attempt 2, because what removes
+the first failure is the `:parked` window above, not the throttle — the
+throttle sets how LONG the wait is, never whether there is one.
+
+Nor can the spec sidestep it by starting from a genuinely `:connected` row:
+every door that respawns a session (`connect_credential/1`, `PATCH
+/networks/:slug`) goes through the same `:parked → :connected` write, and the
+two that do not respawn (`stop_session/2` behind the admin terminate, and
+`disconnect/2`) leave nothing running to retry. There is no operator verb that
+provokes a connect failure on a row that is already `:connected`.
+
+So the budgets are bounded waits on a MEASURED ladder, and they say so at the
+assertion: 30 s throttle + one rung (~5 s) for `:failing`, and for the
+`[dead, dead, live]` ring 2×30 s + a 5 s rung + a 10 s rung + registration
+before `:connected` returns. The polls are condition-based, not sleeps; the
+numbers are the ladder's, not a safety margin.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -58804,3 +58804,154 @@ is the selected channel and is NOT gated on `isDocumentVisible()`, because
 gating on tab visibility makes every alt-tab cost a refetch round. Questions 2
 and 3 (what else goes stale while paused; resume ordering against a JOIN
 landing mid-refetch) are narrowed by the carve-outs above rather than closed.
+<!-- entry #1675 -->
+
+---
+
+## 2026-08-22 — #1675: a fourth connection_state, because `connected` was reporting the spawn
+
+Three networks added on prod on 2026-08-22 (ircnet / efnet / undernet) read
+`connected` in cicchetto while none of them ever completed registration. The
+endpoints were misconfigured, which is a separate matter; the defect is that
+`network_credentials.connection_state` records that a session process was
+STARTED, not that IRC came up. `Networks.connect/1` writes `:connected` on
+spawn success — the U-0 ordering that correctly refuses to claim success when
+the SPAWN is rejected (#642) — and nothing ever walked the row back when the
+upstream TCP/TLS/registration then failed. The reconnect backoff keeps a
+session process alive, so the row stayed `:connected` indefinitely and the
+operator had no way to tell it from a healthy link.
+
+**`:failing` is a fourth value and not a reuse of `:failed`, and the
+constraint was measured rather than assumed.** `Networks.mark_failed/2`
+calls `Session.stop_session/2` BEFORE `transition!/3`, and the child is
+`:transient`, so nothing comes back on its own: a `:failed → :connected`
+edge on `RPL_WELCOME` can never fire, because there is no process left to
+receive the 001. `mark_failed/2` is the terminal verb (k-line, permanent
+SASL rejection) and stays exactly as it is. `:failing` means the opposite —
+the session process is alive and the backoff ladder is running — and that
+difference is load-bearing at boot (below), which is why it is a value and
+not a reason string on `:failed`.
+
+**One value, not a taxonomy.** `:tls_error` / `:rejected` / `:timeout` as
+enum members would have to grow on every new cause. The human-readable half
+already had a home: `connection_state_reason` is a column cic already
+renders (`HomePane.tsx`, `ServerInfoCard.tsx`) behind a `Show when=…`, and
+it read empty **by construction** — `Networks.connect/1` does
+`transition!(cred, :connected, nil)`, so the reason was nulled at connect and
+never rewritten. The missing piece was the writer, not the place to put it.
+The reason therefore carries the ACTUAL cause and not a category label:
+`Grappa.IRC.Client.describe_connect_failure/1` spells the POSIX set an
+operator actually hits and keeps the OTP alert description verbatim, because
+on the ircnet failure that description is where BOTH hostnames of the
+RFC-6125 mismatch live — the alert atom alone would say `handshake_failure`
+and name neither host.
+
+**The trigger is `{:irc_connect_failed, _}`, deliberately not
+`terminate/2`.** Every abnormal teardown lands in `terminate/2`, including
+the mid-session netsplit that reconnects on the first retry; marking THAT
+`:failing` would churn the row on every blip. A failed connect ATTEMPT is
+the honest evidence that the link is not coming up right now.
+
+**Idempotent on `:failing`, and the FIRST cause is kept.** Re-entering
+backoff happens once per attempt on an exponential ladder; a row write plus a
+broadcast per attempt is churn the operator learns nothing from. The first
+cause is also the one closest to the misconfiguration — EFNet rotated one bad
+certificate into four subsequent timeouts, and the certificate is the
+diagnosis. The per-attempt detail is not lost: it lands in the `$server`
+window and the session log. **Those two granularities differ on purpose.**
+The state write is idempotent; the `$server` row is one per ATTEMPT, because
+it is a LOG and a log that collapses repetitions hides the ladder.
+
+**Boot resumes `:failing` and still skips `:failed`.**
+`Credentials.list_credentials_for_all_users/0` selected
+`connection_state == :connected`; the doc above it explains that `:parked` is
+user intent and `:failed` is server-set and deliberately not retried. That
+reasoning holds for `:failed` and is wrong for `:failing` — a reboot landing
+inside a backoff window would otherwise drop the network permanently. This is
+the reason the two are separate values rather than one `:failed` plus a
+reason grep.
+
+**`:connected` has changed meaning: it is now "registered upstream", not
+"a session process is alive".** CLAUDE.md's "DB state and live state" bullet
+named the closed set `[:connected, :parked, :failed]` and that line is now
+false in both halves; it is updated in the same change. Every reader that
+treats `:connected` as liveness is reading a different fact than the one the
+column now records.
+
+**Subject-polymorphic, because the drift is not user-specific.**
+`report_link_state/3` takes a `Session.subject()` — the write set of
+`connection_state` has no subject branch, a visitor credential goes through
+the same `Networks.connect/1`, and the visitor row has carried a real
+`connection_state` since the #211 ruling D. **Named and NOT cured here:** the
+visitor attach path (`Visitors.attach_credential/2`) writes `:connected`
+BEFORE the spawn, which is the #642 class over again on the other subject.
+It is a separate defect with a separate fix and gets its own issue rather
+than riding in on this one.
+
+**Named gap, deliberately left open: there is no registration watchdog.** A
+socket that CONNECTS and then never registers — blocked rDNS, an ident
+timeout, a services hang — emits no `irc_connect_failed`, so the row stays
+`:connected` and this change does nothing for it. A watchdog is a timer, a
+policy for what "too long" means, and a new failure mode of its own; whoever
+wants it opens the issue and argues the policy. Writing it down here so the
+next reader does not mistake silence for coverage.
+
+**The wire bump was decided by the pin digest, not by hand.** A new enum
+value is a wire-shape change, and per the 2026-08-21 ruling the bump is
+unconditional for additive changes too. `mix grappa.wire_pin --update`
+refuses a new digest at a still number, so `@protocol_version` went 3 → 4.
+The 3 was #1677's and has never been deployed (staging and prod serve 2);
+that is a fact about the release train, not about this shape.
+`@min_protocol_version` stays 1 — an additive value strands no client.
+
+**The migration aligns a predicate; it does not restore an index the boot
+query needs, and the difference was measured.** `EXPLAIN QUERY PLAN` on a
+test DB (once, without `ANALYZE`) shows the planner choosing
+`network_credentials_user_id_network_id_index` both before and after the
+change — never the `connection_state` one. So the honest claim is the
+narrow one: the partial index's predicate is brought back into agreement
+with the query that names the column. It is written that way in the
+migration's own moduledoc and must not be promoted to something stronger.
+
+### e2e: two tests, because the two halves want opposite topologies
+
+vjt's ruling made e2e coverage mandatory, and the reason it gave is the one
+that shaped the spec: every part of this failed on prod *between* the
+layers, so an API-only assertion does not discharge the requirement.
+
+The driver is a `network_servers` row on a closed loopback port —
+ECONNREFUSED with no DNS, no route and no wait, where the three real prod
+causes each need either a second ircd or a 30-second wall-clock wait.
+
+`issue1675-failing-link-state.spec.ts` splits because a stable `:failing`
+row and a row that leaves `:failing` on its own cannot be the same fixture.
+Test 1 gives the network ONE dead leaf, so every rung of the ladder refuses
+and the state holds for as long as the assertions take: the row reads
+`failing`, the reason names the cause, and then cicchetto is driven and
+asserted to render the same string — the half that was invisible to the
+operator. Test 2 gives it a ring of [dead, dead, live]: `SessionPlan`'s
+`refresh_plan` closure re-resolves the endpoint at `Backoff.failure_count`
+on every `:transient` respawn and `Servers.pick_server!/2` indexes the
+enabled ring by that ordinal, so the session walks itself onto the live leaf
+at attempt 2 and registers. That is the genuine `mark_failing →
+mark_registered` pair on one credential. The **two** dead rungs are not
+padding: at base 5 s they buy a ~15 s window in which `:failing` is
+observable, where a single dead leaf would leave ~5 s.
+
+**The recovery oracle is `connection.registered === true`, and the
+conjunct is the whole point.** Asserting `connection_state === "connected"`
+alone would be vacuous — `Networks.connect/1` writes exactly that on spawn
+success — so a park→connect cycle would have "proved" recovery against a
+still-dead upstream. The live `connection` projection reports `registered`
+only after 001, which is the event `mark_registered/1` hangs off. This is
+also why recovery is driven by the ring rather than by parking and
+reconnecting.
+
+The subject is `admin-vjt`, the one seeded user with no network bind, so the
+ephemeral network is the only row in its HomePane and neither test can
+disturb the seeded sessions the rest of the suite depends on.
+
+**The reboot arm is NOT in e2e, and that is a choice, not an omission.**
+Restarting the container mid-suite is heavy and flaky. It is covered by
+`bootstrap_test.exs` ("#1675 — resumes a :failing credential"), which runs
+the real `Bootstrap.run/0` against a real socket.

--- a/lib/grappa/bootstrap.ex
+++ b/lib/grappa/bootstrap.ex
@@ -421,10 +421,14 @@ defmodule Grappa.Bootstrap do
     # A visitor who /disconnected network A parked its credential; on a
     # bouncer reboot Bootstrap must NOT respawn it (vjt: "visitor per
     # network disconnect persists after reboot, yes, of course cazzo").
-    # Mirrors the user path (`list_credentials_for_all_users/0` filters to
-    # `:connected`, i.e. skips BOTH :parked and :failed); the visitor path
+    # Mirrors the user path (`list_credentials_for_all_users/0` selects the
+    # WANTED-UP set and so skips BOTH :parked and :failed); the visitor path
     # enumerates ALL credentials (TTL identity lifecycle is orthogonal to
     # per-network session state), so the skip is per-credential here.
+    # #1675 — `:failing` is deliberately NOT in this guard: it means
+    # "wanted up, link not registered", so it falls through to the spawn
+    # clause below exactly as the user path resumes it. Skipping it would
+    # strand a visitor network that was mid-backoff at reboot.
     # `:failed` is included for symmetry with the user path — visitor
     # credentials don't reach it today (the visitor terminal-failure axis
     # is Reaper/TTL on the identity row), but a future `:failed`-for-

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -324,7 +324,100 @@ defmodule Grappa.IRC.Client do
                          30_000
                        )
 
+  # #1675 — ceiling on a rendered connect-failure reason, in GRAPHEMES.
+  # An OTP TLS alert description is a full sentence with a nested error
+  # term inside it and no bound of its own; the real one from prod runs
+  # ~230 characters, so the cap has to sit above that or it truncates the
+  # diagnosis in the one case it exists for. Graphemes and not bytes
+  # because the value lands in a UTF-8 column and a byte slice can end
+  # mid-codepoint.
+  @connect_failure_max_length 500
+
   ## API
+
+  @doc """
+  Renders a connect-failure reason as one line an operator can act on.
+
+  #1675 — this string is the whole diagnosis at two surfaces:
+  `network_credentials.connection_state_reason` (which cicchetto already
+  renders) and the `$server` window row. It therefore carries the ACTUAL
+  cause — which host, which certificate, which address family — never a
+  category like "connection failed". The unmapped arm is `inspect/1` for
+  the same reason: an unrecognised shape must stay diagnosable.
+
+  Lives here because this module PRODUCES every shape it maps: the POSIX
+  atoms come back from `:gen_tcp.connect/4`, the alert tuple from
+  `:ssl.connect/4`, and `{:source_family_mismatch, …}` from this file's
+  own `source_bind/2`. A new failure shape and its wording land in one
+  file.
+
+  Contract the callers depend on: the result is a single line — no CR,
+  LF or NUL, which `Credential.connection_state_changeset/2` rejects
+  outright (an OTP alert description spans lines, so this is a real
+  crash, not a hypothetical) — and is bounded to
+  #{@connect_failure_max_length} graphemes.
+  """
+  @spec describe_connect_failure(term()) :: String.t()
+  def describe_connect_failure(reason) do
+    reason |> connect_failure_text() |> one_line() |> truncate()
+  end
+
+  # The POSIX set worth spelling out: what an operator actually hits.
+  # Anything else falls through to `inspect/1` rather than being flattened
+  # into a friendly lie.
+  defp connect_failure_text(:econnrefused), do: "connection refused"
+  defp connect_failure_text(:timeout), do: "connect timeout"
+  defp connect_failure_text(:etimedout), do: "connect timeout"
+  defp connect_failure_text(:ehostunreach), do: "host unreachable"
+  defp connect_failure_text(:enetunreach), do: "network unreachable"
+  defp connect_failure_text(:econnreset), do: "connection reset by peer"
+  defp connect_failure_text(:nxdomain), do: "host not found (DNS)"
+  defp connect_failure_text(:closed), do: "upstream closed the connection"
+
+  # `:ssl.connect/4`'s alert tuple. The description is a charlist holding
+  # the nested reason — on the 2026-08-22 ircnet failure it is where BOTH
+  # hostnames of the RFC-6125 mismatch live, so it is kept rather than
+  # summarised away; the alert atom alone would say `handshake_failure`
+  # and name neither host.
+  defp connect_failure_text({:tls_alert, {alert, description}}),
+    do: "tls: #{alert} (#{to_string(description)})"
+
+  defp connect_failure_text({:tls_alert, alert}), do: "tls: #{inspect(alert)}"
+
+  # Ours (`source_bind/2`): the egress source is pinned to one family and
+  # the upstream publishes no address in it. `fam` is the SOURCE's family;
+  # the HOST is the side that lacks the record, and saying which is which
+  # is the difference between a fixable line and a puzzle.
+  defp connect_failure_text({:source_family_mismatch, source, host, fam}) do
+    "source address family mismatch: source #{source} is #{family_word(fam)}, " <>
+      "#{host} has no #{family_record(fam)} record"
+  end
+
+  defp connect_failure_text(other), do: inspect(other)
+
+  defp family_word(:inet6), do: "IPv6"
+  defp family_word(:inet), do: "IPv4"
+
+  defp family_record(:inet6), do: "AAAA"
+  defp family_record(:inet), do: "A"
+
+  # CR/LF/NUL are rejected by the changeset that stores this, and an OTP
+  # alert description really does contain newlines. Collapse rather than
+  # strip so two joined sentences do not run into one word.
+  defp one_line(text) do
+    text
+    |> String.replace(["\r\n", "\r", "\n", "\x00"], " ")
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+  end
+
+  defp truncate(text) do
+    if String.length(text) > @connect_failure_max_length do
+      String.slice(text, 0, @connect_failure_max_length - 1) <> "…"
+    else
+      text
+    end
+  end
 
   @doc """
   Spawns and links the Client. `opts` MUST carry `:nick` and

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -1118,6 +1118,37 @@ defmodule Grappa.Networks do
   outranks a server observation — same posture as `mark_failed/2`) and
   `:failed` with `{:error, :terminal}` (terminal never decays into
   non-terminal; a `:failed` row has no session to be failing).
+
+  ## 🔴 KNOWN HOLE — the `:parked` rejection also eats the FIRST failure
+
+  **Not intentional. Measured on the integration stack 2026-08-22, not
+  reasoned about:** every operator-initiated connect SPAWNS BEFORE it
+  writes `:connected` (`Operator.connect_credential/1` and the post-U-0
+  `NetworksController` order both do `resolve → spawn → connect/1`, and
+  that ordering is #642's cure — a refused SPAWN must not report
+  success). So there is a window, between the spawn and that write, in
+  which the row still reads `:parked`. An upstream that refuses
+  instantly closes it inside that window:
+
+      21:49:35.464  credential_bound
+      21:49:35.466  report_link_state: {:failing, "connection refused"}
+                    declined (user_parked)          <- 2 ms after the bind
+      21:49:35.470  INSERT INTO messages            <- the $server row DOES land
+
+  The `user_parked` diagnosis is then **wrong**: nobody parked the row,
+  the writer had not committed yet. The two surfaces disagree for the
+  rest of the window — the `$server` scrollback says the connect was
+  refused while the network row says `connected` with a null reason —
+  and the row only self-corrects on the NEXT attempt, i.e. after
+  `@connect_failure_sleep_ms` (30 s, `config/config.exs`) plus one
+  backoff rung (~5 s): **~35 s of exactly the lie #1675 exists to
+  remove**, bounded but real, and reachable in production by the
+  commonest misconfiguration there is (a wrong port).
+
+  It is NOT fixed here because the fix is an ordering change to the U-0
+  sequence #642 established, which is a separate decision with a
+  separate blast radius. It is written down because the next reader
+  would otherwise have to re-derive it from a log line that lies.
   """
   @spec mark_failing(Credential.t(), String.t()) ::
           {:ok, Credential.t()} | {:error, :user_parked | :terminal}

--- a/lib/grappa/networks.ex
+++ b/lib/grappa/networks.ex
@@ -902,7 +902,17 @@ defmodule Grappa.Networks do
 
   @doc """
   Transitions a credential to `:connected`. Idempotent if already
-  `:connected` (no DB write, no broadcast).
+  `:connected` OR `:failing` (no DB write, no broadcast).
+
+  #1675 — `:failing` is idempotent here rather than a transition,
+  because `connect/1` states the operator's INTENT ("I want this
+  network up") and a `:failing` row is already wanted-up: the session
+  exists and its backoff ladder is retrying. Writing `:connected` would
+  re-assert the exact claim this issue is about — that a row says
+  registered while the link is not — and the honest correction arrives
+  on its own at 001 via `mark_registered/1`. The caller's spawn step
+  still runs first and is what repairs a `:failing` row whose session
+  died, so the door is not a no-op end to end.
 
   Does NOT spawn the `Session.Server` — see the moduledoc T32 boundary
   note. The caller (`NetworkController` for `/connect`, `Bootstrap` at
@@ -918,7 +928,7 @@ defmodule Grappa.Networks do
   the broadcast fans out on the subject's own user-rooted topic.
   """
   @spec connect(Credential.t()) :: {:ok, Credential.t()}
-  def connect(%Credential{connection_state: :connected} = cred) do
+  def connect(%Credential{connection_state: state} = cred) when state in [:connected, :failing] do
     {:ok, preload_subject_and_network(cred)}
   end
 
@@ -943,10 +953,17 @@ defmodule Grappa.Networks do
 
   @doc """
   Transitions a credential to `:parked` (user-initiated `/disconnect`
-  or `/quit`). `:connected → :parked`; rejects from `:parked | :failed`
-  with `{:error, :not_connected}` (idempotency-by-rejection, not
-  silent no-op — the caller is asking to disconnect a row that's
-  already not connected, surface that).
+  or `/quit`). `:connected | :failing → :parked`; rejects from
+  `:parked | :failed` with `{:error, :not_connected}`
+  (idempotency-by-rejection, not silent no-op — the caller is asking to
+  disconnect a row that's already not connected, surface that).
+
+  #1675 — `:failing` parks like `:connected` does, and that is not a
+  nicety: a network hammering a dead upstream is precisely the one an
+  operator reaches for the disconnect button on (it is what vjt did by
+  hand on 2026-08-22). Both states own a live session and a running
+  backoff ladder, so both need the QUIT + `stop_session` this verb does;
+  only `:parked` and `:failed` have nothing left to stop.
 
   Issues an explicit `QUIT :<reason>` upstream first (best-effort —
   no live session is fine) so the upstream sees a clean disconnect
@@ -956,8 +973,8 @@ defmodule Grappa.Networks do
   """
   @spec disconnect(Credential.t(), String.t()) ::
           {:ok, Credential.t()} | {:error, :not_connected}
-  def disconnect(%Credential{connection_state: :connected} = cred, reason)
-      when is_binary(reason) do
+  def disconnect(%Credential{connection_state: from} = cred, reason)
+      when from in [:connected, :failing] and is_binary(reason) do
     cred = preload_subject_and_network(cred)
     subject = subject_of(cred)
 
@@ -968,7 +985,7 @@ defmodule Grappa.Networks do
     # GH #417 — a DELIBERATE park clears the persisted explicit away (see
     # clear_away_on_manual_park/1 for the manual-vs-automatic rationale).
     :ok = clear_away_on_manual_park(cred)
-    broadcast_state_change(updated, :connected, :parked, reason)
+    broadcast_state_change(updated, from, :parked, reason)
     {:ok, updated}
   end
 
@@ -989,27 +1006,32 @@ defmodule Grappa.Networks do
   doesn't restart on `:normal`-shape stops; the supervisor terminating
   the child achieves the same).
 
-  `:connected → :failed`. Idempotent if already `:failed` (no DB
-  write, no broadcast). Rejects from `:parked` with
+  `:connected | :failing → :failed`. Idempotent if already `:failed`
+  (no DB write, no broadcast). Rejects from `:parked` with
   `{:error, :user_parked}` — `:parked` is explicit user intent
   ("don't reconnect this row"), and a server-set terminal failure
   shouldn't quietly overwrite that. The caller (Session.Server's
   `handle_terminal_failure`) is expected to log + drop the
   transition rather than retry.
+
+  #1675 — `:failing → :failed` is the escalation edge: a link that was
+  merely down (backoff running) can then earn a k-line or a permanent
+  SASL rejection, and terminal must win over non-terminal. The reverse
+  edge does not exist; see `mark_failing/2`.
   """
   @spec mark_failed(Credential.t(), String.t()) ::
           {:ok, Credential.t()} | {:error, :user_parked}
   def mark_failed(%Credential{connection_state: :failed} = cred, _), do: {:ok, cred}
 
-  def mark_failed(%Credential{connection_state: :connected} = cred, reason)
-      when is_binary(reason) do
+  def mark_failed(%Credential{connection_state: from} = cred, reason)
+      when from in [:connected, :failing] and is_binary(reason) do
     cred = preload_subject_and_network(cred)
     subject = subject_of(cred)
 
     :ok = Session.stop_session(subject, cred.network_id, reason)
 
     updated = transition!(cred, :failed, reason)
-    broadcast_state_change(updated, :connected, :failed, reason)
+    broadcast_state_change(updated, from, :failed, reason)
     {:ok, updated}
   end
 
@@ -1070,6 +1092,159 @@ defmodule Grappa.Networks do
         :ok
     end
   end
+
+  @doc """
+  Server-internal, NON-TERMINAL: marks a credential `:failing` — "the
+  session process is alive and the reconnect backoff is running, but the
+  upstream link is not registered" (#1675).
+
+  `:connected | :failing → :failing`, carrying `reason` (the ACTUAL
+  cause: `tls: …`, `connect refused`, a source-family mismatch — see
+  `Grappa.IRC.Client.describe_connect_failure/1`). Does **NOT** stop the
+  session, which is the whole point and the reason this is a second verb
+  rather than a widened `mark_failed/2`: the ladder underneath has to
+  keep retrying, and the 001 that ends the outage arrives on the process
+  `mark_failed/2` would have killed.
+
+  Idempotent on `:failing`: no DB write, no broadcast, and the FIRST
+  cause is kept. Re-entering backoff happens once per attempt on an
+  exponential ladder, and a row + broadcast per attempt is churn the
+  operator learns nothing from; the first cause is also the one closest
+  to the misconfiguration (EFNet rotated a bad certificate into four
+  timeouts — the certificate is the diagnosis). The per-attempt detail
+  is not lost: it lands in the `$server` window and the session log.
+
+  Rejects `:parked` with `{:error, :user_parked}` (a deliberate park
+  outranks a server observation — same posture as `mark_failed/2`) and
+  `:failed` with `{:error, :terminal}` (terminal never decays into
+  non-terminal; a `:failed` row has no session to be failing).
+  """
+  @spec mark_failing(Credential.t(), String.t()) ::
+          {:ok, Credential.t()} | {:error, :user_parked | :terminal}
+  def mark_failing(%Credential{connection_state: :failing} = cred, _), do: {:ok, cred}
+
+  def mark_failing(%Credential{connection_state: :connected} = cred, reason)
+      when is_binary(reason) do
+    cred = preload_subject_and_network(cred)
+    updated = transition!(cred, :failing, reason)
+    broadcast_state_change(updated, :connected, :failing, reason)
+    {:ok, updated}
+  end
+
+  def mark_failing(%Credential{connection_state: :parked}, _), do: {:error, :user_parked}
+  def mark_failing(%Credential{connection_state: :failed}, _), do: {:error, :terminal}
+
+  # REV-B / H6: see `connect/1`. Raises on a future enum addition rather
+  # than silently `FunctionClauseError`-ing — the four clauses above are
+  # exhaustive on TODAY's set, and #1675 is itself the proof that this
+  # set grows.
+  def mark_failing(%Credential{connection_state: other}, _),
+    do: raise(ArgumentError, "Networks.mark_failing: unhandled connection_state #{inspect(other)}")
+
+  @doc """
+  Server-internal: the return edge of `mark_failing/2` — 001 RPL_WELCOME
+  proved the link is registered, so the row goes back to `:connected`
+  with the failure cause CLEARED (#1675).
+
+  `:failing → :connected`. Idempotent on `:connected` (no DB write, no
+  broadcast) — 001 fires on every reconnect, including the overwhelming
+  majority that were never failing, so the no-op arm is the hot path and
+  must not churn the row.
+
+  Rejects `:parked | :failed` with `{:error, :not_failing}`: both mean a
+  teardown already won the race (`disconnect/2` and `mark_failed/2` both
+  stop the session BEFORE writing), and resurrecting the row from a late
+  001 would undo an operator's decision.
+  """
+  @spec mark_registered(Credential.t()) :: {:ok, Credential.t()} | {:error, :not_failing}
+  def mark_registered(%Credential{connection_state: :connected} = cred), do: {:ok, cred}
+
+  def mark_registered(%Credential{connection_state: :failing} = cred) do
+    cred = preload_subject_and_network(cred)
+    updated = transition!(cred, :connected, nil)
+    broadcast_state_change(updated, :failing, :connected, nil)
+    {:ok, updated}
+  end
+
+  def mark_registered(%Credential{connection_state: state}) when state in [:parked, :failed],
+    do: {:error, :not_failing}
+
+  # REV-B / H6 fallthrough — see `mark_failing/2`.
+  def mark_registered(%Credential{connection_state: other}),
+    do: raise(ArgumentError, "Networks.mark_registered: unhandled connection_state #{inspect(other)}")
+
+  @doc """
+  The door `Grappa.Session.Server` reaches through its injected
+  `link_state_reporter` closure (#1675): reports what the UPSTREAM LINK
+  is doing to the credential row for `(subject, network_id)`.
+
+  `{:failing, reason}` → `mark_failing/2`; `:registered` →
+  `mark_registered/1`. Always returns `:ok` — the caller is a session on
+  its connect path and has nothing to do with a refusal but log it, so
+  every non-write outcome is logged HERE (never silently swallowed) and
+  the session carries on.
+
+  Subject-polymorphic, unlike its terminal sibling `mark_failed_by_ids/3`.
+  The write set of `connection_state` has no subject branch, so the drift
+  this issue is about is not user-specific: a visitor credential goes
+  through the same `Networks.connect/1` and lands in the same lie. The
+  visitor row carries a real `connection_state` since #211 ruling D.
+  """
+  @spec report_link_state(Session.subject(), integer(), {:failing, String.t()} | :registered) ::
+          :ok
+  def report_link_state(subject, network_id, link_state) when is_integer(network_id) do
+    case fetch_credential_for_subject(subject, network_id) do
+      {:ok, cred} ->
+        log_link_state_outcome(apply_link_state(cred, link_state), subject, network_id, link_state)
+
+      {:error, :not_found} ->
+        # Unbound between spawn and the connect failure (an admin unbind,
+        # a reaped visitor). The session is about to die with it; nothing
+        # to write, but say so rather than drop it.
+        Logger.info(
+          "report_link_state: no credential — unbound or reaped " <>
+            "(subject=#{inspect(subject)} network_id=#{network_id})"
+        )
+
+        :ok
+    end
+  end
+
+  @spec apply_link_state(Credential.t(), {:failing, String.t()} | :registered) ::
+          {:ok, Credential.t()} | {:error, atom()}
+  defp apply_link_state(cred, {:failing, reason}) when is_binary(reason),
+    do: mark_failing(cred, reason)
+
+  defp apply_link_state(cred, :registered), do: mark_registered(cred)
+
+  @spec log_link_state_outcome(
+          {:ok, Credential.t()} | {:error, atom()},
+          Session.subject(),
+          integer(),
+          {:failing, String.t()} | :registered
+        ) :: :ok
+  defp log_link_state_outcome({:ok, _}, _, _, _), do: :ok
+
+  defp log_link_state_outcome({:error, why}, subject, network_id, link_state) do
+    # Not a warning: every one of these is a legitimate race with a
+    # teardown that already won (park / terminal failure), and the row is
+    # correct as it stands. Logged because a silent drop here is how a
+    # future genuinely-wrong transition would hide.
+    Logger.info(
+      "report_link_state: #{inspect(link_state)} declined (#{why}) " <>
+        "(subject=#{inspect(subject)} network_id=#{network_id})"
+    )
+
+    :ok
+  end
+
+  @spec fetch_credential_for_subject(Session.subject(), integer()) ::
+          {:ok, Credential.t()} | {:error, :not_found}
+  defp fetch_credential_for_subject({:user, user_id}, network_id),
+    do: Credentials.get_credential_by_ids(user_id, network_id)
+
+  defp fetch_credential_for_subject({:visitor, visitor_id}, network_id),
+    do: Credentials.get_visitor_credential(visitor_id, network_id)
 
   # REV-J M13: routes through `Credential.connection_state_changeset/2`
   # so the same `safe_line_token` guard that protects `realname`,

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -80,21 +80,46 @@ defmodule Grappa.Networks.Credential do
   # T32 (channel-client-polish S1.1): terminal/user-visible connection
   # state for a credential.
   #
-  # `:connected` — Bootstrap (or `Networks.connect/1`) spawned a
-  #   `Session.Server`; the binding is live, OR the session is in
-  #   continuous reconnect / backoff. Runtime sub-states
-  #   (`:connecting`, `:reconnecting`, `:backing_off`) stay in
-  #   Session.Server GenServer state — NOT mirrored here.
+  # 🔴 #1675 — `:connected` means REGISTERED UPSTREAM, not "a session
+  # process exists". Until #1675 it meant the latter, and the two are not
+  # the same thing: three networks bound to misconfigured endpoints on
+  # 2026-08-22 kept a live `Session.Server` hammering an upstream that
+  # refused every connect, and the row said `connected` for as long as
+  # they did. Read this column as "is IRC up", never as liveness — the
+  # live-pid truth is `Grappa.Session.whereis/2` and stays a SEPARATE
+  # source (the CLAUDE.md two-truths rule).
+  #
+  # `:connected` — 001 RPL_WELCOME arrived: the link is registered.
+  #   Also the state a row starts in at INSERT and the one
+  #   `Networks.connect/1` writes on an operator reconnect, both of
+  #   which are statements of INTENT that the first 001 (or the first
+  #   connect failure) then confirms or corrects.
+  # `:failing`   — the session process is alive and the reconnect
+  #   backoff is running, but the upstream link is NOT registered:
+  #   a refused/timed-out connect, a TLS handshake that cannot pass,
+  #   an egress-family mismatch. Non-terminal — the ladder keeps
+  #   retrying and 001 takes the row back to `:connected`.
   # `:parked`    — user-driven `/disconnect` or `/quit`. Bouncer
   #   stays parked across reboots until `/connect <network>`.
   # `:failed`    — server-set on permanent error (k-line 465 +
   #   permanent SASL 904/906 — see plan S1.4 lenient triggers).
+  #   TERMINAL: the session is stopped and Bootstrap skips the row.
+  #
+  # `:failing` vs `:failed` is exactly the boot question. A reboot
+  # landing inside a backoff window must bring a `:failing` row BACK
+  # (else a misconfigured-then-fixed network stays down until a human
+  # PATCHes it), while a `:failed` row must stay down until the operator
+  # acts. One value plus a reason grep could not express both.
+  #
+  # The finer runtime sub-states (`:connecting`, `:backing_off`) stay in
+  # `Session.Server` GenServer state and reach cic as the #100
+  # `connection_progress` overlay — NOT mirrored here.
   #
   # State-transition policy lives in `Grappa.Networks.connect/1`,
-  # `disconnect/2`, and `mark_failed/2` — the schema accepts any
-  # value in the closed set; the context module enforces which
-  # transitions are valid.
-  @connection_states [:connected, :parked, :failed]
+  # `disconnect/2`, `mark_failed/2`, `mark_failing/2` and
+  # `mark_registered/1` — the schema accepts any value in the closed
+  # set; the context module enforces which transitions are valid.
+  @connection_states [:connected, :failing, :parked, :failed]
 
   # H15 (REV-D 2026-05-22): hard ceiling on the per-credential
   # `last_joined_channels` snapshot. Schema-level cap so every
@@ -141,7 +166,7 @@ defmodule Grappa.Networks.Credential do
   def connection_states, do: @connection_states
 
   @type auth_method :: AuthFSM.auth_method()
-  @type connection_state :: :connected | :parked | :failed
+  @type connection_state :: :connected | :failing | :parked | :failed
 
   @type t :: %__MODULE__{
           id: integer() | nil,

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -1330,8 +1330,9 @@ defmodule Grappa.Networks.Credentials do
   end
 
   @doc """
-  Returns every credential whose `connection_state == :connected`,
-  with `:network` preloaded.
+  Returns every credential the bouncer is meant to bring up at boot —
+  `connection_state in [:connected, :failing]` — with `:network`
+  preloaded.
 
   Used by `Grappa.Bootstrap` to spawn one `Grappa.Session.Server` per
   bound (user, network) at boot. Sub-task 2j swapped the boot path
@@ -1339,14 +1340,24 @@ defmodule Grappa.Networks.Credentials do
   operators using `mix grappa.bind_network` can take effect on the
   next deploy without editing a file.
 
-  T32 (channel-client-polish S1.2): filters on `:connected`. `:parked`
-  and `:failed` rows are intentionally skipped — `:parked` is user
-  intent ("don't reconnect this on reboot"), `:failed` is a server-set
-  terminal flag for hard upstream failures (k-line / permanent SASL).
-  Operator brings them back via `Networks.connect/1` (PATCH endpoint
-  or future mix task), which flips to `:connected` and the next
-  Bootstrap cycle picks them up — though typically the PATCH
-  controller spawns the session inline.
+  T32 (channel-client-polish S1.2) + #1675: the filter is the
+  WANTED-UP set, not the `:connected` value. `:parked` and `:failed`
+  rows are intentionally skipped — `:parked` is user intent ("don't
+  reconnect this on reboot"), `:failed` is a server-set terminal flag
+  for hard upstream failures (k-line / permanent SASL). Operator brings
+  them back via `Networks.connect/1` (PATCH endpoint or future mix
+  task), which flips to `:connected` and the next Bootstrap cycle picks
+  them up — though typically the PATCH controller spawns the session
+  inline.
+
+  🔴 `:failing` IS resumed, and that is the half the pre-#1675 wording
+  could not express. That state means "wanted up, link not registered,
+  backoff running": a reboot landing inside a backoff window would
+  otherwise drop the network permanently, since nothing but a human
+  PATCH could ever move the row again. The `:parked`/`:failed` reasoning
+  above is right for those two and WRONG for this one — which is exactly
+  why #1675 added a fourth value instead of reusing `:failed` with a
+  reason grep.
 
   Ordered by `(inserted_at, user_id, network_id)` so the per-credential
   log lines from Bootstrap are deterministic across reboots — handy
@@ -1369,7 +1380,7 @@ defmodule Grappa.Networks.Credentials do
     # explicit-worthy.
     query =
       from(c in Credential,
-        where: c.connection_state == :connected and not is_nil(c.user_id),
+        where: c.connection_state in [:connected, :failing] and not is_nil(c.user_id),
         order_by: [asc: c.inserted_at, asc: c.user_id, asc: c.network_id],
         preload: [network: :servers]
       )

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -133,6 +133,18 @@ defmodule Grappa.Networks.SessionPlan do
       credential_failer: fn reason ->
         Networks.mark_failed_by_ids(user.id, cred.network_id, reason)
       end,
+      # #1675 — the NON-terminal sibling of `credential_failer`. The
+      # upstream link failing to come up is not a reason to stop the
+      # session (the ladder must keep retrying), but it IS a reason to
+      # stop the row claiming `connected`: pre-#1675 nothing walked the
+      # row back, so three misconfigured networks read as connected in
+      # cicchetto while every attempt was refused. Same Boundary-cycle
+      # indirection as the failer above; the closure captures the subject
+      # so `Networks` can reach the credential through the polymorphic
+      # door rather than the user-only `*_by_ids` one.
+      link_state_reporter: fn link_state ->
+        Networks.report_link_state({:user, user.id}, cred.network_id, link_state)
+      end,
       # #131 — optimistic SET PASSWD commit. User-side mirror of
       # `Visitors.SessionPlan`'s `visitor_committer`. Session.Server can't
       # statically alias `Grappa.Networks.Credentials` (Networks already

--- a/lib/grappa/networks/wire.ex
+++ b/lib/grappa/networks/wire.ex
@@ -65,6 +65,17 @@ defmodule Grappa.Networks.Wire do
   no-ops without a DB write), so it outlives the link by however many
   restarts happened since. `nil` on a session whose state predates the
   field (#216 hot-reload contract): "unknown", never a fabricated instant.
+
+  ⚠️ `registered` does NOT mean "registered with the ircd" (001
+  RPL_WELCOME). It is `Grappa.Session.IdentityState.identified?/1` — the
+  #388 normalized NickServ IDENTIFIED verdict, which is what cic's
+  registration + recover launchers gate on. An `auth_method: :none`
+  credential is `false` here for its whole life while being perfectly
+  registered upstream. The name is kept (it is published wire, and the
+  contract is additive-only) but it is NOT an IRC-registration witness:
+  for that, read `connection_state` — since #1675 it means REGISTERED
+  UPSTREAM. Measured the hard way; the #1675 e2e asserted this field as a
+  001 witness and hung 180 s against a link that had registered fine.
   """
   @type connection_info :: %{
           server: String.t(),

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -573,12 +573,16 @@ defmodule Grappa.Operator do
           {:ok, :transitioned | :noop} | {:error, :not_found}
   defp disconnect_user_session({:user, user_id} = subject, network_id, actor_user_id) do
     case Credentials.get_credential_by_ids(user_id, network_id) do
-      {:ok, %{connection_state: :connected} = cred} ->
-        # Networks.disconnect/2 guarantees {:ok, _} on :connected input
-        # (lib/grappa/networks.ex:369-386 only short-circuits on parked/
-        # failed); the bare match crashes loudly if a future refactor
-        # changes the shape — preferable to a defensive case that hides
-        # the contract (CLAUDE.md "Dialyzer warnings are design signals").
+      {:ok, %{connection_state: state} = cred} when state in [:connected, :failing] ->
+        # Networks.disconnect/2 guarantees {:ok, _} on :connected AND
+        # :failing input (it only short-circuits on parked/failed); the
+        # bare match crashes loudly if a future refactor changes the
+        # shape — preferable to a defensive case that hides the contract
+        # (CLAUDE.md "Dialyzer warnings are design signals").
+        #
+        # #1675 — `:failing` belongs on this arm, not the noop one below:
+        # the row owns a live session hammering a dead upstream, which is
+        # exactly the session an admin reaches for this verb to stop.
         {:ok, _} = Networks.disconnect(cred, @disconnect_reason)
 
         Logger.info(

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -71,11 +71,27 @@ defmodule Grappa.Protocol do
 
   use Boundary, top_level?: true, deps: [], exports: []
 
-  # Protocol v4 (#1679) — v1 was the initial published contract (#447), v2
+  # Protocol v5 (#1675) — v1 was the initial published contract (#447), v2
   # the ruling that made the bump unconditional (#1393d), v3 added
-  # `tls_verify` to `Grappa.Networks.Servers.AdminWire.t` (#1677). v4 adds
+  # `tls_verify` to `Grappa.Networks.Servers.AdminWire.t` (#1677), v4 added
   # the `GET /boot` envelope (`GrappaWeb.BootJSON.index/1`): networks, every
-  # network's channel tree, and each channel's head page in one round trip.
+  # network's channel tree, and each channel's head page in one round trip
+  # (#1679). v5 adds the `failing` value to
+  # `NETWORKS_CREDENTIAL_CONNECTION_STATE` and the `link_failure` key to the
+  # scrollback meta allowlist.
+  #
+  # A fourth value in a literal union is the additive case the #1393d
+  # ruling is about, and it is the direction that bites: a client that
+  # starts REQUIRING `failing` (to grey a hammering network, say) cannot
+  # be served by a server that never emits it, and nothing on the server
+  # side would express that break without this number moving. Which
+  # version it lands in is not a judgement call either — `mix
+  # grappa.wire_pin --update` refuses to rewrite the digest while the
+  # number stands still, so a moved shape either bumps or stays red.
+  #
+  # v5 and not v4 because this branch was written against v3 and #1679
+  # landed v4 first: the rebase put TWO wire changes in one digest, and the
+  # pin recomputed against the union rather than against either half.
   #
   # Purely ADDITIVE — no existing endpoint changed shape, and a v3 client
   # that never calls `/boot` is served exactly as before. It bumps anyway,
@@ -93,8 +109,8 @@ defmodule Grappa.Protocol do
   #
   # @min_protocol_version is NOT the same axis and stays at 1: it rises only
   # when old clients can no longer be SERVED, and every client that spoke v1
-  # is still served — v1 clients tolerate what v4 clients require.
-  @protocol_version 4
+  # is still served — v1 clients tolerate what v5 clients require.
+  @protocol_version 5
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -105,7 +121,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 4
+  @spec version() :: 5
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -106,6 +106,18 @@ defmodule Grappa.Scrollback.Meta do
       :nick_change                  →  %{new_nick: String.t()}
       :mode                         →  %{modes: String.t(), args: [String.t()]}
       :kick                         →  %{target: String.t()}     (body carries reason)
+      :server_event (link failure)  →  %{link_failure: %{reason: String.t()}}
+                                                                 (#1675: an upstream connect attempt that
+                                                                  never reached registration — refused,
+                                                                  timed out, TLS unable to verify, egress
+                                                                  family mismatch. Written by
+                                                                  Session.Server on `$server`, sender is
+                                                                  the anonymous sentinel: nobody said it
+                                                                  and it did not come off the wire. The
+                                                                  body carries the same reason spelled
+                                                                  for a human, so an old client renders
+                                                                  it with no change; the structured copy
+                                                                  is what a future client would style.)
       :notice  | :privmsg           →  %{ctcp_verb: String.t(), ctcp_args: String.t()}
                                                                  (#591: a CTCP frame classified by
                                                                   Grappa.IRC.CTCP.verb_args/1 — a peer's
@@ -205,10 +217,11 @@ defmodule Grappa.Scrollback.Meta do
             | :notice_target
             | :statusmsg
             | :nick_fallback
+            | :link_failure
           ) => term()
         }
 
-  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix sender_kind ctcp_verb ctcp_args ctcp_target notice_target statusmsg nick_fallback]a
+  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix sender_kind ctcp_verb ctcp_args ctcp_target notice_target statusmsg nick_fallback link_failure]a
 
   @doc """
   The atom-key allowlist. Exposed so the test suite can assert that
@@ -240,7 +253,8 @@ defmodule Grappa.Scrollback.Meta do
           | :ctcp_target
           | :notice_target
           | :statusmsg
-          | :nick_fallback,
+          | :nick_fallback
+          | :link_failure,
           ...
         ]
   def known_keys, do: @known_keys

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -254,6 +254,9 @@ defmodule Grappa.Session do
           optional(:visitor_password_rotator) => Deps.visitor_password_rotator(),
           optional(:visitor_nick_persister) => Deps.visitor_nick_persister(),
           optional(:credential_failer) => Deps.credential_failer(),
+          # #1675 — non-terminal link-state reporter; BOTH subject tags
+          # inject it (the `connection_state` write set is subject-blind).
+          optional(:link_state_reporter) => Deps.link_state_reporter(),
           optional(:credential_committer) => Deps.credential_committer(),
           optional(:registration_committer) => Deps.registration_committer(),
           optional(:last_joined_persister) => Deps.last_joined_persister(),

--- a/lib/grappa/session/deps.ex
+++ b/lib/grappa/session/deps.ex
@@ -2,7 +2,7 @@ defmodule Grappa.Session.Deps do
   @moduledoc """
   The callbacks a session is BUILT with, in one struct.
 
-  These ten are dependencies, not state. Nothing in a session's lifetime
+  These eleven are dependencies, not state. Nothing in a session's lifetime
   writes them: `init/1` reads them out of the resolved plan and every later
   read is a call. Carried as opaque function references rather than module
   aliases because the producing contexts (Networks, Visitors, QueryWindows)
@@ -32,12 +32,14 @@ defmodule Grappa.Session.Deps do
 
   * `Grappa.Networks.SessionPlan` (registered users) —
     `away_persister`, `credential_committer`, `credential_failer`,
-    `last_joined_persister`, `registration_committer`;
+    `last_joined_persister`, `link_state_reporter`,
+    `registration_committer`;
   * `Grappa.Visitors.SessionPlan` (visitors) — `credential_failer`,
-    `last_joined_persister`, `recover_source`, `visitor_committer`,
-    `visitor_nick_persister`, `visitor_password_rotator`.
+    `last_joined_persister`, `link_state_reporter`, `recover_source`,
+    `visitor_committer`, `visitor_nick_persister`,
+    `visitor_password_rotator`.
 
-  Two shared, three user-only, four visitor-only. So `nil` is not a
+  Three shared, three user-only, four visitor-only. So `nil` is not a
   default at all: it is a function of the SUBJECT TAG, which
   `Grappa.Subject` already carries. `from_opts/2` validates the set due
   for that tag and raises `Grappa.Session.DepsInjectionError` naming the
@@ -134,6 +136,29 @@ defmodule Grappa.Session.Deps do
   @type credential_failer :: (String.t() -> :ok)
 
   @typedoc """
+  #1675 — the NON-terminal sibling of `credential_failer`, injected by
+  BOTH `SessionPlan`s. Reports what the upstream LINK is doing to the
+  credential row: `{:failing, reason}` when a connect attempt could not
+  reach or negotiate with the upstream, `:registered` at 001 RPL_WELCOME.
+
+  Two events, one closure, because they are one axis — "is IRC up" — and
+  a session that can report one must be able to report the other. Both
+  forward to `Grappa.Networks.report_link_state/3`, which owns the
+  idempotency (a re-entered backoff must not churn the row) and logs
+  every declined transition.
+
+  Unlike `credential_failer` this does NOT stop the session and is
+  therefore called INLINE from the connect path, not from a Task: there
+  is no `stop_session` to deadlock against. Same opaque-function-
+  reference indirection and the same Boundary-cycle reason.
+
+  Shared by both subject tags. The write set of `connection_state` has
+  no subject branch, so a user-only reporter would leave the visitor
+  half of the column claiming a registration that never happened.
+  """
+  @type link_state_reporter :: ({:failing, String.t()} | :registered -> :ok)
+
+  @typedoc """
   #131 — opaque callback injected by `Networks.SessionPlan.resolve/1`
   into every USER-session plan. Invoked from the outbound NickServ-secret
   capture choke point when a well-formed in-session `SET PASSWD` leaves
@@ -228,7 +253,7 @@ defmodule Grappa.Session.Deps do
   @type away_persister :: (String.t() | nil, DateTime.t() | nil -> :ok | {:error, term()})
 
   @typedoc """
-  The ten injected callbacks. Nine field defaults are `nil`, and a `nil`
+  The eleven injected callbacks. Ten field defaults are `nil`, and a `nil`
   on a LIVE session still means "this session cannot do that thing" (a
   user session has no `recover_source`; a visitor session has no
   `away_persister`) — but which nils are legitimate is decided at the
@@ -248,6 +273,7 @@ defmodule Grappa.Session.Deps do
           visitor_password_rotator: visitor_password_rotator() | nil,
           visitor_nick_persister: visitor_nick_persister() | nil,
           credential_failer: credential_failer() | nil,
+          link_state_reporter: link_state_reporter() | nil,
           credential_committer: credential_committer() | nil,
           registration_committer: registration_committer() | nil,
           last_joined_persister: last_joined_persister() | nil,
@@ -260,6 +286,7 @@ defmodule Grappa.Session.Deps do
             visitor_password_rotator: nil,
             visitor_nick_persister: nil,
             credential_failer: nil,
+            link_state_reporter: nil,
             credential_committer: nil,
             registration_committer: nil,
             last_joined_persister: nil,
@@ -277,12 +304,14 @@ defmodule Grappa.Session.Deps do
     credential_committer: 1,
     credential_failer: 1,
     last_joined_persister: 2,
+    link_state_reporter: 1,
     registration_committer: 1
   }
 
   @visitor_injections %{
     credential_failer: 1,
     last_joined_persister: 2,
+    link_state_reporter: 1,
     recover_source: 0,
     visitor_committer: 3,
     visitor_nick_persister: 2,
@@ -294,11 +323,11 @@ defmodule Grappa.Session.Deps do
   @injectable_keys Enum.sort(Enum.uniq(Map.keys(@user_injections) ++ Map.keys(@visitor_injections)))
 
   @typedoc """
-  The closed set of injectable closure keys — NINE, not ten.
+  The closed set of injectable closure keys — TEN, not eleven.
 
-  Nine and not ten because the review's ten is the UNION OF WHAT THE TWO
-  PRODUCERS INJECT, and one member of that union is `refresh_plan`, which
-  this struct does not carry. Measured, not assumed:
+  Ten and not eleven because the union of WHAT THE TWO PRODUCERS INJECT
+  includes `refresh_plan`, which this struct does not carry. Measured,
+  not assumed:
 
   * it is absent from `defstruct` above and always has been;
   * `Server.init/1` reads it with its own `Map.get(opts, :refresh_plan)`
@@ -310,16 +339,17 @@ defmodule Grappa.Session.Deps do
 
   Excluded by that structure, therefore, not by oversight and not because
   its absence is safe: both producers inject it, so it belongs to the same
-  silent-absence class as these nine, and it stays UNGUARDED. That is the
-  documented limitation of this door. `query_window_open?` is the tenth
-  STRUCT field and is likewise not here, for the opposite reason — no
-  producer injects it and it has a real production default.
+  silent-absence class as these ten, and it stays UNGUARDED. That is the
+  documented limitation of this door. `query_window_open?` is the
+  eleventh STRUCT field and is likewise not here, for the opposite
+  reason — no producer injects it and it has a real production default.
   """
   @type injectable ::
           :away_persister
           | :credential_committer
           | :credential_failer
           | :last_joined_persister
+          | :link_state_reporter
           | :recover_source
           | :registration_committer
           | :visitor_committer
@@ -369,6 +399,7 @@ defmodule Grappa.Session.Deps do
       visitor_password_rotator: Map.get(opts, :visitor_password_rotator),
       visitor_nick_persister: Map.get(opts, :visitor_nick_persister),
       credential_failer: Map.get(opts, :credential_failer),
+      link_state_reporter: Map.get(opts, :link_state_reporter),
       credential_committer: Map.get(opts, :credential_committer),
       registration_committer: Map.get(opts, :registration_committer),
       last_joined_persister: Map.get(opts, :last_joined_persister),

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -370,6 +370,9 @@ defmodule Grappa.Session.Server do
           optional(:visitor_password_rotator) => Deps.visitor_password_rotator(),
           optional(:visitor_nick_persister) => Deps.visitor_nick_persister(),
           optional(:credential_failer) => Deps.credential_failer(),
+          # #1675 — non-terminal link-state reporter; BOTH subject tags
+          # inject it (the `connection_state` write set is subject-blind).
+          optional(:link_state_reporter) => Deps.link_state_reporter(),
           optional(:credential_committer) => Deps.credential_committer(),
           optional(:registration_committer) => Deps.registration_committer(),
           optional(:last_joined_persister) => Deps.last_joined_persister(),
@@ -2841,7 +2844,21 @@ defmodule Grappa.Session.Server do
   # untouched by this.
   def handle_info({:irc_connect_failed, reason}, state) do
     maybe_notify_session_phase(state, {:connect_failed, reason})
-    {:noreply, state}
+
+    # #1675 — the same fact, for the two surfaces that outlive this
+    # process. The notify above reaches ONE waiting login and only while
+    # it waits; nothing carried the diagnosis to the operator, so a
+    # network that could never register kept reading `connected`.
+    #
+    # This arm is the trigger and not `terminate/2` on purpose: every
+    # abnormal teardown lands there, including the mid-session netsplit
+    # that reconnects on the first retry, and marking THAT `:failing`
+    # would churn the row on every blip. A failed connect ATTEMPT is the
+    # honest evidence that the link is not coming up right now.
+    described = Client.describe_connect_failure(reason)
+    :ok = report_link_state(state, {:failing, described})
+
+    {:noreply, persist_link_failure(state, described)}
   end
 
   # #550 — the Client captured the upstream peer at connect. Cache it
@@ -3079,6 +3096,16 @@ defmodule Grappa.Session.Server do
     # timer above (which paces the Backoff-ladder RESET, 60s) — the badge
     # flips the instant we're connected, not after the stability window.
     broadcast_connection_progress(state, :connected)
+
+    # #1675 — the DURABLE half of the same fact, and the return edge of
+    # the `:failing` transition below. The badge above is an ephemeral
+    # overlay a page load cannot see; this walks the credential row back
+    # to `:connected` with the failure cause cleared, so a client that
+    # arrives after the recovery reads a row that is true. A no-op on a
+    # row that is already `:connected`, which is the overwhelming
+    # majority of 001s — the idempotency lives in
+    # `Networks.mark_registered/1`, not here.
+    report_link_state(state, :registered)
 
     # #229: query the operator's OWN umode set at registration. ircds don't
     # report umodes unsolicited (only mode CHANGES echo back), so without
@@ -6545,6 +6572,71 @@ defmodule Grappa.Session.Server do
     _ = Broadcaster.to_user(state, SessionWire.connection_progress(state.network_slug, progress))
 
     :ok
+  end
+
+  # #1675 — report the UPSTREAM LINK's registration state to the
+  # credential row through the plan's injected closure. The durable twin
+  # of `broadcast_connection_progress/2` above: that one is an ephemeral
+  # overlay with no snapshot (a page load during a failing loop sees
+  # nothing until the next backoff tick), this one is the row every REST
+  # read and every cold client load goes through.
+  #
+  # Called INLINE, unlike `credential_failer`'s supervised Task: neither
+  # verb behind it stops the session, so there is no `stop_session`
+  # deadlock to dodge, and the write is one row on a path that runs at
+  # most once per connect attempt.
+  #
+  # The nested `Map.get` is hot-reload safety on TWO axes, both real: a
+  # process spawned before #1390 has no `:deps` key at all, and one
+  # spawned before #1675 has a `%Deps{}` struct built without this
+  # field. Either would be a KeyError on the connect path — i.e. a live
+  # session dropped by a deploy. Absent ⇒ no report, which is exactly
+  # the pre-#1675 behaviour.
+  @spec report_link_state(t(), {:failing, String.t()} | :registered) :: :ok
+  defp report_link_state(state, link_state) do
+    case Map.get(Map.get(state, :deps, %Deps{}), :link_state_reporter) do
+      reporter when is_function(reporter, 1) ->
+        _ = reporter.(link_state)
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  # #1675 — the same failure, in the window the operator is looking at.
+  # vjt's three networks failed silently as far as the UI was concerned:
+  # the TLS hostname mismatch existed only in the server log, and the
+  # `$server` window (created by the spawn, like every other window) sat
+  # there looking normal.
+  #
+  # One row per FAILED ATTEMPT, deliberately unlike the row transition
+  # above, which is idempotent. This is a log, and the honest granularity
+  # for a log is per attempt — "still refusing, 6 tries later" is the
+  # fact an operator needs and a single first-cause line cannot carry.
+  # Bounded by the backoff ladder itself (5s doubling to a 5min cap), not
+  # by a dedup we would have to keep honest.
+  #
+  # `:server_event` (event-tier, not content) and the anonymous sender
+  # sentinel: nobody said this, and it did not come off the wire —
+  # `Message.anonymous_sender/0` is the closed-set value the storage
+  # layer already accepts for exactly that.
+  @spec persist_link_failure(t(), String.t()) :: t()
+  defp persist_link_failure(state, described) do
+    attrs =
+      Session.put_subject_id(
+        %{
+          network_id: state.network_id,
+          channel: "$server",
+          server_time: System.system_time(:millisecond),
+          sender: Message.anonymous_sender(),
+          body: "upstream connect failed: " <> described,
+          meta: %{link_failure: %{reason: described}}
+        },
+        state.subject
+      )
+
+    apply_effects([{:persist, :server_event, attrs}], state)
   end
 
   # Channel directory (#84) C3 — per-numeric handling of an in-flight LIST

--- a/lib/grappa/visitors/session_plan.ex
+++ b/lib/grappa/visitors/session_plan.ex
@@ -222,6 +222,20 @@ defmodule Grappa.Visitors.SessionPlan do
       # the full struct so a delete-between-spawn-and-failure race
       # surfaces as `{:error, :not_found}` (handled inside
       # `mark_failed/2`) instead of stale-row write.
+      # #1675 — visitor half of the link reporter. IDENTICAL closure to the
+      # user side (`Networks.SessionPlan`), because the drift it fixes is
+      # subject-blind: a visitor credential goes through the same
+      # `Networks.connect/1` and carries a real `connection_state` since
+      # #211 ruling D, so a user-only reporter would leave half the column
+      # claiming a registration that never happened.
+      #
+      # Note this does NOT mirror `credential_failer` below, which is
+      # deliberately DIFFERENT per subject (the visitor terminal axis is
+      # the TTL/identity row, not the credential state). Non-terminal
+      # link state has no such split: the row is the row.
+      link_state_reporter: fn link_state ->
+        Networks.report_link_state({:visitor, visitor.id}, network.id, link_state)
+      end,
       credential_failer: fn reason ->
         case Visitors.mark_failed(visitor.id, reason) do
           :ok -> :ok

--- a/priv/repo/migrations/20260822204452_widen_boot_credential_index_to_failing.exs
+++ b/priv/repo/migrations/20260822204452_widen_boot_credential_index_to_failing.exs
@@ -1,0 +1,62 @@
+defmodule Grappa.Repo.Migrations.WidenBootCredentialIndexToFailing do
+  @moduledoc """
+  #1675 — the boot query stopped being "WHERE connection_state =
+  'connected'".
+
+  `Credentials.list_credentials_for_all_users/0` now selects the
+  WANTED-UP set, `IN ('connected','failing')`, so a reboot inside a
+  reconnect-backoff window brings the network back instead of leaving it
+  down until a human PATCHes the row. The partial index added by
+  `20260512083037` (and carried through the `20260711123000` XOR-FK
+  table rebuild) is predicated on the old equality, and SQLite may only
+  use a partial index when the query's WHERE clause IMPLIES the index's
+  own — which `IN ('connected','failing')` does not. Left alone, the
+  index would carry a predicate its own query can never match while
+  still costing a write on every transition.
+
+  ## What this does NOT claim, measured rather than assumed
+
+  `EXPLAIN QUERY PLAN` on the boot query (test DB, 2026-08-22) picks
+  `network_credentials_user_id_network_id_index (user_id>?)` — the
+  partial unique index that also serves the `user_id IS NOT NULL`
+  conjunct #211 added — and not this one, before or after the widening.
+  So this is NOT "restoring the index the boot path needs": it keeps the
+  predicate ALIGNED with the query the index was created for. One
+  observation, on a small DB with no `ANALYZE` stats, and SQLite's
+  choice is per-connection — enough to refuse the stronger claim, not
+  enough to justify dropping the index outright.
+
+  No data migration: this is an index predicate, not a value. Rows keep
+  whatever state they carry (no existing row can be `:failing` — the
+  value did not exist before this deploy).
+  """
+  use Ecto.Migration
+
+  @old_name :network_credentials_connection_state_connected_index
+  @new_name :network_credentials_connection_state_boot_index
+  @boot_predicate "connection_state IN ('connected', 'failing')"
+
+  def up do
+    drop index(:network_credentials, [:connection_state],
+            where: "connection_state = 'connected'",
+            name: @old_name
+          )
+
+    create index(:network_credentials, [:connection_state],
+             where: @boot_predicate,
+             name: @new_name
+           )
+  end
+
+  def down do
+    drop index(:network_credentials, [:connection_state],
+            where: @boot_predicate,
+            name: @new_name
+          )
+
+    create index(:network_credentials, [:connection_state],
+             where: "connection_state = 'connected'",
+             name: @old_name
+           )
+  end
+end

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 4
-shape_digest = sha256:b51b3b6fc9fde697c9fb0a3bfe7b3ecfc8db14ddd1f62493828c31fc28b47a43
+protocol_version = 5
+shape_digest = sha256:516f5f58171ad5c5697be017b62c170f761990f3b78bb371b1873e8a4d6ed945

--- a/test/grappa/bootstrap_test.exs
+++ b/test/grappa/bootstrap_test.exs
@@ -104,6 +104,41 @@ defmodule Grappa.BootstrapTest do
       assert is_pid(Session.whereis({:user, vjt.id}, net_b.id))
     end
 
+    test "#1675 — resumes a :failing credential, still skips :parked and :failed" do
+      vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      {_, port_a} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, port_b} = IRCServer.start_server(IRCServer.passthrough_handler())
+
+      net_failing = bind_db(vjt, "failing-#{System.unique_integer([:positive])}", port_a)
+      net_failed = bind_db(vjt, "failed-#{System.unique_integer([:positive])}", port_b)
+
+      on_exit(fn -> stop_session(vjt.id, net_failing.id) end)
+      on_exit(fn -> stop_session(vjt.id, net_failed.id) end)
+
+      # `:failing` = "wanted up, link not registered, backoff running". A
+      # reboot landing inside that backoff window MUST bring the row back,
+      # or a misconfigured-then-fixed network stays down until a human
+      # PATCHes it — the reason `:failing` and `:failed` are two values
+      # and not one `:failed` plus a reason grep.
+      vjt
+      |> Credentials.get_credential!(net_failing)
+      |> Ecto.Changeset.change(
+        connection_state: :failing,
+        connection_state_reason: "connection refused"
+      )
+      |> Repo.update!()
+
+      vjt
+      |> Credentials.get_credential!(net_failed)
+      |> Ecto.Changeset.change(connection_state: :failed, connection_state_reason: "k-line")
+      |> Repo.update!()
+
+      assert {:ok, %Result{}} = Bootstrap.run()
+
+      assert is_pid(Session.whereis({:user, vjt.id}, net_failing.id))
+      assert Session.whereis({:user, vjt.id}, net_failed.id) == nil
+    end
+
     test "logs structured summary line with 5-bucket honest counts" do
       vjt = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())

--- a/test/grappa/irc/connect_failure_description_test.exs
+++ b/test/grappa/irc/connect_failure_description_test.exs
@@ -1,0 +1,99 @@
+defmodule Grappa.IRC.ConnectFailureDescriptionTest do
+  @moduledoc """
+  #1675 — `Grappa.IRC.Client.describe_connect_failure/1`.
+
+  The reason string this produces is what the operator reads in cicchetto
+  (`connection_state_reason`) and in the `$server` window, so it has to
+  carry the ACTUAL cause, not a category label. Every shape pinned here
+  is one the connect path really produces — the POSIX atoms from
+  `:gen_tcp.connect/4`, the `:ssl` alert tuple, and our own
+  `{:source_family_mismatch, …}` from `source_bind/2`.
+
+  The unknown arm is deliberately `inspect/1` rather than a friendly
+  fallback: an unmapped shape must stay diagnosable, and a "connection
+  failed" that hides the tuple is exactly the category label this issue
+  is about.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.IRC.Client
+
+  describe "POSIX connect errors" do
+    test "names the cause in words, one line, no atom syntax" do
+      assert Client.describe_connect_failure(:econnrefused) =~ "refused"
+      assert Client.describe_connect_failure(:timeout) =~ "timeout"
+      assert Client.describe_connect_failure(:etimedout) =~ "timeout"
+      assert Client.describe_connect_failure(:nxdomain) =~ "not found"
+      assert Client.describe_connect_failure(:ehostunreach) =~ "unreachable"
+      assert Client.describe_connect_failure(:enetunreach) =~ "unreachable"
+    end
+  end
+
+  describe "the three shapes prod produced on 2026-08-22" do
+    test "a TLS alert keeps the alert AND the description OTP gave us" do
+      described =
+        Client.describe_connect_failure(
+          {:tls_alert,
+           {:handshake_failure,
+            ~c"TLS client: In state wait_cert_cr at ssl_handshake.erl:2126 generated CLIENT ALERT: Fatal - Handshake Failure - {bad_cert,{hostname_check_failed,{requested,\"irc.ircnet.com\"},{received,[{dNSName,\"ircnet.tngnet.nl\"}]}}}"}}
+        )
+
+      assert described =~ "tls"
+      assert described =~ "handshake_failure"
+      # The hostnames are the whole diagnosis — vjt could not tell the
+      # misconfigured endpoint from a flaky network without them.
+      assert described =~ "irc.ircnet.com"
+      assert described =~ "ircnet.tngnet.nl"
+    end
+
+    test "a source-family mismatch says which side is which" do
+      described =
+        Client.describe_connect_failure(
+          {:source_family_mismatch, "2a01:4f8::1", "irc.undernet.org", :inet6}
+        )
+
+      assert described =~ "2a01:4f8::1"
+      assert described =~ "irc.undernet.org"
+      assert described =~ "IPv6"
+      # The host is the A-only side — say so, don't leave the reader to
+      # infer it from the family of the source.
+      assert described =~ "AAAA"
+    end
+
+    test "an IPv4 source against a v6-only host reads the mirror image" do
+      described =
+        Client.describe_connect_failure({:source_family_mismatch, "10.0.0.1", "irc.example", :inet})
+
+      assert described =~ "IPv4"
+      assert described =~ "A record"
+    end
+  end
+
+  describe "the contract every arm owes the DB column" do
+    test "never returns CR, LF or NUL — the changeset rejects them" do
+      multiline =
+        Client.describe_connect_failure({:tls_alert, {:handshake_failure, ~c"line one\nline two\r\n"}})
+
+      refute multiline =~ "\n"
+      refute multiline =~ "\r"
+      refute multiline =~ <<0>>
+    end
+
+    test "is bounded — an OTP alert description must not become the whole column" do
+      long =
+        Client.describe_connect_failure({:tls_alert, {:handshake_failure, List.duplicate(?x, 4_000)}})
+
+      # Bounded in GRAPHEMES, not bytes: a byte-sliced string can end
+      # mid-codepoint, and the column stores Elixir-canonical UTF-8.
+      assert String.length(long) <= 500
+      assert String.ends_with?(long, "…")
+    end
+
+    test "an unmapped shape stays diagnosable rather than becoming a category" do
+      described = Client.describe_connect_failure({:something_new, %{code: 42}})
+
+      assert described =~ "something_new"
+      assert described =~ "42"
+    end
+  end
+end

--- a/test/grappa/irc/connect_failure_description_test.exs
+++ b/test/grappa/irc/connect_failure_description_test.exs
@@ -48,9 +48,7 @@ defmodule Grappa.IRC.ConnectFailureDescriptionTest do
 
     test "a source-family mismatch says which side is which" do
       described =
-        Client.describe_connect_failure(
-          {:source_family_mismatch, "2a01:4f8::1", "irc.undernet.org", :inet6}
-        )
+        Client.describe_connect_failure({:source_family_mismatch, "2a01:4f8::1", "irc.undernet.org", :inet6})
 
       assert described =~ "2a01:4f8::1"
       assert described =~ "irc.undernet.org"

--- a/test/grappa/networks/connection_state_test.exs
+++ b/test/grappa/networks/connection_state_test.exs
@@ -262,19 +262,265 @@ defmodule Grappa.Networks.ConnectionStateTest do
     end
   end
 
-  describe "Credentials.list_credentials_for_all_users/0 — filter on :connected" do
-    test "returns only :connected credentials, skips :parked + :failed" do
+  # #1675 — the non-terminal half of the pair. `mark_failed/2` above stops
+  # the session and is terminal; these two say "the link is not registered"
+  # / "it is" WITHOUT touching the session, so the reconnect ladder keeps
+  # running underneath and the row stops claiming a registration that never
+  # happened.
+  describe "mark_failing/2" do
+    test "from :connected: writes :failing + the cause, LEAVES the session alive, broadcasts" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, network, cred} = user_with_credential(port, %{})
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      assert {:ok, updated} = Networks.mark_failing(cred, "connect refused")
+
+      assert updated.connection_state == :failing
+      assert updated.connection_state_reason == "connect refused"
+      assert %DateTime{} = updated.connection_state_changed_at
+
+      # THE distinguishing property vs mark_failed/2: no stop_session. The
+      # session must survive so its own backoff ladder can retry — that is
+      # why option 1 as filed (`mark_failed/2` + a 001 edge back) could
+      # never work: it kills the process that would deliver the 001.
+      assert Process.alive?(pid)
+      assert Session.whereis({:user, user.id}, network.id) == pid
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :connection_state_changed,
+                         from: :connected,
+                         to: :failing,
+                         reason: "connect refused"
+                       }
+                     },
+                     500
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "idempotent on :failing: keeps the FIRST cause, no write, no broadcast" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, _, fresh} = user_with_credential(port, %{})
+      cred = set_state(fresh, :failing, "tls: hostname mismatch")
+      original_changed_at = cred.connection_state_changed_at
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, returned} = Networks.mark_failing(cred, "connect timeout")
+      assert returned.connection_state == :failing
+      assert returned.connection_state_reason == "tls: hostname mismatch"
+      assert returned.connection_state_changed_at == original_changed_at
+
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :connection_state_changed}}, 100
+
+      reloaded = reload_credential(cred)
+      assert reloaded.connection_state_reason == "tls: hostname mismatch"
+    end
+
+    test "rejects from :parked — a user park outranks a server-observed failure" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, _, fresh} = user_with_credential(port, %{})
+      cred = set_state(fresh, :parked, "user wants out")
+
+      assert {:error, :user_parked} = Networks.mark_failing(cred, "connect refused")
+
+      reloaded = reload_credential(cred)
+      assert reloaded.connection_state == :parked
+      assert reloaded.connection_state_reason == "user wants out"
+    end
+
+    test "rejects from :failed — terminal does not decay into non-terminal" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, _, fresh} = user_with_credential(port, %{})
+      cred = set_state(fresh, :failed, "k-line: G:Lined")
+
+      assert {:error, :terminal} = Networks.mark_failing(cred, "connect refused")
+
+      reloaded = reload_credential(cred)
+      assert reloaded.connection_state == :failed
+      assert reloaded.connection_state_reason == "k-line: G:Lined"
+    end
+  end
+
+  describe "mark_registered/1" do
+    test "from :failing: back to :connected with the cause CLEARED, broadcasts" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, _, fresh} = user_with_credential(port, %{})
+      cred = set_state(fresh, :failing, "connect refused")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, updated} = Networks.mark_registered(cred)
+      assert updated.connection_state == :connected
+      assert updated.connection_state_reason == nil
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :connection_state_changed,
+                         from: :failing,
+                         to: :connected,
+                         reason: nil
+                       }
+                     },
+                     500
+
+      reloaded = reload_credential(cred)
+      assert reloaded.connection_state == :connected
+      assert reloaded.connection_state_reason == nil
+    end
+
+    test "idempotent on :connected — 001 fires on every reconnect, so this must not write" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, _, cred} = user_with_credential(port, %{})
+      original_changed_at = cred.connection_state_changed_at
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, returned} = Networks.mark_registered(cred)
+      assert returned.connection_state == :connected
+      assert returned.connection_state_changed_at == original_changed_at
+
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :connection_state_changed}}, 100
+    end
+
+    test "rejects from :parked and :failed — neither is wanted-up" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, _, a} = user_with_credential(port, %{})
+      {_, _, b} = user_with_credential(port, %{})
+
+      assert {:error, :not_failing} = Networks.mark_registered(set_state(a, :parked, "manual"))
+      assert {:error, :not_failing} = Networks.mark_registered(set_state(b, :failed, "k-line"))
+    end
+  end
+
+  describe "the three existing verbs against the new state (#1675)" do
+    test "disconnect/2 parks a :failing row — the operator must be able to stop a hammering network" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, _, fresh} = user_with_credential(port, %{})
+      cred = set_state(fresh, :failing, "connect refused")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, updated} = Networks.disconnect(cred, "stop it")
+      assert updated.connection_state == :parked
+      assert updated.connection_state_reason == "stop it"
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :connection_state_changed, from: :failing, to: :parked}
+                     },
+                     500
+    end
+
+    test "mark_failed/2 escalates a :failing row to terminal" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, _, fresh} = user_with_credential(port, %{})
+      cred = set_state(fresh, :failing, "connect refused")
+
+      assert {:ok, updated} = Networks.mark_failed(cred, "k-line: G:Lined")
+      assert updated.connection_state == :failed
+      assert updated.connection_state_reason == "k-line: G:Lined"
+    end
+
+    test "connect/1 is a no-op on :failing — the row is already wanted-up, and it is NOT registered" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, _, fresh} = user_with_credential(port, %{})
+      cred = set_state(fresh, :failing, "connect refused")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert {:ok, returned} = Networks.connect(cred)
+      assert returned.connection_state == :failing
+      assert returned.connection_state_reason == "connect refused"
+
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :connection_state_changed}}, 100
+    end
+  end
+
+  # #1675 — the door `Session.Server` reaches through its injected closure.
+  # Subject-polymorphic on purpose: the write set of `connection_state` has
+  # no subject branch, so a user-only door would leave the visitor half of
+  # the same column lying in exactly the way this issue is about.
+  describe "report_link_state/3" do
+    test "{:failing, reason} then :registered, for a USER credential" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, network, cred} = user_with_credential(port, %{})
+
+      assert :ok =
+               Networks.report_link_state({:user, user.id}, network.id, {:failing, "no route"})
+
+      assert reload_credential(cred).connection_state == :failing
+
+      assert :ok = Networks.report_link_state({:user, user.id}, network.id, :registered)
+
+      reloaded = reload_credential(cred)
+      assert reloaded.connection_state == :connected
+      assert reloaded.connection_state_reason == nil
+    end
+
+    test "{:failing, reason} then :registered, for a VISITOR credential" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {_, network, _} = user_with_credential(port, %{})
+      visitor = visitor_fixture(network_slug: network.slug)
+      {:ok, cred} = Credentials.get_visitor_credential(visitor.id, network.id)
+      assert cred.connection_state == :connected
+
+      assert :ok =
+               Networks.report_link_state(
+                 {:visitor, visitor.id},
+                 network.id,
+                 {:failing, "connect refused"}
+               )
+
+      {:ok, failing} = Credentials.get_visitor_credential(visitor.id, network.id)
+      assert failing.connection_state == :failing
+      assert failing.connection_state_reason == "connect refused"
+
+      assert :ok = Networks.report_link_state({:visitor, visitor.id}, network.id, :registered)
+
+      {:ok, back} = Credentials.get_visitor_credential(visitor.id, network.id)
+      assert back.connection_state == :connected
+      assert back.connection_state_reason == nil
+    end
+
+    test "a deleted credential is a logged no-op, never a crash" do
+      {_, network, _} = user_with_credential(IRCServer.pick_unused_port(), %{})
+
+      assert :ok =
+               Networks.report_link_state(
+                 {:user, Ecto.UUID.generate()},
+                 network.id,
+                 {:failing, "gone"}
+               )
+    end
+  end
+
+  describe "Credentials.list_credentials_for_all_users/0 — the boot set" do
+    test "returns :connected AND :failing, skips :parked + :failed" do
       {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {_, _, cred_connected} = user_with_credential(port, %{})
       {_, _, cred_parked} = user_with_credential(port, %{})
       {_, _, cred_failed} = user_with_credential(port, %{})
+      {_, _, cred_failing} = user_with_credential(port, %{})
       _ = set_state(cred_parked, :parked, "manual")
       _ = set_state(cred_failed, :failed, "k-line")
+      _ = set_state(cred_failing, :failing, "connect refused")
 
       listed = Credentials.list_credentials_for_all_users()
       keys = Enum.map(listed, fn c -> {c.user_id, c.network_id} end)
 
       assert {cred_connected.user_id, cred_connected.network_id} in keys
+      # #1675 point 4 — a reboot inside a backoff window must NOT drop the
+      # network for good. `:failed` stays skipped (terminal, operator acts);
+      # `:failing` is resumed, which is the whole reason they are two values.
+      assert {cred_failing.user_id, cred_failing.network_id} in keys
       refute {cred_parked.user_id, cred_parked.network_id} in keys
       refute {cred_failed.user_id, cred_failed.network_id} in keys
     end

--- a/test/grappa/session/deps_test.exs
+++ b/test/grappa/session/deps_test.exs
@@ -62,12 +62,18 @@ defmodule Grappa.Session.DepsTest do
       assert injected_arities(plan) == Deps.required_injections({:visitor, visitor.id})
     end
 
-    test "the two due sets are disjoint on all but the two shared persisters" do
+    test "the two due sets are disjoint on all but the three shared closures" do
       user_keys = {:user, "u"} |> Deps.required_injections() |> Map.keys() |> MapSet.new()
       visitor_keys = {:visitor, "v"} |> Deps.required_injections() |> Map.keys() |> MapSet.new()
 
+      # #1675 added the third: `link_state_reporter` is shared because the
+      # `connection_state` write set it feeds has no subject branch. The
+      # terminal `credential_failer` is shared as a KEY while the two
+      # producers inject genuinely different closures behind it (visitor
+      # terminal failure expires the identity row, not the credential
+      # state) — this assertion is about the due SET, not the behaviour.
       assert MapSet.intersection(user_keys, visitor_keys) ==
-               MapSet.new([:credential_failer, :last_joined_persister])
+               MapSet.new([:credential_failer, :last_joined_persister, :link_state_reporter])
     end
 
     test "injectable_keys/0 is exactly the union of the two due sets" do

--- a/test/grappa/session/link_state_report_test.exs
+++ b/test/grappa/session/link_state_report_test.exs
@@ -69,13 +69,34 @@ defmodule Grappa.Session.LinkStateReportTest do
       port = IRCServer.pick_unused_port()
       {user, network, _} = user_with_credential(port, %{})
 
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      # Subscribe to the `$server` window itself, NOT to the row-state
+      # event on the user topic: the persist happens AFTER the state
+      # report, so waiting on the state broadcast and then reading the DB
+      # is a race that only shows under load (it did, in the full suite).
+      # The row broadcast is emitted by `Persistor` AFTER the insert
+      # returns, so receiving it is proof the row landed.
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "$server")
+        )
+
       pid = start_session_for(user, network)
 
       assert_receive %Phoenix.Socket.Broadcast{
-                       payload: %{kind: :connection_state_changed, to: :failing}
+                       event: "event",
+                       payload: %{
+                         kind: :message,
+                         message: %{kind: :server_event, body: broadcast_body, meta: meta}
+                       }
                      },
                      5_000
+
+      assert broadcast_body =~ "refused"
+      # Structured beside the prose: an old client renders the body, a
+      # future one can style the cause without re-parsing English.
+      assert %{link_failure: %{reason: reason}} = meta
+      assert reason =~ "refused"
 
       rows =
         Scrollback.fetch({:user, user.id}, network.id, "$server", nil, 50, "grappa-test", false)

--- a/test/grappa/session/link_state_report_test.exs
+++ b/test/grappa/session/link_state_report_test.exs
@@ -1,0 +1,136 @@
+defmodule Grappa.Session.LinkStateReportTest do
+  @moduledoc """
+  #1675 — the seam between a dead upstream and the row the UI reads.
+
+  The defect: `network_credentials.connection_state` recorded that a
+  session process was STARTED, not that IRC came up, so a network failing
+  every connect attempt rendered as `connected` and the operator had no
+  way to tell it from a live one. These tests drive the real path —
+  `Session.Server` → the plan's injected `link_state_reporter` closure →
+  `Networks.report_link_state/3` → the row + the broadcast — against a
+  real socket (`Grappa.IRCServer`), never a mocked `:gen_tcp`.
+
+  Both directions are covered here because both were missing: a failed
+  connect must WRITE `:failing` + the cause, and 001 RPL_WELCOME must
+  take it back to `:connected` with the cause cleared.
+
+  `async: false` — `SessionRegistry`, `SessionSupervisor`, `PubSub` and
+  `Session.Backoff` are singletons.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{IRCServer, Networks, Scrollback, Session}
+  alias Grappa.PubSub.Topic
+
+  describe "a connect that never reaches the upstream" do
+    test "marks the row :failing with the real cause, and leaves the session retrying" do
+      # A port nothing listens on: the connect is refused deterministically,
+      # which is the harness twin of vjt's three prod cases (TLS hostname
+      # mismatch / A-only host against a v6 source / connect timeout) — all
+      # of them arrive here as the SAME `{:irc_connect_failed, reason}`.
+      port = IRCServer.pick_unused_port()
+      {user, network, cred} = user_with_credential(port, %{})
+      assert cred.connection_state == :connected
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :connection_state_changed,
+                         from: :connected,
+                         to: :failing,
+                         reason: reason
+                       }
+                     },
+                     5_000
+
+      # The cause, not a category label. `:econnrefused` is the shape the
+      # gen_tcp connect returns; the operator must read WHY, not "error".
+      assert is_binary(reason)
+      assert reason =~ "refused"
+
+      reloaded = reload_credential(cred)
+      assert reloaded.connection_state == :failing
+      assert reloaded.connection_state_reason == reason
+
+      # Non-terminal: the session is still up and its backoff ladder is
+      # still running. This is the property `mark_failed/2` cannot have.
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "puts the cause in the $server window too — not only in the server log" do
+      port = IRCServer.pick_unused_port()
+      {user, network, _} = user_with_credential(port, %{})
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+      pid = start_session_for(user, network)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       payload: %{kind: :connection_state_changed, to: :failing}
+                     },
+                     5_000
+
+      rows =
+        Scrollback.fetch({:user, user.id}, network.id, "$server", nil, 50, "grappa-test", false)
+
+      assert Enum.any?(rows, fn row ->
+               row.kind == :server_event and is_binary(row.body) and row.body =~ "refused"
+             end),
+             "expected a $server row naming the connect failure, got: " <>
+               inspect(Enum.map(rows, & &1.body))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
+  describe "001 RPL_WELCOME on a row that was failing" do
+    test "takes it back to :connected and clears the cause" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, network, cred} = user_with_credential(port, %{})
+
+      # Seed the state a previous incarnation would have left behind: the
+      # row says the link is down, the reboot resumed it (that resume is
+      # itself #1675 point 4), and this connect is the one that works.
+      :ok =
+        Networks.report_link_state(
+          {:user, user.id},
+          network.id,
+          {:failing, "connection refused"}
+        )
+
+      assert reload_credential(cred).connection_state == :failing
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 2_000)
+      IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :connection_state_changed,
+                         from: :failing,
+                         to: :connected,
+                         reason: nil
+                       }
+                     },
+                     5_000
+
+      reloaded = reload_credential(cred)
+      assert reloaded.connection_state == :connected
+      assert reloaded.connection_state_reason == nil
+
+      assert Session.whereis({:user, user.id}, network.id) == pid
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+end


### PR DESCRIPTION
Addresses #1675. `connection_state` had stopped describing the upstream link and
had started describing the spawn: `Networks.connect/1` writes `:connected` the
moment a `Session.Server` starts, so a network whose upstream refuses every
connect still reads `connected` in the API and in cic, with no reason attached.

## What this changes

- **A fourth value, `:failing`.** `Credential.connection_states/0` is now
  `[:connected, :parked, :failing, :failed]`. `:failed` keeps its terminal
  meaning untouched.
- **A non-terminal verb that does not stop the session** — `mark_failing/2`,
  reversed by `mark_registered/1` at `001`, broadcasting on the existing
  `connection_state_changed`. Idempotent while already `:failing`: no write, no
  broadcast, and the FIRST cause is kept (it is the one closest to the
  misconfiguration).
- **`connection_state_reason` is written on this path**, carrying the actual
  cause from `IRC.Client.describe_connect_failure/1` — never a category label.
  cic already rendered the field; the missing piece was the writer.
- **Boot resumes `:failing`** — `list_credentials_for_all_users/0` selects
  `IN [:connected, :failing]`; `:parked` and `:failed` are still skipped.
- **`:connected` now means REGISTERED UPSTREAM**, and the two doc blocks that
  said otherwise are rewritten.
- **cic renders the fourth state** (⚠️ glyph, `danger` tone, amber) instead of
  degrading it to `unknown`.
- **Wire `protocol_version` 4 → 5.** The number was decided by the pin digest,
  not chosen: `wire_pin --update` refuses a new shape digest at a still number.
  `min_protocol_version` stays `1` — the change is additive.

### Why a fourth value rather than `:failed` plus a reason

Not a preference. `Networks.mark_failed/2` calls `Session.stop_session/2`
BEFORE `transition!/3`, and the child is `:transient`, so no process survives to
receive an `RPL_WELCOME`: the `:failed → :connected` edge that option needed is
unreachable by construction. And a single value rather than a taxonomy
(`:tls_error`, `:rejected`, …) because an enum that names causes must grow on
every new cause, while a reason string does not.

## What was measured, and on which SHA

Everything below was measured on **`9d1218c7`**, rebased onto
**`e935a83a`** (`origin/main`, #1680), working tree empty and frozen for the
duration of each run.

| gate | result |
|------|--------|
| `scripts/check.sh` | **RC=0**, all nine stage markers present |
| ExUnit | `8 doctests, 62 properties, 6810 tests, 0 failures` |
| Credo (strict) | `6261 mods/funs, found no issues` |
| Dialyzer | `Total errors: 0, Skipped: 0` … `done (passed successfully)` |
| `mix deps.audit` | `No vulnerabilities found.` |
| Sobelow | ran clean of Medium-or-above (two pre-existing **Low** findings in `lib/grappa/cic/bundle.ex`, untouched here) |
| doctor | `Doctor validation has passed!` |
| `gen_wire_types --check` | `wireTypes.ts is in sync.` + `wireSchema.ts is in sync.` |
| `wire_pin --check` | `priv/wire/shape.pin: wire shape and protocol 5 agree.` |
| bats | `1..659`, `ok` = 659, `not ok` = 0 |
| `scripts/integration.sh` (FULL) | **RC=0**, `765 passed (35.7m)`, 0 failed, 0 flaky, `retries: 0` |
| `scripts/bun.sh run check` | 4 stages, 0 failed |
| `scripts/design-notes-gate.sh origin/main` | rc=0, `1 new entry heading` |

The `check.sh` per-stage markers are listed rather than the exit code alone
because `mix ci.check` halts on the first non-zero: a stage that never started
leaves no marker, and counting failures would report it as zero.

A note on the integration run: the summary line carries no per-project
breakdown. Counting the per-test lines gives **619 `chromium` + 146
`webkit-iphone-15` = 765**, which reconciles with the total — that split is a
derivation, not a figure read off the summary. Zero reds is independently
corroborated by the suite's own #1584 cold-start census, which printed exactly
2 rows for 2 projects (it mints a fresh cold seat per failed test).

### The e2e

`cicchetto/e2e/tests/issue1675-failing-link-state.spec.ts`, two tests, both
green (35.6 s and 1.3 m).

1. **`failing` + the cic display.** A `network_servers` row on a closed loopback
   port (ECONNREFUSED — instant, no DNS, no route, no wait). Asserts the row
   reads `failing`, that the reason MATCHES `/connection refused/i` rather than
   merely being set, and then that cic renders
   `.home-pane-network-row-failing` with **the same string the API returned**.
2. **The recovery edge.** A ring of `[dead, dead, live]`: `refresh_plan`
   re-resolves at `Backoff.failure_count` and `pick_server!/2` indexes the ring
   by that ordinal, so the session walks onto the live leaf at attempt 2. The
   oracle is the SEQUENCE `failing → connected` with the reason cleared, plus
   `connection.port` on the live leaf. It also asserts the `$server` window
   still carries `upstream connect failed: connection refused` AFTER recovery,
   so an operator can see why the network was down once it came back.

The subject is `admin-vjt`, the one seeded user with no network bind, so neither
test can disturb — or be disturbed by — the seeded sessions the rest of the
suite depends on.

The reboot arm is deliberately not in e2e (restarting the container mid-suite is
heavy and flaky); it is covered by `test/grappa/bootstrap_test.exs` — *"#1675 —
resumes a `:failing` credential, still skips `:parked` and `:failed`"* — against
the real `Bootstrap.run/0`.

## Limits, stated rather than hidden

- **The e2e exercises exactly one cause, ECONNREFUSED.** The TLS-hostname
  mismatch and the source-family mismatch — two of the three real production
  failures — are covered only at the string level in
  `connect_failure_description_test.exs`.
- **No registration watchdog.** A socket that CONNECTS but never registers
  (blocked rDNS, ident hang) emits no `irc_connect_failed` and still reads
  `:connected`. This change does nothing for it; it wants its own issue and its
  own policy argument.
- **The `:parked` window eats the FIRST failure, and is named rather than
  cured.** Every operator-driven connect spawns before writing `:connected`
  (that ordering is the cure of #642), so an instantly-refusing upstream reports
  while the row is still `:parked`, and a `:parked` row declines the write.
  Measured: `credential_bound` at `.464` → `declined (user_parked)` at `.466`.
  The row self-corrects at attempt 2, ~35 s in. Curing it means reordering
  #642's U-0 sequence — a different slice. It is documented on `mark_failing/2`
  and in the DESIGN_NOTES entry, and it is where the e2e budgets come from.
- **The sibling class-#642 defect on the visitor path** —
  `Visitors.attach_credential/2` writes `:connected` BEFORE the spawn — is
  named in DESIGN_NOTES and not cured here.
- **The SQLite index migration ALIGNS a predicate; it does not restore an index
  the boot query needs.** Measured once with `EXPLAIN QUERY PLAN` on a test DB
  with no `ANALYZE`: the planner picks
  `network_credentials_user_id_network_id_index` both before and after. Written
  that way in the migration's moduledoc.
- **No third-party client on v3 or v4 was measured.** `min_protocol_version`
  stays 1 and the change is additive, but that is an argument, not a
  measurement.
- Production was never touched: no deploy, no health check.

## Rebase

Rebased twice. The first, onto `390bd56e`, produced one conflict in
`protocol.ex` + `shape.pin` because **both sides said `4`** (#1679 had taken 4
for `GET /boot`); resolved by keeping both histories — v4 stays #1679's, v5 is
this branch's — and #1679's paragraph was left exactly where it was. The second,
onto `e935a83a`, was clean: #1680 is cic-only plus DESIGN_NOTES and touches
neither `protocol.ex` nor `shape.pin`.

Both times the DESIGN_NOTES ritual ran in full rather than by eye: two-sided
numstat pinned to a file (**227 add / 0 del → 227 add / 0 del**, and the whole
34-file numstat identical line for line), the first `3494135` bytes of the
branch's `DESIGN_NOTES.md` proven **byte-identical** to main's entire file
(pure append, nothing eaten and nothing resurrected), the boundary shape read
back on the real file (`…closed.` / `<!-- entry #1675 -->` / blank / `---` /
blank / `## heading`, no blank ahead of the marker), and the marker's
uniqueness checked against the base's CURRENT tip — 0 occurrences, with a
positive control on `<!-- entry #1680 -->` returning 1 to prove the check can
find one.
