### PR TITLE
#1700 — play could not resume an interrupted live stream

### DIFF
--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -88,10 +88,37 @@ const AudioMiniPlayer: Component = () => {
   //                                    "=== Infinity".
   const live = (): boolean => !Number.isFinite(duration());
 
+  // #1700 — can this element continue from where it is, or must the resource
+  // be fetched again? Two disjoint reasons, and note that neither of them is
+  // "was it interrupted":
+  //   * `error` — the media resource is gone. There is nothing to continue.
+  //   * live    — there is no POSITION to continue TO. `currentTime` on an
+  //               endless source is elapsed-since-tune-in, not a place in a
+  //               work, so resuming in place returns to buffered audio and
+  //               stays exactly that far behind live from then on. Re-tuning
+  //               IS the correct resume for a stream; it is not a sacrifice
+  //               made to fix something else.
+  // A healthy paused FILE matches neither and keeps resuming at its position,
+  // which is the whole point of pausing one.
+  const mustRefetch = (el: HTMLAudioElement): boolean => el.error !== null || live();
+
   const togglePlay = (): void => {
     if (audioEl === undefined) return;
-    if (audioEl.paused) void audioEl.play().catch(() => {});
-    else audioEl.pause();
+    // #1700 — branch on `playing()`, NOT on `audioEl.paused`. The glyph and the
+    // accessible name below read from this signal, and a control must act on
+    // the fact it DISPLAYS: after a failed fetch the element is still not
+    // `paused` while the transport already shows ▶, so reading the element here
+    // pauses at the moment the operator pressed play. One fact, one control.
+    if (playing()) {
+      audioEl.pause();
+      return;
+    }
+    // `play()` re-runs resource selection only from NETWORK_EMPTY, which is not
+    // where a dropped stream lands; `load()` runs it unconditionally. The other
+    // `load()` in this file DETACHES a source on close — same call, opposite
+    // intent, and until now the only one.
+    if (mustRefetch(audioEl)) audioEl.load();
+    void audioEl.play().catch(() => {});
   };
 
   const onSeek = (e: { currentTarget: HTMLInputElement }): void => {
@@ -112,6 +139,17 @@ const AudioMiniPlayer: Component = () => {
         onPlay={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
         onEnded={() => setPlaying(false)}
+        /* #1700 — a failure that is never observed can never be recovered
+           from, and an unobserved one here also made the bar LIE: a stream
+           that dies without firing `pause` left this signal true, so the
+           button kept showing ⏸ over silence and the transport looked like it
+           had worked.
+           `stalled` and `waiting` are deliberately NOT wired. They are
+           recoverable buffering, not a stop, and clearing the state on them
+           would flip the button to ▶ over audio that is still coming — the
+           same lie in the other direction. `error` is the terminal one, so
+           `error` is the one listened to. */
+        onError={() => setPlaying(false)}
         onTimeUpdate={() => setCurrent(audioEl?.currentTime ?? 0)}
         onLoadedMetadata={() => setDuration(audioEl?.duration ?? 0)}
       />

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -10,13 +10,16 @@ import type { RadioStation } from "../lib/radioStations";
 // these tests pin the bar's show/hide + control wiring only.
 let playSpy: ReturnType<typeof vi.spyOn>;
 let pauseSpy: ReturnType<typeof vi.spyOn>;
+let loadSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   playSpy = vi
     .spyOn(HTMLMediaElement.prototype, "play")
     .mockImplementation(() => Promise.resolve());
   pauseSpy = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
-  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+  // #1700 — held, not discarded: `load()` is the only call that re-fetches, so
+  // the resume path is now asserted through it.
+  loadSpy = vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
   closeAudio();
   showPlayer();
 });
@@ -325,6 +328,190 @@ describe("AudioMiniPlayer", () => {
       // `activeAudio` — the shape #1697's own comment forbids — would null this
       // out, and the poll keyed on it would stop with the chrome.
       expect(tunedStation()).toBe(station);
+    });
+  });
+
+  // #1700 — pressing play could not bring an interrupted live stream back.
+  //
+  // THE MECHANISM, stated precisely, because the issue's one-liner ("play never
+  // re-fetches") is not quite what the contract says. `play()` DOES invoke the
+  // resource selection algorithm — but only when `networkState` is
+  // NETWORK_EMPTY, and an Icecast connection that drops mid-stream does not
+  // land there. `load()` runs that algorithm unconditionally, and the only
+  // `load()` in this component was on the CLOSE path, where it DETACHES a
+  // source. Nothing on the resume path re-fetched. (Read off the HTML media
+  // element spec, not measured in a browser — see the test-level notes below
+  // for what these assertions do and do not establish.)
+  //
+  // TWO SOURCES OF TRUTH FOR ONE CONTROL, which is the deeper half. The
+  // button's LABEL came from the `playing()` signal (driven by events) and its
+  // ACTION came from `audioEl.paused` (the element's own property). Those agree
+  // until something goes wrong and then they do not, and a control whose action
+  // disagrees with its label does the opposite of what the operator read. The
+  // fix is not a third state: it is deriving both from `playing()`.
+  //
+  // WE DO NOT DISTINGUISH "paused" FROM "interrupted", and that is deliberate
+  // rather than a gap we could not close. There is no reliable signal for it —
+  // but more to the point, the question does not need answering. The axis that
+  // matters is "is there a POSITION worth resuming to", and for a live source
+  // there is none: `currentTime` is elapsed-since-tune-in, not a place in a
+  // work. Resuming a live stream in place is not a feature being sacrificed, it
+  // is a defect of its own — you come back to buffered audio and stay exactly
+  // that far behind live, forever. So re-fetching a live source on resume is
+  // the CORRECT behaviour independently of any interruption having happened.
+  describe("#1700 — resuming after an interruption", () => {
+    const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
+    const UPLOAD = "https://grappa.example/uploads/abc";
+
+    const element = (): HTMLElement => screen.getByTestId("audio-mini-player-el");
+    const toggle = (): HTMLElement => screen.getByTestId("audio-mini-player-toggle");
+
+    /** Replay one media event by hand. jsdom runs no media pipeline and the
+        methods above are stubbed, so nothing fires on its own — the same seam
+        `loadMetadataWithDuration` uses, at the events the transport listens to. */
+    const fire = (type: string): void => {
+      element().dispatchEvent(new Event(type));
+    };
+
+    /** Put the element in the state a dropped fetch leaves it in: a MediaError
+        set, and — per the spec's resource-fetch failure path, which sets
+        `error` and `networkState` and says nothing about `paused` — still not
+        paused. Stubbed on the INSTANCE, like `duration` above. */
+    const interrupt = (): void => {
+      Object.defineProperty(element(), "error", {
+        configurable: true,
+        value: { code: 2, message: "network" },
+      });
+      Object.defineProperty(element(), "paused", { configurable: true, value: false });
+      fire("error");
+    };
+
+    const clearSpies = (): void => {
+      playSpy.mockClear();
+      pauseSpy.mockClear();
+      loadSpy.mockClear();
+    };
+
+    it("re-fetches a live source before playing it again", () => {
+      // The reported symptom. `play()` on an element whose media resource is
+      // gone resolves and produces silence; only `load()` goes back for a new
+      // one.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      loadMetadataWithDuration(Number.POSITIVE_INFINITY);
+      fire("play");
+      fire("pause");
+      clearSpies();
+
+      toggle().click();
+
+      expect(loadSpy).toHaveBeenCalled();
+      expect(playSpy).toHaveBeenCalled();
+    });
+
+    it("resumes a paused FILE in place, without re-fetching it", () => {
+      // The other side of the same predicate, and the reason it is not "always
+      // reload": a file HAS a position, resuming at `currentTime` is the whole
+      // point of pausing one, and re-fetching would throw that away along with
+      // whatever is already buffered.
+      render(() => <AudioMiniPlayer />);
+      playAudio(UPLOAD, null);
+      loadMetadataWithDuration(212);
+      fire("play");
+      fire("pause");
+      clearSpies();
+
+      toggle().click();
+
+      expect(loadSpy).not.toHaveBeenCalled();
+      expect(playSpy).toHaveBeenCalled();
+    });
+
+    it("re-fetches a FILE too once its resource is in error", () => {
+      // A file whose fetch failed has no position left to preserve either, so
+      // the same rule covers it. This is the half the issue called the broader
+      // form, and it costs nothing to include: `error !== null` is exactly
+      // "cannot continue from here".
+      render(() => <AudioMiniPlayer />);
+      playAudio(UPLOAD, null);
+      loadMetadataWithDuration(212);
+      fire("play");
+      interrupt();
+      clearSpies();
+
+      toggle().click();
+
+      expect(loadSpy).toHaveBeenCalled();
+      expect(playSpy).toHaveBeenCalled();
+    });
+
+    it("stops claiming to play once the element reports an error", () => {
+      // Half the reason nobody noticed the bug: with no `error` handler the bar
+      // kept showing ⏸ over silence, so the transport looked like it had
+      // worked.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      fire("play");
+      expect(toggle()).toHaveAttribute("aria-label", "pause");
+
+      interrupt();
+
+      expect(toggle()).toHaveAttribute("aria-label", "play");
+    });
+
+    it("keeps claiming to play through a stall — a stall is not a stop", () => {
+      // Deliberately NOT wired, against the issue's suggestion of
+      // `onStalled`. A stall or a wait is recoverable buffering: clearing the
+      // state there would flip the button to ▶ over audio that is still
+      // coming, which is the same lie in the other direction. Only `error` is
+      // terminal, and only `error` is listened to.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      fire("play");
+
+      fire("stalled");
+      fire("waiting");
+
+      expect(toggle()).toHaveAttribute("aria-label", "pause");
+    });
+
+    it("acts on what the button SAYS, not on the element's paused flag", () => {
+      // The divergence, made concrete: our signal says not-playing (the error
+      // cleared it) while the element still says not-paused. Reading
+      // `audioEl.paused` here makes the control PAUSE when its own label reads
+      // ▶ — the operator presses play and gets a pause. Reading `playing()`
+      // makes label and action one fact.
+      //
+      // What this establishes: that the two can disagree and which one wins.
+      // What it does NOT establish: that a real browser leaves `paused` false
+      // after a dropped stream. That is a spec reading, and the device verdict
+      // is owed either way.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      fire("play");
+      interrupt();
+      expect(toggle()).toHaveAttribute("aria-label", "play");
+      expect(element()).toHaveProperty("paused", false);
+      clearSpies();
+
+      toggle().click();
+
+      expect(pauseSpy).not.toHaveBeenCalled();
+      expect(playSpy).toHaveBeenCalled();
+    });
+
+    it("still pauses a healthy source, and does not re-fetch to do it", () => {
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      loadMetadataWithDuration(Number.POSITIVE_INFINITY);
+      fire("play");
+      clearSpies();
+
+      toggle().click();
+
+      expect(pauseSpy).toHaveBeenCalled();
+      expect(loadSpy).not.toHaveBeenCalled();
+      expect(playSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/cicchetto/src/__tests__/media-error-default.test.ts
+++ b/cicchetto/src/__tests__/media-error-default.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+// Guards the setupTests conforming-`error` contract (#1700), the media sibling
+// of inert-websocket.test.ts.
+//
+// jsdom implements no `error` on HTMLMediaElement — measured, it reads
+// `undefined`, where the DOM contract types it `MediaError | null` and a real
+// browser answers `null` on a healthy element. That gap is a TRAP and not a
+// missing feature: the type-exact predicate for "did playback fail" is
+// `el.error !== null`, so under raw jsdom a pristine element reads as ERRORED,
+// and a test meaning "this source is healthy" silently exercises the failure
+// branch and reports green about the wrong path.
+//
+// `AudioMiniPlayer`'s resume rule (#1700 — re-fetch when the element cannot
+// continue from where it is) is the first predicate in cic to read this
+// property. Without the default below its "a paused FILE resumes in place"
+// case passes for the wrong reason; with it, that case measures what it names.
+describe("HTMLMediaElement.error default", () => {
+  it("a pristine media element reports NO error, as a browser does", () => {
+    expect(document.createElement("audio").error).toBeNull();
+    expect(document.createElement("video").error).toBeNull();
+  });
+
+  it("stays null across a source assignment — a src is not a failure", () => {
+    const el = document.createElement("audio");
+    el.src = "https://ice.somafm.com/groovesalad-128-mp3";
+
+    expect(el.error).toBeNull();
+  });
+
+  it("an instance-level definition still shadows it, so a test can inject failure", () => {
+    // This is the seam the #1700 tests use to model a dropped stream. If the
+    // prototype default were installed as a non-configurable own property, or
+    // as a value rather than a getter, that seam would break and every
+    // failure-path test would quietly become a healthy-path test.
+    const el = document.createElement("audio");
+    Object.defineProperty(el, "error", {
+      configurable: true,
+      value: { code: 2, message: "network" },
+    });
+
+    expect(el.error).not.toBeNull();
+    expect(el.error?.code).toBe(2);
+    // …and the shadow is per-instance: the next element is healthy again.
+    expect(document.createElement("audio").error).toBeNull();
+  });
+});

--- a/cicchetto/src/setupTests.ts
+++ b/cicchetto/src/setupTests.ts
@@ -103,6 +103,27 @@ class InertIntersectionObserver {
   }
 }
 
+// jsdom implements no `error` on HTMLMediaElement: reading it yields
+// `undefined`, where the DOM contract types it `MediaError | null` and a real
+// browser answers `null` on a healthy element. Measured under jsdom 29, not
+// assumed — `document.createElement("audio").error` is `undefined`.
+//
+// Left alone this is a silent TRAP rather than a missing feature. The
+// type-exact predicate for "did playback fail" is `el.error !== null`, and
+// under jsdom that reads TRUE on a pristine element — so a test meaning "this
+// source is healthy" quietly exercises the FAILURE branch and reports green
+// having measured the wrong path. #1700's resume rule is the first such
+// predicate in cic; pinning the conforming default here means the next one
+// inherits it instead of rediscovering it.
+//
+// A per-instance `Object.defineProperty` still shadows this, which is exactly
+// how a test puts an element INTO the error state. Production always runs in a
+// browser, where the property is real. Covered by media-error-default.test.ts.
+Object.defineProperty(HTMLMediaElement.prototype, "error", {
+  configurable: true,
+  get: () => null,
+});
+
 beforeEach(() => {
   // Fresh in-memory localStorage for every test — no state bleeds between cases.
   vi.stubGlobal("localStorage", makeLocalStorage());

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -60338,3 +60338,130 @@ the device-verify below is a blocking item on this branch and not boilerplate.
   by construction. What an e2e would add beyond that is the bundle-arrival
   oracle, and it would have to intercept the feed anyway — the "no third-party
   outage detector in the gate" posture this table established in #682/#1696.
+<!-- entry #1700 -->
+
+---
+
+## 2026-08-24 — #1700: a live stream is not a file, so `play` is not a resume
+
+Reported from the PWA on staging: after the radio stream is interrupted,
+pressing play does not bring it back. The transport reacts, the audio does not.
+
+### The mechanism, and where the issue's own one-liner is too strong
+
+The issue says `play()` never re-fetches. The contract says something narrower,
+and the difference is the fix. `play()` DOES invoke the resource selection
+algorithm — but only when `networkState` is NETWORK_EMPTY, and an Icecast
+connection dropped mid-stream does not land there. `load()` runs that algorithm
+unconditionally, and the only `load()` in `AudioMiniPlayer` sat on the CLOSE
+path, where it DETACHES a source. Same call, opposite intent, and nothing on
+the resume path ever went back for a new resource.
+
+This is read off the media-element contract, **not measured in a browser** —
+see the last section.
+
+### Two sources of truth for one control, which is the deeper half
+
+The button's LABEL came from the `playing()` signal, driven by media events.
+Its ACTION came from `audioEl.paused`, the element's own property. Those agree
+right up until something goes wrong: a failed fetch sets `error` and says
+nothing about `paused`, so the signal and the property diverge and the control
+does the OPPOSITE of what its label reads — the operator presses ▶ and gets a
+pause.
+
+The cure is not a third state reconciling them, it is deleting one of the two:
+`togglePlay` now branches on `playing()`, the same fact the glyph and the
+accessible name render. **General rule worth keeping: a control's action must
+be derived from the fact it DISPLAYS.** Anything else is a parallel structure
+that will drift, and it drifts precisely when something is already wrong.
+
+### "Paused" versus "interrupted" is the wrong question
+
+There is no reliable signal separating them, but the better reason not to look
+for one is that the answer would not be used. The axis that matters is whether
+there is a POSITION worth resuming to:
+
+* a FILE has one — resuming at `currentTime` is the whole point of pausing it;
+* an endless source does not. `currentTime` there is elapsed-since-tune-in, not
+  a place in a work. Resuming a live stream in place is not a feature being
+  sacrificed to fix something else — it is a defect of its own, where the
+  listener returns to buffered audio and stays exactly that far behind live
+  from then on.
+
+So the predicate is `el.error !== null || live()` — two disjoint reasons the
+element cannot continue from where it is, neither of them a guess about what
+went wrong. Re-fetching a live source on resume is correct whether or not
+anything was ever interrupted. `error` also picks up, for free, the broader
+form the issue named: a FILE whose fetch failed has no position left either.
+
+### `error` is wired, `stalled` and `waiting` are refused
+
+The issue suggested `onError`/`onStalled`; only the first is right. Without any
+handler the bar kept showing ⏸ over silence, so the failure was never observed
+and could never be recovered from — that half stands. But a stall or a wait is
+recoverable buffering, not a stop, and clearing the playing state on one flips
+the button to ▶ over audio that is still coming: the same lie in the other
+direction. Only `error` is terminal, so only `error` is listened to. The
+refusal is asserted, not merely commented — a mutant that adds `onStalled`
+reds a test.
+
+### The jsdom trap that made a HEALTHY source look broken
+
+jsdom implements no `error` on `HTMLMediaElement`: it reads `undefined`, where
+the contract types it `MediaError | null` and a browser answers `null`. The
+type-exact predicate above therefore reads TRUE on a pristine element under the
+unit gate, and the test written to say "a healthy paused FILE resumes in place"
+took the FAILURE branch instead — it would have gone green while measuring the
+wrong path, which is the vacuous-green shape this codebase keeps rediscovering.
+
+Two ways out, and the choice matters. Loosening the production predicate to a
+truthiness test immunises one call site and leaves the trap armed for the next
+reader of the property — and it shapes production around a test double. Pinning
+the conforming default in `setupTests.ts` fixes the CLASS, and that file is
+already where cic keeps exactly this (inert WebSocket, inert
+IntersectionObserver, in-memory localStorage). It is a `configurable` GETTER so
+a per-instance `defineProperty` still shadows it — that shadow is how a test
+injects failure, and `media-error-default.test.ts` asserts the shadow as well
+as the default, because a non-configurable pin would silently turn every
+failure-path test into a healthy-path one.
+
+### What was NOT measured
+
+* 🔴 **No browser was run, and the report is a device report.** jsdom has no
+  media pipeline, so the seven tests pin the WIRING — which call is issued, and
+  off which fact — never that a real interrupted stream comes back. The issue
+  itself is a source reading rather than a reproduction; this branch does not
+  change that, it only makes the named mechanism executable. **The verdict
+  lives on the PWA that reported it.**
+* **No e2e, and the reason is not the lane.** Proving this in a browser needs a
+  stream whose connection can be CUT mid-flight — a controllable audio origin,
+  not an assertion. The existing radio spec plays a real SomaFM stream and
+  cannot interrupt it. That fixture is a piece of infrastructure, and it is not
+  this issue. (The e2e lane was also not free, but that is the smaller reason.)
+* **A stream that dies silently before any metadata arrives** stays outside the
+  predicate: `duration` is still 0, so `live()` is false, and if the browser
+  set no `error` there is nothing to key on. The transport then needs two
+  presses — pause, then play — instead of one. Narrow, and named rather than
+  papered over.
+### The #1698 interaction, re-derived after the rebase rather than predicted
+
+This entry first carried the note as a forecast — "if #1698 lands". It landed
+mid-branch, so the question is live and the answer is a DECISION, not a
+deferral: **the now-playing line is left exactly as it is.**
+
+The poll is keyed on the tuned STATION, not on whether audio is reaching us, so
+a stream that dropped keeps showing a track. That looks like the same family of
+lie this issue is about — and it is not, once the transport is fixed. The line
+says what the STATION is playing, which remains true: SomaFM did not stop
+broadcasting because our socket died. What used to be false was the CONTROL
+next to it claiming playback, and that is now repaired at the control. Read
+together the row is coherent: ▶ (we are not playing) beside a track (this is
+what is on).
+
+Silencing the track on `error` would buy nothing and cost two things. `/np`
+must keep answering — the operator can truthfully tell the channel what the
+station is playing — so the display and the command would need DIFFERENT
+predicates over one fact, which is the parallel structure #1698 went out of its
+way to avoid by keying both on `tunedStation()`. **The general shape: when a
+surface stops being true, fix the element that made the false claim, not every
+neighbour that is still telling the truth.**


### PR DESCRIPTION
🔴 **DEVICE-VERIFY IS THE VERDICT HERE, AND IT IS NOT OPTIONAL.**
The bug was reported from the PWA on staging; the issue itself is a source
reading, not a reproduction; and **no browser was run on this branch either.**
jsdom has no media pipeline, so every assertion below pins the WIRING — which
call is issued, and off which fact — never that a real interrupted stream comes
back. Merging this is merging a named mechanism, not a confirmed cure.

## What was wrong

`togglePlay` called `play()` and nothing else. That is right for a FILE — the
resource is still there and playback picks up at `currentTime` — and wrong for
a live Icecast stream, whose media resource is gone once the connection drops.

**The issue's one-liner is slightly too strong, and the difference is the fix.**
`play()` *does* invoke the resource selection algorithm — but only from
`networkState === NETWORK_EMPTY`, which is not where a dropped stream lands.
`load()` runs it unconditionally, and the only `load()` in the component sat on
the CLOSE path, where it DETACHES a source. Same call, opposite intent.

### The deeper half: two sources of truth for one control

The button's **label** came from the `playing()` signal; its **action** came
from `audioEl.paused`. Those agree until something goes wrong — a failed fetch
sets `error` and says nothing about `paused` — and then the control does the
opposite of what it reads: the operator presses ▶ and gets a pause. Fixed by
deriving both from `playing()`, not by adding a third state.

## The rule, and the question it refuses to ask

We do **not** try to tell "paused" from "interrupted". There is no reliable
signal, but the better reason is that the answer would not be used: the axis
that matters is whether a **position** exists to resume to.

* a FILE has one — resuming at `currentTime` is the point of pausing it;
* an endless source does not. `currentTime` there is elapsed-since-tune-in, so
  resuming a live stream in place is not a sacrifice — it is a defect of its
  own, where you return to buffered audio and stay that far behind live for
  good.

So the predicate is `el.error !== null || live()`. Re-fetching a live source on
resume is correct **whether or not anything was interrupted**, and `error`
picks up the broader form for free: a file whose fetch failed has no position
left either.

## Half of the proposed axis 2 is refused

`onError` — yes. An unobserved failure can never be recovered from, and it left
the bar showing ⏸ over silence, which is why the transport looked like it had
worked.

`onStalled` / `onWaiting` — **no.** Recoverable buffering is not a stop, and
clearing the state there flips the button to ▶ over audio that is still
coming: the same lie in the other direction. The refusal is asserted by a test,
not just written in a comment.

## A harness commit that is load-bearing, not tidying

jsdom implements no `error` on `HTMLMediaElement` — measured, it reads
`undefined`, where the contract says `MediaError | null`. So the type-exact
predicate reads TRUE on a **pristine** element, and the test written to say "a
healthy paused FILE resumes in place" silently took the FAILURE branch. It
would have gone green measuring the wrong path.

Fixed in `setupTests.ts` (where cic already keeps the inert WebSocket /
IntersectionObserver / localStorage) rather than by loosening the production
predicate, because that fixes the CLASS instead of immunising one call site
and shaping production around a test double. A mutant that removes it kills
4 tests.

## Evidence

| gate | result |
|---|---|
| `scripts/bun.sh run check` | 4 stages, 0 failed |
| `scripts/bun.sh run test` | **311 files, 6057 tests, 0 failed** (base is 310/6047 → this branch is +1 file, +10 tests) |
| `scripts/design-notes-gate.sh` | 1 new entry, separator and marker present |
| mutation | **6 injected, 6 killed** |

Mutants: drop `|| live()` → 1 · drop `error !== null ||` → 1 · read
`audioEl.paused` again → 3 · drop `onError` → 3 · **add** `onStalled` → 1 ·
un-conform jsdom's `error` → 4.

Rebased onto `main` mid-branch when #1698 landed (same component). Two-sided
union pin verified with real material on both sides: `DESIGN_NOTES` 111/0 →
111/0, deletions zero, both entry boundaries read on the file.

## Declared non-measurements

1. 🔴 **No browser.** See the top.
2. **No e2e, and the lane is the smaller reason.** Proving this needs a stream
   whose connection can be **cut mid-flight** — a controllable audio origin,
   which is a fixture and not an assertion. The existing radio spec plays a
   real SomaFM stream and cannot interrupt it.
3. **A stream that dies silently before any metadata arrives** stays outside the
   predicate (`duration` is still 0, so `live()` is false; no `error` to key
   on). Two presses instead of one. Narrow, named, not papered over.
4. **The #1698 now-playing line is deliberately left alone** — re-derived after
   the rebase rather than deferred. It states what the STATION is playing,
   which stays true when our socket dies; the false claim was the control, and
   that is repaired at the control.