### PR TITLE
feat(#1773): the credits easter egg, and the build facts it needed derived outside the container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,10 +172,10 @@ LOG_LEVEL=info
 # GRAPPA_SUBSTRATE=docker
 
 # ─── cicchetto bundle build (compose-only, `--profile prod`) ──────────────────
-# #1037: both are read by compose.yaml ALONE — neither reaches config/runtime.exs
-# or bin/start.sh, so neither is an app var. Every deploy wrapper already sets
-# them; documented for the operator who drives `docker compose --profile prod
-# run --rm cicchetto-build` by hand.
+# #1037: all three are read by compose.yaml ALONE — none reaches
+# config/runtime.exs or bin/start.sh, so none is an app var. Every deploy
+# wrapper already sets them; documented for the operator who drives `docker
+# compose --profile prod run --rm cicchetto-build` by hand.
 #
 # GRAPPA_VERSION is the `cicchetto-build` `environment:` entry vite bakes into
 # `<meta name="cicchetto-version">` (#538/#652). Compose forwards it as EMPTY
@@ -185,6 +185,16 @@ LOG_LEVEL=info
 # infra/packaging/version.sh. Set it to stamp a bundle with something other
 # than the checkout's VERSION.
 # GRAPPA_VERSION=
+#
+# GRAPPA_CREDITS is the same shape for the credits easter egg (#1773): the JSON
+# payload of git facts — commit sha, its date, and every contributor with their
+# commit count — that the settings credit roll renders. Same reason it is an env
+# var and not a file read: that container has no repo. The wrappers derive it
+# per launch via infra/packaging/credits.sh, which NEVER fails — on a build with
+# no `.git` (the AUR tarball, the release image) it reports the absence honestly
+# and the roll degrades to the version alone. Vite still refuses an EMPTY value,
+# because empty means a wrapper forgot to plumb it. Do not hand-write one.
+# GRAPPA_CREDITS=
 #
 # CIC_BUILD_OUT is the host side of that service's `volumes:` mount — where the
 # built SPA lands. Defaults to the directory the BEAM serves (CIC_DIST_ROOT

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -29,10 +29,20 @@ COPY cicchetto/ ./
 # layout version.sh expects (SCRIPT_DIR/../.. == repo root, so it reads
 # ./VERSION, #652), so nothing re-implements the read. `--emptyOutDir`
 # because the outDir is outside the vite project root.
+#
+# #1773 — the credit roll's git facts arrive on the same channel, through the
+# same script layout. THIS image is one of the two substrates where they do
+# not exist: `.git` is .dockerignore'd (see the Stage-2 note below, which is
+# why Grappa.Version takes its no-git path here), so credits.sh reports the
+# absence honestly and the roll degrades to the version alone. It must not
+# fail, or the release image stops building over an easter egg.
 COPY VERSION ./VERSION
 COPY infra/packaging/version.sh ./infra/packaging/version.sh
+COPY infra/packaging/credits.sh ./infra/packaging/credits.sh
 RUN GRAPPA_VERSION="$(sh infra/packaging/version.sh)" \
     && export GRAPPA_VERSION \
+    && GRAPPA_CREDITS="$(sh infra/packaging/credits.sh)" \
+    && export GRAPPA_CREDITS \
     && echo "cic build: GRAPPA_VERSION=${GRAPPA_VERSION}" \
     && bun run build -- --outDir /cic-dist --emptyOutDir
 

--- a/cicchetto/e2e/compose.yaml
+++ b/cicchetto/e2e/compose.yaml
@@ -556,6 +556,11 @@ services:
       # cannot read mix.exs; scripts/integration.sh derives it from mix.exs
       # @version (infra/packaging/version.sh) and exports it before compose.
       GRAPPA_VERSION: ${GRAPPA_VERSION:-}
+      # #1773 — the credit roll's git facts, on the same channel and for the
+      # same reason (this container mounts only ../../cicchetto). The credits
+      # e2e compares what the modal PAINTS against this exact payload, which
+      # the playwright-runner service receives too.
+      GRAPPA_CREDITS: ${GRAPPA_CREDITS:-}
     command: ["sh", "-c", "bun install --frozen-lockfile && bun run build"]
 
   # nginx-cert-init — push notifications cluster B5 (2026-05-14).
@@ -675,6 +680,12 @@ services:
       # Specs GET /api/v1/messages (list) + /api/v1/message/{id} (body)
       # to extract the NickServ confirmation code/link.
       E2E_MAILPIT_URL: http://mailpit:8025
+      # #1773 — the SAME payload cicchetto-build-test baked into the bundle.
+      # The credits spec reads it here and compares it against what the modal
+      # paints: without it the spec could only assert a shape, and a shape
+      # assertion cannot tell a correct roll from an empty one — which is the
+      # exact failure the whole build-time channel exists to prevent.
+      GRAPPA_CREDITS: ${GRAPPA_CREDITS:-}
     networks:
       grappa-e2e: {}
     command: ["npx", "playwright", "test"]

--- a/cicchetto/e2e/tests/issue1773-credits-roll-bakes-git-facts.spec.ts
+++ b/cicchetto/e2e/tests/issue1773-credits-roll-bakes-git-facts.spec.ts
@@ -1,0 +1,165 @@
+// #1773 — the credit roll paints the git facts the WRAPPER derived, not a
+// plausible shape.
+//
+// THIS IS THE ONLY GATE THAT CAN SEE THE BAKE. The three facts (commit sha,
+// its date, the contributor counts) are derived outside the build container by
+// `infra/packaging/credits.sh` and carried in as vite's
+// `__GRAPPA_CREDITS_JSON__` define. `vitest.config.ts` is a SEPARATE config
+// with no `define`, so every unit test in the repo — buildCredits.test.ts
+// included — exercises the DEGRADED path by construction. If the define, the
+// env plumbing or the wrapper broke, the whole unit suite would stay green and
+// the modal would roll an empty list in production.
+//
+// So the oracle here is not a shape. `scripts/integration.sh` derives the
+// payload and exports it; `e2e/compose.yaml` hands the SAME string to
+// `cicchetto-build-test` (which bakes it) and to `playwright-runner` (which is
+// this process). Comparing what the modal PAINTS against `GRAPPA_CREDITS`
+// compares the two ends of the channel. A shape assertion — "there is a sha",
+// "the list is an array" — cannot tell a correct roll from an EMPTY one, and
+// an empty roll is the exact defect the channel exists to prevent.
+//
+// The payload is read with a bare `JSON.parse`, NOT with `coerceBuildCredits`:
+// `e2e/` is its own package and allows only TYPE imports from `src/` (see
+// `fixtures/grappaApi.ts`, and `src/__tests__/e2eConstantMirrors.test.ts` for
+// the discipline). That is a feature of the oracle rather than a compromise —
+// parsing the payload independently is what lets this spec disagree with the
+// production coercer instead of inheriting its bugs.
+//
+// SCOPE. chromium only, and deliberately: the defect's platform is the BUILD
+// CHANNEL, which is engine-independent. What is NOT proven here is anything
+// about the surface on a device — the notch clearance is source-level asserted
+// in `src/__tests__/safeAreaInsetToken.test.ts`, the reduced-motion arm is a
+// media query no engine here has the preference set for, and the soundtrack is
+// not observable from Playwright at all.
+//
+// Parity matrix: the roll is subject-shape-agnostic (it names the BUILD, not
+// the reader) — registered vjt suffices.
+
+import { loginAs, openSettingsDrawer } from "../fixtures/cicchettoPage";
+import { expect, specUser, test } from "../fixtures/test";
+
+type BakedContributor = { readonly name: string; readonly commits: number };
+type BakedCredits = {
+  readonly sha: string | null;
+  readonly date: string | null;
+  readonly contributors: readonly BakedContributor[];
+};
+
+/**
+ * The payload the wrapper derived, or a thrown explanation.
+ *
+ * Both refusals below are ANTI-HOLLOW-GREEN guards, and each names a different
+ * broken thing:
+ *
+ *  - UNSET means the compose plumbing did not reach this container. Defaulting
+ *    to `{}` here would turn the spec into a shape check silently, which is the
+ *    failure mode the whole file exists to avoid.
+ *  - DEGRADED (`sha: null`) is a legitimate payload in production — the AUR
+ *    tarball and the release image both build with no `.git` — but it is NOT
+ *    legitimate HERE: `scripts/integration.sh` runs inside the repository, so a
+ *    null sha means the deriver failed rather than that the build has no
+ *    history. Accepting it would let this spec pass against a wrapper that
+ *    silently stopped deriving anything.
+ */
+function bakedCredits(): BakedCredits {
+  const raw = process.env.GRAPPA_CREDITS;
+  if (raw === undefined || raw === "") {
+    throw new Error(
+      "GRAPPA_CREDITS is unset in the playwright-runner. The spec cannot " +
+        "compare the roll against the payload it was built from. Check the " +
+        "export in scripts/integration.sh and the service env in e2e/compose.yaml.",
+    );
+  }
+
+  const parsed = JSON.parse(raw) as BakedCredits;
+  if (parsed.sha === null || parsed.contributors.length === 0) {
+    throw new Error(
+      `GRAPPA_CREDITS is the DEGRADED payload (${raw.slice(0, 120)}). ` +
+        "integration.sh runs inside the repository, so the deriver should have " +
+        "found git. A degraded payload here would make every assertion below " +
+        "vacuous.",
+    );
+  }
+  return parsed;
+}
+
+test("#1773 — the credits roll paints the sha, date and contributors the build baked in", async ({
+  page,
+}) => {
+  const baked = bakedCredits();
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await openSettingsDrawer(page);
+
+  await page.getByTestId("credits-entry").click();
+  const modal = page.getByTestId("credits-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+
+  // Read text, never geometry: the roll is a CSS animation, so every box in it
+  // is moving. Text content is animation-independent and therefore not a
+  // flake source.
+  await expect(page.getByTestId("credits-title")).toHaveText("GRAPPA IRC");
+
+  // ── the sha, exactly as derived ─────────────────────────────────────────
+  await expect(page.getByTestId("credits-sha")).toHaveText(baked.sha ?? "");
+
+  // ── the date, as the calendar day of the derived instant ────────────────
+  // `split("T")[0]` reads the ISO-8601 format itself rather than copying
+  // `creditsDateLabel`'s slice length: same answer, no mirrored constant.
+  if (baked.date !== null) {
+    await expect(page.getByTestId("credits-date")).toHaveText(baked.date.split("T")[0] ?? "");
+  }
+
+  // ── the version comes from the #292 meta, and agrees with the bundle ─────
+  // Not from the credits payload, on purpose (a second carrier is the drift
+  // #538 closed). Asserted against the meta tag so the roll cannot quietly
+  // start rendering something else.
+  const metaVersion = await page.locator('meta[name="cicchetto-version"]').getAttribute("content");
+  expect(metaVersion, "the #292 version meta must be present in the built bundle").toBeTruthy();
+  await expect(page.getByTestId("credits-version")).toHaveText(metaVersion ?? "");
+
+  // ── every contributor, with their count, in the derived order ───────────
+  // The whole list and its ORDER, not a spot check: `git shortlog -sn` ranks
+  // by commit count, and a roll that renamed, reordered or truncated the list
+  // is exactly as wrong as an empty one.
+  const painted = await page.getByTestId("credits-person").evaluateAll((rows) =>
+    rows.map((row) => ({
+      name: row.querySelector(".credits-person-name")?.textContent ?? "",
+      commits: Number(row.querySelector(".credits-person-count")?.textContent ?? "NaN"),
+    })),
+  );
+  expect(painted).toEqual(baked.contributors.map((c) => ({ name: c.name, commits: c.commits })));
+
+  // And the empty-state line is ABSENT — it is the fallback the degraded
+  // build shows, and seeing it here would mean the list rendered from nothing.
+  await expect(page.getByTestId("credits-empty")).toHaveCount(0);
+});
+
+test("#1773 — the roll can be muted and closed, and closing returns the drawer", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await openSettingsDrawer(page);
+
+  await page.getByTestId("credits-entry").click();
+  await expect(page.getByTestId("credits-modal")).toBeVisible({ timeout: 5_000 });
+
+  // The soundtrack itself is not observable from Playwright — no engine here
+  // exposes the output of an AudioContext. What IS observable, and what the
+  // reader actually needs, is that the control exists, is reachable over the
+  // full-bleed rain, and reports its state to assistive tech.
+  const mute = page.getByTestId("credits-mute");
+  await expect(mute).toHaveAttribute("aria-pressed", "false");
+  await mute.click();
+  await expect(mute).toHaveAttribute("aria-pressed", "true");
+
+  await page.getByTestId("credits-close").click();
+  await expect(page.getByTestId("credits-modal")).toHaveCount(0);
+
+  // The drawer that opened it is still there: the modal is a sibling in Shell,
+  // not a page the drawer pushed, so dismissing it must not have unwound the
+  // drawer as well.
+  await expect(page.locator(".settings-drawer.open")).toBeVisible();
+});

--- a/cicchetto/src/AdminDebugTab.tsx
+++ b/cicchetto/src/AdminDebugTab.tsx
@@ -1,7 +1,7 @@
 import { type Component, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import AdminCard from "./admin/AdminCard";
-import MatrixRain from "./admin/MatrixRain";
 import { isDiagEnabled, setDiagEnabled } from "./DiagFloat";
+import MatrixRain from "./MatrixRain";
 
 // UX-6 D12 (2026-05-21) — Admin → Debug tab. Hosts the iOS PWA
 // keyboard / viewport diagnostics. Previously lived inside
@@ -186,7 +186,7 @@ const AdminDebugTab: Component = () => {
           {/* biome-ignore lint/a11y/noStaticElementInteractions: same. */}
           <div class="adm-matrix" onClick={tapHeading}>
             <Show when={rainOn()}>
-              <MatrixRain />
+              <MatrixRain class="adm-rain" testId="admin-matrix-rain" />
             </Show>
             <p class="adm-matrix-prompt" aria-hidden="true">
               grappa@cicchetto:~$ tail -f /dev/viewport

--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -1,0 +1,174 @@
+import { type Component, createEffect, For, onCleanup, Show, untrack } from "solid-js";
+import { buildCredits, creditsDateLabel } from "./lib/buildCredits";
+import { bootBundleVersionAccessor } from "./lib/bundleHash";
+import { type CreditsArpeggio, startCreditsArpeggio } from "./lib/creditsAudio";
+import {
+  closeCreditsModal,
+  creditsModalOpen,
+  creditsMuted,
+  toggleCreditsMuted,
+} from "./lib/creditsModal";
+import { createOverlayLock } from "./lib/overlayScrollLock";
+import MatrixRain from "./MatrixRain";
+
+// #1773 — the credits easter egg: falling characters behind an end-titles
+// roll, on a loop, with a synthesised soundtrack.
+//
+// Mounted in Shell, not in SettingsDrawer, and that is structural rather than
+// tidiness: `.settings-drawer` animates on `transform`, which makes it the
+// containing block for any `position: fixed` descendant — a full-screen modal
+// rendered inside it would be clipped to the drawer. Same reason
+// ShareSessionModal, opened from the same drawer, lives in Shell.
+//
+// `createOverlayLock`, NOT `createOverlayEscape`: this covers the whole
+// viewport, so without the scroll-lock refcount the iOS shell pans behind it
+// (the live #1772 bug). The scrollback freeze the lock also brings is WANTED
+// here for the same reason — nothing of the pane is visible to keep live.
+//
+// Every fact on screen comes from a source that already existed:
+//   * the version from `<meta name="cicchetto-version">` via
+//     `bundleHash.bootBundleVersionAccessor` (#292 — ONE injection point, and
+//     a second carrier is the drift #538 closed);
+//   * the sha, its date and the contributor list from `buildCredits()`, baked
+//     by infra/packaging/credits.sh through the same wrapper channel.
+//
+// Both degrade to "unknown" rather than to blank. A build genuinely can have
+// no git — the AUR source tarball and the release image both do — and a roll
+// that renders an empty line there reads as a bug in the modal rather than as
+// the truth about the build.
+
+const CreditsModal: Component = () => {
+  createOverlayLock(() => creditsModalOpen(), ".credits-modal", closeCreditsModal);
+
+  const credits = buildCredits();
+
+  // ── soundtrack lifecycle ────────────────────────────────────────────────
+  // Tied to the OPEN signal, not to this component's mount: Shell mounts the
+  // component for the whole session, so an onMount-scoped context would be
+  // built at boot (before any gesture) and would outlive every close.
+  let arpeggio: CreditsArpeggio | null = null;
+  const stopArpeggio = (): void => {
+    arpeggio?.stop();
+    arpeggio = null;
+  };
+
+  createEffect(() => {
+    if (!creditsModalOpen()) {
+      stopArpeggio();
+      return;
+    }
+    if (arpeggio !== null) return;
+    // jsdom has no WebAudio, and neither does a browser with it disabled —
+    // a silent modal, not a broken one. `webkitAudioContext` is still what
+    // older iOS Safari exposes.
+    const Ctor =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (Ctor === undefined) return;
+    // `untrack`: the initial mute state is an INPUT to construction, not a
+    // dependency of it. Tracked, a mute toggle would re-run this effect for
+    // nothing — the separate effect below is what carries a live toggle.
+    arpeggio = startCreditsArpeggio(new Ctor(), untrack(creditsMuted));
+  });
+
+  createEffect(() => {
+    const muted = creditsMuted();
+    arpeggio?.setMuted(muted);
+  });
+
+  // A logout unmounts Shell with the modal still open; without this the
+  // context survives the session that opened it.
+  onCleanup(stopArpeggio);
+
+  const versionLabel = (): string => bootBundleVersionAccessor() ?? "version unknown";
+  const dateLabel = (): string | null => creditsDateLabel(credits.date);
+
+  return (
+    <Show when={creditsModalOpen()}>
+      {/* One fixed full-viewport box, not a backdrop plus a centred dialog:
+          the rain IS the backdrop, and a separate scrim would sit between
+          them. `.credits-modal` is the selector the overlay lock targets. */}
+      <div
+        class="credits-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="credits"
+        data-testid="credits-modal"
+      >
+        <MatrixRain class="credits-rain" testId="credits-matrix-rain" />
+
+        <div class="credits-chrome">
+          <button
+            type="button"
+            class="modal-chrome-button credits-mute"
+            data-testid="credits-mute"
+            aria-pressed={creditsMuted()}
+            aria-label={creditsMuted() ? "unmute credits music" : "mute credits music"}
+            onClick={toggleCreditsMuted}
+          >
+            {creditsMuted() ? "🔇" : "🔊"}
+          </button>
+          <button
+            type="button"
+            class="modal-chrome-button credits-close"
+            data-testid="credits-close"
+            aria-label="close credits"
+            onClick={closeCreditsModal}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* The roll scrolls by CSS animation, so the loop costs no frame
+            budget of ours and `prefers-reduced-motion` can turn it into a
+            plain scrollable column with one media query — see default.css. */}
+        <div class="credits-viewport">
+          <div class="credits-roll" data-testid="credits-roll">
+            <h2 class="credits-title" data-testid="credits-title">
+              GRAPPA IRC
+            </h2>
+            <p class="credits-version" data-testid="credits-version">
+              {versionLabel()}
+            </p>
+            <p class="credits-build" data-testid="credits-build">
+              <span data-testid="credits-sha">{credits.sha ?? "no build sha"}</span>
+              <Show when={dateLabel()}>
+                {(day) => (
+                  <>
+                    <span aria-hidden="true"> · </span>
+                    <span data-testid="credits-date">{day()}</span>
+                  </>
+                )}
+              </Show>
+            </p>
+
+            <h3 class="credits-heading">contributors</h3>
+            <ul class="credits-list">
+              <For
+                each={credits.contributors}
+                fallback={
+                  // Honest, not blank: this is what a build from a source
+                  // tarball looks like, and it is a legitimate build.
+                  <li class="credits-empty" data-testid="credits-empty">
+                    this build carries no history
+                  </li>
+                }
+              >
+                {(person) => (
+                  <li class="credits-person" data-testid="credits-person">
+                    <span class="credits-person-name">{person.name}</span>
+                    <span class="credits-person-count">{person.commits}</span>
+                  </li>
+                )}
+              </For>
+            </ul>
+
+            <p class="credits-coda">an always-on IRC bouncer, and a client that looks like irssi</p>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default CreditsModal;

--- a/cicchetto/src/MatrixRain.tsx
+++ b/cicchetto/src/MatrixRain.tsx
@@ -1,8 +1,16 @@
 import { type Component, onCleanup, onMount } from "solid-js";
 
 // Decorative amber character rain. Absolutely positioned inside its
-// parent, which must be `position: relative` and clip its overflow —
-// today that is `.adm-matrix`, the Debug tab's phosphor panel.
+// parent, which must be `position: relative` and clip its overflow.
+//
+// #1773 moved this OUT of `src/admin/` and gave it two required props. It
+// had one consumer (the Debug tab's `.adm-matrix` phosphor panel) and now
+// has two (the credits easter egg's full-screen modal), and a shared
+// component sitting in the admin-only directory is a lie the next reader
+// trips on. The props are the only thing that differs between the two
+// surfaces — everything below, including the four constraints, is one
+// implementation. NOT defaulted: a default class would silently give the
+// second caller the first caller's stylesheet hook.
 //
 // Sized off the PARENT box rather than the window: it is a panel effect,
 // not a page overlay, so it must follow the panel through a resize, a
@@ -26,10 +34,19 @@ const GLYPHS = "01アイウエオカキクケコサシスセソタチツテト�
 const FONT_SIZE = 14;
 const FRAME_MS = 66;
 
-// No props: the caller gates it with `<Show>`, so being MOUNTED is the
+// No `on` prop: the caller gates it with `<Show>`, so being MOUNTED is the
 // on state and unmounting stops the loop through `onCleanup`. An `on`
 // prop would be a second switch that has to agree with the first.
-const MatrixRain: Component = () => {
+type MatrixRainProps = {
+  /** Stylesheet hook on the wrapper. The parent it sits in must be
+      `position: relative` and clip its overflow. */
+  readonly class: string;
+  /** `data-testid` on the wrapper, so each surface is addressable on its
+      own — a shared id would make a spec unable to say WHICH rain it found. */
+  readonly testId: string;
+};
+
+const MatrixRain: Component<MatrixRainProps> = (props) => {
   let canvas: HTMLCanvasElement | undefined;
 
   onMount(() => {
@@ -107,7 +124,7 @@ const MatrixRain: Component = () => {
   // that announces nothing. The wrapper is not focusable, so the hint
   // belongs there; `tabindex={-1}` keeps the canvas out of the tab order.
   return (
-    <div class="adm-rain" aria-hidden="true" data-testid="admin-matrix-rain">
+    <div class={props.class} aria-hidden="true" data-testid={props.testId}>
       <canvas
         tabindex={-1}
         ref={(node) => {

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -22,6 +22,7 @@ import {
   withConversationMute,
   withoutConversationMute,
 } from "./lib/conversationMute";
+import { CREDITS_LABEL, openCreditsModal } from "./lib/creditsModal";
 import {
   syncedSetColoredNicklist,
   syncedSetShowBottomBar,
@@ -1223,6 +1224,33 @@ const SettingsDrawer: Component<Props> = (props) => {
               </p>
             </div>
           </Show>
+
+          {/* #1773 — credits. LAST of the drawer's own entries, and outside
+            every sub-page on purpose: it is not a setting.
+
+            Deliberately NOT a `.settings-nav-row`, and that is the #460
+            contract rather than a styling whim: an index nav row PUSHES a
+            sub-page and wears a chevron saying so. This opens a modal, so it
+            follows the share entry — the drawer's other modal door — and
+            wears its shape instead. Making it a nav row would have put a
+            non-page in the index the `renders the index nav rows in order`
+            case enumerates.
+
+            The modal itself is mounted in Shell, like the share one:
+            `.settings-drawer` animates on `transform`, which makes it the
+            containing block for any `position: fixed` descendant, so a
+            full-screen modal rendered from here would be clipped to it. */}
+          <button
+            type="button"
+            class="settings-share-button settings-credits-entry"
+            data-testid="credits-entry"
+            onClick={() => openCreditsModal()}
+          >
+            <span class="settings-share-button-label">{CREDITS_LABEL}</span>
+            <span class="settings-share-button-subtitle muted">
+              who built this, and out of what
+            </span>
+          </button>
 
           {/* UX-4 bucket L — bottom "done" button. Same close verb as
             the top × — mobile thumb-reach surface. Sits below logout

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -17,6 +17,7 @@ import BanlistModal from "./BanlistModal";
 import BottomBar from "./BottomBar";
 import ComposeBox from "./ComposeBox";
 import ConfirmModal from "./ConfirmModal";
+import CreditsModal from "./CreditsModal";
 import CrtSplash from "./CrtSplash";
 import DiagFloat from "./DiagFloat";
 import DirectoryPane from "./DirectoryPane";
@@ -633,6 +634,12 @@ const Shell: Component = () => {
           <RegistrationWizardModal />
           <RecoverModal />
           <ShareSessionModal />
+          {/* #1773 — the credits easter egg. Mounted here, not in the settings
+              drawer that opens it: `.settings-drawer` animates on `transform`,
+              which makes it the containing block for any `position: fixed`
+              descendant, so a full-screen modal rendered from inside would be
+              clipped to the drawer. Self-gated on `creditsModalOpen()`. */}
+          <CreditsModal />
           <ConfirmModal />
           {/* #473 — ArchiveModal is the single archive surface on BOTH form
               factors. Mounted here on desktop (was mobile-only); the desktop
@@ -923,6 +930,8 @@ const Shell: Component = () => {
         <RegistrationWizardModal />
         <RecoverModal />
         <ShareSessionModal />
+        {/* #1773 — see the desktop branch above for why it is mounted here. */}
+        <CreditsModal />
         <ConfirmModal />
         <Show when={membersOpen()}>
           <div

--- a/cicchetto/src/__tests__/AdminDebugTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminDebugTab.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdminDebugTab from "../AdminDebugTab";
+
+// #1773 — a REGRESSION guard for a move that is outside the issue's mandate.
+//
+// The credits easter egg needed the falling-character effect that already
+// existed as `src/admin/MatrixRain.tsx`, with one consumer: this tab's
+// phosphor panel. Rather than copy it, #1773 promoted it to `src/MatrixRain
+// .tsx` and gave it two required props. tsc proves the props are PASSED; it
+// cannot prove they still carry the values this tab's stylesheet and any
+// future spec key off — a wrong string compiles perfectly.
+//
+// So this pins the values, from the tab, through the real five-tap gate. The
+// tab had no test at all before, which is exactly why the move needed one.
+
+class StubResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+describe("AdminDebugTab phosphor panel (#1773 — MatrixRain promotion)", () => {
+  beforeEach(() => {
+    // Never invoke the callback: a self-driving loop in jsdom is an infinite
+    // one, and the frame's CONTENT is MatrixRain.test.tsx's subject, not this
+    // file's.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal("ResizeObserver", StubResizeObserver);
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("keeps the rain behind its own five-tap gate, off by default", () => {
+    render(() => <AdminDebugTab />);
+
+    // The pre-state, asserted before the gesture: without it, a rain that
+    // never appears and a rain that was always there read the same.
+    expect(screen.queryByTestId("admin-matrix-rain")).toBeNull();
+  });
+
+  it("still renders the promoted MatrixRain with the admin class and test id", () => {
+    const { container } = render(() => <AdminDebugTab />);
+
+    const panel = container.querySelector(".adm-matrix");
+    expect(panel).not.toBeNull();
+    for (let i = 0; i < 5; i++) {
+      fireEvent.click(panel as Element);
+    }
+
+    const rain = screen.getByTestId("admin-matrix-rain");
+    expect(rain.className).toBe("adm-rain");
+    expect(rain.querySelector("canvas")).not.toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/CreditsModal.test.tsx
+++ b/cicchetto/src/__tests__/CreditsModal.test.tsx
@@ -1,0 +1,230 @@
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CreditsModal from "../CreditsModal";
+import type { BuildCredits } from "../lib/buildCredits";
+import {
+  closeCreditsModal,
+  creditsMuted,
+  openCreditsModal,
+  toggleCreditsMuted,
+} from "../lib/creditsModal";
+import { __resetForTest, overlayCount, runTopmostOverlayEscape } from "../lib/overlayScrollLock";
+
+// #1773 — the credits easter egg.
+//
+// The BAKE is the e2e's job (it compares what this paints against the exact
+// payload the wrapper derived). What is proven here is everything that is
+// true regardless of which payload arrives: that the roll renders the facts
+// it is given, that it says so honestly when it is given none, that it holds
+// a COVERING overlay lock rather than a bare escape hook, and that closing it
+// leaves no audio graph behind.
+
+const state = vi.hoisted(() => ({
+  credits: { sha: null, date: null, contributors: [] } as BuildCredits,
+}));
+
+vi.mock("../lib/buildCredits", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/buildCredits")>();
+  return { ...actual, buildCredits: () => state.credits };
+});
+
+vi.mock("../lib/bundleHash", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/bundleHash")>();
+  return { ...actual, bootBundleVersionAccessor: () => "9.9.9" };
+});
+
+// jsdom has no WebAudio. A stub that records `close()` is enough for the one
+// question this file asks of the audio: does the graph outlive the modal.
+const audioContexts: { closed: boolean }[] = [];
+
+class StubAudioContext {
+  readonly state = "running";
+  readonly destination = {};
+  private readonly record: { closed: boolean };
+
+  constructor() {
+    this.record = { closed: false };
+    audioContexts.push(this.record);
+  }
+
+  resume(): void {}
+  close(): void {
+    this.record.closed = true;
+  }
+  createGain() {
+    return {
+      gain: {
+        value: 0,
+        setValueAtTime: (): void => {},
+        exponentialRampToValueAtTime: (): void => {},
+        setTargetAtTime: (): void => {},
+      },
+      connect: (): void => {},
+      disconnect: (): void => {},
+    };
+  }
+  createOscillator() {
+    return {
+      type: "",
+      frequency: { value: 0, setValueAtTime: (): void => {} },
+      connect: (): void => {},
+      disconnect: (): void => {},
+      start: (): void => {},
+      stop: (): void => {},
+      onended: null,
+    };
+  }
+}
+
+const POPULATED: BuildCredits = {
+  sha: "a453325e",
+  date: "2026-08-25T23:15:06+02:00",
+  contributors: [
+    { name: "Marcello Barnaba", commits: 5102 },
+    { name: "Stefy Lanza", commits: 147 },
+  ],
+};
+
+describe("CreditsModal (#1773)", () => {
+  beforeEach(() => {
+    state.credits = POPULATED;
+    audioContexts.length = 0;
+    vi.stubGlobal("AudioContext", StubAudioContext);
+    // MatrixRain's dependencies; its own behaviour is MatrixRain.test.tsx's.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe(): void {}
+        disconnect(): void {}
+      },
+    );
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    );
+  });
+
+  afterEach(() => {
+    closeCreditsModal();
+    // The mute preference is session-scoped by design, so it survives a
+    // close — which means it also survives into the next test unless a case
+    // that flipped it puts it back.
+    if (creditsMuted()) toggleCreditsMuted();
+    __resetForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing and builds no audio graph while closed", () => {
+    // Mounted in Shell for the whole session, so "closed" is its normal
+    // state: a context constructed at mount would exist from boot, before any
+    // gesture, and outlive every close.
+    render(() => <CreditsModal />);
+
+    expect(screen.queryByTestId("credits-modal")).toBeNull();
+    expect(audioContexts).toHaveLength(0);
+  });
+
+  it("rolls the version, the build and every contributor with their count", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    expect(screen.getByTestId("credits-title").textContent).toBe("GRAPPA IRC");
+    // The version comes from the bundle meta (#292), NOT from the credits
+    // payload — one carrier per fact.
+    expect(screen.getByTestId("credits-version").textContent).toBe("9.9.9");
+    expect(screen.getByTestId("credits-sha").textContent).toBe("a453325e");
+    // The bare ISO day git wrote, not a locale rendering.
+    expect(screen.getByTestId("credits-date").textContent).toBe("2026-08-25");
+
+    const people = screen.getAllByTestId("credits-person");
+    expect(people).toHaveLength(2);
+    expect(people[0]?.textContent).toContain("Marcello Barnaba");
+    // The COUNT, not just the name: a roll that lists everyone with no
+    // numbers is the same DOM shape and a different feature.
+    expect(people[0]?.textContent).toContain("5102");
+    expect(people[1]?.textContent).toContain("Stefy Lanza");
+    expect(people[1]?.textContent).toContain("147");
+  });
+
+  it("says the build carries no history rather than rolling an empty list", () => {
+    // What the AUR source tarball and the release image produce: both build
+    // with no `.git`, by construction. A blank panel there reads as a broken
+    // modal; this reads as the truth about the build.
+    state.credits = { sha: null, date: null, contributors: [] };
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    expect(screen.getByTestId("credits-empty")).toBeTruthy();
+    expect(screen.getByTestId("credits-sha").textContent).toBe("no build sha");
+    expect(screen.queryByTestId("credits-date")).toBeNull();
+    expect(screen.queryAllByTestId("credits-person")).toHaveLength(0);
+  });
+
+  it("holds a covering overlay lock while open, and releases it on close", async () => {
+    // The #1772 lesson, as a test rather than a comment: this covers the
+    // whole viewport, so it must take the scroll-lock REFCOUNT
+    // (createOverlayLock) and not merely the escape hook
+    // (createOverlayEscape) — without the refcount the iOS shell pans behind
+    // it. The count is the only observable difference between the two.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    await waitFor(() => {
+      expect(overlayCount()).toBe(1);
+    });
+
+    closeCreditsModal();
+    expect(overlayCount()).toBe(0);
+  });
+
+  it("closes on Escape through the shared topmost-overlay stack", async () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    await waitFor(() => {
+      expect(overlayCount()).toBe(1);
+    });
+
+    // Not a private keydown listener: membership of the ONE ordered stack is
+    // what makes a modal opened over something else close first.
+    expect(runTopmostOverlayEscape()).toBe(true);
+    expect(screen.queryByTestId("credits-modal")).toBeNull();
+  });
+
+  it("tears the audio graph down when it closes", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    expect(audioContexts).toHaveLength(1);
+    expect(audioContexts[0]?.closed).toBe(false);
+
+    fireEvent.click(screen.getByTestId("credits-close"));
+
+    expect(screen.queryByTestId("credits-modal")).toBeNull();
+    // A live context behind a dismissed dialog is silent and permanent —
+    // exactly the shape of the rAF leak, and just as invisible.
+    expect(audioContexts[0]?.closed).toBe(true);
+  });
+
+  it("offers a mute the reader can reach, and remembers it across a reopen", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    const mute = screen.getByTestId("credits-mute");
+    expect(mute.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(mute);
+    expect(screen.getByTestId("credits-mute").getAttribute("aria-pressed")).toBe("true");
+
+    // Session-scoped, not persisted: it survives a close within the session,
+    // which is the case that actually annoys, and does not end up in the
+    // operator's saved preferences.
+    closeCreditsModal();
+    openCreditsModal();
+    expect(screen.getByTestId("credits-mute").getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/cicchetto/src/__tests__/MatrixRain.test.tsx
+++ b/cicchetto/src/__tests__/MatrixRain.test.tsx
@@ -1,0 +1,120 @@
+import { render } from "@solidjs/testing-library";
+import { createSignal, Show } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import MatrixRain from "../MatrixRain";
+
+// #1773 moved this component out of `src/admin/` and gave it two required
+// props, because the credits easter egg is a second consumer of the same
+// falling-character effect. It had no tests before the move; these pin the
+// three properties the move must not have broken, and the one the credits
+// modal newly depends on.
+//
+// The BATTERY contract is the one that matters most here: the credits modal
+// is a full-screen overlay someone opens, watches, and closes, and a rAF loop
+// that survives the close burns a phone behind a dismissed dialog. The rest
+// of the suite runs with the loop mounted, so a leak here would be invisible.
+
+// jsdom implements none of these. `ResizeObserver` the component constructs
+// unconditionally; the rAF pair it drives the loop with; and the 2D context.
+//
+// The canvas stub is NOT optional scaffolding, and finding that out is what
+// this file bought: jsdom's `getContext` returns null without the `canvas`
+// npm package, and the component's `if (ctx === null) return` fires BEFORE it
+// ever requests a frame. Unstubbed, the unmount case below passes for the
+// wrong reason — there is nothing to cancel because nothing ever started.
+class StubResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+function stubCanvas2d(): void {
+  const ctx = {
+    font: "",
+    fillStyle: "",
+    fillRect: (): void => {},
+    fillText: (): void => {},
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    ctx as unknown as CanvasRenderingContext2D,
+  );
+}
+
+describe("MatrixRain (#1773 — shared by the Debug tab and the credits roll)", () => {
+  let raf: ReturnType<typeof vi.fn>;
+  let caf: ReturnType<typeof vi.fn>;
+  let handle = 0;
+
+  beforeEach(() => {
+    handle = 0;
+    // Hand back a fresh handle and NEVER call the callback: one frame is all
+    // this needs to prove, and a self-driving loop in jsdom is an infinite
+    // one.
+    raf = vi.fn(() => {
+      handle += 1;
+      return handle;
+    });
+    caf = vi.fn();
+    vi.stubGlobal("requestAnimationFrame", raf);
+    vi.stubGlobal("cancelAnimationFrame", caf);
+    vi.stubGlobal("ResizeObserver", StubResizeObserver);
+    stubCanvas2d();
+    // Default: no motion preference expressed.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("wears the class and the test id its caller chose", () => {
+    // The whole point of the two props: each surface is addressable on its
+    // own and styles itself. A default would have silently handed the second
+    // caller the first caller's stylesheet hook.
+    const { getByTestId } = render(() => (
+      <MatrixRain class="credits-rain" testId="credits-matrix-rain" />
+    ));
+
+    const wrapper = getByTestId("credits-matrix-rain");
+    expect(wrapper.className).toBe("credits-rain");
+    expect(wrapper.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper.querySelector("canvas")).not.toBeNull();
+  });
+
+  it("cancels its animation frame when it unmounts", () => {
+    // The battery contract. Asserted on the HANDLE, not merely on "cancel was
+    // called": cancelling some other frame would satisfy a call-count check
+    // while leaving this loop running forever.
+    const [shown, setShown] = createSignal(true);
+    render(() => (
+      <Show when={shown()}>
+        <MatrixRain class="credits-rain" testId="credits-matrix-rain" />
+      </Show>
+    ));
+
+    expect(raf).toHaveBeenCalled();
+    const armed = handle;
+    expect(caf).not.toHaveBeenCalled();
+
+    setShown(false);
+
+    expect(caf).toHaveBeenCalledWith(armed);
+  });
+
+  it("never starts a loop when the reader asked for reduced motion", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    );
+
+    render(() => <MatrixRain class="credits-rain" testId="credits-matrix-rain" />);
+
+    // OFF, not slowed — and the canvas is still in the DOM, because the
+    // wrapper is what the stylesheet positions. Absence of the loop is the
+    // assertion, so it has to be the frame request that is missing.
+    expect(raf).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/buildCredits.test.ts
+++ b/cicchetto/src/__tests__/buildCredits.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type BuildCredits,
+  buildCredits,
+  coerceBuildCredits,
+  EMPTY_BUILD_CREDITS,
+} from "../lib/buildCredits";
+
+// #1773 — the credit roll's git facts are baked at BUILD time (vite `define`,
+// fed by infra/packaging/credits.sh through GRAPPA_CREDITS), because the
+// browser has no git and the cic build container has no repo.
+//
+// These cases are about the READER, and deliberately not about the bake: the
+// bake is proven end to end by the credits e2e, which compares what the modal
+// paints against the exact payload the wrapper derived. A unit test here could
+// only assert against a payload it wrote itself.
+//
+// The reader still earns its own cases because it has a real job: the define
+// is ABSENT under vitest (vitest.config.ts is a separate config and carries no
+// `define`), so the degrade path is not hypothetical — it is the path this
+// whole suite runs on.
+
+describe("coerceBuildCredits (#1773)", () => {
+  it("passes a well-formed payload through unchanged", () => {
+    const payload: BuildCredits = {
+      sha: "a453325e",
+      date: "2026-08-25T23:15:06+02:00",
+      contributors: [
+        { name: "Marcello Barnaba", commits: 5102 },
+        { name: "Stefy Lanza", commits: 147 },
+      ],
+    };
+
+    expect(coerceBuildCredits(JSON.stringify(payload))).toEqual(payload);
+  });
+
+  it("accepts the no-git payload as data, not as a fault", () => {
+    // The AUR source tarball and Dockerfile.release both build with no `.git`,
+    // so credits.sh emits exactly this. It is a legitimate build, and the roll
+    // must degrade to the version alone rather than read as corruption.
+    const noGit = '{"sha":null,"date":null,"contributors":[]}';
+
+    expect(coerceBuildCredits(noGit)).toEqual(EMPTY_BUILD_CREDITS);
+  });
+
+  it("keeps the git facts when the contributor list is unusable", () => {
+    // Per-FIELD coercion, not all-or-nothing: a payload that names the commit
+    // should still say which commit, even if the roll itself cannot be read.
+    const partial = '{"sha":"deadbee","date":"2026-08-25T23:15:06+02:00","contributors":"nope"}';
+
+    expect(coerceBuildCredits(partial)).toEqual({
+      sha: "deadbee",
+      date: "2026-08-25T23:15:06+02:00",
+      contributors: [],
+    });
+  });
+
+  it("drops a contributor entry that is not a name and a count", () => {
+    const mixed = JSON.stringify({
+      sha: null,
+      date: null,
+      contributors: [
+        { name: "Ada Lovelace", commits: 3 },
+        { name: "", commits: 9 },
+        { name: "No Count" },
+        { name: "Negative", commits: -1 },
+        { name: "Fractional", commits: 1.5 },
+        "not an object",
+      ],
+    });
+
+    expect(coerceBuildCredits(mixed).contributors).toEqual([{ name: "Ada Lovelace", commits: 3 }]);
+  });
+
+  it("degrades to the empty payload on anything that is not a credits object", () => {
+    // Each of these is a distinct way the define can be wrong — a bundle built
+    // by something other than our vite config, a half-written env var, a value
+    // that parsed but is not an object.
+    for (const raw of ["", "not json at all", "null", "42", '"a string"', "[]", undefined]) {
+      expect(coerceBuildCredits(raw)).toEqual(EMPTY_BUILD_CREDITS);
+    }
+  });
+
+  it("does not treat an empty sha as a sha", () => {
+    // `""` is what a half-derived payload looks like; `null` is what an
+    // honestly repo-less build looks like. Both must render as "unknown", and
+    // an empty string rendered verbatim is a blank line the reader cannot
+    // interpret.
+    expect(coerceBuildCredits('{"sha":"","date":"","contributors":[]}')).toEqual(
+      EMPTY_BUILD_CREDITS,
+    );
+  });
+});
+
+describe("buildCredits() (#1773)", () => {
+  it("is the empty payload when the build-time define is absent", () => {
+    // vitest.config.ts carries no `define`, so this asserts the real degrade
+    // path this suite runs on rather than a simulated one. In a browser bundle
+    // the define is always present — that half is the e2e's job.
+    expect(buildCredits()).toEqual(EMPTY_BUILD_CREDITS);
+  });
+});

--- a/cicchetto/src/__tests__/creditsAudio.test.ts
+++ b/cicchetto/src/__tests__/creditsAudio.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startCreditsArpeggio } from "../lib/creditsAudio";
+
+// #1773 — the credit roll's synthesised soundtrack.
+//
+// Two things are worth proving here and neither is the music. The first is
+// that it can be SILENCED, because the modal autoplays: it opens on a click,
+// so the browser lets it, which means the mute control is the only thing
+// standing between an easter egg and someone's open-plan office. The second
+// is that it LEAVES NOTHING BEHIND — a scheduler still arming oscillators
+// behind a dismissed dialog is the same battery bug as an orphaned rAF loop,
+// and it is completely inaudible, so nothing but a test would ever catch it.
+//
+// jsdom has no WebAudio at all. The AudioContext is handed in rather than
+// constructed by the module precisely so this file can supply one; the
+// component does the feature test.
+
+type StubParam = {
+  value: number;
+  setValueAtTime: ReturnType<typeof vi.fn>;
+  exponentialRampToValueAtTime: ReturnType<typeof vi.fn>;
+  setTargetAtTime: ReturnType<typeof vi.fn>;
+};
+
+type StubOscillator = {
+  type: string;
+  frequency: StubParam;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  onended: (() => void) | null;
+};
+
+function stubParam(): StubParam {
+  return {
+    value: 0,
+    setValueAtTime: vi.fn(),
+    exponentialRampToValueAtTime: vi.fn(),
+    setTargetAtTime: vi.fn(),
+  };
+}
+
+function makeCtx() {
+  const oscillators: StubOscillator[] = [];
+  const gains: { gain: StubParam; connect: ReturnType<typeof vi.fn> }[] = [];
+  const close = vi.fn();
+  const resume = vi.fn();
+
+  const ctx = {
+    currentTime: 0,
+    state: "running" as AudioContextState,
+    destination: {} as AudioDestinationNode,
+    close,
+    resume,
+    createGain: () => {
+      const node = { gain: stubParam(), connect: vi.fn(), disconnect: vi.fn() };
+      gains.push(node);
+      return node;
+    },
+    createOscillator: () => {
+      const node: StubOscillator = {
+        type: "",
+        frequency: stubParam(),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        onended: null,
+      };
+      oscillators.push(node);
+      return node;
+    },
+  };
+
+  return { ctx: ctx as unknown as AudioContext, oscillators, gains, close, resume };
+}
+
+describe("startCreditsArpeggio (#1773)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("opens silent when the reader has already muted it", () => {
+    // Not "mutes shortly after starting": the modal remembers the mute across
+    // a close and reopen within a session, and a ramp-down from full volume
+    // would play the first note anyway — which is the whole thing the reader
+    // asked not to happen.
+    const { ctx, gains } = makeCtx();
+
+    startCreditsArpeggio(ctx, true);
+
+    expect(gains[0]?.gain.value).toBe(0);
+  });
+
+  it("opens audible when it has not been muted", () => {
+    // The positive control for the case above: without it, a master gain
+    // hard-wired to zero would pass that one and ship a silent easter egg.
+    const { ctx, gains } = makeCtx();
+
+    startCreditsArpeggio(ctx, false);
+
+    expect(gains[0]?.gain.value).toBeGreaterThan(0);
+  });
+
+  it("ramps to silence and back on the mute toggle", () => {
+    const { ctx, gains } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+    const master = gains[0];
+
+    arpeggio.setMuted(true);
+    expect(master?.gain.setTargetAtTime).toHaveBeenCalledWith(0, 0, expect.any(Number));
+
+    arpeggio.setMuted(false);
+    // A RAMP back to an AUDIBLE target, not to whatever happened to be
+    // there: asserting only that setTargetAtTime was called again would pass
+    // on an unmute that ramps to zero.
+    const calls = master?.gain.setTargetAtTime.mock.calls ?? [];
+    expect(calls[calls.length - 1]?.[0]).toBeGreaterThan(0);
+  });
+
+  it("arms the next bar while it is running", () => {
+    // The positive control for the teardown case below. Without it, a
+    // scheduler that never re-armed at all would pass "no new voices after
+    // stop" while being broken in the opposite direction.
+    const { ctx, oscillators } = makeCtx();
+    startCreditsArpeggio(ctx, false);
+    const firstBar = oscillators.length;
+
+    vi.advanceTimersByTime(5_000);
+
+    expect(oscillators.length).toBeGreaterThan(firstBar);
+  });
+
+  it("stops scheduling, silences every voice and closes the context", () => {
+    const { ctx, oscillators, close } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+    const armed = oscillators.length;
+    expect(armed).toBeGreaterThan(0);
+
+    arpeggio.stop();
+
+    // Every voice already scheduled — including a note whose start time is
+    // still in the future, which `onended` can never reach because a note
+    // that has not begun never ends.
+    for (const osc of oscillators) {
+      expect(osc.stop).toHaveBeenCalled();
+      expect(osc.disconnect).toHaveBeenCalled();
+    }
+    expect(close).toHaveBeenCalled();
+
+    // And nothing re-arms. This is the leak: inaudible, because the context
+    // is closed, and permanent, because the timer would keep re-arming for
+    // as long as the tab lives.
+    vi.advanceTimersByTime(30_000);
+    expect(oscillators.length).toBe(armed);
+  });
+
+  it("survives a second stop and a mute after teardown", () => {
+    // The component calls stop() from an effect AND from onCleanup, so the
+    // double call is the normal path, not a defensive hypothetical.
+    const { ctx, close } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+
+    arpeggio.stop();
+    arpeggio.stop();
+    arpeggio.setMuted(true);
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes a context the browser handed back suspended", () => {
+    // Safari does this more often than Chromium, and a suspended context
+    // schedules everything correctly while making no sound at all.
+    const { ctx, resume } = makeCtx();
+    (ctx as unknown as { state: AudioContextState }).state = "suspended";
+
+    startCreditsArpeggio(ctx, false);
+
+    expect(resume).toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
+++ b/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
@@ -129,6 +129,14 @@ const CENSUS = [
   // load-bearing comments to remove an inert fallback is not this change.
   ".context-menu | max-height: max( 0px, calc( var(--viewport-height, 100vh) - var(--safe-area-inset-top, 0px) - var(--safe-area-inset-bottom, 0px) ) )",
   ".context-menu-safe-area | inset: var(--safe-area-inset-top) var(--safe-area-inset-right) var(--safe-area-inset-bottom) var(--safe-area-inset-left)",
+  // #1773 — the credits modal is full-bleed (`inset: 0`, no `.modal-backdrop`
+  // ancestor to inherit clearance from), so it insets itself. The `.credits-roll`
+  // row lives inside the `prefers-reduced-motion` arm, where the roll stops
+  // animating and becomes an ordinary scrollable column: only THEN does its
+  // padding reach the physical edges, which is why the animated rule has none.
+  ".credits-chrome | right: max(0.5rem, var(--safe-area-inset-right))",
+  ".credits-chrome | top: max(0.5rem, var(--safe-area-inset-top))",
+  ".credits-roll | padding: max(3rem, var(--safe-area-inset-top)) 1.5rem max(3rem, var(--safe-area-inset-bottom))",
   ".delete-account-modal | padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom))",
   ".diag-float | top: max(0.5rem, var(--safe-area-inset-top))",
   ".error-banners | padding-top: var(--safe-area-inset-top)",

--- a/cicchetto/src/lib/buildCredits.ts
+++ b/cicchetto/src/lib/buildCredits.ts
@@ -1,0 +1,129 @@
+// #1773 — the credit roll's build-time git facts.
+//
+// The credits easter egg names the commit the running bundle was built from,
+// its date, and every contributor with their commit count. All three are git
+// facts, and there is no git in a browser — nor in the cic build container,
+// which mounts ONLY ./cicchetto (vite.config.ts) and so cannot see the repo
+// root either. So they are derived OUTSIDE the container by the same wrappers
+// that already derive GRAPPA_VERSION (infra/packaging/credits.sh →
+// GRAPPA_CREDITS) and baked in by vite as the `__GRAPPA_CREDITS_JSON__`
+// define.
+//
+// The VERSION is deliberately NOT in this payload: it already reaches the
+// client through `<meta name="cicchetto-version">` (#292), and the modal reads
+// it from there via `bundleHash.bootBundleVersionAccessor`. One injection
+// point per fact — a second version carrier is exactly the drift #538 closed.
+//
+// Why a define and not a second `<meta>` tag: the payload is JSON, and the
+// meta channel would have to survive HTML attribute serialisation of quotes
+// and backslashes in contributor names. The define carries a plain string
+// literal into the JS chunk, where there is nothing to escape and nothing to
+// get wrong. The server has no reason to read this back (unlike the version
+// meta, which `Grappa.Cic.Bundle` parses out of the deployed dist), so the
+// meta channel buys nothing here.
+
+/** One credited author and the number of non-merge commits they authored. */
+export type Contributor = {
+  readonly name: string;
+  readonly commits: number;
+};
+
+/**
+ * The build's git facts. `sha` / `date` are `null` on a build that HAD no
+ * repo — the AUR source tarball and Dockerfile.release both build with `.git`
+ * absent by construction, exactly as `Grappa.Version` reports the bare base
+ * there. That is a legitimate build, not a fault.
+ */
+export type BuildCredits = {
+  readonly sha: string | null;
+  readonly date: string | null;
+  readonly contributors: readonly Contributor[];
+};
+
+export const EMPTY_BUILD_CREDITS: BuildCredits = {
+  sha: null,
+  date: null,
+  contributors: [],
+};
+
+// Injected by the `cicchetto-credits` define in vite.config.ts. Declared
+// rather than imported: it does not exist as a module, and it does not exist
+// at all under vitest (a separate config with no `define`), which is why every
+// read below goes through the coercion.
+declare const __GRAPPA_CREDITS_JSON__: string | undefined;
+
+function presence(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+function contributor(entry: unknown): Contributor | null {
+  if (typeof entry !== "object" || entry === null) return null;
+  const { name, commits } = entry as { name?: unknown; commits?: unknown };
+  const named = presence(name);
+  if (named === null) return null;
+  if (typeof commits !== "number" || !Number.isInteger(commits) || commits < 0) return null;
+  return { name: named, commits };
+}
+
+/**
+ * Read a baked payload into the shape the modal renders, degrading per FIELD
+ * rather than all-or-nothing: a payload that names the commit should still say
+ * WHICH commit even when the roll itself is unreadable.
+ *
+ * Accepts the raw define (a JSON string) or anything else, because "anything
+ * else" is what a bundle built by something other than our vite config hands
+ * us. Never throws — an easter egg must not be able to break the drawer.
+ */
+export function coerceBuildCredits(raw: unknown): BuildCredits {
+  if (typeof raw !== "string") return EMPTY_BUILD_CREDITS;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return EMPTY_BUILD_CREDITS;
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return EMPTY_BUILD_CREDITS;
+  }
+
+  const { sha, date, contributors } = parsed as {
+    sha?: unknown;
+    date?: unknown;
+    contributors?: unknown;
+  };
+
+  const roll = Array.isArray(contributors)
+    ? contributors.map(contributor).filter((c): c is Contributor => c !== null)
+    : [];
+
+  return { sha: presence(sha), date: presence(date), contributors: roll };
+}
+
+/**
+ * The calendar day of a `date` from the payload, as the bare `YYYY-MM-DD` git
+ * itself wrote — NOT a locale rendering.
+ *
+ * Deliberate: `toLocaleDateString` would make the roll say something
+ * different per browser locale, which an e2e can only assert loosely, and the
+ * surface is a monospace terminal pastiche where an ISO day is the native
+ * spelling anyway. Anything that is not an ISO-8601 instant is handed back
+ * whole rather than silently truncated to ten wrong characters.
+ */
+export function creditsDateLabel(date: string | null): string | null {
+  if (date === null) return null;
+  const day = date.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(day) ? day : date;
+}
+
+// Read once at module init, like `bundleHash`'s boot readers: the define is a
+// build-time constant, so re-reading it can never yield a different answer.
+const CREDITS: BuildCredits = coerceBuildCredits(
+  typeof __GRAPPA_CREDITS_JSON__ === "undefined" ? undefined : __GRAPPA_CREDITS_JSON__,
+);
+
+/** The build's git facts, or the empty payload when none were baked in. */
+export function buildCredits(): BuildCredits {
+  return CREDITS;
+}

--- a/cicchetto/src/lib/creditsAudio.ts
+++ b/cicchetto/src/lib/creditsAudio.ts
@@ -1,0 +1,140 @@
+// #1773 — the credit roll's soundtrack: a synthesised arpeggio, with ZERO
+// audio assets in the tree.
+//
+// WHY SYNTHESISED, and why this is not a preference. The issue asked for
+// "something epic", and the obvious candidates (Star Wars, Super Mario) are
+// under copyright. grappa ships a PUBLIC PWA and a `.deb`, so shipping either
+// would put a licence violation in a distro package. The alternatives were an
+// original chiptune, a CC0 track with its licence recorded in-tree, or this:
+// a few seconds of WebAudio with no asset at all. It is also by far the
+// smallest payload, and the modal is already a synthetic-graphics affair, so
+// nothing about it is out of place.
+//
+// Autoplay is legal here because the modal opens on a click — the user
+// gesture requirement is satisfied by the thing that mounted this. A
+// suspended context is still resumed explicitly: Safari hands one back
+// suspended more often than Chromium does.
+//
+// The AudioContext is handed IN rather than constructed here, and `stop()`
+// CLOSES it. Two reasons: jsdom has no AudioContext, so the caller has to do
+// the feature test anyway and a constructor inside would make this module
+// untestable; and an easter egg that leaves a live audio graph behind a
+// closed modal is the battery bug this file's sibling rAF loop was careful
+// not to be.
+
+/** A running soundtrack. Both verbs are idempotent. */
+export type CreditsArpeggio = {
+  /** Fade to silence (or back), without tearing down the graph. */
+  readonly setMuted: (muted: boolean) => void;
+  /** Silence it, drop every node, and CLOSE the context handed to `start`. */
+  readonly stop: () => void;
+};
+
+// A minor, because "epic" in eight notes is a minor arpeggio and everyone
+// knows it: A3 · C4 · E4 · A4 · B4 · A4 · E4 · C4, over an A2 drone.
+const SEQUENCE_HZ = [220, 261.63, 329.63, 440, 493.88, 440, 329.63, 261.63] as const;
+const DRONE_HZ = 110;
+const STEP_S = 0.24;
+const LOOP_S = SEQUENCE_HZ.length * STEP_S;
+
+// Quiet on purpose: this opens without being asked for, on a surface someone
+// may be showing a colleague. Loud enough to be a joke, not loud enough to be
+// an incident.
+const PEAK_GAIN = 0.06;
+const DRONE_GAIN = 0.025;
+// Ramp constant for the mute toggle. An instant gain jump clicks.
+const MUTE_RAMP_S = 0.02;
+
+/**
+ * Start the soundtrack on `ctx`, which this function then OWNS — `stop()`
+ * closes it. Never throws: a browser that refuses a node leaves the modal
+ * silent rather than broken.
+ */
+export function startCreditsArpeggio(ctx: AudioContext, muted: boolean): CreditsArpeggio {
+  const master = ctx.createGain();
+  master.gain.value = muted ? 0 : PEAK_GAIN;
+  master.connect(ctx.destination);
+
+  const drone = ctx.createOscillator();
+  const droneGain = ctx.createGain();
+  drone.type = "sine";
+  drone.frequency.value = DRONE_HZ;
+  droneGain.gain.value = DRONE_GAIN / PEAK_GAIN;
+  drone.connect(droneGain);
+  droneGain.connect(master);
+
+  // Every note oscillator is kept so `stop()` can silence one scheduled a
+  // beat into the future — `onended` cannot be relied on for that, because a
+  // note that has not started yet never ends.
+  const voices: OscillatorNode[] = [drone];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const scheduleNote = (hz: number, at: number): void => {
+    const osc = ctx.createOscillator();
+    const env = ctx.createGain();
+    osc.type = "triangle";
+    osc.frequency.value = hz;
+    // Pluck: near-instant attack, exponential decay over the step. Exponential
+    // because a linear fade on a plucked tone reads as a cut.
+    env.gain.setValueAtTime(0.0001, at);
+    env.gain.exponentialRampToValueAtTime(1, at + 0.01);
+    env.gain.exponentialRampToValueAtTime(0.0001, at + STEP_S * 0.9);
+    osc.connect(env);
+    env.connect(master);
+    osc.start(at);
+    osc.stop(at + STEP_S);
+    voices.push(osc);
+    osc.onended = (): void => {
+      const i = voices.indexOf(osc);
+      if (i !== -1) voices.splice(i, 1);
+      osc.disconnect();
+      env.disconnect();
+    };
+  };
+
+  // One loop is scheduled ahead at a time, then re-armed. A per-note timer
+  // would put the rhythm on the main thread's mercy; scheduling the whole bar
+  // against `ctx.currentTime` keeps it on the audio clock, where it belongs.
+  const scheduleLoop = (): void => {
+    if (stopped) return;
+    const base = ctx.currentTime;
+    SEQUENCE_HZ.forEach((hz, i) => {
+      scheduleNote(hz, base + i * STEP_S);
+    });
+    timer = setTimeout(scheduleLoop, LOOP_S * 1000);
+  };
+
+  try {
+    if (ctx.state === "suspended") void ctx.resume();
+    drone.start();
+    scheduleLoop();
+  } catch {
+    // A browser that refuses to start the graph gets a silent modal, not a
+    // broken one. Nothing below depends on the loop having armed.
+  }
+
+  return {
+    setMuted: (next: boolean): void => {
+      if (stopped) return;
+      master.gain.setTargetAtTime(next ? 0 : PEAK_GAIN, ctx.currentTime, MUTE_RAMP_S);
+    },
+    stop: (): void => {
+      if (stopped) return;
+      stopped = true;
+      if (timer !== null) clearTimeout(timer);
+      timer = null;
+      for (const voice of voices) {
+        try {
+          voice.stop();
+        } catch {
+          // Already stopped, or never started. Either way it is silent.
+        }
+        voice.disconnect();
+      }
+      voices.length = 0;
+      master.disconnect();
+      void ctx.close();
+    },
+  };
+}

--- a/cicchetto/src/lib/creditsModal.ts
+++ b/cicchetto/src/lib/creditsModal.ts
@@ -1,0 +1,51 @@
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
+
+// #1773 — the credits easter egg's open/close state, plus the one preference
+// it carries.
+//
+// A module-singleton signal, like `shareModal` / `serviceModal`: ONE modal
+// instance is mounted in Shell and the settings drawer's credits entry flips
+// this flag. It cannot live inside SettingsDrawer, and that is a constraint
+// rather than a style choice — `.settings-drawer` animates on `transform`,
+// which makes it the containing block for any `position: fixed` descendant,
+// so a full-screen modal rendered inside it would be clipped to the drawer.
+//
+// `creditsMuted` is session-scoped and NOT persisted. It is a transient UI
+// preference for a surface you open on purpose; writing it to the settings
+// store would put an easter egg in the operator's saved preferences, and
+// re-reading it there is a round trip for a thing you re-decide in one tap.
+// It does survive close-and-reopen within a session, which is the case that
+// actually annoys.
+
+/** The affordance's name, declared once beside the signal that opens it. */
+export const CREDITS_LABEL = "credits";
+
+const exports_ = moduleRoot(() => {
+  const [creditsModalOpen, setCreditsModalOpen] = createSignal(false);
+  const [creditsMuted, setCreditsMuted] = createSignal(false);
+
+  const openCreditsModal = (): void => {
+    setCreditsModalOpen(true);
+  };
+  const closeCreditsModal = (): void => {
+    setCreditsModalOpen(false);
+  };
+  const toggleCreditsMuted = (): void => {
+    setCreditsMuted((muted) => !muted);
+  };
+
+  return {
+    creditsModalOpen,
+    openCreditsModal,
+    closeCreditsModal,
+    creditsMuted,
+    toggleCreditsMuted,
+  };
+});
+
+export const creditsModalOpen = exports_.creditsModalOpen;
+export const openCreditsModal = exports_.openCreditsModal;
+export const closeCreditsModal = exports_.closeCreditsModal;
+export const creditsMuted = exports_.creditsMuted;
+export const toggleCreditsMuted = exports_.toggleCreditsMuted;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -13843,3 +13843,178 @@ audio.media-viewer-media {
 .share-modal-error {
   color: #d04040;
 }
+
+/* ── credits easter egg (#1773) ──────────────────────────────────────────
+   A full-viewport modal: falling characters behind an end-titles roll, on
+   a loop. Opened from the bottom of the settings drawer, mounted in Shell.
+
+   ONE fixed box rather than the `.modal-backdrop` + centred-dialog pair the
+   other modals wear: the rain IS the backdrop here, and a scrim between the
+   two would only mute it. That also makes `.credits-modal` the element the
+   overlay lock targets, which is the selector CreditsModal passes.
+
+   `position: relative` is NOT decoration — `MatrixRain` sizes its canvas off
+   `parentElement.clientWidth/Height` through a ResizeObserver and positions
+   absolutely inside it, so the parent must establish the containing block
+   and clip. Same contract `.adm-matrix` carries for the Debug tab. */
+.credits-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  overflow: hidden;
+  background: #000;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  /* The roll animates upward past both edges; nothing here scrolls, so the
+     iOS gesture must not be handed to a pan that has nowhere to go. */
+  touch-action: none;
+}
+
+/* Brighter than the Debug tab's `.adm-rain` (0.55): there it sits under
+   readouts an operator must read, here it IS the picture. The glyph alpha
+   itself is shared — one implementation, one look. */
+.credits-rain {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.85;
+  mix-blend-mode: screen;
+}
+
+.credits-rain canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* Above the rain, and inside the safe areas — a full-bleed modal puts its
+   top-right controls under the notch otherwise, exactly as `.settings-drawer`
+   and `.modal-backdrop-viewport` guard against. */
+.credits-chrome {
+  position: absolute;
+  z-index: 2;
+  top: max(0.5rem, var(--safe-area-inset-top));
+  right: max(0.5rem, var(--safe-area-inset-right));
+  display: flex;
+  gap: 0.25rem;
+}
+
+/* The window the titles travel through. Masked top and bottom so they fade
+   in and out of the void instead of being guillotined by the viewport edge. */
+.credits-viewport {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: hidden;
+  pointer-events: none;
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 12%,
+    #000 88%,
+    transparent 100%
+  );
+  mask-image: linear-gradient(to bottom, transparent 0, #000 12%, #000 88%, transparent 100%);
+}
+
+.credits-roll {
+  position: absolute;
+  left: 0;
+  right: 0;
+  /* Starts fully below the fold and ends fully above it, so the loop has no
+     visible seam. 28s: the issue asked for "under ~30s, then it loops". */
+  animation: credits-roll 28s linear infinite;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0 1.5rem;
+  text-align: center;
+  text-shadow: 0 0 0.5rem var(--accent);
+}
+
+@keyframes credits-roll {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(-100%);
+  }
+}
+
+.credits-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.8em;
+  letter-spacing: 0.35em;
+  color: var(--accent);
+}
+
+.credits-version {
+  margin: 0;
+  font-size: 1.1em;
+}
+
+.credits-build {
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+  font-size: 0.9em;
+}
+
+.credits-heading {
+  margin: 0 0 0.5rem;
+  font-size: 0.9em;
+  font-weight: normal;
+  letter-spacing: 0.3em;
+  color: var(--muted);
+}
+
+.credits-list {
+  margin: 0 0 1.5rem;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: min(20rem, 80vw);
+}
+
+.credits-person {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.credits-person-count {
+  color: var(--muted);
+}
+
+.credits-empty,
+.credits-coda {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9em;
+}
+
+/* The falling characters turn themselves off (MatrixRain watches the query
+   live). The ROLL cannot simply stop — a frozen roll shows whichever three
+   lines it happened to be on — so it becomes an ordinary scrollable column
+   that reads top to bottom, and the mask goes with the animation it framed. */
+@media (prefers-reduced-motion: reduce) {
+  .credits-viewport {
+    overflow-y: auto;
+    pointer-events: auto;
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+
+  .credits-modal {
+    touch-action: pan-y;
+  }
+
+  .credits-roll {
+    position: static;
+    animation: none;
+    padding: max(3rem, var(--safe-area-inset-top)) 1.5rem max(3rem, var(--safe-area-inset-bottom));
+  }
+}

--- a/cicchetto/vite.config.ts
+++ b/cicchetto/vite.config.ts
@@ -44,6 +44,42 @@ if (!CIC_VERSION) {
   );
 }
 
+// #1773 — the credits easter egg's git facts (commit sha, its date, every
+// contributor with their commit count), on the SAME channel and for the same
+// reason: this build sees only ./cicchetto, so it has no repo to read them
+// from. A `git shortlog` here would find nothing and bake an EMPTY roll,
+// silently, on every containerised build — release included. So they arrive
+// derived, from infra/packaging/credits.sh, through GRAPPA_CREDITS.
+//
+// UNSET is fatal, exactly like GRAPPA_VERSION, and for exactly its reason: it
+// means a wrapper forgot to plumb it, and a silently empty credit roll is
+// worse than a broken build. A build that HAS NO GIT is a different thing and
+// is NOT an error — the AUR source tarball and Dockerfile.release both build
+// with `.git` absent by construction, and credits.sh reports that as a
+// well-formed payload of nulls. The two states are kept distinct here on
+// purpose; the same distinction `Grappa.Version.verify_build_sha/2` draws
+// between `{:skip, :no_git}` and a degraded snapshot.
+//
+// Parsed rather than passed through: the parse IS the validation, so a
+// malformed payload fails the build here instead of reaching the browser as a
+// roll that silently renders nothing. Re-serialised so what lands in the
+// bundle is canonical JSON and not whatever whitespace the env carried.
+const CIC_CREDITS_RAW = process.env.GRAPPA_CREDITS;
+if (!CIC_CREDITS_RAW) {
+  throw new Error(
+    "vite.config.ts: GRAPPA_CREDITS is unset — the cic build must be launched by a wrapper that derives it from the repo root (infra/packaging/credits.sh, #1773). Refusing to bake an empty credit roll. Note that a build with no .git is NOT this case: credits.sh answers that with a payload of nulls.",
+  );
+}
+let CIC_CREDITS_JSON: string;
+try {
+  CIC_CREDITS_JSON = JSON.stringify(JSON.parse(CIC_CREDITS_RAW));
+} catch (cause) {
+  throw new Error(
+    `vite.config.ts: GRAPPA_CREDITS is not valid JSON (#1773) — it must be the verbatim output of infra/packaging/credits.sh, not a hand-written value. Got: ${CIC_CREDITS_RAW.slice(0, 120)}`,
+    { cause },
+  );
+}
+
 // Dev-only proxy: vite serves the SolidJS app on :5173 and forwards the
 // REST + Channels surfaces to grappa on :4000. In prod, sub-task 6's
 // nginx service handles the same routing — keeping the dev proxy
@@ -217,6 +253,17 @@ export default defineConfig({
         ws: true,
       },
     },
+  },
+  // #1773 — the credit roll's payload, as a plain string literal in the JS
+  // chunk. A define rather than a second `<meta>` tag: the value is JSON, and
+  // the meta channel would have to survive HTML attribute serialisation of the
+  // quotes and backslashes a contributor name can carry. Nothing server-side
+  // reads it back (unlike the version meta, which `Grappa.Cic.Bundle` parses
+  // out of the deployed dist), so the meta channel buys nothing here. Read by
+  // `src/lib/buildCredits.ts`, which coerces it — the define is ABSENT under
+  // vitest, whose config is a separate file.
+  define: {
+    __GRAPPA_CREDITS_JSON__: JSON.stringify(CIC_CREDITS_JSON),
   },
   build: {
     target: "es2022",

--- a/compose.yaml
+++ b/compose.yaml
@@ -149,6 +149,13 @@ services:
       # mounts only ./cicchetto, so the deploy wrappers export it from the
       # repo-root VERSION file (#538/#652). Empty makes vite fail loud.
       GRAPPA_VERSION: ${GRAPPA_VERSION:-}
+      # #1773 — the credit roll's git facts (sha, date, per-author commit
+      # counts), derived by the wrappers via infra/packaging/credits.sh for
+      # the SAME reason: there is no repo in here to read them from. Empty
+      # makes vite fail loud too — an empty value means a wrapper forgot to
+      # plumb it, which is a different thing from a build that HAS no git
+      # (that one arrives as a well-formed payload saying so).
+      GRAPPA_CREDITS: ${GRAPPA_CREDITS:-}
     command: ["sh", "-c", "bun install --frozen-lockfile && bun run build"]
 
   # The `shottino --ircd` bridge (#1027): a real IRC server on a port, so

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -64427,3 +64427,133 @@ Also recorded because it cost a red on a correct rule: `ruleBody` in
 CSS comment that spells a rule out literally (`selector { prop: value }`)
 truncates the body its own source-level guard reads. The assertion fails on a
 declaration that is present and correct.
+<!-- entry #1773 -->
+
+---
+
+## 2026-08-26 — #1773: the credit roll's facts are derived where git still exists
+
+The easter egg needs three facts the browser cannot have: the build's commit
+sha, that commit's date, and the contributor list with commit counts. They are
+`git` facts, and the cic build runs in containers that bind-mount **only**
+`./cicchetto` (`vite.config.ts:30-39`) — there is no repository in there to
+ask. So the payload is derived OUTSIDE the container, by the same eleven
+wrappers that already derive `GRAPPA_VERSION`, on a second env var
+`GRAPPA_CREDITS`.
+
+`infra/packaging/credits.sh` is `version.sh`'s twin: POSIX sh, same
+`SCRIPT_DIR/../..`-is-the-repo-root layout, one line of JSON on stdout
+(`{"sha":…,"date":…,"contributors":[{"name":…,"commits":N}]}`). Nothing
+re-implements the read, and a new launcher inherits both facts by copying one
+pattern instead of two.
+
+### Why the deriver never fails and the CONSUMER does
+
+`credits.sh` cannot fail, and that is a measurement rather than a softening.
+Two of the eleven launchers have no `.git` **by construction**, and both are
+RELEASE builds: `infra/packaging/aur/PKGBUILD` builds from the tag tarball
+(`release.yml` asserts it — "tarball → no .git → bare"), and
+`Dockerfile.release` has `.git` in `.dockerignore`. A throw there would break
+exactly the two builds that ship. On an absent repository it emits
+`sha:null, date:null, contributors:[]` — the same posture
+`Grappa.Version.verify_build_sha/2` already takes (`{:skip, :no_git}` versus a
+degraded snapshot), not a new one.
+
+The noise lives downstream instead, and the distinction it draws is the whole
+point: `vite.config.ts` REFUSES to build when `GRAPPA_CREDITS` is **unset**, or
+when it is not valid JSON. Unset means a wrapper forgot to plumb it — a
+mistake. Empty-but-declared means a build genuinely has no history — a fact.
+A deriver that threw would have collapsed those two into one red, in the
+substrate where the fact is normal.
+
+### What is NOT in the payload
+
+The version. It already arrives through `<meta name="cicchetto-version">`
+(#292) and the modal reads it from `bundleHash.bootBundleVersionAccessor`.
+Carrying it a second time is precisely the drift #538 closed.
+
+Transport into cic is a vite `define` (`__GRAPPA_CREDITS_JSON__`), not a second
+`<meta>`: the payload is JSON, and a meta channel would have to survive HTML
+escaping of quotes and backslashes inside author names. `lib/buildCredits.ts`
+coerces PER FIELD and never throws, so one malformed field costs that field and
+not the roll. **Under vitest the define does not exist** — `vitest.config.ts` is
+a separate config with no `define` — so the entire unit suite exercises the
+DEGRADED path by construction. Only the e2e can prove the bake.
+
+### The soundtrack has no asset
+
+"Something epic" points at Star Wars and Super Mario, and both are under
+copyright; grappa ships a public PWA and a `.deb`, so either would put a
+licence violation into a distro package. The alternatives were an original
+chiptune, a CC0 track with its licence recorded in-tree, or WebAudio. A
+synthesised minor arpeggio over a drone costs zero bytes in the tree, is the
+smallest payload of the three, and sits naturally beside a modal whose graphics
+are already synthetic. The `AudioContext` is handed IN and `stop()` CLOSES it —
+an easter egg that leaves a live audio graph behind a closed modal is a battery
+bug. The mute is session-scoped and deliberately not persisted.
+
+The modal mounts in `Shell`, not in the `SettingsDrawer` that opens it:
+`.settings-drawer` animates on `transform`, and a transformed ancestor becomes
+the containing block for every `position: fixed` descendant, so a full-screen
+modal rendered from inside would be clipped to the drawer. `ShareSessionModal`,
+opened from the same drawer, already lives in Shell for that reason. Its entry
+wears the share button's shape rather than `.settings-nav-row`, because a nav
+row carries a chevron promising a sub-page push and this opens a modal.
+
+### The release image's COPY census fired, as designed
+
+`release_latest_gate_test.bats` pins `grep -c '^COPY.*infra/packaging/'` on
+`Dockerfile.release` to a LITERAL, as the tripwire that makes "neither the
+`:latest` gate nor its classifier enters the image" a reviewed claim rather
+than an assumed one. Adding `credits.sh` took it 2 → 3 and turned the case
+red — which is the case working. The literal stays a literal: deriving the
+count from the file would make it pass by construction and buy nothing.
+
+### Two gotchas worth not rediscovering
+
+**git strips trailing "crud" from an author name** (`"`, `'`, `.`, `,`, `:`,
+`;`, `<`, `>`) when it reads the author line back. A test for the JSON escaper
+must not use a name ENDING in a quote, or it measures git's stripping instead
+of the escaper.
+
+**jsdom's `getContext()` returns null without the `canvas` package**, and
+`MatrixRain` bails before it ever requests a frame. Without a 2D-context stub
+the "cancels the rAF on unmount" case passes for the wrong reason — there was
+nothing to cancel. The stub is in `MatrixRain.test.tsx`.
+
+### Cost, and the alternative not taken
+
+Roughly 25 files: eleven launchers, two compose files, `.env.example`,
+`Dockerfile.release`, the drift guard, and nine bats fixtures that stubbed
+`version.sh` and not `credits.sh` (they died under `set -e`: 21 cases across
+six files). The alternative was the SERVER side — `Grappa.Version` already owns
+a `GitProbe`, so it would have been ONE injection point. It degrades identically
+on the same two substrates, but it adds a REST door and a `protocol_version`
+bump for an easter egg, and it puts the work on the compile lane. Declined.
+
+### Not measured
+
+- **No e2e ran.** The spec EXISTS
+  (`issue1773-credits-roll-bakes-git-facts.spec.ts`) and typechecks, and the
+  harness is in place: `scripts/integration.sh` exports `GRAPPA_CREDITS` and
+  `cicchetto/e2e/compose.yaml` hands the same string to BOTH
+  `cicchetto-build-test` and `playwright-runner`, so the spec compares what the
+  modal PAINTS against `process.env.GRAPPA_CREDITS` — the exact payload the
+  wrapper derived, not a shape. But it was never INVOKED: the STACK lane
+  belonged to another worker for the whole of this work. A shape assertion
+  would not distinguish a correct roll from an EMPTY one, which is the defect
+  this chain exists to prevent — and an unrun spec distinguishes nothing at
+  all. Nothing here establishes that the payload survives the bake on any
+  substrate.
+- **Nothing was measured on a real build of the two no-git substrates.** That
+  `credits.sh` degrades rather than throwing is proven by bats against a
+  synthetic repo-less tree, not by an AUR or release-image build.
+- **`"Your Name"` has 89 commits in the real history.** `git shortlog` on this
+  repo reports 13 contributors in 544 bytes (0.4 s), and one of them is an
+  unconfigured git identity that will be PAINTED in the production roll. The
+  cure is a `.mailmap`, which `git shortlog` honours for free. That is a
+  decision about the CONTENT of the repository and it is vjt's, so it was left
+  open rather than taken.
+- **Nothing about the felt result on a device.** No notched phone, no
+  reduced-motion setting, no audio, were exercised outside jsdom and source-level
+  assertions.

--- a/infra/docker/deploy.sh
+++ b/infra/docker/deploy.sh
@@ -131,17 +131,25 @@ require_docker() {
 	docker compose version >/dev/null 2>&1 || die "docker compose v2 not found — install the Compose plugin."
 }
 
-# ---- the cic build's version input ------------------------------------
+# ---- the cic build's repo-root inputs ---------------------------------
 # vite bakes GRAPPA_VERSION into <meta cicchetto-version> and REFUSES to build
 # without it. The cicchetto-build container mounts only ./cicchetto, so it
 # cannot read the repo-root VERSION itself: this derives it and compose passes
 # it through. Call it AT each launch point, never once at startup — `update`
 # pulls before it builds, and `stop` must not depend on a readable VERSION.
 # Why: docs/OPERATIONS.md § "The Docker deploy driver (infra/docker/)" (#652).
+#
+# #1773 adds the credit roll's git facts on the same channel, for the same
+# reason — and derived at the same launch point, so a bundle built after a
+# pull credits the history the box moved TO. Unlike the version it never
+# fails: credits.sh reports an absent repo honestly rather than aborting a
+# deploy over an easter egg (see that script's header).
 export_cic_version() {
 	GRAPPA_VERSION="$(infra/packaging/version.sh)" \
 		|| die "could not derive the version from $REPO_ROOT/VERSION — is this a complete checkout?"
 	export GRAPPA_VERSION
+	GRAPPA_CREDITS="$(infra/packaging/credits.sh)"
+	export GRAPPA_CREDITS
 }
 
 # ---- one-box-per-host ownership guard ---------------------------------

--- a/infra/freebsd/jail_cic_build.sh
+++ b/infra/freebsd/jail_cic_build.sh
@@ -35,6 +35,13 @@ staged="$(cic_dist_staging "$served")"
 # Why: docs/OPERATIONS.md § "The FreeBSD jail rails (infra/freebsd/)" (#538/#652).
 GRAPPA_VERSION="$(../infra/packaging/version.sh)"
 export GRAPPA_VERSION
+# #1773 — the git facts behind the credit roll, on the same channel and inside
+# the same login shell, for the same env-scrubbing reason. Derived HERE rather
+# than spliced in from the parent: this whole body is one single-quoted string
+# in the outer script, and a contributor name carrying an apostrophe would end
+# that quote and hand the rest of the payload to the shell as code.
+GRAPPA_CREDITS="$(../infra/packaging/credits.sh)"
+export GRAPPA_CREDITS
 # Never pipe npm into tail: buffer to a log and print the tail only on
 # failure, so set -e still sees the npm exit status.
 # Why: docs/OPERATIONS.md § "The FreeBSD jail rails (infra/freebsd/)".

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -244,6 +244,12 @@ substrate_cic() {
 	GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")" \
 		|| die "could not derive the version from $REPO_ROOT/VERSION — is this a complete checkout?"
 	export GRAPPA_VERSION
+	# #1773 — the credit roll's git facts, derived HERE for the same reason
+	# the version is: after substrate_pull, so the roll credits the history
+	# the box is moving TO. It never fails — an absent repo is reported
+	# honestly rather than aborting a deploy (see credits.sh's header).
+	GRAPPA_CREDITS="$("$REPO_ROOT/infra/packaging/credits.sh")"
+	export GRAPPA_CREDITS
 	echo "Building cicchetto dist..."
 	CIC_BUILD_OUT="$cic_build_out" "${DOCKER_COMPOSE[@]}" --profile prod run --rm cicchetto-build
 	# The promote plants the tracked .gitkeep into the tree that lands.

--- a/infra/linux/cic_build.sh
+++ b/infra/linux/cic_build.sh
@@ -28,6 +28,16 @@ STAGE_DIR="$(cic_dist_staging "${OUT_DIR}")"
 # injected into the run_as_grappa command string below.
 GRAPPA_VERSION="$("${REPO_ROOT}/infra/packaging/version.sh")"
 
+# #1773 — the credit roll's git facts (sha, date, per-author commit counts),
+# same channel and same env-scrubbing constraint.
+GRAPPA_CREDITS="$("${REPO_ROOT}/infra/packaging/credits.sh")"
+# Unlike the version — a bare X.Y.Z — this payload carries contributor NAMES,
+# and a name can hold an apostrophe (O'Brien). It is spliced into a
+# single-quoted assignment inside a `sudo bash -c` string, where one raw
+# apostrophe would close the quote and hand the rest of the JSON to the shell
+# as code. `'\''` is the POSIX idiom for a literal quote inside single quotes.
+GRAPPA_CREDITS_SQ="${GRAPPA_CREDITS//\'/\'\\\'\'}"
+
 # PATH must include ~grappa/.local/bin, where install_toolchain.sh put bun:
 # `sudo -u ... bash -c` otherwise falls back to the system default PATH.
 run_as_grappa() {
@@ -39,7 +49,7 @@ echo "[cic_build] bun install && bun run build (outDir=${STAGE_DIR} → ${OUT_DI
 # and the interesting signal is the exit code.
 log="$(mktemp)"
 trap 'rm -f "${log}"' EXIT
-if ! run_as_grappa "export GRAPPA_VERSION='${GRAPPA_VERSION}'; cd '${CIC_DIR}' && bun install && bun run build -- --outDir '${STAGE_DIR}' --emptyOutDir" >"${log}" 2>&1; then
+if ! run_as_grappa "export GRAPPA_VERSION='${GRAPPA_VERSION}'; export GRAPPA_CREDITS='${GRAPPA_CREDITS_SQ}'; cd '${CIC_DIR}' && bun install && bun run build -- --outDir '${STAGE_DIR}' --emptyOutDir" >"${log}" 2>&1; then
 	echo "[cic_build] ERROR: build failed — output:" >&2
 	cat "${log}" >&2
 	exit 1

--- a/infra/packaging/aur/PKGBUILD
+++ b/infra/packaging/aur/PKGBUILD
@@ -122,6 +122,16 @@ build() {
 	GRAPPA_VERSION="$(infra/packaging/version.sh)"
 	export GRAPPA_VERSION
 
+	# #1773 — the git facts behind the credit roll, on the same channel.
+	# THIS recipe is one of the two substrates where they do not exist: the
+	# build runs on the extracted source TARBALL, which carries no `.git`, so
+	# credits.sh reports the absence honestly (sha:null, contributors:[]) and
+	# the roll degrades to the version alone — exactly as Grappa.Version
+	# reports the bare tag here for the same reason. It must NOT be a hard
+	# failure, or the package stops building over an easter egg.
+	GRAPPA_CREDITS="$(infra/packaging/credits.sh)"
+	export GRAPPA_CREDITS
+
 	echo "==> cicchetto SPA (bun + vite)"
 	cd cicchetto
 	bun install --frozen-lockfile

--- a/infra/packaging/build.sh
+++ b/infra/packaging/build.sh
@@ -58,6 +58,13 @@ if [ -z "${GRAPPA_VERSION:-}" ]; then
 fi
 export GRAPPA_VERSION
 
+# #1773 — the git facts behind the credit roll (sha, date, per-author commit
+# counts), which the cic build cannot read for itself. No env override and no
+# die: the payload is derived, never hand-set, and an absent repo is reported
+# honestly rather than failing a package build (see credits.sh).
+GRAPPA_CREDITS="$("${SCRIPT_DIR}/credits.sh")"
+export GRAPPA_CREDITS
+
 # The client keeps its OWN version line (frontends/shottino/version.h) — two
 # artifacts, two cadences (#1447). Same script, different component, so the
 # "which file carries which number" answer stays in one place.

--- a/infra/packaging/credits.sh
+++ b/infra/packaging/credits.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# credits.sh — echo the build's git credits payload, as ONE line of JSON.
+#
+#   {"sha":"a453325e","date":"2026-08-25T18:04:11+02:00",
+#    "contributors":[{"name":"…","commits":903},…]}
+#
+# Sibling of version.sh, and deliberately shaped like it: the cic build runs
+# in containers that mount ONLY ./cicchetto (cicchetto/vite.config.ts:30-39),
+# so the repo root — and therefore git — is out of reach in there. Every
+# cic-build entrypoint already derives GRAPPA_VERSION from version.sh and
+# exports it before the container starts; this script is the second half of
+# that same channel, for the three facts a credit roll needs and a browser
+# cannot have (#1773). A `git shortlog` inside vite.config.ts would find no
+# repo and bake an EMPTY roll, silently, on every containerised build.
+#
+# POSIX sh, NOT bash, for the same reason version.sh is: the FreeBSD jail
+# build (infra/freebsd/jail_cic_build.sh) runs /bin/sh with no bash port and
+# calls this to derive the payload. Always EXECUTED (never sourced), so `$0`
+# locates the script.
+#
+# ── Why this NEVER fails, unlike the GRAPPA_VERSION throw in vite.config.ts ──
+#
+# Two of the launchers that must call it have no `.git` BY CONSTRUCTION, and
+# both are RELEASE builds:
+#
+#   * infra/packaging/aur/PKGBUILD builds from the tag's source TARBALL —
+#     release.yml asserts that shape outright ("tarball → no .git → bare");
+#   * Dockerfile.release .dockerignore's `.git`, which is exactly why the
+#     comment in it says Grappa.Version "takes its no-git path".
+#
+# So a hard failure on a missing repo would break precisely the two builds
+# that ship. This script instead reports the absence honestly — `sha:null`,
+# `date:null`, `contributors:[]` — which is the SAME posture
+# `Grappa.Version.verify_build_sha/2` already takes, where a positively
+# identified no-git build is `{:skip, :no_git}` and only a BROKEN snapshot is
+# an error. The loud half stays where it belongs: vite still refuses to build
+# when GRAPPA_CREDITS is UNSET, because that means a wrapper forgot to plumb
+# it, which is the failure the throw exists to catch.
+#
+# Why: docs/OPERATIONS.md § "Packaging (infra/packaging/)".
+set -eu
+
+# No `dirname --` / `cd --`: BSD dirname (the FreeBSD jail) doesn't accept the
+# end-of-options `--`, and $0 is always an invoked path (never starts with -).
+#
+# `CDPATH= cd` is an env-prefixed command (clear CDPATH for this cd only, so a
+# user's CDPATH cannot teleport it and mis-root the repo), not a botched
+# assignment — hence the SC1007 disable.
+# shellcheck disable=SC1007
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1007
+REPO_ROOT="$(CDPATH= cd "${SCRIPT_DIR}/../.." && pwd)"
+
+sha=""
+date=""
+shortlog=""
+
+# `.git` is a directory in a normal checkout and a FILE in a `git worktree`
+# (it points at the shared gitdir); either is a source build. Absent entirely
+# is a release tarball / package. Tested explicitly rather than letting git
+# walk upwards: a checkout extracted INSIDE some other repo must report its
+# own absence, not that repo's history.
+if [ -e "${REPO_ROOT}/.git" ]; then
+	# Every probe degrades to empty on failure and none of them aborts the
+	# script — same contract as Grappa.Version.GitProbe, and for the same
+	# reason: a missing git binary, an unborn HEAD or a refused checkout
+	# (git's "dubious ownership") must yield a smaller payload, never a
+	# broken build.
+	sha="$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || true)"
+	date="$(git -C "${REPO_ROOT}" log -1 --format=%cI 2>/dev/null || true)"
+	# `--no-merges` so a merge does not credit the merger with the work of
+	# whoever authored the branch; HEAD is named explicitly so shortlog reads
+	# the revision instead of waiting on stdin.
+	shortlog="$(git -C "${REPO_ROOT}" shortlog -sn --no-merges HEAD 2>/dev/null || true)"
+fi
+
+# ONE awk pass builds the whole payload: the contributor rows come in on
+# stdin, the two scalars on -v. LC_ALL=C keeps substr/length byte-oriented, so
+# a multi-byte name is copied through byte by byte and reassembles exactly —
+# awk never reorders what it concatenates.
+printf '%s' "${shortlog}" | LC_ALL=C awk -v sha="${sha}" -v head_date="${date}" '
+	# JSON string literal. Character-by-character rather than gsub: the
+	# replacement text of gsub gives `\` and `&` their own meanings, which is
+	# how an escaper comes to corrupt exactly the input it exists for.
+	function jsonstr(s,   out, i, c) {
+		out = "\""
+		for (i = 1; i <= length(s); i++) {
+			c = substr(s, i, 1)
+			if (c == "\\") {
+				out = out "\\\\"
+			} else if (c == "\"") {
+				out = out "\\\""
+			} else if (c < " ") {
+				# git forbids CR/LF in an author name, so this is
+				# unreachable in practice — but the payload has to be
+				# parseable by construction, not by trust.
+				out = out " "
+			} else {
+				out = out c
+			}
+		}
+		return out "\""
+	}
+
+	function jsonornull(s) {
+		return s == "" ? "null" : jsonstr(s)
+	}
+
+	{
+		# `shortlog -sn` emits "<count>\t<name>"; a line without the tab is
+		# not a contributor row and is dropped rather than guessed at.
+		tab = index($0, "\t")
+		if (tab == 0) {
+			next
+		}
+		if (n > 0) {
+			rows = rows ","
+		}
+		rows = rows "{\"name\":" jsonstr(substr($0, tab + 1)) ",\"commits\":" ($1 + 0) "}"
+		n++
+	}
+
+	END {
+		printf "{\"sha\":%s,\"date\":%s,\"contributors\":[%s]}\n",
+			jsonornull(sha), jsonornull(head_date), rows
+	}
+'

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -39,6 +39,12 @@ mkdir -p "$CICCHETTO_DIR" "$BUN_CACHE_DIR"
 GRAPPA_VERSION="$("$SRC_ROOT/infra/packaging/version.sh")"
 export GRAPPA_VERSION
 
+# #1773 — the credit roll's git facts (sha, date, per-author commit counts),
+# same channel and same reason: this container has no repo to read them from.
+# Derived from SRC_ROOT so the roll describes THIS worktree's history.
+GRAPPA_CREDITS="$("$SRC_ROOT/infra/packaging/credits.sh")"
+export GRAPPA_CREDITS
+
 # Run bun inside the oven/bun:1 oneshot. Args are the trailing `docker run`
 # operands (extra flags + image + `bun` + bun args), so the implicit install
 # and the real invocation share one definition of the mount/uid/cache wiring.
@@ -58,6 +64,7 @@ run_bun() {
         -e HOME=/tmp \
         -e BUN_INSTALL_CACHE_DIR=/cache \
         -e GRAPPA_VERSION \
+        -e GRAPPA_CREDITS \
         -w /app \
         "$@"
 }

--- a/scripts/deploy-cic.sh
+++ b/scripts/deploy-cic.sh
@@ -45,6 +45,10 @@ CIC_BUILD_OUT="$(cic_dist_docker_stage "$CIC_SERVED")"
 # repo root, so pass the version through the compose env (#538).
 GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")"
 export GRAPPA_VERSION
+# #1773 — same channel, same reason: the credit roll's git facts cannot be read
+# from inside that container either.
+GRAPPA_CREDITS="$("$REPO_ROOT/infra/packaging/credits.sh")"
+export GRAPPA_CREDITS
 echo "Building cicchetto dist..."
 CIC_BUILD_OUT="$CIC_BUILD_OUT" docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
 # Swap the finished bundle in; the promote plants the tracked .gitkeep.

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -39,6 +39,14 @@ TESTNET="$(cd "$(dirname "$0")" && pwd)/testnet.sh"
 GRAPPA_VERSION="$("$SRC_ROOT/infra/packaging/version.sh")"
 export GRAPPA_VERSION
 
+# #1773 — the credit roll's git facts, on the same channel and for the same
+# reason. Exported here as well as in testnet.sh so the playwright-runner
+# service sees it too: the e2e spec compares what the modal PAINTS against
+# what this wrapper DERIVED, and a runner that cannot see the payload could
+# only assert a shape — which cannot tell a correct roll from an empty one.
+GRAPPA_CREDITS="$("$SRC_ROOT/infra/packaging/credits.sh")"
+export GRAPPA_CREDITS
+
 LOG_DIR="$E2E_DIR/container-logs"
 CENSUS_FILE="$LOG_DIR/gap-scan.tsv"
 SCAN_AWK="$(cd "$(dirname "$0")" && pwd)/log-gap-scan.awk"

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -31,6 +31,9 @@ E2E_DIR="$SRC_ROOT/cicchetto/e2e"
 # Why: docs/OPERATIONS.md § "Developer and deploy scripts (scripts/*.sh)" (#538).
 GRAPPA_VERSION="$("$SRC_ROOT/infra/packaging/version.sh")"
 export GRAPPA_VERSION
+# #1773 — the credit roll's git facts, same channel, same reason.
+GRAPPA_CREDITS="$("$SRC_ROOT/infra/packaging/credits.sh")"
+export GRAPPA_CREDITS
 
 if [ ! -f "$E2E_DIR/compose.yaml" ]; then
     die "missing $E2E_DIR/compose.yaml"

--- a/test/infra/cic_dist_swap_test.bats
+++ b/test/infra/cic_dist_swap_test.bats
@@ -231,7 +231,10 @@ seed_fake_checkout() {
     FAKE_ROOT="$1"
     mkdir -p "$FAKE_ROOT/cicchetto" "$FAKE_ROOT/infra/packaging" "$FAKE_ROOT/infra/lib" "$FAKE_ROOT/runtime"
     cp "$REPO_SRC/infra/packaging/version.sh" "$FAKE_ROOT/infra/packaging/version.sh"
-    chmod +x "$FAKE_ROOT/infra/packaging/version.sh"
+    # #1773 — the cic builders derive GRAPPA_CREDITS here too, under `set -e`.
+    # A fake checkout missing it is a fake checkout that cannot build.
+    cp "$REPO_SRC/infra/packaging/credits.sh" "$FAKE_ROOT/infra/packaging/credits.sh"
+    chmod +x "$FAKE_ROOT/infra/packaging/version.sh" "$FAKE_ROOT/infra/packaging/credits.sh"
     cp "$LIB" "$FAKE_ROOT/infra/lib/cic_dist.sh"
     printf '9.9.9\n' > "$FAKE_ROOT/VERSION"
     printf '{"name":"cicchetto"}\n' > "$FAKE_ROOT/cicchetto/package.json"

--- a/test/infra/cic_version_export_test.bats
+++ b/test/infra/cic_version_export_test.bats
@@ -1,7 +1,24 @@
 #!/usr/bin/env bats
 #
 # Drift guard: every entrypoint that can launch a cicchetto build must derive
-# GRAPPA_VERSION from the repo-root VERSION file and export it (#538/#652).
+# the repo-root build facts and export them —
+#
+#   * GRAPPA_VERSION, from infra/packaging/version.sh (#538/#652);
+#   * GRAPPA_CREDITS, from infra/packaging/credits.sh (#1773).
+#
+# ONE guard for both, not two files, for the reason the WHY below already
+# gives: what can be shared is the CHECK, and a second file would carry a
+# second copy of the roster — the drift this exists to catch. The filename
+# still says "version" because two DESIGN_NOTES entries cite it by path
+# (2026-07-… and later), and renaming it would falsify a historical record to
+# buy a naming nicety.
+#
+# Both payloads travel the SAME channel and for the same measured reason: the
+# cic build containers mount only ./cicchetto, so the repo root — VERSION file
+# and git alike — is unreachable inside them. They differ in one place only,
+# and it is deliberate: an unset GRAPPA_VERSION makes vite throw, while
+# credits.sh cannot fail, because the AUR tarball and Dockerfile.release have
+# no `.git` by construction (see that script's header).
 #
 # WHY a guard and not a shared helper: the derive+export pair is two lines, but
 # it lives in bash (scripts/*.sh), POSIX sh (the FreeBSD jail, which has no bash
@@ -86,19 +103,38 @@ launches_cic_build() {
     grep -qE 'cicchetto-build|(bun|npm) run build|--profile prod|cicchetto/e2e|oven/bun' <<< "$(code_of "$1")"
 }
 
-# Compliance is BOTH halves. `export GRAPPA_VERSION=0.10.0` alone would pass an
-# export-only check while planting a second hand-edited version carrier —
-# exactly what the VERSION file is the single source of truth against.
+# Compliance is BOTH halves, per payload. `export GRAPPA_VERSION=0.10.0` alone
+# would pass an export-only check while planting a second hand-edited version
+# carrier — exactly what the VERSION file is the single source of truth
+# against; `export GRAPPA_CREDITS='{}'` would bake a hand-written empty roll,
+# which is the #1773 failure with extra steps.
+exports_var() {
+    grep -q "export $2" <<< "$(code_of "$1")"
+}
+
+derives_from() {
+    grep -q "$2" <<< "$(code_of "$1")"
+}
+
 exports_version() {
-    grep -q 'export GRAPPA_VERSION' <<< "$(code_of "$1")"
+    exports_var "$1" GRAPPA_VERSION
 }
 
 derives_version() {
-    grep -q 'version\.sh' <<< "$(code_of "$1")"
+    derives_from "$1" 'version\.sh'
+}
+
+exports_credits() {
+    exports_var "$1" GRAPPA_CREDITS
+}
+
+derives_credits() {
+    derives_from "$1" 'credits\.sh'
 }
 
 complies() {
-    derives_version "$1" && exports_version "$1"
+    derives_version "$1" && exports_version "$1" \
+        && derives_credits "$1" && exports_credits "$1"
 }
 
 # The shell/build entrypoints a cic build can be launched from. compose files
@@ -151,7 +187,25 @@ discovered_launchers() {
     }
 }
 
-@test "scan: no shell or build entrypoint launches a cic build without exporting GRAPPA_VERSION" {
+# Its own case, not a second pair of lines inside the one above: the two
+# payloads fail independently, and a merged case would report "the roster is
+# broken" without saying which fact went missing.
+@test "roster: every known cic-build launcher derives GRAPPA_CREDITS from credits.sh and exports it (#1773)" {
+    local missing=()
+    for rel in "${ROSTER[@]}"; do
+        local f="$REPO_SRC/$rel"
+        [ -f "$f" ] || { missing+=("$rel (file is gone)"); continue; }
+        derives_credits "$f" || missing+=("$rel (no credits.sh derive)")
+        exports_credits "$f" || missing+=("$rel (no export GRAPPA_CREDITS)")
+    done
+    [ "${#missing[@]}" -eq 0 ] || {
+        printf 'launchers that stopped deriving/exporting GRAPPA_CREDITS:\n' >&2
+        printf '  %s\n' "${missing[@]}" >&2
+        return 1
+    }
+}
+
+@test "scan: no shell or build entrypoint launches a cic build without exporting BOTH build facts" {
     run --separate-stderr unexported_launchers "$REPO_SRC"
     [ "$status" -eq 0 ]
     # The scan's own errors are not findings, and must not pass silently
@@ -195,9 +249,31 @@ discovered_launchers() {
 @test "scan: RED — a launcher that hardcodes the version instead of deriving it is caught" {
     local fake="$BATS_TEST_TMPDIR/repo"
     mkdir -p "$fake/scripts"
+    # Compliant on the CREDITS axis on purpose, so this case can only fail for
+    # the reason it names. A fixture missing both would report green-for-the-
+    # wrong-reason the day the version half stopped being checked.
     cat > "$fake/scripts/ship-the-bundle.sh" <<'EOF'
 #!/usr/bin/env bash
 export GRAPPA_VERSION=0.10.0
+GRAPPA_CREDITS="$(infra/packaging/credits.sh)"
+export GRAPPA_CREDITS
+docker compose --profile prod run --rm cicchetto-build
+EOF
+
+    run --separate-stderr unexported_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ "$output" = "scripts/ship-the-bundle.sh" ]
+}
+
+@test "scan: RED — a launcher that plumbs the version but forgets the credits is caught (#1773)" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    # The #1773 shape: fully compliant on the axis the guard already had, and
+    # silently baking an EMPTY credit roll on the axis it did not.
+    cat > "$fake/scripts/ship-the-bundle.sh" <<'EOF'
+#!/usr/bin/env bash
+GRAPPA_VERSION="$(infra/packaging/version.sh)"
+export GRAPPA_VERSION
 docker compose --profile prod run --rm cicchetto-build
 EOF
 
@@ -257,6 +333,8 @@ EOF
 #!/usr/bin/env bash
 GRAPPA_VERSION="$(infra/packaging/version.sh)"
 export GRAPPA_VERSION
+GRAPPA_CREDITS="$(infra/packaging/credits.sh)"
+export GRAPPA_CREDITS
 docker compose --profile prod run --rm cicchetto-build
 EOF
 

--- a/test/infra/credits_payload_test.bats
+++ b/test/infra/credits_payload_test.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+#
+# infra/packaging/credits.sh — the build's git credits payload (#1773).
+#
+# The credits modal needs three facts the browser cannot have: the commit sha,
+# its date, and the contributor list with per-author commit counts. They are
+# git facts, and the cic build runs in containers that mount ONLY ./cicchetto
+# (cicchetto/vite.config.ts:30-39), so the repo root is out of reach there.
+# The payload is therefore derived OUTSIDE the container by the same wrappers
+# that already derive GRAPPA_VERSION, and handed in on an env var.
+#
+# What these cases pin, and why each one exists:
+#
+#   1. the PAYLOAD is exact — a wrong count or a dropped author is a lie the
+#      modal would render as fact, so the assertion is a byte-for-byte compare
+#      against a sandbox repo whose history this file wrote;
+#   2. merges are EXCLUDED — `--no-merges`, so a merge-heavy branch does not
+#      credit the merger for other people's work;
+#   3. a name carrying `"` or `\` stays PARSEABLE — the payload is JSON that
+#      vite parses at build time, and one unescaped quote turns the whole roll
+#      into a build failure (or, worse, a truncated roll);
+#   4. NO GIT is not an error — the AUR recipe builds from a release tarball
+#      and Dockerfile.release .dockerignore's `.git`, so on the two RELEASE
+#      substrates there is no repo to read. The script must exit 0 with an
+#      honestly empty payload there, exactly as `Grappa.Version` reports the
+#      bare base on its no-git path. Failing loud here would break precisely
+#      the two builds that ship;
+#   5. ONE LINE of output — every wrapper captures it with `$(...)` into an
+#      env var, and a multi-line payload would arrive mangled.
+#
+# The sandbox repos are built here rather than measured against this checkout:
+# the real history changes every commit, so a case reading it could only
+# assert a shape, and a shape assertion cannot tell a correct roll from an
+# empty one.
+
+load ../bats_helpers
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../../infra/packaging/credits.sh"
+
+    REPO="$BATS_TEST_TMPDIR/repo"
+    # `credits.sh` derives the repo root as SCRIPT_DIR/../.. (the layout
+    # version.sh already expects), so the sandbox gets its own copy at the
+    # same relative depth and reads the sandbox, not this checkout.
+    mkdir -p "$REPO/infra/packaging"
+    cp "$SCRIPT" "$REPO/infra/packaging/credits.sh"
+    chmod +x "$REPO/infra/packaging/credits.sh"
+    SANDBOX_SCRIPT="$REPO/infra/packaging/credits.sh"
+
+    seq=0
+}
+
+# Commit as a named author, touching a file nobody else touches — the merge
+# case needs two branches that can actually merge without a conflict.
+commit_as() {
+    local name="$1" email="$2" message="$3"
+    seq=$((seq + 1))
+    printf '%s\n' "$message" > "$REPO/file-$seq.txt"
+    git -C "$REPO" add "file-$seq.txt"
+    GIT_AUTHOR_NAME="$name" GIT_AUTHOR_EMAIL="$email" \
+        GIT_COMMITTER_NAME="$name" GIT_COMMITTER_EMAIL="$email" \
+        git -C "$REPO" commit -q -m "$message"
+}
+
+init_repo() {
+    git -C "$REPO" init -q -b main
+    git -C "$REPO" config user.name "sandbox"
+    git -C "$REPO" config user.email "sandbox@example.invalid"
+    # No mailmap: `git shortlog` therefore groups by the author name verbatim
+    # and the expected counts below are the literal ones.
+}
+
+@test "the payload names every contributor with the count of their non-merge commits" {
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "Ada Lovelace" "ada@example.invalid" "two"
+    commit_as "Ada Lovelace" "ada@example.invalid" "three"
+    commit_as "Grace Hopper" "grace@example.invalid" "four"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Descending by count, which is what `shortlog -sn` orders by and what a
+    # credit roll wants — the exact string, so a re-ordering fails too.
+    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","commits":3},{"name":"Grace Hopper","commits":1}]'* ]]
+}
+
+@test "the sha and the date are the ones HEAD actually carries" {
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+
+    local sha date
+    sha="$(git -C "$REPO" rev-parse --short HEAD)"
+    date="$(git -C "$REPO" log -1 --format=%cI)"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == "{\"sha\":\"$sha\",\"date\":\"$date\","* ]]
+}
+
+@test "a merge commit credits nobody — the roll counts authored work" {
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "base"
+    git -C "$REPO" checkout -q -b side
+    commit_as "Grace Hopper" "grace@example.invalid" "side work"
+    git -C "$REPO" checkout -q main
+    commit_as "Ada Lovelace" "ada@example.invalid" "main work"
+    # --no-ff forces a merge COMMIT, which is the thing under test; the merger
+    # is a third name, so a leak shows up as that name appearing at all.
+    GIT_AUTHOR_NAME="Mergebot" GIT_AUTHOR_EMAIL="bot@example.invalid" \
+        GIT_COMMITTER_NAME="Mergebot" GIT_COMMITTER_EMAIL="bot@example.invalid" \
+        git -C "$REPO" merge -q --no-ff -m "merge side" side
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    refute grep -q 'Mergebot' <<< "$output"
+    [[ "$output" == *'{"name":"Ada Lovelace","commits":2}'* ]]
+    [[ "$output" == *'{"name":"Grace Hopper","commits":1}'* ]]
+}
+
+@test "a name carrying a quote or a backslash is escaped, not emitted raw" {
+    init_repo
+    # Both JSON metacharacters in one name: raw, the quote closes the string
+    # early and the rest of the payload becomes syntax. vite PARSES this
+    # payload at build time, so an unescaped name is a broken build — or, if
+    # it happens to stay parseable, a truncated roll.
+    #
+    # The name must not END on a metacharacter: git's own ident parser strips
+    # trailing "crud" (`"`, `'`, `.`, `,`, `:`, `;`, `<`, `>`) when it reads an
+    # author line back, so `… "Quoted"` reaches shortlog as `… "Quoted` and the
+    # case would then be measuring git's stripping instead of this escaper.
+    commit_as 'A "B" C\D' "odd@example.invalid" "one"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Single-quoted pattern: bash takes every character literally, so this is
+    # the payload's exact bytes — two escaped quotes, one escaped backslash.
+    [[ "$output" == *'{"name":"A \"B\" C\\D","commits":1}'* ]]
+}
+
+@test "no git is an honest empty payload, not a failure (AUR tarball, Dockerfile.release)" {
+    # No `git init` at all: the shape both RELEASE substrates present.
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = '{"sha":null,"date":null,"contributors":[]}' ]
+}
+
+@test "the payload is a single line, so a wrapper can carry it in one env var" {
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "Grace Hopper" "grace@example.invalid" "two"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
+}

--- a/test/infra/deploy_docker_convergence_test.bats
+++ b/test/infra/deploy_docker_convergence_test.bats
@@ -58,7 +58,11 @@ setup() {
     fi
     cp "$REPO_SRC/VERSION" "$UPSTREAM/VERSION"
     cp "$REPO_SRC/infra/packaging/version.sh" "$UPSTREAM/infra/packaging/version.sh"
-    chmod +x "$UPSTREAM/infra/docker/deploy.sh" "$UPSTREAM/infra/packaging/version.sh"
+    # #1773 — the cic launch derives GRAPPA_CREDITS from this one, under
+    # `set -e`; a checkout without it is not a checkout the deploy can drive.
+    cp "$REPO_SRC/infra/packaging/credits.sh" "$UPSTREAM/infra/packaging/credits.sh"
+    chmod +x "$UPSTREAM/infra/docker/deploy.sh" "$UPSTREAM/infra/packaging/version.sh" \
+        "$UPSTREAM/infra/packaging/credits.sh"
     cat > "$UPSTREAM/compose.yaml" <<'EOF'
 services:
   grappa:

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -77,6 +77,16 @@ setup() {
 echo 0.0.0-test
 EOF
     chmod +x "$UPSTREAM/infra/packaging/version.sh"
+    # #1773 — credits.sh delegate, same shape and for the same reason: the cic
+    # launch derives GRAPPA_CREDITS from it under `set -e`. A fixed payload,
+    # not the real script: this sandbox is a throwaway git repo whose history
+    # is one "base" commit, so the real derivation would answer with THAT and
+    # make these cases depend on fixture history they do not care about.
+    cat > "$UPSTREAM/infra/packaging/credits.sh" <<'EOF'
+#!/bin/sh
+echo '{"sha":"0000000","date":"2026-01-01T00:00:00+00:00","contributors":[]}'
+EOF
+    chmod +x "$UPSTREAM/infra/packaging/credits.sh"
     touch "$UPSTREAM/runtime/.gitkeep"
     echo base > "$UPSTREAM/lib/base.txt"
     git -C "$UPSTREAM" add -A

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -53,7 +53,11 @@ setup() {
     # cic build with an empty value is refused by vite (#692).
     cp "$REPO_SRC/VERSION" "$UPSTREAM/VERSION"
     cp "$REPO_SRC/infra/packaging/version.sh" "$UPSTREAM/infra/packaging/version.sh"
-    chmod +x "$UPSTREAM/infra/docker/deploy.sh" "$UPSTREAM/infra/packaging/version.sh"
+    # #1773 — the cic launch derives GRAPPA_CREDITS from this one, under
+    # `set -e`; a checkout without it is not a checkout the deploy can drive.
+    cp "$REPO_SRC/infra/packaging/credits.sh" "$UPSTREAM/infra/packaging/credits.sh"
+    chmod +x "$UPSTREAM/infra/docker/deploy.sh" "$UPSTREAM/infra/packaging/version.sh" \
+        "$UPSTREAM/infra/packaging/credits.sh"
     # The ownership guard reads container_name out of compose.yaml.
     cat > "$UPSTREAM/compose.yaml" <<'EOF'
 services:

--- a/test/infra/deploy_docker_verbs_test.bats
+++ b/test/infra/deploy_docker_verbs_test.bats
@@ -38,7 +38,10 @@ setup() {
     # in gets a real number instead of refusing to start (#692).
     cp "$REPO_SRC/VERSION" "$BOX/VERSION"
     cp "$REPO_SRC/infra/packaging/version.sh" "$BOX/infra/packaging/version.sh"
-    chmod +x "$BOX/infra/packaging/version.sh"
+    # #1773 — and GRAPPA_CREDITS beside it, derived at the same launch point
+    # under `set -e`.
+    cp "$REPO_SRC/infra/packaging/credits.sh" "$BOX/infra/packaging/credits.sh"
+    chmod +x "$BOX/infra/packaging/version.sh" "$BOX/infra/packaging/credits.sh"
     # Preflight checks its presence, and the ownership guard reads the
     # pinned container names out of it — those pins are what makes two
     # checkouts collide on one docker daemon (#485 dropped the nginx one).

--- a/test/infra/release_latest_gate_test.bats
+++ b/test/infra/release_latest_gate_test.bats
@@ -339,11 +339,18 @@ workflow_code() {
     grep -qF 'infra/packaging/prerelease_flag.sh' <<<"$scaffolding"
 
     # And the artefact is unchanged by that, which is the reason the list may
-    # grow at all: Dockerfile.release COPYs exactly two files out of
-    # infra/packaging, and neither is one of these. Measured, not assumed —
-    # the moment a third joins, this assertion is the one that notices.
+    # grow at all: Dockerfile.release COPYs a SMALL, enumerated set out of
+    # infra/packaging, and neither of these two is in it. Measured, not
+    # assumed — the moment one more joins, this assertion is the one that
+    # notices, and the count stays a LITERAL for exactly that reason. Deriving
+    # it from the file would make it pass by construction and buy nothing.
+    #
+    # It has fired once, as designed: #1773 added credits.sh (the credit
+    # roll's git facts, on the same channel as version.sh), taking the count
+    # 2 → 3. Reviewed at that point — credits.sh is neither the gate nor the
+    # classifier, so the two refutes below still carry the property.
     run grep -c '^COPY.*infra/packaging/' "$REPO_ROOT/Dockerfile.release"
-    [ "$output" = "2" ]
+    [ "$output" = "3" ]
     refute grep -qF 'infra/packaging/latest_tag_gate.sh' "$REPO_ROOT/Dockerfile.release"
     refute grep -qF 'infra/packaging/prerelease_flag.sh' "$REPO_ROOT/Dockerfile.release"
 }

--- a/test/scripts/bun_self_heal_test.bats
+++ b/test/scripts/bun_self_heal_test.bats
@@ -37,7 +37,10 @@ setup() {
     cp "$REAL_ROOT/scripts/_lib.sh" "$FIXTURE/scripts/_lib.sh"
     cp "$REAL_ROOT/scripts/bun.sh" "$FIXTURE/scripts/bun.sh"
     cp "$REAL_ROOT/infra/packaging/version.sh" "$FIXTURE/infra/packaging/version.sh"
-    chmod +x "$FIXTURE/scripts/bun.sh" "$FIXTURE/infra/packaging/version.sh"
+    # #1773 — bun.sh derives GRAPPA_CREDITS here too, before any verb runs.
+    cp "$REAL_ROOT/infra/packaging/credits.sh" "$FIXTURE/infra/packaging/credits.sh"
+    chmod +x "$FIXTURE/scripts/bun.sh" "$FIXTURE/infra/packaging/version.sh" \
+        "$FIXTURE/infra/packaging/credits.sh"
     # bun.sh derives GRAPPA_VERSION through version.sh, which reads this.
     printf '9.9.9\n' > "$FIXTURE/VERSION"
 

--- a/test/scripts/deploy_worktree_guard_test.bats
+++ b/test/scripts/deploy_worktree_guard_test.bats
@@ -29,6 +29,7 @@ setup() {
     DEPLOY_CIC_SH="$BATS_TEST_DIRNAME/../../scripts/deploy-cic.sh"
     LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
     VERSION_SH="$BATS_TEST_DIRNAME/../../infra/packaging/version.sh"
+    CREDITS_SH="$BATS_TEST_DIRNAME/../../infra/packaging/credits.sh"
 
     FAKE_DIR="$BATS_TEST_TMPDIR/fake"
     mkdir -p "$FAKE_DIR"
@@ -65,7 +66,10 @@ setup() {
     # the real derivation dies under `set -e` before the build.
     mkdir -p "$MAIN/infra/packaging"
     cp "$VERSION_SH" "$MAIN/infra/packaging/version.sh"
-    chmod +x "$MAIN/infra/packaging/version.sh"
+    # #1773 — the same paths also derive GRAPPA_CREDITS, on the same channel
+    # and under the same `set -e`.
+    cp "$CREDITS_SH" "$MAIN/infra/packaging/credits.sh"
+    chmod +x "$MAIN/infra/packaging/version.sh" "$MAIN/infra/packaging/credits.sh"
     printf '9.9.9\n' > "$MAIN/VERSION"
     printf 'defmodule Grappa.MixProject do\n  @version "9.9.9"\nend\n' > "$MAIN/mix.exs"
     : > "$MAIN/compose.yaml"

--- a/test/scripts/integration_log_capture_test.bats
+++ b/test/scripts/integration_log_capture_test.bats
@@ -39,6 +39,7 @@ setup() {
     LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
     SCAN_AWK="$BATS_TEST_DIRNAME/../../scripts/log-gap-scan.awk"
     VERSION_SH="$BATS_TEST_DIRNAME/../../infra/packaging/version.sh"
+    CREDITS_SH="$BATS_TEST_DIRNAME/../../infra/packaging/credits.sh"
 
     TMP="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
     MAIN="$TMP/main"
@@ -54,7 +55,9 @@ setup() {
     # integration.sh derives GRAPPA_VERSION from the repo-root VERSION file
     # (#652) before anything else; under set -e it must succeed.
     cp "$VERSION_SH" "$MAIN/infra/packaging/version.sh"
-    chmod +x "$MAIN/infra/packaging/version.sh"
+    # #1773 — and GRAPPA_CREDITS on the next line of the same prelude.
+    cp "$CREDITS_SH" "$MAIN/infra/packaging/credits.sh"
+    chmod +x "$MAIN/infra/packaging/version.sh" "$MAIN/infra/packaging/credits.sh"
     printf '9.9.9\n' >"$MAIN/VERSION"
     printf 'defmodule Grappa.MixProject do\n  @version "9.9.9"\nend\n' >"$MAIN/mix.exs"
     echo base >"$MAIN/lib/base.ex"

--- a/test/scripts/submodule_init_flag_test.bats
+++ b/test/scripts/submodule_init_flag_test.bats
@@ -26,6 +26,7 @@ setup() {
     BATS_SH="$BATS_TEST_DIRNAME/../../scripts/bats.sh"
     LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
     VERSION_SH="$BATS_TEST_DIRNAME/../../infra/packaging/version.sh"
+    CREDITS_SH="$BATS_TEST_DIRNAME/../../infra/packaging/credits.sh"
 
     FAKE_DIR="$BATS_TEST_TMPDIR/fake"
     mkdir -p "$FAKE_DIR"
@@ -51,7 +52,10 @@ setup() {
     # version.sh (#652) BEFORE the submodule branch — under set -e it must
     # succeed or the script dies before we reach the code under test.
     cp "$VERSION_SH" "$MAIN/infra/packaging/version.sh"
-    chmod +x "$MAIN/infra/packaging/version.sh"
+    # #1773 — GRAPPA_CREDITS is derived on the same lines, before the same
+    # branch, and dies the same way when the script is missing.
+    cp "$CREDITS_SH" "$MAIN/infra/packaging/credits.sh"
+    chmod +x "$MAIN/infra/packaging/version.sh" "$MAIN/infra/packaging/credits.sh"
     printf '9.9.9\n' > "$MAIN/VERSION"
     printf 'defmodule Grappa.MixProject do\n  @version "9.9.9"\nend\n' > "$MAIN/mix.exs"
     # testnet.sh's compose.yaml existence check must pass; the infra


### PR DESCRIPTION
The credits easter egg (#1773): a full-viewport end-titles roll over falling
characters, opened from the bottom of the settings drawer, naming the build
and everyone who wrote it.

## The problem the design is actually solving

The roll needs three facts the browser cannot have — the build's commit sha,
that commit's date, and the contributor list with commit counts. They are
`git` facts, and the cic build runs in containers that bind-mount **only**
`./cicchetto` (`vite.config.ts:30-39`): there is no repository in there to ask.

So the payload is derived **outside** the container, by the same eleven
wrappers that already derive `GRAPPA_VERSION`, on a second env var
`GRAPPA_CREDITS`. `infra/packaging/credits.sh` is `version.sh`'s twin (POSIX
sh, same `SCRIPT_DIR/../..` layout, one line of JSON), so a new launcher
inherits both facts from one pattern instead of two.

**The deriver never fails; the consumer does.** Two of the eleven launchers
have no `.git` *by construction*, and both are RELEASE builds:
`infra/packaging/aur/PKGBUILD` builds from the tag tarball (`release.yml`
asserts it) and `Dockerfile.release` has `.git` in `.dockerignore`. A throw
there would break exactly the two builds that ship. `vite.config.ts` carries
the noise instead — it refuses to build when `GRAPPA_CREDITS` is **unset** (a
wrapper forgot to plumb it) or is not valid JSON. Unset is a mistake;
empty-but-declared is a fact. A deriver that threw would collapse the two into
one red in the substrate where the fact is normal.

The version is deliberately **not** in the payload: it already arrives through
`<meta name="cicchetto-version">` (#292) and the modal reads it from
`bundleHash`. A second carrier is the drift #538 closed.

## ⚠️ Out of the issue's mandate — declared, per the orchestrator's order

**`b0140471` moves `MatrixRain` from `src/admin/` to `src/`.** The issue did
not ask for it. It is reuse instead of duplication: the component already
existed, with exactly ONE consumer (`AdminDebugTab`), already correct on
`prefers-reduced-motion`, rAF cleanup, canvas sizing and pointer-events —
writing a second rain for the credits would have been a copy-paste with tweaks.
It has its own commit and its own regression proof
(`src/__tests__/AdminDebugTab.test.tsx`, which the tab did not previously have).
Revert that commit and the modal loses its background; nothing else moves.

## Other decisions worth a reviewer's eye

- **The soundtrack is synthesised, with zero assets.** "Something epic" points
  at Star Wars and Super Mario; both are under copyright, and grappa ships a
  public PWA and a `.deb`. A WebAudio minor arpeggio over a drone costs no
  bytes in the tree. The `AudioContext` is handed in and `stop()` CLOSES it —
  an easter egg leaving a live audio graph behind a closed modal is a battery
  bug. Muteable; the mute survives a reopen but is deliberately not persisted.
- **The modal mounts in `Shell`, not in the drawer that opens it.**
  `.settings-drawer` animates on `transform`, and a transformed ancestor is the
  containing block for every `position: fixed` descendant — rendered inside, a
  full-screen modal is clipped to the drawer. `ShareSessionModal` already lives
  in Shell for that reason.
- **The entry is not a `.settings-nav-row`.** A nav row wears a chevron
  promising a sub-page push; this opens a modal, so it wears the share entry's
  shape.
- **`release_latest_gate_test.bats` fired, as designed.** Its
  `grep -c '^COPY.*infra/packaging/'` literal went 2 → 3 when `credits.sh`
  joined `Dockerfile.release`. Reviewed and bumped in the same commit that
  added the COPY (`42122fbc`); the literal stays a literal, because deriving
  the count would make it pass by construction.
- **Three new safe-area consumers were added to the #1751 census by hand**,
  which is that list's whole point. One of them had a `, 0px` fallback the
  sheet's convention forbids; removed before transcribing.

## Gates

Measured locally, with the rc read from the log the command wrote — not from a
task notification.

| gate | result | tree |
|---|---|---|
| `scripts/bun.sh run check` | **rc=0**, 5 stages | post-rebase (`4c9270c5`) |
| `scripts/bun.sh run test` | **rc=0**, 322 files / 6336 tests | post-rebase (`4c9270c5`) |
| `scripts/design-notes-gate.sh` | **rc=0**, `1 new entry heading(s), separator and marker present` | post-rebase |
| `scripts/union-rebase.sh` | **rc=0**, `+130 -0 — contribution intact` | the rebase itself |
| `scripts/bats.sh` (full) | **rc=0**, 700/700 | **pre-rebase** (`ad38368b`) |

DESIGN_NOTES integrity was checked beyond the numstat: the preceding entry
(#1772, origin/main's last) is byte-identical to `origin/main`'s copy after the
rebase, and the boundary shape on the real file reads marker / blank / `---` /
blank / `## `.

## What I did NOT establish

- **The e2e never ran.** `issue1773-credits-roll-bakes-git-facts.spec.ts`
  exists and typechecks; it was never invoked, because the STACK lane belonged
  to another worker throughout. This matters more than usual: `vitest.config.ts`
  is a separate config with no `define`, so `__GRAPPA_CREDITS_JSON__` does not
  exist under vitest and **every unit test exercises the DEGRADED path by
  construction**. If the define, the compose plumbing or the wrapper broke, the
  whole unit suite would stay green while the modal rolled an empty list. The
  spec compares what the modal PAINTS against `process.env.GRAPPA_CREDITS`
  rather than a shape, for exactly that reason — but an unrun spec proves
  nothing.
- **Neither no-git substrate was built.** That `credits.sh` degrades rather
  than throwing is proven by bats against a synthetic repo-less tree, not by an
  actual AUR or release-image build.
- **`"Your Name"` has 89 commits in the real history**, and will be PAINTED in
  the production roll. `git shortlog` here reports 13 contributors (544 bytes,
  0.4 s) and one of them is an unconfigured git identity. The cure is a
  `.mailmap`, which `git shortlog` honours for free — but that is a decision
  about the repository's content and it is vjt's, so I left it open.
- **`scripts/bats.sh` full was measured PRE-rebase.** Main moved 3 commits
  under me; the overlap with my branch is `default.css` and `DESIGN_NOTES.md`
  only, and the post-rebase vitest (which reads `default.css` for the safe-area
  census) is green. CI covers the rebased tree.
- **Nothing about the felt result on a device.** No notched phone, no
  reduced-motion preference, no audio, outside jsdom and source-level
  assertions.
- **`scripts/shellcheck.sh` and `scripts/posix-parse.sh` were not run.**
  `infra/packaging/credits.sh` enters both derived sets automatically via its
  `#!/bin/sh` shebang. I did not know whether the orchestrator classes their
  oneshot `docker run` as a docker gate, and did not self-serve.
- **One new BW02 warning.** My line 386 adds a tenth `run --separate-stderr` to
  `test/infra/cic_version_export_test.bats`, which lacks
  `bats_require_minimum_version 1.5.0`. Nine were already there; the run is
  rc=0. Left alone rather than changing a pre-existing condition mid-issue.
