### PR TITLE
fix(#1747): the six reds named a frame that cannot block — give the barrier a wall clock

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61636,3 +61636,101 @@ surface. It is #1744. Kohina's only distinction is frequency:
 occasional for the others, systematic below iOS 18.4. Filing it as a
 gate on one row would have been a general bug mistaken for a
 per-station precondition.
+<!-- entry #1747 -->
+
+---
+
+## 2026-08-24 — #1747: six reds pointed at a frame that cannot block, and the barrier that made them illegible
+
+`lock_watch_test` reddened six unrelated PRs in one night — a GitHub Action
+bump, an elixir image bump, solid-js, phoenix, a `ws_presence.ex` fix, and one
+PR that touches **only TypeScript** — always with a 60 s `ExUnit.TimeoutError`,
+always green on rerun. They were filed as two defects because they sat on two
+line numbers, `:245` and `:270`.
+
+### The line number was never the discriminator; the stack is
+
+Pulling the failed attempt of each run (`gh run view <id> --attempt 1
+--log-failed`) sorts them into two shapes, and the shapes cut ACROSS the lines:
+
+| PR | time | line | `code:` | top frame |
+|---|---|---|---|---|
+| #1723 | 04:21Z | :245 | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
+| #1726 | 04:2xZ | :245 | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
+| #1745 | 11:09Z | :245 | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
+| #1746 | 10:41Z | **:270** | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
+| #1728 | 04:39Z | **:270** | `LockWatch.scan(0)` | `logger_config.erl:67 allow/2` |
+| #1724 | 04:17Z | — | — | not `lock_watch` at all |
+
+So `:245` and `:270` are ONE defect, not two. #1728 is #1715's door 1 and ran
+before that mitigation landed (06:09Z) — a legitimate residue, not a tail.
+#1724 never failed in Elixir at all (`6821 tests, 0 failures`; the red was the
+bats step). **Four** unrelated PRs, not six, and both post-mitigation reds are
+the shape below. Every one of them also shows `capture_log.ex:121` — the test
+BODY — where the earlier #1715 sighting of `:245` showed `:124`, the capture
+teardown. Same outcome, different site: that older reading does not carry over.
+
+### The frame every one of them names cannot block. Measured
+
+The stack looks like a park inside `LockWatch.inspect_lock/0` → `sample/2` →
+`stacktrace/1` → `Exception.format_stacktrace_entry/1`. It is not:
+
+* `:application.get_application/1` answers in **9 µs with the
+  `application_controller` SUSPENDED** (`erlang:suspend_process/1`). It is not
+  a `gen_server:call` — it is an ETS scan, and nothing can wait there.
+* `Process.info(pid, :current_stacktrace)` against a process **inside a dirty
+  NIF** (`:crypto.pbkdf2_hmac`, 40 M iterations) answers in **21 µs**. This was
+  the promising one — the waiter under test is parked in exqlite's dirty NIF —
+  and it is dead.
+
+**The stack was an artefact of SAMPLING A BUSY LOOP.** ExUnit captures
+`current_stacktrace` when it kills the test, so a runnable process reports
+wherever it happens to be, and that is reliably the most expensive thing the
+loop does. Six reports agreed on a location and none of them was evidence of
+one. **That generalises past this issue: on an `ExUnit.TimeoutError` the stack
+is a location, not a cause — establish that the top frame can block before
+reading it as where the time went.**
+
+### What actually consumed the 60 s: an attempt count is not a budget
+
+`await_until(fun, 300)` bounded itself by ATTEMPT COUNT with a `Process.sleep(10)`
+per turn — nominally ~3 s — while ExUnit's ceiling is 60 s. That fails in both
+directions. On a healthy runner it gives up after 3 s, under the wall clock a
+slow runner legitimately needs. On a starved one it runs past 60 s, so its own
+`flunk("condition never held: …")` — the diagnosis the helper exists to print —
+becomes unreachable and ExUnit's opaque timeout wins instead.
+
+Measured on the bench, with a 30 ms predicate standing in for the starved
+runner: a **200 ms** budget was spent in **10 078 ms**, 50× over.
+
+This file already carried the right rule for its other two clocks — *"Derive
+the budget FROM the test deadline and no test ExUnit still allows to run can
+outlive its own waiter"* — and had simply never applied it to the barrier.
+`@barrier_budget_ms` is now `div(@test_timeout_ms, 2)`, so the honest failure
+is always the one that fires.
+
+### The barrier also paid for a diagnostic it discards
+
+`await_roles/2` compares pid lists and nothing else, yet it asked
+`inspect_lock/0`, which runs `Process.info/2` plus twelve frames through
+`Exception.format_stacktrace_entry/1` for every sampled process, on every turn
+of the poll. `LockWatch.lock_roles/0` is that partition as bare pids. It shares
+`rows/0` and `partition/2` deliberately rather than reading the table again —
+the reaping of dead rows lives in `rows/0`, and a second reader that skipped it
+would leave corpses for the instrument to report. The full `inspect_lock/0` is
+now paid once, on the failure path, where the stacktraces ARE the diagnosis.
+
+### What this does NOT settle, stated rather than buried
+
+**Why the loop runs slow enough to be outrun is not established.** The standing
+hypothesis is #1715's root — the test deliberately parks a writer on the write
+lock — reached through the module-load leg rather than the Logger leg, which
+would explain why #1731's priming does not cover it. It is not measured, and
+the bench that would measure it is the one #1715 failed to build across eight
+configurations and 38 million puts. It was not attempted again here, because
+the cure does not depend on the answer: a barrier bounded by wall clock is
+correct whatever starves it.
+
+**So this does not close #1715, and it does not claim to stop the starvation.**
+It stops the starvation from being reported as a stack trace pointing at
+innocent code.

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -362,6 +362,27 @@ defmodule Grappa.Repo.LockWatch do
     }
   end
 
+  @doc """
+  The same partition `inspect_lock/0` reports, as bare pids.
+
+  For a caller that wants to know WHO holds and WHO queues and nothing else.
+  `inspect_lock/0` answers that too, but it pays `sample/2` for every process
+  — `Process.info/2` plus `@stack_frames` frames run through
+  `Exception.format_stacktrace_entry/1` — and a caller polling in a loop pays
+  that on every turn for an answer it discards (#1747).
+
+  Shares `rows/0` and `partition/2` with `inspect_lock/0` rather than reading
+  the table again: the reaping of dead rows lives in `rows/0`, so a second
+  reader that skipped it would leave corpses behind for the instrument to
+  report.
+  """
+  @spec lock_roles() :: %{holders: [pid()], waiters: [pid()]}
+  def lock_roles do
+    {holders, waiters} = partition(rows(), now_ms())
+
+    %{holders: Enum.map(holders, &elem(&1, 0)), waiters: Enum.map(waiters, &elem(&1, 0))}
+  end
+
   if Mix.env() == :test do
     @doc false
     # Test seam: arm/disarm the write-path instrumentation. Gated to :test so

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -390,6 +390,70 @@ defmodule Grappa.Repo.LockWatchTest do
     end
   end
 
+  describe "the barrier itself (#1747)" do
+    test "a slow predicate cannot push the barrier past its own budget" do
+      # #1747 — six unrelated PRs went red here with a 60 s `ExUnit.TimeoutError`
+      # and NEVER with `await_until`'s own `flunk`, which is the diagnosis this
+      # helper exists to print. That is arithmetic, not luck: an attempt count
+      # is not a budget. Bounded at 300 attempts the helper spends ~3 s on a
+      # healthy runner and well past ExUnit's 60 s ceiling on a starved one, so
+      # exactly when the failure is interesting the honest message becomes
+      # unreachable and the report shows a stack sampled from wherever the loop
+      # happened to be.
+      #
+      # A 30 ms predicate is the starved runner, compressed: under the attempt
+      # bound this call costs 200 * (30 + 10) ms = 8 s, under a wall-clock bound
+      # it costs the budget.
+      budget_ms = 200
+
+      {elapsed_us, _} =
+        :timer.tc(fn ->
+          assert_raise ExUnit.AssertionError, fn ->
+            await_until(
+              fn ->
+                Process.sleep(30)
+                false
+              end,
+              budget_ms
+            )
+          end
+        end)
+
+      assert div(elapsed_us, 1000) < 10 * budget_ms
+    end
+
+    test "lock_roles/0 names the same holders and waiters inspect_lock/0 does" do
+      # The barrier compares pid lists and nothing else, but `inspect_lock/0`
+      # formats a 12-frame stacktrace per sampled process to answer it. This
+      # pins the cheap projection to the expensive one so the barrier can stop
+      # paying for a diagnostic it never reads — and so a reimplementation that
+      # drifts from `partition/2` reddens here instead of silently disagreeing
+      # with the instrument it is supposed to mirror.
+      repo = start_tmp_repo()
+
+      {holder, holder_ref} = start_writer(1, :park)
+      assert_receive {:holding, ^holder}, 5_000
+
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+
+      await_roles(holder, [waiter])
+
+      %{holders: held, waiters: queued} = LockWatch.lock_roles()
+      %{holders: held_samples, waiters: queued_samples} = LockWatch.inspect_lock()
+
+      assert Enum.map(held, &inspect/1) == pids(held_samples)
+      assert Enum.sort(Enum.map(queued, &inspect/1)) == Enum.sort(pids(queued_samples))
+      assert held == [holder]
+      assert queued == [waiter]
+
+      send(holder, :release)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+  end
+
   ## ----- helpers --------------------------------------------------------
 
   # Drives the REAL `init/1` — the only way to prove the priming is wired

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -70,6 +70,25 @@ defmodule Grappa.Repo.LockWatchTest do
   @moduletag timeout: @test_timeout_ms
   @waiter_budget_ms @test_timeout_ms * 2
 
+  # 🔴 THE BARRIER IS A THIRD CLOCK, AND IT HAS TO BE ORDERED TOO (#1747).
+  #
+  # `await_until/2` used to count 300 ATTEMPTS, which is not a budget in
+  # either direction. On a healthy runner it gave up after ~3s — under the
+  # roles a slow runner still needs. On a starved one it ran far past ExUnit's
+  # deadline, so its own `flunk` became UNREACHABLE and the test died an
+  # `ExUnit.TimeoutError` whose stack was sampled from wherever the loop
+  # happened to be. Six unrelated PRs went red that way in one night, all six
+  # naming a frame that turns out not to be a blocker at all: measured, an
+  # `:application.get_application/1` answers in 9µs with the
+  # `application_controller` SUSPENDED, and a `Process.info(pid,
+  # :current_stacktrace)` against a process inside a dirty NIF answers in
+  # 21µs. Neither can park; the stack was an artefact of sampling a busy loop.
+  #
+  # Same move as the two clocks above, applied to the clock they missed:
+  # derive FROM the test deadline, and stay strictly UNDER it so the honest
+  # diagnosis is always the one that fires.
+  @barrier_budget_ms div(@test_timeout_ms, 2)
+
   setup do
     LockWatch.put_test_enabled(true)
     on_exit(fn -> LockWatch.put_test_enabled(false) end)
@@ -613,31 +632,44 @@ defmodule Grappa.Repo.LockWatchTest do
 
   # `holder` is `nil` for the #1687 topology — a queue whose holder owns no
   # row, so the barrier is "holders is EMPTY and these pids are queued".
+  # Reads the PID-ONLY projection, not `inspect_lock/0`: this predicate
+  # compares pid lists and discards everything else, while `inspect_lock/0`
+  # runs `Process.info/2` plus twelve frames through
+  # `Exception.format_stacktrace_entry/1` per process, on every turn (#1747).
   defp await_roles(holder, waiters) do
     await_until(
       fn ->
-        %{holders: held, waiters: queued} = LockWatch.inspect_lock()
+        %{holders: held, waiters: queued} = LockWatch.lock_roles()
 
-        pids(held) == expected_holders(holder) and
-          Enum.sort(pids(queued)) == Enum.sort(Enum.map(waiters, &inspect/1))
+        held == expected_holders(holder) and Enum.sort(queued) == Enum.sort(waiters)
       end,
-      300
+      @barrier_budget_ms
     )
   end
 
   defp expected_holders(nil), do: []
-  defp expected_holders(holder), do: [inspect(holder)]
+  defp expected_holders(holder), do: [holder]
 
   defp pids(samples), do: Enum.map(samples, & &1.pid)
 
-  defp await_until(_, 0), do: flunk("condition never held: #{inspect(LockWatch.inspect_lock())}")
+  # A WALL CLOCK. See `@barrier_budget_ms` for why an attempt count was not
+  # one. The full `inspect_lock/0` is paid HERE and only here — on the failure
+  # path, where the stacktraces are the diagnosis rather than overhead.
+  defp await_until(fun, budget_ms) do
+    await_until(fun, budget_ms, System.monotonic_time(:millisecond) + budget_ms)
+  end
 
-  defp await_until(fun, attempts) do
-    if fun.() do
-      :ok
-    else
-      Process.sleep(10)
-      await_until(fun, attempts - 1)
+  defp await_until(fun, budget_ms, deadline) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("condition never held within #{budget_ms}ms: #{inspect(LockWatch.inspect_lock())}")
+
+      true ->
+        Process.sleep(10)
+        await_until(fun, budget_ms, deadline)
     end
   end
 end


### PR DESCRIPTION
Measure first, cure second, as the issue asked. Three commits: RED, cure,
DESIGN_NOTES entry `<!-- entry #1747 -->` (unique against the current tip
`0c46584e`).

🔴 **This does NOT close #1715, and it does not claim to stop the starvation.**
It stops the starvation from being reported as a stack trace pointing at
innocent code.

## (1) `:245` and `:270` are ONE defect — the line was never the discriminator

Pulling the failed attempt of every run sorts the reds by STACK, and the
shapes cut across the lines:

| PR | time | line | `code:` | top frame |
|---|---|---|---|---|
| #1723 | 04:21Z | :245 | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
| #1726 | 04:2xZ | :245 | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
| #1745 | 11:09Z | :245 | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
| #1746 | 10:41Z | **:270** | `await_roles(nil, [waiter])` | `application_controller.erl:470` |
| #1728 | 04:39Z | **:270** | `LockWatch.scan(0)` | `logger_config.erl:67 allow/2` |
| #1724 | 04:17Z | — | — | not `lock_watch` at all |

#1728 is #1715's door 1 and ran before that mitigation landed (06:09Z) — a
legitimate residue. #1724 never failed in Elixir (`6821 tests, 0 failures`;
the red was the bats step). **Four** unrelated PRs, and both post-mitigation
reds are the shape above. All six show `capture_log.ex:121`, the test BODY,
where the earlier #1715 sighting of `:245` showed `:124`, the capture
teardown — so that older reading does not carry over.

## (2) The mechanism: the frame they all name cannot block

* `:application.get_application/1` → **9 µs with the `application_controller`
  SUSPENDED**. Not a `gen_server:call`; an ETS scan. Nothing can wait there.
* `Process.info(pid, :current_stacktrace)` against a process **inside a dirty
  NIF** (`:crypto.pbkdf2_hmac`, 40 M iterations) → **21 µs**. This was the
  promising one, since the waiter under test is parked in exqlite's dirty NIF.
  Dead.

**The stack was an artefact of sampling a busy loop.** ExUnit captures
`current_stacktrace` when it kills the test, so a runnable process reports the
most expensive thing its loop does. Six reports agreed on a location and none
was evidence of one.

What actually spent the 60 s is arithmetic: `await_until(fun, 300)` was bounded
by ATTEMPT COUNT, not wall clock, against ExUnit's 60 s ceiling. Wrong in both
directions — it gives up at ~3 s on a healthy runner, and past 60 s on a
starved one its own `flunk("condition never held: …")` becomes unreachable.
**Measured on the bench: a 200 ms budget spent 10 078 ms, 50× over.**

## (3) The cure

* `@barrier_budget_ms = div(@test_timeout_ms, 2)`, and `await_until/2` bounded
  by wall clock. This file already carried the rule for its other two clocks
  (*"Derive the budget FROM the test deadline…"*) and had never applied it here.
* `LockWatch.lock_roles/0`: the same partition as bare pids, so the barrier
  stops running `Process.info/2` + twelve `format_stacktrace_entry/1` per
  process on every poll turn for an answer it discards. Full `inspect_lock/0`
  still paid on the FAILURE path, where the stacktraces are the diagnosis.

**Deviation from the brief, flagged rather than done quietly.** The brief said
test-side only. `lock_roles/0` is a five-line read-only sibling of
`inspect_lock/0` in the lib, because the test-only alternatives — reading the
`:public` ETS table directly, or duplicating the split — reimplement `alive?/1`
and `partition/2` and silently skip the dead-row reaping that lives in
`rows/0`, leaving corpses for the instrument to report as eternal holders. No
production path changes, no behaviour moves, and the new agreement arm reddens
if projection and instrument ever disagree. Trivially reverted if you disagree.

## (4) What is NOT established, and was not attempted

**Why the loop runs slow enough to be outrun.** The standing hypothesis is
#1715's root through the module-load leg rather than the Logger leg — which
would explain why #1731's priming misses it — and it is not measured. The
bench that would settle it is the one #1715 failed to build across eight
configurations and 38 million puts; per the owner's call it was not attempted
again, because a wall-clock barrier is correct whatever starves it. Written in
the entry, not buried.

## Gates

`lock_watch_test` **11 tests, 0 failures** (RED first, both arms: `left: 10078,
right: 2000`, and `UndefinedFunctionError` on `lock_roles/0`). Format clean,
Credo strict `no issues`, `design-notes-gate` *1 new entry heading, separator
and marker present*. 4 checks to CI.

Merge is yours, in fast-forward.

— w1