### PR TITLE
cic: widen connect-src to the measured SomaFM catalogue host (#1695)

### DIFF
--- a/cicchetto/e2e/tests/issue1695-somafm-connect-src-perimeter.spec.ts
+++ b/cicchetto/e2e/tests/issue1695-somafm-connect-src-perimeter.spec.ts
@@ -1,0 +1,158 @@
+// #1695 — the CSP perimeter around the SomaFM catalogue host.
+//
+// TWO DIFFERENT QUESTIONS, AND ONLY ONE OF THEM IS AN EXUNIT QUESTION.
+// `security_headers_test.exs` proves the policy STRING carries the token.
+// It cannot prove a browser honours it, and it cannot prove what the policy
+// still REFUSES. This spec answers both against the real header the BEAM
+// serves, which is the only place the two can be checked together.
+//
+// THE REFUSALS ARE THE POINT. `connect-src` ships the measured host and
+// nothing wider — measured against the live catalogue on 2026-08-23, all 184
+// `.pls` playlist URLs (the only kind a client fetches, so the only kind
+// `connect-src` governs) are on `api.somafm.com`, with the 138 logos on
+// `img-src https:` and the 103 prerolls on `media-src https:`. So two
+// neighbours of the allowed host must stay blocked, and they are blocked for
+// DIFFERENT reasons:
+//
+//   * the BARE `somafm.com` — the trap #1695 names in its own verification.
+//     The catalogue answers byte-identically from either host (measured:
+//     52,852 bytes for `channels.json`, 2,576 for `songs/groovesalad.json`,
+//     both hosts), so a client author reaching for the shorter spelling gets
+//     a working `curl` and a blocked `fetch`. This pins the refusal so that
+//     mistake reds here instead of in a browser console.
+//
+//   * `ice.somafm.com` — a somafm SUBDOMAIN that is not the API. THIS is the
+//     one that catches a distracted widening to `https://*.somafm.com`, and
+//     the bare domain does NOT: a CSP host-source spelled `*.` requires at
+//     least one label, so `*.somafm.com` refuses the bare domain too and a
+//     bare-domain pin would sail straight through the widening it was added
+//     to catch. A non-api subdomain is the only stimulus that separates the
+//     shipped policy from the wildcard.
+//
+// INTERCEPTION, NOT THE NETWORK. All three hosts are routed, so no assertion
+// here depends on somafm being up (#682 made that rule for the station table
+// and it holds harder for a gate). The renderer enforces CSP BEFORE the
+// request reaches the network layer, so a route handler firing is itself the
+// verdict "the policy let this out", and a handler that never fires is the
+// verdict "the policy refused it". The `securitypolicyviolation` events
+// collected by `fixtures/test.ts` are the second, independent witness. Hosts
+// are routed one literal at a time rather than through a `*.somafm.com`
+// glob — the glob is the very shape under test, and spelling it in the
+// harness would make the harness agree with a widened policy by definition.
+//
+// The fulfilled response carries `Access-Control-Allow-Origin: *` because the
+// real endpoint does (measured, and recorded in `radioStations.ts`). Without
+// it the browser would refuse the RESPONSE for CORS and the fetch would
+// reject exactly as a CSP block does — two different failures wearing the
+// same TypeError. `hits` is what keeps them apart: it records the request
+// leaving the renderer, which is the CSP verdict on its own.
+
+import { expect, test } from "../fixtures/test";
+
+const ALLOWED = "https://api.somafm.com/channels.json";
+const BLOCKED_BARE = "https://somafm.com/channels.json";
+const BLOCKED_SUBDOMAIN = "https://ice.somafm.com/groovesalad-128-mp3";
+
+// A violation reports `blockedURI` as the full URL or as the bare origin
+// depending on the engine, so compare on the HOST and never on the string —
+// `https://somafm.com` and `https://ice.somafm.com` both contain "somafm.com"
+// and this spec's whole job is telling those two apart.
+function blockedSomafmHosts(violations: readonly { blockedURI: string }[]): Set<string> {
+  const hosts = new Set<string>();
+  for (const v of violations) {
+    let host = "";
+    try {
+      host = new URL(v.blockedURI).host;
+    } catch {
+      // "inline" / "eval" and friends are not URLs. Not ours; the suite-wide
+      // guard still sees them and will red the teardown.
+      host = "";
+    }
+    if (host.endsWith("somafm.com")) hosts.add(host);
+  }
+  return hosts;
+}
+
+test("#1695 connect-src admits api.somafm.com and still refuses the bare domain and its siblings", async ({
+  page,
+  cspViolations,
+}) => {
+  const hits: string[] = [];
+
+  // The two that must never get here are routed too. Recording a hit rather
+  // than only fulfilling turns "blocked" into a positive assertion (`hits`
+  // stayed empty for that host) instead of the mere absence of an error.
+  for (const origin of ["https://api.somafm.com", "https://somafm.com", "https://ice.somafm.com"]) {
+    await page.route(`${origin}/**`, async (route) => {
+      hits.push(new URL(route.request().url()).host);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: { "access-control-allow-origin": "*" },
+        body: JSON.stringify({ channels: [] }),
+      });
+    });
+  }
+
+  // Any same-origin document carries the header — the plug registers them on
+  // every response. The login screen needs no subject state and is cheapest.
+  await page.goto("/login");
+  await expect(page.getByLabel(/nick or email/i)).toBeVisible({ timeout: 10_000 });
+
+  expect(
+    cspViolations,
+    "the guard must start empty, or the refusals asserted below prove nothing",
+  ).toEqual([]);
+
+  // ── the host the measurement admits ──────────────────────────────────────
+  const allowed = await page.evaluate(async (url) => {
+    try {
+      const res = await fetch(url);
+      return { ok: res.ok, status: res.status, error: "" };
+    } catch (e) {
+      return { ok: false, status: 0, error: String(e) };
+    }
+  }, ALLOWED);
+
+  expect(
+    hits,
+    "the fetch to api.somafm.com must leave the renderer — if connect-src lost the token the " +
+      "request dies at the policy and the route handler never runs",
+  ).toContain("api.somafm.com");
+  expect(allowed, "and the response must come back clean").toMatchObject({ ok: true, status: 200 });
+
+  // ── the two that must not ────────────────────────────────────────────────
+  await page.evaluate(
+    async (urls) => {
+      for (const url of urls) await fetch(url).catch(() => undefined);
+    },
+    [BLOCKED_BARE, BLOCKED_SUBDOMAIN],
+  );
+
+  await expect
+    .poll(() => [...blockedSomafmHosts(cspViolations)].sort(), {
+      timeout: 10_000,
+      message:
+        "connect-src must refuse the bare somafm.com (the wrong-spelling trap) AND a non-api " +
+        "subdomain (the wildcard tripwire). A missing ice.somafm.com here means the policy was " +
+        "widened to https://*.somafm.com, past everything #1695 measured.",
+    })
+    .toEqual(["ice.somafm.com", "somafm.com"]);
+
+  expect(
+    hits.filter((h) => h !== "api.somafm.com"),
+    "a refused host must never reach the network layer",
+  ).toEqual([]);
+
+  const provoked = cspViolations.find((v) => blockedSomafmHosts([v]).size > 0);
+  expect(provoked?.violatedDirective, "the refusal must come from connect-src").toContain(
+    "connect-src",
+  );
+
+  // Drain only what this spec provoked — the suite-wide teardown asserts an
+  // empty array and is right to. Anything else the page produced is a real
+  // finding and must still red it.
+  const kept = cspViolations.filter((v) => blockedSomafmHosts([v]).size === 0);
+  cspViolations.length = 0;
+  cspViolations.push(...kept);
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59830,3 +59830,109 @@ moved to `Grappa.HotReload` (the listener only accumulates modules for a
 section still attributes module reload to `:code.modified_modules/0` +
 `:code.load_file/1`, both of which `Grappa.HotReload`'s moduledoc names as
 tried-and-rejected with live repros.
+<!-- entry #1695 -->
+
+---
+
+## 2026-08-23 — #1695: one CSP host for the SomaFM catalogue, and why the bare-domain pin is the wrong tripwire
+
+`connect-src` blocked the `fetch` of SomaFM's `channels.json`, which is why
+#682 shipped a curated station table rather than the live catalogue — the
+reasoning is written out at the top of `radioStations.ts`. vjt approved
+widening the policy. The issue arrived titled `*.somafm.com` and carrying a
+measurement that says something narrower; the measurement won.
+
+### What was measured
+
+The live catalogue, re-measured rather than taken from the issue: 46
+channels, 425 absolute URLs, classified by host and by the directive that
+governs each kind.
+
+| kind | `api.somafm.com` | `somafm.com` | directive |
+|---|---|---|---|
+| `.pls` playlists | 184 | 0 | `connect-src` — fetched and parsed |
+| logos | 138 | 0 | `img-src https:` — already passes |
+| prerolls (`.m4a`) | 0 | 103 | `media-src https:` — already passes |
+
+184 of 184 connect-src-governed URLs are on `api.somafm.com`. No other somafm
+subdomain appears in the catalogue at all. `channels.json` and
+`songs/<id>.json` answer byte-identically from either host (52,852 and 2,576
+bytes, both), so a client can address the API host and stay in one origin.
+
+### Why one host and not the wildcard
+
+`https://*.somafm.com` would hand `fetch` to every present and future somafm
+subdomain — ice, ice2..6, hls — with nothing measured asking for it. It would
+also not cover the bare `somafm.com`, because a CSP host-source spelled `*.`
+requires at least one label. So the wildcard is strictly wider where it costs
+and no wider where it might have helped. Widening a CSP past the measurement
+is a security regression; the shipped token is `https://api.somafm.com`.
+
+The consequence lands on a future client author and is recorded in the plug's
+moduledoc, where they will read it: the short spelling works under `curl` and
+dies at the policy.
+
+### The header alone does not make the catalogue load
+
+Nothing in `cicchetto/src` fetches somafm today — the station table is baked
+in. This change removes the server-side blocker #682 named; the live-catalogue
+swap is the follow-up the issue itself puts out of scope. The issue's own
+verification step "load the player and confirm `channels.json` fetches" is
+therefore not executable at this commit, and saying so is cheaper than a
+reader later concluding the change did not work.
+
+### Why the bare-domain pin is not the tripwire it looks like
+
+The reflex when narrowing a CSP is to pin the host you refused — here, the
+bare `somafm.com`. That pin is worth having: identical bytes from both hosts
+make the short spelling the likely client mistake, and the refusal should red
+in CI rather than in a browser console.
+
+But it does **not** catch the regression it appears to catch, and this was
+measured rather than reasoned. The policy was mutated to
+`https://*.somafm.com` and the spec re-run against a real chromium through
+the e2e stack. Result: `https://somafm.com/channels.json` was **still
+blocked** — `violatedDirective: connect-src`, collected by the suite's own
+guard — while `ice.somafm.com` sailed through. That is the `*.` label rule
+observed in a browser instead of cited from CSP3: the wildcard refuses the
+bare domain too, so a bare-domain assertion stays green straight through the
+widening it was added to detect.
+
+The stimulus that separates the shipped policy from the wildcard is a somafm
+subdomain that is **not** the API. `issue1695-somafm-connect-src-perimeter.spec.ts`
+provokes both and asserts the blocked set is exactly
+`{somafm.com, ice.somafm.com}`; the wildcard mutant reduces it to
+`{somafm.com}` and reds.
+
+General rule, and the reason this is written down: **a pin against widening
+must be stimulated by something the WIDER policy would admit.** A stimulus
+both policies refuse measures nothing about the boundary between them — it
+reads like a perimeter test and is one only by coincidence of naming.
+
+The bench also killed the opposite mutant: with the token removed entirely,
+the allowed fetch never reaches the interceptor (`hits` empty) and the spec
+reds on the admission half. Both directions are covered.
+
+### Test shape
+
+`security_headers_test.exs` already held a byte-for-byte golden pin. It is a
+good drift catcher and a poor contract: updating it is the same edit as making
+the change, so on its own it lets a widening land with no statement of what
+was measured. Three tests were added beside it that parse the emitted policy
+into directive → sources and assert what it ADMITS — the host present, the
+host not spelled as a wildcard, and no other directive carrying a somafm
+source. They survive a reformat of the literal and fail on the two mistakes
+that matter.
+
+The e2e is the other half, and a genuinely different question: the plug test
+proves the string, only a browser proves the string is honoured. Interception
+(`page.route`) fulfils the allowed fetch, so the assertion is about the policy
+and a somafm outage cannot turn the gate red — the same rule #682 set for the
+station table. Hosts are routed one literal at a time on purpose: routing them
+through a `*.somafm.com` glob would make the harness agree with a widened
+policy by construction.
+
+### Deploy class
+
+HOT. The policy is a module attribute in `lib/grappa_web/plugs/security_headers.ex`,
+not `config/*.exs` — a recompiled `.beam`, no `VERSION` bump, no migration.

--- a/lib/grappa_web/plugs/security_headers.ex
+++ b/lib/grappa_web/plugs/security_headers.ex
@@ -37,7 +37,8 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
 
     * `default-src 'self'` — same-origin baseline.
     * `connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com
-      https://litterbox.catbox.moe` — REST + WS to grappa (same-origin: `'self'`
+      https://litterbox.catbox.moe https://api.somafm.com` — REST + WS to grappa
+      (same-origin: `'self'`
       covers `ws://$host` / `wss://$host` per CSP3, so this is deployment-host
       agnostic — no edit when `PHX_HOST` changes); Cloudflare Turnstile +
       hCaptcha verification XHRs; `litterbox.catbox.moe` receives cic's
@@ -45,6 +46,24 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
       its OWN — since #1240 a click on that link renders the image in the media
       viewer, but the widened `img-src https:` below already covers it. IRC
       stays text only (CLAUDE.md): the modal is on-click, never on arrival.
+      `api.somafm.com` (#1695) is the SomaFM catalogue: `channels.json` and the
+      `.pls` playlists it points at are `fetch`ed and parsed, so they fall here
+      and not on the `media-src`/`img-src` widenings that already carry the
+      streams and the logos. **It is ONE host and not `https://*.somafm.com`,
+      deliberately.** Measured over the live catalogue on 2026-08-23 — 46
+      channels, 425 absolute URLs — every URL this directive governs is on
+      `api.somafm.com` (184/184 `.pls`), the 138 logos are `img-src https:` and
+      the 103 prerolls are `media-src https:`; the bare `somafm.com` carries
+      the prerolls and nothing else. The wildcard would hand `fetch` to every
+      present and future somafm subdomain (ice, ice2..6, hls) with nothing
+      measured asking for it, and it would not even cover the bare domain — a
+      host-source spelled `*.` requires at least one label. CONSEQUENCE FOR A
+      CLIENT AUTHOR: the catalogue answers byte-identically from either host
+      (52,852 bytes for `channels.json` from both), so a `fetch` aimed at
+      `https://somafm.com/...` works under `curl` and dies here. Aim it at
+      `api.somafm.com`; `issue1695-somafm-connect-src-perimeter.spec.ts` pins
+      both that refusal and the non-api subdomain that separates this policy
+      from the wildcard.
     * `script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM='
       https://challenges.cloudflare.com https://*.hcaptcha.com` — Vite modules +
       the Turnstile / hCaptcha widget loaders. Each loader injects a small
@@ -105,7 +124,7 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
 
   import Plug.Conn
 
-  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   # HTTP header names are lower-cased (HTTP/2 + Plug convention); the VALUES
   # are byte-identical to the retired nginx snippet.

--- a/test/grappa_web/plugs/security_headers_test.exs
+++ b/test/grappa_web/plugs/security_headers_test.exs
@@ -21,10 +21,10 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
   alias GrappaWeb.Plugs.SecurityHeaders
 
   # The plug's Content-Security-Policy SSOT (was byte-identical to the
-  # deleted nginx snippet; #607 widened media-src to https:, #1240 img-src).
-  # If the app must change the policy, change it in ONE place (the plug) and
-  # update this pin deliberately.
-  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  # deleted nginx snippet; #607 widened media-src to https:, #1240 img-src,
+  # #1695 added ONE connect-src host). If the app must change the policy,
+  # change it in ONE place (the plug) and update this pin deliberately.
+  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   defp sent(status) do
     :get

--- a/test/grappa_web/plugs/security_headers_test.exs
+++ b/test/grappa_web/plugs/security_headers_test.exs
@@ -33,6 +33,65 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
     |> send_resp(status, "body")
   end
 
+  # Parse the EMITTED policy into %{directive => MapSet.t(source)}. The golden
+  # pin above catches byte drift; the #1695 tests below need to ask what a
+  # directive ADMITS, and re-typing the expected string to answer that would
+  # make them mirrors of the implementation instead of assertions about it.
+  defp directives do
+    SecurityHeaders.csp()
+    |> String.split(";", trim: true)
+    |> Map.new(fn directive ->
+      [name | sources] = directive |> String.trim() |> String.split(" ", trim: true)
+      {name, MapSet.new(sources)}
+    end)
+  end
+
+  describe "#1695 — the SomaFM catalogue host on connect-src" do
+    # Measured against the live catalogue (46 channels, 425 absolute URLs,
+    # 2026-08-23): the 184 `.pls` playlist URLs — the only kind a client
+    # FETCHES, and so the only kind `connect-src` governs — are 184/184 on
+    # `api.somafm.com`. The 138 logos ride `img-src https:` and the 103
+    # prerolls ride `media-src https:`, both already wide enough, and the
+    # prerolls are the only thing on the bare `somafm.com` at all.
+    test "connect-src admits the catalogue host" do
+      assert MapSet.member?(directives()["connect-src"], "https://api.somafm.com"),
+             "connect-src must admit https://api.somafm.com — it is the host every " <>
+               "connect-src-governed SomaFM URL lives on."
+    end
+
+    # `https://*.somafm.com` (the issue TITLE's spelling) is wider than the
+    # measurement: it admits every present and future somafm subdomain —
+    # ice/ice2..6, hls — for `fetch`, and not one of them appears in the
+    # catalogue's connect-src set. It also does NOT match the bare
+    # `somafm.com` (a CSP host-source with `*.` requires at least one label),
+    # so it buys nothing for the prerolls either. Widening past the measured
+    # host is a security regression, not a convenience.
+    test "connect-src stays at the measured host, not a somafm wildcard" do
+      somafm =
+        directives()["connect-src"]
+        |> Enum.filter(&String.contains?(&1, "somafm.com"))
+        |> Enum.sort()
+
+      assert somafm == ["https://api.somafm.com"],
+             "connect-src must carry exactly the measured host and no wildcard; got " <>
+               inspect(somafm)
+    end
+
+    # #1695 is a one-token change. Its own verification step says so: the
+    # logos and prerolls already pass on directives that must not move.
+    test "no directive other than connect-src gained a somafm source" do
+      leaked =
+        for {name, sources} <- directives(),
+            name != "connect-src",
+            source <- sources,
+            String.contains?(source, "somafm"),
+            do: {name, source}
+
+      assert leaked == [],
+             "only connect-src needed widening; somafm leaked into " <> inspect(leaked)
+    end
+  end
+
   test "csp/0 matches the golden pin (SSOT, incl. the #607 media-src + #1240 img-src https: widenings)" do
     assert SecurityHeaders.csp() == @golden_csp
   end


### PR DESCRIPTION
## What

`connect-src` gains **one** host, `https://api.somafm.com`, so a client can
`fetch` the SomaFM catalogue. Approved widening (#1695).

## Why this shape and not the wildcard in the issue title

The catalogue was re-measured rather than taken on trust — 46 channels, 425
absolute URLs, classified by host and by the directive that governs each kind:

| kind | `api.somafm.com` | `somafm.com` | directive |
|---|---|---|---|
| `.pls` playlists | **184** | 0 | `connect-src` |
| logos | 138 | 0 | `img-src https:` — already passes |
| prerolls | 0 | 103 | `media-src https:` — already passes |

184 of 184 connect-src-governed URLs sit on `api.somafm.com`; no other somafm
subdomain appears at all. `https://*.somafm.com` would hand `fetch` to every
present and future subdomain with nothing measured asking for it, and would not
even cover the bare `somafm.com` — a host-source spelled `*.` requires at least
one label. Widening a CSP past the measurement is a security regression.

Both hosts answer the catalogue byte-identically (52,852 bytes for
`channels.json`), so a client author gets a working `curl` and a blocked
`fetch` from the short spelling. The plug moduledoc says so where they will
read it.

## Scope, stated rather than implied

**This header alone does not make the catalogue load.** Nothing in
`cicchetto/src` fetches somafm today — the station table is baked in (#682).
This removes the server-side blocker that #682 named; the live-catalogue swap
stays the follow-up the issue itself puts out of scope.

## Tests

The existing golden pin is a byte-for-byte drift catcher and a poor contract:
updating it is the same edit as making the change. Three tests were added that
parse the emitted policy into directive → sources and assert what it ADMITS —
host present, host not spelled as a wildcard, no other directive carrying a
somafm source. Red before the change: 8 tests, 2 failures.

The e2e answers the different question — does a browser honour it, and what
does the policy still refuse. Its load-bearing stimulus is `ice.somafm.com`,
not the bare domain, and that choice was measured: mutating the policy to
`https://*.somafm.com` leaves `https://somafm.com/channels.json` **still
blocked** while `ice.somafm.com` passes, so a bare-domain-only pin would stay
green straight through the widening it was added to catch.

Mutants killed, both directions: token removed → the allowed fetch never
reaches the interceptor; wildcard → the blocked set drops to `{somafm.com}`.

All three somafm hosts are intercepted, so no gate here depends on somafm
being up.

## Deploy class

**HOT.** The policy is a module attribute in `lib/`, not `config/*.exs` — a
recompiled `.beam`, no `VERSION` bump, no migration.

## Gates

`test.sh` (3 CSP surfaces) 33/0 · `bun.sh run check` 4/4 · dialyzer 0 errors ·
credo / sobelow / deps.audit / doctor green · `gen_wire_types --check` in sync ·
`wire_pin --check` ok · bats 375/375 · `integration.sh` full suite 766 passed,
1 unrelated flake (`ux-5-bs-resizable-sidebars`, breaks in the shared `loginAs`
helper, 5/5 green on iso-rerun) · `union-rebase.sh` +106 -0.

`mix test` also reds on `Grappa.Repo.LockWatchTest` (#1687) — a known main
defect reproducing on three independent branches, untouched here.
