### PR TITLE
cic: read .txt and .md inline as source, with line numbers (#1764)

### DIFF
--- a/cicchetto/e2e/tests/issue1764-text-source-viewer.spec.ts
+++ b/cicchetto/e2e/tests/issue1764-text-source-viewer.spec.ts
@@ -76,11 +76,21 @@ test("#1764 — a .txt upload opens as readable source with line numbers, and a 
   const source = viewer.getByTestId("media-viewer-text-source");
   const gutter = viewer.getByTestId("media-viewer-text-gutter");
 
-  // Read the CONTENT — every line, in order, as one block.
-  await expect(source).toHaveText(TXT_LINES.join("\n"), { timeout: 10_000 });
+  // 🔴 `textContent` through `expect.poll`, NOT `toHaveText`. Playwright
+  // NORMALIZES whitespace for that matcher, which collapses every newline to a
+  // space — so a viewer that rendered four lines as one run-on paragraph would
+  // pass it, and so would one that lost the gutter's line breaks. Line
+  // structure is the entire subject here, so the assertion has to see the raw
+  // characters. `poll` keeps the retry the matcher would have given.
+  await expect
+    .poll(() => source.textContent(), {
+      message: "the uploaded lines must be on screen, in order, as source",
+      timeout: 10_000,
+    })
+    .toBe(TXT_LINES.join("\n"));
   // …and the numbers are really there, one per line and no phantom for the
   // file's trailing newline.
-  await expect(gutter).toHaveText("1\n2\n3\n4");
+  await expect.poll(() => gutter.textContent()).toBe("1\n2\n3\n4");
 
   // Not a rendered document: the source element is a <pre>.
   expect(await source.evaluate((el) => el.tagName)).toBe("PRE");
@@ -107,8 +117,17 @@ test("#1764 — a .txt upload opens as readable source with line numbers, and a 
 
   const mdViewer = await openMediaViewer(page, mdRow.link);
   const mdSource = mdViewer.getByTestId("media-viewer-text-source");
-  await expect(mdSource).toHaveText(MD_LINES.join("\n"), { timeout: 10_000 });
-  await expect(mdViewer.getByTestId("media-viewer-text-gutter")).toHaveText("1\n2\n3");
+  // Raw characters again, and here it matters twice over: MD_LINES carries a
+  // BLANK line, which whitespace normalisation would erase outright.
+  await expect
+    .poll(() => mdSource.textContent(), {
+      message: "markdown must arrive as its own source, blank line included",
+      timeout: 10_000,
+    })
+    .toBe(MD_LINES.join("\n"));
+  await expect
+    .poll(() => mdViewer.getByTestId("media-viewer-text-gutter").textContent())
+    .toBe("1\n2\n3");
 
   // The three shapes a renderer would have produced. Asserted on generated
   // HTML rather than on looks: cic has no sanitisation surface anywhere today,

--- a/cicchetto/e2e/tests/issue1764-text-source-viewer.spec.ts
+++ b/cicchetto/e2e/tests/issue1764-text-source-viewer.spec.ts
@@ -1,0 +1,123 @@
+// #1764 — `.txt` and `.md` open in the media-viewer modal and are READ inline:
+// monospace source, line numbers, nothing rendered.
+//
+// This asserts the VISIBLE OUTCOME, not the plumbing: that the words in the
+// uploaded file are on screen and that the gutter numbers them. A spec that
+// only proved "the modal exists" or "a function was called" would stay green
+// through a viewer that opens empty, which is precisely the failure mode the
+// CSP note below describes.
+//
+// ## Why the full upload vertical, and not a composed URL
+//
+// The text arm is the only viewer kind that FETCHES its bytes instead of
+// pointing an element at them, so it answers to `connect-src` — `'self'` plus
+// the captcha hosts and api.somafm.com, and deliberately NOT widened to
+// `https:` the way `img-src`/`media-src` are. Running the real journey means
+// the fetch crosses the e2e dumb proxy under the REAL prod CSP (the BEAM emits
+// it via GrappaWeb.Plugs.SecurityHeaders; #485, pinned by
+// nginx-csp-range-parity.spec.ts) with the `_cspGuard` fixture failing the spec
+// on any `securitypolicyviolation`. Text on screen therefore proves BOTH that
+// the bytes came back through the proxy AND that the policy admitted the read.
+//
+// It also exercises the `Range: bytes=0-…` request the viewer sends: the
+// upload controller answers it with a 206 (`GrappaWeb.ByteRange`), and the
+// viewer has to be as happy with a 206 as with a 200.
+//
+// ## Two phases, ONE journey each, in one test
+//
+// workers: 1 — a second `test()` is a second login + channel select for no
+// coverage (the media-link-modal-viewer load-states precedent). The `.md`
+// phase is not a duplicate of the `.txt` one: it is the phase that proves
+// vjt's ruling ("nono nessun rendering di gesu, assolutamente solo il sorgente
+// txt e md", #sbiffo 2026-08-24) survives contact with real markdown.
+
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { closeMediaViewer, openMediaViewer } from "../fixtures/mediaViewer";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+const TXT_LINES = ["alpha one", "beta two", "gamma three", "delta four"];
+// Real markdown, so "shown as source" is a claim about something a renderer
+// would visibly have eaten.
+const MD_LINES = ["# Release notes", "", "**bold** and [a link](https://example.com)"];
+
+test("#1764 — a .txt upload opens as readable source with line numbers, and a .md stays source", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  // ---- Phase 1: .txt — the bytes are on screen and the gutter counts them.
+  const txt = await uploadViaPicker(
+    page,
+    {
+      name: "issue1764.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from(`${TXT_LINES.join("\n")}\n`, "utf8"),
+    },
+    { postTimeout: 10_000 },
+  );
+  expect(txt.url).toMatch(new RegExp(`/uploads/${txt.slug}\\.txt$`));
+
+  const txtRow = await mediaScrollbackRow(page, "📄", txt.slug);
+  // The reversal itself: before #1764 a `.txt` anchor carried no media class
+  // and the click never reached the viewer (issue418's spec pinned exactly
+  // that, and is rewritten in this change).
+  await expect(txtRow.link).toHaveClass(/scrollback-media-link/);
+
+  const cicUrl = page.url();
+  const viewer = await openMediaViewer(page, txtRow.link);
+  expect(page.url()).toBe(cicUrl);
+
+  const source = viewer.getByTestId("media-viewer-text-source");
+  const gutter = viewer.getByTestId("media-viewer-text-gutter");
+
+  // Read the CONTENT — every line, in order, as one block.
+  await expect(source).toHaveText(TXT_LINES.join("\n"), { timeout: 10_000 });
+  // …and the numbers are really there, one per line and no phantom for the
+  // file's trailing newline.
+  await expect(gutter).toHaveText("1\n2\n3\n4");
+
+  // Not a rendered document: the source element is a <pre>.
+  expect(await source.evaluate((el) => el.tagName)).toBe("PRE");
+
+  await closeMediaViewer(viewer);
+
+  // ---- Phase 2: .md — same pane, and markdown is still markdown.
+  const md = await uploadViaPicker(
+    page,
+    {
+      name: "issue1764.md",
+      mimeType: "text/markdown",
+      buffer: Buffer.from(`${MD_LINES.join("\n")}\n`, "utf8"),
+    },
+    { postTimeout: 10_000 },
+  );
+  // The server minted the extension, which is the whole type signal the
+  // classifier keys off (#418). A `.md` could not exist at all before this
+  // change: text/markdown was in neither the accept-allowlist nor MimeExt.
+  expect(md.url).toMatch(new RegExp(`/uploads/${md.slug}\\.md$`));
+
+  const mdRow = await mediaScrollbackRow(page, "📄", md.slug);
+  await expect(mdRow.link).toHaveClass(/scrollback-media-link/);
+
+  const mdViewer = await openMediaViewer(page, mdRow.link);
+  const mdSource = mdViewer.getByTestId("media-viewer-text-source");
+  await expect(mdSource).toHaveText(MD_LINES.join("\n"), { timeout: 10_000 });
+  await expect(mdViewer.getByTestId("media-viewer-text-gutter")).toHaveText("1\n2\n3");
+
+  // The three shapes a renderer would have produced. Asserted on generated
+  // HTML rather than on looks: cic has no sanitisation surface anywhere today,
+  // and this change must not be the reason it grows one.
+  const pane = mdViewer.locator(".media-viewer-text");
+  await expect(pane.locator("h1")).toHaveCount(0);
+  await expect(pane.locator("strong")).toHaveCount(0);
+  await expect(pane.locator("a")).toHaveCount(0);
+
+  await closeMediaViewer(mdViewer);
+  expect(page.url()).toBe(cicUrl);
+});

--- a/cicchetto/e2e/tests/issue418-upload-url-extension.spec.ts
+++ b/cicchetto/e2e/tests/issue418-upload-url-extension.spec.ts
@@ -75,26 +75,39 @@ test("image: server mints /uploads/<slug>.png and the extensioned URL opens the 
   expect(page.url()).toBe(cicUrl);
 });
 
-test("document: server mints /uploads/<slug>.txt — extension does NOT open the viewer and the download still serves the bytes", async ({
+test("document: server mints /uploads/<slug>.pdf — extension does NOT open the viewer and the download still serves the bytes", async ({
   page,
 }) => {
   const body = fixture("upload.txt");
   await openChannel(page);
 
+  // 🔴 This case used to upload a `.txt` and assert that its extension did NOT
+  // open the viewer. #1764 REVERSED that on vjt's call (#sbiffo 2026-08-24):
+  // `.txt` and `.md` now open as monospace source with line numbers, and
+  // `issue1764-text-source-viewer.spec.ts` owns that outcome. What #418 is
+  // actually about survives untouched — a document extension is minted
+  // faithfully, an extension the viewer does not claim leaves the anchor
+  // plain, and BOTH the extensioned URL and the bare slug serve the bytes —
+  // so the case moves to `.pdf`, which is one of the document types vjt
+  // deliberately kept out of scope. Keeping the old assertion on `.txt` would
+  // have pinned a ruling that no longer holds.
   const { slug, url } = await uploadViaPicker(
     page,
-    { name: "issue418.txt", mimeType: "text/plain", buffer: body },
+    // Bytes are the text fixture on purpose: `show/2` serves what was stored
+    // and this case is about the URL and the anchor, not about PDF parsing.
+    { name: "issue418.pdf", mimeType: "application/pdf", buffer: body },
     { postTimeout: 10_000 },
   );
 
   // #418: documents get a faithful extension too (uniform, and the
-  // download filename benefits) — but `.txt` is NOT viewer-relevant.
-  expect(url).toMatch(new RegExp(`/uploads/${slug}\\.txt$`));
+  // download filename benefits) — but `.pdf` is NOT viewer-relevant.
+  expect(url).toMatch(new RegExp(`/uploads/${slug}\\.pdf$`));
 
   // 📄 row lands after the echo; the anchor is a PLAIN link — no media
-  // class → the click never opens the viewer (📄 excluded, `.txt` not in
-  // EXTENSION_KIND). Asserting the class (not a click) mirrors the
-  // "plain web link is NOT intercepted" pattern and avoids a popup race.
+  // class → the click never opens the viewer (📄 excluded, `.pdf` in neither
+  // EXTENSION_KIND nor TEXT_EXTENSION_KIND). Asserting the class (not a click)
+  // mirrors the "plain web link is NOT intercepted" pattern and avoids a popup
+  // race.
   const { link } = await mediaScrollbackRow(page, "📄", slug);
   await expect(link).not.toHaveClass(/scrollback-media-link/);
   await expect(link).toHaveAttribute("href", url);

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -1,6 +1,15 @@
-import { type Component, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createResource,
+  createSignal,
+  Match,
+  onCleanup,
+  Show,
+  Switch,
+} from "solid-js";
 import { closeMediaViewer, type MediaViewerState, mediaViewerState } from "./lib/mediaViewer";
-import { bindDismissGesture } from "./lib/mediaViewerGesture";
+import { bindDismissGesture, type DismissDirections } from "./lib/mediaViewerGesture";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import {
   applyPan,
@@ -14,6 +23,7 @@ import {
   toggleZoom,
 } from "./lib/pinchZoom";
 import { maybeEscapePwaClick } from "./lib/platform";
+import { fetchTextResource, TEXT_VIEW_MAX_BYTES } from "./lib/textResource";
 
 // In-app media viewer modal — media-link cluster (2026-06-11).
 //
@@ -43,6 +53,12 @@ import { maybeEscapePwaClick } from "./lib/platform";
 // token in `media-src` / `img-src` — without it this modal opens EMPTY.
 // The widening rides in the same change as each admission; the plug
 // moduledoc (GrappaWeb.Plugs.SecurityHeaders) is the SSOT.
+//
+// #1764 adds a FOURTH kind, `text`, and it is the one that does not hang off
+// an element: `.txt`/`.md` are FETCHED and put in the DOM as source, so they
+// answer to `connect-src`, which is NOT widened to `https:`. That is why
+// `classifyMediaLink` admits text from an admitted host only — this modal
+// never sees a cross-host text href, and must not be made to.
 //
 // #232 — Escape routes through the shared overlay ESC stack
 // (createOverlayLock's onEscape → the single keybindings keydown listener →
@@ -202,6 +218,93 @@ const ZoomableImage: Component<{
   );
 };
 
+// #1764 — `.txt` / `.md` read inline as SOURCE. vjt, #sbiffo 2026-08-24,
+// verbatim: "nono nessun rendering di gesu, assolutamente solo il sorgente txt
+// e md". Monospace, line numbers, and nothing interpreted — not now and not as
+// a later toggle. That is not only a taste call: cic has no sanitisation
+// surface anywhere today, and a markdown renderer would be the reason it grew
+// one, on a page that holds the bearer token.
+//
+// TWO text nodes, not one row per line. A gutter <pre> and a source <pre> side
+// by side keep the DOM node count constant whatever the file size, and they
+// are rendered from the SAME `lines` array so number N is beside line N by
+// construction rather than by two agreeing loops. The stylesheet does the rest
+// of the alignment (`font: inherit` on both — see mediaViewerTouchAction.test).
+//
+// Mounted only from inside the keyed <Show>, so the fetch fires on OPEN. A
+// createResource at MediaViewerModal scope would fire at Shell BOOT, because
+// the component body runs whether or not the modal is showing (the
+// ThemeEditor/#294 failure).
+const TextPane: Component<{
+  href: string;
+  onLoad: () => void;
+  onError: () => void;
+  // Published upward so the dismiss gesture can ask whether the pane is at its
+  // top. Not a signal: the reader is a touchstart handler, and the element
+  // identity never changes for the life of the mount.
+  paneRef: (el: HTMLDivElement | undefined) => void;
+}> = (props) => {
+  const abort = new AbortController();
+  onCleanup(() => {
+    abort.abort();
+    props.paneRef(undefined);
+  });
+
+  const [source] = createResource(
+    () => props.href,
+    (href) => fetchTextResource(href, abort.signal),
+  );
+
+  // The viewer's shared spinner/failure machinery is driven by element events
+  // for every other kind; here the same two outcomes come off the resource, so
+  // the modal keeps ONE load-state model instead of a second one for text.
+  //
+  // Both the effect and the render below go through `source.state` and never
+  // through a bare `source()`: reading an ERRORED resource RETHROWS, which
+  // takes the component down before it can show the failure the reader is
+  // owed — a fetch 404 rendered as a crash and a forever-spinner.
+  createEffect(() => {
+    if (source.state === "errored") props.onError();
+    else if (source.state === "ready") props.onLoad();
+  });
+
+  const settled = (): ReturnType<typeof source> | undefined =>
+    source.state === "ready" ? source() : undefined;
+
+  const gutter = (count: number): string =>
+    Array.from({ length: count }, (_, i) => String(i + 1)).join("\n");
+
+  return (
+    <Show when={settled()}>
+      {(loaded) => (
+        <>
+          <Show when={loaded().truncated}>
+            {/* Above the pane, not below it: a reader must know they are
+                holding a slice BEFORE they start reading, not discover it at
+                a bottom they may never scroll to. */}
+            <p class="muted media-viewer-text-truncated">
+              showing the first {TEXT_VIEW_MAX_BYTES / 1024} KiB of this file — "open in browser"
+              for the whole thing
+            </p>
+          </Show>
+          <div class="media-viewer-text" ref={props.paneRef}>
+            <pre
+              class="media-viewer-text-gutter"
+              data-testid="media-viewer-text-gutter"
+              aria-hidden="true"
+            >
+              {gutter(loaded().lines.length)}
+            </pre>
+            <pre class="media-viewer-text-source" data-testid="media-viewer-text-source">
+              {loaded().lines.join("\n")}
+            </pre>
+          </div>
+        </>
+      )}
+    </Show>
+  );
+};
+
 // Body subcomponent so the load status resets per open: the keyed
 // <Show> remounts it for every new viewer state, giving each open a
 // fresh signal — no manual reset effect to keep in sync. Spinner until
@@ -211,9 +314,11 @@ const ZoomableImage: Component<{
 // 404 can't spin forever. The failed media element is unmounted —
 // a broken <img> would render its alt text (the raw URL) under the
 // failure line.
-const MediaViewerBody: Component<{ state: MediaViewerState; onScale: (scale: number) => void }> = (
-  props,
-) => {
+const MediaViewerBody: Component<{
+  state: MediaViewerState;
+  onScale: (scale: number) => void;
+  onTextPaneRef: (el: HTMLDivElement | undefined) => void;
+}> = (props) => {
   const [status, setStatus] = createSignal<MediaLoadStatus>("loading");
   // Transitions only leave "loading" (review fix): a transient
   // mid-playback error must not unmount a ready element, and a suspend
@@ -232,7 +337,10 @@ const MediaViewerBody: Component<{ state: MediaViewerState; onScale: (scale: num
   // suspend is what it fires when it defers, and without it the
   // spinner spins forever. The element is fully usable at that point.
   return (
-    <div class="media-viewer-body">
+    <div
+      class="media-viewer-body"
+      classList={{ "media-viewer-body--text": props.state.kind === "text" }}
+    >
       <Show when={status() === "loading"}>
         <div role="status" aria-label="Loading media" class="media-viewer-spinner" />
       </Show>
@@ -277,6 +385,14 @@ const MediaViewerBody: Component<{ state: MediaViewerState; onScale: (scale: num
                 onError={failed}
               />
             </Match>
+            <Match when={props.state.kind === "text"}>
+              <TextPane
+                href={props.state.href}
+                onLoad={ready}
+                onError={failed}
+                paneRef={props.onTextPaneRef}
+              />
+            </Match>
           </Switch>
         }
       >
@@ -310,6 +426,11 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
   // advertise a reactivity that does not exist.
   let scale = MIN_SCALE;
   let backdrop: HTMLButtonElement | undefined;
+  // #1764 — the text arm's scroll container, once it has fetched. Same
+  // plain-mutable reasoning as `scale`: nothing renders from it, and the only
+  // reader is a touchstart handler.
+  let textPane: HTMLDivElement | undefined;
+  const isText = props.state.kind === "text";
 
   const paint = (el: HTMLElement, dy: number): void => {
     el.style.transform = draggedTransform(dy);
@@ -329,7 +450,14 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
       // A zoomed image owns the one-finger drag as a PAN (#213), so the viewer
       // stands down until the image is back at fit. Video and audio never
       // publish a scale, which is exactly right: they are always dismissible.
-      canDismiss: () => scale <= MIN_SCALE,
+      //
+      // #1764 — a text pane owns the drag as a SCROLL for as long as it has
+      // anywhere to scroll back to, so the dismiss is live only at its top.
+      // Paired with `directions: "down"` below, the two gates split the axis
+      // cleanly: scrolled → the pane keeps every vertical drag; at the top →
+      // up still scrolls, and only down dismisses.
+      canDismiss: () => (isText ? (textPane?.scrollTop ?? 0) <= 0 : scale <= MIN_SCALE),
+      directions: (isText ? "down" : "both") satisfies DismissDirections,
       onProgress: (dy) => {
         paint(el, dy);
       },
@@ -358,6 +486,7 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
         aria-modal="true"
         aria-label="Media viewer"
         class="media-viewer-modal"
+        classList={{ "media-viewer-modal--text": isText }}
       >
         <div class="media-viewer-header">
           <a
@@ -384,6 +513,9 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
           state={props.state}
           onScale={(next) => {
             scale = next;
+          }}
+          onTextPaneRef={(el) => {
+            textPane = el;
           }}
         />
       </div>

--- a/cicchetto/src/__tests__/MediaViewerModal.test.tsx
+++ b/cicchetto/src/__tests__/MediaViewerModal.test.tsx
@@ -7,6 +7,7 @@ import {
   overlayEscapeDepth,
   runTopmostOverlayEscape,
 } from "../lib/overlayScrollLock";
+import { TEXT_VIEW_MAX_BYTES } from "../lib/textResource";
 import MediaViewerModal from "../MediaViewerModal";
 import { resetPlatformStubs, stubIosStandalone } from "./helpers/platformStubs";
 import { fireTouchAt } from "./helpers/touchEvents";
@@ -369,5 +370,186 @@ describe("MediaViewerModal — swipe to dismiss (#1438)", () => {
     fireTouchAt(img, "touchstart", 1_100, { clientX: X, clientY: Y0 });
     dragAndLift(dialogIn(container), 400);
     expect(mediaViewerState()).not.toBeNull();
+  });
+});
+
+// #1764 — .txt / .md open as SOURCE in the same modal: monospace, line
+// numbers, no rendering of any kind (vjt, #sbiffo 2026-08-24: "nono nessun
+// rendering di gesu, assolutamente solo il sorgente txt e md"). The fetch/cap
+// arithmetic is pinned in textResource.test.ts against the raw verb; what is
+// asserted HERE is what only this component can get wrong — that the bytes
+// reach the pane, that the gutter numbers the lines the pane shows, that the
+// truncation is VISIBLE, and that a scrolled pane does not lose its scroll to
+// the dismiss gesture.
+describe("MediaViewerModal — text source viewer (#1764)", () => {
+  const TEXT_URL = "https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz.txt";
+
+  // Response-shaped stub, same reason as textResource.test.ts: the component
+  // depends on `res.body.getReader()`, and the platform's own Response is not
+  // what is under test here.
+  const stubBody = (text: string): void => {
+    const chunk = new TextEncoder().encode(text);
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({
+        ok: true,
+        status: 206,
+        body: {
+          getReader: () => {
+            let sent = false;
+            return {
+              read: () => {
+                if (sent) return Promise.resolve({ done: true });
+                sent = true;
+                return Promise.resolve({ done: false, value: chunk });
+              },
+              cancel: () => Promise.resolve(),
+            };
+          },
+        },
+      }),
+    );
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const textPane = (container: HTMLElement): HTMLElement => {
+    const el = container.querySelector<HTMLElement>(".media-viewer-text");
+    if (el === null) throw new Error("no text pane rendered");
+    return el;
+  };
+
+  it("renders the fetched source verbatim in a <pre>", async () => {
+    stubBody("alpha\nbeta\ngamma\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text-source")?.textContent).toBe(
+        "alpha\nbeta\ngamma",
+      );
+    });
+    // The whole point of the ruling: nothing was interpreted on the way in.
+    expect(container.querySelector(".media-viewer-text-source")?.tagName).toBe("PRE");
+  });
+
+  it("numbers every line, and exactly the lines the pane shows", async () => {
+    stubBody("one\ntwo\nthree\nfour\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text-gutter")?.textContent).toBe("1\n2\n3\n4");
+    });
+  });
+
+  it("markdown source is shown as SOURCE — no heading, no emphasis, no anchor", async () => {
+    stubBody("# Title\n\n**bold** and [a link](https://example.com)\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer("https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz.md", "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text-source")?.textContent).toContain(
+        "**bold**",
+      );
+    });
+    const pane = textPane(container);
+    // The three shapes a renderer would have produced. cic has no sanitisation
+    // surface anywhere today and this change must not be the reason it grows
+    // one — so the assertion is about generated HTML, not about looks.
+    expect(pane.querySelector("h1")).toBeNull();
+    expect(pane.querySelector("strong")).toBeNull();
+    expect(pane.querySelector("a")).toBeNull();
+  });
+
+  it("says so, in the pane, when the source was cut at the cap", async () => {
+    stubBody("x".repeat(TEXT_VIEW_MAX_BYTES + 1));
+    render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(screen.getByText(/first .* of this file/i)).not.toBeNull();
+    });
+  });
+
+  it("says nothing about truncation when the whole file arrived", async () => {
+    stubBody("short\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text-source")).not.toBeNull();
+    });
+    expect(container.querySelector(".media-viewer-text-truncated")).toBeNull();
+  });
+
+  it("a failed fetch shows the shared failure text, not a forever-spinner", async () => {
+    vi.stubGlobal("fetch", () => Promise.resolve({ ok: false, status: 404, body: null }));
+    render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).not.toBeNull();
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("a downward drag on a SCROLLED pane does not dismiss — the pane owns its own axis", async () => {
+    stubBody("a\nb\nc\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text")).not.toBeNull();
+    });
+    const dialog = container.querySelector<HTMLElement>(".media-viewer-modal");
+    if (dialog === null) throw new Error("no media viewer dialog rendered");
+    // jsdom has no layout, so scrollTop is a plain writable property here —
+    // which is exactly the state the gate reads on a real phone.
+    textPane(container).scrollTop = 120;
+    fireTouchAt(dialog, "touchstart", 0, { clientX: 160, clientY: 300 });
+    fireTouchAt(dialog, "touchmove", 1_000, { clientX: 160, clientY: 700 });
+    fireTouchAt(dialog, "touchend", 2_000, { clientX: 160, clientY: 700 });
+    expect(mediaViewerState()).not.toBeNull();
+  });
+
+  it("an UPWARD drag never dismisses a text pane — that gesture is 'read on'", async () => {
+    stubBody("a\nb\nc\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text")).not.toBeNull();
+    });
+    const dialog = container.querySelector<HTMLElement>(".media-viewer-modal");
+    if (dialog === null) throw new Error("no media viewer dialog rendered");
+    fireTouchAt(dialog, "touchstart", 0, { clientX: 160, clientY: 300 });
+    fireTouchAt(dialog, "touchmove", 1_000, { clientX: 160, clientY: -100 });
+    fireTouchAt(dialog, "touchend", 2_000, { clientX: 160, clientY: -100 });
+    expect(mediaViewerState()).not.toBeNull();
+  });
+
+  it("a long downward drag from the TOP of the pane still dismisses", async () => {
+    stubBody("a\nb\nc\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text")).not.toBeNull();
+    });
+    const dialog = container.querySelector<HTMLElement>(".media-viewer-modal");
+    if (dialog === null) throw new Error("no media viewer dialog rendered");
+    fireTouchAt(dialog, "touchstart", 0, { clientX: 160, clientY: 300 });
+    fireTouchAt(dialog, "touchmove", 1_000, { clientX: 160, clientY: 700 });
+    fireTouchAt(dialog, "touchend", 2_000, { clientX: 160, clientY: 700 });
+    expect(mediaViewerState()).toBeNull();
+  });
+
+  it("carries the text modifier class, which is what re-opens touch panning for the pane", async () => {
+    stubBody("a\n");
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text")).not.toBeNull();
+    });
+    expect(container.querySelector(".media-viewer-modal--text")).not.toBeNull();
+  });
+
+  it("an image open carries NO text modifier — `touch-action: none` must survive there", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    expect(container.querySelector(".media-viewer-modal--text")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/mediaLink.test.ts
+++ b/cicchetto/src/__tests__/mediaLink.test.ts
@@ -342,15 +342,80 @@ describe("classifyMediaLink", () => {
     });
   });
 
+  // #1764 — .txt and .md are viewer-relevant now, and ONLY from an admitted
+  // host. vjt reversed the "documents are not viewer-relevant" ruling for
+  // these two on 2026-08-24; pdf/odt/ods/docx/xlsx stay out.
+  describe("text source links (#1764)", () => {
+    it(".txt on the page origin classifies as text", () => {
+      expect(classifyMediaLink(`${UPLOAD_URL}.txt`, "", ORIGIN, NO_ALIASES)).toEqual({
+        kind: "text",
+        href: `${UPLOAD_URL}.txt`,
+      });
+    });
+
+    it(".md on the page origin classifies as text", () => {
+      expect(classifyMediaLink(`${UPLOAD_URL}.md`, "", ORIGIN, NO_ALIASES)).toEqual({
+        kind: "text",
+        href: `${UPLOAD_URL}.md`,
+      });
+    });
+
+    it("an advertised alias host re-roots onto the page origin, like every other kind (#324)", () => {
+      expect(
+        classifyMediaLink(`https://${ALIAS_B}/uploads/${SLUG}.txt`, "", ORIGIN, WITH_ALIAS_B),
+      ).toEqual({ kind: "text", href: `${UPLOAD_URL}.txt` });
+    });
+
+    it("a historical http:// same-host .txt is re-rooted, like every other kind", () => {
+      expect(classifyMediaLink(`http://grappa.example/notes.txt`, "", ORIGIN, NO_ALIASES)).toEqual({
+        kind: "text",
+        href: `${ORIGIN}/notes.txt`,
+      });
+    });
+
+    // 🔴 The load-bearing one. A text viewer FETCHES, so it goes through
+    // `connect-src`, which is `'self'` + the captcha hosts + api.somafm.com and
+    // is deliberately NOT widened to `https:` the way `img-src`/`media-src` are
+    // (#607, #1240). A cross-host .txt admitted here would open a modal the CSP
+    // then refuses to fill — strictly worse than the anchor it replaced.
+    it("a third-party https .txt is NOT admitted — connect-src is not widened to https:", () => {
+      expect(classifyMediaLink("https://example.com/notes.txt", "", ORIGIN, NO_ALIASES)).toBeNull();
+    });
+
+    it("a third-party https .md is NOT admitted either", () => {
+      expect(
+        classifyMediaLink(
+          "https://raw.githubusercontent.com/a/b/README.md",
+          "",
+          ORIGIN,
+          NO_ALIASES,
+        ),
+      ).toBeNull();
+    });
+
+    // The legacy extensionless shape (rule 2) has only the emoji as a type
+    // signal, and 📄 covers pdf/odt/docx too — all still out of scope. So a
+    // pre-#418 document link stays a plain anchor even now.
+    it("a legacy extensionless 📄 upload stays unclassified — the emoji cannot say which document", () => {
+      expect(classifyMediaLink(UPLOAD_URL, "📄 ", ORIGIN, NO_ALIASES)).toBeNull();
+    });
+
+    it("the document types vjt kept out of scope stay unclassified", () => {
+      for (const ext of ["pdf", "odt", "ods", "docx", "xlsx"]) {
+        expect(classifyMediaLink(`${UPLOAD_URL}.${ext}`, "", ORIGIN, NO_ALIASES)).toBeNull();
+      }
+    });
+  });
+
   // Cross-language contract pin (#418). The server mints /uploads/<slug>.<ext>
   // with the extension from Grappa.Uploads.MimeExt (lib/grappa/uploads/mime_ext.ex).
-  // EVERY viewer-relevant extension that map can mint (image/video/audio) MUST be
-  // classified here by EXTENSION_KIND, or a fresh upload loses its in-app viewer.
-  // Keep in sync with the image/video/audio rows of MimeExt.ext_for/1. Document
-  // types (pdf/txt/odt/ods/docx/xlsx) are deliberately NOT viewer-relevant and
-  // are excluded, mirroring the server map's doc rows.
+  // EVERY viewer-relevant extension that map can mint MUST be classified here,
+  // or a fresh upload loses its in-app viewer. Keep in sync with the
+  // image/video/audio rows of MimeExt.ext_for/1 — and, since #1764, with the
+  // text/plain + text/markdown rows too. The remaining document types
+  // (pdf/odt/ods/docx/xlsx) are still NOT viewer-relevant and are excluded.
   describe("server-mintable viewer extensions are all classified (#418 drift guard)", () => {
-    const SERVER_VIEWER_EXTS: ReadonlyArray<[string, "image" | "video" | "audio"]> = [
+    const SERVER_VIEWER_EXTS: ReadonlyArray<[string, "image" | "video" | "audio" | "text"]> = [
       ["png", "image"],
       ["jpg", "image"],
       ["gif", "image"],
@@ -364,6 +429,8 @@ describe("classifyMediaLink", () => {
       ["aac", "audio"],
       ["wav", "audio"],
       ["flac", "audio"],
+      ["txt", "text"], // #1764 — MimeExt mints text/plain → .txt
+      ["md", "text"], // #1764 — MimeExt mints text/markdown → .md
     ];
 
     for (const [ext, kind] of SERVER_VIEWER_EXTS) {

--- a/cicchetto/src/__tests__/mediaViewerGesture.test.ts
+++ b/cicchetto/src/__tests__/mediaViewerGesture.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vite
 import {
   bindDismissGesture,
   DISMISS_COMMIT_FRACTION,
+  type DismissDirections,
   DRAGGING_CLASS,
 } from "../lib/mediaViewerGesture";
 import { fireTouch, fireTouchAt } from "./helpers/touchEvents";
@@ -29,12 +30,14 @@ let onProgress: Mock<(dy: number) => void>;
 let onCommit: Mock<() => void>;
 let onRelease: Mock<() => void>;
 let canDismiss: Mock<() => boolean>;
+let directions: DismissDirections;
 let dispose: () => void;
 
 function bind(): void {
   dispose = bindDismissGesture(modal, {
     viewportHeight: () => VH,
     canDismiss,
+    directions,
     onProgress,
     onCommit,
     onRelease,
@@ -52,6 +55,7 @@ beforeEach(() => {
   onCommit = vi.fn<() => void>();
   onRelease = vi.fn<() => void>();
   canDismiss = vi.fn<() => boolean>(() => true);
+  directions = "both";
   bind();
 });
 
@@ -178,5 +182,40 @@ describe("bindDismissGesture — lifecycle", () => {
     dragVertically(media, COMMIT_PX + 20, 2_000);
     expect(onCommit).not.toHaveBeenCalled();
     dispose = (): void => {}; // afterEach must not double-dispose
+  });
+});
+
+// #1764 — a scrolling body (the .txt/.md source pane) cannot share the vertical
+// axis with a gesture that commits in BOTH directions: at the top of the pane
+// an upward drag means "read on", and dismissing there would take the primary
+// interaction away. `directions: "down"` is that constraint, in the binder
+// rather than in the caller, because the caller would have to re-derive the
+// direction the binder already computes.
+describe("bindDismissGesture — directions: 'down' (#1764)", () => {
+  beforeEach(() => {
+    directions = "down";
+    dispose();
+    bind();
+  });
+
+  it("a long downward drag still commits", () => {
+    dragVertically(media, COMMIT_PX + 20, 2_000);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("a long UPWARD drag does not commit — and is not even claimed", () => {
+    const { moves } = dragVertically(media, -(COMMIT_PX + 20), 2_000);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalled();
+    // Unclaimed means the browser keeps the pan: the pane scrolls, which is
+    // the whole reason the direction is narrowed. A claimed-then-refused drag
+    // would have eaten the scroll and given nothing back.
+    expect(moves.every((e) => !e.defaultPrevented)).toBe(true);
+    expect(modal.classList.contains(DRAGGING_CLASS)).toBe(false);
+  });
+
+  it("an upward FLICK does not commit either — velocity is not a way around the direction", () => {
+    dragVertically(media, -(COMMIT_PX + 20), 60);
+    expect(onCommit).not.toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/__tests__/mediaViewerTouchAction.test.ts
+++ b/cicchetto/src/__tests__/mediaViewerTouchAction.test.ts
@@ -33,3 +33,46 @@ describe("media viewer — swipe-to-dismiss stylesheet contract (#1438)", () => 
     expect(ruleBody(`.${DRAGGING_CLASS}`)).toMatch(/transition:\s*none/);
   });
 });
+
+// #1764 — the text-source variant. Same standing as the block above: jsdom
+// applies no stylesheet, so these are SOURCE-level assertions on rules that are
+// invisible in every unit and e2e run and only bite on a real phone.
+describe("media viewer — text source stylesheet contract (#1764)", () => {
+  it("re-opens touch panning on the text variant, which the base rule closes", () => {
+    // `.media-viewer-modal` claims the whole touch stream with `touch-action:
+    // none` for the image/video case. Here the BODY scrolls, and a descendant
+    // cannot widen what an ancestor narrowed — the UA intersects down the
+    // chain — so the re-opening has to happen on the modal element itself.
+    expect(ruleBody(".media-viewer-modal--text")).toMatch(/touch-action:\s*pan-x\s+pan-y/);
+  });
+
+  it("keeps the pane's overscroll to itself so a drag past the end is not the page's", () => {
+    expect(ruleBody(".media-viewer-text")).toMatch(/overscroll-behavior:\s*contain/);
+  });
+
+  it("makes the pane the scroller — the base body is overflow:hidden", () => {
+    expect(ruleBody(".media-viewer-text")).toMatch(/overflow:\s*auto/);
+  });
+
+  it("does not wrap: a wrapped line would put N source rows against one gutter number", () => {
+    expect(ruleBody(".media-viewer-text-source")).toMatch(/white-space:\s*pre/);
+    expect(ruleBody(".media-viewer-text-gutter")).toMatch(/white-space:\s*pre/);
+  });
+
+  it("pins the gutter to the left edge, so panning a long line does not scroll the numbers away", () => {
+    const gutter = ruleBody(".media-viewer-text-gutter");
+    expect(gutter).toMatch(/position:\s*sticky/);
+    expect(gutter).toMatch(/left:\s*0/);
+  });
+
+  // The alignment guarantee, and the reason it is `font: inherit` on BOTH
+  // rather than the same tokens spelled twice: a <pre> carries a UA
+  // font-family/font-size that would otherwise win, and two independently
+  // spelled copies are two things that can drift. One inherited metric means
+  // gutter row N and source row N are the same height by construction.
+  it("takes ONE font metric from the pane, so number N sits beside line N", () => {
+    expect(ruleBody(".media-viewer-text-gutter")).toMatch(/font:\s*inherit/);
+    expect(ruleBody(".media-viewer-text-source")).toMatch(/font:\s*inherit/);
+    expect(ruleBody(".media-viewer-text")).toMatch(/font-family:\s*var\(--font-mono\)/);
+  });
+});

--- a/cicchetto/src/__tests__/textResource.test.ts
+++ b/cicchetto/src/__tests__/textResource.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchTextResource, splitLines, TEXT_VIEW_MAX_BYTES } from "../lib/textResource";
+
+// #1764 — the fetch half of the .txt/.md source viewer.
+//
+// Two things are under test and they are separate on purpose: `splitLines`
+// decides what a LINE is (the gutter and the source pane are rendered from the
+// SAME array, so a disagreement here is a gutter that lies), and
+// `fetchTextResource` decides how many BYTES ever reach the DOM.
+//
+// The cap is enforced by US, from the response stream — not by the server
+// honouring the `Range` header we send. That is the whole point of reading the
+// body through a reader instead of `res.text()`: a proxy that strips `Range`,
+// or a future non-grappa admitted host, would otherwise hand a naive viewer the
+// entire file. The header stays as a courtesy so the server does not push bytes
+// we are going to discard.
+
+const HREF = "https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz.txt";
+
+// A Response-shaped stub whose body streams the given chunks. Hand-rolled
+// rather than `new Response(...)`: the contract this module depends on is
+// `res.body.getReader()`, and stubbing it explicitly is what lets a test hand
+// over MORE bytes than the cap without allocating them for real.
+function stubFetch(opts: { status?: number; chunks: Uint8Array[] }): {
+  calls: { href: string; init: RequestInit | undefined }[];
+  cancelled: () => boolean;
+} {
+  const calls: { href: string; init: RequestInit | undefined }[] = [];
+  let cancelled = false;
+  vi.stubGlobal("fetch", (href: string, init?: RequestInit) => {
+    calls.push({ href, init });
+    let at = 0;
+    const status = opts.status ?? 206;
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      body: {
+        getReader: () => ({
+          read: () =>
+            Promise.resolve(
+              at < opts.chunks.length
+                ? { done: false, value: opts.chunks[at++] }
+                : { done: true, value: undefined },
+            ),
+          cancel: () => {
+            cancelled = true;
+            return Promise.resolve();
+          },
+        }),
+      },
+    });
+  });
+  return { calls, cancelled: () => cancelled };
+}
+
+const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("splitLines", () => {
+  it("splits on LF", () => {
+    expect(splitLines("a\nb\nc")).toEqual(["a", "b", "c"]);
+  });
+
+  it("splits on CRLF without leaving the CR in the line", () => {
+    expect(splitLines("a\r\nb")).toEqual(["a", "b"]);
+  });
+
+  it("a trailing newline does NOT add a phantom last line", () => {
+    // Every editor agrees a file ending in \n has as many lines as it has
+    // newlines. Rendering the phantom would put a number in the gutter with
+    // nothing beside it.
+    expect(splitLines("a\nb\n")).toEqual(["a", "b"]);
+  });
+
+  it("keeps interior blank lines — only the trailing one is dropped", () => {
+    expect(splitLines("a\n\nb\n")).toEqual(["a", "", "b"]);
+  });
+
+  it("empty input is one empty line, not zero lines", () => {
+    expect(splitLines("")).toEqual([""]);
+  });
+});
+
+describe("fetchTextResource", () => {
+  it("returns the body split into lines, untruncated, for a small file", async () => {
+    stubFetch({ chunks: [bytes("first\nsecond\nthird\n")] });
+    await expect(fetchTextResource(HREF, new AbortController().signal)).resolves.toEqual({
+      lines: ["first", "second", "third"],
+      truncated: false,
+    });
+  });
+
+  it("asks the server for at most the cap, so it does not push bytes we discard", async () => {
+    const { calls } = stubFetch({ chunks: [bytes("hi")] });
+    await fetchTextResource(HREF, new AbortController().signal);
+    const headers = calls[0]?.init?.headers as Record<string, string> | undefined;
+    // One PAST the cap: the extra byte is what makes "is there more?"
+    // answerable without a second request.
+    expect(headers?.range).toBe(`bytes=0-${TEXT_VIEW_MAX_BYTES}`);
+  });
+
+  it("stops at the cap and says so when the stream keeps going", async () => {
+    // Three chunks that together overrun the cap. A server that ignored the
+    // Range header would do exactly this.
+    const chunk = new Uint8Array(TEXT_VIEW_MAX_BYTES / 2).fill(0x61); // 'a'
+    const probe = stubFetch({ status: 200, chunks: [chunk, chunk, chunk] });
+    const res = await fetchTextResource(HREF, new AbortController().signal);
+    expect(res.truncated).toBe(true);
+    expect(res.lines.join("\n").length).toBe(TEXT_VIEW_MAX_BYTES);
+    // …and we hung up rather than draining the rest.
+    expect(probe.cancelled()).toBe(true);
+  });
+
+  it("a file EXACTLY the cap is not reported as truncated", async () => {
+    // The off-by-one that would make the honest signal dishonest: reading
+    // `cap` bytes and stopping cannot tell "the file ended here" from "we did".
+    stubFetch({ chunks: [new Uint8Array(TEXT_VIEW_MAX_BYTES).fill(0x62)] });
+    const res = await fetchTextResource(HREF, new AbortController().signal);
+    expect(res.truncated).toBe(false);
+  });
+
+  it("one byte past the cap IS truncated", async () => {
+    stubFetch({ chunks: [new Uint8Array(TEXT_VIEW_MAX_BYTES + 1).fill(0x62)] });
+    const res = await fetchTextResource(HREF, new AbortController().signal);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("rejects on a non-ok response so the modal shows its failure state", async () => {
+    stubFetch({ status: 404, chunks: [] });
+    await expect(fetchTextResource(HREF, new AbortController().signal)).rejects.toThrow();
+  });
+
+  it("forwards the abort signal so closing the viewer cancels an in-flight read", async () => {
+    const { calls } = stubFetch({ chunks: [bytes("x")] });
+    const controller = new AbortController();
+    await fetchTextResource(HREF, controller.signal);
+    expect(calls[0]?.init?.signal).toBe(controller.signal);
+  });
+});

--- a/cicchetto/src/lib/__tests__/uploadCategory.test.ts
+++ b/cicchetto/src/lib/__tests__/uploadCategory.test.ts
@@ -22,8 +22,16 @@ const matrix: ReadonlyArray<[string, UploadCategory]> = [
 ];
 
 describe("categoryOf — full MIME matrix", () => {
-  it("covers all 14 server-mirrored MIMEs", () => {
-    expect(matrix.length).toBe(14);
+  // 15 since #1764 added `text/markdown` to DOCUMENT_MIMES_PORTABLE (so a
+  // `.md` can be uploaded and then read as source in the viewer).
+  //
+  // ⚠️ AUDIO_MIMES is NOT in this matrix and never has been: the audio block
+  // arrived with #115, after this test was written, and mirrors the server
+  // without being pinned here. Left as found — widening the matrix is a
+  // different change from this one — but recorded so the next reader does not
+  // take "full MIME matrix" at its word.
+  it("covers all 15 server-mirrored image/video/document MIMEs", () => {
+    expect(matrix.length).toBe(15);
   });
 
   it.each(matrix)("%s → %s", (mime, category) => {

--- a/cicchetto/src/lib/mediaLink.ts
+++ b/cicchetto/src/lib/mediaLink.ts
@@ -63,6 +63,24 @@
 //    (extension from Grappa.Uploads.MimeExt) — the type is intrinsic to
 //    the URL and the emoji is NOT consulted here. Also covers any other
 //    same-origin direct-served media.
+// 4. ADMITTED-HOST ONLY, `.txt` / `.md` → "text" (#1764,
+//    TEXT_EXTENSION_KIND). Deliberately absent from the external branch:
+//    see the CSP note below.
+//
+// ## Why "text" is admitted-host only, and must stay that way (#1764)
+//
+// Every other kind hangs an ELEMENT off the URL — `<img src>`, `<video
+// src>` — and those are governed by `img-src` / `media-src`, both widened
+// to `https:` (#1240, #607) so a foreign host works. A text viewer has no
+// such element: it FETCHES the bytes and puts them in the DOM, which goes
+// through `connect-src`, and `connect-src` is `'self'` plus the captcha
+// hosts and `api.somafm.com` — NOT widened to `https:`
+// (GrappaWeb.Plugs.SecurityHeaders). That asymmetry is deliberate: an
+// element source can only be rendered, whereas `fetch` can read a
+// response body, so widening it is exfiltration surface in a way the two
+// media directives are not. Admitting a cross-host `.txt` here would open
+// a modal the CSP then refuses to fill — strictly worse than the plain
+// anchor it replaced. Do NOT "fix" that by widening `connect-src`.
 //
 // ## Why the URL extension is the durable fix (#418)
 //
@@ -77,7 +95,7 @@
 // scrollback renders. No previews, no on-arrival rendering — the
 // modal is on-click only (vjt-approved spec, 2026-06-10).
 
-export type MediaKind = "image" | "video" | "audio";
+export type MediaKind = "image" | "video" | "audio" | "text";
 
 // Mirrors Grappa.Uploads @slug_regex (26 chars of lowercase base32).
 const UPLOADS_PATH_RE = /^\/uploads\/[a-z2-7]{26}$/;
@@ -98,10 +116,14 @@ const EMOJI_KIND: Record<string, MediaKind> = {
 // Grappa.Uploads.MimeExt, lib/grappa/uploads/mime_ext.ex), so this table
 // is the PRIMARY type source for uploads — the emoji is now only a
 // fallback for legacy extensionless links. CROSS-LANGUAGE CONTRACT: every
-// viewer-relevant extension MimeExt can mint (image/video/audio) MUST be
-// present here, or a fresh upload loses its in-app viewer. Pinned by the
-// "server-mintable viewer extensions" test in mediaLink.test.ts.
-const EXTENSION_KIND: Record<string, MediaKind> = {
+// viewer-relevant extension MimeExt can mint MUST be classified, or a
+// fresh upload loses its in-app viewer. Pinned by the "server-mintable
+// viewer extensions" test in mediaLink.test.ts.
+//
+// This half is the ELEMENT-BACKED set (an `<img>` / `<video>` / `<audio>`
+// src), and it is the one the external branch may use. The fetch-backed
+// text set is separate, right below, for the CSP reason in the moduledoc.
+const EXTENSION_KIND: Record<string, Exclude<MediaKind, "text">> = {
   png: "image",
   jpg: "image",
   jpeg: "image",
@@ -122,6 +144,23 @@ const EXTENSION_KIND: Record<string, MediaKind> = {
   opus: "audio",
   flac: "audio",
   wav: "audio",
+};
+
+// #1764 — the FETCH-backed half, admitted-host only. Same cross-language
+// contract as EXTENSION_KIND (MimeExt mints text/plain → .txt and
+// text/markdown → .md) and pinned by the same test, but kept a separate
+// table because the two are reachable from different branches: an element
+// source is `img-src`/`media-src` and may be foreign, a fetched body is
+// `connect-src` and may not. One merged table would make that distinction
+// a comment instead of a type.
+//
+// `.md` is here as SOURCE, not as markdown: vjt ruled out rendering
+// outright (#sbiffo 2026-08-24, "nono nessun rendering di gesu,
+// assolutamente solo il sorgente txt e md"), which also keeps generated
+// HTML out of a client that has no sanitisation surface anywhere today.
+const TEXT_EXTENSION_KIND: Record<string, Extract<MediaKind, "text">> = {
+  txt: "text",
+  md: "text",
 };
 
 export type MediaLink = { kind: MediaKind; href: string };
@@ -230,18 +269,27 @@ export function classifyMediaLink(
   return { kind, href: match.rooted };
 }
 
+function extensionOf(url: URL): string {
+  return url.pathname.split(".").pop()?.toLowerCase() ?? "";
+}
+
+// Element-backed kinds only — safe for a foreign host under the widened
+// `img-src`/`media-src`. See the moduledoc's CSP note.
 function extensionKind(url: URL): MediaKind | null {
-  const extension = url.pathname.split(".").pop()?.toLowerCase() ?? "";
-  return EXTENSION_KIND[extension] ?? null;
+  return EXTENSION_KIND[extensionOf(url)] ?? null;
 }
 
 function kindOf(url: URL, precedingText: string): MediaKind | null {
   if (UPLOADS_PATH_RE.test(url.pathname)) {
+    // Legacy extensionless shape: the emoji is the only type signal, and 📄
+    // names every document type at once (pdf/odt/docx included, all still out
+    // of scope) — so it cannot resolve to "text" and stays unclassified.
     const emoji = TRAILING_EMOJI_RE.exec(precedingText)?.[1];
     return emoji !== undefined ? (EMOJI_KIND[emoji] ?? null) : null;
   }
 
-  return extensionKind(url);
+  // Admitted host: both halves are in play, the fetch-backed one included.
+  return extensionKind(url) ?? TEXT_EXTENSION_KIND[extensionOf(url)] ?? null;
 }
 
 /**
@@ -256,6 +304,11 @@ function kindOf(url: URL, precedingText: string): MediaKind | null {
  * - the emoji fallback (rule 2) does NOT apply: it keys off a same-host
  *   extensionless `/uploads/<slug>` shape we only mint ourselves, so a foreign
  *   link without an extension has no type signal and stays null.
+ * - `.txt` / `.md` (#1764) do NOT apply either, and this is the load-bearing
+ *   omission rather than an oversight: `extensionKind` is consulted here and
+ *   `TEXT_EXTENSION_KIND` is not, because a text viewer reads the body through
+ *   `fetch` (`connect-src`, not widened) instead of pointing an element at the
+ *   URL. See the moduledoc.
  *
  * #607 admitted audio first, for the docked mini-player (#115) — cross-channel
  * playback the iOS Safari view can't give. #1240 admitted image and video: the

--- a/cicchetto/src/lib/mediaViewerGesture.ts
+++ b/cicchetto/src/lib/mediaViewerGesture.ts
@@ -39,6 +39,17 @@ export const DISMISS_COMMIT_FRACTION = 0.15;
 // `messageGestures`.
 export const DRAGGING_CLASS = "media-viewer-modal--dragging";
 
+// Which way a drag is allowed to MEAN dismissal. `"both"` is the #1438 media
+// posture (nothing under the finger scrolls, so either direction is free);
+// `"down"` is what a surface with a SCROLLING body needs (#1764, the .txt/.md
+// source pane): at the top of that pane an upward drag means "read on", and a
+// binder that dismissed there would take the primary interaction away.
+//
+// A closed union rather than a boolean: two named values are two things a
+// reviewer can read at the call site, where `false` would be a coin flip
+// (`mediaViewer.ts`'s two-verb argument, same reasoning).
+export type DismissDirections = "both" | "down";
+
 export type DismissGestureParams = {
   // Injected (not read off the element) because jsdom has no layout.
   viewportHeight: () => number;
@@ -48,6 +59,11 @@ export type DismissGestureParams = {
   // off the fit baseline — but a scale, or a media kind, in here would be a
   // second classifier racing the one that already exists.
   canDismiss: () => boolean;
+  // Which drag directions may commit. Narrowing also narrows the CLAIM: a
+  // direction that cannot commit is never claimed either, so the browser keeps
+  // the pan and a scrolling body underneath still scrolls. Claiming and then
+  // refusing at touchend would eat the scroll and give nothing back.
+  directions: DismissDirections;
   // Running vertical delta in px (negative = up), on every claimed move. The
   // caller translates the modal and ramps the backdrop with it.
   onProgress: (dy: number) => void;
@@ -97,6 +113,10 @@ export function bindDismissGesture(el: HTMLElement, params: DismissGestureParams
       // whole — it is how a `<video>` scrubber survives, and how a future
       // left/right binding on this surface stays possible.
       if (!verticalClaim(start, current)) return;
+      // Same release-it-whole posture as the horizontal case above, for a
+      // direction this caller has ruled out: never claimed, never
+      // preventDefault'd, so the scroller underneath keeps the gesture.
+      if (params.directions === "down" && current.y <= start.y) return;
       claimed = true;
       el.classList.add(DRAGGING_CLASS);
     }
@@ -123,7 +143,14 @@ export function bindDismissGesture(el: HTMLElement, params: DismissGestureParams
     const direction = swipeDirection(s, end);
     const farEnough = Math.abs(end.y - s.y) >= params.viewportHeight() * DISMISS_COMMIT_FRACTION;
     const flicked = isFastSwipe(s, end, elapsed);
-    if ((direction === "up" || direction === "down") && (farEnough || flicked)) {
+    // The direction gate is restated here and not left to the claim: velocity
+    // must not be a way around it, and a gesture that started downward can end
+    // above where it began.
+    const meansDismiss =
+      params.directions === "both"
+        ? direction === "up" || direction === "down"
+        : direction === "down";
+    if (meansDismiss && (farEnough || flicked)) {
       params.onCommit();
       return;
     }

--- a/cicchetto/src/lib/textResource.ts
+++ b/cicchetto/src/lib/textResource.ts
@@ -1,0 +1,121 @@
+// Source-text fetch for the media viewer's `.txt` / `.md` arm (#1764).
+//
+// Pure module (no SolidJS, no DOM) — same separation as `mediaLink.ts`:
+// `MediaViewerModal.tsx` owns the pane, this owns "how many bytes reach the
+// DOM, and what a line is".
+//
+// ## Why this is not `res.text()`
+//
+// Every other viewer kind hands a URL to an element and lets the browser
+// stream it; this one reads the bytes itself, so it is the one place where a
+// large file becomes a large DOM. The ceiling above it is real: an upload is
+// capped per category by `ServerSettings.get_upload_per_file_cap_bytes/1`
+// (`:document` defaults to 10 MiB and an operator can raise it) under a hard
+// 128 MB multipart roof (`endpoint.ex`, matched by `client_max_body_size 128m`
+// in the nginx snippets). A naive viewer would pull all of it in.
+//
+// So the cap is enforced HERE, by reading the response through a reader and
+// hanging up, rather than by trusting the `Range` header to be honoured. The
+// header is still sent — it is a courtesy that stops the server pushing bytes
+// we would discard — but a proxy that strips it, or any future admitted host
+// that ignores it, changes nothing about how much lands in the page. Enforcing
+// on our side is also what makes `truncated` a FACT rather than an inference
+// from a `content-range` we may not have been given.
+//
+// ## The number
+//
+// NOT a rendering measurement: a browser cannot be driven from this dev host,
+// so nothing here was timed on a device. It is anchored on the two numbers
+// that were measured, and chosen on the safe side of them because the
+// degradation is visible and reversible — the pane says it was cut, and "open
+// in browser" still serves the whole file. At ~80 columns 512 KiB is ~6,500
+// lines, well past any log or config anyone pastes into IRC, and 20× under the
+// default document upload cap, so the cap bites long before an operator-raised
+// setting could matter. The DOM cost does not scale with it either: the pane
+// renders TWO text nodes (gutter + source), not one node per line, so what
+// grows is text layout, not node count.
+export const TEXT_VIEW_MAX_BYTES = 512 * 1024;
+
+export type TextResource = {
+  // One entry per rendered row. The gutter numbers THIS array and the source
+  // pane joins THIS array, so the two cannot disagree about what a line is.
+  lines: readonly string[];
+  // True only when bytes were left on the server — see `readCapped`.
+  truncated: boolean;
+};
+
+/**
+ * Split source text into the rows the viewer renders. Handles CRLF, and drops
+ * the phantom row a trailing newline would otherwise produce (every editor
+ * agrees a file ending in `\n` has as many lines as it has newlines; rendering
+ * the phantom would put a gutter number beside nothing). Empty input is ONE
+ * empty line, not zero — an empty file still has a first line.
+ */
+export function splitLines(text: string): string[] {
+  const lines = text.split(/\r?\n/);
+  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+/**
+ * Fetch a source file and return it as rows plus an honest truncation flag.
+ *
+ * Rejects on a non-2xx response, a bodyless response, or an aborted/failed
+ * network read — the caller renders the viewer's shared failure state. Reads
+ * at most `TEXT_VIEW_MAX_BYTES` into the page whatever the server does.
+ *
+ * @param href the viewer-safe href from `classifyMediaLink` — ALWAYS an
+ *   admitted host, re-rooted on the page origin. A cross-host href would be
+ *   blocked by `connect-src` and never reaches here; see `mediaLink.ts`.
+ * @param signal aborts the read when the viewer closes mid-flight.
+ */
+export async function fetchTextResource(href: string, signal: AbortSignal): Promise<TextResource> {
+  const res = await fetch(href, {
+    signal,
+    // One byte PAST the cap, so "is there more?" is answerable from the bytes
+    // we already have instead of costing a second request.
+    headers: { range: `bytes=0-${TEXT_VIEW_MAX_BYTES}` },
+  });
+  if (!res.ok) throw new Error(`text source fetch failed: ${res.status}`);
+  if (res.body === null) throw new Error("text source response had no body");
+
+  const { text, truncated } = await readCapped(res.body, TEXT_VIEW_MAX_BYTES);
+  return { lines: splitLines(text), truncated };
+}
+
+// Read until the stream ends or one byte PAST `max` has arrived, then decode
+// the first `max`. The extra byte is what separates "the file ended exactly
+// here" from "we stopped here" — reading exactly `max` and stopping cannot
+// tell those apart, and would report a file of precisely the cap size as
+// truncated forever.
+//
+// A codepoint straddling the cut decodes to U+FFFD. That is unavoidable when
+// capping by BYTES (the server's own `Range` slice would do the same) and is
+// honest: the bytes really were cut there.
+async function readCapped(
+  body: ReadableStream<Uint8Array>,
+  max: number,
+): Promise<{ text: string; truncated: boolean }> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (total <= max) {
+    const { done, value } = await reader.read();
+    if (done === true) break;
+    if (value === undefined || value.byteLength === 0) continue;
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  // Hang up rather than drain a body we are not going to read.
+  if (total > max) await reader.cancel();
+
+  const kept = new Uint8Array(Math.min(total, max));
+  let at = 0;
+  for (const chunk of chunks) {
+    if (at >= kept.length) break;
+    const take = Math.min(chunk.byteLength, kept.length - at);
+    kept.set(chunk.subarray(0, take), at);
+    at += take;
+  }
+  return { text: new TextDecoder().decode(kept), truncated: total > max };
+}

--- a/cicchetto/src/lib/uploadCategory.ts
+++ b/cicchetto/src/lib/uploadCategory.ts
@@ -26,6 +26,15 @@ export const VIDEO_MIMES = ["video/mp4", "video/quicktime", "video/webm"] as con
 export const DOCUMENT_MIMES_PORTABLE = [
   "application/pdf",
   "text/plain",
+  // #1764 — accepted so a `.md` reaches the wire; the viewer then reads it as
+  // SOURCE (mediaLink.ts TEXT_EXTENSION_KIND). ⚠️ A browser does not always
+  // label a .md file `text/markdown` — where the OS MIME table has no entry it
+  // hands over `""` or `application/octet-stream`, and this gate rejects those
+  // before the upload. There is deliberately NO extension rescue for it: the
+  // server's own rescue (@audio_ext_canonical_mime) is scoped to audio, where
+  // the mislabelling was measured, and widening it to documents would reopen
+  // the closed allowlist for a convenience nobody has asked for yet.
+  "text/markdown",
   "application/vnd.oasis.opendocument.text",
   "application/vnd.oasis.opendocument.spreadsheet",
 ] as const;
@@ -132,6 +141,7 @@ export const MIME_EXT_LABEL: Record<
   "video/webm": "webm",
   "application/pdf": "pdf",
   "text/plain": "txt",
+  "text/markdown": "md",
   "application/vnd.oasis.opendocument.text": "odt",
   "application/vnd.oasis.opendocument.spreadsheet": "ods",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -12991,6 +12991,103 @@ audio.media-viewer-media {
   width: min(80vw, 24rem);
 }
 
+/* #1764 — the .txt/.md SOURCE arm of the same modal. vjt ruled out rendering
+   of any kind, so everything below is about making raw source READABLE:
+   monospace, aligned line numbers, no wrapping.
+
+   The base .media-viewer-modal sizes itself to its content (`width:
+   max-content`), which is right for a picture and wrong for text — a
+   three-line file would open in a sliver and a 200-column one at the cap.
+   A fixed share of the viewport gives every file the same frame. */
+.media-viewer-modal--text {
+  width: min(92vw, 72rem);
+  /* Re-opens what the base rule closes. .media-viewer-modal takes the whole
+     touch stream with `touch-action: none` because nothing under it scrolls;
+     here the body DOES, and a descendant cannot widen what an ancestor
+     narrowed (the UA intersects down the chain), so the re-opening has to be
+     on this element. The dismiss binder still owns the drags it claims — it
+     preventDefaults them — and it deliberately claims neither an upward drag
+     nor one starting mid-scroll, which is what leaves those to the pane.
+     NOT VERIFIED ON A DEVICE: no browser can be driven from the dev host, so
+     whether iOS begins a rubber-band before the claim lands is on dogfood. */
+  touch-action: pan-x pan-y;
+}
+
+/* The base body centers a single fixed-size element and hides overflow; text
+   fills the frame and scrolls instead. */
+.media-viewer-body--text {
+  align-items: stretch;
+  justify-content: flex-start;
+  flex-direction: column;
+  /* Without this a flex item refuses to shrink below its content height and
+     the pane's own `overflow: auto` never engages. */
+  min-height: 0;
+}
+
+/* The scroller, and the ONE place the text metric is declared. Both <pre>
+   children take `font: inherit` from here rather than restating the tokens:
+   a <pre> carries a UA font-family/font-size that would otherwise win, and
+   two independently spelled copies are two things that can drift apart —
+   which for a gutter means number N drifting off line N. */
+.media-viewer-text {
+  display: flex;
+  align-items: flex-start;
+  overflow: auto;
+  /* A drag past either end belongs to this pane, not to the page behind the
+     modal (and not to iOS's pull-to-refresh). */
+  overscroll-behavior: contain;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  line-height: 1.4;
+}
+
+/* Sticky, so panning right along a long line does not scroll the numbers out
+   of the frame — the one thing that would make the gutter useless exactly
+   when it is needed. user-select: none keeps a copy of the source free of
+   line numbers. */
+.media-viewer-text-gutter {
+  position: sticky;
+  left: 0;
+  flex: none;
+  margin: 0;
+  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+  font: inherit;
+  white-space: pre;
+  text-align: right;
+  color: var(--muted);
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  user-select: none;
+}
+
+/* `white-space: pre` and NOT pre-wrap: a wrapped line would render as N rows
+   against one gutter number, and source with significant columns (a log, a
+   diff, a table) stops being readable. Long lines pan horizontally instead. */
+.media-viewer-text-source {
+  flex: none;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  white-space: pre;
+  color: var(--fg);
+}
+
+/* The honest-degradation line for a file cut at TEXT_VIEW_MAX_BYTES. Above
+   the pane on purpose: a reader must know they are holding a slice before
+   they start, not at a bottom they may never reach. Colour comes from the
+   shared .muted utility. */
+.media-viewer-text-truncated {
+  flex: none;
+  margin: 0;
+  padding: 0.25rem 0.75rem 0.5rem;
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--border);
+}
+
 /* GH #235 — "jump to next active window" affordance (irssi Alt+A).
    One button, two placements (see .next-active-btn-desktop /
    -mobile). Mounted only while there are unread-activity windows

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62629,3 +62629,111 @@ wrong flavor permanent.
 should request `visitor_enabled` up front so a network is never born in a
 state the panel cannot leave. That is a product call, it is vjt's, and it is
 not built here.
+<!-- entry #1764 -->
+
+---
+
+## 2026-08-25 — #1764: `.txt` and `.md` open as SOURCE in the media viewer
+
+vjt asked on IRC (#sbiffo, 2026-08-24 23:00) for a modal like the image one
+but for text files, "magari anche con i numeri di riga", and ruled three
+minutes later (23:03, verbatim) *"nono nessun rendering di gesu, assolutamente
+solo il sorgente txt e md"*. So: a fourth `MediaKind`, `"text"`, monospace
+source with a line-number gutter, and no interpretation of any kind — not now
+and not as a later toggle. `pdf/odt/ods/docx/xlsx` stay out of scope.
+
+### This REVERSES a ruling, and the SSOT that carried it was amended with it
+
+`Grappa.Uploads.MimeExt`'s moduledoc said, verbatim, that *"Document types
+(pdf/txt/odt/ods/docx/xlsx) are deliberately NOT viewer-relevant and need no
+cic entry"*. That sentence is the cross-language contract's single source of
+truth, and this change makes it false for two of the six. It is amended in the
+same commit, naming the reversal and whose call it was — a SSOT that lies is
+worse than one that is missing, because the next reader copies it. `.md`
+required widening `@mime_categories` and `@mime_ext` in lockstep (`MimeExtTest`
+fails CI on either alone) plus the cic mirror in `uploadCategory.ts`;
+`text/markdown` now exists in the accept-allowlist for exactly one reason,
+which is that the client can read it.
+
+The e2e that pinned the OLD ruling — `issue418-upload-url-extension.spec.ts`'s
+*"extension does NOT open the viewer"* case, on a `.txt` — was moved to `.pdf`
+rather than deleted. What #418 is about (a faithfully minted extension, a
+non-viewer extension leaving the anchor plain, both URL forms serving the
+bytes) is untouched; only the example had to move off a type that is now
+viewer-relevant.
+
+### Why `text` is admitted-host only, and why that is not a limitation to lift
+
+Every other kind hangs an ELEMENT off the URL, governed by `img-src` /
+`media-src` — both widened to `https:` (#607, #1240), which is why a foreign
+image opens. A text viewer has no element: it `fetch`es the body into the DOM,
+which answers to `connect-src`, and that directive is `'self'` plus the captcha
+hosts and `api.somafm.com`, deliberately NOT widened. The asymmetry is the
+point: an element source can only be rendered, whereas `fetch` can READ a
+response body, so widening it is exfiltration surface in a way the two media
+directives are not. Admitting a cross-host `.txt` would open a modal the CSP
+then refuses to fill — strictly worse than the anchor it replaced. The
+classifier therefore keeps two tables, `EXTENSION_KIND` (element-backed, usable
+by the external branch) and `TEXT_EXTENSION_KIND` (fetch-backed, same-host
+only), so the distinction is a type rather than a comment.
+
+### The cap, and what was actually measured
+
+The issue flagged the ceiling as 128 MB (`endpoint.ex` multipart, matched by
+`client_max_body_size 128m`) and left the cap undecided. **Measured
+correction: that is the roof, not the ceiling a `.txt` actually reaches.** The
+binding limit is per category —
+`ServerSettings.get_upload_per_file_cap_bytes(:document)`, default
+`10 * 1024 * 1024` — and an operator can raise it up to the 128 MB roof. A cap
+is still engineering rather than product, so there is one:
+`TEXT_VIEW_MAX_BYTES = 512 KiB`.
+
+That number is **not** a rendering measurement and is not presented as one — no
+browser can be driven from the dev host. It is anchored on the two numbers
+above and chosen on the safe side of them, because the degradation is visible
+and reversible: the pane says it was cut and "open in browser" still serves the
+whole file. At ~80 columns it is ~6,500 lines, past any log or config anyone
+pastes into IRC, and 20× under the default document cap so it bites long before
+an operator-raised setting could matter. **The behaviour AT the cap is UX and
+is vjt's to confirm** — built as a line above the pane reading "showing the
+first 512 KiB of this file", above and not below because a reader must know
+they hold a slice before they start, not at a bottom they may never reach.
+
+**The cap is enforced from the response stream, not by trusting `Range`.** The
+viewer sends `Range: bytes=0-<cap>` — one byte PAST the cap — but reads through
+`res.body.getReader()` and hangs up, so a proxy that strips the header, or any
+future admitted host that ignores it, changes nothing about how much lands in
+the page. The extra byte is what makes `truncated` a FACT: reading exactly the
+cap and stopping cannot tell "the file ended here" from "we stopped here", and
+would report a file of precisely 512 KiB as truncated forever.
+
+### The gesture: a scrolling body cannot share the vertical axis
+
+`bindDismissGesture` (#1438) commits on an up OR down drag, which is right when
+nothing underneath scrolls and wrong the moment something does — at the top of
+a text pane an upward drag means "read on". Rather than a second gesture
+policy in the caller, the binder gained a required `directions: "both" |
+"down"`, and the narrowing applies to the CLAIM as well as the commit: a
+direction that cannot commit is never claimed, never `preventDefault`ed, so the
+scroller keeps it. Paired with `canDismiss: () => pane.scrollTop <= 0`, the two
+gates split the axis cleanly — scrolled, the pane keeps every vertical drag; at
+the top, up still scrolls and only down dismisses.
+
+The stylesheet half: `.media-viewer-modal` claims the whole touch stream with
+`touch-action: none`, correct for a bitmap and fatal for a scroller, and a
+descendant cannot widen what an ancestor narrowed — so `.media-viewer-modal--text`
+re-opens it to `pan-x pan-y` on the modal element itself. Gutter and source are
+TWO `<pre>` text nodes rendered from the SAME `lines` array (node count stays
+constant whatever the file size) and both take `font: inherit` from the pane, so
+number N sits beside line N by construction rather than by two spellings of the
+same tokens agreeing.
+
+### Not established
+
+Whether iOS begins a rubber-band before the dismiss claim lands on a pane at
+`scrollTop 0` was **not** measured — no browser is drivable from this host and
+webkit emulation is not iOS. `overscroll-behavior: contain` is there for it;
+the verdict is dogfood's. Likewise the exact termination rule of the UA's
+`touch-action` ancestor intersection at a scroll container was not measured,
+which is why the re-opening is declared on the modal element rather than relied
+upon to stop at the pane.

--- a/lib/grappa/uploads/mime_ext.ex
+++ b/lib/grappa/uploads/mime_ext.ex
@@ -30,13 +30,31 @@ defmodule Grappa.Uploads.MimeExt do
 
   ## Cross-language contract (drift warning)
 
-  Every extension this map can mint for a VIEWER-RELEVANT type
-  (image / video / audio) MUST be classified by cic's `EXTENSION_KIND`
-  (`cicchetto/src/lib/mediaLink.ts`) — otherwise a fresh upload loses its
-  in-app media viewer on the client. Pinned on the cic side by
-  `mediaLink.test.ts` ("server-mintable viewer extensions"). Document
-  types (pdf/txt/odt/ods/docx/xlsx) are deliberately NOT viewer-relevant
-  and need no cic entry.
+  Every extension this map can mint for a VIEWER-RELEVANT type MUST be
+  classified by cic's `mediaLink.ts` — otherwise a fresh upload loses its
+  in-app viewer on the client. Pinned on the cic side by
+  `mediaLink.test.ts` ("server-mintable viewer extensions").
+
+  Viewer-relevant is TWO sets on the cic side, and the split is a CSP
+  boundary rather than a taste:
+
+    * image / video / audio → `EXTENSION_KIND`. These hang off an
+      element (`<img src>`, `<video src>`), governed by `img-src` /
+      `media-src`, both widened to `https:` — so cic admits them from a
+      foreign host too (#607, #1240).
+    * `txt` / `md` → `TEXT_EXTENSION_KIND`, ADMITTED HOSTS ONLY. A text
+      viewer `fetch`es the bytes into the DOM, which answers to
+      `connect-src`, and that one is NOT widened to `https:`. Do not
+      "fix" a cross-host text link by widening it.
+
+  🔴 This paragraph used to read *"Document types (pdf/txt/odt/ods/docx/
+  xlsx) are deliberately NOT viewer-relevant and need no cic entry"*.
+  **vjt reversed that for `txt` and `md` on 2026-08-24 (#1764, #sbiffo)**:
+  they open in the media-viewer modal as monospace SOURCE with line
+  numbers — no markdown rendering, not now and not as a later toggle.
+  `pdf/odt/ods/docx/xlsx` are unchanged and still need no cic entry.
+  `text/markdown` exists in this map for no other reason than that
+  reversal: nothing server-side reads it.
   """
 
   # Keep in lockstep with `GrappaWeb.UploadsController` @mime_categories
@@ -54,6 +72,7 @@ defmodule Grappa.Uploads.MimeExt do
     "video/webm" => "webm",
     "application/pdf" => "pdf",
     "text/plain" => "txt",
+    "text/markdown" => "md",
     "application/vnd.oasis.opendocument.text" => "odt",
     "application/vnd.oasis.opendocument.spreadsheet" => "ods",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "docx",

--- a/lib/grappa_web/controllers/uploads_controller.ex
+++ b/lib/grappa_web/controllers/uploads_controller.ex
@@ -97,6 +97,11 @@ defmodule GrappaWeb.UploadsController do
     "video/webm" => :video,
     "application/pdf" => :document,
     "text/plain" => :document,
+    # #1764 — accepted so a `.md` can exist on the wire at all: the cic
+    # viewer reads it as SOURCE (no rendering, vjt's ruling), and a type
+    # the server refuses can never be read. Category `:document` like its
+    # sibling text/plain — the cap axis is size, not renderability.
+    "text/markdown" => :document,
     "application/vnd.oasis.opendocument.text" => :document,
     "application/vnd.oasis.opendocument.spreadsheet" => :document,
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => :document,

--- a/test/grappa/uploads/mime_ext_test.exs
+++ b/test/grappa/uploads/mime_ext_test.exs
@@ -17,6 +17,9 @@ defmodule Grappa.Uploads.MimeExtTest do
         "video/webm" => "webm",
         "application/pdf" => "pdf",
         "text/plain" => "txt",
+        # #1764 — text/markdown exists so a .md can be uploaded and READ in
+        # the viewer. It is the one MIME this map mints purely for the client.
+        "text/markdown" => "md",
         "application/vnd.oasis.opendocument.text" => "odt",
         "application/vnd.oasis.opendocument.spreadsheet" => "ods",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "docx",


### PR DESCRIPTION
`.txt` and `.md` open in the media-viewer modal and are read inline: monospace
source, line numbers, nothing rendered. Requested by vjt on IRC (#sbiffo,
2026-08-24 23:00) and ruled three minutes later.

## The two rulings this is built to

1. **Source only, no rendering.** vjt, #sbiffo 23:03, verbatim: *"nono nessun
   rendering di gesu, assolutamente solo il sorgente txt e md"*. Not now and
   not as a later toggle. Beyond taste: cic has **no sanitisation surface
   anywhere today**, and a markdown renderer would be the reason it grew one —
   on the page that holds the bearer token. So the `.md` assertions are about
   generated HTML (no `<h1>`, no `<strong>`, no `<a>`), not about looks: a
   rendered-but-unstyled document passes a looks-based check.
2. **`txt` and `md` only.** `pdf/odt/ods/docx/xlsx` stay out of scope, and the
   e2e coverage for them stays (see below).

## The SSOT that said this would never happen, amended in the same change

`Grappa.Uploads.MimeExt`'s moduledoc read, verbatim: *"Document types
(pdf/txt/odt/ods/docx/xlsx) are deliberately NOT viewer-relevant and need no
cic entry."* This change makes that false for two of the six. It is amended
here, naming the reversal and whose call it was — a SSOT that lies is worse
than one that is missing, because the next reader copies the wrong rule and the
code cannot correct them.

`text/markdown` did not exist anywhere before this. It is widened across
`@mime_categories` and `@mime_ext` in lockstep plus the cic mirror
(`uploadCategory.ts`), and it exists for exactly one reason: so the client can
read it. Nothing server-side consults it.

## 🔴 One e2e assertion was rewritten, not weakened — here is exactly what changed

`issue418-upload-url-extension.spec.ts` carried a case titled *"document:
server mints /uploads/&lt;slug&gt;.txt — extension does NOT open the viewer"*. It
uploaded a `.txt` and asserted:

```ts
await expect(link).not.toHaveClass(/scrollback-media-link/);
```

with the comment *"the click never opens the viewer (📄 excluded, `.txt` not in
EXTENSION_KIND)"*.

**Why it no longer holds:** that is a correct pin of the ruling vjt has just
reversed. A `.txt` anchor now DOES carry the media class and the click DOES
open the viewer. Leaving it would have been a test defending the old behaviour
against the change that was ordered — and the first thing to go red would have
been the feature, not the test.

**What was done, and what is still covered:** the case moved to `.pdf` rather
than being deleted, because what #418 is actually about is untouched and still
asserted, on a type that is still out of scope:

- a document extension is minted faithfully (`/uploads/<slug>.pdf`);
- an extension the viewer does not claim leaves the anchor a **plain** link
  (`not.toHaveClass`), so no click reaches the modal;
- BOTH the extensioned URL and the bare slug serve the identical bytes.

So the negative coverage for the out-of-scope document types did not go away —
it moved onto one of them. The bytes stay the existing text fixture on purpose:
`show/2` serves what was stored, and this case is about the URL and the anchor,
not about PDF parsing. The positive coverage for `.txt`/`.md` lands in the new
`issue1764-text-source-viewer.spec.ts`.

## The size cap: decided, with the issue's framing corrected

The issue left the cap undecided and named **128 MB** as the ceiling. Measured:
**that is the roof, not the ceiling a `.txt` reaches.** The binding limit is
per category — `ServerSettings.get_upload_per_file_cap_bytes(:document)`,
default `10 * 1024 * 1024` (`server_settings.ex:97`) — and an operator can
raise it toward the 128 MB roof.

A cap is engineering, so there is one: **`TEXT_VIEW_MAX_BYTES = 512 KiB`**.
Stated plainly, it is **not** a rendering measurement — no browser can be
driven from this dev host and none was. It is anchored on the two measured
numbers above and taken on the safe side of them, because the degradation is
visible and reversible. ~6,500 lines at 80 columns, 20× under the default
document cap, so it bites long before an operator-raised setting could matter.
The DOM cost does not scale with file size either: the pane is **two** text
nodes (gutter + source), not one row per line, so what grows is text layout.

**The cap is enforced from the response stream, not by trusting `Range`.** The
viewer sends `Range: bytes=0-<cap>` as a courtesy so the server does not push
bytes we discard, but reads through `res.body.getReader()` and hangs up — a
proxy that strips the header, or any future admitted host that ignores it,
changes nothing about how much lands in the page. It asks for **one byte past**
the cap, which is what makes `truncated` a fact instead of an inference: read
exactly the cap and stop, and you cannot tell "the file ended here" from "we
stopped here" — a 512 KiB file would be called truncated forever.

### 🛑 Behaviour at the cap is UX — proposed, needs vjt's confirmation

Built as a line **above** the pane:

> showing the first 512 KiB of this file — "open in browser" for the whole thing

Above and not below, on the reasoning that a reader must know they hold a slice
**before** they start, not at a bottom they may never scroll to. Built under
that assumption rather than waiting on it; say the word and it moves, becomes a
footer too, or changes wording. The number itself is equally movable — it is
defensible, not measured on a device.

## The CSP constraint, and why it is not a limitation to lift later

Every other viewer kind hangs an **element** off the URL, governed by
`img-src`/`media-src`, both widened to `https:` (#607, #1240) — which is why a
foreign image opens. A text viewer has no element: it **fetches** the body into
the DOM, which answers to `connect-src`, and that one is `'self'` plus the
captcha hosts and `api.somafm.com`, deliberately **not** widened.

`connect-src` was **not** touched. The asymmetry is the point: an element
source can only be rendered, whereas `fetch` can READ a response body, so
widening it is exfiltration surface in a way the two media directives are not.
So the classifier scopes text to admitted hosts (page origin ∪ #324 aliases)
and says so where the next person will look — the moduledoc, the
`externalMediaLink` docstring, and a test asserting a third-party `.txt` and
`.md` stay `null` rather than leaving it to be inferred from absence. There are
**two** extension tables, `EXTENSION_KIND` (element-backed, usable by the
external branch) and `TEXT_EXTENSION_KIND` (fetch-backed, same-host only), so
that distinction is a type and not a comment.

## Gestures: a scrolling body cannot share the vertical axis

Per the issue's warning, `pinchZoom`/double-tap are **not** wired to this kind,
and the ESC route through `createOverlayLock` (#232) is reused untouched.

`bindDismissGesture` (#1438) commits on an up OR down drag, which is right when
nothing underneath scrolls and wrong the moment something does — at the top of
a text pane an upward drag means "read on". It gained a **required**
`directions: "both" | "down"` (required, not defaulted: one call site today,
and a silent default is how the media arm would inherit a narrowing meant for
text). The narrowing applies to the **claim** as well as the commit — a
claimed-then-refused drag has already been `preventDefault`ed and hands the
scroller nothing. Paired with `canDismiss: () => pane.scrollTop <= 0`:

- scrolled → the pane keeps every vertical drag;
- at the top → up still scrolls, only down dismisses.

Both cic touch landmines are respected: listeners are element-level with
`{passive: false}` (Solid delegates touch to a passive document listener), and
`.media-viewer-modal--text` re-opens `touch-action` to `pan-x pan-y` on the
modal element itself, because the base rule takes the whole stream with `none`
and a descendant cannot widen what an ancestor narrowed.

### 🛑 The iOS behaviour of this gesture is NOT verified — it awaits dogfood

Stated here and not only in the closing section, because this is a gesture
change and that is the one claim a reader would otherwise assume. **No browser
can be driven from this dev host, and Playwright webkit is not iOS** — so what
the unit and e2e runs prove is the DECISION path (which drags commit, which are
never claimed, which the pane keeps), not the feel and not the interaction with
Safari's own scrolling. Specifically unverified:

- whether iOS begins a **rubber-band before the dismiss claim lands** on a pane
  at `scrollTop 0` — `overscroll-behavior: contain` is what it gets meanwhile;
- the exact **termination rule of the UA's `touch-action` ancestor
  intersection** at a scroll container, which is why the re-opening is declared
  on the modal element rather than relied upon to stop at the pane;
- the `DISMISS_COMMIT_FRACTION` feel on a real phone — inherited from #1438,
  where it is already labelled a defensible default and not a measurement.

None of that blocks reading a file, which is what the issue asked for: ESC, the
✕ and the backdrop are all kind-agnostic and unaffected. But if the swipe feels
wrong on the phone, that is expected to surface in dogfood rather than in CI,
and the two gates above are where to look first.

## What I measured, and what I refuse to claim

**Measured, and it corrects the issue:**

- The document upload cap is **10 MiB** by default, not 128 MB (above).
- **The lockstep guard is ONE-directional, not two.** The issue says
  *"`MimeExtTest` fails CI if a MIME lands in one and not the other"*. Bench,
  on this branch, both directions:
  - `text/markdown` in `@mime_categories`, absent from `@mime_ext` → **RED, 2
    failures**, naming it: *"MIME "text/markdown" is accepted by
    UploadsController.mime_categories/0 but has no
    Grappa.Uploads.MimeExt.ext_for/1 mapping"*.
  - `text/markdown` in `@mime_ext`, absent from `@mime_categories` → **GREEN, 4
    tests, 0 failures.** The lockstep iterates over `mime_categories()`, so it
    structurally cannot see an orphan in `@mime_ext`.

  The uncovered direction is the low-impact one (an extension minted for a MIME
  the server refuses to accept is dead code, not a wrong response), and the
  dangerous direction — accepted but extensionless, so cic loses the viewer —
  IS covered. **Not fixed here**: closing it means exposing `@mime_ext` publicly
  to widen a guard that has produced no defect, which is a different change
  from this one. Flagged for a call rather than done quietly. The existing
  comment does not overstate itself, so nothing there needed correcting.

**Not established, and not dressed up as decided:**

- Whether **iOS begins a rubber-band before the dismiss claim lands** on a pane
  at `scrollTop 0`. No browser can be driven from this host and webkit
  emulation is not iOS. `overscroll-behavior: contain` is what it gets in the
  meantime; the verdict is dogfood's.
- The exact termination rule of the UA's **`touch-action` ancestor
  intersection** at a scroll container. That is why the re-opening is declared
  on the modal element rather than relied upon to stop at the pane — I did not
  measure it, so I did not build on it.
- **`.md` file labelling.** A browser does not always hand a `.md` file
  `text/markdown`; where the OS MIME table has no entry it sends `""` or
  `application/octet-stream`, and the closed allowlist rejects those *before*
  upload. Deliberately **no** extension rescue added: the server's existing one
  is scoped to audio where the mislabelling was measured, and widening it to
  documents reopens the closed allowlist for a convenience nobody has asked
  for. The e2e sets the MIME explicitly, so it proves the pipeline, **not** that
  every OS labels `.md` correctly.
