### PR TITLE
fix(#1685): release add-network crosses into the live node as terms, and stops claiming a session

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -60853,3 +60853,171 @@ must log under contention are enumerable — they live around the Repo
 design-discipline (1) "don't duplicate state that already exists" and (5) "if
 the mechanism is heavier than the problem, the mechanism IS the problem", not a
 performance argument.
+<!-- entry #1685 -->
+
+---
+
+## 2026-08-23 — #1685: the verb wrote the row in a VM that could not hold a session
+
+`grappa add-network` on a RUNNING published-image deployment reported
+success, left `connection_state: :connected`, and started nothing. cic
+then rendered a network that claimed to be connected — so there was
+nothing to press — while every live-session operation answered
+`not_connected`.
+
+Two independent faults, and the interesting one is not the state value.
+
+**The row said `connected` because nobody decided that.** It is the
+schema default (`credential.ex`), and `Networks.add_network/3` →
+`Credentials.bind_credential/3` passes no `connection_state`. The other
+two bind doors — `session_controller.ex` (#642) and
+`admin/credentials_controller.ex` (#1163) — already write `:parked`
+explicitly and let the spawn promote the row. This door was the last one
+inheriting the default.
+
+**Nothing spawned because of the TRANSPORT.** `infra/release/grappa.sh`
+rewrites the account verbs into the boot script's `eval`, and an `eval`
+starts a transient node of its own: it loads the app, writes, and exits.
+A `SpawnOrchestrator.spawn/4` call added inside the verb would have
+started a session in a VM about to die. So "just write `:parked` and
+spawn" was never the fix.
+
+### Why not simply route the verb through `rpc`
+
+MEASURED, and it is the constraint that decided the design.
+`System.argv/0` evaluated under `--rpc-eval` is the **remote** node's
+argv and is always `[]` — with no extra args, with them, and with `--`
+before them. The wrapper's whole safety property is that the operator's
+words travel as argv and are never interpolated into source. That channel
+does not exist under `rpc`, so carrying the words to the live node would
+mean interpolating them — `--password` included — into Elixir evaluated
+on the production BEAM. Base64-in-a-literal was proposed to make that
+safe by alphabet; vjt rejected it, and the structural objection is the
+better one: it still passes TEXT somebody has to interpret.
+
+### The shape that shipped: stay on `eval`, cross as TERMS
+
+Parsing, flag validation and the write stay in the transient node, where
+a mistyped flag can still `System.halt/1` harmlessly. Only the spawn
+crosses, as an `:erpc.call/5` — a function call whose arguments are
+Erlang terms. There is no expression to escape and no `Code.eval_string`
+on the live node: the injection surface is not narrowed, it is absent by
+construction. `Grappa.Release.LiveNode` owns the hop; the far side lands
+on `Grappa.Operator.connect_credential/1`, the same canonical
+admission → backoff-reset → spawn verb #1163's console bind and Bootstrap
+reach, so bind-time and boot-time cannot drift.
+
+**`abort/1` is untouched, and the price everyone expected is not owed.**
+The worry was that code running in the live node can no longer
+`System.halt/1`, and that `stderr` is swallowed under `rpc`. Under this
+shape the CLI never runs in the live node. Measured through the real door
+today: `rc=1` and the message on the operator's stderr, both intact.
+
+### What crosses, and why it is two integers and an atom
+
+`(user_id, network_id)` out, `{:ok, :started}` back. Neither direction
+carries a `%Credential{}`, and the reason is not tidiness: **Cloak hands
+back the CLEARTEXT on load**, so a struct in either direction would put
+the operator's NickServ/SASL password on the distribution socket, which
+is unencrypted by default. `adopt_here/2` loads the row on the far side.
+A test asserts the returned term does not contain the secret.
+
+It deliberately does not answer with the row's `connection_state` either.
+`Networks.connect/1` writes `:connected` as INTENT, and since #1675 that
+value means *registered upstream* — reporting it at the instant of return
+would be a lie the next `001` either confirms or corrects.
+
+### The measurement that gated the build
+
+vjt made "can an `eval` node raise distribution on all four substrates,
+Docker included?" a measurement rather than a discussion. Result: **2–3 ms
+to raise distribution, 1–3 ms to connect**, on the Docker release image in
+three hostname shapes (container id, an FQDN hostname under `sname`, and
+`RELEASE_DISTRIBUTION=name`) and on a real `.deb` installed into Debian 13
+through `/usr/bin/grappa`. The overhead was accepted in advance and is not
+worth optimising.
+
+Three facts from that bench are load-bearing in the code:
+
+- The boot script gives `eval` `--cookie "$RELEASE_COOKIE"` and no
+  `-sname`, and exports `RELEASE_NODE` / `RELEASE_DISTRIBUTION`. So
+  `Node.get_cookie/0` already returns the release cookie the moment
+  `net_kernel` starts — **nothing calls `Node.set_cookie/2`**.
+- 🔴 **The target host comes from our OWN node name, never from
+  `:inet.gethostname/0`.** Under `RELEASE_DISTRIBUTION=name` the two
+  disagree (`box2.example.com` vs `box2`) and the gethostname spelling is
+  not merely wrong, it is rejected: `** Hostname box2 is illegal **`.
+- **There are TWO no-live-node shapes, not one**, and a cure handling
+  only the second crashes on first run. With no epmd (a fresh container, a
+  host that never booted the service) `:net_kernel.start/2` itself fails
+  with `:nodistribution` in ~8 ms — a release `eval` does not spawn epmd,
+  so nothing is left behind. With epmd up and the node down (any
+  long-lived host after a stop) it succeeds and `Node.connect/1` returns
+  `false` in ~1 ms.
+
+Also measured: a **wrong cookie is indistinguishable from a stopped node**
+at the caller (`false` in 1–2 ms either way), so the operator-facing text
+names both possibilities rather than guessing one.
+
+The end-to-end proof was run on the published-image substrate: after
+`add-network`, `whereis` was `nil` with the row reading `:connected` (the
+defect); one `:erpc` later `whereis` was a pid and the row had moved to
+`:failing` with `connection_state_reason: "connection refused"` on its own
+— #1675's semantics working, against a deliberately dead endpoint.
+
+### The state, and the query that was NOT widened
+
+vjt's ruling: bind `:parked`, and **leave
+`Credentials.list_credentials_for_all_users/0` alone** —
+`connection_state in [:connected, :failing]`. A "consequence" that had
+circulated (widen boot adoption to `:parked` so a seeded box comes up on
+restart) was withdrawn, and the withdrawal is measured-correct:
+`networks.ex` writes `:parked` for a user-initiated `/disconnect` and
+documents it as *explicit user intent*, so widening would resurrect at
+reboot every network a user had deliberately disconnected.
+
+The price is that a seed-then-restart no longer brings the network up on
+its own. That is accepted, and therefore the CLI **says so** — the parked
+line names the reason and states that a restart will not dial it. A fast
+path must describe what it observed, and this one observes that nothing is
+listening.
+
+### The seam, and why it has no `boot/0`
+
+`adopt/2` must be substitutable in tests: its own `:net_kernel.start/2`
+would make the TEST VM distributed and leak into every other file. It uses
+the `:persistent_term` DI idiom the codebase already has
+(`Grappa.Push.BadgeSource`, `Grappa.Admission.Config`) with one deliberate
+difference — **no `boot/0`, and the DEFAULT is production**. The caller is
+a release `eval` node, which never runs `Grappa.Application.start/2`, so a
+boot-populated key would be permanently absent on the one path that
+matters.
+
+### Deliberately not done
+
+- **`mix grappa.bind_network` still binds the schema default.** It is the
+  same class of defect, but the cure does not transfer: a source install's
+  live node is `mix phx.server`, which sets no `RELEASE_NODE`, so there is
+  no live hop to promote the row and `:parked` there would be a plain
+  regression for dev seeding. Flagged, not silently widened.
+- **`remove-network` has the mirror defect**: it deletes the row in the
+  transient node while the live node keeps running the session. Same
+  family, different verb, out of this slice's scope.
+- **The packaged `/usr/bin/grappa` boots its eval VM in latin1** — the
+  `runuser` payload sets no `LANG` while the systemd unit beside it pins
+  `C.UTF-8` for exactly that reason (#425), and `add-network --nick` /
+  `--autojoin` carry user-supplied bytes. Observed on the bench; a separate
+  defect.
+
+### Not measured
+
+The **FreeBSD bastille jail**. The ssh key for m42 is unreadable from the
+agent's process (`Operation not permitted`, macOS layer, unchanged with
+the agent sandbox off), so it is a gap in evidence and not a negative
+result. A self-contained read-only probe was handed over on the issue.
+
+It does not block correctness: the offline branch is mandatory anyway —
+first run is the case the CLI exists for — so a substrate that cannot
+raise distribution simply always takes it, and the credential lands
+`:parked` exactly as ruled. What the jail can lose is the convenience,
+never the honesty.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -151,6 +151,51 @@ composition that creates the network + server when needed and REFUSES to
 write access to a network with no enabled server, because a credential
 alone is not a connectable account.
 
+#### What `add-network` says, and why it says two different things (#1685)
+
+The verb runs in a transient `eval` node, so a session it started would
+die with the command. Against a RUNNING deployment it therefore crosses
+to the live node over Erlang distribution and asks it to start the
+session (`Grappa.Release.LiveNode`); against a box that is not running
+yet — the first-run case this door exists for — there is nothing to
+cross to. Both outcomes are printed, because they are not the same
+thing:
+
+```
+vjt can now use azzurra (server irc.azzurra.chat:6697)
+  started a session on the live node — nothing else to do
+```
+
+```
+vjt can now use azzurra (server irc.azzurra.chat:6697)
+  the binding is PARKED: nothing is listening on epmd, so no bouncer is running here.
+  A restart will NOT dial it — vjt connects it with Connect after logging in.
+```
+
+🔴 **The restart caveat is literal.** The row is written `:parked` (like
+the other two bind doors — #642, #1163 — and never the schema default
+`:connected`, which claimed a session no `eval` node could have
+started). `:parked` means explicit user intent and is deliberately NOT in
+the boot adoption query (`connection_state in [:connected, :failing]`),
+so `systemctl start grappa` will not dial it: the user presses Connect at
+first login. Widening that query was considered and rejected — it would
+resurrect every network a user had deliberately `/disconnect`ed.
+
+**Exit status is 0 in both cases**, and in the third one too (the live
+node answered and refused the spawn — capacity, no enabled server). The
+binding is the operator's input and is kept either way, so
+`create-user && add-network && systemctl start grappa` does not break on
+the case that has no live node by definition. Read the second line, not
+the exit code.
+
+Requirements for the live hop, all already satisfied by every substrate's
+own setup: `RELEASE_COOKIE` and `RELEASE_NODE` in the verb's environment
+(the Docker image's entrypoint re-exports them from `/data/grappa.env`
+for `docker exec` — #1683; the jail, systemd and `.deb` doors source
+their env file) and `RELEASE_DISTRIBUTION` not set to `none`. A cookie
+mismatch is indistinguishable from a stopped node at the CLI end and
+prints as "did not answer".
+
 ### Per-server outbound source address (`--source`)
 
 `bind-network` and `add-server` accept `--source <ip>` to pin the

--- a/lib/grappa/release.ex
+++ b/lib/grappa/release.ex
@@ -48,6 +48,10 @@ defmodule Grappa.Release do
       Grappa.Deploy.MigrationAudit,
       Grappa.Networks,
       Grappa.Networks.Network,
+      # #1685 — `LiveNode.adopt_here/2` runs in the LIVE node and reaches
+      # the canonical #1163 spawn verb there, so `add-network` cannot drift
+      # from the console bind or from Bootstrap.
+      Grappa.Operator,
       Grappa.Repo,
       Grappa.Themes,
       Grappa.Vault

--- a/lib/grappa/release/cli.ex
+++ b/lib/grappa/release/cli.ex
@@ -51,6 +51,7 @@ defmodule Grappa.Release.CLI do
   alias Grappa.{Accounts, Networks}
   alias Grappa.Accounts.User
   alias Grappa.Networks.Network
+  alias Grappa.Release.LiveNode
 
   @create_user_switches [password: :string, admin: :boolean]
 
@@ -245,10 +246,77 @@ defmodule Grappa.Release.CLI do
          {:ok, user} <- fetch_user(user_name),
          {:ok, {host, port}} <- parse_endpoint(Keyword.fetch!(opts, :server)),
          {:ok, auth_method} <- parse_auth(Keyword.fetch!(opts, :auth)),
-         {:ok, _} <- grant_access(user, slug, opts, {host, port}, auth_method) do
-      {:ok, "#{user.name} can now use #{slug} (server #{host}:#{port})"}
+         {:ok, credential} <- grant_access(user, slug, opts, {host, port}, auth_method) do
+      outcome = LiveNode.adopt(credential.user_id, credential.network_id)
+
+      {:ok,
+       "#{user.name} can now use #{slug} (server #{host}:#{port})\n" <>
+         outcome_line(user, outcome)}
     end
   end
+
+  # #1685 — the operator is told which of two things happened, because they
+  # are not the same thing and only one of them needs anything further from
+  # anybody.
+  #
+  # The row is bound either way: a refused spawn is not a failed bind (the
+  # operator asked to PROVISION access, and discarding their input because
+  # the bouncer was busy would be the wrong trade — the same call
+  # `Admin.CredentialsController.create/2` makes for the console door). So
+  # the exit status stays 0 in every branch below, which also keeps the
+  # normal first-run script — `create-user && add-network && start the
+  # service` — from breaking on the case that has no live node BY
+  # DEFINITION.
+  #
+  # Silence is what is not allowed. `Grappa.Release.cli/1` prints this
+  # whole string, so "parked and why" reaches the terminal even though the
+  # command succeeded.
+  @spec outcome_line(User.t(), {:ok, :started} | {:error, LiveNode.error()}) :: String.t()
+  defp outcome_line(%User{}, {:ok, :started}) do
+    "  started a session on the live node — nothing else to do"
+  end
+
+  defp outcome_line(%User{name: name}, {:error, reason}) do
+    # The restart caveat is load-bearing, not a courtesy. vjt's #1685
+    # ruling keeps `:parked` OUT of the boot adoption query
+    # (`connection_state in [:connected, :failing]`) on purpose: `:parked`
+    # means explicit user intent, and widening the query would resurrect
+    # every network a user had deliberately disconnected. The price is that
+    # an operator who seeds a box and restarts it gets nothing, so the
+    # message has to say so rather than let them find out.
+    "  the binding is PARKED: #{park_reason(reason)}.\n" <>
+      "  A restart will NOT dial it — #{name} connects it with Connect after logging in."
+  end
+
+  @spec park_reason(LiveNode.error()) :: String.t()
+  defp park_reason(:no_release_node), do: "there is no live node to reach from here"
+
+  defp park_reason(:distribution_disabled),
+    do: "RELEASE_DISTRIBUTION=none, so the running node has no distribution to call"
+
+  defp park_reason(:no_distribution),
+    do: "nothing is listening on epmd, so no bouncer is running here"
+
+  # The live node was reached and could not find the row this command just
+  # wrote. The usual cause is worth naming: the two VMs are looking at
+  # DIFFERENT databases (a `DATABASE_PATH` that differs between the service
+  # environment and this shell's).
+  defp park_reason(:not_found),
+    do:
+      "the live node cannot see this binding — check that it reads the same " <>
+        "DATABASE_PATH as this command"
+
+  # MEASURED (#1685): a cookie mismatch and a node that is simply not there
+  # are indistinguishable at this end — `Node.connect/1` answers `false` in
+  # 1–2 ms either way. Naming both beats guessing one.
+  defp park_reason(:unreachable),
+    do: "the live node did not answer (not running, or a different RELEASE_COOKIE)"
+
+  defp park_reason({:refused, reason}),
+    do: "the live node refused to start the session (#{inspect(reason)})"
+
+  defp park_reason({:call_failed, reason}),
+    do: "the call to the live node failed (#{inspect(reason)})"
 
   defp grant_access(%User{} = user, slug, opts, {host, port}, auth_method) do
     server = %{
@@ -272,7 +340,19 @@ defmodule Grappa.Release.CLI do
       auth_method: auth_method,
       autojoin_channels: parse_autojoin(Keyword.get(opts, :autojoin)),
       realname: Keyword.get(opts, :realname),
-      sasl_user: Keyword.get(opts, :sasl_user)
+      sasl_user: Keyword.get(opts, :sasl_user),
+      # #1685 — bind `:parked`, NEVER the schema default `:connected`. This
+      # door was the last of the three that still inherited the default:
+      # `session_controller.ex` (#642) and
+      # `admin/credentials_controller.ex` (#1163) both write `:parked` and
+      # let the spawn promote the row. Here the write happens in a
+      # transient `eval` VM, so the row CLAIMED a session that VM could not
+      # possibly have started — cic rendered CONNECTED with nothing to
+      # press while every live-session operation answered `not_connected`.
+      #
+      # `Grappa.Operator.connect_credential/1` promotes it, over
+      # `LiveNode`, only once a `Session.Server` is actually running.
+      connection_state: :parked
     }
 
     case Networks.add_network(user, network_spec, settings) do

--- a/lib/grappa/release/live_node.ex
+++ b/lib/grappa/release/live_node.ex
@@ -1,0 +1,301 @@
+defmodule Grappa.Release.LiveNode do
+  @moduledoc """
+  The one hop `grappa add-network` makes out of its own VM and into the
+  running bouncer (#1685).
+
+  ## The problem this exists to solve
+
+  `infra/release/grappa.sh` rewrites the account verbs into the release
+  boot script's `eval`, and an `eval` starts a **transient node of its
+  own**: it loads the app, writes to the database and exits. That is
+  exactly right for the first-run door `Grappa.Release.cli/1` documents —
+  but it means a session spawned there dies with the command, which is why
+  `add-network` could report success against a running deployment while no
+  `Session.Server` existed and every live-session operation answered
+  `not_connected`.
+
+  ## Why a distribution call and not an `rpc` verb
+
+  The obvious fix — route the whole verb through the boot script's `rpc`
+  instead of `eval` — is closed, and not by taste. **MEASURED (#1685):**
+  `System.argv/0` evaluated under `--rpc-eval` is the *remote* node's argv
+  and is always `[]`, so the argv channel the wrapper's safety property
+  rests on does not exist there. Carrying the operator's words to the live
+  node would mean interpolating them — `--password` included — into Elixir
+  source evaluated on the production BEAM.
+
+  So the parsing, the flag validation and the database write stay in the
+  transient node, where they already are and where a mistyped flag can
+  still `System.halt/1` harmlessly, and only the spawn crosses — as a
+  **function call**. The arguments are Erlang terms on the distribution
+  wire: there is no expression to escape and no `Code.eval_string` on the
+  live node. The injection surface is not narrowed, it is absent by
+  construction.
+
+  ## What crosses, in each direction, and why it is that small
+
+  Two identifiers go out and an atom comes back. Neither half carries a
+  `%Grappa.Networks.Credential{}`, and the reason is not tidiness:
+  Cloak hands back the **cleartext** on load, so a struct in either
+  direction would put the operator's NickServ/SASL password on the
+  distribution socket — which is unencrypted by default. `adopt_here/2`
+  loads the row on the far side and answers `{:ok, :started}`.
+
+  It deliberately does NOT answer with the row's `connection_state`.
+  `Networks.connect/1` writes `:connected` as a statement of INTENT, and
+  since #1675 that value means *registered upstream*; reporting it at the
+  instant of return would be a lie the very next `001` either confirms or
+  corrects.
+
+  ## Measured, on three of the four substrates (2026-08-23, issue #1685)
+
+  A release `eval` gets `--cookie "$RELEASE_COOKIE"` and no `-sname`, so it
+  starts undistributed and must raise distribution itself — and it can, in
+  **2–3 ms**, connecting in a further **1–3 ms**, on the published Docker
+  release image (short hostname, FQDN hostname, and
+  `RELEASE_DISTRIBUTION=name`) and on a `.deb` install on glibc. Two
+  further measured facts shape the code below:
+
+    * `Node.get_cookie/0` already returns the release cookie the moment
+      `net_kernel` starts, so nothing here calls `Node.set_cookie/2`.
+    * **There are two no-live-node shapes, not one.** With no epmd running
+      (a fresh container, a host that never booted the service)
+      `:net_kernel.start/2` itself fails with `:nodistribution` in ~8 ms;
+      with epmd up and the node down, it succeeds and `Node.connect/1`
+      returns `false` in ~1 ms. Both must fall through, and both do.
+
+  The FreeBSD bastille jail is **not measured**. It does not need to be for
+  this to be safe: the offline branch is mandatory anyway — first run is
+  the case the CLI exists for — so a substrate that cannot raise
+  distribution simply always takes it, and the credential lands `:parked`
+  exactly as vjt ruled.
+  """
+
+  alias Grappa.Networks.Credentials
+  alias Grappa.Operator
+
+  @typedoc """
+  Why the live node was not reached, or what it said when it was.
+
+  `:unreachable` is deliberately coarse: **MEASURED**, a cookie mismatch
+  and a node that is simply not there are indistinguishable at the caller
+  (`Node.connect/1` returns `false` in 1–2 ms either way). The
+  operator-facing message must not claim to know which.
+  """
+  @type error ::
+          :no_release_node
+          | :distribution_disabled
+          | :no_distribution
+          | :unreachable
+          | :not_found
+          | {:refused, refusal()}
+          | {:call_failed, term()}
+
+  @typedoc """
+  Why the live node DECLINED, having been reached —
+  `Grappa.Operator.connect_credential/1`'s error union minus `:not_found`,
+  which is hoisted out because "the binding is not there" is a different
+  answer from "the bouncer would not start it".
+
+  Spelled out rather than aliased to `Grappa.Admission.capacity_error/0`,
+  for the same reason `Grappa.Networks.Credentials.AdminWire.spawn_error/0`
+  spells it out: this boundary must not depend on `Grappa.Admission`. The
+  payloads are KEPT here, unlike AdminWire's wire-facing twin, because the
+  operator message inspects the reason verbatim and a retry-after is worth
+  reading.
+  """
+  @type refusal ::
+          :resolve_failed
+          | :ip_cap_exceeded
+          | :visitor_cap_exceeded
+          | :user_cap_exceeded
+          | {:network_circuit_open, non_neg_integer()}
+          | {:start_failed, term()}
+
+  @doc """
+  Starts a session for `(user_id, network_id)` in the live release node.
+
+  The seam exists for exactly one reason: `adopt/2`'s own
+  `:net_kernel.start/2` would make the CALLING VM distributed, which is
+  intolerable inside a test suite. There is one production implementation
+  and it is in this module; tests substitute a module through
+  `put_test_impl/1`.
+  """
+  @callback adopt(Ecto.UUID.t(), pos_integer()) :: {:ok, :started} | {:error, error()}
+
+  # An `:erpc.call/5` bound, not a hope. The far side does admission, a
+  # backoff reset and a `DynamicSupervisor.start_child` — none of which
+  # dials upstream synchronously — so this is generous by an order of
+  # magnitude. It exists so that a wedged live node costs the operator a
+  # bounded wait and an honest message instead of a stuck shell.
+  @call_timeout :timer.seconds(15)
+
+  @key {__MODULE__, :impl}
+
+  @doc """
+  Asks the live release node to start a session for `(user_id, network_id)`.
+
+  Returns `{:ok, :started}`, or `{:error, reason}` naming why not — every
+  reason is a fall-through the caller must survive, never a crash. See
+  `t:error/0`.
+  """
+  @spec adopt(Ecto.UUID.t(), pos_integer()) :: {:ok, :started} | {:error, error()}
+  def adopt(user_id, network_id) when is_binary(user_id) and is_integer(network_id) do
+    case impl() do
+      nil -> reach(user_id, network_id)
+      mod -> mod.adopt(user_id, network_id)
+    end
+  end
+
+  @doc """
+  The half that runs INSIDE the live node — the target of the `:erpc.call/5`
+  above, and never called locally by the CLI.
+
+  It needs the application RUNNING (`Grappa.SpawnOrchestrator`, the
+  registry, the session supervisor), which the transient `eval` node has
+  not started; calling it there would crash rather than misbehave.
+
+  It loads the credential on this side so no decrypted secret crosses the
+  wire, then hands it to `Grappa.Operator.connect_credential/1` — the same
+  canonical admission → backoff-reset → spawn verb the #1163 console bind
+  and every other runtime spawn surface reach. Bind-time and boot-time
+  cannot drift because there is one implementation.
+  """
+  @spec adopt_here(Ecto.UUID.t(), pos_integer()) ::
+          {:ok, :started} | {:error, :not_found | {:refused, refusal()}}
+  def adopt_here(user_id, network_id) when is_binary(user_id) and is_integer(network_id) do
+    with {:ok, credential} <- Credentials.get_credential_by_ids(user_id, network_id),
+         {:ok, _} <- Operator.connect_credential(credential) do
+      {:ok, :started}
+    else
+      {:error, :not_found} -> {:error, :not_found}
+      {:error, reason} -> {:error, {:refused, reason}}
+    end
+  end
+
+  @doc """
+  Spells the live node's name from `RELEASE_NODE` and our OWN node name.
+
+  🔴 The host comes from `own_node`, never from `:inet.gethostname/0`.
+  **MEASURED (#1685):** under `RELEASE_DISTRIBUTION=name` the two disagree
+  — our node came up as `…@box2.example.com` while `gethostname` said
+  `box2` — and the gethostname spelling is not merely wrong, it is
+  rejected: `** Hostname box2 is illegal **`. Our own name is
+  self-consistent with the live node's by construction, because both were
+  derived by the same ERTS from the same `RELEASE_DISTRIBUTION`.
+
+  An operator who qualified `RELEASE_NODE` themselves is taken at their
+  word.
+  """
+  @spec target_node(String.t(), node()) :: node()
+  def target_node(release_node, own_node) when is_binary(release_node) and is_atom(own_node) do
+    if String.contains?(release_node, "@") do
+      String.to_atom(release_node)
+    else
+      [_, host] = own_node |> Atom.to_string() |> String.split("@", parts: 2)
+      String.to_atom(release_node <> "@" <> host)
+    end
+  end
+
+  # ── the real transport ────────────────────────────────────────────────
+
+  defp reach(user_id, network_id) do
+    with {:ok, release_node} <- release_node(),
+         {:ok, name_domain} <- name_domain(),
+         {:ok, started?} <- start_distribution(name_domain) do
+      try do
+        call(target_node(release_node, node()), user_id, network_id)
+      after
+        # Only ours to stop. An operator evaluating this from a live remote
+        # shell already had distribution up, and taking it down under them
+        # would disconnect the node from its own cluster.
+        if started?, do: :net_kernel.stop()
+      end
+    end
+  end
+
+  # No `RELEASE_NODE` means this is not running under a release boot script
+  # — a source checkout's `mix` task, or a test — and there is no live
+  # release node whose name we could even spell. Refuse before any I/O.
+  defp release_node do
+    case System.get_env("RELEASE_NODE") do
+      nil -> {:error, :no_release_node}
+      "" -> {:error, :no_release_node}
+      node -> {:ok, node}
+    end
+  end
+
+  # The generated boot script exports `RELEASE_DISTRIBUTION` (default
+  # `sname`) and accepts exactly `sname | name | none`. `none` is an
+  # operator saying the live node has no distribution at all: there is
+  # nothing to reach, and trying would only cost a listener.
+  defp name_domain do
+    case System.get_env("RELEASE_DISTRIBUTION") do
+      "none" -> {:error, :distribution_disabled}
+      "name" -> {:ok, :longnames}
+      # `sname`, or absent: the boot script default.
+      _ -> {:ok, :shortnames}
+    end
+  end
+
+  # `{:error, _}` here is the FIRST of the two no-live-node shapes: no epmd
+  # is listening, which is what a box that has never started the service
+  # looks like. It is the normal first-run path, not a fault.
+  defp start_distribution(name_domain) do
+    case :net_kernel.start(cli_node_name(), %{name_domain: name_domain}) do
+      {:ok, _} -> {:ok, true}
+      {:error, {:already_started, _}} -> {:ok, false}
+      {:error, _} -> {:error, :no_distribution}
+    end
+  end
+
+  # Unique per invocation: two operators typing verbs at once must not
+  # collide on an epmd name, and neither may collide with the live node.
+  defp cli_node_name do
+    :"grappa_cli_#{:os.getpid()}_#{System.unique_integer([:positive])}"
+  end
+
+  defp call(target, user_id, network_id) do
+    # The SECOND no-live-node shape: epmd is up (any long-lived host keeps
+    # it after the service stops) but nothing answers to the name.
+    if Node.connect(target) == true do
+      erpc(target, user_id, network_id)
+    else
+      {:error, :unreachable}
+    end
+  end
+
+  defp erpc(target, user_id, network_id) do
+    :erpc.call(target, __MODULE__, :adopt_here, [user_id, network_id], @call_timeout)
+  catch
+    # `:erpc.call/5` RAISES on transport failure (timeout, a node that went
+    # away between the connect and the call). The operator's shell must get
+    # a message and an exit code, not a stack trace.
+    kind, reason -> {:error, {:call_failed, {kind, reason}}}
+  end
+
+  @doc """
+  The substituted implementation module, or `nil` for the real transport.
+
+  Unlike the sibling `:persistent_term` seams (`Grappa.Push.BadgeSource`,
+  `Grappa.Admission.Config`), this one has NO `boot/0`: the caller is a
+  release `eval` node, which never runs `Grappa.Application.start/2`, so a
+  boot-populated key would be permanently absent on the one path that
+  matters. The default therefore IS production.
+  """
+  @spec impl() :: module() | nil
+  def impl, do: :persistent_term.get(@key, nil)
+
+  if Mix.env() == :test do
+    @doc false
+    @spec put_test_impl(module()) :: :ok
+    def put_test_impl(mod) when is_atom(mod), do: :persistent_term.put(@key, mod)
+
+    @doc false
+    @spec reset_test_impl() :: :ok
+    def reset_test_impl do
+      _ = :persistent_term.erase(@key)
+      :ok
+    end
+  end
+end

--- a/test/grappa/release/cli_test.exs
+++ b/test/grappa/release/cli_test.exs
@@ -25,9 +25,28 @@ defmodule Grappa.Release.CLITest do
 
   import ExUnit.CaptureIO
 
-  alias Grappa.{Accounts, Networks}
-  alias Grappa.Networks.{Credentials, SessionPlan}
-  alias Grappa.Release.CLI
+  alias Grappa.{Accounts, Networks, Session}
+  alias Grappa.Networks.{Credential, Credentials, SessionPlan}
+  alias Grappa.Release.{CLI, LiveNode}
+
+  # #1685 — the live-node outcome, substituted through the seam
+  # `Grappa.Release.LiveNode` owns. A module and not a real second node on
+  # purpose: `adopt/2`'s own `:net_kernel.start/2` would make THIS VM
+  # distributed and leak into every other test file. The real transport was
+  # measured on three substrates (issue #1685) and its live half is driven
+  # for real in `Grappa.Release.LiveNodeTest`.
+  #
+  # The answer comes from the process dictionary because `CLI.run/1` is
+  # synchronous in the calling process — so ONE stub covers every outcome,
+  # and the exhaustive test below can walk the whole error union without a
+  # module per value.
+  defmodule ScriptedLiveNode do
+    @moduledoc false
+    @behaviour LiveNode
+
+    @impl LiveNode
+    def adopt(_, _), do: Process.get(:live_node_answer)
+  end
 
   @dispatcher "infra/release/grappa.sh"
   @external_resource @dispatcher
@@ -51,6 +70,28 @@ defmodule Grappa.Release.CLITest do
   end
 
   defp unique_name, do: "vjt-#{System.unique_integer([:positive])}"
+
+  # The #1685 verb, with the flags held constant so each test varies one
+  # thing: what the live node answered.
+  defp add_network(name) do
+    CLI.run([
+      "add-network",
+      name,
+      "azzurra",
+      "--server",
+      "irc.azzurra.chat:6697",
+      "--nick",
+      "vjt-grappa",
+      "--auth",
+      "none"
+    ])
+  end
+
+  # Arms the seam with one live-node answer for the calling process.
+  defp answering(outcome) do
+    Process.put(:live_node_answer, outcome)
+    LiveNode.put_test_impl(ScriptedLiveNode)
+  end
 
   # Runs the door the way the shipped dispatcher runs it: argv in the
   # process's own argv, the expression evaluated verbatim.
@@ -274,6 +315,118 @@ defmodule Grappa.Release.CLITest do
          %{name: name} do
       assert {:error, message} = CLI.run(["remove-network", name, "no-such-net"])
       assert message =~ "no-such-net"
+    end
+  end
+
+  # #1685 — the verb wrote `connection_state: :connected` (the schema
+  # default, not a decision) and never spawned, because `eval` runs in a
+  # transient VM of its own. cic then rendered a network that claimed to be
+  # connected while every live-session operation answered `not_connected`.
+  #
+  # The cure has two halves and both are asserted here: the row lands
+  # `:parked` like the other two bind doors, and the operator is told, in
+  # words, which of the two things actually happened.
+  describe "add-network — never claims a session it did not start (#1685)" do
+    setup do
+      name = unique_name()
+      {:ok, _} = CLI.run(["create-user", name, "--password", @password])
+      on_exit(&LiveNode.reset_test_impl/0)
+      %{name: name, user: Accounts.get_user_by_name(name)}
+    end
+
+    test "binds :parked, never the schema default :connected", %{name: name, user: user} do
+      assert {:ok, _} = add_network(name)
+
+      network = Networks.get_network_by_slug!("azzurra")
+
+      assert %Credential{connection_state: :parked} = Credentials.get_credential!(user, network)
+      refute Session.whereis({:user, user.id}, network.id)
+    end
+
+    test "with no live node, says it is parked AND that a restart will not dial it",
+         %{name: name} do
+      # The honest half of vjt's ruling: a `:parked` row is NOT in the boot
+      # adoption query (`connection_state in [:connected, :failing]`), so an
+      # operator who seeds a box and restarts it would otherwise wait
+      # forever for a network that never comes up.
+      assert {:ok, message} = add_network(name)
+
+      assert message =~ "PARKED"
+      assert message =~ "Connect"
+      assert message =~ "restart"
+    end
+
+    test "with a live node that starts the session, says THAT instead", %{name: name} do
+      answering({:ok, :started})
+
+      assert {:ok, message} = add_network(name)
+
+      assert message =~ "started a session on the live node"
+      refute message =~ "PARKED"
+    end
+
+    test "a live node that refuses the spawn is reported, not swallowed", %{name: name} do
+      answering({:error, {:refused, :resolve_failed}})
+
+      assert {:ok, message} = add_network(name)
+
+      assert message =~ "PARKED"
+      assert message =~ "resolve_failed"
+    end
+
+    test "the binding survives a refused spawn — the row is the operator's input",
+         %{name: name, user: user} do
+      answering({:error, {:refused, :resolve_failed}})
+
+      assert {:ok, _} = add_network(name)
+
+      network = Networks.get_network_by_slug!("azzurra")
+      assert %Credential{connection_state: :parked} = Credentials.get_credential!(user, network)
+    end
+
+    # The class this closes, found by Dialyzer and not by hand: `adopt/2`
+    # can answer `:not_found` (the far side loaded no row), which was NOT in
+    # the union the message formatter had a clause for — so the operator's
+    # shell would have taken a FunctionClauseError instead of a sentence,
+    # AFTER the credential was written. Every value of
+    # `t:Grappa.Release.LiveNode.error/0` is walked here; a value added to
+    # that type without a matching phrase fails this test.
+    test "every live-node outcome produces a sentence, never a crash", %{name: name} do
+      outcomes = [
+        :no_release_node,
+        :distribution_disabled,
+        :no_distribution,
+        :unreachable,
+        :not_found,
+        {:refused, :resolve_failed},
+        {:refused, :ip_cap_exceeded},
+        {:refused, :visitor_cap_exceeded},
+        {:refused, :user_cap_exceeded},
+        {:refused, {:network_circuit_open, 30}},
+        {:refused, {:start_failed, :badarg}},
+        {:call_failed, {:error, {:erpc, :timeout}}}
+      ]
+
+      for outcome <- outcomes do
+        answering({:error, outcome})
+        slug = "net-#{System.unique_integer([:positive])}"
+
+        assert {:ok, message} =
+                 CLI.run([
+                   "add-network",
+                   name,
+                   slug,
+                   "--server",
+                   "irc.azzurra.chat:6697",
+                   "--nick",
+                   "vjt-grappa",
+                   "--auth",
+                   "none"
+                 ]),
+               "add-network raised or failed on live-node outcome #{inspect(outcome)}"
+
+        assert message =~ "PARKED", "no parked sentence for #{inspect(outcome)}"
+      end
     end
   end
 

--- a/test/grappa/release/live_node_test.exs
+++ b/test/grappa/release/live_node_test.exs
@@ -1,0 +1,160 @@
+defmodule Grappa.Release.LiveNodeTest do
+  @moduledoc """
+  #1685 — the one hop `grappa add-network` makes out of its own transient
+  VM and into the running bouncer.
+
+  ## What is being pinned, and what deliberately is not
+
+  The release wrapper rewrites the account verbs into `eval`, which starts
+  a node of its own; a session spawned there dies with the command. The
+  cure crosses to the live node over Erlang distribution and makes a
+  FUNCTION CALL, so the operator's words travel as terms and nothing they
+  type is ever evaluated as source on the production BEAM.
+
+  The two halves are tested differently, because only one of them can be
+  run here:
+
+    * `adopt_here/2` — the LIVE half. Under ExUnit the app IS running, so
+      this file is a live node: the test drives it for real against
+      `Grappa.IRCServer` and asserts a `Session.Server` exists afterwards.
+    * `adopt/2` — the CALLING half. Its `:net_kernel.start/2` would make
+      the TEST VM distributed and leak into every other test, so only the
+      branches that refuse BEFORE any I/O are exercised here. The rest was
+      measured on three real substrates (issue #1685, 2026-08-23): 2–3 ms
+      to raise distribution, 1–3 ms to connect, and both no-live-node
+      shapes failing in under 10 ms.
+
+  `target_node/2` is public and pinned because it encodes a MEASURED
+  constraint that reads like a detail and is not: under
+  `RELEASE_DISTRIBUTION=name` the host must come from our own node name,
+  never from `:inet.gethostname()`. On the measurement bench the two
+  disagreed (`box2.example.com` vs `box2`) and the gethostname spelling
+  was rejected outright — `** Hostname box2 is illegal **`.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{IRCServer, Networks, Session}
+  alias Grappa.Networks.Credentials
+  alias Grappa.Release.LiveNode
+
+  setup do
+    on_exit(fn ->
+      System.delete_env("RELEASE_NODE")
+      System.delete_env("RELEASE_DISTRIBUTION")
+    end)
+
+    :ok
+  end
+
+  describe "target_node/2 — spelling the live node" do
+    test "takes the host from our own node name, not from the OS hostname" do
+      assert LiveNode.target_node("grappa", :"grappa_cli_1@box2.example.com") ==
+               :"grappa@box2.example.com"
+
+      assert LiveNode.target_node("grappa", :grappa_cli_1@box) == :grappa@box
+    end
+
+    test "an operator-qualified RELEASE_NODE is used verbatim" do
+      assert LiveNode.target_node("grappa@elsewhere.internal", :grappa_cli_1@box) ==
+               :"grappa@elsewhere.internal"
+    end
+  end
+
+  describe "adopt/2 — refusing before any I/O" do
+    test "says so when RELEASE_NODE is absent, because there is no target to name" do
+      System.delete_env("RELEASE_NODE")
+
+      assert LiveNode.adopt(Ecto.UUID.generate(), 1) == {:error, :no_release_node}
+    end
+
+    test "honours RELEASE_DISTRIBUTION=none instead of trying anyway" do
+      System.put_env("RELEASE_NODE", "grappa")
+      System.put_env("RELEASE_DISTRIBUTION", "none")
+
+      assert LiveNode.adopt(Ecto.UUID.generate(), 1) == {:error, :distribution_disabled}
+    end
+  end
+
+  describe "adopt_here/2 — the half that runs in the live node" do
+    test "starts a real session for the bound credential" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {network, _} = network_with_server(port: port, slug: "adopt-#{uniq()}")
+      user = user_fixture(name: "adopt-#{uniq()}")
+      stop_session_on_exit(user, network)
+
+      {:ok, _} =
+        Credentials.bind_credential(user, network, %{
+          nick: "vjt",
+          auth_method: :none,
+          autojoin_channels: [],
+          connection_state: :parked
+        })
+
+      refute Session.whereis({:user, user.id}, network.id)
+
+      assert LiveNode.adopt_here(user.id, network.id) == {:ok, :started}
+
+      assert {:ok, "NICK vjt\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "NICK"), 5_000)
+
+      assert is_pid(Session.whereis({:user, user.id}, network.id))
+    end
+
+    test "returns a SMALL term — no credential, and therefore no decrypted secret" do
+      {_, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {network, _} = network_with_server(port: port, slug: "adopt-terse-#{uniq()}")
+      user = user_fixture(name: "adopt-terse-#{uniq()}")
+      stop_session_on_exit(user, network)
+
+      # The one field that would leak: Cloak hands back the CLEARTEXT on
+      # load, so returning the struct would put this string on the
+      # distribution socket. The contract is that it cannot.
+      secret = "loadbearing-#{uniq()}"
+
+      {:ok, _} =
+        Credentials.bind_credential(user, network, %{
+          nick: "vjt",
+          auth_method: :nickserv_identify,
+          password: secret,
+          autojoin_channels: [],
+          connection_state: :parked
+        })
+
+      result = LiveNode.adopt_here(user.id, network.id)
+
+      assert result == {:ok, :started}
+      refute inspect(result, limit: :infinity) =~ secret
+    end
+
+    test "names an unknown binding rather than crashing the operator's shell" do
+      assert LiveNode.adopt_here(Ecto.UUID.generate(), 987_654) == {:error, :not_found}
+    end
+
+    test "reports a refused spawn instead of claiming a session" do
+      # A network with no ENABLED server: `SessionPlan.resolve/1` cannot
+      # pick one, so the canonical verb refuses — the same
+      # `:resolve_failed` the #1163 console door surfaces.
+      {:ok, network} = Networks.find_or_create_network(%{slug: "adopt-noserver-#{uniq()}"})
+      user = user_fixture(name: "adopt-noserver-#{uniq()}")
+
+      {:ok, _} =
+        Credentials.bind_credential(user, network, %{
+          nick: "vjt",
+          auth_method: :none,
+          autojoin_channels: [],
+          connection_state: :parked
+        })
+
+      assert LiveNode.adopt_here(user.id, network.id) == {:error, {:refused, :resolve_failed}}
+      refute Session.whereis({:user, user.id}, network.id)
+    end
+  end
+
+  defp uniq, do: System.unique_integer([:positive])
+
+  defp stop_session_on_exit(user, network) do
+    on_exit(fn -> Session.stop_session({:user, user.id}, network.id, "test teardown") end)
+  end
+end


### PR DESCRIPTION
Fixes the release-CLI half of the connected-without-a-session class (#1163's
neighbour): `grappa add-network` against a RUNNING deployment reported
success, left `connection_state: :connected`, and started nothing.

## Two faults, and the interesting one is not the state value

**The row said `connected` because nobody decided that.** It is the schema
default, and `bind_credential/3` was passed no state. The two sibling bind
doors already write `:parked` and let the spawn promote the row
(`session_controller.ex` #642, `admin/credentials_controller.ex` #1163) —
this was the last door inheriting the default. It binds `:parked` now.

**Nothing spawned because of the TRANSPORT.** `infra/release/grappa.sh`
rewrites the account verbs into the boot script's `eval`, which starts a
transient node of its own: a session started there dies with the command.
So "write `:parked` and spawn" was never the fix on its own.

Routing the whole verb through `rpc` instead is closed, **measured**:
`System.argv/0` under `--rpc-eval` is the *remote* node's argv and is always
`[]`, so the argv channel the wrapper's safety property rests on does not
exist there. Carrying the operator's words across would mean interpolating
them — `--password` included — into Elixir evaluated on the production BEAM.

## The shape: stay on `eval`, cross as TERMS

Parsing, validation and the write stay in the transient node. Only the spawn
crosses, as an `:erpc.call/5` — a function call whose arguments are Erlang
terms. No expression to escape, no `Code.eval_string` on the live node: the
injection surface is absent by construction rather than narrowed. The far
side lands on `Grappa.Operator.connect_credential/1`, the same canonical
verb the console bind and Bootstrap reach.

Two identifiers go out and an atom comes back. Neither direction carries a
`%Credential{}` — Cloak hands back the **cleartext** on load, so a struct
would put the operator's NickServ/SASL password on the distribution socket,
which is unencrypted by default.

## The measurement that gated the build

vjt made "can an `eval` node raise distribution on all four substrates?" a
measurement rather than a discussion. Full table in
[the issue comment](https://github.com/vjt/grappa-irc/issues/1685#issuecomment-5388278634).

| substrate | shape | result |
|---|---|---|
| Docker release image | live node, container-id / FQDN hostname / `RELEASE_DISTRIBUTION=name` | **2–3 ms** to raise, **3 ms** to connect, `:erpc` answers |
| Docker release image | fresh container, no live node, no epmd | `:net_kernel.start/2` FAILS `:nodistribution` in 8 ms |
| `.deb` on Debian 13 (glibc) | live node, via `/usr/bin/grappa` | **2 ms** / **3 ms**, `:erpc` answers |
| `.deb` on Debian 13 | service stopped, epmd survives | starts, `Node.connect` `false` in 1 ms |
| FreeBSD bastille jail | — | **NOT MEASURED** — see below |

Three of those facts are load-bearing in the code:

- the eval node already carries the release cookie, so nothing calls
  `Node.set_cookie/2`;
- 🔴 the target host must come from our OWN node name — under
  `RELEASE_DISTRIBUTION=name`, `gethostname` gives a spelling ERTS rejects
  outright (`** Hostname box2 is illegal **`);
- there are **two** no-live-node shapes, not one, and a cure handling only
  the second crashes on first run.

Also measured: a wrong cookie is indistinguishable from a stopped node at
the caller, so the operator message names both possibilities.

## Proven end to end on the published-image shape

Before, on the unfixed image: `whereis` `nil` with the row reading
`:connected`. After, on an image rebuilt from this branch:

```
alice can now use testnet (server 127.0.0.1:6667)
  started a session on the live node — nothing else to do
```
→ `live_session=true state=connected`, settling on its own to
`state=failing reason="connection refused"` (the endpoint was deliberately
dead). #1675's semantics working.

And the first-run branch, same image, no live node:

```
bob can now use testnet (server 127.0.0.1:6667)
  the binding is PARKED: nothing is listening on epmd, so no bouncer is running here.
  A restart will NOT dial it — bob connects it with Connect after logging in.
```

That second sentence is vjt's ruling made honest: `:parked` means explicit
user intent and is deliberately NOT in the boot adoption query, so the query
was **not** widened — doing so would resurrect at reboot every network a
user had deliberately `/disconnect`ed.

**Exit status is 0 in every branch.** The binding is the operator's input
and is kept even when the spawn is refused, so `create-user && add-network
&& systemctl start grappa` does not break on the case that has no live node
by definition. Read the second line, not the exit code.

## `abort/1` is untouched

The expected price — code in the live node cannot `System.halt/1`, and
stderr is swallowed under `rpc` — is not owed: the CLI never runs in the
live node. Measured through the real door today: `rc=1` and the message on
the operator's stderr, both intact.

## Not measured

The **FreeBSD bastille jail**. The m42 ssh key is unreadable from this
process (`Operation not permitted`, macOS layer, unchanged with the agent
sandbox off) — a gap in evidence, not a negative result. A self-contained
read-only probe is attached to the issue.

It does not block correctness: the offline branch is mandatory anyway, so a
substrate that cannot raise distribution simply always takes it and the
credential lands `:parked` exactly as ruled. The jail can lose the
convenience, never the honesty.

## Flagged, deliberately not done

- `mix grappa.bind_network` still binds the schema default — same class, but
  a source install's live node sets no `RELEASE_NODE`, so there is no hop to
  promote the row and `:parked` there would be a plain regression.
- `remove-network` has the mirror defect: it deletes the row in the
  transient node while the live node keeps running the session.
- The packaged `/usr/bin/grappa` boots its eval VM in **latin1** (its
  `runuser` payload sets no `LANG` while the systemd unit beside it pins
  `C.UTF-8` — #425), and `--nick`/`--autojoin` carry user-supplied bytes.
- ERTS prints its own `Protocol 'inet_tcp': register/listen error:
  econnrefused` notice on the first-run path, just above our sentence. Left
  in: it is true, it names the mechanism, and suppressing an ERTS diagnostic
  to tidy output is how the next bug hides.

## Gates

`scripts/check.sh` fully green on this branch: **6824 tests, 0 failures**,
Dialyzer **0 errors**, Credo strict clean, Sobelow, 674 bats ok.
Rebased onto `origin/main` through `scripts/union-rebase.sh` — DESIGN_NOTES
contribution `+168 -0`, intact in both directions.

Dialyzer earned its keep here: `contract_supertype` on `adopt_here/2` is
what surfaced that `:not_found` could reach the message formatter with no
clause for it — a `FunctionClauseError` in the operator's shell *after* the
credential was written. The test that closes that class walks every value of
the error union and was falsified (removing the clause turns it red).
