### PR TITLE
#1807 — credits: make the Matrix rain read as rain, without touching the Debug panel

### DIFF
--- a/cicchetto/e2e/tests/issue1807-credits-rain-reads-as-rain.spec.ts
+++ b/cicchetto/e2e/tests/issue1807-credits-rain-reads-as-rain.spec.ts
@@ -1,0 +1,236 @@
+// #1807 — the credits rain is loud, the Debug panel's rain is NOT, and the
+// interlude burst rides the roll's own clock.
+//
+// WHAT ONLY THIS GATE CAN SEE. #1807 made `MatrixRain`'s four drawing knobs
+// per-surface. vitest can pin the numbers each caller passes and the ops the
+// component issues against a recording context, and it does
+// (`AdminDebugTab.test.tsx`, `MatrixRain.test.tsx`). What it cannot do is
+// rasterise: jsdom has no canvas, so "the credits rain actually puts a
+// near-opaque pixel on screen and the phosphor panel actually does not" is
+// unreachable there. Reading the pixels back with `getImageData` is that
+// claim, made against a real 2D rasteriser.
+//
+// It also cannot run a CSS animation. `creditsRain.rollIsParked` reads the
+// roll's phase and takes the start of the interlude off the animation's OWN
+// keyframes, so the stylesheet stays the single source of truth — and every
+// jsdom test of it runs against a HAND-BUILT `getAnimations`. That the
+// browser exposes `computedOffset` and the parked transform the reader
+// depends on is asserted here, on the real animation, and so is the
+// consequence: seeking the ROLL's clock into the hold makes the RAIN change.
+// That is the one-clock contract, and a rain driven by a `setTimeout` of its
+// own would sail straight through it.
+//
+// THE METRIC. Premultiplied channel value, `channel * alpha`. The canvas
+// accumulates a black wash, so the raw (unpremultiplied) value a pixel
+// reports depends on how opaque its backing has become; the premultiplied
+// one does not, and it is what the compositor puts on screen.
+//
+//   * one Debug glyph is `rgba(255, 176, 0, 0.18)` -> premultiplied red 46
+//   * the credits leader is `rgba(255, 232, 176, 0.95)` -> red 242, blue 167
+//   * the BURST leader is white at full alpha -> red 255, blue 255
+//
+// So red separates "there is a bright head" from "there is only dim trail",
+// and blue separates the white burst leader from the amber steady one. The
+// thresholds below sit in the wide middle of each gap.
+//
+// WHAT IS NOT PROVEN HERE, and cannot be: whether it READS as rain. That is
+// a judgement about legibility over a dark theme on a real device, and the
+// issue asks for it on a real iPhone, on BOTH surfaces. See the dogfood
+// checklist on the PR.
+//
+// SCOPE. chromium only. The defect's platform is a phone, and this is not
+// it — but the two claims made here are engine-independent (canvas 2D
+// rasterisation and the Web Animations API), and the mobile project only
+// takes `@webkit`-tagged specs.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: the Debug panel is
+// admin-gated, the EXEMPT shape; the credits roll is subject-shape-agnostic
+// (it names the BUILD, not the reader), so registered vjt suffices — the
+// same reading #1773's spec made.
+
+import type { Page } from "@playwright/test";
+import {
+  adminLogin,
+  loginAs,
+  openAdminConsole,
+  openSettingsDrawer,
+} from "../fixtures/cicchettoPage";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, specUser, test } from "../fixtures/test";
+
+test.setTimeout(90_000);
+
+/**
+ * The rain turns itself OFF under `prefers-reduced-motion`, and the roll
+ * loses its animation with it — so an inherited preference would make every
+ * assertion here vacuous in the same direction (nothing painted reads as
+ * nothing loud). Stated rather than assumed.
+ */
+async function withMotion(page: Page): Promise<void> {
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+}
+
+/** Well above one dim glyph (46), well below a leader (242). */
+const PANEL_INK_CEILING = 120;
+/** A leader lands at 242; a stack of dim trail glyphs cannot reach this. */
+const LEADER_INK_FLOOR = 200;
+/** The steady leader's blue is 167; only the white burst leader clears this. */
+const BURST_BLUE_FLOOR = 210;
+
+type InkPeak = { readonly red: number; readonly blue: number };
+
+/**
+ * The brightest premultiplied red and blue anywhere on a rain canvas.
+ *
+ * Peak rather than mean on purpose: the leader is a handful of pixels per
+ * column against a mostly-empty canvas, so any average would drown exactly
+ * the thing under test.
+ */
+async function inkPeak(page: Page, testId: string): Promise<InkPeak> {
+  return await page.locator(`[data-testid="${testId}"] canvas`).evaluate((node) => {
+    const canvas = node as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null || canvas.width === 0 || canvas.height === 0) return { red: 0, blue: 0 };
+    const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    let red = 0;
+    let blue = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      const alpha = (data[i + 3] ?? 0) / 255;
+      red = Math.max(red, (data[i] ?? 0) * alpha);
+      blue = Math.max(blue, (data[i + 2] ?? 0) * alpha);
+    }
+    return { red, blue };
+  });
+}
+
+/**
+ * The loudest thing the canvas paints over `windowMs`.
+ *
+ * Not a sleep: every iteration is a `getImageData` round trip, so the loop
+ * paces itself off the browser and the window bounds how many of the ~15fps
+ * frames get sampled. A ceiling claim needs MANY frames — one sample could
+ * land between two heads and report a quiet canvas that is never quiet.
+ */
+async function inkPeakOver(page: Page, testId: string, windowMs: number): Promise<InkPeak> {
+  const until = Date.now() + windowMs;
+  let red = 0;
+  let blue = 0;
+  do {
+    const peak = await inkPeak(page, testId);
+    red = Math.max(red, peak.red);
+    blue = Math.max(blue, peak.blue);
+  } while (Date.now() < until);
+  return { red, blue };
+}
+
+test("#1807 — the Debug tab's phosphor rain stays as dim as it always was", async ({ page }) => {
+  // The constraint the whole per-surface shape exists to protect: this rain
+  // falls BEHIND viewport readouts an operator is trying to read. Nobody
+  // asked for it to change, and the type system cannot say a future edit did
+  // not hand it the credits modal's numbers.
+  await withMotion(page);
+  await adminLogin(page, getSeededAdmin());
+  await openAdminConsole(page);
+  await page.getByTestId("admin-tab-debug").click();
+  await expect(page.getByTestId("admin-debug-tab")).toBeVisible({ timeout: 10_000 });
+
+  // Five taps on the panel heading is the gate the rain has always sat
+  // behind — the real gesture, not a signal poked from the outside.
+  const panel = page.locator(".adm-matrix");
+  for (let i = 0; i < 5; i++) await panel.click();
+  await expect(page.getByTestId("admin-matrix-rain")).toBeVisible({ timeout: 5_000 });
+
+  // ANTI-HOLLOW-GREEN. A canvas that never painted satisfies any ceiling.
+  await expect
+    .poll(async () => (await inkPeak(page, "admin-matrix-rain")).red, {
+      timeout: 15_000,
+      message: "the phosphor rain never put a single glyph on its canvas",
+    })
+    .toBeGreaterThan(0);
+
+  const peak = await inkPeakOver(page, "admin-matrix-rain", 3_000);
+  expect(
+    peak.red,
+    "a bright head appeared on the Debug panel — the credits look reached a surface it must not",
+  ).toBeLessThan(PANEL_INK_CEILING);
+});
+
+test("#1807 — the credits rain paints a bright leader, and the burst rides the roll's clock", async ({
+  page,
+}) => {
+  await withMotion(page);
+  await loginAs(page, specUser());
+  await openSettingsDrawer(page);
+  await page.getByTestId("credits-entry").click();
+  await expect(page.getByTestId("credits-modal")).toBeVisible({ timeout: 5_000 });
+
+  // ── the head is actually near-opaque ────────────────────────────────────
+  // This is the defect: at #1773's settings the rain read as a faint texture
+  // because every glyph in a column was painted identically and dim.
+  await expect
+    .poll(async () => (await inkPeak(page, "credits-matrix-rain")).red, {
+      timeout: 15_000,
+      message: "no near-opaque leader ever appeared on the credits rain",
+    })
+    .toBeGreaterThanOrEqual(LEADER_INK_FLOOR);
+
+  // ── the interlude exists, and the browser exposes what the reader needs ──
+  const roll = page.getByTestId("credits-roll");
+  const timing = await roll.evaluate((node) => {
+    const anim = node.getAnimations()[0];
+    const effect = anim?.effect ?? null;
+    if (effect === null) return null;
+    const duration = effect.getComputedTiming().duration;
+    const stops = (effect as KeyframeEffect)
+      .getKeyframes()
+      .map((frame) => ({ at: frame.computedOffset, transform: String(frame.transform) }));
+    return { durationMs: typeof duration === "number" ? duration : null, stops };
+  });
+
+  expect(timing, "the roll carries no running animation to read a phase off").not.toBeNull();
+  const stops = timing?.stops ?? [];
+  const finalTransform = stops.at(-1)?.transform;
+  const parkAt = stops.find((stop) => stop.transform === finalTransform)?.at ?? 1;
+  expect(parkAt, "the roll never parks — there is no interlude to hold on").toBeLessThan(1);
+  const interludeMs = (timing?.durationMs ?? 0) * (1 - parkAt);
+  expect(interludeMs).toBeGreaterThanOrEqual(5_000);
+  expect(interludeMs).toBeLessThanOrEqual(7_000);
+
+  // ── mid-roll there is no white ──────────────────────────────────────────
+  // The counter-claim. Without it, a rain that bursts CONTINUOUSLY would pass
+  // the assertion below.
+  const steady = await inkPeakOver(page, "credits-matrix-rain", 2_000);
+  expect(steady.blue, "the burst is firing while the titles are still rolling").toBeLessThan(
+    BURST_BLUE_FLOOR,
+  );
+
+  // ── ONE CLOCK ───────────────────────────────────────────────────────────
+  // Move the ROLL's time and nothing else. If the burst were on a timer of
+  // its own — the shape that drifts in a backgrounded tab, where rAF stops
+  // and timers do not — this would change the titles and leave the rain
+  // exactly as amber as it was.
+  await roll.evaluate((node) => {
+    const anim = node.getAnimations()[0];
+    if (anim === undefined) return;
+    const effect = anim.effect;
+    if (effect === null) return;
+    const duration = effect.getComputedTiming().duration;
+    const stops = (effect as KeyframeEffect)
+      .getKeyframes()
+      .map((frame) => ({ at: frame.computedOffset, transform: String(frame.transform) }));
+    const finalStop = stops.at(-1)?.transform;
+    const parks = stops.find((stop) => stop.transform === finalStop)?.at ?? 1;
+    // The MIDDLE of the hold, computed from the keyframes rather than typed
+    // here, so retiming the roll retimes this seek with it.
+    anim.currentTime = (typeof duration === "number" ? duration : 0) * ((parks + 1) / 2);
+  });
+
+  await expect
+    .poll(async () => (await inkPeak(page, "credits-matrix-rain")).blue, {
+      timeout: 10_000,
+      message:
+        "the roll is parked in its interlude and the rain never went white — the burst is not " +
+        "reading the roll's phase",
+    })
+    .toBeGreaterThanOrEqual(BURST_BLUE_FLOOR);
+});

--- a/cicchetto/e2e/tests/issue1807-credits-rain-reads-as-rain.spec.ts
+++ b/cicchetto/e2e/tests/issue1807-credits-rain-reads-as-rain.spec.ts
@@ -134,9 +134,18 @@ test("#1807 — the Debug tab's phosphor rain stays as dim as it always was", as
   await page.getByTestId("admin-tab-debug").click();
   await expect(page.getByTestId("admin-debug-tab")).toBeVisible({ timeout: 10_000 });
 
-  // Five taps on the panel heading is the gate the rain has always sat
-  // behind — the real gesture, not a signal poked from the outside.
-  const panel = page.locator(".adm-matrix");
+  // Five taps on the panel is the gate the rain has always sat behind — the
+  // real gesture, not a signal poked from the outside.
+  //
+  // Scoped by the PROMPT line, because the tab carries THREE `.adm-matrix`
+  // panels ("Viewport diagnostics", "Element chain", "Event log") and only
+  // the first one wears `onClick={tapHeading}`. A bare `.adm-matrix` is a
+  // strict-mode violation, and picking `.first()` instead would be a guess
+  // that goes stale the day a panel is added above it. `.adm-matrix-prompt`
+  // is that panel's own affordance line and exists nowhere else; the
+  // assertion below then re-checks the choice for free, since tapping the
+  // wrong panel mounts no rain at all.
+  const panel = page.locator(".adm-matrix:has(.adm-matrix-prompt)");
   for (let i = 0; i < 5; i++) await panel.click();
   await expect(page.getByTestId("admin-matrix-rain")).toBeVisible({ timeout: 5_000 });
 

--- a/cicchetto/src/AdminDebugTab.tsx
+++ b/cicchetto/src/AdminDebugTab.tsx
@@ -1,7 +1,7 @@
 import { type Component, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import AdminCard from "./admin/AdminCard";
 import { isDiagEnabled, setDiagEnabled } from "./DiagFloat";
-import MatrixRain from "./MatrixRain";
+import MatrixRain, { type MatrixRainLook } from "./MatrixRain";
 
 // UX-6 D12 (2026-05-21) — Admin → Debug tab. Hosts the iOS PWA
 // keyboard / viewport diagnostics. Previously lived inside
@@ -28,6 +28,28 @@ import MatrixRain from "./MatrixRain";
 // Per-class parity matrix (`feedback_e2e_user_class_parity_matrix`):
 // admin-gated, EXEMPT. e2e coverage at m7-admin-gate proves
 // non-admin can't reach AdminPane at all; this tab inherits.
+
+/**
+ * What the phosphor rain looks like here — and it is deliberately EXACTLY
+ * what `MatrixRain` hardcoded before #1807 made the knobs per-surface,
+ * measured on `4c9270c5`.
+ *
+ * #1807 made the credits modal's rain loud, because there the rain IS the
+ * picture. Here it is not: it falls BEHIND viewport readouts an operator is
+ * trying to read, and low alpha plus a short trail is what keeps them
+ * readable-through. `leader: null` is the same statement about shape — no
+ * bright head, one glyph per column per frame, which is the drawing the
+ * panel has always had.
+ *
+ * Exported so `AdminDebugTab.test.tsx` can pin the four values against that
+ * commit without re-typing them.
+ */
+export const ADM_RAIN_LOOK: MatrixRainLook = {
+  glyphAlpha: 0.18,
+  fadeAlpha: 0.1,
+  leader: null,
+  rowsPerFrame: 1,
+};
 
 const AdminDebugTab: Component = () => {
   const [diagWinH, setDiagWinH] = createSignal(0);
@@ -186,7 +208,7 @@ const AdminDebugTab: Component = () => {
           {/* biome-ignore lint/a11y/noStaticElementInteractions: same. */}
           <div class="adm-matrix" onClick={tapHeading}>
             <Show when={rainOn()}>
-              <MatrixRain class="adm-rain" testId="admin-matrix-rain" />
+              <MatrixRain class="adm-rain" testId="admin-matrix-rain" look={() => ADM_RAIN_LOOK} />
             </Show>
             <p class="adm-matrix-prompt" aria-hidden="true">
               grappa@cicchetto:~$ tail -f /dev/viewport

--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -8,6 +8,7 @@ import {
   creditsMuted,
   toggleCreditsMuted,
 } from "./lib/creditsModal";
+import { CREDITS_RAIN_LOOK } from "./lib/creditsRain";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import MatrixRain from "./MatrixRain";
 
@@ -95,7 +96,11 @@ const CreditsModal: Component = () => {
         aria-label="credits"
         data-testid="credits-modal"
       >
-        <MatrixRain class="credits-rain" testId="credits-matrix-rain" />
+        <MatrixRain
+          class="credits-rain"
+          testId="credits-matrix-rain"
+          look={() => CREDITS_RAIN_LOOK}
+        />
 
         <div class="credits-chrome">
           <button

--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -8,7 +8,7 @@ import {
   creditsMuted,
   toggleCreditsMuted,
 } from "./lib/creditsModal";
-import { CREDITS_RAIN_LOOK } from "./lib/creditsRain";
+import { creditsRainLook } from "./lib/creditsRain";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import MatrixRain from "./MatrixRain";
 
@@ -84,6 +84,14 @@ const CreditsModal: Component = () => {
   const versionLabel = (): string => bootBundleVersionAccessor() ?? "version unknown";
   const dateLabel = (): string | null => creditsDateLabel(credits.date);
 
+  // #1807 — the roll's own animation is the ONLY clock. `MatrixRain` calls
+  // `look` once per drawn frame from inside the loop it already runs, and
+  // `creditsRainLook` answers by reading this element's animation phase, so
+  // the burst can never drift away from the interlude it belongs to. Assigned
+  // during element creation, which is before any `onMount` — including the
+  // one that starts the rain — so the loop never sees it unset.
+  let roll: HTMLDivElement | undefined;
+
   return (
     <Show when={creditsModalOpen()}>
       {/* One fixed full-viewport box, not a backdrop plus a centred dialog:
@@ -99,7 +107,7 @@ const CreditsModal: Component = () => {
         <MatrixRain
           class="credits-rain"
           testId="credits-matrix-rain"
-          look={() => CREDITS_RAIN_LOOK}
+          look={() => creditsRainLook(roll)}
         />
 
         <div class="credits-chrome">
@@ -126,9 +134,18 @@ const CreditsModal: Component = () => {
 
         {/* The roll scrolls by CSS animation, so the loop costs no frame
             budget of ours and `prefers-reduced-motion` can turn it into a
-            plain scrollable column with one media query — see default.css. */}
+            plain scrollable column with one media query — see default.css.
+            #1807 lengthened the cycle and parked the translate before its
+            end; that tail IS the interlude, and it is read back off this
+            element rather than counted a second time in JS. */}
         <div class="credits-viewport">
-          <div class="credits-roll" data-testid="credits-roll">
+          <div
+            class="credits-roll"
+            data-testid="credits-roll"
+            ref={(node) => {
+              roll = node;
+            }}
+          >
             <h2 class="credits-title" data-testid="credits-title">
               GRAPPA IRC
             </h2>

--- a/cicchetto/src/MatrixRain.tsx
+++ b/cicchetto/src/MatrixRain.tsx
@@ -12,6 +12,17 @@ import { type Component, onCleanup, onMount } from "solid-js";
 // implementation. NOT defaulted: a default class would silently give the
 // second caller the first caller's stylesheet hook.
 //
+// #1807 made the four DRAWING knobs a prop for the same reason. The credits
+// modal read as a faint texture rather than as rain and needed all four
+// louder; the Debug panel needs exactly what it had, because it rains behind
+// readouts an operator must read THROUGH. Hardcoding the louder values here
+// would have changed a surface nobody asked to change, so `look` carries
+// them and each surface owns its own. Not CSS custom properties: reading
+// them costs a style recalc inside the frame loop, jsdom resolves them to
+// empty (so every knob would need a fallback, which is the silent default
+// this component has refused since #1773), and the burst below is a
+// FUNCTION of time that no custom property can express.
+//
 // Sized off the PARENT box rather than the window: it is a panel effect,
 // not a page overlay, so it must follow the panel through a resize, a
 // keyboard slide-in, or a column reflow. A `ResizeObserver` is the only
@@ -23,16 +34,47 @@ import { type Component, onCleanup, onMount } from "solid-js";
 //     LIVE rather than read once at mount — a user who enables it while
 //     this is running is the case the setting most needs to work for.
 //   * One rAF loop at ~15fps, cancelled on cleanup. This shares a phone
-//     with diag readouts that re-render on every resize event.
+//     with diag readouts that re-render on every resize event. `look` is
+//     read INSIDE that loop, once per drawn frame, so a caller that varies
+//     the effect over time does it on this clock and never starts a second
+//     one — a `setTimeout` would drift exactly where it matters, in a
+//     backgrounded tab where rAF stops and timers do not.
 //   * Canvas, not DOM — a few hundred animated glyph nodes would fight
 //     the pane for layout every frame.
 //   * `pointer-events: none`, so it can never take a tap meant for a
 //     control underneath.
-//   * Low alpha: it has to stay readable-through.
 
 const GLYPHS = "01アイウエオカキクケコサシスセソタチツテトナニヌネノ<>[]{}/\\|=+*#$%&";
 const FONT_SIZE = 14;
 const FRAME_MS = 66;
+// `fillText`'s default baseline is alphabetic, so a glyph drawn at `y`
+// occupies roughly [y - FONT_SIZE, y + DESCENDER]. The punch below has to
+// cover the descender too, or a tail of the previous head survives it.
+const DESCENDER = 4;
+
+/** The trail colour. Amber is the phosphor both surfaces are built around;
+    only its alpha is per-surface, so the hue is not a knob. */
+const TRAIL_RGB = "255, 176, 0";
+
+/**
+ * The four drawing knobs, per surface (#1807). Every one of them was a
+ * literal in the loop below until the credits modal needed all four louder
+ * than the Debug panel can afford.
+ */
+export type MatrixRainLook = {
+  /** Alpha of a glyph once the leader has moved past it. */
+  readonly glyphAlpha: number;
+  /** Per-frame black wash over the whole canvas. LOWER leaves a longer
+      streak: the trail dies as `(1 - fadeAlpha)^frames`. */
+  readonly fadeAlpha: number;
+  /** Fill for the head of each column, or `null` to paint it like the rest
+      of the trail — which is what the effect did before #1807, and what the
+      Debug panel still asks for. */
+  readonly leader: string | null;
+  /** Rows advanced per drawn frame. Fractional: the speed must not come
+      from the frame budget, because at ~6fps the columns visibly step. */
+  readonly rowsPerFrame: number;
+};
 
 // No `on` prop: the caller gates it with `<Show>`, so being MOUNTED is the
 // on state and unmounting stops the loop through `onCleanup`. An `on`
@@ -44,7 +86,16 @@ type MatrixRainProps = {
   /** `data-testid` on the wrapper, so each surface is addressable on its
       own — a shared id would make a spec unable to say WHICH rain it found. */
   readonly testId: string;
+  /** What the rain should look like RIGHT NOW. Called once per drawn frame
+      from inside the loop, so a surface whose effect varies over time (the
+      credits interlude burst) answers on this clock instead of running one
+      of its own. A surface with a fixed look returns a constant. */
+  readonly look: () => MatrixRainLook;
 };
+
+/** The head of a column as it was painted last frame, so the next frame can
+    cool it down to the trail colour. `null` until the column has a head. */
+type Head = { readonly y: number; readonly glyph: string };
 
 const MatrixRain: Component<MatrixRainProps> = (props) => {
   let canvas: HTMLCanvasElement | undefined;
@@ -69,12 +120,18 @@ const MatrixRain: Component<MatrixRainProps> = (props) => {
     if (ctx === null) return;
 
     let columns: number[] = [];
+    let heads: (Head | null)[] = [];
     const resize = (): void => {
       const box = el.parentElement;
       if (box === null) return;
       el.width = box.clientWidth;
       el.height = box.clientHeight;
-      columns = new Array(Math.ceil(el.width / FONT_SIZE)).fill(0);
+      const count = Math.ceil(el.width / FONT_SIZE);
+      columns = new Array(count).fill(0);
+      // Dropped rather than kept: after a reflow the previous heads name
+      // cells that may not exist, and demoting a stale one would punch a
+      // hole in a column it no longer belongs to.
+      heads = new Array(count).fill(null);
       ctx.font = `${FONT_SIZE}px monospace`;
     };
     resize();
@@ -89,19 +146,50 @@ const MatrixRain: Component<MatrixRainProps> = (props) => {
       if (now - last < FRAME_MS) return;
       last = now;
 
+      const look = props.look();
+      const trail = `rgba(${TRAIL_RGB}, ${look.glyphAlpha})`;
+
       // The fade that leaves the trails: paint the whole canvas a barely
       // opaque black each frame rather than clearing it.
-      ctx.fillStyle = "rgba(0, 0, 0, 0.10)";
+      ctx.fillStyle = `rgba(0, 0, 0, ${look.fadeAlpha})`;
       ctx.fillRect(0, 0, el.width, el.height);
 
       for (let i = 0; i < columns.length; i++) {
-        const y = (columns[i] ?? 0) * FONT_SIZE;
+        const row = columns[i] ?? 0;
+        // Rounded HERE and nowhere else: the counter stays fractional so a
+        // sub-row speed is possible at the same frame budget.
+        const y = Math.round(row) * FONT_SIZE;
+        const x = i * FONT_SIZE;
         const glyph = GLYPHS[Math.floor(Math.random() * GLYPHS.length)] ?? "0";
-        ctx.fillStyle = "rgba(255, 176, 0, 0.18)";
-        ctx.fillText(glyph, i * FONT_SIZE, y);
+
+        if (look.leader === null) {
+          ctx.fillStyle = trail;
+          ctx.fillText(glyph, x, y);
+        } else {
+          const head = heads[i] ?? null;
+          if (head !== null && head.y !== y) {
+            // Cool last frame's head to the trail colour. The wash alone
+            // cannot do it — it only decays whatever is already there, so a
+            // near-opaque head would leave a near-opaque STREAK and the two
+            // alphas would name one pixel at two ages instead of two things.
+            // The punch is what makes the repaint replace rather than tint;
+            // opaque black is invisible under the `screen` blend both
+            // surfaces composite with, so it costs no visible hole.
+            ctx.fillStyle = "#000";
+            ctx.fillRect(x, head.y - FONT_SIZE, FONT_SIZE, FONT_SIZE + DESCENDER);
+            ctx.fillStyle = trail;
+            // The SAME glyph, not a fresh roll: a demotion should read as a
+            // colour cooling, not as the character flickering.
+            ctx.fillText(head.glyph, x, head.y);
+          }
+          ctx.fillStyle = look.leader;
+          ctx.fillText(glyph, x, y);
+          heads[i] = { y, glyph };
+        }
+
         // Reset a column at random once it is past the bottom, so the
         // rows never fall into lockstep.
-        columns[i] = y > el.height && Math.random() > 0.975 ? 0 : (columns[i] ?? 0) + 1;
+        columns[i] = y > el.height && Math.random() > 0.975 ? 0 : row + look.rowsPerFrame;
       }
     };
     raf = requestAnimationFrame(draw);

--- a/cicchetto/src/__tests__/AdminDebugTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminDebugTab.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import AdminDebugTab from "../AdminDebugTab";
+import AdminDebugTab, { ADM_RAIN_LOOK } from "../AdminDebugTab";
+import { installRainHarness, type RainHarness, rects, texts } from "./helpers/canvasOps";
 
 // #1773 — a REGRESSION guard for a move that is outside the issue's mandate.
 //
@@ -13,32 +14,30 @@ import AdminDebugTab from "../AdminDebugTab";
 //
 // So this pins the values, from the tab, through the real five-tap gate. The
 // tab had no test at all before, which is exactly why the move needed one.
+//
+// #1807 widened the same guard to the DRAWING, and that is now the load-
+// bearing case in this file. The credits modal needed the rain louder on all
+// four knobs; making them per-surface is what keeps this panel out of it, and
+// nothing in the type system says a future edit cannot quietly hand the loud
+// look to both callers. The panel rains BEHIND readouts an operator is trying
+// to read, so "unchanged" here is a requirement and not tidiness — and the
+// only honest way to assert it is on what reaches the canvas.
 
-class StubResizeObserver {
-  observe(): void {}
-  disconnect(): void {}
-}
+// 4 columns of 14px, 40 rows deep — deep enough that no column reaches the
+// bottom within two frames, so the random reset never fires.
+const BOX_W = 56;
+const BOX_H = 560;
 
 describe("AdminDebugTab phosphor panel (#1773 — MatrixRain promotion)", () => {
+  let rain: RainHarness;
+
   beforeEach(() => {
-    // Never invoke the callback: a self-driving loop in jsdom is an infinite
-    // one, and the frame's CONTENT is MatrixRain.test.tsx's subject, not this
-    // file's.
-    vi.stubGlobal(
-      "requestAnimationFrame",
-      vi.fn(() => 1),
-    );
-    vi.stubGlobal("cancelAnimationFrame", vi.fn());
-    vi.stubGlobal("ResizeObserver", StubResizeObserver);
-    vi.stubGlobal(
-      "matchMedia",
-      vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
-    );
+    rain = installRainHarness(BOX_W, BOX_H);
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it("keeps the rain behind its own five-tap gate, off by default", () => {
@@ -58,8 +57,51 @@ describe("AdminDebugTab phosphor panel (#1773 — MatrixRain promotion)", () => 
       fireEvent.click(panel as Element);
     }
 
-    const rain = screen.getByTestId("admin-matrix-rain");
-    expect(rain.className).toBe("adm-rain");
-    expect(rain.querySelector("canvas")).not.toBeNull();
+    const rainLayer = screen.getByTestId("admin-matrix-rain");
+    expect(rainLayer.className).toBe("adm-rain");
+    expect(rainLayer.querySelector("canvas")).not.toBeNull();
+  });
+
+  it("asks for the four knobs #1773 hardcoded, at the values measured on 4c9270c5", () => {
+    // The pin. #1807 turned these four literals into data; if the credits
+    // modal's louder numbers ever leak in here, this is the line that says so
+    // — and it says WHICH knob moved, which the drawing assertion below
+    // cannot.
+    expect(ADM_RAIN_LOOK).toEqual({
+      glyphAlpha: 0.18,
+      fadeAlpha: 0.1,
+      leader: null,
+      rowsPerFrame: 1,
+    });
+  });
+
+  it("paints the panel exactly as it did before the knobs became per-surface", () => {
+    const { container } = render(() => <AdminDebugTab />);
+    const panel = container.querySelector(".adm-matrix");
+    for (let i = 0; i < 5; i++) {
+      fireEvent.click(panel as Element);
+    }
+
+    const first = rain.frame(1_000);
+
+    // ONE rect, and it is the wash over the whole canvas. A second rect would
+    // be the leader's punch — the credits look's tell — arriving on a surface
+    // that must stay readable-through.
+    expect(rects(first)).toEqual([
+      { kind: "fillRect", style: "rgba(0, 0, 0, 0.1)", x: 0, y: 0, w: BOX_W, h: BOX_H },
+    ]);
+
+    // One glyph per column, every one at the same dim alpha: no bright head,
+    // no demoted second draw.
+    const glyphs = texts(first);
+    expect(glyphs.map((op) => op.x)).toEqual([0, 14, 28, 42]);
+    expect(glyphs.map((op) => op.y)).toEqual([0, 0, 0, 0]);
+    expect([...new Set(glyphs.map((op) => op.style))]).toEqual(["rgba(255, 176, 0, 0.18)"]);
+
+    // And still a whole row per frame — the 0.7x is the credits modal's, and
+    // a shared slowdown would make the diagnostics panel drift too.
+    const second = rain.frame(2_000);
+    expect(rects(second)).toHaveLength(1);
+    expect(texts(second).map((op) => op.y)).toEqual([14, 14, 14, 14]);
   });
 });

--- a/cicchetto/src/__tests__/MatrixRain.test.tsx
+++ b/cicchetto/src/__tests__/MatrixRain.test.tsx
@@ -1,7 +1,8 @@
 import { render } from "@solidjs/testing-library";
 import { createSignal, Show } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import MatrixRain from "../MatrixRain";
+import MatrixRain, { type MatrixRainLook } from "../MatrixRain";
+import { installRainHarness, type RainHarness, rects, texts } from "./helpers/canvasOps";
 
 // #1773 moved this component out of `src/admin/` and gave it two required
 // props, because the credits easter egg is a second consumer of the same
@@ -13,56 +14,34 @@ import MatrixRain from "../MatrixRain";
 // is a full-screen overlay someone opens, watches, and closes, and a rAF loop
 // that survives the close burns a phone behind a dismissed dialog. The rest
 // of the suite runs with the loop mounted, so a leak here would be invisible.
-
-// jsdom implements none of these. `ResizeObserver` the component constructs
-// unconditionally; the rAF pair it drives the loop with; and the 2D context.
 //
-// The canvas stub is NOT optional scaffolding, and finding that out is what
-// this file bought: jsdom's `getContext` returns null without the `canvas`
-// npm package, and the component's `if (ctx === null) return` fires BEFORE it
-// ever requests a frame. Unstubbed, the unmount case below passes for the
-// wrong reason — there is nothing to cancel because nothing ever started.
-class StubResizeObserver {
-  observe(): void {}
-  disconnect(): void {}
-}
+// #1807 added the third required prop — `look`, the four drawing knobs — and
+// with it the cases below that assert what the component PAINTS. They use
+// SYNTHETIC looks on purpose: the values each surface actually ships are that
+// surface's business, and are pinned where the surface is (AdminDebugTab
+// .test.tsx for the phosphor panel, creditsRain.test.ts for the modal). What
+// belongs here is only the contract between a look and the canvas.
 
-function stubCanvas2d(): void {
-  const ctx = {
-    font: "",
-    fillStyle: "",
-    fillRect: (): void => {},
-    fillText: (): void => {},
-  };
-  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
-    ctx as unknown as CanvasRenderingContext2D,
-  );
-}
+// 4 columns of 14px, 40 rows deep — deep enough that no column reaches the
+// bottom within the frame counts below, so the random reset never fires and
+// the only nondeterminism left is which glyph is chosen.
+const BOX_W = 56;
+const BOX_H = 560;
+const FONT = 14;
+
+const PLAIN: MatrixRainLook = { glyphAlpha: 0.18, fadeAlpha: 0.1, leader: null, rowsPerFrame: 1 };
+const LOUD: MatrixRainLook = {
+  glyphAlpha: 0.3,
+  fadeAlpha: 0.06,
+  leader: "rgba(255, 255, 255, 0.95)",
+  rowsPerFrame: 0.7,
+};
 
 describe("MatrixRain (#1773 — shared by the Debug tab and the credits roll)", () => {
-  let raf: ReturnType<typeof vi.fn>;
-  let caf: ReturnType<typeof vi.fn>;
-  let handle = 0;
+  let rain: RainHarness;
 
   beforeEach(() => {
-    handle = 0;
-    // Hand back a fresh handle and NEVER call the callback: one frame is all
-    // this needs to prove, and a self-driving loop in jsdom is an infinite
-    // one.
-    raf = vi.fn(() => {
-      handle += 1;
-      return handle;
-    });
-    caf = vi.fn();
-    vi.stubGlobal("requestAnimationFrame", raf);
-    vi.stubGlobal("cancelAnimationFrame", caf);
-    vi.stubGlobal("ResizeObserver", StubResizeObserver);
-    stubCanvas2d();
-    // Default: no motion preference expressed.
-    vi.stubGlobal(
-      "matchMedia",
-      vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
-    );
+    rain = installRainHarness(BOX_W, BOX_H);
   });
 
   afterEach(() => {
@@ -71,11 +50,11 @@ describe("MatrixRain (#1773 — shared by the Debug tab and the credits roll)", 
   });
 
   it("wears the class and the test id its caller chose", () => {
-    // The whole point of the two props: each surface is addressable on its
-    // own and styles itself. A default would have silently handed the second
-    // caller the first caller's stylesheet hook.
+    // The whole point of the props: each surface is addressable on its own and
+    // styles itself. A default would have silently handed the second caller
+    // the first caller's stylesheet hook.
     const { getByTestId } = render(() => (
-      <MatrixRain class="credits-rain" testId="credits-matrix-rain" />
+      <MatrixRain class="credits-rain" testId="credits-matrix-rain" look={() => PLAIN} />
     ));
 
     const wrapper = getByTestId("credits-matrix-rain");
@@ -91,17 +70,17 @@ describe("MatrixRain (#1773 — shared by the Debug tab and the credits roll)", 
     const [shown, setShown] = createSignal(true);
     render(() => (
       <Show when={shown()}>
-        <MatrixRain class="credits-rain" testId="credits-matrix-rain" />
+        <MatrixRain class="credits-rain" testId="credits-matrix-rain" look={() => PLAIN} />
       </Show>
     ));
 
-    expect(raf).toHaveBeenCalled();
-    const armed = handle;
-    expect(caf).not.toHaveBeenCalled();
+    expect(rain.raf).toHaveBeenCalled();
+    const armed = rain.handle();
+    expect(rain.caf).not.toHaveBeenCalled();
 
     setShown(false);
 
-    expect(caf).toHaveBeenCalledWith(armed);
+    expect(rain.caf).toHaveBeenCalledWith(armed);
   });
 
   it("never starts a loop when the reader asked for reduced motion", () => {
@@ -110,11 +89,122 @@ describe("MatrixRain (#1773 — shared by the Debug tab and the credits roll)", 
       vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
     );
 
-    render(() => <MatrixRain class="credits-rain" testId="credits-matrix-rain" />);
+    render(() => (
+      <MatrixRain class="credits-rain" testId="credits-matrix-rain" look={() => PLAIN} />
+    ));
 
     // OFF, not slowed — and the canvas is still in the DOM, because the
     // wrapper is what the stylesheet positions. Absence of the loop is the
     // assertion, so it has to be the frame request that is missing.
-    expect(raf).not.toHaveBeenCalled();
+    expect(rain.raf).not.toHaveBeenCalled();
+  });
+
+  it("paints one glyph per column and nothing else when the look has no leader", () => {
+    // `leader: null` is the shape the Debug tab depends on: the wash is the
+    // only rect, every glyph carries the same alpha, and there is exactly one
+    // per column. Anything extra — a punch, a second draw, a brighter head —
+    // would be a change to a surface nobody asked to change.
+    render(() => <MatrixRain class="adm-rain" testId="admin-matrix-rain" look={() => PLAIN} />);
+
+    const frame = rain.frame(1_000);
+
+    expect(rects(frame)).toEqual([
+      { kind: "fillRect", style: "rgba(0, 0, 0, 0.1)", x: 0, y: 0, w: BOX_W, h: BOX_H },
+    ]);
+    const painted = texts(frame);
+    expect(painted.map((op) => op.x)).toEqual([0, 14, 28, 42]);
+    expect(painted.map((op) => op.y)).toEqual([0, 0, 0, 0]);
+    expect([...new Set(painted.map((op) => op.style))]).toEqual(["rgba(255, 176, 0, 0.18)"]);
+  });
+
+  it("demotes last frame's head to the trail colour before painting the new one", () => {
+    // The leader is only a leader if the glyph BEHIND it is dimmer. The wash
+    // alone cannot do that — it decays whatever colour is already there, so a
+    // near-opaque head would leave a near-opaque trail and `glyphAlpha` and
+    // `leader` would name the same pixel at two ages instead of two things.
+    render(() => (
+      <MatrixRain class="credits-rain" testId="credits-matrix-rain" look={() => LOUD} />
+    ));
+
+    const first = rain.frame(1_000);
+    // Nothing to demote yet: one head per column, no punch.
+    expect(rects(first)).toHaveLength(1);
+    const heads = texts(first);
+    expect(heads.map((op) => op.style)).toEqual(Array(4).fill(LOUD.leader));
+
+    const second = rain.frame(2_000);
+
+    // The wash, then one opaque punch per column over the cell the previous
+    // head occupies — `fillText`'s baseline is alphabetic, so that cell sits
+    // ABOVE the y it was drawn at.
+    expect(rects(second)).toEqual([
+      { kind: "fillRect", style: "rgba(0, 0, 0, 0.06)", x: 0, y: 0, w: BOX_W, h: BOX_H },
+      { kind: "fillRect", style: "#000", x: 0, y: -FONT, w: FONT, h: 18 },
+      { kind: "fillRect", style: "#000", x: 14, y: -FONT, w: FONT, h: 18 },
+      { kind: "fillRect", style: "#000", x: 28, y: -FONT, w: FONT, h: 18 },
+      { kind: "fillRect", style: "#000", x: 42, y: -FONT, w: FONT, h: 18 },
+    ]);
+
+    // Per column: the SAME glyph repainted dim where the head was, then the
+    // new head one row down. Repainted rather than re-rolled, so the demotion
+    // reads as a colour cooling and not as a flicker.
+    const painted = texts(second);
+    for (let i = 0; i < 4; i++) {
+      const demoted = painted[i * 2];
+      const head = painted[i * 2 + 1];
+      expect(demoted).toEqual({
+        kind: "fillText",
+        style: "rgba(255, 176, 0, 0.3)",
+        glyph: heads[i]?.glyph,
+        x: i * FONT,
+        y: 0,
+      });
+      expect(head?.style).toBe(LOUD.leader);
+      expect(head?.y).toBe(FONT);
+    }
+  });
+
+  it("advances by a fractional row, rounding only where the glyph lands", () => {
+    // vjt asked for 0.7x, and NOT by raising the frame budget: at ~6fps the
+    // columns visibly step. So the row counter is fractional and the rounding
+    // happens at paint time — which means the head holds a row on some frames
+    // instead of moving every one.
+    const rowsOf = (look: MatrixRainLook): number[] => {
+      const { unmount } = render(() => (
+        <MatrixRain class="credits-rain" testId="credits-matrix-rain" look={() => look} />
+      ));
+      const rows: number[] = [];
+      for (let i = 1; i <= 10; i++) {
+        const head = texts(rain.frame(i * 1_000)).at(-1);
+        rows.push((head?.y ?? 0) / FONT);
+      }
+      unmount();
+      return rows;
+    };
+
+    const fast = rowsOf(PLAIN);
+    expect(fast).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    const slow = rowsOf(LOUD);
+    // 0.7x the ground covered over the same nine advances, and — the part a
+    // whole-row implementation could never produce — some frames repeat a row.
+    expect(slow.at(-1)).toBe(Math.round(0.7 * 9));
+    expect(new Set(slow).size).toBeLessThan(slow.length);
+    expect([...slow].sort((a, b) => a - b)).toEqual(slow);
+  });
+
+  it("reads the look once per drawn frame, so the caller needs no second clock", () => {
+    // This is what lets the credits burst ride the CSS animation's own phase:
+    // the caller answers "what does it look like right now" inside the rAF
+    // that already exists. A `setTimeout` would be a second clock, and in a
+    // backgrounded tab rAF stops while timers do not.
+    let current = PLAIN;
+    render(() => (
+      <MatrixRain class="credits-rain" testId="credits-matrix-rain" look={() => current} />
+    ));
+
+    expect(rects(rain.frame(1_000))[0]?.style).toBe("rgba(0, 0, 0, 0.1)");
+    current = LOUD;
+    expect(rects(rain.frame(2_000))[0]?.style).toBe("rgba(0, 0, 0, 0.06)");
   });
 });

--- a/cicchetto/src/__tests__/creditsRain.test.ts
+++ b/cicchetto/src/__tests__/creditsRain.test.ts
@@ -1,25 +1,178 @@
 import { describe, expect, it } from "vitest";
 import { ADM_RAIN_LOOK } from "../AdminDebugTab";
-import { CREDITS_RAIN_LOOK } from "../lib/creditsRain";
+import {
+  CREDITS_RAIN_BURST_LOOK,
+  CREDITS_RAIN_LOOK,
+  creditsRainLook,
+  rollIsParked,
+} from "../lib/creditsRain";
+import { ruleBody, themeCss } from "./helpers/themeCss";
 
-// #1807 — the credits rain reads as rain.
+// #1807 — the credits rain reads as rain, and the burst rides the roll's own
+// clock.
 //
-// The numbers are only correct RELATIVE to the surface they were inherited
-// from: the issue's "0.7x the current speed" names the Debug panel's speed,
-// and every other knob is a complaint about that panel's settings behind the
-// end titles. So each assertion compares against the other surface's constant
-// rather than against a copy of itself, which a `toEqual` on a literal would
-// be.
+// Two subjects, and they are one subject: the LOOKS are only correct relative
+// to what the Debug panel still runs (the issue's "0.7x the current speed"
+// names that surface's speed), and the interlude only exists because the
+// stylesheet parks the roll before its cycle ends. So the numbers are checked
+// against the other surface's constant and against the stylesheet, never
+// against a copy of themselves.
+//
+// What is NOT provable here: jsdom runs no animation, so the phase reader is
+// exercised against a fake `getAnimations`. That the REAL CSS animation
+// exposes the offsets this depends on is the e2e's job
+// (issue1807-credits-rain-reads-as-rain.spec.ts) — and that the result looks
+// like rain to a human is nobody's job but a human's, on a real phone.
+
+type FakeStop = { readonly computedOffset: number; readonly transform: string };
+
+/**
+ * An element that answers `getAnimations()` the way a browser running
+ * `credits-roll` would. Only that one method is reached, so the cast is the
+ * whole of the fake.
+ */
+function fakeRoll(progress: number | null, stops: readonly FakeStop[]): HTMLElement {
+  return {
+    getAnimations: () => [
+      {
+        effect: {
+          getComputedTiming: () => ({ progress }),
+          getKeyframes: () => stops,
+        },
+      },
+    ],
+  } as unknown as HTMLElement;
+}
+
+const TRAVELLING = "translateY(100%)";
+const PARKED = "translateY(-100%)";
+const PARKS_AT_082: readonly FakeStop[] = [
+  { computedOffset: 0, transform: TRAVELLING },
+  { computedOffset: 0.82, transform: PARKED },
+  { computedOffset: 1, transform: PARKED },
+];
 
 describe("credits rain look (#1807)", () => {
   it("is louder than the panel the effect was tuned for, on every knob", () => {
     // The defect was that the credits rain read as a faint texture. Each
-    // comparison names the axis it fixes.
+    // comparison names the axis it fixes, against the surface whose settings
+    // it inherited.
     expect(CREDITS_RAIN_LOOK.glyphAlpha).toBeGreaterThan(ADM_RAIN_LOOK.glyphAlpha);
     expect(CREDITS_RAIN_LOOK.fadeAlpha).toBeLessThan(ADM_RAIN_LOOK.fadeAlpha);
     expect(CREDITS_RAIN_LOOK.leader).not.toBeNull();
     // vjt asked for 0.7x THE CURRENT SPEED, and the current speed is the one
     // the Debug panel still runs at.
     expect(CREDITS_RAIN_LOOK.rowsPerFrame).toBeCloseTo(0.7 * ADM_RAIN_LOOK.rowsPerFrame, 10);
+  });
+
+  it("bursts louder still, and faster than its own baseline", () => {
+    expect(CREDITS_RAIN_BURST_LOOK.leader).toBe("rgba(255, 255, 255, 1)");
+    expect(CREDITS_RAIN_BURST_LOOK.glyphAlpha).toBeGreaterThan(CREDITS_RAIN_LOOK.glyphAlpha);
+    expect(CREDITS_RAIN_BURST_LOOK.fadeAlpha).toBeLessThan(CREDITS_RAIN_LOOK.fadeAlpha);
+    expect(CREDITS_RAIN_BURST_LOOK.rowsPerFrame).toBeGreaterThan(CREDITS_RAIN_LOOK.rowsPerFrame);
+  });
+
+  it("stays on the steady look while the titles are travelling", () => {
+    expect(creditsRainLook(fakeRoll(0, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+    expect(creditsRainLook(fakeRoll(0.5, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+    expect(creditsRainLook(fakeRoll(0.8199, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+  });
+
+  it("bursts for exactly the stretch the roll spends parked", () => {
+    // The boundary belongs to the interlude: the instant the translate stops
+    // moving there is nothing on screen but rain.
+    expect(creditsRainLook(fakeRoll(0.82, PARKS_AT_082))).toBe(CREDITS_RAIN_BURST_LOOK);
+    expect(creditsRainLook(fakeRoll(0.99, PARKS_AT_082))).toBe(CREDITS_RAIN_BURST_LOOK);
+  });
+
+  it("takes the park offset from the keyframes rather than from a constant", () => {
+    // Retime the roll and the burst follows, with nothing in TS to edit. A
+    // hardcoded 0.82 would keep bursting at 0.82 of a cycle that now parks
+    // somewhere else, which is the drift this reader exists to avoid.
+    const parksLate: readonly FakeStop[] = [
+      { computedOffset: 0, transform: TRAVELLING },
+      { computedOffset: 0.95, transform: PARKED },
+      { computedOffset: 1, transform: PARKED },
+    ];
+    expect(creditsRainLook(fakeRoll(0.9, parksLate))).toBe(CREDITS_RAIN_LOOK);
+    expect(creditsRainLook(fakeRoll(0.96, parksLate))).toBe(CREDITS_RAIN_BURST_LOOK);
+  });
+
+  it("never bursts when there is no interlude to be inside of", () => {
+    // #1773's seamless two-stop roll. Reintroduce it and the burst must go
+    // away with the hold, not fire against a moving title.
+    const seamless: readonly FakeStop[] = [
+      { computedOffset: 0, transform: TRAVELLING },
+      { computedOffset: 1, transform: PARKED },
+    ];
+    expect(rollIsParked(fakeRoll(0.999, seamless))).toBe(false);
+  });
+
+  it("degrades to the steady look when there is no animation to read", () => {
+    // Three real cases, one answer: before the roll mounts, under
+    // `prefers-reduced-motion` (where the roll is a plain scrollable column),
+    // and in jsdom. None of them is an error, and none of them may throw.
+    expect(creditsRainLook(undefined)).toBe(CREDITS_RAIN_LOOK);
+    expect(creditsRainLook({ getAnimations: () => [] } as unknown as HTMLElement)).toBe(
+      CREDITS_RAIN_LOOK,
+    );
+    expect(creditsRainLook(document.createElement("div"))).toBe(CREDITS_RAIN_LOOK);
+    expect(creditsRainLook(fakeRoll(null, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+  });
+});
+
+describe("credits roll timing (#1807 — the stylesheet owns the interlude)", () => {
+  const cycleSeconds = (): number => {
+    const declared = /animation:\s*credits-roll\s+([\d.]+)s/.exec(ruleBody(".credits-roll"));
+    const seconds = Number(declared?.[1]);
+    expect(Number.isFinite(seconds)).toBe(true);
+    return seconds;
+  };
+
+  /** The `@keyframes credits-roll` stops, as `{ at, transform }`. The block
+      has nested braces, so it is matched up to the first `}` at column 0. */
+  const stops = (): { at: number; transform: string }[] => {
+    const block = /@keyframes credits-roll\s*\{([\s\S]*?)\n\}/.exec(themeCss)?.[1];
+    expect(block, "@keyframes credits-roll not found in default.css").toBeDefined();
+    const parsed = [...(block ?? "").matchAll(/(\d+)%\s*\{\s*transform:\s*([^;]+);/g)].map((m) => ({
+      at: Number(m[1]) / 100,
+      transform: (m[2] ?? "").trim(),
+    }));
+    expect(parsed.length).toBeGreaterThanOrEqual(2);
+    return parsed;
+  };
+
+  it("parks the roll off the top for the 5-7s of pure rain the issue asked for", () => {
+    const all = stops();
+    const last = all.at(-1);
+    expect(last?.at).toBe(1);
+
+    // The hold starts at the FIRST stop already carrying the final transform.
+    const park = all.find((stop) => stop.transform === last?.transform);
+    expect(park?.at, "the last two stops must share a transform, or there is no hold").toBeLessThan(
+      1,
+    );
+
+    const interlude = cycleSeconds() * (1 - (park?.at ?? 1));
+    expect(interlude).toBeGreaterThanOrEqual(5);
+    expect(interlude).toBeLessThanOrEqual(7);
+  });
+
+  it("holds it OFF-SCREEN, and re-enters from the bottom", () => {
+    // Not a pause mid-list: the parked transform is the one that has the roll
+    // fully above the fold, and the cycle restarts from fully below it — the
+    // same entrance as the first pass.
+    const all = stops();
+    expect(all[0]?.transform).toBe("translateY(100%)");
+    expect(all.at(-1)?.transform).toBe("translateY(-100%)");
+  });
+
+  it("did not slow the titles down to buy the interlude", () => {
+    // #1773 rolled the whole 28s cycle. The interlude is bought by a LONGER
+    // cycle, so the travel — and therefore how long a reader has to read each
+    // name — is where it was.
+    const all = stops();
+    const park = all.find((stop) => stop.transform === all.at(-1)?.transform);
+    expect(cycleSeconds() * (park?.at ?? 1)).toBeCloseTo(28, 0);
   });
 });

--- a/cicchetto/src/__tests__/creditsRain.test.ts
+++ b/cicchetto/src/__tests__/creditsRain.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { ADM_RAIN_LOOK } from "../AdminDebugTab";
+import { CREDITS_RAIN_LOOK } from "../lib/creditsRain";
+
+// #1807 — the credits rain reads as rain.
+//
+// The numbers are only correct RELATIVE to the surface they were inherited
+// from: the issue's "0.7x the current speed" names the Debug panel's speed,
+// and every other knob is a complaint about that panel's settings behind the
+// end titles. So each assertion compares against the other surface's constant
+// rather than against a copy of itself, which a `toEqual` on a literal would
+// be.
+
+describe("credits rain look (#1807)", () => {
+  it("is louder than the panel the effect was tuned for, on every knob", () => {
+    // The defect was that the credits rain read as a faint texture. Each
+    // comparison names the axis it fixes.
+    expect(CREDITS_RAIN_LOOK.glyphAlpha).toBeGreaterThan(ADM_RAIN_LOOK.glyphAlpha);
+    expect(CREDITS_RAIN_LOOK.fadeAlpha).toBeLessThan(ADM_RAIN_LOOK.fadeAlpha);
+    expect(CREDITS_RAIN_LOOK.leader).not.toBeNull();
+    // vjt asked for 0.7x THE CURRENT SPEED, and the current speed is the one
+    // the Debug panel still runs at.
+    expect(CREDITS_RAIN_LOOK.rowsPerFrame).toBeCloseTo(0.7 * ADM_RAIN_LOOK.rowsPerFrame, 10);
+  });
+});

--- a/cicchetto/src/__tests__/helpers/canvasOps.ts
+++ b/cicchetto/src/__tests__/helpers/canvasOps.ts
@@ -1,0 +1,139 @@
+import { type Mock, vi } from "vitest";
+
+// A recording 2D context plus a hand-cranked rAF, shared by every test that
+// asks what `MatrixRain` PAINTS rather than what it renders (#1807).
+//
+// Lifted out of MatrixRain.test.tsx's stub the moment AdminDebugTab.test.tsx
+// needed the same rig: #1807 makes the four drawing knobs per-surface, so the
+// assertion that matters most — "the Debug tab paints exactly what it painted
+// before" — has to live in the DEBUG tab's own file, driving the REAL five-tap
+// gate, not in the component's.
+//
+// Three jsdom gaps this closes, and each one silently hollows the suite:
+//
+//   * `getContext` returns null without the `canvas` npm package, and the
+//     component's `if (ctx === null) return` fires BEFORE it ever requests a
+//     frame — every assertion about the loop then passes for the wrong reason.
+//   * jsdom lays nothing out, so `parentElement.clientWidth/Height` read 0 and
+//     the component sizes itself to ZERO columns. A spec asserting on painted
+//     glyphs would pass against a component painting none.
+//   * There is no rAF at all. The callback is captured rather than scheduled,
+//     so a test steps frames one at a time and a self-driving loop can never
+//     hang the run.
+
+export type CanvasOp =
+  | {
+      readonly kind: "fillRect";
+      readonly style: string;
+      readonly x: number;
+      readonly y: number;
+      readonly w: number;
+      readonly h: number;
+    }
+  | {
+      readonly kind: "fillText";
+      readonly style: string;
+      readonly glyph: string;
+      readonly x: number;
+      readonly y: number;
+    };
+
+export type RainHarness = {
+  /** Every op recorded since the harness was installed, in paint order. */
+  readonly ops: CanvasOp[];
+  readonly raf: Mock;
+  readonly caf: Mock;
+  /** The handle the last `requestAnimationFrame` handed out. */
+  readonly handle: () => number;
+  /**
+   * Run the one frame the component has pending, at `now` ms, and return
+   * ONLY the ops that frame painted. `MatrixRain` re-arms at the top of its
+   * callback, so the next `frame()` runs the next iteration.
+   */
+  readonly frame: (now: number) => CanvasOp[];
+};
+
+class StubResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+/**
+ * Stub the browser surfaces `MatrixRain` needs and hand back the recorder.
+ * `width`/`height` are the parent box the canvas sizes itself off, in CSS
+ * pixels — pick them so the column count and the row count are obvious.
+ *
+ * Undone by `vi.unstubAllGlobals()` + `vi.restoreAllMocks()`; a caller that
+ * forgets the second one leaks the layout stub into the next file.
+ */
+export function installRainHarness(width: number, height: number): RainHarness {
+  const ops: CanvasOp[] = [];
+  let pending: FrameRequestCallback | null = null;
+  let handle = 0;
+
+  const raf = vi.fn((cb: FrameRequestCallback) => {
+    pending = cb;
+    handle += 1;
+    return handle;
+  });
+  const caf = vi.fn();
+
+  vi.stubGlobal("requestAnimationFrame", raf);
+  vi.stubGlobal("cancelAnimationFrame", caf);
+  vi.stubGlobal("ResizeObserver", StubResizeObserver);
+  // Default: no motion preference expressed. A test that wants the OFF arm
+  // re-stubs this after installing the harness.
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+  );
+
+  vi.spyOn(Element.prototype, "clientWidth", "get").mockReturnValue(width);
+  vi.spyOn(Element.prototype, "clientHeight", "get").mockReturnValue(height);
+
+  const ctx = {
+    font: "",
+    fillStyle: "" as string,
+    fillRect(x: number, y: number, w: number, h: number): void {
+      ops.push({ kind: "fillRect", style: ctx.fillStyle, x, y, w, h });
+    },
+    fillText(glyph: string, x: number, y: number): void {
+      ops.push({ kind: "fillText", style: ctx.fillStyle, glyph, x, y });
+    },
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    ctx as unknown as CanvasRenderingContext2D,
+  );
+
+  return {
+    ops,
+    raf,
+    caf,
+    handle: () => handle,
+    frame(now: number): CanvasOp[] {
+      const from = ops.length;
+      const cb = pending;
+      pending = null;
+      cb?.(now);
+      return ops.slice(from);
+    },
+  };
+}
+
+/** The `fillText` ops of one frame, in paint order. */
+export function texts(
+  frame: readonly CanvasOp[],
+): readonly Extract<CanvasOp, { kind: "fillText" }>[] {
+  return frame.filter(
+    (op): op is Extract<CanvasOp, { kind: "fillText" }> => op.kind === "fillText",
+  );
+}
+
+/** The `fillRect` ops of one frame, in paint order. */
+export function rects(
+  frame: readonly CanvasOp[],
+): readonly Extract<CanvasOp, { kind: "fillRect" }>[] {
+  return frame.filter(
+    (op): op is Extract<CanvasOp, { kind: "fillRect" }> => op.kind === "fillRect",
+  );
+}

--- a/cicchetto/src/lib/creditsRain.ts
+++ b/cicchetto/src/lib/creditsRain.ts
@@ -1,0 +1,30 @@
+import type { MatrixRainLook } from "../MatrixRain";
+
+// #1807 — what the credits modal's rain looks like.
+//
+// #1773 shipped the effect at the Debug panel's settings, where the rain is
+// dim on purpose because readouts have to stay legible through it. Behind the
+// end titles nothing has to stay legible through it: the rain IS the picture,
+// and at those settings it read as a faint texture rather than as rain
+// (verified on a real iPhone against `4c9270c5`).
+
+/**
+ * The credits look.
+ *
+ * Against `4c9270c5`: the glyph goes 0.18 → 0.30 so it is visible at all; the
+ * wash goes 0.10 → 0.06, which takes the trail from dying in seven frames
+ * (0.9^7 of an alpha that started at 0.18) to a streak that is still a third
+ * as bright twenty frames later; the head gets its own near-opaque light
+ * amber, which is the single change that makes the effect read as rain rather
+ * than as drifting dots; and the column advances 0.7 rows per frame instead
+ * of one, which is vjt's 0.7x (revised up from 0.4x on #grappa at 01:57).
+ *
+ * The speed does NOT come from the frame budget — `MatrixRain` keeps its
+ * ~15fps loop, because at ~6fps the columns visibly step.
+ */
+export const CREDITS_RAIN_LOOK: MatrixRainLook = {
+  glyphAlpha: 0.3,
+  fadeAlpha: 0.06,
+  leader: "rgba(255, 232, 176, 0.95)",
+  rowsPerFrame: 0.7,
+};

--- a/cicchetto/src/lib/creditsRain.ts
+++ b/cicchetto/src/lib/creditsRain.ts
@@ -1,15 +1,18 @@
 import type { MatrixRainLook } from "../MatrixRain";
 
-// #1807 — what the credits modal's rain looks like.
+// #1807 — what the credits modal's rain looks like, and WHEN it changes.
 //
 // #1773 shipped the effect at the Debug panel's settings, where the rain is
 // dim on purpose because readouts have to stay legible through it. Behind the
 // end titles nothing has to stay legible through it: the rain IS the picture,
 // and at those settings it read as a faint texture rather than as rain
 // (verified on a real iPhone against `4c9270c5`).
+//
+// The two looks below are the whole of this module's data; the rest is the
+// one question the modal asks 15 times a second — "is the roll parked?".
 
 /**
- * The credits look.
+ * The steady look, while the titles are travelling.
  *
  * Against `4c9270c5`: the glyph goes 0.18 → 0.30 so it is visible at all; the
  * wash goes 0.10 → 0.06, which takes the trail from dying in seven frames
@@ -28,3 +31,91 @@ export const CREDITS_RAIN_LOOK: MatrixRainLook = {
   leader: "rgba(255, 232, 176, 0.95)",
   rowsPerFrame: 0.7,
 };
+
+/**
+ * The interlude burst: once the titles have scrolled off the top, the roll
+ * holds off-screen for a few seconds and the rain is all there is to look at.
+ * Leaders go full white, the wash drops again so more of every column is lit
+ * at once, and the fall speeds up past the 0.7x baseline (vjt, #grappa 01:55).
+ *
+ * ⚠️ "More columns lighting at once" was the third item vjt named, and it has
+ * no referent in this implementation: every column already paints on every
+ * frame — they differ only in where their head is, so there is no unlit
+ * column to light. It is rendered here as more of each column being lit
+ * (brighter glyph, longer streak) rather than as more columns, and that is a
+ * substitution, not the same thing.
+ */
+export const CREDITS_RAIN_BURST_LOOK: MatrixRainLook = {
+  glyphAlpha: 0.45,
+  fadeAlpha: 0.05,
+  leader: "rgba(255, 255, 255, 1)",
+  rowsPerFrame: 1,
+};
+
+/**
+ * The look for RIGHT NOW, given the element carrying the `credits-roll`
+ * animation. Handed to `MatrixRain` as its `look` prop, so it is called from
+ * inside the frame loop that already exists.
+ *
+ * @param roll the `.credits-roll` element, or `undefined` before it mounts
+ */
+export function creditsRainLook(roll: HTMLElement | undefined): MatrixRainLook {
+  return rollIsParked(roll) ? CREDITS_RAIN_BURST_LOOK : CREDITS_RAIN_LOOK;
+}
+
+/**
+ * Is the roll parked off-screen — i.e. is this the interlude?
+ *
+ * ONE CLOCK. The interlude is a stretch of the CSS animation's own cycle (the
+ * translate finishes early and the last keyframes hold), so the phase is read
+ * off the animation instead of being counted alongside it. A `setTimeout`
+ * would be a second clock that has to agree with the first, and it would
+ * disagree exactly where it matters: in a backgrounded tab, rAF stops and
+ * timers do not, so the burst would come back mid-roll.
+ *
+ * Degrades to "not parked" rather than throwing. `getAnimations` is absent in
+ * jsdom, and absent FOR REAL under `prefers-reduced-motion`, where the roll
+ * is a plain scrollable column with no animation at all — no phase to read,
+ * and no rain running to burst anyway.
+ */
+export function rollIsParked(roll: HTMLElement | undefined): boolean {
+  if (roll === undefined) return false;
+
+  const effect = roll.getAnimations?.()[0]?.effect ?? null;
+  if (effect === null) return false;
+
+  const progress = effect.getComputedTiming().progress;
+  if (typeof progress !== "number") return false;
+
+  const parksAt = parkOffset(effect);
+  return parksAt !== null && progress >= parksAt;
+}
+
+/**
+ * The offset in the cycle at which the roll stops travelling, read off the
+ * animation's OWN keyframes.
+ *
+ * Read rather than declared, so the stylesheet stays the single source of
+ * truth for both ends of the interlude — a constant here would be a second
+ * copy of a number that lives in `@keyframes credits-roll`, and the two would
+ * drift the first time anyone retimed the roll.
+ *
+ * `null` when there is no interlude to be inside of: a roll whose FIRST
+ * keyframe already carries the final transform is not rolling, and one that
+ * only reaches it at the end has no hold.
+ */
+function parkOffset(effect: AnimationEffect): number | null {
+  const keyframed = effect as AnimationEffect & {
+    readonly getKeyframes?: () => readonly ComputedKeyframe[];
+  };
+  const frames = keyframed.getKeyframes?.();
+  const last = frames?.at(-1);
+  if (frames === undefined || last === undefined) return null;
+
+  for (const frame of frames) {
+    if (frame.transform !== last.transform) continue;
+    const at = frame.computedOffset;
+    return at > 0 && at < 1 ? at : null;
+  }
+  return null;
+}

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14028,8 +14028,13 @@ audio.media-viewer-media {
 }
 
 /* Brighter than the Debug tab's `.adm-rain` (0.55): there it sits under
-   readouts an operator must read, here it IS the picture. The glyph alpha
-   itself is shared — one implementation, one look. */
+   readouts an operator must read, here it IS the picture.
+
+   #1807 — the DRAWING is louder here too, and that is a prop rather than a
+   rule in this file: `MatrixRain` takes its four knobs (glyph alpha, wash,
+   leader colour, rows per frame) from the caller since the credits modal
+   needed all four past what the phosphor panel can afford. This layer's
+   opacity is the only part of the difference that is CSS. */
 .credits-rain {
   position: absolute;
   inset: 0;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14085,8 +14085,16 @@ audio.media-viewer-media {
   left: 0;
   right: 0;
   /* Starts fully below the fold and ends fully above it, so the loop has no
-     visible seam. 28s: the issue asked for "under ~30s, then it loops". */
-  animation: credits-roll 28s linear infinite;
+     visible seam. #1773 ran the whole 28s cycle as travel; #1807 keeps the
+     travel at 27.88s (0.82 x 34s — the titles roll at exactly the speed they
+     did) and spends the remaining 6.12s with the roll PARKED off the top.
+     That tail is the interlude of pure rain the issue asked for.
+
+     Lengthening the cycle rather than adding a JS pause is what keeps the
+     frame budget at zero AND keeps one clock: `creditsRain.rollIsParked`
+     reads the phase of THIS animation, and takes the 0.82 off its own
+     keyframes, so retiming the roll needs no edit anywhere else. */
+  animation: credits-roll 34s linear infinite;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -14096,11 +14104,18 @@ audio.media-viewer-media {
   text-shadow: 0 0 0.5rem var(--accent);
 }
 
+/* The last two stops carry the SAME transform on purpose: that hold is the
+   interlude, and its start (82%) is the only place the number lives. The roll
+   re-enters from the bottom afterwards, which is the same entrance as the
+   first pass rather than a resume mid-list. */
 @keyframes credits-roll {
-  from {
+  0% {
     transform: translateY(100%);
   }
-  to {
+  82% {
+    transform: translateY(-100%);
+  }
+  100% {
     transform: translateY(-100%);
   }
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -65480,3 +65480,109 @@ Device dogfood, unverifiable from any harness here: momentum, rubber-band at the
 edges, and whether iOS begins a rubber-band before the dismiss binder's claim
 lands — the same open question #1764 wrote down for the text pane, now on a
 second surface.
+<!-- entry #1807 -->
+
+---
+
+## 2026-08-26 — #1807: the credits rain reads as rain, and the second surface is the constraint that shaped it
+
+The credits easter egg (#1773) shipped with the falling-character effect the
+Debug tab's phosphor panel already had, at that panel's settings. On a real
+iPhone it read as a faint texture rather than as rain: the glyph sat at alpha
+`0.18`, the per-frame black wash at `0.10` killed a trail in about seven frames
+(`0.9^7` of `0.18`), every glyph in a column was painted identically, and the
+column stepped a whole row per drawn frame. vjt asked for four changes —
+brighter glyph, longer trail, a bright leader, `0.7x` speed — plus an interlude
+of pure rain between rolls.
+
+### The knobs are per-surface, and they are props
+
+`MatrixRain` has two consumers since #1773, and the second one is why none of
+those four values could simply be raised in place. The Debug panel rains BEHIND
+viewport readouts an operator is trying to read; its moduledoc named low alpha
+as a constraint rather than a taste. Louder values hardcoded in the component
+would have changed a surface nobody asked to change.
+
+So the four became one non-defaulted prop, `look: () => MatrixRainLook`,
+alongside the `class` / `testId` pair #1773 left non-defaulted for the same
+reason. **Props and not CSS custom properties**, which the issue offered as the
+alternative: reading them means `getComputedStyle` inside the frame loop (a
+style recalc per frame), jsdom resolves a custom property to the empty string
+so every knob would need a fallback — which IS the silent default this
+component has refused since #1773 — and the burst below is a function of time
+that no custom property can express. `AdminDebugTab` exports `ADM_RAIN_LOOK`
+holding the literals measured on `4c9270c5`; the credits looks live in
+`lib/creditsRain.ts`.
+
+### A leader without a demotion is a lie
+
+Raising `leader` alone does not produce a bright head. The wash only DECAYS
+what it finds, so a near-opaque head leaves a near-opaque streak and
+`glyphAlpha` and `leader` end up naming the same pixel at two ages instead of
+two things. Each frame therefore repaints the PREVIOUS head in the trail colour
+before painting the new one — over an opaque black punch, because painting
+`0.30` amber over a `0.95` white cell tints it rather than replacing it. The
+punch costs nothing visible: both surfaces composite with `mix-blend-mode:
+screen`, under which black is the identity. `leader: null` skips the whole
+branch, which is how the Debug panel gets a drawing that is not merely
+equivalent to the old one but the same code path.
+
+### One clock, and the stylesheet keeps the number
+
+The interlude is a stretch of the roll's own cycle rather than a pause bolted
+onto it: `credits-roll` went from `28s` of pure travel to `34s` with the
+translate finishing at `82%` and the last two keyframes holding. Travel is
+`27.88s`, so the titles roll at the speed they always did and the remaining
+`6.12s` is the hold — and because the cycle restarts from `translateY(100%)`,
+the next pass is an entrance from the bottom rather than a resume mid-list.
+
+The burst reads the phase of THAT animation from inside the rAF loop that
+already exists (`MatrixRain` calls `look` once per drawn frame). A `setTimeout`
+would be a second clock that has to agree with the first, and it would disagree
+exactly where it matters: in a backgrounded tab rAF stops and timers do not, so
+the burst would come back mid-roll. The start of the hold is not a constant in
+TS either — `parkOffset` finds the first keyframe already carrying the final
+transform and reads its `computedOffset`, so retiming the roll retimes the
+burst with it and the `82%` lives in exactly one place.
+
+### What was refused rather than faked
+
+Two things, and both are named in the code where someone will hit them.
+
+vjt's third burst ingredient, *"more columns lighting at once"*, **has no
+referent in this implementation**: every column already paints on every frame —
+they differ only in where their head is, so there is no unlit column to light.
+It is rendered as more of each column being lit (brighter glyph, longer streak)
+and `CREDITS_RAIN_BURST_LOOK`'s doc says so. Lighting more COLUMNS would mean a
+per-column activity gate, which is a different effect and was not asked for.
+
+And whether it READS as rain is a judgement about legibility over a dark theme
+on a device, which no gate here can make. It is on the PR as a dogfood
+checklist naming BOTH surfaces, because the issue asks for both.
+
+### What the gates can say, and where each one lives
+
+The assertion that mattered most was the second surface's non-regression, and
+it is in the Debug tab's own file rather than the component's:
+`AdminDebugTab.test.tsx` drives the real five-tap gate and asserts the ops that
+reach a recording 2D context — one wash at `0.10`, one glyph per column at
+`0.18`, no punch, one whole row per frame. `MatrixRain.test.tsx` keeps only the
+contract between a look and the canvas, on synthetic looks. The shared rig is
+`__tests__/helpers/canvasOps.ts`, which also closes the jsdom gap that would
+otherwise hollow all of it: with no layout, `parentElement.clientWidth` reads 0
+and the component paints ZERO columns.
+
+Falsified rather than assumed: four defects injected one at a time — the
+credits values wired into `ADM_RAIN_LOOK`, the demotion disabled,
+`rowsPerFrame` ignored, the seamless two-stop roll restored — and each one is
+caught by the assertion written for it (3 / 1 / 1 / 2 reds).
+
+The e2e (`issue1807-credits-rain-reads-as-rain.spec.ts`, chromium) makes the
+two claims jsdom cannot. It rasterises: `getImageData` over each canvas, on
+PREMULTIPLIED channel value (`channel * alpha`), because the accumulating black
+wash makes the raw value depend on how opaque the backing has become while the
+premultiplied one is what the compositor puts on screen. One Debug glyph is red
+`46`, the credits leader is red `242`, the burst leader is white at `255` blue
+against the steady leader's `167` — three wide gaps. And it proves the one
+clock by moving the ROLL's `currentTime` into the hold and requiring the RAIN
+to go white; a burst on a timer of its own sails straight through that.


### PR DESCRIPTION
# #1807 — the credits rain reads as rain

The credits easter egg (#1773) shipped with the falling-character effect the
Debug tab's phosphor panel already had, at that panel's settings. On a real
iPhone it read as a faint texture rather than as rain: glyph alpha `0.18`, a
`0.10` per-frame wash that kills a trail in about seven frames (`0.9⁷` of an
alpha that started at `0.18`), every glyph in a column painted identically,
and one whole row per drawn frame.

This raises all four, adds the interlude of pure rain between rolls, and —
the part that shaped everything else — does it **without touching the second
surface**.

---

## 🔴 Read this first: one thing asked for was not built, and this is the substitution

vjt named three ingredients for the interlude burst (#grappa 01:55): *leader
glyphs at full white*, *more columns lighting at once*, *a brief speed-up*.

**"More columns lighting at once" has no referent in this implementation.**
Every column already paints on every frame — they differ only in where their
head is, so there is no unlit column to light. Measured, not assumed: the loop
iterates `columns.length` and issues a `fillText` for each, unconditionally,
every drawn frame.

What shipped instead is **more of each column being lit** — brighter glyph
(`0.30` → `0.45`), longer streak (wash `0.06` → `0.05`), plus the white leader
and the speed-up that were asked for. **That is a substitution, not the same
thing**, and it is written as such in `CREDITS_RAIN_BURST_LOOK`'s doc so the
next reader does not assume it was delivered.

Delivering the literal request would mean a per-column activity gate — columns
that are dark and light up — which is a different effect from the one this
component implements, and was not in scope. Say the word and it becomes its
own issue.

---

## The constraint that shaped the design

`MatrixRain` has **two** consumers since #1773: the credits modal and the
Debug tab's `.adm-matrix` phosphor panel. That panel rains BEHIND viewport
readouts an operator is trying to read, and its moduledoc already named low
alpha as a constraint rather than a taste. **Hardcoding the louder values in
the component would have changed a surface nobody asked to change.**

So the four knobs became one non-defaulted prop, `look: () => MatrixRainLook`,
next to the `class` / `testId` pair #1773 deliberately left non-defaulted for
the same reason.

**Props and not CSS custom properties**, which the issue offered as the
alternative:

- reading them means `getComputedStyle` inside the frame loop — a style recalc
  every frame;
- jsdom resolves a custom property to the empty string, so every knob would
  need a fallback, and a fallback IS the silent default this component has
  refused since #1773;
- the burst is a **function of time**, and no custom property can express one.

| knob | Debug panel (`ADM_RAIN_LOOK`) | credits steady | credits burst |
| --- | --- | --- | --- |
| `glyphAlpha` | `0.18` | `0.30` | `0.45` |
| `fadeAlpha` | `0.10` | `0.06` | `0.05` |
| `leader` | `null` | `rgba(255, 232, 176, 0.95)` | `rgba(255, 255, 255, 1)` |
| `rowsPerFrame` | `1` | `0.7` | `1` |

The Debug column is the literals measured on `4c9270c5`. `leader: null` does
not merely reproduce the old drawing — it takes the **same code path**.

## A leader without a demotion is a lie

Raising `leader` alone does not produce a bright head. The wash only DECAYS
what it finds, so a near-opaque head leaves a near-opaque streak, and
`glyphAlpha` and `leader` end up naming the same pixel at two ages instead of
two things.

Each frame therefore repaints the PREVIOUS head in the trail colour, over an
opaque black punch — `0.30` amber over a `0.95` white cell tints it rather
than replacing it. The punch costs nothing visible: both surfaces composite
with `mix-blend-mode: screen`, under which black is the identity. The same
glyph is repainted rather than re-rolled, so a demotion reads as a colour
cooling and not as the character flickering.

## One clock

The interlude is a stretch of the roll's own cycle rather than a pause bolted
onto it. `credits-roll` goes from `28s` of pure travel to `34s` with the
translate finishing at `82%` and the last two keyframes holding:

- travel `27.88s` — **the titles roll at exactly the speed they did**;
- hold `6.12s`, inside the 5–7s the issue asked for;
- the cycle restarts from `translateY(100%)`, so the next pass is an
  **entrance from the bottom**, not a resume mid-list;
- frame budget stays at zero.

The burst reads the phase of THAT animation from inside the rAF loop
`MatrixRain` already runs (`look` is called once per drawn frame). A
`setTimeout` would be a second clock that has to agree with the first, and it
would disagree exactly where it matters: **in a backgrounded tab rAF stops and
timers do not**, so the burst would come back mid-roll.

The `82%` is not copied into TS either. `parkOffset` finds the first keyframe
already carrying the final transform and reads its `computedOffset`, so the
stylesheet stays the single source of truth and retiming the roll retimes the
burst with it. It degrades to "not parked" rather than throwing, which covers
three real cases with one answer: before the roll mounts, in jsdom, and under
`prefers-reduced-motion`, where the roll genuinely has no animation at all.

Unchanged, as the issue requires: `prefers-reduced-motion` turns the rain OFF
(not down) and is watched live; `pointer-events: none`; one rAF loop,
cancelled on cleanup.

---

## What the gates prove, and where each one lives

**The Debug non-regression is the assertion that mattered most**, and it is in
the Debug tab's own file rather than the component's — `AdminDebugTab.test.tsx`
drives the real five-tap gate and asserts the ops that reach a recording 2D
context: one wash at `0.10`, one glyph per column at `0.18`, **no punch**, one
whole row per frame. `MatrixRain.test.tsx` keeps only the contract between a
look and the canvas, on synthetic looks.

The shared rig (`src/__tests__/helpers/canvasOps.ts`) also closes the jsdom gap
that would otherwise hollow all of it: with no layout,
`parentElement.clientWidth` reads `0` and the component paints **zero
columns**, so a spec about painted glyphs would pass against a component
painting none.

**Falsified rather than assumed.** Four defects injected one at a time, each
caught by the assertion written for it:

| injected defect | reds |
| --- | --- |
| the credits values wired into `ADM_RAIN_LOOK` | 3 |
| the demotion disabled | 1 |
| `rowsPerFrame` ignored | 1 |
| the seamless two-stop roll restored | 2 |

**The e2e** (`issue1807-credits-rain-reads-as-rain.spec.ts`, chromium) makes
the two claims jsdom cannot. It rasterises — `getImageData` over each canvas,
on **premultiplied** channel value (`channel * alpha`), because the
accumulating black wash makes the raw value depend on how opaque the backing
has become while the premultiplied one is what the compositor puts on screen:

- one Debug glyph is red `46`; the credits leader is red `242`;
- the burst leader is white at blue `255`, against the steady leader's `167`.

Both directions, both times: the panel ceiling is preceded by an
anti-hollow-green poll (a canvas that never painted satisfies any ceiling), and
the burst floor is preceded by its counter-claim (mid-roll there is no white,
so a rain that bursts continuously cannot pass).

And it proves the one clock the only way it can be proven: seek the ROLL's
`currentTime` into the middle of its hold — computed from the keyframes, so
retiming the roll retimes the seek — and require the RAIN to go white. A burst
on a timer of its own sails straight through that.

---

## 📱 Dogfood checklist — NOT covered by any gate here

Whether it **reads as rain** is a judgement about legibility over a dark theme
on a device. No gate in this PR makes it, and none can. The issue asks for a
real iPhone and for **both** surfaces, so both are listed.

Credits modal (Settings → credits):

- [ ] the rain reads as *rain* — visible streaks with a bright head, not
      drifting dots
- [ ] the head is distinct from its own trail (the demotion is doing its job,
      no white smear behind the leader)
- [ ] the fall speed is right at `0.7×` — slower than before, not sluggish
      (`0.4×` was rejected for that)
- [ ] the titles are still comfortably readable at `27.88s` of travel
- [ ] after the titles leave the top, ~6s of rain alone, then the roll
      **re-enters from the bottom** (not a resume mid-list)
- [ ] during the interlude the burst is visibly louder — white heads, faster
      fall — and it stops when the titles come back
- [ ] leave the tab backgrounded for a while, come back: the burst is still
      aligned with the interlude and has not drifted mid-roll
- [ ] with Reduce Motion ON: no rain at all, and the roll is a plain
      scrollable column

Debug tab (Admin → Debug → five taps on the phosphor panel):

- [ ] **the rain looks exactly as it did before this PR**
- [ ] the viewport readouts underneath are still readable *through* it — no
      bright head, no long streaks

---

## Commits

| sha | what |
| --- | --- |
| `df5984d1` | `feat`: the four drawing knobs become per-surface |
| `67135dfc` | `feat`: the interlude is bought by lengthening the cycle, not by pausing |
| `936ccf7a` | `test`: rasterise both surfaces, and move the roll's clock |
| `7c10c698` | `docs`: DESIGN_NOTES — why the knobs are props, and what has no referent |
| `f3a9b5c5` | `test`: tap the phosphor panel that HAS the gate, not all three |

### One of those is a repair, and it is worth a reviewer's minute

The first full run turned the Debug arm **red in 797 ms** — a `strict mode
violation`, because `AdminDebugTab` carries **three** `.adm-matrix` panels and
only "Viewport diagnostics" wears the five-tap gate. That red proved *nothing
in either direction*: it died twenty lines before the first `getImageData`, so
the pixel ceiling was left unfalsified rather than broken.

**No threshold was moved to fix it** — the locator was scoped by
`.adm-matrix-prompt`, which exists in that panel alone. It is the one
automatable claim in this slice (that the second surface did not change), and
a guard widened until it stops sounding is not a guard.

The evidence that the ceiling now actually *executes* is the **duration**, not
the green: `797 ms → 4.0 s`, of which `3.0 s` is the `inkPeakOver` sampling
window that cannot be skipped. Three of three under `--repeat-each 3`, and
`3.9 s` again in the full suite.

## Gate evidence

Worktree `.worktrees/w2-1807`, rebased onto `origin/main` = `8ce0c836`.

| gate | rc | note |
| --- | --- | --- |
| `bun install --frozen-lockfile` | `0` | |
| mutation bench (4 defects, pre-commit) | — | 4 reds, each from the assertion written for it; tree restored clean |
| `scripts/bun.sh run check` | `0` | 5/5 stages, on the rebased tree |
| `scripts/bun.sh run test` | `0` | 325 files, **6406** tests, on the rebased tree |
| `scripts/design-notes-gate.sh` | `0` | post-commit and post-rebase |
| `scripts/union-rebase.sh` | `0` | `docs/DESIGN_NOTES.md: +106 -0 — contribution intact` |
| iso-rerun, both specs `--repeat-each 3` | `0` | 12/12 |
| `scripts/integration.sh` **full suite** | `0` | **792 passed, 0 failed, 31.1m** |

**⚠️ Attribution, stated rather than glossed:** the 792-green was measured on
base `3693277d`. `#1805` landed while that 31-minute suite was running, so the
branch was rebased onto `8ce0c836` **after** it. Every *cic* gate above was
re-run on the rebased tree; the **integration suite was not**. The regions do
not overlap (`#1805` is MediaViewerModal / pinch-zoom; this is
MatrixRain / credits), and `default.css` is the only file both touch, in
different rules — but that is an argument, not a measurement. This PR's CI is
the measurement on the rebased head.

No Elixir touched: the diff is cic plus `docs/DESIGN_NOTES.md`.

## Unrelated red seen once, not attributed and not archived

The same first run also failed `issue887-focused-unread-badge.spec.ts:136`
(32.2 s). Its artefact shows the page reading **"Could not load Grappa. /
signal timed out"** — the app never booted for that test, and the click timed
out on a sidebar that never existed. Not a DOM or CSS mismatch, and the bundle
is built once for the whole suite, so a boot break from this branch would have
taken all 792 tests rather than one.

It passed 3/3 in the iso-rerun (4.6 s each) and again in the full suite. **That
does not prove it is a flake — it proves it did not reproduce.** Flagging it
here as a first occurrence for whoever tracks them.
