### PR TITLE
fix(cic): two independent CLAUDE.md violations in the channel-scoped command path

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -5750,7 +5750,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
             "socket.pushChannelBan(1, "#a", "bob")",
           ],
@@ -5762,7 +5761,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "effects": [
             "aliasList.aliases()",
             "banlistModal.openBanlistModal("freenode", "#a", "b")",
-            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
@@ -5811,7 +5809,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
             "socket.pushChannelDeop(1, "#a", ["bob"])",
           ],
@@ -5822,7 +5819,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
         "devoice": {
           "effects": [
             "aliasList.aliases()",
-            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
@@ -5889,7 +5885,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
             "socket.pushChannelKick(1, "#a", "bob", "")",
             "socket.resolveUserhost(1, "bob")",
@@ -5901,7 +5896,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
         "kick": {
           "effects": [
             "aliasList.aliases()",
-            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
@@ -5980,7 +5974,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
             "socket.pushChannelMode(1, "#a", "+s", [])",
           ],
@@ -6026,7 +6019,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
         "names": {
           "effects": [
             "aliasList.aliases()",
-            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
@@ -6079,7 +6071,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
         "op": {
           "effects": [
             "aliasList.aliases()",
-            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
@@ -6236,7 +6227,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
             "socket.pushChannelTopicClear(1, "#a")",
           ],
@@ -6249,7 +6239,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "api.postTopic("tok", "freenode", "#a", "new topic")",
             "networks.networkIdBySlug("freenode")",
-            "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
           ],
           "result": {
@@ -6259,7 +6248,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
         "topic-show": {
           "effects": [
             "aliasList.aliases()",
-            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
           ],
@@ -6315,7 +6303,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
-            "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
             "socket.pushChannelUnban(1, "#a", "bob")",
           ],
@@ -6337,7 +6324,6 @@ describe("#1396 — dispatch characterization over every arm", () => {
         "voice": {
           "effects": [
             "aliasList.aliases()",
-            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "selection.selectedChannel()",
@@ -6464,5 +6450,106 @@ describe("#1396 — dispatch characterization over every arm", () => {
         ],
       }
     `);
+  });
+});
+
+// issue 1831 — the window KIND is the answer to "am I in a channel?", and the
+// selection store already carries it. `getActiveChannel` used to re-derive
+// that answer by matching the window NAME against the network's advertised
+// CHANTYPES, so a window the store had already accepted as `kind: "channel"`
+// — and whose key it FOLDED, which `foldChannelKey` does for that kind and no
+// other — could still be invisible to every channel-scoped verb. TopicBar's
+// modes button mounts off `kind` (`Shell.tsx` `<Show when={selKind() ===
+// "channel"}>`) and keeps working straight through the divergence, which is
+// the button-works/command-fails split reported in the PWA. WHICH state
+// produces the divergence there is not established by these tests, and they
+// do not claim it.
+describe("compose submit — the active-channel resolver reads the window KIND (issue 1831)", () => {
+  // A channel window whose sigil the network does not advertise: the store
+  // says `kind: "channel"`, the CHANTYPES sniff says nick. Every
+  // channel-scoped verb has to follow the store.
+  const divergeKindFromSigil = async (): Promise<() => void> => {
+    const sel = await import("../lib/selection");
+    // Not `…Once`: dispatch consults the selection more than once per submit.
+    vi.mocked(sel.selectedChannel).mockReturnValue({
+      networkSlug: "freenode",
+      channelName: "&local",
+      kind: "channel",
+    });
+    isupportMock.chantypes = ["#"];
+    return () => {
+      isupportMock.chantypes = ["#", "&", "+", "!"];
+      vi.mocked(sel.selectedChannel).mockReturnValue({
+        networkSlug: "freenode",
+        channelName: "#a",
+        kind: "channel",
+      });
+    };
+  };
+
+  it("bare /mode opens the modal for the window the store calls a channel", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const restore = await divergeKindFromSigil();
+    try {
+      const modeModal = await import("../lib/modeModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "&local");
+      compose.setDraft(k, "/mode");
+      const result = await compose.submit(k, "freenode", "&local");
+
+      expect(modeModal.openModeModal).toHaveBeenCalledWith("freenode", "&local");
+      expect(result).toEqual({ ok: true });
+    } finally {
+      restore();
+    }
+  });
+
+  // The cure is the resolver, so the whole class moves with it — 13 verbs
+  // share `requireChannel` and 4 more call `getActiveChannel` directly. /op
+  // stands for the class: while it re-derived the sigil it reported "requires
+  // an active channel window" for a window that plainly is one.
+  it("the requireChannel class follows — /op resolves the same window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const restore = await divergeKindFromSigil();
+    try {
+      const socket = await import("../lib/socket");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "&local");
+      compose.setDraft(k, "/op bob");
+      const result = await compose.submit(k, "freenode", "&local");
+
+      expect(socket.pushChannelOp).toHaveBeenCalledWith(1, "&local", ["bob"]);
+      expect(result).toEqual({ ok: true });
+    } finally {
+      restore();
+    }
+  });
+
+  // The guard that has to survive the swap: a QUERY window is still not a
+  // channel, and the operator must still read the actionable error.
+  it("a query window is still refused, by kind rather than by sigil", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sel = await import("../lib/selection");
+    vi.mocked(sel.selectedChannel).mockReturnValue({
+      networkSlug: "freenode",
+      channelName: "alice",
+      kind: "query",
+    });
+    try {
+      const socket = await import("../lib/socket");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "alice");
+      compose.setDraft(k, "/op bob");
+      const result = await compose.submit(k, "freenode", "alice");
+
+      expect(socket.pushChannelOp).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ error: expect.stringContaining("channel window") });
+    } finally {
+      vi.mocked(sel.selectedChannel).mockReturnValue({
+        networkSlug: "freenode",
+        channelName: "#a",
+        kind: "channel",
+      });
+    }
   });
 });

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -260,13 +260,26 @@ vi.mock("../lib/banlistModal", () => ({
 // #1251 — compose decides "list QUERY vs mode change" from the network's 005
 // (`listModesQueryable`, published by the server). Default here is a
 // bahamut-shaped network: `b` and `z` are lists, everything else is a flag.
+//
+// issue 1831 — `chanmodesA` is the SECOND fact that decision needs, and the
+// two sets are not the same. `chanmodes.a` is what the NETWORK advertises as
+// a list; `listModesQueryable` is the subset grappa knows reply numerics for
+// (server-side `ListModes.queryable/1`). A letter in the first and not in the
+// second is a list nobody can read, and it used to be sent to the wire anyway.
 const isupportMock = vi.hoisted(() => ({
   listModesQueryable: ["b", "z"],
+  chanmodesA: ["b", "z"],
   chantypes: ["#", "&", "+", "!"] as readonly string[],
 }));
 vi.mock("../lib/isupport", () => ({
   isupportForNetwork: () => ({
     listModesQueryable: isupportMock.listModesQueryable,
+    chanmodes: {
+      a: isupportMock.chanmodesA,
+      b: ["k"],
+      c: ["l"],
+      d: ["i", "m", "n", "p", "s", "t"],
+    },
     chantypes: isupportMock.chantypes,
   }),
   // #1255 — compose asks the store which sigils open a channel on THIS
@@ -6551,5 +6564,119 @@ describe("compose submit — the active-channel resolver reads the window KIND (
         kind: "channel",
       });
     }
+  });
+});
+
+// issue 1831 — the silent `{ok: true}`. A paramless single letter the NETWORK
+// advertises as type A is a LIST QUERY; when grappa knows no reply numerics
+// for it, the pre-fix code fell through to a raw `MODE #chan <letter>` and
+// returned ok. The ircd streams the list, nothing here collects it, and the
+// operator gets no modal, no error and no rows — indistinguishable from the
+// command never having run. CLAUDE.md forbids exactly that shape at a
+// boundary.
+describe("compose submit — an unreadable list query is reported, not fired (issue 1831)", () => {
+  // `a` is type A on this network AND absent from the queryable set — the one
+  // combination that used to be silent.
+  const advertiseUnreadableList = (): (() => void) => {
+    isupportMock.chanmodesA = ["b", "z", "a"];
+    return () => {
+      isupportMock.chanmodesA = ["b", "z"];
+    };
+  };
+
+  it("/mode #chan <unreadable type-A letter> is reported, not fired at nobody", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const restore = advertiseUnreadableList();
+    try {
+      const socket = await import("../lib/socket");
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/mode #a a");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(socket.pushChannelMode).not.toHaveBeenCalled();
+      expect(banlistModal.openBanlistModal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        error: "/mode: grappa can't read this network's +a list (it offers +b +z)",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  // #1251 ruled the two spellings must behave alike; the WORDING is part of
+  // alike, so this pins the same string rather than merely "some error".
+  it("/mode +<unreadable letter> — the current-channel spelling behaves alike", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const restore = advertiseUnreadableList();
+    try {
+      const socket = await import("../lib/socket");
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/mode +a");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(socket.pushChannelMode).not.toHaveBeenCalled();
+      expect(banlistModal.openBanlistModal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        error: "/mode: grappa can't read this network's +a list (it offers +b +z)",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  // The third spelling of one question, and the reason the message is built in
+  // one place: /banlist names the same cause, with its own verb.
+  it("/banlist <unreadable letter> names the same cause with its own verb", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const restore = advertiseUnreadableList();
+    try {
+      const banlistModal = await import("../lib/banlistModal");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+      compose.setDraft(k, "/banlist a");
+      const result = await compose.submit(k, "freenode", "#a");
+
+      expect(banlistModal.openBanlistModal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        error: "/banlist: grappa can't read this network's +a list (it offers +b +z)",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  // The distinction the wording exists for: a letter the network never
+  // advertised as a list HAS no list here, and blaming grappa would send the
+  // operator after a cause that is not there.
+  it("a letter the network never advertised keeps the network-side wording", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const banlistModal = await import("../lib/banlistModal");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/banlist e");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(banlistModal.openBanlistModal).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      error: "/banlist: this network has no +e list (it offers +b +z)",
+    });
+  });
+
+  // The mutation guard: a single letter that is NOT type A here is a mode
+  // CHANGE with a visible echo, and it must keep reaching the wire.
+  it("a single flag letter is still a mutation, not an unreadable list", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const socket = await import("../lib/socket");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/mode #a m");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(socket.pushChannelMode).toHaveBeenCalledWith(1, "#a", "m", []);
+    expect(result).toEqual({ ok: true });
   });
 });

--- a/cicchetto/src/lib/commands/mode.ts
+++ b/cicchetto/src/lib/commands/mode.ts
@@ -1,7 +1,7 @@
 import { ownNickForNetwork } from "../api";
 import { openBanlistModal } from "../banlistModal";
 import { isChannelName } from "../chantypes";
-import { isupportForNetwork } from "../isupport";
+import { type IsupportEntry, isupportForNetwork } from "../isupport";
 import { openModeModal } from "../modeModal";
 import { networkBySlug, user } from "../networks";
 import { nickEquals } from "../nickEquals";
@@ -19,19 +19,72 @@ import type { CommandHandler } from "./context";
 // #536/#1251 — is this `/mode` a type-A LIST QUERY rather than a mode change?
 // Three conditions, all necessary: no parameter (a mask makes it a MUTATION,
 // `/mode #chan +b nick!*@*`), exactly one optionally-signed letter, and that
-// letter is one this NETWORK offers as a queryable list (server-published, in
-// `isupport.listModesQueryable` — cic never derives it).
+// letter is a LIST on this NETWORK (`isupport.chanmodes.a`, server-published
+// — cic never derives it).
 //
-// Why it is not in the pure parser: the third condition is 005 data.
+// Why it is not in the pure parser: those conditions are 005 data.
 // `/mode #chan +i` on a network where `i` is a flag must stay a mode change,
 // and no letter is a list mode everywhere — `q` is a LIST on solanum and a
-// founder-status prefix elsewhere. Returns the bare letter, or null when the
-// caller should execute the MODE verbatim.
-const listModeQueryLetter = (modes: string, params: string[], networkId: number): string | null => {
-  if (params.length > 0) return null;
+// founder-status prefix elsewhere.
+//
+// issue 1831 — the answer is a THREE-way split, not two, because "not a list
+// query" and "a list query grappa cannot answer" are different facts:
+//
+//   * `execute`    — put the MODE on the wire verbatim. A mask makes it a
+//                    mutation; so does any letter this network does not class
+//                    as type A (`/mode #chan m` sets +m and echoes back).
+//   * `query`      — a type-A letter grappa knows the reply numerics for
+//                    (`listModesQueryable`, server-side `ListModes.known?/1`):
+//                    open the list modal and re-query.
+//   * `unreadable` — a type-A letter grappa has NO numeric pair for. The ircd
+//                    would stream the list happily; nothing here is primed to
+//                    collect it.
+//
+// The third arm used to fold into the first, which put a raw
+// `MODE #chan <letter>` on the wire and returned `{ok: true}`: no modal, no
+// error, no rows — a silent swallow at a boundary (CLAUDE.md), and one the
+// operator cannot tell apart from the command never having run.
+type ListModeIntent =
+  | { kind: "execute" }
+  | { kind: "query"; letter: string }
+  | { kind: "unreadable"; letter: string };
+
+// Takes the capability table as DATA, like `isChannelName` takes the sigils:
+// the caller has already resolved it, and passing it keeps this a pure
+// classification of one typed line.
+const listModeIntent = (
+  modes: string,
+  params: string[],
+  isupport: IsupportEntry,
+): ListModeIntent => {
+  if (params.length > 0) return { kind: "execute" };
   const letter = /^[+-]?([A-Za-z])$/.exec(modes)?.[1];
-  if (letter === undefined) return null;
-  return isupportForNetwork(networkId).listModesQueryable.includes(letter) ? letter : null;
+  if (letter === undefined) return { kind: "execute" };
+  if (isupport.listModesQueryable.includes(letter)) return { kind: "query", letter };
+  return isupport.chanmodes.a.includes(letter)
+    ? { kind: "unreadable", letter }
+    : { kind: "execute" };
+};
+
+/**
+ * The one message every "I cannot show you that list" arm reads from —
+ * `/banlist <letter>`, `/mode #chan <letter>` and `/mode <letter>`. #1251
+ * ruled those spellings must behave alike, and the WORDING is part of alike.
+ *
+ * Two different truths, and conflating them sends the operator after a cause
+ * that is not there: a letter this network never advertised as type A HAS no
+ * list here, while a letter it does advertise and grappa has no numeric pair
+ * for is grappa's limit, not the network's. Both name the set that IS
+ * available, which is the only actionable half.
+ */
+const noListMessage = (verb: string, letter: string, isupport: IsupportEntry): string => {
+  const offered = isupport.listModesQueryable;
+  const available =
+    offered.length > 0 ? `it offers ${offered.map((m) => `+${m}`).join(" ")}` : "it offers none";
+  const cause = isupport.chanmodes.a.includes(letter)
+    ? `grappa can't read this network's +${letter} list`
+    : `this network has no +${letter} list`;
+  return `/${verb}: ${cause} (${available})`;
 };
 
 /**
@@ -52,12 +105,11 @@ export const banlistCommand: CommandHandler<"banlist"> = async (cmd, ctx) => {
   // #1251 — an explicitly typed letter this network cannot answer is an ERROR,
   // not a silent fallback to bans: the operator asked for a specific list and
   // would otherwise read the ban list as the exempt list. The offered set is
-  // server-published, never derived.
-  const offered = isupportForNetwork(networkId).listModesQueryable;
-  if (!offered.includes(cmd.mode)) {
-    return {
-      error: `/banlist: this network has no +${cmd.mode} list (it offers ${offered.map((m) => `+${m}`).join(" ")})`,
-    };
+  // server-published, never derived. issue 1831 — the wording is shared with
+  // the two `/mode` spellings of the same question.
+  const isupport = isupportForNetwork(networkId);
+  if (!isupport.listModesQueryable.includes(cmd.mode)) {
+    return { error: noListMessage("banlist", cmd.mode, isupport) };
   }
   openBanlistModal(ctx.networkSlug, chanOrErr, cmd.mode);
   pushChannelBanlist(networkId, chanOrErr, cmd.mode);
@@ -114,10 +166,26 @@ export const modeCommand: CommandHandler<"mode"> = async (cmd, ctx) => {
   // #536/#1251 — a bare list letter with NO mask is a QUERY, not a mutation:
   // open the list modal instead of putting a raw MODE on the wire whose reply
   // rows nothing is primed to collect.
-  const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
-  if (listMode !== null && isChannelName(cmd.target, ctx.sigils())) {
-    openBanlistModal(ctx.networkSlug, cmd.target, listMode);
-    pushChannelBanlist(networkId, cmd.target, listMode);
+  //
+  // The sigil test stays here, and is NOT the duplicated derivation issue 1831
+  // removed from `getActiveChannel`: the parser emits `{kind: "mode"}` from
+  // BOTH its channel branch and its nick branch (`/mode alice +o` is a user
+  // MODE), so `cmd.target` is a token whose class nothing upstream has fixed.
+  // Only a CHANNEL has type-A lists.
+  //
+  // The `intent.kind !== "execute"` conjunct comes FIRST so `ctx.sigils()`
+  // stays unevaluated on the ordinary mutation path — the same laziness #1396
+  // pins for `requireNetworkId`, and the `#1396` effect snapshot fails if this
+  // arm starts resolving a network id it does not need.
+  const isupport = isupportForNetwork(networkId);
+  const intent = listModeIntent(cmd.modes, cmd.params, isupport);
+  if (intent.kind !== "execute" && isChannelName(cmd.target, ctx.sigils())) {
+    // issue 1831 — say so rather than firing a frame nobody hears.
+    if (intent.kind === "unreadable") {
+      return { error: noListMessage("mode", intent.letter, isupport) };
+    }
+    openBanlistModal(ctx.networkSlug, cmd.target, intent.letter);
+    pushChannelBanlist(networkId, cmd.target, intent.letter);
     return { ok: true };
   }
   await pushChannelMode(networkId, cmd.target, cmd.modes, cmd.params);
@@ -147,11 +215,16 @@ export const modeApplyCurrentCommand: CommandHandler<"mode-apply-current"> = asy
   const networkId = ctx.requireNetworkId(ctx.networkSlug, "mode");
   if (typeof networkId !== "number") return networkId;
   // #536/#1251 — same list-QUERY interception as the explicit-channel arm
-  // above; `/mode +b` and `/mode #chan +b` must behave alike.
-  const listMode = listModeQueryLetter(cmd.modes, cmd.params, networkId);
-  if (listMode !== null) {
-    openBanlistModal(ctx.networkSlug, chanOrErr, listMode);
-    pushChannelBanlist(networkId, chanOrErr, listMode);
+  // above; `/mode +b` and `/mode #chan +b` must behave alike. No sigil test:
+  // the target here IS the current channel window, already resolved.
+  const isupport = isupportForNetwork(networkId);
+  const intent = listModeIntent(cmd.modes, cmd.params, isupport);
+  if (intent.kind === "unreadable") {
+    return { error: noListMessage("mode", intent.letter, isupport) };
+  }
+  if (intent.kind === "query") {
+    openBanlistModal(ctx.networkSlug, chanOrErr, intent.letter);
+    pushChannelBanlist(networkId, chanOrErr, intent.letter);
     return { ok: true };
   }
   await pushChannelMode(networkId, chanOrErr, cmd.modes, cmd.params);

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -660,13 +660,29 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // would reject ops verbs that require a channel).
     const getActiveChannel = (): string | null => {
       const sel = selectedChannel();
-      if (!sel) return null;
-      const name = sel.channelName;
-      // A channel window opens with one of the sigils THIS network
-      // advertises. Query windows use a nick; server/list/mentions
-      // pseudo-windows use synthetic keys that carry no sigil at all.
-      if (!isChannelName(name, sigilsFor(sel.networkSlug))) return null;
-      return name;
+      // issue 1831 — ask the selection's KIND, do not re-derive it from the
+      // name. `WindowKind` mirrors the server-side atom, so `"channel"` IS
+      // the answer to "am I in a channel window?", and the store commits to
+      // it hard enough to MUTATE on it: `foldChannelKey` folds the key for
+      // `kind: "channel"` and for no other kind.
+      //
+      // What this replaces: an `isChannelName(name, sigilsFor(...))` sniff —
+      // a second, independent answer to a question the selection had already
+      // answered, derived from different data (the network's advertised
+      // CHANTYPES) that can disagree with it. When it did, a window the store
+      // had accepted as a channel became invisible to all 17 channel-scoped
+      // verb sites at once (13 through `requireChannel`, 4 here), while
+      // TopicBar — mounted under `<Show when={selKind() === "channel"}>` and
+      // handed `selectedChannel()?.channelName` as a prop — kept opening the
+      // very same modal from its button. Two derivations of one fact, and the
+      // duplicate is the one that can be wrong (CLAUDE.md: derive, don't
+      // duplicate).
+      //
+      // The sigil class is still the right tool one layer out, where the
+      // question is genuinely "is this TOKEN a channel?" and there is no
+      // window to ask: the parser's channel-vs-nick split, `modeCommand`'s
+      // explicit target, and Tab completion all keep it.
+      return sel?.kind === "channel" ? sel.channelName : null;
     };
 
     // Require a channel window; emit inline error if not in one.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42127,3 +42127,123 @@ which is the reason this note records the chain at all.
 about a default, exactly one of them may hold it. If the module writes on
 every boot, the stylesheet's `var(x, default)` is decoration — and a reviewer
 reading the CSS will believe a fallback that cannot fire.
+<!-- entry #1831 -->
+
+---
+
+## 2026-08-27 — #1831: two derivations of one fact, and an `{ok: true}` nobody could see
+
+Investigating "channel-scoped slash commands do nothing in the installed PWA"
+(issue 1831) turned up two defects in cic's command layer. Both are wrong on
+their own terms — one is a duplicated derivation, the other a silent swallow
+at a boundary, and CLAUDE.md forbids each by name. **Neither is established as
+the cause of that report**, and this entry is written so the fixes are not
+later read as a diagnosis. The report's decisive probe — is the ComposeBox
+alert line visible in standalone display-mode at all? — needs the reporter's
+device and had not answered when this landed.
+
+### What the report does and does not narrow to
+
+The issue groups `/banlist`, bare `/mode` and `/mode #chan b` as sharing
+`requireChannel` plus the network-id resolution. Measured, they share nothing:
+`/banlist` uses both guards, `/mode #chan b` uses only the network id, and
+bare `/mode` resolves no network id at all — it is two lines, resolve the
+channel and open the modal. The intersection of the three is empty, so no
+class-wide cure follows from the grouping.
+
+One thing the report settles for free, from its own data: `whoCommand` calls
+`ctx.requireNetworkId`, so `/who <nick>` working in the PWA proves the network
+slug resolves there. The "network does not resolve in standalone" candidate is
+dead. Its channel half is untouched — `/who <nick>` passes an explicit target
+and never reaches `requireChannel`.
+
+Two further readings did NOT survive contact with the code and are recorded so
+they are not re-tried. The ISUPPORT candidate is closed on prod values, not on
+principle: `ListModes.queryable/1` intersects the advertised type-A set with
+grappa's numeric-pair table, bahamut/Azzurra advertises `bz`, so `b` is
+queryable; and the server cannot publish an empty `chantypes` at all
+(`merge_token("CHANTYPES=" <> rest, …)` keeps the prior set on an empty
+token). And "the modal layer is fine because WhoModal renders" is weaker than
+it reads: `/who`'s modal is opened by a SERVER PUSH — the 315 drains into an
+ephemeral `who_reply` on the user topic and the modal renders THAT — so it
+proves the socket and the overlay stack are alive, not that a modal opened
+synchronously from a composer submit is visible.
+
+### 1. The active-channel resolver re-derived a fact the selection carries
+
+`getActiveChannel` answered "am I in a channel window?" by matching the window
+NAME against the network's advertised CHANTYPES. The selection store had
+already answered it: `SelectedChannel.kind` mirrors the server-side
+`WindowKind` atom, and the store commits to it hard enough to MUTATE on it —
+`foldChannelKey` folds the key for `kind: "channel"` and for no other kind.
+
+Two derivations of one fact, from different data, and only the duplicate can
+be wrong. When they disagree, a window the store has accepted as a channel
+becomes invisible to all 17 channel-scoped verb sites at once (13 through
+`requireChannel`, 4 calling `getActiveChannel` directly) — while TopicBar,
+mounted under `<Show when={selKind() === "channel"}>` and handed
+`selectedChannel()?.channelName` as a prop, keeps opening the very same modal
+from its button. That shape — every channel verb silent, the button working —
+is the shape the PWA report describes, which is why it was found; it is not
+evidence that the PWA is in that state.
+
+The resolver now reads `sel?.kind === "channel"`. The sigil class stays where
+the question is genuinely "is this TOKEN a channel?" and there is no window to
+ask: the parser's channel-vs-nick split, `modeCommand`'s explicit target, and
+Tab completion.
+
+Visible consequence, and the reason a pinned snapshot moved: the resolver no
+longer resolves a network id to fetch sigils, so 14 arms in the `#1396`
+dispatch characterization each lose one `networks.networkIdBySlug` effect. The
+results are unchanged. That snapshot is also what caught a second-order slip
+in the fix below — see the laziness note.
+
+### 2. A list query grappa cannot read was a silent `{ok: true}`
+
+`listModeQueryLetter` returned "the letter" or `null`, and `null` meant two
+different things: *this is a mode change* and *this is a list query I cannot
+answer*. Both fell through to a raw `pushChannelMode` returning `{ok: true}`.
+For the second, that puts `MODE #chan <letter>` on the wire, the ircd streams
+the list, and nothing client-side is primed to collect the numerics: no modal,
+no error, no rows. The operator cannot tell it apart from the command never
+having run — which is precisely the silent-swallow-at-a-boundary CLAUDE.md
+forbids, and precisely the pre-#536 behaviour #536 existed to remove.
+
+The classifier is now three-way (`execute` / `query` / `unreadable`), and it
+needs a second 005 fact to be so: `chanmodes.a` says whether the letter is a
+LIST on this network, which is what separates "grappa cannot read it" from
+"`/mode #chan m` sets +m and echoes back". Reading only `listModesQueryable`
+would have turned every single-letter flag mutation into an error.
+
+The wording is shared by all three spellings of the question (`/banlist X`,
+`/mode #chan X`, `/mode +X`), because #1251 ruled they must behave alike and
+the message is part of alike. It distinguishes two truths rather than
+flattening them: a letter the network never advertised as type A HAS no list
+here, while a letter it does advertise and grappa has no numeric pair for is
+grappa's limit. Blaming the network for the second would send the operator
+after a cause that is not there.
+
+**Laziness note.** The first cut evaluated `isChannelName(cmd.target,
+ctx.sigils())` before the intent, which resolved a network id on the ordinary
+mutation path. The `#1396` snapshot went red for the `mode` arm — that
+characterization exists to pin exactly this, and it earned its keep. The
+conjunct order is now intent-first, so `ctx.sigils()` stays unevaluated when
+the line is a plain mode change.
+
+### What this does NOT settle
+
+Every failure arm in `dispatchDraft` — unknown verb, every guard, any throw —
+terminates at one surface: a sticky `role="alert"` `<p class="compose-box-error">`
+rendered as the last child of the ComposeBox fragment, in normal flow, with no
+positioning of its own. Within that code, "no modal AND no error" is not
+producible. So either that line is not visible in the PWA, or the PWA is not
+running this bundle. Neither can be decided from here: standalone display-mode
+is not emulable in Playwright (measured against `playwright-core@1.62.1`'s
+types — `emulateMedia` takes `{colorScheme, contrast, forcedColors, media,
+reducedMotion}` and the string `display-mode` does not appear in them), so an
+e2e on that axis would be a spec that passes without touching the defect.
+
+The probe that decides it is one keystroke on the device: type an unknown verb
+and see whether its banner appears. `/zzzz` is guaranteed to produce
+`{kind: "error"}` in the pure parser, with no server, no network id and no
+channel involved — a positive control for the surface itself.


### PR DESCRIPTION
## What this is, and what it is not

Two defects in cic's channel-scoped command path, found while investigating
issue 1831 (channel-scoped slash commands doing nothing in the installed PWA).

**This PR does NOT claim to be the cause of that report.** The probe that
would decide it — type an unknown verb in the PWA and see whether its error
banner appears at all — is out with vjt on the real device and has not
answered. Nothing here pre-empts that answer, and neither commit should be
read as a diagnosis. Which of the two (if either) is load-bearing for the PWA
report is deliberately left open.

**Both cures stand on their own terms.** Each is a CLAUDE.md violation named
in that file: one is a duplicated derivation of state that already exists, the
other is a silent swallow at a boundary. They are worth landing whatever the
probe says.

## 1. `getActiveChannel` resolves by window KIND, not by sigil

It answered "am I in a channel window?" by matching the window NAME against
the network's advertised CHANTYPES. The selection store had already answered
it: `SelectedChannel.kind` mirrors the server-side `WindowKind` atom, and the
store commits to it hard enough to MUTATE on it — `foldChannelKey` folds the
key for `kind: "channel"` and for no other kind.

Two derivations of one fact, from different data, and only the duplicate can
be wrong. When they disagree, a window the store has accepted as a channel
goes invisible to **17 channel-scoped verb sites at once** — 13 through
`requireChannel`, 4 calling `getActiveChannel` directly — while `TopicBar`,
mounted under `<Show when={selKind() === "channel"}>` and handed
`selectedChannel()?.channelName` as a prop, keeps opening the very same modal
from its button.

The sigil class stays where the question is genuinely "is this TOKEN a
channel?" and there is no window to ask: the parser's channel-vs-nick split,
`modeCommand`'s explicit target, and Tab completion.

## 2. A list query grappa cannot read is reported, not fired at nobody

`listModeQueryLetter` returned "the letter" or `null`, and `null` meant two
different things: *this is a mode change* and *this is a list query I cannot
answer*. Both fell through to a raw `pushChannelMode` returning `{ok: true}`.

For the second that puts `MODE #chan <letter>` on the wire, the ircd streams
the list, and nothing client-side is primed to collect the numerics: no modal,
no error, no rows. The operator cannot tell it apart from the command never
having run.

The classifier is three-way now (`execute` / `query` / `unreadable`), and it
needs a second 005 fact to be so: `chanmodes.a` says whether the letter is a
LIST on this network. That is not decoration — reading only
`listModesQueryable` would classify `/mode #chan m` as unreadable and turn
every single-letter flag mutation into an error.

The wording is shared by all three spellings (`/banlist X`, `/mode #chan X`,
`/mode +X`) per #1251, and keeps two truths apart rather than flattening them:
a letter the network never advertised as type A HAS no list here, while a
letter it does advertise and grappa has no numeric pair for is grappa's limit.

## Tests

8 new tests in `compose.test.ts`. Pre-fix run: **5 failed, 3 passed** — the
three that pass on both sides are guards (a query window is still refused; a
letter the network never advertised keeps the network-side wording; a single
flag letter is still a mutation that reaches the wire).

## Two measured consequences worth a reviewer's eye

**The `#1396` effect snapshot moved, and it should have.** Dropping the sigil
sniff removes one `networkIdBySlug` per channel-scoped arm. Verified two-sided
rather than eyeballed: **14 deleted lines, 14 of which are `networkIdBySlug`,
0 other**, and every arm's `result` unchanged.

**That same snapshot caught a slip during authoring.** The first cut of
`modeCommand` evaluated `isChannelName(cmd.target, ctx.sigils())` before the
intent, which resolved a network id on the ordinary mutation path — the `mode`
arm went +1 effect. #1396 exists to pin exactly that laziness. The conjunct
order is now intent-first.

## Gates

Run on the committed tree (an earlier run was discarded: a file was edited
mid-run, so its result was not attributable).

| gate | rc | detail |
|---|---|---|
| `scripts/bun.sh run check` | 0 | 5/5 stages, 0 failed (stage 1 lock drift included) |
| `scripts/bun.sh run test` | 0 | 326 test files, 0 failures |
| `scripts/design-notes-gate.sh` | 0 | `1 new entry heading(s), separator and marker present` |

Baseline on the same worktree before any edit was also green on both cic
gates, so the result is attributable to this branch rather than inherited.

## Scope

cic only. No server change, no wire-shape change, no migration — so no
`protocol_version` bump is in scope. `docs/DESIGN_NOTES.md` carries one entry
recording what the investigation settled, what it did not, and the device
probe that decides the rest.
