### PR TITLE
#1618: take the droppable client-source write off the WS upgrade path

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63215,3 +63215,111 @@ GNU/perl extension POSIX never defined; BSD grep answers rc=2, which
 (#745's helper doing exactly its job). The stand-in is the printable-ASCII
 byte range under `LC_ALL=C` — strictly tighter, which is the safe direction:
 a value it accepts is certainly ASCII.
+<!-- entry #1618 -->
+
+---
+
+## 2026-08-25 — #1618: a write allowed to be dropped was not allowed to be slow
+
+`GrappaWeb.UserSocket.connect/3` captured the subject's client `/64` by
+calling `Grappa.Vhosts.record_client_source/2` between authentication and
+`{:ok, socket}`. Phoenix holds the WebSocket upgrade open until `connect/3`
+returns, and that call is a `BEGIN IMMEDIATE` write transaction on
+`user_settings` — so with another writer holding the SQLite write lock the
+upgrade waited the entire `busy_timeout` and then dropped the write it had
+waited for. Measured on one `scripts/integration.sh` run over `425426f2`: 682
+connects, 680 at or below 56 ms, one at 11 140 ms, one at **31 575 ms**, the
+last naming its own mechanism in the container log (`db write unavailable:
+SQLite write lock held by another writer for 31572ms` → `dropped
+(best-effort)` → `CONNECTED TO GrappaWeb.UserSocket in 31575ms`).
+
+The interesting part is that the drop was already policy. #523 made
+`record_client_source/2` swallow `:db_unavailable` precisely so a saturated
+DB could never fail a connect, and its comment says so — *"a client-connect
+sample that must NEVER fail the connect"*. **What a best-effort contract
+written about the RESULT does not cover is the CLOCK.** A sample nobody is
+allowed to depend on was allowed to delay every new WebSocket by half a
+minute, and the code read as if that had been considered.
+
+### The cure, and the three that were not chosen
+
+The persist moves to `Grappa.TaskSupervisor` — the same door
+`ReadCursorController.create/2` (#273) uses for the same shape at the same
+kind of boundary: request-critical work stays inline, eventually-consistent
+work leaves it. No new supervision child, so it is hot-deployable.
+`Task.Supervisor.start_child/2` rather than the `Task.start_link/1` that
+CLAUDE.md's fire-and-forget line names, because a LINKED task takes the
+transport down with it on a crash — which would reinstate #523's hole one
+layer up.
+
+*A shorter timeout of its own* was rejected: expressing it means threading a
+per-call `busy_timeout` through `BusyRetry` / `Repo.immediate_transaction/1`,
+which is the `Repo` refactor this issue is not, and the upgrade still waits —
+just less. *Not writing on this path at all* was rejected because the WS
+connect is the ONLY capture point a USER has; #647's fallback reads
+`sessions.ip`, written at login, so a long-lived bearer that roams would never
+refresh. Curing a latency bug by deleting a capability is not a cure.
+
+**The detach is at the CALL SITE, not inside `Vhosts.record_client_source/2`,
+and that is a domain boundary rather than a convenience.** The verb's other
+two callers are ordering-critical: `Visitors.Login` (#645) must have the
+sample PERSISTED before it spawns the anchor session in the same request —
+that ordering is the whole reason #645 exists — and
+`Vhosts.last_known_client_key/1` (#647) re-persists inside a read that a
+session spawn is already blocking on. Detaching in the context would have
+broken both without a test firing. This is design-discipline (6) read
+literally: the 80 % that fits is the fire-and-forget execution, the 20 % that
+does not is the ordering, and the 20 % is where the line goes.
+
+### What the deferral costs, stated rather than waved away
+
+#1618 declined to propose a cure partly on this: #543's static-mapping
+addressing reads `last_client_prefix64`, so a session spawned right after a
+connect could read a sample one connect stale. Resolved by cases rather than
+by assertion. The COLD case cannot be hit — a subject with nothing recorded
+falls through to `sessions.ip` / `visitor.ip` (#647), which on a fresh login
+is the very address this connect would have written, and #647 persists it
+synchronously on the way past. What remains is an ESTABLISHED subject that
+roamed and spawns a session inside the task's scheduling window. There the
+synchronous path was not better: under the contention that makes the window
+wide it waited the full `busy_timeout` and then dropped the write, leaving the
+same stale value plus half a minute of upgrade. **The async path is never
+worse under contention and marginally racier in the sub-millisecond window
+without it.**
+
+### Why the test is a test
+
+A wall-clock threshold would be flaky, and to be honest it would need a real
+30 s lock. The assertion is the PROCESS instead:
+`Phoenix.ChannelTest.connect/3` invokes `connect/3` in the test process, so a
+synchronous capture reports `self()`. The probe is Ecto's own
+`[:grappa, :repo, :query]` — the event `Grappa.DbLatency` already consumes —
+filtered on `source == "user_settings"`, which fires in whichever process ran
+the query. **No production seam was added for the test to be satisfied by**:
+the thing observed is the real write. A second assertion in the same test
+proves it is a deferral and not a drop (the sample is there once the task
+exits), so the two obvious mutants die on different lines — re-synchronising
+kills the `refute`, detaching-without-writing kills the value.
+
+The five pre-existing #543 Part C cases read the persisted value immediately
+after connect; each now drains the supervisor's children first. **The two
+NEGATIVE cases drain too**, deliberately: "nothing was recorded" must not be
+able to pass merely because a task had not got there yet.
+
+### What was measured, and what was not
+
+Measured, on this branch: the red is the discriminating one —
+`refute exec_pid == test_pid`, *"both sides are exactly equal"*, i.e. the
+write ran in the connect process; green afterwards at 38/38 in
+`user_socket_test.exs`; 80/80 across `session_plan_vhost_test.exs`,
+`vhosts_test.exs` and `user_settings_concurrency_test.exs`, the three suites
+that read this sample back.
+
+NOT measured here: the latency improvement itself. The 31 575 ms is #1618's
+number from its own integration run, not one taken again on this branch, and
+no lock-contention bench was built to reproduce it — the cure is argued from
+the mechanism (a process that nobody awaits cannot block its caller), not from
+a second measurement of the symptom. Also not measured: whether the roam
+window above is ever reached in production, and the Linux `integration.yml`
+substrate, which #1618 already flagged as unshared with the darwin/Docker run
+the numbers come from.

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -39,8 +39,11 @@ defmodule Grappa.UserSettings do
   writer's key — two writers touching completely DIFFERENT keys, last one
   wins, no error anywhere. That is not hypothetical: `put_last_client_prefix64/2`
   fires from `Grappa.Vhosts.record_client_source/2` on every client connect,
-  in the socket's own process and its own pool connection, while the settings
-  drawer PUTs from another.
+  on its own pool connection, while the settings drawer PUTs from another.
+  (Since #1618 the connect-side writer is a detached
+  `Grappa.TaskSupervisor` task rather than the socket process itself — that
+  moves WHICH process races, not WHETHER one does, so the argument below is
+  untouched.)
 
   So there is exactly ONE writer here — `update_data/2` — and it holds the
   read and the write in a single `Repo.immediate_transaction/1`. A new

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -167,6 +167,12 @@ defmodule GrappaWeb.UserSocket do
   # `{_, _}` match keeps it honest. The real Phoenix transport always
   # supplies a valid `:inet.ip_address()` peer + a list of x-headers, so the
   # happy path is the only one it exercises.
+  #
+  # The resolution above stays HERE, in the connect process: reading
+  # `peer_data` / `x_headers` and folding them through
+  # `RemoteIpFromProxy.trusted_client_ip/2` is pure map work with no DB in
+  # it, and keeping it inline means a connect that has nothing to capture
+  # spawns nothing at all. Only the PERSIST detaches (#1618, below).
   @spec maybe_record_client_source(Phoenix.Socket.t(), map()) :: :ok
   defp maybe_record_client_source(socket, connect_info) do
     with %{address: peer_ip} <- Map.get(connect_info, :peer_data),
@@ -179,9 +185,73 @@ defmodule GrappaWeb.UserSocket do
         end
 
       client_ip = GrappaWeb.Plugs.RemoteIpFromProxy.trusted_client_ip(peer_ip, x_headers)
-      Grappa.Vhosts.record_client_source(subject, client_ip)
+      detach_client_source_capture(subject, client_ip)
     else
       _ -> :ok
+    end
+  end
+
+  # #1618 — the persist runs OFF the upgrade path, in a supervised
+  # fire-and-forget task.
+  #
+  # #523 already declared this sample droppable: `record_client_source/2`
+  # swallows `:db_unavailable` specifically so it can never fail a connect.
+  # What that contract did not cover is LATENCY. The call used to sit between
+  # authentication and `{:ok, socket}`, Phoenix holds the WebSocket upgrade
+  # open until `connect/3` returns, and the persist is a `BEGIN IMMEDIATE`
+  # write transaction on `user_settings` — so a writer holding the SQLite
+  # write lock made the upgrade wait the entire `busy_timeout` (31 575 ms
+  # measured on one `scripts/integration.sh` run) and then DROP the write it
+  # had waited for. A sample nobody is allowed to depend on was allowed to
+  # delay every new WebSocket by half a minute.
+  #
+  # `Grappa.TaskSupervisor` is the same door `ReadCursorController.create/2`
+  # (#273) uses for the same shape of problem at the same kind of boundary:
+  # request-critical work stays inline, eventually-consistent work moves off
+  # it. No NEW supervision child, so the fix is hot-deployable.
+  # `Task.Supervisor.start_child/2` and not the `Task.start_link/1` that
+  # CLAUDE.md's fire-and-forget line names, because a LINKED task would take
+  # the transport down with it on a crash — reinstating exactly the
+  # never-fail-a-connect hole #523 closed, one layer up.
+  #
+  # DETACHED HERE, NOT INSIDE `Vhosts.record_client_source/2`, and that is
+  # the domain boundary rather than a convenience: the verb's other callers
+  # are ordering-critical. `Visitors.Login` (#645) must have the sample
+  # PERSISTED before it spawns the anchor session in the same request, and
+  # `Vhosts.last_known_client_key/1` (#647) re-persists inside a read a
+  # session spawn is already blocking on. Detaching in the context would
+  # break both in silence.
+  #
+  # What the deferral costs, stated honestly: a session spawned in the window
+  # between the connect and the task's commit reads the PREVIOUS sample. The
+  # cold case cannot be hit — a subject with nothing recorded falls back to
+  # `sessions.ip` / `visitor.ip` (#647), which on a fresh login is the very
+  # address this connect would have written. The remaining case is an
+  # established subject that ROAMED, and there the synchronous path was not
+  # better: under the contention that makes the window wide it waited the
+  # full `busy_timeout` and then dropped the write, leaving the same stale
+  # value plus half a minute of upgrade.
+  #
+  # A `start_child/2` that does not return `{:ok, pid}` is logged, never
+  # matched: `{:ok, _} = ` here would crash the transport and fail the
+  # connect over a diagnostic sample, which is the one thing this call site
+  # must never do. The log keeps it off the silent-swallow list — the
+  # operator sees a skipped sample rather than nothing.
+  @spec detach_client_source_capture(Grappa.Subject.t(), :inet.ip_address()) :: :ok
+  defp detach_client_source_capture(subject, client_ip) do
+    task = fn -> Grappa.Vhosts.record_client_source(subject, client_ip) end
+
+    case Task.Supervisor.start_child(Grappa.TaskSupervisor, task) do
+      {:ok, _} ->
+        :ok
+
+      other ->
+        Logger.warning(
+          "ws connect: could not detach client-source capture for " <>
+            "#{inspect(subject)} — #{inspect(other)} (sample skipped)"
+        )
+
+        :ok
     end
   end
 

--- a/test/grappa/user_settings_concurrency_test.exs
+++ b/test/grappa/user_settings_concurrency_test.exs
@@ -7,8 +7,11 @@ defmodule Grappa.UserSettingsConcurrencyTest do
   key another writer committed in between — silently, with `{:ok, _}` on both
   sides. The pair driven here is the pair the issue names as reachable in
   production: `put_last_client_prefix64/2` fires from
-  `Grappa.Vhosts.record_client_source/2` on every client connect, in the
-  socket's own process, while a settings-drawer PUT runs in another.
+  `Grappa.Vhosts.record_client_source/2` on every client connect — since
+  #1618 from a detached `Grappa.TaskSupervisor` task rather than the socket
+  process itself — while a settings-drawer PUT runs in another. The detach
+  moves which process races, not whether one does, so the pair below is the
+  same pair.
 
   ## How the interleave is forced
 

--- a/test/grappa_web/channels/user_socket_test.exs
+++ b/test/grappa_web/channels/user_socket_test.exs
@@ -73,6 +73,27 @@ defmodule GrappaWeb.UserSocketTest do
   # the exact shape the `_ -> :ok` arm swallowed in silence.
   @shipped_unreadable "1/websocket"
 
+  # #1618 — the client-source capture is a DETACHED `Grappa.TaskSupervisor`
+  # task, so its write lands after `connect/3` has already returned. Every
+  # assertion on the persisted sample waits (bounded) for the live children to
+  # exit first, and the `on_exit` twin keeps a straggler off the sandbox
+  # owner's teardown. `Task.Supervisor.children/1` is GLOBAL — the `async:
+  # false` lane is load-bearing (no concurrent case), same rationale as
+  # `GrappaWeb.ReadCursorControllerTest`'s #273 drain.
+  defp drain_capture_tasks do
+    Grappa.TaskSupervisor
+    |> Task.Supervisor.children()
+    |> Enum.each(fn pid ->
+      ref = Process.monitor(pid)
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _} -> :ok
+      after
+        2_000 -> Process.demonitor(ref, [:flush])
+      end
+    end)
+  end
+
   describe "connect/3" do
     test "returns :error when no token is given" do
       assert :error = Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{})
@@ -455,6 +476,14 @@ defmodule GrappaWeb.UserSocketTest do
     alias Grappa.Vhosts
     alias Grappa.Vhosts.SourceMapping
 
+    # Registered AFTER `ChannelCase`'s sandbox-owner `on_exit`, so LIFO runs
+    # this one FIRST — a #1618 capture task must not still be querying when
+    # `stop_owner` pulls the shared connection out from under it.
+    setup do
+      on_exit(&drain_capture_tasks/0)
+      :ok
+    end
+
     # Mirrors the transport: `peer_data.address` is the peer IP tuple,
     # `x_headers` are the forwarded (`x-*`) request headers, both riding
     # `connect_info` alongside the subprotocol bearer.
@@ -480,6 +509,9 @@ defmodule GrappaWeb.UserSocketTest do
                  {"x-forwarded-for", "2001:db8:1:2:3:4:5:6"}
                ])
 
+      # #1618 — the capture is detached, so wait for it before reading.
+      drain_capture_tasks()
+
       # The stored key equals the production derivation of the RESOLVED IP —
       # the /64 of the XFF client, NOT the loopback peer. No hardcoded bytes.
       assert Vhosts.last_client_prefix64(subject) ==
@@ -491,6 +523,8 @@ defmodule GrappaWeb.UserSocketTest do
       subject = {:user, user.id}
 
       assert {:ok, _} = connect_with_peer(session.id, {203, 0, 113, 7}, [])
+
+      drain_capture_tasks()
 
       assert Vhosts.last_client_prefix64(subject) ==
                SourceMapping.client_key({203, 0, 113, 7})
@@ -506,6 +540,8 @@ defmodule GrappaWeb.UserSocketTest do
                  {"x-forwarded-for", "203.0.113.42"}
                ])
 
+      drain_capture_tasks()
+
       assert Vhosts.last_client_prefix64(subject) ==
                SourceMapping.client_key({203, 0, 113, 42})
     end
@@ -519,6 +555,11 @@ defmodule GrappaWeb.UserSocketTest do
       # proceeds; capture is silently skipped (no crash, nothing recorded).
       assert {:ok, _} =
                Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{auth_token: session.id})
+
+      # #1618 — drain first, so "nothing recorded" cannot pass merely because
+      # a detached capture task had not got there yet: the skip must be a
+      # skip, not a race we outran.
+      drain_capture_tasks()
 
       assert Vhosts.last_client_prefix64(subject) == nil
     end
@@ -541,7 +582,69 @@ defmodule GrappaWeb.UserSocketTest do
                  }
                )
 
+      drain_capture_tasks()
+
       assert Vhosts.last_client_prefix64(subject) == nil
+    end
+  end
+
+  # #1618 — the capture write is best-effort by CONTRACT already: #523 made
+  # `Vhosts.record_client_source/2` swallow `:db_unavailable` precisely so it
+  # could never fail a connect. What it was not is best-effort in LATENCY.
+  # The call sat between authentication and `{:ok, socket}`, and Phoenix holds
+  # the WebSocket upgrade open until `connect/3` returns — so a writer holding
+  # the SQLite write lock made the upgrade wait the whole `busy_timeout`
+  # (31 575 ms measured on one `scripts/integration.sh` run) and then DROP the
+  # write it had waited for. Detaching it to `Grappa.TaskSupervisor` is what
+  # makes "this can never hurt a connect" true of the clock as well as of the
+  # result.
+  #
+  # Proven by the PROCESS the write runs in, not by a wall-clock threshold
+  # (which would be flaky and would need a real 30 s lock to be honest):
+  # `Phoenix.ChannelTest.connect/3` invokes `connect/3` in THIS test process,
+  # so a synchronous capture reports `self()` and the `refute` fails. The
+  # probe is Ecto's own `[:grappa, :repo, :query]` event — the one
+  # `Grappa.DbLatency` already consumes — which fires in whichever process ran
+  # the query, so there is no production seam this test could be satisfied by
+  # instead of the real write.
+  describe "connect/3 client-source capture is off the upgrade path (#1618)" do
+    setup do
+      on_exit(&drain_capture_tasks/0)
+      :ok
+    end
+
+    test "runs the user_settings write in a task process, not the connect process" do
+      {user, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+      test_pid = self()
+      handler = "ws-client-source-probe-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:grappa, :repo, :query],
+        fn _, _, metadata, _ ->
+          if Map.get(metadata, :source) == "user_settings" do
+            send(test_pid, {:user_settings_query_in, self()})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      # Nothing before the capture touches `user_settings` (auth reads
+      # `accounts_sessions` + `users`), so the FIRST such query after the
+      # attach is the capture's own.
+      assert {:ok, _} = connect_with_peer(session.id, {203, 0, 113, 7}, [])
+
+      assert_receive {:user_settings_query_in, exec_pid}, 2_000
+      refute exec_pid == test_pid
+
+      # And it is a DEFERRAL, not a drop — once the task exits the sample is
+      # persisted exactly as the synchronous path persisted it.
+      drain_capture_tasks()
+
+      assert Grappa.Vhosts.last_client_prefix64({:user, user.id}) ==
+               Grappa.Vhosts.SourceMapping.client_key({203, 0, 113, 7})
     end
   end
 


### PR DESCRIPTION
Refs #1618.

## The defect

`UserSocket.connect/3` called `Vhosts.record_client_source/2` between
authentication and `{:ok, socket}`. Phoenix holds the WebSocket upgrade open
until `connect/3` returns, and that call is a `BEGIN IMMEDIATE` write
transaction on `user_settings` — so with another writer holding the SQLite
write lock the upgrade waited the entire `busy_timeout` and then **dropped the
write it had waited for**. #1618's numbers, from one `scripts/integration.sh`
run over `425426f2`: 682 connects, 680 at or below 56 ms, one at 11 140 ms,
one at **31 575 ms**.

The drop was already policy. #523 made the verb swallow `:db_unavailable`
specifically so it could never fail a connect. **What a best-effort contract
written about the RESULT does not cover is the CLOCK** — a sample nobody is
allowed to depend on was allowed to delay every new WebSocket by half a
minute.

## The cure

The persist moves to `Grappa.TaskSupervisor`: the door
`ReadCursorController.create/2` (#273) already uses for the same shape at the
same kind of boundary. No new supervision child, so it is hot-deployable.

`Task.Supervisor.start_child/2` and **not** the `Task.start_link/1` CLAUDE.md's
fire-and-forget line names, because a LINKED task takes the transport down
with it on a crash — which would reinstate #523's hole one layer up. For the
same reason a non-`{:ok, _}` return is LOGGED, never matched.

Two alternatives were weighed and rejected. *A shorter timeout of its own*
needs a per-call `busy_timeout` threaded through `BusyRetry` /
`Repo.immediate_transaction/1` — the `Repo` refactor this issue is not — and
the upgrade still waits, just less. *Not writing on this path at all* deletes
a capability: the WS connect is the ONLY capture point a USER has, since
#647's fallback reads `sessions.ip`, written at login, so a long-lived bearer
that roams would never refresh.

## Why the detach is at the call site and not inside `Vhosts`

This is the domain boundary, not a convenience. The verb's other two callers
are ordering-critical: `Visitors.Login` (#645) must have the sample PERSISTED
before it spawns the anchor session in the same request — that ordering is
why #645 exists — and `Vhosts.last_known_client_key/1` (#647) re-persists
inside a read that a session spawn is already blocking on. Detaching in the
context would have broken both with no test firing.

## The staleness objection #1618 raised, resolved by cases

#1618 declined to propose a cure partly because #543's static-mapping
addressing reads `last_client_prefix64`. The COLD case cannot be hit: a
subject with nothing recorded falls through to `sessions.ip` / `visitor.ip`
(#647), which on a fresh login is the very address this connect would have
written. What remains is an ESTABLISHED subject that roamed and spawns a
session inside the task's scheduling window — and there the synchronous path
was not better: under the contention that widens the window it waited the full
`busy_timeout` and dropped the write anyway. **Never worse under contention,
marginally racier in the sub-millisecond window without it.**

## Why the test is a test

A wall-clock threshold would be flaky and would need a real 30 s lock to be
honest. The assertion is the PROCESS instead: `Phoenix.ChannelTest.connect/3`
invokes `connect/3` in the test process, so a synchronous capture reports
`self()`. The probe is Ecto's own `[:grappa, :repo, :query]` — the event
`Grappa.DbLatency` already consumes, and which
`user_settings_concurrency_test.exs` already established fires synchronously
in the process that issued the query — filtered on `source == "user_settings"`.
**No production seam was added for the test to be satisfied by instead of the
real write.**

It was run red first, and the red is the discriminating one:

```
1) test connect/3 client-source capture is off the upgrade path (#1618)
   runs the user_settings write in a task process, not the connect process
   Refute with == failed, both sides are exactly equal
   code: refute exec_pid == test_pid
   left: #PID<0.1157.0>
```

A second assertion in the same test proves deferral is not drop, so the two
obvious mutants die on different lines: re-synchronising kills the `refute`,
detaching-without-writing kills the value. The five pre-existing #543 Part C
cases now drain the supervisor before reading — **the two NEGATIVE ones too**,
so "nothing was recorded" cannot pass merely because a task had not got there
yet.

## Also corrected

Two prose claims named the socket process as the writer: `UserSettings`'s
#1375 "one write path" moduledoc and `user_settings_concurrency_test.exs`'s.
The detach moves WHICH process races the settings drawer, not whether one
does, so #1375's argument stands untouched and only its example needed fixing.

**Deliberately NOT edited:** the #1375 entry in `docs/DESIGN_NOTES.md`, which
carries the same sentence. The log is chronological and that entry correctly
describes what was true when it was written; the #1618 entry supersedes it.
Say the word if you want a pointer added instead.

## Gates — all local, all green, `MY_RC` read from the log and not from a wrapper

| gate | result |
| --- | --- |
| `scripts/check.sh` | `MY_RC=0` — 8 doctests, 62 properties, **6844 tests, 0 failures**; dialyzer `Total errors: 0`; credo, sobelow, wire pin; bats **0 `not ok`** |
| `scripts/bun.sh run check` | `MY_RC=0` — 5 stages, 0 failed |
| `scripts/bun.sh run test` | `MY_RC=0` — **6220 passed** (re-run after the rebase; main had added 6) |
| `scripts/integration.sh` | `MY_RC=0` — **780 passed, 30.0m**, 0 failed, 0 flaky |

Rebased onto `origin/main` = `ea07678d` with `scripts/union-rebase.sh`:
`docs/DESIGN_NOTES.md: +108 -0 — contribution intact`. Proven two-sided beyond
the numstat — `head -n 63053` of the rebased file is **byte-identical** to
`origin/main`'s whole file, so nothing was eaten at the head and nothing
resurrected in the tail. Marker `<!-- entry #1618 -->` re-checked unique
against `origin/main`'s tip *after* the fetch.

**Gap named rather than papered over:** `check.sh` and `integration.sh` were
NOT re-run after the rebase. The delta `45fc05f7..ea07678d` is three commits
touching only `cicchetto/src/__tests__/{api,readCursor}.test.ts` and
`docs/DESIGN_NOTES.md` — zero `lib/**`, and jsdom unit tests never enter the
bundle the e2e serves. The two cic gates, which the delta *does* touch, were
re-run.

**Not measured, stated so the green is not read as more than it is:** the
latency improvement itself. The 31 575 ms is #1618's number from its own run,
not re-taken here, and no contention bench was built. The cure is argued from
the mechanism — a process nobody awaits cannot block its caller — not from a
second measurement of the symptom. Also unmeasured: whether the roam window is
ever reached in production, and the Linux `integration.yml` substrate, which
#1618 already flagged as unshared with the darwin/Docker run its numbers come
from.