### PR TITLE
#1704 — Kohina ships, and the table learns to say "this station has no logo"

### DIFF
--- a/cicchetto/e2e/tests/issue1704-kohina-undecodable-surface.spec.ts
+++ b/cicchetto/e2e/tests/issue1704-kohina-undecodable-surface.spec.ts
@@ -1,0 +1,144 @@
+// #1704 — Kohina ships knowing it will NOT play for some phones, and this spec
+// is the reason that is allowed.
+//
+// THE SHIP ARGUMENT, and what it rests on. Every other row in the curated table
+// is `audio/mpeg`; Kohina is Ogg Vorbis, measured off the stream's own bytes
+// (`OggS` then `\x01vorbis`). Per the vendored caniuse-lite, iOS Safari decodes
+// Ogg Vorbis from 18.4 (`y`), is partial from 17.4 to 18.3 (`a`, and the packed
+// data carries no note text to say partial HOW), and does not decode it at all
+// at 17.3 and below (`n`). So this row is silent for a population — and #1703's
+// standing condition was that a station which cannot play must not ship while a
+// stream that fails says nothing to anybody. #1744 built the saying-so; this
+// spec is the proof that it fires, in a real browser, for THIS row.
+//
+// WHY A FAKE BODY AND NOT A REAL OGG. The point under test is the SURFACE, not
+// anyone's codec support: `route.fulfill` serves bytes that are not decodable
+// audio, so the element takes its resource-failure path and populates
+// `MediaError` — which is the same door an unsupported codec walks through. A
+// real Ogg body would instead measure whether THIS Playwright build decodes
+// Vorbis, which is a fact about this Playwright build and not about iOS 17.3.
+//
+// ⚠️ WHAT THIS DOES NOT ESTABLISH, stated because a green here is easy to
+// over-read. It does not establish that iOS below 18.4 fails on Kohina — that
+// is caniuse's claim and it is not measurable from CI at any browser version we
+// can drive. What it establishes is the conditional: GIVEN the element reports
+// a media error, the operator is told, on the transport and on the rail, and
+// the bar stops dressing the dead source as a zero-second file. The spec runs
+// on both configured projects, so the WebKit half is measured on WebKit rather
+// than inferred from Chromium.
+
+import {
+  closeMembersDrawer,
+  loginAs,
+  openRailMenu,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Literals, not an import from `src/lib/radioStations` — the posture #682's
+// spec established one file over: a table edit that drops or renames this
+// station must fail HERE, loudly, rather than have the spec follow the rename
+// and assert nothing about what shipped.
+const STATION_ID = "kohina";
+const STATION_TITLE = "Kohina";
+const STATION_STREAM = "https://kohina.brona.dk/icecast/stream.ogg";
+
+test.setTimeout(90_000);
+
+test("#1704 — a Kohina stream the browser cannot decode says so on every surface", async ({
+  page,
+}) => {
+  let streamRequests = 0;
+
+  // Bytes that are NOT decodable audio, served under the type Kohina really
+  // answers with. Scoped to the station's real host so a change that stops
+  // requesting that URL fails here instead of quietly passing.
+  await page.route("https://kohina.brona.dk/**", async (route) => {
+    streamRequests += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "audio/ogg",
+      body: Buffer.from("this is not an ogg vorbis stream", "utf8"),
+    });
+  });
+
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  await openRailMenu(page);
+  await page.getByTestId("rail-action-radio").click();
+  await expect(page.getByTestId("rail-radio-picker")).toBeVisible();
+  await page.getByTestId(`rail-radio-station-${STATION_ID}`).click();
+
+  const audio = page.getByTestId("audio-mini-player-el");
+  await expect(audio).toHaveJSProperty("src", STATION_STREAM);
+  await expect.poll(() => streamRequests, { timeout: 10_000 }).toBeGreaterThan(0);
+
+  // The element really failed — the precondition of everything below, asserted
+  // rather than assumed, because a spec whose subject never happened would pass
+  // its remaining assertions vacuously. The CODE is deliberately not pinned to
+  // 4: the two engines are free to classify an unusable resource differently,
+  // and the surface's job is to name whatever they said, not to make them agree.
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () =>
+            document.querySelector<HTMLAudioElement>("[data-testid='audio-mini-player-el']")?.error
+              ?.code ?? 0,
+        ),
+      { timeout: 15_000 },
+    )
+    .toBeGreaterThan(0);
+
+  // Picking deliberately leaves the picker up (#682: auditioning stations is a
+  // control the operator flips in place), and the picker is an `inset: 0`
+  // overlay ON the rail — so the station chrome underneath it is only genuinely
+  // on screen once the picker is dismissed. Closing it is what makes the next
+  // assertion a claim about something an operator could actually see.
+  await page.getByTestId("rail-radio-picker-close").click();
+  await expect(page.getByTestId("rail-radio-picker")).toHaveCount(0);
+
+  // (1) THE RAIL SAYS IT — the desktop answer to "what is playing", and the one
+  // left standing when the operator hides the docked transport (#1697).
+  await expect(page.getByTestId("rail-radio-now-error")).toBeVisible();
+  await expect(page.getByTestId("rail-radio-now-title")).toHaveText(STATION_TITLE);
+
+  // (2) And the station Kohina publishes no logo for draws SOMETHING — our own
+  // placeholder, never a broken-image glyph. Asserted as the SHAPE (a data URI)
+  // rather than the exact bytes, which `radioLogoPlaceholder.test.ts` pins.
+  await expect(page.locator(".rail-radio-now-logo")).toHaveAttribute(
+    "src",
+    /^data:image\/svg\+xml,/,
+  );
+
+  // On the iPhone profile the rail is a DRAWER whose backdrop is a full-viewport
+  // scrim over the docked transport; on desktop there is no drawer and no
+  // backdrop. Guarded on the element rather than on the project name, so the
+  // spec follows the app's own layout rule instead of restating it.
+  const backdrop = page.locator(".shell-drawer-backdrop.open");
+  if ((await backdrop.count()) > 0) await closeMembersDrawer(page);
+
+  // (3) THE OPERATOR IS TOLD ON THE TRANSPORT. Asserted as "there is a sentence
+  // here" rather than as one particular sentence: which of the five reasons the
+  // element reported is the engine's call, and pinning the prose would make a
+  // wording change a spec failure while a SILENT bar stayed green — the wrong
+  // way round.
+  const notice = page.getByTestId("audio-mini-player-error");
+  await expect(notice).toBeVisible();
+  await expect(notice).toHaveText(/\S{4,}/);
+
+  // (4) AND THE BAR STOPS LYING. The half a "some text appeared" assertion would
+  // miss: with no metadata the element's `duration` is a finite 0, so before
+  // #1744 this row drew the FILE readout — a scrubber at `max="0"` and a
+  // `0:00 / 0:00` clock over a stream that produced no audio at all.
+  await expect(page.getByTestId("audio-mini-player-seek")).toHaveCount(0);
+  await expect(page.getByTestId("audio-mini-player-time")).toHaveCount(0);
+
+  // (5) The station is still NAMED. A reason with nothing beside it does not
+  // tell the operator which station to re-pick.
+  await expect(page.getByTestId("audio-mini-player-label")).toHaveText(STATION_TITLE);
+});

--- a/cicchetto/scripts/check-radio-logos-core.ts
+++ b/cicchetto/scripts/check-radio-logos-core.ts
@@ -78,15 +78,18 @@ export const FEED_CONTENT_TYPE = "application/json";
 /** Whether AGREE has anything to say about this station. A station pointing at
     another provider is outside the catalogue's scope — the table is allowed to
     hold one. Exported so the test can assert the axis is NOT vacuous over the
-    real table; a green built from zero comparisons is silence, not agreement. */
-export function isCatalogueBacked(logoUrl: string): boolean {
-  return new URL(logoUrl).host.endsWith("somafm.com");
+    real table; a green built from zero comparisons is silence, not agreement.
+    #1704 — `null` (the station publishes NO logo) is outside that scope too,
+    and for a stronger reason than a foreign provider: there is no URL for the
+    catalogue to disagree with. */
+export function isCatalogueBacked(logoUrl: string | null): boolean {
+  return logoUrl !== null && new URL(logoUrl).host.endsWith("somafm.com");
 }
 
 /** `null` when the baked URL is the one the catalogue publishes; otherwise the
     disagreement, spelled so the reader can paste the fix straight in. */
 export function agreeFailure(
-  logoUrl: string,
+  logoUrl: string | null,
   id: string,
   catalogue: ReadonlyMap<string, string>,
 ): string | null {
@@ -101,7 +104,11 @@ export function agreeFailure(
 
 export type StationFinding = {
   readonly id: string;
-  readonly logoUrl: string;
+  /** #1704 — the station's logo, or `null` when it publishes none. Carried as
+      a null rather than an empty string for the reason `feedUrl` below gives:
+      the report has to be able to print a SKIPPED row as skipped, and an empty
+      string reads as a probed URL that happened to be blank. */
+  readonly logoUrl: string | null;
   /** #1698 — the station's now-playing feed, or null when it publishes none.
       Carried so the report line can name the URL that failed, and so a null
       row is visibly SKIPPED rather than silently absent. */
@@ -114,6 +121,23 @@ export type StationFinding = {
       red. */
   readonly feed: string | null;
 };
+
+/** How many of `findings` were actually PROBED on each axis.
+ *
+ * #1704 — the denominator, and it exists because both `logoUrl` and `feedUrl`
+ * are nullable now: "21 stations checked, 0 broken" says nothing about how
+ * many logos were fetched, and on a table where the field had gone uniformly
+ * null it would report a perfect green having probed nothing. Same vacuity
+ * argument `isCatalogueBacked` is exported for. */
+export function probedCounts(findings: readonly StationFinding[]): {
+  readonly logos: number;
+  readonly feeds: number;
+} {
+  return {
+    logos: findings.filter((f) => f.logoUrl !== null).length,
+    feeds: findings.filter((f) => f.feedUrl !== null).length,
+  };
+}
 
 /** Every problem found for one station, all three axes, in report order. */
 export function problems(finding: StationFinding): readonly string[] {

--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -61,6 +61,7 @@ import {
   FEED_CONTENT_TYPE,
   LOGO_CONTENT_TYPE,
   problems,
+  probedCounts,
   reachFailure,
   type StationFinding,
 } from "./check-radio-logos-core";
@@ -112,7 +113,13 @@ const findings: StationFinding[] = await Promise.all(
     id: station.id,
     logoUrl: station.logoUrl,
     feedUrl: station.songsUrl,
-    reach: await probeReach(station.logoUrl, LOGO_CONTENT_TYPE),
+    // #1704 — a station that publishes NO logo is not probed and is not a
+    // finding, the same arm `songsUrl` has had since #1698. There is no URL to
+    // reach; what the UI draws instead is our own placeholder, which cannot
+    // 404. Counted out of the denominator below rather than folded into the
+    // green.
+    reach:
+      station.logoUrl === null ? null : await probeReach(station.logoUrl, LOGO_CONTENT_TYPE),
     agree: agreeFailure(station.logoUrl, station.id, catalogue),
     // A station that publishes no feed is not probed and is not a finding.
     feed:
@@ -130,7 +137,8 @@ const idWidth = Math.max(...findings.map((f) => f.id.length)) + 2;
 for (const finding of findings) {
   const found = problems(finding);
   console.log(
-    `  ${found.length === 0 ? "ok  " : "FAIL"}  ${finding.id.padEnd(idWidth)}${finding.logoUrl}`,
+    `  ${found.length === 0 ? "ok  " : "FAIL"}  ${finding.id.padEnd(idWidth)}` +
+      `${finding.logoUrl ?? "(no logo — placeholder)"}`,
   );
   // The feed URL is printed on its own line rather than folded into the one
   // above: a station has two URLs now, and a report that names only one leaves
@@ -148,10 +156,13 @@ const broken = brokenCount(findings);
 // adds a SECOND denominator for the same reason — the FEED axis skips a
 // station that publishes none, so "14 stations checked" alone would read as
 // "14 feeds checked" on a table where the field had gone uniformly null.
-const feedsProbed = findings.filter((f) => f.feedUrl !== null).length;
+// #1704 adds the logo half of that same denominator, now that `logoUrl` is
+// nullable too: without it a table whose logos had all gone null would report
+// "21 stations checked, 0 broken" having fetched nothing at all.
+const probed = probedCounts(findings);
 console.log(
   `\ncheck:radio summary — ${findings.length} stations checked ` +
-    `(${feedsProbed} with a now-playing feed), ${broken} broken`,
+    `(${probed.logos} with a logo, ${probed.feeds} with a now-playing feed), ${broken} broken`,
 );
 
 process.exit(broken === 0 ? 0 : 1);

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -1,10 +1,11 @@
-import { type Component, For, Show } from "solid-js";
+import { type Component, createSignal, For, Show } from "solid-js";
 import { audioFailureLabel, closeAudio, playbackFailure } from "./lib/audioPlayer";
 import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
 import { nowPlayingLabel } from "./lib/nowPlaying";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { closeRadioPicker, radioPickerOpen, tunedStation, tuneStation } from "./lib/radio";
-import { RADIO_STATIONS } from "./lib/radioStations";
+import { radioLogoPlaceholder } from "./lib/radioLogoPlaceholder";
+import { RADIO_STATIONS, type RadioStation } from "./lib/radioStations";
 import PaneTopBar from "./PaneTopBar";
 
 // #682 — the rail's internet-radio surface: a station PICKER and, once
@@ -55,6 +56,42 @@ import PaneTopBar from "./PaneTopBar";
 // in place and re-flips — `denoise` there — is not. Auditioning stations is
 // the second kind, so the picker stays up and marks the tuned row.
 
+// #1704 — the ONE place a station's artwork is drawn, and the two cases it has
+// to survive. Both render sites used to be a bare `<img src={station.logoUrl}>`
+// with no error handling, so a 404 drew the browser's broken-image glyph and a
+// station with no logo could not be expressed at all.
+//
+// TWO DIFFERENT FACTS, ONE STAND-IN. `logoUrl === null` is a DECLARED absence,
+// known when the table is written and true forever (Kohina publishes no station
+// artwork — only a 192px favicon, which is why pointing the field at that
+// favicon was refused: it ANSWERS 200, so no error handler would ever fire and
+// the picker would quietly render a favicon where a logo goes). `onError` is
+// the other one: a URL we believed in that broke at runtime. `bun run
+// check:radio` already gates the URLs, so that second path can only fire on a
+// transient upstream failure — which is exactly when a placeholder beats a
+// broken-image glyph, and never a reason not to fix a logo the gate reports.
+//
+// The swap is a SIGNAL and not `e.currentTarget.src = …` on purpose: writing
+// the src from inside `onError` re-enters the handler if the replacement also
+// fails, and the guard against that loop is a comparison somebody has to keep
+// right. A signal cannot loop — the second failure writes `true` over `true`
+// and Solid re-renders nothing.
+const StationLogo: Component<{ readonly station: RadioStation; readonly class: string }> = (
+  props,
+) => {
+  const [broken, setBroken] = createSignal(false);
+  const src = (): string =>
+    broken() || props.station.logoUrl === null
+      ? radioLogoPlaceholder(props.station.id, props.station.title)
+      : props.station.logoUrl;
+
+  return (
+    // Decorative in both slots: the title sits beside it in the markup, so alt
+    // text would be read out twice by a screen reader.
+    <img class={props.class} src={src()} alt="" onError={() => setBroken(true)} />
+  );
+};
+
 const RailRadio: Component = () => {
   let rootRef: HTMLDivElement | undefined;
 
@@ -69,9 +106,7 @@ const RailRadio: Component = () => {
       <Show when={tunedStation()}>
         {(station) => (
           <div class="rail-radio-now" data-testid="rail-radio-now">
-            {/* Decorative: the title beside it already names the station, so
-                alt text would be read out twice by a screen reader. */}
-            <img class="rail-radio-now-logo" src={station().logoUrl} alt="" />
+            <StationLogo station={station()} class="rail-radio-now-logo" />
             <div class="rail-radio-now-text">
               <span class="rail-radio-now-title" data-testid="rail-radio-now-title">
                 {station().title}
@@ -194,7 +229,7 @@ const RailRadio: Component = () => {
                   aria-pressed={tunedStation()?.id === station.id ? "true" : "false"}
                   title={station.description}
                 >
-                  <img class="rail-radio-station-logo" src={station.logoUrl} alt="" />
+                  <StationLogo station={station} class="rail-radio-station-logo" />
                   <span class="rail-radio-station-text">
                     <span class="rail-radio-station-title">{station.title}</span>
                     <span class="rail-radio-station-genres">{station.genres.join(" · ")}</span>

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -939,6 +939,36 @@ describe("AudioMiniPlayer", () => {
       expect(screen.getByTestId("audio-mini-player-seek")).toBeInTheDocument();
     });
 
+    // #1704 — the SHIP ARGUMENT for Kohina, bound to the row that actually
+    // shipped rather than to a URL typed here.
+    //
+    // Kohina is the table's first Ogg Vorbis row, and per the vendored
+    // caniuse-lite iOS Safari does not decode Ogg Vorbis below 17.4 and is
+    // partial from 17.4 to 18.3. #1703's standing condition was that such a
+    // station must not ship while a stream that fails says nothing — so the
+    // condition is discharged by THIS behaviour, and if it ever regresses the
+    // row should come out of the table. A test tied to a hand-typed URL would
+    // keep passing after the row was renamed or dropped; this one reads the
+    // table.
+    it("names the failure for the curated Ogg station, whose population needs it", async () => {
+      const { RADIO_STATIONS } = await import("../lib/radioStations");
+      const ogg = RADIO_STATIONS.find((s) => s.streamUrl.endsWith(".ogg"));
+      if (ogg === undefined) throw new Error("the table no longer carries an ogg station");
+
+      render(() => <AudioMiniPlayer />);
+      playAudio(ogg.streamUrl, ogg.title);
+
+      failWith(4);
+
+      expect(screen.getByTestId("audio-mini-player-error")).toHaveTextContent(
+        audioFailureLabel("unsupported"),
+      );
+      expect(screen.getByTestId("audio-mini-player-label")).toHaveTextContent(ogg.title);
+      // And it is not wearing the file chrome the measurement found: no
+      // scrubber over a stream that produced nothing.
+      expect(screen.queryByTestId("audio-mini-player-seek")).toBeNull();
+    });
+
     it("still reads ▶, and pressing it is still the retry", () => {
       // Deliberately unchanged. The toggle was never the lie — it says "not
       // playing", which is true, and #1700 already made pressing it re-fetch.

--- a/cicchetto/src/__tests__/RailRadio.test.tsx
+++ b/cicchetto/src/__tests__/RailRadio.test.tsx
@@ -9,6 +9,7 @@ import {
   reportPlaybackFailure,
 } from "../lib/audioPlayer";
 import { closeRadioPicker, openRadioPicker, radioPickerOpen } from "../lib/radio";
+import { radioLogoPlaceholder } from "../lib/radioLogoPlaceholder";
 import { RADIO_STATIONS } from "../lib/radioStations";
 import RailRadio from "../RailRadio";
 
@@ -297,6 +298,75 @@ describe("RailRadio", () => {
 
     expect(screen.queryByTestId("rail-radio-now-track")).toBeNull();
     expect(screen.getByTestId("rail-radio-now-genres")).toBeInTheDocument();
+  });
+
+  // #1704 — THE LOGO A STATION DOES NOT HAVE, and the one it has that breaks.
+  //
+  // Both render sites were a bare `<img>` with no error handling before this,
+  // so a 404 drew the browser's broken-image glyph and "no logo" could not be
+  // said at all. `logoUrl` is nullable now (Kohina publishes only a favicon),
+  // and both cases land on the same stand-in — but they are DIFFERENT facts and
+  // both are exercised here: one is declared in the table, the other happens at
+  // runtime.
+  describe("a station with no logo, and a logo that breaks (#1704)", () => {
+    const logoless = RADIO_STATIONS.find((s) => s.logoUrl === null);
+    const withLogo = RADIO_STATIONS.find((s) => s.logoUrl !== null);
+    if (logoless === undefined || withLogo === undefined) {
+      throw new Error("these tests need one station with a logo and one without in the table");
+    }
+
+    const rowLogo = (container: HTMLElement, id: string): HTMLImageElement => {
+      const img = container.querySelector<HTMLImageElement>(
+        `[data-testid="rail-radio-station-${id}"] img`,
+      );
+      if (img === null) throw new Error(`no logo <img> rendered for station ${id}`);
+      return img;
+    };
+
+    it("draws our own placeholder for a station that publishes none", () => {
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+
+      // The production generator, not a copy of its output: a test holding a
+      // hand-pasted data URI would pass while the tile silently changed.
+      expect(rowLogo(container, logoless.id).getAttribute("src")).toBe(
+        radioLogoPlaceholder(logoless.id, logoless.title),
+      );
+    });
+
+    it("still draws the real logo for a station that has one", () => {
+      // The control. Without it, a predicate inverted by one edit would put the
+      // placeholder on every row and every other assertion here would pass.
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+
+      expect(rowLogo(container, withLogo.id).getAttribute("src")).toBe(withLogo.logoUrl);
+    });
+
+    it("falls back to the placeholder when a real logo fails to load", () => {
+      // The runtime half. `check:radio` gates these URLs, so this can only fire
+      // on a transient upstream failure — which is exactly when a tile beats
+      // the browser's broken-image glyph.
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+      const img = rowLogo(container, withLogo.id);
+
+      img.dispatchEvent(new Event("error"));
+
+      expect(img.getAttribute("src")).toBe(radioLogoPlaceholder(withLogo.id, withLogo.title));
+    });
+
+    it("the rail chrome uses the same stand-in as the picker row", () => {
+      // One component behind both sites: the tuned-station chrome and the list
+      // row must not disagree about what a station looks like, and before this
+      // they were two hand-copied <img> tags free to drift.
+      const { container } = render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${logoless.id}`).click();
+
+      const chrome = container.querySelector<HTMLImageElement>(".rail-radio-now-logo");
+      expect(chrome?.getAttribute("src")).toBe(radioLogoPlaceholder(logoless.id, logoless.title));
+    });
   });
 
   // #1744 — the rail's chrome is the DESKTOP answer to "what is playing", and

--- a/cicchetto/src/__tests__/checkRadioLogos.test.ts
+++ b/cicchetto/src/__tests__/checkRadioLogos.test.ts
@@ -4,6 +4,7 @@ import {
   brokenCount,
   catalogueLogos,
   isCatalogueBacked,
+  probedCounts,
   problems,
   reachFailure,
   type StationFinding,
@@ -173,7 +174,11 @@ describe("the AGREE axis is not vacuous over the real table", () => {
     // An INDEPENDENT spelling of "this logo is SomaFM's", deliberately not
     // reusing `isCatalogueBacked`: a control that asks the predicate to confirm
     // itself passes however the predicate is broken.
-    RADIO_STATIONS.filter((s) => s.logoUrl.includes("//api.somafm.com/")).map((s) => s.id);
+    // #1704 — `?? ""` rather than a filter on non-null: a row with NO logo is
+    // not catalogue-backed, and spelling that as an empty string keeps this an
+    // independent re-derivation of the predicate instead of borrowing its
+    // null-handling too.
+    RADIO_STATIONS.filter((s) => (s.logoUrl ?? "").includes("//api.somafm.com/")).map((s) => s.id);
 
   it("engages on exactly the catalogue-backed stations, and there are some", () => {
     const backed = RADIO_STATIONS.filter((s) => isCatalogueBacked(s.logoUrl)).map((s) => s.id);
@@ -248,5 +253,72 @@ describe("the union verdict", () => {
     // not a broken row. Reported as a finding it would make the table's own
     // nullable field permanently red.
     expect(problems(finding({ feedUrl: null, feed: null }))).toEqual([]);
+  });
+});
+
+// #1704 — `logoUrl` went NULLABLE for a station that publishes no artwork, and
+// a probe of a URL that does not exist is not a defect. Both halves are pinned:
+// the axis goes quiet for such a row, and the report still says how many rows it
+// actually fetched — a green built from zero probes is silence, not agreement,
+// which is the argument the whole file is written around.
+describe("a station that publishes no logo (#1704)", () => {
+  it("is outside the catalogue's scope — there is no URL to disagree with", () => {
+    expect(isCatalogueBacked(null)).toBe(false);
+  });
+
+  it("is never an AGREE finding, however empty the catalogue is", () => {
+    expect(agreeFailure(null, "kohina", new Map())).toBeNull();
+  });
+
+  it("counts out of the LOGO denominator, so a table of nulls cannot read green", () => {
+    const finding = (
+      id: string,
+      logoUrl: string | null,
+      feedUrl: string | null,
+    ): StationFinding => ({
+      id,
+      logoUrl,
+      feedUrl,
+      reach: null,
+      agree: null,
+      feed: null,
+    });
+    const counts = probedCounts([
+      finding("with-logo", "https://api.somafm.com/logos/120/x120.png", null),
+      finding("logoless", null, "https://api.somafm.com/songs/y.json"),
+      finding("neither", null, null),
+    ]);
+
+    expect(counts.logos).toBe(1);
+    expect(counts.feeds).toBe(1);
+  });
+
+  it("counts the real table, so the denominator is not a fixture", () => {
+    // The positive control: the numbers above are computed over hand-made rows,
+    // which proves the function and not the table. This one would catch a table
+    // whose logos had ALL gone null — the state that would make the script
+    // report a perfect green having fetched nothing.
+    const counts = probedCounts(
+      RADIO_STATIONS.map((s) => ({
+        id: s.id,
+        logoUrl: s.logoUrl,
+        feedUrl: s.songsUrl,
+        reach: null,
+        agree: null,
+        feed: null,
+      })),
+    );
+    expect(
+      counts.logos,
+      "no station in the table has a logo — the probe is vacuous",
+    ).toBeGreaterThan(0);
+    // The other direction, and it is a VACUITY guard rather than a rule about
+    // the table: with no logo-less row the SKIP path above is never exercised
+    // by real data. If the table legitimately goes all-logos one day, this is
+    // the line to delete, and deliberately — not the one to edit around.
+    expect(
+      counts.logos,
+      "every station has a logo — the logo-less arm is untested by the real table",
+    ).toBeLessThan(RADIO_STATIONS.length);
   });
 });

--- a/cicchetto/src/__tests__/mediaSession.test.ts
+++ b/cicchetto/src/__tests__/mediaSession.test.ts
@@ -30,8 +30,8 @@ import { RADIO_STATIONS, type RadioStation } from "../lib/radioStations";
     proved the extension is per-station, so the artwork `type` must be READ off
     the URL rather than assumed; a test pinned to one extension would pass while
     the other half of the table shipped the wrong mime. */
-const jpgStation = RADIO_STATIONS.find((s) => s.logoUrl.endsWith(".jpg"));
-const pngStation = RADIO_STATIONS.find((s) => s.logoUrl.endsWith(".png"));
+const jpgStation = RADIO_STATIONS.find((s) => s.logoUrl?.endsWith(".jpg") === true);
+const pngStation = RADIO_STATIONS.find((s) => s.logoUrl?.endsWith(".png") === true);
 if (jpgStation === undefined || pngStation === undefined) {
   throw new Error("these tests need one .jpg-logo and one .png-logo station in the curated table");
 }
@@ -167,6 +167,26 @@ describe("mediaSessionMetadata", () => {
 
     expect(mediaSessionMetadata()).toEqual({
       title: "f00ba7.mp3",
+      artist: "",
+      album: "",
+      artwork: [],
+    });
+  });
+
+  it("hands the OS NO artwork for a station that publishes none (#1704)", () => {
+    // The same answer an upload gets two cases up, and for the same reason: an
+    // empty `artwork` lets the platform keep the app icon rather than be handed
+    // something that is not the station's. Our own placeholder is deliberately
+    // not sent — it is an SVG built for one 120px slot in the rail, and
+    // `MediaImage` support for SVG is not something this codebase has measured
+    // on any platform.
+    const logoless = RADIO_STATIONS.find((s) => s.logoUrl === null);
+    if (logoless === undefined) throw new Error("this test needs a logo-less station in the table");
+
+    tuneStation(logoless);
+
+    expect(mediaSessionMetadata()).toEqual({
+      title: logoless.title,
       artist: "",
       album: "",
       artwork: [],

--- a/cicchetto/src/__tests__/radioLogoPlaceholder.test.ts
+++ b/cicchetto/src/__tests__/radioLogoPlaceholder.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  PLACEHOLDER_GLYPH,
+  placeholderFill,
+  placeholderHue,
+  placeholderInitial,
+  radioLogoPlaceholder,
+} from "../lib/radioLogoPlaceholder";
+import { RADIO_STATIONS } from "../lib/radioStations";
+
+// #1704 — the stand-in logo, and the two properties vjt's #1703 ruling asked
+// for by name: stable per station ("ma che sian consistenti"), and readable in
+// BOTH themes.
+//
+// The readability half is COMPUTED here rather than eyeballed, which is the
+// whole reason the module fixes saturation and lightness and turns only the
+// hue: the worst case is then a hue, and a test can walk all 360 of them. A
+// hand-picked set of swatches could not be checked this way — someone would
+// have had to look at each one and say "fine".
+
+/** sRGB channel → linear light, per WCAG 2.x relative-luminance. */
+const linear = (channel: number): number =>
+  channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+
+const luminance = (r: number, g: number, b: number): number =>
+  0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+
+/** `hsl(h, s%, l%)` → the three sRGB channels in 0..1. The CSS conversion,
+    written out because jsdom computes no colours and the test must not depend
+    on a browser to know what it asked for. */
+const hslToRgb = (h: number, s: number, l: number): [number, number, number] => {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  const sextant = Math.floor(h / 60) % 6;
+  const table: ReadonlyArray<readonly [number, number, number]> = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x],
+  ];
+  const [r, g, b] = table[sextant] ?? [0, 0, 0];
+  return [r + m, g + m, b + m];
+};
+
+const hexToRgb = (hex: string): [number, number, number] => [
+  Number.parseInt(hex.slice(1, 3), 16) / 255,
+  Number.parseInt(hex.slice(3, 5), 16) / 255,
+  Number.parseInt(hex.slice(5, 7), 16) / 255,
+];
+
+const contrast = (a: [number, number, number], b: [number, number, number]): number => {
+  const la = luminance(...a);
+  const lb = luminance(...b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+/** Read `hsl(h, s%, l%)` back out of the production string, so the test
+    measures what the module EMITS rather than a copy of its constants. */
+const parseHsl = (css: string): [number, number, number] => {
+  const m = css.match(/^hsl\((\d+),\s*(\d+)%,\s*(\d+)%\)$/);
+  if (m === null) throw new Error(`not an hsl() the test can read: ${css}`);
+  return [Number(m[1]), Number(m[2]) / 100, Number(m[3]) / 100];
+};
+
+describe("the placeholder logo is stable per station (#1704)", () => {
+  it("gives the same station the same tile every time it is asked", () => {
+    // The ruling's own words. A `Math.random()` pick would redraw on every
+    // open of the drawer, and would put two different tiles for one station on
+    // screen at once — the rail chrome and the picker row render separately.
+    const first = radioLogoPlaceholder("kohina", "Kohina");
+    const second = radioLogoPlaceholder("kohina", "Kohina");
+    expect(second).toBe(first);
+  });
+
+  it("gives different stations different tiles", () => {
+    const hues = RADIO_STATIONS.map((s) => placeholderHue(s.id));
+    // Not "all distinct" — 21 ids into 360 hues will collide eventually and a
+    // collision is not a defect (a placeholder is not an identity). What would
+    // be a defect is a hash that answers the same thing for everything.
+    expect(new Set(hues).size).toBeGreaterThan(1);
+  });
+
+  it("keys the COLOUR on the id and the MARK on the title — two jobs, two fields", () => {
+    // `id` is the field the table promises is stable; `title` is display. So a
+    // station renamed in the picker keeps its colour and only its letter can
+    // move, and two stations with the same initial still differ by hue.
+    const fill = placeholderFill("kohina");
+    expect(decodeURIComponent(radioLogoPlaceholder("kohina", "Kohina"))).toContain(fill);
+    expect(decodeURIComponent(radioLogoPlaceholder("kohina", "Zohina"))).toContain(fill);
+    // The letter followed the rename; the colour did not.
+    expect(decodeURIComponent(radioLogoPlaceholder("kohina", "Zohina"))).toContain(">Z</text>");
+    expect(placeholderFill("kohina")).not.toBe(placeholderFill("kohina-2"));
+  });
+
+  it("never derives a negative hue, whatever the id", () => {
+    // The signed-32-bit trap: JS bitwise operators return SIGNED values, and a
+    // negative modulo would emit `hsl(-137, …)`, which is not a colour.
+    for (const id of [...RADIO_STATIONS.map((s) => s.id), "", "ÿÿÿÿ", "\u{1F4FB}", "zzzzzzzzzz"]) {
+      const hue = placeholderHue(id);
+      expect(hue, `id ${JSON.stringify(id)} produced hue ${hue}`).toBeGreaterThanOrEqual(0);
+      expect(hue).toBeLessThan(360);
+    }
+  });
+});
+
+describe("the placeholder logo reads in both themes (#1704)", () => {
+  it("is OPAQUE, so the page behind it cannot decide whether it is legible", () => {
+    // The mechanism, not a proxy for it: a full-bleed rect at the tile's own
+    // size means no theme background shows through, which is what makes the
+    // contrast measured below the ONLY contrast that matters.
+    const svg = decodeURIComponent(
+      radioLogoPlaceholder("kohina", "Kohina").replace("data:image/svg+xml,", ""),
+    );
+    expect(svg).toContain('<rect width="120" height="120"');
+    expect(svg).not.toContain("fill-opacity");
+    expect(svg).not.toContain("currentColor");
+  });
+
+  it("clears the WCAG NORMAL-text bar at EVERY hue, not just the ones we shipped", () => {
+    // The reason saturation and lightness are fixed and only the hue turns:
+    // the worst case is a hue, so it can be enumerated. The bar that APPLIES
+    // is 3:1 (AA, large text — a 64px glyph in a 120px tile is large by any
+    // reading), and the lightness was chosen so the worst hue clears 4.5:1,
+    // the bar for normal text, instead. Asserted at 4.5 rather than at 3
+    // because that is the property the constant was picked for: at 32%
+    // lightness hue 60 measures 4.47:1 and this test would go red, which is
+    // the point. A test over the current table alone would never see hue 60
+    // until someone added a station whose slug hashed there.
+    const glyph = hexToRgb(PLACEHOLDER_GLYPH);
+    const worst = { hue: -1, ratio: Number.POSITIVE_INFINITY };
+    for (let hue = 0; hue < 360; hue++) {
+      // Through the production string, so a change to S or L is measured here
+      // rather than re-typed.
+      const [, s, l] = parseHsl(placeholderFill("probe"));
+      const ratio = contrast(hslToRgb(hue, s, l), glyph);
+      if (ratio < worst.ratio) {
+        worst.hue = hue;
+        worst.ratio = ratio;
+      }
+    }
+    expect(
+      worst.ratio,
+      `worst hue is ${worst.hue} at ${worst.ratio.toFixed(2)}:1`,
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe("the placeholder logo's mark (#1704)", () => {
+  it("carries the station's initial", () => {
+    const svg = decodeURIComponent(radioLogoPlaceholder("kohina", "Kohina"));
+    expect(svg).toContain(">K</text>");
+  });
+
+  it("uppercases a lowercase title without consulting a locale", () => {
+    // `toUpperCase`, never `toLocaleUpperCase`: under a Turkish locale the
+    // latter maps `i` to `İ`, so the same station would draw a different mark
+    // for two people reading the same table.
+    expect(placeholderInitial("indie pop")).toBe("I");
+  });
+
+  it("takes a whole code point, not half a surrogate pair", () => {
+    // `charAt(0)` on an astral character yields a lone surrogate, which is not
+    // a character and renders as a replacement box.
+    expect(placeholderInitial("📻 Radio")).toBe("📻");
+  });
+
+  it("survives a title with no characters at all", () => {
+    expect(placeholderInitial("")).toBe("");
+    expect(() => radioLogoPlaceholder("x", "")).not.toThrow();
+  });
+
+  it("escapes XML metacharacters instead of emitting a malformed document", () => {
+    // A title beginning `&` or `<` would otherwise produce an SVG that renders
+    // as nothing — a blank tile where the failure is invisible, which is the
+    // opposite of what a placeholder is for.
+    const svg = decodeURIComponent(radioLogoPlaceholder("amp", "& Friends"));
+    expect(svg).toContain(">&amp;</text>");
+    expect(svg).not.toContain(">&</text>");
+  });
+
+  it("is a data: URI, which the CSP already admits", () => {
+    // `img-src 'self' data: https:` — re-read on GrappaWeb.Plugs.SecurityHeaders
+    // 2026-08-24. Pinned as a shape so a later switch to a fetched asset has to
+    // face the CSP question deliberately rather than at runtime in prod.
+    expect(radioLogoPlaceholder("kohina", "Kohina")).toMatch(/^data:image\/svg\+xml,/);
+  });
+});

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -41,10 +41,25 @@ describe("RADIO_STATIONS", () => {
     // are scheme-scoped, and an http subresource on an https page is refused
     // as mixed content regardless. Either way the failure is a station that
     // silently does not play.
+    //
+    // #1704 — the STREAM half is unconditional and the LOGO half skips a null,
+    // because a station is now allowed to publish no artwork. The skip is what
+    // the positive control below exists to keep honest: a rule that skips every
+    // row reports green having compared nothing.
     for (const s of RADIO_STATIONS) {
       expect(s.streamUrl, `station ${s.id} stream`).toMatch(/^https:\/\//);
+      if (s.logoUrl === null) continue;
       expect(s.logoUrl, `station ${s.id} logo`).toMatch(/^https:\/\//);
     }
+  });
+
+  it("carries a logo for at least one station", () => {
+    // #1704 — the positive control for the rule above, the same one #1698 gave
+    // `songsUrl`. `logoUrl` went nullable for Kohina, which publishes only a
+    // favicon; a table where the field had gone uniformly null would sail
+    // through the https rule having checked nothing at all.
+    const withLogo = RADIO_STATIONS.filter((s) => s.logoUrl !== null);
+    expect(withLogo.length).toBeGreaterThan(0);
   });
 
   // #1698 — the now-playing feed URL. Same posture as `logoUrl`: a verbatim

--- a/cicchetto/src/lib/mediaSession.ts
+++ b/cicchetto/src/lib/mediaSession.ts
@@ -131,7 +131,15 @@ export function mediaSessionMetadata(): MediaSessionMetadata | null {
     };
   }
 
-  const artwork = [artworkFor(station.logoUrl)];
+  // #1704 — a station that publishes no artwork hands the OS NOTHING, which is
+  // the same answer an upload gets in the arm above and for the identical
+  // reason: an empty `artwork` lets the platform keep the app icon, which is a
+  // real image at every size it asks for. Our own placeholder is deliberately
+  // NOT sent — it is an SVG built for one 120px slot in the rail, `MediaImage`
+  // support for SVG is not something this codebase has measured on any
+  // platform, and a lock screen that refuses it would fall back to the app icon
+  // anyway. Sending nothing gets there without the claim.
+  const artwork = station.logoUrl === null ? [] : [artworkFor(station.logoUrl)];
 
   // The ARTIST slot, and it is not a compromise: it is the second line, and on
   // a failure there is no track and therefore no artist to displace. `title`

--- a/cicchetto/src/lib/radioLogoPlaceholder.ts
+++ b/cicchetto/src/lib/radioLogoPlaceholder.ts
@@ -1,0 +1,136 @@
+// #1704 — a stand-in logo for a station that publishes none.
+//
+// WHY THIS EXISTS AT ALL. `RadioStation.logoUrl` is nullable since Kohina
+// (`radioStations.ts`), and a null needs something to draw. The rule vjt gave
+// on #1703 is the whole specification: *"if there are no upstream logos, put a
+// set of random placeholders of our own, SVG or similar"*, plus — from the same
+// ruling — *"ma che sian consistenti"*, i.e. **stable per station, not random
+// per render**. A `Math.random()` pick would change the logo every time the
+// drawer opens, and worse, the rail chrome and the picker row would draw two
+// different tiles for the same station in the same frame.
+//
+// WHY A DATA URI. `img-src 'self' data: https:` (GrappaWeb.Plugs.SecurityHeaders,
+// re-read 2026-08-24) already admits it, so this costs no server change and no
+// second request. Serving the same SVG from our own origin would work under
+// `'self'` too; the data URI just skips the round trip.
+//
+// WHY A HUE AND NOT A HAND-WRITTEN SET, which is a deviation from the letter of
+// "a set" and is deliberate. A literal set needs a size K nobody can justify,
+// and two logo-less stations collide the moment the table outgrows it. Deriving
+// the HUE keeps the two properties the ruling actually asked for — stable per
+// station, and distinct between stations — with no constant to pick. It also
+// makes the readability claim CHECKABLE rather than eyeballed: saturation and
+// lightness are FIXED and only the hue turns, so contrast against the glyph
+// cannot depend on which station this is, and `radioLogoPlaceholder.test.ts`
+// computes the WCAG ratio across all 360 hues rather than trusting a swatch.
+//
+// WHY IT READS IN BOTH THEMES. Because it never shows the page behind it: the
+// tile is an OPAQUE square, exactly like the 120px logos it stands in for. A
+// transparent glyph tinted for one theme is the regression the ruling warned
+// about; an opaque tile cannot have it. Nothing here reads a CSS variable —
+// an `<img>` renders its SVG as a separate document, where the page's cascade
+// does not reach, so a `currentColor` placeholder would come out black.
+//
+// The MARK is the station's initial rather than an abstract shape, because it
+// costs the same and says more: a tile that reads "K" beside the word "Kohina"
+// is recognisably that station's, and a lozenge is recognisably nothing.
+
+/** The side of the square, in px. 120 is what the curated table's real logos
+    are (`…/logos/120/…`), so a placeholder and a logo occupy the same box. */
+const SIDE = 120;
+
+/** Fixed saturation / lightness. ONLY the hue varies — see the module note:
+    this is what makes the contrast guarantee independent of the station.
+    31% lightness is not a taste: measured across all 360 hues against the
+    glyph below, it is the point where the WORST hue (60°, yellow) clears the
+    4.5:1 WCAG bar for NORMAL text — 4.71:1, where 32% gives 4.47:1 and misses
+    it. A 64px mark in a 120px tile is large text, whose bar is 3:1, so this
+    clears the one that applies with the one that does not to spare. Raising it
+    weakens yellow first; the test walks every hue rather than trusting this
+    sentence. */
+const SATURATION = 45;
+const LIGHTNESS = 31;
+
+/** The glyph colour. Near-white rather than pure white so the tile does not
+    look like a hole punched in a dark theme. */
+export const PLACEHOLDER_GLYPH = "#f8f8f8";
+
+/** FNV-1a, 32-bit. Any cheap stable hash satisfies the ruling; this one is
+    four lines, has no dependency, and spreads short slugs like ours well.
+    `>>> 0` after each step keeps it in unsigned 32-bit space — JavaScript
+    bitwise operators yield SIGNED 32-bit, and a negative here would make the
+    modulo below produce a negative hue for some ids. */
+function hash32(value: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** The hue this station's tile is painted, in degrees.
+ *
+ * Derived from the `id` — the STABLE slug — and never from the title: a
+ * station renamed in the picker must not change colour, and `id` is the field
+ * the table already promises is stable (`radioStations.ts`). Exported so the
+ * test can measure contrast per station rather than re-deriving it. */
+export function placeholderHue(id: string): number {
+  return hash32(id) % 360;
+}
+
+/** The tile's background, as a CSS colour. */
+export function placeholderFill(id: string): string {
+  return `hsl(${placeholderHue(id)}, ${SATURATION}%, ${LIGHTNESS}%)`;
+}
+
+/** The five characters XML makes special, escaped.
+ *
+ * The table is ours, so nothing hostile reaches this today — but the output is
+ * a DOCUMENT built from a string, and a title beginning `&` or `<` would emit
+ * a malformed SVG that renders as nothing at all. Escaping at the boundary is
+ * cheaper than the afternoon spent finding out why one row draws blank. */
+function escapeXml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/** The station's initial, uppercased — or an empty string when the title has
+ * no first character to take.
+ *
+ * Split by CODE POINT (`[...title]`), not by `charAt`: a title starting with
+ * an astral character would otherwise be cut mid-surrogate and produce a lone
+ * half that is not a character at all. `toLocaleUpperCase` is deliberately NOT
+ * used — this is a graphic mark, not text in the operator's locale, and the
+ * Turkish dotless-i mapping would make the same station draw differently for
+ * two people looking at the same table. */
+export function placeholderInitial(title: string): string {
+  return ([...title][0] ?? "").toUpperCase();
+}
+
+/**
+ * A `data:image/svg+xml` URI for `id`'s tile: an opaque hue-derived square
+ * carrying `title`'s initial.
+ *
+ * Both parameters are required (cic forbids silent-degradation defaults): the
+ * id decides the COLOUR because it is stable, and the title supplies the
+ * LETTER because it is what a human reads. They are two different jobs and a
+ * caller passing one for both would get a tile that moves when the station is
+ * renamed.
+ */
+export function radioLogoPlaceholder(id: string, title: string): string {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${SIDE}" height="${SIDE}" viewBox="0 0 ${SIDE} ${SIDE}">` +
+    `<rect width="${SIDE}" height="${SIDE}" fill="${placeholderFill(id)}"/>` +
+    `<text x="50%" y="50%" fill="${PLACEHOLDER_GLYPH}" font-family="monospace" font-size="64" ` +
+    `text-anchor="middle" dominant-baseline="central">${escapeXml(placeholderInitial(title))}</text>` +
+    `</svg>`;
+  // `encodeURIComponent` rather than base64: the payload stays readable in the
+  // DOM inspector, which matters for a thing whose whole job is to be looked
+  // at when something is missing.
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -85,7 +85,24 @@ export type RadioStation = {
   readonly description: string;
   /** The endless audio endpoint handed to `playAudio`. */
   readonly streamUrl: string;
-  readonly logoUrl: string;
+  /** #1704 — the station's own artwork, or `null` when it publishes none.
+      NULLABLE since Kohina, and the reasoning is the one `songsUrl` gives
+      below rather than a second mechanism: a logo is a thing most stations
+      HAVE, so the field stays required-looking for every row that has one —
+      but "publishes no artwork" is a real state of the world and the type has
+      to be able to say it. The alternative was pointing this at Kohina's
+      192px FAVICON, which answers 200 — and that is the shape to refuse: a
+      favicon is not a station logo, and because it ANSWERS, no runtime error
+      handler would ever notice. An unverifiable claim that cannot even fail
+      loudly is exactly what #1696 was filed about.
+      What a null draws is `lib/radioLogoPlaceholder.ts` — our own SVG, stable
+      per station, per vjt's #1703 ruling. What it hands the OS lock screen is
+      NOTHING (`mediaSession.ts` emits an empty `artwork`), which is the same
+      answer an upload already gets there and for the same reason: the OS then
+      keeps the app icon instead of being handed art that is not the station's.
+      `bun run check:radio` reports a null row as SKIPPED rather than passing
+      it silently — a green built from zero probes is silence, not agreement. */
+  readonly logoUrl: string | null;
   /** #1698 — the JSON feed naming the track on air, or `null` when the
       provider publishes none.
       NULLABLE, unlike every sibling above, and the difference is real rather
@@ -339,6 +356,52 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     streamUrl: "https://stream.rockantenne.de/heavy-metal/stream/mp3",
     logoUrl:
       "https://www.rockantenne.de/media/cache/3/version/597/streamlogo_heavymetal_ra-v1.jpg/f1b996498456cb64.jpg",
+    songsUrl: null,
+  },
+  // #1704 — KOHINA, and the first row in this table that publishes no artwork
+  // at all. Requested in channel as chiptune / demoscene; measured 2026-08-24
+  // before being written, as every row here is.
+  //
+  // THE URL IS NOT THE ONE REQUESTED, and the reason is ours rather than
+  // upstream's. The request was `http://kohina.duckdns.org:8000/stream.ogg`.
+  // `media-src 'self' blob: https:` (GrappaWeb.Plugs.SecurityHeaders, re-read
+  // 2026-08-24) is SCHEME-scoped, so an http stream on our https page is
+  // refused before anything upstream is even consulted — and there is no TLS on
+  // that port to switch to. Kohina's own home page links an https playlist
+  // whose single line is the mirror baked below. That indirection is why this
+  // vendor is deliberately ABSENT from `radioStations.test.ts`'s front-door map:
+  // upstream's stable entry point is an `.m3u` document, not a redirecting
+  // host, and the map cannot express that shape. Inventing a front door for it
+  // would be the unverifiable claim #1696 was filed about.
+  //
+  // Measured on the URL below, with a ranged GET and a browser UA: HTTP 200,
+  // `Content-Type: audio/ogg`, Icecast 2.4.4, `Access-Control-Allow-Origin: *`,
+  // `icy-name: Kohina - Old School Game and Demo Music`, 312 KB pulled before
+  // the client timeout — the timeout being the evidence the source is endless.
+  //
+  // THE CODEC, read off the BYTES and not the mime type: the body opens `OggS`
+  // then `\x01vorbis`, i.e. Ogg VORBIS at 44.1 kHz stereo — the first row here
+  // that is not `audio/mpeg`. Per the vendored caniuse-lite (1.0.30001791),
+  // iOS Safari is `y` from 18.4, `a` (partial, and the packed data carries no
+  // note text to say partial HOW) from 17.4 through 18.3, and a flat `n` at
+  // 17.3 and below. So this row does not play for some population of phones,
+  // and #1744 is why it ships anyway: a source the browser refuses now SAYS so
+  // on the transport, the rail and the lock screen instead of looking paused.
+  // Kohina has no non-Ogg endpoint, so there is no fallback stream to prefer.
+  //
+  // `songsUrl` is null — no now-playing feed published. `logoUrl` is null and
+  // that is the field's new arm: kohina.com serves only favicons, the largest
+  // being a 192px PNG that answers 200. Pointing this at it was refused twice
+  // over — a favicon is not a station logo, and because it ANSWERS no error
+  // handler would ever fire, so the wrong image would render silently forever.
+  {
+    id: "kohina",
+    title: "Kohina",
+    genres: ["chiptune", "demoscene"],
+    description:
+      "Hand picked chip tunes from classic computers and consoles. SID, Amiga, Atari ST, Arcade, PC, and more!",
+    streamUrl: "https://kohina.brona.dk/icecast/stream.ogg",
+    logoUrl: null,
     songsUrl: null,
   },
 ];

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61853,3 +61853,117 @@ of inferred from the first. And a HIDDEN bar on a phone: the rail is
 off-screen there, so the OS lock screen is the only surface carrying the
 failure. Auto-showing the bar was considered and rejected — the operator
 asked for it to be gone, and cic does not originate state.
+<!-- entry #1704 -->
+
+---
+
+## 2026-08-24 — #1704: Kohina ships, and the table learns to say "this station has no logo"
+
+Two decisions, and the second one outlives the row that forced it.
+
+**THE ROW.** Kohina (hand-picked chiptunes — SID, Amiga, Atari ST,
+arcade, PC) is the table's first Ogg Vorbis station and its second
+non-SomaFM one. Measured 2026-08-24 before being written, as every row
+here is: HTTP 200, `Content-Type: audio/ogg`, Icecast 2.4.4,
+`Access-Control-Allow-Origin: *`, `icy-name: Kohina - Old School Game
+and Demo Music`, 312 KB pulled with a ranged GET before the client
+timeout — the timeout itself being the evidence the source is endless.
+
+**The URL is not the one requested, and the decisive reason is OURS.**
+The request named `http://kohina.duckdns.org:8000/stream.ogg`. Our
+`media-src 'self' blob: https:` is SCHEME-scoped, so an http stream on
+an https page is refused before anything upstream is consulted, and
+there is no TLS on that port to switch to. Upstream's own home page
+links an https playlist whose single line is the mirror now baked in.
+⚠️ Neither the http endpoint nor that playlist is reachable from the
+worker's sandbox (every attempt off :443 answers `Recv failure: Socket
+is not connected`), so the 2026-08-23 measurements of them stand
+unrefuted rather than re-confirmed — and the CSP argument above needs
+neither, which is why it is the one recorded.
+
+**The codec is read off the BYTES, not the mime type:** the body opens
+`OggS` then `\x01vorbis` — Ogg Vorbis, 44.1 kHz stereo. **A correction
+to the issue's own text while we are here:** the vendored caniuse-lite
+(1.0.30001791) does NOT say iOS fails to decode Ogg Vorbis below 18.4.
+It says `y` from 18.4, `a` — partial, note #2, whose TEXT the packed
+`caniuse-lite` data does not carry, so we cannot say partial HOW — for
+17.4 through 18.3, and a flat `n` only at 17.3 and below. The
+population for whom this row is guaranteed silent is therefore iOS
+≤ 17.3, and 17.4–18.3 is a year-wide band we can claim nothing about in
+either direction. It changes no decision here; it changes what may be
+written down as measured.
+
+**Why it ships anyway, and the proof rather than the assumption.**
+#1703's standing condition was that a station which cannot play must
+not ship *while a stream that fails says nothing to anybody*. #1744
+built the saying-so, so the condition is discharged — but discharged by
+a BEHAVIOUR, which means it can regress, so it is pinned twice: a unit
+test that tunes the table's real Ogg row and asserts the notice names
+the unsupported reason, and an e2e that serves undecodable bytes at
+Kohina's real URL and asserts, in a real browser and on both configured
+projects (Chromium and WebKit-on-iPhone-15), that the element populated
+`MediaError` and that the transport, the rail and the station name all
+report it. ⚠️ What that green establishes is a CONDITIONAL — given the
+element reports a media error, the operator is told — and NOT that iOS
+below 18.4 fails on Kohina. That second claim is caniuse's and is not
+measurable at any browser version CI can drive.
+
+**THE PART THAT OUTLIVES THE ROW: `logoUrl` is nullable.** Kohina
+publishes no station artwork; `www.kohina.com` serves only favicons, the
+largest being a 192px PNG. Pointing the field at that favicon was
+refused twice over, and the second reason is the interesting one: a
+favicon is not a station logo, **and because it ANSWERS 200 no runtime
+error handler would ever fire** — the picker would render the wrong
+image silently, forever. An unverifiable claim that cannot even fail
+loudly is exactly what #1696 was filed about. So the absence is
+declared in the TYPE, the shape `songsUrl` already had since #1698, with
+the same positive control beside it (`carries a logo for at least one
+station`) because every rule that skips a null reports green having
+compared nothing when the field goes uniformly null.
+
+**The placeholder, and one deliberate deviation from the ruling.** vjt
+ruled "a set of random placeholders of our own, SVG or similar", "ma che
+sian consistenti", readable in both themes. Built as a hue-derived
+opaque tile carrying the station's initial — NOT a hand-written set,
+because a set needs a size K nobody can justify and collides the moment
+the table outgrows it. The deviation buys something a set could not:
+saturation and lightness are FIXED and only the hue turns, so contrast
+against the glyph cannot depend on which station this is, and the test
+walks **all 360 hues** instead of trusting a swatch. That is also how
+the lightness was chosen rather than picked — 31 % is where the worst
+hue (60°, yellow) reaches 4.71:1, clearing the 4.5:1 bar for NORMAL text
+while the bar that actually applies to a 64px mark is 3:1; at 32 % it
+measures 4.47:1 and the test goes red. "Reads in both themes" is
+structural, not tuned: the tile is OPAQUE, so the page behind it never
+gets a vote. The colour keys on `id` (stable) and the letter on `title`
+(display) — two jobs, two fields, so renaming a station cannot repaint
+it.
+
+**One stand-in, two different facts, and one component.** `logoUrl ===
+null` is a DECLARED absence; `onError` is a URL we believed in that
+broke at runtime — the other half of the #1703 ruling, and until now
+both render sites were a bare `<img>` whose 404 drew the browser's
+broken-image glyph. They now share one `StationLogo`, which also ends
+the two hand-copied `<img>` tags that were free to drift. The swap is a
+SIGNAL and not `e.currentTarget.src = …`: rewriting the src from inside
+the handler re-enters it if the replacement also fails, and the guard
+against that loop is a comparison somebody has to keep right, whereas a
+second failure writing `true` over `true` re-renders nothing.
+
+**Where the placeholder deliberately does NOT go: the OS lock screen.**
+A logo-less station hands the platform an empty `artwork`, which is the
+same answer an upload already gets there and for the same reason — the
+OS then keeps the app icon, a real image at every size it asks for. Our
+tile is an SVG built for one 120px slot in the rail, and `MediaImage`
+support for SVG is not something this codebase has measured on any
+platform; sending nothing arrives at the same place without the claim.
+
+**Two smaller things, recorded so they are not rediscovered as new.**
+`bun run check:radio` skips a null logo and now prints a LOGO
+denominator beside the feed one — without it a table whose logos had all
+gone null would report "21 stations checked, 0 broken" having fetched
+nothing. And Kohina's vendor is deliberately ABSENT from
+`radioStations.test.ts`'s front-door map: upstream's stable entry point
+is an `.m3u` DOCUMENT rather than a redirecting host, the map cannot
+express that shape, and inventing a front door for it would be the
+unverifiable claim the map exists to prevent.


### PR DESCRIPTION
Adds Kohina (hand-picked chiptunes) and, with it, the piece #1703 ruled
on but nothing had built: a stand-in logo for a station that publishes
none.

## Why `logoUrl` went nullable instead of just adding an `onError`

The error handler was the lighter option and I costed it first. It needs
`logoUrl` to hold a non-null STRING, so the real question is what string
a logo-less station carries — and both answers are worse than the type
change:

* **Kohina's 192px favicon**, the only image its site serves. Measured:
  `200 image/png`, 791 bytes. It **answers**, so `onError` never fires
  and the picker renders a favicon where a station logo goes, silently
  and forever. An unverifiable claim that cannot even fail loudly is
  what #1696 was filed about.
* **A URL chosen because it 404s**, so the handler fires. That bakes a
  deliberately broken URL into the table, and `bun run check:radio`
  would report a permanent REACH failure for a row that is correct — a
  gate crying wolf trains everyone to stop reading it.

So the absence is **declared**, not simulated: the shape `songsUrl` has
had since #1698 for the same class of fact, with the same positive
control (`carries a logo for at least one station`) beside it.

The cost was also smaller than my earlier estimate of ~21 consumers:
**four sites**, and the compiler enumerated them rather than a grep —
two `<img>` in `RailRadio`, `artworkFor` in `mediaSession`, and the
probe. The `onError` handler is still here, because it answers the
*other* fact: `null` is a declared absence known when the table is
written; `onError` is a URL we believed in that broke at runtime. Both
draw the same tile through one `StationLogo`, which also ends the two
hand-copied `<img>` tags that were free to drift.

## The placeholder, and one deliberate deviation from the ruling

vjt ruled "a set of random placeholders of our own", "ma che sian
consistenti", readable in both themes. Built as a **hue-derived opaque
tile carrying the station's initial** — not a hand-written set, because
a set needs a size K nobody can justify and collides once the table
outgrows it.

What the deviation buys is the reason for it: S and L are **fixed** and
only the hue turns, so contrast cannot depend on which station this is,
and the test walks **all 360 hues**. That is how the lightness stopped
being a taste: **31% is where the worst hue (60°, yellow) reaches
4.71:1**, clearing the 4.5:1 bar for *normal* text while the bar that
applies to a 64px mark is 3:1. At 32% it measures 4.47:1 and the test
goes red. "Reads in both themes" is structural: the tile is **opaque**,
so the page behind it never gets a vote.

Colour keys on `id` (stable), letter on `title` (display) — renaming a
station cannot repaint it.

## Kohina, measured 2026-08-24 before being written

| | |
|---|---|
| stream | `https://kohina.brona.dk/icecast/stream.ogg` — 200 `audio/ogg`, Icecast 2.4.4, CORS `*`, `icy-name: Kohina - Old School Game and Demo Music`, 312 KB pulled before the client timeout |
| codec | read off the BYTES: `OggS` + `\x01vorbis` → Ogg Vorbis 44.1 kHz stereo. First non-`audio/mpeg` row in the table |
| feed | none published → `songsUrl: null` |
| logo | none published → `logoUrl: null` |

**The requested URL is refused by us, not by upstream.**
`media-src 'self' blob: https:` is scheme-scoped, so the requested
`http://…:8000/stream.ogg` cannot be fetched from an https page at all,
and there is no TLS on that port. ⚠️ Neither that endpoint nor
upstream's `.m3u` is reachable from this sandbox (everything off :443
answers `Recv failure: Socket is not connected`), so their 2026-08-23
measurements stand **unrefuted rather than re-confirmed** — and the CSP
argument needs neither.

## A correction to the issue's own text

caniuse-lite (1.0.30001791, vendored) does **not** say iOS fails to
decode Ogg Vorbis below 18.4. It says `y` from 18.4, **`a` (partial;
note text absent from the packed data) across 17.4–18.3**, and `n` only
at 17.3 and below. The guaranteed-silent population is iOS ≤ 17.3, and
17.4–18.3 is a year-wide band we can claim nothing about either way. It
changes no decision — it changes what may be written down as measured.

## The ship condition is PROVEN, not assumed

#1703's condition was that such a station must not ship *while a stream
that fails says nothing*. #1744 built the saying-so; this pins it twice:

* a **unit** test that tunes the table's real Ogg row (read from
  `RADIO_STATIONS`, so a rename fails here rather than being followed)
  and asserts the notice names the unsupported reason with the file
  readout gone;
* an **e2e** that serves undecodable bytes at Kohina's real URL and
  asserts, in a real browser, that the element populated `MediaError`
  **first** — a spec whose subject never happened would pass everything
  after it vacuously — then that the transport, the rail, the station
  name and the placeholder all behave.

A fake body rather than real Vorbis on purpose: the subject is the
surface, and real Vorbis would measure whether *this Playwright build*
decodes it. The error code is not pinned to 4 — the two projects may
classify an unusable resource differently.

⚠️ **What the green establishes is a conditional** — given a media
error, the operator is told — **not** that iOS below 18.4 fails on
Kohina. That is caniuse's claim and is not measurable at any browser
version CI can drive. The spec runs on both projects, so the WebKit half
is measured on WebKit rather than inferred from Chromium.

## Smaller decisions, recorded so they are not refiled as new

* The **lock screen** gets `artwork: []`, not our tile — the same answer
  an upload already gets, so the OS keeps the app icon. `MediaImage` SVG
  support is unmeasured on every platform we ship to.
* `check:radio` skips a null logo and prints a **LOGO denominator**:
  "21 stations checked, 0 broken" over an all-null table is a green
  built from zero fetches.
* The **front-door map is deliberately not extended** to this vendor:
  upstream's stable entry point is an `.m3u` document, not a redirecting
  host, and the map cannot express that shape.

## Gates

* `bun run test`: **313 files / 6140 tests green** (baseline 6117 → +23).
* `bun run check`: green. 59 biome warnings, all pre-existing, none in a
  touched file.
* `design-notes-gate.sh origin/main`: green — base an exact prefix,
  **+114 / −0**, markers 219→220, marker unique.
* Base `711f56c1`, unmoved; no rebase needed.

— w2