### PR TITLE
#1791: give the diag panel the resume seam it never had

### DIFF
--- a/cicchetto/src/DiagFloat.tsx
+++ b/cicchetto/src/DiagFloat.tsx
@@ -1,5 +1,6 @@
 import { type Component, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { diagLog } from "./lib/diagLog";
+import { SETTLE_REREAD_DELAYS_MS } from "./lib/viewportHeight";
 
 // UX-6 bucket D6 (2026-05-21) — floating diag overlay for on-device
 // debugging of iOS PWA layout-viewport shift. The pre-existing diag
@@ -143,6 +144,45 @@ const DiagFloat: Component = () => {
     // apart in the log.
     const onTouchStart = () => snap("touch.start");
     const onTouchEnd = () => snap("touch.end");
+    // #1791 (2026-08-26) — the resume seam. Everything above watches what a
+    // FOREGROUND app emits. An app-switch RETURN reliably emits none of it:
+    // that absence is the whole premise of #649's three resume triggers on the
+    // var writer, and it left the one instrument aimed at this surface unable
+    // to produce a single line for the event class #1791 is reported on. An
+    // absent line then reads as "nothing happened" when it means "nothing was
+    // watching" — the same trap `lib/resumeProbe.ts` declares about itself.
+    //
+    // Same three events, same reason, same source as the writer's: an installed
+    // PWA coming back from an app-switch reports `visibilitychange`, a bfcache
+    // restore reports `pageshow`, and a same-visibility focus return reports
+    // only `focus`. This is a READER of those events; the writer stays the sole
+    // writer of the vars.
+    const settleTimers: ReturnType<typeof setTimeout>[] = [];
+    // The corrective geometry arrives with NO event to announce it (#285
+    // reopen, #649) — so an event-driven-only instrument is blind by
+    // construction on exactly the settle it needs to see. Re-sample on the
+    // writer's own schedule, which is why that constant is imported rather
+    // than restated: the panel and the vars must agree on when "settled" is.
+    const resume = (tag: string): void => {
+      snap(tag);
+      for (const ms of SETTLE_REREAD_DELAYS_MS) {
+        settleTimers.push(setTimeout(() => snap(`${tag}+${ms}ms`), ms));
+      }
+    };
+    const onVisibility = () => {
+      // Both edges, unlike the writer — which GATES on visible because it must
+      // not write a hidden geometry. Dropping the hide edge would lose the
+      // bracket that records the last foreground geometry (the keyboard-open
+      // value #649 says gets frozen) and how long the app was away. Nothing
+      // settles while hidden, so the hide edge takes no re-read schedule.
+      if (document.visibilityState !== "visible") {
+        snap("resume:hidden");
+        return;
+      }
+      resume("resume:visible");
+    };
+    const onPageShow = () => resume("resume:pageshow");
+    const onWinFocus = () => resume("resume:focus");
     window.addEventListener("resize", onResize);
     window.addEventListener("scroll", onWinScroll);
     window.visualViewport?.addEventListener("resize", onVvResize);
@@ -151,6 +191,9 @@ const DiagFloat: Component = () => {
     document.addEventListener("focusout", onFocusOut);
     document.addEventListener("touchstart", onTouchStart, { passive: true });
     document.addEventListener("touchend", onTouchEnd, { passive: true });
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("pageshow", onPageShow);
+    window.addEventListener("focus", onWinFocus);
     onCleanup(() => {
       window.removeEventListener("resize", onResize);
       window.removeEventListener("scroll", onWinScroll);
@@ -160,6 +203,13 @@ const DiagFloat: Component = () => {
       document.removeEventListener("focusout", onFocusOut);
       document.removeEventListener("touchstart", onTouchStart);
       document.removeEventListener("touchend", onTouchEnd);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("pageshow", onPageShow);
+      window.removeEventListener("focus", onWinFocus);
+      // A settle re-read outliving the unmount would `snap()` into a disposed
+      // signal — the resume schedule runs up to 900ms past its trigger, which
+      // is long enough for a real unmount to land inside it.
+      for (const id of settleTimers) clearTimeout(id);
     });
   });
 
@@ -190,12 +240,23 @@ const DiagFloat: Component = () => {
         <div class="diag-float-log" data-testid="diag-float-swipe">
           <For each={diagLog()}>{(line) => <div>{line}</div>}</For>
         </div>
-        <div class="diag-float-log">
+        {/* #1791 — `--vh` per LINE, not only in the live headline above. The
+            report cannot tell "vars stuck at the full viewport" from "vars
+            correct, content scrolled": both paint the identical picture, and
+            the var beside `wy` on one line is what separates them. It was
+            captured all along and rendered only live, which by the time a
+            screenshot is taken has already moved on. The sibling
+            `--viewport-height` is deliberately NOT added: one writer sets both
+            in one call, so a second reading would be a duplicate, not a
+            check. */}
+        <div class="diag-float-log" data-testid="diag-float-geometry">
           <For each={log()}>
             {(s) => (
               <div>
                 {s.t}ms {s.ev}
                 {s.tgt ? `[${s.tgt}]` : ""} vvH={s.vvH} vvOT={s.vvOT} wy={s.winY} dseT={s.dseT}
+                {" --vh="}
+                {s.cssOT}
                 {" | "}html=
                 <strong>{s.posHtml}</strong>
                 {s.htmlSH}/{s.htmlCH} body={s.posBody}

--- a/cicchetto/src/__tests__/DiagFloat.test.tsx
+++ b/cicchetto/src/__tests__/DiagFloat.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DiagFloat, { DIAG_FLAG_KEY } from "../DiagFloat";
+import { SETTLE_REREAD_DELAYS_MS } from "../lib/viewportHeight";
+
+// #1791 — the resume seam on the instrument.
+//
+// DiagFloat (UX-6 D6) is the ONE instrument built for the iOS PWA
+// layout-viewport shift, and until this change it listened only to what a
+// FOREGROUND app emits: `resize`, `scroll`, `focusin`/`focusout`, touch. An
+// app-switch RETURN reliably emits none of those — that absence is the entire
+// premise of #649's three resume triggers on the var writer — so the panel has
+// never produced a single line for the event class #1791 is reported on.
+//
+// What these tests prove: the WIRING. Given a resume event, a line lands, and
+// it carries the two readings that discriminate the rival explanations of the
+// report (`--vh`, the var, and `wy`, the window scroll offset).
+//
+// What they do NOT prove, deliberately (#654's rule — "a green spec that
+// cannot observe the behaviour is worse than no spec"): anything about iOS.
+// jsdom has no visual viewport, no soft keyboard and no WKWebView
+// UIScrollView. Whether a real iOS resume shifts the content, and by how much,
+// is vjt's device leg — which is what the panel now exists to capture.
+
+const geometryLines = (): string[] =>
+  Array.from(screen.getByTestId("diag-float-geometry").children).map((el) => el.textContent ?? "");
+
+const setVisibility = (state: DocumentVisibilityState): void => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+describe("DiagFloat — resume triggers (#1791)", () => {
+  beforeEach(() => {
+    localStorage.setItem(DIAG_FLAG_KEY, "1");
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.documentElement.style.removeProperty("--vh");
+    setVisibility("visible");
+  });
+
+  it("logs a line when visibilitychange returns the document to visible", () => {
+    render(() => <DiagFloat />);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(geometryLines().some((line) => line.includes("resume:visible"))).toBe(true);
+  });
+
+  it("logs a line on pageshow (the bfcache / installed-PWA restore)", () => {
+    render(() => <DiagFloat />);
+    window.dispatchEvent(new Event("pageshow"));
+    expect(geometryLines().some((line) => line.includes("resume:pageshow"))).toBe(true);
+  });
+
+  it("logs a line on window focus (another app dismissed over the top)", () => {
+    render(() => <DiagFloat />);
+    window.dispatchEvent(new Event("focus"));
+    expect(geometryLines().some((line) => line.includes("resume:focus"))).toBe(true);
+  });
+
+  // The hide edge is kept — unlike the var WRITER, which gates on
+  // `visibilityState === "visible"` because it must not write a hidden
+  // geometry. An instrument that drops the hide edge loses the bracket that
+  // says what the last foreground geometry was and how long the app was away.
+  it("logs the hide edge too, as the bracket for the resume that follows", () => {
+    render(() => <DiagFloat />);
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(geometryLines().some((line) => line.includes("resume:hidden"))).toBe(true);
+  });
+
+  it("re-samples on the writer's settle schedule, with no further event", () => {
+    vi.useFakeTimers();
+    render(() => <DiagFloat />);
+    window.dispatchEvent(new Event("pageshow"));
+
+    // Nothing but the immediate line yet.
+    expect(geometryLines().filter((line) => line.includes("resume:pageshow+"))).toHaveLength(0);
+
+    // Import the schedule rather than restating it: the instrument must sample
+    // at the instants the single var writer settles at, or the two disagree
+    // about when "settled" is and a reader correlating them gets a false story.
+    vi.advanceTimersByTime(Math.max(...SETTLE_REREAD_DELAYS_MS));
+    const settled = geometryLines().filter((line) => line.includes("resume:pageshow+"));
+    expect(settled).toHaveLength(SETTLE_REREAD_DELAYS_MS.length);
+    for (const ms of SETTLE_REREAD_DELAYS_MS) {
+      expect(settled.some((line) => line.includes(`resume:pageshow+${ms}ms`))).toBe(true);
+    }
+  });
+
+  it("schedules no settle re-reads on the hide edge (nothing settles while hidden)", () => {
+    vi.useFakeTimers();
+    render(() => <DiagFloat />);
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(Math.max(...SETTLE_REREAD_DELAYS_MS));
+    expect(geometryLines().filter((line) => line.includes("resume:hidden+"))).toHaveLength(0);
+  });
+
+  // The report this issue carries cannot tell "vars stuck at the full viewport"
+  // from "vars correct, content scrolled" — both paint the identical picture.
+  // `--vh` and `wy` on the SAME line are what separates them, and `--vh` was
+  // captured but rendered only in the live headline, which by screenshot time
+  // has already moved on.
+  it("carries the var and the scroll offset on the logged line", () => {
+    document.documentElement.style.setProperty("--vh", "4.81px");
+    render(() => <DiagFloat />);
+    window.dispatchEvent(new Event("pageshow"));
+    const line = geometryLines().find((l) => l.includes("resume:pageshow"));
+    expect(line).toContain("--vh=4.81px");
+    expect(line).toContain("wy=");
+  });
+});

--- a/cicchetto/src/lib/viewportHeight.ts
+++ b/cicchetto/src/lib/viewportHeight.ts
@@ -101,7 +101,14 @@ const VH_VAR = "--vh";
 // re-read reads the LIVE `vv.height`, so overlapping a genuine keyboard-open
 // resize just writes the current correct value (never a stale clobber).
 // Brackets a fast, medium, and slow settle.
-const SETTLE_REREAD_DELAYS_MS = [100, 400, 900];
+//
+// Exported since #1791 for the INSTRUMENT, not for a second writer. `DiagFloat`
+// samples the live geometry on a resume, and it must sample at the instants
+// this writer settles at: sampling on a schedule of its own would make the
+// panel and the vars disagree about when "settled" is, and a reader correlating
+// the two would get a false story. Anything that writes either var still goes
+// through `writeViewport` and nowhere else.
+export const SETTLE_REREAD_DELAYS_MS = [100, 400, 900];
 
 // THE single writer of both CSS vars. Every trigger — boot, resize, and
 // each #649 resume trigger — reaches the vars through here and nowhere

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -64662,3 +64662,146 @@ whose citation has rotted is a contract nobody can check.
   anchors. Normalising zero-width characters changes what "the body" means for
   every sink and is a separate decision; nothing here touches it, and a user
   whose watchlist targets that bot may still see nothing.
+<!-- entry #1791 -->
+
+---
+
+## 2026-08-26 — #1791: the instrument could not see the event class the bug happens on
+
+An installed iOS PWA reopened after an app-switch comes back with the keyboard
+up and the message buffer pushed off the visible viewport, and it does not
+recover on its own. This entry ships no cure. It ships the reason there is no
+cure yet, and the change that makes one earnable.
+
+### The 126 px are CALCULATED, and deliberately NOT explained
+
+The report carries a pixel scan of a 1206x2622 screenshot: content 0–390, empty
+390–1443, keyboard+accessory 1443–2622, and the observation that the empty band
+is 126 device px SHORTER than the keyboard area — which rules out "the keyboard
+height applied one frame late".
+
+Those are device pixels on a 3x display, so the CSS numbers are 130 / 351 / 393
+against a 481 px visible viewport inside an 874 px layout viewport, and the
+shortfall is **42.0 CSS px exactly** — a round number, not a rounding artefact.
+
+It is not explained here. There is a candidate decomposition — the displacement
+is an auto-scroll-to-reveal, which has no reason to equal the keyboard height,
+and the remainder is about one accessory bar, 44 CSS px on stock iOS, close to
+42 but not equal — and it stays a candidate: the accessory bar on the reporting
+device was never measured. Naming a near-miss as a cause is how a surface with
+eight prior iterations earns a ninth.
+
+### The screenshot cannot distinguish the two explanations, including the one in the title
+
+The report's own title says the resume "restores the keyboard but not the
+viewport vars". The measurement it carries does not establish that. The
+screenshot pins exactly two facts: the visible viewport is 481 CSS px, and the
+BOTTOM edge of the body sits at screen y=130. It never sees the TOP edge. So:
+
+* model A — body is 874 (vars stale at the full viewport), displacement 744;
+* model B — body is 481 (vars correct), displacement 351.
+
+Both paint the identical picture. The 126 px do not discriminate them either.
+
+### Structurally, a vars-only cure cannot work
+
+`html.is-ios { position: fixed; inset: 0 }` sizes `html` against the initial
+containing block — the layout viewport, 874, which iOS does not shrink for the
+keyboard. `--vh` is written from `vv.height`, which never exceeds the layout
+viewport, so `body { height: calc(var(--vh) * 100) }` is bounded by `html` and
+the body can never overflow it. **A document scroll is therefore impossible on
+this path**, and the 351 px band is not one: it is below the document, at the
+WKWebView UIScrollView layer — exactly what UX-6 D10 already measured on device
+(`window.scrollY=324, vvOT=324` despite `position: fixed`) and why
+`installSmartScrollPin` exists at all.
+
+So more triggers on the var writer — the fix the issue proposes — cannot move
+the content back down, because the content's position is not decided by the
+vars. They may ALSO be stale; that would be a second, independent defect.
+
+Caveat kept rather than buried: `maximum-scale=1, user-scalable=no` should
+exclude page pinch, but iOS ignores those knobs for accessibility zoom, and
+under zoom-out `vv.height` could exceed 874 and the bound above would fail.
+That is not the reported scenario. The same meta also carries
+`interactive-widget=resizes-content`, which WebKit is not believed to support —
+not verified against a current WebKit here.
+
+### The finding: the one instrument aimed at this surface is blind to resumes
+
+`DiagFloat` (UX-6 D6) exists specifically to read this bug's numbers on device.
+It listened to `resize`, `scroll`, `vv.resize`, `vv.scroll`, `focusin`,
+`focusout`, `touchstart`, `touchend` — everything a FOREGROUND app emits, and
+nothing else. An app-switch RETURN reliably emits none of those; that absence is
+the entire premise of #649's three resume triggers on the var writer.
+
+**#1791 is unexplained because nothing was watching, not because nobody looked.**
+And the blindness points the wrong way: an absent line reads as "nothing
+happened" when it means "nothing was watching" — the trap `lib/resumeProbe.ts`
+already declares about itself.
+
+The change is the same shape as #649's, one layer out: the same three triggers
+(`visibilitychange` → visible, `pageshow`, window `focus`), each re-sampling on
+the writer's own `SETTLE_REREAD_DELAYS_MS`, because on this surface the
+corrective geometry arrives with no event to announce it and a single t=0
+snapshot would miss it. The constant is exported and imported rather than
+restated: the panel and the vars must agree on when "settled" is, or a reader
+correlating them gets a confident false story. `writeViewport` remains the sole
+writer of both vars — this is a reader.
+
+Two smaller decisions inside it. The HIDE edge is logged too, unlike the writer
+which gates on visible: the writer must not write a hidden geometry, but an
+instrument that drops the hide edge loses the bracket recording the last
+foreground geometry (the keyboard-open value #649 says gets frozen) and how long
+the app was away; nothing settles while hidden, so that edge gets no timers.
+And `--vh` now renders per LINE, not only in the live headline — it is precisely
+what separates model A from model B when set beside `wy`, it was captured all
+along, and the headline shows only the live value, which by screenshot time has
+moved. Its sibling `--viewport-height` is deliberately not added: one writer
+sets both in one call, so a second reading is a duplicate, not a check.
+
+### What was refused
+
+**No cure.** The structurally-indicated candidate is real and is written down
+here rather than shipped: `installSmartScrollPin` — the only thing in the
+codebase that corrects a UIScrollView-layer shift — has NO resume trigger. Its
+sole trigger is `scroll`, so if an iOS resume auto-scrolls without emitting one,
+the pin cannot fire. That is the exact twin of the missing `resize` that was
+#649's root cause, in the same module, and #654's own apply rule reads "when a
+variable has exactly one writer, a new failure mode on that variable is a
+missing TRIGGER, not a missing writer".
+
+It is still speculative, and #654 declined code for #209 and #79 on this same
+surface for that reason: "writing speculative code for a symptom you cannot
+observe IS the per-symptom patching the epic exists to forbid." It would also
+add a `scrollTo` to a resume path on a surface with a documented `scrollTo`
+quarantine (WebKit #226689, 1–3 s) — and the report's own "after two scrolls
+it's stuck" is that quarantine. The instrument is what earns the right to it.
+
+**No claim that cic provokes the auto-scroll.** Nothing in `cicchetto/src` calls
+`.focus()` on any resume path; the resume-event consumers are the var writer,
+`socket`, `badge`, `pushResubscribe`, `resumeProbe`, `staleResume`,
+`documentTeardown`, `visibilityHeartbeat`, `subscribe` and `ScrollbackPane`, and
+none of them focuses an element (`subscribe.ts`'s `presencePause.focus` is a
+module method taking a channel key, not a DOM call). `keepKeyboard` PRESERVES
+focus across taps and never restores it. So the refocus at resume is iOS's own,
+and `preventScroll` — our lever against `_zoomToFocusRect` — is not available on
+a path where we never call `focus()`. Any cure here is corrective, not
+preventive.
+
+**A neighbouring inaccuracy, recorded without a fix.** #1067's entry says
+`preventScroll: true` "can now only be forgotten in one place". True of the
+append/focus/caret dance it describes, which is one function. Not true of the
+codebase: `lib/globalPaste.ts` and `lib/pasteRoute.ts` both focus the SAME
+compose textarea without it, and `TopicBar` focuses its topic editor without it.
+None is on a resume path, so none is #1791; they are a sibling class, unmeasured
+here, and widening a claim is not the same as widening the fix.
+
+### What the test does not prove
+
+Nothing about iOS. jsdom has no visual viewport, no soft keyboard and no
+WKWebView UIScrollView, and per #654 this class is not reproducible on desktop
+at all — Playwright's `webkit-iphone-15` does not reproduce real iOS physics.
+The spec asserts WIRING: given a resume event a line lands, the settle schedule
+re-samples with no event in play, the hide edge takes none, and the discriminating
+readings share a line. Whether a real iOS resume shifts the content, and by how
+much, is the device leg — which is now, for the first time, capturable.


### PR DESCRIPTION
Refs #1791.

**This ships no cure.** It ships the reason there is no cure yet, and the change that makes one earnable.

## The finding, which is not in the issue

`DiagFloat` (UX-6 D6) is the ONE instrument built for this surface — "on-device debugging of iOS PWA layout-viewport shift". It listened to `resize`, `scroll`, `vv.resize`, `vv.scroll`, `focusin`, `focusout`, `touchstart`, `touchend`: everything a **foreground** app emits, and nothing else.

An app-switch RETURN reliably emits none of those. That absence is the entire premise of #649's three resume triggers on the var writer.

**So #1791 is unexplained because nothing was watching, not because nobody looked.** And the blindness points the wrong way: an absent line reads as "nothing happened" when it means "nothing was watching" — the trap `lib/resumeProbe.ts` already declares about itself.

## What changed

* **Three resume triggers** on `DiagFloat` — `visibilitychange` → visible, `pageshow`, window `focus`. Same three, same reason, same source as the writer's. This is a **reader** of those events; `writeViewport` stays the sole writer of both vars.
* **Each re-samples on the writer's own settle schedule.** On this surface the corrective geometry arrives with NO event to announce it (#285 reopen, #649), so an event-driven-only instrument is blind by construction on exactly the settle it needs to see. `SETTLE_REREAD_DELAYS_MS` is exported and imported rather than restated: the panel and the vars must agree on when "settled" is, or a reader correlating them gets a confident false story.
* **The hide edge is logged too**, unlike the writer which gates on visible. The writer must not write a hidden geometry; an instrument that drops the hide edge loses the bracket recording the last foreground geometry — the keyboard-open value #649 says gets frozen — and how long the app was away. Nothing settles while hidden, so no timers there.
* **`--vh` renders per LINE**, not only in the live headline. It is precisely what separates the two rival explanations when set beside `wy`; it was captured all along and shown only live, which by screenshot time has moved on. `--viewport-height` is deliberately NOT added: one writer sets both in one call, so a second reading is a duplicate, not a check.

## The measurement, and what it cannot say

The 126 device px are **42.0 CSS px exactly** at 3x — round, so not a rounding artefact — and they stay **unexplained**. The candidate decomposition (an auto-scroll-to-reveal plus roughly an accessory bar) stays a candidate: 44 is not 42, and the bar on the reporting device was never measured.

The screenshot pins the visible viewport (481) and the **bottom** edge of the body (y=130), never the top. So "vars stuck at the full viewport" (displacement 744) and "vars correct, content scrolled" (351) paint the identical picture. That includes the issue's own title, which the measurement it carries does not establish.

**Structurally, a vars-only cure cannot work.** `position: fixed; inset: 0` sizes `html` against the layout viewport (874, which iOS does not shrink for the keyboard); `--vh` comes from `vv.height`, which never exceeds it; so `body ≤ html` and the body can never overflow. A document scroll is impossible on this path. The empty band is at the WKWebView UIScrollView layer — what UX-6 D10 measured on device (`window.scrollY=324, vvOT=324` despite `position: fixed`).

## What was refused

* **The cure.** The structurally-indicated candidate is named in DESIGN_NOTES rather than shipped: `installSmartScrollPin` has no resume trigger either — its sole trigger is `scroll`, the exact twin of the missing `resize` that was #649's root cause, in the same module. Still speculative, and #654 declined code for #209 and #79 on this same surface for that reason. It would also add a `scrollTo` to a resume path on a surface with a documented `scrollTo` quarantine (WebKit #226689) — and the report's own "after two scrolls it's stuck" is that quarantine.
* **That cic provokes the auto-scroll.** Nothing in `cicchetto/src` calls `.focus()` on any resume path (`subscribe.ts`'s `presencePause.focus` takes a `ChannelKey`, not a DOM node; `keepKeyboard` preserves focus and never restores it). So `preventScroll` is not a lever we hold there, and any cure is corrective rather than preventive.
* **A neighbouring inaccuracy**, recorded without a fix: #1067's "`preventScroll: true` can now only be forgotten in one place" is true of the dance it describes and false of the codebase (`globalPaste`, `pasteRoute`, `TopicBar`). None is on a resume path, so none is #1791.

## What the tests do NOT prove

Nothing about iOS. jsdom has no visual viewport, no soft keyboard, no WKWebView UIScrollView, and per #654 this class is not reproducible on desktop at all — Playwright's `webkit-iphone-15` does not reproduce real iOS physics. The spec asserts **wiring** only. **Device-verify is owed; this is not closable on a green.**

## Gates

| gate | result |
|---|---|
| `bun.sh run check` (lock drift, test location, biome, tsc src, tsc e2e) | `rc=0` — 5 stages, 0 failed |
| `bun.sh run test` (full cic suite) | `rc=0` — **323 files, 6350 tests, 0 failed** |
| red-green proof (spec against the pre-fix `DiagFloat`) | **7/7 red**, 7/7 green with |
| `design-notes-gate.sh` | `rc=0` — 1 new entry heading, separator and marker present |

No Elixir file is touched, so the server gates carry no signal here. No e2e: a spec that cannot observe the behaviour would be worse than none.