### PR TITLE
#1737 — the rail owns its horizontal inset, and the now-playing band is no longer inert

### DIFF
--- a/cicchetto/e2e/tests/issue1737-rail-inset-and-band-restore.spec.ts
+++ b/cicchetto/e2e/tests/issue1737-rail-inset-and-band-restore.spec.ts
@@ -1,0 +1,155 @@
+// #1737 — two defects on the rail's now-playing band, and both need a BROWSER.
+//
+//   (a) the band sat flush against the rail edges while the `actions` launcher
+//       below it was inset, so the two surfaces did not line up. vjt ruled the
+//       cure is to move the horizontal inset onto the rail CONTAINER, with the
+//       children at zero, rather than to give the band a matching value by
+//       hand — one owner, one number, no drift between the rows.
+//   (b) the band was inert except for its ⏹: tapping what is playing did not
+//       bring back a transport the operator had hidden (#1697).
+//
+// WHY E2E AND NOT VITEST. (a) is RENDERED GEOMETRY. jsdom computes no layout —
+// every `getBoundingClientRect()` there is zero — so a unit test can only
+// assert that some declaration exists, which is a mirror of the stylesheet and
+// would have passed just as happily before the fix. The whole defect is "these
+// two boxes have different edges", and only a real engine has edges.
+// (b)'s STATE half is pinned in `src/__tests__/RailRadio.test.tsx`; what is
+// left for here is its GEOMETRIC half — that the restore control does not
+// cover the ⏹, which is a hit-test and therefore also engine-only.
+//
+// THE ASSERTION IS A RELATION, NOT A NUMBER. It compares the band's edges with
+// the launcher's rather than checking either against `0.5rem`. A pixel literal
+// would re-encode the very value the fix just made single-source, and would go
+// red on a root-font-size change that broke nothing. Measured on the defect:
+// the band's border box started at the rail's inner edge and the launcher's
+// started 0.5rem in, so the equality below is exactly what did not hold.
+//
+// FORM FACTOR, stated rather than implied: this runs on desktop chromium. The
+// rule it proves lives on `.shell-members`, which both Shell branches mount
+// and both form factors style from — the mobile drawer adds only `padding-top`
+// / `padding-bottom` for the safe area, separate longhands from the
+// `padding-inline` this asserts, so there is no shorthand for one to clobber
+// the other with. The phone is not separately covered here.
+//
+// NO THIRD-PARTY NETWORK, for the reason the #682 spec spells out: the stream
+// and the logos are served from local bytes, so a somafm.com outage cannot
+// turn this red.
+
+import type { Page } from "@playwright/test";
+import { silentMp3 } from "../fixtures/bytes";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Literals, not an import from `src/lib/radioStations`, so a table edit that
+// drops or renames this station fails HERE instead of being followed silently.
+const STATION_ID = "groovesalad";
+const STATION_STREAM = "https://ice.somafm.com/groovesalad-128-mp3";
+
+// Sub-pixel slack: the engine lays these boxes out in device pixels, so two
+// edges that agree can still differ in the last fraction. Written as an
+// explicit `Math.abs(…) < EPSILON` below rather than with `toBeCloseTo`,
+// whose second argument is a DIGIT COUNT and not a tolerance — passing 0.5
+// there would silently mean "round to half a decimal digit".
+const EPSILON = 0.5;
+
+test.setTimeout(90_000);
+
+/** Tune the spec's station from the rail picker and leave the picker shut. */
+const tuneStation = async (page: Page): Promise<void> => {
+  await openRailMenu(page);
+  await page.getByTestId("rail-action-radio").click();
+  await expect(page.getByTestId("rail-radio-picker")).toBeVisible();
+  await page.getByTestId(`rail-radio-station-${STATION_ID}`).click();
+  await expect(page.getByTestId("audio-mini-player-el")).toHaveJSProperty("src", STATION_STREAM);
+  // Picking deliberately does NOT close the picker (#682), and it overlays the
+  // whole rail — so the band underneath is unreachable until it is dismissed.
+  await page.getByTestId("rail-radio-picker-close").click();
+  await expect(page.getByTestId("rail-radio-picker")).toBeHidden();
+  await expect(page.getByTestId("rail-radio-now")).toBeVisible();
+};
+
+const routeLocalAudio = async (page: Page): Promise<void> => {
+  await page.route("https://ice.somafm.com/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "audio/mpeg", body: silentMp3(8) });
+  });
+  await page.route("https://api.somafm.com/logos/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "image/png", body: Buffer.alloc(0) });
+  });
+};
+
+test("#1737 — the rail's surfaces share one horizontal inset, owned by the rail", async ({
+  page,
+}) => {
+  await routeLocalAudio(page);
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await tuneStation(page);
+
+  const rail = await page.locator(".shell-members").boundingBox();
+  const band = await page.getByTestId("rail-radio-now").boundingBox();
+  const launcher = await page.getByTestId("rail-actions-launcher").boundingBox();
+  if (rail === null || band === null || launcher === null) {
+    throw new Error("rail, band and launcher must all be laid out for this to mean anything");
+  }
+
+  // THE DEFECT: a full-bleed band above an inset button. Both edges, because
+  // an inset applied on one side only would satisfy half of this and still
+  // look wrong.
+  expect(Math.abs(band.x - launcher.x)).toBeLessThan(EPSILON);
+  expect(Math.abs(band.x + band.width - (launcher.x + launcher.width))).toBeLessThan(EPSILON);
+
+  // …and they line up INSET, not merely with each other: the pair could agree
+  // by both bleeding to the edges, which is the state this issue rejects.
+  expect(band.x).toBeGreaterThan(rail.x);
+  expect(band.x + band.width).toBeLessThan(rail.x + rail.width);
+
+  // Symmetric, so the inset reads as one value and not as two that happen to
+  // both be non-zero.
+  const leftGap = band.x - rail.x;
+  const rightGap = rail.x + rail.width - (band.x + band.width);
+  // The rail's own `border-left` lives inside its bounding box, so the two
+  // gaps differ by that 1px by construction — the tolerance names it rather
+  // than pretending the box is symmetric.
+  expect(Math.abs(leftGap - rightGap)).toBeLessThanOrEqual(1 + EPSILON);
+});
+
+test("#1737 — tapping the band brings back a hidden transport, and ⏹ still stops", async ({
+  page,
+}) => {
+  await routeLocalAudio(page);
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await tuneStation(page);
+
+  const dockedPlayer = page.getByTestId("audio-mini-player");
+  await expect(dockedPlayer).toBeVisible();
+
+  // Hide the transport the way the operator does — the control #1697 added.
+  await page.getByTestId("audio-mini-player-hide").click();
+  await expect(dockedPlayer).toBeHidden();
+
+  // (b) the band is the obvious door back, and this is a REAL tap: it lands
+  // wherever the restore control actually is, so a control that renders behind
+  // the band or collapses to zero width fails here.
+  await page.getByTestId("rail-radio-now-restore").click();
+  await expect(dockedPlayer).toBeVisible();
+
+  // The ⏹ keeps its own tap target — the issue's explicit constraint, and the
+  // half a unit test cannot reach. `closeAudio` resets `playerHidden` itself,
+  // so "stopped" and "restored then stopped" are the same STATE; what is
+  // provable is that the click lands on stop at all, i.e. that the restore
+  // control neither covers the ⏹ nor swallows its click.
+  await page.getByTestId("audio-mini-player-hide").click();
+  await expect(dockedPlayer).toBeHidden();
+  await page.getByTestId("rail-radio-stop").click();
+  // Both surfaces go: the band because nothing is tuned any more, the docked
+  // chrome because there is no source. NOT `audio-mini-player-el` — that
+  // element is mounted UNCONDITIONALLY (AudioMiniPlayer's header says why: a
+  // <Show> around it would race the ref assignment), so asserting on its
+  // absence would assert the opposite of the design.
+  await expect(page.getByTestId("rail-radio-now")).toBeHidden();
+  await expect(dockedPlayer).toBeHidden();
+});

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -1,5 +1,5 @@
 import { type Component, createSignal, For, Show } from "solid-js";
-import { audioFailureLabel, closeAudio, playbackFailure } from "./lib/audioPlayer";
+import { audioFailureLabel, closeAudio, playbackFailure, showPlayer } from "./lib/audioPlayer";
 import { createDismissOnOutsidePointer } from "./lib/dismissOnOutsidePointer";
 import { nowPlayingLabel } from "./lib/nowPlaying";
 import { createOverlayLock } from "./lib/overlayScrollLock";
@@ -106,12 +106,47 @@ const RailRadio: Component = () => {
       <Show when={tunedStation()}>
         {(station) => (
           <div class="rail-radio-now" data-testid="rail-radio-now">
-            <StationLogo station={station()} class="rail-radio-now-logo" />
-            <div class="rail-radio-now-text">
-              <span class="rail-radio-now-title" data-testid="rail-radio-now-title">
-                {station().title}
-              </span>
-              {/* #1698 — the TRACK takes the genres' slot rather than adding a
+            {/* #1737 — the band's identity half IS the door back to a hidden
+                transport (#1697). The band is the thing that says "this is
+                playing", and tapping what is playing to get the transport
+                back is the platform convention; before this it was inert
+                except for its ⏹.
+
+                WHY THE IDENTITY AND NOT THE WHOLE ROW. The ⏹ beside it is a
+                <button>, and a <button> inside a <button> is invalid HTML —
+                so the row itself cannot become the control. The alternative
+                (a click handler on the row, with ⏹ calling
+                `stopPropagation`) makes "stop must not become restore-then-
+                stop" an event-ordering rule somebody has to keep right; two
+                SIBLING buttons make it true by construction, and give the
+                keyboard two real stops instead of a div nobody can focus.
+                `flex: 1` is what makes it the whole band minus the ⏹ rather
+                than just the text it wraps.
+
+                WHY IT IS NOT GATED ON `playerHidden()`, unlike the
+                `rail-action-show-player` drawer entry that shares its verb:
+                that one is a MENU ROW, and a row that does nothing is
+                clutter you scroll past. This control costs no space — the
+                band is already on screen — so gating it would only make the
+                band change DOM shape, and with it the row's flex layout,
+                every time the operator hides the transport. `showPlayer()`
+                is idempotent, so the ungated tap is a no-op while the bar is
+                up. The drawer entry stays regardless: it is the GENERAL
+                door, because an upload carries `label: null`, is in no
+                station table, and renders no band at all. */}
+            <button
+              type="button"
+              class="rail-radio-now-restore"
+              data-testid="rail-radio-now-restore"
+              onClick={showPlayer}
+              aria-label={`show player — ${station().title}`}
+            >
+              <StationLogo station={station()} class="rail-radio-now-logo" />
+              <div class="rail-radio-now-text">
+                <span class="rail-radio-now-title" data-testid="rail-radio-now-title">
+                  {station().title}
+                </span>
+                {/* #1698 — the TRACK takes the genres' slot rather than adding a
                   third line. #500 bought this rail's vertical budget by
                   collapsing the actions behind one launcher, and a permanently
                   taller chrome would re-charge part of it. Nothing is lost:
@@ -129,32 +164,33 @@ const RailRadio: Component = () => {
                   `tunedStation()`, derived from the SOURCE, so it keeps
                   reporting what the station is broadcasting long after this
                   browser stopped being able to decode it. */}
-              <Show
-                when={playbackFailure()}
-                fallback={
-                  <Show
-                    when={nowPlayingLabel()}
-                    fallback={
-                      <span class="rail-radio-now-genres" data-testid="rail-radio-now-genres">
-                        {station().genres.join(" · ")}
-                      </span>
-                    }
-                  >
-                    {(line) => (
-                      <span class="rail-radio-now-track" data-testid="rail-radio-now-track">
-                        {line()}
-                      </span>
-                    )}
-                  </Show>
-                }
-              >
-                {(failure) => (
-                  <span class="rail-radio-now-error" data-testid="rail-radio-now-error">
-                    {`⚠ ${audioFailureLabel(failure())}`}
-                  </span>
-                )}
-              </Show>
-            </div>
+                <Show
+                  when={playbackFailure()}
+                  fallback={
+                    <Show
+                      when={nowPlayingLabel()}
+                      fallback={
+                        <span class="rail-radio-now-genres" data-testid="rail-radio-now-genres">
+                          {station().genres.join(" · ")}
+                        </span>
+                      }
+                    >
+                      {(line) => (
+                        <span class="rail-radio-now-track" data-testid="rail-radio-now-track">
+                          {line()}
+                        </span>
+                      )}
+                    </Show>
+                  }
+                >
+                  {(failure) => (
+                    <span class="rail-radio-now-error" data-testid="rail-radio-now-error">
+                      {`⚠ ${audioFailureLabel(failure())}`}
+                    </span>
+                  )}
+                </Show>
+              </div>
+            </button>
             {/* `closeAudio` directly: it already IS the stop verb, and the
                 station is derived from the player, so clearing the player is
                 what un-tunes. No radio-flavoured wrapper around it. */}

--- a/cicchetto/src/__tests__/RailRadio.test.tsx
+++ b/cicchetto/src/__tests__/RailRadio.test.tsx
@@ -5,7 +5,9 @@ import {
   audioFailureLabel,
   clearPlaybackFailure,
   closeAudio,
+  hidePlayer,
   playAudio,
+  playerHidden,
   reportPlaybackFailure,
 } from "../lib/audioPlayer";
 import { closeRadioPicker, openRadioPicker, radioPickerOpen } from "../lib/radio";
@@ -121,6 +123,75 @@ describe("RailRadio", () => {
 
     expect(activeAudio()).toBeNull();
     expect(screen.queryByTestId("rail-radio-now")).toBeNull();
+  });
+
+  // #1737 — the band is what says "this is playing", so tapping it is the
+  // obvious way back to a transport the operator hid (#1697). The
+  // `rail-action-show-player` drawer entry stays: it is the GENERAL door,
+  // because an upload carries `label: null`, is in no station table, and
+  // renders no band at all.
+  describe("tap to restore a hidden player (#1737)", () => {
+    it("restores the transport when the band is tapped", () => {
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+      hidePlayer();
+      expect(playerHidden()).toBe(true);
+
+      screen.getByTestId("rail-radio-now-restore").click();
+
+      expect(playerHidden()).toBe(false);
+      // Restoring the CHROME must not touch the SOURCE — the two axes the
+      // store keeps in separate signals for exactly this reason.
+      expect(activeAudio()?.href).toBe(station.streamUrl);
+    });
+
+    it("names the station it would bring back", () => {
+      // Hidden, this control inherits the job the docked bar's caption did:
+      // answering "what am I listening to". Same posture as the drawer entry.
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+      expect(screen.getByTestId("rail-radio-now-restore")).toHaveAccessibleName(
+        `show player — ${station.title}`,
+      );
+    });
+
+    it("leaves ⏹ its own tap target: stopping from a hidden player still stops", () => {
+      // The issue's explicit constraint. Observable half: the restore control
+      // must not SWALLOW the stop click.
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+      hidePlayer();
+
+      screen.getByTestId("rail-radio-stop").click();
+
+      expect(activeAudio()).toBeNull();
+      expect(screen.queryByTestId("rail-radio-now")).toBeNull();
+    });
+
+    it("keeps ⏹ OUTSIDE the restore control, so stop cannot become restore-then-stop", () => {
+      // The other half of that constraint, and it can only be expressed
+      // structurally: `closeAudio` resets `playerHidden` to false itself, so
+      // "stopped" and "restored then stopped" are the SAME observable state.
+      // Nesting is what would make the row handler fire on a ⏹ tap, so the
+      // guarantee is that the two controls are siblings — no `stopPropagation`
+      // ordering rule for a future reader to get wrong.
+      render(() => <RailRadio />);
+      openRadioPicker();
+      screen.getByTestId(`rail-radio-station-${station.id}`).click();
+
+      const restore = screen.getByTestId("rail-radio-now-restore");
+      const stop = screen.getByTestId("rail-radio-stop");
+
+      expect(restore.contains(stop)).toBe(false);
+      // Both are real buttons: a nested <button> is invalid HTML, which is
+      // why the identity half — and not the whole row — is the control.
+      expect(restore.tagName).toBe("BUTTON");
+      expect(stop.tagName).toBe("BUTTON");
+    });
   });
 
   it("drops the chrome when an audio upload takes the player over", () => {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2386,6 +2386,32 @@ html.resize-dragging * {
   background: var(--bg-alt);
 }
 
+/* #1737 — the band's identity half, and the door back to a hidden transport
+   (#1697). A <button> because it IS one: the ⏹ beside it is a button too, and
+   nesting them is invalid HTML, so the control is the identity rather than
+   the whole row — which also makes "stop is not restore-then-stop" true by
+   construction instead of by a `stopPropagation` ordering rule.
+   `flex: 1` is what makes it the whole band MINUS the ⏹ rather than just the
+   text it wraps, so the ⏹ also stops drifting left behind a short station
+   title; `min-width: 0` hands the title the ellipsis budget that used to sit
+   on `.rail-radio-now-text` one level down. The rest is the plain button
+   reset, the `.members-pane li .member-name` idiom. */
+.rail-radio-now-restore {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
 .rail-radio-now-logo {
   flex: none;
   width: 2rem;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1491,6 +1491,44 @@ html.overlay-open #root > div {
   /* UX-5 BS: relative positioning so .resize-handle (absolute, inner-edge)
      anchors against this aside. */
   position: relative;
+  /* #1737 — THE RAIL OWNS ITS HORIZONTAL INSET, ONCE. Every surface mounted
+     in this aside used to declare its own: `.rail-radio-now` 0.5rem of
+     padding, `.rail-actions` 0.5rem of padding, `.rail-server-info` 0.5rem of
+     MARGIN, `.rail-radio-picker-list` 0.5rem again — four hand-written copies
+     of one number, free to drift from each other.
+
+     WHAT THE REPORTED SCREENSHOT ACTUALLY SHOWED, measured before moving
+     anything: the band's CONTENT and the actions launcher already sat at the
+     same 0.5rem. What disagreed was the SURFACE. `.rail-radio-now` draws a
+     background and a `border-top` on a border box that spanned this aside
+     edge to edge, so it read as a full-bleed card; `.rail-actions` spans edge
+     to edge too, but its background is the same `--bg-alt` this aside
+     carries, so its box is invisible and the only surface there is its
+     bordered button, inset by the padding. Full-bleed card above, inset card
+     below. Moving the inset up one level shrinks both border boxes to the
+     same figure, which is the fix — tweaking `.rail-radio-now`'s padding to
+     match `.rail-actions` by hand would have been the fifth copy.
+
+     THE RULE FOR A NEW CHILD: this inset is the gap between the child's
+     BORDER box and the rail edge, and this rule owns it — a new rail surface
+     declares no `padding-inline` / `margin-inline` of its own. A bordered
+     CARD's internal padding is a different axis and stays with the card
+     (`.rail-server-info` keeps its `padding: 0.5rem 0.75rem`,
+     `.rail-actions-menu` its 0.5rem); only the gap to the rail edge moved
+     here.
+
+     THE TWO ABSOLUTES ANCHORED TO THIS ASIDE MOVE WITH IT, because an abspos
+     box resolves `inset` against its ancestor's PADDING box, not its border
+     box. `.rail-radio-picker` (`inset: 0`) inherits deliberately — it is one
+     of the three children the ruling names, and it is visually a non-event:
+     the panel's background is this same `--bg-alt`, and nothing lives in the
+     strips it stops covering (nick text starts further in, `li` carries no
+     background). The same is already true on mobile today, where this aside's
+     safe-area padding makes that `inset: 0` resolve inside it.
+     `.resize-handle-right` does NOT inherit and is compensated at its own
+     rule: it is not a content surface, it is chrome ON the edge. */
+  --rail-inset: 0.5rem;
+  padding-inline: var(--rail-inset);
 }
 
 /* UX-5 bucket BS — drag handles on the inner edge of each sidebar.
@@ -1520,8 +1558,14 @@ html.overlay-open #root > div {
 }
 
 .resize-handle-right {
-  /* Inner (left) edge of the members aside. */
-  left: 0;
+  /* Inner (left) edge of the members aside.
+     #1737 — the aside now carries `padding-inline: var(--rail-inset)`, and an
+     abspos box resolves `left` against its ancestor's PADDING box, so a plain
+     `left: 0` would park this strip one inset INSIDE the edge it exists to
+     grip. Cancelled rather than inherited: every other rail child is a
+     content surface the inset is FOR, and this one is chrome ON the boundary,
+     definitionally outside it. Renders where it did before the move. */
+  left: calc(-1 * var(--rail-inset, 0px));
 }
 
 .resize-handle:hover,
@@ -2138,7 +2182,13 @@ html.resize-dragging * {
    footer). */
 .rail-actions {
   position: relative;
-  padding: 0.5rem;
+  /* #1737 — horizontal padding GONE, to `.shell-members`; see the note there.
+     Nothing inside moves: `.rail-action` is `width: 100%` of this box and
+     `.rail-actions-menu` is abspos at `left/right: 0` against it, so both
+     spanned rail-minus-1rem before and span rail-minus-1rem now — the aside's
+     padding replaces this one exactly. The `border-top` shortens with the
+     band's, deliberately and for the same reason. */
+  padding: 0.5rem 0;
   margin-top: auto;
   border-top: 1px solid var(--border);
   background: var(--bg-alt);
@@ -2321,7 +2371,17 @@ html.resize-dragging * {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.4rem 0.5rem;
+  /* #1737 — horizontal padding GONE, to `.shell-members`. This band's border
+     box is now inset with every other rail surface instead of bleeding to the
+     edges while the launcher below it sat half a rem in.
+     WHAT THAT COSTS, accepted knowingly: the `border-top` stops reaching the
+     rail edges and becomes this card's own rule rather than a full-width
+     separator between the members pane and the radio chrome. The alternative
+     the issue offers — move the separator onto something that still spans the
+     rail — would re-introduce the single full-bleed line the report is about.
+     `.rail-actions` carries the identical `border-top` and shortens with it,
+     so the two rules stay the same length as each other, which is the point. */
+  padding: 0.4rem 0;
   border-top: 1px solid var(--border);
   background: var(--bg-alt);
 }
@@ -2432,7 +2492,13 @@ html.resize-dragging * {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding: 0.5rem;
+  /* #1737 — horizontal padding GONE. The panel above is abspos at `inset: 0`
+     against `.shell-members`, which resolves to its PADDING box, so the panel
+     is already inset by `--rail-inset`; keeping 0.5rem here would land the
+     station rows at a full rem while the band and the launcher sit at half —
+     new drift, from the edit meant to remove it. Rows land exactly where they
+     did before the move. */
+  padding: 0.5rem 0;
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -4289,6 +4355,15 @@ html.resize-dragging * {
 
 .members-pane {
   padding: 0.5rem 0;
+  /* #1737 — the ONE rail child that opts OUT of `--rail-inset`, and the two
+     reasons are both measured. Its rows carry their own `padding-inline: 1rem`
+     (here and on the `h3`), so inheriting would push every nick to 1.5rem —
+     moving a surface nobody reported. And this pane is the SCROLLER (#500):
+     inside the inset its scrollbar would float half a rem off the rail edge
+     it belongs on. The inset exists to line up SURFACES, and a nick row has
+     none — transparent background, no border, hover is an underline. Cancels
+     to zero where the var is undefined, i.e. anywhere but the rail. */
+  margin-inline: calc(-1 * var(--rail-inset, 0px));
   /* #500 — the members list owns the scroll on BOTH form factors. `flex: 1 1
      auto` + `min-height: 0` lets it take the remaining rail height and scroll
      internally (min-height:0 defeats the flex-item min-content floor that would
@@ -10633,7 +10708,12 @@ html.resize-dragging * {
    pushed off-screen on a phone. */
 .rail-server-info {
   flex: 0 0 auto;
-  margin: 0.5rem;
+  /* #1737 — the horizontal half of this margin was the rail inset spelled a
+     fourth way (as MARGIN, where its siblings used padding); it lives on
+     `.shell-members` now. The vertical half is this card's own separation
+     from the pane above and stays. The `padding` below is the card's INTERNAL
+     inset — a different axis, untouched by the move. */
+  margin: 0.5rem 0;
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border);
   border-left: 3px solid var(--accent);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62100,3 +62100,104 @@ criterion is demonstrated to hold, one per plane, and the global-id finding
 above is precisely why neither could be replaced by a check made afterwards.
 The #1229 e2e was rewritten to that criterion rather than deleted, with its
 former contract quoted in its moduledoc so the reversal stays legible.
+<!-- entry #1737 -->
+
+---
+
+## 2026-08-24 — #1737: the rail owns its horizontal inset, and what the measurement corrected
+
+vjt reported the rail's now-playing band as *"manca margin left e right"* — it
+sits flush against the rail edges while the `actions` launcher below it is
+inset — and ruled the shape of the cure twice. First scoped to the band
+(09:41: no padding on the band; the padding lives on the RAIL and the elements
+are margin-zero), then generalised (13:11: the horizontal inset goes on the
+CONTAINER and that applies to the whole rail, not just that band). The second
+is the one implemented.
+
+**The obvious reading of the report is wrong, and measuring first is what
+caught it.** `.rail-radio-now` carried `padding: 0.4rem 0.5rem`; `.rail-actions`
+carried `padding: 0.5rem`. Those are the same number, and both surfaces already
+placed their CONTENT at the same 0.5rem — so nothing about the *content* inset
+disagreed. What disagreed was the **surface**. `.rail-radio-now` draws a
+`background` and a `border-top` on a border box that spanned the rail edge to
+edge, so it reads as a full-bleed card. `.rail-actions` spans edge to edge too,
+but its background is `--bg-alt`, which is exactly the `--bg-alt`
+`.shell-members` itself carries, so its box is INVISIBLE and the only surface
+rendered there is its bordered button, inset by the padding. Full-bleed card
+above, inset card below. The cure therefore does not equalise two content
+insets; it shrinks two border boxes to one figure.
+
+**Why a matching value on the band was refused, in vjt's words and in the
+count.** The rail carried FOUR hand-written copies of one number — the band's
+padding, the actions' padding, `.rail-server-info`'s horizontal MARGIN (the
+same inset spelled a third way), and `.rail-radio-picker-list`'s padding.
+Giving the band a fifth would have been another copy of the thing the ruling
+exists to remove. `--rail-inset` on `.shell-members` is the single owner now,
+and the rule for a new child is stated at that rule: **the inset is the gap
+between the child's BORDER box and the rail edge**. A bordered CARD's internal
+padding is a different axis and stays with the card — which is why
+`.rail-server-info` keeps `padding: 0.5rem 0.75rem` and only its horizontal
+margin moved, and why `.rail-actions-menu` keeps its own 0.5rem.
+
+**Moving a container inset silently moves every absolute anchored to that
+container**, because an absolutely-positioned box resolves `inset` against its
+ancestor's PADDING box, not its border box. `.shell-members` hosts two, and
+they resolve differently on purpose. `.rail-radio-picker` (`inset: 0`, the
+full-rail overlay) INHERITS — it is one of the three children the ruling names,
+and it is visually a non-event: the panel's background is the same `--bg-alt`
+as the rail, nothing lives in the strips it stops covering (nick text starts
+further in and `li` carries no background), and the same is *already* true on
+mobile today, where the drawer's safe-area padding makes that identical
+`inset: 0` resolve inside it. `.resize-handle-right` does NOT inherit and
+cancels the inset instead: it is not a content surface, it is chrome ON the
+boundary, definitionally outside the gap.
+
+**One child opts out, and the reason generalises.** `.members-pane` keeps its
+own geometry (`margin-inline: calc(-1 * var(--rail-inset))`) because its rows
+carry `padding-inline: 1rem` of their own — inheriting would push every nick to
+1.5rem, moving a surface nobody reported — and because it is the scroller
+(#500), so inside the inset its scrollbar would float half a rem off the rail
+edge it belongs on. The general rule that falls out: **the inset lines up
+SURFACES, so a child with no surface does not take it.** A nick row is
+transparent, has no border, and its hover is an underline.
+
+**Accepted cost, named because the issue asked for it to be named.** The band's
+`border-top` no longer reaches the rail edges; it becomes the card's own border
+rather than a full-width separator between the members pane and the radio
+chrome. `.rail-actions` carries the identical `border-top` and shortens with
+it, so the two rules stay the same length as each other — which is the point.
+The alternative the issue offered (move the separator onto something that still
+spans the rail) would re-introduce the single full-bleed line the report is
+about.
+
+**The band is also no longer inert.** Its identity half became the door back to
+a transport hidden by #1697. It is the identity and not the whole row because
+the ⏹ beside it is a `<button>` and a `<button>` inside a `<button>` is invalid
+HTML: two SIBLING buttons make the issue's own constraint ("stop must not
+become restore-then-stop") true by construction, where a row-level handler plus
+`stopPropagation` on the ⏹ would have made it an event-ordering rule somebody
+has to keep right. It is deliberately UNGATED, unlike the
+`rail-action-show-player` drawer entry that shares its verb: that one is a menu
+ROW, where a row that does nothing is clutter, whereas this costs no space and
+gating it would only make the band change DOM shape — and with it the row's
+flex layout — every time the operator hides the bar. The drawer entry stays
+regardless; it is the GENERAL door, because an upload carries `label: null`, is
+in no station table, and renders no band at all.
+
+**Half of that constraint is not observable, and the test says so instead of
+pretending.** `closeAudio` resets `playerHidden` to false itself, so "stopped"
+and "restored then stopped" are the SAME state. The observable half is that ⏹
+still stops; the other half is pinned structurally, as the two controls being
+siblings.
+
+**Two testing facts worth carrying.** jsdom computes no layout — every
+`getBoundingClientRect()` there is zero — so a geometry claim cannot be proven
+in vitest at all; an assertion that some declaration exists is a mirror of the
+stylesheet and passes just as happily on the defect. And the e2e assertion is a
+RELATION (the band's edges against the launcher's) rather than a pixel literal,
+which would re-encode the value just made single-source and go red on a
+root-font-size change that broke nothing. It additionally checks the pair is
+inset and not merely equal, because two full-bleed surfaces agree with each
+other too — that is the state being rejected. Watch the tolerance idiom:
+`toBeCloseTo`'s second argument is a DIGIT COUNT, not a tolerance, so
+sub-pixel slack is written as an explicit `Math.abs(…) < EPSILON`.


### PR DESCRIPTION
Fixes both defects on the rail's now-playing band reported in #1737, in
the shape vjt ruled at 13:11: **the horizontal inset goes on the rail
CONTAINER and applies to the whole rail**, not on the band and not on
the contained elements.

## Measuring first corrected the obvious reading

The report reads as "the band needs a margin". It does not.

`.rail-radio-now` carried `padding: 0.4rem 0.5rem` and `.rail-actions`
carried `padding: 0.5rem` — the **same number**, and both surfaces
already placed their CONTENT at that same 0.5rem. Nothing about the
content inset disagreed. What disagreed was the **surface**:

- `.rail-radio-now` draws a `background` + `border-top` on a border box
  spanning the rail edge to edge, so it reads as a full-bleed card.
- `.rail-actions` spans edge to edge too, but its background is
  `--bg-alt` — the *same* `--bg-alt` `.shell-members` itself carries
  (`#111` both) — so its box is **invisible**, and the only surface
  rendered there is its bordered button, inset by the padding.

Full-bleed card above, inset card below. So the cure is not equalising
two content insets; it is shrinking two **border boxes** to one figure.
Measured on the bench below: the drift is exactly `7px` = 0.5rem at
this app's 14px root.

## What changed

`--rail-inset: 0.5rem` + `padding-inline` on `.shell-members`, and the
rule for a new child is stated at that rule: **the inset is the gap
between the child's BORDER box and the rail edge.** A bordered card's
*internal* padding is a different axis and stays with the card — so
`.rail-server-info` keeps `padding: 0.5rem 0.75rem` (only its
horizontal *margin* moved) and `.rail-actions-menu` keeps its 0.5rem.

Four hand-written copies of one number removed: the band's padding, the
actions' padding, `.rail-server-info`'s horizontal margin (the same
inset spelled a third way), `.rail-radio-picker-list`'s padding.

**Two absolutes anchor to this aside, and an abspos box resolves
`inset` against the PADDING box** — so moving a container inset moves
them silently. Neither was left to chance:

- `.rail-radio-picker` **inherits** (it is one of the three children the
  ruling names). Visually a non-event: its background is the same
  `--bg-alt`, nothing lives in the strips it stops covering (nick text
  starts further in, `li` carries no background), and the same is
  *already* true on mobile today, where the drawer's safe-area padding
  makes that identical `inset: 0` resolve inside it.
- `.resize-handle-right` **cancels** it — not a content surface, it is
  chrome ON the boundary. Renders where it did.

### The border-top consequence, named as the issue asks

I accept the shorter rule as the card's own border. `.rail-actions`
carries the identical `border-top` and shortens with it, so the two
stay the same length as each other — which is the point. Moving the
separator onto something that still spans the rail would re-introduce
the single full-bleed line the report is about.

### One judgement call worth disputing — `.members-pane`

It opts OUT (`margin-inline: calc(-1 * var(--rail-inset))`), so the
nick list renders byte-identical. Its rows carry their own
`padding-inline: 1rem`, so inheriting would push every nick to 1.5rem —
moving a surface nobody reported — and it is the scroller (#500), so
inside the inset its scrollbar would float half a rem off the rail edge
it belongs on. The general rule that falls out: **the inset lines up
SURFACES, and a nick row has none** (transparent, no border, hover is
an underline).

This is the one place I read the ruling rather than followed it
literally: vjt's enumeration names the band, the launcher and the
picker, and the nick list is not among them. It is one declaration to
flip if he wants it inherited.

## Tap the band to restore a hidden player

The band's **identity half** is the control, not the row: the ⏹ is a
`<button>` and a `<button>` inside a `<button>` is invalid HTML. Two
sibling buttons make the issue's own constraint — *stop must not become
restore-then-stop* — true by **construction**, where a row handler plus
`stopPropagation` on the ⏹ would have made it an event-ordering rule
somebody has to keep right.

Deliberately **ungated**, unlike the `rail-action-show-player` drawer
entry that shares its verb: that one is a menu ROW, where a row that
does nothing is clutter; this costs no space, `showPlayer()` is
idempotent, and gating it would only make the band change DOM shape —
and with it the row's flex layout — on every hide. The drawer entry
stays: it is the general door, because an upload carries `label: null`,
is in no station table, and renders no band at all.

**Half that constraint is not observable, and the test says so instead
of pretending.** `closeAudio` resets `playerHidden` itself, so
"stopped" and "restored then stopped" are the *same* state. The
observable half (⏹ still stops) is asserted; the other half is pinned
structurally, as the two controls being siblings.

## Evidence

| gate | result |
|---|---|
| cic unit (`bun run test`) | **313 files / 6146 tests pass** |
| `bun run check` | **4/4 stages ok** (lock drift, biome, tsc src, tsc e2e) |
| `design-notes-gate.sh` | ok — 1 entry, separator + marker present |
| full `scripts/integration.sh` | **772 passed, 1 failed (29.7m)** |

**The e2e is 772/1, not "green", and the one red is #507.**
`cp15-b6-part-archive-rejoin.spec.ts:55` — the spec our register
already describes as green 3/3 in isolation and red under full load. It
did exactly what its issue says it does. It is discriminably not this
branch: the failure is `element(s) not found` on
`.members-pane li` — the row never entered the DOM, which no `margin`
declaration can cause. Every other spec that exercises the rail,
including the `@webkit` mobile-rail set, passed.

### Deliberate-fault bench

A green geometry assertion is worth nothing until it has been shown to
go red, so I ran the mutation rather than assuming. Reverting
`.rail-actions` to `padding: 0.5rem` — precisely the "fix it at the
element" one-liner the ruling refuses — turns the spec red:

```
Expected: < 0.5
Received:   7
```

`7px` is 0.5rem at a 14px root: the exact pre-fix drift. Mutant
reverted, tree clean.

### Why the geometry claim is e2e and not vitest

jsdom computes no layout — every `getBoundingClientRect()` there is
zero — so a unit assertion could only check that some declaration
exists, which is a mirror of the stylesheet and would have passed just
as happily on the defect.

The assertion is a **relation** (the band's edges against the
launcher's), never a pixel literal: a literal would re-encode the value
just made single-source and go red on a root-font-size change that
broke nothing. It additionally checks the pair is *inset* and not
merely equal — two full-bleed surfaces agree with each other too, and
that is the state being rejected.

Form factor, stated rather than implied: the new geometry spec runs on
desktop chromium. The rule lives on `.shell-members`, which both Shell
branches mount, and the mobile drawer adds only
`padding-top`/`padding-bottom` — separate longhands from the
`padding-inline` this proves, so neither can clobber the other.

## Commits

- `fix(#1737)` move the rail's horizontal inset onto the container
- `feat(#1737)` tap the now-playing band to restore a hidden player
- `test(#1737)` pin the rail inset in an engine that has edges
- `docs(#1737)` record what the measurement corrected, and the rule it left

— w1