### PR TITLE
cic: »N resolves a far-behind window by jumping back, not by doing nothing (#1765)

### DIFF
--- a/cicchetto/e2e/tests/issue1765-farbehind-next-active-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue1765-farbehind-next-active-jump.spec.ts
@@ -1,0 +1,173 @@
+// #1765 — `»N` on the only unread window, when that window is far behind.
+//
+// Two cures that are each right cancel out. #1178 made the jump verb
+// short-circuit to `requestScrollToBottom()` when the cycle resolves back to
+// the window the operator is already in; #693/#1019 freeze the read cursor
+// while a window is far behind, deliberately, so that scroll cannot advance
+// it. With both in force the tap moved nothing at all: the bar stayed, the
+// frozen seed stayed, and the button kept advertising a count.
+//
+// The cure routes that arm to the bar's PRIMARY exit — the jump BACK into the
+// unread region — and not to its `×`. What that difference LOOKS like is
+// exactly what this spec measures, because the two are indistinguishable from
+// "the bar went away":
+//
+//   * the bar goes away AND the pane lands on the unread divider, carrying the
+//     server-measured count. A dismiss also clears the bar, and re-latches the
+//     divider away, so the marker is the discriminator between the two;
+//   * the SERVER cursor has NOT crossed the abandoned region. This is the
+//     product claim, not a mechanism: a tap on an unlabelled `»` that reads
+//     `1` (it counts WINDOWS) must not accept thousands of messages as read on
+//     every device. #1062 already removed a second dismiss surface from the
+//     float stack this button lives in, for the neighbouring reason.
+//
+// NOT asserted: that the button hides. It should not, and that is the honest
+// outcome rather than a gap — after the jump the unread is local, real, and on
+// screen, so the count it renders is true for the first time. Reading to the
+// tail clears it, or a second tap now takes #1178's exit with the freeze gone.
+// The issue's Expected clause asked for the button to hide; that followed from
+// its dismiss proposal, which the fix declines.
+//
+// Seeding mirrors `issue1062-far-behind-float-stack.spec.ts` and
+// `issue1019-farbehind-leave-dismiss.spec.ts` (same bar, same precondition):
+// the shared seeder plants 200 rows in #spec-wN and this needs a gap ABOVE the
+// 200-row page cap, so it re-seeds via the admin `resetSubject(baselineSeed)`
+// surface. Nothing has to be undone afterwards: #1078 destroys the whole
+// subject at teardown, rows and cursor with it. Seeding ONE channel is also
+// what makes it the ONLY unread window, which is the state the bug needs.
+//
+// No sleep is used as synchronisation: every step waits on an observable
+// condition. The timeouts are WAIT BUDGETS on those conditions, never the
+// thing being measured.
+//
+// Desktop viewport, as both sibling far-behind specs: the sidebar badge is the
+// clearer read of "the count is no longer the frozen one".
+
+import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  getReadCursor,
+  resetSubject,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Larger than the 200-row server cap, so a cursor planted early leaves a gap
+// the resume cannot drain in one page — the far-behind precondition.
+const LARGE_SEED_COUNT = 260;
+const SEED_SENDER = "seed-bot";
+
+// The server's `@max_http_limit` and the client's `PAGE_LIMIT`. A gap above
+// this is what "far behind" means.
+const MAX_HTTP_LIMIT = 200;
+
+// Rows left after the planted cursor — above the cap, so the pane anchors at
+// the tail and freezes.
+const UNREAD_TARGET = 240;
+
+// Wait budget for the resume probe, the jump's two fetches, and the settle
+// writes. Not a sleep: it bounds `expect` CONDITIONS.
+const OUTCOME_TIMEOUT_MS = 10_000;
+
+const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
+const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
+
+const countIn = (label: string, what: string): number => {
+  const match = label.match(/(\d+)/);
+  if (!match?.[1]) {
+    throw new Error(`#1765 spec: ${what} carries no count: ${JSON.stringify(label)}`);
+  }
+  return Number(match[1]);
+};
+
+test.describe("#1765 — »N on a far-behind window jumps back instead of doing nothing", () => {
+  test("the tap clears the bar, lands on the unread divider, and reads nothing for you", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = specUser();
+    const admin = getSeededAdmin();
+
+    await resetSubject(
+      admin.token,
+      specUser().name,
+      { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
+      { [NETWORK_SLUG]: [{ name: CHANNEL, seedCount: LARGE_SEED_COUNT, seedSender: SEED_SENDER }] },
+    );
+
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
+
+    const lastReadRow = rows[rows.length - UNREAD_TARGET];
+    const tailRow = rows[rows.length - 1];
+    if (!lastReadRow || !tailRow)
+      throw new Error("#1765 spec: seeded #spec-wN rows missing an index");
+
+    // Guard the precondition: below this the pane never goes far behind and
+    // the spec would pass by testing nothing.
+    const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
+    expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+    // Plant the cursor BEFORE login so the channel hydrates with it and takes
+    // the cursor-present fetch arm.
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, lastReadRow.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL);
+
+    // The bar renders only once the resume has probed the count and refused
+    // the gap — the readiness signal for the far-behind arm, and the gate that
+    // says the freeze is actually in force.
+    const bar = page.locator('[data-testid="far-behind-bar"]');
+    await expect(bar).toBeAttached({ timeout: OUTCOME_TIMEOUT_MS });
+
+    const badge = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+    await expect(badge).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
+    await expect(badge).toHaveClass(/far-behind/);
+
+    // The pane is at the tail, so the divider is suppressed (#693): the rows
+    // on screen are NOT the unread region. Pinning its absence here is what
+    // makes its presence after the tap mean something.
+    await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0);
+
+    // The crossed state: this is the ONLY window with unread, so the cycle can
+    // only resolve back to the selection. The count is a WINDOW count — the
+    // `»1` under which a dismiss would have destroyed 240 messages.
+    await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", {
+      timeout: OUTCOME_TIMEOUT_MS,
+    });
+
+    // Nothing has moved the cursor yet: the pane has been open and rendered
+    // and it is still exactly where it was planted. Without this the closing
+    // assertion could be satisfied by a write that never happened at all.
+    expect(await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL)).toBe(lastReadRow.id);
+
+    // THE gesture — the same button #235 ships, through the same verb Alt+A
+    // fires. On the parent commit this is where everything stops moving.
+    await page.locator(NEXT_ACTIVE_BTN).click();
+
+    // Outcome 1 — the far-behind state is resolved. The bar is down and the
+    // badge has dropped the #888 frozen treatment.
+    await expect(bar).toHaveCount(0, { timeout: OUTCOME_TIMEOUT_MS });
+    await expect(badge).not.toHaveClass(/far-behind/, { timeout: OUTCOME_TIMEOUT_MS });
+
+    // Outcome 2 — and it resolved by taking the operator TO the unread, not by
+    // throwing it away. The divider is back, at their read position, carrying
+    // the server-measured count rather than the page cap (#947). A dismiss
+    // clears the bar too and re-latches this marker away, so this is the line
+    // that tells the two exits apart.
+    const marker = page.locator('[data-testid="unread-marker"]');
+    await expect(marker).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
+    expect(countIn(await marker.innerText(), "the unread divider")).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+    // Outcome 3 — the product claim. An unlabelled `»` reading `1` did not
+    // accept the abandoned region as read on every device. The cursor may
+    // creep forward as the newly-rendered rows are read (the freeze is gone,
+    // which is the point), but it must not have crossed to the tail.
+    const cursorAfter = await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL);
+    expect(cursorAfter).toBeLessThan(tailRow.id);
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -22,6 +22,7 @@ import { isDocumentVisible } from "./lib/documentVisibility";
 import { highlightPatterns } from "./lib/highlightList";
 import { type InviteAckEntry, inviteAckBySlug } from "./lib/inviteAck";
 import { chantypesForNetwork, prefixForNetwork } from "./lib/isupport";
+import { jumpToUnreadRequest } from "./lib/jumpToUnreadCommand";
 import { membersByChannel } from "./lib/members";
 import { matchesWatchlist } from "./lib/mentionMatch";
 import {
@@ -3792,6 +3793,32 @@ const ScrollbackPane: Component<Props> = (props) => {
   // re-latch below is the half a second caller would forget — see #997's
   // measurement in DESIGN_NOTES: dropping it slams a stale divider across
   // the top of the buffer.
+  // #693's OTHER exit, the bar's primary one — lifted out of the button's
+  // inline handler by #1765 so a second door can reach the same gesture
+  // (`»N` on a far-behind window; see `jumpToUnreadCommand`). It is a named
+  // function for exactly the reason the dismiss below is: the latch arming is
+  // the half a direct caller of `scrollback.jumpToUnread` would forget.
+  const jumpToUnreadGesture = () => {
+    // Arm the EXISTING marker-activation latch (#168) before the swap:
+    // clearing the far-behind flag re-injects the divider, and the rows-change
+    // that lands the anchor region is exactly the content change that latch
+    // scrolls to. Set synchronously so it is armed when the awaited rows
+    // arrive — one more trigger on the existing scroll writer, not a second
+    // scroll authority. Stood back down if the fetch failed, so a dead latch
+    // can't yank a later unrelated rows() change.
+    setMarkerActivationPending(true);
+    void jumpToUnread(props.networkSlug, props.channelName).then((jumped) => {
+      if (!jumped) setMarkerActivationPending(false);
+    });
+  };
+
+  // #1765 — the `»N` affordance resolves to THIS window when it is the only
+  // one with unread, and on a far-behind window #1178's scroll-to-bottom exit
+  // cannot move the frozen cursor. The jump back is the live verb there, and
+  // it is the same one the bar fires. `defer` skips the value read at mount,
+  // so only a genuine request runs it.
+  createEffect(on(jumpToUnreadRequest, () => jumpToUnreadGesture(), { defer: true }));
+
   const dismissFarBehindGesture = () => {
     // Re-latch the frozen divider to whatever was marked read. Dismiss is an
     // explicit "I've read to here" gesture — the same class as the
@@ -3865,20 +3892,7 @@ const ScrollbackPane: Component<Props> = (props) => {
               type="button"
               class="scrollback-far-behind-jump"
               data-testid="far-behind-jump"
-              onClick={() => {
-                // Arm the EXISTING marker-activation latch (#168) before the
-                // swap: clearing the far-behind flag re-injects the divider,
-                // and the rows-change that lands the anchor region is exactly
-                // the content change that latch scrolls to. Set synchronously
-                // so it is armed when the awaited rows arrive — one more
-                // trigger on the existing scroll writer, not a second scroll
-                // authority. Stood back down if the fetch failed, so a dead
-                // latch can't yank a later unrelated rows() change.
-                setMarkerActivationPending(true);
-                void jumpToUnread(props.networkSlug, props.channelName).then((jumped) => {
-                  if (!jumped) setMarkerActivationPending(false);
-                });
-              }}
+              onClick={jumpToUnreadGesture}
             >
               {far().missed} unread — jump back
             </button>

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -6,6 +6,10 @@ import { activeAudio, closeAudio } from "../lib/audioPlayer";
 // #1156 — the REAL compose store: the swipe's whole outcome is what lands in
 // the draft, and a mock here would assert that the pane called something.
 import { getDraft, setDraft } from "../lib/compose";
+// #1765 — the REAL nonce the `»N` verb bumps. Not mocked: what this file
+// pins is that the pane ANSWERS it with the bar's own gesture, and a mock
+// would leave the wiring untested on both sides.
+import { requestJumpToUnread } from "../lib/jumpToUnreadCommand";
 import { closeMediaViewer, mediaViewerState } from "../lib/mediaViewer";
 import {
   popOverlay,
@@ -2630,6 +2634,28 @@ describe("ScrollbackPane", () => {
           <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
         ));
         screen.getByTestId("far-behind-jump").click();
+        expect(jumpToUnreadSpy).toHaveBeenCalledWith("freenode", "#grappa");
+      });
+
+      // #1765 — the far-behind window can be the ONLY one with unread, and
+      // then the `»N` cycle resolves back to it. #1178's scroll-to-bottom exit
+      // is dead there (the cursor is frozen), so the verb asks the pane for
+      // the bar's jump instead. Asserted through the REAL nonce so both ends
+      // of the bridge are pinned; the pane must answer with the SAME gesture
+      // the button fires, latch included, not a second copy of it.
+      it("runs that same gesture when the »N verb asks for it (#1765)", async () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        // `defer` — the nonce value standing at mount is not a request.
+        expect(jumpToUnreadSpy).not.toHaveBeenCalled();
+
+        requestJumpToUnread();
+        await Promise.resolve();
+
         expect(jumpToUnreadSpy).toHaveBeenCalledWith("freenode", "#grappa");
       });
 

--- a/cicchetto/src/__tests__/activeWindowsStep.test.ts
+++ b/cicchetto/src/__tests__/activeWindowsStep.test.ts
@@ -24,6 +24,7 @@ import { channelKey } from "../lib/channelKey";
 const h = vi.hoisted(() => ({
   channels: [] as Array<{ name: string }>,
   unread: {} as Record<string, number>,
+  farBehind: {} as Record<string, { missed: number; resumeFrom: number }>,
   selected: null as { networkSlug: string; channelName: string; kind: string } | null,
   setSelectedChannel: vi.fn(),
   isActiveSelection: vi.fn(),
@@ -46,7 +47,10 @@ vi.mock("../lib/notificationPrefs", () => ({
 // No local rows: every window's activity id falls back to 0, so the ordering
 // ties and resolves by flat (sidebar) order — deterministic without pinning
 // scrollback shapes this file does not care about.
-vi.mock("../lib/scrollback", () => ({ scrollbackByChannel: () => ({}) }));
+vi.mock("../lib/scrollback", () => ({
+  scrollbackByChannel: () => ({}),
+  farBehindByChannel: () => h.farBehind,
+}));
 
 vi.mock("../lib/selection", () => ({
   messagesUnread: () => h.unread,
@@ -71,6 +75,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.channels = [];
   h.unread = {};
+  h.farBehind = {};
   h.selected = null;
   h.isActiveSelection.mockReturnValue(false);
 });
@@ -106,6 +111,57 @@ describe("stepActiveWindow — the resolved target is the window you are already
     expect(h.requestScrollToBottom).toHaveBeenCalledTimes(1);
     expect(h.setSelectedChannel).not.toHaveBeenCalled();
   });
+});
+
+// #1765 — the SAME resolution, one state narrower: the window the cycle
+// resolves back to is ALSO far behind (#693). #1178's exit is dead there and
+// nothing else takes its place, so the tap moves nothing at all.
+//
+// Why the exit is dead, in two halves that are each correct on their own:
+//   * selection.ts's `perChannelUnread` SKIPS a far-behind window's
+//     local-derived branch, so the frozen server seed stands as its count and
+//     `messagesUnread[key] > 0` holds wherever the pane is scrolled — which is
+//     also why the read-at-the-tail suppression is explicitly not applied to
+//     it. The window therefore never leaves `orderUnreadWindows`.
+//   * `setCursorIfAdvances` — the single cursor door every writer funnels
+//     through, `requestScrollToBottom` included — returns on its first line
+//     for a far-behind window (#1019 documents the freeze as the invariant).
+// Both halves are pinned elsewhere (`unreadBadgeAtTail.test.ts`,
+// `setCursorIfAdvances.test.ts`); what this file pins is the JOIN, at the verb
+// that has to choose between them.
+//
+// The assertion is deliberately cure-AGNOSTIC — it says only "not the dead
+// door" — because which live verb belongs here is a product call, not a
+// mechanical one. Every candidate cure satisfies it; main does not.
+describe("stepActiveWindow — that window is ALSO far behind (#1765)", () => {
+  const arrangeCrossedState = () => {
+    h.channels = [{ name: "#grappa" }];
+    // The frozen seed, not a local-row count — that IS the #693 posture.
+    h.unread = { [channelKey("net", "#grappa")]: 3000 };
+    h.farBehind = { [channelKey("net", "#grappa")]: { missed: 3000, resumeFrom: 100 } };
+    h.selected = chan("#grappa");
+    h.isActiveSelection.mockReturnValue(true);
+  };
+
+  it("does not take the #1178 exit, whose only cursor door is frozen", async () => {
+    arrangeCrossedState();
+
+    const { activeWindows, jumpToNextActiveWindow } = await load();
+    // Pin the crossed state itself, so this can never rot into a vacuous
+    // green: exactly ONE unread window (the mute mock is empty, so it is also
+    // un-muted — #1018 would otherwise drop it from the cycle), and it IS the
+    // current selection.
+    expect(activeWindows()).toEqual([chan("#grappa")]);
+
+    jumpToNextActiveWindow();
+
+    // Not a lateral move — the list has nowhere else to go.
+    expect(h.setSelectedChannel).not.toHaveBeenCalled();
+    // ...and not the vertical one either: it cannot advance the cursor here,
+    // so the seed never falls, the button never hides, and the tap is a no-op.
+    expect(h.requestScrollToBottom).not.toHaveBeenCalled();
+  });
+
 });
 
 // Regression guards, not discriminators for the fix: each of these passes both

--- a/cicchetto/src/__tests__/activeWindowsStep.test.ts
+++ b/cicchetto/src/__tests__/activeWindowsStep.test.ts
@@ -29,6 +29,7 @@ const h = vi.hoisted(() => ({
   setSelectedChannel: vi.fn(),
   isActiveSelection: vi.fn(),
   requestScrollToBottom: vi.fn(),
+  requestJumpToUnread: vi.fn(),
 }));
 
 vi.mock("../lib/networks", () => ({
@@ -64,6 +65,10 @@ vi.mock("../lib/selection", () => ({
 
 vi.mock("../lib/scrollToBottomCommand", () => ({
   requestScrollToBottom: h.requestScrollToBottom,
+}));
+
+vi.mock("../lib/jumpToUnreadCommand", () => ({
+  requestJumpToUnread: h.requestJumpToUnread,
 }));
 
 const chan = (name: string) => ({ networkSlug: "net", channelName: name, kind: "channel" });
@@ -130,9 +135,12 @@ describe("stepActiveWindow — the resolved target is the window you are already
 // `setCursorIfAdvances.test.ts`); what this file pins is the JOIN, at the verb
 // that has to choose between them.
 //
-// The assertion is deliberately cure-AGNOSTIC — it says only "not the dead
-// door" — because which live verb belongs here is a product call, not a
-// mechanical one. Every candidate cure satisfies it; main does not.
+// The first assertion is deliberately cure-AGNOSTIC — it says only "not the
+// dead door". The cure the rest pins fires the bar's PRIMARY exit, the jump
+// BACK into the region, and NOT its `×`: that one accepts the abandoned
+// region as read, irreversibly and on every device, and #1062 already removed
+// a second surface for it from the float stack this button sits in. The arm's
+// own comment carries the argument.
 describe("stepActiveWindow — that window is ALSO far behind (#1765)", () => {
   const arrangeCrossedState = () => {
     h.channels = [{ name: "#grappa" }];
@@ -162,6 +170,58 @@ describe("stepActiveWindow — that window is ALSO far behind (#1765)", () => {
     expect(h.requestScrollToBottom).not.toHaveBeenCalled();
   });
 
+  it("asks the pane for the bar's jump BACK into the unread region", async () => {
+    arrangeCrossedState();
+
+    const { jumpToNextActiveWindow } = await load();
+    jumpToNextActiveWindow();
+
+    expect(h.requestJumpToUnread).toHaveBeenCalledTimes(1);
+  });
+
+  it("does the same for the PREVIOUS direction (Ctrl+P)", async () => {
+    arrangeCrossedState();
+
+    const { jumpToPrevActiveWindow } = await load();
+    jumpToPrevActiveWindow();
+
+    expect(h.requestJumpToUnread).toHaveBeenCalledTimes(1);
+    expect(h.requestScrollToBottom).not.toHaveBeenCalled();
+  });
+
+  // The discriminator against "always jump back": the far-behind flag is what
+  // selects the arm, not the fact that the cycle resolved to the current
+  // window. Without it, deleting the predicate would still pass.
+  it("keeps the #1178 exit on a window that is NOT far behind", async () => {
+    arrangeCrossedState();
+    h.farBehind = {};
+
+    const { jumpToNextActiveWindow } = await load();
+    jumpToNextActiveWindow();
+
+    expect(h.requestScrollToBottom).toHaveBeenCalledTimes(1);
+    expect(h.requestJumpToUnread).not.toHaveBeenCalled();
+  });
+
+  // A far-behind window is a stop on the cycle like any other while there is
+  // somewhere else to go: the arm is reached only through `isActiveSelection`,
+  // so a lateral move must stay lateral.
+  it("still steps AWAY when another window is unread, far behind or not", async () => {
+    h.channels = [{ name: "#grappa" }, { name: "#other" }];
+    h.unread = {
+      [channelKey("net", "#grappa")]: 3000,
+      [channelKey("net", "#other")]: 1,
+    };
+    h.farBehind = { [channelKey("net", "#grappa")]: { missed: 3000, resumeFrom: 100 } };
+    h.selected = chan("#grappa");
+
+    const { jumpToNextActiveWindow } = await load();
+    jumpToNextActiveWindow();
+
+    expect(h.setSelectedChannel).toHaveBeenCalledWith(chan("#other"));
+    expect(h.requestJumpToUnread).not.toHaveBeenCalled();
+    expect(h.requestScrollToBottom).not.toHaveBeenCalled();
+  });
 });
 
 // Regression guards, not discriminators for the fix: each of these passes both

--- a/cicchetto/src/__tests__/jumpToUnreadCommand.test.ts
+++ b/cicchetto/src/__tests__/jumpToUnreadCommand.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { jumpToUnreadRequest, requestJumpToUnread } from "../lib/jumpToUnreadCommand";
+
+// #1765 — the jump-back command nonce, sibling to `scrollToBottomCommand` and
+// pinned for the same property: a monotonic counter, not a boolean toggle, so
+// back-to-back requests each register as a DISTINCT transition. Solid's `===`
+// equality would swallow a repeated `true`, and the second `»N` tap on a
+// window still far behind (a failed fetch leaves the flag standing) is exactly
+// the case that would go missing.
+describe("jumpToUnreadCommand", () => {
+  it("requestJumpToUnread advances the request nonce by one", () => {
+    const before = jumpToUnreadRequest();
+    requestJumpToUnread();
+    expect(jumpToUnreadRequest()).toBe(before + 1);
+  });
+
+  it("each back-to-back call is a distinct transition (monotonic, no === swallow)", () => {
+    const start = jumpToUnreadRequest();
+    requestJumpToUnread();
+    requestJumpToUnread();
+    requestJumpToUnread();
+    expect(jumpToUnreadRequest()).toBe(start + 3);
+  });
+});

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -1,12 +1,13 @@
 import { createMemo, untrack } from "solid-js";
 import { type ChannelKey, channelKey } from "./channelKey";
 import { isConversationMuted, windowMuteKey } from "./conversationMute";
+import { requestJumpToUnread } from "./jumpToUnreadCommand";
 import { mentionCounts } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
 import { channelsBySlug, networks } from "./networks";
 import { notificationPrefs } from "./notificationPrefs";
 import { queryWindowsByNetwork } from "./queryWindows";
-import { scrollbackByChannel } from "./scrollback";
+import { farBehindByChannel, scrollbackByChannel } from "./scrollback";
 import { requestScrollToBottom } from "./scrollToBottomCommand";
 import {
   isActiveSelection,
@@ -285,8 +286,42 @@ function stepActiveWindow(dir: 1 | -1): void {
   // exact negation of the setter's short-circuit (both route through
   // `sameSelection`), so this arm cannot drift from the non-transition
   // rule that makes it necessary.
+  //
+  // #1765 — the sentence above names its own boundary, and the boundary
+  // turned out to be a hole. `requestScrollToBottom` reaches the cursor
+  // ONLY through `setCursorIfAdvances`, which returns on its first line for
+  // a far-behind window (#693's freeze, #1019's invariant). So on a window
+  // that IS far behind, #1178's exit is as dead as the `jumpToUnread` it
+  // rejected — two correct cures cancelling — and the tap moves nothing at
+  // all: the seed count cannot fall, so the button cannot hide.
+  //
+  // The two verbs partition the state exactly along `farBehindByChannel`,
+  // and the comment above already says why each is dead on the other's
+  // side. So take the live one: far behind ⇒ the bar's OWN primary exit,
+  // the jump BACK into the unread region.
+  //
+  // NOT the bar's `×` (`dismissFarBehind`), which the report proposed.
+  // That verb accepts the abandoned region as read — irreversible, fanned
+  // to every device — and #1062 already ruled on putting it under this
+  // thumb: it removed #997's second dismiss surface from the very float
+  // stack this button lives in, on the grounds that "the far-behind gesture
+  // stays on the bar, where it has a label". `»` carries no label but
+  // "jump to next active window", and the count it shows is a WINDOW count
+  // (1), so a tap would destroy thousands of unread while reading `»1`.
+  // The jump is reversible (scroll back down / `loadNewer`) and is what the
+  // glyph promises; the destructive exit stays one labelled tap away on the
+  // bar. Duplicating a non-destructive route is harmless — duplicating a
+  // destructive one is what #1062 measured and removed.
+  //
+  // A nonce rather than a direct `scrollback.jumpToUnread` call for the
+  // same reason #243 is one: the #168 marker-activation latch the gesture
+  // must arm is pane-local. See `jumpToUnreadCommand`.
   if (isActiveSelection(next)) {
-    requestScrollToBottom();
+    if (untrack(farBehindByChannel)[channelKey(next.networkSlug, next.channelName)]) {
+      requestJumpToUnread();
+    } else {
+      requestScrollToBottom();
+    }
     return;
   }
   setSelectedChannel(next);

--- a/cicchetto/src/lib/jumpToUnreadCommand.ts
+++ b/cicchetto/src/lib/jumpToUnreadCommand.ts
@@ -1,0 +1,30 @@
+import { createSignal } from "solid-js";
+
+// #1765 — imperative "run the far-behind bar's jump-back gesture on the
+// active scrollback pane" command. The exact shape of #243's
+// `scrollToBottomCommand`, and here for the exact same reason: the caller
+// owns the GESTURE, ScrollbackPane owns the machinery.
+//
+// The machinery in question is the #168 marker-activation latch. The bar's
+// jump-back arms it synchronously BEFORE the swap (so it is set when the
+// awaited rows land) and stands it back down if the fetch failed — a
+// pane-local signal, like the `markerCursorId` re-latch the × needs. A
+// caller that reached `scrollback.jumpToUnread` directly would swap the rows
+// and leave the pane parked wherever it was, which is the half a caller
+// forgets. So the caller bumps this nonce and the single mounted pane runs
+// its own `jumpToUnreadGesture` — one gesture, two doors, no second scroll
+// authority.
+//
+// Not state: a monotonic nonce is a transient EDGE, for the same reasons
+// spelled out in `scrollToBottomCommand` — a counter rather than a boolean so
+// back-to-back requests each fire a distinct transition, and a plain
+// module-singleton because a value carried across an identity rotation just
+// means "no new request" (the subscriber's `{ defer: true }` skips the value
+// it reads at mount).
+const [jumpToUnreadRequest, setJumpToUnreadRequest] = createSignal(0);
+
+export { jumpToUnreadRequest };
+
+export const requestJumpToUnread = (): void => {
+  setJumpToUnreadRequest((n) => n + 1);
+};

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62737,3 +62737,85 @@ the verdict is dogfood's. Likewise the exact termination rule of the UA's
 `touch-action` ancestor intersection at a scroll container was not measured,
 which is why the re-opening is declared on the modal element rather than relied
 upon to stop at the pane.
+<!-- entry #1765 -->
+
+---
+
+## 2026-08-25 — #1765: two correct cures cancelled, and the tap did nothing
+
+`»N` on a window that is the only one with unread AND is far behind was a
+no-op. Neither half was a bug on its own, which is the fact worth not
+rediscovering.
+
+**#1178** taught the jump verb to short-circuit: when the cycle resolves back
+to the window the operator is already in, hand it `requestScrollToBottom()`
+rather than a non-transition `setSelectedChannel` drops on the floor. That
+exit works because reaching the bottom advances the read cursor (#310), so the
+count that advertised the jump falls and the button auto-hides.
+
+**#693/#1019** freeze the read cursor while a window is far behind, on
+purpose. `setCursorIfAdvances` is the single door every writer funnels
+through, and it returns on its first line for such a window — precisely so
+that scrolling, backgrounding or *tapping to the bottom* cannot silently mark
+an abandoned region read and fan that to every device.
+
+Cross the two and the exit is dead. The cursor cannot move, so the frozen
+server seed stands, so `messagesUnread[key] > 0` holds wherever the pane is
+scrolled, so the window never leaves `orderUnreadWindows`, so the button keeps
+rendering and keeps advertising a count. #1178's own comment had already
+rejected `jumpToUnread` for this arm as "just as dead" — true in the state it
+was looking at, and exactly inverted in this one. **Each cure was measured
+against its own state and neither was measured against the other's.**
+
+### Why the fix is the jump BACK and not the bar's ×
+
+The report proposed firing `dismissFarBehind`, the `×`. Declined, with a
+measurement rather than a preference.
+
+`dismissFarBehind` accepts the abandoned region as read: irreversible, and
+fanned to every device. **#1062 has already ruled on putting that under this
+thumb.** It removed #997's second dismiss surface from the `.scrollback-float-stack`
+— the very stack the mobile `»N` button lives in — on the grounds that the
+corner is a repeated-tap route (scroll-to-bottom, then next-active in the same
+spot) and "the far-behind gesture stays on the bar, where it has a label".
+Routing the dismiss into `»` is worse than what #1062 removed, not better: it
+adds no control and no label, and `activeWindowCount()` is a count of WINDOWS,
+so the button reads `»1` while a tap would accept hundreds or thousands of
+messages as read.
+
+The bar's other exit has none of that. It is reversible (scroll back down,
+`loadNewer`), it is what the glyph promises, and the destructive door stays
+one labelled tap away on the bar that is already on screen. The general rule
+this leaves: **duplicating a non-destructive route is harmless; duplicating a
+destructive one is the thing #1062 measured and removed.**
+
+The two verbs also partition the state exactly along `farBehindByChannel`, and
+#1178's comment already says why each is dead on the other's side — so the arm
+is one predicate, not a new concept.
+
+### The nonce, and why it is not new state
+
+`stepActiveWindow` cannot call `scrollback.jumpToUnread` directly. The gesture
+must arm the #168 marker-activation latch synchronously BEFORE the swap and
+stand it back down if the fetch failed, and that latch is a pane-local signal
+— the same reason `dismissFarBehindGesture` is a named function and not an
+inline handler. So the bar's inline handler became `jumpToUnreadGesture` and
+both doors run it, bridged by `jumpToUnreadCommand`, a monotonic nonce of
+exactly #243's shape. One gesture, two callers, no second scroll authority.
+
+### What the operator sees, and what was left undecided
+
+The bar goes down and the pane lands on the unread divider at their read
+position, carrying the server-measured count (#947's carry, not the page cap).
+**The button does NOT hide on that tap** — the issue's Expected clause asked
+for it, but that followed from the dismiss proposal. After the jump the unread
+is local, real and on screen, so the count is honest for the first time;
+reading to the tail clears it, or a second tap takes #1178's exit now that the
+freeze is gone.
+
+Two candidates were weighed and are NOT built, because both are product calls
+and both are vjt's: firing the `×` after all (a one-arm change), and dropping
+a far-behind CURRENT selection from `orderUnreadWindows` so the button
+auto-hides and the labelled bar is the only affordance — which #1178
+explicitly rejected as trading a lying button for an absent one, an argument
+made before the bar was known to be up in this state.

--- a/test/grappa_web/controllers/messages_limit_mirror_test.exs
+++ b/test/grappa_web/controllers/messages_limit_mirror_test.exs
@@ -5,7 +5,7 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
 
   `@default_limit` (the unconfigured-client page size) is re-declared as
   `REST_PAGE_SIZE` in 14 specs; `@max_http_limit` (the boundary ceiling)
-  as `MAX_HTTP_LIMIT` in 4. Eighteen numbers kept in lockstep by hand,
+  as `MAX_HTTP_LIMIT` in 5. Nineteen numbers kept in lockstep by hand,
   with no witness: change the attribute and every spec keeps asserting
   the old page size, silently, because a Playwright spec seeds its own
   fixture and never asks the server what its default is.
@@ -60,7 +60,7 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   # here, which is the moment someone reads this.
   @mirrors [
     {"REST_PAGE_SIZE", "default_limit", 14},
-    {"MAX_HTTP_LIMIT", "max_http_limit", 4}
+    {"MAX_HTTP_LIMIT", "max_http_limit", 5}
   ]
 
   describe "the extractors (#1646 — the predicates)" do


### PR DESCRIPTION
## What was broken

`»N` on a window that is the **only** one with unread AND is **far behind**
(#693) did nothing at all: the bar stayed up, the count stayed, the button
stayed. Reported by vjt from the mobile PWA on staging.

Neither half was a bug on its own — that is the whole finding.

* **#1178** routes the jump to `requestScrollToBottom()` when the cycle
  resolves back to the window you are already in. It works because reaching
  the bottom advances the read cursor (#310), so the count falls.
* **#693/#1019** freeze the read cursor while a window is far behind, on
  purpose. `setCursorIfAdvances` — the single door every writer funnels
  through, `requestScrollToBottom` included — returns on its first line.

Crossed, the exit is dead: the cursor cannot move ⇒ the frozen seed stands ⇒
`messagesUnread[key] > 0` holds wherever the pane is scrolled ⇒ the window
never leaves `orderUnreadWindows` ⇒ the button renders and lies. #1178's own
comment had rejected `jumpToUnread` here as "just as dead" — true of the state
it was looking at, exactly inverted in this one.

## The fix

The two verbs partition the state exactly along `farBehindByChannel`, so the
arm branches on it and takes whichever is live: far behind ⇒ the bar's
**primary** exit, the jump BACK into the unread region; otherwise ⇒ #1178's
`requestScrollToBottom()`, unchanged.

A nonce (`jumpToUnreadCommand`, exactly #243's shape) rather than a direct
`scrollback.jumpToUnread` call: the gesture must arm the #168
marker-activation latch before the swap and stand it down on a failed fetch,
and that latch is a pane-local signal. The bar's inline handler became a named
`jumpToUnreadGesture` and both doors run it — one gesture, two callers, no
second scroll authority, no new state.

## 🔴 I declined the shape the issue proposed, with a measurement

The issue asked for `dismissFarBehind` — the bar's `×`. That verb accepts the
abandoned region as read: irreversible, fanned to every device.

**#1062 already ruled on putting it under this thumb.** It removed #997's
second dismiss surface from `.scrollback-float-stack` — the very stack the
mobile `»N` lives in — because the corner is a repeated-tap route
(scroll-to-bottom, then next-active in the same spot) and *"the far-behind
gesture stays on the bar, where it has a label"*
(`ScrollbackPane.tsx`, the `dismissFarBehindGesture` and float-stack
comments). Routing the dismiss into `»` is worse than what #1062 removed: no
new control, no label, and `activeWindowCount()` counts WINDOWS — so the
button reads `»1` while the tap would accept 240 messages as read.

The jump back is reversible, is what the glyph promises, and leaves the
destructive door one labelled tap away. General rule, recorded in
DESIGN_NOTES: duplicating a non-destructive route is harmless; duplicating a
destructive one is what #1062 measured and removed.

## ⚠️ For vjt — the product axis, not decided here

**The button does NOT hide on the tap.** The issue's Expected clause asked for
it, but that followed from the dismiss proposal. After the jump the unread is
local, real and on screen, so the count is honest for the first time; reading
to the tail clears it, or a second tap takes #1178's exit with the freeze
gone.

Two alternatives are weighed in the DESIGN_NOTES entry and deliberately NOT
built, because both are yours:

1. fire the `×` after all — a **one-arm change** in `stepActiveWindow`, plus
   the e2e's Outcome 2/3 assertions;
2. drop a far-behind CURRENT selection from `orderUnreadWindows`, so the
   button auto-hides and the labelled bar is the only affordance — which #1178
   explicitly rejected as trading a lying button for an absent one, an
   argument made before it was known the bar is up in exactly this state.

## Tests

* `activeWindowsStep.test.ts` — the crossed state arranged in full (one unread
  window, un-muted, far-behind armed, and it IS the selection). Landed in its
  own commit with a **cure-agnostic** assertion ("not the dead door"),
  measured RED on `af716814`:
  `expected "vi.fn()" to not be called at all, but actually been called 1 times`.
  The cure commit adds the discriminators, including "not far behind ⇒ still
  #1178's exit" so deleting the predicate cannot pass.
* `ScrollbackPane.test.tsx` — the pane answers the REAL nonce with the same
  gesture the bar's button fires. Measured RED with the `createEffect`
  removed: `Number of calls: 0`.
* `jumpToUnreadCommand.test.ts` — the nonce is monotonic (sibling of
  `scrollToBottomCommand.test.ts`).
* `issue1765-farbehind-next-active-jump.spec.ts` — e2e on the visible outcome.
  Both candidate cures clear the bar, so it asserts what tells them apart: the
  unread **divider** is back at the read position with the server-measured
  count, and the server cursor has **not** crossed the region.

## Gates

* `scripts/bun.sh run check` — 4 stages, 0 failed (biome + tsc src + tsc e2e +
  lock drift).
* `scripts/bun.sh run test` — 315 files / 6173 tests green.
* `scripts/design-notes-gate.sh` — `1 new entry heading(s), separator and
  marker present.`
* e2e: needs the STACK lane, requested — not yet run at the time of opening.