### PR TITLE
#1766 — a per-account opt-out for the mobile bottom bar, and the door that replaces it

### DIFF
--- a/cicchetto/e2e/tests/issue1766-hide-bottom-bar.spec.ts
+++ b/cicchetto/e2e/tests/issue1766-hide-bottom-bar.spec.ts
@@ -1,0 +1,140 @@
+// GH #1766 — a per-user setting that hides the mobile BottomBar.
+//
+// vjt, `#grappa` 2026-08-25: *"aggiungiamo setting toggle per disattivare la
+// bottom bar su mobile. ora sono su 7 reti ed e' diventata praticamente
+// inutile"*. The bar is a flat horizontal strip of EVERY window across EVERY
+// network — O(windows), not O(screens) — so past a handful of networks it is
+// longer than the useful scroll distance and the picker stops picking.
+//
+// Default stays ON. #174 closed with the ruling that the bar must NOT be
+// deleted, only made opt-in from settings; #71's second ruling reversed "kill
+// the mobile bottom bar" outright. This is the opt-out those two asked for.
+//
+// ## What this file has to prove that the unit tests cannot
+//
+// The unit suite pins the JSX gate and the child order in jsdom, where there is
+// no layout, no service worker, no server and no second page load. Three claims
+// need a real browser and a real bouncer:
+//
+//   1. The bar actually LEAVES the phone. A `<Show>` that renders nothing in
+//      jsdom still tells you nothing about a strip that is `position`-ed by a
+//      stylesheet jsdom never applies.
+//   2. Something navigable replaces it. That is the whole reason the ☰ ships
+//      with the toggle: #1041's left-edge swipe is gesture-only with zero
+//      affordance, which is the drawer-only navigation #71 refused as a
+//      default. So the test does not stop at "the ☰ is in the DOM" — it taps
+//      it and CHANGES WINDOW through the drawer it opens. A ☰ that renders and
+//      navigates nowhere would pass a presence assertion.
+//   3. The preference is ACCOUNT-scoped, not device-scoped. It sits in the
+//      #449 synced `display_prefs` and not in localStorage alone, deliberately
+//      and against the counter-precedent of its own neighbour in the settings
+//      fieldset (#914's per-device `hide_next_active`). Only a round trip
+//      through the server can tell the two apart, so the second test wipes the
+//      local mirror and reloads: if the bar comes back, the pref was never
+//      synced and the "7 networks is an account property" argument was not
+//      implemented.
+//
+// `@webkit` throughout: the bar renders on the mobile branch only, so a
+// chromium run would assert the absence of something that was never there.
+
+import {
+  closeSettings,
+  loginAs,
+  openSettingsSection,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+const BOTTOM_BAR = ".bottom-bar";
+const WINDOWS_OPENER = "open windows sidebar";
+// The two localStorage keys that make up the LOCAL half of the preference: the
+// owner module's boot mirror and the coordinator's "a PUT never ACKed" marker.
+// Both have to go, or the reload below re-pushes the local value instead of
+// letting the server answer — which is the #222 re-push arm doing its job, and
+// would make the test prove the opposite of what it claims.
+const LOCAL_MIRROR_KEYS = ["cicchetto.showBottomBar", "cic.displayPrefs.unsynced"];
+
+test.setTimeout(90_000);
+
+async function hideTheBar(page: Parameters<typeof loginAs>[0]): Promise<void> {
+  await openSettingsSection(page, "display");
+  const toggle = page.getByTestId("show-bottom-bar-toggle");
+  // Checked by DEFAULT: the bar ships shown. If this is already unchecked the
+  // rest of the test would pass against a build whose default is inverted.
+  await expect(toggle).toBeChecked();
+  await toggle.uncheck();
+  await closeSettings(page);
+}
+
+test("@webkit mobile: turning the bar off removes it and leaves a working door", async ({
+  page,
+}) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  // Baseline: the bar is there, and there is exactly ONE ☰ — the members door
+  // on the right. No left door while the picker is in flow.
+  await expect(page.locator(BOTTOM_BAR)).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByLabel(WINDOWS_OPENER)).toHaveCount(0);
+
+  await hideTheBar(page);
+
+  // 1. The bar is GONE from the page, not merely hidden: the gate is a mount
+  //    gate, because a CSS-hidden BottomBar would keep running #327's
+  //    double-rAF scroll-into-view against a strip nobody can see.
+  await expect(page.locator(BOTTOM_BAR)).toHaveCount(0, { timeout: 10_000 });
+
+  // 2. …and the left ☰ has arrived to replace it.
+  const opener = page.getByLabel(WINDOWS_OPENER);
+  await expect(opener).toBeVisible({ timeout: 10_000 });
+
+  // 3. THE assertion. Tap it, and NAVIGATE — the drawer it opens is the #1041
+  //    channel sidebar, and picking the server window from it must actually
+  //    move the pane. A door that opens onto nothing would satisfy every
+  //    assertion above.
+  await opener.tap();
+  const sidebar = page.locator(".shell-sidebar");
+  await expect(sidebar).toBeVisible({ timeout: 10_000 });
+
+  await sidebar.locator('[data-window-name="$server"]').first().tap();
+  // The server window has no topic bar; the scrollback pane retargeting is the
+  // observable move. Assert the CHANNEL bar is gone rather than that some pane
+  // exists — the latter is true before the tap too.
+  await expect(page.locator(".topic-bar-channel")).toHaveCount(0, { timeout: 10_000 });
+
+  // The rail is still reachable with the bar off — settings must not become
+  // unreachable as a side effect of hiding the navigation strip.
+  await openSettingsSection(page, "display");
+  await expect(page.getByTestId("show-bottom-bar-toggle")).not.toBeChecked();
+});
+
+test("@webkit mobile: the preference is remembered by the ACCOUNT, not the device", async ({
+  page,
+}) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(page.locator(BOTTOM_BAR)).toBeVisible({ timeout: 10_000 });
+
+  await hideTheBar(page);
+  await expect(page.locator(BOTTOM_BAR)).toHaveCount(0, { timeout: 10_000 });
+
+  // Wipe the LOCAL half only — the bearer stays, so this is the same account
+  // arriving on a device that has never seen the preference. (A blanket
+  // `localStorage.clear()` would take the session with it and prove nothing.)
+  await page.evaluate((keys: string[]) => {
+    for (const k of keys) localStorage.removeItem(k);
+  }, LOCAL_MIRROR_KEYS);
+  await page.reload();
+
+  // On boot the owner module reads its empty mirror and defaults to SHOWN, so
+  // the bar may flash in before the login reconcile lands. `toHaveCount(0)`
+  // with a timeout is the honest oracle: it polls, and what it settles on is
+  // the server's answer.
+  await expect(page.locator(BOTTOM_BAR)).toHaveCount(0, { timeout: 15_000 });
+  await expect(page.getByLabel(WINDOWS_OPENER)).toBeVisible({ timeout: 10_000 });
+});

--- a/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
@@ -185,10 +185,44 @@ test("@webkit ux-5-bt mobile — channel: NO standalone .shell-chrome row (#473 
     Math.round(hamBox.height),
     `#305 — hamburger tap target ${hamBox.height}px must meet the 48px HIG floor`,
   ).toBeGreaterThanOrEqual(48);
-  const hamGlyphPx = await hamburger.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+  // #1766 moved this oracle from `font-size` to the PAINTED ink, and the move
+  // is a strengthening, not an accommodation. `font-size` measured the em box;
+  // #305's complaint was that U+2630 is three thin strokes centred in a box
+  // that is not narrow, i.e. precisely that the box overstates the glyph. The
+  // ☰ is now DRAWN (three rules on `::before` + two box-shadow copies), so the
+  // character is suppressed and the old proxy reads 0.
+  //
+  // Measured on this project (root 14px → --chrome-icon-size 19.59px), ink
+  // extents, canvas actualBoundingBox for the character:
+  //
+  //     U+2630 as text        19.59 W × 17.00 H   ← never met this floor
+  //     bars, first cut (/3)  19.59 W × 15.06 H   ← the regression #1766 shipped
+  //     bars, shipped         19.59 W × 19.59 H
+  //
+  // So the threshold is unchanged at 18 and is met in BOTH axes for the first
+  // time. Read off the computed shadow rather than recomputing the CSS
+  // formula, so the test measures what is painted instead of restating it.
+  const ink = await hamburger.evaluate((el) => {
+    const before = getComputedStyle(el, "::before");
+    const barH = Number.parseFloat(before.height);
+    const offsets = [
+      0,
+      ...Array.from(before.boxShadow.matchAll(/(-?[\d.]+)px\s+(-?[\d.]+)px/g), (m) =>
+        Number.parseFloat(m[2] ?? "0"),
+      ),
+    ];
+    return {
+      w: Number.parseFloat(before.width),
+      h: Math.max(...offsets) + barH - Math.min(...offsets),
+    };
+  });
   expect(
-    hamGlyphPx,
-    `#305 — hamburger glyph ${hamGlyphPx}px must be enlarged from the base 14px`,
+    Math.round(ink.w),
+    `#305 — drawn ☰ is ${ink.w}px wide; the glyph must clear the 18px floor`,
+  ).toBeGreaterThanOrEqual(18);
+  expect(
+    Math.round(ink.h),
+    `#305 — drawn ☰ is ${ink.h}px tall; the glyph must clear the 18px floor`,
   ).toBeGreaterThanOrEqual(18);
 
   // Per `feedback_e2e_visitor_members_list` — UI-shape spec is

--- a/cicchetto/src/AdminPane.tsx
+++ b/cicchetto/src/AdminPane.tsx
@@ -145,6 +145,11 @@ const AdminPane: Component<Props> = (props) => {
           the ☰ comes with the band, and comes LAST, which is what finally puts
           it on the same side as the channel bar's. */}
       <PaneTopBar
+        /* #1766 — no left door here. The admin window suppresses `.shell-chrome`
+           and its own ✕ already exits to a window that carries one, so a second
+           ☰ in this band would be a door onto a floor you reach in one tap
+           anyway. Stated at the call site because the slot is required. */
+        leading={null}
         trailing={
           /* #1697 — passed in rather than baked into the band; see the note on
              the channel bar's identical call. */

--- a/cicchetto/src/PaneTopBar.tsx
+++ b/cicchetto/src/PaneTopBar.tsx
@@ -62,8 +62,30 @@ import type { Component, JSX } from "solid-js";
  * The slot is REQUIRED, not defaulted to the ☰: a default would let a new host
  * inherit a rail door it never asked for, silently, which is the degradation
  * pattern this codebase bans.
+ *
+ * ## #1766 — a matching LEADING slot, for the same reason on the other edge
+ *
+ * Turning the mobile window bar off (`showBottomBar.ts`) leaves #1041's
+ * left-edge swipe as the only way to the window list, and a gesture with zero
+ * affordance is the "drawer-only navigation" #71's second ruling refused as a
+ * default. So a second ☰ ships with the opt-out — and it has to appear on
+ * every surface wearing this band, not only the channel one, which is what
+ * puts it here rather than in `TopicBar`.
+ *
+ * REQUIRED and not optional, by the same argument `trailing` already makes: a
+ * host with no left door passes `null` and says so at the call site, instead
+ * of a new host silently inheriting one. `null` emits no element, so a band
+ * that opted out keeps its two children exactly — which is what #1073's
+ * characterization pins.
  */
 export type Props = {
+  /**
+   * The band's FIRST child, or `null`. Being first is what places it on the
+   * left, by the same construction that puts `trailing` on the right — the
+   * `.topic-bar-header` between them carries `flex: 1`, so no margin or
+   * `justify-content` term is involved on this band.
+   */
+  leading: JSX.Element;
   /**
    * The bar's left group, rendered inside `.topic-bar-header`. That wrapper
    * carries `flex: 1; min-width: 0`, so a caller wanting ellipsis gets the
@@ -114,6 +136,7 @@ export const PaneTopBarRailOpener: Component<RailOpenerProps> = (props) => {
 const PaneTopBar: Component<Props> = (props) => {
   return (
     <div class="topic-bar">
+      {props.leading}
       <div class="topic-bar-header">{props.children}</div>
       {props.trailing}
     </div>

--- a/cicchetto/src/PaneTopBar.tsx
+++ b/cicchetto/src/PaneTopBar.tsx
@@ -77,6 +77,10 @@ import type { Component, JSX } from "solid-js";
  * of a new host silently inheriting one. `null` emits no element, so a band
  * that opted out keeps its two children exactly — which is what #1073's
  * characterization pins.
+ *
+ * The control that fills it is `PaneTopBarWindowsOpener`, a SEPARATE component
+ * from the trailing ☰ and deliberately not wearing its class — see that
+ * component's own note for the measurement that forced the split.
  */
 export type Props = {
   /**
@@ -127,6 +131,56 @@ export const PaneTopBarRailOpener: Component<RailOpenerProps> = (props) => {
       class="topic-bar-hamburger shell-chrome-btn"
       aria-label={props.railLabel}
       onClick={props.onOpenRail}
+    >
+      {"\u{2630}"}
+    </button>
+  );
+};
+
+export type WindowsOpenerProps = {
+  onOpenWindows: () => void;
+};
+
+/**
+ * #1766 — the LEFT door: #1041's window sidebar, the navigation that has to
+ * exist once the bottom window bar can be switched off.
+ *
+ * ## Why this is a second component and not `PaneTopBarRailOpener` with
+ * another label
+ *
+ * Because `.topic-bar-hamburger` is not a style hook — it is the NAME of the
+ * rail door, and #1073 wrote that contract down where it is consumed. The e2e
+ * fixture `openMembersDrawer` locates the opener BY CLASS and takes
+ * `.first()`, explaining that "the class is what they have in common, and it
+ * is the thing this helper actually needs — the in-flow opener, whichever pane
+ * is mounted". Singular, and roughly twenty specs reach the rail through it.
+ *
+ * The first cut of #1766 did reuse the rail opener here, and the integration
+ * run measured the consequence: with the bar off, two buttons wore the class,
+ * `.first()` resolved to THIS one, the fixture opened the window sidebar
+ * instead of the members rail, and its retry was then occluded by the
+ * `aside.shell-sidebar.open` it had just opened — a click deadline, on a spec
+ * that has nothing to do with either door. Reusing the class would have made
+ * every rail-reaching spec depend on the bottom-bar preference.
+ *
+ * So the two doors are two classes. What they still SHARE is
+ * `.shell-chrome-btn` (#305's tap floor + icon token) and the drawn-bars rule,
+ * which is the part that genuinely must not drift: with the bar off the two ☰
+ * sit in one 48px band and have to look identical.
+ *
+ * The label is a literal, unlike the sibling's `railLabel` prop. That prop
+ * exists because two hosts genuinely word the same door differently; this door
+ * has one name on both surfaces it appears on — one door, two handles — and a
+ * prop only ever passed one value would state a variability that does not
+ * exist.
+ */
+export const PaneTopBarWindowsOpener: Component<WindowsOpenerProps> = (props) => {
+  return (
+    <button
+      type="button"
+      class="topic-bar-windows-opener shell-chrome-btn"
+      aria-label="open windows sidebar"
+      onClick={props.onOpenWindows}
     >
       {"\u{2630}"}
     </button>

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -224,6 +224,9 @@ const RailRadio: Component = () => {
               picker its only dismiss control on the form factor where it
               works today. */}
           <PaneTopBar
+            /* #1766 — the picker is INSIDE the rail; a window-list door here
+               would be a second rail opened from within one. */
+            leading={null}
             trailing={
               <button
                 type="button"

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -1481,9 +1481,22 @@ const SettingsDrawer: Component<Props> = (props) => {
                 everyone else's. */}
             <fieldset class="auto-away-fieldset">
               <legend>auto-away</legend>
+              {/* #1766 — the visible "mark me away after:" text is GONE (vjt:
+                  "e' gia' incluso nel titolo del fieldset"). It was a second
+                  name for the control the legend already names, with the blurb
+                  below spelling the behaviour out in full underneath it.
+
+                  The catch, and why this is not a deletion: that <label>
+                  WRAPPED the <select>, so the text WAS the select's accessible
+                  name — dropping the string alone leaves the control nameless.
+                  Same cure #1227 applied to the upload-duration select two
+                  fieldsets up: the <label> stays as the row's flex box, the
+                  name moves onto the control. NOT the <legend> instead — a
+                  legend names the GROUP, and a screen reader landing on the
+                  select would still be told nothing. */}
               <label>
-                mark me away after:
                 <select
+                  aria-label="auto-away delay"
                   data-testid="auto-away-select"
                   value={autoAwaySelectValue()}
                   onChange={(e) => {

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -22,7 +22,11 @@ import {
   withConversationMute,
   withoutConversationMute,
 } from "./lib/conversationMute";
-import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
+import {
+  syncedSetColoredNicklist,
+  syncedSetShowBottomBar,
+  syncedSetTimeFormat,
+} from "./lib/displayPrefs";
 import { formatDuration } from "./lib/duration";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { errorMessage, friendlyApiError } from "./lib/friendlyApiError";
@@ -49,6 +53,7 @@ import { reconnectConnectedNetworks } from "./lib/reconnect";
 import { selectedChannel } from "./lib/selection";
 import { consumePendingSettingsPage, type SettingsSubPage } from "./lib/settingsNav";
 import { isShareableSubject, openShareModal, SHARE_SESSION_LABEL } from "./lib/shareModal";
+import { getShowBottomBar } from "./lib/showBottomBar";
 import { getTimeFormat, type TimeFormatKey } from "./lib/timeFormat";
 import { activeHost } from "./lib/uploadHost";
 import {
@@ -233,6 +238,14 @@ const SettingsDrawer: Component<Props> = (props) => {
   // straight to it and there is no second copy to keep in sync.
   const onHideNextActiveChange = (e: Event) => {
     setHideNextActive((e.currentTarget as HTMLInputElement).checked);
+  };
+
+  // #1766 — like the #914 row, no drawer-local mirror: `getShowBottomBar()` IS
+  // the module signal. Unlike it, the write goes through the coordinator, which
+  // is the single PUT authority for the #449 synced prefs — the owner module's
+  // own setter stays local-only on purpose.
+  const onShowBottomBarChange = (e: Event) => {
+    syncedSetShowBottomBar((e.currentTarget as HTMLInputElement).checked);
   };
 
   // #986 — the `onDetach` / `onQuit` handlers moved to RailActions with
@@ -1623,13 +1636,27 @@ const SettingsDrawer: Component<Props> = (props) => {
                 </label>
               </fieldset>
 
-              {/* #443 — per-nick colors in the members pane. Off by default: the
-                nicklist stays monochrome so its color reads as the mode tier,
-                not identity. When on, MembersPane drops `noColor` so NickText
-                applies the per-nick hash hue; the mode-prefix glyph keeps its
-                own tier color either way. */}
-              <fieldset class="colored-nicklist-fieldset">
-                <legend>nicklist</legend>
+              {/* #1766 — ONE fieldset for the three checkboxes (vjt: "andiamo
+                ad accorpare in un unico fieldset i checkbox esistenti e quello
+                nuovo"). They were three one-row fieldsets carrying three
+                legends — `nicklist`, `jump button`, and a third on the way —
+                which is three boxes to say three sentences. The two RADIO
+                groups above keep theirs: a radio group is a fieldset by
+                nature, because the box is what makes the exclusivity legible.
+
+                The dissolved classes (`.colored-nicklist-fieldset`,
+                `.hide-next-active-fieldset`) are referenced NOWHERE else —
+                measured, no CSS rule and no selector in the e2e tree — which
+                is what makes the churn free. The `data-testid`s are the real
+                contract and stay VERBATIM; the e2e suite addresses them. */}
+              <fieldset class="display-checkboxes-fieldset">
+                <legend>options</legend>
+
+                {/* #443 — per-nick colors in the members pane. Off by default:
+                  the nicklist stays monochrome so its color reads as the mode
+                  tier, not identity. When on, MembersPane drops `noColor` so
+                  NickText applies the per-nick hash hue; the mode-prefix glyph
+                  keeps its own tier color either way. */}
                 <label>
                   <input
                     type="checkbox"
@@ -1639,16 +1666,30 @@ const SettingsDrawer: Component<Props> = (props) => {
                   />
                   show colored nicklist
                 </label>
-              </fieldset>
 
-              {/* #914 — hide the #235 "jump to next active window" (»N)
-                button. Off by default. PRESENTATIONAL: it removes the button
-                in BOTH placements (desktop sidebar + mobile overlay) and
-                nothing else — Alt+A and Ctrl+N keep jumping. Client-local and
-                per-DEVICE, unlike the two synced rows above; the complaint is
-                the viewport-fixed mobile overlay. */}
-              <fieldset class="hide-next-active-fieldset">
-                <legend>jump button</legend>
+                {/* #1766 — the mobile window bar (BottomBar), ON by default:
+                  an opt-OUT, never a default change. #174's ruling stands
+                  ("the bottom bar must NOT be deleted, it stays opt-in from
+                  settings") and #71's second ruling reversed "kill the mobile
+                  bottom bar" outright. The bar is O(windows), not O(screens),
+                  so at 7 networks the strip is longer than the useful scroll
+                  distance and the picker stops picking. Turning it off ships a
+                  left ☰ with it, so the #1041 edge swipe is not left as the
+                  whole navigation surface. */}
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={getShowBottomBar()}
+                    onChange={onShowBottomBarChange}
+                    data-testid="show-bottom-bar-toggle"
+                  />
+                  show the window bar on mobile
+                </label>
+
+                {/* #914 — hide the #235 "jump to next active window" (»N)
+                  button. Off by default. PRESENTATIONAL: it removes the button
+                  in BOTH placements (desktop sidebar + mobile overlay) and
+                  nothing else — Alt+A and Ctrl+N keep jumping. */}
                 <label>
                   <input
                     type="checkbox"
@@ -1658,6 +1699,19 @@ const SettingsDrawer: Component<Props> = (props) => {
                   />
                   hide the jump-to-next-active button
                 </label>
+
+                {/* The one thing the merge HIDES, said out loud rather than
+                  inherited: these rows do not persist alike. Two are #449
+                  server-backed and converge across every device on the
+                  account; the jump button is per-DEVICE localStorage, and
+                  deliberately so — #914's complaint was about a viewport, not
+                  an account. Under one legend three identical-looking rows
+                  would otherwise behave differently on a second device with
+                  nothing on screen to say why. */}
+                <p class="settings-section-blurb" data-testid="display-checkboxes-hint">
+                  The first two follow your account onto every device you use. The jump button is
+                  remembered on this device only.
+                </p>
               </fieldset>
             </section>
           </section>

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -58,7 +58,7 @@ import MentionsWindow from "./MentionsWindow";
 import ModeModal from "./ModeModal";
 import NamesModal from "./NamesModal";
 import NextActiveButton from "./NextActiveButton";
-import { PaneTopBarRailOpener } from "./PaneTopBar";
+import { PaneTopBarWindowsOpener } from "./PaneTopBar";
 import PrivacyModal from "./PrivacyModal";
 import RailActions from "./RailActions";
 import RailContext from "./RailContext";
@@ -207,7 +207,7 @@ const Shell: Component = () => {
   // second panel: one door, two handles.
   const windowsRailOpener = (): JSX.Element => (
     <Show when={!getShowBottomBar()}>
-      <PaneTopBarRailOpener onOpenRail={openSidebar} railLabel="open windows sidebar" />
+      <PaneTopBarWindowsOpener onOpenWindows={openSidebar} />
     </Show>
   );
 

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -3,6 +3,7 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  type JSX,
   Match,
   onCleanup,
   Show,
@@ -45,6 +46,7 @@ import {
   setSelectedChannel,
 } from "./lib/selection";
 import { settingsOpenTick } from "./lib/settingsNav";
+import { getShowBottomBar } from "./lib/showBottomBar";
 import { isMobile } from "./lib/theme";
 import { bindEdgeGesture } from "./lib/touchGesture";
 import { loadUploadTtlSeconds } from "./lib/uploadOrchestrator";
@@ -56,6 +58,7 @@ import MentionsWindow from "./MentionsWindow";
 import ModeModal from "./ModeModal";
 import NamesModal from "./NamesModal";
 import NextActiveButton from "./NextActiveButton";
+import { PaneTopBarRailOpener } from "./PaneTopBar";
 import PrivacyModal from "./PrivacyModal";
 import RailActions from "./RailActions";
 import RailContext from "./RailContext";
@@ -189,6 +192,24 @@ const Shell: Component = () => {
   onCleanup(() => {
     if (sidebarExitTimer !== undefined) clearTimeout(sidebarExitTimer);
   });
+
+  // #1766 — the LEFT ☰, and the only reason it exists: turning the mobile
+  // window bar off leaves #1041's left-edge swipe as the whole navigation
+  // surface, and a gesture with zero affordance is the "drawer-only
+  // navigation" #71's second ruling refused as a default. With the bar ON
+  // there is already a picker in flow, so no door renders — a second one
+  // nobody asked for is just chrome.
+  //
+  // Built ONCE and handed to both mobile hosts — the channel band's `leading`
+  // slot and `.shell-chrome` — so the two surfaces cannot drift apart the way
+  // #1073 found them drifted on the trailing side. It opens the SAME sidebar
+  // the swipe opens (`openSidebar`, mount-on-demand + dispose-on-exit), not a
+  // second panel: one door, two handles.
+  const windowsRailOpener = (): JSX.Element => (
+    <Show when={!getShowBottomBar()}>
+      <PaneTopBarRailOpener onOpenRail={openSidebar} railLabel="open windows sidebar" />
+    </Show>
+  );
 
   // #356 — cross-module "open settings" request. A bare watch-family compose
   // verb (/notify, /watch, /hilight, …) can't reach the local setSettingsOpen,
@@ -697,6 +718,12 @@ const Shell: Component = () => {
                       networkSlug={selectedChannel()?.networkSlug ?? ""}
                       channelName={selectedChannel()?.channelName ?? ""}
                       onToggleMembers={() => setMembersOpen((v) => !v)}
+                      /* #1766 — desktop has a permanent sidebar, so there is
+                         no window-list door to open and nothing to hide. The
+                         band's ☰ is `display: none` up here anyway; passing
+                         `null` means the button is never MOUNTED rather than
+                         mounted-and-hidden. */
+                      leading={null}
                     />
                   </Show>
                   <ScrollbackPane
@@ -938,6 +965,7 @@ const Shell: Component = () => {
               switches on — rather than re-deriving the kind here. */}
           <Show when={selKind() !== "channel" && selKind() !== "list" && !isAdminPaneVisible()}>
             <ShellChrome
+              leading={windowsRailOpener()}
               onOpenRail={() =>
                 toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
               }
@@ -990,6 +1018,7 @@ const Shell: Component = () => {
                         setSettingsOpen,
                       })
                     }
+                    leading={windowsRailOpener()}
                   />
                 </Show>
                 <ScrollbackPane
@@ -1037,7 +1066,17 @@ const Shell: Component = () => {
           </Switch>
         </section>
 
-        <BottomBar />
+        {/* #1766 — the window bar is opt-OUT (default shown). A MOUNT gate and
+            not `display: none`: BottomBar carries no internal display guard by
+            design, and a CSS-hidden bar would keep running #327's double-rAF
+            scroll-into-view work against a strip nobody can see. Turning it
+            off is survivable because #1041's left-edge swipe exists — and
+            because `windowsRailOpener()` above gives that swipe an
+            affordance, which is what keeps this short of the drawer-only
+            navigation #71's second ruling refused. */}
+        <Show when={getShowBottomBar()}>
+          <BottomBar />
+        </Show>
 
         {/* GH #235 — "jump to next active window" affordance (mobile).
             #280: on scrollback windows (channel/query/server) it renders

--- a/cicchetto/src/ShellChrome.tsx
+++ b/cicchetto/src/ShellChrome.tsx
@@ -1,4 +1,4 @@
-import type { Component } from "solid-js";
+import type { Component, JSX } from "solid-js";
 
 // UX-4 bucket L (2026-05-19) — sticky chrome bar at the top of
 // `.shell-main`. Always rendered, regardless of selected window kind
@@ -54,7 +54,7 @@ import type { Component } from "solid-js";
 // chrome buttons). The wrapper default export is the only consumer
 // of the archive/cog rendering today; folded back inline.
 
-export type Props = {
+export type RailOpenerProps = {
   /**
    * #71 INC-2 — opens the right rail (the `.shell-members` drawer that hosts
    * the RailActions labelled action drawer). Required — the rail opener is always
@@ -62,6 +62,28 @@ export type Props = {
    * this bar's button now opens the rail rather than the settings drawer.
    */
   onOpenRail: () => void;
+};
+
+/**
+ * #1766 — the BAR's props are the button's plus the leading slot. Split
+ * because the two are no longer the same shape: `RailOpenerButton` is a lone
+ * control that other panes mount inline, and it must not inherit a slot it has
+ * nowhere to put.
+ */
+export type Props = RailOpenerProps & {
+  /**
+   * #1766 — the LEFT ☰, mirroring `PaneTopBar`'s slot of the same name so the
+   * channel band and this float carry the same door. Non-empty only while the
+   * mobile window bar is off; Shell owns that decision and passes the built
+   * control, not a callback this box wraps.
+   *
+   * It costs ZERO vertical pixels: `.shell-chrome` is a `height: 0` box whose
+   * children overflow it, so a second child floats over the pane's top-LEFT
+   * corner exactly as the rail opener floats over the top-right. That is why
+   * this is not a new band — #985 deleted the last one, priced at
+   * `--chrome-tap-min + 1rem + 1px` on every mobile window.
+   */
+  leading: JSX.Element;
 };
 
 /**
@@ -89,7 +111,7 @@ export type Props = {
  * refresh. So the suppression stops an overlap now, where before it only saved
  * a row.
  */
-export const RailOpenerButton: Component<Props> = (props) => {
+export const RailOpenerButton: Component<RailOpenerProps> = (props) => {
   return (
     <button
       type="button"
@@ -106,6 +128,7 @@ export const RailOpenerButton: Component<Props> = (props) => {
 const ShellChrome: Component<Props> = (props) => {
   return (
     <header class="shell-chrome" data-testid="shell-chrome">
+      {props.leading}
       <RailOpenerButton onOpenRail={props.onOpenRail} />
     </header>
   );

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -1,4 +1,4 @@
-import { type Component, createSignal, Show } from "solid-js";
+import { type Component, createSignal, type JSX, Show } from "solid-js";
 import { postTopic } from "./lib/api";
 import { token } from "./lib/auth";
 import { ownHoldsChannelEditorSigil } from "./lib/channelEditPerm";
@@ -84,6 +84,17 @@ export type Props = {
   networkSlug: string;
   channelName: string;
   onToggleMembers: () => void;
+  /**
+   * #1766 — `PaneTopBar`'s leading slot, passed straight through. REQUIRED
+   * and not defaulted, mirroring the band's own contract: Shell's DESKTOP
+   * branch passes `null` (there is a permanent sidebar; the band's ☰ is
+   * `display: none` up there anyway) and the MOBILE branch passes the windows
+   * opener only while the bottom bar is off. Threaded rather than read from
+   * `showBottomBar.ts` here so this component stays presentation-only and the
+   * mobile/desktop decision keeps living in the one place that already knows
+   * the form factor.
+   */
+  leading: JSX.Element;
 };
 
 type ModalState = "closed" | "open";
@@ -304,6 +315,9 @@ const TopicBar: Component<Props> = (props) => {
           and while closed `<Show>` renders no element, which is what
           keeps the bar's child list at exactly two. */}
       <PaneTopBar
+        /* #1766 — the windows ☰ when the mobile bottom bar is off; `null`
+           otherwise and always on desktop. Shell decides; this bar carries. */
+        leading={props.leading}
         trailing={
           /* #1697 — the ☰ is passed IN now: the band's trailing control became
              a slot when the rail's radio picker needed a ✕ there instead. Same

--- a/cicchetto/src/__tests__/PaneTopBar.test.tsx
+++ b/cicchetto/src/__tests__/PaneTopBar.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import PaneTopBar, { PaneTopBarRailOpener } from "../PaneTopBar";
+
+// #1766 — the band grew a LEADING slot, and the band is where it belongs
+// rather than in `TopicBar`: turning the mobile window bar off has to leave a
+// door on every surface wearing this bar, not only the channel one.
+//
+// The slot is REQUIRED, exactly like `trailing` (#1697) and for the same
+// stated reason: a defaulted slot lets a new host inherit a door it never
+// asked for. A host with no left door passes `null` and says so at the call
+// site. That is why these tests assert the CHILD COUNT and not just presence —
+// `null` must emit no element, or every host that opted out silently gains a
+// layout box in a `justify-content: space-between`-adjacent band.
+//
+// Side is child ORDER, not a CSS override. #1073 pinned that for the trailing
+// side after `.admin-pane-header` and `.shell-chrome` had disagreed about
+// which edge the ☰ sits on; the leading side inherits the same oracle.
+
+describe("PaneTopBar — the band's slots", () => {
+  it("with no leading slot the band is two children: header, then trailing", () => {
+    const { container } = render(() => (
+      <PaneTopBar leading={null} trailing={<button type="button">x</button>}>
+        <span>content</span>
+      </PaneTopBar>
+    ));
+
+    const bar = container.querySelector(".topic-bar");
+    expect(bar).not.toBeNull();
+    const kids = Array.from(bar?.children ?? []);
+    expect(kids).toHaveLength(2);
+    expect(kids[0]).toHaveClass("topic-bar-header");
+  });
+
+  it("with a leading slot it is three, and the leading control comes FIRST", () => {
+    const { container } = render(() => (
+      <PaneTopBar
+        leading={
+          <button type="button" data-testid="lead">
+            l
+          </button>
+        }
+        trailing={
+          <button type="button" data-testid="trail">
+            t
+          </button>
+        }
+      >
+        <span>content</span>
+      </PaneTopBar>
+    ));
+
+    const bar = container.querySelector(".topic-bar") as HTMLElement;
+    const kids = Array.from(bar.children);
+    expect(kids).toHaveLength(3);
+    expect(kids[0]).toBe(screen.getByTestId("lead"));
+    expect(kids[1]).toHaveClass("topic-bar-header");
+    expect(kids[2]).toBe(screen.getByTestId("trail"));
+  });
+
+  // The header carries `flex: 1; min-width: 0`, so it is the header — not a
+  // margin on the opener — that pushes the trailing control to the far edge
+  // once something sits on the near one. Nothing else in this band has to
+  // change for the leading slot to land where it should.
+  it("the header keeps the flex-1 slot between the two controls", () => {
+    render(() => (
+      <PaneTopBar
+        leading={<button type="button">l</button>}
+        trailing={<button type="button">t</button>}
+      >
+        <span data-testid="content">content</span>
+      </PaneTopBar>
+    ));
+
+    expect(screen.getByTestId("content").parentElement).toHaveClass("topic-bar-header");
+  });
+});
+
+describe("PaneTopBarRailOpener — one button, two doors", () => {
+  // The same button serves both sides; only the accessible name differs, and
+  // it MUST differ — a screen-reader user meeting two "open sidebar" controls
+  // in one 48px-tall band has been told nothing.
+  it("wears the caller's label", () => {
+    render(() => <PaneTopBarRailOpener onOpenRail={vi.fn()} railLabel="open windows sidebar" />);
+    expect(screen.getByLabelText("open windows sidebar")).toBeInTheDocument();
+  });
+
+  it("keeps the shared classes whichever side it lands on", () => {
+    render(() => <PaneTopBarRailOpener onOpenRail={vi.fn()} railLabel="open windows sidebar" />);
+    const btn = screen.getByLabelText("open windows sidebar");
+    expect(btn).toHaveClass("topic-bar-hamburger");
+    expect(btn).toHaveClass("shell-chrome-btn");
+  });
+
+  it("calls its handler on click", () => {
+    const onOpenRail = vi.fn();
+    render(() => <PaneTopBarRailOpener onOpenRail={onOpenRail} railLabel="open windows sidebar" />);
+    fireEvent.click(screen.getByLabelText("open windows sidebar"));
+    expect(onOpenRail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cicchetto/src/__tests__/PaneTopBar.test.tsx
+++ b/cicchetto/src/__tests__/PaneTopBar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { describe, expect, it, vi } from "vitest";
-import PaneTopBar, { PaneTopBarRailOpener } from "../PaneTopBar";
+import PaneTopBar, { PaneTopBarRailOpener, PaneTopBarWindowsOpener } from "../PaneTopBar";
 
 // #1766 — the band grew a LEADING slot, and the band is where it belongs
 // rather than in `TopicBar`: turning the mobile window bar off has to leave a
@@ -76,26 +76,65 @@ describe("PaneTopBar — the band's slots", () => {
   });
 });
 
-describe("PaneTopBarRailOpener — one button, two doors", () => {
-  // The same button serves both sides; only the accessible name differs, and
-  // it MUST differ — a screen-reader user meeting two "open sidebar" controls
-  // in one 48px-tall band has been told nothing.
+describe("PaneTopBarRailOpener — one button, two hosts", () => {
+  // The same button serves the channel bar and the admin console; only the
+  // accessible name differs, and it MUST differ — a screen-reader user meeting
+  // two "open sidebar" controls in one 48px-tall band has been told nothing.
   it("wears the caller's label", () => {
-    render(() => <PaneTopBarRailOpener onOpenRail={vi.fn()} railLabel="open windows sidebar" />);
-    expect(screen.getByLabelText("open windows sidebar")).toBeInTheDocument();
+    render(() => <PaneTopBarRailOpener onOpenRail={vi.fn()} railLabel="open actions" />);
+    expect(screen.getByLabelText("open actions")).toBeInTheDocument();
   });
 
-  it("keeps the shared classes whichever side it lands on", () => {
-    render(() => <PaneTopBarRailOpener onOpenRail={vi.fn()} railLabel="open windows sidebar" />);
-    const btn = screen.getByLabelText("open windows sidebar");
+  it("keeps the shared classes whichever host it lands in", () => {
+    render(() => <PaneTopBarRailOpener onOpenRail={vi.fn()} railLabel="open members sidebar" />);
+    const btn = screen.getByLabelText("open members sidebar");
     expect(btn).toHaveClass("topic-bar-hamburger");
     expect(btn).toHaveClass("shell-chrome-btn");
   });
 
   it("calls its handler on click", () => {
     const onOpenRail = vi.fn();
-    render(() => <PaneTopBarRailOpener onOpenRail={onOpenRail} railLabel="open windows sidebar" />);
-    fireEvent.click(screen.getByLabelText("open windows sidebar"));
+    render(() => <PaneTopBarRailOpener onOpenRail={onOpenRail} railLabel="open members sidebar" />);
+    fireEvent.click(screen.getByLabelText("open members sidebar"));
     expect(onOpenRail).toHaveBeenCalledTimes(1);
+  });
+});
+
+// #1766 — the LEFT door. A separate component from the rail opener, and the
+// separation is the whole point of the tests below.
+describe("PaneTopBarWindowsOpener — the other door", () => {
+  it("names itself for the sidebar it opens", () => {
+    render(() => <PaneTopBarWindowsOpener onOpenWindows={vi.fn()} />);
+    expect(screen.getByLabelText("open windows sidebar")).toBeInTheDocument();
+  });
+
+  // 🔴 The load-bearing assertion in this file. `.topic-bar-hamburger` is the
+  // NAME of the rail door, not a style hook: `openMembersDrawer` locates it by
+  // class and takes `.first()` (#1073, stated in the fixture). The first cut of
+  // #1766 reused the rail opener here, so with the window bar off two buttons
+  // wore that class, `.first()` resolved to THIS one, and the fixture opened
+  // the window sidebar instead of the rail — then had its retry occluded by the
+  // sidebar it had just opened. Measured on the integration run, not reasoned
+  // about. Roughly twenty specs reach the rail through that helper.
+  it("does NOT wear the rail door's class", () => {
+    render(() => <PaneTopBarWindowsOpener onOpenWindows={vi.fn()} />);
+    const btn = screen.getByLabelText("open windows sidebar");
+    expect(btn).not.toHaveClass("topic-bar-hamburger");
+    expect(btn).toHaveClass("topic-bar-windows-opener");
+  });
+
+  // What the two doors DO still share: the sizing tokens. With the window bar
+  // off they sit in one 48px band, so #305's tap floor and icon size have to
+  // reach both. Only the identity was split.
+  it("still shares the chrome button's sizing", () => {
+    render(() => <PaneTopBarWindowsOpener onOpenWindows={vi.fn()} />);
+    expect(screen.getByLabelText("open windows sidebar")).toHaveClass("shell-chrome-btn");
+  });
+
+  it("calls its handler on click", () => {
+    const onOpenWindows = vi.fn();
+    render(() => <PaneTopBarWindowsOpener onOpenWindows={onOpenWindows} />);
+    fireEvent.click(screen.getByLabelText("open windows sidebar"));
+    expect(onOpenWindows).toHaveBeenCalledTimes(1);
   });
 });

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -1953,6 +1953,38 @@ describe("SettingsDrawer (#476/#478 — per-network identity, both subjects)", (
 // preset must still be visible rather than silently rendering as the
 // nearest option.
 
+// #1766 part 3 — vjt: "da general togliamo il label 'mark me away after' che
+// e' gia' incluso nel titolo del fieldset 'auto-away'". He is right: the
+// <legend> already says it and the blurb below spells the behaviour out in
+// full. The catch is that the <label> WRAPPED the <select>, so it was the
+// select's accessible name — deleting the string alone leaves the control
+// nameless. Same cure #1227 applied to the upload-duration select next door:
+// keep the <label> as the row's flex box, move the naming onto the control.
+describe("SettingsDrawer — the redundant auto-away label (#1766)", () => {
+  it("no longer prints 'mark me away after' anywhere in the general sub-page", () => {
+    wrap(true);
+    openSub("general-settings-entry");
+    const page = screen.getByTestId("general-subpage");
+    expect(page.textContent).not.toMatch(/mark me away after/i);
+  });
+
+  it("keeps the fieldset's own legend, which is what already said it", () => {
+    wrap(true);
+    openSub("general-settings-entry");
+    const fieldset = screen.getByTestId("auto-away-select").closest("fieldset");
+    expect(fieldset?.querySelector("legend")?.textContent).toMatch(/auto-away/i);
+  });
+
+  // THE assertion. A bare deletion of the string passes the first test and
+  // strands `[data-testid="auto-away-select"]` with no accessible name at all.
+  it("leaves the select an accessible name", () => {
+    wrap(true);
+    openSub("general-settings-entry");
+    const byName = screen.getByLabelText(/auto-away/i);
+    expect(byName).toBe(screen.getByTestId("auto-away-select"));
+  });
+});
+
 describe("SettingsDrawer — auto-away debounce (#348)", () => {
   it("offers the presets, an off entry and a custom entry", () => {
     wrap(true);

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -25,6 +25,15 @@ vi.mock("../lib/hideNextActive", () => ({
   setHideNextActive: vi.fn(),
 }));
 
+// #1766 — the third checkbox in the merged fieldset. Mocked like its two
+// siblings so a click is observable without a real signal; the SYNCED setter
+// it actually calls lives in `displayPrefs.ts` and writes through to this
+// module, which is the seam asserted below.
+vi.mock("../lib/showBottomBar", () => ({
+  getShowBottomBar: vi.fn(() => true),
+  setShowBottomBar: vi.fn(),
+}));
+
 const subjectHolder = vi.hoisted(() => ({
   current: null as
     | { kind: "user"; id: string; name: string }
@@ -432,6 +441,86 @@ describe("SettingsDrawer display options section (#443)", () => {
     openSub("display-settings-entry");
     fireEvent.click(screen.getByTestId("hide-next-active-toggle"));
     expect(hideNextActive.setHideNextActive).toHaveBeenCalledWith(true);
+  });
+
+  // #1766 part 1 — the mobile window bar toggle. Default CHECKED: the bar is
+  // opt-OUT, and a dozen e2e specs address `.bottom-bar` on the strength of
+  // that. It is the one SYNCED row of the three, so the click has to reach the
+  // coordinator's setter (which writes through to the owner module) rather
+  // than the owner module directly — the coordinator is the single PUT
+  // authority.
+  it("renders the mobile-window-bar toggle CHECKED by default (opt-out, not opt-in)", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+    const toggle = screen.getByTestId("show-bottom-bar-toggle") as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
+  it("unchecking the mobile-window-bar toggle writes false through the owner module", async () => {
+    const showBottomBar = await import("../lib/showBottomBar");
+    wrap(true);
+    openSub("display-settings-entry");
+    fireEvent.click(screen.getByTestId("show-bottom-bar-toggle"));
+    expect(showBottomBar.setShowBottomBar).toHaveBeenCalledWith(false);
+  });
+});
+
+// #1766 part 2 — vjt: "andiamo ad accorpare in un unico fieldset i checkbox
+// esistenti e quello nuovo". The two RADIO groups keep their own fieldsets (a
+// radio group is a fieldset by nature — the grouping is what makes the
+// exclusivity legible); the three checkboxes were three one-row fieldsets with
+// three legends, which is three boxes to say three sentences.
+//
+// The testids are the contract, not the classes: `colored-nicklist-toggle` and
+// `hide-next-active-toggle` are addressed by the e2e suite, so the merge must
+// be invisible to it. The classes it dissolves (`.colored-nicklist-fieldset`,
+// `.hide-next-active-fieldset`) are referenced nowhere else — measured — which
+// is what makes the churn free.
+describe("SettingsDrawer display options — one fieldset for the checkboxes (#1766)", () => {
+  const displaySection = () => screen.getByTestId("settings-section-display");
+
+  it("puts all three checkboxes inside ONE fieldset", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+
+    const boxes = ["colored-nicklist-toggle", "hide-next-active-toggle", "show-bottom-bar-toggle"]
+      .map((id) => screen.getByTestId(id).closest("fieldset"))
+      .filter((f): f is HTMLFieldSetElement => f !== null);
+
+    expect(boxes).toHaveLength(3);
+    expect(new Set(boxes).size, "the three checkboxes must share one fieldset").toBe(1);
+  });
+
+  it("leaves the two radio groups their own fieldsets — three in total", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+
+    const fieldsets = Array.from(displaySection().querySelectorAll("fieldset"));
+    expect(fieldsets).toHaveLength(3);
+    expect(fieldsets[0]?.querySelector('[data-testid="font-size-M"]')).not.toBeNull();
+    expect(fieldsets[1]?.querySelector('[data-testid="time-format-hms"]')).not.toBeNull();
+    expect(fieldsets[2]?.querySelector('[data-testid="show-bottom-bar-toggle"]')).not.toBeNull();
+  });
+
+  it("keeps every pre-existing testid verbatim — the e2e suite addresses them", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+    expect(screen.getByTestId("colored-nicklist-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("hide-next-active-toggle")).toBeInTheDocument();
+  });
+
+  // The merge hides something the three legends used to keep apart: these rows
+  // do NOT persist alike. Colored nicklist and the window bar are server-synced
+  // across devices; hide-next-active is per-device localStorage (#914, and
+  // deliberately so — its complaint was a viewport). Under one legend three
+  // identical-looking rows behave differently on a second device, so the
+  // fieldset says which is which instead of inheriting the ambiguity.
+  it("says out loud that one of the three rows is per-device", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+    const blurb = screen.getByTestId("display-checkboxes-hint");
+    expect(blurb).toHaveClass("settings-section-blurb");
+    expect(blurb.textContent).toMatch(/this device/i);
   });
 });
 

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -1722,6 +1722,31 @@ describe("#1766 — the mobile window bar is opt-out, and the ☰ ships with the
       expect(screen.getByLabelText(/open members sidebar/i)).toBeInTheDocument();
     });
 
+    // The slot is a PROP, so it is evaluated once when the band mounts. What
+    // keeps it live is the `<Show>` INSIDE it: `Show` reads its `when` in its
+    // own memo, so the toggle re-runs that memo and not the whole band. Pinned
+    // because the alternative — reading the signal where the slot is built —
+    // compiles, renders identically on first paint, and then never updates.
+    it("appears live when the preference flips, without a remount", async () => {
+      mobileState.value = true;
+      selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+      const { container } = render(() => <Shell />);
+      await waitFor(() => {
+        expect(container.querySelector(".topic-bar")).not.toBeNull();
+      });
+      expect(screen.queryByLabelText(/open windows sidebar/i)).toBeNull();
+
+      setShowBottomBar(false);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/open windows sidebar/i)).toBeInTheDocument();
+      });
+
+      setShowBottomBar(true);
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/open windows sidebar/i)).toBeNull();
+      });
+    });
+
     it("opens the #1041 channel sidebar — the door the swipe already opens", async () => {
       mobileState.value = true;
       setShowBottomBar(false);

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAudio, playAudio } from "../lib/audioPlayer";
+import { setShowBottomBar } from "../lib/showBottomBar";
 import { LIST_WINDOW_NAME } from "../lib/windowKinds";
 import { nestedRuleBodies } from "./helpers/themeCss";
 import { swipeHorizontally } from "./helpers/touchEvents";
@@ -1632,5 +1633,179 @@ describe("#1701 — the docked player sits below the compose box", () => {
     const bodies = nestedRuleBodies(".drop-upload-zone");
     expect(bodies.length, ".drop-upload-zone must be declared in exactly one block").toBe(1);
     expect(bodies[0]).toMatch(/flex-direction:\s*column/);
+  });
+});
+
+// #1766 — the mobile window bar becomes opt-OUT, and turning it off must not
+// leave the phone navigable only by an invisible edge swipe.
+//
+// Two halves, and the second is the one worth the file. The gate itself is one
+// `<Show>`; what needs pinning is that it is a MOUNT gate and not a CSS one
+// (BottomBar carries no internal display guard by design, and a hidden bar
+// would keep running #327's double-rAF scroll-into-view against a strip nobody
+// can see), and that the door which replaces it actually appears — #71's
+// second ruling refused drawer-only navigation as a default, and #1041's
+// left-edge swipe is gesture-only with zero affordance.
+//
+// The default-ON case is asserted next to the off case on purpose: a dozen e2e
+// specs address `.bottom-bar`, so a gate that got the polarity backwards would
+// be caught here rather than in the e2e cascade.
+describe("#1766 — the mobile window bar is opt-out, and the ☰ ships with the opt-out", () => {
+  afterEach(() => {
+    setShowBottomBar(true);
+  });
+
+  it("renders the bar by default — the preference ships ON", () => {
+    mobileState.value = true;
+    const { container } = render(() => <Shell />);
+    expect(container.querySelector(".bottom-bar")).not.toBeNull();
+  });
+
+  it("drops the bar from the DOM when the preference is off (a MOUNT gate, not display:none)", () => {
+    mobileState.value = true;
+    setShowBottomBar(false);
+    const { container } = render(() => <Shell />);
+    expect(container.querySelectorAll(".bottom-bar").length).toBe(0);
+  });
+
+  it("re-mounts the bar live when the preference flips back on", async () => {
+    mobileState.value = true;
+    setShowBottomBar(false);
+    const { container } = render(() => <Shell />);
+    expect(container.querySelector(".bottom-bar")).toBeNull();
+
+    setShowBottomBar(true);
+    await waitFor(() => {
+      expect(container.querySelector(".bottom-bar")).not.toBeNull();
+    });
+  });
+
+  describe("the left ☰ on a CHANNEL window (PaneTopBar's leading slot)", () => {
+    it("is absent while the bar is shown — no second door nobody asked for", async () => {
+      mobileState.value = true;
+      selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+      const { container } = render(() => <Shell />);
+      await waitFor(() => {
+        expect(container.querySelector(".topic-bar")).not.toBeNull();
+      });
+      // The members ☰ is the only one: same count the C6.3 pin above asserts.
+      expect(container.querySelectorAll(".topic-bar .topic-bar-hamburger").length).toBe(1);
+    });
+
+    it("appears FIRST in the band when the bar is off, with the members ☰ still LAST", async () => {
+      mobileState.value = true;
+      setShowBottomBar(false);
+      selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+      const { container } = render(() => <Shell />);
+      const bar = await waitFor(() => {
+        const b = container.querySelector(".topic-bar");
+        expect(b).not.toBeNull();
+        return b as HTMLElement;
+      });
+
+      // Side is CHILD ORDER, not a CSS override — the same fact #1073's
+      // characterization pins for the trailing side.
+      expect(bar.firstElementChild).toHaveClass("topic-bar-hamburger");
+      expect(bar.lastElementChild).toHaveClass("topic-bar-hamburger");
+      expect(bar.children.length).toBe(3);
+      expect(bar.children[1]).toHaveClass("topic-bar-header");
+    });
+
+    it("names the two doors apart — left is windows, right is members", async () => {
+      mobileState.value = true;
+      setShowBottomBar(false);
+      selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+      render(() => <Shell />);
+      await waitFor(() => {
+        expect(screen.getByLabelText(/open windows sidebar/i)).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText(/open members sidebar/i)).toBeInTheDocument();
+    });
+
+    it("opens the #1041 channel sidebar — the door the swipe already opens", async () => {
+      mobileState.value = true;
+      setShowBottomBar(false);
+      selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+      const { container } = render(() => <Shell />);
+      const opener = await waitFor(() => screen.getByLabelText(/open windows sidebar/i));
+
+      expect(container.querySelector(".shell-sidebar")).toBeNull();
+      fireEvent.click(opener);
+      await waitFor(() => {
+        expect(container.querySelector(".shell-sidebar")).not.toBeNull();
+      });
+    });
+  });
+
+  describe("the left ☰ on a NON-channel window (.shell-chrome)", () => {
+    it("is absent while the bar is shown", async () => {
+      mobileState.value = true;
+      selectionState.setSelSig({
+        networkSlug: "freenode",
+        channelName: "$server",
+        kind: "server",
+      });
+      const { container } = render(() => <Shell />);
+      await waitFor(() => {
+        expect(container.querySelector(".shell-chrome")).not.toBeNull();
+      });
+      const chrome = container.querySelector(".shell-chrome") as HTMLElement;
+      expect(chrome.children.length).toBe(1);
+      expect(chrome.firstElementChild).toHaveClass("shell-chrome-rail-opener");
+    });
+
+    it("appears FIRST when the bar is off, with the rail opener still LAST", async () => {
+      mobileState.value = true;
+      setShowBottomBar(false);
+      selectionState.setSelSig({
+        networkSlug: "freenode",
+        channelName: "$server",
+        kind: "server",
+      });
+      const { container } = render(() => <Shell />);
+      const chrome = await waitFor(() => {
+        const c = container.querySelector(".shell-chrome");
+        expect(c).not.toBeNull();
+        return c as HTMLElement;
+      });
+
+      expect(chrome.children.length).toBe(2);
+      expect(chrome.firstElementChild).toHaveClass("topic-bar-hamburger");
+      expect(chrome.lastElementChild).toHaveClass("shell-chrome-rail-opener");
+    });
+
+    it("opens the channel sidebar from a non-channel window too", async () => {
+      mobileState.value = true;
+      setShowBottomBar(false);
+      selectionState.setSelSig({
+        networkSlug: "freenode",
+        channelName: "$server",
+        kind: "server",
+      });
+      const { container } = render(() => <Shell />);
+      const opener = await waitFor(() => screen.getByLabelText(/open windows sidebar/i));
+
+      fireEvent.click(opener);
+      await waitFor(() => {
+        expect(container.querySelector(".shell-sidebar")).not.toBeNull();
+      });
+    });
+  });
+
+  // DESKTOP is untouched. The preference is about a bar that only ever renders
+  // on mobile, so a desktop shell must gain no ☰ from it — the permanent
+  // sidebar is already there, and the topic bar's own ☰ is `display: none`
+  // above the breakpoint. This is a JSX assertion and not a CSS one on
+  // purpose: the desktop branch must not MOUNT a door it then hides.
+  it("desktop mounts no left ☰, whatever the preference says", async () => {
+    mobileState.value = false;
+    setShowBottomBar(false);
+    selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+    const { container } = render(() => <Shell />);
+    await waitFor(() => {
+      expect(container.querySelector(".topic-bar")).not.toBeNull();
+    });
+    expect(screen.queryByLabelText(/open windows sidebar/i)).toBeNull();
+    expect(container.querySelector(".topic-bar")?.children.length).toBe(2);
   });
 });

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -1705,10 +1705,39 @@ describe("#1766 — the mobile window bar is opt-out, and the ☰ ships with the
 
       // Side is CHILD ORDER, not a CSS override — the same fact #1073's
       // characterization pins for the trailing side.
-      expect(bar.firstElementChild).toHaveClass("topic-bar-hamburger");
+      expect(bar.firstElementChild).toHaveClass("topic-bar-windows-opener");
       expect(bar.lastElementChild).toHaveClass("topic-bar-hamburger");
       expect(bar.children.length).toBe(3);
       expect(bar.children[1]).toHaveClass("topic-bar-header");
+    });
+
+    // 🔴 `.topic-bar-hamburger` is not a style hook, it is the NAME OF ONE
+    // DOOR, and #1073 wrote that down where it is consumed: `openMembersDrawer`
+    // locates the opener BY CLASS and takes `.first()`, because "the class is
+    // what they have in common, and it is the thing this helper actually needs
+    // — the in-flow opener, whichever pane is mounted". Singular.
+    //
+    // The first cut of #1766 reused `PaneTopBarRailOpener` for the left door,
+    // so with the bar off two buttons wore that class and `.first()` resolved
+    // to this one — which opens the WINDOW sidebar, not the members rail.
+    // Measured on the integration run, not reasoned about: the fixture opened
+    // the sidebar, `.shell-members.open` never appeared, and the retry was
+    // occluded by `aside.shell-sidebar.open` until the click deadline elapsed.
+    // Twenty-odd specs reach the rail through that helper, so the left door
+    // carries its own class and this pins that it keeps doing so.
+    it("does NOT wear the members ☰'s class — that class names ONE door", async () => {
+      mobileState.value = true;
+      setShowBottomBar(false);
+      selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+      const { container } = render(() => <Shell />);
+      await waitFor(() => {
+        expect(container.querySelector(".topic-bar-windows-opener")).not.toBeNull();
+      });
+      expect(container.querySelectorAll(".topic-bar-hamburger").length).toBe(1);
+      expect(container.querySelector(".topic-bar-hamburger")).toHaveAttribute(
+        "aria-label",
+        "open members sidebar",
+      );
     });
 
     it("names the two doors apart — left is windows, right is members", async () => {
@@ -1795,7 +1824,7 @@ describe("#1766 — the mobile window bar is opt-out, and the ☰ ships with the
       });
 
       expect(chrome.children.length).toBe(2);
-      expect(chrome.firstElementChild).toHaveClass("topic-bar-hamburger");
+      expect(chrome.firstElementChild).toHaveClass("topic-bar-windows-opener");
       expect(chrome.lastElementChild).toHaveClass("shell-chrome-rail-opener");
     });
 

--- a/cicchetto/src/__tests__/ShellChrome.test.tsx
+++ b/cicchetto/src/__tests__/ShellChrome.test.tsx
@@ -44,14 +44,14 @@ describe("ShellChrome (bucket L)", () => {
   // #71 INC-2 — the cog left this bar for the rail; the always-present
   // right-edge button is now the ☰ rail opener.
   it("always renders the rail opener (no window selected)", () => {
-    render(() => <ShellChrome onOpenRail={vi.fn()} />);
+    render(() => <ShellChrome leading={null} onOpenRail={vi.fn()} />);
     const opener = screen.getByTestId("shell-chrome-rail-opener");
     expect(opener).toBeInTheDocument();
   });
 
   it("clicking the rail opener fires onOpenRail", () => {
     const onOpenRail = vi.fn();
-    render(() => <ShellChrome onOpenRail={onOpenRail} />);
+    render(() => <ShellChrome leading={null} onOpenRail={onOpenRail} />);
     fireEvent.click(screen.getByTestId("shell-chrome-rail-opener"));
     expect(onOpenRail).toHaveBeenCalled();
   });
@@ -59,13 +59,13 @@ describe("ShellChrome (bucket L)", () => {
   // #71 INC-2 — the cog no longer lives in ShellChrome (moved to the rail's
   // ActionCluster). Guard against a regression that reintroduces it here.
   it("does NOT render the settings cog (moved to the rail's ActionCluster)", () => {
-    render(() => <ShellChrome onOpenRail={vi.fn()} />);
+    render(() => <ShellChrome leading={null} onOpenRail={vi.fn()} />);
     expect(screen.queryByTestId("shell-chrome-cog")).toBeNull();
     expect(screen.queryByTestId("action-cluster-cog")).toBeNull();
   });
 
   it("UX-5 bucket A — does NOT render a hamburger button (slot dropped)", () => {
-    const { container } = render(() => <ShellChrome onOpenRail={vi.fn()} />);
+    const { container } = render(() => <ShellChrome leading={null} onOpenRail={vi.fn()} />);
     expect(container.querySelectorAll(".shell-chrome-hamburger").length).toBe(0);
     expect(screen.queryByLabelText(/open channel sidebar/i)).toBeNull();
     expect(screen.queryByLabelText(/open members sidebar/i)).toBeNull();
@@ -75,7 +75,7 @@ describe("ShellChrome (bucket L)", () => {
   // was a third archive entry point). Guard against a regression that
   // reintroduces it: it must never render, on any window kind or viewport.
   it("does NOT render an archive button (#473 — archive lives in the RailActions drawer)", () => {
-    render(() => <ShellChrome onOpenRail={vi.fn()} />);
+    render(() => <ShellChrome leading={null} onOpenRail={vi.fn()} />);
     expect(screen.queryByTestId("shell-chrome-archive")).toBeNull();
   });
 
@@ -87,9 +87,41 @@ describe("ShellChrome (bucket L)", () => {
   // to re-import them and this bar would stop being the lone-☰ band #985
   // is about to delete.
   it("#986 — renders the opener and NOTHING else (no @ mentions button)", () => {
-    const { container } = render(() => <ShellChrome onOpenRail={vi.fn()} />);
+    const { container } = render(() => <ShellChrome leading={null} onOpenRail={vi.fn()} />);
     expect(screen.queryByTestId("shell-chrome-mentions")).toBeNull();
     expect(screen.queryByLabelText(/open mentions/i)).toBeNull();
     expect(container.querySelectorAll("button")).toHaveLength(1);
+  });
+});
+
+// #1766 — the float grew a LEADING slot: with the mobile window bar off, this
+// zero-height box hosts the windows ☰ on the left as well as the rail opener
+// on the right. `leading={null}` above is what every pre-#1766 assertion in
+// this file was written against, and it must keep emitting no element — a
+// placeholder would put a layout box in a `height: 0` flow row and the rail
+// opener's `justify-content: flex-end` corner would stop being the corner.
+describe("ShellChrome — the leading slot (#1766)", () => {
+  it("emits nothing extra when the host passes null", () => {
+    const { container } = render(() => <ShellChrome leading={null} onOpenRail={vi.fn()} />);
+    const chrome = container.querySelector(".shell-chrome") as HTMLElement;
+    expect(chrome.children.length).toBe(1);
+    expect(chrome.firstElementChild).toHaveClass("shell-chrome-rail-opener");
+  });
+
+  it("puts a passed control FIRST, ahead of the rail opener", () => {
+    const { container } = render(() => (
+      <ShellChrome
+        leading={
+          <button type="button" data-testid="lead">
+            l
+          </button>
+        }
+        onOpenRail={vi.fn()}
+      />
+    ));
+    const chrome = container.querySelector(".shell-chrome") as HTMLElement;
+    expect(chrome.children.length).toBe(2);
+    expect(chrome.firstElementChild).toBe(screen.getByTestId("lead"));
+    expect(chrome.lastElementChild).toHaveClass("shell-chrome-rail-opener");
   });
 });

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -65,10 +65,16 @@ import {
 } from "../lib/overlayScrollLock";
 import TopicBar from "../TopicBar";
 
+// #1766 — `leading` is a REQUIRED slot (`PaneTopBar`'s contract, threaded
+// through this bar). `null` is what a host with no left door passes, and it is
+// the shape every assertion in this file was written against: the band keeps
+// exactly two children. The one test that exercises a NON-null leading lives
+// in `Shell.test.tsx`, because it is Shell that decides when the door exists.
 const baseProps = () => ({
   networkSlug: "freenode",
   channelName: "#italia",
   onToggleMembers: vi.fn(),
+  leading: null,
 });
 
 // A resolved-promise + macrotask drain: lets an awaited postTopic/clear settle

--- a/cicchetto/src/__tests__/displayPrefs.test.ts
+++ b/cicchetto/src/__tests__/displayPrefs.test.ts
@@ -9,6 +9,7 @@ import {
   mountDisplayPrefsSync,
   syncedSetChannelPresencePref,
   syncedSetColoredNicklist,
+  syncedSetShowBottomBar,
   syncedSetTimeFormat,
 } from "../lib/displayPrefs";
 import {
@@ -17,6 +18,7 @@ import {
   replacePresencePrefs,
 } from "../lib/presenceFilter";
 import { loadInitialScrollback, purgeScrollback } from "../lib/scrollback";
+import { getShowBottomBar, setShowBottomBar } from "../lib/showBottomBar";
 import { getTimeFormat, setTimeFormat } from "../lib/timeFormat";
 import type { DisplayPrefs } from "../lib/userSettings";
 
@@ -43,13 +45,14 @@ const TOKEN = "test-bearer";
 const KEY_A = channelKey("n", "#a");
 const KEY_B = channelKey("n", "#b");
 
-// Reset the three module singletons to defaults + drop the token so every test
+// Reset the four module singletons to defaults + drop the token so every test
 // starts from a known local baseline (the signals persist across the suite).
 function resetLocal(): void {
   localStorage.clear();
   setTimeFormat("hms");
   setColoredNicklist(false);
   replacePresencePrefs({});
+  setShowBottomBar(true);
   setToken(null);
 }
 
@@ -82,15 +85,17 @@ afterEach(() => {
 });
 
 describe("buildWireMap", () => {
-  it("reads the three module getters into the wire shape", () => {
+  it("reads the four module getters into the wire shape", () => {
     setTimeFormat("hm");
     setColoredNicklist(true);
     replacePresencePrefs({ [KEY_A]: "hide" });
+    setShowBottomBar(false);
 
     expect(buildWireMap()).toEqual({
       time_format: "hm",
       colored_nicklist: true,
       presence_filter: { [KEY_A]: "hide" },
+      show_bottom_bar: false,
     });
   });
 
@@ -100,16 +105,49 @@ describe("buildWireMap", () => {
 });
 
 describe("applyServerPrefs", () => {
-  it("distributes server prefs into the three local setters", () => {
+  it("distributes server prefs into the four local setters", () => {
     applyServerPrefs({
       time_format: "hm",
       colored_nicklist: true,
       presence_filter: { [KEY_A]: "hide" },
+      show_bottom_bar: false,
     });
 
     expect(getTimeFormat()).toBe("hm");
     expect(getColoredNicklist()).toBe(true);
     expect(getChannelPresencePref(KEY_A)).toBe("hide");
+    expect(getShowBottomBar()).toBe(false);
+  });
+
+  // #1766 — the skew this bundle can be deployed INTO. `--cic` ships the
+  // bundle alone, so a server predating the fourth key answers three. This is
+  // a FULL-REPLACE apply that runs on every login reconcile: passing the
+  // absent value straight through would write `undefined` into the owner
+  // module and take the primary mobile navigation away from every user until
+  // the server caught up.
+  it("an absent show_bottom_bar (pre-#1766 server) takes the default, not undefined", () => {
+    setShowBottomBar(false);
+
+    applyServerPrefs({
+      time_format: "hms",
+      colored_nicklist: false,
+      presence_filter: {},
+    });
+
+    expect(getShowBottomBar()).toBe(true);
+  });
+
+  // …and the coalesce must be `??`, not `||`: a genuine `false` is the whole
+  // point of the preference and must survive the apply.
+  it("a server-sent false survives the coalesce", () => {
+    applyServerPrefs({
+      time_format: "hms",
+      colored_nicklist: false,
+      presence_filter: {},
+      show_bottom_bar: false,
+    });
+
+    expect(getShowBottomBar()).toBe(false);
   });
 
   it("tri-state: an unset channel stays ABSENT after apply (never coerced)", () => {
@@ -165,9 +203,13 @@ describe("mountDisplayPrefsSync — login reconcile", () => {
 
   it("seeds up the local values when the server has NEVER persisted", async () => {
     // Local state the operator built on this device — must survive + push up.
+    // #1766 — the fourth pref joins the seed-up with a NON-default value, so
+    // "the key is in the body" cannot pass by accident: a coordinator that
+    // forgot to read the owner module would push `true` here.
     setTimeFormat("hm");
     setColoredNicklist(true);
     replacePresencePrefs({ [KEY_A]: "hide" });
+    setShowBottomBar(false);
 
     const serverDefaults: DisplayPrefs = {
       time_format: "hms",
@@ -202,12 +244,14 @@ describe("mountDisplayPrefsSync — login reconcile", () => {
         time_format: "hm",
         colored_nicklist: true,
         presence_filter: { [KEY_A]: "hide" },
+        show_bottom_bar: false,
       },
     });
 
     // Local values are untouched by the seed-up (no clobber to server default).
     expect(getTimeFormat()).toBe("hm");
     expect(getColoredNicklist()).toBe(true);
+    expect(getShowBottomBar()).toBe(false);
     dispose();
   });
 
@@ -274,6 +318,7 @@ describe("syncedSet* — optimistic local + full-map PUT", () => {
         time_format: "hm",
         colored_nicklist: true,
         presence_filter: { [KEY_A]: "hide" },
+        show_bottom_bar: true,
       },
     });
   });
@@ -289,6 +334,28 @@ describe("syncedSet* — optimistic local + full-map PUT", () => {
     expect(getChannelPresencePref(KEY_A)).toBe("hide");
     expect(fetchMock).not.toHaveBeenCalled(); // no token → local-only
   });
+
+  // #1766 — the fourth synced setter. The owner module's own setter stays
+  // LOCAL-only so this coordinator remains the single PUT authority; what this
+  // pins is that the settings checkbox goes through the synced door and the
+  // body carries the new value, not the pre-toggle one.
+  it("syncedSetShowBottomBar sets local and PUTs the full wire map", async () => {
+    setToken(TOKEN);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ display_prefs: buildWireMap(), persisted: true }), {
+        status: 200,
+      }),
+    );
+
+    syncedSetShowBottomBar(false);
+    await flush();
+
+    expect(getShowBottomBar()).toBe(false);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/me/settings/display-prefs");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string).display_prefs.show_bottom_bar).toBe(false);
+  });
 });
 
 // S1 (review) — clear-on-logout so a shared browser / visitor→user upgrade can
@@ -297,7 +364,12 @@ describe("syncedSet* — optimistic local + full-map PUT", () => {
 // seed-up made it a WRITE source, so a never-persisted next login would PUT the
 // prior subject's residual values. Parity with mountCustomThemeSync's clear.
 describe("mountDisplayPrefsSync — clear-on-logout (no cross-account bleed)", () => {
-  const DEFAULTS = { time_format: "hms", colored_nicklist: false, presence_filter: {} };
+  const DEFAULTS = {
+    time_format: "hms",
+    colored_nicklist: false,
+    presence_filter: {},
+    show_bottom_bar: true,
+  };
 
   // Phase-mutable fetch stub: the GET body changes across A-login / B-login.
   let getBody: unknown;

--- a/cicchetto/src/__tests__/hamburgerGlyph.test.ts
+++ b/cicchetto/src/__tests__/hamburgerGlyph.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { themeCss } from "./helpers/themeCss";
+
+// #1766 — the ☰ is drawn in CSS instead of being a character.
+//
+// vjt asked for a 40px box; refused with the measure and he confirmed
+// ("si confermo"). `--chrome-tap-min` is declared on `:root` in ABSOLUTE px on
+// purpose — the root font-size is 14px, so in `rem` the target lands under the
+// HIG floor, which is #305's "defect 2" and 40px reopens it. What was actually
+// wrong is not the box: U+2630 is three THIN strokes centred on the em box, so
+// the CHARACTER is thin while the box is not narrow, and next to `⚙`/`@` it
+// reads small. vjt: "va bene css" — three bars, no SVG, no codepoint swap, no
+// icon set.
+//
+// The refusal that shapes these tests: NOT a bump of `--chrome-icon-size`.
+// That token is #305's "desired parity" — raising it grows the cog, mentions,
+// archive, the members ☰ and the presence toggle together, which is not what
+// was asked. So the drawing is per-selector on the hamburgers, and the token
+// keeps sizing them so a text-size change still moves the glyph.
+//
+// Source-level guards, the same shape and for the same reason as
+// `hamburgerCorner.test.ts` / `shellChromeFloat.test.ts`: jsdom has no layout
+// engine and no cascade resolution across the whole sheet, so the rendered
+// outcome is not observable in any locally-runnable gate. What IS observable
+// here is the trap.
+
+/** Innermost rules, comments stripped, in SOURCE ORDER with their offsets. */
+function rulesInOrder(): { selectors: string; body: string; index: number }[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const out: { selectors: string; body: string; index: number }[] = [];
+  for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    out.push({
+      selectors: (match[1] ?? "").trim(),
+      body: match[2] ?? "",
+      index: match.index ?? 0,
+    });
+  }
+  return out;
+}
+
+const RULES = rulesInOrder();
+
+/** Every rule whose selector list mentions `needle`. */
+const mentioning = (needle: string) => RULES.filter((r) => r.selectors.includes(needle));
+
+const barRules = () => RULES.filter((r) => /topic-bar-hamburger[^,{]*::before/.test(r.selectors));
+
+describe("#1766 — the ☰'s three bars are drawn, not typed", () => {
+  it("paints them on a ::before of the hamburger", () => {
+    const rules = barRules();
+    expect(rules.length, "no `.topic-bar-hamburger::before` rule draws the bars").toBeGreaterThan(
+      0,
+    );
+    const body = rules.map((r) => r.body).join("\n");
+    expect(body).toMatch(/content:\s*""/);
+    expect(body).toMatch(/box-shadow:/);
+  });
+
+  // `currentColor`, not `var(--muted)`. `.shell-chrome-btn:hover` /
+  // `:focus-visible` lift the button's COLOR to `var(--fg)`; a hardcoded
+  // paint would leave the bars dead under the hover the rest of the chrome
+  // still answers, and the focus ring would be the only remaining cue.
+  it("paints them in currentColor, so hover and focus still answer", () => {
+    const body = barRules()
+      .map((r) => r.body)
+      .join("\n");
+    expect(body).toMatch(/background:\s*currentColor/);
+    expect(body).toMatch(/box-shadow:[^;]*currentColor/);
+  });
+
+  // The bars must scale with the same token the glyph scaled with, or a user
+  // on XXL text gets a hamburger frozen at the S size — the very "reads small"
+  // complaint, reintroduced one text size up.
+  it("sizes them off --chrome-icon-size rather than a fresh magic number", () => {
+    const body = barRules()
+      .map((r) => r.body)
+      .join("\n");
+    expect(body).toMatch(/var\(--chrome-icon-size\)/);
+  });
+
+  it("suppresses the character, so the glyph and the bars never both paint", () => {
+    const suppressors = mentioning("topic-bar-hamburger").filter((r) =>
+      /font-size:\s*0/.test(r.body),
+    );
+    expect(suppressors.length, "nothing zeroes the ☰ character's font-size").toBeGreaterThan(0);
+  });
+
+  // THE trap, already documented by #305 for `display`. `.shell-chrome-btn`
+  // declares `font-size: var(--chrome-icon-size)` and is declared AFTER
+  // `.topic-bar-hamburger` in this file, so a bare `.topic-bar-hamburger` rule
+  // ties at (0,1,0) and LOSES on source order — the character would come back
+  // at full size under the bars.
+  it("wins that suppression against `.shell-chrome-btn`, not merely declares it", () => {
+    const base = RULES.find((r) => r.selectors === ".shell-chrome-btn");
+    expect(
+      base,
+      "`.shell-chrome-btn` must exist for this comparison to mean anything",
+    ).toBeDefined();
+    expect(base?.body).toMatch(/font-size:\s*var\(--chrome-icon-size\)/);
+
+    const suppressors = mentioning("topic-bar-hamburger").filter((r) =>
+      /font-size:\s*0/.test(r.body),
+    );
+    for (const rule of suppressors) {
+      const beatsBySpecificity = /\bbutton\.topic-bar-hamburger/.test(rule.selectors);
+      const beatsByOrder = rule.index > (base?.index ?? 0);
+      expect(
+        beatsBySpecificity || beatsByOrder,
+        `\`${rule.selectors}\` ties .shell-chrome-btn at (0,1,0) and loses on source order`,
+      ).toBe(true);
+    }
+  });
+
+  // NOT `.topic-bar .topic-bar-hamburger`: good specificity, but it only
+  // matches inside the band, and since #1766 the same hamburger also floats in
+  // `.shell-chrome` on non-channel windows — where it would render as the thin
+  // character next to a drawn twin.
+  it("is not scoped to the band, which the leading ☰ now lives outside of", () => {
+    for (const rule of barRules()) {
+      expect(
+        rule.selectors,
+        "`.topic-bar `-scoped drawing misses the `.shell-chrome` mount",
+      ).not.toMatch(/\.topic-bar\s+\.topic-bar-hamburger[^,{]*::before/);
+    }
+  });
+
+  // The refusal, stated as a test: the shared token must not have grown a
+  // ::before of its own, or every chrome button gets bars.
+  it("leaves the shared `.shell-chrome-btn` without a drawn glyph of its own", () => {
+    const shared = RULES.filter((r) => /^\.shell-chrome-btn::before$/.test(r.selectors));
+    expect(shared).toHaveLength(0);
+  });
+});

--- a/cicchetto/src/__tests__/hamburgerGlyph.test.ts
+++ b/cicchetto/src/__tests__/hamburgerGlyph.test.ts
@@ -43,7 +43,18 @@ const RULES = rulesInOrder();
 /** Every rule whose selector list mentions `needle`. */
 const mentioning = (needle: string) => RULES.filter((r) => r.selectors.includes(needle));
 
-const barRules = () => RULES.filter((r) => /topic-bar-hamburger[^,{]*::before/.test(r.selectors));
+const barRules = () =>
+  RULES.filter((r) => /topic-bar-(hamburger|windows-opener)[^,{]*::before/.test(r.selectors));
+
+/**
+ * Every button that must READ as a ☰. Three classes and not one, since the
+ * left door stopped sharing `.topic-bar-hamburger` — that class names the rail
+ * door and the e2e fixture resolves it with `.first()` (#1073), so a second
+ * bearer sent every rail-reaching spec through the wrong door. The look is
+ * still shared, because with the window bar off the two ☰ sit in ONE 48px
+ * band; only the identity was split.
+ */
+const BEARERS = ["topic-bar-hamburger", "topic-bar-windows-opener", "shell-chrome-rail-opener"];
 
 describe("#1766 — the ☰'s three bars are drawn, not typed", () => {
   it("paints them on a ::before of the hamburger", () => {
@@ -129,5 +140,22 @@ describe("#1766 — the ☰'s three bars are drawn, not typed", () => {
   it("leaves the shared `.shell-chrome-btn` without a drawn glyph of its own", () => {
     const shared = RULES.filter((r) => /^\.shell-chrome-btn::before$/.test(r.selectors));
     expect(shared).toHaveLength(0);
+  });
+
+  // Splitting the left door's CLASS off `.topic-bar-hamburger` (see BEARERS)
+  // split the identity, and identity is the only thing that was meant to
+  // split. With the window bar off the two ☰ share one 48px band, so a bearer
+  // that fell out of either rule would render as the thin character next to a
+  // drawn twin — or, worse, as BOTH at once. Asserted per bearer rather than
+  // over the joined text so the failure names which one dropped out.
+  it.each(BEARERS)("draws AND suppresses `%s`, so no door drifts", (bearer) => {
+    expect(
+      barRules().some((r) => r.selectors.includes(bearer)),
+      `no ::before rule draws \`.${bearer}\``,
+    ).toBe(true);
+    expect(
+      mentioning(bearer).some((r) => /font-size:\s*0/.test(r.body)),
+      `nothing zeroes the character on \`.${bearer}\``,
+    ).toBe(true);
   });
 });

--- a/cicchetto/src/__tests__/showBottomBar.test.ts
+++ b/cicchetto/src/__tests__/showBottomBar.test.ts
@@ -1,0 +1,85 @@
+import { createEffect, createRoot } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #1766 — "show the mobile window bar" display preference. Boolean, ON by
+// default: the BottomBar becomes opt-OUT, never deleted (#174's standing
+// constraint, and #71's second ruling reversed "kill the mobile bottom bar").
+//
+// It takes colorNicklist.ts's SHAPE (module-singleton signal + localStorage
+// write-through) because the flag is read at RENDER time by Shell's <Show>
+// around <BottomBar />, and its POSTURE (one of the #449 server-backed prefs,
+// PUT by `displayPrefs.ts`) because the complaint behind it — "7 networks" —
+// is account-scoped, not viewport-scoped like #914's per-device sibling.
+//
+// The default is the interesting half. Every sibling flag defaults OFF, so
+// `v === "true"` happens to mean both "parse the stored value" and "fall back
+// to the default on garbage". Inverting the default breaks that coincidence:
+// the fallback has to be spelled out, and the tests below are what say which
+// side unparseable storage lands on.
+
+describe("showBottomBar module", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  describe("getShowBottomBar()", () => {
+    it("defaults to TRUE when localStorage is empty — the bar ships shown", async () => {
+      const { getShowBottomBar } = await import("../lib/showBottomBar");
+      expect(getShowBottomBar()).toBe(true);
+    });
+
+    it("returns false when localStorage holds 'false'", async () => {
+      localStorage.setItem("cicchetto.showBottomBar", "false");
+      const { getShowBottomBar } = await import("../lib/showBottomBar");
+      expect(getShowBottomBar()).toBe(false);
+    });
+
+    it("returns true when localStorage holds 'true'", async () => {
+      localStorage.setItem("cicchetto.showBottomBar", "true");
+      const { getShowBottomBar } = await import("../lib/showBottomBar");
+      expect(getShowBottomBar()).toBe(true);
+    });
+
+    // The one that pins the inverted default. A copy-paste of colorNicklist's
+    // `v === "true"` reads garbage as FALSE, i.e. it takes the primary mobile
+    // navigation away over a corrupted key — the opposite of the safe side.
+    it("falls back to TRUE when localStorage holds an unparseable value", async () => {
+      localStorage.setItem("cicchetto.showBottomBar", "1");
+      const { getShowBottomBar } = await import("../lib/showBottomBar");
+      expect(getShowBottomBar()).toBe(true);
+    });
+  });
+
+  describe("setShowBottomBar()", () => {
+    it("persists 'false' to localStorage when hidden", async () => {
+      const { setShowBottomBar } = await import("../lib/showBottomBar");
+      setShowBottomBar(false);
+      expect(localStorage.getItem("cicchetto.showBottomBar")).toBe("false");
+    });
+
+    it("persists 'true' to localStorage when shown", async () => {
+      const { setShowBottomBar } = await import("../lib/showBottomBar");
+      setShowBottomBar(true);
+      expect(localStorage.getItem("cicchetto.showBottomBar")).toBe("true");
+    });
+
+    // The assertion that constrains the SHAPE. A plain `localStorage.getItem`
+    // getter passes every test above — including a set-then-get round trip —
+    // while leaving Shell's mounted <Show> gate stale until a reload. Only a
+    // TRACKED read proves the signal: the effect must re-run.
+    it("re-runs a tracked read, so the mounted gate re-renders on toggle", async () => {
+      const { getShowBottomBar, setShowBottomBar } = await import("../lib/showBottomBar");
+      const seen: boolean[] = [];
+      createRoot(() => {
+        createEffect(() => seen.push(getShowBottomBar()));
+      });
+      await Promise.resolve();
+      expect(seen).toEqual([true]);
+
+      setShowBottomBar(false);
+      await Promise.resolve();
+      expect(seen).toEqual([true, false]);
+    });
+  });
+});

--- a/cicchetto/src/lib/displayPrefs.ts
+++ b/cicchetto/src/lib/displayPrefs.ts
@@ -10,6 +10,7 @@ import {
   setChannelPresencePref,
 } from "./presenceFilter";
 import { loadInitialScrollback, purgeScrollback } from "./scrollback";
+import { getShowBottomBar, setShowBottomBar } from "./showBottomBar";
 import { getTimeFormat, setTimeFormat, type TimeFormatKey } from "./timeFormat";
 import { type DisplayPrefs, getDisplayPrefs, putDisplayPrefs } from "./userSettings";
 
@@ -20,6 +21,11 @@ import { type DisplayPrefs, getDisplayPrefs, putDisplayPrefs } from "./userSetti
 // WITHOUT collapsing the three owner modules: each keeps its signal +
 // localStorage cache (the FOUC-free boot mirror); this coordinator adds the
 // server round-trip on top.
+//
+// #1766 added a FOURTH owner module (`showBottomBar.ts`) on exactly that shape.
+// Every function below that names the wire map has to grow with it — the
+// default baseline, `buildWireMap`, `applyServerPrefs` and a `syncedSet*` — and
+// the server's `default_display_prefs/0` is the authority for the default.
 //
 // ## The THEME sync shape, not the notification-prefs shape
 //
@@ -49,10 +55,11 @@ import { type DisplayPrefs, getDisplayPrefs, putDisplayPrefs } from "./userSetti
 // The reset baseline — mirror of the server's `default_display_prefs/0`
 // (the authoritative default). Used by the logout clear so a logged-out
 // browser holds no subject's residual prefs.
-const DEFAULT_DISPLAY_PREFS: DisplayPrefs = {
+const DEFAULT_DISPLAY_PREFS: Required<DisplayPrefs> = {
   time_format: "hms",
   colored_nicklist: false,
   presence_filter: {},
+  show_bottom_bar: true,
 };
 
 // #449 (issue222 regression fix) — the "unconfirmed local write" marker.
@@ -84,24 +91,35 @@ function hasUnsyncedWrite(): boolean {
   return localStorage.getItem(UNSYNCED_KEY) === "1";
 }
 
-// Read the three owner modules into the wire shape (the seed-up + every PUT
-// body). Pure snapshot; no reactivity intended.
-export function buildWireMap(): DisplayPrefs {
+// Read the four owner modules into the wire shape (the seed-up + every PUT
+// body). Pure snapshot; no reactivity intended. `show_bottom_bar` is OPTIONAL
+// on the type (a pre-#1766 server omits it on the way IN) but always populated
+// here — cic is the writer, and it knows the key.
+export function buildWireMap(): Required<DisplayPrefs> {
   return {
     time_format: getTimeFormat(),
     colored_nicklist: getColoredNicklist(),
     presence_filter: getAllPresencePrefs(),
+    show_bottom_bar: getShowBottomBar(),
   };
 }
 
-// Distribute a server-authoritative payload into the three owner modules'
+// Distribute a server-authoritative payload into the four owner modules'
 // LOCAL setters (write-through to signal + localStorage). No re-PUT — this is
 // the server-wins apply path only. The presence map is a full replace so unset
 // channels stay unset.
+//
+// #1766 — `show_bottom_bar` is coalesced against the baseline rather than
+// passed through. This is a full-replace apply that runs on EVERY login
+// reconcile, so a server that does not carry the key yet (this bundle shipped
+// ahead of it, which `--cic` allows) would otherwise write `undefined` into the
+// owner module and take the primary mobile navigation away from everyone. `??`
+// and not `||`: a genuine `false` from the server must survive.
 export function applyServerPrefs(prefs: DisplayPrefs): void {
   setTimeFormat(prefs.time_format);
   setColoredNicklist(prefs.colored_nicklist);
   replacePresencePrefs(prefs.presence_filter);
+  setShowBottomBar(prefs.show_bottom_bar ?? DEFAULT_DISPLAY_PREFS.show_bottom_bar);
 }
 
 // Reactive server sync — re-runs on every `token()` change (registered inside a
@@ -193,6 +211,11 @@ export function syncedSetTimeFormat(key: TimeFormatKey): void {
 
 export function syncedSetColoredNicklist(on: boolean): void {
   setColoredNicklist(on);
+  pushDisplayPrefs();
+}
+
+export function syncedSetShowBottomBar(on: boolean): void {
+  setShowBottomBar(on);
   pushDisplayPrefs();
 }
 

--- a/cicchetto/src/lib/showBottomBar.ts
+++ b/cicchetto/src/lib/showBottomBar.ts
@@ -1,0 +1,72 @@
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
+
+// #1766 — "show the mobile window bar" display preference. Boolean, ON by
+// default: the BottomBar is not deleted, it becomes opt-OUT. That default is
+// #174's standing constraint ("the bottom bar must NOT be deleted, it stays
+// opt-in from settings") and #71's second ruling, which explicitly reversed
+// "kill the mobile bottom bar".
+//
+// ## Why anyone wants it off
+//
+// BottomBar is a flat, horizontally-scrolled strip of EVERY window across
+// EVERY network. It is O(windows), not O(screens) — at 7 networks the strip is
+// longer than the useful scroll distance and the picker stops picking. The
+// second door that makes the opt-out survivable is #1041's left-edge swipe
+// (plus the ☰ that ships with this toggle); it did not exist when #71 ruled.
+//
+// ## SYNCED, unlike hideNextActive.ts — and that is the interesting call
+//
+// This module takes colorNicklist.ts's shape AND its posture: it is one of the
+// #449 server-backed display prefs, coordinated by `displayPrefs.ts` over
+// `GET/PUT /me/settings/display-prefs`. #914's `hideNextActive` sits right
+// next to it in the same settings fieldset and is deliberately per-DEVICE, so
+// the divergence needs a reason rather than a coin toss: #914's complaint was
+// about a VIEWPORT (a fixed overlay on a phone), and syncing it would have
+// blanked a desktop control nobody objected to. The complaint here is "7
+// networks", which is a property of the ACCOUNT — the window count is
+// identical on the phone and on the tablet, and vjt owns both. A device-local
+// toggle would reproduce the #449 bug that started the whole coordinator
+// (Hypnotize: set on desktop, invisible on the iOS PWA).
+//
+// localStorage is the boot/offline cache for a FOUC-free first paint, not the
+// source of truth: the server wins on login, or is seeded up once when it has
+// never persisted. `setShowBottomBar` stays LOCAL-only (signal + localStorage
+// write-through); the coordinator's `syncedSetShowBottomBar` adds the PUT.
+//
+// ## Why a signal and not a boot-time read
+//
+// Same argument as colorNicklist.ts / hideNextActive.ts: the flag is consumed
+// at RENDER time by Shell's `<Show>` around `<BottomBar />`, so a bare
+// `localStorage.getItem` in the render path would never re-run and the bar
+// would stay on screen until a reload. It is a JSX gate rather than a
+// `display: none` on purpose — BottomBar carries no internal display guard by
+// design, and a CSS-hidden bar would keep running #327's double-rAF
+// scroll-into-view effect against a strip nobody can see.
+
+const STORAGE_KEY = "cicchetto.showBottomBar";
+const DEFAULT_SHOWN = true;
+
+function readStored(): boolean {
+  const v = localStorage.getItem(STORAGE_KEY);
+  // Anything that is not the literal "false" reads as shown — the default is
+  // the safe side here, since the bar is the primary mobile navigation.
+  return v === null ? DEFAULT_SHOWN : v !== "false";
+}
+
+// Module-singleton signal seeded from storage. createRoot anchors it for the
+// app lifetime (same shape as colorNicklist.ts) — the preference is
+// identity-agnostic, so no token-rotation reset arm is needed.
+const { current, setCurrent } = moduleRoot(() => {
+  const [current, setCurrent] = createSignal<boolean>(readStored());
+  return { current, setCurrent };
+});
+
+export function getShowBottomBar(): boolean {
+  return current();
+}
+
+export function setShowBottomBar(on: boolean): void {
+  localStorage.setItem(STORAGE_KEY, on ? "true" : "false");
+  setCurrent(on);
+}

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -337,6 +337,14 @@ export type DisplayPrefs = {
   time_format: TimeFormatKey;
   colored_nicklist: boolean;
   presence_filter: Record<string, PresencePref>;
+  // #1766 — OPTIONAL on the READ side, always sent on the write side. A server
+  // predating #1766 omits it, and this bundle can be deployed ahead of the
+  // server (`deploy-m42.sh --cic` ships the bundle alone). Typed as required,
+  // `applyServerPrefs` would hand `undefined` to the local setter and the bar
+  // would vanish for every user until the server caught up — the mirror of the
+  // skew the server tolerates on the PUT. Absent ⇒ the default, exactly like
+  // `persisted?` below. `buildWireMap()` always populates it.
+  show_bottom_bar?: boolean;
 };
 
 export type DisplayPrefsResponse = {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3146,9 +3146,11 @@ html.resize-dragging * {
    share one 48px-tall band and must look identical. */
 button.topic-bar-hamburger,
 .shell-chrome .shell-chrome-rail-opener {
-  /* Suppress the U+2630 text node. It stays in the DOM — it is the a11y-free
-     fallback if the sheet never loads, and ~20 specs locate these buttons —
-     but it must not paint under the bars. */
+  /* Suppress the U+2630 text node. It stays in the DOM — it is what renders
+     if this sheet never loads, and ~20 specs locate these buttons — but it
+     must not paint underneath the bars. The accessible name comes from
+     `aria-label` either way, so zeroing the glyph costs the screen reader
+     nothing. */
   font-size: 0;
 }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3069,11 +3069,17 @@ html.resize-dragging * {
    `background: var(--bg)` for the same reason it carries one — floating puts
    the glyph over arbitrary scrollback text and over a themed background image.
 
-   Selector: `.shell-chrome .topic-bar-hamburger`. It cannot collide with the
-   trailing opener, which wears `.shell-chrome-rail-opener` and not this class;
-   and `.topic-bar .topic-bar-hamburger`'s desktop `display: none` does not
-   reach here, which is moot anyway — `.shell-chrome` is mobile-only. */
-.shell-chrome .topic-bar-hamburger {
+   Selector: `.shell-chrome .topic-bar-windows-opener`. This class is the
+   left door's OWN, and the first cut of #1766 got that wrong: it reused
+   `.topic-bar-hamburger`, reasoning that the trailing opener here wears
+   `.shell-chrome-rail-opener` and so could not collide. True in THIS host and
+   false in the other one — the channel band's trailing control IS a
+   `.topic-bar-hamburger`, and the e2e fixture that reaches the rail resolves
+   that class with `.first()` (#1073). Measured on the integration run: the
+   fixture opened the window sidebar, the members rail never appeared, and the
+   retry was occluded by the sidebar it had just opened. A selector comment
+   that reasons about one host is not a non-collision proof. */
+.shell-chrome .topic-bar-windows-opener {
   background: var(--bg);
   margin: var(--pane-chrome-inset-block) auto 0 var(--pane-chrome-inset-inline);
 }
@@ -3145,6 +3151,7 @@ html.resize-dragging * {
    the same reason from the other side: with the window bar off, the two ☰
    share one 48px-tall band and must look identical. */
 button.topic-bar-hamburger,
+button.topic-bar-windows-opener,
 .shell-chrome .shell-chrome-rail-opener {
   /* Suppress the U+2630 text node. It stays in the DOM — it is what renders
      if this sheet never loads, and ~20 specs locate these buttons — but it
@@ -3155,6 +3162,7 @@ button.topic-bar-hamburger,
 }
 
 button.topic-bar-hamburger::before,
+button.topic-bar-windows-opener::before,
 .shell-chrome .shell-chrome-rail-opener::before {
   content: "";
   width: var(--chrome-icon-size);

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3048,6 +3048,36 @@ html.resize-dragging * {
   margin: var(--pane-chrome-inset-block) var(--pane-chrome-inset-inline) 0 0;
 }
 
+/* #1766 — the LEADING ☰ (window list), mounted in this same zero-height box
+   only while the mobile window bar is off. It floats over the pane's top-LEFT
+   corner for the same zero vertical pixels the rail opener costs on the right,
+   which is what keeps this short of a new band — #985 deleted the last one at
+   `--chrome-tap-min + 1rem + 1px` on every mobile window, and #985's argument
+   has not expired.
+
+   `margin-right: auto` and NOT `justify-content: space-between` on the parent,
+   which is what the issue proposed. Measured: this child is CONDITIONAL, and
+   `space-between` with a SINGLE item resolves to flex-start — so on every
+   window where the bar is on (the default, i.e. everyone) it would move the
+   EXISTING rail opener from the right corner to the left. The auto margin
+   absorbs the free space before `justify-content` is consulted, so the
+   one-child case stays byte-identical to today's.
+
+   The other three sides mirror the opener's, mirrored: same block inset, same
+   inline inset on the near edge, bottom collapsed so the float stays out of
+   the flow it overflows (#1039's contract, read as a 4-value shorthand).
+   `background: var(--bg)` for the same reason it carries one — floating puts
+   the glyph over arbitrary scrollback text and over a themed background image.
+
+   Selector: `.shell-chrome .topic-bar-hamburger`. It cannot collide with the
+   trailing opener, which wears `.shell-chrome-rail-opener` and not this class;
+   and `.topic-bar .topic-bar-hamburger`'s desktop `display: none` does not
+   reach here, which is moot anyway — `.shell-chrome` is mobile-only. */
+.shell-chrome .topic-bar-hamburger {
+  background: var(--bg);
+  margin: var(--pane-chrome-inset-block) auto 0 var(--pane-chrome-inset-inline);
+}
+
 .shell-chrome-btn {
   background: transparent;
   color: var(--muted);
@@ -3084,6 +3114,57 @@ html.resize-dragging * {
 .shell-chrome-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* #1766 — the ☰ is DRAWN, not typed.
+   U+2630 is three thin strokes centred on the em box, so the CHARACTER is thin
+   while the box is not narrow: next to `⚙` and `@` the glyph reads small even
+   at a 48px tap target. vjt asked for a 40px box; refused with the measure and
+   he confirmed ("si confermo") — `--chrome-tap-min` is ABSOLUTE px on purpose
+   (the root is 14px, so 40px in `rem` lands under the HIG floor, which is
+   #305's "defect 2"). The box was never the problem; the strokes were. vjt on
+   the remedy: "va bene css" — three bars, no SVG, no codepoint swap, no icon
+   set. With the bars drawn, perceived size is set to the pixel, which is why
+   the 40px request has no motive left.
+
+   NOT a bump of `--chrome-icon-size`: that token is #305's "desired parity",
+   and raising it grows the cog, mentions, archive, the presence toggle and
+   this ☰ together — not what was asked. The bars are still SIZED off it, so a
+   text-size change moves them exactly as it moved the glyph.
+
+   Placed AFTER `.shell-chrome-btn` AND written `button.…` — belt and braces
+   against the trap #305 already documented for `display`. `.shell-chrome-btn`
+   declares `font-size: var(--chrome-icon-size)` below its own selector's
+   (0,1,0); a bare `.topic-bar-hamburger` ties and LOSES on source order, and
+   the character would come back at full size underneath the bars.
+
+   NOT `.topic-bar .topic-bar-hamburger`: good specificity, but it matches only
+   inside the band, and since #1766 the same button also floats in
+   `.shell-chrome` on non-channel windows — it would render there as the thin
+   character next to a drawn twin. `.shell-chrome-rail-opener` is listed for
+   the same reason from the other side: with the window bar off, the two ☰
+   share one 48px-tall band and must look identical. */
+button.topic-bar-hamburger,
+.shell-chrome .shell-chrome-rail-opener {
+  /* Suppress the U+2630 text node. It stays in the DOM — it is the a11y-free
+     fallback if the sheet never loads, and ~20 specs locate these buttons —
+     but it must not paint under the bars. */
+  font-size: 0;
+}
+
+button.topic-bar-hamburger::before,
+.shell-chrome .shell-chrome-rail-opener::before {
+  content: "";
+  width: var(--chrome-icon-size);
+  height: 2px;
+  /* `currentColor`, never a literal: `.shell-chrome-btn:hover` /
+     `:focus-visible` lift the button's colour to var(--fg), and a hardcoded
+     paint would leave the bars dead under the one hover the rest of the chrome
+     answers. */
+  background: currentColor;
+  box-shadow:
+    0 calc(-1 * var(--chrome-icon-size) / 3) 0 currentColor,
+    0 calc(var(--chrome-icon-size) / 3) 0 currentColor;
 }
 
 /* Scrollback (existing rules — minor additions for mention highlight) */

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3161,6 +3161,23 @@ button.topic-bar-windows-opener,
   font-size: 0;
 }
 
+/* The bars fill the icon box EXACTLY: three 2px rules whose outermost edges
+   are `--chrome-icon-size` apart, in a box `--chrome-icon-size` wide. So the
+   painted ☰ is a square of the token, and the token stays the one knob.
+
+   The `/3` this replaces was a guess, and measuring it is what caught the
+   regression. On webkit-iphone-15 (root 14px, so the token resolves to
+   19.59px) the numbers are:
+
+       U+2630 as TEXT at 19.59px   ink 19.59 W × 17.00 H   (canvas
+                                   actualBoundingBox, same font stack)
+       bars at `/3`                ink 19.59 W × 15.06 H   ← −1.94px, −11.4%
+       bars at `(token - 2px)/2`   ink 19.59 W × 19.59 H
+
+   #305's floor is 18, and the CHARACTER never met it either — its em box was
+   19.59 but its ink was 17.00, which is why an oracle reading `font-size` was
+   measuring the box and not the glyph. The bars are the first shape here that
+   actually clears 18 in both axes. */
 button.topic-bar-hamburger::before,
 button.topic-bar-windows-opener::before,
 .shell-chrome .shell-chrome-rail-opener::before {
@@ -3173,8 +3190,8 @@ button.topic-bar-windows-opener::before,
      answers. */
   background: currentColor;
   box-shadow:
-    0 calc(-1 * var(--chrome-icon-size) / 3) 0 currentColor,
-    0 calc(var(--chrome-icon-size) / 3) 0 currentColor;
+    0 calc(-1 * (var(--chrome-icon-size) - 2px) / 2) 0 currentColor,
+    0 calc((var(--chrome-icon-size) - 2px) / 2) 0 currentColor;
 }
 
 /* Scrollback (existing rules — minor additions for mention highlight) */

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63801,3 +63801,141 @@ Both driver behaviours are defensible in isolation and wrong together:
 `exqlite_transaction_status` reporting a closed connection as `{:ok, :error}`.
 An `%Exqlite.Error{}` from either would have made this a clean degrade in 2026
 and never reached Ecto. Worth reporting to exqlite; not worth waiting for.
+<!-- entry #1766 -->
+
+---
+
+## 2026-08-25 — #1766: the bottom bar becomes optional, and what a fourth key costs
+
+vjt, `#grappa` 00:10: *"aggiungiamo setting toggle per disattivare la bottom
+bar su mobile. ora sono su 7 reti ed è diventata praticamente inutile"*. The
+BottomBar is a flat horizontal strip of every window across every network —
+**O(windows), not O(screens)** — so past a handful of networks it is longer
+than the useful scroll distance and the picker stops picking. Default stays
+ON: #174 closed with the ruling that the bar must NOT be deleted, only made
+opt-in from settings, and #71's second design ruling reversed *"kill the
+mobile bottom bar"* outright. This is that opt-out, arriving via a different
+carrier because #71 — the one #174 handed the constraint to — closed without
+shipping it.
+
+### SYNCED, and the neighbour it deliberately disagrees with
+
+The pref is the fourth key of the #449 server-backed `display_prefs`, not a
+localStorage flag. Its own sibling in the same settings fieldset argues the
+other way: #914's `hide_next_active` is per-DEVICE on purpose, and the bottom
+bar only ever renders on mobile, so the same reasoning was available. It does
+not hold. #914's complaint was about a **viewport** — a fixed overlay on a
+phone — and syncing it would have blanked a desktop control nobody objected
+to. The complaint here is *"7 networks"*, which is a property of the
+**account**: the window count is identical on the phone and on the tablet, and
+a device-local toggle would reproduce the very bug that produced the
+coordinator (Hypnotize, #449: set on desktop, invisible on the iOS PWA).
+
+### The fourth key is where the work was, and it is a general lesson
+
+`display_prefs` had never grown a key since #449 shipped it, and three
+mandatory keys were free while that held: the only writer is cic's
+`buildWireMap()`, which always sends every key it knows. The moment the shape
+grows, *"every key it knows"* stops meaning *"every key"* for any bundle
+already loaded in a tab — and the server and the bundle deploy separately
+(`deploy-m42.sh` vs `--cic`). So the skew runs **both** ways and each end has
+to tolerate the other:
+
+* **Server**: `fetch_optional_display_bool/3` — absent takes the default,
+  present-but-not-a-boolean still 422s. Without it a pre-#1766 tab's every
+  display write is rejected, so the operator's *time-format and nicklist*
+  toggles quietly stop persisting until they reload. Absence had to be told
+  apart from a present `nil`, which `display_fetch/2` flattens into one; hence
+  `display_has_key?/2`.
+* **Client**: `applyServerPrefs` coalesces `?? DEFAULT_DISPLAY_PREFS`. This
+  bundle can ship AHEAD of the server (`--cic`), and that apply is a
+  full-replace that runs on every login reconcile — passing the absent value
+  through would write `undefined` into the owner module and take the primary
+  mobile navigation away from everyone until the server caught up. `??` and
+  not `||`: a genuine `false` is the point of the preference.
+
+**Accepted consequence, not an oversight:** the PUT is a full-map replace, so
+a pre-#1766 tab's write also resets this key to its default. The alternative —
+reading the stored value for the missing key — turns a documented
+full-replace path into a per-key read-modify-write that the NEXT added key
+would have to remember too. The clobber window is one bundle reload wide and
+self-heals; the drift would not.
+
+### `space-between` was the wrong instruction, measured
+
+The issue specified `.shell-chrome` → `justify-content: space-between` to put
+the new ☰ on the left. It cannot be that, because the leading child is
+**conditional**: `space-between` with a SINGLE item resolves to flex-start, so
+on every window where the bar is ON — the default, i.e. everyone — it would
+move the EXISTING rail opener out of the right corner. `margin-inline-end:
+auto` on the leading child absorbs the free space before `justify-content` is
+consulted, leaving the one-child case byte-identical to what shipped.
+
+### The ☰ was thin, not small
+
+vjt asked for a 40px box; refused with the measure and he confirmed (*"si
+confermo"*). `--chrome-tap-min` is declared in ABSOLUTE px on purpose — the
+root is 14px, so 40px expressed in `rem` lands under the HIG floor, which is
+#305's *"defect 2"*. The box was never the problem: U+2630 is three thin
+strokes centred on the em box, so the **character** is thin while the box is
+not narrow. vjt on the remedy: *"va bene css"*. Three bars drawn on a
+`::before` in `currentColor` (so `.shell-chrome-btn`'s hover/focus colour lift
+still answers), sized off `--chrome-icon-size` so a text-size change still
+moves them — and **not** a bump of that token, which is #305's *"desired
+parity"* and would grow the cog, mentions, archive and the presence toggle
+together. With the bars drawn, perceived size is set to the pixel, which is
+why the 40px request has no motive left.
+
+Two selector traps, both already documented for other properties. The
+suppression of the character (`font-size: 0`) is written `button.` and placed
+after `.shell-chrome-btn`, because a bare `.topic-bar-hamburger` ties that
+rule at (0,1,0) and LOSES on source order — #305's `display` trap, one
+property over. And it is **not** scoped `.topic-bar .topic-bar-hamburger`:
+good specificity, but that matches only inside the band, and the same button
+now also floats in `.shell-chrome`, where it would render as the thin
+character beside a drawn twin.
+
+### The `leading` slot, and the two window kinds that knowingly have none
+
+`PaneTopBar` grew a leading slot, REQUIRED for the reason #1697 made
+`trailing` required: a defaulted slot lets a new host inherit a door it never
+asked for. Hosts with no left door pass `null` and say so at the call site.
+`admin` and `list` are those hosts — both suppress `.shell-chrome` (#1050 /
+the admin redesign) and both already carry a ✕ back to a window that does have
+the door, so a second ☰ there would open onto a floor reachable in one tap.
+Named here rather than left to be rediscovered as a hole.
+
+### What the fieldset merge hides, said out loud
+
+The three display checkboxes collapse into one fieldset (the two radio groups
+keep theirs — a radio group is a fieldset by nature). The merge hides one
+thing the three legends kept apart: **the rows do not persist alike.** Two are
+account-synced, the jump button is per-device. Under one legend three
+identical-looking rows behave differently on a second device, so the fieldset
+carries a `settings-section-blurb` saying which is which. Every `data-testid`
+survives verbatim; the dissolved classes were referenced nowhere else.
+
+### The redundant label had a job
+
+Dropping *"mark me away after:"* from the general sub-page is right — the
+`<legend>` says it and the blurb spells the behaviour out — but that `<label>`
+WRAPPED the `<select>`, so the text WAS the control's accessible name. Same
+cure #1227 applied to the upload-duration select two fieldsets up: the label
+stays as the row's flex box, the name moves onto the control. Not the legend
+instead: a legend names the GROUP, and a screen reader landing on the select
+would still be told nothing.
+
+### Protocol bump, and a gap the pin still has
+
+`Grappa.Protocol.version/0` moves 5 → 6. `display_prefs` is a client-facing
+REST payload and the shape changed, which under the #1393d ruling is enough
+on its own — additivity describes what the server EMITS, not what a client
+comes to REQUIRE. **`mix grappa.wire_pin --check` did not force this and could
+not**: its digest spans the codegen artefacts, whose sources are
+`lib/grappa/**/*wire.ex` plus a hand-kept list of web envelopes, and
+`GrappaWeb.UserSettingsJSON` is not on that list. That is the same silence
+#1679 hit with `BootJSON` — recorded there as a gap in the detector, not as a
+boundary of the rule, and it is still open for every hand-written
+`*_json.ex`. Widening the digest is a coverage change, which the pin
+deliberately cannot distinguish from a shape change, so it is not smuggled in
+here.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -63891,9 +63891,10 @@ suppression of the character (`font-size: 0`) is written `button.` and placed
 after `.shell-chrome-btn`, because a bare `.topic-bar-hamburger` ties that
 rule at (0,1,0) and LOSES on source order — #305's `display` trap, one
 property over. And it is **not** scoped `.topic-bar .topic-bar-hamburger`:
-good specificity, but that matches only inside the band, and the same button
-now also floats in `.shell-chrome`, where it would render as the thin
-character beside a drawn twin.
+good specificity, but that matches only inside the band, while the drawing has
+to reach the leading door too — which floats in `.shell-chrome` on non-channel
+windows, where a band-scoped rule would leave it as the thin character beside
+a drawn twin.
 
 ### The `leading` slot, and the two window kinds that knowingly have none
 
@@ -63939,3 +63940,54 @@ boundary of the rule, and it is still open for every hand-written
 `*_json.ex`. Widening the digest is a coverage change, which the pin
 deliberately cannot distinguish from a shape change, so it is not smuggled in
 here.
+
+### What the full integration run found, and what it cost to believe it
+
+Two reds, both this branch's, both on `webkit-iphone-15`; 780 other tests
+green. Neither was a flake, and neither was curable in a spec.
+
+**A CSS class can be an identity, and this one is.** The new spec died on a
+click deadline in `openMembersDrawer`, the fixture roughly twenty specs reach
+the rail through. It locates the opener BY CLASS and takes `.first()`, and
+#1073 wrote the contract in the fixture's own comment: *"the class is what
+they have in common, and it is the thing this helper actually needs — the
+in-flow opener, whichever pane is mounted."* Singular. Reusing
+`PaneTopBarRailOpener` for the left door put a second `.topic-bar-hamburger`
+in the DOM, ahead of the first, so with the window bar off the fixture opened
+the window sidebar and then had its retry occluded by the very sidebar it had
+just opened. The generalisation is the point: **a shared class is part of the
+interface when a consumer resolves it positionally**, and nothing in the type
+system or the linter says so — only the consumer's comment does. The two doors
+are now two components and two classes, still sharing `.shell-chrome-btn` and
+the drawn-bars rule, because with the bar off they occupy one 48px band and
+must look identical. Identity split; appearance not.
+
+The reading this ruled OUT is worth recording, because it was the live
+question when the red landed: hiding the bar does **not** open the sidebar by
+itself. The failure screenshot shows the server window already reached, so the
+☰ tap and the navigation through it both worked. The open sidebar was the
+fixture's own click.
+
+**The oracle that broke was measuring the wrong thing, and the code was still
+wrong.** `ux-5-bt` asserts `#305`'s legibility floor as
+`getComputedStyle(el).fontSize >= 18`, which `font-size: 0` zeroes. Softening
+that assert was refused; the ink was measured instead, in the browser the spec
+runs in. On webkit-iphone-15 (root 14px, `--chrome-icon-size` → 19.59px):
+
+| ☰ as painted | ink W | ink H |
+| --- | --- | --- |
+| U+2630 as text | 19.59 | 17.00 |
+| bars at `/3` (as first shipped) | 19.59 | **15.06** |
+| bars at `(token − 2px)/2` | 19.59 | 19.59 |
+
+So the red was right twice: the oracle had gone blind AND the glyph really had
+shrunk 11.4% in height. The divisor was a guess; the bars now span the icon
+token exactly, which is a rule with a reason instead of a number. The oracle
+moves to the painted extent, read off the computed shadow rather than
+recomputing the formula — and that is a strengthening, not an accommodation:
+`font-size` measured the em box, when #305's whole complaint was that U+2630
+is three thin strokes centred in a box that is not narrow, i.e. that the box
+overstates the glyph. The table shows the character never cleared 18 either.
+
+The cheap lesson underneath both: **a `--grep`-scoped green proves one spec,
+and neither of these defects lives in the spec you would have scoped to.**

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -107,10 +107,27 @@ defmodule Grappa.Protocol do
   # with protocol 3 at rc=0 beforehand, because the digested set is a glob
   # over `lib/grappa/**` plus a hand-kept list of web-layer envelopes.
   #
+  # v6 (#1766) adds `show_bottom_bar` to the `display_prefs` object on
+  # `GET/PUT /me/settings/display-prefs` — the mobile window bar's per-user
+  # off switch. Additive, and it bumps for the #1393d reason: a client that
+  # comes to REQUIRE the key cannot be served by a server predating it, and
+  # nothing server-side would express that break without this number moving.
+  #
+  # ⚠️ `mix grappa.wire_pin --check` did NOT force this one and could not, so
+  # do not read a green pin as "no bump needed". The digest spans the codegen
+  # artefacts, whose sources are `lib/grappa/**/*wire.ex` plus a hand-kept
+  # `@extra_modules` list of web-layer envelopes, and
+  # `GrappaWeb.UserSettingsJSON` is not on it. That is the SAME silence #1679
+  # hit with `BootJSON` — recorded there as a gap in the detector, not as a
+  # boundary of the rule, and still open for every hand-written `*_json.ex`.
+  # Widening the digest is a COVERAGE change, which the pin deliberately
+  # cannot tell from a shape change (its moduledoc: delete and re-create, no
+  # `--force`), so it is not smuggled in alongside a product change.
+  #
   # @min_protocol_version is NOT the same axis and stays at 1: it rises only
   # when old clients can no longer be SERVED, and every client that spoke v1
-  # is still served — v1 clients tolerate what v5 clients require.
-  @protocol_version 5
+  # is still served — v1 clients tolerate what v6 clients require.
+  @protocol_version 6
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -121,7 +138,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 5
+  @spec version() :: 6
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -210,6 +210,14 @@ defmodule Grappa.UserSettings do
       stores a third value and never coerces unset into a boolean. Font size
       is deliberately excluded — it is per-DEVICE (vjt, #449) and stays
       client-local (`cicchetto/src/lib/fontSize.ts`).
+    * `show_bottom_bar` — whether cic renders the mobile window bar (#1766).
+      Default TRUE: this is an opt-OUT, carrying #174's standing constraint
+      that the bar is never deleted, only made optional. SYNCED rather than
+      per-device (the split above) because the complaint behind it — "7
+      networks and the strip no longer picks" — is account-scoped: the bar is
+      O(windows), and the window count is the same on the phone and the
+      tablet. That is the whole distinction from #914's `hide_next_active`,
+      which stayed client-local because its complaint was about a viewport.
   """
   # `time_format` + the presence values are closed sets ("hms"|"hm",
   # "show"|"hide"), but they stay `String.t()` on PURPOSE: Elixir typespecs
@@ -222,7 +230,8 @@ defmodule Grappa.UserSettings do
   @type display_prefs :: %{
           time_format: String.t(),
           colored_nicklist: boolean(),
-          presence_filter: %{String.t() => String.t()}
+          presence_filter: %{String.t() => String.t()},
+          show_bottom_bar: boolean()
         }
 
   @notification_prefs_key "notification_prefs"
@@ -1305,12 +1314,13 @@ defmodule Grappa.UserSettings do
   @doc """
   Default display preferences applied when a subject has no row OR the
   `"display_prefs"` key is absent: `"hms"` timestamps, monochrome nicklist,
-  and an empty presence-filter map (every channel follows the size default).
+  an empty presence-filter map (every channel follows the size default), and
+  the mobile window bar SHOWN (#1766 is an opt-out, never a default change).
   """
   @dialyzer {:nowarn_function, default_display_prefs: 0}
   @spec default_display_prefs() :: display_prefs()
   def default_display_prefs do
-    %{time_format: "hms", colored_nicklist: false, presence_filter: %{}}
+    %{time_format: "hms", colored_nicklist: false, presence_filter: %{}, show_bottom_bar: true}
   end
 
   @doc """
@@ -1367,6 +1377,9 @@ defmodule Grappa.UserSettings do
 
     * `time_format` ∈ #{inspect(@display_time_formats)}.
     * `colored_nicklist` is a boolean.
+    * `show_bottom_bar` is a boolean IF PRESENT; an absent key takes the
+      default (#1766). Every other key 422s when missing, and that asymmetry
+      is deliberate — see `fetch_optional_display_bool/3`.
     * `presence_filter` is a `%{channel_key => "show" | "hide"}` map. Any
       other value (a boolean, a third state) is REJECTED — the tri-state's
       unset is the ABSENCE of a key, never a stored value, so the server
@@ -1997,7 +2010,8 @@ defmodule Grappa.UserSettings do
     %{
       time_format: read_display_time_format(stored),
       colored_nicklist: read_display_bool(stored, :colored_nicklist, false),
-      presence_filter: read_presence_filter(stored)
+      presence_filter: read_presence_filter(stored),
+      show_bottom_bar: read_display_bool(stored, :show_bottom_bar, true)
     }
   end
 
@@ -2032,8 +2046,15 @@ defmodule Grappa.UserSettings do
   defp validate_and_normalize_display_prefs(prefs, subject) do
     with {:ok, tf} <- fetch_display_time_format(prefs),
          {:ok, cn} <- fetch_display_bool(prefs, :colored_nicklist),
-         {:ok, pf} <- fetch_presence_filter(prefs) do
-      {:ok, %{"time_format" => tf, "colored_nicklist" => cn, "presence_filter" => pf}}
+         {:ok, pf} <- fetch_presence_filter(prefs),
+         {:ok, sbb} <- fetch_optional_display_bool(prefs, :show_bottom_bar, true) do
+      {:ok,
+       %{
+         "time_format" => tf,
+         "colored_nicklist" => cn,
+         "presence_filter" => pf,
+         "show_bottom_bar" => sbb
+       }}
     else
       {:error, message} -> {:error, display_prefs_changeset_error(message, subject)}
     end
@@ -2051,6 +2072,37 @@ defmodule Grappa.UserSettings do
       v when is_boolean(v) -> {:ok, v}
       _ -> {:error, "#{key} must be a boolean"}
     end
+  end
+
+  # #1766 — the same boolean check, except that an ABSENT key takes `default`
+  # instead of 422ing. Every key added before this one is mandatory, and that
+  # was free while the shape never grew: the ONLY writer is cic's
+  # `buildWireMap()`, which always sends every key it knows. The moment the
+  # shape grows a key, "every key it knows" stops meaning "every key" for any
+  # bundle already loaded in a tab — and the server and the bundle deploy
+  # separately (`deploy-m42.sh` vs `--cic`). A mandatory fourth key would then
+  # 422 that tab's every display write, so the time-format and nicklist toggles
+  # would quietly stop persisting until it reloaded. The wire contract already
+  # rules this direction: an unknown-or-missing field is never fatal.
+  #
+  # ACCEPTED CONSEQUENCE, not an oversight: the PUT is a full-map replace, so
+  # such a tab's write also resets this key to `default`. It is a clobber, and
+  # the alternative — reading the stored value for the missing key — turns the
+  # documented full-replace path into a per-key read-modify-write that the
+  # NEXT added key would have to remember too. The window is one bundle
+  # reload wide and it self-heals; the drift would not.
+  defp fetch_optional_display_bool(prefs, key, default) when is_atom(key) do
+    if display_has_key?(prefs, key) do
+      fetch_display_bool(prefs, key)
+    else
+      {:ok, default}
+    end
+  end
+
+  # Absence has to be told apart from a present `nil`, which `display_fetch/2`
+  # flattens into one. Dual atom/string read, mirroring it.
+  defp display_has_key?(prefs, key) when is_atom(key) do
+    Map.has_key?(prefs, key) or Map.has_key?(prefs, Atom.to_string(key))
   end
 
   defp fetch_presence_filter(prefs) do

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 5
+protocol_version = 6
 shape_digest = sha256:516f5f58171ad5c5697be017b62c170f761990f3b78bb371b1873e8a4d6ed945

--- a/test/grappa/user_settings_display_prefs_test.exs
+++ b/test/grappa/user_settings_display_prefs_test.exs
@@ -5,8 +5,9 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
   account converges its UI across devices (report: desktop toggle didn't
   reach the iOS PWA because the prefs were localStorage-only).
 
-  The three prefs: `time_format` (`"hms" | "hm"`, #217), `colored_nicklist`
-  (boolean, #443), and `presence_filter` (a per-channel tri-state map, #222).
+  The four prefs: `time_format` (`"hms" | "hm"`, #217), `colored_nicklist`
+  (boolean, #443), `presence_filter` (a per-channel tri-state map, #222), and
+  `show_bottom_bar` (boolean, #1766).
 
   ## The tri-state invariant (NON-NEGOTIABLE)
 
@@ -39,7 +40,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       %{
         "time_format" => "hms",
         "colored_nicklist" => false,
-        "presence_filter" => %{}
+        "presence_filter" => %{},
+        "show_bottom_bar" => true
       },
       overrides
     )
@@ -56,7 +58,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       assert UserSettings.get_display_prefs({:user, fake_id}) == %{
                time_format: "hms",
                colored_nicklist: false,
-               presence_filter: %{}
+               presence_filter: %{},
+               show_bottom_bar: true
              }
     end
 
@@ -68,7 +71,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       assert UserSettings.get_display_prefs({:user, user.id}) == %{
                time_format: "hms",
                colored_nicklist: false,
-               presence_filter: %{}
+               presence_filter: %{},
+               show_bottom_bar: true
              }
     end
 
@@ -86,7 +90,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       assert UserSettings.get_display_prefs({:user, user.id}) == %{
                time_format: "hm",
                colored_nicklist: false,
-               presence_filter: %{}
+               presence_filter: %{},
+               show_bottom_bar: true
              }
     end
 
@@ -101,7 +106,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       assert UserSettings.get_display_prefs({:user, user.id}) == %{
                time_format: "hms",
                colored_nicklist: false,
-               presence_filter: %{}
+               presence_filter: %{},
+               show_bottom_bar: true
              }
     end
   end
@@ -160,7 +166,7 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
   # ---------------------------------------------------------------------------
 
   describe "put_display_prefs/2 — round-trip" do
-    test "persists all three prefs and reads them back" do
+    test "persists all four prefs and reads them back" do
       user = user_fixture()
 
       body =
@@ -175,7 +181,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       assert UserSettings.get_display_prefs({:user, user.id}) == %{
                time_format: "hm",
                colored_nicklist: true,
-               presence_filter: %{"libera #bofh" => "hide", "libera #cat" => "show"}
+               presence_filter: %{"libera #bofh" => "hide", "libera #cat" => "show"},
+               show_bottom_bar: true
              }
     end
 
@@ -335,6 +342,88 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                  {:user, user.id},
                  valid_wire(%{"presence_filter" => %{long_key => "hide"}})
                )
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # show_bottom_bar (#1766) — the fourth key, and the one whose ARRIVAL is the
+  # interesting case
+  # ---------------------------------------------------------------------------
+  #
+  # The pref itself is an ordinary boolean; what needs pinning is the skew a
+  # fourth key creates. `fetch_display_bool/2` — the validator every prior key
+  # uses — 422s a key that is absent, so a cic bundle predating #1766 would have
+  # every one of its PUTs rejected the moment the server grows this key: the
+  # operator's time-format and nicklist toggles would silently stop persisting
+  # until the tab reloads onto the new bundle. That window is real (the server
+  # and the bundle deploy separately — `deploy-m42.sh` vs `--cic`), and the wire
+  # contract already names the rule: an unknown-or-missing field is never fatal,
+  # in BOTH directions. So absence takes the default; a value that IS sent still
+  # has to be a boolean.
+
+  describe "show_bottom_bar (#1766)" do
+    test "defaults to true — the bar ships shown, this is an opt-OUT" do
+      assert UserSettings.default_display_prefs().show_bottom_bar == true
+      assert UserSettings.get_display_prefs({:user, Ecto.UUID.generate()}).show_bottom_bar == true
+    end
+
+    test "round-trips false" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               UserSettings.put_display_prefs({:user, user.id}, valid_wire(%{"show_bottom_bar" => false}))
+
+      assert UserSettings.get_display_prefs({:user, user.id}).show_bottom_bar == false
+    end
+
+    test "a PUT from a pre-#1766 client (three keys, no show_bottom_bar) is ACCEPTED" do
+      user = user_fixture()
+      legacy_body = Map.delete(valid_wire(), "show_bottom_bar")
+
+      assert {:ok, _} = UserSettings.put_display_prefs({:user, user.id}, legacy_body)
+      # …and the omission reads as the default, not as a crash and not as false.
+      assert UserSettings.get_display_prefs({:user, user.id}).show_bottom_bar == true
+    end
+
+    test "rejects a non-boolean show_bottom_bar — absent is tolerated, garbage is not" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               UserSettings.put_display_prefs({:user, user.id}, valid_wire(%{"show_bottom_bar" => "yes"}))
+
+      assert cs.errors[:display_prefs]
+    end
+
+    test "accepts an atom key too (parity with the sibling booleans)" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               UserSettings.put_display_prefs({:user, user.id}, %{
+                 time_format: "hms",
+                 colored_nicklist: false,
+                 presence_filter: %{},
+                 show_bottom_bar: false
+               })
+
+      assert UserSettings.get_display_prefs({:user, user.id}).show_bottom_bar == false
+    end
+
+    test "a stored blob predating the key reads true, not false" do
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+
+      settings
+      |> Settings.changeset(%{
+        data:
+          Map.put(settings.data, "display_prefs", %{
+            "time_format" => "hm",
+            "colored_nicklist" => true,
+            "presence_filter" => %{}
+          })
+      })
+      |> Repo.update!()
+
+      assert UserSettings.get_display_prefs({:user, user.id}).show_bottom_bar == true
     end
   end
 

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -522,8 +522,9 @@ defmodule GrappaWeb.UserSettingsControllerTest do
   # ===========================================================================
   # display_prefs (#449) — server-backed display preferences, so one account
   # converges its UI across devices. Wrapped-envelope endpoint mirroring
-  # aliases; full-map PUT, no PATCH/diff. Three prefs: time_format,
-  # colored_nicklist, presence_filter (per-channel tri-state map).
+  # aliases; full-map PUT, no PATCH/diff. Four prefs: time_format,
+  # colored_nicklist, presence_filter (per-channel tri-state map), and
+  # show_bottom_bar (#1766).
   #
   # A/B-INDEPENDENT core: font-size (Fork A, escalated to vjt) and the
   # client-side seed-up-once migration (Fork B) are NOT exercised here.
@@ -534,7 +535,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
     %{
       "time_format" => "hms",
       "colored_nicklist" => false,
-      "presence_filter" => %{}
+      "presence_filter" => %{},
+      "show_bottom_bar" => true
     }
   end
 
@@ -569,6 +571,10 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       assert prefs == default_display_prefs_wire()
     end
 
+    # The write below is deliberately the PRE-#1766 three-key body: it is what
+    # a cic bundle predating the fourth key sends, and the GET has to answer
+    # the complete four-key shape anyway (the missing key filled from the
+    # default, not dropped and not false).
     test "reflects the most-recent PUT", %{conn: conn, user: user} do
       {:ok, _} =
         UserSettings.put_display_prefs({:user, user.id}, %{
@@ -584,7 +590,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       assert prefs == %{
                "time_format" => "hm",
                "colored_nicklist" => true,
-               "presence_filter" => %{"libera #bofh" => "hide"}
+               "presence_filter" => %{"libera #bofh" => "hide"},
+               "show_bottom_bar" => true
              }
     end
 
@@ -631,6 +638,32 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       stored = UserSettings.get_display_prefs({:user, user.id})
       assert stored.time_format == "hm"
       assert stored.presence_filter == %{"libera #cat" => "show"}
+    end
+
+    # #1766 — the fourth key through the HTTP door, both directions. The `false`
+    # is the whole point of the pref, so a payload that carried the key but
+    # silently normalised it back to the default would pass every other test
+    # here.
+    test "200 + round-trips show_bottom_bar: false", %{conn: conn, user: user} do
+      body = %{"display_prefs" => Map.put(default_display_prefs_wire(), "show_bottom_bar", false)}
+
+      conn = put(conn, "/me/settings/display-prefs", body)
+
+      assert %{"display_prefs" => returned} = json_response(conn, 200)
+      assert returned["show_bottom_bar"] == false
+      assert UserSettings.get_display_prefs({:user, user.id}).show_bottom_bar == false
+    end
+
+    # A bundle predating #1766 keeps PUTting three keys. It must not start
+    # 422ing the moment the server grows the fourth — that would silently break
+    # the operator's OTHER display toggles until the tab reloaded.
+    test "200 for a pre-#1766 three-key body (no show_bottom_bar)", %{conn: conn} do
+      body = %{"display_prefs" => Map.delete(default_display_prefs_wire(), "show_bottom_bar")}
+
+      conn = put(conn, "/me/settings/display-prefs", body)
+
+      assert %{"display_prefs" => returned} = json_response(conn, 200)
+      assert returned["show_bottom_bar"] == true
     end
 
     test "PUT response carries persisted:true", %{conn: conn} do


### PR DESCRIPTION
Implements #1766 — a per-account opt-out for the mobile BottomBar, plus the two
settings-drawer cleanups vjt asked for in the same breath, plus the left `☰`
that has to exist once the bar can be gone.

## What ships

**Server — `Grappa.UserSettings`.** A fourth display key, `show_bottom_bar`,
defaulting to `true`. Typespec, `default_display_prefs/0`,
`merge_display_with_defaults/1` and `validate_and_normalize_display_prefs/2`
all grow it together.

The load-bearing part is the new pair `fetch_optional_display_bool/3` +
`display_has_key?/2`: **an absent key takes the default, a present-but-not-boolean
key still 422s.** Without it, every `PUT /display` from a cic bundle predating
#1766 — which sends three keys — would be rejected outright. The shape is
allowed to grow a key old clients omit; it is not allowed to grow a key old
clients may send garbage in.

**cic.** New owner module `lib/showBottomBar.ts` (shaped like
`colorNicklist.ts`: signal + localStorage boot mirror, local-only setter,
garbage falls back to `true`). `displayPrefs.ts` carries the coordinator half —
`DEFAULT_DISPLAY_PREFS`, `buildWireMap`, `applyServerPrefs` with a `?? default`
coalesce, and `syncedSetShowBottomBar`. `userSettings.ts` types
`show_bottom_bar?: boolean` as **optional on read**, the mirror-image
tolerance: a new bundle must survive an old server too.

**The gate** is a mount gate, not `display:none` — `Shell.tsx` wraps
`<BottomBar />` in `<Show when={getShowBottomBar()}>`, so the hidden bar stops
running its scroll-into-view effect rather than running it invisibly.

**The left `☰`** (vjt's ruling in-thread): `PaneTopBar` and `ShellChrome` both
take a **required** `leading` slot — required, so a new pane cannot silently
forget it. `TopicBar` passes `PaneTopBarWindowsOpener`; `AdminPane` /
`RailRadio` / the desktop path pass `leading={null}`. It opens `openSidebar`
(#1041), labelled `"open windows sidebar"`.

**Settings drawer.** The three display checkboxes move into one fieldset
(`display-checkboxes-fieldset`) with a shared blurb; existing testids are
untouched and `show-bottom-bar-toggle` is new. The `mark me away after:` label
is gone, its accessible name moved onto `aria-label="auto-away delay"` so the
select does not end up nameless.

**Protocol.** `Grappa.Protocol` 5 → 6, `priv/wire/shape.pin` refreshed.

## Three measurements that changed the plan

**1. The issue's CSS prescription is wrong.** It asked for
`justify-content: space-between` on `.shell-chrome`. The leading child is
**conditional** — when it is absent `.shell-chrome` has exactly one child, and
`space-between` on a single child resolves to `flex-start`, which would drag
the existing rail opener out of the right-hand corner for every pane that has
no hamburger. Shipped instead:
`.shell-chrome .topic-bar-windows-opener { margin-right: auto }`, which pushes
only the child that exists.

**2. A CSS class can be an identity, and `.topic-bar-hamburger` is one.**
Caught by the full integration run, not by reading. The first cut reused
`PaneTopBarRailOpener` for the left door, so with the bar off two buttons wore
that class — and `openMembersDrawer`, the fixture roughly twenty specs reach
the rail through, locates the opener BY CLASS and takes `.first()`. #1073 wrote
the contract in the fixture's own comment: *"the class is what they have in
common, and it is the thing this helper actually needs — the in-flow opener,
whichever pane is mounted."* Singular. The fixture opened the window sidebar
instead of the rail and then had its retry occluded by the sidebar it had just
opened. Fixed by giving the left door its own component and class; the two
still share `.shell-chrome-btn` and the drawn-bars rule, because with the bar
off they sit in one 48px band and must look identical.

Stated because it was the live question: **the feature does not open the
sidebar by itself.** The failure screenshot shows the server window already
reached, so the `☰` tap and the navigation through it both worked.

**3. The drawn `☰` was smaller than the glyph it replaced.** `ux-5-bt` asserts
#305's legibility floor as `getComputedStyle(el).fontSize >= 18`, which the
`font-size: 0` suppressor zeroes. Rather than soften it, the ink was measured
in the browser the spec runs in (root 14px, `--chrome-icon-size` → 19.59px):

| ☰ as painted | ink W | ink H |
| --- | --- | --- |
| U+2630 as text | 19.59 | 17.00 |
| bars at `/3` (first cut) | 19.59 | **15.06** |
| bars at `(token − 2px)/2` (shipped) | 19.59 | 19.59 |

The red was right twice: the oracle had gone blind **and** the glyph really had
shrunk 11.4% in height. The bars now span the icon token exactly. The oracle
moves to the painted extent, read off the computed shadow rather than
recomputing the formula — a strengthening, not an accommodation: `font-size`
measured the em box, when #305's whole complaint was that U+2630 is three thin
strokes centred in a box that is not narrow. The table shows the character
never cleared 18 either. Threshold unchanged at 18, met in both axes for the
first time.

**And one that did not force anything.** The 5 → 6 protocol bump was **not**
required by any gate: `mix grappa.wire_pin --check` reported an **identical
digest** on both sides, because `GrappaWeb.UserSettingsJSON` is not in the
codegen's `@extra_modules` — the same blind spot #1679 hit with `BootJSON`. The
bump is here for the #1393d rule, not because something went red. **That gap is
not closed here**: the wire-pin digest still does not cover hand-written
`*_json.ex`.

## Gaps left open, deliberately

* `admin` and `list` have no left `☰`. Both suppress `.shell-chrome` entirely
  and both already carry a `✕` back to a window that does have one.
* A `PUT /display` from a pre-#1766 bundle omits `show_bottom_bar`, so it
  resets the pref to the default. Accepted: the window is one reload wide.
* The wire-pin digest does not cover hand-written JSON view modules (above).

## Verification

Measured on this branch's HEAD, rebased onto `origin/main` = `7033db7d`:

* `GRAPPA_CACHE_ID=w1-1766 scripts/check.sh` — **rc=0**. 8 doctests /
  62 properties / **6878 tests / 0 failures**; dialyzer
  `done (passed successfully)`; doctor 100% spec + moduledoc.
* `scripts/bun.sh run check` — **rc=0**, 5 stages, 0 failed.
* `scripts/bun.sh run test` — **rc=0**, **314 files / 6274 tests**.
* `scripts/union-rebase.sh origin/main` — `+190 -0 — contribution intact`; the
  base's last entry (`#1708`) verified byte-identical afterwards, 1 occurrence.
* `scripts/design-notes-gate.sh origin/main` — **rc=0**,
  `1 new entry heading(s), separator and marker present`.

**`scripts/integration.sh` (full suite, not a scoped `--grep`)** — the three
specs this branch owns are **green**:

```
✓ issue1766-hide-bottom-bar.spec.ts:72  @webkit  4.4s   (was a 20s timeout)
✓ issue1766-hide-bottom-bar.spec.ts:115 @webkit  3.0s
✓ ux-5-bt-narrow-chrome-compression.spec.ts:124 @webkit 2.9s   (the new #305 oracle)
```

The run's overall `rc` is **1**, on three chromium specs this branch does not
touch. Triaged per `docs/TESTING.md`'s iron rule rather than asserted:

| spec | iso ×3 | verdict |
| --- | --- | --- |
| `issue217-timestamp-format:29` | 3/3 ✓ | cascade |
| `issue80-paste-flood-guard:98` | 3/3 ✓ | cascade |
| `issue127-server-reply-modal:33` | 2/3 ✓ | flake — **pre-existing** |

The last one was attributed by measurement, not by reading the diff: on a
detached worktree at a clean `origin/main` = `7033db7d`, with none of this
branch's code, it is **3 red / 6** (`--repeat-each 6`, chromium). Filed as
**#1789** with both of its distinct failure modes and the provisioning
telemetry that does *not* explain the second one.

TDD order held: server red measured first (30 tests, 11 failures, rc=3) then
green; vitest red was 6 tests across 4 files.

**Not verified, stated plainly:** no human observed a rendering, and no
screenshot was taken deliberately — the only real renderings I saw were the two
Playwright failure captures, which is how measurement 2 was settled. The visual
claim rests on the e2e specs above. The `#1789` flake has **no root cause**: it
was attributed, not diagnosed.
