### PR TITLE
cic: make the short-landscape rails draggable, within their own bounds (issue 1827)

### DIFF
--- a/cicchetto/e2e/tests/issue1827-landscape-rails-draggable.spec.ts
+++ b/cicchetto/e2e/tests/issue1827-landscape-rails-draggable.spec.ts
@@ -1,0 +1,154 @@
+// issue 1827 — in the #319 short-landscape tier the rail drag handles stayed
+// mounted, kept painting a `col-resize` cursor and kept accepting the drag,
+// but the column never moved: that tier pinned `grid-template-columns` to a
+// literal `8rem 1fr 7rem` and did not reference the `--sidebar-width` /
+// `--members-width` custom properties the handle writes. The affordance
+// promised an action the layout had already opted out of.
+//
+// Ruling: a visible rail must be resizable, in every tier, with the shell's
+// height no longer a condition. So the tier consumes the vars now, and the
+// leak it used to prevent by ignoring them — a rail widened on a tall window
+// flooding the centre on a short one — is stopped at the clamp instead:
+// lib/sidebarWidths.ts gives this tier its own floor (COMPACT_MIN_WIDTH_PX)
+// and its own ceiling (a QUARTER of the viewport, not a half), evaluated on
+// every read and write, so a stored width clamps DOWN on the way in.
+//
+// This is the pair #319 could not assert and this issue exists for: the
+// never-dragged default is unchanged (that is issue319-landscape-compact-
+// shell.spec.ts, deliberately untouched) AND the handle now moves something.
+//
+// jsdom renders no layout and cascades no `@media`, so the unit tests can
+// only reach the JS half — whether the *column* moves is a real-browser
+// question and this spec is the only place it is asked. RED pre-fix on the
+// width-changed assertion: the grid ignored the var, so the drag left the
+// sidebar at its literal 8rem.
+//
+// Runs on the desktop chromium project; the viewport is overridden to the
+// same 844x390 5" landscape shape #319 uses, so both specs describe the same
+// tier.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: a UI-shape
+// contract, subject-shape-agnostic. Registered seed suffices.
+
+import type { Page } from "@playwright/test";
+import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Same shape as issue319-landscape-compact-shell.spec.ts: wide enough for the
+// desktop shell (> 768px), short enough for the tier (<= 500px).
+const TIER = { width: 844, height: 390 };
+
+test.use({ viewport: TIER });
+test.setTimeout(60_000);
+
+// The tier's ceiling, mirrored from lib/sidebarWidths.ts: a quarter of the
+// viewport, so both rails at their cap still leave the centre at least half.
+const TIER_CAP_PX = Math.floor(TIER.width / 4);
+
+async function asideWidth(page: Page, selector: string): Promise<number> {
+  const box = await page.locator(selector).boundingBox();
+  if (!box) throw new Error(`${selector} has no bounding box`);
+  return Math.round(box.width);
+}
+
+async function dragHandleBy(page: Page, selector: string, dx: number): Promise<void> {
+  const box = await page.locator(selector).boundingBox();
+  if (!box) throw new Error(`${selector} has no bounding box`);
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x + dx, y, { steps: 10 });
+  await page.mouse.up();
+}
+
+async function openChannel(page: Page): Promise<void> {
+  const vjt = specUser();
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
+}
+
+test("issue 1827 landscape — the drag handle actually moves the rail in the short tier", async ({
+  page,
+}) => {
+  await openChannel(page);
+
+  // Cold, never dragged: the tier's own slim default still renders. This is
+  // #319's contract and it must survive untouched — the var is absent until
+  // the first drag, so the `8rem` fallback is what the grid resolves.
+  const widthBefore = await asideWidth(page, ".shell-sidebar");
+  expect(
+    widthBefore,
+    `issue 1827 — never-dragged left rail ${widthBefore}px must still be #319-slim (< 176px)`,
+  ).toBeLessThan(176);
+
+  const handle = page.locator(".shell-sidebar .resize-handle-left");
+  await expect(handle).toHaveCount(1);
+  await expect(handle).toHaveAttribute("role", "separator");
+
+  // THE assertion the issue is about. RED pre-fix: the tier's
+  // `grid-template-columns: 8rem 1fr 7rem` ignored the var the drag writes,
+  // so this width came back unchanged and the operator saw nothing move.
+  await dragHandleBy(page, ".shell-sidebar .resize-handle-left", 60);
+  const widthAfter = await asideWidth(page, ".shell-sidebar");
+  expect(
+    widthAfter,
+    `issue 1827 — rail must MOVE on drag in the short-landscape tier (was ${widthBefore}px, still ${widthAfter}px)`,
+  ).toBeGreaterThan(widthBefore + 40);
+
+  // And it is a real drag, not a jump to some fixed width.
+  expect(Math.abs(widthAfter - (widthBefore + 60))).toBeLessThanOrEqual(5);
+});
+
+test("issue 1827 landscape — the tier's own ceiling keeps the centre the bulk", async ({
+  page,
+}) => {
+  await openChannel(page);
+
+  // Drag well past anything the tier should allow. The desktop bound would
+  // permit half the viewport (422px); this tier's is a quarter.
+  await dragHandleBy(page, ".shell-sidebar .resize-handle-left", 600);
+
+  const sidebar = await asideWidth(page, ".shell-sidebar");
+  expect(
+    sidebar,
+    `issue 1827 — left rail ${sidebar}px must clamp to the tier ceiling ${TIER_CAP_PX}px, not the desktop half`,
+  ).toBeLessThanOrEqual(TIER_CAP_PX + 5);
+
+  const centre = await asideWidth(page, ".shell-main");
+  expect(
+    centre,
+    `issue 1827 — centre ${centre}px must keep at least half of ${TIER.width}px even at the rail's cap`,
+  ).toBeGreaterThanOrEqual(TIER.width / 2 - 5);
+});
+
+test("issue 1827 landscape — a width stored on a tall window clamps DOWN on the way in", async ({
+  page,
+}) => {
+  // This is the leak the tier used to prevent by refusing to read the vars at
+  // all, and the reason the ruling could keep the affordance without giving
+  // the centre away: 400px is a legitimate desktop rail and a catastrophic
+  // one on an 844px-wide short window.
+  await page.addInitScript(() => {
+    localStorage.setItem("cicchetto.sidebarWidth", "400");
+  });
+  await openChannel(page);
+
+  const sidebar = await asideWidth(page, ".shell-sidebar");
+  expect(
+    sidebar,
+    `issue 1827 — stored 400px must clamp to the tier ceiling ${TIER_CAP_PX}px on entry, got ${sidebar}px`,
+  ).toBeLessThanOrEqual(TIER_CAP_PX + 5);
+
+  // Non-destructive: the read clamps what it returns, it does not rewrite
+  // storage, so leaving the tier restores the operator's desktop width.
+  const stored = await page.evaluate(() => localStorage.getItem("cicchetto.sidebarWidth"));
+  expect(stored, "issue 1827 — clamping a read must not overwrite the stored desktop width").toBe(
+    "400",
+  );
+});

--- a/cicchetto/src/ResizeHandle.tsx
+++ b/cicchetto/src/ResizeHandle.tsx
@@ -1,7 +1,10 @@
 import { type Component, onCleanup } from "solid-js";
 import {
+  clampWidth,
   getSidebarWidth,
-  MIN_WIDTH_PX,
+  getStoredSidebarWidth,
+  maxWidthPx,
+  minWidthPx,
   type SidebarSide,
   setSidebarWidth,
 } from "./lib/sidebarWidths";
@@ -67,11 +70,12 @@ const ResizeHandle: Component<Props> = (props) => {
       if (!aside) return;
       const r = aside.getBoundingClientRect();
       const raw = props.side === "left" ? clientX - r.left : r.right - clientX;
-      const clamped = Math.min(
-        Math.floor(window.innerWidth / 2),
-        Math.max(MIN_WIDTH_PX, Math.round(raw)),
-      );
-      document.documentElement.style.setProperty(CSS_VAR[props.side], `${clamped}px`);
+      // issue 1827 — `clampWidth`, not a second inlined copy of the bound.
+      // It is the SAME function `setSidebarWidth` applies on pointerup, which
+      // is what lets the comment below still promise that the persisted value
+      // equals the one the operator watched; and it is the only reason the
+      // short-landscape tier's tighter bounds reach the live drag at all.
+      document.documentElement.style.setProperty(CSS_VAR[props.side], `${clampWidth(raw)}px`);
     }
 
     function onMove(ev: PointerEvent) {
@@ -117,16 +121,32 @@ const ResizeHandle: Component<Props> = (props) => {
   // width even before the user drags. (main.tsx's
   // applySidebarWidthsFromStorage handles this on cold load; this is a
   // safety net for hot-reload paths that don't re-run main.tsx.)
-  const initial = getSidebarWidth(props.side);
-  document.documentElement.style.setProperty(CSS_VAR[props.side], `${initial}px`);
+  //
+  // issue 1827 — ONLY when there is a stored value. This used to write the
+  // var unconditionally, which defeated every per-tier CSS default exactly
+  // the way the boot call did; a handle that has never been dragged must
+  // leave the stylesheet's own fallback standing.
+  const stored = getStoredSidebarWidth(props.side);
+  if (stored !== null) {
+    document.documentElement.style.setProperty(CSS_VAR[props.side], `${stored}px`);
+  }
 
   // aria-valuenow tracks the current width so screen readers announce
   // the size change as the operator drags. role="separator" with
   // aria-orientation="vertical" requires valuenow/min/max for the
   // resizable-separator pattern (ARIA 1.2 §6.6.16).
-  const ariaValueNow = () => getSidebarWidth(props.side);
-  const ariaValueMax = () =>
-    typeof window === "undefined" ? 1000 : Math.floor(window.innerWidth / 2);
+  //
+  // issue 1827 — measure the owning aside rather than re-deriving from
+  // storage. With the per-tier default now living in CSS, storage does not
+  // know what a never-dragged rail renders at (8rem in the short-landscape
+  // tier, 16rem on the desktop shell), so deriving would announce a width
+  // the operator is not looking at. The rect is the resolved grid track,
+  // whichever arm produced it; the storage read stays as the fallback for
+  // pre-layout mounts, where the rect is 0.
+  const ariaValueNow = () => {
+    const measured = handleEl?.parentElement?.getBoundingClientRect().width ?? 0;
+    return measured > 0 ? Math.round(measured) : getSidebarWidth(props.side);
+  };
 
   return (
     // <hr> can't host pointer-drag interaction or custom CSS sizing;
@@ -145,8 +165,8 @@ const ResizeHandle: Component<Props> = (props) => {
       aria-orientation="vertical"
       aria-label={props.side === "left" ? "Resize sidebar" : "Resize members pane"}
       aria-valuenow={ariaValueNow()}
-      aria-valuemin={MIN_WIDTH_PX}
-      aria-valuemax={ariaValueMax()}
+      aria-valuemin={minWidthPx()}
+      aria-valuemax={maxWidthPx()}
       onPointerDown={onPointerDown}
     />
   );

--- a/cicchetto/src/__tests__/ResizeHandle.test.tsx
+++ b/cicchetto/src/__tests__/ResizeHandle.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@solidjs/testing-library";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ResizeHandle from "../ResizeHandle";
 
 // Helpers to fire PointerEvent-shaped events. jsdom's PointerEvent has
@@ -136,5 +136,69 @@ describe("ResizeHandle component", () => {
     const handle = aside.querySelector(".resize-handle") as HTMLElement;
     handle.dispatchEvent(makePointerEvent("pointerdown", { clientX: 256, button: 2 }));
     expect(document.documentElement.classList.contains("resize-dragging")).toBe(false);
+  });
+
+  // issue 1827 — mounting used to write the CSS var unconditionally, which
+  // defeated the per-tier CSS default exactly the way main.tsx's boot call
+  // did. A handle that has never been dragged must leave the var alone.
+  it("writes NO CSS var on mount when nothing is stored", () => {
+    mountInAside("left", { left: 0, right: 256 });
+    expect(document.documentElement.style.getPropertyValue("--sidebar-width")).toBe("");
+  });
+
+  describe("in the short-landscape tier", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 844 });
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: (q: string) => ({
+          matches: q.includes("max-height: 500px"),
+          media: q,
+          addEventListener() {},
+          removeEventListener() {},
+        }),
+      });
+    });
+
+    afterEach(() => {
+      Reflect.deleteProperty(window, "matchMedia");
+    });
+
+    // The whole point of the issue: in this tier the drag used to write a var
+    // the grid did not reference, so the column never moved. It moves now.
+    it("moves the column on drag, within the tier's own bounds", () => {
+      const { aside } = mountInAside("left", { left: 0, right: 112 });
+      const handle = aside.querySelector(".resize-handle") as HTMLElement;
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientX: 112 }));
+      window.dispatchEvent(makePointerEvent("pointermove", { clientX: 180 }));
+      expect(document.documentElement.style.getPropertyValue("--sidebar-width")).toBe("180px");
+      window.dispatchEvent(makePointerEvent("pointerup", { clientX: 180 }));
+      expect(localStorage.getItem("cicchetto.sidebarWidth")).toBe("180");
+    });
+
+    it("floors at the tier constant, below the 160px desktop floor", async () => {
+      const { COMPACT_MIN_WIDTH_PX } = await import("../lib/sidebarWidths");
+      const { aside } = mountInAside("left", { left: 0, right: 112 });
+      const handle = aside.querySelector(".resize-handle") as HTMLElement;
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientX: 112 }));
+      window.dispatchEvent(makePointerEvent("pointermove", { clientX: 10 }));
+      expect(document.documentElement.style.getPropertyValue("--sidebar-width")).toBe(
+        `${COMPACT_MIN_WIDTH_PX}px`,
+      );
+    });
+
+    // The live drag, the persisted value and aria-valuemax all read the same
+    // bound. Before this they were three separate copies of `innerWidth / 2`
+    // and only one of them could be made tier-aware.
+    it("announces the tier cap as aria-valuemax, matching the drag clamp", () => {
+      const { aside } = mountInAside("left", { left: 0, right: 112 });
+      const handle = aside.querySelector(".resize-handle") as HTMLElement;
+      expect(handle.getAttribute("aria-valuemax")).toBe("211");
+
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientX: 112 }));
+      window.dispatchEvent(makePointerEvent("pointermove", { clientX: 9999 }));
+      expect(document.documentElement.style.getPropertyValue("--sidebar-width")).toBe("211px");
+    });
   });
 });

--- a/cicchetto/src/__tests__/sidebarWidths.test.ts
+++ b/cicchetto/src/__tests__/sidebarWidths.test.ts
@@ -8,6 +8,24 @@ const STORAGE_KEY_RIGHT = "cicchetto.membersWidth";
 const CSS_VAR_LEFT = "--sidebar-width";
 const CSS_VAR_RIGHT = "--members-width";
 
+// issue 1827 — the short-landscape tier predicate, mirrored from
+// themes/default.css. jsdom implements no matchMedia at all, so the desktop
+// cases below leave it UNDEFINED on purpose: that is the "not in the tier"
+// arm, and it also pins the module's absent-matchMedia guard.
+function enterShortLandscape(innerWidth: number): void {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: innerWidth });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (q: string) => ({
+      matches: q.includes("max-height: 500px"),
+      media: q,
+      addEventListener() {},
+      removeEventListener() {},
+    }),
+  });
+}
+
 describe("sidebarWidths module", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -20,6 +38,8 @@ describe("sidebarWidths module", () => {
       writable: true,
       value: 1024,
     });
+    // Undo any tier stub a previous test installed.
+    Reflect.deleteProperty(window, "matchMedia");
   });
 
   describe("getSidebarWidth()", () => {
@@ -125,11 +145,27 @@ describe("sidebarWidths module", () => {
   });
 
   describe("applySidebarWidthsFromStorage()", () => {
-    it("writes both CSS vars from defaults on cold load", async () => {
+    // issue 1827 — this replaces a test that asserted the OPPOSITE ("writes
+    // both CSS vars from defaults on cold load", pinning 256px/224px with
+    // localStorage empty). That behaviour is the defect: the var was written
+    // for EVERY user, so `var(--sidebar-width, 8rem)` in the short-landscape
+    // tier could never reach its 8rem fallback and a never-dragged operator
+    // got the 256px desktop rail in a tier built to prevent exactly that.
+    // Leaving the var unset is what lets each tier's own CSS default win,
+    // and it keeps those defaults in `rem` so they track --font-size.
+    it("writes NO CSS var on cold load, so the CSS default wins", async () => {
       const { applySidebarWidthsFromStorage } = await import("../lib/sidebarWidths");
       applySidebarWidthsFromStorage();
-      expect(document.documentElement.style.getPropertyValue(CSS_VAR_LEFT)).toBe("256px");
-      expect(document.documentElement.style.getPropertyValue(CSS_VAR_RIGHT)).toBe("224px");
+      expect(document.documentElement.style.getPropertyValue(CSS_VAR_LEFT)).toBe("");
+      expect(document.documentElement.style.getPropertyValue(CSS_VAR_RIGHT)).toBe("");
+    });
+
+    it("writes only the side that has a stored value", async () => {
+      localStorage.setItem(STORAGE_KEY_LEFT, "300");
+      const { applySidebarWidthsFromStorage } = await import("../lib/sidebarWidths");
+      applySidebarWidthsFromStorage();
+      expect(document.documentElement.style.getPropertyValue(CSS_VAR_LEFT)).toBe("300px");
+      expect(document.documentElement.style.getPropertyValue(CSS_VAR_RIGHT)).toBe("");
     });
 
     it("writes both CSS vars from stored values", async () => {
@@ -147,6 +183,57 @@ describe("sidebarWidths module", () => {
       const { applySidebarWidthsFromStorage } = await import("../lib/sidebarWidths");
       applySidebarWidthsFromStorage();
       expect(document.documentElement.style.getPropertyValue(CSS_VAR_LEFT)).toBe("400px");
+    });
+  });
+
+  // issue 1827 — the short-landscape tier (#319) used to pin its rails to
+  // fixed 8rem/7rem and ignore these vars outright, so the drag handle moved
+  // nothing. The rails are draggable in EVERY tier now; what the tier keeps
+  // is its own, TIGHTER pair of bounds, so a width chosen on a tall window
+  // cannot leak in and starve the centre.
+  describe("short-landscape tier bounds", () => {
+    it("keeps MIN_WIDTH_PX at 160 — the tier floor is a separate constant", async () => {
+      const { MIN_WIDTH_PX, COMPACT_MIN_WIDTH_PX } = await import("../lib/sidebarWidths");
+      expect(MIN_WIDTH_PX).toBe(160);
+      expect(COMPACT_MIN_WIDTH_PX).toBeLessThan(MIN_WIDTH_PX);
+    });
+
+    it("floors at the tier constant, not at the 160px desktop floor", async () => {
+      enterShortLandscape(844);
+      const { clampWidth, COMPACT_MIN_WIDTH_PX } = await import("../lib/sidebarWidths");
+      expect(clampWidth(10)).toBe(COMPACT_MIN_WIDTH_PX);
+    });
+
+    it("caps at a quarter of the viewport, so the centre keeps the bulk", async () => {
+      enterShortLandscape(844);
+      const { clampWidth, maxWidthPx } = await import("../lib/sidebarWidths");
+      expect(maxWidthPx()).toBe(211);
+      expect(clampWidth(9999)).toBe(211);
+      // Both rails at the cap still leave the centre at least half the width.
+      expect(844 - 2 * 211).toBeGreaterThanOrEqual(844 / 2);
+    });
+
+    it("clamps an already-stored wide value DOWN on entering the tier", async () => {
+      // Widened to 400px on a tall window, then the window goes short.
+      localStorage.setItem(STORAGE_KEY_LEFT, "400");
+      enterShortLandscape(844);
+      const { getSidebarWidth } = await import("../lib/sidebarWidths");
+      expect(getSidebarWidth("left")).toBe(211);
+    });
+
+    it("does not rewrite storage when it clamps a read down", async () => {
+      localStorage.setItem(STORAGE_KEY_LEFT, "400");
+      enterShortLandscape(844);
+      const { getSidebarWidth } = await import("../lib/sidebarWidths");
+      getSidebarWidth("left");
+      // Leaving the tier must restore the operator's desktop width.
+      expect(localStorage.getItem(STORAGE_KEY_LEFT)).toBe("400");
+    });
+
+    it("leaves a usable travel range between the tier floor and cap", async () => {
+      enterShortLandscape(844);
+      const { maxWidthPx, COMPACT_MIN_WIDTH_PX } = await import("../lib/sidebarWidths");
+      expect(maxWidthPx() - COMPACT_MIN_WIDTH_PX).toBeGreaterThan(100);
     });
   });
 });

--- a/cicchetto/src/lib/sidebarWidths.ts
+++ b/cicchetto/src/lib/sidebarWidths.ts
@@ -13,12 +13,29 @@
 // device-local UI prefs (different desktops have different ergonomic widths)
 // stay client-side. fontSize.ts + theme.ts set the precedent.
 //
-// Clamp policy:
-//   * Min width:  MIN_WIDTH_PX (operator can't accidentally hide the column).
-//   * Max width:  50% of window.innerWidth (operator can't accidentally hide
-//                 all scrollback). Evaluated at read/write time against the
-//                 current viewport, so resizing the browser narrower than
-//                 the stored width clamps down on next read.
+// 🔴 A SIDE WITH NO STORED WIDTH GETS NO CSS VAR (issue 1827). The var is
+// written only once the operator has actually dragged. That is load-bearing,
+// not tidiness: the per-tier DEFAULT lives in the stylesheet, as the fallback
+// arm of `var(--sidebar-width, …)`, and a var written for everybody makes
+// every one of those fallbacks unreachable. This module used to write
+// DEFAULT_PX (256 / 224) on every cold load, so the #319 short-landscape
+// tier's `8rem` / `7rem` could never render and a never-dragged operator got
+// the 256px desktop rail in the tier built to prevent exactly that. Keeping
+// the defaults in CSS also keeps them in `rem`, so they track --font-size
+// (S=12px … XXL=20px) the way the rest of that tier does; a px constant here
+// would freeze them at one font size.
+//
+// Clamp policy — TWO tiers, because the bound is not one number:
+//   * Min width:  MIN_WIDTH_PX on the desktop shell; COMPACT_MIN_WIDTH_PX in
+//                 the short-landscape tier, whose whole rail is narrower than
+//                 the desktop floor.
+//   * Max width:  half the viewport on the desktop shell; a QUARTER of it in
+//                 the short-landscape tier, so both rails at their cap still
+//                 leave the centre at least half the width.
+//   * Both are evaluated at read/write time against the current viewport, so
+//     a width chosen on a tall window clamps DOWN on entering the tier
+//     instead of leaking in — and, because a read never writes back, it is
+//     restored in full on leaving.
 
 export type SidebarSide = "left" | "right";
 
@@ -39,21 +56,56 @@ const DEFAULT_PX: Record<SidebarSide, number> = {
 
 export const MIN_WIDTH_PX = 160;
 
-function viewportMaxPx(): number {
+// issue 1827 — the tier's own floor. Deliberately a SECOND constant rather
+// than a smaller MIN_WIDTH_PX: 160px is the right floor for the desktop
+// shell and must not move. In the short-landscape tier it is wider than the
+// tier's own 7rem rail (98px at the default font size), so reusing it would
+// pin the handle against its floor and give the operator nothing to drag.
+export const COMPACT_MIN_WIDTH_PX = 96;
+
+// Mirrors the #319 tier predicate in themes/default.css. Same caveat theme.ts
+// records for MOBILE_QUERY: a media query cannot read a var(), so the
+// predicate is mirrored here, not shared — change one and you must change the
+// other. Read live on every clamp, exactly as window.innerWidth already is;
+// no signal and no listener, because nothing here is reactive.
+const SHORT_LANDSCAPE_QUERY =
+  "(orientation: landscape) and (max-height: 500px) and (min-width: 769px)";
+
+function inShortLandscape(): boolean {
+  // jsdom implements no matchMedia; absent means "not in the tier", which is
+  // also the correct answer for any environment that cannot evaluate it.
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(SHORT_LANDSCAPE_QUERY).matches;
+}
+
+export function minWidthPx(): number {
+  return inShortLandscape() ? COMPACT_MIN_WIDTH_PX : MIN_WIDTH_PX;
+}
+
+// The single source of the upper bound. ResizeHandle reads it for BOTH the
+// live-drag clamp and `aria-valuemax`; before issue 1827 each of those was
+// its own inlined copy of `Math.floor(window.innerWidth / 2)`, so making the
+// bound tier-aware in one place would have left the rail snapping back at
+// pointerup and the separator announcing a maximum that was not the real one.
+export function maxWidthPx(): number {
   if (typeof window === "undefined") return Number.POSITIVE_INFINITY;
-  return Math.max(MIN_WIDTH_PX, Math.floor(window.innerWidth / 2));
+  const divisor = inShortLandscape() ? 4 : 2;
+  return Math.max(minWidthPx(), Math.floor(window.innerWidth / divisor));
 }
 
 export function clampWidth(px: number): number {
   if (!Number.isFinite(px)) return DEFAULT_PX.left;
-  return Math.min(viewportMaxPx(), Math.max(MIN_WIDTH_PX, Math.round(px)));
+  return Math.min(maxWidthPx(), Math.max(minWidthPx(), Math.round(px)));
 }
 
-function readStoredWidth(side: SidebarSide): number {
+// Clamped stored width, or null when the operator has never dragged this
+// side. null is the signal that the stylesheet owns the value — see the
+// no-var rule at the top.
+function readStoredWidth(side: SidebarSide): number | null {
   const raw = localStorage.getItem(STORAGE_KEY[side]);
-  if (raw === null) return DEFAULT_PX[side];
+  if (raw === null) return null;
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n)) return DEFAULT_PX[side];
+  if (!Number.isFinite(n)) return null;
   return clampWidth(n);
 }
 
@@ -61,8 +113,12 @@ function writeCssVar(side: SidebarSide, px: number): void {
   document.documentElement.style.setProperty(CSS_VAR[side], `${px}px`);
 }
 
-export function getSidebarWidth(side: SidebarSide): number {
+export function getStoredSidebarWidth(side: SidebarSide): number | null {
   return readStoredWidth(side);
+}
+
+export function getSidebarWidth(side: SidebarSide): number {
+  return readStoredWidth(side) ?? clampWidth(DEFAULT_PX[side]);
 }
 
 export function setSidebarWidth(side: SidebarSide, px: number): number {
@@ -72,10 +128,12 @@ export function setSidebarWidth(side: SidebarSide, px: number): number {
   return clamped;
 }
 
-// Boot-time entry. Reads both stored widths (falling back to defaults)
-// and writes both CSS vars on <html> so the first paint already has the
-// right grid template.
+// Boot-time entry. Writes the CSS var for each side the operator has
+// actually sized, and leaves the others alone so the stylesheet's own
+// per-tier default renders.
 export function applySidebarWidthsFromStorage(): void {
-  writeCssVar("left", readStoredWidth("left"));
-  writeCssVar("right", readStoredWidth("right"));
+  for (const side of ["left", "right"] as const) {
+    const stored = readStoredWidth(side);
+    if (stored !== null) writeCssVar(side, stored);
+  }
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1257,12 +1257,26 @@ html.overlay-open #root > div {
 /* Three-pane shell (P4-1) */
 
 /* UX-5 bucket BS — sidebar widths driven by CSS custom properties on
-   <html>, set by lib/sidebarWidths.ts at boot AND on drag. The fallbacks
-   (16rem / 14rem) match the pre-bucket literal values, so a fresh
-   visitor without localStorage gets the original layout. */
+   <html>, set by lib/sidebarWidths.ts on drag, and at boot for a side the
+   operator has already sized. A side never dragged has NO var, and this
+   fallback is what renders — see the no-var rule at the top of
+   sidebarWidths.ts (issue 1827).
+
+   issue 1827 — the fallbacks are `256px / 224px` and used to read
+   `16rem / 14rem`. That is a rewrite to PRESERVE what ships today, not a
+   change of it. Measured: sidebarWidths.ts wrote DEFAULT_PX (256 / 224) to
+   these vars on every cold load, so this arm never rendered and a fresh
+   visitor got 256 / 224 — while the literals here say 16rem / 14rem, which
+   at the default --font-size of 14px are 224 / 196. The two disagreed by
+   32 / 28px and the JS won every time. Now that the var is absent for a
+   fresh visitor this arm finally renders, so it has to carry the number
+   that was actually shipping, or the desktop shell would silently narrow.
+   The px also states the truth that these have not tracked --font-size
+   since UX-5 BS; the short-landscape tier below keeps `rem`, because there
+   the fallback is the tier's real default and it is meant to scale. */
 .shell {
   display: grid;
-  grid-template-columns: var(--sidebar-width, 16rem) 1fr var(--members-width, 14rem);
+  grid-template-columns: var(--sidebar-width, 256px) 1fr var(--members-width, 224px);
   grid-template-rows: 1fr;
   /* #205 — iPad standalone-PWA safe area. An iPad is WIDER than the
      768px mobile breakpoint in BOTH orientations, so `isMobile()` is
@@ -1385,10 +1399,31 @@ html.overlay-open #root > div {
    matchMedia signal to wire up (the #319 fix-direction's simpler arm). */
 @media (orientation: landscape) and (max-height: 500px) and (min-width: 769px) {
   .shell {
-    /* Slim rails; center (1fr) takes the rest. Overrides the drag-persisted
-       --sidebar-width / --members-width vars (not referenced here) so a
-       previously-widened desktop rail can't leak into the compact tier. */
-    grid-template-columns: 8rem 1fr 7rem;
+    /* Slim rails; center (1fr) takes the rest.
+
+       issue 1827 — this REFERENCES the drag vars now, where it used to
+       ignore them outright. The old comment here read "Overrides the
+       drag-persisted --sidebar-width / --members-width vars (not referenced
+       here) so a previously-widened desktop rail can't leak into the compact
+       tier", and the leak it named is real — but not referencing the vars
+       also meant the handles stayed mounted, kept painting `col-resize` and
+       kept accepting the drag while the column could not move. The ruling is
+       that a visible rail must be resizable, in every tier, with the shell's
+       height no longer a condition.
+
+       The leak is stopped where it is actually caused instead: the vars
+       carry a value already clamped to this tier's own tighter bounds
+       (COMPACT_MIN_WIDTH_PX, and a quarter of the viewport rather than a
+       half — see the clamp policy in lib/sidebarWidths.ts), so a rail
+       widened on a tall window clamps DOWN on the way in rather than
+       flooding the centre.
+
+       The `8rem` / `7rem` fallbacks are this tier's real defaults and are
+       what a never-dragged operator still gets, unchanged: the var is absent
+       until the first drag. They stay in `rem` on purpose — unlike the
+       desktop fallbacks above, these do track --font-size, which is the
+       behaviour this tier already had when the widths were literals. */
+    grid-template-columns: var(--sidebar-width, 8rem) 1fr var(--members-width, 7rem);
   }
 
   .shell.shell-no-members {
@@ -1398,8 +1433,14 @@ html.overlay-open #root > div {
        floors at the RailActions launcher's min-content, a few px over 7rem):
        a server window's `max-content` card would otherwise blow straight
        past the slim rails this compact tier exists to enforce, re-creating
-       the centre-starve inside the tier meant to prevent it. */
-    grid-template-columns: 8rem 1fr fit-content(7rem);
+       the centre-starve inside the tier meant to prevent it.
+
+       issue 1827 — the sidebar column takes the var for the same reason the
+       members-bearing arm above does: the left rail is visible here, so it
+       must be draggable. The `fit-content(7rem)` members cap is #605's and
+       is deliberately left alone — there is no members rail to drag in this
+       arm, so no dead affordance to cure. */
+    grid-template-columns: var(--sidebar-width, 8rem) 1fr fit-content(7rem);
   }
 }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1360,7 +1360,16 @@ html.overlay-open #root > div {
    or a long unbreakable token WITHOUT break-word would floor `fit-content`
    at that min-content and re-starve the centre. */
 .shell.shell-no-members {
-  grid-template-columns: var(--sidebar-width, 16rem) 1fr fit-content(14rem);
+  /* issue 1827 — `256px`, matching the sibling `.shell` rule above, for the
+     same reason and by the same measurement: the fallback arm never rendered
+     while sidebarWidths.ts wrote the var for everybody, and `16rem` is 224px
+     at the default --font-size, 32px short of the 256px the JS default was
+     really producing. Now that a never-dragged side leaves the var unset,
+     this arm renders — so it has to carry the shipping number or the
+     no-members shell alone would narrow while the members-bearing one did
+     not. The `fit-content(14rem)` cap is untouched: there is no members rail
+     to drag in this arm. */
+  grid-template-columns: var(--sidebar-width, 256px) 1fr fit-content(14rem);
 }
 
 /* #319 — landscape-compact tier. A small phone (~5") rotated to landscape

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42003,3 +42003,127 @@ real render, and this host has no browser to make it on — Chrome dies at the
 OS level here. If the logo still reads left on the reporter's screen, the
 value moves and the gate stays green, which is exactly why the gate does not
 name it.
+<!-- entry #1827 -->
+
+---
+
+## 2026-08-26 — #1827: a boot-time "apply from storage" that writes a DEFAULT kills every per-tier CSS default downstream
+
+The reported defect was small: in the #319 short-landscape tier
+(`(orientation: landscape) and (max-height: 500px) and (min-width: 769px)`)
+the rail drag handles stayed mounted, painted `col-resize` and accepted the
+drag, but the column never moved. That tier pinned `grid-template-columns`
+to a literal `8rem 1fr 7rem` and did not reference the `--sidebar-width` /
+`--members-width` custom properties the handle writes. The affordance
+promised an action the layout had opted out of.
+
+The ruling (relayed, not read first-hand — see the provenance note below) was
+the option the issue itself did not recommend: keep the affordance, in every
+tier, with the shell's height no longer a condition. "Se i rail si vedono
+devono essere resizable."
+
+### The measurement that changed the shape of the fix
+
+The obvious implementation is to make the tier read the vars with the slim
+widths as the CSS fallback — `var(--sidebar-width, 8rem)` — so a
+never-dragged operator keeps the tier's own default. **That does not work,
+and the reason generalises well past this issue.**
+
+`main.tsx:69` calls `applySidebarWidthsFromStorage()` unconditionally at
+boot, and `readStoredWidth()` returned `DEFAULT_PX` (256 / 224) when
+`localStorage` was empty. So the var was written on `<html>` for **every**
+user, dragged or not. `var(--sidebar-width, 8rem)` therefore resolves to
+`256px` in every browser where JS ran, and the fallback arm is dead code.
+Measured, not argued: the module's own committed test pinned exactly this —
+*"writes both CSS vars from defaults on cold load"*, asserting `256px` with
+storage empty.
+
+The consequence is worth stating in full, because it is the trap: had the
+tier been given that naive fallback and nothing else, a fresh visitor would
+have got a **256px** rail in the tier built to prevent precisely that, and
+`issue319-landscape-compact-shell.spec.ts` — which runs at 844x390 on a clean
+profile and asserts each rail under 176px — would have gone red. The fix
+would have shipped the #319 regression inside the cure for #319's leftover.
+
+**The general rule: a boot-time apply-from-storage helper must write only
+what the operator actually chose.** The moment it substitutes a default of
+its own, it takes ownership of a value the stylesheet was entitled to decide,
+and every per-tier `var(x, default)` downstream becomes unreachable — silently,
+because the fallback still reads correctly in the source. Storage holds
+preferences; the stylesheet holds defaults. A `null` return for "never set"
+is what keeps that boundary honest, and it is why `getStoredSidebarWidth/1`
+now exists next to `getSidebarWidth/1`.
+
+`ResizeHandle` had the identical bug on its mount path (a "safety net for
+hot-reload" write that fired for undragged handles too), which is the usual
+shape of this class: the same wrong default gets applied at two different
+doors and only one of them is where anybody looks.
+
+### Two tiers of clamp, and why MIN_WIDTH_PX did not move
+
+Ignoring the vars was preventing something real: a rail widened to 400px on a
+tall window would flood the centre of an 844px-wide short one. Consuming the
+vars means that leak has to be stopped where it is caused — at the clamp.
+
+The tier gets its OWN floor and ceiling: `COMPACT_MIN_WIDTH_PX` (96) and a
+QUARTER of the viewport rather than a half, so both rails at their cap still
+leave the centre at least half the width. `MIN_WIDTH_PX` stays 160 and is
+deliberately untouched — it is the right floor for the desktop shell, and it
+is *wider than the tier's whole 7rem rail* (98px at the default font size),
+so reusing it there would pin the handle against its own floor and give the
+operator nothing to drag. That would have been the same dead affordance in a
+smaller box, which is the objection the issue raised against this option and
+the reason a second constant is the answer rather than a smaller first one.
+
+Both bounds are evaluated at read AND write against the live viewport, so a
+stored width clamps DOWN on entering the tier; and because a read never
+writes back, the operator's desktop width is restored in full on leaving.
+
+### The upper bound had three copies, and the code claimed they were one
+
+`Math.floor(window.innerWidth / 2)` existed in three places:
+`sidebarWidths.ts` (`viewportMaxPx`, read + persist), `ResizeHandle.tsx`'s
+`applyLiveWidth` (the live drag), and `ResizeHandle.tsx`'s `ariaValueMax`
+(what assistive tech is told). `ResizeHandle.tsx` asserted in a comment that
+the first two "apply identical clamping math, so the persisted value matches
+the operator-visible one".
+
+Making one of them tier-aware would have falsified that comment: the rail
+would have followed the pointer past the tier cap and snapped back at
+pointerup, and the separator would have announced a maximum that was not the
+real one. All three now route through the exported `maxWidthPx/0`. This is
+the ordinary cost of a duplicated constant coming due — the duplication was
+harmless only while the value was a single global expression.
+
+`aria-valuenow` moved too, and for a related reason: with the default now
+living in CSS, storage no longer knows what an undragged rail renders at, so
+it measures the owning aside instead of re-deriving. The rect is the resolved
+grid track whichever arm produced it.
+
+### The desktop fallback was rewritten to PRESERVE behaviour, not change it
+
+`.shell`'s fallbacks now read `256px / 224px` where they read `16rem / 14rem`.
+This looks like a change and is the opposite of one. Because JS wrote the var
+unconditionally, that arm never rendered — and the literals disagreed with
+what shipped: at the default `--font-size` of 14px, `16rem / 14rem` are
+`224 / 196`, against the `256 / 224` the JS default actually produced, a gap
+of 32 / 28px nobody could see. Now that a fresh visitor has no var, the arm
+finally renders, so it has to carry the number that was really shipping or
+the desktop shell would silently narrow.
+
+The split that results is deliberate: the desktop fallbacks are px and state
+the truth that they have not tracked `--font-size` since UX-5 BS; the tier's
+stay `rem`, because there the fallback *is* the tier's real default and it is
+meant to scale with the S..XXL range the rest of that tier scales with.
+
+### Provenance
+
+The ruling reached this work RELAYED by another agent, from vjt's trusted
+nick, and was not read first-hand on IRC. An earlier relay of the same
+decision, from an untrusted nick, was rejected before it could be acted on —
+which is the reason this note records the chain at all.
+
+**Apply:** when a preference module and a stylesheet both have an opinion
+about a default, exactly one of them may hold it. If the module writes on
+every boot, the stylesheet's `var(x, default)` is decoration — and a reviewer
+reading the CSS will believe a fallback that cannot fire.


### PR DESCRIPTION
In the #319 short-landscape tier
(`(orientation: landscape) and (max-height: 500px) and (min-width: 769px)`)
the rail drag handles stayed mounted, painted a `col-resize` cursor and
accepted the drag — but the column never moved. That tier pinned
`grid-template-columns` to a literal `8rem 1fr 7rem` and never referenced the
`--sidebar-width` / `--members-width` custom properties the handle writes.
The affordance promised an action the layout had already opted out of.

Addresses issue 1827.

## Provenance of the ruling

The issue lists three options and says "No recommendation". The call is
**option 3** — keep the affordance, in every tier, with the shell's height no
longer a condition ("se i rail si vedono devono essere resizable"). Options 1
and 2 both remove the affordance and are out.

⚠️ **This reached the branch RELAYED and was not read first-hand.** It came
from vjt's trusted nick (`vjt!~antani@due.dita.di.grappa.chat`), relayed by
another agent; an earlier relay of the same decision, from an untrusted nick,
was rejected before it could be acted on. Recorded here and in the
DESIGN_NOTES entry because the chain, not just the content, is what made it
actionable.

## The measurement that changed the shape of the work

The obvious implementation — teach the tier `var(--sidebar-width, 8rem)` and
let the fallback carry the slim default — **does not work**, and finding out
why is most of this change.

`main.tsx:69` calls `applySidebarWidthsFromStorage()` unconditionally at boot,
and `readStoredWidth()` returned `DEFAULT_PX` (256 / 224) when `localStorage`
was empty. The var was therefore written on `<html>` for **every** user,
dragged or not, so `var(--sidebar-width, 8rem)` resolves to `256px` in any
browser where JS ran and the fallback arm is dead code. The module's own
committed test pinned exactly this — *"writes both CSS vars from defaults on
cold load"*, asserting `256px` with storage empty.

Shipping the naive fallback alone would have given a never-dragged operator a
**256px** rail inside the tier built to prevent exactly that, and turned
`issue319-landscape-compact-shell.spec.ts` (844x390, clean profile, each rail
asserted under 176px) red. The cure would have shipped the #319 regression.

So storage now answers `null` for "never set" and writes nothing. The
stylesheet keeps ownership of the per-tier default — and keeps it in `rem`,
so it tracks `--font-size` across S..XXL the way the rest of that tier does.
`ResizeHandle`'s mount path carried the identical unconditional write and had
to change with it.

## 🔴 Deliberate change flagged: the DESKTOP fallbacks become `256px / 224px`

`.shell`'s fallbacks read `16rem / 14rem` and now read `256px / 224px`. **This
is a rewrite to PRESERVE what ships, not a change of it, and it is called out
here rather than left in the diff to be discovered.**

Because JS wrote the var unconditionally, that arm never rendered — and the
literals disagreed with what actually shipped. At the default `--font-size` of
14px (`:root:177`, `html, body { font-size: var(--font-size) }`),
`16rem / 14rem` are **224 / 196**, against the **256 / 224** the JS default
produced: a gap of 32 / 28px that nobody could see because the JS won every
time. Now that a fresh visitor has no var, that arm finally renders — so it
has to carry the number that was really shipping, or **the desktop shell would
have silently narrowed by 32px**.

The px/rem split that results is deliberate: the desktop fallbacks are px and
state the truth that they have not tracked `--font-size` since UX-5 BS; the
tier's stay `rem`, because there the fallback *is* the tier's real default and
is meant to scale.

## Two tiers of clamp, and why `MIN_WIDTH_PX` did not move

Ignoring the vars was preventing something real: a rail widened to 400px on a
tall window would flood the centre of an 844px-wide short one. Consuming them
means that leak is stopped at the clamp instead.

The tier gets its own floor (`COMPACT_MIN_WIDTH_PX`, 96) and its own ceiling —
a **quarter** of the viewport rather than a half, so both rails at their cap
still leave the centre at least half the width. `MIN_WIDTH_PX` stays **160**
and is untouched: it is the right floor for the desktop shell, and it is wider
than the tier's whole 7rem rail (98px at the default font size), so reusing it
would pin the handle against its own floor and hand back the same dead
affordance in a smaller box — the objection the issue itself raises against
option 3, and the reason this is a second constant rather than a smaller
first one.

Both bounds are evaluated at read AND write against the live viewport, so a
stored width clamps DOWN on entering the tier; and because a read never writes
back, the operator's desktop width is restored in full on leaving.

## The upper bound had three copies, and the code claimed they were one

`Math.floor(window.innerWidth / 2)` lived in `sidebarWidths.ts`
(`viewportMaxPx`, read + persist), `ResizeHandle.tsx`'s `applyLiveWidth` (the
live drag) and `ResizeHandle.tsx`'s `ariaValueMax` (what assistive tech is
told) — while `ResizeHandle.tsx:82-84` asserted in a comment that the first
two "apply identical clamping math". Making one tier-aware would have left the
rail snapping back at pointerup and the separator announcing a maximum that
was not the real one. All three now route through the exported `maxWidthPx/0`.

`aria-valuenow` moved too: with the default living in CSS, storage no longer
knows what an undragged rail renders at, so it measures the owning aside
rather than re-deriving.

`.shell-no-members` gets the same treatment on its sidebar column. The
`fit-content(7rem)` members cap (#605) is deliberately untouched — there is no
members rail to drag in that arm, so no dead affordance to cure.

`issue319-landscape-compact-shell.spec.ts` is deliberately untouched: its
contract is the never-dragged default, and that default does not change.

## Falsification — every assertion was seen RED

A green e2e that has never been red is not evidence. All three new assertions
were driven red by breaking the production code in two different ways, then
green as committed:

| arm | what was broken | result |
|---|---|---|
| **R1** | tier CSS back to the literal `8rem 1fr 7rem` | assertion 1 **RED** — `rail must MOVE on drag (was 112px, still 112px)` |
| **R2** | clamp forced non-tier-aware (desktop bounds everywhere) | assertions 2+3 **RED** — `left rail 422px must clamp to the tier ceiling 211px`; `stored 400px … got 400px` |
| **GREEN** | nothing — the tree as committed | **3/3 pass**, rc=0 |

R1's `112px` is `8rem` at 14px measured in a real browser, and R2's `422px` is
the desktop half-viewport leaking in — the defect this change exists to stop,
observed rather than predicted.

Note the split is real and not redundancy: R1 leaves assertions 2 and 3
passing vacuously, R2 leaves assertion 1 passing. Neither arm alone falsifies
the spec — running one and stopping would feel like falsification and would
not be it.

The three arms were measured before the rebase onto #1828; all three
assertions then passed again inside the post-rebase full suite, so the green
is not stale against the base this merges into.

## Gates

Measured after rebasing onto `origin/main` at `4f4c039c` (#1828 landed
mid-branch; the rebase went through `scripts/union-rebase.sh`, which reported
`docs/DESIGN_NOTES.md: +124 -0 — contribution intact`, and the `#1827` marker
was re-checked unique against the NEW tip, not the one this branched from):

- `scripts/bun.sh run check` — 5/5 stages, rc=0
- `scripts/bun.sh run test` — 6427 passed / 326 files, rc=0
- `scripts/design-notes-gate.sh origin/main` — rc=0
- `scripts/integration.sh` — full suite, 797 passed / 2 failed, rc=1. **The
  two reds are not attributable to this branch**; the evidence is below, and
  the limit of that evidence is stated with it.

### The integration reds, and why they are not this change

Two full-suite runs, two reds each, **four distinct specs and zero overlap**:
`issue255-close-x-touch-action` + `pwa-badge-title-mirror` on the first,
`issue254-own-echo-live` + `ux-6-j-push-deep-link` on the second. All four
were 30-34s timeouts, not assertion failures. All ten tests in those four
files then passed in an iso-rerun on this branch, rc=0, in 27.5s total.

Three of the four carry the failure's own exoneration in the captured page
snapshot: `Could not load Grappa. — signal timed out`, or the boot screen
stuck on `fetching networks...`. In the `pwa-badge-title-mirror` snapshot the
sidebar is present and its `separator "Resize sidebar"` is in the accessibility
tree — the element this PR changes the width of is mounted and exposed; the
app simply never received its data. The ~33s window matches the 31.8s SQLite
write-lock stall already observed once in a 32.7-minute run of this suite.

A regression from this change would be stable across runs and would reproduce
in isolation. Neither holds. `ux-6-j-push-deep-link` is grouped here for
timing but NOT for cause: its snapshot shows the app fully loaded, so it is a
different flake and is not being explained by the stall.

For the reader's reference point: `main` at `4f4c039c` — the exact base this
branches from — ran the full `integration` job GREEN in CI overnight.

**Not established:** the full suite was not run on `origin/main` *locally*, so
nothing here claims the two reds reproduce on the base on this host — only
that they are unstable across runs, self-exonerating in three cases out of
four, and green in isolation. The clean base-vs-branch comparison is this
PR's own CI, which runs both on the same substrate; the local host does not
control that variable.

## What is NOT asserted

The unit tests reach the JS half only: jsdom renders no layout and cascades no
`@media`, so one of the new in-tier unit tests would have passed before this
change too — it guards the JS path, it does not detect the defect. Whether the
column moves is answered only by the e2e above. The tier ceiling is also
unverified outside the 844px width used here: `211` is arithmetic on that
viewport, and no other short-landscape width was measured.
