### PR TITLE
fix(#1734): come back where the file was, instead of starting it over

### DIFF
--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -1,5 +1,12 @@
-import { type Component, createEffect, createSignal, on, Show } from "solid-js";
-import { activeAudio, closeAudio, hidePlayer, playerHidden } from "./lib/audioPlayer";
+import { type Component, createEffect, createSignal, on, onCleanup, Show } from "solid-js";
+import {
+  activeAudio,
+  closeAudio,
+  hidePlayer,
+  playerHidden,
+  rememberResumePoint,
+  resumePoint,
+} from "./lib/audioPlayer";
 import { nowPlayingLabel } from "./lib/nowPlaying";
 
 // Docked audio mini-player (GH #115) — a slim transport bar pinned above
@@ -75,11 +82,20 @@ const AudioMiniPlayer: Component = () => {
   const [current, setCurrent] = createSignal(0);
   const [duration, setDuration] = createSignal(0);
 
+  // #1734 — a position waiting for the element to know its own length.
+  // `currentTime` written next to `.src` is dropped by a real browser: the
+  // seekable range does not exist until metadata arrives, which is why this
+  // is applied from `onLoadedMetadata` below and not two lines after the
+  // assignment. Always cleared at the top of the effect, so a source that
+  // changes mid-flight cannot land the previous one's position.
+  let pendingSeek: number | null = null;
+
   // Point the element at the active href + autoplay on open; on close,
   // stop + detach the source so a closed player holds no buffered audio.
   createEffect(
     on(activeAudio, (a) => {
       if (audioEl === undefined) return;
+      pendingSeek = null;
       if (a === null) {
         audioEl.pause();
         audioEl.removeAttribute("src");
@@ -88,14 +104,54 @@ const AudioMiniPlayer: Component = () => {
         setDuration(0);
         return;
       }
+
+      // #1734 — this effect's FIRST execution cannot tell a new source from a
+      // re-mount: the source is module state and outlives the component, so
+      // leaving a scrollback window for home / list / mentions / admin and
+      // coming back re-runs exactly this code. A remembered point is the
+      // difference, and there is one only after a destruction.
+      //
+      // Restoring `duration` FIRST is load-bearing and is why no second
+      // predicate was added: `mustRefetch` asks `live()`, which reads the
+      // `duration` signal — recreated at a finite 0 on a fresh element. Left
+      // at 0 the predicate answers "no re-fetch" for a stream as well, which
+      // is both the wrong resume AND, measured, a seek slider drawn across an
+      // endless source. Fed the remembered length it answers correctly for
+      // both, exactly as it does everywhere else.
+      const resume = resumePoint();
+      setCurrent(resume?.position ?? 0);
+      setDuration(resume?.duration ?? 0);
+
       audioEl.src = a.href;
-      setCurrent(0);
-      setDuration(0);
+
+      if (resume !== null && !mustRefetch(audioEl)) {
+        // A healthy FILE: come back where it was, and preserve the transport
+        // rather than pick one. The operator changed window; they did not ask
+        // for a stop, and they did not ask for a start either.
+        pendingSeek = resume.position;
+        if (resume.playing) void audioEl.play().catch(() => {});
+        return;
+      }
+
+      // Everything else — a first tune, or a stream, whose correct resume IS
+      // re-tuning (#1700). Unchanged.
+      //
       // Autoplay may be blocked (no user gesture / iOS policy); the user
       // taps play in that case — swallow the rejection, don't surface it.
       void audioEl.play().catch(() => {});
     }),
   );
+
+  // #1734 — the element is about to be destroyed; the transport's position is
+  // about to go with it. One write, at the only instant that has the fact.
+  onCleanup(() => {
+    if (audioEl === undefined || activeAudio() === null) return;
+    rememberResumePoint({
+      position: audioEl.currentTime,
+      duration: audioEl.duration,
+      playing: playing(),
+    });
+  });
 
   // Endless source? `duration` starts at 0 — a FINITE number, so a source
   // whose metadata has not arrived yet keeps today's file chrome and does not
@@ -172,7 +228,18 @@ const AudioMiniPlayer: Component = () => {
            `error` is the one listened to. */
         onError={() => setPlaying(false)}
         onTimeUpdate={() => setCurrent(audioEl?.currentTime ?? 0)}
-        onLoadedMetadata={() => setDuration(audioEl?.duration ?? 0)}
+        onLoadedMetadata={() => {
+          setDuration(audioEl?.duration ?? 0);
+          // #1734 — the element now has a seekable range, so the position
+          // remembered from the last destruction can finally be applied. The
+          // browser clamps it to the real length, so a source that turned out
+          // shorter lands at its end rather than nowhere.
+          if (pendingSeek !== null && audioEl !== undefined) {
+            audioEl.currentTime = pendingSeek;
+            setCurrent(audioEl.currentTime);
+            pendingSeek = null;
+          }
+        }}
       />
       <Show when={activeAudio() !== null && !playerHidden()}>
         <div class="audio-mini-player" data-testid="audio-mini-player">

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -551,4 +551,131 @@ describe("AudioMiniPlayer", () => {
       expect(playSpy).not.toHaveBeenCalled();
     });
   });
+
+  // #1734 — LEAVING A WINDOW AND COMING BACK.
+  //
+  // The source is MODULE state and outlives this component, but the ELEMENT
+  // does not: navigating a scrollback window → home / list / mentions / admin
+  // unmounts the player. Coming back re-mounts it, the `on(activeAudio, …)`
+  // effect runs its FIRST execution, and a re-mount is indistinguishable from
+  // a new source at that point — so a file used to restart from zero, unasked.
+  //
+  // MEASURED before the fix, and the second line is why the shape below is
+  // what it is:
+  //
+  //   [FILE]   before: play=1 currentTime=42 duration=180 seek-max=180
+  //            after:  play=2 currentTime=0                seek-max=0
+  //   [STREAM] before: live-badge=true
+  //            after:  live-badge=FALSE  seek-present=TRUE
+  //
+  // A re-mounted STREAM came back dressed as a file. `live()` reads `duration`,
+  // a signal of THIS component, and a re-mount recreates it at 0 — a finite
+  // number. So #1700's `mustRefetch` (`el.error !== null || live()`) answers
+  // "no re-fetch needed" for a stream too, and cannot tell the two apart at the
+  // one moment that matters. Restoring the remembered `duration` BEFORE
+  // consulting it is what puts the predicate back in a position to answer, and
+  // is why there is no second predicate here.
+  //
+  // WHY RESUME AND NOT SIT STILL. Sitting still needs the same remembered
+  // `duration` (a stream must still re-tune — #1700's rule), and it needs the
+  // position too or the transport reads 0:00 on a file that is at 0:42. Once
+  // both are restored the only thing left to decide is whether to call
+  // `play()`, and the operator never asked for a stop: they changed window. So
+  // the transport is preserved rather than chosen — playing resumes, paused
+  // stays paused. Anything else is cic originating state.
+  describe("#1734 — re-mounting after leaving the window", () => {
+    const UPLOAD = "https://grappa.example/uploads/abc";
+    const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
+
+    const element = (): HTMLAudioElement =>
+      screen.getByTestId("audio-mini-player-el") as HTMLAudioElement;
+
+    /** Bring the element to the state a played source leaves it in: metadata
+        arrived, the transport is at `at`, and it is playing or not. jsdom runs
+        no media pipeline, so the properties are stubbed on the INSTANCE and the
+        events replayed by hand — the same seam the rest of this file uses. */
+    const settleAt = (duration: number, at: number, isPlaying: boolean): void => {
+      const el = element();
+      Object.defineProperty(el, "duration", { configurable: true, value: duration });
+      el.dispatchEvent(new Event("loadedmetadata"));
+      el.currentTime = at;
+      el.dispatchEvent(new Event("timeupdate"));
+      el.dispatchEvent(new Event(isPlaying ? "play" : "pause"));
+    };
+
+    /** The metadata round the re-mounted element does on its own. The position
+        can only be applied once the element knows its length, which is why the
+        fix waits for this event rather than writing `currentTime` next to
+        `.src` — that write is dropped by a real browser before metadata. */
+    const metadataArrives = (duration: number): void => {
+      const el = element();
+      Object.defineProperty(el, "duration", { configurable: true, value: duration });
+      el.dispatchEvent(new Event("loadedmetadata"));
+    };
+
+    it("a FILE that was playing comes back at its position, still playing", () => {
+      playAudio(UPLOAD, null);
+      const first = render(() => <AudioMiniPlayer />);
+      settleAt(180, 42, true);
+      playSpy.mockClear();
+
+      first.unmount();
+      render(() => <AudioMiniPlayer />);
+      metadataArrives(180);
+
+      expect(element().currentTime).toBe(42);
+      expect(playSpy).toHaveBeenCalled();
+    });
+
+    it("a FILE that was PAUSED comes back at its position and stays paused", () => {
+      // The half that separates "resume" from "restart something": a re-mount
+      // the operator did not ask for must not start audio they had stopped.
+      playAudio(UPLOAD, null);
+      const first = render(() => <AudioMiniPlayer />);
+      settleAt(180, 42, false);
+      playSpy.mockClear();
+
+      first.unmount();
+      render(() => <AudioMiniPlayer />);
+      metadataArrives(180);
+
+      expect(element().currentTime).toBe(42);
+      expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it("a STREAM still re-tunes, and never wears the file chrome on the way", () => {
+      // #1700's rule, unchanged: re-tuning IS the correct resume for a stream.
+      // The second assertion is the measured regression above — the bar must
+      // not draw a seek slider across an endless source while the re-mounted
+      // element waits for metadata it will never usefully answer.
+      playAudio(STATION, "Groove Salad");
+      const first = render(() => <AudioMiniPlayer />);
+      settleAt(Number.POSITIVE_INFINITY, 42, true);
+      playSpy.mockClear();
+
+      first.unmount();
+      render(() => <AudioMiniPlayer />);
+
+      expect(playSpy).toHaveBeenCalled();
+      expect(screen.getByTestId("audio-mini-player-live")).toBeInTheDocument();
+      expect(screen.queryByTestId("audio-mini-player-seek")).toBeNull();
+    });
+
+    it("a NEW source does not inherit the previous one's position", () => {
+      // The invalidation, and the reason the remembered point needs no href of
+      // its own: every writer of `activeAudio` clears it, so a point that
+      // exists belongs to the source that is active. This test is what keeps
+      // that invariant from being quietly broken by a fourth writer.
+      playAudio(UPLOAD, null);
+      const first = render(() => <AudioMiniPlayer />);
+      settleAt(180, 42, true);
+      first.unmount();
+
+      render(() => <AudioMiniPlayer />);
+      playAudio("https://grappa.example/uploads/second", null);
+      metadataArrives(90);
+
+      expect(element().currentTime).toBe(0);
+    });
+  });
 });

--- a/cicchetto/src/lib/audioPlayer.ts
+++ b/cicchetto/src/lib/audioPlayer.ts
@@ -27,6 +27,21 @@ export type AudioPlayerState = {
   label: string | null;
 };
 
+/** Where the transport was when the element went away (#1734). */
+export type AudioResumePoint = {
+  /** Seconds into the source. */
+  position: number;
+  /** The element's last stated length — `Infinity` / `NaN` for an endless
+      source. Carried for a reason that is not display: it is what puts
+      `AudioMiniPlayer`'s `mustRefetch` back in a position to answer on a
+      fresh element, whose own `duration` signal starts at a finite 0 and so
+      makes a stream look like a file. See that file's #1734 comment. */
+  duration: number;
+  /** Whether it was playing. A re-mount nobody asked for must not start
+      audio the operator had paused — cic does not originate state. */
+  playing: boolean;
+};
+
 const exports_ = identityScopedStore((onIdentityChange) => {
   const [activeAudio, setActiveAudio] = createSignal<AudioPlayerState | null>(null);
   // #1697 — HIDING IS NOT STOPPING, and this is the signal that separates them.
@@ -49,14 +64,41 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // different signals.
   const [playerHidden, setPlayerHidden] = createSignal(false);
 
+  // #1734 — where the transport was when the element was last destroyed.
+  //
+  // A SIBLING SIGNAL, for the reason #1697 spells out one comment up and
+  // measured: `AudioMiniPlayer` drives the element from
+  // `createEffect(on(activeAudio, …))`, whose body assigns `audioEl.src`, and
+  // assigning `.src` re-invokes the media load algorithm even when the URL has
+  // not changed. A position riding INSIDE `AudioPlayerState` would hand that
+  // effect a new object on every write and restart the source — inside the fix
+  // whose entire purpose is to stop unrequested restarts. `position` describes
+  // the TRANSPORT; `href`/`label` describe the SOURCE. Different axes.
+  //
+  // It carries no href of its own because it does not need one: every writer
+  // of `activeAudio` below clears it, so a point that exists belongs to the
+  // source that is active. A FOURTH writer of `activeAudio` must clear it too,
+  // or a new source inherits the old one's position — pinned by
+  // "a NEW source does not inherit the previous one's position".
+  const [resumePoint, setResumePoint] = createSignal<AudioResumePoint | null>(null);
+
   onIdentityChange(() => {
     setActiveAudio(null);
     setPlayerHidden(false);
+    setResumePoint(null);
   });
 
   return {
     activeAudio,
     playerHidden,
+    resumePoint,
+    // #1734 — called from the component's `onCleanup`, i.e. exactly once per
+    // destruction, at the instant the fact is about to be lost. Deliberately
+    // NOT written on every `timeupdate`: that would be four writes a second to
+    // module state to keep a value only this one moment reads.
+    rememberResumePoint(point: AudioResumePoint): void {
+      setResumePoint(point);
+    },
     // Start (or swap to) the audio at `href`. One instance: a second
     // click replaces the source rather than stacking a new player.
     //
@@ -76,6 +118,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // hidden would let the next upload play with no controls anywhere on
     // screen, which is a worse version of the bug this fixes.
     playAudio(href: string, label: string | null): void {
+      // #1734 — a remembered position belongs to the source it was taken
+      // from, and clearing it here is what lets the point carry no href.
+      //
+      // 🔴 BEFORE `setActiveAudio`, not after, and this order is load-bearing
+      // — MEASURED. Solid runs the `on(activeAudio, …)` effect SYNCHRONOUSLY
+      // inside the setter, so a clear written on the next line arrives after
+      // the effect has already read the OLD point: it armed the previous
+      // source's position and the new source landed at 0:42.
+      // `[D] after playAudio: currentTime=0` then `after metadata: 42`.
+      setResumePoint(null);
       setActiveAudio({ href, label });
       setPlayerHidden(false);
     },
@@ -83,6 +135,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // element effect pause and detach it. #1697 only adds the reset, so a
     // dismissed player cannot leave a stale flag for the next source.
     closeAudio(): void {
+      // #1734 — ✕ is the STOP verb: it must not leave a position behind for
+      // whatever gets tuned next. Cleared first, for the same synchronous
+      // -effect reason spelled out in `playAudio` — the null arm does not read
+      // the point today, and ordering it defensively costs nothing while
+      // relying on that fact costs the next reader a measurement.
+      setResumePoint(null);
       setActiveAudio(null);
       setPlayerHidden(false);
     },
@@ -98,5 +156,13 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   };
 });
 
-export const { activeAudio, playAudio, closeAudio, playerHidden, hidePlayer, showPlayer } =
-  exports_;
+export const {
+  activeAudio,
+  playAudio,
+  closeAudio,
+  playerHidden,
+  hidePlayer,
+  showPlayer,
+  resumePoint,
+  rememberResumePoint,
+} = exports_;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61169,3 +61169,102 @@ race dressed as a check.
 GitHub offers no FreeBSD runner — every `runs-on:` in this repo is
 `ubuntu-latest` — so the bastille jail keeps its manual probe. Accepted,
 not an oversight.
+<!-- entry #1734 -->
+
+---
+
+## 2026-08-24 — #1734: a re-mount is not a new source, and the predicate could not tell
+
+Leaving a scrollback window for home / list / mentions / admin unmounts
+`AudioMiniPlayer` and destroys the `<audio>`. The source is MODULE state
+(`lib/audioPlayer.ts`) and outlives it, so coming back re-mounts the
+component and the `on(activeAudio, …)` effect runs its FIRST execution —
+indistinguishable, at that point, from a new source. A file restarted
+from zero, unasked.
+
+### The constraint did not hold as written, and that is the finding
+
+The rule was: reuse #1700's `mustRefetch`, never a second predicate. The
+rule is right — two predicates answering one question is how they start
+to diverge — but taken literally it does not work, and the reason is
+worth keeping.
+
+`mustRefetch` is `el.error !== null || live()`, and `live()` reads the
+`duration` **signal**, which belongs to the component and is recreated at
+`0` on a re-mount. `0` is finite. So on a fresh element the predicate
+answers "no re-fetch needed" for a stream as well as a file — at exactly
+the one moment the two must be told apart. Measured in jsdom:
+
+```
+[FILE]   before: play=1 currentTime=42 duration=180 seek-max=180
+         after:  play=2 currentTime=0                seek-max=0
+[STREAM] before: live-badge=true
+         after:  live-badge=FALSE  seek-present=TRUE
+```
+
+The second pair was not in the issue: a re-mounted STREAM came back
+**dressed as a file**, with a scrub slider drawn across an endless
+source, until metadata arrived to correct it.
+
+So the remembered point carries the DURATION, and restoring it before
+consulting the predicate is what puts the predicate back in a position to
+answer. The constraint is honoured in the form that matters — one
+predicate — by fixing its INPUT rather than by adding a sibling that
+would answer the same question a second way.
+
+### Resume, not sit still — decided by the same measurement
+
+The issue left this open and priced it as "resuming costs a state to
+maintain; sitting still costs nothing". That pricing is wrong under the
+constraint. Sitting still needs the same remembered `duration` (a stream
+must still re-tune, #1700's rule), and it needs the position too, or the
+transport reads `0:00` on a file that is at `0:42`. Both are owed either
+way. The real difference between the two options is a single call to
+`play()`.
+
+Given that, the transport is **preserved rather than chosen**: playing
+resumes, paused stays paused. The operator changed window — they asked
+for neither a stop nor a start, and picking one is cic originating state.
+
+### A sibling signal, because #1697 already measured the alternative
+
+The issue said the position belongs in `activeAudio`. It does not.
+Assigning `.src` re-invokes the media load algorithm even when the URL
+has not changed, so a field inside `AudioPlayerState` hands the effect a
+new reference and RESTARTS the source on every write — #1697 measured
+this for the hidden flag and rejected it there. Doing it here would
+reintroduce an unrequested restart inside the fix for unrequested
+restarts. `position` describes the TRANSPORT; `href`/`label` describe the
+SOURCE. Different axes, different signals — the same split #1697 drew.
+
+The point carries no href because every writer of `activeAudio` clears
+it, so a point that exists belongs to the source that is active. A FOURTH
+writer must clear it too; the test named "a NEW source does not inherit
+the previous one's position" is what keeps that from being broken
+quietly.
+
+### 🔴 The clear goes BEFORE the source, and this cost a measurement
+
+`playAudio` originally cleared the point after `setActiveAudio`. Solid
+runs the effect **synchronously inside the setter**, so the clear arrived
+after the effect had already read the OLD point: it armed the previous
+source's position and the new source landed at `0:42`. The diagnostic
+line, kept because it is the shape of the bug:
+
+```
+[D] after playAudio: currentTime=0 src=…/second
+[D] after metadata:  currentTime=42
+```
+
+The regression test was written before the bug existed — it was the
+guard on the no-href invariant — and is what caught it. General rule for
+this store: **a signal that an effect READS must be settled before the
+signal that TRIGGERS that effect is written.**
+
+### Two mechanics, stated so they are not re-litigated
+
+The position is applied from `onLoadedMetadata`, not next to `.src`: a
+real browser has no seekable range before metadata and silently drops
+the write. And it is remembered ONCE, in `onCleanup`, at the instant the
+fact is about to be lost — never on `timeupdate`, which would be four
+writes a second to module state to keep a value that one moment reads.


### PR DESCRIPTION
Leaving a scrollback window for `home` / `list` / `mentions` / `admin`
unmounts the player and destroys the `<audio>`. The source is module state
and outlives it, so coming back re-mounts the component, the
`on(activeAudio, …)` effect runs its first execution, reassigns `.src` and
plays — a file restarted from zero, unasked. Refs #1734, #1700, #1697.

## The constraint did not hold as written, and that is the finding

The rule was: reuse `mustRefetch`, never a second predicate. Right rule —
but it could not answer yet. `mustRefetch` is `el.error !== null ||
live()`, and `live()` reads the `duration` **signal**, which belongs to the
component and is recreated at a finite `0` on a re-mount. Measured in
jsdom, before any change:

```
[FILE]   before: play=1 currentTime=42 duration=180 seek-max=180
         after:  play=2 currentTime=0                seek-max=0
[STREAM] before: live-badge=true
         after:  live-badge=FALSE  seek-present=TRUE
```

**The second pair is not in the issue: a re-mounted STREAM came back
dressed as a file** — a scrub slider drawn across an endless source, and
the predicate answering "no re-fetch needed" for the one case whose
correct resume *is* re-fetching (#1700).

So the remembered point carries the **duration**, and restoring it before
consulting the predicate is what puts the predicate back in a position to
answer. One predicate, as required — its *input* was what was missing.

## Resume, not sit still — the same measurement decides it

The issue priced this as "resuming costs a state to maintain; sitting still
costs nothing". Under the constraint that is not true. Sitting still needs
the same remembered `duration` (a stream must still re-tune), and it needs
the position too, or the transport reads `0:00` on a file that is at
`0:42`. Both are owed either way, so **the real difference is one call to
`play()`**.

Given that: the transport is *preserved* rather than chosen. Playing
resumes, paused stays paused. The operator changed window — they asked for
neither a stop nor a start, and picking one would be cic originating state.

## A sibling signal, because #1697 already measured the alternative

The issue said the position belongs in `activeAudio`. It does not:
assigning `.src` re-invokes the media load algorithm even when the URL has
not changed, so a field inside `AudioPlayerState` hands the effect a new
reference and **restarts the source on every write** — #1697 measured
exactly this for the hidden flag and rejected it there. Doing it here would
reintroduce an unrequested restart inside the fix for unrequested restarts.
`position` describes the TRANSPORT; `href`/`label` describe the SOURCE.

## 🔴 One ordering bug, caught by a test written before it existed

`playAudio` first cleared the point *after* `setActiveAudio`. Solid runs
the effect **synchronously inside the setter**, so the clear arrived after
the effect had already read the OLD point — the new source landed at the
previous one's `0:42`:

```
[D] after playAudio: currentTime=0 src=…/second
[D] after metadata:  currentTime=42
```

The test that caught it ("a NEW source does not inherit the previous one's
position") was written as the guard on the no-href invariant, and went red
the moment the implementation landed. General rule now in the log: a signal
an effect READS must be settled before the signal that TRIGGERS it is
written.

## Tests

Four new, RED first for the right reasons (`expected +0 to be 42` on both
files; `Unable to find audio-mini-player-live` on the stream):

- a FILE that was playing comes back at its position, still playing
- a FILE that was PAUSED comes back at its position and stays paused
- a STREAM still re-tunes, and never wears the file chrome on the way
- a NEW source does not inherit the previous one's position

## Gates

- `AudioMiniPlayer.test.tsx` 30/30 (26 pre-existing + 4)
- full cic suite **311 files / 6064 tests**, all green
- `bun run check` — 4 stages, 0 failed (lock drift, biome, tsc src, tsc e2e);
  none of the 59 pre-existing biome warnings are in the touched files

Mechanics worth one line each: the position is applied from
`onLoadedMetadata`, not next to `.src` (a real browser has no seekable range
before metadata and drops the write), and it is remembered ONCE in
`onCleanup` rather than on every `timeupdate` — four writes a second to
module state for a value one moment reads.

— w2