### PR TITLE
docs(#1592): stop crediting the AUR sentinel's net to a lint that accepts '@'

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63122,3 +63122,96 @@ Where that is impossible because one arm has no body at all (`GET …/members`'s
 No production log was read for either axis, so nothing here carries a field
 frequency. And the sweep is a sweep: three greps over the shapes they can see,
 with their blind spot stated above rather than argued away.
+<!-- entry #1592 -->
+
+---
+
+## 2026-08-25 — #1592: a safety net credited to a lint that accepts the character
+
+`infra/packaging/aur/PKGBUILD` commits `pkgver=@GRAPPA_VERSION@` unfilled, and
+`regen.sh` derives the real number before any build. Since #538 the tree has
+explained WHY that is safe: makepkg's pkgver lint *refuses* `@`, so an
+underived recipe dies loudly instead of publishing `grappa-@GRAPPA_VERSION@`.
+
+It does not refuse it. `check_pkgver`'s entire rejecting surface is two
+bracket expressions — `*[[:space:]/:-]*` (colons, forward slashes, hyphens,
+whitespace) and `*[![:ascii:]]*` — and `@` is ASCII and in neither. Measured
+on `menci/archlinuxarm:base-devel` with a minimal recipe: `pkgver=1.3.0`
+rc=0 (positive control), `pkgver=1.3.0-rc1` rc=12 with the lint's own message
+(negative control — the lint does fire), `pkgver=@GRAPPA_VERSION@` **rc=0**,
+and the same through `--printsrcinfo`.
+
+The tree already held its own refutation. `aur/pkgver.sh`'s header transcribes
+that first bracket expression, cited to `lint_pkgbuild/pkgver.sh` and measured
+under #1591 — two files away from the comment asserting a class it does not
+contain. One claim measured, one asserted, neither reconciled, for four
+issues.
+
+### Eight sites, and why that number changed the fix
+
+The issue named two: the recipe comment and the Elixir test's NAME. A census
+found **eight**, because one sentence was pasted forward across #538, #1447
+and #1591: both recipes (`aur/PKGBUILD`, `aur/shottino/PKGBUILD`), both
+`aur/README.md` passages, the carrier test's moduledoc AND its test name, a
+comment in `packaging_shottino_pkg_test.bats`, and `docs/OPERATIONS.md`'s Arch
+section.
+
+Fixing the two named would have left six asserting a mechanism the other two
+deny. A reader consults whichever copy is nearest, so a half-corrected tree is
+worse than an uncorrected one — it makes the false reading *survivable* by
+looking like the majority. All eight moved.
+
+### What replaced it is LESS, deliberately
+
+The bouncer recipe's `pkgver` comment is the single site carrying the full
+account; every other site states the correction in a line and points there,
+so there is no second copy to drift. And that account names **no mechanism**:
+which stage would actually stop an underived build is NOT MEASURED, and this
+entry does not close it.
+
+The minimal recipe that produced the rc=0 had **no `source=()`**. The real one
+does, and it interpolates the sentinel into a tag URL
+(`v${_grappaver}.tar.gz`), so the download is a plausible stage — plausible,
+not established, and `sha256sums=('SKIP')` rules out a checksum mismatch as a
+candidate. Closing it needs the REAL recipe, sentinel unfilled, through
+`makepkg -sf` in the same container, with the derived `pkgver=1.3.0` run
+alongside so a green harness cannot be mistaken for a green build. Until
+someone runs it, the operative rule is procedural: `regen.sh` is mandatory,
+not something a tool will remind you of.
+
+That distinction is the whole point. The old text promised a guard at a stage
+that does not guard, so a change removing the *real* guard — pinning `source`
+to a branch instead of the tag — would have read as safe.
+
+### The guard, and what it cannot do
+
+`test/infra/packaging_aur_sentinel_test.bats` makes the refuted predicate
+executable (host-side: the class is a shell bracket expression) with the
+hyphen as a known-answer control on every case, and adds a copy-paste guard
+over the sites: **a refusal claimed within two lines of the sentinel must name
+the HYPHEN**, the only refusal measured. It reads whole files, because all
+eight wrapped their claim across a line break and a line-wise grep sees half
+a sentence.
+
+Three things it says out loud rather than hiding. It is a copy-paste guard,
+not a semantic one — it catches the sentence reaching a ninth file, which is
+how eight copies happened, and not a freshly-worded mechanism claim. It
+excludes this log (the #538 entry legitimately records what was believed then,
+and this one quotes the claim to retract it) and its own file (a detector
+forbidden to name its target cannot be tested), and it is pointed at that
+target in a positive control so a broken regex, an absent perl or an empty
+file list cannot pass it vacuously. And it caught its author: the first draft
+of the corrected test comment quoted the retracted phrase verbatim, and the
+guard flagged it — correctly, since a reader scanning sees the phrase either
+way.
+
+Two mistakes worth recording because both were near-misses that read as
+correct. `pkgver.sh` does **not** clear `@` through its closing guard: that
+guard sits on the hyphen branch, and a value with no hyphen takes the `*)` arm
+and exits first — the mapper never inspects the sentinel, which is a different
+and weaker fact than the one first written down. And `[:ascii:]` is a
+GNU/perl extension POSIX never defined; BSD grep answers rc=2, which
+`refute` reports as proving nothing rather than as a satisfied negation
+(#745's helper doing exactly its job). The stand-in is the printable-ASCII
+byte range under `LC_ALL=C` — strictly tighter, which is the safe direction:
+a value it accepts is certainly ASCII.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4800,9 +4800,18 @@ the same reason the `.deb` does.
 - **No `--warnings-as-errors` in `build()`.** The recipe compiles on the
   user's own Arch toolchain, which can be newer than the dev pin; a distro
   rebuild must not hard-fail on a newer compiler's warnings.
-- **The committed `pkgver=@GRAPPA_VERSION@` sentinel is deliberate.**
-  `makepkg`'s pkgver lint REFUSES `@`, so an UNDERIVED build fails LOUDLY
-  instead of silently shipping `grappa-@GRAPPA_VERSION@`. `regen.sh` is
+- **The committed `pkgver=@GRAPPA_VERSION@` sentinel is deliberate — and
+  NOTHING IS KNOWN TO CATCH IT (#1592).** This entry used to say `makepkg`'s
+  pkgver lint bars `@`, so an underived build failed loudly instead of
+  silently shipping `grappa-@GRAPPA_VERSION@`. It does not: `check_pkgver`
+  rejects only `*[[:space:]/:-]*` and `*[![:ascii:]]*` (the first is
+  transcribed from makepkg's source, with its measurement, in
+  `aur/pkgver.sh`'s header), and `@` is ASCII and in neither — rc=0 through
+  both `makepkg -sf` and `--printsrcinfo`, against rc=12 for `1.3.0-rc1`.
+  Which stage WOULD stop an underived build is unmeasured; the
+  `v@GRAPPA_VERSION@.tar.gz` fetch is a candidate, not a finding. So running
+  `regen.sh` is mandatory PROCEDURE, not something a tool reminds you of.
+  `regen.sh` is
   the ONE path that fills it (from `version.sh`), refreshes the checksums
   with `updpkgsums` and regenerates `.SRCINFO`. Run it from a checkout ON
   the release tag — `updpkgsums` fetches the `vX.Y.Z` tarball, so the tag

--- a/infra/packaging/aur/PKGBUILD
+++ b/infra/packaging/aur/PKGBUILD
@@ -20,9 +20,20 @@
 pkgname=grappa
 # pkgver is DERIVED, not hand-edited. The single source of truth is the
 # repo-root `VERSION` file; `regen.sh` (run by release.yml's Arch job and by
-# the human AUR publish) fills this from `version.sh` before makepkg. The
-# `@GRAPPA_VERSION@` sentinel is deliberate: makepkg's pkgver lint REFUSES '@',
-# so an underived build fails loudly instead of shipping `grappa-@GRAPPA_VERSION@`.
+# the human AUR publish) fills this from `version.sh` before makepkg.
+#
+# `regen.sh` IS NOT OPTIONAL — and until #1592 this comment told you why with
+# a mechanism that does not exist. It said makepkg's pkgver lint bars '@', so
+# an underived build could not ship. It does not bar it: `check_pkgver`'s
+# whole rejecting surface is `*[[:space:]/:-]*` and `*[![:ascii:]]*` (the
+# first is transcribed, cited and measured in `pkgver.sh`'s header), and '@'
+# is ASCII and in neither. Measured rc=0 through `makepkg -sf` and through
+# `--printsrcinfo`, against rc=12 for `1.3.0-rc1`.
+#
+# WHICH stage would actually stop an underived build is NOT MEASURED, so this
+# file names none. The `v@GRAPPA_VERSION@.tar.gz` download below is a
+# candidate, not a finding. Read the sentinel as a MARKER that regen.sh has
+# not run, never as a net that will catch you if it did not.
 #
 # DERIVED ≠ EQUAL, since #1591: makepkg's same lint refuses the hyphen a
 # semver pre-release spells its suffix with, so `regen.sh` fills this through

--- a/infra/packaging/aur/README.md
+++ b/infra/packaging/aur/README.md
@@ -51,8 +51,9 @@ three first.
 cd infra/packaging/aur
 # Derive the version from the VERSION file (#538/#652) + refresh checksums/.SRCINFO
 # against the tag tarball. The committed pkgver is the @GRAPPA_VERSION@
-# sentinel (makepkg REFUSES it), so regen.sh is REQUIRED first — and makepkg
-# downloads the vX.Y.Z source tarball anyway, so the tag must already exist:
+# sentinel and nothing is known to catch it downstream (#1592), so regen.sh is
+# REQUIRED first — and makepkg downloads the vX.Y.Z source tarball anyway, so
+# the tag must already exist:
 ./regen.sh
 # builds the mix release + cicchetto, stages FHS, produces the package.
 # -s auto-installs makedepends (elixir, erlang-headless, bun) via pacman:
@@ -120,9 +121,13 @@ tag, because there is only ever one.
 The committed `PKGBUILD`/`.SRCINFO` are a **template**, turned into the
 concrete publishable recipe by `regen.sh`:
 
-- `pkgver=@GRAPPA_VERSION@` is a sentinel `makepkg` REFUSES (#538) — an
-  underived build fails loudly instead of silently shipping
-  `grappa-@GRAPPA_VERSION@`. `regen.sh` fills it from the repo-root `VERSION`
+- `pkgver=@GRAPPA_VERSION@` is a sentinel marking "not derived yet" (#538).
+  It was documented here as a value `makepkg` bars, so that an underived
+  build would fail loudly rather than silently ship
+  `grappa-@GRAPPA_VERSION@`. **It is not** — the pkgver lint accepts `@`
+  (#1592, measured), and which stage would stop such a build is unmeasured.
+  Treat running `regen.sh` as mandatory procedure, not as something a tool
+  will remind you about. `regen.sh` fills it from the repo-root `VERSION`
   file, the single source of truth — **through `pkgver.sh`, which is the
   identity on a bare `X.Y.Z` and not on a pre-release** (#1591: `makepkg`
   refuses the hyphen too, so `1.3.0-rc1` becomes `1.3.0rc1`). That is why

--- a/infra/packaging/aur/shottino/PKGBUILD
+++ b/infra/packaging/aur/shottino/PKGBUILD
@@ -26,8 +26,10 @@
 pkgname=shottino
 # DERIVED, never hand-edited — and from a DIFFERENT carrier than the bouncer's:
 # frontends/shottino/version.h, read via `infra/packaging/version.sh shottino`.
-# The `@SHOTTINO_VERSION@` sentinel is deliberate: makepkg's pkgver lint refuses
-# '@', so an underived build fails loudly instead of publishing the sentinel.
+# The `@SHOTTINO_VERSION@` sentinel marks "../regen.sh has not run yet". It is
+# NOT a value makepkg catches — its pkgver lint accepts '@' (#1592, measured;
+# the refuted mechanism and what replaced it are in ../PKGBUILD's pkgver
+# comment). Nothing is known to stop an underived build of this recipe either.
 pkgver=@SHOTTINO_VERSION@
 pkgrel=1
 # The grappa tag that carries this source. Distinct from pkgver ON PURPOSE:

--- a/test/grappa/version_single_source_test.exs
+++ b/test/grappa/version_single_source_test.exs
@@ -14,8 +14,10 @@ defmodule Grappa.VersionSingleSourceTest do
       `VERSION`), and `nfpm.yaml` interpolates `${GRAPPA_VERSION}`;
     * the Arch `pkgver` — `infra/packaging/aur/regen.sh` derives it from the
       same `version.sh` at release time, filling the committed
-      `@GRAPPA_VERSION@` sentinel (a value `makepkg` REFUSES, so an
-      underived build fails loudly instead of shipping `grappa-@…@`).
+      `@GRAPPA_VERSION@` sentinel (a MARKER that `regen.sh` has not run —
+      not, as this said until #1592, a value `makepkg` bars: its pkgver
+      lint accepts `@`, measured, and what would stop an underived build
+      is unmeasured).
       DERIVED ≠ EQUAL since #1591: `makepkg` also refuses the hyphen a semver
       pre-release spells its suffix with, so the value goes through
       `aur/pkgver.sh` (`1.3.0-rc1` → `1.3.0rc1`, identity on a bare `X.Y.Z`).
@@ -101,7 +103,14 @@ defmodule Grappa.VersionSingleSourceTest do
       assert version_line == "${GRAPPA_VERSION}"
     end
 
-    test "PKGBUILD pkgver is the @GRAPPA_VERSION@ sentinel (makepkg refuses it → loud)" do
+    test "PKGBUILD pkgver stays the @GRAPPA_VERSION@ sentinel, never a derived number" do
+      # The name used to carry a parenthetical crediting the sentinel's
+      # safety net to makepkg's pkgver lint — which measurably accepts '@'
+      # (#1592). The assertion never depended on it: this pins the CARRIER'S
+      # SHAPE, which is all it ever pinned. So the mechanism came OUT of the
+      # name rather than a correct one going in, because which stage stops
+      # an underived build is not measured. The recipe's pkgver comment says
+      # exactly that, and is the one place to keep it.
       pkgver = carrier_value("infra/packaging/aur/PKGBUILD", ~r/^pkgver=(.+)$/m)
       assert pkgver == "@GRAPPA_VERSION@"
     end

--- a/test/infra/packaging_aur_sentinel_test.bats
+++ b/test/infra/packaging_aur_sentinel_test.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #1592 — the AUR sentinel's safety net was credited, in
+# eight places, to a `makepkg` pkgver lint that accepts '@'.
+#
+# THE CLAIM. `pkgver=@GRAPPA_VERSION@` is committed unfilled; `regen.sh`
+# derives the real number before any build. Eight comments/docs/test names
+# explained WHY an underived recipe cannot ship: makepkg's pkgver lint
+# "REFUSES '@'", so the build dies loudly instead of publishing
+# `grappa-@GRAPPA_VERSION@`.
+#
+# THE MEASUREMENT. That lint's whole rejecting surface is two bracket
+# expressions in `check_pkgver` (libmakepkg/lint_pkgbuild/pkgver.sh):
+#
+#     [[ $ver = *[[:space:]/:-]* ]]   colons, forward slashes, hyphens, whitespace
+#     [[ $ver = *[![:ascii:]]* ]]     non-ascii
+#
+# '@' is ASCII and is in neither class. On `menci/archlinuxarm:base-devel`
+# with a minimal recipe, `makepkg -sf --noconfirm` measures rc=0 on
+# `pkgver=@GRAPPA_VERSION@` and rc=0 via `--printsrcinfo`, against rc=12 on
+# `1.3.0-rc1` — the negative control that proves the lint fires at all. The
+# tree already carried the refuting evidence: `aur/pkgver.sh`'s header
+# transcribes that same bracket expression, cited to the file, measured under
+# #1591. Two files apart, one measured and one asserted, and the asserted one
+# was wrong.
+#
+# WHAT THIS SUITE DOES NOT SETTLE. Which stage DOES stop an underived build
+# is not measured and is deliberately left open (#1592). The real recipe has
+# a `source=()` that interpolates the sentinel into a tag URL, so a download
+# failure is a candidate — a candidate, not a finding. Nothing here asserts a
+# mechanism, and neither should any comment in the tree.
+#
+# Scope: the refuted predicate (host-side, no Arch needed — the lint's class
+# is a shell bracket expression and `pkgver.sh` enforces its transcription),
+# and a copy-paste guard over the eight sites, so the ninth is not written.
+
+load ../bats_helpers
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+    PKGVER_SH="$REPO_ROOT/infra/packaging/aur/pkgver.sh"
+}
+
+# ── The refuted predicate ───────────────────────────────────────────────────
+
+@test "#1592 makepkg's rejecting class ACCEPTS the sentinel, with the hyphen as control" {
+    # makepkg's punctuation class, transcribed — the same bracket expression
+    # `pkgver.sh` carries. The rejected loop is the known-answer control:
+    # without it a mis-typed class would accept everything and this case would
+    # pass while proving nothing.
+    for accepted in '@GRAPPA_VERSION@' '@SHOTTINO_VERSION@' '1.3.0' '1.3.0rc1'; do
+        refute grep -qE '[[:space:]/:-]' <<<"$accepted"
+    done
+
+    for rejected in '1.3.0-rc1' '1.3 0' '1:3.0' '1/3.0'; do
+        grep -qE '[[:space:]/:-]' <<<"$rejected"
+    done
+
+    # makepkg's SECOND class is `*[![:ascii:]]*`, and `[:ascii:]` is a
+    # GNU/perl extension POSIX never defined — BSD grep answers "invalid
+    # character class" (rc=2), which `refute` reports as proving nothing
+    # rather than as a satisfied negation. So the stand-in is the printable
+    # ASCII byte range under the C locale. It is STRICTLY TIGHTER than
+    # makepkg's, which is the safe direction for the claim being made: a
+    # value this accepts is certainly ASCII, so makepkg's ascii test accepts
+    # it too.
+    for accepted in '@GRAPPA_VERSION@' '@SHOTTINO_VERSION@'; do
+        refute env LC_ALL=C grep -q '[^ -~]' <<<"$accepted"
+    done
+    LC_ALL=C grep -q '[^ -~]' <<<'1.3.0-café'
+}
+
+@test "#1592 the sentinel reaches makepkg byte-for-byte — pkgver.sh never inspects it" {
+    # Stated precisely, because the near-miss reading is tempting and false:
+    # this is NOT the mapper's closing guard clearing '@'. That guard
+    # (`*[[:space:]/:-]*`, makepkg's class transcribed a second time) sits on
+    # the HYPHEN branch, and a value with no hyphen takes the `*)` arm and
+    # `exit 0`s before ever reaching it. So the mapper neither maps nor
+    # examines the sentinel — it hands it to makepkg exactly as committed,
+    # which is what makes the previous case the whole of the story.
+    run "$PKGVER_SH" '@GRAPPA_VERSION@'
+    [ "$status" -eq 0 ]
+    [ "$output" = '@GRAPPA_VERSION@' ]
+
+    # The branch that DOES reach the guard, for contrast: a hyphen is mapped
+    # away rather than passed through, which is the refusal we have measured.
+    run "$PKGVER_SH" '1.3.0-rc1'
+    [ "$status" -eq 0 ]
+    [ "$output" = '1.3.0rc1' ]
+}
+
+# ── The copy-paste guard ────────────────────────────────────────────────────
+
+# Emit every place where a refusal is claimed within two lines of the
+# sentinel, EXCEPT the ones that name the hyphen — the only refusal this tree
+# has measured (#1591, rc=12). Reads whole files, not lines: every one of the
+# eight sites wrapped its claim across a line break, so a line-wise grep sees
+# half a sentence and misses it.
+#
+# Honest about its own reach: this is a COPY-PASTE guard, not a semantic one.
+# It catches the sentence being pasted into a ninth file — which is how eight
+# copies came to exist across #538, #1447 and #1591 — and it does not catch a
+# freshly-worded mechanism claim. The recipes' comments carry the reasoning;
+# this carries the regression.
+sentinel_refusal_claims() {
+    perl -0777 -ne '
+      while (/(?:[^\n]*\n){0,2}[^\n]*(?:\@GRAPPA_VERSION\@|\@SHOTTINO_VERSION\@|sentinel)[^\n]*\n(?:[^\n]*\n){0,2}/gi) {
+        # Take the offset BEFORE anything else matches: the two tests below
+        # overwrite @- with their own offsets inside $blk, which reports every
+        # hit at line 3-ish of its file.
+        my ($blk, $off) = ($&, $-[0]);
+        next unless $blk =~ /refus/i;
+        next if $blk =~ /hyphen/i;
+        my $ln = 1 + (substr($_, 0, $off) =~ tr/\n//);
+        print "$ARGV:$ln\n$blk\n";
+      }' "$@"
+}
+
+@test "#1592 nothing near the sentinel claims a refusal except the measured hyphen" {
+    # TWO exclusions, both deliberate.
+    #
+    # docs/DESIGN_NOTES.md: the chronological log. Its #538 entry legitimately
+    # records what was believed then, and the #1592 entry quotes the false
+    # claim in order to retract it. Rewriting either would be falsifying the
+    # record, not fixing a doc.
+    #
+    # This file: it quotes the retracted sentence in its header and feeds it
+    # verbatim to the positive control below. A detector that may not name
+    # what it hunts cannot be tested at all — so it is excluded here and
+    # pointed at itself in the case that follows.
+    cd "$REPO_ROOT"
+    files=()
+    while IFS= read -r f; do
+        files+=("$f")
+    done < <(
+        grep -rl 'GRAPPA_VERSION@\|SHOTTINO_VERSION@' \
+            --include='*.md' --include='*.exs' --include='*.sh' --include='*.yml' \
+            --include='*.bats' --include='PKGBUILD' --include='.SRCINFO' --include='*.ts' \
+            . --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=_build \
+            --exclude-dir=deps --exclude='DESIGN_NOTES.md' \
+            --exclude="$(basename "$BATS_TEST_FILENAME")"
+    )
+    # Not a formality: an empty list would make the assertion below hold
+    # vacuously, which is the failure mode `refute` exists to refuse.
+    [ "${#files[@]}" -gt 0 ]
+
+    run sentinel_refusal_claims "${files[@]}"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "#1592 that guard fires on the sentence it was written for" {
+    # Without this the case above passes on a broken detector — a bad regex, a
+    # perl that is not there, a file list that came back empty. The fixture is
+    # the bouncer recipe's own wording as it stood before this issue.
+    fixture="$BATS_TEST_TMPDIR/PKGBUILD"
+    cat >"$fixture" <<'EOF'
+# The `@GRAPPA_VERSION@` sentinel is deliberate: makepkg's pkgver lint
+# REFUSES '@', so an underived build fails loudly.
+pkgver=@GRAPPA_VERSION@
+EOF
+
+    run sentinel_refusal_claims "$fixture"
+    [ "$status" -eq 0 ]
+    grep -q 'REFUSES' <<<"$output"
+
+    # And it stays quiet on the surviving TRUE claim, which names the hyphen.
+    cat >"$fixture" <<'EOF'
+# DERIVED != EQUAL: makepkg's lint refuses the hyphen a semver pre-release
+# spells its suffix with, so regen.sh maps it before filling the sentinel.
+pkgver=@GRAPPA_VERSION@
+EOF
+
+    run sentinel_refusal_claims "$fixture"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/test/infra/packaging_shottino_pkg_test.bats
+++ b/test/infra/packaging_shottino_pkg_test.bats
@@ -145,8 +145,9 @@ upload_dirs() {
 @test "#1447 the AUR client recipe carries its OWN version sentinel, plus the tag that has the source" {
     # THE property that forced a second pkgbase. pkgver comes from the client
     # carrier; _grappaver names the tag that actually exists on GitHub, since
-    # one repository ships both. Sentinels, not numbers: makepkg's pkgver lint
-    # refuses '@', so an underived build fails loudly.
+    # one repository ships both. Sentinels, not numbers — markers that
+    # ../regen.sh has not run, NOT values makepkg catches: its pkgver lint
+    # accepts '@' (#1592, measured).
     grep -qx 'pkgver=@SHOTTINO_VERSION@' "$PKGBUILD_CLIENT"
     grep -qx '_grappaver=@GRAPPA_VERSION@' "$PKGBUILD_CLIENT"
     refute grep -qx 'pkgver=@GRAPPA_VERSION@' "$PKGBUILD_CLIENT"


### PR DESCRIPTION
Refs #1592.

## The defect

`infra/packaging/aur/PKGBUILD` commits `pkgver=@GRAPPA_VERSION@` unfilled and
`regen.sh` derives the real number before any build. Since #538 the tree has
explained why that is safe: makepkg's pkgver lint *refuses* `@`, so an
underived recipe dies loudly instead of publishing `grappa-@GRAPPA_VERSION@`.

It does not refuse it.

## Measured

`check_pkgver`'s entire rejecting surface is two bracket expressions:

```sh
[[ $ver = *[[:space:]/:-]* ]]   # colons, forward slashes, hyphens, whitespace
[[ $ver = *[![:ascii:]]* ]]     # non-ascii
```

`@` is ASCII and in neither. From the issue's container run on
`menci/archlinuxarm:base-devel` with a minimal recipe:

| `pkgver` | rc | |
|---|---|---|
| `1.3.0` | 0 | positive control |
| `1.3.0-rc1` | 12 | negative control — the lint *does* fire |
| **`@GRAPPA_VERSION@`** | **0** | and the same via `--printsrcinfo` |

**The tree already held its own refutation.** `aur/pkgver.sh:35` transcribes
that first bracket expression, cited to `lint_pkgbuild/pkgver.sh` and measured
under #1591 (rc=12 on the hyphen) — two files away from the comment asserting a
class it does not contain. One claim measured, one asserted, never reconciled,
across four issues.

## The issue named two sites. There are eight.

One sentence, pasted forward across #538, #1447 and #1591:

| | site |
|---|---|
| 1 | `infra/packaging/aur/PKGBUILD:24` |
| 2 | `infra/packaging/aur/shottino/PKGBUILD:29` — the **second** recipe, other sentinel |
| 3 | `infra/packaging/aur/README.md:54` |
| 4 | `infra/packaging/aur/README.md:123` |
| 5 | `test/grappa/version_single_source_test.exs:17` (moduledoc) |
| 6 | `test/grappa/version_single_source_test.exs:104` (test **name**) |
| 7 | `test/infra/packaging_shottino_pkg_test.bats` (comment) |
| 8 | `docs/OPERATIONS.md:4804` |

The issue named 1 and 6. Correcting only those would leave six asserting a
mechanism the other two deny, and a reader consults whichever copy is nearest —
a half-corrected tree is worse than an untouched one, because it makes the
false reading survivable by looking like the majority. All eight moved.

## What this deliberately does NOT assert

**Which stage actually stops an underived build.** Not measured, not closed
here. The recipe that produced the rc=0 had **no `source=()`**; the real one
does and interpolates the sentinel into a tag URL, so the download is a
*candidate*, not a finding (`sha256sums=('SKIP')` rules out a checksum
mismatch as one). Closing it needs the real recipe, sentinel unfilled, through
`makepkg -sf` in the same container, with the derived `pkgver=1.3.0` run
alongside so a green harness is not mistaken for a green build.

So **no site names a mechanism now.** The bouncer recipe's `pkgver` comment
carries the full account — claimed, measured, and unmeasured — and every other
site states the correction in a line and points there, so there is no second
copy to drift. The operative rule is procedural: `regen.sh` is mandatory, not
something a tool will remind you of. That is the whole point — the old text
promised a guard at a stage that does not guard, so a change removing the
*real* guard (pinning `source` to a branch instead of the tag) would have read
as safe.

## The guard (`test/infra/packaging_aur_sentinel_test.bats`)

Genuinely RED before the fix, green after. Its rule: **a refusal claimed within
two lines of the sentinel must name the HYPHEN**, the only refusal measured. It
reads whole files, because all eight wrapped their claim across a line break
and a line-wise grep sees half a sentence.

Three things it states rather than hides: it is a **copy-paste** guard, not a
semantic one (it catches the sentence reaching a ninth file, which is how eight
copies happened; it does not catch a freshly-worded claim); it excludes this
log and its own file, with the reason for each; and a positive control points
it at the retracted sentence so a broken regex, an absent perl or an empty file
list cannot pass it vacuously.

It caught its author — the first corrected test comment quoted the retracted
phrase verbatim.

Two near-misses that read as correct, both recorded in DESIGN_NOTES because
they are the kind of thing that gets re-derived:

- `pkgver.sh` does **not** clear `@` through its closing guard. That guard sits
  on the hyphen branch; a hyphenless value takes the `*)` arm and exits first,
  so the mapper never inspects the sentinel — a different and weaker fact than
  the one first written down.
- `[:ascii:]` is a GNU/perl extension POSIX never defined; BSD grep answers
  rc=2, which #745's `refute` reports as *proving nothing* rather than as a
  satisfied negation. The stand-in is the printable-ASCII byte range under
  `LC_ALL=C` — strictly tighter, the safe direction.

## Gates

- `scripts/design-notes-gate.sh` — green. Marker `<!-- entry #1592 -->`
  verified unique against `origin/main`'s tip *after* the rebase; contribution
  +93/-0, and the file is provably `origin/main`'s byte-for-byte plus exactly
  those 93 lines.
- `scripts/bats.sh` on the four packaging suites — 47/47 green; full host suite
  running.
- `scripts/check.sh` not run locally (no COMPILE lane allocated) — CI covers it.

> ℹ️ **Expect FOUR checks, not five.** `integration.yml` has neither `test/**`
> nor `infra/**` in its `paths:`, so the integration job does not trigger on
> this change. 4/4 here is not the same coverage as 5/5 elsewhere.