### PR TITLE
#1761: bind the auto-clear watchdog's pane once, and make going blind observable

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -134,7 +134,14 @@ never have to say "read the handoff and resume."** If absent, first-ever run —
 every ship, dispatch, halt, design decision, and run-config change — it is the ONLY
 thing that survives the orchestrator's own `/clear` (manual OR the auto-clearer). A stale
 handoff is the highest-severity bug. **Resolve panes BY TITLE, never hardcode `%NN`** (ids
-are ephemeral): sibling = "grappa-worker", orchestrator = "grappa-orch", ircbot = "vjt-claude".
+are ephemeral ACROSS sessions): sibling = "grappa-worker", orchestrator = "grappa-orch",
+ircbot = "vjt-claude".
+⚠️ **But a TITLE is only stable across sessions, not inside one — Claude Code renames a pane to
+the conversation's topic as the session runs (#1761).** The two stabilities are on opposite axes,
+so anything LONG-LIVED resolves by title **once, at startup, and then pins the `%NN` for the life
+of that process**. Re-grepping the title on a loop is what blinded the auto-clearer, silently, for
+two days. Re-pinning the title by hand (`tmux select-pane -T grappa-orch`) buys exactly ONE clear
+and is a manual mitigation, never the cure — the rename happens again at the next topic change.
 
 **THE HANDOFF IS BOUNDED — PRUNE DONE WORK, DO NOT APPEND (vjt direct order 2026-07-15).**
 The handoff is a LIVE-STATE snapshot, NOT a log. It must not grow unbounded. Every update
@@ -349,7 +356,7 @@ is DELETE-then-write, never append-only:
   `status:queued → status:cooking`. This
   REPLACES waiting for an ircbot handover. Only when the queued set is **EMPTY** do you ping
   vjt "what next?" — don't invent work.
-- **Auto-clearer**: `lib/auto-clear-watch.sh start|status grappa-orch` runs an external
+- **Auto-clearer**: `lib/auto-clear-watch.sh start|status grappa-orch [--pane %NN]` runs an external
   watchdog that, at ctx≥40% (idle+quiet, 60s debounce), FIRST prompts the orchestrator to
   flush its handoff, WAITS for that flush turn to settle (polls busy→idle, capped at
   `AUTOCLEAR_FLUSH_MAX`=180s), and only THEN /clears + /orchestrates. The flush-before-clear
@@ -357,6 +364,12 @@ is DELETE-then-write, never append-only:
   Still: keep the handoff current proactively — the watchdog's flush-prompt is a safety net,
   not a substitute (a wedged/slow flush past the cap clears anyway; and you may be mid-halt on
   something the prompt can't fully capture). ALWAYS flush any open decision before going idle.
+  🔴 **`status` names the PANE it is bound to and re-reads it live — check that id against your own
+  `$TMUX_PANE` (#1761).** The binding is made ONCE at `start` (`--pane %NN` > `$TMUX_PANE` > the
+  title, grepped once and refused if it matches zero or several panes) and never re-resolved, so a
+  `running` line now carries either `watching (ctx=NN%)` or a `BLIND: …` naming what it cannot see.
+  A bare `running` with no pane id means a pre-#1761 build — stop and restart it. `pgrep -fl
+  'auto-clear-watch'` does NOT diagnose this: the pattern matches the probing command itself.
 - **Halt + ESCALATE** on: design picker, plan deviation, real breakage, CI regression (2nd
   recurrence), ambiguous scope, daemon/pane death, PACK COMPLETE. Don't auto-pick design/
   product choices; orchestration mechanics MAY be auto-defaulted.

--- a/.claude/skills/orchestrate/lib/auto-clear-watch.sh
+++ b/.claude/skills/orchestrate/lib/auto-clear-watch.sh
@@ -13,8 +13,48 @@
 # just-dispatched phase, a live waiter id) would lose it. Automates what
 # vjt does manually.
 #
-# Resolves the target pane BY TITLE every tick (default "grappa-orch")
-# — pane ids are ephemeral, the title is stable. Never hardcode %NN.
+# PANE BINDING — resolved ONCE at `start`, then PINNED (#1761)
+#
+# This used to re-grep the pane TITLE on every tick, on the reasoning that
+# "pane ids are ephemeral, the title is stable". Half of that is true, and
+# the wrong half was load-bearing: an id is unstable ACROSS sessions, a
+# title is unstable WITHIN one. Claude Code renames its pane to the
+# conversation's topic while the session runs, so the first topic change
+# made the grep return empty — and the loop `continue`d with no log line,
+# no error, a live pid and a `status` still reading `running`. Observed
+# twice: once dead for two days, once bound to `%5`, an unrelated pane,
+# which is worse than dead because it lies. Cost the first time: the
+# orchestrator at 87% context with both workers idle ~13 hours.
+#
+# A watchdog lives inside ONE session, which is exactly the axis on which
+# an id does not move. So the binding happens once and never again:
+#
+#   --pane %NN   explicit, wins over everything
+#   $TMUX_PANE   when set AND naming a live pane
+#   the TITLE    grepped ONCE, and only if it matches EXACTLY ONE pane
+#
+# Refusals are synchronous and non-zero — no pane, an ambiguous title, a
+# `--pane` that does not exist: nothing is forked. A watch that cannot
+# resolve must not become a process that reports `running`.
+#
+# LOG POSTURE: healthy-but-not-firing is quiet (ctx below threshold, pane
+# busy — the watch is working, the conditions just aren't met). CANNOT-SEE
+# is loud, and there are THREE such states, not one: the capture fails
+# (pane gone), the capture is empty, or the pane renders no context
+# marker at all. Each used to end in a bare `continue`.
+#
+# "Loud every time" is implemented as TRANSITION + DERIVED STATUS, not as
+# one identical line per tick. A line every 15s is not more visible than
+# a line every hour — it is less, because it buries the transition and
+# the operator learns to skip the file. So: the log records ENTERING a
+# blind state and RECOVERING from it (a change of reason is a transition
+# too), which keeps `tail -4` truthful in both directions; and `status`
+# re-runs the very same observation LIVE, so the answer to "is it
+# actually watching" is measured on demand rather than remembered. No
+# state file: the blindness is derived from the pane, never duplicated.
+#
+# The pane is deliberately NOT re-resolved when it goes: re-resolving is
+# how it bound `%5`.
 #
 # Safeguards (all must hold to fire):
 #   - ctx >= THRESHOLD (default 40%)
@@ -23,11 +63,37 @@
 #   - the above held for IDLE_TICKS_REQUIRED consecutive ticks (debounce)
 # After firing, COOLDOWN seconds before it can fire again.
 #
-# Usage: auto-clear-watch.sh {start|stop|status} [TITLE]
+# Usage:
+#   auto-clear-watch.sh start  [TITLE] [--pane %NN]
+#   auto-clear-watch.sh stop   [TITLE]
+#   auto-clear-watch.sh status [TITLE]
 set -u
 
 CMD="${1:-start}"
-TITLE="${2:-grappa-orch}"
+[ $# -gt 0 ] && shift
+
+TITLE=""
+PANE_OPT=""
+SOURCE_OPT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --pane)
+    [ $# -ge 2 ] || { echo "auto-clear-watch: --pane needs a pane id (%NN)" >&2; exit 64; }
+    PANE_OPT="$2"; shift 2 ;;
+  --pane=*) PANE_OPT="${1#--pane=}"; shift ;;
+  # Internal: `start` tells the forked loop how the pane was bound, so
+  # the log records it. Not part of the operator surface.
+  --source)
+    [ $# -ge 2 ] || { echo "auto-clear-watch: --source needs a value" >&2; exit 64; }
+    SOURCE_OPT="$2"; shift 2 ;;
+  -*) echo "auto-clear-watch: unknown option '$1'" >&2; exit 64 ;;
+  *)
+    [ -z "$TITLE" ] || { echo "auto-clear-watch: unexpected argument '$1'" >&2; exit 64; }
+    TITLE="$1"; shift ;;
+  esac
+done
+TITLE="${TITLE:-grappa-orch}"
+
 THRESHOLD="${AUTOCLEAR_THRESHOLD:-40}"
 TICK="${AUTOCLEAR_TICK:-15}"                       # seconds between checks
 IDLE_TICKS_REQUIRED="${AUTOCLEAR_IDLE_TICKS:-2}"   # consecutive qualifying ticks (2*15=30s; is_busy already guards mid-turn)
@@ -37,14 +103,63 @@ FLUSH_MAX="${AUTOCLEAR_FLUSH_MAX:-180}"            # max secs to wait for the pr
 SLUG="$(printf '%s' "$TITLE" | tr -c 'a-zA-Z0-9' '-')"
 PIDFILE="/tmp/orchestrate-autoclear-${SLUG}.pid"
 LOGFILE="/tmp/orchestrate-autoclear-${SLUG}.log"
+PANEFILE="/tmp/orchestrate-autoclear-${SLUG}.pane"   # what `status` reports (#1761)
 
 log() { printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$*" >> "$LOGFILE"; }
 
-resolve_pane() {
-  # Match the pane whose title CONTAINS the target (the title carries a
-  # varying activity-glyph prefix, so substring-match, not equality).
+pane_exists() {
+  [ -n "${1:-}" ] || return 1
+  # -x: `%1` must not be satisfied by `%12`.
+  tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$1"
+}
+
+# Pane ids whose TITLE contains $TITLE. Matched against the title FIELD
+# only — the id shares the line and must not be able to satisfy the match.
+panes_matching_title() {
   tmux list-panes -a -F '#{pane_id} #{pane_title}' 2>/dev/null \
-    | grep -F "$TITLE" | awk '{print $1}' | head -1
+    | awk -v t="$TITLE" '{ title = substr($0, index($0, " ") + 1); if (index(title, t) > 0) print $1 }'
+}
+
+# Echoes "<pane_id> <source>" on success. Diagnostics go to stderr and a
+# failure returns non-zero: the caller must NOT fork on one.
+resolve_pane_once() {
+  if [ -n "$PANE_OPT" ]; then
+    if pane_exists "$PANE_OPT"; then
+      printf '%s explicit\n' "$PANE_OPT"
+      return 0
+    fi
+    printf "auto-clear-watch: --pane %s names no live pane — refusing to start.\n" "$PANE_OPT" >&2
+    return 1
+  fi
+
+  if [ -n "${TMUX_PANE:-}" ]; then
+    if pane_exists "$TMUX_PANE"; then
+      printf '%s TMUX_PANE\n' "$TMUX_PANE"
+      return 0
+    fi
+    printf "auto-clear-watch: \$TMUX_PANE=%s is set but names no live pane — falling through to the title.\n" \
+      "$TMUX_PANE" >&2
+  fi
+
+  local matches count
+  matches="$(panes_matching_title)"
+  count="$(printf '%s\n' "$matches" | grep -c '[^[:space:]]')" || true
+
+  if [ "$count" -eq 0 ]; then
+    printf "auto-clear-watch: no tmux pane title contains '%s' — refusing to start a watch that can never resolve.\n" \
+      "$TITLE" >&2
+    printf "auto-clear-watch: pass --pane %%NN if the pane has been renamed (Claude Code renames it to the conversation topic).\n" >&2
+    return 1
+  fi
+
+  if [ "$count" -gt 1 ]; then
+    printf "auto-clear-watch: AMBIGUOUS — %s panes match title '%s': %s\n" \
+      "$count" "$TITLE" "$(printf '%s' "$matches" | tr '\n' ' ')" >&2
+    printf "auto-clear-watch: pass --pane %%NN to say which one. Refusing to guess.\n" >&2
+    return 1
+  fi
+
+  printf '%s title\n' "$matches"
 }
 
 parse_ctx() { printf '%s' "$1" | grep -oE '🧠 [0-9]+%' | grep -oE '[0-9]+' | head -1; }
@@ -53,18 +168,57 @@ input_pending() {
   printf '%s' "$1" | grep -E '^❯ ' | tail -1 | sed -E 's/^❯ +//' | grep -qE '[^[:space:]]'
 }
 
+# The ONE classifier for "the watch cannot see", shared by the loop and by
+# `status` so the two can never disagree about what blindness is. Takes a
+# capture attempt (pane, tmux's exit code, the captured text) and echoes
+# the reason, or NOTHING when the pane is readable.
+blind_reason() {
+  local pane="$1" rc="$2" cap="$3"
+  if [ "$rc" -ne 0 ]; then
+    printf 'pane %s is GONE (tmux rc=%s) — the pane no longer exists, or there is no tmux server. This id was bound once at start and is deliberately NOT re-resolved; stop and restart the watch.' \
+      "$pane" "$rc"
+    return 0
+  fi
+  if [ -z "$cap" ]; then
+    printf 'pane %s captured EMPTY — nothing to read.' "$pane"
+    return 0
+  fi
+  if [ -z "$(parse_ctx "$cap")" ]; then
+    printf "pane %s renders no '🧠 NN%%' context marker — it may not be the Claude pane at all." "$pane"
+    return 0
+  fi
+}
+
 run() {
+  local pane="$1" bound_by="$2"
   printf '%s' "$$" > "$PIDFILE"
-  log "START title='$TITLE' threshold=${THRESHOLD}% tick=${TICK}s idle_req=${IDLE_TICKS_REQUIRED} cooldown=${COOLDOWN}s"
+  printf '%s' "$pane" > "$PANEFILE"
+  log "START pane=${pane} (bound by ${bound_by}) title='$TITLE' threshold=${THRESHOLD}% tick=${TICK}s idle_req=${IDLE_TICKS_REQUIRED} cooldown=${COOLDOWN}s"
   local qualifying=0
+  # The blind state the log last recorded. A transition — in, out, or
+  # from one reason to another — is what gets a line; a tick that only
+  # repeats the known state does not (see LOG POSTURE in the header).
+  local blind_now=""
   while true; do
     sleep "$TICK"
-    local pane; pane="$(resolve_pane)"
-    if [ -z "$pane" ]; then qualifying=0; continue; fi
-    local cap; cap="$(tmux capture-pane -t "$pane" -p -S -25 2>/dev/null)"
-    [ -z "$cap" ] && { qualifying=0; continue; }
-    local ctx; ctx="$(parse_ctx "$cap")"; [ -z "$ctx" ] && ctx=-1
 
+    local cap rc=0 reason
+    cap="$(tmux capture-pane -t "$pane" -p -S -25 2>/dev/null)" || rc=$?
+    reason="$(blind_reason "$pane" "$rc" "$cap")"
+    if [ -n "$reason" ]; then
+      if [ "$reason" != "$blind_now" ]; then
+        blind_now="$reason"
+        log "BLIND: $reason"
+      fi
+      qualifying=0; continue
+    fi
+    if [ -n "$blind_now" ]; then
+      log "RECOVERED: reading pane ${pane} again (was BLIND: ${blind_now})"
+      blind_now=""
+    fi
+    local ctx; ctx="$(parse_ctx "$cap")"
+
+    # Healthy but not firing: quiet on purpose.
     if [ "$ctx" -lt "$THRESHOLD" ]; then qualifying=0; continue; fi
     if is_busy "$cap"; then qualifying=0; continue; fi
     if input_pending "$cap"; then log "ctx=${ctx}% idle but USER TYPING — back off"; qualifying=0; continue; fi
@@ -110,23 +264,55 @@ run() {
 }
 
 case "$CMD" in
-  start)
-    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
-      echo "already running pid=$(cat "$PIDFILE")"; exit 0
+start)
+  if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+    echo "already running pid=$(cat "$PIDFILE") pane=$(cat "$PANEFILE" 2>/dev/null || echo UNKNOWN)"
+    exit 0
+  fi
+  # Resolve BEFORE forking, so an unresolvable watch is an exit code the
+  # operator sees rather than a background process reporting `running`.
+  binding="$(resolve_pane_once)" || exit 1
+  pane="${binding%% *}"
+  bound_by="${binding##* }"
+  nohup "$0" _run "$TITLE" --pane "$pane" --source "$bound_by" >/dev/null 2>&1 &
+  disown
+  sleep 1
+  echo "started auto-clear watch pane=${pane} (bound by ${bound_by}) title='$TITLE' pid=$(cat "$PIDFILE" 2>/dev/null) log=$LOGFILE"
+  ;;
+_run)
+  [ -n "$PANE_OPT" ] || { echo "auto-clear-watch: _run is internal and requires --pane" >&2; exit 64; }
+  run "$PANE_OPT" "${SOURCE_OPT:-unknown}"
+  ;;
+stop)
+  if [ -f "$PIDFILE" ]; then
+    kill "$(cat "$PIDFILE")" 2>/dev/null
+    rm -f "$PIDFILE" "$PANEFILE"
+    echo "stopped"
+  else echo "not running"; fi
+  ;;
+status)
+  if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+    # WHICH pane, always — a bare `running` is what let a watch bound
+    # to `%5` look healthy for as long as it did (#1761).
+    watched="$(cat "$PANEFILE" 2>/dev/null || true)"
+    if [ -z "$watched" ]; then
+      echo "running pid=$(cat "$PIDFILE") pane=UNKNOWN — no pane file, so this was started by a pre-#1761 build; stop and restart it. log=$LOGFILE"
+    else
+      # DERIVED, not remembered: run the loop's own observation right
+      # now. A `running` that never looked is how the %5 misbinding
+      # survived, and a status reading a state file would be one more
+      # thing that can go stale.
+      scap=""; srr=0
+      scap="$(tmux capture-pane -t "$watched" -p -S -25 2>/dev/null)" || srr=$?
+      sreason="$(blind_reason "$watched" "$srr" "$scap")"
+      if [ -n "$sreason" ]; then
+        echo "running pid=$(cat "$PIDFILE") pane=${watched} BLIND: ${sreason} log=$LOGFILE"
+      else
+        echo "running pid=$(cat "$PIDFILE") pane=${watched} watching (ctx=$(parse_ctx "$scap")%) log=$LOGFILE"
+      fi
     fi
-    nohup "$0" _run "$TITLE" >/dev/null 2>&1 &
-    disown
-    sleep 1
-    echo "started auto-clear watch on title='$TITLE' pid=$(cat "$PIDFILE" 2>/dev/null) log=$LOGFILE"
-    ;;
-  _run) run ;;
-  stop)
-    if [ -f "$PIDFILE" ]; then kill "$(cat "$PIDFILE")" 2>/dev/null; rm -f "$PIDFILE"; echo "stopped"; else echo "not running"; fi
-    ;;
-  status)
-    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
-      echo "running pid=$(cat "$PIDFILE") log=$LOGFILE"; tail -4 "$LOGFILE" 2>/dev/null
-    else echo "not running"; fi
-    ;;
-  *) echo "usage: $0 {start|stop|status} [TITLE]"; exit 64 ;;
+    tail -4 "$LOGFILE" 2>/dev/null
+  else echo "not running"; fi
+  ;;
+*) echo "usage: $0 {start|stop|status} [TITLE] [--pane %NN]"; exit 64 ;;
 esac

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63452,3 +63452,74 @@ either, which nothing sampled from the test process can show.
 
 It moves no timeout, weakens no assertion and does not touch
 `Grappa.Repo.LockWatch`.
+<!-- entry #1761 -->
+
+---
+
+## 2026-08-25 — #1761: a watchdog that re-resolves its target is a watchdog that can go blind quietly
+
+`.claude/skills/orchestrate/lib/auto-clear-watch.sh` clears the orchestrator's
+own Claude pane when its context crosses a threshold. It resolved that pane by
+grepping the pane TITLE **on every tick**, and when the grep came back empty the
+loop `continue`d — no log line, no error, a live pid, and `status` still reading
+`running`. Claude Code renames a pane to the conversation's topic while the
+session runs, so the first topic change ended the watch. Observed twice: once
+dead for two days, once bound to `%5`, an unrelated pane, which is worse than
+dead because it lies. Cost the first time: the orchestrator at 87% context with
+both workers idle ~13 hours.
+
+**The doctrine that produced it was half right, and the wrong half was
+load-bearing.** The skill said *"resolve panes BY TITLE, never hardcode `%NN` —
+ids are ephemeral"*. True across sessions. But a watchdog lives INSIDE one
+session, and on that axis the stability is reversed: the id does not move, the
+title does. So the binding now happens ONCE, at `start` — `--pane %NN`, else
+`$TMUX_PANE`, else the title grepped once — and the id is pinned for the life of
+the process. The skill text is narrowed rather than deleted: both halves are
+true, on different axes.
+
+`$TMUX_PANE` is a FALLBACK and not the mechanism, and that ordering was
+measured rather than assumed. On the worker harness the Claude Bash tool sees
+`TERM=tmux-256color` but no `TMUX`/`TMUX_PANE` at all and no reachable tmux
+server — the pane is on the ssh client side. On the orchestrator's host, where
+tmux is local, the variable IS present and correct (`%80`, measured the same
+evening). One environment having it is not a reason to require it.
+
+**Three silent `continue`s, not one.** The issue named the unresolved pane; the
+code had two more — an empty capture, and a capture with no `🧠 NN%` marker in
+it. The last is precisely the `%5` observable: a pane that exists and is not a
+Claude session. All three are now one classifier, `blind_reason`, shared by the
+loop and by `status` so the two cannot disagree about what blindness means.
+
+**Why the loud state is a TRANSITION and not a line per tick.** The first
+instinct — and the first draft, with a test pinning `>= 2` occurrences — was to
+log on every tick, on the reasoning that a one-shot line recreates the same
+silence from the second tick on. That is wrong about how the file is read. A
+line every 15s does not make the state more visible; it buries the transition
+that announces it and trains the reader to skip the log. So the log records
+entering a blind state, recovering from one, and any change of reason — which
+keeps `tail -4` truthful in both directions, the recovery line being the half
+that is easy to forget — and the always-available answer to *"is it watching
+right now"* is `status`, which **re-runs the observation live**. No state file:
+the blindness is derived from the pane on demand, never remembered, so there is
+nothing to go stale. Pinned by a test in which the pane still EXISTS but has
+stopped rendering a context marker — an existence check alone calls that
+healthy.
+
+Two smaller things fixed in passing, both of the same family. The title grep
+matched the whole `#{pane_id} #{pane_title}` line, so the id could satisfy the
+match; it now matches the title field only. And `head -1` over multiple matches
+presented an arbitrary binding as a resolved one — an ambiguous title is now a
+refusal naming every candidate. Both refusals are synchronous and non-zero,
+before anything is forked: a watch that cannot resolve must not become a process
+that reports `running`.
+
+**Not claimed.** The rename mechanism itself was not reproduced here — no tmux
+server is reachable from a worker host — so "Claude Code renames the pane to the
+topic" is taken from the two field observations, not re-measured. The fix does
+not depend on it: it needs only that a title CAN stop matching, which the
+ambiguity and no-match paths exercise directly. Also deliberately not done:
+`status` still exits 0 when it reports blindness, because nothing consumes its
+exit code today and an exit contract nobody reads is a guess about a future
+caller. Out of scope and filed separately: `scripts/shellcheck.sh` derives its
+set from `bin/ infra/ scripts/`, so the nine shell scripts under
+`.claude/skills/**` — this watchdog among them — have never been linted.

--- a/test/scripts/orchestrate_auto_clear_watch_test.bats
+++ b/test/scripts/orchestrate_auto_clear_watch_test.bats
@@ -1,0 +1,331 @@
+#!/usr/bin/env bats
+#
+# .claude/skills/orchestrate/lib/auto-clear-watch.sh — the pane binding (#1761).
+#
+# The watchdog used to re-grep the pane TITLE on every tick and, when the
+# grep came back empty, `continue` with no log line at all. Claude Code
+# renames a pane to the conversation's topic while the session runs, so
+# the moment the topic changed the watch stopped watching — while `status`
+# still said `running` with a live pid. Observed twice; once bound to an
+# unrelated pane (`%5`), which is worse than dead because it lies.
+#
+# So these cases are about OBSERVABILITY, not about resolution:
+#
+#   1. a rename under the watch must not blind it (the id is pinned at
+#      start, and a title is not ours to rely on);
+#   2. every state in which the watchdog CANNOT SEE must be recorded —
+#      there are three of them, and all three used to be a bare
+#      `continue`. Recorded as a TRANSITION (in and out), not as one line
+#      per tick: a line every 15s buries the transition it is supposed to
+#      announce;
+#   3. `status` must name the pane it is bound to and DERIVE, live,
+#      whether it can still read it. `running` without a pane id is
+#      exactly how the `%5` misbinding survived, and a status that
+#      reported a remembered state would be one more thing that can go
+#      stale.
+#
+# tmux is stubbed on PATH: the pane table lives in $PANES (TAB-separated
+# `%id<TAB>title`) and each pane's screen in $STATE/cap-<n>, so a case can
+# rename a pane, delete it, or change the rendered context percentage
+# while the watchdog is mid-flight. A real tmux server is not available on
+# a worker host anyway (measured: the pane is on the ssh client side).
+#
+# The suite never uses the real "grappa-orch" title: PIDFILE/LOGFILE/
+# PANEFILE are derived from it under /tmp, and a case that used it would
+# clobber the operator's live watchdog state.
+
+load ../bats_helpers
+
+setup() {
+    WATCH="$BATS_TEST_DIRNAME/../../.claude/skills/orchestrate/lib/auto-clear-watch.sh"
+
+    # Unique per test file+case so a stray /tmp file cannot leak between
+    # cases, and the real watchdog's slug can never be hit.
+    TITLE="bats-1761-${BATS_SUITE_TEST_NUMBER}"
+    SLUG="$(printf '%s' "$TITLE" | tr -c 'a-zA-Z0-9' '-')"
+    PIDFILE="/tmp/orchestrate-autoclear-${SLUG}.pid"
+    LOGFILE="/tmp/orchestrate-autoclear-${SLUG}.log"
+    rm -f "$PIDFILE" "$LOGFILE" "/tmp/orchestrate-autoclear-${SLUG}."*
+
+    STATE="$BATS_TEST_TMPDIR/state"
+    mkdir -p "$STATE"
+    export STATE
+    PANES="$STATE/panes"
+    : > "$PANES"
+    export PANES
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+
+    # A tmux that answers from $PANES and $STATE/cap-<n>. capture-pane
+    # FAILS for a pane that is not in the table — that non-zero is how the
+    # real thing reports "can't find pane", and the watchdog reads it.
+    cat > "$FAKE_DIR/tmux" <<'EOF'
+#!/bin/sh
+sub="$1"; shift
+case "$sub" in
+list-panes)
+    fmt=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -F) fmt="$2"; shift 2 ;;
+        *)  shift ;;
+        esac
+    done
+    if [ "$fmt" = '#{pane_id}' ]; then
+        awk -F'\t' 'NF {print $1}' "$PANES"
+    else
+        awk -F'\t' 'NF {printf "%s %s\n", $1, $2}' "$PANES"
+    fi
+    ;;
+capture-pane)
+    target=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -t) target="$2"; shift 2 ;;
+        *)  shift ;;
+        esac
+    done
+    awk -F'\t' -v want="$target" 'NF && $1 == want {found=1} END {exit !found}' "$PANES" \
+        || { echo "can't find pane: $target" >&2; exit 1; }
+    capfile="$STATE/cap-$(printf '%s' "$target" | tr -d '%')"
+    [ -f "$capfile" ] && cat "$capfile"
+    ;;
+send-keys)
+    printf 'send-keys %s\n' "$*" >> "$STATE/keys.log"
+    ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/tmux"
+    export PATH="$FAKE_DIR:$PATH"
+
+    # tmux is inherited by the forked watchdog, so the knobs must be too.
+    export AUTOCLEAR_TICK=1
+    # High enough that no case ever reaches the send-keys/clear path: this
+    # suite is about what the loop OBSERVES, not about firing.
+    export AUTOCLEAR_IDLE_TICKS=99
+    export AUTOCLEAR_THRESHOLD=40
+
+    # $TMUX_PANE is NOT set in a Claude Bash-tool environment (measured on
+    # the worker harness), so no case may inherit one from the runner.
+    unset TMUX_PANE
+}
+
+teardown() {
+    if [ -f "$PIDFILE" ]; then
+        kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null || true
+    fi
+    rm -f "/tmp/orchestrate-autoclear-${SLUG}."*
+}
+
+# --- helpers -----------------------------------------------------------------
+
+add_pane() { printf '%s\t%s\n' "$1" "$2" >> "$PANES"; }
+
+rename_pane() {
+    local id="$1" new="$2" tmp="$PANES.tmp"
+    awk -F'\t' -v id="$id" -v new="$new" \
+        'NF { if ($1 == id) printf "%s\t%s\n", $1, new; else print }' "$PANES" > "$tmp"
+    mv "$tmp" "$PANES"
+}
+
+kill_pane() {
+    local id="$1" tmp="$PANES.tmp"
+    awk -F'\t' -v id="$id" 'NF && $1 != id' "$PANES" > "$tmp"
+    mv "$tmp" "$PANES"
+}
+
+# An idle Claude pane rendering a context percentage above the threshold:
+# qualifying, so the loop logs a progress line on every tick.
+render_idle_at() {
+    printf 'some scrollback\n🧠 %s%% context left\n❯ \n' "$2" > "$STATE/cap-$(printf '%s' "$1" | tr -d '%')"
+}
+
+count_in_log() { grep -c "$1" "$LOGFILE" 2>/dev/null || true; }
+
+# Ticks are 1s; give the loop room for a few without racing a slow box.
+wait_ticks() { sleep "$1"; }
+
+# --- binding at start --------------------------------------------------------
+
+@test "start names the pane it bound, so it can be checked against the real one" {
+    add_pane '%3' "$TITLE — some topic"
+    render_idle_at '%3' 55
+
+    run "$WATCH" start "$TITLE"
+
+    [ "$status" -eq 0 ]
+    # WHICH pane, not just "started". The %5 misbinding survived precisely
+    # because nothing ever printed the id.
+    [[ "$output" == *"%3"* ]]
+}
+
+@test "start refuses, loudly, when no pane title matches" {
+    add_pane '%3' 'unrelated shell'
+
+    run "$WATCH" start "$TITLE"
+
+    # Starting a watchdog that can never resolve is the silence itself.
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"$TITLE"* ]]
+    refute test -f "$PIDFILE"
+}
+
+@test "start refuses when the title is AMBIGUOUS instead of taking the first" {
+    add_pane '%3' "$TITLE — orchestrator"
+    add_pane '%5' "$TITLE — a second one"
+
+    run "$WATCH" start "$TITLE"
+
+    # `head -1` over two matches is an arbitrary binding presented as a
+    # resolved one — the shape of the %5 report.
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"%3"* ]]
+    [[ "$output" == *"%5"* ]]
+    refute test -f "$PIDFILE"
+}
+
+@test "--pane binds explicitly and does not consult the title at all" {
+    add_pane '%7' 'a pane whose title says nothing about the watch'
+    render_idle_at '%7' 55
+
+    run "$WATCH" start "$TITLE" --pane '%7'
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"%7"* ]]
+}
+
+@test "--pane naming a pane that does not exist is refused, not accepted" {
+    add_pane '%3' "$TITLE"
+
+    run "$WATCH" start "$TITLE" --pane '%99'
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"%99"* ]]
+    refute test -f "$PIDFILE"
+}
+
+# --- the defect: a rename under the watch ------------------------------------
+
+@test "a RENAME under the watch does not blind it (#1761)" {
+    add_pane '%3' "$TITLE — orchestrator"
+    render_idle_at '%3' 55
+
+    "$WATCH" start "$TITLE"
+    wait_ticks 3
+
+    local before; before="$(count_in_log 'idle+quiet')"
+    [ "$before" -ge 1 ]
+
+    # Claude Code renames the pane to the conversation topic mid-session.
+    rename_pane '%3' 'reviewing the scrollback pagination bug'
+    wait_ticks 3
+
+    local after; after="$(count_in_log 'idle+quiet')"
+    # The observation must CONTINUE. Before #1761 the title grep came back
+    # empty here and the loop went quiet for good.
+    [ "$after" -gt "$before" ]
+}
+
+# --- the reverse: a pinned pane that dies must not be a second silence -------
+
+@test "a pane that DISAPPEARS is logged — once, on the transition (#1761)" {
+    add_pane '%3' "$TITLE — orchestrator"
+    render_idle_at '%3' 55
+
+    "$WATCH" start "$TITLE"
+    wait_ticks 2
+
+    kill_pane '%3'
+    wait_ticks 5
+
+    # It must SAY it (the bare `continue` said nothing at all)...
+    local blind; blind="$(count_in_log 'BLIND')"
+    [ "$blind" -eq 1 ]
+    grep -q 'GONE' "$LOGFILE"
+    # ...and exactly once over five ticks. A line every tick buries the
+    # transition and trains the reader to skip the file; `status` is the
+    # surface that answers "still blind?" on demand.
+}
+
+@test "a pane that renders no context marker is logged, not silently skipped" {
+    add_pane '%3' "$TITLE — orchestrator"
+    # A pane that is not a Claude session at all — the %5 misbinding's
+    # observable. No 🧠 marker anywhere.
+    printf 'total 0\ndrwxr-xr-x  mbarnaba  staff\n❯ \n' > "$STATE/cap-3"
+
+    "$WATCH" start "$TITLE"
+    wait_ticks 4
+
+    local blind; blind="$(count_in_log 'BLIND')"
+    [ "$blind" -eq 1 ]
+    grep -q 'context marker' "$LOGFILE"
+}
+
+@test "coming back from blind is logged too, so tail -4 is not stale" {
+    add_pane '%3' "$TITLE — orchestrator"
+    render_idle_at '%3' 55
+
+    "$WATCH" start "$TITLE"
+    wait_ticks 2
+    kill_pane '%3'
+    wait_ticks 3
+
+    [ "$(count_in_log 'BLIND')" -eq 1 ]
+    [ "$(count_in_log 'RECOVERED')" -eq 0 ]
+
+    # Without the exit transition, a log whose last line is BLIND reads as
+    # "still blind" forever after the watch has recovered.
+    add_pane '%3' 'some entirely new topic'
+    wait_ticks 3
+
+    [ "$(count_in_log 'RECOVERED')" -eq 1 ]
+}
+
+# --- status ------------------------------------------------------------------
+
+@test "status names the pane it is watching" {
+    add_pane '%3' "$TITLE — orchestrator"
+    render_idle_at '%3' 55
+
+    "$WATCH" start "$TITLE"
+
+    run "$WATCH" status "$TITLE"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"running"* ]]
+    # Without this the operator cannot compare the binding with reality.
+    [[ "$output" == *"%3"* ]]
+}
+
+@test "status says the bound pane is GONE rather than just running" {
+    add_pane '%3' "$TITLE — orchestrator"
+    render_idle_at '%3' 55
+
+    "$WATCH" start "$TITLE"
+    kill_pane '%3'
+
+    run "$WATCH" status "$TITLE"
+
+    # A live pid on a dead pane is the lie the issue was filed about.
+    [[ "$output" == *"%3"* ]]
+    [[ "$output" == *"GONE"* ]]
+}
+
+@test "status DERIVES blindness live, it does not report a remembered state" {
+    add_pane '%3' "$TITLE — orchestrator"
+    render_idle_at '%3' 55
+
+    "$WATCH" start "$TITLE"
+
+    # The pane still EXISTS, so an existence check alone would call this
+    # healthy. It stopped being a Claude pane — the %5 shape exactly.
+    printf 'total 0\ndrwxr-xr-x  mbarnaba  staff\n❯ \n' > "$STATE/cap-3"
+
+    run "$WATCH" status "$TITLE"
+
+    [[ "$output" == *"%3"* ]]
+    [[ "$output" == *"BLIND"* ]]
+    [[ "$output" == *"context marker"* ]]
+}


### PR DESCRIPTION
Fixes the silent-blindness class in `.claude/skills/orchestrate/lib/auto-clear-watch.sh` (#1761).

## The defect

The watchdog re-grepped its target pane by **TITLE on every tick** and, when the grep
came back empty, `continue`d — no log line, no error, a live pid, and `status` still
reading `running`. Claude Code renames a pane to the conversation's topic while the
session runs, so the first topic change ended the watch. Observed twice: once dead for
two days, once bound to `%5` (an unrelated pane), which is worse than dead because it
lies.

## The reasoning that produced it, corrected rather than deleted

The skill's doctrine — *"resolve panes BY TITLE, never hardcode `%NN`, ids are
ephemeral"* — is true **across sessions** and false **within one**. A watchdog lives
inside exactly one session, and on that axis the stability is reversed: the id does not
move, the title does. So the binding is made **once at `start`** and pinned:

    --pane %NN   >   $TMUX_PANE   >   the title, grepped once

`$TMUX_PANE` is a **fallback and not the mechanism**, and that ordering was measured
rather than assumed: on the worker harness the Claude Bash tool sees `TERM=tmux-256color`
but no `TMUX_PANE` and no reachable tmux server (the pane is on the ssh client side),
while on the orchestrator's host the variable is present and correct. One environment
having it is not a reason to require it.

## Three silences, not one

The issue named the unresolved pane. The code had two more: an empty capture, and a
capture with no `🧠 NN%` marker in it. The last is precisely the `%5` observable — a pane
that exists and is not a Claude session. All three now go through one `blind_reason`
classifier, **shared with `status`**, so the loop and the operator cannot disagree about
what blindness means.

## Why loudness is a TRANSITION, not a line per tick

The first draft logged on every tick, with a test pinning `>= 2` occurrences. Both were
wrong for the same reason: a line every 15s does not make the state more visible, it
buries the transition and trains the reader to skip the file. So:

- the **log** records entering a blind state, recovering from one, and any change of
  reason — the recovery line being the half that keeps `tail -4` from reading stale;
- **`status`** re-runs the observation **live** and reports `watching (ctx=NN%)` or
  `BLIND: <what it cannot see>`, next to the pane id.

No state file: blindness is derived from the pane on demand, never remembered, so there
is nothing to go stale. Pinned by a case where the pane still **exists** but has stopped
rendering a context marker — an existence check alone calls that healthy.

## Two smaller repairs of the same family

- the title grep matched the whole `#{pane_id} #{pane_title}` line, so the **id** could
  satisfy the match; it matches the title field only now;
- `head -1` over several matches presented an arbitrary binding as a resolved one —
  ambiguity is now a refusal naming every candidate.

Both refusals are synchronous and non-zero, **before anything is forked**: a watch that
cannot resolve must not become a process that reports `running`.

## Tests

New `test/scripts/orchestrate_auto_clear_watch_test.bats`, 12 cases, tmux stubbed on PATH
(no tmux server is reachable from a worker host). **All 12 shown RED against the unfixed
code first**, each on the assertion naming the defect — including the one that matters,
the rename under the watch, where `before >= 1` passed and `after > before` failed.

## Gates

| gate | result |
|---|---|
| `scripts/bats.sh test/scripts/orchestrate_auto_clear_watch_test.bats` | 12/12, rc=0 |
| `scripts/bats.sh` (full) | **688/688, rc=0** |
| `scripts/design-notes-gate.sh` | rc=0 — 1 entry, separator + marker present |
| `scripts/union-rebase.sh` | rc=0, `+71 -0` intact; boundary shape read on the file, preceding entry byte-identical to `origin/main` |
| shellcheck (pinned container, `-x`) | rc=0, no findings |
| `scripts/check.sh` / integration / e2e | **not run** — no Elixir, JS or infra code is touched; no lane was requested |

## Not claimed

- The rename mechanism itself was **not reproduced here** — no tmux server is reachable
  from a worker host — so "Claude Code renames the pane to the topic" rests on the two
  field observations, not on a measurement of mine. The fix does not depend on it: it
  needs only that a title *can* stop matching, which the no-match and ambiguity paths
  exercise directly.
- `status` deliberately still exits **0** while reporting blindness. Nothing consumes its
  exit code today, and an exit contract nobody reads is a guess about a future caller.

## Out of scope, flagged not fixed

`scripts/shellcheck.sh` derives its set from `bin/ infra/ scripts/`, so the **nine shell
scripts under `.claude/skills/**`** — this watchdog among them — have never been linted.
Widening the roots inside this PR would turn the gate red on other people's files. Filed
separately by the orchestrator.

— w1