### PR TITLE
#1796 — /reconnect and /cycle: two bounce verbs, each on the grammar it round-trips

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Typed in cicchetto's compose box, parsed client-side, dispatched to REST or IRC.
 | `/me <text>` | CTCP ACTION in the active channel |
 | `/join <#chan>` | Join a channel |
 | `/part [#chan] [reason]` | Part the active or named channel |
+| `/cycle [#chan] [message]` | Part then re-join the active or named channel (irssi's `CYCLE`). Channel-scoped only — the network bounce is `/reconnect`. A first word without a channel sigil is the message, not a target. No key slot, so a `+k` channel needs `/part` + `/join #chan <key>` |
 | `/topic <text>` · `/topic -delete` | Set / clear the channel topic |
 | `/nick <newnick>` | Change nick (users and visitors) |
 | `/msg <nick> <text>` | Private message — opens a query window (channel-shaped targets are rejected). When the target is a network service (NickServ/ChanServ/SeenServ/…), its replies land in that open query window rather than the server tab (#400); unsolicited service traffic with no open query still lands in the server tab |
@@ -239,6 +240,7 @@ Typed in cicchetto's compose box, parsed client-side, dispatched to REST or IRC.
 | `/alias <name> <expansion>` · `/unalias <name>` | Define / remove your own slash-command alias (`/alias wii whois $1 $1` → `/wii foo` runs `/whois foo foo`). `$1`..`$9` positional, `$N-` the Nth arg and everything after it (`/alias k kick $1 $2-`), `$*` all args; with no placeholder the rest is appended. Server-synced per user; builtins can't be shadowed. Bare `/alias` opens the **aliases** settings section, where existing aliases are also editable in place (rename + change expansion) |
 | `/connect <network>` | Unpark + respawn a network |
 | `/disconnect [network] [reason]` | Park one network (persists across reboots until `/connect`) |
+| `/reconnect [network] [reason]` | Bounce one network — park, then unpark, in that order (irssi's `RECONNECT`). The one-command form of `/disconnect` + `/connect`, and the way to re-roll a vhost (the source address is picked per connect). Bare form targets the active window's network; the reason travels as the upstream QUIT |
 | `/quit [reason]` | Park all networks, QUIT upstream, log out |
 
 Per-window UI behavior — channel header, query/DM focus rule, archive section, the server-owned window-state machine, mobile layout, scrollback polish, the mention-aware scroll-to-bottom badge (jump to the next unseen mention below), mentions-while-away, auto-away, image upload, multi-line paste flood guard (a confirm dialog before pasting >3 lines, since each line sends as its own message) — is documented in `docs/DESIGN_NOTES.md`. cic mirrors server state; it never originates window state client-side.

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -938,6 +938,66 @@ export async function patchNetworkConnectionState(
   }
 }
 
+// Settle a network back to "fully autojoined and NAMES-seeded" after a spec
+// parked it. Returns as soon as that holds; gives up silently after the
+// budget, because the caller is a best-effort `afterEach` and throwing there
+// would replace one spec's failure with a confusing second one.
+//
+// #1796 — extracted from `cp15-b6-parked-disconnect-reconnect.spec.ts`, which
+// is where the argument was made and paid for; a second network-parking spec
+// re-typing it is how the subtle half of it (the 200-vs-204 distinction) would
+// get dropped. Its reasoning, unchanged:
+//
+//   The testnet does NOT reset between specs, so leaving a parked credential
+//   breaks every following spec that expects autojoin to be live. Observed:
+//   skipping this poll cascaded 18 failures across m1-m9 and the downstream
+//   cp15-b6-* specs, because every following spec inherits a half-spawned
+//   Session.
+//
+//   #522 — `joined` is NOT a sufficient settle signal. The channels endpoint
+//   reports `joined: true` the instant the channel enters `state.members` (the
+//   self-JOIN echo), which lands BEFORE the 353/366 NAMES burst seeds the
+//   member list; returning there leaks a mid-stabilization session into the
+//   next spec and flakes its members assertion ~60% of the time. Only a 200
+//   from GET /members (channel in `seeded_channels` → 366 landed, no NAMES in
+//   flight) WITH the own nick present is the deterministic signal. HTTP 204
+//   (`:uninitialized`) is joined-but-pre-NAMES → keep polling.
+//
+//   60 × 500ms = 30s: SpawnOrchestrator → IRC connect → SASL → autojoin →
+//   JOIN echo → 353/366 → members seeded is empirically ~3-5s on a healthy
+//   testnet; the ceiling absorbs upstream rate-limit penalties accumulated by
+//   prior specs' churn. Budget the CALLER's `test.setTimeout` for it.
+export async function settleNetworkAutojoin(
+  token: string,
+  networkSlug: string,
+  channel: string,
+  ownNick: string,
+): Promise<void> {
+  await patchNetworkConnectionState(token, networkSlug, {
+    connection_state: "connected",
+  }).catch(() => {});
+
+  const headers = { authorization: `Bearer ${token}` };
+  const channelsUrl = `${GRAPPA_BASE_URL}/networks/${networkSlug}/channels`;
+  const membersUrl = `${GRAPPA_BASE_URL}/networks/${networkSlug}/channels/${encodeURIComponent(
+    channel,
+  )}/members`;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    const res = await fetch(channelsUrl, { headers }).catch(() => null);
+    if (res?.ok) {
+      const channels = (await res.json()) as Array<{ name: string; joined: boolean }>;
+      if (channels.find((c) => c.name === channel)?.joined) {
+        const membersRes = await fetch(membersUrl, { headers }).catch(() => null);
+        if (membersRes?.status === 200) {
+          const { members } = (await membersRes.json()) as { members: Array<{ nick: string }> };
+          if (members.some((m) => m.nick === ownNick)) return;
+        }
+      }
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
 // #498 — self-serve accretion (`POST /session/networks`). Binds + spawns
 // the visitor_enabled `slug` for the authenticated subject, anon
 // (`auth_method: :none`), with the account name as the default nick. `204`

--- a/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
@@ -53,7 +53,7 @@
 // gets the row back to its baseline live state.
 
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { settleNetworkAutojoin } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -69,70 +69,13 @@ const PARK_REASON = "testing parked state cp19";
 test.setTimeout(90_000);
 
 test.afterEach(async () => {
-  // If the spec failed mid-run the network may still be parked. The
-  // testnet doesn't reset between specs — leaving a parked credential
-  // would break every subsequent spec that expects autojoin to be
-  // live. Best-effort reconnect via the same fixture; ignore failure
-  // (already-connected returns :not_parked, that's fine).
-  //
-  // CRITICAL: also poll the REST surface until #spec-wN is not merely
-  // joined but fully MEMBERS-SEEDED. /connect spawns a fresh
-  // Session.Server but autojoin is async — without settling, the next
-  // spec starts before #spec-wN is back and its loginAs sees a sidebar
-  // without the autojoin row. Observed during full integration suite
-  // run: skipping this poll cascaded 18 failures across m1-m9 +
-  // downstream cp15-b6-* specs because every following spec inherits a
-  // half-spawned Session.
-  //
-  // #522: `joined` is NOT a sufficient settle signal. The channels
-  // endpoint reports `joined: true` the instant #spec-wN enters
-  // `state.members` — the self-JOIN echo (event_router.ex:457) — which
-  // lands BEFORE the 353/366 NAMES burst seeds the member list. Return
-  // at that point and we leak a mid-stabilization session (autojoin
-  // NAMES still in flight) into the immediately-following
-  // cp15-b6-part-archive-rejoin spec (#53): it PARTs #spec-wN, and the
-  // still-arriving 353/366 races its re-JOIN's members-seeding, flaking
-  // the "members pane populates" assert ~60% of the time. Settle
-  // deterministically instead — only return once GET /members returns
-  // 200 (channel in `seeded_channels` → 366 RPL_ENDOFNAMES landed, no
-  // NAMES in flight) AND the own nick is present, the exact signal #53
-  // asserts on. HTTP 204 (`:uninitialized`) = joined-but-pre-NAMES →
-  // keep polling. This hardens the settle for EVERY downstream spec,
-  // not just #53.
-  //
-  // 60 × 500ms = 30s budget for SpawnOrchestrator → IRC connect →
-  // SASL → autojoin → JOIN echo → 353/366 NAMES → members seeded.
-  // Empirically ~3-5s on a healthy testnet; the 30s ceiling absorbs
-  // upstream rate-limit penalties accumulated by prior specs' churn.
+  // If the spec failed mid-run the network may still be parked, and the
+  // testnet does not reset between specs. `settleNetworkAutojoin` is the
+  // reconnect + poll-until-NAMES-seeded ritual this spec originated; it moved
+  // to the fixtures in #1796 when a second network-parking spec needed it, and
+  // the whole argument (why `joined` is not enough, why 30s) lives on it.
   const vjt = specUser();
-  const { patchNetworkConnectionState } = await import("../fixtures/grappaApi");
-  await patchNetworkConnectionState(vjt.token, NETWORK_SLUG, {
-    connection_state: "connected",
-  }).catch(() => {});
-
-  const headers = { authorization: `Bearer ${vjt.token}` };
-  const channelsUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`;
-  const membersUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels/${encodeURIComponent(
-    SEED_CHANNEL,
-  )}/members`;
-  for (let attempt = 0; attempt < 60; attempt++) {
-    const res = await fetch(channelsUrl, { headers }).catch(() => null);
-    if (res?.ok) {
-      const channels = (await res.json()) as Array<{ name: string; joined: boolean }>;
-      const bofh = channels.find((c) => c.name === SEED_CHANNEL);
-      if (bofh?.joined) {
-        // 200 = members seeded (366 landed); 204 = joined-but-pre-NAMES.
-        const membersRes = await fetch(membersUrl, { headers }).catch(() => null);
-        if (membersRes?.status === 200) {
-          const { members } = (await membersRes.json()) as {
-            members: Array<{ nick: string }>;
-          };
-          if (members.some((m) => m.nick === specNick())) return;
-        }
-      }
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
+  await settleNetworkAutojoin(vjt.token, NETWORK_SLUG, SEED_CHANNEL, specNick());
 });
 
 test("CP19 T32 — /disconnect parks network + redirects to Home; Reconnect ungreys + autojoin restores channel", async ({

--- a/cicchetto/e2e/tests/issue1796-cycle-part-rejoin.spec.ts
+++ b/cicchetto/e2e/tests/issue1796-cycle-part-rejoin.spec.ts
@@ -1,0 +1,78 @@
+// #1796 — `/cycle [<channel>] [<message>]`: the CHANNEL bounce, irssi's CYCLE.
+//
+// Asserts the VISIBLE outcome of BOTH legs, in the window the operator typed
+// in: a PART line carrying the message they typed, then a second self-JOIN
+// line for the SAME channel, and a live sidebar row at the end.
+//
+// COUNTED, not merely matched. The testnet does not reset between specs and
+// the scrollback is persistent, so #spec-wN already carries at least one
+// self-JOIN line — and possibly several, since `cp15-b6-part-archive-rejoin`
+// parts and re-joins the same channel. Each assertion is therefore "one MORE
+// than the count this spec observed before it typed anything", which is
+// order-independent and survives `--repeat-each`.
+//
+// The message is a bare sigil-less word ON PURPOSE: it is the #1208 trap.
+// `/cycle brb` must part THIS window with the reason "brb" — not manufacture a
+// channel named `brb` — and the cure is that `/cycle` shares `/part`'s parser
+// arm rather than owning a second copy of the sigil rule. Under that
+// regression the DELETE and the JOIN both go to a phantom `brb`, so BOTH
+// counts below stay flat and both assertions fail. Asserting only the JOIN
+// would pass with the part leg aimed anywhere.
+//
+// FOCUS is part of what is asserted, implicitly and deliberately: parting the
+// focused window drops it from `channelsBySlug`, and selection.ts's UX-4
+// bucket E picker moves focus off it. Both locators read the VISIBLE
+// scrollback, so they only reach their counts once the join leg has put the
+// operator back in the channel — which is the behaviour `cycleCommand`
+// inherits from `joinCommand`.
+//
+// Cleanup: the spec's own end state IS the seed state (joined), so the
+// afterEach is defensive — it only matters if the run died between the legs.
+
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { joinChannel } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const CYCLE_MESSAGE = "brb";
+
+test.afterEach(async () => {
+  const vjt = specUser();
+  await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
+});
+
+test("#1796 — /cycle parts the current channel with its message, then rejoins it", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const selfJoins = page
+    .locator('[data-testid="scrollback-line"][data-kind="join"]')
+    .filter({ hasText: specNick() })
+    .filter({ hasText: CHANNEL });
+  const selfParts = page
+    .locator('[data-testid="scrollback-line"][data-kind="part"]')
+    .filter({ hasText: specNick() })
+    .filter({ hasText: CHANNEL })
+    .filter({ hasText: CYCLE_MESSAGE });
+
+  const joinsBefore = await selfJoins.count();
+  const partsBefore = await selfParts.count();
+
+  await composeSend(page, `/cycle ${CYCLE_MESSAGE}`);
+
+  // Leg 1 — the PART reached THIS channel and carried the typed message.
+  await expect(selfParts).toHaveCount(partsBefore + 1, { timeout: 20_000 });
+  // Leg 2 — the JOIN came back, to the same channel.
+  await expect(selfJoins).toHaveCount(joinsBefore + 1, { timeout: 20_000 });
+
+  // End state: a live sidebar row, not an archived one. `/cycle` that parts
+  // and fails to rejoin leaves the operator out of the channel with a green
+  // compose box, which is the failure mode worth naming.
+  const row = sidebarWindow(page, NETWORK_SLUG, CHANNEL);
+  await expect(row).toHaveCount(1, { timeout: 20_000 });
+  await expect(row.locator(".sidebar-window-greyed")).toHaveCount(0);
+});

--- a/cicchetto/e2e/tests/issue1796-reconnect-bounces-network.spec.ts
+++ b/cicchetto/e2e/tests/issue1796-reconnect-bounces-network.spec.ts
@@ -1,0 +1,95 @@
+// #1796 — `/reconnect [<network>] [<reason>]`: the NETWORK bounce, irssi's
+// RECONNECT. One verb where the operator used to type two, and the second of
+// those two made them spell out a slug the client already knew.
+//
+// What makes this spec discriminating is that BOTH legs leave a signal, and
+// neither signal is a transient the assertion has to catch mid-flight:
+//
+//   PARK — selection.ts's UX-4 bucket D redirects to Home the moment a
+//   network the operator is looking at transitions INTO `:parked`. That
+//   redirect is one-way: nothing sends them back. So "the operator ends on
+//   Home" is durable proof that the park leg fired, readable long after it
+//   did. A `/reconnect` that quietly skipped the park would leave the
+//   operator in the channel and this assertion fails.
+//
+//   UNPARK — the network ends CONNECTED, with NO click. That is the whole
+//   difference from `/disconnect` (cp15-b6-parked-disconnect-reconnect, which
+//   has to click the Home card's Reconnect chip to get here). A `/reconnect`
+//   that only parked would leave the section greyed and the parked card up.
+//
+// Deliberately NOT asserted: that the sidebar is greyed BETWEEN the legs. It
+// is, but only for as long as the bounce takes, and pinning a state the
+// implementation is racing to leave is how a spec becomes a flake detector for
+// testnet latency instead of a regression detector for this verb.
+//
+// Also not asserted: the reason reaching upstream as the QUIT message. It is
+// only visible to OTHER users on the channel, and the park-leg
+// `connection_state_reason` that IS visible here is cleared by the unpark leg
+// (`Networks.connect/1` clears the prior reason by contract). The reason
+// riding the park body is pinned in the unit suite instead
+// (compose.test.ts, "/reconnect <net> <reason> carries the reason into the
+// park leg only").
+//
+// Timeout: 90s. The body itself is seconds, but the afterEach settle polls up
+// to 30s for SpawnOrchestrator → connect → SASL → autojoin → NAMES, and the
+// bounce inside the body pays that cost once already.
+
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { settleNetworkAutojoin } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
+const BOUNCE_REASON = "rolling a fresh vhost";
+
+test.setTimeout(90_000);
+
+test.afterEach(async () => {
+  // The testnet does not reset between specs: if this spec died between the
+  // two legs the credential is left parked, which breaks every following spec
+  // that expects autojoin to be live. Same ritual, same 30s budget, as
+  // cp15-b6-parked-disconnect-reconnect — shared, not re-typed.
+  const vjt = specUser();
+  await settleNetworkAutojoin(vjt.token, NETWORK_SLUG, SEED_CHANNEL, specNick());
+});
+
+test("#1796 — /reconnect bounces the network end to end: parks, then comes back connected with no click", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, SEED_CHANNEL, { ownNick: specNick() });
+
+  const networkSection = page.locator(".sidebar-network-section", {
+    has: page.locator(".sidebar-network-header", { hasText: NETWORK_SLUG }),
+  });
+  const channelRow = sidebarWindow(page, NETWORK_SLUG, SEED_CHANNEL);
+
+  // Baseline: live network, live channel row, live compose.
+  await expect(networkSection).not.toHaveClass(/sidebar-network-greyed/);
+  await expect(channelRow.locator(".sidebar-window-greyed")).toHaveCount(0);
+
+  // The park leg unmounts the ComposeBox out from under the submit (bucket D
+  // redirects to Home, and Home renders no compose), so `expectUnmount` waits
+  // for the textarea-gone signal rather than for it to go empty.
+  await composeSend(page, `/reconnect ${NETWORK_SLUG} ${BOUNCE_REASON}`, { expectUnmount: true });
+
+  // PARK happened, and this is the durable evidence of it: the operator is on
+  // Home and stays there. Nothing in the unpark leg navigates back.
+  await expect(page.locator(".home-pane")).toHaveCount(1, { timeout: 15_000 });
+
+  // UNPARK happened, with no click anywhere: the network is connected again,
+  // so the greyed cascade is gone and no parked card is left on Home.
+  await expect(networkSection).not.toHaveClass(/sidebar-network-greyed/, { timeout: 30_000 });
+  await expect(
+    page.locator(".home-pane-network-row-parked", {
+      has: page.locator(".home-pane-network-slug", { hasText: NETWORK_SLUG }),
+    }),
+  ).toHaveCount(0, { timeout: 30_000 });
+
+  // A genuinely fresh session, not a row flipped in the DB: the respawned
+  // Session.Server ran its autojoin loop, so the seeded channel is back as a
+  // live (un-greyed) row.
+  await expect(channelRow).toHaveCount(1, { timeout: 30_000 });
+  await expect(channelRow.locator(".sidebar-window-greyed")).toHaveCount(0, { timeout: 30_000 });
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -3563,6 +3563,233 @@ describe("compose submit — T32 verbs", () => {
   });
 });
 
+// #1796 — /reconnect: the network bounce. Two PATCH legs on ONE slug, park
+// then connect, in that order and sequentially — the ordering is #282's
+// (`lib/reconnect.ts`: "the park must settle before the reconnect") and this
+// verb shares that file's `bounceNetwork` rather than re-deriving it.
+describe("compose submit — /reconnect (#1796)", () => {
+  const parkedCredential = {
+    network: "freenode",
+    nick: "vjt",
+    ident: null,
+    realname: null,
+    sasl_user: null,
+    auth_method: "sasl" as const,
+    auth_command_template: null,
+    autojoin_channels: [],
+    connection_state: "parked" as const,
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "",
+    updated_at: "",
+  };
+
+  // `Once`, twice, rather than a blanket `mockResolvedValue` — and the reason
+  // is not style. `clearAllMocks` in this file's `beforeEach` clears CALLS,
+  // not implementations, so a blanket stub set here outlives the describe and
+  // reaches the #1396 characterization table further down, silently repinning
+  // the `connect` and `disconnect` rows to whatever this block last left
+  // behind. Measured: it did, until this became `Once`. The call count is
+  // known exactly (a bounce is two PATCHes), which is the condition under
+  // which the one-shot form is safe — see the #1255 note above for the case
+  // where it is not.
+  const mockBothLegs = (api: typeof import("../lib/api")): void => {
+    vi.mocked(api.patchNetwork)
+      .mockResolvedValueOnce(parkedCredential)
+      .mockResolvedValueOnce(parkedCredential);
+  };
+
+  it("/reconnect bare parks THEN connects the active window's network", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    mockBothLegs(api);
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/reconnect");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    // Both legs AND their order: a bounce that connects before it parks is
+    // not a bounce, and asserting the two calls as a set would not say so.
+    expect(vi.mocked(api.patchNetwork).mock.calls).toEqual([
+      ["tok", "freenode", { connection_state: "parked" }],
+      ["tok", "freenode", { connection_state: "connected" }],
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("/reconnect <net> bounces the named slug, not the active one", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    mockBothLegs(api);
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/reconnect libera");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(api.patchNetwork).mock.calls).toEqual([
+      ["tok", "libera", { connection_state: "parked" }],
+      ["tok", "libera", { connection_state: "connected" }],
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  // The reason is the upstream QUIT message, so it rides the PARK leg — the
+  // leg that closes the socket. Putting it on the connect leg would send the
+  // operator's goodbye to nobody.
+  it("/reconnect <net> <reason> carries the reason into the park leg only", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    mockBothLegs(api);
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/reconnect libera rolling a fresh vhost");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(api.patchNetwork).mock.calls).toEqual([
+      ["tok", "libera", { connection_state: "parked", reason: "rolling a fresh vhost" }],
+      ["tok", "libera", { connection_state: "connected" }],
+    ]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  // A network that could not be parked must NOT be connected: the sequential
+  // await is what makes the half-bounce unreachable, and a `Promise.all` here
+  // would leave the operator's network in a state neither leg intended.
+  it("/reconnect does not run the connect leg when the park leg fails", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.patchNetwork).mockRejectedValueOnce(new api.ApiError(503, "too_many_sessions"));
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/reconnect libera");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(api.patchNetwork).mock.calls).toEqual([
+      ["tok", "libera", { connection_state: "parked" }],
+    ]);
+    expect(result).toMatchObject({
+      error: expect.stringMatching(/already at the session limit/i),
+    });
+  });
+
+  // A parked network has nothing to bounce, and the SHARED copy for
+  // `not_connected` ("isn't in a state to connect or disconnect right now")
+  // is wrong here in a way the operator cannot act on — it IS in a state to
+  // connect. Name the cure instead.
+  it("/reconnect on a network that is not connected names /connect as the cure", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.patchNetwork).mockRejectedValueOnce(new api.ApiError(400, "not_connected"));
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/reconnect libera");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(api.patchNetwork).mock.calls).toEqual([
+      ["tok", "libera", { connection_state: "parked" }],
+    ]);
+    expect(result).toEqual({
+      error: "/reconnect: libera is not connected — use /connect libera",
+    });
+  });
+});
+
+// #1796 — /cycle: the CHANNEL bounce (part then join), irssi's CYCLE. Nothing
+// network-scoped happens here; that is `/reconnect`'s job.
+describe("compose submit — /cycle (#1796)", () => {
+  it("/cycle bare parts THEN rejoins the submitting window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.postPart).mockResolvedValueOnce();
+    vi.mocked(api.postJoin).mockResolvedValueOnce();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/cycle");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postPart).toHaveBeenCalledWith("tok", "freenode", "#a", null);
+    expect(api.postJoin).toHaveBeenCalledWith("tok", "freenode", "#a", null);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("/cycle #chan <message> parts the named channel with the message, then rejoins it", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.postPart).mockResolvedValueOnce();
+    vi.mocked(api.postJoin).mockResolvedValueOnce();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/cycle #other brb");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postPart).toHaveBeenCalledWith("tok", "freenode", "#other", "brb");
+    expect(api.postJoin).toHaveBeenCalledWith("tok", "freenode", "#other", null);
+    expect(result).toEqual({ ok: true });
+  });
+
+  // The #1208 trap, end to end: the parser keeps `brb` as the message, and the
+  // JOIN leg is where a regression would SHOW — a phantom `brb` channel would
+  // be created here, not merely parsed. Asserting the part alone would pass
+  // with the join regressed.
+  it("/cycle with a sigil-less message cycles the current channel, not a phantom one", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.postPart).mockResolvedValueOnce();
+    vi.mocked(api.postJoin).mockResolvedValueOnce();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/cycle brb");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postPart).toHaveBeenCalledWith("tok", "freenode", "#a", "brb");
+    expect(api.postJoin).toHaveBeenCalledWith("tok", "freenode", "#a", null);
+    expect(result).toEqual({ ok: true });
+  });
+
+  // A part that failed leaves the operator IN the channel, so rejoining would
+  // be a second JOIN to a channel they never left — and on a +i channel it is
+  // the one that earns a 473. Sequential await, same rule as /reconnect.
+  it("/cycle does not join when the part fails", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.postPart).mockRejectedValueOnce(new api.ApiError(404, "not_found"));
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/cycle");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postJoin).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ error: expect.any(String) });
+  });
+
+  // `/part` tolerates a non-channel submitting window (its DELETE just fails
+  // server-side), but `/cycle` cannot: its second leg would JOIN whatever the
+  // window is named, manufacturing a channel out of `$server` or a peer nick.
+  // Refuse before either leg.
+  it("/cycle refuses a non-channel window instead of joining its name", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "bob");
+    compose.setDraft(k, "/cycle");
+    const result = await compose.submit(k, "freenode", "bob");
+
+    expect(api.postPart).not.toHaveBeenCalled();
+    expect(api.postJoin).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ error: expect.stringContaining("/cycle") });
+  });
+});
+
 // C2.2 / C4.3 — handler wiring for DM verbs.
 // /msg /query /q all open the query window AND switch focus (user-action).
 describe("compose submit — /query and /q DM verbs", () => {
@@ -5173,6 +5400,7 @@ const DISPATCH_CASE_LABELS = [
   "banlist",
   "connect",
   "ctcp",
+  "cycle",
   "deop",
   "devoice",
   "disconnect",
@@ -5206,6 +5434,7 @@ const DISPATCH_CASE_LABELS = [
   "query",
   "quit",
   "quote",
+  "reconnect",
   "recover",
   "rehash",
   "service-modal",
@@ -5304,6 +5533,14 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: SlashCommand["kind"]; draft: string
   { kind: "quote", draft: "/quote PING :x" },
   { kind: "connect", draft: "/connect libera" },
   { kind: "disconnect", draft: "/disconnect libera" },
+  // #1796 — the reason is NOT decoration here. Without it this row's effect
+  // signature is byte-identical to `disconnect`'s (the harness's rejecting
+  // `patchNetwork` stops the bounce after its park leg), and the net reported
+  // the two as an indistinguishable pair — a row that buys nothing. The reason
+  // rides the park body, so it is what tells them apart. Measured, not
+  // reasoned: the pair was in the snapshot until this word was added.
+  { kind: "reconnect", draft: "/reconnect libera bouncing" },
+  { kind: "cycle", draft: "/cycle #other brb" },
   { kind: "quit", draft: "/quit bye" },
   { kind: "recover", draft: "/recover libera" },
   { kind: "alias-define", draft: "/alias hi /msg bob $*" },
@@ -5404,12 +5641,12 @@ describe("#1396 — dispatch characterization over every arm", () => {
       misparsed,
     }).toMatchInlineSnapshot(`
       {
-        "arms": 60,
+        "arms": 62,
         "armsWithNoDraft": [],
         "draftsNamingNoArm": [],
         "duplicated": [],
         "misparsed": [],
-        "rows": 60,
+        "rows": 62,
       }
     `);
   });
@@ -5551,6 +5788,19 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "scrollback.sendMessage("freenode", "#a", "\\u0001VERSION\\u0001", {"kind":"ctcp","target":"bob"})",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
+        "cycle": {
+          "effects": [
+            "aliasList.aliases()",
+            "api.postJoin("tok", "freenode", "#other", null)",
+            "api.postPart("tok", "freenode", "#other", "brb")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+            "selection.setSelectedChannel({"networkSlug":"freenode","channelName":"#other","kind":"channel"})",
           ],
           "result": {
             "ok": true,
@@ -5927,6 +6177,16 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "ok": true,
           },
         },
+        "reconnect": {
+          "effects": [
+            "aliasList.aliases()",
+            "api.patchNetwork("tok", "libera", {"connection_state":"parked","reason":"bouncing"})",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "error": "You're already at the session limit for this network from this device. Disconnect first or open from a different device.",
+          },
+        },
         "recover": {
           "effects": [
             "aliasList.aliases()",
@@ -6191,7 +6451,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "aliasList.aliases()",
           "networks.networkIdBySlug("freenode")",
         ],
-        "arms": 60,
+        "arms": 62,
         "indistinguishablePairs": [
           [
             "ame",

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -512,6 +512,99 @@ describe("parseSlash — T32 verbs (/quit /disconnect /connect)", () => {
   });
 });
 
+// #1796 — the bounce pair, and they are scoped to DIFFERENT things on purpose:
+// `/reconnect` is NETWORK-scoped (park then unpark), `/cycle` is CHANNEL-scoped
+// (part then join). That is irssi's own split (`RECONNECT <tag>` /
+// `CYCLE [<channel>] [<message>]`) and cic, which is irssi-shaped, must not
+// invert it. Each verb therefore inherits the grammar of the verb it is the
+// round trip of — `/reconnect` from `/disconnect`, `/cycle` from `/part`.
+describe("parseSlash — /reconnect + /cycle (#1796)", () => {
+  it("/reconnect bare → network: null, reason: null", () => {
+    expect(parseSlash("/reconnect")).toEqual({
+      kind: "reconnect",
+      network: null,
+      reason: null,
+    });
+  });
+
+  it("/reconnect <netslug> → network: slug, reason: null", () => {
+    expect(parseSlash("/reconnect libera")).toEqual({
+      kind: "reconnect",
+      network: "libera",
+      reason: null,
+    });
+  });
+
+  it("/reconnect <netslug> <reason...> → network: slug, reason: rest of args", () => {
+    expect(parseSlash("/reconnect libera rolling a fresh vhost")).toEqual({
+      kind: "reconnect",
+      network: "libera",
+      reason: "rolling a fresh vhost",
+    });
+  });
+
+  // The first token is ALWAYS the slug, exactly as `/disconnect` reads it. A
+  // network name carries no sigil, so the channel heuristic below cannot apply
+  // here and the two verbs must not be "made consistent" with each other: an
+  // operator alternating between them would otherwise get a different answer
+  // to the same first word.
+  it("/reconnect reads its first token as a slug, never as a reason", () => {
+    expect(parseSlash("/reconnect brb")).toEqual({
+      kind: "reconnect",
+      network: "brb",
+      reason: null,
+    });
+  });
+
+  it("/cycle bare → channel: null, reason: null (the current window)", () => {
+    expect(parseSlash("/cycle")).toEqual({ kind: "cycle", channel: null, reason: null });
+  });
+
+  it("/cycle #chan → channel target, no message", () => {
+    expect(parseSlash("/cycle #grappa")).toEqual({
+      kind: "cycle",
+      channel: "#grappa",
+      reason: null,
+    });
+  });
+
+  it("/cycle #chan <message> → target plus the PART message", () => {
+    expect(parseSlash("/cycle #grappa brb")).toEqual({
+      kind: "cycle",
+      channel: "#grappa",
+      reason: "brb",
+    });
+  });
+
+  // The #1208 sigil rule, inherited: a first token without a channel sigil is
+  // the MESSAGE, not a target. `/cycle brb` must not manufacture a channel
+  // named `brb` — that is the exact defect #1208 fixed for `/part`, and a
+  // second verb with the same grammar is precisely how it would come back.
+  it("/cycle with a sigil-less first token is all message, not a target (#1208)", () => {
+    expect(parseSlash("/cycle brb")).toEqual({
+      kind: "cycle",
+      channel: null,
+      reason: "brb",
+    });
+  });
+
+  it("/cycle with a sigil-less multi-word message keeps the whole text (#1208)", () => {
+    expect(parseSlash("/cycle non trovo utili le bestemmie")).toEqual({
+      kind: "cycle",
+      channel: null,
+      reason: "non trovo utili le bestemmie",
+    });
+  });
+
+  it.each(["&local", "+modeless", "!safe"])("/cycle %s is a target, not a message", (chan) => {
+    expect(parseSlash(`/cycle ${chan} brb`)).toEqual({
+      kind: "cycle",
+      channel: chan,
+      reason: "brb",
+    });
+  });
+});
+
 describe("parseSlash — /away", () => {
   it("/away bare → unset explicit away", () => {
     expect(parseSlash("/away")).toEqual({ kind: "away", action: "unset" });
@@ -1768,6 +1861,26 @@ describe("parseSlash — network-advertised CHANTYPES (#1255)", () => {
   it("/part still recognises an advertised sigil", () => {
     expect(parseSlash("/part #italia bye", {}, HASH_ONLY)).toEqual({
       kind: "part",
+      channel: "#italia",
+      reason: "bye",
+    });
+  });
+
+  // #1796 — `/cycle` answers the per-network question the same way `/part`
+  // does, because it is the same arm. Pinned separately anyway: "they share an
+  // arm" is an implementation detail, and a future split that gave `/cycle` a
+  // hardcoded sigil class would pass every test above this one.
+  it("/cycle treats an unadvertised sigil as the start of the message", () => {
+    expect(parseSlash("/cycle &local bye", {}, HASH_ONLY)).toEqual({
+      kind: "cycle",
+      channel: null,
+      reason: "&local bye",
+    });
+  });
+
+  it("/cycle still recognises an advertised sigil", () => {
+    expect(parseSlash("/cycle #italia bye", {}, HASH_ONLY)).toEqual({
+      kind: "cycle",
       channel: "#italia",
       reason: "bye",
     });

--- a/cicchetto/src/lib/commands/network.ts
+++ b/cicchetto/src/lib/commands/network.ts
@@ -1,4 +1,5 @@
-import { patchNetwork } from "../api";
+import { ApiError, patchNetwork } from "../api";
+import { bounceNetwork } from "../reconnect";
 import type { CommandHandler } from "./context";
 
 /**
@@ -7,5 +8,41 @@ import type { CommandHandler } from "./context";
  */
 export const connectCommand: CommandHandler<"connect"> = async (cmd, ctx) => {
   await patchNetwork(ctx.token, cmd.network, { connection_state: "connected" });
+  return { ok: true };
+};
+
+/**
+ * #1796 — `/reconnect [network] [reason]`: bounce ONE network, park then
+ * unpark. Bare form resolves the active window's network, symmetric with
+ * `/disconnect`, so the two verbs an operator alternates between read their
+ * arguments the same way.
+ *
+ * The bounce itself is `lib/reconnect.ts`'s `bounceNetwork` — the same two-leg
+ * PATCH #282's vhost button drives, extracted rather than re-typed. That is
+ * also where the sequential ordering is decided and argued.
+ *
+ * NO confirmation modal, and that is #283 (2026-07-20) on record rather than
+ * an omission: DISCONNECT is the verb behind the #195 confirm, RECONNECT is
+ * the awaited PATCH, because it is trivially reversible. The error sink is the
+ * compose feedback seam (the shared catch in `compose.ts`), not a new alert.
+ *
+ * `not_connected` is re-copy'd rather than left to `friendlyApiError`: the
+ * shared line ("isn't in a state to connect or disconnect right now") is true
+ * of `/connect` and `/disconnect` but wrong here — a parked network IS in a
+ * state to connect, and the operator can act on being told so. Still an
+ * `{error}`: this does not silently fall through to the unpark leg, because
+ * "bounce" and "bring up" are different intentions and only the operator can
+ * say which one they meant.
+ */
+export const reconnectCommand: CommandHandler<"reconnect"> = async (cmd, ctx) => {
+  const targetSlug = cmd.network ?? ctx.networkSlug;
+  try {
+    await bounceNetwork(ctx.token, targetSlug, cmd.reason);
+  } catch (e) {
+    if (e instanceof ApiError && e.code === "not_connected") {
+      return { error: `/reconnect: ${targetSlug} is not connected — use /connect ${targetSlug}` };
+    }
+    throw e;
+  }
   return { ok: true };
 };

--- a/cicchetto/src/lib/commands/window.ts
+++ b/cicchetto/src/lib/commands/window.ts
@@ -1,6 +1,7 @@
 import { postJoin, postPart } from "../api";
 import { setQuery } from "../channelDirectory";
 import { canonicalChannel } from "../channelKey";
+import { isChannelName } from "../chantypes";
 import { networkIdBySlug } from "../networks";
 import { canonicalQueryNick, openQueryWindowState } from "../queryWindows";
 import { selectedChannel, setSelectedChannel } from "../selection";
@@ -75,6 +76,48 @@ export const joinCommand: CommandHandler<"join"> = async (cmd, ctx) => {
     kind: "channel",
   });
   return { ok: true };
+};
+
+/**
+ * #1796 — `/cycle [#chan] [message]`: part then join, and nothing else.
+ * irssi's CYCLE, and channel-scoped like irssi's (the NETWORK bounce is
+ * `/reconnect`, in `commands/network.ts`).
+ *
+ * Composed from the two handlers above rather than from two `post*` calls, so
+ * a step either verb grows later is inherited here instead of being forgotten
+ * here. The target is resolved ONCE and passed to both legs explicitly, which
+ * is also what stops `part`'s own `?? ctx.submittedFrom` fallback from
+ * answering a second time for the JOIN.
+ *
+ * SEQUENTIAL: the JOIN runs only if the PART resolved. A part that failed
+ * leaves the operator in the channel, so rejoining would be a JOIN to a
+ * channel they never left. Same rule, same reason, as `/reconnect`'s two legs.
+ *
+ * The guard has no `/part` twin and needs one here: `/part` in a non-channel
+ * window merely posts a DELETE the server refuses, whereas `/cycle`'s second
+ * leg would JOIN whatever the window is called — manufacturing a channel out
+ * of a peer nick or `$server`. Same family as the #1208 phantom, one layer
+ * down, so it is refused before either leg rather than after the first.
+ *
+ * FOCUS follows the join, inherited from `joinCommand` and wanted twice over:
+ * for `/cycle #other` it is what `/join #other` already does, and for the bare
+ * form it is the repair for a yank — parting the focused window drops it from
+ * `channelsBySlug`, and selection.ts's close-window picker (UX-4 bucket E)
+ * moves focus off it before the JOIN puts it back.
+ *
+ * NO key: irssi's grammar has no slot for one (`CYCLE [<channel>]
+ * [<message>]`), so a `+k` channel cannot be cycled from here. Named rather
+ * than papered over — `/part` + `/join #chan <key>` is the two-command form
+ * that still works.
+ */
+export const cycleCommand: CommandHandler<"cycle"> = async (cmd, ctx) => {
+  const target = cmd.channel ?? ctx.submittedFrom;
+  if (!isChannelName(target, ctx.sigils())) {
+    return { error: `/cycle: ${target} is not a channel — use /cycle <#channel> [message]` };
+  }
+  const parted = await partCommand({ kind: "part", channel: target, reason: cmd.reason }, ctx);
+  if ("error" in parted) return parted;
+  return await joinCommand({ kind: "join", channels: [target], key: null }, ctx);
 };
 
 /**

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -22,7 +22,7 @@ import {
   umodeTargetViewCommand,
   umodeViewCommand,
 } from "./commands/mode";
-import { connectCommand } from "./commands/network";
+import { connectCommand, reconnectCommand } from "./commands/network";
 import {
   banCommand,
   deopCommand,
@@ -63,7 +63,13 @@ import {
   recoverCommand,
 } from "./commands/session";
 import { topicClearCommand, topicSetCommand, topicShowCommand } from "./commands/topic";
-import { joinCommand, listCommand, partCommand, queryCommand } from "./commands/window";
+import {
+  cycleCommand,
+  joinCommand,
+  listCommand,
+  partCommand,
+  queryCommand,
+} from "./commands/window";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { type FramePreview, framePreview } from "./frameBudget";
 import { friendlyError } from "./friendlyError";
@@ -815,6 +821,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = await partCommand(cmd, ctx);
           break;
         }
+        // #1796 — the CHANNEL bounce. Its network sibling is `reconnect`.
+        case "cycle": {
+          result = await cycleCommand(cmd, ctx);
+          break;
+        }
         case "topic-show":
           return await topicShowCommand(cmd, ctx);
         case "topic-set": {
@@ -929,6 +940,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         }
         case "connect": {
           result = await connectCommand(cmd, ctx);
+          break;
+        }
+        // #1796 — the NETWORK bounce: the two arms above, as one verb.
+        case "reconnect": {
+          result = await reconnectCommand(cmd, ctx);
           break;
         }
         case "away": {

--- a/cicchetto/src/lib/reconnect.ts
+++ b/cicchetto/src/lib/reconnect.ts
@@ -36,10 +36,36 @@ import { networks } from "./networks";
 // abort the others (mirrors `quitAll`); failures are logged per-network,
 // then the FIRST is re-thrown so the caller can surface it (the button
 // renders `friendlyApiError`). A network whose park PATCH fails is never
-// reconnected (the sequential await short-circuits its `bounce`).
+// reconnected (the sequential await short-circuits its `bounceNetwork`).
 
-async function bounce(t: string, slug: string): Promise<void> {
-  await patchNetwork(t, slug, { connection_state: "parked" });
+/**
+ * Bounce ONE network: park it, then reconnect it. The two-leg PATCH itself,
+ * with no opinion about WHICH networks deserve it — that is the caller's.
+ *
+ * #1796 — exported, because the compose verb `/reconnect <slug>` is the same
+ * bounce aimed at one slug the operator named. It must not reach for
+ * `reconnectConnectedNetworks` below (that is the whole connected SET, the
+ * wrong one) nor for `lib/networkReconnect.ts` (#1331: the unpark leg alone,
+ * and shaped as a Solid hook for button surfaces).
+ *
+ * SEQUENTIAL, and that is the #282 decision this function was extracted from
+ * rather than a fresh one: "Each network's park→reconnect is sequential (the
+ * park must settle before the reconnect)". The park PATCH resolves only after
+ * the server has issued the upstream QUIT and stopped the session, so awaiting
+ * it is what keeps the connect leg from racing a socket that is still open.
+ *
+ * `reason` is the upstream QUIT message and therefore rides the PARK leg —
+ * the leg that closes the socket. `null` omits the key entirely, which is what
+ * the caller with nothing to say passes (the server then supplies its own
+ * `user-disconnect`); it is not a default this function chooses.
+ *
+ * A park that fails means the connect leg never runs: a network that could not
+ * be torn down must not be left half-bounced.
+ */
+export async function bounceNetwork(t: string, slug: string, reason: string | null): Promise<void> {
+  const park: { connection_state: "parked"; reason?: string } = { connection_state: "parked" };
+  if (reason !== null) park.reason = reason;
+  await patchNetwork(t, slug, park);
   await patchNetwork(t, slug, { connection_state: "connected" });
 }
 
@@ -49,7 +75,10 @@ export async function reconnectConnectedNetworks(): Promise<void> {
   const connected = (networks() ?? []).filter((n) => n.connection_state === "connected");
   if (connected.length === 0) return;
 
-  const results = await Promise.allSettled(connected.map((n) => bounce(t, n.slug)));
+  // No reason: the vhost bounce is not the operator saying goodbye to anyone,
+  // and this call has never sent one. The server's own `user-disconnect`
+  // stands in.
+  const results = await Promise.allSettled(connected.map((n) => bounceNetwork(t, n.slug, null)));
   const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
   for (const f of failures) {
     console.warn("[reconnect] bounce failed:", f.reason);

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -18,15 +18,18 @@ import { DEFAULT_CHANTYPES, isChannelName } from "./chantypes";
 // verb, message}` so the UI can render an inline error like
 // "unknown command: /whois" without losing what the user typed.
 //
-// T32 verbs — /quit /disconnect /connect:
+// T32 verbs — /quit /disconnect /connect, and #1796's /reconnect:
 //
-// `/disconnect [network] [reason]` heuristic: the first whitespace-
-// delimited token is ALWAYS treated as the network slug (no state
-// lookup, no ambiguity). Bare `/disconnect` (no args) returns
-// `network: null` so the handler resolves the active-window's network.
-// If the user wants a reason without specifying a network they must use
-// `/disconnect <activenet> reason` explicitly. This keeps the parser
-// pure (zero state dependency).
+// `/disconnect [network] [reason]` and `/reconnect [network] [reason]` share
+// ONE arm (`parseNetworkReason`) — see the comment there for the
+// first-token-is-always-the-slug heuristic and why it is not the sigil one.
+//
+// #1796 — the two BOUNCE verbs are scoped to different things, deliberately:
+// `/reconnect` bounces a NETWORK (park then unpark), `/cycle` bounces a
+// CHANNEL (part then join). That is irssi's own split — `RECONNECT <tag>` vs
+// `CYCLE [<channel>] [<message>]` — and cic, being irssi-shaped, must not
+// invert an irssi verb. `/cycle` shares `/part`'s arm (`parseChannelReason`),
+// which is what keeps the #1208 sigil rule from having to be remembered twice.
 //
 // S3.4 — /away verb:
 //
@@ -110,6 +113,13 @@ export type SlashCommand =
   | { kind: "amsg"; body: string }
   | { kind: "join"; channels: string[]; key: string | null }
   | { kind: "part"; channel: string | null; reason: string | null }
+  // #1796 — /cycle [<channel>] [<message>]: part then join, and nothing else.
+  // irssi's CYCLE, spelled the same way and scoped the same way (a CHANNEL,
+  // never a network — the network bounce is `reconnect` below). It carries
+  // `part`'s field names because the message IS the PART message and the two
+  // verbs share one parser arm; the operator-facing grammar keeps irssi's
+  // `[<message>]` spelling.
+  | { kind: "cycle"; channel: string | null; reason: string | null }
   | { kind: "topic-show"; channel: string | null }
   | { kind: "topic-set"; channel: string | null; text: string }
   | { kind: "topic-clear"; channel: string | null }
@@ -132,6 +142,12 @@ export type SlashCommand =
   | { kind: "quit"; reason: string | null }
   | { kind: "disconnect"; network: string | null; reason: string | null }
   | { kind: "connect"; network: string }
+  // #1796 — /reconnect [<network>] [<reason>]: park then unpark ONE network,
+  // the round trip `/disconnect` + `/connect` used to cost two commands (the
+  // second of which made the operator type a slug the client already knows).
+  // irssi's RECONNECT is network-scoped, so ours is too; the grammar is
+  // `disconnect`'s, verbatim, via the same parser arm.
+  | { kind: "reconnect"; network: string | null; reason: string | null }
   | { kind: "away"; action: "set"; reason: string }
   | { kind: "away"; action: "unset" }
   | { kind: "op"; nicks: string[] }
@@ -356,6 +372,66 @@ function parsePing(rest: string): SlashCommand {
   return { kind: "ping", target };
 }
 
+// #1208/#1796 — the `[<channel>] [<reason>]` grammar, shared by /part and its
+// round trip /cycle.
+//
+// #1208 — `/part <reason>` is the common form and it MUST NOT eat its first
+// word as a target. Pre-fix the first token was the channel unconditionally, so
+// `/part non trovo utili le bestemmie` issued a DELETE against a channel named
+// "non" and the operator was told "The request was malformed." about a name
+// they never typed.
+//
+// The sigil resolves the ambiguity, as it does in every other IRC client: a
+// first token carrying one of the network's advertised sigils (#1255) is the
+// target, anything else is the start of the reason and the target falls back to
+// the current window (in the handler).
+//
+// Deliberately NOT symmetric with `join`: /join auto-prepends `#` to a bare
+// name because a JOIN has no second meaning for its first token. /part does,
+// and so does /cycle, so the same sugar here is precisely what manufactures the
+// phantom channel.
+//
+// #1796 — ONE function rather than a second copy for /cycle, and that is the
+// point: the rule above is a rule about a grammar, not about a verb, and a
+// copy is how `/cycle brb` would have grown its own phantom `brb` channel while
+// every /part test stayed green.
+type ChannelReasonKind = "part" | "cycle";
+
+function parseChannelReason(
+  kind: ChannelReasonKind,
+  rest: string,
+  chantypes: readonly string[],
+): SlashCommand {
+  if (rest === "") return { kind, channel: null, reason: null };
+  const sp = rest.search(/\s/);
+  const first = sp === -1 ? rest : rest.slice(0, sp);
+  if (!isChannelName(first, chantypes)) return { kind, channel: null, reason: rest };
+  if (sp === -1) return { kind, channel: first, reason: null };
+  return { kind, channel: first, reason: rest.slice(sp + 1).trim() };
+}
+
+// T32/#1796 — the `[<network>] [<reason>]` grammar, shared by /disconnect and
+// /reconnect.
+//
+// The first whitespace-delimited token is ALWAYS the network slug (no state
+// lookup, no ambiguity). A bare form returns `network: null` so the handler
+// resolves the active window's network. A user who wants a reason without
+// naming a network must spell the network out (`/disconnect <activenet> ...`).
+// This keeps the parser pure (zero state dependency).
+//
+// NOT the sigil heuristic above, and the asymmetry is deliberate: a network
+// slug wears no sigil, so there is nothing to disambiguate it with. Sharing one
+// arm between the two network verbs is what keeps an operator from getting two
+// different answers to the same first word.
+type NetworkReasonKind = "disconnect" | "reconnect";
+
+function parseNetworkReason(kind: NetworkReasonKind, rest: string): SlashCommand {
+  if (rest === "") return { kind, network: null, reason: null };
+  const sp = rest.search(/\s/);
+  if (sp === -1) return { kind, network: rest, reason: null };
+  return { kind, network: rest.slice(0, sp), reason: rest.slice(sp + 1).trim() };
+}
+
 // Dispatch table: verb (lowercased) → handler(verb, rest) → SlashCommand.
 // Every registered verb must appear here; unknown verbs produce {kind: "error"}.
 // #1255 — handlers receive the network's advertised channel sigils as DATA,
@@ -432,29 +508,13 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
     return { kind: "join", channels, key };
   },
 
-  part: (_verb, rest, chantypes) => {
-    // #1208 — `/part <reason>` is the common form and it MUST NOT eat its
-    // first word as a target. Pre-fix the first token was the channel
-    // unconditionally, so `/part non trovo utili le bestemmie` issued a
-    // DELETE against a channel named "non" and the operator was told "The
-    // request was malformed." about a name they never typed.
-    //
-    // The sigil resolves the ambiguity, as it does in every other IRC
-    // client: a first token carrying one of the network's advertised sigils
-    // (#1255) is the target, anything else is the start of the reason and
-    // the target falls back to the current window (in compose.ts).
-    //
-    // Deliberately NOT symmetric with `join` above: /join auto-prepends `#`
-    // to a bare name because a JOIN has no second meaning for its first
-    // token. /part does, so the same sugar here is precisely what
-    // manufactures the phantom channel.
-    if (rest === "") return { kind: "part", channel: null, reason: null };
-    const sp = rest.search(/\s/);
-    const first = sp === -1 ? rest : rest.slice(0, sp);
-    if (!isChannelName(first, chantypes)) return { kind: "part", channel: null, reason: rest };
-    if (sp === -1) return { kind: "part", channel: first, reason: null };
-    return { kind: "part", channel: first, reason: rest.slice(sp + 1).trim() };
-  },
+  // The #1208 sigil rule lives on `parseChannelReason` — read it there, not
+  // here, and add nothing to this arm that /cycle should not inherit.
+  part: (_verb, rest, chantypes) => parseChannelReason("part", rest, chantypes),
+
+  // #1796 — /cycle is /part's round trip, so it is /part's grammar. The
+  // handler runs the second leg (the JOIN); the parser knows nothing about it.
+  cycle: (_verb, rest, chantypes) => parseChannelReason("cycle", rest, chantypes),
 
   topic: (_verb, rest, chantypes) => {
     // Context-aware /topic (issue #23):
@@ -563,16 +623,13 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
 
   quit: (_verb, rest) => ({ kind: "quit", reason: rest === "" ? null : rest }),
 
-  disconnect: (_verb, rest) => {
-    if (rest === "") return { kind: "disconnect", network: null, reason: null };
-    const sp = rest.search(/\s/);
-    if (sp === -1) return { kind: "disconnect", network: rest, reason: null };
-    return {
-      kind: "disconnect",
-      network: rest.slice(0, sp),
-      reason: rest.slice(sp + 1).trim(),
-    };
-  },
+  disconnect: (_verb, rest) => parseNetworkReason("disconnect", rest),
+
+  // #1796 — the round trip of `disconnect` + `connect`, as ONE verb. It takes
+  // `disconnect`'s grammar and not `connect`'s: the bare form must work, and
+  // the reason must have somewhere to go. `connect` keeps its slug requirement
+  // untouched.
+  reconnect: (_verb, rest) => parseNetworkReason("reconnect", rest),
 
   connect: (verb, rest) => {
     const [network] = tokens(rest);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -65123,3 +65123,133 @@ installed web app on iOS/iPadOS — which is a citation, not something measured.
 
 A WebKit bug report is the only road upstream, and filing it is a decision that
 belongs outside this repository. It is not blocked on anything here.
+<!-- entry #1796 -->
+
+---
+
+## 2026-08-26 — #1796: two bounce verbs, and the one that already existed
+
+`/reconnect [network] [reason]` and `/cycle [channel] [message]` land in cic's
+compose box. No wire change, no server change: `PATCH /networks/:slug` already
+does both legs of the network bounce, and `POST/DELETE` on the channel surface
+already do the channel one. `Grappa.Protocol`'s `protocol_version` is therefore
+untouched — nothing about the shape the server emits changed.
+
+### The names are irssi's, and the split is the load-bearing part
+
+The verb was first asked for as `/cycle`. That name is taken: irssi ships both,
+and they are scoped to different things — `CYCLE [<channel>] [<message>]` is
+part+join, `RECONNECT <tag> [<quit message>]` is the network. cic is
+irssi-shaped, so inverting an irssi verb would cost more than it buys. vjt
+ruled on #sbiffo (2026-08-25, peluche concurring): the network bounce is
+`/reconnect`, `/cycle` keeps its canonical meaning. Both shipped, because
+shipping only one leaves the other name free to be taken wrongly later.
+
+Each verb inherits the grammar of the verb it is the round trip of, and the two
+grammars are deliberately NOT unified: `/reconnect` reads its first token as a
+slug ALWAYS (`parseNetworkReason`, shared with `/disconnect`), because a network
+name wears no sigil and there is nothing to disambiguate it with; `/cycle` reads
+a first token without a channel sigil as the MESSAGE (`parseChannelReason`,
+shared with `/part`). Making them agree with each other would break whichever
+one lost.
+
+### The sigil rule is now a function, not a rule to remember
+
+#1208 fixed `/part non trovo utili le bestemmie` issuing a DELETE against a
+channel named `non`. `/cycle` has the same grammar, so a second copy of that
+arm is how the same defect comes back under a new verb — and worse, because
+`/cycle`'s second leg would JOIN the phantom rather than merely fail to part
+it. The two arms are one function now. That is the whole reason the extraction
+happened; it is not tidying.
+
+`/cycle` also carries a guard `/part` does not need: it refuses a non-channel
+submitting window instead of parting it. `/part` in a `$server` or query window
+merely posts a DELETE the server refuses, which is harmless; `/cycle` would go
+on to JOIN whatever the window is called. Same family as the #1208 phantom, one
+layer down.
+
+### Three things were already called "reconnect", and only one was the nucleus
+
+The interesting half of this issue was not writing the verbs. cic already had:
+
+- `lib/reconnect.ts` → `reconnectConnectedNetworks` (#282), the vhost bounce.
+  Right VERB, wrong SET — it bounces every `:connected` network in one go.
+  Calling it for `/reconnect <slug>` would be a bug wearing the name of a reuse.
+- `lib/networkReconnect.ts` → `createNetworkReconnect` (#1331), per-slug and
+  therefore the tempting one. Wrong LEG (unpark only, no park) and wrong SHAPE:
+  it is a Solid hook with a pending signal and an error sink, built for button
+  surfaces (`HomePane`, the greyed compose seam). A command handler is not a
+  component.
+- The `commands/` handlers the issue proposed writing.
+
+The reusable nucleus was INSIDE the first one: its private per-slug
+`bounce(t, slug)`, park-then-connect. That is now the exported
+`bounceNetwork(t, slug, reason)`, with `reconnectConnectedNetworks` passing
+`null` so its wire behaviour is byte-identical to before. The general rule the
+episode teaches: **when a second use case fits an existing verb but not its
+set, extract the nucleus — do not call the wrapper, and do not reach for the
+sibling module whose NAME matches better than its behaviour.**
+
+### The ordering was already decided; the latency is NOT measured
+
+The issue asked whether an immediate unpark races the upstream QUIT. #282 had
+already answered the shape of it, in `reconnect.ts`'s own comment: *"Each
+network's park→reconnect is sequential (the park must settle before the
+reconnect)"*. That precedent is followed and cited rather than re-derived.
+
+What the server code establishes, read end to end: `Networks.disconnect/2`
+issues the QUIT through `Session.send_quit/3`, which is a GenServer **call**
+into the live session and then into `IRC.Client` — so the bytes are on the
+socket before it returns — then `Session.stop_session/2` terminates the pid,
+and only then writes the DB transition and broadcasts. The PATCH response is
+written after all of that, and the unpark is a SECOND request the client issues
+only once the first resolved. So the two legs cannot overlap, and TCP orders
+the QUIT ahead of the FIN on the same connection.
+
+What is **NOT measured, and is not claimed**: whether the upstream ircd has
+finished PROCESSING that QUIT (releasing the nick) before the fresh
+registration reaches it. That is a property of the peer server under load, no
+number for it was taken here, and none is invented. The existing 433 nick
+ladder is what covers the case if it ever loses.
+
+### `not_connected` gets its own copy, and still fails
+
+`/reconnect` on a parked network surfaces
+`/reconnect: <slug> is not connected — use /connect <slug>` instead of the
+shared `friendlyApiError` line ("isn't in a state to connect or disconnect
+right now"), which is true of the other two verbs and wrong here — a parked
+network IS in a state to connect. It stays an error rather than falling through
+to the unpark leg: "bounce this" and "bring this up" are different intentions
+and only the operator can say which one they meant. Naming the cure costs one
+word of typing; guessing costs a network state they did not ask for.
+
+### The characterization net can be poisoned by a neighbour's mock
+
+Adding the two arms to #1396's dispatch net surfaced a trap worth recording.
+`compose.test.ts`'s `beforeEach` calls `vi.clearAllMocks()`, which clears CALLS
+and not IMPLEMENTATIONS — so a `mockRejectedValue` set by any test in the file
+outlives its describe and reaches the characterization table hundreds of lines
+below, repinning the `connect` and `disconnect` rows to whatever was left
+behind. Measured: the new `/reconnect` tests silently rewrote both rows'
+snapshotted result until they switched to the one-shot `Once` forms. The rule:
+**in this file, a stub whose call count is known exactly uses `Once`; a
+blanket stub must be restored explicitly** (the #1255 note already says the
+inverse case — do not use `Once` when the call count is uncertain).
+
+Two smaller notes. The net's own report caught that `/reconnect libera` and
+`/disconnect libera` produced identical effect signatures — the harness's
+rejecting `patchNetwork` stops the bounce after its park leg — so the fixture
+carries a reason, which rides the park body and is what tells them apart; a row
+that cannot be distinguished from its neighbour buys nothing. And the
+`settleNetworkAutojoin` ritual (reconnect, then poll until GET /members answers
+200 with the own nick present) moved from
+`cp15-b6-parked-disconnect-reconnect.spec.ts` into the e2e fixtures, because a
+second network-parking spec re-typing it is exactly how the subtle half of it —
+the 200-vs-204 distinction from #522 — gets dropped.
+
+### Known limit, named rather than papered over
+
+`/cycle` cannot rejoin a `+k` channel: irssi's grammar has no slot for a key
+(`CYCLE [<channel>] [<message>]`) and inventing one would make cic's verb
+something other than the verb it is named after. `/part` followed by
+`/join #chan <key>` is the two-command form that still works.


### PR DESCRIPTION
## What this adds

Two compose verbs, each on the grammar it round-trips, plus the e2e that
proves both legs of each.

**`/reconnect [<network>] [<reason>]`** — the NETWORK bounce (irssi's
`RECONNECT`). Park then unpark one network, with the reason riding the park
leg so it reaches upstream as the QUIT message. Bare form resolves the active
window's network from `ctx.networkSlug`, symmetric with `/disconnect`; the
parser stays state-free (both verbs share `parseNetworkReason`).

**`/cycle [<channel>] [<message>]`** — the CHANNEL bounce (irssi's `CYCLE`).
Part then join, and nothing else. Defaults to the active window's channel.

The naming follows the ruling in the issue: `CYCLE` is channel-scoped and
`RECONNECT` is network-scoped upstream, and cic does not invert an irssi verb.

### Reuse, not a third copy

`lib/reconnect.ts` already owned the park→unpark pair as a private `bounce`
helper for the #282 vhost re-roll. It is now `bounceNetwork(t, slug, reason)`,
exported, and `/reconnect` calls it. The existing caller passes `reason: null`,
which omits the key entirely, so its request body is byte-identical to before.
The two neighbours were deliberately NOT reused: `reconnectConnectedNetworks`
is the whole connected SET, and `lib/networkReconnect.ts` (#1331) is the unpark
leg alone, shaped as a Solid hook for button surfaces.

`/cycle` and `/part` now share ONE parser function (`parseChannelReason`). That
is the #1208 sigil rule honoured structurally rather than by remembering it: a
first token with no channel sigil is the REASON, not a channel, so `/cycle brb`
parses to `{channel: null, reason: "brb"}` instead of manufacturing a phantom
channel named `brb`.

## What the e2e covers

| spec | status |
|---|---|
| `issue1796-cycle-part-rejoin.spec.ts` (new) | both legs, COUNTED |
| `issue1796-reconnect-bounces-network.spec.ts` (new) | both legs |
| `cp15-b6-parked-disconnect-reconnect.spec.ts` (**modified**) | re-run |

`/cycle` asserts one MORE self-PART carrying the typed message and one MORE
self-JOIN for the same channel than the counts it observed before typing —
order-independent and `--repeat-each`-safe on a testnet that does not reset
between specs. Asserting only the JOIN would pass with the part leg aimed at a
phantom, so both counts are the discriminator.

`/reconnect` asserts the Home redirect (UX-4 bucket D, one-way and therefore
durable evidence the park leg fired) and then an un-greyed network plus a live
channel row with NO click — which is exactly what separates it from
`/disconnect`, whose spec has to click the Home card's Reconnect chip.

`cp15-b6-parked-disconnect-reconnect` is modified, not merely adjacent: its
40-line `afterEach` settle ritual moved to `e2e/fixtures/grappaApi.ts` as
`settleNetworkAutojoin` because the new `/reconnect` spec needs the same one.
The extraction is behaviour-preserving; the argument that makes it subtle (why
`joined` is not a sufficient signal, why the 200-vs-204 distinction, why 30s)
travelled with it.

## Gate provenance — which sha each was taken on

| gate | result | sha |
|---|---|---|
| `bun.sh run check` (5 stages) | **rc=0** | `4020862e` (post-rebase) |
| `bun.sh run test` (vitest) | **rc=0**, 323 files / **6374 passed** | `4020862e` (post-rebase) |
| `scripts/design-notes-gate.sh` | **rc=0**, 1 new entry, separator + marker present | `4020862e` (post-rebase) |
| `scripts/union-rebase.sh` | **rc=0**, `+130 -0 — contribution intact` | rebase `daccdd68` → `01ae3287` |
| **e2e full** `scripts/integration.sh` | **778 passed / 9 failed**, 58.8m | `7ec0ae44` (pre-rebase) |
| **e2e iso-rerun** of all 9 reds + the 3 specs above, `--repeat-each 3` | **rc=0, 96 passed / 0 failed** | `7ec0ae44` (pre-rebase) |
| **e2e post-rebase**, 3 specs + `_smoke` + `issue363-incognito`, `--repeat-each 2` | **rc=0, 14 passed** | `4020862e` (post-rebase) |

Every `rc=` read from the log FILE, never from a pipe tail and never from the
harness notification (which reported `exit code 0` for the run whose sentinel
file said `rc=1`).

### The 9 reds in the full run were the host, and it is measured, not asserted

None of the nine is an assertion about wrong content — every one is "it did not
happen in time". They split into two mechanisms, each with its own oracle:

**Provisioning starvation (5).** Against 710 measured provisionings with a
median `seed_ms` of **247 ms**, the failing specs rank **1st** (25 376 ms),
**8th**, **9th** and **21st**; the fifth got a server-side
`504 {"error":"autojoin_timeout"}` and emitted no cost line at all.
`cp15-b6-kicked-greyed-state` is arithmetic: `total_ms=27946` of a 30 000 ms
test budget leaves 2.05 s for the body.

**BEAM stalls (3).** The #1429 gap census recorded exactly three silences ≥10 s
on `grappa-test` in the whole 59-minute run — **32.9 s**, **16.3 s**, **31.4 s**
— and each lands on one of the three remaining reds, to the millisecond. m9's
own Playwright trace shows three boot fetches issued at `02:25:41.036` taking
**16 346 ms** each (`/service-worker.js` among them) while their burst-mates
finished in 1.7–9.4 ms, against a 10 s shell-ready budget.

**Controlled comparison.** Same commit, same specs, same stack, run again:
`gaps_ge_10=0`, `maxgap=4.8 s`, `dropped=0` — and all nine green, 3/3.

The branch changes **no `.ex` file**, so the BEAM under test is built from
`origin/main`'s server code; a branch that changes no server code cannot change
BEAM stall behaviour.

## Not claimed

- **No latency number for the QUIT race** the issue's closing note asks about.
  Established by reading the server: `Networks.disconnect/2` issues the QUIT
  through a GenServer *call* before returning, then stops the pid, then writes
  the transition — and the unpark is a second HTTP request the client issues
  only after the first resolved, so the two legs cannot overlap. NOT
  established: whether the peer ircd has finished *processing* that QUIT before
  the fresh registration arrives. The existing 433 nick ladder covers it if it
  loses.
- **The greyed sidebar between the two legs is not asserted.** It is observable,
  but only for as long as the bounce takes; pinning a state the implementation
  is racing to leave makes the spec a flake detector for testnet latency.
- **The reason reaching upstream as the QUIT text is not asserted end to end.**
  It is visible only to other users on the channel, and the park-leg
  `connection_state_reason` is cleared by the unpark leg by contract. Pinned in
  the unit suite instead, and the e2e comment says so out loud.
- **The FULL e2e suite has not run on the rebased head.** The 778/9 run and its
  96/96 iso-rerun were taken on `7ec0ae44`, before the rebase onto `01ae3287`.
  On the rebased head only a scoped run exists (14/14): the three specs above
  plus `_smoke` and `issue363-incognito` — the last chosen deliberately, because
  `origin/main` added `visitorExists` to the very fixture file this branch
  extends, and that merge is where a break would live. `cicchetto/src` is
  byte-identical across the rebase (`git diff --quiet` rc=0), so the vitest and
  biome/tsc greens carry over by construction; the rest of the e2e roster is
  CI's integration job, not a claim made here.
- **No mutant was built for the `/reconnect` spec's un-greyed assertion.**
  `expect(section).not.toHaveClass(/…greyed/)` would pass vacuously if the
  locator matched zero elements. Two things argue it does not — the class is
  live (`Sidebar.tsx:303`) and `cp15-b6-parked-disconnect-reconnect` asserts the
  POSITIVE greyed class on the same locator shape and is green — but "argues"
  is not "measured", and the spec has not been shown to go red against a
  `/reconnect` that only parks.

## Design calls that are reversible in one line

- **`/reconnect` on a parked network fails** with `use /connect <slug>` rather
  than falling through to the unpark leg. "Bounce this" and "bring this up" are
  different intentions and the client should not guess. irssi's `RECONNECT`
  *does* revive a disconnected server, so there is a real argument the other way.
- **`/cycle` moves focus to the channel it cycled**, inherited from
  `joinCommand`. For the bare form this is a repair: parting the focused window
  drops it from `channelsBySlug` and UX-4 bucket E moves focus off it.
- **`/cycle` cannot rejoin a `+k` channel** — irssi's grammar has no key slot.
  Named in the README row and in DESIGN_NOTES rather than silently absent.

Refs #1796.
