### PR TITLE
ci(#1714): gate the release CLI's distribution hop on the real substrate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,6 +312,159 @@ jobs:
           [ "$got" = "$want" ] || {
             echo "::error::client package is stamped '$got', expected '$want'"; exit 1; }
 
+      # ── #1714: the release CLI's distribution hop, on the real substrate ──
+      #
+      # #1685 taught `grappa add-network` to cross out of its transient `eval`
+      # VM and into the running bouncer as Erlang terms. Every branch of that
+      # hop was proven by hand exactly once, and the branch a self-hoster meets
+      # FIRST — no live node at all — had no gate.
+      #
+      # WHICH OUTCOMES GET AN ARM, AND THE CRITERION USED
+      #
+      # `Grappa.Release.LiveNode.reach/2` distinguishes five transport
+      # outcomes before the far side is even reached: `:no_release_node`,
+      # `:distribution_disabled`, `:no_distribution`, `:unreachable`, and the
+      # `{:ok, :started}` round trip. Three are gated below and two are not.
+      # The split is NOT the issue title's "both branches" — it is which
+      # outcomes only THIS substrate can falsify:
+      #
+      #   gated here    `:no_distribution`, `:unreachable`, `{:ok, :started}`
+      #                 — each is a STATE OF THE DEPLOYMENT (is epmd up? is the
+      #                 node up?) and turns on systemd, epmd, the release
+      #                 cookie and the node name ERTS derives. Nothing
+      #                 in-process can make any of them true or false.
+      #   left to unit  `:no_release_node`, `:distribution_disabled`
+      #                 — both are refusals taken BEFORE any I/O, on the value
+      #                 of one environment variable, and
+      #                 test/grappa/release/live_node_test.exs already covers
+      #                 them. An arm here would re-read the same
+      #                 `System.get_env` through a slower door: CI minutes, no
+      #                 extra falsifying power.
+      #
+      # WHY THE TAIL OF THE JOB AND NOT WHERE #1714 PUT IT
+      #
+      # The issue says "right after Install both packages". That would run the
+      # live arm — which must START the service — BEFORE every existing proof
+      # in this job, leaving a daemon nobody asked for running underneath them.
+      # A proof that runs with unrequested state up no longer proves what it
+      # says it proves. So the arms go last among the proofs, and still ahead
+      # of the uploads: a failed arm must keep the artifacts unpublished.
+      #
+      # NOT asserted: the exit status. `Grappa.Release.CLI` returns 0 in every
+      # branch ON PURPOSE (cli.ex — the first-run script `create-user &&
+      # add-network && start the service` must not break on the case that has
+      # no live node BY DEFINITION). The bind is reported through stdout and
+      # the row, so that is what these steps read.
+      - name: Create the account the distribution-hop arms bind against
+        run: |
+          sudo grappa create-user gate --password 'ci-not-a-secret' | tee /tmp/hop-user.log
+          grep -q '^created user gate ' /tmp/hop-user.log || {
+            echo "::error::create-user did not report the account it created"; exit 1; }
+
+      # ARM 1 — no epmd at all. This is a box that has never started the
+      # service, which is the FIRST of the two no-live-node shapes #1685
+      # measured (`:net_kernel.start/2` itself fails `:nodistribution`) and the
+      # one whose cure, missing, "crashes on first run". The postinstall
+      # `enable`s the unit and deliberately does NOT start it (a real PHX_HOST
+      # must be set first), so this state is what the job is already sitting in.
+      #
+      # The premise is ASSERTED, not assumed: with epmd somehow already up this
+      # step would silently test arm 2 instead and report a green for a claim
+      # it never made.
+      - name: 'Hop arm 1/3: no epmd — the bind parks and says why'
+        run: |
+          pgrep -x epmd >/dev/null && {
+            echo "::error::epmd is already running — this arm cannot test the no-epmd shape"
+            exit 1; }
+          echo "epmd: not running (arm premise holds)"
+
+          sudo grappa add-network gate gate-no-epmd \
+            --server 127.0.0.1:6667 --nick gatebot --auth none | tee /tmp/hop-arm1.log
+
+          grep -qF 'the binding is PARKED: nothing is listening on epmd' /tmp/hop-arm1.log || {
+            echo "::error::expected the no-epmd park reason on stdout"; exit 1; }
+
+          state="$(sudo sqlite3 /var/lib/grappa/grappa.db \
+            "SELECT c.connection_state FROM network_credentials c
+               JOIN networks n ON n.id = c.network_id WHERE n.slug = 'gate-no-epmd'")"
+          echo "gate-no-epmd connection_state: '$state'"
+          [ "$state" = "parked" ] || {
+            echo "::error::row reads '$state', expected 'parked' — #1685's whole point"; exit 1; }
+
+      # ARM 2 — epmd up, nothing answering to the name. The SECOND no-live-node
+      # shape: `:net_kernel.start/2` succeeds and `Node.connect/1` returns
+      # false. It is reached here by starting epmd on its own rather than by
+      # stopping the service, and that is deliberate — systemd's default
+      # KillMode is control-group, so `systemctl stop grappa` takes epmd down
+      # WITH the node and lands back in arm 1. On a real host epmd outlives the
+      # service because something outside the unit started it; `epmd -daemon`
+      # from the release's own ERTS is that, staged.
+      - name: 'Hop arm 2/3: epmd up, node down — the bind parks on unreachable'
+        run: |
+          epmd_bin="$(find /usr/lib/grappa -type f -name epmd -perm -u+x -print -quit)"
+          [ -n "$epmd_bin" ] || { echo "::error::no epmd in the installed release"; exit 1; }
+          "$epmd_bin" -daemon
+          pgrep -x epmd >/dev/null || { echo "::error::epmd did not stay up"; exit 1; }
+          echo "epmd: running, no node registered (arm premise holds)"
+
+          sudo grappa add-network gate gate-no-node \
+            --server 127.0.0.1:6667 --nick gatebot --auth none | tee /tmp/hop-arm2.log
+
+          grep -qF 'the binding is PARKED: the live node did not answer' /tmp/hop-arm2.log || {
+            echo "::error::expected the unreachable park reason on stdout"; exit 1; }
+
+          state="$(sudo sqlite3 /var/lib/grappa/grappa.db \
+            "SELECT c.connection_state FROM network_credentials c
+               JOIN networks n ON n.id = c.network_id WHERE n.slug = 'gate-no-node'")"
+          echo "gate-no-node connection_state: '$state'"
+          [ "$state" = "parked" ] || {
+            echo "::error::row reads '$state', expected 'parked'"; exit 1; }
+
+      # ARM 3 — the hop itself. Starting the service is NEW scaffolding: no
+      # workflow in this repo has ever run `systemctl start grappa`, and the
+      # postinstall ships PHX_HOST=REPLACE_ME because it is the one value
+      # nothing can generate. Both are set here explicitly.
+      #
+      # The row assertion is NOT `= connected`, and the reason is #1675: since
+      # then `:connected` means REGISTERED UPSTREAM, and 127.0.0.1:6667 has
+      # nothing listening, so the session starts and then settles to `:failing`
+      # on its own. Pinning either value would be a race. What this arm exists
+      # to prove is that the hop LANDED — that the transport promoted the row
+      # out of `:parked`, which no amount of retrying can do from this side.
+      - name: 'Hop arm 3/3: live node — the session starts across the hop'
+        run: |
+          sudo sed -i 's/^PHX_HOST=.*/PHX_HOST=127.0.0.1/' /etc/grappa/grappa.env
+          sudo systemctl start grappa
+
+          for _ in $(seq 1 60); do
+            curl -fsS http://127.0.0.1:4000/healthz >/dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -fsS http://127.0.0.1:4000/healthz >/dev/null || {
+            echo "::error::the service never became healthy"
+            sudo systemctl status grappa --no-pager || true
+            sudo journalctl -u grappa --no-pager -n 200 || true
+            exit 1; }
+          echo "service: healthy (arm premise holds)"
+
+          sudo grappa add-network gate gate-live \
+            --server 127.0.0.1:6667 --nick gatebot --auth none | tee /tmp/hop-arm3.log
+
+          grep -qF 'started a session on the live node' /tmp/hop-arm3.log || {
+            echo "::error::the CLI did not report a session started on the live node"
+            sudo journalctl -u grappa --no-pager -n 200 || true
+            exit 1; }
+
+          state="$(sudo sqlite3 /var/lib/grappa/grappa.db \
+            "SELECT c.connection_state FROM network_credentials c
+               JOIN networks n ON n.id = c.network_id WHERE n.slug = 'gate-live'")"
+          echo "gate-live connection_state: '$state'"
+          case "$state" in
+            connected|failing) ;;
+            *) echo "::error::row reads '$state' — the hop did not promote it out of parked"
+               exit 1 ;;
+          esac
+
       # Two packages, two upload steps (#1447 slice B). One glob over a shared
       # directory would publish whatever landed there next; a step per artifact
       # keeps publication something a human wrote down. `publish` then attaches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ name: release
 # packaging README.
 #
 # This workflow runs on a `v*` tag push (the real release — every job PUBLISHES)
-# OR via manual workflow_dispatch, which has TWO mutually-exclusive modes:
+# OR via manual workflow_dispatch, which has THREE mutually-exclusive modes:
 #
 #   * REPAIR (default, `docker_validation=false`, #504): (re)build an EXISTING
 #     tag's deb/arch/rpm AND its ghcr images and upload to its release, no tag
@@ -97,6 +97,17 @@ name: release
 #     proves the build (arm64 QEMU + ABI-lockstep assertion + cic + mix release)
 #     and publishes NOTHING. deb/arch/rpm/publish are skipped. Run it with:
 #       gh workflow run release.yml --ref <branch> -f docker_validation=true
+#   * DEB DRY-RUN (`deb_validation=true`, #1714): the same idea for the package
+#     job — a ZERO-PUBLICATION validation of the deb job ITSELF, from the
+#     DISPATCHED ref, so its proofs can be exercised BEFORE a release leans on
+#     them. It exists because #1714 put the distribution-hop arms in that job,
+#     AHEAD of the uploads: unprovable, the first thing to discover a broken arm
+#     would be a blocked release cut. No tag is involved (`RELEASE_TAG` resolves
+#     to the dispatched ref, the two tag-comparing steps opt out) and
+#     arch/rpm/docker/publish are skipped — `deb` still uploads its artifact, so
+#     it is the `publish` exclusion, not an empty artifact set, that keeps
+#     branch-built packages off a real release. Run it with:
+#       gh workflow run release.yml --ref <branch> -f deb_validation=true
 #
 # The tag-push path is unchanged by the dry-run plumbing: the default publishes.
 # A normal main-branch push never triggers this workflow (ci.yml + integration.yml
@@ -122,6 +133,11 @@ on:
         required: false
         type: boolean
         default: false
+      deb_validation:
+        description: "Zero-publication validation of the .deb job: build + install the package from the DISPATCHED ref (branch) and run its proofs, including the #1714 distribution-hop arms. No tag involved, NOTHING published. Skips arch/rpm/docker/publish."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -133,16 +149,26 @@ permissions:
 jobs:
   deb:
     name: build + prove .deb (amd64)
-    # Runs on a tag push and on a repair dispatch (unchanged). Skipped ONLY on a
-    # docker-image dry-run dispatch (docker_validation=true), which validates the
-    # release-image job alone and must publish nothing.
+    # Runs on a tag push, on a repair dispatch, and — since #1714 — on a
+    # deb-validation dispatch, which needs no change here: that path sets
+    # docker_validation=false, so the condition already admits it. Skipped ONLY
+    # on a docker-image dry-run dispatch (docker_validation=true), which
+    # validates the release-image job alone and must publish nothing.
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation) }}
     runs-on: ubuntu-latest
     env:
       # The release tag, resolved from whichever trigger fired: the input on a
       # manual repair dispatch, else the pushed tag. Every tag reference in this
       # job uses it (never bare GITHUB_REF_NAME, which is `main` on a dispatch).
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      #
+      # #1714 — on a deb-validation dispatch there IS no tag: the point is to
+      # prove this job's own steps from a branch, before a release leans on
+      # them. `inputs.tag` is ignored there and this resolves to the dispatched
+      # ref, so the checkout below takes the BRANCH. The two steps that compare
+      # against a tag opt out explicitly rather than being fed a branch name
+      # and asked to pretend.
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && !inputs.deb_validation && inputs.tag || github.ref_name }}
+      DEB_VALIDATION: ${{ github.event_name == 'workflow_dispatch' && inputs.deb_validation }}
     steps:
       - name: Checkout (tags for #391 version derivation)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -159,8 +185,20 @@ jobs:
       - name: Verify the tag matches the VERSION file
         id: ver
         run: |
-          tag="${RELEASE_TAG#v}"
           srcv="$(infra/packaging/version.sh)"
+
+          # #1714 — a deb-validation dispatch builds a BRANCH: there is no tag
+          # to match, and matching a branch name against VERSION would fail for
+          # a reason that has nothing to do with what is being validated. The
+          # VERSION file is the single source either way (§ version.sh), so it
+          # supplies the number directly here.
+          if [ "$DEB_VALIDATION" = "true" ]; then
+            echo "deb-validation dispatch: no tag involved; version from VERSION ($srcv)"
+            echo "version=$srcv" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tag="${RELEASE_TAG#v}"
           echo "tag=$tag VERSION=$srcv"
           if [ "$tag" != "$srcv" ]; then
             echo "::error::tag v$tag does not match the VERSION file ($srcv) — bump VERSION before cutting the tag"
@@ -217,7 +255,16 @@ jobs:
             exit 1
           fi
 
+      # #1714 — skipped on a deb-validation dispatch, and the reason is this
+      # step's own contract: #391 says a CLEAN TAG makes `Grappa.Version` report
+      # the bare `X.Y.Z`. A branch is by definition not that — `git describe
+      # --exact-match` finds nothing and the release correctly reports the
+      # unreleased `X.Y.Z-<sha>`. Asserting the bare form there would fail on
+      # the version machinery working exactly as designed. The sibling proof
+      # below (the nfpm package stamp) derives from VERSION, not from a tag, and
+      # so keeps running on both paths.
       - name: Prove the artifact reports the bare tag version
+        if: ${{ env.DEB_VALIDATION != 'true' }}
         run: |
           want="${{ steps.ver.outputs.version }}"
           # Sentinel-prefix the printed version so a stray stdout line from the
@@ -487,8 +534,10 @@ jobs:
 
   arch:
     name: build + prove Arch pkg (x86_64)
-    # See the deb job: skipped only on a docker-image dry-run dispatch.
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation) }}
+    # See the deb job: skipped on either dry-run dispatch — the docker-image one
+    # and, since #1714, the deb one (which proves the deb job alone and must
+    # publish nothing).
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && !inputs.deb_validation) }}
     runs-on: ubuntu-latest
     container: archlinux:latest
     env:
@@ -707,8 +756,9 @@ jobs:
 
   rpm:
     name: build + prove .rpm (x86_64)
-    # See the deb job: skipped only on a docker-image dry-run dispatch.
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation) }}
+    # See the deb job: skipped on either dry-run dispatch — the docker-image one
+    # and, since #1714, the deb one.
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && !inputs.deb_validation) }}
     runs-on: ubuntu-latest
     # Pinned Fedora MAJOR (not :latest): a release artifact's glibc floor must
     # not move under us (#438 open-q2). The rule: the OLDEST still-supported
@@ -956,7 +1006,11 @@ jobs:
     #
     # A repair dispatch with an EMPTY tag input is not a repair: it falls through
     # to no job at all, rather than silently republishing main as some tag.
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_validation) || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && inputs.tag != '') }}
+    # #1714 adds one exclusion to the repair arm: a deb-validation dispatch
+    # proves the deb job alone and must not build images nobody asked for. The
+    # docker_validation arm is untouched — asking for both dry-runs at once is
+    # contradictory but harmless, since neither publishes anything.
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_validation) || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && !inputs.deb_validation && inputs.tag != '') }}
     runs-on: ubuntu-latest
     # Job-level permissions REPLACE the workflow default (contents: write) for
     # this job — so re-grant `contents: read` for checkout and ADD
@@ -1241,7 +1295,11 @@ jobs:
     # obtained, this job FAILS. A smoke test that quietly passes having tested
     # nothing is worse than not having one, and a repair is precisely the run
     # you least want to take on trust: it publishes a mixed tree.
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_validation) || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && inputs.tag != '') }}
+    # #1714 adds one exclusion to the repair arm: a deb-validation dispatch
+    # proves the deb job alone and must not build images nobody asked for. The
+    # docker_validation arm is untouched — asking for both dry-runs at once is
+    # contradictory but harmless, since neither publishes anything.
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_validation) || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && !inputs.deb_validation && inputs.tag != '') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1338,7 +1396,13 @@ jobs:
     # the attach step, not here, because it needs the downloaded asset set.
     # ALSO skipped on a docker-image dry-run dispatch (its needs are skipped and
     # there is nothing to publish) — else it would fail "no artifacts present".
-    if: ${{ !cancelled() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation)) }}
+    # 🔴 And, since #1714, on a deb-validation dispatch — where the exclusion is
+    # not about empty artifacts but about REACH: that path builds a BRANCH, and
+    # publishing would attach branch-built assets to a real release. `deb` DOES
+    # run there and does upload its artifact, so the "nothing downloaded" guard
+    # would not have caught it. This condition is the only thing standing
+    # between a validation run and a published release.
+    if: ${{ !cancelled() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && !inputs.deb_validation)) }}
     runs-on: ubuntu-latest
     env:
       # The release to attach to — the input on a repair dispatch, else the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61021,3 +61021,96 @@ first run is the case the CLI exists for — so a substrate that cannot
 raise distribution simply always takes it, and the credential lands
 `:parked` exactly as ruled. What the jail can lose is the convenience,
 never the honesty.
+<!-- entry #1714 -->
+
+---
+
+## 2026-08-24 — #1714: gating the release CLI's distribution hop, and how many arms that is
+
+#1685 taught `grappa add-network` to cross out of its transient `eval` VM
+into the running bouncer as Erlang terms. Every branch of that hop was
+proven by hand exactly once. This is the gate — three arms at the tail of
+`release.yml`'s `deb` job — and the reasoning that picked three.
+
+### The criterion: gate what only the substrate can falsify
+
+The issue asked for "both branches", which is how its author named the
+pair they had in mind, not a count. `Grappa.Release.LiveNode.reach/2`
+distinguishes **five** transport outcomes before the far side is reached:
+`:no_release_node`, `:distribution_disabled`, `:no_distribution`,
+`:unreachable`, and the `{:ok, :started}` round trip.
+
+Three are gated in CI. Each is a **state of the deployment** — is epmd
+up? is the node up? — and turns on systemd, epmd, the release cookie and
+the node name ERTS derives. No in-process test can make any of them true
+or false.
+
+Two are not, and stay where they already are. `:no_release_node` and
+`:distribution_disabled` are refusals taken **before any I/O**, on the
+value of one environment variable, and
+`test/grappa/release/live_node_test.exs` covers both. An arm would
+re-read the same `System.get_env` through a slower door: CI minutes, no
+extra falsifying power.
+
+So the rule this leaves behind is not "gate every branch" and not "gate
+the two the issue named" — it is **gate the outcomes the substrate owns,
+and leave the ones a unit test owns to the unit test**.
+
+### `systemctl stop` does not give you the second offline shape
+
+#1685 measured that there are two no-live-node shapes, not one: with no
+epmd `:net_kernel.start/2` itself fails `:nodistribution`; with epmd up
+and the node down it succeeds and `Node.connect/1` returns false. The
+obvious way to stage the second — start the service, then stop it — does
+**not** work. `grappa.service` sets no `KillMode`, so systemd's default
+`control-group` applies and the stop takes epmd down *with* the node,
+landing back in the first shape with a green tick and the wrong claim
+tested.
+
+The arm therefore starts `epmd -daemon` from the installed release's own
+ERTS, outside the unit's cgroup. That is not a contrivance: on a real
+host epmd outlives the service precisely because something outside the
+unit started it.
+
+Each arm also **asserts its own premise** (`pgrep -x epmd` before arm 1,
+after arm 2; `/healthz` before arm 3). An arm that silently finds itself
+in another arm's state would otherwise report a green for a claim it
+never made.
+
+### What is asserted, and two things that are not
+
+Not the exit status: `Grappa.Release.CLI` returns 0 in every branch on
+purpose, so that `create-user && add-network && start the service` does
+not break on the case that has no live node by definition. The gate reads
+stdout and the row instead.
+
+Not `connection_state = 'connected'` on the live arm either. Since #1675
+`:connected` means *registered upstream*, and the arm points at
+`127.0.0.1:6667` with nothing listening, so the row settles to `:failing`
+on its own — pinning either value races. What the arm exists to prove is
+that the hop **landed**: the transport promoted the row out of `:parked`,
+which nothing on the CLI side can fake.
+
+### Placement, and a spec line that fell to a grep
+
+The issue put the steps "right after Install both packages". That would
+run the live arm — which must START the service — before every existing
+proof in the job, leaving a daemon nobody asked for running underneath
+them. A proof that runs with unrequested state up no longer proves what
+it says it proves. The arms go last among the proofs, and still ahead of
+the uploads, so a failed arm keeps the artifacts unpublished.
+
+The issue also said the job "needs no new scaffolding". Measured: the
+postinstall `enable`s the unit and deliberately does **not** start it (a
+real `PHX_HOST` must be set first; the env file ships `REPLACE_ME`), and
+no workflow in this repo had ever run `systemctl` or probed `/healthz` —
+zero hits across `.github/workflows/*.yml`. The offline arms are free;
+the live arm is scaffolding, and saying so cost one grep.
+
+### Limits, stated rather than discovered later
+
+`release.yml` fires on a **tag**, so these arms prove the hop at
+release-cut time and not on the pull request that changes it. And GitHub
+offers no FreeBSD runner — every `runs-on:` in this repo is
+`ubuntu-latest` — so the bastille jail keeps its manual probe. Both are
+accepted, neither is an oversight.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61107,10 +61107,65 @@ no workflow in this repo had ever run `systemctl` or probed `/healthz` —
 zero hits across `.github/workflows/*.yml`. The offline arms are free;
 the live arm is scaffolding, and saying so cost one grep.
 
-### Limits, stated rather than discovered later
+### A gate you cannot execute is not a gate
 
-`release.yml` fires on a **tag**, so these arms prove the hop at
-release-cut time and not on the pull request that changes it. And GitHub
-offers no FreeBSD runner — every `runs-on:` in this repo is
-`ubuntu-latest` — so the bastille jail keeps its manual probe. Both are
-accepted, neither is an oversight.
+The first cut of this shipped unexecuted, with the limit written down
+honestly — `release.yml` fires on a tag, so the arms would first run
+during a release. That honesty was not enough, and the ruling says why:
+the arms sit AHEAD of the uploads, so the first person to learn one was
+broken would be whoever cuts the next release, holding a blocked cut and
+no explanation. Writing a limit down does not pay for it.
+
+The existing dispatch is not the way out, measured: the repair path
+checks out the TAG's tree, the newest tag is `v1.3.1`, and
+`live_node.ex` does not exist there — it would build a package with no
+transport in it and fail all three arms for a reason that is not a
+defect. Worse, it reaches `publish`, which runs even on a red leg, and
+would re-attach assets to a release that is already out.
+
+So `deb_validation` was added: the twin of `docker_validation`, which is
+already exactly this shape for the image job — a zero-publication dry run
+of the deb job ITSELF, from the dispatched ref. Not new machinery; the
+pattern was in the file. Five points, all inside `release.yml`: the
+input; `RELEASE_TAG` resolving to the dispatched ref plus a
+`DEB_VALIDATION` flag; the tag/VERSION gate taking its number from the
+file; the bare-tag version proof opting out (a branch is not a clean tag,
+and #391's contract is about clean tags — asserting the bare form there
+would fail on the version machinery working as designed); and
+arch/rpm/docker/smoke/publish skipping. The deb job's own `if:` needed
+none — that path sets `docker_validation=false`, which it already admits.
+
+**The `publish` exclusion is the load-bearing one, and it is not about
+empty artifacts.** `deb` DOES run on this path and DOES upload, so the
+"nothing downloaded" guard would not have caught it. That one condition
+is the whole distance between a validation run and branch-built packages
+on a real release.
+
+The tag-push path is unchanged BY CONSTRUCTION rather than by review:
+`github.event_name == 'push'` is the first disjunct of every condition
+touched, so it short-circuits before any new term is evaluated.
+
+Then the arms were run — [run
+32706000296](https://github.com/vjt/grappa-irc/actions/runs/32706000296),
+`deb` success, every other job skipped, no release touched:
+
+```
+arm 1  epmd: not running (arm premise holds)
+       Protocol 'inet_tcp': register/listen error: econnrefused
+       the binding is PARKED: nothing is listening on epmd…   → 'parked'
+arm 2  epmd: running, no node registered (arm premise holds)
+       the binding is PARKED: the live node did not answer…   → 'parked'
+arm 3  service: healthy (arm premise holds)
+       started a session on the live node                     → 'connected'
+```
+
+Arm 3 landing on `connected` rather than `failing` is exactly why that
+assertion accepts both: the row had not settled when the query ran, and a
+slower runner catches the other value. Pinning either would have been a
+race dressed as a check.
+
+### The limit that stands
+
+GitHub offers no FreeBSD runner — every `runs-on:` in this repo is
+`ubuntu-latest` — so the bastille jail keeps its manual probe. Accepted,
+not an oversight.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -196,6 +196,21 @@ their env file) and `RELEASE_DISTRIBUTION` not set to `none`. A cookie
 mismatch is indistinguishable from a stopped node at the CLI end and
 prints as "did not answer".
 
+**How the hop is gated (#1714).** Three arms at the tail of
+`release.yml`'s `deb` job, on the installed `.deb`: no epmd at all (the
+first-run box), epmd up with no node answering, and the live hop against
+a started service. Each asserts the operator-facing line AND the row —
+never the exit status, which is 0 by design (above). The two remaining
+transport outcomes, `:no_release_node` and `:distribution_disabled`, are
+refusals taken before any I/O on one environment variable and stay in
+`test/grappa/release/live_node_test.exs`: the substrate cannot make them
+any truer. **Two limits, both deliberate.** The arms run on a TAG (that
+is when `release.yml` fires), so a change to the hop is proven at
+release-cut time and not on the pull request that makes it. And GitHub
+offers no FreeBSD runner — every `runs-on:` in this repo is
+`ubuntu-latest` — so the bastille jail stays covered by the manual probe
+alone.
+
 ### Per-server outbound source address (`--source`)
 
 `bind-network` and `add-server` accept `--source <ip>` to pin the

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -204,12 +204,28 @@ never the exit status, which is 0 by design (above). The two remaining
 transport outcomes, `:no_release_node` and `:distribution_disabled`, are
 refusals taken before any I/O on one environment variable and stay in
 `test/grappa/release/live_node_test.exs`: the substrate cannot make them
-any truer. **Two limits, both deliberate.** The arms run on a TAG (that
-is when `release.yml` fires), so a change to the hop is proven at
-release-cut time and not on the pull request that makes it. And GitHub
-offers no FreeBSD runner — every `runs-on:` in this repo is
-`ubuntu-latest` — so the bastille jail stays covered by the manual probe
-alone.
+any truer.
+
+**Running them without cutting a tag.** `release.yml` fires on a `v*`
+tag, so left alone these arms would first execute during a release — and
+they sit AHEAD of the uploads, so a broken one blocks that release. The
+`deb_validation` dispatch is the door out of that: a zero-publication dry
+run of the deb job itself, from a branch.
+
+```
+gh workflow run release.yml --ref <branch> -f deb_validation=true
+```
+
+No tag is involved (`RELEASE_TAG` resolves to the dispatched ref and the
+two tag-comparing steps opt out) and `arch` / `rpm` / `docker` / `smoke` /
+`publish` all skip. The `publish` exclusion is the load-bearing one: `deb`
+DOES run and DOES upload its artifact there, so without it a branch-built
+package would be attached to a real release. Sibling of the older
+`docker_validation`, same posture.
+
+**One limit stands.** GitHub offers no FreeBSD runner — every `runs-on:`
+in this repo is `ubuntu-latest` — so the bastille jail stays covered by
+the manual probe alone.
 
 ### Per-server outbound source address (`--source`)
 


### PR DESCRIPTION
Three arms at the tail of `release.yml`'s `deb` job hold the distribution
hop #1685 introduced. Refs #1714, #1685.

## How many arms, and the criterion

The issue asked for "both branches". `Grappa.Release.LiveNode.reach/2`
distinguishes **five** transport outcomes, so the count came from the code
instead:

| outcome | gated where | why |
|---|---|---|
| `:no_distribution` (no epmd) | **CI arm 1** | state of the deployment |
| `:unreachable` (epmd up, node down) | **CI arm 2** | state of the deployment |
| `{:ok, :started}` | **CI arm 3** | needs systemd + cookie + derived node name |
| `:no_release_node` | `live_node_test.exs:66` | refusal before any I/O, on one env var |
| `:distribution_disabled` | `live_node_test.exs:72` | refusal before any I/O, on one env var |

**Criterion: gate the outcomes the substrate owns; leave to the unit test
the ones a unit test already owns.** An arm for the bottom two would
re-read the same `System.get_env` through a slower door — CI minutes, no
extra falsifying power.

## Two places the spec was wrong, both measured

**"Right after Install both packages."** That runs the live arm — which
must START the service — before every existing proof in the job, leaving a
daemon nobody asked for running underneath them. A proof that runs with
unrequested state up no longer proves what it says it proves. The arms go
last among the proofs, still ahead of the uploads, so a failed arm keeps
the artifacts unpublished.

**"Needs no new scaffolding."** The postinstall `enable`s the unit and
deliberately does NOT start it (`postinstall.sh:68-74` — a real `PHX_HOST`
must be set first; the env file ships `REPLACE_ME`), and no workflow in
this repo had ever run `systemctl` or probed `/healthz`: zero hits across
`.github/workflows/*.yml`. The offline arms are free; the live arm is
genuinely new scaffolding.

## Two measurements that shaped the arms

**`systemctl stop` does not stage the second offline shape.**
`grappa.service` sets no `KillMode`, so systemd's default `control-group`
takes epmd down *with* the node and lands back in arm 1 — a green tick on
the wrong claim. Arm 2 starts `epmd -daemon` from the installed release's
own ERTS instead, outside the unit's cgroup, which is how epmd outlives
the service on a real host anyway.

**Each arm asserts its own premise** (`pgrep -x epmd` before arm 1 and
after arm 2, `/healthz` before arm 3). An arm that silently found itself
in a neighbour's state would otherwise report green for a claim it never
made.

## What is deliberately NOT asserted

- **The exit status.** `Grappa.Release.CLI` returns 0 in every branch on
  purpose (`cli.ex:263-268`), so `create-user && add-network && start the
  service` does not break on the case that has no live node by definition.
- **`connection_state = 'connected'`** on the live arm. Since #1675 that
  means *registered upstream*, and the arm points at `127.0.0.1:6667` with
  nothing listening, so the row settles to `:failing` on its own — pinning
  either value races. The arm asserts the row **left `:parked`**, which is
  what the hop does and what nothing on the CLI side can fake.

## Limits, stated rather than discovered later

- ~~`release.yml` fires on a tag, so these arms will not run on this PR.~~
  **No longer true.** A `deb_validation` dispatch now runs the deb job — and
  its arms — from a branch, with nothing published. They have been executed:
  [run 32706000296](https://github.com/vjt/grappa-irc/actions/runs/32706000296),
  all three green, `publish` skipped, no release touched. See the comment
  below for the output lines.
- GitHub offers no FreeBSD runner (every `runs-on:` here is
  `ubuntu-latest`), so the bastille jail keeps its manual probe. Accepted
  in the issue, restated in the docs.

## Verification

`shellcheck` clean on all four new `run` blocks; YAML parses and the steps
land in the intended order; `scripts/design-notes-gate.sh` green; full
`scripts/check.sh` reported below once it settles.

— w2
