### PR TITLE
#1708: degrade the pool disconnect that arrives wearing an Ecto struct

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63641,3 +63641,163 @@ unknown, and the O(rows) → O(windows) change is asserted structurally rather
 than as a measured multiple. The issue's own caveat still stands too: at
 `00:15:24.941` the handler switched from `:async` to `:drop`, so the verdict
 that closed the socket may never have reached disk.
+<!-- entry #1708 -->
+
+---
+
+## 2026-08-25 — #1708: the exception that named the wrong bug, and the half of a race nobody closed
+
+22 live IRC sessions died on m42 between 16:37 and 16:39 on 2026-08-22, some
+of them 19 hours old, each one killed by an `Ecto.MultiplePrimaryKeyError`
+raised out of `Scrollback.persist_event/1`. The error says the primary key on
+`messages` does not uniquely identify a row. It is wrong about that, and the
+proof was printed on every one of the 22 lines: the message renders `got
+entries` with **two spaces where the count belongs**, so the number Ecto
+interpolated was the empty string.
+
+### What actually happens
+
+`Ecto.MultiplePrimaryKeyError` carries only `:message`, and Ecto builds it by
+interpolating `count` straight into the sentence
+(`ecto/lib/ecto/exceptions.ex:232`). An empty rendering therefore means
+`count` was **`nil`**, and `nil` reaches that constructor because of the guard
+that selects the raising clause:
+
+```elixir
+# ecto_sql/lib/ecto/adapters/sql.ex:1195-1201
+{:ok, %{rows: [values], num_rows: 1}} -> {:ok, Enum.zip(returning, values)}
+{:ok, %{num_rows: 0}}                 -> ...
+{:ok, %{num_rows: num_rows}} when num_rows > 1 -> raise Ecto.MultiplePrimaryKeyError, count: num_rows, ...
+```
+
+🔴 **`nil > 1` is TRUE.** Erlang's term order sorts every number before every
+atom, so the guard written to catch "more than one row came back" also catches
+"no count at all", and the error it raises names the only cause its author had
+in mind. **The error text lies about its own cause, and the empty count is the
+tell.**
+
+`num_rows: nil` has exactly one producer. `exqlite`'s `maybe_changes/2`
+(`connection.ex:657-664`) is `case Sqlite3.changes(db) do {:ok, t} -> t; _ ->
+nil end`, and `exqlite_changes` (`c_src/sqlite3_nif.c:625`) answers `{:error,
+:connection_closed}` when `conn->db` is `NULL` — i.e. when the connection was
+closed under the caller.
+
+The failure is not caught one line earlier, and that is the non-obvious link.
+`execute/4`'s `with` binds `Sqlite3.transaction_status/1` as `{:ok, status}`,
+and on a closed handle that NIF returns **`make_ok_tuple(env, am_error)`** —
+`{:ok, :error}` (`sqlite3_nif.c:1199-1202`). It matches. The closed connection
+sails through into `maybe_changes`, and the driver reports `%Result{num_rows:
+nil}` to Ecto as **SUCCESS**.
+
+### It is the other half of #1657, not a new race
+
+`Exqlite.Connection.disconnect/2` does two things in order: `Sqlite3.cancel/1`
+then `Sqlite3.close/1`. The pool fires it from a DIFFERENT process than the one
+running the statement — `db_connection/connection_pool.ex:188-210` fires the
+checkout deadline in the POOL process, while `Holder.handle/4:166` runs
+`handle_execute` in the CLIENT process by reading module+state out of an ETS
+holder. So which of the two verbs an in-flight statement meets is a race, and
+it has two outcomes:
+
+* the **cancel** lands DURING the step — `SQLITE_INTERRUPT`, the statement
+  LOSES, no row. `%Exqlite.Error{message: "interrupted"}`. #1657 classified
+  this as contention-by-construction and it degrades correctly.
+* the **close** lands AFTER the step completed — the statement **WON**. The
+  row is committed (autocommit; `exqlite_close` rolls back only when
+  `sqlite3_get_autocommit` is 0), and what the pool took away is the handle the
+  driver then consults for the change count.
+
+🔴 **#1657 closed the arm where the write is lost and left open the arm where
+the write survives** — and the surviving-write arm is the one that killed
+sessions, because its symptom is not a driver exception at all. It arrives
+wearing an *Ecto* struct.
+
+### Why it landed on the wrong side of the degrade
+
+`BusyRetry.loop/4` and `Scrollback.with_pool_retry/1` both rescue an
+**allowlist of two driver structs**. The guarantee they implement — #336, a
+persist must never crash the calling `Session.Server` — is a statement about
+the CALLER, not about which exception the driver happened to throw. An
+allowlist is only ever as complete as the last incident, and this fault was
+not in the last incident.
+
+### The cure, and why it is not a wider net
+
+The ONE classifier learns the third driver symptom.
+`BusyRetry.classify/1` gains a clause for `%Ecto.MultiplePrimaryKeyError{}`
+and **discriminates on the count**:
+
+* **empty count** → `:connection_closed`. Only the pool can produce it, so it
+  is contention by construction, exactly like `:interrupted`.
+* **a count that is there** → stays `:permanent` and re-raises. More than one
+  row genuinely came back, which on an UPDATE or DELETE with too loose a
+  filter is a real bug that must stay loud.
+
+The scrollback path can only ever meet the first: a single-row `INSERT …
+VALUES … RETURNING` has `sqlite3_changes() == 1` or it failed. The
+discrimination exists for the *other* write paths, so widening the rescue did
+not cost the codebase the multiple-primary-key signal it is named after. The
+predicate reads only the message's FIRST line, because the tail inspects the
+bound params — user-controlled message bodies on this path — and a body
+echoing the sentence must not be able to reclassify a real bug as recoverable.
+
+🔴 **TRANSIENT and RETRYABLE stopped being the same axis.** They coincided for
+three fault kinds and stop at the fourth: `:connection_closed`'s statement
+COMPLETED, so its row is durable and a second attempt does not re-drive a lost
+write — **it inserts a duplicate**. It degrades on attempt 1 by verdict,
+never by clock. `retryable?/1` is that second axis; a new fault kind now has to
+answer two questions, not one. The engine's terminal line for it does not
+borrow the shared `db write unavailable:` opening either, because that opening
+is FALSE here and would send an operator hunting for a row sitting in the
+table.
+
+### The proven negative is worth as much as the cure
+
+**`messages` has no primary-key problem.**
+`priv/repo/migrations/20260425000000_init.exs:38` is a plain `create
+table(:messages)` with Ecto's default single `id`, and no reachable shape of
+the scrollback insert can return two rows. Anyone reading the 22 stack traces
+would have started by auditing the schema; the empty count says not to. Two of
+the issue's three open questions close with it: the contention **causes** this
+rather than co-occurring with it (the closer is the pool's own deadline,
+traced above through three deps), and it cannot fire outside a disconnect —
+but a disconnect is not exclusively a saturation event (`max_lifetime`, a
+`:disconnect` return from any callback), so **"only under contention" is NOT
+established** and is left open deliberately.
+
+### What is measured and what is read
+
+Measured against the shipped driver and the shipped Ecto, in
+`Grappa.Repo.BusyRetryFidelityTest`: `Sqlite3.changes/1` on a closed handle
+errors; `Sqlite3.transaction_status/1` on the same handle answers `{:ok,
+:error}` and does not bail the `with`; the driver-derived `nil` satisfies the
+`num_rows > 1` guard; Ecto's OWN constructor renders `count: nil` as the
+`got  entries` prod printed. **Read, not run:** `struct/10`'s clause order —
+its adapter is reached through a module-local `query/4`, so no test can inject
+the `%Result{}`. **Not reproduced at all:** the race itself.
+`Exqlite.Connection` re-prepares against `state.db` on every
+`handle_execute/4`, so a closed handle cannot be smuggled past the public
+callback, and forcing the window open would mean stepping a statement on a
+`sqlite3_close_v2`'d connection — deferred-close territory this suite will not
+build a pin on.
+
+### Accepted limitation: the census over-counts
+
+`Scrollback` maps every engine terminal onto the same `:persist_unavailable`,
+so `Persistor` logs `scrollback row dropped` for a row that is durably in the
+table — the one-atom-two-outcomes lie #1657b removed for the preload arm,
+re-entering through a different door. It was NOT fixed here: the honest fix is
+a fourth terminal atom out of `BusyRetry`, and `:db_unavailable` appears in
+roughly 150 `@spec`s across the tree, so that is a separate change with its own
+blast radius. The mitigation is the new `orphaned` counter in
+`scripts/log-gap-scan.awk`: `dropped` is the UPPER bound on lost rows and
+`dropped - orphaned` the LOWER one. Stated here so nobody reads `dropped` as
+exact again.
+
+### Upstream
+
+Both driver behaviours are defensible in isolation and wrong together:
+`maybe_changes/2` swallowing an error into `nil`, and
+`exqlite_transaction_status` reporting a closed connection as `{:ok, :error}`.
+An `%Exqlite.Error{}` from either would have made this a clean degrade in 2026
+and never reached Ecto. Worth reporting to exqlite; not worth waiting for.

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -21,10 +21,11 @@ defmodule Grappa.Repo.BusyRetry do
       the op. Passed straight through, **never retried** (it is not a
       fault).
     * `{:error, :db_unavailable}` — a TRANSIENT fault
-      (`DBConnection.ConnectionError`, or a busy-or-locked / INTERRUPTED
-      `%Exqlite.Error{}` — see `classify/1`) that persisted for the whole
-      retry budget. A web caller routes this through `FallbackController`
-      to a clean **503** (#518) instead of a 500 raise.
+      (`DBConnection.ConnectionError`, a busy-or-locked / INTERRUPTED
+      `%Exqlite.Error{}`, or an empty-count `%Ecto.MultiplePrimaryKeyError{}`
+      — see `classify/1`) that persisted for the whole retry budget, or
+      that is not retryable at all. A web caller routes this through
+      `FallbackController` to a clean **503** (#518) instead of a 500 raise.
 
   A **non-transient** `%Exqlite.Error{}` (syntax / corruption) is NOT
   saturation: retrying only spins. It **re-raises** with its original
@@ -38,6 +39,16 @@ defmodule Grappa.Repo.BusyRetry do
   The retry loop runs over a wall-clock BUDGET, sleeping a linear backoff
   capped per attempt, so a normal write caught behind a burst is ridden
   out; only sustained saturation degrades.
+
+  ## TRANSIENT and RETRYABLE are two axes, not one (#1708)
+
+  They coincided for the first three fault kinds and stopped coinciding with
+  the fourth. `:connection_closed` is transient by construction — only the
+  pool can produce it — but its statement **completed**, so the row is
+  already durable and a second attempt does not re-drive a lost write, it
+  inserts a duplicate. It therefore degrades on the FIRST attempt, whatever
+  the budget says. `retryable?/1` is that second axis, and a new fault kind
+  has to answer both questions, not one.
 
   ## How far the budget REACHES (#1421)
 
@@ -92,7 +103,7 @@ defmodule Grappa.Repo.BusyRetry do
   @backoff_ms Application.compile_env(:grappa, [:busy_retry, :backoff_ms], 25)
   @backoff_cap_ms Application.compile_env(:grappa, [:busy_retry, :backoff_cap_ms], 200)
 
-  @type fault_kind :: :queue_timeout | :busy_locked | :interrupted
+  @type fault_kind :: :queue_timeout | :busy_locked | :interrupted | :connection_closed
 
   @typedoc """
   Per-contention observer. Called once per RIDDEN-OUT transient attempt with
@@ -134,7 +145,7 @@ defmodule Grappa.Repo.BusyRetry do
     maybe_inject_fault()
     op.()
   rescue
-    error in [DBConnection.ConnectionError, Exqlite.Error] ->
+    error in [DBConnection.ConnectionError, Exqlite.Error, Ecto.MultiplePrimaryKeyError] ->
       elapsed_ms = System.monotonic_time(:millisecond) - started
 
       cond do
@@ -145,8 +156,12 @@ defmodule Grappa.Repo.BusyRetry do
 
         # Identical to the pre-#1421 `monotonic_time < started + @budget_ms`,
         # rearranged so the same subtraction feeds the terminal line. Same
-        # arm, same boundary, no timing change.
-        elapsed_ms < @budget_ms ->
+        # arm, same boundary, no timing change. #1708 adds the `retryable?/1`
+        # conjunct in FRONT of it, not inside it: a fault whose write already
+        # landed must skip this arm on attempt 1 regardless of the clock, and
+        # folding that into the budget comparison would make it look like a
+        # timing accident rather than a verdict.
+        retryable?(error) and elapsed_ms < @budget_ms ->
           on_contention(opts, fault_kind(error), attempt, false)
           # The backoff sleep runs after the failed checkout was already
           # released, so it holds no connection — bounded backpressure on the
@@ -178,10 +193,20 @@ defmodule Grappa.Repo.BusyRetry do
   # statement was cancelled mid-flight — and not the pool deadline that
   # caused it, which this frame never sees and which is already the subject
   # of the timing-out client's own `queue_timeout` line elsewhere in the log.
+  #
+  # #1708 adds the fourth, and it is the same rule again. It names what this
+  # frame OBSERVED — the connection it went to consult was gone — and not the
+  # pool deadline that closed it, which this frame never sees. It deliberately
+  # does NOT say "cancelled": the statement was not cancelled, it COMPLETED,
+  # and that difference is the whole reason the row survives and the retry
+  # must not happen.
   @spec observed_state(fault_kind()) :: String.t()
   defp observed_state(:queue_timeout), do: "SQLite pool saturated"
   defp observed_state(:busy_locked), do: "SQLite write lock held by another writer"
   defp observed_state(:interrupted), do: "SQLite statement cancelled by a pool timeout"
+
+  defp observed_state(:connection_closed),
+    do: "SQLite connection closed after the write completed"
 
   # The same rule, applied to the NUMBER on that line (#1421). It used to read
   # "for the full #{@budget_ms}ms retry budget", which is false in the regime
@@ -197,7 +222,23 @@ defmodule Grappa.Repo.BusyRetry do
   # `test/scripts/log_gap_scan_test.bats` in the SAME commit. A census whose
   # pattern stopped matching reports zero, and zero is what a clean run looks
   # like.
+  #
+  # 🔴 `:connection_closed` gets its OWN sentence rather than the shared
+  # template, because the template's opening clause is FALSE for it (#1708).
+  # "db write unavailable" would send an operator looking for a row that is
+  # sitting durably in the table: the statement completed and committed, and
+  # what was lost is the RETURNING id and therefore the live broadcast. The
+  # "not retried" clause is on the line for the same reason — the attempt
+  # count is 1 by verdict here, not because a budget ran out, and a reader
+  # comparing it against the other three kinds is entitled to know which.
   @spec terminal_message(fault_kind(), non_neg_integer(), pos_integer()) :: String.t()
+  defp terminal_message(:connection_closed, elapsed_ms, attempt) do
+    "db write landed but its result was lost: " <>
+      "#{observed_state(:connection_closed)}, #{elapsed_ms}ms into the write, " <>
+      "on attempt #{attempt} (not retried — the row is durable, a retry would " <>
+      "duplicate it) — returning :db_unavailable"
+  end
+
   defp terminal_message(kind, elapsed_ms, attempt) do
     "db write unavailable: #{observed_state(kind)} for #{elapsed_ms}ms across " <>
       "#{attempt} attempts (#{@budget_ms}ms retry budget) — returning :db_unavailable"
@@ -247,6 +288,38 @@ defmodule Grappa.Repo.BusyRetry do
     * `"busy"` / `"locked"` — a writer held the file lock past
       `busy_timeout`.
 
+  An `%Ecto.MultiplePrimaryKeyError{}` is the third driver symptom, and the
+  only one that does not arrive wearing a driver struct (#1708). It is the
+  OTHER half of the same pool disconnect: `Exqlite.Connection.disconnect/2`
+  runs `Sqlite3.cancel/1` and THEN `Sqlite3.close/1`, and which of the two an
+  in-flight statement meets decides the symptom.
+
+    * the cancel lands DURING the step — the statement LOSES, no row, and the
+      driver raises `"interrupted"`. That is the arm above.
+    * the close lands AFTER the step completed — the statement WON and its row
+      is durable, but the handle the driver then consults for the change count
+      is gone. `exqlite_changes` answers `{:error, :connection_closed}`,
+      `maybe_changes/2` swallows that into `nil`, and — because
+      `transaction_status/1` on a closed handle answers `{:ok, :error}` rather
+      than an error tuple — the `with` in `execute/4` sails through and reports
+      `%Result{num_rows: nil}` to Ecto as SUCCESS. `Ecto.Adapters.SQL.struct/10`
+      has clauses for `num_rows: 1` and `num_rows: 0` and then
+      `num_rows when num_rows > 1`, which `nil` satisfies (term order puts
+      every number before every atom), so it raises about a primary key that
+      is not the problem. Measured against the shipped driver in
+      `Grappa.Repo.BusyRetryFidelityTest`.
+
+  The discriminator is Ecto's own rendering: it interpolates the count
+  straight into the sentence, so `count: nil` prints as NOTHING and leaves the
+  `got  entries` double space production logged 22 times on 2026-08-22. An
+  EMPTY count is therefore `:connection_closed` (transient, and the one kind
+  that is NOT retryable — see `retryable?/1`); a count that is actually there
+  means more than one row genuinely came back, which on an UPDATE or DELETE
+  with too loose a filter is a real bug, so it stays `:permanent` and re-raises.
+  A single-row `INSERT … VALUES … RETURNING` cannot produce the latter at all
+  (`sqlite3_changes()` is 1, or the statement failed), which is why the
+  scrollback path only ever meets the former.
+
   Anything else (syntax, corruption) is `:permanent`: retrying only spins.
 
   🔴 It earns its OWN kind rather than borrowing one. #1420 split
@@ -272,14 +345,45 @@ defmodule Grappa.Repo.BusyRetry do
 
   def classify(%Exqlite.Error{}), do: :permanent
 
+  def classify(%Ecto.MultiplePrimaryKeyError{message: message}) when is_binary(message) do
+    if empty_count?(message), do: :connection_closed, else: :permanent
+  end
+
+  # Only the FIRST line is examined. The tail of Ecto's message inspects the
+  # bound PARAMS, which on the scrollback path are user-controlled message
+  # bodies — a body echoing the sentence must not be able to reclassify a
+  # genuine multi-row result as recoverable. `source` is a table name, so the
+  # first line cannot itself contain a newline.
+  #
+  # Pinned by building the error through `Ecto.MultiplePrimaryKeyError`'s OWN
+  # constructor in `Grappa.Repo.BusyRetryTest` and
+  # `Grappa.Repo.BusyRetryFidelityTest` — never against a hand-typed sentence,
+  # so an Ecto release that rewords it fails RED here instead of silently
+  # reverting the cure.
+  @spec empty_count?(String.t()) :: boolean()
+  defp empty_count?(message) do
+    message
+    |> String.split("\n", parts: 2)
+    |> hd()
+    |> String.ends_with?("but got  entries.")
+  end
+
+  # Is this fault worth a SECOND attempt? Distinct from `transient_fault?/1`
+  # (#1708): `:connection_closed` is transient — only the pool can cause it —
+  # but its statement already completed, so its write is durable and a retry
+  # would insert the row a second time rather than recover a lost one. The
+  # other three kinds all mean the write did NOT take effect, so they retry.
+  @spec retryable?(Exception.t()) :: boolean()
+  defp retryable?(error), do: classify(error) != :connection_closed
+
   # Only reached after `transient_fault?/1` returned true, so `classify/1`
   # cannot answer `:permanent` here — but the clause is explicit rather than
   # a bare pass-through, so a future transient kind that forgets to teach
   # `observed_state/1` fails LOUD at the case instead of printing a stray atom.
-  @spec fault_kind(DBConnection.ConnectionError.t() | Exqlite.Error.t()) :: fault_kind()
+  @spec fault_kind(Exception.t()) :: fault_kind()
   defp fault_kind(error) do
     case classify(error) do
-      kind when kind in [:queue_timeout, :busy_locked, :interrupted] -> kind
+      kind when kind in [:queue_timeout, :busy_locked, :interrupted, :connection_closed] -> kind
     end
   end
 

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -266,7 +266,9 @@ defmodule Grappa.Scrollback do
 
   `op` is a zero-arity fun returning `{:ok, term()}` or `{:error,
   Ecto.Changeset.t()}`. A transient fault (a pool `queue_timeout`
-  `DBConnection.ConnectionError`, or a busy/locked `%Exqlite.Error{}`) is
+  `DBConnection.ConnectionError`, a busy/locked or INTERRUPTED
+  `%Exqlite.Error{}`, or an empty-count `%Ecto.MultiplePrimaryKeyError{}` —
+  the pool closing the connection after the write landed, #1708) is
   retried over the engine's wall-clock budget; each ridden-out attempt fires
   `Telemetry.contention/3` (#357 mechanism 2) via the engine's
   `:on_contention` observer, and budget-exhaustion degrades to `{:error,

--- a/lib/grappa/scrollback/telemetry.ex
+++ b/lib/grappa/scrollback/telemetry.ex
@@ -55,6 +55,11 @@ defmodule Grappa.Scrollback.Telemetry do
   `:telemetry.attach_many/4` — no code here changes when it lands.
   """
 
+  # Typespec-only reference: the fault set's SSOT is the retry engine, so this
+  # module names it rather than keeping a third copy (#1708). A remote type in
+  # a `@spec` is metadata, not a call, so it adds no Boundary edge.
+  alias Grappa.Repo.BusyRetry
+
   @type subject :: :user | :visitor | :unknown
   @type persist_outcome :: :ok | :validation_error | :unavailable
 
@@ -93,10 +98,23 @@ defmodule Grappa.Scrollback.Telemetry do
   final attempt (the row is lost), `false` while the loop is still riding it
   out. Fires ONLY on the contention path — already the slow path — so it adds
   zero cost to an uncontended insert.
+
+  🔴 `dropped: true` is the BUDGET-EXHAUSTED reading of "terminal", and for
+  `:connection_closed` (#1708) the row is NOT lost — that fault degrades on
+  attempt 1 with its write already durable. The flag is left as-is rather than
+  renamed: it is the metadata key an attached exporter keys off, and the fault
+  kind on the same event already discriminates the two. A consumer that counts
+  LOST rows must exclude `:connection_closed`, not sum `dropped`.
+
+  The fault set is `Grappa.Repo.BusyRetry.fault_kind/0` and that module is its
+  SSOT. The guard below has to spell the atoms out (a guard cannot reference a
+  type), so it is a second copy by necessity — a new kind added there without
+  being added here fails LOUD at this clause, which is how #1708 found it.
   """
-  @spec contention(:queue_timeout | :busy_locked | :interrupted, pos_integer(), boolean()) :: :ok
+  @spec contention(BusyRetry.fault_kind(), pos_integer(), boolean()) :: :ok
   def contention(fault, attempt, dropped)
-      when fault in [:queue_timeout, :busy_locked, :interrupted] and is_integer(attempt) and
+      when fault in [:queue_timeout, :busy_locked, :interrupted, :connection_closed] and
+             is_integer(attempt) and
              attempt > 0 and
              is_boolean(dropped) do
     :telemetry.execute(

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -104,6 +104,13 @@ function count_signatures(line) {
     # connection, so counting it as a checkout that never happened would
     # misreport where the write died.
     if (line ~ /statement cancelled by a pool timeout/) CNT["interrupted"]++
+    # #1708 — the fourth BusyRetry terminal state, and the only one whose row
+    # is NOT lost: the statement completed and committed, and what the pool
+    # took away was the connection the driver then asked for the row count.
+    # Its own counter for the reason #1687 gives above, plus one more — folding
+    # it into `dropped` would count a durable row as a lost one, and `dropped`
+    # is the number the #1429 census exists to be trusted on.
+    if (line ~ /SQLite connection closed after the write completed/) CNT["orphaned"]++
 
     # `index` before the three regexes: every lock signature carries the
     # literal "lock", and the stream is ~10^6 lines. The known-answer
@@ -130,7 +137,7 @@ function zero_counters(   i) {
 function summary_line(svc, nlines, mg, mat) {
     return sprintf(SUMFMT, svc, nlines, mg, mat, THRESH, ngap, \
         CNT["db30"], CNT["idle30"], CNT["dropped"], CNT["saturated"], \
-        CNT["interrupted"], CNT["lockheld"], CNT["lockstall"], \
+        CNT["interrupted"], CNT["orphaned"], CNT["lockheld"], CNT["lockstall"], \
         CNT["lockstall_resolved"], CNT["lockstall_unattributed"])
 }
 
@@ -202,7 +209,7 @@ BEGIN {
 
     SUMFMT = "%s\tSUMMARY\tlines=%d\tmaxgap=%.1f\tmaxgap_at=%s\tgaps_ge_%d=%d" \
         "\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d\tinterrupted=%d" \
-        "\tlockheld=%d\tlockstall=%d\tlockstall_resolved=%d" \
+        "\torphaned=%d\tlockheld=%d\tlockstall=%d\tlockstall_resolved=%d" \
         "\tlockstall_unattributed=%d\n"
 
     # Samples copied from the emitting call site. Keep them verbatim: a
@@ -211,6 +218,23 @@ BEGIN {
     #   dropped            — Grappa.Scrollback, #336 never-crash contract.
     #   saturated          — Repo.BusyRetry, pool queue_timeout arm.
     #   interrupted        — Repo.BusyRetry, interrupted arm (#1657).
+    #   orphaned           — Repo.BusyRetry, connection_closed arm (#1708):
+    #                      the pool closed the connection AFTER the statement
+    #                      completed, so the row is DURABLE and only its
+    #                      RETURNING id and live broadcast were lost. 22 of
+    #                      these killed 22 live IRC sessions on 2026-08-22
+    #                      while losing no message at all.
+    #                      🔴 It OVERLAPS `dropped`, it does not sit beside it.
+    #                      Scrollback maps this fault onto the same
+    #                      `:persist_unavailable` as a row that never landed
+    #                      (the engine cannot hand the kind back without a
+    #                      fourth terminal atom, and ~150 `@spec`s carry the
+    #                      current three), so every orphaned fault on the
+    #                      scrollback path ALSO raises `dropped`. Read it as:
+    #                      `dropped` is the UPPER bound on lost rows and
+    #                      `dropped - orphaned` the LOWER one — orphaned also
+    #                      counts the non-scrollback write paths, which emit
+    #                      no `dropped` line of their own.
     #   lockheld           — Repo.BusyRetry, busy_locked arm (#1420).
     #   lockstall{,_resolved} — Grappa.Repo.LockWatch's two episode edges.
     #   lockstall_unattributed — LockWatch's third edge (#1687): a queue past
@@ -227,6 +251,10 @@ BEGIN {
     sig("interrupted", \
         "db write unavailable: SQLite statement cancelled by a pool timeout for 15042ms" \
         " across 1 attempts (1500ms retry budget) — returning :db_unavailable")
+    sig("orphaned", \
+        "db write landed but its result was lost: SQLite connection closed after the" \
+        " write completed, 15042ms into the write, on attempt 1 (not retried — the row" \
+        " is durable, a retry would duplicate it) — returning :db_unavailable")
     sig("lockheld", \
         "db write unavailable: SQLite write lock held by another writer for 30067ms" \
         " across 1 attempts (1500ms retry budget) — returning :db_unavailable")

--- a/test/grappa/repo/busy_retry_fidelity_test.exs
+++ b/test/grappa/repo/busy_retry_fidelity_test.exs
@@ -74,4 +74,88 @@ defmodule Grappa.Repo.BusyRetryFidelityTest do
     assert raised.message =~ ~r/busy/i
     assert BusyRetry.transient_fault?(raised)
   end
+
+  # #1708 — the same fidelity discipline applied to the OTHER pool-disconnect
+  # symptom. The chain that ends in `Ecto.MultiplePrimaryKeyError` has four
+  # links; three of them are measured here against the SHIPPED driver and the
+  # SHIPPED Ecto, and the fourth is a two-line read of
+  # `ecto_sql/lib/ecto/adapters/sql.ex:1195-1201` that no test can drive
+  # (`struct/10` reaches its adapter through a module-local `query/4`, so the
+  # `%Result{}` cannot be injected). Stating which is which is the point:
+  #
+  #   1. MEASURED below — `Sqlite3.changes/1` on a CLOSED handle answers
+  #      `{:error, :connection_closed}`. That is the only branch in
+  #      `exqlite/lib/exqlite/connection.ex:657-664` (`maybe_changes/2`) that
+  #      yields `nil`, and it yields it by swallowing the tuple in a `_ ->`.
+  #   2. MEASURED below — `Sqlite3.transaction_status/1` on the SAME closed
+  #      handle answers `{:ok, :error}`, NOT an error tuple. This is the
+  #      non-obvious link and the reason the failure is not caught one line
+  #      earlier: `execute/4`'s `with` binds that clause with `{:ok, status}`,
+  #      so a closed connection sails straight through it into `maybe_changes`
+  #      and the result is reported to Ecto as SUCCESS with `num_rows: nil`.
+  #   3. MEASURED below — `nil > 1` is TRUE (term order puts every number
+  #      before every atom) and Ecto renders `count: nil` as the empty string,
+  #      which is the `got  entries` double space prod printed 22 times.
+  #   4. READ, not run — `struct/10`'s `case` has clauses for `num_rows: 1`
+  #      and `num_rows: 0` and then `num_rows when num_rows > 1`; (3) says
+  #      `nil` selects the last one.
+  #
+  # No test here reproduces the RACE itself (a pool `disconnect/2` landing
+  # between a completed step and the `changes()` call). `Exqlite.Connection`
+  # re-prepares against `state.db` on every `handle_execute/4`, so a closed
+  # handle cannot be smuggled past the public callback, and forcing the window
+  # open would mean stepping a statement on a `sqlite3_close_v2`'d connection —
+  # deferred-close territory this suite will not build a pin on.
+  describe "a closed connection is what produces an empty count (#1708)" do
+    test "Sqlite3.changes/1 on a CLOSED handle errors — the one branch maybe_changes/2 turns into nil" do
+      {:ok, db} = Exqlite.Sqlite3.open(":memory:")
+      :ok = Exqlite.Sqlite3.close(db)
+
+      assert {:error, :connection_closed} = Exqlite.Sqlite3.changes(db)
+
+      # `maybe_changes/2`'s swallow, verbatim from
+      # `exqlite/lib/exqlite/connection.ex:657-664`. Deriving the value from
+      # the driver rather than writing `nil` is deliberate: the guard below is
+      # then measured against what the connection actually produces.
+      num_rows =
+        case Exqlite.Sqlite3.changes(db) do
+          {:ok, total} -> total
+          _ -> nil
+        end
+
+      assert is_nil(num_rows)
+
+      # `Ecto.Adapters.SQL.struct/10`'s last clause, `num_rows when num_rows >
+      # 1` (`ecto_sql/lib/ecto/adapters/sql.ex:1198`). Term order puts every
+      # number before every atom, so the guard written to catch "more than one
+      # row came back" also catches "no count at all" — and that is the whole
+      # reason the raised error names a primary key.
+      assert match?(n when n > 1, num_rows)
+    end
+
+    test "Sqlite3.transaction_status/1 on a CLOSED handle answers {:ok, :error} — the with does NOT bail" do
+      {:ok, db} = Exqlite.Sqlite3.open(":memory:")
+      :ok = Exqlite.Sqlite3.close(db)
+
+      # `{:ok, _}`, so `with {:ok, transaction_status} <- ...` MATCHES. Had the
+      # driver returned an error tuple here the whole defect would be a clean
+      # `{:error, _}` out of `handle_execute/4` and no exception would ever be
+      # raised. It does not, and that is why the closed connection survives to
+      # the next line.
+      assert {:ok, :error} = Exqlite.Sqlite3.transaction_status(db)
+    end
+
+    test "Ecto renders a nil count as an EMPTY interpolation — the `got  entries` prod printed" do
+      message =
+        Ecto.MultiplePrimaryKeyError.exception(
+          operation: :insert,
+          source: "messages",
+          params: [],
+          count: nil
+        ).message
+
+      # Byte-for-byte the shape prod logged, double space included.
+      assert message =~ "expected insert on messages to return at most one entry but got  entries."
+    end
+  end
 end

--- a/test/grappa/repo/busy_retry_test.exs
+++ b/test/grappa/repo/busy_retry_test.exs
@@ -47,6 +47,34 @@ defmodule Grappa.Repo.BusyRetryTest do
     raise %Exqlite.Error{message: "interrupted", statement: nil}
   end
 
+  # #1708 — the pool closing the connection AFTER the statement completed.
+  # Built through Ecto's OWN constructor, never a hand-typed sentence: the
+  # empty-count rendering IS the discriminator, so a test that spelled the
+  # message itself would keep passing after Ecto reworded it. See the describe
+  # block below.
+  defp orphaned_write_error do
+    Ecto.MultiplePrimaryKeyError.exception(
+      operation: :insert,
+      source: "messages",
+      params: [1, "#bofh", "hello"],
+      count: nil
+    )
+  end
+
+  # The reading the exception's own text asserts: more than one row really came
+  # back. Unreachable on a single-row `INSERT … VALUES … RETURNING`
+  # (`sqlite3_changes()` is 1, or the statement failed) but perfectly reachable
+  # on an UPDATE or DELETE whose filter is too loose — a real bug the engine
+  # must keep surfacing LOUD.
+  defp genuine_multi_row_error do
+    Ecto.MultiplePrimaryKeyError.exception(
+      operation: :update,
+      source: "messages",
+      params: [1],
+      count: 2
+    )
+  end
+
   # Every captured terminal line tagged with this fault kind. The `fault=`
   # metadata is what the prose has to agree with, so it is also what selects
   # the lines to judge.
@@ -205,6 +233,110 @@ defmodule Grappa.Repo.BusyRetryTest do
       kinds = Agent.get(observed, & &1)
       assert kinds != []
       assert Enum.all?(kinds, &(&1 == :interrupted))
+    end
+  end
+
+  # #1708 — the OTHER half of the same pool-disconnect race #1657 closed.
+  #
+  # `disconnect/2` does two things in order: `Sqlite3.cancel(db)` and then
+  # `Sqlite3.close(db)`. Which one the in-flight statement meets decides which
+  # symptom the caller gets, and the two are complementary:
+  #
+  #   * the cancel lands DURING the step -> SQLITE_INTERRUPT -> the statement
+  #     LOST, no row -> `%Exqlite.Error{message: "interrupted"}` -> #1657.
+  #   * the close lands AFTER the step completed -> the statement WON and the
+  #     row is durable, but the handle the driver then consults for the change
+  #     count is gone. `exqlite_changes` answers `{:error, :connection_closed}`,
+  #     `maybe_changes/2` turns that into `nil`, and `%Result{num_rows: nil}` is
+  #     reported to Ecto as SUCCESS. `Ecto.Adapters.SQL.struct/10` has no clause
+  #     for it and falls through to `num_rows > 1`, which `nil` satisfies (term
+  #     order: every number sorts before every atom), so it raises
+  #     `Ecto.MultiplePrimaryKeyError` about a primary key that is not the
+  #     problem. Its `count: nil` renders as NOTHING — the `got  entries` with a
+  #     double space that prod printed 22 times on 2026-08-22.
+  #
+  # `Ecto.MultiplePrimaryKeyError` is in NEITHER rescue list on the persistence
+  # path (`loop/4` here, `Scrollback.with_pool_retry/1` above it), so it
+  # propagated out of `Session.Persistor.persist_and_broadcast/3` and killed 22
+  # live IRC sessions — several of them 19 hours old — for a scrollback row
+  # that had already landed. The driver-level halves of that chain are measured
+  # in `Grappa.Repo.BusyRetryFidelityTest`; this block pins the verdict.
+  #
+  # It earns its OWN kind for the #1420 reason, and here the borrowing would be
+  # worse than a mislabel: `:interrupted` says the statement was cancelled, and
+  # this statement COMPLETED. It is also the first NON-RETRYABLE transient —
+  # the row is durable, so a retry does not re-attempt a lost write, it inserts
+  # a second one.
+  describe "a connection closed after the write completed (#1708)" do
+    test "the empty count is what prod printed — Ecto renders `got  entries` for count: nil" do
+      assert orphaned_write_error().message =~ "but got  entries."
+    end
+
+    test "classify/1 answers :connection_closed for an EMPTY count" do
+      assert BusyRetry.classify(orphaned_write_error()) == :connection_closed
+    end
+
+    test "classify/1 keeps a GENUINE multi-row result :permanent — the real PK bug stays loud" do
+      assert BusyRetry.classify(genuine_multi_row_error()) == :permanent
+    end
+
+    test "a genuine multi-row result still RE-RAISES out of run/1" do
+      assert_raise Ecto.MultiplePrimaryKeyError, fn ->
+        BusyRetry.run(fn -> raise genuine_multi_row_error() end)
+      end
+    end
+
+    test "an orphaned write degrades to {:error, :db_unavailable} — it never reaches the caller" do
+      assert {:error, :db_unavailable} = BusyRetry.run(fn -> raise orphaned_write_error() end)
+    end
+
+    test "an orphaned write is NEVER retried — a retry would insert the row a second time" do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      op = fn ->
+        Agent.update(counter, &(&1 + 1))
+        raise orphaned_write_error()
+      end
+
+      assert {:error, :db_unavailable} = BusyRetry.run(op)
+
+      # The discriminator against every other transient kind. This op raises
+      # instantly, so the 1_500ms budget is untouched and `:busy_locked` /
+      # `:interrupted` would both re-enter the loop dozens of times here (the
+      # #1657 sibling test asserts exactly that, `> 1`). Exactly one attempt
+      # means the no-retry decision came from the VERDICT, not from the clock.
+      assert Agent.get(counter, & &1) == 1
+    end
+
+    test "the observer sees a distinct :connection_closed kind, once, flagged terminal" do
+      {:ok, observed} = Agent.start_link(fn -> [] end)
+      on_contention = fn kind, attempt, terminal? -> Agent.update(observed, &[{kind, attempt, terminal?} | &1]) end
+
+      assert {:error, :db_unavailable} =
+               BusyRetry.run(fn -> raise orphaned_write_error() end, on_contention: on_contention)
+
+      assert Agent.get(observed, &Enum.reverse(&1)) == [{:connection_closed, 1, true}]
+    end
+
+    test "the terminal line says the write LANDED — it must not report an unavailable write" do
+      log =
+        capture_log(fn ->
+          assert {:error, :db_unavailable} = BusyRetry.run(fn -> raise orphaned_write_error() end)
+        end)
+
+      lines =
+        log
+        |> String.split("\n")
+        |> Enum.filter(&(&1 =~ "fault=connection_closed"))
+
+      assert lines != []
+      assert Enum.all?(lines, &(&1 =~ "SQLite connection closed after the write completed"))
+
+      # CLAUDE.md log honesty: the row is durably in the table, so the shared
+      # `db write unavailable:` opening of the other three kinds is FALSE here
+      # and this kind does not borrow it. An operator reading this line must
+      # not go looking for a lost row.
+      refute Enum.any?(lines, &(&1 =~ "db write unavailable"))
     end
   end
 

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -427,6 +427,31 @@ defmodule Grappa.ScrollbackTest do
       assert {:error, :persist_unavailable} = Scrollback.with_pool_retry(op)
       assert Agent.get(counter, & &1) == 1
     end
+
+    # #1708 — the exception that broke the #336 contract in production. The
+    # pool closed the connection AFTER the INSERT had completed, so the driver
+    # reported success with no row count, `Ecto.Adapters.SQL.struct/10` fell
+    # through to its `num_rows > 1` clause (which `nil` satisfies) and raised
+    # `Ecto.MultiplePrimaryKeyError`. Neither rescue list on this path named
+    # that struct, so it propagated out of `persist_event/1` and out of
+    # `Session.Persistor.persist_and_broadcast/3`, killing 22 live IRC sessions
+    # on 2026-08-22 — one of the very disconnections #336 exists to prevent.
+    #
+    # The mechanism, the term-order guard and the empty-count rendering are
+    # measured in `Grappa.Repo.BusyRetryFidelityTest`; the verdict and the
+    # no-retry rule in `Grappa.Repo.BusyRetryTest`. What THIS pins is the only
+    # thing the session cares about: the row is lost, the session is not.
+    test "a connection closed after the write degrades to :persist_unavailable — it does NOT escape (#1708)" do
+      orphaned =
+        Ecto.MultiplePrimaryKeyError.exception(
+          operation: :insert,
+          source: "messages",
+          params: [1, "#bofh"],
+          count: nil
+        )
+
+      assert {:error, :persist_unavailable} = Scrollback.with_pool_retry(fn -> raise orphaned end)
+    end
   end
 
   describe "persist_event/1" do

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -24,7 +24,7 @@ setup() {
     # Verbatim from the call sites, so a pin that drifts from production
     # prose fails here rather than reporting a confident zero.
     #   lock_watch.ex — the two edges of one stall episode
-    #   busy_retry.ex — the three terminal arms, one per fault kind
+    #   busy_retry.ex — the four terminal arms, one per fault kind
     LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
     LOCKUNATTR_LINE='db lock stall UNATTRIBUTED: 3 writer(s) queued past the threshold, longest 31303ms — no holder registered, so the holder is NOT attributable at the BEGIN IMMEDIATE seam; longest waiter #PID<0.512.0> status=:waiting at :gen_server.loop/7, stack: a <- b'
@@ -34,6 +34,12 @@ setup() {
     # raised only once DBConnection's own `:timeout` has expired, which is
     # also why its attempt count is 1 and not 14 like the saturated line.
     INTERRUPTED_LINE='db write unavailable: SQLite statement cancelled by a pool timeout for 15042ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
+    # #1708 — the fourth arm, and the only one that does NOT open with "db
+    # write unavailable": its statement completed, so the row is durable and
+    # the prose must not send an operator hunting for it. Attempt count is 1
+    # by VERDICT here (the fault is classified non-retryable) rather than
+    # because a budget expired.
+    ORPHANED_LINE='db write landed but its result was lost: SQLite connection closed after the write completed, 15042ms into the write, on attempt 1 (not retried — the row is durable, a retry would duplicate it) — returning :db_unavailable'
 }
 
 # The scanner as integration.sh invokes it: a service label and a
@@ -99,6 +105,7 @@ stamp() {
         stamp '12:00:05.' "$LOCKSTALL_LINE"
         stamp '12:00:06.' "$LOCKRESOLVED_LINE"
         stamp '12:00:07.' "$INTERRUPTED_LINE"
+        stamp '12:00:08.' "$ORPHANED_LINE"
     } | scan 10 )"
 
     grep -q 'db30=1' <<<"$out"
@@ -107,6 +114,9 @@ stamp() {
     grep -q 'saturated=1' <<<"$out"
     # #1657 — and specifically NOT folded into `saturated`, which stays 1.
     grep -q 'interrupted=1' <<<"$out"
+    # #1708 — nor into `interrupted`, nor into `dropped`: the write LANDED, so
+    # counting it as a lost row is the one reading the census must not offer.
+    grep -q 'orphaned=1' <<<"$out"
     grep -q 'lockheld=1' <<<"$out"
     grep -q 'lockstall=1' <<<"$out"
     grep -q 'lockstall_resolved=1' <<<"$out"


### PR DESCRIPTION
Fixes the 22 killed IRC sessions in #1708.

## The error lies about its own cause, and said so

Every one of the 22 lines rendered `got  entries` — **two spaces where the
count belongs**, so the count Ecto interpolated was the empty string.

`nil > 1` is **TRUE**: Erlang term order puts every number before every atom,
so `Ecto.Adapters.SQL.struct/10`'s guard for *"more than one row came back"*
(`ecto_sql/lib/ecto/adapters/sql.ex:1198`) also catches *"no count at all"*,
and raises an error named after the only cause its author had in mind.

`num_rows: nil` has exactly one producer: `maybe_changes/2`
(`exqlite/lib/exqlite/connection.ex:657-664`) swallowing
`Sqlite3.changes/1`'s `{:error, :connection_closed}` into `nil`. The `with`
above it does **not** bail, because `transaction_status/1` on a closed handle
answers `{:ok, :error}` rather than an error tuple
(`c_src/sqlite3_nif.c:1199-1202`) — so the driver reports the insert to Ecto
as **SUCCESS**.

## It is the other half of #1657's race

`Exqlite.Connection.disconnect/2` runs `cancel` then `close`, fired from the
**pool** process (`db_connection/connection_pool.ex:188-210`) while the
**client** process runs the statement (`Holder.handle/4:166` applies
`handle_execute` in the caller). Which verb the in-flight statement meets
decides the symptom:

| when the disconnect lands | statement | row | symptom | handled |
|---|---|---|---|---|
| cancel **during** the step | LOSES | none | `%Exqlite.Error{"interrupted"}` | #1657 ✅ |
| close **after** the step | **WON** | **durable** | `Ecto.MultiplePrimaryKeyError` | ❌ until now |

The surviving-write arm was never handled because its symptom is not a driver
exception at all — so neither rescue allowlist on the persistence path named
it, and it propagated out of `Persistor.persist_and_broadcast/3`.

## Why it landed on the wrong side of the degrade

`BusyRetry.loop/4` and `Scrollback.with_pool_retry/1` both rescue an
**allowlist of two driver structs**. The guarantee they implement (#336 — a
persist must never crash the calling `Session.Server`) is a statement about
the CALLER, not about which exception the driver threw. An allowlist is only
ever as complete as the last incident.

## The cure — not a wider net

The ONE classifier learns the third symptom and **discriminates on the
count**:

* **empty count** → `:connection_closed`. Only the pool can produce it.
* **a count that is there** → stays `:permanent` and **re-raises**. A genuine
  multi-row UPDATE/DELETE keeps surfacing loud.

The predicate reads only the message's **first line** — the tail inspects the
bound params, which on this path are user-controlled message bodies, and a
body echoing the sentence must not reclassify a real bug as recoverable.

🔴 **TRANSIENT and RETRYABLE stop being the same axis.** They coincided for
three kinds and stop at the fourth: this statement COMPLETED, so a retry does
not re-drive a lost write — **it inserts a duplicate**. `retryable?/1`
degrades it on attempt 1 by verdict, never by clock. Its terminal line does
not borrow the shared `db write unavailable:` opening, which is false for it.

## Proven negative — worth as much as the cure

**`messages` has no primary-key problem.** Plain `create table(:messages)`
with Ecto's default single `id` (`20260425000000_init.exs:38`), no triggers
anywhere in `priv/repo/migrations/`, so `sqlite3_changes()` on a single-row
`INSERT … VALUES … RETURNING` is 1 or the statement failed. The audit anyone
would have started with, closed.

## Measured / read / not reproduced

* **Measured** against the shipped exqlite and Ecto (`BusyRetryFidelityTest`):
  `changes/1` errors on a closed handle; `transaction_status/1` answers
  `{:ok, :error}` and does not bail; the driver-derived `nil` satisfies the
  `> 1` guard; Ecto's OWN constructor renders `count: nil` as the prod string.
* **Read, not run:** `struct/10`'s clause order — its adapter is reached via a
  module-local `query/4`, so no test can inject the `%Result{}`.
* **Not reproduced:** the race itself. `Exqlite.Connection` re-prepares against
  `state.db` on every `handle_execute/4`, so a closed handle cannot be smuggled
  past the public callback.

## Left open deliberately

Whether this can fire **outside** a saturation window. A disconnect is the
trigger and saturation is the overwhelming producer of one, but `max_lifetime`
and a `:disconnect` from any callback also produce one — so *"only under
contention"* is **not** established.

## Accepted limitation

`Scrollback` maps every engine terminal onto the same `:persist_unavailable`,
so `Persistor` still logs `scrollback row dropped` for a row that is durably
in the table. The honest fix is a fourth terminal atom out of `BusyRetry`, and
`:db_unavailable` appears in ~150 `@spec`s — a separate change. Mitigated by
the new `orphaned` census counter: `dropped` is the UPPER bound on lost rows,
`dropped - orphaned` the LOWER one. Stated in the code, the awk and the entry.

## Gates

`scripts/check.sh` green pre-rebase (`rc=0`): 6855 tests / 0 failures,
Dialyzer 0 errors, Credo 0 issues, Doctor passed, `deps.audit` clean.
`bats` 21/21 on the census scanner, including its own known-answer,
no-cross-talk and complete-set controls. Targeted suites re-run green after
each of the two rebases (274 tests / 0 failures). The awk sample, the bats pin
and `terminal_message/3`'s output were compared **byte-for-byte
mechanically**, not by eyeball.