### PR TITLE
#1692 — runtime.exs wrote a compile-time key, and the Mix lane died on it

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -353,18 +353,13 @@ if config_env() == :prod do
     http: [ip: {0, 0, 0, 0}, port: port],
     check_origin: ["//#{phx_host}" | extra_origins],
     secret_key_base: secret_key_base,
-    server: true,
-    # CP23 cluster `code-reload` B2 — enable Phoenix.CodeReloader in
-    # prod so `Phoenix.CodeReloader.reload!/1` (called by the admin
-    # endpoint, B3) can hot-swap modules in the running container.
-    # Default in `config/dev.exs` is `true`; flipping it on in prod
-    # is the only-line-of-config change that unlocks the cluster's
-    # whole hot-deploy story. The reloader does file IO only on the
-    # explicit reload! call, not on every request — attack surface is
-    # the admin endpoint itself (loopback-only via
-    # GrappaWeb.Plugs.LoopbackOnly).
-    code_reloader: true,
-    reloadable_apps: [:grappa]
+    server: true
+
+  # No `code_reloader` / `reloadable_apps` here, deliberately: Phoenix reads
+  # `code_reloader` with `Application.compile_env/3`, so setting it from this
+  # file kills every Mix-lane verb (#1692, pinned by
+  # test/grappa/config/compile_env_runtime_overlap_test.exs). Prod hot-reload
+  # is `Grappa.HotReload`, which needs neither flag.
 
   # Cloak vault key — base64-encoded 32 bytes. Generate once with
   # `scripts/mix.sh grappa.gen_encryption_key` and back up separately.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59694,3 +59694,139 @@ before the assertion gave up, inside a 35.4s window in which ~103 tests
 flushed; the three accelerators above were each tested and refuted, and no
 fourth is elected here. The ordering fix does not depend on knowing which one
 it was — it removes the class.
+<!-- entry #1692 -->
+
+---
+
+## 2026-08-23 — #1692: a runtime write to a compile-time key, and the build that could not be recompiled out of it
+
+`bin/grappa`'s boot verbs and `scripts/mix.sh --env=prod` were dead on a
+compose prod stack, all of them, before their task ran:
+
+```
+** (Mix) the application :grappa has a different value set for path [:code_reloader]
+   inside key GrappaWeb.Endpoint during runtime compared to compile time.
+  * Compile time value was set to: true
+  * Runtime value was not set
+```
+
+`gen-vapid` failed identically to `bind-network`, which is the tell: the
+gate is `Config.Provider.validate_compile_env/1`, and it fires before any
+task code. The `--rpc-eval` verbs were unaffected — they never enter Mix.
+
+### The precondition, and why it could only ever be a matter of time
+
+`config/runtime.exs`'s prod block set `code_reloader: true` on the
+Endpoint. Phoenix reads that key with `Application.compile_env/3` in its
+`use` macro (`endpoint.ex:426`, alongside `debug_errors` and `force_ssl`),
+so the value observed at compile time is recorded into
+`_build/<env>/lib/grappa/ebin/grappa.app` and compared, at every later Mix
+invocation, against what the config files say. `runtime.exs` is not one of
+those files: in the Mix lane it is evaluated by `app.config`, AFTER
+compilation. A compile_env key written from there cannot agree with its
+own record except by accident.
+
+The release lane already knew. `mix.exs` carried
+`validate_compile_env: false` with a comment naming this exact key as the
+reason, so the jail booted by silencing the detector rather than by
+satisfying it. The Mix lane had no such silencer, which is why it is the
+one that broke — and the mix.exs comment's closing claim, that "the Docker
+path doesn't hit this because it boots via `mix phx.server`", was the
+half-truth: true of the boot, false of every other `mix` invocation
+against the build that boot produced.
+
+### What actually bakes the wrong value in
+
+A clean prod compile records `error` (unset) for the key: measured on an
+untouched `_build/prod` and again on a wiped one. The `{ok,true}` in the
+reported build therefore came from a compile that observed the RUNTIME
+value — i.e. one that ran in a VM where runtime.exs had already been
+applied.
+
+`mix compile` cannot be that compile: it depends on `loadpaths`, which
+re-runs `loadconfig` and resets the app env to config-file values. Measured
+— a `put_env` followed by `Mix.Task.rerun("compile", ["--force"])` records
+`error`, not `{ok,true}`. What CAN be that compile is
+`Phoenix.CodeReloader`: its default `reloadable_compilers` include `:app`
+(`endpoint/supervisor.ex:247`) and it invokes those compiler tasks directly
+via `run_compilers/4` (`code_reloader/server.ex:330`), bypassing
+`loadconfig` entirely. Replicating exactly that shape —
+`Mix.Task.run("compile.elixir", ["--force"])` then
+`Mix.Task.run("compile.app", [])` with the value put into the app env
+first — records `{ok,true}`, and the very next `scripts/mix.sh` run
+reproduces the reported error byte for byte.
+
+And `code_reloader: true` is precisely what puts such a reloader inside the
+prod VM at all (`endpoint/supervisor.ex:91`). The flag's one live effect in
+production was the ability to poison its own build.
+
+### It does not heal
+
+Measured, and it is the part worth remembering: on a poisoned build **`mix
+compile` dies on the same gate**, rc=1. The state is therefore sticky — an
+operator cannot recompile out of it. The exits are `mix deps.clean grappa
+--build`, a wiped `_build/<env>`, or `--no-validate-compile-env`. Note that
+a change to a `config/*.exs` file DOES heal it, because Elixir treats those
+as compile inputs and recompiles before the gate can bite; a value that
+entered through runtime.exs has no such file behind it, so nothing
+invalidates it. That asymmetry is the whole bug in one sentence.
+
+### The cure, and why removal rather than silence
+
+Both halves of the mismatch were removed, not papered.
+`config/runtime.exs` no longer writes `code_reloader` (nor its
+`reloadable_apps` companion), and `mix.exs` no longer disables the release
+boot check. Passing `--no-validate-compile-env` on the toolchain lane —
+the issue's own preferred axis — was rejected: it disables a correct
+detector for every future key in order to keep a flag that does nothing.
+
+Nothing does. No `Phoenix.CodeReloader` plug exists in the endpoint, and
+`/admin/reload` has gone through `Grappa.HotReload`'s md5 beam walk since
+CP28, exactly because the Phoenix reloader no-ops without mix. The 2026-07-31
+"#503 unit C" entry left the flag in place as "harmless in a release"; that
+reading was right about the release image and wrong about the Mix lane, and
+this entry is the correction.
+
+Re-arming the release check is safe by enumeration, not by hope: five
+loaded applications declare any `compile_env` (grappa, bunt, mime, plug,
+remote_ip), runtime.exs writes to three (`:grappa`, `:ex_nudge`,
+`:logger`), only `:grappa` is in both, and inside it no written path meets
+a read path. In a release the config provider is the ONLY thing that can
+move a value between compile and boot, so that intersection IS the whole
+exposure. Verified on the artefact: a fresh `mix release --overwrite` ships
+`sys.config` with `validate_compile_env => [...]` (armed) and the entry it
+will check reading `error`.
+
+### The pin
+
+`test/grappa/config/compile_env_runtime_overlap_test.exs` asserts the
+intersection stays empty. Both sides are DERIVED — reads from the `.app`
+files the build just produced, writes from the parsed AST of runtime.exs —
+because a hand-kept list of either drifts from the thing it describes.
+Matching is prefix-symmetric: `Config.config/3` deep-merges a keyword
+value, so a write to `[:admission, :captcha_secret]` must not flag a read
+of `[:admission, :network_circuit_threshold]`, while a write of a
+non-keyword value replaces a whole key and a read may itself name a whole
+key (`[Grappa.ChannelDirectory]`) that any subkey write disturbs.
+
+### Deploy class and what stayed unproven
+
+COLD, twice over: `config/*.exs` matches `Grappa.Deploy.Preflight`'s
+`config?/1` and `mix.exs` matches `mix_deps?/1`.
+
+Not established: WHICH agent recompiled on the reporting operator's box.
+The mechanism and its stickiness are reproduced; the trigger is not, and
+today's tree contains no caller that would fire `Phoenix.CodeReloader.reload/1`.
+The fix does not depend on the answer — it removes the precondition every
+candidate needs — but the question is left open rather than closed by
+assertion.
+
+Two adjacent staleness findings were left alone deliberately, being
+neither caused nor touched by this change: `mix.exs`'s `listeners:
+[Phoenix.CodeReloader]` comment claims the listener is what lets "the next
+/admin/reload pick up the new beams", which has not been true since reload
+moved to `Grappa.HotReload` (the listener only accumulates modules for a
+`Server.reload!` that never comes); and `docs/OPERATIONS.md`'s hot-deploy
+section still attributes module reload to `:code.modified_modules/0` +
+`:code.load_file/1`, both of which `Grappa.HotReload`'s moduledoc names as
+tried-and-rejected with live repros.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2772,9 +2772,15 @@ cicchetto SPA, and nothing to compile with — no Elixir, no mix, no
 source, no code reloader, no inotify. It boots `bin/grappa start`, and a
 hot update swaps beams into `lib/grappa-<vsn>/ebin` and fires
 `Grappa.HotReload` (unit E), never the dev reloader. Do not expect the
-compose hot-edit loop from it. `code_reloader: true` survives in the prod
-Endpoint config and is harmless in a release — the reasoning is in
-DESIGN_NOTES 2026-07-31, "#503 unit C".
+compose hot-edit loop from it. `code_reloader: true` NO LONGER survives in
+the prod Endpoint config: #1692 measured that it was not harmless after
+all — Phoenix reads that key with `Application.compile_env/3`, and setting
+it from `config/runtime.exs` is what killed every `bin/grappa` boot verb
+and every `scripts/mix.sh --env=prod` on a compose prod stack. It is now
+set in `config/dev.exs` only. The 2026-07-31 "#503 unit C" reasoning stands
+for the release image itself (no mix, so no reloader either way); what it
+got wrong was the Mix lane, and DESIGN_NOTES 2026-08-23 "#1692" carries the
+correction.
 
 **Base image: `elixir:1.19-otp-28-alpine` (Docker Hub official).** The
 earlier multi-stage debian build used

--- a/mix.exs
+++ b/mix.exs
@@ -100,17 +100,13 @@ defmodule Grappa.MixProject do
           # boot: `mix deps.get --only prod`, `mix compile`,
           # `mix release --overwrite`, then `_build/prod/rel/grappa/bin/grappa
           # daemon` under an rc.d wrapper.
-          applications: [runtime_tools: :permanent],
-          # `config/runtime.exs` flips `code_reloader: true` on Phoenix's
-          # Endpoint (CP23 cluster B2 — hot-reload story for Docker).
-          # Phoenix marks that key as compile_env, so the release boot
-          # check refuses to start when the runtime value doesn't match
-          # the compile-time one (unset). Disabling the check is the
-          # release-doc-recommended escape hatch for genuinely-meant
-          # compile_env overrides. The Docker path doesn't hit this
-          # because it boots via `mix phx.server`, not via the release
-          # boot script.
-          validate_compile_env: false
+          applications: [runtime_tools: :permanent]
+          # No `validate_compile_env: false` here, deliberately: the release
+          # boot check is left ARMED. It was disabled for exactly one key
+          # (#1692) and now has none to absorb — the pin at
+          # test/grappa/config/compile_env_runtime_overlap_test.exs keeps
+          # runtime.exs off every compile_env key, so re-disabling it would
+          # only hide the next one.
         ]
       ]
     ]

--- a/test/grappa/config/compile_env_runtime_overlap_test.exs
+++ b/test/grappa/config/compile_env_runtime_overlap_test.exs
@@ -1,0 +1,147 @@
+defmodule Grappa.Config.CompileEnvRuntimeOverlapTest do
+  @moduledoc """
+  Pin for #1692: no key written by `config/runtime.exs` may also be read
+  with `Application.compile_env/3`.
+
+  `Application.compile_env/3` records the value it observed into the
+  owning app's `.app` file, and `Config.Provider.validate_compile_env/1`
+  refuses to proceed when that record disagrees with the live app env.
+  `config/runtime.exs` is evaluated AFTER compilation in the Mix lane and
+  at boot in the release lane, so a key written there and read with
+  `compile_env` disagrees by construction — the only open question is
+  which door reports it first, and how loudly.
+
+  Measured on #1692: `[GrappaWeb.Endpoint, :code_reloader]` was both.
+  Phoenix reads it with `Application.compile_env/3` in its `use` macro,
+  and `config/runtime.exs`'s prod block wrote it. The release lane
+  silenced the resulting boot check with `validate_compile_env: false` in
+  `mix.exs`; the Mix lane had no silencer, so every `bin/grappa` boot verb
+  and every `scripts/mix.sh --env=prod` died before its task ran with
+  `** (Mix) the application :grappa has a different value set for path
+  [:code_reloader] inside key GrappaWeb.Endpoint`. `mix compile` dies on
+  the same gate, so a build that reaches that state cannot be recompiled
+  out of it — only `mix deps.clean grappa --build` or a wiped `_build`
+  clears it.
+
+  DERIVED, not manifested (CLAUDE.md design rule 1): the compile-time
+  reads come from the `.app` files the build just produced, and the
+  runtime writes from the parsed AST of `config/runtime.exs`. A hand-kept
+  list of either would be a parallel structure that drifts from the thing
+  it describes — the exact failure this pin exists to catch.
+
+  Matching is prefix-symmetric on purpose. `Config.config/3` deep-merges a
+  keyword value, so a write to `[:admission, :captcha_secret]` leaves a
+  read of `[:admission, :network_circuit_threshold]` alone. But a write of
+  a non-keyword value REPLACES the whole key, and a read may itself name a
+  whole key (`[Grappa.ChannelDirectory]`) that any subkey write disturbs.
+  So a write collides with a read when either path is a prefix of the
+  other, and only then.
+
+  Scope is every app `config/runtime.exs` writes to, not just `:grappa`:
+  the `.app` that records a compile-time read is the one belonging to the
+  app being READ, so a dep that reads our config — or its own — is covered
+  by the same sweep.
+  """
+
+  # async: true — pure file reads, no global state.
+  use ExUnit.Case, async: true
+
+  @runtime_exs "config/runtime.exs"
+
+  test "no config/runtime.exs key is also read with Application.compile_env" do
+    writes = runtime_writes()
+
+    overlap =
+      for {app, read_path, _observed} <- compile_env_reads(),
+          write_path <- Map.get(writes, app, []),
+          collides?(read_path, write_path),
+          do: "  * #{inspect(app)} #{inspect(read_path)} (written as #{inspect(write_path)})"
+
+    assert overlap == [],
+           """
+           #{@runtime_exs} writes keys that are read at COMPILE time:
+
+           #{Enum.join(Enum.sort(overlap), "\n")}
+
+           A compile_env key set from runtime.exs cannot agree with the value
+           baked into the .app file, and validate_compile_env exists to refuse
+           exactly that. It kills the Mix lane outright (every bin/grappa boot
+           verb, every scripts/mix.sh --env=prod) and takes `mix compile` with
+           it, so the build cannot be recompiled back to health.
+
+           Fix the WRITE, not the check: move the key to a compile-time config
+           (config/config.exs or config/<env>.exs), or stop setting it. Passing
+           --no-validate-compile-env, or setting :validate_compile_env to false
+           in the release config, silences the detector and leaves the mismatch.
+           """
+  end
+
+  # Every {app, key_path, observed} triple the current build recorded, across
+  # all loaded applications — the app that OWNS the key owns the record.
+  defp compile_env_reads do
+    for {app, _description, _vsn} <- Application.loaded_applications(),
+        entry <- app_compile_env(app),
+        do: entry
+  end
+
+  defp app_compile_env(app) do
+    with dir when is_list(dir) <- :code.lib_dir(app),
+         path = Path.join([List.to_string(dir), "ebin", "#{app}.app"]),
+         {:ok, [{:application, ^app, properties}]} <- :file.consult(path) do
+      Keyword.get(properties, :compile_env, [])
+    else
+      _ -> []
+    end
+  end
+
+  # %{app => [key_path]} for every `config/2` and `config/3` call in
+  # runtime.exs, read off the AST rather than by regex so a multi-line call
+  # or a computed value reads the same as a one-liner.
+  defp runtime_writes do
+    @runtime_exs
+    |> File.read!()
+    |> Code.string_to_quoted!()
+    |> Macro.prewalk([], fn
+      {:config, _meta, args} = node, acc when is_list(args) -> {node, writes(args) ++ acc}
+      node, acc -> {node, acc}
+    end)
+    |> elem(1)
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+  end
+
+  defp writes([app, keyword]) when is_atom(app) do
+    case keyword_keys(keyword) do
+      {:ok, keys} -> Enum.map(keys, &{app, [&1]})
+      :error -> []
+    end
+  end
+
+  defp writes([app, key, value]) when is_atom(app) do
+    case {config_key(key), keyword_keys(value)} do
+      {:error, _} -> []
+      {{:ok, key}, {:ok, keys}} -> Enum.map(keys, &{app, [key, &1]})
+      # A non-keyword value replaces the whole key, so the write is the key.
+      {{:ok, key}, :error} -> [{app, [key]}]
+    end
+  end
+
+  defp writes(_args), do: []
+
+  defp config_key(key) when is_atom(key), do: {:ok, key}
+  defp config_key({:__aliases__, _meta, parts}), do: {:ok, Module.concat(parts)}
+  defp config_key(_key), do: :error
+
+  defp keyword_keys(list) when is_list(list) and list != [] do
+    if Enum.all?(list, &match?({key, _value} when is_atom(key), &1)) do
+      {:ok, Enum.map(list, &elem(&1, 0))}
+    else
+      :error
+    end
+  end
+
+  defp keyword_keys(_value), do: :error
+
+  defp collides?(read_path, write_path) do
+    List.starts_with?(read_path, write_path) or List.starts_with?(write_path, read_path)
+  end
+end

--- a/test/grappa/config/compile_env_runtime_overlap_test.exs
+++ b/test/grappa/config/compile_env_runtime_overlap_test.exs
@@ -52,7 +52,7 @@ defmodule Grappa.Config.CompileEnvRuntimeOverlapTest do
     writes = runtime_writes()
 
     overlap =
-      for {app, read_path, _observed} <- compile_env_reads(),
+      for {app, read_path, _} <- compile_env_reads(),
           write_path <- Map.get(writes, app, []),
           collides?(read_path, write_path),
           do: "  * #{inspect(app)} #{inspect(read_path)} (written as #{inspect(write_path)})"
@@ -79,7 +79,7 @@ defmodule Grappa.Config.CompileEnvRuntimeOverlapTest do
   # Every {app, key_path, observed} triple the current build recorded, across
   # all loaded applications — the app that OWNS the key owns the record.
   defp compile_env_reads do
-    for {app, _description, _vsn} <- Application.loaded_applications(),
+    for {app, _, _} <- Application.loaded_applications(),
         entry <- app_compile_env(app),
         do: entry
   end
@@ -102,7 +102,7 @@ defmodule Grappa.Config.CompileEnvRuntimeOverlapTest do
     |> File.read!()
     |> Code.string_to_quoted!()
     |> Macro.prewalk([], fn
-      {:config, _meta, args} = node, acc when is_list(args) -> {node, writes(args) ++ acc}
+      {:config, _, args} = node, acc when is_list(args) -> {node, writes(args) ++ acc}
       node, acc -> {node, acc}
     end)
     |> elem(1)
@@ -125,21 +125,21 @@ defmodule Grappa.Config.CompileEnvRuntimeOverlapTest do
     end
   end
 
-  defp writes(_args), do: []
+  defp writes(_), do: []
 
   defp config_key(key) when is_atom(key), do: {:ok, key}
-  defp config_key({:__aliases__, _meta, parts}), do: {:ok, Module.concat(parts)}
-  defp config_key(_key), do: :error
+  defp config_key({:__aliases__, _, parts}), do: {:ok, Module.concat(parts)}
+  defp config_key(_), do: :error
 
   defp keyword_keys(list) when is_list(list) and list != [] do
-    if Enum.all?(list, &match?({key, _value} when is_atom(key), &1)) do
+    if Enum.all?(list, &match?({key, _} when is_atom(key), &1)) do
       {:ok, Enum.map(list, &elem(&1, 0))}
     else
       :error
     end
   end
 
-  defp keyword_keys(_value), do: :error
+  defp keyword_keys(_), do: :error
 
   defp collides?(read_path, write_path) do
     List.starts_with?(read_path, write_path) or List.starts_with?(write_path, read_path)


### PR DESCRIPTION
For #1692.

`config/runtime.exs`'s prod block set `code_reloader: true` on the Endpoint. Phoenix
reads that key with `Application.compile_env/3` in its `use` macro, so the value is
recorded into `grappa.app` and compared by `Config.Provider.validate_compile_env/1`
against what the *config files* say. runtime.exs is not one of those — in the Mix lane
it runs after compilation — so the two can only agree by accident. When they stopped
agreeing, every `bin/grappa` boot verb and every `scripts/mix.sh --env=prod` died
before its task ran.

### Measured

- A clean prod compile records `error` for the key. `{ok,true}` is **not** the normal
  state of a prod build.
- `mix compile` cannot produce `{ok,true}`: it depends on `loadpaths`, which re-runs
  `loadconfig` and resets the app env to config-file values. Measured — `put_env` plus
  `Mix.Task.rerun("compile", ["--force"])` records `error`.
- What can: a `compile.app` invoked *outside* `mix compile`. `Phoenix.CodeReloader` is
  exactly that shape — its default `reloadable_compilers` include `:app` and it runs
  the compiler tasks directly. Replicating that shape reproduces the reported error
  byte for byte, in the compile lane, with no stack and no prod secrets.
- 🔴 **The state does not heal: `mix compile` dies on the same gate.** Only
  `mix deps.clean grappa --build` or a wiped `_build` clears it. A `config/*.exs`
  change *does* heal it, because Elixir treats those as compile inputs — a value that
  arrived through runtime.exs has no file behind it to invalidate anything. That
  asymmetry is the bug in one sentence.
- The issue's open question, answered: a fresh self-host install does **not** trip
  this, so P2 holds. `infra/docker/deploy.sh:330` compiles under `-e MIX_ENV=dev`, the
  prod build is first produced by `mix phx.server`, and that compile is clean.

### The change

Both halves of the mismatch are removed rather than papered over.
`--no-validate-compile-env` (the issue's preferred axis) was declined: it disables a
correct detector for every future key in order to keep a flag that does nothing. No
`Phoenix.CodeReloader` plug exists in the endpoint, and `/admin/reload` has gone
through `Grappa.HotReload`'s md5 beam walk since CP28. The flag's one live effect in
production was the ability to poison its own build.

`mix.exs`'s `validate_compile_env: false` also goes: it was installed for exactly this
one key, per its own comment, and a silencer kept past its cause does not stay neutral.
Safe by enumeration — five loaded applications declare any `compile_env`, runtime.exs
writes to three, only `:grappa` is in both, and inside it no written path meets a read
path. **This third commit is separable; drop it for the smaller diff if you prefer.**

Verified on the artefact: a fresh `mix release --overwrite` ships `sys.config` with
`validate_compile_env => [...]` (armed, not `false`) and the entry it will check reads
`error`. `scripts/mix.sh --env=prod ecto.migrations` → rc=0.

### The pin

`test/grappa/config/compile_env_runtime_overlap_test.exs` holds the intersection of
*keys runtime.exs writes* and *keys read with `Application.compile_env/3`* empty. It is
an ExUnit and not a bats on purpose: a bats could only assert the symptom, and would
have to manufacture a poisoned `_build` to do it. Both sides are derived — reads from
the `.app` files the build produced, writes from runtime.exs's AST. Matching is
prefix-symmetric because `Config.config/3` deep-merges.

### Deploy class

**COLD, twice over:** `config/*.exs` matches `Preflight`'s `config?/1`, `mix.exs`
matches `mix_deps?/1`. On a box that is currently in the bad state, the cold recreate
is also the cure.

### Not claimed

Which agent recompiled on the reporting operator's box. The mechanism and its
stickiness are reproduced; the trigger is not, and today's tree has no caller that
would fire `Phoenix.CodeReloader.reload/1`. The change removes the precondition every
candidate needs. I also did not boot a release, and did not run `integration.sh` (no
stack lane).

### Gates

`scripts/check.sh` → **rc=0, 8 doctests, 62 properties, 6818 tests, 0 failures**.
Rebased onto `c4acaf6c` via `scripts/union-rebase.sh` (`docs/DESIGN_NOTES.md +136 -0`,
contribution intact, boundary shape re-read on the real file).

⚠️ **If CI comes back red on `lock_watch_test`, it is not from this branch.** That is
the #1715 defect, measured at 3 hangs in 20 runs on a pristine, unmodified `c4acaf6c`.
