### PR TITLE
#1760: let the admin networks pane set visitor_enabled, visitor_autoconnect and services_flavor

### DIFF
--- a/cicchetto/e2e/tests/issue1760-admin-network-visitor-settings.spec.ts
+++ b/cicchetto/e2e/tests/issue1760-admin-network-visitor-settings.spec.ts
@@ -1,0 +1,238 @@
+// #1760 — the admin networks pane can now reach `visitor_enabled`,
+// `visitor_autoconnect` and `services_flavor`. Before this, a network
+// created from the panel was born `visitor_enabled = false`
+// (`network.ex` column default) and there was no control to flip it: on
+// 2026-08-24 `rizon` was added from the panel and had to be finished
+// with a hand-written UPDATE against `runtime/grappa_prod.db`.
+//
+// 🔴 What this spec asserts is the EFFECT, not the control. A checkbox
+// that renders and PATCHes nothing passes a "the control exists" test,
+// and a checkbox whose PATCH lands passes a "the input is checked"
+// test — neither would have caught the bug this issue is about, which
+// is that the network stays unreachable. So the oracle is the server's
+// own visitor allowlist, read back through `GET /me`:
+// `home_data.available_networks` is `Networks.list_visitor_enabled/0`
+// minus the subject's attached networks (`networks.ex`), i.e. exactly
+// the tier a network created from the panel could not enter. Absent
+// before the click, present after it. That is the operator's actual
+// complaint, expressed as a number the server produced.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated EXEMPT —
+// only the admin user class reaches the tab; gate spec at
+// m7-admin-gate-settings-drawer.spec.ts.
+//
+// Per `feedback_cicchetto_browser_smoke`: chromium renders the
+// disabled→enabled transition on the autoconnect box, which is a
+// computed `disabled` attribute jsdom can assert but only a browser can
+// prove is actually unclickable.
+//
+// The seeded networks (bahamut-test, azzurra, azzurra2, azzurra3) are
+// LOAD-BEARING for other specs and several are already visitor_enabled —
+// never toggle those. This spec creates its own slug and deletes it in
+// `finally`, the admin-network-crud.spec.ts pattern. The runner is
+// `workers: 1, fullyParallel: false`, so the window in which a
+// visitor_enabled extra network exists is inside this test alone.
+
+import { adminLogin, openAdminConsole } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+type AdminNetworkRow = {
+  id: number;
+  slug: string;
+  visitor_enabled: boolean;
+  visitor_autoconnect: boolean;
+  services_flavor: string | null;
+};
+
+async function openNetworksTab(page: import("@playwright/test").Page): Promise<void> {
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-networks").click();
+  await expect(page.getByTestId("admin-networks-table")).toBeVisible({ timeout: 10_000 });
+}
+
+// The server's own row, not the pane's echo of it. Used for the
+// `services_flavor` + `visitor_autoconnect` half, where there is no
+// downstream projection as direct as the visitor allowlist.
+async function fetchNetworkRow(token: string, slug: string): Promise<AdminNetworkRow | undefined> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  expect(res.ok).toBe(true);
+  const body = (await res.json()) as { networks: AdminNetworkRow[] };
+  return body.networks.find((n) => n.slug === slug);
+}
+
+// The visitor allowlist as the SERVER computes it for this subject.
+async function availableSlugs(token: string): Promise<string[]> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/me`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  expect(res.ok).toBe(true);
+  const body = (await res.json()) as {
+    home_data: { available_networks: Array<{ slug: string }> };
+  };
+  return body.home_data.available_networks.map((n) => n.slug);
+}
+
+async function createNetwork(token: string, slug: string): Promise<number> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ slug }),
+  });
+  expect(res.ok).toBe(true);
+  return ((await res.json()) as { id: number }).id;
+}
+
+async function deleteNetworkBestEffort(token: string, id: number | null): Promise<void> {
+  if (id === null) return;
+  try {
+    await fetch(`${GRAPPA_BASE_URL}/admin/networks/${id}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+test("#1760 flipping visitors-allowed from the pane puts the network in the visitor allowlist", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const slug = `e2enet-vis-${Date.now()}`;
+  let networkId: number | null = null;
+
+  try {
+    networkId = await createNetwork(admin.token, slug);
+
+    // The bug, stated as a measurement: a network born from the panel is
+    // NOT in the allowlist. If this ever starts out true, the default
+    // moved and the rest of the spec proves nothing.
+    expect(
+      await availableSlugs(admin.token),
+      "a freshly created network must start OUTSIDE the visitor allowlist",
+    ).not.toContain(slug);
+
+    await adminLogin(page, admin);
+    await openNetworksTab(page);
+
+    const enabled = page.getByTestId(`admin-network-visitor-enabled-${slug}`);
+    const save = page.getByTestId(`admin-network-save-${slug}`);
+    await expect(enabled).not.toBeChecked();
+    await expect(save).toBeDisabled();
+
+    await enabled.check();
+    await expect(save).toBeEnabled();
+    await save.click();
+
+    // The pane agrees with itself: post-Save the row re-fetches and the
+    // box is no longer dirty. Necessary, nowhere near sufficient.
+    await expect(enabled).toBeChecked();
+    await expect(save).toBeDisabled();
+    await expect(page.getByTestId("admin-networks-error")).toHaveCount(0);
+
+    // The oracle. The server now offers this network to the subject.
+    await expect
+      .poll(async () => await availableSlugs(admin.token), { timeout: 10_000 })
+      .toContain(slug);
+  } finally {
+    await deleteNetworkBestEffort(admin.token, networkId);
+  }
+});
+
+test("#1760 autoconnect unlocks with visitor access and is revoked together with it", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const slug = `e2enet-auto-${Date.now()}`;
+  let networkId: number | null = null;
+
+  try {
+    networkId = await createNetwork(admin.token, slug);
+
+    await adminLogin(page, admin);
+    await openNetworksTab(page);
+
+    const enabled = page.getByTestId(`admin-network-visitor-enabled-${slug}`);
+    const auto = page.getByTestId(`admin-network-visitor-autoconnect-${slug}`);
+    const save = page.getByTestId(`admin-network-save-${slug}`);
+
+    // Locked while the network accepts no visitors — the server would
+    // take the flag and the login filter would silently drop it
+    // (`Networks.list_visitor_autoconnect/0`'s callers AND the pair), so the only
+    // place the operator can be told is here.
+    await expect(auto).toBeDisabled();
+
+    await enabled.check();
+    await expect(auto).toBeEnabled();
+    await auto.check();
+    await save.click();
+    await expect(save).toBeDisabled();
+
+    // Both landed, in one PATCH.
+    const armed = await fetchNetworkRow(admin.token, slug);
+    expect(armed?.visitor_enabled).toBe(true);
+    expect(armed?.visitor_autoconnect).toBe(true);
+
+    // Revoking visitor access must take autoconnect with it. Leaving
+    // `visitor_autoconnect = true` on a network visitors cannot reach is
+    // the stranded pair — no error, no effect, and invisible until
+    // somebody re-enables the network months later and gets an
+    // auto-connect nobody asked for.
+    await enabled.uncheck();
+    await expect(auto).not.toBeChecked();
+    await expect(auto).toBeDisabled();
+    await save.click();
+    await expect(save).toBeDisabled();
+
+    const revoked = await fetchNetworkRow(admin.token, slug);
+    expect(revoked?.visitor_enabled).toBe(false);
+    expect(
+      revoked?.visitor_autoconnect,
+      "revoking visitor access must clear autoconnect in the same write",
+    ).toBe(false);
+    await expect(page.getByTestId("admin-networks-error")).toHaveCount(0);
+  } finally {
+    await deleteNetworkBestEffort(admin.token, networkId);
+  }
+});
+
+test("#1760 services flavor round-trips through the server, blank included", async ({ page }) => {
+  const admin = getSeededAdmin();
+  const slug = `e2enet-flavor-${Date.now()}`;
+  let networkId: number | null = null;
+
+  try {
+    networkId = await createNetwork(admin.token, slug);
+    expect((await fetchNetworkRow(admin.token, slug))?.services_flavor).toBeNull();
+
+    await adminLogin(page, admin);
+    await openNetworksTab(page);
+
+    const flavor = page.getByTestId(`admin-network-services-flavor-${slug}`);
+    const save = page.getByTestId(`admin-network-save-${slug}`);
+    await expect(flavor).toHaveValue("");
+
+    await flavor.selectOption("atheme");
+    await save.click();
+    await expect(save).toBeDisabled();
+    expect((await fetchNetworkRow(admin.token, slug))?.services_flavor).toBe("atheme");
+
+    // Back to unclassified. The blank option is `null` on the wire, not
+    // an omitted key — omitting it would make a wrong flavor permanent,
+    // since unsupplied keys keep their current value.
+    await flavor.selectOption("");
+    await save.click();
+    await expect(save).toBeDisabled();
+    expect(
+      (await fetchNetworkRow(admin.token, slug))?.services_flavor,
+      "the blank option must CLEAR the flavor, not leave the previous one",
+    ).toBeNull();
+    await expect(page.getByTestId("admin-networks-error")).toHaveCount(0);
+  } finally {
+    await deleteNetworkBestEffort(admin.token, networkId);
+  }
+});

--- a/cicchetto/src/AdminNetworksTab.tsx
+++ b/cicchetto/src/AdminNetworksTab.tsx
@@ -12,7 +12,7 @@ import { liveCountsByNetworkId } from "./lib/adminEvents";
 import {
   type AdminFeaturedChannel,
   type AdminNetwork,
-  type AdminNetworkCapsPatch,
+  type AdminNetworkSettingsPatch,
   type AdminServer,
   ApiError,
   adminAddFeaturedChannel,
@@ -24,7 +24,7 @@ import {
   adminListFeaturedChannels,
   adminListNetworks,
   adminListServers,
-  adminPatchNetworkCaps,
+  adminPatchNetworkSettings,
   adminResetCircuit,
   adminRunReaper,
   adminUpdateFeaturedChannel,
@@ -41,7 +41,7 @@ import { isAdminNarrow } from "./lib/theme";
 //     `max_concurrent_user_sessions` + `max_per_ip` (post-U-1 the
 //     network-total cap is split per subject; logic split lands in
 //     U-2). Empty string == null (the "unlimited" sentinel per
-//     `Networks.update_network_caps/2`'s three-valued contract).
+//     `Networks.update_network_settings/2`'s three-valued contract).
 //     Save fires PATCH with ONLY the changed keys (server contract:
 //     unsupplied keys keep their value; sending all keys on every
 //     edit would silently overwrite a concurrent admin's edit to the
@@ -289,7 +289,7 @@ const AdminNetworksTab: Component = () => {
     if (Object.keys(patch).length === 0) return; // pristine bypass — no-op
     setError(null);
     try {
-      await adminPatchNetworkCaps(t, net.slug, patch);
+      await adminPatchNetworkSettings(t, net.slug, patch);
       await refresh();
     } catch (e) {
       const code = e instanceof ApiError ? e.code : "request_failed";
@@ -975,14 +975,14 @@ function parseCap(raw: string): ParseResult {
 // keys keep their current value. Returns null if ANY field fails
 // validation (Save should be disabled in that case); returns an empty
 // object if the row is pristine. CRIT-1 of M-10 review.
-function buildPatchBody(net: AdminNetwork, edit: RowEdit): AdminNetworkCapsPatch | null {
+function buildPatchBody(net: AdminNetwork, edit: RowEdit): AdminNetworkSettingsPatch | null {
   const visitorSessions = parseCap(edit.max_concurrent_visitor_sessions);
   if (!visitorSessions.ok) return null;
   const userSessions = parseCap(edit.max_concurrent_user_sessions);
   if (!userSessions.ok) return null;
   const perIp = parseCap(edit.max_per_ip);
   if (!perIp.ok) return null;
-  const body: AdminNetworkCapsPatch = {};
+  const body: AdminNetworkSettingsPatch = {};
   if (visitorSessions.value !== net.max_concurrent_visitor_sessions) {
     body.max_concurrent_visitor_sessions = visitorSessions.value;
   }

--- a/cicchetto/src/AdminNetworksTab.tsx
+++ b/cicchetto/src/AdminNetworksTab.tsx
@@ -32,6 +32,10 @@ import {
 } from "./lib/api";
 import { token } from "./lib/auth";
 import { isAdminNarrow } from "./lib/theme";
+import {
+  NETWORKS_NETWORK_SERVICES_FLAVOR,
+  type NetworksNetworkServicesFlavor,
+} from "./lib/wireTypes";
 
 // M-cluster M-10 — Networks admin tab. Operator surface for the
 // admission caps + circuit-breaker recovery + on-demand visitor reap.
@@ -46,6 +50,15 @@ import { isAdminNarrow } from "./lib/theme";
 //     unsupplied keys keep their value; sending all keys on every
 //     edit would silently overwrite a concurrent admin's edit to the
 //     other cap — CRIT-1 of the M-10 review).
+//   * #1760 — `visitor_enabled` + `visitor_autoconnect` checkboxes and
+//     a `services_flavor` select, sharing that SAME draft and that same
+//     Save. The backend has whitelisted all six keys since #211 phase 3
+//     (`NetworksController.settings_attrs/1`) but the pane edited three,
+//     and the three it could not reach are the ones that decide whether
+//     a network is usable: a network created here was born
+//     `visitor_enabled = false` (`network.ex` column default) with no
+//     way out of it except an UPDATE against the production DB, which
+//     is what `rizon` needed on 2026-08-24.
 //   * Reset Circuit (InlineConfirmButton) — only rendered when
 //     `circuit_state !== null`. POST /admin/circuit/:id/reset.
 //
@@ -76,11 +89,26 @@ import { isAdminNarrow } from "./lib/theme";
 // `<For>` row. Per-row dirty state lives in a top-level store keyed
 // on slug; handlers close over slug (string copy), not DOM refs.
 
+// The per-row draft. The three caps hold the operator's RAW text (a
+// half-typed number has to survive in the draft, and `""` is the
+// "unlimited" null sentinel); the toggles and the flavor are already
+// closed values, so they hold the value itself. `""` on the flavor is
+// `services_flavor: null` — the schema's nullable "never classified",
+// a real wire value and not a missing one.
 type RowEdit = {
   max_concurrent_visitor_sessions: string;
   max_concurrent_user_sessions: string;
   max_per_ip: string;
+  visitor_enabled: boolean;
+  visitor_autoconnect: boolean;
+  services_flavor: FlavorDraft;
 };
+
+type CapField = "max_concurrent_visitor_sessions" | "max_concurrent_user_sessions" | "max_per_ip";
+
+type ToggleField = "visitor_enabled" | "visitor_autoconnect";
+
+type FlavorDraft = NetworksNetworkServicesFlavor | "";
 
 type ParseResult = { ok: true; value: number | null } | { ok: false };
 
@@ -94,21 +122,37 @@ const MAX_CAP = 2 ** 31 - 1;
 // `field` → human label. Mirrors the table `<th>` text so screen-
 // reader users get the same wording sighted users see (MED-8 of
 // M-10 review).
-const FIELD_LABELS: Record<keyof RowEdit, string> = {
+const FIELD_LABELS: Record<CapField, string> = {
   max_concurrent_visitor_sessions: "max visitor sessions",
   max_concurrent_user_sessions: "max user sessions",
   max_per_ip: "max per ip",
 };
 
-const FIELD_TEST_ID_SLUG: Record<keyof RowEdit, string> = {
+const FIELD_TEST_ID_SLUG: Record<CapField, string> = {
   max_concurrent_visitor_sessions: "max-visitor-sessions",
   max_concurrent_user_sessions: "max-user-sessions",
   max_per_ip: "max-per-ip",
 };
 
-// slug + the six secondary columns + actions. Feeds the detail row's
+const TOGGLE_LABELS: Record<ToggleField, string> = {
+  visitor_enabled: "visitors allowed",
+  visitor_autoconnect: "autoconnect visitors",
+};
+
+const TOGGLE_TEST_ID_SLUG: Record<ToggleField, string> = {
+  visitor_enabled: "visitor-enabled",
+  visitor_autoconnect: "visitor-autoconnect",
+};
+
+// Why autoconnect is inert while visitors are not allowed, in the words
+// an operator needs — the server drops the pair silently, so the UI is
+// the only place that can say so (`Networks.list_visitor_autoconnect/0`).
+const AUTOCONNECT_LOCKED_HINT =
+  "a network that does not accept visitors has nobody to autoconnect — allow visitors first";
+
+// slug + the nine secondary columns + actions. Feeds the detail row's
 // `colspan` at desktop width; on a phone only slug + actions survive.
-const NETWORK_COLUMNS = 8;
+const NETWORK_COLUMNS = 11;
 
 function reapKey(): string {
   return "force-reap";
@@ -195,6 +239,9 @@ const AdminNetworksTab: Component = () => {
             max_concurrent_visitor_sessions: capToInput(n.max_concurrent_visitor_sessions),
             max_concurrent_user_sessions: capToInput(n.max_concurrent_user_sessions),
             max_per_ip: capToInput(n.max_per_ip),
+            visitor_enabled: n.visitor_enabled,
+            visitor_autoconnect: n.visitor_autoconnect,
+            services_flavor: n.services_flavor ?? "",
           };
         }
       }),
@@ -220,12 +267,36 @@ const AdminNetworksTab: Component = () => {
   // width. ONE definition each: the cap editor is a live control, and a
   // second copy of it would mean two elements answering to one test id
   // and two inputs writing the same draft.
-  const capEditor = (net: AdminNetwork, field: keyof RowEdit): JSX.Element => (
+  const capEditor = (net: AdminNetwork, field: CapField): JSX.Element => (
     <CapInput
       slug={net.slug}
       field={field}
       value={edits[net.slug]?.[field] ?? ""}
       onInput={(v) => onEditCap(net.slug, field, v)}
+    />
+  );
+
+  // #1760 — the same one-definition-relocated rule as the cap editors:
+  // these are live controls, so the phone card renders the control
+  // itself, never a read-only echo of its value.
+  const visitorToggle = (net: AdminNetwork, field: ToggleField): JSX.Element => (
+    <VisitorToggle
+      slug={net.slug}
+      field={field}
+      checked={edits[net.slug]?.[field] ?? false}
+      // Gated on the DRAFT, not on the server row: an operator who has
+      // just ticked "visitors allowed" should be able to tick
+      // autoconnect in the same edit rather than Save twice.
+      locked={field === "visitor_autoconnect" && !(edits[net.slug]?.visitor_enabled ?? false)}
+      onChange={(v) => onEditToggle(net.slug, field, v)}
+    />
+  );
+
+  const flavorSelect = (net: AdminNetwork): JSX.Element => (
+    <FlavorSelect
+      slug={net.slug}
+      value={edits[net.slug]?.services_flavor ?? ""}
+      onChange={(v) => onEditFlavor(net.slug, v)}
     />
   );
 
@@ -262,12 +333,43 @@ const AdminNetworksTab: Component = () => {
     }
   };
 
-  const onEditCap = (slug: string, field: keyof RowEdit, value: string): void => {
+  const onEditCap = (slug: string, field: CapField, value: string): void => {
     setEdits(
       produce((draft) => {
         const row = draft[slug];
         if (row === undefined) return;
         row[field] = value;
+      }),
+    );
+  };
+
+  // #1760 — `visitor_autoconnect` is a strict SUBSET of `visitor_enabled`
+  // at the admin-intent level: `Networks.list_visitor_autoconnect/0`
+  // returns the raw set and the login/home readers AND it with
+  // `visitor_enabled`, so an autoconnect flag on a network that does not
+  // accept visitors is a benign no-op nobody is told about. Revoking
+  // visitor access therefore clears autoconnect IN THE DRAFT, so the
+  // operator sees the consequence before committing and the one PATCH
+  // carries both keys. Doing this with two fire-immediately toggles
+  // could not work: between the two requests the row would sit at
+  // exactly the stranded pair this exists to prevent.
+  const onEditToggle = (slug: string, field: ToggleField, checked: boolean): void => {
+    setEdits(
+      produce((draft) => {
+        const row = draft[slug];
+        if (row === undefined) return;
+        row[field] = checked;
+        if (field === "visitor_enabled" && !checked) row.visitor_autoconnect = false;
+      }),
+    );
+  };
+
+  const onEditFlavor = (slug: string, value: FlavorDraft): void => {
+    setEdits(
+      produce((draft) => {
+        const row = draft[slug];
+        if (row === undefined) return;
+        row.services_flavor = value;
       }),
     );
   };
@@ -700,9 +802,15 @@ const AdminNetworksTab: Component = () => {
                   <Show when={!isAdminNarrow()}>
                     <th>visitors (live/cap)</th>
                     <th>max visitor sessions</th>
+                    {/* #1760 — the visitor axis reads as one block: how
+                        many are on, how many may be, whether any may be
+                        at all, and whether they arrive unasked. */}
+                    <th>visitors allowed</th>
+                    <th>autoconnect</th>
                     <th>users (live/cap)</th>
                     <th>max user sessions</th>
                     <th>max per ip</th>
+                    <th>services</th>
                     <th>circuit</th>
                   </Show>
                   <th class="adm-table-sticky-actions">actions</th>
@@ -731,11 +839,18 @@ const AdminNetworksTab: Component = () => {
                           <td data-label="max visitors">
                             {capEditor(net, "max_concurrent_visitor_sessions")}
                           </td>
+                          <td data-label="visitors allowed">
+                            {visitorToggle(net, "visitor_enabled")}
+                          </td>
+                          <td data-label="autoconnect">
+                            {visitorToggle(net, "visitor_autoconnect")}
+                          </td>
                           <td data-label="users">{liveCount(net, "users")}</td>
                           <td data-label="max users">
                             {capEditor(net, "max_concurrent_user_sessions")}
                           </td>
                           <td data-label="max per ip">{capEditor(net, "max_per_ip")}</td>
+                          <td data-label="services">{flavorSelect(net)}</td>
                           <td data-label="circuit">
                             <CircuitBadge net={net} />
                           </td>
@@ -802,12 +917,21 @@ const AdminNetworksTab: Component = () => {
                                   label: "max visitor sessions",
                                   value: capEditor(net, "max_concurrent_visitor_sessions"),
                                 },
+                                {
+                                  label: "visitors allowed",
+                                  value: visitorToggle(net, "visitor_enabled"),
+                                },
+                                {
+                                  label: "autoconnect",
+                                  value: visitorToggle(net, "visitor_autoconnect"),
+                                },
                                 { label: "users (live/cap)", value: liveCount(net, "users") },
                                 {
                                   label: "max user sessions",
                                   value: capEditor(net, "max_concurrent_user_sessions"),
                                 },
                                 { label: "max per ip", value: capEditor(net, "max_per_ip") },
+                                { label: "services", value: flavorSelect(net) },
                                 { label: "circuit", value: <CircuitBadge net={net} /> },
                               ]}
                             />
@@ -889,9 +1013,71 @@ const AdminNetworksTab: Component = () => {
   );
 };
 
+// #1760 — `visitor_enabled` / `visitor_autoconnect`. A bare checkbox
+// rather than a labelled `.adm-check`: the column header (desktop) and
+// the `AdminFacts` label (phone) already name it, and a second word in
+// the cell would be the same string twice. The `aria-label` carries the
+// name for assistive tech either way, as `CapInput` does.
+const VisitorToggle: Component<{
+  slug: string;
+  field: ToggleField;
+  checked: boolean;
+  locked: boolean;
+  onChange: (checked: boolean) => void;
+}> = (props) => {
+  const testId = `admin-network-${TOGGLE_TEST_ID_SLUG[props.field]}-${props.slug}`;
+  return (
+    <input
+      type="checkbox"
+      checked={props.checked}
+      disabled={props.locked}
+      onChange={(e) => props.onChange((e.currentTarget as HTMLInputElement).checked)}
+      data-testid={testId}
+      aria-label={`${TOGGLE_LABELS[props.field]} for ${props.slug}`}
+      title={props.locked ? AUTOCONNECT_LOCKED_HINT : undefined}
+    />
+  );
+};
+
+// #1760 — `services_flavor`. Options come from the generated wire SSOT
+// (`NETWORKS_NETWORK_SERVICES_FLAVOR`, mirroring the `Ecto.Enum` values
+// in `network.ex`) so a flavor added server-side cannot leave the pane
+// silently short of one. The leading blank is the schema's nullable
+// "never classified", which the registration wizard treats as
+// `:unknown` — distinct values on the wire, so both stay selectable.
+const FlavorSelect: Component<{
+  slug: string;
+  value: FlavorDraft;
+  onChange: (value: FlavorDraft) => void;
+}> = (props) => {
+  return (
+    <select
+      value={props.value}
+      onChange={(e) => props.onChange(toFlavorDraft((e.currentTarget as HTMLSelectElement).value))}
+      data-testid={`admin-network-services-flavor-${props.slug}`}
+      aria-label={`services flavor for ${props.slug}`}
+    >
+      <option value="">unclassified</option>
+      <For each={NETWORKS_NETWORK_SERVICES_FLAVOR}>
+        {(flavor) => <option value={flavor}>{flavor}</option>}
+      </For>
+    </select>
+  );
+};
+
+// A `<select>` can only emit one of its own option values, so the else
+// arm IS the blank option and not a swallowed unknown. It exists because
+// the DOM types the event value as `string` and the draft is a closed
+// set — narrowing at the boundary rather than casting through it.
+function toFlavorDraft(raw: string): FlavorDraft {
+  return (NETWORKS_NETWORK_SERVICES_FLAVOR as readonly string[]).includes(raw)
+    ? (raw as NetworksNetworkServicesFlavor)
+    : "";
+}
+
 const CapInput: Component<{
   slug: string;
-  field: keyof RowEdit;
+  field: CapField;
   value: string;
   onInput: (value: string) => void;
 }> = (props) => {
@@ -991,6 +1177,20 @@ function buildPatchBody(net: AdminNetwork, edit: RowEdit): AdminNetworkSettingsP
   }
   if (perIp.value !== net.max_per_ip) {
     body.max_per_ip = perIp.value;
+  }
+  if (edit.visitor_enabled !== net.visitor_enabled) {
+    body.visitor_enabled = edit.visitor_enabled;
+  }
+  if (edit.visitor_autoconnect !== net.visitor_autoconnect) {
+    body.visitor_autoconnect = edit.visitor_autoconnect;
+  }
+  // `""` is the operator choosing "unclassified", which is
+  // `services_flavor: null` on the wire — a value to SEND, not a key to
+  // omit. Omitting it would make clearing a flavor impossible, since
+  // unsupplied keys keep their current value.
+  const flavor = edit.services_flavor === "" ? null : edit.services_flavor;
+  if (flavor !== net.services_flavor) {
+    body.services_flavor = flavor;
   }
   return body;
 }

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -135,7 +135,7 @@ function cellActions(
 
 function renderCap(cap: number | null): string {
   // Mirrors the AdminNetworksTab cap-cell convention: `null` is the
-  // "unlimited" sentinel per `Networks.update_network_caps/2`.
+  // "unlimited" sentinel per `Networks.update_network_settings/2`.
   return cap === null ? "∞" : String(cap);
 }
 

--- a/cicchetto/src/__tests__/AdminNetworksTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminNetworksTab.test.tsx
@@ -12,7 +12,7 @@ vi.mock("../lib/api", async () => {
   return {
     ...actual,
     adminListNetworks: vi.fn(),
-    adminPatchNetworkCaps: vi.fn(),
+    adminPatchNetworkSettings: vi.fn(),
     adminRunReaper: vi.fn(),
     adminResetCircuit: vi.fn(),
     adminCreateNetwork: vi.fn(),
@@ -225,7 +225,7 @@ describe("AdminNetworksTab", () => {
     vi.mocked(api.adminListNetworks)
       .mockResolvedValueOnce([BAHAMUT])
       .mockResolvedValueOnce([{ ...BAHAMUT, max_concurrent_visitor_sessions: 200 }]);
-    vi.mocked(api.adminPatchNetworkCaps).mockResolvedValue({
+    vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
       ...BAHAMUT,
       max_concurrent_visitor_sessions: 200,
     });
@@ -243,7 +243,7 @@ describe("AdminNetworksTab", () => {
     // the operator didn't touch it (CRIT-1 of M-10 review — sending
     // the unchanged value would lose concurrent edits to that field).
     await waitFor(() => {
-      expect(api.adminPatchNetworkCaps).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
+      expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
         max_concurrent_visitor_sessions: 200,
       });
     });
@@ -260,7 +260,7 @@ describe("AdminNetworksTab", () => {
     vi.mocked(api.adminListNetworks)
       .mockResolvedValueOnce([BAHAMUT])
       .mockResolvedValueOnce([{ ...BAHAMUT, max_concurrent_visitor_sessions: 200, max_per_ip: 9 }]);
-    vi.mocked(api.adminPatchNetworkCaps).mockResolvedValue({
+    vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
       ...BAHAMUT,
       max_concurrent_visitor_sessions: 200,
       max_per_ip: 9,
@@ -278,7 +278,7 @@ describe("AdminNetworksTab", () => {
     fireEvent.input(perIpInput, { target: { value: "9" } });
     fireEvent.click(screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`));
     await waitFor(() => {
-      expect(api.adminPatchNetworkCaps).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
+      expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
         max_concurrent_visitor_sessions: 200,
         max_per_ip: 9,
       });
@@ -290,7 +290,7 @@ describe("AdminNetworksTab", () => {
     vi.mocked(api.adminListNetworks)
       .mockResolvedValueOnce([BAHAMUT])
       .mockResolvedValueOnce([{ ...BAHAMUT, max_concurrent_visitor_sessions: null }]);
-    vi.mocked(api.adminPatchNetworkCaps).mockResolvedValue({
+    vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
       ...BAHAMUT,
       max_concurrent_visitor_sessions: null,
     });
@@ -303,7 +303,7 @@ describe("AdminNetworksTab", () => {
     fireEvent.input(sessionsInput, { target: { value: "" } });
     fireEvent.click(screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`));
     await waitFor(() => {
-      expect(api.adminPatchNetworkCaps).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
+      expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
         max_concurrent_visitor_sessions: null,
       });
     });
@@ -322,7 +322,7 @@ describe("AdminNetworksTab", () => {
     const save = screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`) as HTMLButtonElement;
     expect(save.disabled).toBe(true);
     expect(sessionsInput.getAttribute("aria-invalid")).toBe("true");
-    expect(api.adminPatchNetworkCaps).not.toHaveBeenCalled();
+    expect(api.adminPatchNetworkSettings).not.toHaveBeenCalled();
   });
 
   it("rejects out-of-range (> MAX_CAP) input client-side", async () => {
@@ -345,7 +345,7 @@ describe("AdminNetworksTab", () => {
   it("PATCH error surfaces with verb-only prefix and preserves the operator's typed value", async () => {
     const api = await import("../lib/api");
     vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
-    vi.mocked(api.adminPatchNetworkCaps).mockRejectedValue(
+    vi.mocked(api.adminPatchNetworkSettings).mockRejectedValue(
       new api.ApiError(422, "validation_failed"),
     );
 

--- a/cicchetto/src/__tests__/AdminNetworksTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminNetworksTab.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import type { Channel } from "phoenix";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AdminNetwork, WireAdminEvent } from "../lib/api";
+import { NETWORKS_NETWORK_SERVICES_FLAVOR } from "../lib/wireTypes";
 
 vi.mock("../lib/auth", () => ({
   token: () => "test-bearer",
@@ -825,6 +826,261 @@ describe("AdminNetworksTab", () => {
       fireEvent.click(delBtn);
       await waitFor(() => {
         expect(api.adminDeleteFeaturedChannel).toHaveBeenCalledWith("test-bearer", BAHAMUT.id, 1);
+      });
+    });
+  });
+
+  // #1760 — the three settings the backend has whitelisted since #211
+  // phase 3 but the pane could not reach. They ride the SAME draft +
+  // per-row Save as the caps (one dirty check, one PATCH, only the
+  // changed keys), not the fire-immediately toggle the servers and
+  // featured sub-tables use. That is not stylistic: `visitor_autoconnect`
+  // has a documented ordering hazard against `visitor_enabled`, and only
+  // a single PATCH carrying both can flip them without the incoherent
+  // pair ever being written.
+  describe("visitor allowlist + services flavor (#1760)", () => {
+    const VISITOR_ON: AdminNetwork = {
+      ...BAHAMUT,
+      id: 9,
+      slug: "visitor-on",
+      services_flavor: "azzurra",
+      visitor_enabled: true,
+      visitor_autoconnect: true,
+    };
+
+    it("seeds the two toggles and the flavor select from the server row", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([VISITOR_ON, BAHAMUT]);
+
+      render(() => <AdminNetworksTab />);
+
+      const on = (await screen.findByTestId(
+        `admin-network-visitor-enabled-${VISITOR_ON.slug}`,
+      )) as HTMLInputElement;
+      expect(on.checked).toBe(true);
+      const auto = screen.getByTestId(
+        `admin-network-visitor-autoconnect-${VISITOR_ON.slug}`,
+      ) as HTMLInputElement;
+      expect(auto.checked).toBe(true);
+      const flavor = screen.getByTestId(
+        `admin-network-services-flavor-${VISITOR_ON.slug}`,
+      ) as HTMLSelectElement;
+      expect(flavor.value).toBe("azzurra");
+
+      // A default row: both false, flavor unclassified (null → "").
+      const off = screen.getByTestId(
+        `admin-network-visitor-enabled-${BAHAMUT.slug}`,
+      ) as HTMLInputElement;
+      expect(off.checked).toBe(false);
+      const offFlavor = screen.getByTestId(
+        `admin-network-services-flavor-${BAHAMUT.slug}`,
+      ) as HTMLSelectElement;
+      expect(offFlavor.value).toBe("");
+    });
+
+    it("offers every wire flavor plus the unclassified blank, from the generated SSOT", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
+
+      render(() => <AdminNetworksTab />);
+
+      const flavor = (await screen.findByTestId(
+        `admin-network-services-flavor-${BAHAMUT.slug}`,
+      )) as HTMLSelectElement;
+      const values = Array.from(flavor.options).map((o) => o.value);
+      // The blank is `services_flavor: null` — a real, distinct wire value
+      // (`network.ex`: nullable, "never classified"), not a placeholder.
+      expect(values).toEqual(["", ...NETWORKS_NETWORK_SERVICES_FLAVOR]);
+    });
+
+    it("ticking visitor_enabled enables Save and PATCHes ONLY that key", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks)
+        .mockResolvedValueOnce([BAHAMUT])
+        .mockResolvedValueOnce([{ ...BAHAMUT, visitor_enabled: true }]);
+      vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
+        ...BAHAMUT,
+        visitor_enabled: true,
+      });
+
+      render(() => <AdminNetworksTab />);
+
+      const toggle = (await screen.findByTestId(
+        `admin-network-visitor-enabled-${BAHAMUT.slug}`,
+      )) as HTMLInputElement;
+      const save = screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`) as HTMLButtonElement;
+      expect(save.disabled).toBe(true);
+
+      fireEvent.click(toggle);
+      expect(save.disabled).toBe(false);
+      fireEvent.click(save);
+
+      await waitFor(() => {
+        expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
+          visitor_enabled: true,
+        });
+      });
+      await waitFor(() => {
+        const post = screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`) as HTMLButtonElement;
+        expect(post.disabled).toBe(true);
+      });
+    });
+
+    it("choosing a flavor PATCHes it; choosing the blank PATCHes null", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
+      vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
+        ...BAHAMUT,
+        services_flavor: "atheme",
+      });
+
+      render(() => <AdminNetworksTab />);
+
+      const flavor = (await screen.findByTestId(
+        `admin-network-services-flavor-${BAHAMUT.slug}`,
+      )) as HTMLSelectElement;
+      fireEvent.change(flavor, { target: { value: "atheme" } });
+      fireEvent.click(screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`));
+
+      await waitFor(() => {
+        expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
+          services_flavor: "atheme",
+        });
+      });
+    });
+
+    it("clearing an existing flavor back to unclassified PATCHes services_flavor null", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([VISITOR_ON]);
+      vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
+        ...VISITOR_ON,
+        services_flavor: null,
+      });
+
+      render(() => <AdminNetworksTab />);
+
+      const flavor = (await screen.findByTestId(
+        `admin-network-services-flavor-${VISITOR_ON.slug}`,
+      )) as HTMLSelectElement;
+      fireEvent.change(flavor, { target: { value: "" } });
+      fireEvent.click(screen.getByTestId(`admin-network-save-${VISITOR_ON.slug}`));
+
+      await waitFor(() => {
+        expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", VISITOR_ON.slug, {
+          services_flavor: null,
+        });
+      });
+    });
+
+    // The invariant, half one: autoconnect is a SUBSET of enabled
+    // (`networks.ex` `list_visitor_autoconnect/0` — the login filter ANDs
+    // the two and drops the odd pair as a no-op). Arming the subset while
+    // the superset is off is not an error the server reports, it is a
+    // silent nothing — so the control must not be reachable.
+    it("cannot arm autoconnect on a network that does not accept visitors", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
+
+      render(() => <AdminNetworksTab />);
+
+      const auto = (await screen.findByTestId(
+        `admin-network-visitor-autoconnect-${BAHAMUT.slug}`,
+      )) as HTMLInputElement;
+      expect(auto.disabled).toBe(true);
+
+      // Ticking visitor_enabled in the DRAFT — before any Save — is
+      // enough to unlock it. Requiring a round-trip first would make
+      // "enable a network and auto-connect it" a two-Save chore.
+      fireEvent.click(screen.getByTestId(`admin-network-visitor-enabled-${BAHAMUT.slug}`));
+      expect(auto.disabled).toBe(false);
+    });
+
+    // The invariant, half two: revoking the superset must take the subset
+    // with it, in the SAME body. Sending `visitor_enabled: false` alone
+    // would leave `visitor_autoconnect: true` behind in the row — exactly
+    // the stranded pair, reachable by one careless click.
+    it("revoking visitor access clears autoconnect in the same PATCH", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([VISITOR_ON]);
+      vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
+        ...VISITOR_ON,
+        visitor_enabled: false,
+        visitor_autoconnect: false,
+      });
+
+      render(() => <AdminNetworksTab />);
+
+      const enabled = (await screen.findByTestId(
+        `admin-network-visitor-enabled-${VISITOR_ON.slug}`,
+      )) as HTMLInputElement;
+      const auto = screen.getByTestId(
+        `admin-network-visitor-autoconnect-${VISITOR_ON.slug}`,
+      ) as HTMLInputElement;
+      expect(auto.checked).toBe(true);
+
+      fireEvent.click(enabled);
+
+      // Visibly cleared, not merely dropped from the body on the way out —
+      // the operator has to SEE what their click did before they commit it.
+      expect(auto.checked).toBe(false);
+      expect(auto.disabled).toBe(true);
+
+      fireEvent.click(screen.getByTestId(`admin-network-save-${VISITOR_ON.slug}`));
+      await waitFor(() => {
+        expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", VISITOR_ON.slug, {
+          visitor_enabled: false,
+          visitor_autoconnect: false,
+        });
+      });
+    });
+
+    it("carries a cap edit and a toggle in one body when both are dirty", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
+      vi.mocked(api.adminPatchNetworkSettings).mockResolvedValue({
+        ...BAHAMUT,
+        visitor_enabled: true,
+        max_per_ip: 9,
+      });
+
+      render(() => <AdminNetworksTab />);
+
+      const perIp = (await screen.findByTestId(
+        `admin-network-max-per-ip-${BAHAMUT.slug}`,
+      )) as HTMLInputElement;
+      fireEvent.input(perIp, { target: { value: "9" } });
+      fireEvent.click(screen.getByTestId(`admin-network-visitor-enabled-${BAHAMUT.slug}`));
+      fireEvent.click(screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`));
+
+      await waitFor(() => {
+        expect(api.adminPatchNetworkSettings).toHaveBeenCalledWith("test-bearer", BAHAMUT.slug, {
+          visitor_enabled: true,
+          max_per_ip: 9,
+        });
+      });
+    });
+
+    it("refresh discards a toggle draft the operator never saved", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
+
+      render(() => <AdminNetworksTab />);
+
+      const toggle = (await screen.findByTestId(
+        `admin-network-visitor-enabled-${BAHAMUT.slug}`,
+      )) as HTMLInputElement;
+      fireEvent.click(toggle);
+      expect(toggle.checked).toBe(true);
+
+      fireEvent.click(screen.getByTestId("admin-networks-refresh"));
+      await waitFor(() => {
+        expect(api.adminListNetworks).toHaveBeenCalledTimes(2);
+      });
+      await waitFor(() => {
+        const post = screen.getByTestId(
+          `admin-network-visitor-enabled-${BAHAMUT.slug}`,
+        ) as HTMLInputElement;
+        expect(post.checked).toBe(false);
       });
     });
   });

--- a/cicchetto/src/__tests__/adminCardRegime.test.tsx
+++ b/cicchetto/src/__tests__/adminCardRegime.test.tsx
@@ -46,7 +46,7 @@ vi.mock("../lib/api", async () => {
     adminUpdateUserPassword: vi.fn(),
     adminDeleteUser: vi.fn(),
     adminListNetworks: vi.fn(),
-    adminPatchNetworkCaps: vi.fn(),
+    adminPatchNetworkSettings: vi.fn(),
     adminRunReaper: vi.fn(),
     adminResetCircuit: vi.fn(),
     adminCreateNetwork: vi.fn(),

--- a/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
+++ b/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../lib/api", async () => {
     adminUpdateUserPassword: vi.fn(),
     adminDeleteUser: vi.fn(),
     adminListNetworks: vi.fn(),
-    adminPatchNetworkCaps: vi.fn(),
+    adminPatchNetworkSettings: vi.fn(),
     adminRunReaper: vi.fn(),
     adminResetCircuit: vi.fn(),
     adminCreateNetwork: vi.fn(),

--- a/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
+++ b/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
@@ -193,6 +193,13 @@ describe("#1074 — Networks drops its secondary columns on a phone", () => {
       `admin-network-circuit-${BAHAMUT.slug}`,
       `admin-network-live-visitors-${BAHAMUT.slug}`,
       `admin-network-live-users-${BAHAMUT.slug}`,
+      // #1760 — the three settings that decide whether a network is
+      // usable at all follow the caps into the card. A control an
+      // operator can only reach on a desktop is a control the operator
+      // holding a phone does not have.
+      `admin-network-visitor-enabled-${BAHAMUT.slug}`,
+      `admin-network-visitor-autoconnect-${BAHAMUT.slug}`,
+      `admin-network-services-flavor-${BAHAMUT.slug}`,
     ]) {
       expect(panel.contains(screen.getByTestId(testId)), testId).toBe(true);
     }

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1983,7 +1983,7 @@ export async function adminListSessionLogSessions(
 // `circuit_state` from `Grappa.Admission.NetworkCircuit.AdminWire.t()`
 // (controller composition in `lib/grappa_web/controllers/admin/networks_controller.ex`).
 //
-// Three-valued cap contract per `Networks.update_network_caps/2`:
+// Three-valued cap contract per `Networks.update_network_settings/2`:
 //   * `null` — explicit "unlimited" (operator-cleared)
 //   * `0`    — degenerate lock-down ("allow none")
 //   * `N>0`  — the cap itself
@@ -2023,16 +2023,22 @@ export type AdminNetwork = NetworksAdminWireT & {
 
 export type AdminNetworksResponse = { networks: AdminNetwork[] };
 
-// PATCH body is keys-optional per `Networks.update_network_caps/2`'s
-// `%{optional(:max_concurrent_visitor_sessions) => ...,
-// optional(:max_concurrent_user_sessions) => ...,
-// optional(:max_per_ip) => ...}` contract: unsupplied keys keep
-// their current value. Cic MUST only include keys whose value
-// actually changed vs the server-echoed row — sending all keys on
-// every edit creates a lost-update race (operator A's Save would
-// silently roll back operator B's concurrently-saved change to the
-// OTHER cap). CRIT-1 of M-10 review.
-export type AdminNetworkCapsPatch = {
+// PATCH body is keys-optional per `Networks.update_network_settings/2`'s
+// contract: unsupplied keys keep their current value. Cic MUST only
+// include keys whose value actually changed vs the server-echoed row —
+// sending all keys on every edit creates a lost-update race (operator A's
+// Save would silently roll back operator B's concurrently-saved change to
+// another key). CRIT-1 of M-10 review.
+//
+// The six keys mirror `NetworksController.settings_attrs/1`'s whitelist
+// exactly. It was named `AdminNetworkCapsPatch` while cic could only
+// reach the three caps; #1760 added the other three, and "caps" stopped
+// being true of the shape — the server has called the verb
+// `update_network_settings/2` since #211 phase 3.
+export type AdminNetworkSettingsPatch = {
+  services_flavor?: NetworksNetworkServicesFlavor | null;
+  visitor_enabled?: boolean;
+  visitor_autoconnect?: boolean;
   max_concurrent_visitor_sessions?: number | null;
   max_concurrent_user_sessions?: number | null;
   max_per_ip?: number | null;
@@ -2045,10 +2051,10 @@ export async function adminListNetworks(token: string): Promise<AdminNetwork[]> 
   return body.networks;
 }
 
-export async function adminPatchNetworkCaps(
+export async function adminPatchNetworkSettings(
   token: string,
   slug: string,
-  body: AdminNetworkCapsPatch,
+  body: AdminNetworkSettingsPatch,
 ): Promise<AdminNetwork> {
   const res = await fetch(`/admin/networks/${encodeURIComponent(slug)}`, {
     method: "PATCH",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62548,3 +62548,84 @@ layer instead.
 states, not the two production deaths. A VM-wide stall of the kind #1715
 describes is outside what an in-process ExUnit harness can construct, and it
 was not constructed. Those two `:ping_timeout` deaths remain unexplained.
+<!-- entry #1760 -->
+
+---
+
+## 2026-08-25 — #1760: a silent AND on the server is a single write on the client
+
+The admin networks pane could edit three of the six keys
+`PATCH /admin/networks/:slug` has whitelisted since #211 phase 3, and the three
+it could not reach were the ones that decide whether a network is usable:
+`visitor_enabled`, `visitor_autoconnect`, `services_flavor`. `rizon` was added
+from the panel on 2026-08-24 and finished with a hand-written `UPDATE` against
+`runtime/grappa_prod.db`, because `networks.visitor_enabled` defaults to false
+and `Networks.list_visitor_enabled/0` is the sole allowlist gate.
+
+**Measured before building, because it decides the class of the deploy.** The
+issue asserted "the wire contract exists; no backend change needed" and it is
+true, but it was checked rather than taken: `settings_attrs/1` whitelists all
+six, `Network.changeset/2` casts all six, `Networks.AdminWire` projects all
+six, and the generated `wireTypes.ts` already carries them. Cic-only, no BEAM
+file touched, hot-deployable.
+
+### The rule: a subset the server enforces as a silent AND must be written once
+
+`visitor_autoconnect` is a strict subset of `visitor_enabled` at the
+admin-intent level — the login and home readers intersect the two, so
+autoconnect on a network that accepts no visitors is a benign no-op. Benign is
+the problem. There is **no error and no effect**, so nothing downstream can
+tell an operator they have armed a flag that does nothing, and the flag stays
+armed until somebody re-enables the network months later and gets an
+auto-connect nobody asked for.
+
+That is what forced the interaction shape, rather than taste. The pane's other
+booleans (server TLS, featured-channel enabled) are fire-immediately toggles,
+and **two of those could not express this invariant at all**: whichever request
+goes first, the row sits at the stranded pair until the second lands, and a
+failure in between makes it permanent. So the three new controls join the
+caps' draft-and-Save instead: revoking visitor access clears autoconnect **in
+the draft**, visibly, and one PATCH carries both keys. The incoherent row is
+never written, not merely corrected quickly.
+
+The lock is gated on the DRAFT's `visitor_enabled`, not on the server row —
+gating on the row would make "allow visitors and autoconnect them" a two-Save
+chore for no gain, since nothing is persisted until Save either way.
+
+**Generalise it as:** when two persisted flags have a subset relation that the
+server resolves by intersecting at READ time, the client owns the coherence,
+and it can only own it with a single write. Look for the same shape wherever a
+reader ANDs two columns and the writer does not.
+
+### The e2e oracle is the downstream projection, not the control
+
+A checkbox that renders passes "the control exists"; a checkbox whose PATCH
+lands passes "the input is checked". Neither would have failed against the bug
+this issue is about, which is that the network stays unreachable. The spec
+therefore reads `GET /me`'s `home_data.available_networks` — the server's own
+`list_visitor_enabled/0` minus attached — and asserts the slug ABSENT before
+the click and PRESENT after. The pane agreeing with itself is checked too, and
+is explicitly labelled as necessary and nowhere near sufficient.
+
+### Two smaller things
+
+`AdminNetworkCapsPatch` / `adminPatchNetworkCaps` were renamed to
+`…SettingsPatch` / `adminPatchNetworkSettings`, in their own commit ahead of
+the feature. The trigger is worth stating as a rule: **the name was accurate
+until this change made it false, and a name falsified by a change belongs to
+that change** — leaving it would have created the misnomer, not inherited one.
+Three comments citing `Networks.update_network_caps/2`, a function no longer
+exported under that name anywhere in `lib/`, were corrected in the same commit.
+
+The flavor `<select>` builds its options from
+`NETWORKS_NETWORK_SERVICES_FLAVOR`, the generated wire SSOT, so a fifth flavor
+added server-side cannot leave the pane silently four-valued. Its blank option
+is `services_flavor: null` — the schema's nullable "never classified", a real
+wire value distinct from `:unknown` — and it is SENT rather than omitted:
+unsupplied keys keep their current value, so an omitted blank would make a
+wrong flavor permanent.
+
+**Left undecided, deliberately.** The issue asks whether the create form
+should request `visitor_enabled` up front so a network is never born in a
+state the panel cannot leave. That is a product call, it is vjt's, and it is
+not built here.


### PR DESCRIPTION
Refs #1760.

The admin networks pane could edit three of the six keys `PATCH
/admin/networks/:slug` has whitelisted since #211 phase 3, and the three it
could not reach are the ones that decide whether a network is usable at all.
`networks.visitor_enabled` defaults to false and `Networks.list_visitor_enabled/0`
is the sole allowlist gate, so a network created from the panel was born
invisible to visitors with no control to change that — `rizon` was added on
2026-08-24 and finished with a hand-written `UPDATE` against
`runtime/grappa_prod.db`.

## Verified, not assumed: this is cic-only

The issue says "the wire contract exists; no backend change needed". True, and
checked rather than taken, because it decides hot vs cold:

- `NetworksController.settings_attrs/1` whitelists all six keys
- `Network.changeset/2` casts all six
- `Networks.AdminWire.network_to_admin_json/1` projects all six
- the generated `cicchetto/src/lib/wireTypes.ts` already carries them

`git diff --name-only origin/main...HEAD` touches nothing outside `cicchetto/`
and `docs/`. No BEAM file, hot-deployable.

## The invariant forced the interaction shape

`visitor_autoconnect` is a strict subset of `visitor_enabled`: the login and
home readers intersect the two, so autoconnect on a network that accepts no
visitors is a benign no-op. Benign is the problem — **no error and no effect**,
so nothing tells the operator they armed a flag that does nothing, and it stays
armed until somebody re-enables the network later and gets an auto-connect
nobody asked for.

The pane's other booleans (server TLS, featured-channel enabled) are
fire-immediately toggles, and **two of those could not express this at all**:
whichever request goes first, the row sits at the stranded pair until the
second lands, and a failure in between makes it permanent. So the three new
controls join the caps' draft-and-Save. Revoking visitor access clears
autoconnect **in the draft**, visibly, and one PATCH carries both keys — the
incoherent row is never written rather than corrected quickly.

The lock is gated on the DRAFT's `visitor_enabled`, not the server row:
gating on the row would make "allow visitors and autoconnect them" a two-Save
chore for nothing, since neither is persisted until Save.

Placement follows the file's own one-definition-relocated rule — the controls
live in the row on desktop and move into the phone card via `AdminFacts`, never
a live control in one place and a read-only echo in the other.
`NETWORK_COLUMNS` 8 → 11.

Flavor options come from `NETWORKS_NETWORK_SERVICES_FLAVOR`, the generated wire
SSOT, so a fifth flavor added server-side cannot leave the pane silently
four-valued. Its blank option is `services_flavor: null` and is SENT, not
omitted: unsupplied keys keep their value, so an omitted blank would make a
wrong flavor permanent.

## Tests assert the effect, not the control

A checkbox that renders passes "the control exists"; one whose PATCH lands
passes "the input is checked". Neither fails against this bug, which is that
the network stays unreachable. The e2e oracle is therefore `GET /me`'s
`home_data.available_networks` — the server's own `list_visitor_enabled/0`
minus attached — asserted ABSENT before the click and PRESENT after.

Measured, in order:

| gate | before | after |
|---|---|---|
| the two vitest suites, at the test commit | **10 failed / 33 passed** | 43 passed |
| `bun run test` | 6156 passed | **6165** passed (+9) |
| `bun run check` | 4/4 | 4/4 |
| `design-notes-gate.sh` | — | `1 new entry heading(s), separator and marker present.` |
| `scripts/integration.sh` (full) | — | **776 passed, 2 failed** — see below |

## The two integration reds are not this branch, and here is the measurement

`cursor-forward-only.spec.ts:305` and `issue887-focused-unread-badge.spec.ts:81`.
Both die in the `loginAs` fixture's 5 s user-topic barrier, before either
spec's own body runs, with an identical socket health readout
(`state: "connecting"`, `connectAttempts: 1`, zero errors).

The fixture's diagnostic says to read the server log rather than the spec, so
that is what was read. `grappa-test.log` has **780** `CONNECTED TO
GrappaWeb.UserSocket` lines: 778 completed in ≤ 3.6 s, and exactly **two took
33040 ms and 33047 ms** — the 33.4 s and 33.6 s of the two failures. The stall
is server-side, in the WS upgrade. One of the two is immediately preceded by
`record_client_source: db unavailable persisting client prefix — dropped
(best-effort)`. The two are 18 minutes apart, so two separate events.

Iso-rerun on this branch, `--project chromium --repeat-each 3`: **6/6 passed**,
2.0–3.4 s each. Combined with the diff carrying no BEAM file, the reds are not
attributable here.

**Attributed after the fact, and not by me:** the orchestrator identifies both
as #1618 — WS upgrade behind a droppable write — already measured there at
31575 ms, making these 33040/33047 a second occurrence. A main-only rerun came
back green. That issue is theirs and already commented on; nothing is filed
from here.

What this branch established on its own stops short of that: the stall is
server-side and in the upgrade, it is not reproducible here (6/6, 2.0-3.4 s),
and the diff carries no BEAM file. The mechanism was deliberately left
unnamed — 33 s sits near but above the 30 000 ms `busy_timeout` anchor of the
#1715 / #1420 entries, and there is a `db unavailable` line correlated with one
of the two events and nothing for the other, which is a pointer and not a
diagnosis. #1618 is the answer to it, arrived at with evidence I did not have.

## The open question is left open

The issue asks whether the create form should request `visitor_enabled` up
front. **Not built — it is a product call.**

For whoever decides: I would add it as an unchecked checkbox on the create
form rather than defaulting it on. The reason is that it is the only choice
that changes nothing for an operator who ignores it — the row is still born
`false`, exactly as today — while removing the surprise for the one who reads
the form, which is where the cost of this bug actually landed. Defaulting it on
would flip a security-shaped default ("play safe", vjt 2026-07-11) for a
convenience, and leaving the form alone is now merely a second click rather
than a DB edit, so the pressure to act is much lower than before this PR.
