### PR TITLE
test(#1705): follow the "switch account" rename in the two e2e specs that read the words

### DIFF
--- a/cicchetto/e2e/tests/issue43-split-logout.spec.ts
+++ b/cicchetto/e2e/tests/issue43-split-logout.spec.ts
@@ -45,7 +45,12 @@ test("issue #43 — registered user sees detach + quit in the rail, not a bare '
   const detach = page.getByTestId("detach-btn");
   const quit = page.getByTestId("quit-irc-btn");
   await expect(detach).toBeVisible();
-  await expect(detach).toHaveText(/detach/i);
+  // #1705 — the entry READS "switch account" while the verb, the class and the
+  // testid stay `detach`. What #43 asserts is unchanged: two distinct verbs,
+  // neither of them a bare "log out". The expected word follows the rename
+  // rather than loosening to /detach|switch/ — a label that drifts again must
+  // still redden this line.
+  await expect(detach).toHaveText(/switch account/i);
   await expect(quit).toBeVisible();
   await expect(quit).toHaveText(/quit/i);
   // Positive twin for the negative assertion so a testid typo can't

--- a/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
+++ b/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
@@ -95,7 +95,13 @@ const RAIL_BUTTONS: ReadonlyArray<{ testid: string; label: string }> = [
   { testid: "rail-action-mute", label: "mute" },
   // #986 — the lifecycle pair, moved out of the settings drawer. `detach` is
   // canDetach()-gated: vjt is a persistent user, so it renders.
-  { testid: "detach-btn", label: "detach" },
+  //
+  // #1705 — its LABEL now reads "switch account". Only the words moved: the
+  // verb, the class and this testid are still `detach`, which is why the pair
+  // below looks mismatched and must stay that way. The label is named on the
+  // INTENT axis ("I want to be someone else here") because two reporters in one
+  // evening scanned this menu for a word the bouncer axis does not contain.
+  { testid: "detach-btn", label: "switch account" },
   { testid: "quit-irc-btn", label: "quit" },
 ];
 


### PR DESCRIPTION
## What this fixes

`origin/main` is RED on `integration`, and it is main's own red, not a branch's:

- `bc9c6c9d` (*"fix(#1705): name the lifecycle entry after the intent, not the bouncer"*) renamed the label of the lifecycle rail entry from **detach** to **switch account**. The verb, the class `rail-action-detach` and the testid `detach-btn` were deliberately left alone — only the words the operator reads moved.
- Two Playwright specs assert those words. Both now fail:
  - `cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts:98` — the `RAIL_BUTTONS` table, matched EXACTLY against `.rail-action-label` (`Expected: "detach"` / `Received: "switch account"`, ×9 per engine).
  - `cicchetto/e2e/tests/issue43-split-logout.spec.ts:48` — `toHaveText(/detach/i)`. **A regex, so no grep for the literal label string surfaces it**; it is the second shape a label assertion takes and the one a rename sweep misses.

Chromium and WebKit both read the same table, which is why the failure showed up as three reds (shard 2/4 + shard 4/4 + the roll-up) with one cause.

## Why the spec follows the code and not the other way round

The rename is a deliberate ruling, not a slip: vjt in #1705 — *"switch account … è molto meglio di detach"* — after two self-hosters in one evening looked for a way to leave one account and come back as another and neither found it. `logout` was ruled out for the reason #126 retired it. The spec is the mirror of that decision, so the expected words move.

## Not weakened

Both assertions keep their ability to fail. `/detach|switch account/i`, a `toContainText`, or dropping to a bare visibility check would green this today and stay green through the next rename — exactly the drift #473's exhaustive table exists to catch. The exact word moved, nothing else.

`DETACH_BODY` is unchanged upstream, so issue43's modal arms (`/keeps running/i` vs `/survive/i`) still assert the distinguishing claim and needed no edit. No testid, no gate, no helper touched.

## Scope check

The whole diff of `bc9c6c9d` is three files (`RailActions.tsx`, `RailActions.test.tsx`, `lifecycle.ts`) and the only user-visible strings it moved are the rail label, the `aria-label`, and the confirm modal's `title` + `confirmLabel`. Swept for all of them across `cicchetto/e2e/` (including the fixtures): the modal title/confirmLabel are asserted nowhere in e2e, no spec looks the button up by accessible name, and `"detach from cicchetto"` appears nowhere in the tree. Two sites is the complete set.

## No DESIGN_NOTES entry

Deliberate. The decision is already recorded where decisions live — the #1705 ruling, `bc9c6c9d`'s message, and the why-comments that commit put in `RailActions.tsx` and `lifecycle.ts`. This change adds no decision of its own: it is a mechanical alignment of two assertions to a rename already ruled and already shipped.

## Gates

- `scripts/bun.sh run check` — **green** (4 stages: lock drift, biome src+e2e, tsc src, tsc e2e; 0 failed).
- `scripts/bun.sh run test` — **green** (304 files, 5920 tests).
- The e2e suite itself is not run locally; CI is the measure.

Refs #1705.