### PR TITLE
fix(#1538): stop carving rows out of the middle of a rendered scrollback range

### DIFF
--- a/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
+++ b/cicchetto/e2e/tests/issue1229-unread-retention-bound.spec.ts
@@ -14,6 +14,37 @@
 // exactly this shape: divider suppressed, "N unread — jump back" banner,
 // `jumpToUnread` rebuilding the region from the server.
 //
+// ── #1538 REVERSED points 3 and 4 of this spec. Read this before the list ──
+//
+// This spec used to pin the opposite of what it pins now, and the history
+// matters because the reversal is a ruling, not a refactor.
+//
+// Points 3 and 4 below USED TO read: "the OLDEST unread row is gone from the
+// DOM, and the rows the operator is looking at are NOT", and "`scrollTop` is
+// preserved across the bite" — with the note that this "distinguishes the
+// implementation that shipped from the simpler one that did not: dropping
+// 'everything but the newest page' would have satisfied (2) while deleting
+// the screen out from under a reader scrolled up in history."
+//
+// What that traded away is what #1538 came back as. Keeping the read context
+// while excising the oldest unread means lifting a block out of the INTERIOR
+// of the loaded range, and the read cursor was standing in for "where the
+// operator is looking". For the reader who has scrolled DOWN past the divider
+// — into the unread region — the rows "just under the divider" are the rows on
+// screen, and the excision cut them out from under them. Two reporters,
+// #sniffo, nine rows out of the middle of a rendered range, unrepairable by
+// scrolling up (`loadMore` pages before `rows[0]`, which sits ABOVE the hole).
+//
+// vjt's ruling on #1538, and it is the acceptance criterion this spec now
+// verifies rather than a preference it accommodates:
+//
+//     "basta che lo scroll sia contiguo e non ci siano buchi"
+//
+// So the bound now collapses to a contiguous tail window, the read context
+// goes with the prefix, and the viewport DOES move — an announced loss, on a
+// pane that is simultaneously raising "N unread — jump back". The assertions
+// below are that criterion, checked from outside.
+//
 // ── What this spec pins, and why each assertion is here ──────────────────
 //
 // The gesture is ONE live PRIVMSG, not a flood. The cursor is planted so the
@@ -27,17 +58,19 @@
 //      (a cold far-behind resume, #693) and the spec would test nothing.
 //   2. After it: the bar is up with the honest total, and the divider is gone.
 //      That is the state transition, seen from outside.
-//   3. The OLDEST unread row is gone from the DOM, and the rows the operator
-//      is looking at are NOT. This is the one assertion that distinguishes the
-//      implementation that shipped from the simpler one that did not: dropping
-//      "everything but the newest page" would have satisfied (2) while
-//      deleting the screen out from under a reader scrolled up in history.
-//      The absence assertion is only meaningful because the list is not
-//      virtualised — every retained row is in the DOM whatever the scroll
-//      position, which is the same measurement that motivated the fix.
-//   4. `scrollTop` is preserved across the bite, within the tolerance the
-//      sibling scroll specs use. Rows leaving from BELOW the fold must not
-//      move the viewport.
+//   3. THE RULING: what remains in the DOM is a CONTIGUOUS run of the
+//      channel's rows as the server orders them — no hole, at any width.
+//      Checked against `fetchAllMessagesAsc` rather than by id arithmetic,
+//      and that is load-bearing: `messages.id` is a GLOBAL autoincrement, so
+//      consecutive rows of one channel carry non-consecutive ids and an
+//      id-gap scan cannot tell a punched hole from ordinary numbering. The
+//      server's own ordering is the only thing that can. The assertion is
+//      only meaningful because the list is not virtualised — every retained
+//      row is in the DOM whatever the scroll position, which is the same
+//      measurement that motivated #1229 in the first place.
+//   4. The oldest unread row AND the read-context row are both gone: the drop
+//      is a PREFIX. Pinning both ends is what separates the collapse from an
+//      excision that merely happened to take the row this spec sampled.
 //
 // Scrolling up is also what keeps the precondition alive: `setCursorIfAdvances`
 // is forward-only, so with the pane scrolled into the read context the settle
@@ -135,7 +168,7 @@ const scrollGeometry = (page: import("@playwright/test").Page) =>
 test.describe("#1229 — the unread retention bound", () => {
   test.use({ viewport: { width: 800, height: 400 } });
 
-  test("crossing one page of unread prunes from the divider and raises the far-behind bar", async ({
+  test("crossing one page of unread collapses to a CONTIGUOUS tail window and raises the far-behind bar (#1538)", async ({
     page,
   }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
@@ -235,16 +268,33 @@ test.describe("#1229 — the unread retention bound", () => {
       await expect(bar).toContainText(String(UNREAD_BOUND + 1));
       await expect(marker).toHaveCount(0);
 
-      // (3) pruned from the divider, not from the screen
+      // (4) a PREFIX drop: both the oldest unread AND the read context above
+      // it are gone. The live row that crossed the ceiling is still there —
+      // the tail is never what leaves.
       await expect(oldestUnreadLine).toHaveCount(0);
-      await expect(readContextLine).toHaveCount(1);
+      await expect(readContextLine).toHaveCount(0);
       await expect(
         page.locator('.scrollback-line:has-text("the row that crosses the ceiling")'),
       ).toHaveCount(1);
 
-      // (4) the viewport did not move
-      const after = await scrollGeometry(page);
-      expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(SCROLL_TOLERANCE_PX);
+      // (3) THE RULING — "basta che lo scroll sia contiguo e non ci siano
+      // buchi". What the pane still holds must be an unbroken run of the
+      // channel as the server orders it: take the DOM's ids, find where the
+      // first one sits in the server's list, and require the rest to follow it
+      // one for one. A hole anywhere inside the retained range fails here, and
+      // nothing weaker can see one (see the moduledoc on global ids).
+      const serverIds = (await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL)).map(
+        (r) => r.id,
+      );
+      const domIds = await page.$$eval(".scrollback-line[data-msg-id]", (els) =>
+        els.map((el) => Number((el as HTMLElement).dataset.msgId)),
+      );
+      expect(domIds.length).toBeGreaterThan(0);
+      const start = serverIds.indexOf(domIds[0] as number);
+      expect(start, "the pane's oldest row is not one the server served").toBeGreaterThanOrEqual(0);
+      expect(domIds, "the retained range has a hole in it").toEqual(
+        serverIds.slice(start, start + domIds.length),
+      );
     } finally {
       await peer.part(CHANNEL, "done");
     }

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -1856,19 +1856,29 @@ describe("appendToScrollback — #1229 unread-retention bound", () => {
     // NEWEST page — the live tail is never what gets dropped.
     expect(rows.filter((m) => m.id > cursor).length).toBe(bound);
     expect(rows[rows.length - 1]?.id).toBe(total);
-    // The read context is untouched by this bound (the ring cap still owns
-    // it), boundary row included: `cursor` read rows plus one page of unread —
-    // bounded, where before the fix it was `total` and grew with every
-    // arriving row.
-    expect(rows.length).toBe(cursor + bound);
-    expect(rows.map((m) => m.id)).toContain(cursor);
+    // #1538 — the whole window is now that page and nothing else. It used to be
+    // `cursor + bound`: the read context below the divider was kept while the
+    // oldest unread was excised from between the two, which is the interior
+    // hole that issue is about. The collapse takes the read context with it, so
+    // the retained window is one contiguous page — a TIGHTER memory bound than
+    // the shape this test used to pin, which is what #1229 was for.
+    expect(rows.length).toBe(bound);
+    expect(rows.map((m) => m.id)).not.toContain(cursor);
   });
 
   // The FIRST bite, by exactly one row. Every other case in this file sits a
   // page or more away from the ceiling, where a one-row phase error in the
   // trim is invisible — so nothing pinned WHICH end the trim takes, nor WHERE
   // the threshold sits. Those are the two facts the bound is made of.
-  it("bites one row past the ceiling, dropping the OLDEST unread and never the boundary", async () => {
+  //
+  // 🔴 #1538 — this test used to ASSERT THE DEFECT. It read
+  //   expect(ids).toContain(cursor); expect(ids).not.toContain(cursor + 1);
+  // i.e. the row above the gap alive and the first row of the gap gone: the
+  // interior hole, pinned as the contract, under a title that called it
+  // "never the boundary". Two reporters on #sniffo lost nine rows out of the
+  // middle of a rendered range to exactly that shape, and this green is why
+  // nobody could have found it by running the suite. Rewritten with the cure.
+  it("collapses to the newest page one row past the ceiling, dropping a PREFIX", async () => {
     localStorage.setItem("grappa-token", "tok");
     const scrollback = await import("../lib/scrollback");
     const bound = scrollback.UNREAD_RETENTION_CAP;
@@ -1878,14 +1888,15 @@ describe("appendToScrollback — #1229 unread-retention bound", () => {
     const total = cursor + bound + 1;
     for (let i = 1; i <= total; i++) scrollback.appendToScrollback(key, mkRow(i));
     const ids = (scrollback.scrollbackByChannel()[key] ?? []).map((m) => m.id);
-    // The boundary row is READ. The divider anchors on it and this module's
-    // rule exempts `id >= cursor`, so it is not this bound's to drop: the
-    // ceiling is on the UNREAD region, and the row that leaves is the oldest
-    // unread — the one just under the divider.
-    expect(ids).toContain(cursor);
-    expect(ids).not.toContain(cursor + 1);
-    expect(ids.filter((id) => id > cursor).length).toBe(bound);
+    // One contiguous run ending at the live tail — no interior gap at any
+    // width, which is the property the excision could not offer.
+    expect(ids).toEqual(Array.from({ length: bound }, (_, i) => total - bound + 1 + i));
     expect(ids[ids.length - 1]).toBe(total);
+    // The boundary row goes with the prefix. It is exempt only because the
+    // divider anchors on it, and this same transition arms far-behind, which
+    // SUPPRESSES the divider — so there is no anchor left to preserve it for.
+    expect(ids).not.toContain(cursor);
+    expect(scrollback.farBehindByChannel()[key]).toBeDefined();
   });
 
   it("does not bite AT one page of unread — the line `isFarBehind` already draws", async () => {
@@ -1981,6 +1992,114 @@ describe("appendToScrollback — #1229 unread-retention bound", () => {
     for (let i = cursor; i <= total; i++) expect(ids).toContain(i);
     // No pruning of unread happened → the window is NOT far behind.
     expect(scrollback.farBehindByChannel()[key]).toBeUndefined();
+  });
+});
+
+// #1538 — the invariant the middle-excision broke, stated where it can
+// actually be enforced: ON THE FUNCTION.
+//
+// It cannot be checked after the fact, and that is not a stylistic
+// preference. `messages.id` is a GLOBAL autoincrement, not per-channel, so
+// two consecutive rows of one channel routinely carry non-consecutive ids —
+// every busy server interleaves other channels between them. No id-gap scan
+// over a loaded window can therefore distinguish a hole the client punched
+// from ordinary numbering, in production or in a test. The only place the
+// difference is observable is at the moment of the cut, against the input
+// the cut was made from. So the guard lives here, and it is structural:
+// whatever leaves this function is a CONTIGUOUS RUN of what entered it.
+//
+// (In the field probe that found #1538 the ids were synthetic and
+// consecutive, which is the ONLY reason the hole was visible at all.)
+describe("capScrollbackRing — structural contiguity invariant (#1538)", () => {
+  const mkRow = (id: number): import("../lib/api").ScrollbackMessage => ({
+    id,
+    network: "freenode",
+    channel: "#grappa",
+    server_time: id,
+    kind: "privmsg",
+    sender: "peer",
+    body: `line ${id}`,
+    meta: {},
+  });
+
+  // `out` must be `input.slice(start, start + out.length)` for some start —
+  // compared by REFERENCE, so no id arithmetic can fake it.
+  const assertContiguousRun = (
+    input: import("../lib/api").ScrollbackMessage[],
+    out: import("../lib/api").ScrollbackMessage[],
+    label: string,
+  ): void => {
+    if (out.length === 0) return;
+    const start = input.indexOf(out[0] as import("../lib/api").ScrollbackMessage);
+    expect(start, `${label}: first output row is not from the input`).toBeGreaterThanOrEqual(0);
+    expect(out, `${label}: output is not a contiguous run of the input`).toEqual(
+      input.slice(start, start + out.length),
+    );
+  };
+
+  it("returns a contiguous run of its input for every cursor position and size", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    const bound = scrollback.UNREAD_RETENTION_CAP;
+    const ring = scrollback.SCROLLBACK_RING_CAP;
+
+    // Sizes straddle both thresholds and both their ±1 neighbourhoods; cursor
+    // positions cover "no cursor", "before every row", "one read row",
+    // mid-window, "one unread row" and "everything read".
+    const sizes = [1, bound, bound + 1, bound + 50, ring, ring + 1, ring + 300];
+    for (const size of sizes) {
+      const input = Array.from({ length: size }, (_, i) => mkRow(i + 1));
+      const positions: Array<number | null> = [
+        null,
+        0,
+        1,
+        Math.floor(size / 2),
+        size - 1,
+        size,
+        size + 10,
+      ];
+      for (const cursor of positions) {
+        mockGetReadCursor.mockReturnValue(cursor);
+        const capped = scrollback.capScrollbackRing(key, input);
+        assertContiguousRun(input, capped.rows, `size=${size} cursor=${cursor}`);
+        // And the live tail is never what leaves: the newest row always stays.
+        expect(capped.rows[capped.rows.length - 1], `size=${size} cursor=${cursor}`).toBe(
+          input[input.length - 1],
+        );
+      }
+    }
+  });
+
+  it("the reported shape: read context above + a live arrival leaves NO hole", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    const bound = scrollback.UNREAD_RETENTION_CAP;
+    // #sniffo as reported: the operator scrolled up past their own read
+    // position, so read context sits ABOVE the divider, and the unread region
+    // below it is over the ceiling. This is the exact state in which the
+    // excision used to carve rows out from under the operator's eyes.
+    const cursor = 1000;
+    mockGetReadCursor.mockReturnValue(cursor);
+    const input = [
+      ...Array.from({ length: 50 }, (_, i) => mkRow(cursor - 49 + i)),
+      ...Array.from({ length: bound + 51 }, (_, i) => mkRow(cursor + 1 + i)),
+    ];
+    const capped = scrollback.capScrollbackRing(key, input);
+    const ids = capped.rows.map((m) => m.id);
+    for (let i = 1; i < ids.length; i++) {
+      expect(ids[i], "a row went missing from the middle of the kept range").toBe(
+        (ids[i - 1] as number) + 1,
+      );
+    }
+    // What it keeps is the TAIL, contiguous, exactly one page of it.
+    expect(capped.rows.length).toBe(bound);
+    expect(ids[ids.length - 1]).toBe(cursor + bound + 51);
+    // And it still reports the pruning, so the caller arms far-behind: the
+    // window announces itself as far behind rather than lying quietly.
+    expect(capped.unreadDropped).toBe(51);
+    expect(capped.unreadHeld).toBe(bound + 51);
   });
 });
 

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -188,14 +188,21 @@ const isCanonicallyOrdered = (rows: ScrollbackMessage[]): boolean => {
   return true;
 };
 
-// Trim `rows` (ASC by id) to the ring cap by dropping the OLDEST, but NEVER a
-// row at/after the read cursor: the in-pane `── XX unread ──` divider anchors
-// on the cursor and its unread rows (CLAUDE.md "Read state is server-owned"),
-// so dropping the boundary would break the unread contract. The evictable
-// region is exactly the read-context strictly below the divider (id <
-// cursor); a pathological all-unread channel simply holds above the cap until
-// the operator reads (advancing the cursor makes those rows evictable). With
-// no cursor (fresh channel, no divider) eviction is unconstrained.
+// Trim `rows` (ASC by id) to the bounds below, ALWAYS by dropping a PREFIX —
+// never a block out of the interior (#1538; the invariant is enforced by a test
+// on this function, because global `messages.id` makes a hole undetectable from
+// the outside afterwards).
+//
+// Two bounds, in order:
+//   * the #1229 unread ceiling — past one page of unread the window collapses
+//     to the newest page and the caller arms far-behind. See below.
+//   * the S20 ring cap — under that ceiling, drop the OLDEST but NEVER a row
+//     at/after the read cursor: the in-pane `── XX unread ──` divider anchors
+//     on the cursor and its unread rows (CLAUDE.md "Read state is
+//     server-owned"), so the evictable region is exactly the read context
+//     strictly below the divider. With no cursor (fresh channel, no divider)
+//     eviction is unconstrained.
+//
 // What the cap did, so the caller can arm the far-behind state without the
 // pure updater reaching for a signal. `unreadDropped > 0` is the ONLY way a row
 // at/after the cursor ever leaves the store on this path.
@@ -208,7 +215,13 @@ type CappedRing = {
   cursor: number | null;
 };
 
-const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRing => {
+// #1538 — exported for its structural contiguity test, and for nothing else:
+// no production caller outside this module. Same reason
+// `shouldRescueUnderfillLoadOlder` is exported from `ScrollbackPane` — the
+// decision is where the defect lives, so the decision is what a test must be
+// able to address. See the invariant's own comment in `scrollback.test.ts`
+// for why it CANNOT be checked from the outside after the fact.
+export const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRing => {
   const decoded = decodeChannelKey(key);
   const cursor = decoded ? getReadCursor(decoded.slug, decoded.name) : null;
   // Rows are ASC by id, so the first index with id >= cursor bounds the
@@ -227,45 +240,71 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): CappedRi
   // ring cap because it can bite while the total is still under it (900 unread
   // and no read history is 900 rows the operator cannot see the top of).
   //
-  // It drops the OLDEST unread — the rows just under the divider — and not
-  // simply "everything but the newest page", which would have been one slice
-  // instead of two. The difference is the operator scrolled UP reading history
-  // while a busy channel runs on below them: their cursor sits at the last row
-  // they can see, so the arriving rows are unread and the ceiling bites: the
-  // one-slice version deletes the screen they are reading, the pane jumps to
-  // the tail. Dropping from just below the divider instead removes rows that
-  // are off-screen BELOW, leaving `scrollTop` and everything above it intact.
-  // What remains of the read context is then trimmed by the ring cap, exactly
-  // as it was before this bound existed.
-  //
-  // Two invariants decide the arithmetic, and both are one row wide:
-  //   * the BOUNDARY row (`id === cursor`, the newest READ row) is not this
-  //     bound's to drop — it is what the divider anchors on, and the rule this
-  //     whole function is built around exempts `id >= cursor`. So the trim
-  //     starts at `firstUnread`, never at `firstProtected`.
-  //   * the ceiling is crossed at `unreadCount > UNREAD_RETENTION_CAP`, the
-  //     SAME comparison `isFarBehind` makes, because the bound's job is to
-  //     deliver the window into that state. Biting at `=== CAP` would arm the
-  //     banner for a window the reload path's gap probe still calls near, and
-  //     the shared constant exists precisely so those two cannot disagree.
+  // The ceiling is crossed at `unreadCount > UNREAD_RETENTION_CAP`, the SAME
+  // comparison `isFarBehind` makes, because the bound's job is to deliver the
+  // window into that state. Biting at `=== CAP` would arm the banner for a
+  // window the reload path's gap probe still calls near, and the shared
+  // constant exists precisely so those two cannot disagree.
   const overflowUnread =
     unreadCount > UNREAD_RETENTION_CAP ? unreadCount - UNREAD_RETENTION_CAP : 0;
-  const afterUnreadTrim =
-    overflowUnread > 0
-      ? [...rows.slice(0, firstUnread), ...rows.slice(firstUnread + overflowUnread)]
-      : rows;
 
-  const surplus = afterUnreadTrim.length - SCROLLBACK_RING_CAP;
+  // #1538 — past the ceiling the window COLLAPSES to a contiguous tail window.
+  //
+  // It used to excise the oldest unread instead — `[...slice(0, firstUnread),
+  // ...slice(firstUnread + overflowUnread)]`, two slices, a block lifted out of
+  // the INTERIOR — on the argument that those rows are "off-screen BELOW,
+  // leaving scrollTop and everything above it intact". That argument reads the
+  // read cursor as a proxy for where the operator is looking, and the proxy
+  // fails in exactly one case: the operator has scrolled DOWN past the divider
+  // into the unread region. Then the rows just under the divider are the rows
+  // on screen, and the excision cut them out from under them — two reporters,
+  // #sniffo, nine rows out of the middle of a rendered range (#1538).
+  //
+  // So: keep the newest page, drop a PREFIX, never an interior block. What the
+  // operator loses is the read context above the divider — and that is a cost
+  // the pane ANNOUNCES, because the same transition arms far-behind: the
+  // "N unread — jump back" banner goes up and `jumpToUnread` rebuilds the
+  // region from the server. The excision's cost was a hole nothing declared and
+  // scrolling up could not repair (`loadMore` pages before `rows[0]`, which sits
+  // ABOVE the hole). An announced loss and a silent one are not comparable.
+  //
+  // This is also the shape `anchorAtTail` already produces, and for the reason
+  // it already states: a non-contiguous loaded set "renders a silent hole — two
+  // regions abutting as if they were consecutive". That verb refuses to create
+  // one; this one no longer does either. Contiguity is now a property of every
+  // path (`loadMore`, `loadNewer`, `jumpToUnread`, `anchorAtTail`, this), which
+  // is what makes it an invariant worth a test rather than a habit.
+  //
+  // The BOUNDARY row (`id === cursor`) goes too, and that is deliberate: it is
+  // exempt only because the divider anchors on it, and the far-behind state
+  // this same transition arms SUPPRESSES the divider (`ScrollbackPane`'s
+  // `injectMarker` gate). Keeping an anchor for a divider that is not drawn
+  // would be keeping it for nobody. Below the ceiling the exemption is
+  // untouched and S20's contract is byte-identical.
+  //
+  // Returning here leaves the ring cap below to the one case it still owns.
+  // The kept slice is `UNREAD_RETENTION_CAP` rows and that constant is
+  // `PAGE_LIMIT`, an order of magnitude under `SCROLLBACK_RING_CAP`, so the
+  // ring cap has nothing left to say about this window.
+  if (overflowUnread > 0) {
+    return {
+      rows: rows.slice(rows.length - UNREAD_RETENTION_CAP),
+      unreadDropped: overflowUnread,
+      unreadHeld: unreadCount,
+      cursor,
+    };
+  }
+
+  const surplus = rows.length - SCROLLBACK_RING_CAP;
   let dropCount = surplus > 0 ? surplus : 0;
   if (cursor !== null && dropCount > 0) {
-    // The evictable prefix shrank with the unread trim only in its tail, so the
-    // read-context boundary is still where it was: `firstProtected`.
-    const maxDroppable = firstProtected === -1 ? afterUnreadTrim.length : firstProtected;
+    // The evictable region is the read context strictly below the divider.
+    const maxDroppable = firstProtected === -1 ? rows.length : firstProtected;
     if (dropCount > maxDroppable) dropCount = maxDroppable;
   }
   return {
-    rows: dropCount > 0 ? afterUnreadTrim.slice(dropCount) : afterUnreadTrim,
-    unreadDropped: overflowUnread,
+    rows: dropCount > 0 ? rows.slice(dropCount) : rows,
+    unreadDropped: 0,
     unreadHeld: unreadCount,
     cursor,
   };

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -61967,3 +61967,115 @@ nothing. And Kohina's vendor is deliberately ABSENT from
 is an `.m3u` DOCUMENT rather than a redirecting host, the map cannot
 express that shape, and inventing a front door for it would be the
 unverifiable claim the map exists to prevent.
+<!-- entry #1538 -->
+
+---
+
+## 2026-08-24 — #1538: rows vanish from the MIDDLE of a rendered range
+
+Two reporters on #sniffo, mobile, nine rows gone from between two rows that
+both stayed on screen. The issue asked for one thing first: separate "rows
+left the STORE" from "rows left the DOM", because the two have opposite
+cures. Recorded here is what the measurement settled, one discovery that
+makes the cure defensible, and one conflict it does NOT settle.
+
+### It is the store, and the DOM is a faithful projection
+
+Measured on both planes rather than argued from one.
+
+STORE, real module, the reported route (scroll-up then live arrivals),
+cursor 1000: six `loadMore` prepends give 301 rows, 950..1250, 51 read + 250
+unread, **no holes**. ONE live append then yields a contiguous **hole
+[1001..1051]** — the last READ row alive above it, the rest of the unread
+alive below. Eight further arrivals grow it to [1001..1059], **one row per
+message**. A further scroll-up moves the oldest row 950 → 900 and leaves the
+hole untouched: `loadMore` pages before `rows[0]`, which sits ABOVE the hole,
+so the gesture that looks like it should repair it never can.
+
+DOM, real `ScrollbackPane` in jsdom: 301 store rows → 301 `.scrollback-line`
+nodes; then the holed 251-row array → 251 nodes, exact set AND order
+equality. The pane reads the store directly and `<For each={rows()}>`
+rebuilds the list on every change, so it renders the hole and does not make
+one.
+
+The `rows()` presence filter (#222) is excluded by the SHAPE of the report,
+not by assumption: the gap contains ordinary messages while a presence row
+(`* mizar…`) survived it — the exact inverse of what that filter does.
+
+Control arm: with the cursor BELOW every loaded row (no read context above),
+500 rows become 200 with **no hole** — a prefix drop. The S20 ring cap alone
+therefore cannot open an interior gap, which is what the issue already
+suspected; the arm that opens one lives in the same function.
+
+### Why the guard has to be ON the function, not a check afterwards
+
+`messages.id` is a GLOBAL autoincrement, not per-channel. Two consecutive
+rows of one channel routinely carry non-consecutive ids, because every other
+channel on the server is interleaved between them. So **no id-gap scan over a
+loaded window can tell a hole the client punched from ordinary numbering** —
+not in production, not in a test, not after the fact. The difference is
+observable only at the moment of the cut, against the input the cut was made
+from.
+
+That is why `capScrollbackRing` is exported and carries a structural
+invariant test: whatever leaves it is a CONTIGUOUS RUN of what entered it,
+compared by reference across a grid of sizes and cursor positions. The probe
+that found #1538 only saw the hole because its ids were synthetic and
+consecutive. Nothing in the field would have.
+
+### Two further measurements
+
+**The ratchet.** `setCursorIfAdvances` (`selection.ts`) returns early while
+the window is far behind — measured: `setReadCursor` called **0 times**. The
+first bite arms far-behind, far-behind freezes the cursor, the frozen cursor
+keeps the unread region above the ceiling, and every later message takes one
+more row. Forty arrivals took the hole from 51 to 90 rows. Reading cannot
+stop it; only `jumpToUnread` or `dismissFarBehind` can. This is the second
+reporter's "after the third scroll it's toast".
+
+**The mobile bridge, without inventing a second defect.** The mechanism is
+platform-independent JS, so "mobile only" needed an explanation. It is the
+catch-up path: a HEALTHY window (201 rows, 120 unread, under the ceiling, no
+hole) takes ONE 150-row `refreshScrollback` page and comes out with a
+**70-row hole in a single step**. iOS suspends the web process on every app
+switch, so that path is the norm on a phone and the exception on a desktop.
+The frequency itself is inferred from the platform, not measured here. The
+#230 touch-underfill trigger is excluded with a proof rather than a guess:
+its seam returns false whenever the pane is natively scrollable, and a
+200-row pane overflows.
+
+### The cure, and the decision it reverses
+
+`capScrollbackRing` now collapses to a contiguous tail window past the unread
+ceiling — `rows.slice(rows.length - UNREAD_RETENTION_CAP)`, a PREFIX drop —
+instead of excising `[...slice(0, firstUnread), ...slice(firstUnread +
+overflow)]` from the interior. The boundary row goes with the prefix, which
+is consistent rather than careless: it is exempt only because the divider
+anchors on it, and the same transition arms far-behind, which suppresses the
+divider.
+
+The argument for it is that the two costs are not comparable. The operator is
+already being told "you are N behind, jump back"; losing the read context
+above the divider is part of that announcement, while losing a block from the
+middle is a silent loss of history that scrolling up cannot repair. It also
+restores contiguity as a property of every path — `loadMore`, `loadNewer`,
+`jumpToUnread`, `anchorAtTail` — and `anchorAtTail` already refuses to create
+a non-contiguous window for the reason it states in place: two regions
+abutting as if they were consecutive render "a silent hole".
+
+**What this does NOT settle, and it is written down because the branch must
+not be read as closing it.** #1229 did not arrive at the excision by
+accident: it considered this exact collapse and rejected it, and left an e2e
+(`issue1229-unread-retention-bound.spec.ts`) whose moduledoc says so —
+dropping "everything but the newest page" *"would have satisfied (2) while
+deleting the screen out from under a reader scrolled up in history"* — with
+assertions pinning that the read-context row survives and `scrollTop` does
+not move. So the cure trades #1538's victim (a reader scrolled DOWN past the
+divider, into the unread region) for #1229's victim (a reader parked ABOVE
+it, in read history). Both failures have one root: the store picks what to
+destroy using the read cursor as a proxy for the viewport, and the proxy is
+wrong for whichever reader is on the other side of the divider. A rule that
+serves both has to prune the end FURTHEST from the viewport — still prefix or
+suffix, never interior, both ends re-pageable by `loadMore` / `loadNewer` —
+which needs a viewport signal the store does not have today. That is the
+open question, and it is vjt's to rule on.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62063,19 +62063,40 @@ restores contiguity as a property of every path — `loadMore`, `loadNewer`,
 a non-contiguous window for the reason it states in place: two regions
 abutting as if they were consecutive render "a silent hole".
 
-**What this does NOT settle, and it is written down because the branch must
-not be read as closing it.** #1229 did not arrive at the excision by
-accident: it considered this exact collapse and rejected it, and left an e2e
-(`issue1229-unread-retention-bound.spec.ts`) whose moduledoc says so —
-dropping "everything but the newest page" *"would have satisfied (2) while
-deleting the screen out from under a reader scrolled up in history"* — with
-assertions pinning that the read-context row survives and `scrollTop` does
-not move. So the cure trades #1538's victim (a reader scrolled DOWN past the
-divider, into the unread region) for #1229's victim (a reader parked ABOVE
-it, in read history). Both failures have one root: the store picks what to
+### The decision this reverses, and the ruling that authorised it
+
+#1229 did not arrive at the excision by accident: it considered this exact
+collapse and rejected it, and left an e2e
+(`issue1229-unread-retention-bound.spec.ts`) whose moduledoc said so in
+place — dropping "everything but the newest page" *"would have satisfied (2)
+while deleting the screen out from under a reader scrolled up in history"* —
+with assertions pinning that the read-context row survives and `scrollTop`
+does not move.
+
+So the two are a straight trade, and the trade is worth stating because
+neither side is free. #1229 protected the reader parked ABOVE the divider, in
+read history; the cost it accepted, without knowing it, was the reader
+scrolled DOWN past the divider, into the unread region, whose screen the
+excision cuts out. Both failures have ONE root: **the store picks what to
 destroy using the read cursor as a proxy for the viewport, and the proxy is
-wrong for whichever reader is on the other side of the divider. A rule that
-serves both has to prune the end FURTHEST from the viewport — still prefix or
+wrong for whichever reader is on the far side of the divider.** A rule that
+serves both would prune the end FURTHEST from the viewport — still prefix or
 suffix, never interior, both ends re-pageable by `loadMore` / `loadNewer` —
-which needs a viewport signal the store does not have today. That is the
-open question, and it is vjt's to rule on.
+which needs a viewport signal the store does not have and which the DOM-free
+seam (`lib/scrollback.ts` says WHEN, the pane reads WHAT) would have to be
+reopened to supply.
+
+Put to vjt as that trade. Ruled, 2026-08-24:
+
+> "basta che lo scroll sia contiguo e non ci siano buchi"
+
+**That sentence is the acceptance criterion, not a side condition, and it is
+why the structural invariant above is load-bearing rather than good
+practice.** The ruling does not say "prefer contiguity"; it makes contiguity
+the thing the cure is accepted FOR. The reference-equality contiguity sweep
+on `capScrollbackRing` and the e2e's run-check against the server's own
+ordering are therefore not extra coverage — they are the two places the
+criterion is demonstrated to hold, one per plane, and the global-id finding
+above is precisely why neither could be replaced by a check made afterwards.
+The #1229 e2e was rewritten to that criterion rather than deleted, with its
+former contract quoted in its moduledoc so the reversal stays legible.


### PR DESCRIPTION
Rows vanished from the **middle** of an already-rendered scrollback range
for two independent reporters on #sniffo — the row above the gap and the row
below it both still on screen. Issue #1538.

The issue asked for one thing before any code: separate *"rows left the
STORE"* from *"rows left the DOM"*, because the two have opposite cures. That
came first, and it is what gave the hunt one target instead of two.

## What the measurement settled

**It is the store. The DOM is a faithful projection of it.**

*Store*, real module, the reported route (scroll-up, then live arrivals),
cursor 1000: six `loadMore` prepends give 301 rows, `950..1250`, 51 read +
250 unread, **no holes**. One live append then yields a contiguous hole
`[1001..1051]` — the last READ row alive above it, the rest of the unread
alive below. Eight further arrivals grow it to `[1001..1059]`: **one row per
message**. A further scroll-up moves the oldest row `950 → 900` and leaves
the hole untouched, because `loadMore` pages before `rows[0]`, which sits
*above* the hole — the gesture that looks like it should repair it never can.

*DOM*, real `ScrollbackPane` in jsdom: 301 store rows → 301
`.scrollback-line` nodes; the holed 251-row array → 251 nodes, **exact set
and order equality**.

The `rows()` presence filter is excluded by the **shape of the report**, not
by assumption: the gap contains ordinary messages while a presence row
(`* mizar…`) survived it — the exact inverse of what that filter does.

Control arm: with the cursor *below* every loaded row (no read context
above), 500 rows become 200 with **no hole** — a prefix drop. The S20 ring
cap alone cannot open an interior gap. The arm that does lives in the same
function: #1229's unread ceiling, `[...slice(0, firstUnread),
...slice(firstUnread + overflow)]`.

Two further measurements, both in `DESIGN_NOTES`:

- **A ratchet.** `setCursorIfAdvances` returns early while the window is far
  behind (measured: `setReadCursor` called **0 times**). The first bite arms
  far-behind, far-behind freezes the cursor, the frozen cursor keeps unread
  above the ceiling, and every later message takes one more row. Forty
  arrivals took the hole from 51 to 90. Reading cannot stop it.
- **The mobile bridge, without inventing a second defect.** A *healthy*
  window (201 rows, 120 unread, under the ceiling, no hole) takes one 150-row
  `refreshScrollback` catch-up and comes out with a **70-row hole in a single
  step**. iOS suspends the web process on every app switch, so that path is
  the norm on a phone. The #230 touch-underfill trigger is excluded with a
  proof, not a guess: its seam returns false whenever the pane is natively
  scrollable, and a 200-row pane overflows.

## The cure, and the criterion it is accepted for

Past the unread ceiling the window now **collapses to a contiguous tail
window** — `rows.slice(rows.length - UNREAD_RETENTION_CAP)`, a prefix drop —
instead of excising a block from the interior.

This reverses a deliberate #1229 decision, which is why it went to vjt as a
trade rather than as a bug fix. #1229 protected the reader parked *above* the
divider; the cost it accepted, without knowing it, was the reader scrolled
*down* past the divider, whose screen the excision cuts out. One root: the
store chooses its victims using the read cursor as a **proxy for the
viewport**, and the proxy is wrong for whichever reader is on the far side of
the divider.

vjt's ruling, 2026-08-24:

> **"basta che lo scroll sia contiguo e non ci siano buchi"**

That sentence is the **acceptance criterion**, not a side condition. So the
structural invariant is not good practice here — it is *the condition*, and
these two tests are where the criterion is demonstrated to hold, one per
plane:

- **store** — `capScrollbackRing` now carries a contiguity sweep: whatever
  leaves the function is a contiguous run of what entered it, compared by
  **reference**, across a grid of sizes and cursor positions (both thresholds
  and their ±1 neighbourhoods; cursor absent / before all / mid / at tail /
  past the end).
- **DOM** — the #1229 e2e now asserts the rendered rows are a contiguous
  slice of the channel **as the server orders it**
  (`fetchAllMessagesAsc`), plus that the drop took *both* the oldest unread
  and the read context above it, i.e. a prefix and not an excision that
  happened to take the sampled row.

The boundary row goes with the prefix, and that is coherent rather than
careless: it is exempt only because the divider anchors on it, and the same
transition arms far-behind, which **suppresses** the divider.

## Two green tests were asserting the bug. Both rewritten, not patched.

1. **`scrollback.test.ts:1871`** — *"bites one row past the ceiling, dropping
   the OLDEST unread and never the boundary"*. It asserted `ids` **contains**
   `cursor` and **does not contain** `cursor + 1`: the row above the gap alive
   and the first row of the gap gone. That is the defect, pinned as the
   contract, under a title calling it *"never the boundary"*. This is why no
   one could have found #1538 by running the suite. Rewritten with the cure,
   with the old assertion quoted in place so the next reader knows what the
   green was worth.
2. **`issue1229-unread-retention-bound.spec.ts`** — its moduledoc points 3
   and 4 pinned that the read-context row *survives* and `scrollTop` does
   *not* move. Rewritten to the ruling. Its former contract is quoted
   verbatim rather than deleted: it was not wrong when it was written, and a
   reader who finds this spec in a year should see the trade and who made it,
   not only the surviving side.

## Why the invariant had to be structural

`messages.id` is a **global** autoincrement, not per-channel. Two consecutive
rows of one channel routinely carry non-consecutive ids, because every other
channel on the server is interleaved between them. So **no id-gap scan over a
loaded window can tell a hole the client punched from ordinary numbering** —
not in production, not in a test, not after the fact. The difference is
observable only at the moment of the cut, against the input the cut was made
from.

That is why `capScrollbackRing` is exported and guarded on the function, and
why the e2e checks against the server's ordering instead of doing arithmetic
on ids. The probe that found #1538 only saw the hole because its ids were
synthetic and consecutive; nothing in the field would have.

## Not measured — stated, not glossed

- **Real iOS: no measurement at all.** The proofs run in jsdom and chromium.
  The DOM measurement argues against a *reconciliation* defect; it says
  nothing about iOS Safari's rendering. For the reported shape no second
  defect is needed — the store one produces all of it — but that is an
  argument, not an iOS measurement.
- **The real frequency of the iOS suspend/reconnect cycle.** The *path* is
  measured (a 150-row catch-up opens a 70-row hole in one step); the claim
  that it is frequent on a phone is architectural inference.
- **Which phase the reporters saw** — a first bite of 9 rows, or 9 arrivals
  in the steady state after an earlier bite. Same mechanism, two phases; the
  screenshots cannot separate them.

## Gates

- `bun run check` — 4/4 stages green (lock-drift, biome, tsc src, tsc e2e).
- `bun run test` — 313 files, 6142 tests green.
- `scripts/integration.sh`, full local suite — **769 passed, 2 failed
  (30.5m)**. Stated as measured rather than as "green", because it was not.

  The spec this PR rewrote is **green**: `✓ 136 [chromium]
  issue1229-unread-retention-bound.spec.ts:171 — crossing one page of unread
  collapses to a CONTIGUOUS tail window and raises the far-behind bar
  (#1538)`, 1.5s. That is the ruling's criterion executed in a real browser.

  The two failures are unrelated to scrollback pruning, and named so the
  claim can be checked rather than taken:
  - `cp15-b5-window-state-pending-to-joined.spec.ts:50` (32.6s)
  - `issue247-notify-watch.spec.ts:49` (32.9s)

  Both chromium, both timeout-shaped, neither touching the store or the
  retention bound. `cp15-b5` is the sibling of `cp15-b6`, which #507
  documents as green 3/3 in isolation and red under full load — same family,
  same profile. Not re-run in isolation here: local e2e is not the ship gate
  and CI re-runs the suite on this PR anyway.

— w1
