### PR TITLE
#1094: bind the prepend preserve to the commit, and float a spinner while the page is on the wire

### DIFF
--- a/cicchetto/e2e/tests/issue1094-prepend-preserve-commit.spec.ts
+++ b/cicchetto/e2e/tests/issue1094-prepend-preserve-commit.spec.ts
@@ -34,6 +34,15 @@
 // deliberately not folded in: the tolerance below is wide enough to survive
 // that residue and narrow enough that the ~150px this issue is about cannot
 // hide inside it.
+//
+// IT DISCRIMINATES, measured 2026-08-24. Reverting the cure to the pre-#1094
+// shape — geometry captured before the `loadMoreScrollback` call instead of at
+// its commit seam — fails this test on the anchor assertion at
+// `Received: 150.5625` against a tolerance of 12, i.e. `ARM_AT_PX` to within
+// half a pixel, exactly the error the restore makes and nothing else. With the
+// cure in place the same run is green. A green here that has never been shown
+// that red is not a guard, and this file spent three runs being red for a
+// reason that had nothing to do with either (see the route hold below).
 
 import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";

--- a/cicchetto/e2e/tests/issue1094-prepend-preserve-commit.spec.ts
+++ b/cicchetto/e2e/tests/issue1094-prepend-preserve-commit.spec.ts
@@ -1,0 +1,198 @@
+// #1094 — paging older history must not move the rows the operator is reading,
+// even when they keep scrolling while the page is on the wire.
+//
+// The field report (vjt, 2026-08-23): *"salire e ripescare messaggi vecchi
+// smuove tutto l'elenco e non è smooth per niente. arrivare in area di fetch
+// in sostanza che causa il prelevamento dei vecchi messaggi sposta lo
+// scrolltop e quindi sposta i messaggi visualizzati"*.
+//
+// WHY THIS SPEC EXISTS AND THE UNIT TESTS DO NOT COVER IT. The units
+// (`scrollback.test.ts` #1094, `ScrollbackPane.test.tsx` #1094) pin the
+// MECHANISM: which instant the geometry is read at, and that the correction
+// lands in the same task as the mutation. They cannot pin the OUTCOME, because
+// jsdom has no layout engine — every px in them is a `defineProperty`, so a
+// change that kept the arithmetic and broke the rendered result would leave
+// them green. What the operator reports is rendered geometry, and the only
+// oracle for rendered geometry is a real browser.
+//
+// The oracle here is deliberately NOT frame sampling. A composited-frame probe
+// is what measured the original defect (see the issue), but it needs a bespoke
+// rAF harness and it answers a question that is inherently one frame wide. The
+// durable statement is about an END STATE: pick a row the reader is looking at,
+// note where it sits in the viewport, page older history in underneath it, and
+// it must still be in the same place. That survives a retry, a slower CI box
+// and a different page size.
+//
+// CP14 B2 already pins the same gesture, but from `scrollTop === 0`: it wheels
+// all the way to the top in one throw, so the geometry at the moment the fetch
+// is armed and the geometry at the moment it lands are the same numbers, and
+// the defect is invisible. THE WHOLE POINT here is that they differ — the
+// operator's flick carries on while the request is in flight, which is what an
+// operator's flick does.
+//
+// #1151 (the frozen pane moving 11px for an 18px insertion) is ADJACENT and
+// deliberately not folded in: the tolerance below is wide enough to survive
+// that residue and narrow enough that the ~150px this issue is about cannot
+// hide inside it.
+
+import type { Page } from "@playwright/test";
+import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import { fetchAllMessagesAsc, setReadCursorToId } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// REST default page size (Grappa.Web.MessagesController.@default_limit).
+const REST_PAGE_SIZE = 50;
+
+// Mirror of ScrollbackPane.LOAD_MORE_THRESHOLD_PX (not exported). Same
+// re-declaration + same lockstep caveat as cp14-b2.
+const LOAD_MORE_THRESHOLD_PX = 200;
+
+// Where the first wheel parks the reader: inside the threshold, so the fetch
+// is armed, but well clear of 0, so there is room left to scroll DURING it.
+// The distance between this and 0 is exactly the error the old shape made.
+const ARM_AT_PX = 150;
+
+// How long the older page is held on the wire. Long enough to complete a
+// second wheel gesture inside it and still leave slack on a loaded CI box.
+const FETCH_HOLD_MS = 1_500;
+
+// Anchor drift we accept. Zero is not honest: sub-pixel layout, the row's own
+// line-box rounding, and the #1151 residue all live below this. The defect
+// this spec guards is ARM_AT_PX wide.
+const ANCHOR_TOLERANCE_PX = 12;
+
+async function scrollTop(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    return el.scrollTop;
+  });
+}
+
+// The id of the first row whose box is fully inside the viewport — the row the
+// reader is looking at, and the thing that must not move. Read by id rather
+// than by index: the prepend changes every row's index by definition.
+async function topVisibleRowId(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    const paneTop = el.getBoundingClientRect().top;
+    for (const row of Array.from(
+      el.querySelectorAll<HTMLElement>(".scrollback-line[data-msg-id]"),
+    )) {
+      if (row.getBoundingClientRect().top >= paneTop) {
+        const id = row.dataset.msgId;
+        if (id !== undefined) return id;
+      }
+    }
+    throw new Error("no fully-visible scrollback row found");
+  });
+}
+
+// That row's offset from the top of the pane, in viewport px.
+async function rowOffsetFromPaneTop(page: Page, msgId: string): Promise<number> {
+  return await page.evaluate((id) => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    const row = el.querySelector<HTMLElement>(`.scrollback-line[data-msg-id="${id}"]`);
+    if (!row) throw new Error(`anchor row ${id} left the DOM`);
+    return row.getBoundingClientRect().top - el.getBoundingClientRect().top;
+  }, msgId);
+}
+
+async function wheelOverScrollback(page: Page, deltaY: number): Promise<void> {
+  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
+  if (!box) throw new Error("scrollback bounding box null");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, deltaY);
+}
+
+test.describe("#1094 — the prepend preserve reads the geometry at the commit", () => {
+  // Same tiny viewport as CP14 B1/B2: it guarantees the initial REST page
+  // overflows, so there is a scroll position to preserve at all.
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  test("an anchor row does not move when older history lands mid-flick", async ({ page }) => {
+    const vjt = specUser();
+
+    // Read cursor at the tail before login, exactly as CP14 B2 explains: it
+    // is what makes the channel hydrate through the cursor-PRESENT arm and
+    // open on the ~50-row read-context page, leaving older rows to fetch.
+    const seeded = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    const tail = seeded[seeded.length - 1];
+    if (!tail) throw new Error("#1094: seeded corpus is empty");
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, tail.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+
+    const initialCount = await scrollbackLines(page).count();
+    // Same precondition guard as CP14 B2: with the whole corpus already in the
+    // pane there is no older page to fetch and a green run would mean nothing.
+    expect(initialCount).toBeLessThan(seeded.length);
+
+    // Hold the older page on the wire. Installed only NOW: the initial load
+    // uses the same `before=` route and delaying it would just slow the setup.
+    await page.route("**/api/networks/**/messages?**", async (route) => {
+      if (!route.request().url().includes("before=")) {
+        await route.continue();
+        return;
+      }
+      await new Promise((r) => setTimeout(r, FETCH_HOLD_MS));
+      await route.continue();
+    });
+
+    // First flick: land inside the threshold but NOT at the top. This is what
+    // arms the fetch, and the geometry here is what the pre-#1094 shape spent.
+    const from = await scrollTop(page);
+    expect(from).toBeGreaterThan(LOAD_MORE_THRESHOLD_PX);
+    await wheelOverScrollback(page, -(from - ARM_AT_PX));
+    await expect
+      .poll(async () => await scrollTop(page), { timeout: 5_000 })
+      .toBeLessThanOrEqual(LOAD_MORE_THRESHOLD_PX);
+
+    // CALIBRATION. Everything below is meaningless if the hold did not take:
+    // a fetch that returns instantly leaves no window to scroll inside, the
+    // second flick lands after the commit, and both shapes pass. The loading
+    // affordance IS the observable that the request is still out — so this
+    // arm proves the injected delay AND covers the issue's second half in one
+    // assertion. If it ever fails, the spec below is not measuring #1094.
+    await expect(page.getByTestId("scrollback-loading-older")).toBeVisible({ timeout: 5_000 });
+
+    // Second flick, WHILE the page is in flight: the operator carries on to
+    // the very top. Nothing about this reaches the armed request.
+    await wheelOverScrollback(page, -100_000);
+    await expect.poll(async () => await scrollTop(page), { timeout: 5_000 }).toBe(0);
+
+    // The row the reader is now looking at, and where it sits. Captured with
+    // the fetch still out, so it is the state the commit has to preserve.
+    await expect(page.getByTestId("scrollback-loading-older")).toBeVisible();
+    const anchorId = await topVisibleRowId(page);
+    const before = await rowOffsetFromPaneTop(page, anchorId);
+
+    // Let the page land.
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 15_000 })
+      .toBeGreaterThan(initialCount);
+    // …and the affordance comes back down with it (the DirectoryPane lesson:
+    // a spinner that outlives the commit is worse than none).
+    await expect(page.getByTestId("scrollback-loading-older")).toBeHidden({ timeout: 5_000 });
+
+    const after = await rowOffsetFromPaneTop(page, anchorId);
+
+    // THE ASSERTION. Rows were inserted above this one; it must not have
+    // moved. The pre-#1094 shape restored to `delta + 150` — the scrollTop the
+    // reader had when the gesture crossed the threshold, not the 0 they
+    // actually reached — so the anchor came out ~ARM_AT_PX lower than here.
+    expect(Math.abs(after - before)).toBeLessThanOrEqual(ANCHOR_TOLERANCE_PX);
+
+    await page.unroute("**/api/networks/**/messages?**");
+  });
+});

--- a/cicchetto/e2e/tests/issue1094-prepend-preserve-commit.spec.ts
+++ b/cicchetto/e2e/tests/issue1094-prepend-preserve-commit.spec.ts
@@ -140,7 +140,17 @@ test.describe("#1094 — the prepend preserve reads the geometry at the commit",
 
     // Hold the older page on the wire. Installed only NOW: the initial load
     // uses the same `before=` route and delaying it would just slow the setup.
-    await page.route("**/api/networks/**/messages?**", async (route) => {
+    //
+    // MATCHED BY REGEX, and that is the whole spec's load-bearing detail. The
+    // first three runs of this file used the glob `**/api/networks/**/messages?**`
+    // and it matched NOTHING: cic fetches `/networks/<slug>/channels/<name>/
+    // messages?before=<id>` — there is no `/api` segment, the router mounts
+    // this under `scope "/networks/:network_id"`. So the hold was INERT, the
+    // older page landed in under 100ms, and the second flick below always
+    // arrived after the commit instead of during it. The regex is also the
+    // house pattern for this endpoint (`delayMessageFetches` in
+    // issue1089-switch-into-unread-flicker.spec.ts).
+    await page.route(/\/messages(\?|$)/, async (route) => {
       if (!route.request().url().includes("before=")) {
         await route.continue();
         return;
@@ -193,6 +203,6 @@ test.describe("#1094 — the prepend preserve reads the geometry at the commit",
     // actually reached — so the anchor came out ~ARM_AT_PX lower than here.
     expect(Math.abs(after - before)).toBeLessThanOrEqual(ANCHOR_TOLERANCE_PX);
 
-    await page.unroute("**/api/networks/**/messages?**");
+    await page.unroute(/\/messages(\?|$)/);
   });
 });

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -51,6 +51,7 @@ import { isSettled, nextFollowMode, resolveIntent, type ScrollIntent } from "./l
 import {
   dismissFarBehind,
   farBehindByChannel,
+  isLoadingOlder,
   jumpToUnread,
   lastOwnSend,
   loadMore as loadMoreScrollback,
@@ -3843,6 +3844,39 @@ const ScrollbackPane: Component<Props> = (props) => {
             </button>
           </div>
         )}
+      </Show>
+      {/* #1094 — the older-page fetch affordance. Before this the pane had no
+          loading state at all on this path: the operator scrolled to the top,
+          a request went out, and for the whole round trip the pane was
+          indistinguishable from one that had reached the beginning of history.
+          Nothing else in the pane announces it, so this carries `role=status`
+          (unlike `.directory-pull-spinner`, which is aria-hidden because the
+          Refresh button it accompanies already says "Refreshing…").
+
+          FLOATING, not a slot above the first row, and that is the whole
+          design decision (DESIGN_NOTES 2026-08-24). An in-flow slot is a
+          second height change on the exact quantity `applyPrependPreserve`
+          compensates, and it has TWO edges, not one: it grows the list the
+          moment the fetch starts — which nothing compensates, so the cure for
+          a jump at t=RTT would open a new one at t=0 — and it shrinks it again
+          at the commit, where it only cancels out if it lands in the very same
+          flush as the prepend. Floating has neither edge by construction: it
+          is not inside `.scrollback`, so it is not in its `scrollHeight`. This
+          pane already made the same call once, for the same reason, and paid
+          for the in-flow version first — see the `.scrollback-overlay` comment
+          above ("rendered as flex siblings BEFORE `.scrollback` they shrank
+          the scroll list on mount, shifting the reader's anchor"). The one
+          thing an in-flow slot buys — reserving the space the page will fill —
+          it does not actually buy: a ring is ~18px and a page is ~1000. */}
+      <Show when={isLoadingOlder(props.networkSlug, props.channelName)}>
+        <div
+          class="scrollback-loading-older"
+          data-testid="scrollback-loading-older"
+          role="status"
+          aria-label="Loading older messages"
+        >
+          <span class="scrollback-loading-older-spinner" />
+        </div>
       </Show>
       <div
         ref={listRef}

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -3087,18 +3087,23 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (winner) dispatchScrollWrite(winner);
   };
 
-  // #608 (deep-review §6.4) — the prepend-preserve applier entrypoint. UNLIKE
-  // the commit-frame intents, loadMore preserve is POST-AWAIT: an older page is
-  // fetched, PREPENDED, and the reader's on-screen row must stay put across that
-  // mutation. It is a DISTINCT entrypoint (not `resolveIntent` at the commit
-  // frame) because the restore needs the geometry captured BEFORE the await and
-  // runs on the commit AFTER the prepend lands — the commit-frame length-effect
-  // already ran for that same rows() change and, per the followMode gate, left a
-  // scrolled-up reader in place. `prepend-preserve` is the LOWEST precedence in
-  // the array: it never fights a higher authority because it fires only on the
-  // operator's own scroll-to-top / #230 underfill-rescue, when nothing higher is
-  // arming. The single owner of the W6 write; logs via the shared dev-log.
-  // `oldScrollHeight` / `oldScrollTop` are the geometry captured pre-await.
+  // #608 (deep-review §6.4) — the prepend-preserve applier entrypoint. An older
+  // page is fetched, PREPENDED, and the reader's on-screen row must stay put
+  // across that mutation. It is a DISTINCT entrypoint (not `resolveIntent` at
+  // the commit frame) because the restore needs a BEFORE and an AFTER reading
+  // of the same geometry, which a single commit-frame pass cannot give it — the
+  // length-effect already ran for that same rows() change and, per the
+  // followMode gate, left a scrolled-up reader in place. `prepend-preserve` is
+  // the LOWEST precedence in the array: it never fights a higher authority
+  // because it fires only on the operator's own scroll-to-top / #230
+  // underfill-rescue, when nothing higher is arming. The single owner of the W6
+  // write; logs via the shared dev-log.
+  //
+  // #1094 — `oldScrollHeight` / `oldScrollTop` are read at the store's commit
+  // seam, one statement before the prepend lands; this runs one statement
+  // after it, in the same task. They used to be a pre-await snapshot spent in
+  // the verb's `.then()`, which is what this issue removed — see
+  // `maybeLoadOlder`. The arithmetic is unchanged; only its two instants are.
   const applyPrependPreserve = (oldScrollHeight: number, oldScrollTop: number): void => {
     if (!listRef) return;
     const intent: ScrollIntent = { kind: "prepend-preserve", key: key(), lifetime: "one-shot" };
@@ -3389,10 +3394,17 @@ const ScrollbackPane: Component<Props> = (props) => {
   // jump to the new top (scrollTop=0 stays pinned) — where they were already
   // looking — or stay numerically pinned to scrollTop=N relative to the OLD
   // scrollHeight, which is now a different position relative to the new
-  // content. We capture (scrollHeight, scrollTop) BEFORE the await, then the
-  // #608 applier's post-await `applyPrependPreserve` restores the reader's row
-  // via the height delta (see its doc). DOM mutation lives here in the
+  // content. The #608 applier's `applyPrependPreserve` restores the reader's
+  // row via the height delta (see its doc). DOM mutation lives here in the
   // component; lib/scrollback.ts stays DOM-free.
+  //
+  // #1094 — the geometry is read at the verb's COMMIT SEAM, not before the
+  // call. It used to be captured here and spent in the returned promise's
+  // `.then()`, which made both terms of the delta a round trip old: the
+  // operator goes on scrolling past the 200px that armed the fetch, and live
+  // rows go on appending at the tail, so the restore aimed at where the reader
+  // WAS and dragged the pane out from under them by the difference (vjt, from
+  // the field, on the ordinary scroll-to-top gesture). See `PrependCommitSeam`.
   const maybeLoadOlder = (): void => {
     if (!listRef) return;
     if (listRef.scrollTop > LOAD_MORE_THRESHOLD_PX) return;
@@ -3400,11 +3412,15 @@ const ScrollbackPane: Component<Props> = (props) => {
     // yanking this (it re-asserts ONLY when a marker exists; a no-marker latch
     // falls through to the followMode tail-follow, which preserves here because the
     // operator scrolled UP).
-    const oldScrollHeight = listRef.scrollHeight;
-    const oldScrollTop = listRef.scrollTop;
-    void loadMoreScrollback(props.networkSlug, props.channelName).then(() =>
-      applyPrependPreserve(oldScrollHeight, oldScrollTop),
-    );
+    void loadMoreScrollback(props.networkSlug, props.channelName, () => {
+      // Re-read the ref rather than closing over the one the guard above
+      // proved: this runs a round trip later and the pane can have unmounted.
+      const list = listRef;
+      if (!list) return undefined;
+      const oldScrollHeight = list.scrollHeight;
+      const oldScrollTop = list.scrollTop;
+      return () => applyPrependPreserve(oldScrollHeight, oldScrollTop);
+    });
   };
 
   const onWheel = (e: WheelEvent): void => {

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -106,6 +106,9 @@ const [farBehind, setFarBehind] = createSignal<
 const [measuredUnread, setMeasuredUnread] = createSignal<
   Record<string, { at: number; count: number }>
 >({});
+// #1094 — "an older page is on the wire for this key", the state the loading
+// affordance renders from. Keyed the same way the store keys it.
+const [loadingOlder, setLoadingOlder] = createSignal<Record<string, boolean>>({});
 // Resolves TRUE by default (the swap happened) — the pane chains off the
 // result to stand the marker latch back down on a failed jump.
 const jumpToUnreadSpy = vi.fn((_slug: string, _name: string) => Promise.resolve(true));
@@ -120,6 +123,11 @@ vi.mock("../lib/scrollback", () => ({
   // `loadMore` (production imports it as `loadMore as
   // loadMoreScrollback`).
   loadMore: vi.fn(() => Promise.resolve()),
+  // #1094 — the in-flight read the older-page affordance renders from.
+  // Signal-backed for the same reason `farBehindByChannel` is: a spec drives
+  // the flag AFTER mount and the pane must re-render, which a plain-fn stub
+  // cannot express.
+  isLoadingOlder: (slug: string, name: string) => loadingOlder()[`${slug} ${name}`] ?? false,
   // #161: onScroll also calls `loadNewer` when the pane nears the BOTTOM
   // (forward-paging, production imports it as `loadNewer as
   // loadNewerScrollback`). Same no-op resolved-promise stub so synthetic
@@ -379,6 +387,7 @@ beforeEach(() => {
   setHighlightPatternsForTest([]);
   setDocVisible(true);
   setOwnSend(null);
+  setLoadingOlder({});
   mockMembersByChannel.mockReturnValue({});
   // Reset the C5.0 auto-focus shown-set between tests (test seam, see ScrollbackPane.tsx).
   resetAutoFocusedJoinsForTest();
@@ -1945,6 +1954,52 @@ describe("ScrollbackPane", () => {
       // same task as the mutation. `await waitFor` here would pass on the old
       // shape too — it is exactly the frame this issue is about.
       expect(list.scrollTop).toBe(540);
+    });
+  });
+
+  // #1094 second half — the loading affordance. `ScrollbackPane` had no
+  // loading state at all on this path; the reader stared at a frozen pane for
+  // the length of the fetch with nothing to say a fetch was happening.
+  describe("#1094 — the older-page fetch has a loading affordance", () => {
+    it("shows it while the older page is in flight and drops it when the rows land", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+
+      expect(screen.queryByTestId("scrollback-loading-older")).toBeNull();
+
+      setLoadingOlder({ "freenode #grappa": true });
+      await waitFor(() => expect(screen.queryByTestId("scrollback-loading-older")).not.toBeNull());
+
+      setLoadingOlder({ "freenode #grappa": false });
+      await waitFor(() => expect(screen.queryByTestId("scrollback-loading-older")).toBeNull());
+    });
+
+    it("shows it only for the window doing the fetching", async () => {
+      setScrollback({ "freenode #grappa": fixture, "freenode #other": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+
+      setLoadingOlder({ "freenode #other": true });
+      await waitFor(() => expect(screen.queryByTestId("scrollback-loading-older")).toBeNull());
+    });
+
+    it("keeps the affordance OUT of the scroll container", async () => {
+      // The decision this pins (see DESIGN_NOTES 2026-08-24): the spinner
+      // floats over the pane instead of occupying a slot above the first row.
+      // An in-flow slot is a second height change on the exact quantity
+      // `applyPrependPreserve` compensates — one at mount (uncompensated by
+      // anything, so the cure would open a new jump at t=0) and one at unmount
+      // that has to land in the same flush as the prepend or leave a residue.
+      // Containment is what makes that structurally impossible: an element
+      // outside `.scrollback` cannot be in its `scrollHeight`. The pane made
+      // the same call for the #133 WHOIS/WHOWAS/LUSERS cards, for the same
+      // reason and after paying for the in-flow version once.
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      setLoadingOlder({ "freenode #grappa": true });
+
+      const affordance = await waitFor(() => screen.getByTestId("scrollback-loading-older"));
+      const list = screen.getByTestId("scrollback");
+      expect(list.contains(affordance)).toBe(false);
     });
   });
 

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1833,16 +1833,118 @@ describe("ScrollbackPane", () => {
       Object.defineProperty(list, "scrollTop", { value: 40, writable: true, configurable: true });
       Object.defineProperty(list, "scrollHeight", { value: 1000, configurable: true });
 
-      // loadMore resolves AND simulates the prepend (scrollHeight 1000 → 1500).
-      vi.mocked(loadMore).mockImplementationOnce(() => {
+      // loadMore drives the #1094 commit seam AND simulates the prepend
+      // (scrollHeight 1000 → 1500). The arithmetic pinned here is unchanged by
+      // #1094 — only its transport moved: the geometry used to be read by the
+      // pane before the call and spent in a `.then()`, and is now read at the
+      // seam's open edge and spent at its close edge. Nothing moves during
+      // this fetch, so the two readings coincide and the expected px is the
+      // same 540 it always was. (What #1094 changes is the case where they do
+      // NOT coincide — see the describe below.)
+      vi.mocked(loadMore).mockImplementationOnce((_slug, _name, aroundCommit) => {
+        const committed = aroundCommit();
         Object.defineProperty(list, "scrollHeight", { value: 1500, configurable: true });
+        committed?.();
         return Promise.resolve();
       });
 
       list.dispatchEvent(new Event("scroll"));
 
-      // Post-await restore: 1500 - 1000 + 40 = 540 (the reader's row held).
+      // Restore: 1500 - 1000 + 40 = 540 (the reader's row held).
       await waitFor(() => expect(list.scrollTop).toBe(540));
+    });
+  });
+
+  // #1094 — the preserve is bound to the COMMIT, not to the verb.
+  //
+  // The pane used to read (scrollHeight, scrollTop) BEFORE calling `loadMore`
+  // and spend them in the returned promise's `.then()`. Both numbers are live
+  // DOM geometry and the fetch is a network round trip, so everything that
+  // happens in between moves them under the snapshot: the operator carries on
+  // scrolling upward past the threshold that armed the fetch, and live rows
+  // keep appending at the tail. The restore then aims at where the reader WAS
+  // when the gesture crossed 200px, not where they are — and the pane visibly
+  // shifts under them, which is the field report on the operator's own
+  // scroll-to-top path ("salire e ripescare messaggi vecchi smuove tutto
+  // l'elenco", 2026-08-23).
+  //
+  // The two cases below are the two axes of that: WHICH geometry is spent, and
+  // WHEN it is spent. Both fail on the pre-#1094 shape.
+  describe("#1094 — the prepend preserve reads the geometry at the commit", () => {
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+    beforeEach(() => {
+      // Same isolation as the #608 block above: stub scrollIntoView so the
+      // mount tail-follow never touches scrollTop and the only write under
+      // test is the preserve.
+      origScrollIntoView = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = vi.fn();
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+
+    it("ignores the pre-fetch snapshot when the pane moved during the fetch", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      // The gesture that arms the fetch: scrollTop 40 (<= 200), height 1000.
+      Object.defineProperty(list, "clientHeight", { value: 300, configurable: true });
+      Object.defineProperty(list, "scrollTop", { value: 40, writable: true, configurable: true });
+      Object.defineProperty(list, "scrollHeight", { value: 1000, configurable: true });
+
+      vi.mocked(loadMore).mockImplementationOnce((_slug, _name, aroundCommit) => {
+        // …and this is the fetch. The operator keeps flicking upward and lands
+        // on the very top (40 → 0), and one live row arrives at the tail
+        // (1000 → 1120). Neither is visible to a snapshot taken before the
+        // call, and BOTH are terms in the restore.
+        list.scrollTop = 0;
+        Object.defineProperty(list, "scrollHeight", { value: 1120, configurable: true });
+
+        const committed = aroundCommit();
+        Object.defineProperty(list, "scrollHeight", { value: 1620, configurable: true });
+        committed?.();
+        return Promise.resolve();
+      });
+
+      list.dispatchEvent(new Event("scroll"));
+
+      // Only the 500px the PREPEND added is compensated, onto where the reader
+      // actually is: 1620 - 1120 + 0 = 500. The pre-fetch snapshot would have
+      // answered 1620 - 1000 + 40 = 660 — 160px of pane yanked out from under
+      // them, of which 120 is a live append the prepend never caused.
+      await waitFor(() => expect(list.scrollTop).toBe(500));
+    });
+
+    it("has already compensated by the time the verb resolves", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      Object.defineProperty(list, "clientHeight", { value: 300, configurable: true });
+      Object.defineProperty(list, "scrollTop", { value: 40, writable: true, configurable: true });
+      Object.defineProperty(list, "scrollHeight", { value: 1000, configurable: true });
+
+      // The verb commits the prepend, then keeps going — the store's own
+      // `loadMore` has bookkeeping after its merge, and a future one may grow
+      // more. A restore chained to the RESOLUTION inherits however many awaits
+      // that turns out to be; a restore chained to the commit inherits none.
+      // Here the resolution is deferred by a whole macrotask, which is a frame
+      // the browser is free to paint with the content shifted and scrollTop
+      // untouched.
+      vi.mocked(loadMore).mockImplementationOnce((_slug, _name, aroundCommit) => {
+        const committed = aroundCommit();
+        Object.defineProperty(list, "scrollHeight", { value: 1500, configurable: true });
+        committed?.();
+        return new Promise<void>((resolve) => setTimeout(resolve, 0));
+      });
+
+      list.dispatchEvent(new Event("scroll"));
+
+      // NOT awaited: the assertion is that the write already happened, in the
+      // same task as the mutation. `await waitFor` here would pass on the old
+      // shape too — it is exactly the frame this issue is about.
+      expect(list.scrollTop).toBe(540);
     });
   });
 
@@ -5030,7 +5132,9 @@ describe("ScrollbackPane", () => {
       // scrolls); only the wheel path can rescue the operator.
       list.dispatchEvent(new WheelEvent("wheel", { deltaY: -120, bubbles: true }));
 
-      await waitFor(() => expect(loadMore).toHaveBeenCalledWith("freenode", "#grappa"));
+      await waitFor(() =>
+        expect(loadMore).toHaveBeenCalledWith("freenode", "#grappa", expect.any(Function)),
+      );
     });
 
     it("wheel-DOWN on a non-overflowing pane does NOT call loadMore", async () => {
@@ -5475,7 +5579,9 @@ describe("ScrollbackPane", () => {
       fireTouch(list, "touchstart", 100);
       fireTouch(list, "touchmove", 260);
 
-      await waitFor(() => expect(loadMore).toHaveBeenCalledWith("freenode", "#grappa"));
+      await waitFor(() =>
+        expect(loadMore).toHaveBeenCalledWith("freenode", "#grappa", expect.any(Function)),
+      );
     });
 
     it("finger drag UP on an underfilled pane does NOT call loadMore", async () => {

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -194,6 +194,10 @@ vi.mock("../lib/scrollback", () => ({
   // contiguous pane, which is what every Shell render test wants; the
   // far-behind rendering itself is pinned in ScrollbackPane.test.tsx.
   farBehindByChannel: () => ({}),
+  // #1094 — ScrollbackPane renders its older-page loading affordance from
+  // this. Static false: no Shell test drives a scroll-to-top fetch, and the
+  // affordance itself is pinned in ScrollbackPane.test.tsx.
+  isLoadingOlder: () => false,
   jumpToUnread: vi.fn(() => Promise.resolve(true)),
   dismissFarBehind: vi.fn(),
 }));

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -181,6 +181,7 @@ const MIRRORS: readonly Mirror[] = [
   ),
   ...[
     "e2e/tests/cp14-b2-scroll-up-loadmore.spec.ts",
+    "e2e/tests/issue1094-prepend-preserve-commit.spec.ts",
     "e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts",
   ].map(
     (file): Mirror => ({

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -57,6 +57,12 @@ vi.mock("../lib/readCursor", () => ({
     mockSetReadCursor(bearer, slug, chan, id),
 }));
 
+// #1094 — `loadMore` brackets its prepend with a commit seam supplied by the
+// caller (the pane restores the reader's scroll position across it). Cases
+// that are not about the seam pass this: returning `undefined` is the
+// contract's own way of saying "I want neither edge", not a stub.
+const noSeam = (): undefined => undefined;
+
 beforeEach(() => {
   vi.resetModules();
   localStorage.clear();
@@ -221,7 +227,7 @@ describe("scrollback verbs", () => {
         meta: {},
       },
     ]);
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     const key = channelKey("freenode", "#grappa");
     // CP29 R-2: cursor flipped from oldest.server_time (500) to oldest.id (5).
     expect(api.listMessages).toHaveBeenLastCalledWith("tok", "freenode", "#grappa", 5);
@@ -797,8 +803,8 @@ describe("loadMore — B2 concurrency guard + end-of-history latch", () => {
     const scrollback = await import("../lib/scrollback");
     seedOne(scrollback);
     // Fire two loadMore calls back-to-back without awaiting the first.
-    const p1 = scrollback.loadMore("freenode", "#grappa");
-    const p2 = scrollback.loadMore("freenode", "#grappa");
+    const p1 = scrollback.loadMore("freenode", "#grappa", noSeam);
+    const p2 = scrollback.loadMore("freenode", "#grappa", noSeam);
     // The second call should resolve immediately (no-op) without
     // adding a second REST request.
     expect(api.listMessages).toHaveBeenCalledTimes(1);
@@ -828,13 +834,13 @@ describe("loadMore — B2 concurrency guard + end-of-history latch", () => {
     const scrollback = await import("../lib/scrollback");
     seedOne(scrollback);
     // First loadMore: REST returns [] → exhausted latch fires.
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
     // Second loadMore: latch makes this a no-op (no REST).
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
     // Third loadMore: still latched.
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
   });
 
@@ -855,7 +861,7 @@ describe("loadMore — B2 concurrency guard + end-of-history latch", () => {
     ]);
     const scrollback = await import("../lib/scrollback");
     seedOne(scrollback);
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
     // Fresh page came back non-empty → not exhausted. Second call,
     // serial (in-flight cleared), fires a second REST request.
@@ -871,7 +877,7 @@ describe("loadMore — B2 concurrency guard + end-of-history latch", () => {
         meta: {},
       },
     ]);
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(2);
   });
 
@@ -881,13 +887,147 @@ describe("loadMore — B2 concurrency guard + end-of-history latch", () => {
     vi.mocked(api.listMessages).mockRejectedValueOnce(new Error("boom"));
     const scrollback = await import("../lib/scrollback");
     seedOne(scrollback);
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
     // Failed call must NOT latch as exhausted — error is transient.
     // User scrolls again; REST retries.
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(2);
+  });
+
+  // #1094 — the prepend commit seam.
+  //
+  // `loadMore` used to be a verb with no seam at all: the pane read its
+  // geometry BEFORE calling it and restored the reader's position from the
+  // returned promise's `.then()`. Everything that happens in between — the
+  // operator carrying on scrolling for the length of the fetch, live rows
+  // appending at the tail — moves the very numbers that restore is computed
+  // from, and it never learned about any of it.
+  //
+  // These pin both edges observably, by reading the store's OWN row count
+  // from inside the callbacks: that is the only evidence saying WHEN they ran
+  // relative to the mutation, and it says it without asserting a call
+  // sequence. The pane's half is in `ScrollbackPane.test.tsx`.
+  describe("#1094 — the commit seam brackets the prepend", () => {
+    const older = (id: number): ScrollbackMessage => ({
+      id,
+      network: "freenode",
+      channel: "#grappa",
+      server_time: id * 10,
+      kind: "privmsg",
+      sender: "bob",
+      body: `older ${id}`,
+      meta: {},
+    });
+
+    it("opens before the prepend lands and closes after it, in one task", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValueOnce([older(50), older(40)]);
+      const scrollback = await import("../lib/scrollback");
+      seedOne(scrollback);
+      const key = channelKey("freenode", "#grappa");
+      const count = (): number => (scrollback.scrollbackByChannel()[key] ?? []).length;
+
+      const atOpen: number[] = [];
+      const atClose: number[] = [];
+      // No await between the two edges — the verb invokes the finaliser
+      // itself, in place, rather than scheduling it.
+      let closed = false;
+
+      await scrollback.loadMore("freenode", "#grappa", () => {
+        atOpen.push(count());
+        return () => {
+          atClose.push(count());
+          closed = true;
+        };
+      });
+
+      // Opened with only the seeded row in the pane, closed with the two
+      // older rows already merged.
+      expect(atOpen).toEqual([1]);
+      expect(atClose).toEqual([3]);
+      expect(closed).toBe(true);
+    });
+
+    it("stays shut when the server has no older rows", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValueOnce([]);
+      const scrollback = await import("../lib/scrollback");
+      seedOne(scrollback);
+
+      const opened = vi.fn((): undefined => undefined);
+      await scrollback.loadMore("freenode", "#grappa", opened);
+
+      // An empty page prepends nothing, so there is no mutation to
+      // compensate for. Firing the seam anyway would have the pane spend a
+      // scroll write on a geometry that never moved.
+      expect(opened).not.toHaveBeenCalled();
+    });
+
+    it("stays shut when the request fails", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockRejectedValueOnce(new Error("boom"));
+      const scrollback = await import("../lib/scrollback");
+      seedOne(scrollback);
+
+      const opened = vi.fn((): undefined => undefined);
+      await scrollback.loadMore("freenode", "#grappa", opened);
+
+      expect(opened).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1094 — the in-flight state the pane's loading affordance renders from.
+  // Deliberately the SAME state as the burst guard above rather than a second
+  // boolean beside it: an affordance derived from a mirror is the one that
+  // hangs on whichever terminal its author forgot.
+  describe("#1094 — isLoadingOlder tracks the older-page fetch", () => {
+    it("is true for exactly the fetch's lifetime, and only for its own key", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      let release: ((v: ScrollbackMessage[]) => void) | null = null;
+      vi.mocked(api.listMessages).mockImplementation(
+        () =>
+          new Promise<ScrollbackMessage[]>((resolve) => {
+            release = resolve;
+          }),
+      );
+      const scrollback = await import("../lib/scrollback");
+      seedOne(scrollback);
+
+      expect(scrollback.isLoadingOlder("freenode", "#grappa")).toBe(false);
+      const inFlight = scrollback.loadMore("freenode", "#grappa", noSeam);
+      // Held SYNCHRONOUSLY, before the first await: a flag set one microtask
+      // later is one the operator's own next scroll event beats to the draw.
+      expect(scrollback.isLoadingOlder("freenode", "#grappa")).toBe(true);
+      // Per key, not per pane — a fetch in one window must not spin another.
+      expect(scrollback.isLoadingOlder("freenode", "#other")).toBe(false);
+
+      if (!release) throw new Error("release never bound");
+      (release as (v: ScrollbackMessage[]) => void)([]);
+      await inFlight;
+
+      expect(scrollback.isLoadingOlder("freenode", "#grappa")).toBe(false);
+    });
+
+    it("comes back down when the request fails", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockRejectedValueOnce(new Error("boom"));
+      const scrollback = await import("../lib/scrollback");
+      seedOne(scrollback);
+
+      await scrollback.loadMore("freenode", "#grappa", noSeam);
+
+      // The DirectoryPane lesson, restated (`onCommit` clearing the paint on
+      // the one path that actually works): an affordance must come down on
+      // every terminal, not just the happy one.
+      expect(scrollback.isLoadingOlder("freenode", "#grappa")).toBe(false);
+    });
   });
 });
 
@@ -1477,11 +1617,11 @@ describe("purgeScrollback (UX-7-B 2026-05-22)", () => {
 
     // Latch the channel as exhausted via an empty loadMore.
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
-    await scrollback.loadMore("bahamut", "#bofh");
+    await scrollback.loadMore("bahamut", "#bofh", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(2);
 
     // Subsequent loadMore: exhausted latch short-circuits, no REST.
-    await scrollback.loadMore("bahamut", "#bofh");
+    await scrollback.loadMore("bahamut", "#bofh", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(2);
 
     // After purge + reseed: loadMore can fire again.
@@ -1500,7 +1640,7 @@ describe("purgeScrollback (UX-7-B 2026-05-22)", () => {
     ]);
     await scrollback.loadInitialScrollback("bahamut", "#bofh");
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
-    await scrollback.loadMore("bahamut", "#bofh");
+    await scrollback.loadMore("bahamut", "#bofh", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(4);
   });
 
@@ -1659,17 +1799,17 @@ describe("appendToScrollback — S20 per-channel ring cap", () => {
     scrollback.appendToScrollback(key, mkRow(1));
     // Latch loadMore as exhausted (server has no older history yet).
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
     // Latched: a second loadMore is a no-op.
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
     // Grow past the cap so eviction fires → the seed (id 1) is dropped, so
     // there IS older history again → the exhausted latch must clear.
     for (let i = 2; i <= cap + 5; i++) scrollback.appendToScrollback(key, mkRow(i));
     expect(scrollback.scrollbackByChannel()[key]?.some((m) => m.id === 1)).toBe(false);
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
-    await scrollback.loadMore("freenode", "#grappa");
+    await scrollback.loadMore("freenode", "#grappa", noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(2);
   });
 });

--- a/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
+++ b/cicchetto/src/__tests__/scrollbackIngestCost.test.ts
@@ -65,6 +65,10 @@ vi.mock("../lib/readCursor", () => ({
 const SLUG = "freenode";
 const CHAN = "#grappa";
 const KEY = channelKey(SLUG, CHAN);
+// #1094 — `loadMore` brackets its prepend with a caller-supplied commit seam.
+// Nothing here is about scroll position, so these pass the contract's own
+// "neither edge" answer. Pinned in `scrollback.test.ts`.
+const noSeam = (): undefined => undefined;
 
 // Row whose `id` is a counting getter. Every read the store performs — the
 // dedupe scan, the tail comparison, the ring-cap protection scan, a sort — is
@@ -309,9 +313,9 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
 
     // Latch loadMore as exhausted, then prove a page-driven eviction clears it.
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
-    await scrollback.loadMore(SLUG, CHAN);
+    await scrollback.loadMore(SLUG, CHAN, noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
-    await scrollback.loadMore(SLUG, CHAN);
+    await scrollback.loadMore(SLUG, CHAN, noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(1);
 
     const page = Array.from({ length: 200 }, (_, i) => plainRow(cap + 1 + i));
@@ -322,7 +326,7 @@ describe("#1288 — the batched ingest keeps every per-row invariant", () => {
     expect(scrollback.scrollbackByChannel()[KEY]?.some((m) => m.id === 1)).toBe(false);
 
     vi.mocked(api.listMessages).mockResolvedValueOnce([]);
-    await scrollback.loadMore(SLUG, CHAN);
+    await scrollback.loadMore(SLUG, CHAN, noSeam);
     expect(api.listMessages).toHaveBeenCalledTimes(2);
   });
 

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -309,16 +309,61 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRi
 // same predicate to drop a stale RESPONSE; this module uses it one step
 // earlier, to refuse a stale REQUEST.
 
+/**
+ * #1094 — the synchronous seam `loadMore` wraps around its prepend.
+ *
+ * Called with no arguments IMMEDIATELY BEFORE the store write that prepends
+ * the older page, and the function it returns (when it returns one) called
+ * IMMEDIATELY AFTER that write, with nothing awaited in between.
+ *
+ * Why a seam and not a return value the caller acts on. What the pane has to
+ * preserve across a prepend is GEOMETRY — the container's `scrollHeight` and
+ * `scrollTop` — and geometry is only true at an instant. Read before the verb
+ * is called it is stale by a whole network round trip: the operator carries on
+ * scrolling past the threshold that armed the fetch, and live rows keep
+ * appending at the tail, so BOTH terms of the height-delta correction move
+ * under the snapshot and the pane restores the reader to where they were
+ * rather than where they are. Read after the verb RESOLVES it is correct but
+ * late by however many awaits the verb happens to have left, which is not a
+ * number the caller can know and not one that stays fixed as the verb grows.
+ * Bracketing the mutation is the only reading that is neither.
+ *
+ * `lib/scrollback.ts` stays DOM-free: the store says WHEN, the pane reads
+ * WHAT. Returning nothing is legitimate — a caller that only wants the "about
+ * to prepend" edge (or neither) says so by returning `undefined`.
+ */
+export type PrependCommitSeam = () => (() => void) | undefined;
+
 const exports = identityScopedStore((onIdentityChange) => {
   const loadedChannels = new Set<ChannelKey>();
   // CP14 B2: per-key in-flight Set guards against scroll-burst fan-out
   // (the user flicks the scrollbar; the browser fires `scroll` 5+ times
   // in a frame and the onScroll handler would otherwise dispatch 5+
   // identical REST requests). While a key is in `loadMoreInFlight`, a
-  // second `loadMore` call for the same key is a no-op. Released in
-  // `finally` so a transient REST error doesn't permanently lock out
+  // second `loadMore` call for the same key is a no-op. Released on every
+  // terminal so a transient REST error doesn't permanently lock out
   // future retries — only the exhausted-latch is forward-only.
-  const loadMoreInFlight = new Set<ChannelKey>();
+  //
+  // #1094 — and it is a SIGNAL rather than a plain Set, unlike its four
+  // siblings below, because the pane RENDERS from it: the older-page fetch
+  // now has a loading affordance, and "is a page on the wire for this key"
+  // is precisely this state. A second boolean mirroring it would be a
+  // parallel structure with its own housekeeping to drift (CLAUDE.md: derive,
+  // don't duplicate) — and it would drift on exactly the paths that matter,
+  // the ones where the fetch ends badly. Reading it from `loadMore` creates
+  // no reactive dependency: the verb runs outside any tracking scope.
+  const [loadMoreInFlight, setLoadMoreInFlight] = createSignal<ReadonlySet<ChannelKey>>(new Set());
+  const holdLoadMoreInFlight = (key: ChannelKey): void => {
+    setLoadMoreInFlight((prev) => new Set(prev).add(key));
+  };
+  const releaseLoadMoreInFlight = (key: ChannelKey): void => {
+    setLoadMoreInFlight((prev) => {
+      if (!prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  };
   // CP14 B2: end-of-history latch. When `loadMore` returns 0 fresh
   // rows, the channel is exhausted — the server has no rows older than
   // our current oldest. Subsequent calls are no-ops. Latch is forward-
@@ -463,7 +508,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   // merge paths; `jumpToUnread` REPLACES the key's rows, so a second concurrent
   // jump would discard whatever landed between the two writes.)
   onIdentityChange(() => loadedChannels.clear());
-  onIdentityChange(() => loadMoreInFlight.clear());
+  onIdentityChange(() => setLoadMoreInFlight(new Set()));
   onIdentityChange(() => loadMoreExhausted.clear());
   onIdentityChange(() => loadNewerInFlight.clear());
   onIdentityChange(() => loadNewerExhausted.clear());
@@ -1005,7 +1050,33 @@ const exports = identityScopedStore((onIdentityChange) => {
     }
   };
 
-  const loadMore = async (slug: string, name: string): Promise<void> => {
+  // #1094 — the fetch half of `loadMore`, split out so the `catch` that
+  // deliberately swallows a transient REST failure covers the REQUEST and
+  // nothing else. What follows it is a DOM-visible scroll write supplied by
+  // the pane, and a boundary that absorbs an exception from that would hide
+  // the next bug to fall into it (CLAUDE.md: no silent-swallow at boundaries).
+  //
+  // `null` is the failure; it is NOT `[]`, which is the server answering "no
+  // older rows" and is what latches `loadMoreExhausted`. Collapsing the two
+  // would latch the channel permanently on one flaky request.
+  const fetchOlderPage = async (
+    t: string,
+    slug: string,
+    name: string,
+    before: number,
+  ): Promise<ScrollbackMessage[] | null> => {
+    try {
+      return await listMessages(t, slug, name, before);
+    } catch {
+      return null;
+    }
+  };
+
+  const loadMore = async (
+    slug: string,
+    name: string,
+    aroundCommit: PrependCommitSeam,
+  ): Promise<void> => {
     const t = token();
     if (!t) return;
     const key = channelKey(slug, name);
@@ -1017,33 +1088,45 @@ const exports = identityScopedStore((onIdentityChange) => {
     //      onto a single REST request; the second call returns void
     //      while the first is still pending.
     if (loadMoreExhausted.has(key)) return;
-    if (loadMoreInFlight.has(key)) return;
+    if (loadMoreInFlight().has(key)) return;
     const current = scrollbackByChannel()[key];
     if (!current || current.length === 0) return;
     const oldest = current[0];
     if (!oldest) return;
-    loadMoreInFlight.add(key);
+    // Held SYNCHRONOUSLY, before the first await: the pane's loading
+    // affordance reads this, and one set a microtask later is one the
+    // operator's own next scroll event beats to the draw.
+    holdLoadMoreInFlight(key);
+    // CP29 R-2: cursor flipped from `oldest.server_time` to
+    // `oldest.id`. The server-side `?before=` parameter now expects
+    // a `messages.id` value, eliminating same-ms ties that straddled
+    // page boundaries pre-flip.
+    const page = await fetchOlderPage(t, slug, name, oldest.id);
+    // Past a rotation the identity reset already emptied the in-flight set, so
+    // releasing here would unlock a fetch belonging to whoever replaced us.
+    if (identityMoved(t)) return;
     try {
-      // CP29 R-2: cursor flipped from `oldest.server_time` to
-      // `oldest.id`. The server-side `?before=` parameter now expects
-      // a `messages.id` value, eliminating same-ms ties that straddled
-      // page boundaries pre-flip.
-      const page = await listMessages(t, slug, name, oldest.id);
-      if (identityMoved(t)) return;
+      // A transient failure does NOT latch as exhausted: the operator can
+      // retry by scrolling again, and the in-flight guard releases below.
+      if (page === null) return;
       // CP14 B2: empty page from the server means there's no older
       // history to load. Latch the channel so subsequent scroll-to-
-      // top events don't re-fetch.
+      // top events don't re-fetch. No prepend, so the seam stays shut —
+      // there is no mutation for the pane to compensate for.
       if (page.length === 0) {
         loadMoreExhausted.add(key);
-      } else {
-        mergeIntoScrollback(key, page);
+        return;
       }
-    } catch {
-      // Transient error — do NOT latch as exhausted. The user can
-      // retry by scrolling again; the in-flight guard releases via
-      // the finally clause below.
+      // #1094 — the commit seam, wrapped tight around the ONE store write
+      // that prepends the page. Solid flushes a signal write's render effects
+      // and user effects before the setter returns, so `settled` runs with the
+      // new rows already in the DOM, in this same task, with no frame between
+      // it and the mutation. See `PrependCommitSeam`.
+      const settled = aroundCommit();
+      mergeIntoScrollback(key, page);
+      settled?.();
     } finally {
-      if (!identityMoved(t)) loadMoreInFlight.delete(key);
+      releaseLoadMoreInFlight(key);
     }
   };
 
@@ -1425,7 +1508,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     if (!hasSignal && !hasGate) return;
     loadedChannels.delete(key);
     loadMoreExhausted.delete(key);
-    loadMoreInFlight.delete(key);
+    releaseLoadMoreInFlight(key);
     loadNewerExhausted.delete(key);
     loadNewerInFlight.delete(key);
     // #693 — the rows the far-behind record points back to were just deleted
@@ -1454,11 +1537,20 @@ const exports = identityScopedStore((onIdentityChange) => {
   const wasLoaded = (slug: string, name: string): boolean =>
     loadedChannels.has(channelKey(slug, name));
 
+  // #1094 — "an older page is on the wire for this window". The pane renders
+  // its loading affordance from this and nothing else, so the flag and the
+  // guard that makes the fetch idempotent are the SAME state: an affordance
+  // derived from a second boolean would be the one that hangs when a fetch
+  // ends on a path whoever added it forgot about.
+  const isLoadingOlder = (slug: string, name: string): boolean =>
+    loadMoreInFlight().has(channelKey(slug, name));
+
   return {
     scrollbackByChannel,
     appendToScrollback,
     dismissFarBehind,
     farBehindByChannel,
+    isLoadingOlder,
     jumpToUnread,
     loadInitialScrollback,
     loadMore,
@@ -1478,6 +1570,7 @@ export const scrollbackByChannel = exports.scrollbackByChannel;
 export const appendToScrollback = exports.appendToScrollback;
 export const dismissFarBehind = exports.dismissFarBehind;
 export const farBehindByChannel = exports.farBehindByChannel;
+export const isLoadingOlder = exports.isLoadingOlder;
 export const jumpToUnread = exports.jumpToUnread;
 export const loadInitialScrollback = exports.loadInitialScrollback;
 export const loadMore = exports.loadMore;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1206,7 +1206,8 @@ html.overlay-open #root > div {
   .login-matrix::after,
   .login-spinner,
   .compose-send-spinner,
-  .directory-pull-spinner {
+  .directory-pull-spinner,
+  .scrollback-loading-older-spinner {
     animation: none;
   }
   /* #1445 — same call as the swipe-to-reply snap-back below: the pull still
@@ -3514,6 +3515,35 @@ html.resize-dragging * {
    cannot be translucent without both layers becoming unreadable. Both
    buttons carry the 44px tap-target floor in absolute px — the root
    font-size is 14px, so a rem-based target comes out short on mobile. */
+
+/* #1094 — the older-page fetch affordance. Container-anchored like the #133
+   overlay and the #693 far-behind bar rather than in-flow at the top of
+   `.scrollback`, and here the reason is not just "don't resize the list": this
+   affordance accompanies the ONE mutation whose height delta the pane
+   measures and compensates (`applyPrependPreserve`). In flow it would add a
+   term to that delta at mount and subtract it again at the commit, and the
+   subtraction only cancels if it lands in the same flush as the prepend. Out
+   of `.scrollback` it is not in its `scrollHeight` at all, so there is no term
+   and nothing to keep in step. Full rationale in ScrollbackPane.tsx.
+
+   z-index 5 puts it one above the far-behind bar (4), which pins to the same
+   top-0 strip and is opaque: when a far-behind pane pages older, the spinner
+   still has to be visible. Below the #280 float stack (40) and the #133 cards
+   (42), both of which are deliberate operator affordances and outrank a
+   transient. `pointer-events: none` — nothing here is clickable, and the rows
+   it floats over stay scrollable and tappable. */
+.scrollback-loading-older {
+  position: absolute;
+  top: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  pointer-events: none;
+}
 
 .scrollback-far-behind {
   position: absolute;
@@ -12064,8 +12094,16 @@ button.home-pane-network-title:hover .home-pane-network-slug {
 /* Reuses the `.login-spinner` ring recipe and the shared `login-spin`
    keyframes, exactly as `.compose-send-spinner` does — a third hand-copied
    ring is how that recipe would start to drift. In `--accent` like the
-   original: this one sits on the pane background, not on a coloured button. */
-.directory-pull-spinner {
+   original: this one sits on the pane background, not on a coloured button.
+
+   #1094 — the scrollback's older-page ring wants this recipe EXACTLY (same
+   18px, same accent, same pane background), so it joins the selector instead
+   of becoming the fourth copy the comment above warns about. It is only a
+   selector away rather than a hoisted `.spinner-ring` because the other two
+   rings genuinely differ (2.5rem/3px; 16px/currentColor), and migrating them
+   is a change to Login and ComposeBox, which is not this issue. */
+.directory-pull-spinner,
+.scrollback-loading-older-spinner {
   box-sizing: border-box;
   display: inline-block;
   width: 18px;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -60011,3 +60011,121 @@ the logo probe, and out of scope here rather than silently folded in.
 cic bundle only. No server module, no `VERSION` bump, no migration: the change
 is the station table, one new `cicchetto/scripts/` probe and a `package.json`
 script that CI never calls.
+<!-- entry #1094 -->
+
+---
+
+## 2026-08-24 — #1094: the prepend preserve moves onto a commit seam, and the fetch gets a floating spinner
+
+Paging older history in `ScrollbackPane` has always had to compensate for the
+prepend: rows land ABOVE the viewport, so `scrollTop` has to move by the height
+they added or the reader's row slides down the pane. The compensation
+(`applyPrependPreserve`, #608 W6) was correct arithmetic wired to the wrong two
+instants:
+
+```ts
+const oldScrollHeight = listRef.scrollHeight;
+const oldScrollTop = listRef.scrollTop;
+void loadMoreScrollback(slug, name).then(() =>
+  applyPrependPreserve(oldScrollHeight, oldScrollTop),
+);
+```
+
+Both terms are live DOM geometry, read BEFORE a network round trip and spent
+AFTER it. #1094 filed the second half of that (the restore lands at least a
+frame after the store write) from a frame-sampled harness on the anchored
+initial load. vjt's field report of 2026-08-23 supplied the first half from the
+ORDINARY scroll-to-top gesture — *"salire e ripescare messaggi vecchi smuove
+tutto l'elenco"* — which the issue itself had listed under *What is NOT
+measured*.
+
+### What was measured here, and what was not
+
+The staleness is the operator-visible half and it is arithmetic, not timing.
+`maybeLoadOlder` arms at `scrollTop <= 200`; the flick that armed it carries on
+to 0 while the request is out; the restore then aims at `delta + 150` (say)
+instead of `delta + 0` and drags the pane down by the difference. A live row
+appending at the tail during the same window inflates `newScrollHeight -
+oldScrollHeight` by its own height, so the prepend is credited with growth it
+did not cause. Both are now pinned in jsdom, red-first, in
+`ScrollbackPane.test.tsx`.
+
+**Not established, and deliberately not asserted anywhere: that the ORIGINAL
+one-frame gap reproduces on the `loadMore` path.** Reading the code, it should
+not: `loadMore`'s store write is the last thing before the async function
+returns, Solid flushes render effects and user effects synchronously inside
+`setScrollbackByChannel`, and a `.then()` on the resulting promise is a
+microtask of that same task — microtasks drain before paint. The issue's
+measurement was taken on the anchored initial load, which has a different await
+shape. That question is left open; the fix does not depend on the answer,
+because binding the compensation to the mutation makes the timing correct by
+construction however many awaits the verb grows later.
+
+### The seam
+
+`loadMore(slug, name, aroundCommit)` — a `PrependCommitSeam`, called with no
+arguments immediately BEFORE the one store write that prepends the page, and
+the function it returns called immediately AFTER it. The store stays DOM-free:
+it says WHEN, the pane reads WHAT. `lib/scrollback.ts` was the only place that
+could offer those two instants, and the pane is the only place that can read
+geometry — that split is the whole reason this is a callback and not a return
+value.
+
+Required, not optional: `ScrollbackPane` is the sole caller, and an optional
+parameter here would be a silent degradation path (CLAUDE.md).
+
+One consequence worth naming: `loadMore`'s `try/catch` was narrowed to cover
+the REQUEST only, via a `fetchOlderPage` helper returning `null` for a failure
+(distinct from `[]`, which is the server saying "no older rows" and is what
+latches `loadMoreExhausted`). Leaving the seam inside the old wide catch would
+have had a boundary silently absorb an exception thrown by a DOM scroll write.
+
+### The spinner: FLOATING, and why
+
+`ScrollbackPane` had no loading state at all on this path. The open question
+the issue left was whether the affordance sits ABOVE the first row, occupying
+the space the prepend will fill, or floats over the pane. **Floating**, on
+three grounds, the third being decisive:
+
+1. An in-flow slot adds a term to the exact quantity `applyPrependPreserve`
+   compensates. Correctness would then depend on the slot's unmount landing in
+   the same flush as the prepend.
+2. It has TWO edges, not one. It grows the list when the fetch STARTS, and
+   nothing compensates that — so the cure for a jump at t=RTT would open a new
+   one at t=0.
+3. The pane already made this call once and paid for the in-flow version
+   first: the #133 WHOIS/WHOWAS/LUSERS cards were flex siblings before
+   `.scrollback` and *"shrank the scroll list on mount, shifting the reader's
+   anchor"*. `DirectoryPane`'s pull affordance states the same rule from the
+   other side — *"a transform does not touch layout, so scrollHeight and the
+   pane's scroll-preservation effect are untouched"*.
+
+The one thing an in-flow slot buys — reserving the space the page will fill —
+it does not actually buy: the ring is 18px and a page is ~1000px.
+
+The in-flight state it renders from is `isLoadingOlder(slug, name)`, which is
+the burst guard itself, promoted from a plain `Set` to a signal. Not a second
+boolean beside it: a mirrored flag is the one that hangs on whichever terminal
+its author forgot, which is the `directory-pull-spinner` failure mode
+(`onCommit` clearing the paint on the one path that works) restated.
+
+The ring reuses `.directory-pull-spinner`'s declaration block by joining its
+selector rather than becoming the fourth hand-copy that block's own comment
+warns about. It is a selector and not a hoisted `.spinner-ring` because the
+other two rings genuinely differ (2.5rem/3px accent; 16px currentColor), and
+migrating them is a change to Login and ComposeBox.
+
+### Coverage, stated honestly
+
+The units pin the MECHANISM and cannot pin the OUTCOME: jsdom has no layout
+engine, so every px in them is a `defineProperty`. `issue1094-prepend-preserve-commit.spec.ts`
+is the outcome guard — anchor a row, page older history in underneath it while
+the operator keeps flicking, assert it did not move — with the loading
+affordance doubling as the calibration arm that proves the injected fetch delay
+took effect. It is an END-STATE oracle, not frame sampling, deliberately.
+**That spec has not been executed: no browser is runnable on this host, and the
+e2e lane is exclusive.** CI is its first run.
+
+#1151 (11px of drift for an 18px insertion, same applier) is adjacent and was
+left alone. The e2e tolerance is set wide enough to survive that residue and
+narrow enough that the ~150px this issue is about cannot hide inside it.

--- a/test/grappa_web/controllers/messages_limit_mirror_test.exs
+++ b/test/grappa_web/controllers/messages_limit_mirror_test.exs
@@ -4,8 +4,8 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   limits, and until this file nothing compared a copy with its original.
 
   `@default_limit` (the unconfigured-client page size) is re-declared as
-  `REST_PAGE_SIZE` in 13 specs; `@max_http_limit` (the boundary ceiling)
-  as `MAX_HTTP_LIMIT` in 4. Seventeen numbers kept in lockstep by hand,
+  `REST_PAGE_SIZE` in 14 specs; `@max_http_limit` (the boundary ceiling)
+  as `MAX_HTTP_LIMIT` in 4. Eighteen numbers kept in lockstep by hand,
   with no witness: change the attribute and every spec keeps asserting
   the old page size, silently, because a Playwright spec seeds its own
   fixture and never asks the server what its default is.
@@ -59,7 +59,7 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   # to the state #1646 measured. Landing either means changing the number
   # here, which is the moment someone reads this.
   @mirrors [
-    {"REST_PAGE_SIZE", "default_limit", 13},
+    {"REST_PAGE_SIZE", "default_limit", 14},
     {"MAX_HTTP_LIMIT", "max_http_limit", 4}
   ]
 


### PR DESCRIPTION
Fixes the scroll jump vjt reported from the field on 2026-08-23 — *"salire e
ripescare messaggi vecchi smuove tutto l'elenco"* — plus the loading affordance
asked for in the same report. Issue #1094.

## What the defect actually is

`maybeLoadOlder` read `(scrollHeight, scrollTop)` BEFORE calling `loadMore` and
spent them in the returned promise's `.then()`. Both are live DOM geometry and
what sits between the two reads is a network round trip, so both move under the
snapshot:

* the flick that armed the fetch at `scrollTop <= 200` carries on to 0 while
  the request is out, so the restore aims at where the reader **was** — up to
  200px below where they are;
* a live row appending at the tail during the same window inflates
  `newScrollHeight - oldScrollHeight`, so the prepend is credited with growth it
  did not cause.

Both are now pinned red-first in jsdom.

## What I refuse to affirm

**That the one-frame gap the issue is titled after reproduces on the `loadMore`
path.** Reading the code it should not: the store write is `loadMore`'s last
act, Solid flushes render + user effects synchronously inside the setter, and a
`.then()` on the resulting promise is a microtask of that same task — microtasks
drain before paint. The issue's frame sample came from the anchored initial
load, which has a different await shape. I did not reproduce it and I assert it
nowhere. The fix does not rest on the answer: binding the compensation to the
mutation makes the timing correct by construction however many awaits the verb
grows later.

## The seam

`loadMore(slug, name, aroundCommit)` — a `PrependCommitSeam`, called immediately
before the one store write that prepends the page, and the function it returns
called immediately after it. The store stays DOM-free: it says WHEN, the pane
reads WHAT. Required, not optional — the pane is the sole caller.

Carried along because the seam forces it: `loadMore`'s `try/catch` is narrowed
to the REQUEST via a `fetchOlderPage` helper (`null` = failure, distinct from
`[]` = no older rows). Left wide, it would silently absorb an exception from the
pane's scroll write.

## The spinner: FLOATING — the decision, and why

The issue left this open. In-flow, above the first row, adds a term to the exact
quantity `applyPrependPreserve` compensates — and it has **two** edges, not one.
It grows the list when the fetch STARTS, which nothing compensates, so curing a
jump at t=RTT would open a new one at t=0; and it shrinks at the commit, where
it only cancels if it lands in the very same flush as the prepend. Out of
`.scrollback` it is not in its `scrollHeight` at all.

This pane already made the call once and paid for the in-flow version first —
the #133 cards were flex siblings before `.scrollback` and *"shrank the scroll
list on mount, shifting the reader's anchor"*. The one thing an in-flow slot
buys (reserving the space) it does not buy: 18px ring, ~1000px page.

It renders from `isLoadingOlder`, which IS the burst guard promoted to a signal,
not a boolean mirroring it — a mirror is the flag that hangs on whichever
terminal its author forgot, which is the hung `directory-pull-spinner` restated.
The ring joins `.directory-pull-spinner`'s declaration block rather than
becoming the fourth hand-copy that block's own comment warns about.

## Gates

* `bun run check` — 4/4 green (lock drift, biome, tsc src, tsc e2e).
* `bun run test` — **5937/5937**, whole suite.
* iso-rerun **x5** of the five touched suites — 394/394 each time, no flake.

## Not executed, stated as such

`cicchetto/e2e/tests/issue1094-prepend-preserve-commit.spec.ts` **has never
run.** No browser is startable on this host and the e2e lane is exclusive; CI is
its first execution. It is the only guard for the OUTCOME (jsdom has no layout
engine, so every px in the units is a `defineProperty`). Its oracle is an END
STATE — anchor a row, page older history in underneath it while the operator
keeps flicking, assert it did not move — and the loading affordance doubles as
the calibration arm proving the injected fetch delay took effect.

#1151 is adjacent and untouched; the e2e tolerance is set wide enough to survive
its residue and narrow enough that the ~150px here cannot hide inside it.