### PR TITLE
#1808 — a .mailmap: one credit per contributor, and the provenance of the two rulings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,86 @@
+# .mailmap — one person, one identity, WITHOUT rewriting history (#1808).
+#
+# git resolves author identity through this file before it reports one, so
+# `git log --format='%aN <%aE>'`, `git shortlog` and everything downstream of
+# them see the collapsed set. `infra/packaging/credits.sh` is downstream: it
+# derives the credit roll (#1773) from `git shortlog -sn --no-merges`, and
+# before this file existed the roll listed the same people two and three
+# times. No hash moves and nothing is force-pushed — the commits keep the
+# identity they were authored with; only the REPORT is canonical.
+#
+# ── Why every line carries all four fields ─────────────────────────────────
+#
+#     Proper Name <proper@addr> Commit Name <commit@addr>
+#
+# and never the shorter `Proper Name <proper@addr> <commit@addr>`. The short
+# spelling keys on the commit ADDRESS ALONE, and one address here is shared by
+# two identities: `marcello.barnaba@gmail.com` carries both Marcello's own
+# commits and `vjt-claude`'s. Measured in a sandbox before this file was
+# written — with the short spelling, `git check-mailmap 'vjt-claude
+# <marcello.barnaba@gmail.com>'` answers `Marcello Barnaba <vjt@openssl.it>`;
+# with the four-field spelling it answers itself.
+#
+# So the short form would silently overrule the decision recorded below: the
+# Claude session identities were ruled a SEPARATE credit under `vjt-claude`,
+# and an address-keyed mapping folds them into Marcello anyway, with nothing
+# to read. One spelling throughout, and it is the one that cannot do that:
+# every line names both sides in full, and a new alias needs its own line
+# rather than being absorbed by an address someone else also uses.
+# `test/infra/credits_payload_test.bats` pins both halves.
+
+Marcello Barnaba <vjt@openssl.it> vjt <vjt@openssl.it>
+Marcello Barnaba <vjt@openssl.it> Marcello Barnaba <mbarnaba@meta.com>
+Marcello Barnaba <vjt@openssl.it> Marcello Barnaba <marcello.barnaba@gmail.com>
+
+Alessio Bonforti <info@alessiobonforti.com> Alessio Bonforti <38355294+abonforti@users.noreply.github.com>
+
+Gabriele Marrone <gabriele.marrone@gmail.com> gabrielemarrone <131861953+gabrielemarrone@users.noreply.github.com>
+
+# The two Claude session identities collapse under `vjt-claude`, which is a
+# ruling and not a dedup: #1808 says outright that whether they merge, and
+# under which name, is vjt's call. Relayed from #grappa on 2026-08-26 — see
+# the DESIGN_NOTES entry for the provenance, which is worth reading before
+# trusting this line.
+#
+# The canonical identity deliberately sits on `marcello.barnaba@gmail.com`,
+# the address `vjt-claude` actually commits from and the one Marcello's own
+# gmail commits are mapped AWAY from three lines above. That is safe, and
+# measured rather than assumed: a mailmap lookup is NOT transitive, so
+# `claude` resolves to `vjt-claude <marcello.barnaba@gmail.com>` and stops
+# there instead of chaining on into `Marcello Barnaba <vjt@openssl.it>`.
+# Verified in both rule orders; the file's order carries no meaning.
+vjt-claude <marcello.barnaba@gmail.com> claude <claude@sonic88.org>
+
+# `Your Name <you@example.com>` is the git default nobody configured, and the
+# repository cannot name its author on its own — but it points hard at one
+# person. 83 of those 89 commits are `frontends/shottino`; the last one under
+# this identity is 2026-08-01T02:05:02+02:00 and the first under
+# `Stefy Lanza <stefy@nexlab.net>` is 2026-08-01T02:11:58+02:00, six minutes
+# and fifty-six seconds later, on the same tree, with no overlap in either
+# direction and 146 of Stefy's 147 commits in that same directory. That is
+# the shape of a `git config user.name` run at two in the morning.
+#
+# Evidence is not testimony, so it was asked rather than assumed. Confirmed by
+# vjt and relayed from #grappa on 2026-08-26 — same provenance caveat as the
+# line above, and the DESIGN_NOTES entry carries both in full.
+Stefy Lanza <stefy@nexlab.net> Your Name <you@example.com>
+
+# ── NOTHING IS LEFT UNMAPPED ───────────────────────────────────────────────
+#
+# As of the census below, every author identity in this history either appears
+# above or is the only identity its owner has. That is a claim worth stating
+# rather than leaving as the absence of a list: a contributor who starts
+# committing from a second address should add a line here, and knowing the
+# file is meant to be COMPLETE is what makes that obvious.
+#
+# `dependabot[bot]` is in the roll on purpose and is not an oversight — it was
+# raised and ruled in. Nothing here can exclude an author anyway: a mailmap
+# renames, it never drops. The two identity rulings, and the provenance they
+# arrived with, are in the #1808 DESIGN_NOTES entry — read it before trusting
+# either.
+#
+# Census taken on 8ce0c836. `%an <%ae>` and not the issue's `%aN <%aE>`: the
+# capitals are the RESOLVED identity, so once this file exists they report the
+# collapse back to you instead of the history it was derived from.
+#
+#     git log --format='%an <%ae>' | sort | uniq -c | sort -rn

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -65586,3 +65586,152 @@ premultiplied one is what the compositor puts on screen. One Debug glyph is red
 against the steady leader's `167` — three wide gaps. And it proves the one
 clock by moving the ROLL's `currentTime` into the hold and requiring the RAIN
 to go white; a burst on a timer of its own sails straight through that.
+<!-- entry #1808 -->
+
+---
+
+## 2026-08-26 — #1808: a `.mailmap`, two rulings, and the provenance written next to them
+
+The credit roll (#1773) bakes its contributor list from `git shortlog -sn
+--no-merges`, and the history had never been de-duplicated, so the modal
+listed the same people two and three times. The cure is a root `.mailmap`:
+git resolves author identity through it before reporting one, so `git log`,
+`git shortlog` and everything downstream of them — `infra/packaging/credits.sh`
+included — see the collapsed set with no hash moved and nothing force-pushed.
+
+### What it changed, and the part of the issue it corrects
+
+Measured on `8ce0c836`. Distinct author names `13 → 9`; distinct identities
+(`%an <%ae>` raw versus `%aN <%aE>` resolved) `16 → 9`; the `credits.sh`
+payload `13 → 9` rows — `vjt`'s one commit folding into Marcello Barnaba
+(5140 → 5141), `gabrielemarrone`'s one into Gabriele Marrone (24 → 25),
+`claude`'s six into `vjt-claude` (2 → 8), and `Your Name`'s 89 into Stefy
+Lanza (147 → 236).
+
+**Nothing else moved in the roll, and that corrects the issue's own framing.**
+`shortlog -sn` groups by NAME, so the same-name address splits #1808 tabulates
+— Marcello across three addresses, Alessio across two — were ALREADY a single
+row in the modal before this file existed. Only an alias differing by NAME was
+ever visible there. The mailmap still collapses the address axis, because
+`%aN <%aE>` is the oracle the issue names and a `shortlog -sne` would split on
+it; but the two same-name collapses buy the modal nothing, and saying so is
+the difference between five fixes and the four rows that actually vanish.
+
+The A/B has one trap worth recording: `git -c mailmap.file=/dev/null` does NOT
+disable the root `.mailmap` — that setting ADDS a file to the ones consulted,
+so the "before" it produces is the after. The honest before/after is
+`%an`/`%ae` (raw, what git recorded) against `%aN`/`%aE` (resolved), which
+needs no configuration at all.
+
+### Every line carries all four fields, because one address is shared
+
+A mapping may be written `Proper Name <proper@addr> <commit@addr>`, which keys
+on the commit ADDRESS ALONE, or `Proper Name <proper@addr> Commit Name
+<commit@addr>`, which keys on the PAIR. This file uses the four-field spelling
+throughout, and not for tidiness: `marcello.barnaba@gmail.com` carries both
+Marcello's own commits and `vjt-claude`'s. Measured in a sandbox before the
+file was written — under the short spelling `git check-mailmap 'vjt-claude
+<marcello.barnaba@gmail.com>'` answers `Marcello Barnaba <vjt@openssl.it>`;
+under the four-field spelling it answers itself.
+
+So the short form would silently overrule the first ruling below, folding into
+Marcello an identity that was decided to stand on its own, with nothing left
+to read. One spelling throughout, and it is the one that cannot: every line
+names both sides in full, and a new alias needs its own line rather than being
+absorbed by an address someone else also uses.
+
+The second measurement the Claude line rests on: **a mailmap lookup is not
+transitive, and rule order carries no meaning.** With Marcello's gmail address
+mapped away on one line and `claude` mapped ONTO that same address on another,
+`claude` resolves to `vjt-claude <marcello.barnaba@gmail.com>` and stops
+there. Verified in both rule orders, because a transitive resolver would have
+turned the ruling into its opposite.
+
+### The two rulings, and where they came from
+
+Neither was derivable from the repository, and #1808 says so about the first
+in its own body: *"is vjt's call — not a mechanical dedup"*.
+
+1. **`claude <claude@sonic88.org>` and `vjt-claude
+   <marcello.barnaba@gmail.com>` are one credit, under `vjt-claude`** — a
+   decision about how this project credits assisted work.
+2. **`Your Name <you@example.com>` is Stefy Lanza** — 89 commits attributed on
+   a human's word.
+
+**Both arrived by relay, and that is recorded next to them because the channel
+is not first-hand.** They were passed on from `#grappa` on 2026-08-26 via
+ircbot, textually *"1) vjt-claude 2) dentro"* at 08:38 and *"si your name ==
+stefy lanza"* at 08:47, and neither was seen directly by the orchestrator who
+relayed them. The same relay had already fabricated a ruling on the first
+question at 06:23 that morning — it claimed the issue body already carried the
+answer, when the body says the opposite — and that was retracted in channel.
+So the lines are applied and their origin sits beside them: if a relay was
+wrong, the correction is one line of `.mailmap` and one assertion, not a slice
+to redo. **The general rule this is an instance of: when a decision reaches
+the code through a channel nobody in the loop can verify, the provenance is
+part of the change, not context that evaporates with the conversation.**
+
+The evidence behind the second ruling was measured before it was asked for,
+and is worth keeping because it is what made the question answerable: 83 of
+the 89 commits are `frontends/shottino`; the last one under `Your Name` is
+`2026-08-01T02:05:02+02:00` and the first under `Stefy Lanza
+<stefy@nexlab.net>` is `2026-08-01T02:11:58+02:00` — six minutes and
+fifty-six seconds later, on the same tree, with no overlap in either
+direction, and 146 of Stefy's 147 commits in that same directory. That is the
+shape of a `git config user.name` run at two in the morning. It was still put
+as a question rather than written as a fact: evidence is not testimony, and
+putting a person's name on 89 commits deserves that person's word. (12 of the
+89 were COMMITTED by `Marcello Barnaba <vjt@openssl.it>`, which is a rebase or
+an apply and says nothing about who authored them.)
+
+**`2) dentro` answered a question this work never asked.** It was read as
+"dependabot goes INSIDE the credits", which is measurably already true and
+always was: `dependabot[bot]` carries 42 commits in the payload before this
+file and 42 after. Nothing excluded it; `credits.sh` filters only
+`--no-merges`, and a mailmap renames rather than drops, so it could not
+exclude anybody even if asked to. No change was made rather than writing inert
+code to satisfy the shape of an instruction — the fact is recorded in the
+file's closing comment instead, so the next reader does not take the bot for
+an oversight.
+
+With both rulings in, **no author identity in this history is left unmapped**,
+and `.mailmap` says that out loud rather than leaving it as the absence of a
+list: a contributor who starts committing from a second address should add a
+line, and knowing the file is meant to be COMPLETE is what makes that obvious.
+
+### How it is pinned
+
+`test/infra/credits_payload_test.bats` grew three cases, dying of three causes,
+because a dedup test that passes without the dedup has measured nothing. Every
+one was falsified on a bench, with `.mailmap` and `credits.sh` re-checksummed
+after each mutation:
+
+- a SANDBOX case pins the CHANNEL — that `credits.sh` still reaches the
+  mailmap-resolved name. Falsified by rewriting the deriver over `%an` (raw)
+  instead of `shortlog` (resolved), a plausible "portable" rewrite: it and the
+  next case go red, the rest stay green;
+- a case reading THIS checkout pins the MAPPINGS via `git check-mailmap` —
+  exact strings, and stable because it reads the committed file rather than a
+  history that grows every commit. Falsified three times, once per removed
+  line (`gabrielemarrone`, and each of the two rulings): each time only that
+  case dies, on the assertion for the line that went, so no mapping rests on
+  nothing. Its second half re-derives the real payload and refutes the
+  collapsed alias names, guarded against hollow green by first requiring the
+  canonical names to be PRESENT — a checkout with no readable git yields the
+  honest empty payload, against which every refutation would hold vacuously;
+- a third case pins the one NON-collapse, `vjt-claude` against the address it
+  shares. Falsified by rewriting that line short — only that case dies, which
+  is the first ruling being overruled in silence.
+
+The e2e roll spec (`issue1773-credits-roll-bakes-git-facts.spec.ts`) is
+unaffected by construction, and it is worth saying why rather than discovering
+it: it compares what the modal PAINTS against the `GRAPPA_CREDITS` payload
+derived from the SAME repository at run time, so a mailmap moves both ends of
+the channel together.
+
+Not fixed here, and noted so it is not rediscovered: `credits.sh` closes with
+*"Why: docs/OPERATIONS.md § Packaging (infra/packaging/)"*, and that section
+does not mention the credits payload at all — the word does not appear in
+`OPERATIONS.md`. That is #1773's documentation debt, not this slice's, and
+inventing a credits subsection to hang one `.mailmap` sentence on would put
+the note somewhere no reader would look for it.

--- a/test/infra/credits_payload_test.bats
+++ b/test/infra/credits_payload_test.bats
@@ -26,7 +26,10 @@
 #      bare base on its no-git path. Failing loud here would break precisely
 #      the two builds that ship;
 #   5. ONE LINE of output — every wrapper captures it with `$(...)` into an
-#      env var, and a multi-line payload would arrive mangled.
+#      env var, and a multi-line payload would arrive mangled;
+#   6. one person gets ONE credit — `.mailmap` collapses the identities a
+#      contributor has committed under, and the roll must show the collapsed
+#      list rather than the same person two or three times (#1808).
 #
 # The sandbox repos are built here rather than measured against this checkout:
 # the real history changes every commit, so a case reading it could only
@@ -37,6 +40,12 @@ load ../bats_helpers
 
 setup() {
     SCRIPT="$BATS_TEST_DIRNAME/../../infra/packaging/credits.sh"
+
+    # The checkout this suite runs in. The #1808 cases below read the REAL
+    # `.mailmap` through it: unlike the history, that file is a committed
+    # artefact this repo owns, so an exact assertion against it is stable and
+    # dies on the one edit that matters — a removed or reshaped mapping.
+    REAL_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 
     REPO="$BATS_TEST_TMPDIR/repo"
     # `credits.sh` derives the repo root as SCRIPT_DIR/../.. (the layout
@@ -66,8 +75,9 @@ init_repo() {
     git -C "$REPO" init -q -b main
     git -C "$REPO" config user.name "sandbox"
     git -C "$REPO" config user.email "sandbox@example.invalid"
-    # No mailmap: `git shortlog` therefore groups by the author name verbatim
-    # and the expected counts below are the literal ones.
+    # No mailmap unless a case writes one: `git shortlog` therefore groups by
+    # the author name verbatim and the expected counts below are the literal
+    # ones. The #1808 case that needs a mailmap adds it after this.
 }
 
 @test "the payload names every contributor with the count of their non-merge commits" {
@@ -158,4 +168,111 @@ init_repo() {
 
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 1 ]
+}
+
+# ── #1808 — one person, one credit ──────────────────────────────────────────
+#
+# The roll used to split people across the identities they had committed
+# under, because nothing had ever de-duplicated them. The cure is a root
+# `.mailmap`: `git shortlog` resolves author identity through it before
+# grouping, so the collapse costs no history rewrite and no change to
+# credits.sh.
+#
+# Three cases, dying of three different causes:
+#
+#   * the first is a SANDBOX case and pins the CHANNEL — that credits.sh
+#     still reaches the mailmap-resolved name. It goes red on `--no-mailmap`,
+#     or on a reimplementation over `%an` (raw) instead of `%aN` (resolved);
+#   * the second reads THIS checkout and pins the MAPPINGS — it goes red when
+#     a line is removed from `.mailmap`;
+#   * the third reads THIS checkout and pins the one NON-collapse: an identity
+#     that merely shares an address with a mapped one must stay its own. That
+#     is what a mechanical dedup gets wrong, and it is invisible once done.
+
+@test "#1808 — a .mailmap collapses one person's identities into a single credit" {
+    init_repo
+    # Ada under two addresses AND two names, with a namesake-free second
+    # person to prove the collapse is not "everything became one row".
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "Ada Lovelace" "ada@work.invalid" "two"
+    commit_as "ada" "ada@example.invalid" "three"
+    commit_as "Grace Hopper" "grace@example.invalid" "four"
+
+    printf '%s\n' \
+        'Ada Lovelace <ada@example.invalid> Ada Lovelace <ada@work.invalid>' \
+        'Ada Lovelace <ada@example.invalid> ada <ada@example.invalid>' \
+        > "$REPO/.mailmap"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Three commits on ONE row. The exact string, like the case at the top of
+    # this file: a partial collapse (two rows for Ada) is as wrong as none.
+    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","commits":3},{"name":"Grace Hopper","commits":1}]'* ]]
+}
+
+@test "#1808 — every alias this repo's .mailmap collapses resolves to one identity" {
+    # `check-mailmap` reads the FILE, not the log, so this asserts exact
+    # strings without depending on a history that grows every commit.
+    run git -C "$REAL_ROOT" check-mailmap \
+        'vjt <vjt@openssl.it>' \
+        'Marcello Barnaba <mbarnaba@meta.com>' \
+        'Marcello Barnaba <marcello.barnaba@gmail.com>' \
+        'Alessio Bonforti <38355294+abonforti@users.noreply.github.com>' \
+        'gabrielemarrone <131861953+gabrielemarrone@users.noreply.github.com>' \
+        'claude <claude@sonic88.org>' \
+        'Your Name <you@example.com>'
+
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = 'Marcello Barnaba <vjt@openssl.it>' ]
+    [ "${lines[1]}" = 'Marcello Barnaba <vjt@openssl.it>' ]
+    [ "${lines[2]}" = 'Marcello Barnaba <vjt@openssl.it>' ]
+    [ "${lines[3]}" = 'Alessio Bonforti <info@alessiobonforti.com>' ]
+    [ "${lines[4]}" = 'Gabriele Marrone <gabriele.marrone@gmail.com>' ]
+    # The Claude session identities are ONE credit under `vjt-claude` — a
+    # ruling, not a dedup (#1808). Its canonical address is the one shared
+    # with Marcello, and it does NOT chain on into him: a mailmap lookup is
+    # a single resolution, not a transitive one.
+    [ "${lines[5]}" = 'vjt-claude <marcello.barnaba@gmail.com>' ]
+    # The git default nobody configured, attributed on a human's word rather
+    # than on the (strong) inference the history supports — also a ruling.
+    [ "${lines[6]}" = 'Stefy Lanza <stefy@nexlab.net>' ]
+
+    # And the PAYLOAD this checkout actually produces carries the collapse:
+    # an alias is only ever VISIBLE in the roll when it differs by NAME
+    # (`shortlog -sn` groups by name, so the same-name address splits above
+    # never reached it), and none of the four is there now.
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+
+    # Anti-hollow-green: a checkout with no readable git yields the honest
+    # empty payload, against which every `refute` below holds vacuously. The
+    # canonical names must be PRESENT before their aliases may be absent.
+    [[ "$output" == *'{"name":"Marcello Barnaba","commits":'* ]]
+    [[ "$output" == *'{"name":"Gabriele Marrone","commits":'* ]]
+    [[ "$output" == *'{"name":"vjt-claude","commits":'* ]]
+    [[ "$output" == *'{"name":"Stefy Lanza","commits":'* ]]
+    refute grep -q '"name":"vjt"' <<< "$output"
+    refute grep -q '"name":"gabrielemarrone"' <<< "$output"
+    refute grep -q '"name":"claude"' <<< "$output"
+    refute grep -q '"name":"Your Name"' <<< "$output"
+}
+
+@test "#1808 — a shared address does not drag one identity into another" {
+    # `vjt-claude` is the canonical name the Claude session identities were
+    # ruled into, and it commits under `marcello.barnaba@gmail.com` — the
+    # SAME address as one of the aliases collapsed in the case above. A
+    # mapping written `Proper <new> <old>` keys on the commit ADDRESS ALONE,
+    # so that spelling folds `vjt-claude` into Marcello and quietly overrules
+    # the ruling. The four-field `Proper <new> Commit Name <old>` spelling
+    # keys on the pair; measured both ways before the file was written.
+    #
+    # So this asserts a NON-collapse, and it is the only case that does. It is
+    # the one line of defence against a future tidy-up shortening the entries:
+    # the wrong spelling breaks nothing loudly, it just silently reassigns
+    # eight commits to somebody who did not write them.
+    run git -C "$REAL_ROOT" check-mailmap 'vjt-claude <marcello.barnaba@gmail.com>'
+
+    [ "$status" -eq 0 ]
+    [ "$output" = 'vjt-claude <marcello.barnaba@gmail.com>' ]
 }


### PR DESCRIPTION
`.mailmap` at the repo root, so the credits modal (#1773) stops listing the same
people two and three times. git resolves author identity through it before
reporting one, so `git log`, `git shortlog` and `infra/packaging/credits.sh`
downstream of them all see the collapsed set — with no hash moved and nothing
force-pushed.

## 🔴 Provenance of the two rulings — read this first

Two of the five mappings are **decisions, not dedups**, and #1808 says so in its
own body: *"is vjt's call — not a mechanical dedup"*. Both reached this branch
**relayed by ircbot from `#grappa`**, and **neither was verified first-hand by
the orchestrator who passed them on** (reading IRC is out of her reach). Textual,
with times, both on 2026-08-26:

- **08:38** — *"1) vjt-claude 2) dentro"*
- **08:47** — *"si your name == stefy lanza"*

Context that belongs with them: **the same relay fabricated a ruling on the first
question at 06:23 that morning** — it claimed the issue body already carried the
answer, when the body says the opposite — and that was retracted in channel.

So they are applied and their origin is written next to them, in `.mailmap` and in
the DESIGN_NOTES entry. **If a relay was wrong, the correction is one line of
`.mailmap` and one assertion, not a slice to redo.** Worth a second look at review.

## The mappings

| commit identity | resolves to | why |
| --- | --- | --- |
| `vjt <vjt@openssl.it>` | `Marcello Barnaba <vjt@openssl.it>` | same address |
| `Marcello Barnaba <mbarnaba@meta.com>` | `Marcello Barnaba <vjt@openssl.it>` | same name |
| `Marcello Barnaba <marcello.barnaba@gmail.com>` | `Marcello Barnaba <vjt@openssl.it>` | same name |
| `Alessio Bonforti <38355294+abonforti@…>` | `Alessio Bonforti <info@alessiobonforti.com>` | same name, matching GH handle |
| `gabrielemarrone <131861953+gabrielemarrone@…>` | `Gabriele Marrone <gabriele.marrone@gmail.com>` | matching GH handle |
| `claude <claude@sonic88.org>` | `vjt-claude <marcello.barnaba@gmail.com>` | **ruling (08:38)** |
| `Your Name <you@example.com>` | `Stefy Lanza <stefy@nexlab.net>` | **ruling (08:47)** |

After these, **no author identity in this history is left unmapped**, and the file
says so out loud rather than leaving it as the absence of a list.

## `2) dentro` — a measured NO-OP, and it is declared rather than coded

Read as *"dependabot goes INSIDE the credits"*. It **already was, and always had
been**: `dependabot[bot]` carries **42 commits in the payload before this branch
and 42 after**. Nothing excluded it — `credits.sh` filters only `--no-merges` — and
a mailmap **renames, it never drops**, so nothing here could exclude anybody even
if asked to. No code was written to "include" it, because that code would be inert.
The fact is recorded in the file's closing comment so the next reader does not take
the bot for an oversight.

## The oracle, before and after — and a correction to the issue's framing

`%an`/`%ae` (raw, what git recorded) against `%aN`/`%aE` (resolved), on `8ce0c836`:

| | before | after |
| --- | --- | --- |
| distinct author names | 13 | **9** |
| distinct identities | 16 | **9** |
| `credits.sh` payload rows | 13 | **9** |

Gone from the roll: `Your Name`, `claude`, `gabrielemarrone`, `vjt`.
Moved: Marcello 5140→5141 · **Stefy Lanza 147→236** · Gabriele 24→25 ·
**vjt-claude 2→8** · dependabot 42→**42**.

⚠️ **`shortlog -sn` groups by NAME, so the same-name address splits the issue
tabulates were ALREADY one row in the modal** — Marcello across three addresses,
Alessio across two, both collapsed before this file existed. Only an alias
differing by NAME was ever visible there. The address axis is still collapsed
(that is the `%aN <%aE>` oracle the issue names, and a `shortlog -sne` would split
on it), but **the modal gains four rows, not six**, and claiming otherwise would
be selling two fixes that fix nothing visible.

Second trap, recorded so nobody repeats it: **`git -c mailmap.file=/dev/null` does
NOT disable the root `.mailmap`** — that setting ADDS a file to the ones consulted,
so an A/B taken that way compares the after with itself.

## Every line carries all four fields, and that is load-bearing

`Proper <new> <old>` keys on the commit **ADDRESS ALONE**;
`Proper <new> Commit Name <old>` keys on the **pair**. `marcello.barnaba@gmail.com`
carries both Marcello's own commits and `vjt-claude`'s. **Measured in a sandbox
before the file was written**: under the short spelling
`git check-mailmap 'vjt-claude <marcello.barnaba@gmail.com>'` answers
`Marcello Barnaba <vjt@openssl.it>`; under the four-field spelling it answers
itself. So the short form would have **silently overruled the 08:38 ruling**. One
spelling throughout, and it is the one that cannot do that.

The Claude line rests on a second measurement: **a mailmap lookup is NOT transitive,
and rule order carries no meaning** (verified both ways). That is the only reason
`claude` can canonicalise onto an address that is itself mapped away one line above
— it lands on `vjt-claude <marcello.barnaba@gmail.com>` and stops.

## Tests — three cases, every one falsified on a bench

`test/infra/credits_payload_test.bats`, extended where #1808 asks (against the
**payload**), not a new shape check elsewhere. Five mutants, each restored and the
files re-checksummed (`md5`) afterwards:

| mutant | rc | dies |
| --- | --- | --- |
| remove the `gabrielemarrone` line | 1 | **only** case 8, on the Gabriele assertion |
| short 3-field spelling on the shared address | 1 | **only** case 9, on `vjt-claude` |
| remove the **08:38 ruling** line | 1 | **only** case 8, on `vjt-claude` |
| remove the **08:47 ruling** line | 1 | **only** case 8, on `Stefy Lanza` |
| deriver rewritten over `%an` (bypasses the mailmap) | 1 | cases 7 and 8 |

So no mapping — the two rulings included — rests on nothing. The payload half of
case 8 is guarded against hollow green: a checkout with no readable git yields the
honest empty payload, against which every refutation would hold vacuously, so the
**canonical** names must be PRESENT before their aliases may be absent.

`issue1773-credits-roll-bakes-git-facts.spec.ts` is unaffected **by construction**,
checked rather than assumed: it compares what the modal PAINTS against the
`GRAPPA_CREDITS` payload derived from the SAME repo at run time, so a mailmap moves
both ends of the channel together.

## Gates

| gate | rc | note |
| --- | --- | --- |
| `scripts/bats.sh` (whole suite: `test/bin/ test/infra/ test/scripts/`) | **0** | **703 ok, 0 not ok** |
| `scripts/design-notes-gate.sh` (post-commit) | **0** | *1 new entry heading(s), separator and marker present* |
| `scripts/union-rebase.sh` | **0** | ⚠️ **vacuous, and the tool says so itself**: the branch was already on top of `origin/main`, so the union driver never ran. Re-run it if `main` moves before merge. |

Run from the worktree (`cd .worktrees/w1-1808`), rc read from files, no blind sleeps.
`bats` runs on the host — no docker, no lane consumed.

## ℹ️ This PR should show FOUR checks, not five

`integration.yml` has neither `test/**` nor `infra/**` in its `paths:`, and this
slice touches `.mailmap` (root), `infra/packaging/` (read only, not modified) and
`test/infra/`. **4/4 is not 5/5** — if that is what appears, it is correct, not a
truncated CI.

## What I did NOT do

- Did not merge, deploy, close the issue, or poll CI.
- Did not touch `docs/OPERATIONS.md`. `credits.sh` closes with *"Why:
  docs/OPERATIONS.md § Packaging"* and **that section does not mention the credits
  payload at all** — the word does not appear anywhere in the file. That is #1773's
  documentation debt; inventing a credits subsection to hang one `.mailmap` sentence
  on would put the note where no reader would look. Noted in DESIGN_NOTES.
