### PR TITLE
#1703: rock and metal in the curated station list

### DIFF
--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -122,9 +122,16 @@ const findings: StationFinding[] = await Promise.all(
   })),
 );
 
+// #1703 — DERIVED, not a constant. The column was a hand-typed 16, which the
+// first id longer than that ran straight into the URL beside it. An id length
+// is a curation choice and the report must not quietly constrain it.
+const idWidth = Math.max(...findings.map((f) => f.id.length)) + 2;
+
 for (const finding of findings) {
   const found = problems(finding);
-  console.log(`  ${found.length === 0 ? "ok  " : "FAIL"}  ${finding.id.padEnd(16)}${finding.logoUrl}`);
+  console.log(
+    `  ${found.length === 0 ? "ok  " : "FAIL"}  ${finding.id.padEnd(idWidth)}${finding.logoUrl}`,
+  );
   // The feed URL is printed on its own line rather than folded into the one
   // above: a station has two URLs now, and a report that names only one leaves
   // the reader guessing which of them a `FEED` line is about. `(no feed)` is

--- a/cicchetto/src/__tests__/checkRadioLogos.test.ts
+++ b/cicchetto/src/__tests__/checkRadioLogos.test.ts
@@ -159,22 +159,39 @@ describe("agreeFailure", () => {
 });
 
 describe("the AGREE axis is not vacuous over the real table", () => {
-  it("has something to say about every station in RADIO_STATIONS", () => {
-    // The positive control, and the reason it is here: AGREE skips stations
-    // pointing at another provider, so one inverted comparison skips them ALL
-    // and `check:radio` reports "0 broken" having compared nothing. That green
-    // means silence, and it is indistinguishable from the real one at the
-    // summary line. Assert the axis actually engages.
-    const backed = RADIO_STATIONS.filter((s) => isCatalogueBacked(s.logoUrl));
-    expect(backed.length).toBe(RADIO_STATIONS.length);
+  // #1703 — these two used to assert the axis engages on EVERY row, which was
+  // true only because every row was SomaFM. The first non-SomaFM station made
+  // that reading false, and it was never the property worth holding: the
+  // module's own header says the table "is allowed to hold" a station from
+  // another provider, and the sibling case fifteen lines up asserts exactly
+  // that such a row is SKIPPED. Totality and non-vacuity are different claims;
+  // conflating them meant the control would have gone red for the table doing
+  // the thing it was designed to do. What survives is the threat the control
+  // was actually written against — an inverted predicate that skips everything
+  // — plus a guard the old spelling did not have.
+  const catalogueRows = (): readonly string[] =>
+    // An INDEPENDENT spelling of "this logo is SomaFM's", deliberately not
+    // reusing `isCatalogueBacked`: a control that asks the predicate to confirm
+    // itself passes however the predicate is broken.
+    RADIO_STATIONS.filter((s) => s.logoUrl.includes("//api.somafm.com/")).map((s) => s.id);
+
+  it("engages on exactly the catalogue-backed stations, and there are some", () => {
+    const backed = RADIO_STATIONS.filter((s) => isCatalogueBacked(s.logoUrl)).map((s) => s.id);
+    // Non-vacuity: an inverted predicate skips every row and lands on zero.
     expect(backed.length).toBeGreaterThan(0);
+    // Precision: a predicate wrong for SOME rows still clears the bar above.
+    expect(backed).toEqual(catalogueRows());
   });
 
-  it("flags the whole table against an empty catalogue", () => {
+  it("flags every catalogue-backed station against an empty catalogue", () => {
     // The other side of the same control: if the comparator can never fail,
-    // the case above would still pass.
+    // the case above would still pass. Scoped to the backed rows because a row
+    // from another provider is correctly null here — that is the skip, not a
+    // comparator that has gone quiet.
     const empty = new Map<string, string>();
-    for (const s of RADIO_STATIONS) {
+    const backed = RADIO_STATIONS.filter((s) => isCatalogueBacked(s.logoUrl));
+    expect(backed.length).toBeGreaterThan(0);
+    for (const s of backed) {
       expect(agreeFailure(s.logoUrl, s.id, empty), `station ${s.id}`).not.toBeNull();
     }
   });
@@ -185,14 +202,21 @@ describe("the AGREE axis is not vacuous over the real table", () => {
 // claim, not a fact. Adding one without extending this probe would repeat the
 // exact defect the probe exists for.
 describe("the FEED axis is not vacuous over the real table", () => {
-  it("has something to probe on every station that publishes a feed", () => {
+  it("has something to probe, on the stations that publish a feed", () => {
     // The positive control, the sibling of AGREE's above: FEED skips a station
     // whose `songsUrl` is null, so a table that lost the field would report
-    // "0 broken" having probed nothing. Both halves are asserted — the count
-    // matches the rows that carry one, AND that count is not zero.
+    // "0 broken" having probed nothing.
+    //
+    // #1703 — the second clause used to be `toBe(RADIO_STATIONS.length)`, i.e.
+    // every row publishes a feed. That was an accident of the table being
+    // all-SomaFM and it contradicted the field's own type: `songsUrl` is
+    // nullable precisely because a track feed is a provider CAPABILITY, and
+    // the first provider without one made the assertion red for a row that is
+    // correctly spelled. Non-vacuity is the property worth holding here, and
+    // `> 0` is the whole of it — a table that went uniformly null lands on
+    // zero and this goes red, which is the threat the control names.
     const withFeed = RADIO_STATIONS.filter((s) => s.songsUrl !== null);
     expect(withFeed.length).toBeGreaterThan(0);
-    expect(withFeed.length).toBe(RADIO_STATIONS.length);
   });
 });
 

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -114,17 +114,65 @@ describe("RADIO_STATIONS", () => {
     expect(tagged("rock").length, "the table is back to a single rock row").toBeGreaterThan(1);
   });
 
-  it("uses SomaFM's stable front door, never a numbered pool host", () => {
-    // Measured 2026-08-23: a channel's `.pls` lists three ROTATING hosts
-    // (ice2 / ice5 / ice6) while the unnumbered `ice.somafm.com` answers for
-    // all of them. Copying a URL straight out of a `.pls` — the obvious way
-    // to add a station — pins one pool member and rots when the pool moves.
-    // Scoped to somafm hosts on purpose: this table is allowed to hold a
-    // station from another provider, and must not be pinned to one vendor.
+  // #1703 — the FRONT DOOR rule, once per vendor.
+  //
+  // Every streaming provider this table touches puts a load balancer in front
+  // of a numbered pool, and the obvious way to add a station — copy the URL a
+  // player or a `.pls` hands you — pins one pool member. That URL works on the
+  // day it is pasted and rots when the pool moves, which is a station that
+  // silently stops playing.
+  //
+  // Measured, per vendor, and the two are not the same shape:
+  //   * somafm       (2026-08-23) — a channel's `.pls` lists three ROTATING
+  //     hosts (ice2 / ice5 / ice6) while the unnumbered `ice.somafm.com`
+  //     answers for all of them.
+  //   * rockantenne  (2026-08-24) — `stream.rockantenne.de` 302s to
+  //     `s<N>-webradio.rockantenne.de`, and it rotates PER REQUEST: five
+  //     consecutive fetches of the same channel answered s2, s6, s2, s1, s2.
+  //     The redirect target is also https, so following it costs no
+  //     mixed-content step. Baking any `s<N>` host pins one member of a
+  //     balancer that is actively distributing.
+  //
+  // WHY A TABLE AND NOT A SECOND COPY OF THE SOMAFM TEST. This rule used to
+  // name somafm alone, and the moment the first non-SomaFM station landed that
+  // asymmetry would have been a rule that pins the vendor we already got right
+  // and says nothing about the new one — the same shape of gap that let a vite
+  // bump through `integration.yml` without running a line of JavaScript, which
+  // that file's own header records. The map lives in the TEST and not in the
+  // type on purpose: it is a fact about vendors' infrastructure, and baking it
+  // into `RadioStation` is exactly the "table of vendor slugs" the module
+  // header refuses to become.
+  const STREAM_FRONT_DOORS: readonly { readonly vendor: string; readonly frontDoor: string }[] = [
+    { vendor: "somafm.com", frontDoor: "ice.somafm.com" },
+    { vendor: "rockantenne.de", frontDoor: "stream.rockantenne.de" },
+  ];
+
+  it("uses each vendor's stable front door, never a numbered pool host", () => {
     for (const s of RADIO_STATIONS) {
       const host = new URL(s.streamUrl).host;
-      if (!host.endsWith("somafm.com")) continue;
-      expect(host, `station ${s.id} pins a rotating pool host`).toBe("ice.somafm.com");
+      const door = STREAM_FRONT_DOORS.find((d) => host.endsWith(d.vendor));
+      // A vendor absent from the map is not a failure: the table is allowed to
+      // hold a station from a provider whose topology nobody has measured yet,
+      // and inventing a front door for it would be the unverifiable claim
+      // #1696 was filed about. It is simply un-pinned until someone measures.
+      if (door === undefined) continue;
+      expect(host, `station ${s.id} pins a rotating pool host`).toBe(door.frontDoor);
+    }
+  });
+
+  it("has a station behind every vendor it pins — an unused rule proves nothing", () => {
+    // The positive control, and the reason it is a separate test: the rule
+    // above SKIPS, so a vendor whose rows all disappeared (renamed, pruned,
+    // re-hosted) would keep reporting green having compared nothing. That is
+    // the vacuity `check-radio-logos-core.ts` exports `isCatalogueBacked` to
+    // guard against, in the same table, for the same reason — a green built
+    // from zero comparisons is silence, not agreement.
+    for (const door of STREAM_FRONT_DOORS) {
+      const behind = RADIO_STATIONS.filter((s) => new URL(s.streamUrl).host.endsWith(door.vendor));
+      expect(
+        behind,
+        `no station streams from ${door.vendor} — the rule is vacuous`,
+      ).not.toHaveLength(0);
     }
   });
 });

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -85,6 +85,35 @@ describe("RADIO_STATIONS", () => {
     }
   });
 
+  // #1703 — the CURATION floor. The issue is not a shape bug: the table was
+  // structurally perfect and offered no metal at all and exactly one row of
+  // guitar music. Those two counts are the report, so they are what is pinned.
+  //
+  // FLOORS, never exact counts, and the difference is the whole reason these
+  // are worth writing: an exact count is a mirror of today's table that goes
+  // red on the next station anyone adds, which trains the next author to edit
+  // the assertion instead of reading it. A floor only goes red when the table
+  // stops answering the request this issue made — which is the fact worth
+  // defending.
+  //
+  // Keyed on the `rock` / `metal` TAGS rather than on ids, so pruning or
+  // swapping a specific station is free and only emptying the genre is not.
+  // `alternative` is deliberately NOT counted as guitar music: `u80s` carries
+  // it and is synthpop, so folding it in would let the floor be satisfied by
+  // rows that do not answer the request.
+  const tagged = (tag: string): readonly string[] =>
+    RADIO_STATIONS.filter((s) => s.genres.includes(tag)).map((s) => s.id);
+
+  it("offers metal at all — the list had none when #1703 was filed", () => {
+    expect(tagged("metal"), "no station carries the `metal` tag").not.toHaveLength(0);
+  });
+
+  it("offers more than one rock station — the list had exactly one", () => {
+    // `indiepop` was that one. A single row is what the issue called "almost no
+    // rock", so one is a regression to the reported state, not a pass.
+    expect(tagged("rock").length, "the table is back to a single rock row").toBeGreaterThan(1);
+  });
+
   it("uses SomaFM's stable front door, never a numbered pool host", () => {
     // Measured 2026-08-23: a channel's `.pls` lists three ROTATING hosts
     // (ice2 / ice5 / ice6) while the unnumbered `ice.somafm.com` answers for

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -231,4 +231,72 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     logoUrl: "https://api.somafm.com/logos/120/missioncontrol120.jpg",
     songsUrl: "https://api.somafm.com/songs/missioncontrol.json",
   },
+  // #1703 — guitar music. The table above answered "no metal, and one row of
+  // rock", and these six are what SomaFM can contribute to that: measured
+  // 2026-08-24 against the live catalogue, `metal` is the ONLY metal channel
+  // upstream has, so one slot is this provider's ceiling and the rest of the
+  // request had to leave SomaFM (see the Rock Antenne row below).
+  //
+  // ⚠️ The logo extensions below are MIXED and that is not an oversight — it is
+  // #1696's defect reproduced in advance if anyone "tidies" them. `metal120`,
+  // `poptron120` and `doomed120` are PNG; `seventies120`, `covers120` and
+  // `brfm120` are JPG. Every one is a verbatim copy of the catalogue's `image`
+  // minus the `?v=` stamp, per the rule the header states, and the negative
+  // control was run: `seventies120.png` answers 404. The 120 and 256 sizes are
+  // not interchangeable either.
+  {
+    id: "metal",
+    title: "Metal Detector",
+    genres: ["metal"],
+    description:
+      "From black to doom, prog to sludge, thrash to post, stoner to crossover, punk to industrial.",
+    streamUrl: "https://ice.somafm.com/metal-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/metal120.png",
+    songsUrl: "https://api.somafm.com/songs/metal.json",
+  },
+  {
+    id: "seventies",
+    title: "Left Coast 70s",
+    genres: ["70s", "rock"],
+    description: "Mellow album rock from the Seventies. Yacht not required.",
+    streamUrl: "https://ice.somafm.com/seventies-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/seventies120.jpg",
+    songsUrl: "https://api.somafm.com/songs/seventies.json",
+  },
+  {
+    id: "poptron",
+    title: "PopTron",
+    genres: ["alternative"],
+    description: "Electropop and indie dance rock with sparkle and pop.",
+    streamUrl: "https://ice.somafm.com/poptron-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/poptron120.png",
+    songsUrl: "https://api.somafm.com/songs/poptron.json",
+  },
+  {
+    id: "covers",
+    title: "Covers",
+    genres: ["eclectic"],
+    description: "Just covers. Songs you know by artists you don't. We've got you covered.",
+    streamUrl: "https://ice.somafm.com/covers-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/covers120.jpg",
+    songsUrl: "https://api.somafm.com/songs/covers.json",
+  },
+  {
+    id: "brfm",
+    title: "Black Rock FM",
+    genres: ["eclectic"],
+    description: "From the Black Rock Desert playa to the world, year round!",
+    streamUrl: "https://ice.somafm.com/brfm-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/brfm120.jpg",
+    songsUrl: "https://api.somafm.com/songs/brfm.json",
+  },
+  {
+    id: "doomed",
+    title: "Doomed",
+    genres: ["ambient", "industrial"],
+    description: "Where every day is Halloween: dark industrial/ambient music for tortured souls.",
+    streamUrl: "https://ice.somafm.com/doomed-128-mp3",
+    logoUrl: "https://api.somafm.com/logos/120/doomed120.png",
+    songsUrl: "https://api.somafm.com/songs/doomed.json",
+  },
 ];

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -299,4 +299,46 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     logoUrl: "https://api.somafm.com/logos/120/doomed120.png",
     songsUrl: "https://api.somafm.com/songs/doomed.json",
   },
+  // #1703 — THE FIRST STATION THAT IS NOT SOMAFM, and the row the issue was
+  // actually about. SomaFM publishes exactly one metal channel, so "more than a
+  // token amount of metal" cannot be bought from that provider at any price;
+  // this is a full-time metal channel rather than a genre tag on a mixed
+  // station. Measured 2026-08-24: 200 `audio/mpeg`, `icy-name: ROCK ANTENNE
+  // Heavy Metal`, 128 kbps stereo — the same bitrate as the rows above.
+  //
+  // What changes now that the table is no longer a SomaFM mirror, all three
+  // already provided for by the type and none of them requiring a server edit:
+  //
+  //   * `songsUrl` is null because Rock Antenne publishes no now-playing feed —
+  //     probed, not assumed. That is the field's designed arm (`unsupported`),
+  //     and it is also what keeps this a pure client change: `connect-src`
+  //     names `api.somafm.com` alone, so ANY feed URL here would have needed a
+  //     CSP widening — for a document `parseSongsFeed` could not read anyway,
+  //     since it parses SomaFM's `{songs:[…]}` shape and nothing else.
+  //   * `check:radio`'s AGREE axis goes quiet for this row by construction
+  //     (`isCatalogueBacked` keys on a somafm logo host) and it stays REACH-only
+  //     forever. There is no upstream catalogue to pin it against; naming that
+  //     absence beats inventing a comparison that would pass on anything.
+  //   * The CSP needs nothing: `media-src 'self' blob: https:` and `img-src
+  //     'self' data: https:` are scheme-scoped, not host-scoped, and the front
+  //     door's 302 target is https too — so the redirect adds no mixed-content
+  //     step.
+  //
+  // The logo is a content-addressed derivative (`…/<hash>.jpg`) and the hash is
+  // LOAD-BEARING: the hash-less form answers 403 and a wrong hash 404, so the
+  // URL cannot be shortened the way the `?v=` stamp above is dropped. It is
+  // served `cache-control: public, max-age=31536000, immutable`, which is a
+  // stronger stability claim than the timestamp query the SomaFM rows strip —
+  // an immutable content address does not rot on re-upload, it is simply not
+  // the URL a re-upload mints.
+  {
+    id: "rockantenne-metal",
+    title: "ROCK ANTENNE Heavy Metal",
+    genres: ["metal", "rock"],
+    description: "Heavy metal around the clock, from Bavaria's rock station.",
+    streamUrl: "https://stream.rockantenne.de/heavy-metal/stream/mp3",
+    logoUrl:
+      "https://www.rockantenne.de/media/cache/3/version/597/streamlogo_heavymetal_ra-v1.jpg/f1b996498456cb64.jpg",
+    songsUrl: null,
+  },
 ];

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61507,3 +61507,132 @@ instead of replacing it. Known and deliberately left: `reset_for_test/0` drops
 `refs_to_user` without demonitoring, unlike `reset_for_user/1`. A leaked monitor's
 `:DOWN` finds no ref and takes the no-op branch, so it cannot produce an event;
 fixing it is a behaviour change to a test helper with no failure to its name.
+<!-- entry #1703 -->
+
+---
+
+## 2026-08-24 — #1703: the station table stops being a SomaFM mirror
+
+The curated radio list was structurally perfect and musically empty:
+14 rows, exactly ONE of guitar music (`indiepop`), no metal at all. No
+shape invariant could have caught that, because nothing about the shape
+was wrong — which is why the two new tests pin the two COUNTS from the
+report rather than any structure.
+
+### SomaFM's ceiling is one metal channel, so the work had to leave it
+
+Measured against the live catalogue (46 channels): `metal` is the only
+metal channel upstream publishes. Six rows are what this provider can
+contribute — `metal`, `seventies`, `poptron`, `covers`, `brfm`,
+`doomed` — and the rest of the request could not be bought here at any
+price. `rockantenne-metal` is therefore the first row in this table
+that is not SomaFM, and the type was written for it ("a table of
+stations, not a table of SomaFM slugs"); this is the first time that
+sentence had to hold weight.
+
+Three consequences, all already provided for, none needing a server edit:
+
+* **`songsUrl` is null** because Rock Antenne publishes no now-playing
+  feed — probed, not assumed. That is also what keeps the change purely
+  client-side: `connect-src` names `api.somafm.com` alone, so ANY feed
+  URL would have forced a CSP widening — for a document
+  `parseSongsFeed` could not read anyway, since it parses SomaFM's
+  `{songs:[…]}` shape and nothing else. Worth stating plainly, because
+  the field's doc comment reads more generally than the parser behaves:
+  a non-SomaFM JSON feed would pass `check:radio`'s FEED axis (200
+  `application/json`) and then yield `unanswered` forever — the
+  symptomless defect the probe exists for, walking through the probe.
+* **The AGREE axis goes dark for that row, permanently.** There is no
+  catalogue behind a non-SomaFM station, so it is REACH-only. Naming
+  the absence beats inventing a comparison that would pass on anything.
+* **The CSP needs nothing.** `media-src 'self' blob: https:` and
+  `img-src 'self' data: https:` are scheme-scoped, not host-scoped, and
+  the front door's 302 target is https too.
+
+### The front-door rule is now per-vendor, and it has a vacuity guard
+
+Every provider here fronts a numbered pool, and the obvious way to add
+a station — copy the URL a player hands you — pins one pool member.
+Measured, and the two vendors are not the same shape: SomaFM's `.pls`
+lists three rotating hosts while unnumbered `ice.somafm.com` answers
+for all; `stream.rockantenne.de` rotates PER REQUEST, five consecutive
+fetches of one channel answering s2, s6, s2, s1, s2.
+
+The rule used to name SomaFM alone. Left that way it would have pinned
+the vendor already correct and said nothing about the new one — the
+asymmetry that let a vite bump through `integration.yml` without
+running a line of JavaScript. It is now a vendor→front-door map with a
+SECOND test asserting every vendor in it has a row behind it, because
+the rule SKIPS unknown vendors and a skip that covers everything is a
+green built from zero comparisons. A vendor absent from the map is
+deliberately not a failure: the table may hold a provider whose
+topology nobody has measured, and inventing a front door for it is the
+unverifiable claim #1696 was filed about. The map lives in the TEST,
+not in the type — it is a fact about vendors' infrastructure, and
+baking it into `RadioStation` is exactly the vendor-slug table the
+module header refuses to become.
+
+### Two positive controls were asserting totality and calling it non-vacuity
+
+`checkRadioLogos.test.ts` held `backed.length === RADIO_STATIONS.length`
+and `withFeed.length === RADIO_STATIONS.length`. Both were true only
+because every row was SomaFM, and neither was the property named in its
+own comment. The FEED one directly contradicted the field's type —
+`songsUrl` is nullable precisely because a feed is a provider
+capability — so the first provider without one turned a correctly
+spelled row red. Non-vacuity is `> 0`; totality is a different claim.
+The AGREE control also gained precision it never had: it now compares
+the engaged set against an INDEPENDENT spelling of "this logo is
+SomaFM's", because a control that asks a predicate to confirm itself
+passes however the predicate is broken.
+
+### Curation tests are floors, never counts
+
+An exact count is a mirror of today's table: it goes red on the next
+station anyone adds, which teaches the next author to edit the
+assertion instead of reading it. A floor only goes red when the table
+stops answering the request that filed the issue. They key on the
+`rock` / `metal` tags rather than ids so pruning or swapping a station
+stays free, and `alternative` is excluded on purpose — `u80s` carries
+it and is synthpop, so counting it would let the floor be satisfied by
+rows that do not answer the request.
+
+### Why Kohina is not in this table
+
+#1704 was held and re-queued behind #1744, and the measurements are
+worth keeping because they reversed two readings.
+
+The codec question was framed from `caniuse-lite` 1.0.30001791 as "`a`
+(partial) from 17.6, dataset ends at 18.3". Read from the same
+vendored dataset, sorted by version, `ios_saf` × `ogg-vorbis` is `n` →
+**`a #2` from 17.4** → **`y` from 18.4**, with entries running to 26.5.
+Ogg Vorbis is fully supported on every iOS from 18.4 up. In the same
+dataset `aac` × `ios_saf` is `y` from 4.0, so the AAC candidates
+recorded alongside it were never a codec question either.
+
+That moved the blocker to a different place, and the second measurement
+is the one that mattered. Characterised on the existing harness with
+`MediaError` code 4 (`MEDIA_ERR_SRC_NOT_SUPPORTED`): `el.error`
+populates and `mustRefetch` reads it, but nothing RENDERS it — the sole
+effect of `onError` is `setPlaying(false)`. Worse, `loadedmetadata`
+never fires, so `duration` stays 0 — a FINITE number — `live()` is
+false, and the bar draws the FILE chrome: a seek slider at `max="0"`, a
+`0:00 / 0:00` readout and a download link over an endless cross-origin
+stream. A station that cannot decode does not merely fail quietly; it
+renders as a zero-length audio file.
+
+Re-measured after #1702 landed mid-branch, because that commit touches
+this component: the finding is unchanged, and there is now one more
+surface asserting the false state. `setMediaSessionPlaybackState` is
+driven off `playing()`, which the error handler has just set false, so
+the OS lock screen reports `paused` for a source that never played.
+Four surfaces agree on "paused" and none of them has been told there is
+an error to report.
+
+That is a general defect across all rows — any stream that fails to
+start looks the same — and it is the third instance of the #1700 class,
+which stopped the BUTTON lying without touching the chrome or adding a
+surface. It is #1744. Kohina's only distinction is frequency:
+occasional for the others, systematic below iOS 18.4. Filing it as a
+gate on one row would have been a general bug mistaken for a
+per-station precondition.


### PR DESCRIPTION
Fixes the curation gap in #1703. **Scoped to #1703 only** — Kohina (#1704) is
held behind #1744, for the reason recorded at the bottom.

14 → 21 stations. Every URL probed before it was written; `bun run check:radio`
reports **21 stations, 20 feeds, 0 broken** across all three axes.

## Six rows from SomaFM, one from outside

Measured 2026-08-24 against the live catalogue: `metal` is the **only** metal
channel SomaFM publishes, so one slot is that provider's ceiling and the rest
of the request had to leave it. `rockantenne-metal` is a full-time metal
channel rather than a genre tag on a mixed station, and it is the first row in
this table that is not SomaFM — the type was written for that ("a table of
stations, not a table of SomaFM slugs"); this is the first time the sentence
had to hold weight.

Three consequences, none needing a server change:

* **`songsUrl: null`** — probed, not assumed. It is also what keeps this purely
  client-side: `connect-src` names `api.somafm.com` alone, so any feed URL
  would have forced a CSP widening, for a document `parseSongsFeed` could not
  read anyway (it parses SomaFM's `{songs:[…]}` shape and nothing else).
* **The AGREE axis goes permanently dark for that row** — no catalogue behind
  a non-SomaFM station, so it is REACH-only. Naming the absence beats inventing
  a comparison that would pass on anything.
* **The CSP needs nothing** — `media-src`/`img-src` are scheme-scoped, and the
  front door's 302 target is https too.

The logo extensions are mixed on purpose (`metal`/`poptron`/`doomed` PNG,
`seventies`/`covers`/`brfm` JPG) and the comment says so, because tidying them
to a uniform `<id>120.png` is #1696 reproduced by hand. Negative control run:
`seventies120.png` answers 404.

## The front-door rule is now per-vendor

Both providers front a numbered pool and rotate. SomaFM's `.pls` lists three
hosts behind the unnumbered front door; `stream.rockantenne.de` rotates **per
request** — five consecutive fetches of one channel answered s2, s6, s2, s1,
s2. Left naming SomaFM alone, the rule would have pinned the vendor already
correct and said nothing about the new one. A second test asserts every vendor
in the map has a row behind it, because the rule SKIPS unknown vendors and a
skip that covers everything is a green built from zero comparisons. The map
lives in the test, not the type.

## Two positive controls were asserting totality and calling it non-vacuity

`backed.length === RADIO_STATIONS.length` and the same for `withFeed` were true
only because every row was SomaFM, and neither was the property its own comment
named. The FEED one contradicted the field's type outright — `songsUrl` is
nullable precisely because a feed is a provider capability — so the first
provider without one turned a correctly spelled row red. AGREE also gained
precision it never had: it now compares the engaged set against an independent
spelling of "this logo is SomaFM's", because a control that asks a predicate to
confirm itself passes however the predicate is broken.

The curation tests are **floors, never counts** — an exact count is a mirror
that goes red on the next station anyone adds. Their RED reproduced the issue's
own two numbers: `[]` for metal, `1` for rock.

## Why Kohina is not here

Two readings were reversed by measurement, both recorded in DESIGN_NOTES.

The codec framing ("`a` from 17.6, dataset ends at 18.3") is wrong against the
same vendored `caniuse-lite` 1.0.30001791: sorted by version, `ios_saf` ×
`ogg-vorbis` is `a #2` from **17.4** and **`y` from 18.4**, with entries to
26.5 — full support on every current iOS. `aac` is `y` from 4.0, so the AAC
candidates were never a codec question either.

That moved the blocker, and the second measurement is the one that mattered. On
`MediaError` code 4 nothing renders the failure — `onError`'s sole effect is
`setPlaying(false)` — and because metadata never arrives `duration` stays a
finite 0, so the bar draws FILE chrome: a seek slider at `max="0"` and a
download link over an endless stream. A station that cannot decode renders as a
zero-length audio file. Re-measured after #1702 landed mid-branch: unchanged,
plus a fourth false surface — the OS lock screen reports `paused`.

That is general across every row; Kohina's only distinction is frequency. It is
**#1744**, and gating one row on it would have been a general bug mistaken for
a per-station precondition.

## Gates

* `bun run test` — **312 files / 6083 tests green, zero failures**
* `bun run check` — 0 errors; 59 warnings, all pre-existing, none in the
  touched files
* `bun run check:radio` — 21 stations, 20 feeds, 0 broken
* `design-notes-gate.sh` — 1 entry, separator + marker present
* `union-rebase.sh origin/main` — +129 −0, contribution intact; main verified
  an exact 61409-line prefix. Rebased onto `bf0dd225`; marker `#1703`
  re-verified unique against the new tip.

One flake seen and not reproduced: `userTopic.test.ts` failed once with
`Hook timed out in 10000ms` (a hook timeout, not an assertion). Isolated
re-runs 3/3 green, and it did not recur in the full post-rebase suite. My diff
touches no file it imports. Recorded so the next occurrence has a datum to join.

— w2