### PR TITLE
cic(#1805): pan the zoomed media-viewer image with the browser's own scroller

### DIFF
--- a/cicchetto/e2e/fixtures/bytes.ts
+++ b/cicchetto/e2e/fixtures/bytes.ts
@@ -1,3 +1,5 @@
+import { deflateSync } from "node:zlib";
+
 // Shared tiny-file byte fixtures for upload specs.
 //
 // 1×1 transparent RGBA PNG — VALID bytes (correct IDAT CRC), verified
@@ -36,4 +38,61 @@ export function silentMp3(frames: number): Buffer {
   const frame = Buffer.alloc(MP3_FRAME_BYTES);
   for (const [i, byte] of MP3_FRAME_HEADER.entries()) frame[i] = byte;
   return Buffer.concat(Array.from({ length: frames }, () => frame));
+}
+
+// #1805 — a PNG of a GIVEN SIZE, built rather than pasted, for the same reason
+// silentMp3 is built: a hex constant for anything bigger than a dot is
+// kilobytes of noise, and the size is the parameter that matters.
+//
+// Why it had to exist: TINY_PNG_HEX is 1×1, and the media viewer renders an
+// image at its intrinsic size capped by max-width/max-height — it never scales
+// UP. So on that constant the viewer's image is one pixel, and EVERY geometric
+// assertion about it (does zooming create a scrollable area, did the visible
+// portion move) is satisfied by a one-pixel answer whether or not the feature
+// works. A spec that needs to see the picture move needs a picture.
+//
+// Solid mid-grey RGB, no alpha, no ancillary chunks: the smallest thing the
+// server's fail-closed exiftool strip (#39) will accept, and the CRCs are
+// computed rather than transcribed, which is the failure mode that cost the
+// inline copies TINY_PNG_HEX replaced.
+const CRC_TABLE: number[] = Array.from({ length: 256 }, (_, n) => {
+  let c = n;
+  for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  return c >>> 0;
+});
+
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (const byte of buf) c = (CRC_TABLE[(c ^ byte) & 0xff] as number) ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const typed = Buffer.concat([Buffer.from(type, "ascii"), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(typed), 0);
+  return Buffer.concat([length, typed, crc]);
+}
+
+export function pngOfSize(width: number, height: number): Buffer {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // colour type 2 = truecolour RGB
+  // 10..12 = compression 0, filter 0, interlace 0 — already zeroed.
+
+  // One filter byte (0 = None) per scanline, then width RGB triples.
+  const stride = 1 + width * 3;
+  const raw = Buffer.alloc(stride * height, 0x80);
+  for (let y = 0; y < height; y++) raw[y * stride] = 0;
+
+  return Buffer.concat([
+    Buffer.from("89504e470d0a1a0a", "hex"),
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(raw)),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
 }

--- a/cicchetto/e2e/fixtures/mediaViewer.ts
+++ b/cicchetto/e2e/fixtures/mediaViewer.ts
@@ -55,7 +55,7 @@
 // boundary, not a gap: the thing they share is the DOOR, and they use it.
 
 import { expect, type Locator, type Page } from "@playwright/test";
-import { TINY_PNG_HEX } from "./bytes";
+import { pngOfSize, TINY_PNG_HEX } from "./bytes";
 import { mediaScrollbackRow, uploadViaPicker } from "./uploadJourney";
 
 // The accessible name MediaViewerModal renders (role=dialog + aria-label), and
@@ -128,9 +128,34 @@ export async function uploadImageAndGetLink(
   page: Page,
   fileName: string,
 ): Promise<{ slug: string; url: string; row: Locator; link: Locator }> {
+  return uploadPngAndGetLink(page, fileName, Buffer.from(TINY_PNG_HEX, "hex"));
+}
+
+// #1805 — the same journey with a picture that has a SIZE. Its own verb rather
+// than a `bytes` parameter on the one above, the same call the two openers make
+// at the top of this file: eight call sites want the dot and do not care, one
+// wants a measurable box and cares about nothing else, and a parameter at nine
+// sites is a thing a reviewer has to check nine times.
+//
+// Needed because the viewer never scales an image UP past its intrinsic size,
+// so on the 1×1 constant every geometric assertion is answered by one pixel
+// whether the feature works or not.
+export async function uploadSizedImageAndGetLink(
+  page: Page,
+  fileName: string,
+  size: { width: number; height: number },
+): Promise<{ slug: string; url: string; row: Locator; link: Locator }> {
+  return uploadPngAndGetLink(page, fileName, pngOfSize(size.width, size.height));
+}
+
+async function uploadPngAndGetLink(
+  page: Page,
+  fileName: string,
+  buffer: Buffer,
+): Promise<{ slug: string; url: string; row: Locator; link: Locator }> {
   const { slug, url } = await uploadViaPicker(
     page,
-    { name: fileName, mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
+    { name: fileName, mimeType: "image/png", buffer },
     { postTimeout: IMAGE_POST_TIMEOUT_MS },
   );
   const { row, link } = await mediaScrollbackRow(page, "📸", slug);

--- a/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
@@ -135,14 +135,29 @@ test("#1438 — mid-drag the modal moves by the finger's travel, centering intac
   expect(after - before).toBeCloseTo(90, 0);
 });
 
-test("@webkit #1438 — the viewer container is touch-action:none (iPhone 15)", async ({ page }) => {
+test("@webkit #1438 — the IMAGE viewer container re-opens the pan, and still dismisses (iPhone 15)", async ({
+  page,
+}) => {
   test.slow();
   const { viewer } = await openImageViewer(page);
 
-  // Declared on the CONTAINER, not the media element: the UA intersects
-  // touch-action down the ancestor chain, which is what makes a <video>
-  // dismissible on the same terms as an <img>. Reverting the rule turns this
-  // red — and nothing else in the suite would.
+  // 🔴 This assertion INVERTED at #1805, and the inversion is deliberate.
+  //
+  // Until then the container declared `touch-action: none` for every kind, and
+  // this spec pinned that on the real engine. #1805 gave the zoomed image a
+  // scroll container and re-opened the stream on the image variant
+  // (`.media-viewer-modal--zoomable`, the `--text` precedent from #1764 one
+  // issue along), because under the reading where the UA intersects
+  // touch-action all the way to the root a `none` up here closes the scroller
+  // underneath.
+  //
+  // What #1438 actually owns is unaffected, and is asserted by the two drag
+  // tests above rather than by this line: at fit there is nothing to scroll, so
+  // the browser starts no pan and the dismiss binder still receives every move
+  // (measured on the #1805 bench — 11 cancelable touchmoves out of 11, exactly
+  // as under `none`). The BASE rule is still `touch-action: none` and is pinned
+  // at source level in mediaViewerTouchAction.test.ts, which is where a
+  // <video>'s posture lives now.
   const touchAction = await viewer.evaluate((el) => getComputedStyle(el).touchAction);
-  expect(touchAction).toBe("none");
+  expect(touchAction).toBe("pan-x pan-y");
 });

--- a/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
+++ b/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
@@ -1,47 +1,68 @@
 // #213 — the media-viewer modal image must pinch-zoom + pan, and the gesture
 // must stay CONFINED to the viewer (no page-zoom, no body-scroll bleed).
+// #1805 — the PAN half is the browser's own scroller now; only the pinch is
+// still synthesized.
 //
-// WHY hand-rolled instead of native pinch: iOS-1 (2026-05-17) locked the app
-// viewport (`maximum-scale=1, user-scalable=no`) so cic feels like an app, not
-// a website — that kills the browser's native pinch app-wide with no
-// per-element opt-out. So the modal image synthesizes the gesture in JS
-// (lib/pinchZoom.ts geometry + element-level {passive:false} touch listeners in
-// MediaViewerModal's ZoomableImage) and applies a CSS `transform` to the <img>
-// alone. Element-scoped transform + preventDefault'd touchmove = the gesture
-// can't reach the page.
+// WHY the pinch is hand-rolled: iOS-1 (2026-05-17) locked the app viewport
+// (`maximum-scale=1, user-scalable=no`) so cic feels like an app, not a
+// website — that kills the browser's native pinch app-wide with no per-element
+// opt-out. So the modal image synthesizes it in JS (lib/pinchZoom.ts geometry +
+// element-level {passive:false} touch listeners in MediaViewerModal's
+// ZoomableImage) and applies a CSS `transform` to the <img> alone.
 //
-// TWO guards, one per what's provable where (issue123 precedent):
+// WHY the pan is NOT, since #1805: that lock governs PAGE ZOOM and says nothing
+// about element scrolling. Measured on a standalone chromium/iPhone-15 bench
+// through the real touch pipeline: an `overflow: auto` box scrolled 112px under
+// the lock against 128px without it, where the whole question was whether it
+// would be zero.
+//
+// FOUR guards, one per what is provable where:
 //
 //   1. WIRING (chromium, untagged): the synthesized pinch is wired end-to-end.
-//      A two-finger TouchEvent whose fingers move APART scales the <img>'s
-//      transform above 1; a single-finger touchmove is preventDefault'd (the
-//      confinement signal — `dispatchEvent` returns false iff a listener called
-//      preventDefault, a JS-level fact independent of `touch-action`, so it's
-//      deterministic in chromium even though synthetic events can't drive real
-//      pixel zoom). Chromium supports the Touch/TouchEvent constructors;
-//      webkit's are unreliable (feedback_playwright_webkit_not_ios_scroll).
+//      Chromium supports the Touch/TouchEvent constructors; webkit's are
+//      unreliable (feedback_playwright_webkit_not_ios_scroll).
+//   2. NON-CLAIM (chromium, untagged): a ONE-finger touchmove must come back
+//      un-prevented. This is the inverse of what #213 asserted, and it is the
+//      whole of #1805 at the JS layer — a blanket preventDefault leaves every
+//      other symptom in place while the browser simply never scrolls.
+//   3. GEOMETRY (chromium, untagged): a REAL one-finger drag, dispatched
+//      through chromium's own input pipeline over CDP rather than as a DOM
+//      event, moves the visible portion of the picture. Asserted as pixels of
+//      painted displacement, not as "the node exists".
+//   4. CSS CONTRACT + scrollable area (@webkit, iPhone 15): the declarations
+//      and the fact that zooming creates real overflow, on the engine this
+//      issue is actually about.
 //
-//   2. CSS CONTRACT (@webkit, iPhone 15): the zoomable image must be
-//      `touch-action: none` so the real target browser hands EVERY touch to our
-//      JS handlers instead of interpreting it as a scroll/zoom pan.
-//      getComputedStyle on the real webkit target (ux-6-a / issue123 guard-3
-//      precedent). Reverting the CSS turns this red.
-//
-// The pinch/pan PHYSICS (does it FEEL right on a real iPhone?) is a device
-// call — vjt dogfoods post-ship. The load-bearing geometry (clamp, pan bound,
-// scale ratio) is covered by the pinchZoom.ts unit tests (jsdom); these e2es
-// guard the DOM wiring + the CSS contract, not the physics.
+// 🔴 What NO leg here proves, and what therefore stays a dogfood call: the
+// touch DRAG itself on WebKit. Playwright's WebKit backend exposes
+// `Input.dispatchTapEvent` and nothing else for touch (playwright-core
+// wkInput.js), and `mouse.wheel` is refused outright in mobile WebKit, so there
+// is no way to drive a pan there — a zero from that engine would measure the
+// harness, not the product. Momentum, rubber-band, and whether iOS starts a
+// rubber-band before the dismiss binder's claim lands are all on a real phone.
 
-import type { Page } from "@playwright/test";
+import type { CDPSession, Page } from "@playwright/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
-import { openMediaViewerInPlace, uploadImageAndGetLink } from "../fixtures/mediaViewer";
+import { openMediaViewerInPlace, uploadSizedImageAndGetLink } from "../fixtures/mediaViewer";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-// Upload a tiny image and open it in the media viewer, then narrow to the
-// ZOOMABLE <img> — the element these three tests actually drive.
+// Big enough that the viewer renders a MEASURABLE box on both projects. The
+// shared 1×1 constant cannot be used for anything geometric: the viewer caps an
+// image with max-width/max-height and never scales one up, so on 1×1 every
+// assertion about displacement is answered by one pixel whether or not the
+// feature works (see uploadSizedImageAndGetLink).
+const IMAGE_SIZE = { width: 400, height: 300 };
+
+// Must match DOUBLE_TAP_MS in MediaViewerModal.tsx. Used only to SEPARATE two
+// attempts so they cannot pair into a spurious double-tap — it is the
+// protocol's own window, not a guess at how slow the machine is.
+const DOUBLE_TAP_MS = 300;
+
+// Upload an image and open it in the media viewer, then narrow to the ZOOMABLE
+// <img> and the scroller that now wraps it.
 //
 // The door itself (upload → anchor → in-place click → dialog visible) is
 // fixtures/mediaViewer.ts since #1441. The extra barrier below stays here: it
@@ -55,12 +76,71 @@ async function openImageViewer(page: Page) {
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const { link } = await uploadImageAndGetLink(page, "x213.png");
+  const { link } = await uploadSizedImageAndGetLink(page, "x213.png", IMAGE_SIZE);
   const viewer = await openMediaViewerInPlace(page, link);
 
   const img = viewer.locator(".media-viewer-media--zoomable");
   await expect(img).toBeVisible({ timeout: 5_000 });
-  return { viewer, img };
+  const scroller = viewer.locator(".media-viewer-zoom-scroller");
+  await expect(scroller).toBeVisible({ timeout: 5_000 });
+  return { viewer, img, scroller };
+}
+
+// Chromium's real input pipeline. `Emulation.setTouchEmulationEnabled` rather
+// than a `test.use({ hasTouch: true })` on the project: the context options
+// stay exactly what every other chromium spec boots with, so nothing about the
+// app's own startup changes to serve this one file.
+async function touchPipeline(page: Page): Promise<CDPSession> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 2 });
+  return cdp;
+}
+
+async function cdpTap(cdp: CDPSession, x: number, y: number): Promise<void> {
+  const point = [{ x, y, radiusX: 8, radiusY: 8, force: 1, id: 1 }];
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: point });
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+}
+
+// Drag one finger from (x, y) upward by `dy`, in steps, through the browser's
+// own gesture recogniser.
+async function cdpDragUp(cdp: CDPSession, page: Page, x: number, y: number, dy: number) {
+  const point = (at: number) => [{ x, y: at, radiusX: 8, radiusY: 8, force: 1, id: 1 }];
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: point(y) });
+  for (let moved = 10; moved <= dy; moved += 10) {
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchMove", touchPoints: point(y - moved) });
+    await page.waitForTimeout(16);
+  }
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+}
+
+// Where the picture is PAINTED, relative to the scroller's own frame. This is
+// the geometric oracle: with `transform-origin: 0 0` the painted top sits at
+// exactly minus the scroll offset, so it moves if and only if the scroller
+// really panned. Reading `scrollTop` alone would pass on a scroller that
+// scrolls nothing visible.
+async function paintedOffset(page: Page): Promise<{ dx: number; dy: number; scrollTop: number }> {
+  return page.evaluate(() => {
+    const scroller = document.querySelector(".media-viewer-zoom-scroller");
+    const img = document.querySelector(".media-viewer-media--zoomable");
+    if (scroller === null || img === null) throw new Error("zoomable image gone");
+    const s = scroller.getBoundingClientRect();
+    const i = img.getBoundingClientRect();
+    return { dx: i.left - s.left, dy: i.top - s.top, scrollTop: scroller.scrollTop };
+  });
+}
+
+async function zoomState(page: Page) {
+  return page.evaluate(() => {
+    const scroller = document.querySelector(".media-viewer-zoom-scroller");
+    const img = document.querySelector(".media-viewer-media--zoomable");
+    if (scroller === null || img === null) throw new Error("zoomable image gone");
+    return {
+      scale: new DOMMatrixReadOnly(getComputedStyle(img).transform).a,
+      scrollHeight: scroller.scrollHeight,
+      clientHeight: scroller.clientHeight,
+    };
+  });
 }
 
 test("#213 — a synthesized two-finger pinch scales the modal image (chromium)", async ({
@@ -105,46 +185,150 @@ test("#213 — a synthesized two-finger pinch scales the modal image (chromium)"
   expect(scaledUp).toBeGreaterThan(1.5);
 });
 
-test("#213 — a touchmove on the modal image is preventDefault'd (confined to the viewer, chromium)", async ({
+test("#1805 — a ONE-finger touchmove on the modal image is NOT claimed (chromium)", async ({
   page,
 }) => {
   test.slow();
   const { img } = await openImageViewer(page);
 
-  // A single-finger touchmove must be claimed (preventDefault) so the gesture
-  // can never bleed to a page pan/zoom. dispatchEvent returns false iff a
-  // listener called preventDefault on a cancelable event.
-  const prevented = await img.evaluate((el) => {
-    const touch = (x: number) => new Touch({ identifier: 1, target: el, clientX: x, clientY: 200 });
-    const fire = (type: "touchstart" | "touchmove", x: number): boolean => {
-      const t = touch(x);
-      return el.dispatchEvent(
+  // Until #1805 EVERY cancelable touchmove was preventDefault'd, which is what
+  // kept the browser from scrolling. `dispatchEvent` returns false iff a
+  // listener called preventDefault — a JS-level fact independent of
+  // `touch-action`, so it is deterministic in chromium even though a synthetic
+  // event cannot drive a real pixel scroll.
+  //
+  // Both branches in one evaluate, because the interesting assertion is the
+  // CONTRAST: two fingers still ours, one finger the browser's. A spec that
+  // only checked the one-finger case would go green on a component that had
+  // stopped claiming anything at all, pinch included.
+  const claims = await img.evaluate((el) => {
+    const touch = (x: number, id: number) =>
+      new Touch({ identifier: id, target: el, clientX: x, clientY: 200 });
+    const fire = (type: "touchstart" | "touchmove", touches: Touch[]): boolean =>
+      el.dispatchEvent(
         new TouchEvent(type, {
           bubbles: true,
           cancelable: true,
-          touches: [t],
-          targetTouches: [t],
-          changedTouches: [t],
+          touches,
+          targetTouches: touches,
+          changedTouches: touches,
         }),
       );
-    };
-    fire("touchstart", 200);
-    const notPrevented = fire("touchmove", 260);
-    return !notPrevented;
+    fire("touchstart", [touch(200, 1)]);
+    const oneFinger = !fire("touchmove", [touch(260, 1)]);
+    fire("touchstart", [touch(150, 1), touch(250, 2)]);
+    const twoFingers = !fire("touchmove", [touch(100, 1), touch(300, 2)]);
+    return { oneFinger, twoFingers };
   });
 
-  expect(prevented).toBe(true);
+  expect(claims.oneFinger).toBe(false);
+  expect(claims.twoFingers).toBe(true);
 });
 
-test("@webkit #213 — the zoomable modal image is touch-action:none (iPhone 15)", async ({
+test("#1805 — a real one-finger drag moves the visible portion of the zoomed image (chromium)", async ({
   page,
 }) => {
   test.slow();
-  const { img } = await openImageViewer(page);
+  const { scroller } = await openImageViewer(page);
+  const cdp = await touchPipeline(page);
 
-  // The load-bearing CSS contract: `touch-action: none` reclaims the raw touch
-  // stream for our JS pinch handlers on the real webkit target. Reverting it
-  // turns this red.
-  const touchAction = await img.evaluate((el) => getComputedStyle(el).touchAction);
-  expect(touchAction).toBe("none");
+  const box = await scroller.boundingBox();
+  if (box === null) throw new Error("scroller has no box");
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  // Double-tap to 2×. Bounded retry rather than one attempt: the pairing window
+  // is 300ms of wall clock and a loaded CI box can miss it. A missed attempt
+  // leaves the scale AT 1, so the loop cannot overshoot, and the wait between
+  // attempts is the window itself so two attempts can never pair with each
+  // other.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if ((await zoomState(page)).scale > 1) break;
+    await cdpTap(cdp, cx, cy);
+    await cdpTap(cdp, cx, cy);
+    await page.waitForTimeout(DOUBLE_TAP_MS + 100);
+  }
+
+  // PRECONDITION, and the load-bearing half of #1805: a CSS transform does not
+  // change layout, so without the sizer the scaled image would create no
+  // overflow at all and there would be nothing for any drag to move. Asserted
+  // before the gesture (anti-hollow-green) — if this is an equality the test
+  // that follows is measuring nothing.
+  const zoomed = await zoomState(page);
+  expect(zoomed.scale).toBeGreaterThan(1.5);
+  expect(zoomed.scrollHeight).toBeGreaterThan(zoomed.clientHeight + 50);
+
+  const before = await paintedOffset(page);
+  await cdpDragUp(cdp, page, cx, cy, 80);
+  const after = await paintedOffset(page);
+
+  // The picture moved UP by the distance the scroller scrolled: painted
+  // displacement and scroll offset are the same number seen twice, and
+  // asserting both is what separates "the scroller moved" from "the reader saw
+  // a different part of the picture".
+  expect(after.scrollTop).toBeGreaterThan(before.scrollTop);
+  expect(after.dy).toBeLessThan(before.dy - 20);
+  expect(Math.abs(after.dy + after.scrollTop)).toBeLessThan(2);
+});
+
+test("@webkit #1805 — the zoomable modal image and its scroller declare the pan (iPhone 15)", async ({
+  page,
+}) => {
+  test.slow();
+  const { img, scroller } = await openImageViewer(page);
+
+  // The load-bearing CSS contract, on the real webkit target. `none` on the
+  // <img> — the pre-#1805 value — closes the scroller that wraps it, because
+  // the UA intersects touch-action from the HIT TARGET up to the scroll
+  // container: measured on the bench at 0px against 130px. Reverting either
+  // declaration turns this red.
+  expect(await img.evaluate((el) => getComputedStyle(el).touchAction)).toBe("pan-x pan-y");
+  expect(await img.evaluate((el) => getComputedStyle(el).transformOrigin)).toBe("0px 0px");
+  const style = await scroller.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { touchAction: s.touchAction, overflowY: s.overflowY, overscroll: s.overscrollBehaviorY };
+  });
+  expect(style.touchAction).toBe("pan-x pan-y");
+  expect(style.overflowY).toBe("auto");
+  expect(style.overscroll).toBe("contain");
+});
+
+test("@webkit #1805 — zooming creates a real scrollable area, and scrolling moves the picture (iPhone 15)", async ({
+  page,
+}) => {
+  test.slow();
+  const { scroller } = await openImageViewer(page);
+
+  const box = await scroller.boundingBox();
+  if (box === null) throw new Error("scroller has no box");
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  // Real taps: `page.touchscreen.tap` is `Input.dispatchTapEvent`, which is the
+  // ONE touch verb Playwright's WebKit backend exposes. Same bounded-retry
+  // reasoning as the chromium leg.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if ((await zoomState(page)).scale > 1) break;
+    await page.touchscreen.tap(cx, cy);
+    await page.touchscreen.tap(cx, cy);
+    await page.waitForTimeout(DOUBLE_TAP_MS + 100);
+  }
+
+  const zoomed = await zoomState(page);
+  expect(zoomed.scale).toBeGreaterThan(1.5);
+  // The whole point of the sizer, on the engine the issue is about: a transform
+  // alone leaves scrollHeight === clientHeight and there is nothing to pan.
+  expect(zoomed.scrollHeight).toBeGreaterThan(zoomed.clientHeight + 50);
+
+  // The DRAG cannot be driven here (see the header), so what is asserted is the
+  // consequence a drag would produce: the scroller is real, and moving it moves
+  // the painted picture rather than leaving it pinned under a clipped box.
+  const before = await paintedOffset(page);
+  await page.evaluate(() => {
+    const el = document.querySelector(".media-viewer-zoom-scroller");
+    if (el !== null) el.scrollTop = 60;
+  });
+  const after = await paintedOffset(page);
+  expect(after.scrollTop).toBe(60);
+  expect(Math.abs(after.dy - (before.dy - 60))).toBeLessThan(2);
 });

--- a/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
+++ b/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
@@ -104,11 +104,20 @@ async function cdpTap(cdp: CDPSession, x: number, y: number): Promise<void> {
 
 // Drag one finger from (x, y) upward by `dy`, in steps, through the browser's
 // own gesture recogniser.
-async function cdpDragUp(cdp: CDPSession, page: Page, x: number, y: number, dy: number) {
+async function cdpDragUp(
+  cdp: CDPSession,
+  page: Page,
+  x: number,
+  y: number,
+  dy: number,
+): Promise<void> {
   const point = (at: number) => [{ x, y: at, radiusX: 8, radiusY: 8, force: 1, id: 1 }];
   await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: point(y) });
   for (let moved = 10; moved <= dy; moved += 10) {
-    await cdp.send("Input.dispatchTouchEvent", { type: "touchMove", touchPoints: point(y - moved) });
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: point(y - moved),
+    });
     await page.waitForTimeout(16);
   }
   await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
@@ -286,7 +295,11 @@ test("@webkit #1805 — the zoomable modal image and its scroller declare the pa
   expect(await img.evaluate((el) => getComputedStyle(el).transformOrigin)).toBe("0px 0px");
   const style = await scroller.evaluate((el) => {
     const s = getComputedStyle(el);
-    return { touchAction: s.touchAction, overflowY: s.overflowY, overscroll: s.overscrollBehaviorY };
+    return {
+      touchAction: s.touchAction,
+      overflowY: s.overflowY,
+      overscroll: s.overscrollBehaviorY,
+    };
   });
   expect(style.touchAction).toBe("pan-x pan-y");
   expect(style.overflowY).toBe("auto");

--- a/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
+++ b/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
@@ -102,6 +102,37 @@ async function cdpTap(cdp: CDPSession, x: number, y: number): Promise<void> {
   await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 }
 
+// Double-tap to the 2× toggle, retried up to four times.
+//
+// A bounded retry rather than one attempt, and it is not a timeout in disguise:
+// the pairing window is 300ms of WALL CLOCK, and a loaded CI box can miss it
+// between two round trips. A missed attempt leaves the scale AT 1 — the toggle
+// only fires when the pair lands — so the loop cannot overshoot into a zoom-out,
+// and the wait between attempts is the window itself, which is what makes two
+// attempts unable to pair with each other. The caller asserts the scale
+// afterwards, so a loop that never lands is a red and not a silent skip.
+//
+// `tap` is the engine's own tap verb in both projects: CDP on chromium,
+// `page.touchscreen.tap` (`Input.dispatchTapEvent`) on webkit, which is the ONE
+// touch verb Playwright's WebKit backend exposes.
+async function zoomByDoubleTap(
+  page: Page,
+  cdp: CDPSession | null,
+  x: number,
+  y: number,
+): Promise<void> {
+  const tap = async (): Promise<void> => {
+    if (cdp === null) await page.touchscreen.tap(x, y);
+    else await cdpTap(cdp, x, y);
+  };
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if ((await zoomState(page)).scale > 1) return;
+    await tap();
+    await tap();
+    await page.waitForTimeout(DOUBLE_TAP_MS + 100);
+  }
+}
+
 // Drag one finger from (x, y) upward by `dy`, in steps, through the browser's
 // own gesture recogniser.
 async function cdpDragUp(
@@ -194,44 +225,73 @@ test("#213 — a synthesized two-finger pinch scales the modal image (chromium)"
   expect(scaledUp).toBeGreaterThan(1.5);
 });
 
-test("#1805 — a ONE-finger touchmove on the modal image is NOT claimed (chromium)", async ({
+test("#1805 — a ONE-finger touchmove is claimed at fit and released once zoomed (chromium)", async ({
   page,
 }) => {
   test.slow();
-  const { img } = await openImageViewer(page);
+  const { img, scroller } = await openImageViewer(page);
+  const cdp = await touchPipeline(page);
 
-  // Until #1805 EVERY cancelable touchmove was preventDefault'd, which is what
-  // kept the browser from scrolling. `dispatchEvent` returns false iff a
-  // listener called preventDefault — a JS-level fact independent of
-  // `touch-action`, so it is deterministic in chromium even though a synthetic
-  // event cannot drive a real pixel scroll.
+  // `dispatchEvent` returns false iff a listener called preventDefault — a
+  // JS-level fact independent of `touch-action`, deterministic in chromium even
+  // though a synthetic event cannot drive a real pixel scroll.
   //
-  // Both branches in one evaluate, because the interesting assertion is the
-  // CONTRAST: two fingers still ours, one finger the browser's. A spec that
-  // only checked the one-finger case would go green on a component that had
-  // stopped claiming anything at all, pinch included.
-  const claims = await img.evaluate((el) => {
-    const touch = (x: number, id: number) =>
-      new Touch({ identifier: id, target: el, clientX: x, clientY: 200 });
-    const fire = (type: "touchstart" | "touchmove", touches: Touch[]): boolean =>
-      el.dispatchEvent(
-        new TouchEvent(type, {
-          bubbles: true,
-          cancelable: true,
-          touches,
-          targetTouches: touches,
-          changedTouches: touches,
-        }),
-      );
-    fire("touchstart", [touch(200, 1)]);
-    const oneFinger = !fire("touchmove", [touch(260, 1)]);
-    fire("touchstart", [touch(150, 1), touch(250, 2)]);
-    const twoFingers = !fire("touchmove", [touch(100, 1), touch(300, 2)]);
-    return { oneFinger, twoFingers };
-  });
+  // 🔴 The one-finger answer is DIFFERENT at fit and when zoomed, and the first
+  // draft of this spec asserted "never claimed" and went red on the real stack.
+  // It was the spec that was wrong. At fit the drag IS still claimed, by
+  // `overlayScrollLock`'s document-level touchmove handler (#219): it walks the
+  // gesture target's ancestors and lets the gesture through only when it finds
+  // an ancestor that is genuinely scrollable — `overflow: auto` AND
+  // `scrollHeight > clientHeight`. At fit the sizer is zero, so nothing
+  // overflows, so nothing is scrollable, so the page is held still. That is the
+  // behaviour #219 exists for and #1805 must not break.
+  //
+  // Which makes the pair below the real contract, and neither half alone says
+  // it: the pan is released EXACTLY when there is something to pan, and the two
+  // mechanisms compose through the lock's overflow test rather than by anyone
+  // knowing about anyone.
+  const probe = () =>
+    img.evaluate((el) => {
+      const touch = (x: number, id: number) =>
+        new Touch({ identifier: id, target: el, clientX: x, clientY: 200 });
+      const fire = (type: "touchstart" | "touchmove", touches: Touch[]): boolean =>
+        el.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches,
+            targetTouches: touches,
+            changedTouches: touches,
+          }),
+        );
+      fire("touchstart", [touch(200, 1)]);
+      const oneFinger = !fire("touchmove", [touch(260, 1)]);
+      fire("touchstart", [touch(150, 1), touch(250, 2)]);
+      const twoFingers = !fire("touchmove", [touch(100, 1), touch(300, 2)]);
+      return { oneFinger, twoFingers };
+    });
 
-  expect(claims.oneFinger).toBe(false);
-  expect(claims.twoFingers).toBe(true);
+  const atFit = await probe();
+  expect(atFit.oneFinger).toBe(true);
+  expect(atFit.twoFingers).toBe(true);
+
+  // Longer than the pairing window, so the taps below cannot pair with the
+  // synthetic touchstart above — the protocol's own 300ms, not a guess.
+  await page.waitForTimeout(DOUBLE_TAP_MS + 100);
+  const box = await scroller.boundingBox();
+  if (box === null) throw new Error("scroller has no box");
+  await zoomByDoubleTap(page, cdp, box.x + box.width / 2, box.y + box.height / 2);
+
+  // PRECONDITION: without real overflow the lock would still (correctly) claim
+  // the drag, and the assertion below would be measuring the absence of a zoom.
+  const zoomed = await zoomState(page);
+  expect(zoomed.scale).toBeGreaterThan(1.5);
+  expect(zoomed.scrollHeight).toBeGreaterThan(zoomed.clientHeight + 50);
+
+  await page.waitForTimeout(DOUBLE_TAP_MS + 100);
+  const whenZoomed = await probe();
+  expect(whenZoomed.oneFinger).toBe(false);
+  expect(whenZoomed.twoFingers).toBe(true);
 });
 
 test("#1805 — a real one-finger drag moves the visible portion of the zoomed image (chromium)", async ({
@@ -246,17 +306,7 @@ test("#1805 — a real one-finger drag moves the visible portion of the zoomed i
   const cx = box.x + box.width / 2;
   const cy = box.y + box.height / 2;
 
-  // Double-tap to 2×. Bounded retry rather than one attempt: the pairing window
-  // is 300ms of wall clock and a loaded CI box can miss it. A missed attempt
-  // leaves the scale AT 1, so the loop cannot overshoot, and the wait between
-  // attempts is the window itself so two attempts can never pair with each
-  // other.
-  for (let attempt = 0; attempt < 4; attempt++) {
-    if ((await zoomState(page)).scale > 1) break;
-    await cdpTap(cdp, cx, cy);
-    await cdpTap(cdp, cx, cy);
-    await page.waitForTimeout(DOUBLE_TAP_MS + 100);
-  }
+  await zoomByDoubleTap(page, cdp, cx, cy);
 
   // PRECONDITION, and the load-bearing half of #1805: a CSS transform does not
   // change layout, so without the sizer the scaled image would create no
@@ -317,15 +367,8 @@ test("@webkit #1805 — zooming creates a real scrollable area, and scrolling mo
   const cx = box.x + box.width / 2;
   const cy = box.y + box.height / 2;
 
-  // Real taps: `page.touchscreen.tap` is `Input.dispatchTapEvent`, which is the
-  // ONE touch verb Playwright's WebKit backend exposes. Same bounded-retry
-  // reasoning as the chromium leg.
-  for (let attempt = 0; attempt < 4; attempt++) {
-    if ((await zoomState(page)).scale > 1) break;
-    await page.touchscreen.tap(cx, cy);
-    await page.touchscreen.tap(cx, cy);
-    await page.waitForTimeout(DOUBLE_TAP_MS + 100);
-  }
+  // Real taps, via the ONE touch verb Playwright's WebKit backend exposes.
+  await zoomByDoubleTap(page, null, cx, cy);
 
   const zoomed = await zoomState(page);
   expect(zoomed.scale).toBeGreaterThan(1.5);
@@ -333,15 +376,28 @@ test("@webkit #1805 — zooming creates a real scrollable area, and scrolling mo
   // alone leaves scrollHeight === clientHeight and there is nothing to pan.
   expect(zoomed.scrollHeight).toBeGreaterThan(zoomed.clientHeight + 50);
 
+  // PRE-STATE, asserted rather than assumed: `dy === -scrollTop` is the whole
+  // geometric invariant (a 0 0 transform-origin puts the painted top at minus
+  // the scroll offset), and the double-tap has ALREADY scrolled — it anchors to
+  // the tapped point, which was the centre. The first draft of this spec
+  // assumed the pre-state was zero and asserted a 60px displacement against it;
+  // it went red by 128px, which is exactly the half-box the anchoring had
+  // correctly applied. The spec was wrong and the anchoring was right, so the
+  // fix is to measure the DELTA and to pin the invariant at both ends.
+  const before = await paintedOffset(page);
+  expect(Math.abs(before.dy + before.scrollTop)).toBeLessThan(2);
+
   // The DRAG cannot be driven here (see the header), so what is asserted is the
   // consequence a drag would produce: the scroller is real, and moving it moves
   // the painted picture rather than leaving it pinned under a clipped box.
-  const before = await paintedOffset(page);
-  await page.evaluate(() => {
+  const target = before.scrollTop + 60;
+  await page.evaluate((to) => {
     const el = document.querySelector(".media-viewer-zoom-scroller");
-    if (el !== null) el.scrollTop = 60;
-  });
+    if (el !== null) el.scrollTop = to;
+  }, target);
+
   const after = await paintedOffset(page);
-  expect(after.scrollTop).toBe(60);
-  expect(Math.abs(after.dy - (before.dy - 60))).toBeLessThan(2);
+  expect(after.scrollTop).toBe(target);
+  expect(Math.abs(after.dy + after.scrollTop)).toBeLessThan(2);
+  expect(after.dy).toBeLessThan(before.dy - 50);
 });

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -14,8 +14,8 @@ import { createOverlayLock } from "./lib/overlayScrollLock";
 import {
   applyPinch,
   distance,
-  midpoint,
   MIN_SCALE,
+  midpoint,
   type Point,
   rescaleScroll,
   type Size,

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -12,14 +12,13 @@ import { closeMediaViewer, type MediaViewerState, mediaViewerState } from "./lib
 import { bindDismissGesture, type DismissDirections } from "./lib/mediaViewerGesture";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import {
-  applyPan,
   applyPinch,
   distance,
-  IDENTITY,
+  midpoint,
   MIN_SCALE,
   type Point,
+  rescaleScroll,
   type Size,
-  type Transform,
   toggleZoom,
 } from "./lib/pinchZoom";
 import { maybeEscapePwaClick } from "./lib/platform";
@@ -75,12 +74,30 @@ const DOUBLE_TAP_MS = 300;
 
 const touchPoint = (t: Touch): Point => ({ x: t.clientX, y: t.clientY });
 
-// Pinch-to-zoom + pan for the modal image (#213). The browser's native pinch is
-// dead app-wide (iOS-1 viewport lock — maximum-scale=1, user-scalable=no; no
-// per-element opt-out), so the gesture is synthesized here and applied as a CSS
-// `transform` to THIS <img> only. Because the transform is element-scoped and
-// every touchmove is preventDefault'd, the zoom/pan is confined to the viewer —
-// no page zoom, no body-scroll bleed.
+// Pinch-to-zoom for the modal image (#213), panned by the browser's own
+// scroller (#1805).
+//
+// The PINCH is still synthesized: the browser's native one is dead app-wide
+// (iOS-1 viewport lock — maximum-scale=1, user-scalable=no; no per-element
+// opt-out), so it is applied as a CSS `transform` to THIS <img> alone.
+//
+// The PAN is not, any more. That lock governs page zoom and says nothing about
+// element scrolling, so an `overflow: auto` box scrolls natively underneath it
+// — measured through chromium's real touch pipeline at iPhone-15 metrics, 112px
+// of scroll with the lock against 128px without. Handing the pan back buys
+// momentum, rubber-band, a scrollbar and exact bounds that no synthesized
+// version had. It costs the blanket `preventDefault` that used to sit on every
+// touchmove: only the TWO-FINGER branch is ours now, because a one-finger drag
+// preventDefault'd is a one-finger drag the browser will not scroll with
+// (measured: claiming it while zoomed pins the scroll at 0).
+//
+// A transform does not change layout, so a scaled image creates no overflow and
+// there would be nothing to scroll. `.media-viewer-zoom-sizer` is what grows —
+// an absolutely-positioned box at `fit × scale`. Absolute so it stays out of
+// the scroller's intrinsic size: the <img> keeps sizing the container at fit,
+// its `max-width: 100%` keeps resolving against a box that does not move, and
+// the CSS remains the owner of the fit — this component only MIRRORS the fit it
+// measures, it never recomputes `object-fit: contain` in JS.
 //
 // Touch listeners are bound element-level via a ref + addEventListener with
 // touchmove `{ passive: false }` (bindSwipe precedent, ComposeBox): Solid
@@ -92,7 +109,7 @@ const touchPoint = (t: Touch): Point => ({ x: t.clientX, y: t.clientY });
 // #1438 — the zoom level is PUBLISHED upward (`onScale`) instead of the
 // transform being lifted into the modal. The dismiss gesture needs one bit
 // ("is this image zoomed?") to stand down, and the transform is deliberately
-// element-scoped: hoisting it would put the image's pan geometry in a
+// element-scoped: hoisting it would put the image's zoom geometry in a
 // component that also owns a <video>. Published synchronously with every
 // mutation rather than through an effect, because the reader is a touchstart
 // handler and a frame of lag there is a dismiss that fires on a pan.
@@ -102,95 +119,134 @@ const ZoomableImage: Component<{
   onError: () => void;
   onScale: (scale: number) => void;
 }> = (props) => {
-  const [transform, setTransform] = createSignal<Transform>(IDENTITY);
+  let scroller: HTMLDivElement | undefined;
+  let sizer: HTMLDivElement | undefined;
+  let image: HTMLImageElement | undefined;
 
-  // The ONE writer: signal + publication cannot drift apart if there is no
-  // other way to move the transform.
-  const apply = (next: Transform): void => {
-    setTransform(next);
-    props.onScale(next.scale);
-  };
+  // Plain mutables, not signals: nothing RENDERS from either. Both are painted
+  // imperatively for an ORDERING reason, not a style one — the sizer has to be
+  // its new size BEFORE a scroll offset is assigned, or the assignment clamps
+  // against the old bounds and the zoom lands somewhere else. Same device as
+  // `paint` in MediaViewerDialog below.
+  let scale = MIN_SCALE;
+  let fit: Size = { width: 0, height: 0 }; // the CSS-computed fit box, mirrored
 
   // Non-reactive gesture state, mutated across the touchstart→move→end span.
-  let gestureStart: Transform = IDENTITY; // transform when the current gesture began
+  let gestureStartScale = MIN_SCALE; // scale when the current pinch began
   let startDistance = 0; // two-finger pinch baseline (0 = not pinching)
-  let startPan: Point | null = null; // one-finger pan baseline (screen coords)
   let lastTapAt = 0; // event-timeStamp of the previous single-finger tap
 
-  // Confinement box = the image's own fit-to-viewer client rect. A CSS
-  // transform doesn't change layout size, so clientWidth/Height stay the fit
-  // dimensions regardless of the current scale.
-  const viewportOf = (el: HTMLElement): Size => ({
-    width: el.clientWidth,
-    height: el.clientHeight,
-  });
+  // At fit there must be NOTHING to scroll. Not an optimisation: at fit the
+  // swipe-to-dismiss owns the single-finger drag, and it only keeps it while
+  // the browser has no pan to start. `fit` is read from `clientWidth`, which is
+  // rounded to an integer, so `fit × 1` can exceed the real box by a sub-pixel
+  // — enough overflow for the browser to claim the drag and take the dismiss
+  // away. Zero is the only value that cannot do that.
+  const sizerSize = (): Size =>
+    scale > MIN_SCALE
+      ? { width: fit.width * scale, height: fit.height * scale }
+      : { width: 0, height: 0 };
+
+  const paint = (): void => {
+    if (image !== undefined) image.style.transform = `scale(${scale})`;
+    if (sizer !== undefined) {
+      const size = sizerSize();
+      sizer.style.width = `${size.width}px`;
+      sizer.style.height = `${size.height}px`;
+    }
+  };
+
+  // Screen coordinates → the scroller's own viewport coordinates, which is the
+  // frame `rescaleScroll` is written in.
+  const focusIn = (p: Point): Point => {
+    const box = scroller?.getBoundingClientRect();
+    if (box === undefined) return { x: 0, y: 0 };
+    return { x: p.x - box.left, y: p.y - box.top };
+  };
+
+  // The ONE writer. Publication, paint and scroll compensation cannot drift
+  // apart if there is no other way to move the scale.
+  const applyScale = (next: number, focus: Point): void => {
+    const previous = scale;
+    if (next === previous) return;
+    scale = next;
+    props.onScale(scale);
+    paint();
+    if (scroller === undefined) return;
+    const to = rescaleScroll(
+      { left: scroller.scrollLeft, top: scroller.scrollTop },
+      focus,
+      previous,
+      scale,
+    );
+    scroller.scrollLeft = to.left;
+    scroller.scrollTop = to.top;
+  };
+
+  // The fit box is whatever the stylesheet's max-width/max-height resolve to.
+  // It changes on load, on rotation, and on a --viewport-height write (the
+  // software keyboard), and a ResizeObserver catches all three where a load
+  // handler catches one. `clientWidth` and not `getBoundingClientRect`: the
+  // rect is the TRANSFORMED box, so it would report `fit × scale` and feed the
+  // sizer its own output.
+  const measureFit = (): void => {
+    if (image === undefined) return;
+    const next: Size = { width: image.clientWidth, height: image.clientHeight };
+    if (next.width === fit.width && next.height === fit.height) return;
+    fit = next;
+    paint();
+  };
 
   const onTouchStart = (e: TouchEvent): void => {
-    gestureStart = transform();
+    gestureStartScale = scale;
     if (e.touches.length >= 2) {
       const a = e.touches[0];
       const b = e.touches[1];
       if (a && b) startDistance = distance(touchPoint(a), touchPoint(b));
-      startPan = null;
       return;
     }
     const t0 = e.touches[0];
     if (!t0) return;
     startDistance = 0;
-    // Double-tap toggles fit⇄2x. Second tap within the window → toggle and
-    // arm nothing (don't treat the toggle tap as a pan start).
+    // Double-tap toggles fit⇄2x, around the tapped point rather than the
+    // centre: the same `rescaleScroll` the pinch uses, so there is one answer
+    // to "where does the picture land" and not two.
     if (e.timeStamp - lastTapAt < DOUBLE_TAP_MS) {
-      apply(toggleZoom(transform()));
+      applyScale(toggleZoom(scale), focusIn(touchPoint(t0)));
       lastTapAt = 0;
-      startPan = null;
       return;
     }
     lastTapAt = e.timeStamp;
-    startPan = touchPoint(t0);
   };
 
   const onTouchMove = (e: TouchEvent): void => {
-    const el = e.currentTarget as HTMLImageElement;
-    // Belt-and-braces confinement: own the gesture, never let it reach the page.
+    // ONE finger is the browser's: no claim, no preventDefault, no JS geometry.
+    // Returning early is the whole of #1805 at this layer.
+    if (e.touches.length < 2 || startDistance <= 0) return;
+    const a = e.touches[0];
+    const b = e.touches[1];
+    if (!a || !b) return;
+    // Two fingers ARE ours — the native pinch this replaces does not exist, and
+    // an unclaimed two-finger move is a page gesture we do not want.
     if (e.cancelable) e.preventDefault();
-    const vp = viewportOf(el);
-    if (e.touches.length >= 2 && startDistance > 0) {
-      const a = e.touches[0];
-      const b = e.touches[1];
-      if (a && b) {
-        apply(applyPinch(gestureStart, startDistance, distance(touchPoint(a), touchPoint(b)), vp));
-      }
-      return;
-    }
-    // Single-finger pan only when zoomed in (an un-zoomed image can't pan).
-    if (startPan && gestureStart.scale > MIN_SCALE) {
-      const t0 = e.touches[0];
-      if (t0) {
-        const delta = { x: t0.clientX - startPan.x, y: t0.clientY - startPan.y };
-        apply(applyPan(gestureStart, delta, vp));
-      }
-    }
+    const pa = touchPoint(a);
+    const pb = touchPoint(b);
+    applyScale(
+      applyPinch(gestureStartScale, startDistance, distance(pa, pb)),
+      focusIn(midpoint(pa, pb)),
+    );
   };
 
   const onTouchEnd = (e: TouchEvent): void => {
-    // Lifting one finger of a pinch leaves one touch: rebase the pan gesture on
-    // the survivor so pan continues seamlessly. All fingers up → clear state.
-    if (e.touches.length === 1) {
-      const t0 = e.touches[0];
-      if (t0) {
-        gestureStart = transform();
-        startPan = touchPoint(t0);
-        startDistance = 0;
-      }
-      return;
-    }
-    if (e.touches.length === 0) {
-      startPan = null;
-      startDistance = 0;
-    }
+    // Below two fingers there is no pinch left to continue; whatever remains on
+    // the glass is a pan, and a pan is the browser's. Re-baselining the scale
+    // here is what makes a second pinch compound on the first.
+    if (e.touches.length < 2) startDistance = 0;
+    gestureStartScale = scale;
   };
 
-  const bindZoom = (el: HTMLImageElement): void => {
+  const bindScroller = (el: HTMLDivElement): void => {
+    scroller = el;
     el.addEventListener("touchstart", onTouchStart, { passive: true });
     el.addEventListener("touchmove", onTouchMove, { passive: false });
     el.addEventListener("touchend", onTouchEnd, { passive: true });
@@ -198,23 +254,41 @@ const ZoomableImage: Component<{
       el.removeEventListener("touchstart", onTouchStart);
       el.removeEventListener("touchmove", onTouchMove);
       el.removeEventListener("touchend", onTouchEnd);
+      scroller = undefined;
     });
   };
 
-  const styleFor = (t: Transform): { transform: string } => ({
-    transform: `translate(${t.tx}px, ${t.ty}px) scale(${t.scale})`,
-  });
+  const bindImage = (el: HTMLImageElement): void => {
+    image = el;
+    // Guarded for jsdom, which ships no ResizeObserver (the #285 precedent in
+    // ScrollbackPane): the load handler still measures once there.
+    const observer =
+      typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(measureFit);
+    observer?.observe(el);
+    onCleanup(() => {
+      observer?.disconnect();
+      image = undefined;
+    });
+  };
 
   return (
-    <img
-      ref={bindZoom}
-      class="media-viewer-media media-viewer-media--zoomable"
-      src={props.href}
-      alt={props.href}
-      style={styleFor(transform())}
-      onLoad={props.onLoad}
-      onError={props.onError}
-    />
+    <div ref={bindScroller} class="media-viewer-zoom-scroller">
+      {/* Purely geometric: it carries the scrollable area a transform cannot
+          create. aria-hidden + pointer-events:none so it is neither read nor
+          tapped. */}
+      <div ref={sizer} class="media-viewer-zoom-sizer" aria-hidden="true" />
+      <img
+        ref={bindImage}
+        class="media-viewer-media media-viewer-media--zoomable"
+        src={props.href}
+        alt={props.href}
+        onLoad={() => {
+          measureFit();
+          props.onLoad();
+        }}
+        onError={props.onError}
+      />
+    </div>
   );
 };
 
@@ -431,6 +505,18 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
   // reader is a touchstart handler.
   let textPane: HTMLDivElement | undefined;
   const isText = props.state.kind === "text";
+  // #1805 — the image arm now has a scroller under it, and `.media-viewer-modal`
+  // closes the touch stream with `touch-action: none`. Whether that closure
+  // even reaches a descendant scroll container is engine-dependent and only
+  // half-measurable here: chromium intersects touch-action from the hit element
+  // up to the SCROLL CONTAINER and stops, so the modal's `none` is inert (arm C
+  // of the #1805 bench, 105px of scroll through it); Playwright's WebKit
+  // exposes no touch-drag drive at all, so the same question cannot be put to
+  // the engine this issue is about. Re-opening on the modal — the #1764
+  // precedent, one class along — is correct under BOTH readings, and measured
+  // free under the one that can be measured: at fit the dismiss still received
+  // 11 cancelable moves out of 11, exactly as it does under `none`.
+  const isImage = props.state.kind === "image";
 
   const paint = (el: HTMLElement, dy: number): void => {
     el.style.transform = draggedTransform(dy);
@@ -486,7 +572,10 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
         aria-modal="true"
         aria-label="Media viewer"
         class="media-viewer-modal"
-        classList={{ "media-viewer-modal--text": isText }}
+        classList={{
+          "media-viewer-modal--text": isText,
+          "media-viewer-modal--zoomable": isImage,
+        }}
       >
         <div class="media-viewer-header">
           <a

--- a/cicchetto/src/__tests__/MediaViewerModal.test.tsx
+++ b/cicchetto/src/__tests__/MediaViewerModal.test.tsx
@@ -358,18 +358,186 @@ describe("MediaViewerModal — swipe to dismiss (#1438)", () => {
     expect(backdrop.style.opacity).toBe("");
   });
 
-  it("a zoomed image keeps its pan — the dismiss stands down until it is back at fit", () => {
+  it("a zoomed image keeps the drag — the dismiss stands down until it is back at fit", () => {
     const { container } = render(() => <MediaViewerModal />);
     openMediaViewer(IMAGE_URL, "image");
     const img = container.querySelector<HTMLElement>("img");
     if (img === null) throw new Error("no image rendered");
     // Double-tap zoom (#213), the same two touchstarts the viewer reads: it is
     // the published scale, not a test seam, that stands the dismiss down.
+    // Since #1805 the drag it stands down FOR is the browser's own scroll
+    // rather than a synthesized pan, but the gate and its reason are unchanged.
     fireTouchAt(img, "touchstart", 1_000, { clientX: X, clientY: Y0 });
     fireTouchAt(img, "touchend", 1_020, { clientX: X, clientY: Y0 });
     fireTouchAt(img, "touchstart", 1_100, { clientX: X, clientY: Y0 });
     dragAndLift(dialogIn(container), 400);
     expect(mediaViewerState()).not.toBeNull();
+  });
+});
+
+// #1805 — the pan is the browser's scroller now, not a synthesized transform.
+// The pure arithmetic (rescaleScroll, applyPinch, toggleZoom) is pinned in
+// pinchZoom.test.ts; what is asserted HERE is what only this component can get
+// wrong, and each item is one that a plausible-looking implementation gets
+// wrong silently:
+//
+//   - a single-finger touchmove must NOT be claimed. A blanket preventDefault
+//     is exactly what shipped before, and it leaves every other symptom intact
+//     while the scroll simply never happens (measured on the #1805 bench:
+//     claiming while zoomed pins scrollTop at 0 with the scroller otherwise
+//     correct in every respect).
+//   - the sizer must be ZERO at fit. Non-zero there is a browser pan at fit,
+//     which is the swipe-to-dismiss taken away.
+//   - the zoom must be anchored to the touched point. Anchoring to the corner
+//     also "works": it zooms, it scrolls, and it is wrong.
+//
+// jsdom has no layout, so the fit box the component MIRRORS and the scroll
+// offsets it WRITES are injected below. That is a seam on the DOM, not on the
+// component — nothing in production code knows these tests exist.
+describe("MediaViewerModal — native pan for the zoomed image (#1805)", () => {
+  const FIT = { width: 300, height: 200 };
+
+  const openZoomable = (container: HTMLElement) => {
+    openMediaViewer(IMAGE_URL, "image");
+    const scroller = container.querySelector<HTMLElement>(".media-viewer-zoom-scroller");
+    const sizer = container.querySelector<HTMLElement>(".media-viewer-zoom-sizer");
+    const img = container.querySelector<HTMLImageElement>("img.media-viewer-media--zoomable");
+    if (scroller === null || sizer === null || img === null) {
+      throw new Error("no zoomable image rendered");
+    }
+    Object.defineProperty(img, "clientWidth", { value: FIT.width, configurable: true });
+    Object.defineProperty(img, "clientHeight", { value: FIT.height, configurable: true });
+    scroller.getBoundingClientRect = (): DOMRect =>
+      ({
+        left: 0,
+        top: 0,
+        right: FIT.width,
+        bottom: FIT.height,
+        width: FIT.width,
+        height: FIT.height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    let scrollLeft = 0;
+    let scrollTop = 0;
+    Object.defineProperty(scroller, "scrollLeft", {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (v: number) => {
+        scrollLeft = v;
+      },
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+      },
+    });
+    // The load handler is where the fit is first measured — no ResizeObserver
+    // in jsdom, which the component tolerates on purpose.
+    fireEvent.load(img);
+    return { scroller, sizer, img };
+  };
+
+  const doubleTapAt = (el: HTMLElement, clientX: number, clientY: number): void => {
+    fireTouchAt(el, "touchstart", 1_000, { clientX, clientY });
+    fireTouchAt(el, "touchend", 1_020, { clientX, clientY });
+    fireTouchAt(el, "touchstart", 1_100, { clientX, clientY });
+  };
+
+  it("leaves a single-finger touchmove unclaimed, so the browser can scroll with it", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    const { img } = openZoomable(container);
+    doubleTapAt(img, 150, 100);
+    fireTouchAt(img, "touchstart", 2_000, { clientX: 150, clientY: 100 });
+    const move = fireTouchAt(img, "touchmove", 2_050, { clientX: 150, clientY: 40 });
+    expect(move.defaultPrevented).toBe(false);
+  });
+
+  it("still claims a TWO-finger touchmove — the native pinch it replaces does not exist", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    const { img } = openZoomable(container);
+    fireTouchAt(
+      img,
+      "touchstart",
+      2_000,
+      { clientX: 100, clientY: 100 },
+      { clientX: 200, clientY: 100 },
+    );
+    const move = fireTouchAt(
+      img,
+      "touchmove",
+      2_050,
+      { clientX: 0, clientY: 100 },
+      { clientX: 300, clientY: 100 },
+    );
+    expect(move.defaultPrevented).toBe(true);
+    expect(img.style.transform).toBe("scale(3)");
+  });
+
+  it("carries NO scrollable area at fit, so the dismiss keeps the single-finger drag", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    const { sizer } = openZoomable(container);
+    expect(sizer.style.width).toBe("0px");
+    expect(sizer.style.height).toBe("0px");
+  });
+
+  it("grows the scrollable area to fit x scale once zoomed — a transform alone would grow nothing", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    const { sizer, img } = openZoomable(container);
+    doubleTapAt(img, 150, 100);
+    expect(img.style.transform).toBe("scale(2)");
+    expect(sizer.style.width).toBe(`${FIT.width * 2}px`);
+    expect(sizer.style.height).toBe(`${FIT.height * 2}px`);
+  });
+
+  it("anchors a double-tap zoom to the tapped point, not to the corner", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    const { scroller, img } = openZoomable(container);
+    // Tap dead centre of a 300x200 box: at 2x the point that was at (150,100)
+    // paints at (300,200), so holding it under the finger costs exactly one
+    // half-box of scroll on each axis.
+    doubleTapAt(img, 150, 100);
+    expect(scroller.scrollLeft).toBe(150);
+    expect(scroller.scrollTop).toBe(100);
+  });
+
+  it("holds the top-left corner when THAT is what was tapped", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    const { scroller, img } = openZoomable(container);
+    doubleTapAt(img, 0, 0);
+    expect(scroller.scrollLeft).toBe(0);
+    expect(scroller.scrollTop).toBe(0);
+  });
+
+  it("unwinds the scroll when the second double-tap returns the image to fit", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    const { scroller, sizer, img } = openZoomable(container);
+    doubleTapAt(img, 150, 100);
+    doubleTapAt(img, 150, 100);
+    expect(img.style.transform).toBe("scale(1)");
+    expect(sizer.style.width).toBe("0px");
+    expect(scroller.scrollLeft).toBe(0);
+    expect(scroller.scrollTop).toBe(0);
+  });
+
+  it("marks the modal as the image variant, so the stylesheet can re-open the touch stream", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openZoomable(container);
+    const dialog = container.querySelector<HTMLElement>(".media-viewer-modal");
+    if (dialog === null) throw new Error("no media viewer dialog rendered");
+    expect(dialog.classList.contains("media-viewer-modal--zoomable")).toBe(true);
+  });
+
+  it("does NOT mark a video as the image variant — a <video> has no scroller under it", () => {
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(VIDEO_URL, "video");
+    const dialog = container.querySelector<HTMLElement>(".media-viewer-modal");
+    if (dialog === null) throw new Error("no media viewer dialog rendered");
+    expect(dialog.classList.contains("media-viewer-modal--zoomable")).toBe(false);
+    expect(container.querySelector(".media-viewer-zoom-scroller")).toBeNull();
   });
 });
 

--- a/cicchetto/src/__tests__/mediaViewerTouchAction.test.ts
+++ b/cicchetto/src/__tests__/mediaViewerTouchAction.test.ts
@@ -18,7 +18,9 @@ describe("media viewer — swipe-to-dismiss stylesheet contract (#1438)", () => 
   it("claims the whole touch stream on the modal container", () => {
     // On the CONTAINER, not per media element: the UA intersects touch-action
     // down the ancestor chain, so this one declaration is what covers the
-    // <video> as well as the <img>.
+    // <video> as well as the <img>. Two variants re-open it on top of this
+    // base — `--text` (#1764) and `--zoomable` (#1805) — because a surface
+    // with a SCROLLER under it needs the browser to keep the pan.
     expect(ruleBody(".media-viewer-modal")).toMatch(/touch-action:\s*none/);
   });
 
@@ -74,5 +76,70 @@ describe("media viewer — text source stylesheet contract (#1764)", () => {
     expect(ruleBody(".media-viewer-text-gutter")).toMatch(/font:\s*inherit/);
     expect(ruleBody(".media-viewer-text-source")).toMatch(/font:\s*inherit/);
     expect(ruleBody(".media-viewer-text")).toMatch(/font-family:\s*var\(--font-mono\)/);
+  });
+});
+
+// #1805 — the zoomed image pans with the browser's own scroller. Same standing
+// as the two blocks above: jsdom applies no stylesheet, and a headless browser
+// cannot feel momentum or a rubber-band, so these are SOURCE-level assertions
+// on declarations whose absence is invisible everywhere except a real phone.
+//
+// The two `touch-action` assertions are the ones that were MEASURED rather than
+// reasoned (chromium/iPhone-15, real touch pipeline). They are not
+// interchangeable, and that is the point of asserting both: the declaration on
+// the <img> and the declaration on the modal answer different questions, and
+// each was wrong in a different direction before the bench said so.
+describe("media viewer — native pan stylesheet contract (#1805)", () => {
+  it("lets the hit target pan — a touch-action:none on the <img> closes the scroller around it", () => {
+    // The <img> is what every touch in the viewer lands on, and the UA
+    // intersects touch-action from the hit target up to the scroll container.
+    // Measured: img `none` inside a `pan-x pan-y` scroller scrolls 0px, img
+    // `pan-x pan-y` scrolls 130px. `none` here is the pre-#1805 value, so the
+    // negative assertion is a guard against a revert, not a tautology.
+    const img = ruleBody(".media-viewer-media--zoomable");
+    expect(img).toMatch(/touch-action:\s*pan-x\s+pan-y/);
+    expect(img).not.toMatch(/touch-action:\s*none/);
+  });
+
+  it("puts the transform origin at 0 0, which is what rescaleScroll's arithmetic assumes", () => {
+    // Not a style preference: with a 0 0 origin an image coordinate is a scroll
+    // coordinate divided by the scale, which is the whole derivation in
+    // lib/pinchZoom.ts. A center origin silently offsets every zoom by half a
+    // box, and the picture still moves, so nothing else would report it.
+    expect(ruleBody(".media-viewer-media--zoomable")).toMatch(/transform-origin:\s*0\s+0/);
+  });
+
+  it("re-opens touch panning on the image variant, which the base modal rule closes", () => {
+    // The #1764 precedent one issue along. Under the reading where the UA
+    // intersects to the ROOT, `.media-viewer-modal { touch-action: none }`
+    // closes the scroller and only a declaration on the modal itself re-opens
+    // it. Chromium does not read it that way; WebKit cannot be asked, because
+    // Playwright's WebKit exposes no touch-drag drive. This declaration is
+    // correct under both readings.
+    expect(ruleBody(".media-viewer-modal--zoomable")).toMatch(/touch-action:\s*pan-x\s+pan-y/);
+  });
+
+  it("makes the wrapper the scroller — the base body is overflow:hidden", () => {
+    const scroller = ruleBody(".media-viewer-zoom-scroller");
+    expect(scroller).toMatch(/overflow:\s*auto/);
+    expect(scroller).toMatch(/touch-action:\s*pan-x\s+pan-y/);
+  });
+
+  it("keeps the scroller's overscroll to itself so a drag past the end is not the page's", () => {
+    expect(ruleBody(".media-viewer-zoom-scroller")).toMatch(/overscroll-behavior:\s*contain/);
+  });
+
+  it("makes the scroller the containing block the sizer is positioned against", () => {
+    expect(ruleBody(".media-viewer-zoom-scroller")).toMatch(/position:\s*relative/);
+  });
+
+  it("keeps the sizer OUT OF FLOW, or the scroller's own size would chase it", () => {
+    // In flow the sizer would contribute to the scroller's intrinsic size, the
+    // scroller would grow with the zoom instead of scrolling, and the <img>'s
+    // max-width: 100% would resolve against a box that moves. Absolute keeps it
+    // contributing to scrollable overflow only.
+    const sizer = ruleBody(".media-viewer-zoom-sizer");
+    expect(sizer).toMatch(/position:\s*absolute/);
+    expect(sizer).toMatch(/pointer-events:\s*none/);
   });
 });

--- a/cicchetto/src/__tests__/pinchZoom.test.ts
+++ b/cicchetto/src/__tests__/pinchZoom.test.ts
@@ -1,29 +1,24 @@
 import { describe, expect, it } from "vitest";
 import {
-  applyPan,
   applyPinch,
   clamp,
   clampScale,
-  clampTransform,
   DOUBLE_TAP_SCALE,
   distance,
-  IDENTITY,
   MAX_SCALE,
   MIN_SCALE,
-  maxTranslate,
   midpoint,
-  type Size,
-  type Transform,
+  rescaleScroll,
+  type Scroll,
   toggleZoom,
 } from "../lib/pinchZoom";
 
-// The pure pinch/pan geometry (gemello di swipe.ts) is DOM-free so it
-// unit-tests without touch physics. A `Transform` is the CSS state applied to
-// the modal <img>: { scale, tx, ty } → `translate(tx, ty) scale(scale)` with a
-// center transform-origin. `Size` is the viewport (container) the image is
-// confined to. Pan is clamped so a zoomed image can never fly entirely off the
-// viewer.
-const VIEWPORT: Size = { width: 400, height: 300 };
+// The pure pinch geometry (gemello di swipe.ts) is DOM-free so it unit-tests
+// without touch physics. Since #1805 a zoom state is a bare `scale`: the pan
+// belongs to the browser's own scroller, so there is no `tx`/`ty` to confine
+// and no `applyPan`/`maxTranslate`/`clampTransform` to test. What replaced them
+// is `rescaleScroll` — the one thing the scroller CANNOT do for itself, because
+// only we know which image point the fingers were holding.
 
 describe("distance", () => {
   it("is the euclidean distance between two points", () => {
@@ -63,107 +58,93 @@ describe("clampScale", () => {
   });
 });
 
-describe("maxTranslate", () => {
-  it("is zero at scale 1 — an unzoomed image cannot pan", () => {
-    expect(maxTranslate(1, 400)).toBe(0);
-  });
-  it("grows with scale: half the overflow at the given scale", () => {
-    // At 2x over a 400px axis the image is 800px wide → 400px overflow →
-    // 200px pannable each side.
-    expect(maxTranslate(2, 400)).toBe(200);
-  });
-  it("never goes negative below scale 1", () => {
-    expect(maxTranslate(0.5, 400)).toBe(0);
-  });
-});
-
-describe("clampTransform", () => {
-  it("forces translate to 0 when not zoomed", () => {
-    const t: Transform = { scale: 1, tx: 50, ty: 50 };
-    expect(clampTransform(t, VIEWPORT)).toEqual({ scale: 1, tx: 0, ty: 0 });
-  });
-
-  it("keeps a within-bounds pan untouched when zoomed", () => {
-    const t: Transform = { scale: 2, tx: 100, ty: 50 };
-    expect(clampTransform(t, VIEWPORT)).toEqual({ scale: 2, tx: 100, ty: 50 });
-  });
-
-  it("clamps an over-panned image back to the confinement bound", () => {
-    // 2x over 400×300 → max pan 200 (x), 150 (y).
-    const t: Transform = { scale: 2, tx: 9999, ty: -9999 };
-    expect(clampTransform(t, VIEWPORT)).toEqual({ scale: 2, tx: 200, ty: -150 });
-  });
-
-  it("clamps scale AND re-clamps the now-illegal translate together", () => {
-    const t: Transform = { scale: 99, tx: 5000, ty: 5000 };
-    const out = clampTransform(t, VIEWPORT);
-    expect(out.scale).toBe(MAX_SCALE);
-    expect(out.tx).toBe(maxTranslate(MAX_SCALE, VIEWPORT.width));
-    expect(out.ty).toBe(maxTranslate(MAX_SCALE, VIEWPORT.height));
-  });
-});
-
 describe("applyPinch", () => {
   it("scales relative to the gesture-start distance", () => {
-    const start: Transform = { scale: 1, tx: 0, ty: 0 };
     // fingers move twice as far apart → 2x.
-    expect(applyPinch(start, 100, 200, VIEWPORT)).toEqual({ scale: 2, tx: 0, ty: 0 });
+    expect(applyPinch(1, 100, 200)).toBe(2);
   });
 
   it("compounds on the start scale (mid-gesture continuation)", () => {
-    const start: Transform = { scale: 2, tx: 0, ty: 0 };
-    expect(applyPinch(start, 100, 150, VIEWPORT).scale).toBe(3);
+    expect(applyPinch(2, 100, 150)).toBe(3);
   });
 
   it("clamps the resulting scale to MAX_SCALE", () => {
-    const start: Transform = { scale: 1, tx: 0, ty: 0 };
-    expect(applyPinch(start, 100, 9999, VIEWPORT).scale).toBe(MAX_SCALE);
+    expect(applyPinch(1, 100, 9999)).toBe(MAX_SCALE);
   });
 
-  it("re-clamps translate when pinching back down shrinks the pan bound", () => {
-    // start zoomed-and-panned at 3x (pan 400/2*(3-1)=... within bound), pinch
-    // back to ~1x → translate must collapse to 0.
-    const start: Transform = { scale: 3, tx: 200, ty: 100 };
-    const out = applyPinch(start, 300, 100, VIEWPORT); // 3 * (100/300) = 1
-    expect(out.scale).toBe(1);
-    expect(out.tx).toBe(0);
-    expect(out.ty).toBe(0);
+  it("floors at MIN_SCALE when the fingers close past fit", () => {
+    expect(applyPinch(3, 300, 10)).toBe(MIN_SCALE);
   });
 
   it("is a no-op when the start distance is zero (divide guard)", () => {
-    const start: Transform = { scale: 2, tx: 10, ty: 10 };
-    expect(applyPinch(start, 0, 200, VIEWPORT)).toEqual(start);
-  });
-});
-
-describe("applyPan", () => {
-  it("adds the drag delta to the start translate when zoomed", () => {
-    const start: Transform = { scale: 2, tx: 10, ty: 20 };
-    expect(applyPan(start, { x: 30, y: -5 }, VIEWPORT)).toEqual({ scale: 2, tx: 40, ty: 15 });
-  });
-
-  it("clamps a pan that would push the image past the confinement bound", () => {
-    const start: Transform = { scale: 2, tx: 150, ty: 0 };
-    // max x pan at 2x/400 = 200; +100 would be 250 → clamp to 200.
-    expect(applyPan(start, { x: 100, y: 0 }, VIEWPORT).tx).toBe(200);
-  });
-
-  it("cannot pan an unzoomed image (bound is 0)", () => {
-    const start: Transform = { scale: 1, tx: 0, ty: 0 };
-    expect(applyPan(start, { x: 50, y: 50 }, VIEWPORT)).toEqual({ scale: 1, tx: 0, ty: 0 });
+    expect(applyPinch(2, 0, 200)).toBe(2);
   });
 });
 
 describe("toggleZoom", () => {
-  it("zooms an unzoomed image to the double-tap scale, centered", () => {
-    expect(toggleZoom(IDENTITY)).toEqual({ scale: DOUBLE_TAP_SCALE, tx: 0, ty: 0 });
+  it("zooms an unzoomed image to the double-tap scale", () => {
+    expect(toggleZoom(MIN_SCALE)).toBe(DOUBLE_TAP_SCALE);
   });
 
   it("resets a zoomed image back to fit", () => {
-    expect(toggleZoom({ scale: 3, tx: 100, ty: 50 })).toEqual({ scale: 1, tx: 0, ty: 0 });
+    expect(toggleZoom(3)).toBe(MIN_SCALE);
   });
 
   it("resets even a slightly-zoomed image (any scale above MIN)", () => {
-    expect(toggleZoom({ scale: 1.2, tx: 5, ty: 5 }).scale).toBe(MIN_SCALE);
+    expect(toggleZoom(1.2)).toBe(MIN_SCALE);
+  });
+});
+
+describe("rescaleScroll", () => {
+  const AT_TOP: Scroll = { left: 0, top: 0 };
+
+  it("keeps the point under the focus under the focus (the whole contract)", () => {
+    // Container 200 wide, focus at its centre (100). At scale 1 with no scroll
+    // the image point under the focus is image-x 100. At scale 2 that point
+    // paints at 200, so the container must scroll to 200 - 100 = 100 to keep it
+    // under the finger.
+    expect(rescaleScroll(AT_TOP, { x: 100, y: 100 }, 1, 2)).toEqual({ left: 100, top: 100 });
+  });
+
+  it("compounds correctly from an already-scrolled, already-zoomed state", () => {
+    // At scale 2 scrolled to 100, the focus at 100 holds image point
+    // (100 + 100) / 2 = 100. Going to scale 4 puts it at 400 → scroll 300.
+    expect(rescaleScroll({ left: 100, top: 100 }, { x: 100, y: 100 }, 2, 4)).toEqual({
+      left: 300,
+      top: 300,
+    });
+  });
+
+  it("returns to zero scroll when zooming back out to fit", () => {
+    // Whatever was held at 2x, at fit the image is smaller than the container
+    // on both axes, so the arithmetic must not leave a positive offset behind.
+    // (100 + 100)/2 * 1 - 100 = 0.
+    expect(rescaleScroll({ left: 100, top: 100 }, { x: 100, y: 100 }, 2, 1)).toEqual({
+      left: 0,
+      top: 0,
+    });
+  });
+
+  it("holds the top-left corner when the focus IS the top-left corner", () => {
+    expect(rescaleScroll(AT_TOP, { x: 0, y: 0 }, 1, 3)).toEqual({ left: 0, top: 0 });
+  });
+
+  it("treats the two axes independently", () => {
+    // A focus off-centre on x and at the corner on y must move x only.
+    expect(rescaleScroll(AT_TOP, { x: 50, y: 0 }, 1, 2)).toEqual({ left: 50, top: 0 });
+  });
+
+  it("hands back an out-of-range offset rather than clamping it", () => {
+    // The DOM clamps on assignment and is the only thing that knows the real
+    // bounds; re-deriving them here is the duplicated geometry #1805 deleted.
+    // Zooming OUT from a deep scroll legitimately computes a negative.
+    const out = rescaleScroll({ left: 10, top: 10 }, { x: 500, y: 500 }, 4, 1);
+    expect(out.left).toBeLessThan(0);
+    expect(out.top).toBeLessThan(0);
+  });
+
+  it("is a no-op when the previous scale is zero (divide guard)", () => {
+    const scroll: Scroll = { left: 7, top: 9 };
+    expect(rescaleScroll(scroll, { x: 100, y: 100 }, 0, 2)).toEqual(scroll);
   });
 });

--- a/cicchetto/src/lib/pinchZoom.ts
+++ b/cicchetto/src/lib/pinchZoom.ts
@@ -1,32 +1,40 @@
-// Pure pinch/pan geometry for the media-viewer image (#213). DOM-free so it
+// Pure pinch geometry for the media-viewer image (#213, #1805). DOM-free so it
 // unit-tests without touch physics — gemello di `swipe.ts`. The gesture itself
 // (element-level touch listeners, {passive:false}) lives in the ZoomableImage
 // component; this module owns only the math.
 //
-// WHY a hand-rolled pinch instead of native browser pinch: iOS-1
-// (2026-05-17, `<meta viewport ... maximum-scale=1, user-scalable=no>`)
-// deliberately kills the browser's native pinch-zoom app-wide so cic feels
-// like an app, not a website. That lock is a viewport-level property with no
-// per-element opt-out, so the ONLY way to zoom the modal image is to synthesize
-// the gesture ourselves and apply a CSS `transform` to the <img> alone. Because
-// the transform is scoped to the image element (not the page), the zoom/pan is
-// confined to the viewer by construction — no page-zoom, no body-scroll bleed
-// (the component ALSO preventDefaults the non-passive touchmove as belt-and-
-// braces; see DESIGN_NOTES 2026-07-12).
+// WHY the PINCH is still hand-rolled: iOS-1 (2026-05-17, `<meta viewport ...
+// maximum-scale=1, user-scalable=no>`) deliberately kills the browser's native
+// pinch-zoom app-wide so cic feels like an app, not a website. That lock is a
+// viewport-level property with no per-element opt-out, so the only way to zoom
+// the modal image is to synthesize the gesture and apply a CSS `transform` to
+// the <img> alone.
 //
-// A `Transform` is the CSS state applied to the <img>: `translate(tx px, ty px)
-// scale(scale)` under a CENTER transform-origin. `Size` is the container the
-// image is confined to (the viewer body). Translate is always clamped so a
-// zoomed image can never be dragged entirely out of the viewport: at a given
-// scale the image overflows the container by `(scale - 1) * axis`, half of
-// which is pannable each side.
+// WHY the PAN is NOT (#1805): that lock governs PAGE ZOOM, and nothing else. An
+// `overflow: auto` box inside the modal scrolls natively underneath it —
+// measured, chromium/iPhone-15 through the real touch pipeline: 112px of scroll
+// with the lock in place against 128px without it, where the whole question was
+// whether it would be zero. So the pan is the browser's job now: momentum,
+// rubber-band, scrollbar and exact bounds come for free, and the geometry that
+// used to synthesize it (`applyPan`, `maxTranslate`, and `clampTransform`'s
+// translate half) is gone rather than kept as a second answer to "where is the
+// image". What replaces it is `rescaleScroll`, which is a different job: a
+// scroll offset is anchored to a point on the IMAGE, so changing the scale has
+// to move the offset or the picture jumps out from under the fingers.
+//
+// A scale therefore travels alone — no `tx`/`ty` — and is applied as
+// `transform: scale(s)` under a `transform-origin: 0 0`. The 0 0 origin is
+// load-bearing and not a style choice: it makes image coordinates and scroll
+// coordinates the same coordinate system times `s`, which is the whole of
+// `rescaleScroll`'s arithmetic. `Size` is the image's fit-to-viewer box, which
+// the component reads off the CSS rather than recomputing.
 
 export type Point = { x: number; y: number };
 export type Size = { width: number; height: number };
-export type Transform = { scale: number; tx: number; ty: number };
 
-// Fit-to-viewer (unzoomed) baseline.
-export const IDENTITY: Transform = { scale: 1, tx: 0, ty: 0 };
+// A scroll container's offset, in the same shape the DOM uses
+// (`scrollLeft`/`scrollTop`) so a caller never has to rename fields.
+export type Scroll = { left: number; top: number };
 
 // Zoom bounds. MIN_SCALE = fit (can't zoom out past the object-fit:contain
 // baseline); MAX_SCALE caps the hand-rolled zoom so a frantic pinch can't blow
@@ -51,42 +59,41 @@ export const clamp = (value: number, min: number, max: number): number =>
 
 export const clampScale = (scale: number): number => clamp(scale, MIN_SCALE, MAX_SCALE);
 
-// Half the overflow at the given scale over `axis` px — the pannable distance
-// each side of center. Zero (never negative) at or below fit, so an unzoomed
-// image cannot pan.
-export const maxTranslate = (scale: number, axis: number): number =>
-  Math.max(0, ((scale - 1) * axis) / 2);
-
-// Clamp a transform to the legal zoom range AND confine its pan to the current
-// scale's bound (both axes). Scale is clamped FIRST so the pan bound reflects
-// the final scale — pinching back down shrinks the bound and re-clamps a pan
-// that was legal at the larger scale.
-export const clampTransform = (t: Transform, viewport: Size): Transform => {
-  const scale = clampScale(t.scale);
-  const maxX = maxTranslate(scale, viewport.width);
-  const maxY = maxTranslate(scale, viewport.height);
-  return { scale, tx: clamp(t.tx, -maxX, maxX), ty: clamp(t.ty, -maxY, maxY) };
-};
-
-// Pinch: scale the START transform by the ratio of current/start finger
-// distance, then re-confine. A zero start distance (degenerate touch) is a
-// no-op guard against divide-by-zero.
+// Pinch: scale the START scale by the ratio of current/start finger distance,
+// then re-confine. A zero start distance (degenerate touch) is a no-op guard
+// against divide-by-zero.
 export const applyPinch = (
-  start: Transform,
+  startScale: number,
   startDistance: number,
   currentDistance: number,
-  viewport: Size,
-): Transform => {
-  if (startDistance <= 0) return start;
-  const scale = start.scale * (currentDistance / startDistance);
-  return clampTransform({ scale, tx: start.tx, ty: start.ty }, viewport);
+): number => {
+  if (startDistance <= 0) return startScale;
+  return clampScale(startScale * (currentDistance / startDistance));
 };
 
-// Pan: add the drag delta to the START translate, then re-confine. The clamp
-// makes an unzoomed image (bound 0) unpannable for free.
-export const applyPan = (start: Transform, delta: Point, viewport: Size): Transform =>
-  clampTransform({ scale: start.scale, tx: start.tx + delta.x, ty: start.ty + delta.y }, viewport);
+// Double-tap toggle: fit → DOUBLE_TAP_SCALE, any zoom → back to fit. Where the
+// zoom lands is `rescaleScroll`'s business, not this function's — the toggle
+// says WHAT scale, the caller says AROUND WHAT POINT.
+export const toggleZoom = (scale: number): number =>
+  scale > MIN_SCALE ? MIN_SCALE : DOUBLE_TAP_SCALE;
 
-// Double-tap toggle: fit → DOUBLE_TAP_SCALE (centered), any zoom → back to fit.
-export const toggleZoom = (t: Transform): Transform =>
-  t.scale > MIN_SCALE ? IDENTITY : { scale: DOUBLE_TAP_SCALE, tx: 0, ty: 0 };
+// Keep the point under `focus` under `focus` across a scale change.
+//
+// `focus` is in the scroll container's own viewport coordinates (0,0 = the
+// container's top-left corner, NOT the page's). With `transform-origin: 0 0`
+// the image point currently under it is `(scroll + focus) / from`, and putting
+// that same image point back under `focus` at the new scale is
+// `imagePoint * to - focus`. That is the whole derivation.
+//
+// Deliberately NOT clamped here: assigning `scrollLeft`/`scrollTop` clamps to
+// the container's real bounds, which is the one authority that knows them — and
+// re-deriving those bounds in here is exactly the duplicated geometry #1805
+// deleted. A negative or over-large result is therefore correct input, not a
+// bug to guard.
+export const rescaleScroll = (scroll: Scroll, focus: Point, from: number, to: number): Scroll => {
+  if (from <= 0) return scroll;
+  return {
+    left: ((scroll.left + focus.x) / from) * to - focus.x,
+    top: ((scroll.top + focus.y) / from) * to - focus.y,
+  };
+};

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -13214,18 +13214,73 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   object-fit: contain;
 }
 
-/* Pinch-zoomable image (#213). `touch-action: none` hands EVERY touch to our
-   element-level JS handlers instead of letting the browser interpret it as a
-   scroll/zoom pan — mandatory for the synthesized pinch (the shell's native
-   pinch is dead via iOS-1's viewport lock; this reclaims the raw touch stream
-   for the modal image only). transform-origin: center matches the geometry in
-   lib/pinchZoom.ts (translate is measured from center). will-change hints the
-   compositor for smooth pinch. The inline `transform` style is written by the
-   component per gesture frame. */
+/* Pinch-zoomable image (#213, #1805).
+
+   `touch-action: pan-x pan-y` and NOT `none`, which is what it was until #1805.
+   The <img> is the hit target for every touch in the viewer, and the UA
+   intersects touch-action from the hit target up to the scroll container that
+   would handle the gesture — so a `none` HERE closes the scroller that wraps
+   it. Measured, chromium/iPhone-15 through the real touch pipeline: img `none`
+   inside a `pan-x pan-y` scroller scrolls 0px; img `pan-x pan-y` scrolls 130px.
+   The pinch is unaffected — `pan-x pan-y` withholds the `pinch-zoom` token, so
+   two fingers still belong to our JS.
+
+   transform-origin: 0 0 (was center center) is load-bearing arithmetic, not a
+   style: it makes image coordinates and scroll coordinates the same system
+   times the scale, which is what lets rescaleScroll in lib/pinchZoom.ts hold a
+   point under the fingers. will-change hints the compositor for smooth pinch.
+   The inline `transform` style is written by the component per gesture frame. */
 .media-viewer-media--zoomable {
-  touch-action: none;
-  transform-origin: center center;
+  touch-action: pan-x pan-y;
+  transform-origin: 0 0;
   will-change: transform;
+}
+
+/* #1805 — the image arm's re-opening of the touch stream, twin of
+   .media-viewer-modal--text one issue earlier. The base .media-viewer-modal
+   closes it with `touch-action: none`, and a descendant cannot widen what an
+   ancestor narrowed under the read where the intersection walks to the root.
+   Whether it does is engine-dependent: chromium stops at the scroll container,
+   so the base rule is inert there and this one changes nothing; Playwright's
+   WebKit exposes no touch-drag drive, so the same question cannot be put to the
+   engine this issue is about. Declaring it is correct under BOTH readings, and
+   measured free under the one that can be measured — at fit the dismiss binder
+   still received 11 cancelable touchmoves out of 11, exactly as under `none`,
+   because at fit nothing overflows and the browser has no pan to start. */
+.media-viewer-modal--zoomable {
+  touch-action: pan-x pan-y;
+}
+
+/* The scroller that replaced the synthesized pan (#1805). overscroll-behavior
+   keeps a drag past either end off the page behind the modal, the same posture
+   .media-viewer-text takes. position: relative makes it the containing block
+   for the sizer below. max-width so a zoomed image never widens the modal
+   instead of scrolling inside it. */
+.media-viewer-zoom-scroller {
+  position: relative;
+  overflow: auto;
+  overscroll-behavior: contain;
+  touch-action: pan-x pan-y;
+  max-width: 100%;
+}
+
+/* A CSS transform does not change layout, so a scaled <img> produces no
+   overflow and there would be nothing to scroll. This box is the scrollable
+   area: the component sizes it to fit x scale, and to ZERO at fit, so that at
+   fit the swipe-to-dismiss keeps the single-finger drag.
+
+   Absolutely positioned on purpose — an out-of-flow child contributes to its
+   container's scrollable overflow but NOT to its intrinsic size, so the <img>
+   goes on sizing the scroller at fit and its own max-width: 100% goes on
+   resolving against a box that does not move. In flow it would be a feedback
+   loop. pointer-events: none so the invisible box never eats a tap. */
+.media-viewer-zoom-sizer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
 }
 
 /* <audio> has no intrinsic size — give the bare controls strip a

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -65363,3 +65363,120 @@ Surface for a child that paints one, ink for a child that does not: a nick row
 is transparent and unbordered, so its border box is the full-bleed scroller it
 lives in, and measuring that sees nothing at all. That is how a 2:1 survived a
 year of specs which only ever compared the band with the launcher.
+<!-- entry #1805 -->
+
+---
+
+## 2026-08-26 — #1805: the pan goes back to the browser, and the question the bench could not be asked
+
+The media viewer's zoomed image used to pan with a JS-synthesized `translate`.
+It pans with the browser's own scroller now: momentum, rubber-band, a scrollbar
+and exact bounds arrive for free, and `applyPan` / `maxTranslate` / the
+translate half of `clampTransform` are deleted rather than kept as a second
+answer to "where is the picture". The PINCH stays synthesized — the iOS-1
+viewport lock (`maximum-scale=1, user-scalable=no`) kills native pinch app-wide
+and has no per-element opt-out, and that is unchanged and unchallenged.
+
+### The premise was measured before a line was written
+
+The issue asserted that the lock governs page zoom and not element scrolling.
+Measured on a standalone chromium/iPhone-15 bench driven through the browser's
+real input pipeline (CDP `Input.dispatchTouchEvent`, not DOM events — synthetic
+`TouchEvent`s never drive a scroll in any engine, and scored 0 in every arm, as
+labelled):
+
+| arm | lock | ancestor `touch-action` | scrolled |
+|---|---|---|---|
+| A — positive control | no | auto | 128px |
+| B — the premise | yes | auto | 112px |
+| C — production chain | yes | `none` | 105px |
+
+Arm A exists so that B and C mean something: a mechanism that cannot scroll a
+plain box has not measured the other three.
+
+### The issue's step 1 was inert, and the fix is the one that does not need to guess
+
+The issue prescribed `touch-action: pan-x pan-y` on the new wrapper alone. Under
+the reading where the UA intersects `touch-action` up to the ROOT, that is a
+no-op: `.media-viewer-modal` declares `touch-action: none` and a descendant
+cannot widen what an ancestor narrowed. #1764 had already paid exactly this and
+re-opened on the MODAL element (`.media-viewer-modal--text`); #1805 does the
+same one class along (`--zoomable`).
+
+Chromium does not read it that way — arm C above scrolls 105px straight through
+an ancestor `none`, because the intersection stops at the scroll container. So
+on chromium the re-opening changes nothing. It is declared anyway, and the
+reason is not that it is cheap: **a cure that is correct under both readings
+beats one that is correct only if the guess is right**, and the reading that
+applies on WebKit is not measurable here (below). Measured free on the arm that
+can be measured: at fit the dismiss binder still received 11 cancelable
+touchmoves out of 11, exactly as it does under `none`, because at fit nothing
+overflows and the browser has no pan to start.
+
+### What the issue did not say: the `<img>` is the hit target
+
+`.media-viewer-media--zoomable` declared `touch-action: none`. Intersection runs
+from the HIT TARGET up to the scroll container, so that `none` closes the
+scroller that wraps it — a different question from arm C, and it has the
+opposite answer: img `none` inside a `pan-x pan-y` scroller scrolls **0px**; img
+`pan-x pan-y` scrolls 130px. Both declarations are therefore load-bearing and
+neither is redundant with the other.
+
+### The sizer, and why it is out of flow
+
+A CSS transform does not change layout, so a scaled `<img>` produces no overflow
+and there is nothing to scroll. `.media-viewer-zoom-sizer` carries the
+scrollable area at `fit × scale`. It is absolutely positioned on purpose: an
+out-of-flow child contributes to its container's scrollable overflow but NOT to
+its intrinsic size, so the `<img>` goes on sizing the scroller at fit and its
+own `max-width: 100%` goes on resolving against a box that does not move. In
+flow it is a feedback loop. The component MIRRORS the fit box (`clientWidth`,
+via a `ResizeObserver`) rather than recomputing `object-fit: contain` in JS —
+the CSS stays the owner of the fit.
+
+The sizer is **zero at fit**, not `fit × 1`. `clientWidth` is rounded to an
+integer, so `fit × 1` can exceed the real box by a sub-pixel, and a sub-pixel of
+overflow is enough for the browser to claim the single-finger drag and take
+swipe-to-dismiss away. Measured why it matters: with the dismiss binder claiming
+while zoomed, its `preventDefault` pins the scroll at 0 — the `canDismiss` gate
+is load-bearing, and it must be asked at touchstart, because from the second
+move onward the browser has already taken the gesture and `cancelable` collapses
+to 1 in 9.
+
+`transform-origin` moved from `center center` to `0 0`. That is arithmetic, not
+taste: with a 0 0 origin an image coordinate is a scroll coordinate over the
+scale, which is the whole derivation of `rescaleScroll`, the pure function that
+holds the touched point under the fingers across a scale change. Pinch and
+double-tap both go through it, so there is one answer to "where does the picture
+land" instead of two.
+
+### Rejected: CSS `zoom`
+
+`zoom: s` scales LAYOUT, so the scroller would overflow with no sizer, no
+`ResizeObserver` and no mirrored fit — one property against three moving parts.
+Declined because it re-rasters a full-size photo every pinch frame where
+`transform` composites an existing texture, and the pinch smoothness that would
+cost cannot be measured from this host on the device that matters. The sizer
+keeps the compositor path the pinch already had.
+
+### 🔴 What was NOT measured, and must not be read as if it were
+
+**No touch measurement exists on WebKit.** Playwright's WebKit backend exposes
+`Input.dispatchTapEvent` and nothing else for touch (`playwright-core`
+`wkInput.js`: key, mouse, wheel, tap), and `mouse.wheel` is refused outright in
+mobile WebKit. So the positive control for touch on WebKit is EMPTY, and its
+zeros measure the harness rather than the product. From WebKit there is only:
+the box overflows, it scrolls programmatically under the lock, and the computed
+styles are what the stylesheet says. Whether WebKit stops its `touch-action`
+intersection at the scroll container the way chromium does is **unknown**, which
+is precisely why the modal-level re-opening is declared.
+
+Real taps ARE drivable on WebKit, so the e2e's webkit leg double-taps for real
+and asserts that zooming creates genuine overflow (`scrollHeight >
+clientHeight`) and that moving the scroller moves the painted picture. The DRAG
+itself is not drivable and is not faked.
+
+Device dogfood, unverifiable from any harness here: momentum, rubber-band at the
+edges, and whether iOS begins a rubber-band before the dismiss binder's claim
+lands — the same open question #1764 wrote down for the text pane, now on a
+second surface.


### PR DESCRIPTION
Refs #1805.

The media viewer's zoomed image panned with a JS-synthesized `translate`. It
pans with the browser's own scroller now — momentum, rubber-band, a scrollbar
and exact bounds arrive for free — and the geometry that used to synthesize it
(`applyPan`, `maxTranslate`, the translate half of `clampTransform`) is deleted
rather than left as a second answer to "where is the picture".

The **pinch stays synthesized**. iOS-1's viewport lock (`maximum-scale=1,
user-scalable=no`) kills native pinch app-wide with no per-element opt-out; that
is unchanged and unchallenged. Scope is the pan only.

## The premise was measured before any code was written

The issue asserted that the lock governs page zoom and not element scrolling.
Measured on a standalone chromium/iPhone-15 bench driven through the browser's
**real input pipeline** (CDP `Input.dispatchTouchEvent`, not DOM events — a
script-dispatched `TouchEvent` never drives a scroll in any engine and scored 0
in every arm, which is why it is labelled inert rather than reported as a
result):

| arm | viewport lock | ancestor `touch-action` | scrolled |
|---|---|---|---|
| A — positive control | no | `auto` | 128px |
| B — the premise | **yes** | `auto` | **112px** |
| C — the production chain | yes | `none` | 105px |

Arm A is there so B and C mean something: a drive mechanism that cannot scroll a
plain box has measured nothing in the other arms.

## Four things this PR declares, because three of them are not in the issue

### 1. The issue's step 1 is inert as written, and the fix is the one that does not depend on a guess

The issue prescribed `touch-action: pan-x pan-y` **on the new wrapper alone**.
Under the reading where the UA intersects `touch-action` up to the ROOT that is
a no-op: `.media-viewer-modal` declares `touch-action: none`, and a descendant
cannot widen what an ancestor narrowed. **#1764 already paid exactly this** and
re-opened on the MODAL element (`.media-viewer-modal--text`). This PR does the
same one class along — `.media-viewer-modal--zoomable`.

Chromium does not read it that way: arm C above scrolls **105px straight through
an ancestor `none`**, because the intersection stops at the scroll container. So
on chromium the re-opening changes nothing at all.

It is declared anyway, and the reason is **not** that it is cheap. The reading
that applies on WebKit is not measurable from this harness (see "what was not
measured"), and **a cure that is correct under both readings beats one that is
correct only if the guess is right.** It is also measured free under the reading
that can be measured: at fit the dismiss binder still received **11 cancelable
touchmoves out of 11**, exactly as it does under `none`, because at fit nothing
overflows and the browser has no pan to start.

### 2. The `<img>`'s own `touch-action: none` had to fall — a DIFFERENT question, with the opposite answer

`.media-viewer-media--zoomable` declared `touch-action: none`. The `<img>` is the
**hit target** for every touch in the viewer, and the intersection runs from the
hit target up to the scroll container — so that `none` closes the scroller that
wraps it. Measured, same bench:

| `<img>` | scroller | scrolled |
|---|---|---|
| `none` | `pan-x pan-y` | **0px** |
| `pan-x pan-y` | `pan-x pan-y` | **130px** |
| `auto` | `pan-x pan-y` | 128px |
| `pan-x pan-y` | `none` | 0px |

This is not the same question as arm C and it does not have the same answer: an
ancestor ABOVE the scroller is irrelevant, the hit target below it is decisive.
The issue does not mention it.

### 3. An assertion belonging to #1438 changed, and it is an update rather than a weakening

`e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts` asserted that the viewer
container computes `touch-action: none` on iPhone 15. With the image variant
re-opening the stream, that now reads `pan-x pan-y`. The assertion is
**updated in place with the reason written next to it, not deleted.**

What #1438 actually owns is unaffected and is still asserted **by tests this PR
does not touch**: the two drag tests directly above it check that a drag
dismisses and that the modal tracks the finger with its centering intact. The
base `touch-action: none` is still the rule for every other kind and is pinned
at source level in `mediaViewerTouchAction.test.ts`.

### 4. `pngOfSize` exists because the geometric e2e would otherwise have been a hollow green

The shared upload fixture uploads `TINY_PNG_HEX`, which is **1×1**, and the
viewer never scales an image UP past its intrinsic size. So on that constant the
viewer's image is one pixel and **every geometric assertion about it — does
zooming create a scrollable area, did the visible portion move — is satisfied by
a one-pixel answer whether or not the feature works.**

`e2e/fixtures/bytes.ts` gains `pngOfSize(w, h)`, built rather than pasted (the
`silentMp3` precedent in the same file; CRCs computed, not transcribed, which is
the failure mode the shared constant exists to prevent), and `mediaViewer.ts`
gains `uploadSizedImageAndGetLink` as its own verb — eight call sites want the
dot and do not care, and a parameter at nine sites is a thing a reviewer has to
check nine times.

## How it works

A CSS transform does not change layout, so a scaled `<img>` produces no overflow
and there would be nothing to scroll. `.media-viewer-zoom-sizer` carries the
scrollable area at `fit × scale`. It is **absolutely positioned**: an out-of-flow
child contributes to its container's scrollable overflow but NOT to its intrinsic
size, so the `<img>` goes on sizing the scroller at fit and its own
`max-width: 100%` goes on resolving against a box that does not move. In flow it
is a feedback loop. The component MIRRORS the fit box (`clientWidth`, via a
`ResizeObserver`) rather than recomputing `object-fit: contain` in JS — the CSS
stays the owner of the fit.

The sizer is **zero at fit**, not `fit × 1`. `clientWidth` is rounded to an
integer, so `fit × 1` can exceed the real box by a sub-pixel, and a sub-pixel of
overflow is enough for the browser to claim the single-finger drag and take
swipe-to-dismiss away. Measured why that gate matters: with the dismiss binder
claiming while zoomed, its `preventDefault` **pins the scroll at 0** — so
`canDismiss` is load-bearing, and it must be asked at touchstart, because from
the second move onward the browser has already taken the gesture and `cancelable`
collapses to 1 in 9.

`transform-origin` moves from `center center` to `0 0`. That is arithmetic, not
taste: with a 0 0 origin an image coordinate is a scroll coordinate over the
scale, which is the whole derivation of `rescaleScroll` — the pure function both
the pinch and the double-tap go through to hold the touched point under the
fingers, so there is one answer to "where does the picture land" and not two.

**Rejected: CSS `zoom`.** It scales LAYOUT, so the scroller would overflow with
no sizer, no `ResizeObserver` and no mirrored fit — one property against three
moving parts. Declined because it re-rasters a full-size photo every pinch frame
where `transform` composites an existing texture, and that cost cannot be
measured from this host on the device that matters.

## 🔴 What was NOT measured

**There is no touch measurement on WebKit at all, and its zeros are not
reported as results.** Playwright's WebKit backend exposes
`Input.dispatchTapEvent` and nothing else for touch (`playwright-core`
`wkInput.js`: key, mouse, wheel, tap), and `mouse.wheel` is refused outright in
mobile WebKit. The positive control for touch on that engine is therefore
**empty**, so a zero from it would measure the harness rather than the product.
From WebKit there is only: the box overflows, it scrolls programmatically under
the lock, and the computed styles are what the stylesheet says.

Real **taps** are drivable there, so the webkit e2e leg double-taps for real and
asserts that zooming creates genuine overflow (`scrollHeight > clientHeight`)
and that moving the scroller moves the painted picture. The **drag** is not
drivable and is not faked.

## Device dogfood — required, and not simulated by anything here

- [ ] Zoom in, drag with one finger: **momentum** carries after the finger lifts.
- [ ] Drag past an edge: **rubber-band**, and it does not drag the page or the
      browser chrome in behind the modal.
- [ ] At fit, a single-finger drag still **dismisses** the viewer, up and down.
- [ ] The open question inherited from #1764, now on a second surface: does iOS
      begin a rubber-band **before** the dismiss binder's claim lands?
- [ ] Pinch still feels the way it did — the transform path is unchanged, but
      the scroll compensation per frame is new.

## Tests

- `pinchZoom.test.ts` — the pan-geometry tests are **replaced, not deleted**:
  `applyPan` / `maxTranslate` / the `clampTransform` translate bounds go away
  with the code they covered, and `rescaleScroll` arrives with its own set.
- `MediaViewerModal.test.tsx` — the wiring only this component can get wrong: a
  one-finger touchmove left unclaimed, a two-finger one still claimed, the sizer
  zero at fit and `fit × scale` when zoomed, and the zoom anchored to the tapped
  point rather than the corner.
- `mediaViewerTouchAction.test.ts` — the source-level CSS contract, including the
  negative assertion that the `<img>` is no longer `touch-action: none`.
- `issue213-pinch-zoom.spec.ts` — a **real** one-finger drag on chromium through
  CDP, asserting painted displacement cross-checked against the scroller's
  offset; the CSS contract and the scrollable-area fact on webkit.

### Red before green, measured — and one of the mutants was kept until it answered

Each new assertion was shown to fail against a deliberate break before being
believed. Control run with no mutant planted: **86 passed, rc=0** — without a
green control the kills mean nothing.

| mutant | the break | killed |
|---|---|---|
| M1 | blanket `preventDefault` back on every touchmove | 1 |
| M2 | `touch-action: none` back on the `<img>` | 1 |
| M3 | sizer sized `fit × scale` **even at fit** | **2** |
| M4 | `transform-origin` back to `center center` | 1 |
| M5 | the double-tap's RETURN path floored above `MIN_SCALE` | 1 |

M3 killing **two** left a real question open — is *"unwinds the scroll when the
second double-tap returns the image to fit"* redundant with *"carries NO
scrollable area at fit"*? The discriminating test is not an argument, it is
whether a break exists that kills the second and **not** the first. M5 is that
break: at the double-tap call site the toggle is floored at `MIN_SCALE + 0.01`,
so the OPENING arm is bit-for-bit unchanged (`max(2, 1.01) = 2`) and only the
RETURN arm breaks (`max(1, 1.01) = 1.01`). It was planted at the call site
rather than inside `toggleZoom` precisely so the pure function's own unit tests
stay green and the reading is not muddied by a third casualty.

**Result: `1 failed | 85 passed` — only the second assertion died.** The two are
not redundant and both stay.

The bench refuses two failure modes it has already paid for: a mutant that
breaks SYNTAX is not a mutant (`tsc` runs first and a non-zero rc voids the run
— here `tsc rc=0`), and an injector that truncates its own target reports a
green-looking rout (line count is printed either side — here 630 → 630).
