### PR TITLE
perf(#1759): resolve a per-channel join's (subject, network) once — a declared mitigation, not the property

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -65824,3 +65824,123 @@ that both its engines honour `font-size-adjust: cap-height`; that Safari on a
 phone does too is inference from the same WebKit lineage, not a measurement.
 Should it turn out otherwise there, the fallback path is the one already
 described and its worst case is 4%.
+<!-- entry #1759a -->
+
+---
+
+## 2026-08-26 — #1759a: the join door was half identity, and the fix is a constant
+
+The pool-saturation half of #1759 asks who FILLS the queue. The issue's own
+frame census answers it for the per-row push — 412 of 413 dropped queries were
+badge arithmetic — and #1768 already bounded that path with
+`WindowCounts.Pusher.Coalescer`. Two facts reframe what was left.
+
+**The coalescer has never run in production.** `git cat-file -e
+v1.3.1:lib/grappa/window_counts/pusher/coalescer.ex` answers *exists on disk,
+but not in `v1.3.1`* — and 1.3.1 is the release the jail was running in BOTH
+incidents. #1768 landed 2026-08-25, the same day as the 00:15 recurrence and in
+response to its measurement. So the principal cure for this half exists, is
+merged, and is a DEPLOY decision, exactly like #1715 on the other half.
+
+**The badge math has three doors, and only two were bounded.** `/me` costs a
+constant 2 queries for any window count (`bulk_snapshot/4`, #396); the per-row
+push is O(distinct windows) per window (#1768); the per-channel JOIN reply ran
+a full `WindowCounts.snapshot/7` per join, behind neither. It is the door that
+fires at RECONNECT — `cicchetto/src/lib/socket.ts` records that phoenix.js
+re-joins every held topic after a socket drop — which is the instant after a
+saturation, when the pool has least to give.
+
+### What the measurement said, against what reading it suggested
+
+`GrappaWeb.JoinSeedCostTest` counts `[:grappa, :repo, :query]` around real
+channel joins. A live join cost **11 queries**, and only five of them were
+arithmetic. **Six were one `(subject, network)` pair resolved three times** in
+the same join: `canonicalize_topic/1`, `join_reply/1`, and the after-join
+`push_channel_snapshot/4` each resolved it from scratch. Half the door was
+identity, not counting — which reading the code had not shown, and is why the
+number came first.
+
+`channel_context/1` now resolves the pair ONCE in `join/3` and threads it to
+all four legs (the fourth is `assign_presence_suppression/4`'s own-nick
+carve-out). It is carried as `{:ok, {subject, network}} | :error` rather than
+unwrapped, so every leg keeps the fall-through it already had — `:ascii`, a
+zero snapshot, `nil`, `:ok` — instead of a shared one invented here.
+
+### 🔴 This moves the CONSTANT, not the LAW
+
+Measured on the live fixture at three W, before and after:
+
+| W | before | after |
+|---|---|---|
+| 1 | 12 | 8 |
+| 4 | 45 | 29 |
+| 8 | 89 | 57 |
+
+`11·W + 1` becomes `7·W + 1`. The `+1` is the fixture's own
+`Networks.mark_registered/1` on the 001, which does not scale and drops out of
+the per-join delta. The exponent does not move: **W full snapshots remain W
+full snapshots**, and the reconnect loop that re-feeds itself is still O(W),
+1.57× slower to arrive. Shipped as a declared MITIGATION. #1759 is NOT closed
+by it.
+
+### Why `bulk_snapshot/4` cannot be the fix — the mechanism, not the analogy
+
+The obvious move is to route the join door through the primitive that makes
+`/me` flat. It does not fit, and the reason is not ergonomic. `/me`'s O(1)
+comes from `ReadCursor.bulk_unread_split/3` asking every window in ONE grouped
+statement; the GROUP BY is what buys the property. A join reply is a
+single-window question arriving in its own WS frame, in its own channel
+process — **there is no second window in scope to group with**. The input that
+makes the primitive O(1) does not exist at that door. Measured: at W=8 it
+answers for all eight at a cost of 2, and no arity asks it for one. Routing
+each join there would cut badge reads 4 → 2 while making every call compute
+the whole account and discard all but one window — O(W²) of row work across
+the storm.
+
+Nor does the socket rescue it, though the locality is real. phoenix.js issues
+all W rejoins in one synchronous loop (`onConnOpen` → `stateChangeCallbacks.
+open.forEach`), and every frame of one connection does enter
+`Phoenix.Socket.__in__/2` in the same transport process. But `handle_in/4`
+takes ONE frame and must return THAT frame's reply: two joins are sequential
+calls, never a shared scope. What exists is a burst in a mailbox. Turning it
+into a GROUP BY input means holding the first W−1 replies until the last
+arrives, and W is unknowable — the client never announces how many topics it
+will re-join — so it would be a timeout batch, adding latency to every join
+ACK including the single-join case. This is a property of the API contract,
+not a magnitude, which is why it is settled by reading and not by measuring.
+
+### What was NOT established
+
+The distribution of the incident's frames across windows is still unmeasured
+(#1768's own caveat), and this entry adds no per-channel data. The join storm
+is not shown to have HAPPENED in either incident: at `00:15:24.941` the logger
+was in `:drop` mode, so the verdict that closed the reporter's socket may never
+have reached disk, and no inference is built on its absence. A second plausible
+amplifier is READ and NOT measured: `Grappa.TaskSupervisor` is started with no
+`max_children`, so the coalescer's flush fan-out is bounded by O(windows) — a
+bound unrelated to `pool_size: 10`. And the `user_settings` row read twice per
+join is the lever #1768 named and deliberately left; it is still here, still
+deliberately.
+
+One race is accepted rather than removed: the after-join leg now uses the pair
+resolved at join time, so a user deleted in the microseconds between the two
+legs is served from the pre-deletion struct instead of degrading to `:error`.
+The loser of that race is a snapshot pushed onto a socket already being torn
+down.
+
+### Two instrument faults caught, both of which would have shipped a lie
+
+`GrappaWeb.BootCostTest`'s telemetry handler filters on `self()`, which is
+exact for a controller. Copied here it reports ZERO, because
+`Phoenix.ChannelTest` runs `join/3` in the spawned channel process — a filtered
+count is indistinguishable from "this door is already free". And the arrival
+ORDER of sources is not deterministic: the session process emits into the same
+window, and `network_credentials` moved from position 9 to position 2 between
+two runs of one test, so the pin is a TALLY and the per-join figure is a DELTA
+between two W, which cancels fixture-constant noise without a sleep or a retry.
+
+The same class killed a third measurement before it was taken. Asking a
+ChannelTest whether the W joins of a reconnect share a transport process
+answers TRUE by construction: `Phoenix.Test.ChannelTest` assigns
+`transport_pid: self()`. An instrument that cannot fail earns no green, so that
+question is recorded as unmeasured rather than answered.

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -452,7 +452,7 @@ defmodule GrappaWeb.GrappaChannel do
     {:channel, user_name, network_slug, Identifier.canonical_target(channel, casemapping)}
   end
 
-  defp canonicalize_topic(other, _context), do: other
+  defp canonicalize_topic(other, _), do: other
 
   # The network's CASEMAPPING for a stateless per-channel topic join.
   # `Session.casemapping/2` reads the live Server (`:ascii` when no pid), and
@@ -512,7 +512,7 @@ defmodule GrappaWeb.GrappaChannel do
         {:error, :no_session} -> nil
       end
 
-      # #267 — the per-channel WS seed is the full server-authoritative
+    # #267 — the per-channel WS seed is the full server-authoritative
     # `WindowCounts.snapshot/7` (messages/mentions/events + severity),
     # NOT the former scalar unread_count. cic renders these directly and
     # stops deriving counts client-side. cursor == nil → snapshot counts
@@ -555,11 +555,11 @@ defmodule GrappaWeb.GrappaChannel do
   # here: a client already past the handshake was, by definition, at or
   # above the floor, so it needs the floor only pre-connect (via /api/config
   # + the 426 refusal), not after.
-  defp join_reply({:user, _}, _context) do
+  defp join_reply({:user, _}, _) do
     %{protocol_version: Grappa.Protocol.version()}
   end
 
-  defp join_reply(_, _context), do: %{}
+  defp join_reply(_, _), do: %{}
 
   @impl Phoenix.Channel
   def handle_info({:after_join, {:user, user_name}}, socket) do

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -249,12 +249,33 @@ defmodule GrappaWeb.GrappaChannel do
       # + network and queries that subject's session. A rejected join must not
       # do work on behalf of the user named in the topic — see the authz test
       # in `GrappaWeb.GrappaChannelTest`.
-      parsed = canonicalize_topic(parsed)
+      # #1759 — resolve `(subject, network)` ONCE for the whole join. Four
+      # legs need that same pair, and each used to resolve it from scratch:
+      # `canonicalize_topic/2`, `assign_presence_suppression/4`'s own-nick
+      # carve-out, `join_reply/2`, and the after-join `push_channel_snapshot/2`.
+      # Measured before this change (`GrappaWeb.JoinSeedCostTest`): a live
+      # per-channel join cost 11 queries of which SIX were that one pair,
+      # resolved three times — half the door, and it fires once per window at
+      # a phoenix.js auto-rejoin, which is the instant after a saturation.
+      #
+      # Carried as `{:ok, {subject, network}} | :error` rather than unwrapped,
+      # so every leg keeps the fall-through it already had (`:ascii`, a zero
+      # snapshot, `nil`, `:ok`) instead of a shared one invented here.
+      context = channel_context(parsed)
+      parsed = canonicalize_topic(parsed, context)
 
       # #1769 — the ONLY join param this channel reads. Resolved here so the
       # after-join leg (which swaps the fastlane) and `handle_out/3` (which
       # filters) both read one decided assign rather than re-parsing params.
-      socket = assign_presence_suppression(parsed, params, socket)
+      socket = assign_presence_suppression(parsed, params, context, socket)
+
+      # The after-join leg runs as a separate message, so the pair has to
+      # survive the return. It is a snapshot taken at join time: a user or
+      # network deleted in the microseconds between the two legs is served
+      # from the pre-deletion struct instead of degrading to the `:error`
+      # branch — a race whose loser is a snapshot pushed onto a socket that
+      # is already being torn down, which is why it is accepted and named.
+      socket = assign(socket, :channel_context, context)
 
       # NO manual `Phoenix.PubSub.subscribe/2` on THIS channel's own topic —
       # the framework's fastlane subscription (installed by
@@ -262,7 +283,7 @@ defmodule GrappaWeb.GrappaChannel do
       # moduledoc + BUG 6.
       subscribe_socket_topic(parsed, socket)
       Process.send_after(self(), {:after_join, parsed}, 0)
-      {:ok, join_reply(parsed), socket}
+      {:ok, join_reply(parsed, context), socket}
     else
       :error -> {:error, %{error: "unknown_topic"}}
       {:error, :forbidden} -> {:error, %{error: "forbidden"}}
@@ -284,38 +305,42 @@ defmodule GrappaWeb.GrappaChannel do
   # Presence only ever travels a per-channel topic, so the user- and
   # network-level clauses ignore the param outright rather than carrying a
   # flag that could never fire.
-  @spec assign_presence_suppression(Topic.parsed(), map(), Phoenix.Socket.t()) ::
+  @spec assign_presence_suppression(
+          Topic.parsed(),
+          map(),
+          channel_context(),
           Phoenix.Socket.t()
-  defp assign_presence_suppression({:channel, user_name, network_slug, _}, params, socket)
+        ) :: Phoenix.Socket.t()
+  defp assign_presence_suppression({:channel, _, _, _}, params, context, socket)
        when is_map(params) do
     case params do
       %{"presence" => false} ->
         socket
         |> assign(:presence_suppressed, true)
-        |> assign(:presence_own_nick, own_nick_or_nil(user_name, network_slug))
+        |> assign(:presence_own_nick, own_nick_or_nil(context))
 
       _ ->
         assign(socket, :presence_suppressed, false)
     end
   end
 
-  defp assign_presence_suppression(_, _, socket), do: assign(socket, :presence_suppressed, false)
+  defp assign_presence_suppression(_, _, _, socket),
+    do: assign(socket, :presence_suppressed, false)
 
   # The own nick at join time, or `nil` when there is no live session to ask
   # (a cold socket on a parked network). `nil` never matches a sender, so the
   # carve-out degrades toward DELIVERING presence rather than dropping it —
   # the safe direction, since a dropped own PART strands a dead window while a
   # delivered peer JOIN only costs a frame.
-  @spec own_nick_or_nil(String.t(), String.t()) :: String.t() | nil
-  defp own_nick_or_nil(user_name, network_slug) do
-    with {:ok, subject} <- resolve_subject(user_name),
-         {:ok, %Network{} = network} <- Networks.get_network_by_slug(network_slug),
-         {:ok, nick} <- Session.current_nick(subject, network.id) do
-      nick
-    else
+  @spec own_nick_or_nil(channel_context()) :: String.t() | nil
+  defp own_nick_or_nil({:ok, {subject, %Network{} = network}}) do
+    case Session.current_nick(subject, network.id) do
+      {:ok, nick} -> nick
       _ -> nil
     end
   end
+
+  defp own_nick_or_nil(:error), do: nil
 
   # #1769 — trade this socket's fastlane subscription for a plain one, so its
   # broadcasts arrive as `%Phoenix.Socket.Broadcast{}` structs the channel
@@ -422,28 +447,22 @@ defmodule GrappaWeb.GrappaChannel do
   # byte-identical to the pre-#537 ASCII fold. cic normally joins with the
   # already-folded key it learned from server events (a no-op here); the
   # network-aware fold is the robustness path for a raw user-typed topic.
-  defp canonicalize_topic({:channel, user_name, network_slug, channel}) do
-    casemapping = topic_casemapping(user_name, network_slug)
+  defp canonicalize_topic({:channel, user_name, network_slug, channel}, context) do
+    casemapping = topic_casemapping(context)
     {:channel, user_name, network_slug, Identifier.canonical_target(channel, casemapping)}
   end
 
-  defp canonicalize_topic(other), do: other
+  defp canonicalize_topic(other, _context), do: other
 
-  # Resolve the network's CASEMAPPING for a stateless per-channel topic join.
-  # `resolve_subject/1` yields the session subject; `get_network_by_slug/1`
-  # the network_id; `Session.casemapping/2` reads the live Server (`:ascii`
-  # when no pid). Any unresolvable leg degrades to `:ascii` — the safe,
-  # prod-invariant default. Only ever reached for an ALREADY-authorized
-  # topic, so `user_name` is the socket's own subject label.
-  @spec topic_casemapping(String.t(), String.t()) :: Identifier.casemapping()
-  defp topic_casemapping(user_name, network_slug) do
-    with {:ok, subject} <- resolve_subject(user_name),
-         {:ok, %Network{} = network} <- Networks.get_network_by_slug(network_slug) do
-      Session.casemapping(subject, network.id)
-    else
-      _ -> :ascii
-    end
-  end
+  # The network's CASEMAPPING for a stateless per-channel topic join.
+  # `Session.casemapping/2` reads the live Server (`:ascii` when no pid), and
+  # an unresolvable context degrades to `:ascii` — the safe, prod-invariant
+  # default, unchanged from when this resolved the pair itself (#1759).
+  @spec topic_casemapping(channel_context()) :: Identifier.casemapping()
+  defp topic_casemapping({:ok, {subject, %Network{} = network}}),
+    do: Session.casemapping(subject, network.id)
+
+  defp topic_casemapping(:error), do: :ascii
 
   # CP29 R-3: per-channel topic joins return the current read cursor in
   # the join reply so cic doesn't need a per-window REST round-trip on
@@ -475,56 +494,57 @@ defmodule GrappaWeb.GrappaChannel do
   # A protocol bump updates both specs, and since #1393d that is every
   # wire-shape change rather than a rare one — so this literal is the second
   # place Dialyzer stops a bump that was only done half-way.
-  @spec join_reply(Topic.parsed()) :: %{
+  @spec join_reply(Topic.parsed(), channel_context()) :: %{
           optional(:read_cursor) => integer() | nil,
           optional(:window_counts) => WindowCounts.t(),
           optional(:protocol_version) => 2
         }
-  defp join_reply({:channel, user_name, network_slug, channel}) do
-    with {:ok, subject} <- resolve_subject(user_name),
-         {:ok, %Network{} = network} <- Networks.get_network_by_slug(network_slug) do
-      cursor =
-        case ReadCursor.get(subject, network.id, channel) do
-          %ReadCursor.Cursor{last_read_message_id: id} -> id
-          _ -> nil
-        end
+  defp join_reply({:channel, _, _, channel}, {:ok, {subject, %Network{} = network}}) do
+    cursor =
+      case ReadCursor.get(subject, network.id, channel) do
+        %ReadCursor.Cursor{last_read_message_id: id} -> id
+        _ -> nil
+      end
 
-      own_nick =
-        case Session.current_nick(subject, network.id) do
-          {:ok, nick} -> nick
-          {:error, :no_session} -> nil
-        end
+    own_nick =
+      case Session.current_nick(subject, network.id) do
+        {:ok, nick} -> nick
+        {:error, :no_session} -> nil
+      end
 
       # #267 — the per-channel WS seed is the full server-authoritative
-      # `WindowCounts.snapshot/7` (messages/mentions/events + severity),
-      # NOT the former scalar unread_count. cic renders these directly and
-      # stops deriving counts client-side. cursor == nil → snapshot counts
-      # from row 0 (all unread); cic treats `:read_cursor = nil` as "no
-      # cursor yet". Highlight patterns feed the mention count (SSOT).
-      patterns = UserSettings.get_highlight_patterns(subject)
+    # `WindowCounts.snapshot/7` (messages/mentions/events + severity),
+    # NOT the former scalar unread_count. cic renders these directly and
+    # stops deriving counts client-side. cursor == nil → snapshot counts
+    # from row 0 (all unread); cic treats `:read_cursor = nil` as "no
+    # cursor yet". Highlight patterns feed the mention count (SSOT).
+    patterns = UserSettings.get_highlight_patterns(subject)
 
-      # #505 — the seed must apply the channel's presence filter, or the
-      # faint `events` count includes rows the pane never renders and drops
-      # the moment cic hydrates. Same resolver the history fetch uses
-      # (#458), so the seed and the page agree on which rows exist.
-      hide_presence = Resolver.hidden?(subject, network.slug, network.id, channel)
+    # #505 — the seed must apply the channel's presence filter, or the
+    # faint `events` count includes rows the pane never renders and drops
+    # the moment cic hydrates. Same resolver the history fetch uses
+    # (#458), so the seed and the page agree on which rows exist.
+    hide_presence = Resolver.hidden?(subject, network.slug, network.id, channel)
 
-      counts =
-        WindowCounts.snapshot(
-          subject,
-          network.id,
-          channel,
-          cursor,
-          own_nick,
-          patterns,
-          hide_presence
-        )
+    counts =
+      WindowCounts.snapshot(
+        subject,
+        network.id,
+        channel,
+        cursor,
+        own_nick,
+        patterns,
+        hide_presence
+      )
 
-      %{read_cursor: cursor, window_counts: counts}
-    else
-      _ -> %{read_cursor: nil, window_counts: WindowCounts.zero()}
-    end
+    %{read_cursor: cursor, window_counts: counts}
   end
+
+  # The unresolvable-context fall-through, unchanged in behaviour: it used to
+  # be this clause's own `else`, and #1759 only moved the resolution that
+  # selects it out to the one call in `join/3`.
+  defp join_reply({:channel, _, _, _}, :error),
+    do: %{read_cursor: nil, window_counts: WindowCounts.zero()}
 
   # #447 — the user topic is the FIRST topic cic joins, so its join reply
   # is the "initial WS payload": it carries `protocol_version`, the wire
@@ -535,11 +555,11 @@ defmodule GrappaWeb.GrappaChannel do
   # here: a client already past the handshake was, by definition, at or
   # above the floor, so it needs the floor only pre-connect (via /api/config
   # + the 426 refusal), not after.
-  defp join_reply({:user, _}) do
+  defp join_reply({:user, _}, _context) do
     %{protocol_version: Grappa.Protocol.version()}
   end
 
-  defp join_reply(_), do: %{}
+  defp join_reply(_, _context), do: %{}
 
   @impl Phoenix.Channel
   def handle_info({:after_join, {:user, user_name}}, socket) do
@@ -547,12 +567,12 @@ defmodule GrappaWeb.GrappaChannel do
     {:noreply, socket}
   end
 
-  def handle_info({:after_join, {:channel, user_name, network_slug, channel}}, socket) do
+  def handle_info({:after_join, {:channel, _, _, channel}}, socket) do
     # #1769 — FIRST, before the snapshot's DB + session round-trips: every
     # millisecond spent here is a millisecond of presence still fastlaning
     # past a socket that asked not to see it.
     :ok = drop_fastlane_if_suppressing(socket)
-    push_channel_snapshot(user_name, network_slug, channel, socket)
+    push_channel_snapshot(channel, socket)
     {:noreply, socket}
   end
 
@@ -1589,7 +1609,7 @@ defmodule GrappaWeb.GrappaChannel do
   # Pre-CP22 also pushed `push_all_topics_and_modes/2` (topic + modes
   # for every joined channel) on the user socket. That was legacy
   # backfill from when cic polled REST for those fields. cic now joins
-  # each per-channel topic and `push_channel_snapshot/4` (the
+  # each per-channel topic and `push_channel_snapshot/2` (the
   # `:after_join` clause for `{:channel, ...}`) covers topic + modes +
   # members + window_state for that channel — the user-topic backfill
   # was producing duplicate events that cic dropped as malformed
@@ -1733,16 +1753,17 @@ defmodule GrappaWeb.GrappaChannel do
   # `"visitor:"` prefix and was rescued to `:error`), so visitors who
   # WS-subscribed after the upstream JOIN's NAMES landed never saw the
   # members list — the broadcast had already fired with no subscribers.
-  @spec push_channel_snapshot(String.t(), String.t(), String.t(), Phoenix.Socket.t()) :: :ok
-  defp push_channel_snapshot(user_name, network_slug, channel, socket) do
-    with {:ok, subject} <- resolve_subject(user_name),
-         {:ok, %Network{} = network} <- Networks.get_network_by_slug(network_slug) do
-      push_topic_if_cached(subject, network, channel, socket)
-      push_modes_if_cached(subject, network, channel, socket)
-      push_members_if_seeded(subject, network, channel, socket)
-      push_window_state_if_known(subject, network, channel, socket)
-    else
-      _ -> :ok
+  @spec push_channel_snapshot(String.t(), Phoenix.Socket.t()) :: :ok
+  defp push_channel_snapshot(channel, socket) do
+    case socket.assigns.channel_context do
+      {:ok, {subject, %Network{} = network}} ->
+        push_topic_if_cached(subject, network, channel, socket)
+        push_modes_if_cached(subject, network, channel, socket)
+        push_members_if_seeded(subject, network, channel, socket)
+        push_window_state_if_known(subject, network, channel, socket)
+
+      :error ->
+        :ok
     end
   end
 
@@ -2259,6 +2280,31 @@ defmodule GrappaWeb.GrappaChannel do
   # web/S7) — classifies the label; the user branch then delegates to
   # `safe_get_user/1` so a deleted-row race surfaces as `:error` →
   # `user_not_found` reply.
+  @typedoc """
+  #1759 — the `(subject, network)` pair a per-channel join needs, resolved
+  ONCE in `join/3` and threaded to every leg that used to resolve it again.
+  `:error` for an unresolvable pair (deleted user, missing network) AND for
+  the user- / network-level topics, which have no channel context to resolve
+  — each consumer maps it onto the fall-through it already had.
+  """
+  @type channel_context :: {:ok, {Session.subject(), Network.t()}} | :error
+
+  # The ONE resolution per join. Only a per-channel topic has a pair to
+  # resolve; the user- and network-level clauses of `join_reply/2` and
+  # `assign_presence_suppression/4` ignore the value, so answering `:error`
+  # for them costs nothing and keeps this total.
+  @spec channel_context(Topic.parsed()) :: channel_context()
+  defp channel_context({:channel, user_name, network_slug, _}) do
+    with {:ok, subject} <- resolve_subject(user_name),
+         {:ok, %Network{} = network} <- Networks.get_network_by_slug(network_slug) do
+      {:ok, {subject, network}}
+    else
+      _ -> :error
+    end
+  end
+
+  defp channel_context(_), do: :error
+
   @spec resolve_subject(String.t()) :: {:ok, Session.subject()} | :error
   defp resolve_subject(user_name) do
     case Subject.from_topic_label(user_name) do

--- a/test/grappa_web/channels/join_seed_cost_test.exs
+++ b/test/grappa_web/channels/join_seed_cost_test.exs
@@ -15,13 +15,13 @@ defmodule GrappaWeb.JoinSeedCostTest do
   because a path read in the code says only that it EXISTS — never what it
   costs nor how many times it fires.
 
-  What the measurement finds is NOT what reading it suggested. The badge
-  arithmetic is five of the eleven queries a live join costs; SIX are one
-  `(subject, network)` pair resolved three times over in the same join, by
-  `canonicalize_topic/1`, `join_reply/1` and the after-join
-  `push_channel_snapshot/4` independently. Half the door is identity, not
-  counting. The tally below pins WHICH reads those are, so a later change
-  can be told apart from a change to the arithmetic itself.
+  What the measurement found was NOT what reading it suggested. The badge
+  arithmetic was five of the eleven queries a live join cost; SIX were one
+  `(subject, network)` pair resolved three times over in the same join.
+  #1759 resolves it once (`channel_context/1`) and threads it, taking a join
+  from 11 to 7. The tally below pins WHICH reads moved, so the win cannot be
+  confused with a change to the arithmetic itself — and the law is unchanged:
+  `11·W + 1` became `7·W + 1`, and W full snapshots are still W.
 
   ## Why the storm is the unit, not one join
 
@@ -139,10 +139,11 @@ defmodule GrappaWeb.JoinSeedCostTest do
       # deterministic; the sequence is not, and pinning the sequence would
       # have shipped a flake.
       #
-      #   users/networks ×3  — ONE (subject, network) pair, resolved from
-      #                        scratch by `canonicalize_topic/1`, by
-      #                        `join_reply/1`, and by the after-join
-      #                        `push_channel_snapshot/4`. Half the door.
+      #   users/networks ×1  — the (subject, network) pair, resolved ONCE by
+      #                        `channel_context/1` and threaded. Measured at
+      #                        ×3 before #1759, when `canonicalize_topic`,
+      #                        `join_reply` and `push_channel_snapshot` each
+      #                        resolved it — half the door.
       #   read_cursors       — the cursor the snapshot counts from
       #   user_settings ×2   — highlight patterns, then the #505 presence
       #                        prefs. The lever #1768 named and left alone,
@@ -152,15 +153,15 @@ defmodule GrappaWeb.JoinSeedCostTest do
       #                        NOT part of the door: it does not scale with W
       #                        and drops out of `per_join_tally/3`.
       assert Enum.frequencies(sources) == %{
-               "users" => 3,
-               "networks" => 3,
+               "users" => 1,
+               "networks" => 1,
                "read_cursors" => 1,
                "user_settings" => 2,
                "messages" => 2,
                "network_credentials" => 1
              }
 
-      assert length(sources) == 12
+      assert length(sources) == 8
     end
 
     test "the LIVE storm is linear in W — measured at three W, never extrapolated" do
@@ -185,18 +186,28 @@ defmodule GrappaWeb.JoinSeedCostTest do
         totals: #{one}, #{four}, #{eight}
       """
 
-      # WHICH reads scale, named — not a bare total. Six of the eleven are
-      # the identity pair, resolved three times over; five are the badge
-      # arithmetic this door exists to serve.
+      # WHICH reads scale, named — not a bare total.
+      #
+      # THE DISPLACEMENT. Measured on this same harness at the same three W:
+      #
+      #   before: users 3, networks 3, read_cursors 1, user_settings 2,
+      #           messages 2  =  11 a join   (totals 12, 45, 89)
+      #   after:  users 1, networks 1, read_cursors 1, user_settings 2,
+      #           messages 2  =   7 a join   (totals  8, 29, 57)
+      #
+      # Only the two reads the de-duplication touches moved, and by exactly
+      # the two redundant resolutions removed. The arithmetic did not move,
+      # which is the control: had the total dropped while `messages` changed
+      # too, something other than the cause under test would have acted.
       assert high == %{
-               "users" => 3,
-               "networks" => 3,
+               "users" => 1,
+               "networks" => 1,
                "read_cursors" => 1,
                "user_settings" => 2,
                "messages" => 2
              }
 
-      assert Enum.sum(Map.values(high)) == 11
+      assert Enum.sum(Map.values(high)) == 7
     end
 
     test "routing the join door through bulk_snapshot/4 does NOT fit — the 20% named" do

--- a/test/grappa_web/channels/join_seed_cost_test.exs
+++ b/test/grappa_web/channels/join_seed_cost_test.exs
@@ -1,0 +1,435 @@
+defmodule GrappaWeb.JoinSeedCostTest do
+  @moduledoc """
+  #1759 — what the per-channel JOIN door costs the database, measured.
+
+  The badge math has three doors. Two are bounded and one is not:
+
+    * `/me` cold load → `WindowCounts.bulk_snapshot/4`, pinned at a CONSTANT
+      2 queries for any window count (`WindowCountsTest`, #396);
+    * the per-row push → `WindowCounts.Pusher.Coalescer`, O(distinct windows
+      touched) per `window_ms` (#1768);
+    * the per-channel join reply → `WindowCounts.snapshot/7` in full, once
+      per join, behind neither of those.
+
+  This file measures the third, which #1759 found unmeasured. It exists
+  because a path read in the code says only that it EXISTS — never what it
+  costs nor how many times it fires.
+
+  What the measurement finds is NOT what reading it suggested. The badge
+  arithmetic is five of the eleven queries a live join costs; SIX are one
+  `(subject, network)` pair resolved three times over in the same join, by
+  `canonicalize_topic/1`, `join_reply/1` and the after-join
+  `push_channel_snapshot/4` independently. Half the door is identity, not
+  counting. The tally below pins WHICH reads those are, so a later change
+  can be told apart from a change to the arithmetic itself.
+
+  ## Why the storm is the unit, not one join
+
+  `cicchetto/src/lib/socket.ts` documents phoenix.js's behaviour on its
+  `joinChannel` wrapper: `onJoinOk` *"fires on EVERY successful join — both
+  the initial join and every auto-rejoin after a socket disconnect"*. A
+  socket drop therefore re-joins every topic the client held, so the door
+  fires W times at once for a W-window account — and it fires in the
+  instant AFTER a saturation, which is when the pool has least to give.
+
+  So the measurement moves W and reads the query count off it
+  (displacement), rather than timing anything: a timing would measure this
+  host's disk, while a count measures the fan-out that is the defect.
+
+  ## The counter does NOT filter on `self()`
+
+  `GrappaWeb.BootCostTest` filters its telemetry handler to the test pid,
+  which is exact there because a controller runs inside the request that
+  the test process drives. **Copied verbatim it would report zero here**:
+  `Phoenix.ChannelTest.subscribe_and_join/3` runs `join/3` in the spawned
+  CHANNEL process, so every query this file is about is emitted off the
+  test pid. A filtered count would read `0` and be indistinguishable from
+  "this door is already free", which is the exact false green the file
+  exists to prevent. `async: false` is what buys the unfiltered count back:
+  no sibling test is running to contaminate the mailbox.
+
+  ## The storm arm measures a FLOOR, and says so
+
+  With no live `Session.Server` there is no own nick, and
+  `WindowCounts.count_mentions/6`'s `nil` clause then answers `0` without
+  touching the database — so the cheap arm below is one `messages` read
+  short of what a real socket pays. `a live session pays MORE` is the arm
+  that closes that gap: it stands up the IRC fake so `Session.current_nick/2`
+  answers, and pins the difference.
+
+  The storm is then measured on that SAME live fixture at more than one W,
+  never extrapolated from one: W windows on one network is ONE session, not
+  W of them, so there was never a reason to measure the shape on the cheap
+  bench and multiply. The cheap arm is kept only as the control that isolates
+  which read the nil nick hides.
+  """
+  use GrappaWeb.ChannelCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{IRCServer, Networks, Repo, ScrollbackHelpers, Session}
+  alias Grappa.Networks.{Credentials, Servers}
+  alias Grappa.PubSub.Topic
+  alias GrappaWeb.UserSocket
+
+  @query_event [:grappa, :repo, :query]
+
+  describe "the per-channel join door" do
+    test "the counter sees the join at all — the instrument's own control" do
+      %{user_name: user_name, slug: slug, channels: [chan | _]} = account(1)
+
+      {_, sources} = measure(fn -> join_topic(user_name, slug, chan) end)
+
+      # The known-answer control, and the reason it is a test rather than a
+      # comment: with the `self()` filter this file deliberately does NOT
+      # use, every arm here would read zero and pass as "already free". So
+      # the instrument is proven to see the door before any number it
+      # produces is believed.
+      assert "read_cursors" in sources and "messages" in sources, """
+      the join did not reach `join_reply/2` — the counter is filtered, or the
+      topic was rejected before the seed. A zero is an instrument fault, not
+      a free door. See the moduledoc on the `self()` filter.
+        sources: #{inspect(sources)}
+      """
+    end
+
+    test "the storm cost MOVES with the number of windows — displacement, not correlation" do
+      one = storm_cost(1)
+      eight = storm_cost(8)
+
+      # The claim under test is that the join door is the unbounded one. If
+      # it were bounded like `/me`, these two would be equal.
+      assert eight.total > one.total, """
+      the join door did NOT scale with the window count, which contradicts
+      reading `join_reply/2` as an uncoalesced per-window snapshot.
+        W=1: #{one.total} #{inspect(one.sources)}
+        W=8: #{eight.total} #{inspect(eight.sources)}
+      """
+
+      per_join = div(eight.total - one.total, 7)
+
+      assert eight.total == one.total * 8, """
+      DISPLACEMENT — the storm is linear in W at #{per_join} queries a join.
+        W=1: #{one.total}
+        W=8: #{eight.total}  (expected #{one.total * 8})
+        per-join delta: #{per_join}
+      Sources at W=1: #{inspect(one.sources)}
+      """
+    end
+
+    test "a live session pays MORE — the cheap fixture's nil own_nick hides one read" do
+      {irc, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      %{user: user, network: network, channels: [chan]} = account_with_session(port, 1)
+      welcome(irc)
+
+      {_, sources} = measure(fn -> join_topic(user.name, network.slug, chan) end)
+
+      # The mention tail is the read the nil-nick clause skips. Its presence
+      # here is what makes the cheap arm's number a FLOOR rather than the
+      # cost: a real socket always has a nick.
+      assert Enum.count(sources, &(&1 == "messages")) == 2, """
+      expected the mention tail AND the split aggregate with a live nick.
+        sources: #{inspect(sources)}
+      """
+
+      # Pinned as a TALLY, not an ordered list: the counter is unfiltered and
+      # the session process emits into the same window, so arrival ORDER is a
+      # race (measured — `network_credentials` moved from position 9 to
+      # position 2 between two runs of this same test). The multiset is
+      # deterministic; the sequence is not, and pinning the sequence would
+      # have shipped a flake.
+      #
+      #   users/networks ×3  — ONE (subject, network) pair, resolved from
+      #                        scratch by `canonicalize_topic/1`, by
+      #                        `join_reply/1`, and by the after-join
+      #                        `push_channel_snapshot/4`. Half the door.
+      #   read_cursors       — the cursor the snapshot counts from
+      #   user_settings ×2   — highlight patterns, then the #505 presence
+      #                        prefs. The lever #1768 named and left alone,
+      #                        deliberately still here.
+      #   messages ×2        — the split aggregate and the mention tail
+      #   network_credentials— the fixture's own `mark_registered/1` on 001,
+      #                        NOT part of the door: it does not scale with W
+      #                        and drops out of `per_join_tally/3`.
+      assert Enum.frequencies(sources) == %{
+               "users" => 3,
+               "networks" => 3,
+               "read_cursors" => 1,
+               "user_settings" => 2,
+               "messages" => 2,
+               "network_credentials" => 1
+             }
+
+      assert length(sources) == 12
+    end
+
+    test "the LIVE storm is linear in W — measured at three W, never extrapolated" do
+      # Displacement on the fixture that pays the real per-join cost. Three
+      # points, because two can be joined by any line and the claim is
+      # linearity through the origin — that the door fires once per window
+      # with no amortization between firings.
+      {one, _} = w1 = live_storm(1)
+      {four, _} = w4 = live_storm(4)
+      {eight, _} = w8 = live_storm(8)
+
+      # Three points, because two can be joined by any line. The claim is a
+      # CONSTANT marginal cost — the door fires once per window with nothing
+      # amortized between firings — so the two independent deltas must agree.
+      low = per_join_tally(w4, w1, 3)
+      high = per_join_tally(w8, w4, 4)
+
+      assert low == high, """
+      the marginal cost of a join is not constant across W.
+        W=1→4: #{inspect(low)}
+        W=4→8: #{inspect(high)}
+        totals: #{one}, #{four}, #{eight}
+      """
+
+      # WHICH reads scale, named — not a bare total. Six of the eleven are
+      # the identity pair, resolved three times over; five are the badge
+      # arithmetic this door exists to serve.
+      assert high == %{
+               "users" => 3,
+               "networks" => 3,
+               "read_cursors" => 1,
+               "user_settings" => 2,
+               "messages" => 2
+             }
+
+      assert Enum.sum(Map.values(high)) == 11
+    end
+
+    test "routing the join door through bulk_snapshot/4 does NOT fit — the 20% named" do
+      # The first hypothesis, tested rather than argued: `/me` does this same
+      # arithmetic for this same subject at a constant 2, so route the join
+      # door there. The measurement below is why it is declined.
+      #
+      # `bulk_snapshot/4` amortizes ACROSS a subject's windows WITHIN ONE
+      # CALL. The join door is W separate calls of ONE window each, so there
+      # is nothing to amortize inside any of them — and each call does the
+      # WHOLE account's arithmetic to keep one window's answer.
+      %{subject: subject} = account(8)
+
+      {answered, per_call} =
+        measure(fn -> Grappa.WindowCounts.bulk_snapshot(subject, %{}, [], %{}) end)
+
+      windows = answered |> Map.values() |> Enum.flat_map(&Map.keys/1)
+
+      # Constant in queries, yes — but it answered for ALL EIGHT windows,
+      # and a join needs one. There is no arity that asks it for one: the
+      # whole-subject shape IS the primitive. Eight joins routed here would
+      # each compute eight windows and discard seven.
+      assert length(windows) == 8, """
+      expected the whole-subject envelope; got #{inspect(windows)}
+      """
+
+      assert length(per_call) == 2, "bulk cost #{length(per_call)}: #{inspect(per_call)}"
+    end
+
+    test "the SAME account through the /me door costs 2, whatever W is" do
+      # The positive control, and the reason the join number is a defect
+      # rather than the intrinsic price of the arithmetic: the identical
+      # per-window math for the identical subject is already available at a
+      # constant two queries. Any per-join figure above that is the gap.
+      %{subject: subject_one} = account(1)
+      %{subject: subject_eight} = account(8)
+
+      {_, one} = measure(fn -> Grappa.WindowCounts.bulk_snapshot(subject_one, %{}, [], %{}) end)
+      {_, eight} = measure(fn -> Grappa.WindowCounts.bulk_snapshot(subject_eight, %{}, [], %{}) end)
+
+      assert length(one) == 2, "W=1 bulk cost #{length(one)}: #{inspect(one)}"
+      assert length(eight) == 2, "W=8 bulk cost #{length(eight)}: #{inspect(eight)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Harness
+  # ---------------------------------------------------------------------------
+
+  # Joins every one of the account's channel topics, the way a phoenix.js
+  # auto-rejoin does after a socket drop, and returns the total query count
+  # plus the sources of the FIRST join (so a regression names the read).
+  defp storm_cost(w) do
+    %{user_name: user_name, slug: slug, channels: channels} = account(w)
+
+    {_, sources} =
+      measure(fn ->
+        for chan <- channels, do: join_topic(user_name, slug, chan)
+      end)
+
+    %{total: length(sources), sources: Enum.take(sources, 12)}
+  end
+
+  defp join_topic(user_name, slug, chan) do
+    {:ok, _, socket} =
+      user_name
+      |> build_socket()
+      |> subscribe_and_join(Topic.channel(user_name, slug, chan), %{})
+
+    socket
+  end
+
+  # `join_reply/1` resolves the subject from the user NAME, not from this
+  # assign, so the generated subject here only has to satisfy the authz
+  # check — the same shape `GrappaChannelPresenceParamsTest` uses.
+  defp build_socket(user_name) do
+    socket(UserSocket, "user_socket:#{user_name}", %{
+      user_name: user_name,
+      current_subject: {:user, Ecto.UUID.generate()},
+      current_session_id: Ecto.UUID.generate(),
+      socket_ref: Ecto.UUID.generate()
+    })
+  end
+
+  # A subject on ONE network holding `w` channel windows, each with an
+  # anchor row, a read cursor on it, and one unread row after it — so the
+  # snapshot has real arithmetic to do rather than short-circuiting on an
+  # empty window.
+  defp account(w) do
+    uniq = System.unique_integer([:positive])
+    user_name = "join-cost-#{uniq}"
+    user = user_fixture(name: user_name)
+    subject = {:user, user.id}
+
+    {:ok, network} = Networks.find_or_create_network(%{slug: "join-cost-#{uniq}"})
+
+    channels =
+      for i <- 1..w do
+        chan = "#jc#{i}"
+        {:ok, anchor} = row(user, network, chan, 1, "anchor")
+        {:ok, _} = row(user, network, chan, 2, "unread")
+        {:ok, _} = Grappa.ReadCursor.set(subject, network.id, chan, anchor.id)
+        chan
+      end
+
+    %{user_name: user_name, subject: subject, slug: network.slug, channels: channels}
+  end
+
+  # A user + network with a LIVE `Session.Server` against the IRC fake, so
+  # `Session.current_nick/2` answers and the mention tail is actually read.
+  # Mirrors `GrappaWeb.GrappaChannelTest`'s session fixture, including its
+  # `on_exit` teardown — without it the fake's shutdown drives a `:transient`
+  # respawn that leaves an orphan in `SessionRegistry`.
+  defp account_with_session(port, w) do
+    uniq = System.unique_integer([:positive])
+    user = user_fixture(name: "join-cost-live-#{uniq}")
+    subject = {:user, user.id}
+
+    {:ok, network} = Networks.find_or_create_network(%{slug: "join-cost-live-#{uniq}"})
+    {:ok, _} = Servers.add_server(network, %{host: "127.0.0.1", port: port, tls: false})
+
+    channels = for i <- 1..w, do: "#jc#{i}"
+
+    {:ok, credential} =
+      Credentials.bind_credential(user, network, %{
+        nick: "grappa-jc",
+        auth_method: :none,
+        autojoin_channels: channels
+      })
+
+    {:ok, plan} = credential |> Repo.preload(:network) |> Networks.SessionPlan.resolve()
+    {:ok, _} = Session.start_session(subject, network.id, plan)
+
+    on_exit(fn -> Session.stop_session(subject, network.id) end)
+
+    for chan <- channels do
+      {:ok, anchor} = row(user, network, chan, 1, "anchor")
+      {:ok, _} = row(user, network, chan, 2, "unread")
+      {:ok, _} = Grappa.ReadCursor.set(subject, network.id, chan, anchor.id)
+    end
+
+    %{user: user, network: network, channels: channels}
+  end
+
+  # Registers the fake so `Session.current_nick/2` answers — without the 001
+  # the session is still connecting and the nick is `{:error, :no_session}`,
+  # which is exactly the degraded shape the cheap bench measures.
+  defp welcome(irc) do
+    :ok = IRCServer.await_handshake(irc, 1_000)
+    IRCServer.feed(irc, ":irc.test.org 001 grappa-jc :Welcome\r\n")
+  end
+
+  # The live storm: one session, W channel topics re-joined the way a
+  # phoenix.js auto-rejoin does. Returns `{total, tally}`.
+  #
+  # ## Why the caller must compare two W and never read one
+  #
+  # The counter is unfiltered (see the moduledoc), so it also catches the
+  # SESSION process's own reads — `Networks.mark_registered/1` fires on the
+  # 001 this fixture feeds, and whether that write lands inside or outside
+  # the measured window is a race. Measured: it shifted `network_credentials`
+  # from position 9 to position 2 between two runs of the same test, and it
+  # is why the total is `11·W + 1` rather than `12·W`.
+  #
+  # A DELTA between two W cancels any such fixture-constant noise exactly,
+  # and a tally is immune to the arrival ORDER that the cross-process race
+  # scrambles. So both robustness problems are solved by the same move, and
+  # neither is papered over with a retry or a sleep.
+  defp live_storm(w) do
+    {irc, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+    %{user: user, network: network, channels: channels} = account_with_session(port, w)
+    welcome(irc)
+
+    {_, sources} =
+      measure(fn ->
+        for chan <- channels, do: join_topic(user.name, network.slug, chan)
+      end)
+
+    {length(sources), Enum.frequencies(sources)}
+  end
+
+  # The per-join cost, isolated: what `hi - lo` joins added, divided by how
+  # many they were. Any read that does NOT scale with W cancels out and is
+  # absent from the result — which is the point, and how the fixture's own
+  # registration write disappears without being special-cased.
+  defp per_join_tally({_, hi_tally}, {_, lo_tally}, joins) do
+    hi_tally
+    |> Map.merge(lo_tally, fn _source, hi, lo -> hi - lo end)
+    |> Enum.reject(fn {_source, n} -> n == 0 end)
+    |> Map.new(fn {source, n} -> {source, div(n, joins)} end)
+  end
+
+  defp row(user, network, chan, st, body) do
+    ScrollbackHelpers.insert(%{
+      user_id: user.id,
+      network_id: network.id,
+      channel: chan,
+      server_time: 1_700_000_000_000 + st,
+      kind: :privmsg,
+      sender: "bob",
+      body: body
+    })
+  end
+
+  # Counts `[:grappa, :repo, :query]` emitted by ANY process while `fun`
+  # runs. Unfiltered on purpose — see the moduledoc.
+  defp measure(fun) do
+    test_pid = self()
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+
+    :ok = :telemetry.attach(handler_id, @query_event, &__MODULE__.forward_query/4, {test_pid, ref})
+
+    try do
+      result = fun.()
+      {result, drain(ref, [])}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  @doc false
+  @spec forward_query([atom()], map(), map(), {pid(), reference()}) :: :ok
+  def forward_query(_, _, metadata, {test_pid, ref}) do
+    send(test_pid, {ref, Map.get(metadata, :source)})
+    :ok
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, source} -> drain(ref, [source | acc])
+    after
+      20 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/grappa_web/channels/join_seed_cost_test.exs
+++ b/test/grappa_web/channels/join_seed_cost_test.exs
@@ -395,8 +395,8 @@ defmodule GrappaWeb.JoinSeedCostTest do
   # registration write disappears without being special-cased.
   defp per_join_tally({_, hi_tally}, {_, lo_tally}, joins) do
     hi_tally
-    |> Map.merge(lo_tally, fn _source, hi, lo -> hi - lo end)
-    |> Enum.reject(fn {_source, n} -> n == 0 end)
+    |> Map.merge(lo_tally, fn _, hi, lo -> hi - lo end)
+    |> Enum.reject(fn {_, n} -> n == 0 end)
     |> Map.new(fn {source, n} -> {source, div(n, joins)} end)
   end
 


### PR DESCRIPTION
## What this is, stated first: a MITIGATION. #1759 does not close with it.

This addresses only the "who fills the queue" half of #1759. It moves a
**constant** and leaves the **law** where it was. The fork that would change
the law is written up as a comment on the issue and needs a ruling — it is not
taken here.

It also does not touch the "what closes a socket" half, which stays where the
2026-08-25 correction left it.

---

## The fact that reframes the half

`Grappa.WindowCounts.Pusher.Coalescer` — the #1768 fix for exactly the badge
fan-out this issue measured — **has never run in production**:

```
$ git cat-file -e v1.3.1:lib/grappa/window_counts/pusher/coalescer.ex
fatal: path '...coalescer.ex' exists on disk, but not in 'v1.3.1'
```

`1.3.1` is the release the jail ran in **both** incidents, and #1768 landed
2026-08-25 — the same day as the 00:15 recurrence, written in response to its
frame census. The principal cure for this half is merged and undeployed, the
same shape as #1715 on the other half. **That is a deploy decision, not a code
one, and this PR does not substitute for it.**

## The third door

The badge arithmetic has three doors; two were bounded and one was not.

| door | cost | bounded by |
|---|---|---|
| `/me` cold load | 2 queries, constant in window count | `bulk_snapshot/4` (#396) |
| per-row push | O(distinct windows) per 250 ms | `Coalescer` (#1768) |
| **per-channel join reply** | **a full `snapshot/7`, per join** | **nothing** |

`join_reply/1` ran the whole per-window snapshot, and `cicchetto/src/lib/socket.ts`
records that phoenix.js re-joins **every** held topic after a socket drop — so
the door fires once per window, all at once, in the instant *after* a
saturation, when the pool has least to give.

## What the measurement found, which is not what reading it suggested

New bench (`GrappaWeb.JoinSeedCostTest`) counting `[:grappa, :repo, :query]`
around real channel joins against a live session: **a join cost 11 queries and
only five were arithmetic.** Six were one `(subject, network)` pair resolved
**three times** in the same join — `canonicalize_topic/1`, `join_reply/1` and
the after-join `push_channel_snapshot/4` each resolved it from scratch. Half
the door was identity, not counting.

`channel_context/1` resolves it once in `join/3` (after `authorize/2`, never
before — a rejected join must still not work on the topic's behalf) and threads
it to all four legs. The fourth is `assign_presence_suppression/4`'s own-nick
carve-out, which only fires on `presence: false` and so never appeared in the
measurement; leaving it would have hidden the same defect behind a flag.

Carried as `{:ok, {subject, network}} | :error`, so every leg keeps the
fall-through it already had — `:ascii`, a zero snapshot, `nil`, `:ok` — rather
than a shared one invented here.

## 🔴 The displacement: the constant moved, the law did not

Measured on the live fixture at **three** W, before and after — not
extrapolated from one:

| W | before | after |
|---|---|---|
| 1 | 12 | 8 |
| 4 | 45 | 29 |
| 8 | 89 | 57 |

`11·W + 1` → `7·W + 1`. The `+1` is the fixture's own `mark_registered/1` on
the 001 and drops out of the per-join delta.

**W full snapshots are still W full snapshots.** The reconnect loop that
re-feeds itself is still O(W), 1.57× slower to arrive. Verified across two
independent deltas (W=1→4 and W=4→8) which agree, and **only the two reads the
de-duplication touches moved** — the arithmetic did not, which is the control.

## Why `bulk_snapshot/4` is not the fix — mechanism, not analogy

`/me`'s O(1) comes from `ReadCursor.bulk_unread_split/3` asking **every window
in one grouped statement**; the GROUP BY buys the property. A join reply is a
single-window question in its own WS frame and its own channel process —
**there is no second window in scope to group with.** Measured: at W=8 the
primitive answers for all eight at a cost of 2, and no arity asks it for one.
Routing each join there would cut badge reads 4 → 2 while making every call
compute the whole account and discard all but one window: O(W²) of row work
across the storm. That granularity mismatch is the domain boundary.

The socket does not rescue it either, and this one is settled by the API
contract rather than by measurement: phoenix.js does issue all W rejoins in one
synchronous loop and they do enter one transport process, but `handle_in/4`
takes one frame and must return **that frame's** reply, so two joins are
sequential calls and never a shared scope. Holding W−1 replies would require
knowing W, which the client never announces.

---

## What is NOT established — read this before treating anything above as a cause

- **The join storm is not shown to have happened** in either incident. No
  per-channel breakdown exists, and at `00:15:24.941` the handler switched
  `:async → :drop`, so the verdict that closed the reporter's socket may never
  have reached disk. No inference is built on that absence.
- **A second plausible amplifier is READ and NOT MEASURED:**
  `Grappa.TaskSupervisor` is started with no `max_children`
  (`application.ex:369`), so the coalescer's flush fan-out is bounded by
  O(windows) — a bound unrelated to `pool_size: 10`. Deliberately out of scope
  here; recorded so it is not lost.
- **The distribution of the incident's 412 frames across windows** remains
  unmeasured (#1768's own caveat stands).
- **Whether a reconnect's joins are observable together at the socket was NOT
  measured.** A `Phoenix.ChannelTest` answers TRUE by construction —
  `Phoenix.Test.ChannelTest` assigns `transport_pid: self()` — and an
  instrument that cannot fail earns no green.
- The `user_settings` row read twice per join is the lever #1768 named and
  deliberately left. Still there, still deliberately.
- **Accepted race, named in the code:** the after-join leg now uses the pair
  resolved at join time, so a user deleted in the microseconds between the two
  legs is served from the pre-deletion struct instead of degrading to `:error`.
  The loser is a snapshot pushed onto a socket already being torn down.

## Two instrument faults caught before they shipped a number

`BootCostTest`'s telemetry handler filters on `self()`. Copied here it reports
**zero**, because `Phoenix.ChannelTest` runs `join/3` in the spawned channel
process — indistinguishable from "this door is already free". The first arm is
a known-answer control proving the instrument sees the door.

Source **order** is not deterministic: the session process emits into the same
window and `network_credentials` moved from position 9 to position 2 between
two runs of one test. The pin is a **tally**, and the per-join figure is a
**delta between two W**, which cancels fixture-constant noise with no sleep and
no retry.

## Deploy shape

`lib/` + `test/` + `docs/` only. No migration, no wire-shape change, no
`protocol_version` bump. **HOT.** (Declared by me; the diff is worth a second
look.)

## Gates

Rebased onto `origin/main` via `scripts/union-rebase.sh` — `+120 -0`,
contribution intact, boundary shape verified on the real file;
`design-notes-gate.sh` green, marker `<!-- entry #1759a -->` unique against the
base tip (`#1759` bare was already taken by the 2026-08-24 entry).

A pre-rebase `check.sh` reached `8 doctests, 62 properties, 6919 tests, 0
failures` with wire types in sync — but the tree changed under the rebase, so
that evidence does not carry and the **full** `check.sh` is re-running on this
head. Its result goes in a comment; this PR is not claimed green until it is
posted.
