### PR TITLE
#1430b: close the body axis, and name the rule the collapse obeys

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63047,7 +63047,78 @@ The production log was **not** read, so there is no field frequency for the 202
 arm — only the proof that the flow is reachable and documented. Nothing here
 measures how often an operator `/msg`es a service.
 
-Whether any REST door is a *body*-discriminated union that cic collapses is a
-different axis and was not audited; this census keyed on the HTTP status.
-`POST /auth/login`'s two 202 shapes are one such pair, and they are narrowed
-correctly, but that is one observation and not a sweep.
+Whether any REST door is a *body*-discriminated union that cic collapses was a
+different axis and is **no longer open** — swept in entry #1430b, negative, and
+it is what turned this finding into a rule. The paragraph that stood here
+declared the refusal; it has been closed by measurement rather than left
+standing.
+<!-- entry #1430b -->
+
+---
+
+## 2026-08-25 — #1430b: the body axis, and the rule that names the collapse
+
+Entry #1430 closed the status axis and left one refusal standing: whether any
+REST door is a *body*-discriminated union cic collapses the same way. It is
+closed here, negative, and closing it turned the finding from an instance into
+a rule.
+
+### Measured
+
+Three passes — multi-clause render functions across all twelve `*_json.ex`,
+conditional response key-set construction in the controllers, and the same in
+the `*/wire.ex` builders. Four multi-clause views, no conditional key sets on
+any REST response, and the one conditional key that exists
+(`Cic.Wire.bundle_hash`'s `optional(:version)`) belongs to a WS event and
+declares itself optional.
+
+Three of the four views are the same polymorphism — subject kind — and every
+one of them carries `kind` **inside the body**: `AuthJSON.login`'s `subject`,
+`MeJSON.show`, and both arms of `NetworksJSON.index`. cic models all three as
+TypeScript discriminated unions. The fourth,
+`UserSettingsJSON.auto_away_debounce_seconds`, renders one key in both clauses
+and is not a union at all. **Nothing collapses on the body axis either.**
+
+The census cannot see a shape that varies inside a builder the greps do not
+reach; it is a sweep, not a proof of exhaustion.
+
+### The rule
+
+> A success union is collapsible **in silence** if and only if its discriminant
+> lives ONLY in the HTTP status **and** both arms have parseable bodies.
+
+The three status-discriminated doors from entry #1430 are one clean instance of
+each regime, which is why exactly one of them broke:
+
+| door | discriminant | both bodies parse? | outcome |
+|---|---|---|---|
+| `POST …/channels/:c/messages` 201/202 | status only | **yes** | **the collapse** |
+| `GET …/channels/:c/members` 200/204 | status only | no — 204 is empty | cannot be silent; `.json()` throws |
+| `POST /auth/login` 200/202 | status **and** `two_factor_required` | yes | the client may ignore the status and still be right — and `auth.ts` does |
+
+The mechanism at the one that broke has a name. Its 202 arm reuses
+`{ok: true}`, the house acknowledgement body — six sites across four actions.
+At the other three actions that shape IS the answer; here it is one of two, and
+once `res.ok` has erased the status the JSON alone cannot say which arm
+arrived. A borrowed ack shape is fine until it stands in a union.
+
+### Why this was not bad luck
+
+The convention was already in the codebase and this door was the exception to
+it: every other polymorphic success payload tags itself. `MeJSON` puts `kind`,
+both `NetworksJSON` builders put `kind`, `AuthJSON`'s `subject` puts `kind`.
+`POST …/messages`'s 202 was the only polymorphic success body with no internal
+tag — so the only one whose discriminant a client could drop without noticing.
+
+**The design rule that follows, for a new door:** a success answer that can take
+more than one shape carries its own discriminant IN the body, even when the
+status already distinguishes the arms. The status is a second signal, not the
+only one — the client that forgets to read it should still be able to be right.
+Where that is impossible because one arm has no body at all (`GET …/members`'s
+204), the absence is itself safe, because parsing nothing fails loud.
+
+### Not established
+
+No production log was read for either axis, so nothing here carries a field
+frequency. And the sweep is a sweep: three greps over the shapes they can see,
+with their blind spot stated above rather than argued away.


### PR DESCRIPTION
Refs #1430. Docs-only follow-up to #1777, which is merged.

## Why a separate PR and not an amend to #1777

`#1777` touches `cicchetto/src/__tests__`, which **is** in `integration.yml`'s
path filter, so a force-push there would have re-run the full integration suite
(~25 min). The saving is the path filter, not "the in-flight run is worth more"
— a follow-up is a CI round either way.

**This PR trips 4 checks and no integration.** Verified rather than assumed:
`ci.yml` has exactly four jobs (`test`, `shottino`, `dialyzer`, `cicchetto`),
and `integration.yml`'s `paths:` block lists eighteen entries, none of which is
`docs/**` — `grep -nE '^\s+- .*docs'` over it returns nothing. The workflow's
own header says the same in prose ("Doc-only / CI-only changes don't trigger
this"), but the grep is what this claim rests on.

## What it does

**Closes the one refusal entry #1430 left standing.** That entry swept the
status axis and wrote that the body axis "was not audited". A declared refusal
is a work item, not a disclaimer, so it is closed here — by measurement,
negative.

Three passes, no sampling:

| pass | scope | result |
|---|---|---|
| multi-clause render functions | all twelve `lib/grappa_web/controllers/*_json.ex` | **4** |
| conditional response key-set construction | the controllers (`Map.put`/`Map.merge`, request-side attr building excluded) | **0** |
| same | the `*/wire.ex` builders | **2** — one unconditional put; one WS event payload that declares its key `optional` in its own typespec |

Three of the four views are the same subject-kind polymorphism and every one
of them carries `kind` **inside the body** (`AuthJSON.login`'s `subject`,
`MeJSON.show`, both arms of `NetworksJSON.index`); cic models all three as TS
discriminated unions. The fourth,
`UserSettingsJSON.auto_away_debounce_seconds`, renders one key in both clauses
and is not a union. **Nothing collapses on the body axis either.**

**Closing it is what turns #1430's finding from an instance into a rule:**

> A success union is collapsible **in silence** if and only if its discriminant
> lives ONLY in the HTTP status **and** both arms have parseable bodies.

The three doors #1430 audited are one clean instance of each regime, which is
exactly why one broke and the other two could not — `GET …/members`'s 204 has
no body, so `.json()` throws rather than lying, and `POST /auth/login` carries
`two_factor_required` in the body, so a client that ignores the status is still
right (and `auth.ts` does). The mechanism at the one that broke also has a
name: its 202 arm borrows `{ok: true}`, the house acknowledgement body — six
sites across four actions. At the other three that shape IS the answer; here it
is one of two.

## Second edit, and its limit

Entry #1430's own `### Not established` section said the body axis "was not
audited". That stops being true with this entry, so the paragraph is replaced.
**Only my own entry is touched** — the production-log refusal directly above it
is left byte-for-byte, because that one is structural: the log is not reachable
from this host, and no measurement here changes that.

## Gates

`scripts/design-notes-gate.sh` after the commit: `MY_RC=0`,
`design-notes-gate: 1 new entry heading(s), separator and marker present.` —
the POSITIVE reading, not the `nothing to check` rc=0 that would be an empty
green.

Marker `<!-- entry #1430b -->` re-checked against `origin/main`'s **current
tip** (`ea07678d`), not the base branched from: 0 occurrences. Suffix `b`
because `#1430` is already on main, and a marker the base already carries costs
FOUR lines instead of three — one more than no marker at all. Boundary shape
read on the real file: full stop / marker / blank / `---` / blank / heading,
no blank before the marker.

No code touched, so no ExUnit, no vitest and no lane were used, and none is
claimed.

⚠️ **One thing for whoever rebases this.** Unlike a plain tail-append, this
branch **deletes 4 lines** (the replaced paragraph): `docs/DESIGN_NOTES.md |
75 ++++, 4 ----`. `scripts/union-rebase.sh` asserts `deletions == 0`, so it
would report a FALSE RED here — and, worse, it cannot tell a deletion that
survived from one the union driver ate. If this needs a rebase, the invariant
to check by hand is `additions == 75 && deletions == 4`, plus that the
replaced paragraph is still gone from entry #1430.