### PR TITLE
perf(#1768): coalesce the window_counts emit per window, not per row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Grappa.Application
 ├── Grappa.RateLimit.TokenBucket       (#340 per-(subject, network) send token bucket)
 ├── Grappa.Net.PtrCache                (#252 vhost reverse-DNS (PTR) name cache)
 ├── Task.Supervisor                    (name: Grappa.TaskSupervisor — detached tasks)
+├── Grappa.WindowCounts.Pusher.Coalescer (#1768 one window_counts snapshot per window per window_ms; after TaskSupervisor — flushes into it)
 ├── DynamicSupervisor                  (name: Grappa.SessionSupervisor)
 │   └── Grappa.Session.Server          (one per (user, network), :transient)
 ├── GrappaWeb.Endpoint                 (Phoenix HTTP + WS)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63523,3 +63523,121 @@ exit code today and an exit contract nobody reads is a guess about a future
 caller. Out of scope and filed separately: `scripts/shellcheck.sh` derives its
 set from `bin/ infra/ scripts/`, so the nine shell scripts under
 `.claude/skills/**` — this watchdog among them — have never been linted.
+<!-- entry #1768 -->
+
+---
+
+## 2026-08-25 — #1768: the badge fan-out was O(rows); the lever is the emit, not the wire
+
+The request arrived as "a batching endpoint to relieve the multi-network
+load". Batching the WIRE saves bytes, and it would not have touched this: the
+snapshot tasks are spawned before any framing exists, and what saturated the
+SQLite pool was their NUMBER. `Grappa.Session.Persistor.dispatch_push/2` fires
+the #267 push for EVERY persisted row, and `Grappa.WindowCounts.Pusher.push/1`
+handed each one straight to `Grappa.TaskSupervisor` — one task, one fresh
+`WindowCounts.snapshot/7`, per row, with nothing bounding the fan-out against
+a pool 10 connections wide.
+
+`Grappa.WindowCounts.Pusher.Coalescer` folds a burst of rows in one
+`{subject, network_id, channel}` window into ONE flush. In-flight snapshot
+work becomes **O(distinct windows touched)** instead of **O(rows persisted)**,
+which is the property that maps onto a fixed-size pool: rows per unit time are
+unbounded (a netsplit delivers one presence row per shared channel per peer)
+while windows are bounded by the channels the subject is in.
+
+### What was measured here, and what was inherited
+
+Inherited from the issue, measured on prod in jail `grappa-new`,
+`runtime/log/erlang.log.19` around `00:15:24.891`: of 413 queries dropped from
+the pool in the saturation burst, **412 were badge arithmetic** — 304 stack
+frames in `WindowCounts.count_mentions/6`, 108 in
+`Scrollback.count_after_split/6`, 1 in the visitors reaper.
+
+Measured HERE, on this branch, by attaching to `[:grappa, :repo, :query]`
+around one `Pusher.emit/1`: **one emit costs 5 DB queries, not 2** —
+`user_settings` twice (the highlight patterns, then the display prefs the #505
+presence decision reads), `read_cursors` once, and `messages` twice (the
+`count_after_split/6` aggregate and the capped mention tail). The issue's "two
+queries per row per window" counted only the two on `messages`, because those
+are the two the dropped frames named. So each row the coalescer suppresses
+saves five queries, not two — and the pool pressure attributable to badges in
+that burst was correspondingly larger than the frame census alone can show.
+
+That the same `user_settings` row is read TWICE per emit is a real, separate
+inefficiency. It is named here and deliberately not fixed: it is a different
+lever (fold two reads into one), it is now behind the coalescer, and widening
+this change to chase it would have been scope creep.
+
+### A throttle, never a debounce — the starvation trap
+
+The timer is armed by the FIRST touch of an idle window and is **never
+extended** by later ones. A debounce that restarts on every arrival emits
+NOTHING while rows keep arriving faster than the window, and the presence rate
+measured for #1680 on a 7-network account (24.4 presence events/s sustained,
+one every ~41 ms) is exactly that regime. A badge that freezes during the only
+period it matters would be a worse bug than the one being fixed.
+
+So the contract is two-sided and both sides are load-bearing: **at most one**
+emit per window per `Coalescer.window_ms/0`, and **at least one** within
+`window_ms/0` of any row that arrives.
+
+250 ms is set by two ceilings and not by the floor. Ceiling one is perception:
+this is the lag a sidebar badge takes on after its message is already
+rendered, because the ROW's own broadcast is not delayed — only the derived
+count waits. Ceiling two is the at-least-once bound above. The floor is
+irrelevant: an IRC flood arrives at socket speed, sub-millisecond between
+rows, so anything above a few milliseconds already collapses it.
+
+### Dropping the intermediate emits is lossless BY CONSTRUCTION
+
+Not by argument. The snapshot is absolute — cic "replaces its stored snapshot
+verbatim" — and `emit/1` reads the DB at FLUSH time, not at touch time, so the
+one snapshot that survives a burst has seen every row of it. This makes a
+property of `emit/1` load-bearing for a module that does not call it on the
+hot path: **a future change that pre-computes any part of the snapshot at
+`push/1` time breaks the coalescer without touching it.** Recorded in both
+moduledocs for that reason.
+
+### The key takes the channel VERBATIM
+
+`{subject, network_id, channel}`, unfolded, because it must partition the same
+way the broadcast topic does (`PubSub.Topic.channel/3`, also verbatim).
+Folding it would let one casing's flush stand in for another's and leave the
+losing topic's subscribers with nothing — a fold that silently merges two
+DESTINATIONS, which is the opposite of what the #537 key fold exists to do.
+This is the case where the channel pattern's "fold at every key boundary" does
+not apply: the key is not a storage or lookup key, it is a partition of an
+output stream.
+
+### Rejected: gating presence kinds out of the snapshot entirely
+
+The issue's second proposal was to decide, before spawning the task, that a
+presence row cannot change the badge. It is declined on two independent
+grounds.
+
+It is not free of a correctness cost: a JOIN/PART/QUIT DOES change `events`,
+and so can move `severity` from `:none` to `:event`. Skipping it leaves the
+events badge stale on a quiet channel where presence is the only traffic,
+until the next content row or the next seed.
+
+And the gate cannot be cheap where it would have to live. Whether presence
+counts for a window is `PresenceFilter.Resolver.hidden?/4`, which reads the
+display prefs and may call into the live session for a member count — two of
+the five queries the emit already pays. Deciding it BEFORE spawning the task
+puts those queries back on the Session hot path, which is the thing the Task
+existed to avoid. Its entire benefit is subsumed by the coalescer anyway: once
+a window's rows fold into one flush, a presence-only burst costs one snapshot,
+not none-instead-of-N.
+
+### What this does NOT establish
+
+The lever bites on the BURST, which is what the incident was. It is **not** a
+claim about the sustained rate: a subject taking ~29.5 events/s spread thinly
+across many windows coalesces very little, because each window is then already
+below one row per window length. The distribution of the incident's 412 frames
+ACROSS windows was not measured — the log carries no per-channel breakdown and
+the jail is not reachable from here — so the burst's actual collapse ratio is
+unknown, and the O(rows) → O(windows) change is asserted structurally rather
+than as a measured multiple. The issue's own caveat still stands too: at
+`00:15:24.941` the handler switched from `:async` to `:drop`, so the verdict
+that closed the socket may never have reached disk.

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -36,6 +36,10 @@ defmodule Grappa.Application do
       # #364 J/cross-module-S2: start/2 calls WindowCounts.PushSource.boot/0
       # + Themes.boot/0 to inject the two remaining DI-seams at boot.
       Grappa.WindowCounts,
+      # #1768 — supervises WindowCounts.Pusher.Coalescer. This edge is on
+      # the SUPERVISOR, not on Session: the DI seam exists so `Session`
+      # carries no static edge onto the impl, and it still does not.
+      Grappa.WindowCounts.Pusher,
       Grappa.Themes,
       Grappa.WSPresence,
       GrappaWeb
@@ -363,6 +367,14 @@ defmodule Grappa.Application do
         # is a visible SASL report. Must precede SessionSupervisor so a
         # session terminating on its start path can already reach it.
         {Task.Supervisor, name: Grappa.TaskSupervisor},
+        # #1768 — window_counts snapshot coalescer. AFTER TaskSupervisor
+        # (every flush hands its snapshot to it) and BEFORE
+        # SessionSupervisor, because the first persisted row of the first
+        # session touches it. Its absence is not fatal — `touch/1` is a
+        # cast, so an un-started coalescer silently skips the live-render
+        # optimization instead of crashing the persist path — but that is
+        # a degradation contract, not a licence to start it late.
+        Grappa.WindowCounts.Pusher.Coalescer,
         # max_restarts: 10_000, max_seconds: 60 — DynamicSupervisor's
         # default (3 restarts in 5s) is GLOBAL across all children; one
         # upstream network-wide outage causing several Session.Server

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -138,6 +138,11 @@ defmodule Grappa.HotReload.LongLivedModules do
     Grappa.RateLimit.FailureWindow,
     Grappa.RateLimit.TokenBucket,
     Grappa.Net.PtrCache,
+    # #1768 — its `init/1` returns the bare `{:ok, %{}}` literal, which is
+    # exactly the empty-map case this list takes on purpose: the day the
+    # pending map gains a field beside the ctx, THAT field-add is the
+    # hot-unsafe change, and only a listed module is checked for it.
+    Grappa.WindowCounts.Pusher.Coalescer,
     Grappa.Session.Server,
     Grappa.IRC.Client,
     Grappa.IRC.AuthFSM,
@@ -191,6 +196,7 @@ defmodule Grappa.HotReload.LongLivedModules do
           | Grappa.RateLimit.FailureWindow
           | Grappa.RateLimit.TokenBucket
           | Grappa.Net.PtrCache
+          | Grappa.WindowCounts.Pusher.Coalescer
           | Grappa.Session.Server
           | Grappa.IRC.Client
           | Grappa.IRC.AuthFSM

--- a/lib/grappa/window_counts/pusher.ex
+++ b/lib/grappa/window_counts/pusher.ex
@@ -16,12 +16,20 @@ defmodule Grappa.WindowCounts.Pusher do
   `push/1` gates on live WS presence (`WSPresence.ws_count/1` > 0): if
   no socket is connected for the subject, it skips — the next
   `join_reply` / `/me` re-seeds the absolute snapshot on reconnect, so a
-  disconnected subject costs nothing. When connected, it hands the work
-  to `Grappa.TaskSupervisor` (like `Push.Triggers`) so the Session hot
-  path never blocks on the snapshot's DB work, then `emit/1` computes the fresh
-  `WindowCounts.snapshot/7` (cursor from `ReadCursor`, highlight patterns
-  from `UserSettings`) and broadcasts the `window_counts` event on the
-  per-channel topic. cic replaces its stored snapshot verbatim.
+  disconnected subject costs nothing. When connected, it hands the window
+  to `Coalescer` (#1768), which folds a burst of rows in the same window
+  into ONE flush and runs it under `Grappa.TaskSupervisor` (like
+  `Push.Triggers`) so the Session hot path never blocks on the snapshot's
+  DB work. `emit/1` then computes the fresh `WindowCounts.snapshot/7`
+  (cursor from `ReadCursor`, highlight patterns from `UserSettings`) and
+  broadcasts the `window_counts` event on the per-channel topic. cic
+  replaces its stored snapshot verbatim.
+
+  `emit/1` reads the DB at FLUSH time, which is what makes the coalescing
+  lossless: the one snapshot that survives a burst has seen every row of
+  it. That property is load-bearing — see `Coalescer`'s moduledoc — so a
+  future change that pre-computes any part of the snapshot at `push/1`
+  time breaks the coalescer without touching it.
   """
 
   @behaviour Grappa.WindowCounts.PushSource
@@ -36,33 +44,37 @@ defmodule Grappa.WindowCounts.Pusher do
       Grappa.UserSettings,
       Grappa.WindowCounts,
       Grappa.WSPresence
-    ]
+    ],
+    # #1768 — the coalescer is a supervised singleton, so `Grappa.Application`
+    # has to name it in the child list. Nothing else outside this boundary
+    # may: `push/1` is still the only door in.
+    exports: [Coalescer]
 
   alias Grappa.PresenceFilter.Resolver
   alias Grappa.PubSub.Topic
   alias Grappa.{ReadCursor, UserSettings, WindowCounts, WSPresence}
+  alias Grappa.WindowCounts.Pusher.Coalescer
   alias Grappa.WindowCounts.{PushSource, Wire}
 
   @impl PushSource
   @spec push(PushSource.ctx()) :: :ok
   def push(%{subject_label: subject_label} = ctx) do
-    # `_ =` — the `if` is evaluated for its side effect (starting the
-    # emit task); its value is intentionally discarded (dialyzer
+    # `_ =` — the `if` is evaluated for its side effect (arming the
+    # coalescer's flush); its value is intentionally discarded (dialyzer
     # `:unmatched_returns`).
     _ =
       if WSPresence.ws_count(subject_label) > 0 do
-        # Detached, but not orphaned: under `Grappa.TaskSupervisor` (S37)
-        # the worker is visible to the operator and a crash in it is a
-        # report rather than a silent disappearance. The snapshot DB work
-        # stays off the Session hot path either way. A worker that never
-        # runs just means the live-render optimization is skipped for this
-        # row; the next seed re-bases the count.
+        # #1768 — through the coalescer, NOT straight to a Task. One row
+        # used to be one task and one snapshot; a burst in one window is
+        # now one snapshot, so in-flight snapshot work is bounded by the
+        # windows touched instead of by the rows persisted. See
+        # `Coalescer`'s moduledoc for the measurement and for why dropping
+        # the intermediate emits is lossless.
         #
-        # The return is DISCARDED, not matched. `Task.start/1` could not
-        # fail, but a supervisor can refuse — and the day this supervisor
-        # is given a child ceiling, a strict match here would turn a
-        # skipped optimization into a crash on the session hot path.
-        Task.Supervisor.start_child(Grappa.TaskSupervisor, fn -> emit(ctx) end)
+        # The presence gate stays HERE, ahead of the cast, so a subject
+        # with no socket still costs nothing at all — not even a message
+        # into the coalescer's mailbox.
+        Coalescer.touch(ctx)
       end
 
     :ok

--- a/lib/grappa/window_counts/pusher/coalescer.ex
+++ b/lib/grappa/window_counts/pusher/coalescer.ex
@@ -117,7 +117,7 @@ defmodule Grappa.WindowCounts.Pusher.Coalescer do
   The coalescing window, in milliseconds. Public so a test can express its
   waits in terms of the shipped value instead of restating it.
   """
-  @spec window_ms() :: pos_integer()
+  @spec window_ms() :: unquote(@window_ms)
   def window_ms, do: @window_ms
 
   @spec start_link(keyword()) :: GenServer.on_start()

--- a/lib/grappa/window_counts/pusher/coalescer.ex
+++ b/lib/grappa/window_counts/pusher/coalescer.ex
@@ -1,0 +1,176 @@
+defmodule Grappa.WindowCounts.Pusher.Coalescer do
+  @moduledoc """
+  #1768 — at most ONE `window_counts` snapshot per window per
+  `window_ms/0`, however many rows land inside it.
+
+  ## Why the emit and not the wire
+
+  `Grappa.Session.Persistor.dispatch_push/2` fires the #267 push for
+  EVERY persisted row, and `Pusher.push/1` used to hand each one straight
+  to `Grappa.TaskSupervisor` — one task, and one fresh
+  `WindowCounts.snapshot/7`, per row. Measured on prod during the
+  2026-08-25 00:15 incident: of 413 queries dropped from the SQLite pool
+  in the saturation burst, **412 were badge arithmetic** (304 frames in
+  `WindowCounts.count_mentions/6`, 108 in
+  `Scrollback.count_after_split/6`). The pool is 10 connections wide
+  (`config/runtime.exs`); the snapshot fan-out is bounded by nothing.
+
+  Batching the WIRE would have saved bytes. It would not have helped:
+  the tasks are spawned before any framing exists, and what saturated
+  the pool was their NUMBER.
+
+  ## The property this buys, stated exactly
+
+  In-flight snapshot work becomes **O(distinct windows touched)** instead
+  of **O(rows persisted)**. That is the whole claim, and it is the one
+  that maps onto a fixed-size pool: rows per unit time are unbounded (a
+  netsplit delivers one presence row per shared channel per peer), while
+  windows are bounded by the channels the subject is in.
+
+  It is NOT a claim about the sustained rate. A subject taking 29.5
+  events/s spread thinly across many windows coalesces very little,
+  because each window is already below one row per window length. The
+  lever bites on the BURST, which is what the incident was.
+
+  ## Dropping intermediate emits is lossless BY CONSTRUCTION
+
+  The snapshot is absolute — cic "replaces its stored snapshot verbatim"
+  (`Pusher` moduledoc) — and `Pusher.emit/1` computes it from the DB at
+  flush time, not at touch time. So a later snapshot supersedes an
+  earlier one completely, and the one this module does emit has seen
+  every row of the burst. Nothing is deferred that a reader could miss:
+  the ROW itself is broadcast by the Persistor immediately and
+  independently, ahead of the push. Only the derived count waits.
+
+  ## A fixed window, never extended — the starvation trap
+
+  The timer is armed by the FIRST touch of an idle window and is never
+  reset by later ones. That is deliberate and is the difference between
+  a throttle and a debounce: a debounce that restarts on every arrival
+  emits NOTHING while rows keep arriving faster than the window, and the
+  measured presence flood (#1680: 24.4 presence events/s sustained, one
+  every ~41 ms) is exactly that regime. A badge that freezes during the
+  only period it matters is a worse bug than the one being fixed.
+
+  So the contract is two-sided: **at most one** emit per window per
+  `window_ms/0`, and **at least one** within `window_ms/0` of any row
+  that arrives — no arrival is ever left unrepresented for longer than
+  the window.
+
+  ## Why a GenServer
+
+  State that must persist between calls, serialized by a mailbox —
+  the CLAUDE.md GenServer case. The state is a map of the windows with a
+  flush armed, keyed by `{subject, network_id, channel}`; presence of the
+  key IS the "armed" flag, so no parallel bookkeeping can drift from it
+  (design discipline 1). Idle windows hold nothing.
+
+  A crash costs the pending flushes and nothing else: the snapshot is a
+  live-render optimization, and the next `join_reply` / `/me` /
+  `read_cursor_set` re-seeds the absolute snapshot regardless — the same
+  degradation `PushSource` already documents for its `nil` impl. The
+  restarted process starts empty and the next row re-arms.
+
+  ## The key is NOT folded
+
+  `{subject, network_id, channel}` takes the channel verbatim, because it
+  must partition the same way the BROADCAST TOPIC does
+  (`Topic.channel/3`, also verbatim). Folding it here would let one
+  casing's flush stand in for another's, and the subscribers of the topic
+  that lost the draw would get nothing — a fold that silently merges two
+  destinations, which is the opposite of what the #537 key fold is for.
+  """
+
+  use GenServer
+
+  alias Grappa.WindowCounts.{Pusher, PushSource}
+
+  @typedoc """
+  The window a snapshot is for. `subject` + `network_id` are the DB-side
+  identity the snapshot queries on; `channel` is verbatim (see moduledoc).
+  """
+  @type key :: {Grappa.Subject.t(), integer(), String.t()}
+
+  @typedoc """
+  Windows with a flush armed → the newest ctx seen for each. Presence of
+  the key is the armed flag.
+  """
+  @type pending :: %{key() => PushSource.ctx()}
+
+  # 250 ms. Chosen against two ceilings and one floor.
+  #
+  # Ceiling 1 — perception: this is the lag a sidebar badge takes on
+  # after its message is already rendered (the row's own broadcast is not
+  # delayed). A quarter second on a peripheral counter is below notice; a
+  # full second is not.
+  #
+  # Ceiling 2 — the at-least-once side of the contract above: a row is
+  # never unrepresented for longer than this.
+  #
+  # Floor — it has to span a real burst. An IRC flood (netsplit QUITs, a
+  # rejoin's JOIN storm) arrives at socket speed, sub-millisecond between
+  # rows, so anything above a few milliseconds collapses it. The value is
+  # therefore set by the ceilings, not the floor.
+  @window_ms 250
+
+  @doc """
+  The coalescing window, in milliseconds. Public so a test can express its
+  waits in terms of the shipped value instead of restating it.
+  """
+  @spec window_ms() :: pos_integer()
+  def window_ms, do: @window_ms
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(_), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @doc """
+  Records that `ctx`'s window has new rows. Arms a flush if the window is
+  idle; otherwise folds into the one already armed.
+
+  Asynchronous and non-blocking: this runs on the Session hot path, and a
+  `GenServer.cast/2` to a process that is not up is a no-op returning
+  `:ok` — the same graceful degradation `PushSource` documents, a skipped
+  live-render optimization rather than a crash on the persist path.
+  """
+  @spec touch(PushSource.ctx()) :: :ok
+  def touch(ctx) when is_map(ctx), do: GenServer.cast(__MODULE__, {:touch, ctx})
+
+  @impl GenServer
+  @spec init(:ok) :: {:ok, pending()}
+  def init(:ok), do: {:ok, %{}}
+
+  @impl GenServer
+  def handle_cast({:touch, ctx}, pending), do: {:noreply, arm(pending, key(ctx), ctx)}
+
+  @impl GenServer
+  def handle_info({:flush, key}, pending) do
+    {ctx, rest} = Map.pop!(pending, key)
+
+    # Detached under `Grappa.TaskSupervisor` for the same reason `push/1`
+    # detached it before this module existed: the snapshot's DB work is
+    # visible to the operator and a crash in it is a report. The return is
+    # discarded, not matched — a supervisor that refuses must skip the
+    # optimization, never take this process down with it.
+    _ = Task.Supervisor.start_child(Grappa.TaskSupervisor, fn -> Pusher.emit(ctx) end)
+
+    {:noreply, rest}
+  end
+
+  # Already armed: fold in. The ctx is REPLACED rather than kept, because
+  # `own_nick` can move under the subject mid-burst (a /nick) and the
+  # flush must key the mention fold on the newest one.
+  @spec arm(pending(), key(), PushSource.ctx()) :: pending()
+  defp arm(pending, key, ctx) when is_map_key(pending, key), do: %{pending | key => ctx}
+
+  # Idle window: arm the ONE flush for it. Never extended afterwards —
+  # see the moduledoc on why a resetting debounce starves.
+  defp arm(pending, key, ctx) do
+    _ = Process.send_after(self(), {:flush, key}, @window_ms)
+
+    Map.put(pending, key, ctx)
+  end
+
+  @spec key(PushSource.ctx()) :: key()
+  defp key(%{subject: subject, network_id: network_id, channel: channel}),
+    do: {subject, network_id, channel}
+end

--- a/test/grappa/window_counts/pusher/coalescer_test.exs
+++ b/test/grappa/window_counts/pusher/coalescer_test.exs
@@ -16,6 +16,14 @@ defmodule Grappa.WindowCounts.Pusher.CoalescerTest do
   be a correctness regression, since the payload is per-channel and each
   channel's subscribers get their own topic.
 
+  The third covers the half the first two cannot see. "At most one emit
+  per window" is satisfied by a resetting DEBOUNCE as well, and a debounce
+  emits nothing at all while rows keep arriving faster than the window —
+  which is the regime the whole change exists for. So the third test keeps
+  the arrivals coming and asserts an emit lands anyway. Verified by
+  mutation: turning `arm/3` into a resetting debounce leaves the first two
+  green and takes only this one red.
+
   ## Why the setup carries no race
 
   Every row is inserted BEFORE the first push, so the counts the flush
@@ -95,6 +103,41 @@ defmodule Grappa.WindowCounts.Pusher.CoalescerTest do
 
     assert Enum.sort(Enum.map(payloads, & &1.channel)) == ["#one", "#two"]
     assert Enum.all?(payloads, &(&1.messages == @burst))
+  end
+
+  test "arrivals faster than the window still emit — a throttle, not a debounce", ctx do
+    subscribe(ctx, "#chan")
+    insert(ctx, "#chan")
+
+    window = Coalescer.window_ms()
+
+    # Feeds for THREE windows at one push every fifth of a window, so the
+    # arrivals never stop while the assertion below is waiting.
+    {feeder, ref} =
+      spawn_monitor(fn ->
+        feed_until(ctx, "#chan", System.monotonic_time(:millisecond) + window * 3, div(window, 5))
+      end)
+
+    # The discriminator. A debounce restarts its timer on every arrival and
+    # so emits NOTHING before the feeder stops — not before three windows.
+    # The armed-once flush lands one window in, and the budget here is two,
+    # so the two designs are separated by a whole window rather than by a
+    # margin. This is the "at least one emit within `window_ms/0` of any
+    # arrival" half of the contract; the other tests only pin "at most one".
+    assert_receive %Phoenix.Socket.Broadcast{payload: %{kind: :window_counts}}, window * 2
+
+    # Let the feeder retire and its last flush land before the test ends,
+    # so nothing from this window leaks into the next test's sandbox.
+    assert_receive {:DOWN, ^ref, :process, ^feeder, :normal}, window * 8
+    drain()
+  end
+
+  defp feed_until(ctx, channel, deadline, gap_ms) do
+    if System.monotonic_time(:millisecond) < deadline do
+      push(ctx, channel)
+      Process.sleep(gap_ms)
+      feed_until(ctx, channel, deadline, gap_ms)
+    end
   end
 
   defp subscribe(ctx, channel) do

--- a/test/grappa/window_counts/pusher/coalescer_test.exs
+++ b/test/grappa/window_counts/pusher/coalescer_test.exs
@@ -1,0 +1,154 @@
+defmodule Grappa.WindowCounts.Pusher.CoalescerTest do
+  @moduledoc """
+  #1768 — a burst of persisted rows in ONE window must cost ONE snapshot,
+  not one per row.
+
+  ## What is asserted, and what is deliberately not
+
+  The oracle is the NUMBER of `window_counts` broadcasts, because that is
+  one-to-one with the number of snapshot tasks: `Pusher.emit/1` broadcasts
+  exactly once per invocation, and the flush is the only thing that
+  invokes it. A timing assertion ("the burst finishes faster") would be a
+  flake wearing a performance costume — nothing here measures duration.
+
+  The second test is the anti-over-coalescing guard: collapsing every
+  window of a subject into one snapshot would satisfy the first test and
+  be a correctness regression, since the payload is per-channel and each
+  channel's subscribers get their own topic.
+
+  ## Why the setup carries no race
+
+  Every row is inserted BEFORE the first push, so the counts the flush
+  reads are already final and the assertion never depends on an insert
+  winning a race against the coalescing window. The only thing the pushes
+  race is the window itself, and they are `GenServer.cast/2` calls issued
+  back to back — microseconds against `Coalescer.window_ms/0`.
+
+  `async: false` — touches the `Grappa.WSPresence` singleton and the
+  node-wide `Coalescer`, and its flush queries the Repo from a task that
+  needs the shared sandbox the async:false lane provides (same stance as
+  `Grappa.WindowCounts.PusherTest`).
+  """
+  use Grappa.DataCase, async: false
+
+  alias Grappa.{AuthFixtures, ScrollbackHelpers, WSPresence}
+  alias Grappa.PubSub.Topic
+  alias Grappa.WindowCounts.Pusher
+  alias Grappa.WindowCounts.Pusher.Coalescer
+
+  @burst 10
+  @own_nick "vjt"
+  @peer "alice"
+
+  # Four windows: long enough that the one coalesced emit (armed at the
+  # first touch, fired one window later) has certainly landed, and that an
+  # UNcoalesced burst — which emits immediately, per row — would have
+  # delivered every one of its broadcasts. Derived from the production
+  # constant rather than restated, so retuning the window cannot silently
+  # turn this into a test of nothing.
+  @drain_ms Coalescer.window_ms() * 4
+
+  setup do
+    user = AuthFixtures.user_fixture()
+    network = AuthFixtures.network_fixture()
+
+    :ok = WSPresence.reset_for_test()
+    :ok = WSPresence.register(user.name, self())
+    on_exit(fn -> WSPresence.reset_for_test() end)
+
+    %{user: user, network: network, subject: {:user, user.id}, label: user.name}
+  end
+
+  test "a burst in ONE window produces one snapshot carrying the final counts", ctx do
+    subscribe(ctx, "#chan")
+    for _ <- 1..@burst, do: insert(ctx, "#chan")
+
+    for _ <- 1..@burst, do: push(ctx, "#chan")
+
+    assert [
+             %{
+               kind: :window_counts,
+               channel: "#chan",
+               messages: @burst,
+               mentions: 0,
+               events: 0,
+               severity: :message
+             }
+           ] = drain()
+  end
+
+  test "two windows in the same burst coalesce SEPARATELY — one snapshot each", ctx do
+    subscribe(ctx, "#one")
+    subscribe(ctx, "#two")
+
+    for _ <- 1..@burst do
+      insert(ctx, "#one")
+      insert(ctx, "#two")
+    end
+
+    for _ <- 1..@burst do
+      push(ctx, "#one")
+      push(ctx, "#two")
+    end
+
+    payloads = drain()
+
+    assert Enum.sort(Enum.map(payloads, & &1.channel)) == ["#one", "#two"]
+    assert Enum.all?(payloads, &(&1.messages == @burst))
+  end
+
+  defp subscribe(ctx, channel) do
+    :ok =
+      Phoenix.PubSub.subscribe(
+        Grappa.PubSub,
+        Topic.channel(ctx.label, ctx.network.slug, channel)
+      )
+  end
+
+  defp insert(ctx, channel) do
+    {:ok, message} =
+      ScrollbackHelpers.insert(%{
+        user_id: ctx.user.id,
+        network_id: ctx.network.id,
+        channel: channel,
+        server_time: System.unique_integer([:positive]),
+        kind: :privmsg,
+        sender: @peer,
+        body: "hi"
+      })
+
+    message
+  end
+
+  defp push(ctx, channel) do
+    :ok =
+      Pusher.push(%{
+        subject: ctx.subject,
+        network_id: ctx.network.id,
+        network_slug: ctx.network.slug,
+        subject_label: ctx.label,
+        channel: channel,
+        own_nick: @own_nick
+      })
+  end
+
+  # Every `window_counts` payload that lands before the deadline, in
+  # arrival order. A deadline (not a per-message timeout) so the whole
+  # drain is bounded by `@drain_ms` however many payloads arrive.
+  defp drain, do: collect(System.monotonic_time(:millisecond) + @drain_ms)
+
+  defp collect(deadline) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      []
+    else
+      receive do
+        %Phoenix.Socket.Broadcast{payload: %{kind: :window_counts} = payload} ->
+          [payload | collect(deadline)]
+      after
+        remaining -> []
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refs #1768.

## What this changes

`Session.Persistor.dispatch_push/2` fires the #267 `window_counts` push for
**every persisted row**, and `WindowCounts.Pusher.push/1` handed each one
straight to `Grappa.TaskSupervisor` — one task, one fresh
`WindowCounts.snapshot/7`, per row, with nothing bounding the fan-out
against a pool 10 connections wide.

A new `Grappa.WindowCounts.Pusher.Coalescer` folds a burst of rows in one
`{subject, network_id, channel}` window into ONE flush. In-flight snapshot
work becomes **O(distinct windows touched)** instead of **O(rows
persisted)** — the property that maps onto a fixed-size pool, since rows
per unit time are unbounded while windows are bounded by the channels the
subject is in.

**No wire change**: no new frame, no new field, no shape change.
`grappa.gen_wire_types --check` and `grappa.wire_pin --check` both in sync,
so no `protocol_version` bump. cic is untouched.

## Design calls a reviewer should check

* **A throttle, not a debounce.** The timer is armed by the FIRST touch of
  an idle window and never extended. A resetting debounce emits *nothing*
  while rows keep arriving faster than the window, which is exactly the
  measured presence regime (#1680: 24.4 events/s, one every ~41 ms). The
  contract is two-sided — at most one emit per window per `window_ms/0`,
  **and at least one** within `window_ms/0` of any arrival. Third test
  pins that second half; verified by mutation (a resetting `arm/3` leaves
  the first two tests green and takes only that one red).
* **250 ms** is set by two ceilings (badge perception, and the
  at-least-once bound) and not by the floor — an IRC flood arrives at
  socket speed, so any window above a few ms already collapses it.
* **The key takes the channel VERBATIM.** It must partition the same way
  `Topic.channel/3` does; folding it would let one casing's flush stand in
  for another's and strand the losing topic's subscribers.
* **Lossless by construction, not by argument.** `emit/1` reads the DB at
  FLUSH time, so the surviving snapshot has seen every row of the burst,
  and the ROW itself is broadcast by the Persistor immediately and
  independently. A future change that pre-computes any part of the
  snapshot at `push/1` time would break the coalescer without touching it
  — recorded in both moduledocs.

## Measured here (not deduced)

* **One emit costs 5 DB queries, not 2.** Telemetry on
  `[:grappa, :repo, :query]` around one `Pusher.emit/1`: `user_settings`
  ×2 (highlight patterns, then the #505 display prefs), `read_cursors` ×1,
  `messages` ×2. The issue's "two queries per row per window" counted only
  the two on `messages`, because those are the two the dropped stack frames
  named.
* The doubled `user_settings` read is named as a separate lever and
  deliberately left alone — different change, and it now sits behind the
  coalescer.

## Declined, with reasons

The issue's proposal 2 (gate presence kinds out of the snapshot before
spawning) is declined on two independent grounds: a presence row *does*
move `events` and can move `severity` off `:none`, so skipping it leaves a
stale badge on a presence-only channel; and the gate
(`PresenceFilter.Resolver.hidden?/4`) is itself two of the five queries,
so deciding it before the task puts them back on the Session hot path.
Its benefit is subsumed by the coalescer anyway.

## Not established

The distribution of the incident's 412 frames *across* windows was never
measured — no per-channel breakdown in the log, jail unreachable from the
worker host — so the collapse ratio for that burst is unknown and the
O(rows) → O(windows) change is asserted structurally, not as a measured
multiple. It is **not** a claim about the sustained rate. The issue's own
caveat carries forward: the handler switched to `:drop` at 00:15:24.941,
so the verdict that closed the socket may never have reached disk.

## Gates

`scripts/check.sh` **rc=0** on `2187ce0b` (pre-rebase):
8 doctests, 62 properties, 6858 tests, 0 failures · Dialyzer `Total
errors: 0` · `gen_wire_types --check` + `wire_pin --check` in sync · bats
680 ok / 0 not ok.

Rebased onto `b2b203a3` with `scripts/union-rebase.sh` (rc=0,
`docs/DESIGN_NOTES.md +118 -0`, contribution intact; boundary shape and
the 40 lines preceding the marker verified byte-identical to the base
tail). `scripts/bats.sh` re-run after the rebase — **692 ok / 0 not ok** —
because main's three new commits add a bats file. The Elixir gates are
carried over rather than re-run: those commits touch only
`.claude/skills/orchestrate/**`, `docs/DESIGN_NOTES.md` and that bats
file, so no `lib/`, `test/*.exs`, `mix.exs` or `config/` input changed.

`test/grappa/repo/lock_watch_test.exs` timed out at 60 s on two earlier
runs. **Attributed to the open #1767 flake, measured, not assumed:** it
reproduces on the BASE `78665343` with no changes of mine, 1 failure in 5
isolated runs (1 in 3 on the branch), and #1767's own entry — landed on
that very commit — records it reddening main seven times with the cause
still open. The final `check.sh` run was clean.

e2e was **not** run (stack lane not held). Analysed instead: the two badge
specs (`issue267-mention-server-authoritative`,
`issue576-own-msg-unread-badge`) budget 5–30 s per assertion against a
250 ms added badge latency.
