### PR TITLE
#1701: move the docked player below the compose box

### DIFF
--- a/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
+++ b/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
@@ -102,12 +102,50 @@ test("🎵 upload link click opens the docked mini-player, NOT the modal (GH #11
   const { row, link } = await mediaScrollbackRow(page, "🎵", slug);
   await expect(link).toHaveClass(/scrollback-media-link/);
 
+  // #1701 — the bar now docks BELOW the compose box, and what makes that safe
+  // for the float stack (scroll-to-bottom + next-active, anchored `bottom:
+  // 0.75rem` INSIDE `.scrollback-pane`) is that mounting it no longer comes
+  // between the pane and the compose box: the pane's bottom edge, which is the
+  // floats' frame of reference, keeps the same relationship to the send button's
+  // row whether or not audio is playing.
+  //
+  // `issue278-next-active-send-overlap` pins the float-vs-send geometry, but it
+  // runs with NO audio — so a player that started displacing that geometry again
+  // would sail past it unseen. This is the witness for the case #278 cannot see,
+  // and it asserts the IDENTITY rather than the numbers: repeating #278's
+  // overlap arithmetic with the bar up would buy no coverage and cost a second
+  // place to maintain the same constants.
+  //
+  // Form-factor independent on purpose — both Shell branches mount the same
+  // `.drop-upload-zone` column, so this holds wherever the spec's project runs.
+  const paneToComposeGap = async (): Promise<number> => {
+    const pane = await page.locator(".scrollback-pane").boundingBox();
+    const compose = await page.locator(".compose-box").boundingBox();
+    if (pane === null || compose === null) {
+      throw new Error("pane and compose box must both be laid out to compare the gap");
+    }
+    return compose.y - (pane.y + pane.height);
+  };
+  const gapWithoutBar = await paneToComposeGap();
+
   const cicUrl = page.url();
   await link.click();
 
   // The docked bar appears; the media viewer modal stays closed.
   const player = page.getByTestId("audio-mini-player");
   await expect(player).toBeVisible({ timeout: 5_000 });
+
+  // …and it did NOT insert itself between the pane and the compose box. Polled,
+  // because the bar changes height a second time when `onLoadedMetadata`
+  // resolves and swaps the seek slider for the live badge — measuring once on
+  // first paint would read a layout that is still settling.
+  await expect
+    .poll(async () => Math.abs((await paneToComposeGap()) - gapWithoutBar), {
+      message:
+        "#1701: mounting the docked bar must not change the pane→compose gap — a bar that lands between them moves the float stack's frame relative to the send button, which #278 cannot see because it runs with no audio",
+      timeout: 5_000,
+    })
+    .toBeLessThan(1);
   await expect(mediaViewer(page)).toBeHidden();
   expect(page.url()).toBe(cicUrl);
 

--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -19,8 +19,9 @@ import {
 } from "./lib/mediaSession";
 import { nowPlayingLabel } from "./lib/nowPlaying";
 
-// Docked audio mini-player (GH #115) — a slim transport bar pinned above
-// the compose box. Non-modal: scrollback stays scrollable + readable
+// Docked audio mini-player (GH #115) — a slim transport bar pinned BELOW
+// the compose box (#1701: between it and the mobile bottom bar; it used to
+// sit above compose). Non-modal: scrollback stays scrollable + readable
 // while audio plays (CLAUDE.md "IRC stays text only" — audio routes here
 // instead of MediaViewerModal). Persistent: switching the active channel
 // doesn't kill playback; a new audio link swaps the source on the single

--- a/cicchetto/src/DropUploadZone.tsx
+++ b/cicchetto/src/DropUploadZone.tsx
@@ -13,8 +13,10 @@ import { dragHasFiles, dropUpload } from "./lib/dropUpload";
 // Layout: `.drop-upload-zone` is a transparent pass-through flex column
 // (`flex: 1`) occupying the exact slot the stack used to fill directly, so
 // `.scrollback-pane`'s `flex: 1` still grows within it and TopicBar /
-// AudioMiniPlayer / ComposeBox keep their natural heights. `position:
-// relative` anchors the overlay.
+// ComposeBox / AudioMiniPlayer keep their natural heights (#1701 put the
+// player last, below compose — the zone still wraps it, so a drop on the
+// transport strip uploads like a drop anywhere else in the pane).
+// `position: relative` anchors the overlay.
 //
 // Drag-depth counter: dragenter/dragleave fire once per child element the
 // cursor crosses, so a naive boolean flickers the overlay off every time the

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -704,15 +704,17 @@ const Shell: Component = () => {
                     channelName={selectedChannel()?.channelName ?? ""}
                     kind={(selKind() as "channel" | "query" | "server") ?? "channel"}
                   />
-                  {/* GH #115 — docked audio mini-player, above compose.
-                      Inside this Match so it survives channel↔query↔server
-                      switches (the kindHasScrollback Match stays mounted);
-                      leaving chat for home/list/mentions stops playback. */}
-                  <AudioMiniPlayer />
                   <ComposeBox
                     networkSlug={selectedChannel()?.networkSlug ?? ""}
                     channelName={selectedChannel()?.channelName ?? ""}
                   />
+                  {/* GH #115 — docked audio mini-player, BELOW compose (#1701).
+                      Inside this Match so it survives channel↔query↔server
+                      switches (the kindHasScrollback Match stays mounted);
+                      leaving chat for home/list/mentions stops playback.
+                      Still inside DropUploadZone, so #351's whole-pane drop
+                      target keeps covering the strip. */}
+                  <AudioMiniPlayer />
                 </DropUploadZone>
               </Match>
               <Match when={selKind() === "mentions"}>
@@ -995,12 +997,14 @@ const Shell: Component = () => {
                   channelName={selectedChannel()?.channelName ?? ""}
                   kind={(selKind() as "channel" | "query" | "server") ?? "channel"}
                 />
-                {/* GH #115 — docked audio mini-player, above compose (mobile). */}
-                <AudioMiniPlayer />
                 <ComposeBox
                   networkSlug={selectedChannel()?.networkSlug ?? ""}
                   channelName={selectedChannel()?.channelName ?? ""}
                 />
+                {/* GH #115 — docked audio mini-player. #1701 moved it BELOW
+                    compose, so on mobile it lands between the compose box and
+                    the BottomBar (a sibling of `.shell-main`, further down). */}
+                <AudioMiniPlayer />
               </DropUploadZone>
             </Match>
             <Match when={selKind() === "mentions"}>

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAudio, playAudio } from "../lib/audioPlayer";
 import { LIST_WINDOW_NAME } from "../lib/windowKinds";
+import { nestedRuleBodies } from "./helpers/themeCss";
 import { swipeHorizontally } from "./helpers/touchEvents";
 
 // #500 — RailActions collapsed every rail affordance behind ONE launcher, so a
@@ -1554,5 +1556,81 @@ describe("Shell — #608 overlay-refcount leak on same-tick open→close", () =>
     selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
     await flushMacrotask();
     expect(overlayCount()).toBe(0);
+  });
+});
+
+// #1701 — vjt's ruling (relayed from IRC, 2026-08-24): the docked player stays
+// at the bottom of the main view but moves BELOW the compose box, between it
+// and the bottom bar. It is none of the three options that were on the table,
+// and taking the player out of the contested corner is the whole point: nothing
+// is hidden and nothing is gated by window kind, so #1051's ☰ ruling and the
+// four e2e specs that pin it are untouched.
+//
+// TWO assertions, and the pair is what carries the meaning. Document order
+// alone says only "later in the tree" — satisfied equally by a player hoisted
+// out to a sibling of `.shell-main`, which renders BELOW the bottom bar and not
+// between the two. Shared parent alone says only "same column" — satisfied
+// equally by today's above-compose mount. Together they say "inside the compose
+// box's own flex column, after it", which is the ruling verbatim.
+//
+// jsdom applies no stylesheet and computes no layout, so the fact that turns
+// document order into VISUAL order is read off the CSS text instead — the same
+// reason `audioMiniPlayerLayout` guards this bar's flex contract that way.
+describe("#1701 — the docked player sits below the compose box", () => {
+  beforeEach(() => {
+    // jsdom implements no HTMLMediaElement playback, and mounting the bar drives
+    // `play()` through the open effect. Same stubs `AudioMiniPlayer.test` installs.
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
+    vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // The audio store is a module singleton: a bar left mounted here leaks into
+    // every sibling suite that counts elements in the shell.
+    closeAudio();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["mobile", true],
+    ["desktop", false],
+  ])("on %s it renders in the compose box's column, after it", async (_form, mobile) => {
+    mobileState.value = mobile;
+    selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+    // An UPLOAD href on purpose. `radio.ts` derives the tuned station by matching
+    // this against the curated table's exact `streamUrl`, and a station tunes
+    // `nowPlaying`'s poll at `api.somafm.com` — a live third-party request from a
+    // unit test. An `/uploads/` URL cannot match, so nothing reaches the network.
+    playAudio("https://grappa.example/uploads/abc", null);
+    const { container } = render(() => <Shell />);
+
+    // Anti-false-green: assert the bar is actually mounted before measuring
+    // where it is. An unmounted player trivially satisfies "not above compose".
+    const player = await waitFor(() => {
+      const el = container.querySelector(".audio-mini-player");
+      expect(el, "the docked bar must be mounted for this to measure anything").not.toBeNull();
+      return el as HTMLElement;
+    });
+    const compose = container.querySelector(".compose-box") as HTMLElement | null;
+    expect(compose, "the compose box must be mounted").not.toBeNull();
+    if (compose === null) return;
+
+    expect(
+      player.parentElement,
+      "the bar shares the compose box's column — hoisting it out puts it under the bottom bar",
+    ).toBe(compose.parentElement);
+    expect(
+      compose.compareDocumentPosition(player) & Node.DOCUMENT_POSITION_FOLLOWING,
+      "the bar must come AFTER the compose box, not before it",
+    ).toBeTruthy();
+  });
+
+  it("that column is a plain top-to-bottom flex, so document order IS visual order", () => {
+    // `order` would break the equivalence silently; measured, the property
+    // appears nowhere in the sheet, so this one declaration is the whole link.
+    const bodies = nestedRuleBodies(".drop-upload-zone");
+    expect(bodies.length, ".drop-upload-zone must be declared in exactly one block").toBe(1);
+    expect(bodies[0]).toMatch(/flex-direction:\s*column/);
   });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3864,10 +3864,21 @@ html.resize-dragging * {
 
 /* ComposeBox */
 
-/* GH #115 — docked audio mini-player. In-flow slim transport bar
-   between scrollback and the compose box; non-modal so scrollback stays
-   scrollable + readable while audio plays. Sits above compose (and above
-   compose's own safe-area handling), so it needs no bottom inset. */
+/* GH #115 — docked audio mini-player. In-flow slim transport bar, non-modal
+   so scrollback stays scrollable + readable while audio plays.
+   #1701 — it is now the LAST row of the compose column rather than the row
+   above it: below the compose box, and on mobile above `.bottom-bar` (a
+   sibling of `.shell-main`, so still further down). `border-top` is unchanged
+   and still the correct edge — the neighbour it separates from is simply the
+   compose box now instead of the scrollback pane.
+   🔴 It still declares NO bottom inset, and the reason changed with the
+   position: the inset is owned by the SHELL, not by whatever happens to be
+   last. Base `.shell` carries `env(safe-area-inset-bottom)`; `.shell-mobile`
+   deliberately zeroes it (#1127, flush bottom edge), and that comment's
+   warning now applies to this rule too — with the keyboard up iOS reports
+   `env(safe-area-inset-bottom)` against the DEVICE, not the shrunken visual
+   viewport, so an inset added HERE double-counts against `--viewport-height`
+   and reopens the ~34px gap above the keyboard. */
 .audio-mini-player {
   display: flex;
   align-items: center;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62201,3 +62201,106 @@ inset and not merely equal, because two full-bleed surfaces agree with each
 other too — that is the state being rejected. Watch the tolerance idiom:
 `toBeCloseTo`'s second argument is a DIGIT COUNT, not a tolerance, so
 sub-pixel slack is written as an explicit `Math.abs(…) < EPSILON`.
+<!-- entry #1701b -->
+
+---
+
+## 2026-08-24 — #1701b: the player left the contested corner instead of winning it
+
+vjt's ruling on the repositioning half of #1701, relayed from IRC: *"lasciamo il
+player sotto ma mettiamolo SOTTO la compose box — tra compose box e bottom bar"*.
+It is none of the three options that had been argued, and that is the interesting
+part. The debate had narrowed to who wins the bottom corner on a mobile query
+window — the ☰ float (#1051's ruling) or the docked bar's own controls — and the
+ruling dissolves the question by moving the bar out of the corner entirely.
+
+Three things follow, and none of them is a compromise. The ☰ is never covered, so
+the premise of #1051 is not contested and that ruling stands as written — no
+reopening, and the four e2e specs that pin ☰ on query windows
+(`issue1039-hamburger-corner`, `issue1051-card-close-above-float` ×2,
+`issue985-mobile-floating-opener`) are untouched, because nothing here is hidden
+or gated by window kind. The bar's ✕ — the only STOP verb reachable from a phone
+while the rail is a drawer off-screen (#682) — stays in the main view. And the
+earlier local commit that implemented option ② (dock under the top bar, yield the
+corner) was DISCARDED rather than rebased: it implemented a decision that had been
+superseded, and building on it would have shipped the wrong one carefully.
+
+### The measurement the ruling asked for, and its limit
+
+The ruling named one thing as not-yet-measured: whether the position between the
+compose box and the bottom bar fights the on-screen keyboard (#209) or the
+scroll-to-bottom / next-window buttons. It does not, and the reason is that #280
+already solved the general form of it.
+
+Both floats live in `.scrollback-float-stack` — `position: absolute; bottom:
+0.75rem`, anchored inside `.scrollback-pane`. #280 chose the message container
+over the viewport precisely so their position is *"CONSTANT relative to the
+container regardless of keyboard state"*; before that they had two independent
+anchors and the keyboard-open lift drove one into the other. The pane is `flex: 1`
+inside `.drop-upload-zone`, a plain flex column whose other children take natural
+height, so reordering two natural-height siblings within it leaves the grown
+item's border box identical. Nothing keys on their order: the sheet declares no
+sibling combinator, `:nth-*` or `:last-child` involving `.audio-mini-player` or
+`.compose-box`, and `order` appears nowhere in it at all. The keyboard axis is the
+same argument — `.shell-mobile` is `height: var(--viewport-height)` tracking
+`visualViewport.height`, the shrink is absorbed by the pane through a
+`min-height: 0` chain, and the player stays inside that same chain, so the fixed
+pixels below the pane are unchanged by the reorder. Only the order changed.
+
+One delta is real and worth naming rather than burying: while the radio plays the
+float pair used to be separated from the send button by the bar's own row, and now
+it is adjacent. But adjacency is already the shipped geometry whenever the radio is
+NOT playing, and it is exactly what `issue278-next-active-send-overlap.spec.ts`
+pins green, keyboard-open, on webkit-iphone-15. The move makes the radio case
+converge onto an already-pinned case instead of opening a new one.
+
+The new pin is a PAIR of assertions, because either alone is satisfiable by a
+wrong shape: document order alone ("later in the tree") is satisfied by a player
+hoisted below the bottom bar, and shared parent alone ("same column") is satisfied
+by the pre-move mount above compose. Together they say "inside the compose box's
+own flex column, after it". jsdom computes no layout, so the fact that turns
+document order into VISUAL order — the column is `flex-direction: column` — is
+read off the stylesheet text, the same technique `audioMiniPlayerLayout` uses.
+
+⚠️ What this does NOT establish. #209's own text says soft-keyboard physics do not
+reproduce under chromium, and #278/#280 accordingly drive the app's OWN
+keyboard-open signal (focus the textarea → `.shell-mobile:has(textarea:focus)`)
+rather than a real keyboard. What is pinned in CI is the var-driven and
+focus-driven branch. The device leg remains vjt's.
+
+### Shape: last child of the zone, not a sibling of the main section
+
+"Between the compose box and the bottom bar" has two implementations. The bar can
+stay inside `DropUploadZone` as its last child, or be hoisted out to a sibling of
+`.shell-main` sitting just before `<BottomBar />`. On the windows where the player
+mounts they render identically, and the in-zone shape was chosen.
+
+The hoisted one costs two things the ruling did not ask to spend. #351's whole-pane
+drop target would stop covering the transport strip, so a file dropped there would
+do nothing. And the bar would mount on every mobile window kind rather than the
+scrollback kinds it mounts on today — a behaviour change nobody requested,
+arriving disguised as a reposition.
+
+`border-top` needed no flip, unlike the discarded option-② commit: the edge the bar
+separates on is still its top one; the neighbour above it is simply the compose box
+now instead of the pane.
+
+### The comment that went stale by moving, and its class
+
+`.audio-mini-player`'s header said it *"Sits above compose (and above compose's own
+safe-area handling), so it needs no bottom inset."* The conclusion survived the
+move and the reason did not: the bar still declares no bottom inset, but because
+the SHELL owns that inset, not because something below it does. Base `.shell`
+carries `env(safe-area-inset-bottom)`; `.shell-mobile` deliberately zeroes it
+(#1127, flush bottom edge). The distinction is load-bearing rather than pedantic,
+because #1127 measured what happens if an inset is added on this edge: with the
+keyboard up iOS reports `env(safe-area-inset-bottom)` against the DEVICE and not
+the shrunken visual viewport, so it double-counts against `--viewport-height` and
+reopens a ~34px gap above the keyboard. The bar is now the bottom-most row of that
+column, so the warning applies to its rule too and is recorded there.
+
+The general shape, worth more than the instance: **a comment that justifies an
+ABSENT declaration by naming a NEIGHBOUR is falsified silently by a reorder**,
+because the declaration it describes does not change and no gate can see prose go
+wrong. Two more said "above compose" (`AudioMiniPlayer`'s moduledoc,
+`DropUploadZone`'s layout note) and were corrected in the same commit.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62254,6 +62254,22 @@ NOT playing, and it is exactly what `issue278-next-active-send-overlap.spec.ts`
 pins green, keyboard-open, on webkit-iphone-15. The move makes the radio case
 converge onto an already-pinned case instead of opening a new one.
 
+**That convergence was at first left as an ARGUMENT, and the correction is the
+transferable part.** "The geometry is identical with the bar up" is a claim, and
+#278 cannot be its witness: it runs with **no audio**, so a player that began
+displacing that geometry again would sail past it green. The cure is not a
+radio-mounted copy of #278 — repeating those constants buys no coverage and
+creates a second place for them to drift — but a witness for the case #278 is
+blind to, asserting the IDENTITY instead of the values. The float stack is
+anchored inside `.scrollback-pane`, so the pane's bottom edge IS the floats'
+frame of reference and the send button rides the compose box; therefore if
+mounting the bar leaves the pane→compose gap unchanged, the with-audio
+float-vs-send relationship is by construction the one #278 already pins without
+it. Measured before and after the link click in `media-link-modal-viewer`, which
+already has both on screen. **The rule: an identity that a spec's own
+preconditions exclude is not covered by that spec, however green it is — pin it
+or declare it, never leave it silent.**
+
 The new pin is a PAIR of assertions, because either alone is satisfiable by a
 wrong shape: document order alone ("later in the tree") is satisfied by a player
 hoisted below the bottom bar, and shared parent alone ("same column") is satisfied


### PR DESCRIPTION
The repositioning half of #1701, on vjt's ruling relayed from IRC (2026-08-24):
*"lasciamo il player sotto ma mettiamolo SOTTO la compose box — tra compose box e
bottom bar"*. The re-pin half of that issue landed separately in #1732 and is not
touched here.

It is **none of the three options** that had been argued. The debate had narrowed
to who wins the bottom corner on a mobile query window — the ☰ float or the
docked bar's controls — and the ruling dissolves the question by moving the bar
out of the corner. Consequences, all of them good:

- the ☰ is never covered, so the premise of **#1051's ruling is not contested and
  it stands as written** — no reopening;
- the four e2e specs that pin ☰ on query windows (`issue1039-hamburger-corner`,
  `issue1051-card-close-above-float` ×2, `issue985-mobile-floating-opener`) are
  **untouched** — nothing here is hidden or gated by window kind;
- the bar's ✕, the only STOP verb reachable from a phone while the rail is a
  drawer off-screen (#682), **stays in the main view**.

The superseded local commit that implemented option ② (dock under the top bar,
yield the corner) was **discarded, not rebased** — it never left this host.

## The measurement the ruling asked for

The ruling named one thing as not-yet-measured: whether the placement fights the
on-screen keyboard (#209) or the scroll-to-bottom / next-window buttons.
**Neither.**

**The floats.** Both live in ONE container — `.scrollback-float-stack`,
`position: absolute; bottom: 0.75rem` — inside `.scrollback-pane`. That is
**#280's root-cause fix**, and its own comment states the property that answers
this: anchoring to the message container rather than the viewport keeps their
position *"CONSTANT relative to the container regardless of keyboard state"*.
The reorder cannot move that box — the pane is the `flex: 1` item of a column
whose other children take natural height, so swapping two natural-height siblings
leaves the grown item's border box identical.

Falsifiers checked rather than assumed: no sibling combinator / `:nth-*` /
`:last-child` in the sheet touching `.audio-mini-player` or `.compose-box`;
`order:` appears **zero** times in the entire stylesheet; no TS reads DOM order
near these; one stylesheet only.

**The keyboard.** `.shell-mobile` is `height: var(--viewport-height)`, written
from `visualViewport.height`. The keyboard shrinks the var and the pane absorbs
it through a `min-height: 0` chain. The player stays inside that same chain, so
the fixed pixels below the pane are unchanged — only their order is.

## What is pinned, and what is only declared

The one real delta: while the radio plays, the float pair used to be separated
from the send button by the bar's own row, and now it is adjacent — which is
already the shipped geometry whenever the radio is **not** playing.

That convergence was at first left as an argument, and **#278 cannot be its
witness: it runs with no audio**, so a player that began displacing that geometry
again would sail past it green. Rather than clone #278 with the radio on —
repeating its overlap constants buys no coverage and creates a second place for
them to drift — the **identity** is asserted:

> the floats are anchored inside the pane, so the pane's bottom edge is their
> frame of reference, and the send button rides the compose box; therefore if
> mounting the bar leaves the **pane→compose gap unchanged**, the with-audio
> float-vs-send relationship is *by construction* the one #278 already pins.

Measured before the link click and again with the bar up, inside
`media-link-modal-viewer.spec.ts` (which already has both on screen). Polled, not
read once — the bar changes height a second time when `onLoadedMetadata` swaps
the seek slider for the live badge. The failure signal is the bar's own height
against a 1px tolerance: **≈47px, derived from the sheet** (`min-height: 2.5rem`
controls at `1rem = 14px`, plus `0.8rem` vertical padding and a `1px` border) —
so the threshold is not a tight one.

⚠️ **Declared, not pinned.** #209 says it itself — *"soft keyboard physics don't
reproduce under chromium e2e"* — and #278/#280 accordingly drive the app's own
focus-derived signal (`.shell-mobile:has(textarea:focus)`), not a real keyboard.
What CI holds is that branch. **The device leg is vjt's**, and no chromium green
here should be read as a claim about an iPhone.

## Shape: last child of the zone, not a sibling of the main section

`<BottomBar />` is a sibling of `.shell-main` while the player lives inside it, so
the ruling's words admit two implementations. The bar became the **last child of
`DropUploadZone`**, after `<ComposeBox />`. They render identically where the
player mounts; hoisting it out would spend two things nobody asked for — #351's
whole-pane drop target would stop covering the transport strip, and the bar would
begin mounting on *every* mobile window kind instead of the scrollback kinds it
mounts on today, a behaviour change disguised as a reposition.

`border-top` needed **no flip**, unlike the discarded option-② commit: the edge
it separates on is still its top one; the neighbour above it is simply the
compose box now.

## The stale comment, and its class

`.audio-mini-player`'s header justified an **absent** declaration by naming a
**neighbour** — *"Sits above compose (and above compose's own safe-area
handling), so it needs no bottom inset."* The conclusion survived the move and
the reason did not: the **shell** owns that inset (base `.shell` carries
`env(safe-area-inset-bottom)`, `.shell-mobile` deliberately zeroes it per #1127).

Load-bearing rather than pedantic, because #1127 measured the failure: with the
keyboard up iOS reports `env(safe-area-inset-bottom)` against the DEVICE, not the
shrunken visual viewport, so an inset on this edge double-counts against
`--viewport-height` and reopens a ~34px gap. The bar is now the bottom-most row
of that column, so the warning is recorded on its rule.

**The general shape, worth more than the instance:** a comment that justifies an
ABSENT declaration by naming a NEIGHBOUR is falsified silently by a reorder — the
declaration it describes never changes, and no gate reads prose. Two more said
"above compose" and were corrected in the same commit.

## Tests

The unit pin asserts a **pair**, because either half alone passes a wrong shape:
document order alone ("later in the tree") is satisfied by a player hoisted below
the bottom bar; shared parent alone ("same column") is satisfied by the pre-move
mount above compose. Together they say "inside the compose box's own flex column,
after it". jsdom computes no layout, so the step that turns document order into
VISUAL order — the column is `flex-direction: column`, and `order` appears
nowhere in the sheet — is read off the CSS text, the technique
`audioMiniPlayerLayout` already uses on this bar.

Measured RED before the move on the order assertion, both form factors, with the
parent assertion already green.

## Gates

| gate | result |
|---|---|
| `bun.sh run check` — lock drift, biome (src+e2e), tsc (src), tsc (e2e) | 4 stages, 0 failed |
| `bun.sh run test --run` — full vitest | 313 files, 6145 tests green |
| `design-notes-gate.sh` | green — 1 entry, separator + marker `#1701b` |
| e2e — new identity assertion | **RED→GREEN, both demonstrated** |
| e2e — `issue278` + `issue280` (regression witnesses) | 4 passed, webkit-iphone-15 |
| `scripts/integration.sh` run 1 | 770 passed, 1 failed — `issue981` |
| `scripts/integration.sh` run 2 | 770 passed, 1 failed — `issue152`; **`issue981` green** |

The RED was constructed, not assumed: restoring the pre-move `Shell.tsx` from the
base makes the identity assertion fail with `Expected: < 1 / Received: 47.1875` —
the bar's own height, matching the ~47.2px derived from the stylesheet beforehand.

⚠️ **The full suite has not gone green, and neither red is this branch's.**

`issue981-no-badge-at-tail` is the one that needed discriminating, because it has
a plausible link to this change (a badge on a window read at the TAIL, while the
bar moves toward the tail). It was measured, not waved off:

- the failure is in the **setup**, not the badge — `.sidebar-network-header` never
  found, 10s timeout, sidebar showing only Home;
- **no causal path** — the branch touches neither `Sidebar.tsx` nor
  `lib/networks.ts`, which own that element;
- **not deterministic** — same branch, same suite, same roster position 458:
  ✘ 33.6s in run 1, ✓ 4.0s in run 2;
- **3/3 green in isolation** on this branch *and* on a detached control worktree
  at clean `31f9502f`;
- run 2's single red was a **different** spec (`issue152-ident-realname:37`),
  itself 3/3 green in isolation.

By `docs/TESTING.md`'s decision tree that is branch 1 — CASCADE, *"filed as a
follow-up bucket. DO NOT change production code."* The rotating single red across
two runs is that section's own listed cascade signature. The #1584 cold-start
exception was checked and does not apply (`issue981` was not a cold seat).

**Attribution, stated precisely because it is easy to garble:** BOTH reds are on
this branch — run 1 red `issue981`, run 2 red `issue152`. The only clean-base
measurement taken was a detached control worktree at `31f9502f` running
`--grep "#981" --repeat-each 3` (3 passed); `issue152` was not in that roster, so
**no clean-base full run was performed** and none should be inferred.

**What was NOT done, declared rather than left silent:** the targeted 5×5
repetition of `issue981` (five iso runs each side) was not run. It was judged the
weaker instrument here and the reason is structural — isolation removes the
upstream poisoner *by construction*, so a cascade returns 0/5 on both sides and
the comparison discriminates nothing. The evidence relied on instead is the
same-load, same-position full-suite flip (✘ 33.6s → ✓ 4.0s at roster position
458) plus the absent causal path. Anyone who wants the 5×5 anyway should know it
is expected to come back green on both sides regardless of cause.

What is **not** established at all is which upstream spec is the poisoner. That
is a bisect, and by the runbook's own instruction it belongs in its own bucket
rather than in this slice. Observed environmental rate: ~1 red per 770 with a
rotating target, measured over two full local runs.

**Local e2e informs; it does not decide.** The gate that matters is this PR's CI,
on different hardware under a different load. If CI reproduces either red, it
should be triaged there against real data rather than against a single local run.

— w2
