### PR TITLE
cic(reply): put the reply quote in front of a draft the operator typed (#1688)

### DIFF
--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -365,13 +365,91 @@ describe("replyToMessage", () => {
     expect(getDraft(KEY)).toBe("<vjt> ciao mondo << ");
   });
 
-  // Never destroy work in progress: the quote lands AFTER what is already
-  // there, so a half-typed line survives the gesture.
+  // Never destroy work in progress — #1067's rule, and it still holds: the
+  // half-typed line survives the gesture whole. #1688 changed only WHERE the
+  // quote goes relative to it. The old expectation here was
+  // `bozza <vjt> ciao mondo << `, which is the defect peluche reported.
   it("does not clobber an existing draft", () => {
     mountCompose();
     setDraft(KEY, "bozza ");
     replyToMessage(msg({}), NET, CHAN);
-    expect(getDraft(KEY)).toBe("bozza <vjt> ciao mondo << ");
+    // Both halves, so a cure that dropped either one cannot pass here while the
+    // ordering arms below carry the shape.
+    expect(getDraft(KEY)).toContain("bozza ");
+    expect(getDraft(KEY)).toContain("<vjt> ciao mondo << ");
+  });
+
+  // #1688 — the tail is documented (`replyQuote.ts`) as ending the line "so the
+  // answer is typed straight after the caret": quote first, answer last. A
+  // draft holding the operator's own words used to come back with the quote
+  // BEHIND them, which inverts that and leaves a `<<` reading as if it
+  // separated a quote from an answer sitting in front of it.
+  it("puts the quote in FRONT of a draft the operator typed — #1688", () => {
+    mountCompose();
+    setDraft(KEY, "la mia risposta");
+    replyToMessage(msg({}), NET, CHAN);
+    expect(getDraft(KEY)).toBe("<vjt> ciao mondo << la mia risposta");
+  });
+
+  // The documented invariant is about the END of the line, so it is asserted as
+  // one: whatever the draft held, the tail is followed by the operator's words
+  // and by nothing of ours.
+  it("leaves the operator's words after the tail, not before it — #1688", () => {
+    mountCompose();
+    setDraft(KEY, "la mia risposta");
+    replyToMessage(msg({}), NET, CHAN);
+    const draft = getDraft(KEY);
+    expect(draft.indexOf(REPLY_QUOTE_TAIL)).toBeLessThan(draft.indexOf("la mia risposta"));
+  });
+
+  // The caret decision #1688 worried about costs nothing: `updateCompose` places
+  // it at the very end unconditionally, which after a prepend IS the end of the
+  // typed answer. Asserted rather than assumed — it is the half of the
+  // invariant a string comparison cannot see.
+  it("leaves the caret at the end of the typed answer after a prepend — #1688", async () => {
+    const ta = mountCompose();
+    setDraft(KEY, "la mia risposta");
+    replyToMessage(msg({}), NET, CHAN);
+    ta.value = getDraft(KEY);
+    await Promise.resolve();
+    expect(ta.selectionStart).toBe("<vjt> ciao mondo << la mia risposta".length);
+    expect(document.activeElement).toBe(ta);
+  });
+
+  // A draft is OURS to reorder only when it actually carries one of our quotes.
+  // `<<` is ordinary text — the same trap `quotableBody`'s de-nesting regex was
+  // written to avoid (`shift << 2`, `cat <<EOF`) — so a discriminator that
+  // merely searched for the marker would treat a human's shift expression as a
+  // quote and append behind it, leaving #1688 unfixed for exactly those drafts.
+  it("treats a draft containing a bare << as the operator's own text — #1688", () => {
+    mountCompose();
+    setDraft(KEY, "shift << 2 gives four");
+    replyToMessage(msg({}), NET, CHAN);
+    expect(getDraft(KEY)).toBe("<vjt> ciao mondo << shift << 2 gives four");
+  });
+
+  // A draft that ENDS with our tail without STARTING with our quote is the
+  // shape the pre-#1688 code produced (type first, then reply) — and it can
+  // still be sitting in a persisted draft when this change ships. It is ours to
+  // extend, not to reorder: #1357's marker shed applies and the quote goes at
+  // the end. Found by the mutant bench, which kept a green suite when the
+  // `endsWith` half of the test was deleted.
+  it("still sheds the marker on a legacy draft that only ENDS with our tail", () => {
+    mountCompose();
+    setDraft(KEY, "bozza <a> primo << ");
+    replyToMessage(msg({ sender: "b", body: "secondo" }), NET, CHAN);
+    expect(getDraft(KEY)).toBe("bozza <a> primo <b> secondo << ");
+  });
+
+  // Reply, type, reply. The second quote must NOT jump in front of the answer
+  // written after the first — that is #1357's acceptance criterion 3, reached
+  // here through the #1688 prepend rather than through a hand-set draft.
+  it("appends once the draft already carries our quote — #1357 still holds", () => {
+    mountCompose();
+    replyToMessage(msg({ sender: "a", body: "primo" }), NET, CHAN);
+    setDraft(KEY, `${getDraft(KEY)}ciao`);
+    replyToMessage(msg({ id: 2, sender: "b", body: "secondo" }), NET, CHAN);
+    expect(getDraft(KEY)).toBe("<a> primo << ciao<b> secondo << ");
   });
 
   it("writes nothing for an unquotable row", () => {

--- a/cicchetto/src/lib/quotableBody.ts
+++ b/cicchetto/src/lib/quotableBody.ts
@@ -40,6 +40,18 @@ function withoutPreviousQuote(body: string): string {
   return body.replace(PREVIOUS_QUOTE, "").trim();
 }
 
+// #1688 — the same question asked of a COMPOSE DRAFT rather than of a wire
+// body: does this string already open with a quote WE emitted?
+//
+// Shares `PREVIOUS_QUOTE` rather than re-deriving it, because the trap is
+// identical on both sides and it is the trap this regex exists for: a bare
+// `<<` search calls `shift << 2` a quote, and on the draft side that
+// mis-classification is what decides whether the operator's own sentence gets
+// reordered. One nick charset, one anchor, one answer.
+export function startsWithReplyQuote(text: string): boolean {
+  return PREVIOUS_QUOTE.test(text);
+}
+
 // Only CONTENT kinds quote (`isContentKind` — privmsg/notice/action, the same
 // classifier the unread/badge math uses). A presence row is not somebody
 // speaking: a PART carries a reason in `body`, so a bare body check would

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -1,6 +1,6 @@
 import type { ScrollbackMessage } from "./api";
 import { updateCompose } from "./composeAppend";
-import { attributionHead, quotableBody } from "./quotableBody";
+import { attributionHead, quotableBody, startsWithReplyQuote } from "./quotableBody";
 
 // #1067 — the reply verb, shared by the left→right swipe on a message row and
 // the long-press menu's Reply item. Both doors, one code path.
@@ -71,11 +71,47 @@ const REPLY_QUOTE_MARKER = REPLY_QUOTE_TAIL.trimStart();
 //
 // THIS is the function to change if replace-semantics ever wins (vjt: "start
 // with 2, we change it later if needed") — last-swipe-wins means returning the
-// draft with its whole quote removed instead of just the marker. The door below
-// hands it the draft and appends to whatever comes back, so nothing else moves.
+// draft with its whole quote removed instead of just the marker.
+// `draftWithReplyQuote` below hands it the draft and appends to whatever comes
+// back, so nothing else moves.
 export function draftBeforeReplyQuote(draft: string): string {
   if (!draft.endsWith(REPLY_QUOTE_TAIL)) return draft;
   return draft.slice(0, draft.length - REPLY_QUOTE_MARKER.length);
+}
+
+// #1688 — WHERE the quote goes. The tail is documented above as ending the line
+// "so the answer is typed straight after the caret": the shape is
+// `quote << answer`, an invariant about the END of the line and not merely
+// about concatenation. A draft holding the operator's own words used to come
+// back with the quote BEHIND them, inverting it — peluche reported the result
+// on #grappa, and the `<<` then reads as if it separated a quote from an answer
+// sitting in front of it.
+//
+// So: a draft that already carries a quote of OURS is extended (the #1357
+// path); anything else is the operator's text and the quote goes in FRONT of
+// it, restoring the documented order.
+//
+// "Carries a quote of ours" is deliberately two tests, not one.
+//   - ENDS with our tail — the #1357 accumulate case, whose marker is shed.
+//   - STARTS with our quote shape (`startsWithReplyQuote`) — the case where the
+//     operator has already typed an answer past the tail. #1357's acceptance
+//     criterion 3 rules on exactly that draft: the new quote "must not land
+//     before that text". A trigger phrased as "does not end with the tail"
+//     — which is how the shapes were first written down — would prepend there
+//     and break a standing ruling, so the head test is what keeps the two
+//     issues compatible.
+// Neither test is a bare `<<` search: `shift << 2` is somebody's sentence, and
+// treating it as ours is how #1688 would stay unfixed for the drafts that
+// happen to contain the marker.
+//
+// The caret needs no decision here, measured rather than assumed:
+// `updateCompose` places it at the very end unconditionally, which after a
+// prepend IS the end of the typed answer.
+export function draftWithReplyQuote(draft: string, quote: string): string {
+  if (draft.endsWith(REPLY_QUOTE_TAIL) || startsWithReplyQuote(draft)) {
+    return draftBeforeReplyQuote(draft) + quote;
+  }
+  return quote + draft;
 }
 
 // Drop the quote into the window's compose box with the caret at the end. A
@@ -88,5 +124,5 @@ export function replyToMessage(
 ): void {
   const quote = replyQuote(msg);
   if (quote === null) return;
-  updateCompose(networkSlug, channelName, (draft) => draftBeforeReplyQuote(draft) + quote);
+  updateCompose(networkSlug, channelName, (draft) => draftWithReplyQuote(draft, quote));
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59398,3 +59398,102 @@ sites, `userAgent.test.ts` pins the classification matrix directly, and
 `push.test.ts` pins the grouping the format feeds; a browser-driven spec
 would exercise Playwright's own UA rather than the branch under test, and
 would assert rendering plumbing that #964's specs already cover.
+<!-- entry #1688 -->
+
+---
+
+## 2026-08-23 — #1688: where the reply quote goes, and the standing ruling that shaped the trigger
+
+peluche reported that right-click → Reply on a compose box already holding
+typed text appended the quote AFTER it. `replyToMessage` was unconditionally
+`draftBeforeReplyQuote(draft) + quote`, and that helper only ever sheds a
+TRAILING marker, so a draft carrying the operator's own words came back
+untouched with the quote behind them.
+
+It is a defect and not a preference because the tail says so. `REPLY_QUOTE_TAIL`
+is documented as carrying a trailing space "so the answer is typed straight
+after the caret" — an invariant about the END of the line, i.e. the shape
+`quote << answer`. Type-then-reply inverts it and leaves a `<<` reading as if it
+separated a quote from an answer sitting in front of it.
+
+### The trigger the issue proposed would have broken #1357
+
+The issue phrased the cure as "if the draft is non-empty and does NOT end with
+`REPLY_QUOTE_TAIL`, put the quote first". That sweeps in a draft the standing
+#1357 ruling already governs. Its acceptance criterion 3 reads: *a draft with
+operator text already typed after the tail is not silently mangled — the
+appended quote must not land before that text*, and it is pinned by a green test
+("does not touch a tail the operator has already typed past"). A draft like
+`<a> primo << ciao` does not end with the tail either, so the proposed trigger
+would have prepended there and reversed a ruling nobody meant to reopen.
+
+So the question the code asks is not "does this draft end with our tail" but
+**"does this draft already carry a quote of OURS"**, and that is deliberately
+two tests joined by `||`:
+
+- it ENDS with our tail — the #1357 accumulate case, whose marker is shed;
+- it STARTS with our quote shape — the case where an answer has been typed past
+  the tail, which must keep appending.
+
+Everything else is the operator's text and the quote goes in front of it.
+
+### The head test reuses `quotableBody`'s regex rather than searching for `<<`
+
+`startsWithReplyQuote/1` is a new export over the existing `PREVIOUS_QUOTE`
+regex — the anchored `^(?:<nick>|\* nick) [\s\S]*<<(?: |$)` that #1123 wrote for
+the de-nesting cut. The trap is identical on both sides and it is the trap that
+regex exists for: a bare `<<` search calls `shift << 2` and `cat <<EOF` quotes.
+On the body side that ate a real message; on the draft side it would decide
+whether to reorder somebody's sentence, and it would leave #1688 unfixed for
+exactly the drafts that happen to contain the marker. One nick charset, one
+anchor, one answer.
+
+### The caret cost the issue anticipated is zero, and that was measured
+
+The issue noted that a prepend "costs a caret decision: after a prepend the
+caret should land at the end of the typed answer, not at the end of the quote".
+It costs nothing: `updateCompose` calls `placeCaretAtEndInView(ta)`
+unconditionally, so the caret is already at the very end of the draft, which
+after a prepend IS the end of the typed answer. Asserted in the suite rather
+than left as a reading, because it is the half of the invariant a string
+comparison cannot see.
+
+### A mutant survived, and it proved the `endsWith` half is not redundant
+
+Seven mutants were run against the cure. Six died on the first pass; deleting
+the `endsWith` disjunct left the suite GREEN, because every draft that
+legitimately ends with our tail today also starts with our quote, so the head
+test alone covered them.
+
+The input that separates them is real, not contrived: `bozza <a> primo << ` —
+type first, then reply — is precisely what the PRE-#1688 code produced, and
+compose drafts are persisted, so one can be on screen when this ships. It ends
+with our tail and does not start with our quote. Without the disjunct the next
+reply would prepend and produce a two-marker line. The disjunct stays and the
+case is now pinned by its own test.
+
+Left alone, and noted rather than fixed: a draft that is pure operator text
+ending in ` << ` (`ciao << `) still has that marker shed, because it satisfies
+the `endsWith` test. That is today's behaviour, it predates this issue, and
+changing it is a ruling about which markers are ours to remove — a different
+question from where the quote goes.
+
+### The #1067 expectation that moved, and why its intent did not
+
+`replyToMessage`'s "does not clobber an existing draft" test asserted
+`bozza <vjt> ciao mondo << `, which is the reported defect. Its stated intent —
+"never destroy work in progress: a half-typed line survives the gesture" — is
+untouched by the cure: the line survives whole, only its position relative to
+the quote changed. The test now asserts that both halves are present and leaves
+the ordering to the arms filed under this issue.
+
+### No e2e spec, deliberately
+
+The change is a pure string function plus the one call site that feeds it.
+`replyQuote.test.ts` drives `replyToMessage` through a real mounted textarea in
+jsdom and asserts both the draft and `selectionStart`/`activeElement`, so the
+caret half is covered at the same door. The DOM dance underneath —
+focus, the iOS `preventScroll` short-circuit, `placeCaretAtEndInView` — is
+byte-identical to the one `issue1105-reply-quote-caret-visible.spec.ts` already
+drives in a real browser; this change does not touch it, and a new spec would
+re-assert somebody else's plumbing.


### PR DESCRIPTION
Fixes the ordering peluche reported on #grappa: right-click → Reply on a compose
box that already holds typed text used to append the quote AFTER it.

`replyToMessage` was unconditionally `draftBeforeReplyQuote(draft) + quote`, and
that helper only ever sheds a **trailing** marker, so a draft carrying the
operator's own words came back untouched with the quote behind them.

The tail is what makes this a defect rather than a preference. It is documented
in `replyQuote.ts` as carrying a trailing space *"so the answer is typed straight
after the caret"* — an invariant about the END of the line, i.e. the shape
`quote << answer`. Type-then-reply inverts it, and the `<<` then reads as if it
separated a quote from an answer sitting in front of it.

## The trigger is deliberately not the one the issue proposed

The issue phrased the cure as *"if the draft is non-empty and does NOT end with
`REPLY_QUOTE_TAIL`, put the quote first"*. **That would have reversed a standing
ruling.** #1357's acceptance criterion 3 reads: *a draft with operator text
already typed after the tail is not silently mangled — the appended quote must
not land before that text*, and it is pinned by a green test (`does not touch a
tail the operator has already typed past`). A draft like `<a> primo << ciao`
does not end with the tail either, so the proposed trigger would have prepended
exactly there.

So the question the code asks is **"does this draft already carry a quote of
OURS"**, which is two tests joined by `||`:

| draft | reached by | result |
|---|---|---|
| `""` | neither | `<b> secondo << ` |
| `<a> primo << ` | ends with our tail | `<a> primo <b> secondo << ` (#1357 shed, unchanged) |
| `<a> primo << ciao` | starts with our quote | `<a> primo << ciao<b> secondo << ` (#1357 criterion 3, unchanged) |
| `la mia risposta` | neither | `<b> secondo << la mia risposta` ← **the fix** |
| `shift << 2 gives four` | neither | `<b> secondo << shift << 2 gives four` |

## The head test reuses `quotableBody`'s regex rather than searching for `<<`

`startsWithReplyQuote` is a new export over the existing anchored
`PREVIOUS_QUOTE` (`^(?:<nick>|\* nick) [\s\S]*<<(?: |$)`) that #1123 wrote for
the de-nesting cut. The trap is identical on both sides and it is the trap that
regex exists for: a bare `<<` search calls `shift << 2` and `cat <<EOF` quotes.
On the body side that ate a real message; on the draft side it would decide
whether to reorder somebody's sentence, and would leave this bug unfixed for
exactly the drafts that happen to contain the marker. One nick charset, one
anchor, one answer.

## The caret cost the issue anticipated is zero — measured

The issue expected a prepend to *"cost a caret decision"*. It costs nothing:
`updateCompose` calls `placeCaretAtEndInView(ta)` unconditionally, so the caret
is already at the very end of the draft, which after a prepend IS the end of the
typed answer. Asserted in the suite rather than left as a reading.

## A mutant survived the first bench, and it changed the code's justification

Seven mutants, one per decision. Six died immediately; **deleting the `endsWith`
disjunct left the suite GREEN**, because every draft that legitimately ends with
our tail today also starts with our quote.

The input that separates them is real: `bozza <a> primo << ` — type first, then
reply — is precisely what the pre-#1688 code produced, and compose drafts are
persisted, so one can be on screen when this ships. Without the disjunct the
next reply would prepend and produce a two-marker line. The disjunct stays and
the case now has its own test. Second pass: **7/7 dead.**

## Scope held

- **Named and deliberately not fixed:** a pure-operator draft ending in ` << `
  (`ciao << `) still has that marker shed. That predates this issue and is a
  ruling about which markers are ours to remove, not about where the quote goes.
- **The #1067 expectation moved, its intent did not.** `does not clobber an
  existing draft` asserted the defect string. Its stated intent — a half-typed
  line survives the gesture — is untouched; it now asserts both halves are
  present and leaves ordering to the arms filed here.

## No e2e spec, deliberately

The change is a pure string function plus the one call site that feeds it.
`replyQuote.test.ts` drives `replyToMessage` through a real mounted textarea in
jsdom and asserts the draft **and** `selectionStart`/`activeElement`, so the
caret half is covered at the same door. The DOM dance underneath — focus, the
iOS `preventScroll` short-circuit, `placeCaretAtEndInView` — is byte-identical
to the one `issue1105-reply-quote-caret-visible.spec.ts` already drives in a
real browser; this change does not touch it, and a new spec would re-assert
somebody else's plumbing. The two existing reply e2e specs both start from an
asserted-empty compose, so neither is affected.

## Gates

- `bun run check` — **4 stages ran, 0 failed** (lock drift, biome, tsc src, tsc e2e).
  Stated as the stage count on purpose: a red biome silently skips tsc.
- `bun run test` — **5926 passed / 5926**, whole cic suite.
- `design-notes-gate.sh` — post-commit: `1 new entry heading(s), separator and
  marker present.`
- Mutant bench — 7/7 dead (see above).

Measured on `bc9c6c9d`.
