### PR TITLE
fix(#1705): align detach and quit icons

### DIFF
--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -729,7 +729,7 @@ const RailActions: Component<Props> = (props) => {
               }}
             >
               <span class="rail-action-icon" aria-hidden="true">
-                {"\u{1F50C}"}
+                {"\u{1F6AA}"}
               </span>
               <span class="rail-action-label">detach</span>
             </button>
@@ -751,7 +751,7 @@ const RailActions: Component<Props> = (props) => {
             }}
           >
             <span class="rail-action-icon" aria-hidden="true">
-              {"\u{1F6AA}"}
+              {"\u{1F50C}"}
             </span>
             <span class="rail-action-label">quit</span>
           </button>

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -606,6 +606,16 @@ describe("RailActions — detach + quit (#986)", () => {
     expect(screen.getByTestId("quit-irc-btn")).toHaveTextContent("quit");
   });
 
+  it("pairs the door with detach and the plug with the upstream-disconnecting quit (#1705)", () => {
+    mountWithSubject(USER);
+    expect(screen.getByTestId("detach-btn").querySelector(".rail-action-icon")).toHaveTextContent(
+      "\u{1F6AA}",
+    );
+    expect(screen.getByTestId("quit-irc-btn").querySelector(".rail-action-icon")).toHaveTextContent(
+      "\u{1F50C}",
+    );
+  });
+
   // THE assertion of this issue. Three subjects, three visibly different
   // sentences in the rendered modal — not three calls that happen to open a
   // modal carrying one shared string.


### PR DESCRIPTION
## Summary

- show the door icon for Detach, which leaves the web client while the bouncer stays connected
- show the plug icon for Quit IRC, which actually disconnects the upstream networks
- add a focused component assertion to keep that mapping from regressing

The broader switch-account wording discussion remains out of scope for this change.

## Testing

- `scripts/bun.sh run test -- src/__tests__/RailActions.test.tsx` (59 passed)
- `scripts/bun.sh run check` (4 stages, 0 failed)

Refs #1705