### PR TITLE
#1430 — audit the status-discriminated success unions, and pin what held

### DIFF
--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -1218,6 +1218,43 @@ describe("sendMessage reads the STATUS, not just res.ok (#1430)", () => {
   });
 });
 
+// #1430 — the audit this issue asked for turned up exactly three REST doors
+// whose SUCCESS answer is a status-discriminated union, and this is the second
+// of them: `MembersController.index/2` answers 204 for `{:ok, :uninitialized}`
+// (joined but pre-NAMES, or not joined at all) and 200 with the envelope for
+// `{:ok, [member()]}`. `listMembers` reads the status and returns `null`, so it
+// does NOT collapse the union the way `sendMessage` used to — but that claim
+// rested on an UNTESTED line: #1680 shipped the door with no vitest at all, and
+// a mutant deleting `if (res.status === 204) return null;` went green, taking
+// `.json()` on an empty body to a throw the caller logs as a refetch failure.
+// The audit's conclusion for this door is only worth as much as its pin.
+//
+// (Door three is `POST /auth/login`, 200 envelope vs 202 challenge; that one is
+// typed as a genuine TS union — `LoginResponse` — and narrowed in `auth.ts` on
+// `two_factor_required`, with its own coverage in `auth.test.ts`.)
+describe("listMembers reads the STATUS, not just res.ok (#1430 audit, #1680 door)", () => {
+  it("returns null on the 204 instead of an empty list", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
+    await expect(api.listMembers("t", "azzurra", "#italia")).resolves.toBeNull();
+  });
+
+  it("returns the narrowed members on 200", async () => {
+    stubFetch(200, { members: [{ nick: "vjt", modes: ["o"] }] });
+    await expect(api.listMembers("t", "azzurra", "#italia")).resolves.toEqual([
+      { nick: "vjt", modes: ["o"] },
+    ]);
+  });
+
+  it("distinguishes 204 from a genuinely empty channel", async () => {
+    // The distinction CP24 bucket E drew and #1680's caller depends on: an
+    // empty `members` array is a real answer (seed it), 204 is "not known yet"
+    // (leave the map alone). Collapsing 204 to `[]` would let a refetch BLANK a
+    // good member list while the session is still filling it.
+    stubFetch(200, { members: [] });
+    await expect(api.listMembers("t", "azzurra", "#italia")).resolves.toEqual([]);
+  });
+});
+
 describe("converted REST doors fail loud on a shape mismatch (#1400)", () => {
   it("rejects an admin vhost response that is missing a required field", async () => {
     // The deploy-window case: cic ahead of its server. Before #1400 this

--- a/cicchetto/src/__tests__/readCursor.test.ts
+++ b/cicchetto/src/__tests__/readCursor.test.ts
@@ -174,6 +174,53 @@ describe("readCursor", () => {
     });
   });
 
+  // #1430 — the ABSENT id, as opposed to #44's wrong-but-present ones. Before
+  // #1400 converted the door, `sendMessage` cast the server's 202 `{ok: true}`
+  // ack (a *Serv target, `/notice` to a service) to a `ScrollbackMessage`, and
+  // `scrollback.sendMessage` then read `row.id` off it — `undefined`. The
+  // anti-poison gate lets that through whenever the cursor is still null, so
+  // `setReadCursor` WAS called with an absent id.
+  //
+  // It never reached the server: `Number.isInteger(undefined)` is false, so
+  // #44's guard — written 2026-06-09 for a different reason, and for the SAME
+  // service-nick windows — refused the POST. That is the whole reason the
+  // #1430 chain was inert in production rather than writing junk cursors, and
+  // it was load-bearing by accident: nothing in #44's set names the absent
+  // case, so a mutant dropping `!Number.isInteger(messageId) ||` (leaving the
+  // `<= 0` half, which `undefined` does NOT satisfy) passed. Pin it, so the
+  // backstop cannot be removed as dead weight by someone who only reads #44.
+  //
+  // `as unknown as number` on purpose: TypeScript forbids this call, and the
+  // point is that the value came off the WIRE, where the compiler was not.
+  describe("absent id is refused too (#1430)", () => {
+    it.each([
+      ["undefined", undefined],
+      ["null", null],
+    ])("does NOT POST when messageId is %s", async (_label, absentId) => {
+      const { setReadCursor } = await import("../lib/readCursor");
+      const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      await setReadCursor("tok", "azzurra", "NickServ", absentId as unknown as number);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT advance the local cursor for an absent id", async () => {
+      const { setReadCursor, getReadCursor, applyJoinReply, clearReadCursors } = await import(
+        "../lib/readCursor"
+      );
+      clearReadCursors();
+      applyJoinReply("azzurra", "NickServ", 7);
+      const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      // As the NaN case above: `undefined <= 7` is false, so an absent id slips
+      // past the forward-only optimistic gate. Without the isInteger half the
+      // signal would take `undefined`.
+      await setReadCursor("tok", "azzurra", "NickServ", undefined as unknown as number);
+      expect(getReadCursor("azzurra", "NickServ")).toBe(7);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe("optimistic local advance (flicker + own-msg-unread fix)", () => {
     // Root cause of two bugs: the local cursor signal was round-trip-only
     // (advanced ONLY when the server's read_cursor_set WS event echoed

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -62737,3 +62737,112 @@ the verdict is dogfood's. Likewise the exact termination rule of the UA's
 `touch-action` ancestor intersection at a scroll container was not measured,
 which is why the re-opening is declared on the modal element rather than relied
 upon to stop at the pane.
+<!-- entry #1430 -->
+
+---
+
+## 2026-08-25 — #1430: a status-discriminated success union, audited and measured
+
+The report was explicit that it was **NOT observed**: a structural reading of
+three files, no trace, no log, no reproduction. `POST …/messages` has two
+success shapes discriminated by HTTP status (201 + the row, 202 + `{ok: true}`
+for a `*Serv` target or a `/notice` to a service); `res.ok` is true for both, so
+the ack was cast to a `ScrollbackMessage` and `scrollback.sendMessage` read
+`row.id` off it. What the issue deliberately left open was whether the chain
+fires, and whether the resulting `undefined` cursor write ever reached the
+server. Both are now measured, and the second answer is the interesting one.
+
+### Measured
+
+**The path fires, and it is a first-class flow rather than an exotic one.**
+`/msg <service> …` is the documented route to a services nick — cic's own
+`/query` refusal tells the operator so in as many words (`commands/window.ts`),
+the `/ns`, `/cs`, … shortcuts rewrite to `{kind: "msg"}`, and `compose.ts`
+routes a services target through `sendPacedBody` → `scrollback.sendMessage` →
+`POST …/messages` with the service nick as `channel_id`. Eleven nicks are in the
+closed allowlist (`Identifier.services_sender?/1`), and the server answers 202
+for every one of them.
+
+**The narrow cure had already landed, in `341d6b0c` (#1400).** Both halves:
+`sendMessage` returns `ScrollbackMessage | null` and reads `res.status === 202`,
+and `scrollback.sendMessage` gates the cursor advance on `row !== null`. The
+issue's line numbers were already stale when it was filed, which is why the
+sites were re-found by name.
+
+**The `undefined` never reached the server.** `setReadCursor`'s positive-int
+guard — `f22568dd`, 2026-06-09, issue #44 — refuses a non-integer id before both
+the POST and the optimistic local advance, and `Number.isInteger(undefined)` is
+false. So the pre-#1400 chain ran to completion and then died at a boundary
+written fourteen weeks earlier, for a different reason, guarding the *same*
+service-nick windows. The blast radius of the defect as reported was **zero
+observable effect**: a real type lie, absorbed by an accidental backstop. That
+is a #788-class arrangement — correct only by an invariant nobody wrote down —
+so the backstop is now pinned under its own name rather than left to #44's set,
+which is entirely wrong-but-present ids (0 / −1 / NaN / 1.5) and blind to the
+absent one.
+
+**The audit answers NO.** Every 2xx-producing terminal under `lib/grappa_web`
+was censused per action, resolving the private-helper indirection
+(`render_send_result/2`, `mint_user_session/1`, `render_theme/3`) by hand.
+Exactly three JSON doors answer two different success statuses with two
+different body shapes:
+
+| door | shapes | client |
+|---|---|---|
+| `POST …/channels/:c/messages` | 201 row / 202 ack | **was** the collapse; cured by #1400 |
+| `POST /auth/login` | 200 envelope / 202 challenge (×2) | genuine TS union `LoginResponse`, narrowed in `auth.ts` on `two_factor_required` |
+| `GET …/channels/:c/members` | 200 envelope / 204 empty | `listMembers` reads the status → `null` |
+
+`GET /uploads/:slug` is 200/206, but it is a byte stream with no `fetch` caller
+in cic and no JSON cast. Everything else is one success status per action —
+including `themes_controller`, where a shared `render_theme/3` takes the status
+as an argument and each action passes exactly one.
+
+So no other REST door collapses a status union. What the audit *did* find is
+that the members door — the second-largest case — shipped in #1680 with **no
+vitest at all**: its 204 branch was unpinned, and the verdict "this one is fine"
+rested on a line no test touched.
+
+### The bench
+
+Four mutants, each restored with `git checkout --`; the control column is the
+same mutant against the base test files at `e1c87d8f`.
+
+| mutant | site | with the new pins | base tests alone |
+|---|---|---|---|
+| M1 — drop `res.status === 202` | `api.sendMessage` | 1 dead | 1 dead (already pinned by #1400) |
+| M2 — drop `res.status === 204` | `api.listMembers` | 1 dead | **0 — fully green** |
+| M3 — drop the `isInteger` half of the guard | `setReadCursor` | 5 dead | 3 dead |
+| M4 — `messageId ?? 1` "totality" rewrite | `setReadCursor` | 3 dead | **0 — fully green** |
+
+M3 is *not* discriminating: #44's NaN and non-integer cases already kill it, so
+the new cases only add kills. M4 is the one that earns the pin — a defensive
+nullish default is exactly the edit that reinstates the hole, it leaves every
+#44 case caught, and the base suite passes it in silence. M3 also split the two
+new values: `null` **survived** M3 while `undefined` died, because `null <= 0`
+coerces to true. The two halves of the guard carry one value each, so the
+two-value set is not redundant.
+
+### Design
+
+No wire change, no field added, therefore **no `protocol_version` bump** — the
+discriminant the client was ignoring was already on the wire, as the status. The
+cure was client-only by construction.
+
+`ScrollbackMessage | null` is the closed-set encoding here, not a tagged union.
+The second member carries no payload, so `{kind: "ack"}` would add ceremony for
+zero information, and TypeScript's strict null checks already force the caller
+to narrow — which is what the `row !== null` gate is. It also now matches
+`listMembers`' `MemberEntry[] | null`: two doors, one house spelling for "the
+server said yes and there is no row".
+
+### Not established
+
+The production log was **not** read, so there is no field frequency for the 202
+arm — only the proof that the flow is reachable and documented. Nothing here
+measures how often an operator `/msg`es a service.
+
+Whether any REST door is a *body*-discriminated union that cic collapses is a
+different axis and was not audited; this census keyed on the HTTP status.
+`POST /auth/login`'s two 202 shapes are one such pair, and they are narrowed
+correctly, but that is one observation and not a sweep.


### PR DESCRIPTION
Re #1430. The issue's own preamble says NOT observed — a structural read of
three files, no trace, no log, no reproduction — and asks not to be re-stated
as an observed bug. This branch respects that and answers the two questions it
deliberately left open, with measurements.

## What was measured

**The path fires.** `/msg <service> …` is the documented route to a services
nick: cic's `/query` refusal points the operator at it in words
(`commands/window.ts:138`), the `/ns` / `/cs` / … shortcuts rewrite to
`{kind: "msg"}`, and `compose.ts` routes a services target through
`sendPacedBody` → `scrollback.sendMessage` → `POST …/messages` with the service
nick as `channel_id`. Eleven nicks (`Identifier.services_sender?/1`) reach the
202 arm.

**The narrow cure had already landed** in `341d6b0c` (#1400) — both halves.
`sendMessage` returns `ScrollbackMessage | null` and reads `res.status === 202`;
`scrollback.sendMessage` gates on `row !== null`. The issue's line numbers were
already stale, so the sites were re-found by name.

**The `undefined` never reached the server.** `setReadCursor`'s positive-int
guard (`f22568dd`, 2026-06-09, issue #44) refuses a non-integer before both the
POST and the optimistic local advance, and `Number.isInteger(undefined)` is
false. The chain ran to completion and died at a boundary written fourteen
weeks earlier, for a different reason, guarding the same service-nick windows.
Blast radius as reported: a real type lie with **zero observable effect**, held
up by an invariant nobody had written down.

**The audit answers NO.** Every 2xx-producing terminal under `lib/grappa_web`
was censused per action, resolving the private-helper indirection by hand.
Exactly three JSON doors answer two success statuses with two body shapes:

| door | shapes | client |
|---|---|---|
| `POST …/channels/:c/messages` | 201 row / 202 ack | **was** the collapse; cured by #1400 |
| `POST /auth/login` | 200 envelope / 202 challenge (×2) | genuine TS union, narrowed in `auth.ts` |
| `GET …/channels/:c/members` | 200 envelope / 204 empty | `listMembers` reads the status |

`GET /uploads/:slug` is 200/206 but is a byte stream with no `fetch` caller and
no JSON cast. No other door collapses a status union.

What the census *did* turn up: the members door shipped in #1680 with **no
vitest at all**, so the verdict "this one is fine" rested on an unpinned line.

## What ships

Two pins and the record. No production code changed — nothing was found that
needed changing.

- `readCursor.test.ts` — the absent id, as distinct from #44's wrong-but-present
  set (0 / −1 / NaN / 1.5). Separate describe, own provenance.
- `api.test.ts` — the members door's 204/200/empty-200 triple. The middle case
  matters: an empty `members` array is a real answer, 204 is "not known yet",
  and collapsing them blanks a good member list mid-fill.
- `docs/DESIGN_NOTES.md` — entry `#1430`.

No wire change, no field added, **no `protocol_version` bump**: the discriminant
the client was ignoring was already on the wire, as the status.

`ScrollbackMessage | null` is kept as the closed-set encoding rather than a
tagged union — the second member carries no payload, strict null checks already
force the narrow, and it now matches `listMembers`' `MemberEntry[] | null`.

## The bench

Four mutants, each restored with `git checkout --`. Control column = the same
mutant against the base test files at `e1c87d8f`.

| mutant | site | with the new pins | base alone |
|---|---|---|---|
| M1 — drop `res.status === 202` | `api.sendMessage` | 1 dead | 1 dead (pinned by #1400) |
| M2 — drop `res.status === 204` | `api.listMembers` | 1 dead | **0 — fully green** |
| M3 — drop the `isInteger` half | `setReadCursor` | 5 dead | 3 dead |
| M4 — `messageId ?? 1` totality rewrite | `setReadCursor` | 3 dead | **0 — fully green** |

M3 is not discriminating (#44's NaN/non-integer already kill it). M4 is what
earns the pin: a defensive nullish default is exactly the edit that reinstates
the hole, it leaves every #44 case caught, and the base suite passes it in
silence. M3 also split the two new values — `null` **survived** it while
`undefined` died, because `null <= 0` coerces to true, so the two halves of the
guard carry one value each and the pair is not redundant.

## Gates

- `scripts/bun.sh run test` — 315 files, 6214 tests, `rc=0`.
- `scripts/bun.sh run check` — 4 stages, 0 failed (lock drift, biome, tsc src,
  tsc e2e), on a clean tree.
- `scripts/design-notes-gate.sh` — `1 new entry heading(s), separator and marker
  present.`
- No Elixir touched, so no COMPILE lane was taken.
- **No e2e, deliberately.** There is no visible outcome to assert: the pre-fix
  chain produced no ghost row and no server write (the #44 guard ate it), so an
  e2e here would be green and empty.

## Not established

The production log was not read, so there is no field frequency for the 202
arm — only the proof that the flow is reachable and documented. And a
*body*-discriminated union census is a different axis that was not run; this
one keyed on the HTTP status.