### PR TITLE
#1797: declare the version watch set instead of discovering it

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -64911,3 +64911,120 @@ returns what it OBSERVED — `:closed | :gone | :not_incognito | :registered |
 :reconnected | :failed`. Naming the observed STATE rather than the action taken
 is the log-honesty rule applied to a return type: a fast path that reports "did
 nothing" tells an operator nothing about why.
+<!-- entry #1797 -->
+
+---
+
+## 2026-08-26 — #1797: the version watch set was DISCOVERED, and git moved the file it was looking for
+
+`/api/config` on the Pi's docker staging answered `protocol_version: 7` — the
+value #1769 had just bumped, so the new code was demonstrably running — next to
+`version: "1.3.1-ead66d40"`, the sha from BEFORE the deploy. Two fields of one
+response, from two builds. Only the wire bump made the two distinguishable at
+all; without a second field to cross against, the honest reading of a stale
+`version` is "the deploy did not land".
+
+`_build/prod/.../Elixir.Grappa.Protocol.beam` carried Aug 25 21:35, `…Version.beam`
+Aug 25 09:44, and `.git/refs/heads/main` 21:34. So prod HAD compiled and
+`Grappa.Version` had NOT — although #533/#542 exists precisely to make a moved
+branch ref recompile it.
+
+### The mechanism, measured
+
+Two clones of one origin, identical but for a single `git pack-refs --all` in the
+clone BEFORE the first compile. Each then compiles a module that registers
+`Grappa.Version.GitProbe.resource_paths/1` (the real production function) as
+`@external_resource` and snapshots `facts/1`, takes a `git pull --ff-only` of an
+upstream commit, and compiles again:
+
+| arm | watch set registered at compile #1 | compile #2 | compiled sha vs HEAD |
+|---|---|---|---|
+| loose | `HEAD`, `refs/heads/main`, `packed-refs` | `Compiling 1 file` | `21bcaa9` == `21bcaa9` |
+| packed | `HEAD`, `packed-refs` | *(nothing)* | `4d10202` != `bf4107d` |
+
+In the packed arm the pull left `HEAD` and `packed-refs` byte-identical — same
+mtime, same md5 — and wrote 41 bytes into `.git/refs/heads/main`, the one file
+that had been filtered out of the watch set for not existing yet. The `.beam`'s
+mtime and md5 did not move. That is the reported symptom, reproduced.
+
+So of the three candidates the issue listed and declined to rank: the SECOND is
+the mechanism — "the paths registered at the previous build differ from the
+current ones, the ref was packed and is now loose". The FIRST (`@repo_root`
+resolving somewhere else in the container) is refuted by the symptom itself: a
+wrong root makes `facts/1` degrade to `-dev`, not to a real previous sha, and
+`Path.expand("../..", __DIR__)` is `/app`, where the bind-mounted `.git` is. The
+THIRD (the compile manifest) is where the second is RECORDED rather than a
+separate cause.
+
+**Only one direction is a defect.** packed→loose is invisible. loose→packed is
+not: the disappearance of a registered file IS seen, so a `git gc` after a
+loose-ref build merely costs one extra recompile.
+
+### Why the filter was the bug, and why a missing path is the fix
+
+#533/#542 named the right three files but resolved them through
+`Enum.filter(&File.exists?/1)`. Git's ref layout is **mutable at runtime**:
+`git gc --auto` — which `git pull` invokes — packs refs and deletes the loose
+one, and the next `update-ref` writes it back. A set conditioned on the current
+layout is therefore a snapshot of a moving target, and the window between a
+`gc` and the next fast-forward is exactly the window in which the version goes
+stale and stays stale, since nothing afterwards dirties the module either.
+
+Registering a path that does not exist is what `Mix.Compilers.Elixir` is built
+for. `process_external_resources/2` stores
+`{Path.relative_to(file, cwd), Mix.Utils.last_modified_and_size(file), digest}`,
+i.e. `{path, {0, 0}, nil}` for a missing file, and `stale_external?/2` reads
+
+    %{^external => {0, 0}} -> digest != nil
+    %{^external => {last_mtime, last_size}} ->
+      size != last_size or (last_mtime > mtime and digest_changed?(external, digest))
+
+so while the file is absent the answer is `nil != nil` — false, no recompile
+loop — and the instant it appears with 41 bytes in it, `size != last_size` is
+true and the module recompiles. Deletion is caught by the same rule in reverse.
+The cure is one deleted pipeline stage: the watch set is now DECLARED, never
+DISCOVERED. Re-run of the same bench with it applied: the packed arm flips to
+`7dcc1af == 7dcc1af`, `Compiling 1 file`.
+
+### Substrate: docker is where it is invisible, not where it lives
+
+The defect is Mix + git, and every substrate does `git pull` then an incremental
+`mix compile`, so none of them is structurally immune. What differs is whether
+anybody checks. The jail, systemd, the `.deb` and the AUR source package all run
+`mix release --overwrite`, and #542's `assert_version_sha` step compares the sha
+compiled into the beam against `HEAD` and raises `{:stale, compiled, head}`. That
+entry's own words — *"if a future `@external_resource` gap re-opens #542 and
+`mix compile` leaves `Version.beam` stale, the step reads that stale sha, sees it
+≠ HEAD, and FAILS the release"* — describe this incident in advance, and the
+belt held everywhere it is worn. The docker stack wears none: hot compiles with
+`mix compile --warnings-as-errors` (`infra/lib/deploy_docker.sh`) and cold lets
+the recreated container's own `mix phx.server` boot compile write the beams. No
+`mix release`, no guard, so the stale sha reaches `/api/config` unchallenged.
+This is read from the deploy code paths, not measured on m42 or systemd.
+
+`dev` was immune by CHANCE, not by reason. Both environments read the same
+`.git` and the mechanism has no environment term; a `_build` is exposed exactly
+when its last `Grappa.Version` compile happened inside a packed window. On this
+worker host today `main` is itself packed, so a dev build here would register
+the same blind set.
+
+### Two things the manifest will not tell you
+
+The compile manifest is ETF-**compressed** (`131 80 …`), so `grep` for a ref path
+in `_build/<env>/lib/<app>/.mix/compile.elixir` answers 0 even when the path IS
+registered — measured on the arm that watched it. It has to be
+`binary_to_term`-decoded, and the traversal must descend MAPS, not only tuples
+and lists, or it silently finds nothing. And the paths inside are stored
+**relative to the compile cwd** (`.git/refs/heads/main`), not absolute.
+
+### What this does not establish
+
+The Pi's own `_build/prod` manifest was not read — the box is not reachable from
+here — so what is proven is that this mechanism produces exactly this symptom,
+not that this incident was an instance of it; the box-side confirmation is one
+decode of that manifest plus `git reflog show main --date=iso` against the
+`packed-refs` mtime. The Mix half (a missing `@external_resource` detected on
+appearance) is measured by the bench and NOT pinned by a committed test: doing so
+costs a scratch project and a real compile inside the suite. The committed
+regression tests pin the grappa-owned half — that the loose ref is in the watch
+set while packed away, and that a commit on a packed branch moves nothing else.

--- a/lib/grappa/version.ex
+++ b/lib/grappa/version.ex
@@ -79,7 +79,10 @@ defmodule Grappa.Version do
   mix release --overwrite`; the jail does NOT wipe `_build`, so the old
   "cold deploy recompiles from scratch" belief was false). The corrected
   watch set — the loose branch ref, plus `HEAD` and `packed-refs` — is
-  resolved by `Grappa.Version.GitProbe.resource_paths/1` (#533 / #542).
+  resolved by `Grappa.Version.GitProbe.resource_paths/1` (#533 / #542) —
+  and registered UNCONDITIONALLY, because naming the loose ref only when
+  git happens to be storing it loosely at compile time re-opened the very
+  same staleness the moment a `git gc` packed it (#1797).
 
   When there was **no `.git` at build** — a package built from a release
   tarball (Arch) — `@git_facts` is `nil` and the reported version is the
@@ -120,9 +123,11 @@ defmodule Grappa.Version do
   # Re-run compilation whenever the build's git ref moves so an incremental
   # build re-snapshots the sha. The watch set is the corrected #533/#542 one
   # (the LOOSE branch ref a same-branch fast-forward rewrites, plus HEAD and
-  # packed-refs) — see `GitProbe.resource_paths/1`. Registering each existing
-  # path as an `@external_resource` is what dirties this module on the next
-  # `mix compile`.
+  # packed-refs) — see `GitProbe.resource_paths/1`. Registering each path as
+  # an `@external_resource` is what dirties this module on the next
+  # `mix compile`, and each is registered whether or not it exists TODAY:
+  # git packs and unpacks refs behind us, so a set filtered by existence
+  # goes blind to the very fast-forward it was written to catch (#1797).
   for path <- GitProbe.resource_paths(@repo_root) do
     @external_resource path
   end

--- a/lib/grappa/version/git_probe.ex
+++ b/lib/grappa/version/git_probe.ex
@@ -36,6 +36,31 @@ defmodule Grappa.Version.GitProbe do
   normal checkout, a packed ref, a detached HEAD, and a `git worktree`
   (where `.git` is a FILE and refs live in a shared common dir) — no
   hand-parsing of `.git` internals.
+
+  ## Why existence is not a filter (#1797)
+
+  Naming the right three files is only half of it: the set used to be
+  `File.exists?`-filtered, and **git's ref layout is mutable at runtime**.
+  `git gc --auto` (which `git pull` runs) packs refs and DELETES the loose
+  one; the next `update-ref` writes it back. So a build taken while the
+  branch is packed registers `HEAD` + `packed-refs` only — and the next
+  `git pull --ff-only` rewrites nothing but the loose ref it never
+  registered. Measured (#1797): two identical clones, one `pack-refs --all`
+  apart, both pulled a fast-forward and recompiled — the loose-ref clone
+  re-snapshotted (`Compiling 1 file`, sha followed HEAD), the packed clone
+  emitted nothing and kept the previous sha, with `HEAD` and `packed-refs`
+  byte-identical across the pull. That is the whole defect: the previous
+  fix (#533/#542) named the file, but only when git happened to be storing
+  it that way at compile time.
+
+  Registering a path that does not exist is not a hack, it is exactly what
+  `Mix.Compilers.Elixir` is built for: `process_external_resources/2`
+  records `{path, Mix.Utils.last_modified_and_size(path), digest}`, which
+  is `{path, {0, 0}, nil}` for a missing file, and `stale_external?/2`
+  answers `digest != nil` (false → not stale, so no recompile loop) while
+  the file is absent, and `size != last_size` (true → stale) the instant it
+  appears with 41 bytes of ref in it. Deletion is caught by the same rule
+  in reverse. So the honest watch set is DECLARED, never DISCOVERED.
   """
 
   # No `use Boundary` — this module belongs to the `Grappa.Version` boundary
@@ -70,9 +95,10 @@ defmodule Grappa.Version.GitProbe do
     * `HEAD` — moves on a branch switch or a checkout to a detached HEAD;
     * `packed-refs` — moves when the ref is stored packed.
 
-  Only paths that exist on disk are returned (callers register each as an
-  `@external_resource`). `[]` when there is no git at build (a release
-  tarball / package) — nothing to watch and nothing to keep fresh.
+  Paths are returned WHETHER OR NOT they exist right now (#1797) — see
+  "Why existence is not a filter" in the moduledoc. `[]` when there is no
+  git at build (a release tarball / package) — nothing to watch and nothing
+  to keep fresh. Callers register each as an `@external_resource`.
   """
   @spec resource_paths(String.t()) :: [String.t()]
   def resource_paths(root) do
@@ -82,7 +108,6 @@ defmodule Grappa.Version.GitProbe do
       |> Enum.map(&git_path(root, &1))
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
-      |> Enum.filter(&File.exists?/1)
     else
       []
     end

--- a/test/grappa/version_git_probe_test.exs
+++ b/test/grappa/version_git_probe_test.exs
@@ -82,14 +82,69 @@ defmodule Grappa.Version.GitProbeTest do
       assert Path.join(dir, ".git/HEAD") in GitProbe.resource_paths(dir)
     end
 
-    test "returns only paths that exist on disk", %{dir: dir} do
+    test "returns a watch-set member that does NOT exist yet — its appearance is the signal (#1797)",
+         %{dir: dir} do
       init_repo!(dir)
-      assert Enum.all?(GitProbe.resource_paths(dir), &File.exists?/1)
+
+      packed_refs = Path.join(dir, ".git/packed-refs")
+      # A fresh `git init` + commit writes no packed-refs file at all; it
+      # appears the first time refs are packed. That is precisely a watch-set
+      # member whose EXISTENCE is the thing that changes.
+      refute File.exists?(packed_refs)
+
+      assert packed_refs in GitProbe.resource_paths(dir),
+             "a not-yet-existing watch path must still be registered: Mix records it as " <>
+               "{0, 0} and reports it stale the moment it appears with a non-zero size"
     end
 
     test "is [] when there is no .git (a release tarball / package)", %{dir: dir} do
       # A fresh dir with no `git init`.
       assert GitProbe.resource_paths(dir) == []
+    end
+  end
+
+  describe "resource_paths/1 — a PACKED branch ref is still watched (#1797)" do
+    test "a commit on a packed branch rewrites ONLY the loose ref — HEAD and packed-refs are byte-identical",
+         %{dir: dir} do
+      init_repo!(dir)
+      git!(dir, ["pack-refs", "--all"])
+
+      head = Path.join(dir, ".git/HEAD")
+      packed_refs = Path.join(dir, ".git/packed-refs")
+      loose_ref = Path.join(dir, ".git/refs/heads/main")
+
+      refute File.exists?(loose_ref), "pack-refs --all removes the loose ref"
+      head_before = File.read!(head)
+      packed_before = File.read!(packed_refs)
+      sha_before = git!(dir, ["rev-parse", "--short", "HEAD"])
+
+      # The production shape: the branch tip advances (a `git pull --ff-only`
+      # of an already-checked-out branch does exactly this write).
+      File.write!(Path.join(dir, "a.txt"), "two\n")
+      git!(dir, ["add", "-A"])
+      git!(dir, ["commit", "-qm", "two"])
+
+      assert git!(dir, ["rev-parse", "--short", "HEAD"]) != sha_before
+      assert File.exists?(loose_ref), "the advanced tip lands in the LOOSE ref"
+
+      assert File.read!(head) == head_before,
+             "HEAD does not move on a same-branch advance — it cannot carry the signal"
+
+      assert File.read!(packed_refs) == packed_before,
+             "packed-refs keeps the STALE tip — it cannot carry the signal either"
+    end
+
+    test "the loose ref is in the watch set even while it is currently packed away", %{dir: dir} do
+      init_repo!(dir)
+      git!(dir, ["pack-refs", "--all"])
+
+      loose_ref = Path.join(dir, ".git/refs/heads/main")
+      refute File.exists?(loose_ref)
+
+      assert loose_ref in GitProbe.resource_paths(dir),
+             "the ref layout is MUTABLE at runtime (`git gc --auto` packs, `update-ref` " <>
+               "unpacks), so a watch set conditioned on the CURRENT layout goes blind: a " <>
+               "build taken while packed never sees the next fast-forward (#1797)"
     end
   end
 


### PR DESCRIPTION
Refs #1797.

## What was not established, and now is

The issue listed three candidate mechanisms and ranked none. Measured:

* **the registered set drifting** is the mechanism. `resource_paths/1`
  filtered the watch set by `File.exists?`, and git's ref layout is
  mutable at runtime — `git gc --auto` (which `git pull` runs) packs refs
  and deletes the loose one, the next `update-ref` writes it back. A build
  taken inside that window registers `HEAD` + `packed-refs` only, and the
  next `git pull --ff-only` rewrites nothing else.
* **`@repo_root` resolving elsewhere** is refuted by the symptom itself: a
  wrong root makes `facts/1` degrade to `-dev`, it cannot produce a real
  PREVIOUS sha. In the container `Path.expand("../..", __DIR__)` is `/app`,
  where the bind-mounted `.git` is.
* **the compile manifest** is where the first is recorded, not a separate
  cause.

## The measurement

Two clones of one origin, identical but for a single `git pack-refs --all`
in the clone before the first compile. Each compiles a module registering
the real `Grappa.Version.GitProbe.resource_paths/1` as `@external_resource`,
takes a `git pull --ff-only` of an upstream commit, and compiles again.

| arm | watch set at compile #1 | compile #2 | compiled sha vs HEAD |
|---|---|---|---|
| loose | HEAD, refs/heads/main, packed-refs | `Compiling 1 file` | `21bcaa9` == `21bcaa9` |
| packed | HEAD, packed-refs | *(nothing)* | `4d10202` != `bf4107d` |

In the packed arm the pull left `HEAD` and `packed-refs` byte-identical —
same mtime, same md5 — and wrote 41 bytes into `.git/refs/heads/main`, the
path the filter had dropped. The `.beam` mtime and md5 did not move. Same
bench with this branch applied: the packed arm reports `7dcc1af == 7dcc1af`.

## The fix

One deleted pipeline stage. Registering an absent path is what Mix is built
for: `process_external_resources/2` stores `{path, {0, 0}, nil}` for it and
`stale_external?/2` answers `digest != nil` (false — no recompile loop)
while it is missing, then `size != last_size` (true — stale) the instant it
appears. Deletion is caught by the same rule in reverse, so a `gc` after a
loose-ref build costs one extra recompile and nothing else.

## The other two axes the issue left open

**Substrate.** The defect is Mix + git and no substrate is structurally
immune. What differs is whether anybody checks: the jail, systemd, the .deb
and the AUR package all assemble with `mix release`, whose #542
`assert_version_sha` step raises `{:stale, compiled, head}` on exactly this
drift — that entry predicted this incident in as many words. The docker
stack runs `mix compile` hot and a boot compile cold, never `mix release`,
so it is the one substrate where the stale sha reaches `/api/config`
unchallenged. Read from the deploy paths; not measured on m42 or systemd.

**`dev` was immune by chance**, not by reason: same `.git`, no environment
term in the mechanism, and a `_build` is exposed exactly when its last
`Grappa.Version` compile fell inside a packed window.

## What this does NOT prove

The Pi's own `_build/prod` manifest was not read — the box is not reachable
from here. What is proven is that this mechanism produces exactly this
symptom, not that this incident was an instance of it. The Mix half (an
absent `@external_resource` seen on appearance) is measured by the bench and
deliberately not pinned by a committed test; the committed tests pin the
grappa-owned half.

## Gates

`format` rc=0 · `credo --strict` rc=0 (no issues) · `sobelow` rc=0 ·
`design-notes-gate` rc=0 · `union-rebase` +117 -0 contribution intact ·
version tests 38/38 rc=0, all re-run after the rebase onto `9c0f4ddf`.
Full suite, dialyzer and integration are left to this PR's CI — the local
lanes are contended.