### PR TITLE
fix(#1696): copy the station logo URLs from the catalogue, and make the claim executable

### DIFF
--- a/cicchetto/package.json
+++ b/cicchetto/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "check": "bun scripts/check.ts",
     "check:fix": "biome check --write",
+    "check:radio": "bun scripts/check-radio-logos.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "gen:emoji": "bun scripts/gen-emoji.ts"

--- a/cicchetto/scripts/check-radio-logos-core.ts
+++ b/cicchetto/scripts/check-radio-logos-core.ts
@@ -1,0 +1,104 @@
+// #1696 — the pure half of the radio-logo probe.
+//
+// No filesystem, no network, no Bun API, no imports. `check-radio-logos.ts`
+// does the IO and calls in here; `src/__tests__/checkRadioLogos.test.ts`
+// exercises both sides of every rule. This is the `lock-drift-core.ts` split
+// and it exists for the same measured reason: `cicchetto/scripts/` is outside
+// the tsconfig `include` AND outside biome's `files.includes`, so a
+// runner-only module is checked by NOTHING. Keeping the rules importable from
+// `src` is what puts them under `tsc --noEmit`.
+//
+// That is not a hypothetical here. Written as a runner-only file, this module's
+// `?v=` strip read `image.split("?")[0]` and typechecked fine under bun — under
+// the project's `noUncheckedIndexedAccess` it is `string | undefined`, i.e. the
+// exact silent-`undefined` class the strict flag exists to catch. The probe
+// that exists to stop unverifiable claims was itself unverified.
+//
+// The second reason is vacuity. AGREE skips stations that point at another
+// provider, so a rule inverted by one edit skips EVERY station and the script
+// reports "0 broken" having compared nothing — a green that means silence. The
+// test file holds a positive control against the real table for that.
+
+/** The shape `channels.json` gives us. Everything is optional on purpose: this
+    is a third party's document and a missing field must degrade to a finding,
+    never to a crash. */
+export type CatalogueChannel = { readonly id?: string; readonly image?: string };
+export type CatalogueBody = { readonly channels?: readonly CatalogueChannel[] };
+
+/** Drop the `?v=` cache-buster. The table bakes the versionless path on
+    purpose — a timestamp in a stored URL rots on the next re-upload, while the
+    versionless path keeps serving — so the comparison must strip it or every
+    station would read as a disagreement. */
+export function versionless(url: string): string {
+  return url.split("?")[0] ?? url;
+}
+
+/** id → the catalogue's logo URL, `?v=` stripped. Channels missing an id or an
+    image are dropped rather than half-entered: a station whose row is absent is
+    reported by `agreeFailure` as a finding, which is the honest outcome, and a
+    half-entry would instead read as agreement with an empty string. */
+export function catalogueLogos(body: CatalogueBody): Map<string, string> {
+  const entries = (body.channels ?? []).flatMap((c) =>
+    c.id !== undefined && c.image !== undefined
+      ? ([[c.id, versionless(c.image)]] as const)
+      : ([] as const),
+  );
+  return new Map(entries);
+}
+
+/** `null` when the response is a served image; otherwise why it is not.
+    Content type is checked and not just the status because api.somafm.com
+    answers some paths with a 200-shaped `text/html` body — a status-only
+    assert would wave a soft 404 straight through, and a soft 404 is exactly
+    the failure this probe was written to catch. */
+export function reachFailure(status: number, contentType: string | null): string | null {
+  if (status < 200 || status >= 300) return `HTTP ${status}`;
+  const type = contentType ?? "(none)";
+  if (!type.startsWith("image/")) return `HTTP ${status} but content-type ${type}`;
+  return null;
+}
+
+/** Whether AGREE has anything to say about this station. A station pointing at
+    another provider is outside the catalogue's scope — the table is allowed to
+    hold one. Exported so the test can assert the axis is NOT vacuous over the
+    real table; a green built from zero comparisons is silence, not agreement. */
+export function isCatalogueBacked(logoUrl: string): boolean {
+  return new URL(logoUrl).host.endsWith("somafm.com");
+}
+
+/** `null` when the baked URL is the one the catalogue publishes; otherwise the
+    disagreement, spelled so the reader can paste the fix straight in. */
+export function agreeFailure(
+  logoUrl: string,
+  id: string,
+  catalogue: ReadonlyMap<string, string>,
+): string | null {
+  if (!isCatalogueBacked(logoUrl)) return null;
+  const published = catalogue.get(id);
+  // A somafm URL with no catalogue row behind it is precisely the unverifiable
+  // claim this probe exists to kill, so it is a finding rather than a skip.
+  if (published === undefined) return `points at somafm but the catalogue has no channel "${id}"`;
+  if (published !== logoUrl) return `catalogue ships ${published}`;
+  return null;
+}
+
+export type StationFinding = {
+  readonly id: string;
+  readonly logoUrl: string;
+  readonly reach: string | null;
+  readonly agree: string | null;
+};
+
+/** Every problem found for one station, both axes, in report order. */
+export function problems(finding: StationFinding): readonly string[] {
+  return [
+    finding.reach === null ? null : `REACH ${finding.reach}`,
+    finding.agree === null ? null : `AGREE ${finding.agree}`,
+  ].filter((p): p is string => p !== null);
+}
+
+/** A station is broken if EITHER axis has something to say — the union
+    verdict, the `scripts/check.ts` posture. */
+export function brokenCount(findings: readonly StationFinding[]): number {
+  return findings.filter((f) => problems(f).length > 0).length;
+}

--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env bun
+// #1696 — hold `src/lib/radioStations.ts`'s baked logo URLs to the catalogue
+// that actually serves them.
+//
+// WHY THIS EXISTS AS A SCRIPT AND NOT AS A TEST. #682 shipped the table with a
+// moduledoc claiming "the versionless logo URLs were checked the same way".
+// They were not: measured 2026-08-24, TEN of the fourteen answered 404, and the
+// four that answered 200 were exactly the four SomaFM genuinely serves as PNG.
+// The defect was never the extension — it was a claim about external state that
+// nothing in the repo could establish, so nobody could tell a true one from a
+// false one. The cure is to make the claim EXECUTABLE, not to write it more
+// carefully.
+//
+// It is deliberately NOT wired into `bun run check` or CI.
+// `src/__tests__/radioStations.test.ts` already states the reason and it is the
+// right one: a gate that fetches somafm.com is a third-party outage detector
+// bolted onto our build, and it goes red on days when nothing of ours is
+// broken. This runs on demand — `bun run check:radio` — and the table's
+// moduledoc names it, so the next author edits the table and has a command
+// instead of a ritual.
+//
+// TWO AXES, both reported, union verdict (the `scripts/check.ts` posture):
+//
+//   REACH  — the URL answers 200 with an `image/*` content type. This is the
+//            property the picker needs, and it covers every station including
+//            one from another provider. Content type is checked and not just
+//            the status because api.somafm.com serves its 404 as `text/html`
+//            with a 200-shaped body on some paths; a status-only assert would
+//            wave through a soft 404.
+//   AGREE  — for a station whose logo we point at somafm, the baked URL is the
+//            one `channels.json` ships. Stronger than REACH: it catches a logo
+//            that still resolves but is no longer the one upstream publishes,
+//            and it is what pins the table to the authority WITHOUT making the
+//            running client depend on that authority (see the table's
+//            moduledoc for why the fetch stays out of the render path).
+//
+// The `?v=` cache-buster is stripped before comparing, because the table drops
+// it on purpose — a timestamp in a baked URL rots on every re-upload while the
+// versionless path keeps serving. That divergence used to live only in a
+// comment; here it is executed.
+//
+// A catalogue that cannot be fetched is a FAILURE, not a pass: "not measured"
+// must never read as "measured ok" — that equivalence is the whole bug.
+
+import { RADIO_STATIONS } from "../src/lib/radioStations";
+
+const CATALOGUE_URL = "https://api.somafm.com/channels.json";
+const TIMEOUT_MS = 15_000;
+
+type CatalogueChannel = { readonly id: string; readonly image?: string };
+
+/** The catalogue's logo URL for each id, `?v=` stripped, or null when the
+    catalogue itself is unreachable — which the caller must not treat as "no
+    disagreement found". */
+async function fetchCatalogueLogos(): Promise<Map<string, string> | null> {
+  try {
+    const res = await fetch(CATALOGUE_URL, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (!res.ok) {
+      console.error(`catalogue ${CATALOGUE_URL} answered ${res.status}`);
+      return null;
+    }
+    const body = (await res.json()) as { channels?: readonly CatalogueChannel[] };
+    const channels = body.channels ?? [];
+    return new Map(
+      channels.flatMap((c) => (c.image ? [[c.id, c.image.split("?")[0]] as const] : [])),
+    );
+  } catch (err) {
+    console.error(`catalogue ${CATALOGUE_URL} could not be fetched: ${err}`);
+    return null;
+  }
+}
+
+/** `null` when the logo is served as an image; otherwise why it is not. */
+async function reachFailure(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, { method: "HEAD", signal: AbortSignal.timeout(TIMEOUT_MS) });
+    const type = res.headers.get("content-type") ?? "(none)";
+    if (!res.ok) return `HTTP ${res.status}`;
+    if (!type.startsWith("image/")) return `HTTP 200 but content-type ${type}`;
+    return null;
+  } catch (err) {
+    return `${err}`;
+  }
+}
+
+/** `null` when the baked URL is the catalogue's; otherwise the disagreement.
+    Stations pointing at another provider are out of the catalogue's scope and
+    answer null — the table is allowed to hold one (see radioStations.ts). */
+function agreeFailure(logoUrl: string, id: string, catalogue: Map<string, string>): string | null {
+  if (!new URL(logoUrl).host.endsWith("somafm.com")) return null;
+  const published = catalogue.get(id);
+  // A somafm URL with no catalogue row behind it is exactly the unverifiable
+  // claim this script exists to kill, so it fails rather than being skipped.
+  if (!published) return `points at somafm but the catalogue has no channel "${id}"`;
+  if (published !== logoUrl) return `catalogue ships ${published}`;
+  return null;
+}
+
+const catalogue = await fetchCatalogueLogos();
+if (catalogue === null) {
+  console.error("\ncheck:radio — cannot verify the table without the catalogue.");
+  process.exit(1);
+}
+
+const findings = await Promise.all(
+  RADIO_STATIONS.map(async (station) => ({
+    id: station.id,
+    logoUrl: station.logoUrl,
+    reach: await reachFailure(station.logoUrl),
+    agree: agreeFailure(station.logoUrl, station.id, catalogue),
+  })),
+);
+
+for (const f of findings) {
+  const problems = [
+    f.reach === null ? null : `REACH ${f.reach}`,
+    f.agree === null ? null : `AGREE ${f.agree}`,
+  ].filter((p) => p !== null);
+  const verdict = problems.length === 0 ? "ok  " : "FAIL";
+  console.log(`  ${verdict}  ${f.id.padEnd(16)}${f.logoUrl}`);
+  for (const p of problems) console.log(`          ${p}`);
+}
+
+const broken = findings.filter((f) => f.reach !== null || f.agree !== null);
+
+// The denominator is the honesty payload, as in scripts/check.ts: "14 stations
+// checked" is what tells a reader the verdict covers the whole table.
+console.log(
+  `\ncheck:radio summary — ${findings.length} stations checked, ${broken.length} broken`,
+);
+
+process.exit(broken.length === 0 ? 0 : 1);

--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -7,9 +7,9 @@
 // They were not: measured 2026-08-24, TEN of the fourteen answered 404, and the
 // four that answered 200 were exactly the four SomaFM genuinely serves as PNG.
 // The defect was never the extension — it was a claim about external state that
-// nothing in the repo could establish, so nobody could tell a true one from a
-// false one. The cure is to make the claim EXECUTABLE, not to write it more
-// carefully.
+// nothing in the repo could establish, so a true one and a false one read
+// identically to every later reader. The cure is to make the claim EXECUTABLE,
+// not to write it more carefully.
 //
 // It is deliberately NOT wired into `bun run check` or CI.
 // `src/__tests__/radioStations.test.ts` already states the reason and it is the
@@ -23,10 +23,7 @@
 //
 //   REACH  — the URL answers 200 with an `image/*` content type. This is the
 //            property the picker needs, and it covers every station including
-//            one from another provider. Content type is checked and not just
-//            the status because api.somafm.com serves its 404 as `text/html`
-//            with a 200-shaped body on some paths; a status-only assert would
-//            wave through a soft 404.
+//            one from another provider.
 //   AGREE  — for a station whose logo we point at somafm, the baked URL is the
 //            one `channels.json` ships. Stronger than REACH: it catches a logo
 //            that still resolves but is no longer the one upstream publishes,
@@ -34,99 +31,83 @@
 //            running client depend on that authority (see the table's
 //            moduledoc for why the fetch stays out of the render path).
 //
-// The `?v=` cache-buster is stripped before comparing, because the table drops
-// it on purpose — a timestamp in a baked URL rots on every re-upload while the
-// versionless path keeps serving. That divergence used to live only in a
-// comment; here it is executed.
+// THIS FILE IS THE IO HALF ONLY. Every rule lives in `check-radio-logos-core.ts`
+// so that it is reachable from `src` and therefore covered by `tsc --noEmit`;
+// `cicchetto/scripts/` is checked by neither tsc nor biome. See that file's
+// header — the split is `lock-drift.ts` / `lock-drift-core.ts`, and it is not
+// ceremony: written runner-only, the `?v=` strip in here carried a real
+// `noUncheckedIndexedAccess` violation that no gate could see.
 //
 // A catalogue that cannot be fetched is a FAILURE, not a pass: "not measured"
 // must never read as "measured ok" — that equivalence is the whole bug.
 
 import { RADIO_STATIONS } from "../src/lib/radioStations";
+import {
+  agreeFailure,
+  brokenCount,
+  type CatalogueBody,
+  catalogueLogos,
+  problems,
+  reachFailure,
+  type StationFinding,
+} from "./check-radio-logos-core";
 
 const CATALOGUE_URL = "https://api.somafm.com/channels.json";
 const TIMEOUT_MS = 15_000;
 
-type CatalogueChannel = { readonly id: string; readonly image?: string };
-
-/** The catalogue's logo URL for each id, `?v=` stripped, or null when the
-    catalogue itself is unreachable — which the caller must not treat as "no
-    disagreement found". */
-async function fetchCatalogueLogos(): Promise<Map<string, string> | null> {
+/** The catalogue's logo URL per id, or null when the catalogue itself could not
+    be read — which the caller must NOT treat as "no disagreement found". */
+async function fetchCatalogue(): Promise<Map<string, string> | null> {
   try {
     const res = await fetch(CATALOGUE_URL, { signal: AbortSignal.timeout(TIMEOUT_MS) });
     if (!res.ok) {
       console.error(`catalogue ${CATALOGUE_URL} answered ${res.status}`);
       return null;
     }
-    const body = (await res.json()) as { channels?: readonly CatalogueChannel[] };
-    const channels = body.channels ?? [];
-    return new Map(
-      channels.flatMap((c) => (c.image ? [[c.id, c.image.split("?")[0]] as const] : [])),
-    );
+    return catalogueLogos((await res.json()) as CatalogueBody);
   } catch (err) {
     console.error(`catalogue ${CATALOGUE_URL} could not be fetched: ${err}`);
     return null;
   }
 }
 
-/** `null` when the logo is served as an image; otherwise why it is not. */
-async function reachFailure(url: string): Promise<string | null> {
+/** A transport error is a REACH failure like any other: the picker would show
+    no logo either way, and swallowing it to null would be the soft green this
+    probe exists to refuse. */
+async function probeReach(url: string): Promise<string | null> {
   try {
     const res = await fetch(url, { method: "HEAD", signal: AbortSignal.timeout(TIMEOUT_MS) });
-    const type = res.headers.get("content-type") ?? "(none)";
-    if (!res.ok) return `HTTP ${res.status}`;
-    if (!type.startsWith("image/")) return `HTTP 200 but content-type ${type}`;
-    return null;
+    return reachFailure(res.status, res.headers.get("content-type"));
   } catch (err) {
     return `${err}`;
   }
 }
 
-/** `null` when the baked URL is the catalogue's; otherwise the disagreement.
-    Stations pointing at another provider are out of the catalogue's scope and
-    answer null — the table is allowed to hold one (see radioStations.ts). */
-function agreeFailure(logoUrl: string, id: string, catalogue: Map<string, string>): string | null {
-  if (!new URL(logoUrl).host.endsWith("somafm.com")) return null;
-  const published = catalogue.get(id);
-  // A somafm URL with no catalogue row behind it is exactly the unverifiable
-  // claim this script exists to kill, so it fails rather than being skipped.
-  if (!published) return `points at somafm but the catalogue has no channel "${id}"`;
-  if (published !== logoUrl) return `catalogue ships ${published}`;
-  return null;
-}
-
-const catalogue = await fetchCatalogueLogos();
+const catalogue = await fetchCatalogue();
 if (catalogue === null) {
   console.error("\ncheck:radio — cannot verify the table without the catalogue.");
   process.exit(1);
 }
 
-const findings = await Promise.all(
+const findings: StationFinding[] = await Promise.all(
   RADIO_STATIONS.map(async (station) => ({
     id: station.id,
     logoUrl: station.logoUrl,
-    reach: await reachFailure(station.logoUrl),
+    reach: await probeReach(station.logoUrl),
     agree: agreeFailure(station.logoUrl, station.id, catalogue),
   })),
 );
 
-for (const f of findings) {
-  const problems = [
-    f.reach === null ? null : `REACH ${f.reach}`,
-    f.agree === null ? null : `AGREE ${f.agree}`,
-  ].filter((p) => p !== null);
-  const verdict = problems.length === 0 ? "ok  " : "FAIL";
-  console.log(`  ${verdict}  ${f.id.padEnd(16)}${f.logoUrl}`);
-  for (const p of problems) console.log(`          ${p}`);
+for (const finding of findings) {
+  const found = problems(finding);
+  console.log(`  ${found.length === 0 ? "ok  " : "FAIL"}  ${finding.id.padEnd(16)}${finding.logoUrl}`);
+  for (const p of found) console.log(`          ${p}`);
 }
 
-const broken = findings.filter((f) => f.reach !== null || f.agree !== null);
+const broken = brokenCount(findings);
 
 // The denominator is the honesty payload, as in scripts/check.ts: "14 stations
 // checked" is what tells a reader the verdict covers the whole table.
-console.log(
-  `\ncheck:radio summary — ${findings.length} stations checked, ${broken.length} broken`,
-);
+console.log(`\ncheck:radio summary — ${findings.length} stations checked, ${broken} broken`);
 
-process.exit(broken.length === 0 ? 0 : 1);
+process.exit(broken === 0 ? 0 : 1);

--- a/cicchetto/src/__tests__/checkRadioLogos.test.ts
+++ b/cicchetto/src/__tests__/checkRadioLogos.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  agreeFailure,
+  brokenCount,
+  catalogueLogos,
+  isCatalogueBacked,
+  problems,
+  reachFailure,
+  type StationFinding,
+  versionless,
+} from "../../scripts/check-radio-logos-core";
+import { RADIO_STATIONS } from "../lib/radioStations";
+
+// #1696 — the rules behind `bun run check:radio`.
+//
+// This file is doing two jobs, and the second is the one worth stating.
+//
+// (1) Every case is two-sided, the `lockDrift.test.ts` posture: a rule is worth
+//     something only if the red side reddens AND the green side stays green
+//     under the same comparator, so a mutation that disables the check cannot
+//     pass by making everything one colour.
+//
+// (2) Importing the core from `src` is what puts `cicchetto/scripts/` under
+//     `tsc --noEmit` at all. That directory is outside the tsconfig `include`
+//     and outside biome's `files.includes`, so a runner-only module is checked
+//     by nothing — and the first draft of this probe shipped a real
+//     `noUncheckedIndexedAccess` violation in its `?v=` strip because of it.
+//     Deleting this import would silently return the probe to unchecked.
+
+const CATALOGUE = new Map([
+  ["dronezone", "https://api.somafm.com/logos/120/dronezone120.jpg"],
+  ["groovesalad", "https://api.somafm.com/logos/120/groovesalad120.png"],
+]);
+
+const finding = (over: Partial<StationFinding>): StationFinding => ({
+  id: "dronezone",
+  logoUrl: "https://api.somafm.com/logos/120/dronezone120.jpg",
+  reach: null,
+  agree: null,
+  ...over,
+});
+
+describe("versionless", () => {
+  it("drops the ?v= cache-buster the catalogue spells", () => {
+    // The table bakes the versionless path deliberately — a timestamp in a
+    // stored URL rots on the next re-upload. Without the strip EVERY station
+    // would read as a disagreement, which is a gate that cries wolf forever.
+    expect(versionless("https://api.somafm.com/logos/120/lush120.jpg?v=1674955397")).toBe(
+      "https://api.somafm.com/logos/120/lush120.jpg",
+    );
+  });
+
+  it("leaves a URL that carries no query untouched", () => {
+    const bare = "https://api.somafm.com/logos/120/lush120.jpg";
+    expect(versionless(bare)).toBe(bare);
+  });
+});
+
+describe("catalogueLogos", () => {
+  it("indexes the catalogue by id with the buster stripped", () => {
+    const map = catalogueLogos({
+      channels: [{ id: "lush", image: "https://api.somafm.com/logos/120/lush120.jpg?v=167" }],
+    });
+    expect(map.get("lush")).toBe("https://api.somafm.com/logos/120/lush120.jpg");
+  });
+
+  it("drops a channel with no image rather than half-entering it", () => {
+    // A half-entry would compare as agreement with an empty string. Absent is
+    // the honest state: `agreeFailure` then reports "no channel", a finding.
+    const map = catalogueLogos({ channels: [{ id: "lush" }, { image: "https://x/y.jpg" }] });
+    expect(map.size).toBe(0);
+  });
+
+  it("survives a document with no channels key at all", () => {
+    // Third-party JSON. A missing field must degrade to a finding downstream,
+    // never to a crash that reads as an infrastructure problem.
+    expect(catalogueLogos({}).size).toBe(0);
+  });
+});
+
+describe("reachFailure", () => {
+  it("passes a served image", () => {
+    expect(reachFailure(200, "image/jpeg")).toBeNull();
+  });
+
+  it("fails a 404 and names the status", () => {
+    expect(reachFailure(404, "text/html")).toBe("HTTP 404");
+  });
+
+  it("fails a 200 that is not an image — the soft 404 this host serves", () => {
+    // The reason the axis checks content type at all: api.somafm.com answers
+    // some paths with a 200-shaped `text/html` body, and a status-only assert
+    // would wave exactly the failure this probe exists to catch straight
+    // through.
+    expect(reachFailure(200, "text/html")).toBe("HTTP 200 but content-type text/html");
+  });
+
+  it("fails a 200 with no content type rather than assuming one", () => {
+    expect(reachFailure(200, null)).toBe("HTTP 200 but content-type (none)");
+  });
+});
+
+describe("agreeFailure", () => {
+  it("passes when the baked URL is what the catalogue publishes", () => {
+    expect(
+      agreeFailure("https://api.somafm.com/logos/120/dronezone120.jpg", "dronezone", CATALOGUE),
+    ).toBeNull();
+  });
+
+  it("fails a stale extension and spells the URL to paste in", () => {
+    // This is the #1696 bug itself, as the gate sees it.
+    expect(
+      agreeFailure("https://api.somafm.com/logos/120/dronezone120.png", "dronezone", CATALOGUE),
+    ).toBe("catalogue ships https://api.somafm.com/logos/120/dronezone120.jpg");
+  });
+
+  it("fails a somafm URL with no catalogue row behind it", () => {
+    // Not a skip: a somafm URL the catalogue does not back is precisely the
+    // unverifiable claim the probe exists to kill.
+    expect(agreeFailure("https://api.somafm.com/logos/120/ghost120.jpg", "ghost", CATALOGUE)).toBe(
+      'points at somafm but the catalogue has no channel "ghost"',
+    );
+  });
+
+  it("skips a station from another provider, which the table is allowed to hold", () => {
+    expect(agreeFailure("https://example.org/logo.png", "elsewhere", CATALOGUE)).toBeNull();
+  });
+});
+
+describe("the AGREE axis is not vacuous over the real table", () => {
+  it("has something to say about every station in RADIO_STATIONS", () => {
+    // The positive control, and the reason it is here: AGREE skips stations
+    // pointing at another provider, so one inverted comparison skips them ALL
+    // and `check:radio` reports "0 broken" having compared nothing. That green
+    // means silence, and it is indistinguishable from the real one at the
+    // summary line. Assert the axis actually engages.
+    const backed = RADIO_STATIONS.filter((s) => isCatalogueBacked(s.logoUrl));
+    expect(backed.length).toBe(RADIO_STATIONS.length);
+    expect(backed.length).toBeGreaterThan(0);
+  });
+
+  it("flags the whole table against an empty catalogue", () => {
+    // The other side of the same control: if the comparator can never fail,
+    // the case above would still pass.
+    const empty = new Map<string, string>();
+    for (const s of RADIO_STATIONS) {
+      expect(agreeFailure(s.logoUrl, s.id, empty), `station ${s.id}`).not.toBeNull();
+    }
+  });
+});
+
+describe("the union verdict", () => {
+  it("reports both axes when both have something to say", () => {
+    expect(problems(finding({ reach: "HTTP 404", agree: "catalogue ships x" }))).toEqual([
+      "REACH HTTP 404",
+      "AGREE catalogue ships x",
+    ]);
+  });
+
+  it("counts a station broken on EITHER axis alone", () => {
+    // The union is the point: a logo that resolves but is no longer the one
+    // upstream publishes is broken even though REACH is happy, and vice versa.
+    expect(brokenCount([finding({ reach: "HTTP 404" })])).toBe(1);
+    expect(brokenCount([finding({ agree: "catalogue ships x" })])).toBe(1);
+  });
+
+  it("counts a clean station as unbroken", () => {
+    expect(problems(finding({}))).toEqual([]);
+    expect(brokenCount([finding({}), finding({ id: "lush" })])).toBe(0);
+  });
+});

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -5,12 +5,16 @@ import { RADIO_STATIONS } from "../lib/radioStations";
 // exists because breaking it fails SILENTLY in production rather than loudly
 // here.
 //
-// What this file deliberately does NOT assert: that a stream is reachable.
-// That needs the network, and a unit test that hits somafm.com would be a
-// third-party outage detector wired into our gate. Reachability was measured
-// by hand when each entry was added (see the module header for the date and
-// the method) and is re-measured when the list changes — it is not something
-// a test run in CI can honestly stand behind.
+// What this file deliberately does NOT assert: that a stream or a logo is
+// reachable. That needs the network, and a unit test that hits somafm.com would
+// be a third-party outage detector wired into our gate — it would go red on
+// days when nothing of ours is broken. That reasoning still holds; what #1696
+// changed is where the measurement lives. "Measured by hand when each entry was
+// added" was the standing answer here, and for the logos it was false for ten
+// of fourteen rows on the day it was written. So the logo half is now an
+// executable, on-demand probe — `bun run check:radio`
+// (`scripts/check-radio-logos.ts`) — and the stream half remains hand-measured,
+// for the mechanical reason the table's moduledoc gives.
 
 describe("RADIO_STATIONS", () => {
   it("is not empty — an empty table is a picker that opens onto nothing", () => {

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -1,15 +1,35 @@
 // #682 — the curated internet-radio station list.
 //
 // WHY A BAKED-IN TABLE AND NOT A LIVE CATALOGUE. SomaFM publishes its whole
-// catalogue at `https://somafm.com/channels.json` (46 channels, with genre,
-// listener counts and a `lastPlaying` track name), and that endpoint answers
-// `Access-Control-Allow-Origin: *` — measured 2026-08-23. So CORS is NOT what
-// rules it out. OUR OWN CSP is: `connect-src` (GrappaWeb.Plugs.SecurityHeaders)
-// admits `'self'` plus three named third parties, and a `fetch` to somafm.com
-// is not among them. Widening it is a server change and a security-surface
-// decision, so the first cut ships the list as data instead. The same applies
-// to the `.pls` playlists the catalogue points at: fetching one to read the
-// stream URL out of it is a `fetch` too, and falls at the same door.
+// catalogue at `https://api.somafm.com/channels.json` (46 channels, with genre,
+// listener counts and a `lastPlaying` track name), it answers
+// `Access-Control-Allow-Origin: *`, and since #1695 our own `connect-src`
+// (GrappaWeb.Plugs.SecurityHeaders) admits `api.somafm.com`. A live fetch is
+// therefore POSSIBLE now, and the reason this table exists is no longer the one
+// #682 wrote here — that reason was our CSP, and it is spent. The reasons that
+// survive #1696, in the order that decides it:
+//
+//   * The list is CURATED: 46 channels upstream, 14 here. Whatever a render
+//     path reads, the CHOICE of rows is ours and stays in this file.
+//   * `logoUrl` cannot leave the type. A station from another provider has no
+//     row in SomaFM's catalogue and must still carry a logo — this is a table
+//     of stations, not a table of SomaFM slugs. So reading `image` at runtime
+//     would not REPLACE the baked field, it would stack a second source on top
+//     of it and split ONE record across two authorities field by field. That
+//     is more housekeeping than it removes, not less.
+//   * The failure that filed #1696 was NOT upstream drift, measured
+//     2026-08-24: every `.jpg` this table got wrong carries a `?v=` upload
+//     stamp of 2026-06-12 or earlier — three of them from 2023 — while the
+//     table was written 2026-08-23. Nothing moved under us. The claim further
+//     down was simply never checked. A runtime read is the cure for drift, and
+//     drift is not what happened.
+//   * A cosmetic pixel is a thin reason to put a third party in the render
+//     path. The picker renders from a constant and awaits nothing today.
+//
+// So the catalogue IS the authority for these URLs, and `bun run check:radio`
+// consults it at CHECK time rather than at RENDER time. That buys the pinning
+// without buying a runtime failure mode: when somafm is unreachable the picker
+// still draws the logos it drew yesterday.
 //
 // What needs NO server change, and is why this works at all:
 //   * `media-src 'self' blob: https:` already admits the <audio> stream —
@@ -23,8 +43,24 @@
 // `ice.somafm.com` also answers, serving `audio/mpeg` with the channel's
 // `icy-name` — it is the stable front door, and ice1..ice6 are the pool
 // behind it. Every entry below was fetched through it and returned real MPEG
-// audio on 2026-08-23; the versionless logo URLs were checked the same way
-// (the catalogue spells them with a `?v=` cache-buster that would rot).
+// audio on 2026-08-23.
+//
+// THE LOGO URL IS NOT DERIVED, IT IS COPIED — and `bun run check:radio` is what
+// says so truthfully. The `<id>120.png` shape this table used to spell only
+// LOOKED like a convention: the extension is per-station AND per-size
+// (`dronezone120.jpg` at 120px, `dronezone256.png` at 256px), and there is no
+// extension-free form to fall back on — `…/logos/120/dronezone120` is a 404.
+// Every logo URL here is therefore a verbatim copy of a catalogue value, minus
+// the `?v=` cache-buster the catalogue spells and we drop on purpose (a
+// timestamp baked into a URL rots on the next re-upload; the versionless path
+// keeps serving). Run the script when you touch this table — it checks both
+// reachability and agreement with the catalogue, and it is out of CI
+// deliberately, for the reason its own header gives.
+//
+// ⚠️ The STREAM half of that claim is still hand-measured and stays that way
+// here: `HEAD` on `ice.somafm.com` returns an empty reply (curl exit 52),
+// because icecast answers a GET with an endless body — proving a stream needs a
+// ranged-or-aborted fetch, a different mechanism from the logo probe.
 //
 // The list is CURATED, not user-editable. A user-editable list is user state
 // and would want `lib/displayPrefs.ts` treatment (server-backed + synced,
@@ -68,7 +104,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description:
       "Served best chilled, safe with most medications. Atmospheric textures with minimal beats.",
     streamUrl: "https://ice.somafm.com/dronezone-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/dronezone120.png",
+    logoUrl: "https://api.somafm.com/logos/120/dronezone120.jpg",
   },
   {
     id: "spacestation",
@@ -76,7 +112,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["electronic"],
     description: "Tune in, turn on, space out. Spaced-out ambient and mid-tempo electronica.",
     streamUrl: "https://ice.somafm.com/spacestation-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/spacestation120.png",
+    logoUrl: "https://api.somafm.com/logos/120/spacestation120.jpg",
   },
   {
     id: "lush",
@@ -84,7 +120,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["electronic"],
     description: "Sensuous and mellow female vocals, many with an electronic influence.",
     streamUrl: "https://ice.somafm.com/lush-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/lush120.png",
+    logoUrl: "https://api.somafm.com/logos/120/lush120.jpg",
   },
   {
     id: "indiepop",
@@ -92,7 +128,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["alternative", "rock"],
     description: "New and classic favorite indie pop tracks.",
     streamUrl: "https://ice.somafm.com/indiepop-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/indiepop120.png",
+    logoUrl: "https://api.somafm.com/logos/120/indiepop120.jpg",
   },
   {
     id: "u80s",
@@ -109,7 +145,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description:
       "The soundtrack for your stylish, mysterious, dangerous life. For Spies and PIs too!",
     streamUrl: "https://ice.somafm.com/secretagent-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/secretagent120.png",
+    logoUrl: "https://api.somafm.com/logos/120/secretagent120.jpg",
   },
   {
     id: "defcon",
@@ -125,7 +161,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["folk", "alternative"],
     description: "Indie Folk, Alt-folk and the occasional folk classics. ",
     streamUrl: "https://ice.somafm.com/folkfwd-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/folkfwd120.png",
+    logoUrl: "https://api.somafm.com/logos/120/folkfwd120.jpg",
   },
   {
     id: "bootliquor",
@@ -133,7 +169,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["americana"],
     description: "Americana Roots music for Cowhands, Cowpokes and Cowtippers",
     streamUrl: "https://ice.somafm.com/bootliquor-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/bootliquor120.png",
+    logoUrl: "https://api.somafm.com/logos/120/bootliquor120.jpg",
   },
   {
     id: "bossa",
@@ -141,7 +177,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["bossanova", "world"],
     description: "Silky-smooth, laid-back Brazilian-style rhythms of Bossa Nova, Samba and beyond",
     streamUrl: "https://ice.somafm.com/bossa-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/bossa120.png",
+    logoUrl: "https://api.somafm.com/logos/120/bossa120.jpg",
   },
   {
     id: "reggae",
@@ -157,7 +193,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["jazz"],
     description: "Transcending the world of jazz with eclectic, avant-garde takes on tradition.",
     streamUrl: "https://ice.somafm.com/sonicuniverse-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/sonicuniverse120.png",
+    logoUrl: "https://api.somafm.com/logos/120/sonicuniverse120.jpg",
   },
   {
     id: "missioncontrol",
@@ -165,6 +201,6 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["ambient", "electronic"],
     description: "Celebrating NASA and Space Explorers everywhere.",
     streamUrl: "https://ice.somafm.com/missioncontrol-128-mp3",
-    logoUrl: "https://api.somafm.com/logos/120/missioncontrol120.png",
+    logoUrl: "https://api.somafm.com/logos/120/missioncontrol120.jpg",
   },
 ];

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -59936,3 +59936,78 @@ policy by construction.
 
 HOT. The policy is a module attribute in `lib/grappa_web/plugs/security_headers.ex`,
 not `config/*.exs` — a recompiled `.beam`, no `VERSION` bump, no migration.
+<!-- entry #1696 -->
+
+---
+
+## 2026-08-24 — #1696: the catalogue is the authority, consulted at check time and not at render time
+
+Ten of the fourteen radio-station logos 404'd. `radioStations.ts` spelled every
+one as `<id>120.png`, and that shape only LOOKED like a convention: measured,
+the extension is per-station AND per-size — `dronezone120.jpg` at 120px,
+`dronezone256.png` at 256px — and no extension-free form exists to fall back
+on (`…/logos/120/dronezone120` is a 404, served as `text/html`). Every logo URL
+in that table is therefore a verbatim COPY of a catalogue value, never a
+derivation, and the four that happened to work were the four SomaFM genuinely
+serves as PNG.
+
+### Why the runtime read was declined
+
+#1695 had just admitted `api.somafm.com` to `connect-src`, so reading `image`
+straight from `channels.json` was newly possible, and the issue proposed it as
+the real cure with the extension fix as an admitted stopgap. It was declined,
+on four grounds:
+
+* **`logoUrl` cannot leave the type.** A station from another provider has no
+  catalogue row and must still carry a logo — the table's own stated invariant
+  is that it is a table of STATIONS, not of SomaFM slugs. So a runtime read
+  would not REPLACE the baked field, it would stack a second source on top of
+  it and split one record across two authorities field by field. That is more
+  housekeeping than it removes, which inverts the reason for reaching for it.
+* **The list is curated** — 46 channels upstream, 14 here — so the choice of
+  rows stays in this file regardless of what a render path reads.
+* **This was not drift, and drift is the only thing a runtime read cures.**
+  Every `.jpg` the table got wrong carries a `?v=` upload stamp of 2026-06-12
+  or earlier, three of them from 2023, while the table was written 2026-08-23.
+  Nothing moved under us in the 2.5 months between. The extensions were wrong
+  the day they were typed.
+* **A cosmetic pixel is a thin reason** to put a third party in a render path
+  that today awaits nothing.
+
+### The general rule this leaves
+
+The defect was never the ten characters. It was that `radioStations.ts` asserted
+a fact about EXTERNAL state — "the versionless logo URLs were checked" — that
+no artefact in the repo could establish, so a true claim and a false one read
+identically to every later reader. Writing the claim more carefully does not
+fix that; making it executable does.
+
+So the catalogue IS the authority for these URLs, and `bun run check:radio`
+(`cicchetto/scripts/check-radio-logos.ts`) consults it at CHECK time rather than
+at RENDER time. Two axes per station, union verdict, the `scripts/check.ts`
+posture: REACH (200 AND an `image/*` content type — a status-only assert would
+wave through the `text/html` soft 404 this host serves) and AGREE (the baked URL
+equals what `channels.json` publishes, `?v=` stripped, for stations pointing at
+somafm). That pins the table to the authority and buys no runtime failure mode:
+when somafm is unreachable the picker still draws the logos it drew yesterday.
+There is no fetch to fail.
+
+It is out of `bun run check` and out of CI deliberately. `radioStations.test.ts`
+had already argued that a gate fetching somafm.com is a third-party outage
+detector bolted to our build, going red on days when nothing of ours is broken.
+That argument is right and survives; what was wrong was leaving the alternative
+as a human's memory. An unfetchable catalogue exits 1 and never 0 — "not
+measured" reading as "measured ok" is the original bug in miniature.
+
+### What stays hand-measured, and why
+
+The stream half of the same claim. `HEAD` on `ice.somafm.com` returns an empty
+reply (curl exit 52) because icecast answers a GET with an endless body, so
+proving a stream needs a ranged-or-aborted fetch — a different mechanism from
+the logo probe, and out of scope here rather than silently folded in.
+
+### Deploy class
+
+cic bundle only. No server module, no `VERSION` bump, no migration: the change
+is the station table, one new `cicchetto/scripts/` probe and a `package.json`
+script that CI never calls.


### PR DESCRIPTION
Ten of the fourteen radio-station logos 404. `radioStations.ts` spelled every one
as `<id>120.png`; the four that worked were the four SomaFM genuinely serves as
PNG. Re-measured on this branch before touching anything: **10 × 404, 4 × 200**,
matching the issue exactly.

## What was actually wrong

`<id>120.png` only LOOKED like a convention. Measured:

- the extension is per-station **and per-size** — `dronezone120.jpg` at 120px,
  `dronezone256.png` at 256px;
- there is no extension-free form to fall back on: `…/logos/120/dronezone120`
  is a 404, served as `text/html`.

So every logo URL in that table is a verbatim **copy** of a catalogue value,
never a derivation. The ten now spell what `channels.json` publishes.

## The design question: why not read `channels.json` at runtime

#1695 has just admitted `api.somafm.com` to `connect-src`, so the runtime read
the issue proposes is newly possible. It was **declined**, on four grounds — the
third is the one that decides it:

- **`logoUrl` cannot leave the type.** A station from another provider has no
  catalogue row and must still carry a logo; the table's own stated invariant is
  that it is a table of *stations*, not of SomaFM slugs. A runtime read would not
  REPLACE the baked field, it would stack a second source on top of it and split
  one record across two authorities field by field — more housekeeping than it
  removes, which inverts the reason for reaching for it.
- **The list is curated** (46 upstream, 14 here), so the choice of rows stays in
  this file whatever a render path reads.
- **This was not drift, and drift is the only thing a runtime read cures.** Every
  `.jpg` the table got wrong carries a `?v=` upload stamp of **2026-06-12 or
  earlier** — three of them from **2023** — while the table was written
  **2026-08-23**. Nothing moved under us in those 2.5 months; the extensions were
  wrong the day they were typed.
- **A cosmetic pixel is a thin reason** to put a third party in a render path
  that today awaits nothing.

The catalogue **is** the authority for these URLs. The change consults it at
**check time** rather than at **render time**.

### What happens when the fetch fails

There is no fetch to fail. The picker renders from a constant, as before; when
somafm is unreachable it draws the logos it drew yesterday. That is the whole
point of keeping the authority at the gate instead of in the render path.

## The class, not the instance

The defect was never the ten characters. `radioStations.ts` asserted a fact about
**external state** — *"the versionless logo URLs were checked"* — that no
artefact in the repo could establish, so a true claim and a false one read
identically to every later reader. Writing the claim more carefully does not fix
that; making it executable does.

`bun run check:radio` (`cicchetto/scripts/check-radio-logos.ts`), two axes per
station, union verdict, the `scripts/check.ts` posture:

- **REACH** — 200 **and** an `image/*` content type. Status alone would wave
  through the `text/html` soft 404 this host serves.
- **AGREE** — the baked URL equals what `channels.json` publishes, `?v=`
  stripped, for stations pointing at somafm.

It is **out of `bun run check` and out of CI deliberately**.
`radioStations.test.ts` had already argued that a gate fetching somafm.com is a
third-party outage detector bolted to our build, going red on days when nothing
of ours is broken — that argument is right and survives. What was wrong was
leaving the alternative as a human's memory. An unfetchable catalogue exits 1 and
never 0: *"not measured"* reading as *"measured ok"* is the original bug in
miniature.

## Declared non-measure

The **stream** half of the same claim stays hand-measured, and now says so in the
moduledoc. `HEAD` on `ice.somafm.com` returns an empty reply (curl exit 52)
because icecast answers a GET with an endless body — proving a stream needs a
ranged-or-aborted fetch, a different mechanism from the logo probe. Out of scope
here rather than silently folded in.

No e2e was run: this branch needed no lane and changes no runtime behaviour in
the picker beyond the string in `src`.

## Gates

| gate | result |
|---|---|
| `bun run check:radio` **before** the fix | **exit 1** — 14 checked, **10 broken**, both axes naming each station |
| `bun run check:radio` **after** | **exit 0** — 14 checked, 0 broken |
| `scripts/bun.sh run check` | 4 stages ran, **0 failed** (lock drift, biome, tsc src, tsc e2e) |
| `scripts/bun.sh run test` | **304 files, 5926 tests passed** |
| `scripts/design-notes-gate.sh` | `1 new entry heading(s), separator and marker present` |

Refs #1696.