### PR TITLE
cic: a now-playing source per vendor, and one opaque line (1835)

### DIFF
--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -30,17 +30,32 @@
 //            and it is what pins the table to the authority WITHOUT making the
 //            running client depend on that authority (see the table's
 //            moduledoc for why the fetch stays out of the render path).
-//   FEED   — #1698: the `songsUrl` now-playing feed answers 200 with
+//   FEED   — #1698: the `nowPlayingSource` feed answers 200 with
 //            `application/json`. A third baked third-party URL in the same
 //            table, so it inherits the same problem this script exists for:
 //            get the slug wrong and the station still plays perfectly while
 //            the track line stays permanently empty — a defect with no symptom
 //            anywhere the operator looks. A station that publishes no feed
-//            (`songsUrl: null`) is SKIPPED, not failed.
+//            (`nowPlayingSource: null`) is SKIPPED, not failed.
 //            No AGREE twin: `channels.json` publishes a `lastPlaying` STRING,
 //            not the feed's URL, so there is no upstream value to compare the
 //            baked one against. Naming that absence beats inventing a
 //            comparison that would pass on anything.
+//            #1835 — the axis is PER KIND now, and both halves of that are
+//            measured rather than stylistic:
+//              * a somafm feed is probed with HEAD, as before;
+//              * an icecast `status-json.xsl` answers HEAD with **400**
+//                (measured on kohina.brona.dk 2026-08-27), so it is probed with
+//                a GET. A shared HEAD would report a false RED for a feed that
+//                works perfectly.
+//              * and because the GET has the body in hand anyway, the icecast
+//                arm runs the PRODUCTION parser over it and demands a track.
+//                That is the only executable check on `mount`, which is a
+//                hand-copied string that nothing else can validate: get it
+//                wrong and the feed still answers 200 `application/json` while
+//                the station's track line stays empty forever. A content-type
+//                probe would wave that straight through — which is the exact
+//                defect class the paragraph above says this script exists for.
 //   BYTES  — #1739: `public/radio-logos/<id>.<ext>` still holds what upstream
 //            serves. The picker draws the VENDORED bytes now — no viewer
 //            contacts api.somafm.com — and the one thing that mirror gave up
@@ -72,8 +87,13 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { assertNever } from "../src/lib/api";
+// The PRODUCTION parser, not a copy. #1835 — `nowPlayingFeeds.ts` is pure
+// precisely so this script can import it: pulling `nowPlaying.ts` instead would
+// eagerly open the store's reactive root in a process with no DOM.
+import { parseIcecastStatus } from "../src/lib/nowPlayingFeeds";
 import { RADIO_LOGO_PATHS } from "../src/lib/radioLogoPaths";
-import { RADIO_STATIONS } from "../src/lib/radioStations";
+import { type NowPlayingSource, RADIO_STATIONS } from "../src/lib/radioStations";
 import {
   agreeFailure,
   brokenCount,
@@ -129,6 +149,40 @@ async function probeReach(url: string, expected: string): Promise<string | null>
   }
 }
 
+/** `null` when the station's declared source answers with a track we would
+ * actually show; otherwise why it does not.
+ *
+ * #1835 — dispatched on `kind` rather than shared, for the two measured reasons
+ * the header gives (HEAD is a 400 on icecast; `mount` has no other check). The
+ * `assertNever` is what makes a third vendor added to the union impossible to
+ * ship with this axis silently un-probed.
+ */
+async function probeFeed(source: NowPlayingSource): Promise<string | null> {
+  switch (source.kind) {
+    case "somafm":
+      return probeReach(source.url, FEED_CONTENT_TYPE);
+    case "icecast-status": {
+      try {
+        const res = await fetch(source.url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+        const reach = reachFailure(res.status, res.headers.get("content-type"), FEED_CONTENT_TYPE);
+        if (reach !== null) return reach;
+        // The body is already here, so the strong claim costs nothing extra.
+        // Reported with the mount spelled out because that is the value the
+        // reader has to go and fix, and it is the one the document disagrees
+        // with.
+        const track = parseIcecastStatus(await res.json(), source.mount);
+        return track === null
+          ? `answers 200 but carries no track at mount ${source.mount}`
+          : null;
+      } catch (err) {
+        return `${err}`;
+      }
+    }
+    default:
+      return assertNever(source);
+  }
+}
+
 /** REACH and the payload BYTES for one logo, from ONE request.
  *
  * #1739 — a GET rather than the HEAD above, because the BYTES axis needs the
@@ -171,22 +225,20 @@ if (catalogue === null) {
 const findings: StationFinding[] = await Promise.all(
   RADIO_STATIONS.map(async (station) => {
     // #1704 — a station that publishes NO logo is not probed and is not a
-    // finding, the same arm `songsUrl` has had since #1698. There is no URL to
-    // reach; what the UI draws instead is our own placeholder, which cannot
-    // 404. Counted out of the denominator below rather than folded into the
-    // green.
+    // finding, the same arm `nowPlayingSource` has had since #1698. There is no
+    // URL to reach; what the UI draws instead is our own placeholder, which
+    // cannot 404. Counted out of the denominator below rather than folded into
+    // the green.
     const logo = station.logoUrl === null ? null : await probeLogo(station.logoUrl);
+    const source = station.nowPlayingSource;
     return {
       id: station.id,
       logoUrl: station.logoUrl,
-      feedUrl: station.songsUrl,
+      feedUrl: source?.url ?? null,
       reach: logo?.reach ?? null,
       agree: agreeFailure(station.logoUrl, station.id, catalogue),
       // A station that publishes no feed is not probed and is not a finding.
-      feed:
-        station.songsUrl === null
-          ? null
-          : await probeReach(station.songsUrl, FEED_CONTENT_TYPE),
+      feed: source === null ? null : await probeFeed(source),
       // #1739 — only when there is an upstream payload in hand. A skipped row
       // and a row whose fetch died both report null here: the first has
       // nothing to compare, and the second is already red on REACH.

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -42,7 +42,8 @@ beforeEach(() => {
   // a real track that was genuinely on the air.
   //
   // It also RACED. The in-flight real answer clears the poll's own guard
-  // (`tunedStation()?.songsUrl !== url`) because the feed test tunes the SAME
+  // (`tunedStation() !== station`, `?.songsUrl !== url` before #1835) because
+  // the feed test tunes the SAME
   // station, so it lands on top of the stub. That guard is not the defect and
   // is deliberately left alone — it is asking the right question; the barrier
   // below is what let a stale answer reach it at the wrong moment.

--- a/cicchetto/src/__tests__/checkRadioLogos.test.ts
+++ b/cicchetto/src/__tests__/checkRadioLogos.test.ts
@@ -204,25 +204,26 @@ describe("the AGREE axis is not vacuous over the real table", () => {
   });
 });
 
-// #1698 — the FEED axis. `songsUrl` is a third baked third-party URL in the
+// #1698 — the FEED axis. `nowPlayingSource` is a third baked third-party URL
+// in the
 // same table, and #1696's lesson is that a baked URL nothing can check is a
 // claim, not a fact. Adding one without extending this probe would repeat the
 // exact defect the probe exists for.
 describe("the FEED axis is not vacuous over the real table", () => {
   it("has something to probe, on the stations that publish a feed", () => {
     // The positive control, the sibling of AGREE's above: FEED skips a station
-    // whose `songsUrl` is null, so a table that lost the field would report
+    // whose `nowPlayingSource` is null, so a table that lost the field would report
     // "0 broken" having probed nothing.
     //
     // #1703 — the second clause used to be `toBe(RADIO_STATIONS.length)`, i.e.
     // every row publishes a feed. That was an accident of the table being
-    // all-SomaFM and it contradicted the field's own type: `songsUrl` is
+    // all-SomaFM and it contradicted the field's own type: `nowPlayingSource` is
     // nullable precisely because a track feed is a provider CAPABILITY, and
     // the first provider without one made the assertion red for a row that is
     // correctly spelled. Non-vacuity is the property worth holding here, and
     // `> 0` is the whole of it — a table that went uniformly null lands on
     // zero and this goes red, which is the threat the control names.
-    const withFeed = RADIO_STATIONS.filter((s) => s.songsUrl !== null);
+    const withFeed = RADIO_STATIONS.filter((s) => s.nowPlayingSource !== null);
     expect(withFeed.length).toBeGreaterThan(0);
   });
 });
@@ -312,7 +313,7 @@ describe("the union verdict", () => {
   });
 
   it("says nothing about a station that publishes no feed", () => {
-    // A null `songsUrl` is a station from a provider that has no track feed,
+    // A null `nowPlayingSource` is a station from a provider that has no track feed,
     // not a broken row. Reported as a finding it would make the table's own
     // nullable field permanently red.
     expect(problems(finding({ feedUrl: null, feed: null }))).toEqual([]);
@@ -389,7 +390,7 @@ describe("a station that publishes no logo (#1704)", () => {
       RADIO_STATIONS.map((s) => ({
         id: s.id,
         logoUrl: s.logoUrl,
-        feedUrl: s.songsUrl,
+        feedUrl: s.nowPlayingSource?.url ?? null,
         reach: null,
         agree: null,
         feed: null,

--- a/cicchetto/src/__tests__/mediaSession.test.ts
+++ b/cicchetto/src/__tests__/mediaSession.test.ts
@@ -40,20 +40,20 @@ const pngStation = RADIO_STATIONS.find((s) => RADIO_LOGO_PATHS[s.id]?.endsWith("
 if (jpgStation === undefined || pngStation === undefined) {
   throw new Error("these tests need one .jpg-logo and one .png-logo station in the curated table");
 }
-const feedUrl = jpgStation.songsUrl;
-if (feedUrl === null) {
+// A guard, not a binding anyone reads: these tests stub `fetch` wholesale and
+// only need the station they tune to HAVE a feed, so that the poll runs at all.
+if (jpgStation.nowPlayingSource === null) {
   throw new Error("this test needs a station that publishes a now-playing feed");
 }
 
 /** A provider with no track feed — the `unsupported` arm. Constructed rather
-    than found, because no real row is null today and a skipped test is
-    silence. */
+    than found, so the arm is exercised whichever real rows happen to be null. */
 const feedless: RadioStation = {
   ...jpgStation,
   id: "feedless",
   title: "Feedless FM",
   streamUrl: "https://stream.example.org/feedless",
-  songsUrl: null,
+  nowPlayingSource: null,
 };
 
 const okOnce = (body: unknown): Response =>

--- a/cicchetto/src/__tests__/nowPlaying.test.ts
+++ b/cicchetto/src/__tests__/nowPlaying.test.ts
@@ -4,11 +4,15 @@ import { setToken } from "../lib/auth";
 import {
   NOW_PLAYING_POLL_MS,
   NOW_PLAYING_STALE_MS,
-  type NowPlayingTrack,
   nowPlaying,
   nowPlayingLine,
-  parseSongsFeed,
 } from "../lib/nowPlaying";
+import {
+  type NowPlayingTrack,
+  parseIcecastStatus,
+  parseNowPlayingFeed,
+  parseSongsFeed,
+} from "../lib/nowPlayingFeeds";
 import { tuneStation } from "../lib/radio";
 import { RADIO_STATIONS, type RadioStation } from "../lib/radioStations";
 
@@ -23,24 +27,39 @@ const other = RADIO_STATIONS[1];
 if (station === undefined || other === undefined) {
   throw new Error("the curated table must carry at least two stations for these tests");
 }
-// Narrowed once: `songsUrl` is nullable in the type and these tests are about
-// the arm where it is present. A row that lost its feed would otherwise make
-// them pass while probing nothing.
-const feedUrl = station.songsUrl;
-const otherFeedUrl = other.songsUrl;
-if (feedUrl === null || otherFeedUrl === null) {
+// Narrowed once: `nowPlayingSource` is nullable in the type and these tests are
+// about the arm where it is present. A row that lost its feed would otherwise
+// make them pass while probing nothing.
+const source = station.nowPlayingSource;
+const otherSource = other.nowPlayingSource;
+if (source === null || otherSource === null) {
   throw new Error("these tests need two stations that publish a now-playing feed");
 }
+const feedUrl = source.url;
+const otherFeedUrl = otherSource.url;
 
-/** A station from a provider with no track feed — the null arm of `songsUrl`.
-    Constructed rather than taken from the table, because no real row is null
-    today and a test that skipped when none was found would be silence. */
+// #1835 — the SECOND vendor shape, taken from the real table rather than
+// invented. A positive control by construction: the moment the table holds no
+// `icecast-status` row, every assertion below it stops being reachable and this
+// throws instead of reporting a green built from zero comparisons.
+const icecastStation = RADIO_STATIONS.find((s) => s.nowPlayingSource?.kind === "icecast-status");
+const icecastSource = icecastStation?.nowPlayingSource;
+if (icecastStation === undefined || icecastSource?.kind !== "icecast-status") {
+  throw new Error("these tests need a station whose feed is an icecast status document");
+}
+
+/** A station from a provider with no track feed — the null arm of
+    `nowPlayingSource`. Constructed rather than taken from the table, and the
+    reason is that it must be OUTSIDE it: the one test that uses it asserts that
+    an untabled station is not tunable at all. (Real null rows do exist —
+    rockantenne-metal since #1703 — so this is not standing in for an empty
+    arm.) */
 const feedless: RadioStation = {
   ...station,
   id: "feedless",
   title: "Feedless FM",
   streamUrl: "https://stream.example.org/feedless",
-  songsUrl: null,
+  nowPlayingSource: null,
 };
 
 const songsBody = (
@@ -122,6 +141,178 @@ describe("parseSongsFeed", () => {
     expect(parseSongsFeed("not json at all")).toBeNull();
     expect(parseSongsFeed({ songs: "not an array" })).toBeNull();
     expect(parseSongsFeed({ songs: [42] })).toBeNull();
+  });
+});
+
+// #1835 — the icecast `status-json.xsl` document, in the shape Kohina's server
+// actually answers with. Measured 2026-08-27 against
+// `https://kohina.brona.dk/icecast/status-json.xsl`: HTTP 200,
+// `application/json`, `Access-Control-Allow-Origin: *`, Icecast 2.4.4, THREE
+// mounts, and every `listenurl` on `http://localhost:8000/...` because the
+// icecast sits behind a reverse proxy that does not rewrite it.
+const mountSource = (mount: string, over: Record<string, unknown>): Record<string, unknown> => ({
+  listenurl: `http://localhost:8000${mount}`,
+  server_name: "Kohina - Old School Game and Demo Music",
+  server_description: "Hand picked chip tunes from classic computers and consoles.",
+  ...over,
+});
+
+const icecastBody = (sources: readonly Record<string, unknown>[]): unknown => ({
+  icestats: { server_id: "Icecast 2.4.4", host: "localhost", source: sources },
+});
+
+/** The title as measured, and the whole reason this vendor renders opaquely:
+    FOUR segments on `" - "`, artist not recoverable by any split. */
+const OPAQUE_TITLE = "Yuzo Koshiro - SOR2 - Good End - Mega Drive";
+
+describe("parseIcecastStatus", () => {
+  it("renders the mount's title as ONE opaque line, inventing no artist", () => {
+    // The load-bearing assertion of the whole slice. `" - "` appears three
+    // times and none of them is an artist boundary — the string is
+    // `<composer> - <game> - <track> - <platform>`. A split-and-hope would put
+    // "Yuzo Koshiro" in `artist` and "SOR2 - Good End - Mega Drive" in `title`,
+    // which is wrong here and unfixably wrong in general, and it is exactly the
+    // shape `nowPlaying.ts`'s header already refused for SomaFM's `lastPlaying`.
+    expect(
+      parseIcecastStatus(
+        icecastBody([mountSource("/stream.ogg", { title: OPAQUE_TITLE })]),
+        "/stream.ogg",
+      ),
+    ).toEqual({ artist: null, title: OPAQUE_TITLE });
+  });
+
+  it("takes the title from the mount asked for, not from the first source", () => {
+    // Measured: this server publishes three mounts off ONE status document, and
+    // the row we ship is the ogg. Reading `source[0]` would caption our stream
+    // with the aac mount's title — which is the same track today and is not
+    // guaranteed to be, since each mount is a separate icecast source.
+    expect(
+      parseIcecastStatus(
+        icecastBody([
+          mountSource("/stream.aac", { title: "aac mount track" }),
+          mountSource("/stream.ogg", { title: OPAQUE_TITLE }),
+          mountSource("/stream.opus", {}),
+        ]),
+        "/stream.ogg",
+      ),
+    ).toEqual({ artist: null, title: OPAQUE_TITLE });
+  });
+
+  it("matches the mount on the listenurl PATH, never on the whole URL", () => {
+    // The measured trap. `listenurl` names `http://localhost:8000/stream.ogg`
+    // while our station streams from `https://kohina.brona.dk/icecast/stream.ogg`
+    // — neither the host, the scheme nor the path prefix agree. A comparison
+    // against the stream URL would match nothing and the row would read
+    // `unanswered` forever, silently.
+    const body = icecastBody([mountSource("/stream.ogg", { title: OPAQUE_TITLE })]);
+    expect(parseIcecastStatus(body, icecastStation.streamUrl)).toBeNull();
+    expect(parseIcecastStatus(body, "/stream.ogg")).toEqual({
+      artist: null,
+      title: OPAQUE_TITLE,
+    });
+  });
+
+  it("refuses a mount the document does not carry rather than guessing one", () => {
+    // A mistyped `mount` in the table must read as "no track", not as some
+    // other mount's track. This is the arm that makes `check:radio`'s FEED
+    // probe able to catch the typo at all.
+    expect(
+      parseIcecastStatus(
+        icecastBody([mountSource("/stream.ogg", { title: OPAQUE_TITLE })]),
+        "/stream.mp3",
+      ),
+    ).toBeNull();
+  });
+
+  it("refuses a mount with no title key at all", () => {
+    // Measured: the opus mount answers with no `title` whatsoever. A source
+    // that is up and silent about what it is playing is not a track.
+    expect(
+      parseIcecastStatus(icecastBody([mountSource("/stream.opus", {})]), "/stream.opus"),
+    ).toBeNull();
+  });
+
+  it("refuses a blank title — the empty line, caught at the same door", () => {
+    // The icecast twin of `parseSongsFeed`'s blank-title rule. Without it
+    // `/np` publishes `* nick is now playing:  [Kohina]` into a channel, and
+    // the rail draws a caption made of nothing.
+    expect(
+      parseIcecastStatus(
+        icecastBody([mountSource("/stream.ogg", { title: "   " })]),
+        "/stream.ogg",
+      ),
+    ).toBeNull();
+  });
+
+  it("survives garbage rather than throwing at the caller", () => {
+    // Same contract `parseSongsFeed` states: a crash here takes out the poll's
+    // error handling, whose whole job is to keep the previous track on screen
+    // through a bad answer.
+    expect(parseIcecastStatus(null, "/stream.ogg")).toBeNull();
+    expect(parseIcecastStatus("not json at all", "/stream.ogg")).toBeNull();
+    expect(parseIcecastStatus({ icestats: null }, "/stream.ogg")).toBeNull();
+    // A single-mount icecast is REPORTED to answer `source` as a bare object
+    // rather than a one-element array. Unmeasured — we have no single-mount
+    // server to point at — so it is deliberately NOT handled: it degrades to
+    // "no track", never to a throw, and inventing the branch would be the
+    // unverifiable claim #1696 was filed about. `check:radio`'s FEED axis is
+    // where such a station would go red, loudly, before it ever shipped.
+    expect(parseIcecastStatus({ icestats: { source: { title: "x" } } }, "/stream.ogg")).toBeNull();
+    expect(parseIcecastStatus({ icestats: { source: [42] } }, "/stream.ogg")).toBeNull();
+    expect(
+      parseIcecastStatus({ icestats: { source: [{ title: "x" }] } }, "/stream.ogg"),
+    ).toBeNull();
+    expect(
+      parseIcecastStatus(
+        { icestats: { source: [{ listenurl: "://not a url", title: "x" }] } },
+        "/stream.ogg",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseNowPlayingFeed", () => {
+  // The dispatcher is what makes `kind` a CLOSED set with teeth: a third vendor
+  // added to the union without an arm here is a compile error at `assertNever`,
+  // not a station that silently reads `unanswered`.
+  it("reads a somafm body through the somafm arm — title and artist stay SPLIT", () => {
+    // The non-regression that matters: the vendor that CAN separate the two
+    // still does. Collapsing SomaFM into the opaque shape "for consistency"
+    // would lose a fact we are given.
+    expect(
+      parseNowPlayingFeed(
+        { kind: "somafm", url: feedUrl },
+        songsBody([{ title: "A Land Unknown", artist: "Trestal" }]),
+      ),
+    ).toEqual({ artist: "Trestal", title: "A Land Unknown" });
+  });
+
+  it("reads an icecast body through the icecast arm, at the descriptor's mount", () => {
+    expect(
+      parseNowPlayingFeed(
+        icecastSource,
+        icecastBody([
+          mountSource("/stream.aac", { title: "aac mount track" }),
+          mountSource(icecastSource.mount, { title: OPAQUE_TITLE }),
+        ]),
+      ),
+    ).toEqual({ artist: null, title: OPAQUE_TITLE });
+  });
+
+  it("hands each vendor's body to its OWN reader and to no other", () => {
+    // Crossed on purpose. Each parser must fail to find a track in the other
+    // vendor's document — if either one accidentally read the other's shape,
+    // the dispatch would be decoration and a mis-typed `kind` would go
+    // unnoticed.
+    expect(
+      parseNowPlayingFeed(
+        { kind: "somafm", url: feedUrl },
+        icecastBody([mountSource("/stream.ogg", { title: OPAQUE_TITLE })]),
+      ),
+    ).toBeNull();
+    expect(
+      parseNowPlayingFeed(icecastSource, songsBody([{ title: "Juno", artist: "Setsuna" }])),
+    ).toBeNull();
   });
 });
 
@@ -411,6 +602,74 @@ describe("nowPlaying store", () => {
     // one, and saying otherwise would put a track-shaped hole where an
     // honest "the feed has not answered" belongs.
     expect(nowPlaying()).toEqual({ status: "unanswered", station: station.title });
+  });
+
+  it("plays an icecast station's opaque line, from the descriptor's own URL", async () => {
+    // #1835, end to end through the real table row. The station that used to
+    // land in `unsupported` with a muted band now names what is on — as ONE
+    // line, with no artist, which is all this provider can honestly give.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        okOnce(icecastBody([mountSource(icecastSource.mount, { title: OPAQUE_TITLE })])),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(icecastStation);
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(icecastSource.url);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ credentials: "omit" });
+    expect(nowPlaying()).toEqual({
+      status: "playing",
+      track: { artist: null, title: OPAQUE_TITLE },
+      station: icecastStation.title,
+    });
+  });
+
+  it("keeps an icecast station on the SAME cadence as every other vendor", async () => {
+    // The brief's non-negotiable, pinned rather than trusted: a second vendor
+    // must not quietly buy itself a tighter poll. One read at tune-in, then one
+    // per interval, at a third party's expense exactly like SomaFM.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        okOnce(icecastBody([mountSource(icecastSource.mount, { title: OPAQUE_TITLE })])),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(icecastStation);
+    await settle();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    closeAudio();
+    await vi.advanceTimersByTimeAsync(NOW_PLAYING_POLL_MS * 5);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishes an icecast track as the opaque line `/np` would send", async () => {
+    // The wire text, built by the production formatter rather than retyped.
+    // The four `" - "` segments must arrive VERBATIM: any pipeline stage that
+    // decided to split them would show up here as a mangled sentence.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        okOnce(icecastBody([mountSource(icecastSource.mount, { title: OPAQUE_TITLE })])),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    tuneStation(icecastStation);
+    await settle();
+
+    const state = nowPlaying();
+    if (state.status !== "playing") throw new Error(`expected a track, got ${state.status}`);
+    expect(nowPlayingLine(state.track, state.station)).toBe(
+      `is now playing: ${OPAQUE_TITLE} [${icecastStation.title}]`,
+    );
   });
 
   it("the stale threshold outlives more than one missed read", () => {

--- a/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
+++ b/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
@@ -4,16 +4,21 @@ import type { RadioStation } from "../lib/radioStations";
 
 // #1698 — the `unsupported` arm, which needs its own file.
 //
-// `songsUrl` is nullable because publishing a now-playing feed is a provider
-// CAPABILITY, and the type therefore FORCES `nowPlaying()` to answer something
-// for a station that has none. Answering `idle` would be a lie — a station IS
-// tuned — so the arm exists, and it must be tested.
+// `nowPlayingSource` is nullable because publishing a now-playing feed is a
+// provider CAPABILITY, and the type therefore FORCES `nowPlaying()` to answer
+// something for a station that has none. Answering `idle` would be a lie — a
+// station IS tuned — so the arm exists, and it must be tested.
 //
-// It cannot be tested from `nowPlaying.test.ts`. `tunedStation()` derives the
-// station by matching the playing href against RADIO_STATIONS, so only a table
-// row can be tuned, and all fourteen rows carry a feed today. The arm is
-// therefore unreachable in production RIGHT NOW and reachable the moment a row
-// from another provider lands — which is exactly the edit this file protects.
+// #1835 — WHAT NULL STILL MEANS, now that it means less. The field used to be
+// `songsUrl`, so null said BOTH "no feed" and "not a shape we can read", and
+// Kohina was filed under it while its icecast published a title all along. With
+// one reader per vendor, null is only the first of those. This arm is therefore
+// narrower and more honest than it was, and it still has to exist:
+// rockantenne-metal publishes nothing at all.
+//
+// Mocking rather than reaching for that real row: a test bound to whichever
+// station happens to be feedless today goes green-and-vacuous the day someone
+// finds it a feed, which is exactly the edit this file protects against.
 //
 // Mocking `../lib/radio` rather than adding a feedless row to the real table:
 // production must not gain a fixture to make a test reachable (CLAUDE.md —
@@ -34,7 +39,7 @@ vi.mock("../lib/radio", () => {
     description: "A station from a provider that publishes no track feed.",
     streamUrl: "https://stream.example.org/feedless",
     logoUrl: "https://example.org/logo.png",
-    songsUrl: null,
+    nowPlayingSource: null,
   };
   return { tunedStation: (): RadioStation | null => feedless };
 });

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -55,48 +55,99 @@ describe("RADIO_STATIONS", () => {
 
   it("carries a logo for at least one station", () => {
     // #1704 — the positive control for the rule above, the same one #1698 gave
-    // `songsUrl`. `logoUrl` went nullable for Kohina, which publishes only a
-    // favicon; a table where the field had gone uniformly null would sail
-    // through the https rule having checked nothing at all.
+    // `nowPlayingSource`. `logoUrl` went nullable for Kohina, which publishes
+    // only a favicon; a table where the field had gone uniformly null would
+    // sail through the https rule having checked nothing at all.
     const withLogo = RADIO_STATIONS.filter((s) => s.logoUrl !== null);
     expect(withLogo.length).toBeGreaterThan(0);
   });
 
-  // #1698 — the now-playing feed URL. Same posture as `logoUrl`: a verbatim
-  // copy, never templated from `id` (this is a table of stations, not a table
-  // of SomaFM slugs), and nullable because publishing a track feed is a
+  // #1698 / #1835 — the now-playing SOURCE. Same posture as `logoUrl`: a
+  // verbatim copy, never templated from `id` (this is a table of stations, not
+  // a table of SomaFM slugs), and nullable because publishing a track feed is a
   // provider CAPABILITY, not something every station has.
-  it("carries a now-playing feed for at least one station", () => {
+  const sources = RADIO_STATIONS.flatMap((s) =>
+    s.nowPlayingSource === null ? [] : [{ id: s.id, source: s.nowPlayingSource }],
+  );
+
+  it("carries a now-playing source for at least one station", () => {
     // The positive control for every rule below it. Each of those skips a
-    // station whose `songsUrl` is null, so a table where the field went
+    // station whose `nowPlayingSource` is null, so a table where the field went
     // uniformly null would report green having compared nothing — silence
     // read as agreement.
-    const withFeed = RADIO_STATIONS.filter((s) => s.songsUrl !== null);
-    expect(withFeed.length).toBeGreaterThan(0);
+    expect(sources.length).toBeGreaterThan(0);
   });
 
   it("serves every now-playing feed over https", () => {
     // A feed is a `fetch`, so it is governed by `connect-src`, and the CSP
-    // token that admits it (`https://api.somafm.com`) is scheme-scoped. An
-    // http URL is refused as mixed content before the CSP is even consulted.
-    for (const s of RADIO_STATIONS) {
-      if (s.songsUrl === null) continue;
-      expect(s.songsUrl, `station ${s.id} songs feed`).toMatch(/^https:\/\//);
+    // tokens that admit these hosts are scheme-scoped. An http URL is refused
+    // as mixed content before the CSP is even consulted.
+    for (const { id, source } of sources) {
+      expect(source.url, `station ${id} feed`).toMatch(/^https:\/\//);
     }
   });
 
-  it("aims every somafm now-playing feed at api.somafm.com, the host the CSP admits", () => {
-    // #1695 measured this and it is the trap worth pinning: `connect-src`
-    // admits `https://api.somafm.com` and NOT the bare `somafm.com`, which
-    // answers an identical 200 under curl and dies in the browser. The failure
-    // is a console CSP violation and a permanently empty track line — silent
-    // from the operator's side. Scoped to somafm hosts for the same reason the
-    // stream rule is: the table may hold a station from another provider.
-    for (const s of RADIO_STATIONS) {
-      if (s.songsUrl === null) continue;
-      const host = new URL(s.songsUrl).host;
-      if (!host.endsWith("somafm.com")) continue;
-      expect(host, `station ${s.id} songs feed is off the CSP's host`).toBe("api.somafm.com");
+  // #1835 — the CSP TWIN, client-side. `connect-src` is a per-vendor gate on
+  // the server (`GrappaWeb.Plugs.SecurityHeaders`) and it is deliberately NOT a
+  // wildcard, so a feed added here on an unlisted host fails in a way nobody
+  // sees: a console violation and a permanently empty track line, with the
+  // station otherwise playing fine. The Elixir side cannot check this — it has
+  // no idea what the table holds — and this side cannot read the header, so the
+  // two halves are pinned against the same literal set from opposite ends.
+  //
+  // ⚠️ ADDING A HOST HERE IS A NETWORK-SURFACE CHANGE. It has to land in
+  // `@csp`'s `connect-src` in the SAME change, or this table points at a host
+  // the browser will refuse.
+  const CSP_FEED_HOSTS: readonly string[] = ["api.somafm.com", "kohina.brona.dk"];
+
+  it("aims every now-playing feed at a host the CSP's connect-src admits", () => {
+    // #1695 measured the trap this generalises: `connect-src` admits
+    // `https://api.somafm.com` and NOT the bare `somafm.com`, which answers an
+    // identical 200 under curl and dies in the browser. Exact hosts, never a
+    // suffix match — a suffix would wave through the very neighbour that
+    // separates the shipped policy from a wildcard.
+    for (const { id, source } of sources) {
+      expect(CSP_FEED_HOSTS, `station ${id} feed is off the CSP's host set`).toContain(
+        new URL(source.url).host,
+      );
+    }
+  });
+
+  it("has a feed behind every host it pins — an unused entry proves nothing", () => {
+    // The positive control for the rule above, and the same vacuity argument
+    // the stream front doors get: a host left in the list after its station was
+    // pruned keeps the CSP wider than the table needs, and nothing would say so.
+    for (const host of CSP_FEED_HOSTS) {
+      expect(
+        sources.filter((s) => new URL(s.source.url).host === host),
+        `no station feeds from ${host} — the CSP entry outlived its station`,
+      ).not.toHaveLength(0);
+    }
+  });
+
+  it("keeps every somafm source on api.somafm.com — the #1695 pin, now keyed on kind", () => {
+    // Scoped by `kind` rather than by host suffix, which is what the old
+    // spelling did: the suffix version could only notice a somafm URL that had
+    // drifted to the wrong somafm host, while this one also notices a row
+    // declaring the somafm READER over some other provider's document — a
+    // parser/document mismatch that answers 200 and yields no track.
+    for (const { id, source } of sources) {
+      if (source.kind !== "somafm") continue;
+      expect(new URL(source.url).host, `station ${id} reads somafm off the wrong host`).toBe(
+        "api.somafm.com",
+      );
+    }
+  });
+
+  it("gives every icecast source an absolute mount path", () => {
+    // #1835 — the mount is compared against a `URL.pathname`, which always
+    // starts with `/`. A mount spelled `stream.ogg` would therefore match no
+    // source in any document, and the station would read `unanswered` forever
+    // with the feed answering 200 the whole time. The failure is silent from
+    // every surface, which is why it is pinned rather than left to review.
+    for (const { id, source } of sources) {
+      if (source.kind !== "icecast-status") continue;
+      expect(source.mount, `station ${id} mount is not an absolute path`).toMatch(/^\//);
     }
   });
 

--- a/cicchetto/src/lib/nowPlaying.ts
+++ b/cicchetto/src/lib/nowPlaying.ts
@@ -1,8 +1,30 @@
 import { createEffect, createSignal, on } from "solid-js";
 import { moduleRoot } from "./moduleRoot";
+import { type NowPlayingTrack, parseNowPlayingFeed } from "./nowPlayingFeeds";
 import { tunedStation } from "./radio";
+import type { NowPlayingSource, RadioStation } from "./radioStations";
 
 // #1698 — what the tuned station is playing right now.
+//
+// ONE READER PER VENDOR (#1835). The station table declares WHERE its fact
+// lives and in WHOSE shape (`NowPlayingSource`, a closed union of literals) and
+// `nowPlayingFeeds.ts` holds one parser per `kind`; this module stays the
+// STORE, and asks that one door. Before #1835 there was one parser, SomaFM's,
+// and the field was spelled `songsUrl` — so a station from any other provider
+// had nothing to put there, landed in `unsupported`, and showed a muted band
+// for a fact its server was publishing all along. Adding a vendor is a `kind`,
+// a parser and a CSP entry; the store, the cadence, the five states and every
+// consumer are untouched by construction.
+//
+// WHAT A VENDOR IS ALLOWED TO GIVE US, and it is not the same everywhere. The
+// somafm arm hands back a track already SPLIT by the provider; the
+// icecast-status arm hands back ONE OPAQUE LINE with no artist, because that is
+// all its document honestly contains (see `parseIcecastStatus`). Both flow into
+// the same `NowPlayingTrack`, whose `artist` has been nullable since #1698 —
+// the display, the lock screen and the `/np` wire line already say a shorter
+// sentence when it is null, so an opaque vendor needed NO consumer change and
+// gets no discriminator of its own. A field no door reads is a field that rots
+// unnoticed, which is the same reason `album` never entered the type.
 //
 // WHERE THE FACT COMES FROM, AND WHAT WAS RULED OUT. Measured 2026-08-24:
 //
@@ -78,15 +100,6 @@ export const NOW_PLAYING_POLL_MS = 60_000;
     Expressed as a multiple so a cadence change carries it along. */
 export const NOW_PLAYING_STALE_MS = NOW_PLAYING_POLL_MS * 3;
 
-/** The track on air. `album` is in the feed and deliberately NOT here: nothing
-    renders it, and a field no door reads is a field that rots unnoticed. */
-export type NowPlayingTrack = {
-  /** Absent when the feed gave a blank one — the line then names the title
-      alone rather than dangling a dash. */
-  readonly artist: string | null;
-  readonly title: string;
-};
-
 /** What the store can honestly say. Named for what was OBSERVED, per the
     log-honesty rule: `unanswered` is true whether the feed has been silent for
     200ms or for an hour, and does not promise a "yet". */
@@ -103,36 +116,6 @@ export type NowPlaying =
   | { readonly status: "unanswered"; readonly station: string }
   | { readonly status: "stale"; readonly station: string }
   | { readonly status: "playing"; readonly track: NowPlayingTrack; readonly station: string };
-
-/** The shape SomaFM gives us. Everything optional: this is a third party's
-    document and a missing field must degrade to "no track", never to a throw —
-    the poll's error handling exists to keep the previous track on screen
-    through a bad answer, and it cannot do that if parsing takes it out. */
-type SongsBody = { readonly songs?: unknown };
-
-const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
-
-/**
- * The newest track in a `…/songs/<id>.json` body, or `null` when the document
- * carries none we would show.
- *
- * A blank TITLE is rejected here rather than downstream, and that is the
- * boundary doing its job: `/np` renders the track into a channel, and a blank
- * title is exactly the empty sentence that must never reach the wire. A blank
- * ARTIST is kept — it shortens the line instead of voiding it.
- */
-export function parseSongsFeed(body: unknown): NowPlayingTrack | null {
-  if (typeof body !== "object" || body === null) return null;
-  const songs = (body as SongsBody).songs;
-  if (!Array.isArray(songs)) return null;
-  const first: unknown = songs[0];
-  if (typeof first !== "object" || first === null) return null;
-  const row = first as Record<string, unknown>;
-  const title = str(row.title);
-  if (title === "") return null;
-  const artist = str(row.artist);
-  return { artist: artist === "" ? null : artist, title };
-}
 
 /**
  * A track as one string: `<artist> — <title>`, or the title alone when the
@@ -191,16 +174,16 @@ const exports_ = moduleRoot(() => {
     }
   };
 
-  const poll = async (url: string): Promise<void> => {
+  const poll = async (station: RadioStation, source: NowPlayingSource): Promise<void> => {
     let track: NowPlayingTrack | null = null;
     try {
-      const res = await fetch(url, {
+      const res = await fetch(source.url, {
         // Explicit, though it is also the cross-origin default: this is a
         // third party's host and must never be handed a grappa cookie. Stated
         // so a later edit to this options object cannot silently turn it on.
         credentials: "omit",
       });
-      if (res.ok) track = parseSongsFeed(await res.json());
+      if (res.ok) track = parseNowPlayingFeed(source, await res.json());
     } catch {
       // A transport failure and a malformed answer are the SAME event here —
       // "we did not learn anything this time" — and both are handled below by
@@ -210,10 +193,15 @@ const exports_ = moduleRoot(() => {
 
     // The station may have changed while this was in flight. Writing anyway
     // would caption the new station with the old one's track, which `/np`
-    // would then publish into a channel. Compared by URL rather than by a
-    // generation counter, which also makes a re-tune of the SAME station
-    // accept the answer it is still waiting for.
-    if (tunedStation()?.songsUrl !== url) return;
+    // would then publish into a channel. Compared by station IDENTITY rather
+    // than by a generation counter: `tunedStation()` resolves to a row of the
+    // module-constant table, so the reference is stable and a re-tune of the
+    // SAME station still accepts the answer it is already waiting for.
+    // #1835 — identity rather than the feed URL, which this used to compare.
+    // One icecast status document serves EVERY mount on that server, so two
+    // rows of the same station's mounts would share a URL and each would have
+    // accepted the other's answer.
+    if (tunedStation() !== station) return;
 
     if (track !== null) {
       setRead({ track, at: Date.now() });
@@ -233,19 +221,22 @@ const exports_ = moduleRoot(() => {
       stopPolling();
       setRead(null);
       setStaleFlag(false);
-      const url = station?.songsUrl;
-      if (url === undefined || url === null) return;
+      if (station === null) return;
+      const source = station.nowPlayingSource;
+      if (source === null) return;
       // Immediately, then on the interval: a 60s blank at tune-in is the
-      // operator's first impression of the feature.
-      void poll(url);
-      timer = setInterval(() => void poll(url), NOW_PLAYING_POLL_MS);
+      // operator's first impression of the feature. The cadence is the vendor's
+      // business in NO respect — every `kind` polls on the same interval, for
+      // the reasons the header gives about who pays for it.
+      void poll(station, source);
+      timer = setInterval(() => void poll(station, source), NOW_PLAYING_POLL_MS);
     }),
   );
 
   const nowPlaying = (): NowPlaying => {
     const station = tunedStation();
     if (station === null) return { status: "idle" };
-    if (station.songsUrl === null) return { status: "unsupported", station: station.title };
+    if (station.nowPlayingSource === null) return { status: "unsupported", station: station.title };
     if (staleFlag()) return { status: "stale", station: station.title };
     const last = read();
     if (last === null) return { status: "unanswered", station: station.title };

--- a/cicchetto/src/lib/nowPlayingFeeds.ts
+++ b/cicchetto/src/lib/nowPlayingFeeds.ts
@@ -1,0 +1,159 @@
+import { assertNever } from "./api";
+import type { NowPlayingSource } from "./radioStations";
+
+// #1835 — ONE READER PER VENDOR, and nothing reactive.
+//
+// The pure half of `nowPlaying.ts`: the parsers that turn a third party's
+// document into a track, split out so they can be imported without opening the
+// store's reactive root. That split is not tidiness — it is the same one
+// `check-radio-logos-core.ts` states its own reason for. `bun run check:radio`
+// must be able to run the PRODUCTION parser against a live feed (it is the only
+// executable check on a hand-copied `mount`), and importing `nowPlaying.ts`
+// from a bun script would eagerly run `moduleRoot`, creating a `createEffect`
+// over `tunedStation()` in a process with no DOM and no identity.
+//
+// So: no solid-js here, no state, no IO. Every function is total on `unknown`.
+//
+// WHAT A PARSER OWES ITS CALLER, and it is the same contract for every vendor:
+//
+//   * NEVER THROW. A malformed answer is "we did not learn anything this time",
+//     which the poll handles by ageing the previous read rather than blanking
+//     it — and it cannot do that if parsing takes the caller out.
+//   * NEVER YIELD A BLANK TITLE. `/np` renders a track into a CHANNEL, so the
+//     empty sentence has to die at the door and not three layers downstream.
+//   * NEVER INVENT A FIELD THE DOCUMENT DOES NOT CARRY. This is the rule that
+//     shaped the whole issue: see `parseIcecastStatus`.
+
+/** The track on air. `album` is in the somafm feed and deliberately NOT here:
+    nothing renders it, and a field no door reads is a field that rots
+    unnoticed. */
+export type NowPlayingTrack = {
+  /** Absent when the feed gave a blank one, or — for a vendor that publishes
+      one joined string — when there is no honest way to know it. The line then
+      names the title alone rather than dangling a dash. */
+  readonly artist: string | null;
+  readonly title: string;
+};
+
+/** The shape SomaFM gives us. Everything optional: this is a third party's
+    document and a missing field must degrade to "no track", never to a throw —
+    the poll's error handling exists to keep the previous track on screen
+    through a bad answer, and it cannot do that if parsing takes it out. */
+type SongsBody = { readonly songs?: unknown };
+
+const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+
+/**
+ * The newest track in a `…/songs/<id>.json` body, or `null` when the document
+ * carries none we would show.
+ *
+ * A blank TITLE is rejected here rather than downstream, and that is the
+ * boundary doing its job: `/np` renders the track into a channel, and a blank
+ * title is exactly the empty sentence that must never reach the wire. A blank
+ * ARTIST is kept — it shortens the line instead of voiding it.
+ */
+export function parseSongsFeed(body: unknown): NowPlayingTrack | null {
+  if (typeof body !== "object" || body === null) return null;
+  const songs = (body as SongsBody).songs;
+  if (!Array.isArray(songs)) return null;
+  const first: unknown = songs[0];
+  if (typeof first !== "object" || first === null) return null;
+  const row = first as Record<string, unknown>;
+  const title = str(row.title);
+  if (title === "") return null;
+  const artist = str(row.artist);
+  return { artist: artist === "" ? null : artist, title };
+}
+
+/** The shape an Icecast `status-json.xsl` gives us. Optional throughout for the
+    reason `SongsBody` states, plus one of its own: `source` is a LIST because
+    one status document describes every mount the server carries, and the mount
+    we stream is picked out of it by path rather than assumed to be first. */
+type IcestatsBody = { readonly icestats?: { readonly source?: unknown } };
+
+/** The mount path an icecast source is served at, or `null` when the row does
+ * not name one we can read.
+ *
+ * `listenurl` is the ONLY mount identity Icecast 2.4.4 puts in this document —
+ * there is no bare `mount` key — and it is parsed for its PATH and nothing
+ * else. Measured on Kohina 2026-08-27, that URL reads
+ * `http://localhost:8000/stream.ogg`: the icecast sits behind a reverse proxy
+ * that does not rewrite it, so its host, scheme and port describe the server's
+ * own loopback and say nothing about how anyone reaches it. Comparing whole
+ * URLs would therefore match nothing, forever, and silently.
+ */
+function mountOf(row: Record<string, unknown>): string | null {
+  const listenurl = str(row.listenurl);
+  if (listenurl === "") return null;
+  try {
+    return new URL(listenurl).pathname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The track on `mount` in an Icecast `status-json.xsl` body, as ONE OPAQUE
+ * LINE, or `null` when the document carries none we would show.
+ *
+ * 🔴 IT DOES NOT SPLIT, AND THAT IS THE DESIGN. Icecast carries a single
+ * `title` string with no agreed internal structure. Measured on Kohina twice:
+ * `Hisayoshi Ogura (Zuntata) - The Ninja Warriors - Che! - Arcade` and
+ * `Yuzo Koshiro - SOR2 - Good End - Mega Drive` — FOUR segments on `" - "`,
+ * spelling `<composer> - <game> - <track> - <platform>`. Splitting on the first
+ * dash puts a composer in `artist` and three joined facts in `title`; splitting
+ * on the last is worse. There is no separator to trust, so `artist` is `null`
+ * BY CONSTRUCTION here rather than by absence in the feed, and the line is
+ * shown whole. `nowPlaying.ts`'s header already refused SomaFM's `lastPlaying`
+ * for exactly this reason; re-introducing the split for a different vendor
+ * would be reopening a door the module shut on itself.
+ *
+ * A blank title is refused at this door, like `parseSongsFeed`'s: `/np` renders
+ * the track into a channel and a blank one is the empty sentence that must
+ * never reach the wire.
+ *
+ * A `source` that is not an ARRAY yields `null` rather than a guess. A
+ * single-mount icecast is reported to answer with a bare object instead, and we
+ * have no such server to measure — so it degrades to "no track" and would be
+ * caught LOUDLY by `bun run check:radio`'s FEED axis before such a station
+ * could ship, rather than handled here on an unverifiable claim.
+ */
+export function parseIcecastStatus(body: unknown, mount: string): NowPlayingTrack | null {
+  if (typeof body !== "object" || body === null) return null;
+  const icestats = (body as IcestatsBody).icestats;
+  if (typeof icestats !== "object" || icestats === null) return null;
+  const sources = icestats.source;
+  if (!Array.isArray(sources)) return null;
+
+  for (const entry of sources) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const row = entry as Record<string, unknown>;
+    if (mountOf(row) !== mount) continue;
+    const title = str(row.title);
+    return title === "" ? null : { artist: null, title };
+  }
+  return null;
+}
+
+/**
+ * The track a station's declared source is currently naming, or `null`.
+ *
+ * The one door the poll goes through, and the reason `kind` is a closed union:
+ * a vendor added to `NowPlayingSource` without an arm here widens the parameter
+ * away from `never` and `tsc` rejects the `assertNever` call. The alternative —
+ * a string field and a lookup that returns undefined — would ship a station
+ * that reads `unanswered` forever with nothing anywhere saying why.
+ */
+export function parseNowPlayingFeed(
+  source: NowPlayingSource,
+  body: unknown,
+): NowPlayingTrack | null {
+  switch (source.kind) {
+    case "somafm":
+      return parseSongsFeed(body);
+    case "icecast-status":
+      return parseIcecastStatus(body, source.mount);
+    default:
+      return assertNever(source);
+  }
+}

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -72,6 +72,38 @@
 // first entry that is not a SomaFM channel; this is a table of stations, not
 // a table of SomaFM slugs.
 
+/** #1835 — WHERE a station's now-playing fact comes from, and in WHOSE shape.
+ *
+ * A CLOSED set of literals rather than a free string, per CLAUDE.md: the reader
+ * is picked by `kind`, and `parseNowPlayingFeed`'s `assertNever` turns a new
+ * vendor added here without an arm there into a compile error rather than a
+ * station that silently reads `unanswered` forever.
+ *
+ * This replaced a bare `songsUrl: string | null`, which encoded ONE vendor's
+ * document shape in a field name and left every other provider with no way to
+ * say "I publish this, in my own format". Kohina is the row that showed it: it
+ * landed as `unsupported` with a muted band while its icecast has been
+ * publishing a title all along.
+ *
+ * The URL is COPIED, never templated from `id` — the rule `logoUrl` states
+ * above, for the same reason.
+ */
+export type NowPlayingSource =
+  /** SomaFM's `…/songs/<id>.json`: `songs[0]` is the current track, already
+      SPLIT into title / artist / album by the provider. */
+  | { readonly kind: "somafm"; readonly url: string }
+  /** An Icecast `status-json.xsl` document. Renders ONE OPAQUE LINE and
+      deliberately no artist — see `parseIcecastStatus`.
+      `mount` is icecast's OWN mount path and is NOT derivable from `streamUrl`:
+      measured on Kohina 2026-08-27, the document's `listenurl` reads
+      `http://localhost:8000/stream.ogg` (the icecast sits behind a reverse
+      proxy that does not rewrite it) while we stream from
+      `https://kohina.brona.dk/icecast/stream.ogg`. Neither host, scheme nor
+      path prefix agree, so the mount is a copied value like every other URL in
+      this table — and it is load-bearing, because one status document serves
+      every mount the server carries. */
+  | { readonly kind: "icecast-status"; readonly url: string; readonly mount: string };
+
 /** One tunable station. All URLs must be https — the CSP tokens that admit
     them (`media-src https:`, `img-src https:`) are scheme-scoped, and an http
     stream on an https page is refused as mixed content anyway. */
@@ -86,8 +118,8 @@ export type RadioStation = {
   /** The endless audio endpoint handed to `playAudio`. */
   readonly streamUrl: string;
   /** #1704 — the station's own artwork, or `null` when it publishes none.
-      NULLABLE since Kohina, and the reasoning is the one `songsUrl` gives
-      below rather than a second mechanism: a logo is a thing most stations
+      NULLABLE since Kohina, and the reasoning is the one `nowPlayingSource`
+      gives below rather than a second mechanism: a logo is a thing most stations
       HAVE, so the field stays required-looking for every row that has one —
       but "publishes no artwork" is a real state of the world and the type has
       to be able to say it. The alternative was pointing this at Kohina's
@@ -103,20 +135,19 @@ export type RadioStation = {
       `bun run check:radio` reports a null row as SKIPPED rather than passing
       it silently — a green built from zero probes is silence, not agreement. */
   readonly logoUrl: string | null;
-  /** #1698 — the JSON feed naming the track on air, or `null` when the
-      provider publishes none.
+  /** #1698 — where the track on air is published, or `null` when the provider
+      publishes it NOWHERE a browser can read.
       NULLABLE, unlike every sibling above, and the difference is real rather
       than defensive: a title, a stream and a logo are things every station HAS,
       while a machine-readable now-playing feed is a provider CAPABILITY. A
-      required field would force the next non-SomaFM station to invent a URL,
-      and an invented URL is the unverifiable claim #1696 was filed about.
-      COPIED, never templated from `id` — the same rule `logoUrl` states above,
-      for the same reason: `id` is our slug, not a SomaFM one, and deriving
-      `…/songs/${id}.json` would bake a vendor's naming convention into the
-      type. That the two coincide for all fourteen rows today is a fact about
-      SomaFM, not a contract. `bun run check:radio` probes this URL alongside
-      the logo, so the claim stays executable. */
-  readonly songsUrl: string | null;
+      required field would force the next station to invent a URL, and an
+      invented URL is the unverifiable claim #1696 was filed about.
+      #1835 — a DESCRIPTOR rather than a URL, because the second vendor to
+      publish a feed did not publish SomaFM's document. `null` now means "no
+      readable feed", which is a smaller claim than it used to make: it no
+      longer also means "not SomaFM". `bun run check:radio` probes it per kind,
+      so the claim stays executable. */
+  readonly nowPlayingSource: NowPlayingSource | null;
 };
 
 export const RADIO_STATIONS: readonly RadioStation[] = [
@@ -127,7 +158,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "A nicely chilled plate of ambient/downtempo beats and grooves.",
     streamUrl: "https://ice.somafm.com/groovesalad-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/groovesalad120.png",
-    songsUrl: "https://api.somafm.com/songs/groovesalad.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/groovesalad.json" },
   },
   {
     id: "dronezone",
@@ -137,7 +168,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
       "Served best chilled, safe with most medications. Atmospheric textures with minimal beats.",
     streamUrl: "https://ice.somafm.com/dronezone-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/dronezone120.jpg",
-    songsUrl: "https://api.somafm.com/songs/dronezone.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/dronezone.json" },
   },
   {
     id: "spacestation",
@@ -146,7 +177,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Tune in, turn on, space out. Spaced-out ambient and mid-tempo electronica.",
     streamUrl: "https://ice.somafm.com/spacestation-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/spacestation120.jpg",
-    songsUrl: "https://api.somafm.com/songs/spacestation.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/spacestation.json" },
   },
   {
     id: "lush",
@@ -155,7 +186,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Sensuous and mellow female vocals, many with an electronic influence.",
     streamUrl: "https://ice.somafm.com/lush-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/lush120.jpg",
-    songsUrl: "https://api.somafm.com/songs/lush.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/lush.json" },
   },
   {
     id: "indiepop",
@@ -164,7 +195,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "New and classic favorite indie pop tracks.",
     streamUrl: "https://ice.somafm.com/indiepop-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/indiepop120.jpg",
-    songsUrl: "https://api.somafm.com/songs/indiepop.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/indiepop.json" },
   },
   {
     id: "u80s",
@@ -173,7 +204,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Early 80s UK Synthpop and a bit of New Wave.",
     streamUrl: "https://ice.somafm.com/u80s-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/u80s120.png",
-    songsUrl: "https://api.somafm.com/songs/u80s.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/u80s.json" },
   },
   {
     id: "secretagent",
@@ -183,7 +214,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
       "The soundtrack for your stylish, mysterious, dangerous life. For Spies and PIs too!",
     streamUrl: "https://ice.somafm.com/secretagent-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/secretagent120.jpg",
-    songsUrl: "https://api.somafm.com/songs/secretagent.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/secretagent.json" },
   },
   {
     id: "defcon",
@@ -192,7 +223,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Music for Hacking. The DEF CON Year-Round Channel.",
     streamUrl: "https://ice.somafm.com/defcon-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/defcon120.png",
-    songsUrl: "https://api.somafm.com/songs/defcon.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/defcon.json" },
   },
   {
     id: "folkfwd",
@@ -201,7 +232,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Indie Folk, Alt-folk and the occasional folk classics. ",
     streamUrl: "https://ice.somafm.com/folkfwd-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/folkfwd120.jpg",
-    songsUrl: "https://api.somafm.com/songs/folkfwd.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/folkfwd.json" },
   },
   {
     id: "bootliquor",
@@ -210,7 +241,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Americana Roots music for Cowhands, Cowpokes and Cowtippers",
     streamUrl: "https://ice.somafm.com/bootliquor-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/bootliquor120.jpg",
-    songsUrl: "https://api.somafm.com/songs/bootliquor.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/bootliquor.json" },
   },
   {
     id: "bossa",
@@ -219,7 +250,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Silky-smooth, laid-back Brazilian-style rhythms of Bossa Nova, Samba and beyond",
     streamUrl: "https://ice.somafm.com/bossa-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/bossa120.jpg",
-    songsUrl: "https://api.somafm.com/songs/bossa.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/bossa.json" },
   },
   {
     id: "reggae",
@@ -228,7 +259,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Reggae, Ska, Rocksteady classic and deep tracks.",
     streamUrl: "https://ice.somafm.com/reggae-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/reggae120.png",
-    songsUrl: "https://api.somafm.com/songs/reggae.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/reggae.json" },
   },
   {
     id: "sonicuniverse",
@@ -237,7 +268,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Transcending the world of jazz with eclectic, avant-garde takes on tradition.",
     streamUrl: "https://ice.somafm.com/sonicuniverse-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/sonicuniverse120.jpg",
-    songsUrl: "https://api.somafm.com/songs/sonicuniverse.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/sonicuniverse.json" },
   },
   {
     id: "missioncontrol",
@@ -246,7 +277,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Celebrating NASA and Space Explorers everywhere.",
     streamUrl: "https://ice.somafm.com/missioncontrol-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/missioncontrol120.jpg",
-    songsUrl: "https://api.somafm.com/songs/missioncontrol.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/missioncontrol.json" },
   },
   // #1703 — guitar music. The table above answered "no metal, and one row of
   // rock", and these six are what SomaFM can contribute to that: measured
@@ -269,7 +300,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
       "From black to doom, prog to sludge, thrash to post, stoner to crossover, punk to industrial.",
     streamUrl: "https://ice.somafm.com/metal-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/metal120.png",
-    songsUrl: "https://api.somafm.com/songs/metal.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/metal.json" },
   },
   {
     id: "seventies",
@@ -278,7 +309,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Mellow album rock from the Seventies. Yacht not required.",
     streamUrl: "https://ice.somafm.com/seventies-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/seventies120.jpg",
-    songsUrl: "https://api.somafm.com/songs/seventies.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/seventies.json" },
   },
   {
     id: "poptron",
@@ -287,7 +318,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Electropop and indie dance rock with sparkle and pop.",
     streamUrl: "https://ice.somafm.com/poptron-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/poptron120.png",
-    songsUrl: "https://api.somafm.com/songs/poptron.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/poptron.json" },
   },
   {
     id: "covers",
@@ -296,7 +327,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Just covers. Songs you know by artists you don't. We've got you covered.",
     streamUrl: "https://ice.somafm.com/covers-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/covers120.jpg",
-    songsUrl: "https://api.somafm.com/songs/covers.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/covers.json" },
   },
   {
     id: "brfm",
@@ -305,7 +336,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "From the Black Rock Desert playa to the world, year round!",
     streamUrl: "https://ice.somafm.com/brfm-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/brfm120.jpg",
-    songsUrl: "https://api.somafm.com/songs/brfm.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/brfm.json" },
   },
   {
     id: "doomed",
@@ -314,7 +345,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description: "Where every day is Halloween: dark industrial/ambient music for tortured souls.",
     streamUrl: "https://ice.somafm.com/doomed-128-mp3",
     logoUrl: "https://api.somafm.com/logos/120/doomed120.png",
-    songsUrl: "https://api.somafm.com/songs/doomed.json",
+    nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/doomed.json" },
   },
   // #1703 — THE FIRST STATION THAT IS NOT SOMAFM, and the row the issue was
   // actually about. SomaFM publishes exactly one metal channel, so "more than a
@@ -326,12 +357,15 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
   // What changes now that the table is no longer a SomaFM mirror, all three
   // already provided for by the type and none of them requiring a server edit:
   //
-  //   * `songsUrl` is null because Rock Antenne publishes no now-playing feed —
-  //     probed, not assumed. That is the field's designed arm (`unsupported`),
-  //     and it is also what keeps this a pure client change: `connect-src`
-  //     names `api.somafm.com` alone, so ANY feed URL here would have needed a
-  //     CSP widening — for a document `parseSongsFeed` could not read anyway,
-  //     since it parses SomaFM's `{songs:[…]}` shape and nothing else.
+  //   * `nowPlayingSource` is null because Rock Antenne publishes no
+  //     now-playing feed — probed, not assumed. That is the field's designed
+  //     arm (`unsupported`), and it is also what keeps this a pure client
+  //     change: `connect-src` names `api.somafm.com` alone, so ANY feed URL
+  //     here would have needed a CSP widening. (#1835 has since widened it once
+  //     more, for Kohina, and the half of this bullet about `parseSongsFeed`
+  //     being unable to read a foreign document is what that issue fixed —
+  //     there is now a reader per vendor. Rock Antenne stays null because it
+  //     publishes nothing to read, which is the ONLY thing null still claims.)
   //   * `check:radio`'s AGREE axis goes quiet for this row by construction
   //     (`isCatalogueBacked` keys on a somafm logo host) and it stays REACH-only
   //     forever. There is no upstream catalogue to pin it against; naming that
@@ -356,7 +390,7 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     streamUrl: "https://stream.rockantenne.de/heavy-metal/stream/mp3",
     logoUrl:
       "https://www.rockantenne.de/media/cache/3/version/597/streamlogo_heavymetal_ra-v1.jpg/f1b996498456cb64.jpg",
-    songsUrl: null,
+    nowPlayingSource: null,
   },
   // #1704 — KOHINA, and the first row in this table that publishes no artwork
   // at all. Requested in channel as chiptune / demoscene; measured 2026-08-24
@@ -387,13 +421,45 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
   // 17.3 and below. So this row does not play for some population of phones,
   // and #1744 is why it ships anyway: a source the browser refuses now SAYS so
   // on the transport, the rail and the lock screen instead of looking paused.
-  // Kohina has no non-Ogg endpoint, so there is no fallback stream to prefer.
   //
-  // `songsUrl` is null — no now-playing feed published. `logoUrl` is null and
-  // that is the field's new arm: kohina.com serves only favicons, the largest
-  // being a 192px PNG that answers 200. Pointing this at it was refused twice
-  // over — a favicon is not a station logo, and because it ANSWERS no error
-  // handler would ever fire, so the wrong image would render silently forever.
+  // ⚠️ CORRECTION (#1835, measured 2026-08-27). This comment used to end "Kohina
+  // has no non-Ogg endpoint, so there is no fallback stream to prefer", and that
+  // is FALSE. The status document read for the feed below enumerates THREE
+  // mounts, and both siblings answer over our own https front door:
+  // `…/icecast/stream.aac` → 200 `audio/aac`, `…/icecast/stream.opus` → 200
+  // `audio/webm`. An AAC mount would play on every iOS version the Vorbis note
+  // above excludes. Switching the baked `streamUrl` is NOT done here on purpose:
+  // it is a codec decision with its own trade (aac carries no in-band Vorbis
+  // comments, and #1744's failure surfacing was designed around this row), it
+  // belongs to that issue rather than to this one, and a slice that widens a CSP
+  // should not also silently move which bytes the operator hears. The false
+  // sentence is corrected rather than left standing; acting on it is a separate
+  // call.
+  //
+  // #1835 — `nowPlayingSource` IS NO LONGER NULL, and this row is why the field
+  // stopped being a URL. Kohina publishes nothing in SomaFM's shape, so under
+  // the old `songsUrl` it could only be null, which rendered as `unsupported`:
+  // a muted band and a `/np` that refused, for a station that has been naming
+  // its track all along. Measured 2026-08-27 on the URL below: HTTP 200,
+  // `application/json`, `Access-Control-Allow-Origin: *`, Icecast 2.4.4.
+  // `HEAD` on it answers 400 — it reads with a GET, which is why
+  // `check:radio`'s FEED axis needs a per-kind probe and not one shared HEAD.
+  //
+  // WHY THE LINE IS OPAQUE, and it is the whole design rather than a shortcut.
+  // The title is ONE joined string: measured twice on different days,
+  // `Hisayoshi Ogura (Zuntata) - The Ninja Warriors - Che! - Arcade` and
+  // `Yuzo Koshiro - SOR2 - Good End - Mega Drive` — FOUR segments on `" - "`,
+  // spelling `<composer> - <game> - <track> - <platform>`. No split recovers an
+  // artist from that, and guessing one is precisely why this module's own
+  // header already REFUSED SomaFM's `lastPlaying`. So the row renders a single
+  // line with no artist, and the UI says a shorter sentence rather than a wrong
+  // one.
+  //
+  // `logoUrl` is null and that is the field's new arm: kohina.com serves only
+  // favicons, the largest being a 192px PNG that answers 200. Pointing this at
+  // it was refused twice over — a favicon is not a station logo, and because it
+  // ANSWERS no error handler would ever fire, so the wrong image would render
+  // silently forever.
   {
     id: "kohina",
     title: "Kohina",
@@ -402,6 +468,13 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
       "Hand picked chip tunes from classic computers and consoles. SID, Amiga, Atari ST, Arcade, PC, and more!",
     streamUrl: "https://kohina.brona.dk/icecast/stream.ogg",
     logoUrl: null,
-    songsUrl: null,
+    // `mount` is the icecast-internal path, copied off the document's
+    // `listenurl` (`http://localhost:8000/stream.ogg`) and NOT derived from
+    // `streamUrl` — the proxy prefix `/icecast` is ours, not icecast's.
+    nowPlayingSource: {
+      kind: "icecast-status",
+      url: "https://kohina.brona.dk/icecast/status-json.xsl",
+      mount: "/stream.ogg",
+    },
   },
 ];

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42473,3 +42473,142 @@ And `test/infra/cic_version_export_test.bats` still guards only
 `GRAPPA_VERSION`. All eleven rostered launchers plumb `GRAPPA_CREDITS`
 today (measured), but nothing turns red if one stops — the drift guard
 #1773 inherited was never generalised to the second variable it created.
+<!-- entry #1835 -->
+
+---
+
+## 2026-08-27 — #1835: a now-playing descriptor per vendor, and one opaque line
+
+`nowPlaying` could read exactly one document shape — SomaFM's
+`…/songs/<id>.json` — so `RadioStation` spelled the capability as
+`songsUrl: string | null` and every station from any other provider was null,
+i.e. `{status: "unsupported"}`: muted band, `/np` refusing. Kohina is the row
+that showed it, and it is not metadata-less: its Icecast has been publishing a
+title the whole time.
+
+The field is now a DESCRIPTOR, `nowPlayingSource: NowPlayingSource | null`, a
+closed union of literals (`{kind: "somafm", url}` /
+`{kind: "icecast-status", url, mount}` / `null`) with one parser per `kind`
+behind `parseNowPlayingFeed`. `null` still exists and still means the same
+thing for rockantenne-metal, but it means LESS than it did: it used to say both
+"publishes nothing" and "publishes nothing we can read", and only the first
+survives.
+
+### The constraint that shaped it: the title is one string, so it stays one
+
+Icecast carries a single `title` with no agreed internal structure. Measured on
+Kohina twice, on different days:
+
+```
+Hisayoshi Ogura (Zuntata) - The Ninja Warriors - Che! - Arcade
+Yuzo Koshiro - SOR2 - Good End - Mega Drive
+```
+
+FOUR segments on `" - "`, spelling `<composer> - <game> - <track> - <platform>`.
+No split recovers an artist. Splitting on the first dash is wrong here and
+unfixably wrong in general — and it is the exact defect for which
+`nowPlaying.ts`'s own header had ALREADY rejected SomaFM's `lastPlaying`, so
+re-introducing it for a second vendor would be reopening a door the module shut
+on itself. `parseIcecastStatus` therefore returns `artist: null` BY
+CONSTRUCTION, never by absence in the feed, and the line is shown whole.
+
+**No discriminator was added for "opaque" and that is deliberate.** The
+temptation is a third field distinguishing "no artist because the feed omitted
+one" from "no artist because the format cannot express one". Measured against
+the consumers: `trackLabel` drops the dash with the artist, `mediaSession` sends
+`artist ?? ""`, `/np` renders `trackLabel`. Not one of them would branch on it.
+`NowPlayingTrack.artist` has been nullable since #1698, so the opaque vendor
+needed NO consumer change at all — and a field no door reads is a field that
+rots unnoticed, which is why `album` never entered the type either.
+
+### Measured on the third party, 2026-08-27, before anything was typed
+
+* `GET https://kohina.brona.dk/icecast/status-json.xsl` → 200,
+  `application/json; charset=UTF-8`, `Access-Control-Allow-Origin: *`,
+  Icecast 2.4.4, 1707 bytes.
+* `HEAD` on the same URL → **400**. The issue claimed this and it reproduces;
+  it is why `check:radio`'s FEED axis cannot keep one shared HEAD probe.
+* THREE mounts in one document (`/stream.aac`, `/stream.ogg`, `/stream.opus`),
+  and the opus one carries no `title` key at all.
+
+**The mount is matched on the `listenurl` PATH, and that is not a style
+choice.** Icecast 2.4.4 puts no bare `mount` key in this document; `listenurl`
+is the only mount identity, and it reads `http://localhost:8000/stream.ogg` —
+the icecast sits behind a reverse proxy that does not rewrite it. So its host,
+scheme and port describe the server's own loopback and say nothing about how
+anyone reaches it. Comparing the whole URL against `streamUrl`
+(`https://kohina.brona.dk/icecast/stream.ogg`) would match nothing, forever, and
+silently. `mount` is consequently a COPIED value like every other URL in that
+table, not derivable from `streamUrl` — the `/icecast` prefix is the proxy's,
+not icecast's.
+
+### `mount` is a hand-copied string, so `check:radio` runs the real parser
+
+A wrong mount answers 200 `application/json` and yields no track: the station
+plays perfectly and its line stays empty. A content-type probe waves that
+straight through, which is precisely the defect class `check-radio-logos.ts`
+exists for. Since the icecast arm must GET anyway (the 400 above), it has the
+body in hand and runs the PRODUCTION `parseIcecastStatus` over it, demanding a
+track. That is the only executable check `mount` can have.
+
+To import a parser from a bun script without opening the store's reactive root
+(`nowPlaying.ts` runs `moduleRoot` eagerly, creating a `createEffect` over
+`tunedStation()` — no DOM, no identity in that process), the parsers moved to a
+pure `lib/nowPlayingFeeds.ts`. Same split, and the same stated reason, as
+`check-radio-logos-core.ts`.
+
+### The in-flight guard moved from the feed URL to the station's identity
+
+`poll` used to discard a late answer by comparing `tunedStation()?.songsUrl`
+against the URL it had fetched. One icecast status document serves EVERY mount
+on that server, so two rows for two mounts of the same station would share a
+URL and each would have accepted the other's answer. Comparing
+`tunedStation() !== station` is total instead: `tunedStation()` resolves to a
+row of the module-constant table, so the reference is stable and a re-tune of
+the SAME station still accepts the answer it is already waiting for — the
+property the URL comparison was chosen for in the first place.
+
+### CSP: a second host, and the gate stays per-vendor
+
+`connect-src` gains `https://kohina.brona.dk`. **This is a network-surface
+change and it is meant to be visible.** The shape refused is `connect-src
+https:`, which would let any future table row `fetch` anywhere and would take
+the #1695 refusals with it. The station's AUDIO already comes off that host and
+needed no entry — a stream is `media-src https:`, a status document is a
+`fetch`; the two directives are not one axis, and `security_headers_test.exs`
+pins that nothing leaked sideways plus a positive control proving the
+scheme-detector can match at all.
+
+Neither side can see the other — the plug does not know what the station table
+holds, the browser bundle cannot read the header — so the allowlist is pinned
+from both ends: `@csp` in Elixir and `CSP_FEED_HOSTS` in
+`radioStations.test.ts`, the latter with a vacuity control that reds when a host
+outlives the station that needed it.
+
+### Refused, and left refused
+
+* **The in-band path.** `<audio>` does not surface ICY or Vorbis comments to the
+  page, and becoming the player (fetch + demux) is out of proportion for a band
+  of text. VLC shows Kohina's track by reading the ogg pages; we are not VLC.
+* **A single-mount icecast** is reported to answer `source` as a bare object
+  rather than a one-element array. We have no such server to measure, so it is
+  NOT handled: it degrades to "no track", never to a throw, and such a station
+  would go red on `check:radio`'s FEED axis before it could ship. Handling an
+  unmeasured shape is the unverifiable claim #1696 was filed about.
+* **The cadence.** Unchanged at 60 s, one poll per listening tab, keyed on
+  `tunedStation()`. A second vendor buys itself nothing here, and a test pins it.
+
+### A correction this work owes the record
+
+`radioStations.ts` asserted "Kohina has no non-Ogg endpoint, so there is no
+fallback stream to prefer" (#1744's iOS-Vorbis note). That is FALSE, and the
+status document read for this feed is what exposed it. Measured over our own
+https front door on 2026-08-27: `…/icecast/stream.aac` → 200 `audio/aac`,
+`…/icecast/stream.opus` → 200 `audio/webm`. An AAC mount would play on every
+iOS version the Vorbis note excludes.
+
+The sentence is corrected; the baked `streamUrl` is NOT changed here. Which
+bytes an operator hears is a codec decision with its own trade — #1744's failure
+surfacing was designed around this row, and aac carries no in-band Vorbis
+comments — and it belongs to that issue. A slice that widens a CSP should not
+also silently move the audio.

--- a/lib/grappa_web/plugs/security_headers.ex
+++ b/lib/grappa_web/plugs/security_headers.ex
@@ -37,7 +37,8 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
 
     * `default-src 'self'` — same-origin baseline.
     * `connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com
-      https://litterbox.catbox.moe https://api.somafm.com` — REST + WS to grappa
+      https://litterbox.catbox.moe https://api.somafm.com https://kohina.brona.dk`
+      — REST + WS to grappa
       (same-origin: `'self'`
       covers `ws://$host` / `wss://$host` per CSP3, so this is deployment-host
       agnostic — no edit when `PHX_HOST` changes); Cloudflare Turnstile +
@@ -64,6 +65,25 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
       `api.somafm.com`; `issue1695-somafm-connect-src-perimeter.spec.ts` pins
       both that refusal and the non-api subdomain that separates this policy
       from the wildcard.
+      `kohina.brona.dk` (#1835) is the SECOND metadata host, and the fact that
+      it needed its own line is the point rather than an inconvenience. cic's
+      radio table reads a now-playing feed per station; Kohina publishes one as
+      an Icecast `status-json.xsl` (measured 2026-08-27: HTTP 200
+      `application/json`, `Access-Control-Allow-Origin: *`) and before this it
+      was unreadable purely because the CSP admitted no host to read it from.
+      **This directive stays a PER-VENDOR gate, deliberately** — the shape to
+      refuse is `connect-src https:`, which would let any future table row
+      `fetch` anywhere and turn a curated list into an open outbound
+      permission. One host per provider we actually chose is the whole
+      mechanism: adding a station that needs a feed is a visible network-surface
+      change, reviewed as one, and a row pointing somewhere unlisted fails
+      loudly in the console instead of quietly widening the app. The SAME host
+      already carries this station's audio, and that needs no entry — a stream
+      is `media-src https:` and a status document is a `fetch`; the two
+      directives are not interchangeable. cic pins the mirror image of this list
+      in `radioStations.test.ts` (`CSP_FEED_HOSTS`), because neither side can
+      see the other: the plug does not know what the table holds, and the
+      browser bundle cannot read this header.
     * `script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM='
       https://challenges.cloudflare.com https://*.hcaptcha.com` — Vite modules +
       the Turnstile / hCaptcha widget loaders. Each loader injects a small
@@ -124,7 +144,7 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
 
   import Plug.Conn
 
-  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com https://kohina.brona.dk; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   # HTTP header names are lower-cased (HTTP/2 + Plug convention); the VALUES
   # are byte-identical to the retired nginx snippet.

--- a/test/grappa_web/plugs/security_headers_test.exs
+++ b/test/grappa_web/plugs/security_headers_test.exs
@@ -24,7 +24,7 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
   # deleted nginx snippet; #607 widened media-src to https:, #1240 img-src,
   # #1695 added ONE connect-src host). If the app must change the policy,
   # change it in ONE place (the plug) and update this pin deliberately.
-  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com https://kohina.brona.dk; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   defp sent(status) do
     :get
@@ -89,6 +89,59 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
 
       assert leaked == [],
              "only connect-src needed widening; somafm leaked into " <> inspect(leaked)
+    end
+  end
+
+  describe "#1835 — the second metadata host on connect-src" do
+    # Kohina publishes its now-playing fact as an Icecast `status-json.xsl`
+    # (measured 2026-08-27: HTTP 200 `application/json`,
+    # `Access-Control-Allow-Origin: *`). A `fetch` is governed by connect-src,
+    # so without this token the station plays perfectly and its track line stays
+    # empty forever, with nothing but a browser console saying why.
+    test "connect-src admits the icecast status host" do
+      assert MapSet.member?(directives()["connect-src"], "https://kohina.brona.dk"),
+             "connect-src must admit https://kohina.brona.dk — it is the host cic reads " <>
+               "the Kohina now-playing feed from."
+    end
+
+    # The audio for this station comes off the SAME host and needs no entry of
+    # its own: a stream is `media-src https:`, already scheme-wide. Pinned
+    # because the tempting "tidy" move is to add the host to media-src too,
+    # which would narrow nothing and imply the two directives are one axis.
+    test "no directive other than connect-src gained the icecast host" do
+      leaked =
+        for {name, sources} <- directives(),
+            name != "connect-src",
+            source <- sources,
+            String.contains?(source, "kohina"),
+            do: {name, source}
+
+      assert leaked == [],
+             "only connect-src needed the feed host; kohina leaked into " <> inspect(leaked)
+    end
+
+    # 🔴 THE RULE THE WHOLE DIRECTIVE RESTS ON, and the one a second vendor
+    # makes tempting to break. Two hosts is where somebody proposes
+    # `connect-src https:` "so the table can hold anything" — which would turn a
+    # curated station list into a blanket outbound-fetch permission for every
+    # future row, and take with it the #1695 refusals that pin this policy apart
+    # from a wildcard. Adding a THIRD metadata host is fine and is meant to be
+    # visible; collapsing them into a scheme is not.
+    test "connect-src names hosts, never a bare scheme" do
+      schemes =
+        directives()["connect-src"]
+        |> Enum.filter(&(&1 in ["https:", "http:", "*"]))
+        |> Enum.sort()
+
+      assert schemes == [],
+             "connect-src must stay a per-vendor host allowlist; found " <> inspect(schemes)
+
+      # The positive control beside it: the filter above must be capable of
+      # matching, or an inverted predicate would report this green having
+      # compared nothing. `media-src` genuinely carries `https:` (#607).
+      assert Enum.any?(directives()["media-src"], &(&1 == "https:")),
+             "the scheme filter matched nothing anywhere — it cannot be trusted to " <>
+               "have checked connect-src either."
     end
   end
 


### PR DESCRIPTION
## What

`nowPlaying` could read exactly one document shape — SomaFM's `songs/<id>.json` — so `RadioStation` spelled the capability as `songsUrl: string | null` and every station from any other provider was `null`, i.e. `{status: "unsupported"}`: muted band, `/np` refusing. Kohina is the row that shows it, and it is not metadata-less.

The field becomes a **descriptor**: `{kind:"somafm",url}` / `{kind:"icecast-status",url,mount}` / `null` — a closed union of literals with one parser per `kind` behind `parseNowPlayingFeed`, whose `assertNever` makes a third vendor added without an arm a compile error rather than a station that reads `unanswered` forever. `null` survives for `rockantenne-metal` but claims less than it did: it used to mean both "publishes nothing" and "publishes nothing we can read".

## The opaque line is the design

Icecast carries one joined `title`. Measured on Kohina twice, on different days:

```
Hisayoshi Ogura (Zuntata) - The Ninja Warriors - Che! - Arcade
Yuzo Koshiro - SOR2 - Good End - Mega Drive
```

Four segments on `" - "`, spelling `<composer> - <game> - <track> - <platform>`. No split recovers an artist, and `nowPlaying.ts`'s own header had **already** refused SomaFM's `lastPlaying` for exactly that — so `artist` is `null` by construction and the line renders whole.

**No discriminator was added for it.** `trackLabel` drops the dash with the artist, `mediaSession` sends `artist ?? ""`, `/np` renders `trackLabel`: not one consumer would branch on the difference. `NowPlayingTrack.artist` has been nullable since #1698, so the opaque vendor needed **no consumer change at all**.

## 🔴 Network surface

`connect-src` gains `https://kohina.brona.dk`. The gate stays **per-vendor** — the shape refused is `connect-src https:`, which would let any future table row `fetch` anywhere and would take the #1695 refusals with it. The station's audio already comes off that host and needs no entry (`media-src https:` governs a stream; a status document is a `fetch`). Pinned from both ends, because neither side can see the other: `@csp` in Elixir, `CSP_FEED_HOSTS` in `radioStations.test.ts`, the latter with a vacuity control that reds when a host outlives its station.

## Measured, 2026-08-27 (re-verified, not inherited from the issue)

| probe | result |
|---|---|
| `GET …/icecast/status-json.xsl` | 200, `application/json`, `Access-Control-Allow-Origin: *`, Icecast 2.4.4 |
| `HEAD` on the same URL | **400** — reproduces; it is why the offline probe needs a per-kind method |
| mounts in the document | **three** (`/stream.aac`, `/stream.ogg`, `/stream.opus`); the opus one carries no `title` key |
| every `listenurl` | `http://localhost:8000/...` — the proxy does not rewrite it |

That last row is load-bearing: the mount is matched on the `listenurl` **path**, because comparing whole URLs against `streamUrl` (`https://kohina.brona.dk/icecast/stream.ogg`) would match nothing, forever, silently.

## Also in here

- **In-flight guard** moves from the feed URL to the station's identity. One status document serves *every* mount on a server, so two rows for two mounts would have shared a URL and each accepted the other's answer.
- **Parsers extracted** to a pure `nowPlayingFeeds.ts`, so `check:radio` can import the *production* parser — pulling `nowPlaying.ts` from a bun script would eagerly open `moduleRoot`'s reactive root in a process with no DOM. Same split, same stated reason, as `check-radio-logos-core.ts`.
- **`check:radio`'s FEED axis is per-kind**, and the icecast arm parses the body it already GET'd, demanding a track. That is the only executable check `mount` can have — a wrong one answers 200 `application/json` while the line stays empty.

## A correction this work owes the record

`radioStations.ts` asserted *"Kohina has no non-Ogg endpoint, so there is no fallback stream to prefer"* — the note explaining why the row ships despite iOS's Vorbis gap. Reading the status document exposed it as **false**: over our own https front door, `…/icecast/stream.aac` answers 200 `audio/aac` and `…/icecast/stream.opus` 200 `audio/webm`, and an AAC mount would play on every iOS version that note excludes.

The sentence is corrected. The baked `streamUrl` is **not** moved here — which bytes an operator hears is a codec decision with its own trade, and it belongs to issue 1744, not to a slice whose job was widening a CSP.

## Refused, and left refused

- **In-band metadata.** `<audio>` surfaces neither ICY nor Vorbis comments to the page; becoming the player is out of proportion for a band of text.
- **A single-mount icecast** is *reported* to answer `source` as a bare object rather than a one-element array. We have no such server to measure, so it is **not** handled: it degrades to "no track", never to a throw, and would go red on the offline probe before shipping. Handling an unmeasured shape is the unverifiable claim #1696 was filed about.
- **The cadence.** Unchanged — 60 s, one poll per listening tab. A test pins that a second vendor buys itself nothing here.

## Gates

| gate | result |
|---|---|
| `bun.sh run check` | **rc=0**, 5/5 stages (lock drift, test location, biome, tsc src, tsc e2e) |
| `bun.sh run test` | **rc=0**, 326/326 files, 6453/6453 tests |
| `check.sh` | **rc=0** — ExUnit 6936 tests / 0 failures, bats `1..703` with 703 `ok` and 0 `not ok`, Credo + Sobelow + Dialyzer ran |
| `design-notes-gate.sh` | **rc=0**, post-commit: `1 new entry heading(s), separator and marker present.` |
| `check:radio` | **rc=0**, 22 stations, 0 broken; the feed denominator went 20 → 21 |

**Negative control on the new FEED axis**, because a green on a fresh axis proves nothing until it can go red: mutating the mount to `/stream.mp3` and re-running produced `FEED answers 200 but carries no track at mount /stream.mp3`, rc=1, 1 broken. A content-type-only probe would have passed that mutant. Reverted, verified with a fixed-string grep.

One flake seen and attributed: `e2eConstantMirrors.test.ts` timed out at 5000 ms in the first full vitest run. Its input set is the `e2e/` tree, which this branch does not touch; it passes in 244 ms in isolation, and the settled re-run above is 326/326.

No e2e was run — no e2e file changed, and no spec pins a CSP substring this touches (`nginx-csp-range-parity.spec.ts`'s list does not include `connect-src`).