### PR TITLE
fix(#1786): anchor a watchlist term on its own edge, so punctuation can match

### DIFF
--- a/cicchetto/src/__tests__/mentionMatch.test.ts
+++ b/cicchetto/src/__tests__/mentionMatch.test.ts
@@ -60,6 +60,62 @@ describe("matchesWatchlist — own nick ∪ custom highlight patterns (#370)", (
   });
 });
 
+// #1786 — a term whose own edge is punctuation could never match, because both
+// ports wrapped every term in `\b…\b` unconditionally.
+//
+// `\b` is a TRANSITION between a word char and a non-word one. On `QUACK!` the
+// trailing `\b` therefore demands a word character immediately AFTER the `!`,
+// which end-of-line and a space both fail — so the term was inert. Found in
+// prod: a whole watchlist of `["QUACK!","flap!","quack!"]`, listed as active by
+// the settings pane and silently matching nothing, forever.
+//
+// The cure makes each anchor conditional on the term's OWN edge: `\b` where the
+// edge character is a word char (it is satisfiable there), a lookaround where
+// it is not. THE TRUTH TABLE BELOW IS SHARED with `test/grappa/mentions_test.exs`
+// — a case added here without its server twin is exactly how the two ports
+// drift, which is the failure `mentionMatch.ts`'s own header exists to prevent.
+describe("matchesWatchlist — a punctuated edge still anchors (#1786)", () => {
+  it("matches a term ending in punctuation, mid-line and at end of body", () => {
+    expect(matchesWatchlist("say QUACK! now", null, ["QUACK!"])).toBe(true);
+    expect(matchesWatchlist("QUACK!", null, ["QUACK!"])).toBe(true);
+  });
+
+  it("matches a term starting in punctuation — a command-prefix highlight", () => {
+    expect(matchesWatchlist("!list please", null, ["!list"])).toBe(true);
+    expect(matchesWatchlist("!list", null, ["!list"])).toBe(true);
+  });
+
+  it("matches a term punctuated at BOTH edges", () => {
+    expect(matchesWatchlist("run (deploy) now", null, ["(deploy)"])).toBe(true);
+  });
+
+  // ── the two discriminating cases ────────────────────────────────────────
+  // Everything above passes just as well if the anchor is DROPPED on a
+  // punctuated edge instead of replaced by a lookaround. These two do not:
+  // they are the only cases that can tell "not glued to a word" from "no rule
+  // at all", and without them the cheap wrong fix ships green.
+  it("does not match a punctuation-led term glued to the end of a word", () => {
+    expect(matchesWatchlist("foo!list", null, ["!list"])).toBe(false);
+  });
+
+  it("does not match a punctuation-tailed term glued to the start of a word", () => {
+    expect(matchesWatchlist("QUACK!x", null, ["QUACK!"])).toBe(false);
+  });
+
+  // ── the rule that must NOT move ─────────────────────────────────────────
+  it("still refuses a substring match on a word-edged term", () => {
+    expect(matchesWatchlist("vjt123 is here", "vjt", [])).toBe(false);
+    expect(matchesWatchlist("QUACKING!", null, ["QUACK!"])).toBe(false);
+  });
+
+  it("still escapes regex metacharacters rather than honouring them", () => {
+    // `5+1` is word-edged at BOTH ends, so both anchors stay `\b` — the
+    // conditional must not disturb the terms that already worked.
+    expect(matchesWatchlist("got 5+1 alerts", "vjt", ["5+1"])).toBe(true);
+    expect(matchesWatchlist("got 555 alerts", "vjt", ["5+1"])).toBe(false);
+  });
+});
+
 // #1674 — the SENDER half of the mention rule. Mirror of
 // `Grappa.Mentions.mentionable_sender?/1`. Keyed on the sender because
 // neither of the alternatives survives: excluding `:notice` silences a

--- a/cicchetto/src/lib/mentionMatch.ts
+++ b/cicchetto/src/lib/mentionMatch.ts
@@ -24,10 +24,35 @@
 
 import { isServerSender, isServicesSender } from "./servicesSender";
 
+// #1786 — the anchor is conditional on the term's OWN edge, and that is a fix
+// rather than a loosening.
+//
+// `\b` is a TRANSITION between a word char and a non-word one, so it is only
+// satisfiable on a side where the term's edge character IS a word char. Wrapped
+// unconditionally, a term like `QUACK!` demanded a word character immediately
+// after the `!` — end-of-line and a space both fail it, so the term could never
+// match anything. Found in prod as a whole watchlist of trailing-`!` terms the
+// settings pane listed as active while they silently matched nothing.
+//
+// The lookarounds say what `\b` was always meant to say on those edges: "not
+// glued to a word". They are NOT the same as dropping the anchor — `!list` must
+// still refuse `foo!list` — which is the pair of cases the test file calls
+// discriminating.
+//
+// The probe is a regex over the RAW term rather than a character-class literal
+// so that it consults the SAME `\w` the anchor will: one definition, no second
+// spelling to drift from it. Mirror of `Grappa.Mentions.build_matchers/1`; a
+// change here lands in both ports together, per this module's header.
+const termAnchors = (term: string): { readonly prefix: string; readonly suffix: string } => ({
+  prefix: /^\w/.test(term) ? "\\b" : "(?<!\\w)",
+  suffix: /\w$/.test(term) ? "\\b" : "(?!\\w)",
+});
+
 const matchesTerm = (body: string | null, term: string | null): boolean => {
   if (!body || !term) return false;
   const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`\\b${escaped}\\b`, "i").test(body);
+  const { prefix, suffix } = termAnchors(term);
+  return new RegExp(`${prefix}${escaped}${suffix}`, "i").test(body);
 };
 
 export const matchesWatchlist = (

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -64557,3 +64557,108 @@ bump for an easter egg, and it puts the work on the compile lane. Declined.
 - **Nothing about the felt result on a device.** No notched phone, no
   reduced-motion setting, no audio, were exercised outside jsdom and source-level
   assertions.
+<!-- entry #1786 -->
+
+---
+
+## 2026-08-26 — #1786: `\b` is a transition, so it cannot anchor a punctuated edge
+
+A watchlist term whose first or last character is not a word character could
+never match. Both ports wrapped every term in `\b…\b` unconditionally —
+`Grappa.Mentions.build_matchers/1` and cic's `matchesTerm` — and `\b` is a
+TRANSITION between a word character and a non-word one. It is therefore
+satisfiable only on a side where the term's own edge character IS a word char.
+On `QUACK!` the trailing anchor demanded a word character immediately AFTER the
+`!`; end-of-line and a space both fail it. On `!list` the leading anchor failed
+the same way, taking every command-prefix highlight with it.
+
+Found in prod: a user's watchlist was `["QUACK!","flap!","quack!", …]`, every
+term trailing a `!`, so the entire list was inert. **What makes it a bug and not
+a regex footnote is the silence** — the settings pane accepted the term, listed
+it as active, and it did nothing forever. No gate, no log line and no UI state
+distinguishes "no message matched this yet" from "this can never match".
+
+### The cure is per-edge, and the lookaround is not the anchor's absence
+
+Each anchor is chosen by the term's own edge: `\b` where the edge character is a
+word char, `(?<!\w)` / `(?!\w)` where it is not. The lookarounds say what `\b`
+was always meant to say there — "not glued to a word" — while the existing rule
+is untouched wherever it was satisfiable: `vjt` still refuses `vjt123`, and a
+both-ends-word-edged term like `5+1` keeps two literal `\b`s.
+
+**Dropping the anchor on a punctuated edge is the cheaper wrong fix, and only
+two cases separate it from this one.** `!list` must still refuse `foo!list`, and
+`QUACK!` must still refuse `QUACK!x`. Measured on the client port: mutating the
+cure to emit `""` instead of the lookaround leaves **18 of 20** cases green and
+kills exactly those two. Every other new case — the punctuated matches, the
+both-edges case, the substring regressions — passes under the wrong cure. Those
+two rows are the whole reason the table is worth adding.
+
+### The edge probe is a regex, not a character class
+
+`prefix_anchor/1` asks `~r/\A\w/u` and cic asks `/^\w/`, both over the RAW term.
+That is deliberate: the probe consults the SAME `\w` the anchor it is choosing
+for will consult, under the same compile options, so there is one definition of
+"word character" and no second spelling to drift from it. A literal
+`[A-Za-z0-9_]` would have been a second spelling.
+
+It is also why **the two ports agree on a non-ASCII edge even though JavaScript's
+`\w` is unconditionally ASCII and Erlang's depends on whether `unicode` implies
+`ucp`**. Each port's probe asks its OWN engine, so each is internally consistent,
+and the two resulting formulations then accept and reject the same bodies. Take
+`café` as the term: where the engine calls `é` a word char the port emits `\b`,
+which needs a non-word char after `é`; where it does not, the port emits
+`(?!\w)`, which needs the same thing. `café ` matches on both, `cafés` on
+neither. The agreement is a property of the construction, not a coincidence to
+re-verify per term.
+
+### One site per port — the class is closed
+
+Grepped rather than assumed: there is exactly ONE `\b`-wrapping regex in each
+port, and no third site. The visual highlight is not one — `.scrollback-mention`
+/ `.scrollback-highlight` are WHOLE-LINE classes driven by the same boolean
+`matchesWatchlist`, not a span-wrapping second regex with its own anchors. Had
+it been a span wrapper it would have needed the same cure and a different one,
+because a lookaround that consumes nothing and a `\W` that consumes a character
+differ the moment match INDICES matter rather than a boolean.
+
+### Both ports in one commit
+
+Deliberate, and against the usual bite-sized instinct: splitting server from
+client would put a state on the branch where the badge cic raises and the OS
+push the server fires disagree, which is the exact divergence the `Mentions`
+moduledoc's mirror contract exists to forbid. The truth table is extended on
+both sides in that same commit for the same reason.
+
+Two stale docs were corrected in passing: the moduledoc stated the blanket
+`\b..\b` as the rule, which the cure makes false, and cited the client mirror as
+`mentionsUser/2` — a function that module does not export. A mirror contract
+whose citation has rotted is a contract nobody can check.
+
+### Not measured
+
+- **No Elixir gate ran.** The server port — the `build_matchers/1` change, the
+  two anchor helpers and the eight new truth-table cases — is UNCOMPILED and
+  UNTESTED here: the COMPILE lane belonged to another worker for the whole of
+  this work, and `mix` on the host is banned. `mix format`-cleanliness was
+  reasoned against `.formatter.exs` (`line_length: 120`, which is why the
+  `Regex.compile!/2` call is one 101-character line and not wrapped) and the
+  regex-sigil-in-a-module-attribute shape was checked against 29 existing
+  precedents in `lib/`, but reasoning is not a green gate and neither Credo nor
+  Dialyzer nor ExUnit has seen this.
+- **The client mutation proof covers the CLIENT port only.** The 18/20 figure
+  above is a vitest measurement. The server truth table is its textual twin and
+  no mutant was run against it.
+- **The lookbehind's runtime floor is argued, not exercised.** `(?<!\w)` is
+  ES2018; cic's declared build target is `es2022` (`vite.config.ts`) and
+  `tsconfig` targets ES2022, so the toolchain admits it four years over. But
+  there is no lookbehind precedent anywhere in cic's source, and nothing here
+  ran on a Safari older than Playwright's bundled WebKit. On an engine without
+  lookbehind `new RegExp` throws, and `matchesTerm` is on the per-message render
+  path.
+- **The zero-width-space cause is out of scope and stays open.** The issue
+  records that the upstream bot injects `U+200B` inside its own trigger word, so
+  `QUACK​!` defeats any literal containing the punctuation regardless of the
+  anchors. Normalising zero-width characters changes what "the body" means for
+  every sink and is a separate decision; nothing here touches it, and a user
+  whose watchlist targets that bot may still see nothing.

--- a/lib/grappa/mentions.ex
+++ b/lib/grappa/mentions.ex
@@ -30,10 +30,20 @@ defmodule Grappa.Mentions do
   ## Watchlist matching rule
 
   A message matches if its body (case-insensitively) contains `own_nick`
-  OR any pattern from `watchlist_patterns` as a whole word
-  (`\\b..\\b` word-boundary). Substring-only matches are excluded: "vjt"
-  must not match "vjt123". Empty `watchlist_patterns` list is valid
-  (only `own_nick` matches are returned).
+  OR any pattern from `watchlist_patterns` as a whole word.
+  Substring-only matches are excluded: "vjt" must not match "vjt123".
+  Empty `watchlist_patterns` list is valid (only `own_nick` matches are
+  returned).
+
+  **The anchor is per-edge, not a blanket `\\b..\\b` (#1786).** `\\b` is a
+  TRANSITION between a word char and a non-word one, so it is satisfiable
+  only on a side where the term's own edge character IS a word char.
+  Wrapped unconditionally — as it was until #1786 — a term like `QUACK!`
+  demanded a word character immediately after the `!`, which end-of-line
+  and a space both fail: the term could never match anything, and nothing
+  told the operator so. `build_matchers/1` therefore picks `\\b` where the
+  edge is a word char and a lookaround (`(?<!\\w)` / `(?!\\w)`) where it is
+  not. That is not a loosening: `!list` still refuses `foo!list`.
 
   ## Return order
 
@@ -54,9 +64,11 @@ defmodule Grappa.Mentions do
   two consumers — same predicate guarantees the badge cic raises in
   the sidebar and the OS push that fires server-side never disagree.
 
-  Mirror of `cicchetto/src/lib/mentionMatch.ts`'s `mentionsUser/2`. A
-  regex tweak (e.g. broader Unicode word-boundary support) MUST land
-  in both ports together.
+  Mirror of `cicchetto/src/lib/mentionMatch.ts`'s `matchesWatchlist`. A
+  regex tweak (e.g. broader Unicode word-boundary support, or #1786's
+  per-edge anchor) MUST land in both ports together, and the truth table
+  is shared between `test/grappa/mentions_test.exs` and that module's
+  `src/__tests__/mentionMatch.test.ts` so a one-sided change is red.
 
   ## `mentionable_sender?/1` — the SENDER half (#1674)
 
@@ -241,6 +253,11 @@ defmodule Grappa.Mentions do
   # Private helpers
   # ---------------------------------------------------------------------------
 
+  # Options every matcher is compiled with. Named so the EDGE PROBES below can
+  # be built from the same list: a probe that disagreed with the anchor it is
+  # choosing for would be worse than no probe at all.
+  @matcher_opts [:caseless, :unicode]
+
   # Build a list of compiled word-boundary regexes, one per term.
   # Empty and duplicate terms are tolerated; `Regex.escape/1` ensures
   # special characters in watchlist patterns (e.g. "+", ".") are treated
@@ -251,8 +268,54 @@ defmodule Grappa.Mentions do
     |> Enum.reject(&(&1 == ""))
     |> Enum.uniq()
     |> Enum.map(fn term ->
-      Regex.compile!("\\b#{Regex.escape(term)}\\b", [:caseless, :unicode])
+      Regex.compile!(prefix_anchor(term) <> Regex.escape(term) <> suffix_anchor(term), @matcher_opts)
     end)
+  end
+
+  # #1786 — the anchor is conditional on the term's OWN edge, and that is a fix
+  # rather than a loosening.
+  #
+  # `\b` is a TRANSITION between a word char and a non-word one, so it is only
+  # satisfiable on a side where the term's edge character IS a word char.
+  # Wrapped unconditionally, a term like `QUACK!` demanded a word character
+  # immediately after the `!` — end-of-line and a space both fail it, so the
+  # term could never match anything. Found in prod as a whole watchlist of
+  # trailing-`!` terms that the settings pane listed as active while they
+  # silently matched nothing, forever.
+  #
+  # The lookarounds say what `\b` was always meant to say on those edges: "not
+  # glued to a word". They are NOT the same as dropping the anchor — `!list`
+  # must still refuse `foo!list`, which is the pair of cases the test file
+  # calls discriminating, and the only pair that separates this cure from the
+  # cheaper wrong one.
+  #
+  # The probe is a regex over the RAW term rather than a character-class
+  # literal so that it consults the SAME `\w` the anchor will, under the same
+  # compile options: one definition, no second spelling to drift from it.
+  #
+  # Mirror of `cicchetto/src/lib/mentionMatch.ts`'s `termAnchors`. JS `\w` is
+  # ASCII-only and unconditionally so, which is why the ports agree on a
+  # non-ASCII edge as well: whichever way each engine classifies `é`, each
+  # port's probe asks its OWN engine, and the two formulations then accept and
+  # reject the same bodies.
+  #
+  # The probes carry `u` and not `i`: `:caseless` cannot change what a `\w`
+  # class accepts, so the `u` modifier IS the whole of the option surface the
+  # probe shares with `@matcher_opts`. Sigils, so they are compiled once with
+  # the module rather than per term — `matchers/2` exists precisely so a caller
+  # with many bodies pays compilation once, and a probe rebuilt per term would
+  # take that back.
+  @word_led ~r/\A\w/u
+  @word_tailed ~r/\w\z/u
+
+  @spec prefix_anchor(String.t()) :: String.t()
+  defp prefix_anchor(term) do
+    if Regex.match?(@word_led, term), do: "\\b", else: "(?<!\\w)"
+  end
+
+  @spec suffix_anchor(String.t()) :: String.t()
+  defp suffix_anchor(term) do
+    if Regex.match?(@word_tailed, term), do: "\\b", else: "(?!\\w)"
   end
 
   # Returns true if body matches ANY compiled pattern.

--- a/test/grappa/mentions_test.exs
+++ b/test/grappa/mentions_test.exs
@@ -429,6 +429,64 @@ defmodule Grappa.MentionsTest do
     end
   end
 
+  # #1786 — a term whose own edge is punctuation could never match, because
+  # `build_matchers/1` wrapped every term in `\b…\b` unconditionally.
+  #
+  # `\b` is a TRANSITION between a word char and a non-word one, so the
+  # trailing anchor on `QUACK!` demanded a word character immediately AFTER
+  # the `!` — end-of-line and a space both fail it. Found in prod: a whole
+  # watchlist of `["QUACK!", "flap!", "quack!"]`, listed as active by the
+  # settings pane and silently matching nothing, forever.
+  #
+  # THE TRUTH TABLE BELOW IS SHARED with
+  # `cicchetto/src/__tests__/mentionMatch.test.ts` — a case added here without
+  # its client twin is exactly how the two ports drift, which is the failure
+  # this module's own moduledoc contract exists to prevent.
+  describe "mentioned?/3 — a punctuated edge still anchors (#1786)" do
+    test "matches a term ending in punctuation, mid-line and at end of body" do
+      assert Mentions.mentioned?("say QUACK! now", "", ["QUACK!"])
+      assert Mentions.mentioned?("QUACK!", "", ["QUACK!"])
+    end
+
+    test "matches a term starting in punctuation — a command-prefix highlight" do
+      assert Mentions.mentioned?("!list please", "", ["!list"])
+      assert Mentions.mentioned?("!list", "", ["!list"])
+    end
+
+    test "matches a term punctuated at BOTH edges" do
+      assert Mentions.mentioned?("run (deploy) now", "", ["(deploy)"])
+    end
+
+    # ── the two discriminating cases ──────────────────────────────────────
+    # Everything above passes just as well if the anchor is DROPPED on a
+    # punctuated edge instead of replaced by a lookaround. These two do not:
+    # they are the only cases that can tell "not glued to a word" from "no
+    # rule at all". Measured on the client twin — mutating the cure to drop
+    # the anchor leaves 18 of 20 cases green and kills exactly these two.
+    test "does not match a punctuation-led term glued to the end of a word" do
+      refute Mentions.mentioned?("foo!list", "", ["!list"])
+    end
+
+    test "does not match a punctuation-tailed term glued to the start of a word" do
+      refute Mentions.mentioned?("QUACK!x", "", ["QUACK!"])
+    end
+
+    # ── the rule that must NOT move ───────────────────────────────────────
+    test "still refuses a substring match on a word-edged term" do
+      refute Mentions.mentioned?("vjt123 is here", "vjt", [])
+      refute Mentions.mentioned?("QUACKING!", "", ["QUACK!"])
+    end
+
+    test "a word-edged term keeps both \\b anchors — the metas case is unmoved" do
+      # `5+1` is word-edged at BOTH ends, so the conditional must leave it
+      # exactly as it was. Duplicated from the patterns block deliberately:
+      # there it guards the escape, here it guards that #1786 did not disturb
+      # the terms that already worked.
+      assert Mentions.mentioned?("got 5+1 alerts", "vjt", ["5+1"])
+      refute Mentions.mentioned?("got 555 alerts", "vjt", ["5+1"])
+    end
+  end
+
   describe "mentioned?/3 — guards + degenerate inputs" do
     test "nil body never matches" do
       refute Mentions.mentioned?(nil, "vjt", ["oncall"])


### PR DESCRIPTION
A watchlist term whose first or last character is not a word character could
**never** match. Both ports wrapped every term in `\b…\b` unconditionally, and
`\b` is a TRANSITION between a word character and a non-word one — so it is
satisfiable only on a side where the term's own edge character IS a word char.

On `QUACK!` the trailing anchor demanded a word character immediately *after*
the `!`; end-of-line and a space both fail it. On `!list` the leading anchor
failed the same way, taking every command-prefix highlight with it.

```
/\bQUACK!\b/i.test("say QUACK! now")  // false
/\b!list\b/i.test("!list")            // false
```

Found in prod: a watchlist of `["QUACK!","flap!","quack!", …]`, every term
trailing a `!`, so the whole list was inert. **What makes this a bug and not a
regex footnote is the silence** — the settings pane accepted each term, listed
it as active, and it did nothing forever. Nothing distinguishes "nothing has
matched yet" from "this can never match".

## The cure

Each anchor is chosen by the term's **own edge**: `\b` where the edge character
is a word char, `(?<!\w)` / `(?!\w)` where it is not. The lookarounds say what
`\b` was always meant to say there — *not glued to a word* — and the existing
rule is untouched wherever it was satisfiable: `vjt` still refuses `vjt123`, and
a both-ends-word-edged term like `5+1` keeps two literal `\b`s.

**Dropping the anchor is the cheaper wrong fix, and exactly two cases separate
it from this one.** Measured on the client port: mutating the cure to emit `""`
instead of the lookaround leaves **18 of 20** cases green and kills only
`foo!list` and `QUACK!x`. Every other new case passes under the wrong cure —
those two rows are what the table is for.

**The edge probe is a regex, not a character class.** `~r/\A\w/u` and `/^\w/`
consult the SAME `\w` the anchor they are choosing for will consult; a literal
`[A-Za-z0-9_]` would have been a second spelling free to drift. It is also why
the ports agree on a non-ASCII edge despite JS `\w` being unconditionally ASCII
and Erlang's depending on `ucp`: each probe asks its own engine, so the two
formulations accept and reject the same bodies by construction.

**One site per port — grepped, not assumed.** The visual highlight is not a
third: `.scrollback-mention` / `.scrollback-highlight` are whole-line classes
driven by the same boolean, not a span-wrapping regex with its own anchors.

## One commit for both ports, deliberately

Splitting server from client would put a state on the branch where the badge cic
raises and the OS push the server fires disagree — the exact divergence
`Grappa.Mentions`'s mirror contract exists to forbid. The shared truth table is
extended on both sides in that same commit for the same reason.

Two stale docs corrected in passing: the moduledoc stated the blanket `\b..\b`
as the rule (now false), and cited the client mirror as `mentionsUser/2`, which
that module does not export.

## Gates

rc read from the log the command wrote, never from a task notification.

| gate | result | tree |
|---|---|---|
| `scripts/bun.sh run check` | **rc=0**, 5 stages | post-rebase (`8343373f`) |
| `scripts/bun.sh run test` | **rc=0**, 322 files / 6343 tests | post-rebase (`8343373f`) |
| `scripts/design-notes-gate.sh` | **rc=0**, `1 new entry heading(s), separator and marker present` | post-rebase |
| `scripts/union-rebase.sh` | **rc=0**, `+105 -0 — contribution intact` | the rebase itself |
| **every Elixir gate** | **NOT RUN** — see below | — |

DESIGN_NOTES checked past the numstat: the preceding entry (#1773,
`origin/main`'s last) is byte-identical to `origin/main`'s copy after the
rebase, and the boundary shape on the real file reads marker / blank / `---` /
blank / `## `.

## 🔴 What I did NOT establish

- **No Elixir gate ran at all.** The server half — `build_matchers/1`, the two
  anchor helpers, the eight new truth-table cases — is **uncompiled and
  untested**. The COMPILE lane belonged to another worker for the whole of this
  work and `mix` on the host is banned. Two things were reasoned rather than
  measured: `mix format` cleanliness (checked against `.formatter.exs`
  `line_length: 120`, which is why the `Regex.compile!/2` call is one
  101-character line and not wrapped), and the regex-sigil-in-a-module-attribute
  shape (checked against 29 existing precedents under `lib/`). Reasoning is not
  a green gate — CI is the first thing that will actually compile this.
- **The mutation proof covers the CLIENT port only.** The 18/20 figure is a
  vitest measurement. The server truth table is its textual twin; no mutant was
  run against it.
- **The lookbehind's runtime floor is argued, not exercised.** `(?<!\w)` is
  ES2018; cic's declared build target is `es2022` (vite) and `tsconfig` targets
  ES2022, so the toolchain admits it four years over. But there is **no
  lookbehind precedent anywhere in cic's source**, and nothing here ran on a
  Safari older than Playwright's bundled WebKit. On an engine without lookbehind
  `new RegExp` throws, and `matchesTerm` sits on the per-message render path.
  If that floor matters, it is a decision worth taking explicitly.
- **The issue's zero-width-space cause is untouched and still open.** The
  upstream bot injects `U+200B` inside its own trigger word, so `QUACK​!`
  defeats any literal containing the punctuation regardless of anchors. The
  issue puts it out of scope and this change respects that — meaning the very
  user whose watchlist reported this bug may still see nothing.
- **Nothing was observed end to end.** No e2e, no running bouncer, no push
  notification: the claim is at the predicate, not at the badge or the OS
  notification that consume it.
