### PR TITLE
session(1832): count the connect server-info burst as signalling, not as messages

### DIFF
--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1008,10 +1008,18 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       if (meta && typeof meta.raw_verb === "string") {
         return renderRawEvent(meta, msg, bareSenderSpan, handlers);
       }
-      // Defensive: a :server_event row with no raw_verb is a server
-      // bug, but render the body so it isn't invisible. Server-generated
-      // → the #455 marker layer stays OFF here, like the sibling ERROR /
-      // generic-numeric arms (only the wire mIRC layer renders).
+      // No raw_verb. This used to be described here as a server bug
+      // rendered defensively; since issue 1832 it is also the ORDINARY
+      // shape of the connect-time server-info burst — MOTD lines and the
+      // unprimed ADMIN / INFO / VERSION replies, which the server persists
+      // as `:server_event` with `meta.sender_kind` and no verb, precisely
+      // so they count in the low `events` tier instead of badging $server
+      // with unread messages. This arm is what keeps those lines READABLE,
+      // which is the only reason to keep them in the window at all — do
+      // not "tidy" it into a drop. Server-generated → the #455 marker
+      // layer stays OFF here, like the sibling ERROR / generic-numeric
+      // arms (only the wire mIRC layer renders, so a colour-coded MOTD
+      // banner keeps its colours).
       return (
         <span class="scrollback-body">
           *** {bareSenderSpan(msg.sender)} <MircBody body={msg.body ?? ""} />

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4258,6 +4258,60 @@ describe("ScrollbackPane", () => {
       expect(line.textContent).toContain("naked body — meta missing raw_verb");
     });
 
+    // issue 1832 — the connect-time MOTD burst is persisted `:server_event`
+    // so it counts in the low `events` tier. That only holds up if the lines
+    // stay READABLE in $server, which is the entire reason the server keeps
+    // them instead of dropping them: `:server_event` is outside the server's
+    // `@body_required_kinds`, which makes the body OPTIONAL, not forbidden.
+    // The row shape here is the real one EventRouter writes — sender = server
+    // hostname, `meta.sender_kind`, NO raw_verb — not the synthetic empty
+    // meta of the defensive case above.
+    it("kind=server_event MOTD row (sender_kind, no raw_verb) still shows the MOTD text", () => {
+      setScrollback({
+        "freenode $server": [
+          {
+            id: 205,
+            network: "freenode",
+            channel: "$server",
+            server_time: 205,
+            kind: "server_event",
+            sender: "irc.azzurra.chat",
+            body: "- Benvenuto su Azzurra IRC Network",
+            meta: { sender_kind: "server" },
+          },
+        ],
+      });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="$server" kind="channel" />);
+      const line = screen.getByTestId("scrollback-line");
+      expect(line.textContent).toContain("irc.azzurra.chat");
+      expect(line.textContent).toContain("- Benvenuto su Azzurra IRC Network");
+    });
+
+    // A MOTD banner is very often mIRC-coloured ASCII art. The arm renders
+    // through <MircBody> without the #455 emphasis layer, so the colour runs
+    // must survive as spans while the control bytes never reach the text.
+    it("kind=server_event MOTD row keeps mIRC colour runs out of the text", () => {
+      setScrollback({
+        "freenode $server": [
+          {
+            id: 206,
+            network: "freenode",
+            channel: "$server",
+            server_time: 206,
+            kind: "server_event",
+            sender: "irc.azzurra.chat",
+            body: "\x0304red banner\x0F plain",
+            meta: { sender_kind: "server" },
+          },
+        ],
+      });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="$server" kind="channel" />);
+      const line = screen.getByTestId("scrollback-line");
+      expect(line.textContent).toContain("red banner");
+      expect(line.textContent).toContain("plain");
+      expect(line.textContent).not.toContain("\x03");
+    });
+
     it("kind=server_event row gets scrollback-presence + scrollback-muted classes", () => {
       setScrollback({
         "freenode $server": [

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42247,3 +42247,95 @@ The probe that decides it is one keystroke on the device: type an unknown verb
 and see whether its banner appears. `/zzzz` is guaranteed to produce
 `{kind: "error"}` in the pure parser, with no server, no network id and no
 channel involved — a positive control for the surface itself.
+<!-- entry #1832 -->
+
+---
+
+## 2026-08-27 — #1832: connect-time MOTD is signalling, so it counts as one
+
+Connect-time MOTD lines landed in `$server` as `:notice`. `:notice` is a
+CONTENT kind (`Scrollback.Message.content_kinds/0`), so `WindowCounts`
+bucketed every line as an unread MESSAGE and pushed the window severity to
+`:message`: a bare reconnect badged the server tab as if somebody had talked
+to you. vjt's ruling, relayed from IRC on 2026-08-27 — *"dovrebbero esser
+contate come signalling, quindi col numeretto piccolo che usiamo per i
+join/part"* — settles the tier: `events`, i.e. kind `:server_event`.
+
+### Why the cure sits at the fallback, not at the window
+
+The issue asked for the change to be scoped to the numeric fallback rather
+than applied to `persist_server_notice/2` wholesale, on the grounds that a
+genuine server NOTICE (services, opers) must stay content. Measured, the two
+turn out to be the same cut: **every one of the six callers of that function
+is an unprimed-burst clause** — MOTD (375/372/376/422), ADMIN
+(256/257/258/259/423/447), an uncorrelated 402, INFO (371/374) and VERSION
+(351). A real NOTICE never reaches it; it is routed by the CP13 non-channel
+NOTICE chain, which builds its own `:notice` persist. So the whole family
+moved together and the function was renamed `persist_server_event/2` — the
+old name would have been a lie about the row it writes.
+
+### The body is not the casualty
+
+`:server_event` is outside `@body_required_kinds`, which makes the body
+OPTIONAL, not forbidden — the distinction the fix depends on, because the
+only reason to keep these rows at all is that they be readable. cic's
+`case "server_event"` arm falls through to a body render when `meta.raw_verb`
+is absent, which is exactly the shape this path writes. That arm's comment
+used to call a verb-less `:server_event` row "a server bug, rendered
+defensively"; it is now also the ordinary connect-burst shape, and the
+comment says so, because the next reader would otherwise be entitled to
+delete it. The rows do inherit cic's `PRESENCE_KINDS` treatment (muted,
+greyed) — accepted: that is the join/part treatment the ruling named.
+
+### Moving a kind across the tier moves everything keyed off the tier
+
+Worth stating once, because the next kind reclassification will hit the same
+set and it is not obvious from the diff. cic keys several behaviours off
+`isContentKind` (`CONTENT_KINDS`, the mirror of `content_kinds/0`), so a
+`$server` window whose only unread rows are MOTD now: does NOT light the
+Alt+A "worth reading" affordance (`activeWindows.ts` gates on
+`messagesUnread`, not the total); gets NO in-pane unread divider
+(`selection.ts` splits the tail by `isContentKind`); and yields no quotable
+body (`quotableBody.ts` refuses non-content kinds). Server-side the row also
+leaves `@dm_with_eligible_kinds` and the `@content_kinds` sender-prefix
+snapshot — both no-ops here, since `$server` is neither a DM peer nor a
+sigil-shaped channel. All of it is what "count it like join/part" means; none
+of it is a separate decision. The rows keep rendering, and keep their mIRC
+colours, in the muted presence style join/part already use.
+
+### History is not rewritten
+
+Rows already persisted keep `:notice` and keep counting as messages; the
+badge settles on the next connection. A backfill is a data migration, hence
+a COLD deploy, hence every live IRC session dropped — not a price a cosmetic
+count gets to charge. `20260514071049_add_server_event_to_messages_kind_enum`
+did pay it once, for a kind that did not exist yet; this is a reclassification
+of rows that render fine either way.
+
+### Measured, and NOT fixed here: the MOTD is not the only offender
+
+The issue's acceptance criterion is that a fresh connect leaves `$server`
+badged at the `events` tier "or nothing". This change does not achieve that
+on its own, and the gap is in a different mechanism. `NumericRouter` does not
+delegate **002 RPL_YOURHOST, 003 RPL_CREATED or 396 RPL_HOSTHIDDEN** — measured
+by routing real bahamut wire shapes through `NumericRouter.route/2`, all three
+answer `{:server, nil}` — so they fall to the generic scan clause in
+`Session.Server`, which persists EVERY scan-routed numeric as `:notice`. Two
+or three content-tier rows therefore still land on `$server` at every connect.
+(001 and 005 never reach the scan: dedicated `handle_info` clauses consume
+them. The LUSERS block 251–255/265/266 and 221 RPL_UMODEIS are delegated and
+fold into bundles.)
+
+That is the general class this issue is one instance of, and flipping the
+scan path is a much larger behavioural change — it reclassifies every
+unhandled numeric in the product, including the ones a `/stats` or a `/list`
+puts in front of an operator who ASKED for them, where content-tier is
+arguably right. It needs its own ruling, so it is recorded here rather than
+smuggled in.
+
+### Provenance
+
+The ruling reached this work RELAYED by another agent (vjt-claude) from the
+GitHub comment, not read first-hand on IRC. The comment's author field reads
+`vjt`, but every agent in this project comments with the same token, so the
+field is not independent evidence of authorship.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2276,9 +2276,11 @@ defmodule Grappa.Session.EventRouter do
   #
   #   * connect-time / unprimed (motd_pending == nil) — the server auto-sends
   #     the MOTD on registration (or a stray 402 arrives with no /motd in
-  #     flight). Keep the legacy BUG2 behaviour: persist each line as a
-  #     `:notice` row on the synthetic "$server" window so the server-messages
-  #     window has content. NumericRouter marks these :delegated so no
+  #     flight). Keep the BUG2 routing: persist each line on the synthetic
+  #     "$server" window so the server-messages window has content — as a
+  #     `:server_event` row since issue 1832, so the burst counts in the low
+  #     `events` tier instead of badging the tab with unread messages (see
+  #     `persist_server_event/2`). NumericRouter marks these :delegated so no
   #     numeric_routed persist fires — this clause is the canonical surface.
   #
   #   * explicit /motd (motd_pending == %{lines: _}) — the operator asked.
@@ -2290,7 +2292,7 @@ defmodule Grappa.Session.EventRouter do
   #     they fold their own body before draining — an explicit /motd never
   #     dangles and a 402 never gets swallowed into a wrong-server MOTD.
   #
-  # BUG2 fix-up (still applies to the $server path in persist_server_notice/2):
+  # BUG2 fix-up (still applies to the $server path in persist_server_event/2):
   # sender must be Message.sender_nick/1, never "".
   defp do_route(
          %Message{command: {:numeric, motd_numeric}} = msg,
@@ -2299,7 +2301,7 @@ defmodule Grappa.Session.EventRouter do
        when motd_numeric in [375, 372, 376, 422] do
     case Map.get(state, :motd_pending) do
       nil ->
-        persist_server_notice(state, msg)
+        persist_server_event(state, msg)
 
       accum ->
         cond do
@@ -2321,7 +2323,7 @@ defmodule Grappa.Session.EventRouter do
   # #992 — ADMIN (256 RPL_ADMINME, 257 RPL_ADMINLOC1, 258 RPL_ADMINLOC2,
   # 259 RPL_ADMINEMAIL) + 423 ERR_NOADMININFO + 447 ERR_RESTRICTED. Fourth
   # member of the #127 family, gated on `state.admin_pending` (primed by
-  # `:send_admin`); unprimed it falls back to the same `$server` :notice
+  # `:send_admin`); unprimed it falls back to the same `$server` `:server_event`
   # persist, so an unsolicited burst is visible, never silent.
   #
   # WHY the terminator set is four wide and not one. Read out of
@@ -2356,7 +2358,7 @@ defmodule Grappa.Session.EventRouter do
        when admin_numeric in [256, 257, 258, 259, 423, 447] do
     case Map.get(state, :admin_pending) do
       nil ->
-        persist_server_notice(state, msg)
+        persist_server_event(state, msg)
 
       accum ->
         folded = server_reply_fold(accum, msg)
@@ -2392,7 +2394,7 @@ defmodule Grappa.Session.EventRouter do
   defp do_route(%Message{command: {:numeric, 402}} = msg, state) do
     case Enum.filter(@server_reply_402_owners, fn {key, _} -> Map.get(state, key) end) do
       [] ->
-        persist_server_notice(state, msg)
+        persist_server_event(state, msg)
 
       [{key, source} | _] = armed ->
         accum = Map.get(state, key)
@@ -2410,11 +2412,11 @@ defmodule Grappa.Session.EventRouter do
   # #127 — INFO (371 RPL_INFO burst, 374 RPL_ENDOFINFO terminator). Gated on
   # state.info_pending (primed by :send_info). Primed: fold 371 lines, drain
   # `{:server_reply, :info, lines}` on 374. Unprimed (no connect-time INFO —
-  # on-demand only): fall back to the same `$server` :notice persist, so an
+  # on-demand only): fall back to the same `$server` `:server_event` persist, so an
   # unsolicited reply is still visible, never silent.
   defp do_route(%Message{command: {:numeric, 371}} = msg, state) do
     case Map.get(state, :info_pending) do
-      nil -> persist_server_notice(state, msg)
+      nil -> persist_server_event(state, msg)
       accum -> {:cont, %{state | info_pending: server_reply_fold(accum, msg)}, []}
     end
   end
@@ -2422,7 +2424,7 @@ defmodule Grappa.Session.EventRouter do
   defp do_route(%Message{command: {:numeric, 374}} = msg, state) do
     case Map.get(state, :info_pending) do
       nil ->
-        persist_server_notice(state, msg)
+        persist_server_event(state, msg)
 
       accum ->
         {:cont, %{state | info_pending: nil},
@@ -2437,7 +2439,7 @@ defmodule Grappa.Session.EventRouter do
   defp do_route(%Message{command: {:numeric, 351}, params: [_ | rest]} = msg, state) do
     case Map.get(state, :version_pending) do
       nil ->
-        persist_server_notice(state, msg)
+        persist_server_event(state, msg)
 
       accum ->
         line = rest |> Enum.filter(&is_binary/1) |> Enum.join(" ")
@@ -3326,10 +3328,15 @@ defmodule Grappa.Session.EventRouter do
   # shape is the ONLY thing telling another client whether a NOTICE came
   # from a user or a server, and clients route the two differently.
   #
-  # The `$server` window is where the two become indistinguishable —
-  # `persist_server_notice/2` files MOTD and INFO numerics there as
-  # `:notice` with a SERVER sender, while a private notice to the user's
-  # own nick lands on the same window, same kind, with a USER sender.
+  # The `$server` window is where the two become indistinguishable — the
+  # generic numeric scan (`Session.Server`'s routed-numeric clause) files
+  # server replies there as `:notice` with a SERVER sender, while a private
+  # notice to the user's own nick lands on the same window, same kind, with a
+  # USER sender. `persist_server_event/2` used to be the headline example of
+  # that collision and no longer is (issue 1832 moved it to `:server_event`),
+  # but it still writes a server sender to `$server`, and the scan path — a
+  # much larger set of numerics — still writes `:notice` there. The key earns
+  # its keep on both.
   #
   # Additive, same contract as `sender_prefix` above: a consumer that does
   # not know the key behaves exactly as before, and rows persisted earlier
@@ -3408,26 +3415,51 @@ defmodule Grappa.Session.EventRouter do
     )
   end
 
-  # #127 — legacy `$server` :notice persist for an unprimed / connect-time
-  # server-info numeric (connect MOTD, unsolicited INFO/VERSION). Extracted
-  # from the pre-#127 MOTD BUG2 clause; sender via Message.sender_nick/1 (a
-  # server-prefixed numeric returns the server hostname, a prefix-less line
-  # the "*" sentinel — both pass Identifier.valid_sender?).
-  defp persist_server_notice(state, %Message{params: [_ | rest]} = msg) do
+  # #127 — the `$server` persist for an unprimed / connect-time server-info
+  # numeric (connect MOTD, unsolicited ADMIN/INFO/VERSION, an uncorrelated
+  # 402). Extracted from the pre-#127 MOTD BUG2 clause; sender via
+  # Message.sender_nick/1 (a server-prefixed numeric returns the server
+  # hostname, a prefix-less line the "*" sentinel — both pass
+  # Identifier.valid_sender?).
+  #
+  # issue 1832 — the kind is `:server_event`, and it used to be `:notice`.
+  # `:notice` is a CONTENT kind (`Scrollback.Message.content_kinds/0`), so
+  # `WindowCounts` bucketed every connect-MOTD line as an unread MESSAGE and
+  # pushed the `$server` severity to `:message`: a bare reconnect badged the
+  # tab as if somebody had talked to you. vjt's ruling (IRC, 2026-08-27,
+  # relayed): these lines are signalling and belong in the low `events` tier,
+  # the one join/part use — which is exactly what `:server_event` is.
+  #
+  # The change lives HERE, at the fallback, and not in a kind swap on the
+  # `$server` window: a REAL server NOTICE (services, opers) is somebody
+  # talking to you and keeps `:notice`. Every caller of this function is an
+  # unprimed-burst clause, so the whole family moves together and no arm is
+  # left half-migrated (CLAUDE.md "Total consistency or nothing").
+  #
+  # Body survives the move: `:server_event` is outside `@body_required_kinds`
+  # (body OPTIONAL, not barred), and cic renders a `:server_event` row with no
+  # `meta.raw_verb` through its body arm, so the MOTD text stays legible in
+  # the window — which is the only reason to keep these rows at all.
+  #
+  # HISTORY IS NOT REWRITTEN. Rows persisted before this keep `:notice` and
+  # keep counting as messages; the badge settles on the next connection. A
+  # backfill would be a data migration, hence a COLD deploy, hence every live
+  # IRC session dropped — not a price this cosmetic fix gets to charge.
+  defp persist_server_event(state, %Message{params: [_ | rest]} = msg) do
     body = List.last(rest)
 
     if is_binary(body) do
       sender = Message.sender_nick(msg)
       # sender_meta/1, not %{}: this is the exact call that makes a server
       # hostname and a user nick indistinguishable downstream (#1070).
-      {state, eff} = build_persist(state, :notice, "$server", sender, body, sender_meta(msg))
+      {state, eff} = build_persist(state, :server_event, "$server", sender, body, sender_meta(msg))
       {:cont, state, [eff]}
     else
       {:cont, state, []}
     end
   end
 
-  defp persist_server_notice(state, _), do: {:cont, state, []}
+  defp persist_server_event(state, _), do: {:cont, state, []}
 
   defp build_persist(state, kind, channel, sender, body, meta) do
     meta = put_sender_prefix(meta, state, kind, channel, sender)

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -641,7 +641,7 @@ defmodule Grappa.Session.NumericRouter do
                         # state.motd_pending — an explicit /motd drains the
                         # burst into a `{:server_reply, :motd, lines}` modal
                         # effect; connect-time MOTD (no pending flag) keeps the
-                        # legacy `$server` :notice persist. Both live inside
+                        # `$server` persist. Both live inside
                         # the delegated clause, so 422 joins the family (a
                         # /motd against a server with no MOTD still resolves
                         # the modal instead of dangling).
@@ -649,15 +649,18 @@ defmodule Grappa.Session.NumericRouter do
                         # an unknown server. Delegated so the primed MOTD clause
                         # drains a modal + clears motd_pending (never a
                         # wrong-server MOTD); an unprimed 402 falls through the
-                        # clause's nil branch to the same `$server` :notice
+                        # clause's nil branch to the same `$server`
                         # persist the rest of the MOTD family uses (same window
-                        # + kind as the pre-#374 scan route). One difference vs
-                        # the old generic scan: `persist_server_notice/2` writes
-                        # NO meta, so the unprimed row loses the scan path's
+                        # as the pre-#374 scan route). TWO differences vs
+                        # the old generic scan. (1) `persist_server_event/2` writes
+                        # NO numeric meta, so the unprimed row loses the scan path's
                         # `severity: :error` (renders plain, not red) — but that
                         # matches how unprimed 422/375/372/376 already persist,
                         # so it's family-consistent, and it stays VISIBLE on
-                        # $server (no silent swallow). Introduced WITH the
+                        # $server (no silent swallow). (2) issue 1832 — the KIND
+                        # is `:server_event`, not the scan path's `:notice`: the
+                        # unprimed burst is signalling and counts in the low
+                        # `events` tier. Introduced WITH the
                         # EventRouter clause in the same commit per the
                         # delegation contract.
                         375,
@@ -672,8 +675,8 @@ defmodule Grappa.Session.NumericRouter do
                         # drains into a `{:server_reply, source, lines}` modal
                         # effect (NOT persisted); unprimed (never happens at
                         # connect — these are on-demand only) they fall back to
-                        # the same `$server` :notice persist MOTD uses, so an
-                        # unsolicited reply is still visible, never silent.
+                        # the same `$server` `:server_event` persist MOTD uses,
+                        # so an unsolicited reply is still visible, never silent.
                         371,
                         374,
                         351,

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -843,12 +843,15 @@ defmodule Grappa.Session.EventRouterTest do
     # sender = server hostname from the numeric's prefix. Previously sender
     # was hardcoded to "" which fails valid_sender? and causes changeset
     # rejection → every MOTD line silently dropped.
+    #
+    # issue 1832 — the KIND is `:server_event`, not `:notice`. The routing
+    # and sender contract this test was written for is untouched.
     test "372 RPL_MOTD routes to $server with sender from numeric prefix" do
       state = base_state()
 
       m = msg({:numeric, 372}, ["vjt", "- Welcome to this IRC server"], {:server, "irc.azzurra.chat"})
 
-      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:persist, :server_event, attrs}]} =
                EventRouter.route(m, state)
 
       assert attrs.channel == "$server"
@@ -862,7 +865,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg({:numeric, 372}, ["vjt", "- MOTD line"], nil)
 
-      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:persist, :server_event, attrs}]} =
                EventRouter.route(m, state)
 
       assert attrs.channel == "$server"
@@ -1641,12 +1644,13 @@ defmodule Grappa.Session.EventRouterTest do
       assert drained.motd_pending == nil
     end
 
-    # Connect-time MOTD (motd_pending == nil) keeps the legacy $server
-    # :notice persist — the modal is ONLY for an explicit /motd.
+    # Connect-time MOTD (motd_pending == nil) keeps the $server persist —
+    # the modal is ONLY for an explicit /motd. issue 1832 moved the kind
+    # from `:notice` to `:server_event`; the window is unchanged.
     test "unprimed (connect-time) MOTD persists to $server, no server_reply" do
       state = base_state()
 
-      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:persist, :server_event, attrs}]} =
                EventRouter.route(msg({:numeric, 372}, ["vjt", "- connect banner"], {:server, "irc.test"}), state)
 
       assert attrs.channel == "$server"
@@ -1671,12 +1675,12 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     # An UNPRIMED 402 (no explicit /motd in flight) falls back to the same
-    # $server :notice persist the connect-time MOTD family uses — never
-    # silently swallowed.
+    # $server `:server_event` persist the connect-time MOTD family uses —
+    # never silently swallowed.
     test "unprimed 402 persists to $server, no server_reply" do
       state = base_state()
 
-      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:persist, :server_event, attrs}]} =
                EventRouter.route(
                  msg({:numeric, 402}, ["vjt", "nope.invalid", "No such server"], {:server, "irc.test"}),
                  state
@@ -1717,18 +1721,18 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     # Unprimed INFO/VERSION (unsolicited — no connect-time source) fall back
-    # to the $server :notice persist, never silently dropped.
+    # to the $server `:server_event` persist, never silently dropped.
     test "unprimed 371 RPL_INFO persists to $server" do
       state = base_state()
 
-      assert {:cont, ^state, [{:persist, :notice, %{channel: "$server"}}]} =
+      assert {:cont, ^state, [{:persist, :server_event, %{channel: "$server"}}]} =
                EventRouter.route(msg({:numeric, 371}, ["vjt", "stray info"], {:server, "irc.test"}), state)
     end
 
     test "unprimed 351 RPL_VERSION persists to $server" do
       state = base_state()
 
-      assert {:cont, ^state, [{:persist, :notice, %{channel: "$server"}}]} =
+      assert {:cont, ^state, [{:persist, :server_event, %{channel: "$server"}}]} =
                EventRouter.route(
                  msg({:numeric, 351}, ["vjt", "v", "irc.test", "stray version"], {:server, "irc.test"}),
                  state
@@ -1820,7 +1824,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "unprimed 257 with a DOTLESS A-line persists to $server, never a query window" do
       state = base_state()
 
-      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+      assert {:cont, ^state, [{:persist, :server_event, attrs}]} =
                EventRouter.route(
                  msg({:numeric, 257}, ["vjt", "Azzurra"], {:server, "irc.test"}),
                  state
@@ -1832,7 +1836,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "unprimed 259 RPL_ADMINEMAIL persists to $server, no server_reply" do
       state = base_state()
 
-      assert {:cont, ^state, [{:persist, :notice, %{channel: "$server"}}]} =
+      assert {:cont, ^state, [{:persist, :server_event, %{channel: "$server"}}]} =
                EventRouter.route(
                  msg({:numeric, 259}, ["vjt", "staff@azzurra.org"], {:server, "irc.test"}),
                  state
@@ -1874,6 +1878,71 @@ defmodule Grappa.Session.EventRouterTest do
       # of the ruling.
       assert drained.motd_pending == nil
       assert drained.admin_pending == nil
+    end
+  end
+
+  describe "route/2 — issue 1832: the unprimed server-info fallback is event-tier" do
+    # vjt's ruling (IRC, 2026-08-27, relayed): connect-time MOTD lines
+    # "dovrebbero esser contate come signalling, quindi col numeretto piccolo
+    # che usiamo per i join/part" — i.e. the `events` tier, i.e. kind
+    # `:server_event`. Every clause that falls back to
+    # `persist_server_event/2` is that same unprimed-burst shape, so the whole
+    # family moves together (CLAUDE.md "Total consistency or nothing").
+    #
+    # The table IS the guard: a seventh fallback clause added later without
+    # the right kind fails here, not in review.
+    @unprimed_fallbacks [
+      {375, ["vjt", "- irc.test Message of the Day -"], "375 RPL_MOTDSTART"},
+      {372, ["vjt", "- welcome aboard"], "372 RPL_MOTD"},
+      {376, ["vjt", "End of /MOTD command."], "376 RPL_ENDOFMOTD"},
+      {422, ["vjt", "MOTD File is missing"], "422 ERR_NOMOTD"},
+      {402, ["vjt", "nope.invalid", "No such server"], "402 ERR_NOSUCHSERVER"},
+      {256, ["vjt", "Administrative info about irc.test"], "256 RPL_ADMINME"},
+      {257, ["vjt", "Azzurra"], "257 RPL_ADMINLOC1"},
+      {258, ["vjt", "Milano"], "258 RPL_ADMINLOC2"},
+      {259, ["vjt", "staff@azzurra.org"], "259 RPL_ADMINEMAIL"},
+      {423, ["vjt", "No administrative info available"], "423 ERR_NOADMININFO"},
+      {447, ["vjt", "Restricted connection"], "447 ERR_RESTRICTED"},
+      {371, ["vjt", "grappa test server"], "371 RPL_INFO"},
+      {374, ["vjt", "End of /INFO list."], "374 RPL_ENDOFINFO"},
+      {351, ["vjt", "bahamut-2.2.1", "irc.test", "options"], "351 RPL_VERSION"}
+    ]
+
+    test "every unprimed server-info numeric persists :server_event on $server" do
+      state = base_state()
+
+      for {code, params, label} <- @unprimed_fallbacks do
+        assert {:cont, ^state, [{:persist, kind, attrs}]} =
+                 EventRouter.route(msg({:numeric, code}, params, {:server, "irc.test"}), state),
+               "#{label} did not persist exactly one row"
+
+        assert kind == :server_event, "#{label} persisted #{inspect(kind)}, expected :server_event"
+        assert attrs.channel == "$server", "#{label} landed on #{inspect(attrs.channel)}"
+
+        # The counting consequence, stated against the SSOT rather than a
+        # copied literal: a content kind is what `WindowCounts` buckets as
+        # `messages`, and that is the bucket these rows must NOT be in.
+        refute kind in Grappa.Scrollback.Message.content_kinds(),
+               "#{label} is still a content kind — it will inflate the unread MESSAGE count"
+      end
+    end
+
+    # The other half of the ruling, and the reason the cure is scoped to the
+    # numeric fallback rather than to a kind swap on the `$server` window: a
+    # REAL server NOTICE (services, opers) is somebody talking to you. It
+    # keeps `:notice`, stays a content kind, and so keeps raising the window
+    # severity to `:message`.
+    test "a real server NOTICE to $server stays :notice — a content kind" do
+      state = base_state()
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+               EventRouter.route(
+                 msg(:notice, ["vjt", "This nickname is registered."], {:nick, "NickServ", "s", "services."}),
+                 state
+               )
+
+      assert attrs.channel == "$server"
+      assert :notice in Grappa.Scrollback.Message.content_kinds()
     end
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -31,7 +31,19 @@ defmodule Grappa.Session.ServerTest do
   import Mox
 
   alias Grappa.IRC.Message
-  alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, ReadCursor, Repo, Scrollback, Session, WSPresence}
+
+  alias Grappa.{
+    IRCServer,
+    PubSub.Topic,
+    QueryWindows,
+    ReadCursor,
+    Repo,
+    Scrollback,
+    Session,
+    WindowCounts,
+    WSPresence
+  }
+
   alias Grappa.Networks.{Credentials, SessionPlan}
 
   alias Grappa.Session.{
@@ -12417,9 +12429,11 @@ defmodule Grappa.Session.ServerTest do
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 372 vjt :- Welcome to TestNet\r\n")
 
-      # Exactly one event for this MOTD line.
+      # Exactly one event for this MOTD line. issue 1832 moved the kind to
+      # `:server_event`; the one-row property this test exists for is
+      # unchanged.
       assert_message_event(
-        kind: :notice,
+        kind: :server_event,
         channel: "$server",
         network: network.slug
       )
@@ -12430,11 +12444,65 @@ defmodule Grappa.Session.ServerTest do
       # Confirms it came from the delegated handler, not the routed path —
       # which is what `numeric` + `severity` would prove, so assert their
       # ABSENCE rather than an empty map. #1070 adds `sender_kind` to every
-      # notice row, and an exact-equality assertion here would read as a
-      # routing regression when the discriminator is untouched.
+      # row this path writes, and an exact-equality assertion here would read
+      # as a routing regression when the discriminator is untouched.
       refute Map.has_key?(row.meta, :numeric)
       refute Map.has_key?(row.meta, :severity)
       assert row.meta.sender_kind == "server"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # issue 1832 — the defect was a COUNT, so this asserts the count, end to
+    # end: socket → parser → Session.Server → EventRouter → persist → DB →
+    # `WindowCounts.snapshot/7`. Asserting the persisted KIND would only
+    # restate the fix; the tier is what the operator sees on the tab.
+    test "connect MOTD counts as events, a real NOTICE still counts as a message" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, network, _} = setup_user_and_network(port)
+
+      topic = Topic.channel(user.name, network.slug, "$server")
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      IRCServer.feed(server, ":irc.test.org 375 vjt :- irc.test.org Message of the Day -\r\n")
+      IRCServer.feed(server, ":irc.test.org 372 vjt :- welcome aboard\r\n")
+      IRCServer.feed(server, ":irc.test.org 376 vjt :End of /MOTD command.\r\n")
+
+      for _ <- 1..3, do: assert_message_event(channel: "$server", network: network.slug)
+
+      subject = {:user, user.id}
+      counts = WindowCounts.snapshot(subject, network.id, "$server", nil, nil, [], false)
+
+      # Three unread MOTD lines and the badge is the LOW tier — the numeretto
+      # piccolo used for join/part, not three unread messages.
+      assert counts.messages == 0
+      assert counts.events == 3
+      assert counts.severity == :event
+
+      # And the lines are still READABLE in the window, which is the whole
+      # reason for keeping them on `$server` rather than dropping them:
+      # `:server_event` is outside `@body_required_kinds`, not barred from
+      # carrying a body.
+      bodies =
+        subject
+        |> Scrollback.fetch(network.id, "$server", nil, 10, nil, false)
+        |> Enum.map(& &1.body)
+
+      assert "- welcome aboard" in bodies
+
+      # Non-regression, the other half of the ruling: a REAL NOTICE into the
+      # SAME window is somebody talking to you. It stays content and takes the
+      # severity back up to `:message`.
+      IRCServer.feed(server, ":NickServ!services@services. NOTICE vjt :This nickname is registered.\r\n")
+      assert_message_event(kind: :notice, channel: "$server", network: network.slug)
+
+      after_notice = WindowCounts.snapshot(subject, network.id, "$server", nil, nil, [], false)
+      assert after_notice.messages == 1
+      assert after_notice.events == 3
+      assert after_notice.severity == :message
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end


### PR DESCRIPTION
Addresses issue 1832 — connect-time MOTD lines counted as unread **messages**
in `$server`, so every (re)connect badged the server tab as if somebody had
talked to you.

## The ruling, and where it came from

vjt's ruling, from the issue comment: MOTD lines *"dovrebbero esser contate
come signalling, quindi col numeretto piccolo che usiamo per i join/part"* →
the `events` tier → kind `:server_event`.

⚠️ **Provenance: that ruling reached this branch RELAYED, not read
first-hand on IRC.** The comment's author field reads `vjt`, but every agent
in this project comments with the same token, so the field is not
independent evidence of authorship. If the relay is crooked, this is the
paragraph that should catch it.

## What changed

`EventRouter.persist_server_notice/2` → `persist_server_event/2`, writing
`:server_event` instead of `:notice`. The old name would have been a lie
about the row it produces.

**Scoped to the numeric fallback, as the issue asked — and measured, that
scope is the whole function.** All six callers are unprimed-burst clauses:

| clause | numerics |
| --- | --- |
| MOTD | 375, 372, 376, 422 |
| ADMIN | 256, 257, 258, 259, 423, 447 |
| uncorrelated `ERR_NOSUCHSERVER` | 402 |
| INFO | 371, 374 |
| VERSION | 351 |

A genuine server NOTICE (NickServ, an oper) never reaches it — the CP13
non-channel NOTICE chain builds its own `:notice` persist, so it stays a
content kind and still raises the window to `:message`. The whole family
moves together because the issue names the other bursts too ("total
consistency or nothing").

## The three guardrails the issue posed

1. **Scoped to the fallback, not to the function wholesale** — same cut, as
   above, with the caller list.
2. **The MOTD text still renders.** `:server_event` is outside
   `@body_required_kinds`, which makes a body OPTIONAL, not forbidden. cic's
   `case "server_event"` arm falls through to a body render when
   `meta.raw_verb` is absent — exactly this path's shape. Two new vitest
   cases pin it on the REAL row shape (sender = server hostname,
   `meta.sender_kind`, no `raw_verb`), including that a colour-coded banner
   keeps its mIRC runs. That arm's comment called itself "a server bug,
   rendered defensively"; it now also describes the ordinary case, so nobody
   deletes it as dead code.
3. **VERSION / INFO / ADMIN moved with MOTD** — see the table.

## No backfill

Rows already persisted keep `:notice`; the badge settles on the next
connection. A backfill is a data migration → a COLD deploy → every live IRC
session dropped. Not asked for, and not taken.

## 🔴 Measured: this does not, on its own, meet the issue's acceptance criterion

The issue asks that a fresh connect leave `$server` at the `events` tier "or
nothing". It will not, and the remainder is a different mechanism.

`NumericRouter` does **not** delegate **002 RPL_YOURHOST**, **003
RPL_CREATED** or **396 RPL_HOSTHIDDEN**. Measured by routing real bahamut
wire shapes through `NumericRouter.route/2` (positive control: 372 answers
`:delegated`): all three answer `{:server, nil}`, so they fall to the generic
scan clause in `Session.Server`, which persists **every** scan-routed numeric
as `:notice`. Two or three content-tier rows therefore still land on
`$server` at every connect.

(001 and 005 never reach the scan — dedicated `handle_info` clauses consume
them. The LUSERS block 251–255 / 265 / 266 and 221 RPL_UMODEIS are delegated
and fold into bundles.)

Widening to the scan path is deliberately **not** in this branch: it
reclassifies every unhandled numeric in the product, including the replies an
operator explicitly asked for (`/stats`, `/list`), where content-tier is
arguably correct. It needs its own ruling. Recorded in DESIGN_NOTES rather
than smuggled in here.

## Downstream, and intended

Moving a kind from content to presence moves everything keyed off
`isContentKind` in cic: `$server` no longer lights the Alt+A
"worth-reading" affordance from MOTD alone, no in-pane unread divider is
placed for a MOTD-only tail, and a MOTD line stops being quotable. That is
what "count it like join/part" means; none of it is a new decision.

## Gates

| gate | result |
| --- | --- |
| `scripts/test.sh` (full) | 8 doctests, 62 properties, **6933 tests, 0 failures** |
| `scripts/check.sh` | see below |
| `scripts/bun.sh run test` | **6429 tests, 326 files, 0 failures** |
| `scripts/bun.sh run check` | 5 stages, **0 failed** |
| `scripts/design-notes-gate.sh` | 1 new entry heading, separator + marker present |

The end-to-end test asserts the **count**, not the kind: a MOTD burst fed
through a real session leaves `$server` at `messages: 0, events: 3,
severity: :event`, and a following NickServ NOTICE takes it back to
`messages: 1, severity: :message`. **Measured RED before the change at
`messages: 3`** (single-atom revert, re-run, restore).
