### PR TITLE
Release image: hand the credit roll in from the runner (issue 1834)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,9 +191,12 @@ LOG_LEVEL=info
 # commit count — that the settings credit roll renders. Same reason it is an env
 # var and not a file read: that container has no repo. The wrappers derive it
 # per launch via infra/packaging/credits.sh, which NEVER fails — on a build with
-# no `.git` (the AUR tarball, the release image) it reports the absence honestly
-# and the roll degrades to the version alone. Vite still refuses an EMPTY value,
-# because empty means a wrapper forgot to plumb it. Do not hand-write one.
+# no `.git` (the AUR tarball; a plain `docker build` of Dockerfile.release) it
+# reports the absence honestly and the roll degrades to the version alone. The
+# PUBLISHED release image is not in that set since #1834: release.yml derives
+# the payload on the runner and passes it as a build arg. Vite still refuses an
+# EMPTY value, because empty means a wrapper forgot to plumb it. Do not
+# hand-write one.
 # GRAPPA_CREDITS=
 #
 # CIC_BUILD_OUT is the host side of that service's `volumes:` mount — where the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1172,13 +1172,17 @@ jobs:
       - name: Derive the credit roll (the build context has no .git)
         id: credits
         run: |
-          # ABSENT is not an error. A repair dispatch checks out the TAG's
-          # tree, and every tag cut before #1773 predates this script — the
-          # same hazard the scaffolding step above documents for
-          # prerelease_flag.sh. The arg then stays empty, the Dockerfile's
-          # fallback answers, and that tag's image ships the roll it always
-          # shipped. Loud, because a silently degraded release image is the
-          # whole defect.
+          # ABSENT is warned about rather than fatal here — and that is a
+          # smaller claim than it looks, so it is spelled out. A repair
+          # dispatch checks out the TAG's tree while taking the Dockerfile
+          # from the dispatched ref, and every tag cut before #1773 predates
+          # this script: the same hazard the scaffolding step above documents
+          # for prerelease_flag.sh, except credits.sh is deliberately NOT on
+          # that list (the image COPYs it, so taking it from elsewhere would
+          # move the artifact). Such a repair therefore dies at
+          # `COPY infra/packaging/credits.sh` regardless — this arm does not
+          # rescue it. What it buys is that the run does not die HERE first,
+          # at exit 127, blaming the credit roll for a tag being too old.
           if [ ! -f infra/packaging/credits.sh ]; then
             echo "::warning::infra/packaging/credits.sh is absent from this tree (pre-#1773 tag) — the image will bake the degraded credit roll"
             {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1019,6 +1019,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # #1834 — the credit roll the image was built with, handed DOWN to smoke
+      # rather than re-derived there. Two reasons, and the second is the one
+      # that bites: a build arg is part of buildkit's cache key, so smoke's
+      # dry-run re-export must pass the BYTE-IDENTICAL value or it misses the
+      # cache and silently rebuilds stage 1 in-context — which is exactly the
+      # degraded build this change exists to stop, wearing a green face.
+      # Re-deriving it there would also read a fetch-depth-1 checkout, whose
+      # `git shortlog` sees one commit.
+      credits: ${{ steps.credits.outputs.credits }}
     env:
       # ONE definition of "this is a repair run", referenced by every step that
       # has to behave differently. Re-deriving the condition per step is how the
@@ -1138,6 +1148,74 @@ jobs:
             echo "scaffolding=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
+      # ── #1834: the credit roll, derived HERE because the build cannot ─────
+      #
+      # `.git` is .dockerignore'd for this image, deliberately (it is why
+      # Grappa.Version takes its no-git path), so `credits.sh` running inside
+      # stage 1 reaches its own no-repo guard and answers
+      # `{"sha":null,"date":null,"contributors":[]}` — honestly, and uselessly.
+      # Measured on the built dist, not inferred: that is the payload
+      # `ghcr.io/vjt/grappa` was baking into the credits easter egg.
+      #
+      # This runner is a full checkout (fetch-depth 0, for the #391 version
+      # derivation and the `:latest` gate), so the facts exist HERE. Derive
+      # them with the SAME script every other substrate uses and hand the
+      # result to the build as an arg; `Dockerfile.release` keeps its
+      # in-context call as the fallback, so a plain `docker build` from a
+      # source checkout is byte-for-byte unchanged.
+      #
+      # The payload must reach the build VERBATIM — vite.config.ts parses it as
+      # JSON and refuses a malformed one — so the two properties `build-args`
+      # actually needs are ASSERTED here rather than assumed: non-empty, and
+      # exactly one line (a `build-args: |` block is line-delimited, so an
+      # embedded newline would silently become a second, bogus argument).
+      - name: Derive the credit roll (the build context has no .git)
+        id: credits
+        run: |
+          # ABSENT is not an error. A repair dispatch checks out the TAG's
+          # tree, and every tag cut before #1773 predates this script — the
+          # same hazard the scaffolding step above documents for
+          # prerelease_flag.sh. The arg then stays empty, the Dockerfile's
+          # fallback answers, and that tag's image ships the roll it always
+          # shipped. Loud, because a silently degraded release image is the
+          # whole defect.
+          if [ ! -f infra/packaging/credits.sh ]; then
+            echo "::warning::infra/packaging/credits.sh is absent from this tree (pre-#1773 tag) — the image will bake the degraded credit roll"
+            {
+              echo 'credits<<CREDITS_EOF'
+              echo 'CREDITS_EOF'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          credits="$(sh infra/packaging/credits.sh)"
+
+          # Degraded HERE means the deriver failed, not that the build has no
+          # history: this step only runs with the script present and the
+          # checkout intact. Shipping the nulls anyway is precisely the silent
+          # regression #1834 closes, and the job already refuses to publish on
+          # a verdict it could not derive (see the `:latest` gate below).
+          case "$credits" in
+            *'"sha":null'*)
+              echo "::error::credits.sh derived the DEGRADED payload on a full checkout ($credits) — refusing to publish an image whose credit roll is empty"
+              exit 1
+              ;;
+          esac
+
+          # `printf '%s'` appends nothing, so this counts EMBEDDED newlines.
+          embedded="$(printf '%s' "$credits" | wc -l | tr -d ' ')"
+          if [ "$embedded" != "0" ]; then
+            echo "::error::the credits payload spans $((embedded + 1)) lines — a build-args block is line-delimited and would truncate it"
+            exit 1
+          fi
+
+          echo "credit roll: $credits"
+          {
+            echo 'credits<<CREDITS_EOF'
+            echo "$credits"
+            echo 'CREDITS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Compute image names + tag lists
         id: img
         run: |
@@ -1231,6 +1309,14 @@ jobs:
           # arm64 builds under QEMU emulation (slow — the gha cache below keeps
           # re-runs cheap).
           platforms: linux/amd64,linux/arm64
+          # #1834 — the credit roll, derived above from this full checkout. The
+          # cic stage declares the matching `ARG` and prefers it over its own
+          # in-context call; empty (a pre-#1773 tag being repaired) falls back
+          # to that call, which is also the plain-`docker build` behaviour.
+          # smoke's dry-run re-export MUST pass the same value — see the job
+          # output that carries it there.
+          build-args: |
+            GRAPPA_CREDITS=${{ steps.credits.outputs.credits }}
           # ZERO PUBLICATION on a dry-run: push on a tag push and on a repair. A
           # docker_validation dispatch still builds BOTH arches (proving the
           # arm64 QEMU path + the ABI-lockstep assertion + cic + mix release) and
@@ -1367,6 +1453,16 @@ jobs:
           load: true
           push: false
           tags: grappa-release:smoke
+          # #1834 — BYTE-IDENTICAL to what the docker job passed, taken from
+          # its job output rather than re-derived. A build arg participates in
+          # buildkit's cache key: a different value (or none) misses the cic
+          # layer, rebuilds stage 1 inside a context with no `.git`, and the
+          # image smoke then probes carries the degraded roll while the one
+          # that would have shipped does not. Re-deriving here would also read
+          # this job's fetch-depth-1 checkout, whose `git shortlog` sees one
+          # commit.
+          build-args: |
+            GRAPPA_CREDITS=${{ needs.docker.outputs.credits }}
           # MUST name the same scope the docker job's bouncer build writes
           # (#1168). That build is scoped now, because the bridge build shares
           # this job's gha cache backend; an unscoped `cache-from` here would

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -36,12 +36,30 @@ COPY cicchetto/ ./
 # why Grappa.Version takes its no-git path here), so credits.sh reports the
 # absence honestly and the roll degrades to the version alone. It must not
 # fail, or the release image stops building over an easter egg.
+#
+# #1834 — so the PUBLISHED image takes them from OUTSIDE instead. The build
+# context cannot have the history, but the machine driving the build does:
+# release.yml runs the same credits.sh in its full checkout and hands the
+# result in as this arg. Measured on the built dist before the change, not
+# inferred — `{"sha":null,"date":null,"contributors":[]}` is what
+# `ghcr.io/vjt/grappa` was shipping.
+#
+# `${GRAPPA_CREDITS:-$(sh …)}` and not an `if`, because the point is that the
+# in-context derive stays the DEFAULT: a plain `docker build` from a source
+# checkout passes no arg, the substitution runs credits.sh exactly as before,
+# and the roll degrades honestly. Turning that path into a failure would be a
+# worse bug than the one being fixed — vite.config.ts throws on an UNSET
+# GRAPPA_CREDITS (a wrapper that forgot to plumb it) and that throw must keep
+# meaning only that. The arg is declared INSIDE this stage on purpose: an
+# `ARG` is stage-scoped, so one declared next to `mix release` would leave
+# `--build-arg` accepted, warned about and silently ignored.
+ARG GRAPPA_CREDITS
 COPY VERSION ./VERSION
 COPY infra/packaging/version.sh ./infra/packaging/version.sh
 COPY infra/packaging/credits.sh ./infra/packaging/credits.sh
 RUN GRAPPA_VERSION="$(sh infra/packaging/version.sh)" \
     && export GRAPPA_VERSION \
-    && GRAPPA_CREDITS="$(sh infra/packaging/credits.sh)" \
+    && GRAPPA_CREDITS="${GRAPPA_CREDITS:-$(sh infra/packaging/credits.sh)}" \
     && export GRAPPA_CREDITS \
     && echo "cic build: GRAPPA_VERSION=${GRAPPA_VERSION}" \
     && bun run build -- --outDir /cic-dist --emptyOutDir

--- a/cicchetto/e2e/tests/issue1773-credits-roll-bakes-git-facts.spec.ts
+++ b/cicchetto/e2e/tests/issue1773-credits-roll-bakes-git-facts.spec.ts
@@ -55,7 +55,9 @@ type BakedCredits = {
  *    to `{}` here would turn the spec into a shape check silently, which is the
  *    failure mode the whole file exists to avoid.
  *  - DEGRADED (`sha: null`) is a legitimate payload in production — the AUR
- *    tarball and the release image both build with no `.git` — but it is NOT
+ *    tarball builds with no `.git`, and so does a plain `docker build` of
+ *    Dockerfile.release (the PUBLISHED image no longer degrades: release.yml
+ *    passes the payload in as a build arg, #1834) — but it is NOT
  *    legitimate HERE: `scripts/integration.sh` runs inside the repository, so a
  *    null sha means the deriver failed rather than that the build has no
  *    history. Accepting it would let this spec pass against a wrapper that

--- a/cicchetto/src/__tests__/buildCredits.test.ts
+++ b/cicchetto/src/__tests__/buildCredits.test.ts
@@ -36,9 +36,11 @@ describe("coerceBuildCredits (#1773)", () => {
   });
 
   it("accepts the no-git payload as data, not as a fault", () => {
-    // The AUR source tarball and Dockerfile.release both build with no `.git`,
-    // so credits.sh emits exactly this. It is a legitimate build, and the roll
-    // must degrade to the version alone rather than read as corruption.
+    // The AUR source tarball builds with no `.git`, and so does a plain
+    // `docker build` of Dockerfile.release — the PUBLISHED image is fed the
+    // payload as a build arg instead (#1834). credits.sh emits exactly this
+    // for the ones that are not. It is a legitimate build, and the roll must
+    // degrade to the version alone rather than read as corruption.
     const noGit = '{"sha":null,"date":null,"contributors":[]}';
 
     expect(coerceBuildCredits(noGit)).toEqual(EMPTY_BUILD_CREDITS);

--- a/cicchetto/src/lib/buildCredits.ts
+++ b/cicchetto/src/lib/buildCredits.ts
@@ -30,9 +30,14 @@ export type Contributor = {
 
 /**
  * The build's git facts. `sha` / `date` are `null` on a build that HAD no
- * repo — the AUR source tarball and Dockerfile.release both build with `.git`
- * absent by construction, exactly as `Grappa.Version` reports the bare base
- * there. That is a legitimate build, not a fault.
+ * repo — the AUR source tarball builds with `.git` absent by construction,
+ * exactly as `Grappa.Version` reports the bare base there. That is a
+ * legitimate build, not a fault.
+ *
+ * Dockerfile.release's context has no `.git` either, but since #1834 it is no
+ * longer a degraded build: release.yml derives the payload on the runner and
+ * passes it in as a build arg, so the PUBLISHED image carries the real facts.
+ * Only a plain `docker build` from a source checkout degrades there.
  */
 export type BuildCredits = {
   readonly sha: string | null;

--- a/cicchetto/vite.config.ts
+++ b/cicchetto/vite.config.ts
@@ -54,11 +54,15 @@ if (!CIC_VERSION) {
 // UNSET is fatal, exactly like GRAPPA_VERSION, and for exactly its reason: it
 // means a wrapper forgot to plumb it, and a silently empty credit roll is
 // worse than a broken build. A build that HAS NO GIT is a different thing and
-// is NOT an error — the AUR source tarball and Dockerfile.release both build
-// with `.git` absent by construction, and credits.sh reports that as a
-// well-formed payload of nulls. The two states are kept distinct here on
-// purpose; the same distinction `Grappa.Version.verify_build_sha/2` draws
-// between `{:skip, :no_git}` and a degraded snapshot.
+// is NOT an error — the AUR source tarball builds with `.git` absent by
+// construction, and credits.sh reports that as a well-formed payload of
+// nulls. The two states are kept distinct here on purpose; the same
+// distinction `Grappa.Version.verify_build_sha/2` draws between
+// `{:skip, :no_git}` and a degraded snapshot. Dockerfile.release's context has
+// no `.git` either, but since #1834 the PUBLISHED image is not a degraded
+// build: release.yml derives the payload on the runner (which has the
+// history) and passes it as `--build-arg GRAPPA_CREDITS`, with the in-context
+// call left as the fallback a naked `docker build` still takes.
 //
 // Parsed rather than passed through: the parse IS the validation, so a
 // malformed payload fails the build here instead of reaching the browser as a

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42339,3 +42339,137 @@ The ruling reached this work RELAYED by another agent (vjt-claude) from the
 GitHub comment, not read first-hand on IRC. The comment's author field reads
 `vjt`, but every agent in this project comments with the same token, so the
 field is not independent evidence of authorship.
+<!-- entry #1834 -->
+
+---
+
+## 2026-08-27 — #1834: the release image's credit roll, and why the cure had to be an inlet and not a repair
+
+`ghcr.io/vjt/grappa` shipped a credits easter egg containing the version
+and nothing else. Reported from the outside, on IRC, which is the only
+place it could have been reported from: nothing in this repository was
+red.
+
+### What was actually wrong, and what was not
+
+Measured before touching anything, by building `Dockerfile.release
+--target cic` and reading the dist out of the image: the shipped chunk
+carried `{"sha":null,"date":null,"contributors":[]}`. That is
+`infra/packaging/credits.sh` reaching its own no-repo guard and reporting
+the absence, exactly as designed — `.git` is `.dockerignore`d for this
+image, which is the same fact that makes `Grappa.Version` take its no-git
+path here and report the bare `X.Y.Z`.
+
+So there was no broken code to find. Three things were already right and
+had to STAY right, and naming them is most of the design:
+
+* **`credits.sh` must never fail hard.** `aur/PKGBUILD` calls it while
+  building from the tag's source tarball. A hard error on a missing repo
+  would break precisely the two builds that ship.
+* **`vite.config.ts` must keep throwing on an UNSET `GRAPPA_CREDITS`.**
+  That throw catches a wrapper that forgot to plumb the variable, which is
+  a different failure from a build that legitimately has no history. The
+  two states are kept distinct on purpose, the same way
+  `Grappa.Version.verify_build_sha/2` separates `{:skip, :no_git}` from a
+  broken snapshot.
+* **A plain `docker build` from a source checkout must keep degrading
+  honestly**, not start failing. Converting an honest degradation into a
+  broken path would be a worse bug than the one being closed.
+
+The defect was therefore not in any of those; it was that the image was
+being *allowed* to take the degraded answer while the machine building it
+had the whole history sitting on disk.
+
+### The inlet
+
+`release.yml`'s docker job already checks out at `fetch-depth: 0` — for
+the #391 version derivation and the `:latest` gate. So it runs the same
+`credits.sh` on the runner and hands the payload in as `--build-arg
+GRAPPA_CREDITS`; the `cic` stage declares the matching `ARG` and spells
+its own call as the fallback.
+
+The fallback is a parameter expansion, `${GRAPPA_CREDITS:-$(sh
+infra/packaging/credits.sh)}`, and not an `if`, because the shape has to
+say that the in-context derive is still the DEFAULT rather than a
+leftover. Measured, and this is the paletto that made the cure
+non-regressive: with the arg absent, the new recipe produces a dist tree
+`diff -rq`-identical to the one the old recipe produced, still carrying
+the honest nulls.
+
+The `ARG` sits INSIDE the `cic` stage, not at the top of the file. An
+`ARG` is stage-scoped, and one declared next to `mix release` would leave
+`--build-arg` accepted, warned about and silently ignored — the original
+bug with a fix-shaped commit in front of it.
+
+### The hop that was worth proving instead of assuming
+
+The payload must reach vite VERBATIM: vite parses it as JSON and refuses a
+malformed one, and a contributor name is arbitrary text. So the
+re-quoting question was measured, not reasoned about. With the arg passed,
+the payload lands in the shipped chunk byte-for-byte identical to
+`credits.sh`'s 413-byte output — `dependabot[bot]` included, whose
+brackets are exactly the sort of character an intermediate shell would
+have eaten.
+
+Two properties `build-args` actually depends on are now asserted in the
+workflow rather than trusted: the payload is refused if it is degraded on
+a full checkout (nulls THERE mean the deriver broke, not that the build has
+no past), and refused if it spans more than one line, because a
+`build-args: |` block is line-delimited and an embedded newline would
+quietly become a second, bogus argument.
+
+### The cache key is part of the contract
+
+The `smoke` job's dry-run path re-exports the amd64 image from the docker
+job's buildkit cache. **A build arg participates in the cache key**, so
+that re-export has to pass the byte-identical value or it misses the cic
+layer, rebuilds stage 1 in a context with no `.git`, and probes the
+degraded image while the one that would have shipped is fine. It takes the
+value as a JOB OUTPUT from the docker job rather than re-deriving it —
+which would also have been wrong for a second reason, since that job
+checks out at depth 1 and `git shortlog` there sees one commit.
+
+### Why the test had to be the smoke job
+
+The issue asked for a test that the released image's credits are
+non-empty. Nothing already in CI could answer it, and the reason is
+structural: the vitest config carries no `define` at all, so every
+`buildCredits` unit test exercises the degraded path BY CONSTRUCTION, and
+the #1773 e2e spec builds its own bundle from a full checkout and treats a
+degraded payload as a setup error. Both stay green while ghcr ships nulls.
+
+Probe 5 reads the dist the container ships — every chunk under the image's
+own `CIC_DIST_ROOT`, not one named chunk, because which chunk the payload
+lands in is the bundler's business and pinning it would make this a
+code-splitting test. It has THREE outcomes and the third is what stops it
+being a mirror: populated, degraded, or *neither shape present*, which
+means the payload's spelling moved and the probe has gone blind — and
+which FAILS. That arm doubles as the positive control, since the greps
+that must reject a degraded roll must also be able to find one.
+
+All three were measured by running the probe's own bytes over real dists:
+the pre-change dist fails naming the exact degraded payload, the build-arg
+dist passes reporting `a1d57bd3` and 9 contributor rows (`git shortlog -sn
+--no-merges HEAD` agrees on 9), and a dist with the `"sha"` key renamed
+fails blind rather than passing.
+
+One incidental measurement worth keeping, because a probe was nearly
+written on top of the opposite assumption: the minifier bakes the payload
+into a **backtick** literal, which leaves the JSON's own quotes bare. A
+`"` delimiter would escape every one of them. The probe folds the escaped
+spelling onto the bare one so no assertion depends on that choice.
+
+### What this does NOT settle
+
+The AUR tarball is unchanged and cannot be changed the same way — there is
+no build host with history there, and nulls remain the honest answer.
+
+The claim was never verified against a real published image: no release
+was cut, and the only paths that build the real thing are a tag push and a
+`docker_validation` dispatch. What was verified is stage 1 of the same
+recipe, locally, on both arms.
+
+And `test/infra/cic_version_export_test.bats` still guards only
+`GRAPPA_VERSION`. All eleven rostered launchers plumb `GRAPPA_CREDITS`
+today (measured), but nothing turns red if one stops — the drift guard
+#1773 inherited was never generalised to the second variable it created.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1888,6 +1888,20 @@ D** — see **Running the published image** below.
 - **Version.** The image reports the BARE `X.Y.Z` (no `.git` in the build
   context → the `#391` no-git path, like the AUR tarball). `docker inspect`
   shows the image tag; the RUNNING app is the version source of truth.
+- **Credits (#1834) — the one fact that does NOT follow the no-git path.**
+  The credits easter egg wants three git facts (`#1773`), and the build
+  context cannot have them for the same reason the version goes bare. But
+  unlike the version, they cannot be recovered from a file in the tree, and
+  unlike the AUR tarball, the machine driving THIS build does have the
+  history. So `release.yml` runs `infra/packaging/credits.sh` on the runner
+  and passes the payload as `--build-arg GRAPPA_CREDITS`; the `cic` stage
+  declares the matching `ARG` and prefers it over its own in-context call.
+  **The in-context call stays the default**, so a plain `docker build` still
+  bakes the honest `{"sha":null,"date":null,"contributors":[]}` rather than
+  failing — see the Local build line below, and § "Deriving the credit roll"
+  under Packaging. The published image is asserted non-degraded by the smoke
+  job; the derive step also refuses to publish if the payload comes back
+  degraded on a full checkout.
 - **VALIDATE BEFORE A REAL TAG — the zero-publication dry-run.** A tag push is
   the only thing that publishes, so a broken `docker` job is discovered with the
   tag already cut and `:latest` possibly moved. Validate the job (the SAME one
@@ -1918,8 +1932,9 @@ D** — see **Running the published image** below.
   `smoke`, `needs: [docker]` and brings a real box up from the image through the
   same `infra/docker/get.sh` → `deploy.sh` path an operator runs, then asks it
   questions over HTTP: `GET /` serves a shell whose chunk actually loads as
-  JavaScript, `GET /api/config` reports this version, and a restart does not
-  rotate the generated `/data/grappa.env`. On a tag it pulls the PUBLISHED
+  JavaScript, `GET /api/config` reports this version, a restart does not
+  rotate the generated `/data/grappa.env`, and (#1834) the bundle it ships
+  carries a POPULATED credit roll rather than the degraded nulls. On a tag it pulls the PUBLISHED
   `:v<version>` — the ref operators resolve; on a dry-run it probes the amd64
   image re-exported from the build cache. amd64 only (the arm64 leg is proven by
   the build). **An unobtainable image fails the job; it never skips.** The driver
@@ -1927,10 +1942,18 @@ D** — see **Running the published image** below.
   evidence and the explicit non-coverage list are in
   `docs/TESTING.md` § "The release-image smoke".
 - **Local build** (validate the Dockerfile without CI):
-  `docker buildx build -f Dockerfile.release --load -t grappa-release:test .`
+
+  ```sh
+  docker buildx build -f Dockerfile.release --load -t grappa-release:test \
+      --build-arg GRAPPA_CREDITS="$(infra/packaging/credits.sh)" .
+  ```
+
   builds the native arch; add `--platform linux/amd64,linux/arm64` for the
   multi-arch manifest (needs `docker run --privileged --rm tonistiigi/binfmt
-  --install all` first for a recent QEMU).
+  --install all` first for a recent QEMU). **The `--build-arg` is what makes
+  this the image CI builds** (#1834) — drop it and the build still succeeds,
+  with the degraded credit roll, which is correct for a source build and is
+  what the smoke script's probe 5 will (rightly) fail on.
 
 ### Running the published image (`docker run` / `curl | bash`) — #503 unit D
 
@@ -4395,6 +4418,53 @@ Consequences to know when touching the Arch recipes:
 **Publishing an Arch pre-release to the AUR is still a human step**, and
 the ordering above is the reason to think twice before doing it: pacman
 has no `epoch`-free way back if the mapping ever changes.
+
+### Deriving the credit roll — `credits.sh` (#1773, #1834)
+
+`infra/packaging/credits.sh` is `version.sh`'s sibling and is shaped like
+it on purpose: the cic build runs in containers that mount only
+`./cicchetto`, so the repo root — and therefore git — is out of reach in
+there. It echoes ONE line of JSON with the three facts the credits easter
+egg needs and a browser cannot have:
+
+    {"sha":"a1d57bd3","date":"2026-08-27T12:22:32+02:00",
+     "contributors":[{"name":"…","commits":5193},…]}
+
+Every cic-build entrypoint that exports `GRAPPA_VERSION` exports
+`GRAPPA_CREDITS` beside it, from this script, and `cicchetto/vite.config.ts`
+parses it (the parse IS the validation) and bakes it as the
+`__GRAPPA_CREDITS_JSON__` define. POSIX `/bin/sh`, always EXECUTED, for the
+same FreeBSD-jail reason `version.sh` is.
+
+**It NEVER fails.** Two launchers that must call it have no `.git` BY
+CONSTRUCTION — `aur/PKGBUILD` builds from the tag's source tarball, and
+`Dockerfile.release` `.dockerignore`s `.git` — and both are RELEASE builds,
+so a hard error would break precisely the two paths that ship. It reports
+the absence instead: `sha:null`, `date:null`, `contributors:[]`, the same
+posture `Grappa.Version.verify_build_sha/2` takes with `{:skip, :no_git}`.
+The loud half stays in vite, which refuses an **unset** `GRAPPA_CREDITS` —
+that means a wrapper forgot to plumb it, which is a different failure from
+a build that legitimately has no history, and the two must not collapse.
+
+**The release image is the one substrate that takes the payload from
+OUTSIDE (#1834).** Its context cannot have the history, but the runner
+driving the build does, so `release.yml` derives the payload there and
+passes it as `--build-arg GRAPPA_CREDITS`; the `cic` stage declares the
+`ARG` and spells its own call as the fallback,
+`${GRAPPA_CREDITS:-$(sh infra/packaging/credits.sh)}`, so a plain
+`docker build` from a source checkout is unchanged — measured, as a
+byte-identical dist tree. The AUR tarball case is NOT changed and cannot
+be: there is no build host with history there, and nulls stay the honest
+answer. Pinned by `test/infra/release_image_credits_test.bats` (the recipe,
+every PR) and by probe 5 of `scripts/smoke-release-image.sh` (the shipped
+artifact, in the `smoke` job).
+
+⚠️ `test/infra/cic_version_export_test.bats` guards the derive+export pair
+for `GRAPPA_VERSION` only. Its roster is the same set of launchers and all
+eleven plumb `GRAPPA_CREDITS` today (measured by grep — nine `export` it
+directly, `infra/linux/cic_build.sh` exports it inside the `su` it runs and
+`Dockerfile.release` inside its `RUN`), but nothing fails if one stops: the
+drift guard was never generalised to the second variable.
 
 ### `build.sh` — one throwaway build tree, one format at a time
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -402,9 +402,11 @@ what finally makes the documented "mandatory workflow_dispatch smoke
 before a real tag" smoke something). It is also runnable by hand, see the
 quick reference.
 
-Three probes, and every assertion has a mutant that kills it — measured,
-not asserted. Reproduce any row by deriving a one-line mutant image
-`FROM ghcr.io/vjt/grappa:latest` and pointing `GRAPPA_IMAGE` at it:
+Every assertion has a mutant that kills it — measured, not asserted.
+Reproduce a row by deriving a one-line mutant image
+`FROM ghcr.io/vjt/grappa:latest` and pointing `GRAPPA_IMAGE` at it
+(the count of probes is deliberately not stated here: it has already
+rotted once, and the script is the roster):
 
 | Assertion | Mutation that kills it | Observed |
 |---|---|---|
@@ -413,6 +415,8 @@ not asserted. Reproduce any row by deriving a one-line mutant image
 | the named chunk arrives as JavaScript | `RUN rm -rf /app/cicchetto-dist/assets` | 200 `text/html` |
 | `/api/config` reports the expected version | deploy an older published tag | reports the older version |
 | a restart keeps `/data/grappa.env` | drop the `[ ! -f "$secrets_file" ]` guard from the entrypoint | hash changes |
+| the shipped bundle carries a populated credit roll (#1834) | build the image with no `--build-arg GRAPPA_CREDITS`, i.e. the pre-#1834 recipe | the degraded `{"sha":null,"date":null,"contributors":[]}`, quoted in the failure |
+| …and the probe can still SEE one | rename the payload's `"sha"` key in a shipped chunk | "neither shape present" — it fails blind rather than passing quietly |
 
 Two of those are worth knowing on their own. **A missing hashed chunk is
 served as the SPA shell with 200 and `content-type: text/html`** —
@@ -422,6 +426,22 @@ are blind to it. And **the never-rotate probe needs a second container
 shape**: under `deploy.sh` every secret rides in from the host env file,
 so the entrypoint's first-boot bootstrap (#862) never fires there. Only a
 bare `docker run` with just `PHX_HOST` generates them onto `/data`.
+
+**The two credit-roll rows were measured on the DIST, not on a booted
+mutant** — the two `docker build --target cic` outputs, with and without
+the build arg, run through the probe's own assertion block. The probe
+reads the shipped chunks either way, so what the shortcut skips is the
+container, not the oracle. Stated because the rest of this table was
+measured the long way and the difference should not have to be guessed.
+
+⚠️ **This probe asserts a RELEASE build, and a naked local build fails
+it — deliberately.** `.git` is `.dockerignore`d, so an image from a plain
+`docker build -f Dockerfile.release .` legitimately bakes the degraded
+roll; `release.yml` derives the payload on the runner and passes
+`--build-arg GRAPPA_CREDITS` (#1834). Smoking a hand-built image means
+passing that arg too — see § "The published release image" in
+`docs/OPERATIONS.md`. The asymmetry is the point: the naked build must
+keep degrading honestly, the shipped image must not.
 
 What it deliberately does NOT cover: one architecture (whatever the host
 runs — the arm64 leg of the manifest is proven by the build, not here);

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -10,8 +10,8 @@
 # directory to the left. No script-level assertion can see it; one HTTP GET
 # can.
 #
-# This is that GET, plus the discovery, secret-persistence and account-bootstrap
-# probes, against a container that was
+# This is that GET, plus the discovery, secret-persistence, account-bootstrap
+# and credit-roll probes, against a container that was
 # brought up by the SAME infra/docker/get.sh -> deploy.sh path an operator
 # runs (GRAPPA_RAW_BASE points get.sh at this checkout instead of GitHub raw,
 # so the mirror step is exercised too — a file get.sh forgets to mirror is
@@ -25,6 +25,13 @@
 #   GRAPPA_IMAGE          (required) the image ref under test, already local.
 #   GRAPPA_SMOKE_VERSION  (required) the version the running node must report.
 #   GRAPPA_SMOKE_PUBLISH  host:port to publish on (default 127.0.0.1:14000).
+#
+# ⚠️ Probe 5 asserts a RELEASE build. An image from a plain
+#    `docker build -f Dockerfile.release .` legitimately bakes the degraded
+#    credit roll (`.git` is .dockerignore'd, #1834) and will fail it — pass
+#    `--build-arg GRAPPA_CREDITS="$(infra/packaging/credits.sh)"` to build the
+#    thing release.yml builds. That asymmetry is the point: the naked build
+#    must keep DEGRADING, the shipped image must not.
 #
 # A MISSING IMAGE IS A FAILURE, NEVER A SKIP: a smoke test that quietly passes
 # when it tested nothing is worse than no smoke test. Same for every probe —
@@ -212,5 +219,65 @@ grep -Fq 'created user release-smoke-admin' <<<"$created" \
 grep -Fq '[admin]' <<<"$created" \
     || die "docker exec create-user did not grant the requested admin flag: $created"
 pass "docker exec created release-smoke-admin [admin] without a password argument"
+
+# ---- probe 5: the shipped SPA carries the build's REAL credit roll ---------
+#
+# #1834. `.git` is .dockerignore'd for Dockerfile.release, so the credits.sh
+# call INSIDE the image build can only reach its own no-repo guard and answer
+# `{"sha":null,"date":null,"contributors":[]}` — which is what ghcr was
+# shipping. release.yml now derives the payload on the runner (which HAS the
+# history) and hands it in as a build arg. Nothing else in CI can see whether
+# that arrived: the unit suite runs under a vitest config with no `define` at
+# all, and the #1773 e2e spec builds its own bundle from a full checkout. This
+# probe is the only oracle that reads the artifact that ships.
+#
+# The dist, not the wire: probe 1 already proved the shell and its entry chunk
+# are SERVED. Which chunk the payload lands in is rolldown's business, and
+# pinning it here would make this a code-splitting test — so this asks the
+# container for every chunk it ships, resolving the root from the image's own
+# CIC_DIST_ROOT rather than a second copy of the path.
+#
+# THREE outcomes, not two. "Populated" and "degraded" are the two that name a
+# verdict; the third — neither shape present — means the payload's spelling
+# moved and this probe went blind, and it FAILS rather than passing quietly.
+# That is the anti-hollow-green guard, and it doubles as the positive control:
+# the same greps that must reject the degraded roll must also be able to FIND
+# one.
+say "probe 5: the SPA the image ships carries a populated credit roll"
+shipped_js="$SMOKE_HOME/shipped-chunks.js"
+# `sed` folds the escaped spelling onto the bare one: the minifier picks the
+# cheapest delimiter for the string literal it bakes the payload into —
+# backticks in the build measured for #1834, which leaves the JSON's own
+# quotes bare, but a `"` delimiter would escape every one of them. Neither
+# assertion below should depend on that choice. `set -o pipefail` above is
+# what keeps a failed `docker exec` from being masked by the sed.
+docker exec "$BOX" sh -c 'cat "$CIC_DIST_ROOT"/assets/*.js' | sed 's/\\"/"/g' > "$shipped_js" \
+    || die "could not read the shipped JS chunks out of $BOX"
+
+# The exact payload credits.sh emits with no repo — canonical, because
+# vite.config.ts re-serialises it through JSON.parse/stringify.
+degraded_roll='{"sha":null,"date":null,"contributors":[]}'
+# One contributor row. Absent from a degraded bundle and present once per
+# credited author in a populated one — measured 0 vs 9 on the two dists #1834
+# built to check exactly this.
+contributor_row='\{"name":"[^"]*","commits":[0-9]+\}'
+# The whole populated payload, head-anchored: a real sha, a real date, and at
+# least one contributor. All three, because each degrades on its own — a roll
+# that names the commit and credits nobody is still an empty roll.
+populated_roll='\{"sha":"[0-9a-f]+","date":"[^"]+","contributors":\['"$contributor_row"
+
+if grep -qF "$degraded_roll" "$shipped_js"; then
+    die "the image bakes the DEGRADED credit roll ($degraded_roll) — the build ran credits.sh in a context with no .git and nothing passed GRAPPA_CREDITS in (#1834)"
+fi
+
+if ! grep -qE "$populated_roll" "$shipped_js"; then
+    die "the shipped chunks carry NEITHER a populated credit roll nor the degraded one — the payload's spelling changed and this probe is now blind (#1834); check the vite define in cicchetto/vite.config.ts"
+fi
+
+roll_sha="$(grep -oE '\{"sha":"[0-9a-f]+"' "$shipped_js" | head -n1 | sed 's/.*"sha":"//; s/"$//')"
+# `grep -c` counts LINES and the bundle is minified onto a handful of them, so
+# it would report 1 for any roll of any size. Count MATCHES.
+roll_people="$(grep -oE "$contributor_row" "$shipped_js" | wc -l | tr -d ' ')"
+pass "the shipped bundle credits commit ${roll_sha} and ${roll_people} contributor row(s)"
 
 say "release image $GRAPPA_IMAGE deployed and answered every probe 🎉"

--- a/test/infra/release_image_credits_test.bats
+++ b/test/infra/release_image_credits_test.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+#
+# #1834 — the release image's credit roll arrives from OUTSIDE the build
+# context, and the naked build keeps degrading honestly.
+#
+# `.git` is .dockerignore'd for `Dockerfile.release`, by design, so
+# `infra/packaging/credits.sh` running INSIDE stage 1 can only ever answer
+# `{"sha":null,"date":null,"contributors":[]}` — measured on the built dist,
+# not inferred. The machine that builds the image HAS the history, so
+# release.yml derives the payload on the runner and hands it in as a build
+# arg; the in-context call stays as the fallback, which is what keeps a plain
+# `docker build` from a source checkout working exactly as it did.
+#
+# THREE claims, because removing any one of them is a different defect and
+# none of the three is visible from the others:
+#
+#   * Dockerfile.release DECLARES the arg  — without `ARG GRAPPA_CREDITS` in
+#     the `cic` stage, `--build-arg` is accepted, warned about, and silently
+#     ignored: the image builds green and ships the degraded roll, which is
+#     the exact bug this closes wearing a fixed face.
+#   * Dockerfile.release KEEPS the fallback — without it, a naked `docker
+#     build` (no arg) bakes an empty `GRAPPA_CREDITS`, and vite.config.ts
+#     THROWS on unset. That turns today's honest degradation into a broken
+#     build, which is the one thing this change must not do.
+#   * release.yml SUPPLIES it — the plumbing is worthless if the shipping job
+#     stops deriving it, and that job runs only on a tag, where a regression
+#     is discovered by shipping.
+#
+# This guard reads the recipe. The claim it CANNOT make is that the payload
+# reaches the bundle — that is asserted on the artifact by probe 5 of
+# `scripts/smoke-release-image.sh`, in release.yml's `smoke` job, and the two
+# are complementary on purpose: this one runs on every PR and costs nothing,
+# that one runs where a real image exists.
+
+setup() {
+    REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DOCKERFILE="$REPO_SRC/Dockerfile.release"
+    WORKFLOW="$REPO_SRC/.github/workflows/release.yml"
+}
+
+# The `cic` stage only — an `ARG` is scoped to the stage that declares it, so
+# one declared next to the `mix release` stage would look compliant to a
+# whole-file grep and reach the vite build as nothing at all. Stage 1 runs
+# from its `FROM ... AS cic` to the next `FROM`.
+cic_stage() {
+    awk '/^FROM .* AS cic$/ { inside = 1; next } /^FROM / { inside = 0 } inside' "$1"
+}
+
+declares_credits_arg() {
+    grep -qE '^ARG GRAPPA_CREDITS$' <<< "$(cic_stage "$1")"
+}
+
+# The fallback, spelled as the parameter expansion that only RUNS the deriver
+# when the arg is absent or empty. Matched on the pair rather than on
+# `credits.sh` alone: the in-context call surviving with no `:-` in front of
+# it would mean the build arg is derived, passed, declared — and overwritten.
+falls_back_to_credits_sh() {
+    grep -qF '${GRAPPA_CREDITS:-$(sh infra/packaging/credits.sh)}' <<< "$(cic_stage "$1")"
+}
+
+# The workflow half: the docker job derives the payload with the same script
+# every other substrate uses, and hands it to the build as GRAPPA_CREDITS.
+# Two greps, because either half alone passes while the channel is cut.
+workflow_derives_credits() {
+    grep -qF 'infra/packaging/credits.sh' "$1"
+}
+
+workflow_passes_build_arg() {
+    grep -qE '^ +GRAPPA_CREDITS=\$\{\{ steps\.[a-z_]+\.outputs\.credits \}\}$' "$1"
+}
+
+@test "#1834 — Dockerfile.release's cic stage declares the GRAPPA_CREDITS build arg" {
+    declares_credits_arg "$DOCKERFILE" || {
+        printf 'the cic stage does not declare `ARG GRAPPA_CREDITS`; a --build-arg\n' >&2
+        printf 'would be ignored and the release image would ship the degraded roll:\n' >&2
+        cic_stage "$DOCKERFILE" >&2
+        return 1
+    }
+}
+
+@test "#1834 — Dockerfile.release still derives the credits in-context when no arg is passed" {
+    falls_back_to_credits_sh "$DOCKERFILE" || {
+        printf 'the cic stage lost its `${GRAPPA_CREDITS:-$(sh infra/packaging/credits.sh)}`\n' >&2
+        printf 'fallback. A naked `docker build` would hand vite an EMPTY GRAPPA_CREDITS,\n' >&2
+        printf 'which vite.config.ts throws on — an honest degradation turned into a\n' >&2
+        printf 'broken build:\n' >&2
+        cic_stage "$DOCKERFILE" >&2
+        return 1
+    }
+}
+
+@test "#1834 — release.yml derives the credits on the runner and passes them as a build arg" {
+    workflow_derives_credits "$WORKFLOW" || {
+        printf 'release.yml no longer calls infra/packaging/credits.sh — the runner has\n' >&2
+        printf 'the history and the build context does not, so nothing else can derive it.\n' >&2
+        return 1
+    }
+    workflow_passes_build_arg "$WORKFLOW" || {
+        printf 'release.yml does not pass GRAPPA_CREDITS as a build arg to the image\n' >&2
+        printf 'build. Deriving it and not handing it over ships the degraded roll.\n' >&2
+        grep -n 'build-args' -A 4 "$WORKFLOW" >&2 || true
+        return 1
+    }
+}
+
+@test "#1834 — RED: an ARG declared outside the cic stage does not satisfy the guard" {
+    local fake="$BATS_TEST_TMPDIR/Dockerfile.release"
+    cat > "$fake" <<'EOF'
+FROM oven/bun:1-alpine AS cic
+RUN GRAPPA_CREDITS="${GRAPPA_CREDITS:-$(sh infra/packaging/credits.sh)}" \
+    && bun run build
+
+FROM elixir:1.19-otp-28-alpine AS build
+ARG GRAPPA_CREDITS
+RUN mix release
+EOF
+    run declares_credits_arg "$fake"
+    [ "$status" -ne 0 ]
+
+    # POSITIVE control: the same predicate MUST accept the declaration once it
+    # sits in the stage that runs the vite build. Without this, a predicate
+    # broken into always-false would report the RED above as a pass.
+    local ok="$BATS_TEST_TMPDIR/Dockerfile.ok"
+    cat > "$ok" <<'EOF'
+FROM oven/bun:1-alpine AS cic
+ARG GRAPPA_CREDITS
+RUN bun run build
+
+FROM elixir:1.19-otp-28-alpine AS build
+RUN mix release
+EOF
+    run declares_credits_arg "$ok"
+    [ "$status" -eq 0 ]
+}
+
+@test "#1834 — RED: an unconditional in-context derive does not satisfy the fallback guard" {
+    # The pre-#1834 shape. It builds, it is green, and it overwrites whatever
+    # the build arg carried — the failure mode the `:-` spelling exists to
+    # make unrepresentable.
+    local fake="$BATS_TEST_TMPDIR/Dockerfile.overwrite"
+    cat > "$fake" <<'EOF'
+FROM oven/bun:1-alpine AS cic
+ARG GRAPPA_CREDITS
+RUN GRAPPA_CREDITS="$(sh infra/packaging/credits.sh)" \
+    && export GRAPPA_CREDITS \
+    && bun run build
+EOF
+    run falls_back_to_credits_sh "$fake"
+    [ "$status" -ne 0 ]
+
+    # POSITIVE control, same reason as above.
+    local ok="$BATS_TEST_TMPDIR/Dockerfile.fallback"
+    cat > "$ok" <<'EOF'
+FROM oven/bun:1-alpine AS cic
+ARG GRAPPA_CREDITS
+RUN GRAPPA_CREDITS="${GRAPPA_CREDITS:-$(sh infra/packaging/credits.sh)}" \
+    && export GRAPPA_CREDITS \
+    && bun run build
+EOF
+    run falls_back_to_credits_sh "$ok"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
`ghcr.io/vjt/grappa` ships a credits easter egg with the version and
nothing else. Addresses issue 1834.

## What was wrong, measured

Built `Dockerfile.release --target cic` and read the dist out of the
image: the shipped chunk carried `{"sha":null,"date":null,"contributors":[]}`.

That is not a broken code path. `.git` is `.dockerignore`d for this
image by design — the same fact that makes `Grappa.Version` take its
no-git path and report the bare `X.Y.Z` — so `credits.sh` reaches its own
no-repo guard and reports the absence honestly. The defect is that the
image was allowed to take that answer while the machine building it had
the whole history on disk.

## The change

`release.yml`'s docker job already checks out at `fetch-depth: 0` (for
the #391 version derivation and the `:latest` gate), so it runs the same
`credits.sh` there and passes the payload as `--build-arg
GRAPPA_CREDITS`. The `cic` stage declares the matching `ARG` and spells
its own call as the fallback.

Three constraints held throughout, and they shaped the result:

- **`credits.sh` still never fails hard.** Untouched. `aur/PKGBUILD`
  builds from the tag tarball and calls it; a hard error there would
  break one of the two builds that ship. The AUR case is unchanged and
  cannot be changed this way — no build host with history exists there.
- **The `vite.config.ts` throw on UNSET stays.** Untouched. It catches a
  wrapper that forgot to plumb the variable, which is a different
  failure from a build with no history, and the two must not collapse.
- **A naked `docker build` keeps working, identically.** The fallback is
  `${GRAPPA_CREDITS:-$(sh …)}`, not an `if`, so the in-context derive is
  still the DEFAULT. **Measured:** with the arg absent, the new recipe
  produces a dist tree `diff -rq`-identical to the one the old recipe
  produced, still carrying the honest nulls.

The verbatim-payload constraint was proven rather than assumed: with the
arg passed, the payload lands in the shipped chunk **byte-for-byte
identical** to `credits.sh`'s 413-byte output, `dependabot[bot]`
included — brackets being exactly what a re-quoting hop eats. The
workflow also refuses a payload that comes back degraded on a full
checkout, and refuses one spanning more than one line (a `build-args: |`
block is line-delimited).

**One thing not visible in the diff:** a build arg participates in
buildkit's cache key, so the `smoke` job's dry-run re-export must pass
the byte-identical value or it misses the cic layer, rebuilds stage 1 in
a context with no `.git`, and probes the degraded image while the one
that would have shipped is fine. It takes the value as a **job output**
from the docker job rather than re-deriving it — which would also have
been wrong because that job checks out at depth 1, where `git shortlog`
sees one commit.

## The test the issue asked for

Nothing already in CI could answer "are the released image's credits
non-empty", and the reason is structural: the vitest config carries no
`define` at all, so every `buildCredits` unit test exercises the degraded
path BY CONSTRUCTION, and the #1773 e2e spec builds its own bundle from a
full checkout. Both stay green while ghcr ships nulls.

- **`scripts/smoke-release-image.sh` probe 5** — reads the dist the
  container ships, in the job that already deploys and probes the real
  image. Three outcomes, not two: populated, degraded, or *neither shape
  present* — which fails, because it means the payload's spelling moved
  and the probe went blind. That arm is also the positive control.
- **`test/infra/release_image_credits_test.bats`** — the recipe-level
  drift guard that runs on every PR, pinning three separable claims (the
  `ARG` is declared IN the `cic` stage, since an `ARG` is stage-scoped;
  the fallback survives; the workflow supplies the value), each with a
  RED case and a positive control beside it.

Every arm measured by running the probe's own bytes over real dists: the
pre-change dist fails naming the exact degraded payload, the build-arg
dist passes reporting `a1d57bd3` and 9 contributor rows (`git shortlog
-sn --no-merges HEAD` agrees on 9), and a dist with the `"sha"` key
renamed fails blind rather than passing.

## Gates

| Gate | Result |
|---|---|
| `bats test/infra/` | 542/542, `1..542`, 0 `not ok` (at the tip, and again post-rebase for the new file) |
| `scripts/shellcheck.sh` | rc=0, 82 derived scripts; `smoke-release-image.sh` confirmed IN the set |
| `scripts/design-notes-gate.sh` | rc=0, `1 new entry heading(s)` (post-commit and post-rebase) |
| `scripts/union-rebase.sh` | `+134 -0 — contribution intact`; preceding entry `cmp`-identical to base |
| `bun.sh run check` | 5/5 stages, post-rebase |
| `bun.sh run test` | 326 files / 6437 tests green, post-rebase |

**Not verified, and stated rather than implied:** no real published image
was built. Only a tag push or a `docker_validation` dispatch builds the
whole thing; what was measured locally is stage 1 of the same recipe, on
both arms. A `docker_validation` dry-run before the next tag would
exercise the workflow half end to end.

**Pre-existing, untouched:** repairing a tag cut before #1773 already
dies at `COPY infra/packaging/credits.sh` (that file is deliberately not
in the repair scaffolding list, since the image ships it). The new
absent-script arm does not rescue that — it only keeps the derive step
from dying at 127 first and blaming the credit roll.

**Adjacent gap, reported not fixed:** `cic_version_export_test.bats`
still guards only `GRAPPA_VERSION`. All eleven rostered launchers plumb
`GRAPPA_CREDITS` today (measured), but nothing turns red if one stops.