### PR TITLE
fix(#1701): restore the follow INTENT when the box the held px was measured in moves

### DIFF
--- a/cicchetto/e2e/tests/issue1701-player-under-picker-tail.spec.ts
+++ b/cicchetto/e2e/tests/issue1701-player-under-picker-tail.spec.ts
@@ -1,0 +1,157 @@
+// #1701 — chrome mounting UNDER a covering overlay must not leave a tail reader
+// short of the tail once the overlay goes.
+//
+// The container twin of issue1121-overlay-close-tail-reader, which drives the
+// same site on the CONTENT axis: there the box was steady and lines grew
+// underneath, here the content is steady and the BOX shortens. Both are the one
+// sentence `applyOverlayRestore` is now written around — the freeze holds a
+// single number, and a scrollTop names a position only relative to the viewport
+// it was read through.
+//
+// The gesture is the reported one, and every step of it is load-bearing:
+//
+//   * the rail's station picker holds a `createOverlayLock` refcount, so the
+//     pane is FROZEN from the moment it opens;
+//   * picking a station deliberately does NOT close it (`RailRadio`: a control
+//     the operator re-flips in place is not a launcher), so the docked bar
+//     mounts WHILE the freeze is up;
+//   * the bar takes ~47px out of `.scrollback`, and #778's ResizeObserver
+//     re-pin — which exists for exactly this class — is outranked by
+//     overlay-freeze and dropped. Correctly: a mid-list reader under an overlay
+//     must not be yanked;
+//   * no overlay edge fires again until the picker is closed, and that close
+//     edge is where the debt is owed.
+//
+// WHY THE ASSERTIONS ARE IN RAW PIXELS AND NOT IN THE TAIL THRESHOLD.
+// `SCROLL_BOTTOM_THRESHOLD_PX` is 50 and the bar is about 47, so "is the reader
+// within the tail band" answers YES on the BROKEN build. A spec written against
+// the threshold here would be green against the defect it is named after. The
+// distance is therefore compared against the measured shrink and against a
+// sub-pixel epsilon, and the shrink is measured rather than assumed so a bar
+// that changes height does not quietly turn this vacuous.
+//
+// NO THIRD-PARTY NETWORK, the #682 posture: the stream and the logos are served
+// from local bytes by `page.route`, scoped to the station's real URL so a change
+// that stops requesting it still fails.
+//
+// Desktop project (untagged → chromium), like both siblings on this site. The
+// freeze is not form-factor gated — `RailRadio` calls `createOverlayLock`
+// unconditionally — so the defect reproduces identically here, and desktop
+// Chrome is the platform whose scroll physics these specs are written against
+// (feedback: webkit is not iOS). The mobile-only half of #1701, where the bar
+// should be docked, is a separate layout ruling and is not this spec's subject.
+
+import { silentMp3 } from "../fixtures/bytes";
+import {
+  composeSend,
+  loginAs,
+  openRailMenu,
+  scrollbackDistanceFromBottom,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Literals rather than an import from `src/lib/radioStations`, matching the #682
+// spec: a table edit that drops or renames this station must fail HERE instead
+// of being followed silently.
+const STATION_ID = "groovesalad";
+const STATION_STREAM = "https://ice.somafm.com/groovesalad-128-mp3";
+
+// Sub-pixel band. "At the tail" in a real browser is a fractional zero, not an
+// integral one, and this is deliberately far below the 47px the defect leaves.
+const TAIL_EPSILON_PX = 2;
+
+test.setTimeout(90_000);
+
+test("#1701 — tuning a station under the open picker leaves the reader ON the tail", async ({
+  page,
+}) => {
+  test.slow();
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  await page.route("https://ice.somafm.com/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "audio/mpeg", body: silentMp3(8) });
+  });
+  await page.route("https://api.somafm.com/logos/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "image/png", body: Buffer.alloc(0) });
+  });
+
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  // A line of our own at the tail. An own send also arms the follow intent
+  // through its own edge, so the reader is following for the honest reason
+  // rather than because the mount default has not been disturbed yet.
+  await composeSend(page, "arr1701-last-line");
+  await expect(page.getByText("arr1701-last-line")).toBeVisible({ timeout: 15_000 });
+
+  const sc = page.getByTestId("scrollback");
+
+  // Pin AND let onScroll measure it — the measurement is the precondition, the
+  // same one #1121's helper spells out: without it the pane never learns it is
+  // at the tail and the state the bug needs cannot exist.
+  const before = await sc.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+    return { clientHeight: el.clientHeight };
+  });
+  await page.waitForTimeout(300);
+  await expect
+    .poll(() => scrollbackDistanceFromBottom(page), { timeout: 5_000 })
+    .toBeLessThanOrEqual(TAIL_EPSILON_PX);
+
+  // Tune a station. The rail drawer's own overlay opens first and the picker
+  // inherits the refcount from it; either way the snapshot is captured while the
+  // reader is at the tail and BEFORE the bar exists.
+  await openRailMenu(page);
+  await page.getByTestId("rail-action-radio").click();
+  const picker = page.getByTestId("rail-radio-picker");
+  await expect(picker).toBeVisible();
+  await page.getByTestId(`rail-radio-station-${STATION_ID}`).click();
+
+  const audio = page.getByTestId("audio-mini-player-el");
+  await expect(audio).toHaveJSProperty("src", STATION_STREAM);
+  await expect(page.getByTestId("audio-mini-player")).toBeVisible({ timeout: 15_000 });
+
+  // Precondition, asserted and not assumed: picking must leave the picker UP.
+  // The day that changes, the freeze lifts on the same tick as the bar mounts
+  // and this spec silently stops reproducing anything — so it should go red
+  // here, at the premise, rather than pass for the wrong reason below.
+  await expect(picker).toBeVisible();
+
+  const during = await sc.evaluate((el) => ({
+    clientHeight: el.clientHeight,
+    distanceToBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+  }));
+
+  // The bar really took its space out of the scroll container — measured, not
+  // assumed, because every assertion below is vacuous without it.
+  const shrink = before.clientHeight - during.clientHeight;
+  expect(shrink).toBeGreaterThan(20);
+
+  // And the reader was left behind by exactly that much, because the freeze ate
+  // the re-pin. This is the defect observed live, and it is TRUE ON BOTH BUILDS:
+  // the fix lands on the close edge, deliberately, rather than teaching a
+  // container change to outrank the freeze (which is the signal #219 exists to
+  // suppress). Pinned so a future widening of the freeze is visible here.
+  expect(during.distanceToBottom).toBeGreaterThan(shrink - TAIL_EPSILON_PX);
+
+  await page.getByTestId("rail-radio-picker-close").click();
+  await expect(picker).toBeHidden();
+
+  // OBSERVABLE 1 — the close edge restores the INTENT, not the stale proxy.
+  // Pre-fix this sits at `shrink` and stays there for as long as the reader
+  // keeps reading: nothing else will ever move it.
+  await expect
+    .poll(() => scrollbackDistanceFromBottom(page), { timeout: 5_000 })
+    .toBeLessThanOrEqual(TAIL_EPSILON_PX);
+
+  // OBSERVABLE 2 — the same fact in the reporter's own words: "the last lines
+  // are left under it". The LAST row rather than our marker, so a line arriving
+  // from elsewhere on this shared channel moves the target instead of breaking
+  // the claim.
+  await expect(scrollbackLines(page).last()).toBeInViewport({ ratio: 1 });
+});

--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -32,14 +32,35 @@ import { nowPlayingLabel } from "./lib/nowPlaying";
 // makes "hide while it keeps playing" free. Narrowing the <Show> predicate
 // cannot reach the element.
 //
-// Two shapes this must NOT become, both of which stop playback:
+// Two shapes this must NOT become, both of which break playback:
 //   * hiding by unmounting this component from Shell — that destroys the
-//     element (which is why leaving chat for home already stops playback);
+//     element;
 //   * carrying the hidden flag inside `activeAudio` — that re-fires the effect
 //     below, which reassigns `.src` and re-buffers a live stream.
+//
 // The door back is in `RailActions`, not here: a restore handle left in this
 // slot would still have to clear the 44px tap floor, so it would give back
 // almost none of the vertical space that motivated hiding.
+//
+// #1701 — what unmounting ACTUALLY does, measured, because the first bullet
+// above used to end "(which is why leaving chat for home already stops
+// playback)" and that is not what happens. The source is MODULE state
+// (`lib/audioPlayer.ts`) and outlives the component, so leaving a scrollback
+// window for home / list / mentions / admin destroys the element — and coming
+// back RE-MOUNTS it: the `on(activeAudio, …)` effect below runs on its first
+// execution, reassigns `.src` and calls `play()`. The semantics are
+// kill-and-re-tune, not stop. A station re-buffers (#1700's `mustRefetch` says
+// re-tuning IS the correct resume for one), and an UPLOAD restarts from the
+// beginning, unasked — that half is a defect in its own right and is not this
+// file's to fix. Recorded here so the next reader reasons about the code
+// rather than about this comment.
+//
+// Where "stop" genuinely lives, and neither of the two depends on where this
+// component is mounted: `closeAudio` (the ✕ — it clears the source, and the
+// effect below pauses and detaches on null), and the `identityScopedStore`
+// wrapper around the store, whose `onIdentityChange` nulls the same signal.
+// That second one is what keeps a logout or a token rotation from playing the
+// previous identity's audio over the new identity's shell.
 
 const formatTime = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds < 0) return "0:00";

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1184,6 +1184,19 @@ const ScrollbackPane: Component<Props> = (props) => {
   // messages they missed, and lost tail-follow for it. Captured with the px,
   // spent on the intent; the geometry signal is measured fresh instead.
   let overlaySnapshotDistance: number | null = null;
+  // #1701 — the height of the BOX the px above was measured in, captured at the
+  // same instant for the same reason #1121 captured the distance. A scrollTop is
+  // meaningless on its own: it names a position only relative to the viewport it
+  // was read through. Chrome mounting UNDER the freeze — the docked audio player
+  // is the reported case, tuned from a rail picker that deliberately stays open
+  // after a station is picked — shortens `.scrollback` while the snapshot is
+  // held, and the #778 ResizeObserver re-pin that exists for exactly that class
+  // is gated out by `isOverlayFrozen()` (correctly: a mid-list reader must not be
+  // yanked). No overlay edge fires again until the close, so without this the
+  // restore replays a px that is short of the tail by the bar's height. Comparing
+  // it against the LIVE clientHeight makes the correction event-independent —
+  // it holds whether or not the observer fired. `null` when no snapshot is held.
+  let overlaySnapshotClientHeight: number | null = null;
   // #608 (deep-review §6.1) — the overloaded `atBottom` split into its two
   // independent concerns, the PRIMARY reshape of the single-scroll-authority
   // work:
@@ -2119,11 +2132,16 @@ const ScrollbackPane: Component<Props> = (props) => {
           // #1121 — same instant, same epoch as the px above. See its
           // declaration for why the restore cannot recompute this later.
           overlaySnapshotDistance = listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight;
+          // #1701 — same instant again, and the third member of one snapshot:
+          // position, what it meant, and the box it meant it in.
+          overlaySnapshotClientHeight = listRef.clientHeight;
         }
         const target = overlayScrollSnapshot;
         const snapKey = overlaySnapshotKey;
         const snapDistance = overlaySnapshotDistance;
+        const snapClientHeight = overlaySnapshotClientHeight;
         if (target === null || snapKey === null || snapDistance === null) return;
+        if (snapClientHeight === null) return;
         // Re-assert across rAF×2 (matching scrollToActivation's frame budget so
         // it lands after the overlay's layout commits) via the applier's W1
         // restore entrypoint — the single owner of this write, key-guarded there.
@@ -2137,7 +2155,9 @@ const ScrollbackPane: Component<Props> = (props) => {
         // close→reopen nulling a just-re-armed snapshot) is now structurally
         // impossible, as is the field-bug "frozen forever under a leaked count".
         requestAnimationFrame(() =>
-          requestAnimationFrame(() => applyOverlayRestore(target, snapKey, snapDistance)),
+          requestAnimationFrame(() =>
+            applyOverlayRestore(target, snapKey, snapDistance, snapClientHeight),
+          ),
         );
       },
       { defer: true },
@@ -3130,7 +3150,12 @@ const ScrollbackPane: Component<Props> = (props) => {
   // mid-overlay channel switch owns its own activation; never stamp the leaving
   // channel's px onto it) and skips a no-op write. `target` is the px captured on
   // the open edge; `snapKey` the channel it was captured on.
-  const applyOverlayRestore = (target: number, snapKey: string, snapDistance: number): void => {
+  const applyOverlayRestore = (
+    target: number,
+    snapKey: string,
+    snapDistance: number,
+    snapClientHeight: number,
+  ): void => {
     if (!listRef || snapKey !== key()) return;
     // #608 (regression fix) — reconcile the follow INTENT with the reader's
     // trusted position. The snapshot is the authoritative position across the
@@ -3154,14 +3179,38 @@ const ScrollbackPane: Component<Props> = (props) => {
     // edge it also counts every line that arrived under the overlay, which reads
     // as a scroll-up the reader never performed. #608's mid-list case is
     // unchanged — a snapshot taken mid-list carries a large distance either way.
-    setFollowMode(snapDistance <= SCROLL_BOTTOM_THRESHOLD_PX);
+    const wasFollowing = snapDistance <= SCROLL_BOTTOM_THRESHOLD_PX;
+    setFollowMode(wasFollowing);
+    // #1701 — WHERE to put them, once the intent is known. The px is a proxy for
+    // a position and it stops being one the moment the viewport it was read
+    // through changes size: chrome mounting under the freeze (the docked audio
+    // player, tuned from a picker that stays open) shortens the box, so the same
+    // scrollTop now sits the bar's height ABOVE the tail. Restore the INTENT
+    // instead of the proxy when the two have come apart — and only then. Gated on
+    // the box, NOT on the extent: content arriving underneath is #1121's axis and
+    // its ruling stands (a held position is not a scroll-up the reader never
+    // performed), so a steady box still replays the px whatever landed under it.
+    // A mid-list reader asked for a position, not for the tail, and a shorter box
+    // does not change what they asked for — `wasFollowing` is the whole
+    // difference, and it is the SAME predicate the intent above is set from
+    // rather than a second one free to drift from it.
+    const boxMoved = listRef.clientHeight !== snapClientHeight;
+    // The bottom of the scrollable range, spelled out rather than leaning on the
+    // browser clamping `scrollTop = scrollHeight`: this value is also what the
+    // geometry below is published from, and a number that has to be clamped
+    // before it is true cannot be measured against.
+    const restoreTo =
+      wasFollowing && boxMoved ? listRef.scrollHeight - listRef.clientHeight : target;
     // #1121 — and the GEOMETRY is republished for the close edge, where it
     // belongs. It is the SAME expression the intent used to be computed from —
     // current extent against the restored position — because that expression was
     // never wrong, only misaddressed: it answers "is the pane at the tail now",
     // which is `atBottomNow`'s question, not `followMode`'s. Measured against
-    // `target` rather than the live `scrollTop`: both exits below leave the pane
-    // there, so this is the position the reader is about to be looking from.
+    // `restoreTo` rather than the live `scrollTop`: both exits below leave the
+    // pane there, so this is the position the reader is about to be looking from.
+    // (#1701 renamed the operand from `target`; on the unchanged-box path the two
+    // ARE the same number, and on the corrected path the old one would publish a
+    // staleness the write on the next line is about to remove.)
     //
     // This is the only place the pane can learn that the tail moved away from it
     // while it was held: nothing scrolled, so no `scroll` event fires and
@@ -3171,12 +3220,12 @@ const ScrollbackPane: Component<Props> = (props) => {
     // suppress this window's unread badge. Published BEFORE the no-op early
     // return, because the held-position case IS the one that goes stale.
     setAtBottomNow(
-      listRef.scrollHeight - target - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
+      listRef.scrollHeight - restoreTo - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
     );
-    if (listRef.scrollTop === target) return;
+    if (listRef.scrollTop === restoreTo) return;
     const intent: ScrollIntent = { kind: "overlay-freeze", key: snapKey, lifetime: "sticky" };
     logScrollDecision("overlay-restore", [intent], intent, "overlay-restore");
-    listRef.scrollTop = target;
+    listRef.scrollTop = restoreTo;
   };
 
   // #608 — the applier's smooth-scroll INTERRUPT (W9). The mention-jump is the

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -20,6 +20,33 @@ beforeEach(() => {
   // #1700 — held, not discarded: `load()` is the only call that re-fetches, so
   // the resume path is now asserted through it.
   loadSpy = vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+  // #1701 — an OFFLINE `fetch`, for every test in this file, installed before
+  // any of them can tune anything.
+  //
+  // Two tests here call `playAudio("https://ice.somafm.com/groovesalad-128-mp3",
+  // …)` to exercise the transport, and neither of them is about the feed — but
+  // `tunedStation()` is DERIVED, not declared: `radio.ts` matches
+  // `activeAudio()?.href` against the curated table, so those two calls tune
+  // Groove Salad as far as the rest of the app is concerned. `nowPlaying.ts`'s
+  // effect then polls `api.somafm.com` IMMEDIATELY, and in CI — where a network
+  // exists and this sandbox's does not — that is a live third-party request
+  // issued from a unit test. Measured: the run that caught it reported
+  // `Expected "Trestal — A Land Unknown", Received "Alex Cortiz — Paluka days"`,
+  // a real track that was genuinely on the air.
+  //
+  // It also RACED. The in-flight real answer clears the poll's own guard
+  // (`tunedStation()?.songsUrl !== url`) because the feed test tunes the SAME
+  // station, so it lands on top of the stub. That guard is not the defect and
+  // is deliberately left alone — it is asking the right question; the barrier
+  // below is what let a stale answer reach it at the wrong moment.
+  //
+  // Rejecting rather than answering `ok: false`: both leave `track` null via the
+  // poll's catch, and "there is no network here" is the honest one to model. A
+  // test that WANTS a feed says so by overriding this — see `tuneWithFeed`.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockRejectedValue(new Error("offline: a unit test must not reach the network")),
+  );
   closeAudio();
   showPlayer();
 });
@@ -275,8 +302,18 @@ describe("AudioMiniPlayer", () => {
       render(() => <AudioMiniPlayer />);
       tuneStation(station);
 
+      // #1701 — wait for the STUBBED TEXT, not for the element.
+      //
+      // Presence is not the state this helper promises. Any answer at all mounts
+      // the span, so a barrier keyed on `toBeInTheDocument` returns on WHICHEVER
+      // read landed first and hands the caller a row it never checked the
+      // provenance of. With the offline default above there is only one possible
+      // answer left — but a barrier that is correct only because nothing else
+      // can happen is one leak away from deciding by timing again, and this one
+      // already did once (a live SomaFM track, in CI). Keyed on the text, the
+      // helper cannot return until the feed IT installed is the one on screen.
       await vi.waitFor(() =>
-        expect(screen.getByTestId("audio-mini-player-track")).toBeInTheDocument(),
+        expect(screen.getByTestId("audio-mini-player-track")).toHaveTextContent(TRACK),
       );
       return station;
     };

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -6100,6 +6100,125 @@ describe("ScrollbackPane", () => {
         expect(readingAtTailKey()).toBeNull();
       });
     });
+
+    // #1701 — the CONTAINER axis of the defect #1121 closed on the CONTENT axis,
+    // at the same site and for the same reason: the freeze holds ONE number, a
+    // scrollTop, and a scrollTop only names the position it was captured at
+    // while the box it was measured in is the same box. #1121's box was steady
+    // and the CONTENT grew under it; here the content is steady and the BOX
+    // shortens.
+    //
+    // The field path is the docked audio player. It is tuned from the rail's
+    // station picker, the picker is a `createOverlayLock` surface, and picking
+    // deliberately does NOT close it (RailRadio: "Auditioning stations is the
+    // second kind, so the picker stays up") — so the bar mounts between
+    // `.scrollback-pane` and `.compose-box` WHILE the freeze is up. The #778
+    // ResizeObserver re-pin that exists for exactly this class ("chrome growing
+    // inside the shell shrinks THIS box with no event at all") is gated out by
+    // `isOverlayFrozen()`, correctly — a mid-list reader under an overlay must
+    // not be yanked — and no overlay edge fires again until the close. So the
+    // restore replays a px that is short of the tail by the bar's height and the
+    // reader is left looking at a pane whose last lines sit below the fold: the
+    // reported "opening the player does not push the scrollback up".
+    //
+    // The cure is derived from the CAPTURED clientHeight, not from the observer,
+    // so it holds whether or not the RO fired — which matters, because the field
+    // report does not say which of the two suppressed paths ran and this test
+    // cannot settle that either.
+    describe("#1701 — chrome mounting under an overlay strands a tail reader", () => {
+      // `.audio-mini-player`: a 2.5rem control (35px at this app's 14px root)
+      // plus 0.4rem block padding either side and a 1px top border.
+      const BAR_PX = 47;
+      const VIEWPORT_PX = 500;
+      const EXTENT_PX = 2000;
+
+      afterEach(() => {
+        vi.unstubAllGlobals();
+      });
+
+      const mountChromeUnderOverlay = async (scrollTop: number): Promise<HTMLDivElement> => {
+        let roCallback: ResizeObserverCallback | undefined;
+        class FakeResizeObserver {
+          constructor(cb: ResizeObserverCallback) {
+            roCallback = cb;
+          }
+          observe(): void {}
+          unobserve(): void {}
+          disconnect(): void {}
+        }
+        vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+        seedRows();
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        const list = screen.getByTestId("scrollback") as HTMLDivElement;
+        await flushRaf();
+
+        Object.defineProperty(list, "scrollHeight", { value: EXTENT_PX, configurable: true });
+        Object.defineProperty(list, "clientHeight", { value: VIEWPORT_PX, configurable: true });
+        Object.defineProperty(list, "scrollTop", {
+          value: scrollTop,
+          writable: true,
+          configurable: true,
+        });
+        // MEASURED, not merely set — same load-bearing scroll event as #1121's
+        // helper: without it `tailGeometryMeasured` is unset and the geometry the
+        // restore republishes is withheld.
+        list.dispatchEvent(new Event("scroll"));
+        await flushRaf();
+
+        pushOverlay(null);
+        await flushRaf();
+        scrollIntoViewSpy.mockClear();
+
+        // The bar takes its space. The scroll list loses height; the CONTENT is
+        // untouched, which is what separates this from #1121.
+        Object.defineProperty(list, "clientHeight", {
+          value: VIEWPORT_PX - BAR_PX,
+          configurable: true,
+        });
+        roCallback?.([], {} as ResizeObserver);
+        await flushRaf();
+
+        return list;
+      };
+
+      it("drops the #778 re-pin while the overlay is up (the freeze eats it, as designed)", async () => {
+        const list = await mountChromeUnderOverlay(EXTENT_PX - VIEWPORT_PX);
+
+        // Characterization, not a defect: the freeze outranking the re-pin is
+        // what keeps a mid-list reader still. It is the CLOSE edge that owes the
+        // tail reader an honest answer, and the test below is where that is due.
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+        expect(list.scrollTop).toBe(EXTENT_PX - VIEWPORT_PX);
+      });
+
+      it("lands a tail reader ON the tail when the overlay closes, not on the stale px", async () => {
+        const list = await mountChromeUnderOverlay(EXTENT_PX - VIEWPORT_PX);
+
+        popOverlay(null);
+        await flushRaf();
+
+        // The tail of a 2000px buffer seen through a 453px box is 1547 — not the
+        // 1500 that was the tail of the 500px box the snapshot was taken in.
+        // Pre-fix the restore replayed 1500 and the last 47px, two chat lines,
+        // stayed under the bar for as long as the reader kept reading.
+        expect(list.scrollTop).toBe(EXTENT_PX - (VIEWPORT_PX - BAR_PX));
+      });
+
+      it("still holds a MID-LIST reader across the same shrink (the #608 posture is not widened)", async () => {
+        const list = await mountChromeUnderOverlay(750);
+
+        popOverlay(null);
+        await flushRaf();
+
+        // distance 2000-750-500 = 750, far past the tail band: this reader asked
+        // for a position, not for the tail, and a shorter box does not change
+        // what they asked for. Guards the fix against becoming "always tail".
+        expect(list.scrollTop).toBe(750);
+      });
+    });
   });
 
   // affordances. Rendered as flex siblings BEFORE `.scrollback` they

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -60556,3 +60556,87 @@ commit moved the value and left the citation. Fixed by naming the ANCHOR
 (`busy_timeout: @waiter_budget_ms`, and `min(15_000, the budget)` for the
 historical arithmetic, kept and labelled rather than deleted), never by writing
 the new number in, which would only reschedule the rot.
+<!-- entry #1701a -->
+
+---
+
+## 2026-08-24 — #1701a: a held scrollTop is only a position while the box it was measured in is
+
+The report was "opening the radio player does not push the scrollback up —
+the bar takes its space and the last lines are left under it". The issue
+itself established that this should not be able to happen: the bar is IN
+FLOW (`Shell.tsx`, between `ScrollbackPane` and `ComposeBox`;
+`.audio-mini-player` is a plain flex row), the whole chain above it carries
+`min-height: 0`, so mounting it genuinely shortens `.scrollback` rather
+than covering it — and #778 already re-pins a follower on any container
+height change, via the `ResizeObserver` on the scroll list, for exactly the
+class *"chrome growing inside the shell shrinks THIS box with no event at
+all"*.
+
+What closed it is a fact the report could not carry, because it is one
+component over: **the player is tuned from the rail's station picker, the
+picker holds a `createOverlayLock` refcount, and picking deliberately does
+not close it.** `RailRadio` states that rule in prose — *"a launcher that
+NAVIGATES away is single-shot, a control the operator flips in place is
+not; auditioning stations is the second kind, so the picker stays up"* —
+and it is correct on its own terms. The consequence is that the bar mounts
+while the overlay freeze is UP. `applyActivation` hands the re-pin to
+`resolveIntent`, `overlay-freeze` outranks `tail-follow`, and the write is
+dropped. That drop is also correct: a reader parked mid-list under an
+overlay must not be yanked to the tail. No overlay edge fires again until
+the picker closes, so the correction never comes; the close edge then
+replays a `scrollTop` captured through a viewport ~47px taller than the one
+it lands in, and the reader keeps reading a pane whose last two lines sit
+below the fold.
+
+### The same defect #1121 closed, on the other axis
+
+This is not a new shape. #1121 fixed `applyOverlayRestore` for the case
+where the box was steady and the CONTENT grew underneath; here the content
+is steady and the BOX shortens. Both say one thing: **the freeze holds a
+single number, and a `scrollTop` names a position only relative to the
+viewport it was read through.** #1121 captured the distance-to-tail with
+the px because the INTENT belongs to the open edge; this captures the
+`clientHeight` with it because the POSITION does too.
+
+So `applyOverlayRestore` restores the tail instead of the proxy when — and
+only when — the reader was following AND the box has changed size. Two
+gates, each carrying its own argument:
+
+* **on the box, not on the extent.** Content arriving underneath is
+  #1121's axis and its ruling stands: a held position is not a scroll-up
+  the reader never performed. A steady box replays the px whatever landed
+  under it.
+* **on the follow intent.** A mid-list reader asked for a position, not
+  for the tail, and a shorter box does not change what they asked for. The
+  predicate is the SAME `snapDistance <= SCROLL_BOTTOM_THRESHOLD_PX` the
+  intent is set from, not a second one free to drift from it.
+
+Both gates are measured, not asserted: dropping the follow gate reddens the
+new mid-list guard, and dropping the box gate reddens #1121's own two
+geometry specs plus the W1 restore characterization.
+
+### Why it is derived from the snapshot and not from the observer
+
+The alternative was to remember that a re-pin had been suppressed and
+replay it on the thaw. That is a second structure with its own lifecycle,
+and it answers a narrower question: it only fires if the `ResizeObserver`
+fired. Comparing the captured `clientHeight` against the live one is
+event-independent — the correction holds whether the observer ran or not,
+which matters here because the field report cannot say which of the two
+suppressed paths ran and no local gate can settle it either.
+
+### Known residue, stated rather than papered over
+
+The cure lands on the CLOSE edge. On mobile that is the moment the reader
+can see the pane again — `.shell-members` is a full drawer while the picker
+is up — so there is nothing left to fix. **On desktop the rail is a
+permanent grid column and the picker covers only the rail, so an operator
+watching the scrollback with the picker still open sees the stale pane
+until they close it.** Curing that means letting a container-height change
+outrank the freeze, and #219's whole reason for existing is a mobile
+fullscreen modal shrinking the visual viewport and tail-snapping the pane —
+the same signal. The narrower reading (that a *non-covering* surface should
+take `createOverlayEscape` and not the scroll-lock refcount, which is what
+`overlayScrollLock.ts` already says the split is for) is a change to the
+rail's own posture with its own blast radius, not this fix's to make.


### PR DESCRIPTION
Half of #1701 — the **push-up** complaint. The reposition half is
deliberately NOT here: it collides with the #985 floating ☰ on mobile
query/server windows, over exactly the corner the player's ✕ sits in, and
that corner has already cost two owner rulings (#1050, #1051). Reported for
a ruling rather than settled here.

## Root cause

The issue established the machinery is present — the bar is in flow, the
flex chain shortens `.scrollback`, and #778's `ResizeObserver` re-pins a
follower on any container height change — and asked which of three things
was failing. It is none of them.

The player is tuned from the rail's **station picker**, the picker holds a
`createOverlayLock` refcount, and picking deliberately does not close it
(`RailRadio`: *"auditioning stations is the second kind, so the picker
stays up"*). So the bar mounts while the overlay freeze is up:
`applyActivation` hands the re-pin to `resolveIntent`, `overlay-freeze`
outranks `tail-follow`, and the write is dropped — correctly, a mid-list
reader under an overlay must not be yanked. No overlay edge fires again
until the picker closes, and the close edge then replays a `scrollTop`
captured through a viewport ~47px taller than the one it lands in.

## Fix

This is #1121's defect on the other axis, at the same site: there the box
was steady and the content grew under it, here the content is steady and
the box shortens. Both say the same thing — the freeze holds one number,
and a `scrollTop` names a position only relative to the viewport it was
read through.

So the viewport is captured with it, and `applyOverlayRestore` restores the
tail instead of the proxy when — and only when — the reader was following
AND the box changed size. Gated on the box and not the extent (content
arriving underneath is #1121's axis, ruling unchanged); gated on the follow
intent via the *same* predicate the intent is set from, not a second one.

Derived from the captured `clientHeight` rather than from the observer, so
the correction holds whether or not the RO fired — which matters, because
nothing available can settle which of the two suppressed paths ran.

## Evidence

TDD, RED first: `expected 1500 to be 1547`, the 47px the bar takes.

Two mutants, both caught — dropping the follow gate reddens the new
mid-list guard; dropping the box gate reddens #1121's own two geometry
specs plus the W1 restore characterization.

Gates: full vitest **+3 tests, +0 files** as a difference from the base
(310/6047 → 310/6050); `check` green on all four stages;
`design-notes-gate.sh` green.

## Residue, declared

The cure lands on the close edge. On mobile that is the moment the reader
can see the pane again. **On desktop the picker covers only the rail, so an
operator watching the scrollback with it still open sees the stale pane
until they close it.** Curing that means letting a height change outrank
the freeze, which is the signal #219 exists to suppress; the narrower
reading (a non-covering surface should take `createOverlayEscape`, not the
refcount — `overlayScrollLock.ts` already says so) is a change to the
rail's posture and not this fix's to make. Named, not hidden.