### PR TITLE
fix(#1687): report the queue that names nobody — and the 62s hold that was not one

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -409,6 +409,12 @@ config :logger, :console,
     # and the log line IS the door that reaches CI container logs.
     :held_ms,
     :waiters,
+    # #1687 — the unattributed arm's own measurement. Deliberately NOT
+    # `:held_ms`: nothing in that report observed a hold, and reusing the key
+    # would smuggle the claim back into the structured half after the prose
+    # was written to leave it out. An operator aggregating `held_ms` must not
+    # find waits mixed into it.
+    :longest_wait_ms,
     :pid,
     :unexpected,
     # Bootstrap summary: how many credentials we enumerated and how

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59497,3 +59497,152 @@ focus, the iOS `preventScroll` short-circuit, `placeCaretAtEndInView` — is
 byte-identical to the one `issue1105-reply-quote-caret-visible.spec.ts` already
 drives in a real browser; this change does not touch it, and a new spec would
 re-assert somebody else's plumbing.
+<!-- entry #1687 -->
+
+---
+
+## 2026-08-23 — #1687: the instrument was silent, and the number that alarmed us measured something else
+
+`Grappa.Repo.LockWatch` was ARMED in production through the 2026-08-22
+16:36–16:38 episode — `enabled: true`, `stall_threshold_ms: 2_000`,
+`tick_ms: 1_000` — and put **zero** lines in `erlang.log.5` while 23
+`busy_locked` terminals piled up over ~170 s. #1420 built it precisely to
+answer *who holds the write lock*, and on the first live stall after it
+shipped it answered nothing.
+
+### The gap was by construction, not by accident
+
+`observe/1` has exactly one producer, `Repo.immediate_transaction/1`, so only
+a writer that passed that seam is ever tagged `:holding` — 20 call sites in
+`lib/`, against 123 bare `Repo.{insert,update,delete,*_all}` sites. The writer
+that dominates the hot path under an IRC flood is one of the 123:
+`Scrollback.persist_row/1` is `with_pool_retry(fn -> Repo.insert(changeset) end)`
+(`lib/grappa/scrollback.ex:227`), and `Grappa.Repo` overrides no write
+callback, so nothing wraps it. `detect/2` then declined to report, on a
+comment that said so out loud: *"waiters with no holder are the pool's
+business, not the write lock's."* So the one class of writer the instrument
+cannot see was also the one case its reporting rule turned into silence.
+
+### 🔴 The 62-second hold does not exist
+
+The issue opened on `SQLite write lock held by another writer for 62494ms`
+and read it as one writer holding for 62 s. **It is not a hold, and the
+arithmetic in the log says so.** `BusyRetry.run/1` stamps `started` BEFORE the
+first `op.()` (`busy_retry.ex:127`) and reports `now - started` (`:138`), so
+with `attempts=1` the figure is one whole `Repo.insert/2` — pool checkout AND
+statement, indistinguishable — while the prose composed around it
+(`terminal_message/3`) asserts a *hold*. Subject inferred from the fault
+class, number measured from something else.
+
+Subtracting `elapsed` from the emission stamps decomposes it:
+
+| emitted | elapsed | implied start |
+|---|---|---|
+| 16:36:32.556 | 31303 ms | 16:36:01.253 |
+| 16:37:03.422 | 62494 ms | 16:36:00.928 |
+| 16:37:03.484 | 31282 ms | 16:36:32.202 |
+
+The 62.5 s and 31.3 s victims **start together** at 16:36:01 ±350 ms. Blocked
+on the same busy handler from the same instant they would raise together at
+~30 s (`busy_timeout: 30_000`); they do not. And the cohort that raises at
+16:37:03 having waited 31.3 s **starts at 16:36:32.2** — the instant the first
+cohort died and released its connections. So `62494ms` = ~31.2 s queued for a
+pool connection + ~31.3 s on `busy_timeout`, inside one un-preemptable call.
+**The longest write-lock wait anywhere in the episode is ~31.3 s, i.e. one
+`busy_timeout`.**
+
+Corroborated independently: the same quantum appears in `pool saturated`
+(33371, 33426, 33371, 33361, 32979 …), a class that never touches the write
+lock, alongside a genuinely short ~2.17 s cluster in the same millisecond —
+so the quantum is `busy_timeout` propagating through a pool whose connections
+are all held by writers parked in their own busy waits. The WS upgrade series
+(1146 → 31576 → **63399** → 31863 → 31921 → 31816 → 31741 ms) is the same
+quantum and the same doubling, on a real user — evidence for #1618, filed
+there.
+
+**The rule, and it outlives this incident: a quantum that recurs across fault
+classes is a TIMEOUT signature, not a duration of work.** Read a repeated
+number as a clock somebody set, and go find whose.
+
+### What the new line says, and the sentence it refuses to say
+
+The issue proposed *"N waiters queued ≥Xms, holder unattributed"*. That still
+asserts a HOLD by an unregistered writer — and the decomposition above shows
+pool queueing is an equally live cause that this frame never measured. So the
+unattributed arm states only what it observed: how many registered writers are
+queued, the longest wait, and how many holders are registered. The two
+candidate topologies are separated by the WAITERS' OWN STACKS, which it
+samples and carries — the discipline `LockWatch`'s moduledoc already claimed
+(*"its sampled stack says which"*) and did not yet practise on this path.
+
+The measurement is `longest_wait_ms`, never `held_ms`. Reusing the hold field
+would have smuggled the claim back in through the schema after the prose was
+written to keep it out — which is exactly the defect `terminal_message/3` was
+rewritten twice to stop committing (#1420 split the phrase, #1421 fixed the
+number). In `Grappa.DbLatency` the row's `holder_pid` and `held_ms` are `nil`:
+the explicit-null honesty signal, because `held_ms: 0` asserts a measured hold
+of zero and nothing here measured a hold at all.
+
+The half-right half of the old comment survives in the code: the pool IS
+implicated. What died is the conclusion that being implicated justifies
+silence.
+
+### Two defects the design surfaced before it shipped
+
+**The flag.** `acquired/0` promoted a row with `[{2, :holding}, {3, now_ms()}]`
+— role and clock, not `reported?`. Giving that flag a second writer (the new
+arm arms it on WAITER rows) meant a pid reported once while queued would carry
+an armed flag into its own hold and be **permanently unreportable as a
+holder**. The cure for the unattributed blindness would have blinded the path
+that already worked. `acquired/0` now clears it: the promotion IS a new
+episode, with a new clock.
+
+**The fork.** Splitting on "did we print something" rather than on
+ATTRIBUTABLE (holders past the threshold, reported or not) drops an
+already-announced episode into the second arm on the very next tick, printing
+*"none past the threshold"* about a holder that is past it. Nameable-at-all
+and not-yet-named are two different questions and only the first chooses the
+arm.
+
+**And one in code that predates this.** `Operator.lock_stall_detail_lines/1`
+matched `%{holder: nil} -> []`, correct for `:resolved` and catastrophic for
+an unattributed row: it would discard the waiters and their stacks, the only
+payload such an episode has. Split into two blocks, so `:resolved` renders as
+a header line by the DATA (`waiters == []`) rather than by a clause guessing
+from the wrong field.
+
+`scripts/log-gap-scan.awk` gains `lockstall_unattributed` in the same commit
+as the prose, per the rule on its own call site. It is NOT folded into
+`lockstall`, which means *a holder was NAMED*: folding them would let the
+artefact report an attribution the instrument explicitly declined to make.
+Through the whole prod episode both existing counters read zero, and zero is
+what a clean run looks like.
+
+### #1420 stays closed
+
+Its closing criterion reads *"Re-open, or file fresh, when LockWatch names a
+holder in a live stall."* Disjunctive, and its trigger — LockWatch **naming**
+a holder — never fired. An instrument that stayed mute is a defect in the
+instrument, a different axis from #1420's (which delivered the mechanism and
+the observer), and the "file fresh" branch is already exercised by #1687. The
+speculative reading that this was #1420's mirror case and should reopen it was
+tested against the text and dropped.
+
+### What is still NOT measured
+
+**Who held the lock is not named, and this work does not name it.** The log
+carries zero LockWatch lines — that is the defect, not a gap in the extract.
+`persist_row/1` remains the obvious structural suspect and obvious is not
+measured. Whether a single holder persisted for ~3 minutes is not
+distinguishable from no single holder at all on this evidence: every
+observable quantum is a victim's timeout, never a release.
+
+The **coverage** half — registering autocommit writers as holders — is
+deliberately not attempted here. It is not a wrapping exercise: an autocommit
+statement has no `waiting → acquired` fracture (it blocks inside the NIF with
+no callback between "queued" and "granted"), so tagging it `:holding` for its
+whole duration would label a victim parked on `busy_timeout` as the HOLDER —
+the instrument accusing the victim, which is worse than silence and is the
+precise confusion it exists to resolve. Tagging it `:waiting` reports nothing
+new. A third role is needed, and it must be priced in ETS writes on the hot
+path before it is proposed.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59646,3 +59646,51 @@ the instrument accusing the victim, which is worse than silence and is the
 precise confusion it exists to resolve. Tagging it `:waiting` reports nothing
 new. A third role is needed, and it must be priced in ETS writes on the hot
 path before it is proposed.
+
+### The test harness had two clocks, in the wrong order
+
+CI run `32663241142` turned the new cohort test red — `6817 tests, 1 failure` —
+with `assert_receive {:unattributed, _, _}` timing out at 1000ms and an
+`%Exqlite.Error{message: "database is locked", statement: "BEGIN IMMEDIATE
+TRANSACTION"}` sitting in the mailbox instead: the writer that was supposed to
+be QUEUED had died. Local `check.sh` was green, so it is load-dependent.
+
+Measured, in the harness's own topology, before changing anything:
+
+* The give-up is the configured `busy_timeout` and it tracks: `500` → 586ms,
+  `2_000` → 4.2s, `30_000` → 35.1s. The option reaches the connection.
+* That budget is wall-clock and load-INSENSITIVE: 33.9s idle versus 32.8s with
+  32 spinning processes on the same BEAM. exqlite's custom busy handler
+  (`c_src/sqlite3_nif.c:332`) models elapsed from an invocation count, so the
+  worry that a loaded scheduler would burn it faster was checked, and refuted.
+* Sampling a writer parked inside the dirty NIF is cheap, not blocking:
+  `LockWatch.inspect_lock/0` costs 0–3ms against a waiter whose
+  `current_function` is `Exqlite.Sqlite3NIF.execute/2`.
+* A killed waiter dies AT ONCE (0ms) and its watch-table row goes with it —
+  exqlite's busy handler polls `enif_is_process_alive` on the caller — so the
+  suspected "ghost row poisons the next test's barrier" cascade is refuted too.
+* Every test in the file costs 15–378ms.
+
+So the waiter has one hard budget that starts at its `BEGIN IMMEDIATE` and has
+to cover everything the test does before the holder is released, and that
+budget was SMALLER than ExUnit's per-test deadline. A test ExUnit still allowed
+to run could therefore outlive its own waiter, and reported the consequence
+rather than the cause. The cure is the ORDER, not a bigger number: the budget
+is now derived from the module's own deadline (`@waiter_budget_ms =
+@test_timeout_ms * 2`), so a stalled runner fails as an ExUnit timeout naming
+the test and the line. It is the same move as `observed_write/3`'s
+`timeout: :infinity` one layer out — that removed the checkout deadline so
+`busy_timeout` was the only bound left; this bounds `busy_timeout` in turn.
+
+Proven by displacement, not by re-running the flake: with a 35s stall injected
+between the barrier and the scan, the OLD shape reproduces the CI failure
+exactly — same assertion, same mailbox value, same two stack frames — and the
+NEW shape passes with the same injection (8 tests, 0 failures, 37.3s). The
+injection is a measurement and is not committed.
+
+**Not measured, and not guessed at:** what consumed ~30s of that waiter's
+budget on the runner. The exception is stamped `20:07:53.782`, one second
+before the assertion gave up, inside a 35.4s window in which ~103 tests
+flushed; the three accelerators above were each tested and refuted, and no
+fourth is elected here. The ordering fix does not depend on knowing which one
+it was — it removes the class.

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -48,7 +48,8 @@ defmodule Grappa.DbLatency do
         - **mechanism 3 (pure insert / index write-amplification):** the
           `persist` row `mean_ms` on its own, watched as the table grows.
 
-    * **`[:grappa, :repo, :lock_stall, :detected | :resolved]`** (#1420) —
+    * **`[:grappa, :repo, :lock_stall, :detected | :resolved |
+      :unattributed]`** (#1420, #1687) —
       the write-lock HOLDER, which neither family above can see. Both of
       them are completion-driven, so a process sitting idle inside
       `BEGIN IMMEDIATE` emits nothing while it sits and only its victims
@@ -56,6 +57,12 @@ defmodule Grappa.DbLatency do
       reads at the seam instead and hands over the holder's sampled stack
       plus the queue behind it; here they are kept as a bounded ring, so
       the existing CLI and admin doors surface them with no new noun.
+      `:unattributed` is the same ring for the episodes that seam CANNOT
+      name — an autocommit writer holds the same file lock and never
+      registers — and it carries the queue's stacks with explicit nils
+      where the holder would be. Filing it elsewhere would mean an operator
+      asking what the write lock did has to already know that a third,
+      differently-shaped answer exists somewhere else.
 
   ## Reading a window
 
@@ -95,7 +102,8 @@ defmodule Grappa.DbLatency do
     [:grappa, :session, :send_privmsg, :stop],
     [:grappa, :scrollback, :persist, :contention],
     [:grappa, :repo, :lock_stall, :detected],
-    [:grappa, :repo, :lock_stall, :resolved]
+    [:grappa, :repo, :lock_stall, :resolved],
+    [:grappa, :repo, :lock_stall, :unattributed]
   ]
 
   # #1420 — the lock-stall ring is bounded: these rows carry sampled
@@ -139,11 +147,20 @@ defmodule Grappa.DbLatency do
   sampled stack and the queue behind it; `:resolved` brackets the same
   episode with the TOTAL hold and no samples (by then there is nothing left
   to sample). Newest first.
+
+  `:unattributed` (#1687) is the third phase and the reason two fields are
+  nilable: a queue past the threshold that LockWatch could name nobody for.
+  Its `holder_pid` and `held_ms` are `nil` — the explicit-null honesty
+  signal, not a gap to paper over. A `held_ms: 0` would assert a hold of
+  zero was measured, and nothing in that episode measured a hold at all; its
+  own figure is the longest WAIT, which rides the telemetry measurements and
+  is derivable from `waiters` rather than duplicated here. It gets no
+  `:resolved` bracket, because there is no hold to total.
   """
   @type lock_stall_row :: %{
-          phase: :detected | :resolved,
-          holder_pid: String.t(),
-          held_ms: non_neg_integer(),
+          phase: :detected | :resolved | :unattributed,
+          holder_pid: String.t() | nil,
+          held_ms: non_neg_integer() | nil,
           waiter_count: non_neg_integer(),
           holder: map() | nil,
           waiters: [map()]
@@ -278,6 +295,22 @@ defmodule Grappa.DbLatency do
       held_ms: measurements.held_ms,
       waiter_count: measurements.waiter_count,
       holder: metadata.holder,
+      waiters: metadata.waiters
+    })
+  end
+
+  # #1687 — the episode that named nobody. It reaches the SAME ring and the
+  # same two doors as the other two: an operator asking "what did the write
+  # lock do" must not have to know that a third, differently-shaped answer
+  # exists somewhere else. What it does NOT do is synthesise a holder to fit
+  # the row shape — the nils are the finding.
+  defp fold([:grappa, :repo, :lock_stall, :unattributed], measurements, metadata, state) do
+    push_stall(state, %{
+      phase: :unattributed,
+      holder_pid: nil,
+      held_ms: nil,
+      waiter_count: measurements.waiter_count,
+      holder: nil,
       waiters: metadata.waiters
     })
   end

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -1032,8 +1032,8 @@ defmodule Grappa.Operator do
 
     Enum.each(snapshot.lock_stalls, fn stall ->
       IO.puts(
-        "#{stall.phase}\tholder=#{stall.holder_pid}\theld_ms=#{stall.held_ms}" <>
-          "\twaiters=#{stall.waiter_count}"
+        "#{stall.phase}\tholder=#{lock_stall_field(stall.holder_pid)}" <>
+          "\theld_ms=#{lock_stall_field(stall.held_ms)}\twaiters=#{stall.waiter_count}"
       )
 
       Enum.each(lock_stall_detail_lines(stall), &IO.puts/1)
@@ -1042,15 +1042,35 @@ defmodule Grappa.Operator do
     :ok
   end
 
-  # A `:resolved` row carries no samples (the episode is over and there is
-  # nothing left to inspect), so it renders as its header line alone.
-  @spec lock_stall_detail_lines(DbLatency.lock_stall_row()) :: [String.t()]
-  defp lock_stall_detail_lines(%{holder: nil}), do: []
+  # #1687 — an `:unattributed` row has no holder and no hold, and the column
+  # has to SAY so. Interpolating the nil would print `holder=`, which reads
+  # as a formatting slip rather than as the finding it is.
+  @spec lock_stall_field(String.t() | non_neg_integer() | nil) :: String.t()
+  defp lock_stall_field(nil), do: "unattributed"
+  defp lock_stall_field(value), do: to_string(value)
 
+  # The two blocks are separate because the phases carry different halves.
+  # A `:resolved` row has neither (the episode is over, nothing left to
+  # inspect) and still renders as its header line alone — `waiters` is `[]`
+  # there, so that behaviour is preserved by the data, not by a clause.
+  #
+  # 🔴 The clause this replaces was `%{holder: nil} -> []`, which would have
+  # thrown away an `:unattributed` row's ENTIRE payload: those waiters and
+  # their stacks are the only thing such an episode can honestly show, and
+  # they are what separates "blocked on the lock" from "queued for a
+  # connection".
+  @spec lock_stall_detail_lines(DbLatency.lock_stall_row()) :: [String.t()]
   defp lock_stall_detail_lines(%{holder: holder, waiters: waiters}) do
-    ["  holder at #{holder.current_function} (#{holder.status}, mailbox #{holder.message_queue_len})"] ++
-      Enum.map(holder.stacktrace, &"    #{&1}") ++
+    holder_lines(holder) ++
       Enum.map(waiters, &"  waiter #{&1.pid} waiting #{&1.elapsed_ms}ms at #{&1.current_function}")
+  end
+
+  @spec holder_lines(map() | nil) :: [String.t()]
+  defp holder_lines(nil), do: []
+
+  defp holder_lines(holder) do
+    ["  holder at #{holder.current_function} (#{holder.status}, mailbox #{holder.message_queue_len})"] ++
+      Enum.map(holder.stacktrace, &"    #{&1}")
   end
 
   @doc """

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -57,15 +57,58 @@ defmodule Grappa.Repo.LockWatch do
 
   ## What it reports, and when
 
-  A watchdog tick scans the table and reports only when a holder has held
-  for at least `stall_threshold_ms` **AND at least one waiter is queued
-  behind it**. A slow-but-uncontended transaction is not a stall, and
-  reporting one would bury the signal it exists to find.
+  A watchdog tick scans the table and reports a NAMED stall only when a
+  holder has held for at least `stall_threshold_ms` **AND at least one
+  waiter is queued behind it**. A slow-but-uncontended transaction is not a
+  stall, and reporting one would bury the signal it exists to find.
 
-  One report per episode (the row's `reported?` flag arms on the first and
-  disarms on release) — otherwise a 30 s stall prints 30 times. Release
-  emits a second, `:resolved` event carrying the TOTAL hold, so an episode
-  has both an opening and a closing bracket.
+  ### The unattributed arm (#1687)
+
+  A queue past the threshold that named nobody is reported too, as its own
+  line. This arm exists because the first one is blind by construction:
+  `observe/1` has a single producer, so ONLY a writer that went through
+  `Grappa.Repo.immediate_transaction/1` can ever be tagged `:holding`. Every
+  autocommit single-statement write — `Grappa.Scrollback.persist_row/1`
+  (`lib/grappa/scrollback.ex:227`) and its ~120 peers — takes the same file
+  lock and owns no row here at all.
+
+  This code used to answer that case with silence, on the reasoning that
+  *"waiters with no holder are the pool's business, not the write lock's."*
+  🔴 **Measured in prod on 2026-08-22 (grappa 1.3.1, `erlang.log.5`), that
+  reasoning was half right and the conclusion was wrong.** Half right: the
+  pool IS a real component — victims' `elapsed` decomposes as ~31 s of
+  DBConnection checkout plus ~31 s of `busy_timeout`, which is the whole of
+  the "62 s" that opened #1687. Wrong: through a ~170 s episode, with this
+  observer ARMED at `stall_threshold_ms: 2_000` and 23 `busy_locked`
+  terminals in the log, it emitted **zero** lines. A long unattributed stall
+  was indistinguishable from a healthy system, so the one thing the operator
+  learned from the instrument was nothing.
+
+  🔴 **The line states what was OBSERVED and stops there.** It does NOT say
+  the write lock is held by an unregistered writer — that is an inference,
+  and the same prod episode shows pool queueing is an equally live cause.
+  What it can vouch for is exactly: N registered writers have been queued
+  past the threshold, and this many holders are registered (usually none).
+  The two candidate causes are separated by the WAITERS' OWN STACKS, which
+  it samples and carries — a waiter parked in `Exqlite.Sqlite3NIF` is
+  blocked on the lock, one inside `DBConnection.Holder` is queued for a
+  connection. Asserting a cause the frame never measured is the exact defect
+  `terminal_message/3` in `Grappa.Repo.BusyRetry` was twice rewritten to
+  stop committing (#1420, #1421); this arm does not re-commit it here.
+
+  ### One report per episode, on either arm
+
+  The row's `reported?` flag arms on the first report and disarms on release
+  — otherwise a 30 s stall prints 30 times. Release emits a second,
+  `:resolved` event carrying the TOTAL hold, so a NAMED episode has both an
+  opening and a closing bracket.
+
+  Both arms share that one flag, and the unattributed arm arms it on WAITER
+  rows rather than a holder's. So `acquired/0` CLEARS it on promotion: a pid
+  reported once while queued would otherwise carry an armed flag into its own
+  hold and never be reportable as the holder it went on to become. An
+  unattributed episode gets no closing bracket — there was no hold to total,
+  and inventing one is the claim this arm exists to avoid.
 
   ## Deriving the holder's identity instead of storing it
 
@@ -149,6 +192,19 @@ defmodule Grappa.Repo.LockWatch do
           holder: sample(),
           waiters: [sample()],
           waiter_count: non_neg_integer()
+        }
+
+  @typedoc """
+  A queue nobody can be blamed for (#1687): writers past the threshold with
+  no holder this instrument can name. `holders_registered` is the honesty
+  field — `0` says the seam saw no holder at all (the autocommit case),
+  a positive value says one is registered but has not crossed the
+  threshold. There is deliberately no `holder` key: a record cannot carry a
+  field for a thing that was never observed.
+  """
+  @type unattributed :: %{
+          waiters: [sample()],
+          holders_registered: non_neg_integer()
         }
 
   defstruct [:stall_threshold_ms, :tick_ms, :enabled]
@@ -235,10 +291,18 @@ defmodule Grappa.Repo.LockWatch do
   # precisely the semantic change this instrument is forbidden to make.
   # `enabled?/0` proves the table exists and `:ets.update_element/3` answers
   # `false` (never raises) for an absent key.
+  #
+  # 🔴 The `reported?` reset is load-bearing since #1687 gave the flag a
+  # second writer. The unattributed arm arms it on WAITER rows, and this
+  # update rewrites the role and restarts the clock in place — so without
+  # `{4, false}` a pid reported once while queued would carry an armed flag
+  # into its own hold and `unreported?/1` would suppress it forever. Clearing
+  # it here is not defensive: the promotion IS a new episode, with a new
+  # clock, and a new episode has not been reported.
   @spec acquired() :: :ok
   defp acquired do
     if depth() == 1 and enabled?() do
-      :ets.update_element(@table, self(), [{2, :holding}, {3, now_ms()}])
+      :ets.update_element(@table, self(), [{2, :holding}, {3, now_ms()}, {4, false}])
     end
 
     :ok
@@ -344,21 +408,60 @@ defmodule Grappa.Repo.LockWatch do
 
   ## ----- Detection -----------------------------------------------------
 
-  # A stall is a holder past the threshold WITH a queue behind it. Neither
-  # half alone qualifies: a lone slow transaction blocks nobody, and waiters
-  # with no holder are the pool's business, not the write lock's.
+  # A NAMED stall is a holder past the threshold WITH a queue behind it.
+  # Neither half alone qualifies: a lone slow transaction blocks nobody.
+  #
+  # The `else` is the #1687 arm, and it is a fallback rather than a second
+  # independent test on purpose — the two are mutually exclusive, so a real
+  # stall is reported once, by its own name, and never also as an anonymous
+  # queue. It fires in both shapes the first arm walks away from: no holder
+  # registered at all (the autocommit case that produced the prod episode),
+  # and a holder registered but still under the threshold while the queue
+  # behind it is already past it. Both are the same defect — writers
+  # demonstrably stuck, instrument silent — so they get the same cure and one
+  # metadata field tells them apart.
   @spec detect(integer(), non_neg_integer()) :: :ok
   defp detect(now, threshold_ms) do
     {holders, waiters} = partition(rows(), now)
 
-    stalled = Enum.filter(holders, fn {pid, elapsed} -> elapsed >= threshold_ms and unreported?(pid) end)
-
-    if stalled != [] and waiters != [] do
-      waiter_samples = Enum.map(waiters, fn {pid, elapsed} -> sample(pid, elapsed) end)
-      Enum.each(stalled, &report(&1, waiter_samples))
+    # 🔴 The fork is ATTRIBUTABLE, not "did we print something". Splitting on
+    # the reportable set instead would make an already-announced episode fall
+    # through to the second arm on the very next tick and print "none past
+    # the threshold" about a holder that is past it — the instrument lying in
+    # the act of being more talkative. Nameable-at-all and
+    # not-yet-named-this-episode are two different questions, and only the
+    # first one chooses the arm.
+    if attributable(holders, threshold_ms) == [] do
+      report_unattributed(unreported_past(waiters, threshold_ms), length(holders))
+    else
+      report_stalls(unreported_past(holders, threshold_ms), waiters)
     end
 
     :ok
+  end
+
+  # Holders past the threshold, whether or not this episode already named
+  # them. This is the "can anyone be blamed at all?" question.
+  @spec attributable([{pid(), non_neg_integer()}], non_neg_integer()) :: [{pid(), non_neg_integer()}]
+  defp attributable(holders, threshold_ms) do
+    Enum.filter(holders, fn {_, elapsed} -> elapsed >= threshold_ms end)
+  end
+
+  # Rows past the threshold that this episode has not reported yet — the
+  # "what is left to say?" question. Shared by both arms so they cannot
+  # drift on either half of the predicate.
+  @spec unreported_past([{pid(), non_neg_integer()}], non_neg_integer()) :: [{pid(), non_neg_integer()}]
+  defp unreported_past(rows, threshold_ms) do
+    Enum.filter(rows, fn {pid, elapsed} -> elapsed >= threshold_ms and unreported?(pid) end)
+  end
+
+  @spec report_stalls([{pid(), non_neg_integer()}], [{pid(), non_neg_integer()}]) :: :ok
+  defp report_stalls([], _), do: :ok
+  defp report_stalls(_, []), do: :ok
+
+  defp report_stalls(stalled, waiters) do
+    waiter_samples = Enum.map(waiters, fn {pid, elapsed} -> sample(pid, elapsed) end)
+    Enum.each(stalled, &report(&1, waiter_samples))
   end
 
   @spec report({pid(), non_neg_integer()}, [sample()]) :: :ok
@@ -390,6 +493,54 @@ defmodule Grappa.Repo.LockWatch do
       stall
     )
   end
+
+  # #1687 — the queue nobody can be blamed for. Same two doors as `report/2`,
+  # and deliberately the same SHAPE of line, so an operator scanning the log
+  # reads them as one instrument with two verdicts rather than two tools.
+  #
+  # It carries the LONGEST waiter's stack for the same reason `report/2`
+  # carries the holder's: it is the one frame that says which of the two
+  # topologies this is. The measurement is named `longest_wait_ms` and not
+  # `held_ms` — nothing here observed a hold, and reusing the hold field
+  # would smuggle the claim back in through the schema after the prose had
+  # been careful to leave it out.
+  @spec report_unattributed([{pid(), non_neg_integer()}], non_neg_integer()) :: :ok
+  defp report_unattributed([], _), do: :ok
+
+  defp report_unattributed(queued, holders_registered) do
+    # Arm BEFORE emitting, exactly as `report/2` does: a 170-second prod
+    # episode at `tick_ms: 1_000` would otherwise print the same warning ~170
+    # times, which an operator reads the same way as never printing it.
+    Enum.each(queued, fn {pid, _} -> :ets.update_element(@table, pid, [{4, true}]) end)
+
+    samples = Enum.map(queued, fn {pid, elapsed} -> sample(pid, elapsed) end)
+    longest = Enum.max_by(samples, & &1.elapsed_ms)
+    report = %{waiters: samples, holders_registered: holders_registered}
+
+    Logger.warning(
+      "db lock stall UNATTRIBUTED: #{length(samples)} writer(s) queued past the threshold, " <>
+        "longest #{longest.elapsed_ms}ms — #{holder_clause(holders_registered)}, so the holder is " <>
+        "NOT attributable at the BEGIN IMMEDIATE seam; longest waiter #{longest.pid} " <>
+        "status=#{inspect(longest.status)} at #{longest.current_function}, " <>
+        "stack: #{Enum.join(longest.stacktrace, " <- ")}",
+      waiters: length(samples),
+      longest_wait_ms: longest.elapsed_ms
+    )
+
+    :telemetry.execute(
+      [:grappa, :repo, :lock_stall, :unattributed],
+      %{waiter_count: length(samples), longest_wait_ms: longest.elapsed_ms},
+      report
+    )
+  end
+
+  # The two sub-cases, named apart because they call for different next
+  # moves: `0` means the writer holding the lock never passed the seam (widen
+  # coverage, or accept the blindness knowingly), while a positive count
+  # means the seam DID see a holder and the queue is simply older than it.
+  @spec holder_clause(non_neg_integer()) :: String.t()
+  defp holder_clause(0), do: "no holder registered"
+  defp holder_clause(n), do: "#{n} holder(s) registered, none past the threshold"
 
   ## ----- Sampling -------------------------------------------------------
 

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -112,6 +112,12 @@ function count_signatures(line) {
         if (line ~ /write lock held by another writer/) CNT["lockheld"]++
         if (line ~ /db lock stall: holder /) CNT["lockstall"]++
         if (line ~ /db lock stall RESOLVED/) CNT["lockstall_resolved"]++
+        # #1687 — the third LockWatch edge. Its own counter, not folded into
+        # `lockstall`: that one means "a holder was NAMED", and the whole
+        # point of this one is that nobody could be. Folding them would let
+        # an episode the instrument could not attribute be read off the
+        # artefact as one it did.
+        if (line ~ /db lock stall UNATTRIBUTED/) CNT["lockstall_unattributed"]++
     }
 }
 
@@ -125,7 +131,7 @@ function summary_line(svc, nlines, mg, mat) {
     return sprintf(SUMFMT, svc, nlines, mg, mat, THRESH, ngap, \
         CNT["db30"], CNT["idle30"], CNT["dropped"], CNT["saturated"], \
         CNT["interrupted"], CNT["lockheld"], CNT["lockstall"], \
-        CNT["lockstall_resolved"])
+        CNT["lockstall_resolved"], CNT["lockstall_unattributed"])
 }
 
 function bail(msg) {
@@ -196,7 +202,8 @@ BEGIN {
 
     SUMFMT = "%s\tSUMMARY\tlines=%d\tmaxgap=%.1f\tmaxgap_at=%s\tgaps_ge_%d=%d" \
         "\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d\tinterrupted=%d" \
-        "\tlockheld=%d\tlockstall=%d\tlockstall_resolved=%d\n"
+        "\tlockheld=%d\tlockstall=%d\tlockstall_resolved=%d" \
+        "\tlockstall_unattributed=%d\n"
 
     # Samples copied from the emitting call site. Keep them verbatim: a
     # sample edited to fit the pattern turns the control into a mirror.
@@ -206,6 +213,11 @@ BEGIN {
     #   interrupted        — Repo.BusyRetry, interrupted arm (#1657).
     #   lockheld           — Repo.BusyRetry, busy_locked arm (#1420).
     #   lockstall{,_resolved} — Grappa.Repo.LockWatch's two episode edges.
+    #   lockstall_unattributed — LockWatch's third edge (#1687): a queue past
+    #                      the threshold that named nobody. It counted ZERO
+    #                      through the whole 2026-08-22 prod episode because
+    #                      the line did not exist; a census blind to it reads
+    #                      exactly like a clean run.
     sig("db30", "QUERY OK source=\"messages\" db=30064.1ms queue=0.1ms")
     sig("idle30", "client #PID<0.700.0> checked out, idle=30062.4ms")
     sig("dropped", "scrollback row dropped for #bofh: :persist_unavailable")
@@ -223,6 +235,11 @@ BEGIN {
         " waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: …")
     sig("lockstall_resolved", \
         "db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms")
+    sig("lockstall_unattributed", \
+        "db lock stall UNATTRIBUTED: 3 writer(s) queued past the threshold, longest" \
+        " 31303ms — no holder registered, so the holder is NOT attributable at the" \
+        " BEGIN IMMEDIATE seam; longest waiter #PID<0.512.0> status=:waiting at" \
+        " :gen_server.loop/7, stack: …")
 
     # Deliberately ordinary: a real line from the same stream that names
     # none of the signatures. It DOES carry the word "lock" so the

--- a/test/grappa/db_latency_test.exs
+++ b/test/grappa/db_latency_test.exs
@@ -24,7 +24,8 @@ defmodule Grappa.DbLatencyTest do
     [:grappa, :session, :send_privmsg, :stop],
     [:grappa, :scrollback, :persist, :contention],
     [:grappa, :repo, :lock_stall, :detected],
-    [:grappa, :repo, :lock_stall, :resolved]
+    [:grappa, :repo, :lock_stall, :resolved],
+    [:grappa, :repo, :lock_stall, :unattributed]
   ]
 
   # Native-unit duration for a whole number of milliseconds, via the
@@ -218,6 +219,41 @@ defmodule Grappa.DbLatencyTest do
       assert detected.waiter_count == 2
       assert detected.holder.stacktrace == ["Foo.bar/1"]
       assert length(detected.waiters) == 2
+    end
+
+    test "[:grappa, :repo, :lock_stall, :unattributed] folds with an explicit nil where the holder would be" do
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :unattributed],
+        %{waiter_count: 3, longest_wait_ms: 31_303},
+        %{
+          holders_registered: 0,
+          waiters: [
+            %{pid: "#PID<0.222.0>", elapsed_ms: 31_303, stacktrace: ["Exqlite.Sqlite3NIF.step/2"]},
+            %{pid: "#PID<0.333.0>", elapsed_ms: 2_100},
+            %{pid: "#PID<0.444.0>", elapsed_ms: 2_050}
+          ]
+        }
+      )
+
+      assert [row] = DbLatency.snapshot().lock_stalls
+
+      assert row.phase == :unattributed
+      assert row.waiter_count == 3
+
+      # 🔴 The two nils are the POINT, not an omission. CLAUDE.md's admin rule
+      # — an explicit null is the honesty signal, never papered over with a
+      # computed field — lands exactly here: a `held_ms: 0` would assert a
+      # measured hold of zero, and a synthesised `holder_pid` would name
+      # somebody. A mutant that defaults either one dies on these two lines.
+      assert row.holder_pid == nil
+      assert row.held_ms == nil
+      assert row.holder == nil
+
+      # The waiters ARE the payload: they are the only thing this episode can
+      # honestly show, and the stack is what separates "blocked on the lock"
+      # from "queued for a connection".
+      assert length(row.waiters) == 3
+      assert hd(row.waiters).stacktrace == ["Exqlite.Sqlite3NIF.step/2"]
     end
 
     test "the lock-stall ring is bounded, keeping the newest episodes" do

--- a/test/grappa/repo/lock_watch_report_test.exs
+++ b/test/grappa/repo/lock_watch_report_test.exs
@@ -60,6 +60,66 @@ defmodule Grappa.Repo.LockWatchReportTest do
     assert log =~ "status=:waiting"
   end
 
+  test "the UNATTRIBUTED warning refuses to name a holder, and says which kind of silence it is" do
+    waiter = start_role(:waiter)
+
+    await_queue_only(waiter)
+
+    log = capture_log(fn -> LockWatch.scan(0) end)
+
+    # #1687 — in prod this was the empty string for ~170 seconds.
+    assert log =~ "db lock stall UNATTRIBUTED: 1 writer(s) queued past the threshold"
+    assert log =~ "no holder registered"
+
+    # 🔴 The load-bearing negative. The issue's own wording ("holder
+    # unattributed") invites a line that still asserts a HOLD by an
+    # unregistered writer. Prod says that inference is unsafe: the victims'
+    # 62 s decomposes into ~31 s of pool checkout plus ~31 s of
+    # `busy_timeout`, so pool queueing is a live cause and this frame
+    # measured neither. A mutant that reinstates the claim dies here.
+    refute log =~ "held"
+    assert log =~ "NOT attributable at the BEGIN IMMEDIATE seam"
+
+    # What it CAN vouch for: which waiter, and where it is parked — the one
+    # field that separates "blocked on the lock" from "queued for a
+    # connection" without guessing between them.
+    assert log =~ "longest waiter #{inspect(waiter)}"
+    assert log =~ "status=:waiting"
+  end
+
+  test "a holder registered but still under the threshold is reported as such, not as no holder" do
+    # Order is the point: the waiter must be measurably OLDER than the
+    # holder, so one threshold can sit between them. Both are registered.
+    #
+    # The waiter has to be AGED before the holder starts, and starting them
+    # back to back is not enough — measured: `acquired/0` restarts the
+    # holder's clock at promotion, which lands microseconds after its own
+    # `waiting/0`, so two roles started together read the SAME elapsed and no
+    # threshold can separate them.
+    waiter = start_role(:waiter)
+    await_age(waiter, 150)
+    holder = start_role(:holder)
+
+    # A polled CONDITION on the instrument's own reading, never a sleep. The
+    # 100ms margin is what makes the threshold choice below safe: the arm
+    # under test only mis-selects if this process is descheduled for 50ms
+    # between the reading and the scan on the next line.
+    {holder_ms, waiter_ms} = await_gap(holder, waiter, 100)
+
+    log = capture_log(fn -> LockWatch.scan(holder_ms + 50) end)
+
+    assert waiter_ms > holder_ms + 100
+
+    # M — a mutant that reports `holders_registered` as a plain boolean, or
+    # that hardcodes the "no holder" clause because it is the case the issue
+    # described, cannot tell an operator whether the seam is working. These
+    # two sub-cases call for opposite next moves: widen coverage, versus
+    # nothing at all because the queue is simply older than the holder.
+    assert log =~ "db lock stall UNATTRIBUTED"
+    assert log =~ "1 holder(s) registered, none past the threshold"
+    refute log =~ "no holder registered"
+  end
+
   ## ----- helpers --------------------------------------------------------
 
   # Both roles go through `LockWatch.observe/1`, production's own wrapper:
@@ -92,6 +152,70 @@ defmodule Grappa.Repo.LockWatchReportTest do
   defp park do
     receive do
       :never -> :ok
+    end
+  end
+
+  # #1687 — the queue-with-no-holder barrier. Same discipline as
+  # `await_roles/2`: the `send` proves the process reached `observe/1`, not
+  # that its ETS row is visible yet.
+  defp await_queue_only(waiter), do: await_queue_only(waiter, 300)
+
+  defp await_queue_only(waiter, 0) do
+    flunk("queue never settled: #{inspect(LockWatch.inspect_lock())} (#{inspect(waiter)})")
+  end
+
+  defp await_queue_only(waiter, attempts) do
+    %{holders: holders, waiters: waiters} = LockWatch.inspect_lock()
+
+    if holders == [] and Enum.map(waiters, & &1.pid) == [inspect(waiter)] do
+      :ok
+    else
+      Process.sleep(10)
+      await_queue_only(waiter, attempts - 1)
+    end
+  end
+
+  # Polls until `waiter`'s own row has aged past `ms`. Read off the
+  # instrument rather than slept, so a loaded runner waits longer instead of
+  # asserting against a clock it never checked.
+  defp await_age(waiter, ms), do: await_age(waiter, ms, 300)
+
+  defp await_age(waiter, ms, 0) do
+    flunk("waiter never aged to #{ms}ms: #{inspect(LockWatch.inspect_lock())} (#{inspect(waiter)})")
+  end
+
+  defp await_age(waiter, ms, attempts) do
+    case LockWatch.inspect_lock() do
+      %{waiters: [%{pid: pid, elapsed_ms: elapsed}]} when elapsed >= ms ->
+        ^pid = inspect(waiter)
+        :ok
+
+      _ ->
+        Process.sleep(10)
+        await_age(waiter, ms, attempts - 1)
+    end
+  end
+
+  # Polls until the waiter is at least `margin` ms older than the holder, and
+  # returns both readings so the caller can place a threshold between them.
+  defp await_gap(holder, waiter, margin), do: await_gap(holder, waiter, margin, 300)
+
+  defp await_gap(holder, waiter, margin, 0) do
+    flunk("gap never opened: #{inspect(LockWatch.inspect_lock())} (#{inspect({holder, waiter, margin})})")
+  end
+
+  defp await_gap(holder, waiter, margin, attempts) do
+    %{holders: holders, waiters: waiters} = LockWatch.inspect_lock()
+
+    with [%{pid: h_pid, elapsed_ms: h_ms}] <- holders,
+         [%{pid: w_pid, elapsed_ms: w_ms}] <- waiters,
+         true <- h_pid == inspect(holder) and w_pid == inspect(waiter),
+         true <- w_ms > h_ms + margin do
+      {h_ms, w_ms}
+    else
+      _ ->
+        Process.sleep(10)
+        await_gap(holder, waiter, margin, attempts - 1)
     end
   end
 

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -42,6 +42,34 @@ defmodule Grappa.Repo.LockWatchTest do
   @detected [:grappa, :repo, :lock_stall, :detected]
   @unattributed [:grappa, :repo, :lock_stall, :unattributed]
 
+  # 🔴 TWO CLOCKS BOUND EVERY TEST HERE, AND THEY HAVE TO BE ORDERED.
+  #
+  # The queued writer stays queued only while SQLite's busy handler keeps
+  # waiting for it: `busy_timeout` is a hard wall-clock budget that starts at
+  # that writer's `BEGIN IMMEDIATE` and has to cover everything the test does
+  # before it releases the holder. ExUnit's own per-test deadline is the other
+  # clock. While the budget was the SMALLER of the two, a runner slow enough to
+  # push a test past it killed the WAITER first, and the test then reported the
+  # consequence — a telemetry message that never arrived, with an unrelated
+  # `%Exqlite.Error{message: "database is locked"}` sitting in the mailbox —
+  # rather than "this test is too slow" (#1687, CI run 32663241142).
+  #
+  # Measured on 29bea21d, in this file's own topology: the budget is
+  # wall-clock and load-INSENSITIVE (`30_000` configured → 32.9s idle and
+  # 32.8s with 32 spinning processes; `500` → 586ms, `2_000` → 4.2s, so it
+  # tracks the setting), while every test in this file costs 15–378ms. So the
+  # cure is not a bigger guess at the budget: it is the ORDER. Derive the
+  # budget FROM the test deadline and no test ExUnit still allows to run can
+  # outlive its own waiter — a stalled runner then fails as an ExUnit timeout,
+  # which names the test and the line instead of the symptom.
+  #
+  # This is the same move as `observed_write/3`'s `timeout: :infinity`, one
+  # layer out: that one removed the checkout deadline so `busy_timeout` was
+  # the only bound left, and this one bounds `busy_timeout` in turn.
+  @test_timeout_ms 60_000
+  @moduletag timeout: @test_timeout_ms
+  @waiter_budget_ms @test_timeout_ms * 2
+
   setup do
     LockWatch.put_test_enabled(true)
     on_exit(fn -> LockWatch.put_test_enabled(false) end)
@@ -336,14 +364,21 @@ defmodule Grappa.Repo.LockWatchTest do
     path = Path.join(System.tmp_dir!(), "lock_watch_#{System.unique_integer([:positive])}.db")
     on_exit(fn -> Enum.each(["", "-wal", "-shm"], &File.rm(path <> &1)) end)
 
-    # busy_timeout is generous on purpose: the waiter must still be WAITING
-    # when the scan runs. A short timeout would turn it into an error path
-    # and measure `BusyRetry` instead of this module.
+    # busy_timeout is the waiter's whole life: it must still be WAITING when
+    # the scan runs, and a short timeout would turn it into an error path and
+    # measure `BusyRetry` instead of this module. The value is DERIVED from the
+    # test deadline rather than chosen — see `@waiter_budget_ms` for why the
+    # two clocks have to be ordered and what a mis-order looks like.
     #
     # It is NOT the only wait on that writer, and on its own it does not
     # govern — see `observed_write/3`.
     {:ok, repo} =
-      TmpRepo.start_link(database: path, pool_size: 2, busy_timeout: 30_000, journal_mode: :wal)
+      TmpRepo.start_link(
+        database: path,
+        pool_size: 2,
+        busy_timeout: @waiter_budget_ms,
+        journal_mode: :wal
+      )
 
     TmpRepo.query!("CREATE TABLE t(id integer)")
 

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -30,6 +30,8 @@ defmodule Grappa.Repo.LockWatchTest do
   """
   use Grappa.DataCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias Grappa.Repo.LockWatch
 
   defmodule TmpRepo do
@@ -38,6 +40,7 @@ defmodule Grappa.Repo.LockWatchTest do
   end
 
   @detected [:grappa, :repo, :lock_stall, :detected]
+  @unattributed [:grappa, :repo, :lock_stall, :unattributed]
 
   setup do
     LockWatch.put_test_enabled(true)
@@ -46,12 +49,17 @@ defmodule Grappa.Repo.LockWatchTest do
     handler = "lock-watch-test-#{System.unique_integer([:positive])}"
     test_pid = self()
 
+    # Both doors on ONE handler, tagged by event: a test that asserts the
+    # attributed line fired must also be able to REFUTE the unattributed one
+    # (and vice versa). Two separate handlers would let a mutant that emits
+    # both pass every assertion in the file.
     :ok =
-      :telemetry.attach(
+      :telemetry.attach_many(
         handler,
-        @detected,
-        fn _, measurements, metadata, _ ->
-          send(test_pid, {:stall, measurements, metadata})
+        [@detected, @unattributed],
+        fn
+          @detected, measurements, metadata, _ -> send(test_pid, {:stall, measurements, metadata})
+          @unattributed, measurements, metadata, _ -> send(test_pid, {:unattributed, measurements, metadata})
         end,
         nil
       )
@@ -96,6 +104,12 @@ defmodule Grappa.Repo.LockWatchTest do
       # CONTENT of the stack tells the two apart. This frame is the reason
       # the holder is stuck, which is the datum #1420 says is missing.
       assert Enum.any?(stall.holder.stacktrace, &(&1 =~ "park_until_released"))
+
+      # #1687 — the two arms are mutually exclusive by construction. A mutant
+      # that emits the unattributed line unconditionally (rather than only
+      # when nothing was named) would double-report every real stall, and the
+      # operator would learn to ignore both.
+      refute_receive {:unattributed, _, _}, 100
 
       send(holder, :release)
       assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
@@ -146,6 +160,147 @@ defmodule Grappa.Repo.LockWatchTest do
 
       send(holder, :release)
       assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+
+      Supervisor.stop(repo)
+    end
+  end
+
+  describe "a queue with no attributable holder (#1687)" do
+    test "reports the queue instead of staying silent, and says the holder was never attributed" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(nil, [waiter])
+
+      # The LOG is the door that failed in prod: LockWatch was armed through a
+      # three-minute episode and put NOT ONE line in `erlang.log.5`, so the
+      # #1429 census and the operator both read a healthy system. Pinning the
+      # telemetry alone would leave exactly the door that was dark, dark.
+      log = capture_log(fn -> LockWatch.scan(0) end)
+
+      assert log =~ "db lock stall UNATTRIBUTED"
+      assert log =~ "no holder registered"
+
+      assert_receive {:unattributed, measurements, report}, 1_000
+
+      # M6 — a mutant reporting the holder-less queue with a fabricated holder
+      # (the shape the issue's own wording invites) dies here: there is no
+      # holder to name, and the record says so rather than guessing.
+      assert report.holders_registered == 0
+
+      # M7 — a mutant sampling `self()` (the scanning process) instead of the
+      # queued writers still produces a well-formed record; only the pid tells
+      # them apart. The waiters ARE the payload here — they are the only thing
+      # the instrument can honestly show.
+      assert [sample] = report.waiters
+      assert sample.pid == inspect(waiter)
+      assert is_integer(sample.elapsed_ms)
+
+      assert measurements.waiter_count == 1
+      assert is_integer(measurements.longest_wait_ms)
+
+      # M8 — the queue is NOT a named stall. A mutant that routes this through
+      # the attributed door would put a `holder` key on a record that has none.
+      refute_receive {:stall, _, _}, 100
+
+      send(blind, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a queue that has not crossed the threshold is not reported either" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(nil, [waiter])
+
+      # M9 — the mirror of M5 on the new arm. A mutant that drops the
+      # threshold comparison for waiters turns every transient queue behind
+      # every autocommit write into a warning, which on the hot path is a log
+      # flood, not a signal.
+      LockWatch.scan(10_000)
+
+      refute_receive {:unattributed, _, _}, 300
+
+      send(blind, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "one line per queued cohort, not one per watchdog tick" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(nil, [waiter])
+
+      LockWatch.scan(0)
+      assert_receive {:unattributed, _, _}, 1_000
+
+      # M10 — the prod episode ran ~170s at `tick_ms: 1_000`. A mutant that
+      # forgets to arm the row's `reported?` flag prints ~170 identical
+      # warnings for one episode, which is the same as printing none.
+      LockWatch.scan(0)
+      refute_receive {:unattributed, _, _}, 300
+
+      send(blind, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a waiter already reported as unattributed is still reportable once it becomes the holder" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      {writer, writer_ref} = start_writer(2, :park)
+      await_roles(nil, [writer])
+
+      LockWatch.scan(0)
+      assert_receive {:unattributed, _, _}, 1_000
+
+      # The unregistered writer lets go; the pid that was just reported as a
+      # WAITER now takes RESERVED itself.
+      send(blind, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:holding, ^writer}, 10_000
+
+      {queued, queued_ref} = start_writer(3, :straight_through)
+      await_roles(writer, [queued])
+
+      LockWatch.scan(0)
+
+      # 🔴 M11, and it is the whole reason this test exists. `acquired/0`
+      # promotes the row's role and restarts its clock but leaves the
+      # `reported?` flag exactly where it was, so a pid reported once as a
+      # waiter would be permanently unreportable as a HOLDER — the cure for
+      # the unattributed blindness having quietly blinded the attributed path
+      # that already worked. The flag has to clear on promotion, because the
+      # promotion starts a new episode with a new clock.
+      assert_receive {:stall, _, stall}, 1_000
+      assert stall.holder.pid == inspect(writer)
+
+      send(writer, :release)
+      assert_receive {:DOWN, ^writer_ref, :process, ^writer, :normal}, 5_000
+      assert_receive {:DOWN, ^queued_ref, :process, ^queued, :normal}, 10_000
 
       Supervisor.stop(repo)
     end
@@ -246,6 +401,45 @@ defmodule Grappa.Repo.LockWatchTest do
     end)
   end
 
+  # #1687 — a writer that takes RESERVED WITHOUT going through
+  # `LockWatch.observe/1`: it holds the file lock and owns no row in the watch
+  # table. That is the production blindness in person.
+  #
+  # Honest limit, and it is why this is not literally `TmpRepo.insert/2`: the
+  # production writer is a bare autocommit statement
+  # (`Scrollback.persist_row/1` -> `Repo.insert/2`,
+  # `lib/grappa/scrollback.ex:227`), and an autocommit statement cannot be
+  # held open from outside — it commits the moment it returns, so it cannot be
+  # parked while a second writer queues behind it. An un-observed
+  # `mode: :immediate` transaction CAN be parked, and the state `detect/2`
+  # actually reads is byte-identical between the two: RESERVED held, zero rows
+  # in the watch table. This harness reproduces the OBSERVABLE state, not the
+  # statement shape.
+  defp start_unobserved_writer(id) do
+    test_pid = self()
+
+    {pid, ref} = spawn_monitor(fn -> unobserved_write(id, test_pid) end)
+
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    {pid, ref}
+  end
+
+  # `timeout: :infinity` for the same reason `observed_write/3` carries it —
+  # see the 🔴 note there. Without it the park is capped at Ecto's default
+  # 15_000 checkout deadline rather than by this test's own release message.
+  defp unobserved_write(id, test_pid) do
+    TmpRepo.transaction(
+      fn ->
+        TmpRepo.query!("INSERT INTO t VALUES (?)", [id])
+        send(test_pid, {:holding, self()})
+        park_until_released()
+      end,
+      mode: :immediate,
+      timeout: :infinity
+    )
+  end
+
   defp insert_then(id, after_insert, test_pid, acquired) do
     acquired.()
     TmpRepo.query!("INSERT INTO t VALUES (?)", [id])
@@ -261,16 +455,22 @@ defmodule Grappa.Repo.LockWatchTest do
     end
   end
 
+  # `holder` is `nil` for the #1687 topology — a queue whose holder owns no
+  # row, so the barrier is "holders is EMPTY and these pids are queued".
   defp await_roles(holder, waiters) do
     await_until(
       fn ->
         %{holders: held, waiters: queued} = LockWatch.inspect_lock()
 
-        pids(held) == [inspect(holder)] and Enum.sort(pids(queued)) == Enum.sort(Enum.map(waiters, &inspect/1))
+        pids(held) == expected_holders(holder) and
+          Enum.sort(pids(queued)) == Enum.sort(Enum.map(waiters, &inspect/1))
       end,
       300
     )
   end
+
+  defp expected_holders(nil), do: []
+  defp expected_holders(holder), do: [inspect(holder)]
 
   defp pids(samples), do: Enum.map(samples, & &1.pid)
 

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -27,6 +27,7 @@ setup() {
     #   busy_retry.ex — the three terminal arms, one per fault kind
     LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
+    LOCKUNATTR_LINE='db lock stall UNATTRIBUTED: 3 writer(s) queued past the threshold, longest 31303ms — no holder registered, so the holder is NOT attributable at the BEGIN IMMEDIATE seam; longest waiter #PID<0.512.0> status=:waiting at :gen_server.loop/7, stack: a <- b'
     LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for 30067ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
     SATURATED_LINE='db write unavailable: SQLite pool saturated for 1512ms across 14 attempts (1500ms retry budget) — returning :db_unavailable'
     # #1657 — the third arm. The elapsed is ~15s because a cancellation is
@@ -150,6 +151,38 @@ stamp() {
 
     grep -q 'lockstall=1' <<<"$out"
     grep -q 'lockstall_resolved=0' <<<"$out"
+}
+
+# --- #1687: the episode that named NOBODY has to reach the artefact too ----
+#
+# Prod, 2026-08-22: LockWatch armed at `stall_threshold_ms: 2_000` through a
+# ~170 s episode with 23 `busy_locked` terminals, and BOTH counters above read
+# zero — because `observe/1`'s only producer is `immediate_transaction/1` while
+# the writer that dominates the hot path is a bare autocommit `Repo.insert`. A
+# census that can only count NAMED episodes reports a clean run for exactly the
+# incident it exists to catch.
+
+@test "an UNATTRIBUTED episode is counted, and not as a named stall" {
+    local out
+    out="$( stamp '12:00:00.' "$LOCKUNATTR_LINE" | scan 10 )"
+
+    grep -q 'lockstall_unattributed=1' <<<"$out"
+    # The discrimination that matters: `lockstall` means a holder was NAMED.
+    # Folding the two would let an episode nobody could attribute be read off
+    # the artefact as one that was — the census asserting an attribution the
+    # instrument explicitly declined to make.
+    grep -q 'lockstall=0' <<<"$out"
+    grep -q 'lockstall_resolved=0' <<<"$out"
+}
+
+@test "a NAMED stall does not score as unattributed" {
+    local out
+    out="$( {
+        stamp '12:00:00.' "$LOCKSTALL_LINE"
+        stamp '12:00:30.' "$LOCKRESOLVED_LINE"
+    } | scan 60 )"
+
+    grep -q 'lockstall_unattributed=0' <<<"$out"
 }
 
 @test "a retry budget exhausted on the write LOCK is counted apart from a saturated POOL" {


### PR DESCRIPTION
Refs #1687. Reporting half only — the coverage half is deliberately not attempted here, and the last section says why.

## The holder is still not named, and this PR does not name it

`LockWatch` emitted **zero** lines through the 2026-08-22 production episode, so there is no attribution in the log to read. That silence *is* the defect. `Scrollback.persist_row/1` is the obvious structural suspect and obvious is not measured; I did not elect it.

## 🔴 What did get measured: the 62-second hold does not exist

The issue opens on `SQLite write lock held by another writer for 62494ms` and reads it as one writer holding for 62 s. That number is not a hold.

`BusyRetry.run/1` stamps `started` **before** the first `op.()` (`busy_retry.ex:127`) and reports `now - started` (`:138`). With `attempts=1` the figure covers one whole `Repo.insert/2` — DBConnection checkout **and** statement — while `terminal_message/3` composes it into a sentence asserting a *hold*. Subject inferred from the fault class; number measured from something else.

Subtracting `elapsed` from the emission stamps:

| emitted | elapsed | implied start |
|---|---|---|
| 16:36:32.556 | 31303 ms | 16:36:01.253 |
| 16:37:03.422 | 62494 ms | 16:36:00.928 |
| 16:37:03.484 | 31282 ms | 16:36:32.202 |

The 62.5 s and 31.3 s victims **start together** at 16:36:01 ±350 ms — blocked on the same busy handler from the same instant they would raise together at ~30 s (`busy_timeout: 30_000`), and they do not. The cohort that raises at 16:37:03 having waited 31.3 s **starts at 16:36:32.2**, the instant the first cohort died and released its connections.

So `62494ms` = **~31.2 s queued for a pool connection + ~31.3 s on `busy_timeout`**, in one un-preemptable call. The longest write-lock wait anywhere in the episode is **~31.3 s — one `busy_timeout`**.

Corroborated: the same quantum appears in `pool saturated` (33371, 33426, 33361, 32979 …), a class that never touches the write lock, alongside a genuinely short ~2.17 s cluster in the same millisecond. And in the WS upgrade series (1146 → 31576 → **63399** → 31863 → 31921 → 31741 ms), which is #1618 seen in prod on a real user.

**The rule, now in DESIGN_NOTES: a quantum that recurs ACROSS fault classes is a timeout signature, not a duration of work.**

This does not overturn the incident — dropped rows and checkout deadlines are real. It overturns the *shape*: "one writer holding for a very long time, not many small writers contending" is not established by the evidence cited for it.

## What ships

`detect/2` gains a second arm: a queue past the threshold that named nobody is reported instead of met with silence. Same two doors as the existing phases — `Logger.warning` plus `[:grappa, :repo, :lock_stall, :unattributed]`, folded by `DbLatency` into the same bounded ring so `GET /admin/db_latency` and `bin/grappa db-latency` inherit it with no new noun.

**The line refuses the sentence the issue proposed.** *"N waiters queued, holder unattributed"* still asserts a hold by an unregistered writer, and the decomposition above shows pool queueing is an equally live cause this frame never measured. It states only what was observed — how many registered writers are queued, the longest wait, how many holders are registered — and carries the **waiters' own stacks**, which are what separate the two topologies. For the same reason the measurement is `longest_wait_ms` and the ring row's `holder_pid` / `held_ms` are `nil`: reusing the hold field would reinstate through the schema the claim the prose was written to keep out, which is the defect `terminal_message/3` was rewritten twice to stop committing (#1420, #1421).

### Three defects surfaced while designing

1. **`acquired/0` did not clear `reported?`.** The flag gains a second writer here (armed on WAITER rows), and `update_element` rewrites role and clock in place — so a pid reported once while queued would carry an armed flag into its own hold and be **permanently unreportable as a holder**. The cure for the unattributed blindness would have blinded the path that worked. Guarded by its own test.
2. **The fork had to be on *attributable*, not on "did we print".** The latter drops an already-announced episode into the second arm on the next tick, printing *"none past the threshold"* about a holder that is past it.
3. **Pre-existing:** `Operator.lock_stall_detail_lines(%{holder: nil}) -> []` — right for `:resolved`, and it would have discarded an unattributed row's entire payload. Split into two blocks; `:resolved` still renders as a header line alone, now by the data rather than by a clause reading the wrong field.

`scripts/log-gap-scan.awk` gains `lockstall_unattributed` in the same commit as the prose, per the rule on its own call site — **not** folded into `lockstall`, which means *a holder was NAMED*. Through the whole prod episode both existing counters read zero, and zero is what a clean run looks like.

Bought red first: 3 failures in `lock_watch_test` (`assert log =~ "db lock stall UNATTRIBUTED"` with `left: ""`) and 2 in `db_latency_test` (`FunctionClauseError … in fold/4`). The fidelity case parks an un-observed `mode: :immediate` transaction against real `SQLITE_BUSY` contention — an autocommit statement cannot be held open from outside, and what `detect/2` reads is identical either way.

## Gates

| gate | marker |
|---|---|
| `scripts/check.sh` | `CHECK_RC=0`, `grep -c '^not ok'` → 0 |
| ExUnit | `8 doctests, 62 properties, 6817 tests, 0 failures` |
| Dialyzer | `Total errors: 0, Skipped: 0, Unnecessary Skips: 0` |
| Credo `--strict` | `6287 mods/funs, found no issues.` |
| bats (`log_gap_scan`) | `1..21`, 21 × ok |
| touched suites, post-rebase | `28 tests, 0 failures` |
| `design-notes-gate.sh`, **post-commit** | `1 new entry heading(s), separator and marker present.` |

Rebase: `union-rebase.sh` → `+149 -0 — contribution intact`, then the ritual redone by hand in full (two-sided numstat identical on every path; append purity `cmp` against the new base; boundary shape read on the real bytes; marker uniqueness re-verified post-rebase with a positive control).

⚠️ **Inherited red, named:** `origin/main` is red at `bc9c6c9d` on `issue473-rail-actions-drawer.spec.ts:98` (`Expected: "detach"` / `Received: "switch account"`, from #1705). This PR inherits it and it is not mine. A red on any spec **other** than `issue473` is mine until proven otherwise. I did not run `integration.sh` or e2e — that lane was not granted.

## What I refuse to assert

- **Who held the lock. Not measured.**
- That a 62 s hold occurred — refused, with measurement.
- That a single holder persisted ~3 minutes: indistinguishable from no single holder on this evidence. Every observable quantum is a victim's timeout, never a release.
- That the 31 s logging silence (16:36:01 → 16:36:32) is real: I do not know whether the extract's per-second histogram was computed over the full file or the curated extract, so I did not use it.
- Any ETS cost figure for the hot path — so the **coverage** half is not proposed. It is not a wrapping exercise: an autocommit statement has no `waiting → acquired` fracture, so tagging it `:holding` for its whole duration would label a victim parked on `busy_timeout` as the HOLDER — the instrument accusing the victim, which is worse than silence.

## #1420 stays closed

Its criterion — *"Re-open, or file fresh, when LockWatch names a holder in a live stall"* — is disjunctive, and its trigger never fired. A mute instrument is a defect in the instrument, and the "file fresh" branch is already exercised by #1687.
