### PR TITLE
#1697 — radio player: hideable transport, shared pane band in the picker, tap targets that land

### DIFF
--- a/cicchetto/src/AdminPane.tsx
+++ b/cicchetto/src/AdminPane.tsx
@@ -11,7 +11,7 @@ import AdminVhostsTab from "./AdminVhostsTab";
 import AdminNav, { type AdminNavGroup, type AdminNavTab } from "./admin/AdminNav";
 import { startAdminEventsSubscription, uninstallAdminEvents } from "./lib/adminEvents";
 import { adminOverview } from "./lib/adminOverview";
-import PaneTopBar from "./PaneTopBar";
+import PaneTopBar, { PaneTopBarRailOpener } from "./PaneTopBar";
 
 // M-7 — Admin console pane. Replaces the channel content in
 // Shell.tsx when an admin operator clicks "admin console" in
@@ -144,7 +144,13 @@ const AdminPane: Component<Props> = (props) => {
           the `--adm-*` layer. Everything admin-shaped goes in the content slot;
           the ☰ comes with the band, and comes LAST, which is what finally puts
           it on the same side as the channel bar's. */}
-      <PaneTopBar onOpenRail={props.onOpenRail} railLabel="open actions">
+      <PaneTopBar
+        trailing={
+          /* #1697 — passed in rather than baked into the band; see the note on
+             the channel bar's identical call. */
+          <PaneTopBarRailOpener onOpenRail={props.onOpenRail} railLabel="open actions" />
+        }
+      >
         <h1>admin console</h1>
         {/* #1073 — the live key stats, fed by the `"overview"` push the admin
             channel already carries (`lib/adminOverview.ts`). Read here rather

--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -1,5 +1,5 @@
 import { type Component, createEffect, createSignal, on, Show } from "solid-js";
-import { activeAudio, closeAudio } from "./lib/audioPlayer";
+import { activeAudio, closeAudio, hidePlayer, playerHidden } from "./lib/audioPlayer";
 
 // Docked audio mini-player (GH #115) — a slim transport bar pinned above
 // the compose box. Non-modal: scrollback stays scrollable + readable
@@ -22,6 +22,23 @@ import { activeAudio, closeAudio } from "./lib/audioPlayer";
 // the caller — so it is correct for ANY endless source, not just the radio
 // stations that motivated it, and it cannot drift from the element's truth.
 // It is the general rule, not the incident.
+//
+// #1697 — HIDING. The bar was permanent once a source was tuned: the only way
+// off the screen was the ✕, which STOPS. Hiding is now a second control and a
+// second signal (`playerHidden`), and the mechanism costs nothing because the
+// element is ALREADY mounted outside the <Show> below — the unconditional mount
+// documented just above, put there for the ref-assignment race, is exactly what
+// makes "hide while it keeps playing" free. Narrowing the <Show> predicate
+// cannot reach the element.
+//
+// Two shapes this must NOT become, both of which stop playback:
+//   * hiding by unmounting this component from Shell — that destroys the
+//     element (which is why leaving chat for home already stops playback);
+//   * carrying the hidden flag inside `activeAudio` — that re-fires the effect
+//     below, which reassigns `.src` and re-buffers a live stream.
+// The door back is in `RailActions`, not here: a restore handle left in this
+// slot would still have to clear the 44px tap floor, so it would give back
+// almost none of the vertical space that motivated hiding.
 
 const formatTime = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
@@ -97,7 +114,7 @@ const AudioMiniPlayer: Component = () => {
         onTimeUpdate={() => setCurrent(audioEl?.currentTime ?? 0)}
         onLoadedMetadata={() => setDuration(audioEl?.duration ?? 0)}
       />
-      <Show when={activeAudio() !== null}>
+      <Show when={activeAudio() !== null && !playerHidden()}>
         <div class="audio-mini-player" data-testid="audio-mini-player">
           <button
             type="button"
@@ -168,6 +185,21 @@ const AudioMiniPlayer: Component = () => {
               ⬇
             </a>
           </Show>
+          {/* #1697 — HIDE, beside the ✕ and never merged with it. The ✕ is the
+              STOP verb, and on a phone it is the only reachable one while the
+              rail that holds the station chrome is slid off-screen; collapsing
+              the two would cost the operator the ability to stop. The glyph is
+              a chevron down (the surface leaves downward, past the compose
+              box), and the accessible name says what survives the gesture. */}
+          <button
+            type="button"
+            class="audio-mini-player-hide"
+            data-testid="audio-mini-player-hide"
+            onClick={hidePlayer}
+            aria-label="hide player, keep playing"
+          >
+            ⌄
+          </button>
           <button
             type="button"
             class="audio-mini-player-close"

--- a/cicchetto/src/PaneTopBar.tsx
+++ b/cicchetto/src/PaneTopBar.tsx
@@ -41,6 +41,27 @@ import type { Component, JSX } from "solid-js";
  * genuinely name the same door differently — the channel bar's ☰ has always
  * been *"open members sidebar"*, and changing it would rewrite the eight specs
  * that click it by that name.
+ *
+ * ## #1697 — the trailing control became a SLOT, and the ☰ became a passenger
+ *
+ * The third host is the rail's radio picker, and it is the one that broke the
+ * "extraction, not parameterisation" reading above. Two measured reasons, and
+ * either alone is decisive: the picker's trailing control must be a ✕ (a
+ * rail-opener inside the already-open rail is a door to the floor you are
+ * standing on), and `.topic-bar .topic-bar-hamburger` is `display: none` on
+ * desktop — so a picker inheriting the ☰ would lose its only dismiss control
+ * to a CSS rule written for a different host.
+ *
+ * So `trailing` is a slot, and the ☰ moved out into `PaneTopBarRailOpener`,
+ * which both original hosts render. The emitted markup is unchanged for them,
+ * which is why #1073's ordering pin in `TopicBar.test.tsx` and the accessible
+ * name in `AdminPane.test.tsx` stay green without an edit — the extraction's
+ * invariant (the trailing child is what puts the control on the right) is now
+ * stated by the slot rather than by the hard-coded button.
+ *
+ * The slot is REQUIRED, not defaulted to the ☰: a default would let a new host
+ * inherit a rail door it never asked for, silently, which is the degradation
+ * pattern this codebase bans.
  */
 export type Props = {
   /**
@@ -50,30 +71,51 @@ export type Props = {
    * for #344's intra-block line registration on the channel bar.
    */
   children: JSX.Element;
+  /**
+   * The band's LAST child. Being last is what places it on the right, on every
+   * surface wearing this band (#1073) — so a host passes the control itself,
+   * not a callback the band wraps.
+   */
+  trailing: JSX.Element;
+};
+
+export type RailOpenerProps = {
   onOpenRail: () => void;
-  /** Accessible name for the ☰ — the two hosts word this door differently. */
+  /** Accessible name for the ☰ — the hosts word this door differently. */
   railLabel: string;
+};
+
+/**
+ * #881 — UNCONDITIONAL. This ☰ is not a members toggle, it is the rail door: on
+ * mobile it opens `.shell-members`, the permanent right rail hosting Archive,
+ * Settings, Rooms and Admin. It used to sit behind `windowIsJoined` on the
+ * premise that it toggled a member list, and that gate took the whole
+ * navigation with it, stranding a `:failed`/`:kicked`/`:parked` window with no
+ * way out. Joinedness gates the LIST, never the DOOR.
+ *
+ * #1697 lifted it out of the band's body so the band could take a different
+ * trailing control. It lives HERE rather than being duplicated at its two call
+ * sites for the ordinary reason: two copies of a button whose class drives a
+ * desktop `display: none` rule is one copy too many.
+ */
+export const PaneTopBarRailOpener: Component<RailOpenerProps> = (props) => {
+  return (
+    <button
+      type="button"
+      class="topic-bar-hamburger shell-chrome-btn"
+      aria-label={props.railLabel}
+      onClick={props.onOpenRail}
+    >
+      {"\u{2630}"}
+    </button>
+  );
 };
 
 const PaneTopBar: Component<Props> = (props) => {
   return (
     <div class="topic-bar">
       <div class="topic-bar-header">{props.children}</div>
-      {/* #881 — UNCONDITIONAL. This ☰ is not a members toggle, it is the rail
-          door: on mobile it opens `.shell-members`, the permanent right rail
-          hosting Archive, Settings, Rooms and Admin. It used to sit behind
-          `windowIsJoined` on the premise that it toggled a member list, and
-          that gate took the whole navigation with it, stranding a
-          `:failed`/`:kicked`/`:parked` window with no way out. Joinedness
-          gates the LIST, never the DOOR. */}
-      <button
-        type="button"
-        class="topic-bar-hamburger shell-chrome-btn"
-        aria-label={props.railLabel}
-        onClick={props.onOpenRail}
-      >
-        {"\u{2630}"}
-      </button>
+      {props.trailing}
     </div>
   );
 };

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@solidjs/router";
 import { type Component, createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 import { refreshInCardHead, refreshSlot } from "./admin/refreshSlot";
 import { archiveSlugForSelection } from "./lib/archiveContext";
+import { activeAudio, playerHidden, showPlayer } from "./lib/audioPlayer";
 import { type ChannelKey, channelKey } from "./lib/channelKey";
 import { conversationMuteKey, isConversationMuted } from "./lib/conversationMute";
 import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
@@ -431,6 +432,51 @@ const RailActions: Component<Props> = (props) => {
                   {"\u{1F4E3}"}
                 </span>
                 <span class="rail-action-label">mentions</span>
+              </button>
+            )}
+          </Show>
+
+          {/* #1697 — the door back to a HIDDEN transport. `AudioMiniPlayer`
+              can now be taken off screen while it keeps playing, and this is
+              what restores it.
+              WHY HERE. It has to be general: an upload passes `label: null`
+              and is in no station table, so the rail's `rail-radio-now` chrome
+              (gated on `tunedStation()`) cannot be the door — whatever
+              restores the bar is keyed on the PLAYER, not on the radio. And it
+              has to cost no vertical space, which is the entire point of
+              hiding: a restore handle left in the docked slot would still owe
+              the 44px HIG floor, giving back almost none of the room the
+              operator hid the bar to reclaim. This drawer already carries
+              zero permanent cost (#500) and already hosts `radio`.
+              Gated on there being something to restore, the same
+              CAPABILITY gate the mentions launcher above uses. Closes the menu
+              like every launcher that navigates away: what it reveals is
+              behind this drawer. */}
+          <Show when={activeAudio() !== null && playerHidden()}>
+            {(_present) => (
+              <button
+                type="button"
+                class="shell-chrome-btn rail-action rail-action-show-player"
+                /* The label names the source when it has one: hidden, this row
+                   inherits the job the docked bar's caption did on mobile
+                   (#682), which is answering "what am I listening to". An
+                   upload has no title on the wire, so it says nothing rather
+                   than inventing one. */
+                aria-label={
+                  activeAudio()?.label === null || activeAudio()?.label === undefined
+                    ? "show player"
+                    : `show player — ${activeAudio()?.label}`
+                }
+                data-testid="rail-action-show-player"
+                onClick={() => {
+                  showPlayer();
+                  close();
+                }}
+              >
+                <span class="rail-action-icon" aria-hidden="true">
+                  {"\u{1F39A}"}
+                </span>
+                <span class="rail-action-label">player</span>
               </button>
             )}
           </Show>

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -4,6 +4,7 @@ import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { closeRadioPicker, radioPickerOpen, tunedStation, tuneStation } from "./lib/radio";
 import { RADIO_STATIONS } from "./lib/radioStations";
+import PaneTopBar from "./PaneTopBar";
 
 // #682 — the rail's internet-radio surface: a station PICKER and, once
 // something is tuned, the station CHROME. Two views of the ONE audio player.
@@ -79,9 +80,13 @@ const RailRadio: Component = () => {
             {/* `closeAudio` directly: it already IS the stop verb, and the
                 station is derived from the player, so clearing the player is
                 what un-tunes. No radio-flavoured wrapper around it. */}
+            {/* #1697 — `.shell-chrome-btn` here too. The issue named the
+                picker's ✕, but this button carried the identical `2rem`
+                (= 28px at a 14px root) tap floor: one defect, two instances,
+                and fixing only the reported one leaves the class alive. */}
             <button
               type="button"
-              class="rail-radio-stop"
+              class="rail-radio-stop shell-chrome-btn"
               data-testid="rail-radio-stop"
               onClick={closeAudio}
               aria-label="stop radio"
@@ -94,43 +99,67 @@ const RailRadio: Component = () => {
 
       <Show when={radioPickerOpen()}>
         <div class="rail-radio-picker" data-testid="rail-radio-picker">
-          <div class="rail-radio-picker-head">
+          {/* #1697 — the SHARED band, not a lookalike. This used to be a
+              hand-rolled `.rail-radio-picker-head` on its own `--rail-radio-*`
+              layer, free to drift from the two surfaces rendering the real
+              one; #1073 extracted the band for exactly this reason and this is
+              its third host. The trailing control is a ✕, which is why #1697
+              had to turn that position into a slot: a rail-opener here would
+              be a door to the surface it is standing on, and its class is
+              `display: none` on desktop, so inheriting it would have cost the
+              picker its only dismiss control on the form factor where it
+              works today. */}
+          <PaneTopBar
+            trailing={
+              <button
+                type="button"
+                /* `.shell-chrome-btn` is what gives this a tap target. The
+                   bespoke rule it replaces asked for `2rem`, which is 28px at
+                   this app's 14px root — under the 44px HIG floor, and the
+                   reason the ✕ rendered without landing. Reuse, not a bigger
+                   number. */
+                class="rail-radio-picker-close shell-chrome-btn"
+                data-testid="rail-radio-picker-close"
+                onClick={closeRadioPicker}
+                aria-label="close radio picker"
+              >
+                {"✕"}
+              </button>
+            }
+          >
             {/* Mirrors the MembersPane `<h3>` slot (uppercased by CSS), the
                 established heading shape for rail content. */}
             <h3 class="rail-radio-heading">radio</h3>
-            <button
-              type="button"
-              class="rail-radio-picker-close"
-              data-testid="rail-radio-picker-close"
-              onClick={closeRadioPicker}
-              aria-label="close radio picker"
-            >
-              {"✕"}
-            </button>
+          </PaneTopBar>
+          {/* The scroll moved off the picker box onto this list when the band
+              arrived: the band must span the panel edge to edge, the way it
+              does on its other two hosts, so the padding that used to sit on
+              the scroller sits here instead. */}
+          <div class="rail-radio-picker-list">
+            <For each={RADIO_STATIONS}>
+              {(station) => (
+                <button
+                  type="button"
+                  class="rail-radio-station"
+                  classList={{ tuned: tunedStation()?.id === station.id }}
+                  data-testid={`rail-radio-station-${station.id}`}
+                  onClick={() => tuneStation(station)}
+                  /* aria-pressed, not aria-selected: these are toggle buttons in
+                     a plain container, not options in a listbox — and it is what
+                     marks the tuned row for a screen reader, matching the visual
+                     `.tuned` class. */
+                  aria-pressed={tunedStation()?.id === station.id ? "true" : "false"}
+                  title={station.description}
+                >
+                  <img class="rail-radio-station-logo" src={station.logoUrl} alt="" />
+                  <span class="rail-radio-station-text">
+                    <span class="rail-radio-station-title">{station.title}</span>
+                    <span class="rail-radio-station-genres">{station.genres.join(" · ")}</span>
+                  </span>
+                </button>
+              )}
+            </For>
           </div>
-          <For each={RADIO_STATIONS}>
-            {(station) => (
-              <button
-                type="button"
-                class="rail-radio-station"
-                classList={{ tuned: tunedStation()?.id === station.id }}
-                data-testid={`rail-radio-station-${station.id}`}
-                onClick={() => tuneStation(station)}
-                /* aria-pressed, not aria-selected: these are toggle buttons in
-                   a plain container, not options in a listbox — and it is what
-                   marks the tuned row for a screen reader, matching the visual
-                   `.tuned` class. */
-                aria-pressed={tunedStation()?.id === station.id ? "true" : "false"}
-                title={station.description}
-              >
-                <img class="rail-radio-station-logo" src={station.logoUrl} alt="" />
-                <span class="rail-radio-station-text">
-                  <span class="rail-radio-station-title">{station.title}</span>
-                  <span class="rail-radio-station-genres">{station.genres.join(" · ")}</span>
-                </span>
-              </button>
-            )}
-          </For>
         </div>
       </Show>
     </div>

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -18,7 +18,7 @@ import { createOverlayLock } from "./lib/overlayScrollLock";
 import { pushChannelTopicClear } from "./lib/socket";
 import { windowIsJoined } from "./lib/windowState";
 import { MircBody } from "./MircText";
-import PaneTopBar from "./PaneTopBar";
+import PaneTopBar, { PaneTopBarRailOpener } from "./PaneTopBar";
 
 // Top bar of the middle pane. Hosts:
 //  * channel-name + modes box (#275): the channel name (bold accent) on line
@@ -303,7 +303,17 @@ const TopicBar: Component<Props> = (props) => {
           selector descending from `.topic-bar`, so the move is inert;
           and while closed `<Show>` renders no element, which is what
           keeps the bar's child list at exactly two. */}
-      <PaneTopBar onOpenRail={props.onToggleMembers} railLabel="open members sidebar">
+      <PaneTopBar
+        trailing={
+          /* #1697 — the ☰ is passed IN now: the band's trailing control became
+             a slot when the rail's radio picker needed a ✕ there instead. Same
+             button, same class, same position — the markup is unchanged. */
+          <PaneTopBarRailOpener
+            onOpenRail={props.onToggleMembers}
+            railLabel="open members sidebar"
+          />
+        }
+      >
         {/* #275 — channel name + modes STACKED in ONE width-capped clickable
           box. The whole box opens the /mode viewer/editor modal (reuse
           `openModeModal` — the SAME verb `/mode #chan`, bare `/mode`, and the

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AudioMiniPlayer from "../AudioMiniPlayer";
-import { activeAudio, closeAudio, playAudio } from "../lib/audioPlayer";
+import { activeAudio, closeAudio, playAudio, playerHidden, showPlayer } from "../lib/audioPlayer";
 
 // jsdom does not implement HTMLMediaElement playback — stub the methods
 // the player drives so the component mounts without "Not implemented".
@@ -17,10 +17,12 @@ beforeEach(() => {
   pauseSpy = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
   vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
   closeAudio();
+  showPlayer();
 });
 
 afterEach(() => {
   closeAudio();
+  showPlayer();
   vi.restoreAllMocks();
 });
 
@@ -151,5 +153,86 @@ describe("AudioMiniPlayer", () => {
     playAudio("https://grappa.example/uploads/abc", null);
 
     expect(screen.queryByTestId("audio-mini-player-label")).toBeNull();
+  });
+
+  // #1697 — the bar was permanent once a station was tuned: the only way off
+  // the screen was the ✕, which STOPS. Hiding is a different gesture and the
+  // two must not be one control.
+  //
+  // Why these assertions and not a screenshot: jsdom implements no media
+  // pipeline, so "it kept playing" is not directly observable here. What IS
+  // observable — and is the entire mechanism — is that the <audio> element
+  // survives the gesture with its source attached and that neither `pause()`
+  // nor a fresh `play()` is issued. Those three together are exactly the
+  // footprint of "nothing in the element's effect chain ran".
+  describe("#1697 — hiding the surface without stopping the audio", () => {
+    const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
+
+    it("hiding removes the bar but leaves the source loaded and untouched", () => {
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      playSpy.mockClear();
+      pauseSpy.mockClear();
+
+      screen.getByTestId("audio-mini-player-hide").click();
+
+      expect(screen.queryByTestId("audio-mini-player")).toBeNull();
+      expect(screen.getByTestId("audio-mini-player-el")).toHaveAttribute("src", STATION);
+      expect(activeAudio()).not.toBeNull();
+      expect(playerHidden()).toBe(true);
+    });
+
+    it("hiding issues no pause and no re-play — the element is not disturbed", () => {
+      // The mutation this kills: reaching for `activeAudio` to carry the hidden
+      // flag. That re-fires `on(activeAudio)`, which reassigns `audioEl.src`
+      // and calls `play()` again — a visible re-buffer of a live stream, which
+      // is precisely the thing "hide ≠ stop" forbids.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      playSpy.mockClear();
+      pauseSpy.mockClear();
+
+      screen.getByTestId("audio-mini-player-hide").click();
+
+      expect(pauseSpy).not.toHaveBeenCalled();
+      expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it("the bar comes back with the same source still attached", () => {
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      screen.getByTestId("audio-mini-player-hide").click();
+      playSpy.mockClear();
+
+      showPlayer();
+
+      expect(screen.getByTestId("audio-mini-player")).toBeInTheDocument();
+      expect(screen.getByTestId("audio-mini-player-el")).toHaveAttribute("src", STATION);
+      expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it("hide and close stay two distinct controls, and only close stops", () => {
+      // Guards against the tempting simplification of folding them: the ✕ is
+      // the STOP verb (#115) and the phone's only reachable one while the rail
+      // is slid off-screen.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+
+      expect(screen.getByTestId("audio-mini-player-hide")).toBeInTheDocument();
+      screen.getByTestId("audio-mini-player-close").click();
+
+      expect(activeAudio()).toBeNull();
+      expect(pauseSpy).toHaveBeenCalled();
+    });
+
+    it("a new source re-shows a hidden bar rather than playing behind it", () => {
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      screen.getByTestId("audio-mini-player-hide").click();
+
+      playAudio("https://grappa.example/uploads/abc", null);
+
+      expect(screen.getByTestId("audio-mini-player")).toBeInTheDocument();
+    });
   });
 });

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -165,6 +165,14 @@ vi.mock("../lib/mobilePanel", () => ({
 }));
 
 import ConfirmModal from "../ConfirmModal";
+import {
+  activeAudio,
+  closeAudio,
+  hidePlayer,
+  playAudio,
+  playerHidden,
+  showPlayer,
+} from "../lib/audioPlayer";
 import { channelKey } from "../lib/channelKey";
 import { dismissConfirm } from "../lib/confirmDialog";
 import RailActions from "../RailActions";
@@ -1044,5 +1052,117 @@ describe("the admin refresh, moved into the rail (#1073)", () => {
     render(() => <RailActions setters={setters} />);
     expect(screen.queryByTestId("admin-visitors-refresh")).toBeNull();
     expect(screen.queryByTestId("rail-action-refresh")).toBeNull();
+  });
+});
+
+// #1697 — the door back to a hidden transport.
+//
+// `AudioMiniPlayer` can now be taken off screen while it keeps playing, and
+// something has to bring it back. It lands HERE, and the placement is the
+// argument:
+//
+//   * GENERAL. An upload passes `label: null` and is in no station table, so
+//     the rail's `rail-radio-now` chrome — which is gated on `tunedStation()` —
+//     cannot be the door. Whatever restores the bar has to be keyed on the
+//     PLAYER, not on the radio.
+//   * ZERO VERTICAL COST, which is the entire point of hiding. A restore
+//     handle left in the docked slot would still have to clear the 44px HIG
+//     floor this very issue is about, so it would give back almost none of the
+//     space the operator hid the bar to reclaim.
+//   * CAPABILITY-GATED, exactly like the `mentions` launcher above: the row
+//     exists only while there is something to restore.
+//
+// The cost, stated rather than hidden: on mobile this is three taps
+// (☰ → launcher → row) against one for a handle in place. Hiding is the
+// frequent gesture; restoring is the occasional one.
+describe("RailActions — restoring a hidden audio player (#1697)", () => {
+  const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
+
+  afterEach(() => {
+    closeAudio();
+    showPlayer();
+  });
+
+  it("offers no restore row while nothing is playing", () => {
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    expect(screen.queryByTestId("rail-action-show-player")).toBeNull();
+  });
+
+  it("offers no restore row while the player is on screen", () => {
+    // The row is not a duplicate transport door — with the bar visible there is
+    // nothing to restore, and a row saying otherwise would be chrome noise in a
+    // drawer #500 exists to keep short.
+    playAudio(STATION, "Groove Salad");
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    expect(screen.queryByTestId("rail-action-show-player")).toBeNull();
+  });
+
+  it("offers the restore row once a playing player has been hidden", () => {
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+
+    const row = screen.getByTestId("rail-action-show-player");
+    expect(row).toBeInTheDocument();
+    expect(row).toHaveTextContent("player");
+  });
+
+  it("names the hidden source, so the operator knows what is still playing", () => {
+    // On mobile the docked bar was the ONLY surface naming a station (#682);
+    // hidden, this row inherits that job.
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+
+    expect(screen.getByTestId("rail-action-show-player")).toHaveAttribute(
+      "aria-label",
+      "show player — Groove Salad",
+    );
+  });
+
+  it("names an unlabelled source generically rather than lying about it", () => {
+    // An upload has no title on the wire (slug only), so there is nothing to
+    // name. It must still be restorable — that is the case a radio-flavoured
+    // door would have stranded.
+    playAudio("https://grappa.example/uploads/abc", null);
+    hidePlayer();
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+
+    expect(screen.getByTestId("rail-action-show-player")).toHaveAttribute(
+      "aria-label",
+      "show player",
+    );
+  });
+
+  it("clicking it brings the transport back without touching the source", () => {
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+    const before = activeAudio();
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+
+    fireEvent.click(screen.getByTestId("rail-action-show-player"));
+
+    expect(playerHidden()).toBe(false);
+    expect(activeAudio()).toBe(before);
+  });
+
+  it("closes the menu behind it, like every launcher that navigates away", () => {
+    // RailActions' own rule: a launcher that takes the operator somewhere is
+    // single-shot; a control they flip in place (denoise) is not. Restoring the
+    // bar is the first kind — the thing it reveals is behind this drawer.
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+
+    fireEvent.click(screen.getByTestId("rail-action-show-player"));
+
+    expect(screen.queryByTestId("rail-action-show-player")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/RailRadio.test.tsx
+++ b/cicchetto/src/__tests__/RailRadio.test.tsx
@@ -152,4 +152,81 @@ describe("RailRadio", () => {
 
     expect(screen.getByTestId("rail-radio-picker")).toBeInTheDocument();
   });
+
+  // #1697 — the picker had rebuilt the band `PaneTopBar` already provides, on
+  // its own `--rail-radio-*` layer, free to drift from the two surfaces that
+  // render the real one. #1073 extracted that band for exactly this reason;
+  // the picker is its third host.
+  describe("#1697 — the picker hosts the shared pane band", () => {
+    const band = (container: HTMLElement): Element | null =>
+      container.querySelector(".rail-radio-picker .topic-bar");
+
+    it("renders the shared band, not a lookalike of it", () => {
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+
+      expect(band(container)).not.toBeNull();
+      expect(container.querySelector(".rail-radio-picker-head")).toBeNull();
+    });
+
+    it("puts its heading in the band's content slot", () => {
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+
+      const slot = container.querySelector(".rail-radio-picker .topic-bar-header");
+      expect(slot).toHaveTextContent("radio");
+    });
+
+    it("puts the ✕ LAST in the band, where the other two hosts put their ☰", () => {
+      // #1073's ordering rule, inherited: the trailing child is what places the
+      // control on the right, on every surface that wears this band.
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+
+      expect(band(container)?.lastElementChild).toBe(screen.getByTestId("rail-radio-picker-close"));
+    });
+
+    it("the ✕ wears the shared chrome button, which is what gives it a tap target", () => {
+      // The hit-target half of item 3. `.shell-chrome-btn` carries
+      // `min-width/height: var(--chrome-tap-min)` (48px ABSOLUTE); the bespoke
+      // rule it replaces asked for 2rem, which is 28px at this app's 14px root.
+      render(() => <RailRadio />);
+      openRadioPicker();
+
+      expect(screen.getByTestId("rail-radio-picker-close")).toHaveClass("shell-chrome-btn");
+    });
+
+    it("the rail's stop control wears it too — the same defect, twice", () => {
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+      expect(screen.getByTestId("rail-radio-stop")).toHaveClass("shell-chrome-btn");
+    });
+
+    it("keeps the accessible name and the dismiss wiring across the move", () => {
+      render(() => <RailRadio />);
+      openRadioPicker();
+
+      const close = screen.getByTestId("rail-radio-picker-close");
+      expect(close).toHaveAttribute("aria-label", "close radio picker");
+      close.click();
+
+      expect(radioPickerOpen()).toBe(false);
+    });
+
+    it("does not offer a rail opener inside the already-open rail", () => {
+      // The band's other two hosts put a ☰ in the trailing slot. Rendering one
+      // HERE would be a door to the surface it is already standing on — and on
+      // desktop it is `display: none`, so the picker would lose its only
+      // dismiss control to a CSS rule written for a different host.
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+
+      expect(container.querySelector(".rail-radio-picker .topic-bar-hamburger")).toBeNull();
+      expect(
+        container.querySelector(".rail-radio-picker [data-testid='shell-chrome-rail-opener']"),
+      ).toBeNull();
+    });
+  });
 });

--- a/cicchetto/src/__tests__/audioPlayer.test.ts
+++ b/cicchetto/src/__tests__/audioPlayer.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { activeAudio, closeAudio, playAudio } from "../lib/audioPlayer";
+import {
+  activeAudio,
+  closeAudio,
+  hidePlayer,
+  playAudio,
+  playerHidden,
+  showPlayer,
+} from "../lib/audioPlayer";
 import { setToken } from "../lib/auth";
 
 // Docked audio mini-player store (GH #115). Module-singleton signal —
@@ -58,5 +65,76 @@ describe("audioPlayer store", () => {
     playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
     playAudio("https://grappa.example/uploads/abc", null);
     expect(activeAudio()).toEqual({ href: "https://grappa.example/uploads/abc", label: null });
+  });
+});
+
+// #1697 — HIDING IS NOT STOPPING. `closeAudio` clears the source, and the
+// element effect then pauses + detaches it; that is the STOP verb and it stays.
+// Hiding is a third fact, orthogonal to both "there is a source" and "it is
+// playing", and it gets its own signal.
+describe("audioPlayer transport visibility (#1697)", () => {
+  const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
+
+  afterEach(() => {
+    showPlayer();
+  });
+
+  it("the transport starts shown", () => {
+    expect(playerHidden()).toBe(false);
+  });
+
+  it("hidePlayer hides the transport", () => {
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+    expect(playerHidden()).toBe(true);
+  });
+
+  it("showPlayer brings it back", () => {
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+    showPlayer();
+    expect(playerHidden()).toBe(false);
+  });
+
+  // THE load-bearing assertion, and it is `toBe`, not `toEqual`, on purpose.
+  //
+  // `AudioMiniPlayer` drives the element from `createEffect(on(activeAudio,…))`,
+  // whose body assigns `audioEl.src` — and assigning `.src` re-invokes the media
+  // load algorithm even when the URL is unchanged. So the ONLY shape of this
+  // feature that does not restart the stream on every hide is one where the
+  // source object's IDENTITY survives the gesture. Folding `hidden` into
+  // `AudioPlayerState` (the shape #682 chose for `label`, which describes the
+  // SOURCE) would hand back a fresh object here and turn a hide into a re-buffer.
+  it("hiding does not touch the source object at all — same reference in, same out", () => {
+    playAudio(STATION, "Groove Salad");
+    const before = activeAudio();
+
+    hidePlayer();
+
+    expect(activeAudio()).toBe(before);
+  });
+
+  it("a new source always shows its transport — a hidden player cannot swallow it", () => {
+    hidePlayer();
+    playAudio("https://grappa.example/uploads/abc", null);
+    expect(playerHidden()).toBe(false);
+  });
+
+  it("closing the player leaves no stale hidden flag behind", () => {
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+    closeAudio();
+    expect(playerHidden()).toBe(false);
+  });
+
+  it("token rotation resets the flag with the rest of the store (identity-scoped)", () => {
+    setToken("tokA");
+    playAudio(STATION, "Groove Salad");
+    hidePlayer();
+
+    setToken("tokB");
+
+    expect(playerHidden()).toBe(false);
+    expect(activeAudio()).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/audioPlayerChrome.test.ts
+++ b/cicchetto/src/__tests__/audioPlayerChrome.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #1697 — the DOCKED transport's chrome, from the CSS side.
+//
+// This file deliberately asserts NOTHING about the row's tap floor, and the
+// omission is the point rather than an oversight.
+//
+// What was measured: `html { font-size: var(--font-size) }` with
+// `--font-size: 14px`, so the row's `min-width/height: 2.5rem` resolves to
+// 35px — under the 44px `--tap-min` floor. Same class as the rail picker's ✕
+// at 2rem/28px; #115 sized these in rem and #306's absolute-px sweep never
+// reached them.
+//
+// Why it is not fixed here: #1697 names the PICKER's ✕. Lifting this row grows
+// the docked bar by ~9px, a visible change to a surface that was looked at and
+// approved. That decision is not this issue's to take, so the finding was
+// carved out and filed on its own.
+//
+// A test asserting `2.5rem` would be worse than no test — it would encode a
+// known defect and stop anyone from finding it (CLAUDE.md: never assert buggy
+// behavior). So what is pinned here is floor-NEUTRAL: that the control this
+// issue adds is styled by the row's SHARED rule rather than by a bespoke copy
+// beside it. When the carve-out lands, all four move together because they
+// already share one rule.
+//
+// jsdom applies no stylesheet, so this reads the source. It proves what the
+// cascade is asked to do, never what a device paints.
+
+describe("#1697 — the hide control shares the transport row's rule", () => {
+  const GROUP =
+    ".audio-mini-player-toggle,\n.audio-mini-player-hide,\n.audio-mini-player-close,\n.audio-mini-player-download";
+
+  it("styles the hide control in the shared group, not in a copy of it", () => {
+    // `ruleBody` throws on an absent rule, so a group that stopped naming the
+    // hide control fails here rather than passing vacuously — the #734 guard.
+    expect(ruleBody(GROUP)).toMatch(/flex:\s*none/);
+    expect(() => ruleBody(".audio-mini-player-hide")).toThrow();
+  });
+
+  it("keeps the four controls sized from ONE declaration, whatever it says", () => {
+    // The invariant that survives the carve-out: one rule sets the row's box,
+    // so raising the floor later is a single edit and cannot leave a straggler.
+    // Keyed on "they agree", not on the value — which is exactly what lets this
+    // test stay honest while the value is still wrong.
+    const body = ruleBody(GROUP);
+    const width = body.match(/min-width:\s*([^;]+);/)?.[1]?.trim();
+    const height = body.match(/min-height:\s*([^;]+);/)?.[1]?.trim();
+    expect(width).toBeDefined();
+    expect(width).toBe(height);
+  });
+
+  it("no OTHER rule re-declares the box of one of the four controls", () => {
+    // A second rule setting min-width/height on one of these four would split
+    // the row in two and defeat the single-edit property above — the
+    // cascade-override shape the rail's sibling guard caught on a mutant, where
+    // the class was worn and the floor overridden underneath it.
+    //
+    // Scoped to the four CONTROLS on purpose. `.audio-mini-player-label` and
+    // `-seek` legitimately carry `min-width: 0` — that is the flex ellipsis
+    // chain, not a tap-target box, and an earlier draft of this test flagged
+    // both. A guard that cries about layout it does not govern gets deleted by
+    // the next reader, which is worse than not having it.
+    const CONTROLS = GROUP.split(",\n");
+    const offenders = [
+      ...themeCss.matchAll(/^([.a-z0-9\-,\n]*audio-mini-player[^{]*)\{([^}]*)\}/gm),
+    ]
+      .filter(([, selectors, body]) => {
+        const list = (selectors ?? "").trim();
+        if (list === GROUP) return false;
+        const touchesAControl = CONTROLS.some((c) =>
+          new RegExp(`(^|[\\s,])${c.replace(".", "\\.")}([\\s,{]|$)`).test(list),
+        );
+        return touchesAControl && /min-(width|height):/.test(body ?? "");
+      })
+      .map(([, selectors]) => (selectors ?? "").trim());
+    expect(offenders).toEqual([]);
+  });
+});

--- a/cicchetto/src/__tests__/railRadioChrome.test.ts
+++ b/cicchetto/src/__tests__/railRadioChrome.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #1697 — the rail radio's chrome, from the CSS side.
+//
+// Two defects with ONE root: the picker carried a hand-rolled `--rail-radio-*`
+// chrome layer instead of the band `PaneTopBar` already provides, and its
+// buttons sized their tap target in `rem`.
+//
+// The rem part is arithmetic, not taste. `html { font-size: var(--font-size) }`
+// and `--font-size: 14px`, so the `min-width/height: 2rem` these two buttons
+// carried resolved to 28px — against `--tap-min: 44px` (Apple HIG) and
+// `--chrome-tap-min: 48px`. That is the whole reason the ✕ "renders but does
+// not land". The cure is not a bigger number: it is wearing
+// `.shell-chrome-btn`, which already carries the floor for every other chrome
+// button in the app.
+//
+// jsdom applies no stylesheet, so this reads the source. It proves what the
+// cascade is asked to do, never what a device paints — the tap itself is
+// e2e/dogfood territory.
+
+function declares(body: string, property: string): boolean {
+  return new RegExp(`(^|;)\\s*${property}\\s*:`, "m").test(body);
+}
+
+// Absent rule == no delta left == pass, same reading as sharedButtonRules.ts:
+// a per-instance class whose every declaration moved to the shared class it is
+// worn beside carries no rule of its own.
+function deltaBody(selector: string): string {
+  try {
+    return ruleBody(selector);
+  } catch {
+    return "";
+  }
+}
+
+describe("#1697 — the rail radio's buttons wear the shared chrome button", () => {
+  // Everything `.shell-chrome-btn` declares. A per-instance re-declaration is
+  // the clone coming back, and the tap floor is the one that bites.
+  const SHARED = [
+    "background",
+    "color",
+    "border",
+    "min-width",
+    "min-height",
+    "font-size",
+    "cursor",
+  ];
+
+  it("the shared class is what carries the HIG floor, in absolute px", () => {
+    // Guards the assertion below from being vacuous: adopting a class that has
+    // stopped carrying the floor would buy nothing.
+    const shared = ruleBody(".shell-chrome-btn");
+    expect(shared).toMatch(/min-width:\s*var\(--chrome-tap-min\)/);
+    expect(shared).toMatch(/min-height:\s*var\(--chrome-tap-min\)/);
+    expect(themeCss).toMatch(/--chrome-tap-min:\s*48px/);
+  });
+
+  it.each([".rail-radio-picker-close", ".rail-radio-stop"])(
+    "%s no longer re-declares any shared property",
+    (selector) => {
+      const body = deltaBody(selector);
+      for (const property of SHARED) {
+        expect(declares(body, property), `${selector} must not re-declare ${property}`).toBe(false);
+      }
+    },
+  );
+
+  // The CLASS, not the two examples. A future rail-radio control that sizes its
+  // hit area in rem re-creates the same 28px defect, and nothing else would
+  // catch it — the issue named one button; the sheet had two.
+  it("no rail-radio rule sizes a tap target in rem", () => {
+    const offenders = [...themeCss.matchAll(/^(\.rail-radio[a-z0-9-]*)\s*\{([^}]*)\}/gm)]
+      .filter(([, , body]) => /min-(width|height):\s*[\d.]+rem/.test(body ?? ""))
+      .map(([, selector]) => selector);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("#1697 — the picker inherits the pane band instead of cloning it", () => {
+  it("the hand-rolled header band is gone from the sheet", () => {
+    // `.rail-radio-picker-head` / `.rail-radio-heading` were a lookalike of the
+    // band `.topic-bar` provides. A rule left behind is a second chrome layer
+    // still able to drift, whether or not any element still wears it.
+    expect(() => ruleBody(".rail-radio-picker-head")).toThrow();
+  });
+
+  it("the band the picker now hosts still carries the pane chrome inset", () => {
+    // This is the missing top padding, item 3a: the hand-rolled head took the
+    // scroller's flat 0.5rem, while the band reads the shared inset pair.
+    expect(ruleBody(".topic-bar")).toMatch(
+      /padding:\s*var\(--pane-chrome-inset-block\) var\(--pane-chrome-inset-inline\)/,
+    );
+  });
+
+  it("the picker no longer pads its own box, so the band can span it edge to edge", () => {
+    // A padded scroller would inset the band and re-open the gap between it and
+    // the two surfaces that render the same band flush.
+    expect(declares(ruleBody(".rail-radio-picker"), "padding")).toBe(false);
+  });
+
+  it("the scrolling list keeps the #913 gesture contract", () => {
+    // #913's descendant carve-out is load-bearing on iOS: `touch-action` does
+    // not inherit, and iOS elects the gesture consumer from the hit-test
+    // target's OWN value — so the rows need it, not just the scroller. Moving
+    // the scroll onto an inner list must not drop either half.
+    const list = ruleBody(".rail-radio-picker-list");
+    expect(list).toMatch(/overflow-y:\s*auto/);
+    expect(list).toMatch(/overscroll-behavior:\s*contain/);
+    expect(ruleBody(".rail-radio-picker *")).toMatch(/touch-action:\s*pan-y/);
+  });
+});

--- a/cicchetto/src/lib/audioPlayer.ts
+++ b/cicchetto/src/lib/audioPlayer.ts
@@ -29,11 +29,34 @@ export type AudioPlayerState = {
 
 const exports_ = identityScopedStore((onIdentityChange) => {
   const [activeAudio, setActiveAudio] = createSignal<AudioPlayerState | null>(null);
+  // #1697 — HIDING IS NOT STOPPING, and this is the signal that separates them.
+  //
+  // Three facts live around this player: there IS a source (`activeAudio`), it
+  // IS playing (the <audio> element itself, mounted unconditionally by
+  // `AudioMiniPlayer` OUTSIDE the <Show> that gates the chrome), and the
+  // transport is ON SCREEN. The third had no home, so dismissing the bar could
+  // only be spelled `closeAudio` — which clears the source and therefore stops.
+  //
+  // WHY A SIBLING SIGNAL AND NOT A FIELD OF `AudioPlayerState`. #682 put
+  // `label` in there because it must swap atomically WITH the source, and the
+  // instinct is to follow that. It is wrong here, measurably:
+  // `AudioMiniPlayer` drives the element from `createEffect(on(activeAudio,…))`
+  // and that effect's body assigns `audioEl.src`. Assigning `.src` re-invokes
+  // the media load algorithm even when the URL has not changed, so a hidden
+  // flag riding inside the state object would hand the effect a new reference
+  // and RESTART the stream on every hide — the exact thing this issue forbids.
+  // `label` describes the SOURCE; this describes the CHROME. Different axes,
+  // different signals.
+  const [playerHidden, setPlayerHidden] = createSignal(false);
 
-  onIdentityChange(() => setActiveAudio(null));
+  onIdentityChange(() => {
+    setActiveAudio(null);
+    setPlayerHidden(false);
+  });
 
   return {
     activeAudio,
+    playerHidden,
     // Start (or swap to) the audio at `href`. One instance: a second
     // click replaces the source rather than stacking a new player.
     //
@@ -48,13 +71,32 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // off-screen (`transform: translateX(100%)`), so while a radio station
     // plays, this docked bar is the only surface naming it. Without the label
     // the phone cannot answer "what am I listening to".
+    //
+    // #1697 — a new source ALWAYS shows its transport. Leaving a hidden bar
+    // hidden would let the next upload play with no controls anywhere on
+    // screen, which is a worse version of the bug this fixes.
     playAudio(href: string, label: string | null): void {
       setActiveAudio({ href, label });
+      setPlayerHidden(false);
     },
+    // The STOP verb (#115), unchanged: clearing the source is what makes the
+    // element effect pause and detach it. #1697 only adds the reset, so a
+    // dismissed player cannot leave a stale flag for the next source.
     closeAudio(): void {
       setActiveAudio(null);
+      setPlayerHidden(false);
+    },
+    // #1697 — take the transport off screen. Deliberately says nothing about
+    // the source: the element keeps its src and keeps playing, and that is the
+    // whole point. `RailActions` renders the door back while this is true.
+    hidePlayer(): void {
+      setPlayerHidden(true);
+    },
+    showPlayer(): void {
+      setPlayerHidden(false);
     },
   };
 });
 
-export const { activeAudio, playAudio, closeAudio } = exports_;
+export const { activeAudio, playAudio, closeAudio, playerHidden, hidePlayer, showPlayer } =
+  exports_;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3749,7 +3749,22 @@ html.resize-dragging * {
   font-size: var(--font-size);
 }
 
+/* #1697 — the hide control joins the group rather than sizing itself, and the
+   group's `2.5rem` is left ALONE deliberately.
+   Measured while adding it: the html root font-size is 14px
+   (`:root --font-size`), so `2.5rem` resolves to 35px — under the 44px
+   `--tap-min` floor, the same class of defect as the rail picker's ✕ at
+   2rem/28px, which #306's absolute-px sweep never reached here. Raising it is
+   the right call and it is NOT this issue's: #1697 names the picker's ✕, and
+   lifting this row would grow the docked bar by ~9px — a visible change to a
+   surface vjt looked at and approved ("keeping it above the message box is
+   right"). Filed separately so he decides.
+   The new control therefore ships at the row's height rather than above it: a
+   lone 44px button here grows the bar by exactly the 9px that carve-out exists
+   to avoid, and settling one member of a four-button row apart from its
+   siblings is how a sheet ends up with two patterns. */
 .audio-mini-player-toggle,
+.audio-mini-player-hide,
 .audio-mini-player-close,
 .audio-mini-player-download {
   flex: none;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2361,14 +2361,13 @@ html.resize-dragging * {
   color: var(--muted);
 }
 
+/* #1697 — the only delta left. Everything this rule used to declare
+   (background / colour / border / cursor / the tap floor) now comes from
+   `.shell-chrome-btn`, worn beside this class in the markup. It asked for
+   `min-width/height: 2rem`, which is 28px at this app's 14px root — under the
+   44px HIG floor, the same defect the picker's ✕ was reported with. */
 .rail-radio-stop {
   flex: none;
-  min-width: 2rem;
-  min-height: 2rem;
-  background: var(--bg);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  cursor: pointer;
 }
 
 /* The picker OVERLAYS the whole rail. Deliberately not the
@@ -2381,20 +2380,40 @@ html.resize-dragging * {
    grid track. z-index one step above the actions menu so the two cannot
    argue if both are ever up.
    `overscroll-behavior: contain` stops the scroll chaining into the nick list
-   behind it, as its sibling menu does. */
+   behind it, as its sibling menu does — it moved to the inner list below with
+   the scroll it qualifies.
+
+   #1697 — the scroll moved OFF this box onto `.rail-radio-picker-list`, and
+   the padding with it. The panel now hosts the shared `.topic-bar` band
+   (PaneTopBar), and a band inset by its scroller's padding is not the band its
+   two other hosts render — it has to span the panel edge to edge, which is
+   also where the missing top padding came from: the hand-rolled head inherited
+   this flat 0.5rem, while the band reads `--pane-chrome-inset-block/inline`
+   (0.5rem / 1rem). */
 .rail-radio-picker {
   position: absolute;
   inset: 0;
   z-index: 302;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.5rem;
   background: var(--bg-alt);
   border-left: 1px solid var(--border);
+  touch-action: pan-y;
+}
+
+/* #1697 — the station list, and now the scrolling element. `min-height: 0` is
+   what lets it shrink inside the flex column instead of overflowing the panel
+   (the same flooring `.shell-members` needed at #500); the band above it is
+   `flex: none` by virtue of not growing, so it stays put while this scrolls. */
+.rail-radio-picker-list {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem;
   overflow-y: auto;
   overscroll-behavior: contain;
-  touch-action: pan-y;
 }
 
 /* #913's descendant carve-out, for the same reason it exists on
@@ -2406,15 +2425,17 @@ html.resize-dragging * {
   touch-action: pan-y;
 }
 
-.rail-radio-picker-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
+/* #1697 — `.rail-radio-picker-head` is GONE, not merely unused. It was a
+   lookalike of the band `PaneTopBar` provides (flex row, centred, a content
+   slot and a trailing control), rebuilt on the `--rail-radio-*` layer and free
+   to drift from the two surfaces rendering the real one. The picker hosts
+   `.topic-bar` now, so the row shape, the `--pane-chrome-inset-*` padding and
+   the bottom border all come from there. Leaving the rule behind would leave a
+   second chrome layer alive for the next component to reach for. */
 
 /* Matches the `.members-pane h3` / `.rail-query-heading` slot — the
-   established heading shape for rail content. */
+   established heading shape for rail content. Now rendered INSIDE
+   `.topic-bar-header`, which supplies the `flex: 1; min-width: 0` chain. */
 .rail-radio-heading {
   margin: 0;
   font-size: var(--font-size);
@@ -2422,14 +2443,10 @@ html.resize-dragging * {
   color: var(--muted);
 }
 
+/* #1697 — the only delta left; see the twin note on `.rail-radio-stop`. The
+   tap floor, the palette and the border come from `.shell-chrome-btn`. */
 .rail-radio-picker-close {
   flex: none;
-  min-width: 2rem;
-  min-height: 2rem;
-  background: var(--bg);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  cursor: pointer;
 }
 
 /* A station row. The tap floor is the app-wide absolute one, so it does not


### PR DESCRIPTION
Fixes the three chrome items reported on the radio player after staging. Refs #1697.

> ### 🔴 Item 3 is DEVICE-VERIFY, and this PR cannot close it
>
> "The ✕ is not tappable" was reported **from a phone**. jsdom applies no stylesheet and computes no layout, and CI's Playwright shards are chromium/webkit — **webkit is not iOS**. Everything green here pins the cascade the source *asks for* and the DOM wiring; **nothing in this PR presses a finger to glass.** The verdict for item 3 lives on staging, under vjt's thumb.
>
> What *is* established is the mechanism: the hit target was **28px against a 44px floor**, measured off the sheet, and it is now the shared 48px chrome button. That explains the report; it does not confirm the cure.

## 1. "Hiding is not stopping" — where the playing state lives

Three facts sit around this player, and two of them were fused:

| fact | lives in | before |
|---|---|---|
| there IS a source | `activeAudio` | ✅ |
| it IS playing | the `<audio>` **element** | ✅ already independent |
| the transport is ON SCREEN | — | ❌ fused into fact 1 |

`closeAudio` clears the source; the element effect then pauses and detaches it. That is why dismissing stopped.

**The mechanism was already there.** The `<audio>` element is mounted UNCONDITIONALLY, *outside* the `<Show>` that gates the chrome — put there by #115 for an unrelated ref-assignment race. Narrowing that predicate cannot reach the element, so hiding is free.

Two shapes deliberately refused, each measured:

- **`hidden` as a field of `AudioPlayerState`** (the shape #682 chose for `label`). `AudioMiniPlayer` drives the element from `createEffect(on(activeAudio, …))`, whose body assigns `audioEl.src` — and assigning `.src` re-invokes the media load algorithm *even with an unchanged URL*. Measured on a mutant carrying exactly that shape: a hide gesture calls `play()` **1 time**, i.e. the live stream re-buffers. `label` describes the SOURCE; hiding describes the CHROME.
- **A `<Show>` around `<AudioMiniPlayer/>` at Shell's call sites.** That destroys the element — which the codebase already records in the sibling comment noting that leaving chat for home stops playback.

**The door back** is a `RailActions` row, gated on there being something to restore (the same capability gate the `mentions` launcher uses). It must be general — an upload passes `label: null` and is in no station table, so the rail's `tunedStation()`-gated chrome cannot be the door — and it must cost no vertical space, since reclaiming that space is the entire point of hiding. A restore handle left in the docked slot would still owe the 44px floor and give back almost nothing. Price stated rather than hidden: three taps on mobile vs one for a handle in place.

## 2. The picker inherits the band instead of cloning it

`.rail-radio-picker-head` was a lookalike of `PaneTopBar`'s band on a parallel `--rail-radio-*` layer. The picker hosts the real band now; the rule is **deleted**, not merely unused.

`PaneTopBar`'s trailing control became a slot to make that possible, and not on taste — the picker needs a ✕ (a rail-opener inside the already-open rail is a door to the floor it stands on) and `.topic-bar-hamburger` is `display: none` on desktop, so inheriting the ☰ would have cost the picker its only dismiss control there. The ☰ moved out into `PaneTopBarRailOpener`; emitted markup for the two original hosts is byte-identical, which is why #1073's ordering pin and the admin accessible-name assertion **stay green with no edit** — that is the evidence the refactor is behaviour-preserving.

The missing top padding falls out of this by construction: the hand-rolled head inherited the scroller's flat `0.5rem`, the band reads `--pane-chrome-inset-block/inline` (0.5rem / 1rem). The short axis was the **inline** one — so "not enough top padding" is really "the band was never there".

## 3. The ✕ that renders but does not land — measured, and it is a class

`html { font-size: var(--font-size) }`, `--font-size: 14px`. So:

| control | declared | resolved | in this PR |
|---|---|---|---|
| `.rail-radio-picker-close` | `2rem` | **28px** | ✅ fixed — the reported ✕ |
| `.rail-radio-stop` | `2rem` | **28px** | ✅ fixed — same defect, one line away, on the same surface |
| `.audio-mini-player-{toggle,close,download}` | `2.5rem` | **35px** | ⛔️ **carved out — filed separately** |

The rail pair adopts `.shell-chrome-btn`, which already carries the floor and the glyph size for every other chrome button in the app. Reuse, not a bigger number.

**Why the docked row is carved out.** It is the same class on a different surface, found while adding the hide control. Raising it grows the docked bar by ~9px — a **visible** change to a surface that was looked at and approved ("keeping it above the message box is right"), and #1697 names the picker's ✕. That decision is not this issue's to take.

Consequence, stated plainly: **the new hide button ships at 35px, below the floor, on purpose.** A lone 44px button in that row grows the bar by exactly the 9px the carve-out exists to avoid, and settling one member of a four-button row apart from its siblings is how a sheet ends up with two patterns. The CSS guard added for it is floor-**neutral** — it pins that one rule sizes all four, so the carve-out stays a single edit that cannot leave a straggler. A test asserting `2.5rem` would encode a known defect and stop anyone from finding it.

## Evidence

- **All three commits individually green**: full vitest (306 / 306 / 307 files, 5981 tests) **and** `bun run check` 4/4 on each — no bisect hazard.
- **Four mutants killed**, each by the assertion written for it:
  - hidden folded into the state object → `play()` called **1** time on a hide, plus the `toBe` identity assertion on the source object;
  - `.rail-radio-picker-close` re-declaring `2rem` while still *wearing* `.shell-chrome-btn` → **the DOM class assertion stays green** and only the CSS-text guard fails. That is the pair doing its job: a cascade override defeats the fix while every DOM assertion passes;
  - the same shape on the docked row (`.audio-mini-player-close { min-height: 2rem }`) → the carve-out's single-rule guard fails;
  - the restore row losing its `playerHidden()` conjunct → "offers no restore row while the player is on screen".

## What this does NOT establish

Beyond the device caveat at the top: **it is not proven that the hidden player keeps playing in a browser.** What is proven is the footprint of *nothing having run* — the element survives with its `src` attached, no `pause()`, no second `play()`. That is the mechanism, and the strongest statement jsdom supports. Audio continuity is dogfood.

The three-tap restore path is a design bet made on measured grounds, not a usability finding. #1698 (now-playing + `/np`) is deliberately untouched.