### PR TITLE
perf(#1769): finish #1680 on the server — presence suppressed by join params

### DIFF
--- a/cicchetto/e2e/tests/issue1769-presence-suppressed-on-the-socket.spec.ts
+++ b/cicchetto/e2e/tests/issue1769-presence-suppressed-on-the-socket.spec.ts
@@ -1,0 +1,263 @@
+// Issue #1769 — presence suppressed by join params, measured ON THE SOCKET.
+//
+// WHY THIS SPEC EXISTS AND WHY IT LOOKS AT FRAMES
+//
+// #1680 already stops a paused channel from APPLYING peer join/part/quit: the
+// events cross the socket, get decoded, wake the main thread, and are dropped
+// at cic's dispatch edge. So the obvious end-to-end assertion — "the member
+// list does not move on a paused channel" — is green with or without #1769.
+// It would be a spec that cannot fail for the reason it was written.
+//
+// What #1769 buys is the thing #1680 could not: the bytes never arrive. That
+// is only observable at the transport, so this spec counts WebSocket frames
+// (`page.on("websocket")` → `framereceived`, the same instrument
+// `issue375-rehash-option.spec.ts` and `i2b-image-upload-litterbox-host.spec.ts`
+// use) and asserts on which ones are absent.
+//
+// THE CONTROLS, BECAUSE AN ABSENCE PROVES NOTHING BY ITSELF
+//
+// "No frame arrived" is also what a broken fixture, a peer that never joined,
+// and a dead socket look like. Three positive controls run in the same page,
+// against the same peer, on the same socket:
+//
+//   1. BEFORE the pause, a peer JOIN on the very same channel DOES produce a
+//      frame. Same topic, same event, same everything — only the pause differs.
+//   2. AFTER the pause, the FOCUSED channel still receives its peer JOIN. The
+//      suppression is per-channel, not per-socket, and this is the arm that
+//      fails if the whole socket went quiet.
+//   3. AFTER the pause, a PRIVMSG to the PAUSED channel still arrives. This is
+//      vjt's ruling as an assertion — a paused window goes quiet, never blind
+//      — and it is the one that fails if someone "simplifies" the pause into
+//      an abandoned topic.
+//
+// And one more, on the outbound side: the join frame cic SENT for the paused
+// channel must carry `{"presence":false}`. Without it the absence downstream
+// would prove the server dropped frames nobody asked it to drop.
+//
+// THE CLOCK
+//
+// `PRESENCE_COOLDOWN_MS` is two minutes. Rather than burn that in wall-clock
+// on every CI run, or add a production seam to shorten it, the spec drives
+// Playwright's clock: install → resume (so boot and the network run at real
+// speed) → `fastForward` past the window, which fires the pending cooldown
+// timer and nothing else that matters. The cooldown's own arithmetic is
+// covered by `presencePause.test.ts` under fake timers; what this spec is for
+// is everything downstream of it.
+
+import type { Page, WebSocket } from "@playwright/test";
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// The channel that gets blurred and paused: the seeded autojoin one.
+const PAUSED_CHANNEL = AUTOJOIN_CHANNELS[0];
+// The channel that stays focused, so control (2) can tell "this channel is
+// suppressed" from "this socket is dead".
+const FOCUSED_CHANNEL = `#pp1769-${crypto.randomUUID().slice(0, 8)}`;
+
+// Boot + two joins + a peer + a clock jump. Well inside the reconnect-class
+// budgets, but past the 30s default.
+test.setTimeout(90_000);
+
+const PRESENCE_COOLDOWN_MS = 120_000;
+
+type Frame = {
+  topic: string;
+  event: string;
+  payload: unknown;
+};
+
+// phoenix.js v2 serializer: every frame is the JSON array
+// `[join_ref, ref, topic, event, payload]`. Anything else (a heartbeat reply
+// shape we do not care about, a binary frame) is not a Frame for our purposes.
+function parseFrame(raw: string): Frame | null {
+  try {
+    const a: unknown = JSON.parse(raw);
+    if (!Array.isArray(a) || a.length !== 5) return null;
+    const [, , topic, event, payload] = a as [unknown, unknown, unknown, unknown, unknown];
+    if (typeof topic !== "string" || typeof event !== "string") return null;
+    return { topic, event, payload };
+  } catch {
+    return null;
+  }
+}
+
+type Recorder = {
+  received: Frame[];
+  sent: Frame[];
+};
+
+/**
+ * Record every app frame in BOTH directions. Must be attached before `goto`,
+ * or the boot socket is missed entirely (`issue1061-offline-does-nothing.spec.ts`
+ * makes the same point about attach order).
+ */
+function recordFrames(page: Page): Recorder {
+  const rec: Recorder = { received: [], sent: [] };
+  page.on("websocket", (ws: WebSocket) => {
+    ws.on("framereceived", ({ payload }) => {
+      if (typeof payload !== "string") return;
+      const f = parseFrame(payload);
+      if (f) rec.received.push(f);
+    });
+    ws.on("framesent", ({ payload }) => {
+      if (typeof payload !== "string") return;
+      const f = parseFrame(payload);
+      if (f) rec.sent.push(f);
+    });
+  });
+  return rec;
+}
+
+// Topics are user-rooted; matching on the suffix keeps the assertion readable
+// without rebuilding the server's `Topic.channel/3` here.
+function onChannel(frames: Frame[], channel: string): Frame[] {
+  return frames.filter((f) => f.topic.endsWith(`/channel:${channel.toLowerCase()}`));
+}
+
+// A scrollback row of `kind` from `sender`, as it appears inside an "event"
+// frame's payload (`Grappa.Scrollback.Wire.message_payload/2`).
+function rows(frames: Frame[], kind: string, sender: string): Frame[] {
+  return frames.filter((f) => {
+    if (f.event !== "event") return false;
+    const p = f.payload as { kind?: unknown; message?: { kind?: unknown; sender?: unknown } };
+    if (p?.kind !== "message") return false;
+    return (
+      p.message?.kind === kind &&
+      String(p.message?.sender ?? "").toLowerCase() === sender.toLowerCase()
+    );
+  });
+}
+
+let peer: IrcPeer | null = null;
+
+test.afterEach(async () => {
+  if (peer) {
+    await peer.disconnect("e2e cleanup").catch(() => {});
+    peer = null;
+  }
+});
+
+test("issue #1769 — a paused channel stops RECEIVING peer presence, while messages and the focused channel keep arriving", async ({
+  page,
+}) => {
+  const frames = recordFrames(page);
+
+  // install() pauses the page clock; resume() lets it tick again immediately,
+  // so boot, the WS handshake and every REST call run at real speed. The only
+  // thing we will do with the clock is jump it once, later.
+  await page.clock.install();
+  await page.clock.resume();
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+
+  const ownNick = specNick();
+  await selectChannel(page, NETWORK_SLUG, PAUSED_CHANNEL, { ownNick });
+
+  // A second REAL channel, so the focused-control arm has somewhere to live.
+  // Joined through cic's own compose so the window exists in the sidebar the
+  // way a user's would.
+  await composeSend(page, `/join ${FOCUSED_CHANNEL}`);
+  await selectChannel(page, NETWORK_SLUG, FOCUSED_CHANNEL, { ownNick });
+
+  peer = await IrcPeer.connect({ nick: `pp1769-${crypto.randomUUID().slice(0, 6)}` });
+  // Bound once: `peer` is nullable for the afterEach teardown, and the arms
+  // below would otherwise each need a non-null assertion.
+  const peerNick = peer.nick;
+  const livePeer = peer;
+
+  // ── CONTROL 1 — the same channel, before the pause, DOES deliver a peer
+  // JOIN over the socket. The selection has already moved on, so the channel
+  // is BLURRED here — its cooldown is armed but has not fired, which is
+  // exactly the state that must still deliver. Establishes that the
+  // instrument works, that the peer is real, and that this topic carries
+  // these frames at all. Without it the absence asserted later is
+  // unfalsifiable.
+  await livePeer.join(PAUSED_CHANNEL);
+  await expect
+    .poll(() => rows(onChannel(frames.received, PAUSED_CHANNEL), "join", peerNick).length, {
+      message: `no peer JOIN frame arrived for ${PAUSED_CHANNEL} before its cooldown elapsed — the instrument or the fixture is broken, not the feature`,
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0);
+
+  // The paused channel is currently BLURRED (the selection moved to
+  // FOCUSED_CHANNEL above), so its cooldown window is already armed. Jump
+  // past it: the timer fires, cic re-joins the topic with `presence: false`.
+  const sentBefore = frames.sent.length;
+  await page.clock.fastForward(PRESENCE_COOLDOWN_MS + 5_000);
+
+  // ── The outbound half, asserted rather than assumed. If cic never sent the
+  // param, every absence below would be measuring something else entirely.
+  await expect
+    .poll(
+      () =>
+        frames.sent
+          .slice(sentBefore)
+          .filter(
+            (f) =>
+              f.event === "phx_join" &&
+              f.topic.endsWith(`/channel:${PAUSED_CHANNEL.toLowerCase()}`) &&
+              (f.payload as { presence?: unknown } | null)?.presence === false,
+          ).length,
+      {
+        message: `cic never sent a phx_join carrying {"presence": false} for ${PAUSED_CHANNEL}`,
+        timeout: 15_000,
+      },
+    )
+    .toBeGreaterThan(0);
+
+  // Everything from here on is measured AFTER the re-join landed, so the
+  // baseline JOIN from control 1 cannot leak into the counts.
+  const receivedAfter = frames.received.length;
+  const since = () => frames.received.slice(receivedAfter);
+
+  // The peer leaves and re-enters BOTH channels. Same peer, same instant,
+  // same socket — the only difference between the two channels is the param.
+  await livePeer.part(PAUSED_CHANNEL, "cycling");
+  await livePeer.join(PAUSED_CHANNEL);
+  await livePeer.join(FOCUSED_CHANNEL);
+
+  // ── CONTROL 2 — the focused channel still receives its peer JOIN. This is
+  // what separates "that channel is suppressed" from "the socket is dead".
+  await expect
+    .poll(() => rows(onChannel(since(), FOCUSED_CHANNEL), "join", peerNick).length, {
+      message: `the FOCUSED channel stopped receiving peer JOINs — suppression is meant to be per-channel, not per-socket`,
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(0);
+
+  // ── CONTROL 3 — the paused channel is QUIET, not BLIND. vjt's ruling:
+  // messages must not be lost.
+  const body = `pp1769-${crypto.randomUUID().slice(0, 8)}`;
+  livePeer.privmsg(PAUSED_CHANNEL, body);
+  await expect
+    .poll(
+      () =>
+        onChannel(since(), PAUSED_CHANNEL).some((f) => {
+          const p = f.payload as { message?: { body?: unknown } };
+          return p?.message?.body === body;
+        }),
+      {
+        message: `a PRIVMSG to the paused channel never arrived — the pause made the window BLIND, which is exactly what the shape was chosen to avoid`,
+        timeout: 15_000,
+      },
+    )
+    .toBe(true);
+
+  // ── THE ASSERTION THE SPEC IS FOR. The message above is the ordering
+  // barrier: it was broadcast on the SAME topic AFTER the peer's part/join,
+  // and it has arrived — so if the presence rows were coming, they would
+  // already be here. No sleep, no window to tune.
+  const presenceOnPaused = onChannel(since(), PAUSED_CHANNEL).filter((f) => {
+    const p = f.payload as { kind?: unknown; message?: { kind?: unknown } };
+    return p?.kind === "message" && (p.message?.kind === "join" || p.message?.kind === "part");
+  });
+
+  expect(
+    presenceOnPaused,
+    `peer presence still crossed the socket for the paused channel — #1680's dispatch-edge drop would hide this in the UI, which is why this spec reads frames`,
+  ).toEqual([]);
+});

--- a/cicchetto/src/__tests__/presencePause.test.ts
+++ b/cicchetto/src/__tests__/presencePause.test.ts
@@ -2,10 +2,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
 import { PRESENCE_COOLDOWN_MS } from "../lib/presenceCooldown";
 import { SUPPRESSED_PRESENCE_KINDS } from "../lib/presenceFilter";
-import { createPresencePause, PAUSABLE_PRESENCE_KINDS } from "../lib/presencePause";
+import {
+  createPresencePause,
+  PAUSABLE_PRESENCE_KINDS,
+  type PresencePauseHandlers,
+} from "../lib/presencePause";
 
 const alice = channelKey("azzurra", "#alice");
 const bob = channelKey("azzurra", "#bob");
+
+// #1769 made the callbacks an object of two. Most arms below care about
+// neither edge, so they take the defaults; the arms that assert on one pass
+// it in by name — which is the point of the object shape (two same-typed
+// positional callbacks would swap silently).
+function handlers(over: Partial<PresencePauseHandlers> = {}): PresencePauseHandlers {
+  return { onPause: vi.fn(), onResume: vi.fn(), ...over };
+}
 
 describe("presencePause (#1680)", () => {
   beforeEach(() => {
@@ -42,7 +54,7 @@ describe("presencePause (#1680)", () => {
 
   describe("the drop predicate", () => {
     it("drops a peer join/part/quit once the channel is paused", () => {
-      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers(), PRESENCE_COOLDOWN_MS);
       pause.focus(alice);
       pause.focus(bob);
       vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
@@ -55,7 +67,7 @@ describe("presencePause (#1680)", () => {
     });
 
     it("drops nothing before the window elapses", () => {
-      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers(), PRESENCE_COOLDOWN_MS);
       pause.focus(alice);
       pause.focus(bob);
       vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS - 1);
@@ -65,7 +77,7 @@ describe("presencePause (#1680)", () => {
     });
 
     it("never drops OUR OWN presence, however long the channel sat paused", () => {
-      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers(), PRESENCE_COOLDOWN_MS);
       pause.focus(alice);
       pause.focus(bob);
       vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 10);
@@ -78,7 +90,7 @@ describe("presencePause (#1680)", () => {
     });
 
     it("never drops a message, whatever the pause state", () => {
-      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers(), PRESENCE_COOLDOWN_MS);
       pause.focus(alice);
       pause.focus(bob);
       vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
@@ -91,7 +103,7 @@ describe("presencePause (#1680)", () => {
     });
 
     it("never drops on the focused channel", () => {
-      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers(), PRESENCE_COOLDOWN_MS);
       pause.focus(alice);
       vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 10);
 
@@ -100,10 +112,64 @@ describe("presencePause (#1680)", () => {
     });
   });
 
+  // #1769 — the pause edge exists so the events can be stopped at the SERVER
+  // (a re-join carrying `{presence: false}`), not merely discarded here. It
+  // has to fire exactly once, at the moment the window elapses, because each
+  // firing costs a leave + join + backfill round trip.
+  describe("the pause seam", () => {
+    it("fires once, when the window elapses — not on the blur", () => {
+      const onPause = vi.fn();
+      const pause = createPresencePause(handlers({ onPause }), PRESENCE_COOLDOWN_MS);
+
+      pause.focus(alice);
+      pause.focus(bob);
+      expect(onPause).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+      expect(onPause).toHaveBeenCalledTimes(1);
+      expect(onPause).toHaveBeenCalledWith(alice);
+
+      // The window is spent; nothing re-arms it while the channel stays
+      // blurred, so no second re-join is ever ordered.
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 3);
+      expect(onPause).toHaveBeenCalledTimes(1);
+      pause.dispose();
+    });
+
+    it("does not fire for a channel refocused inside its window", () => {
+      const onPause = vi.fn();
+      const pause = createPresencePause(handlers({ onPause }), PRESENCE_COOLDOWN_MS);
+
+      pause.focus(alice);
+      pause.focus(bob);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS / 2);
+      pause.focus(alice);
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 2);
+
+      // alice never paused, so she never re-joins. bob did — he was blurred
+      // by the refocus and his own window then elapsed.
+      expect(onPause).toHaveBeenCalledTimes(1);
+      expect(onPause).toHaveBeenCalledWith(bob);
+      pause.dispose();
+    });
+
+    it("dispose cancels a pending window, so no re-join is ordered after teardown", () => {
+      const onPause = vi.fn();
+      const pause = createPresencePause(handlers({ onPause }), PRESENCE_COOLDOWN_MS);
+
+      pause.focus(alice);
+      pause.focus(bob);
+      pause.dispose();
+      vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 2);
+
+      expect(onPause).not.toHaveBeenCalled();
+    });
+  });
+
   describe("the resume seam", () => {
     it("refetches exactly when presence was actually missed", () => {
       const onResume = vi.fn();
-      const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers({ onResume }), PRESENCE_COOLDOWN_MS);
 
       pause.focus(alice);
       pause.focus(bob);
@@ -123,7 +189,7 @@ describe("presencePause (#1680)", () => {
     // prevent — #1679's failure mode, reintroduced at the other end.
     it("does not refetch for a channel that was never paused", () => {
       const onResume = vi.fn();
-      const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers({ onResume }), PRESENCE_COOLDOWN_MS);
 
       pause.focus(alice);
       pause.focus(bob);
@@ -136,7 +202,7 @@ describe("presencePause (#1680)", () => {
 
     it("re-focusing the already-focused channel is a no-op", () => {
       const onResume = vi.fn();
-      const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers({ onResume }), PRESENCE_COOLDOWN_MS);
 
       pause.focus(alice);
       pause.focus(alice);
@@ -152,7 +218,7 @@ describe("presencePause (#1680)", () => {
 
   describe("selection leaving channel-shaped windows", () => {
     it("arms the window when selection goes to null", () => {
-      const pause = createPresencePause(vi.fn(), PRESENCE_COOLDOWN_MS);
+      const pause = createPresencePause(handlers(), PRESENCE_COOLDOWN_MS);
       pause.focus(alice);
       pause.focus(null);
       vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
@@ -164,7 +230,7 @@ describe("presencePause (#1680)", () => {
 
   it("dispose un-pauses everything and cancels pending windows", () => {
     const onResume = vi.fn();
-    const pause = createPresencePause(onResume, PRESENCE_COOLDOWN_MS);
+    const pause = createPresencePause(handlers({ onResume }), PRESENCE_COOLDOWN_MS);
 
     pause.focus(alice);
     pause.focus(bob);

--- a/cicchetto/src/__tests__/socket.test.ts
+++ b/cicchetto/src/__tests__/socket.test.ts
@@ -260,11 +260,26 @@ describe("socket singleton", () => {
   it("joinChannel builds the topic-vocabulary string and calls channel.join()", async () => {
     localStorage.setItem("grappa-token", "tok-1");
     const socket = await import("../lib/socket");
-    socket.joinChannel("alice", "freenode", "#grappa");
+    socket.joinChannel("alice", "freenode", "#grappa", undefined, {});
     expect(h.mockSocketInstance.channel).toHaveBeenCalledWith(
       "grappa:user:alice/network:freenode/channel:#grappa",
+      {},
     );
     expect(h.mockChannel.join).toHaveBeenCalledTimes(1);
+  });
+
+  // #1769 — the join params reach phoenix.js verbatim. The server reads the
+  // param ONCE, in `GrappaChannel.join/3`, so a params object that never made
+  // it onto the channel would fail silently: the socket would keep receiving
+  // the full presence flood and nothing client-side would notice.
+  it("joinChannel passes the presence param through to socket.channel()", async () => {
+    localStorage.setItem("grappa-token", "tok-1");
+    const socket = await import("../lib/socket");
+    socket.joinChannel("alice", "freenode", "#grappa", undefined, { presence: false });
+    expect(h.mockSocketInstance.channel).toHaveBeenCalledWith(
+      "grappa:user:alice/network:freenode/channel:#grappa",
+      { presence: false },
+    );
   });
 
   it("joinChannel registers error + timeout handlers on the join Push (S48)", async () => {
@@ -275,7 +290,7 @@ describe("socket singleton", () => {
     // future refactor that drops one fails this test.
     localStorage.setItem("grappa-token", "tok-1");
     const socket = await import("../lib/socket");
-    socket.joinChannel("alice", "freenode", "#grappa");
+    socket.joinChannel("alice", "freenode", "#grappa", undefined, {});
     const eventNames = h.mockJoinPush.receive.mock.calls.map((c) => c[0]);
     expect(eventNames).toContain("error");
     expect(eventNames).toContain("timeout");

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -400,12 +400,14 @@ describe("subscribe — WS join effect", () => {
       "freenode",
       "#grappa",
       expect.any(Function),
+      { presence: true },
     );
     expect(socket.joinChannel).toHaveBeenCalledWith(
       "alice",
       "freenode",
       "#cicchetto",
       expect.any(Function),
+      { presence: true },
     );
     // DM-listener join uses the operator's own nick as the channel
     // segment — server broadcasts inbound PRIVMSGs on this topic.
@@ -414,6 +416,7 @@ describe("subscribe — WS join effect", () => {
       "freenode",
       "alice",
       expect.any(Function),
+      {},
     );
     // BUG2: server-messages loop joins the $server synthetic channel.
     expect(socket.joinChannel).toHaveBeenCalledWith(
@@ -421,6 +424,7 @@ describe("subscribe — WS join effect", () => {
       "freenode",
       "$server",
       expect.any(Function),
+      {},
     );
     expect(mockChannel.on).toHaveBeenCalledWith("event", expect.any(Function));
   });
@@ -823,6 +827,7 @@ describe("subscribe — WS join effect", () => {
         "freenode",
         "#grappa",
         expect.any(Function),
+        { presence: true },
       );
 
       fireMessageEvent("#grappa", { id: 1, body: "as A" });
@@ -875,6 +880,7 @@ describe("subscribe — WS join effect", () => {
           "freenode",
           "bob",
           expect.any(Function),
+          {},
         );
       });
       expect(socket.joinChannel).toHaveBeenCalledWith(
@@ -882,12 +888,14 @@ describe("subscribe — WS join effect", () => {
         "freenode",
         "#grappa",
         expect.any(Function),
+        { presence: true },
       );
       expect(socket.joinChannel).toHaveBeenCalledWith(
         "bob",
         "freenode",
         "#cicchetto",
         expect.any(Function),
+        { presence: true },
       );
     });
 
@@ -959,6 +967,7 @@ describe("subscribe — WS join effect", () => {
           "freenode",
           "#grappa",
           expect.any(Function),
+          { presence: true },
         );
       });
 
@@ -1520,6 +1529,7 @@ describe("subscribe — query-window WS subscribe (DM live-WS gap)", () => {
       "freenode",
       "#grappa",
       expect.any(Function),
+      { presence: true },
     );
     // Query topic uses the targetNick as the channel-name segment —
     // matches the server-side broadcast on Topic.channel(user,
@@ -1529,6 +1539,7 @@ describe("subscribe — query-window WS subscribe (DM live-WS gap)", () => {
       "freenode",
       "vjt",
       expect.any(Function),
+      {},
     );
   });
 
@@ -1557,12 +1568,14 @@ describe("subscribe — query-window WS subscribe (DM live-WS gap)", () => {
       "freenode",
       "vjt",
       expect.any(Function),
+      {},
     );
     expect(socket.joinChannel).toHaveBeenCalledWith(
       "alice",
       "freenode",
       "carol",
       expect.any(Function),
+      {},
     );
   });
 
@@ -1644,6 +1657,7 @@ describe("subscribe — query-window WS subscribe (DM live-WS gap)", () => {
       "freenode",
       "vjt",
       expect.any(Function),
+      {},
     );
   });
 
@@ -1721,6 +1735,7 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
       "freenode",
       "alice",
       expect.any(Function),
+      {},
     );
   });
 
@@ -2311,18 +2326,21 @@ describe("subscribe — query-window loop skips own-nick topic (Bug A root cause
       "freenode",
       "#grappa",
       expect.any(Function),
+      { presence: true },
     );
     expect(socket.joinChannel).toHaveBeenCalledWith(
       "alice",
       "freenode",
       "alice",
       expect.any(Function),
+      {},
     );
     expect(socket.joinChannel).toHaveBeenCalledWith(
       "alice",
       "freenode",
       "$server",
       expect.any(Function),
+      {},
     );
     // Exactly 3 calls — no extra join for the own-nick query window.
     expect(socket.joinChannel).toHaveBeenCalledTimes(3);
@@ -2415,13 +2433,20 @@ describe("subscribe — nick-clash regression (user.name === targetNick, IRC nic
       expect(socket.joinChannel).toHaveBeenCalledTimes(4);
     });
     // query-windows-loop must join channel:vjt (targetNick != IRC nick "grappa").
-    expect(socket.joinChannel).toHaveBeenCalledWith("vjt", "freenode", "vjt", expect.any(Function));
+    expect(socket.joinChannel).toHaveBeenCalledWith(
+      "vjt",
+      "freenode",
+      "vjt",
+      expect.any(Function),
+      {},
+    );
     // DM-listener must join channel:grappa (the actual IRC nick, from net.nick).
     expect(socket.joinChannel).toHaveBeenCalledWith(
       "vjt",
       "freenode",
       "grappa",
       expect.any(Function),
+      {},
     );
     // $server loop joins $server.
     expect(socket.joinChannel).toHaveBeenCalledWith(
@@ -2429,6 +2454,7 @@ describe("subscribe — nick-clash regression (user.name === targetNick, IRC nic
       "freenode",
       "$server",
       expect.any(Function),
+      {},
     );
   });
 
@@ -3551,6 +3577,7 @@ describe("subscribe - not-joined pre-subscribe loop (CP15 B5 fix + #78)", () => 
         "freenode",
         "#new-room",
         expect.any(Function),
+        { presence: true },
       );
     });
   };
@@ -4330,6 +4357,7 @@ describe("subscribe — the DM listener releases its own-nick topic on a rename 
         "freenode",
         "alice",
         expect.any(Function),
+        {},
       );
     });
 
@@ -4340,6 +4368,7 @@ describe("subscribe — the DM listener releases its own-nick topic on a rename 
         "freenode",
         "zelda",
         expect.any(Function),
+        {},
       );
     });
 
@@ -4372,6 +4401,7 @@ describe("subscribe — the DM listener releases its own-nick topic on a rename 
         "freenode",
         "alice",
         expect.any(Function),
+        {},
       );
     });
 
@@ -4384,6 +4414,7 @@ describe("subscribe — the DM listener releases its own-nick topic on a rename 
         "freenode",
         "zelda",
         expect.any(Function),
+        {},
       );
     });
 
@@ -4570,7 +4601,24 @@ describe("subscribe — presence pause on unfocused channels (#1680)", () => {
   // A paused channel must go QUIET, never BLIND. This is the assertion that
   // encodes vjt's ruling ("messages must not be lost") as a test rather than
   // as a comment — and the one that fails the moment someone "simplifies"
-  // the pause into a `phx.leave()`.
+  // the pause into an abandoned topic.
+  //
+  // #1769 CHANGED WHAT "NEVER BLIND" LOOKS LIKE, so the oracle changed with
+  // it — deliberately, and toward being stricter rather than looser. The
+  // pause now also asks the SERVER to stop sending peer presence, and the
+  // only way to say that is a join param, which is read once at join. So a
+  // pause is a re-join, and a re-join calls `phx.leave()`. The old assertion
+  // ("leave was never called") can no longer tell abandonment from a swap,
+  // and would now forbid the correct implementation.
+  //
+  // What it was protecting is asserted DIRECTLY instead: the topic is joined
+  // AGAIN, with `{presence: false}`. That is a stronger statement than the
+  // absence of a leave — it names the end state rather than one gesture that
+  // could reach a bad one.
+  //
+  // What this arm does NOT prove, and cannot: that no message is lost across
+  // the swap. `fireMessageEvent` drives the installed handler directly, so
+  // there is no socket here to have a gap. The live-side proof is the e2e.
   it("still delivers MESSAGES on a paused channel — quiet, not blind", async () => {
     localStorage.setItem("grappa-token", "tok");
     localStorage.setItem(
@@ -4596,6 +4644,65 @@ describe("subscribe — presence pause on unfocused channels (#1680)", () => {
 
     const rows = store.scrollbackByChannel()[channelKey("freenode", "#grappa")] ?? [];
     expect(rows.some((r: { id: number }) => r.id === 4006)).toBe(true);
-    expect(mockChannel.leave).not.toHaveBeenCalled();
+
+    // Still subscribed, and now suppressing at the server too.
+    const socket = await import("../lib/socket");
+    expect(socket.joinChannel).toHaveBeenCalledWith(
+      "alice",
+      "freenode",
+      "#grappa",
+      expect.any(Function),
+      { presence: false },
+    );
+  });
+
+  // The other half of the same rule, and the one an implementation can fail
+  // silently: a channel that regains focus must be re-joined WITHOUT the
+  // param. Miss it and the window stays muted forever — the operator is
+  // looking straight at a member list that has stopped updating, with no
+  // error anywhere.
+  it("re-joins WITHOUT the param when the channel regains focus", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const socket = await import("../lib/socket");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS);
+    vi.useRealTimers();
+
+    // Pre-state, asserted rather than assumed: without this the arm below
+    // would pass on an implementation that never paused at all.
+    expect(socket.joinChannel).toHaveBeenCalledWith(
+      "alice",
+      "freenode",
+      "#grappa",
+      expect.any(Function),
+      { presence: false },
+    );
+
+    vi.mocked(socket.joinChannel).mockClear();
+    focus(store, "#grappa");
+    await flushEffects();
+
+    expect(socket.joinChannel).toHaveBeenCalledWith(
+      "alice",
+      "freenode",
+      "#grappa",
+      expect.any(Function),
+      { presence: true },
+    );
   });
 });

--- a/cicchetto/src/lib/presencePause.ts
+++ b/cicchetto/src/lib/presencePause.ts
@@ -21,6 +21,22 @@
 //
 // So the subscription stays and the noise is dropped where it arrives.
 //
+// #1769 ADDS a second cut without reversing that. The subscription still
+// stays — what changes is that a paused channel RE-JOINS the same topic
+// carrying `{presence: false}`, and the server then declines to push the
+// three pausable kinds at all. The events stop crossing the socket instead of
+// being decoded and discarded here, which is the cost #1680 could not reach:
+// it saved render and store work, never bytes, parse or wakeups.
+//
+// The drop below is KEPT rather than replaced, and not out of caution. It is
+// what serves an older server (the param is read once at join and silently
+// ignored by anything predating protocol 7), and it is what covers the
+// microseconds between a re-join landing and the server swapping this
+// socket's fastlane. Two cuts, one rule — `PAUSABLE_PRESENCE_KINDS` below is
+// pinned to the server's `Message.pausable_presence_kinds/0` by
+// `presence_filter_test.exs`, so they cannot disagree about which kinds those
+// are.
+//
 // WHY NOT ALL FIVE PRESENCE KINDS
 //
 // `SUPPRESSED_PRESENCE_KINDS` (presenceFilter.ts, byte-pinned to the server
@@ -75,16 +91,39 @@ export interface PresencePause {
   dispose(): void;
 }
 
+// The two edges of a pause, as injected callbacks — the shape
+// `presenceCooldown.ts` chose for its own terminal action, for the same
+// reason: what "paused" DOES is the contested part, and holding it behind a
+// seam keeps changing it a one-line edit at the wiring site.
+//
+// `onPause` fires when a blurred channel's cooldown expires. #1769 hangs the
+// server-side half off it: a re-join carrying `{presence: false}`, so the
+// events stop crossing the socket at all instead of being decoded and thrown
+// away here.
+//
 // `onResume` fires when a channel that WAS paused regains focus — the seam
 // the members refetch hangs off, because that is the one store the pause let
 // go stale. It does not fire for a channel that was merely blurred and came
 // back inside its window: nothing was dropped, so nothing needs rebuilding.
+//
+// An OBJECT rather than two positional callbacks: they have identical types,
+// so a swapped pair would type-check and then refetch on pause and mute on
+// resume — a bug with no compiler to catch it.
+export interface PresencePauseHandlers {
+  onPause: (key: ChannelKey) => void;
+  onResume: (key: ChannelKey) => void;
+}
+
 export function createPresencePause(
-  onResume: (key: ChannelKey) => void,
+  handlers: PresencePauseHandlers,
   cooldownMs: number,
 ): PresencePause {
   const pausedKeys = new Set<ChannelKey>();
-  const cooldown = createPresenceCooldown((key) => pausedKeys.add(key), cooldownMs);
+
+  const cooldown = createPresenceCooldown((key) => {
+    pausedKeys.add(key);
+    handlers.onPause(key);
+  }, cooldownMs);
   let focused: ChannelKey | null = null;
 
   return {
@@ -96,7 +135,7 @@ export function createPresencePause(
       cooldown.focused(key);
       // `delete` returns whether it was there — so the refetch is ordered
       // exactly when presence was actually missed, never on a plain re-focus.
-      if (pausedKeys.delete(key)) onResume(key);
+      if (pausedKeys.delete(key)) handlers.onResume(key);
     },
 
     isPaused(key: ChannelKey): boolean {

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -463,11 +463,29 @@ export function joinUser(userName: string, onJoinOk?: (reply: unknown) => void):
   return ch;
 }
 
+// #1769 — the join params a per-channel topic accepts. One key today.
+//
+// `presence: false` asks the server not to push peer join/part/quit for this
+// channel (the server half of #1680's pause). OMITTING the key is the
+// default and means everything — which is the whole compatibility argument
+// for the shape, so this type must never grow a required member.
+//
+// The server reads it ONCE, in `GrappaWeb.GrappaChannel.join/3`. Changing
+// your mind is a re-join, not a push; `subscribe.ts:rejoinChannelWithPresence`
+// is the one caller that does that.
+export interface ChannelJoinParams {
+  presence?: boolean;
+}
+
 export function joinChannel(
   userName: string,
   networkSlug: string,
   channelName: string,
-  onJoinOk?: (reply: unknown) => void,
+  onJoinOk: ((reply: unknown) => void) | undefined,
+  // REQUIRED, not defaulted: a default would let a new call site acquire the
+  // presence decision without naming it, and every existing site passing an
+  // explicit `{}` is what makes "who asks for suppression?" greppable.
+  params: ChannelJoinParams,
 ): Channel {
   // UX-4 bucket A — canonicalise channel-shape segment so cic joins
   // the same Phoenix topic the server broadcasts on. Server-side
@@ -476,7 +494,12 @@ export function joinChannel(
   // fastlane fan-out would skip this socket entirely. Nicks (DM
   // windows) pass through unchanged.
   const topic = `grappa:user:${userName}/network:${networkSlug}/channel:${canonicalChannel(channelName)}`;
-  const ch = getSocket().channel(topic);
+  // Params are passed as an OBJECT rather than a thunk deliberately. phoenix.js
+  // re-evaluates a thunk on every auto-rejoin, which sounds like the safer
+  // choice and is not: it would let a socket-level reconnect silently change
+  // what this Channel asked for, so the object it joined with would stop
+  // describing it. A pause/resume transition re-joins explicitly instead.
+  const ch = getSocket().channel(topic, params);
   // Surface server-side join failures to the console + Phase 5
   // telemetry hook (the `unknown topic` and `forbidden` shapes the
   // server returns from `GrappaChannel.join/3` would otherwise vanish

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -36,7 +36,7 @@ import { applyJoinReply, applyReadCursorSet, renameReadCursorChannel } from "./r
 import { recordSeen } from "./reconnectBackfill";
 import { appendToScrollback, refreshScrollback, renameScrollbackKey } from "./scrollback";
 import { followQueryNick, selectedChannel, setServerSeedCount } from "./selection";
-import { joinChannel } from "./socket";
+import { type ChannelJoinParams, joinChannel } from "./socket";
 import { socketHealth } from "./socketHealth";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
 import {
@@ -151,32 +151,58 @@ moduleRoot(() => {
   // `PRESENCE_COOLDOWN_MS` stops applying those, and regaining focus refetches
   // the one store the pause let go stale — the members map.
   //
-  // The subscription itself is NEVER dropped: the per-channel topic also
-  // carries the messages (`Grappa.Session.Persistor` broadcasts them there),
-  // so leaving it would make the window blind rather than quiet. See
-  // `presencePause.ts` for the full argument and the carve-outs.
-  const presencePause = createPresencePause((key) => {
-    const t = untrack(token);
-    if (!t) return;
-    // `decodeChannelKey` is nullable by contract; a key that cannot be
-    // decoded cannot be refetched, and inventing a slug would fetch the
-    // wrong channel. Leave the members map alone.
-    const decoded = decodeChannelKey(key);
-    if (decoded === null) return;
-    const { slug, name } = decoded;
-    // A refetch that throws must not take the handler down with it — the
-    // members map simply stays as it was until the next seed. `null` is the
-    // server's 204 (`:uninitialized`): joined but pre-NAMES, or not joined.
-    // Seeding `[]` there would blank a good list, which is exactly the
-    // distinction CP24 bucket E drew.
-    void listMembers(t, slug, name)
-      .then((members) => {
-        if (members !== null) seedMembers(key, members);
-      })
-      .catch((err: unknown) => {
-        console.warn("[subscribe] members refetch failed on resume", key, err);
-      });
-  }, PRESENCE_COOLDOWN_MS);
+  // The channel is never ABANDONED: the per-channel topic also carries the
+  // messages (`Grappa.Session.Persistor` broadcasts them there), so a paused
+  // window must end up subscribed or it goes blind rather than quiet. Since
+  // #1769 the pause does call `phx.leave()`, immediately followed by a join
+  // carrying the new param — the param is read once at join, so a swap is the
+  // only way to change it. The cost of that swap is a short window with no
+  // live delivery, closed by the join-ACK `refreshScrollback` that every
+  // channel join already runs. See `presencePause.ts` for the full argument
+  // and the carve-outs.
+  //
+  // #1769 wires BOTH edges. `onPause` re-joins the topic with
+  // `{presence: false}` so the events stop crossing the socket; `onResume`
+  // re-joins without it AND rebuilds the members map. Both handlers reference
+  // `rejoinWithPresence`, declared further down: they only ever run from a
+  // cooldown timer or a selection change, long after this root has evaluated,
+  // and neither can fire during it (no channel is paused at boot).
+  const presencePause = createPresencePause(
+    {
+      onPause: (key) => {
+        rejoinWithPresence(key, false);
+      },
+      onResume: (key) => {
+        // Re-subscribe FIRST, then refetch. The other order races a JOIN landing
+        // between the two: the refetch would return a member list taken before
+        // it, and the event that would have corrected the list arrives while the
+        // socket is still suppressing. Subscribing first can only duplicate an
+        // apply, which the members store is idempotent under.
+        rejoinWithPresence(key, true);
+        const t = untrack(token);
+        if (!t) return;
+        // `decodeChannelKey` is nullable by contract; a key that cannot be
+        // decoded cannot be refetched, and inventing a slug would fetch the
+        // wrong channel. Leave the members map alone.
+        const decoded = decodeChannelKey(key);
+        if (decoded === null) return;
+        const { slug, name } = decoded;
+        // A refetch that throws must not take the handler down with it — the
+        // members map simply stays as it was until the next seed. `null` is the
+        // server's 204 (`:uninitialized`): joined but pre-NAMES, or not joined.
+        // Seeding `[]` there would blank a good list, which is exactly the
+        // distinction CP24 bucket E drew.
+        void listMembers(t, slug, name)
+          .then((members) => {
+            if (members !== null) seedMembers(key, members);
+          })
+          .catch((err: unknown) => {
+            console.warn("[subscribe] members refetch failed on resume", key, err);
+          });
+      },
+    },
+    PRESENCE_COOLDOWN_MS,
+  );
 
   // Selection IS focus, for the pause's purposes — deliberately NOT gated on
   // `isDocumentVisible()`. A backgrounded tab that comes back must not pay a
@@ -955,6 +981,78 @@ moduleRoot(() => {
     w.__cic_channelReady.add(key);
   };
 
+  // The one door a REAL IRC channel topic is joined through — the channels
+  // loop, the pending pre-subscribe loop, and #1769's pause/resume re-join
+  // all come here, so the join-ACK obligations (seed, backfill, ready seam)
+  // cannot be half-applied by one of them.
+  const joinRealChannel = (
+    userName: string,
+    slug: string,
+    name: string,
+    key: ChannelKey,
+    params: ChannelJoinParams,
+  ): void => {
+    const phx = joinChannel(
+      userName,
+      slug,
+      name,
+      (reply) => {
+        applyJoinReplyAndSeed(slug, name, reply);
+        // CP29 R-5: refresh on EVERY successful join (initial + every
+        // auto-rejoin). This is the ONLY refresh ordered after the
+        // subscription is live, so it is the one that closes the
+        // subscribe-vs-backfill gap (#1593); the socket-open sweep cannot.
+        // The per-key guard inside refreshScrollback keeps bursty rejoins
+        // off the wire concurrently and QUEUES the loser (never drops it);
+        // the resume-cursor heuristic keeps the fetch short.
+        //
+        // #1769 leans on this: a pause/resume re-join is a join like any
+        // other, so rows that landed while the topic was being swapped are
+        // backfilled here rather than by a second mechanism.
+        void refreshScrollback(slug, name);
+        // #79: this callback fires on the join ACK (subscribed), NOT the
+        // `joined.set(key, phx)` below which fires on join-ATTEMPT. Stamp
+        // the ready seam here so waitForChannelReady observes a live
+        // subscription, never a merely-issued join.
+        stampChannelReady(key);
+      },
+      params,
+    );
+    installChannelHandler(phx, slug, name, key, () => ownNickForSlug(slug));
+    joined.set(key, phx);
+  };
+
+  // #1769 — the pause/resume edge, server side. The param is read ONCE by
+  // `GrappaWeb.GrappaChannel.join/3`, so changing the answer means joining
+  // again; there is deliberately no verb to flip it in place (vjt ruled join
+  // params, and a verb would be a second way to say the same thing).
+  //
+  // Leave-then-join, in that order and both explicit. Phoenix closes the
+  // previous channel by itself on a duplicate join, but the stale
+  // `phx.on("event", …)` handler on the OLD Channel object would survive on
+  // this socket — the cic H2 leak, one extra handler per transition, which on
+  // a channel that pauses and resumes all day is unbounded.
+  //
+  // Called from a timer and from a selection effect, so `untrack`: this must
+  // never register `socketUserName` as a dependency of whatever reactive
+  // scope happens to be running when a cooldown expires.
+  const rejoinWithPresence = (key: ChannelKey, presence: boolean): void => {
+    untrack(() => {
+      // Not joined (parted, rotated, never seeded) — nothing to re-join, and
+      // joining here would resurrect a subscription the #200 own-part
+      // teardown deliberately dropped.
+      if (!joined.has(key)) return;
+      const userName = socketUserName();
+      if (!userName) return;
+      const decoded = decodeChannelKey(key);
+      if (decoded === null) return;
+      const { slug, name } = decoded;
+      joined.get(key)?.leave();
+      joined.delete(key);
+      joinRealChannel(userName, slug, name, key, { presence });
+    });
+  };
+
   // Channels loop — one join per real IRC channel in channelsBySlug.
   createEffect(() => {
     // Channel topics are addressed by the server's socket-side
@@ -980,24 +1078,7 @@ moduleRoot(() => {
       for (const ch of list) {
         const key = channelKey(slug, ch.name);
         if (joined.has(key)) continue;
-        const phx = joinChannel(name, slug, ch.name, (reply) => {
-          applyJoinReplyAndSeed(slug, ch.name, reply);
-          // CP29 R-5: refresh on EVERY successful join (initial + every
-          // auto-rejoin). This is the ONLY refresh ordered after the
-          // subscription is live, so it is the one that closes the
-          // subscribe-vs-backfill gap (#1593); the socket-open sweep cannot.
-          // The per-key guard inside refreshScrollback keeps bursty rejoins
-          // off the wire concurrently and QUEUES the loser (never drops it);
-          // the resume-cursor heuristic keeps the fetch short.
-          void refreshScrollback(slug, ch.name);
-          // #79: this callback fires on the join ACK (subscribed), NOT the
-          // `joined.set(key, phx)` below which fires on join-ATTEMPT. Stamp
-          // the ready seam here so waitForChannelReady observes a live
-          // subscription, never a merely-issued join.
-          stampChannelReady(key);
-        });
-        installChannelHandler(phx, slug, ch.name, key, () => ownNickForSlug(slug));
-        joined.set(key, phx);
+        joinRealChannel(name, slug, ch.name, key, { presence: true });
       }
     }
   });
@@ -1048,19 +1129,11 @@ moduleRoot(() => {
       if (joined.has(typedKey)) continue;
       const net = nets.find((n) => n.slug === slug) ?? null;
       if (net === null) continue;
-      const phx = joinChannel(name, slug, channelName, (reply) => {
-        applyJoinReplyAndSeed(slug, channelName, reply);
-        void refreshScrollback(slug, channelName);
-        // #79: the OTHER channel-topic join path (a mid-session /join goes
-        // pending → subscribed HERE → joined, at which point the
-        // channels-loop skips it via the `joined` guard and never fires its
-        // own ACK). Stamp the ready seam here too so waitForChannelReady
-        // works regardless of which loop owned the join. Uniform rule:
-        // every channel-topic join ACK stamps `__cic_channelReady`.
-        stampChannelReady(typedKey);
-      });
-      installChannelHandler(phx, slug, channelName, typedKey, () => ownNickForSlug(slug));
-      joined.set(typedKey, phx);
+      // Same door as the channels loop (`joinRealChannel`), so the #79 ready
+      // seam and the join-ACK backfill cannot drift between the two paths.
+      // `presence: true` — a window the operator just opened is by definition
+      // the one being looked at.
+      joinRealChannel(name, slug, channelName, typedKey, { presence: true });
     }
   });
 
@@ -1104,12 +1177,20 @@ moduleRoot(() => {
     if (pending) return pending;
     if (joined.has(key)) return Promise.resolve();
     const acked = new Promise<void>((resolve) => {
-      const phx = joinChannel(userName, slug, target, (reply) => {
-        applyJoinReplyAndSeed(slug, target, reply);
-        void refreshScrollback(slug, target);
-        stampQueryWindowReady(slug, target);
-        resolve();
-      });
+      // A query window is not a channel: no peer join/part/quit is broadcast
+      // on a DM topic, so the presence param would have nothing to suppress.
+      const phx = joinChannel(
+        userName,
+        slug,
+        target,
+        (reply) => {
+          applyJoinReplyAndSeed(slug, target, reply);
+          void refreshScrollback(slug, target);
+          stampQueryWindowReady(slug, target);
+          resolve();
+        },
+        {},
+      );
       installChannelHandler(phx, slug, target, key, () => ownNickForSlug(slug));
       joined.set(key, phx);
     });
@@ -1190,46 +1271,54 @@ moduleRoot(() => {
         dmListenerKeys.delete(net.slug);
       }
       if (joined.has(key)) continue;
-      const phx = joinChannel(userName, net.slug, ownNick, (reply) => {
-        applyJoinReplyAndSeed(net.slug, ownNick, reply);
-        // DM-listener topic refresh: fetches self-msgs only because
-        // the controller applies own-nick narrowing when channel ==
-        // own_nick (CP14-B3 rule). Inbound peer DMs persist with
-        // channel=ownNick AND dm_with=peer; the narrowing filters
-        // them out from this fetch by intent (the own-nick query
-        // window display would otherwise leak every peer's DMs in).
-        // Recovery for inbound peer DMs goes through each open
-        // per-peer query window's own refresh — that subscription's
-        // rejoin uses the (slug, peer) cursor and the bidirectional
-        // DM fetch shape returns BOTH directions. First-contact DMs
-        // that arrive during the gap (no per-peer subscription
-        // existed yet) are not recovered by this design — deferred
-        // edge case, documented here for traceability.
-        void refreshScrollback(net.slug, ownNick);
-        // UX-6-L e2e seam: stamp the per-slug DM-listener ready set
-        // on window after a successful phx.join() ack. Playwright
-        // polls `__cic_dmListenerReady?.has(slug)` to await the
-        // subscription before driving a peer DM — eliminates the
-        // peer-arrives-before-cic-subscribed race (silent broadcast
-        // drop) that flaked the ux-6-l e2e ~20% in suite. Production
-        // never reads the property; same seam shape as
-        // `socket.ts:__cic_dropSocketForTests`. The query-window loop
-        // has the SAME no-pre-event-DOM-signal gap (its outbound-echo
-        // topic, no self-JOIN line) and carries its own
-        // `__cic_queryWindowReady` seam (above); the real-channels loop
-        // carries `__cic_channelReady` (stampChannelReady, above) since
-        // #79 — the self-JOIN scrollback line is NOT a reliable pre-event
-        // signal (it is a boot-persisted row served by the initial REST
-        // /messages page, so it renders before the channel `phx.join()`
-        // ACKs; the own-echo then fastlanes past the not-yet-subscribed
-        // socket and the row never appears). The $server synthetic window
-        // is read-only (no compose-then-echo flow) so it needs no seam.
-        if (typeof window !== "undefined") {
-          const w = window as Window & { __cic_dmListenerReady?: Set<string> };
-          if (!w.__cic_dmListenerReady) w.__cic_dmListenerReady = new Set();
-          w.__cic_dmListenerReady.add(net.slug);
-        }
-      });
+      // The own-nick DM-listener topic carries inbound DMs, never peer
+      // presence — nothing for `{presence: false}` to suppress.
+      const phx = joinChannel(
+        userName,
+        net.slug,
+        ownNick,
+        (reply) => {
+          applyJoinReplyAndSeed(net.slug, ownNick, reply);
+          // DM-listener topic refresh: fetches self-msgs only because
+          // the controller applies own-nick narrowing when channel ==
+          // own_nick (CP14-B3 rule). Inbound peer DMs persist with
+          // channel=ownNick AND dm_with=peer; the narrowing filters
+          // them out from this fetch by intent (the own-nick query
+          // window display would otherwise leak every peer's DMs in).
+          // Recovery for inbound peer DMs goes through each open
+          // per-peer query window's own refresh — that subscription's
+          // rejoin uses the (slug, peer) cursor and the bidirectional
+          // DM fetch shape returns BOTH directions. First-contact DMs
+          // that arrive during the gap (no per-peer subscription
+          // existed yet) are not recovered by this design — deferred
+          // edge case, documented here for traceability.
+          void refreshScrollback(net.slug, ownNick);
+          // UX-6-L e2e seam: stamp the per-slug DM-listener ready set
+          // on window after a successful phx.join() ack. Playwright
+          // polls `__cic_dmListenerReady?.has(slug)` to await the
+          // subscription before driving a peer DM — eliminates the
+          // peer-arrives-before-cic-subscribed race (silent broadcast
+          // drop) that flaked the ux-6-l e2e ~20% in suite. Production
+          // never reads the property; same seam shape as
+          // `socket.ts:__cic_dropSocketForTests`. The query-window loop
+          // has the SAME no-pre-event-DOM-signal gap (its outbound-echo
+          // topic, no self-JOIN line) and carries its own
+          // `__cic_queryWindowReady` seam (above); the real-channels loop
+          // carries `__cic_channelReady` (stampChannelReady, above) since
+          // #79 — the self-JOIN scrollback line is NOT a reliable pre-event
+          // signal (it is a boot-persisted row served by the initial REST
+          // /messages page, so it renders before the channel `phx.join()`
+          // ACKs; the own-echo then fastlanes past the not-yet-subscribed
+          // socket and the row never appears). The $server synthetic window
+          // is read-only (no compose-then-echo flow) so it needs no seam.
+          if (typeof window !== "undefined") {
+            const w = window as Window & { __cic_dmListenerReady?: Set<string> };
+            if (!w.__cic_dmListenerReady) w.__cic_dmListenerReady = new Set();
+            w.__cic_dmListenerReady.add(net.slug);
+          }
+        },
+        {},
+      );
       installDmListenerHandler(phx, net.slug, net.id, ownNick);
       joined.set(key, phx);
       dmListenerKeys.set(net.slug, key);
@@ -1257,10 +1346,18 @@ moduleRoot(() => {
     for (const net of nets) {
       const key = channelKey(net.slug, SERVER_WINDOW_NAME);
       if (joined.has(key)) continue;
-      const phx = joinChannel(userName, net.slug, SERVER_WINDOW_NAME, (reply) => {
-        applyJoinReplyAndSeed(net.slug, SERVER_WINDOW_NAME, reply);
-        void refreshScrollback(net.slug, SERVER_WINDOW_NAME);
-      });
+      // The synthetic $server window carries MOTD and server NOTICEs; no
+      // peer presence is ever broadcast on it, so there is nothing to pause.
+      const phx = joinChannel(
+        userName,
+        net.slug,
+        SERVER_WINDOW_NAME,
+        (reply) => {
+          applyJoinReplyAndSeed(net.slug, SERVER_WINDOW_NAME, reply);
+          void refreshScrollback(net.slug, SERVER_WINDOW_NAME);
+        },
+        {},
+      );
       installChannelHandler(phx, net.slug, SERVER_WINDOW_NAME, key, () => null);
       joined.set(key, phx);
     }

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -319,6 +319,49 @@ The event is pushed on both the live edge and the user-topic cold snapshot,
 so a reload re-learns the verdict; the REST twin is the `registered` field
 of `GET /networks`' `connection` object.
 
+### 4a. Muting peer presence on a channel you are not reading (#1769)
+
+A per-channel topic accepts ONE join param. Join with
+
+```json
+{"presence": false}
+```
+
+and the server stops pushing you `join`, `part` and `quit` rows for that
+channel — the three whose only consumer is the member list. Everything else
+on that topic is delivered exactly as before: messages, `window_counts`, the
+read cursor, topic and mode changes, and the cold-subscribe snapshots.
+
+**You do not have to do anything.** Omit the param and you get everything, as
+you do today. Only the literal `false` suppresses — `true`, a string, or a
+misspelled key all mean the default — so a server that predates this reads
+your params and ignores them, and a client that never learns about them is
+unaffected. That is why this is a join param and not a negotiated capability:
+there is no flag day and nothing to coordinate.
+
+Three things are NEVER suppressed, and they are the reason the drop set is
+three kinds rather than five:
+
+* **`nick_change`** — you need it to migrate anything keyed by a nick
+  (scrollback, read cursors, an open query window). Miss one and your caches
+  point at a nick nobody holds, silently.
+* **`mode`** — channel-mode state outlives the pause.
+* **your OWN `join`/`part`/`quit`** — an own PART is how you learn the window
+  is gone. The server matches your live nick with the same ASCII fold it uses
+  everywhere else and follows it across a rename.
+
+The intended use is a window the operator has stopped looking at: leave the
+topic joined (leaving it would make the window blind, not quiet — it carries
+the messages too), re-join with `{"presence": false}` when the window goes
+cold, and re-join without the param when it comes back. **Re-join, plural:
+the param is read once, at join.** Changing your mind means joining the topic
+again — Phoenix closes the previous channel for you — and the events that
+arrive between the two joins are not replayed, so refetch the member list on
+resume and backfill messages from your last known id.
+
+Check `protocol_version >= 7` before relying on it. An older server will
+accept the join and quietly send you everything.
+
 ---
 
 ## 5. Wire format

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -64172,3 +64172,138 @@ for artwork any more, so they can never fire — and a stub that cannot fire is
 worse than absent, because it would absorb a real regression in silence
 instead of letting it fail. One spec keeps the watch and makes it loud:
 `issue682` ABORTS the request and asserts the count is zero.
+<!-- entry #1769 -->
+
+---
+
+## 2026-08-25 — #1769: the choke point the issue named cannot see the traffic
+
+#1680 shipped the presence pause at cic's dispatch edge: a channel nobody has
+looked at for two minutes stops APPLYING peer join/part/quit. The events still
+cross the socket, still get decoded, still wake the main thread. This is the
+server half — a join param that stops them being sent — and three of its four
+interesting decisions came out of measuring something the issue asserted.
+
+### The choke point named in the issue is unreachable for this traffic
+
+The issue pointed at `handle_info(%Phoenix.Socket.Broadcast{})`
+(`grappa_channel.ex:474`) as "one choke point that already exists". It is not
+one for per-channel traffic, and the module says so in its own moduledoc
+twenty lines earlier: the framework installs a FASTLANE subscription on a
+channel's own topic, so `Grappa.PubSub.broadcast_event/2` is encoded once by
+the dispatcher and written straight to the transport. That clause only ever
+serves #1088's foreign socket topic, which carries no fastlane. Confirmed in
+Phoenix's own dispatcher (`phoenix/channel/server.ex:93-118`).
+
+### Why not `intercept`, which is the idiom
+
+`Phoenix.Channel.intercept/1` compiles to `__intercepts__/0`, and
+`init_join/3` copies that list into EVERY socket's fastlane metadata. It is a
+per-MODULE, all-sockets switch. Declaring it would route every `"event"`
+broadcast on every topic for every client through a channel process: one extra
+`send` and a per-socket `encode!` in place of one cached encode — small, but a
+regression on the DEFAULT path of a performance issue, paid by clients that
+never asked. The larger objection is the mailbox. With the fastlane, a channel
+process is immune to a broadcast flood; with `intercept`, every channel
+process becomes a relay for it, during exactly the netsplit bursts this work
+exists to survive (#1715, #1739).
+
+The way out is that the intercept list lives in the SUBSCRIPTION METADATA, not
+in a global. A per-socket answer is expressible: a suppressing socket trades
+its fastlane for a plain subscription, and Phoenix then routes a `%Broadcast{}`
+whose topic equals the socket's own to `handle_out/3`. Everyone else's path is
+not "equivalent" — it is untouched.
+
+Two consequences, both stated in the code rather than discovered later.
+`handle_out/3` is defined with a VARIABLE head and no `intercept` declaration;
+Phoenix's `__on_definition__` warning fires only on a literal head, i.e. only
+for the case where the declaration really would be missing. And the swap runs
+in `:after_join`, because `join/3` returns BEFORE the framework subscribes —
+so there is a window of microseconds where a presence frame still fastlanes
+past. cic's dispatch-edge drop is what makes that harmless, which is one of
+the two reasons #1680's client-side drop is KEPT rather than replaced. The
+other is an older server, which reads the param and ignores it.
+
+### Own presence, and a cache that follows a rename
+
+Dropping our OWN part would strand a dead window (an own PART is what tears it
+down client-side), so the filter needs the live nick. Reading it per event is a
+GenServer call on the hot path — the load being shed. So it is resolved once at
+join and then FOLLOWS a rename, off the `nick_change` row that the carve-out
+already guarantees delivery of. Piggybacking on that carve-out rather than
+adding a second source of truth is the whole point: the event that must not be
+dropped is exactly the event that says the identity moved.
+
+With no live session the cache is `nil` and nothing matches, so the failure
+direction is DELIVERING presence rather than dropping our own. The fold is
+`Identifier.canonical_target/1`, the same compare `Push.Triggers.own_row?/2`
+uses. Known gap, taken deliberately: an rfc1459 national-char nick echoed in
+the other spelling would not fold together, because closing it costs a second
+`Session.casemapping/2` call on the join path. Same carve-out CLAUDE.md
+already records for `dm_with` and the members map.
+
+### The wire pin was silent, and this time no widening would fix it
+
+`mix grappa.wire_pin --check` answered `wire shape and protocol 6 agree.` with
+the channel change already applied. Third recorded instance of that gap —
+#1679 (`BootJSON`), #1766 (`UserSettingsJSON`), now a channel callback — and
+the FIRST where the un-covered surface is INBOUND. Worth separating from the
+other two: widening the outbound codegen digest, which is the fix those notes
+gesture at, would not have caught this at any width. The bump to 7 is the rule
+(#1393d), not the gate. Filed as #1787.
+
+### The client half re-joins, and that changed what a ruling test asserts
+
+The param is read once, at join, so changing the answer is a re-join. #1680's
+`presenceCooldown.ts` had already anticipated needing this: it holds its
+terminal action behind an injected callback precisely because what "paused"
+DOES was the contested part.
+
+The consequence is a short window with no live delivery on that topic. Nothing
+is lost — every channel join already runs `refreshScrollback` on its ACK, the
+same mechanism every reconnect relies on — but it is a real cost of the ruled
+shape and it is not hidden. It also invalidated an existing oracle.
+`"still delivers MESSAGES on a paused channel — quiet, not blind"` asserted
+that `phx.leave()` is never called, the executable form of vjt's "messages
+must not be lost". A re-join calls leave, so that assertion would now forbid
+the correct implementation. It was replaced by a STRICTER one — the topic is
+joined AGAIN, with `{presence: false}` — which names the end state instead of
+forbidding one gesture that could reach a bad one.
+
+### Two of our own oracles were wrong, in different ways
+
+**`Process.send_after(self(), …, 0)` is a TIMER, not a `send`.** A synchronous
+call to the channel does NOT queue behind it: the timer service can enqueue
+the message after a call made later in wall-clock time. A barrier built on
+`:sys.get_state/1` therefore passed early on some seeds, and the symptom read
+as a product bug — fastlane frames (`join_ref: nil`) reaching a socket that
+had asked for suppression. The cure was to poll the framework's own
+bookkeeping (the PubSub registry) for the state the arms actually depend on.
+
+**A barrier that waits for the state you START in is not a barrier.** The
+`:plain` subscription is a state the join must REACH; `:fastlane` is what
+`init_join/3` installs before `join/3` returns. Polling for the latter is
+satisfied instantly. Measured: two mutants that made the param bite on the
+user topic both survived 13/13. The fix pins the DECISION — the assign, set
+synchronously inside `join/3` — instead of racing the effect. Both die now.
+
+Seven one-axis mutants, all killed deterministically. The `join_ref` split is
+what makes the BUG 6 arm timing-free: a fastlane frame carries `join_ref: nil`
+and a `push/3` frame carries the integer (the same distinction the V2
+serializer puts in element 0 on the real wire), and the dispatcher writes the
+fastlane copy synchronously inside `broadcast_event/2`, so a duplicate is
+already AHEAD of the push copy in the mailbox. Assert on the FIRST matching
+frame and there is no window at all.
+
+### Not measured
+
+The delivered event rate for a paused channel, before and after, on a real
+socket under real load. The issue asks for it and this work does not supply
+it: the e2e proves the frames are ABSENT, which is the qualitative claim, but
+no rate was taken — `origin/main` is undeployed by standing decision and the
+jail is unreachable from here. The `intercept` alternative's cost is likewise
+reasoned from Phoenix's dispatcher source (sends and encodes counted), not
+benchmarked. And nothing here establishes that a paused window is CHEAPER end
+to end once the pause/resume re-join, its join reply and its REST backfill are
+counted against the ~24.4 events/s it stops paying for; that trade is argued,
+not measured.

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -124,10 +124,30 @@ defmodule Grappa.Protocol do
   # cannot tell from a shape change (its moduledoc: delete and re-create, no
   # `--force`), so it is not smuggled in alongside a product change.
   #
+  # v7 (#1769) adds an INBOUND shape rather than an outbound one: the
+  # per-channel topic now reads a join param, `%{"presence" => false}`, and a
+  # socket that sends it stops being pushed peer join/part/quit. Additive in
+  # both directions — only the literal `false` suppresses, so a client that
+  # joins the way it joins today receives what it receives today — and it
+  # bumps for the #1393d reason all the same: the break it expresses runs
+  # new-client → old-server. A cic that has come to rely on the pause will
+  # ask an old server for it, be silently served the full flood, and have no
+  # way to know except this number.
+  #
+  # ⚠️ `mix grappa.wire_pin --check` was SILENT here too — measured, with the
+  # channel change already applied it answered `wire shape and protocol 6
+  # agree.` It could not have done otherwise: the digest spans the codegen
+  # artefacts, and a join param read in `GrappaWeb.GrappaChannel.join/3` is
+  # in no `*wire.ex` and on no `@extra_modules` list. Third recorded instance
+  # of the same detector gap (#1679 `BootJSON`, #1766 `UserSettingsJSON`,
+  # this one a channel callback), and the first where the un-covered surface
+  # is INBOUND — which no widening of the outbound codegen digest would ever
+  # reach. Filed as #1787. The bump here is the RULE, not the gate.
+  #
   # @min_protocol_version is NOT the same axis and stays at 1: it rises only
   # when old clients can no longer be SERVED, and every client that spoke v1
-  # is still served — v1 clients tolerate what v6 clients require.
-  @protocol_version 6
+  # is still served — v1 clients tolerate what v7 clients require.
+  @protocol_version 7
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -138,7 +158,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 6
+  @spec version() :: 7
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/scrollback/message.ex
+++ b/lib/grappa/scrollback/message.ex
@@ -196,6 +196,19 @@ defmodule Grappa.Scrollback.Message do
   # never drop a real message.
   @suppressed_presence_kinds [:join, :part, :quit, :nick_change, :mode]
 
+  # #1769 — the subset a socket that ASKED for the #1680 presence pause may be
+  # denied outright. A strict subset of @suppressed_presence_kinds and NOT
+  # derived from it, because the two answer different questions: that one is
+  # "is this presence?" (what the history fetch omits), this one is "is this
+  # presence we can afford never to receive?". A kind landing in the
+  # suppressed set must be considered HERE on purpose rather than inherited
+  # silently — `nick_change` drives the #372/#373 identity migration and
+  # `mode` feeds channel-mode state, so both stay deliverable even to a paused
+  # window. Mirrors cic's PAUSABLE_PRESENCE_KINDS
+  # (cicchetto/src/lib/presencePause.ts), same order; the subset relation and
+  # the cross-language agreement are both gated by `presence_filter_test.exs`.
+  @pausable_presence_kinds [:join, :part, :quit]
+
   # M8 fix 2026-05-08: kinds for which `:dm_with` may legitimately
   # carry a peer nick. CP23 cluster `code-reload` extended the list to
   # include :notice — peer-to-peer NOTICEs (CTCP-VERSION-query
@@ -276,6 +289,30 @@ defmodule Grappa.Scrollback.Message do
   """
   @spec suppressed_presence_kinds() :: [:join | :part | :quit | :nick_change | :mode, ...]
   def suppressed_presence_kinds, do: @suppressed_presence_kinds
+
+  @doc """
+  Returns the droppable subset of `suppressed_presence_kinds/0` —
+  `[:join, :part, :quit]`. #1769 SINGLE SOURCE: the kinds
+  `GrappaWeb.GrappaChannel` refuses to push to a socket that joined a
+  per-channel topic with `presence: false`, the server half of #1680's
+  pause.
+
+  The two presence sets are deliberately distinct rather than one derived
+  from the other. `suppressed_presence_kinds/0` answers "is this presence?"
+  and governs what the HISTORY fetch omits — a row the operator can always
+  scroll back to. This one answers "is this presence the client can afford
+  never to be told about?", and a kind that says no has a consumer that
+  breaks silently without it: `nick_change` drives the #372/#373 client-side
+  identity migration, `mode` feeds channel-mode state that outlives the
+  pause. Their only consumer being the members map is what makes
+  join/part/quit safe to drop — the refetch on resume rebuilds exactly that.
+
+  Mirrors cic's `PAUSABLE_PRESENCE_KINDS`
+  (`cicchetto/src/lib/presencePause.ts`), same order; `presence_filter_test.exs`
+  gates both the subset relation and the cross-language agreement.
+  """
+  @spec pausable_presence_kinds() :: [:join | :part | :quit, ...]
+  def pausable_presence_kinds, do: @pausable_presence_kinds
 
   @type kind ::
           :privmsg

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -193,6 +193,7 @@ defmodule GrappaWeb.GrappaChannel do
   alias Grappa.Networks.Network
   alias Grappa.PresenceFilter.Resolver
   alias Grappa.PubSub.Topic
+  alias Grappa.Scrollback.Message, as: ScrollbackMessage
   alias Grappa.Scrollback.Wire, as: ScrollbackWire
   alias Grappa.ServerSettings
   alias Grappa.ServerSettings.Wire, as: ServerSettingsWire
@@ -238,7 +239,7 @@ defmodule GrappaWeb.GrappaChannel do
   @type window_state_snapshot_payload :: Session.window_state_snapshot()
 
   @impl Phoenix.Channel
-  def join(topic, _, socket) do
+  def join(topic, params, socket) do
     with {:ok, parsed} <- Topic.parse(topic),
          :ok <- authorize(parsed, socket) do
       # `authorize/2` runs on the PARSED topic, before `canonicalize_topic/1`:
@@ -248,6 +249,11 @@ defmodule GrappaWeb.GrappaChannel do
       # do work on behalf of the user named in the topic — see the authz test
       # in `GrappaWeb.GrappaChannelTest`.
       parsed = canonicalize_topic(parsed)
+
+      # #1769 — the ONLY join param this channel reads. Resolved here so the
+      # after-join leg (which swaps the fastlane) and `handle_out/3` (which
+      # filters) both read one decided assign rather than re-parsing params.
+      socket = assign_presence_suppression(parsed, params, socket)
 
       # NO manual `Phoenix.PubSub.subscribe/2` on THIS channel's own topic —
       # the framework's fastlane subscription (installed by
@@ -261,6 +267,95 @@ defmodule GrappaWeb.GrappaChannel do
       {:error, :forbidden} -> {:error, %{error: "forbidden"}}
     end
   end
+
+  # #1769 — the server half of #1680's presence pause. cic joins a per-channel
+  # topic with `%{"presence" => false}` for a window it has stopped watching;
+  # this decides, ONCE per join, whether that socket is a suppressing one and
+  # caches the identity the own-presence carve-out needs.
+  #
+  # ONLY `false` suppresses. An absent key, `true`, a string, or anything else
+  # is the DEFAULT — everything — because the compatibility guarantee is the
+  # whole reason the shape is join params: a client that joins the way it
+  # joins today receives what it receives today, by construction, so
+  # third-party clients need no coordination (vjt, 2026-08-25). That also
+  # makes the param unknown-is-never-fatal in the client→server direction.
+  #
+  # Presence only ever travels a per-channel topic, so the user- and
+  # network-level clauses ignore the param outright rather than carrying a
+  # flag that could never fire.
+  @spec assign_presence_suppression(Topic.parsed(), map(), Phoenix.Socket.t()) ::
+          Phoenix.Socket.t()
+  defp assign_presence_suppression({:channel, user_name, network_slug, _channel}, params, socket)
+       when is_map(params) do
+    case params do
+      %{"presence" => false} ->
+        socket
+        |> assign(:presence_suppressed, true)
+        |> assign(:presence_own_nick, own_nick_or_nil(user_name, network_slug))
+
+      _ ->
+        assign(socket, :presence_suppressed, false)
+    end
+  end
+
+  defp assign_presence_suppression(_, _, socket), do: assign(socket, :presence_suppressed, false)
+
+  # The own nick at join time, or `nil` when there is no live session to ask
+  # (a cold socket on a parked network). `nil` never matches a sender, so the
+  # carve-out degrades toward DELIVERING presence rather than dropping it —
+  # the safe direction, since a dropped own PART strands a dead window while a
+  # delivered peer JOIN only costs a frame.
+  @spec own_nick_or_nil(String.t(), String.t()) :: String.t() | nil
+  defp own_nick_or_nil(user_name, network_slug) do
+    with {:ok, subject} <- resolve_subject(user_name),
+         {:ok, %Network{} = network} <- Networks.get_network_by_slug(network_slug),
+         {:ok, nick} <- Session.current_nick(subject, network.id) do
+      nick
+    else
+      _ -> nil
+    end
+  end
+
+  # #1769 — trade this socket's fastlane subscription for a plain one, so its
+  # broadcasts arrive as `%Phoenix.Socket.Broadcast{}` structs the channel
+  # process can filter, instead of being encoded once and written straight to
+  # the transport.
+  #
+  # WHY NOT `intercept ["event"]`, THE OBVIOUS PHOENIX IDIOM
+  #
+  # `Phoenix.Channel.intercept/1` compiles to `__intercepts__/0`, a
+  # per-MODULE, all-sockets switch: `Phoenix.Channel.Server.init_join/3`
+  # copies it into EVERY socket's fastlane metadata. Declaring it here would
+  # route every "event" broadcast — on every topic, for every client — through
+  # the channel process, which is a regression on the default path of a
+  # PERF issue and hands each channel process the whole flood in its mailbox
+  # during exactly the netsplit bursts this work exists to survive. Measured
+  # in Phoenix's own dispatcher (`channel/server.ex:93-118`): the fastlane
+  # branch does one `send` of a once-encoded frame, the intercept branch does
+  # a `send` to the channel plus a per-socket `encode!`.
+  #
+  # The intercept list lives in the SUBSCRIPTION METADATA, not in a global, so
+  # a per-socket answer is expressible: drop the metadata and this pid becomes
+  # an ordinary subscriber. `Registry.unregister/2` (what
+  # `Phoenix.PubSub.unsubscribe/2` calls) removes ALL of this pid's entries for
+  # the key, so the pair below leaves exactly ONE subscription — it does not
+  # reintroduce BUG 6, which was a manual subscription ADDED alongside the
+  # fastlane. `grappa_channel_presence_params_test.exs` pins that with an
+  # exactly-once assertion on a message.
+  #
+  # Run from `:after_join` because `join/3` returns BEFORE the framework
+  # subscribes (`Phoenix.Channel.Server.channel_join/4` calls `init_join/3` on
+  # the way out), so there is nothing to unsubscribe from yet. The gap between
+  # the two is the few microseconds it takes the channel to return and read its
+  # mailbox; a presence frame landing inside it is delivered, and cic's
+  # dispatch-edge drop (`presencePause.ts`) is what makes that harmless.
+  @spec drop_fastlane_if_suppressing(Phoenix.Socket.t()) :: :ok
+  defp drop_fastlane_if_suppressing(%{assigns: %{presence_suppressed: true}, topic: topic}) do
+    :ok = Phoenix.PubSub.unsubscribe(Grappa.PubSub, topic)
+    :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
+  end
+
+  defp drop_fastlane_if_suppressing(_), do: :ok
 
   # #1088 — addressed delivery. This IS a manual `Phoenix.PubSub.subscribe/2`
   # and it does NOT reintroduce BUG 6: the doubled push happened because a
@@ -452,6 +547,10 @@ defmodule GrappaWeb.GrappaChannel do
   end
 
   def handle_info({:after_join, {:channel, user_name, network_slug, channel}}, socket) do
+    # #1769 — FIRST, before the snapshot's DB + session round-trips: every
+    # millisecond spent here is a millisecond of presence still fastlaning
+    # past a socket that asked not to see it.
+    :ok = drop_fastlane_if_suppressing(socket)
     push_channel_snapshot(user_name, network_slug, channel, socket)
     {:noreply, socket}
   end
@@ -475,6 +574,104 @@ defmodule GrappaWeb.GrappaChannel do
     push(socket, event, payload)
     {:noreply, socket}
   end
+
+  # #1769 — the per-channel filter. Reached ONLY by a socket that joined with
+  # `presence: false`: `drop_fastlane_if_suppressing/1` traded that socket's
+  # fastlane for a plain subscription, and Phoenix routes a `%Broadcast{}`
+  # whose topic equals the socket's own topic to `handle_out/3` rather than to
+  # `handle_info/2` (`Phoenix.Channel.Server.handle_info/2`). Every other
+  # socket never gets here — its frames are still encoded once by the
+  # dispatcher and written straight to the transport, byte-for-byte as before.
+  #
+  # No `intercept/1` declaration accompanies this, deliberately, and the head
+  # is a VARIABLE rather than the `"event"` literal: `intercept` is the
+  # per-module all-sockets switch this design exists to avoid (see
+  # `drop_fastlane_if_suppressing/1`), and Phoenix's `__on_definition__` warning
+  # fires only on a literal head — i.e. only for the case where the declaration
+  # really would be missing. Stating it here rather than dodging it quietly.
+  #
+  # The `handle_out/3` contract is push-or-drop only: it must never mutate
+  # anything a consumer reads as state, because a NON-suppressing socket does
+  # not run it at all and would silently diverge.
+  @impl Phoenix.Channel
+  def handle_out(event, payload, socket) do
+    socket = track_own_nick(payload, socket)
+
+    if drop_presence?(payload, socket) do
+      {:noreply, socket}
+    else
+      push(socket, event, payload)
+      {:noreply, socket}
+    end
+  end
+
+  # Is this frame peer presence a paused window can afford never to be told
+  # about? Three conjuncts, and every one of them is load-bearing:
+  #
+  #   1. The socket ASKED (`presence_suppressed`) — nothing is ever dropped
+  #      from a client that did not opt in.
+  #   2. The kind is in `Message.pausable_presence_kinds/0`, the strict
+  #      subset whose only consumer is the members map. `nick_change` and
+  #      `mode` are OUT of that set on purpose (#372/#373 identity migration
+  #      and channel-mode state), which is why this reads the pausable list
+  #      and not `suppressed_presence_kinds/0`.
+  #   3. The row is not OURS. An own PART tears the window down client-side,
+  #      so dropping it would leak a subscription and strand a dead window —
+  #      cic's `presencePause.shouldDrop/3` carves out the same case with
+  #      `isOwnNick`, and this is its server twin.
+  #
+  # The identity test is `Identifier.canonical_target/1` on both sides, the
+  # same folded compare `Push.Triggers.own_row?/2` uses (#121/#532 C). Known
+  # gap, deliberate: on an rfc1459 network a national-char nick echoed in the
+  # other spelling would not fold together here, because that would cost a
+  # second `Session.casemapping/2` GenServer call on the join path. It is the
+  # same rfc1459-only carve-out CLAUDE.md already records for `dm_with` and
+  # the members map, and it fails toward DELIVERING.
+  @spec drop_presence?(map(), Phoenix.Socket.t()) :: boolean()
+  defp drop_presence?(payload, socket) do
+    suppressing?(socket) and pausable_peer_presence?(payload, socket.assigns[:presence_own_nick])
+  end
+
+  defp suppressing?(socket), do: socket.assigns[:presence_suppressed] == true
+
+  defp pausable_peer_presence?(%{kind: :message, message: %{kind: kind, sender: sender}}, own_nick)
+       when is_binary(sender) do
+    kind in ScrollbackMessage.pausable_presence_kinds() and not own?(sender, own_nick)
+  end
+
+  defp pausable_peer_presence?(_, _), do: false
+
+  defp own?(_sender, nil), do: false
+
+  defp own?(sender, own_nick) when is_binary(own_nick),
+    do: Identifier.canonical_target(sender) == Identifier.canonical_target(own_nick)
+
+  # The cached own nick has to survive a rename or the carve-out above starts
+  # matching a nick nobody holds, and the very next own PART is dropped. The
+  # signal is the `nick_change` row itself — which is NOT in the pausable set,
+  # so a suppressing socket is guaranteed to see it (that carve-out was taken
+  # for cic's #372/#373 migration; the server piggybacks on it rather than
+  # adding a second source of truth).
+  #
+  # Only OUR rename moves the cache: a peer's `nick_change` carries the peer's
+  # old nick as `sender` and folds against a different identity.
+  @spec track_own_nick(map(), Phoenix.Socket.t()) :: Phoenix.Socket.t()
+  defp track_own_nick(
+         %{kind: :message, message: %{kind: :nick_change, sender: sender, meta: meta}},
+         socket
+       )
+       when is_binary(sender) do
+    new_nick = meta[:new_nick]
+
+    if is_binary(new_nick) and suppressing?(socket) and
+         own?(sender, socket.assigns[:presence_own_nick]) do
+      assign(socket, :presence_own_nick, new_nick)
+    else
+      socket
+    end
+  end
+
+  defp track_own_nick(_, socket), do: socket
 
   # GH #630 — the SINGLE inbound choke point for this channel. Phoenix
   # offers no pre-dispatch hook, so EVERY inbound WS frame enters through

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -285,7 +285,7 @@ defmodule GrappaWeb.GrappaChannel do
   # flag that could never fire.
   @spec assign_presence_suppression(Topic.parsed(), map(), Phoenix.Socket.t()) ::
           Phoenix.Socket.t()
-  defp assign_presence_suppression({:channel, user_name, network_slug, _channel}, params, socket)
+  defp assign_presence_suppression({:channel, user_name, network_slug, _}, params, socket)
        when is_map(params) do
     case params do
       %{"presence" => false} ->
@@ -641,7 +641,7 @@ defmodule GrappaWeb.GrappaChannel do
 
   defp pausable_peer_presence?(_, _), do: false
 
-  defp own?(_sender, nil), do: false
+  defp own?(_, nil), do: false
 
   defp own?(sender, own_nick) when is_binary(own_nick),
     do: Identifier.canonical_target(sender) == Identifier.canonical_target(own_nick)

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 6
+protocol_version = 7
 shape_digest = sha256:516f5f58171ad5c5697be017b62c170f761990f3b78bb371b1873e8a4d6ed945

--- a/test/grappa/presence_filter_test.exs
+++ b/test/grappa/presence_filter_test.exs
@@ -135,4 +135,92 @@ defmodule Grappa.PresenceFilterTest do
              """
     end
   end
+
+  # #1769 — the PAUSABLE set is a second cross-language pair, and it fails
+  # differently from the one above. The suppressed set governs what the
+  # history fetch OMITS (a row the operator can still scroll to); this one
+  # governs what the socket is never SENT. A kind that drifts INTO it on one
+  # side alone is a frame the client is entitled to and never receives, with
+  # no page-up that recovers it — which is exactly the `nick_change` /`mode`
+  # case, whose consumers (#372/#373 identity migration, channel-mode state)
+  # break silently rather than loudly.
+  describe "cross-language pausable-presence parity (#1769)" do
+    @pause_path "cicchetto/src/lib/presencePause.ts"
+
+    test "pausable_presence_kinds/0 is a STRICT subset of suppressed_presence_kinds/0" do
+      pausable = Message.pausable_presence_kinds()
+      suppressed = Message.suppressed_presence_kinds()
+
+      assert pausable -- suppressed == [],
+             """
+             `pausable_presence_kinds/0` contains a kind that is not presence at all:
+
+               pausable:   #{inspect(pausable)}
+               suppressed: #{inspect(suppressed)}
+
+             The pausable set answers "is this presence we can afford to miss?",
+             so every member must first BE presence. A kind outside the
+             suppressed set landing here means the socket is dropping something
+             that is not presence noise.
+             """
+
+      refute suppressed -- pausable == [],
+             """
+             `pausable_presence_kinds/0` has grown to cover the WHOLE presence set.
+
+             The carve-out is the point: `nick_change` drives the #372/#373
+             identity migration and `mode` feeds channel-mode state, and neither
+             has a refetch that rebuilds it on resume. If the sets are now equal
+             this assertion is the only thing left saying so — decide it on
+             purpose, in `Message`, and change this test with the reason.
+             """
+    end
+
+    test "pausable_presence_kinds/0 equals cic's PAUSABLE_PRESENCE_KINDS, in order" do
+      source = File.read!(@pause_path)
+
+      body =
+        case Regex.run(
+               ~r/export\s+const\s+PAUSABLE_PRESENCE_KINDS[^=]*=\s*new\s+Set\(\[(.*?)\]\)/s,
+               source
+             ) do
+          [_, captured] ->
+            captured
+
+          _ ->
+            flunk("Could not locate `export const PAUSABLE_PRESENCE_KINDS = new Set([...])` in #{@pause_path}")
+        end
+
+      cic_kinds =
+        ~r/"([a-z_]+)"/
+        |> Regex.scan(body)
+        |> Enum.map(fn [_, kind] -> String.to_atom(kind) end)
+
+      # Same positive control as the sibling gate above: a parse that yields
+      # nothing must fail as "the gate stopped reading", not as a puzzling
+      # empty-list mismatch.
+      refute cic_kinds == [],
+             """
+             Parsed ZERO kinds out of #{@pause_path}.
+
+             The literal was located but no `"kind"` strings came out of it, so
+             this parity gate is no longer reading anything. Fix the parse, not
+             the assertion.
+             """
+
+      assert cic_kinds == Message.pausable_presence_kinds(),
+             """
+             The pausable KIND SET has drifted between the two languages.
+
+               #{@pause_path}: #{inspect(cic_kinds)}
+               Grappa.Scrollback.Message:       #{inspect(Message.pausable_presence_kinds())}
+
+             cic drops these at its dispatch edge (#1680) and the server refuses
+             to push them to a socket that joined with `presence: false` (#1769).
+             A kind present only server-side is one the client will never see and
+             cannot recover; a kind present only client-side merely wastes a
+             frame. Both are drift. Move BOTH or neither.
+             """
+    end
+  end
 end

--- a/test/grappa_web/channels/grappa_channel_presence_params_test.exs
+++ b/test/grappa_web/channels/grappa_channel_presence_params_test.exs
@@ -1,0 +1,330 @@
+defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
+  @moduledoc """
+  #1769 — the server half of #1680's presence pause: a socket that joins a
+  per-channel topic with `%{"presence" => false}` stops being sent PEER
+  join/part/quit frames, and everything else on that topic is delivered
+  byte-for-byte as before.
+
+  The tests are written against the two guarantees the shape was chosen for,
+  not against the mechanism:
+
+    * **Default is everything.** A join that does not ask keeps the
+      framework fastlane (asserted structurally off the PubSub registry
+      metadata — the only place "this socket is still a fastlane subscriber"
+      is observable) and keeps receiving every kind.
+    * **Suppression drops only what the client can afford to miss.** The
+      drop set is `Message.pausable_presence_kinds/0` — a strict subset of
+      the presence kinds — and NEVER our own presence, mirroring cic's
+      `PAUSABLE_PRESENCE_KINDS` (`presencePause.ts`) and its carve-outs:
+      `nick_change` drives the #372/#373 identity migration, `mode` feeds
+      channel-mode state, and an own PART tears the window down.
+
+  ⚠️ `socket.join_ref` is nil in `Phoenix.ChannelTest` (nothing sets it), so
+  the production wire difference between a fastlane frame (`[nil, nil, …]`)
+  and a `push/3` frame (`[join_ref, nil, …]`) is NOT observable here — an
+  assertion on `join_ref` would be vacuously green on both arms. The registry
+  metadata is the oracle that is not.
+  """
+  use GrappaWeb.ChannelCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.IRCServer
+
+  alias Grappa.{
+    AdmissionStateHelpers,
+    Networks,
+    Repo,
+    ScrollbackHelpers,
+    Session
+  }
+
+  alias Grappa.Networks.{Credentials, Servers}
+  alias Grappa.PubSub.Topic
+  alias Grappa.Scrollback.Message
+  alias Grappa.Scrollback.Wire
+  alias GrappaWeb.UserSocket
+
+  setup do
+    AdmissionStateHelpers.reset_all()
+    :ok
+  end
+
+  defp build_socket(user_name) do
+    socket(UserSocket, "user_socket:#{user_name}", %{
+      user_name: user_name,
+      current_subject: {:user, Ecto.UUID.generate()},
+      current_session_id: Ecto.UUID.generate(),
+      socket_ref: Ecto.UUID.generate()
+    })
+  end
+
+  # A user + network with NO live session: enough for every peer-presence
+  # arm, since the own-nick carve-out only ever ADDS deliveries.
+  defp setup_user_and_network do
+    user_name = "pp-#{System.unique_integer([:positive])}"
+    user = user_fixture(name: user_name)
+
+    {:ok, network} =
+      Networks.find_or_create_network(%{slug: "pp-net-#{System.unique_integer([:positive])}"})
+
+    {user, network}
+  end
+
+  # Persists a row through the production changeset and renders it with the
+  # production broadcast formatter, so the payload under test is the one
+  # `Session.Persistor` publishes — never a hand-built map.
+  defp broadcast_row(user, network, chan, attrs) do
+    {:ok, message} =
+      ScrollbackHelpers.insert(
+        Map.merge(
+          %{
+            user_id: user.id,
+            network_id: network.id,
+            channel: chan,
+            server_time: System.unique_integer([:positive, :monotonic]) + 1_700_000_000_000,
+            body: nil
+          },
+          attrs
+        )
+      )
+
+    payload = Wire.message_payload(message, network.slug)
+    :ok = Grappa.PubSub.broadcast_event(Topic.channel(user.name, network.slug, chan), payload)
+    payload
+  end
+
+  # The one place "this socket still holds the framework fastlane" is
+  # observable: `Phoenix.Channel.Server.init_join/3` subscribes with
+  # `metadata: {:fastlane, transport_pid, serializer, intercepts}`, and the
+  # PubSub registry IS `Grappa.PubSub`.
+  defp subscription_metadata(topic) do
+    Grappa.PubSub
+    |> Registry.lookup(topic)
+    |> Enum.map(fn {_pid, meta} -> meta end)
+  end
+
+  describe "default join (no params) — the compatibility guarantee" do
+    test "keeps the framework fastlane subscription untouched" do
+      {user, network} = setup_user_and_network()
+      chan = "#pp_default"
+      topic = Topic.channel(user.name, network.slug, chan)
+
+      {:ok, _, _} =
+        user.name
+        |> build_socket()
+        |> subscribe_and_join(topic, %{})
+
+      assert Enum.any?(subscription_metadata(topic), &match?({:fastlane, _, _, _}, &1)),
+             "a default join must stay a fastlane subscriber — that is what makes it " <>
+               "byte-identical and free for third-party clients"
+    end
+
+    test "delivers a peer join, part and quit" do
+      {user, network} = setup_user_and_network()
+      chan = "#pp_default_kinds"
+      topic = Topic.channel(user.name, network.slug, chan)
+
+      {:ok, _, _} =
+        user.name
+        |> build_socket()
+        |> subscribe_and_join(topic, %{})
+
+      for kind <- Message.pausable_presence_kinds() do
+        payload = broadcast_row(user, network, chan, %{kind: kind, sender: "peer"})
+        assert_push("event", ^payload)
+      end
+    end
+
+    test "an unrecognised presence param value is treated as the default" do
+      {user, network} = setup_user_and_network()
+      chan = "#pp_garbage"
+      topic = Topic.channel(user.name, network.slug, chan)
+
+      {:ok, _, _} =
+        user.name
+        |> build_socket()
+        |> subscribe_and_join(topic, %{"presence" => "nope"})
+
+      payload = broadcast_row(user, network, chan, %{kind: :join, sender: "peer"})
+      assert_push("event", ^payload)
+    end
+  end
+
+  describe "join with presence: false" do
+    setup do
+      {user, network} = setup_user_and_network()
+      chan = "#pp_suppressed"
+      topic = Topic.channel(user.name, network.slug, chan)
+
+      {:ok, _, _} =
+        user.name
+        |> build_socket()
+        |> subscribe_and_join(topic, %{"presence" => false})
+
+      %{user: user, network: network, chan: chan, topic: topic}
+    end
+
+    test "drops every pausable peer presence kind", ctx do
+      for kind <- Message.pausable_presence_kinds() do
+        broadcast_row(ctx.user, ctx.network, ctx.chan, %{kind: kind, sender: "peer"})
+        refute_push("event", _, 50)
+      end
+    end
+
+    test "still delivers a peer message — messages must not be lost", ctx do
+      payload =
+        broadcast_row(ctx.user, ctx.network, ctx.chan, %{
+          kind: :privmsg,
+          sender: "peer",
+          body: "ciao raga"
+        })
+
+      assert_push("event", ^payload)
+    end
+
+    test "delivers the message EXACTLY once — BUG 6 regression", ctx do
+      payload =
+        broadcast_row(ctx.user, ctx.network, ctx.chan, %{
+          kind: :privmsg,
+          sender: "peer",
+          body: "una sola volta"
+        })
+
+      assert_push("event", ^payload)
+      refute_push("event", ^payload, 50)
+    end
+
+    test "still delivers the non-pausable presence kinds (nick_change, mode)", ctx do
+      carved_out = Message.suppressed_presence_kinds() -- Message.pausable_presence_kinds()
+      assert carved_out != [], "the carve-out set must not be empty or this test is vacuous"
+
+      for kind <- carved_out do
+        meta = if kind == :nick_change, do: %{new_nick: "peer2"}, else: %{}
+
+        payload =
+          broadcast_row(ctx.user, ctx.network, ctx.chan, %{
+            kind: kind,
+            sender: "peer",
+            meta: meta
+          })
+
+        assert_push("event", ^payload)
+      end
+    end
+
+    test "still delivers a non-message event (window_counts)", ctx do
+      payload = %{kind: :window_counts, channel: ctx.chan, counts: %{messages: 1}}
+      :ok = Grappa.PubSub.broadcast_event(ctx.topic, payload)
+
+      assert_push("event", ^payload)
+    end
+  end
+
+  describe "presence: false on a topic that is not channel-shaped" do
+    test "is ignored on the user topic — its traffic is unaffected" do
+      {user, _network} = setup_user_and_network()
+      topic = Topic.user(user.name)
+
+      {:ok, _, _} =
+        user.name
+        |> build_socket()
+        |> subscribe_and_join(topic, %{"presence" => false})
+
+      assert Enum.any?(subscription_metadata(topic), &match?({:fastlane, _, _, _}, &1)),
+             "presence never travels the user topic, so the param must not cost it its fastlane"
+    end
+  end
+
+  describe "own presence is never dropped" do
+    setup do
+      {irc_server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+
+      user_name = "pp-own-#{System.unique_integer([:positive])}"
+      user = user_fixture(name: user_name)
+      slug = "pp-own-net-#{System.unique_integer([:positive])}"
+      {:ok, network} = Networks.find_or_create_network(%{slug: slug})
+      {:ok, _} = Servers.add_server(network, %{host: "127.0.0.1", port: port, tls: false})
+
+      {:ok, credential} =
+        Credentials.bind_credential(user, network, %{
+          nick: "grappa-snap",
+          auth_method: :none,
+          autojoin_channels: ["#pp_own"]
+        })
+
+      {:ok, plan} = Networks.SessionPlan.resolve(Repo.preload(credential, :network))
+      {:ok, _} = Session.start_session({:user, user.id}, network.id, plan)
+      on_exit(fn -> Session.stop_session({:user, user.id}, network.id) end)
+
+      :ok = IRCServer.await_handshake(irc_server, 1_000)
+      IRCServer.feed(irc_server, ":irc.test.org 001 grappa-snap :Welcome\r\n")
+
+      {:ok, _} =
+        IRCServer.wait_for_line(irc_server, &String.starts_with?(&1, "JOIN #pp_own"), 1_000)
+
+      IRCServer.feed(irc_server, ":grappa-snap!u@h JOIN :#pp_own\r\n")
+
+      chan = "#pp_own"
+      topic = Topic.channel(user.name, network.slug, chan)
+
+      live_socket =
+        socket(UserSocket, "user_socket:#{user.name}", %{
+          user_name: user.name,
+          current_subject: {:user, user.id},
+          current_session_id: Ecto.UUID.generate(),
+          socket_ref: Ecto.UUID.generate()
+        })
+
+      {:ok, _, _} = subscribe_and_join(live_socket, topic, %{"presence" => false})
+
+      # Drain the cold-subscribe snapshots so the arms below assert on their
+      # own frame and not on a leftover.
+      drain_pushes()
+
+      %{user: user, network: network, chan: chan, topic: topic, irc_server: irc_server}
+    end
+
+    test "delivers our OWN part — dropping it would strand a dead window", ctx do
+      payload = broadcast_row(ctx.user, ctx.network, ctx.chan, %{kind: :part, sender: "grappa-snap"})
+      assert_push("event", ^payload)
+    end
+
+    test "own-nick match folds ASCII (#121/#537), so casing does not leak a drop", ctx do
+      payload = broadcast_row(ctx.user, ctx.network, ctx.chan, %{kind: :part, sender: "GRAPPA-Snap"})
+      assert_push("event", ^payload)
+    end
+
+    test "still drops a peer part on the same socket — the carve-out is not a bypass", ctx do
+      broadcast_row(ctx.user, ctx.network, ctx.chan, %{kind: :part, sender: "someone-else"})
+      refute_push("event", _, 50)
+    end
+
+    test "the own-nick cache follows an own nick_change", ctx do
+      # The rename itself is carved out of the drop set, so the socket sees it
+      # — and that is the only signal the channel process gets. A part by the
+      # NEW nick must still be delivered afterwards.
+      rename =
+        broadcast_row(ctx.user, ctx.network, ctx.chan, %{
+          kind: :nick_change,
+          sender: "grappa-snap",
+          meta: %{new_nick: "grappa-snap2"}
+        })
+
+      assert_push("event", ^rename)
+
+      payload =
+        broadcast_row(ctx.user, ctx.network, ctx.chan, %{kind: :part, sender: "grappa-snap2"})
+
+      assert_push("event", ^payload)
+    end
+  end
+
+  defp drain_pushes do
+    receive do
+      %Phoenix.Socket.Message{} -> drain_pushes()
+    after
+      100 -> :ok
+    end
+  end
+end

--- a/test/grappa_web/channels/grappa_channel_presence_params_test.exs
+++ b/test/grappa_web/channels/grappa_channel_presence_params_test.exs
@@ -56,8 +56,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
 
   alias Grappa.Networks.{Credentials, Servers}
   alias Grappa.PubSub.Topic
-  alias Grappa.Scrollback.Message
-  alias Grappa.Scrollback.Wire
+  alias Grappa.Scrollback.{Message, Wire}
   alias GrappaWeb.UserSocket
 
   setup do
@@ -116,7 +115,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
   defp subscription_metadata(topic) do
     Grappa.PubSub
     |> Registry.lookup(topic)
-    |> Enum.map(fn {_pid, meta} -> meta end)
+    |> Enum.map(fn {_, meta} -> meta end)
   end
 
   describe "default join (no params) — the compatibility guarantee" do
@@ -265,7 +264,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
 
   describe "presence: false on a topic that is not channel-shaped" do
     test "is ignored on the user topic — its traffic is unaffected" do
-      {user, _network} = setup_user_and_network()
+      {user, _} = setup_user_and_network()
       topic = Topic.user(user.name)
 
       {:ok, _, socket} =
@@ -497,15 +496,20 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
     end
   end
 
+  # `:absent` and `nil` are DIFFERENT answers and must not collapse: `nil` IS
+  # the metadata of a plain subscription, which is the very state the barrier
+  # waits for, while `:absent` means this pid holds no subscription at all.
+  # Matching the pid with a filter (rather than `Enum.find_value/2`, which
+  # reads a `nil` value as "keep looking") is what keeps them apart.
   defp channel_metadata(socket) do
     Grappa.PubSub
     |> Registry.lookup(socket.topic)
-    |> Enum.find_value(fn {pid, meta} -> if pid == socket.channel_pid, do: {:found, meta} end)
-    |> case do
-      {:found, meta} -> meta
-      nil -> :absent
-    end
+    |> Enum.filter(fn {pid, _} -> pid == socket.channel_pid end)
+    |> metadata_of()
   end
+
+  defp metadata_of([{_, meta} | _]), do: meta
+  defp metadata_of([]), do: :absent
 
   defp drain_pushes do
     receive do

--- a/test/grappa_web/channels/grappa_channel_presence_params_test.exs
+++ b/test/grappa_web/channels/grappa_channel_presence_params_test.exs
@@ -130,7 +130,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
         |> build_socket()
         |> subscribe_and_join(topic, %{})
 
-      settle(socket)
+      settle(socket, :fastlane)
 
       assert Enum.any?(subscription_metadata(topic), &match?({:fastlane, _, _, _}, &1)),
              "a default join must stay a fastlane subscriber — that is what makes it " <>
@@ -153,7 +153,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
         |> build_socket()
         |> subscribe_and_join(topic, %{})
 
-      settle(socket)
+      settle(socket, :fastlane)
 
       for kind <- Message.pausable_presence_kinds() do
         payload = broadcast_row(user, network, chan, %{kind: kind, sender: "peer"})
@@ -171,7 +171,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
         |> build_socket()
         |> subscribe_and_join(topic, %{"presence" => "nope"})
 
-      settle(socket)
+      settle(socket, :fastlane)
 
       payload = broadcast_row(user, network, chan, %{kind: :join, sender: "peer"})
       assert_push("event", ^payload)
@@ -189,15 +189,14 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
         |> build_socket()
         |> subscribe_and_join(topic, %{"presence" => false})
 
-      settle(socket)
+      settle(socket, :plain)
 
       %{user: user, network: network, chan: chan, topic: topic}
     end
 
     test "drops every pausable peer presence kind", ctx do
       for kind <- Message.pausable_presence_kinds() do
-        broadcast_row(ctx.user, ctx.network, ctx.chan, %{kind: kind, sender: "peer"})
-        refute_push("event", _, 50)
+        refute_delivered(ctx, %{kind: kind, sender: "peer"})
       end
     end
 
@@ -231,7 +230,11 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
                "still holds the subscription `drop_fastlane_if_suppressing/1` was meant to " <>
                "trade away (BUG 6: one broadcast, two frames)"
 
-      refute_receive %Phoenix.Socket.Message{event: "event", payload: ^payload}, 50
+      # Zero window for the same reason as `refute_delivered/2`: the duplicate
+      # this guards is written by the DISPATCHER, synchronously inside
+      # `broadcast_event/2`, so it is in the mailbox before the push copy the
+      # assertion above just consumed.
+      refute_receive %Phoenix.Socket.Message{event: "event", payload: ^payload}, 0
     end
 
     test "still delivers the non-pausable presence kinds (nick_change, mode)", ctx do
@@ -270,7 +273,10 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
         |> build_socket()
         |> subscribe_and_join(topic, %{"presence" => false})
 
-      settle(socket)
+      # `:fastlane`, not `:plain` — that IS the assertion. The param is only
+      # read for a channel-shaped topic, so the user topic must keep the
+      # subscription the framework gave it even though the join asked.
+      settle(socket, :fastlane)
 
       assert Enum.any?(subscription_metadata(topic), &match?({:fastlane, _, _, _}, &1)),
              "presence never travels the user topic, so the param must not cost it its fastlane"
@@ -321,7 +327,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
 
       # Barrier + drain: the arms below must assert on their own frame, and
       # must not race the fastlane swap.
-      settle(joined_socket)
+      settle(joined_socket, :plain)
 
       %{user: user, network: network, chan: chan, topic: topic, irc_server: irc_server}
     end
@@ -337,8 +343,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
     end
 
     test "still drops a peer part on the same socket — the carve-out is not a bypass", ctx do
-      broadcast_row(ctx.user, ctx.network, ctx.chan, %{kind: :part, sender: "someone-else"})
-      refute_push("event", _, 50)
+      refute_delivered(ctx, %{kind: :part, sender: "someone-else"})
     end
 
     test "the own-nick cache follows an own nick_change", ctx do
@@ -361,23 +366,145 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
     end
   end
 
-  # The barrier every arm below needs, and the reason it is a barrier rather
-  # than a wait. `:after_join` is a `Process.send_after(self(), …, 0)`, so a
-  # synchronous call to the channel queues BEHIND it: when `:sys.get_state/1`
-  # returns, the after-join leg has run to completion — which means the
-  # fastlane swap (its first statement) is installed and the cold-subscribe
-  # snapshot pushes are already in this process's mailbox.
+  # Assert a row was DROPPED, with no timing window anywhere.
   #
-  # Measured, not precautionary: without it the BUG 6 mutant (subscribe
-  # without unsubscribing) was caught on one seed and missed on the next.
-  # The `refute_push` was racing `push_channel_snapshot/4`'s DB round-trips,
-  # so the duplicate frame sometimes landed after the refute window. The cure
-  # is the deterministic setup, never a longer window — a timeout raised to
-  # cover a race turns the assertion into a coin toss with better odds.
-  defp settle(socket) do
-    :sys.get_state(socket.channel_pid)
+  # A bare `refute_push(..., 50)` is wrong twice. It is a race (the suppressed
+  # path runs dispatcher -> channel mailbox -> `handle_out` -> `push`, so the
+  # frame can land after the window), and with a wildcard payload it also
+  # catches unrelated live traffic — measured: a session's own `window_state`
+  # broadcast tripped it once in 6893 tests.
+  #
+  # Instead: broadcast the row under test, then a SENTINEL on the same topic.
+  # Both travel the same process pair, so Erlang's message ordering makes the
+  # sentinel a barrier — once it has arrived, the row under test has either
+  # arrived before it or was dropped. `assert_receive` scans the mailbox
+  # selectively and leaves non-matching messages in place, so a delivered row
+  # is still sitting there for the refute, which can therefore use a ZERO
+  # window: the answer is already in the mailbox or it is never coming.
+  defp refute_delivered(ctx, attrs) do
+    dropped = broadcast_row(ctx.user, ctx.network, ctx.chan, attrs)
+
+    sentinel =
+      broadcast_row(ctx.user, ctx.network, ctx.chan, %{
+        kind: :privmsg,
+        sender: "sentinel",
+        body: "barrier-#{System.unique_integer([:positive])}"
+      })
+
+    assert_push("event", ^sentinel)
+    refute_push("event", ^dropped, 0)
+  end
+
+  # The barrier every arm needs, and the two corrections it took to get right
+  # — both measured, both worth keeping written down.
+  #
+  # FIRST TRY, WRONG: `:sys.get_state(socket.channel_pid)` alone. The
+  # reasoning was that a synchronous call queues behind the `:after_join`
+  # message, so returning proves the after-join leg ran. It does not.
+  # `:after_join` arrives via `Process.send_after(self(), …, 0)`, which is a
+  # TIMER and not a `send`: the message is enqueued by the timer service and
+  # can land AFTER a call made later in wall-clock time. Symptom, on some
+  # seeds only — frames arriving with `join_ref: nil`, i.e. FASTLANE frames,
+  # on a socket that had asked for suppression.
+  #
+  # SECOND TRY, AND WHY THIS ONE IS A BARRIER: poll the PubSub registry until
+  # this channel pid's subscription metadata has reached the expected shape.
+  # That is the exact state every arm depends on, read out of the framework's
+  # own bookkeeping rather than inferred from a proxy, so it cannot be early.
+  # `:sys.get_state/1` stays afterwards doing the job it IS good for —
+  # draining a mid-flight callback so the snapshot pushes are in this
+  # process's mailbox before we clear it.
+  #
+  # `expect` is asserted rather than assumed: a barrier that gave up quietly
+  # would leave every arm downstream racing again, which is the failure it
+  # exists to remove.
+  # ⚠️ THE TWO EXPECTATIONS ARE NOT SYMMETRIC, and pretending they were is what
+  # let two mutants live.
+  #
+  # `:plain` is a state the join must REACH, so polling for it is a genuine
+  # barrier: it cannot pass early.
+  #
+  # `:fastlane` is the state the join STARTS in — `init_join/3` installs it
+  # before `join/3` has even returned. Polling for it is satisfied instantly
+  # and proves nothing about what `:after_join` did afterwards. Measured:
+  # mutants that made the param bite on the user topic (M6: assign it for
+  # every topic shape; M7: M6 plus a swap in the user arm) both survived a
+  # suite that only polled for `:fastlane`.
+  #
+  # So the `:fastlane` side pins the DECISION instead of racing the effect.
+  # `presence_suppressed` is assigned synchronously inside `join/3`, so
+  # reading it out of the channel's state is timing-free and is exactly the
+  # fact the non-channel clause exists to establish. Both mutants die on it.
+  #
+  # Honest residual, since the difference matters: nothing here forbids a swap
+  # arriving LATER on a default socket. What forbids it is structural — only
+  # the `{:channel, …}` after-join clause calls the swap verb — and this suite
+  # does not independently prove that.
+  defp settle(socket, expect) when expect in [:fastlane, :plain] do
+    if expect == :plain, do: wait_for_subscription(socket, expect, 200)
+
+    state = :sys.get_state(socket.channel_pid)
+
+    assert state.assigns.presence_suppressed == (expect == :plain),
+           """
+           the join's presence DECISION is wrong for this topic.
+
+             topic:               #{socket.topic}
+             presence_suppressed: #{inspect(state.assigns.presence_suppressed)}
+             expected:            #{inspect(expect == :plain)}
+
+           Only a channel-shaped topic reads the param — presence never travels
+           the user or network topics, so a flag there could only ever cost
+           them their fastlane for nothing.
+           """
+
+    if expect == :fastlane do
+      assert match?({:fastlane, _, _, _}, channel_metadata(socket)),
+             "expected this channel to still hold the framework fastlane, got " <>
+               inspect(channel_metadata(socket))
+    end
+
     drain_pushes()
     socket
+  end
+
+  defp wait_for_subscription(socket, expect, 0) do
+    flunk("""
+    the channel never reached the #{expect} subscription state.
+
+      topic:   #{socket.topic}
+      channel: #{inspect(socket.channel_pid)}
+      now:     #{inspect(channel_metadata(socket))}
+
+    `:fastlane` is what the framework installs in `init_join/3`; `:plain` is
+    what `drop_fastlane_if_suppressing/1` trades it for in `:after_join`.
+    """)
+  end
+
+  defp wait_for_subscription(socket, expect, tries) do
+    actual =
+      case channel_metadata(socket) do
+        {:fastlane, _, _, _} -> :fastlane
+        nil -> :plain
+        _ -> :unknown
+      end
+
+    if actual == expect do
+      :ok
+    else
+      Process.sleep(5)
+      wait_for_subscription(socket, expect, tries - 1)
+    end
+  end
+
+  defp channel_metadata(socket) do
+    Grappa.PubSub
+    |> Registry.lookup(socket.topic)
+    |> Enum.find_value(fn {pid, meta} -> if pid == socket.channel_pid, do: {:found, meta} end)
+    |> case do
+      {:found, meta} -> meta
+      nil -> :absent
+    end
   end
 
   defp drain_pushes do

--- a/test/grappa_web/channels/grappa_channel_presence_params_test.exs
+++ b/test/grappa_web/channels/grappa_channel_presence_params_test.exs
@@ -19,11 +19,26 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
       `nick_change` drives the #372/#373 identity migration, `mode` feeds
       channel-mode state, and an own PART tears the window down.
 
-  ⚠️ `socket.join_ref` is nil in `Phoenix.ChannelTest` (nothing sets it), so
-  the production wire difference between a fastlane frame (`[nil, nil, …]`)
-  and a `push/3` frame (`[join_ref, nil, …]`) is NOT observable here — an
-  assertion on `join_ref` would be vacuously green on both arms. The registry
-  metadata is the oracle that is not.
+  ## The oracle: `join_ref`, and why it is timing-free
+
+  Which PATH delivered a frame is directly observable, and it is the same
+  distinction production makes. `Phoenix.ChannelTest.join/4` mints a
+  `ref: System.unique_integer/1` for the join message and the framework
+  carries it onto `socket.join_ref`, so:
+
+    * a FASTLANE frame is built by `serializer.fastlane!/1` from a
+      `%Broadcast{}`, which has no ref — `join_ref: nil`, exactly the
+      `[nil, nil, topic, event, payload]` the V2 serializer puts on the wire;
+    * a `push/3` frame is built from `%Message{join_ref: socket.join_ref}` —
+      a positive integer here, the `[join_ref, nil, …]` shape on the wire.
+
+  That makes "did this socket keep its fastlane?" an assertion on a delivered
+  frame rather than on a clock. It matters most for the BUG 6 arm: the
+  dispatcher writes the fastlane copy SYNCHRONOUSLY inside
+  `broadcast_event/2`, so a duplicate is already AHEAD of the push copy in
+  this process's mailbox — asserting on the FIRST matching frame catches it
+  with no window to tune. `subscription_metadata/1` is kept as the structural
+  companion for the arms that assert about a topic nobody broadcasts on.
   """
   use GrappaWeb.ChannelCase, async: false
 
@@ -110,14 +125,22 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
       chan = "#pp_default"
       topic = Topic.channel(user.name, network.slug, chan)
 
-      {:ok, _, _} =
+      {:ok, _, socket} =
         user.name
         |> build_socket()
         |> subscribe_and_join(topic, %{})
 
+      settle(socket)
+
       assert Enum.any?(subscription_metadata(topic), &match?({:fastlane, _, _, _}, &1)),
              "a default join must stay a fastlane subscriber — that is what makes it " <>
                "byte-identical and free for third-party clients"
+
+      # ...and prove it on a real frame, not only in the registry: a fastlane
+      # frame carries no join_ref.
+      payload = broadcast_row(user, network, chan, %{kind: :privmsg, sender: "peer", body: "oi"})
+
+      assert_receive %Phoenix.Socket.Message{event: "event", payload: ^payload, join_ref: nil}
     end
 
     test "delivers a peer join, part and quit" do
@@ -125,10 +148,12 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
       chan = "#pp_default_kinds"
       topic = Topic.channel(user.name, network.slug, chan)
 
-      {:ok, _, _} =
+      {:ok, _, socket} =
         user.name
         |> build_socket()
         |> subscribe_and_join(topic, %{})
+
+      settle(socket)
 
       for kind <- Message.pausable_presence_kinds() do
         payload = broadcast_row(user, network, chan, %{kind: kind, sender: "peer"})
@@ -141,10 +166,12 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
       chan = "#pp_garbage"
       topic = Topic.channel(user.name, network.slug, chan)
 
-      {:ok, _, _} =
+      {:ok, _, socket} =
         user.name
         |> build_socket()
         |> subscribe_and_join(topic, %{"presence" => "nope"})
+
+      settle(socket)
 
       payload = broadcast_row(user, network, chan, %{kind: :join, sender: "peer"})
       assert_push("event", ^payload)
@@ -157,10 +184,12 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
       chan = "#pp_suppressed"
       topic = Topic.channel(user.name, network.slug, chan)
 
-      {:ok, _, _} =
+      {:ok, _, socket} =
         user.name
         |> build_socket()
         |> subscribe_and_join(topic, %{"presence" => false})
+
+      settle(socket)
 
       %{user: user, network: network, chan: chan, topic: topic}
     end
@@ -183,7 +212,7 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
       assert_push("event", ^payload)
     end
 
-    test "delivers the message EXACTLY once — BUG 6 regression", ctx do
+    test "arrives once, on the push path — BUG 6 regression", ctx do
       payload =
         broadcast_row(ctx.user, ctx.network, ctx.chan, %{
           kind: :privmsg,
@@ -191,8 +220,18 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
           body: "una sola volta"
         })
 
-      assert_push("event", ^payload)
-      refute_push("event", ^payload, 50)
+      # FIRST matching frame, deliberately: a leftover fastlane subscription
+      # would have written its copy synchronously inside `broadcast_event/2`,
+      # so it would be ahead of this one and `join_ref` would be nil. No
+      # window to tune, and it fails naming the mechanism.
+      assert_receive %Phoenix.Socket.Message{event: "event", payload: ^payload, join_ref: join_ref}
+
+      assert is_integer(join_ref),
+             "frame arrived with join_ref nil — that is a FASTLANE frame, so this socket " <>
+               "still holds the subscription `drop_fastlane_if_suppressing/1` was meant to " <>
+               "trade away (BUG 6: one broadcast, two frames)"
+
+      refute_receive %Phoenix.Socket.Message{event: "event", payload: ^payload}, 50
     end
 
     test "still delivers the non-pausable presence kinds (nick_change, mode)", ctx do
@@ -226,10 +265,12 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
       {user, _network} = setup_user_and_network()
       topic = Topic.user(user.name)
 
-      {:ok, _, _} =
+      {:ok, _, socket} =
         user.name
         |> build_socket()
         |> subscribe_and_join(topic, %{"presence" => false})
+
+      settle(socket)
 
       assert Enum.any?(subscription_metadata(topic), &match?({:fastlane, _, _, _}, &1)),
              "presence never travels the user topic, so the param must not cost it its fastlane"
@@ -276,11 +317,11 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
           socket_ref: Ecto.UUID.generate()
         })
 
-      {:ok, _, _} = subscribe_and_join(live_socket, topic, %{"presence" => false})
+      {:ok, _, joined_socket} = subscribe_and_join(live_socket, topic, %{"presence" => false})
 
-      # Drain the cold-subscribe snapshots so the arms below assert on their
-      # own frame and not on a leftover.
-      drain_pushes()
+      # Barrier + drain: the arms below must assert on their own frame, and
+      # must not race the fastlane swap.
+      settle(joined_socket)
 
       %{user: user, network: network, chan: chan, topic: topic, irc_server: irc_server}
     end
@@ -320,11 +361,30 @@ defmodule GrappaWeb.GrappaChannelPresenceParamsTest do
     end
   end
 
+  # The barrier every arm below needs, and the reason it is a barrier rather
+  # than a wait. `:after_join` is a `Process.send_after(self(), …, 0)`, so a
+  # synchronous call to the channel queues BEHIND it: when `:sys.get_state/1`
+  # returns, the after-join leg has run to completion — which means the
+  # fastlane swap (its first statement) is installed and the cold-subscribe
+  # snapshot pushes are already in this process's mailbox.
+  #
+  # Measured, not precautionary: without it the BUG 6 mutant (subscribe
+  # without unsubscribing) was caught on one seed and missed on the next.
+  # The `refute_push` was racing `push_channel_snapshot/4`'s DB round-trips,
+  # so the duplicate frame sometimes landed after the refute window. The cure
+  # is the deterministic setup, never a longer window — a timeout raised to
+  # cover a race turns the assertion into a coin toss with better odds.
+  defp settle(socket) do
+    :sys.get_state(socket.channel_pid)
+    drain_pushes()
+    socket
+  end
+
   defp drain_pushes do
     receive do
       %Phoenix.Socket.Message{} -> drain_pushes()
     after
-      100 -> :ok
+      0 -> :ok
     end
   end
 end


### PR DESCRIPTION
#1680 shipped the presence pause at cic's **dispatch edge**: a channel nobody
has looked at for two minutes stops APPLYING peer join/part/quit. The events
still cross the socket, still get decoded, still wake the main thread. This is
the server half — a join param that stops them being sent.

The shape is join params by ruling (vjt, 2026-08-25), and the reason is the
default: a client that joins the way it joins today receives what it receives
today, **by construction**. No flag day, nothing to coordinate with the other
client authors. Only the literal `false` suppresses.

## The issue named a choke point that cannot see this traffic

The scope said to filter at `handle_info(%Phoenix.Socket.Broadcast{})`
(`grappa_channel.ex:474`). Measured, that clause never sees per-channel
traffic: the framework installs a **fastlane** subscription on a channel's own
topic, so `broadcast_event/2` is encoded once by the dispatcher and written
straight to the transport. The module's own moduledoc says so twenty lines
above the clause (`:161-162`), and Phoenix's dispatcher confirms it
(`channel/server.ex:93-118`). That clause only ever serves #1088's foreign
socket topic.

`intercept ["event"]`, the idiom, is the wrong fix here: it compiles to
`__intercepts__/0`, a **per-module, all-sockets** switch copied into every
socket's fastlane metadata. It would route every broadcast on every topic
through a channel process — a regression on the default path of a perf issue,
and it would hand each channel process the whole flood in its mailbox during
exactly the netsplit bursts this work exists to survive (#1715, #1739).

But the intercept list lives in the **subscription metadata**, not in a global,
so a per-socket answer is expressible: a suppressing socket trades its fastlane
for a plain subscription in `:after_join`, and its broadcasts then arrive as
structs routed to `handle_out/3`. Everyone else's path is not "equivalent" —
it is untouched.

## What is never dropped

`Message.pausable_presence_kinds/0` (`[:join, :part, :quit]`) is a **strict
subset** of the presence kinds, declared separately rather than derived:
`nick_change` drives the #372/#373 identity migration and `mode` feeds
channel-mode state, and both fail silently without it. Our OWN presence is
never dropped either — an own PART tears the window down — on a folded compare
seeded at join that then **follows a rename**, off the `nick_change` row the
carve-out already guarantees delivery of.

## Wire

Bumped to **7**. `mix grappa.wire_pin --check` was silent — measured, with the
change applied it answered `wire shape and protocol 6 agree.` Third instance of
that detector gap (#1679, #1766) and the first where the un-covered surface is
**inbound**, which no widening of the outbound codegen digest would reach.
Filed as #1787. `min_version` stays at 1 — nothing is stranded.

## Evidence

| gate | result |
|---|---|
| `scripts/check.sh` | **rc=0** — Credo 0, Dialyzer 0, Sobelow, doctor, deps.audit clean, bats 692, `shape.pin: wire shape and protocol 7 agree.` |
| `scripts/test.sh` (full) | 8 doctests, 62 properties, **6893 tests, 0 failures** |
| `scripts/bun.sh run test` | **314 files, 0 failures** |
| `scripts/bun.sh run check` | **5/5 stages ok** |
| `scripts/design-notes-gate.sh` (post-commit) | `1 new entry heading(s), separator and marker present.` |
| mutation testing | **7 one-axis mutants, 7 killed**, all deterministic over repeated runs |
| `playwright test --list` | the new spec is collected: 1 test, `Total: 634 tests in 376 files`, rc=0 |

Mutants: the fastlane swap never fires (9 arms); subscribe without
unsubscribing, i.e. the BUG 6 shape (9); the own carve-out never matches (3);
the whole presence set dropped instead of the pausable subset (2); the rename
never followed (1); the param read on every topic shape (1); that last one plus
a swap in the user arm (1).

## 🔴 NOT run locally — read a red here as expected cost

**The new e2e spec has never been executed.** The STACK/e2e lane is held by
another worker, so this is gated from CI per the contended-lane rule. Static
gates on it are green (biome, `tsc -p e2e/tsconfig.json`, and Playwright
collects it), but that is not a run.

Two things about it are worth knowing before the job goes red:

* it uses **`page.clock`** (`install` → `resume` → one `fastForward` past the
  two-minute cooldown), which has **no precedent in this repo's e2e** — chosen
  over burning two minutes of wall clock per run, and over adding a production
  seam. If the clock disturbs boot, the fallback is the wall-clock wait and I
  will say so rather than weaken the spec;
* it asserts an **absence** (no presence frames on the paused topic), so it
  carries four positive controls in the same page against the same peer on the
  same socket: the same channel delivers before the pause, the focused channel
  keeps delivering after it, a PRIVMSG to the paused channel still arrives, and
  cic's outbound `phx_join` carries `{"presence": false}`. The negative has no
  timing window — the PRIVMSG is the ordering barrier.

Also not supplied: **the delivered event-rate measurement the issue asks for**
("measure the delivered event rate for a paused channel before/after ... at the
socket"). `origin/main` is undeployed by standing decision and the jail is not
reachable from here. The e2e proves the frames are absent; no rate was taken.
The `intercept` alternative's cost is reasoned from Phoenix's dispatcher source
(sends and encodes counted), not benchmarked. And nothing here establishes that
a paused window is cheaper end to end once the pause/resume re-join, its join
reply and its REST backfill are counted against the events it stops paying for.

## One consequence of the ruled shape

The param is read once, at join, so changing the answer is a **re-join** —
`phx.leave()` then join. There is a short window with no live delivery on that
topic. Nothing is lost (every channel join already runs `refreshScrollback` on
its ACK), but it invalidated an existing oracle: the test encoding vjt's
"messages must not be lost" asserted `phx.leave()` is never called, which would
now forbid the correct implementation. It was replaced by a **stricter** one —
the topic is joined AGAIN, with `{presence: false}` — plus a sibling arm for
the resume half, which is the one an implementation can get wrong in silence.