### PR TITLE
test(#1767): measure what the lock_watch stall IS, and refute both cures

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41796,3 +41796,131 @@ different granularity. And before asking "at what N does X saturate", check
 that the environment can express the lever: a number measured at half the
 production pool reads as the production number, and multiplying it is the
 extrapolation the question was asked to avoid.
+<!-- entry #1767b -->
+
+---
+
+## 2026-08-26 — #1767b: the stall IS the parked waiter's budget, and both cures are measured to fail
+
+`lock_watch_test.exs` turns main red at roughly one run in three to one in
+ten, with a single test consuming 54.7-129.4 s against a body that costs
+15-378 ms. This pass did not fix it. It established what the number IS,
+refuted the two cures that present themselves, and falsified the two
+premises the round was dispatched on. All of that is worth more than a
+guess, and none of it is a cure.
+
+### The instrument first, because the old one could not place the number
+
+Three separate lies had to come out of the filmer before any reading could
+be trusted, and each was found by adding a second way to measure the same
+thing.
+
+`SAMPLER STARVED` divided a numerator bounded by the target's LIFETIME by a
+denominator spanning setup, body AND teardown: `collected` only counts ticks
+that find the target alive, and ExUnit runs `on_exit` in a SEPARATE process,
+so every tick of the teardown is uncollectable by construction. The line
+therefore fired on any long teardown and then made a claim about the VM. A
+quiet host, on a PASSING run, printed `1 collected / 218 expected` over
+54718 ms. The loop now counts its OWN turns; a tick that finds nothing alive
+is a different line.
+
+`reductions: X -> X (+0)` came from ONE sample, where `hd` and `List.last`
+are the same element — a value differenced against itself, rendered in the
+exact notation a reader uses for "this process ran no code". The registered
+diagnosis of #1767 rested on one of those.
+
+`elapsed_ms` ran from `setup` to the printing hook and so conflated setup,
+body and teardown in one number. `TARGET GONE` could say the time was
+outside the body but not HOW MUCH, because a ratio is not a duration. The
+filmer now monitors its target and stamps the instant it dies, which turns
+that heuristic into a clock — and the clock immediately caught its own
+neighbour: `film_collect/2` stops appending at `@film_max_samples`, so past
+the cap `TARGET GONE` fires unconditionally. A real 129406 ms run printed
+`TARGET GONE for 257 of 507 ticks` three lines above `teardown 15ms`.
+
+The split has a bias that cannot be engineered away and is DECLARED instead:
+the stamp is taken when the filmer HANDLES the DOWN, not when it arrives, so
+a starved filmer reads the boundary late and understates teardown. A stall
+wide enough to starve the filmer starves anything that would time it.
+
+### The measurement: the stall is the waiter's `busy_timeout`, 1:1
+
+`@waiter_budget_ms` is `@test_timeout_ms * 2` = 120 000, used as the private
+repo's `busy_timeout`, so the queued writer sits inside exqlite's dirty-IO
+`execute/2` for up to two minutes. Two batches on a quiet host, same tree,
+same command, only that constant moved:
+
+| `@waiter_budget_ms` | hits | stalled test `elapsed_ms` |
+|---|---|---|
+| 120 000 | 3 of 10 runs | 128 501 / 128 960 / 129 406 |
+| 30 000 | 2 of 14 runs | 42 255 / 42 238 |
+
+Removing 90 000 ms of budget removed 86 722 ms of stall — a ratio of
+**0.96**. The stall is the parked NIF's lifetime, which is the same 1:1
+identity #1715's third retraction found for its own harness, arrived at
+independently here.
+
+The split places it differently on different runs and the total does not
+move: `setup+body 60004 | teardown 68497` on one (ExUnit's deadline DID cut,
+and the teardown then ate the rest of the budget), `setup+body 129391 |
+teardown 15` on another. Whichever half blocks, it blocks until the NIF
+returns.
+
+### The victim is a `receive` timeout, and it is not CPU starvation
+
+On the best-filmed hit the reel ran 507 of 517 due turns while the test
+process accrued 249 reductions across 250 samples — one per sample, which is
+the cost of the filmer's own `process_info` signal. So the test process ran
+no code of its own for ~63 s **while the VM scheduled another process in the
+same run normally**. That rules out host-wide CPU starvation, which is the
+reading a single stack sample invites.
+
+Where it sat is the sharp part: `assert_receive {:DOWN, ^holder_ref, ...},
+5_000` and its 10 000 ms sibling, `status: waiting`, for tens of seconds
+past their own timeouts. A `receive after` that overruns by up to 119 s, in
+a VM that is scheduling normally, is not a slow assertion.
+
+### Both cures are refuted, and they are refuted in opposite directions
+
+Lowering the budget is the obvious move and it was measured: at 30 000 the
+waiter's `BEGIN IMMEDIATE` gives up before the test can observe it, the
+writer dies `SQLITE_BUSY` instead of `:normal`, and
+`assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}` fails with
+an empty mailbox — which is exactly the #1687 symptom the `* 2` was written
+to prevent. Raising ExUnit's deadline is the other side and is barred: it
+does not shorten a stall, it only stops it being reported.
+
+So the two clocks pinch, and the pinch is not resolved by choosing a number
+for either. The budget must exceed what the test needs (#1687) and must not
+exceed the deadline (#1767), and under a stall the test's need BECOMES the
+stall, so no value satisfies both. Naming that is the result; inventing a
+third number would not be.
+
+### Two briefed premises, falsified before they were built on
+
+The round was dispatched to bench a parked COMMIT, on a field log showing
+`Exqlite.Connection.handle_transaction/3` under `DBConnection.run_commit/3`.
+Re-read, the same log shows the `commit` at **`db=6.7ms`** and the 31 840 ms
+on the UPDATE statement before it; the frame comes from the pool's
+15 000 ms ownership timeout sampling the client, 12 ms after the commit had
+already returned. A stack sample lands wherever the machine stopped — the
+same correction this file's own moduledoc already records for a different
+frame. There was no parked COMMIT to bench.
+
+The second premise was that the parked-NIF bench was still open. #1715's
+round 4 ran the full 2x2x2 across {word-sized, literal-bearing put} x {dirty
+NIF parked, not} x {concurrent code load, not}, v1 through v8, roughly 38 M
+timed puts, and nothing came within three orders of magnitude of the field.
+A ninth configuration would have been a repeat round. What this pass adds
+instead is a REPRODUCER at 3-in-10 in the tree, which is the thing round 4
+said it could not build — and its victim is a `receive` timeout, not a
+`persistent_term:put`, so it is a different leg of the same family.
+
+**Apply:** when an instrument reports one number for a window containing
+several phases, the first bug is the instrument, not the system. Three
+readings in a row here were artefacts of the measurement, and each was found
+by adding a SECOND way to measure the same quantity and letting the two
+contradict each other — a ratio against a clock, a derivative against a
+sample count, a cap against a stamp. And a cure that moves a constant should
+be measured in BOTH directions before it is proposed: this one is a pinch
+between two clocks, and each direction restores the other's bug.

--- a/test/bench_1767.exs
+++ b/test/bench_1767.exs
@@ -95,7 +95,7 @@ time_puts = fn label, n ->
       t
     end
 
-  %{label: label, max_us: Enum.max(us), median_us: Enum.sort(us) |> Enum.at(div(n, 2))}
+  %{label: label, max_us: Enum.max(us), median_us: Enum.at(Enum.sort(us), div(n, 2))}
 end
 
 {:ok, ledger} = Agent.start_link(fn -> [] end)

--- a/test/bench_1767.exs
+++ b/test/bench_1767.exs
@@ -1,0 +1,214 @@
+# Bench for #1767 — does a dirty SQLite NIF parked on a contended write
+# lock actually block `:persistent_term.put/2` in this file's topology?
+#
+#   ./scripts/mix.sh --env=dev run --no-start test/bench_1767.exs
+#
+# WHY THIS EXISTS. `lock_watch_test.exs` calls `LockWatch.put_test_enabled/1`
+# — which is `:persistent_term.put/2` (`lock_watch.ex:392`) — in `setup` AND
+# in `on_exit`, once per test, in the one file whose whole purpose is parking
+# a writer on a contended `BEGIN IMMEDIATE`. CLAUDE.md's #1715 entry says a
+# dirty NIF parked on a SQLite write-lock blocks EVERY `persistent_term`
+# write for the whole wait, word-sized ones included — and says in the same
+# breath that the mechanism was measured in the field and NEVER reproduced on
+# a bench, with its final causal link INFERRED. This is that bench.
+#
+# It is a falsification attempt, not a demonstration: a null result kills the
+# hypothesis that #1767's missing time sits in those two puts, and that is
+# worth as much as a positive.
+#
+# EVERY NUMBER IS GATED on known-answer controls. Nothing prints if one fails.
+
+db = "/tmp/bench_1767.db"
+for suffix <- ["", "-wal", "-shm"], do: File.rm(db <> suffix)
+
+{:ok, _} = Application.ensure_all_started(:ecto_sql)
+{:ok, _} = Application.ensure_all_started(:exqlite)
+
+defmodule TmpRepo do
+  @moduledoc false
+  use Ecto.Repo, otp_app: :grappa, adapter: Ecto.Adapters.SQLite3
+end
+
+# The same shape `lock_watch_test.exs` builds: pool_size 2 so two writers can
+# genuinely contend, and a busy_timeout long enough that the waiter is still
+# WAITING while we measure rather than erroring out.
+busy_timeout_ms = 20_000
+
+{:ok, _} =
+  TmpRepo.start_link(
+    database: db,
+    pool_size: 2,
+    busy_timeout: busy_timeout_ms,
+    journal_mode: :wal,
+    log: false
+  )
+
+TmpRepo.query!("CREATE TABLE t(id integer)")
+
+parent = self()
+
+# A writer that takes RESERVED and parks, exactly like the test file's
+# `unobserved_write/2`: `timeout: :infinity` so the pool's 15s checkout
+# deadline is not the thing we end up measuring.
+park = fn id ->
+  spawn(fn ->
+    TmpRepo.transaction(
+      fn ->
+        TmpRepo.query!("INSERT INTO t VALUES (?)", [id], log: false)
+        send(parent, {:holding, self()})
+
+        receive do
+          :release -> :ok
+        end
+      end,
+      mode: :immediate,
+      timeout: :infinity
+    )
+  end)
+end
+
+# A writer that just tries to BEGIN IMMEDIATE and therefore parks INSIDE the
+# dirty NIF on SQLite's busy handler. It never reports, by construction —
+# that silence is what the control below checks.
+contend = fn id ->
+  spawn(fn ->
+    TmpRepo.transaction(
+      fn ->
+        TmpRepo.query!("INSERT INTO t VALUES (?)", [id], log: false)
+        send(parent, {:got_through, self()})
+      end,
+      mode: :immediate,
+      timeout: :infinity
+    )
+  end)
+end
+
+# `put` a WORD-SIZED value: CLAUDE.md singles those out as the surprising
+# case, because they trigger no global GC of their own and the shipped docs
+# do not lead you to expect them to queue behind somebody else's.
+time_puts = fn label, n ->
+  us =
+    for i <- 1..n do
+      key = {:bench_1767, label, i}
+      {t, :ok} = :timer.tc(fn -> :persistent_term.put(key, i) end)
+      :persistent_term.erase(key)
+      t
+    end
+
+  %{label: label, max_us: Enum.max(us), median_us: Enum.sort(us) |> Enum.at(div(n, 2))}
+end
+
+{:ok, ledger} = Agent.start_link(fn -> [] end)
+control = fn name, ok?, detail -> Agent.update(ledger, &[{name, ok?, detail} | &1]) end
+
+# ── BASELINE: no contention at all ───────────────────────────────────
+baseline = time_puts.(:baseline, 20)
+
+# ── CONTENDED: one holder parked, one writer inside the busy handler ──
+holder = park.(1)
+
+holder_ok? =
+  receive do
+    {:holding, ^holder} -> true
+  after
+    5_000 -> false
+  end
+
+control.("the holder took RESERVED and parked", holder_ok?, "no {:holding, holder} within 5s")
+
+waiter = contend.(2)
+
+# Give the waiter time to reach BEGIN IMMEDIATE and enter the busy handler.
+Process.sleep(500)
+
+# CONTROL (known answer): the waiter must still be BLOCKED. If it got
+# through, there is no contention and every number below measures nothing.
+got_through? =
+  receive do
+    {:got_through, ^waiter} -> true
+  after
+    0 -> false
+  end
+
+control.(
+  "the waiter is still blocked in BEGIN IMMEDIATE",
+  not got_through?,
+  "the waiter got through — no contention was measured"
+)
+
+# CONTROL (known answer): and it must be alive to be blocked.
+control.("the waiter process is alive", Process.alive?(waiter), "the waiter died instead of waiting")
+
+contended = time_puts.(:contended, 20)
+
+# ── RELEASE and re-measure: the recovery is what makes it causal ──────
+send(holder, :release)
+
+drained? =
+  receive do
+    {:got_through, ^waiter} -> true
+  after
+    busy_timeout_ms -> false
+  end
+
+control.("releasing the holder let the waiter through", drained?, "the waiter never got through after release")
+
+after_release = time_puts.(:after_release, 20)
+
+# CONTROL (instrument): the timer must be able to see a delay at all.
+{slow_us, _} = :timer.tc(fn -> Process.sleep(50) end)
+control.("the timer can see a 50ms delay", slow_us > 40_000, "timer read #{slow_us}us for a 50ms sleep")
+
+controls = ledger |> Agent.get(& &1) |> Enum.reverse()
+failed = Enum.reject(controls, fn {_, ok?, _} -> ok? end)
+
+if failed != [] do
+  IO.puts("\n!! CONTROLS FAILED — no measurement printed")
+  for {name, _, detail} <- failed, do: IO.puts("   FAIL #{name}\n        #{detail}")
+  System.halt(1)
+end
+
+IO.puts("\n== CONTROLS: #{length(controls)}/#{length(controls)} passed")
+for {name, _, _} <- controls, do: IO.puts("   ok  #{name}")
+
+IO.puts("\n== :persistent_term.put/2, 20 word-sized puts per phase")
+IO.puts("phase          | median us | max us")
+
+for m <- [baseline, contended, after_release] do
+  IO.puts(
+    "#{String.pad_trailing(to_string(m.label), 14)} | " <>
+      "#{String.pad_trailing(to_string(m.median_us), 9)} | #{m.max_us}"
+  )
+end
+
+IO.puts("\n== VERDICT")
+
+# The bar is NOT a multiple of the idle cost. A ratio between microsecond
+# quantities is noise with an opinion: 5us -> 385us is 77x and explains
+# nothing. The hypothesis under test is that these puts hold the tens of
+# SECONDS #1767 cannot account for, so the comparison has to be against the
+# WAIT the put is supposed to be trapped behind.
+wait_us = busy_timeout_ms * 1000
+holds_the_wait? = contended.max_us > div(wait_us, 2)
+measurable_tail? = contended.max_us > 10 * max(baseline.max_us, 1)
+
+IO.puts(
+  cond do
+    holds_the_wait? ->
+      "BLOCKS FOR THE WAIT: worst contended put #{contended.max_us}us against a " <>
+        "#{wait_us}us busy_timeout — a put really is trapped behind the parked NIF."
+
+    measurable_tail? ->
+      "TAIL, NOT A BLOCK: worst contended put #{contended.max_us}us vs #{baseline.max_us}us " <>
+        "idle — a real contention-correlated tail, and #{Float.round(contended.max_us / wait_us * 100, 4)}% " <>
+        "of the #{div(wait_us, 1000)}ms wait it would have to hold.\n" <>
+        "REFUTES the hypothesis that #1767's missing tens of seconds sit in these puts.\n" <>
+        "It does NOT refute #1715, whose field mechanism was a COMMIT and not a busy-handler wait."
+
+    true ->
+      "NOT BLOCKED: worst contended put #{contended.max_us}us vs #{baseline.max_us}us idle,\n" <>
+        "no contention-correlated tail at all."
+  end
+)
+
+IO.puts("\n== done")

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -527,11 +527,11 @@ defmodule Grappa.Repo.LockWatchTest do
     end
 
     test "a test under the threshold films silently" do
-      assert film_verdict(:under, samples(20, 1_000), 20, true, @film_threshold_ms - 1) == :silent
+      assert film_verdict(:under, samples(20, 1_000), 20, true, @film_threshold_ms - 1, nil) == :silent
     end
 
     test "a test over the threshold reports the trajectory, and names the test" do
-      assert {:report, text} = film_verdict(:over, samples(20, 1_000), 20, true, @film_threshold_ms)
+      assert {:report, text} = film_verdict(:over, samples(20, 1_000), 20, true, @film_threshold_ms, nil)
 
       assert text =~ "#1767 FILM"
       assert text =~ "test=:over"
@@ -548,7 +548,7 @@ defmodule Grappa.Repo.LockWatchTest do
     test "an over-threshold test with no samples says so instead of printing an empty film" do
       # Noisy blindness: a film with nothing in it reads as "the test was
       # idle", which is the one conclusion the filmer must never invite.
-      assert {:report, text} = film_verdict(:empty, [], 12, true, @film_threshold_ms)
+      assert {:report, text} = film_verdict(:empty, [], 12, true, @film_threshold_ms, nil)
 
       assert text =~ "NO SAMPLES"
     end
@@ -556,7 +556,7 @@ defmodule Grappa.Repo.LockWatchTest do
     test "a broken sampler is reported even under the threshold, and produces no film" do
       # A plausible film from a sampler that cannot read a stack is worse
       # than no film: it would be believed.
-      assert {:report, text} = film_verdict(:broken, samples(20, 1_000), 20, false, 0)
+      assert {:report, text} = film_verdict(:broken, samples(20, 1_000), 20, false, 0, nil)
 
       assert text =~ "SAMPLER BROKEN"
       refute text =~ "reductions:"
@@ -572,19 +572,19 @@ defmodule Grappa.Repo.LockWatchTest do
       expected = div(@film_threshold_ms, @film_interval_ms)
 
       # Starved: the filmer itself barely ran. That IS a VM reading.
-      assert {:report, starved} = film_verdict(:starved, samples(1, 1_000), 1, true, @film_threshold_ms)
+      assert {:report, starved} = film_verdict(:starved, samples(1, 1_000), 1, true, @film_threshold_ms, nil)
       assert starved =~ "SAMPLER STARVED"
       assert starved =~ "1 of #{expected}"
 
       # NOT starved: the filmer took every turn it was due and found the target
       # gone for almost all of them. Same single sample, opposite verdict —
       # which is the whole point of splitting the two counters.
-      assert {:report, gone} = film_verdict(:gone, samples(1, 1_000), expected, true, @film_threshold_ms)
+      assert {:report, gone} = film_verdict(:gone, samples(1, 1_000), expected, true, @film_threshold_ms, nil)
       refute gone =~ "SAMPLER STARVED"
       assert gone =~ "TARGET GONE"
 
       assert {:report, full} =
-               film_verdict(:full, samples(expected, 1_000), expected, true, @film_threshold_ms)
+               film_verdict(:full, samples(expected, 1_000), expected, true, @film_threshold_ms, nil)
 
       refute full =~ "SAMPLER STARVED"
       refute full =~ "TARGET GONE"
@@ -594,7 +594,7 @@ defmodule Grappa.Repo.LockWatchTest do
       # The vacuous statistic behind #1767's registered diagnosis: with one
       # sample `hd` and `List.last` are the same element, so the old line read
       # `X -> X (+0)` — indistinguishable from a genuinely frozen process.
-      assert {:report, one} = film_verdict(:one, samples(1, 1_000), 1, true, @film_threshold_ms)
+      assert {:report, one} = film_verdict(:one, samples(1, 1_000), 1, true, @film_threshold_ms, nil)
 
       refute one =~ "(+0)"
       refute one =~ "REDUCTIONS DID NOT ADVANCE"
@@ -605,10 +605,10 @@ defmodule Grappa.Repo.LockWatchTest do
       # The discriminator #1767 lacked: a stack sample cannot separate a
       # process blocked inside a call from one that was never scheduled.
       # Reductions can — they are monotonic and local to the process.
-      assert {:report, frozen} = film_verdict(:frozen, samples(20, 0), 20, true, @film_threshold_ms)
+      assert {:report, frozen} = film_verdict(:frozen, samples(20, 0), 20, true, @film_threshold_ms, nil)
       assert frozen =~ "REDUCTIONS DID NOT ADVANCE"
 
-      assert {:report, moving} = film_verdict(:moving, samples(20, 1_000), 20, true, @film_threshold_ms)
+      assert {:report, moving} = film_verdict(:moving, samples(20, 1_000), 20, true, @film_threshold_ms, nil)
       refute moving =~ "REDUCTIONS DID NOT ADVANCE"
     end
 
@@ -621,7 +621,7 @@ defmodule Grappa.Repo.LockWatchTest do
 
       Process.sleep(@film_interval_ms * 3)
 
-      assert {:film, true, samples, ticks} = ask_filmer(filmer)
+      assert {:film, true, samples, ticks, nil} = ask_filmer(filmer)
       assert length(samples) >= 2
       assert ticks >= length(samples)
 
@@ -645,7 +645,7 @@ defmodule Grappa.Repo.LockWatchTest do
       filmer = spawn_filmer_at(target)
 
       Process.sleep(@film_interval_ms * 3)
-      assert {:film, true, alive_samples, alive_ticks} = ask_filmer(filmer)
+      assert {:film, true, alive_samples, alive_ticks, nil} = ask_filmer(filmer)
       assert alive_samples != []
 
       # Monitor BEFORE the kill: established afterwards it fires `:noproc`
@@ -655,7 +655,7 @@ defmodule Grappa.Repo.LockWatchTest do
       assert_receive {:DOWN, ^ref, :process, ^target, :killed}, 5_000
 
       Process.sleep(@film_interval_ms * 4)
-      assert {:film, true, dead_samples, dead_ticks} = ask_filmer(filmer)
+      assert {:film, true, dead_samples, dead_ticks, _} = ask_filmer(filmer)
 
       # The filmer kept taking its turns…
       assert dead_ticks > alive_ticks
@@ -665,12 +665,65 @@ defmodule Grappa.Repo.LockWatchTest do
       Process.exit(filmer, :kill)
     end
 
+    test "the filmer stamps the instant its target died, and carries nil until then" do
+      # The clock the 54718ms reading was missing. `elapsed_ms` runs from
+      # `start_filmer/1` in `setup` to the printing hook in `on_exit`, so it
+      # spans setup, body AND teardown in one number — and the body of every
+      # test in this file costs 15-378ms, which means the interesting part is
+      # whichever of the other two it is. `TARGET GONE` already says the time
+      # is outside the body, but it says it from a RATIO of ticks to samples;
+      # a ratio cannot be subtracted from a wall clock. Monitoring the target
+      # turns that heuristic into a measurement.
+      target = spawn(fn -> Process.sleep(:infinity) end)
+      filmer = spawn_filmer_at(target)
+
+      Process.sleep(@film_interval_ms * 2)
+      assert {:film, true, _, _, nil} = ask_filmer(filmer)
+
+      # Monitor BEFORE the kill, for the reason the sibling test above states.
+      ref = Process.monitor(target)
+      Process.exit(target, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^target, :killed}, 5_000
+
+      Process.sleep(@film_interval_ms)
+      assert {:film, true, _, _, down_at} = ask_filmer(filmer)
+      assert is_integer(down_at)
+
+      Process.exit(filmer, :kill)
+    end
+
+    test "the report splits the wall clock into setup+body and teardown" do
+      assert {:report, text} =
+               film_verdict(
+                 :split,
+                 samples(3, 1_000),
+                 40,
+                 true,
+                 @film_threshold_ms * 3,
+                 @film_threshold_ms
+               )
+
+      assert text =~ "setup+body #{@film_threshold_ms}ms"
+      assert text =~ "teardown #{@film_threshold_ms * 2}ms"
+    end
+
+    test "a target still alive when the film prints is said to be, not given a zero teardown" do
+      # A missing stamp and a zero teardown are different facts, and printing
+      # the second for the first is the same class of lie as the `(+0)`
+      # derivative: a reader would place the whole wall clock in the body.
+      assert {:report, text} =
+               film_verdict(:alive, samples(3, 1_000), 40, true, @film_threshold_ms, nil)
+
+      assert text =~ "STILL ALIVE"
+      refute text =~ "teardown"
+    end
+
     test "the printing door emits over the threshold and stays quiet under it" do
       filmer = spawn_filmer()
       Process.sleep(@film_interval_ms * 2)
 
-      over = capture_io(fn -> print_film(filmer, :over, @film_threshold_ms) end)
-      under = capture_io(fn -> print_film(filmer, :under, @film_threshold_ms - 1) end)
+      over = capture_io(fn -> print_film(filmer, :over, started_ms_ago(@film_threshold_ms)) end)
+      under = capture_io(fn -> print_film(filmer, :under, started_ms_ago(0)) end)
 
       assert over =~ "#1767 FILM test=:over"
       assert under == ""
@@ -686,7 +739,7 @@ defmodule Grappa.Repo.LockWatchTest do
       ref = Process.monitor(dead)
       assert_receive {:DOWN, ^ref, :process, ^dead, :normal}, 5_000
 
-      output = capture_io(fn -> print_film(dead, :gone, @film_threshold_ms) end)
+      output = capture_io(fn -> print_film(dead, :gone, started_ms_ago(@film_threshold_ms)) end)
 
       assert output =~ "#1767 FILM UNAVAILABLE"
       assert output =~ "test=:gone"
@@ -701,7 +754,8 @@ defmodule Grappa.Repo.LockWatchTest do
                  samples(@film_max_samples, 1_000),
                  @film_max_samples,
                  true,
-                 @film_threshold_ms
+                 @film_threshold_ms,
+                 nil
                )
 
       assert text =~ "sample(s) omitted"
@@ -736,23 +790,38 @@ defmodule Grappa.Repo.LockWatchTest do
   # printing hook, so a test can drive the reel and assert on it directly.
   defp spawn_filmer do
     test_pid = self()
-    spawn(fn -> film_loop(test_pid, true, [], 0) end)
+    spawn_filmer_at(test_pid)
   end
 
   # Aimed at a pid the caller chooses, so a test can point the reel at a
   # process it is about to KILL — the only way to buy the tick/sample split
   # against the real loop instead of against the pure verdict function.
-  defp spawn_filmer_at(pid), do: spawn(fn -> film_loop(pid, true, [], 0) end)
+  defp spawn_filmer_at(pid), do: spawn_film_loop(pid, true)
+
+  # The monitor is established INSIDE the filmer, so the stamp belongs to the
+  # process that reports it. An already-dead target answers `:noproc`
+  # immediately, which stamps at once — the honest reading, not an error.
+  defp spawn_film_loop(pid, sampler_ok?) do
+    spawn(fn ->
+      Process.monitor(pid)
+      film_loop(pid, sampler_ok?, [], 0, nil)
+    end)
+  end
 
   defp ask_filmer(filmer) do
     send(filmer, {:film, self()})
 
     receive do
-      {:film, _, _, _} = answer -> answer
+      {:film, _, _, _, _} = answer -> answer
     after
       @film_answer_budget_ms -> flunk("the filmer never answered")
     end
   end
+
+  # `print_film/3` takes the START of the window rather than its length, so
+  # that one clock reads both the whole span and the split inside it. A test
+  # that wants a span of N therefore has to name a start, not a duration.
+  defp started_ms_ago(ms), do: System.monotonic_time(:millisecond) - ms
 
   ## ----- the filmer (#1767) ---------------------------------------------
 
@@ -764,10 +833,10 @@ defmodule Grappa.Repo.LockWatchTest do
   defp start_filmer(test_name) do
     test_pid = self()
     started_at = System.monotonic_time(:millisecond)
-    filmer = spawn(fn -> film_loop(test_pid, film_sampler_ok?(), [], 0) end)
+    filmer = spawn_film_loop(test_pid, film_sampler_ok?())
 
     on_exit(fn ->
-      print_film(filmer, test_name, System.monotonic_time(:millisecond) - started_at)
+      print_film(filmer, test_name, started_at)
       Process.exit(filmer, :kill)
     end)
   end
@@ -823,14 +892,25 @@ defmodule Grappa.Repo.LockWatchTest do
   # (`--trace`) reported `1 collected / 218 expected` over 54718ms and printed
   # "the VM was not scheduling the FILMER either", which was false. Counting the
   # filmer's own turns is the only way to say anything true about the filmer.
-  defp film_loop(test_pid, sampler_ok?, samples, ticks) do
+  #
+  # 🔴 THE STAMP IS A THIRD THING AGAIN, AND IT IS A CLOCK RATHER THAN A COUNT.
+  # `TARGET GONE` can say the time was spent outside the body, because a tick
+  # that finds nothing alive proves the target was gone. It cannot say HOW
+  # MUCH, because a ratio of ticks to samples is not a duration. The DOWN
+  # stamp is: subtracted from the window's start it gives setup+body, and the
+  # remainder is teardown. That is the split the 54718ms reading needed and
+  # did not have — a number nobody could place is a number nobody can act on.
+  defp film_loop(test_pid, sampler_ok?, samples, ticks, down_at) do
     receive do
       {:film, from} ->
-        send(from, {:film, sampler_ok?, Enum.reverse(samples), ticks})
-        film_loop(test_pid, sampler_ok?, samples, ticks)
+        send(from, {:film, sampler_ok?, Enum.reverse(samples), ticks, down_at})
+        film_loop(test_pid, sampler_ok?, samples, ticks, down_at)
+
+      {:DOWN, _ref, :process, ^test_pid, _reason} ->
+        film_loop(test_pid, sampler_ok?, samples, ticks, System.monotonic_time(:millisecond))
     after
       @film_interval_ms ->
-        film_loop(test_pid, sampler_ok?, film_collect(test_pid, samples), ticks + 1)
+        film_loop(test_pid, sampler_ok?, film_collect(test_pid, samples), ticks + 1, down_at)
     end
   end
 
@@ -862,16 +942,22 @@ defmodule Grappa.Repo.LockWatchTest do
     end
   end
 
-  defp print_film(filmer, test_name, elapsed_ms) do
+  # Takes the START of the window, never a precomputed length: the split below
+  # and the total have to come off ONE clock, or they can disagree.
+  defp print_film(filmer, test_name, started_at) do
     send(filmer, {:film, self()})
 
     receive do
-      {:film, sampler_ok?, samples, ticks} ->
-        emit_film(film_verdict(test_name, samples, ticks, sampler_ok?, elapsed_ms))
+      {:film, sampler_ok?, samples, ticks, down_at} ->
+        elapsed_ms = System.monotonic_time(:millisecond) - started_at
+        body_ms = down_at && down_at - started_at
+
+        emit_film(film_verdict(test_name, samples, ticks, sampler_ok?, elapsed_ms, body_ms))
     after
       @film_answer_budget_ms ->
         IO.puts(
-          "#1767 FILM UNAVAILABLE: test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms — the filmer " <>
+          "#1767 FILM UNAVAILABLE: test=#{inspect(test_name)} " <>
+            "elapsed=#{System.monotonic_time(:millisecond) - started_at}ms — the filmer " <>
             "did not answer within #{@film_answer_budget_ms}ms, so this run has NO trajectory"
         )
     end
@@ -882,30 +968,32 @@ defmodule Grappa.Repo.LockWatchTest do
 
   # Pure, so every branch below is a test above rather than something only a
   # real 60s red could exercise.
-  defp film_verdict(test_name, _, _, false, elapsed_ms) do
+  defp film_verdict(test_name, _, _, false, elapsed_ms, _) do
     {:report,
      "#1767 FILM SAMPLER BROKEN: test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms — the canary's own " <>
        "frame was absent from the stack the sampler read, so NO film is produced: a plausible " <>
        "trajectory from a sampler that cannot read a stack would be believed"}
   end
 
-  defp film_verdict(_, _, _, true, elapsed_ms) when elapsed_ms < @film_threshold_ms do
+  defp film_verdict(_, _, _, true, elapsed_ms, _) when elapsed_ms < @film_threshold_ms do
     :silent
   end
 
-  defp film_verdict(test_name, [], _, true, elapsed_ms) do
+  defp film_verdict(test_name, [], _, true, elapsed_ms, body_ms) do
     {:report,
      "#1767 FILM NO SAMPLES: test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms over a #{@film_interval_ms}ms " <>
-       "tick — the filmer was alive and collected nothing, which is a reading about the VM, not an idle test"}
+       "tick — the filmer was alive and collected nothing, which is a reading about the VM, not an idle test" <>
+       "\n" <> clock_split_line(elapsed_ms, body_ms)}
   end
 
-  defp film_verdict(test_name, samples, ticks, true, elapsed_ms) do
+  defp film_verdict(test_name, samples, ticks, true, elapsed_ms, body_ms) do
     collected = length(samples)
     expected = div(elapsed_ms, @film_interval_ms)
 
     lines =
       [
         "#1767 FILM test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms threshold=#{@film_threshold_ms}ms",
+        clock_split_line(elapsed_ms, body_ms),
         "  ticks: #{ticks} taken / #{expected} due at #{@film_interval_ms}ms  (filmer scheduling)",
         "  samples: #{collected} collected of those #{ticks} ticks  (target alive)",
         reductions_line(samples),
@@ -916,6 +1004,19 @@ defmodule Grappa.Repo.LockWatchTest do
       ] ++ film_frames(samples, hd(samples).at_ms)
 
     {:report, lines |> Enum.reject(&(&1 == "")) |> Enum.join("\n")}
+  end
+
+  # The whole point of the DOWN stamp, rendered. Without a stamp the target
+  # outlived the film, so there IS no teardown to name and saying `teardown
+  # 0ms` would put the entire wall clock in the body — a reader would go
+  # looking for a slow assertion that does not exist.
+  defp clock_split_line(_elapsed_ms, nil) do
+    "  clock: the target was STILL ALIVE when the film printed — no split available"
+  end
+
+  defp clock_split_line(elapsed_ms, body_ms) do
+    "  clock: setup+body #{body_ms}ms | teardown #{elapsed_ms - body_ms}ms  " <>
+      "(ExUnit runs on_exit in another process, so only the first half is the test)"
   end
 
   # 🔴 A DERIVATIVE NEEDS TWO POINTS. With one sample `hd` and `List.last` are

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -527,11 +527,11 @@ defmodule Grappa.Repo.LockWatchTest do
     end
 
     test "a test under the threshold films silently" do
-      assert film_verdict(:under, samples(20, 1_000), true, @film_threshold_ms - 1) == :silent
+      assert film_verdict(:under, samples(20, 1_000), 20, true, @film_threshold_ms - 1) == :silent
     end
 
     test "a test over the threshold reports the trajectory, and names the test" do
-      assert {:report, text} = film_verdict(:over, samples(20, 1_000), true, @film_threshold_ms)
+      assert {:report, text} = film_verdict(:over, samples(20, 1_000), 20, true, @film_threshold_ms)
 
       assert text =~ "#1767 FILM"
       assert text =~ "test=:over"
@@ -548,7 +548,7 @@ defmodule Grappa.Repo.LockWatchTest do
     test "an over-threshold test with no samples says so instead of printing an empty film" do
       # Noisy blindness: a film with nothing in it reads as "the test was
       # idle", which is the one conclusion the filmer must never invite.
-      assert {:report, text} = film_verdict(:empty, [], true, @film_threshold_ms)
+      assert {:report, text} = film_verdict(:empty, [], 12, true, @film_threshold_ms)
 
       assert text =~ "NO SAMPLES"
     end
@@ -556,31 +556,59 @@ defmodule Grappa.Repo.LockWatchTest do
     test "a broken sampler is reported even under the threshold, and produces no film" do
       # A plausible film from a sampler that cannot read a stack is worse
       # than no film: it would be believed.
-      assert {:report, text} = film_verdict(:broken, samples(20, 1_000), false, 0)
+      assert {:report, text} = film_verdict(:broken, samples(20, 1_000), 20, false, 0)
 
       assert text =~ "SAMPLER BROKEN"
       refute text =~ "reductions:"
     end
 
-    test "a filmer that missed its own ticks names its own starvation" do
+    test "starvation is read off the filmer's OWN turns, not off what it collected" do
+      # 🔴 This case USED to assert the defect. It fed one sample and demanded
+      # "SAMPLER STARVED", which is exactly the false line a quiet host printed
+      # during a PASSING run of this file: 1 collected / 218 expected over
+      # 54718ms, while the body cost 132.8ms. Collected-vs-elapsed compares a
+      # numerator bounded by the target's LIFETIME against a denominator
+      # spanning setup and teardown too.
       expected = div(@film_threshold_ms, @film_interval_ms)
 
-      assert {:report, starved} = film_verdict(:starved, samples(1, 1_000), true, @film_threshold_ms)
+      # Starved: the filmer itself barely ran. That IS a VM reading.
+      assert {:report, starved} = film_verdict(:starved, samples(1, 1_000), 1, true, @film_threshold_ms)
       assert starved =~ "SAMPLER STARVED"
       assert starved =~ "1 of #{expected}"
 
-      assert {:report, full} = film_verdict(:full, samples(expected, 1_000), true, @film_threshold_ms)
+      # NOT starved: the filmer took every turn it was due and found the target
+      # gone for almost all of them. Same single sample, opposite verdict —
+      # which is the whole point of splitting the two counters.
+      assert {:report, gone} = film_verdict(:gone, samples(1, 1_000), expected, true, @film_threshold_ms)
+      refute gone =~ "SAMPLER STARVED"
+      assert gone =~ "TARGET GONE"
+
+      assert {:report, full} =
+               film_verdict(:full, samples(expected, 1_000), expected, true, @film_threshold_ms)
+
       refute full =~ "SAMPLER STARVED"
+      refute full =~ "TARGET GONE"
+    end
+
+    test "a single sample prints no delta, because a derivative needs two points" do
+      # The vacuous statistic behind #1767's registered diagnosis: with one
+      # sample `hd` and `List.last` are the same element, so the old line read
+      # `X -> X (+0)` — indistinguishable from a genuinely frozen process.
+      assert {:report, one} = film_verdict(:one, samples(1, 1_000), 1, true, @film_threshold_ms)
+
+      refute one =~ "(+0)"
+      refute one =~ "REDUCTIONS DID NOT ADVANCE"
+      assert one =~ "one sample — no delta"
     end
 
     test "reductions that never advance are named, and reductions that do are not" do
       # The discriminator #1767 lacked: a stack sample cannot separate a
       # process blocked inside a call from one that was never scheduled.
       # Reductions can — they are monotonic and local to the process.
-      assert {:report, frozen} = film_verdict(:frozen, samples(20, 0), true, @film_threshold_ms)
+      assert {:report, frozen} = film_verdict(:frozen, samples(20, 0), 20, true, @film_threshold_ms)
       assert frozen =~ "REDUCTIONS DID NOT ADVANCE"
 
-      assert {:report, moving} = film_verdict(:moving, samples(20, 1_000), true, @film_threshold_ms)
+      assert {:report, moving} = film_verdict(:moving, samples(20, 1_000), 20, true, @film_threshold_ms)
       refute moving =~ "REDUCTIONS DID NOT ADVANCE"
     end
 
@@ -593,12 +621,46 @@ defmodule Grappa.Repo.LockWatchTest do
 
       Process.sleep(@film_interval_ms * 3)
 
-      assert {:film, true, samples} = ask_filmer(filmer)
+      assert {:film, true, samples, ticks} = ask_filmer(filmer)
       assert length(samples) >= 2
+      assert ticks >= length(samples)
 
       assert Enum.all?(samples, &(&1.reductions > 0))
       assert List.last(samples).reductions > hd(samples).reductions
       assert Enum.any?(samples, fn s -> Enum.any?(s.stack, &match?({__MODULE__, _, _, _}, &1)) end)
+
+      Process.exit(filmer, :kill)
+    end
+
+    test "ticks keep advancing after the target dies, and samples do not" do
+      # The other half of the tick/sample split, bought against the REAL loop
+      # rather than the pure verdict: the pure tests could all pass over a loop
+      # that still counted a dead target's ticks as collections.
+      #
+      # This is the shape every timed-out test in this file takes — ExUnit kills
+      # the test process and then runs `on_exit` in another one — so what the
+      # filmer sees here is what it saw on the 54718ms green run that started
+      # this pass.
+      target = spawn(fn -> Process.sleep(:infinity) end)
+      filmer = spawn_filmer_at(target)
+
+      Process.sleep(@film_interval_ms * 3)
+      assert {:film, true, alive_samples, alive_ticks} = ask_filmer(filmer)
+      assert alive_samples != []
+
+      # Monitor BEFORE the kill: established afterwards it fires `:noproc`
+      # against an already-dead pid, which asserts the wrong fact.
+      ref = Process.monitor(target)
+      Process.exit(target, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^target, :killed}, 5_000
+
+      Process.sleep(@film_interval_ms * 4)
+      assert {:film, true, dead_samples, dead_ticks} = ask_filmer(filmer)
+
+      # The filmer kept taking its turns…
+      assert dead_ticks > alive_ticks
+      # …and collected nothing more, because there was nothing alive to sample.
+      assert length(dead_samples) == length(alive_samples)
 
       Process.exit(filmer, :kill)
     end
@@ -633,7 +695,14 @@ defmodule Grappa.Repo.LockWatchTest do
     test "a film longer than the printable window declares what it dropped" do
       # No silent caps: a window that quietly discards the middle of the
       # trajectory reads as a complete film of a shorter run.
-      assert {:report, text} = film_verdict(:long, samples(@film_max_samples, 1_000), true, @film_threshold_ms)
+      assert {:report, text} =
+               film_verdict(
+                 :long,
+                 samples(@film_max_samples, 1_000),
+                 @film_max_samples,
+                 true,
+                 @film_threshold_ms
+               )
 
       assert text =~ "sample(s) omitted"
     end
@@ -667,14 +736,19 @@ defmodule Grappa.Repo.LockWatchTest do
   # printing hook, so a test can drive the reel and assert on it directly.
   defp spawn_filmer do
     test_pid = self()
-    spawn(fn -> film_loop(test_pid, true, []) end)
+    spawn(fn -> film_loop(test_pid, true, [], 0) end)
   end
+
+  # Aimed at a pid the caller chooses, so a test can point the reel at a
+  # process it is about to KILL — the only way to buy the tick/sample split
+  # against the real loop instead of against the pure verdict function.
+  defp spawn_filmer_at(pid), do: spawn(fn -> film_loop(pid, true, [], 0) end)
 
   defp ask_filmer(filmer) do
     send(filmer, {:film, self()})
 
     receive do
-      {:film, _, _} = answer -> answer
+      {:film, _, _, _} = answer -> answer
     after
       @film_answer_budget_ms -> flunk("the filmer never answered")
     end
@@ -690,7 +764,7 @@ defmodule Grappa.Repo.LockWatchTest do
   defp start_filmer(test_name) do
     test_pid = self()
     started_at = System.monotonic_time(:millisecond)
-    filmer = spawn(fn -> film_loop(test_pid, film_sampler_ok?(), []) end)
+    filmer = spawn(fn -> film_loop(test_pid, film_sampler_ok?(), [], 0) end)
 
     on_exit(fn ->
       print_film(filmer, test_name, System.monotonic_time(:millisecond) - started_at)
@@ -736,13 +810,27 @@ defmodule Grappa.Repo.LockWatchTest do
   # would turn any second read into `FILM UNAVAILABLE` — an honest message
   # about the wrong thing, and the exact shape of report this issue is
   # trying to stop producing.
-  defp film_loop(test_pid, sampler_ok?, samples) do
+  # 🔴 `ticks` and `samples` COUNT DIFFERENT THINGS, and conflating them is
+  # what made this filmer lie (#1767, second pass). A tick is the filmer being
+  # SCHEDULED; a sample is the tick finding the target ALIVE. They diverge for
+  # a reason that has nothing to do with the VM: ExUnit runs `on_exit` in a
+  # SEPARATE process, so from the moment the test body ends the target pid is
+  # dead, `Process.info/2` answers nil and `film_collect/2` can only return the
+  # accumulator unchanged. Every tick of the teardown is therefore uncollectable
+  # BY CONSTRUCTION.
+  #
+  # Measured on a QUIET host with a GREEN suite: a test whose body costs 132.8ms
+  # (`--trace`) reported `1 collected / 218 expected` over 54718ms and printed
+  # "the VM was not scheduling the FILMER either", which was false. Counting the
+  # filmer's own turns is the only way to say anything true about the filmer.
+  defp film_loop(test_pid, sampler_ok?, samples, ticks) do
     receive do
       {:film, from} ->
-        send(from, {:film, sampler_ok?, Enum.reverse(samples)})
-        film_loop(test_pid, sampler_ok?, samples)
+        send(from, {:film, sampler_ok?, Enum.reverse(samples), ticks})
+        film_loop(test_pid, sampler_ok?, samples, ticks)
     after
-      @film_interval_ms -> film_loop(test_pid, sampler_ok?, film_collect(test_pid, samples))
+      @film_interval_ms ->
+        film_loop(test_pid, sampler_ok?, film_collect(test_pid, samples), ticks + 1)
     end
   end
 
@@ -778,7 +866,8 @@ defmodule Grappa.Repo.LockWatchTest do
     send(filmer, {:film, self()})
 
     receive do
-      {:film, sampler_ok?, samples} -> emit_film(film_verdict(test_name, samples, sampler_ok?, elapsed_ms))
+      {:film, sampler_ok?, samples, ticks} ->
+        emit_film(film_verdict(test_name, samples, ticks, sampler_ok?, elapsed_ms))
     after
       @film_answer_budget_ms ->
         IO.puts(
@@ -793,57 +882,96 @@ defmodule Grappa.Repo.LockWatchTest do
 
   # Pure, so every branch below is a test above rather than something only a
   # real 60s red could exercise.
-  defp film_verdict(test_name, _, false, elapsed_ms) do
+  defp film_verdict(test_name, _, _, false, elapsed_ms) do
     {:report,
      "#1767 FILM SAMPLER BROKEN: test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms — the canary's own " <>
        "frame was absent from the stack the sampler read, so NO film is produced: a plausible " <>
        "trajectory from a sampler that cannot read a stack would be believed"}
   end
 
-  defp film_verdict(_, _, true, elapsed_ms) when elapsed_ms < @film_threshold_ms do
+  defp film_verdict(_, _, _, true, elapsed_ms) when elapsed_ms < @film_threshold_ms do
     :silent
   end
 
-  defp film_verdict(test_name, [], true, elapsed_ms) do
+  defp film_verdict(test_name, [], _, true, elapsed_ms) do
     {:report,
      "#1767 FILM NO SAMPLES: test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms over a #{@film_interval_ms}ms " <>
        "tick — the filmer was alive and collected nothing, which is a reading about the VM, not an idle test"}
   end
 
-  defp film_verdict(test_name, samples, true, elapsed_ms) do
+  defp film_verdict(test_name, samples, ticks, true, elapsed_ms) do
     collected = length(samples)
     expected = div(elapsed_ms, @film_interval_ms)
-    advanced = List.last(samples).reductions - hd(samples).reductions
 
     lines =
       [
         "#1767 FILM test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms threshold=#{@film_threshold_ms}ms",
-        "  samples: #{collected} collected / #{expected} expected at #{@film_interval_ms}ms",
-        "  reductions: #{hd(samples).reductions} -> #{List.last(samples).reductions} (+#{advanced})",
-        starved_line(collected, expected),
-        frozen_line(advanced, collected, elapsed_ms),
+        "  ticks: #{ticks} taken / #{expected} due at #{@film_interval_ms}ms  (filmer scheduling)",
+        "  samples: #{collected} collected of those #{ticks} ticks  (target alive)",
+        reductions_line(samples),
+        starved_line(ticks, expected),
+        target_gone_line(collected, ticks),
+        frozen_line(samples, elapsed_ms),
         truncated_line(collected)
       ] ++ film_frames(samples, hd(samples).at_ms)
 
     {:report, lines |> Enum.reject(&(&1 == "")) |> Enum.join("\n")}
   end
 
-  # The filmer missing its OWN ticks is a reading in its own right: it says
-  # the VM was not scheduling the observer either, which no sample of the
-  # test process can show.
-  defp starved_line(collected, expected) when collected * 2 < expected do
-    "  ⚠ SAMPLER STARVED: the filmer collected #{collected} of #{expected} ticks it was due — " <>
+  # 🔴 A DERIVATIVE NEEDS TWO POINTS. With one sample `hd` and `List.last` are
+  # the SAME element, so the old unconditional line printed `X -> X (+0)` — a
+  # value differenced against itself, rendered in the exact notation a reader
+  # uses for "this process ran no code". The registered diagnosis of #1767
+  # rested on one of those, and a green quiet-host run of this very file
+  # produced `reductions: 9255 -> 9255 (+0)` from a single sample.
+  defp reductions_line([_only]), do: "  reductions: one sample — no delta (a derivative needs two)"
+
+  defp reductions_line(samples) do
+    advanced = List.last(samples).reductions - hd(samples).reductions
+
+    "  reductions: #{hd(samples).reductions} -> #{List.last(samples).reductions} (+#{advanced})"
+  end
+
+  # The filmer missing its OWN TURNS is a reading about the VM. Counted from
+  # the ticks the loop actually took, never from the samples it managed to
+  # collect: a tick that finds the target dead is not a missed tick, and
+  # measuring the second while claiming the first is what made this line fire
+  # on a quiet host during a passing test.
+  defp starved_line(ticks, expected) when ticks * 2 < expected do
+    "  ⚠ SAMPLER STARVED: the filmer took #{ticks} of #{expected} turns it was due — " <>
       "the VM was not scheduling the FILMER either, so this is not only the test"
   end
 
   defp starved_line(_, _), do: ""
 
-  defp frozen_line(0, collected, elapsed_ms) when collected > 1 do
-    "  ⚠ REDUCTIONS DID NOT ADVANCE across #{collected} samples spanning #{elapsed_ms}ms — the test " <>
-      "process ran no code at all, so any frame below is where it STOPPED, not where it is working"
+  # The other half of the split, and the common case: the filmer was scheduled
+  # fine and found nothing to sample because the test process was already gone.
+  # That is a statement about WHERE the wall-clock went — setup and teardown
+  # rather than the body — and it is the opposite of a VM reading.
+  defp target_gone_line(collected, ticks) when collected * 2 < ticks do
+    "  ⚠ TARGET GONE for #{ticks - collected} of #{ticks} ticks — the test process was not alive " <>
+      "to be sampled, so that time is OUTSIDE the test body (ExUnit runs on_exit in another process)"
   end
 
-  defp frozen_line(_, _, _), do: ""
+  defp target_gone_line(_, _), do: ""
+
+  # Takes the SAMPLES, not a precomputed delta: the guard that keeps this
+  # honest (two points or nothing) then cannot be satisfied by a caller that
+  # computed the delta wrongly, which is exactly how the `(+0)` above survived.
+  defp frozen_line([_ | _] = samples, elapsed_ms) when length(samples) > 1 do
+    collected = length(samples)
+
+    case List.last(samples).reductions - hd(samples).reductions do
+      0 ->
+        "  ⚠ REDUCTIONS DID NOT ADVANCE across #{collected} samples spanning #{elapsed_ms}ms — the test " <>
+          "process ran no code at all, so any frame below is where it STOPPED, not where it is working"
+
+      _ ->
+        ""
+    end
+  end
+
+  defp frozen_line(_, _), do: ""
 
   defp truncated_line(collected) when collected >= @film_max_samples do
     "  ⚠ FILM TRUNCATED: the filmer stopped collecting at #{@film_max_samples} samples"

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -951,7 +951,7 @@ defmodule Grappa.Repo.LockWatchTest do
         send(from, {:film, sampler_ok?, Enum.reverse(samples), ticks, down_at})
         film_loop(test_pid, sampler_ok?, samples, ticks, down_at)
 
-      {:DOWN, _ref, :process, ^test_pid, _reason} ->
+      {:DOWN, _, :process, ^test_pid, _} ->
         film_loop(test_pid, sampler_ok?, samples, ticks, System.monotonic_time(:millisecond))
     after
       @film_interval_ms ->
@@ -1055,7 +1055,7 @@ defmodule Grappa.Repo.LockWatchTest do
   # outlived the film, so there IS no teardown to name and saying `teardown
   # 0ms` would put the entire wall clock in the body — a reader would go
   # looking for a slow assertion that does not exist.
-  defp clock_split_line(_elapsed_ms, nil, _starved?) do
+  defp clock_split_line(_, nil, _) do
     "  clock: the target was STILL ALIVE when the film printed — no split available"
   end
 
@@ -1087,7 +1087,7 @@ defmodule Grappa.Repo.LockWatchTest do
   # uses for "this process ran no code". The registered diagnosis of #1767
   # rested on one of those, and a green quiet-host run of this very file
   # produced `reductions: 9255 -> 9255 (+0)` from a single sample.
-  defp reductions_line([_only]), do: "  reductions: one sample — no delta (a derivative needs two)"
+  defp reductions_line([_]), do: "  reductions: one sample — no delta (a derivative needs two)"
 
   defp reductions_line(samples) do
     advanced = List.last(samples).reductions - hd(samples).reductions
@@ -1121,7 +1121,7 @@ defmodule Grappa.Repo.LockWatchTest do
   # 129406ms run reported `TARGET GONE for 257 of 507 ticks` while the same
   # report's split read `teardown 15ms`. The two lines contradicted each other
   # and the ratio was the one that was wrong.
-  defp target_gone_line(collected, _ticks) when collected >= @film_max_samples, do: ""
+  defp target_gone_line(collected, _) when collected >= @film_max_samples, do: ""
 
   defp target_gone_line(collected, ticks) when collected * 2 < ticks do
     "  ⚠ TARGET GONE for #{ticks - collected} of #{ticks} ticks — the test process was not alive " <>

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -707,6 +707,51 @@ defmodule Grappa.Repo.LockWatchTest do
       assert text =~ "teardown #{@film_threshold_ms * 2}ms"
     end
 
+    test "a truncated film does not report its own cap as a dead target" do
+      # 🔴 Measured on a real 129406ms run: `TARGET GONE for 257 of 507 ticks`
+      # printed alongside `teardown 15ms` in the SAME report. Past
+      # `@film_max_samples` every further tick collects nothing however alive
+      # the target is, so the collected-vs-ticks ratio fires unconditionally
+      # once ticks exceed twice the cap. The clock is the one that was right.
+      ticks = @film_max_samples * 3
+
+      assert {:report, text} =
+               film_verdict(
+                 :capped,
+                 samples(@film_max_samples, 1_000),
+                 ticks,
+                 true,
+                 @film_threshold_ms,
+                 0
+               )
+
+      assert text =~ "FILM TRUNCATED"
+      refute text =~ "TARGET GONE"
+    end
+
+    test "a starved filmer declares that its own split was read late" do
+      # The stamp is taken when the filmer HANDLES the DOWN. A filmer that was
+      # not scheduled reads the boundary late, so teardown is understated —
+      # and a number that is quietly a lower bound is the same kind of lie the
+      # rest of this pass removed.
+      assert {:report, starved} =
+               film_verdict(:starved, samples(1, 1_000), 1, true, @film_threshold_ms, 10)
+
+      assert starved =~ "LOWER bound"
+
+      assert {:report, fed} =
+               film_verdict(
+                 :fed,
+                 samples(12, 1_000),
+                 div(@film_threshold_ms, @film_interval_ms),
+                 true,
+                 @film_threshold_ms,
+                 10
+               )
+
+      refute fed =~ "LOWER bound"
+    end
+
     test "a target still alive when the film prints is said to be, not given a zero teardown" do
       # A missing stamp and a zero teardown are different facts, and printing
       # the second for the first is the same class of lie as the `(+0)`
@@ -979,11 +1024,11 @@ defmodule Grappa.Repo.LockWatchTest do
     :silent
   end
 
-  defp film_verdict(test_name, [], _, true, elapsed_ms, body_ms) do
+  defp film_verdict(test_name, [], ticks, true, elapsed_ms, body_ms) do
     {:report,
      "#1767 FILM NO SAMPLES: test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms over a #{@film_interval_ms}ms " <>
        "tick — the filmer was alive and collected nothing, which is a reading about the VM, not an idle test" <>
-       "\n" <> clock_split_line(elapsed_ms, body_ms)}
+       "\n" <> clock_split_line(elapsed_ms, body_ms, starved?(ticks, div(elapsed_ms, @film_interval_ms)))}
   end
 
   defp film_verdict(test_name, samples, ticks, true, elapsed_ms, body_ms) do
@@ -993,7 +1038,7 @@ defmodule Grappa.Repo.LockWatchTest do
     lines =
       [
         "#1767 FILM test=#{inspect(test_name)} elapsed=#{elapsed_ms}ms threshold=#{@film_threshold_ms}ms",
-        clock_split_line(elapsed_ms, body_ms),
+        clock_split_line(elapsed_ms, body_ms, starved?(ticks, expected)),
         "  ticks: #{ticks} taken / #{expected} due at #{@film_interval_ms}ms  (filmer scheduling)",
         "  samples: #{collected} collected of those #{ticks} ticks  (target alive)",
         reductions_line(samples),
@@ -1010,14 +1055,31 @@ defmodule Grappa.Repo.LockWatchTest do
   # outlived the film, so there IS no teardown to name and saying `teardown
   # 0ms` would put the entire wall clock in the body — a reader would go
   # looking for a slow assertion that does not exist.
-  defp clock_split_line(_elapsed_ms, nil) do
+  defp clock_split_line(_elapsed_ms, nil, _starved?) do
     "  clock: the target was STILL ALIVE when the film printed — no split available"
   end
 
-  defp clock_split_line(elapsed_ms, body_ms) do
+  # 🔴 THE STAMP IS TAKEN WHEN THE FILMER HANDLES THE DOWN, NOT WHEN IT
+  # ARRIVES, so a starved filmer reads the boundary LATE: setup+body comes out
+  # too big and teardown too small, by however long the filmer sat unscheduled
+  # with the message already in its mailbox. There is no in-VM clock that
+  # escapes this — a stall wide enough to starve the filmer starves whatever
+  # would time it — so the bias is DECLARED rather than engineered away. Under
+  # starvation the split is a lower bound on teardown, and saying so is the
+  # difference between a measurement and a number.
+  defp clock_split_line(elapsed_ms, body_ms, starved?) do
+    caveat =
+      if starved?,
+        do: " — the filmer was starved, so this boundary was read LATE: teardown is a LOWER bound",
+        else: ""
+
     "  clock: setup+body #{body_ms}ms | teardown #{elapsed_ms - body_ms}ms  " <>
-      "(ExUnit runs on_exit in another process, so only the first half is the test)"
+      "(ExUnit runs on_exit in another process, so only the first half is the test)" <> caveat
   end
+
+  # One predicate, so the caveat above and the STARVED line below can never
+  # disagree about whether the filmer got its turns.
+  defp starved?(ticks, expected), do: ticks * 2 < expected
 
   # 🔴 A DERIVATIVE NEEDS TWO POINTS. With one sample `hd` and `List.last` are
   # the SAME element, so the old unconditional line printed `X -> X (+0)` — a
@@ -1038,17 +1100,29 @@ defmodule Grappa.Repo.LockWatchTest do
   # collect: a tick that finds the target dead is not a missed tick, and
   # measuring the second while claiming the first is what made this line fire
   # on a quiet host during a passing test.
-  defp starved_line(ticks, expected) when ticks * 2 < expected do
-    "  ⚠ SAMPLER STARVED: the filmer took #{ticks} of #{expected} turns it was due — " <>
-      "the VM was not scheduling the FILMER either, so this is not only the test"
+  defp starved_line(ticks, expected) do
+    if starved?(ticks, expected) do
+      "  ⚠ SAMPLER STARVED: the filmer took #{ticks} of #{expected} turns it was due — " <>
+        "the VM was not scheduling the FILMER either, so this is not only the test"
+    else
+      ""
+    end
   end
-
-  defp starved_line(_, _), do: ""
 
   # The other half of the split, and the common case: the filmer was scheduled
   # fine and found nothing to sample because the test process was already gone.
   # That is a statement about WHERE the wall-clock went — setup and teardown
   # rather than the body — and it is the opposite of a VM reading.
+  # 🔴 TRUNCATION IS NOT ABSENCE, and it took the clock above to notice.
+  # `film_collect/2` stops appending at `@film_max_samples`, so past the cap
+  # every further tick collects nothing — for a target that is alive and
+  # working. The ratio below cannot tell that apart from a dead one, and past
+  # `2 * @film_max_samples` ticks it fires unconditionally. Measured: a real
+  # 129406ms run reported `TARGET GONE for 257 of 507 ticks` while the same
+  # report's split read `teardown 15ms`. The two lines contradicted each other
+  # and the ratio was the one that was wrong.
+  defp target_gone_line(collected, _ticks) when collected >= @film_max_samples, do: ""
+
   defp target_gone_line(collected, ticks) when collected * 2 < ticks do
     "  ⚠ TARGET GONE for #{ticks - collected} of #{ticks} ticks — the test process was not alive " <>
       "to be sampled, so that time is OUTSIDE the test body (ExUnit runs on_exit in another process)"


### PR DESCRIPTION
## What this is

**This is not a cure for issue 1767.** (Deliberately spelled without a `#`: the original wording paired a closing keyword with the issue reference, and GitHub's parser does not read negation — it fired at merge and closed the issue.) It establishes what the number is, refutes the
two cures that present themselves, and falsifies the two premises the round
was dispatched on. The file can still go red on this branch — see *Known
red* below.

## The measurement

`@waiter_budget_ms` is `@test_timeout_ms * 2` = 120 000, used as the private
repo's `busy_timeout`, so the queued writer sits inside exqlite's dirty-IO
`execute/2` for up to two minutes. Two batches on a quiet host, same tree,
same command, only that constant moved:

| `@waiter_budget_ms` | hits | stalled test `elapsed_ms` |
|---|---|---|
| 120 000 | 3 of 10 runs | 128 501 / 128 960 / 129 406 |
| 30 000 | 2 of 14 runs | 42 255 / 42 238 |

Removing 90 000 ms of budget removed 86 722 ms of stall — a ratio of
**0.96**. The stall is the parked NIF's lifetime, the same 1:1 identity
#1715's third retraction found for its own harness.

Two later hits at the 120 000 setting bound the residual above the budget
from both sides: **136 913 ms** (post-rebase, locally) and **120 352 ms**
(CI). The second is the tightest fit yet — a 352 ms residual on a 120 000 ms
budget — and the spread of the residual (0.3 % to 14 %) is not explained.
The dominant term is unchanged in all five.

## The victim is not one frame, and the identity is what unifies them

Across hits the blocked call DIFFERS, and reporting any single one as *the*
signature is the mistake this branch exists to correct. Two are measured:

* an `assert_receive {:DOWN, ...}, 5_000` in the test, `status: waiting`,
  tens of seconds past its own timeout;
* `Process.info/2` inside **production** `LockWatch`, on a pid parked in the
  dirty NIF — see *Known red*.

What every hit shares is arithmetic, not a place: `elapsed_ms` tracks
`@waiter_budget_ms`. That is the finding; the frame is not.

It is also not host-wide CPU starvation. On the best-filmed hit the reel
took 507 of 517 due turns while the test process accrued 249 reductions
across 250 samples — one per sample, the cost of the filmer's own
`process_info` signal — so the test process ran no code of its own for ~63 s
**while the VM scheduled another process in the same run normally**.

## Both cures refuted, in opposite directions

* **Lowering the budget** restores #1687, measured: at 30 000 the waiter's
  `BEGIN IMMEDIATE` gives up before the test can observe it, the writer dies
  `SQLITE_BUSY` instead of `:normal`, and the DOWN assertion fails on an
  empty mailbox. 2 of 14 runs.
* **Raising the deadline** does not shorten a stall, it stops it being
  reported.

The two clocks pinch: the budget must exceed what the test needs (#1687) and
must not exceed the deadline (#1767), and under a stall the test's need
BECOMES the stall. No value satisfies both. Naming that is the result.

## Two dispatched premises, corrected

* The field log's `Exqlite.Connection.handle_transaction/3` frame is the
  pool's 15 000 ms ownership timeout sampling the client **12 ms after** a
  `db=6.7ms` commit had already returned; the 31 840 ms sits on the UPDATE
  before it. There was no parked COMMIT to bench.
* #1715's round 4 already ran the full 2x2x2 across {word-sized,
  literal-bearing put} x {dirty NIF parked, not} x {concurrent code load,
  not}, v1-v8, ~38 M timed puts. A ninth configuration would have been a
  repeat round.

## The instrument, because the old one could not place the number

Three lies came out of the filmer first, each found by adding a second way
to measure the same thing and letting the two contradict each other:

* `SAMPLER STARVED` divided a numerator bounded by the target's lifetime by
  a denominator spanning setup, body and teardown — it fired on a PASSING
  quiet-host run (`1 collected / 218 expected` over 54 718 ms).
* `reductions: X -> X (+0)` was a value differenced against itself, from one
  sample.
* `elapsed_ms` conflated setup, body and teardown; the filmer now monitors
  its target and stamps the instant it dies, which turns `TARGET GONE`'s
  ratio into a clock — and that clock caught `TARGET GONE` reporting the
  sample cap as a dead target (`TARGET GONE for 257 of 507 ticks` three
  lines above `teardown 15ms`).

The split's bias is declared rather than hidden: the stamp is taken when the
filmer HANDLES the DOWN, so a starved filmer understates teardown, and the
report says so.

No timeout was moved and no assertion was weakened.

## Known red

The branch does not cure the flake, so `lock_watch_test.exs` can still fail
on CI. **An earlier revision of this section named one line
(`:227`, the `5_000` DOWN assertion) and that was too narrow** — the same
error, one level up, that the branch spends its diff correcting. The
signature is a MECHANISM, and it is in production code this diff does not
touch.

**Mechanism.** `LockWatch` reports a stall by SAMPLING the very processes
that cannot answer. A waiter is by definition parked inside exqlite's
dirty-IO `execute/2` on a contended `BEGIN IMMEDIATE`, and a process
executing a dirty NIF cannot service a `process_info` signal until the NIF
returns. So the observer waits out the NIF's whole `busy_timeout`.

**Every arm is exposed, which is why one line will not do.** The fork at
`lib/grappa/repo/lock_watch.ex:503` splits on whether any holder is
attributable, and **both** arms funnel into `sample/2` (`:659`), as does a
third door that is not on the fork at all:

* `:503` false arm -> `report_unattributed/2` (`:578`) -> `:584` samples the
  QUEUED waiters;
* `:503` true arm -> `report_stalls/2` (`:530`) -> `:531` samples the
  waiters and `:541` the holder;
* `inspect_lock/0` (`:360-361`) samples holders and waiters alike — the
  admin/debug door, same exposure, reachable without a scan.

`sample/2` then touches the parked pid twice: `Process.info/2` at `:660` and
`stacktrace/1` at `:669`, whose own `Process.info(pid, :current_stacktrace)`
is `:682`.

**How to attribute a red.** `elapsed_ms` ~= `@waiter_budget_ms` (120 000),
with the stack anywhere in the list above. The CI red that prompted this
correction fell in the `#1687` describe at `:257`, under
`capture_log(fn -> LockWatch.scan(0) end)` at `:271`, through
`report_unattributed/2` -> `detect/2`, at `elapsed=120352ms`. The earlier
local hits fell at `:227`. Same mechanism, different arm.

**One recorded measurement is now in tension and should be re-run.** This
file's moduledoc states that
`Process.info(pid, :current_stacktrace)` against a writer parked inside
`Exqlite.Sqlite3NIF.execute/2` "answers in 2-78us and NEVER blocked", over
40 samples. The CI frame puts the wait at exactly that call, and it carries
`erts_internal:await_result/1` — a frame that appears ONLY when
`process_info` had to signal-and-wait, so unlike a bare stack sample it is
positive evidence of a wait rather than of where the machine stopped. That
moduledoc claim is NOT amended in this diff: it is one CI sample against 40
recorded ones, and reversing a measurement needs a measurement.

## Gates

* `scripts/check.sh` — **rc=0** (full run).
* `scripts/design-notes-gate.sh origin/main` — `1 new entry heading(s),
  separator and marker present`. Marker is `#1767b`; `#1767` was already
  taken on the base tip.
* `scripts/union-rebase.sh origin/main` — `docs/DESIGN_NOTES.md: +128 -0 —
  contribution intact`.
* Post-rebase: `mix format --check-formatted` rc=0, `mix credo --strict`
  rc=0, `lock_watch_test.exs` 29 tests with the known red above.
* Diff touches `test/**` and `docs/**` only, neither of which is in
  `integration.yml`'s path filter — 4 checks expected, all from `ci.yml`.