### PR TITLE
packaging(#1686): rank ghcr :latest over releases, not over every tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -852,6 +852,19 @@ jobs:
       # `mix.exs`, `mix.lock`, `VERSION` and `cicchetto` are POINTEDLY absent: the
       # moment source joins this list, the artifact stops being the tag and the
       # label lies.
+      #
+      # The two `infra/packaging` scripts are the exception that proves it, and
+      # they are WORKFLOW LOGIC rather than shipped bytes (#1686). The `:latest`
+      # gate below calls them, and the tree this job checks out on a repair is
+      # the OLD TAG's: `git tag --contains d622616d` answers `v1.3.0 v1.3.1`, so
+      # every earlier tag predates `prerelease_flag.sh` and the call would die
+      # 127 on a path that works today. Taking them from the dispatched ref is
+      # the same principle the whole repair path rests on — "dispatching from
+      # main runs the FIXED workflow against the tag" — extended to the two
+      # helpers that workflow now reasons with. MEASURED not to touch the
+      # artifact: `Dockerfile.release` COPYs exactly two files out of
+      # infra/packaging (`version.sh`, `gen-secrets.sh`) and neither is one of
+      # these, so the image is byte-for-byte the tag's either way.
       - name: Repair path — take the image build scaffolding from the dispatched ref
         if: ${{ env.IMAGE_REPAIR == 'true' }}
         run: |
@@ -860,7 +873,9 @@ jobs:
             Dockerfile.release \
             Dockerfile.shottino \
             .dockerignore \
-            infra/docker
+            infra/docker \
+            infra/packaging/latest_tag_gate.sh \
+            infra/packaging/prerelease_flag.sh
           # Print it. A repair that silently changed nothing means the tag was
           # already fine and the failure is elsewhere; a repair that changed more
           # than expected is the reviewer's business, not a surprise found later
@@ -930,19 +945,28 @@ jobs:
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "shottino_name=${shottino_name}" >> "$GITHUB_OUTPUT"
 
-          # :v<version> always; :latest ONLY when v<version> is the highest semver
-          # tag in the repo — a backport tag push (v0.7.5 after v0.8.0) must not
-          # re-point `:latest` at an OLDER image. deb/rpm/arch are immune (they
-          # attach to a tag-keyed Release); only the docker images have a MUTABLE
-          # `:latest`. These tags are USED only when push:true — a dry-run
-          # (push:false) computes but discards them. `-v:refname` sorts by semver.
-          highest="$(git tag -l 'v*' --sort=-v:refname | head -1)"
-          if [ "v${version}" = "${highest}" ]; then
-            latest=yes
-            echo "v${version} is the highest tag — tagging :latest"
-          else
-            latest=no
-            echo "v${version} is NOT the highest (${highest}) — NOT tagging :latest"
+          # :v<version> always; :latest ONLY when v<version> is the highest
+          # RELEASE tag in the repo. TWO hazards, ONE gate: a backport tag push
+          # (v0.7.5 after v0.8.0) must not re-point `:latest` at an OLDER image,
+          # and a release candidate must not take it at all. deb/rpm/arch are
+          # immune (they attach to a tag-keyed Release); only the docker images
+          # have a MUTABLE `:latest`. These tags are USED only when push:true —
+          # a dry-run (push:false) computes but discards them.
+          #
+          # The ranking used to be `git tag -l 'v*' --sort=-v:refname | head -1`
+          # written out here, and `versionsort.suffix` is unset in this repo, so
+          # git placed `-rcN` ABOVE the bare version. Both faces were read off
+          # the runs' own logs (#1686): v1.3.0-rc2 took `:latest`, and v1.3.0 was
+          # then DENIED it by its own candidate. The rule now lives in ONE script
+          # that reuses the ONE pre-release classifier — a second hand-rolled
+          # semver comparison is exactly how two `:latest` owners come to drift.
+          #
+          # A verdict that cannot be derived STOPS the job. The permissive
+          # reading — carry on with an empty `latest` — is the one that
+          # publishes, and this decision is not retractable from a registry.
+          if ! latest="$(infra/packaging/latest_tag_gate.sh "v${version}")"; then
+            echo "::error::cannot decide :latest for v${version} — refusing to publish images whose mutable tag was never derived (#1686)"
+            exit 1
           fi
 
           # ONE gate, BOTH images (#1168). Bouncer and bridge are cut from the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59163,3 +59163,121 @@ block autoplay without a gesture, and a rail click is one.
 
 Widening `connect-src` for the live catalogue is left as a NON-blocking note
 for vjt rather than taken here.
+<!-- entry #1686 -->
+
+---
+
+## 2026-08-23 — #1686: ghcr `:latest` ranked over every tag, so a candidate took it and a release was refused it
+
+`release.yml` chose which image gets the mutable ghcr `:latest` with
+
+    highest="$(git tag -l 'v*' --sort=-v:refname | head -1)"
+
+and `versionsort.suffix` is not configured in this repository, so git's
+version sort places a `-rcN` suffix **above** the bare version.
+
+### The report named one face; the runs' logs carry two
+
+Not derived — quoted:
+
+    2026-08-20T23:38:15Z  v1.3.0-rc2 is the highest tag — tagging :latest
+    2026-08-21T19:18:58Z  v1.3.0 is NOT the highest (v1.3.0-rc2) — NOT tagging :latest
+    2026-08-22T08:40:28Z  v1.3.1 is the highest tag — tagging :latest
+
+Face one is the reported one: a **candidate took `:latest`**. Face two is the
+mirror the issue does not name: the **stable release that followed was then
+denied it by its own candidate**, so `:latest` skipped `v1.3.0` entirely and
+served rc2 until `v1.3.1` — roughly **33 hours**, not the ~20 the issue bounds
+it at by assuming the next stable run closed the window. It could not: that
+run is the second line above.
+
+**The rule this leaves: an issue that under-states its own damage sends the
+next person to cure half a defect.** The bound was reasoned from "the next
+stable release shipped" rather than read from the log that stable release
+wrote, and the mechanism denies exactly that inference. When a report bounds
+an exposure, check the closing edge against the artefact that supposedly
+closed it.
+
+### `versionsort.suffix` was rejected, by measurement
+
+The issue proposes belt-and-braces: restrict the ranking **and** set
+`versionsort.suffix`. On a scratch repository holding the tag set as it stood
+at the rc2 push (`v1.0.0 v1.1.0 v1.2.0 v1.3.0-rc1 v1.3.0-rc2`, with no
+`v1.3.0` yet):
+
+    git tag -l 'v*' --sort=-v:refname                   -> v1.3.0-rc2
+    git -c versionsort.suffix=- tag -l ... --sort=...    -> v1.3.0-rc2
+
+Identical. The suffix orders a candidate against **its own release** and
+nothing else, so it repairs face two and leaves the measured face one exactly
+where it was. Restricting the ranking to releases repairs both — and once
+pre-releases are out of the candidate set, the suffix has nothing left to
+order, so configuring it as well is a second mechanism doing the first one's
+job. That is the drift #1591 / #1594 / #1636 all were. **One mechanism, one
+owner.**
+
+### The classifier is not written twice
+
+"Does semver call this a pre-release" already has an owner in this tree:
+`infra/packaging/prerelease_flag.sh` (#1636), measured against `Version.parse/1`
+on the pinned toolchain, refusing with exit 2 what it cannot classify. The new
+`infra/packaging/latest_tag_gate.sh` reuses it rather than comparing versions a
+second time. A hand-rolled filter would be wrong on the very row that decided
+that script's implementation: `v1.4.0+foo-bar` carries a hyphen inside its
+**build** metadata and is a release.
+
+The verdict feeds the existing `emit_tags`, so it reaches the bridge image
+too — `grappa` and `grappa-shottino` are cut from the same tag and have shared
+one gate since #1168. Curing only the bouncer would have been half a cure, and
+the half nobody looks at.
+
+A pre-release gets its **own arm** rather than falling through the ranking.
+Falling through prints `v1.3.0-rc2 is NOT the highest (v1.2.0)`, which is
+false — rc2 *is* higher. A fast path states what it observed.
+
+A tag the classifier refuses is treated differently depending on which one it
+is. The tag **under test** is refused outright (exit 2): the permissive answer
+there is the one that publishes. A tag found in the **repository** is skipped,
+out loud, and the scan carries on — a stray `nightly-…` must not become a
+permanent veto over every future release, and skipping is conservative because
+a tag nobody could classify never had images published under it.
+
+### The cure would have broken the repair path, which works today
+
+The `docker` job checks out `ref: REPAIR_TAG`, so on a #573 (b) image repair
+the tree is the **old tag's**. `git tag --contains d622616d` answers
+`v1.3.0 v1.3.1`: every earlier tag predates `prerelease_flag.sh`, and a naive
+call would have exited 127 on a path that works. The two scripts therefore join
+the repair scaffolding checkout, which is the verb the job **already has** for
+"this comes from the dispatched ref" — the same principle #504 stated as
+"dispatching from main runs the FIXED workflow against the tag", extended to
+the helpers that workflow now reasons with. Measured not to touch the artefact:
+`Dockerfile.release` COPYs exactly two files out of `infra/packaging`
+(`version.sh`, `gen-secrets.sh`) and neither is one of these, so the image
+stays byte-for-byte the tag's. The bats case pins that count at 2 — the moment
+a third joins, it is what notices.
+
+### The bench, and the green that meant nothing
+
+Eight mutants against `test/infra/release_latest_gate_test.bats`; seven died on
+the first pass and **one survived**. Replacing the skip arm with a hard failure
+left the suite green at 15/15, because the case fabricated its unreadable tag
+as `v1.2` — which sorts *under* the tag being asked about, and the scan stops
+at the first release it finds. The classifier was never handed anything it
+could refuse. Fixed by making the stray **outrank** the tag under test (`v9.9`)
+and asserting the skip line on stderr, so "the scan skipped it" is told apart
+from "the scan never looked". Second pass: 8 mutants, 8 killed.
+
+**The general shape: a test that exercises an early-exit scan must place its
+subject on the side of the exit that is actually reached.** A fixture below the
+break point is decoration.
+
+### What the suite does not cover, stated so a green is not read wider
+
+It drives shell logic against fabricated git repositories. It does not run
+GitHub Actions, does not exercise `docker/build-push-action`, and never
+contacts a registry — "which tags the runner pushed" is asserted only as the
+tag list the gate feeds that action, via the workflow text. The end-to-end fact
+is unreachable without cutting a release. `.github/workflows/**` is also
+outside `integration.yml`'s `paths:`, so this change's PR runs fewer checks
+than a source change does.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4547,6 +4547,67 @@ or a repair dispatch against an existing release) does not touch the
 marker, and neither does the body-reconciliation `gh release edit` below
 it. rc1 and rc2 are already correct because they were fixed by hand.
 
+### `latest_tag_gate.sh` — who gets the mutable ghcr `:latest` (#1686)
+
+**`:latest` was ranked over every tag, so a release candidate took it.** The
+`docker` job picked the image that gets the mutable tag with
+`git tag -l 'v*' --sort=-v:refname | head -1`, and `versionsort.suffix` is
+not configured here, so git's version sort places a `-rcN` suffix ABOVE the
+bare version. Quoted from the runs' own logs:
+
+    2026-08-20T23:38:15Z  v1.3.0-rc2 is the highest tag — tagging :latest
+    2026-08-21T19:18:58Z  v1.3.0 is NOT the highest (v1.3.0-rc2) — NOT tagging :latest
+    2026-08-22T08:40:28Z  v1.3.1 is the highest tag — tagging :latest
+
+**Two faces, and the second bounds the exposure.** A candidate took the tag;
+the stable release that followed was then DENIED it by that candidate, so
+`:latest` skipped `v1.3.0` entirely and served rc2 until `v1.3.1` — roughly
+33 hours. `:latest` is what an operator following the published docker path
+pulls (`compose.release.yaml`, `infra/docker/deploy.sh update`).
+
+`infra/packaging/latest_tag_gate.sh` answers the eligibility question. The
+verdict is a bare token on **stdout**; the reason goes to **stderr**, where
+the runner logs it:
+
+    latest_tag_gate.sh v1.3.1      -> yes   (the highest release tag)
+    latest_tag_gate.sh v1.3.0-rc2  -> no    (a pre-release, whatever it outranks)
+    latest_tag_gate.sh v0.7.5      -> no    (a backport, below v0.8.0)
+    latest_tag_gate.sh v1.3        -> refused, exit 2
+
+**It reuses `prerelease_flag.sh` rather than comparing versions again.** A
+hand-rolled filter is wrong on the row that decided that script's
+implementation: `v1.4.0+foo-bar` carries a hyphen inside its BUILD metadata
+and is a release. One rule, one owner.
+
+**`versionsort.suffix` was rejected, by measurement.** On a scratch
+repository holding the tag set as it stood at the rc2 push (no `v1.3.0` yet),
+`git -c versionsort.suffix=- tag -l 'v*' --sort=-v:refname` still answers
+`v1.3.0-rc2`: the suffix orders a candidate against its own release and
+nothing else, so it repairs the second face and leaves the measured first one
+untouched. Restricting the ranking to releases repairs both, and then the
+suffix has nothing left to order.
+
+**ONE gate, BOTH images.** The verdict feeds the existing `emit_tags`, so
+`grappa` and the `grappa-shottino` bridge share it — they are cut from the
+same tag and have shared one gate since #1168.
+
+**A verdict that cannot be derived stops the job** (`::error::`, exit 1). A
+tag found in the REPOSITORY that the classifier refuses is the opposite case:
+it is skipped out loud and the scan carries on, so a stray tag cannot become
+a permanent veto over every future release.
+
+**Operator-visible consequence: a candidate tag now publishes `:v<version>`
+only.** `docker pull ghcr.io/<owner>/grappa` keeps resolving to the newest
+stable release across a candidate cycle; to run a candidate, name its tag.
+
+**A repair dispatch takes both scripts from the dispatched ref.** The docker
+job checks out `ref: REPAIR_TAG`, so on a #573 (b) image repair the tree is
+the OLD TAG's, and every tag before `v1.3.0` predates `prerelease_flag.sh`.
+They ride in the repair scaffolding checkout for that reason; measured not to
+change the artifact, since `Dockerfile.release` COPYs only `version.sh` and
+`gen-secrets.sh` out of `infra/packaging`. Gate:
+`test/infra/release_latest_gate_test.bats`.
+
 ### The packaged operator CLI and the migrate path (#419)
 
 **`/usr/bin/grappa` is the only door to the release on a packaged host.**

--- a/infra/packaging/latest_tag_gate.sh
+++ b/infra/packaging/latest_tag_gate.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+# latest_tag_gate.sh — answer whether a release TAG may take the MUTABLE ghcr
+# `:latest` pointer, so the answer is DERIVED rather than sorted for.
+#
+#   latest_tag_gate.sh v1.3.1      -> yes   (the highest release tag)
+#   latest_tag_gate.sh v1.3.0-rc2  -> no    (a pre-release, whatever it outranks)
+#   latest_tag_gate.sh v0.7.5      -> no    (a backport, below v0.8.0)
+#   latest_tag_gate.sh v1.3        -> refused, exit 2
+#
+# The VERDICT goes to stdout as a bare `yes`/`no`, the REASON to stderr. The
+# caller consumes the first and logs the second — the same split
+# `prerelease_flag.sh` uses for its token and its refusals.
+#
+# WHY THIS EXISTS (GH #1686). The gate this replaces ranked with
+#
+#     highest="$(git tag -l 'v*' --sort=-v:refname | head -1)"
+#
+# and `versionsort.suffix` is not configured in this repository, so git's
+# version sort puts a `-rcN` suffix ABOVE the bare version. The defect has TWO
+# faces and the issue reports one. Both are quoted from the runs' own logs,
+# not derived:
+#
+#     2026-08-20T23:38:15Z  v1.3.0-rc2 is the highest tag — tagging :latest
+#     2026-08-21T19:18:58Z  v1.3.0 is NOT the highest (v1.3.0-rc2) — NOT tagging :latest
+#     2026-08-22T08:40:28Z  v1.3.1 is the highest tag — tagging :latest
+#
+# Face one: a CANDIDATE took `:latest`. Face two: the STABLE release that
+# followed was then DENIED it by its own candidate, so `:latest` skipped
+# v1.3.0 entirely and served rc2 until v1.3.1 — ~33h, not the ~20h the issue
+# bounds it at. `:latest` is what an operator following the published docker
+# path pulls (`compose.release.yaml`, `infra/docker/deploy.sh update`).
+#
+# WHY NOT `versionsort.suffix`, which the issue also proposes — falsified by
+# measurement, not by taste. On a scratch repository holding the tag set as it
+# stood at the rc2 push (v1.0.0 v1.1.0 v1.2.0 v1.3.0-rc1 v1.3.0-rc2, no
+# v1.3.0 yet):
+#
+#     git tag -l 'v*' --sort=-v:refname                 -> v1.3.0-rc2
+#     git -c versionsort.suffix=- tag -l ... --sort=...  -> v1.3.0-rc2
+#
+# Identical. The suffix orders a candidate against ITS OWN release and nothing
+# else, so it repairs face two and leaves the MEASURED face one exactly where
+# it was. Restricting the ranking to releases repairs both — and once
+# pre-releases are out of the candidate set the suffix has nothing left to
+# order, so configuring it as well would be a second mechanism doing the
+# first one's job. One mechanism, one owner: the drift #1591 / #1594 / #1636
+# all were is what two of them become.
+#
+# THE CLASSIFIER IS NOT WRITTEN TWICE. "Does semver call this a pre-release"
+# already has an answer in this directory — `prerelease_flag.sh` (#1636),
+# measured against `Version.parse/1` on the pinned toolchain, and it already
+# REFUSES with exit 2 what it cannot classify. A hand-rolled second comparison
+# here (`grep -v -- -`, say) would be wrong on the row that decided that
+# script's implementation: `v1.4.0+foo-bar` carries a hyphen INSIDE its build
+# metadata and is a release.
+#
+# A TAG THIS CANNOT CLASSIFY IS SKIPPED, NOT FATAL — for tags found in the
+# REPOSITORY. A stray `nightly-2026-08-01` must not become a permanent veto
+# over every future release, and skipping is the conservative direction: a tag
+# the classifier refuses never had images published under it, so it cannot be
+# the release `:latest` should point at. The tag UNDER TEST is the opposite
+# case and is refused outright (exit 2) — the permissive answer there is the
+# one that publishes.
+#
+# Caller: the `docker` job of `.github/workflows/release.yml`, for BOTH
+# images — `grappa` and the `grappa-shottino` bridge are cut from the same tag
+# and share one `emit_tags` (#1168), so this verdict reaches both. Gate:
+# `test/infra/release_latest_gate_test.bats`.
+#
+# POSIX sh, like its siblings `version.sh` / `pkgversion.sh` /
+# `prerelease_flag.sh` — the derived dash-parse gate (scripts/posix-parse.sh)
+# keys on line 1.
+#
+# Why: docs/OPERATIONS.md § "Packaging (infra/packaging/)".
+set -eu
+
+die() {
+	printf 'latest_tag_gate.sh: %s\n' "$1" >&2
+	exit 2
+}
+
+classify="$(dirname "$0")/prerelease_flag.sh"
+
+tag="${1:-}"
+
+[ -n "${tag}" ] || die 'no tag given (usage: latest_tag_gate.sh vX.Y.Z)'
+
+# The floor. Without it a missing classifier degrades into "no tag is ever a
+# pre-release", which answers `yes` for a candidate — the exact publication
+# this gate exists to stop. On a #573 (b) image repair the checked-out tree is
+# the OLD TAG's, and every tag before v1.3.0 predates `prerelease_flag.sh`;
+# release.yml takes both scripts from the dispatched ref for that reason, and
+# this line is what makes a mistake there loud instead of permissive.
+[ -x "${classify}" ] || die "classifier ${classify} is missing — refusing to decide :latest without it"
+
+if ! flag="$("${classify}" "${tag}")"; then
+	die "cannot classify ${tag} — refusing to decide :latest for a tag nobody can read"
+fi
+
+# A pre-release is ineligible whatever it outranks, so this arm answers before
+# any ranking happens. It is a SEPARATE arm rather than a fall-through of the
+# scan below for log honesty: `v1.3.0-rc2 is NOT the highest (v1.2.0)` is what
+# the fall-through would print, and it is false — rc2 IS higher than v1.2.0.
+# A fast path states what it observed.
+if [ "${flag}" = '--prerelease=true' ]; then
+	printf '%s is a pre-release — NOT tagging :latest\n' "${tag}" >&2
+	printf 'no\n'
+	exit 0
+fi
+
+# The highest RELEASE tag: walk git's version order from the top and stop at
+# the first tag the classifier calls a release. Pre-releases above it are
+# named as they are passed over — they are the evidence for the verdict, and
+# the loop stops at the winner so the list cannot run long.
+#
+# Word splitting is what iterates here, and it is safe: `git check-ref-format`
+# forbids whitespace in a refname, so no tag can split into two.
+highest=''
+for candidate in $(git tag -l 'v*' --sort=-v:refname); do
+	if candidate_flag="$("${classify}" "${candidate}" 2>/dev/null)"; then
+		if [ "${candidate_flag}" = '--prerelease=false' ]; then
+			highest="${candidate}"
+			break
+		fi
+		printf 'ranking skips %s — a pre-release is not a candidate for :latest\n' "${candidate}" >&2
+	else
+		printf 'ranking skips %s — the classifier refuses it, so no release was ever published under it\n' "${candidate}" >&2
+	fi
+done
+
+if [ "${tag}" = "${highest}" ]; then
+	printf '%s is the highest release tag — tagging :latest\n' "${tag}" >&2
+	printf 'yes\n'
+else
+	printf '%s is NOT the highest release tag (%s) — NOT tagging :latest\n' "${tag}" "${highest:-none}" >&2
+	printf 'no\n'
+fi

--- a/test/infra/release_latest_gate_test.bats
+++ b/test/infra/release_latest_gate_test.bats
@@ -147,6 +147,11 @@ at_stable_push() {
     run --separate-stderr "$GATE_SH" v1.3.0
     [ "$status" -eq 0 ]
     [ "$output" = "yes" ]
+
+    # The candidates it ranked PAST, named on the way. Without this the case
+    # cannot tell "the scan skipped rc2" from "the scan never looked" — and
+    # what the skip line reports is the evidence for the verdict above it.
+    grep -qF 'ranking skips v1.3.0-rc2' <<<"$stderr"
 }
 
 @test "#1686 an ordinary release with no candidates around it takes :latest" {
@@ -233,11 +238,23 @@ at_stable_push() {
     # over every future release. It is skipped, out loud, and the scan carries
     # on to the highest tag that IS a release — the conservative direction,
     # since a tag the classifier refuses never had images published under it.
-    cd "$(tagged_repo stray v1.0.0 v1.1.0 nightly-2026-08-01 v1.2 v1.3.0)"
+    #
+    # THE STRAY MUST OUTRANK THE TAG UNDER TEST or this case proves nothing:
+    # the scan stops at the first release it finds, so a stray BELOW the winner
+    # is never reached and the assertion holds with the skip arm replaced by a
+    # hard failure. Measured — that mutant SURVIVED against `v1.2` (which sorts
+    # under v1.3.0) and is killed by `v9.9`, which sorts over it.
+    #
+    # `nightly-2026-08-01` rides along to pin the other half: the scan globs
+    # `v*`, so a tag outside that shape never enters the ranking at all and it
+    # is only the `v`-spelled stray that can reach the classifier.
+    cd "$(tagged_repo stray v1.0.0 v1.1.0 v1.3.0 v9.9 nightly-2026-08-01)"
 
     run --separate-stderr "$GATE_SH" v1.3.0
     [ "$status" -eq 0 ]
     [ "$output" = "yes" ]
+    grep -qF 'ranking skips v9.9' <<<"$stderr"
+    refute grep -qF 'nightly-2026-08-01' <<<"$stderr"
 }
 
 @test "#1686 a repository with no release tags at all answers 'no', not 'yes'" {

--- a/test/infra/release_latest_gate_test.bats
+++ b/test/infra/release_latest_gate_test.bats
@@ -1,0 +1,340 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1686 — the mutable ghcr `:latest` pointer must land on
+# the newest RELEASE, and never on a release candidate.
+#
+# THE DEFECT HAS TWO FACES AND THE ISSUE NAMES ONE. Both were read off the
+# runs' own logs rather than derived:
+#
+#     2026-08-20T23:38:15Z  v1.3.0-rc2 is the highest tag — tagging :latest
+#     2026-08-21T19:18:58Z  v1.3.0 is NOT the highest (v1.3.0-rc2) — NOT tagging :latest
+#     2026-08-22T08:40:28Z  v1.3.1 is the highest tag — tagging :latest
+#
+# Face one is the reported one: a CANDIDATE took `:latest`. Face two is that
+# the STABLE release which followed was then DENIED it — `:latest` skipped
+# v1.3.0 entirely and stayed on the candidate until v1.3.1, so the exposure
+# ran ~33h, not the ~20h the issue bounds it at. A cure measured against face
+# one alone would leave a stable release unable to claim the tag operators
+# actually pull.
+#
+# THE ROOT IS THE RANKING. `git tag -l 'v*' --sort=-v:refname` places a
+# `-rcN` suffix ABOVE the bare version unless `versionsort.suffix` says
+# otherwise, so the candidate outranks both its own release and the ranking's
+# whole purpose.
+#
+# WHY NOT `versionsort.suffix` — falsified by measurement, not by taste. On a
+# scratch repo holding the tag set as it stood at the rc2 push (v1.0.0 v1.1.0
+# v1.2.0 v1.3.0-rc1 v1.3.0-rc2, with NO v1.3.0 yet):
+#
+#     git tag -l 'v*' --sort=-v:refname                    -> v1.3.0-rc2
+#     git -c versionsort.suffix=- tag -l ... --sort=...    -> v1.3.0-rc2
+#
+# Identical. The suffix only orders a candidate against ITS OWN release, so it
+# repairs face two and leaves the MEASURED face one exactly as it was. And on
+# top of the cure below it is inert by construction: once pre-releases are out
+# of the candidate set there is no suffix left to order. The issue proposes
+# belt-and-braces; a second mechanism that does the first one's job is the
+# drift #1591 / #1594 / #1636 all were, so this suite pins ONE.
+#
+# THE CLASSIFIER IS NOT WRITTEN TWICE. `infra/packaging/prerelease_flag.sh`
+# (#1636) already answers "does semver call this a pre-release" and already
+# REFUSES with exit 2 what it cannot classify. The gate reuses it; a second
+# hand-rolled semver comparison is what leaves two `:latest` owners to drift.
+#
+# WHAT THIS SUITE DOES NOT COVER, stated so a green is not read wider than it
+# is. It drives the gate's SHELL LOGIC against fabricated git repositories.
+# It does not run GitHub Actions, does not exercise `docker/build-push-action`,
+# and never contacts a registry — so "which tags the runner actually pushed"
+# is asserted here only as the tag LIST the gate feeds that action, via the
+# workflow text. The end-to-end fact is unreachable without cutting a release.
+
+# `run --separate-stderr` is a 1.5.0 flag and the vendored bats is 1.9.0, but
+# without this declaration bats emits BW02 once PER CALL — 26 lines of warning
+# around this suite's assertions. Fourteen other suites in this tree pass flags
+# to `run` without it and carry the same noise; that is the drifted spelling,
+# not the one to copy.
+bats_require_minimum_version 1.5.0
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    GATE_SH="$REPO_ROOT/infra/packaging/latest_tag_gate.sh"
+    FLAG_SH="$REPO_ROOT/infra/packaging/prerelease_flag.sh"
+    WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+
+    # The FLOOR. Without it every refusal case below is satisfied by a missing
+    # script (127 is non-zero too) and the suite reports green against nothing.
+    [ -x "$GATE_SH" ]
+    [ -x "$FLAG_SH" ]
+
+    export GIT_CONFIG_GLOBAL="$BATS_TEST_TMPDIR/gitconfig"
+    export GIT_AUTHOR_NAME=bats GIT_AUTHOR_EMAIL=bats@example.org
+    export GIT_COMMITTER_NAME=bats GIT_COMMITTER_EMAIL=bats@example.org
+}
+
+# A throwaway repository carrying exactly the tags named. The gate reads the
+# tag set from the CURRENT repository, so the fixture is the cwd — while the
+# gate itself stays the real one in the real tree, reaching its classifier by
+# its own dirname.
+tagged_repo() {
+    local dir="$BATS_TEST_TMPDIR/repo-$1"
+    shift
+    git init -q -b main "$dir"
+    git -C "$dir" commit -q --allow-empty -m base
+    local tag
+    for tag in "$@"; do
+        git -C "$dir" tag "$tag"
+    done
+    printf '%s\n' "$dir"
+}
+
+# The tag set as it stood when v1.3.0-rc2 was pushed: the candidate is the
+# newest thing in the repository and its own release does not exist yet. This
+# is the state the measured incident happened in, and the one
+# `versionsort.suffix` does not fix.
+at_rc2_push() {
+    tagged_repo rc2 v1.0.0 v1.1.0 v1.2.0 v1.3.0-rc1 v1.3.0-rc2
+}
+
+# The same repository one tag later: the stable release now exists alongside
+# the candidates that preceded it. This is face two.
+at_stable_push() {
+    tagged_repo stable v1.0.0 v1.1.0 v1.2.0 v1.3.0-rc1 v1.3.0-rc2 v1.3.0
+}
+
+# ── The two measured faces ──────────────────────────────────────────────────
+
+@test "#1686 a release candidate does NOT take :latest, even when nothing outranks it" {
+    # Face one, in the exact tag set that produced it. The candidate IS the
+    # newest tag by every ordering git offers; eligibility is not a question
+    # of ordering at all.
+    cd "$(at_rc2_push)"
+
+    run --separate-stderr "$GATE_SH" v1.3.0-rc2
+    [ "$status" -eq 0 ]
+    [ "$output" = "no" ]
+
+    # And for every spelling of a candidate the classifier recognises, so the
+    # gate cannot be passing on the literal string "rc2".
+    local tag
+    for tag in v1.3.0-rc1 v1.3.0-rc.1 v1.3.0-rc-1 v1.3.0-1 v1.3.0-alpha.1 v1.3.0-rc1+foo; do
+        git tag "$tag" 2>/dev/null || true
+        run --separate-stderr "$GATE_SH" "$tag"
+        [ "$status" -eq 0 ]
+        [ "$output" = "no" ]
+    done
+}
+
+@test "#1686 the refusal says the tag is a pre-release — not that something outranks it" {
+    # Log honesty. The old gate would have answered "v1.3.0-rc2 is NOT the
+    # highest (v1.2.0)", which is FALSE: 1.3.0-rc2 is higher than 1.2.0 by
+    # semver and by git's own sort. A fast path states what it OBSERVED.
+    cd "$(at_rc2_push)"
+
+    run --separate-stderr "$GATE_SH" v1.3.0-rc2
+    [ "$status" -eq 0 ]
+    grep -qF 'pre-release' <<<"$stderr"
+    refute grep -qF 'v1.2.0' <<<"$stderr"
+}
+
+@test "#1686 the stable release that FOLLOWS a candidate does take :latest" {
+    # Face two, the one the issue does not name. Measured:
+    # `v1.3.0 is NOT the highest (v1.3.0-rc2)` — the release was denied the
+    # pointer by its own candidate, and `:latest` skipped it entirely.
+    cd "$(at_stable_push)"
+
+    run --separate-stderr "$GATE_SH" v1.3.0
+    [ "$status" -eq 0 ]
+    [ "$output" = "yes" ]
+}
+
+@test "#1686 an ordinary release with no candidates around it takes :latest" {
+    # The positive control. A cure that answered "no" to everything would
+    # satisfy both refusal cases above and be caught here.
+    cd "$(tagged_repo plain v1.0.0 v1.1.0 v1.2.0)"
+
+    run --separate-stderr "$GATE_SH" v1.2.0
+    [ "$status" -eq 0 ]
+    [ "$output" = "yes" ]
+}
+
+# ── The exclusion that already worked must keep working ─────────────────────
+
+@test "#1686 a backport tag is STILL excluded — the property the gate had" {
+    # The hazard the gate was written for (v0.7.5 pushed after v0.8.0 must not
+    # re-point `:latest` at an OLDER image). A cure for the pre-release hole
+    # that dropped this would trade one wrong `:latest` for another.
+    cd "$(tagged_repo backport v0.7.0 v0.8.0 v0.7.5)"
+
+    run --separate-stderr "$GATE_SH" v0.7.5
+    [ "$status" -eq 0 ]
+    [ "$output" = "no" ]
+
+    run --separate-stderr "$GATE_SH" v0.8.0
+    [ "$status" -eq 0 ]
+    [ "$output" = "yes" ]
+}
+
+@test "#1686 a backport is excluded even when the newest tag is a candidate" {
+    # The two rules composed, which is where a gate that special-cased one of
+    # them would come apart: the highest RELEASE is v0.8.0, so the backport
+    # stays out and the candidate above it does not become the yardstick.
+    cd "$(tagged_repo backport-rc v0.7.0 v0.8.0 v0.9.0-rc1 v0.7.5)"
+
+    run --separate-stderr "$GATE_SH" v0.7.5
+    [ "$status" -eq 0 ]
+    [ "$output" = "no" ]
+
+    run --separate-stderr "$GATE_SH" v0.8.0
+    [ "$status" -eq 0 ]
+    [ "$output" = "yes" ]
+
+    run --separate-stderr "$GATE_SH" v0.9.0-rc1
+    [ "$status" -eq 0 ]
+    [ "$output" = "no" ]
+}
+
+@test "#1686 build metadata is not a candidate — the classifier's own decisive row" {
+    # Semver orders the suffixes pre-release-then-build, so the hyphen in
+    # `1.4.0+foo-bar` belongs to the build and `Version.parse/1` reports
+    # `pre: []` (measured in #1636). A gate that filtered on "contains a
+    # hyphen" — the second writing of the rule this reuse exists to avoid —
+    # would answer "no" here and strand `:latest` on an older release.
+    cd "$(tagged_repo build v1.3.0 'v1.4.0+foo-bar')"
+
+    run --separate-stderr "$GATE_SH" 'v1.4.0+foo-bar'
+    [ "$status" -eq 0 ]
+    [ "$output" = "yes" ]
+}
+
+# ── Refusal, and what it does NOT take down with it ─────────────────────────
+
+@test "#1686 a tag the classifier cannot read is REFUSED, never answered 'yes'" {
+    # The permissive default is the one that publishes. The refusal's OWN exit
+    # code, not merely non-zero: 127 (absent script) would satisfy `-ne 0`
+    # while proving nothing, and the setup floor guards that too.
+    cd "$(at_stable_push)"
+
+    local tag
+    for tag in "" 1.3.0 v vfoo v1.3 v1.3.0.4 "v 1.3.0"; do
+        run --separate-stderr "$GATE_SH" "$tag"
+        [ "$status" -eq 2 ]
+        refute grep -qxE 'yes|no' <<<"$output"
+    done
+
+    run --separate-stderr "$GATE_SH"
+    [ "$status" -eq 2 ]
+    refute grep -qxE 'yes|no' <<<"$output"
+}
+
+@test "#1686 an unreadable tag ELSEWHERE in the repo does not block a release" {
+    # A stray tag nobody cut a release from must not become a permanent veto
+    # over every future release. It is skipped, out loud, and the scan carries
+    # on to the highest tag that IS a release — the conservative direction,
+    # since a tag the classifier refuses never had images published under it.
+    cd "$(tagged_repo stray v1.0.0 v1.1.0 nightly-2026-08-01 v1.2 v1.3.0)"
+
+    run --separate-stderr "$GATE_SH" v1.3.0
+    [ "$status" -eq 0 ]
+    [ "$output" = "yes" ]
+}
+
+@test "#1686 a repository with no release tags at all answers 'no', not 'yes'" {
+    # The empty-set edge, in the direction that cannot move a pointer wrongly.
+    cd "$(tagged_repo empty)"
+
+    run --separate-stderr "$GATE_SH" v1.0.0
+    [ "$status" -eq 0 ]
+    [ "$output" = "no" ]
+}
+
+# ── The pipeline uses it, for BOTH images, and spells the rule nowhere else ──
+
+# The `docker` job of release.yml, from its key to the next top-level job key.
+# Read off the JOB: release.yml also builds deb, rpm and arch, and a whole-file
+# grep would be satisfied by any of their steps.
+docker_job() {
+    awk '/^  docker:/ { f = 1; next } f && /^  [a-z]/ { exit } f' "$WORKFLOW"
+}
+
+# The workflow with its comments stripped, so a gate about what the pipeline
+# DOES is never satisfied — nor broken — by prose about what it does.
+workflow_code() {
+    sed 's/^[[:space:]]*#.*$//; s/[[:space:]]#[[:space:]].*$//' "$WORKFLOW"
+}
+
+@test "#1686 the docker job derives :latest from the gate, and stops if it cannot" {
+    job="$(docker_job)"
+    [ -n "$job" ]
+    grep -qF 'latest_tag_gate.sh' <<<"$job"
+
+    # The refusal is not swallowed. The script exits 2 on a tag it cannot
+    # classify, and the permissive reading of that — carry on with an empty
+    # verdict — is what publishes `:latest` onto an unclassified tag.
+    grep -qF 'if ! latest=' <<<"$job"
+}
+
+@test "#1686 the hand-rolled semver ranking is GONE — the rule has one writing" {
+    # The defect itself, as a line of shell. `--sort=-v:refname` picking
+    # `highest` is the ranking that put a candidate on top; leaving it in
+    # place next to the gate would be two owners for one decision.
+    refute grep -qF -- '-v:refname' <<<"$(workflow_code)"
+    refute grep -qF -- 'versionsort.suffix' <<<"$(workflow_code)"
+
+    # The stripper must not have eaten the code it is supposed to be reading.
+    grep -qF 'latest_tag_gate.sh' <<<"$(workflow_code)"
+}
+
+@test "#1686 ONE gate feeds BOTH images — the bridge shares the bouncer's answer" {
+    # `grappa-shottino` is cut from the same tag and published by the same job
+    # (#1168). A cure that reached only the bouncer would leave the bridge's
+    # `:latest` on a candidate — half a cure, and the half nobody looks at.
+    job="$(docker_job)"
+
+    # Both repositories go through the SAME emitter, and the emitter is what
+    # consults the verdict. Asserted structurally rather than by counting
+    # occurrences of `:latest`, which prose would satisfy.
+    grep -qF 'emit_tags "${name}" tags' <<<"$job"
+    grep -qF 'emit_tags "${shottino_name}" shottino_tags' <<<"$job"
+    grep -qF '[ "${latest}" = yes ]' <<<"$job"
+
+    # And the bridge's build step consumes the tag list that emitter produced.
+    grep -qF 'steps.img.outputs.shottino_tags' <<<"$job"
+}
+
+@test "#1686 a repair dispatch can still reach the gate — an OLD tag's tree cannot" {
+    # THE REGRESSION THIS CURE WOULD OTHERWISE HAVE CAUSED. The docker job
+    # checks out `ref: REPAIR_TAG`, so on a #573 (b) image repair the tree is
+    # the OLD TAG's. Measured: `git tag --contains d622616d` answers
+    # `v1.3.0 v1.3.1` — every earlier tag predates prerelease_flag.sh, so a
+    # naive call would exit 127 and kill a path that works today.
+    #
+    # The cure reuses the verb the job ALREADY has for "this comes from the
+    # dispatched ref" — the scaffolding checkout — rather than inventing a
+    # second one. Both scripts must be in that list: the gate and the
+    # classifier it reaches.
+    job="$(docker_job)"
+    scaffolding="$(awk '/^[[:space:]]*git checkout "\$\{GITHUB_SHA\}" -- \\$/ { f = 1 }
+                        f { print; if (!/\\$/) exit }' <<<"$job")"
+    [ -n "$scaffolding" ]
+    grep -qF 'infra/packaging/latest_tag_gate.sh' <<<"$scaffolding"
+    grep -qF 'infra/packaging/prerelease_flag.sh' <<<"$scaffolding"
+
+    # And the artefact is unchanged by that, which is the reason the list may
+    # grow at all: Dockerfile.release COPYs exactly two files out of
+    # infra/packaging, and neither is one of these. Measured, not assumed —
+    # the moment a third joins, this assertion is the one that notices.
+    run grep -c '^COPY.*infra/packaging/' "$REPO_ROOT/Dockerfile.release"
+    [ "$output" = "2" ]
+    refute grep -qF 'infra/packaging/latest_tag_gate.sh' "$REPO_ROOT/Dockerfile.release"
+    refute grep -qF 'infra/packaging/prerelease_flag.sh' "$REPO_ROOT/Dockerfile.release"
+}
+
+@test "#1686 the gate is POSIX sh, like every sibling under infra/packaging" {
+    # Not a style rule: `scripts/posix-parse.sh` derives its file set from line
+    # 1, so the dialect declaration is what enrols this script in the parse
+    # gate. A bash shebang would silently drop it out of that set.
+    head -1 "$GATE_SH" | grep -qE '^#!/bin/sh$'
+    "$REPO_ROOT/scripts/posix-parse.sh" --list | grep -qxF 'infra/packaging/latest_tag_gate.sh'
+}


### PR DESCRIPTION
## What this fixes

`release.yml` chose which image gets the mutable ghcr `:latest` with

```sh
highest="$(git tag -l 'v*' --sort=-v:refname | head -1)"
```

and `versionsort.suffix` is not configured in this repository, so git's version
sort places a `-rcN` suffix **above** the bare version.

## The defect has two faces; #1686 names one

Quoted from the runs' own logs, not derived:

```
2026-08-20T23:38:15Z  v1.3.0-rc2 is the highest tag — tagging :latest
2026-08-21T19:18:58Z  v1.3.0 is NOT the highest (v1.3.0-rc2) — NOT tagging :latest
2026-08-22T08:40:28Z  v1.3.1 is the highest tag — tagging :latest
```

* **Face one** (reported): a release **candidate took `:latest`**.
* **Face two** (not reported): the **stable release that followed was then denied
  it** by its own candidate. `:latest` skipped `v1.3.0` entirely and served rc2
  until `v1.3.1` — roughly **33 hours**, not the ~20 the issue bounds it at. The
  issue closes the window at "the next stable run"; the second line above is
  that run, saying it did not take the tag.

Still latent, not a live incident: `:latest` today resolves to `v1.3.1`.

## Why not `versionsort.suffix`, which the issue also proposes

Measured on a scratch repository holding the tag set as it stood at the rc2
push (`v1.0.0 v1.1.0 v1.2.0 v1.3.0-rc1 v1.3.0-rc2`, no `v1.3.0` yet):

```
git tag -l 'v*' --sort=-v:refname                  -> v1.3.0-rc2
git -c versionsort.suffix=- tag -l ... --sort=...   -> v1.3.0-rc2
```

Identical. The suffix orders a candidate against **its own release** and nothing
else, so it repairs face two and leaves the measured face one exactly where it
was. Restricting the ranking to releases repairs both — and once pre-releases
are out of the candidate set the suffix has nothing left to order, so setting it
as well would be a second mechanism doing the first one's job. The issue asks
for belt-and-braces; this takes one, deliberately.

## The change

* **New `infra/packaging/latest_tag_gate.sh`** — verdict (`yes`/`no`) on stdout,
  reason on stderr, exit 2 on a tag it cannot read. It **reuses**
  `prerelease_flag.sh` (#1636) rather than comparing versions a second time: a
  hand-rolled filter is wrong on the row that decided that script's
  implementation, since `v1.4.0+foo-bar` carries a hyphen inside its **build**
  metadata and is a release.
* **`release.yml`** calls it instead of ranking inline; a verdict that cannot be
  derived stops the job, because the permissive reading is the one that
  publishes.
* **A pre-release gets its own arm** for log honesty. Falling through would
  print `v1.3.0-rc2 is NOT the highest (v1.2.0)`, which is false — rc2 *is*
  higher.
* **One gate, both images.** The verdict feeds the existing `emit_tags`, so
  `grappa` and the `grappa-shottino` bridge share it (#1168).
* **The repair path keeps working.** The docker job checks out
  `ref: REPAIR_TAG`, so on a #573 (b) image repair the tree is the **old tag's**;
  `git tag --contains d622616d` answers `v1.3.0 v1.3.1`, so every earlier tag
  predates `prerelease_flag.sh` and a naive call would have exited **127** on a
  path that works today. Both scripts therefore join the repair scaffolding
  checkout — the verb the job already has for "this comes from the dispatched
  ref". Measured not to change the artifact: `Dockerfile.release` COPYs exactly
  two files out of `infra/packaging` and neither is one of these; the bats case
  pins that count.

Operator-visible consequence: a candidate tag now publishes `:v<version>` only,
so `docker pull ghcr.io/<owner>/grappa` keeps resolving to the newest stable
release across a candidate cycle.

## Tests

`test/infra/release_latest_gate_test.bats`, 15 cases driving the gate against
fabricated git repositories: the two measured faces, the backport exclusion
(alone and composed with a candidate above it), build metadata, refusal of an
unreadable tag under test, a stray tag elsewhere not vetoing a release, the
empty-tag-set edge, and the workflow wiring for both images and the repair path.

**Mutation bench: 8 mutants, 8 killed** — and the first pass was 7/8. Replacing
the skip arm with a hard failure left the suite green at 15/15, because the
stray tag sat *below* the tag under test and the scan stops at the first release
it finds, so the classifier was never handed anything it could refuse. Fixed by
making the stray outrank the subject and asserting the skip line; the second
pass kills all eight. The decisive mutant is `versionsort.suffix` in place of
the filter — it turns face one red, which is the argument above expressed as a
test.

**What the suite does not cover**, stated so a green is not read wider than it
is: it drives shell logic, not GitHub Actions. It does not exercise
`docker/build-push-action` and never contacts a registry — "which tags the
runner pushed" is asserted only as the tag list the gate feeds that action, via
the workflow text. The end-to-end fact is unreachable without cutting a release.

## Gates

* `scripts/bats.sh` (full): `1..674`, 674 ok, 0 failures.
* `scripts/shellcheck.sh`: 81 scripts, clean. `scripts/posix-parse.sh`: 32
  sh-dialect scripts, clean — the new gate is enrolled in both.
* `scripts/design-notes-gate.sh origin/main`: 1 new entry heading, separator and
  marker present.
* `scripts/check.sh`: green.

⚠️ `.github/workflows/**` is not in `integration.yml`'s `paths:`, so this PR
runs **fewer checks than usual** — `ci.yml` has no path filter and does run.
Four of four is not five of five.
