### PR TITLE
#1751: padding does not move an abspos child — clear the notch with `top`

### DIFF
--- a/cicchetto/e2e/tests/issue1751-safe-area-token.spec.ts
+++ b/cicchetto/e2e/tests/issue1751-safe-area-token.spec.ts
@@ -1,0 +1,132 @@
+// #1751 — the safe-area top inset reaches the radio picker's band through its
+// ANCESTOR, exactly once, on both form factors.
+//
+// This is the measurement that settles what the issue got wrong. #1751 was
+// filed as "the picker rides under the notch, give it the settings-drawer top
+// inset". The picker is `position: absolute; inset: 0` inside `.shell-members`,
+// and an abspos box resolves `inset` against its ancestor's PADDING box (the
+// #1737 rule, stated at that aside) — so the aside's own inset already moves
+// it. Adding a second one to the picker is the #205 double-count, not a fix.
+// That argument was made from the stylesheet; this spec makes it a number.
+//
+// THE MEASUREMENT PROBLEM, and the same answer #913 found. Playwright
+// synthesizes `env(safe-area-inset-*)` on NO engine — they resolve to 0, and
+// the `webkit-iphone-15` project is `devices["iPhone 15"]`, a viewport and a
+// touch flag, not a notch. So no absolute claim about a 59px inset can be
+// honest here. What IS observable is the WIRING: measure the same band twice,
+// once at the Playwright value and once with the inset stubbed, and assert it
+// moved by exactly that much.
+//
+// EXACTLY is the whole point, and it is what makes this more than a #913
+// clone. `>= STUB` would pass on a build that insets the picker AS WELL as its
+// ancestor — the regression the issue asked for, which lands the band a full
+// inset too low with nothing red. `=== STUB` fails on both sides: 0 if the
+// inset never reaches the picker, 2× if it reaches it twice.
+//
+// The stub goes through `--safe-area-inset-top`, and that indirection is what
+// #1751 generalized: before it, `.shell` and `.shell-members` wrote `env()`
+// inline and this spec could not have been written at all — the delta would be
+// 0 on a correct build and on a broken one alike.
+//
+// BOTH CHAINS, because they are different. On mobile the picker's ancestor is
+// the fixed `.shell-members` drawer carrying its own inset; on desktop it is a
+// grid child of the inset `.shell`. `isMobile()` is a `matchMedia` width query
+// (lib/theme.ts), so a viewport resize crosses the same 768px breakpoint the
+// stylesheet does and both chains are reachable from one project. The felt
+// result on a notched device is still vjt's to confirm; this spec does not
+// claim it.
+
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// A plausible notch: iPhone 17 Pro reports ~59px. The exact number does not
+// matter — the assertion is a delta — only that it is non-zero and large
+// enough to dwarf sub-pixel layout noise. Same value as the #913 sibling.
+const STUB_INSET = 59;
+
+// Sub-pixel slack. `toBeCloseTo`'s second argument is a DIGIT COUNT rather than
+// a tolerance, which reads like a tolerance and is not one, so the comparison
+// is written out.
+const EPSILON = 0.5;
+
+const FORM_FACTORS = [
+  {
+    name: "desktop — the picker's ancestor is a grid child of the inset .shell",
+    width: 1280,
+    height: 800,
+  },
+  {
+    name: "mobile — the picker's ancestor is the fixed .shell-members drawer",
+    width: 390,
+    height: 844,
+  },
+] as const;
+
+test.setTimeout(90_000);
+
+for (const factor of FORM_FACTORS) {
+  test(`#1751 — the top inset reaches the radio picker's band exactly once (${factor.name})`, async ({
+    page,
+  }) => {
+    // Station logos are third-party <img> requests off the picker's rows. The
+    // #682 spec routes them for the same reason: a somafm outage must not be
+    // able to turn a layout assertion red.
+    await page.route("https://api.somafm.com/logos/**", async (route) => {
+      await route.fulfill({ status: 200, contentType: "image/png", body: Buffer.alloc(0) });
+    });
+
+    await loginAs(page, specUser());
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+    // Resized after the session is up, mirroring the #913 sibling: the login
+    // and channel-select fixtures are written against the default viewport.
+    await page.setViewportSize({ width: factor.width, height: factor.height });
+
+    await openRailMenu(page);
+    await page.getByTestId("rail-action-radio").click();
+    await expect(page.getByTestId("rail-radio-picker")).toBeVisible();
+
+    // The band, not the panel: "the `radio` header is hidden behind the status
+    // bar" is what was reported, so the band's own top edge is the thing whose
+    // clearance is in question. It is the panel's first child with no margin,
+    // so the two move together — measuring the band keeps the assertion on the
+    // reported surface.
+    const band = page.locator(".rail-radio-picker .topic-bar");
+    await expect(band).toBeVisible();
+
+    const boxBefore = await band.boundingBox();
+    expect(boxBefore, "the picker's band must have a layout box").not.toBeNull();
+
+    // `:root:root` (0,2,0) rather than `:root` (0,1,0) so the override wins on
+    // specificity without depending on where the bundler injected the sheet.
+    await page.addStyleTag({
+      content: `:root:root { --safe-area-inset-top: ${STUB_INSET}px; }`,
+    });
+
+    // Read straight back, as the #913 sibling does: the band is laid out by an
+    // ancestor's padding, so the reflow is synchronous with the style tag and
+    // `boundingBox()` forces layout anyway. Deliberately NOT polled for a
+    // change first — that would turn the delta-is-0 case (the inset never
+    // reaching the picker, i.e. the defect) into an unhelpful poll timeout
+    // instead of the message below, which names both failure directions.
+    const boxAfter = await band.boundingBox();
+    expect(boxAfter, "the picker's band must still have a layout box").not.toBeNull();
+
+    const moved = (boxAfter?.y ?? 0) - (boxBefore?.y ?? 0);
+    expect(
+      Math.abs(moved - STUB_INSET),
+      `band moved ${moved}px for a ${STUB_INSET}px inset — 0 means the inset never reaches the picker, ${2 * STUB_INSET} means it reaches it twice (the #205 double-count the issue asked for)`,
+    ).toBeLessThan(EPSILON);
+
+    // The other half of the same claim, stated positively: the picker itself
+    // must own no inset. A rule added there would show up as the 2× delta
+    // above, but this says WHERE to look when it does.
+    const pickerPadding = await page
+      .getByTestId("rail-radio-picker")
+      .evaluate((el) => getComputedStyle(el).paddingTop);
+    expect(pickerPadding, "the picker carries no top padding of its own").toBe("0px");
+  });
+}

--- a/cicchetto/e2e/tests/issue1751-safe-area-token.spec.ts
+++ b/cicchetto/e2e/tests/issue1751-safe-area-token.spec.ts
@@ -1,13 +1,19 @@
 // #1751 — the safe-area top inset reaches the radio picker's band through its
 // ANCESTOR, exactly once, on both form factors.
 //
-// This is the measurement that settles what the issue got wrong. #1751 was
-// filed as "the picker rides under the notch, give it the settings-drawer top
-// inset". The picker is `position: absolute; inset: 0` inside `.shell-members`,
-// and an abspos box resolves `inset` against its ancestor's PADDING box (the
-// #1737 rule, stated at that aside) — so the aside's own inset already moves
-// it. Adding a second one to the picker is the #205 double-count, not a fix.
-// That argument was made from the stylesheet; this spec makes it a number.
+// This spec is what caught the real defect, and it caught it by failing. The
+// first reading of #1751 was that the symptom could not exist — the picker is
+// `position: absolute; inset: 0` inside `.shell-members`, that aside insets
+// itself, so the picker must already be clear. This spec's MOBILE arm returned
+// a 0px delta and killed that argument: padding on a container is invisible to
+// its abspos descendants, because the containing rectangle is the padding EDGE
+// and INCLUDES the padding. The clearance now sits on the drawer's `top`, which
+// moves the border box and every child with it.
+//
+// The desktop arm passes by a DIFFERENT mechanism and always did: there the
+// aside is a grid item of the inset `.shell`, so its border box moves. Keeping
+// both arms is the point — one mechanism per form factor, and only one of them
+// was broken.
 //
 // THE MEASUREMENT PROBLEM, and the same answer #913 found. Playwright
 // synthesizes `env(safe-area-inset-*)` on NO engine — they resolve to 0, and

--- a/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
+++ b/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
@@ -111,7 +111,10 @@ test("@webkit UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do 
   // The longhands MAY be authored or expanded; tolerate either.
   const shellTop = shell?.paddingTop ?? "";
   const shellBottom = shell?.paddingBottom ?? "";
-  expect(shellTop).toContain("env(");
+  // #1751 — the inset arrives as `var(--safe-area-inset-top)` now; `env()`
+  // survives only on `:root`. The claim is unchanged: this container declares
+  // the top inset.
+  expect(shellTop).toContain("var(");
   expect(shellTop).toContain("safe-area-inset-top");
   // Zero, and declared: an empty string here means the longhand is gone
   // and base `.shell`'s inset cascades in. CSSOM may serialize the
@@ -131,12 +134,23 @@ test("@webkit UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do 
   const topicBar = await findRulePadding(page, ".topic-bar");
   expect(topicBar).not.toBeNull();
   const topicPadding = `${topicBar?.padding ?? ""} ${topicBar?.paddingTop ?? ""}`;
-  expect(topicPadding).not.toContain("env(");
+  // #1751 — STRENGTHENED, not merely re-spelled. `not.toContain("env(")` alone
+  // would now pass on `var(--safe-area-inset-top)`, i.e. on exactly the edit it
+  // exists to stop, because #1751 moved every consumer onto the token. This
+  // band is THE surface vjt's directive singled out: `env(safe-area-inset-top)`
+  // is a viewport constant and not position-aware, and `.topic-bar` also renders
+  // MID-COLUMN under the mobile header, where an inset would pad it away from a
+  // notch it never touches. Reject the inset by NAME, whichever vector carries
+  // it.
+  expect(topicPadding).not.toContain("safe-area-inset");
 
   // .bottom-bar MUST NOT carry the inset anymore (container handles
   // the home-indicator clearance via padding-bottom).
   const bottomBar = await findRulePadding(page, ".bottom-bar");
   expect(bottomBar).not.toBeNull();
   const bottomPadding = `${bottomBar?.padding ?? ""} ${bottomBar?.paddingBottom ?? ""}`;
-  expect(bottomPadding).not.toContain("env(");
+  // Same strengthening as the band above, same reason: the container owns the
+  // home-indicator clearance, and after #1751 an inset would arrive here spelled
+  // `var(--safe-area-inset-bottom)` and slip straight past an `env(`-only guard.
+  expect(bottomPadding).not.toContain("safe-area-inset");
 });

--- a/cicchetto/e2e/tests/ux-5-bd-bottom-safe-area-floor.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bd-bottom-safe-area-floor.spec.ts
@@ -98,7 +98,11 @@ test("@webkit ux-5-bd — .settings-drawer padding uses 1.5rem env() bottom floo
   // CSS-source shape: `max(1.5rem, env(safe-area-inset-bottom))` for
   // the bottom arm of the shorthand. The bottom arm is the 3rd value
   // in `padding: top horizontal bottom horizontal` (4-arm form).
-  expect(pad).toContain("max(1.5rem, env(safe-area-inset-bottom))");
+  // #1751 re-spelled the inset through the `:root` token — this file's own
+  // computed-value siblings below are what prove the floor still takes effect
+  // (they stayed green across that change; only these declared-spelling pins
+  // moved). The pinned half is the 1.5rem FLOOR, and it is untouched.
+  expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
 test("@webkit ux-5-bd — .settings-drawer computed padding-bottom >= 1.5rem floor (non-notched)", async ({
@@ -134,7 +138,11 @@ test("@webkit ux-5-bd — .archive-modal padding uses 1.5rem env() bottom floor"
 
   const pad = await readDeclaredCssValue(page, ".archive-modal", "padding");
   expect(pad).not.toBeNull();
-  expect(pad).toContain("max(1.5rem, env(safe-area-inset-bottom))");
+  // #1751 re-spelled the inset through the `:root` token — this file's own
+  // computed-value siblings below are what prove the floor still takes effect
+  // (they stayed green across that change; only these declared-spelling pins
+  // moved). The pinned half is the 1.5rem FLOOR, and it is untouched.
+  expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
 test("@webkit ux-5-bd — .archive-modal computed padding-bottom >= 1.5rem floor (non-notched)", async ({
@@ -174,7 +182,11 @@ test("@webkit ux-5-bd — .image-upload-modal padding uses 1.5rem env() bottom f
   expect(pad).not.toBeNull();
   // Pre-BD the modal had flat `padding: 1.5rem` (no env() arm at all
   // for bottom). Post-BD the bottom arm gets the safe-area treatment.
-  expect(pad).toContain("max(1.5rem, env(safe-area-inset-bottom))");
+  // #1751 re-spelled the inset through the `:root` token — this file's own
+  // computed-value siblings below are what prove the floor still takes effect
+  // (they stayed green across that change; only these declared-spelling pins
+  // moved). The pinned half is the 1.5rem FLOOR, and it is untouched.
+  expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
 test("@webkit ux-5-bd — .shell-members padding-bottom uses 1.5rem env() floor (BM launcher footer trap)", async ({
@@ -193,7 +205,11 @@ test("@webkit ux-5-bd — .shell-members padding-bottom uses 1.5rem env() floor 
   // chrome.
   const pad = await readDeclaredCssValue(page, ".shell-members", "padding-bottom");
   expect(pad).not.toBeNull();
-  expect(pad).toContain("max(1.5rem, env(safe-area-inset-bottom))");
+  // #1751 re-spelled the inset through the `:root` token — this file's own
+  // computed-value siblings below are what prove the floor still takes effect
+  // (they stayed green across that change; only these declared-spelling pins
+  // moved). The pinned half is the 1.5rem FLOOR, and it is untouched.
+  expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
 test("@webkit ux-5-bd — .shell-members computed padding-bottom >= 1.5rem floor (non-notched)", async ({

--- a/cicchetto/src/__tests__/contextMenuSafeArea.test.ts
+++ b/cicchetto/src/__tests__/contextMenuSafeArea.test.ts
@@ -55,9 +55,21 @@ describe("#949 context menu safe-area clamp", () => {
     // bottom and the two sides are not decoration — the bottom is the home
     // indicator, and in landscape the sides are the notch and the rounded
     // corners, which is the other half of `d129bfb0`'s "both edges".
+    //
+    // #1751 moved the spelling from an inline `env(…, 0px)` per edge to the
+    // `:root` tokens, which carry the same fallback. Both halves of the claim
+    // are still asserted, and the second half deliberately still reads :root
+    // here: the fallback is what keeps ONE unknown edge from invalidating the
+    // whole `inset` shorthand and collapsing the ruler to a zero-sized rect,
+    // so a test about this rule has to see it even though it is declared
+    // elsewhere now.
     const body = ruleBody(".context-menu-safe-area");
+    const root = ruleBody(":root");
     for (const edge of ["top", "right", "bottom", "left"]) {
-      expect(body).toMatch(new RegExp(`env\\(safe-area-inset-${edge},\\s*0px\\)`));
+      expect(body).toMatch(new RegExp(`var\\(--safe-area-inset-${edge}[,)]`));
+      expect(root).toMatch(
+        new RegExp(`--safe-area-inset-${edge}:\\s*env\\(safe-area-inset-${edge},\\s*0px\\)`),
+      );
     }
   });
 
@@ -71,7 +83,14 @@ describe("#949 context menu safe-area clamp", () => {
   it("the ruler is declared once, so the measured box is the one written here", () => {
     // The rect is read from live layout, so ANY second rule reaching this class
     // silently redefines what the placement math measures.
-    expect(themeCss.match(/\.context-menu-safe-area/g)?.length).toBe(1);
+    //
+    // Comments stripped first, which is this module's convention everywhere
+    // else ("prose that mentions a property cannot satisfy or trip a
+    // declaration assertion", helpers/themeCss.ts) and was the one place that
+    // missed it: #1751 named this class in the `:root` note explaining what
+    // the fallback protects, and a guard about RULES went red over a sentence.
+    const declarations = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(declarations.match(/\.context-menu-safe-area/g)?.length).toBe(1);
   });
 
   it(".context-menu caps its height against the viewport MINUS both vertical insets", () => {

--- a/cicchetto/src/__tests__/ipadSafeArea.test.ts
+++ b/cicchetto/src/__tests__/ipadSafeArea.test.ts
@@ -48,11 +48,15 @@ describe("#205 iPad standalone-PWA safe area", () => {
     // top chrome (settings cog) clears the status bar and stays tappable.
     // Left/right matter in landscape where the home-indicator + camera
     // housing eat the side gutters.
+    //
+    // #1751 moved the spelling to the `:root` tokens (one `env()` per edge,
+    // there and nowhere else). The claim is unchanged — this container carries
+    // all four insets — only the vector is the token now.
     const body = ruleBody(".shell");
-    expect(body).toMatch(/padding-top:\s*env\(safe-area-inset-top\)/);
-    expect(body).toMatch(/padding-bottom:\s*env\(safe-area-inset-bottom\)/);
-    expect(body).toMatch(/padding-left:\s*env\(safe-area-inset-left\)/);
-    expect(body).toMatch(/padding-right:\s*env\(safe-area-inset-right\)/);
+    expect(body).toMatch(/padding-top:\s*var\(--safe-area-inset-top\)/);
+    expect(body).toMatch(/padding-bottom:\s*var\(--safe-area-inset-bottom\)/);
+    expect(body).toMatch(/padding-left:\s*var\(--safe-area-inset-left\)/);
+    expect(body).toMatch(/padding-right:\s*var\(--safe-area-inset-right\)/);
   });
 
   it("desktop .shell height is dynamic-viewport, not a bare clipping 100vh", () => {
@@ -73,8 +77,16 @@ describe("#205 iPad standalone-PWA safe area", () => {
     // double-inset regression — guard against it. `ruleBody` anchors to
     // column 0, so it captures the BASE rule, not the indented mobile
     // override.
+    //
+    // Both spellings, since #1751: an `env()` here and a `var(--safe-area-…)`
+    // here are the same double-count, and pinning only the older one would
+    // leave this guard passing over exactly the edit it exists to stop. This
+    // is also the rule that keeps `.rail-radio-picker` correct — the picker is
+    // abspos `inset: 0` against this aside, so an inset landing here reaches
+    // it too (#1751 declined to put one on the picker for the mirror reason).
     const body = ruleBody(".shell-members");
     expect(body).not.toMatch(/env\(safe-area-inset-/);
+    expect(body).not.toMatch(/var\(--safe-area-inset-/);
   });
 
   it("mobile .shell-members (the fixed drawer) keeps its own safe-area insets", () => {
@@ -85,10 +97,10 @@ describe("#205 iPad standalone-PWA safe area", () => {
     // substring, not `ruleBody`'s column-0 anchor). Both top and the
     // 1.5rem-floored bottom must survive the move.
     expect(css).toMatch(
-      /@media[^{]*\(max-width: 768px\)[\s\S]*\.shell-members\s*\{[\s\S]*?padding-top:\s*env\(safe-area-inset-top\)/,
+      /@media[^{]*\(max-width: 768px\)[\s\S]*\.shell-members\s*\{[\s\S]*?padding-top:\s*var\(--safe-area-inset-top\)/,
     );
     expect(css).toMatch(
-      /\.shell-members\s*\{[\s\S]*?padding-bottom:\s*max\(1\.5rem,\s*env\(safe-area-inset-bottom\)\)/,
+      /\.shell-members\s*\{[\s\S]*?padding-bottom:\s*max\(1\.5rem,\s*var\(--safe-area-inset-bottom\)\)/,
     );
   });
 });
@@ -122,8 +134,8 @@ describe("#1127 mobile shell bottom edge", () => {
     // chrome tappable (UX-3 BIS); the sides matter in the sub-768 landscape
     // edge on small notched devices.
     const body = nestedRuleBodies(".shell-mobile").join("\n");
-    expect(body).toMatch(/padding-top:\s*env\(safe-area-inset-top\)/);
-    expect(body).toMatch(/padding-left:\s*env\(safe-area-inset-left\)/);
-    expect(body).toMatch(/padding-right:\s*env\(safe-area-inset-right\)/);
+    expect(body).toMatch(/padding-top:\s*var\(--safe-area-inset-top\)/);
+    expect(body).toMatch(/padding-left:\s*var\(--safe-area-inset-left\)/);
+    expect(body).toMatch(/padding-right:\s*var\(--safe-area-inset-right\)/);
   });
 });

--- a/cicchetto/src/__tests__/ipadSafeArea.test.ts
+++ b/cicchetto/src/__tests__/ipadSafeArea.test.ts
@@ -96,8 +96,13 @@ describe("#205 iPad standalone-PWA safe area", () => {
     // in the `@media (max-width: 768px)` override (indented, so matched by
     // substring, not `ruleBody`'s column-0 anchor). Both top and the
     // 1.5rem-floored bottom must survive the move.
+    // #1751 — the TOP arm moved from `padding-top` to `top` (+ a compensating
+    // `height`). Not cosmetic: padding does not move a container's abspos
+    // descendants, so the padded form left `.rail-radio-picker` under the
+    // notch. The claim here is unchanged — the fixed drawer owns its own top
+    // clearance — only the property carrying it moved.
     expect(css).toMatch(
-      /@media[^{]*\(max-width: 768px\)[\s\S]*\.shell-members\s*\{[\s\S]*?padding-top:\s*var\(--safe-area-inset-top\)/,
+      /@media[^{]*\(max-width: 768px\)[\s\S]*\.shell-members\s*\{[\s\S]*?top:\s*var\(--safe-area-inset-top\)/,
     );
     expect(css).toMatch(
       /\.shell-members\s*\{[\s\S]*?padding-bottom:\s*max\(1\.5rem,\s*var\(--safe-area-inset-bottom\)\)/,

--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -468,9 +468,14 @@ const BACKDROP_VIEWPORT_REST = {
   "align-items": "center",
   "justify-content": "center",
   "z-index": "1000",
-  "padding-top": "max(1rem, env(safe-area-inset-top))",
+  // #1751 re-spelled the two insets through the `:root` tokens — the ONE place
+  // this stylesheet writes `env()` now. `max(1rem, env(x))` and
+  // `max(1rem, var(--x))` compute the same length, so the transcription moves
+  // without the promise it encodes ("changes no pixel") moving with it. The
+  // floors are the pinned half and they are untouched.
+  "padding-top": "max(1rem, var(--safe-area-inset-top))",
   "padding-right": "1rem",
-  "padding-bottom": "max(1.5rem, env(safe-area-inset-bottom))",
+  "padding-bottom": "max(1.5rem, var(--safe-area-inset-bottom))",
   "padding-left": "1rem",
 };
 

--- a/cicchetto/src/__tests__/railMenuSafeArea.test.ts
+++ b/cicchetto/src/__tests__/railMenuSafeArea.test.ts
@@ -17,10 +17,15 @@ import { ruleBody, themeCss } from "./helpers/themeCss";
 // an unregistered custom property with `getComputedStyle().getPropertyValue()`
 // is not guaranteed to yield a length — it can hand back the literal token
 // stream, which `parseFloat` turns into NaN and a `|| 0` fallback silently
-// swallows, leaving the bug in place while looking fixed. Every other inset in
-// this stylesheet is a plain CSS `env()` for the same reason; this one joins
-// them. JS supplies only what CSS cannot know — the anchor's viewport offset,
-// as `--rail-menu-space-above` (see RailActions.test.tsx for that half).
+// swallows, leaving the bug in place while looking fixed. JS supplies only what
+// CSS cannot know — the anchor's viewport offset, as `--rail-menu-space-above`
+// (see RailActions.test.tsx for that half).
+//
+// This paragraph used to end "every other inset in this stylesheet is a plain
+// CSS `env()` for the same reason; this one joins them." #1751 inverted that:
+// the token this cap needed turned out to be what makes ANY inset observable
+// in a gate, so all of them read it now and `env()` survives only on `:root`.
+// See safeAreaInsetToken.test.ts, which owns that invariant.
 //
 // SOURCE-LEVEL guards. Playwright does not synthesize `env(safe-area-inset-*)`
 // (they resolve to 0), and jsdom resolves neither `env()` nor `calc()`, so the

--- a/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
+++ b/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #1751 — ONE mechanism for the safe-area insets, instead of one copy per
+// surface.
+//
+// The reported symptom was the radio station picker riding under the notch.
+// The picker is NOT the defect (it is abspos `inset: 0` inside `.shell-members`
+// and so resolves against an ancestor that already insets itself — giving it
+// its own inset would DOUBLE-COUNT, the #205 regression the `.shell-members`
+// base rule records). The defect the symptom points at is that
+// `env(safe-area-inset-*)` was hand-written at 23 declarations across 16 rules,
+// with four different floors, and a new top-reaching surface joins that set by
+// remembering to.
+//
+// THE INVARIANT, and it is mechanical on purpose: `env(safe-area-inset-*)`
+// appears EXACTLY ONCE PER EDGE, at `:root`, and every consumer reads the
+// token. That is checkable by reading the sheet, needs no list of which
+// surfaces reach the physical top (a semantic judgement that would rot), and
+// has no exclusion list. The next copy is red in CI the day it is written.
+//
+// WHY A TOKEN AND NOT INLINE `env()` — this reverses the note that used to sit
+// on `:root` saying inline "is right for a padding: the engine substitutes it
+// and nobody has to read it back". True of the ENGINE, false of every gate we
+// run. Playwright synthesizes no safe-area inset on any engine (they resolve to
+// 0 — measured in e2e/tests/issue913-rail-menu-safe-area.spec.ts) and jsdom
+// resolves no `env()` at all, so an inline site is not observable ANYWHERE. A
+// site reading the token is stubbable (`:root:root { --safe-area-inset-top:
+// 59px }`), which is exactly how the #913 spec proves its own wiring. #913
+// introduced the token for that reason on the one site it touched; this
+// finishes the move rather than reversing it.
+//
+// SOURCE-LEVEL, like every safe-area guard in this suite. It proves what the
+// cascade is asked to do, never what a device paints — the felt behaviour on a
+// notched phone stays vjt's to confirm.
+
+const EDGES = ["top", "right", "bottom", "left"] as const;
+
+/**
+ * Every declaration in the sheet that mentions a safe-area inset, as
+ * `"<selector> | <declaration>"`, sorted.
+ *
+ * The `[^{}]` classes cannot span a brace, so this matches INNERMOST rules at
+ * any depth and an `@media` prelude is never captured as a selector — a rule
+ * inside one comes back under its own selector, which is what the mobile
+ * overrides need. Comments are stripped, so prose naming `env()` can neither
+ * satisfy nor trip an assertion.
+ */
+function insetCensus(): string[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rows: string[] = [];
+  for (const rule of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const selector = (rule[1] ?? "").trim().replace(/\s+/g, " ");
+    for (const declaration of (rule[2] ?? "")
+      .split(";")
+      .map((text) => text.trim())
+      .filter(Boolean)) {
+      if (!declaration.includes("safe-area-inset")) continue;
+      rows.push(`${selector} | ${declaration.replace(/\s+/g, " ")}`);
+    }
+  }
+  return rows.sort();
+}
+
+describe("#1751 — the safe-area inset has one source and one edit point", () => {
+  it.each(EDGES)(":root exposes the %s inset as a token with a 0px fallback", (edge) => {
+    // The `0px` fallback is load-bearing, not defensive, and now serves every
+    // consumer instead of the two that spelled it out: an engine that does not
+    // know the variable makes a bare `env()` declaration invalid as a whole,
+    // which drops the whole property. On `.context-menu-safe-area`'s `inset`
+    // shorthand that collapsed the ruler to a zero-sized rect (#949); on
+    // `.rail-actions-menu`'s cap it brought the #588 overflow back.
+    expect(ruleBody(":root")).toMatch(
+      new RegExp(`--safe-area-inset-${edge}:\\s*env\\(safe-area-inset-${edge},\\s*0px\\)`),
+    );
+  });
+
+  it("writes env(safe-area-inset-*) nowhere but those four declarations", () => {
+    // THE mechanism assertion. Everything else in this file is a transcription;
+    // this is the rule. A seventh copy of `max(x, env(safe-area-inset-top))` on
+    // a new pane fails here by existing, with no census of top-reaching
+    // surfaces to keep current and nothing to add to an allowlist.
+    const offenders = insetCensus().filter(
+      (row) => !row.startsWith(":root |") && /env\(safe-area-inset-/.test(row),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("moves no pixel: every consumer keeps the floor it already had", () => {
+    // The census, transcribed from the stylesheet at 713736f9 (origin/main,
+    // pre-extraction) and rewritten through the token BY HAND, one declaration
+    // at a time. `max(<floor>, env(x))` and `max(<floor>, var(--x))` compute
+    // the same length, so this pin is what makes "an extraction changes no
+    // pixel" (#407) a measured claim here rather than an assurance.
+    //
+    // The four floors are NOT noise and are deliberately not unified: 1rem on
+    // the drawer + viewport scrim, 0.75rem on the three modals and the A2HS
+    // hint, 0.5rem on the diag float, and none at all on the shell containers
+    // and the fixed drawers. Each has its own comment and its own incident
+    // behind it; one shared floor would re-space five surfaces nobody reported.
+    //
+    // A floorless site reads the token bare rather than `max(0px, var(--x))`:
+    // same value, and the difference between "this surface has a floor" and
+    // "it does not" stays legible in the sheet.
+    expect(insetCensus()).toEqual(CENSUS);
+  });
+
+  it("leaves the picker OUT — its ancestor already insets it", () => {
+    // The issue asked for `max(<x>, env(safe-area-inset-top))` on
+    // `.rail-radio-picker`. That would be the seventh copy AND a regression:
+    // the picker is `position: absolute; inset: 0` and an abspos box resolves
+    // `inset` against its ancestor's PADDING box (the #1737 rule, stated at
+    // `.shell-members`). `.shell-members` carries the inset on both form
+    // factors — as the mobile fixed drawer directly, and on desktop as a grid
+    // child of the inset `.shell` — so the picker already starts below the
+    // safe area. A second inset here is the #205 double-count.
+    expect(ruleBody(".rail-radio-picker")).not.toMatch(/safe-area-inset/);
+  });
+});
+
+// Transcribed census. A new safe-area consumer is a new row here, which is the
+// point: adding one is a deliberate edit to a list somebody reads, not a line
+// copied from whichever rule was nearest.
+const CENSUS = [
+  ".archive-modal | padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom))",
+  // Already on the token before #1751 — #913 and #949 put it there, and the
+  // redundant `, 0px)` inside the `var()` is left exactly as they wrote it.
+  // The token cannot be undeclared, so it is inert; rewriting two dense
+  // load-bearing comments to remove an inert fallback is not this change.
+  ".context-menu | max-height: max( 0px, calc( var(--viewport-height, 100vh) - var(--safe-area-inset-top, 0px) - var(--safe-area-inset-bottom, 0px) ) )",
+  ".context-menu-safe-area | inset: var(--safe-area-inset-top) var(--safe-area-inset-right) var(--safe-area-inset-bottom) var(--safe-area-inset-left)",
+  ".delete-account-modal | padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom))",
+  ".diag-float | top: max(0.5rem, var(--safe-area-inset-top))",
+  ".error-banners | padding-top: var(--safe-area-inset-top)",
+  ".image-upload-modal | padding: 1.5rem 1.5rem max(1.5rem, var(--safe-area-inset-bottom))",
+  ".install-a2hs | bottom: max(0.75rem, var(--safe-area-inset-bottom))",
+  ".install-a2hs | right: max(0.75rem, var(--safe-area-inset-right))",
+  ".modal-backdrop-viewport | padding: max(1rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom)) 1rem",
+  ".next-active-btn-mobile | right: calc(0.5rem + var(--safe-area-inset-right))",
+  ".rail-actions-menu | max-height: max( 0px, calc( var(--rail-menu-space-above, var(--viewport-height, 80vh)) - var(--safe-area-inset-top, 0px) ) )",
+  ".settings-drawer | padding: max(1rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom)) 1rem",
+  ".shell | padding-bottom: var(--safe-area-inset-bottom)",
+  ".shell | padding-left: var(--safe-area-inset-left)",
+  ".shell | padding-right: var(--safe-area-inset-right)",
+  ".shell | padding-top: var(--safe-area-inset-top)",
+  ".shell-members | padding-bottom: max(1.5rem, var(--safe-area-inset-bottom))",
+  ".shell-members | padding-top: var(--safe-area-inset-top)",
+  ".shell-mobile .shell-sidebar | padding-bottom: max(1.5rem, var(--safe-area-inset-bottom))",
+  ".shell-mobile .shell-sidebar | padding-top: var(--safe-area-inset-top)",
+  ".shell-mobile | padding-left: var(--safe-area-inset-left)",
+  ".shell-mobile | padding-right: var(--safe-area-inset-right)",
+  ".shell-mobile | padding-top: var(--safe-area-inset-top)",
+  ".theme-editor-modal | padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom))",
+  ":root | --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px)",
+  ":root | --safe-area-inset-left: env(safe-area-inset-left, 0px)",
+  ":root | --safe-area-inset-right: env(safe-area-inset-right, 0px)",
+  ":root | --safe-area-inset-top: env(safe-area-inset-top, 0px)",
+];

--- a/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
+++ b/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
@@ -105,15 +105,15 @@ describe("#1751 — the safe-area inset has one source and one edit point", () =
     expect(insetCensus()).toEqual(CENSUS);
   });
 
-  it("leaves the picker OUT — its ancestor already insets it", () => {
-    // The issue asked for `max(<x>, env(safe-area-inset-top))` on
-    // `.rail-radio-picker`. That would be the seventh copy AND a regression:
-    // the picker is `position: absolute; inset: 0` and an abspos box resolves
-    // `inset` against its ancestor's PADDING box (the #1737 rule, stated at
-    // `.shell-members`). `.shell-members` carries the inset on both form
-    // factors — as the mobile fixed drawer directly, and on desktop as a grid
-    // child of the inset `.shell` — so the picker already starts below the
-    // safe area. A second inset here is the #205 double-count.
+  it("leaves the picker OUT — the clearance belongs to its container", () => {
+    // The issue asked for `max(<x>, env(safe-area-inset-top))` here. The
+    // symptom was real (the band DID paint under the notch on the phone) but
+    // the fix is not: on desktop the picker's ancestor is a grid child of the
+    // inset `.shell`, so its BORDER BOX has already moved and an inset here
+    // would double-count. The phone case is fixed where it belongs — the
+    // mobile drawer carries its clearance on `top` instead of `padding-top`,
+    // because padding is invisible to an abspos child. Measured; see the note
+    // at that rule, and issue1751-safe-area-token.spec.ts for the numbers.
     expect(ruleBody(".rail-radio-picker")).not.toMatch(/safe-area-inset/);
   });
 });

--- a/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
+++ b/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
@@ -143,10 +143,19 @@ const CENSUS = [
   ".shell | padding-left: var(--safe-area-inset-left)",
   ".shell | padding-right: var(--safe-area-inset-right)",
   ".shell | padding-top: var(--safe-area-inset-top)",
+  // 🔴 The two fixed drawers carry the TOP clearance on `top` + a compensating
+  // `height`, NOT on `padding-top`, and that is not a spelling choice — it is
+  // #1751's actual defect. Padding is invisible to a container's absolutely
+  // positioned descendants, so a padded top-pinned drawer leaves `.rail-radio-
+  // picker` (`inset: 0`) under the notch. Measured; see the note at the mobile
+  // `.shell-members` rule. A future edit that "tidies" these back into a
+  // `padding-top` re-opens the bug silently on the phone, and lands here first.
+  ".shell-members | height: calc(var(--viewport-height, 100dvh) - var(--safe-area-inset-top))",
   ".shell-members | padding-bottom: max(1.5rem, var(--safe-area-inset-bottom))",
-  ".shell-members | padding-top: var(--safe-area-inset-top)",
+  ".shell-members | top: var(--safe-area-inset-top)",
+  ".shell-mobile .shell-sidebar | height: calc(var(--viewport-height, 100dvh) - var(--safe-area-inset-top))",
   ".shell-mobile .shell-sidebar | padding-bottom: max(1.5rem, var(--safe-area-inset-bottom))",
-  ".shell-mobile .shell-sidebar | padding-top: var(--safe-area-inset-top)",
+  ".shell-mobile .shell-sidebar | top: var(--safe-area-inset-top)",
   ".shell-mobile | padding-left: var(--safe-area-inset-left)",
   ".shell-mobile | padding-right: var(--safe-area-inset-right)",
   ".shell-mobile | padding-top: var(--safe-area-inset-top)",

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1542,16 +1542,35 @@ html.overlay-open #root > div {
      `.rail-actions-menu` its 0.5rem); only the gap to the rail edge moved
      here.
 
-     THE TWO ABSOLUTES ANCHORED TO THIS ASIDE MOVE WITH IT, because an abspos
-     box resolves `inset` against its ancestor's PADDING box, not its border
-     box. `.rail-radio-picker` (`inset: 0`) inherits deliberately — it is one
-     of the three children the ruling names, and it is visually a non-event:
-     the panel's background is this same `--bg-alt`, and nothing lives in the
-     strips it stops covering (nick text starts further in, `li` carries no
-     background). The same is already true on mobile today, where this aside's
-     safe-area padding makes that `inset: 0` resolve inside it.
-     `.resize-handle-right` does NOT inherit and is compensated at its own
-     rule: it is not a content surface, it is chrome ON the edge. */
+     🔴 THE TWO ABSOLUTES ANCHORED TO THIS ASIDE DO **NOT** MOVE WITH IT, and
+     #1737 said the opposite here. Corrected by #1751, measured rather than
+     reasoned. An abspos box resolves its offsets against this box's PADDING
+     EDGE — the OUTER edge of the padding, just inside the border — so the
+     containing rectangle INCLUDES the padding and `inset: 0` lands ON that
+     edge, above and outside the padding. Padding on a container is invisible
+     to its absolutely positioned descendants.
+
+     Measured at 390px with the inset token stubbed at 59px: this aside's
+     `padding-top` read 59px while `.rail-radio-picker` (`inset: 0`) stayed at
+     y=0. Horizontally, same physics: the aside's border box spans x 138–390
+     with a 1px border and 7px of padding, so its padding BOX is 146–383, and
+     the picker measured 139–390 — the padding edge, full-bleed inside the
+     border, NOT inset by `--rail-inset`.
+
+     So the horizontal half of #1737's ruling never took effect on this child.
+     It stayed visually a non-event for the reason #1737 gave — the panel's
+     background is this same `--bg-alt` and nothing lives in the strips — which
+     is why nobody saw it. The VERTICAL half was the bug in #1751: the picker's
+     band painted under the notch on the phone. Fixed at the mobile rule, by
+     moving the clearance onto `top` where it moves this box and every child
+     with it; see the long note there.
+
+     THE RULE FOR A NEW ABSPOS CHILD OF THIS ASIDE: it is NOT inset by
+     `--rail-inset` and it does NOT clear the safe area on its own. Give it its
+     own offsets deliberately, or make the ancestor's BOX carry what it needs.
+     `.resize-handle-right` was already compensated at its own rule — for a
+     stated different reason (it is chrome ON the edge, not a content surface),
+     but it is the only one of the three that was ever actually correct. */
   --rail-inset: 0.5rem;
   padding-inline: var(--rail-inset);
 }
@@ -7939,20 +7958,31 @@ html.resize-dragging * {
      flex column; only the fixed-drawer geometry is bespoke. */
   .shell-mobile .shell-sidebar {
     position: fixed;
-    top: 0;
+    /* #1751 — clearance on `top`, not `padding-top`, for the reason spelled out
+       at `.shell-members` below: padding does not move a container's absolutely
+       positioned descendants, so a top-pinned fixed drawer that clears the
+       notch with padding leaves any abspos child under it.
+
+       This drawer has NO such child today, so the change moves nothing and
+       fixes nothing here — it is made anyway because the comment above says
+       this rule is the MIRROR of `.shell-members`, and two drawers answering
+       the same geometry problem two different ways is how the next one gets
+       copied from whichever was nearer. That is the mechanism that put four
+       hand-written copies of the rail inset in this file (#1737). */
+    top: var(--safe-area-inset-top);
     left: 0;
     /* UX-5 bucket BV — iOS lies about 100vh (and dvh/svh) while the on-screen
        keyboard is up; `--viewport-height` tracks `visualViewport.height` via
        lib/viewportHeight.ts and shrinks in lockstep. Same fallback chain as
        `.shell-members`: `100dvh` for the boot window before the JS sets the var
-       and for browsers without VisualViewport. */
-    height: var(--viewport-height, 100dvh);
+       and for browsers without VisualViewport. Less the top inset, which `top`
+       now carries (#1751) — else the drawer overruns the bottom edge. */
+    height: calc(var(--viewport-height, 100dvh) - var(--safe-area-inset-top));
     /* #205 — `position: fixed` puts this OUTSIDE `.shell`'s padding box, so it
        owns its notch / Dynamic-Island and home-indicator clearance. The 1.5rem
        bottom floor mirrors UX-5 BD on the members drawer: env() is 0px on
        non-notched iPhones, which left the last row cramped under the Safari
-       chrome / gesture indicator. */
-    padding-top: var(--safe-area-inset-top);
+       chrome / gesture indicator. #1751 moved the TOP arm to `top`. */
     padding-bottom: max(1.5rem, var(--safe-area-inset-bottom));
     width: 80vw;
     max-width: 18rem;
@@ -7983,7 +8013,37 @@ html.resize-dragging * {
   /* Members drawer slide-in from right (unchanged from pre-C6) */
   .shell-members {
     position: fixed;
-    top: 0;
+    /* 🔴 #1751 — THE CLEARANCE IS ON `top`, NOT ON `padding-top`, AND THAT IS
+       THE WHOLE BUG THIS ISSUE WAS FILED FOR. An absolutely positioned child
+       resolves its offsets against this box's PADDING EDGE — the outer edge of
+       the padding, just inside the border — so the rectangle INCLUDES the
+       padding and `top: 0` on such a child lands ABOVE it. Padding on a
+       container does NOT move its abspos descendants. Measured on a 390px
+       viewport with the token stubbed at 59px: this rule's `padding-top` went
+       0px → 59px while `.rail-radio-picker` (`position: absolute; inset: 0`)
+       stayed at y=0 — under the notch, which is exactly the screenshot.
+
+       Moving the clearance onto `top` moves the BORDER BOX, which every child
+       follows, in flow or not. It is pixel-identical for the flow children:
+       they used to start at the inset because the padding pushed them, and now
+       start there because the box does. `height` has to lose the same amount
+       or the drawer overruns the bottom edge it used to reach exactly.
+
+       WHY THE DESKTOP NEVER SHOWED IT: there this aside is a grid ITEM of
+       `.shell`, so `.shell`'s padding moves this box and the picker follows the
+       box. Same inset, different mechanism — which is why the defect is
+       phone-only and why a source-level guard could never have caught it.
+
+       Corroboration, not theory: `.rail-actions-menu` is the rail's other
+       abspos child and #913 had to subtract the inset by hand from its
+       `max-height`. It hit this same physics from the other end and worked
+       around it locally. This rule is the general form of that workaround.
+
+       THE RULE FOR A NEW TOP-PINNED FIXED CONTAINER: put the safe-area
+       clearance on `top` and compensate `height`. Reach for `padding-top` only
+       once you are sure nothing inside is absolutely positioned — and that is
+       a promise about the future, which is why it is not the default here. */
+    top: var(--safe-area-inset-top);
     /* UX-5 bucket BV (2026-05-20) — VisualViewport keyboard-react.
        Pre-BV: `height: 100vh`. On iOS Safari the on-screen keyboard
        overlays the viewport without resizing CSS units (100vh/100dvh/
@@ -7997,7 +8057,11 @@ html.resize-dragging * {
        `100dvh` for the brief boot window before the JS sets the var
        OR browsers without VisualViewport. Mirrors `.shell-mobile`
        (~:2120). */
-    height: var(--viewport-height, 100dvh);
+    /* #1751 — MINUS the top inset, because `top` now carries it
+       (see above). Without this subtraction the drawer starts one inset lower
+       and still asks for a full viewport of height, so it overruns the bottom
+       edge it used to reach exactly. Content area is unchanged either way. */
+    height: calc(var(--viewport-height, 100dvh) - var(--safe-area-inset-top));
     /* #205 — safe-area insets relocated here from the base `.shell-members`
        rule (~:439). The mobile members drawer is `position: fixed` so it
        sits OUTSIDE `.shell`'s container padding box and needs its own
@@ -8007,8 +8071,9 @@ html.resize-dragging * {
        the bottom `.rail-actions` launcher row (#473; was BM's
        `.mobile-panel-actions` footer) hosts buttons that relied on
        env(safe-area-inset-bottom) alone — 0px on non-notched iPhones —
-       leaving the row cramped under Safari chrome / the gesture indicator. */
-    padding-top: var(--safe-area-inset-top);
+       leaving the row cramped under Safari chrome / the gesture indicator.
+       #1751 moved the TOP arm to `top`; the bottom arm stays a padding
+       because nothing is abspos-anchored to this box's bottom edge. */
     padding-bottom: max(1.5rem, var(--safe-area-inset-bottom));
     width: 80vw;
     max-width: 18rem;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -232,25 +232,50 @@
      option runs under the caret. Theme-independent, so base :root. */
   --select-caret-inset: 0.6rem;
   --select-caret-room: 1.75rem;
-  /* #913 — the iOS top safe-area inset, as a variable. Everything else in this
-     file writes `env(safe-area-inset-top)` inline, which is right for a
-     padding: the engine substitutes it and nobody has to read it back. The
-     rail actions menu is the one cap whose OTHER operand is measured in JS
-     (`--rail-menu-space-above`), and JS cannot reliably obtain the inset: an
-     unregistered custom property hands `getComputedStyle().getPropertyValue()`
-     its token stream, not a length, so `parseFloat` yields NaN and a `|| 0`
-     fallback hides it. Keeping the arithmetic in CSS keeps `env()` where the
-     engine resolves it. The `0px` fallback is load-bearing: without it an
-     engine that does not know the variable invalidates the whole declaration
-     and the cap disappears (the #588 overflow, back). Theme-independent, so it
-     lives on base :root. */
+  /* #913 / #949 / #1751 — THE FOUR SAFE-AREA INSETS, AND THE ONLY PLACE THIS
+     FILE WRITES `env()`.
+
+     THE RULE: `env(safe-area-inset-*)` appears exactly once per edge, here,
+     and every consumer reads the token. A surface that needs a MINIMUM of its
+     own writes `max(<its floor>, var(--safe-area-inset-top))`; one that wants
+     the bare inset writes the token alone. Do not inline `env()` at a call
+     site — `safeAreaInsetToken.test.ts` fails on it, by census, with no
+     allowlist to add yourself to.
+
+     WHY A TOKEN, reversing what this comment said until #1751 ("inline is
+     right for a padding: the engine substitutes it and nobody has to read it
+     back"). That is true of the ENGINE and false of every gate we run.
+     Playwright synthesizes no safe-area inset on any engine — they resolve to
+     0, measured in issue913-rail-menu-safe-area.spec.ts — and jsdom resolves
+     no `env()` at all. So an inline site's inset is not observable in ANY
+     test we can write, while a site reading the token is stubbable — a spec
+     re-declares `--safe-area-inset-top` on a `:root:root` override at a
+     non-zero length and every consumer moves at once, which is how that same
+     #913 spec proves its own wiring. #913 introduced the indirection for one
+     site; #1751 finished it for all of them. The other half of #913's reason
+     still holds and is why the arithmetic stays in CSS rather than moving to
+     JS: reading an unregistered custom property back with
+     `getComputedStyle().getPropertyValue()` hands you its token stream, not a
+     length, so `parseFloat` yields NaN and a `|| 0` fallback hides it. JS
+     supplies only what CSS cannot know (`--rail-menu-space-above`).
+
+     THE `0px` FALLBACKS ARE LOAD-BEARING, not defensive, and now cover every
+     consumer instead of the two that used to spell them out. Without one, an
+     engine that does not know the inset invalidates the WHOLE declaration:
+     `.context-menu-safe-area`'s `inset` shorthand collapses to a zero-sized
+     rect and pins every menu to the corner (#949), and `.rail-actions-menu`'s
+     cap disappears (the #588 overflow, back).
+
+     NB, keep CURLY BRACES out of the prose in this whole block: the `ruleBody`
+     test helper captures a rule with a negated character class and stops dead
+     at the first closing one, so a brace in a comment truncates :root and
+     fails every test that reads it.
+
+     Theme-independent, so base :root. */
   --safe-area-inset-top: env(safe-area-inset-top, 0px);
-  /* #949 — the bottom (home-indicator) inset, same contract, same reason: the
-     `.context-menu` height cap subtracts BOTH vertical insets from a value
-     (`--viewport-height`) that JS writes, so the subtraction has to happen in
-     CSS. Sibling of the top inset above; the `0px` fallback is load-bearing
-     for the same reason. */
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
   /* grappa-irc#69: theme the scrollbars. `scrollbar-color` and
      `scrollbar-width` inherit, so declaring them on :root themes every
      scrollable descendant (.scrollback, members pane, admin tables…)
@@ -1271,10 +1296,10 @@ html.overlay-open #root > div {
         reported). */
   height: 100dvh;
   min-height: 0;
-  padding-top: env(safe-area-inset-top);
-  padding-bottom: env(safe-area-inset-bottom);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
+  padding-top: var(--safe-area-inset-top);
+  padding-bottom: var(--safe-area-inset-bottom);
+  padding-left: var(--safe-area-inset-left);
+  padding-right: var(--safe-area-inset-right);
 }
 
 /* #205 — dvh fallback floor for engines without dynamic-viewport units
@@ -1613,7 +1638,7 @@ html.resize-dragging * {
   z-index: 1000;
   display: flex;
   flex-direction: column;
-  padding-top: env(safe-area-inset-top);
+  padding-top: var(--safe-area-inset-top);
 }
 
 .error-banner {
@@ -4312,7 +4337,8 @@ html.resize-dragging * {
    one shrinks to the padding box and lands between the safe areas. */
 .modal-backdrop-viewport {
   height: var(--viewport-height, 100dvh);
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
+  padding: max(1rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom))
+    1rem;
 }
 
 /* Privacy modal — full-viewport backdrop + centred dialog. */
@@ -4328,7 +4354,7 @@ html.resize-dragging * {
      non-notched devices. Uniform 1.5rem floor with `.settings-drawer`
      / `.archive-modal`. Top/horizontal arms preserve the original
      1.5rem padding shape. */
-  padding: 1.5rem 1.5rem max(1.5rem, env(safe-area-inset-bottom));
+  padding: 1.5rem 1.5rem max(1.5rem, var(--safe-area-inset-bottom));
   max-width: 28rem;
   /* UX-5 bucket BV (2026-05-20) — defensive keyboard-react cap.
      Modal centers inside fixed backdrop (~:1173) so it CAN grow past
@@ -4561,7 +4587,8 @@ html.resize-dragging * {
      cramped against Safari's chrome / gesture indicator strip. 1.5rem
      (24px) gives mobile-thumb-reach breathing room while still
      yielding to the larger notched-device env value via max(). */
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
+  padding: max(1rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom))
+    1rem;
   z-index: 100;
   transform: translateX(100%);
   transition: transform 200ms ease-out;
@@ -4891,7 +4918,7 @@ html.resize-dragging * {
   /* #987 — the scrim has to be visible AROUND the dialog, not just behind it;
      `.confirm-modal` carries the same margin for the same reason. */
   margin: 1rem;
-  padding: max(0.75rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom));
+  padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom));
   font-family: var(--font-mono);
   font-size: var(--font-size);
   display: flex;
@@ -7705,11 +7732,13 @@ html.resize-dragging * {
    ruler to `auto` on every side and hand back a zero-sized rect: a safe box of
    [0,0] on both axes, i.e. every menu pinned to the corner. With the fallbacks
    an engine that knows no insets reports the full viewport, which is exactly
-   the pre-#949 behaviour. */
+   the pre-#949 behaviour. #1751 moved the fallbacks INTO the tokens (see the
+   :root block); they still cover this shorthand, and this rule no longer
+   spells them out four times. */
 .context-menu-safe-area {
   position: fixed;
-  inset: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px)
-    env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+  inset: var(--safe-area-inset-top) var(--safe-area-inset-right) var(--safe-area-inset-bottom)
+    var(--safe-area-inset-left);
   pointer-events: none;
 }
 
@@ -7797,7 +7826,7 @@ html.resize-dragging * {
        clear-ish but was non-interactive. box-sizing: border-box
        (global, line 67) means the inset is consumed FROM the height,
        not added to it. */
-    padding-top: env(safe-area-inset-top);
+    padding-top: var(--safe-area-inset-top);
     /* #1127 — the bottom edge is FLUSH: no home-indicator inset, so the
        whole mobile shell (the `.bottom-bar` tab strip included) reaches
        the physical bottom and the reclaimed band goes to content.
@@ -7848,8 +7877,8 @@ html.resize-dragging * {
        iPhones exceed 768px and get the desktop shell) but non-zero in the
        sub-768 landscape edge (small notched devices): correct clearance
        for the camera housing / rounded corners, not a regression. */
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
+    padding-left: var(--safe-area-inset-left);
+    padding-right: var(--safe-area-inset-right);
   }
 
   /* Legacy fallback for browsers that don't grok `dvh` (Safari < 15.4).
@@ -7923,8 +7952,8 @@ html.resize-dragging * {
        bottom floor mirrors UX-5 BD on the members drawer: env() is 0px on
        non-notched iPhones, which left the last row cramped under the Safari
        chrome / gesture indicator. */
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+    padding-top: var(--safe-area-inset-top);
+    padding-bottom: max(1.5rem, var(--safe-area-inset-bottom));
     width: 80vw;
     max-width: 18rem;
     z-index: 90;
@@ -7979,8 +8008,8 @@ html.resize-dragging * {
        `.mobile-panel-actions` footer) hosts buttons that relied on
        env(safe-area-inset-bottom) alone — 0px on non-notched iPhones —
        leaving the row cramped under Safari chrome / the gesture indicator. */
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+    padding-top: var(--safe-area-inset-top);
+    padding-bottom: max(1.5rem, var(--safe-area-inset-bottom));
     width: 80vw;
     max-width: 18rem;
     z-index: 90;
@@ -8089,7 +8118,7 @@ html.resize-dragging * {
    was obscured by the keyboard. */
 .diag-float {
   position: fixed;
-  top: max(0.5rem, env(safe-area-inset-top));
+  top: max(0.5rem, var(--safe-area-inset-top));
   right: 0.5rem;
   z-index: 99999;
   background: rgba(0, 0, 0, 0.85);
@@ -8421,7 +8450,7 @@ html.resize-dragging * {
      uniformly with `.settings-drawer` (~:1382). Non-notched iOS
      bug class: env(safe-area-inset-bottom) = 0 → 0.75rem left
      modal's bottom row visually cramped under Safari chrome. */
-  padding: max(0.75rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom));
+  padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom));
   font-family: var(--font-mono);
   font-size: var(--font-size);
   display: flex;
@@ -9659,7 +9688,7 @@ html.resize-dragging * {
   width: 100%;
   max-width: 32rem;
   max-height: var(--viewport-height, 100dvh);
-  padding: max(0.75rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom));
+  padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom));
   font-family: var(--font-mono);
   font-size: var(--font-size);
   display: flex;
@@ -11364,8 +11393,8 @@ html.resize-dragging * {
    reproducible in jsdom or Playwright). */
 .install-a2hs {
   position: fixed;
-  right: max(0.75rem, env(safe-area-inset-right));
-  bottom: max(0.75rem, env(safe-area-inset-bottom));
+  right: max(0.75rem, var(--safe-area-inset-right));
+  bottom: max(0.75rem, var(--safe-area-inset-bottom));
   z-index: 201;
   display: flex;
   flex-direction: column;
@@ -13020,7 +13049,7 @@ audio.media-viewer-media {
      actual height below the default --font-size. */
   --nab-lift: 0.75rem;
   top: calc(var(--viewport-height, 100dvh) - max(3.5rem, 48px) - var(--nab-lift));
-  right: calc(0.5rem + env(safe-area-inset-right, 0px));
+  right: calc(0.5rem + var(--safe-area-inset-right));
   z-index: 40;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62320,3 +62320,99 @@ ABSENT declaration by naming a NEIGHBOUR is falsified silently by a reorder**,
 because the declaration it describes does not change and no gate can see prose go
 wrong. Two more said "above compose" (`AudioMiniPlayer`'s moduledoc,
 `DropUploadZone`'s layout note) and were corrected in the same commit.
+<!-- entry #1751 -->
+
+---
+
+## 2026-08-24 — #1751: one safe-area mechanism, and the picker that did not need it
+
+**The reported defect was not the defect, and the requested fix was a
+regression.** #1751 came in as "the radio station picker rides under the notch;
+give it the settings-drawer top inset". Measured on `origin/main` at 713736f9,
+`.rail-radio-picker` is `position: absolute; inset: 0` inside `.shell-members`,
+and an abspos box resolves `inset` against its ancestor's PADDING box — the rule
+#1737 had just finished writing at that very aside. `.shell-members` carries the
+top inset on BOTH form factors: on mobile as the fixed drawer's own
+`padding-top`, on desktop as a grid child of the inset `.shell`. Both mounts of
+`<RailRadio/>` (Shell.tsx) are inside that aside; there is no third. So the
+picker already starts below the safe area, and giving it one of its own is the
+#205 double-count the `.shell-members` base rule has recorded since #205 —
+"keeping insets here too double-counted the top inset". The position-awareness
+trap the issue itself warned about landed on the element in its own title.
+
+⚠️ **The symptom is NOT explained and this entry does not claim it is.** The
+screenshot was not reproduced. Playwright synthesizes no safe-area inset on any
+engine we run and jsdom resolves no `env()` at all, so on-device geometry is
+observable in no gate we have; a notched device was not available. What is
+established is the containing-block chain, which says the inset is applied
+exactly once already. Something is wrong on that phone and it is not a missing
+inset on the picker.
+
+**What the directive asked for instead, and the invariant it produced.**
+`env(safe-area-inset-*)` was hand-written at 23 declarations across 16 rules
+with four different floors; the picker would have been the seventh copy of the
+`max(x, env(top))` shape. The mechanism is now: **`env()` appears exactly once
+per edge, at `:root`, and every consumer reads the token.** A surface with a
+minimum of its own writes `max(<its floor>, var(--safe-area-inset-top))`; one
+without writes the token bare. Left and right joined top and bottom as tokens,
+because a rule needing an exception list is not a rule.
+
+**Why that shape beat the alternatives.** A `:where(.safe-top)` group class was
+rejected on measurement, not taste: zero specificity loses to the `padding:`
+shorthands already on `.archive-modal` / `.settings-drawer` /
+`.modal-backdrop-viewport`, so every site needs editing anyway; it needs markup
+edits on top; it cannot express `.diag-float`'s `top:`; and per-site floors
+would need a second custom property, which does not work the obvious way — a
+`var()` inside a custom property declared on `:root` resolves against `:root`,
+not against the consumer. One shared floor was rejected because the four floors
+(1rem, 0.75rem, 0.5rem, none) each have an incident behind them and unifying
+them re-spaces five surfaces nobody reported.
+
+🔴 **The load-bearing argument is TESTABILITY, and it reverses what this
+codebase told itself.** The `:root` note used to say inline `env()` "is right
+for a padding: the engine substitutes it and nobody has to read it back". That
+is true of the ENGINE and false of every gate we run. Playwright resolves
+`env(safe-area-inset-*)` to 0 on every engine in the suite — including the
+`webkit-iphone-15` project, which is `devices["iPhone 15"]`, i.e. a viewport and
+a touch flag and no notch whatsoever — and jsdom resolves `env()` not at all.
+**So an inline site's inset is observable in NO test that can be written**,
+while a site reading the token is stubbable by re-declaring it on a
+`:root:root` override, which is precisely how `issue913-rail-menu-safe-area`
+proves its own wiring. #913 introduced the token for one site for this reason;
+#1751 finished the move rather than reversing it. **General rule: an
+engine-substituted value that no harness can synthesize must be reached through
+an indirection a harness CAN set, or the behaviour depending on it is
+unfalsifiable.**
+
+**The guard is a census, not a judgement.** `safeAreaInsetToken.test.ts`
+asserts (a) four tokens at `:root` with their `0px` fallbacks, (b) that no
+declaration outside `:root` writes `env(safe-area-inset-*)`, and (c) a
+transcription of all 27 safe-area declarations, selector by selector. (b) is
+the mechanism: it needs no list of which surfaces reach the physical top —
+a semantic judgement that would rot — and has no allowlist to add yourself to.
+(c) is what makes "an extraction changes no pixel" (#407's promise) a measured
+claim: `max(1rem, env(x))` and `max(1rem, var(--x))` compute the same length,
+so the pin moves without the promise moving with it.
+
+**Two further members of the same defect class, found by the census and NOT
+fixed here** (an extraction that also moves pixels is two changes wearing one
+commit): `.image-upload-modal` carries the BOTTOM inset and no top one, inside a
+`.modal-backdrop-full` with no padding and `max-height: var(--viewport-height)`,
+so at full height its top edge is the physical top. The issue body's claim that
+this modal "already carries" the inset is false, and the half-truth that
+produced it is the bottom inset that IS there. `.confirm-modal` is the weaker
+sibling: flat `1rem` padding, `margin: 1rem`, no `max-height`, in the same
+centred scrim, so tall content overflows above y=0. Filed separately.
+
+**A test-harness trap worth not rediscovering.** `helpers/themeCss.ruleBody`
+captures a rule body with a negated character class and stops at the FIRST
+closing brace, and it strips comments only AFTER capturing. So a curly brace
+inside a comment in the `:root` block truncates the capture and fails every
+test that reads `:root` — including ones nowhere near the edit. Cost two cycles
+here, writing `:root:root { … }` as an example inside the very comment
+explaining the stub. There is now an NB at that block. The same
+strip-after-capture ordering was a live false positive in
+`contextMenuSafeArea`'s uniqueness guard, which counted raw matches including
+prose and went red because the `:root` note names the class in a sentence; it
+now strips comments first, which is what every other helper in that module
+already documents itself as doing.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62324,29 +62324,65 @@ wrong. Two more said "above compose" (`AudioMiniPlayer`'s moduledoc,
 
 ---
 
-## 2026-08-24 — #1751: one safe-area mechanism, and the picker that did not need it
+## 2026-08-24 — #1751: padding does not move an abspos child, and one safe-area mechanism
 
-**The reported defect was not the defect, and the requested fix was a
-regression.** #1751 came in as "the radio station picker rides under the notch;
-give it the settings-drawer top inset". Measured on `origin/main` at 713736f9,
-`.rail-radio-picker` is `position: absolute; inset: 0` inside `.shell-members`,
-and an abspos box resolves `inset` against its ancestor's PADDING box — the rule
-#1737 had just finished writing at that very aside. `.shell-members` carries the
-top inset on BOTH form factors: on mobile as the fixed drawer's own
-`padding-top`, on desktop as a grid child of the inset `.shell`. Both mounts of
-`<RailRadio/>` (Shell.tsx) are inside that aside; there is no third. So the
-picker already starts below the safe area, and giving it one of its own is the
-#205 double-count the `.shell-members` base rule has recorded since #205 —
-"keeping insets here too double-counted the top inset". The position-awareness
-trap the issue itself warned about landed on the element in its own title.
+🔴 **PADDING ON A CONTAINER IS INVISIBLE TO ITS ABSOLUTELY POSITIONED
+DESCENDANTS. That is the whole defect, and this file said the opposite.** An
+abspos box resolves its offsets against the ancestor's padding EDGE — the OUTER
+edge of the padding, just inside the border — so the containing rectangle
+INCLUDES the padding and `inset: 0` lands ON that edge, above and outside it.
+"Resolves against the padding box" does NOT mean "so the padding pushes it
+down"; it means the opposite. The #1737 entry and the comment it left at
+`.shell-members` both asserted the wrong reading, and this entry is the
+correction.
 
-⚠️ **The symptom is NOT explained and this entry does not claim it is.** The
-screenshot was not reproduced. Playwright synthesizes no safe-area inset on any
-engine we run and jsdom resolves no `env()` at all, so on-device geometry is
-observable in no gate we have; a notched device was not available. What is
-established is the containing-block chain, which says the inset is applied
-exactly once already. Something is wrong on that phone and it is not a missing
-inset on the picker.
+**Measured, not reasoned — and it took being wrong first.** The initial reading
+of #1751 was that the reported symptom could not exist: the picker is
+`position: absolute; inset: 0` inside `.shell-members`, that aside insets
+itself, therefore the picker was already clear and the requested
+`max(x, env(top))` would be a #205 double-count. A probe at 390px with the
+token stubbed at 59px killed it:
+
+| | `.shell-members` `padding-top` | `.rail-radio-picker` y |
+|---|---|---|
+| before stub | 0px | 0 |
+| after stub | **59px** | **0** |
+
+The inset reaches the drawer; the picker does not move. vjt's screenshot was
+real and the CSS-only argument against it was wrong. Horizontally the same
+physics, measured on the same run: the aside's padding box is x 146–383 and the
+picker measured 139–390 — the padding edge — so it never inherited
+`--rail-inset` either, and #1737's "inherits deliberately" never took effect. It
+stayed invisible for the reason #1737 gave (same `--bg-alt`, nothing in the
+strips), which is why nobody caught it there.
+
+**Why the desktop never showed it, and why one arm of the spec passed while the
+other failed.** On desktop the aside is a grid ITEM of `.shell`, so `.shell`'s
+padding moves the aside's BORDER BOX and the picker follows the box. On mobile
+the aside is `position: fixed; top: 0`: the box stays put and only the padding
+grows inward. Same inset, two different mechanisms — the defect is phone-only,
+and no source-level guard could ever have seen it.
+
+🔴 **THE RULE: on a top-pinned `position: fixed` container, safe-area clearance
+goes on `top` (with `height` losing the same amount), not on `padding-top`.**
+Moving the border box moves every child, in flow or not, and it is
+pixel-identical for the flow children — they started at the inset because the
+padding pushed them and now start there because the box does. Applied to both
+mobile drawers, including `.shell-sidebar`, which has no abspos child today and
+so changes nothing: its own comment calls it the mirror of `.shell-members`, and
+two drawers answering one geometry problem two ways is how the next one gets
+copied from whichever was nearer.
+
+**Not the fix the issue asked for, and the original objection survives in half.**
+A plain `max(x, env(top))` on the picker fixes the phone and DOUBLE-COUNTS on
+the desktop, where the ancestor's box has already moved. The fix belongs at the
+container.
+
+**Corroboration that this is a general shape and not one rule's accident:**
+`.rail-actions-menu`, the rail's other abspos child, has subtracted the inset by
+hand from its `max-height` since #913. It hit this same physics from the other
+end — a JS-measured offset taken from the physical top — and worked around it
+locally without anyone naming the class.
 
 **What the directive asked for instead, and the invariant it produced.**
 `env(safe-area-inset-*)` was hand-written at 23 declarations across 16 rules


### PR DESCRIPTION
## 🔴 Read this first: two guards were about to go blind

`.topic-bar` and `.bottom-bar` are guarded by `not.toContain("env(")` — the pins
that stop the safe-area inset from landing on the band vjt's directive singled
out (it is a viewport constant, not position-aware, and that band also renders
**mid-column** under the mobile header, where an inset pads it away from a notch
it never touches).

Routing every consumer through `var(--safe-area-inset-*)` would have made those
two guards pass on `var(--safe-area-inset-top)` — i.e. **stop stopping exactly
the edit they exist for**, silently, as a side effect of a refactor that never
mentions them. Both now reject `safe-area-inset` by NAME, whichever vector
carries it. The same weakening hit `.shell-members`' negative guard in vitest;
same treatment.

## 🔴 And the second thing: the reported symptom is REAL. My first reading was wrong.

I originally argued #1751 could not exist — the picker is `position: absolute;
inset: 0` inside `.shell-members`, that aside insets itself, so the picker must
already be clear. The e2e probe killed it at 390px with the token stubbed at 59px:

| | `.shell-members` `padding-top` | `.rail-radio-picker` y |
|---|---|---|
| before | 0px | 0 |
| after | **59px** | **0** |

**Padding on a container is invisible to its absolutely positioned
descendants.** An abspos box resolves its offsets against the ancestor's padding
**EDGE** — the outer edge, just inside the border — so the containing rectangle
*includes* the padding and `inset: 0` lands above it. "Resolves against the
padding box" does not mean "so the padding pushes it down". I took that sentence
from **#1737's own comment**, which asserts the wrong reading; it is corrected
here, along with its horizontal half — measured false on the same run (the
aside's padding box is x 146–383, the picker measured 139–390, so it never
inherited `--rail-inset` either; invisible because the backgrounds match, which
is why it survived).

**Why desktop never showed it:** there the aside is a grid ITEM of `.shell`, so
`.shell`'s padding moves the aside's **border box** and the picker follows it.
Phone-only, and no source-level guard could ever have caught it.

### The fix, and why it is not the one the issue asked for

> On a top-pinned `position: fixed` container, safe-area clearance goes on
> **`top`** (with `height` losing the same amount), not on `padding-top`.

Moving the border box moves every child, in flow or not, and it is
pixel-identical for the flow children. A plain `max(x, env(top))` on the picker
would fix the phone and **double-count on the desktop** — so the original
objection survives, in half. Applied to `.shell-sidebar` too: no abspos child
today, so it changes nothing, but its own comment calls it the mirror of
`.shell-members` and divergent twins are how the next copy gets made.

Corroboration this is a class and not one rule's accident: `.rail-actions-menu`,
the rail's other abspos child, has subtracted the inset by hand from its
`max-height` since **#913** — the same physics from the other end, never named.

## The mechanism (vjt's directive)

`env(safe-area-inset-*)` was hand-written at **23 declarations across 16 rules**,
four floors. vjt's list of five was taken against an older tree and was
incomplete (`.diag-float` missing, and it is a `top:` not a padding). Now:

> `env(safe-area-inset-*)` appears exactly once per edge, at `:root`; every
> consumer reads the token.

Rejected on measurement, not taste: a `:where()` class (zero specificity loses to
the `padding:` shorthands already on three sites; cannot express `.diag-float`'s
`top:`; per-site floors need a second custom property, and a `var()` inside a
custom property declared on `:root` resolves against `:root`, not the consumer)
and one unified floor (re-spaces five surfaces nobody reported).

🔴 **The load-bearing argument is testability, and it reverses what the `:root`
note itself argued.** Playwright synthesizes no safe-area inset on any engine and
jsdom resolves no `env()`, so an inline site's inset is observable in **no** test
that can be written. The token is stubbable — and that is not decoration here:
**the token is what made this defect visible at all.** With `env()` inline the
delta is 0 on a correct build and a broken one alike.

## Verification

- `safeAreaInsetToken.test.ts` — four tokens at `:root`; **no `env()` outside
  `:root`** (the mechanism, no allowlist, no semantic census to keep current);
  a transcription of all 31 declarations, so "changes no pixel" is measured.
- `issue1751-safe-area-token.spec.ts` — the differential, both chains, two-sided
  (0 = never arrives, 2× = double-count).
- **Deliberate-fault run, on the lane:** reverting the mobile drawer to
  `padding-top` turns the mobile arm RED with the diagnostic message and leaves
  the desktop arm green — targeted, not blanket. Restored; tree clean.
- Five e2e spelling pins moved. **They were never a broken bottom floor**, and
  the proof is inside the same file: every declared-spelling test went red
  (`:90 :129 :167 :180`) while every computed-value sibling stayed **green**
  (`:104 :140 :199`) under WebKit — so the token is equivalent to the `env()` it
  replaced. Five reds explained without touching a line of CSS.

## Gates

| gate | result |
|---|---|
| `bun run check` | 4/4 ok |
| `bun run test` | 314 files / 6153 tests green |
| `design-notes-gate.sh` | ok |
| e2e `--grep "#1751"` (lane) | **2/2 green** |
| deliberate fault | **red where it should be, green where it should be** |

Full-suite `integration.sh` has NOT been run — only the scoped grep. CI on this
PR is the full gate.

## Found, not fixed here

`.image-upload-modal` carries the bottom inset and **no top one** while able to
reach the physical top (the issue body's claim that it "already carries" the
inset is false — the half-truth is the bottom one that is there), and
`.confirm-modal` is the weaker sibling. Filed as **#1756**: both are pixel
changes, and this is an extraction.

— w1