### PR TITLE
fix(#1715): buy LockWatch's Logger cache key at boot — a mitigation, and it says so

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -60465,3 +60465,94 @@ predicates over one fact, which is the parallel structure #1698 went out of its
 way to avoid by keying both on `tunedStation()`. **The general shape: when a
 surface stops being true, fix the element that made the false claim, not every
 neighbour that is still telling the truth.**
+<!-- entry #1715 -->
+
+---
+
+## 2026-08-24 — #1715: the watchdog's own log line waits out the lock it reports
+
+`Grappa.Repo.LockWatch.report_unattributed/2` blocked for the whole ExUnit
+deadline inside `Logger.warning`, on pristine main, in ~15 % of runs. There is
+no VM stall behind it, and the mechanism is not specific to this module.
+
+`Logger.__should_log__/2` calls `:logger_config.allow/2` at every call site
+unconditionally, and `allow/2` writes `{logger_config, Module}` — one
+`persistent_term` key PER MODULE — the FIRST time that module logs. A
+`persistent_term` write blocks on a **thread-progress barrier**; SQLite's busy
+handler sleeps out its `busy_timeout` inside a **dirty-IO** NIF and holds that
+barrier for the whole sleep. So a module's first log line during a write-lock
+wait waits for the wait — and this module's first line is, by construction, its
+own stall report, i.e. exactly the line that must not.
+
+Measured rather than inferred: halve the budget and the stall halves. 133 s →
+66.7 / 67.4 / 66.1 s, ratio **1.99**.
+
+### The mitigation, and the exact ground it holds
+
+`init/1` calls `prime_logger_module_cache/0` — a bare `Logger.debug(fn -> "" end)`
+— paying this module's one lazy put at boot, where nothing holds the write lock.
+`debug` is deliberate and emits nothing: `allow/2` caches
+`?PRIMARY_TO_CACHE(get_primary_level())`, i.e. the PRIMARY level, so `debug`
+writes the same key with the same value `warning` would while staying below the
+bar itself. Measured on `ad1df939`: the key reads `:absent` at boot before the
+change and the primary level after it.
+
+🔴 **It covers ONE of the three measured mechanisms, and 6 of the 9 measured
+victims. It does NOT cover:**
+
+* `logger_config:set/3` — a CONFIG write, with no module key to prime; measured
+  as the suspended site in 3 of 30 bench runs;
+* `code:ensure_loaded/1` — module LOADING, a different serialisation point
+  entirely, outside this design's reach;
+* the first log line of every OTHER module — measured on a booted dev node, 7
+  modules hold a cache key against 597 loaded — and in particular a **crash
+  report**, which is by definition the first line from whichever module just
+  died, i.e. during an incident the module nobody anticipated;
+* **the coupling itself, which is untouched.**
+
+🔴 **And priming every module is not a bigger cure, it is a bigger version of the
+bug.** `logger_config:set/3` on a PRIMARY level change does one
+`persistent_term:put` per CACHED module (its flush loop), so a
+`Logger.configure(level: …)` would go from today's 7 thread-progress waits to one
+per loaded module. That is why the prime is one module and not a sweep.
+
+### What the bench does NOT say
+
+52 primed runs, 0 stalls, against 6 stalls in 30 unprimed. **That is not quoted
+as a cure rate.** The rate on that bench is void: the watchdog is a co-cause, and
+the run was designed to census WHICH victim site survives priming — no primed run
+stalled, so the census collected no data. That is the UNINTERPRETABLE branch of
+its own pre-registration, and it is reported as one. Suggestive; not the
+measurement that was set out to be taken.
+
+### Still open, and deliberately not blocking
+
+Whether the coupling is an **ERTS defect** (→ an upstream report, and grappa
+gains no architectural constraint) or **`umrefc` by design** (→ grappa has a real
+production constraint: during any SQLite write-lock wait, up to `busy_timeout`,
+the first log line of any module and any module load block). The second reading
+is a production claim larger than #1687 and is **unmeasured in production**. It
+is a separate question, answered after this ships, not before.
+
+### #1687 (`c4acaf6c`) holds — the pre-registered prediction was REFUTED
+
+`c4acaf6c` moved `start_tmp_repo/0` from `busy_timeout: 30_000` to
+`@waiter_budget_ms` (`@test_timeout_ms * 2`), which quadrupled the wall clock
+burnt per occurrence (≈33 s → ≈133 s). That prices the fix; it does not condemn
+it, so the other half was run. **Pre-registered prediction:** restore only
+`busy_timeout` to `30_000`, leave the deadline; the stall then fits inside the
+deadline and the runs go green. **Refuted, informatively** — 2 stalls in 18 runs,
+both red, failing on the test's own `assert_receive` at 10 s with an unrelated
+`%Exqlite.Error{message: "database is locked"}` in the mailbox. That is verbatim
+the symptom #1687 exists to remove. At the larger budget the same stall fails as
+an honest ExUnit timeout naming the test and the line. ⇒ `c4acaf6c` does what it
+claims; it neither causes #1715 nor cures it, and it makes the failure legible.
+
+### One drift, fixed by anchor and not by value
+
+`lock_watch_test.exs` still cited *"`start_tmp_repo/0`'s `busy_timeout: 30_000`"*
+while `c4acaf6c` had changed that very line to `@waiter_budget_ms` — the same
+commit moved the value and left the citation. Fixed by naming the ANCHOR
+(`busy_timeout: @waiter_budget_ms`, and `min(15_000, the budget)` for the
+historical arithmetic, kept and labelled rather than deleted), never by writing
+the new number in, which would only reschedule the rot.

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -383,6 +383,10 @@ defmodule Grappa.Repo.LockWatch do
       enabled: Keyword.fetch!(opts, :enabled)
     }
 
+    # Before anything else: buy this module's Logger cache key while no
+    # write lock is held. See `prime_logger_module_cache/0`.
+    prime_logger_module_cache()
+
     # `:public` because the seam writes from every caller's own process; the
     # table is owned here so a supervisor restart rebuilds it clean.
     _ = :ets.new(@table, [:named_table, :public, :set, write_concurrency: true])
@@ -405,6 +409,49 @@ defmodule Grappa.Repo.LockWatch do
     :persistent_term.put(@enabled_key, false)
     :ok
   end
+
+  # #1715 — pay this module's ONE lazy `persistent_term:put` here, at boot,
+  # where nothing is holding the SQLite write lock. That is not a hope: this
+  # child starts BEFORE `Grappa.Repo` (see `application.ex`), so at prime
+  # time the tree holds no SQLite connection at all and the prime cannot
+  # wait on the very thing it exists to step around.
+  #
+  # `Logger.__should_log__/2` calls `:logger_config.allow/2` at every call
+  # site unconditionally, and `allow/2` writes `{logger_config, Module}` the
+  # FIRST time a given module logs. A `persistent_term` write blocks on a
+  # thread-progress barrier, and SQLite's busy handler sleeps out its
+  # `busy_timeout` inside a dirty-IO NIF, which holds that barrier for the
+  # whole sleep. So a module's first log line during a lock wait waits for
+  # the lock wait — and THIS module's first line is its own stall report,
+  # i.e. precisely the line that must not wait on the stall it reports.
+  # Measured: `busy_timeout` halved, stall halved (133 s → 66.7/67.4/66.1,
+  # ratio 1.99).
+  #
+  # `debug` is deliberate and emits nothing: `allow/2` caches
+  # `?PRIMARY_TO_CACHE(get_primary_level())`, i.e. the PRIMARY level, so
+  # `debug` writes the same key with the same value `warning` would while
+  # staying below the bar itself.
+  #
+  # 🔴 What this does NOT cover, so a later stall here is not read as a
+  # regression of a cure that never claimed the ground. It is ONE of the
+  # three mechanisms measured, and 6 of the 9 measured victims:
+  #
+  #   * `logger_config:set/3` — a CONFIG write, with no module key to prime;
+  #   * `code:ensure_loaded/1` — module LOADING, a different serialisation
+  #     point entirely;
+  #   * the first log line of EVERY other module — measured on a booted dev
+  #     node, 7 modules hold a cache key against 597 loaded — and in
+  #     particular a CRASH REPORT, which is by definition the first line
+  #     from whichever module just died;
+  #   * the coupling itself, which is untouched.
+  #
+  # 🔴 And priming every module is not a bigger cure, it is a bigger bug:
+  # `logger_config:set/3` on a PRIMARY level change does one
+  # `persistent_term:put` per CACHED module (the flush loop), so
+  # `Logger.configure(level: …)` would go from today's 7 waits to one per
+  # loaded module.
+  @spec prime_logger_module_cache() :: :ok
+  defp prime_logger_module_cache, do: Logger.debug(fn -> "" end)
 
   ## ----- Detection -----------------------------------------------------
 

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -461,11 +461,13 @@ defmodule Grappa.Repo.LockWatchTest do
   # drives the real edge sequence rather than a hand-written copy of it.
   #
   # 🔴 `timeout: :infinity` is load-bearing, and it is what makes
-  # `start_tmp_repo/0`'s `busy_timeout: 30_000` mean what that comment says
-  # it means. Without it both writers inherit Ecto's DEFAULT `:timeout` of
-  # 15_000 (`ecto_sql/lib/ecto/adapters/sql.ex`), which DBConnection arms as
-  # a checkout deadline covering the WHOLE transaction — queue, statements
-  # and the holder's park alike. So the real wait was `min(15_000, 30_000)`,
+  # `start_tmp_repo/0`'s `busy_timeout: @waiter_budget_ms` mean what that
+  # comment says it means. Without it both writers inherit Ecto's DEFAULT
+  # `:timeout` of 15_000 (`ecto_sql/lib/ecto/adapters/sql.ex`), which
+  # DBConnection arms as a checkout deadline covering the WHOLE transaction
+  # — queue, statements and the holder's park alike. So the real wait was
+  # `min(15_000, the budget)` — cited by anchor because #1687 moved that
+  # budget off its literal and the number here would have rotted with it —
   # the smaller number was never written down anywhere, and once a loaded
   # runner pushed the window past 15s the pool disconnected BOTH
   # connections: the parked holder mid-park, and the waiter mid-`BEGIN

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -358,7 +358,62 @@ defmodule Grappa.Repo.LockWatchTest do
     end
   end
 
+  # `:logger_config` caches "may this module log?" under one
+  # `persistent_term` key PER MODULE, and writes it the first time that
+  # module logs. `allow/2` stores `?PRIMARY_TO_CACHE(get_primary_level())`,
+  # so the cached value is the PRIMARY level — the same for every module,
+  # and unrelated to the level of the call that happened to arrive first.
+  @logger_module_cache {:logger_config, LockWatch}
+  @logger_primary_cache {:logger_config, :"$primary_config$"}
+
+  describe "the logger module cache (#1715)" do
+    test "init/1 primes it, so no report path pays the first persistent_term:put" do
+      # A `persistent_term` write blocks on a thread-progress barrier, and a
+      # SQLite busy handler sleeping out its `busy_timeout` on a dirty-IO
+      # scheduler holds that barrier. So whichever call site logs FIRST from
+      # this module pays a wait of up to the whole `busy_timeout` — and the
+      # first line this module ever emits is, by construction, its stall
+      # report: the one thing that must not wait on the stall it is
+      # reporting. Paying the put at `init/1` moves it to boot, where no
+      # write lock is held.
+      #
+      # Erasing first is what gives the assertion teeth: without it the key
+      # is already there from the application's own boot and the test would
+      # pass with the priming deleted.
+      :persistent_term.erase(@logger_module_cache)
+      assert :persistent_term.get(@logger_module_cache, :absent) == :absent
+
+      restart_lock_watch()
+
+      assert :persistent_term.get(@logger_module_cache, :absent) ==
+               :persistent_term.get(@logger_primary_cache)
+    end
+  end
+
   ## ----- helpers --------------------------------------------------------
+
+  # Drives the REAL `init/1` — the only way to prove the priming is wired
+  # into it rather than merely available as a function. Calling `init/1`
+  # directly is not an option: it creates a `:named_table`, which the live
+  # child already owns.
+  #
+  # A child left stopped would poison every test after this one, so the
+  # restore is registered BEFORE the terminate, and tolerates the child
+  # already running — the happy path restarts it here, in the test body,
+  # where a failure is attributable.
+  defp restart_lock_watch do
+    on_exit(fn ->
+      case Supervisor.restart_child(Grappa.Supervisor, LockWatch) do
+        {:ok, _} -> :ok
+        {:error, :running} -> :ok
+      end
+    end)
+
+    :ok = Supervisor.terminate_child(Grappa.Supervisor, LockWatch)
+    {:ok, _} = Supervisor.restart_child(Grappa.Supervisor, LockWatch)
+
+    :ok
+  end
 
   defp start_tmp_repo do
     path = Path.join(System.tmp_dir!(), "lock_watch_#{System.unique_integer([:positive])}.db")


### PR DESCRIPTION
Refs #1715. **This is a mitigation, not a cure, and the PR is written so that
is impossible to misread later.**

## The mechanism

`Grappa.Repo.LockWatch.report_unattributed/2` blocked for the whole ExUnit
deadline inside `Logger.warning`, on pristine main, in ~15 % of runs. There is
no VM stall behind it.

`Logger.__should_log__/2` calls `:logger_config.allow/2` at every call site
unconditionally, and `allow/2` writes `{logger_config, Module}` — one
`persistent_term` key **per module** — the FIRST time that module logs. A
`persistent_term` write blocks on a **thread-progress barrier**, and SQLite's
busy handler sleeps out its `busy_timeout` inside a **dirty-IO** NIF, holding
that barrier for the whole sleep. So a module's first log line during a
write-lock wait waits out the lock wait — and this module's first line is, by
construction, its own stall report.

Measured, not inferred: halve the budget and the stall halves. 133 s →
66.7 / 67.4 / 66.1 s, **ratio 1.99**.

## The change

`init/1` calls `prime_logger_module_cache/0` — a bare
`Logger.debug(fn -> "" end)` — paying the put at boot. That is structural
rather than hopeful: this child starts **before** `Grappa.Repo`, so at prime
time the tree holds no SQLite connection at all.

`debug` is deliberate and emits nothing: `allow/2` caches
`?PRIMARY_TO_CACHE(get_primary_level())`, the PRIMARY level, so `debug` writes
the same key with the same value `warning` would. Measured on `ad1df939`: the
key reads `:absent` at boot before the change, the primary level after it.

## 🔴 What it does NOT cover

It covers **one of the three measured mechanisms** and **6 of the 9 measured
victims**. It does **not** cover:

* **`logger_config:set/3`** — a CONFIG write, with no module key to prime;
  measured as the suspended site in 3 of 30 bench runs;
* **`code:ensure_loaded/1`** — module LOADING, a different serialisation point
  entirely, outside this design's reach;
* **the first log line of every other module** — measured on a booted dev node,
  7 modules hold a cache key against 597 loaded — and in particular **a crash
  report**, which is by definition the first line from whichever module just
  died, i.e. during an incident the one module nobody anticipated;
* **the coupling itself**, which is untouched.

## 🔴 Why not prime everything

Because the sweep is not a bigger cure, it is **a bigger version of the bug**.
`logger_config:set/3` on a **primary** level change does one
`persistent_term:put` **per cached module** (its flush loop), so a
`Logger.configure(level: …)` would go from today's 7 thread-progress waits to
one per loaded module.

## ⚠️ The number that is deliberately not quoted

52 primed runs, 0 stalls, against 6 stalls in 30 unprimed. **That is not a cure
rate and is not offered as one.** The rate on that bench is void: the watchdog
is a co-cause, and the run was designed to census *which victim site survives
priming* — no primed run stalled, so the census collected no data. That is the
UNINTERPRETABLE branch of its own pre-registration, reported as one.

## The test

TDD, and the RED was re-taken against the committed tree: with the `lib/` hunk
reverse-applied, the test fails `left: :absent / right: 4`; restored, 9 tests /
0 failures, and 20/20 under `--repeat-until-failure`.

Two decisions in it are load-bearing. It **erases the key first** — the running
application would otherwise have supplied it at boot and the assertion would
pass with the priming deleted, which is the exact mutant it exists to kill. And
it drives the **real `init/1`** through a supervisor restart rather than calling
a function, so it cannot go green on a priming that is available and never
wired (`init/1` creates a `:named_table` the live child already owns, so a
direct call is not an option).

## One drift, fixed by anchor

`lock_watch_test.exs` still cited *"`start_tmp_repo/0`'s `busy_timeout:
30_000`"* while `c4acaf6c` had changed that very line to `@waiter_budget_ms` —
the same commit moved the value and left the citation. Fixed by naming the
ANCHOR, never by writing the new number in, which would only reschedule the
rot. The historical arithmetic in the same paragraph is kept and labelled
rather than deleted.

## Still open, deliberately not blocking

Whether the coupling is an **ERTS defect** (→ upstream report, grappa gains no
architectural constraint) or **`umrefc` by design** (→ grappa has a real
production constraint: during any SQLite write-lock wait, up to `busy_timeout`,
the first log line of any module and any module load block). The second reading
is a production claim larger than #1687 and is **unmeasured in production**.
Separate question, answered after this ships.

## Gates

`scripts/check.sh` green end-to-end (`CHECK_RC=0`): compile
`--warnings-as-errors`, `format --check-formatted`, `credo --strict` (no
issues), `deps.audit`, sobelow (`Total errors: 0`), dialyzer (`passed
successfully`), doctor, **8 doctests / 62 properties / 6822 tests / 0
failures**, `gen_wire_types --check` + `wire_pin --check` in sync, bats
`1..676` with 0 `not ok`. Rebased onto `164a973b` via
`scripts/union-rebase.sh` (`+91 -0 — contribution intact`); the incoming set is
cicchetto-only, and format + credo + the touched test file were re-run green
after the rebase.