### PR TITLE
cicchetto: nudge the rail radio band's station logo off the rail edge (issue 1828)

### DIFF
--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -64,6 +64,85 @@ export function selectorList(selectors: string): string[] {
 }
 
 /**
+ * Split a CSS value on top-level whitespace. `calc(-1 * var(--rail-inset))` is
+ * ONE value with two spaces inside it, so a naive `split(/\s+/)` would read it
+ * as three and take the wrong one as the horizontal component.
+ */
+function splitTopLevel(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of value) {
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth -= 1;
+    if (depth === 0 && /\s/.test(ch)) {
+      if (current !== "") parts.push(current);
+      current = "";
+    } else current += ch;
+  }
+  if (current !== "") parts.push(current);
+  return parts;
+}
+
+/**
+ * The HORIZONTAL components a single declaration contributes, or `[]` when it
+ * contributes none. Shorthands are expanded by arity the way the cascade does
+ * it (1 → all, 2 → `block inline`, 3 → `top inline bottom`, 4 → clockwise), so
+ * a `padding: 0.25rem 1rem` is caught and a `padding-block: 0.25rem` is not.
+ */
+function horizontalComponents(property: string, value: string): string[] {
+  const parts = splitTopLevel(value);
+  const [p0, p1, p2, p3] = parts;
+  if (property === "margin" || property === "padding") {
+    if (parts.length === 1) return p0 === undefined ? [] : [p0];
+    if (parts.length === 2 || parts.length === 3) return p1 === undefined ? [] : [p1];
+    if (parts.length === 4) {
+      return p1 !== undefined && p3 !== undefined ? [p1, p3] : [];
+    }
+    return [];
+  }
+  if (property === "margin-inline" || property === "padding-inline") {
+    return parts;
+  }
+  if (/^(margin|padding)-(left|right|inline-start|inline-end)$/.test(property)) {
+    return parts.length === 0 ? [] : [parts.join(" ")];
+  }
+  // `-block`, `-top`, `-bottom`, and everything that is not a box inset.
+  void p2;
+  return [];
+}
+
+/**
+ * Every horizontal margin/padding component a rule body declares.
+ *
+ * Lifted out of `railInset.test.ts` when #1828 needed the same reader for the
+ * radio band (CLAUDE.md "implement once, reuse everywhere"): both gates ask
+ * "which boxes in this region inset themselves horizontally, and how?", and a
+ * second copy of the shorthand-arity expansion is a second place to get
+ * `padding: 0.4rem 0` wrong.
+ */
+export function horizontalInsets(body: string): { property: string; component: string }[] {
+  const out: { property: string; component: string }[] = [];
+  for (const raw of body.split(";")) {
+    const colon = raw.indexOf(":");
+    if (colon === -1) continue;
+    const property = raw.slice(0, colon).trim();
+    const value = raw.slice(colon + 1).trim();
+    for (const component of horizontalComponents(property, value)) {
+      out.push({ property, component });
+    }
+  }
+  return out;
+}
+
+/**
+ * Whether an inset component is a RESET rather than a declared gap — killing
+ * the user-agent list indent, resetting a button. Anything else is a box
+ * deciding its own horizontal position.
+ */
+export const isZeroInset = (component: string): boolean => /^0(px|rem|em|%)?$/.test(component);
+
+/**
  * Every body of a rule whose selector is EXACTLY `selector`, at any nesting
  * depth — `ruleBody`'s column-0 anchor cannot see rules inside an `@media` /
  * `@supports` block. Returns one entry per block on purpose: a selector can

--- a/cicchetto/src/__tests__/railInset.test.ts
+++ b/cicchetto/src/__tests__/railInset.test.ts
@@ -19,76 +19,10 @@
 // long as the ownership holds.
 
 import { describe, expect, it } from "vitest";
-import { allRules, selectorList } from "./helpers/themeCss";
+import { allRules, horizontalInsets, isZeroInset, selectorList } from "./helpers/themeCss";
 
 const CONTAINER = ".shell-members";
 const TOKEN = "--rail-inset";
-
-/**
- * Split a CSS value on top-level whitespace. `calc(-1 * var(--rail-inset))` is
- * ONE value with two spaces inside it, so a naive `split(/\s+/)` would read it
- * as three and take the wrong one as the horizontal component.
- */
-function splitTopLevel(value: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let current = "";
-  for (const ch of value) {
-    if (ch === "(") depth += 1;
-    else if (ch === ")") depth -= 1;
-    if (depth === 0 && /\s/.test(ch)) {
-      if (current !== "") parts.push(current);
-      current = "";
-    } else current += ch;
-  }
-  if (current !== "") parts.push(current);
-  return parts;
-}
-
-/**
- * The HORIZONTAL components a single declaration contributes, or `[]` when it
- * contributes none. Shorthands are expanded by arity the way the cascade does
- * it (1 → all, 2 → `block inline`, 3 → `top inline bottom`, 4 → clockwise), so
- * a `padding: 0.25rem 1rem` is caught and a `padding-block: 0.25rem` is not.
- */
-function horizontalComponents(property: string, value: string): string[] {
-  const parts = splitTopLevel(value);
-  const [p0, p1, p2, p3] = parts;
-  if (property === "margin" || property === "padding") {
-    if (parts.length === 1) return p0 === undefined ? [] : [p0];
-    if (parts.length === 2 || parts.length === 3) return p1 === undefined ? [] : [p1];
-    if (parts.length === 4) {
-      return p1 !== undefined && p3 !== undefined ? [p1, p3] : [];
-    }
-    return [];
-  }
-  if (property === "margin-inline" || property === "padding-inline") {
-    return parts;
-  }
-  if (/^(margin|padding)-(left|right|inline-start|inline-end)$/.test(property)) {
-    return parts.length === 0 ? [] : [parts.join(" ")];
-  }
-  // `-block`, `-top`, `-bottom`, and everything that is not a box inset.
-  void p2;
-  return [];
-}
-
-/** Every horizontal margin/padding component a rule body declares. */
-function horizontalInsets(body: string): { property: string; component: string }[] {
-  const out: { property: string; component: string }[] = [];
-  for (const raw of body.split(";")) {
-    const colon = raw.indexOf(":");
-    if (colon === -1) continue;
-    const property = raw.slice(0, colon).trim();
-    const value = raw.slice(colon + 1).trim();
-    for (const component of horizontalComponents(property, value)) {
-      out.push({ property, component });
-    }
-  }
-  return out;
-}
-
-const isZero = (component: string): boolean => /^0(px|rem|em|%)?$/.test(component);
 
 describe("#1802 — the rail's horizontal inset is owned by the container", () => {
   it("defines the inset token exactly once, and in the container's own rule", () => {
@@ -143,7 +77,7 @@ describe("#1802 — the rail's horizontal inset is owned by the container", () =
       for (const { property, component } of horizontalInsets(rule.body)) {
         // Zero is a reset (killing the user-agent list indent, resetting a
         // button), not an inset. Anything else is the child deciding.
-        if (isZero(component)) continue;
+        if (isZeroInset(component)) continue;
         offenders.push(`${rule.selectors} → ${property}: ${component}`);
       }
     }

--- a/cicchetto/src/__tests__/railRadioBandInset.test.ts
+++ b/cicchetto/src/__tests__/railRadioBandInset.test.ts
@@ -1,0 +1,80 @@
+// #1828 — the radio band carries ONE horizontal inset, on the logo, as padding.
+//
+// WHAT THE DEFECT WAS. The station logo read as further left than the nick rows
+// stacked above it while both sat on the same 7px `--rail-inset`. Nothing was
+// misaligned: the logo is an image whose pixels start at its box edge, a nick is
+// monospace text whose glyphs carry a left side bearing, so an image flush to an
+// inset the glyph beside it only approaches reads as further out. The cure is an
+// OPTICAL nudge of the logo's ink, not a geometry change.
+//
+// WHY THAT NUDGE IS A PADDING AND NOT A MARGIN, which is the half of the ruling
+// worth guarding. The logo and the title are consecutive flex items, so the
+// space has to come out of one of them: a MARGIN takes it from the row and
+// carries the title (and the track line under it) right with the logo, a PADDING
+// takes it from the logo's own content box and moves nothing else. The issue
+// forbids moving the title, so padding it is — at the measured cost of the image
+// rendering 2.1px narrower inside an unchanged 2rem box (`object-fit: cover`, so
+// the artwork is cropped, never distorted).
+//
+// WHAT IS DELIBERATELY NOT ASSERTED: the SIZE of the nudge. It is an optical
+// value that only an eye on a real render can judge, and a test that re-read
+// `0.15rem` off the sheet it is reading would be a mirror of the fix rather than
+// a statement about it. These two tests name a property no band box may carry
+// and a mechanism the one allowed inset must use; the value is free to move.
+
+import { describe, expect, it } from "vitest";
+import { allRules, horizontalInsets, isZeroInset, selectorList } from "./helpers/themeCss";
+
+const LOGO = ".rail-radio-now-logo";
+
+// The band is `.rail-radio` and its own children — the identity button, the
+// logo, the two text lines and the ⏹. The PICKER that overlays the rail is a
+// different surface and out of scope by the issue's own ruling: its rows carry
+// `padding: 0.25rem 0.375rem` of their own and must keep it.
+const BAND = /\.rail-radio(?!-picker|-heading|-station)[\w-]*/;
+
+/** Every rule that styles a box inside the band, picker rules excluded. */
+function bandRules(): { selectors: string; body: string }[] {
+  return allRules().filter((rule) => selectorList(rule.selectors).some((one) => BAND.test(one)));
+}
+
+/** The band's declared horizontal insets as `selectors → property` strings. */
+function declaredInsets(rules: { selectors: string; body: string }[]): string[] {
+  return rules.flatMap((rule) =>
+    horizontalInsets(rule.body)
+      .filter(({ component }) => !isZeroInset(component))
+      .map(({ property }) => `${rule.selectors} → ${property}`),
+  );
+}
+
+describe("#1828 — the radio band's one horizontal inset", () => {
+  it("keeps every band surface except the logo on the rail's own inset", () => {
+    const rules = bandRules();
+    // Positive control, and the reason this is not vacuous: an over-tight BAND
+    // pattern would satisfy the assertion below by matching nothing at all.
+    expect(rules.map((rule) => rule.selectors)).toContain(".rail-radio-now");
+
+    // #1737 moved the band's horizontal padding to `.shell-members` so its
+    // border box lines up with every other rail surface, and the tempting cure
+    // for THIS issue is to put it straight back — which would re-bleed the band
+    // and move the title, the track line and the ⏹ with it. Anything in the band
+    // that insets itself horizontally, other than the logo, is that regression.
+    const offenders = declaredInsets(rules.filter((rule) => !rule.selectors.includes(LOGO)));
+    expect(offenders).toEqual([]);
+  });
+
+  it("insets the logo's content with a padding, never its box with a margin", () => {
+    const logoRules = bandRules().filter((rule) => rule.selectors.includes(LOGO));
+    const insets = logoRules.flatMap((rule) =>
+      horizontalInsets(rule.body).filter(({ component }) => !isZeroInset(component)),
+    );
+
+    // The nudge has to EXIST — without this the pair passes cleanly on a sheet
+    // where somebody deleted the fix, which is the one regression a source test
+    // of an optical correction can still catch.
+    expect(insets.length).toBeGreaterThan(0);
+    expect(insets.map(({ property }) => property.replace(/-(left|inline-start)$/, ""))).toEqual(
+      insets.map(() => "padding"),
+    );
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2504,11 +2504,42 @@ html.resize-dragging * {
   cursor: pointer;
 }
 
+/* #1828 — the one horizontal inset in this band, and it is OPTICAL.
+   The report is that this logo reads as further left than the nick rows above
+   it. Measured, nothing is misaligned: `.shell-members` puts both left edges on
+   the same `--rail-inset` (7px at this app's 14px root, #1737 for the band and
+   #1802 for the rows). What differs is what sits on that edge. The logo is an
+   image whose pixels start at the box edge; a nick is monospace text whose
+   glyphs carry a left side bearing — measured off the two fonts `--font-mono`
+   actually resolves to on macOS, the median lowercase bearing at a 14px em is
+   1.36px in SF Mono and 1.30px in Menlo, rising to 2.02px and 2.47px for the
+   widest letters. So the glyph ink starts about 1.3px inside a line the image
+   ink sits ON, and a solid mass flush to an edge its neighbour only approaches
+   reads as further out. 0.15rem is 2.1px: between that median and that maximum,
+   which puts the logo's ink just INSIDE the typical nick's rather than level
+   with it — the right direction, because a filled block still reads heavier
+   than sparse strokes at the same x.
+
+   WHY PADDING AND NOT MARGIN, which is the whole shape of this fix. The logo
+   and the title are consecutive flex items, so the 2.1px comes out of one of
+   them and there is no third option in the box model: a margin takes it from
+   the ROW and carries the title and the track line right along with the logo,
+   which the issue forbids; a padding takes it from this box's own content and
+   moves nothing else. Priced before choosing, and the price is real: with the
+   global `border-box`, the content box goes 28px to 25.9px wide against an
+   unchanged 28px height, so `object-fit: cover` starts cropping about 1.05px
+   off each side of artwork that is square in every station file today. Cover
+   crops, never distorts, and that is the policy this rule already declared.
+
+   The picker's `.rail-radio-station-logo` is NOT the same case and is not
+   touched: it sits in a row with its own `padding: 0.25rem 0.375rem`, so its
+   pixels never reach a shared edge. */
 .rail-radio-now-logo {
   flex: none;
   width: 2rem;
   height: 2rem;
   object-fit: cover;
+  padding-inline-start: 0.15rem;
 }
 
 /* `min-width: 0` is what lets the title ellipsise instead of forcing the row

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -41924,3 +41924,82 @@ contradict each other — a ratio against a clock, a derivative against a
 sample count, a cap against a stamp. And a cure that moves a constant should
 be measured in BOTH directions before it is proposed: this one is a pinch
 between two clocks, and each direction restores the other's bug.
+<!-- entry #1828 -->
+
+---
+
+## 2026-08-26 — #1828: the rail radio band's logo, and an inset that is optical rather than metric
+
+**What was reported:** the station logo in the rail's radio band reads as
+further left than the nick rows stacked directly above it. **What was
+measured:** both left edges are on the same 7px. `.shell-members` owns
+`--rail-inset: 0.5rem` and the band's border box takes it directly (#1737);
+the nick rows reach the identical number through the #1802 pair, the pane
+cancelling the inset with a negative margin and the container giving it back
+to the pane's children. There was nothing to align.
+
+**Two candidate extra offsets, both looked for and both absent.** A leading
+space sigil would have put a whole monospace advance of whitespace in front of
+every unprefixed nick — `memberSigil/1` does return `" "` for plain, but
+`sigilToPrefix` in `MembersPane.tsx` maps that to `""` and `NickText` then
+emits no prefix span at all, so a plain nick's first glyph IS its first
+letter. A padding on the row's click button would have done the same —
+`.members-pane li .member-name` resets it to `padding: 0`. Both refuted before
+touching anything, which is what leaves the side bearing as the whole of it.
+
+**So the difference is ink, not geometry.** The logo is an image whose pixels
+start at its box edge; a nick is monospace text whose glyphs carry a left side
+bearing. Read out of the two fonts `--font-mono` actually resolves to on
+macOS, at a 14px em: median lowercase bearing 1.36px in SF Mono and 1.30px in
+Menlo, maximum 2.02px (`k`) and 2.47px (`r`), advance width 8.65px and 8.43px.
+The image ink sits ON a line the glyph ink only approaches by about 1.3px, and
+a filled mass reads heavier than sparse strokes at the same x — so the cure is
+an optical nudge, and `0.15rem` (2.1px) puts the logo's ink between the median
+and the maximum bearing, i.e. just INSIDE a typical nick's rather than level
+with it.
+
+**The mechanism was forced, not preferred, and this is the durable part.** The
+logo and the title are consecutive flex items, so the 2.1px comes out of one
+of them and the box model offers no third option. A `margin-inline-start`
+keeps the artwork pristine and carries the title and the track line right
+along with the logo; a `padding-inline-start` moves nothing but the logo and
+pays for it in the image. The report forbids moving the title, so it is the
+padding — priced first: with the global `border-box` the content box goes 28px
+to 25.9px against an unchanged 28px height, so `object-fit: cover` crops about
+1.05px off each side of artwork that is square in all twenty station files.
+Cover crops and never distorts, which is the policy that rule already
+declared. **The general rule to keep: an optical inset on one flex item is
+never free — it is charged either to the neighbours' position or to the item's
+own content box, and which one is a decision to make out loud.**
+
+**What the gate holds, and what no gate can.** `railRadioBandInset.test.ts`
+asserts that nothing in the band except the logo insets itself horizontally —
+the tempting cure for this report is to put #1737's `padding-inline` back on
+`.rail-radio-now`, which re-bleeds the band and moves everything in it, and
+that regression was previously ungated because `railInset.test.ts` only
+polices the children the container addresses by name (`.members-pane`) — and
+that the logo's inset is a padding rather than a margin, which is the rejected
+mechanism above. Each assertion was falsified by its own mutant: the band
+padding restored kills the first and leaves the second green, the logo's
+padding swapped for a margin kills the second and leaves the first green.
+The VALUE is deliberately unasserted: 2.1px is an optical judgement, and
+re-reading `0.15rem` off the sheet under test would mirror the fix instead of
+constraining it.
+
+**Why there is no e2e for this, which is a claim about the DOM and not a
+shrug.** The pixel this fix moves is the left edge of the image's CONTENT box,
+and no DOM geometry API exposes it: `getBoundingClientRect`, `getClientRects`
+and `offsetLeft` all return the BORDER box, which is unchanged at 7px by
+design, and a replaced element's painted rect under `object-fit` is not
+exposed at all. The only browser-side handle is
+`getComputedStyle().paddingInlineStart` — the stylesheet read back through an
+engine, which is what the vitest source gate already does without a browser or
+a lane. So an e2e here would cost a lane to add nothing the source test does
+not have, and would still not witness the thing that matters.
+
+**Not measured, and not claimed:** whether 2.1px is enough. The nudge is
+grounded in the bearing it corrects, but optical adequacy is a judgement on a
+real render, and this host has no browser to make it on — Chrome dies at the
+OS level here. If the logo still reads left on the reporter's screen, the
+value moves and the gate stays green, which is exactly why the gate does not
+name it.


### PR DESCRIPTION
Addresses issue 1828 — the station logo in the rail's radio band reads as
further left than the nick rows above it.

## What was measured

**The premise holds: there is nothing to align.** Both left edges land on the
same 7px. `.shell-members` owns `--rail-inset: 0.5rem` and the band's border
box takes it directly (#1737); the nick rows reach the identical number
through the #1802 container pair.

**Two candidate extra offsets, both looked for, both absent** — so the side
bearing really is the whole of the difference:

* a leading space sigil would have put a full monospace advance of whitespace
  in front of every unprefixed nick. `memberSigil/1` does return `" "` for
  plain, but `sigilToPrefix` maps that to `""` and `NickText` then emits no
  prefix span at all.
* a padding on the row's click button would have done the same.
  `.members-pane li .member-name` resets it to `padding: 0`.

**The bearing itself, measured rather than guessed** — read out of the two
fonts `--font-mono` resolves to on macOS, at a 14px em:

| font | advance | lsb a–z median | lsb a–z max |
|---|---|---|---|
| SF Mono (`ui-monospace`) | 8.65px | 1.36px | 2.02px (`k`) |
| Menlo | 8.43px | 1.30px | 2.47px (`r`) |

The image ink sits ON a line the glyph ink only approaches by ~1.3px, and a
filled mass reads heavier than sparse strokes at the same x. `0.15rem` = 2.1px
puts the logo's ink between that median and that maximum, i.e. just *inside* a
typical nick's rather than level with it.

## What changed

One declaration: `padding-inline-start: 0.15rem` on `.rail-radio-now-logo`.

**The mechanism was forced, not preferred.** The logo and the title are
consecutive flex items, so the 2.1px comes out of one of them and the box
model has no third option: a `margin` keeps the artwork pristine and carries
the title and the track line right along with the logo; a `padding` moves
nothing else and pays for it in the image. The report forbids moving the
title, so it is the padding — priced before choosing: with the global
`border-box` the content box goes 28px → 25.9px against an unchanged 28px
height, so `object-fit: cover` crops ~1.05px off each side of artwork that is
square in all twenty station files. Cover crops and never distorts; that is
the policy the rule already declared.

Untouched, per the report's own scope: `.rail-radio-now`'s zero horizontal
padding (#1737's full-bleed removal), the title, the track line, the ⏹, the
band's border box, and the picker's `.rail-radio-station-logo`.

## Gates

* `scripts/bun.sh run check` — **rc=0**, 5 stages, 0 failed.
* `scripts/bun.sh run test` — **rc=0**, 326 files / 6416 tests.
* `scripts/design-notes-gate.sh origin/main` — **rc=0**, run after the commit,
  reports `1 new entry heading(s), separator and marker present`.
* Not run, not mine to run: `scripts/check.sh`, mix, docker, e2e. This branch
  touches no Elixir — one CSS declaration, one new vitest file, one test-helper
  move, one decision-log entry.
* No rebase: `origin/main` is still `b6c8dda8`, the commit this branched from,
  so the branch is already fast-forwardable and a `union-rebase` run here would
  be vacuous rather than green.

## The new gate, and what it refuses to assert

`railRadioBandInset.test.ts` holds the two things a source reader honestly can,
and each was falsified by its own mutant:

| assertion | mutant | result |
|---|---|---|
| nothing in the band but the logo insets itself horizontally | `padding: 0.4rem 0` → `0.4rem 0.5rem` on `.rail-radio-now` | RED on this one, other stays green |
| the logo's inset is a padding, never a margin | `padding-inline-start` → `margin-inline-start` | RED on this one, other stays green |

The first closes a real gap: `railInset.test.ts` only polices the children the
container addresses by name, so a `padding-inline` sneaking back onto
`.rail-radio-now` — the tempting cure for exactly this report — was ungated.

**The value is deliberately unasserted.** 2.1px is an optical judgement, and
re-reading `0.15rem` off the sheet under test would mirror the fix rather than
constrain it.

**And there is no e2e, as a property of the DOM rather than a shrug.** The
pixel this moves is the left edge of the image's CONTENT box.
`getBoundingClientRect`, `getClientRects` and `offsetLeft` all return the
BORDER box, which is unchanged at 7px by design, and a replaced element's
painted rect under `object-fit` is not exposed at all. The only browser-side
handle is `getComputedStyle().paddingInlineStart` — the stylesheet read back
through an engine, which is what the vitest gate already does without a
browser or a lane.

## What I will not claim

Whether 2.1px is **enough**. The nudge is grounded in the bearing it corrects,
but optical adequacy is a judgement on a real render and this host has no
browser to make it on. If it still reads left on the reporter's screen the
value moves and the gate stays green — which is why the gate does not name it.