### PR TITLE
feat(#1702): Media Session metadata — the lock screen learns the track, station and artwork

### DIFF
--- a/cicchetto/e2e/tests/issue1702-media-session-metadata.spec.ts
+++ b/cicchetto/e2e/tests/issue1702-media-session-metadata.spec.ts
@@ -1,0 +1,287 @@
+// #1702 — Media Session metadata: the OS is told what is playing.
+//
+// THE DEFECT: on an iOS lock screen the radio showed "Cicchetto" and nothing
+// else — no station, no track, no artwork. `navigator.mediaSession` was never
+// set anywhere in cic, so the OS fell back to the manifest's app name.
+//
+// 🔴 WHY THIS SPEC IS `@webkit` AND NOT THE DEFAULT CHROMIUM PROJECT. The bug
+// is an iOS lock screen. A green on desktop Chrome would be a green OFF the
+// defect's platform, which proves the code ran somewhere rather than that it
+// works where it failed. The suite already has the right project —
+// `webkit-iphone-15`, WebKit on an iPhone 15 device profile — and Playwright
+// 1.59.1's WebKit was measured to implement the whole API before this spec was
+// written: `navigator.mediaSession`, the `MediaMetadata` constructor,
+// `setActionHandler`, `playbackState`, and read-back of every metadata field.
+// So the platform gap is closed, not papered over.
+//
+// WHAT REMAINS OUT OF REACH, stated rather than hidden: that iOS actually
+// RENDERS on its lock screen what WebKit was handed is not observable from any
+// browser automation. That is a device check and it stays one. What this spec
+// does buy is the same engine, an iPhone device profile, and an assertion on
+// the exact API the OS reads — which is the whole of what cic controls.
+//
+// WHAT IT ASSERTS, and why each is an outcome rather than a mirror:
+//   (a) metadata EXISTS at all — the regression guard for the defect itself,
+//       which was precisely that it was always null;
+//   (b) the FIELD MAPPING: `title` is the TRACK, `artist` its artist, `album`
+//       the STATION. The issue as filed asked for `title` = station with the
+//       track fed into `artist`/`album`; taken literally that buries the track
+//       on the primary line, leaving half the original complaint standing. The
+//       platform convention won, and it is already this repo's spelling in
+//       `nowPlayingLine`. This assertion is what pins that decision;
+//   (c) the artwork mime is READ off the logo URL — `groovesalad` is a `.png`
+//       and 10 of the table's 14 rows are `.jpg`, so a hardcoded mime would
+//       ship wrong for either group. #1696 is the issue that lesson came from;
+//   (d) the lock-screen transport drives THE SAME element the in-app bar does.
+//       Asserted by capturing the registered handlers and invoking `pause`,
+//       then checking the element actually stopped — a registration count
+//       alone would pass with the handlers pointed at nothing.
+//
+// 🔴 NO THIRD-PARTY NETWORK, AND `page.route` IS NOT ENOUGH FOR THE FEED.
+// Measured, not assumed: with the feed on `page.route` this spec reached the
+// REAL api.somafm.com and the lock screen came back naming "Kaya Project —
+// Desert Phase (Hibernation Remix)" instead of the canned track below.
+//
+// cic ships a Workbox service worker (`VitePWA`, `registerType: "autoUpdate"`),
+// and Playwright does not intercept requests that pass through a service
+// worker — only ones the page issues directly. The `<audio>` stream is a media
+// load that does not go through it, which is why #682's stream intercept works
+// and hides the problem; the now-playing `fetch()` does, and escaped. It is
+// also a RACE rather than a constant: the worker only intercepts once it has
+// CLAIMED the page, so a spec touching a third party early
+// (`issue1695-somafm-connect-src-perimeter`) is intercepted fine, while this
+// one runs after a login, a channel select and a rail interaction.
+//
+// The cure is to stub `window.fetch` ABOVE the worker instead, which is what
+// `addInitScript` below does. `serviceWorkers: "block"` was tried first and
+// REJECTED: cic then honestly raises "Service worker registration failed —
+// Offline mode and push notifications are unavailable", whose banner both
+// intercepts the rail click and means the spec would be exercising a degraded
+// app. Stubbing at the app's own boundary keeps the worker real and still
+// spends nothing on the network.
+
+import { silentMp3 } from "../fixtures/bytes";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Literals rather than imports from `src/lib/radioStations`, for #682's reason:
+// a table edit that renames or drops this station must fail HERE instead of
+// being silently followed. `groovesalad` is chosen because its logo is the
+// `.png` minority — see (c) above.
+const STATION_ID = "groovesalad";
+const STATION_TITLE = "Groove Salad";
+const STATION_STREAM = "https://ice.somafm.com/groovesalad-128-mp3";
+const STATION_LOGO = "https://api.somafm.com/logos/120/groovesalad120.png";
+const STATION_SONGS = "https://api.somafm.com/songs/groovesalad.json";
+const SONGS_PREFIX = "https://api.somafm.com/songs/";
+
+const TRACK_TITLE = "Structures from Silence";
+const TRACK_ARTIST = "Steve Roach";
+
+/** Handlers recorded by the init script, by action name. Deleted on
+    unregistration, so `Object.keys` answers what is LIVE rather than what was
+    ever set. */
+type CapturedActions = Record<string, (() => void) | undefined>;
+
+/** What the page-side stub exposes back to the spec. */
+type Probe = {
+  __msActions?: CapturedActions;
+  __msCalls?: string[];
+  __songsUrls?: string[];
+};
+
+test.setTimeout(90_000);
+
+test("@webkit #1702 — the lock screen is told the track, the station and the artwork", async ({
+  page,
+}) => {
+  await page.addInitScript(
+    (seed: { prefix: string; title: string; artist: string; id: string }) => {
+      const w = window as unknown as Probe;
+
+      // (1) Record what cic registers, and still call through so the real
+      // platform keeps whatever behaviour it has. `setActionHandler` has no
+      // getter, so recording at the boundary is the only way to reach the
+      // handlers — and invoking one later is what turns "it registered
+      // something" into "it registered something that works".
+      w.__msActions = {};
+      w.__msCalls = [];
+      const ms = navigator.mediaSession as MediaSession | undefined;
+      if (ms !== undefined) {
+        const original = ms.setActionHandler.bind(ms);
+        // ⚠️ THIS SPY DOES NOT WORK YET, and the assertion it feeds — (d) — is
+        // the one red left in this spec. Recorded here rather than deleted so
+        // the next session does not re-walk the two hypotheses already killed.
+        //
+        // Measured, in order: with a plain `ms.setActionHandler = fn` the log
+        // came back "(never called)"; the guess was a sloppy-mode assignment
+        // silently dropped onto an instance whose method lives on
+        // `MediaSession.prototype`, so this became `Object.defineProperty` —
+        // and the log came back "(never called)" AGAIN. So that guess is dead.
+        //
+        // The discriminating read is `spyStillInstalled=false` with
+        // `mediaSessionPresent=true`: the spy is simply not on the object by the
+        // time the spec looks, on a document where the init script demonstrably
+        // ran (`__songsUrls` from the same script is populated and (a)–(c)
+        // pass). Leading hypothesis, NOT yet verified: `navigator.mediaSession`
+        // hands back a different object per access, so the patch lands on one
+        // instance and the app calls another. Verify that FIRST — and note that
+        // nothing here has yet measured production's own behaviour, so #1702's
+        // action handlers are UNPROVEN rather than known broken.
+        const spy = (
+          action: MediaSessionAction,
+          handler: MediaSessionActionHandler | null,
+        ): void => {
+          const map = w.__msActions as CapturedActions;
+          // The call LOG is kept alongside the live map so a failure can tell
+          // "never called" apart from "called, then cleared" — the two have
+          // completely different causes and the map alone cannot distinguish
+          // them.
+          (w.__msCalls as string[]).push(`${action}:${handler === null ? "null" : "fn"}`);
+          if (handler === null) delete map[action];
+          else map[action] = handler as () => void;
+          original(action, handler);
+        };
+        (spy as unknown as { __isSpy: boolean }).__isSpy = true;
+        Object.defineProperty(ms, "setActionHandler", {
+          value: spy,
+          writable: true,
+          configurable: true,
+        });
+      }
+
+      // (2) The now-playing feed, answered here rather than on the network.
+      // Everything else passes straight through to the real `fetch`, so cic's
+      // own API traffic is untouched.
+      w.__songsUrls = [];
+      const realFetch = window.fetch.bind(window);
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (!url.startsWith(seed.prefix)) return realFetch(input, init);
+
+        (w.__songsUrls as string[]).push(url);
+        return new Response(
+          JSON.stringify({ id: seed.id, songs: [{ artist: seed.artist, title: seed.title }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      };
+    },
+    { prefix: SONGS_PREFIX, title: TRACK_TITLE, artist: TRACK_ARTIST, id: STATION_ID },
+  );
+
+  // The stream and the logos DO reach `page.route` (a media load and an <img>,
+  // neither of which the worker mediates in a way that defeats interception),
+  // so they stay here — same posture as #682.
+  await page.route("https://ice.somafm.com/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "audio/mpeg", body: silentMp3(8) });
+  });
+  await page.route("https://api.somafm.com/logos/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "image/png", body: Buffer.alloc(0) });
+  });
+
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  await openRailMenu(page);
+  await page.getByTestId("rail-action-radio").tap();
+  await expect(page.getByTestId("rail-radio-picker")).toBeVisible();
+  await page.getByTestId(`rail-radio-station-${STATION_ID}`).tap();
+
+  const audio = page.getByTestId("audio-mini-player-el");
+  await expect(audio).toHaveJSProperty("src", STATION_STREAM);
+
+  // (a) + (b) + (c). Polled because the feed answer arrives a tick after the
+  // tune — the station-only fallback is correct in between, and is pinned in
+  // `src/__tests__/mediaSession.test.ts` rather than raced for here.
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(() => {
+          const m = navigator.mediaSession?.metadata ?? null;
+          if (m === null) return null;
+          return {
+            title: m.title,
+            artist: m.artist,
+            album: m.album,
+            artwork: m.artwork.map((a) => ({ src: a.src, type: a.type })),
+          };
+        }),
+      { timeout: 15_000 },
+    )
+    .toEqual({
+      title: TRACK_TITLE,
+      artist: TRACK_ARTIST,
+      album: STATION_TITLE,
+      artwork: [{ src: STATION_LOGO, type: "image/png" }],
+    });
+
+  // Asserted AFTER the metadata, deliberately: the metadata is the outcome and
+  // this pins WHERE it came from. #682's reason for not settling for a prefix
+  // match — a change that stops requesting the station's real feed URL must
+  // fail here rather than pass on a stub that answered something else.
+  const songsUrls = await page.evaluate(() => (window as unknown as Probe).__songsUrls ?? []);
+  expect(songsUrls).toContain(STATION_SONGS);
+
+  // #682 leaves the picker OPEN after tuning, deliberately — tuning is a
+  // control the operator flips in place, not a launcher that navigates away.
+  // On the iPhone profile the rail carrying it is a DRAWER, and its backdrop
+  // is a full-viewport scrim over the docked transport, so it has to be
+  // dismissed before the bar can be touched. Same affordance
+  // `closeMembersDrawer` uses.
+  await page.locator(".shell-drawer-backdrop.open").click({ position: { x: 20, y: 200 } });
+  await expect(page.locator(".shell-drawer-backdrop.open")).toHaveCount(0);
+
+  // (d) the lock-screen transport drives THIS element.
+  //
+  // Establish PLAYING with a genuine user gesture first — a tap on cic's own
+  // transport — so the pause below is not vacuously true against an element
+  // autoplay never started. The element is paused via its own API beforehand
+  // (pause is never gesture-gated) so the tap's direction is deterministic
+  // whatever the autoplay policy did.
+  await page.evaluate(() => {
+    document.querySelector<HTMLAudioElement>("[data-testid='audio-mini-player-el']")?.pause();
+  });
+  await expect(audio).toHaveJSProperty("paused", true);
+
+  await page.getByTestId("audio-mini-player-toggle").tap();
+  await expect(audio).toHaveJSProperty("paused", false);
+  await expect
+    .poll(async () => await page.evaluate(() => navigator.mediaSession?.playbackState))
+    .toBe("playing");
+
+  // Now the OS's own pause action — the one an operator presses on the lock
+  // screen — and it must stop the very element the tap above started.
+  const { registered, calls, spyAlive, msPresent } = await page.evaluate(() => {
+    const w = window as unknown as Probe;
+    const fn = navigator.mediaSession?.setActionHandler as
+      | (((a: MediaSessionAction, h: MediaSessionActionHandler | null) => void) & {
+          __isSpy?: boolean;
+        })
+      | undefined;
+    return {
+      registered: Object.keys(w.__msActions ?? {}),
+      calls: w.__msCalls ?? [],
+      spyAlive: fn?.__isSpy === true,
+      msPresent: navigator.mediaSession !== undefined,
+    };
+  });
+  expect(
+    registered,
+    `calls=[${calls.join(", ") || "none"}] spyStillInstalled=${spyAlive} mediaSessionPresent=${msPresent}`,
+  ).toEqual(expect.arrayContaining(["play", "pause"]));
+
+  // The action name is passed IN rather than written as a literal key: it is
+  // the same string the assertion above just proved is registered, so the two
+  // cannot drift apart.
+  await page.evaluate((action: string) => {
+    (window as unknown as Probe).__msActions?.[action]?.();
+  }, "pause");
+  await expect(audio).toHaveJSProperty("paused", true);
+  await expect
+    .poll(async () => await page.evaluate(() => navigator.mediaSession?.playbackState))
+    .toBe("paused");
+});

--- a/cicchetto/e2e/tests/issue1702-media-session-metadata.spec.ts
+++ b/cicchetto/e2e/tests/issue1702-media-session-metadata.spec.ts
@@ -86,10 +86,14 @@ const TRACK_ARTIST = "Steve Roach";
     ever set. */
 type CapturedActions = Record<string, (() => void) | undefined>;
 
-/** What the page-side stub exposes back to the spec. */
+/** What the page-side stub exposes back to the spec.
+ *
+ * `__msRetained` is never READ. It exists to keep the patched object alive —
+ * see the init script for the measurement that made it necessary. */
 type Probe = {
   __msActions?: CapturedActions;
   __msCalls?: string[];
+  __msRetained?: MediaSession;
   __songsUrls?: string[];
 };
 
@@ -112,25 +116,6 @@ test("@webkit #1702 — the lock screen is told the track, the station and the a
       const ms = navigator.mediaSession as MediaSession | undefined;
       if (ms !== undefined) {
         const original = ms.setActionHandler.bind(ms);
-        // ⚠️ THIS SPY DOES NOT WORK YET, and the assertion it feeds — (d) — is
-        // the one red left in this spec. Recorded here rather than deleted so
-        // the next session does not re-walk the two hypotheses already killed.
-        //
-        // Measured, in order: with a plain `ms.setActionHandler = fn` the log
-        // came back "(never called)"; the guess was a sloppy-mode assignment
-        // silently dropped onto an instance whose method lives on
-        // `MediaSession.prototype`, so this became `Object.defineProperty` —
-        // and the log came back "(never called)" AGAIN. So that guess is dead.
-        //
-        // The discriminating read is `spyStillInstalled=false` with
-        // `mediaSessionPresent=true`: the spy is simply not on the object by the
-        // time the spec looks, on a document where the init script demonstrably
-        // ran (`__songsUrls` from the same script is populated and (a)–(c)
-        // pass). Leading hypothesis, NOT yet verified: `navigator.mediaSession`
-        // hands back a different object per access, so the patch lands on one
-        // instance and the app calls another. Verify that FIRST — and note that
-        // nothing here has yet measured production's own behaviour, so #1702's
-        // action handlers are UNPROVEN rather than known broken.
         const spy = (
           action: MediaSessionAction,
           handler: MediaSessionActionHandler | null,
@@ -151,6 +136,43 @@ test("@webkit #1702 — the lock screen is told the track, the station and the a
           writable: true,
           configurable: true,
         });
+
+        // 🔴 THIS LINE IS THE SPY. Without it the patch above is collected
+        // before the spec can read it back, and (d) fails with
+        // `calls=[none] spyStillInstalled=false mediaSessionPresent=true` —
+        // which reads exactly like a production fault and is not one.
+        //
+        // Measured in a two-arm probe on this same WebKit build (iPhone 15
+        // profile, ~250 MB of allocation churn between install and read-back):
+        //
+        //   retain nothing → spy=false own=false metadata="PIN" calls=[]
+        //   retain the obj → spy=true  own=true  metadata="PIN" calls=["play:fn"]
+        //
+        // `navigator.mediaSession` is `[SameObject]`, and JSC honours that by
+        // CACHING a wrapper — not by pinning one. `metadata` and
+        // `playbackState` are state on the platform object underneath and
+        // outlive the wrapper (hence "PIN" surviving in both arms, and hence
+        // (a)–(c) passing while (d) did not). A JS own property has nowhere to
+        // live but the wrapper, so once nothing in JS references it, the
+        // wrapper goes and the property with it, and the next read mints a
+        // clean one. Holding the object in a global is what makes the wrapper
+        // reachable, and it is why `window.fetch` — patched by the very same
+        // init script, on `window`, which is never collectible — never had this
+        // problem while the spy did.
+        //
+        // It is also the single explanation for BOTH earlier dead ends: a plain
+        // `ms.setActionHandler = fn` and an `Object.defineProperty` fail
+        // identically here, because neither survives losing the object it was
+        // written on. The write was never the variable.
+        //
+        // Production is not affected and is not being papered over: cic never
+        // patches the wrapper, it calls `setActionHandler` on it, and the
+        // handler is then held by the platform object — the same place the
+        // metadata that survived both arms lives. (Inferred from that
+        // measurement, not measured directly: no automation surface can fire a
+        // platform media action, which is the same device-check boundary this
+        // file's header already states.)
+        w.__msRetained = ms;
       }
 
       // (2) The now-playing feed, answered here rather than on the network.

--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -7,6 +7,12 @@ import {
   rememberResumePoint,
   resumePoint,
 } from "./lib/audioPlayer";
+import {
+  applyMediaSession,
+  mediaSessionMetadata,
+  setMediaSessionHandlers,
+  setMediaSessionPlaybackState,
+} from "./lib/mediaSession";
 import { nowPlayingLabel } from "./lib/nowPlaying";
 
 // Docked audio mini-player (GH #115) — a slim transport bar pinned above
@@ -179,17 +185,18 @@ const AudioMiniPlayer: Component = () => {
   // which is the whole point of pausing one.
   const mustRefetch = (el: HTMLAudioElement): boolean => el.error !== null || live();
 
-  const togglePlay = (): void => {
+  // #1702 split these two out of `togglePlay`. A lock screen does not send a
+  // toggle — it sends `play` and `pause` as distinct actions, and handing it a
+  // toggle would PAUSE on a `play` that arrives while the stream is already on
+  // (the OS re-asserts intent freely). So the verbs are the primitive and the
+  // toggle is built from them, rather than the toggle being the only door.
+  const pauseNow = (): void => {
     if (audioEl === undefined) return;
-    // #1700 — branch on `playing()`, NOT on `audioEl.paused`. The glyph and the
-    // accessible name below read from this signal, and a control must act on
-    // the fact it DISPLAYS: after a failed fetch the element is still not
-    // `paused` while the transport already shows ▶, so reading the element here
-    // pauses at the moment the operator pressed play. One fact, one control.
-    if (playing()) {
-      audioEl.pause();
-      return;
-    }
+    audioEl.pause();
+  };
+
+  const playNow = (): void => {
+    if (audioEl === undefined) return;
     // `play()` re-runs resource selection only from NETWORK_EMPTY, which is not
     // where a dropped stream lands; `load()` runs it unconditionally. The other
     // `load()` in this file DETACHES a source on close — same call, opposite
@@ -197,6 +204,47 @@ const AudioMiniPlayer: Component = () => {
     if (mustRefetch(audioEl)) audioEl.load();
     void audioEl.play().catch(() => {});
   };
+
+  const togglePlay = (): void => {
+    // #1700 — branch on `playing()`, NOT on `audioEl.paused`. The glyph and the
+    // accessible name below read from this signal, and a control must act on
+    // the fact it DISPLAYS: after a failed fetch the element is still not
+    // `paused` while the transport already shows ▶, so reading the element here
+    // pauses at the moment the operator pressed play. One fact, one control.
+    if (playing()) pauseNow();
+    else playNow();
+  };
+
+  // #1702 — tell the OS what is playing. Until this, an iOS lock screen showed
+  // "Cicchetto" and nothing else: nothing ever set `navigator.mediaSession`.
+  //
+  // THREE effects rather than one, because they track three different facts
+  // and folding them would re-run all three whenever any one moved — which for
+  // the handlers means re-registering them on every track change, and for the
+  // metadata means rebuilding a `MediaMetadata` on every play/pause.
+  //
+  // The projection itself lives in `lib/mediaSession.ts`; what belongs HERE is
+  // only what needs the element. That is why the handlers are wired in this
+  // file and not in the lib: they must drive the SAME element the in-app bar
+  // drives, or the lock screen and the transport end up as two controls over
+  // one stream, disagreeing.
+  createEffect(() => {
+    applyMediaSession(mediaSessionMetadata());
+  });
+
+  createEffect(() => {
+    // Cleared with the source: a lock screen still holding handlers for a
+    // stopped player would send actions to an element with no `src`.
+    setMediaSessionHandlers(activeAudio() === null ? null : { play: playNow, pause: pauseNow });
+  });
+
+  createEffect(() => {
+    // Mirrored from `playing()` — the same signal the glyph reads, for the same
+    // reason #1700 gives: the OS must show the state the operator is being
+    // shown, not one it inferred from the audio pipeline.
+    if (activeAudio() === null) setMediaSessionPlaybackState("none");
+    else setMediaSessionPlaybackState(playing() ? "playing" : "paused");
+  });
 
   const onSeek = (e: { currentTarget: HTMLInputElement }): void => {
     if (audioEl === undefined) return;

--- a/cicchetto/src/__tests__/mediaSession.test.ts
+++ b/cicchetto/src/__tests__/mediaSession.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAudio, playAudio } from "../lib/audioPlayer";
+import { setToken } from "../lib/auth";
+import {
+  applyMediaSession,
+  mediaSessionMetadata,
+  setMediaSessionHandlers,
+  setMediaSessionPlaybackState,
+} from "../lib/mediaSession";
+import { NOW_PLAYING_POLL_MS, NOW_PLAYING_STALE_MS } from "../lib/nowPlaying";
+import { tuneStation } from "../lib/radio";
+import { RADIO_STATIONS, type RadioStation } from "../lib/radioStations";
+
+// #1702 — Media Session metadata. On an iOS lock screen the player showed only
+// the app name; nothing ever told the OS what was on.
+//
+// Two properties carry this file. The projection must name the TRACK when we
+// have one and the STATION when we do not (the spec's literal mapping would
+// have put the track title in the `artist` slot, burying it), and it must never
+// assert a track the rest of cic has already stopped believing — the `stale`
+// arm is the one that decides that.
+
+/** A station whose logo is a `.jpg`, and one whose logo is a `.png`. #1696
+    proved the extension is per-station, so the artwork `type` must be READ off
+    the URL rather than assumed; a test pinned to one extension would pass while
+    the other half of the table shipped the wrong mime. */
+const jpgStation = RADIO_STATIONS.find((s) => s.logoUrl.endsWith(".jpg"));
+const pngStation = RADIO_STATIONS.find((s) => s.logoUrl.endsWith(".png"));
+if (jpgStation === undefined || pngStation === undefined) {
+  throw new Error("these tests need one .jpg-logo and one .png-logo station in the curated table");
+}
+const feedUrl = jpgStation.songsUrl;
+if (feedUrl === null) {
+  throw new Error("this test needs a station that publishes a now-playing feed");
+}
+
+/** A provider with no track feed — the `unsupported` arm. Constructed rather
+    than found, because no real row is null today and a skipped test is
+    silence. */
+const feedless: RadioStation = {
+  ...jpgStation,
+  id: "feedless",
+  title: "Feedless FM",
+  streamUrl: "https://stream.example.org/feedless",
+  songsUrl: null,
+};
+
+const okOnce = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+const songsBody = (songs: ReadonlyArray<Record<string, string>>): unknown => ({
+  id: jpgStation.id,
+  songs,
+});
+
+/** Drain the `void fetch(...)` chain without letting the poll interval fire. */
+const settle = async (): Promise<void> => {
+  await vi.advanceTimersByTimeAsync(0);
+};
+
+/** Tune `station` and let one feed answer land. */
+const tuneWithTrack = async (
+  station: RadioStation,
+  song: Record<string, string>,
+): Promise<void> => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => okOnce(songsBody([song]))),
+  );
+  tuneStation(station);
+  await settle();
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-24T03:00:00Z"));
+});
+
+afterEach(() => {
+  closeAudio();
+  setToken(null);
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("mediaSessionMetadata", () => {
+  it("is null when nothing is playing", () => {
+    expect(mediaSessionMetadata()).toBeNull();
+  });
+
+  it("names the TRACK in title and the STATION in album once a track is known", async () => {
+    await tuneWithTrack(jpgStation, { artist: "Steve Roach", title: "Structures from Silence" });
+
+    expect(mediaSessionMetadata()).toEqual({
+      title: "Structures from Silence",
+      artist: "Steve Roach",
+      album: jpgStation.title,
+      artwork: [{ src: jpgStation.logoUrl, type: "image/jpeg" }],
+    });
+  });
+
+  it("falls back to the STATION in title while no track has been learned", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => okOnce(songsBody([]))),
+    );
+    tuneStation(jpgStation);
+
+    // No `settle()`: the feed has not answered, which is the `unanswered` arm.
+    expect(mediaSessionMetadata()).toEqual({
+      title: jpgStation.title,
+      artist: "",
+      album: "",
+      artwork: [{ src: jpgStation.logoUrl, type: "image/jpeg" }],
+    });
+  });
+
+  it("names the station alone when the provider publishes no feed", () => {
+    tuneStation(feedless);
+
+    expect(mediaSessionMetadata()?.title).toBe("Feedless FM");
+    expect(mediaSessionMetadata()?.artist).toBe("");
+  });
+
+  it("leaves artist empty when the feed gave a blank one", async () => {
+    await tuneWithTrack(jpgStation, { title: "Unattributed" });
+
+    expect(mediaSessionMetadata()).toMatchObject({ title: "Unattributed", artist: "" });
+  });
+
+  it("reads the artwork mime off the URL, so a .png station is not shipped as jpeg", () => {
+    tuneStation(pngStation);
+
+    expect(mediaSessionMetadata()?.artwork).toEqual([
+      { src: pngStation.logoUrl, type: "image/png" },
+    ]);
+  });
+
+  it("stops asserting the track once the read has gone stale", async () => {
+    await tuneWithTrack(jpgStation, { artist: "Steve Roach", title: "Structures from Silence" });
+    expect(mediaSessionMetadata()?.title).toBe("Structures from Silence");
+
+    // Every later poll fails, long enough for the store to flag the read stale.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("feed down");
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_STALE_MS + NOW_PLAYING_POLL_MS);
+
+    // The lock screen must not keep naming a track cic has stopped believing.
+    expect(mediaSessionMetadata()).toMatchObject({ title: jpgStation.title, artist: "" });
+  });
+
+  it("names an upload by its slug, with no artwork to borrow", () => {
+    // `null` label spelled out: `playAudio` takes both since #682 and cic
+    // forbids default arguments, so an upload states that it has no name.
+    playAudio("https://grappa.example/uploads/f00ba7.mp3", null);
+
+    expect(mediaSessionMetadata()).toEqual({
+      title: "f00ba7.mp3",
+      artist: "",
+      album: "",
+      artwork: [],
+    });
+  });
+});
+
+describe("applyMediaSession", () => {
+  it("hands the projection to the platform", () => {
+    const session = { metadata: null } as unknown as MediaSession;
+    vi.stubGlobal("navigator", { mediaSession: session });
+    vi.stubGlobal(
+      "MediaMetadata",
+      class {
+        constructor(readonly init: unknown) {}
+      },
+    );
+
+    applyMediaSession({
+      title: "T",
+      artist: "A",
+      album: "S",
+      artwork: [{ src: "https://x/y.png", type: "image/png" }],
+    });
+
+    expect((session.metadata as unknown as { init: unknown })?.init).toEqual({
+      title: "T",
+      artist: "A",
+      album: "S",
+      artwork: [{ src: "https://x/y.png", type: "image/png" }],
+    });
+  });
+
+  it("clears the platform metadata when nothing is playing", () => {
+    const session = { metadata: {} } as unknown as MediaSession;
+    vi.stubGlobal("navigator", { mediaSession: session });
+
+    applyMediaSession(null);
+
+    expect(session.metadata).toBeNull();
+  });
+
+  it("is a no-op where the platform has no Media Session at all", () => {
+    vi.stubGlobal("navigator", {});
+
+    // The assertion is that this does not throw: every non-iOS browser without
+    // the API must keep playing audio exactly as before.
+    expect(() => {
+      applyMediaSession({ title: "T", artist: "", album: "", artwork: [] });
+    }).not.toThrow();
+  });
+});
+
+describe("setMediaSessionHandlers", () => {
+  it("points the lock-screen transport at the callbacks it is given", () => {
+    const handlers = new Map<string, () => void>();
+    vi.stubGlobal("navigator", {
+      mediaSession: {
+        setActionHandler: (action: string, fn: (() => void) | null) => {
+          if (fn === null) handlers.delete(action);
+          else handlers.set(action, fn);
+        },
+      },
+    });
+    const play = vi.fn();
+    const pause = vi.fn();
+
+    setMediaSessionHandlers({ play, pause });
+    handlers.get("play")?.();
+    handlers.get("pause")?.();
+
+    expect(play).toHaveBeenCalledOnce();
+    expect(pause).toHaveBeenCalledOnce();
+  });
+
+  it("unregisters both handlers when handed null", () => {
+    const handlers = new Map<string, () => void>();
+    vi.stubGlobal("navigator", {
+      mediaSession: {
+        setActionHandler: (action: string, fn: (() => void) | null) => {
+          if (fn === null) handlers.delete(action);
+          else handlers.set(action, fn);
+        },
+      },
+    });
+
+    setMediaSessionHandlers({ play: vi.fn(), pause: vi.fn() });
+    setMediaSessionHandlers(null);
+
+    expect(handlers.size).toBe(0);
+  });
+
+  it("is a no-op where the platform has no Media Session at all", () => {
+    vi.stubGlobal("navigator", {});
+
+    expect(() => {
+      setMediaSessionHandlers({ play: vi.fn(), pause: vi.fn() });
+    }).not.toThrow();
+  });
+});
+
+describe("setMediaSessionPlaybackState", () => {
+  it("mirrors the element's state so the lock-screen glyph is not the OS guessing", () => {
+    const session = { playbackState: "none" } as unknown as MediaSession;
+    vi.stubGlobal("navigator", { mediaSession: session });
+
+    setMediaSessionPlaybackState("playing");
+    expect(session.playbackState).toBe("playing");
+
+    setMediaSessionPlaybackState("paused");
+    expect(session.playbackState).toBe("paused");
+  });
+
+  it("is a no-op where the platform has no Media Session at all", () => {
+    vi.stubGlobal("navigator", {});
+
+    expect(() => {
+      setMediaSessionPlaybackState("playing");
+    }).not.toThrow();
+  });
+});

--- a/cicchetto/src/lib/mediaSession.ts
+++ b/cicchetto/src/lib/mediaSession.ts
@@ -1,0 +1,208 @@
+import { activeAudio } from "./audioPlayer";
+import { nowPlaying } from "./nowPlaying";
+import { tunedStation } from "./radio";
+
+// #1702 — what the OS is told about what we are playing.
+//
+// On an iOS lock screen the player showed "Cicchetto" and nothing else: the OS
+// knew an app was making noise and had no way to learn more, because nothing
+// ever set `navigator.mediaSession`. This module is the projection that tells
+// it, and `AudioMiniPlayer` is what drives the projection at the element.
+//
+// WHY A PROJECTION AND NOT A STORE. Everything on a lock screen is already
+// written down somewhere in cic: the source in `activeAudio()`, the station
+// derived from it by `tunedStation()`, the track derived from THAT by
+// `nowPlaying()`. A signal holding "current lock-screen metadata" would be a
+// fourth copy needing housekeeping, and it would drift the first time a source
+// swapped without anyone remembering to update it. Same reasoning `radio.ts`
+// gives for not storing the tuned station — derive, don't duplicate.
+//
+// THE FIELD MAPPING IS THE PLATFORM'S, NOT THE ISSUE'S. #1702 as filed asked
+// for `title` = the station name with the track fed into `artist`/`album`.
+// Taken literally that puts a TRACK TITLE in the `artist` slot, and since
+// `title` is the primary line on a lock screen it would leave the station
+// shouting and the track buried — half of the very complaint the issue opens
+// with ("no station, no track"). So: `title` is the TRACK, `artist` is its
+// artist, `album` is the STATION. That is not a new direction invented here,
+// it is the spelling this codebase already uses in `nowPlayingLine`:
+// `<artist> — <title> [<station>]`, which treats the station as context and
+// the track as the subject. Approved on the issue before this was written.
+//
+// WHAT IT SAYS WHEN IT DOES NOT KNOW. With no track yet, `title` falls back to
+// the station name so the lock screen still names something real. It never
+// invents: an upload has no station and no feed, so it is named by its own
+// slug, which is the only honest thing we hold about it.
+
+/** One lock-screen image. `type` is ABSENT rather than guessed when the URL
+    carries an extension we have no mime for — see `artworkFor`. */
+export type MediaSessionArtwork = {
+  readonly src: string;
+  readonly type?: string;
+};
+
+/** Our projection of what is playing, in the shape `MediaMetadata` takes. */
+export type MediaSessionMetadata = {
+  readonly title: string;
+  readonly artist: string;
+  readonly album: string;
+  readonly artwork: readonly MediaSessionArtwork[];
+};
+
+/** Extension → mime, for the logo URLs the curated table carries.
+ *
+ * #1696 is why this READS the URL instead of assuming one extension: the table
+ * holds 10 `.jpg` and 4 `.png`, and the `<id>120.png` shape that used to be
+ * assumed only LOOKED like a convention. Reading the extension off the string
+ * is reading a value we were given; inferring it would be repeating the exact
+ * mistake that issue existed to fix. */
+const LOGO_MIME: Readonly<Record<string, string>> = {
+  avif: "image/avif",
+  gif: "image/gif",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+/** Describe a logo for the OS.
+ *
+ * `sizes` is deliberately NOT emitted. Every row today sits under `/logos/120/`
+ * and the temptation is to read 120 out of the path — but that is inferring a
+ * dimension from a directory name, which is the guess #1696 punished, not the
+ * verbatim read that fixed it. The dimensions are not in `RadioStation`, so we
+ * do not claim them; `MediaImage` requires only `src`. */
+function artworkFor(logoUrl: string): MediaSessionArtwork {
+  const ext = logoUrl.split(".").pop()?.toLowerCase();
+  const type = ext === undefined ? undefined : LOGO_MIME[ext];
+  return type === undefined ? { src: logoUrl } : { src: logoUrl, type };
+}
+
+/** The last path segment of an upload's URL — the only name we hold for it.
+ *
+ * An upload is identified by its link, not by a title (`AudioPlayerState.label`
+ * is null for one), so the honest lock-screen caption is the slug rather than
+ * an invented "Audio" or the app's own name, which is what the OS already
+ * falls back to and what filed this issue. */
+function uploadTitle(href: string): string {
+  try {
+    const segment = new URL(href).pathname
+      .split("/")
+      .filter((s) => s !== "")
+      .pop();
+    // `decodeURIComponent` is inside the same `try` on purpose: a malformed
+    // escape throws, and the whole href is a better caption than a crash.
+    return segment === undefined ? href : decodeURIComponent(segment);
+  } catch {
+    return href;
+  }
+}
+
+/**
+ * What the platform should be told, or `null` when nothing is playing.
+ *
+ * Reactive: it reads `activeAudio()`, `tunedStation()` and `nowPlaying()`, so
+ * it re-derives on every transition that matters — tuning, swapping station, an
+ * upload seizing the player, the transport's ✕, identity rotation — without
+ * subscribing to any of them itself.
+ */
+export function mediaSessionMetadata(): MediaSessionMetadata | null {
+  const audio = activeAudio();
+  if (audio === null) return null;
+
+  const station = tunedStation();
+  if (station === null) {
+    // An upload, or any source outside the curated table. No station, no feed,
+    // no logo to borrow — an empty `artwork` lets the OS keep the app icon
+    // rather than be handed some other station's art.
+    return {
+      title: audio.label ?? uploadTitle(audio.href),
+      artist: "",
+      album: "",
+      artwork: [],
+    };
+  }
+
+  const artwork = [artworkFor(station.logoUrl)];
+  const state = nowPlaying();
+
+  // Matching `playing` alone is the STALE RULE, and it is deliberate: reading
+  // `state.track` off whatever arm happens to carry one would keep the lock
+  // screen naming a track after `nowPlayingLabel()` has already stopped naming
+  // it on screen, i.e. cic would assert to the OS something it has stopped
+  // telling the operator. Same predicate, same answer, both surfaces.
+  if (state.status === "playing") {
+    return {
+      title: state.track.title,
+      artist: state.track.artist ?? "",
+      album: station.title,
+      artwork,
+    };
+  }
+
+  return { title: station.title, artist: "", album: "", artwork };
+}
+
+/** The platform's session, or `null` where there is none.
+ *
+ * Every entry point below feature-detects through here. A browser without the
+ * API must keep playing audio exactly as it did before #1702 — the metadata is
+ * an enhancement, and failing to set it is never a reason to break playback. */
+function session(): MediaSession | null {
+  if (typeof navigator === "undefined") return null;
+  return (navigator as Navigator & { mediaSession?: MediaSession }).mediaSession ?? null;
+}
+
+/** Hand `metadata` to the OS, or clear it when nothing is playing. */
+export function applyMediaSession(metadata: MediaSessionMetadata | null): void {
+  const s = session();
+  if (s === null) return;
+
+  if (metadata === null) {
+    s.metadata = null;
+    return;
+  }
+  // `MediaMetadata` can be absent even where `mediaSession` is present; the
+  // constructor is a separate global.
+  if (typeof MediaMetadata !== "function") return;
+
+  s.metadata = new MediaMetadata({
+    title: metadata.title,
+    artist: metadata.artist,
+    album: metadata.album,
+    // Copied into a mutable array of plain objects: the init dict is consumed
+    // by the platform, and our own shape is readonly.
+    artwork: metadata.artwork.map((a) =>
+      a.type === undefined ? { src: a.src } : { src: a.src, type: a.type },
+    ),
+  });
+}
+
+/** Mirror the element's own state, so the lock-screen glyph is what is true
+    rather than what the OS inferred from the audio pipeline. */
+export function setMediaSessionPlaybackState(state: MediaSessionPlaybackState): void {
+  const s = session();
+  if (s === null) return;
+  s.playbackState = state;
+}
+
+/**
+ * Point the lock-screen transport at the same element the in-app bar drives.
+ *
+ * `null` unregisters both. Without this the OS guesses — and its guess acts on
+ * the audio pipeline directly, which is how a lock-screen pause can leave cic's
+ * own glyph claiming the stream is still on.
+ *
+ * No `try` around `setActionHandler`: `play` and `pause` are supported by every
+ * implementation that ships `mediaSession` at all, and a catch here would be a
+ * silent swallow at a boundary — it would hide the next action we add and get
+ * wrong, which is the failure mode CLAUDE.md names.
+ */
+export function setMediaSessionHandlers(
+  handlers: { readonly play: () => void; readonly pause: () => void } | null,
+): void {
+  const s = session();
+  if (s === null || typeof s.setActionHandler !== "function") return;
+
+  s.setActionHandler("play", handlers === null ? null : handlers.play);
+  s.setActionHandler("pause", handlers === null ? null : handlers.pause);
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61268,3 +61268,142 @@ real browser has no seekable range before metadata and silently drops
 the write. And it is remembered ONCE, in `onCleanup`, at the instant the
 fact is about to be lost — never on `timeupdate`, which would be four
 writes a second to module state to keep a value that one moment reads.
+<!-- entry #1702 -->
+
+---
+
+## 2026-08-24 — #1702: telling the OS what is playing, and the spy that the garbage collector ate
+
+On an iOS lock screen cic's radio showed "Cicchetto" and nothing else — no
+station, no track, no artwork. Nothing in the client had ever set
+`navigator.mediaSession`, so the OS fell back to the web app manifest's name.
+This entry records what shipped, the one place the issue's own wording was
+overruled, and the measurement that cost this issue eight e2e runs.
+
+### The field mapping is the platform's, not the issue's
+
+#1702 as filed asked for `title` = the station name, with the track fed into
+`artist` / `album`. Taken literally that puts a TRACK TITLE into the `artist`
+slot, and since `title` is the primary line on an iOS lock screen it leaves the
+station shouting and the track buried — which is half of the complaint the
+issue opens with ("no station, **no track**"). Shipped instead: **`title` is
+the TRACK, `artist` is its artist, `album` is the STATION**, falling back to
+`title` = station (or an upload's own URL slug) when no track is known.
+
+That is not a direction invented here. It is already this codebase's spelling
+in `nowPlayingLine`: `<artist> — <title> [<station>]`, which treats the station
+as context and the track as the subject. Approved on the issue before the code
+was written, under CLAUDE.md's "challenge the spec" rule; e2e assertion (b)
+and `src/__tests__/mediaSession.test.ts` are what pin it, so a future reader
+who takes the issue text literally will break a test rather than the lock
+screen.
+
+### A projection, not a store
+
+Everything a lock screen needs is already written down: the source in
+`activeAudio()`, the station derived from it by `tunedStation()`, the track
+derived from that by `nowPlaying()`. A signal holding "current lock-screen
+metadata" would be a fourth copy needing housekeeping, and it would drift the
+first time a source swapped without anyone updating it. `mediaSessionMetadata()`
+derives on read — the same reasoning `radio.ts` already gives for not storing
+the tuned station.
+
+Two rules the projection inherits rather than invents. **Stale tracks stay off
+the lock screen**: it matches `status === "playing"` only, never reading
+`state.track` off whatever arm happens to carry one, because the alternative is
+cic asserting to the OS a track it has already stopped showing the operator —
+same predicate as `nowPlayingLabel()`, same answer, both surfaces. And **the
+artwork mime is READ off the logo URL**, never hardcoded: the curated table is
+10 `.jpg` and 4 `.png`, so either constant ships wrong for the other group.
+`sizes` is deliberately not emitted — every row sits under `/logos/120/` and
+reading `120` out of a directory name is inferring a dimension, which is
+exactly the guess #1696 existed to punish.
+
+### Why the handlers live in the component and the projection does not
+
+`play` and `pause` were split out of `togglePlay` in `AudioMiniPlayer`. A lock
+screen does not send a toggle; it sends the two actions as distinct verbs, and
+the OS re-asserts intent freely — handing it a toggle would PAUSE on a `play`
+that arrives while the stream is already on. So the verbs are now the
+primitive and the toggle is built from them.
+
+The handlers are wired in `AudioMiniPlayer` and not in `lib/mediaSession.ts`
+because they must drive the SAME `<audio>` element the in-app bar drives, and
+only the component owns it. Two controls over one stream that disagree is the
+failure this avoids. Three separate effects rather than one, because they track
+three different facts: folding them would re-register handlers on every track
+change and rebuild a `MediaMetadata` on every play/pause.
+
+### 🔴 The e2e instrument was the suspect, and it was guilty
+
+The spec runs on `webkit-iphone-15` rather than the default chromium project —
+a green on desktop Chrome would be a green off the defect's own platform. Four
+assertions: metadata exists at all, the field mapping, the artwork mime, and
+(d) that the lock-screen transport drives the same element the in-app bar does.
+(d) failed eight runs in a row with:
+
+```
+calls=[none] spyStillInstalled=false mediaSessionPresent=true
+```
+
+The spy the spec installs on `navigator.mediaSession.setActionHandler` was
+simply not on the object by the time the spec read it — in a document where
+the same init script demonstrably ran, since its `fetch` stub was populated and
+(a)–(c) passed. Two hypotheses were killed before the right one: a sloppy-mode
+assignment dropped onto an instance whose method lives on the prototype (so the
+patch became `Object.defineProperty` — and failed identically), and then
+`navigator.mediaSession` handing back a different object per access.
+
+**Measured, in a two-arm probe on the same WebKit build and device profile,
+with ~250 MB of allocation churn between install and read-back:**
+
+| arm | spy | own property | `metadata` | calls seen |
+|---|---|---|---|---|
+| retain nothing | `false` | `false` | `"PIN"` | `[]` |
+| retain the object | `true` | `true` | `"PIN"` | `["play:fn"]` |
+
+The first row reproduces the failure exactly. `navigator.mediaSession` is
+`[SameObject]`, and JSC honours that by **caching** a wrapper, not by pinning
+one. `metadata` and `playbackState` are state on the platform object
+underneath and outlive the wrapper — which is why `"PIN"` survives in BOTH arms,
+and why (a)–(c) passed while (d) did not. A JS own property has nowhere to live
+but the wrapper, so once nothing in JS references it the wrapper is collected
+and the property goes with it; the next read mints a clean one. Holding the
+object in a global is what makes the wrapper reachable, and it is the whole fix.
+
+**The general rule, and it is what makes this worth writing down: a Playwright
+spy patched onto a platform-provided sub-object of `navigator` (or any
+`[SameObject]` accessor) must be kept reachable from JS, or it is collectible
+and its disappearance reads as a production fault.** The same init script's
+stub on `window.fetch` never had this problem, because `window` is not
+collectible — the two patches differed only in what they were written on. It is
+also the single explanation for both earlier dead ends: a plain assignment and
+a `defineProperty` fail the same way, because neither survives losing the
+object it was written on. The write was never the variable. Two other specs
+patch `navigator.serviceWorker` in an init script and carry the same latent
+exposure; that belongs to the testing-findings issue (#1741), not here.
+
+Isolated probes are what hid it: a bare page installs the spy and reads it back
+in about two seconds with no allocation pressure, and passes. The real spec
+spends nearly nine seconds booting a Solid SPA over a WebSocket first. **A
+mechanism that only fails under load will pass every short reproduction you
+write for it.**
+
+### What stays out of reach, stated rather than hidden
+
+That iOS actually RENDERS on its lock screen what WebKit was handed is not
+observable from any browser automation; it is a device check and it remains
+one. Two narrower limits were also measured along the way. WebKit maintains
+`playbackState` **itself** — it moved to `"playing"` in the probe on a bare
+element with no cic code present at all — so an assertion on `playbackState`
+alone is weak evidence that our effect ran, and (d) invoking a captured handler
+is what carries the weight. And the handlers surviving a collected wrapper in
+production is **inferred** from the metadata that survived both probe arms, not
+measured: no automation surface can fire a platform media action.
+
+Separately, and the reason the spec stubs `window.fetch` in an init script
+rather than using `page.route` for the now-playing feed: `page.route` does not
+intercept a third-party `fetch()` once cic's Workbox service worker has claimed
+the page, and the first runs of this spec reached the real api.somafm.com and
+came back naming a track SomaFM was actually playing. That finding is not
+specific to #1702 and is tracked as #1741.


### PR DESCRIPTION
⚠️ **DRAFT, and honestly so: the e2e spec RAN and lands partly red.** (a)–(c)
pass on the defect's own platform; (d) fails on this spec's instrumentation,
not on production. Details below — nothing here is claimed green that is not.

On an iOS lock screen the radio showed "Cicchetto" and nothing else. Measured:
`mediaSession` / `MediaMetadata` appeared **nowhere** in `cicchetto/src`.

## What lands

| commit | |
|---|---|
| `5d58def0` | 16 unit cases, RED-first, over a module that did not exist |
| `5833b2ce` | `lib/mediaSession.ts` — the projection |
| `12373bc8` | `AudioMiniPlayer` — play/pause split out of the toggle, three effects |
| `b0865589` | the `@webkit` e2e spec |

Unit suite: **6076/6076 green**. cic gates (biome + tsc src + tsc e2e + lock
drift): **4/4 green**.

## Three spec corrections, agreed on the issue before building

1. **The spec was stale.** It gates `artist`/`album` on "#1698 landing" and
   offers an ordering choice. **#1698 and #1696 are both CLOSED and in the
   tree**, so the metadata is complete on day one and no title-only interim was
   built.
2. **Taken literally, the field mapping buries the track.** The issue asks for
   `title` = station with the track in `artist`/`album`; on iOS `title` is the
   primary line, so that leaves half the original complaint ("no station, **no
   track**") standing. Shipped instead with the platform convention — `title` =
   track, `artist` = artist, `album` = station — which is **already this repo's
   spelling** in `nowPlayingLine`: `<artist> — <title> [<station>]`.
3. **The `albumArt` fallback has nothing to fall back from.** #1698's
   `parseSongsFeed` returns only `{artist, title}`; the artwork is just
   `station.logoUrl`. What DOES survive from #1696: the table is 10 `.jpg` and 4
   `.png`, so the mime is **read off the URL**, never hardcoded.

## e2e: run, and what it proved

Eight runs on `webkit-iphone-15` (WebKit + iPhone 15 profile, `@webkit`), not
the default chromium project — the bug is an iOS lock screen and a chromium
green would be a green off the defect's platform.

**Green:** metadata exists at all; the field mapping above; `image/png` read off
a `.png` station's logo URL; the station's exact feed URL requested.

**Red — (d), the action handlers.** `calls=[none] spyStillInstalled=false
mediaSessionPresent=true`. The spy this spec installs on
`navigator.mediaSession.setActionHandler` is gone by read time, on a document
where the init script demonstrably ran. Two hypotheses already killed (plain
assignment, then `Object.defineProperty`). Leading unverified hypothesis:
`navigator.mediaSession` returns a different object per access. **Production's
action handlers are therefore UNPROVEN, not known broken** — that distinction is
the point of leaving this visible rather than deleting the assertion.

## Findings worth more than this issue

🔴 **`page.route` does not intercept a third-party `fetch()` once the service
worker has claimed the page.** Measured: the first runs reached the real
api.somafm.com and returned a track SomaFM was actually playing. cic ships a
Workbox SW; Playwright does not intercept through one. It is a **race**, which
is why `issue1695-…` (which touches a third party early) is fine and this one —
after a login, a channel select and a rail interaction — was not. Cure used:
stub `window.fetch` above the worker. `serviceWorkers: "block"` was tried and
rejected — cic then raises a registration-failed banner that blocks the rail tap
and would mean testing a degraded app.

## Not asserted, by platform limit

That iOS actually renders what WebKit was handed is not observable from any
browser automation. That stays a device check, and is not claimed here.

## Left for the next session

Resolve (d), then undraft. `docs/DESIGN_NOTES.md` entry still to write
(marker `#1702`, verified free against the tip at time of writing).

— w1