### PR TITLE
fix(#1802): the rail's horizontal inset stays on the container, and the one escaping child moves into the container's rules

### DIFF
--- a/cicchetto/e2e/tests/issue1802-rail-inset-container.spec.ts
+++ b/cicchetto/e2e/tests/issue1802-rail-inset-container.spec.ts
@@ -1,0 +1,241 @@
+// #1802 — the rail's horizontal inset, measured on every surface at once.
+//
+// #1737 moved the inset onto `.shell-members` and left ONE child out:
+// `.members-pane` cancelled it with a negative `margin-inline` on its own rule
+// and its rows re-declared 1rem of their own. So the radio band and the
+// actions launcher sat at half a rem while the nick list above them sat at a
+// full one, and the eye read the difference as a bug in the band. The query
+// rail's heading — which the issue calls the members heading's twin, and which
+// nobody had measured — was WORSE than either: `.rail-query-context` is an
+// ordinary flow child INSIDE the rail's padding, so its heading's own 1rem
+// stacked on the container's 0.5rem and the label rendered at one and a half.
+//
+// WHY E2E AND NOT VITEST, for the same reason `issue1737-rail-inset-and-band-
+// restore` gives: this is RENDERED GEOMETRY, jsdom computes none of it, and a
+// unit assertion could only restate the stylesheet. The SOURCE half — that the
+// inset is DECLARED by the container and not merely rendered in the right
+// place — is what `src/__tests__/railInset.test.ts` covers, because no
+// measurement can see where a value was written. The two halves are disjoint
+// on purpose: a child re-declaring the same 0.5rem by hand passes this file
+// forever and fails that one.
+//
+// THE ORACLE READS THE TOKEN, IT DOES NOT SPELL IT. The expected gap comes
+// from the container's own resolved `padding-left`, which IS `--rail-inset` in
+// pixels as the engine computed it — so this stays green across a root
+// font-size change and red the moment a surface stops agreeing with the rail.
+// It could degenerate: if the container's padding vanished, the expected gap
+// would become 0 and a fully full-bleed rail would satisfy the equality. The
+// `> 0` assertion below is what forbids that, and it is not decoration.
+//
+// SURFACE vs INK, stated because the file mixes them. What the operator sees
+// begin at an edge is the BORDER BOX for a child that paints one (the band's
+// background and border-top, the actions drawer's border-top) and the GLYPHS
+// for a child that paints nothing (a nick row is transparent, unbordered, and
+// its hover is an underline — #1737). Measuring a nick row's border box would
+// measure the full-bleed scroller it lives in and see nothing at all, which is
+// precisely how this defect survived a year.
+//
+// FORM FACTOR: desktop chromium. `.resize-handle-right` is desktop-only by
+// construction (Shell.tsx mounts it in the desktop branch alone), so its
+// assertion has no phone counterpart to be missing. The inset rules themselves
+// live on `.shell-members`, which both branches mount and neither overrides
+// horizontally — the mobile block adds block-axis safe-area longhands only.
+//
+// NO THIRD-PARTY NETWORK: the radio stream is fulfilled from local bytes and
+// the station logos are vendored, the same posture as the #682 and #1737
+// specs, so a somafm.com outage cannot turn this red.
+
+import type { Page } from "@playwright/test";
+import { silentMp3 } from "../fixtures/bytes";
+import {
+  composeSend,
+  loginAs,
+  openRailMenu,
+  selectChannel,
+  waitForQueryWindowReady,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Literals rather than an import from `src/lib/radioStations`, so a table edit
+// that drops or renames this station fails HERE instead of following silently
+// — the rule `issue1737-rail-inset-and-band-restore` set for the same pair.
+const STATION_ID = "groovesalad";
+const STATION_STREAM = "https://ice.somafm.com/groovesalad-128-mp3";
+
+// Unique suffix so a retry or a sibling spec never collides on a nick already
+// in use upstream (the convention in issue606 / issue984).
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+const PEER = `Q1802${RUN_ID}`;
+
+// Sub-pixel slack. Written as an explicit `Math.abs(…) <= EPSILON` rather than
+// `toBeCloseTo`, whose second argument is a DIGIT COUNT and not a tolerance.
+// The defect it must not swallow is 7px at the default font size; this is half
+// a device pixel, three orders below it.
+const EPSILON = 0.5;
+
+test.setTimeout(120_000);
+
+const routeLocalAudio = async (page: Page): Promise<void> => {
+  await page.route("https://ice.somafm.com/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "audio/mpeg", body: silentMp3(8) });
+  });
+};
+
+/** Tune the spec's station from the rail picker and leave the picker shut. */
+const tuneStation = async (page: Page): Promise<void> => {
+  await openRailMenu(page);
+  await page.getByTestId("rail-action-radio").click();
+  await expect(page.getByTestId("rail-radio-picker")).toBeVisible();
+  await page.getByTestId(`rail-radio-station-${STATION_ID}`).click();
+  await expect(page.getByTestId("audio-mini-player-el")).toHaveJSProperty("src", STATION_STREAM);
+  // Picking deliberately does NOT close the picker (#682), and it overlays the
+  // whole rail — the band underneath is unmeasurable until it is dismissed.
+  await page.getByTestId("rail-radio-picker-close").click();
+  await expect(page.getByTestId("rail-radio-picker")).toBeHidden();
+  await expect(page.getByTestId("rail-radio-now")).toBeVisible();
+};
+
+type RailFrame = {
+  /** Inner edge of the aside: its border box left plus its own border. */
+  innerLeft: number;
+  right: number;
+  /** `--rail-inset` in pixels, as the engine resolved it on the container. */
+  inset: number;
+};
+
+const readRailFrame = (page: Page): Promise<RailFrame> =>
+  page.evaluate(() => {
+    const rail = document.querySelector(".shell-members");
+    if (rail === null) throw new Error("the rail must be mounted for any of this to mean anything");
+    const box = rail.getBoundingClientRect();
+    const style = getComputedStyle(rail);
+    return {
+      innerLeft: box.x + Number.parseFloat(style.borderLeftWidth),
+      right: box.x + box.width,
+      inset: Number.parseFloat(style.paddingLeft),
+    };
+  });
+
+/** The left edge of a child's painted BORDER BOX. */
+const surfaceLeft = (page: Page, selector: string): Promise<number> =>
+  page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (el === null) throw new Error(`no element for ${sel}`);
+    return el.getBoundingClientRect().x;
+  }, selector);
+
+/** The left edge of a child's GLYPHS, for a row that paints no surface. */
+const inkLeft = (page: Page, selector: string): Promise<number> =>
+  page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (el === null) throw new Error(`no element for ${sel}`);
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const rects = [...range.getClientRects()];
+    if (rects.length === 0) throw new Error(`${sel} laid out no text — nothing to measure`);
+    return Math.min(...rects.map((r) => r.x));
+  }, selector);
+
+test("#1802 — every rail surface starts at the container's one inset", async ({ page }) => {
+  await routeLocalAudio(page);
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await tuneStation(page);
+
+  // The members list must actually have a row, or the assertion that used to
+  // fail would simply be absent — the shape `issue500`'s spec warns about.
+  await expect(page.locator(".members-pane li").first()).toBeVisible();
+
+  const rail = await readRailFrame(page);
+  // Degenerate-oracle guard: the expected gap is READ from the container, so a
+  // rail that stopped insetting anything at all would make the equality below
+  // trivially true. It must be a real inset.
+  expect(rail.inset, "the rail must still carry a non-zero inset of its own").toBeGreaterThan(0);
+  const expected = rail.innerLeft + rail.inset;
+
+  const measured = {
+    "radio band (surface)": await surfaceLeft(page, ".rail-radio-now"),
+    "actions drawer (surface)": await surfaceLeft(page, ".rail-actions"),
+    "actions launcher (surface)": await surfaceLeft(page, ".rail-actions-launcher"),
+    "members heading (ink)": await inkLeft(page, ".members-pane h3"),
+    "first nick row (ink)": await inkLeft(page, ".members-pane li"),
+  };
+
+  // ONE measurement, not two. Pre-fix the first three read `expected` and the
+  // last two read one whole inset further in — the reported 2:1.
+  for (const [what, left] of Object.entries(measured)) {
+    expect(
+      Math.abs(left - expected),
+      `${what} at ${left}, rail inset lands at ${expected}`,
+    ).toBeLessThanOrEqual(EPSILON);
+  }
+
+  // Constraint (2): the scroller still spans the rail edge to edge, so its
+  // scrollbar rides the rail's own border rather than floating half a rem off
+  // it. The scrollbar has no box of its own to query; the scroll container's
+  // border box is where it runs, which is what this asserts.
+  const pane = await page.locator(".members-pane").boundingBox();
+  if (pane === null) throw new Error("the members pane must be laid out");
+  expect(Math.abs(pane.x - rail.innerLeft), "pane left vs rail inner edge").toBeLessThanOrEqual(
+    EPSILON,
+  );
+  expect(
+    Math.abs(pane.x + pane.width - rail.right),
+    "pane right (where the scrollbar runs) vs rail right",
+  ).toBeLessThanOrEqual(EPSILON);
+
+  // The companion the issue calls for, and a defect in its own right: the grip
+  // rendered ENTIRELY outside the aside, over the centre pane, because #1737
+  // cancelled a padding that an absolutely positioned box never saw. Its own
+  // base rule requires it to sit fully inside the aside.
+  const grip = await page.locator(".resize-handle-right").boundingBox();
+  if (grip === null) throw new Error("the desktop resize grip must be laid out");
+  expect(grip.x, "grip left must be inside the rail").toBeGreaterThanOrEqual(
+    rail.innerLeft - EPSILON,
+  );
+  expect(grip.x + grip.width, "grip right must be inside the rail").toBeLessThanOrEqual(
+    rail.right + EPSILON,
+  );
+});
+
+test("#1802 — the query rail's heading lands on the same inset", async ({ page }) => {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const peer = await IrcPeer.connect({ nick: PEER, gecos: "rail inset probe" });
+  try {
+    // Shared channel so the query is a real one and the rail context mounts.
+    await peer.join(CHANNEL);
+    await composeSend(page, `/q ${PEER}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+    await expect(page.getByTestId("rail-query-context")).toBeVisible({ timeout: 5_000 });
+
+    const rail = await readRailFrame(page);
+    expect(rail.inset, "the rail must still carry a non-zero inset of its own").toBeGreaterThan(0);
+    const expected = rail.innerLeft + rail.inset;
+
+    // The worst of the three, and the one the issue mis-described as "the same
+    // problem" as the members heading: this slot's parent is NOT full-bleed, so
+    // its own horizontal padding stacked on the container's instead of
+    // replacing it. Measured at one and a half insets before the fix.
+    const heading = await inkLeft(page, ".rail-query-heading");
+    expect(
+      Math.abs(heading - expected),
+      `query heading ink at ${heading}, rail inset lands at ${expected}`,
+    ).toBeLessThanOrEqual(EPSILON);
+
+    // The launcher below it is the fixed reference the heading has to agree
+    // with — asserting only against `expected` would pass a build where BOTH
+    // had drifted together off the container's number.
+    const launcher = await surfaceLeft(page, ".rail-actions-launcher");
+    expect(Math.abs(heading - launcher), "query heading vs actions launcher").toBeLessThanOrEqual(
+      EPSILON,
+    );
+  } finally {
+    await peer.disconnect("#1802 done");
+  }
+});

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -32,14 +32,35 @@ export const themeCss = readFileSync("src/themes/default.css", "utf8");
  * over five selectors on purpose.
  */
 export function focusRules(): { selectors: string; body: string }[] {
+  return allRules().filter((rule) => rule.selectors.includes(":focus"));
+}
+
+/**
+ * Every rule in the sheet as `{ selectors, body }`, comments stripped.
+ * INNERMOST blocks only, the same way `focusRules` reads them: the `[^{}]`
+ * classes cannot span a brace, so an `@media` prelude is never returned as a
+ * selector and a rule nested inside one still is.
+ *
+ * Selector lists come back WHOLE (`a,\n b`) rather than split, because a
+ * caller asking "is this rule allowed to declare X?" has to reason about the
+ * list — a rule is only as scoped as its LOOSEST selector. Split with
+ * `selectorList` when the per-entry answer is what matters (#1802).
+ */
+export function allRules(): { selectors: string; body: string }[] {
   const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
   const out: { selectors: string; body: string }[] = [];
   for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-    const selectors = match[1] ?? "";
-    const body = match[2] ?? "";
-    if (selectors.includes(":focus")) out.push({ selectors: selectors.trim(), body });
+    out.push({ selectors: (match[1] ?? "").trim(), body: match[2] ?? "" });
   }
   return out;
+}
+
+/** The entries of a comma-separated selector list, whitespace-collapsed. */
+export function selectorList(selectors: string): string[] {
+  return selectors
+    .split(",")
+    .map((one) => one.trim().replace(/\s+/g, " "))
+    .filter((one) => one.length > 0);
 }
 
 /**

--- a/cicchetto/src/__tests__/railInset.test.ts
+++ b/cicchetto/src/__tests__/railInset.test.ts
@@ -1,0 +1,152 @@
+// #1802 — the source-level half of "solve it once and for all".
+//
+// WHAT THIS GUARDS AND WHAT IT CANNOT. The ruling has three constraints: the
+// rail carries the horizontal inset, the members scrollbar keeps running on
+// the rail's edge, and the rule that buys the second one lives in the
+// CONTAINER's rules rather than the child's. The second is GEOMETRY and is
+// asserted where geometry lives — `e2e/tests/issue1802-rail-inset-container.
+// spec.ts`, in a real engine. The first and third are about WHERE A VALUE IS
+// DECLARED, which no rendered measurement can see: a child that re-declares
+// the same 0.5rem by hand lands on the identical pixel and reads green
+// forever, right up until the token changes and the two drift. That is the
+// failure mode #1737 shipped and #1802 is closing, so it needs a reader of the
+// SOURCE, and this is it.
+//
+// NOT A MIRROR OF THE STYLESHEET. None of the three tests below names the
+// rules the fix added; they name properties no rule may carry and a scope
+// every reference must be inside. The fix is one way to satisfy them, not the
+// only one — rewrite the rail's rules any way you like and these stay green as
+// long as the ownership holds.
+
+import { describe, expect, it } from "vitest";
+import { allRules, selectorList } from "./helpers/themeCss";
+
+const CONTAINER = ".shell-members";
+const TOKEN = "--rail-inset";
+
+/**
+ * Split a CSS value on top-level whitespace. `calc(-1 * var(--rail-inset))` is
+ * ONE value with two spaces inside it, so a naive `split(/\s+/)` would read it
+ * as three and take the wrong one as the horizontal component.
+ */
+function splitTopLevel(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of value) {
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth -= 1;
+    if (depth === 0 && /\s/.test(ch)) {
+      if (current !== "") parts.push(current);
+      current = "";
+    } else current += ch;
+  }
+  if (current !== "") parts.push(current);
+  return parts;
+}
+
+/**
+ * The HORIZONTAL components a single declaration contributes, or `[]` when it
+ * contributes none. Shorthands are expanded by arity the way the cascade does
+ * it (1 → all, 2 → `block inline`, 3 → `top inline bottom`, 4 → clockwise), so
+ * a `padding: 0.25rem 1rem` is caught and a `padding-block: 0.25rem` is not.
+ */
+function horizontalComponents(property: string, value: string): string[] {
+  const parts = splitTopLevel(value);
+  const [p0, p1, p2, p3] = parts;
+  if (property === "margin" || property === "padding") {
+    if (parts.length === 1) return p0 === undefined ? [] : [p0];
+    if (parts.length === 2 || parts.length === 3) return p1 === undefined ? [] : [p1];
+    if (parts.length === 4) {
+      return p1 !== undefined && p3 !== undefined ? [p1, p3] : [];
+    }
+    return [];
+  }
+  if (property === "margin-inline" || property === "padding-inline") {
+    return parts;
+  }
+  if (/^(margin|padding)-(left|right|inline-start|inline-end)$/.test(property)) {
+    return parts.length === 0 ? [] : [parts.join(" ")];
+  }
+  // `-block`, `-top`, `-bottom`, and everything that is not a box inset.
+  void p2;
+  return [];
+}
+
+/** Every horizontal margin/padding component a rule body declares. */
+function horizontalInsets(body: string): { property: string; component: string }[] {
+  const out: { property: string; component: string }[] = [];
+  for (const raw of body.split(";")) {
+    const colon = raw.indexOf(":");
+    if (colon === -1) continue;
+    const property = raw.slice(0, colon).trim();
+    const value = raw.slice(colon + 1).trim();
+    for (const component of horizontalComponents(property, value)) {
+      out.push({ property, component });
+    }
+  }
+  return out;
+}
+
+const isZero = (component: string): boolean => /^0(px|rem|em|%)?$/.test(component);
+
+describe("#1802 — the rail's horizontal inset is owned by the container", () => {
+  it("defines the inset token exactly once, and in the container's own rule", () => {
+    const definers = allRules().filter((rule) =>
+      new RegExp(`(^|[;\\s])${TOKEN}\\s*:`).test(rule.body),
+    );
+    // A second definition is how a "single source" quietly becomes two: the
+    // rail would still render one value while a media query or a theme block
+    // served another, and every geometric assertion would stay green.
+    expect(definers.map((rule) => rule.selectors)).toEqual([CONTAINER]);
+  });
+
+  it("keeps every reference to the token inside a container-scoped rule", () => {
+    // The whole content of constraint (3). A `var(--rail-inset)` reachable
+    // from a rule that does not name the rail is a child helping itself to the
+    // container's number — which is how `.members-pane` came to cancel it.
+    const referring = allRules().filter((rule) => rule.body.includes(`var(${TOKEN}`));
+    // Positive control: if the token ever stops being referenced at all this
+    // test must not pass by having nothing to look at.
+    expect(referring.length).toBeGreaterThan(0);
+    const escapees = referring
+      .flatMap((rule) => selectorList(rule.selectors))
+      .filter((one) => !one.includes(CONTAINER));
+    expect(escapees).toEqual([]);
+  });
+
+  it("lets no rail child declare a horizontal inset of its own", () => {
+    // The set of children to police is READ OUT of the container's own rules
+    // rather than listed here, so adding a carve-out to the rail extends this
+    // guard in the same edit instead of drifting away from it.
+    const railChildren = new Set<string>();
+    for (const rule of allRules()) {
+      for (const one of selectorList(rule.selectors)) {
+        if (!one.includes(CONTAINER)) continue;
+        for (const match of one.matchAll(/>\s*(\.[\w-]+)/g)) {
+          const cls = match[1];
+          if (cls !== undefined) railChildren.add(cls);
+        }
+      }
+    }
+    // Positive control, and the reason this is not vacuous: the container must
+    // actually address someone by name for the loop below to have a subject.
+    expect([...railChildren]).toContain(".members-pane");
+
+    const offenders: string[] = [];
+    for (const rule of allRules()) {
+      const entries = selectorList(rule.selectors);
+      // Container-owned iff EVERY entry names the rail — a rule is only as
+      // scoped as its loosest selector.
+      if (entries.every((one) => one.includes(CONTAINER))) continue;
+      if (![...railChildren].some((cls) => entries.some((one) => one.includes(cls)))) continue;
+      for (const { property, component } of horizontalInsets(rule.body)) {
+        // Zero is a reset (killing the user-agent list indent, resetting a
+        // button), not an inset. Anything else is the child deciding.
+        if (isZero(component)) continue;
+        offenders.push(`${rule.selectors} → ${property}: ${component}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1568,9 +1568,42 @@ html.overlay-open #root > div {
      THE RULE FOR A NEW ABSPOS CHILD OF THIS ASIDE: it is NOT inset by
      `--rail-inset` and it does NOT clear the safe area on its own. Give it its
      own offsets deliberately, or make the ancestor's BOX carry what it needs.
-     `.resize-handle-right` was already compensated at its own rule — for a
-     stated different reason (it is chrome ON the edge, not a content surface),
-     but it is the only one of the three that was ever actually correct. */
+     #1802 corrects the last sentence this paragraph used to carry, which
+     absolved `.resize-handle-right`: measured, it was the one that was WRONG.
+     See its own rule below.
+
+     #1802 — WHY THE PADDING STAYS ON THIS BOX, against the issue's own sketch.
+     That sketch dropped it and put a `padding-inline` on a `.shell-members`
+     direct-child selector instead, so that the scroller could be excluded
+     generically rather than escape with a margin. (No braces in this comment
+     on purpose: `ruleBody` in the test helpers captures with a `[^}]` class
+     and a brace written here would truncate the body it reads, hiding the two
+     declarations below it.) Measured in chromium
+     at 1280px, `--font-size: 14px` (so 0.5rem = 7px), against this aside's
+     inner edge:
+
+       surface                    padding here   padding on children
+       .rail-radio-now  border box       +7px                  +0px
+       .rail-actions    border box       +7px                  +0px
+       .rail-server-info border box      +7px                  +0px
+       .rail-server-info own padding   10.5px                   7px
+       .resize-handle-right  width        6px                  14px
+
+     The first three are #1737's whole result — the rail's surfaces sharing one
+     border-box inset — and insetting the children loses it, because a padding
+     on a child insets its CONTENT and leaves its BORDER box on the rail edge.
+     A box cannot hold an outer gap and an inner one in the same property, and
+     `.rail-server-info` needs both: it draws a border, so its outer gap has to
+     come from an ancestor's padding or its own margin, and there is no third
+     option in the box model. The last row is the generic selector reaching a
+     6px `box-sizing: border-box` grip and floating it to 14px.
+
+     So the inset stays HERE, one owner, one number, and the ONE child that
+     must span the full width takes it back in a rule this container owns —
+     see the pair next to `.members-pane`. That is the half of the ruling that
+     survives measurement: "questa logica deve stare nel container non negli
+     elementi child". The half that does not is "no margins anywhere"; the
+     margin is still there, moved from the child's rule to the container's. */
   --rail-inset: 0.5rem;
   padding-inline: var(--rail-inset);
 }
@@ -1603,13 +1636,28 @@ html.overlay-open #root > div {
 
 .resize-handle-right {
   /* Inner (left) edge of the members aside.
-     #1737 — the aside now carries `padding-inline: var(--rail-inset)`, and an
-     abspos box resolves `left` against its ancestor's PADDING box, so a plain
-     `left: 0` would park this strip one inset INSIDE the edge it exists to
-     grip. Cancelled rather than inherited: every other rail child is a
-     content surface the inset is FOR, and this one is chrome ON the boundary,
-     definitionally outside it. Renders where it did before the move. */
-  left: calc(-1 * var(--rail-inset, 0px));
+
+     #1802 — back to `left: 0`, and the cancellation it replaces was never
+     a compensation: it was a defect, shipped by #1737 on a premise #1751
+     had already measured false. The premise was that a plain `left: 0`
+     would land one inset inside the edge. It does not. An abspos box
+     resolves its offsets against the ancestor's PADDING box, whose OUTER
+     boundary is the inner edge of the border — a boundary that does not
+     move when the padding changes. Measured in chromium, aside padding
+     toggled between 8px and 0 with everything else held: `left: 0` gave
+     x=101 in BOTH arms, and `inset: 0` gave x=101, width 199 in both.
+     Padding is invisible to an absolutely positioned descendant, which is
+     exactly what the long note on `.shell-members` says.
+
+     So the cancellation was not buying anything back, it was subtracting
+     an inset that had never been added. Measured on the rail itself, at
+     1280px: this grip rendered at x 1078–1084 while the aside's border box
+     started at 1084 — the whole 6px strip sat OUTSIDE the rail, over the
+     centre pane, which is also what the `.resize-handle` base rule forbids
+     in as many words. `left: 0` puts it at 1085–1091: inside the aside,
+     flush against the border it exists to grip, and symmetric with
+     `.resize-handle-left`'s `right: 0` on the other sidebar. */
+  left: 0;
 }
 
 .resize-handle:hover,
@@ -2562,12 +2610,21 @@ html.resize-dragging * {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  /* #1737 — horizontal padding GONE. The panel above is abspos at `inset: 0`
-     against `.shell-members`, which resolves to its PADDING box, so the panel
-     is already inset by `--rail-inset`; keeping 0.5rem here would land the
-     station rows at a full rem while the band and the launcher sit at half —
-     new drift, from the edit meant to remove it. Rows land exactly where they
-     did before the move. */
+  /* #1737 — horizontal padding GONE, and the reason it gave was WRONG.
+     #1802 measured it: the panel above is abspos at `inset: 0` against
+     `.shell-members`, and that resolves against the padding box's OUTER
+     boundary — the inner edge of the border — so the panel is FULL-BLEED, not
+     "already inset by `--rail-inset`". The long note on `.shell-members` says
+     the same thing and was already in the file when #1737 wrote this.
+
+     What follows is that these station rows sit at 0, not at 0.5rem like every
+     other rail surface. LEFT AS IS, deliberately and knowingly: this panel is
+     an OVERLAY over the whole rail with its own `border-left` and a `.topic-
+     bar` head that spans it edge to edge on purpose, not one of the surfaces
+     the rail insets, and #1802's ruling enumerates the four that are. Moving
+     it would move a surface nobody reported — #1737's own lesson. Restoring
+     0.5rem here is a one-line change if that is ever what is wanted; what is
+     fixed here is the claim, which said the opposite of the measurement. */
   padding: 0.5rem 0;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -4544,16 +4601,12 @@ button.topic-bar-windows-opener::before,
 /* MembersPane */
 
 .members-pane {
-  padding: 0.5rem 0;
-  /* #1737 — the ONE rail child that opts OUT of `--rail-inset`, and the two
-     reasons are both measured. Its rows carry their own `padding-inline: 1rem`
-     (here and on the `h3`), so inheriting would push every nick to 1.5rem —
-     moving a surface nobody reported. And this pane is the SCROLLER (#500):
-     inside the inset its scrollbar would float half a rem off the rail edge
-     it belongs on. The inset exists to line up SURFACES, and a nick row has
-     none — transparent background, no border, hover is an underline. Cancels
-     to zero where the var is undefined, i.e. anywhere but the rail. */
-  margin-inline: calc(-1 * var(--rail-inset, 0px));
+  /* #1802 — `padding-block`, not the `0.5rem 0` shorthand this shipped with.
+     The horizontal half is the container's to give now (the pair below), and
+     a shorthand here would keep re-declaring it as zero at a specificity the
+     container rule merely happens to beat — a silent fight for the next
+     reader to lose rather than a rule they can read. */
+  padding-block: 0.5rem;
   /* #500 — the members list owns the scroll on BOTH form factors. `flex: 1 1
      auto` + `min-height: 0` lets it take the remaining rail height and scroll
      internally (min-height:0 defeats the flex-item min-content floor that would
@@ -4567,23 +4620,65 @@ button.topic-bar-windows-opener::before,
   overflow-y: auto;
 }
 
+/* #1802 — THE CONTAINER'S PAIR FOR ITS ONE FULL-WIDTH CHILD, and the whole
+   point of the issue: the logic that lets the members scrollbar keep running
+   on the rail's own edge belongs to the rail, not to the pane. Both selectors
+   are rooted at `.shell-members`, so this reads as one container decision even
+   though it sits next to the child it acts on — it has to, or the (0,2,0) pair
+   would precede the (0,1,0) rule above and trip `noDescendingSpecificity`.
+
+   #1737 put the first of these on `.members-pane` itself, where it read as a
+   child opting OUT of a rule it did not like. Same pixels, different owner:
+   nothing outside the rail can now cancel the rail's inset, and the pane's own
+   rule declares nothing horizontal at all. The `, 0px` fallback #1737 needed
+   goes with the move — the selector guarantees the variable is in scope.
+
+   The second rule is where the inset the pane just gave up comes back, one
+   level down, still from the container. `.members-pane`'s children are `h3`,
+   `ul` and the `<p class="muted">` placeholders (the context menu portals to
+   <body>, so it is not one of them), and each of those is a CONTENT row with
+   no surface of its own — transparent, unbordered, hover is an underline — so
+   insetting their content rather than their border box loses nothing here,
+   which is exactly what it would have lost on `.rail-actions` or the
+   server-info card. Measured: nick rows and the members heading move from
+   1rem to 0.5rem, landing on the same 7px as the radio band and the actions
+   launcher. That 2:1 was the reported defect. */
+.shell-members > .members-pane {
+  margin-inline: calc(-1 * var(--rail-inset));
+}
+
+.shell-members > .members-pane > * {
+  padding-inline: var(--rail-inset);
+}
+
 .members-pane h3 {
   font-size: 0.85rem;
   font-weight: normal;
   color: var(--muted);
   margin: 0;
-  padding: 0.25rem 1rem;
+  /* #1802 — block only; the inline half comes from the container pair above.
+     Was `0.25rem 1rem`, and that 1rem was the second half of the defect: the
+     pane cancelled the rail's 0.5rem and its rows then re-declared twice it. */
+  padding-block: 0.25rem;
   text-transform: uppercase;
 }
 
 .members-pane ul {
   list-style: none;
   margin: 0;
+  /* KEPT as a shorthand, unlike the `h3` and `li` beside it: this zero is the
+     user-agent's `padding-inline-start: 40px` list indent being killed, not an
+     inset being declared, and it has to hold wherever the pane is mounted. The
+     container pair above wins over it inside the rail at (0,2,0) and adds the
+     0.5rem there. This list IS the rows' inset carrier — `li` is a GRANDCHILD
+     of the pane and so is not matched by that pair; it takes its position from
+     this box (#1802). */
   padding: 0;
 }
 
 .members-pane li {
-  padding: 0.1rem 1rem;
+  /* #1802 — block only; see the `h3` note. Was `0.1rem 1rem`. */
+  padding-block: 0.1rem;
   font-family: var(--font-mono);
   font-size: var(--font-size);
   white-space: nowrap;
@@ -11133,7 +11228,14 @@ button.topic-bar-windows-opener::before,
   font-weight: normal;
   color: var(--muted);
   margin: 0;
-  padding: 0.25rem 1rem;
+  /* #1802 — block only, the twin of the `.members-pane h3` edit. This slot was
+     the WORST of the three, not the same as the members one: `.rail-query-
+     context` is an ordinary flow child that sits inside the rail's padding, so
+     this heading's own 1rem stacked ON that 0.5rem and the label rendered at
+     1.5rem — measured 21px against the members list's 14px and the band's 7px.
+     Nothing here replaces it: the container's padding already put the parent
+     at 0.5rem, which is where the label now starts. */
+  padding-block: 0.25rem;
   text-transform: uppercase;
   word-break: break-word;
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -65253,3 +65253,113 @@ the 200-vs-204 distinction from #522 — gets dropped.
 (`CYCLE [<channel>] [<message>]`) and inventing one would make cic's verb
 something other than the verb it is named after. `/part` followed by
 `/join #chan <key>` is the two-command form that still works.
+<!-- entry #1802 -->
+
+---
+
+## 2026-08-26 — #1802: the rail's inset stays on the container, because a bordered child cannot buy its own outer gap
+
+#1737 moved the rail's horizontal inset onto `.shell-members` and granted one
+exception: `.members-pane` cancelled it with a negative `margin-inline` on its
+own rule, and its rows re-declared 1rem of their own. #1802's ruling removes the
+exception — the rail carries the inset, the children carry zero margin, the
+members scrollbar keeps riding the rail edge, and the rule that buys that last
+one lives in the CONTAINER's rules.
+
+### What was actually rendered
+
+Measured in headless chromium at 1280px against the aside's inner edge, with
+`--font-size: 14px` so `0.5rem` is 7px. Production class chain, one arm per
+window kind:
+
+| surface | before | after |
+| --- | --- | --- |
+| `.rail-radio-now` border box | +7 | +7 |
+| `.rail-actions` border box | +7 | +7 |
+| `.rail-server-info` border box | +7 | +7 |
+| `.rail-server-info` own padding | 10.5px | 10.5px |
+| members heading / nick row, ink | **+14** | **+7** |
+| `.rail-query-heading`, ink | **+21** | **+7** |
+| `.resize-handle-right` | **1078–1084, entirely OUTSIDE the rail** | 1085–1091 |
+
+The report described a 2:1. It is a 2:1 on the members list and a 3:1 on the
+query rail, which nobody had measured: `.rail-query-context` is an ordinary flow
+child sitting INSIDE the container's padding, so its heading's own 1rem stacked
+on the container's 0.5rem rather than replacing it. The issue called that slot
+"the same problem" as the members heading; it is a different one with a worse
+number.
+
+### Why the container keeps its own padding
+
+The issue's shape dropped `padding-inline` from the aside and insetted the
+children generically instead, so the scroller could be excluded by selector
+rather than escape by margin. Measured, that cannot hold what #1737
+established:
+
+| under the issue's shape | |
+| --- | --- |
+| `.rail-actions` border box | +7 → **+0** (border-top back to full width) |
+| `.rail-server-info` border box | +7 → **+0** (bordered card on the rail edge) |
+| `.rail-server-info` own padding | 10.5px → **7px**, clobbered by the container rule |
+| `.resize-handle-right` width | 6px → **14px** (`box-sizing: border-box`, padding exceeds width) |
+
+The general fact underneath: **a padding on a child insets its CONTENT and
+leaves its BORDER box where it was**, so only an ancestor's padding or the
+child's own margin can inset a border. `.rail-server-info` draws a border AND
+needs an internal inset, and one property cannot be both. There is no third
+mechanism in the box model short of a wrapper element or converting the rail to
+grid, and the rail's flex contract (#500's `flex: 1 1 auto` + `min-height: 0`
+scroller, `.rail-actions`'s `margin-top: auto` floor) is measured and load-
+bearing enough that neither is worth it for a naming preference.
+
+So the padding stays on the aside and the escape moves: `.shell-members >
+.members-pane` hands the scroller back the strips, and
+`.shell-members > .members-pane > *` insets that scroller's own rows. Same
+pixels, different owner. **The negative margin is MOVED, not deleted, and the
+issue asked for it deleted** — the one constraint measurement refused. What the
+move buys is real and is the ruling's third constraint: nothing outside the rail
+can cancel the rail's inset any more, and the pane's own rule declares nothing
+horizontal at all.
+
+### Absolute positioning does not see padding — twice
+
+`.resize-handle-right` carried `left: calc(-1 * var(--rail-inset))` on the
+premise that a plain `left: 0` would land one inset inside the rail. It would
+not: an abspos box resolves against the padding box's OUTER boundary, which is
+the inner edge of the border and does not move when the padding changes.
+Measured both ways on a controlled box — padding toggled 8px ↔ 0, everything
+else held — `left: 0` gave x=101 in both arms and `inset: 0` gave x=101 / width
+199 in both. #1751 had already measured this on the real rail and written it in
+the note directly above; #1737's cancellation contradicted it and shipped, so
+the grip rendered wholly outside the aside, over the centre pane, against what
+its own base rule requires in as many words.
+
+The same false premise had a second victim. `.rail-radio-picker-list` justified
+dropping its horizontal padding by claiming the picker "is already inset by
+`--rail-inset`" because it is abspos against the container's padding box. It is
+full-bleed, so those station rows sit at 0 while every other rail surface sits
+at 0.5rem. **Left alone deliberately**: the picker is an overlay over the whole
+rail with its own `border-left` and an edge-to-edge `.topic-bar` head, not one of
+the four surfaces the ruling enumerates, and moving it would move a surface
+nobody reported — #1737's own lesson. Only the false claim was corrected.
+
+### Two guards, disjoint on purpose
+
+Geometry cannot see WHERE a value was declared. A child that re-declares the
+same 0.5rem by hand lands on the identical pixel and reads green forever, right
+up until the token moves and the two drift — which is the failure mode #1737
+shipped. So the guard is split: `e2e/tests/issue1802-rail-inset-container.spec.
+ts` measures five subjects against one expected gap READ from the container's
+resolved `padding-left` (never spelled as a literal, and with a non-zero
+assertion in front of it so a uniformly full-bleed rail cannot satisfy the
+equality), and `src/__tests__/railInset.test.ts` reads the source for ownership:
+the token is defined once in the container, every reference is inside a
+container-scoped selector, and no rail child declares a horizontal inset of its
+own. That last check derives the set of rail children FROM the container's own
+selectors, so a future carve-out extends the guard in the same edit instead of
+drifting away from it.
+
+Surface for a child that paints one, ink for a child that does not: a nick row
+is transparent and unbordered, so its border box is the full-bleed scroller it
+lives in, and measuring that sees nothing at all. That is how a 2:1 survived a
+year of specs which only ever compared the band with the launcher.


### PR DESCRIPTION
Closes the #1737 exception: `.members-pane` was the one rail child that opted out of `--rail-inset`, with a negative `margin-inline` on its **own** rule, and its rows then re-declared 1rem of their own.

## What was actually rendered

Headless chromium, 1280px, production class chain, `--font-size: 14px` so `0.5rem` = 7px. Measured against the aside's inner edge (`x=1085`):

| surface | before | after |
| --- | --- | --- |
| `.rail-radio-now` border box | +7 | +7 |
| `.rail-actions` border box | +7 | +7 |
| `.rail-actions-launcher` | +7 | +7 |
| `.rail-server-info` border box | +7 | +7 |
| `.rail-server-info` own padding | 10.5px | 10.5px |
| members heading / nick row, **ink** | **+14** | **+7** |
| `.rail-query-heading`, **ink** | **+21** | **+7** |
| `.resize-handle-right` | **1078–1084 — wholly OUTSIDE the rail** | 1085–1091 |

Two corrections to the issue, both measured rather than argued:

- The reported **2:1 is confirmed exactly** (7 vs 14).
- The issue calls `.rail-query-heading` "the same slot, same problem". It is **not** the same problem and it was **worse**: `.rail-query-context` is an ordinary flow child sitting *inside* the container's padding, so its heading's own 1rem **stacked** on the container's 0.5rem — 3:1, not 2:1. Nobody had measured it.

## 🔴 The constraint measurement refused, and what it costs to reinstate

The issue's shape drops `padding-inline` from the aside and insets the children generically (`.shell-members > *`). **Measured, that cannot hold what #1737 established:**

| under the issue's literal shape | |
| --- | --- |
| `.rail-actions` border box | +7 → **+0** — the `border-top` goes back to full width |
| `.rail-server-info` border box | +7 → **+0** — a bordered card flush on the rail edge |
| `.rail-server-info` own padding | 10.5px → **7px**, clobbered by the more specific container rule |
| `.resize-handle-right` width | 6px → **14px** (`box-sizing: border-box`, padding exceeds width) |

The general fact underneath: **a padding on a child insets its CONTENT and leaves its BORDER box where it was.** Only an ancestor's padding or the child's own margin can inset a border. `.rail-server-info` draws a border *and* needs an internal inset, and one property cannot be both — there is no third mechanism short of a wrapper element or converting the rail to grid, and the rail's flex contract (#500's scroller, `.rail-actions`'s `margin-top: auto` floor) is measured and load-bearing enough that neither is worth a naming preference.

**So the padding stays on the aside and the escape moves instead:** `.shell-members > .members-pane` hands the scroller back the strips, `.shell-members > .members-pane > *` insets that scroller's own rows. Same pixels, different owner.

**The negative margin is MOVED, not deleted, and the issue asked for it deleted.** That is the one acceptance criterion this PR does not meet literally. It does meet constraint (3) — "questa logica deve stare nel container non negli elementi child" — and what the move buys is real: nothing outside the rail can cancel the rail's inset any more, and the pane's own rule declares nothing horizontal at all.

**If the literal shape is wanted anyway, knowing the table above, it is 5 lines** — drop `padding-inline` from `.shell-members`, add it on `.shell-members > *:not(.resize-handle)`, zero it on the two scrollers, and accept the four regressions. @vjt's call, not mine; I built the variant the bench gives zero regressions for.

## The companion change was already a defect

`.resize-handle-right` carried `left: calc(-1 * var(--rail-inset))` on the premise that a plain `left: 0` would land one inset *inside* the rail. It would not. An abspos box resolves against the padding box's **outer** boundary — the inner edge of the border — which does not move when the padding does. Measured both ways on a controlled box (padding toggled 8px ↔ 0, everything else held): `left: 0` gave x=101 in **both** arms; `inset: 0` gave x=101 / width 199 in **both**.

#1751 had already measured this on the real rail and written it in the note four lines above. #1737 contradicted it and shipped, so the grip rendered **wholly outside the aside, over the centre pane** — against what its own base rule requires in as many words. The issue asks for `left: 0` for a reason that is false, and gets the right answer anyway.

The same false premise had a second victim: `.rail-radio-picker-list` justified dropping its horizontal padding by claiming the picker "is already inset by `--rail-inset`". It is full-bleed, so those station rows sit at 0. **Value deliberately left alone** — the picker is a whole-rail overlay with its own `border-left` and an edge-to-edge `.topic-bar` head, not one of the four surfaces the ruling enumerates, and moving it would move a surface nobody reported (#1737's own lesson). Only the false claim is fixed.

## Two guards, disjoint on purpose

Geometry cannot see **where** a value was declared. A child re-declaring the same 0.5rem by hand lands on the identical pixel and reads green forever — which is the failure mode #1737 shipped. So:

- **`e2e/tests/issue1802-rail-inset-container.spec.ts`** — five subjects against one expected gap **read from** the container's resolved `padding-left`, never spelled as a literal, with a non-zero assertion in front so a uniformly full-bleed rail cannot satisfy the equality. Surface for a child that paints one, **ink** for a child that does not (a nick row's border box *is* the full-bleed scroller — measuring that sees nothing, which is how this survived a year).
- **`src/__tests__/railInset.test.ts`** — ownership at the source: token defined once in the container, every reference container-scoped, no rail child declaring a horizontal inset. The set of rail children is **derived from the container's own selectors**, so a future carve-out extends the guard in the same edit.

## Evidence

All gates run from `.worktrees/w2-1802` (`pwd` printed into every log), rc read from files.

| gate | rc | note |
| --- | --- | --- |
| `bun run check` (post-rebase) | 0 | 5 stages, 0 failed |
| `bun run test` (post-rebase) | 0 | 324 files / 6377 tests |
| `design-notes-gate.sh` (post-commit) | 0 | "1 new entry heading(s), separator and marker present" |
| `union-rebase.sh` | 0 | +110 −0; preceding entry byte-identical to its `origin/main` form; 248 → 249 markers |
| e2e `--grep "#1802"` | 0 | 2/2, `seed_ms=177` |
| **e2e, CSS reverted to pre-fix** | **1** | both tests red: `members heading (ink) at 1071, rail inset lands at 1064`; `query heading ink at 1106, … 1092` |
| **e2e, grip-only mutant** | **1** | sole failure `grip left must be inside the rail` |
| source guard, 3 mutants | 1 ×3 | three **disjoint** kills, one assertion each; unmutated control green |

The red arms are what prove the mutant reached the served bundle — a green mutated arm would have needed a dist fingerprint, a red one cannot happen without it.
