### PR TITLE
#1770: closing an incognito PWA is a /quit, not an hour's wait

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -634,6 +634,24 @@ export async function adminDeleteVisitor(adminToken: string, visitorId: string):
   }
 }
 
+// #1770 — "is this visitor row still there?", read from the admin listing.
+//
+// The oracle is deliberately the ADMIN index and not the visitor's own bearer
+// coming back 401: a revoked-but-present row answers 401 too, so that reading
+// could not tell a deleted row from a merely logged-out one — and "the row is
+// gone" is the whole claim. `GET /admin/visitors` renders
+// `Grappa.Visitors.AdminWire.index_payload/1`, i.e. `{visitors: [...]}`.
+export async function visitorExists(adminToken: string, visitorId: string): Promise<boolean> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/visitors`, {
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.visitorExists: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { visitors: Array<{ id: string }> };
+  return body.visitors.some((v) => v.id === visitorId);
+}
+
 // #574 — reap minted visitors LOUD in test cleanup. The single de-swallowing
 // primitive every spec's teardown must go through instead of the old
 // `adminDeleteVisitor(...).catch(() => {})`.

--- a/cicchetto/e2e/tests/issue363-incognito.spec.ts
+++ b/cicchetto/e2e/tests/issue363-incognito.spec.ts
@@ -7,12 +7,17 @@
 //   - reconcile + linger + reap ......... visitors_test / reaper_test.exs
 //   - [HERE] checkbox visibility in a real DOM (nick vs email)
 //   - [HERE] incognito session disables share-session (server → /me → gate)
+//   - [HERE] #1770: closing the PWA is a /quit — the row is gone at once
 //
 // Copy is deliberately NOT asserted: the checkbox keys off its data-testid,
 // so vjt's final (pending) wording swap can never break this spec.
 
-import { openSettingsDrawer } from "../fixtures/cicchettoPage";
-import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import {
+  bootVisitorContext,
+  openSettingsDrawer,
+  waitForUserTopicReady,
+} from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors, visitorExists } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -80,5 +85,51 @@ test("#363 incognito session disables share-session; a normal visitor keeps it",
     // Reap BOTH visitors — the variadic collects so a failed first delete
     // can't skip the second (see reapVisitors).
     await reapVisitors(admin.token, ghost.id, normal.id);
+  }
+});
+
+// #1770 (item 2 of #363) — the fast path the wiring never got. Before it,
+// `client_closing` only marked the socket hidden and the row lived on until the
+// 1h linger stopped being renewed.
+//
+// 🔴 The close gesture is `page.close({ runBeforeUnload: true })`, and that is a
+// MEASUREMENT, not a preference. On a standalone chromium + webkit bench,
+// `context.close()` delivers NO pagehide report at all (chromium sends only the
+// WebSocket close frame; webkit sends nothing), and `window.close()` likewise —
+// Playwright skips unload handlers unless asked, which a real tab close does
+// not. With `runBeforeUnload` the report lands over the socket at +4 ms
+// (chromium) / +2 ms (webkit), in both engines. A spec written around
+// `ctx.close()` would fail here for a harness reason and send the reader
+// hunting a product bug that is not there.
+//
+// The wait is the real grace, not a guess: `config/dev.exs` sets
+// `:incognito_close_grace_ms` to 2s for this stack (production is 30s — see
+// `Grappa.Visitors.Reaper`), so the poll ceiling below is grace + margin and
+// still well inside Playwright's 30s per-test default.
+test("#1770 closing an incognito PWA is a /quit: the row is gone, no linger wait", async ({
+  browser,
+}) => {
+  const admin = getSeededAdmin();
+  const ghost = await mintVisitor(`quit-${Date.now()}`, true);
+  expect(ghost.subject.incognito).toBe(true);
+
+  const { ctx, page } = await bootVisitorContext(browser, ghost);
+  try {
+    // The report rides the USER channel, so no joined channel means no report:
+    // gate on the subscribe rather than on paint.
+    await waitForUserTopicReady(page, `visitor:${ghost.id}`);
+
+    // Pre-state, asserted rather than assumed — without it a wipe that never
+    // happened and a row that never existed read identically.
+    expect(await visitorExists(admin.token, ghost.id)).toBe(true);
+
+    await page.close({ runBeforeUnload: true });
+
+    await expect.poll(() => visitorExists(admin.token, ghost.id), { timeout: 15_000 }).toBe(false);
+  } finally {
+    await ctx.close();
+    // Idempotent: `adminDeleteVisitor` counts 404 as success, so this is a
+    // no-op on the green path and a real cleanup on every red one.
+    await reapVisitors(admin.token, ghost.id);
   }
 });

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,19 @@
 import Config
 
+# #1770 — shorten the incognito fast-close grace for the dev stack, which is
+# also the stack `scripts/integration.sh` boots (`MIX_ENV: dev` in
+# `cicchetto/e2e/compose.yaml`). Production's 30s is chosen so a RELOAD gets to
+# land its replacement socket before the wipe; an e2e that closes a page and
+# asserts the row is gone would otherwise idle out the whole window inside
+# Playwright's 30s per-test default.
+#
+# The divergence is deliberate and it is named here rather than hidden behind
+# an env var: dev is where you WANT the behaviour to be observable inside one
+# attention span. A developer debugging the reload-protection window itself
+# must read `Grappa.Visitors.Reaper`'s `@default_incognito_grace_ms`, which is
+# the production number and the single source of it.
+config :grappa, :incognito_close_grace_ms, 2_000
+
 config :grappa, Grappa.Repo,
   database: Path.expand("../runtime/grappa_dev.db", __DIR__),
   pool_size: 5,

--- a/config/test.exs
+++ b/config/test.exs
@@ -111,6 +111,14 @@ config :grappa, :start_source_alias_manager, false
 # timeout bump: it REMOVES a nondeterministic writer from the suite.
 config :grappa, :reaper_interval_ms, :timer.hours(24)
 
+# #1770 — the incognito fast close is armed by an explicit `client_closing`
+# cast and never by a tick, so unlike the cadence above a short window here
+# adds NO ambient writer: nothing arms it unless a test does. Production's 30s
+# would only make the two tests that drive the door sleep for half a minute
+# each. Same posture as the interval — the test value is about determinism and
+# runtime, not about what production should do.
+config :grappa, :incognito_close_grace_ms, 50
+
 # UX-6-B1 (2026-05-20): embedded image uploader storage dir for
 # `mix test`. The Reaper child in the application supervisor mkdir_p's
 # this at boot; per-test isolation comes from `start_supervised`-ing

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -64805,3 +64805,109 @@ The spec asserts WIRING: given a resume event a line lands, the settle schedule
 re-samples with no event in play, the hide edge takes none, and the discriminating
 readings share a line. Whether a real iOS resume shifts the content, and by how
 much, is the device leg — which is now, for the first time, capturable.
+<!-- entry #1770 -->
+
+---
+
+## 2026-08-25 — #1770: closing an incognito PWA is a /quit, and the client event alone could never say so
+
+Item 2 of #363 shipped a pipe and never connected its trigger. `client_closing`
+travelled from cic's `pagehide`/`beforeunload` through the user channel into
+`WSPresence`, marked the socket `:hidden`, and stopped. Nothing read
+`visitor.incognito`; nothing called a deletion. So an incognito session survived
+the tab close until the 1h linger stopped being renewed — the FALLBACK doing the
+entire job, with no fast path above it.
+
+### The discriminator is not `event.persisted`, and that is measured
+
+The issue offered two candidate discriminators and left the choice open:
+`event.persisted`, or requiring the socket's real `:DOWN` within a short grace.
+`pagehide` is not a teardown — it also fires on bfcache entry and on the iOS PWA
+freeze, and `documentTeardown.ts` already says so — so something has to tell
+"going away" from "coming back".
+
+A standalone chromium + webkit bench (raw-node WS server, no grappa stack, so it
+consumes no e2e lane) settles it against `persisted`:
+
+| gesture | `pagehide.persisted` | next socket |
+|---|---|---|
+| reload (chromium) | **false** | +3 ms |
+| reload (webkit) | **false** | +2 ms |
+| navigate away (both) | false | new document on back |
+
+A RELOAD fires the byte-identical signal a genuine close fires. Deleting on
+`persisted === false` would wipe a session on F5 — irreversibly, on the one
+gesture users perform without thinking. So the client's report can only ARM; what
+DECIDES is the question the event cannot answer, asked at the far end of a grace:
+does this visitor still have a socket in `WSPresence`? Reload, second device and
+a frozen-but-connected document all land there and all abstain.
+
+### What the bench could NOT establish, and why the control says so
+
+`pageshow.persisted` came back **false** on the back-navigation even for the
+WS-LESS control page. The positive control is therefore EMPTY: bfcache never
+engaged in that harness, so nothing there licenses either "a WebSocket blocks
+bfcache" or "`persisted` discriminates a freeze". That axis is **unmeasured, not
+negative**. The iOS PWA freeze is likewise unmeasured — webkit is not iOS and
+there is no device in the loop. Named here so a future reader does not mistake
+the absence for a result.
+
+One thing the bench did show, and it argues the same way: on webkit, closing the
+context delivered **no report at all** — not over the socket, not by beacon. The
+fast path is best-effort by construction, which is exactly why the linger stays.
+
+### Scope: the fast path may only ACCELERATE the fallback
+
+`Visitors.list_expired/0` excludes registered visitors (`v.id not in
+subquery(registered_ids_subquery())`), so the 1h linger — the authoritative
+guarantee this issue explicitly leaves untouched — will NEVER collect a
+registered incognito row. A fast path that deleted one would not be an
+acceleration of the fallback; it would be a new destruction with no fallback
+behind it. Hence the anon gate, which makes the fast path's scope byte-equal to
+the sweep's.
+
+That same measurement is why this does NOT route through
+`AccountDeletion.delete_account({:visitor, visitor})`, which #363 named and the
+issue repeated. That door answers `{:error, :forbidden}` for an anon visitor —
+pinned on main by `account_deletion_test.exs:128` — and `incognito` is only ever
+written on the fresh-anon branch of `create_anon/4`, so an incognito visitor is
+anon by construction at birth. The named door would have deleted nothing in
+precisely the case the issue is about. The verb that DOES fit already existed:
+the anon co-terminus quit (stop every attached session, then wipe), which is the
+sweep's own `reap_one/2`, now taking the QUIT reason from its caller so a channel
+peer reads `session closed` rather than the untrue `visitor session expired`.
+
+### Where the clock lives, and why there is no bookkeeping
+
+The grace cannot live in the channel process — that pid dies with the tab, which
+is the event it exists to survive. It lives in `Visitors.Reaper`, the process
+that already owns "delete visitors whose time is up" and already reads
+`WSPresence` for the linger reconcile: the fast close is that same verb on a
+30s clock armed by a client signal instead of a TTL.
+
+No pending-set, deliberately. cic registers BOTH `pagehide` and `beforeunload`,
+so two timers fire per close; the second finds the row gone and answers `:gone`.
+Deduplicating would add a structure whose only job is housekeeping for a case
+idempotency already covers (design discipline (1) and (4)). Every gate is
+re-derived at expiry from the DB and from live presence, never captured at arm
+time — during the grace a row can register, vanish, or come back on a new socket.
+
+### The 30s comes from an asymmetry, not from a distribution
+
+Too short wipes a session its holder is still using, and the wipe is
+irreversible. Too long merely delays a QUIT that would otherwise have waited out
+the full hour. Those costs are not comparable, so the number errs long: 120×
+faster than the linger it accelerates, four orders of magnitude above the 3 ms
+reconnect the bench measured. What has NOT been measured is a real cic reload on
+a cold cache or a slow mobile link — the bundle fetch + boot + auth + connect
+chain — so 30s is chosen from the asymmetry and should be revised by measurement,
+not by taste.
+
+### The verbs, stated once
+
+`Reaper.client_closing/1` arms (a cast; the caller is dying, and a cast to a
+down server is a no-op). `Reaper.close_incognito/1` decides, synchronously, and
+returns what it OBSERVED — `:closed | :gone | :not_incognito | :registered |
+:reconnected | :failed`. Naming the observed STATE rather than the action taken
+is the log-honesty rule applied to a return type: a fast path that reports "did
+nothing" tells an operator nothing about why.

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -423,7 +423,7 @@ defmodule Grappa.Application do
           # anyway — ordering is
           # belt-and-braces. Reaper consumes Grappa.Visitors; the
           # Application boundary has it listed in deps for that reason.
-          {Grappa.Visitors.Reaper, interval_ms: reaper_interval_ms()},
+          {Grappa.Visitors.Reaper, [interval_ms: reaper_interval_ms()] ++ incognito_grace_opt()},
 
           # UX-6-B1 (2026-05-20): embedded image uploader Reaper. Same
           # rationale as Visitors.Reaper for the ordering: after Repo
@@ -556,6 +556,20 @@ defmodule Grappa.Application do
   # boundary only (CLAUDE.md "Application.get_env: boot-time only").
   defp reaper_interval_ms do
     Application.get_env(:grappa, :reaper_interval_ms, 60_000)
+  end
+
+  # #1770 — the incognito fast-close grace, passed ONLY when an env actually
+  # configures one. Deliberately not `get_env(..., 30_000)` like its sibling
+  # above: that shape puts the production default in two files, and the pair
+  # drifts the day one of them moves. The single source is
+  # `Grappa.Visitors.Reaper`'s own `@default_incognito_grace_ms`; this reader
+  # exists so `config/test.exs` can shorten the window without the suite
+  # sleeping 30s per assertion.
+  defp incognito_grace_opt do
+    case Application.fetch_env(:grappa, :incognito_close_grace_ms) do
+      {:ok, ms} -> [incognito_grace_ms: ms]
+      :error -> []
+    end
   end
 
   # #399: the built cicchetto SPA dist root. Configured via

--- a/lib/grappa/visitors/reaper.ex
+++ b/lib/grappa/visitors/reaper.ex
@@ -123,12 +123,25 @@ defmodule Grappa.Visitors.Reaper do
   @type t :: %__MODULE__{interval_ms: pos_integer(), incognito_grace_ms: non_neg_integer()}
 
   @typedoc """
+  What `close_incognito/1` OBSERVED once it has a LIVE incognito row in hand:
+  the row was kept because the identity is persistent (`:registered`) or the
+  holder came back (`:reconnected`), or it was wiped (`:closed`), or the wipe
+  degraded on a saturated DB (`:failed`).
+  """
+  @type live_close_outcome :: :closed | :failed | :reconnected | :registered
+
+  @typedoc """
   What `close_incognito/1` OBSERVED. Every value names a state the fast path
   found, never "what it did" — a skipped fast path that logs the absence of
   work instead of the state it saw is the lie CLAUDE.md's log-honesty rule is
   about.
+
+  Split in two because the row lookup can answer before any policy runs, and
+  Dialyzer is right to insist: the arm that decides on a live row can never
+  return `:gone` or `:not_incognito`, so spelling the whole set on it would be
+  a spec that promises more than the function can do.
   """
-  @type close_outcome :: :closed | :gone | :not_incognito | :registered | :reconnected | :failed
+  @type close_outcome :: :gone | :not_incognito | live_close_outcome()
 
   @spec start_link(opts()) :: GenServer.on_start()
   def start_link(opts) do
@@ -219,7 +232,7 @@ defmodule Grappa.Visitors.Reaper do
     end
   end
 
-  @spec close_live_incognito(Visitors.Visitor.t()) :: close_outcome()
+  @spec close_live_incognito(Visitors.Visitor.t()) :: live_close_outcome()
   defp close_live_incognito(%Visitors.Visitor{id: id} = visitor) do
     cond do
       Credentials.visitor_registered?(id) ->

--- a/lib/grappa/visitors/reaper.ex
+++ b/lib/grappa/visitors/reaper.ex
@@ -36,6 +36,25 @@ defmodule Grappa.Visitors.Reaper do
   sweep logs once at `:info` so operators can grep visitor lifecycle
   across the deletion boundary.
 
+  ## Incognito fast close (#1770 — item 2 of #363)
+
+  Closing the PWA on an incognito session must read as a `/quit`, not as
+  "parked, collected an hour later". `GrappaWeb.GrappaChannel` therefore
+  casts `client_closing/1` here when a VISITOR's browser reports its
+  document is going away, and this server arms a short grace
+  (`:incognito_grace_ms`) before `close_incognito/1` decides.
+
+  It is a fast path over the SAME verb the sweep runs (`reap_one/2`),
+  never a second wipe, and it is scoped to exactly what the sweep would
+  eventually collect: `Visitors.list_expired/0` excludes registered
+  visitors, so a registered incognito row — which the 1h linger would
+  never touch — is kept here too. Widening that would not be an
+  acceleration of the fallback but a new destruction.
+
+  The linger itself is untouched and remains the authoritative guarantee
+  for force-kill, tab crash, and every mobile case where the unload event
+  never fires at all.
+
   ## Boundary
 
   `top_level?: true` — Reaper opts out of `Grappa.Visitors`'s
@@ -67,11 +86,49 @@ defmodule Grappa.Visitors.Reaper do
 
   @default_interval_ms 60_000
 
-  @type opts :: [interval_ms: pos_integer(), name: GenServer.name()]
+  # #1770 — how long the incognito fast close waits before it believes the
+  # browser. Not a debounce, and not an estimate of "how long a close takes":
+  # it is the window in which a RELOAD gets to land its replacement socket.
+  #
+  # Measured on a standalone chromium + webkit bench (2026-08-25): a reload
+  # fires `pagehide` with `persisted === false` — byte-identical to what a
+  # genuine close fires — and the new document's socket is up 2-3 ms later. So
+  # the client's own signal cannot discriminate the two, and this window is
+  # what does: at the far end of it, "does this visitor still have a socket"
+  # answers the question the event could not.
+  #
+  # 30s, not a value fitted to that 3 ms, because the two errors are not
+  # symmetric. Too short wipes a session its holder is still using, and the
+  # wipe is irreversible; too long merely delays a QUIT that would otherwise
+  # have waited out the full 1h linger. A real cic reload is a bundle fetch +
+  # boot + auth + connect, and that has NOT been measured on a cold cache or a
+  # slow mobile link — this number comes from the asymmetry, not from a
+  # distribution.
+  @default_incognito_grace_ms 30_000
 
-  defstruct [:interval_ms]
+  # The upstream QUIT reason per door. Each names what was OBSERVED: the TTL
+  # elapsing and the client going away are different facts, and a channel peer
+  # reads this line.
+  @expired_reason "visitor session expired"
+  @client_closed_reason "session closed"
 
-  @type t :: %__MODULE__{interval_ms: pos_integer()}
+  @type opts :: [
+          interval_ms: pos_integer(),
+          incognito_grace_ms: non_neg_integer(),
+          name: GenServer.name()
+        ]
+
+  defstruct [:interval_ms, :incognito_grace_ms]
+
+  @type t :: %__MODULE__{interval_ms: pos_integer(), incognito_grace_ms: non_neg_integer()}
+
+  @typedoc """
+  What `close_incognito/1` OBSERVED. Every value names a state the fast path
+  found, never "what it did" — a skipped fast path that logs the absence of
+  work instead of the state it saw is the lie CLAUDE.md's log-honesty rule is
+  about.
+  """
+  @type close_outcome :: :closed | :gone | :not_incognito | :registered | :reconnected | :failed
 
   @spec start_link(opts()) :: GenServer.on_start()
   def start_link(opts) do
@@ -94,17 +151,8 @@ defmodule Grappa.Visitors.Reaper do
 
     deleted =
       Enum.reduce(expired, 0, fn v, acc ->
-        # #211 phase 7 — capture the representative (anchor) nick BEFORE the
-        # delete: the identity nick lives per-network on the credentials,
-        # which CASCADE with the visitor row, so it can't be read after.
-        reaped_nick = reaped_nick(v)
-
-        case reap_visitor(v) do
+        case reap_one(v, @expired_reason) do
           :ok ->
-            # M-11: per-row reap event for the admin events stream.
-            # Emitted ONLY on successful delete — a failed delete logs
-            # but doesn't fire a misleading "reaped" signal.
-            :ok = AdminEvents.record(AdminWire.visitor_reaped(v.id, reaped_nick))
             acc + 1
 
           {:error, reason} ->
@@ -118,6 +166,95 @@ defmodule Grappa.Visitors.Reaper do
       end)
 
     {:ok, deleted}
+  end
+
+  @doc """
+  #1770 — arm the incognito fast close for `visitor_id`.
+
+  The browser reported its document is going away (`client_closing` on the
+  user channel). That is a HINT and not a teardown: a reload fires the very
+  same event, with the same `persisted === false`, and lands a replacement
+  socket milliseconds later. So this only starts the grace; what decides is
+  `close_incognito/1` at the far end of it, which requires the visitor to
+  have NO socket left in `Grappa.WSPresence`.
+
+  Fire-and-forget by construction — the channel process calling this is about
+  to die with the tab, and a `GenServer.cast/2` to a Reaper that is not up is
+  a no-op returning `:ok` (the posture `WindowCounts.Pusher.Coalescer` states
+  for the same reason). Arming twice is harmless and expected: cic registers
+  BOTH `pagehide` and `beforeunload`, so two timers fire and the second finds
+  the row already gone (`:gone`). That is why there is no pending-set to keep
+  — deduplicating would add a structure whose only job is housekeeping for a
+  case idempotency already covers.
+  """
+  @spec client_closing(Ecto.UUID.t()) :: :ok
+  def client_closing(visitor_id) when is_binary(visitor_id),
+    do: GenServer.cast(__MODULE__, {:client_closing, visitor_id})
+
+  @doc """
+  #1770 — the incognito fast close, synchronous (the event-driven sibling of
+  `sweep/0`, which is why it is public: the timer calls exactly this).
+
+  Returns what it OBSERVED (`t:close_outcome/0`). It wipes only when all three
+  hold, and each guard closes a case the client event cannot speak to:
+
+    * the row is still there and carries `incognito` — the flag is a
+      fresh-session choice made at provisioning (#363);
+    * it holds NO NickServ credential — the same scope
+      `Visitors.list_expired/0` sweeps, so the fast path accelerates the
+      linger rather than widening it;
+    * no socket for this visitor is left in `Grappa.WSPresence` — the reload
+      and second-device cases both land here, and both must abstain.
+
+  The wipe itself is `reap_one/2`, the sweep's own verb: stop every attached
+  network's `Session.Server` (the `/quit` the contract promises) and then
+  delete the row, whose FK CASCADE takes the dependents.
+  """
+  @spec close_incognito(Ecto.UUID.t()) :: close_outcome()
+  def close_incognito(visitor_id) when is_binary(visitor_id) do
+    case Visitors.get(visitor_id) do
+      nil -> :gone
+      %Visitors.Visitor{incognito: false} -> :not_incognito
+      %Visitors.Visitor{incognito: true} = visitor -> close_live_incognito(visitor)
+    end
+  end
+
+  @spec close_live_incognito(Visitors.Visitor.t()) :: close_outcome()
+  defp close_live_incognito(%Visitors.Visitor{id: id} = visitor) do
+    cond do
+      Credentials.visitor_registered?(id) ->
+        Logger.debug("incognito close: holds a NickServ credential — row kept",
+          visitor_id: id
+        )
+
+        :registered
+
+      WSPresence.ws_count(Subject.label({:visitor, id})) > 0 ->
+        Logger.info("incognito close: a browser socket is still connected — row kept",
+          visitor_id: id
+        )
+
+        :reconnected
+
+      true ->
+        wipe_closed_incognito(visitor)
+    end
+  end
+
+  @spec wipe_closed_incognito(Visitors.Visitor.t()) :: :closed | :failed
+  defp wipe_closed_incognito(%Visitors.Visitor{id: id} = visitor) do
+    case reap_one(visitor, @client_closed_reason) do
+      :ok ->
+        Logger.info("incognito close: no browser socket left — session quit, row wiped",
+          visitor_id: id
+        )
+
+        :closed
+
+      {:error, reason} ->
+        Logger.error("incognito close failed", visitor_id: id, error: inspect(reason))
+        :failed
+    end
   end
 
   # #363 — before enumerating expiries, refresh the linger TTL of every
@@ -152,15 +289,29 @@ defmodule Grappa.Visitors.Reaper do
   defp reaped_nick(%Visitors.Visitor{id: id}),
     do: Credentials.representative_visitor_nick(id)
 
+  # The one teardown-then-wipe verb, shared by the periodic sweep and the
+  # #1770 fast close so the two doors cannot drift: stop every attached
+  # network's session with the reason the CALLER observed, delete the row, and
+  # emit the reap event only once both landed.
+  #
   # #590 — `Visitors.delete/1` can now degrade a sustained SQLITE_BUSY to
-  # `{:error, :db_unavailable}`; the sweep's per-row `{:error, reason}` arm logs
+  # `{:error, :db_unavailable}`; each caller's `{:error, reason}` arm logs
   # + continues (best-effort DROP — the row is left for the next tick), so the
   # reaper rides transient contention rather than crashing.
-  @spec reap_visitor(Visitors.Visitor.t()) :: :ok | {:error, :not_found | :db_unavailable}
-  defp reap_visitor(v) do
-    with :ok <- stop_visitor_session(v),
+  @spec reap_one(Visitors.Visitor.t(), String.t()) ::
+          :ok | {:error, :not_found | :db_unavailable}
+  defp reap_one(v, quit_reason) do
+    # #211 phase 7 — capture the representative (anchor) nick BEFORE the
+    # delete: the identity nick lives per-network on the credentials, which
+    # CASCADE with the visitor row, so it can't be read after.
+    reaped_nick = reaped_nick(v)
+
+    with :ok <- stop_visitor_session(v, quit_reason),
          :ok <- Visitors.delete(v.id) do
-      :ok
+      # M-11: per-row reap event for the admin events stream. Emitted ONLY on
+      # a successful delete — a failed delete logs but doesn't fire a
+      # misleading "reaped" signal.
+      AdminEvents.record(AdminWire.visitor_reaped(v.id, reaped_nick))
     end
   end
 
@@ -169,10 +320,10 @@ defmodule Grappa.Visitors.Reaper do
   # network (`stop_session/3` no-ops without a live pid); empty list (no
   # credentials) → nothing to stop. The retired `visitors.network_slug`
   # scalar only ever resolved the primary session.
-  @spec stop_visitor_session(Visitors.Visitor.t()) :: :ok
-  defp stop_visitor_session(%Visitors.Visitor{id: id}) do
+  @spec stop_visitor_session(Visitors.Visitor.t(), String.t()) :: :ok
+  defp stop_visitor_session(%Visitors.Visitor{id: id}, quit_reason) do
     for %Credential{network_id: network_id} <- Credentials.list_visitor_credentials(id) do
-      :ok = Session.stop_session({:visitor, id}, network_id, "visitor session expired")
+      :ok = Session.stop_session({:visitor, id}, network_id, quit_reason)
     end
 
     :ok
@@ -182,7 +333,21 @@ defmodule Grappa.Visitors.Reaper do
   def init(opts) do
     interval = Keyword.get(opts, :interval_ms, @default_interval_ms)
     schedule_tick(interval)
-    {:ok, %__MODULE__{interval_ms: interval}}
+
+    {:ok,
+     %__MODULE__{
+       interval_ms: interval,
+       incognito_grace_ms: Keyword.get(opts, :incognito_grace_ms, @default_incognito_grace_ms)
+     }}
+  end
+
+  # #1770 — arm, don't act. The grace is read from the state rather than the
+  # attribute so a caller that started this server with its own window (the
+  # test suite does) is not silently overridden by the default.
+  @impl GenServer
+  def handle_cast({:client_closing, visitor_id}, state) do
+    Process.send_after(self(), {:incognito_close, visitor_id}, state.incognito_grace_ms)
+    {:noreply, state}
   end
 
   @impl GenServer
@@ -216,6 +381,17 @@ defmodule Grappa.Visitors.Reaper do
         :ok = AdminEvents.record(AdminWire.reaper_swept(n))
     end
 
+    {:noreply, state}
+  end
+
+  # #1770 — the grace has elapsed; `close_incognito/1` re-derives EVERY gate
+  # from the DB and from live presence rather than trusting anything captured
+  # at arm time. The row may have registered, been deleted, or come back on a
+  # new socket in the meantime, and the authoritative answer is the one taken
+  # here.
+  @impl GenServer
+  def handle_info({:incognito_close, visitor_id}, state) do
+    _ = close_incognito(visitor_id)
     {:noreply, state}
   end
 

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -67,6 +67,10 @@ defmodule GrappaWeb do
         Grappa.Version,
         Grappa.Vhosts,
         Grappa.Visitors,
+        # #1770 — the channel arms the incognito fast close on `client_closing`.
+        # The Reaper is its own `top_level?: true` boundary, so this declares
+        # the leaf that owns the verb rather than widening `Grappa.Visitors`.
+        Grappa.Visitors.Reaper,
         Grappa.Visitors.Visitor,
         Grappa.WindowCounts,
         Grappa.WSPresence,

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -198,6 +198,7 @@ defmodule GrappaWeb.GrappaChannel do
   alias Grappa.ServerSettings
   alias Grappa.ServerSettings.Wire, as: ServerSettingsWire
   alias Grappa.Session.Wire, as: SessionWire
+  alias Grappa.Visitors.Reaper
   alias GrappaWeb.{BodyLimit, Subject}
 
   require Logger
@@ -726,6 +727,7 @@ defmodule GrappaWeb.GrappaChannel do
     # `WSPresence.handle_call({:client_closing, ...}, ...)` no-ops
     # if the pid was never registered).
     :ok = WSPresence.client_closing(user_name, socket.transport_pid)
+    :ok = arm_incognito_close(socket.assigns.current_subject)
 
     {:noreply, socket}
   end
@@ -1528,6 +1530,27 @@ defmodule GrappaWeb.GrappaChannel do
   defp do_handle_in(_, _, socket) do
     {:reply, {:error, %{error: "unknown_event"}}, socket}
   end
+
+  # #1770 (item 2 of #363) — `client_closing` also arms the incognito fast
+  # close for a VISITOR. Closing the PWA on an incognito session is meant to
+  # be a `/quit`; before this it only flipped presence to hidden and the row
+  # survived until the 1h linger elapsed.
+  #
+  # The channel routes and nothing else. Every gate that decides whether
+  # anything is wiped — incognito? anon? any socket left once the grace
+  # elapses? — lives in `Reaper.close_incognito/1`, re-derived there at the
+  # far end of the grace. Routing on the subject KIND is the one fact this
+  # frame holds without a query: `current_subject` is the bare-id tuple, so
+  # reading `incognito` here would cost a DB read on the closing tab's last
+  # breath AND fork the policy across two modules. A non-incognito visitor is
+  # armed too, and abstains there.
+  #
+  # Lives down here rather than beside its caller because the `do_handle_in/3`
+  # clauses must stay contiguous — splitting them is a compiler warning, and
+  # `--warnings-as-errors` makes it a red.
+  @spec arm_incognito_close(Grappa.Subject.t()) :: :ok
+  defp arm_incognito_close({:visitor, visitor_id}), do: Reaper.client_closing(visitor_id)
+  defp arm_incognito_close({:user, _}), do: :ok
 
   # Watchlist add helper — extracted to keep handle_in nesting ≤ 2 levels.
   @spec watchlist_add(Grappa.Subject.t(), String.t(), Phoenix.Socket.t()) ::

--- a/test/grappa/release/live_node_test.exs
+++ b/test/grappa/release/live_node_test.exs
@@ -35,11 +35,13 @@ defmodule Grappa.Release.LiveNodeTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{IRCServer, Networks, Session}
+  alias Grappa.{AdmissionStateHelpers, IRCServer, Networks, Session}
   alias Grappa.Networks.Credentials
   alias Grappa.Release.LiveNode
 
   setup do
+    AdmissionStateHelpers.reset_all()
+
     on_exit(fn ->
       System.delete_env("RELEASE_NODE")
       System.delete_env("RELEASE_DISTRIBUTION")

--- a/test/grappa/visitors/reaper_test.exs
+++ b/test/grappa/visitors/reaper_test.exs
@@ -264,6 +264,47 @@ defmodule Grappa.Visitors.ReaperTest do
       assert :gone = Reaper.close_incognito(Ecto.UUID.generate())
     end
 
+    # The `:failed` arm, and the only one where an unhandled error would take
+    # the Reaper down and the 1h linger with it. It is the #590 sweep twin
+    # ("sustained DB busy → best-effort drop") re-run through the fast door:
+    # the same `reap_one/2` degrades the same way, so the fast path must reach
+    # the same best-effort DROP rather than a crash or a half-wipe.
+    #
+    # The second half is the load-bearing one. `:failed` is only honest if it
+    # leaves the row exactly as the fallback expects to find it — so the test
+    # does not stop at the degraded return, it lifts the fault and shows the
+    # SAME row still collectable. A degrade that stranded the row would pass
+    # the first three assertions and fail here.
+    #
+    # `close_incognito/1` runs in the test process (it is the synchronous verb
+    # the timer calls), so the process-dictionary fault seam reaches
+    # `Visitors.delete/1`'s BusyRetry directly — the property the sweep twin
+    # relies on too.
+    test "sustained DB busy → best-effort drop: FAILED, row kept, and the fallback still collects it" do
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      _ = network_fixture(slug: slug)
+      {:ok, ghost} = Visitors.find_or_provision_anon("saturated", slug, nil, true)
+
+      log =
+        capture_log(fn ->
+          BusyRetry.inject_transient_faults(10_000)
+          assert :failed = Reaper.close_incognito(ghost.id)
+          BusyRetry.inject_transient_faults(0)
+        end)
+
+      # The wipe degraded rather than landing — the row is LEFT for the linger.
+      assert Repo.reload(ghost)
+      # No silent-swallow: the operator sees the fast door's own line, not the
+      # sweep's, and the transient classification that produced it.
+      assert log =~ "incognito close failed"
+      assert log =~ "unavailable"
+
+      # …and the safety net it was left for still works on it, unchanged.
+      expire(ghost)
+      assert {:ok, 1} = Reaper.sweep()
+      refute Repo.reload(ghost)
+    end
+
     test "client_closing/1 arms the grace and the row is gone once it elapses" do
       slug = "azzurra-#{System.unique_integer([:positive])}"
       _ = network_fixture(slug: slug)

--- a/test/grappa/visitors/reaper_test.exs
+++ b/test/grappa/visitors/reaper_test.exs
@@ -16,7 +16,20 @@ defmodule Grappa.Visitors.ReaperTest do
   import ExUnit.CaptureLog
   import Grappa.AuthFixtures, only: [network_fixture: 1, start_visitor_session_for: 2, visitor_with_network: 2]
 
-  alias Grappa.{AdmissionStateHelpers, IRCServer, Push, QueryWindows, ReadCursor, Session, UserSettings, Visitors}
+  alias Grappa.{
+    AdmissionStateHelpers,
+    IRCServer,
+    Push,
+    QueryWindows,
+    ReadCursor,
+    Session,
+    Subject,
+    UserSettings,
+    Visitors,
+    WSPresence
+  }
+
+  alias Grappa.Networks.Credentials
   alias Grappa.Repo.BusyRetry
   alias Grappa.Visitors.{Reaper, Visitor}
 
@@ -185,6 +198,89 @@ defmodule Grappa.Visitors.ReaperTest do
     end
   end
 
+  describe "incognito fast close (#1770)" do
+    test "no socket left → CLOSED: the IRC session quits and the row is gone" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {visitor, network} = visitor_with_network(port, incognito: true)
+      pid = start_visitor_session_for(visitor, network)
+      ref = Process.monitor(pid)
+
+      assert visitor.incognito
+      assert Session.whereis({:visitor, visitor.id}, network.id) == pid
+
+      assert :closed = Reaper.close_incognito(visitor.id)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}
+      assert Session.whereis({:visitor, visitor.id}, network.id) == nil
+      refute Repo.reload(visitor)
+
+      # The user-visible contract is a /quit, and the reason names what was
+      # observed — the client closed, the TTL did not elapse.
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &(&1 == "QUIT :session closed\r\n"), 1_000)
+    end
+
+    test "a socket is still registered → RECONNECTED, the row survives (the reload case)" do
+      # The discriminator this whole slice turns on. Measured in a standalone
+      # chromium/webkit bench: a RELOAD fires `pagehide` with
+      # `persisted === false` — byte-identical to a genuine close — and lands
+      # a NEW socket 2-3ms later. So the client's teardown report can never be
+      # the gate on its own; "is anybody still connected when the grace
+      # elapses" is.
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      _ = network_fixture(slug: slug)
+      {:ok, ghost} = Visitors.find_or_provision_anon("ghost", slug, nil, true)
+      :ok = WSPresence.register(Subject.label({:visitor, ghost.id}), self())
+
+      assert :reconnected = Reaper.close_incognito(ghost.id)
+      assert Repo.reload(ghost)
+    end
+
+    test "a NON-incognito visitor is untouched — the away-only behaviour is correct for it" do
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      _ = network_fixture(slug: slug)
+      {:ok, plain} = Visitors.find_or_provision_anon("plain", slug, nil, false)
+
+      assert :not_incognito = Reaper.close_incognito(plain.id)
+      assert Repo.reload(plain)
+    end
+
+    test "a REGISTERED incognito visitor is untouched — same scope as list_expired/0" do
+      # The fast path may only ACCELERATE the linger, never widen it.
+      # `Visitors.list_expired/0` excludes registered visitors, so the 1h
+      # fallback would never delete this row; deleting it here would not be an
+      # acceleration but a new destruction.
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      network = network_fixture(slug: slug)
+      {:ok, ghost} = Visitors.find_or_provision_anon("identified-ghost", slug, nil, true)
+      {:ok, _} = Visitors.commit_password(ghost.id, network.id, "s3cret")
+      assert Credentials.visitor_registered?(ghost.id)
+
+      assert :registered = Reaper.close_incognito(ghost.id)
+      assert Repo.reload(ghost)
+    end
+
+    test "an unknown id is GONE, not a crash — pagehide and beforeunload both arm" do
+      assert :gone = Reaper.close_incognito(Ecto.UUID.generate())
+    end
+
+    test "client_closing/1 arms the grace and the row is gone once it elapses" do
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      _ = network_fixture(slug: slug)
+      {:ok, ghost} = Visitors.find_or_provision_anon("armed", slug, nil, true)
+
+      # The ambient Reaper is the one the channel casts to; grant it the
+      # shared sandbox connection so its delete lands on this test's DB.
+      Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), Process.whereis(Reaper))
+
+      assert :ok = Reaper.client_closing(ghost.id)
+
+      # Poll, never sleep blind: the grace is config-driven and the assertion
+      # is "it happened", not "it happened at N ms".
+      assert wait_until(fn -> Repo.reload(ghost) == nil end)
+    end
+  end
+
   describe "GenServer tick" do
     test "scheduled tick fires sweep" do
       slug = "azzurra-#{System.unique_integer([:positive])}"
@@ -202,6 +298,28 @@ defmodule Grappa.Visitors.ReaperTest do
       Process.sleep(150)
 
       refute Repo.reload(dead)
+    end
+  end
+
+  # Poll a predicate to a deadline instead of sleeping past a guessed grace.
+  # The grace is config-driven (`:incognito_close_grace_ms`), so a fixed sleep
+  # would either be a flake or a hardcoded twin of the config.
+  defp wait_until(fun) do
+    deadline = System.monotonic_time(:millisecond) + 2_000
+    poll_until(fun, deadline)
+  end
+
+  defp poll_until(fun, deadline) do
+    cond do
+      fun.() ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(10)
+        poll_until(fun, deadline)
     end
   end
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -51,12 +51,15 @@ defmodule GrappaWeb.GrappaChannelTest do
     Repo,
     ScrollbackHelpers,
     Session,
+    Subject,
+    Visitors,
     WSPresence
   }
 
   alias Grappa.Networks.{Credentials, Servers}
   alias Grappa.PubSub.Topic
   alias Grappa.Scrollback.Wire
+  alias Grappa.Visitors.Reaper
   alias Grappa.Visitors.SessionPlan, as: VisitorSessionPlan
   alias GrappaWeb.UserSocket
 
@@ -3655,6 +3658,85 @@ defmodule GrappaWeb.GrappaChannelTest do
 
       assert_reply(ref, :error, %{error: "unknown_event"})
       assert Process.alive?(chan_pid), "channel must survive a wrong-typed known event"
+    end
+  end
+
+  # #1770 (item 2 of #363) — `client_closing` used to terminate in the
+  # auto-away FSM. For an incognito visitor it must also be a `/quit`: the
+  # channel arms the fast close, and the row is gone without waiting out the
+  # 1h linger. The decision itself belongs to `Reaper.close_incognito/1` and is
+  # exercised there; what these two pin is the ROUTING, which is the part that
+  # was missing.
+  describe "client_closing — incognito fast close (#1770)" do
+    setup do
+      :ok = WSPresence.reset_for_test()
+      # The channel casts to the AMBIENT Reaper; grant it this test's shared
+      # sandbox connection so its delete lands on the DB the test can read.
+      Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), Process.whereis(Reaper))
+      :ok
+    end
+
+    test "an incognito visitor's client_closing wipes the row once the grace elapses" do
+      slug = "azzurra-cc-#{System.unique_integer([:positive])}"
+      _ = network_fixture(slug: slug)
+      {:ok, ghost} = Visitors.find_or_provision_anon("ghost", slug, nil, true)
+      visitor_name = Subject.label({:visitor, ghost.id})
+
+      {:ok, _, socket} =
+        visitor_name
+        |> build_socket()
+        |> subscribe_and_join(Topic.user(visitor_name), %{})
+
+      # No transport registered: the state the grace exists to detect is "the
+      # socket is gone", which is where a real close lands before the window
+      # elapses. `WSPresence.client_closing/2` no-ops on an untracked pid, so
+      # the S3.3 leg is unchanged (pinned in ws_presence_test).
+      push(socket, "client_closing", %{})
+
+      assert wait_until(fn -> Repo.reload(ghost) == nil end),
+             "an incognito visitor's row must be wiped on client_closing, not left to the linger"
+    end
+
+    test "a USER's client_closing marks the tab hidden and arms nothing" do
+      user_name = "ch-cc-#{System.unique_integer([:positive])}"
+      _ = user_fixture(name: user_name)
+
+      {:ok, _, socket} =
+        user_name
+        |> build_socket()
+        |> subscribe_and_join(Topic.user(user_name), %{})
+
+      :ok = WSPresence.register(user_name, socket.transport_pid)
+      :ok = WSPresence.set_visibility(user_name, socket.transport_pid, true)
+      assert WSPresence.any_visible?(user_name)
+
+      push(socket, "client_closing", %{})
+
+      # The S3.3 contract is all a user gets — and the channel must not have
+      # tried to route a `{:user, _}` subject into the visitor door.
+      assert wait_until(fn -> not WSPresence.any_visible?(user_name) end)
+      assert Process.alive?(socket.channel_pid)
+    end
+  end
+
+  # Poll to a deadline rather than sleep past the configured grace: a fixed
+  # sleep would either flake or hardcode a twin of `:incognito_close_grace_ms`.
+  defp wait_until(fun) do
+    deadline = System.monotonic_time(:millisecond) + 2_000
+    poll_until(fun, deadline)
+  end
+
+  defp poll_until(fun, deadline) do
+    cond do
+      fun.() ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(10)
+        poll_until(fun, deadline)
     end
   end
 end


### PR DESCRIPTION
Item 2 of #363. Closing the PWA on an incognito session now reads as a
`/quit` instead of "parked, collected an hour later".

## What it does

`client_closing` from a VISITOR socket arms a short grace in
`Grappa.Visitors.Reaper`. When it elapses, `Reaper.close_incognito/1`
decides, and wipes only if all three hold: the row exists and is
`incognito`, it holds no NickServ credential, and `WSPresence` has no
socket left for that visitor. The wipe is `reap_one/2` — the sweep's own
verb, with the caller's reason (`"session closed"` rather than
`"visitor session expired"`). The 1h linger is untouched and remains the
authoritative fallback for force-kill, tab crash, and every mobile case
where the unload event never fires.

## Why the grace exists at all

The client's own event cannot discriminate a close from a reload.
Measured on a standalone chromium + webkit bench: a RELOAD fires
`pagehide` with `persisted === false` — byte-identical to a genuine close
— and lands its replacement socket 2-3 ms later. So `event.persisted` is
excluded as a discriminator, and what decides is the question asked at
the far end of the grace: does this visitor still have a socket?

30s comes from the asymmetry of the two errors, not from a distribution.
Too short wipes a session its holder is still using, irreversibly; too
long merely delays a QUIT that would otherwise have waited out the full
hour.

## Scope, deliberately not widened

`Visitors.list_expired/0` excludes registered visitors, so the 1h linger
would never delete a registered incognito row. Deleting it here would not
be an acceleration of the fallback but a new destruction, so the fast path
abstains. Using `AccountDeletion.delete_account/1` was rejected for the
same reason, and separately because that door answers `{:error,
:forbidden}` to an anon visitor (pinned on main by
`account_deletion_test.exs:128`).

## Not measured, and stated as such

- **bfcache.** The control page (no WebSocket) also returned
  `pageshow.persisted === false`, so bfcache never engaged in the
  harness. The axis is unmeasured, NOT negative.
- **iOS PWA freeze.** webkit is not iOS and no device was available.
- **A real cic reload on a cold cache or a slow mobile link.**

## Gates

| gate | result |
|---|---|
| `scripts/check.sh` | rc=0 — 6904 tests / 0 failures, Dialyzer `Total errors: 0`, 692 bats ok / 0 not ok |
| `scripts/integration.sh` (FULL suite) | rc=0 — **784 passed, 0 failed** |
| `scripts/bun.sh run check` | rc=0 — 5 stages, 0 failed |
| `scripts/bun.sh run test` | rc=0 — 317 files, 6310 tests |
| `scripts/union-rebase.sh` | rc=0 — `+106 -0`, contribution intact both directions |

The e2e spec ran green on its first ever execution:
`#1770 closing an incognito PWA is a /quit: the row is gone, no linger wait`.

The e2e close gesture is `page.close({ runBeforeUnload: true })`, measured:
on `ctx.close()` no `pagehide` fires at all (chromium sends only the close
frame, webkit nothing), and `window.close()` behaves the same. A spec
written on `ctx.close()` would have been red for a harness reason.

**Gate provenance.** The full-suite green was taken at `605b8d9a`; the
branch was then rebased onto `8343373f` (main gained #1773 and #1786
while the gate ran). Those commits touch none of this slice's files, and
the slice's own tests were re-run green on the rebased tree (177 tests, 0
failures). CI on this PR is the gate for the rebased code.

Three earlier full-suite runs each produced 1-2 red specs, never the same
ones, all timeouts, all iso-green on repetition on both the branch and the
base. The discriminator was provisioning latency under concurrent gates:
`seed_ms` reached 10421-13609 in those runs against 159-277 at rest. The
decisive run above was taken with the host quiesced.

## Also carried here: a pre-existing test-isolation fix

`Grappa.Release.LiveNodeTest` reads `Grappa.Admission.NetworkCircuit` through
`SpawnOrchestrator` but did not reset it in `setup`, unlike the fifteen sibling
files that exercise spawn/admission. The file is byte-identical to main and this
branch touches neither the circuit nor its only writer; what the branch changes is
rowid allocation, and so the probability of the existing defect surfacing. Cured
here in its own commit rather than left to land on an unrelated branch next.
