### PR TITLE
measure(#1759c): what a cross-user reconnect storm does to the connection pool

### DIFF
--- a/cicchetto/e2e/compose.yaml
+++ b/cicchetto/e2e/compose.yaml
@@ -659,6 +659,11 @@ services:
     working_dir: /work
     environment:
       CI: "1"
+      # #1759c — the SAME value the BEAM booted with, so the measurement
+      # labels its own reading instead of the reader guessing which pool a
+      # number came from. A run that reports a saturation point without
+      # naming the pool it saturated is not a displacement, it is a number.
+      POOL_SIZE: ${POOL_SIZE:-5}
       # The base URL specs hit. `nginx-test` resolves via the docker
       # bridge (alias defined on the nginx-test service above). HTTPS
       # is required for the cic SW + Push API + Notification API to

--- a/cicchetto/e2e/compose.yaml
+++ b/cicchetto/e2e/compose.yaml
@@ -486,6 +486,12 @@ services:
     environment:
       MIX_ENV: dev
       ELIXIR_ERL_OPTIONS: "+fnu"
+      # #1759c — the measurement lever reaching the BEAM. `config/dev.exs`
+      # reads `POOL_SIZE` with a `5` default (the value that was hardcoded
+      # there before), so an unset variable leaves this stack exactly as it
+      # was. Set it to take the same reading at a second pool size, which is
+      # what turns a saturation number into a displacement.
+      POOL_SIZE: ${POOL_SIZE:-5}
       # #485 — self-serve the built SPA from the mounted dist (see volumes).
       CIC_DIST_ROOT: /app/cicchetto-dist
       # Captcha disabled — the test suite drives signup directly via

--- a/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
+++ b/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
@@ -70,7 +70,13 @@ test.describe.configure({ mode: "serial" });
 // The ladder. Powers of two so a linear and a knee-shaped response are
 // distinguishable with few points, and three points minimum because two can
 // be joined by any line.
-const N_LADDER = [1, 2, 4, 8, 16] as const;
+//
+// It runs to 32 because the question is "at what N", and a ladder that stops
+// before the answer produces "not at any N we tried" — true, but weaker than
+// it needs to be. 24 is in there for resolution: the first reading knee'd
+// between 8 and 16, so a doubling-only ladder would place any second knee
+// only to within a factor of two.
+const N_LADDER = [1, 2, 4, 8, 16, 24, 32] as const;
 
 // Windows per subject. Held CONSTANT across the ladder on purpose: N is the
 // lever under test here, and moving both at once would make the response

--- a/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
+++ b/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
@@ -279,14 +279,32 @@ test("#1759c — cross-user join storm vs the connection pool", async ({ page })
     "C1: POST /admin/db_latency/reset did not zero the contention counters — every number below would be an aggregate of somebody else's load",
   ).toBe(0);
 
+  // Provision the whole cohort ONCE, SEQUENTIALLY, and slice it per rung.
+  //
+  // Both properties were bought with a failed run, and neither is tidiness.
+  //
+  // SEQUENTIALLY: minting in parallel is itself a write storm — each mint
+  // logs a visitor in AND spawns a live IRC session — and at `pool_size=5`
+  // the FOURTH concurrent mint came back `503 {"error":"db_unavailable"}`
+  // before the join burst had started. That is a real observation about
+  // cross-user concurrency, but it belongs to the PROVISIONING door, not the
+  // join door this file is measuring, and leaving it in would have let a
+  // setup confound masquerade as the result. It is reported as its own
+  // finding rather than engineered out of sight.
+  //
+  // ONCE: the ladder would otherwise mint 1+2+4+8+16 = 31 visitors and open
+  // 31 IRC sessions to bring 16 subjects to the bench. Reusing one cohort
+  // also holds the SUBJECTS fixed across rungs, so N is the only thing that
+  // moves — which is what makes the response attributable to N.
+  const cohort = [];
+  for (let i = 0; i < Math.max(...N_LADDER); i++) {
+    cohort.push(await mintVisitor(`s1759-${poolSize}-${i}-${Date.now() % 100000}`));
+  }
+
   const rows: string[] = [];
 
   for (const n of N_LADDER) {
-    const visitors = await Promise.all(
-      Array.from({ length: n }, (_, i) =>
-        mintVisitor(`s1759-${poolSize}-${n}-${i}-${Date.now() % 100000}`),
-      ),
-    );
+    const visitors = cohort.slice(0, n);
 
     const sockets = visitors.map((v) => ({
       token: v.token,

--- a/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
+++ b/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
@@ -1,0 +1,343 @@
+// #1759c — does a CROSS-USER reconnect storm saturate the connection pool,
+// and if so at what N?
+//
+// ## Why this exists, and why it could not be an Elixir test
+//
+// #1759's working premise was that one account with W windows produces W
+// SIMULTANEOUS `join_reply` computations. That premise is dead: the transport
+// blocks inside one join until the channel answers
+// (`phoenix/lib/phoenix/socket.ex:739` → `channel/server.ex:40-52`, a bare
+// `receive` with ZERO `after` → `:315-319`, which replies only after
+// `join/3` returns). Per CONNECTION there is at most ONE join in flight.
+//
+// But every connection has its OWN transport process, and the pool is a NODE
+// resource. So if the saturation is real it has to be CROSS-USER — N distinct
+// subjects reconnecting together — and nobody has measured that.
+//
+// `Phoenix.Test.ChannelTest` cannot answer it: it pins `transport_pid: self()`
+// and calls `Channel.Server.join/4` straight from the test process, so it
+// reports "serial" by construction whatever the truth is. An instrument that
+// cannot fail earns no green. This needs REAL, CONCURRENT WebSockets, which
+// is why it lives here and drives raw sockets in a page (the same move
+// `issue95-ws-token-subprotocol.spec.ts` makes) rather than booting N copies
+// of cic — the server cannot tell the two apart, and N browser contexts would
+// buy nothing but wall-clock.
+//
+// ## What is measured, and with what
+//
+// No new instrumentation. `Grappa.DbLatency` already accumulates Ecto's
+// `queue_time` and counts `contention.queue_timeout` — a checkout the pool
+// could not serve, which IS saturation rather than a proxy for it — and
+// `GrappaWeb.Admin.DbLatencyController` already exposes both with a reset.
+// The cycle is reset → drive the burst → snapshot.
+//
+// ## Displacement, not correlation
+//
+// Two levers move, and the reading must follow them or the hypothesis dies:
+//
+//   * **N** (concurrent subjects) — stepped over a ladder inside one run;
+//   * **`pool_size`** — 5 and 10, supplied by the harness through
+//     `POOL_SIZE` (see the `#1759c` lever in `config/dev.exs`). If the
+//     saturation point tracks the pool, the mechanism is the pool. If it does
+//     not move, the pool is not the bottleneck and that is a RESULT.
+//
+// A single reading at a single pool size cannot separate those two, which is
+// the whole reason the lever was added.
+//
+// ## Declared limits — read these before quoting any number
+//
+//   * **The per-join cost here is a FLOOR.** The windows these sockets join
+//     carry no seeded scrollback and no read cursor, so `join_reply/2` does
+//     less arithmetic than a real window does (the same caveat
+//     `GrappaWeb.JoinSeedCostTest`'s cheap arm carries). Saturation seen at
+//     the floor is a strong positive; saturation NOT seen at the floor does
+//     not clear a seeded storm.
+//   * **The host is noisy** — this machine permanently carries unrelated
+//     load. That is a limit on the numbers, and it is NOT offered as an
+//     explanation of them.
+//   * **N is bounded by what the testnet tolerates**, not by the question.
+//     If the ladder runs out before saturation, the report says so; it does
+//     not extrapolate.
+
+import { GRAPPA_BASE_URL, login, mintVisitor } from "../fixtures/grappaApi";
+import { ADMIN_IDENTIFIER, ADMIN_PASSWORD } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// Raw WebSocket construction needs a real socket engine; the iPhone project
+// adds nothing to a server-side pool measurement.
+test.describe.configure({ mode: "serial" });
+
+// The ladder. Powers of two so a linear and a knee-shaped response are
+// distinguishable with few points, and three points minimum because two can
+// be joined by any line.
+const N_LADDER = [1, 2, 4, 8, 16] as const;
+
+// Windows per subject. Held CONSTANT across the ladder on purpose: N is the
+// lever under test here, and moving both at once would make the response
+// unattributable.
+const W = 8;
+
+const BURST_TIMEOUT_MS = 60_000;
+
+type Contention = {
+  n: number;
+  queue_timeout: number;
+  busy_locked: number;
+  interrupted?: number;
+  dropped: number;
+};
+
+type QueryRow = { source: string | null; op: string; n: number; queue_ms: number };
+
+type Snapshot = { queries: QueryRow[]; contention: Contention };
+
+type BurstResult = {
+  socketsOpened: number;
+  socketsFailed: number;
+  joinsOk: number;
+  joinsFailed: number;
+  // The concurrency the CLIENT observed: the high-water mark of sockets
+  // simultaneously open. Without this the run could have been serial and the
+  // whole measurement would be answering a different question.
+  maxConcurrentOpen: number;
+  elapsedMs: number;
+};
+
+async function adminToken(): Promise<string> {
+  const { token } = await login(ADMIN_IDENTIFIER, ADMIN_PASSWORD);
+  return token;
+}
+
+async function resetLatency(token: string): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/db_latency/reset`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (res.status !== 204) {
+    throw new Error(`db_latency reset → ${res.status} ${await res.text()}`);
+  }
+}
+
+async function snapshot(token: string): Promise<Snapshot> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/admin/db_latency`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`db_latency → ${res.status} ${await res.text()}`);
+  return (await res.json()) as Snapshot;
+}
+
+function totalQueueMs(snap: Snapshot): number {
+  return snap.queries.reduce((acc, q) => acc + (q.queue_ms ?? 0), 0);
+}
+
+function totalQueries(snap: Snapshot): number {
+  return snap.queries.reduce((acc, q) => acc + (q.n ?? 0), 0);
+}
+
+// Opens `sockets.length` real WebSockets from the page, waits for every one
+// to be OPEN, and only then fires every join — so the burst is a burst and
+// not a staircase. Returns what the client itself observed, which is the only
+// place the concurrency can be witnessed.
+//
+// The Phoenix v2 transport frame is `[join_ref, ref, topic, event, payload]`;
+// the bearer rides the `base64url.bearer.phx.<token>` subprotocol, which is
+// the production shape (`GrappaWeb.Endpoint`, #95) and not one invented here.
+const BURST = ({
+  sockets,
+  timeoutMs,
+}: {
+  sockets: Array<{ token: string; topics: string[] }>;
+  timeoutMs: number;
+}) =>
+  new Promise<BurstResult>((resolve) => {
+    const started = performance.now();
+    const scheme = location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${scheme}//${location.host}/socket/websocket?vsn=2.0.0`;
+
+    let opened = 0;
+    let failed = 0;
+    let concurrentOpen = 0;
+    let maxConcurrentOpen = 0;
+    let joinsOk = 0;
+    let joinsFailed = 0;
+    const expectedJoins = sockets.reduce((acc, s) => acc + s.topics.length, 0);
+    const live: WebSocket[] = [];
+
+    const finish = () => {
+      for (const ws of live) {
+        try {
+          ws.close();
+        } catch {
+          /* the socket is already gone; nothing to report */
+        }
+      }
+      resolve({
+        socketsOpened: opened,
+        socketsFailed: failed,
+        joinsOk,
+        joinsFailed,
+        maxConcurrentOpen,
+        elapsedMs: Math.round(performance.now() - started),
+      });
+    };
+
+    const timer = setTimeout(finish, timeoutMs);
+
+    const maybeDone = () => {
+      const allAnswered = joinsOk + joinsFailed >= expectedJoins;
+      const nothingOpened = opened === 0 && opened + failed >= sockets.length;
+      if (allAnswered || nothingOpened) {
+        clearTimeout(timer);
+        finish();
+      }
+    };
+
+    // Fire every join only once EVERY socket is open. A staircase would
+    // measure N sequential single-socket bursts, which is the shape this
+    // spec exists to distinguish itself from.
+    const fireAll = () => {
+      sockets.forEach((spec, i) => {
+        const ws = live[i];
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        spec.topics.forEach((topic, j) => {
+          const ref = String(i * 1000 + j);
+          ws.send(JSON.stringify([ref, ref, topic, "phx_join", {}]));
+        });
+      });
+    };
+
+    sockets.forEach((spec, i) => {
+      const ws = new WebSocket(url, [`base64url.bearer.phx.${spec.token}`]);
+      live[i] = ws;
+
+      ws.onopen = () => {
+        opened += 1;
+        concurrentOpen += 1;
+        maxConcurrentOpen = Math.max(maxConcurrentOpen, concurrentOpen);
+        if (opened + failed === sockets.length) fireAll();
+      };
+
+      ws.onclose = () => {
+        concurrentOpen = Math.max(0, concurrentOpen - 1);
+      };
+
+      ws.onerror = () => {
+        failed += 1;
+        if (opened + failed === sockets.length) {
+          if (opened > 0) fireAll();
+          else maybeDone();
+        }
+      };
+
+      ws.onmessage = (event) => {
+        const frame = JSON.parse(String(event.data)) as [
+          string | null,
+          string | null,
+          string,
+          string,
+          { status?: string },
+        ];
+        if (frame[3] !== "phx_reply") return;
+        if (frame[4]?.status === "ok") joinsOk += 1;
+        else joinsFailed += 1;
+        maybeDone();
+      };
+    });
+  });
+
+test("#1759c — cross-user join storm vs the connection pool", async ({ page }) => {
+  const token = await adminToken();
+  const poolSize = Number(process.env.POOL_SIZE ?? "5");
+
+  // Land on the origin so the page's WebSockets are same-origin and reach the
+  // BEAM through the same edge a real client uses.
+  await page.goto("/");
+
+  // ---------------------------------------------------------------------
+  // Known-answer controls. Every one of these must hold BEFORE any number
+  // is believed; the run reports nothing if one fails.
+  // ---------------------------------------------------------------------
+
+  // C1 — the reset door actually zeroes. Without this a "saturation" reading
+  // could be an aggregate accumulated since boot by unrelated specs.
+  await resetLatency(token);
+  const zeroed = await snapshot(token);
+  expect(
+    zeroed.contention.queue_timeout,
+    "C1: POST /admin/db_latency/reset did not zero the contention counters — every number below would be an aggregate of somebody else's load",
+  ).toBe(0);
+
+  const rows: string[] = [];
+
+  for (const n of N_LADDER) {
+    const visitors = await Promise.all(
+      Array.from({ length: n }, (_, i) =>
+        mintVisitor(`s1759-${poolSize}-${n}-${i}-${Date.now() % 100000}`),
+      ),
+    );
+
+    const sockets = visitors.map((v) => ({
+      token: v.token,
+      // A visitor's topic segment is `visitor:<id>` (`UserSocket`
+      // `assign_subject/2`), NOT the nick — read from the server, not guessed.
+      topics: Array.from(
+        { length: W },
+        (_, w) => `grappa:user:visitor:${v.id}/network:${v.network_slug}/channel:%23s1759-${w}`,
+      ),
+    }));
+
+    await resetLatency(token);
+    const burst: BurstResult = await page.evaluate(BURST, {
+      sockets,
+      timeoutMs: BURST_TIMEOUT_MS,
+    });
+    const snap = await snapshot(token);
+
+    // C2 — the instrument SAW the door. A zero here is an instrument fault
+    // (wrong topic, rejected join, counters not wired) and is indistinguishable
+    // from "the door is free", which is the exact false green to avoid.
+    expect(
+      totalQueries(snap),
+      `C2 at N=${n}: the burst produced ZERO queries — the joins never reached join_reply/2, so this is an instrument fault and not a free door`,
+    ).toBeGreaterThan(0);
+
+    // C3 — every join was acknowledged. A burst whose joins were refused did
+    // not happen, and its queue reading would describe nothing.
+    expect(
+      burst.joinsFailed,
+      `C3 at N=${n}: ${burst.joinsFailed} join(s) were refused — the storm did not occur as described`,
+    ).toBe(0);
+    expect(
+      burst.joinsOk,
+      `C3 at N=${n}: expected ${n * W} acknowledged joins, saw ${burst.joinsOk}`,
+    ).toBe(n * W);
+
+    // C4 — the sockets were genuinely CONCURRENT. This is the control that
+    // separates this measurement from the serial one already refuted: if the
+    // high-water mark is 1, the run answered the wrong question.
+    expect(
+      burst.maxConcurrentOpen,
+      `C4 at N=${n}: high-water concurrency was ${burst.maxConcurrentOpen}, so the sockets did not overlap and this is not a cross-user measurement`,
+    ).toBe(n);
+
+    rows.push(
+      [
+        `pool=${poolSize}`,
+        `N=${n}`,
+        `W=${W}`,
+        `joins=${burst.joinsOk}`,
+        `concurrent=${burst.maxConcurrentOpen}`,
+        `elapsed_ms=${burst.elapsedMs}`,
+        `queries=${totalQueries(snap)}`,
+        `queue_ms=${totalQueueMs(snap).toFixed(1)}`,
+        `queue_timeout=${snap.contention.queue_timeout}`,
+        `busy_locked=${snap.contention.busy_locked}`,
+        `dropped=${snap.contention.dropped}`,
+      ].join("  "),
+    );
+  }
+
+  // The reading. Printed only once every control above has held for every
+  // rung, so a number that appears here is one the instrument earned.
+  console.log(`\n#1759c MEASUREMENT (pool_size=${poolSize}, W=${W})\n${rows.join("\n")}\n`);
+});

--- a/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
+++ b/cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts
@@ -139,9 +139,18 @@ function totalQueries(snap: Snapshot): number {
 // not a staircase. Returns what the client itself observed, which is the only
 // place the concurrency can be witnessed.
 //
-// The Phoenix v2 transport frame is `[join_ref, ref, topic, event, payload]`;
-// the bearer rides the `base64url.bearer.phx.<token>` subprotocol, which is
-// the production shape (`GrappaWeb.Endpoint`, #95) and not one invented here.
+// The Phoenix v2 transport frame is `[join_ref, ref, topic, event, payload]`.
+//
+// The handshake is copied from the library rather than from the prose about
+// it. `phoenix/priv/static/phoenix.mjs:1353` builds
+//
+//     ["phoenix", `base64url.bearer.phx.${btoa(token).replace(/=/g, "")}`]
+//
+// and all three details are load-bearing: TWO protocols with `"phoenix"`
+// FIRST, and the token base64'd with its `=` padding stripped. A first
+// attempt here passed one protocol carrying the RAW token — the shape the
+// #95 comments describe in words — and every handshake was refused, which
+// C3a below now names in one line instead of leaving it as "0 joins".
 const BURST = ({
   sockets,
   timeoutMs,
@@ -207,7 +216,10 @@ const BURST = ({
     };
 
     sockets.forEach((spec, i) => {
-      const ws = new WebSocket(url, [`base64url.bearer.phx.${spec.token}`]);
+      const ws = new WebSocket(url, [
+        "phoenix",
+        `base64url.bearer.phx.${btoa(spec.token).replace(/=/g, "")}`,
+      ]);
       live[i] = ws;
 
       ws.onopen = () => {
@@ -300,6 +312,17 @@ test("#1759c — cross-user join storm vs the connection pool", async ({ page })
       totalQueries(snap),
       `C2 at N=${n}: the burst produced ZERO queries — the joins never reached join_reply/2, so this is an instrument fault and not a free door`,
     ).toBeGreaterThan(0);
+
+    // C3a — the sockets HANDSHOOK. Split out from C3 because the two fail
+    // for completely different reasons and the combined form hid it: the
+    // first run of this file reported "expected 8 acknowledged joins, saw 0"
+    // when the truth was that not one socket had opened, because the bearer
+    // subprotocol was built by hand instead of copied from phoenix.js. A
+    // control that names the wrong layer costs a whole run.
+    expect(
+      burst.socketsOpened,
+      `C3a at N=${n}: ${burst.socketsFailed} of ${n} WebSocket handshake(s) were refused — the bearer subprotocol or the origin is wrong, and nothing about the pool has been measured`,
+    ).toBe(n);
 
     // C3 — every join was acknowledged. A burst whose joins were refused did
     // not happen, and its queue reading would describe nothing.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,7 +16,23 @@ config :grappa, :incognito_close_grace_ms, 2_000
 
 config :grappa, Grappa.Repo,
   database: Path.expand("../runtime/grappa_dev.db", __DIR__),
-  pool_size: 5,
+  # #1759c — a MEASUREMENT LEVER, not a behaviour change and not a cure.
+  #
+  # `config/runtime.exs:187` already reads `POOL_SIZE` this way, but that
+  # block is gated on `config_env() == :prod` (`:137`), and the e2e stack
+  # runs `MIX_ENV: dev` (`cicchetto/e2e/compose.yaml:61`). So the pool the
+  # e2e suite exercises was a literal `5` that nothing could move — and a
+  # question of the form "at what N does a `pool_size: 10` pool saturate?"
+  # could only have been answered at HALF the production pool and then
+  # extrapolated, which is the one move the investigation is not allowed.
+  #
+  # The default is `5`, so an unset environment is byte-for-byte the
+  # behaviour that shipped before this line. What it buys is the ability to
+  # take the SAME reading at two pool sizes: if the saturation point tracks
+  # the pool, the mechanism is the pool; if it does not, the hypothesis is
+  # dead and that is a result. A lever that only ever reads one value cannot
+  # tell those two apart.
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
   # CP24 cluster `post-cr-review` bucket B, persistence/S2: mirror prod's
   # 30s busy_timeout so iex sessions + integration scripts hit the same
   # "database is locked" cushion as prod. Default ~2s otherwise.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41696,3 +41696,103 @@ plausible table. When a wire field is what blocks a property, the question is
 not "can this be removed" but "who ruled, and what did the real client do when
 it went" — and a version floor answers a session-wide question, so never raise
 it to describe one endpoint.
+<!-- entry #1759c -->
+
+---
+
+## 2026-08-26 — #1759c: the pool queues under a cross-user storm, and never gives up
+
+**Context.** #1759 was filed on the premise that one account with W windows
+produces W SIMULTANEOUS `join_reply` computations, and that this is what
+saturated the pool. That premise is dead. Phoenix's dispatch blocks the
+transport inside a join until the channel answers — `socket.ex:739` matches
+the RETURN of `Channel.Server.join/4`, which parks in a bare `receive` with
+**zero** `after` clauses (`channel/server.ex:40-52`) until the channel has
+run `join/3` to completion and replied (`:315-319`). Per CONNECTION there is
+at most one join in flight, so a same-account storm is SERIAL.
+
+The refutation is per-connection and nothing more: every connection has its
+own transport process and the pool is a NODE resource. So the surviving form
+of the hypothesis is CROSS-USER — N subjects reconnecting together — and it
+had never been measured. This entry records that measurement.
+
+### The instrument, and why it is not an Elixir test
+
+`Phoenix.Test.ChannelTest` pins `transport_pid: self()` and calls
+`Channel.Server.join/4` from the test process. Any concurrency statistic
+taken there reports "serial" whatever the truth is, because the test
+sequenced the joins. An instrument that cannot fail earns no green, so the
+bench is e2e: `issue1759-cross-user-join-storm.spec.ts` opens N REAL
+WebSockets from a page, waits for all of them to be OPEN, and only then
+fires every join, so the burst is a burst and not a staircase.
+
+No new instrumentation was written. `Grappa.DbLatency` already accumulates
+Ecto's `queue_time` and counts `contention.queue_timeout` — a checkout the
+pool REFUSED, which is saturation itself rather than a proxy — and the admin
+controller already exposes it with a reset.
+
+`pool_size` had to be made movable first: `config/runtime.exs` reads
+`POOL_SIZE`, but that block is `config_env() == :prod` and the e2e stack
+boots `MIX_ENV: dev`, where the value was a literal `5`. `config/dev.exs` now
+mirrors prod with a `5` default, so unset is byte-for-byte the old behaviour.
+A lever that reads one value cannot displace anything.
+
+### What was measured
+
+Four runs, all green, controls held at every rung. W=8 windows per subject;
+`queue_ms` is the SUM over the rung, `mean` is per query.
+
+| N | queries | queue_ms @5 | mean @5 | queue_ms @10 | mean @10 |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 61 | 1.1 | 0.018 | 1.1 | 0.019 |
+| 2 | 115 | 1.8 | 0.016 | 1.8 | 0.016 |
+| 4 | 228 | 3.9 | 0.017 | 4.4 | 0.019 |
+| 8 | 454 | 197.5 | 0.435 | 14.7 | 0.032 |
+| 16 | 908 | 1831.8 | 2.017 | 928.5 | 1.022 |
+| 24 | 1356 | 4284.8 | 3.160 | 2826.8 | 2.085 |
+| 32 | 1804 | 7694.4 | 4.265 | 5339.8 | 2.960 |
+
+**The work is identical at both pool sizes** — the query counts match rung by
+rung. Only the WAITING moved, which is what makes the rest a displacement and
+not a coincidence.
+
+**The knee is at N=8 and it tracks the pool**: 0.435 ms → 0.032 ms mean queue
+for a 2x pool, a 13.6x drop for the same work. There the pool IS the
+mechanism.
+
+**Past the knee the pool stops explaining it.** Doubling buys 1.97x at N=16,
+1.52x at N=24 and 1.44x at N=32. Something else co-limits and this
+measurement does not name it; SQLite's single-writer file lock, CPU and host
+noise are candidates, none of them measured.
+
+🔴 **`queue_timeout` is ZERO at every rung, at both pool sizes, in all four
+runs.** At N=32 that is 256 concurrent joins and 1804 queries against a pool
+of five, with 7.7 s of accumulated queue time, and not one checkout refused.
+**No saturation point exists at any N this bench can drive.** That is the
+result, and it is worth the same as a positive: the pool queues, it does not
+give up.
+
+**Unplanned cross-validation.** Queries per subject is 1804/32 = 56.4, i.e.
+`7·W` at W=8. `GrappaWeb.JoinSeedCostTest`'s post-mitigation law `7·W + 1`
+reproduces through a real browser over a real socket, from an instrument
+built independently and never fitted to it.
+
+### What this does NOT establish
+
+The measurement says the pool queues under cross-user load. It does **not**
+say that queueing caused either production incident, and no cure follows from
+it. The windows carry no seeded scrollback or read cursor, so the per-join
+cost here is a **FLOOR** — the absence of a timeout does not clear a seeded
+storm. The readings are the e2e stack's `MIX_ENV=dev` pool at 5 and 10; prod's
+10 is the same number on a different machine and nothing is transferred. The
+host carries permanent unrelated load, which bounds every absolute figure and
+is offered as a limit, never as an explanation. `elapsed_ms` plateaus near
+5.3 s at N=24 and N=32 on both pools and is not interpreted.
+
+**Apply:** when a concurrency premise is refuted, check whether the
+refutation's PERIMETER leaves the hypothesis alive somewhere else before
+declaring the question closed — here it survived one layer out, at a
+different granularity. And before asking "at what N does X saturate", check
+that the environment can express the lever: a number measured at half the
+production pool reads as the production number, and multiplying it is the
+extrapolation the question was asked to avoid.


### PR DESCRIPTION
Measurement for #1759. **This is a measurement, not a cure** — no fix for #1759 is proposed here, and nothing about the join door or the who-closes-the-socket half is touched.

## The question

#1759's working premise was that one account with W windows produces W *simultaneous* `join_reply` computations. That premise is dead: the transport blocks inside one join until the channel answers (`phoenix/lib/phoenix/socket.ex:739` → `channel/server.ex:40-52`, a bare `receive` with zero `after`), so per connection there is at most ONE join in flight.

But every connection has its own transport process and the pool is a *node* resource. So if the saturation is real it has to be CROSS-USER — N distinct subjects reconnecting together — and nobody had measured that.

`Phoenix.Test.ChannelTest` cannot answer it: it pins `transport_pid: self()` and calls `Channel.Server.join/4` from the test process, so it reports "serial" by construction whatever the truth is. An instrument that cannot fail earns no green. Hence a real browser driving N real, concurrent WebSockets.

## Result — the load-bearing finding is a NEGATIVE

W = 8 windows per subject. `queue_ms` is the SUM over the rung; `media` is per query.

| N | queries | queue_ms @5 | mean @5 | queue_ms @10 | mean @10 | queue_timeout |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 61 | 1.1 | 0.018 | 1.1 | 0.019 | 0 |
| 2 | 115 | 1.8 | 0.016 | 1.8 | 0.016 | 0 |
| 4 | 228 | 3.9 | 0.017 | 4.4 | 0.019 | 0 |
| 8 | 454 | **197.5** | **0.435** | **14.7** | **0.032** | 0 |
| 16 | 908 | 1831.8 | 2.017 | 928.5 | 1.022 | 0 |
| 24 | 1356 | 4284.8 | 3.160 | 2826.8 | 2.085 | 0 |
| 32 | 1804 | 7694.4 | 4.265 | 5339.8 | 2.960 | 0 |

**`queue_timeout` = 0 at every rung, at BOTH pool sizes, in all four runs.** At N=32 that is 256 concurrent joins and 1804 queries against a pool of five, with 7.7 s of accumulated queueing — and not one refused checkout. **There is no saturation point this bench can drive.** The pool queues; it does not give up. That closes a hypothesis which would otherwise be re-guessed forever, and it is worth as much as a positive would have been.

`concurrent == N` at every rung (control C4), so the sockets genuinely overlapped — the property `ChannelTest` cannot witness.

### The knee follows the pool — that is the displacement

At N=8 the mean goes **0.435 → 0.032 ms** for a doubled pool: **13.6×** for the same work. The query counts coincide rung for rung across the two pools, so only the WAIT moved, never the WORK. That is what makes it a displacement rather than a correlation.

### Past the knee, the pool stops explaining

Doubling it buys **1.97× at N=16**, **1.52× at N=24**, **1.44× at N=32**. Something else co-limits and it is **not identified**. Named, not measured: SQLite's single-writer lock, CPU, host noise.

### Unplanned cross-validation

Queries per subject = 1804/32 = **56.4** = `7·W` with W=8. The post-mitigation law from the Elixir bench (`7·W + 1`, `GrappaWeb.JoinSeedCostTest`) reproduces through a real browser over a real socket, from an independently built instrument that was never calibrated against it.

## What this does NOT claim

1. That queueing **caused** the production incidents. It does not follow, and **no cure descends from this slice**.
2. The per-join cost here is a **FLOOR**: these windows carry no scrollback and no read cursor, so the absence of timeouts does **not** clear a seeded burst.
3. Pools 5 and 10 are the e2e stack's, under `MIX_ENV=dev`. Production's 10 is the same NUMBER on a different machine: nothing is transferred.
4. `elapsed_ms` plateaus at ~5.3 s at N=24 and N=32 on both pools. **Not interpreted.**
5. The host is noisy (permanent unrelated load). That is a LIMIT on the numbers, never an explanation of them.
6. The co-limiter past the knee is **named, not diagnosed**.

## The `POOL_SIZE` lever

`c173f0cc` is deliberately a separate commit. `config/runtime.exs:187` already resolves the pool from `POOL_SIZE`, but that block is gated on `config_env() == :prod` while the e2e stack boots `MIX_ENV: dev` — so the pool the suite exercised was an immovable literal `5`, half of production's `10`.

* It is a **MEASUREMENT LEVER, never a cure for #1759.**
* Default is `5`, so an unset environment reproduces today's behaviour byte for byte; the compose passthrough is `${POOL_SIZE:-5}` for both the BEAM and the runner.
* One reading at one pool size cannot separate "the pool is the bottleneck" from "something else is, and the pool happened to be there". Two readings can.

🔴 **Deploy classification: COLD.** This edits `config/*.exs`, which the release reads at boot.

## Two reds that were results

1. **C3 refused to print** with zero ACKed joins: the subprotocol had been built from the *prose* of #95's comments. `phoenix.mjs:1353` wants TWO protocols, `"phoenix"` first, and the `btoa()` token with `=` padding stripped. C3a was added because C3 named the wrong layer.
2. **The setup saturated on its own**: at rung N=4 the fourth concurrent `mintVisitor` took `503 db_unavailable` *before* the burst. The cohort is now built once and in sequence. The datum is **kept, not hidden** — but it is the PROVISIONING door, not the join door, and `db_unavailable` covers both `queue_timeout` and the SQLite lock, so it is **not attributed**.

## Gates

* `scripts/check.sh` — **rc=0**: 8 doctests, 62 properties, **6919 tests, 0 failures**; Dialyzer `Total errors: 0`; Credo strict `found no issues`; `mix deps.audit` clean; Doctor passed; Sobelow low-confidence only.
* `scripts/bun.sh run check` — 5 stages, 0 failed.
* `scripts/design-notes-gate.sh` — 1 new entry, separator and marker present.
* `scripts/integration.sh` (**full suite**, no `--grep`, `POOL_SIZE` unset) — `795 passed, 1 failed (32.7m)`.

**The one red, and why it is not this branch.** `p0b-peer-away` died in the shared `loginAs` boot barrier (`.sidebar-network-header`, 10 s), not in its own assertion. The BEAM log names the cause: a single `SQLite write lock held by another writer for 31842ms` → `503 :db_unavailable` on cic's boot fetch, one occurrence in the whole 32.7-minute run, inside the failing test's window. Triaged per `docs/TESTING.md`:

* iso-rerun ×3 → **3 passed (29.0s)**;
* the storm spec run ADJACENT to `p0b` (where any damage would be freshest) → **2 passed (36.4s)**; in the full suite the storm spec is #195 and passes, while `p0b` fails at #549, 354 tests later;
* the branch touches none of `Vhosts` / `LockWatch` / `BusyRetry`, and with `POOL_SIZE` unset the pool is the same literal `5`.

## Reviewing

The measurement lives in `cicchetto/e2e/tests/issue1759-cross-user-join-storm.spec.ts`. No new instrumentation: `Grappa.DbLatency` already accumulates Ecto's `queue_time` and counts `contention.queue_timeout`, and `GrappaWeb.Admin.DbLatencyController` already exposes both with a reset. Four known-answer controls gate every rung and nothing prints if one fails — the reset actually zeroes, the burst produced queries at all, every join was ACKed, and the sockets genuinely overlapped.
