### PR TITLE
#1698 — radio now-playing metadata and /np

### DIFF
--- a/cicchetto/scripts/check-radio-logos-core.ts
+++ b/cicchetto/scripts/check-radio-logos-core.ts
@@ -46,17 +46,34 @@ export function catalogueLogos(body: CatalogueBody): Map<string, string> {
   return new Map(entries);
 }
 
-/** `null` when the response is a served image; otherwise why it is not.
+/** `null` when the response is a served resource of the `expected` type;
+    otherwise why it is not.
     Content type is checked and not just the status because api.somafm.com
     answers some paths with a 200-shaped `text/html` body — a status-only
     assert would wave a soft 404 straight through, and a soft 404 is exactly
-    the failure this probe was written to catch. */
-export function reachFailure(status: number, contentType: string | null): string | null {
+    the failure this probe was written to catch.
+    #1698 — `expected` is a PARAMETER because the table now bakes two kinds of
+    third-party URL: a logo (`image/`) and a now-playing feed
+    (`application/json`). One predicate rather than a near-copy, and the
+    message names what was WANTED because otherwise the two axes report the
+    identical sentence for opposite defects. */
+export function reachFailure(
+  status: number,
+  contentType: string | null,
+  expected: string,
+): string | null {
   if (status < 200 || status >= 300) return `HTTP ${status}`;
   const type = contentType ?? "(none)";
-  if (!type.startsWith("image/")) return `HTTP ${status} but content-type ${type}`;
+  if (!type.startsWith(expected)) {
+    return `HTTP ${status} but content-type ${type} (wanted ${expected})`;
+  }
   return null;
 }
+
+/** The content types each axis demands. Named rather than spelled at the call
+    sites so the runner and its tests cannot drift apart on the string. */
+export const LOGO_CONTENT_TYPE = "image/";
+export const FEED_CONTENT_TYPE = "application/json";
 
 /** Whether AGREE has anything to say about this station. A station pointing at
     another provider is outside the catalogue's scope — the table is allowed to
@@ -85,19 +102,29 @@ export function agreeFailure(
 export type StationFinding = {
   readonly id: string;
   readonly logoUrl: string;
+  /** #1698 — the station's now-playing feed, or null when it publishes none.
+      Carried so the report line can name the URL that failed, and so a null
+      row is visibly SKIPPED rather than silently absent. */
+  readonly feedUrl: string | null;
   readonly reach: string | null;
   readonly agree: string | null;
+  /** #1698 — the FEED axis: whether `feedUrl` answers with JSON. Always null
+      for a station that publishes no feed — that is not a defect, and
+      reporting it as one would make the table's nullable field permanently
+      red. */
+  readonly feed: string | null;
 };
 
-/** Every problem found for one station, both axes, in report order. */
+/** Every problem found for one station, all three axes, in report order. */
 export function problems(finding: StationFinding): readonly string[] {
   return [
     finding.reach === null ? null : `REACH ${finding.reach}`,
     finding.agree === null ? null : `AGREE ${finding.agree}`,
+    finding.feed === null ? null : `FEED ${finding.feed}`,
   ].filter((p): p is string => p !== null);
 }
 
-/** A station is broken if EITHER axis has something to say — the union
+/** A station is broken if ANY axis has something to say — the union
     verdict, the `scripts/check.ts` posture. */
 export function brokenCount(findings: readonly StationFinding[]): number {
   return findings.filter((f) => problems(f).length > 0).length;

--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -19,17 +19,28 @@
 // moduledoc names it, so the next author edits the table and has a command
 // instead of a ritual.
 //
-// TWO AXES, both reported, union verdict (the `scripts/check.ts` posture):
+// THREE AXES, all reported, union verdict (the `scripts/check.ts` posture):
 //
-//   REACH  — the URL answers 200 with an `image/*` content type. This is the
-//            property the picker needs, and it covers every station including
-//            one from another provider.
+//   REACH  — the logo URL answers 200 with an `image/*` content type. This is
+//            the property the picker needs, and it covers every station
+//            including one from another provider.
 //   AGREE  — for a station whose logo we point at somafm, the baked URL is the
 //            one `channels.json` ships. Stronger than REACH: it catches a logo
 //            that still resolves but is no longer the one upstream publishes,
 //            and it is what pins the table to the authority WITHOUT making the
 //            running client depend on that authority (see the table's
 //            moduledoc for why the fetch stays out of the render path).
+//   FEED   — #1698: the `songsUrl` now-playing feed answers 200 with
+//            `application/json`. A third baked third-party URL in the same
+//            table, so it inherits the same problem this script exists for:
+//            get the slug wrong and the station still plays perfectly while
+//            the track line stays permanently empty — a defect with no symptom
+//            anywhere the operator looks. A station that publishes no feed
+//            (`songsUrl: null`) is SKIPPED, not failed.
+//            No AGREE twin: `channels.json` publishes a `lastPlaying` STRING,
+//            not the feed's URL, so there is no upstream value to compare the
+//            baked one against. Naming that absence beats inventing a
+//            comparison that would pass on anything.
 //
 // THIS FILE IS THE IO HALF ONLY. Every rule lives in `check-radio-logos-core.ts`
 // so that it is reachable from `src` and therefore covered by `tsc --noEmit`;
@@ -47,6 +58,8 @@ import {
   brokenCount,
   type CatalogueBody,
   catalogueLogos,
+  FEED_CONTENT_TYPE,
+  LOGO_CONTENT_TYPE,
   problems,
   reachFailure,
   type StationFinding,
@@ -73,11 +86,16 @@ async function fetchCatalogue(): Promise<Map<string, string> | null> {
 
 /** A transport error is a REACH failure like any other: the picker would show
     no logo either way, and swallowing it to null would be the soft green this
-    probe exists to refuse. */
-async function probeReach(url: string): Promise<string | null> {
+    probe exists to refuse.
+    #1698 — shared by the logo and the now-playing feed, which differ only in
+    the content type they must answer with. Measured 2026-08-24: `HEAD` on
+    `api.somafm.com/songs/<id>.json` answers 200 `application/json`, and a slug
+    the host does not know answers 404 `text/html` — so one HEAD separates a
+    live feed from a mistyped one, exactly as it does for a logo. */
+async function probeReach(url: string, expected: string): Promise<string | null> {
   try {
     const res = await fetch(url, { method: "HEAD", signal: AbortSignal.timeout(TIMEOUT_MS) });
-    return reachFailure(res.status, res.headers.get("content-type"));
+    return reachFailure(res.status, res.headers.get("content-type"), expected);
   } catch (err) {
     return `${err}`;
   }
@@ -93,21 +111,40 @@ const findings: StationFinding[] = await Promise.all(
   RADIO_STATIONS.map(async (station) => ({
     id: station.id,
     logoUrl: station.logoUrl,
-    reach: await probeReach(station.logoUrl),
+    feedUrl: station.songsUrl,
+    reach: await probeReach(station.logoUrl, LOGO_CONTENT_TYPE),
     agree: agreeFailure(station.logoUrl, station.id, catalogue),
+    // A station that publishes no feed is not probed and is not a finding.
+    feed:
+      station.songsUrl === null
+        ? null
+        : await probeReach(station.songsUrl, FEED_CONTENT_TYPE),
   })),
 );
 
 for (const finding of findings) {
   const found = problems(finding);
   console.log(`  ${found.length === 0 ? "ok  " : "FAIL"}  ${finding.id.padEnd(16)}${finding.logoUrl}`);
+  // The feed URL is printed on its own line rather than folded into the one
+  // above: a station has two URLs now, and a report that names only one leaves
+  // the reader guessing which of them a `FEED` line is about. `(no feed)` is
+  // stated for the same reason the summary states its denominator — a skipped
+  // row must not read as a probed one.
+  console.log(`          feed ${finding.feedUrl ?? "(no feed)"}`);
   for (const p of found) console.log(`          ${p}`);
 }
 
 const broken = brokenCount(findings);
 
 // The denominator is the honesty payload, as in scripts/check.ts: "14 stations
-// checked" is what tells a reader the verdict covers the whole table.
-console.log(`\ncheck:radio summary — ${findings.length} stations checked, ${broken} broken`);
+// checked" is what tells a reader the verdict covers the whole table. #1698
+// adds a SECOND denominator for the same reason — the FEED axis skips a
+// station that publishes none, so "14 stations checked" alone would read as
+// "14 feeds checked" on a table where the field had gone uniformly null.
+const feedsProbed = findings.filter((f) => f.feedUrl !== null).length;
+console.log(
+  `\ncheck:radio summary — ${findings.length} stations checked ` +
+    `(${feedsProbed} with a now-playing feed), ${broken} broken`,
+);
 
 process.exit(broken === 0 ? 0 : 1);

--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -1,5 +1,6 @@
 import { type Component, createEffect, createSignal, on, Show } from "solid-js";
 import { activeAudio, closeAudio, hidePlayer, playerHidden } from "./lib/audioPlayer";
+import { nowPlayingLabel } from "./lib/nowPlaying";
 
 // Docked audio mini-player (GH #115) — a slim transport bar pinned above
 // the compose box. Non-modal: scrollback stays scrollable + readable
@@ -133,6 +134,21 @@ const AudioMiniPlayer: Component = () => {
             {(label) => (
               <span class="audio-mini-player-label" data-testid="audio-mini-player-label">
                 {label()}
+              </span>
+            )}
+          </Show>
+          {/* #1698 — what the station is playing, on the surface a phone can
+              actually see. The rail carries the same fact, and on mobile the
+              rail is `translateX(100%)` off-screen while the station plays —
+              the identical argument that put the label above here in #682,
+              one field further. Absent for an upload, which has no feed, and
+              absent for a station whose feed has gone quiet: the store's
+              `nowPlayingLabel` is null on every arm but `playing`, so the
+              stale rule reaches this row without this row knowing about it. */}
+          <Show when={nowPlayingLabel()}>
+            {(track) => (
+              <span class="audio-mini-player-track" data-testid="audio-mini-player-track">
+                {track()}
               </span>
             )}
           </Show>

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -1,6 +1,7 @@
 import { type Component, For, Show } from "solid-js";
 import { closeAudio } from "./lib/audioPlayer";
 import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
+import { nowPlayingLabel } from "./lib/nowPlaying";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { closeRadioPicker, radioPickerOpen, tunedStation, tuneStation } from "./lib/radio";
 import { RADIO_STATIONS } from "./lib/radioStations";
@@ -75,7 +76,27 @@ const RailRadio: Component = () => {
               <span class="rail-radio-now-title" data-testid="rail-radio-now-title">
                 {station().title}
               </span>
-              <span class="rail-radio-now-genres">{station().genres.join(" · ")}</span>
+              {/* #1698 — the TRACK takes the genres' slot rather than adding a
+                  third line. #500 bought this rail's vertical budget by
+                  collapsing the actions behind one launcher, and a permanently
+                  taller chrome would re-charge part of it. Nothing is lost:
+                  every picker row still carries its genres, and browsing by
+                  genre is what the picker is for — this row answers "what is
+                  on", which is the track. */}
+              <Show
+                when={nowPlayingLabel()}
+                fallback={
+                  <span class="rail-radio-now-genres" data-testid="rail-radio-now-genres">
+                    {station().genres.join(" · ")}
+                  </span>
+                }
+              >
+                {(line) => (
+                  <span class="rail-radio-now-track" data-testid="rail-radio-now-track">
+                    {line()}
+                  </span>
+                )}
+              </Show>
             </div>
             {/* `closeAudio` directly: it already IS the stop verb, and the
                 station is derived from the player, so clearing the player is

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AudioMiniPlayer from "../AudioMiniPlayer";
 import { activeAudio, closeAudio, playAudio, playerHidden, showPlayer } from "../lib/audioPlayer";
+import type { RadioStation } from "../lib/radioStations";
 
 // jsdom does not implement HTMLMediaElement playback — stub the methods
 // the player drives so the component mounts without "Not implemented".
@@ -24,6 +25,10 @@ afterEach(() => {
   closeAudio();
   showPlayer();
   vi.restoreAllMocks();
+  // #1698 — `restoreAllMocks` does NOT undo `stubGlobal`, so without this the
+  // feed stub the track tests install would outlive them and sit under every
+  // later test in the file. Same pairing `RailRadio.test.tsx` already uses.
+  vi.unstubAllGlobals();
 });
 
 describe("AudioMiniPlayer", () => {
@@ -233,6 +238,93 @@ describe("AudioMiniPlayer", () => {
       playAudio("https://grappa.example/uploads/abc", null);
 
       expect(screen.getByTestId("audio-mini-player")).toBeInTheDocument();
+    });
+  });
+
+  // #1698 — the track, on the one surface a phone can see.
+  //
+  // The SAME argument the label above is defended with, applied one field
+  // further: `.shell-members` is `translateX(100%)` on mobile, so the rail's
+  // chrome is off-screen while the station plays and this bar is the only
+  // place the track can appear at all. Rail-only would have meant the phone —
+  // where a radio is most used — never learns what is on.
+  describe("the now-playing track (#1698)", () => {
+    const TRACK = "Trestal — A Land Unknown";
+
+    /** Render the bar, tune the first curated station against a stubbed feed
+        and wait for the track to reach the row. Returns the station, so a
+        caller can assert against the title the table actually carries rather
+        than a copy of it. */
+    const tuneWithFeed = async (): Promise<RadioStation> => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ songs: [{ title: "A Land Unknown", artist: "Trestal" }] }),
+        } as unknown as Response),
+      );
+      const { tuneStation } = await import("../lib/radio");
+      const { RADIO_STATIONS } = await import("../lib/radioStations");
+      const station = RADIO_STATIONS[0];
+      if (station === undefined) throw new Error("the curated table must carry a station");
+
+      render(() => <AudioMiniPlayer />);
+      tuneStation(station);
+
+      await vi.waitFor(() =>
+        expect(screen.getByTestId("audio-mini-player-track")).toBeInTheDocument(),
+      );
+      return station;
+    };
+
+    it("names the track next to the station once the feed has answered", async () => {
+      const station = await tuneWithFeed();
+
+      expect(screen.getByTestId("audio-mini-player-track")).toHaveTextContent(TRACK);
+      // Both, not one: the station answers "what am I listening to" and the
+      // track answers "what is on". Collapsing them would cost the phone the
+      // station name, which is the #682 reason this label exists.
+      expect(screen.getByTestId("audio-mini-player-label")).toHaveTextContent(station.title);
+    });
+
+    it("shows no track slot for an audio upload", () => {
+      // An upload is not a station and has no feed. The slot must be absent
+      // rather than empty — an empty span still takes its gap.
+      render(() => <AudioMiniPlayer />);
+      playAudio("https://grappa.example/uploads/abc", null);
+
+      expect(screen.queryByTestId("audio-mini-player-track")).toBeNull();
+    });
+
+    // Where the two slices meet, and the one case neither of them owns alone.
+    //
+    // #1697 gave the transport a HIDDEN state; #1698 put a live fact on that
+    // transport. The chrome half needs no code: the span sits inside the same
+    // <Show> the hide predicate narrows, so a hidden bar cannot render a track
+    // — showing one on a surface that is not there would be nothing at all.
+    //
+    // The half that DOES need stating is the other one. `/np` is a COMMAND, not
+    // chrome, and an operator who hid the bar to get their screen back is
+    // exactly the operator who then asks the channel what is on. So the fact
+    // must outlive the surface — which it does because the poll is keyed on
+    // `tunedStation()`, i.e. on the AUDIO, and hiding deliberately says nothing
+    // about the audio. Keying it on visibility instead would have made `/np`
+    // answer "nothing is playing" in the state a phone spends most of its time
+    // in, and that refusal would have been a lie rather than a report.
+    it("hiding the bar takes the track off screen without taking it from /np", async () => {
+      const station = await tuneWithFeed();
+      const { nowPlayingLabel } = await import("../lib/nowPlaying");
+      const { tunedStation } = await import("../lib/radio");
+
+      screen.getByTestId("audio-mini-player-hide").click();
+
+      expect(screen.queryByTestId("audio-mini-player-track")).toBeNull();
+      expect(nowPlayingLabel()).toBe(TRACK);
+      // The mechanism, not a proxy for it: routing the hidden flag through
+      // `activeAudio` — the shape #1697's own comment forbids — would null this
+      // out, and the poll keyed on it would stop with the chrome.
+      expect(tunedStation()).toBe(station);
     });
   });
 });

--- a/cicchetto/src/__tests__/RailRadio.test.tsx
+++ b/cicchetto/src/__tests__/RailRadio.test.tsx
@@ -20,9 +20,23 @@ if (station === undefined || other === undefined) {
   throw new Error("the curated table must carry at least two stations for these tests");
 }
 
+/** One 200 carrying a `…/songs/<id>.json` body. */
+const songsOk = (title: string, artist: string): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ songs: [{ title, artist }] }),
+  }) as unknown as Response;
+
 beforeEach(() => {
   vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
   vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+  // #1698 — MANDATORY, not decoration. This component now reads `nowPlaying`,
+  // whose poll fires on every tune. Unstubbed, each test that clicks a station
+  // would make a real cross-origin request to api.somafm.com from the worker —
+  // a unit gate quietly depending on a third party's uptime. Same hazard the
+  // `InertWebSocket` in setupTests exists for, one module over.
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(songsOk("A Land Unknown", "Trestal")));
   closeAudio();
   closeRadioPicker();
 });
@@ -31,6 +45,7 @@ afterEach(() => {
   closeAudio();
   closeRadioPicker();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("RailRadio", () => {
@@ -228,5 +243,51 @@ describe("RailRadio", () => {
         container.querySelector(".rail-radio-picker [data-testid='shell-chrome-rail-opener']"),
       ).toBeNull();
     });
+  });
+
+  // #1698 — the chrome answers "what is playing" and now says it twice: which
+  // STATION, and which TRACK.
+  it("names the track once the feed has answered", async () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+    await vi.waitFor(() => expect(screen.getByTestId("rail-radio-now-track")).toBeInTheDocument());
+
+    expect(screen.getByTestId("rail-radio-now-track")).toHaveTextContent(
+      "Trestal — A Land Unknown",
+    );
+    // The station name stays: the track is the second fact, not a replacement
+    // for the first.
+    expect(screen.getByTestId("rail-radio-now-title")).toHaveTextContent(station.title);
+  });
+
+  it("shows the genres while no track is known, and swaps them for the track", async () => {
+    // Same SLOT, not a third line. #500 bought the rail's vertical budget by
+    // collapsing the actions behind one launcher, and a permanently taller
+    // chrome would re-charge part of that. Nothing is lost: the genres are
+    // still on every picker row, which is where browsing by genre happens.
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+    expect(screen.getByTestId("rail-radio-now-genres")).toBeInTheDocument();
+
+    await vi.waitFor(() => expect(screen.getByTestId("rail-radio-now-track")).toBeInTheDocument());
+    expect(screen.queryByTestId("rail-radio-now-genres")).toBeNull();
+  });
+
+  it("claims no track when the feed refuses to answer", async () => {
+    // The honest empty: a station that plays while its feed is down shows the
+    // station and says nothing about the track, rather than showing the last
+    // one it knew from some other station.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    render(() => <RailRadio />);
+    openRadioPicker();
+    screen.getByTestId(`rail-radio-station-${station.id}`).click();
+    await vi.waitFor(() => expect(screen.getByTestId("rail-radio-now")).toBeInTheDocument());
+
+    expect(screen.queryByTestId("rail-radio-now-track")).toBeNull();
+    expect(screen.getByTestId("rail-radio-now-genres")).toBeInTheDocument();
   });
 });

--- a/cicchetto/src/__tests__/audioMiniPlayerLayout.test.ts
+++ b/cicchetto/src/__tests__/audioMiniPlayerLayout.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { nestedRuleBodies } from "./helpers/themeCss";
+
+// #1698 — the docked bar's layout contract, read off the STYLESHEET.
+//
+// WHY A CSS-TEXT GUARD AND NOT A DOM ASSERTION. #1697's finding, one bar over:
+// `.rail-radio-picker-close` wore a shared button class and then re-declared
+// its own size 2rem below it, and the DOM assertion stayed GREEN — jsdom
+// applies no stylesheet and computes no layout, so only a guard on the CSS text
+// can see a cascade override at all. That is the mechanism here too, and the
+// stake is the same one: this row is the WHOLE player on a phone, and a text
+// span that can grow without bound pushes ✕ past the right edge, where it
+// cannot be tapped.
+//
+// #1698 adds a SECOND growable text span to a row that had one. That is exactly
+// the edit the rule below exists to survive, so it is pinned rather than
+// assumed.
+//
+// And the budget it is spent against SHRANK while this was in flight: #1697
+// landed a fourth fixed-width control (the hide chevron) into the same row, so
+// the two spans now share what is left after 4 × 2.5rem rather than 3 × 2.5rem.
+// Both slices are individually defensible and neither measured the sum — which
+// is why the ⚠️ below is not boilerplate on this branch.
+//
+// ⚠️ What this does NOT establish, stated because a green here is easy to
+// over-read: it says the declarations are present, not that the bar fits on any
+// particular device. Real widths are device territory.
+
+/** The single body of a rule, asserting there is exactly one — a selector with
+    two blocks is the #1697 shape (a later one silently overriding an earlier),
+    and a guard that read only the first would be blind to it. */
+const soleRuleBody = (selector: string): string => {
+  const bodies = nestedRuleBodies(selector);
+  expect(bodies.length, `${selector} is declared in ${bodies.length} blocks`).toBe(1);
+  return bodies[0] ?? "";
+};
+
+describe("the docked player's text spans can shrink, and its controls cannot", () => {
+  it.each([".audio-mini-player-label", ".audio-mini-player-track"])(
+    "%s ellipsises instead of widening the row",
+    (selector) => {
+      const body = soleRuleBody(selector);
+      // `min-width: 0` is the load-bearing one: without it a flex item's
+      // automatic minimum size is its CONTENT, so `overflow: hidden` never
+      // engages and the span widens the row instead of clipping.
+      expect(body).toMatch(/min-width:\s*0/);
+      expect(body).toMatch(/overflow:\s*hidden/);
+      expect(body).toMatch(/text-overflow:\s*ellipsis/);
+      expect(body).toMatch(/white-space:\s*nowrap/);
+      // Shrink factor non-zero. `flex: <grow> 1 auto` — a `0` in the second
+      // slot would let the span refuse to give ground, which is the failure
+      // the three properties above are meant to prevent.
+      expect(body).toMatch(/flex:\s*\d+\s+1\s+auto/);
+    },
+  );
+
+  it("keeps the transport controls unshrinkable, so ✕ never leaves the screen", () => {
+    // Grouped in one rule with the toggle, the hide chevron and the download
+    // anchor; asserted through the group rather than per-selector, because
+    // that IS the shape and splitting it would let one member drift out
+    // silently.
+    //
+    // The list is spelled out in full, and the exactness is the point: this
+    // pin was first written against a THREE-member group and #1697 landed a
+    // fourth (`.audio-mini-player-hide`) into it while this branch was in
+    // flight. `nestedRuleBodies` matches the selector list verbatim, so the
+    // stale spelling threw `CSS rule not found` instead of quietly measuring
+    // a rule that no longer existed — which is the whole reason this guard
+    // reads the group and not one member of it.
+    const body = soleRuleBody(
+      ".audio-mini-player-toggle,\n.audio-mini-player-hide,\n.audio-mini-player-close,\n.audio-mini-player-download",
+    );
+    expect(body).toMatch(/flex:\s*none/);
+  });
+
+  it("gives the track more of the free space than the station name", () => {
+    // Ordering, not decoration: the station is short and mostly known (it is
+    // also on the rail), the track is long and is the fact the row exists to
+    // carry. Both still shrink, so neither can starve the other to zero.
+    const grow = (selector: string): number => {
+      const match = soleRuleBody(selector).match(/flex:\s*(\d+)\s+1\s+auto/);
+      const captured = match?.[1];
+      if (captured === undefined) throw new Error(`${selector} declares no flex grow factor`);
+      return Number(captured);
+    };
+    expect(grow(".audio-mini-player-track")).toBeGreaterThan(grow(".audio-mini-player-label"));
+    // …and the label still grows, so a station with no track yet does not
+    // leave a gap trailing the ✕.
+    expect(grow(".audio-mini-player-label")).toBeGreaterThan(0);
+  });
+});

--- a/cicchetto/src/__tests__/checkRadioLogos.test.ts
+++ b/cicchetto/src/__tests__/checkRadioLogos.test.ts
@@ -35,8 +35,10 @@ const CATALOGUE = new Map([
 const finding = (over: Partial<StationFinding>): StationFinding => ({
   id: "dronezone",
   logoUrl: "https://api.somafm.com/logos/120/dronezone120.jpg",
+  feedUrl: "https://api.somafm.com/songs/dronezone.json",
   reach: null,
   agree: null,
+  feed: null,
   ...over,
 });
 
@@ -80,11 +82,11 @@ describe("catalogueLogos", () => {
 
 describe("reachFailure", () => {
   it("passes a served image", () => {
-    expect(reachFailure(200, "image/jpeg")).toBeNull();
+    expect(reachFailure(200, "image/jpeg", "image/")).toBeNull();
   });
 
   it("fails a 404 and names the status", () => {
-    expect(reachFailure(404, "text/html")).toBe("HTTP 404");
+    expect(reachFailure(404, "text/html", "image/")).toBe("HTTP 404");
   });
 
   it("fails a 200 that is not an image — the soft 404 this host serves", () => {
@@ -92,11 +94,40 @@ describe("reachFailure", () => {
     // some paths with a 200-shaped `text/html` body, and a status-only assert
     // would wave exactly the failure this probe exists to catch straight
     // through.
-    expect(reachFailure(200, "text/html")).toBe("HTTP 200 but content-type text/html");
+    expect(reachFailure(200, "text/html", "image/")).toBe(
+      "HTTP 200 but content-type text/html (wanted image/)",
+    );
   });
 
   it("fails a 200 with no content type rather than assuming one", () => {
-    expect(reachFailure(200, null)).toBe("HTTP 200 but content-type (none)");
+    expect(reachFailure(200, null, "image/")).toBe(
+      "HTTP 200 but content-type (none) (wanted image/)",
+    );
+  });
+
+  // #1698 — the expected type is a PARAMETER because a second kind of baked
+  // URL now rides the same probe. Measured 2026-08-24: `HEAD` on
+  // `api.somafm.com/songs/<id>.json` answers 200 `application/json`, and a
+  // WRONG slug answers 404 `text/html` — so the same two-part rule (status
+  // AND type) separates a live feed from a mistyped one.
+  it("passes a served JSON feed", () => {
+    expect(reachFailure(200, "application/json", "application/json")).toBeNull();
+  });
+
+  it("fails a JSON feed served as html, naming what was wanted", () => {
+    // Without the `wanted` half the two axes would report the identical
+    // sentence for opposite defects, and a reader could not tell which URL
+    // was mistyped.
+    expect(reachFailure(200, "text/html", "application/json")).toBe(
+      "HTTP 200 but content-type text/html (wanted application/json)",
+    );
+  });
+
+  it("does NOT accept an image where a feed was wanted", () => {
+    // The two-sided half of parameterising the type: a probe that ignored its
+    // `expected` argument would pass this, and both axes would collapse into
+    // "any 200 with any body".
+    expect(reachFailure(200, "image/png", "application/json")).not.toBeNull();
   });
 });
 
@@ -149,12 +180,27 @@ describe("the AGREE axis is not vacuous over the real table", () => {
   });
 });
 
+// #1698 — the FEED axis. `songsUrl` is a third baked third-party URL in the
+// same table, and #1696's lesson is that a baked URL nothing can check is a
+// claim, not a fact. Adding one without extending this probe would repeat the
+// exact defect the probe exists for.
+describe("the FEED axis is not vacuous over the real table", () => {
+  it("has something to probe on every station that publishes a feed", () => {
+    // The positive control, the sibling of AGREE's above: FEED skips a station
+    // whose `songsUrl` is null, so a table that lost the field would report
+    // "0 broken" having probed nothing. Both halves are asserted — the count
+    // matches the rows that carry one, AND that count is not zero.
+    const withFeed = RADIO_STATIONS.filter((s) => s.songsUrl !== null);
+    expect(withFeed.length).toBeGreaterThan(0);
+    expect(withFeed.length).toBe(RADIO_STATIONS.length);
+  });
+});
+
 describe("the union verdict", () => {
-  it("reports both axes when both have something to say", () => {
-    expect(problems(finding({ reach: "HTTP 404", agree: "catalogue ships x" }))).toEqual([
-      "REACH HTTP 404",
-      "AGREE catalogue ships x",
-    ]);
+  it("reports every axis that has something to say", () => {
+    expect(
+      problems(finding({ reach: "HTTP 404", agree: "catalogue ships x", feed: "HTTP 500" })),
+    ).toEqual(["REACH HTTP 404", "AGREE catalogue ships x", "FEED HTTP 500"]);
   });
 
   it("counts a station broken on EITHER axis alone", () => {
@@ -162,10 +208,21 @@ describe("the union verdict", () => {
     // upstream publishes is broken even though REACH is happy, and vice versa.
     expect(brokenCount([finding({ reach: "HTTP 404" })])).toBe(1);
     expect(brokenCount([finding({ agree: "catalogue ships x" })])).toBe(1);
+    // #1698 — and on the feed alone: a station whose track feed 404s plays
+    // fine and shows a permanently empty track line, which is precisely the
+    // silent failure a checkable claim is supposed to convert into a red.
+    expect(brokenCount([finding({ feed: "HTTP 404" })])).toBe(1);
   });
 
   it("counts a clean station as unbroken", () => {
     expect(problems(finding({}))).toEqual([]);
     expect(brokenCount([finding({}), finding({ id: "lush" })])).toBe(0);
+  });
+
+  it("says nothing about a station that publishes no feed", () => {
+    // A null `songsUrl` is a station from a provider that has no track feed,
+    // not a broken row. Reported as a finding it would make the table's own
+    // nullable field permanently red.
+    expect(problems(finding({ feedUrl: null, feed: null }))).toEqual([]);
   });
 });

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
 import type { SlashCommand } from "../lib/slashCommands";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "../lib/windowKinds";
@@ -1388,6 +1388,195 @@ describe("compose submit — slash command dispatch", () => {
       target: "bob",
     });
     expect(result).toEqual({ ok: true });
+  });
+
+  // #1698 — `/np`. Driven through the REAL `nowPlaying` store rather than a
+  // mock of it, because the thing worth testing is precisely which store state
+  // reaches the wire and which does not; a mocked store would test the mock.
+  // `fetch` is stubbed per case to place the store in the state under test.
+  describe("/np (#1698)", () => {
+    afterEach(() => {
+      // Local to this block: the file's own beforeEach must not unstub, or it
+      // would strip the localStorage / WebSocket stand-ins setupTests installs
+      // just before it. setupTests re-installs those on the next test, which is
+      // exactly the contract its header describes.
+      vi.unstubAllGlobals();
+    });
+
+    /** Tune `RADIO_STATIONS[0]` with `fetch` answering `body`, and hand back
+        the station so a case can name it in its expectation. */
+    const tuneWith = async (body: unknown): Promise<{ title: string }> => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => body } as Response),
+      );
+      const { RADIO_STATIONS } = await import("../lib/radioStations");
+      const station = RADIO_STATIONS[0];
+      if (station === undefined) throw new Error("the curated table must carry a station");
+      const { tuneStation } = await import("../lib/radio");
+      const { nowPlaying } = await import("../lib/nowPlaying");
+      tuneStation(station);
+      await vi.waitFor(() => expect(nowPlaying().status).not.toBe("unanswered"));
+      return station;
+    };
+
+    it("sends an ACTION naming artist, track and station into the current window", async () => {
+      // ACTION, not PRIVMSG: `* nick is now playing: …` is the verb's whole
+      // shape, and the framing is the shared `ctcpFrame` seam — the same one
+      // /me and /ctcp ACTION go through, never a second hand-rolled \x01.
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      vi.mocked(sb.sendMessage).mockResolvedValue();
+      const station = await tuneWith({ songs: [{ title: "A Land Unknown", artist: "Trestal" }] });
+
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/np");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(sb.sendMessage).toHaveBeenCalledWith(
+        "freenode",
+        "#a",
+        `\x01ACTION is now playing: Trestal — A Land Unknown [${station.title}]\x01`,
+      );
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("refuses, locally, when nothing is playing", async () => {
+      // The verb WRITES INTO A CHANNEL, so "nothing to say" must cost the
+      // channel nothing at all — not a blank action, not a station-only line
+      // the operator did not ask for.
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      vi.mocked(sb.sendMessage).mockResolvedValue();
+
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/np");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(sb.sendMessage).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        error: "/np: nothing is playing — tune a station from the radio picker first",
+      });
+    });
+
+    it("refuses when the feed has not answered, and names the station", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      vi.mocked(sb.sendMessage).mockResolvedValue();
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      const { RADIO_STATIONS } = await import("../lib/radioStations");
+      const station = RADIO_STATIONS[0];
+      if (station === undefined) throw new Error("the curated table must carry a station");
+      const { tuneStation } = await import("../lib/radio");
+      tuneStation(station);
+
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/np");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(sb.sendMessage).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        error: `/np: no track from ${station.title} yet — its feed has not answered`,
+      });
+    });
+
+    it("refuses a feed answer carrying no usable track", async () => {
+      // A 200 with an empty `songs` is not a track, and the arm that would
+      // otherwise build `* nick is now playing:  [Groove Salad]` is the one
+      // this whole chain exists to make unreachable.
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      vi.mocked(sb.sendMessage).mockResolvedValue();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ songs: [] }),
+        } as Response),
+      );
+      const { RADIO_STATIONS } = await import("../lib/radioStations");
+      const station = RADIO_STATIONS[0];
+      if (station === undefined) throw new Error("the curated table must carry a station");
+      const { tuneStation } = await import("../lib/radio");
+      tuneStation(station);
+
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/np");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(sb.sendMessage).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ error: expect.stringContaining("has not answered") });
+    });
+
+    it("refuses a track that has gone stale, rather than publishing a lie", async () => {
+      // The arm vjt asked to have decided in advance. A ten-minute-old track
+      // announced as "now" is wrong in a way only OTHER PEOPLE can see, which
+      // is precisely why a local error beats it — and the refusal quotes the
+      // threshold from the store's constant, so a cadence change moves the
+      // sentence with it instead of leaving the operator a stale number.
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      vi.mocked(sb.sendMessage).mockResolvedValue();
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ songs: [{ title: "Juno", artist: "Setsuna" }] }),
+          } as Response)
+          .mockRejectedValue(new Error("offline")),
+      );
+      const { RADIO_STATIONS } = await import("../lib/radioStations");
+      const station = RADIO_STATIONS[0];
+      if (station === undefined) throw new Error("the curated table must carry a station");
+      const { tuneStation } = await import("../lib/radio");
+      const { NOW_PLAYING_POLL_MS, NOW_PLAYING_STALE_MS, nowPlaying } = await import(
+        "../lib/nowPlaying"
+      );
+
+      vi.useFakeTimers();
+      tuneStation(station);
+      await vi.advanceTimersByTimeAsync(NOW_PLAYING_STALE_MS + NOW_PLAYING_POLL_MS);
+      expect(nowPlaying().status).toBe("stale");
+      vi.useRealTimers();
+
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/np");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(sb.sendMessage).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        error: `/np: the last track from ${station.title} is over 3 minutes old — not sending it`,
+      });
+    });
+
+    it("sends into a QUERY window when that is where it was typed", async () => {
+      // Targets `ctx.submittedFrom`, exactly as /me does — an ACTION to a peer
+      // is ordinary conversation, so there is no channel-only guard to add.
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      vi.mocked(sb.sendMessage).mockResolvedValue();
+      await tuneWith({ songs: [{ title: "Juno", artist: "Setsuna" }] });
+
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "bob");
+      compose.setDraft(k, "/np");
+      await compose.submit(k, "freenode", "bob");
+
+      expect(sb.sendMessage).toHaveBeenCalledWith(
+        "freenode",
+        "bob",
+        expect.stringContaining("\x01ACTION is now playing: Setsuna — Juno ["),
+      );
+    });
   });
 
   // #1192 — a deliberate behaviour change, pinned so it cannot regress by
@@ -5007,6 +5196,7 @@ const DISPATCH_CASE_LABELS = [
   "nick",
   "notice",
   "notify",
+  "np",
   "op",
   "open-settings",
   "oper",
@@ -5059,6 +5249,14 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: SlashCommand["kind"]; draft: string
   { kind: "amsg", draft: "/amsg hi" },
   { kind: "ctcp", draft: "/ctcp bob VERSION" },
   { kind: "ping", draft: "/ping bob" },
+  // #1698 — this row lands in the UNPROTECTED list below, and that is the
+  // truth rather than a gap to paper over: nothing is tuned in this harness,
+  // so `/np` refuses locally and touches no mocked seam. Its sending arm needs
+  // a tuned station and a stubbed feed, which is what the `/np (#1698)`
+  // describe block above sets up. The row still earns its place — it keeps the
+  // arm reachable from the coverage reconciliation, which is what fails when
+  // the switch and this table drift apart.
+  { kind: "np", draft: "/np" },
   { kind: "join", draft: "/join #b" },
   { kind: "part", draft: "/part #other" },
   { kind: "invite", draft: "/invite bob #other" },
@@ -5206,12 +5404,12 @@ describe("#1396 — dispatch characterization over every arm", () => {
       misparsed,
     }).toMatchInlineSnapshot(`
       {
-        "arms": 59,
+        "arms": 60,
         "armsWithNoDraft": [],
         "draftsNamingNoArm": [],
         "duplicated": [],
         "misparsed": [],
-        "rows": 59,
+        "rows": 60,
       }
     `);
   });
@@ -5619,6 +5817,15 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "ok": "notify: watching bob",
           },
         },
+        "np": {
+          "effects": [
+            "aliasList.aliases()",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "/np: nothing is playing — tune a station from the radio picker first",
+          },
+        },
         "op": {
           "effects": [
             "aliasList.aliases()",
@@ -5984,7 +6191,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "aliasList.aliases()",
           "networks.networkIdBySlug("freenode")",
         ],
-        "arms": 59,
+        "arms": 60,
         "indistinguishablePairs": [
           [
             "ame",
@@ -5992,6 +6199,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           ],
         ],
         "unprotected": [
+          "np",
           "error",
         ],
       }

--- a/cicchetto/src/__tests__/nowPlaying.test.ts
+++ b/cicchetto/src/__tests__/nowPlaying.test.ts
@@ -172,6 +172,7 @@ describe("nowPlaying store", () => {
     expect(nowPlaying()).toEqual({
       status: "playing",
       track: { artist: "Setsuna", title: "Juno" },
+      station: station.title,
     });
   });
 
@@ -286,7 +287,7 @@ describe("nowPlaying store", () => {
 
     tuneStation(other);
     await settle();
-    expect(nowPlaying()).toEqual({ status: "unanswered" });
+    expect(nowPlaying()).toEqual({ status: "unanswered", station: other.title });
   });
 
   it("does not let a fetch that outlives its station write the wrong track", async () => {
@@ -307,12 +308,20 @@ describe("nowPlaying store", () => {
     await settle();
     tuneStation(other);
     await settle();
-    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "B", title: "B track" } });
+    expect(nowPlaying()).toEqual({
+      status: "playing",
+      track: { artist: "B", title: "B track" },
+      station: other.title,
+    });
 
     resolveA?.(okOnce(songsBody([{ title: "A track", artist: "A" }])));
     await settle();
 
-    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "B", title: "B track" } });
+    expect(nowPlaying()).toEqual({
+      status: "playing",
+      track: { artist: "B", title: "B track" },
+      station: other.title,
+    });
   });
 
   it("keeps the last track through a single failed read", async () => {
@@ -329,7 +338,11 @@ describe("nowPlaying store", () => {
     await settle();
     await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS);
 
-    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "S", title: "Juno" } });
+    expect(nowPlaying()).toEqual({
+      status: "playing",
+      track: { artist: "S", title: "Juno" },
+      station: station.title,
+    });
   });
 
   it("goes stale once the last successful read is older than the threshold", async () => {
@@ -347,7 +360,7 @@ describe("nowPlaying store", () => {
     await settle();
     await vi.advanceTimersByTimeAsync(NOW_PLAYING_STALE_MS + NOW_PLAYING_POLL_MS);
 
-    expect(nowPlaying()).toEqual({ status: "stale" });
+    expect(nowPlaying()).toEqual({ status: "stale", station: station.title });
   });
 
   it("recovers from stale when the feed answers again", async () => {
@@ -364,10 +377,14 @@ describe("nowPlaying store", () => {
     tuneStation(station);
     await settle();
     await vi.advanceTimersByTimeAsync(NOW_PLAYING_STALE_MS + NOW_PLAYING_POLL_MS);
-    expect(nowPlaying()).toEqual({ status: "stale" });
+    expect(nowPlaying()).toEqual({ status: "stale", station: station.title });
 
     await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS);
-    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "S", title: "Back" } });
+    expect(nowPlaying()).toEqual({
+      status: "playing",
+      track: { artist: "S", title: "Back" },
+      station: station.title,
+    });
   });
 
   it("treats a non-2xx answer as a failed read, not as a track", async () => {
@@ -379,7 +396,7 @@ describe("nowPlaying store", () => {
     tuneStation(station);
     await settle();
 
-    expect(nowPlaying()).toEqual({ status: "unanswered" });
+    expect(nowPlaying()).toEqual({ status: "unanswered", station: station.title });
   });
 
   it("stays unanswered — never pretends — when the feed has never answered", async () => {
@@ -393,7 +410,7 @@ describe("nowPlaying store", () => {
     // NOT "stale": stale means "we had a track and it aged out". We never had
     // one, and saying otherwise would put a track-shaped hole where an
     // honest "the feed has not answered" belongs.
-    expect(nowPlaying()).toEqual({ status: "unanswered" });
+    expect(nowPlaying()).toEqual({ status: "unanswered", station: station.title });
   });
 
   it("the stale threshold outlives more than one missed read", () => {

--- a/cicchetto/src/__tests__/nowPlaying.test.ts
+++ b/cicchetto/src/__tests__/nowPlaying.test.ts
@@ -1,0 +1,405 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAudio, playAudio } from "../lib/audioPlayer";
+import { setToken } from "../lib/auth";
+import {
+  NOW_PLAYING_POLL_MS,
+  NOW_PLAYING_STALE_MS,
+  type NowPlayingTrack,
+  nowPlaying,
+  nowPlayingLine,
+  parseSongsFeed,
+} from "../lib/nowPlaying";
+import { tuneStation } from "../lib/radio";
+import { RADIO_STATIONS, type RadioStation } from "../lib/radioStations";
+
+// #1698 — the now-playing store.
+//
+// Two properties carry the whole file. The store must never claim a track it
+// cannot stand behind (that is what `/np` publishes into a channel), and it
+// must never poll a third party for a player that is off.
+
+const station = RADIO_STATIONS[0];
+const other = RADIO_STATIONS[1];
+if (station === undefined || other === undefined) {
+  throw new Error("the curated table must carry at least two stations for these tests");
+}
+// Narrowed once: `songsUrl` is nullable in the type and these tests are about
+// the arm where it is present. A row that lost its feed would otherwise make
+// them pass while probing nothing.
+const feedUrl = station.songsUrl;
+const otherFeedUrl = other.songsUrl;
+if (feedUrl === null || otherFeedUrl === null) {
+  throw new Error("these tests need two stations that publish a now-playing feed");
+}
+
+/** A station from a provider with no track feed — the null arm of `songsUrl`.
+    Constructed rather than taken from the table, because no real row is null
+    today and a test that skipped when none was found would be silence. */
+const feedless: RadioStation = {
+  ...station,
+  id: "feedless",
+  title: "Feedless FM",
+  streamUrl: "https://stream.example.org/feedless",
+  songsUrl: null,
+};
+
+const songsBody = (
+  songs: ReadonlyArray<Record<string, string>>,
+): { id: string; songs: ReadonlyArray<Record<string, string>> } => ({
+  id: station.id,
+  songs,
+});
+
+/** One 200 carrying `body`. */
+const okOnce = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+/** Flush the microtasks a `void fetch(...)` chain needs, without letting the
+    poll interval fire. `advanceTimersByTimeAsync(0)` is the vitest verb that
+    drains the queue under fake timers — an `await Promise.resolve()` drains
+    only one tick and the chain here is longer than one. */
+const settle = async (): Promise<void> => {
+  await vi.advanceTimersByTimeAsync(0);
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-24T03:00:00Z"));
+});
+
+afterEach(() => {
+  closeAudio();
+  setToken(null);
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("parseSongsFeed", () => {
+  // The third-party boundary. Every case here is a document SomaFM could hand
+  // us; none of them may throw, and none may yield a track the `/np` line
+  // would render as an empty sentence.
+  it("reads the newest song out of the feed", () => {
+    expect(
+      parseSongsFeed({
+        id: "groovesalad",
+        songs: [
+          { title: "A Land Unknown", artist: "Trestal", album: "Ceramic Illumination" },
+          { title: "older", artist: "someone else" },
+        ],
+      }),
+    ).toEqual({ artist: "Trestal", title: "A Land Unknown" });
+  });
+
+  it("refuses a feed with no songs rather than inventing a blank track", () => {
+    expect(parseSongsFeed({ id: "groovesalad", songs: [] })).toBeNull();
+  });
+
+  it("refuses a document with no songs key at all", () => {
+    expect(parseSongsFeed({ id: "groovesalad" })).toBeNull();
+  });
+
+  it("refuses a song whose title is empty — the empty line, caught at the door", () => {
+    // The failure worth naming: a blank title renders `* nick is now playing:
+    // Trestal —  [Groove Salad]` into a channel. Refusing here is what makes
+    // the whole rest of the pipeline unable to publish one.
+    expect(parseSongsFeed(songsBody([{ title: "   ", artist: "Trestal" }]))).toBeNull();
+  });
+
+  it("keeps a titled song whose artist is empty, with no artist", () => {
+    // Measured 2026-08-24 across all 14 stations: 0 of 237 songs had an empty
+    // artist or title. That is a sample, not a contract, so an absent artist
+    // degrades to a shorter line rather than to no line.
+    expect(parseSongsFeed(songsBody([{ title: "Untitled Drone", artist: "" }]))).toEqual({
+      artist: null,
+      title: "Untitled Drone",
+    });
+  });
+
+  it("survives garbage rather than throwing at the caller", () => {
+    // A crash here would take out the poll's error handling, whose whole job
+    // is to keep the previous track on screen through a bad answer.
+    expect(parseSongsFeed(null)).toBeNull();
+    expect(parseSongsFeed("not json at all")).toBeNull();
+    expect(parseSongsFeed({ songs: "not an array" })).toBeNull();
+    expect(parseSongsFeed({ songs: [42] })).toBeNull();
+  });
+});
+
+describe("nowPlayingLine", () => {
+  const track = (over: Partial<NowPlayingTrack>): NowPlayingTrack => ({
+    artist: "Trestal",
+    title: "A Land Unknown",
+    ...over,
+  });
+
+  it("names the artist, the track and the station", () => {
+    // The station is IN the line on purpose: it is the only part a reader can
+    // act on. Without it the line is a boast; with it, it is a recommendation
+    // someone else can tune to.
+    expect(nowPlayingLine(track({}), "Groove Salad")).toBe(
+      "is now playing: Trestal — A Land Unknown [Groove Salad]",
+    );
+  });
+
+  it("drops the dash along with the artist rather than leaving it dangling", () => {
+    expect(nowPlayingLine(track({ artist: null }), "Drone Zone")).toBe(
+      "is now playing: A Land Unknown [Drone Zone]",
+    );
+  });
+});
+
+describe("nowPlaying store", () => {
+  it("is idle with nothing tuned, and asks the network nothing", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(nowPlaying()).toEqual({ status: "idle" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reads the feed the moment a station is tuned", async () => {
+    // Immediately, not on the first interval tick: a 60s blank line at tune-in
+    // is the operator's whole first impression of the feature.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okOnce(songsBody([{ title: "Juno", artist: "Setsuna" }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(feedUrl);
+    expect(nowPlaying()).toEqual({
+      status: "playing",
+      track: { artist: "Setsuna", title: "Juno" },
+    });
+  });
+
+  it("sends no credentials to the third party", async () => {
+    // A cross-origin `fetch` omits cookies by default, but the default is a
+    // default: state it, so a later edit that adds an options object cannot
+    // silently turn it on.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okOnce(songsBody([{ title: "Juno", artist: "S" }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ credentials: "omit" });
+  });
+
+  it("cannot be tuned to a station outside the curated table", () => {
+    // Not a limitation to work around — it is why `nowPlayingUnsupported.test.ts`
+    // exists as a separate file. `tunedStation()` matches the playing href
+    // against RADIO_STATIONS, so a station the table does not hold is not
+    // tunable at all, and the `unsupported` arm is unreachable from here.
+    tuneStation(feedless);
+    expect(nowPlaying()).toEqual({ status: "idle" });
+  });
+
+  it("re-reads on the poll interval while tuned", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okOnce(songsBody([{ title: "Juno", artist: "S" }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops polling when the player is closed", async () => {
+    // The issue's own requirement, and the one that decides whether this is a
+    // polite guest on someone else's host: a stopped radio must cost SomaFM
+    // nothing at all.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okOnce(songsBody([{ title: "Juno", artist: "S" }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    const afterTune = fetchMock.mock.calls.length;
+
+    closeAudio();
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS * 5);
+
+    expect(fetchMock).toHaveBeenCalledTimes(afterTune);
+    expect(nowPlaying()).toEqual({ status: "idle" });
+  });
+
+  it("stops polling when an upload takes the one player over", async () => {
+    // Same derivation `tunedStation` already relies on: there is ONE <audio>
+    // element, so a clicked audio link un-tunes the station. A poll keyed on
+    // anything but that fact would keep hammering the feed for a station that
+    // is no longer playing.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okOnce(songsBody([{ title: "Juno", artist: "S" }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    const afterTune = fetchMock.mock.calls.length;
+
+    playAudio("https://grappa.example/uploads/abc", null);
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS * 3);
+
+    expect(fetchMock).toHaveBeenCalledTimes(afterTune);
+    expect(nowPlaying()).toEqual({ status: "idle" });
+  });
+
+  it("switches feeds when a second station is tuned", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(okOnce(songsBody([{ title: "Juno", artist: "S" }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    tuneStation(other);
+    await settle();
+
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe(otherFeedUrl);
+  });
+
+  it("shows no track from the previous station while the new one is loading", async () => {
+    // A swap must blank, not carry over: the docked bar would otherwise
+    // caption the new station with the old one's track, and `/np` would
+    // publish that pairing into a channel.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okOnce(songsBody([{ title: "Juno", artist: "S" }])))
+      .mockReturnValueOnce(new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    expect(nowPlaying()).toMatchObject({ status: "playing" });
+
+    tuneStation(other);
+    await settle();
+    expect(nowPlaying()).toEqual({ status: "unanswered" });
+  });
+
+  it("does not let a fetch that outlives its station write the wrong track", async () => {
+    // The race the swap opens. Station A's read is still in flight when the
+    // operator tunes B; if it resolves into the store unguarded, B is captioned
+    // with A's track and nothing anywhere says so.
+    let resolveA: ((r: Response) => void) | undefined;
+    const fetchMock = vi.fn((url: string) =>
+      url === feedUrl
+        ? new Promise<Response>((res) => {
+            resolveA = res;
+          })
+        : Promise.resolve(okOnce(songsBody([{ title: "B track", artist: "B" }]))),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    tuneStation(other);
+    await settle();
+    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "B", title: "B track" } });
+
+    resolveA?.(okOnce(songsBody([{ title: "A track", artist: "A" }])));
+    await settle();
+
+    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "B", title: "B track" } });
+  });
+
+  it("keeps the last track through a single failed read", async () => {
+    // One blip must not blank the display: at a 60s cadence against a median
+    // 259s track (measured 2026-08-24, 223 gaps), the track we hold is still
+    // very likely the one on air.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okOnce(songsBody([{ title: "Juno", artist: "S" }])))
+      .mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS);
+
+    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "S", title: "Juno" } });
+  });
+
+  it("goes stale once the last successful read is older than the threshold", async () => {
+    // The state vjt asked to be decided rather than discovered: a ten-minute-
+    // old track published into a channel is worse than a local error. Past the
+    // threshold the store stops claiming a track at ALL — one predicate, so
+    // `/np`'s refusal is not a special case bolted onto a display that lies.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okOnce(songsBody([{ title: "Juno", artist: "S" }])))
+      .mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_STALE_MS + NOW_PLAYING_POLL_MS);
+
+    expect(nowPlaying()).toEqual({ status: "stale" });
+  });
+
+  it("recovers from stale when the feed answers again", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okOnce(songsBody([{ title: "Juno", artist: "S" }])))
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(okOnce(songsBody([{ title: "Back", artist: "S" }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_STALE_MS + NOW_PLAYING_POLL_MS);
+    expect(nowPlaying()).toEqual({ status: "stale" });
+
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS);
+    expect(nowPlaying()).toEqual({ status: "playing", track: { artist: "S", title: "Back" } });
+  });
+
+  it("treats a non-2xx answer as a failed read, not as a track", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 503, json: async () => ({}) } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+
+    expect(nowPlaying()).toEqual({ status: "unanswered" });
+  });
+
+  it("stays unanswered — never pretends — when the feed has never answered", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(station);
+    await settle();
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_STALE_MS * 2);
+
+    // NOT "stale": stale means "we had a track and it aged out". We never had
+    // one, and saying otherwise would put a track-shaped hole where an
+    // honest "the feed has not answered" belongs.
+    expect(nowPlaying()).toEqual({ status: "unanswered" });
+  });
+
+  it("the stale threshold outlives more than one missed read", () => {
+    // Pinned as a RELATION, not as a number: the threshold's whole
+    // justification is that it is several poll intervals, so a future cadence
+    // change must carry it along rather than silently collapse the two.
+    expect(NOW_PLAYING_STALE_MS).toBeGreaterThan(NOW_PLAYING_POLL_MS * 2);
+  });
+});

--- a/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
+++ b/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NOW_PLAYING_POLL_MS, nowPlaying } from "../lib/nowPlaying";
+import type { RadioStation } from "../lib/radioStations";
+
+// #1698 — the `unsupported` arm, which needs its own file.
+//
+// `songsUrl` is nullable because publishing a now-playing feed is a provider
+// CAPABILITY, and the type therefore FORCES `nowPlaying()` to answer something
+// for a station that has none. Answering `idle` would be a lie — a station IS
+// tuned — so the arm exists, and it must be tested.
+//
+// It cannot be tested from `nowPlaying.test.ts`. `tunedStation()` derives the
+// station by matching the playing href against RADIO_STATIONS, so only a table
+// row can be tuned, and all fourteen rows carry a feed today. The arm is
+// therefore unreachable in production RIGHT NOW and reachable the moment a row
+// from another provider lands — which is exactly the edit this file protects.
+//
+// Mocking `../lib/radio` rather than adding a feedless row to the real table:
+// production must not gain a fixture to make a test reachable (CLAUDE.md —
+// never weaken production code to make tests pass). Its own file, because
+// `vi.mock` is hoisted per-module and the sibling file needs the REAL store.
+
+// The fixture lives INSIDE the factory, not beside it. `vi.mock` is hoisted
+// above the module body, so a factory closing over a module-level `const`
+// reads it in its temporal dead zone — measured here: the store's first effect
+// threw `Cannot access 'feedless' before initialization`, `moduleRoot`'s error
+// context logged it, and all the assertions below still went green. A green
+// standing on a caught throw is not a green.
+vi.mock("../lib/radio", () => {
+  const feedless: RadioStation = {
+    id: "feedless",
+    title: "Feedless FM",
+    genres: ["ambient"],
+    description: "A station from a provider that publishes no track feed.",
+    streamUrl: "https://stream.example.org/feedless",
+    logoUrl: "https://example.org/logo.png",
+    songsUrl: null,
+  };
+  return { tunedStation: (): RadioStation | null => feedless };
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("a tuned station that publishes no now-playing feed", () => {
+  it("says unsupported, not idle and not unanswered", () => {
+    // Three states, three different facts. `idle` would deny that anything is
+    // playing; `unanswered` would promise an answer that will never come and
+    // send `/np` looking for one. `unsupported` is what was OBSERVED.
+    expect(nowPlaying()).toEqual({ status: "unsupported" });
+  });
+
+  it("never touches the network for it", async () => {
+    // The other half: a station with no feed must not be probed once, let
+    // alone every minute forever, at some third party's expense.
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS * 5);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
+++ b/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
@@ -53,7 +53,7 @@ describe("a tuned station that publishes no now-playing feed", () => {
     // Three states, three different facts. `idle` would deny that anything is
     // playing; `unanswered` would promise an answer that will never come and
     // send `/np` looking for one. `unsupported` is what was OBSERVED.
-    expect(nowPlaying()).toEqual({ status: "unsupported" });
+    expect(nowPlaying()).toEqual({ status: "unsupported", station: "Feedless FM" });
   });
 
   it("never touches the network for it", async () => {
@@ -65,5 +65,36 @@ describe("a tuned station that publishes no now-playing feed", () => {
     await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS * 5);
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // `/np`'s arm for this state, tested against the HANDLER rather than through
+  // `compose.submit` like every other verb. Not a preference: the dispatcher
+  // can only be driven into this state by tuning a station the curated table
+  // holds, and no such row is feedless — so the arm is unreachable from there,
+  // and the alternative to this test is a production switch arm with no test
+  // at all. Reached here because the mock above is already the station it
+  // needs.
+  it("tells `/np` to refuse, naming the station and the reason", async () => {
+    const sendMessage = vi.fn();
+    vi.doMock("../lib/scrollback", () => ({ sendMessage }));
+    const { npCommand } = await import("../lib/commands/radio");
+
+    // A context that THROWS on any read. The arm must decide from the store
+    // alone — it has no window to send to and no network to resolve — so
+    // touching the record at all is the bug, and this makes that a failure
+    // rather than a detail nobody checks.
+    const hostileCtx = new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          throw new Error(`/np's refusal read ctx.${String(prop)}`);
+        },
+      },
+    ) as unknown as Parameters<typeof npCommand>[1];
+
+    const result = await npCommand({ kind: "np" }, hostileCtx);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ error: "/np: Feedless FM publishes no track information" });
   });
 });

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -47,6 +47,44 @@ describe("RADIO_STATIONS", () => {
     }
   });
 
+  // #1698 — the now-playing feed URL. Same posture as `logoUrl`: a verbatim
+  // copy, never templated from `id` (this is a table of stations, not a table
+  // of SomaFM slugs), and nullable because publishing a track feed is a
+  // provider CAPABILITY, not something every station has.
+  it("carries a now-playing feed for at least one station", () => {
+    // The positive control for every rule below it. Each of those skips a
+    // station whose `songsUrl` is null, so a table where the field went
+    // uniformly null would report green having compared nothing — silence
+    // read as agreement.
+    const withFeed = RADIO_STATIONS.filter((s) => s.songsUrl !== null);
+    expect(withFeed.length).toBeGreaterThan(0);
+  });
+
+  it("serves every now-playing feed over https", () => {
+    // A feed is a `fetch`, so it is governed by `connect-src`, and the CSP
+    // token that admits it (`https://api.somafm.com`) is scheme-scoped. An
+    // http URL is refused as mixed content before the CSP is even consulted.
+    for (const s of RADIO_STATIONS) {
+      if (s.songsUrl === null) continue;
+      expect(s.songsUrl, `station ${s.id} songs feed`).toMatch(/^https:\/\//);
+    }
+  });
+
+  it("aims every somafm now-playing feed at api.somafm.com, the host the CSP admits", () => {
+    // #1695 measured this and it is the trap worth pinning: `connect-src`
+    // admits `https://api.somafm.com` and NOT the bare `somafm.com`, which
+    // answers an identical 200 under curl and dies in the browser. The failure
+    // is a console CSP violation and a permanently empty track line — silent
+    // from the operator's side. Scoped to somafm hosts for the same reason the
+    // stream rule is: the table may hold a station from another provider.
+    for (const s of RADIO_STATIONS) {
+      if (s.songsUrl === null) continue;
+      const host = new URL(s.songsUrl).host;
+      if (!host.endsWith("somafm.com")) continue;
+      expect(host, `station ${s.id} songs feed is off the CSP's host`).toBe("api.somafm.com");
+    }
+  });
+
   it("uses SomaFM's stable front door, never a numbered pool host", () => {
     // Measured 2026-08-23: a channel's `.pls` lists three ROTATING hosts
     // (ice2 / ice5 / ice6) while the unnumbered `ice.somafm.com` answers for

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1816,3 +1816,31 @@ describe("parseSlash — network-advertised CHANTYPES (#1255)", () => {
     });
   });
 });
+
+describe("parseSlash — /np (#1698)", () => {
+  it("takes no arguments", () => {
+    expect(parseSlash("/np")).toEqual({ kind: "np" });
+  });
+
+  it("ignores trailing tokens rather than erroring on them", () => {
+    // The no-arg family's posture (`/info`, `/version`): there is nothing a
+    // second token could mean, and refusing one buys the operator a scolding
+    // instead of the line they asked for.
+    expect(parseSlash("/np right now")).toEqual({ kind: "np" });
+  });
+
+  it("stays a plain privmsg behind the literal-slash escape", () => {
+    // `//np` is how the operator says "the text /np", per the mIRC escape the
+    // parser already implements. A new verb must not steal it.
+    expect(parseSlash("//np")).toEqual({ kind: "privmsg", body: "/np" });
+  });
+
+  it("can be shadowed by a user alias, like every builtin but /alias", () => {
+    // #427's rule, checked on the new verb rather than assumed to apply: the
+    // non-shadowable set is a FIXED two names, and /np is not one of them.
+    expect(parseSlash("/np", { np: "me is listening" })).toEqual({
+      kind: "me",
+      body: "is listening",
+    });
+  });
+});

--- a/cicchetto/src/lib/commands/radio.ts
+++ b/cicchetto/src/lib/commands/radio.ts
@@ -1,0 +1,72 @@
+import { assertNever } from "../api";
+import { ctcpFrame } from "../ctcpAction";
+import { NOW_PLAYING_STALE_MS, nowPlaying, nowPlayingLine } from "../nowPlaying";
+import { sendMessage as sendWindowMessage } from "../scrollback";
+import type { CommandHandler } from "./context";
+
+/**
+ * #1698 — `/np`: an ACTION naming the track the tuned radio station is
+ * playing.
+ *
+ * THIS VERB WRITES INTO A CHANNEL, which is what makes its refusals the
+ * interesting part. Four of its five arms send nothing, and each one refuses
+ * for a DIFFERENT observed reason with a different sentence — because the
+ * operator's next move differs too (pick a station / stop expecting one from
+ * this provider / wait / check the network). A single "nothing to report"
+ * would collapse four different repairs into one shrug.
+ *
+ * WHY IT NEVER SENDS A DEGRADED LINE. The two shapes worth naming, both of
+ * which vjt called out as worse than a local error:
+ *
+ *   * The EMPTY line. `* nick is now playing:  []` is refused three levels
+ *     deep — a blank title never becomes a track (`parseSongsFeed`), a
+ *     trackless state never becomes a body, and the arms below never reach
+ *     the send.
+ *   * The STALE line. A track from ten minutes ago published as "now" is a
+ *     lie told to other people, so the store stops calling it a track at
+ *     three poll intervals and this arm refuses it. Refusing is not this
+ *     handler's own rule — it is the same predicate the DISPLAY obeys, so the
+ *     rail, the docked bar and the channel can never disagree about whether a
+ *     track is current.
+ *
+ * A station-only fallback ("is listening to Groove Salad") was considered for
+ * the trackless arms and rejected: `/np` means "now PLAYING", the operator
+ * typed it to name a track, and quietly sending a different sentence is the
+ * command deciding it knows better. The station is already one `/me` away for
+ * anyone who wants to say that.
+ *
+ * TARGETING is `ctx.submittedFrom` — the window it was typed in, which is what
+ * `/me` does, reached through the same `ctcpFrame` + `sendMessage` seam
+ * `/ctcp <t> ACTION` uses. No pacing plan: the body is one generated line
+ * (112 bytes at the longest of 237 songs measured), so there is no multi-line
+ * fan-out to resume.
+ */
+export const npCommand: CommandHandler<"np"> = async (_cmd, ctx) => {
+  const state = nowPlaying();
+  switch (state.status) {
+    case "idle":
+      return { error: "/np: nothing is playing — tune a station from the radio picker first" };
+    case "unsupported":
+      return { error: `/np: ${state.station} publishes no track information` };
+    case "unanswered":
+      return { error: `/np: no track from ${state.station} yet — its feed has not answered` };
+    case "stale": {
+      // The threshold is DERIVED from the store's constant, not retyped: a
+      // cadence change must move the sentence with it, or the operator is told
+      // a number the code stopped using.
+      const minutes = Math.round(NOW_PLAYING_STALE_MS / 60_000);
+      return {
+        error: `/np: the last track from ${state.station} is over ${minutes} minutes old — not sending it`,
+      };
+    }
+    case "playing":
+      await sendWindowMessage(
+        ctx.networkSlug,
+        ctx.submittedFrom,
+        ctcpFrame("ACTION", nowPlayingLine(state.track, state.station)),
+      );
+      return { ok: true };
+    default:
+      return assertNever(state);
+  }
+};

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -35,6 +35,7 @@ import {
   unbanCommand,
   voiceCommand,
 } from "./commands/ops";
+import { npCommand } from "./commands/radio";
 import { ctcpCommand, noticeCommand, pingCommand } from "./commands/relay";
 import {
   adminCommand,
@@ -797,6 +798,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         }
         case "ping": {
           result = await pingCommand(cmd, ctx);
+          break;
+        }
+        case "np": {
+          result = await npCommand(cmd, ctx);
           break;
         }
         case "notice": {

--- a/cicchetto/src/lib/nowPlaying.ts
+++ b/cicchetto/src/lib/nowPlaying.ts
@@ -1,0 +1,240 @@
+import { createEffect, createSignal, on } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
+import { tunedStation } from "./radio";
+
+// #1698 — what the tuned station is playing right now.
+//
+// WHERE THE FACT COMES FROM, AND WHAT WAS RULED OUT. Measured 2026-08-24:
+//
+//   * ICY in-band metadata is NOT an option, twice over. Requesting the stream
+//     with `Icy-MetaData: 1` returns `icy-name` / `icy-genre` / `icy-br` and NO
+//     `icy-metaint`, so there is no in-band title track to read at all — and
+//     even where there were, a browser `<audio>` element does not surface ICY
+//     to the page.
+//   * `channels.json` DOES carry a now-playing value (`lastPlaying`), and it is
+//     the wrong one: it is a single joined STRING ("Charlie North - Never
+//     (Means Forever)"), so reading artist and title out of it means splitting
+//     on " - " and getting it wrong the first time a title contains a hyphen.
+//     It also costs 52,767 bytes to learn about 46 channels when we want one —
+//     19× the 2,771 the per-channel feed costs.
+//   * `…/songs/<id>.json` is the workable source: `songs[0]` is the current
+//     track, newest first, already SPLIT into `title` / `artist` / `album` /
+//     `date`.
+//
+// CADENCE, AND WHO PAYS FOR IT. This polls a third party's host, once per
+// listening tab, and that is an operational choice rather than a detail:
+//
+//   * 60s. The shortest gap between consecutive tracks measured across all 14
+//     stations (223 gaps) was 105s, so a 60s read cannot miss a track outright;
+//     the median gap is 259s, so the worst-case staleness is under a quarter of
+//     a typical track. Tighter buys accuracy nobody can perceive; looser starts
+//     missing short tracks.
+//   * The bill is 2.7 KB/min per LISTENING tab — against the 128 kbps stream
+//     the same tab is already pulling from the same provider, which is
+//     960 KB/min. The metadata is 0.28% of the audio. That ratio is the whole
+//     argument: we are already SomaFM's listener, and this is a rounding error
+//     on top of what listening costs them.
+//   * It is keyed on `tunedStation()`, so an idle player, an audio upload that
+//     took the element over, a logout and the transport's ✕ each cost exactly
+//     zero. There is no separate "is the radio on" flag to forget to clear —
+//     that is the whole reason `radio.ts` derives rather than stores.
+//   * NOT keyed on pause, and not on tab visibility, deliberately. `paused`
+//     lives inside `AudioMiniPlayer`'s element and lifting it into a store to
+//     save 2.7 KB/min would be exactly the parallel structure that drifts. A
+//     backgrounded tab is still playing audio, so the ratio above is unchanged.
+//   * SERVER-SIDE polling was considered and rejected: it would dedupe the read
+//     across users, and it would buy that with a supervised process, a wire
+//     event, a protocol bump and a bouncer that depends on somafm being up —
+//     for a station that is a purely client-side concept. The mechanism would
+//     be heavier than the problem.
+//
+// FIVE STATES, NOT A TRACK-OR-NULL. Each one has a distinct answer for `/np`,
+// which WRITES INTO A CHANNEL, and a distinct display; collapsing them would
+// force the command to reconstruct the difference from context it does not
+// have. `assertNever` at the consumers makes a sixth compile-loud.
+//
+// `stale` is the state that exists because of what `/np` is: publishing a
+// ten-minute-old track into a channel is worse than a local error. It is
+// declared from the age of our last SUCCESSFUL READ, never from the track's own
+// `date` — a Drone Zone piece measured 86 minutes long is not stale, it is
+// long. And it blanks the DISPLAY too, on purpose: one predicate for both
+// doors, so `/np`'s refusal is not a special case bolted onto a surface that
+// keeps lying.
+//
+// The whole module has no reset of its own. It derives from `tunedStation()`,
+// which derives from the identity-scoped `audioPlayer` store, so a rotation
+// stops the poll by construction — the same reason `radio.ts` gives for owning
+// no tuned-station signal.
+
+/** How often the tuned station's feed is re-read. See the cadence note above:
+    the number is measured against the observed track-gap distribution, not
+    picked. */
+export const NOW_PLAYING_POLL_MS = 60_000;
+
+/** How old the last SUCCESSFUL read may get before the track stops being
+    something we will show or publish. Three poll intervals: one missed read is
+    a blip on a median 259s track, three means we have been blind across the
+    p25 gap (193s) and the track we hold is likelier wrong than right.
+    Expressed as a multiple so a cadence change carries it along. */
+export const NOW_PLAYING_STALE_MS = NOW_PLAYING_POLL_MS * 3;
+
+/** The track on air. `album` is in the feed and deliberately NOT here: nothing
+    renders it, and a field no door reads is a field that rots unnoticed. */
+export type NowPlayingTrack = {
+  /** Absent when the feed gave a blank one — the line then names the title
+      alone rather than dangling a dash. */
+  readonly artist: string | null;
+  readonly title: string;
+};
+
+/** What the store can honestly say. Named for what was OBSERVED, per the
+    log-honesty rule: `unanswered` is true whether the feed has been silent for
+    200ms or for an hour, and does not promise a "yet". */
+export type NowPlaying =
+  | { readonly status: "idle" }
+  | { readonly status: "unsupported" }
+  | { readonly status: "unanswered" }
+  | { readonly status: "stale" }
+  | { readonly status: "playing"; readonly track: NowPlayingTrack };
+
+/** The shape SomaFM gives us. Everything optional: this is a third party's
+    document and a missing field must degrade to "no track", never to a throw —
+    the poll's error handling exists to keep the previous track on screen
+    through a bad answer, and it cannot do that if parsing takes it out. */
+type SongsBody = { readonly songs?: unknown };
+
+const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+
+/**
+ * The newest track in a `…/songs/<id>.json` body, or `null` when the document
+ * carries none we would show.
+ *
+ * A blank TITLE is rejected here rather than downstream, and that is the
+ * boundary doing its job: `/np` renders the track into a channel, and a blank
+ * title is exactly the empty sentence that must never reach the wire. A blank
+ * ARTIST is kept — it shortens the line instead of voiding it.
+ */
+export function parseSongsFeed(body: unknown): NowPlayingTrack | null {
+  if (typeof body !== "object" || body === null) return null;
+  const songs = (body as SongsBody).songs;
+  if (!Array.isArray(songs)) return null;
+  const first: unknown = songs[0];
+  if (typeof first !== "object" || first === null) return null;
+  const row = first as Record<string, unknown>;
+  const title = str(row.title);
+  if (title === "") return null;
+  const artist = str(row.artist);
+  return { artist: artist === "" ? null : artist, title };
+}
+
+/**
+ * The CTCP ACTION body `/np` sends: `is now playing: <artist> — <title>
+ * [<station>]`.
+ *
+ * The STATION is in the line by decision, not by inheritance from the issue's
+ * example. It is the only part of the sentence a reader can act on — it turns
+ * a boast into something someone else can tune to — and it disambiguates a
+ * track title that means nothing on its own.
+ *
+ * Lives here rather than in the command handler so both doors spell a track
+ * the same way, and so a test of the wire text calls the production formatter
+ * instead of re-typing it.
+ */
+export function nowPlayingLine(track: NowPlayingTrack, station: string): string {
+  const what = track.artist === null ? track.title : `${track.artist} — ${track.title}`;
+  return `is now playing: ${what} [${station}]`;
+}
+
+/** What a read of the feed left behind. `at` is stamped at SUCCESS, so
+    staleness is measured from when we last knew something — not from the
+    track's own start time, which says how long a piece is, not how blind we
+    are. */
+type LastRead = { readonly track: NowPlayingTrack; readonly at: number };
+
+// `moduleRoot`, not `identityScopedStore`, and the difference is the point:
+// this store registers NO identity reset because it has nothing of its own to
+// reset. Everything it holds is downstream of `tunedStation()`, which a
+// rotation already clears — declaring a reset here would be a second mechanism
+// enforcing what the derivation guarantees, and the two would drift.
+const exports_ = moduleRoot(() => {
+  const [read, setRead] = createSignal<LastRead | null>(null);
+  // Separated from `read` rather than folded into it: the two answer different
+  // questions ("what did we last learn" vs "is it still worth showing"), and a
+  // single nullable would make a recovered read indistinguishable from a first
+  // one.
+  const [staleFlag, setStaleFlag] = createSignal(false);
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const stopPolling = (): void => {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const poll = async (url: string): Promise<void> => {
+    let track: NowPlayingTrack | null = null;
+    try {
+      const res = await fetch(url, {
+        // Explicit, though it is also the cross-origin default: this is a
+        // third party's host and must never be handed a grappa cookie. Stated
+        // so a later edit to this options object cannot silently turn it on.
+        credentials: "omit",
+      });
+      if (res.ok) track = parseSongsFeed(await res.json());
+    } catch {
+      // A transport failure and a malformed answer are the SAME event here —
+      // "we did not learn anything this time" — and both are handled below by
+      // ageing the previous read rather than by blanking it.
+      track = null;
+    }
+
+    // The station may have changed while this was in flight. Writing anyway
+    // would caption the new station with the old one's track, which `/np`
+    // would then publish into a channel. Compared by URL rather than by a
+    // generation counter, which also makes a re-tune of the SAME station
+    // accept the answer it is still waiting for.
+    if (tunedStation()?.songsUrl !== url) return;
+
+    if (track !== null) {
+      setRead({ track, at: Date.now() });
+      setStaleFlag(false);
+      return;
+    }
+    const last = read();
+    if (last !== null && Date.now() - last.at > NOW_PLAYING_STALE_MS) setStaleFlag(true);
+  };
+
+  // The lifecycle, derived. Every transition that matters — tuning, swapping,
+  // an upload seizing the player, the ✕, a logout — arrives here as one
+  // `tunedStation()` change, because that value is itself derived from the one
+  // audio store. There is nothing else to hook and nothing to keep in step.
+  createEffect(
+    on(tunedStation, (station) => {
+      stopPolling();
+      setRead(null);
+      setStaleFlag(false);
+      const url = station?.songsUrl;
+      if (url === undefined || url === null) return;
+      // Immediately, then on the interval: a 60s blank at tune-in is the
+      // operator's first impression of the feature.
+      void poll(url);
+      timer = setInterval(() => void poll(url), NOW_PLAYING_POLL_MS);
+    }),
+  );
+
+  const nowPlaying = (): NowPlaying => {
+    const station = tunedStation();
+    if (station === null) return { status: "idle" };
+    if (station.songsUrl === null) return { status: "unsupported" };
+    if (staleFlag()) return { status: "stale" };
+    const last = read();
+    if (last === null) return { status: "unanswered" };
+    return { status: "playing", track: last.track };
+  };
+
+  return { nowPlaying };
+});
+
+export const { nowPlaying } = exports_;

--- a/cicchetto/src/lib/nowPlaying.ts
+++ b/cicchetto/src/lib/nowPlaying.ts
@@ -128,6 +128,18 @@ export function parseSongsFeed(body: unknown): NowPlayingTrack | null {
 }
 
 /**
+ * A track as one string: `<artist> — <title>`, or the title alone when the
+ * feed gave no artist (the dash goes with it rather than dangling).
+ *
+ * The ONE spelling of a track, shared by the rail chrome, the docked transport
+ * and the `/np` wire line. Three surfaces re-implementing the same join is
+ * three chances for the phone and the channel to disagree about what is on.
+ */
+export function trackLabel(track: NowPlayingTrack): string {
+  return track.artist === null ? track.title : `${track.artist} — ${track.title}`;
+}
+
+/**
  * The CTCP ACTION body `/np` sends: `is now playing: <artist> — <title>
  * [<station>]`.
  *
@@ -141,8 +153,7 @@ export function parseSongsFeed(body: unknown): NowPlayingTrack | null {
  * instead of re-typing it.
  */
 export function nowPlayingLine(track: NowPlayingTrack, station: string): string {
-  const what = track.artist === null ? track.title : `${track.artist} — ${track.title}`;
-  return `is now playing: ${what} [${station}]`;
+  return `is now playing: ${trackLabel(track)} [${station}]`;
 }
 
 /** What a read of the feed left behind. `at` is stamped at SUCCESS, so
@@ -234,7 +245,18 @@ const exports_ = moduleRoot(() => {
     return { status: "playing", track: last.track };
   };
 
-  return { nowPlaying };
+  // The DISPLAY projection, next to the state it projects. Both surfaces —
+  // the rail chrome and the docked transport — want the same two facts
+  // ("is there a track" / "how is it spelled"), and a component computing
+  // them for itself is the second one drifting from the first. Null on every
+  // arm but `playing`, which is what makes the stale rule reach the SCREEN
+  // and not just `/np`.
+  const nowPlayingLabel = (): string | null => {
+    const state = nowPlaying();
+    return state.status === "playing" ? trackLabel(state.track) : null;
+  };
+
+  return { nowPlaying, nowPlayingLabel };
 });
 
-export const { nowPlaying } = exports_;
+export const { nowPlaying, nowPlayingLabel } = exports_;

--- a/cicchetto/src/lib/nowPlaying.ts
+++ b/cicchetto/src/lib/nowPlaying.ts
@@ -92,10 +92,17 @@ export type NowPlayingTrack = {
     200ms or for an hour, and does not promise a "yet". */
 export type NowPlaying =
   | { readonly status: "idle" }
-  | { readonly status: "unsupported" }
-  | { readonly status: "unanswered" }
-  | { readonly status: "stale" }
-  | { readonly status: "playing"; readonly track: NowPlayingTrack };
+  // `station` is the TITLE, and EVERY arm that has one carries it — only
+  // `idle` does not, because there is no station to name. Uniform on purpose:
+  // each of these is a sentence `/np` says to the operator about a particular
+  // station, and an arm without the name forces a caller to go and read
+  // `tunedStation()` again, at a different instant, to finish the sentence.
+  // Projected out of the same synchronous derivation rather than stored, so it
+  // cannot drift from the player it comes from.
+  | { readonly status: "unsupported"; readonly station: string }
+  | { readonly status: "unanswered"; readonly station: string }
+  | { readonly status: "stale"; readonly station: string }
+  | { readonly status: "playing"; readonly track: NowPlayingTrack; readonly station: string };
 
 /** The shape SomaFM gives us. Everything optional: this is a third party's
     document and a missing field must degrade to "no track", never to a throw —
@@ -238,11 +245,11 @@ const exports_ = moduleRoot(() => {
   const nowPlaying = (): NowPlaying => {
     const station = tunedStation();
     if (station === null) return { status: "idle" };
-    if (station.songsUrl === null) return { status: "unsupported" };
-    if (staleFlag()) return { status: "stale" };
+    if (station.songsUrl === null) return { status: "unsupported", station: station.title };
+    if (staleFlag()) return { status: "stale", station: station.title };
     const last = read();
-    if (last === null) return { status: "unanswered" };
-    return { status: "playing", track: last.track };
+    if (last === null) return { status: "unanswered", station: station.title };
+    return { status: "playing", track: last.track, station: station.title };
   };
 
   // The DISPLAY projection, next to the state it projects. Both surfaces —

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -86,6 +86,20 @@ export type RadioStation = {
   /** The endless audio endpoint handed to `playAudio`. */
   readonly streamUrl: string;
   readonly logoUrl: string;
+  /** #1698 — the JSON feed naming the track on air, or `null` when the
+      provider publishes none.
+      NULLABLE, unlike every sibling above, and the difference is real rather
+      than defensive: a title, a stream and a logo are things every station HAS,
+      while a machine-readable now-playing feed is a provider CAPABILITY. A
+      required field would force the next non-SomaFM station to invent a URL,
+      and an invented URL is the unverifiable claim #1696 was filed about.
+      COPIED, never templated from `id` — the same rule `logoUrl` states above,
+      for the same reason: `id` is our slug, not a SomaFM one, and deriving
+      `…/songs/${id}.json` would bake a vendor's naming convention into the
+      type. That the two coincide for all fourteen rows today is a fact about
+      SomaFM, not a contract. `bun run check:radio` probes this URL alongside
+      the logo, so the claim stays executable. */
+  readonly songsUrl: string | null;
 };
 
 export const RADIO_STATIONS: readonly RadioStation[] = [
@@ -96,6 +110,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "A nicely chilled plate of ambient/downtempo beats and grooves.",
     streamUrl: "https://ice.somafm.com/groovesalad-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/groovesalad120.png",
+    songsUrl: "https://api.somafm.com/songs/groovesalad.json",
   },
   {
     id: "dronezone",
@@ -105,6 +120,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
       "Served best chilled, safe with most medications. Atmospheric textures with minimal beats.",
     streamUrl: "https://ice.somafm.com/dronezone-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/dronezone120.jpg",
+    songsUrl: "https://api.somafm.com/songs/dronezone.json",
   },
   {
     id: "spacestation",
@@ -113,6 +129,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Tune in, turn on, space out. Spaced-out ambient and mid-tempo electronica.",
     streamUrl: "https://ice.somafm.com/spacestation-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/spacestation120.jpg",
+    songsUrl: "https://api.somafm.com/songs/spacestation.json",
   },
   {
     id: "lush",
@@ -121,6 +138,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Sensuous and mellow female vocals, many with an electronic influence.",
     streamUrl: "https://ice.somafm.com/lush-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/lush120.jpg",
+    songsUrl: "https://api.somafm.com/songs/lush.json",
   },
   {
     id: "indiepop",
@@ -129,6 +147,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "New and classic favorite indie pop tracks.",
     streamUrl: "https://ice.somafm.com/indiepop-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/indiepop120.jpg",
+    songsUrl: "https://api.somafm.com/songs/indiepop.json",
   },
   {
     id: "u80s",
@@ -137,6 +156,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Early 80s UK Synthpop and a bit of New Wave.",
     streamUrl: "https://ice.somafm.com/u80s-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/u80s120.png",
+    songsUrl: "https://api.somafm.com/songs/u80s.json",
   },
   {
     id: "secretagent",
@@ -146,6 +166,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
       "The soundtrack for your stylish, mysterious, dangerous life. For Spies and PIs too!",
     streamUrl: "https://ice.somafm.com/secretagent-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/secretagent120.jpg",
+    songsUrl: "https://api.somafm.com/songs/secretagent.json",
   },
   {
     id: "defcon",
@@ -154,6 +175,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Music for Hacking. The DEF CON Year-Round Channel.",
     streamUrl: "https://ice.somafm.com/defcon-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/defcon120.png",
+    songsUrl: "https://api.somafm.com/songs/defcon.json",
   },
   {
     id: "folkfwd",
@@ -162,6 +184,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Indie Folk, Alt-folk and the occasional folk classics. ",
     streamUrl: "https://ice.somafm.com/folkfwd-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/folkfwd120.jpg",
+    songsUrl: "https://api.somafm.com/songs/folkfwd.json",
   },
   {
     id: "bootliquor",
@@ -170,6 +193,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Americana Roots music for Cowhands, Cowpokes and Cowtippers",
     streamUrl: "https://ice.somafm.com/bootliquor-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/bootliquor120.jpg",
+    songsUrl: "https://api.somafm.com/songs/bootliquor.json",
   },
   {
     id: "bossa",
@@ -178,6 +202,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Silky-smooth, laid-back Brazilian-style rhythms of Bossa Nova, Samba and beyond",
     streamUrl: "https://ice.somafm.com/bossa-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/bossa120.jpg",
+    songsUrl: "https://api.somafm.com/songs/bossa.json",
   },
   {
     id: "reggae",
@@ -186,6 +211,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Reggae, Ska, Rocksteady classic and deep tracks.",
     streamUrl: "https://ice.somafm.com/reggae-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/reggae120.png",
+    songsUrl: "https://api.somafm.com/songs/reggae.json",
   },
   {
     id: "sonicuniverse",
@@ -194,6 +220,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Transcending the world of jazz with eclectic, avant-garde takes on tradition.",
     streamUrl: "https://ice.somafm.com/sonicuniverse-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/sonicuniverse120.jpg",
+    songsUrl: "https://api.somafm.com/songs/sonicuniverse.json",
   },
   {
     id: "missioncontrol",
@@ -202,5 +229,6 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Celebrating NASA and Space Explorers everywhere.",
     streamUrl: "https://ice.somafm.com/missioncontrol-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/missioncontrol120.jpg",
+    songsUrl: "https://api.somafm.com/songs/missioncontrol.json",
   },
 ];

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -234,6 +234,13 @@ export type SlashCommand =
   // target; compose.ts stamps the outbound timestamp token and owns the
   // reply-correlation state (RTT synthesized locally in the source window).
   | { kind: "ping"; target: string }
+  // #1698 — /np: an ACTION naming the track the tuned radio station is
+  // playing. It carries NOTHING, and that is the shape rather than an
+  // omission: the track, the station and whether either is currently
+  // knowable all live in the `nowPlaying` store, and a parser that stays
+  // pure cannot see any of them. compose.ts resolves the state and decides
+  // between a wire frame and a local refusal.
+  | { kind: "np" }
   | { kind: "error"; verb: string; message: string };
 
 function err(verb: string, message: string): SlashCommand {
@@ -374,6 +381,15 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   // #591 — CTCP send verbs. /ctcp is the general form; /ping is the RTT sugar.
   ctcp: (_verb, rest) => parseCtcp(rest),
   ping: (_verb, rest) => parsePing(rest),
+
+  // #1698 — /np. Registered here like any other verb rather than special-cased
+  // in the composer, which the issue asks for explicitly and which is also the
+  // only way it inherits the whole path for free: the `//np` literal escape,
+  // #427 alias shadowing, and the dispatch characterization net.
+  // Trailing tokens are ignored, the no-arg family's posture (/info, /version):
+  // there is nothing a second token could mean, so refusing one would buy the
+  // operator a scolding instead of the line they asked for.
+  np: (_verb, _rest) => ({ kind: "np" }),
 
   join: (verb, rest, chantypes) => {
     // UX-4 bucket F: `/join #chan` OR `/join #chan key` (+k channel

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2352,13 +2352,24 @@ html.resize-dragging * {
   color: var(--fg);
 }
 
+/* #1698 — `.rail-radio-now-track` shares the genres' slot because it REPLACES
+   them: same second line, same clipping, so the chrome's height is the same
+   whether or not the feed has answered. #500's vertical budget is why it is a
+   swap and not a third line. */
 .rail-radio-now-genres,
+.rail-radio-now-track,
 .rail-radio-station-genres {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.8em;
   color: var(--muted);
+}
+
+/* One step brighter than the genres it stands in for: a genre tag is static
+   metadata, the track is the live fact this row exists to carry. */
+.rail-radio-now-track {
+  color: var(--fg-dim, var(--fg));
 }
 
 /* #1697 — the only delta left. Everything this rule used to declare
@@ -3815,6 +3826,28 @@ html.resize-dragging * {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--fg);
+}
+
+/* #1698 — the track, beside the station name. A SECOND growable span on a row
+   that had one, so the split is stated rather than left to chance: grow 2 vs
+   the label's 1, because the station is short and also on the rail while the
+   track is long and lives only here. Both keep shrink 1 and `min-width: 0`, so
+   neither can widen the row — the transport controls are `flex: none` above,
+   and on a phone this row IS the player: a ✕ pushed past the right edge is a
+   ✕ that cannot be tapped. That was #1697's finding one bar over, and it is no
+   longer one bar over: #1697 shipped the hide chevron INTO this row, so the
+   fixed cost the two spans divide what is left of is 4 × 2.5rem, not 3. The
+   label keeps grow 1 rather than dropping to 0 so a station whose feed has not
+   answered still fills the row instead of leaving a gap trailing the ✕.
+   Pinned by `audioMiniPlayerLayout.test.ts` against the STYLESHEET, because
+   jsdom applies no CSS and a DOM assertion cannot see a cascade override. */
+.audio-mini-player-track {
+  flex: 2 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-dim, var(--fg));
 }
 
 /* #682 — the "this has no end" badge that stands in for the seek slider.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -60129,3 +60129,212 @@ e2e lane is exclusive.** CI is its first run.
 #1151 (11px of drift for an 18px insertion, same applier) is adjacent and was
 left alone. The e2e tolerance is set wide enough to survive that residue and
 narrow enough that the ~150px this issue is about cannot hide inside it.
+<!-- entry #1698 -->
+
+---
+
+## 2026-08-24 — #1698: now-playing metadata, and a `/np` that would rather say nothing
+
+Two wants, one store. The radio player names the track on air, and `/np`
+says it in channel. The interesting decisions are all about what NOT to
+publish.
+
+### Where the fact comes from — and the two sources that lost
+
+Measured 2026-08-24, and the negative results are worth as much as the
+positive one.
+
+**ICY in-band is not an option, twice over.** Requesting a stream with
+`Icy-MetaData: 1` returns `icy-name`, `icy-genre`, `icy-br` and **no
+`icy-metaint`** — there is no in-band title track to read at all. And even
+where one were offered, a browser `<audio>` element does not surface ICY
+metadata to the page. Either fact alone closes the door.
+
+**`channels.json` DOES carry a now-playing value, and it is the wrong one.**
+`lastPlaying` is a single joined STRING (`"Charlie North - Never (Means
+Forever)"`), so artist and title come out of a split on `" - "` that the first
+hyphenated title breaks. Measured: 0 of 46 channels are ambiguous under that
+split *right now*, which is a sample and not a contract. It also costs 52,767
+bytes to learn about 46 channels when we want one — **19x** the 2,771 the
+per-channel feed costs.
+
+`https://api.somafm.com/songs/<id>.json` is the source: `songs[0]` is current,
+already split into `title` / `artist` / `album` / `date`.
+
+**`albumArt` is empty. 0 of 237 songs across all 14 stations.** Nothing is
+built on it, and the issue's warning about it needing `img-src` rather than
+`connect-src` is correct but moot: there is no image to admit. (Had there been,
+`img-src 'self' data: https:` already admits any https image — no server change
+would have been needed, which is a different fact from the one #1695 bought.)
+
+### Cadence: 60 seconds, and the bill is named
+
+Polling a third party's host once per listening tab is an operational choice.
+
+* **60s.** The shortest gap between consecutive tracks across all 14 stations
+  (223 gaps) is **105s**, so a 60s read cannot miss a track outright. The
+  median gap is **259s**, so worst-case staleness is under a quarter of a
+  typical track. Tighter buys accuracy nobody can perceive.
+* **The bill is 2.7 KB/min per LISTENING tab**, against the 128 kbps stream
+  that same tab already pulls from the same provider — 960 KB/min. The
+  metadata is **0.28% of the audio**. That ratio is the argument: we are
+  already SomaFM's listener, and this is a rounding error on what listening
+  costs them.
+* **Keyed on `tunedStation()`**, the fact `radio.ts` already derives from the
+  one audio store. An idle player, an upload seizing the element, the
+  transport's ✕ and a logout each cost zero, with no separate "radio is on"
+  flag to forget to clear.
+* **NOT keyed on pause, and not on tab visibility.** `paused` lives inside the
+  `<audio>` element, and lifting it into a store to save 2.7 KB/min is exactly
+  the parallel structure that drifts. A backgrounded tab is still playing
+  audio, so the ratio above is unchanged.
+* **Server-side polling rejected.** It would dedupe the read across users and
+  pay for it with a supervised process, a wire event, a protocol bump and a
+  bouncer that depends on somafm being up — for a station that is a purely
+  client-side concept. The mechanism would be heavier than the problem.
+
+### Five states, and `stale` is the one `/np` forced
+
+`nowPlaying()` answers a five-arm union — `idle` / `unsupported` /
+`unanswered` / `stale` / `playing` — rather than a track-or-null, because
+`/np` writes into a channel and each state needs a different sentence and a
+different repair. Arms are named for what was OBSERVED (log honesty):
+`unanswered` is true whether the feed has been silent for 200ms or an hour,
+and promises no "yet".
+
+**`stale` is measured from our last successful READ, never from the track's
+own `date`.** A Drone Zone piece measured 86 minutes long (5,171s, the longest
+of 223 gaps) is long, not stale. The threshold is three poll intervals,
+cross-checked against the p25 gap of 193s: past that we have been blind across
+the point where three quarters of tracks would have ended.
+
+**It blanks the DISPLAY too, not just `/np`.** One predicate, both doors —
+proven by mutation rather than asserted: deleting the stale gate from the store
+kills the store's own test AND `/np`'s refusal, in two different files. A
+refusal bolted onto a surface that keeps lying would not have that property.
+
+### `/np`: four refusals and no fallback
+
+Registered in `slashCommands.ts` like any other verb (the issue asks for it,
+and it is also how the verb inherits the `//np` literal escape, #427 alias
+shadowing, and the dispatch reconciliation net). It carries no arguments —
+the parser stays pure and cannot see the store.
+
+Four of five arms send nothing, each with its own sentence, because the
+operator's next move differs: pick a station / stop expecting one from this
+provider / wait / check the network. The two degraded lines vjt named as worse
+than a local error cannot be built at all: the EMPTY one is refused three
+levels deep (a blank title never becomes a track, a trackless state never
+becomes a body, no arm reaches the send), and the STALE one by the shared
+predicate above. The stale sentence quotes the threshold from the store's
+constant, so a cadence change moves the number instead of stranding the
+operator with one the code stopped using.
+
+**The station is IN the line** (`is now playing: Trestal — A Land Unknown
+[Groove Salad]`) — it is the only part a reader can act on, which turns a
+boast into a recommendation. **A station-only fallback for the trackless arms
+was rejected**: `/np` means now PLAYING, the operator typed it to name a track,
+and quietly sending a different sentence is the command deciding it knows
+better. `/me` is one keystroke away for anyone who wants that.
+
+Targets `ctx.submittedFrom` exactly as `/me` does, through the shared
+`ctcpFrame` + `sendMessage` seam. **Known and deliberately out of scope:**
+`/me` in the `$server` window has no guard (only `privmsg` is refused there),
+so `/np` inherits the same gap. Adding one for `/np` alone would be two
+patterns for one behaviour; the honest fix spans `/me`, `/ctcp ACTION` and
+`/np` together.
+
+### The baked feed URL is checkable, because #1696 said so
+
+`songsUrl` is a THIRD baked third-party URL in `radioStations.ts`, and #1696's
+finding was that such a URL with nothing to execute against it is a claim, not
+a fact. `bun run check:radio` gains a FEED axis: 200 + `application/json`.
+Measured — a slug the host does not know answers 404 `text/html`, and that
+failure has no other symptom, since the station plays perfectly while the track
+line stays empty forever. Proven by injecting a wrong slug: `FEED HTTP 404`,
+`1 broken`, rc=1.
+
+**No AGREE twin, and the absence is measured:** `channels.json` publishes no
+per-channel songs-feed URL at all (46 channels, keys `description dj djmail
+featured genre id image largeimage lastPlaying listeners playlists preroll
+title twitter updated xlimage`), so there is no upstream value to compare the
+baked one against. Naming that beats inventing a comparison that passes on
+anything.
+
+`songsUrl` is `string | null` because publishing a feed is a provider
+CAPABILITY. That makes `unsupported` a type-FORCED arm which no current table
+row can reach — `tunedStation()` derives from RADIO_STATIONS and all fourteen
+carry a feed — so it is tested against the handler with `../lib/radio` mocked,
+in its own file. A production arm with no test was the alternative.
+
+### Rebased onto #1697, and the sum neither slice measured
+
+#1697 (hide-while-playing, and the picker's move to the shared `PaneTopBar`
+band) landed on main while this was in flight, against the same four files.
+Three things came out of the rebase that are not conflict resolution.
+
+**The layout pin caught it, LOUDLY, and that is the argument for pinning the
+GROUP.** `audioMiniPlayerLayout.test.ts` names the unshrinkable-controls rule
+by its full selector list, and #1697 inserted a fourth member
+(`.audio-mini-player-hide`) into that rule. `nestedRuleBodies` compares the
+list verbatim, so the stale spelling threw `CSS rule not found` instead of
+measuring a rule that had stopped existing. Had the guard asserted one member
+— `.audio-mini-player-close` alone — it would have stayed GREEN across the
+change and said nothing about the new button, which could then have shrunk and
+pushed the ✕ off the very edge #1697 exists to keep it on. **A CSS pin that
+names a grouped selector verbatim converts a silent rebase drift into a red;
+one that names a single member converts it into a vacuous green.**
+
+**Hiding splits the track in two, and only one half needed code.** The chrome
+half is free: the span sits inside the same `<Show>` the hide predicate
+narrows, so a hidden bar cannot render a track. The other half is the one worth
+stating — `/np` is a COMMAND, not chrome, and an operator who hid the bar to
+get their screen back is precisely the one who then asks the channel what is
+on. The fact outlives the surface because the poll is keyed on
+`tunedStation()`, i.e. on the AUDIO, and hiding deliberately says nothing about
+the audio. Keying it on visibility would have made `/np` answer "nothing is
+playing" in the state a phone spends most of its time in — a refusal that lies
+rather than reports. Pinned by a test that asserts all three at once: the span
+is gone, `nowPlayingLabel()` is intact, and `tunedStation()` still names the
+station (the last one is the mechanism, not a proxy: routing the hidden flag
+through `activeAudio` — the shape #1697's own comment forbids — nulls it).
+
+**And the row's fixed cost grew by a whole control.** In LIVE mode the download
+anchor is not rendered, so the docked bar carried two buttons before #1697 and
+carries three now, while #1698 adds a second growable span to the space they
+leave. Off the stylesheet: `html, body { font-size: var(--font-size) }` with
+`:root --font-size: 14px`, so `1rem` is 14px and the group's `min-width: 2.5rem`
+is 35px; `.audio-mini-player` declares `gap: 0.5rem` and `padding: 0.4rem
+0.5rem`; `.audio-mini-player-live` and `-time` are both `flex: none`. Three
+buttons (105px) + six gaps (42px) + inline padding (14px) = **161px before a
+single character of text**, and the live badge and elapsed clock take their
+intrinsic width out of what is left. On a 375px-wide viewport the two spans
+divide roughly 138px, and the 2:1 split hands the station label about 46px.
+**This is arithmetic off the stylesheet with an assumed 0.6em monospace
+advance, not a measurement** — the digit is soft, the ORDER is not: the station
+name on a small phone goes from most of the row to a handful of characters.
+Neither slice is wrong on its own and neither measured the sum, which is why
+the device-verify below is a blocking item on this branch and not boilerplate.
+
+### What was NOT measured
+
+* **The docked bar on a real phone.** #1698 adds a second text span to the row
+  #1697/#1721 measured as cramped, and #1697 has since added a third button to
+  it — see the arithmetic above. The layout contract is pinned against the
+  STYLESHEET (`min-width: 0`, ellipsis, `flex` shrink non-zero, controls
+  `flex: none`, and exactly ONE block per selector) because jsdom applies no
+  CSS — the #1697 mechanism. Two mutants confirm it: dropping `min-width: 0`
+  reds the CSS guard while all 16 DOM tests stay green, and appending a second
+  `.audio-mini-player-track` block (the #1697 shape exactly) reds it too. None
+  of that says the bar FITS. Device-verify. The named remedy if it does not,
+  recorded here so it is not re-derived under pressure: drop the label's grow
+  to 0 while a track is present, so the station name keeps its intrinsic width
+  and the track absorbs the shortfall — NOT a smaller track, which would put
+  both spans below legibility instead of one.
+* **No e2e was written, and the CSP half needs none.**
+  `issue1695-somafm-connect-src-perimeter.spec.ts` already proves a browser
+  lets a `fetch` to `api.somafm.com` out and blocks both neighbours; the CSP
+  token is a host-source with no path, so its verdict covers `songs/<id>.json`
+  by construction. What an e2e would add beyond that is the bundle-arrival
+  oracle, and it would have to intercept the feed anyway — the "no third-party
+  outage detector in the gate" posture this table established in #682/#1696.


### PR DESCRIPTION
⚠️ **DEVICE-VERIFY (docked bar layout).** This adds a SECOND text span to the
`.audio-mini-player` row — the row #1697/#1721 measured as cramped on a phone
(28px vs 35px ✕). The layout contract is pinned against the STYLESHEET, and two
mutants confirm the guard bites (below), but **none of that says the bar fits.**
jsdom applies no CSS and computes no layout, and webkit in CI is not iOS. Please
check the docked player on a real phone with a station tuned.

---

Closes the two wants in #1698: the player says what is on, and `/np` says it in
channel.

## Where the fact comes from — the negatives are results too

Measured 2026-08-24.

**ICY in-band is closed twice over.** `Icy-MetaData: 1` returns `icy-name` /
`icy-genre` / `icy-br` and **no `icy-metaint`** — there is no in-band title
track — and a browser `<audio>` does not surface ICY to the page regardless.

**`channels.json` DOES carry a now-playing value, and it loses anyway.**
`lastPlaying` is one joined STRING (`"Charlie North - Never (Means Forever)"`),
so artist and title come out of a split on `" - "` that the first hyphenated
title breaks — 0 of 46 are ambiguous *right now*, which is a sample, not a
contract. It also costs **52,767 bytes** to learn about 46 channels when we
want one, **19×** the 2,771 the per-channel feed costs.

`api.somafm.com/songs/<id>.json` ships the fields already split.

## The four questions, answered

**1 — Cadence, and who pays.** **60s.** The shortest gap between consecutive
tracks across all 14 stations (223 gaps) is **105s**, so 60s cannot miss a
track; the median is **259s**, so worst-case staleness is under a quarter of a
typical track. The bill is **2.7 KB/min per LISTENING tab**, against the
128 kbps stream that same tab already pulls from the same provider —
960 KB/min. **The metadata is 0.28% of the audio.** We are already SomaFM's
listener; this is a rounding error on what listening costs them.

It polls only while `tunedStation()` is non-null — the fact `radio.ts` already
derives — so an idle player, an upload seizing the element, the ✕ and a logout
each cost zero. **Not keyed on pause or tab visibility**: `paused` lives in the
element and lifting it into a store to save 2.7 KB/min is the parallel
structure CLAUDE.md forbids, and a hidden tab is still playing audio.
**Server-side polling rejected** — it would dedupe the read and pay with a
supervised process, a wire event, a protocol bump and a bouncer depending on
somafm, for a purely client-side concept.

**2 — CSP.** `connect-src` admits `https://api.somafm.com` (confirmed in
`security_headers.ex`), so the feed passes. **`albumArt` is EMPTY — 0 of 237
songs across all 14 stations.** Nothing is built on it. The `img-src` caution
in the issue is correct and moot: there is no image to admit. (Had there been,
`img-src 'self' data: https:` already admits any https image, so no server
change would have been needed either way — a different fact from what #1695
bought.)

**3 — `/np` writes in channel, so four of its five arms send NOTHING**, each
with its own sentence, because the operator's next move differs: pick a station
/ stop expecting one from this provider / wait / check the network.

The two lines you named as worse than a local error **cannot be built**:

* **Empty** — refused three levels deep. A blank title never becomes a track
  (`parseSongsFeed`), a trackless state never becomes a body, no arm reaches
  the send.
* **Stale** — a track from ten minutes ago announced as "now" is wrong in a way
  only other people can see. Past **three poll intervals** the store stops
  calling it a track *at all*, so the display goes quiet with the command: **one
  predicate, both doors.** Measured from our last successful READ, never from
  the track's own `date` — a Drone Zone piece 86 minutes long (5,171s) is long,
  not stale. The threshold is cross-checked against the p25 gap of 193s, and
  the refusal quotes it from the store's constant so a cadence change moves the
  number with it.

**A station-only fallback was rejected**: `/np` means now PLAYING, you typed it
to name a track, and quietly sending a different sentence is the command
deciding it knows better. The station IS in the line
(`is now playing: Trestal — A Land Unknown [Groove Salad]`) — it is the only
part a reader can act on, which turns a boast into a recommendation.

**4 — Precedent found and followed.** Registered in `slashCommands.ts` DISPATCH
+ a `commands/radio.ts` handler + one `compose.ts` arm, like every other verb.
That is also how it inherits the `//np` literal escape, #427 alias shadowing,
and the dispatch reconciliation net for free. It targets `ctx.submittedFrom`
exactly as `/me` does, through the shared `ctcpFrame` + `sendMessage` seam —
never a second hand-rolled `\x01`.

## `check:radio` grows a FEED axis

`songsUrl` is a THIRD baked third-party URL in `radioStations.ts`, and #1696's
finding was that such a URL with nothing to execute against it is a claim.
Positive control on the runner: injecting a wrong slug gives `FEED HTTP 404`,
`1 broken`, `rc=1`. Live run is 14/14 green. **No AGREE twin, and the absence
is measured** — `channels.json` carries no per-channel feed URL at all, so
there is nothing upstream to compare against.

## Gates

| gate | result |
|---|---|
| `bun.sh run check` | 4 stages, **0 failed** (baseline identical) |
| `bun.sh run test` | **308 files / 6009 tests**, exit 0 (baseline 305 / 5955) |
| `bun.sh run check:radio` | 14 stations, 14 feeds, **0 broken**, live |
| `scripts/design-notes-gate.sh` | `1 new entry heading(s), separator and marker present` |

**No server file is touched** (`git diff --name-only` against the base is
entirely under `cicchetto/`), so `scripts/check.sh` was not run — declared, not
skipped silently.

## Mutation evidence — 6 injected, 6 killed

| mutant | killed |
|---|---|
| drop the `stale` gate in `nowPlaying()` | **3** — 2 store tests **and** `/np`'s refusal, in two files (this is the "one predicate, both doors" proof) |
| drop the in-flight `songsUrl !== url` guard | 1 — the swap race |
| drop the blank-title refusal in `parseSongsFeed` | 1 |
| drop `stopPolling()` from the lifecycle effect | 2 |
| drop `min-width: 0` from `.audio-mini-player-track` | 1 (the CSS guard) — **and all 13 `AudioMiniPlayer` DOM tests stayed GREEN**, the #1697 mechanism exactly |
| append a second `.audio-mini-player-track` block (`flex: none`) — the #1697 SHAPE | 2, via the "exactly one block per selector" assertion |

## Declared non-measurements

* **The docked bar on a real phone.** See the device-verify note at the top.
* **No e2e was written, and the CSP half needs none.**
  `issue1695-somafm-connect-src-perimeter.spec.ts` already proves a browser lets
  a `fetch` to `api.somafm.com` out and blocks both neighbours; the CSP token is
  a **host-source with no path**, so its verdict covers `songs/<id>.json` by
  construction. What an e2e would add is a bundle-arrival oracle, and it would
  have to intercept the feed anyway — the "no third-party outage detector in the
  gate" posture #682/#1696 already set for this table. **The e2e lane is w1's; I
  did not take it.** Say the word if you want the spec anyway.
* **`unsupported` is a type-FORCED arm no current table row can reach** —
  `songsUrl` is nullable because a track feed is a provider capability, and all
  fourteen rows have one. Tested against the handler with `../lib/radio` mocked,
  in its own file, with a ctx that throws on any read. The alternative was a
  production arm with no test.
* **`np` lands in the characterization net's UNPROTECTED list**, and the
  snapshot records it: nothing is tuned in that harness, so the row refuses
  locally and touches no mocked seam. Its sending arm is covered by the
  dedicated block that tunes a station with a stubbed feed.

## Known gap, deliberately not patched

`/me` in the `$server` window has no guard (only `privmsg` is refused there), so
`/np` inherits the same gap. Patching it for `/np` alone would be two patterns
for one behaviour; the honest fix spans `/me`, `/ctcp ACTION` and `/np`
together, and is not this issue.

## Base

Branched from `origin/main` at `7ab07c61`; **main has not moved**, merge-base ==
`origin/main`, so no rebase and no `union-rebase.sh` ritual was owed. If main
moves before merge, it is.
