### PR TITLE
#1744 — a stream that will not start now says so, on every surface that was claiming otherwise

### DIFF
--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -1,10 +1,14 @@
 import { type Component, createEffect, createSignal, on, onCleanup, Show } from "solid-js";
 import {
   activeAudio,
+  audioFailureLabel,
+  clearPlaybackFailure,
   closeAudio,
   hidePlayer,
+  playbackFailure,
   playerHidden,
   rememberResumePoint,
+  reportPlaybackFailure,
   resumePoint,
 } from "./lib/audioPlayer";
 import {
@@ -197,6 +201,13 @@ const AudioMiniPlayer: Component = () => {
 
   const playNow = (): void => {
     if (audioEl === undefined) return;
+    // #1744 — a new attempt invalidates the verdict on the last one, and the
+    // clear is what makes a REPEATED failure visible: the same reason written
+    // to the same signal changes nothing, so without this the operator presses
+    // play on a source that cannot play and the bar sits there unchanged.
+    // It deliberately does NOT touch `el.error`, which stays set until the
+    // fetch below lands — that property is `mustRefetch`'s, not the surface's.
+    clearPlaybackFailure();
     // `play()` re-runs resource selection only from NETWORK_EMPTY, which is not
     // where a dropped stream lands; `load()` runs it unconditionally. The other
     // `load()` in this file DETACHES a source on close — same call, opposite
@@ -273,8 +284,17 @@ const AudioMiniPlayer: Component = () => {
            recoverable buffering, not a stop, and clearing the state on them
            would flip the button to ▶ over audio that is still coming — the
            same lie in the other direction. `error` is the terminal one, so
-           `error` is the one listened to. */
-        onError={() => setPlaying(false)}
+           `error` is the one listened to.
+           #1744 — and it is now REPORTED, not only absorbed. Clearing the
+           transport was half the answer: it stopped the bar claiming to play
+           and left it looking like a station the operator had PAUSED. The
+           element's own `error` goes to the store, which classifies it once
+           (`reportPlaybackFailure`); every surface reads the reason from
+           there. */
+        onError={() => {
+          setPlaying(false);
+          reportPlaybackFailure(audioEl?.error ?? null);
+        }}
         onTimeUpdate={() => setCurrent(audioEl?.currentTime ?? 0)}
         onLoadedMetadata={() => {
           setDuration(audioEl?.duration ?? 0);
@@ -311,60 +331,115 @@ const AudioMiniPlayer: Component = () => {
               </span>
             )}
           </Show>
-          {/* #1698 — what the station is playing, on the surface a phone can
-              actually see. The rail carries the same fact, and on mobile the
-              rail is `translateX(100%)` off-screen while the station plays —
-              the identical argument that put the label above here in #682,
-              one field further. Absent for an upload, which has no feed, and
-              absent for a station whose feed has gone quiet: the store's
-              `nowPlayingLabel` is null on every arm but `playing`, so the
-              stale rule reaches this row without this row knowing about it. */}
-          <Show when={nowPlayingLabel()}>
-            {(track) => (
-              <span class="audio-mini-player-track" data-testid="audio-mini-player-track">
-                {track()}
+          {/* #1744 — THE NOTICE TAKES THE TRACK'S SLOT. The feed polls
+              `tunedStation()`, which is derived from the SOURCE and knows
+              nothing about whether the element decoded it — so a live-updating
+              track name keeps scrolling over silence, which is the single
+              loudest way a dead station looks like a playing one. The row is
+              also one row: on a phone it IS the player, so the notice takes a
+              slot rather than adding one.
+              The LABEL above deliberately stays. "connection lost" with nothing
+              beside it does not tell the operator which station to re-pick. */}
+          <Show
+            when={playbackFailure()}
+            fallback={
+              /* #1698 — what the station is playing, on the surface a phone can
+                 actually see. The rail carries the same fact, and on mobile the
+                 rail is `translateX(100%)` off-screen while the station plays —
+                 the identical argument that put the label above here in #682,
+                 one field further. Absent for an upload, which has no feed, and
+                 absent for a station whose feed has gone quiet: the store's
+                 `nowPlayingLabel` is null on every arm but `playing`, so the
+                 stale rule reaches this row without this row knowing about it. */
+              <Show when={nowPlayingLabel()}>
+                {(track) => (
+                  <span class="audio-mini-player-track" data-testid="audio-mini-player-track">
+                    {track()}
+                  </span>
+                )}
+              </Show>
+            }
+          >
+            {(failure) => (
+              /* `role="status"`: this appears without the operator having done
+                 anything, so an assistive technology must be able to learn
+                 about it without polling the bar. */
+              <span
+                class="audio-mini-player-error"
+                data-testid="audio-mini-player-error"
+                role="status"
+              >
+                {`⚠ ${audioFailureLabel(failure())}`}
               </span>
             )}
           </Show>
-          <Show
-            when={!live()}
-            fallback={
-              <>
-                <span class="audio-mini-player-live" data-testid="audio-mini-player-live">
-                  live
-                </span>
-                {/* Elapsed since tune-in, NOT a position: there is no total
-                    to divide it by, so it is shown alone rather than as one
-                    half of a "cur / dur" pair with a hollow denominator. */}
-                <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
-                  {formatTime(current())}
-                </span>
-              </>
-            }
-          >
-            <input
-              type="range"
-              class="audio-mini-player-seek"
-              data-testid="audio-mini-player-seek"
-              min="0"
-              max={duration() || 0}
-              step="any"
-              value={current()}
-              onInput={onSeek}
-              aria-label="seek"
-            />
-            <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
-              {formatTime(current())} / {formatTime(duration())}
-            </span>
-            {/* Same-origin download: the `download` attribute forces a save
-                (overriding the server's `inline` Content-Disposition) and
-                inherits the server-sent filename — cic has no filename on
-                the wire (slug only), so no `download` value is set.
-                #682 — gated OFF for a live source, for two independent
-                reasons either of which is sufficient: the resource has no
-                end, so the save never completes; and `download` is ignored
-                outright on a cross-origin href, so the anchor would navigate
-                the operator out of the app instead of saving anything. */}
+          {/* THE READOUT, and #1744 gives it a third arm: NONE.
+              Measured on a source the browser refuses (MediaError code 4):
+              `loadedmetadata` never arrives, so `duration` stays at a finite 0,
+              so `live()` answers false and this row drew the FILE readout over
+              a dead endless stream — a scrubber at `max="0"` and a `0:00 /
+              0:00` clock. Both are statements about a resource that does not
+              exist, and the live arm is no better: an elapsed counter frozen at
+              a "live" badge says the stream is still on. A failed source has no
+              readout, so it is given none. */}
+          <Show when={playbackFailure() === null}>
+            <Show
+              when={!live()}
+              fallback={
+                <>
+                  <span class="audio-mini-player-live" data-testid="audio-mini-player-live">
+                    live
+                  </span>
+                  {/* Elapsed since tune-in, NOT a position: there is no total
+                      to divide it by, so it is shown alone rather than as one
+                      half of a "cur / dur" pair with a hollow denominator. */}
+                  <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
+                    {formatTime(current())}
+                  </span>
+                </>
+              }
+            >
+              <input
+                type="range"
+                class="audio-mini-player-seek"
+                data-testid="audio-mini-player-seek"
+                min="0"
+                max={duration() || 0}
+                step="any"
+                value={current()}
+                onInput={onSeek}
+                aria-label="seek"
+              />
+              <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
+                {formatTime(current())} / {formatTime(duration())}
+              </span>
+            </Show>
+          </Show>
+          {/* Same-origin download: the `download` attribute forces a save
+              (overriding the server's `inline` Content-Disposition) and
+              inherits the server-sent filename — cic has no filename on the
+              wire (slug only), so no `download` value is set.
+              #682 — gated OFF for a live source, for two independent reasons
+              either of which is sufficient: the resource has no end, so the
+              save never completes; and `download` is ignored outright on a
+              cross-origin href, so the anchor would navigate the operator out
+              of the app instead of saving anything.
+              #1744 — LIFTED OUT of the file readout above, and it is the one
+              piece of chrome a failure does NOT take away. The two were one
+              <Show> only because they share a predicate, and that merge made
+              this case unsayable: an upload the browser cannot DECODE is
+              exactly the upload the operator wants to SAVE and open elsewhere.
+              This anchor is not a claim about playback — it is the remedy for
+              the notice standing beside it.
+              ⚠️ Still gated on `live()` and therefore still wrong in one
+              corner, unchanged from before this issue: a STREAM that failed
+              before metadata has a finite `duration` of 0, so it is not live as
+              far as this predicate can tell, and the anchor renders on an
+              endless cross-origin href. The honest gate is same-origin, which
+              is #682's own second reason spelled as a test rather than
+              inferred from the first — out of scope here, and named so it is
+              not rediscovered as new. */}
+          <Show when={!live()}>
             <a
               class="audio-mini-player-download"
               data-testid="audio-mini-player-download"

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -1,5 +1,5 @@
 import { type Component, For, Show } from "solid-js";
-import { closeAudio } from "./lib/audioPlayer";
+import { audioFailureLabel, closeAudio, playbackFailure } from "./lib/audioPlayer";
 import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
 import { nowPlayingLabel } from "./lib/nowPlaying";
 import { createOverlayLock } from "./lib/overlayScrollLock";
@@ -82,18 +82,40 @@ const RailRadio: Component = () => {
                   taller chrome would re-charge part of it. Nothing is lost:
                   every picker row still carries its genres, and browsing by
                   genre is what the picker is for — this row answers "what is
-                  on", which is the track. */}
+                  on", which is the track.
+                  #1744 — and a THIRD tenant of the same line, ahead of both,
+                  because a station that will not play is not "on" at all. Two
+                  reasons it belongs on this surface and not only on the docked
+                  bar: this is the DESKTOP answer to "what is playing", and it
+                  is what is left standing when the operator hides the bar
+                  (#1697) — which takes the transport, and with it the docked
+                  notice, off the screen while the audio keeps running. The
+                  track in particular must yield: the feed polls
+                  `tunedStation()`, derived from the SOURCE, so it keeps
+                  reporting what the station is broadcasting long after this
+                  browser stopped being able to decode it. */}
               <Show
-                when={nowPlayingLabel()}
+                when={playbackFailure()}
                 fallback={
-                  <span class="rail-radio-now-genres" data-testid="rail-radio-now-genres">
-                    {station().genres.join(" · ")}
-                  </span>
+                  <Show
+                    when={nowPlayingLabel()}
+                    fallback={
+                      <span class="rail-radio-now-genres" data-testid="rail-radio-now-genres">
+                        {station().genres.join(" · ")}
+                      </span>
+                    }
+                  >
+                    {(line) => (
+                      <span class="rail-radio-now-track" data-testid="rail-radio-now-track">
+                        {line()}
+                      </span>
+                    )}
+                  </Show>
                 }
               >
-                {(line) => (
-                  <span class="rail-radio-now-track" data-testid="rail-radio-now-track">
-                    {line()}
+                {(failure) => (
+                  <span class="rail-radio-now-error" data-testid="rail-radio-now-error">
+                    {`⚠ ${audioFailureLabel(failure())}`}
                   </span>
                 )}
               </Show>

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AudioMiniPlayer from "../AudioMiniPlayer";
-import { activeAudio, closeAudio, playAudio, playerHidden, showPlayer } from "../lib/audioPlayer";
+import {
+  activeAudio,
+  audioFailureLabel,
+  closeAudio,
+  playAudio,
+  playerHidden,
+  showPlayer,
+} from "../lib/audioPlayer";
 import type { RadioStation } from "../lib/radioStations";
 
 // jsdom does not implement HTMLMediaElement playback — stub the methods
@@ -676,6 +683,274 @@ describe("AudioMiniPlayer", () => {
       metadataArrives(90);
 
       expect(element().currentTime).toBe(0);
+    });
+  });
+
+  // #1744 — A STREAM THAT NEVER STARTS SAID NOTHING TO ANYONE.
+  //
+  // MEASURED on the harness above with `MediaError` code 4, the codec case:
+  //
+  //   el.error.code                    4      ← the element populates it
+  //   elements naming the error        0      ← nobody reads it for display
+  //   toggle                           "▶" / aria-label="play"
+  //   LIVE badge                       false
+  //   SEEK slider                      present, max="0"
+  //   readout                          "0:00 / 0:00"
+  //   download link                    present
+  //
+  // NOT MERELY MUTE — LYING, and the second half is why this is more than one
+  // span. `loadedmetadata` never arrives, so `duration` stays at 0, which is a
+  // FINITE number, so `live()` answers false and the bar dresses a dead endless
+  // stream as a FILE: a scrubber over nothing and a `0:00 / 0:00` readout. The
+  // failure therefore REPLACES the readout rather than joining it.
+  //
+  // THE DOWNLOAD ANCHOR IS THE EXCEPTION, and finding it is what split that
+  // <Show> in two. It sat inside the file readout because the two share a
+  // predicate, not because they answer the same question — and an upload the
+  // browser cannot DECODE is exactly the upload the operator wants to SAVE.
+  // Taking it away would remove the remedy at the moment it is needed. So the
+  // notice replaces the readout, and the anchor keeps #682's own `live()`
+  // gate, unchanged.
+  //
+  // WHY THIS IS NOT A SECOND PREDICATE BESIDE `mustRefetch` (#1700's rule that
+  // the predicate is one). Two independent reasons, and either is sufficient:
+  //   * `mustRefetch` is `el.error !== null || live()`, so it is TRUE for every
+  //     healthy live stream. A surface gated on it would show a failure on
+  //     every station that works.
+  //   * It is a question ASKED OF THE ELEMENT at the instant of a decision, and
+  //     `el.error` is a plain property. Solid cannot subscribe to it, so no
+  //     amount of asking re-renders anything. The signal below is the reactive
+  //     record of the EVENT, which is a different object with a different job:
+  //     `mustRefetch` decides whether to call `load()`, this decides what the
+  //     operator is told. They can legitimately disagree — a retry clears the
+  //     notice while `el.error` is still set until the new fetch lands.
+  describe("#1744 — saying so when the source will not play", () => {
+    const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
+    const UPLOAD = "https://grappa.example/uploads/abc";
+
+    const element = (): HTMLElement => screen.getByTestId("audio-mini-player-el");
+    const toggle = (): HTMLElement => screen.getByTestId("audio-mini-player-toggle");
+
+    /** Put the element in the state a failed load leaves it in, at `code`. Same
+        instance-stub seam as `interrupt()` above, parameterised because the
+        REASON is what this slice is about. */
+    const failWith = (code: number): void => {
+      Object.defineProperty(element(), "error", {
+        configurable: true,
+        value: { code, message: "" },
+      });
+      element().dispatchEvent(new Event("error"));
+    };
+
+    /** Stub `duration` and replay the metadata round, as the file above does. */
+    const metadataArrives = (duration: number): void => {
+      Object.defineProperty(element(), "duration", { configurable: true, value: duration });
+      element().dispatchEvent(new Event("loadedmetadata"));
+    };
+
+    it("names the failure on the bar", () => {
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+
+      failWith(2);
+
+      expect(screen.getByTestId("audio-mini-player-error")).toHaveTextContent(
+        audioFailureLabel("network"),
+      );
+    });
+
+    it("says which failure it was — a codec is not a dropped connection", () => {
+      // The distinction the operator acts on: a lost connection is worth
+      // pressing play for, a source this browser cannot decode never will be.
+      // Kohina on iOS < 18.4 is the second kind, permanently.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+
+      failWith(4);
+
+      const said = screen.getByTestId("audio-mini-player-error");
+      expect(said).toHaveTextContent(audioFailureLabel("unsupported"));
+      expect(said).not.toHaveTextContent(audioFailureLabel("network"));
+    });
+
+    it("drops the FILE readout a failed load leaves behind", () => {
+      // The measured lie, and the reason the failure REPLACES the readout
+      // instead of sitting beside it: with no metadata `duration` is a finite
+      // 0, so the bar would otherwise draw a scrubber and a `0:00 / 0:00`
+      // clock over a source that produced no audio at all.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      expect(screen.getByTestId("audio-mini-player-seek")).toBeInTheDocument();
+
+      failWith(4);
+
+      expect(screen.queryByTestId("audio-mini-player-seek")).toBeNull();
+      expect(screen.queryByTestId("audio-mini-player-time")).toBeNull();
+      expect(screen.getByTestId("audio-mini-player-error")).toBeInTheDocument();
+    });
+
+    it("keeps the download link on a file it could not decode — that IS the remedy", () => {
+      // The one piece of chrome a failure must NOT take, and the reason the
+      // anchor was lifted out of the readout's <Show>: an upload this browser
+      // cannot decode is exactly the upload the operator wants to save and open
+      // in something that can. It is not a claim about playback — it is what
+      // to do about the notice beside it.
+      render(() => <AudioMiniPlayer />);
+      playAudio(UPLOAD, null);
+
+      failWith(4);
+
+      const dl = screen.getByTestId("audio-mini-player-download");
+      expect(dl).toHaveAttribute("href", UPLOAD);
+      expect(dl).toHaveAttribute("download");
+      expect(screen.getByTestId("audio-mini-player-error")).toBeInTheDocument();
+    });
+
+    it("a failed LIVE source still has no download link — #682's gate is untouched", () => {
+      // The gate stays `live()`, so a stream that had stated its length keeps
+      // refusing a save that would never complete. What this does NOT fix, and
+      // what is unchanged from before this issue: a stream that failed BEFORE
+      // metadata reads `duration = 0`, which is finite, so it is not live as
+      // far as this predicate can see.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      metadataArrives(Number.POSITIVE_INFINITY);
+
+      failWith(2);
+
+      expect(screen.queryByTestId("audio-mini-player-download")).toBeNull();
+    });
+
+    it("drops the LIVE chrome too, when metadata had arrived before the drop", () => {
+      // The other arm of the same <Show>. A stream that played and then died
+      // keeps `duration = Infinity`, so it wears the live badge and an elapsed
+      // counter that has stopped counting — a clock that says the stream is
+      // still on.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      metadataArrives(Number.POSITIVE_INFINITY);
+      expect(screen.getByTestId("audio-mini-player-live")).toBeInTheDocument();
+
+      failWith(2);
+
+      expect(screen.queryByTestId("audio-mini-player-live")).toBeNull();
+      expect(screen.queryByTestId("audio-mini-player-time")).toBeNull();
+      expect(screen.getByTestId("audio-mini-player-error")).toBeInTheDocument();
+    });
+
+    it("keeps naming the source — the failure is ABOUT something", () => {
+      // The label survives on purpose. "connection lost" with nothing beside it
+      // does not tell the operator which station to re-pick.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+
+      failWith(2);
+
+      expect(screen.getByTestId("audio-mini-player-label")).toHaveTextContent("Groove Salad");
+    });
+
+    it("takes the now-playing track off the row — the loudest of the lies", async () => {
+      // A live-updating track name is the single thing that makes a dead
+      // station look like a playing one, and the feed keeps answering: it polls
+      // `tunedStation()`, which is derived from the SOURCE and knows nothing
+      // about whether the element decoded it.
+      const TRACK = "Trestal — A Land Unknown";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ songs: [{ title: "A Land Unknown", artist: "Trestal" }] }),
+        } as unknown as Response),
+      );
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      // #1701's barrier, for its reason: keyed on the STUBBED TEXT, so it
+      // cannot return on whichever answer happened to land first.
+      await vi.waitFor(() =>
+        expect(screen.getByTestId("audio-mini-player-track")).toHaveTextContent(TRACK),
+      );
+
+      failWith(4);
+
+      expect(screen.queryByTestId("audio-mini-player-track")).toBeNull();
+      expect(screen.getByTestId("audio-mini-player-error")).toBeInTheDocument();
+    });
+
+    // The family defect, pinned for the third time. #1697 (`hidden`) and #1734
+    // (`resumePoint`) each proved that a field added to `AudioPlayerState`
+    // re-fires `on(activeAudio, …)`, whose body assigns `audioEl.src` — and a
+    // re-assignment re-invokes the media load algorithm even at an unchanged
+    // URL. Here that would mean the error handler RESTARTING the source, which
+    // for a codec failure is an infinite retry loop nobody asked for.
+    it("reporting the failure does not re-tune the source", () => {
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      playSpy.mockClear();
+      loadSpy.mockClear();
+
+      failWith(4);
+
+      expect(playSpy).not.toHaveBeenCalled();
+      expect(loadSpy).not.toHaveBeenCalled();
+      expect(element()).toHaveAttribute("src", STATION);
+    });
+
+    it("pressing play clears the notice and goes back for the resource", () => {
+      // The retry is #1700's, unchanged — `mustRefetch` still decides to
+      // `load()`. What is new is that the notice describes the LAST ATTEMPT, so
+      // it must go when a new one starts.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      failWith(2);
+
+      toggle().click();
+
+      expect(screen.queryByTestId("audio-mini-player-error")).toBeNull();
+      expect(loadSpy).toHaveBeenCalled();
+      expect(playSpy).toHaveBeenCalled();
+    });
+
+    it("a retry that fails again says so again", () => {
+      // Without the clear above, the second failure would write the same value
+      // to the same signal, nothing would re-render, and the operator would tap
+      // play and watch the bar do nothing at all.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      failWith(4);
+      toggle().click();
+      expect(screen.queryByTestId("audio-mini-player-error")).toBeNull();
+
+      failWith(4);
+
+      expect(screen.getByTestId("audio-mini-player-error")).toHaveTextContent(
+        audioFailureLabel("unsupported"),
+      );
+    });
+
+    it("tuning something else clears the previous source's failure", () => {
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      failWith(4);
+
+      playAudio(UPLOAD, null);
+
+      expect(screen.queryByTestId("audio-mini-player-error")).toBeNull();
+      expect(screen.getByTestId("audio-mini-player-seek")).toBeInTheDocument();
+    });
+
+    it("still reads ▶, and pressing it is still the retry", () => {
+      // Deliberately unchanged. The toggle was never the lie — it says "not
+      // playing", which is true, and #1700 already made pressing it re-fetch.
+      // What was missing was the operator knowing there was something to retry,
+      // and that is the span above, not a fourth glyph.
+      render(() => <AudioMiniPlayer />);
+      playAudio(STATION, "Groove Salad");
+      element().dispatchEvent(new Event("play"));
+
+      failWith(2);
+
+      expect(toggle()).toHaveAttribute("aria-label", "play");
     });
   });
 });

--- a/cicchetto/src/__tests__/RailRadio.test.tsx
+++ b/cicchetto/src/__tests__/RailRadio.test.tsx
@@ -1,6 +1,13 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { activeAudio, closeAudio, playAudio } from "../lib/audioPlayer";
+import {
+  activeAudio,
+  audioFailureLabel,
+  clearPlaybackFailure,
+  closeAudio,
+  playAudio,
+  reportPlaybackFailure,
+} from "../lib/audioPlayer";
 import { closeRadioPicker, openRadioPicker, radioPickerOpen } from "../lib/radio";
 import { RADIO_STATIONS } from "../lib/radioStations";
 import RailRadio from "../RailRadio";
@@ -44,6 +51,7 @@ beforeEach(() => {
 afterEach(() => {
   closeAudio();
   closeRadioPicker();
+  clearPlaybackFailure();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -289,5 +297,59 @@ describe("RailRadio", () => {
 
     expect(screen.queryByTestId("rail-radio-now-track")).toBeNull();
     expect(screen.getByTestId("rail-radio-now-genres")).toBeInTheDocument();
+  });
+
+  // #1744 — the rail's chrome is the DESKTOP answer to "what is playing", and
+  // it is also the surface left standing when the operator hides the docked bar
+  // (#1697), which takes the transport — and with it #1744's own notice — off
+  // the screen while the audio keeps running. A station that cannot play must
+  // not sit here wearing its genres as if nothing had happened.
+  //
+  // Same SLOT as the track and the genres, for #500's reason one line up: the
+  // chrome's height must not depend on what the second line happens to say.
+  describe("a station that will not play (#1744)", () => {
+    it("says so in the second line, in place of the genres", () => {
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+      expect(screen.getByTestId("rail-radio-now-genres")).toBeInTheDocument();
+
+      reportPlaybackFailure({ code: 4, message: "" } as MediaError);
+
+      expect(screen.getByTestId("rail-radio-now-error")).toHaveTextContent(
+        audioFailureLabel("unsupported"),
+      );
+      expect(screen.queryByTestId("rail-radio-now-genres")).toBeNull();
+      // The station keeps its name and its stop button: the failure is ABOUT
+      // this row, it does not replace it.
+      expect(screen.getByTestId("rail-radio-now-title")).toHaveTextContent(station.title);
+      expect(screen.getByTestId("rail-radio-stop")).toBeInTheDocument();
+    });
+
+    it("takes precedence over a track the feed is still reporting", async () => {
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+      await vi.waitFor(() =>
+        expect(screen.getByTestId("rail-radio-now-track")).toBeInTheDocument(),
+      );
+
+      reportPlaybackFailure({ code: 2, message: "" } as MediaError);
+
+      expect(screen.queryByTestId("rail-radio-now-track")).toBeNull();
+      expect(screen.getByTestId("rail-radio-now-error")).toBeInTheDocument();
+    });
+
+    it("clears when the operator picks another station", () => {
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+      reportPlaybackFailure({ code: 2, message: "" } as MediaError);
+
+      screen.getByTestId(`rail-radio-station-${other.id}`).click();
+
+      expect(screen.queryByTestId("rail-radio-now-error")).toBeNull();
+      expect(screen.getByTestId("rail-radio-now-genres")).toBeInTheDocument();
+    });
   });
 });

--- a/cicchetto/src/__tests__/audioMiniPlayerLayout.test.ts
+++ b/cicchetto/src/__tests__/audioMiniPlayerLayout.test.ts
@@ -36,7 +36,10 @@ const soleRuleBody = (selector: string): string => {
 };
 
 describe("the docked player's text spans can shrink, and its controls cannot", () => {
-  it.each([".audio-mini-player-label", ".audio-mini-player-track"])(
+  // #1744 adds a THIRD growable span, and it is the one that arrives while the
+  // operator is already unhappy: it takes the track's slot on a failed source,
+  // so it inherits the same contract rather than being a new shape beside it.
+  it.each([".audio-mini-player-label", ".audio-mini-player-track", ".audio-mini-player-error"])(
     "%s ellipsises instead of widening the row",
     (selector) => {
       const body = soleRuleBody(selector);

--- a/cicchetto/src/__tests__/audioPlayer.test.ts
+++ b/cicchetto/src/__tests__/audioPlayer.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  type AudioFailure,
   activeAudio,
+  audioFailureLabel,
+  clearPlaybackFailure,
   closeAudio,
   hidePlayer,
   playAudio,
+  playbackFailure,
   playerHidden,
+  reportPlaybackFailure,
   showPlayer,
 } from "../lib/audioPlayer";
 import { setToken } from "../lib/auth";
@@ -136,5 +141,135 @@ describe("audioPlayer transport visibility (#1697)", () => {
 
     expect(playerHidden()).toBe(false);
     expect(activeAudio()).toBeNull();
+  });
+});
+
+// #1744 — A SOURCE THAT WILL NOT PLAY. The element populates `el.error` and
+// nothing was reading it for DISPLAY, so a station that never decoded looked
+// exactly like one the operator had paused.
+//
+// A THIRD SIBLING SIGNAL, and by now that is a rule rather than a choice. The
+// obvious home is a field on `AudioPlayerState` — and it is the same trap
+// #1697 (`hidden`) and #1734 (`resumePoint`) each walked up to: `AudioMiniPlayer`
+// drives the element from `createEffect(on(activeAudio, …))`, whose body assigns
+// `audioEl.src`, and assigning `.src` re-invokes the media load algorithm even
+// when the URL has not changed. A failure riding inside the state object would
+// hand that effect a new reference and RESTART the source — on the very event
+// that says the source cannot be started. Pinned below by the same
+// same-reference assertion #1697 uses.
+describe("audioPlayer playback failure (#1744)", () => {
+  const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
+
+  /** A `MediaError` as the element hands one over. Only `code` is read: the
+      `message` is empty on every browser measured and vendor-flavoured where it
+      is not, so it is never shown. */
+  const mediaError = (code: number): MediaError => ({ code, message: "" }) as MediaError;
+
+  afterEach(() => {
+    clearPlaybackFailure();
+  });
+
+  it("starts with no failure", () => {
+    expect(playbackFailure()).toBeNull();
+  });
+
+  // The four the spec defines, as a table — a `switch` that answered the same
+  // reason twice would still pass a single-code test.
+  it.each([
+    [1, "aborted"],
+    [2, "network"],
+    [3, "decode"],
+    [4, "unsupported"],
+  ] as ReadonlyArray<readonly [number, AudioFailure]>)(
+    "records MediaError code %i as %s",
+    (code, reason) => {
+      reportPlaybackFailure(mediaError(code));
+      expect(playbackFailure()).toBe(reason);
+    },
+  );
+
+  it("records a code outside the spec's four as unknown rather than dropping it", () => {
+    // A failure we cannot NAME is still a failure, and the surface must say
+    // something. Silently ignoring an unrecognised code is how a bar goes back
+    // to looking like a paused station.
+    reportPlaybackFailure(mediaError(9));
+    expect(playbackFailure()).toBe("unknown");
+  });
+
+  it("records a failure even when the element supplies no MediaError", () => {
+    // `error` is typed `MediaError | null`, and the event having fired is
+    // itself the fact. Same argument as the unknown code above.
+    reportPlaybackFailure(null);
+    expect(playbackFailure()).toBe("unknown");
+  });
+
+  it("every reason has a sentence for the operator", () => {
+    const reasons: readonly AudioFailure[] = [
+      "aborted",
+      "network",
+      "decode",
+      "unsupported",
+      "unknown",
+    ];
+    const said = reasons.map((r) => audioFailureLabel(r));
+    expect(said.every((s) => s.length > 0)).toBe(true);
+    // Distinct, because the operator's next move differs: a lost connection is
+    // worth re-pressing play for and an unplayable source never will be.
+    expect(new Set(said).size).toBe(reasons.length);
+  });
+
+  it("tuning a new source clears the previous one's failure", () => {
+    playAudio(STATION, "Groove Salad");
+    reportPlaybackFailure(mediaError(4));
+
+    playAudio("https://grappa.example/uploads/abc", null);
+
+    expect(playbackFailure()).toBeNull();
+  });
+
+  it("closing the player leaves no stale failure behind", () => {
+    playAudio(STATION, "Groove Salad");
+    reportPlaybackFailure(mediaError(2));
+
+    closeAudio();
+
+    expect(playbackFailure()).toBeNull();
+  });
+
+  it("clearPlaybackFailure re-arms the notice for a retry of the SAME source", () => {
+    // The retry door. Without it a second failure of the same source would
+    // change no signal, so the operator would press play and watch nothing
+    // happen — the bar would look frozen rather than re-refused.
+    playAudio(STATION, "Groove Salad");
+    reportPlaybackFailure(mediaError(2));
+
+    clearPlaybackFailure();
+
+    expect(playbackFailure()).toBeNull();
+    expect(activeAudio()).not.toBeNull();
+  });
+
+  it("token rotation clears it with the rest of the store (identity-scoped)", () => {
+    setToken("tokA");
+    playAudio(STATION, "Groove Salad");
+    reportPlaybackFailure(mediaError(3));
+
+    setToken("tokB");
+
+    expect(playbackFailure()).toBeNull();
+    expect(activeAudio()).toBeNull();
+  });
+
+  // THE load-bearing assertion, third time on this edge, and `toBe` for the
+  // same reason #1697 spells out: only a source object whose IDENTITY survives
+  // the write leaves the element's effect asleep. A `failure` field inside
+  // `AudioPlayerState` fails exactly here.
+  it("reporting a failure does not touch the source object — same reference in, same out", () => {
+    playAudio(STATION, "Groove Salad");
+    const before = activeAudio();
+
+    reportPlaybackFailure(mediaError(4));
+
+    expect(activeAudio()).toBe(before);
   });
 });

--- a/cicchetto/src/__tests__/mediaSession.test.ts
+++ b/cicchetto/src/__tests__/mediaSession.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { closeAudio, playAudio } from "../lib/audioPlayer";
+import {
+  audioFailureLabel,
+  clearPlaybackFailure,
+  closeAudio,
+  playAudio,
+  reportPlaybackFailure,
+} from "../lib/audioPlayer";
 import { setToken } from "../lib/auth";
 import {
   applyMediaSession,
@@ -78,6 +84,7 @@ beforeEach(() => {
 
 afterEach(() => {
   closeAudio();
+  clearPlaybackFailure();
   setToken(null);
   vi.useRealTimers();
   vi.unstubAllGlobals();
@@ -163,6 +170,78 @@ describe("mediaSessionMetadata", () => {
       artist: "",
       album: "",
       artwork: [],
+    });
+  });
+
+  // #1744 — the OS is the FOURTH surface, and on a phone it is often the only
+  // one: the screen is locked, the docked bar is behind it, and the rail is a
+  // drawer slid off-screen. A lock screen that reads "SomaFM Metal" over a
+  // stream that never decoded is the same silence as the bar's, one layer out.
+  //
+  // WHY THE ARTIST SLOT. It is the second line, and on a failure there is no
+  // track and therefore no artist to displace — the projection's `title` keeps
+  // naming the SOURCE, which is what makes the sentence complete ("Groove
+  // Salad / connection lost"). Putting the failure in `title` would cost the
+  // operator the name of the thing that failed.
+  //
+  // WHY `playbackState` IS DELIBERATELY LEFT AT "paused". The states the
+  // platform defines are `none | paused | playing`, and "none" is the only one
+  // that could carry "broken" — but a UA is free to drop the whole now-playing
+  // card on "none", which would take the sentence above off the screen with it.
+  // Read off the Media Session spec, not measured on a device: the safe move is
+  // to keep the card (and its retry button, which `playNow` already re-fetches
+  // through) and let the TEXT carry the fact.
+  describe("a source that will not play (#1744)", () => {
+    it("hands the failure to the lock screen beside the station's name", () => {
+      tuneStation(jpgStation);
+
+      reportPlaybackFailure({ code: 2, message: "" } as MediaError);
+
+      expect(mediaSessionMetadata()).toEqual({
+        title: jpgStation.title,
+        artist: audioFailureLabel("network"),
+        album: "",
+        artwork: [{ src: jpgStation.logoUrl, type: "image/jpeg" }],
+      });
+    });
+
+    it("stops naming a track the operator cannot hear", async () => {
+      // Same rule the `stale` arm above obeys, from the other direction: cic
+      // must not assert to the OS something it has stopped telling the
+      // operator. The feed keeps answering — it polls the station, and the
+      // station is derived from the SOURCE, which a decode failure does not
+      // touch.
+      await tuneWithTrack(jpgStation, { artist: "Steve Roach", title: "Structures from Silence" });
+      expect(mediaSessionMetadata()?.title).toBe("Structures from Silence");
+
+      reportPlaybackFailure({ code: 4, message: "" } as MediaError);
+
+      expect(mediaSessionMetadata()).toMatchObject({
+        title: jpgStation.title,
+        artist: audioFailureLabel("unsupported"),
+      });
+    });
+
+    it("says it for an upload too, which has no station to name", () => {
+      playAudio("https://grappa.example/uploads/f00ba7.mp3", null);
+
+      reportPlaybackFailure({ code: 3, message: "" } as MediaError);
+
+      expect(mediaSessionMetadata()).toEqual({
+        title: "f00ba7.mp3",
+        artist: audioFailureLabel("decode"),
+        album: "",
+        artwork: [],
+      });
+    });
+
+    it("goes quiet again as soon as another source is tuned", () => {
+      tuneStation(jpgStation);
+      reportPlaybackFailure({ code: 2, message: "" } as MediaError);
+
+      tuneStation(pngStation);
+
+      expect(mediaSessionMetadata()?.artist).toBe("");
     });
   });
 });

--- a/cicchetto/src/lib/audioPlayer.ts
+++ b/cicchetto/src/lib/audioPlayer.ts
@@ -27,6 +27,56 @@ export type AudioPlayerState = {
   label: string | null;
 };
 
+/** Why the element refused a source (#1744) — the four codes `MediaError`
+    defines, plus the honest arm for one it does not.
+ *
+ * A closed set rather than the raw number: the code is a platform detail, and
+ * every reader of this wants the REASON. `unknown` is not a default hiding a
+ * gap — it is what we say when the element reports a failure it cannot name,
+ * because a failure we cannot classify is still a failure the operator must
+ * see. Same log-honesty rule `NowPlaying`'s `unanswered` arm is named for. */
+export type AudioFailure = "aborted" | "network" | "decode" | "unsupported" | "unknown";
+
+/** The four codes, by their spec meanings. Kept as a lookup rather than a
+    `switch` so the mapping reads as the table it is; anything else is
+    `unknown`. */
+const FAILURE_BY_CODE: Readonly<Record<number, AudioFailure>> = {
+  1: "aborted",
+  2: "network",
+  3: "decode",
+  4: "unsupported",
+};
+
+/**
+ * What the operator is told, per reason.
+ *
+ * ONE spelling, shared by the docked transport, the rail chrome and the OS
+ * lock screen — the same argument `nowPlaying`'s `trackLabel` makes for the
+ * track: three surfaces re-wording the same fact is three chances for the
+ * phone, the rail and the lock screen to describe different failures.
+ *
+ * The sentences are DISTINCT because the operator's next move is: a lost
+ * connection is worth pressing play for, and a source this browser cannot
+ * decode never will be — that second one is Kohina on iOS < 18.4, where the
+ * station is not down at all, it simply cannot be played here. Code 4 covers
+ * more than a codec (a 404 or a blocked cross-origin fetch land there too), so
+ * it is worded as "this source, here" rather than as a claim about the format.
+ */
+export function audioFailureLabel(failure: AudioFailure): string {
+  switch (failure) {
+    case "aborted":
+      return "playback was stopped before it started";
+    case "network":
+      return "connection lost";
+    case "decode":
+      return "the audio stream is corrupted";
+    case "unsupported":
+      return "this browser cannot play this source";
+    case "unknown":
+      return "playback failed";
+  }
+}
+
 /** Where the transport was when the element went away (#1734). */
 export type AudioResumePoint = {
   /** Seconds into the source. */
@@ -82,16 +132,61 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // "a NEW source does not inherit the previous one's position".
   const [resumePoint, setResumePoint] = createSignal<AudioResumePoint | null>(null);
 
+  // #1744 — WHY THE LAST LOAD ATTEMPT FAILED, or null when none has.
+  //
+  // A THIRD SIBLING SIGNAL, and by now the two comments above have said why
+  // twice: a field inside `AudioPlayerState` hands `on(activeAudio, …)` a new
+  // reference, that effect assigns `audioEl.src`, and assigning `.src`
+  // re-invokes the media load algorithm at an unchanged URL. Here the write
+  // happens in the ERROR handler, so the field version would restart the
+  // source on the very event saying the source cannot be started — an
+  // unbounded retry loop for a codec that will never decode. `href`/`label`
+  // describe the SOURCE, `playerHidden` the CHROME, `resumePoint` the
+  // TRANSPORT; this describes the last ATTEMPT to load. Four axes, four
+  // signals, one of which is the object.
+  //
+  // IT IS NOT A MIRROR OF `el.error`, and the difference is load-bearing.
+  // `el.error` is the element's CURRENT resource state and stays set until a
+  // new fetch lands; this is "the last attempt failed and nothing has been
+  // attempted since", which is what a SURFACE must say. `AudioMiniPlayer`'s
+  // `mustRefetch` keeps reading the element — it decides whether to call
+  // `load()` — and this decides what the operator is told. They disagree for
+  // exactly the length of a retry, on purpose.
+  //
+  // SOURCE-LIFETIME, not element-lifetime: every writer of `activeAudio` below
+  // clears it, for the reason `resumePoint` gives one comment up. It is NOT
+  // cleared on a re-mount, and that is deliberate — the component's element is
+  // destroyed and rebuilt when the operator leaves a scrollback window, and a
+  // source that could not be played before will not have become playable in
+  // the meantime; the re-tune that follows re-measures it anyway.
+  const [playbackFailure, setPlaybackFailure] = createSignal<AudioFailure | null>(null);
+
   onIdentityChange(() => {
     setActiveAudio(null);
     setPlayerHidden(false);
     setResumePoint(null);
+    setPlaybackFailure(null);
   });
 
   return {
     activeAudio,
     playerHidden,
     resumePoint,
+    playbackFailure,
+    // #1744 — called from the element's `error` handler with whatever the
+    // element holds. Takes the raw `MediaError` rather than a pre-classified
+    // reason so the mapping (and the `null` the DOM type allows) is decided
+    // ONCE, at this boundary, instead of in each caller.
+    reportPlaybackFailure(error: MediaError | null): void {
+      setPlaybackFailure(error === null ? "unknown" : (FAILURE_BY_CODE[error.code] ?? "unknown"));
+    },
+    // #1744 — the RETRY door: a new attempt invalidates the verdict on the last
+    // one. Without it a second failure of the same source writes the same value
+    // to this signal, nothing re-renders, and the operator presses play and
+    // watches the bar do nothing.
+    clearPlaybackFailure(): void {
+      setPlaybackFailure(null);
+    },
     // #1734 — called from the component's `onCleanup`, i.e. exactly once per
     // destruction, at the instant the fact is about to be lost. Deliberately
     // NOT written on every `timeupdate`: that would be four writes a second to
@@ -128,6 +223,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       // source's position and the new source landed at 0:42.
       // `[D] after playAudio: currentTime=0` then `after metadata: 42`.
       setResumePoint(null);
+      // #1744 — same instant, same reason, same ORDER: the verdict belongs to
+      // the source it was reached about, and the effect that runs synchronously
+      // inside the setter below must not see the previous source's failure.
+      setPlaybackFailure(null);
       setActiveAudio({ href, label });
       setPlayerHidden(false);
     },
@@ -141,6 +240,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       // the point today, and ordering it defensively costs nothing while
       // relying on that fact costs the next reader a measurement.
       setResumePoint(null);
+      // #1744 — a dismissed player must not leave a failure notice for the next
+      // source, exactly as #1697 says of the hidden flag.
+      setPlaybackFailure(null);
       setActiveAudio(null);
       setPlayerHidden(false);
     },
@@ -165,4 +267,7 @@ export const {
   showPlayer,
   resumePoint,
   rememberResumePoint,
+  playbackFailure,
+  reportPlaybackFailure,
+  clearPlaybackFailure,
 } = exports_;

--- a/cicchetto/src/lib/mediaSession.ts
+++ b/cicchetto/src/lib/mediaSession.ts
@@ -1,4 +1,4 @@
-import { activeAudio } from "./audioPlayer";
+import { activeAudio, audioFailureLabel, playbackFailure } from "./audioPlayer";
 import { nowPlaying } from "./nowPlaying";
 import { tunedStation } from "./radio";
 
@@ -109,6 +109,15 @@ export function mediaSessionMetadata(): MediaSessionMetadata | null {
   const audio = activeAudio();
   if (audio === null) return null;
 
+  // #1744 — the failure OUTRANKS the track, on both arms below. The OS is the
+  // fourth surface and on a phone it is often the only one awake: the screen
+  // is locked, the docked bar is behind it, the rail is a drawer off-screen.
+  // A lock screen naming a track over a stream that never decoded is the
+  // silence this issue is about, one layer out — and it is the same rule the
+  // `stale` arm obeys further down: cic must not assert to the OS something it
+  // has stopped telling the operator.
+  const failure = playbackFailure();
+
   const station = tunedStation();
   if (station === null) {
     // An upload, or any source outside the curated table. No station, no feed,
@@ -116,13 +125,29 @@ export function mediaSessionMetadata(): MediaSessionMetadata | null {
     // rather than be handed some other station's art.
     return {
       title: audio.label ?? uploadTitle(audio.href),
-      artist: "",
+      artist: failure === null ? "" : audioFailureLabel(failure),
       album: "",
       artwork: [],
     };
   }
 
   const artwork = [artworkFor(station.logoUrl)];
+
+  // The ARTIST slot, and it is not a compromise: it is the second line, and on
+  // a failure there is no track and therefore no artist to displace. `title`
+  // keeps naming the SOURCE, which is what completes the sentence — "Groove
+  // Salad / connection lost". Putting the reason in `title` would cost the
+  // operator the name of the thing that failed.
+  //
+  // `playbackState` is deliberately NOT moved to "none" alongside this. The
+  // platform's three states are `none | paused | playing`, and a UA is free to
+  // drop the whole now-playing card on "none" — which would take this sentence
+  // off the lock screen along with the transport button that `playNow` already
+  // retries through. Read off the Media Session spec, not measured on a device.
+  if (failure !== null) {
+    return { title: station.title, artist: audioFailureLabel(failure), album: "", artwork };
+  }
+
   const state = nowPlaying();
 
   // Matching `playing` alone is the STALE RULE, and it is deliberate: reading

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3850,6 +3850,23 @@ html.resize-dragging * {
   color: var(--fg-dim, var(--fg));
 }
 
+/* #1744 — why the source will not play, in the slot the track vacates. It
+   inherits the track's contract exactly (grow 2, shrink 1, `min-width: 0`,
+   clip) rather than declaring a new one: it stands in the same place, on the
+   same row, and a span that could widen the row would push ✕ off a phone —
+   the failure this file's #1698 note and `audioMiniPlayerLayout.test.ts` both
+   exist to prevent. Pinned there alongside its two neighbours.
+   `--error` with the same fallback every other error text in this sheet uses,
+   so a theme that recolours failures recolours this one too. */
+.audio-mini-player-error {
+  flex: 2 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--error, #e06c75);
+}
+
 /* #682 — the "this has no end" badge that stands in for the seek slider.
    Deliberately a LABEL and not a disabled slider: a greyed-out position bar
    still draws a scale, and there is no scale — the operator would read a

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2358,6 +2358,7 @@ html.resize-dragging * {
    swap and not a third line. */
 .rail-radio-now-genres,
 .rail-radio-now-track,
+.rail-radio-now-error,
 .rail-radio-station-genres {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2370,6 +2371,15 @@ html.resize-dragging * {
    metadata, the track is the live fact this row exists to carry. */
 .rail-radio-now-track {
   color: var(--fg-dim, var(--fg));
+}
+
+/* #1744 — the third tenant of that one line, and the only one that is bad
+   news. It shares the clipping rule above for #500's reason (the chrome's
+   height must not depend on what the second line says) and takes the same
+   `--error` the docked bar's notice takes, so one failure reads as one thing
+   across both surfaces. */
+.rail-radio-now-error {
+  color: var(--error, #e06c75);
 }
 
 /* #1697 — the only delta left. Everything this rule used to declare

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61734,3 +61734,122 @@ correct whatever starves it.
 **So this does not close #1715, and it does not claim to stop the starvation.**
 It stops the starvation from being reported as a stack trace pointing at
 innocent code.
+<!-- entry #1744 -->
+
+---
+
+## 2026-08-24 — #1744: a stream that will not start now says so, on every surface that was claiming otherwise
+
+`el.error` had a reader (`mustRefetch`, #1700) and no VIEWER. A station
+that failed to start looked exactly like one the operator had paused,
+which is the worst of the failure modes: there is nothing to tell you
+whether to wait, press play again, or pick something else.
+
+**Where the fact lives: a fourth sibling signal, and by now that is a
+rule.** The obvious home is a field on `AudioPlayerState`, and it is the
+same trap #1697 (`hidden`) and #1734 (`resumePoint`) each walked up to
+and stepped around. `AudioMiniPlayer` drives the element from
+`createEffect(on(activeAudio, …))` whose body assigns `audioEl.src`, and
+assigning `.src` re-invokes the media load algorithm even at an
+unchanged URL — so a field in that object hands the effect a new
+reference and RESTARTS the source. Here the write happens in the ERROR
+handler, so the field version restarts the source on the very event
+saying the source cannot be started: an unbounded retry loop for a codec
+that will never decode. Three issues, one edge, one remedy — the shape
+of the object is the defect, and `playbackFailure` is declared beside
+`activeAudio`, not inside it. Four axes now, four signals: `href`/`label`
+describe the SOURCE, `playerHidden` the CHROME, `resumePoint` the
+TRANSPORT, `playbackFailure` the last ATTEMPT to load. Pinned by the
+same-reference assertion #1697 introduced, now in its third copy.
+
+**It is not a second predicate beside `mustRefetch`, and it is not a
+mirror of `el.error`.** #1700 ruled that the predicate is one, and this
+does not add one — for two independent reasons, either sufficient.
+`mustRefetch` is `el.error !== null || live()`, so it is TRUE for every
+healthy live stream; a surface gated on it would show a failure on every
+station that works. And it is a question asked OF THE ELEMENT at the
+instant of a decision, over a plain property Solid cannot subscribe to,
+so no amount of asking re-renders anything. What the signal records is
+the EVENT. The two then answer different questions and are allowed to
+disagree: `el.error` is the element's CURRENT resource state and stays
+set until a new fetch lands, while the signal means "the last attempt
+failed and nothing has been attempted since" — which is what a surface
+must say. `playNow` clears the signal and deliberately does not touch
+`el.error`, so `mustRefetch` still decides to `load()`. That clear is
+also what makes a REPEATED failure visible: the same reason written to
+the same signal changes nothing, so without it the operator presses play
+on a source that cannot play and the bar sits there unchanged.
+
+**Source-lifetime, not element-lifetime.** Every writer of `activeAudio`
+clears it (the `resumePoint` discipline, extended), and identity
+rotation clears it with the rest of the store. It is deliberately NOT
+cleared on a re-mount: leaving a scrollback window destroys the element,
+and a source that could not be played will not have become playable in
+the meantime — the re-tune that follows re-measures it anyway.
+
+**Four codes, five reasons, one spelling.** `MediaError` is classified
+ONCE at the store boundary into a closed set, plus an `unknown` arm for
+a code the spec does not define and for the `null` the DOM type allows —
+a failure we cannot NAME is still a failure the operator must see.
+`audioFailureLabel` is the single spelling, shared by the three
+surfaces, for the reason `nowPlaying`'s `trackLabel` gives. The
+sentences are distinct because the next move is: a lost connection is
+worth re-pressing play for and a source this browser cannot decode never
+will be. Code 4 is worded as "this source, here" rather than as a claim
+about the format, because it also covers a 404 and a blocked
+cross-origin fetch.
+
+**Three surfaces, because fixing one leaves the others lying.** The
+docked bar (the notice takes the TRACK's slot — the feed polls
+`tunedStation()`, derived from the SOURCE, so a live-updating track name
+keeps scrolling over silence, which is the loudest way a dead station
+looks like a playing one) and its READOUT (dropped entirely: with no
+metadata `duration` is a finite 0, so `live()` is false and the row drew
+a scrubber at `max="0"` and a `0:00 / 0:00` clock over a resource that
+does not exist; the live arm is no better, being a frozen counter under
+a "live" badge). The RAIL chrome, which is the desktop answer to "what
+is playing" and the only surface left standing when the operator hides
+the bar (#1697). And the OS LOCK SCREEN, which on a phone is often the
+only one awake.
+
+**The download anchor is the exception, and finding it split a `<Show>`
+in two.** It sat inside the file readout because the two share a
+predicate, not because they answer the same question — and an upload the
+browser cannot DECODE is exactly the upload the operator wants to SAVE
+and open in something that can. It is not a claim about playback; it is
+the remedy for the notice beside it. So the notice replaces the readout
+and the anchor keeps #682's own `live()` gate, unchanged. Caught by
+reading `media-link-modal-viewer.spec.ts`, which uploads a deliberately
+FAKE mp3 and then asserts the download affordance — a real browser fails
+that body, so the first shape of this fix would have gone red in e2e
+having been green in every unit test.
+
+**The lock screen gets the reason in the ARTIST slot and keeps
+`playbackState` at `paused`.** Artist because it is the second line and
+a failure has no track and therefore no artist to displace, while
+`title` must keep naming the SOURCE or the sentence loses what failed.
+`playbackState` because the platform's three states are `none | paused |
+playing`, "none" is the only one that could mean broken, and a UA is
+free to drop the whole now-playing card on "none" — which would take the
+message off the lock screen along with the transport button `playNow`
+already retries through. Read off the Media Session spec; not measured
+on a device.
+
+**What was deliberately NOT changed, each named so it is not
+rediscovered as new.** The TOGGLE: it reads ▶ and pressing it already
+re-fetches (#1700), so it was never the lie — the missing thing was
+knowing there was something to retry, and that is the notice, not a
+fourth glyph. `/np` and `nowPlaying()`: the store is not keyed on PAUSE
+either, deliberately, so it means "what the station is broadcasting, as
+far as we know" rather than "what the operator is hearing", and a failed
+element does not change what the station is broadcasting. Whether `/np`
+should refuse when cic is not actually hearing the track (paused or
+failed) is a real question about what that command asserts, and it is a
+different one. The download's gate: still `live()`, so a stream that
+failed before metadata reads a finite `duration` of 0 and still renders
+the anchor on an endless cross-origin href — the honest gate is
+same-origin, which is #682's own second reason spelled as a test instead
+of inferred from the first. And a HIDDEN bar on a phone: the rail is
+off-screen there, so the OS lock screen is the only surface carrying the
+failure. Auto-showing the bar was considered and rejected — the operator
+asked for it to be gone, and cic does not originate state.


### PR DESCRIPTION
Fixes the general defect behind #1744: `el.error` had a reader
(`mustRefetch`, #1700) and no VIEWER, so a source that failed to start
rendered exactly like one the operator had paused.

## Where the fact lives — a fourth sibling signal, not a field

The obvious home is a field on `AudioPlayerState`. It is the same edge
#1697 (`hidden`) and #1734 (`resumePoint`) each walked up to and stepped
around: `AudioMiniPlayer` drives the element from
`createEffect(on(activeAudio, …))`, whose body assigns `audioEl.src`, and
assigning `.src` re-invokes the media load algorithm even at an unchanged
URL — so a field there hands the effect a new reference and RESTARTS the
source. Here the write happens in the ERROR handler, so the field shape
restarts the source on the very event saying the source cannot be
started: an unbounded retry loop for a codec that will never decode.

Third visit, one remedy: `playbackFailure` is declared beside
`activeAudio`. Four axes, four signals — `href`/`label` = the SOURCE,
`playerHidden` = the CHROME, `resumePoint` = the TRANSPORT,
`playbackFailure` = the last ATTEMPT to load. Pinned by the
same-reference assertion #1697 wrote, now in its third copy.

## Not a second predicate beside `mustRefetch`

#1700 ruled the predicate is one, and this does not add one — two
independent reasons, either sufficient:

* `mustRefetch` is `el.error !== null || live()`, so it is TRUE for every
  healthy live stream. A surface gated on it would report a failure on
  every station that works.
* It is a question asked OF THE ELEMENT over a plain property Solid
  cannot subscribe to, so no amount of asking re-renders anything.

They answer different questions and are allowed to disagree: `el.error`
is the element's CURRENT resource state and stays set until a new fetch
lands; the signal means "the last attempt failed and nothing has been
attempted since". `playNow` clears the signal and deliberately leaves
`el.error` alone, so `mustRefetch` still decides to `load()`. That clear
is also what makes a REPEATED failure visible.

## Three surfaces, because fixing one leaves the others lying

| surface | before | after |
|---|---|---|
| docked bar | file readout: scrubber at `max="0"`, `0:00 / 0:00` | the notice, in the track's slot; no readout |
| rail chrome | station + genres/track, as if on air | the notice, in the genres' slot |
| OS lock screen | `paused`, no reason | the reason in the ARTIST slot |

The bar was not merely mute: `loadedmetadata` never arrives, so
`duration` stays at a FINITE 0, `live()` answers false, and the row drew
FILE chrome over an endless stream. The track goes too — the feed polls
`tunedStation()`, derived from the SOURCE, so a live-updating track name
keeps scrolling over silence, which is the loudest way a dead station
looks like a playing one.

## The download anchor is the exception — and an e2e caught it

The first shape of this fix dropped the whole file chrome, download
included. `media-link-modal-viewer.spec.ts` uploads a deliberately FAKE
mp3 and then asserts the download affordance; a real browser fails that
body, so that shape would have gone red in e2e having been green in
every unit test. Reading it produced the right rule rather than just the
fix: an upload the browser cannot DECODE is exactly the upload the
operator wants to SAVE and open elsewhere. The anchor is not a claim
about playback — it is the remedy for the notice beside it. It keeps
#682's own `live()` gate, unchanged.

## Deliberately NOT changed (each named in DESIGN_NOTES)

* **The toggle.** It reads ▶ and pressing it already re-fetches (#1700);
  it was never the lie. What was missing was knowing there was something
  to retry.
* **`/np` and `nowPlaying()`.** That store is not keyed on PAUSE either,
  deliberately, so it means "what the station is broadcasting" and not
  "what the operator is hearing". Whether `/np` should refuse when cic is
  not actually hearing the track is a real question about what the
  command asserts, and a different one.
* **The download's `live()` gate.** A stream that failed BEFORE metadata
  reads a finite `duration` of 0, so the anchor still renders on an
  endless cross-origin href. The honest gate is same-origin — #682's own
  second reason spelled as a test rather than inferred from the first.
  Pre-existing, unchanged, now named in the code.
* **`playbackState`.** Left at `paused`: "none" is the only state that
  could mean broken, and a UA may drop the whole now-playing card on it,
  taking the message off the lock screen with it. Spec reading, not a
  device measurement.
* **A hidden bar on a phone.** The rail is off-screen there, so the lock
  screen is the only carrier. Auto-showing the bar was rejected — the
  operator asked for it to be gone, and cic does not originate state.

## Gates

* `bun run test`: **312 files / 6117 tests green** (baseline 6083 → +34).
* `bun run check`: green. 59 biome warnings, all pre-existing, none in a
  touched file.
* `scripts/design-notes-gate.sh origin/main`: green. Base is an exact
  prefix, +119/−0, marker unique.
* No rebase was needed — `origin/main` did not move (`0c46584e`).

Unblocks #1704 (Kohina).

— w2