### PR TITLE
docs(#1820): one fresh-worktree bootstrap procedure, and the cp -Rc step nothing stated

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -422,6 +422,10 @@ ever recurs: offline-init from the main checkout's already-cloned objects
 — `git -c protocol.file.allow=always -c
 submodule."cicchetto/e2e/infra".url=<main-checkout>/.git/modules/cicchetto/e2e/infra
 submodule update --init cicchetto/e2e/infra`.
+This is ONE item of the fresh-worktree bootstrap; the ordered list —
+submodules, the two per-worktree `node_modules` trees, the `bun.sh`
+self-heal, and the `cp -Rc` clone with the lock check that makes it safe
+— is `docs/TESTING.md` → "Bootstrapping a fresh worktree" (#1820).
 
 **…and the removal side of it: `git worktree remove` needs `--force`
 once a submodule has EVER been initialised in that worktree.** The

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -103,6 +103,74 @@ clean before claiming LANDED — per `feedback_landed_claim_evidence`,
 "LANDED" requires `scripts/check.sh` exit-0 with literal tail evidence,
 not "format ✓ credo ✓ dialyzer ✓" hand-waving.
 
+## Bootstrapping a fresh worktree (#1820)
+
+A new worktree carries the source and nothing else — no submodules, no
+`node_modules`. Every failure that produces is documented in this file
+already; what was missing is the ORDER, and one step that no operational
+doc stated at all (step 4). This section points at the paragraphs rather
+than restating them.
+
+**A docs-only branch needs none of this.** Every step below is a
+precondition for RUNNING a gate, not for having a worktree.
+
+**1. Submodules do not come with a worktree.** `vendor/bats-core` and
+`cicchetto/e2e/infra` are empty until initialised, and the init REQUIRES
+`-c protocol.file.allow=always`: the clone comes from the superproject's
+own local module store over `file://`, which the CVE-2022-39253
+mitigation blocks by default (#592). You are walked through it —
+`scripts/bats.sh` auto-inits the first, `scripts/testnet.sh` the second —
+so the by-hand form is a fallback. Commands, the `git submodule status`
+reading, and the ⛔ never-`rsync` rule: **trap 5** in "Five e2e gate traps
+that fake a green (or a red)"; the one-liners also sit under "When the
+test stack itself is broken". Note the exit cost before you opt in: once
+ANY submodule has been initialised here, `git worktree remove` needs
+`--force` for the life of the worktree — `docs/OPERATIONS.md`,
+"Fresh-worktree e2e submodule gotcha".
+
+**2. TWO `node_modules` trees, both per-worktree.**
+`cicchetto/node_modules` (vitest, tsc, vite, biome) and
+`cicchetto/e2e/node_modules` (`@playwright/test`, `@types/node`,
+`irc-framework`) — unlike the bun download cache at `runtime/bun-cache`,
+which every worktree shares. "A fresh worktree has no `node_modules`"
+below has the two signatures an absent tree produces (`exit 127`, and
+`Cannot find type definition file for 'node'`, which is an ABSENT
+TOOLCHAIN reported as a type error) plus the third state: an
+`e2e/node_modules` that exists and is EMPTY.
+
+**3. `scripts/bun.sh` self-heals both, on demand, for every non-install
+verb.** The wrapper is the answer; a bare `vitest` / `tsc` / `biome` is
+the question. Either signature in step 2 means you invoked something
+other than the wrapper — or that the install failed earlier in the same
+run.
+
+**4. Cloning `node_modules` from another worktree is `cp -Rc`** — a CoW
+clone of `cicchetto/node_modules` from a tree that already has one. This
+is "the documented `cp -Rc` procedure" the lock-drift paragraph below
+names; it was recorded in `docs/DESIGN_NOTES.md` (2026-08-20, #1571) and
+stated in no operational doc until this section. `-c` is macOS `cp(1)`'s
+`clonefile(2)` flag (`man cp`), which falls back to a plain copy when the
+target filesystem cannot clone; nothing in this repo states an equivalent
+for another `cp(1)`, so confirm your own before copying the flag.
+**It copies whatever is there**, so it is safe only when the donor's
+content is what `bun.lock` pins — `scripts/bun.sh run check`'s `lock
+drift` stage is what proves that, and it prints the cure
+(`scripts/bun.sh install --frozen-lockfile`).
+
+**5. Checking the donor by hand: hash `cicchetto/bun.lock`, and nothing
+else.** It is the only lock file in the tree. There is no
+`cicchetto/e2e/bun.lock`, and `cicchetto/e2e/infra` is a SUBMODULE, whose
+checked-out commit the superproject records as a gitlink — `git submodule
+status`, never a lock at that path. Hashing a path that does not exist
+fakes a measurement the moment a pipe is involved:
+`cat cicchetto/e2e/bun.lock 2>/dev/null | md5` prints
+`d41d8cd98f00b204e9800998ecf8427e`, the md5 of the EMPTY STRING, at
+rc 0 — donor and target "agree" because neither was read. Hash the path
+directly instead (`md5 -q <path>`: rc 1 and a loud `No such file`). Same
+class as "`| tail -N` on a gate script eats the verdict AND the exit
+code" below. And equal digests are a precondition, not the proof — the
+`lock drift` stage in step 4 is the proof.
+
 ## Architecture: why the scripts exist
 
 **NEVER run `docker`, `docker run`, `docker exec`, or `docker compose`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -114,19 +114,37 @@ than restating them.
 **A docs-only branch needs none of this.** Every step below is a
 precondition for RUNNING a gate, not for having a worktree.
 
-**1. Submodules do not come with a worktree.** `vendor/bats-core` and
-`cicchetto/e2e/infra` are empty until initialised, and the init REQUIRES
+**1. Submodules do not come with a worktree.** `.gitmodules` lists
+**three** — `vendor/bats-core`, `cicchetto/e2e/infra` and
+`frontends/shottino/vendor/libdatachannel` — and all three are empty
+until initialised. In a worktree the init REQUIRES
 `-c protocol.file.allow=always`: the clone comes from the superproject's
 own local module store over `file://`, which the CVE-2022-39253
-mitigation blocks by default (#592). You are walked through it —
-`scripts/bats.sh` auto-inits the first, `scripts/testnet.sh` the second —
-so the by-hand form is a fallback. Commands, the `git submodule status`
-reading, and the ⛔ never-`rsync` rule: **trap 5** in "Five e2e gate traps
-that fake a green (or a red)"; the one-liners also sit under "When the
-test stack itself is broken". Note the exit cost before you opt in: once
-ANY submodule has been initialised here, `git worktree remove` needs
-`--force` for the life of the worktree — `docs/OPERATIONS.md`,
-"Fresh-worktree e2e submodule gotcha".
+mitigation blocks by default (#592).
+
+**You are walked through TWO of the three.** `scripts/bats.sh` auto-inits
+`vendor/bats-core`, `scripts/testnet.sh` auto-inits `cicchetto/e2e/infra`,
+so for those the by-hand form is a fallback: the commands, the `git
+submodule status` reading, and the ⛔ never-`rsync` rule are in **trap 5**
+of "Five e2e gate traps that fake a green (or a red)", with the one-liners
+repeated under "When the test stack itself is broken".
+
+**`frontends/shottino/vendor/libdatachannel` has no auto-init, and no
+gate in this file needs it.** It is a precondition of the opt-in
+`make -C frontends/shottino call` helper only — never `make all`, and
+`make check` deliberately links a hand-written `<rtc/rtc.h>` stub so it
+runs without the submodule (#880). Skipping it is the normal case; it is
+named here because a bootstrap list that counts two leaves whoever builds
+`call` with neither a step nor a warning. The command and why the helper
+is opt-in: `frontends/shottino/docs/CALLS.md` → "The helper, as it
+stands"; `make call` also fails with that exact command rather than a
+bare cmake error. Note that CALLS.md's form carries no
+`protocol.file.allow` — it is not written for a worktree.
+
+Note the exit cost before you init anything: once ANY submodule has been
+initialised here, `git worktree remove` needs `--force` for the life of
+the worktree — `docs/OPERATIONS.md`, "Fresh-worktree e2e submodule
+gotcha".
 
 **2. TWO `node_modules` trees, both per-worktree.**
 `cicchetto/node_modules` (vitest, tsc, vite, biome) and


### PR DESCRIPTION
Lifts the fresh-worktree bootstrap into one place. Docs only — no `lib/`,
no `test/`, no `scripts/`, no gate changes.

## Where it went, and why

**`docs/TESTING.md`**, as a new `## Bootstrapping a fresh worktree
(#1820)` section placed immediately after `## Quick reference` and before
`## Architecture: why the scripts exist`.

The issue names the deciding argument as *where a newcomer looks first*.
A newcomer opens a worktree in order to **run a gate**, and they arrive at
this problem by copying a command out of the Quick reference block and
watching it die — so the answer belongs on the next screen, in the file
that owns gate-running. Three supporting measurements:

- Three of the issue's four items already live in `TESTING.md`
  (`:197` absent `node_modules`, `:210` the empty `e2e/node_modules`,
  `:219` lock drift). The fourth — submodules — has its *full* treatment
  here too, in **trap 5** of "Five e2e gate traps" and in "When the test
  stack itself is broken", not only in `OPERATIONS.md`. Putting the entry
  point in `OPERATIONS.md` would have pointed away from three of four.
- `OPERATIONS.md:410-413` already forwards test-running to `TESTING.md`.
  The reverse forward does not exist, so `TESTING.md` is the sink, not
  the source, for this class.
- CLAUDE.md's Docs map splits them as *how-to-run-tests runbook (every
  gate, gotchas)* versus *operator + developer runbook (verbs, scripts,
  deploy, runtime data, monitoring)*. A gate **precondition** sits on the
  gate side of that line.

`OPERATIONS.md`'s "Fresh-worktree e2e submodule gotcha" keeps its own
content and gains a four-line pointer naming itself as one item of the
ordered list. Cross-link, not a fourth copy: every step in the new
section points at the paragraph that already carries the detail instead
of restating it.

## The one genuinely new statement (step 4)

`cp -Rc`. `TESTING.md:223` calls it *"the documented `cp -Rc` procedure"*
while the only statement of it in the repo is
`docs/DESIGN_NOTES.md:53131` — the archive. That is the hole the issue
describes, so the step is now stated in the operational doc, with the
archive cross-linked rather than copied.

`-c` is glossed as macOS `cp(1)`'s `clonefile(2)` flag, sourced from the
local `man cp` (which also documents the fallback to `copyfile(2)` when
the target filesystem cannot clone). The text says explicitly that
nothing in this repo states an equivalent for another `cp(1)` and tells a
non-Darwin reader to confirm their own before copying the flag — see
"refused to assert" below.

## The trap this branch measured today (step 5)

The donor check is **the md5 of `cicchetto/bun.lock` and nothing else**.
The doc carries the METHOD, not the census of donor worktrees that
happened to be populated this morning — that list would rot by tomorrow.

**Correcting the briefed premise, measured.** The brief told me
`cicchetto/e2e` is a submodule and that hashing `cicchetto/e2e/bun.lock`
therefore yields the empty-string md5. The first half is false and the
second half is only true through a pipe:

```
git ls-tree HEAD cicchetto/  → 040000 tree … cicchetto/e2e     (a plain tree, not 160000 commit)
.gitmodules                  → the submodule is cicchetto/e2e/infra, plus vendor/bats-core
                               and frontends/shottino/vendor/libdatachannel
find cicchetto -name 'bun.lock*'  → cicchetto/bun.lock, and nothing else

md5 -q cicchetto/e2e/bun.lock              → "No such file or directory", rc=1   (loud)
cat cicchetto/e2e/bun.lock 2>/dev/null|md5 → d41d8cd98f00b204e9800998ecf8427e, rc=0 (silent)
printf '' | md5                            → d41d8cd98f00b204e9800998ecf8427e
```

So the trap survives, with a different mechanism than briefed: there is
no `cicchetto/e2e/bun.lock` at all, and the empty-string digest appears
only once a pipe swallows the read failure. The doc states it that way,
and links it to the `| tail -N` trap (#1741) it shares a class with. The
submodule sentence names `cicchetto/e2e/infra` and its gitlink, which is
what actually carries that tree's provenance.

## No DESIGN_NOTES entry

Deliberate, and the brief asked me to say so rather than leave it
implicit. This is a lift: the placement follows the existing Docs map
instead of departing from it, and the one durable new fact (step 5's
trap) is a gotcha, which is exactly what `TESTING.md` is for. An entry
would add the union-merge separator hazard for no rationale that is not
already in the doc or in this body.

## What I refused to assert

- **That `cicchetto/e2e`'s deps are pinned by `cicchetto/bun.lock`.**
  `TESTING.md:190` says the *compiler* is ("one repo, one compiler
  version, pinned by `cicchetto/bun.lock`"), which is not the same claim.
  `grep -c playwright cicchetto/bun.lock` is 1 — ambiguous, and I did not
  chase it. The doc says only what I measured: `cicchetto/bun.lock` is
  the only lock file in the tree and there is no `cicchetto/e2e/bun.lock`.
- **Whether the `lock drift` stage covers `e2e/node_modules` as well as
  `cicchetto/node_modules`.** `TESTING.md:227` says it "compares the two"
  without naming which trees. I did not read `lock-drift.ts` to settle
  it, so the section attributes no e2e coverage to the stage.
- **What `-c` does to a non-macOS `cp(1)`.** I measured `man cp` on
  Darwin only, and no repo doc states it for GNU coreutils. Rather than
  guess, the text bounds the claim to macOS and tells the reader to check.
- **A donor list.** Named in the brief, excluded on purpose: true this
  morning, false next week. Method only.

## Out of slice, named not touched

- `scripts/bun.sh`'s `needs_install` still tests emptiness, never
  freshness — `DESIGN_NOTES:53128` records it. A preflight there would be
  a script change; not this fetta.
- The step-5 trap argues for a helper that hashes the donor's lock for
  you. Same reason: `scripts/` is out of perimeter.
- No gate was run. Docs-only, no lane taken, no `node_modules` in either
  tree, per the brief.

Refs #1820.

---

## Review correction (2nd commit, `58797ce1`)

**Step 1 undercounted the submodules.** It named two
(`vendor/bats-core`, `cicchetto/e2e/infra`) and declared both
auto-initialised. There are **three**, and the claim is true of two:

```
git show origin/main:.gitmodules
  → cicchetto/e2e/infra
    vendor/bats-core
    frontends/shottino/vendor/libdatachannel

git grep -n "submodule update --init" origin/main -- scripts/
  → scripts/bats.sh:48     vendor/bats-core
    scripts/testnet.sh:47  cicchetto/e2e/infra
    (nothing else)
```

Raised by review; re-measured here before acting, and it holds. Worse
than a miscount: **`TESTING.md` already contradicted itself.** Line 420,
under "The e2e stack", names all three by path — so a section titled
"Bootstrapping a fresh worktree" that counts two is the precise debt
#1820 exists to close, reintroduced 310 lines above the paragraph that
gets it right.

Step 1 is now three paragraphs: the three names, the **two** you are
walked through, and the third stated by its distinguishing property —
**no auto-init, and no gate in this file needs it**. It is a precondition
of the opt-in `make -C frontends/shottino call` only, never `make all`
(`CALLS.md`, "The helper, as it stands"), and `make check` links a
hand-written `<rtc/rtc.h>` stub *precisely so it runs without the
submodule* (#880, `frontends/shottino/Makefile`). Cross-linked, not
re-copied, like every other step; `frontends/shottino/Makefile:284` also
prints that exact command as its missing-submodule failure, so `make
call` fails readably rather than with a bare cmake error.

**One more thing I refused to assert.** `CALLS.md:255` carries no
`-c protocol.file.allow=always`. That file is not written for a worktree,
and I did not measure the third submodule's clone from a linked worktree.
The text therefore states what `CALLS.md` states and marks the gap,
rather than generalising the flag onto a path I never ran.

**Out of slice, named not touched (new):** the missing auto-init for
`frontends/shottino/vendor/libdatachannel` looks like a real asymmetry —
two of three submodules are self-healing and the third is not. Fixing it
is a `scripts/` (or `Makefile`) change and is outside this perimeter;
worth its own issue if you want it.
