### PR TITLE
fix(#1682): name a third-party client from its product token, and give the device-name format one owner

### DIFF
--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -56,7 +56,7 @@ import {
   saveUploadTtlSeconds,
   uploadTtlSecondsValue,
 } from "./lib/uploadOrchestrator";
-import { deviceClassIcon, parseUserAgent } from "./lib/userAgent";
+import { deviceClassIcon, deviceDisplayName, parseUserAgent } from "./lib/userAgent";
 import {
   DEFAULT_NOTIFICATION_PREFS,
   getNotificationPrefs,
@@ -1948,7 +1948,7 @@ const SettingsDrawer: Component<Props> = (props) => {
                                         twice on an unnamed row says nothing. */}
                                     <Show when={row.named}>
                                       <span class="device-activity" data-testid="device-parsed">
-                                        {parsed.browser} on {parsed.os}
+                                        {deviceDisplayName(parsed)}
                                       </span>
                                     </Show>
                                     <Show when={activity !== null}>

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -735,8 +735,14 @@ describe("deviceRows — #964: the name the device row prints", () => {
       dev({ id: "a", user_agent: null, created_at: "2026-08-01T09:00:00Z" }),
       dev({ id: "b", user_agent: "", created_at: "2026-08-02T09:00:00Z" }),
     ]);
-    expect(nameOf(rows, "a")).toBe("Unknown browser on Unknown OS #1");
-    expect(nameOf(rows, "b")).toBe("Unknown browser on Unknown OS #2");
+    // #1682 — these used to read "Unknown browser on Unknown OS #n". The
+    // suffix is dropped whenever the OS is unknown, and that rule takes no
+    // exception for a UA that is absent rather than merely unrecognised: a
+    // second branch for the empty case would be the same duplication this
+    // change removes. The grouping itself is unaffected — both rows still
+    // collapse into one group and are still numbered within it.
+    expect(nameOf(rows, "a")).toBe("Unknown browser #1");
+    expect(nameOf(rows, "b")).toBe("Unknown browser #2");
   });
 
   it("returns an empty list for an empty device list", () => {

--- a/cicchetto/src/__tests__/userAgent.test.ts
+++ b/cicchetto/src/__tests__/userAgent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deviceClassIcon, parseUserAgent } from "../lib/userAgent";
+import { deviceClassIcon, deviceDisplayName, parseUserAgent } from "../lib/userAgent";
 
 // UX-4 bucket L (2026-05-19) — minimal UA-string parser.
 // Tests cover the common modern browsers/platforms in plain UA-string
@@ -96,12 +96,97 @@ describe("userAgent.parseUserAgent", () => {
     });
   });
 
-  it("returns Unknown browser + Unknown OS on a totally weird UA", () => {
-    expect(parseUserAgent("HypotheticalBot/9000")).toEqual({
+  it("returns Unknown browser + Unknown OS on a UA carrying no product token", () => {
+    // #1682 note: "HypotheticalBot/9000" used to live here as the
+    // never-classified case. It IS a well-formed product token, so it now
+    // parses as "HypotheticalBot" — that reclassification is the fix, not a
+    // regression. The genuinely unclassifiable UA is one with no `Name/version`
+    // at its head at all.
+    expect(parseUserAgent("some free-form nonsense")).toEqual({
       browser: "Unknown browser",
       os: "Unknown OS",
       deviceClass: "unknown",
     });
+  });
+});
+
+// #1682 — third-party / native clients. `detectBrowser`'s allowlist only ever
+// knew browsers, so every native client collapsed to "Unknown browser". The
+// product-token branch runs LAST, after every browser branch, and only on a UA
+// that is not Mozilla-shaped.
+describe("userAgent.parseUserAgent — third-party clients (#1682)", () => {
+  it("names a bare native client from its leading product token", () => {
+    expect(parseUserAgent("Resentin/1.2.3")).toEqual({
+      browser: "Resentin",
+      os: "Unknown OS",
+      deviceClass: "unknown",
+    });
+  });
+
+  it("names a native client that carries a platform comment it cannot place", () => {
+    expect(parseUserAgent("Resentin/1.2 (FreeBSD 14.1; amd64)")).toEqual({
+      browser: "Resentin",
+      os: "Unknown OS",
+      deviceClass: "unknown",
+    });
+  });
+
+  it("keeps the OS when a native client DOES carry a platform token", () => {
+    // The product-token branch replaces only the browser; detectOs and
+    // detectDeviceClass are untouched and still get their chance.
+    expect(parseUserAgent("Resentin/1.2 (Macintosh; arm64)")).toEqual({
+      browser: "Resentin",
+      os: "macOS",
+      deviceClass: "desktop",
+    });
+  });
+
+  it("does NOT name an unrecognised BROWSER 'Mozilla'", () => {
+    // The load-bearing guard. Every browser UA starts "Mozilla/5.0", so
+    // without the not-Mozilla-shaped test the first product token of an
+    // unknown Chromium fork is literally "Mozilla" — a confident wrong
+    // answer, strictly worse than "Unknown browser".
+    const ua =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) NotAKnownFork/9.9";
+    expect(parseUserAgent(ua).browser).toBe("Unknown browser");
+  });
+
+  it("still prefers a browser branch over the product token", () => {
+    // Order guard: the allowlist runs first, so a Mozilla-shaped Firefox is
+    // "Firefox" and never reaches the new branch.
+    expect(parseUserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Firefox/120.0").browser).toBe(
+      "Firefox",
+    );
+  });
+
+  it("rejects a product name carrying markup rather than sanitising it", () => {
+    // The capture class is an ALLOWLIST, so `<` cannot survive into the name:
+    // the token simply fails to match and we fall back. Rejecting at the
+    // boundary beats emitting a scrubbed half-name.
+    expect(parseUserAgent("Res<script>entin/1.0").browser).toBe("Unknown browser");
+  });
+
+  it("rejects a product name carrying a control character", () => {
+    // Built rather than written as a literal escape: a raw control byte in a
+    // source file turns it binary to grep and survives review unseen.
+    const nul = String.fromCharCode(0);
+    expect(parseUserAgent(`Resentin${nul}Evil/1.0`).browser).toBe("Unknown browser");
+  });
+
+  it("rejects a product name carrying whitespace before the version", () => {
+    expect(parseUserAgent("Resentin Evil/1.0").browser).toBe("Unknown browser");
+  });
+
+  it("caps an absurdly long product name at 32 characters, ellipsis included", () => {
+    const name = "A".repeat(200);
+    const parsed = parseUserAgent(`${name}/1.0`);
+    expect(parsed.browser).toBe(`${"A".repeat(31)}…`);
+    expect(parsed.browser.length).toBe(32);
+  });
+
+  it("leaves a product name exactly at the cap untouched", () => {
+    const name = "B".repeat(32);
+    expect(parseUserAgent(`${name}/1.0`).browser).toBe(name);
   });
 });
 
@@ -120,5 +205,35 @@ describe("userAgent.deviceClassIcon", () => {
 
   it("returns ❔ for unknown", () => {
     expect(deviceClassIcon("unknown")).toBe("❔");
+  });
+});
+
+// #1682 — the ONE owner of the `Browser on OS` format. Before this it was
+// composed by hand in two places (`push.ts` and `SettingsDrawer.tsx`), which
+// is why the OS-suffix drop needed a home rather than a second copy.
+describe("userAgent.deviceDisplayName", () => {
+  it("prints `Browser on OS` when the OS is known", () => {
+    const ua =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    expect(deviceDisplayName(parseUserAgent(ua))).toBe("Chrome on macOS");
+  });
+
+  it("drops the suffix entirely when the OS is unknown", () => {
+    // "Resentin on Unknown OS" is noise; "Resentin" is what the reader
+    // expects. The icon stays unknown — that axis is untouched.
+    expect(deviceDisplayName(parseUserAgent("Resentin/1.2"))).toBe("Resentin");
+  });
+
+  it("keeps the suffix for a native client that DID place its OS", () => {
+    expect(deviceDisplayName(parseUserAgent("Resentin/1.2 (Macintosh; arm64)"))).toBe(
+      "Resentin on macOS",
+    );
+  });
+
+  it("applies the same rule to an absent UA — no special case for empty", () => {
+    // One rule, "OS unknown ⇒ no suffix", rather than a second branch that
+    // would drift from the first the moment either is touched.
+    expect(deviceDisplayName(parseUserAgent(null))).toBe("Unknown browser");
+    expect(deviceDisplayName(parseUserAgent(""))).toBe("Unknown browser");
   });
 });

--- a/cicchetto/src/lib/push.ts
+++ b/cicchetto/src/lib/push.ts
@@ -35,7 +35,7 @@
 import { ApiError, readError } from "./api";
 import { formatDurationSince } from "./duration";
 import { isIos, isStandalonePwa } from "./platform";
-import { parseUserAgent } from "./userAgent";
+import { deviceDisplayName, parseUserAgent } from "./userAgent";
 
 const SUBSCRIBED_VAPID_KEY_STORAGE_KEY = "cic.vapidPublicKey";
 
@@ -184,10 +184,11 @@ export type DeviceRow = {
   named: boolean;
 };
 
-const parsedDeviceName = (device: PushDeviceSummary): string => {
-  const parsed = parseUserAgent(device.user_agent);
-  return `${parsed.browser} on ${parsed.os}`;
-};
+// #1682 — the format itself lives in `deviceDisplayName`, which is also
+// what SettingsDrawer renders. This string is the GROUPING KEY below, so
+// it has to stay byte-identical to what the user actually reads.
+const parsedDeviceName = (device: PushDeviceSummary): string =>
+  deviceDisplayName(parseUserAgent(device.user_agent));
 
 // Oldest first, id as the tiebreak so the ordering is TOTAL — two rows
 // created in the same microsecond (or with an unparseable instant) must

--- a/cicchetto/src/lib/userAgent.ts
+++ b/cicchetto/src/lib/userAgent.ts
@@ -18,6 +18,14 @@
 // Pattern order matters: Edge UA contains "Chrome" + "Safari" + "Edg"
 // — we check Edg first. iOS Chrome contains "CriOS" not "Chrome" —
 // check CriOS first. Match the most specific brand wins.
+//
+// #1682 (2026-08-23) — the allowlist above only ever knew BROWSERS, so
+// every third-party native client (a self-hoster's `Resentin/1.2`, the
+// native Android shell of #1193) rendered as "Unknown browser". The cure
+// is a product-token branch that runs LAST, after every brand branch:
+// see `detectProductName`. It is deliberately not an entry per client —
+// an allowlist that has to grow once per client is the defect, not the
+// gap in it.
 
 export type DeviceClass = "desktop" | "mobile" | "tablet" | "unknown";
 
@@ -27,9 +35,15 @@ export type ParsedUserAgent = {
   deviceClass: DeviceClass;
 };
 
+// One literal each, one owner: `deviceDisplayName` compares against
+// UNKNOWN_OS to decide whether the ` on <os>` suffix is worth printing,
+// and a second spelling of either string would silently break that test.
+const UNKNOWN_BROWSER = "Unknown browser";
+const UNKNOWN_OS = "Unknown OS";
+
 const UNKNOWN: ParsedUserAgent = {
-  browser: "Unknown browser",
-  os: "Unknown OS",
+  browser: UNKNOWN_BROWSER,
+  os: UNKNOWN_OS,
   deviceClass: "unknown",
 };
 
@@ -49,6 +63,47 @@ export const deviceClassIcon = (cls: DeviceClass): string => {
   }
 };
 
+// Every browser UA on earth opens with "Mozilla/5.0" for historical
+// reasons, so a UA of that shape which matched none of the brand
+// branches is an unrecognised BROWSER, not a native client — and its
+// first product token is the literal string "Mozilla". Naming it that
+// would be a confident wrong answer, which is strictly worse than
+// admitting we do not know.
+const MOZILLA_SHAPED = /^Mozilla\//;
+
+// RFC 9110 §10.1.5: `User-Agent = product *( RWS ( product / comment ) )`
+// and `product = token "/" product-version`. We take the FIRST product,
+// which is the one naming the client itself.
+//
+// The capture class is an ALLOWLIST, and that is the whole sanitisation
+// story: the name comes from an attacker-controlled request header and
+// is rendered in the drawer, so rather than scrub afterwards we simply
+// cannot capture a control character, a quote, an angle bracket, an
+// ampersand or whitespace — none of them are in the class, so a UA
+// carrying them fails to match and falls back. Rejecting at the
+// boundary beats emitting a mangled half-name. (Solid escapes text
+// nodes anyway; this holds the line one layer earlier, where the
+// closed set is actually expressible.)
+const PRODUCT_TOKEN = /^([A-Za-z0-9][A-Za-z0-9._+-]*)\/[\d.]+/;
+
+// The remaining unbounded axis is length, so it gets the one cap.
+// 32 is ~2.3x the longest product token that actually ships in the wild
+// ("SamsungBrowser" / "HeadlessChrome", 14), so no real client is ever
+// truncated, while the row stays inside a drawer whose width was the
+// original reason (see the header) this module exists at all. The class
+// above is ASCII-only, so `.length` counts characters and `slice` cannot
+// split a surrogate pair. The ellipsis is not decoration: without it a
+// truncated name reads as a genuine product name.
+const MAX_PRODUCT_NAME = 32;
+
+const detectProductName = (ua: string): string | null => {
+  if (MOZILLA_SHAPED.test(ua)) return null;
+  const match = PRODUCT_TOKEN.exec(ua);
+  const name = match?.[1];
+  if (name === undefined) return null;
+  return name.length > MAX_PRODUCT_NAME ? `${name.slice(0, MAX_PRODUCT_NAME - 1)}…` : name;
+};
+
 const detectBrowser = (ua: string): string => {
   // Order: most specific first. Edg / OPR / CriOS / FxiOS all
   // embed substrings from upstream Chrome/Safari.
@@ -59,7 +114,9 @@ const detectBrowser = (ua: string): string => {
   if (/\bFirefox\/[\d.]+/.test(ua)) return "Firefox";
   if (/\bChrome\/[\d.]+/.test(ua)) return "Chrome";
   if (/\bSafari\/[\d.]+/.test(ua) && /Version\/[\d.]+/.test(ua)) return "Safari";
-  return "Unknown browser";
+  // #1682 — LAST, and only here: a brand branch must always win, or Edge
+  // and Opera break (see the header).
+  return detectProductName(ua) ?? UNKNOWN_BROWSER;
 };
 
 const detectOs = (ua: string): string => {
@@ -69,7 +126,7 @@ const detectOs = (ua: string): string => {
   if (/Windows NT/.test(ua)) return "Windows";
   if (/X11.*Linux|Linux x86_64|Linux i686/.test(ua)) return "Linux";
   if (/CrOS/.test(ua)) return "ChromeOS";
-  return "Unknown OS";
+  return UNKNOWN_OS;
 };
 
 const detectDeviceClass = (ua: string): DeviceClass => {
@@ -83,12 +140,45 @@ const detectDeviceClass = (ua: string): DeviceClass => {
 };
 
 /**
+ * The ONE owner of the displayed device name.
+ *
+ * `${browser} on ${os}` (e.g. "Chrome on macOS") when we placed the OS,
+ * and the bare browser otherwise. Consumers pair it with
+ * `deviceClassIcon(p.deviceClass)` to render a chip like
+ * "💻 Chrome on macOS".
+ *
+ * ## Why the suffix is DROPPED rather than printed as "on Unknown OS"
+ *
+ * A native client typically sends no platform token at all, so the old
+ * format produced "Resentin on Unknown OS" — a sentence whose second
+ * half carries no information and reads as a parser failure. "Resentin"
+ * is what the reader expects (minimum surprise). The device-class icon
+ * still shows ❔, so nothing is being hidden: the unknown-ness moved to
+ * the axis that can express it in one glyph instead of three words.
+ *
+ * ONE rule, "OS unknown ⇒ no suffix", with no exception for a UA that is
+ * absent rather than merely unrecognised — an absent UA prints "Unknown
+ * browser", not "Unknown browser on Unknown OS". A second branch for the
+ * empty case would be a second rule, free to drift from the first.
+ *
+ * ## Why this is a function and not a template literal at the call site
+ *
+ * #1682: it WAS a template literal at the call site, in two of them
+ * (`push.ts` and `SettingsDrawer.tsx`), written out by hand. In `push.ts`
+ * that string is not merely display — it is the GROUPING KEY the `#1`/`#2`
+ * ordinals are derived from (see `deviceRows`). Had the suffix been
+ * dropped at one site only, the key would have stopped being the thing
+ * the user reads, which is the property that whole design rests on.
+ */
+export const deviceDisplayName = (parsed: ParsedUserAgent): string =>
+  parsed.os === UNKNOWN_OS ? parsed.browser : `${parsed.browser} on ${parsed.os}`;
+
+/**
  * Parses a UA string into `{browser, os, deviceClass}`. Returns
  * UNKNOWN-shaped placeholder for null/empty inputs.
  *
- * Format choice: `${browser} on ${os}` (e.g. "Chrome on macOS").
- * Consumers pair the parsed name with `deviceClassIcon(p.deviceClass)`
- * to render a chip like "💻 Chrome on macOS".
+ * Render the result through `deviceDisplayName`, which owns the format;
+ * do not compose `browser` and `os` by hand.
  */
 export const parseUserAgent = (ua: string | null | undefined): ParsedUserAgent => {
   if (ua === null || ua === undefined || ua === "") return UNKNOWN;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59281,3 +59281,120 @@ tag list the gate feeds that action, via the workflow text. The end-to-end fact
 is unreachable without cutting a release. `.github/workflows/**` is also
 outside `integration.yml`'s `paths:`, so this change's PR runs fewer checks
 than a source change does.
+<!-- entry #1682 -->
+
+---
+
+## 2026-08-23 — #1682: the UA parser knew browsers, not clients
+
+`cicchetto/src/lib/userAgent.ts` classified the push-device list's
+`user_agent` through a fixed allowlist of browser tokens (`Edg` / `OPR` /
+`CriOS` / `FxiOS` / `Firefox` / `Chrome` / `Safari`+`Version`). Anything
+else fell through to `"Unknown browser"`. A self-hoster running a native
+third-party client (`Resentin/1.2`) therefore read **"Unknown browser on
+Unknown OS"** for their own device, and so would the native Android shell
+of #1193.
+
+cic-only: the server neither filters nor classifies. It stores the header
+verbatim (`push_subscription_controller.ex`) and ships the raw string back
+(`push_subscription_json.ex`), and that stays true here.
+
+### The fix is a branch, not an entry
+
+Growing the allowlist once per client is the defect rather than a gap in
+it, so the cure is a final **product-token** branch: RFC 9110 §10.1.5 says
+`User-Agent = product *( RWS ( product / comment ) )`, so the first product
+names the client. It runs **LAST**, after every brand branch, because Edge
+and Opera UAs embed `Chrome`/`Safari` substrings and any other order breaks
+them — the pre-existing ordering constraint is unchanged, only extended.
+
+It is guarded on the UA not being **Mozilla-shaped**, and that guard is
+load-bearing rather than decorative. Every browser UA on earth opens
+`Mozilla/5.0`, so without it an unrecognised Chromium fork would be named
+**"Mozilla"** — a confident wrong answer, which is strictly worse than
+"Unknown browser". A parser that guesses is worse than one that abstains.
+
+### Sanitisation by construction, and the one cap
+
+The product name is attacker-controlled text from a request header that
+ends up rendered in the drawer, so it is sanitised — but by the shape of
+the capture, not by scrubbing afterwards. The capture class is an
+allowlist, `[A-Za-z0-9._+-]`, a deliberate subset of RFC 9110's `tchar`
+with every character that means something in an HTML or attribute context
+removed. A control byte, a quote, an angle bracket, an ampersand or a
+space therefore **cannot** reach the name: the token fails to match and the
+UA falls back. Rejecting at the boundary beats emitting a scrubbed
+half-name, and it is one rule instead of a filter list that must be kept
+in step with its own threat model.
+
+Length is the single axis a character class cannot bound, so it takes the
+single cap: **32 characters, ellipsis included**. The number is argued, not
+picked: it is ~2.3x the longest product token that actually ships in the
+wild (`SamsungBrowser` / `HeadlessChrome`, 14), so no real client is ever
+truncated, while the row stays inside the drawer width that motivated this
+module's existence in the first place (UX-4 bucket L). The class is
+ASCII-only, so `.length` counts characters and `slice` cannot split a
+surrogate pair. The ellipsis is not decoration — without it a truncated
+name reads as a genuine product name.
+
+### Why the OS-suffix drop forced a formatter, and a measurement
+
+A native client usually carries no platform token, so it would have
+rendered as "Resentin on Unknown OS": a sentence whose second half is
+noise. The suffix is dropped whenever the OS is unknown.
+
+That decision looked like a display tweak and was not. `${browser} on
+${os}` was composed **by hand in two places** — `push.ts` and, inline in
+JSX, `SettingsDrawer.tsx` — and in `push.ts` that string is not display at
+all: it is the **grouping key** the `#1`/`#2` ordinals for unlabelled twins
+are derived from (#964, whose own moduledoc states "the grouping key is the
+OUTPUT of `parseUserAgent`"). Dropping the suffix at one site would not
+have risked divergence between the two, it would have guaranteed it, and
+it would have severed the key from the string the user actually reads.
+
+So the format moved into **`deviceDisplayName`**, its one owner, and both
+sites call it. The alternative considered and rejected was making the type
+carry the absence (`os: null` in `ParsedUserAgent`): it changes the
+semantics for every reader and collapses "OS unknown" into "OS absent"
+exactly while the device-class icon still wants them distinct. The
+already-duplicated literal is the evidence that a second consumer always
+arrives; a format with one owner is what to have in place before the third.
+
+### One rule, no exception for the empty UA
+
+"OS unknown ⇒ no suffix" takes no special case for a UA that is absent
+rather than merely unrecognised: an empty or null UA now prints **"Unknown
+browser"**, not "Unknown browser on Unknown OS". A branch for the empty
+case would be a second rule, free to drift from the first the moment either
+is touched — the same defect being cured here, in miniature. This
+**supersedes** the first "Limitations" bullet of the #964 entry, which
+records the old two-word-noise spelling; the grouping behaviour it
+describes is unchanged, only the string is.
+
+The device-class icon is untouched. An unplaceable client still shows ❔,
+so nothing is concealed: the unknown-ness moved to the axis that expresses
+it in one glyph instead of three words.
+
+`HypotheticalBot/9000` had been the test suite's never-classified case. It
+is a well-formed product token and now parses as "HypotheticalBot" — that
+reclassification IS the fix, so the test was rewritten around a UA carrying
+no product token at its head at all.
+
+### Measured, and what was deliberately left alone
+
+Measured on `f1d9ff2f`. The issue recorded "whether any other surface
+renders this string" as NOT MEASURED; a three-way sweep (parser symbols,
+module imports, raw `user_agent`) settles it at **two** consumers,
+`SettingsDrawer.tsx` and `push.ts` — the second of which the issue did not
+name, and is the one that made this more than a display change.
+
+`SettingsDrawer.tsx` also puts the **raw** UA in a `title=` attribute. That
+is pre-existing, is an attribute rather than markup, and is left untouched
+here rather than folded into this slice; it is recorded so the next reader
+does not have to rediscover that the raw string still reaches the DOM.
+
+No e2e spec was added. The change is a pure function plus its two call
+sites, `userAgent.test.ts` pins the classification matrix directly, and
+`push.test.ts` pins the grouping the format feeds; a browser-driven spec
+would exercise Playwright's own UA rather than the branch under test, and
+would assert rendering plumbing that #964's specs already cover.


### PR DESCRIPTION
Refs #1682. cic-only; no server change.

## The defect

`detectBrowser` in `cicchetto/src/lib/userAgent.ts` was an allowlist of **browser** tokens, so any native third-party client sending a plain `Product/version` UA fell through to `"Unknown browser"`. A self-hoster on `Resentin/1.2` read *"Unknown browser on Unknown OS"* as their own device in the push-device list, and the native Android shell of #1193 would have too.

## The change

**A product-token branch, not an allowlist entry.** RFC 9110 §10.1.5 makes the first `product` the one that names the client, so a UA that matched no brand gets its leading token as the name. The branch runs **last** — the brand branches must stay first or Edge and Opera break on the `Chrome`/`Safari` substrings they embed.

**Guarded on the UA not being Mozilla-shaped, and that guard is correctness.** Every browser UA opens `Mozilla/5.0`, so without it an unrecognised Chromium fork would be named **"Mozilla"** — a confident wrong answer, strictly worse than admitting we don't know.

**Sanitisation by construction.** The name is attacker-controlled header text rendered in the drawer. Rather than scrub after capture, the capture class *is* an allowlist (`[A-Za-z0-9._+-]`, a subset of RFC 9110 `tchar` with every HTML/attribute-meaningful character removed): a control byte, quote, angle bracket, ampersand or space cannot reach the name, because such a UA fails to match and falls back. Length is the one axis a character class can't bound, so it takes the one cap — **32 chars, ellipsis included**: ~2.3× the longest product token that actually ships (`SamsungBrowser`, 14), so no real client is ever truncated, while the row stays inside the drawer width that motivated this module. The ellipsis is not decoration: without it a truncated name reads as a real one.

**The OS-suffix drop forced a formatter, and that is the non-obvious half.** A native client usually carries no platform token, so it would have rendered *"Resentin on Unknown OS"*. The suffix is now dropped whenever the OS is unknown — but `${browser} on ${os}` was composed **by hand in two places**, and in `push.ts` that string is not display: it is the **grouping key** `deviceRows` derives the `#1`/`#2` ordinals from (#964). Dropping it at one site would have *guaranteed* divergence and severed the key from what the user reads. So the format moved into `deviceDisplayName`, its one owner, called by both sites. Rejected alternative: `os: null` in `ParsedUserAgent` — it changes the type's semantics for every reader and collapses "unknown" into "absent" exactly while the device-class icon still wants them distinct.

**One rule, no exception for the empty UA.** An absent UA now prints `Unknown browser`, not `Unknown browser on Unknown OS`. A branch for the empty case would be a second rule free to drift from the first. `push.test.ts` pinned the old string and is updated, not worked around; grouping behaviour is unchanged.

The device-class icon is untouched — an unplaceable client still shows ❔, so the unknown-ness moved to the axis that says it in one glyph instead of three words.

`HypotheticalBot/9000` was the suite's never-classified case. It is a well-formed product token and now parses as `HypotheticalBot`; that reclassification **is** the fix, so the test was rewritten around a UA with no product token at its head.

## Measured

On `f1d9ff2f`. The issue listed *"whether any other surface renders this string"* as NOT MEASURED. A three-way sweep (parser symbols, module imports, raw `user_agent`) settles it at **two** consumers: `SettingsDrawer.tsx` and `push.ts`. The second is not named in the issue and is the one that made this more than a display change.

## Gates

| gate | result |
|---|---|
| `scripts/bun.sh run check` | **rc=0 — 4 stages ran, 0 failed** (lock drift, biome src+e2e, tsc src, tsc e2e) |
| `scripts/bun.sh run test` | **rc=0 — 304 files / 5919 tests** |
| `scripts/design-notes-gate.sh origin/main` | **rc=0 — "1 new entry heading(s), separator and marker present."** |

The 59 biome warnings + 4 infos are the pre-existing `src/themes/default.css` `noDescendingSpecificity` set; that stage reports `ok`.

TDD: red first — 9 failed / 19 passed on the new spec before implementation, the 19 being the untouched pre-existing matrix.

## Not claimed

- **No e2e spec.** The change is a pure function plus two call sites; `userAgent.test.ts` pins the classification matrix directly and `push.test.ts` pins the grouping it feeds. A browser-driven spec would exercise Playwright's own UA rather than the branch under test, and would assert rendering plumbing #964's specs already cover. Stated as a judgement, not as coverage.
- **`SettingsDrawer.tsx` still puts the raw UA in a `title=` attribute.** Pre-existing, an attribute rather than markup, and left alone rather than folded into this slice — recorded in DESIGN_NOTES so it isn't rediscovered.
- **No rebase ritual claimed**: the branch's merge base is `f1d9ff2f`, which is `origin/main`'s tip, so no rebase was performed and no two-sided numstat comparison applies. Append purity of `docs/DESIGN_NOTES.md` was verified byte-for-byte over the base's full 3,514,890 bytes; the entry is a pure append (117 added, 0 deleted).
