### PR TITLE
cicchetto/mobile: the left top-band door becomes an ASCII # at the hamburger's ink size (#1801)

### DIFF
--- a/cicchetto/e2e/tests/issue1766-hide-bottom-bar.spec.ts
+++ b/cicchetto/e2e/tests/issue1766-hide-bottom-bar.spec.ts
@@ -138,3 +138,171 @@ test("@webkit mobile: the preference is remembered by the ACCOUNT, not the devic
   await expect(page.locator(BOTTOM_BAR)).toHaveCount(0, { timeout: 15_000 });
   await expect(page.getByLabel(WINDOWS_OPENER)).toBeVisible({ timeout: 10_000 });
 });
+
+// GH #1801 — with the bar off, this spec's end state is the ONLY one where the
+// two openers share a band, which is why the third test lives here rather than
+// beside #305's floor in `ux-5-bt`: that spec runs with the bar ON, so the left
+// door is not mounted and an assertion there would be vacuous.
+//
+// The claim is rendered geometry, so the oracle is PAINTED PIXELS. Nothing
+// cheaper will do, and #1766 paid to learn it twice: `getComputedStyle(el)
+// .fontSize` measures the em box, which is exactly the quantity that overstates
+// a thin glyph, and it reads 0 on a suppressed character; and the ☰'s ink lives
+// in a `::before` + two `box-shadow` copies that no rect API reports at all.
+// One screenshot, both doors measured the same way, is the only comparison that
+// means "the same size".
+//
+// Scanned 4px inside each button so the 1px border is out of frame — a
+// decoration is not ink (and at 48px box vs ~20px glyph there is 14px of
+// clearance a side, so the inset cannot clip what we came to measure). The
+// background is taken as the most frequent colour in the scanned region rather
+// than sampled from a corner, so a theme background image cannot fake ink.
+async function inkOf(
+  page: Parameters<typeof loginAs>[0],
+  selector: string,
+  shot: string,
+): Promise<{ w: number; h: number }> {
+  const ink = await page.evaluate(
+    async ({ selector, shot }: { selector: string; shot: string }) => {
+      const el = document.querySelector(selector);
+      if (el === null) return null;
+      const r = el.getBoundingClientRect();
+      const dsf = window.devicePixelRatio;
+      const img = new Image();
+      await new Promise((res, rej) => {
+        img.onload = res;
+        img.onerror = rej;
+        img.src = `data:image/png;base64,${shot}`;
+      });
+      const canvas = document.createElement("canvas");
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext("2d");
+      if (ctx === null) return null;
+      ctx.drawImage(img, 0, 0);
+
+      const inset = 4 * dsf;
+      const x0 = Math.max(0, Math.floor(r.left * dsf + inset));
+      const y0 = Math.max(0, Math.floor(r.top * dsf + inset));
+      const w = Math.min(canvas.width - x0, Math.ceil(r.width * dsf - 2 * inset));
+      const h = Math.min(canvas.height - y0, Math.ceil(r.height * dsf - 2 * inset));
+      if (w <= 0 || h <= 0) return null;
+      const data = ctx.getImageData(x0, y0, w, h).data;
+
+      const tally = new Map<number, number>();
+      for (let i = 0; i < data.length; i += 4) {
+        const key = (data[i] ?? 0) * 65536 + (data[i + 1] ?? 0) * 256 + (data[i + 2] ?? 0);
+        tally.set(key, (tally.get(key) ?? 0) + 1);
+      }
+      let bgKey = 0;
+      let bgCount = -1;
+      for (const [key, count] of tally) {
+        if (count > bgCount) {
+          bgCount = count;
+          bgKey = key;
+        }
+      }
+      const bg = [Math.floor(bgKey / 65536), Math.floor(bgKey / 256) % 256, bgKey % 256];
+
+      let minX = Number.POSITIVE_INFINITY;
+      let minY = Number.POSITIVE_INFINITY;
+      let maxX = Number.NEGATIVE_INFINITY;
+      let maxY = Number.NEGATIVE_INFINITY;
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          const i = (y * w + x) * 4;
+          const delta =
+            Math.abs((data[i] ?? 0) - (bg[0] ?? 0)) +
+            Math.abs((data[i + 1] ?? 0) - (bg[1] ?? 0)) +
+            Math.abs((data[i + 2] ?? 0) - (bg[2] ?? 0));
+          if (delta > 24) {
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (y < minY) minY = y;
+            if (y > maxY) maxY = y;
+          }
+        }
+      }
+      if (minX === Number.POSITIVE_INFINITY) return { w: 0, h: 0 };
+      return { w: (maxX - minX + 1) / dsf, h: (maxY - minY + 1) / dsf };
+    },
+    { selector, shot },
+  );
+  if (ink === null) throw new Error(`no ink measurable for ${selector}`);
+  return ink;
+}
+
+test("@webkit mobile: the two doors are a `#` and a ☰ at one ink size, and the left one is off the channel name", async ({
+  page,
+}) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await hideTheBar(page);
+
+  const left = page.locator(".topic-bar .topic-bar-windows-opener");
+  const right = page.locator(".topic-bar .topic-bar-hamburger");
+  await expect(left).toBeVisible({ timeout: 10_000 });
+  await expect(right).toBeVisible({ timeout: 10_000 });
+
+  // The split itself, before any measuring: the left door TYPES its glyph and
+  // the right one DRAWS it. Both wearing bars is the reported defect; both
+  // painting at once is what the removed `font-size: 0` used to prevent.
+  await expect(left).toHaveText("#");
+  const pseudo = await left.evaluate((el) => getComputedStyle(el, "::before").content);
+  expect(pseudo, "the left door still draws the hamburger's bars under its `#`").toBe("none");
+  const rightPseudo = await right.evaluate((el) => getComputedStyle(el, "::before").content);
+  expect(rightPseudo, "the rail door stopped drawing its bars").not.toBe("none");
+
+  const shot = (await page.screenshot({ fullPage: false })).toString("base64");
+  const hash = await inkOf(page, ".topic-bar .topic-bar-windows-opener", shot);
+  const bars = await inkOf(page, ".topic-bar .topic-bar-hamburger", shot);
+
+  // Ruling 3: "che sia stessa dimensione del glifo dell'hamburger". HEIGHT is
+  // the axis — a `#` is a narrower shape than a square, so equal width would
+  // mean a `#` ~12% TALLER than the twin it was told to match. The tolerance is
+  // the sampling grid (dsf 3 quantises each edge to 1/3px), not a slack band:
+  // the derivation targets exact parity and the measured pair is 19.67 / 19.33.
+  expect(hash.h, `the \`#\` paints ${hash.h}px tall and nothing at all under 1`).toBeGreaterThan(1);
+  expect(
+    Math.abs(hash.h - bars.h),
+    `\`#\` ink ${hash.h}px vs ☰ ink ${bars.h}px — the two doors are not one size`,
+  ).toBeLessThanOrEqual(2);
+  // #305's floor, on the painted extent for both. The `#`'s ink WIDTH (~16.3px)
+  // is deliberately not asserted against 18: see the CSS note — no `#` is as
+  // wide as it is tall, and buying that width costs the height parity above.
+  expect(hash.h, `#305 — the \`#\` is ${hash.h}px tall; the floor is 18`).toBeGreaterThanOrEqual(
+    18,
+  );
+  expect(bars.h, `#305 — the ☰ is ${bars.h}px tall; the floor is 18`).toBeGreaterThanOrEqual(18);
+  expect(bars.w, `#305 — the ☰ is ${bars.w}px wide; the floor is 18`).toBeGreaterThanOrEqual(18);
+
+  // Ruling 4, both halves in one measurement. The leading side gains the
+  // clearance (band gap + the new margin, ~14px at root 14px, up from ~7px);
+  // the trailing side's inset stays exactly `.topic-bar`'s own padding, which
+  // #1039 pinned to `--pane-chrome-inset-inline` so the ☰'s two mobile hosts
+  // cannot drift apart. Read from the layout, not from the stylesheet.
+  const spacing = await page.evaluate(() => {
+    const bar = document.querySelector(".topic-bar");
+    const opener = document.querySelector(".topic-bar .topic-bar-windows-opener");
+    const header = document.querySelector(".topic-bar .topic-bar-header");
+    const rail = document.querySelector(".topic-bar .topic-bar-hamburger");
+    if (bar === null || opener === null || header === null || rail === null) return null;
+    const cs = getComputedStyle(bar);
+    return {
+      leading: header.getBoundingClientRect().left - opener.getBoundingClientRect().right,
+      bandGap: Number.parseFloat(cs.columnGap),
+      trailingInset: bar.getBoundingClientRect().right - rail.getBoundingClientRect().right,
+      barPaddingRight: Number.parseFloat(cs.paddingRight),
+    };
+  });
+  if (spacing === null) throw new Error("the band did not render its three children");
+  expect(
+    spacing.leading,
+    `the \`#\` sits ${spacing.leading}px from the channel name — the band gap alone (${spacing.bandGap}px) is the reported defect`,
+  ).toBeGreaterThan(spacing.bandGap);
+  expect(
+    spacing.trailingInset,
+    "#1039 — the rail door's inset must stay the band's own padding",
+  ).toBeCloseTo(spacing.barPaddingRight, 1);
+});

--- a/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
@@ -199,6 +199,16 @@ test("@webkit ux-5-bt mobile — channel: NO standalone .shell-chrome row (#473 
   //     bars, first cut (/3)  19.59 W × 15.06 H   ← the regression #1766 shipped
   //     bars, shipped         19.59 W × 19.59 H
   //
+  // ⚠️ #1801 correction, first row only: that 19.59 W is the ADVANCE, not ink.
+  // Re-measured against a pixel scan of the same glyph in the same engine at
+  // the same size, webkit reports `actualBoundingBoxLeft + Right` as the
+  // advance (painted: 17.67 W × 16.00 H) while chromium reports true ink;
+  // heights are sound in both. Nothing here moves — the bars' width is
+  // CSS-computed and the row that decided #1766 was the HEIGHT — but the
+  // column is a box measurement in a table written to say boxes overstate
+  // glyphs, so: an ink oracle is per-engine until painted pixels say
+  // otherwise. #1801's own guard scans pixels for exactly that reason.
+  //
   // So the threshold is unchanged at 18 and is met in BOTH axes for the first
   // time. Read off the computed shadow rather than recomputing the CSS
   // formula, so the test measures what is painted instead of restating it.

--- a/cicchetto/src/PaneTopBar.tsx
+++ b/cicchetto/src/PaneTopBar.tsx
@@ -68,9 +68,11 @@ import type { Component, JSX } from "solid-js";
  * Turning the mobile window bar off (`showBottomBar.ts`) leaves #1041's
  * left-edge swipe as the only way to the window list, and a gesture with zero
  * affordance is the "drawer-only navigation" #71's second ruling refused as a
- * default. So a second ☰ ships with the opt-out — and it has to appear on
+ * default. So a second door ships with the opt-out — and it has to appear on
  * every surface wearing this band, not only the channel one, which is what
- * puts it here rather than in `TopicBar`.
+ * puts it here rather than in `TopicBar`. (It shipped as a second ☰ and is a
+ * `#` since #1801; see that component's note for why sameness became the
+ * defect.)
  *
  * REQUIRED and not optional, by the same argument `trailing` already makes: a
  * host with no left door passes `null` and says so at the call site, instead
@@ -164,15 +166,42 @@ export type WindowsOpenerProps = {
  * every rail-reaching spec depend on the bottom-bar preference.
  *
  * So the two doors are two classes. What they still SHARE is
- * `.shell-chrome-btn` (#305's tap floor + icon token) and the drawn-bars rule,
- * which is the part that genuinely must not drift: with the bar off the two ☰
- * sit in one 48px band and have to look identical.
+ * `.shell-chrome-btn` — #305's tap floor and the `--chrome-icon-size` token
+ * both glyphs are sized off.
+ *
+ * ## #1801 — and what they stopped sharing is the DRAWING
+ *
+ * #1766 also gave this button the drawn-bars rule, on the argument that with
+ * the bar off the two openers sit in one 48px band "and have to look
+ * identical". That was right while both were "a menu". It stopped being right
+ * the moment this one named a specific list: the band then carried TWO doors
+ * drawn with the same three bars, one at each end, promising the same thing
+ * and doing different things.
+ *
+ * vjt's ruling (`#grappa`, 2026-08-26): the trailing ☰ stays a hamburger — "fa
+ * anche molto altro rispetto alla lista membri", it is a catch-all and the
+ * generic glyph is the honest name for that — and this one becomes `#`.
+ *
+ * 🔴 The ASCII character U+0023, never the keycap: "il # non emoji / il #
+ * carattere / ascii / roba anni '70". An emoji was floated and dropped with
+ * the reason stated in channel, and the reason is mechanical rather than
+ * aesthetic — a platform-painted glyph ignores `currentColor`, so it would sit
+ * dead under the `:hover` / `:focus-visible` lift the rest of the chrome
+ * answers, and it renders differently on iOS and Android. A text glyph keeps
+ * both. `PaneTopBar.test.tsx` asserts the CODEPOINT, because `#` + U+FE0F is
+ * invisible in a diff.
+ *
+ * Sizing lives in `themes/default.css` and is not `var(--chrome-icon-size)`:
+ * a character's ink is smaller than its em box, so the `#` is derived from
+ * that token rather than set to it. The measurement and the three font faces
+ * are in the rule's own note.
  *
  * The label is a literal, unlike the sibling's `railLabel` prop. That prop
  * exists because two hosts genuinely word the same door differently; this door
  * has one name on both surfaces it appears on — one door, two handles — and a
  * prop only ever passed one value would state a variability that does not
- * exist.
+ * exist. It is also unchanged by #1801: roughly a dozen specs locate this
+ * button by that name, and the door it opens did not move.
  */
 export const PaneTopBarWindowsOpener: Component<WindowsOpenerProps> = (props) => {
   return (
@@ -182,7 +211,7 @@ export const PaneTopBarWindowsOpener: Component<WindowsOpenerProps> = (props) =>
       aria-label="open windows sidebar"
       onClick={props.onOpenWindows}
     >
-      {"\u{2630}"}
+      {"\u{0023}"}
     </button>
   );
 };

--- a/cicchetto/src/__tests__/PaneTopBar.test.tsx
+++ b/cicchetto/src/__tests__/PaneTopBar.test.tsx
@@ -98,6 +98,18 @@ describe("PaneTopBarRailOpener — one button, two hosts", () => {
     fireEvent.click(screen.getByLabelText("open members sidebar"));
     expect(onOpenRail).toHaveBeenCalledTimes(1);
   });
+
+  // #1801, ruling 1: this one STAYS a hamburger. It was the other door that
+  // had to stop being one, and the temptation while splitting them was to give
+  // this one a "people" icon — refused in channel, because it is a catch-all
+  // (home, rooms, mentions, player, radio, themes, archive, settings, admin
+  // AND the member list), and the generic glyph is the honest name for that.
+  // The character is what renders if the stylesheet never loads; the bars are
+  // drawn over it (#1766).
+  it("still carries U+2630, the character the CSS bars are drawn over", () => {
+    render(() => <PaneTopBarRailOpener onOpenRail={vi.fn()} railLabel="open members sidebar" />);
+    expect(screen.getByLabelText("open members sidebar").textContent).toBe("\u{2630}");
+  });
 });
 
 // #1766 — the LEFT door. A separate component from the rail opener, and the
@@ -136,5 +148,23 @@ describe("PaneTopBarWindowsOpener — the other door", () => {
     render(() => <PaneTopBarWindowsOpener onOpenWindows={onOpenWindows} />);
     fireEvent.click(screen.getByLabelText("open windows sidebar"));
     expect(onOpenWindows).toHaveBeenCalledTimes(1);
+  });
+
+  // 🔴 #1801, ruling 2 — and the assertion is on the CODEPOINT, not on the
+  // rendered string, because the spellings that must not ship are INVISIBLE in
+  // a diff: U+0023 followed by U+FE0F (emoji presentation) reads as one `#` in
+  // every editor, and the keycap U+0023 U+FE0F U+20E3 differs from it by one
+  // more zero-width character. `Array.from` splits by codepoint, so a trailing
+  // selector makes the array two long and the test names it. vjt in channel:
+  // "il # non emoji / il # carattere / ascii / roba anni '70". The reason is
+  // not taste — an emoji is painted by the platform,
+  // so it ignores `currentColor` and would sit dead under the `:hover` /
+  // `:focus-visible` lift the rest of the chrome answers, and it renders
+  // differently on iOS and Android.
+  it("paints the ASCII `#` (U+0023) and nothing emoji-adjacent", () => {
+    render(() => <PaneTopBarWindowsOpener onOpenWindows={vi.fn()} />);
+    const text = screen.getByLabelText("open windows sidebar").textContent ?? "";
+    expect(Array.from(text)).toEqual(["#"]);
+    expect(text.codePointAt(0)).toBe(0x23);
   });
 });

--- a/cicchetto/src/__tests__/hamburgerGlyph.test.ts
+++ b/cicchetto/src/__tests__/hamburgerGlyph.test.ts
@@ -47,14 +47,22 @@ const barRules = () =>
   RULES.filter((r) => /topic-bar-(hamburger|windows-opener)[^,{]*::before/.test(r.selectors));
 
 /**
- * Every button that must READ as a ☰. Three classes and not one, since the
- * left door stopped sharing `.topic-bar-hamburger` — that class names the rail
- * door and the e2e fixture resolves it with `.first()` (#1073), so a second
- * bearer sent every rail-reaching spec through the wrong door. The look is
- * still shared, because with the window bar off the two ☰ sit in ONE 48px
- * band; only the identity was split.
+ * Every button that must READ as a ☰. Two classes and not one, since the left
+ * door stopped sharing `.topic-bar-hamburger` — that class names the rail door
+ * and the e2e fixture resolves it with `.first()` (#1073), so a second bearer
+ * sent every rail-reaching spec through the wrong door.
+ *
+ * #1801 took `.topic-bar-windows-opener` OUT of this list, and the removal is
+ * the point rather than an omission: #1766 kept the two doors identical
+ * because both were "a menu", and with the bottom bar off that left two
+ * openers drawn the same at either end of one 48px band. The left one names a
+ * specific list, so sameness became the defect. Its own contract is the
+ * mirror image of this one and is asserted below.
  */
-const BEARERS = ["topic-bar-hamburger", "topic-bar-windows-opener", "shell-chrome-rail-opener"];
+const BEARERS = ["topic-bar-hamburger", "shell-chrome-rail-opener"];
+
+/** The left door — asserted the other way round throughout (#1801). */
+const WINDOWS_OPENER = "topic-bar-windows-opener";
 
 describe("#1766 — the ☰'s three bars are drawn, not typed", () => {
   it("paints them on a ::before of the hamburger", () => {
@@ -142,12 +150,12 @@ describe("#1766 — the ☰'s three bars are drawn, not typed", () => {
     expect(shared).toHaveLength(0);
   });
 
-  // Splitting the left door's CLASS off `.topic-bar-hamburger` (see BEARERS)
-  // split the identity, and identity is the only thing that was meant to
-  // split. With the window bar off the two ☰ share one 48px band, so a bearer
-  // that fell out of either rule would render as the thin character next to a
-  // drawn twin — or, worse, as BOTH at once. Asserted per bearer rather than
-  // over the joined text so the failure names which one dropped out.
+  // A bearer that fell out of either rule would render as the thin character
+  // next to a drawn twin — or, worse, as BOTH at once. Asserted per bearer
+  // rather than over the joined text so the failure names which one dropped
+  // out. Both surviving bearers are the SAME door (the rail) on its two hosts,
+  // which is why they still have to look alike; see WINDOWS_OPENER for the one
+  // that deliberately does not.
   it.each(BEARERS)("draws AND suppresses `%s`, so no door drifts", (bearer) => {
     expect(
       barRules().some((r) => r.selectors.includes(bearer)),
@@ -157,5 +165,101 @@ describe("#1766 — the ☰'s three bars are drawn, not typed", () => {
       mentioning(bearer).some((r) => /font-size:\s*0/.test(r.body)),
       `nothing zeroes the character on \`.${bearer}\``,
     ).toBe(true);
+  });
+});
+
+// #1801 — the LEFT door leaves both rules, and every assertion below is the
+// inverse of one above. vjt's ruling: the right ☰ stays generic because it is
+// a catch-all, and the left one becomes the ASCII `#` — "il # non emoji / il #
+// carattere / ascii / roba anni '70". The character itself is pinned in
+// `PaneTopBar.test.tsx`; what lives here is the CSS half.
+describe("#1801 — the windows opener is a typed `#`, not a drawn ☰", () => {
+  const sizingRules = () =>
+    mentioning(WINDOWS_OPENER).filter((r) => /(^|[;\s])font-size:/.test(r.body));
+
+  it("draws no bars: nothing gives it a ::before", () => {
+    const drawn = barRules().filter((r) => r.selectors.includes(WINDOWS_OPENER));
+    expect(
+      drawn.map((r) => r.selectors),
+      "the left door is a character now — bars under it would paint BOTH",
+    ).toEqual([]);
+  });
+
+  it("is not zeroed: the character is what paints here", () => {
+    const suppressors = mentioning(WINDOWS_OPENER).filter((r) => /font-size:\s*0/.test(r.body));
+    expect(
+      suppressors.map((r) => r.selectors),
+      "`font-size: 0` on the left door renders an empty 48px box",
+    ).toEqual([]);
+  });
+
+  // The size requirement is the one that cannot be eyeballed. A character's
+  // INK is smaller than its em box — measured on the e2e runner's Liberation
+  // Mono, `#` is 0.659 em tall — so `font-size: var(--chrome-icon-size)` would
+  // paint a `#` ~34% shorter than the bars it stands beside, which is exactly
+  // what vjt asked not to happen. The size is therefore DERIVED from the same
+  // token, never a fresh px: one knob stays one knob, and a text-size change
+  // still moves both glyphs together.
+  it("derives its size from --chrome-icon-size rather than a fresh px", () => {
+    expect(sizingRules().length, "nothing sizes the left door's character").toBeGreaterThan(0);
+    for (const rule of sizingRules()) {
+      const decl = /font-size:([^;]*)/.exec(rule.body)?.[1] ?? "";
+      expect(decl, `\`${rule.selectors}\` sizes the \`#\` off the shared token`).toMatch(
+        /var\(--chrome-icon-size\)/,
+      );
+      expect(decl, `\`${rule.selectors}\` hardcodes a px size for the \`#\``).not.toMatch(/\dpx/);
+    }
+  });
+
+  // THE trap, same one #305 documented for `display` and #1766 for the
+  // suppression: `.shell-chrome-btn` declares `font-size:
+  // var(--chrome-icon-size)`, so a bare `.topic-bar-windows-opener` ties at
+  // (0,1,0) and the `#` would silently fall back to the un-derived size — a
+  // glyph a third too small, with no rule looking wrong.
+  it("wins that sizing against `.shell-chrome-btn`, not merely declares it", () => {
+    const base = RULES.find((r) => r.selectors === ".shell-chrome-btn");
+    expect(
+      base,
+      "`.shell-chrome-btn` must exist for this comparison to mean anything",
+    ).toBeDefined();
+    expect(base?.body).toMatch(/font-size:\s*var\(--chrome-icon-size\)/);
+
+    for (const rule of sizingRules()) {
+      const beatsBySpecificity = /\bbutton\.topic-bar-windows-opener/.test(rule.selectors);
+      const beatsByOrder = rule.index > (base?.index ?? 0);
+      expect(
+        beatsBySpecificity || beatsByOrder,
+        `\`${rule.selectors}\` ties .shell-chrome-btn at (0,1,0) and loses on source order`,
+      ).toBe(true);
+    }
+  });
+
+  // The bars answer `:hover` / `:focus-visible` because they paint in
+  // `currentColor`; a character answers for free, by BEING text — but only
+  // while nothing pins a colour on it. That is also the measured reason an
+  // emoji was refused: a platform-painted glyph ignores `currentColor` and
+  // would sit dead under the one lift the rest of the chrome answers.
+  it("declares no colour of its own, so the hover lift still reaches it", () => {
+    for (const rule of mentioning(WINDOWS_OPENER)) {
+      expect(
+        rule.body,
+        `\`${rule.selectors}\` pins a colour and would go dead under :hover`,
+      ).not.toMatch(/(^|[;\s])color:/);
+    }
+  });
+
+  // Ruling 4: the left door sat flush against the channel name. The clearance
+  // goes on the LEADING side only — #1039 pinned the trailing side to
+  // `--pane-chrome-inset-*` precisely so the ☰'s two hosts cannot drift apart,
+  // and widening the band's own `gap` would have moved that side too.
+  it("takes its clearance on the leading side alone", () => {
+    const clearance = mentioning(WINDOWS_OPENER).filter((r) => /margin-inline-end:/.test(r.body));
+    expect(clearance.length, "nothing separates the left door from the channel name").toBe(1);
+    for (const rule of clearance) {
+      expect(
+        rule.selectors,
+        `\`${rule.selectors}\` also matches the trailing door, whose inset #1039 pinned`,
+      ).not.toMatch(/topic-bar-hamburger|shell-chrome-rail-opener/);
+    }
   });
 });

--- a/cicchetto/src/__tests__/hamburgerGlyph.test.ts
+++ b/cicchetto/src/__tests__/hamburgerGlyph.test.ts
@@ -174,8 +174,20 @@ describe("#1766 — the ☰'s three bars are drawn, not typed", () => {
 // carattere / ascii / roba anni '70". The character itself is pinned in
 // `PaneTopBar.test.tsx`; what lives here is the CSS half.
 describe("#1801 — the windows opener is a typed `#`, not a drawn ☰", () => {
+  const fontSizeOf = (body: string) => /(?:^|[;{\s])font-size:([^;]*)/.exec(body)?.[1]?.trim();
+
+  // `font-size: 0` IS a font-size, so a filter that merely looks for the
+  // property makes the suppression mutant fail BOTH this test and the one
+  // above — measured: one mutant, two reds, neither naming which mechanism
+  // broke. Suppression is that test's business; this one owns the derivation.
+  // Read the VALUE and drop the zero rather than writing a lookahead: `\s*`
+  // backtracks to width zero and lets `(?!0…)` pass on ` 0;`, which is a
+  // silently vacuous filter (measured too, on the same mutant).
   const sizingRules = () =>
-    mentioning(WINDOWS_OPENER).filter((r) => /(^|[;\s])font-size:/.test(r.body));
+    mentioning(WINDOWS_OPENER).filter((r) => {
+      const decl = fontSizeOf(r.body);
+      return decl !== undefined && decl !== "0";
+    });
 
   it("draws no bars: nothing gives it a ::before", () => {
     const drawn = barRules().filter((r) => r.selectors.includes(WINDOWS_OPENER));
@@ -203,7 +215,7 @@ describe("#1801 — the windows opener is a typed `#`, not a drawn ☰", () => {
   it("derives its size from --chrome-icon-size rather than a fresh px", () => {
     expect(sizingRules().length, "nothing sizes the left door's character").toBeGreaterThan(0);
     for (const rule of sizingRules()) {
-      const decl = /font-size:([^;]*)/.exec(rule.body)?.[1] ?? "";
+      const decl = fontSizeOf(rule.body) ?? "";
       expect(decl, `\`${rule.selectors}\` sizes the \`#\` off the shared token`).toMatch(
         /var\(--chrome-icon-size\)/,
       );

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3205,10 +3205,15 @@ html.resize-dragging * {
    inside the band, and since #1766 the same button also floats in
    `.shell-chrome` on non-channel windows — it would render there as the thin
    character next to a drawn twin. `.shell-chrome-rail-opener` is listed for
-   the same reason from the other side: with the window bar off, the two ☰
-   share one 48px-tall band and must look identical. */
+   the same reason from the other side: it is the SAME door on its other host.
+
+   #1801 removed `.topic-bar-windows-opener` from this list and from the
+   `::before` below. #1766 had put it here because with the bottom bar off the
+   two openers share one 48px band "and must look identical" — true while both
+   were "a menu", and the defect once the left one named a specific list: two
+   doors drawn with the same three bars, one at each end of one band. It is a
+   `#` now; see its own rule further down. */
 button.topic-bar-hamburger,
-button.topic-bar-windows-opener,
 .shell-chrome .shell-chrome-rail-opener {
   /* Suppress the U+2630 text node. It stays in the DOM — it is what renders
      if this sheet never loads, and ~20 specs locate these buttons — but it
@@ -3236,7 +3241,6 @@ button.topic-bar-windows-opener,
    measuring the box and not the glyph. The bars are the first shape here that
    actually clears 18 in both axes. */
 button.topic-bar-hamburger::before,
-button.topic-bar-windows-opener::before,
 .shell-chrome .shell-chrome-rail-opener::before {
   content: "";
   width: var(--chrome-icon-size);
@@ -3249,6 +3253,87 @@ button.topic-bar-windows-opener::before,
   box-shadow:
     0 calc(-1 * (var(--chrome-icon-size) - 2px) / 2) 0 currentColor,
     0 calc((var(--chrome-icon-size) - 2px) / 2) 0 currentColor;
+}
+
+/* #1801 — the LEFT door is a `#`, and it is a CHARACTER.
+
+   With the bottom bar off the mobile top band carried two openers drawn
+   identically — the same three bars, one at each end — and they are two
+   different things: this one opens the window/channel list, the trailing ☰
+   opens the rail. vjt ruled the right one STAYS a hamburger ("fa anche molto
+   altro rispetto alla lista membri" — it is a catch-all and the generic glyph
+   is the honest name for that), and this one becomes `#`: "il # non emoji / il
+   # carattere / ascii / roba anni '70". An emoji was floated and dropped with
+   the trade-off stated in channel — a platform-painted glyph ignores
+   `currentColor`, so it would sit dead under the `:hover` / `:focus-visible`
+   lift the rest of the chrome answers, and it renders differently on iOS and
+   Android. A text `#` keeps both for free, by being text.
+
+   ## Why the size is a division and not plain `var(--chrome-icon-size)`
+
+   "Ma che sia stessa dimensione del glifo dell'hamburger" is a measurement,
+   not a guess. The bars above fill the token EXACTLY — a 19.59px square at
+   root 14px. A character does not: its INK is smaller than its em box, which
+   is precisely how #305's floor came to be missed by an oracle reading
+   `font-size`. Ink height in em, read off the font files, calibrated against
+   the painted pixels:
+
+       Liberation Mono (the e2e runner)    #  0.5415 W x 0.6587 H
+       SF Mono (`ui-monospace` on iOS)     #  0.5366 W x 0.7046 H
+       Menlo (the stack's macOS fallback)  #  0.6060 W x 0.7153 H
+
+   So `font-size: var(--chrome-icon-size)` paints a `#` a third shorter than
+   the bars beside it — exactly what was asked not to happen — and the ratio
+   that corrects it is a property of the FONT, which differs per platform.
+
+   Hence the pair, which cancels. `font-size-adjust: cap-height N` scales the
+   used size so that the resolved face's cap height is N x the SPECIFIED size,
+   whatever face that turns out to be; and `#` is drawn TO cap height (1.000 of
+   it in Liberation Mono AND in SF Mono, 0.981 in Menlo). Specifying `token /
+   N` and adjusting to `N` therefore states "the `#`'s ink is
+   `--chrome-icon-size` tall" on any font — the same square the bars fill.
+   Verified on the e2e image's webkit and chromium, painted pixels, scanned 4px
+   inside the box so the 1px border is out of frame:
+
+       `#`   ink 16.33 W x 19.67 H        bars  ink 19.33 W x 19.33 H
+
+   N = 0.68 is the midpoint of the two faces that matter (0.659 / 0.705) and is
+   load-bearing ONLY where `font-size-adjust` is not honoured: there the
+   specified size stands alone and still lands within 4% of parity on all three
+   faces, clear of #305's 18px floor. Both engines in the e2e image honour it.
+
+   The WIDTH does not match, and cannot. `#` is a narrower shape than a square,
+   so at equal height it paints 16.33 against the bars' 19.33. Matching the
+   width instead would make the `#` 21.9px TALL — 12% taller than the twin it
+   was told to match. Height is the axis a reader compares glyphs on, and the
+   axis #305's floor was missed in.
+
+   One knob stays one knob: the size is DERIVED from `--chrome-icon-size`, so a
+   text-size change still moves both glyphs together. `button.` and placed
+   after `.shell-chrome-btn` for the belt-and-braces reason the rule above
+   states — that base declares `font-size: var(--chrome-icon-size)`, so a bare
+   class ties at (0,1,0), loses on source order, and the `#` falls back to the
+   un-derived size with nothing looking wrong. */
+button.topic-bar-windows-opener {
+  font-size: calc(var(--chrome-icon-size) / 0.68);
+  font-size-adjust: cap-height 0.68;
+}
+
+/* #1801 ruling 4 — "serve un pelo di margin-right sull'hamburger di sx, o in
+   alternativa di spazio nei contenitori". `.topic-bar`'s 0.5rem gap plus the
+   button's 1px border left ~7px between a boxed control and the channel name.
+   One more gap doubles that to ~14px: the band's own value re-used, not a
+   fresh number.
+
+   LEADING side only, and scoped to the band. Widening `.topic-bar`'s `gap`
+   would take the trailing side with it, and #1039 pinned that side to
+   `--pane-chrome-inset-*` precisely so the ☰'s two mobile hosts cannot drift
+   apart again. Scoping also keeps this longhand from competing at all with the
+   float host's `margin` shorthand, whose `margin-right: auto` is what holds a
+   lone trailing opener in its corner (#1766); relying on specificity to settle
+   that would be a race nobody can see. */
+.topic-bar .topic-bar-windows-opener {
+  margin-inline-end: 0.5rem;
 }
 
 /* Scrollback (existing rules — minor additions for mention highlight) */

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -65735,3 +65735,92 @@ does not mention the credits payload at all — the word does not appear in
 `OPERATIONS.md`. That is #1773's documentation debt, not this slice's, and
 inventing a credits subsection to hang one `.mailmap` sentence on would put
 the note somewhere no reader would look for it.
+<!-- entry #1801 -->
+
+---
+
+## 2026-08-26 — #1801: two doors drawn alike, and the measurement that decides a glyph's size
+
+With the mobile bottom bar off, #1766's top band carried two openers drawn
+identically — the same three CSS bars, one at each end — and they open
+different things: the leading one the window/channel list, the trailing one the
+rail. #1766 gave them one drawing on purpose, in its own words *"with the bar
+off the two ☰ sit in one 48px band and have to look identical"*. That was right
+while both were "a menu"; it became the defect the moment the left one named a
+specific list. **Sameness is a claim, and a shared drawing makes it.**
+
+vjt ruled on `#grappa`: the trailing hamburger STAYS generic — *"fa anche molto
+altro rispetto alla lista membri"*, it is a catch-all (home, rooms, mentions,
+player, radio, themes, archive, settings, admin AND the member list) and the
+generic glyph is the honest name for that, so no "people" icon there. The
+leading one becomes `#`, at the trailing glyph's size, with clearance from the
+channel name it sat flush against. An emoji was floated and dropped with the
+reason stated in channel and not as taste: a platform-painted glyph ignores
+`currentColor`, so it would sit dead under the `:hover` / `:focus-visible` lift
+the rest of the chrome answers, and it renders differently on iOS and Android.
+
+### The size is a font metric, so the CSS has to be one too
+
+"Stessa dimensione del glifo dell'hamburger" cannot be satisfied by
+`font-size: var(--chrome-icon-size)`, and the reason is #1766's own lesson one
+level down: the bars fill the token EXACTLY (a 19.59px square at root 14px)
+while a character's INK is smaller than its em box. Worse, by how much is a
+property of the FONT, and `--font-mono` resolves to a different face on every
+platform this ships to. Ink height in em, read off the font binaries with a
+hand-written table reader calibrated against painted pixels:
+
+| face | where it is the resolved `--font-mono` | `#` ink W | `#` ink H |
+| --- | --- | --- | --- |
+| Liberation Mono | the e2e image (Linux) | 0.5415 | 0.6587 |
+| SF Mono | `ui-monospace` on iOS/macOS | 0.5366 | 0.7046 |
+| Menlo | the stack's next macOS entry | 0.6060 | 0.7153 |
+
+A single measured divisor would therefore be correct on exactly one platform,
+and the one it would be measured on is the CI runner rather than the phone the
+defect was reported from. What closes that gap is a pair that cancels:
+`font-size: calc(var(--chrome-icon-size) / 0.68)` with `font-size-adjust:
+cap-height 0.68`. The adjust scales the used size so the resolved face's cap
+height is `0.68 ×` the SPECIFIED size, whatever face resolves; `#` is drawn TO
+cap height (measured 1.000 of it in Liberation Mono AND in SF Mono, 0.981 in
+Menlo); so the pair states *"the `#`'s ink is `--chrome-icon-size` tall"* on any
+font, which is the same square the bars fill. Painted pixels on the e2e image,
+scanned 4px inside the box so the 1px border is out of frame: `#` 16.33 W ×
+19.67 H against bars 19.33 × 19.33, on both engines it ships.
+
+`0.68` is not a size and not a second knob — the token stays the one knob, so a
+text-size change still moves both glyphs. It is the aspect target, and it is
+load-bearing only where `font-size-adjust` is unsupported: there the specified
+size stands alone and still lands within 4% of parity on all three faces, clear
+of #305's 18px floor. It is the midpoint of the two faces that matter.
+
+**The width does not match, and no `#` can.** At equal height it paints 16.33
+against the bars' 19.33; buying it 18px of width would make it 21.9px TALL, 12%
+taller than the twin it was told to match. Height is the axis a reader compares
+glyphs on and the axis #305's floor was missed in, so height is the axis that
+matches and the refusal is stated in the rule, the spec and the report rather
+than absorbed silently.
+
+### A correction to #1766's own table, in exactly its own genre
+
+That entry records `U+2630 as text — 19.59 W × 17.00 H`, from canvas
+`actualBoundingBox`, and the W is not ink. Measured here against a pixel scan
+of the same glyph in the same engine at the same size: webkit reports
+`actualBoundingBoxLeft + Right` as the ADVANCE (`200.00` at 200px, painted
+`180.00`; `#` `120.02`, painted `108.67`), while chromium reports the true ink
+(`109` for `#`, painted `109`). Heights are sound in both. So the W column of a
+table whose entire point was *"the box overstates the glyph"* is itself a box
+measurement, on the engine the numbers were taken from. Nothing downstream
+moves — the bars' width is CSS-computed, not canvas-measured, and the row that
+decided #1766 was the height — but the class does: **an ink oracle is per
+engine until a painted-pixel scan says otherwise**, and that is why the guard
+this issue ships measures pixels rather than asking a text-metrics API.
+
+### What was NOT measured
+
+No real iOS device was available, so the SF Mono numbers above are read from
+`/System/Library/Fonts/SFNSMono.ttf` — the same family iOS resolves
+`ui-monospace` to — and not from a rendered iPhone. What the runner proves is
+that both its engines honour `font-size-adjust: cap-height`; that Safari on a
+phone does too is inference from the same WebKit lineage, not a measurement.
+Should it turn out otherwise there, the fallback path is the one already
+described and its worst case is 4%.


### PR DESCRIPTION
Fixes the two-identical-doors defect in the mobile top band: the leading opener
becomes an ASCII `#` sized to the trailing hamburger's **ink**, with clearance
from the channel name. Issue #1801, vjt's four-point ruling implemented as
given — no design choices were taken here.

## What changed

| | before | after |
| --- | --- | --- |
| `.topic-bar-windows-opener` | three drawn bars, character zeroed | typed `#` (U+0023), no `::before`, not zeroed |
| `.topic-bar-hamburger` | three drawn bars | **unchanged** |
| leading clearance | ~7px to the channel name | ~14px (`margin-inline-end: 0.5rem`) |
| trailing inset | `--pane-chrome-inset-*` | **byte-identical** |

Neither class is renamed and neither `aria-label` moves — roughly twenty specs
reach the rail through `.first()` on `.topic-bar-hamburger` (#1073).

## The size is a font metric, so the CSS is one

`font-size: var(--chrome-icon-size)` would paint the `#` a third shorter than
the bars beside it: the bars fill the token exactly (a 19.59px square at root
14px) while a character's **ink** is smaller than its em box — the same
quantity that made #305's floor miss under an oracle reading `font-size`. And
the correcting ratio is a property of the FACE, which differs per platform:

| face | where `--font-mono` resolves to it | `#` ink W | `#` ink H |
| --- | --- | --- | --- |
| Liberation Mono | the e2e image (Linux) | 0.5415 | 0.6587 |
| SF Mono | `ui-monospace` on iOS/macOS | 0.5366 | 0.7046 |
| Menlo | the stack's next macOS entry | 0.6060 | 0.7153 |

So a single measured divisor would be right on the CI runner and wrong on the
phone the defect was reported from. The shipped rule is a pair that cancels:

```css
font-size: calc(var(--chrome-icon-size) / 0.68);
font-size-adjust: cap-height 0.68;
```

`font-size-adjust` scales the used size so the resolved face's cap height is
`0.68 ×` the **specified** size, and `#` is drawn to cap height (measured 1.000
of it in Liberation Mono AND SF Mono, 0.981 in Menlo). The pair therefore states
*"the `#`'s ink is `--chrome-icon-size` tall"* on any font. `0.68` is not a size
and not a second knob — the token stays the one knob — and it is load-bearing
only where `font-size-adjust` is unsupported, where the specified size alone
still lands within 4% of parity on all three faces, clear of the 18px floor.
Both engines in the e2e image honour it.

Painted pixels, e2e image, scanned 4px inside the box so the 1px border is out
of frame: **`#` 16.33 W × 19.67 H** against **bars 19.33 × 19.33**.

## What is deliberately NOT asserted

The `#`'s ink **width** does not match and no `#` can: buying it 18px of width
would make it 21.9px tall, 12% taller than the twin it was told to match.
Height is the axis a reader compares glyphs on and the axis #305's floor was
missed in, so height is what matches; the refusal is stated in the CSS, in the
spec and in the report rather than absorbed.

No real iOS device was reachable, so the SF Mono numbers are read from the font
binary (the same family iOS resolves `ui-monospace` to) rather than from a
rendered iPhone, and Safari-on-phone honouring `font-size-adjust` is inference
from the WebKit lineage. Worst case if it does not: the 4% fallback above.

## Guards

`hamburgerGlyph.test.ts` is **extended, not relaxed**. The windows opener
leaves `BEARERS` and gains the inverse contract: no `::before`, no
`font-size: 0`, size derived from the shared token, that derivation winning the
cascade against `.shell-chrome-btn`, no colour of its own, and clearance on the
leading selector alone. `PaneTopBar.test.tsx` asserts the CODEPOINT, because
`#` + U+FE0F is invisible in a diff.

A new e2e in `issue1766-hide-bottom-bar.spec.ts` — the only state that mounts
both doors — measures **painted pixels**. Both cheaper oracles are blind here:
`getComputedStyle().fontSize` measures the em box and reads 0 on a suppressed
character, and no rect API reports a `::before`'s box-shadows.

**10 mutants, 10 kills, each naming exactly one assertion** (the first pass had
one mutant killing two; the filter was narrowed and re-measured).

## One correction to #1766

Its ink table records `U+2630 as text — 19.59 W × 17.00 H`. Re-measured against
a pixel scan of the same glyph in the same engine at the same size, **webkit
reports `actualBoundingBoxLeft + Right` as the ADVANCE** (200.00 at 200px,
painted 180.00) while chromium reports true ink; heights are sound in both. So
that W is a box measurement inside a table written to say boxes overstate
glyphs. Nothing downstream moves — the bars' width is CSS-computed and the row
that decided #1766 was the height — so it is annotated in place, and the class
is recorded: an ink oracle is per-engine until painted pixels say otherwise.

## Gates

All from cwd `.worktrees/w2-1801`, on the rebased tree (base `01ae3287`):

- `scripts/bun.sh run check` — 5 stages, 0 failed
- `scripts/bun.sh run test` — 323 files / **6357 passed**, rc=0 (baseline 6350)
- `scripts/design-notes-gate.sh` — `1 new entry heading(s), separator and marker present`
- `scripts/union-rebase.sh` — `docs/DESIGN_NOTES.md: +89 -0 — contribution intact`

**Not run: the e2e.** The STACK lane belongs to another worker, so the new spec
has never executed; CI is its first run. Its algorithm was validated in a
standalone playwright container against a static page carrying the real
stylesheet and production markup, with the same background rule the spec ships.


## The ruling, and the rebase that re-gates it (2026-08-26)

### The ruling, textual, with its provenance

vjt, `#grappa` (Azzurra), 2026-08-26 08:21Z, verbatim: **"parita' altezza"**
("parity on height").

Read as: #305's floor (*"both >= 18px"*) applies to **both glyphs with parity
on the HEIGHT axis** — 19.67 vs 19.33 — and **not on both axes**. So the `#`'s
**16.33px ink WIDTH is not a violation** and **no constant changes**. That is
the reading this branch already implements.

**Provenance, stated because it is not first-hand.** The ruling reached this
branch **relayed via ircbot**, and **nobody in the chain read it in person** —
neither the orchestrator who relayed it (who said so himself) nor the worker
applying it here. It is quoted verbatim above so that, if the relay is crooked,
it surfaces in review and costs one line instead of a silent constant change.
Same posture as the two relayed rulings recorded in #1808.

### Nothing in the code changed, and that is the point

A ruling that **confirms** the branch's existing behaviour is a no-op on the
tree: zero edits to `.tsx`, `.css`, `.ts` or any test. Verified rather than
asserted — the per-file `--numstat` pinned before this rebase and re-pinned
after is identical across all seven paths (`diff -u` rc=0).

### Rebased onto `58797ce1`

The branch was `behind 22 / ahead 4`, and GitHub reported
`mergeable=CONFLICTING`, `mergeStateStatus=DIRTY` — the 9/9 green it carried
was taken at 03:15Z and attests the branch against a main five hours old, never
the union. **Locally that conflict does not exist**: `merge=union` on
`docs/DESIGN_NOTES.md` resolves it alone, rc=0 and zero conflict markers, and
GitHub does not apply the driver. A clean local rebase therefore proves nothing
about mergeability — which is also exactly why the five controls below are not
a ritual. Where the driver resolves in silence they are the only thing that
separates a correct resolution from one that ate lines.

`docs/DESIGN_NOTES.md` was +89 on the branch and main had gained five commits
on that same file (#1796, #1802, #1805, #1807, #1808), so the driver did run.

| # | control | result |
| --- | --- | --- |
| 1 | previous entry byte-identical | **rc=0.** `head -c "$(stat -f%z main-DN)" DN \| cmp - main-DN` (the BSD-safe form: `cmp -n N` prints `EOF on <file>` and returns non-zero even when every byte matches). Independent witness: sha256 `e2c0598a…` on both sides. All **3,887,965 bytes** of main's file — all 253 prior entries, #1808's included — are the untouched prefix, so the entry before mine is byte-identical a fortiori. |
| 2 | two-sided numstat, on FILE, diffed | **rc=0.** All 7 paths unchanged; `docs/DESIGN_NOTES.md` `+89 −0`. Additions **unchanged** *and* deletions **zero** — neither the eaten-separator sign nor the resurrected-text sign. |
| 3 | boundary shape read ON the file | lines 65737–65742: prose full stop / `<!-- entry #1801 -->` with **no blank line before it** / blank / `---` / blank / `## `. |
| 4 | marker unique, whole line | `^<!-- entry #1801 -->$` = **1** on disk; **254** markers total (253 + mine). Checked against the base's **TIP `58797ce1` at the moment of this rebase**, not against an earlier count: 0 occurrences of `<!-- entry #1801 -->` and 0 of any `#1801<suffix>` variant. Known-answer controls in the same run: `#1808` = 1, an invented `#999999` = 0. |
| 5 | arithmetic counterproof | **exact.** 3,887,965 B + 5,370 B = **3,893,335 B** on disk; 65,737 + 89 = **65,826** lines. With control 1 this pins the whole file: main's bytes, then this entry's, and nothing else. |

Tooling alongside the hand controls:

- `scripts/union-rebase.sh origin/main` — rc=0,
  `docs/DESIGN_NOTES.md: +89 -0 — contribution intact`.
- `scripts/design-notes-gate.sh origin/main`, **post-commit** — printed the
  non-vacuous line `1 new entry heading(s), separator and marker present.`
  Pre-commit the same gate measures commits, not the working tree, and answers
  `nothing to check`: a green that means nothing. The line is the verdict, not
  the exit code.
- Rebase confirmed with `git merge-base --is-ancestor origin/main HEAD` (rc=0),
  never with GitHub's asynchronous `mergeable`. After the force-push GitHub
  did recompute to `MERGEABLE`.

### What this pass refuses to assert

- **Nothing about the gates on the new base.** No local gate was run in this
  pass — the host is occupied by another worker's `check.sh`. The **Gates**
  section above stands exactly as measured, against base `01ae3287`, before
  these 22 commits landed. The 9-check CI on this push is the first and only
  re-gate of the union, and until it settles green the union is untested.
- **Nothing about the ruling's wording beyond the relay.** It was not read
  first-hand by anyone in the chain; the quote is what arrived.
- **`MERGEABLE` is not "fast-forwardable" and not a CI statement.** It says
  GitHub could build the merge commit, nothing more.
