### PR TITLE
fix(#1772): unweld the iOS touch lock from the scrollback freeze

### DIFF
--- a/cicchetto/src/ContextMenu.tsx
+++ b/cicchetto/src/ContextMenu.tsx
@@ -72,11 +72,19 @@ const ContextMenu: Component<Props> = (props) => {
   // Stack membership also gives the menu LIFO precedence, so a modal opened
   // over it closes first.
   //
-  // The ESC-only variant (#1199), not `createOverlayLock`: the menu is a
-  // dismissable surface that holds no scroll-lock refcount today, and taking
-  // one would freeze the scrollback snapshot behind it and arm the iOS
-  // `overlay-open` touch lock. The predicate is the constant `true` because all
-  // three hosts mount this component behind a `<Show>` on their own open state.
+  // The NO-FREEZE variant (#1199), not `createOverlayLock`: the menu floats at
+  // fixed coordinates over a pane that stays live behind it, so taking a
+  // COVERING refcount would freeze the scrollback snapshot for the life of a
+  // long-press. The predicate is the constant `true` because all three hosts
+  // mount this component behind a `<Show>` on their own open state.
+  //
+  // #1772 — it does take the iOS touch lock, which this helper now carries on
+  // the other side of that split. It did not, and the shell panned under an
+  // open menu: `.context-menu-backdrop` is `position: fixed; inset: 0`, which
+  // reads like a shield but only ever intercepted CLICKS, so a DRAG went to
+  // UIKit as a page pan while the menu itself — `position: fixed` — stayed put
+  // and the content slid out from under it. The stylesheet half (backdrop
+  // claims the stream, menu re-opens its own pan) is in `default.css`.
   createOverlayEscape(
     () => true,
     () => props.onClose(),

--- a/cicchetto/src/LusersCard.tsx
+++ b/cicchetto/src/LusersCard.tsx
@@ -30,8 +30,9 @@ const LusersCard: Component<Props> = (props) => {
   const snapshot = () => lusersBundleByNetwork()[props.networkSlug];
   // #1199 — Escape dismisses through the shared ordered ESC stack (the same
   // door every modal uses), invoking the SAME verb the × does, so a modal
-  // opened over the card still closes first. Escape-only, no scroll-lock
-  // refcount: the card sits IN the scrollback flow, not over it.
+  // opened over the card still closes first. No COVERING refcount: the card
+  // sits IN the scrollback flow, not over it, so the pane behind must not
+  // freeze. #1772 — the iOS touch lock is not part of what that gives up.
   createOverlayEscape(
     () => snapshot() !== undefined,
     () => dismissLusersCard(props.networkSlug),

--- a/cicchetto/src/WhoisCard.tsx
+++ b/cicchetto/src/WhoisCard.tsx
@@ -86,8 +86,11 @@ const WhoisCard: Component<Props> = (props) => {
   // first. Gated on `onDismiss`: it is the dismissability of the mount site,
   // and the rail card (which omits it) must NOT be closable — a persistent
   // per-window surface Escape can close is one the operator cannot bring back.
-  // Escape-only, no scroll-lock refcount: the card sits IN the scrollback flow,
-  // not over it.
+  // No COVERING refcount: the card sits IN the scrollback flow, not over it, so
+  // the pane behind must keep scrolling and must not freeze its snapshot.
+  // #1772 — the iOS touch lock is NOT part of what that gives up (it was, and a
+  // drag with the card open panned the whole app shell). The gate below decides
+  // both: the rail card, which cannot be dismissed, takes neither.
   createOverlayEscape(
     () => bundle() !== undefined && props.onDismiss !== undefined,
     () => props.onDismiss?.(),

--- a/cicchetto/src/WhowasCard.tsx
+++ b/cicchetto/src/WhowasCard.tsx
@@ -30,8 +30,9 @@ const WhowasCard: Component<Props> = (props) => {
   const bundle = () => whowasCardBySlug()[props.networkSlug];
   // #1199 — Escape dismisses through the shared ordered ESC stack (the same
   // door every modal uses), invoking the SAME verb the × does, so a modal
-  // opened over the card still closes first. Escape-only, no scroll-lock
-  // refcount: the card sits IN the scrollback flow, not over it.
+  // opened over the card still closes first. No COVERING refcount: the card
+  // sits IN the scrollback flow, not over it, so the pane behind must not
+  // freeze. #1772 — the iOS touch lock is not part of what that gives up.
   createOverlayEscape(
     () => bundle() !== undefined,
     () => dismissWhowasCard(props.networkSlug),

--- a/cicchetto/src/__tests__/cardEscape.test.tsx
+++ b/cicchetto/src/__tests__/cardEscape.test.tsx
@@ -26,11 +26,14 @@ import WhowasCard from "../WhowasCard";
 // only on the ordering arm (`MediaViewerModal.tsx` records the same warning).
 //
 // The cards are inline scrollback content, NOT covering overlays, so they
-// join the ESC stack WITHOUT the scroll-lock refcount: `overlayCount()` must
-// stay 0 while a card is up. A refcount held for the life of a card would
-// freeze the scrollback snapshot behind it and add the iOS `overlay-open`
-// touch lock — the hazard `RailActions.tsx:74-77` already records for the
-// permanent rail column.
+// join the ESC stack WITHOUT the covering refcount: `overlayCount()` must
+// stay 0 while a card is up. A covering refcount held for the life of a card
+// would freeze the scrollback snapshot behind it — the hazard
+// `RailActions.tsx` already records for the permanent rail column.
+//
+// #1772 — that is the FREEZE axis and it is the only one this file speaks to.
+// The iOS touch lock rides the same helper but a different counter now, and
+// which surfaces arm it is pinned in `overlaySurfaceLockContract.test.tsx`.
 
 // Dispatched on a real in-document target and left to BUBBLE, exactly as a
 // browser delivers a keypress. Not on `window` directly: an event whose target
@@ -196,14 +199,13 @@ describe("#1199 scrollback cards close on Escape", () => {
     expect(screen.queryByTestId("lusers-card")).toBeNull();
   });
 
-  it("a card holds no scroll-lock refcount while it is up", async () => {
+  it("a card holds no COVERING refcount while it is up", async () => {
     setWhowasBundle("net-esc-refcount", WHOWAS_BUNDLE);
     render(() => <WhowasCard networkSlug="net-esc-refcount" />);
     await flush();
 
     expect(overlayEscapeDepth()).toBe(1);
     expect(overlayCount()).toBe(0);
-    expect(document.documentElement.classList.contains("overlay-open")).toBe(false);
   });
 });
 
@@ -284,7 +286,7 @@ describe("#1199 Escape ordering: a modal over a card", () => {
 
 // #1411 (review K-S4) — the context-menu shell is the same contract as the
 // cards above: dismissable, covering nothing, therefore an ESC-stack member
-// with no scroll-lock refcount. It was never enumerated among #232's twelve
+// with no COVERING refcount. It was never enumerated among #232's twelve
 // and kept the private `document` keydown listener that #232 ("ONE global
 // listener, the sole ESC authority") and `createOverlayEscape`'s own doc both
 // state cannot exist. The cost is not theoretical: on a phone `MembersPane`
@@ -310,7 +312,7 @@ describe("#1411 the context menu closes on Escape through the shared stack", () 
     expect(handlers.closeDrawer).not.toHaveBeenCalled();
   });
 
-  it("holds no scroll-lock refcount while it is up", async () => {
+  it("holds no COVERING refcount while it is up", async () => {
     render(() => <ContextMenu items={MENU_ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
     await flush();
 

--- a/cicchetto/src/__tests__/contextMenuTouchAction.test.ts
+++ b/cicchetto/src/__tests__/contextMenuTouchAction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #1772 — the stylesheet half of "the shell does not move while the long-press
+// menu is open", asserted at SOURCE level (the railMenuSafeArea /
+// mediaViewerTouchAction precedent): jsdom applies no stylesheet, so a
+// computed-style oracle would read every one of these back as empty whether or
+// not the rule exists, and Playwright's webkit does not reproduce UIKit's
+// gesture model either. These are invisible in every gate we run and only bite
+// on a real phone — which is exactly why they need a guard that fails in CI.
+//
+// Two declarations, opposite directions, one cause. The menu now arms the iOS
+// touch lock (see `lib/overlayScrollLock.ts`), which puts `html.overlay-open
+// body { touch-action: none }` over the portal root the menu lives in:
+//
+//   * the BACKDROP must claim the gesture and give nothing back — it is a
+//     full-viewport shield, and at the `auto` it had by omission a drag on it
+//     went straight to UIKit as a page pan (the reported symptom: the content
+//     slid out from under a menu that stayed at its fixed coordinates);
+//   * the MENU must give the pan back, because it is a real scroller
+//     (`max-height` + `overflow-y: auto`) and the blanket it now sits under
+//     would otherwise refuse the scroll — fixing the pan by removing it.
+//
+// The menu is the one overlay scroller that PORTALS to <body>, outside
+// `.shell-mobile { touch-action: none }`, which is why it is the only one that
+// had no carve-out to begin with.
+
+describe("#1772 context menu touch-action contract", () => {
+  it("the backdrop claims the whole touch stream", () => {
+    expect(ruleBody(".context-menu-backdrop")).toMatch(/touch-action:\s*none/);
+  });
+
+  it("the menu re-opens vertical panning for its own overflow", () => {
+    expect(ruleBody(".context-menu")).toMatch(/touch-action:\s*pan-y/);
+  });
+
+  it("the items carry the carve-out too — they are the hit-test target", () => {
+    // #913's lesson at `.rail-actions-menu *`, which shipped scroller-only
+    // first and did not work: touch-action does not inherit, so every row sits
+    // at `auto` under a `none` ancestor and iOS elects the gesture consumer
+    // from the hit-test target's own value.
+    expect(themeCss).toMatch(/\.context-menu \*\s*\{[^}]*touch-action:\s*pan-y/);
+  });
+});

--- a/cicchetto/src/__tests__/overlayScrollLock.test.ts
+++ b/cicchetto/src/__tests__/overlayScrollLock.test.ts
@@ -28,8 +28,11 @@ import {
   overlayCount,
   overlayEscapeDepth,
   popOverlay,
+  popShellLock,
   pushOverlay,
+  pushShellLock,
   runTopmostOverlayEscape,
+  shellLockCount,
 } from "../lib/overlayScrollLock";
 
 // createOverlayLock defers its push + Esc-registration a microtask (so the
@@ -149,6 +152,77 @@ describe("overlayScrollLock refcount + class", () => {
   });
 });
 
+// #1772 — the touch lock and the freeze used to be one number. They are two
+// populations now, summed for the lock and read separately for the freeze.
+// These pin the arithmetic; which SURFACES land in which population is pinned
+// in overlaySurfaceLockContract.test.ts.
+describe("overlayScrollLock — the shell lock is a second population (#1772)", () => {
+  test("a shell lock arms the class + listener without moving overlayCount", () => {
+    pushShellLock();
+    expect(shellLockCount()).toBe(1);
+    expect(document.documentElement.classList.contains(CLASS)).toBe(true);
+    expect(isListenerAttached()).toBe(true);
+    // The freeze axis is untouched — this is the whole point of the split.
+    expect(overlayCount()).toBe(0);
+  });
+
+  test("the lock survives until the LAST holder drops, across both populations", () => {
+    pushOverlay(makeEl());
+    pushShellLock();
+    expect(document.documentElement.classList.contains(CLASS)).toBe(true);
+
+    popOverlay(null); // the covering half goes; the shell lock still holds
+    expect(overlayCount()).toBe(0);
+    expect(document.documentElement.classList.contains(CLASS)).toBe(true);
+    expect(isListenerAttached()).toBe(true);
+
+    popShellLock();
+    expect(document.documentElement.classList.contains(CLASS)).toBe(false);
+    expect(isListenerAttached()).toBe(false);
+  });
+
+  test("the covering half can drop last and still hold the lock meanwhile", () => {
+    pushShellLock();
+    pushOverlay(makeEl());
+
+    popShellLock();
+    expect(shellLockCount()).toBe(0);
+    expect(document.documentElement.classList.contains(CLASS)).toBe(true);
+    expect(isListenerAttached()).toBe(true);
+
+    popOverlay(null);
+    expect(document.documentElement.classList.contains(CLASS)).toBe(false);
+    expect(isListenerAttached()).toBe(false);
+  });
+
+  test("popping a shell lock below zero is clamped", () => {
+    popShellLock();
+    popShellLock();
+    expect(shellLockCount()).toBe(0);
+    // A negative counter would leave the class un-removable by the NEXT
+    // surface's balanced pop — the mirror of the covering clamp above.
+    pushShellLock();
+    popShellLock();
+    expect(document.documentElement.classList.contains(CLASS)).toBe(false);
+  });
+
+  test("a shell lock does NOT make the pane freeze predicate's source move", () => {
+    createRoot((dispose) => {
+      const observed: number[] = [];
+      const derived = createMemo(() => overlayCount());
+      observed.push(derived());
+      pushShellLock();
+      observed.push(derived());
+      popShellLock();
+      observed.push(derived());
+      dispose();
+      // Flat 0: ScrollbackPane's memo never even recomputes to a new value, so
+      // the snapshot behind an in-flow surface is never captured.
+      expect(observed).toEqual([0, 0, 0]);
+    });
+  });
+});
+
 describe("overlayScrollLock listener lifecycle", () => {
   test("listener attaches on first push, detaches on last pop", () => {
     expect(isListenerAttached()).toBe(false);
@@ -186,7 +260,7 @@ describe("overlay escape stack (#232)", () => {
       createOverlayLock(open, ".x-scroll-only");
       setOpen(true);
       await flush();
-      expect(overlayCount()).toBe(1); // scroll-lock refcount pushed
+      expect(overlayCount()).toBe(1); // covering refcount pushed
       expect(overlayEscapeDepth()).toBe(0); // but not ESC-closable
       expect(runTopmostOverlayEscape()).toBe(false);
       dispose();
@@ -241,15 +315,18 @@ describe("overlay escape stack (#232)", () => {
   });
 });
 
-// #1199 — `createOverlayEscape` is the ESC half of `createOverlayLock` on its
-// own: the SAME LIFO stack and the same lifecycle edges, minus the scroll-lock
-// refcount. It exists because the scrollback cards (whois/whowas/lusers) are
-// inline content, not covering overlays — enrolling them through
-// createOverlayLock would hold a refcount for the life of the card, freezing
-// the scrollback snapshot behind it and adding the iOS `overlay-open` touch
-// lock (`RailActions.tsx:74-77` records the same hazard for the rail column).
+// #1199 — `createOverlayEscape` is the NO-FREEZE variant of `createOverlayLock`:
+// the SAME LIFO stack, the same lifecycle edges, minus the COVERING refcount. It
+// exists because the scrollback cards (whois/whowas/lusers) are inline content,
+// not covering overlays — enrolling them through createOverlayLock would hold a
+// covering refcount for the life of the card, freezing the scrollback snapshot
+// behind it (`RailActions.tsx` records the same hazard for the rail column).
+//
+// #1772 — the iOS touch lock is NOT part of what it gives up. It used to be, and
+// that was the bug: a drag with a card or the context menu open panned the whole
+// app shell, because the lock and the freeze were one number.
 describe("overlay escape-only registration (#1199)", () => {
-  test("joins the Esc stack without touching the scroll-lock refcount", async () => {
+  test("joins the Esc stack + the touch lock, without the covering refcount", async () => {
     await createRoot(async (dispose) => {
       const [open, setOpen] = createSignal(false);
       createOverlayEscape(open, () => setOpen(false));
@@ -257,14 +334,19 @@ describe("overlay escape-only registration (#1199)", () => {
       setOpen(true);
       await flush();
       expect(overlayEscapeDepth()).toBe(1);
+      // The freeze axis stays clear — the pane behind keeps its own behaviour.
       expect(overlayCount()).toBe(0);
-      expect(document.documentElement.classList.contains(CLASS)).toBe(false);
-      expect(isListenerAttached()).toBe(false);
+      // …and the touch-lock axis is armed, which is the whole of #1772.
+      expect(shellLockCount()).toBe(1);
+      expect(document.documentElement.classList.contains(CLASS)).toBe(true);
+      expect(isListenerAttached()).toBe(true);
 
       expect(runTopmostOverlayEscape()).toBe(true);
       await flush();
       expect(open()).toBe(false);
       expect(overlayEscapeDepth()).toBe(0);
+      expect(shellLockCount()).toBe(0);
+      expect(isListenerAttached()).toBe(false);
       dispose();
     });
   });
@@ -287,6 +369,62 @@ describe("overlay escape-only registration (#1199)", () => {
       expect(overlayEscapeDepth()).toBe(1);
       dispose();
       expect(overlayEscapeDepth()).toBe(0);
+    });
+  });
+
+  // #1772 — the ESC registration and the shell lock share ONE lifecycle, so
+  // the two structures cannot drift. Asserted on the SAME edges as above, on
+  // the lock axis: a shell lock stranded by a close-then-teardown leaves the
+  // non-passive document `preventDefault` attached until a full page reload —
+  // i.e. an iOS scroll frozen for good, the exact hazard `createOverlayLock`'s
+  // deferred-push re-check exists to avoid on the covering side.
+  test("the shell lock follows the same open / close / unmount edges", async () => {
+    await createRoot(async (dispose) => {
+      const [open, setOpen] = createSignal(true);
+      createOverlayEscape(open, vi.fn());
+      await flush();
+      expect(shellLockCount()).toBe(1);
+
+      setOpen(false);
+      await flush();
+      expect(shellLockCount()).toBe(0);
+      expect(isListenerAttached()).toBe(false);
+
+      setOpen(true); // re-opened, then torn down while still open
+      await flush();
+      expect(shellLockCount()).toBe(1);
+      dispose();
+      expect(shellLockCount()).toBe(0);
+      expect(isListenerAttached()).toBe(false);
+      expect(document.documentElement.classList.contains(CLASS)).toBe(false);
+    });
+  });
+
+  // The re-entrancy guard, on the lock axis. `createEffect` re-runs on any
+  // tracked read, and an open surface whose predicate recomputes to the same
+  // `true` must NOT push a second time — the `registered` latch is what makes
+  // push/release one-to-one, and a double push would survive the release.
+  test("a re-run of the open predicate does not double-push the shell lock", async () => {
+    await createRoot(async (dispose) => {
+      const [open, setOpen] = createSignal(false);
+      const [nudge, setNudge] = createSignal(0);
+      createOverlayEscape(() => {
+        nudge();
+        return open();
+      }, vi.fn());
+
+      setOpen(true);
+      await flush();
+      expect(shellLockCount()).toBe(1);
+
+      setNudge(1); // predicate re-runs, still open
+      await flush();
+      expect(shellLockCount()).toBe(1);
+
+      setOpen(false);
+      await flush();
+      expect(shellLockCount()).toBe(0);
+      dispose();
     });
   });
 

--- a/cicchetto/src/__tests__/overlaySurfaceLockContract.test.tsx
+++ b/cicchetto/src/__tests__/overlaySurfaceLockContract.test.tsx
@@ -1,0 +1,244 @@
+import { render } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
+import LusersCard from "../LusersCard";
+import type { WhoisBundle, WhoReply, WhoUser } from "../lib/api";
+import { applyLusersBundle, markLusersRequested } from "../lib/lusersBundle";
+import {
+  __resetForTest,
+  isListenerAttached,
+  overlayCount,
+  shellLockCount,
+} from "../lib/overlayScrollLock";
+import { setSelectedChannel } from "../lib/selection";
+import { dismissWhoModal, setWhoReply } from "../lib/whoModal";
+import { setWhowasBundle } from "../lib/whowasCard";
+import WhoisCard from "../WhoisCard";
+import WhoModal from "../WhoModal";
+import WhowasCard from "../WhowasCard";
+
+// #1772 — WHICH SURFACES ARM WHICH AXIS. `overlayScrollLock` already had unit
+// coverage for the refcount/listener lifecycle, and that is precisely what let
+// this bug through: nothing said which SURFACES enrol. The inline whois card
+// and the long-press context menu both took `createOverlayEscape`, which held
+// no lock at all, so on an iPhone a drag with either of them open panned the
+// whole app shell — the one thing the shell is never supposed to do.
+//
+// The two axes are now two counters, and every surface is pinned against BOTH:
+//
+//   * TOUCH LOCK — `html.overlay-open` + the non-passive document `touchmove`
+//     handler that preventDefaults a gesture with no scrollable ancestor. This
+//     is the only thing that stops UIKit claiming the drag as a page pan
+//     (overlayScrollLock's v1-v6 history: CSS alone never did). EVERY
+//     dismissable surface wants it.
+//   * FREEZE — `overlayCount()`, the covering-overlay count `ScrollbackPane`
+//     derives `isOverlayFrozen()` from (and `globalPaste` / `Shell`'s swipe
+//     guard read as "something is covering the shell"). Only a surface that
+//     COVERS the pane wants it; a surface that sits in or over the flow must
+//     leave the pane live, which is why #1199 kept the cards out of it.
+//
+// WhoModal is the contrast arm on purpose: it is a covering modal, it takes
+// `createOverlayLock`, and it must keep BOTH — a test that only ever asserted
+// "no freeze" would pass just as happily on a build that had lost the freeze
+// everywhere.
+//
+// jsdom sees the class, the listener and the counts; it does NOT see the iOS
+// gesture. The felt result on a real iPhone is a device-dogfood item — see the
+// PR body and `feedback_playwright_webkit_not_ios_scroll`: Playwright's webkit
+// does not reproduce UIScrollView's gesture model either, so no gate we run can
+// close this. What these assertions DO close is the actual regression shape:
+// a surface wired to the wrong helper.
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+const touchLockArmed = (): boolean =>
+  isListenerAttached() && document.documentElement.classList.contains("overlay-open");
+
+const WHOIS_BUNDLE: WhoisBundle = {
+  network: "azzurra",
+  target: "alice",
+  source: "user",
+  user: "alice_u",
+  host: "alice.host",
+  realname: "Alice Liddell",
+  server: "irc.azzurra.org",
+  server_info: "Azzurra Hub",
+  is_operator: false,
+  oper_text: null,
+  idle_seconds: null,
+  signon: null,
+  channels: null,
+  using_ssl: false,
+  is_registered: false,
+  is_admin: false,
+  is_services_admin: false,
+  is_helper: false,
+  is_chanop: false,
+  is_agent: false,
+  is_java: false,
+  umodes: null,
+  away_message: null,
+  actually_host: null,
+  actually_ip: null,
+  account: null,
+  secure: false,
+  secure_cipher: null,
+  certfp: null,
+  extra_lines: null,
+};
+
+const WHOWAS_BUNDLE = {
+  network: "azzurra",
+  target: "Alice",
+  user: "alice_u",
+  host: "alice.host",
+  realname: "Alice Liddell",
+  server: "irc.azzurra.org",
+  logoff_time: "Mon May 13 12:34:56 2026",
+  not_found: false,
+};
+
+const LUSERS_SNAPSHOT = {
+  total_users: 1234,
+  invisible: 56,
+  servers: 3,
+  operators: 7,
+  unknown_connections: 2,
+  channels_formed: 89,
+  local_clients: 100,
+  local_servers: 1,
+  current_local: 100,
+  max_local: 200,
+  current_global: 1234,
+  max_global: 5000,
+};
+
+const MENU_ITEMS: ContextMenuItem[] = [{ label: "whois", enabled: true, action: vi.fn() }];
+
+const WHO_SLUG = "azzurra";
+
+const whoRow = (over: Partial<WhoUser>): WhoUser => ({
+  nick: "alice",
+  user: "au",
+  host: "ah.example.org",
+  server: "irc.test.org",
+  modes: "H",
+  hops: 0,
+  realname: "Alice Liddell",
+  channel: "#bofh",
+  ...over,
+});
+
+const whoRoster = (users: WhoUser[]): WhoReply => ({
+  network: WHO_SLUG,
+  target: "#bofh",
+  users,
+});
+
+beforeEach(() => {
+  __resetForTest();
+});
+
+afterEach(() => {
+  dismissWhoModal(WHO_SLUG);
+  setSelectedChannel(null);
+  __resetForTest();
+});
+
+describe("#1772 in-flow surfaces arm the touch lock and do NOT freeze the pane", () => {
+  it("the dismissable WHOIS card arms the touch lock, holding no covering refcount", async () => {
+    render(() => <WhoisCard bundle={WHOIS_BUNDLE} onDismiss={vi.fn()} />);
+    await flush();
+
+    expect(touchLockArmed()).toBe(true);
+    expect(shellLockCount()).toBe(1);
+    // The pane behind stays LIVE: the freeze predicate reads this count only.
+    expect(overlayCount()).toBe(0);
+  });
+
+  it("the WHOIS card releases the touch lock on unmount", async () => {
+    const { unmount } = render(() => <WhoisCard bundle={WHOIS_BUNDLE} onDismiss={vi.fn()} />);
+    await flush();
+    expect(touchLockArmed()).toBe(true);
+
+    unmount();
+
+    // A stranded holder leaves the non-passive document `preventDefault`
+    // attached until a full reload — i.e. an iOS scroll frozen for good.
+    expect(shellLockCount()).toBe(0);
+    expect(touchLockArmed()).toBe(false);
+  });
+
+  it("the message context menu arms the touch lock, holding no covering refcount", async () => {
+    render(() => <ContextMenu items={MENU_ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+    await flush();
+
+    expect(touchLockArmed()).toBe(true);
+    expect(shellLockCount()).toBe(1);
+    expect(overlayCount()).toBe(0);
+  });
+
+  it("the context menu releases the touch lock on unmount", async () => {
+    const { unmount } = render(() => (
+      <ContextMenu items={MENU_ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />
+    ));
+    await flush();
+    expect(touchLockArmed()).toBe(true);
+
+    unmount();
+
+    expect(shellLockCount()).toBe(0);
+    expect(touchLockArmed()).toBe(false);
+  });
+
+  // The whois card was the reported surface; whowas and lusers are the same
+  // class through the same helper, and enumerating them is what makes this a
+  // class fix rather than a fix of the two instances that got reported.
+  it("the WHOWAS card arms the touch lock, holding no covering refcount", async () => {
+    setWhowasBundle("net-lock-whowas", WHOWAS_BUNDLE);
+    render(() => <WhowasCard networkSlug="net-lock-whowas" />);
+    await flush();
+
+    expect(touchLockArmed()).toBe(true);
+    expect(overlayCount()).toBe(0);
+  });
+
+  it("the LUSERS card arms the touch lock, holding no covering refcount", async () => {
+    markLusersRequested("net-lock-lusers");
+    applyLusersBundle("net-lock-lusers", LUSERS_SNAPSHOT);
+    render(() => <LusersCard networkSlug="net-lock-lusers" />);
+    await flush();
+
+    expect(touchLockArmed()).toBe(true);
+    expect(overlayCount()).toBe(0);
+  });
+});
+
+describe("#1772 a covering modal keeps BOTH axes", () => {
+  it("WhoModal arms the touch lock AND holds the covering refcount", async () => {
+    setSelectedChannel({ networkSlug: WHO_SLUG, channelName: "#bofh", kind: "channel" });
+    setWhoReply(WHO_SLUG, whoRoster([whoRow({ nick: "alice" })]));
+    render(() => <WhoModal />);
+    await flush();
+
+    expect(touchLockArmed()).toBe(true);
+    // The freeze axis — the pane behind a covering modal must NOT move, which
+    // is the whole reason `createOverlayEscape` exists as a separate helper.
+    expect(overlayCount()).toBe(1);
+    // …and it takes that axis through the covering counter, not the shell one.
+    expect(shellLockCount()).toBe(0);
+  });
+});
+
+describe("#1772 a persistent rail surface arms neither axis", () => {
+  it("the rail WHOIS card (no onDismiss) holds no lock at all", async () => {
+    render(() => <WhoisCard bundle={WHOIS_BUNDLE} />);
+    await flush();
+
+    // #1199's rule, unchanged: a permanent per-window surface must not hold a
+    // lock for its whole life. Nothing dismisses it, so nothing would release.
+    expect(touchLockArmed()).toBe(false);
+    expect(shellLockCount()).toBe(0);
+    expect(overlayCount()).toBe(0);
+  });
+});

--- a/cicchetto/src/lib/overlayScrollLock.ts
+++ b/cicchetto/src/lib/overlayScrollLock.ts
@@ -41,8 +41,40 @@
 // lock chain (`html.overlay-open body/#root/#root>div { touch-action:
 // none }`) stays as defense-in-depth.
 //
+// #1772 — TWO CONCERNS, TWO COUNTERS. Until this issue a single refcount
+// carried both "arm the iOS touch lock" and "freeze the scrollback
+// snapshot", and the two are not the same question. A surface that sits
+// IN or OVER the flow (the inline whois/whowas/lusers cards, the
+// long-press context menu) wants the shell immobile and the pane behind
+// LIVE; only a surface that COVERS the pane wants the freeze. Welded to
+// one number, those surfaces had to choose, chose no-freeze via
+// `createOverlayEscape` (#1199), and thereby also gave up the touch lock
+// — so on an iPhone a drag with a whois card or a context menu open
+// panned the whole app shell.
+//
+//   coveringCount  — surfaces that COVER the pane. Read by
+//                    `overlayCount()`, which `ScrollbackPane` derives
+//                    `isOverlayFrozen()` from and which `globalPaste` /
+//                    `Shell`'s swipe guard read as "something is
+//                    covering the shell". Its population is unchanged by
+//                    #1772, so every one of those consumers is too.
+//   shellLocks     — surfaces that want the shell immobile WITHOUT
+//                    covering the pane. Touch lock only.
+//
+// The class + the document listener key off the SUM: the touch lock is
+// one global thing, and either population arming it is enough.
+//
+// Safe to arm the class for a NON-covering surface, measured rather than
+// assumed: on mobile the shell already carries `.shell-mobile {
+// touch-action: none }` permanently (default.css, UX-3 UNDEC R3), so the
+// v3 chain adds nothing there and every inner scroller already carries
+// its own `pan-y` carve-out. The one surface that ESCAPES that blanket
+// is the context menu — it portals to `<body>`, outside `.shell-mobile`
+// — which is why it gains a `pan-y` carve-out of its own in this issue,
+// exactly like `.rail-actions-menu` (#913) did.
+//
 // Test surface: pure module state + DOM side-effects. `__resetForTest()`
-// clears refcount + class + detaches the listener so vitest order
+// clears both counters + class + detaches the listener so vitest order
 // doesn't leak state across tests.
 
 import { createEffect, createSignal, onCleanup } from "solid-js";
@@ -58,15 +90,29 @@ const CLASS_NAME = "overlay-open";
 // it, the mutators set it. iOS touch-lock semantics are unchanged (the class +
 // listener side-effects still key off the same numeric value).
 const [count, setCount] = createSignal(0);
+
+// #1772 — the non-covering half of the touch lock. A plain `let`, NOT a signal,
+// and deliberately so: nothing DERIVES from it. The covering count above is a
+// signal because `ScrollbackPane` reads it inside a memo (a stale read there
+// means a pane that never freezes); this one has exactly two consumers, the DOM
+// class and the document listener, and both are imperative side-effects applied
+// at the push/pop edges below. A signal would advertise a reactive contract that
+// no reader wants and that no test could hold anyone to.
+let shellLocks = 0;
 let listenerAttached = false;
 
-// #232 — ordered ESC-close stack. Parallel to the scroll-lock refcount but
-// a DIFFERENT population: it carries the close verb, and only overlays that
-// pass an `onEscape` to createOverlayLock register here (scroll-lock-only
-// overlays — the members/settings drawers, admin pane — push the refcount
-// but NOT this stack). Cannot be derived from the refcount (onEscape ⊆
-// pushed), so it's a separate structure, but its lifecycle is bolted to the
-// SAME push/pop edges inside createOverlayLock so the two never drift.
+/** Holders of the iOS touch lock, from BOTH populations. */
+function touchLockHolders(): number {
+  return count() + shellLocks;
+}
+
+// #232 — ordered ESC-close stack. Parallel to the two counters above but a
+// THIRD population: it carries the close verb, and only overlays that pass an
+// `onEscape` to createOverlayLock register here (lock-only overlays — the
+// members/settings drawers, admin pane — push the covering refcount but NOT
+// this stack). Cannot be derived from either count (onEscape ⊆ pushed), so
+// it's a separate structure, but its lifecycle is bolted to the SAME push/pop
+// edges inside createOverlayLock / createOverlayEscape so they never drift.
 //
 // `runTopmostOverlayEscape()` invokes the LAST-registered overlay's onEscape
 // (topmost-first) — the single ESC authority `keybindings.ts` calls before
@@ -99,11 +145,23 @@ function root(): HTMLElement | null {
 function applyClass(): void {
   const el = root();
   if (el === null) return;
-  if (count() > 0) {
+  if (touchLockHolders() > 0) {
     el.classList.add(CLASS_NAME);
   } else {
     el.classList.remove(CLASS_NAME);
   }
+}
+
+/**
+ * Re-derive both touch-lock side-effects from the current holder total. Called
+ * from EVERY push/pop edge on either counter, so the class and the listener can
+ * never disagree with the numbers — and so a new counter, if this ever grows a
+ * third population, has one place to join rather than four.
+ */
+function syncTouchLock(): void {
+  applyClass();
+  if (touchLockHolders() > 0) attachListener();
+  else detachListener();
 }
 
 /**
@@ -154,27 +212,67 @@ function detachListener(): void {
  */
 export function pushOverlay(_target: HTMLElement | null): void {
   setCount(count() + 1);
-  applyClass();
-  attachListener();
+  syncTouchLock();
 }
 
 /**
  * Pop an overlay off the lock stack. Pops below zero are clamped.
- * Detaches the touchmove listener when the refcount drops to zero.
+ * Detaches the touchmove listener when the last holder — of EITHER
+ * population — drops off.
  */
 export function popOverlay(_target: HTMLElement | null): void {
   setCount(Math.max(0, count() - 1));
-  applyClass();
-  if (count() === 0) detachListener();
+  syncTouchLock();
 }
 
 /**
- * Current refcount — a TRACKED Solid source. Reading it inside a memo /
- * effect subscribes to overlay open/close transitions (#219-general).
- * Also exposed for vitest assertions.
+ * #1772 — take the iOS touch lock WITHOUT joining the covering-overlay count:
+ * "the shell must not move while I am open", said by a surface that does not
+ * cover the scrollback pane. Pair with `popShellLock()`.
+ *
+ * Same global effect as `pushOverlay` (the `overlay-open` class + the
+ * non-passive document `touchmove` handler) and a DIFFERENT population:
+ * `overlayCount()` does not move, so the pane behind keeps scrolling, keeps
+ * following the tail, and never freezes its snapshot.
+ *
+ * Not a parameter on `pushOverlay`: the two verbs have different pop
+ * obligations, and a `push(el, {freeze:false})` / `pop(el, {freeze:true})`
+ * mismatch would corrupt both counters at once with nothing to catch it.
+ * Distinct verbs make that mistake unspellable.
+ */
+export function pushShellLock(): void {
+  shellLocks += 1;
+  syncTouchLock();
+}
+
+/** Release a shell lock. Pops below zero are clamped, as with `popOverlay`. */
+export function popShellLock(): void {
+  shellLocks = Math.max(0, shellLocks - 1);
+  syncTouchLock();
+}
+
+/**
+ * Current COVERING-overlay refcount — a TRACKED Solid source. Reading it
+ * inside a memo / effect subscribes to overlay open/close transitions
+ * (#219-general). Also exposed for vitest assertions.
+ *
+ * #1772 — this counts surfaces that COVER the pane, which is narrower than
+ * "surfaces holding the touch lock": an in-flow card or the context menu arms
+ * the lock and is deliberately absent here, because every consumer of this
+ * number is asking the covering question (freeze the snapshot, suppress the
+ * global paste, refuse a swipe that would stack a drawer under something).
  */
 export function overlayCount(): number {
   return count();
+}
+
+/**
+ * Current non-covering shell-lock count. Exposed for vitest assertions only —
+ * production code has no business asking, since the two side-effects this
+ * number drives are applied here.
+ */
+export function shellLockCount(): number {
+  return shellLocks;
 }
 
 /** Whether the document-level touchmove listener is currently attached. */
@@ -204,9 +302,10 @@ export function overlayEscapeDepth(): number {
   return escapeStack.length;
 }
 
-/** Test reset — clears refcount, DOM class, detaches listener, empties the ESC stack. */
+/** Test reset — clears BOTH counters, the DOM class, the listener, the ESC stack. */
 export function __resetForTest(): void {
   setCount(0);
+  shellLocks = 0;
   const el = root();
   if (el !== null) el.classList.remove(CLASS_NAME);
   detachListener();
@@ -292,19 +391,28 @@ export function createOverlayLock(
 }
 
 /**
- * #1199 — the ESC half of `createOverlayLock` on its own: the SAME ordered
- * stack and the same open/close/unmount edges, WITHOUT the scroll-lock
- * refcount. Call from a component body:
+ * #1199 — the NO-FREEZE variant of `createOverlayLock`: the SAME ordered ESC
+ * stack, the same iOS touch lock, the same open/close/unmount edges — WITHOUT
+ * the covering-overlay refcount. Call from a component body:
  *
  *   createOverlayEscape(() => myBundle() !== undefined, dismissMyCard);
  *
- * For a surface that is dismissable but covers nothing — the inline scrollback
+ * For a surface that is dismissable but covers nothing: the inline scrollback
  * cards (whois / whowas / lusers), which render in the message flow rather than
- * over it. Going through `createOverlayLock` would ALSO hold a refcount for the
- * whole life of the card, which freezes the scrollback snapshot behind it
- * (`ScrollbackPane`'s `isOverlayFrozen`) and adds the iOS `overlay-open` touch
- * lock: the hazard `RailActions.tsx` already records for the permanent rail
- * column. A surface that DOES cover the pane still wants `createOverlayLock`.
+ * over it, and the long-press context menu, which floats at fixed coordinates
+ * over a pane that stays live behind it. Going through `createOverlayLock`
+ * would ALSO hold a COVERING refcount for the whole life of the surface, which
+ * freezes the scrollback snapshot behind it (`ScrollbackPane`'s
+ * `isOverlayFrozen`) — the hazard `RailActions.tsx` records for the permanent
+ * rail column. A surface that DOES cover the pane still wants
+ * `createOverlayLock`.
+ *
+ * #1772 — the touch lock is on this side of the split. It used to be welded to
+ * the covering refcount, so a card or a menu could have the shell immobile or
+ * the pane live but not both, and the surfaces here silently took the second:
+ * on an iPhone a drag with a whois card or a context menu open panned the whole
+ * app shell. The shell is meant to be furniture. Now `pushShellLock` arms the
+ * lock from the non-covering population and `overlayCount()` never moves.
  *
  * Membership of the one shared stack is the point, not an implementation
  * detail: it is what makes a modal opened over a card close FIRST. A private
@@ -313,7 +421,12 @@ export function createOverlayLock(
  *
  * No deferred microtask, unlike `createOverlayLock`: that deferral exists only
  * so Solid can commit the render before `querySelector` looks for the lock
- * element, and there is no element to look for here.
+ * element, and there is no element to look for here. Leak-safety therefore
+ * comes from the shape rather than from a re-check — the `registered` latch
+ * makes push and release idempotent and pairs them one-to-one, `onCleanup`
+ * releases on unmount-while-open, and `popShellLock` clamps at zero. There is
+ * no window in which a queued push can outlive the close that should have
+ * cancelled it, which is the failure `createOverlayLock` has to guard against.
  */
 export function createOverlayEscape(isOpen: () => boolean, onEscape: () => void): void {
   const escapeToken = {};
@@ -321,6 +434,7 @@ export function createOverlayEscape(isOpen: () => boolean, onEscape: () => void)
   const release = (): void => {
     if (!registered) return;
     unregisterEscape(escapeToken);
+    popShellLock();
     registered = false;
   };
   createEffect(() => {
@@ -330,6 +444,7 @@ export function createOverlayEscape(isOpen: () => boolean, onEscape: () => void)
     }
     if (registered) return;
     registerEscape(escapeToken, onEscape);
+    pushShellLock();
     registered = true;
   });
   onCleanup(release);

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7810,6 +7810,17 @@ button.topic-bar-windows-opener::before,
   padding: 0;
   margin: 0;
   cursor: default;
+  /* #1772 — the backdrop reads like a shield and, until this issue, only ever
+     intercepted CLICKS. A DRAG on it fell through to UIKit as a page pan: the
+     shell slid while the fixed-position menu stayed put, so the content came
+     out from under its own menu. `none` is the honest declaration for a
+     full-viewport shield — there is nothing beneath it that a gesture is meant
+     to reach, and `auto` (the value it had by omission) is precisely the
+     iOS chrome-drag hole #1067 records for any untouched touchable surface.
+     Defense-in-depth only: CSS alone has never stopped UIKit here (see
+     `lib/overlayScrollLock.ts`, v1-v3), and the menu now arms the JS touch
+     lock, which is the half that actually works. */
+  touch-action: none;
 }
 
 .context-menu {
@@ -7846,6 +7857,28 @@ button.topic-bar-windows-opener::before,
     )
   );
   overflow-y: auto;
+  /* #1772 — the scroller carve-out, now that the menu arms the touch lock and
+     so puts the `html.overlay-open body` none-blanket over its own parent. The
+     menu PORTALS to <body>, which is why it escaped `.shell-mobile`'s
+     permanent blanket and needed no carve-out before: it was the one overlay
+     scroller living outside it. The `max-height` + `overflow-y: auto` above
+     make a long item list genuinely scrollable, and without this that scroll
+     would be refused the moment the lock it now takes is armed — fixing the
+     pan by removing the scroll. Same shape as `.rail-actions-menu` (#913).
+     No braces in this comment on purpose: `ruleBody` in the test helper
+     captures up to the first closing brace, so a comment that spells a CSS
+     rule out literally truncates the body its own guard reads. */
+  touch-action: pan-y;
+}
+
+/* #1772 — descendant half of the carve-out above, for the reason #913 spells
+   out at `.rail-actions-menu *`: touch-action does NOT inherit, so every item
+   row sits at the default `auto` under a `none` ancestor, and iOS elects the
+   gesture consumer from the hit-test target's own value. The rows ARE the
+   hit-test target across the whole menu, so the scroller-level declaration
+   alone is the version that ships and does not work. */
+.context-menu * {
+  touch-action: pan-y;
 }
 
 /* #949 — the ruler the placement math measures (ContextMenu.tsx). Fixed, so

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -64307,3 +64307,123 @@ benchmarked. And nothing here establishes that a paused window is CHEAPER end
 to end once the pause/resume re-join, its join reply and its REST backfill are
 counted against the ~24.4 events/s it stops paying for; that trade is argued,
 not measured.
+<!-- entry #1772 -->
+
+---
+
+## 2026-08-25 — #1772: the iOS touch lock and the scrollback freeze are two concerns, not one counter
+
+vjt, iPhone PWA: with the inline `/whois` card open, or with the long-press
+message context menu open, a touch drag pans the whole app shell. Everywhere
+else the shell is furniture.
+
+The only thing that makes it furniture is the JS touch lock in
+`cicchetto/src/lib/overlayScrollLock.ts` — the v6 non-passive document
+`touchmove` handler that walks the gesture target's ancestor chain and
+`preventDefault`s when no scrollable ancestor exists. The module's own v1-v6
+history already records that CSS is not enough: UIKit's `UIScrollView` claims
+the gesture at `touchstart`, and `touch-action` / `overscroll-behavior` do not
+stop it. Neither reported surface armed that handler.
+
+### The forced choice
+
+They could not arm it. ONE refcount carried two unrelated concerns — "hold the
+shell still" and "freeze the scrollback snapshot behind me" — because
+`ScrollbackPane`'s `isOverlayFrozen()` derives from the same number the class
+and the listener key off. A surface that sits in or over the flow wants the
+first and must refuse the second, so #1199 gave the inline cards
+`createOverlayEscape`, which buys the no-freeze by giving up the lock as well.
+The choice was forced by the data structure, not by anything true about the
+surfaces.
+
+### What was split, and what deliberately was not
+
+The POPULATION, not the helper. `shellLocks` counts surfaces that want the
+shell immobile without covering the pane; the `overlay-open` class and the
+document listener key off the SUM of the two counters. `overlayCount()` keeps
+its exact former population — covering overlays — and that is the load-bearing
+half of the design: its three consumers are all asking the covering question
+and none of them change. `ScrollbackPane.isOverlayFrozen`, `globalPaste`
+("respect open modals"), and `Shell`'s swipe guard against stacking a drawer
+under an open overlay. Renaming it to `coveringOverlayCount()` was considered
+and declined: ~12 files including four `vi.mock` factories, against a naming
+nicety, on a bug fix.
+
+TWO VERBS, not a `{ freeze: false }` flag on `pushOverlay`. A flag makes
+`push(el, {freeze: false})` / `pop(el, {freeze: true})` spellable, and that
+mismatch corrupts BOTH counters at once with nothing to catch it — one clamps
+at zero while the other strands a holder, and a stranded holder leaves the
+non-passive `preventDefault` attached until a full page reload, i.e. an iOS
+scroll frozen for good. Distinct verbs make the mistake unspellable.
+
+NO THIRD HELPER, which is where this departs from the issue's own sketch.
+`createOverlayEscape` gained the lock instead. The three-way split collapses to
+a two-way one because no surface wants ESC without the shell held still: the
+four callers are the whois / whowas / lusers cards and the context menu, all
+dismissable, all covering nothing. A third helper fixes the two reported
+instances and leaves whowas and lusers carrying the same defect, with two
+helpers differing on an axis nobody can name.
+
+`shellLocks` is a plain `let`, not a signal, and the asymmetry with the
+covering count is deliberate: that one is a signal because `ScrollbackPane`
+reads it inside a memo, where a stale read means a pane that never freezes.
+Nothing derives from this one — its two consumers are DOM side-effects applied
+imperatively at the push/pop edges — so a signal would advertise a reactive
+contract no reader wants.
+
+### Why arming the class for a non-covering surface is safe
+
+Measured, not assumed. The worry was real: the v3 chain puts `touch-action:
+none` on html / body / #root / #root > div, and a non-covering surface leaves
+the shell underneath LIVE and usable. But on mobile `.shell-mobile` already
+carries `touch-action: none` PERMANENTLY (UX-3 UNDEC R3) — not overlay-gated —
+so the v3 chain adds nothing there, and every inner scroller already carries
+its own `pan-y` carve-out because of it. The union of two identical blankets is
+the same blanket.
+
+Exactly one scroller escapes it: the context menu PORTALS to `<body>`, outside
+`.shell-mobile`, which is why it is the only overlay scroller in the app with
+no carve-out. It gets one now — `pan-y` on the menu AND on its descendants,
+the shape #913 arrived at for `.rail-actions-menu` after the scroller-only form
+shipped and did not work (touch-action does not inherit; iOS elects the gesture
+consumer from the hit-test target's own value, and the item rows ARE the target
+across the whole menu). Without it, arming the lock would have fixed the pan by
+removing the scroll.
+
+The backdrop takes the opposite declaration for the same cause.
+`.context-menu-backdrop` is `position: fixed; inset: 0` and reads like a
+shield, but it only ever intercepted CLICKS; a DRAG on it went to UIKit as a
+page pan, and since the menu is at fixed coordinates, the content slid out from
+under its own menu. `touch-action: none` is the honest value for a
+full-viewport shield. Defense-in-depth only — CSS never stopped UIKit here.
+
+### Coverage, and what it does not buy
+
+`overlayScrollLock` had lifecycle coverage for the refcount and NONE for which
+SURFACES enrol, and that is precisely the gap this bug walked through.
+`overlaySurfaceLockContract.test.tsx` now pins every surface against BOTH axes,
+with `WhoModal` as the covering contrast arm — a build that lost the freeze
+everywhere must not pass. Four mutants, each killing a disjoint set: dropping
+the push kills the nine "arms the lock" assertions and nothing else; routing
+the shell lock through the covering counter (the obvious fix the issue rejects)
+kills twelve including the freeze-axis ones; each CSS declaration kills exactly
+its own assertion.
+
+None of it is the gesture. jsdom sees the class, the listener and the counts;
+Playwright's webkit does not reproduce UIScrollView, so an e2e here would prove
+the refcount and the classes, not the drag. **This issue is not closable on a
+green gate** — the felt result on a real iPhone is the verdict, and the PR
+carries the device checklist.
+
+One measured non-change, stated so it is not rediscovered as new:
+`.scrollback-overlay` (the floating card layer) is `overflow-y: auto` and sits
+at `auto`, inside `.shell-mobile`'s permanent blanket. A whois card taller than
+the pane therefore cannot be scrolled on mobile TODAY, before and after this
+change. It is a real defect and a different one; fixing it here would be an
+unverifiable behaviour change riding a bug fix.
+
+Also recorded because it cost a red on a correct rule: `ruleBody` in
+`__tests__/helpers/themeCss.ts` captures up to the first CLOSING BRACE, so a
+CSS comment that spells a rule out literally (`selector { prop: value }`)
+truncates the body its own source-level guard reads. The assertion fails on a
+declaration that is present and correct.


### PR DESCRIPTION
Fixes the iOS shell pan reported in #1772: with the inline `/whois` card or the
long-press message context menu open, a touch drag moved the whole app shell.

## The change

The only thing that holds the shell still on iOS is the JS touch lock in
`cicchetto/src/lib/overlayScrollLock.ts` — the v6 non-passive document
`touchmove` handler that walks the gesture target's ancestor chain and
`preventDefault`s when no scrollable ancestor exists. Neither surface armed it,
and neither could: **one refcount carried two unrelated concerns** — "hold the
shell still" and "freeze the scrollback snapshot behind me". A surface in or
over the flow wants the first and must refuse the second, so #1199 gave the
cards `createOverlayEscape`, which buys the no-freeze by giving up the lock too.

Split the **population**, not the helper:

| | covering count (`overlayCount()`) | shell locks (new) |
|---|---|---|
| freeze the pane | yes | no |
| `overlay-open` class + document listener | yes | yes |
| holders | `createOverlayLock` — modals, drawers, WhoModal | `createOverlayEscape` — whois / whowas / lusers cards, context menu |

The class and the listener key off the **sum**. `overlayCount()` keeps its exact
former population, which is the load-bearing half: its three consumers are all
asking the covering question and none of them change —
`ScrollbackPane.isOverlayFrozen`, `globalPaste`, and `Shell`'s guard against
swiping a drawer under an open overlay.

Three judgement calls, argued in the DESIGN_NOTES entry:

* **Two verbs, not a `{ freeze: false }` flag.** A flag makes
  `push(el, {freeze:false})` / `pop(el, {freeze:true})` spellable, and that
  mismatch corrupts both counters at once with nothing to catch it. A stranded
  holder leaves the `preventDefault` attached until a full reload — an iOS
  scroll frozen for good.
* **No third helper — `createOverlayEscape` gained the lock.** This departs from
  the issue's sketch. The three-way split collapses to a two-way one because no
  surface wants ESC without the shell held still; a third helper fixes the two
  reported instances and leaves whowas and lusers carrying the same defect.
* **`overlayCount()` not renamed** to say which population it means. ~12 files
  including four `vi.mock` factories, for a naming nicety, on a bug fix.

### The stylesheet half

`.context-menu-backdrop` is `position: fixed; inset: 0` and reads like a shield
but only intercepted **clicks**; a drag went to UIKit as a page pan, and since
the menu is at fixed coordinates the content slid out from under its own menu.
It now declares `touch-action: none`.

The menu takes the opposite declaration for the same cause. It is a real
scroller (`max-height` + `overflow-y: auto`, #487) and it **portals to
`<body>`** — the one overlay scroller outside `.shell-mobile`'s permanent
`touch-action: none` blanket, hence the only one that never needed a carve-out.
Arming the lock puts `html.overlay-open body` over its parent, so without
`pan-y` on the menu **and its descendants** (#913's shape for
`.rail-actions-menu`) this would have fixed the pan by removing the scroll.

**Measured, so the blanket is not a worry:** on mobile `.shell-mobile` already
carries `touch-action: none` permanently (UX-3 UNDEC R3), not overlay-gated, so
arming the v3 chain for a surface that leaves the shell live adds nothing on the
platform of the defect, and every inner scroller already carries its own pan-y.

## 🔴 Device verification is owed — this is not closable on a green gate

jsdom sees the class, the listener and the counts; it does not see the gesture.
Playwright's `webkit` does not reproduce UIScrollView, so an e2e here would
prove the refcount and the classes, **not the drag**. No e2e spec was added for
that reason (and it would have needed a STACK lane I did not hold). Checklist
for the iPhone PWA:

1. `/whois <nick>` → card up → drag anywhere on the shell (topic bar, compose,
   the card itself): **nothing moves**.
2. Same, drag on the scrollback: **the pane still scrolls normally** and the
   reader's position is not frozen when new lines arrive.
3. Long-press a message → menu up → drag on the backdrop and on the menu:
   **shell still**; a menu long enough to overflow **still scrolls**.
4. `/who #chan` → WhoModal → unchanged: shell still, pane behind frozen.
5. `/whowas`, `/lusers` cards: same as (1)+(2).
6. Open and dismiss each surface a few times, then scroll: **scrolling still
   works** (a stranded refcount would leave it dead until reload).

## Gates

| gate | result |
|---|---|
| `scripts/bun.sh run check` | **rc=0** — 5 stages, 0 failed (lock drift, test location, biome, tsc src, tsc e2e) |
| `scripts/bun.sh run test` | **rc=0** — 317 files, **6310 passed**, 0 failed |
| `scripts/design-notes-gate.sh` | **rc=0** — `1 new entry heading(s), separator and marker present` (re-run after the rebase) |
| `scripts/union-rebase.sh` | **rc=0** — `docs/DESIGN_NOTES.md: +120 -0 — contribution intact` |

Both cic gates were re-run **after** the rebase onto `a453325e`, not before.

**Not run, deliberately:** `scripts/check.sh` / `test.sh` (COMPILE lane — the
diff has zero Elixir), `scripts/integration.sh` (STACK lane — no new e2e spec;
CI will run it anyway, `cicchetto/src/**` is in the path filter), `scripts/bats.sh`
beyond the DESIGN_NOTES gate (no bash touched).

## Mutation evidence

Four mutants, each killing a disjoint set — the tests are not mirrors:

| mutant | dead assertions |
|---|---|
| drop `pushShellLock()` from `createOverlayEscape` (= the bug, restored) | 9, all "arms the touch lock"; WhoModal and the rail card stay green |
| route the shell lock through the covering counter (= the obvious fix the issue rejects) | 12, including every freeze-axis assertion |
| drop `touch-action: none` from `.context-menu-backdrop` | exactly 1 |
| drop `touch-action: pan-y` from `.context-menu` | exactly 1 |

## Measured non-changes, so they are not rediscovered as new

* **`.scrollback-overlay` cannot scroll a tall card on mobile, today.** The
  floating card layer is `overflow-y: auto` at `touch-action: auto`, inside
  `.shell-mobile`'s permanent blanket — so a whois card taller than the pane is
  unpannable **before and after** this change. Real, different defect; fixing it
  here would be an unverifiable behaviour change riding a bug fix. Worth its own
  issue if you want it.
* **`ruleBody` truncates at the first closing brace.** A CSS comment that quotes
  a rule literally (`selector { prop: value }`) reds its own source-level guard
  on a declaration that is present and correct. Cost one red here; recorded in
  place and in DESIGN_NOTES.
