### PR TITLE
perf(#1626)!: the archive listing seeks per target, and row_count leaves the wire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,20 @@ Key invariants — break only with deliberate cause + DESIGN_NOTES entry:
   client MUST ignore verbs/fields it does not recognise
   (unknown-is-never-fatal, BOTH directions — an unknown client verb
   earns a non-fatal error frame and the socket stays open); existing
-  fields are NEVER repurposed or removed. **🔴 But `protocol_version`
+  fields are NEVER repurposed. **🔴 "…or removed" fell on 2026-08-26
+  (vjt's ruling, #1626): removal is no longer NEVER, it is ONLY ON A
+  RULING.** One field has been taken back — `row_count` on the archive
+  entry (protocol v8) — because emitting it forced
+  `Scrollback.list_archive/3` to visit the whole `(subject, network)`
+  partition, and no amount of query work buys the complexity class back
+  while an exact per-group count is in the shape. The bar that case
+  sets, and it is deliberately high: the field must be the thing
+  standing between the server and a property it cannot otherwise have;
+  the break must be MEASURED on the real client (cic's generated
+  `wireSchema` rejects an object missing a required key, so an old
+  bundle throws every archive response away) rather than argued; and it
+  takes a ruling, not a judgement call inside the slice. Everything
+  short of that is still additive-only. **`protocol_version`
   BUMPS ON EVERY WIRE-SHAPE CHANGE, ADDITIVE INCLUDED (vjt's ruling,
   2026-08-21, #1393d — reversing this file's own former "may appear at
   ANY time WITHOUT a version bump").** Two reasons, and the second is

--- a/cicchetto/src/__tests__/ArchiveModal.test.tsx
+++ b/cicchetto/src/__tests__/ArchiveModal.test.tsx
@@ -227,9 +227,7 @@ describe("ArchiveModal (#473 grouped)", () => {
   it("clicking a channel entry selects it (from its group's slug) + closes", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
-      slug === "freenode"
-        ? [{ target: "#bofh", kind: "channel", last_activity: 200 }]
-        : [],
+      slug === "freenode" ? [{ target: "#bofh", kind: "channel", last_activity: 200 }] : [],
     );
     render(() => <ArchiveModal />);
     fireEvent.click(screen.getByText("#bofh"));
@@ -244,9 +242,7 @@ describe("ArchiveModal (#473 grouped)", () => {
   it("clicking a query entry selects it (from its group's slug) + closes", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
-      slug === "libera"
-        ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }]
-        : [],
+      slug === "libera" ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }] : [],
     );
     render(() => <ArchiveModal />);
     fireEvent.click(screen.getByText("vjt-peer"));
@@ -268,9 +264,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     // casing need not match the window the peer is already open under.
     mockOpenQueryNicks.mockReturnValue(["VJT-Peer"]);
     mockEntries.mockImplementation((slug) =>
-      slug === "libera"
-        ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }]
-        : [],
+      slug === "libera" ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }] : [],
     );
     render(() => <ArchiveModal />);
     fireEvent.click(screen.getByText("vjt-peer"));
@@ -287,9 +281,7 @@ describe("ArchiveModal (#473 grouped)", () => {
   it("renders the unread msg badge for an archived DM holding unread (#532 B)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
-      slug === "libera"
-        ? [{ target: "DebugServ", kind: "query", last_activity: 100 }]
-        : [],
+      slug === "libera" ? [{ target: "DebugServ", kind: "query", last_activity: 100 }] : [],
     );
     // Seed is keyed by the server's CANONICAL nick (DM keys fold, #532 D);
     // the row must fold the DISPLAY-cased "DebugServ" to hit "libera debugserv".
@@ -304,9 +296,7 @@ describe("ArchiveModal (#473 grouped)", () => {
   it("renders the event badge for an archived channel holding unread (#532 B)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
-      slug === "freenode"
-        ? [{ target: "#bofh", kind: "channel", last_activity: 200 }]
-        : [],
+      slug === "freenode" ? [{ target: "#bofh", kind: "channel", last_activity: 200 }] : [],
     );
     mockEventsUnread.mockReturnValue({ "freenode #bofh": 2 });
 
@@ -319,9 +309,7 @@ describe("ArchiveModal (#473 grouped)", () => {
   it("renders NO unread cluster for an archived window read to the tail (#532 B)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
-      slug === "libera"
-        ? [{ target: "quietpeer", kind: "query", last_activity: 100 }]
-        : [],
+      slug === "libera" ? [{ target: "quietpeer", kind: "query", last_activity: 100 }] : [],
     );
     // No seed entry for this window → nothing pending.
     render(() => <ArchiveModal />);
@@ -332,9 +320,7 @@ describe("ArchiveModal (#473 grouped)", () => {
   it("first click on × delete arms; second calls deleteArchiveEntry with token + slug + target", async () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
-      slug === "freenode"
-        ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }]
-        : [],
+      slug === "freenode" ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }] : [],
     );
     render(() => <ArchiveModal />);
     const deleteBtn = screen.getByTestId("archive-modal-delete-freenode-vjt-peer");

--- a/cicchetto/src/__tests__/ArchiveModal.test.tsx
+++ b/cicchetto/src/__tests__/ArchiveModal.test.tsx
@@ -83,7 +83,6 @@ const {
       target: string;
       kind: "channel" | "query";
       last_activity: number;
-      row_count: number;
     }>
   >(() => []),
   mockArchivedBySlug: vi.fn<() => Record<string, unknown[]>>(() => ({})),
@@ -169,8 +168,8 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockEntries.mockImplementation((slug) =>
       slug === "freenode"
         ? [
-            { target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 },
-            { target: "#bofh", kind: "channel", last_activity: 200, row_count: 8 },
+            { target: "vjt-peer", kind: "query", last_activity: 100 },
+            { target: "#bofh", kind: "channel", last_activity: 200 },
           ]
         : [],
     );
@@ -229,7 +228,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
       slug === "freenode"
-        ? [{ target: "#bofh", kind: "channel", last_activity: 200, row_count: 8 }]
+        ? [{ target: "#bofh", kind: "channel", last_activity: 200 }]
         : [],
     );
     render(() => <ArchiveModal />);
@@ -246,7 +245,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
       slug === "libera"
-        ? [{ target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 }]
+        ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }]
         : [],
     );
     render(() => <ArchiveModal />);
@@ -270,7 +269,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockOpenQueryNicks.mockReturnValue(["VJT-Peer"]);
     mockEntries.mockImplementation((slug) =>
       slug === "libera"
-        ? [{ target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 }]
+        ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }]
         : [],
     );
     render(() => <ArchiveModal />);
@@ -289,7 +288,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
       slug === "libera"
-        ? [{ target: "DebugServ", kind: "query", last_activity: 100, row_count: 4 }]
+        ? [{ target: "DebugServ", kind: "query", last_activity: 100 }]
         : [],
     );
     // Seed is keyed by the server's CANONICAL nick (DM keys fold, #532 D);
@@ -306,7 +305,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
       slug === "freenode"
-        ? [{ target: "#bofh", kind: "channel", last_activity: 200, row_count: 8 }]
+        ? [{ target: "#bofh", kind: "channel", last_activity: 200 }]
         : [],
     );
     mockEventsUnread.mockReturnValue({ "freenode #bofh": 2 });
@@ -321,7 +320,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
       slug === "libera"
-        ? [{ target: "quietpeer", kind: "query", last_activity: 100, row_count: 4 }]
+        ? [{ target: "quietpeer", kind: "query", last_activity: 100 }]
         : [],
     );
     // No seed entry for this window → nothing pending.
@@ -334,7 +333,7 @@ describe("ArchiveModal (#473 grouped)", () => {
     mockOpen.mockReturnValue(true);
     mockEntries.mockImplementation((slug) =>
       slug === "freenode"
-        ? [{ target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 }]
+        ? [{ target: "vjt-peer", kind: "query", last_activity: 100 }]
         : [],
     );
     render(() => <ArchiveModal />);

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -1348,7 +1348,6 @@ const ARCHIVE_ROW = {
   target: "#italia",
   kind: "channel",
   last_activity: 1_700_000_000,
-  row_count: 942,
 };
 
 const USER_ROW = {
@@ -1422,9 +1421,27 @@ describe("#1400 slice 1 — the nine class-A doors reject an incomplete row", ()
     );
   });
 
-  it("listArchive rejects an entry missing `row_count`", async () => {
-    stubFetch(200, { archive: [without(ARCHIVE_ROW, "row_count")] });
+  it("listArchive rejects an entry missing `last_activity`", async () => {
+    stubFetch(200, { archive: [without(ARCHIVE_ROW, "last_activity")] });
     await expect(api.listArchive("t", "azzurra")).rejects.toBeInstanceOf(WireShapeError);
+  });
+
+  // #1626 — this case used to be `rejects an entry missing row_count`, and
+  // that requirement is exactly what broke: cic never rendered the value, it
+  // only insisted on it, so a v8 server dropping the field would have had
+  // every archive response thrown away wholesale. Its replacement asserts
+  // the OTHER direction, which is the one that has to keep holding: a v7
+  // server still sends `row_count`, and an undeclared key is dropped rather
+  // than rejected (additive-only, #447). This is what lets this bundle keep
+  // talking to a server predating the removal, and it is why
+  // `MIN_SERVER_PROTOCOL_VERSION` did not have to move.
+  it("listArchive accepts an entry that still carries `row_count` and drops it", async () => {
+    stubFetch(200, { archive: [{ ...ARCHIVE_ROW, row_count: 942 }] });
+
+    const entries = await api.listArchive("t", "azzurra");
+
+    expect(entries).toEqual([ARCHIVE_ROW]);
+    expect(entries[0]).not.toHaveProperty("row_count");
   });
 
   it("adminListUsers rejects a user missing `is_admin`", async () => {

--- a/cicchetto/src/__tests__/archive.test.ts
+++ b/cicchetto/src/__tests__/archive.test.ts
@@ -44,16 +44,16 @@ describe("archive.loadArchive", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "vjt-peer", kind: "query", last_activity: 300, row_count: 8 },
-      { target: "#sniffo", kind: "channel", last_activity: 200, row_count: 576 },
+      { target: "vjt-peer", kind: "query", last_activity: 300 },
+      { target: "#sniffo", kind: "channel", last_activity: 200 },
     ]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
 
     expect(archive.archivedBySlug().freenode).toEqual([
-      { target: "vjt-peer", kind: "query", last_activity: 300, row_count: 8 },
-      { target: "#sniffo", kind: "channel", last_activity: 200, row_count: 576 },
+      { target: "vjt-peer", kind: "query", last_activity: 300 },
+      { target: "#sniffo", kind: "channel", last_activity: 200 },
     ]);
   });
 
@@ -68,18 +68,18 @@ describe("archive.loadArchive", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive)
-      .mockResolvedValueOnce([{ target: "#a", kind: "channel", last_activity: 100, row_count: 1 }])
-      .mockResolvedValueOnce([{ target: "#b", kind: "channel", last_activity: 200, row_count: 2 }]);
+      .mockResolvedValueOnce([{ target: "#a", kind: "channel", last_activity: 100 }])
+      .mockResolvedValueOnce([{ target: "#b", kind: "channel", last_activity: 200 }]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
     await archive.loadArchive("libera");
 
     expect(archive.archivedBySlug().freenode).toEqual([
-      { target: "#a", kind: "channel", last_activity: 100, row_count: 1 },
+      { target: "#a", kind: "channel", last_activity: 100 },
     ]);
     expect(archive.archivedBySlug().libera).toEqual([
-      { target: "#b", kind: "channel", last_activity: 200, row_count: 2 },
+      { target: "#b", kind: "channel", last_activity: 200 },
     ]);
   });
 
@@ -87,15 +87,15 @@ describe("archive.loadArchive", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive)
-      .mockResolvedValueOnce([{ target: "#a", kind: "channel", last_activity: 100, row_count: 1 }])
-      .mockResolvedValueOnce([{ target: "#a", kind: "channel", last_activity: 999, row_count: 5 }]);
+      .mockResolvedValueOnce([{ target: "#a", kind: "channel", last_activity: 100 }])
+      .mockResolvedValueOnce([{ target: "#a", kind: "channel", last_activity: 999 }]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
     await archive.loadArchive("freenode");
 
     expect(archive.archivedBySlug().freenode).toEqual([
-      { target: "#a", kind: "channel", last_activity: 999, row_count: 5 },
+      { target: "#a", kind: "channel", last_activity: 999 },
     ]);
   });
 
@@ -125,17 +125,17 @@ describe("archive.loadArchive", () => {
     const fresh = archive.loadArchive("freenode"); // seq 2
 
     // Fresh (call #2) resolves first → store reflects the post-PART set.
-    resolveFresh([{ target: "#bofh", kind: "channel", last_activity: 999, row_count: 5 }]);
+    resolveFresh([{ target: "#bofh", kind: "channel", last_activity: 999 }]);
     await fresh;
     expect(archive.archivedBySlug().freenode).toEqual([
-      { target: "#bofh", kind: "channel", last_activity: 999, row_count: 5 },
+      { target: "#bofh", kind: "channel", last_activity: 999 },
     ]);
 
     // Stale (call #1) resolves LAST → its result is dropped, store unchanged.
-    resolveStale([{ target: "#old", kind: "channel", last_activity: 100, row_count: 1 }]);
+    resolveStale([{ target: "#old", kind: "channel", last_activity: 100 }]);
     await stale;
     expect(archive.archivedBySlug().freenode).toEqual([
-      { target: "#bofh", kind: "channel", last_activity: 999, row_count: 5 },
+      { target: "#bofh", kind: "channel", last_activity: 999 },
     ]);
   });
 });
@@ -145,7 +145,7 @@ describe("archive.clearArchive — identity-scoped cleanup", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "#a", kind: "channel", last_activity: 100, row_count: 1 },
+      { target: "#a", kind: "channel", last_activity: 100 },
     ]);
 
     const archive = await import("../lib/archive");
@@ -170,16 +170,16 @@ describe("archive.visibleArchiveForNetwork", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "#bofh", kind: "channel", last_activity: 200, row_count: 8 },
-      { target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 },
+      { target: "#bofh", kind: "channel", last_activity: 200 },
+      { target: "vjt-peer", kind: "query", last_activity: 100 },
     ]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
 
     expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
-      { target: "#bofh", kind: "channel", last_activity: 200, row_count: 8 },
-      { target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 },
+      { target: "#bofh", kind: "channel", last_activity: 200 },
+      { target: "vjt-peer", kind: "query", last_activity: 100 },
     ]);
   });
 
@@ -198,15 +198,15 @@ describe("archive.visibleArchiveForNetwork", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "#sniffo", kind: "channel", last_activity: 200, row_count: 576 },
-      { target: "#bofh", kind: "channel", last_activity: 100, row_count: 8 },
+      { target: "#sniffo", kind: "channel", last_activity: 200 },
+      { target: "#bofh", kind: "channel", last_activity: 100 },
     ]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
 
     expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
-      { target: "#bofh", kind: "channel", last_activity: 100, row_count: 8 },
+      { target: "#bofh", kind: "channel", last_activity: 100 },
     ]);
   });
 
@@ -225,15 +225,15 @@ describe("archive.visibleArchiveForNetwork", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "vjt-peer", kind: "query", last_activity: 200, row_count: 8 },
-      { target: "alice-peer", kind: "query", last_activity: 100, row_count: 4 },
+      { target: "vjt-peer", kind: "query", last_activity: 200 },
+      { target: "alice-peer", kind: "query", last_activity: 100 },
     ]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
 
     expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
-      { target: "alice-peer", kind: "query", last_activity: 100, row_count: 4 },
+      { target: "alice-peer", kind: "query", last_activity: 100 },
     ]);
   });
 
@@ -257,8 +257,8 @@ describe("archive.visibleArchiveForNetwork", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "DebugServ", kind: "query", last_activity: 200, row_count: 3 },
-      { target: "alice-peer", kind: "query", last_activity: 100, row_count: 4 },
+      { target: "DebugServ", kind: "query", last_activity: 200 },
+      { target: "alice-peer", kind: "query", last_activity: 100 },
     ]);
 
     const archive = await import("../lib/archive");
@@ -267,7 +267,7 @@ describe("archive.visibleArchiveForNetwork", () => {
     // `DebugServ` folds to the active `debugserv` → suppressed; the
     // unrelated peer survives.
     expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
-      { target: "alice-peer", kind: "query", last_activity: 100, row_count: 4 },
+      { target: "alice-peer", kind: "query", last_activity: 100 },
     ]);
   });
 
@@ -293,16 +293,16 @@ describe("archive.visibleArchiveForNetwork", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "#it-opers", kind: "channel", last_activity: 300, row_count: 1 },
-      { target: "#kicked-from", kind: "channel", last_activity: 200, row_count: 5 },
-      { target: "#old-chan", kind: "channel", last_activity: 100, row_count: 12 },
+      { target: "#it-opers", kind: "channel", last_activity: 300 },
+      { target: "#kicked-from", kind: "channel", last_activity: 200 },
+      { target: "#old-chan", kind: "channel", last_activity: 100 },
     ]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
 
     expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
-      { target: "#old-chan", kind: "channel", last_activity: 100, row_count: 12 },
+      { target: "#old-chan", kind: "channel", last_activity: 100 },
     ]);
   });
 
@@ -335,7 +335,7 @@ describe("archive.visibleArchiveForNetwork", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "#bofh", kind: "channel", last_activity: 200, row_count: 203 },
+      { target: "#bofh", kind: "channel", last_activity: 200 },
     ]);
 
     const archive = await import("../lib/archive");
@@ -344,7 +344,7 @@ describe("archive.visibleArchiveForNetwork", () => {
     // The server placed #bofh in the archive (it IS parted) and it is not
     // in channelsBySlug — the stale `:joined` must NOT suppress it.
     expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
-      { target: "#bofh", kind: "channel", last_activity: 200, row_count: 203 },
+      { target: "#bofh", kind: "channel", last_activity: 200 },
     ]);
   });
 
@@ -364,14 +364,14 @@ describe("archive.visibleArchiveForNetwork", () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
     vi.mocked(api.listArchive).mockResolvedValue([
-      { target: "#it-opers", kind: "channel", last_activity: 100, row_count: 1 },
+      { target: "#it-opers", kind: "channel", last_activity: 100 },
     ]);
 
     const archive = await import("../lib/archive");
     await archive.loadArchive("freenode");
 
     expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
-      { target: "#it-opers", kind: "channel", last_activity: 100, row_count: 1 },
+      { target: "#it-opers", kind: "channel", last_activity: 100 },
     ]);
   });
 

--- a/cicchetto/src/__tests__/mobileWindowSurfaces.test.tsx
+++ b/cicchetto/src/__tests__/mobileWindowSurfaces.test.tsx
@@ -106,7 +106,7 @@ async function mobileSurfacesFor(state: string): Promise<{
   localStorage.setItem("grappa-token", "tok");
   const api = await import("../lib/api");
   vi.mocked(api.listArchive).mockResolvedValue([
-    { target: "#gated", kind: "channel", last_activity: 300, row_count: 42 },
+    { target: "#gated", kind: "channel", last_activity: 300 },
   ]);
 
   const archive = await import("../lib/archive");

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2606,7 +2606,11 @@ export async function deleteInvite(
 }
 
 // Mirror of `GrappaWeb.ArchiveJSON.index/1` (CP15 B4) — wire shape:
-//   { "archive": [{"target", "kind", "last_activity", "row_count"}] }
+//   { "archive": [{"target", "kind", "last_activity"}] }
+// `row_count` was removed by #1626 (protocol v8): an exact per-target count
+// had to visit the whole partition, which is what kept the listing's cost
+// bound to the size of the account. cic never rendered it — only its schema
+// insisted on it, which is what would have broken.
 // Server-side `Scrollback.list_archive/3` already sorts by
 // `last_activity` DESC and excludes the active keyset (joined channels +
 // open query windows) + the `$server` pseudo-channel. The unwrap below

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -862,7 +862,7 @@ export const S_ScrollbackWireArchivePurgedPayload = {
 
 // Grappa.Scrollback.Wire.archive_wire_entry/0
 export const S_ScrollbackWireArchiveWireEntry = {
-  o: { target: "s", kind: { e: ["channel", "query"] }, last_activity: "i", row_count: "i" },
+  o: { target: "s", kind: { e: ["channel", "query"] }, last_activity: "i" },
 } as const;
 
 // Grappa.Scrollback.Wire.archive_wire_index/0

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -905,7 +905,6 @@ export type ScrollbackWireArchiveWireEntry = {
   target: string;
   kind: "channel" | "query";
   last_activity: number;
-  row_count: number;
 };
 
 export type ScrollbackWireArchiveWireIndex = {

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -98,11 +98,13 @@ There are **two** numbers, and they mean different things:
   client MUST ignore fields and events it does not recognise. The server,
   symmetrically, replies to an unknown client verb with a non-fatal error
   frame and keeps the socket open.
-- **Existing fields are never repurposed or removed.** A field means the
-  same thing forever.
+- **Existing fields are never repurposed.** A field means the same thing
+  forever.
+- **Removal is not "never" — it is "only on a ruling" (2026-08-26).**
+  See §2b. Design your client as if a field could go, i.e. do not make a
+  hard requirement of one you do not actually read.
 
-That half is unchanged, and it is what keeps an OLD client working
-against a NEW server.
+That half is what keeps an OLD client working against a NEW server.
 
 ### 2a. `protocol_version` moves on EVERY wire-shape change (2026-08-21)
 
@@ -142,6 +144,39 @@ is: `protocol_version` has moved several times under this rule while
 `min_protocol_version` has never left `1`. (The current pair is not
 written here on purpose — see the note under `GET /api/config`; the
 moving number is stale the moment it is typed, and it has been, twice.)
+
+### 2b. One field has been REMOVED, and what that costs you
+
+⚠️ `row_count` is gone from the archive entry
+(`GET /networks/:slug/archive`) as of protocol **v8**. It is the first
+and so far only field this wire has taken back.
+
+**Why it was allowed.** An exact per-target row count has to visit that
+target's rows, which is the whole `(subject, network)` partition, so
+while the field was emitted the listing's cost was bound to the size of
+the account rather than to its number of targets. The field was the only
+thing standing between the server and a listing that seeks once per
+target. Nothing else about the entry changed: `target`, `kind` and
+`last_activity` mean what they always meant.
+
+**The bar for a future removal**, so you can judge how likely another is:
+the field must be what blocks a property the server cannot otherwise
+have; the break must be measured against a real client rather than
+argued; and it takes an explicit ruling. Ordinary tidying does not
+qualify — nothing has ever been removed for being unused.
+
+**What it means for your client, concretely.** Validate *permissively*:
+tolerate an absent field you do not read, and never make a hard
+requirement of one you only pass through. The reference client got this
+wrong in exactly the way to learn from — it rendered `target` and `kind`
+only, never `row_count`, yet its generated schema listed the field as
+required, so a v8 server's response failed validation wholesale and its
+archive pane went blank. It never used the value it insisted on.
+
+`min_protocol_version` did **not** move for this, deliberately: it gates
+the whole socket, and this break is one listing. A pre-v8 client is
+still served everything else. The signal you get is `protocol_version`,
+in `GET /api/config` and in the user-topic join reply.
 
 ### 2b. What this means for you, as a client author
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41506,3 +41506,183 @@ Before cutting a log on a time boundary, measure that the boundary is
 disjoint — order the file claims is not order the file has. A frozen file
 does not inherit the live file's merge driver; state the refusal where the
 attribute would go.
+<!-- entry #1626 -->
+
+---
+
+## 2026-08-26 — #1626: the archive listing seeks per target, and the field that stood in the way
+
+`Scrollback.list_archive/3` answered the per-network Archive section by
+grouping every row of the `(subject, network)` partition. #1626 filed it as a
+complexity problem rather than a slow query: the cost of listing ~180 windows
+was bound to how much the account had ever said, so it grew forever while the
+answer did not. It now answers from a LOOSE INDEX SCAN — a recursive CTE that
+hops group boundary to group boundary, one seek per TARGET — in ONE statement,
+and the cost tracks the target count instead.
+
+The price, ruled on by vjt rather than decided in the slice: `row_count` is
+removed from the archive entry, and the wire is at `protocol_version` 8. An
+exact per-group count has to VISIT the group's rows, and the union of the
+groups is the partition, so while the count was in the shape no amount of
+query work could buy the class back.
+
+### One number cannot tell a law from a factor
+
+That is the trap #1626 was filed about and the one #1759 hit again, so the
+harness (`test/bench_1626.exs`, committed) measures two axes and refuses to
+print anything unless every control passes. Corpus is prod-shaped — 178
+targets, 30 channels on a heavy tail plus DM peers in CP14 B3 form, casing
+variants included — built through the app's own pool on a scratch SQLite file
+OUTSIDE the sandbox, warm median of 5.
+
+**Axis A — partition varies 10k → 1.3M, target count HELD at 178:**
+
+| rows | pre-#1626 | `list_archive/3` | ruler `count(*)` |
+|---|---|---|---|
+| 10,000 | 2.61 ms | 0.63 ms | 0.33 ms |
+| 100,000 | 29.87 ms | 0.60 ms | 2.56 ms |
+| 650,000 | 395.93 ms | 0.56 ms | 17.81 ms |
+| 1,300,000 | 1101.76 ms | 0.79 ms | 54.83 ms |
+
+Partition ×130 → pre-#1626 **×422.78**, ruler **×164.65**, `list_archive/3`
+**×1.25**.
+
+**Axis B — targets 20 → 1000, partition HELD at exactly 100,000 rows:**
+
+| targets | pre-#1626 | `list_archive/3` |
+|---|---|---|
+| 20 | 19.48 ms | 0.18 ms |
+| 180 | 32.64 ms | 0.62 ms |
+| 1000 | 38.55 ms | 2.48 ms |
+
+Targets ×50 → pre-#1626 **×1.98**, `list_archive/3` **×14.09**.
+
+Axis B is not decoration. Flatness on axis A alone is equally consistent with
+"the harness cannot see size", so the claim is a DISPLACEMENT and needs the
+other side: the cost left the partition axis and appeared on the target axis.
+Two independent arms that DO grow on axis A in the same run — a `count(*)`
+ruler and the pre-#1626 shape itself — are what make the flat line a
+measurement rather than a blind instrument, and both are gate controls.
+
+**The strongest single piece of evidence is the noise.** Across two runs of
+the same harness the new arm read 0.53 / 0.58 / 0.61 / 0.68 and then 0.63 /
+0.60 / 0.56 / 0.79 — non-monotone in the partition, in both directions. Its
+variation across a 130× size range is smaller than its variation between runs.
+A quantity that cannot be ordered by the axis is not a function of it.
+
+### What the plans say, and one thing nobody expected
+
+The plan is taken off the SQL the function EMITS, captured from
+`[:grappa, :repo, :query]` telemetry — never a local rebuild, per #1372. All
+three seeks are covering:
+
+    SEARCH messages USING COVERING INDEX messages_archive_user_idx (user_id=? AND network_id=?)
+    SEARCH m USING COVERING INDEX messages_archive_user_idx (user_id=? AND network_id=? AND <expr>>?)
+    SEARCH m USING COVERING INDEX messages_archive_user_idx (user_id=? AND network_id=? AND <expr>=?)
+
+The BEFORE plan does **not** use that index at all — it walks
+`messages_user_id_network_id_dm_coalesce_fold_id_kind_index`, the fold
+covering index added by `20260816013504`. So #1484's reading that
+`messages_archive_{user,visitor}_idx` (`20260522073826`) were dead weight worth
+dropping for INSERT cost was TRUE of the old query, and it is this scan that
+makes them load-bearing. Dropping them now costs a migration to put back, and
+the degradation would be SILENT: SQLite declines an expression index the moment
+the query's spelling of `COALESCE(dm_with, channel)` drifts by one character,
+and the seek becomes a scan without failing. That is why the SQL is a literal
+constant in `scrollback.ex` and not Ecto-generated, and why a control asserts
+the index name appears in the emitted plan.
+
+Second surprise: the old shape was SUPER-linear, ×422 over a ×130 partition,
+not the ~0.16 ms per 1,000 rows linear model #1626 fitted at smaller sizes —
+the GROUP BY's temp structure, growing faster than the scan feeding it.
+
+### Honest limits on these numbers
+
+The absolute constants do NOT transfer and are not claimed to. This host reads
+395.93 ms at the 650k anchor where #1626 reported 101–104 ms — roughly 4×, on
+different hardware and against a planner that had a fold covering index #1626
+may not have had. w2 measured the same law on a third host with different
+constants again. What reproduces is the shape: one arm proportional to the
+partition, one arm indifferent to it.
+
+Not measured, and not to be inferred: prod (m42) — every number is one docker
+host; the VISITOR arm's timing — the SQL is the `visitor_id` mirror and the
+plan test covers it structurally, but no visitor stopwatch was run; cold-cache
+cost — two warm-ups precede every median; the end-to-end HTTP path — this is
+the context function; and whether 1000 targets is a realistic ceiling — 178 is
+the prod-shaped anchor, 1000 is a stress point, and prod's real target
+distribution was not sampled.
+
+### The fork not taken
+
+w2 built the same listing WITH the count retained (`w2-1626` @ `9d2fb782`) and
+measured ~10× on the constant, its own entry recording that "the count still
+visits the partition, so the LAW is unchanged". That branch was NOT rebased or
+cherry-picked: once the ruling chose the property, merging a branch that
+implements the other fork would have been a green with nothing behind it, and
+a vacuous green is worse than a red. Reused from it BY HAND: the loose-scan
+SQL, taken VERBATIM — every `COALESCE(dm_with, channel)` must match the indexed
+expression character for character — and the display-casing rule, rewritten as
+`Enum.max_by/2`. Declined: its `Repo.deferred_transaction/1`, which existed to
+hold two statements under one snapshot. Without the count there is one
+statement, and an API with no caller is a liability.
+
+`Enum.max_by/2` additionally FIXES a tie the old shape left to SQLite: equal
+`server_time` across two spellings of one fold resolved arbitrarily under the
+bare-column rule and now resolves to the lexicographically smallest, because
+the scan yields ascending and `max_by/2` keeps the first maximum. The oracle
+comparison in the bench is only sound because a control proves the corpus
+contains no such tie.
+
+### `protocol_version` 7 → 8; `min_protocol_version` stays at 1
+
+The bump is not discretionary (the #1393d rule). The floor NOT moving is, so
+it is argued from three measurements rather than left implicit.
+
+1. **The break is real and runs old-client → new-server.** cic's generated
+   `wireSchema` declares `row_count` REQUIRED and `wireValidate.walkObject`
+   REJECTs an object missing a required key — `api.test.ts` carried a case
+   named exactly *"listArchive rejects an entry missing row_count"*.
+2. **The blast radius is ONE listing and it is contained.** `loadArchive`
+   catches, leaving already-rendered entries in place, and the renderer reads
+   an absent slug as "not loaded yet". The socket is untouched.
+3. **The floor is not endpoint-scoped.** Raising it to 8 would 426 the WHOLE
+   socket for every client declaring 1..7, including clients that never call
+   `/archive`. Matching a session-wide gate to an endpoint-scoped break is a
+   category error.
+
+cic's `MIN_SERVER_PROTOCOL_VERSION` stays at 2 for a measured reason too:
+`walkObject` DROPS undeclared keys rather than rejecting them (additive-only,
+#447), so a v8 bundle still talks to a v7 server that is still sending the
+field. The `api.test.ts` case above is replaced by one pinning that tolerance,
+because the tolerance is the property holding the floor where it is.
+Observed and deliberately NOT changed: cic's `CLIENT_PROTOCOL_VERSION` is 2
+while the server is at 8 — it has never followed the bumps. Moving it here
+would be inertia, not a decision.
+
+### The doctrine that fell
+
+"Existing fields are NEVER removed" is now false, and pretending otherwise in
+`CLAUDE.md`, `Grappa.Protocol`'s moduledoc and `docs/CLIENT_PROTOCOL.md` would
+have left three documents lying. Removal is not "never", it is "only on a
+ruling", and the bar this case sets is deliberately high: the field must be the
+thing standing between the server and a property it cannot otherwise have; the
+break must be MEASURED on the real client rather than argued; and it takes a
+ruling, not a judgement call inside a slice. Everything short of that is still
+additive-only. The bar is written down because the danger is not this removal
+— it is the next reader taking it as licence to tidy fields away.
+
+The REV-B/H18 plan test was deleted rather than adapted: it built the archive
+SQL by hand and EXPLAINed its own copy, so from the moment production stopped
+emitting that shape it would have pinned a query nobody runs. Its replacement
+reads the plan off `capture_one_query/1` — the singular, not its plural twin,
+because answering in ONE statement is part of the property being pinned.
+
+**Apply:** a claim about a complexity class needs two axes and two arms that
+move — the axis you say the cost left, the axis you say it moved to, and a
+known-linear ruler plus the old shape both growing in the same run. Gate the
+output on the controls so a broken instrument prints nothing rather than a
+plausible table. When a wire field is what blocks a property, the question is
+not "can this be removed" but "who ruled, and what did the real client do when
+it went" — and a version floor answers a session-wide question, so never raise
+it to describe one endpoint.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41539,36 +41539,46 @@ OUTSIDE the sandbox, warm median of 5.
 
 | rows | pre-#1626 | `list_archive/3` | ruler `count(*)` |
 |---|---|---|---|
-| 10,000 | 2.61 ms | 0.63 ms | 0.33 ms |
-| 100,000 | 29.87 ms | 0.60 ms | 2.56 ms |
-| 650,000 | 395.93 ms | 0.56 ms | 17.81 ms |
-| 1,300,000 | 1101.76 ms | 0.79 ms | 54.83 ms |
+| 10,000 | 2.52 ms | 0.60 ms | 0.29 ms |
+| 100,000 | 37.18 ms | 0.60 ms | 2.87 ms |
+| 650,000 | 428.93 ms | 0.66 ms | 19.45 ms |
+| 1,300,000 | 1076.59 ms | 0.77 ms | 56.20 ms |
 
-Partition ×130 → pre-#1626 **×422.78**, ruler **×164.65**, `list_archive/3`
-**×1.25**.
+Partition ×130 → pre-#1626 **×427.22**, ruler **×190.51**, `list_archive/3`
+**×1.28**.
 
 **Axis B — targets 20 → 1000, partition HELD at exactly 100,000 rows:**
 
 | targets | pre-#1626 | `list_archive/3` |
 |---|---|---|
-| 20 | 19.48 ms | 0.18 ms |
-| 180 | 32.64 ms | 0.62 ms |
-| 1000 | 38.55 ms | 2.48 ms |
+| 20 | 22.03 ms | 0.16 ms |
+| 180 | 31.13 ms | 0.62 ms |
+| 1000 | 41.59 ms | 2.69 ms |
 
-Targets ×50 → pre-#1626 **×1.98**, `list_archive/3` **×14.09**.
+Targets ×50 → pre-#1626 **×1.89**, `list_archive/3` **×16.64**.
 
 Axis B is not decoration. Flatness on axis A alone is equally consistent with
 "the harness cannot see size", so the claim is a DISPLACEMENT and needs the
 other side: the cost left the partition axis and appeared on the target axis.
 Two independent arms that DO grow on axis A in the same run — a `count(*)`
-ruler and the pre-#1626 shape itself — are what make the flat line a
-measurement rather than a blind instrument, and both are gate controls.
+ruler and the pre-#1626 shape itself — are what make the third arm's near-
+stillness a measurement rather than a blind instrument, and both are gate
+controls.
 
-**The strongest single piece of evidence is the noise.** Across two runs of
-the same harness the new arm read 0.53 / 0.58 / 0.61 / 0.68 and then 0.63 /
-0.60 / 0.56 / 0.79 — non-monotone in the partition, in both directions. Its
-variation across a 130× size range is smaller than its variation between runs.
-A quantity that cannot be ordered by the axis is not a function of it.
+**The residual rise is real, and it is not the old law.** Three runs read the
+new arm on axis A as 0.53 / 0.58 / 0.61 / 0.68, then 0.63 / 0.60 / 0.56 / 0.79,
+then 0.60 / 0.60 / 0.66 / 0.77 — one of the three non-monotone, and the spread
+BETWEEN runs at a single point (0.56–0.66 at 650k) about as wide as the total
+rise ACROSS the axis (~0.17 ms). So "flat" would be an overstatement and is not
+the claim: ×1.28 over a ×130 partition is a rise, next to ×427 for the old
+shape on the same instrument in the same run.
+
+The likely reading, and it is INFERRED rather than measured: B-tree depth grows
+with the table, so 178 constant-count seeks each cost slightly more at 1.3M
+than at 10k. That would make the surviving dependence logarithmic where it used
+to be super-linear — a change of class, which is what was asked for, and NOT
+independence, which was not. Nobody measured the depth; the sentence stands as
+a reading of the shape, not as a result.
 
 ### What the plans say, and one thing nobody expected
 
@@ -41592,18 +41602,18 @@ and the seek becomes a scan without failing. That is why the SQL is a literal
 constant in `scrollback.ex` and not Ecto-generated, and why a control asserts
 the index name appears in the emitted plan.
 
-Second surprise: the old shape was SUPER-linear, ×422 over a ×130 partition,
+Second surprise: the old shape was SUPER-linear, ×427 over a ×130 partition,
 not the ~0.16 ms per 1,000 rows linear model #1626 fitted at smaller sizes —
 the GROUP BY's temp structure, growing faster than the scan feeding it.
 
 ### Honest limits on these numbers
 
 The absolute constants do NOT transfer and are not claimed to. This host reads
-395.93 ms at the 650k anchor where #1626 reported 101–104 ms — roughly 4×, on
+428.93 ms at the 650k anchor where #1626 reported 101–104 ms — roughly 4×, on
 different hardware and against a planner that had a fold covering index #1626
 may not have had. w2 measured the same law on a third host with different
 constants again. What reproduces is the shape: one arm proportional to the
-partition, one arm indifferent to it.
+partition, one arm barely moved by it.
 
 Not measured, and not to be inferred: prod (m42) — every number is one docker
 host; the VISITOR arm's timing — the SQL is the `visitor_id` mirror and the

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -27,8 +27,18 @@ defmodule Grappa.Protocol do
   time — a client MUST ignore verbs and fields it does not recognise
   (unknown-is-never-fatal, in BOTH directions: an unknown client verb earns
   a non-fatal error frame and the socket stays open), and existing fields
-  are NEVER repurposed or removed. That half of #447 is unchanged and is
-  what keeps an OLD client working against a NEW server.
+  are NEVER repurposed. That half of #447 is what keeps an OLD client
+  working against a NEW server.
+
+  **Removal is no longer "never", it is "only on a ruling" (v8, #1626).**
+  One field has been taken back: `row_count` on the archive entry, because
+  emitting it forced the listing to visit the whole partition and no
+  amount of query work could buy the complexity class back while it
+  stayed. The bar that removal has to clear, set by that case: the field
+  must be the thing standing between the server and a property it cannot
+  otherwise have, the break has to be measured on the real client rather
+  than argued, and it takes a ruling — not a judgement call inside the
+  slice. Everything short of that is still additive-only.
 
   What changed on 2026-08-21 is the other half. This moduledoc used to say
   such a change lands *"WITHOUT a version bump"*, and it was true right up
@@ -144,10 +154,55 @@ defmodule Grappa.Protocol do
   # is INBOUND — which no widening of the outbound codegen digest would ever
   # reach. Filed as #1787. The bump here is the RULE, not the gate.
   #
-  # @min_protocol_version is NOT the same axis and stays at 1: it rises only
-  # when old clients can no longer be SERVED, and every client that spoke v1
-  # is still served — v1 clients tolerate what v7 clients require.
-  @protocol_version 7
+  # v8 (#1626) is the FIRST version that takes a field BACK:
+  # `row_count` is gone from `Grappa.Scrollback.Wire.archive_wire_entry`.
+  # Every bump before this one was additive, and the moduledoc's promise
+  # that "existing fields are NEVER repurposed or removed" is what makes
+  # this one different in kind rather than in degree. It is taken on a
+  # ruling (vjt, 2026-08-26) with the price named up front: an exact
+  # per-group count has to VISIT the group's rows, so while the field was
+  # emitted the archive listing stayed bound to the size of the account
+  # rather than to its number of targets. Keeping it meant keeping a
+  # complexity class; the field is what was paid.
+  #
+  # @min_protocol_version STILL stays at 1, and here that is an argument
+  # rather than the usual "additive strands nobody". Three measurements,
+  # in the order that decides it:
+  #
+  #   1. The break is REAL and runs old-client → new-server, which is
+  #      exactly this floor's axis: cic's generated schema declares
+  #      `row_count` REQUIRED (`wireSchema.ts`), and `wireValidate`'s
+  #      `walkObject` REJECTs an object missing a required key. An old
+  #      bundle therefore throws away every archive response a v8 server
+  #      sends. Measured, not inferred — `api.test.ts` carries a case
+  #      named "listArchive rejects an entry missing `row_count`".
+  #   2. Its blast radius is ONE listing, and it is contained: cic's
+  #      `loadArchive` catches and leaves the previously rendered entries
+  #      in place, and the renderer reads an absent slug key as "not
+  #      loaded yet". Nothing else in the client degrades, the socket is
+  #      untouched, no other endpoint changes shape.
+  #   3. This floor is not endpoint-scoped. Raising it to 8 refuses the
+  #      WHOLE SOCKET with 426 to every client declaring 1..7, including
+  #      the ones that never call `/archive` at all — converting a quiet
+  #      one-modal failure into a total refusal for clients the change
+  #      does not touch. Matching a session-wide gate to an
+  #      endpoint-scoped break is a category error, and it is the reason
+  #      this stays put.
+  #
+  # So: "can no longer be SERVED" is read as the client, not as one of its
+  # calls. A v1..v7 client is still served; one of its listings is not.
+  # The honest signal for that is `version/0` moving, which a client can
+  # see in `GET /api/config` and in the user-topic join reply, and which
+  # cic already compares against its own floor.
+  #
+  # The mirror obligation on the cic side does NOT fire either, and that
+  # was measured too: cic's `MIN_SERVER_PROTOCOL_VERSION` rises when the
+  # bundle starts REQUIRING a newer field, and this change makes it
+  # require one FEWER. A v8 bundle still talks to a v7 server, because
+  # `walkObject` drops undeclared keys rather than rejecting them
+  # (additive-only, #447) — so the `row_count` an old server still sends
+  # is simply ignored. It stays at 2.
+  @protocol_version 8
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -158,7 +213,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 7
+  @spec version() :: 8
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1024,12 +1024,17 @@ defmodule Grappa.Scrollback do
   otherwise `:query`. Single source of truth for the predicate;
   every consumer (this fn + `dm_eligible?/1` + `nick_shaped?/1`)
   derives from it.
+
+  `row_count` was part of this shape until #1626 and is NOT coming
+  back: an exact per-group count has to visit the group's rows, which
+  is the whole partition, so keeping it kept the listing's cost bound
+  to the account rather than to its target count. Removing it is the
+  cure, and it is a wire change — see `Grappa.Protocol` v8.
   """
   @type archive_entry :: %{
           target: String.t(),
           kind: :channel | :query,
-          last_activity: integer(),
-          row_count: non_neg_integer()
+          last_activity: integer()
         }
 
   @doc """
@@ -1047,12 +1052,17 @@ defmodule Grappa.Scrollback do
   instead of splitting. `dm_with` is stored case-PRESERVED (nick display
   rule, `message.ex`); the fold applies at the MATCH, exactly as the DM
   read (`channel_or_dm_where/3`) and delete (`delete_for_dm/3`) do. The
-  selected `target` is a bare `COALESCE` (not the folded key) so the
-  display casing is preserved; SQLite picks it from the row carrying the
-  single `max(server_time)` aggregate (documented bare-column rule), i.e.
-  the most-recent spelling. Channels fold idempotently (already canonical
-  at write) so this is a no-op for them; non-ASCII case variants stay
-  distinct (ASCII-only fold, matching the ircd).
+  returned `target` is a bare `COALESCE` (not the folded key) so the
+  display casing is preserved: of the spellings that share a fold, the
+  one carrying the group's `max(server_time)` wins — the most-recent
+  spelling. Pre-#1626 that choice was SQLite's documented bare-column
+  rule; it is now `Enum.max_by/2` here, which picks the same row and
+  additionally FIXES the tie: equal `server_time` resolves to the
+  lexicographically smallest spelling, because the scan below yields
+  spellings in ascending order and `max_by/2` keeps the first maximum.
+  Channels fold idempotently (already canonical at write) so this is a
+  no-op for them; non-ASCII case variants stay distinct (ASCII-only
+  fold, matching the ircd).
 
   `active_keyset` is a `MapSet` of currently-active target strings —
   joined channels (from `Grappa.Session.list_channels/2`) plus open
@@ -1069,28 +1079,128 @@ defmodule Grappa.Scrollback do
   across read paths.
 
   Result is sorted by `last_activity` DESC for stable client rendering.
+
+  ## Cost (#1626)
+
+  ONE statement, a LOOSE INDEX SCAN: one seek per TARGET, group boundary
+  to group boundary, instead of one visit per row of the partition. The
+  cost therefore tracks the number of targets and NOT the size of the
+  account — which is the property #1626 asked for, and it is a change of
+  complexity class rather than of constant.
+
+  What it cost to get there: `row_count` is gone from the shape. An exact
+  per-group count cannot be a seek — it has to visit the group's rows, so
+  it visits the partition — and while it stayed, the listing stayed
+  partition-bound no matter how fast the target half became. Dropping a
+  field the wire already ships is a `protocol_version` decision (v8), not
+  a query one; vjt ruled for the property and accepted the price.
   """
   @spec list_archive(subject(), integer(), MapSet.t(String.t())) :: [archive_entry()]
   def list_archive(subject, network_id, %MapSet{} = active_keyset)
       when is_integer(network_id) do
     folded_active = MapSet.new(active_keyset, &Identifier.canonical_target/1)
 
-    Message
-    |> Subject.subject_where(subject)
-    |> where([m], m.network_id == ^network_id)
-    |> group_by([m], Identifier.nick_fold(fragment("COALESCE(?, ?)", m.dm_with, m.channel)))
-    |> select([m], %{
-      target: fragment("COALESCE(?, ?)", m.dm_with, m.channel),
-      last_activity: max(m.server_time),
-      row_count: count(m.id)
-    })
-    |> Repo.all()
-    |> Enum.reject(fn %{target: t} ->
-      t == "$server" or MapSet.member?(folded_active, Identifier.canonical_target(t))
-    end)
-    |> Enum.map(fn entry -> Map.put(entry, :kind, target_kind(entry.target)) end)
+    subject
+    |> archive_target_spellings(network_id)
+    |> Enum.group_by(fn {target, _} -> Identifier.canonical_target(target) end)
+    |> Enum.reject(fn {key, _} -> key == "$server" or MapSet.member?(folded_active, key) end)
+    |> Enum.map(fn {_key, group} -> archive_entry(group) end)
     |> Enum.sort_by(& &1.last_activity, :desc)
   end
+
+  # The display/key split, resolved: the KEY is the fold, the DISPLAY is
+  # the spelling on the most recent row of the fold group.
+  @spec archive_entry([{String.t(), integer()}]) :: archive_entry()
+  defp archive_entry(group) do
+    {target, last_activity} = Enum.max_by(group, fn {_, last_activity} -> last_activity end)
+
+    %{target: target, kind: target_kind(target), last_activity: last_activity}
+  end
+
+  # #1626 — the loose index scan, one seek per target instead of one visit
+  # per row, written as literal SQL with one constant per subject column.
+  #
+  # WHY RAW SQL in a context that otherwise builds every query with Ecto:
+  # the shape is a recursive CTE whose recursive term carries a correlated
+  # scalar subquery over the CTE's own row, and — load-bearing — every
+  # `COALESCE(dm_with, channel)` here must match the expression indexed by
+  # `messages_archive_{user,visitor}_idx` (`20260522073826`) or SQLite
+  # silently declines the expression index and the seek degrades to a scan.
+  # A generated spelling that drifts by one character costs the whole
+  # property and nothing fails. Same reason the migrations spell their DDL
+  # literally; the shape is pinned by an `EXPLAIN QUERY PLAN` test taken
+  # off the SQL this function EMITS (#1372), never a local rebuild.
+  #
+  # WHY IT IS FAST: that index is
+  # `(<subject>, network_id, COALESCE(dm_with, channel), server_time)`.
+  # The anchor seeks the partition's first target; each recursive step
+  # seeks the first target strictly GREATER than the previous one; the
+  # per-target `max(server_time)` is one further seek because
+  # `server_time` is the very next column. All three are COVERING.
+  #
+  # ⚠️ #1484 read these two indexes as dead weight worth dropping for
+  # INSERT cost, having measured that no plan used them. They are the
+  # index this scan runs on: dropping them costs a migration to put back.
+  @archive_target_scan_sql """
+  WITH RECURSIVE archive_target(target) AS (
+    SELECT min(COALESCE(dm_with, channel))
+      FROM messages
+     WHERE <subject_column> = ?1 AND network_id = ?2
+    UNION ALL
+    SELECT (SELECT min(COALESCE(m.dm_with, m.channel))
+              FROM messages m
+             WHERE m.<subject_column> = ?1
+               AND m.network_id = ?2
+               AND COALESCE(m.dm_with, m.channel) > archive_target.target)
+      FROM archive_target
+     WHERE archive_target.target IS NOT NULL
+  )
+  SELECT archive_target.target,
+         (SELECT max(m.server_time)
+            FROM messages m
+           WHERE m.<subject_column> = ?1
+             AND m.network_id = ?2
+             AND COALESCE(m.dm_with, m.channel) = archive_target.target)
+    FROM archive_target
+   WHERE archive_target.target IS NOT NULL
+  """
+
+  @archive_target_scan_sql_user String.replace(
+                                  @archive_target_scan_sql,
+                                  "<subject_column>",
+                                  "user_id"
+                                )
+  @archive_target_scan_sql_visitor String.replace(
+                                     @archive_target_scan_sql,
+                                     "<subject_column>",
+                                     "visitor_id"
+                                   )
+
+  # Every RAW spelling that has rows in the partition, with the newest
+  # `server_time` under that exact spelling. Folding + merging is the
+  # caller's job — the SQL stays unfolded on purpose, because the
+  # unfolded expression is what the archive index carries AND what
+  # preserves the display casing.
+  @spec archive_target_spellings(subject(), integer()) :: [{String.t(), integer()}]
+  defp archive_target_spellings(subject, network_id) do
+    {sql, subject_id} = archive_scan_binding(subject)
+    %{rows: rows} = Repo.query!(sql, [subject_id, network_id])
+
+    Enum.map(rows, fn [target, last_activity] -> {target, last_activity} end)
+  end
+
+  # Mirrors `Subject.subject_where/2`'s three-clause shape, fall-through
+  # included (#1392): an explicit ArgumentError naming the offending value
+  # beats a FunctionClauseError that hides both it and the function.
+  @spec archive_scan_binding(subject()) :: {String.t(), Ecto.UUID.t()}
+  defp archive_scan_binding({:user, user_id}) when is_binary(user_id),
+    do: {@archive_target_scan_sql_user, user_id}
+
+  defp archive_scan_binding({:visitor, visitor_id}) when is_binary(visitor_id),
+    do: {@archive_target_scan_sql_visitor, visitor_id}
+
+  defp archive_scan_binding(other),
+    do: raise(ArgumentError, "unknown subject: #{inspect(other)}")
 
   @doc """
   M7 2026-05-08 — canonical sigil-rule classifier for IRC targets.

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1104,7 +1104,7 @@ defmodule Grappa.Scrollback do
     |> archive_target_spellings(network_id)
     |> Enum.group_by(fn {target, _} -> Identifier.canonical_target(target) end)
     |> Enum.reject(fn {key, _} -> key == "$server" or MapSet.member?(folded_active, key) end)
-    |> Enum.map(fn {_key, group} -> archive_entry(group) end)
+    |> Enum.map(fn {_, group} -> archive_entry(group) end)
     |> Enum.sort_by(& &1.last_activity, :desc)
   end
 

--- a/lib/grappa/scrollback/wire.ex
+++ b/lib/grappa/scrollback/wire.ex
@@ -79,12 +79,18 @@ defmodule Grappa.Scrollback.Wire do
   `mix grappa.gen_wire_types` pins the literal TS union
   (`"channel" | "query"`) — same S14 convention as the message
   `:kind` in `t/0`. See `archive_entry/1`.
+
+  Carried `row_count` until #1626 (protocol v8), which removed it. It is
+  the first field this wire has ever taken back, and the removal is the
+  cure rather than a tidy-up: an exact per-group count has to visit the
+  group's rows, so while it was emitted the archive listing stayed bound
+  to the size of the account instead of to its number of targets. See
+  `Grappa.Scrollback.list_archive/3` and `Grappa.Protocol`.
   """
   @type archive_wire_entry :: %{
           target: String.t(),
           kind: :channel | :query,
-          last_activity: integer(),
-          row_count: non_neg_integer()
+          last_activity: integer()
         }
 
   @typedoc """
@@ -183,13 +189,12 @@ defmodule Grappa.Scrollback.Wire do
   natively.
   """
   @spec archive_entry(Scrollback.archive_entry()) :: archive_wire_entry()
-  def archive_entry(%{target: target, kind: kind, last_activity: last_activity, row_count: row_count})
+  def archive_entry(%{target: target, kind: kind, last_activity: last_activity})
       when kind in [:channel, :query] do
     %{
       target: target,
       kind: kind,
-      last_activity: last_activity,
-      row_count: row_count
+      last_activity: last_activity
     }
   end
 

--- a/lib/grappa_web/controllers/archive_controller.ex
+++ b/lib/grappa_web/controllers/archive_controller.ex
@@ -96,7 +96,8 @@ defmodule GrappaWeb.ArchiveController do
   `GET /networks/:network_id/archive` — returns the archived target
   list as `%{"archive" => [...]}` sorted by `last_activity` DESC.
 
-  Wire shape per entry: `%{target, kind, last_activity, row_count}`
+  Wire shape per entry: `%{target, kind, last_activity}` — `row_count`
+  was removed by #1626 (protocol v8); see `Grappa.Protocol`.
   where `kind` is the wire string `"channel" | "query"`.
 
   Metered: one token per call from the per-`(subject, network)`

--- a/lib/grappa_web/controllers/archive_json.ex
+++ b/lib/grappa_web/controllers/archive_json.ex
@@ -1,6 +1,6 @@
 defmodule GrappaWeb.ArchiveJSON do
   @moduledoc """
-  Wire shape: `%{archive: [%{target, kind, last_activity, row_count}]}`,
+  Wire shape: `%{archive: [%{target, kind, last_activity}]}`,
   with `kind` (`:channel | :query`) atom-stringified at the wire
   boundary so cic doesn't see Elixir-specific values.
 

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 7
-shape_digest = sha256:516f5f58171ad5c5697be017b62c170f761990f3b78bb371b1873e8a4d6ed945
+protocol_version = 8
+shape_digest = sha256:6e3316b86b59be3cffbcb9ff674f6bff6d31b3f7deb9dc5a15fc581678742deb

--- a/test/bench_1626.exs
+++ b/test/bench_1626.exs
@@ -101,12 +101,9 @@ defmodule Bench do
 
   import Ecto.Query
 
-  require Grappa.IRC.Identifier
+  alias Grappa.{IRC.Identifier, Repo, Scrollback.Message, Subject}
 
-  alias Grappa.IRC.Identifier
-  alias Grappa.Repo
-  alias Grappa.Scrollback.Message
-  alias Grappa.Subject
+  require Identifier
 
   @own_nick "vjt"
 
@@ -627,9 +624,7 @@ drain = fn drain, acc ->
   end
 end
 
-emitted =
-  drain.(drain, [])
-  |> Enum.filter(fn {q, _} -> String.starts_with?(q, ["SELECT", "WITH"]) end)
+emitted = Enum.filter(drain.(drain, []), fn {q, _} -> String.starts_with?(q, ["SELECT", "WITH"]) end)
 
 # CONTROL (known answer): answering in ONE statement is part of the
 # property, not a detail. Two statements under one snapshot would need a

--- a/test/bench_1626.exs
+++ b/test/bench_1626.exs
@@ -1,0 +1,770 @@
+# Bench harness for #1626 — the measurement that justified taking a
+# field OFF the wire. Committed, deliberately: this change cost a
+# `protocol_version` bump and a doctrine reversal, and a ruling of that
+# weight should rest on evidence somebody else can re-run rather than on
+# a table pasted into a PR.
+#
+# It is NOT a test and `mix test` never collects it (no `_test.exs`
+# suffix, by design — a multi-minute 1.3M-row corpus build has no place
+# in the suite). The DURABLE regression guard for this property is the
+# EXPLAIN-plan test in `test/grappa/scrollback_test.exs`, which pins the
+# plan off the SQL `list_archive/3` EMITS; this file is the one-time
+# quantitative record behind it.
+#
+# Run (from the worktree root):
+#
+#   ./scripts/mix.sh --env=dev run --no-start test/bench_1626.exs
+#
+# Takes a couple of minutes: axis A alone builds 1.3M rows. To exercise
+# the machinery quickly, shrink `@axis_a_sizes` / `@axis_b_rows` below —
+# an edit and not an env knob, deliberately, because `scripts/mix.sh`
+# does not forward host environment into the container and a knob that
+# silently does nothing is worse than no knob. A shrunk run is a DRY RUN
+# of the harness, not a measurement: at toy sizes SQLite may decline the
+# index, and no number produced that way may be quoted.
+#
+# Boots ONLY Grappa.Repo, pointed at a scratch SQLite file, migrated with
+# the real migration set, so `Scrollback.list_archive/3` runs through the
+# app's own pool (SQLite plans are per-connection — a hand-driven sqlite3
+# would measure a different thing) and OUTSIDE the test sandbox.
+#
+# ── WHAT THIS BENCH IS FOR, AND WHAT WOULD MAKE IT WORTHLESS ──────────
+#
+# #1626 is a claim about a COMPLEXITY CLASS, not about a constant: the
+# archive listing must stop being bound to the size of the account. A
+# single measurement, or a set of measurements at ONE partition size,
+# cannot tell a law from a factor — it is exactly the confusion that
+# filed #1626 and #1759. So the harness measures TWO axes:
+#
+#   AXIS A — partition size varies (10k → 1.3M), target count HELD STILL.
+#            A partition-bound cost grows here. A target-bound cost does
+#            not. This is the axis the claim is about.
+#   AXIS B — target count varies (20 → 1000), partition size HELD STILL
+#            at exactly 100k rows. This is the axis the cost is claimed
+#            to have MOVED ONTO, and measuring it is what makes the flat
+#            line on axis A a displacement rather than a disappearance.
+#
+# Flatness on axis A alone is consistent with "the harness cannot see
+# size at all". Two independent KNOWN-ANSWER controls rule that out: a
+# ruler query (`count(*)` over the partition) and the PRE-#1626 shape
+# itself must BOTH visibly grow on the same instrument, in the same run.
+#
+# ── THE OUTPUT GATE ───────────────────────────────────────────────────
+#
+# Every control is buffered into a ledger and every number is withheld
+# until the ledger is clean. A failing control prints the failures and
+# halts rc=1 having printed NO measurement — an output that cannot exist
+# without its controls cannot lie in silence.
+#
+# The CLAIM is deliberately NOT a control. Controls check the instrument
+# and the answers it can be checked against; gating the output on the
+# claim would hide the numbers in exactly the case where they are most
+# worth reading. The claim is printed as a VERDICT computed from the
+# numbers, with the ratios it rests on.
+
+import Ecto.Query
+
+alias Grappa.IRC.Identifier
+alias Grappa.Repo
+alias Grappa.Scrollback
+alias Grappa.Scrollback.Message
+
+db = System.get_env("BENCH_DB", "/tmp/bench_1626.db")
+for suffix <- ["", "-wal", "-shm"], do: File.rm(db <> suffix)
+
+# The two axes. 650k is #1626's prod anchor and 1.3M is its doubling —
+# the pair that tells a law from a constant. Shrink to dry-run the
+# harness; see the header for why that is not a measurement.
+axis_a_sizes = [10_000, 100_000, 650_000, 1_300_000]
+axis_b_rows = 100_000
+
+# `--no-start` keeps :grappa's supervision tree down (no Endpoint, no
+# sessions) but Ecto's own registry must be up before a repo can start.
+{:ok, _} = Application.ensure_all_started(:ecto_sql)
+{:ok, _} = Application.ensure_all_started(:exqlite)
+
+{:ok, _} =
+  Repo.start_link(
+    database: db,
+    pool_size: 1,
+    journal_mode: :wal,
+    cache_size: -64_000,
+    busy_timeout: 30_000,
+    log: false
+  )
+
+IO.puts("== migrating #{db}")
+Ecto.Migrator.run(Repo, Path.expand("priv/repo/migrations"), :up, all: true, log: false)
+
+defmodule Bench do
+  @moduledoc false
+
+  import Ecto.Query
+
+  require Grappa.IRC.Identifier
+
+  alias Grappa.IRC.Identifier
+  alias Grappa.Repo
+  alias Grappa.Scrollback.Message
+  alias Grappa.Subject
+
+  @own_nick "vjt"
+
+  @type target :: {:chan, String.t()} | {:dm, String.t()}
+  @type sampler :: {tuple(), pos_integer(), [String.t()], [String.t()], [String.t()]}
+
+  @spec own_nick() :: String.t()
+  def own_nick, do: @own_nick
+
+  @spec median([number()]) :: number()
+  def median(list) do
+    sorted = Enum.sort(list)
+    n = length(sorted)
+
+    if rem(n, 2) == 1,
+      do: Enum.at(sorted, div(n, 2)),
+      else: (Enum.at(sorted, div(n, 2) - 1) + Enum.at(sorted, div(n, 2))) / 2
+  end
+
+  @spec ms(number()) :: float()
+  def ms(us), do: Float.round(us / 1000, 2)
+
+  @spec ratio(number(), number()) :: float()
+  def ratio(a, b), do: Float.round(a / b, 2)
+
+  @spec pad(term(), pos_integer()) :: String.t()
+  def pad(v, n), do: String.pad_trailing(to_string(v), n)
+
+  @doc """
+  Median of `reps` timings after 2 warm-up calls — warm, so the number
+  is the steady-state cost and not the page-cache miss.
+  """
+  @spec time((-> any()), pos_integer()) :: number()
+  def time(fun, reps) do
+    for _ <- 1..2, do: fun.()
+    us = for _ <- 1..reps, do: fun |> :timer.tc() |> elem(0)
+    median(us)
+  end
+
+  @doc """
+  Target inventory for a corpus. Prod-shaped heavy tail: one dominant
+  channel, two busy, the rest thin; DM peers with their own tail.
+
+  Returns `{bag, bag_size, channels, peers, variants}` where `bag` is a
+  weight-expanded tuple for O(1) sampling.
+  """
+  @spec sampler(pos_integer(), pos_integer(), [String.t()]) :: sampler()
+  def sampler(n_channels, n_peers, case_variants) do
+    channels = for i <- 0..(n_channels - 1), do: "#chan#{String.pad_leading(to_string(i), 3, "0")}"
+    peers = for i <- 0..(n_peers - 1), do: "peer#{String.pad_leading(to_string(i), 3, "0")}"
+
+    chan_weights =
+      channels
+      |> Enum.with_index()
+      |> Enum.map(fn
+        {c, 0} -> {{:chan, c}, 300}
+        {c, i} when i in [1, 2] -> {{:chan, c}, 100}
+        {c, _} -> {{:chan, c}, 8}
+      end)
+
+    peer_weights =
+      peers
+      |> Enum.with_index()
+      |> Enum.map(fn {p, i} -> {{:dm, p}, max(1, 8 - div(i, 25))} end)
+
+    variant_weights = Enum.map(case_variants, fn v -> {{:dm, v}, 4} end)
+
+    bag =
+      (chan_weights ++ peer_weights ++ variant_weights)
+      |> Enum.flat_map(fn {t, w} -> List.duplicate(t, w) end)
+      |> List.to_tuple()
+
+    {bag, tuple_size(bag), channels, peers, case_variants}
+  end
+
+  @doc """
+  The FOLDED target set the corpus is built to contain — the known
+  answer the entry-set control checks against.
+  """
+  @spec expected_targets(sampler()) :: [String.t()]
+  def expected_targets({_, _, channels, peers, variants}) do
+    (channels ++ peers ++ variants)
+    |> Enum.map(&Identifier.canonical_target/1)
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Seeds ONE row per target so no target can be missing by sampling
+  accident — the entry-set control must not be able to measure a short
+  set and call it agreement. Returns the next clock.
+  """
+  @spec seed_every_target(Ecto.UUID.t(), integer(), sampler(), integer()) :: integer()
+  def seed_every_target(user_id, network_id, {bag, _, _, _, _}, clock) do
+    now = DateTime.utc_now()
+    targets = bag |> Tuple.to_list() |> Enum.uniq()
+
+    {rows, clock} =
+      Enum.map_reduce(targets, clock, fn target, clock ->
+        {row(target, clock, user_id, network_id, :privmsg, now, @own_nick), clock + 1}
+      end)
+
+    {_, _} = Repo.insert_all(Message, rows)
+    clock
+  end
+
+  @doc """
+  Appends EXACTLY `n_to_add` rows to `(user_id, network_id)`, sampling
+  targets from the bag. Returns the next clock. Exact rather than
+  grow-to-total so axis B can hold the partition size perfectly still —
+  a "within 2%" size axis is not a held axis.
+  """
+  @spec grow(Ecto.UUID.t(), integer(), sampler(), non_neg_integer(), integer()) :: integer()
+  def grow(user_id, network_id, {bag, bag_size, _, peers, _}, n_to_add, clock) do
+    now = DateTime.utc_now()
+    :rand.seed(:exsss, {1, 2, 3 + clock})
+
+    1..n_to_add//1
+    |> Stream.chunk_every(2_000)
+    |> Enum.reduce(clock, fn chunk, clock ->
+      {rows, clock} =
+        Enum.map_reduce(chunk, clock, fn _, clock ->
+          sampled_row(
+            elem(bag, :rand.uniform(bag_size) - 1),
+            peers,
+            clock,
+            user_id,
+            network_id,
+            now
+          )
+        end)
+
+      {_, _} = Repo.insert_all(Message, rows)
+      clock
+    end)
+  end
+
+  # One sampled row and the next clock. ~8% presence events on channel
+  # targets, ~4% own-authored, DM targets always content kinds (a presence
+  # event never carries `dm_with`).
+  @spec sampled_row(target(), [String.t()], integer(), Ecto.UUID.t(), integer(), DateTime.t()) ::
+          {map(), integer()}
+  defp sampled_row(target, peers, clock, user_id, network_id, now) do
+    roll = :rand.uniform(100)
+
+    kind =
+      cond do
+        match?({:dm, _}, target) -> if roll <= 4, do: :action, else: :privmsg
+        roll <= 8 -> Enum.random([:join, :part, :quit])
+        roll <= 12 -> :action
+        true -> :privmsg
+      end
+
+    sender = if roll <= 4, do: @own_nick, else: Enum.random(peers)
+
+    {row(target, clock, user_id, network_id, kind, now, sender), clock + 1}
+  end
+
+  # Channel rows: dm_with = nil, channel FOLDED (the write-time rule).
+  # DM rows (CP14 B3): inbound `channel = own_nick, dm_with = peer`,
+  # outbound `channel = peer (folded), dm_with = peer`. `dm_with` is
+  # stored RAW — that is what makes the #372 fold load-bearing, and what
+  # lets the casing-variant control below have anything to collapse.
+  @spec row(target(), integer(), Ecto.UUID.t(), integer(), atom(), DateTime.t(), String.t()) ::
+          map()
+  def row(target, clock, user_id, network_id, kind, now, sender_override) do
+    shape =
+      case target do
+        {:chan, chan} ->
+          %{channel: chan, dm_with: nil, sender: sender_override}
+
+        {:dm, peer} ->
+          if rem(clock, 2) == 0 do
+            %{channel: @own_nick, dm_with: peer, sender: peer}
+          else
+            %{channel: Identifier.canonical_target(peer), dm_with: peer, sender: @own_nick}
+          end
+      end
+
+    Map.merge(shape, %{
+      user_id: user_id,
+      visitor_id: nil,
+      network_id: network_id,
+      server_time: clock,
+      kind: kind,
+      body: "bench body #{clock}",
+      meta: %{},
+      inserted_at: now
+    })
+  end
+
+  @doc """
+  The PRE-#1626 query, transcribed verbatim from
+  `origin/main:lib/grappa/scrollback.ex`'s `list_archive/3` — the same
+  Ecto expression, through the same Ecto→SQL compiler.
+
+  It is the BASELINE (what the change is measured against) and the
+  correctness ORACLE (what the new answer must equal). It shares no code
+  with the new implementation: this one groups in SQLite and leans on
+  SQLite's bare-column rule for the display spelling; the new one seeks
+  per target and folds in Elixir with `Enum.max_by/2`. Comparing the new
+  function against a prototype that shared its implementation would
+  prove nothing.
+  """
+  @spec legacy_query(Subject.t() | {:user, Ecto.UUID.t()}, integer()) :: Ecto.Query.t()
+  def legacy_query(subject, network_id) do
+    Message
+    |> Subject.subject_where(subject)
+    |> where([m], m.network_id == ^network_id)
+    |> group_by([m], Identifier.nick_fold(fragment("COALESCE(?, ?)", m.dm_with, m.channel)))
+    |> select([m], %{
+      target: fragment("COALESCE(?, ?)", m.dm_with, m.channel),
+      last_activity: max(m.server_time),
+      row_count: count(m.id)
+    })
+  end
+end
+
+# ----------------------------------------------------------------------
+# The arms
+# ----------------------------------------------------------------------
+
+# UNDER TEST — the production function, called the way the controller
+# calls it.
+current_fun = fn uid, nid -> Scrollback.list_archive({:user, uid}, nid, MapSet.new()) end
+
+# BASELINE + ORACLE — the pre-#1626 shape, Elixir tail included.
+legacy_fun = fn uid, nid ->
+  {:user, uid}
+  |> Bench.legacy_query(nid)
+  |> Repo.all()
+  |> Enum.reject(fn %{target: t} -> t == "$server" end)
+  |> Enum.map(fn entry -> Map.put(entry, :kind, Scrollback.target_kind(entry.target)) end)
+  |> Enum.sort_by(& &1.last_activity, :desc)
+end
+
+# The two answers differ by exactly one field, and that field IS the
+# subject of the ruling — so the oracle comparison is on the three that
+# survived. Dropping `row_count` here is not weakening the check: it is
+# the whole content of the wire change, checked separately by the
+# protocol tests.
+oracle_shape = fn entries -> Enum.map(entries, &Map.drop(&1, [:row_count])) end
+
+# RULER — a query whose cost is known to be partition-linear. If this
+# does not grow with the partition, the instrument is not measuring size
+# and no flat line elsewhere means anything.
+ruler_sql = "SELECT count(*) FROM messages WHERE user_id = ?1 AND network_id = ?2"
+ruler_fun = fn uid, nid -> Repo.query!(ruler_sql, [uid, nid], log: false) end
+
+count_rows = fn uid, nid ->
+  %Exqlite.Result{rows: [[n]]} = ruler_fun.(uid, nid)
+  n
+end
+
+# DISCRIMINATION — the same grouping WITHOUT the #372 fold. On a corpus
+# carrying casing variants it must answer DIFFERENTLY, or the row-for-row
+# comparator cannot see a fold at all and its agreement is vacuous.
+unfolded_sql = """
+SELECT COALESCE(dm_with, channel), max(server_time)
+  FROM messages
+ WHERE user_id = ?1 AND network_id = ?2
+ GROUP BY COALESCE(dm_with, channel)
+"""
+
+unfolded_fun = fn uid, nid ->
+  %Exqlite.Result{rows: rows} = Repo.query!(unfolded_sql, [uid, nid], log: false)
+  Enum.map(rows, fn [t, la] -> {t, la} end)
+end
+
+# ----------------------------------------------------------------------
+# Control ledger — nothing prints until every entry is :ok
+# ----------------------------------------------------------------------
+
+{:ok, ledger} = Agent.start_link(fn -> [] end)
+control = fn name, ok?, detail -> Agent.update(ledger, &[{name, ok?, detail} | &1]) end
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+user =
+  Repo.insert!(%Grappa.Accounts.User{
+    name: "bench1626",
+    password_hash: "x",
+    inserted_at: DateTime.utc_now(),
+    updated_at: DateTime.utc_now()
+  })
+
+mknet = fn slug ->
+  Repo.insert!(%Grappa.Networks.Network{
+    slug: slug,
+    inserted_at: DateTime.utc_now(),
+    updated_at: DateTime.utc_now()
+  })
+end
+
+# ----------------------------------------------------------------------
+# AXIS A — partition grows, target SET constant
+# ----------------------------------------------------------------------
+
+net_a = mknet.("bench-axis-a")
+sampler_a = Bench.sampler(30, 146, ["debugserv", "DebugServ", "chanserv", "ChanServ"])
+expected_a = Bench.expected_targets(sampler_a)
+
+IO.puts("== building corpus (axis A, #{length(expected_a)} targets) — the slow part")
+
+clock = Bench.seed_every_target(user.id, net_a.id, sampler_a, 1)
+
+# `$server` is the pseudo-channel that must NEVER appear in an archive.
+{1, _} =
+  Repo.insert_all(Message, [
+    Bench.row({:chan, "$server"}, clock, user.id, net_a.id, :server_event, DateTime.utc_now(), "-")
+  ])
+
+clock = clock + 1
+seeded_a = clock - 1
+
+{axis_a, _} =
+  Enum.map_reduce(axis_a_sizes, {seeded_a, clock}, fn size, {have, clock} ->
+    clock = Bench.grow(user.id, net_a.id, sampler_a, size - have, clock)
+    n_rows = count_rows.(user.id, net_a.id)
+    IO.puts("   .. #{n_rows} rows")
+
+    legacy = Bench.time(fn -> legacy_fun.(user.id, net_a.id) end, 5)
+    cur = Bench.time(fn -> current_fun.(user.id, net_a.id) end, 5)
+    ruler = Bench.time(fn -> ruler_fun.(user.id, net_a.id) end, 5)
+
+    entries = current_fun.(user.id, net_a.id)
+
+    control.(
+      "axis A @#{size}: list_archive/3 == the pre-#1626 answer, row for row",
+      entries == oracle_shape.(legacy_fun.(user.id, net_a.id)),
+      "row-for-row mismatch at partition size #{size}"
+    )
+
+    {{n_rows, length(entries), legacy, cur, ruler}, {size, clock}}
+  end)
+
+final_entries = current_fun.(user.id, net_a.id)
+got_targets = final_entries |> Enum.map(&Identifier.canonical_target(&1.target)) |> Enum.sort()
+want_targets = Enum.sort(expected_a)
+
+# CONTROL (known answer): the corpus is built to hold exactly this folded
+# target set, one seeded row each, so the listing must return it in full
+# — minus `$server`, which is always excluded.
+control.(
+  "entry set == constructed target set (#{length(want_targets)} targets)",
+  got_targets == want_targets,
+  "missing=#{inspect(want_targets -- got_targets)} extra=#{inspect(got_targets -- want_targets)}"
+)
+
+# CONTROL (negative, known answer): a target that was never seeded must
+# be ABSENT. Without this, "the set matches" could be true of a
+# comparator that accepts anything.
+control.(
+  "a never-seeded target is absent",
+  "#chan999" not in got_targets,
+  "the listing returned a target the corpus never contained"
+)
+
+# CONTROL (known answer): `$server` was inserted and must not surface.
+control.(
+  "$server excluded from the listing",
+  not Enum.any?(final_entries, &(&1.target == "$server")),
+  "found $server in the listing"
+)
+
+# CONTROL (known answer): the two casing variants of one peer collapse to
+# ONE entry — the #372 fold, which the loose scan does in Elixir now.
+control.(
+  "DebugServ/debugserv collapse to one entry",
+  Enum.count(final_entries, &(Identifier.canonical_target(&1.target) == "debugserv")) == 1,
+  "got #{Enum.count(final_entries, &(Identifier.canonical_target(&1.target) == "debugserv"))}"
+)
+
+# CONTROL (known answer): `active_keyset` still excludes, and it excludes
+# on the FOLD of both sides — pass the target in a casing that appears
+# nowhere in the corpus and the entry must still disappear, exactly one.
+excluded = Scrollback.list_archive({:user, user.id}, net_a.id, MapSet.new(["DEBUGSERV"]))
+
+control.(
+  "active_keyset excludes on the fold (DEBUGSERV removes debugserv, and only it)",
+  length(excluded) == length(final_entries) - 1 and
+    not Enum.any?(excluded, &(Identifier.canonical_target(&1.target) == "debugserv")),
+  "before=#{length(final_entries)} after=#{length(excluded)}"
+)
+
+# CONTROL (discrimination): the comparator must be ABLE to see a fold.
+# The unfolded grouping answers differently on this corpus; if it did
+# not, every agreement above would be vacuous.
+control.(
+  "comparator discriminates (the unfolded grouping answers differently)",
+  length(unfolded_fun.(user.id, net_a.id)) != length(final_entries),
+  "unfolded and folded set sizes are equal — the corpus carries no casing variant"
+)
+
+# CONTROL (precondition for the display-spelling comparison): the clock
+# is strictly increasing, so no two rows share a `server_time`. That is
+# what makes the oracle comparison legitimate on the `target` field —
+# SQLite's bare-column rule picks an ARBITRARY row among ties, and
+# `Enum.max_by/2` picks the first, so a tie would let the two disagree
+# for a reason that is not a defect.
+%Exqlite.Result{rows: [[dupes]]} =
+  Repo.query!(
+    "SELECT count(*) - count(DISTINCT server_time) FROM messages " <>
+      "WHERE user_id = ?1 AND network_id = ?2",
+    [user.id, net_a.id],
+    log: false
+  )
+
+control.(
+  "no two corpus rows share a server_time (no display-spelling tie)",
+  dupes == 0,
+  "#{dupes} duplicate server_time value(s) — the oracle comparison on `target` is not sound"
+)
+
+# The bar both instrument controls must clear: a partition-LINEAR cost
+# should track the partition ratio, so a quarter of it is a generous
+# floor that still cannot be cleared by noise. Derived from the axis
+# rather than hardcoded, so shrinking the axis (smoke) relaxes it by the
+# same amount it relaxes the evidence.
+{rows_first, _, _, _, _} = List.first(axis_a)
+{rows_last, _, _, _, _} = List.last(axis_a)
+growth_floor = rows_last / rows_first / 4
+
+# CONTROL (instrument, known answer #1): a query known to be
+# partition-linear MUST grow with the partition on this instrument.
+rulers = Enum.map(axis_a, fn {_, _, _, _, r} -> r end)
+
+control.(
+  "instrument sees size: the ruler count(*) grows >=x#{Float.round(growth_floor, 1)}",
+  List.last(rulers) / List.first(rulers) >= growth_floor,
+  "ruler medians (us): #{inspect(rulers)}"
+)
+
+# CONTROL (instrument, known answer #2 — the load-bearing one): the
+# PRE-#1626 shape is partition-bound by construction, and must be
+# visibly so in this very run. This is what turns the new arm's flat
+# line into evidence instead of an artefact: same corpus, same pool,
+# same timing code, one arm grows and one does not.
+legacies = Enum.map(axis_a, fn {_, _, l, _, _} -> l end)
+
+control.(
+  "instrument sees size: the pre-#1626 shape grows >=x#{Float.round(growth_floor, 1)}",
+  List.last(legacies) / List.first(legacies) >= growth_floor,
+  "pre-1626 medians (us): #{inspect(legacies)}"
+)
+
+# ----------------------------------------------------------------------
+# AXIS B — target count varies, partition size CONSTANT
+# ----------------------------------------------------------------------
+
+IO.puts("== building corpora (axis B, partition pinned at #{axis_b_rows})")
+
+axis_b =
+  for {n_chan, n_peer, slug} <- [
+        {4, 16, "bench-b-20"},
+        {30, 150, "bench-b-180"},
+        {200, 800, "bench-b-1000"}
+      ] do
+    net = mknet.(slug)
+    sampler = Bench.sampler(n_chan, n_peer, [])
+    expected = Bench.expected_targets(sampler)
+
+    clock = Bench.seed_every_target(user.id, net.id, sampler, 1)
+    _ = Bench.grow(user.id, net.id, sampler, axis_b_rows - (clock - 1), clock)
+
+    n_rows = count_rows.(user.id, net.id)
+    IO.puts("   .. #{slug}: #{length(expected)} targets, #{n_rows} rows")
+
+    legacy = Bench.time(fn -> legacy_fun.(user.id, net.id) end, 5)
+    cur = Bench.time(fn -> current_fun.(user.id, net.id) end, 5)
+
+    entries = current_fun.(user.id, net.id)
+    got = entries |> Enum.map(&Identifier.canonical_target(&1.target)) |> Enum.sort()
+
+    control.(
+      "axis B #{slug}: entry set == constructed target set",
+      got == Enum.sort(expected),
+      "want=#{length(expected)} got=#{length(got)}"
+    )
+
+    control.(
+      "axis B #{slug}: list_archive/3 == the pre-#1626 answer, row for row",
+      entries == oracle_shape.(legacy_fun.(user.id, net.id)),
+      "row-for-row mismatch"
+    )
+
+    control.(
+      "axis B #{slug}: the partition is EXACTLY #{axis_b_rows} rows (size axis held still)",
+      n_rows == axis_b_rows,
+      "partition has #{n_rows} rows, not #{axis_b_rows} — the size axis moved under axis B"
+    )
+
+    {length(entries), n_rows, legacy, cur}
+  end
+
+# ----------------------------------------------------------------------
+# EXPLAIN — off the SQL the PRODUCTION function actually emits (#1372)
+# ----------------------------------------------------------------------
+
+me = self()
+
+:telemetry.attach(
+  "bench-1626",
+  [:grappa, :repo, :query],
+  fn _, _, meta, _ -> send(me, {:sql, meta.query, meta.params}) end,
+  nil
+)
+
+_ = current_fun.(user.id, net_a.id)
+:telemetry.detach("bench-1626")
+
+drain = fn drain, acc ->
+  receive do
+    {:sql, q, p} -> drain.(drain, [{q, p} | acc])
+  after
+    0 -> Enum.reverse(acc)
+  end
+end
+
+emitted =
+  drain.(drain, [])
+  |> Enum.filter(fn {q, _} -> String.starts_with?(q, ["SELECT", "WITH"]) end)
+
+# CONTROL (known answer): answering in ONE statement is part of the
+# property, not a detail. Two statements under one snapshot would need a
+# transaction; #1626 answers in one, so the plans below are the whole
+# story rather than a sample of it.
+control.(
+  "production SQL captured from repo telemetry: exactly 1 statement",
+  length(emitted) == 1,
+  "captured #{length(emitted)} readable statement(s) — the plan below would be partial"
+)
+
+explain = fn sql, params ->
+  %Exqlite.Result{rows: rows} = Repo.query!("EXPLAIN QUERY PLAN " <> sql, params, log: false)
+  Enum.map_join(rows, "\n    ", fn row -> List.last(row) end)
+end
+
+after_plan =
+  case emitted do
+    [{sql, params}] -> explain.(sql, params)
+    _ -> ""
+  end
+
+{legacy_sql, legacy_params} = Repo.to_sql(:all, Bench.legacy_query({:user, user.id}, net_a.id))
+before_plan = explain.(legacy_sql, legacy_params)
+
+# CONTROL (structural corroboration, known answer): the emitted plan must
+# SEARCH the archive expression index. `messages_archive_user_idx`
+# (`20260522073826`) is the index the loose scan seeks on; SQLite declines
+# an expression index the moment the query's spelling of the expression
+# drifts by one character, and it does so SILENTLY — the seek degrades to
+# a scan and nothing fails. The timing would catch it, but only if
+# somebody read the timing; this makes it a red.
+control.(
+  "the emitted plan seeks messages_archive_user_idx",
+  String.contains?(after_plan, "messages_archive_user_idx"),
+  "plan:\n    #{after_plan}"
+)
+
+# CONTROL (known answer, the other side): the PRE-#1626 plan must NOT be
+# a per-target seek — it is the partition-visiting shape, and if the
+# planner had already been seeking, there would have been nothing to fix.
+control.(
+  "the pre-#1626 plan visits the partition (SCAN or a full index walk)",
+  not String.contains?(before_plan, "USING INDEX messages_archive_user_idx (") or
+    String.contains?(before_plan, "SCAN"),
+  "plan:\n    #{before_plan}"
+)
+
+# ----------------------------------------------------------------------
+# GATE — no number is printed unless every control passed
+# ----------------------------------------------------------------------
+
+controls = ledger |> Agent.get(& &1) |> Enum.reverse()
+failed = Enum.reject(controls, fn {_, ok?, _} -> ok? end)
+
+if failed != [] do
+  IO.puts("\n!! CONTROLS FAILED — no measurement printed")
+
+  for {name, _, detail} <- failed do
+    IO.puts("   FAIL #{name}\n        #{detail}")
+  end
+
+  IO.puts("\n   (#{length(controls) - length(failed)}/#{length(controls)} controls passed)")
+  System.halt(1)
+end
+
+IO.puts("\n== CONTROLS: #{length(controls)}/#{length(controls)} passed")
+for {name, _, _} <- controls, do: IO.puts("   ok  #{name}")
+
+IO.puts("\n== AXIS A — partition size varies, target count HELD STILL")
+IO.puts("rows      | targets | pre-1626 ms | list_archive/3 ms | ruler count(*) ms")
+
+for {rows, n, legacy, cur, ruler} <- axis_a do
+  IO.puts(
+    "#{Bench.pad(rows, 9)} | #{Bench.pad(n, 7)} | #{Bench.pad(Bench.ms(legacy), 11)} | " <>
+      "#{Bench.pad(Bench.ms(cur), 17)} | #{Bench.ms(ruler)}"
+  )
+end
+
+IO.puts("\n== AXIS B — target count varies, partition size HELD STILL at #{axis_b_rows}")
+IO.puts("targets   | rows    | pre-1626 ms | list_archive/3 ms")
+
+for {n, rows, legacy, cur} <- axis_b do
+  IO.puts(
+    "#{Bench.pad(n, 9)} | #{Bench.pad(rows, 7)} | #{Bench.pad(Bench.ms(legacy), 11)} | " <>
+      "#{Bench.ms(cur)}"
+  )
+end
+
+# ----------------------------------------------------------------------
+# VERDICT — the claim, computed from the numbers above
+# ----------------------------------------------------------------------
+
+{rows_lo, _, legacy_lo, cur_lo, ruler_lo} = List.first(axis_a)
+{rows_hi, _, legacy_hi, cur_hi, ruler_hi} = List.last(axis_a)
+
+{tgt_lo, _, legacy_b_lo, cur_b_lo} = List.first(axis_b)
+{tgt_hi, _, legacy_b_hi, cur_b_hi} = List.last(axis_b)
+
+IO.puts("\n== VERDICT")
+
+IO.puts(
+  "AXIS A  partition x#{Bench.ratio(rows_hi, rows_lo)} " <>
+    "(#{rows_lo} -> #{rows_hi} rows, targets held):\n" <>
+    "          pre-1626        x#{Bench.ratio(legacy_hi, legacy_lo)}   " <>
+    "(#{Bench.ms(legacy_lo)} -> #{Bench.ms(legacy_hi)} ms)\n" <>
+    "          ruler count(*)  x#{Bench.ratio(ruler_hi, ruler_lo)}   " <>
+    "(#{Bench.ms(ruler_lo)} -> #{Bench.ms(ruler_hi)} ms)\n" <>
+    "          list_archive/3  x#{Bench.ratio(cur_hi, cur_lo)}   " <>
+    "(#{Bench.ms(cur_lo)} -> #{Bench.ms(cur_hi)} ms)"
+)
+
+IO.puts(
+  "AXIS B  targets x#{Bench.ratio(tgt_hi, tgt_lo)} " <>
+    "(#{tgt_lo} -> #{tgt_hi} targets, partition held at #{axis_b_rows}):\n" <>
+    "          pre-1626        x#{Bench.ratio(legacy_b_hi, legacy_b_lo)}   " <>
+    "(#{Bench.ms(legacy_b_lo)} -> #{Bench.ms(legacy_b_hi)} ms)\n" <>
+    "          list_archive/3  x#{Bench.ratio(cur_b_hi, cur_b_lo)}   " <>
+    "(#{Bench.ms(cur_b_lo)} -> #{Bench.ms(cur_b_hi)} ms)"
+)
+
+IO.puts(
+  "\nThe claim is a DISPLACEMENT, and it needs both axes: the cost left\n" <>
+    "the partition axis (A) and appeared on the target axis (B). Two arms\n" <>
+    "that DO grow on axis A, in this same run, are what make the flat one\n" <>
+    "a measurement rather than a blind instrument."
+)
+
+IO.puts("\n== EXPLAIN QUERY PLAN — AFTER (the SQL list_archive/3 emits)")
+[{after_sql, _}] = emitted
+IO.puts("-- statement:\n#{after_sql}")
+IO.puts("-- plan:\n    #{after_plan}\n")
+
+IO.puts("== EXPLAIN QUERY PLAN — BEFORE (the pre-#1626 shape)")
+IO.puts("-- statement:\n#{legacy_sql}")
+IO.puts("-- plan:\n    #{before_plan}")
+
+IO.puts("\n== done")

--- a/test/grappa/scrollback/wire_test.exs
+++ b/test/grappa/scrollback/wire_test.exs
@@ -129,7 +129,7 @@ defmodule Grappa.Scrollback.WireTest do
       wire = Wire.archive_entry(%{target: "#sniffo", kind: :channel, last_activity: 1})
 
       refute Map.has_key?(wire, :row_count)
-      assert Map.keys(wire) |> Enum.sort() == [:kind, :last_activity, :target]
+      assert Enum.sort(Map.keys(wire)) == [:kind, :last_activity, :target]
     end
 
     # An Elixir map pattern matches a SUBSET, so a caller still holding the

--- a/test/grappa/scrollback/wire_test.exs
+++ b/test/grappa/scrollback/wire_test.exs
@@ -113,22 +113,43 @@ defmodule Grappa.Scrollback.WireTest do
       assert Wire.archive_entry(%{
                target: "#sniffo",
                kind: :channel,
-               last_activity: 12_345,
-               row_count: 7
+               last_activity: 12_345
              }) == %{
                target: "#sniffo",
                kind: :channel,
-               last_activity: 12_345,
-               row_count: 7
+               last_activity: 12_345
              }
+    end
+
+    # #1626 (protocol v8) — `row_count` is GONE, and the equality above is
+    # what pins that: an extra key in the output would fail it. This case
+    # states the removal from the other side, so a reader of the test file
+    # sees the field named rather than absent.
+    test "does not emit row_count — removed in protocol v8" do
+      wire = Wire.archive_entry(%{target: "#sniffo", kind: :channel, last_activity: 1})
+
+      refute Map.has_key?(wire, :row_count)
+      assert Map.keys(wire) |> Enum.sort() == [:kind, :last_activity, :target]
+    end
+
+    # An Elixir map pattern matches a SUBSET, so a caller still holding the
+    # pre-#1626 shape does NOT hit a clause error — measured, after asserting
+    # the opposite and being wrong. What actually protects the wire is that
+    # this function BUILDS its result rather than passing the input through:
+    # the stale key is dropped, never re-emitted. That is the assertion worth
+    # having, and it is the same tolerance the client side relies on.
+    test "an entry still carrying row_count has it dropped, not re-emitted" do
+      wire = Wire.archive_entry(%{target: "#s", kind: :channel, last_activity: 1, row_count: 7})
+
+      refute Map.has_key?(wire, :row_count)
+      assert wire == %{target: "#s", kind: :channel, last_activity: 1}
     end
 
     test "passes the :query kind atom through for nick-targeted DM windows" do
       assert Wire.archive_entry(%{
                target: "vjt-peer",
                kind: :query,
-               last_activity: 999,
-               row_count: 1
+               last_activity: 999
              }).kind == :query
     end
 
@@ -140,8 +161,7 @@ defmodule Grappa.Scrollback.WireTest do
         Wire.archive_entry(%{
           target: "vjt-peer",
           kind: :query,
-          last_activity: 999,
-          row_count: 1
+          last_activity: 999
         })
 
       assert Jason.decode!(Jason.encode!(wire))["kind"] == "query"
@@ -151,14 +171,14 @@ defmodule Grappa.Scrollback.WireTest do
   describe "archive_index/1" do
     test "wraps a list of entries in the %{archive: [...]} envelope" do
       entries = [
-        %{target: "vjt-peer", kind: :query, last_activity: 300, row_count: 1},
-        %{target: "#a", kind: :channel, last_activity: 100, row_count: 1}
+        %{target: "vjt-peer", kind: :query, last_activity: 300},
+        %{target: "#a", kind: :channel, last_activity: 100}
       ]
 
       assert Wire.archive_index(entries) == %{
                archive: [
-                 %{target: "vjt-peer", kind: :query, last_activity: 300, row_count: 1},
-                 %{target: "#a", kind: :channel, last_activity: 100, row_count: 1}
+                 %{target: "vjt-peer", kind: :query, last_activity: 300},
+                 %{target: "#a", kind: :channel, last_activity: 100}
                ]
              }
     end

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -2562,7 +2562,7 @@ defmodule Grappa.ScrollbackTest do
   # `:query` otherwise. Mirrors `dm_eligible?/1`'s sigil predicate so
   # the two stay in lockstep.
   describe "list_archive/3" do
-    test "excludes $server and active_keyset; returns archived DM target with kind/last_activity/row_count",
+    test "excludes $server and active_keyset; returns archived DM target with kind/last_activity",
          %{user: user, network: net} do
       # Seed: 3 channel rows for #a (active), 2 DM rows for "vjt-peer"
       # (archived), 1 $server row (always-active per intent doc).
@@ -2572,8 +2572,7 @@ defmodule Grappa.ScrollbackTest do
                %{
                  target: "vjt-peer",
                  kind: :query,
-                 last_activity: 200,
-                 row_count: 2
+                 last_activity: 200
                }
              ] =
                Scrollback.list_archive({:user, user.id}, net.id, MapSet.new(["#a"]))
@@ -2588,8 +2587,8 @@ defmodule Grappa.ScrollbackTest do
       # #a (max ts 30) and vjt-peer (max ts 200) both archived; $server
       # excluded; sorted last_activity desc.
       assert [
-               %{target: "vjt-peer", kind: :query, last_activity: 200, row_count: 2},
-               %{target: "#a", kind: :channel, last_activity: 30, row_count: 3}
+               %{target: "vjt-peer", kind: :query, last_activity: 200},
+               %{target: "#a", kind: :channel, last_activity: 30}
              ] = result
     end
 
@@ -2650,7 +2649,7 @@ defmodule Grappa.ScrollbackTest do
         })
 
       assert [
-               %{target: "#visitor-only", kind: :channel, last_activity: 200, row_count: 1}
+               %{target: "#visitor-only", kind: :channel, last_activity: 200}
              ] =
                Scrollback.list_archive({:visitor, visitor.id}, net.id, MapSet.new())
     end
@@ -3443,57 +3442,106 @@ defmodule Grappa.ScrollbackTest do
     end
   end
 
-  # REV-B / H18 (2026-05-22 codebase review). Covering expression index
-  # on `(<subject>, network_id, COALESCE(dm_with, channel))` for
-  # `list_archive/3`'s GROUP BY shape. The migration is purely
-  # additive — the planner picks it up automatically once present. We
-  # assert via `EXPLAIN QUERY PLAN` that the planner consults
-  # `messages_archive_user_idx` (or `messages_archive_visitor_idx`)
-  # for the archive query shape.
+  # #1626 — the archive listing must answer from a LOOSE INDEX SCAN: one
+  # seek per TARGET, group boundary to group boundary, instead of one visit
+  # per ROW of the `(subject, network)` partition. That is a complexity
+  # class, and this is where it is pinned.
   #
-  # SQLite is permitted to fall through to `SCAN messages` on very
-  # small tables (zero or one row) — the test seeds enough rows to
-  # nudge the planner past that heuristic.
-  describe "REV-B H18 — list_archive/3 covering index" do
-    test "EXPLAIN QUERY PLAN consults messages_archive_user_idx", %{user: user, network: net} do
-      # Seed a handful of rows so the planner has cardinality to
-      # reason about; bias toward heterogeneous COALESCE values so
-      # the index is materially useful.
-      for {ch, dm, st} <- [
-            {"#a", nil, 10},
-            {"#b", nil, 20},
-            {"peer", "peer", 30},
-            {"other", "other", 40}
-          ] do
-        {:ok, _} = Scrollback.persist_event(sample(user, net, st, %{channel: ch, dm_with: dm}))
+  # It is a PLAN test and not a timing test on purpose: a wall-clock
+  # assertion on a shared host measures the host. The law was measured on a
+  # bench (`test/bench_1626.exs`) at two partition sizes; what has to hold
+  # forever is the SHAPE that produced it.
+  #
+  # It also settles, in the opposite direction, what #1484 recorded about
+  # the two `messages_archive_*_idx` (`20260522073826`): it read them as
+  # dead weight worth dropping for INSERT cost, having measured that no
+  # plan used them. They are the index this scan RUNS on — COVERING, in
+  # every one of its seeks — so dropping them would cost a migration to put
+  # back. This test fails if the index goes AND if the query stops seeking.
+  #
+  # It REPLACES the REV-B/H18 test that used to sit here. That one built the
+  # archive SQL by hand and EXPLAINed its own copy, so from the moment
+  # production stopped emitting that shape it pinned a query nobody ran —
+  # the exact blindness #1372 documented. The plan below comes off the SQL
+  # the production function EMITS.
+  #
+  # `capture_one_query/1` and not its plural twin: answering in ONE
+  # statement is itself part of the property. While `row_count` was in the
+  # shape the listing needed a second, partition-visiting pass, and that
+  # pass is what kept the cost bound to the account. If a second statement
+  # ever comes back, this raises instead of pinning whichever came last.
+  describe "#1626 — list_archive/3 seeks per target, not per row" do
+    test "the target read is a boundary-to-boundary seek on messages_archive_user_idx",
+         %{user: user, network: net} do
+      # Enough rows across enough targets that the planner has cardinality
+      # to reason about — SQLite may fall through to SCAN on a table of one
+      # or two rows.
+      for i <- 1..30 do
+        {:ok, _} =
+          Scrollback.persist_event(sample(user, net, i * 10, %{channel: "#chan#{rem(i, 6)}"}))
       end
 
-      sql = """
-      EXPLAIN QUERY PLAN
-        SELECT COALESCE(dm_with, channel) AS target,
-               MAX(server_time) AS last_activity,
-               COUNT(*) AS row_count
-          FROM messages
-         WHERE user_id = ? AND network_id = ?
-         GROUP BY COALESCE(dm_with, channel)
-      """
+      {sql, params} =
+        capture_one_query(fn ->
+          Scrollback.list_archive({:user, user.id}, net.id, MapSet.new())
+        end)
 
-      %Exqlite.Result{rows: rows} = Repo.query!(sql, [user.id, net.id])
+      {:ok, %{rows: rows}} = Repo.query("EXPLAIN QUERY PLAN " <> sql, params)
+      plan = rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
 
-      plan = Enum.map_join(rows, "\n", fn [_, _, _, detail] -> detail end)
-
-      # The planner output for SQLite uses "SEARCH messages USING INDEX
-      # <name>" when the index is actually applied. We accept either
-      # the user-scoped index by name OR the broader assertion that
-      # SOME index is used (defensive against minor SQLite planner
-      # wording variance across versions); the index name is the
-      # canonical signal and what the migration guarantees exists.
       assert plan =~ "messages_archive_user_idx",
              """
-             Expected EXPLAIN QUERY PLAN to reference messages_archive_user_idx,
-             got:
+             Expected the plan to run on messages_archive_user_idx, got:
              #{plan}
              """
+
+      assert plan =~ "<expr>>?",
+             """
+             Expected a boundary-to-boundary seek (`<expr>>?`) — the loose
+             index scan hopping to the next target — rather than a visit of
+             the whole partition. Plan:
+             #{plan}
+             """
+    end
+
+    test "the visitor arm seeks on its own index", %{network: net} do
+      visitor = visitor_fixture()
+
+      for i <- 1..30 do
+        {:ok, _} =
+          ScrollbackHelpers.insert(%{
+            visitor_id: visitor.id,
+            network_id: net.id,
+            channel: "#vchan#{rem(i, 6)}",
+            server_time: i * 10,
+            kind: :privmsg,
+            sender: "anon",
+            body: "m",
+            meta: %{},
+            dm_with: nil
+          })
+      end
+
+      {sql, params} =
+        capture_one_query(fn ->
+          Scrollback.list_archive({:visitor, visitor.id}, net.id, MapSet.new())
+        end)
+
+      {:ok, %{rows: rows}} = Repo.query("EXPLAIN QUERY PLAN " <> sql, params)
+      plan = rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
+
+      assert plan =~ "messages_archive_visitor_idx" and plan =~ "<expr>>?",
+             """
+             Expected the visitor arm to seek on messages_archive_visitor_idx.
+             Plan:
+             #{plan}
+             """
+    end
+
+    test "an unknown subject shape raises instead of failing a clause silently" do
+      assert_raise ArgumentError, ~r/unknown subject/, fn ->
+        Scrollback.list_archive({:nobody, "x"}, 1, MapSet.new())
+      end
     end
   end
 
@@ -3826,7 +3874,6 @@ defmodule Grappa.ScrollbackTest do
 
       assert [entry] = Scrollback.list_archive({:user, user.id}, net.id, MapSet.new())
       assert entry.kind == :query
-      assert entry.row_count == 2
       assert entry.last_activity == 200
       # Representative display casing is incidental; the fold is the identity.
       assert Identifier.canonical_target(entry.target) == "debugserv"

--- a/test/grappa_web/controllers/archive_controller_test.exs
+++ b/test/grappa_web/controllers/archive_controller_test.exs
@@ -121,9 +121,9 @@ defmodule GrappaWeb.ArchiveControllerTest do
 
       assert json_response(conn, 200) == %{
                "archive" => [
-                 %{"target" => "vjt-peer", "kind" => "query", "last_activity" => 300, "row_count" => 1},
-                 %{"target" => "#b", "kind" => "channel", "last_activity" => 200, "row_count" => 1},
-                 %{"target" => "#a", "kind" => "channel", "last_activity" => 100, "row_count" => 1}
+                 %{"target" => "vjt-peer", "kind" => "query", "last_activity" => 300},
+                 %{"target" => "#b", "kind" => "channel", "last_activity" => 200},
+                 %{"target" => "#a", "kind" => "channel", "last_activity" => 100}
                ]
              }
     end


### PR DESCRIPTION
## What this does

`Scrollback.list_archive/3` answered the per-network Archive section by grouping
every row of the `(subject, network)` partition. #1626 filed that as a
complexity problem rather than a slow query: listing ~180 windows cost whatever
the account had ever said, so it grew forever while the answer did not.

It now answers from a **loose index scan** — a recursive CTE hopping group
boundary to group boundary, one seek per TARGET — in **one statement**, and the
cost tracks the target count instead.

The price: **`row_count` is removed from the archive entry**, and the wire moves
to `protocol_version` **8**.

## The ruling, and where it came from

vjt chose the variant **WITHOUT `row_count`** — the property (~0.5 ms at both
650k and 1.3M) over the ~10x constant improvement that left the law
partition-bound — and **explicitly accepted the price: a `protocol_version` bump
and work on cic**.

**Provenance, stated plainly:** the ruling was taken by the orchestrator in
session with vjt. A relay separately reported a consistent line from vjt in
channel (*"i problemi di performance vanno sistemati"*, ~13:12Z) which the
orchestrator **did not verify first-hand**; it is quoted here only as that.

## The measurement

Harness: `test/bench_1626.exs`, committed. Prod-shaped corpus (178 targets, 30
channels on a heavy tail plus DM peers in CP14 B3 form, casing variants
included), through the app's own pool on a scratch SQLite file **outside the
sandbox**, warm median of 5. **25 known-answer controls gate the output — a
single failure prints the failures and halts with no measurement at all.**

One number cannot tell a law from a factor, which is the trap #1626 was filed
about and the one #1759 hit again. So there are two axes.

**Axis A — partition 10k to 1.3M, target count HELD at 178:**

| rows | pre-#1626 | `list_archive/3` | ruler `count(*)` |
|---|---|---|---|
| 10,000 | 2.52 ms | 0.60 ms | 0.29 ms |
| 100,000 | 37.18 ms | 0.60 ms | 2.87 ms |
| 650,000 | 428.93 ms | 0.66 ms | 19.45 ms |
| 1,300,000 | 1076.59 ms | 0.77 ms | 56.20 ms |

Partition x130 → pre-#1626 **x427.22**, ruler **x190.51**, `list_archive/3`
**x1.28**.

**Axis B — targets 20 to 1000, partition HELD at exactly 100,000 rows:**

| targets | pre-#1626 | `list_archive/3` |
|---|---|---|
| 20 | 22.03 ms | 0.16 ms |
| 180 | 31.13 ms | 0.62 ms |
| 1000 | 41.59 ms | 2.69 ms |

Targets x50 → pre-#1626 **x1.89**, `list_archive/3` **x16.64**.

Axis B is not decoration. Near-stillness on axis A alone is equally consistent
with *"the harness cannot see size"*, so the claim is a **displacement** and
needs the other side. Two independent arms that DO grow on axis A in the same
run — a `count(*)` ruler and the pre-#1626 shape itself — are gate controls, not
commentary.

**I am not claiming flat.** Three runs read the new arm as 0.53/0.58/0.61/0.68,
0.63/0.60/0.56/0.79, 0.60/0.60/0.66/0.77. One is non-monotone; two rise weakly.
A rise exists — x1.28 over x130 — next to x427 for the old shape on the same
instrument in the same run. The likely reading (B-tree depth growing with the
table, so a constant count of seeks each costs slightly more) is **inferred, not
measured**, and the DESIGN_NOTES entry labels it that way.

### Plans, off the emitted SQL

Taken from `[:grappa, :repo, :query]` telemetry, never a local rebuild (#1372).
All three seeks are covering on `messages_archive_user_idx`: the anchor
`(user_id=? AND network_id=?)`, the recursive step `(... AND <expr>>?)`, the
per-target max `(... AND <expr>=?)`.

**Unexpected finding worth flagging:** the BEFORE plan does not use
`messages_archive_{user,visitor}_idx` at all — it walks the fold covering index
added by `20260816013504`. So **#1484's reading that those two indexes were dead
weight worth dropping for INSERT cost was TRUE of the old query**, and it is this
scan that makes them load-bearing. Dropping them now would degrade the seek to a
scan **silently**: SQLite declines an expression index the moment the query's
spelling of `COALESCE(dm_with, channel)` drifts by one character. That is why the
SQL is a literal constant and not Ecto-generated, and why a control asserts the
index name appears in the emitted plan.

## Relationship to `w2-1626`

w2's branch (`9d2fb782`, 4 commits) implements the **other fork** — the one that
KEEPS the count. Its own DESIGN_NOTES entry says so: *"the count still visits the
partition, so the LAW is unchanged"*, ~10x on the constant.

**It was not rebased or cherry-picked.** Once the ruling chose the property, a
green on a branch implementing the rejected fork would be a green with nothing
behind it, and a vacuous green is worse than a red.

Reused from it **by hand**, and declared:

- the loose-scan SQL, **verbatim** — every `COALESCE(dm_with, channel)` must
  match the indexed expression character for character;
- the display-casing rule, rewritten as `Enum.max_by/2`.

**Declined:** its `Repo.deferred_transaction/1` (`ab10399e`). It existed to hold
two statements under one snapshot; without the count there is one statement, and
an API with no caller is a liability. Its 606-line bench was read for shape, not
taken.

`Enum.max_by/2` additionally **fixes** a tie the old shape left to SQLite: equal
`server_time` across two spellings of one fold resolved arbitrarily under the
bare-column rule, and now resolves to the lexicographically smallest. The bench's
oracle comparison is only sound because a control proves the corpus contains no
such tie.

## `protocol_version` 7 -> 8; `min_protocol_version` STAYS at 1

The bump is not discretionary (#1393d). The floor **not** moving is, so it is
argued from three measurements rather than left implicit.

1. **The break is real and runs old-client -> new-server.** cic's generated
   `wireSchema` declares `row_count` REQUIRED and `wireValidate.walkObject`
   REJECTs an object missing a required key — `api.test.ts` carried a case named
   exactly *"listArchive rejects an entry missing row_count"*.
2. **The blast radius is ONE listing and it is contained.** `loadArchive`
   catches, leaving already-rendered entries in place, and the renderer reads an
   absent slug as "not loaded yet". The socket is untouched.
3. **The floor is not endpoint-scoped.** Raising it to 8 would 426 the WHOLE
   socket for every client declaring 1..7, **including clients that never call
   `/archive`**. Matching a session-wide gate to an endpoint-scoped break is a
   category error.

**cic's `MIN_SERVER_PROTOCOL_VERSION` stays at 2, measured:** `walkObject` DROPS
undeclared keys rather than rejecting them (additive-only, #447), so a v8 bundle
still talks to a v7 server that is still sending the field. The `api.test.ts`
case above is replaced by one pinning exactly that tolerance, because the
tolerance is the property holding the floor where it is.

**Declared, deliberately NOT fixed here:** cic's `CLIENT_PROTOCOL_VERSION` is
still **2** while the server is at **8** — it has never followed the bumps.
Moving it in this slice would be inertia, not a decision.

## The doctrine that fell

*"Existing fields are NEVER removed"* is now false, and leaving it written in
three places would leave three documents lying. Updated: `CLAUDE.md`'s wire
invariant, `Grappa.Protocol`'s moduledoc, `docs/CLIENT_PROTOCOL.md` (§2 + a new
§2b).

Removal is not "never", it is **"only on a ruling"**, and the bar this case sets
is deliberately high:

- the field must be the thing standing between the server and a property it
  cannot otherwise have;
- the break must be **MEASURED on the real client**, not argued;
- it takes a **ruling**, not a judgement call inside a slice.

Everything short of that is still additive-only. The bar is written down because
the danger is not this removal — it is the next reader taking it as licence to
tidy fields away.

## Test changes

The REV-B/H18 plan test is **deleted, not adapted**: it built the archive SQL by
hand and EXPLAINed its own copy, so from the moment production stopped emitting
that shape it would pin a query nobody runs — the blindness #1372 documented. Its
replacement (`describe "#1626 — list_archive/3 seeks per target, not per row"`)
reads the plan off `capture_one_query/1` — the **singular**, not its plural twin,
because answering in ONE statement is part of the property being pinned. Visitor
arm and unknown-subject arm included.

## What I refuse to assert

Not measured, and not to be inferred from anything above:

- **prod (m42).** Every number is one docker host. The constants do not transfer
  and are not claimed to: this host reads 428.93 ms at the 650k anchor where the
  issue reported 101-104 ms (~4x), against a planner that had a fold covering
  index #1626 may not have had. w2 measured a third set on a third host. What
  reproduces is the shape.
- **the visitor arm's timing.** The SQL is the `visitor_id` mirror and the plan
  test covers it structurally, but no visitor stopwatch was run.
- **cold-cache cost.** Two warm-ups precede every median.
- **the end-to-end HTTP path.** The bench measures the context function.
- **whether 1000 targets is a realistic ceiling.** 178 is the prod-shaped anchor;
  1000 is a stress point. Prod's real target distribution was not sampled.
- **any client-side effect of the removal beyond the schema behaviour above.** No
  cic render was timed; it was never the point.

## Gates

Run from the worktree with absolute `cd` — a cwd slip mid-session ran one Credo
pass against `main` instead of the branch; caught, and redone here.

- `scripts/check.sh` — full, rc captured to a FILE (the background-task
  notification reports the wrapper's rc, not the gate's). The first full run on
  this branch was **rc=1** on four Credo-strict findings — a one-function pipe, a
  `_key` where this codebase names throwaways `_`, and in the bench a `require`
  ahead of its aliases plus single aliases where 116 files in `lib/` use the
  multi form. Fixed in `45c8821b`, then re-run.
- `scripts/design-notes-gate.sh origin/main` — run **after** the commit:
  `1 new entry heading(s), separator and marker present.` — not the empty
  `nothing to check` green. Marker uniqueness checked against `origin/main`'s
  **current tip** with known-answer controls: `#1626` -> 0, a marker known present
  (`#1537`) -> 1, an invented one -> 0.
- `mix grappa.wire_pin --check` — *wire shape and protocol 8 agree.*
- The bench itself — rc=0, **25/25 controls**, re-run against the committed form
  of the harness after the Credo cleanup, and the DESIGN_NOTES table requoted
  from that run rather than from the superseded one.

**Checks expected: 8**, derived by reading the workflows rather than watching a
monitor. `ci.yml` has **no** path filter, so its 4 jobs always run (`test + lint
+ audit`, `shottino (build + tests)`, `dialyzer`, `cicchetto (types + lint +
unit)`). `integration.yml` **is** path-filtered, and this diff touches `lib/**`,
`priv/**` and `cicchetto/src/**` — all three in its list — so its
`shard: [1,2,3,4]` matrix runs too, 4 more jobs.
