### PR TITLE
cic: declare each station's codec and bitrate, and badge the lossless rows

### DIFF
--- a/cicchetto/scripts/check-radio-logos-core.ts
+++ b/cicchetto/scripts/check-radio-logos-core.ts
@@ -255,6 +255,126 @@ export function parseIcyBitrate(header: string | null): UpstreamBitrate {
   return { kind: "kbps", kbps: Number(header) };
 }
 
+// #1836 (ruling, 2026-08-27) — WHERE A BITRATE IS READ FROM, per codec.
+//
+// The ruling: `bitrate` is valued from the STREAM ITSELF and `null` is
+// reserved for "not knowable", never for "the provider said nothing". It rests
+// on this work's own reggae measurement, which showed that a string a vendor
+// puts in a URL is a LABEL rather than a declaration.
+//
+// 🔴 IT DOES NOT GENERALISE TO "the frame header", and the refusal is measured
+// rather than argued. FLAC's STREAMINFO — decoded from radioparadise's own
+// first bytes on 2026-08-27 — carries min/max blocksize, sample rate (44100),
+// channels (2), bits per sample (16) and a `minframesize/maxframesize` of
+// 0/0 (= unknown). There is NO bitrate field, because FLAC is inherently
+// variable-rate. Under a frame-header-only rule every FLAC row would be
+// `null`, i.e. the rows the `[hi-fi]` badge exists for would show no cost at
+// all — the opposite of what the issue asked for. And computing one from the
+// PCM rate (44100 × 2 × 16 = 1411 kbps) would OVERSTATE it: FLAC compresses
+// well below PCM, so that is an invented plausible number, the very defect
+// #1696 names.
+//
+// 🔴 The premise also needs one correction. On reggae the URL said 128, the
+// frame header said 160 and `icy-br` said 160 — so what that measurement
+// convicted is the URL, and it ACQUITS `icy-br`, which agreed with the bytes.
+// `icy-br` is not a label somebody stuck on the stream; it is the origin
+// server restating its encoder configuration on every connection.
+//
+// So: a per-codec AUTHORITY, total over the union, with the provenance DERIVED
+// from the codec rather than stored beside each row — the codec is already a
+// field, and a second column repeating what it implies is the parallel
+// structure CLAUDE.md's design discipline says to derive instead.
+export type BitrateSource = "mpeg-frame" | "vorbis-nominal" | "icy-br";
+
+/** An upstream bitrate together with which authority produced it. */
+export type BitrateReading = UpstreamBitrate & { readonly source: BitrateSource };
+
+/** MPEG1 Layer III, the only frame shape decoded here. Index 0 is "free" and
+    15 is "reserved"; both mean the header is not stating a rate. */
+const MPEG1_LAYER3_KBPS: readonly (number | null)[] = [
+  null, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, null,
+];
+
+/** The kbps an MPEG frame header states, or a reason it does not.
+ *
+ * Version and layer are CHECKED, not assumed: MPEG2/2.5 and Layers I/II have
+ * different bitrate tables, so decoding one of those against this table would
+ * produce a confident wrong number — the single worst outcome for a field
+ * whose whole purpose is to be true. Measured 2026-08-27: every mp3 row in the
+ * table is MPEG1 Layer III (`ff fb ..`). */
+export function mpegFrameBitrate(head: Uint8Array): UpstreamBitrate {
+  const [first, second, third] = head;
+  if (first === undefined || second === undefined || third === undefined) {
+    return { kind: "unreadable", raw: "fewer than 3 bytes of stream" };
+  }
+  const version = (second >> 3) & 0x03;
+  const layer = (second >> 1) & 0x03;
+  if (version !== 0x03 || layer !== 0x01) {
+    return { kind: "unreadable", raw: `MPEG version bits ${version}, layer bits ${layer}` };
+  }
+  const kbps = MPEG1_LAYER3_KBPS[third >> 4];
+  if (kbps === null || kbps === undefined) {
+    return { kind: "unreadable", raw: `MPEG bitrate index ${third >> 4}` };
+  }
+  return { kind: "kbps", kbps };
+}
+
+/** The kbps an Ogg Vorbis identification header NOMINATES, or `absent`.
+ *
+ * Vorbis states its own rate inside the codec stream — `bitrate_nominal`, a
+ * signed 32-bit little-endian bits-per-second — so this is the stream speaking
+ * about itself, exactly what the ruling asks for. Measured on kohina
+ * 2026-08-27: nominal 128000, max 0, min 0.
+ *
+ * A nominal of 0 is LEGAL and means the encoder ran in pure quality mode and
+ * nominated nothing. That is `absent`, not zero: it is the one Vorbis shape
+ * where a row honestly cannot state a number. */
+export function vorbisNominalBitrate(head: Uint8Array): UpstreamBitrate {
+  const magic = [0x01, 0x76, 0x6f, 0x72, 0x62, 0x69, 0x73];
+  for (let at = 0; at + magic.length <= head.length; at++) {
+    if (!magic.every((byte, i) => head[at + i] === byte)) continue;
+    // packet type + "vorbis" (7) + version (4) + channels (1) + rate (4) = 16
+    const off = at + 16;
+    const bytes = [head[off + 4], head[off + 5], head[off + 6], head[off + 7]];
+    if (bytes.some((b) => b === undefined)) {
+      return { kind: "unreadable", raw: "identification header cut short" };
+    }
+    const nominal = new DataView(
+      Uint8Array.from(bytes as number[]).buffer,
+    ).getInt32(0, true);
+    if (nominal <= 0) return { kind: "absent" };
+    return { kind: "kbps", kbps: Math.round(nominal / 1000) };
+  }
+  return { kind: "unreadable", raw: "no vorbis identification header in the first bytes" };
+}
+
+/** Which authority speaks for each codec. A `Record`, so a codec cannot be
+ * added without somebody deciding where its bitrate comes from — the same
+ * totality `isLossless` and the byte signatures carry.
+ *
+ * `flac` is `icy-br` and that is the measured exception, not laziness: see the
+ * block comment above. */
+const CODEC_BITRATE_AUTHORITY: Record<
+  RadioCodec,
+  (head: Uint8Array, icyBr: string | null) => BitrateReading
+> = {
+  mp3: (head) => ({ ...mpegFrameBitrate(head), source: "mpeg-frame" }),
+  vorbis: (head) => ({ ...vorbisNominalBitrate(head), source: "vorbis-nominal" }),
+  flac: (_head, icyBr) => ({ ...parseIcyBitrate(icyBr), source: "icy-br" }),
+};
+
+/** What the stream says its own bitrate is, read by the authority its codec
+    supports. Keyed on the codec the bytes turned out to BE, never on the one
+    the table claims — a row lying about its codec is already red on CODEC, and
+    asking the wrong decoder would add a second, misleading finding. */
+export function readBitrate(
+  served: RadioCodec,
+  head: Uint8Array,
+  icyBr: string | null,
+): BitrateReading {
+  return CODEC_BITRATE_AUTHORITY[served](head, icyBr);
+}
+
 /** `null` when the table's bitrate claim matches what upstream declares —
  * INCLUDING when both say nothing.
  *
@@ -263,16 +383,17 @@ export function parseIcyBitrate(header: string | null): UpstreamBitrate {
  * number the table dropped over a provider that states one is the opposite and
  * just as wrong, because the picker then draws no cost for a station that has
  * one. */
-export function bitrateFailure(declared: number | null, upstream: UpstreamBitrate): string | null {
-  if (upstream.kind === "unreadable") {
-    return `upstream declares icy-br ${JSON.stringify(upstream.raw)}, which is not a bitrate`;
+export function bitrateFailure(declared: number | null, reading: BitrateReading): string | null {
+  const from = reading.source;
+  if (reading.kind === "unreadable") {
+    return `${from} reads ${JSON.stringify(reading.raw)}, which is not a bitrate`;
   }
-  if (upstream.kind === "absent") {
-    return declared === null ? null : `upstream declares no bitrate, the table claims ${declared} kbps`;
+  if (reading.kind === "absent") {
+    return declared === null ? null : `${from} states no bitrate, the table claims ${declared} kbps`;
   }
-  if (declared === null) return `upstream declares ${upstream.kbps} kbps, the table claims none`;
-  if (declared !== upstream.kbps) {
-    return `upstream declares ${upstream.kbps} kbps, the table claims ${declared} kbps`;
+  if (declared === null) return `${from} says ${reading.kbps} kbps, the table claims none`;
+  if (declared !== reading.kbps) {
+    return `${from} says ${reading.kbps} kbps, the table claims ${declared} kbps`;
   }
   return null;
 }

--- a/cicchetto/scripts/check-radio-logos-core.ts
+++ b/cicchetto/scripts/check-radio-logos-core.ts
@@ -1,6 +1,9 @@
 // #1696 — the pure half of the radio-logo probe.
 //
-// No filesystem, no network, no Bun API, no imports. `check-radio-logos.ts`
+// No filesystem, no network, no Bun API. #1836 added the ONE import: the
+// table's codec vocabulary, which is data rather than IO and is the same closed
+// set the rules below have to be total over — re-spelling it here would be two
+// copies of a set that exists to have one. `check-radio-logos.ts`
 // does the IO and calls in here; `src/__tests__/checkRadioLogos.test.ts`
 // exercises both sides of every rule. This is the `lock-drift-core.ts` split
 // and it exists for the same measured reason: `cicchetto/scripts/` is outside
@@ -18,6 +21,8 @@
 // provider, so a rule inverted by one edit skips EVERY station and the script
 // reports "0 broken" having compared nothing — a green that means silence. The
 // test file holds a positive control against the real table for that.
+
+import { RADIO_CODECS, type RadioCodec } from "../src/lib/radioStations";
 
 /** The shape `channels.json` gives us. Everything is optional on purpose: this
     is a third party's document and a missing field must degrade to a finding,
@@ -138,6 +143,140 @@ export function bytesFailure(upstream: Uint8Array, vendored: Uint8Array | null):
   return null;
 }
 
+// #1836 — the two claims the table makes about the STREAM: `codec` and
+// `bitrate`. Same argument as every axis above, in the field where it bites
+// hardest: a baked claim about external state that nothing can check reads
+// identically whether it is true or false, and this one decides whether the
+// picker draws `[hi-fi]` — i.e. whether somebody on a metered connection is
+// told the truth before pressing play.
+//
+// 🔴 THE CODEC IS READ OFF THE BYTES, NOT OFF THE CONTENT TYPE, and the
+// measurement is why. On 2026-08-27 kohina's Ogg VORBIS answered
+// `Content-Type: audio/ogg` and radioparadise's Ogg FLAC answered
+// `application/ogg`; both are "an Ogg container" and neither names its codec.
+// So a content-type check is green in exactly the comparison the badge rests
+// on — lossy vs lossless inside one container — which is the "green that means
+// silence" this whole file is written against. The bytes separate them in the
+// first 32.
+
+/** `\x01vorbis`, `\x7fFLAC` and `OggS` as the servers actually send them —
+    read off the wire on 2026-08-27, not copied out of a spec. */
+const OGG_PAGE = [0x4f, 0x67, 0x67, 0x53];
+const OGG_VORBIS_ID = [0x01, 0x76, 0x6f, 0x72, 0x62, 0x69, 0x73];
+const OGG_FLAC_ID = [0x7f, 0x46, 0x4c, 0x41, 0x43];
+/** `fLaC` — FLAC's OWN framing, outside any Ogg page. Unlike the three above
+    this one is UNMEASURED: every FLAC endpoint looked at so far ships inside
+    Ogg, and the constant is here because the format defines both framings and a
+    row that used the other one would otherwise be reported as unidentifiable
+    rather than as flac. Labelled so the next reader knows which of these four
+    has an endpoint behind it. */
+const NATIVE_FLAC_MAGIC = [0x66, 0x4c, 0x61, 0x43];
+
+function startsWith(head: Uint8Array, magic: readonly number[]): boolean {
+  return magic.every((byte, i) => head[i] === byte);
+}
+
+function contains(head: Uint8Array, magic: readonly number[]): boolean {
+  for (let at = 0; at + magic.length <= head.length; at++) {
+    if (magic.every((byte, i) => head[at + i] === byte)) return true;
+  }
+  return false;
+}
+
+/** How each codec announces itself in the first bytes a listener receives.
+ *
+ * A `Record` over the closed set, so a new codec is a COMPILE error until
+ * somebody supplies the bytes that identify it — the same totality
+ * `isLossless` buys, and for a sharper reason: a codec with no signature would
+ * be permanently unidentifiable, and every row declaring it would go red with
+ * no way to tell that from a genuinely wrong claim. */
+const CODEC_SIGNATURES: Record<RadioCodec, (head: Uint8Array) => boolean> = {
+  // An MPEG frame header: eleven set sync bits. Measured at offset ZERO on both
+  // mp3 vendors in the table — icecast hands a new listener whole frames — so
+  // this asks for the sync at the start rather than hunting for it, which would
+  // match a byte pair occurring by chance inside any payload.
+  mp3: (head) => {
+    const [first, second] = head;
+    return first === 0xff && second !== undefined && (second & 0xe0) === 0xe0;
+  },
+  // The container first, then the codec: `OggS` alone is not an answer, and a
+  // rule that treated it as one would have called radioparadise's FLAC vorbis.
+  vorbis: (head) => startsWith(head, OGG_PAGE) && contains(head, OGG_VORBIS_ID),
+  flac: (head) =>
+    (startsWith(head, OGG_PAGE) && contains(head, OGG_FLAC_ID)) ||
+    startsWith(head, NATIVE_FLAC_MAGIC),
+};
+
+/** Which codec these leading bytes are, or `null` when they are none of the
+ * ones this table can declare.
+ *
+ * `null` on AMBIGUITY too, not just on no-match: two signatures agreeing means
+ * the rules have gone wrong, and answering with whichever came first would
+ * hide that behind a verdict. Downstream a null is a FINDING and never a skip —
+ * "not measured" reading as "measured ok" is the equivalence this script
+ * exists to break. */
+export function identifyCodec(head: Uint8Array): RadioCodec | null {
+  const matched = RADIO_CODECS.filter((codec) => CODEC_SIGNATURES[codec](head));
+  const [only] = matched;
+  return matched.length === 1 && only !== undefined ? only : null;
+}
+
+/** `null` when the stream serves the codec the table declares; otherwise the
+    disagreement. */
+export function codecFailure(declared: RadioCodec, served: RadioCodec | null): string | null {
+  if (served === null) {
+    return `the first bytes match no codec this table can declare — the claim ${declared} is unverified`;
+  }
+  if (served !== declared) return `upstream serves ${served}, the table claims ${declared}`;
+  return null;
+}
+
+/** What upstream says about its own bitrate — THREE states, because collapsing
+ * them is the bug.
+ *
+ * `absent` is a provider that states nothing (measured: kohina's icecast sends
+ * `icy-name` and `icy-genre` and no `icy-br`), and it is the state the table's
+ * `bitrate: null` exists to agree with. `unreadable` is a header that is there
+ * and is not a number: `Number("")` is 0 and `parseInt("128kbps")` is 128, so a
+ * two-state parser would turn a value nobody can read into a fact. */
+export type UpstreamBitrate =
+  | { readonly kind: "absent" }
+  | { readonly kind: "kbps"; readonly kbps: number }
+  | { readonly kind: "unreadable"; readonly raw: string };
+
+/** The boundary where a third party's free string becomes a number, or is
+    refused. Strict on purpose — no trim, no partial parse: `fetch` already
+    strips the surrounding whitespace a well-formed header may carry, so
+    anything left over is the server saying something this rule should not be
+    guessing at. */
+export function parseIcyBitrate(header: string | null): UpstreamBitrate {
+  if (header === null) return { kind: "absent" };
+  if (!/^[1-9][0-9]*$/.test(header)) return { kind: "unreadable", raw: header };
+  return { kind: "kbps", kbps: Number(header) };
+}
+
+/** `null` when the table's bitrate claim matches what upstream declares —
+ * INCLUDING when both say nothing.
+ *
+ * Both directions are failures. A number the table invented over a silent
+ * provider is #1696's defect exactly (an unverifiable claim baked as fact); a
+ * number the table dropped over a provider that states one is the opposite and
+ * just as wrong, because the picker then draws no cost for a station that has
+ * one. */
+export function bitrateFailure(declared: number | null, upstream: UpstreamBitrate): string | null {
+  if (upstream.kind === "unreadable") {
+    return `upstream declares icy-br ${JSON.stringify(upstream.raw)}, which is not a bitrate`;
+  }
+  if (upstream.kind === "absent") {
+    return declared === null ? null : `upstream declares no bitrate, the table claims ${declared} kbps`;
+  }
+  if (declared === null) return `upstream declares ${upstream.kbps} kbps, the table claims none`;
+  if (declared !== upstream.kbps) {
+    return `upstream declares ${upstream.kbps} kbps, the table claims ${declared} kbps`;
+  }
+  return null;
+}
+
 export type StationFinding = {
   readonly id: string;
   /** #1704 — the station's logo, or `null` when it publishes none. Carried as
@@ -149,6 +288,11 @@ export type StationFinding = {
       Carried so the report line can name the URL that failed, and so a null
       row is visibly SKIPPED rather than silently absent. */
   readonly feedUrl: string | null;
+  /** #1836 — the station's stream. Not nullable, unlike its two siblings: a
+      station without one is not a station. Carried for the reason `feedUrl`
+      gives — a row now names THREE third-party URLs, and a report that prints
+      one leaves the reader guessing which of them an axis is talking about. */
+  readonly streamUrl: string;
   readonly reach: string | null;
   readonly agree: string | null;
   /** #1698 — the FEED axis: whether `feedUrl` answers with JSON. Always null
@@ -162,6 +306,20 @@ export type StationFinding = {
       offline gate's job), and null when REACH already failed — one dead fetch
       must be reported once, not counted twice under two names. */
   readonly bytes: string | null;
+  /** #1836 — the STREAM axis: whether the endless audio endpoint answers at
+      all. Its own axis rather than folded into the two below, because "the
+      connection was refused" and "the codec is not what you claim" are
+      different facts and a report that spells the first under the second name
+      sends the reader to edit the table. */
+  readonly stream: string | null;
+  /** #1836 — the CODEC axis, read off the first bytes upstream sends. Null
+      when STREAM already failed: nothing was compared, and reporting one dead
+      connection twice under two names is the double-count BYTES already
+      refuses. */
+  readonly codec: string | null;
+  /** #1836 — the BITRATE axis, `icy-br` against the declared kbps, in both
+      directions. Null when STREAM already failed, for the same reason. */
+  readonly bitrate: string | null;
 };
 
 /** How many of `findings` were actually PROBED on each axis.
@@ -175,10 +333,17 @@ export function probedCounts(findings: readonly StationFinding[]): {
   readonly logos: number;
   readonly feeds: number;
   readonly mirrored: number;
+  readonly streams: number;
 } {
   return {
     logos: findings.filter((f) => f.logoUrl !== null).length,
     feeds: findings.filter((f) => f.feedUrl !== null).length,
+    // #1836 — a FOURTH denominator, on the same argument as `mirrored`: every
+    // row has a stream URL, so the count that means anything is how many
+    // streams actually OPENED. A run where every connection timed out compares
+    // no codec and no bitrate, and "22 stations checked, 0 broken" would read
+    // as agreement with claims nothing looked at.
+    streams: findings.filter((f) => f.stream === null).length,
     // #1739 — a THIRD denominator, and deliberately not the same number as
     // `logos`: BYTES can only compare a payload it managed to fetch, so a run
     // where every logo timed out would print "21 with a logo, 0 broken" having
@@ -188,13 +353,16 @@ export function probedCounts(findings: readonly StationFinding[]): {
   };
 }
 
-/** Every problem found for one station, all four axes, in report order. */
+/** Every problem found for one station, all seven axes, in report order. */
 export function problems(finding: StationFinding): readonly string[] {
   return [
     finding.reach === null ? null : `REACH ${finding.reach}`,
     finding.agree === null ? null : `AGREE ${finding.agree}`,
     finding.feed === null ? null : `FEED ${finding.feed}`,
     finding.bytes === null ? null : `BYTES ${finding.bytes}`,
+    finding.stream === null ? null : `STREAM ${finding.stream}`,
+    finding.codec === null ? null : `CODEC ${finding.codec}`,
+    finding.bitrate === null ? null : `BITRATE ${finding.bitrate}`,
   ].filter((p): p is string => p !== null);
 }
 

--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -19,7 +19,7 @@
 // moduledoc names it, so the next author edits the table and has a command
 // instead of a ritual.
 //
-// FOUR AXES, all reported, union verdict (the `scripts/check.ts` posture):
+// SEVEN AXES, all reported, union verdict (the `scripts/check.ts` posture):
 //
 //   REACH  — the logo URL answers 200 with an `image/*` content type. This is
 //            the property the picker needs, and it covers every station
@@ -67,6 +67,28 @@
 //            `src/__tests__/radioLogoFiles.test.ts`'s job, offline), and so is
 //            one whose REACH already failed — a single dead fetch is reported
 //            once, not counted twice under two names.
+//   STREAM — #1836: the endless audio endpoint answers 2xx at all. This was
+//            the LAST hand-measured claim in the table — `radioStations.ts`
+//            said so in a ⚠️ of its own — and it stayed hand-measured because
+//            a stream cannot be HEADed: icecast answers a GET with a body that
+//            never ends, so `HEAD` returns an empty reply (curl exit 52). The
+//            cure is an ABORTED get, which is what `probeStream` below is.
+//   CODEC  — #1836: the first bytes upstream sends ARE the codec the table
+//            declares. The picker draws `[hi-fi]` off that field, so a wrong
+//            one tells somebody on a metered connection the opposite of the
+//            truth, silently and on every render.
+//            🔴 THE BYTES, NOT THE CONTENT TYPE, and it is measured rather
+//            than fastidious: on 2026-08-27 kohina's Ogg VORBIS answered
+//            `audio/ogg` and radioparadise's Ogg FLAC answered
+//            `application/ogg` — both mean "an Ogg container" and neither
+//            names a codec, so a header check is green in exactly the
+//            lossy-vs-lossless comparison the badge exists to make.
+//   BITRATE— #1836: `icy-br` against the declared kbps, IN BOTH DIRECTIONS. A
+//            number invented over a silent provider is #1696's own defect in a
+//            new field; a number dropped over a provider that states one draws
+//            no cost for a station that has one. A station whose provider
+//            declares nothing must declare `bitrate: null` and is not a
+//            finding — that agreement is the check, not a skip.
 //
 // ⚠️ THE LOGO AXIS FETCHES WITH `GET`, NOT `HEAD`, and the feed axis still
 // uses HEAD. BYTES needs the payload, and one GET yields the status, the
@@ -96,12 +118,16 @@ import { RADIO_LOGO_PATHS } from "../src/lib/radioLogoPaths";
 import { type NowPlayingSource, RADIO_STATIONS } from "../src/lib/radioStations";
 import {
   agreeFailure,
+  bitrateFailure,
   brokenCount,
   bytesFailure,
   type CatalogueBody,
   catalogueLogos,
+  codecFailure,
   FEED_CONTENT_TYPE,
+  identifyCodec,
   LOGO_CONTENT_TYPE,
+  parseIcyBitrate,
   problems,
   probedCounts,
   reachFailure,
@@ -110,6 +136,15 @@ import {
 
 const CATALOGUE_URL = "https://api.somafm.com/channels.json";
 const TIMEOUT_MS = 15_000;
+
+/** #1836 — how much of an endless stream to pull before hanging up.
+ *
+ * Enough for the Ogg identification header and then some: measured
+ * 2026-08-27, `\x01vorbis` sits at byte 28 of kohina's first page and
+ * `\x7fFLAC` at byte 29 of radioparadise's. A kilobyte is two orders of
+ * headroom over that and still nothing — the connection is closed before the
+ * server has finished its first second of audio. */
+const STREAM_HEAD_BYTES = 1024;
 
 /** Resolved against THIS script, so the mirror is found wherever the verb is
     run from — the reason `gen-emoji.ts` and `sync-radio-logos.ts` do the
@@ -204,6 +239,58 @@ async function probeLogo(url: string): Promise<{
   }
 }
 
+/** #1836 — the first bytes of a station's stream and what it says about
+ * itself, from ONE aborted GET.
+ *
+ * ABORTED, and that is the whole mechanism: icecast answers a GET with a body
+ * that never ends, which is why `HEAD` returns an empty reply and why this
+ * claim stayed hand-measured until now. The reader is cancelled the moment
+ * there are enough bytes to identify the codec, so the probe costs a kilobyte
+ * per station and closes the socket itself rather than waiting for a timeout.
+ *
+ * `head` is null exactly when `stream` is not — the `probeLogo` contract one
+ * function up, and for the same reason: there are no bytes to identify when the
+ * fetch produced none, and reporting one dead connection under three axis names
+ * would treble-count it. */
+async function probeStream(url: string): Promise<{
+  readonly stream: string | null;
+  readonly head: Uint8Array | null;
+  readonly icyBr: string | null;
+}> {
+  const dead = (why: string): { stream: string; head: null; icyBr: null } => ({
+    stream: why,
+    head: null,
+    icyBr: null,
+  });
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (!res.ok) return dead(`HTTP ${res.status}`);
+    // Not `reachFailure`: a stream has no one content type to demand. Measured
+    // 2026-08-27, the three vendors here answer `audio/mpeg`, `audio/ogg` and
+    // `application/ogg`, and the CODEC axis reads the payload precisely because
+    // the header cannot separate the last two. A status check is what this axis
+    // can honestly assert on its own.
+    const body = res.body;
+    if (body === null) return dead("answered 2xx with no body at all");
+
+    const reader = body.getReader();
+    const head = new Uint8Array(STREAM_HEAD_BYTES);
+    let filled = 0;
+    while (filled < STREAM_HEAD_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value === undefined) continue;
+      const take = Math.min(value.byteLength, STREAM_HEAD_BYTES - filled);
+      head.set(value.subarray(0, take), filled);
+      filled += take;
+    }
+    await reader.cancel();
+    return { stream: null, head: head.subarray(0, filled), icyBr: res.headers.get("icy-br") };
+  } catch (err) {
+    return dead(`${err}`);
+  }
+}
+
 /** What `public/radio-logos/` holds for this station, or null when it holds
     nothing — which `bytesFailure` reports rather than skips. */
 function mirroredBytes(id: string): Uint8Array | null {
@@ -230,11 +317,16 @@ const findings: StationFinding[] = await Promise.all(
     // cannot 404. Counted out of the denominator below rather than folded into
     // the green.
     const logo = station.logoUrl === null ? null : await probeLogo(station.logoUrl);
+    // #1836 — unconditional, unlike the two probes above: `streamUrl` is not
+    // nullable, so there is no arm to skip. A station with no stream is not a
+    // station.
+    const stream = await probeStream(station.streamUrl);
     const source = station.nowPlayingSource;
     return {
       id: station.id,
       logoUrl: station.logoUrl,
       feedUrl: source?.url ?? null,
+      streamUrl: station.streamUrl,
       reach: logo?.reach ?? null,
       agree: agreeFailure(station.logoUrl, station.id, catalogue),
       // A station that publishes no feed is not probed and is not a finding.
@@ -246,6 +338,16 @@ const findings: StationFinding[] = await Promise.all(
         logo?.upstream === undefined || logo.upstream === null
           ? null
           : bytesFailure(logo.upstream, mirroredBytes(station.id)),
+      stream: stream.stream,
+      // #1836 — gated on the bytes being IN HAND, the `bytes` arm above. A
+      // connection that never opened has already been reported once under
+      // STREAM; saying it again under two more names is the double-count that
+      // gate exists to refuse.
+      codec: stream.head === null ? null : codecFailure(station.codec, identifyCodec(stream.head)),
+      bitrate:
+        stream.head === null
+          ? null
+          : bitrateFailure(station.bitrate, parseIcyBitrate(stream.icyBr)),
     };
   }),
 );
@@ -267,6 +369,12 @@ for (const finding of findings) {
   // stated for the same reason the summary states its denominator — a skipped
   // row must not read as a probed one.
   console.log(`          feed ${finding.feedUrl ?? "(no feed)"}`);
+  // #1836 — the third URL gets its own line for the reason the feed does, and
+  // more sharply: THREE of the seven axes talk about this endpoint, so a reader
+  // holding a `STREAM`/`CODEC`/`BITRATE` red would otherwise have to go back to
+  // the table to learn which URL was probed. No `(no stream)` arm — the field
+  // is not nullable.
+  console.log(`          stream ${finding.streamUrl}`);
   for (const p of found) console.log(`          ${p}`);
 }
 
@@ -280,11 +388,16 @@ const broken = brokenCount(findings);
 // #1704 adds the logo half of that same denominator, now that `logoUrl` is
 // nullable too: without it a table whose logos had all gone null would report
 // "21 stations checked, 0 broken" having fetched nothing at all.
+// #1836 adds the STREAM half. Every row has a stream, so the number that means
+// anything is how many actually OPENED: a run where the connections all timed
+// out compared no codec and no bitrate, and the station count alone would read
+// as agreement with claims nothing looked at.
 const probed = probedCounts(findings);
 console.log(
   `\ncheck:radio summary — ${findings.length} stations checked ` +
     `(${probed.logos} with a logo, ${probed.mirrored} compared against the mirror, ` +
-    `${probed.feeds} with a now-playing feed), ${broken} broken`,
+    `${probed.feeds} with a now-playing feed, ${probed.streams} streams opened), ` +
+    `${broken} broken`,
 );
 
 process.exit(broken === 0 ? 0 : 1);

--- a/cicchetto/scripts/check-radio-logos.ts
+++ b/cicchetto/scripts/check-radio-logos.ts
@@ -83,12 +83,23 @@
 //            `application/ogg` — both mean "an Ogg container" and neither
 //            names a codec, so a header check is green in exactly the
 //            lossy-vs-lossless comparison the badge exists to make.
-//   BITRATE— #1836: `icy-br` against the declared kbps, IN BOTH DIRECTIONS. A
-//            number invented over a silent provider is #1696's own defect in a
-//            new field; a number dropped over a provider that states one draws
-//            no cost for a station that has one. A station whose provider
-//            declares nothing must declare `bitrate: null` and is not a
-//            finding — that agreement is the check, not a skip.
+//   BITRATE— #1836: the declared kbps against what the STREAM states about
+//            itself, IN BOTH DIRECTIONS. A number invented over a silent
+//            provider is #1696's own defect in a new field; a number dropped
+//            over a stream that states one draws no cost for a station that has
+//            one.
+//            🔴 THE AUTHORITY IS PER CODEC and `readBitrate` owns the table.
+//            An MPEG frame header states its own rate exactly; an Ogg Vorbis
+//            identification header NOMINATES one; FLAC's STREAMINFO states
+//            NONE — decoded off radioparadise's own bytes 2026-08-27, it
+//            carries blocksize, sample rate, channels and bit depth and a
+//            framesize of 0/0, because FLAC is inherently variable-rate — so a
+//            FLAC row's only authority is `icy-br`. That exception is why this
+//            axis is not simply "read the frame header": applied literally,
+//            every FLAC row would be `null` and the stations the `[hi-fi]`
+//            badge exists for would show no cost at all.
+//            `null` therefore means NOT KNOWABLE, never "the provider was
+//            quiet" — if the stream states it, the table states it.
 //
 // ⚠️ THE LOGO AXIS FETCHES WITH `GET`, NOT `HEAD`, and the feed axis still
 // uses HEAD. BYTES needs the payload, and one GET yields the status, the
@@ -127,10 +138,10 @@ import {
   FEED_CONTENT_TYPE,
   identifyCodec,
   LOGO_CONTENT_TYPE,
-  parseIcyBitrate,
   problems,
   probedCounts,
   reachFailure,
+  readBitrate,
   type StationFinding,
 } from "./check-radio-logos-core";
 
@@ -321,6 +332,10 @@ const findings: StationFinding[] = await Promise.all(
     // nullable, so there is no arm to skip. A station with no stream is not a
     // station.
     const stream = await probeStream(station.streamUrl);
+    // #1836 — identified ONCE and shared by the two axes below: the codec the
+    // bytes turned out to be is both the CODEC verdict and the choice of which
+    // authority may state a bitrate.
+    const served = stream.head === null ? null : identifyCodec(stream.head);
     const source = station.nowPlayingSource;
     return {
       id: station.id,
@@ -343,11 +358,14 @@ const findings: StationFinding[] = await Promise.all(
       // connection that never opened has already been reported once under
       // STREAM; saying it again under two more names is the double-count that
       // gate exists to refuse.
-      codec: stream.head === null ? null : codecFailure(station.codec, identifyCodec(stream.head)),
+      codec: stream.head === null ? null : codecFailure(station.codec, served),
+      // #1836 (ruling) — read by the authority the SERVED codec supports, not
+      // the declared one. Quiet when the codec could not be identified: there
+      // is no authority to choose without it, and CODEC has already said so.
       bitrate:
-        stream.head === null
+        stream.head === null || served === null
           ? null
-          : bitrateFailure(station.bitrate, parseIcyBitrate(stream.icyBr)),
+          : bitrateFailure(station.bitrate, readBitrate(served, stream.head, stream.icyBr)),
     };
   }),
 );

--- a/cicchetto/src/RailRadio.tsx
+++ b/cicchetto/src/RailRadio.tsx
@@ -5,7 +5,7 @@ import { nowPlayingLabel } from "./lib/nowPlaying";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { closeRadioPicker, radioPickerOpen, tunedStation, tuneStation } from "./lib/radio";
 import { RADIO_LOGO_PATHS } from "./lib/radioLogoPaths";
-import { RADIO_STATIONS, type RadioStation } from "./lib/radioStations";
+import { isLossless, RADIO_STATIONS, type RadioStation } from "./lib/radioStations";
 import PaneTopBar from "./PaneTopBar";
 
 // #682 — the rail's internet-radio surface: a station PICKER and, once
@@ -83,6 +83,25 @@ import PaneTopBar from "./PaneTopBar";
 // The `undefined` arm of the lookup is unreachable by construction: that same
 // gate fails the build for any station id the map does not carry. Spelling a
 // fallback for it would put the branch back for a case no build can ship.
+/** #1836 — what a lossless row is marked with, per vjt's ruling.
+ *
+ * Exported so the tests assert against the production string rather than a
+ * copy of it, and spelled with its brackets because that IS the badge: this
+ * client is irssi-shaped, a bracketed token reads as a mark in a monospace
+ * column, and it stays legible with the stylesheet off — which the colour it
+ * carries does not. */
+export const HI_FI_BADGE = "[hi-fi]";
+
+/** #1836 — the format a row DECLARES, as the picker prints it.
+ *
+ * `bitrate: null` prints the codec ALONE. Not "0k", not "unknown", not a
+ * plausible number: a provider that states no bitrate is a fact this table
+ * records, and dressing it up as one it does not have is the defect #1696 was
+ * filed about. The codec still shows, because that much IS known. */
+function formatLabel(station: RadioStation): string {
+  return station.bitrate === null ? station.codec : `${station.codec} ${station.bitrate}k`;
+}
+
 const StationLogo: Component<{ readonly station: RadioStation; readonly class: string }> = (
   props,
 ) => (
@@ -270,7 +289,44 @@ const RailRadio: Component = () => {
                   <StationLogo station={station} class="rail-radio-station-logo" />
                   <span class="rail-radio-station-text">
                     <span class="rail-radio-station-title">{station.title}</span>
-                    <span class="rail-radio-station-genres">{station.genres.join(" · ")}</span>
+                    {/* #1836 — the format SHARES the genres' line rather than
+                        taking a third one, the same trade #1698 made for the
+                        track on the chrome band: #500 bought this rail's
+                        vertical budget by collapsing the actions behind one
+                        launcher, and a row a third taller charges part of it
+                        back on every station in the list. Nothing is lost —
+                        genres keep the ellipsis and the format is two short
+                        tokens pinned to the end.
+
+                        WHY IT IS ON THE PICKER AND NOT THE CHROME BAND. This is
+                        the DECISION surface: the issue is that the listener
+                        cannot tell a 128k MP3 from a 1000+ kbps FLAC BEFORE
+                        pressing play, and after pressing play the cost is
+                        already being paid. The band's one spare line also
+                        already has three tenants (genres, track, failure). */}
+                    <span class="rail-radio-station-sub">
+                      <span class="rail-radio-station-genres">{station.genres.join(" · ")}</span>
+                      <span
+                        class="rail-radio-station-format"
+                        data-testid={`rail-radio-station-format-${station.id}`}
+                      >
+                        {formatLabel(station)}
+                      </span>
+                      {/* Derived from the CODEC, never from a list of station
+                          names: a name list is right for exactly the rows
+                          somebody remembered and silently wrong for the next
+                          one added. `isLossless` is total over the codec union
+                          by construction — see its Record in
+                          `lib/radioStations.ts`. */}
+                      <Show when={isLossless(station.codec)}>
+                        <span
+                          class="rail-radio-station-hifi"
+                          data-testid={`rail-radio-station-hifi-${station.id}`}
+                        >
+                          {HI_FI_BADGE}
+                        </span>
+                      </Show>
+                    </span>
                   </span>
                 </button>
               )}

--- a/cicchetto/src/__tests__/RailRadio.test.tsx
+++ b/cicchetto/src/__tests__/RailRadio.test.tsx
@@ -82,6 +82,28 @@ describe("RailRadio", () => {
     }
   });
 
+  it("prices every curated station, so no row is a blind press-play", () => {
+    // #1836 — the wiring half, over the REAL table: the badge's own three
+    // cases live in `railRadioHiFiBadge.test.tsx`, which can construct a
+    // lossless row that the curated table does not yet carry. What this one
+    // holds is that the declared format actually reaches the picker for every
+    // row that exists today, in the shape the row declares it — a component
+    // reading the wrong field, or rendering nothing at all, is green in that
+    // file and red here.
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    for (const s of RADIO_STATIONS) {
+      const format = screen.getByTestId(`rail-radio-station-format-${s.id}`);
+      expect(format, `station ${s.id} format`).toHaveTextContent(s.codec);
+      if (s.bitrate === null) {
+        expect(format.textContent ?? "", `station ${s.id} invented a number`).not.toMatch(/\d/);
+      } else {
+        expect(format, `station ${s.id} bitrate`).toHaveTextContent(`${s.bitrate}k`);
+      }
+    }
+  });
+
   it("picking a station hands its stream and title to the one player", () => {
     render(() => <RailRadio />);
     openRadioPicker();

--- a/cicchetto/src/__tests__/checkRadioLogos.test.ts
+++ b/cicchetto/src/__tests__/checkRadioLogos.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   agreeFailure,
+  bitrateFailure,
   brokenCount,
   bytesFailure,
   catalogueLogos,
+  codecFailure,
+  identifyCodec,
   isCatalogueBacked,
+  parseIcyBitrate,
   probedCounts,
   problems,
   reachFailure,
@@ -38,10 +42,14 @@ const finding = (over: Partial<StationFinding>): StationFinding => ({
   id: "dronezone",
   logoUrl: "https://api.somafm.com/logos/120/dronezone120.jpg",
   feedUrl: "https://api.somafm.com/songs/dronezone.json",
+  streamUrl: "https://ice.somafm.com/dronezone-128-mp3",
   reach: null,
   agree: null,
   feed: null,
   bytes: null,
+  stream: null,
+  codec: null,
+  bitrate: null,
   ...over,
 });
 
@@ -273,6 +281,158 @@ describe("bytesFailure", () => {
   });
 });
 
+// #1836 — the CODEC and BITRATE axes. `codec` and `bitrate` are a fourth and
+// fifth DECLARED claim about external state in this table, and the whole point
+// of #1696 is that a baked claim nothing can check is not a fact. The `[hi-fi]`
+// badge rests on the first of them, so a wrong codec is not a cosmetic slip:
+// it is the picker telling somebody on a metered connection the opposite of
+// the truth.
+//
+// The byte prefixes below are MEASURED, 2026-08-27, off the real endpoints —
+// the first 48 bytes each server sent a fresh listener. A hand-drawn fixture
+// would prove the parser against itself.
+describe("identifyCodec", () => {
+  const bytes = (hex: string): Uint8Array =>
+    Uint8Array.from((hex.match(/../g) ?? []).map((b) => Number.parseInt(b, 16)));
+
+  // ice.somafm.com/groovesalad-128-mp3 — an MPEG frame header, sync word first.
+  const MP3 = bytes("fffb9204ef8ff3274655834f32e264a5faa063084c0ba0d1540dbc6b81731a2a");
+  // kohina.brona.dk/icecast/stream.ogg — Ogg page, then `\x01vorbis`.
+  const OGG_VORBIS = bytes(
+    "4f676753000200000000000000008ec9fc1600000000ac3972cb011e01766f7262697300000000",
+  );
+  // stream.radioparadise.com/flac — the same Ogg framing, then `\x7fFLAC`.
+  const OGG_FLAC = bytes(
+    "4f67675300020000000000000000717a3b3f00000000423dae9f01337f464c414301000001664c61",
+  );
+
+  it("reads an MPEG frame sync as mp3", () => {
+    expect(identifyCodec(MP3)).toBe("mp3");
+  });
+
+  it("reads an Ogg page carrying a vorbis identification header as vorbis", () => {
+    expect(identifyCodec(OGG_VORBIS)).toBe("vorbis");
+  });
+
+  it("reads an Ogg page carrying a FLAC identification header as flac", () => {
+    // THE case the badge rests on, and the reason this axis reads BYTES at all
+    // rather than the content type: measured the same day, kohina answers
+    // `audio/ogg` and radioparadise's FLAC answers `application/ogg`, and both
+    // headers are simply "an Ogg container". A header-only check would be
+    // green in exactly the comparison `[hi-fi]` exists to make.
+    expect(identifyCodec(OGG_FLAC)).toBe("flac");
+  });
+
+  it("refuses to name a codec it cannot see, rather than guessing the common one", () => {
+    // "not measured" must never read as "measured ok" — the equivalence this
+    // whole script was written against. A null here is a FINDING downstream,
+    // not a skip.
+    expect(identifyCodec(bytes("00112233445566778899aabbccddeeff"))).toBeNull();
+    expect(identifyCodec(bytes(""))).toBeNull();
+  });
+
+  it("refuses an Ogg container whose codec header it does not recognise", () => {
+    // CONSTRUCTED, not measured — no station in the table serves Opus, and the
+    // fixture is the real Ogg page framing above with `OpusHead` where the
+    // identification header sits. The property is what matters: the container
+    // is not the codec, and a rule that answered "vorbis" for any `OggS` would
+    // have called radioparadise lossy.
+    const OGG_OPUS = bytes(
+      "4f676753000200000000000000008ec9fc1600000000ac3972cb011e4f70757348656164",
+    );
+    expect(identifyCodec(OGG_OPUS)).toBeNull();
+  });
+});
+
+describe("codecFailure", () => {
+  it("is quiet when the stream serves what the table declares", () => {
+    expect(codecFailure("mp3", "mp3")).toBeNull();
+  });
+
+  it("fails a lossless claim the stream does not back — the badge's own defect", () => {
+    // THE positive control the whole axis exists for: a row declaring `flac`
+    // over a stream that is vorbis draws `[hi-fi]` on a lossy station. This
+    // MUST be red, and it is the case a probe that only compared content types
+    // would wave through.
+    expect(codecFailure("flac", "vorbis")).toBe("upstream serves vorbis, the table claims flac");
+  });
+
+  it("fails a lossy claim over a lossless stream, which is the same lie inverted", () => {
+    expect(codecFailure("mp3", "flac")).not.toBeNull();
+  });
+
+  it("fails a stream it could not identify rather than passing it", () => {
+    expect(codecFailure("mp3", null)).toBe(
+      "the first bytes match no codec this table can declare — the claim mp3 is unverified",
+    );
+  });
+});
+
+describe("parseIcyBitrate", () => {
+  it("reads the kbps a provider states", () => {
+    expect(parseIcyBitrate("128")).toEqual({ kind: "kbps", kbps: 128 });
+  });
+
+  it("reports a header the provider does not send as ABSENT, not as zero", () => {
+    // Measured 2026-08-27: kohina's icecast sends `icy-name` and `icy-genre`
+    // and no `icy-br` at all. That is the state `bitrate: null` exists to
+    // spell, and folding it to 0 would turn "nobody said" into a number.
+    expect(parseIcyBitrate(null)).toEqual({ kind: "absent" });
+  });
+
+  it("rejects a value that is not a bitrate instead of coercing it", () => {
+    // The boundary: `icy-br` is a free string from a third party. `Number("")`
+    // is 0 and `parseInt("128kbps")` is 128 — both of them are a made-up fact
+    // downstream, so an unreadable value gets its own state and is reported.
+    for (const raw of ["", "  ", "quite fast", "-1", "0", "128.5", "1e3"]) {
+      expect(parseIcyBitrate(raw), `icy-br ${JSON.stringify(raw)}`).toEqual({
+        kind: "unreadable",
+        raw,
+      });
+    }
+  });
+});
+
+describe("bitrateFailure", () => {
+  it("is quiet when the table states the kbps upstream states", () => {
+    expect(bitrateFailure(128, { kind: "kbps", kbps: 128 })).toBeNull();
+  });
+
+  it("is quiet when neither the table nor upstream states one", () => {
+    expect(bitrateFailure(null, { kind: "absent" })).toBeNull();
+  });
+
+  it("fails a number the table invented — #1696's defect in this field", () => {
+    // The positive control for the nullable arm: a plausible bitrate baked to
+    // fill a column, over a provider that declares nothing. It renders as a
+    // fact and is a guess.
+    expect(bitrateFailure(128, { kind: "absent" })).toBe(
+      "upstream declares no bitrate, the table claims 128 kbps",
+    );
+  });
+
+  it("fails a number the table dropped, so a knowable fact is not left unsaid", () => {
+    expect(bitrateFailure(null, { kind: "kbps", kbps: 320 })).toBe(
+      "upstream declares 320 kbps, the table claims none",
+    );
+  });
+
+  it("fails a number that has moved under the table", () => {
+    expect(bitrateFailure(128, { kind: "kbps", kbps: 320 })).toBe(
+      "upstream declares 320 kbps, the table claims 128 kbps",
+    );
+  });
+
+  it("fails an unreadable header rather than treating it as absent", () => {
+    // Absent and unreadable are different facts about upstream, and collapsing
+    // them would make a table that says `null` green against a server that is
+    // saying something nobody can parse.
+    expect(bitrateFailure(null, { kind: "unreadable", raw: "128kbps" })).toBe(
+      'upstream declares icy-br "128kbps", which is not a bitrate',
+    );
+  });
+});
+
 describe("the union verdict", () => {
   it("reports every axis that has something to say", () => {
     expect(
@@ -282,6 +442,9 @@ describe("the union verdict", () => {
           agree: "catalogue ships x",
           feed: "HTTP 500",
           bytes: "mirror is stale",
+          stream: "HTTP 502",
+          codec: "upstream serves vorbis, the table claims flac",
+          bitrate: "upstream declares no bitrate, the table claims 128 kbps",
         }),
       ),
     ).toEqual([
@@ -289,6 +452,9 @@ describe("the union verdict", () => {
       "AGREE catalogue ships x",
       "FEED HTTP 500",
       "BYTES mirror is stale",
+      "STREAM HTTP 502",
+      "CODEC upstream serves vorbis, the table claims flac",
+      "BITRATE upstream declares no bitrate, the table claims 128 kbps",
     ]);
   });
 
@@ -305,6 +471,13 @@ describe("the union verdict", () => {
     // that still resolves and still agrees with the catalogue, while the bytes
     // this build ships are last month's.
     expect(brokenCount([finding({ bytes: "mirror is stale" })])).toBe(1);
+    // #1836 — and on each of the three stream axes alone. A station whose
+    // artwork, catalogue row, feed and mirror are all perfect while the row
+    // claims a codec it does not serve is the picker lying about the one thing
+    // the `[hi-fi]` badge is there to say.
+    expect(brokenCount([finding({ stream: "HTTP 502" })])).toBe(1);
+    expect(brokenCount([finding({ codec: "upstream serves vorbis" })])).toBe(1);
+    expect(brokenCount([finding({ bitrate: "upstream declares no bitrate" })])).toBe(1);
   });
 
   it("counts a clean station as unbroken", () => {
@@ -342,11 +515,15 @@ describe("a station that publishes no logo (#1704)", () => {
     ): StationFinding => ({
       id,
       logoUrl,
+      streamUrl: `https://ice.somafm.com/${id}-128-mp3`,
       feedUrl,
       reach: null,
       agree: null,
       feed: null,
       bytes: null,
+      stream: null,
+      codec: null,
+      bitrate: null,
     });
     const counts = probedCounts([
       finding("with-logo", "https://api.somafm.com/logos/120/x120.png", null),
@@ -369,16 +546,57 @@ describe("a station that publishes no logo (#1704)", () => {
       {
         id: "unreachable",
         logoUrl: "https://api.somafm.com/logos/120/x120.png",
+        streamUrl: "https://ice.somafm.com/x-128-mp3",
         feedUrl: null,
         reach: "HTTP 503",
         agree: null,
         feed: null,
         bytes: null,
+        stream: null,
+        codec: null,
+        bitrate: null,
       },
     ]);
 
     expect(counts.logos).toBe(1);
     expect(counts.mirrored).toBe(0);
+  });
+
+  it("counts a stream it could not open out of the FORMAT denominator (#1836)", () => {
+    // The same argument one axis over, and it is why `streams` exists at all:
+    // a run where every station's stream refused the connection would compare
+    // no codec and no bitrate, and "22 stations checked, 0 broken" would read
+    // as agreement with claims nothing looked at.
+    const counts = probedCounts([
+      {
+        id: "reachable",
+        logoUrl: null,
+        streamUrl: "https://ice.somafm.com/x-128-mp3",
+        feedUrl: null,
+        reach: null,
+        agree: null,
+        feed: null,
+        bytes: null,
+        stream: null,
+        codec: null,
+        bitrate: null,
+      },
+      {
+        id: "refused",
+        logoUrl: null,
+        streamUrl: "https://ice.somafm.com/y-128-mp3",
+        feedUrl: null,
+        reach: null,
+        agree: null,
+        feed: null,
+        bytes: null,
+        stream: "TimeoutError: The operation timed out.",
+        codec: null,
+        bitrate: null,
+      },
+    ]);
+
+    expect(counts.streams).toBe(1);
   });
 
   it("counts the real table, so the denominator is not a fixture", () => {
@@ -391,10 +609,14 @@ describe("a station that publishes no logo (#1704)", () => {
         id: s.id,
         logoUrl: s.logoUrl,
         feedUrl: s.nowPlayingSource?.url ?? null,
+        streamUrl: s.streamUrl,
         reach: null,
         agree: null,
         feed: null,
         bytes: null,
+        stream: null,
+        codec: null,
+        bitrate: null,
       })),
     );
     expect(

--- a/cicchetto/src/__tests__/checkRadioLogos.test.ts
+++ b/cicchetto/src/__tests__/checkRadioLogos.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   agreeFailure,
+  type BitrateReading,
   bitrateFailure,
   brokenCount,
   bytesFailure,
@@ -8,12 +9,15 @@ import {
   codecFailure,
   identifyCodec,
   isCatalogueBacked,
+  mpegFrameBitrate,
   parseIcyBitrate,
   probedCounts,
   problems,
   reachFailure,
+  readBitrate,
   type StationFinding,
   versionless,
+  vorbisNominalBitrate,
 } from "../../scripts/check-radio-logos-core";
 import { RADIO_STATIONS } from "../lib/radioStations";
 
@@ -393,42 +397,191 @@ describe("parseIcyBitrate", () => {
   });
 });
 
-describe("bitrateFailure", () => {
-  it("is quiet when the table states the kbps upstream states", () => {
-    expect(bitrateFailure(128, { kind: "kbps", kbps: 128 })).toBeNull();
+// #1836 (ruling, 2026-08-27) — WHERE a bitrate is read from, per codec.
+//
+// The byte prefixes are the SAME measured captures the codec fixtures use, so
+// these decode real streams rather than a hand-drawn header that would only
+// prove the parser against itself.
+describe("mpegFrameBitrate", () => {
+  const bytes = (hex: string): Uint8Array =>
+    Uint8Array.from((hex.match(/../g) ?? []).map((b) => Number.parseInt(b, 16)));
+
+  it("reads the rate an MPEG1 Layer III frame states", () => {
+    // ice.somafm.com/groovesalad-128-mp3, bitrate index 9.
+    expect(mpegFrameBitrate(bytes("fffb9204ef8ff327"))).toEqual({ kind: "kbps", kbps: 128 });
   });
 
-  it("is quiet when neither the table nor upstream states one", () => {
-    expect(bitrateFailure(null, { kind: "absent" })).toBeNull();
+  it("reads the rate that CONTRADICTS the mount name", () => {
+    // ice.somafm.com/reggae-128-mp3, bitrate index 10. This is the whole
+    // reason the field is not derived from the URL, and it is the row that
+    // reddened on the probe's first run.
+    expect(mpegFrameBitrate(bytes("fffba004eb8ff3cd"))).toEqual({ kind: "kbps", kbps: 160 });
+  });
+
+  it("refuses a version and layer whose table this is not", () => {
+    // MPEG2 Layer III (`ff f3 ..`) indexes a DIFFERENT bitrate table, so
+    // decoding it against this one would produce a confident wrong number —
+    // the worst outcome for a field that exists to be true.
+    const failure = mpegFrameBitrate(bytes("fff39204"));
+    expect(failure.kind).toBe("unreadable");
+  });
+
+  it("refuses the reserved bitrate index rather than reading it as a rate", () => {
+    expect(mpegFrameBitrate(bytes("fffbf204")).kind).toBe("unreadable");
+    expect(mpegFrameBitrate(bytes("fffb0204")).kind).toBe("unreadable");
+  });
+
+  it("refuses a stream too short to carry a header", () => {
+    expect(mpegFrameBitrate(bytes("fffb")).kind).toBe("unreadable");
+  });
+});
+
+describe("vorbisNominalBitrate", () => {
+  const bytes = (hex: string): Uint8Array =>
+    Uint8Array.from((hex.match(/../g) ?? []).map((b) => Number.parseInt(b, 16)));
+
+  // kohina.brona.dk/icecast/stream.ogg — bitrate_nominal 128000, max 0, min 0.
+  const KOHINA = bytes(
+    "4f676753000200000000000000008ec9fc1600000000ac3972cb011e01766f72626973000000000244ac00000000000000f40100000000b801",
+  );
+
+  it("reads the rate the identification header nominates", () => {
+    // The measurement that corrected this table: kohina sends NO `icy-br`, and
+    // "the provider said nothing" was read as "we cannot know". Vorbis states
+    // it inside the codec stream.
+    expect(vorbisNominalBitrate(KOHINA)).toEqual({ kind: "kbps", kbps: 128 });
+  });
+
+  it("reports a nominal of zero as ABSENT, which is what it means", () => {
+    // Legal, and it means the encoder ran in pure quality mode and nominated
+    // nothing. A 0 kbps station is not a thing; `absent` is the honest state
+    // and the one arm where a Vorbis row may still declare null.
+    // The offset is DERIVED from the header layout, not hunted for by byte
+    // value: packet type + "vorbis" (7) + version (4) + channels (1) + sample
+    // rate (4) = 16, then bitrate_maximum (4), then the nominal.
+    const magic = [0x01, 0x76, 0x6f, 0x72, 0x62, 0x69, 0x73];
+    const at = KOHINA.findIndex((_, i) => magic.every((b, k) => KOHINA[i + k] === b));
+    expect(at, "the fixture must carry an identification header").toBeGreaterThan(-1);
+    const zeroed = Uint8Array.from(KOHINA);
+    zeroed.set([0, 0, 0, 0], at + 16 + 4);
+    // Guard against zeroing the wrong field: the fixture must still parse as
+    // vorbis, and only the nominal may have moved.
+    expect(vorbisNominalBitrate(KOHINA)).toEqual({ kind: "kbps", kbps: 128 });
+    expect(vorbisNominalBitrate(zeroed)).toEqual({ kind: "absent" });
+  });
+
+  it("refuses bytes carrying no identification header at all", () => {
+    expect(vorbisNominalBitrate(bytes("00112233445566778899aabbccddeeff")).kind).toBe("unreadable");
+  });
+});
+
+describe("readBitrate picks the authority the codec supports", () => {
+  const bytes = (hex: string): Uint8Array =>
+    Uint8Array.from((hex.match(/../g) ?? []).map((b) => Number.parseInt(b, 16)));
+
+  it("reads mp3 off the frame header and IGNORES a disagreeing icy-br", () => {
+    // The frame is the stream speaking; `icy-br` is the server speaking about
+    // it. Where both exist the bytes win, which is the ruling.
+    expect(readBitrate("mp3", bytes("fffba004eb8ff3cd"), "128")).toEqual({
+      kind: "kbps",
+      kbps: 160,
+      source: "mpeg-frame",
+    });
+  });
+
+  it("reads vorbis off the identification header, with no icy-br in sight", () => {
+    const kohina = bytes(
+      "4f676753000200000000000000008ec9fc1600000000ac3972cb011e01766f72626973000000000244ac00000000000000f40100000000b801",
+    );
+    expect(readBitrate("vorbis", kohina, null)).toEqual({
+      kind: "kbps",
+      kbps: 128,
+      source: "vorbis-nominal",
+    });
+  });
+
+  it("reads flac off icy-br, because STREAMINFO states no bitrate at all", () => {
+    // 🔴 The measured exception, and the reason the ruling could not be applied
+    // as "read the frame header". Decoded off radioparadise's own first bytes
+    // 2026-08-27, FLAC's STREAMINFO carries blocksize 4096/4096, sample rate
+    // 44100, 2 channels, 16 bits and a framesize of 0/0 — no bitrate field,
+    // because FLAC is inherently variable-rate. Applied literally the ruling
+    // would leave every FLAC row null, i.e. the stations `[hi-fi]` exists for
+    // would show no cost at all.
+    const oggFlac = bytes(
+      "4f67675300020000000000000000717a3b3f00000000423dae9f01337f464c414301000001664c61",
+    );
+    expect(readBitrate("flac", oggFlac, "1441")).toEqual({
+      kind: "kbps",
+      kbps: 1441,
+      source: "icy-br",
+    });
+  });
+
+  it("gives every codec an authority — none may fall through", () => {
+    // Non-vacuity over the closed set: the table is a `Record`, so a missing
+    // arm is a compile error, but a `Record` of no-ops would still typecheck.
+    // Each codec must produce a reading with ITS own source.
+    const kohina = bytes(
+      "4f676753000200000000000000008ec9fc1600000000ac3972cb011e01766f72626973000000000244ac00000000000000f40100000000b801",
+    );
+    expect(readBitrate("mp3", bytes("fffb9204"), null).source).toBe("mpeg-frame");
+    expect(readBitrate("vorbis", kohina, null).source).toBe("vorbis-nominal");
+    expect(readBitrate("flac", bytes("00"), "1441").source).toBe("icy-br");
+  });
+});
+
+describe("bitrateFailure", () => {
+  const frame = (kbps: number): BitrateReading => ({ kind: "kbps", kbps, source: "mpeg-frame" });
+
+  it("is quiet when the table states the kbps the stream states", () => {
+    expect(bitrateFailure(128, frame(128))).toBeNull();
+  });
+
+  it("is quiet when neither the table nor the stream states one", () => {
+    expect(bitrateFailure(null, { kind: "absent", source: "icy-br" })).toBeNull();
   });
 
   it("fails a number the table invented — #1696's defect in this field", () => {
     // The positive control for the nullable arm: a plausible bitrate baked to
-    // fill a column, over a provider that declares nothing. It renders as a
-    // fact and is a guess.
-    expect(bitrateFailure(128, { kind: "absent" })).toBe(
-      "upstream declares no bitrate, the table claims 128 kbps",
+    // fill a column over a stream that states nothing. It renders as a fact
+    // and is a guess.
+    expect(bitrateFailure(128, { kind: "absent", source: "icy-br" })).toBe(
+      "icy-br states no bitrate, the table claims 128 kbps",
     );
   });
 
   it("fails a number the table dropped, so a knowable fact is not left unsaid", () => {
-    expect(bitrateFailure(null, { kind: "kbps", kbps: 320 })).toBe(
-      "upstream declares 320 kbps, the table claims none",
+    // The mirror image, and the half vjt's ruling added: `null` is reserved for
+    // NOT KNOWABLE. kohina sat here for an hour — no `icy-br`, and a Vorbis
+    // identification header stating 128000 all along.
+    expect(bitrateFailure(null, { kind: "kbps", kbps: 128, source: "vorbis-nominal" })).toBe(
+      "vorbis-nominal says 128 kbps, the table claims none",
     );
   });
 
   it("fails a number that has moved under the table", () => {
-    expect(bitrateFailure(128, { kind: "kbps", kbps: 320 })).toBe(
-      "upstream declares 320 kbps, the table claims 128 kbps",
+    expect(bitrateFailure(128, frame(320))).toBe(
+      "mpeg-frame says 320 kbps, the table claims 128 kbps",
     );
   });
 
-  it("fails an unreadable header rather than treating it as absent", () => {
-    // Absent and unreadable are different facts about upstream, and collapsing
-    // them would make a table that says `null` green against a server that is
-    // saying something nobody can parse.
-    expect(bitrateFailure(null, { kind: "unreadable", raw: "128kbps" })).toBe(
-      'upstream declares icy-br "128kbps", which is not a bitrate',
+  it("names the authority that spoke, so a red says where to look", () => {
+    // Three sources answer this axis and they fail for different reasons — a
+    // message that named none of them would send the reader to the wrong
+    // place.
+    expect(bitrateFailure(128, { kind: "absent", source: "vorbis-nominal" })).toContain(
+      "vorbis-nominal",
+    );
+    expect(bitrateFailure(128, { kind: "absent", source: "mpeg-frame" })).toContain("mpeg-frame");
+  });
+
+  it("fails an unreadable reading rather than treating it as absent", () => {
+    // Absent and unreadable are different facts, and collapsing them would
+    // make a table that says `null` green against a stream saying something no
+    // one can read.
+    expect(bitrateFailure(null, { kind: "unreadable", raw: "128kbps", source: "icy-br" })).toBe(
+      'icy-br reads "128kbps", which is not a bitrate',
     );
   });
 });

--- a/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
+++ b/cicchetto/src/__tests__/nowPlayingUnsupported.test.ts
@@ -38,6 +38,8 @@ vi.mock("../lib/radio", () => {
     genres: ["ambient"],
     description: "A station from a provider that publishes no track feed.",
     streamUrl: "https://stream.example.org/feedless",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://example.org/logo.png",
     nowPlayingSource: null,
   };

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -13,8 +13,10 @@ import { isLossless, RADIO_STATIONS } from "../lib/radioStations";
 // added" was the standing answer here, and for the logos it was false for ten
 // of fourteen rows on the day it was written. So the logo half is now an
 // executable, on-demand probe — `bun run check:radio`
-// (`scripts/check-radio-logos.ts`) — and the stream half remains hand-measured,
-// for the mechanical reason the table's moduledoc gives.
+// (`scripts/check-radio-logos.ts`). #1836 took the STREAM half the same way:
+// that one had stayed hand-measured because a stream cannot be HEADed, and an
+// aborted GET is the mechanism that was missing. Nothing about a station's
+// reachability is hand-asserted here any more.
 
 describe("RADIO_STATIONS", () => {
   it("is not empty — an empty table is a picker that opens onto nothing", () => {
@@ -179,17 +181,26 @@ describe("RADIO_STATIONS", () => {
     expect(priced.length).toBeGreaterThan(0);
   });
 
-  it("leaves at least one station's bitrate null — the arm that draws no number", () => {
-    // The other direction, and it is a VACUITY guard rather than a rule about
-    // the table, the same shape `checkRadioLogos.test.ts` gives the logo-less
-    // arm: with every row priced, the "provider states nothing" path is never
-    // exercised by real data. If every provider in the table legitimately
-    // declares a bitrate one day, this is the line to DELETE, deliberately —
-    // not the one to edit around by inventing a plausible number for a row
-    // that has none, which is the defect #1696 was filed about.
-    const unpriced = RADIO_STATIONS.filter((s) => s.bitrate === null);
-    expect(unpriced.length).toBeGreaterThan(0);
-  });
+  // 🔴 WHAT USED TO BE HERE, and why it is gone (vjt's ruling, 2026-08-27).
+  // A vacuity guard demanding that at least one row keep `bitrate: null`, so
+  // that the "draws no number" arm was exercised by real data. It rested on
+  // kohina, whose icecast sends no `icy-br` — and the ruling is that `null`
+  // means NOT KNOWABLE, never "the provider was quiet". Kohina's Vorbis
+  // identification header nominates 128000 bits per second, decoded off the
+  // bytes it serves, so the row is `128` and the guard has no row left to
+  // stand on.
+  //
+  // It is deleted rather than kept, exactly as its own text said it should be:
+  // "if the table legitimately goes all-priced one day, this is the line to
+  // DELETE, deliberately — not the one to edit around by inventing a plausible
+  // number for a row that has none." The inverse temptation is the live one
+  // now — keeping a null somewhere to keep a test honest — and that would be
+  // the same lie pointing the other way.
+  //
+  // The arm is still reachable and still tested: `null` survives in the type
+  // for a stream whose bitrate genuinely cannot be read (a FLAC row whose
+  // server sends no `icy-br` — FLAC's STREAMINFO carries no bitrate field),
+  // and `railRadioHiFiBadge.test.tsx` renders it from a fixture.
 
   it("decides hi-fi from the CODEC, so no station name is ever consulted", () => {
     // The `[hi-fi]` badge (vjt's #1836 ruling) marks a row whose codec keeps

--- a/cicchetto/src/__tests__/radioStations.test.ts
+++ b/cicchetto/src/__tests__/radioStations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { RADIO_STATIONS } from "../lib/radioStations";
+import { isLossless, RADIO_STATIONS } from "../lib/radioStations";
 
 // #682 — the curated station table. These are SHAPE invariants, and each one
 // exists because breaking it fails SILENTLY in production rather than loudly
@@ -150,6 +150,79 @@ describe("RADIO_STATIONS", () => {
       expect(source.mount, `station ${id} mount is not an absolute path`).toMatch(/^\//);
     }
   });
+
+  // #1836 — the FORMAT half of a row: what codec it serves and at what
+  // bitrate. Both DECLARED, for the reason the module header gives for every
+  // other field — this is a curated table and what a row claims stays ours —
+  // and both checkable, at CHECK time, by `bun run check:radio`. The rules
+  // below are the OFFLINE half: they hold on a laptop with no network, in CI,
+  // where the probe deliberately does not run.
+
+  it("declares a bitrate as a whole positive number of kbps, or nothing at all", () => {
+    // A zero, a negative or a fraction would all render — "0k", "-1k",
+    // "128.5k" — and none of them is a bitrate. The field is nullable
+    // precisely so that "we do not know" has a spelling that is not a number.
+    for (const s of RADIO_STATIONS) {
+      if (s.bitrate === null) continue;
+      expect(Number.isInteger(s.bitrate), `station ${s.id} bitrate is not a whole number`).toBe(
+        true,
+      );
+      expect(s.bitrate, `station ${s.id} bitrate`).toBeGreaterThan(0);
+    }
+  });
+
+  it("declares a bitrate for at least one station", () => {
+    // The positive control for the rule above, the same one `logoUrl` and
+    // `nowPlayingSource` carry: that rule SKIPS a null, so a table where the
+    // field had gone uniformly null would report green having checked nothing.
+    const priced = RADIO_STATIONS.filter((s) => s.bitrate !== null);
+    expect(priced.length).toBeGreaterThan(0);
+  });
+
+  it("leaves at least one station's bitrate null — the arm that draws no number", () => {
+    // The other direction, and it is a VACUITY guard rather than a rule about
+    // the table, the same shape `checkRadioLogos.test.ts` gives the logo-less
+    // arm: with every row priced, the "provider states nothing" path is never
+    // exercised by real data. If every provider in the table legitimately
+    // declares a bitrate one day, this is the line to DELETE, deliberately —
+    // not the one to edit around by inventing a plausible number for a row
+    // that has none, which is the defect #1696 was filed about.
+    const unpriced = RADIO_STATIONS.filter((s) => s.bitrate === null);
+    expect(unpriced.length).toBeGreaterThan(0);
+  });
+
+  it("decides hi-fi from the CODEC, so no station name is ever consulted", () => {
+    // The `[hi-fi]` badge (vjt's #1836 ruling) marks a row whose codec keeps
+    // every sample it was handed. Keying that on a list of station names would
+    // be right for exactly the rows somebody remembered to list and silently
+    // wrong for the next one added, which is why the classification lives on
+    // the codec and this pins it.
+    expect(isLossless("flac")).toBe(true);
+    expect(isLossless("mp3")).toBe(false);
+    expect(isLossless("vorbis")).toBe(false);
+  });
+
+  // 🔴 WHAT IS DELIBERATELY NOT HERE, and it was written first and then
+  // MEASURED AWAY. Twenty rows stream from a mount named `<id>-<kbps>-<codec>`,
+  // so the obvious offline rule — and the one this file carried for an hour —
+  // is that `bitrate` must equal the number in the path. It looks like the
+  // provider writing its own claim down where a test can read it with no
+  // network.
+  //
+  // It is false. The FIRST run of `bun run check:radio` against the real table
+  // reddened exactly one row: `ice.somafm.com/reggae-128-mp3` answers
+  // `icy-br: 160`, and the frame header confirms it independently of the
+  // server's own say-so (byte 2 is `0xa0`, MPEG1 Layer III bitrate index 10 =
+  // 160 kbps, where every sibling reads `0x92` = index 9 = 128). The mount NAME
+  // is a legacy label, not a declaration.
+  //
+  // So the rule would have forced a wrong number into the table to stay green —
+  // a test dictating a falsehood to the data, which is worse than no test. It
+  // is gone rather than scoped to nineteen rows, and the codec half went with
+  // it: if the vendor's naming convention lies about one field of the mount
+  // there is no reason to trust it about the other, and `check:radio` reads
+  // BOTH off the payload, which is the authority the name only imitates.
+  // Recorded in DESIGN_NOTES 2026-08-27.
 
   // #1703 — the CURATION floor. The issue is not a shape bug: the table was
   // structurally perfect and offered no metal at all and exactly one row of

--- a/cicchetto/src/__tests__/railRadioHiFiBadge.test.tsx
+++ b/cicchetto/src/__tests__/railRadioHiFiBadge.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAudio } from "../lib/audioPlayer";
+import { closeRadioPicker, openRadioPicker } from "../lib/radio";
+import { RADIO_STATIONS } from "../lib/radioStations";
+import RailRadio, { HI_FI_BADGE } from "../RailRadio";
+
+// #1836 — the `[hi-fi]` badge (vjt's ruling), and the one property the REAL
+// table cannot yet demonstrate.
+//
+// WHY THIS FILE MOCKS THE TABLE, when its sibling `RailRadio.test.tsx` states
+// in its own header that the table is used for real. The badge is a
+// PRECONDITION for the FLAC stations, not a follow-up: it is what makes those
+// rows safe to offer to somebody on a metered connection, so it ships BEFORE
+// them and no row in the curated table is lossless today. A test written
+// against the real table could therefore only assert that nothing draws the
+// badge — which passes just as happily against a component that cannot draw it
+// at all, i.e. a mirror of the bug rather than a test of the feature.
+//
+// So the fixtures below are the real rows with their FORMAT overridden, and
+// nothing else: real ids, so `RADIO_LOGO_PATHS` still resolves and the render
+// path is the production one end to end; only the two fields under test move.
+// The lossy and null-bitrate arms are here rather than in the sibling for the
+// same reason the positive one is — all three cases side by side, over rows
+// this file controls, is what makes the badge's ABSENCE evidence instead of a
+// coincidence of today's table.
+vi.mock("../lib/radioStations", async (importActual) => {
+  const actual = await importActual<typeof import("../lib/radioStations")>();
+  const [first, second, third] = actual.RADIO_STATIONS;
+  if (first === undefined || second === undefined || third === undefined) {
+    throw new Error("the curated table must carry at least three stations for these fixtures");
+  }
+  // Typed off the real row rather than cast: a fixture the type would reject
+  // is a fixture the table could never hold, and a `as` here would let the
+  // codec drift to a free string — the exact thing the closed set exists to
+  // stop.
+  const reformat = (
+    station: typeof first,
+    codec: (typeof first)["codec"],
+    bitrate: number | null,
+  ): typeof first => ({ ...station, codec, bitrate });
+  return {
+    ...actual,
+    RADIO_STATIONS: [
+      reformat(first, "flac", 1411),
+      reformat(second, "mp3", 128),
+      reformat(third, "vorbis", null),
+    ],
+  };
+});
+
+const [lossless, lossy, unpriced] = RADIO_STATIONS;
+if (lossless === undefined || lossy === undefined || unpriced === undefined) {
+  throw new Error("the mocked table must carry the three fixtures");
+}
+
+beforeEach(() => {
+  vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
+  vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+  closeAudio();
+  closeRadioPicker();
+});
+
+afterEach(() => {
+  closeAudio();
+  closeRadioPicker();
+  vi.restoreAllMocks();
+});
+
+describe("the picker's hi-fi badge (#1836)", () => {
+  it("marks a lossless row, so a metered listener sees the cost before pressing play", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    expect(screen.getByTestId(`rail-radio-station-hifi-${lossless.id}`)).toHaveTextContent(
+      HI_FI_BADGE,
+    );
+  });
+
+  it("leaves a lossy row unmarked — a badge on everything marks nothing", () => {
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    expect(screen.queryByTestId(`rail-radio-station-hifi-${lossy.id}`)).toBeNull();
+    // And the row is still priced: the absent badge must be the CODEC's doing,
+    // not the whole format line failing to render.
+    expect(screen.getByTestId(`rail-radio-station-format-${lossy.id}`)).toHaveTextContent(
+      "mp3 128k",
+    );
+  });
+
+  it("draws no number for a station whose provider declares no bitrate", () => {
+    // #1696's defect in the shape this field invites: rendering the absence as
+    // "null" or "0k" is a fact the row does not have, dressed as one it does.
+    // The codec still shows — that much IS known.
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    const format = screen.getByTestId(`rail-radio-station-format-${unpriced.id}`);
+    expect(format).toHaveTextContent("vorbis");
+    expect(format.textContent ?? "", "an unpriced row rendered a number").not.toMatch(/\d/);
+    expect(format.textContent ?? "", "an unpriced row rendered its own nullness").not.toMatch(
+      /null|undefined|NaN/,
+    );
+  });
+
+  it("keeps the badge off the row whose bitrate is merely unknown", () => {
+    // The two nullable-shaped facts are independent: "we do not know the
+    // bitrate" is not "this is lossless", and a badge keyed on the missing
+    // number instead of the codec would say it is.
+    render(() => <RailRadio />);
+    openRadioPicker();
+
+    expect(screen.getByTestId(`rail-radio-station-${unpriced.id}`)).toBeInTheDocument();
+    expect(screen.queryByTestId(`rail-radio-station-hifi-${unpriced.id}`)).toBeNull();
+  });
+});

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -57,10 +57,15 @@
 // reachability and agreement with the catalogue, and it is out of CI
 // deliberately, for the reason its own header gives.
 //
-// ⚠️ The STREAM half of that claim is still hand-measured and stays that way
-// here: `HEAD` on `ice.somafm.com` returns an empty reply (curl exit 52),
-// because icecast answers a GET with an endless body — proving a stream needs a
-// ranged-or-aborted fetch, a different mechanism from the logo probe.
+// ⚠️ The STREAM half of that claim used to be hand-measured and is not any
+// more (#1836). It stayed out because `HEAD` on `ice.somafm.com` returns an
+// empty reply (curl exit 52) — icecast answers a GET with an endless body, so a
+// stream needs an ABORTED fetch, a different mechanism from the logo probe.
+// That mechanism is now written down: `check:radio` opens each stream, reads
+// the first bytes it sends and hangs up. Two claims ride on it — `codec` and
+// `bitrate` below — and the argument for making them executable is #1696's own:
+// a baked claim about external state that nothing can check reads identically
+// whether it is true or false.
 //
 // The list is CURATED, not user-editable. A user-editable list is user state
 // and would want `lib/displayPrefs.ts` treatment (server-backed + synced,
@@ -104,6 +109,52 @@ export type NowPlayingSource =
       every mount the server carries. */
   | { readonly kind: "icecast-status"; readonly url: string; readonly mount: string };
 
+/** #1836 — every codec this table is allowed to declare.
+ *
+ * A CLOSED SET and not a free string, for the reason CLAUDE.md gives for every
+ * closed set: a typo in a free string is a row that renders "mp4" forever and
+ * fails nowhere. The members are the ones the table actually serves today
+ * (`mp3`, `vorbis`) plus `flac`, which is what the `[hi-fi]` badge exists FOR —
+ * the badge is a PRECONDITION for the FLAC stations rather than a follow-up, so
+ * the type can say lossless before any row does.
+ *
+ * Deliberately NOT a superset of what an ircd-shaped listener might one day
+ * meet: `aac` and `opus` are real and no row streams them, and a member nothing
+ * exercises is a signature in `check-radio-logos-core.ts` that no measurement
+ * stands behind. They go in with the first row that needs one, alongside the
+ * bytes measured off that row's stream.
+ *
+ * The LIST is the source and the union is derived from it, not the other way
+ * round: `check-radio-logos-core.ts` has to walk every codec to identify one
+ * off a stream's bytes, and a hand-written union would have forced a second
+ * hand-written array beside it — two spellings of one closed set, free to
+ * drift, which is the thing a closed set exists to prevent. */
+export const RADIO_CODECS = ["mp3", "vorbis", "flac"] as const;
+
+export type RadioCodec = (typeof RADIO_CODECS)[number];
+
+/** Whether a codec keeps every sample it was handed.
+ *
+ * A RECORD and not a `switch` or an "is it in this array" test: `Record<
+ * RadioCodec, …>` makes a new member of the union above a COMPILE error until
+ * somebody classifies it, which is the only version of this that cannot drift.
+ * A missing arm would otherwise default to lossy and the next lossless codec
+ * would ship silently un-badged.
+ *
+ * This is also the ONLY thing that decides a badge. Keying it on a list of
+ * station names — the obvious shortcut while FLAC means "the radioparadise
+ * rows" — is right for exactly the rows somebody remembered and silently wrong
+ * for the next one added. */
+const CODEC_IS_LOSSLESS: Record<RadioCodec, boolean> = {
+  mp3: false,
+  vorbis: false,
+  flac: true,
+};
+
+export function isLossless(codec: RadioCodec): boolean {
+  return CODEC_IS_LOSSLESS[codec];
+}
+
 /** One tunable station. All URLs must be https — the CSP tokens that admit
     them (`media-src https:`, `img-src https:`) are scheme-scoped, and an http
     stream on an https page is refused as mixed content anyway. */
@@ -117,6 +168,32 @@ export type RadioStation = {
   readonly description: string;
   /** The endless audio endpoint handed to `playAudio`. */
   readonly streamUrl: string;
+  /** #1836 — what that endpoint serves, DECLARED.
+      Beside `streamUrl` rather than discovered at render for the reason this
+      file's header already argues for every URL here: it is a curated table
+      and what a row claims stays OUR choice. Sniffing the codec in the picker
+      would mean opening the audio connection before the listener asked for it,
+      on every row — the exact opposite of what the picker does today, which is
+      draw from a constant and await nothing.
+      Checked rather than trusted, at CHECK time: `bun run check:radio` reads
+      the first bytes each stream sends and reddens when a row's claim stops
+      being true. The bytes and not the content type, measured 2026-08-27,
+      because both Ogg codecs answer with an Ogg content type and the one
+      comparison the `[hi-fi]` badge rests on is vorbis vs flac. */
+  readonly codec: RadioCodec;
+  /** #1836 — kbps, or `null` where the provider declares none.
+      NULLABLE for the reason `nowPlayingSource` gives above and `logoUrl`
+      gives below (that field was `songsUrl` when this was written; #1835
+      renamed it and the argument is unchanged),
+      and here it is the whole point rather than an accommodation: a bitrate is
+      something the provider either states or does not, and a plausible number
+      invented to fill the column would render as a fact. That is precisely the
+      defect #1696 was filed about, one field over. A null draws NO number —
+      not "0k", not "unknown".
+      Measured 2026-08-27 and the reason the arm is not hypothetical: SomaFM
+      and Rock Antenne both send `icy-br: 128`; kohina's icecast sends
+      `icy-name` and `icy-genre` and no `icy-br` at all. */
+  readonly bitrate: number | null;
   /** #1704 — the station's own artwork, or `null` when it publishes none.
       NULLABLE since Kohina, and the reasoning is the one `nowPlayingSource`
       gives below rather than a second mechanism: a logo is a thing most stations
@@ -157,6 +234,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["ambient", "electronic"],
     description: "A nicely chilled plate of ambient/downtempo beats and grooves.",
     streamUrl: "https://ice.somafm.com/groovesalad-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/groovesalad120.png",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/groovesalad.json" },
   },
@@ -167,6 +246,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description:
       "Served best chilled, safe with most medications. Atmospheric textures with minimal beats.",
     streamUrl: "https://ice.somafm.com/dronezone-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/dronezone120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/dronezone.json" },
   },
@@ -176,6 +257,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["electronic"],
     description: "Tune in, turn on, space out. Spaced-out ambient and mid-tempo electronica.",
     streamUrl: "https://ice.somafm.com/spacestation-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/spacestation120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/spacestation.json" },
   },
@@ -185,6 +268,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["electronic"],
     description: "Sensuous and mellow female vocals, many with an electronic influence.",
     streamUrl: "https://ice.somafm.com/lush-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/lush120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/lush.json" },
   },
@@ -194,6 +279,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["alternative", "rock"],
     description: "New and classic favorite indie pop tracks.",
     streamUrl: "https://ice.somafm.com/indiepop-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/indiepop120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/indiepop.json" },
   },
@@ -203,6 +290,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["alternative", "electronic"],
     description: "Early 80s UK Synthpop and a bit of New Wave.",
     streamUrl: "https://ice.somafm.com/u80s-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/u80s120.png",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/u80s.json" },
   },
@@ -213,6 +302,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description:
       "The soundtrack for your stylish, mysterious, dangerous life. For Spies and PIs too!",
     streamUrl: "https://ice.somafm.com/secretagent-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/secretagent120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/secretagent.json" },
   },
@@ -222,6 +313,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["electronic", "specials"],
     description: "Music for Hacking. The DEF CON Year-Round Channel.",
     streamUrl: "https://ice.somafm.com/defcon-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/defcon120.png",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/defcon.json" },
   },
@@ -231,6 +324,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["folk", "alternative"],
     description: "Indie Folk, Alt-folk and the occasional folk classics. ",
     streamUrl: "https://ice.somafm.com/folkfwd-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/folkfwd120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/folkfwd.json" },
   },
@@ -240,6 +335,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["americana"],
     description: "Americana Roots music for Cowhands, Cowpokes and Cowtippers",
     streamUrl: "https://ice.somafm.com/bootliquor-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/bootliquor120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/bootliquor.json" },
   },
@@ -249,15 +346,33 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["bossanova", "world"],
     description: "Silky-smooth, laid-back Brazilian-style rhythms of Bossa Nova, Samba and beyond",
     streamUrl: "https://ice.somafm.com/bossa-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/bossa120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/bossa.json" },
   },
+  // #1836 — 🔴 160, NOT the 128 its own mount name spells, and this is the row
+  // that proved the check-time probe was worth building. The first run of
+  // `bun run check:radio` after the two fields landed reddened exactly this one:
+  // `ice.somafm.com/reggae-128-mp3` answers `icy-br: 160`, and the payload
+  // agrees independently of the server's say-so — the first frame header reads
+  // `ff fb a0 04`, MPEG1 Layer III bitrate index 10 = 160 kbps, where every
+  // sibling row reads `ff fb 92 ..` = index 9 = 128. `icy-name` differs from the
+  // house style too (`SomaFM Reggae: Stuff`), so the mount was very likely
+  // rebuilt at a higher rate and kept its old path.
+  //
+  // DO NOT "correct" this to 128 to match the URL. The mount name is a legacy
+  // label, the bytes are the fact, and an offline test asserting the two agree
+  // was written for this table and then deleted for exactly this row — see
+  // `radioStations.test.ts`.
   {
     id: "reggae",
     title: "Heavyweight Reggae",
     genres: ["reggae"],
     description: "Reggae, Ska, Rocksteady classic and deep tracks.",
     streamUrl: "https://ice.somafm.com/reggae-128-mp3",
+    codec: "mp3",
+    bitrate: 160,
     logoUrl: "https://api.somafm.com/logos/120/reggae120.png",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/reggae.json" },
   },
@@ -267,6 +382,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["jazz"],
     description: "Transcending the world of jazz with eclectic, avant-garde takes on tradition.",
     streamUrl: "https://ice.somafm.com/sonicuniverse-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/sonicuniverse120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/sonicuniverse.json" },
   },
@@ -276,6 +393,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["ambient", "electronic"],
     description: "Celebrating NASA and Space Explorers everywhere.",
     streamUrl: "https://ice.somafm.com/missioncontrol-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/missioncontrol120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/missioncontrol.json" },
   },
@@ -299,6 +418,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description:
       "From black to doom, prog to sludge, thrash to post, stoner to crossover, punk to industrial.",
     streamUrl: "https://ice.somafm.com/metal-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/metal120.png",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/metal.json" },
   },
@@ -308,6 +429,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["70s", "rock"],
     description: "Mellow album rock from the Seventies. Yacht not required.",
     streamUrl: "https://ice.somafm.com/seventies-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/seventies120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/seventies.json" },
   },
@@ -317,6 +440,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["alternative"],
     description: "Electropop and indie dance rock with sparkle and pop.",
     streamUrl: "https://ice.somafm.com/poptron-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/poptron120.png",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/poptron.json" },
   },
@@ -326,6 +451,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["eclectic"],
     description: "Just covers. Songs you know by artists you don't. We've got you covered.",
     streamUrl: "https://ice.somafm.com/covers-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/covers120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/covers.json" },
   },
@@ -335,6 +462,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["eclectic"],
     description: "From the Black Rock Desert playa to the world, year round!",
     streamUrl: "https://ice.somafm.com/brfm-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/brfm120.jpg",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/brfm.json" },
   },
@@ -344,6 +473,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["ambient", "industrial"],
     description: "Where every day is Halloween: dark industrial/ambient music for tortured souls.",
     streamUrl: "https://ice.somafm.com/doomed-128-mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl: "https://api.somafm.com/logos/120/doomed120.png",
     nowPlayingSource: { kind: "somafm", url: "https://api.somafm.com/songs/doomed.json" },
   },
@@ -388,6 +519,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     genres: ["metal", "rock"],
     description: "Heavy metal around the clock, from Bavaria's rock station.",
     streamUrl: "https://stream.rockantenne.de/heavy-metal/stream/mp3",
+    codec: "mp3",
+    bitrate: 128,
     logoUrl:
       "https://www.rockantenne.de/media/cache/3/version/597/streamlogo_heavymetal_ra-v1.jpg/f1b996498456cb64.jpg",
     nowPlayingSource: null,
@@ -467,6 +600,8 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
     description:
       "Hand picked chip tunes from classic computers and consoles. SID, Amiga, Atari ST, Arcade, PC, and more!",
     streamUrl: "https://kohina.brona.dk/icecast/stream.ogg",
+    codec: "vorbis",
+    bitrate: null,
     logoUrl: null,
     // `mount` is the icecast-internal path, copied off the document's
     // `listenurl` (`http://localhost:8000/stream.ogg`) and NOT derived from

--- a/cicchetto/src/lib/radioStations.ts
+++ b/cicchetto/src/lib/radioStations.ts
@@ -181,18 +181,25 @@ export type RadioStation = {
       because both Ogg codecs answer with an Ogg content type and the one
       comparison the `[hi-fi]` badge rests on is vorbis vs flac. */
   readonly codec: RadioCodec;
-  /** #1836 — kbps, or `null` where the provider declares none.
+  /** #1836 — kbps, or `null` where it is NOT KNOWABLE.
       NULLABLE for the reason `nowPlayingSource` gives above and `logoUrl`
       gives below (that field was `songsUrl` when this was written; #1835
-      renamed it and the argument is unchanged),
-      and here it is the whole point rather than an accommodation: a bitrate is
-      something the provider either states or does not, and a plausible number
-      invented to fill the column would render as a fact. That is precisely the
-      defect #1696 was filed about, one field over. A null draws NO number —
-      not "0k", not "unknown".
-      Measured 2026-08-27 and the reason the arm is not hypothetical: SomaFM
-      and Rock Antenne both send `icy-br: 128`; kohina's icecast sends
-      `icy-name` and `icy-genre` and no `icy-br` at all. */
+      renamed it and the argument is unchanged), and here it is the whole point
+      rather than an accommodation: a plausible number invented to fill the
+      column renders as a fact and is a guess — the defect #1696 was filed
+      about, one field over. A null draws NO number, not "0k" and not
+      "unknown".
+      🔴 `null` is NOT "the provider sent no header" (vjt's ruling,
+      2026-08-27). The value comes from what the STREAM states about ITSELF,
+      and which part of the stream that is depends on the codec: an MPEG frame
+      header states a rate exactly, an Ogg Vorbis identification header
+      NOMINATES one, and FLAC's STREAMINFO states none at all — so a FLAC row's
+      only authority is the server's `icy-br`. `check-radio-logos-core.ts` owns
+      that per-codec table (`readBitrate`) together with the measurements
+      behind it, and `bun run check:radio` re-derives every row through it.
+      Putting `null` on a fact the bytes already hold is the mirror image of an
+      invented number and just as false — kohina was exactly that, for an
+      hour. */
   readonly bitrate: number | null;
   /** #1704 — the station's own artwork, or `null` when it publishes none.
       NULLABLE since Kohina, and the reasoning is the one `nowPlayingSource`
@@ -601,7 +608,15 @@ export const RADIO_STATIONS: readonly RadioStation[] = [
       "Hand picked chip tunes from classic computers and consoles. SID, Amiga, Atari ST, Arcade, PC, and more!",
     streamUrl: "https://kohina.brona.dk/icecast/stream.ogg",
     codec: "vorbis",
-    bitrate: null,
+    // #1836 (ruling, 2026-08-27) — 128, and it was `null` for one wrong hour.
+    // This icecast sends NO `icy-br`, and "the provider said nothing" was taken
+    // for "we cannot know". It is not: Vorbis states its rate INSIDE the codec
+    // stream, and the identification header here reads `bitrate_nominal =
+    // 128000` (max 0, min 0, 44100 Hz, 2ch), decoded off the first bytes this
+    // mount serves. `null` is reserved for NOT KNOWABLE — putting it on a fact
+    // we hold is the mirror image of #1696's invented number, and just as
+    // false.
+    bitrate: 128,
     logoUrl: null,
     // `mount` is the icecast-internal path, copied off the document's
     // `listenurl` (`http://localhost:8000/stream.ogg`) and NOT derived from

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2767,11 +2767,59 @@ html.resize-dragging * {
   object-fit: cover;
 }
 
+/* #1836 — `flex: 1` is new and it is what gives the sub-line below something
+   to distribute. Without it this box is sized by its content, so the format
+   token would sit wherever the longest title happened to end and the column
+   would ragged from row to row. Nothing else moves: the row is already
+   `width: 100%` with `text-align: start`, so a wider box only pushes the
+   title's ellipsis further out, which is the direction anyone would want. */
 .rail-radio-station-text {
   display: flex;
+  flex: 1;
   flex-direction: column;
   min-width: 0;
   gap: 0.1rem;
+}
+
+/* #1836 — the genres and the declared format share ONE line.
+   #500's vertical budget is why: a third line charges its cost on every row of
+   a 22-row list, and the format is two short tokens. `baseline` rather than
+   `center` so the smaller text sits on the genres' line rather than floating
+   in the middle of it. */
+.rail-radio-station-sub {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+/* The genres take the slack and the ellipsis; the format keeps its width. A
+   long genre list must clip rather than push the codec off the row — the
+   format is the fact this line was widened for. */
+.rail-radio-station-genres {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Muted like the genres it sits beside: this is the COST, quiet until you look
+   for it. */
+.rail-radio-station-format {
+  flex: none;
+  white-space: nowrap;
+  font-size: 0.8em;
+  color: var(--muted);
+}
+
+/* #1836 — the `[hi-fi]` badge (vjt's ruling). Accent, one step out of the
+   muted row, because it is the one token on this line the eye should catch
+   while scrolling — and it is bracketed TEXT rather than a pill, so it still
+   reads as a badge with the stylesheet off, which a background colour would
+   not. Colour is never the only signal: the brackets carry it. */
+.rail-radio-station-hifi {
+  flex: none;
+  white-space: nowrap;
+  font-size: 0.8em;
+  color: var(--accent);
 }
 
 /* The tuned row, marked the same way the presence toggle marks its active

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42612,3 +42612,121 @@ bytes an operator hears is a codec decision with its own trade — #1744's failu
 surfacing was designed around this row, and aac carries no in-band Vorbis
 comments — and it belongs to that issue. A slice that widens a CSP should not
 also silently move the audio.
+<!-- entry #1836 -->
+
+---
+
+## 2026-08-27 — #1836: a station declares its codec and bitrate, and the picker prices the row
+
+`RadioStation` said nothing about how heavy a row is to listen to. Fine while
+every station was a ~128k SomaFM MP3; not fine the moment a 1000+ kbps FLAC is
+offered beside one, because on a metered connection those are different
+propositions and the picker gave the listener no way to tell them apart before
+pressing play. vjt's ruling: the FLAC rows get a `[hi-fi]` badge. Two DECLARED
+fields (`codec`, `bitrate`), the format rendered on every picker row, and the
+badge derived from the codec.
+
+### Declared, not sniffed — and the badge ships BEFORE the rows it marks
+
+The values sit next to `streamUrl` for the reason that file's header already
+gives for every URL in it: the table is CURATED and what a row claims stays our
+choice. Discovering the codec at render would mean opening the audio connection
+before the listener asked for it, on every row — the exact opposite of what the
+picker does today, which is draw from a constant and await nothing.
+
+The badge is a PRECONDITION for adding the FLAC stations, not a follow-up: it is
+what makes them safe to offer. So `flac` is in the codec union with no row using
+it, and the slice stands alone. The consequence for testing is stated where it
+bites: the real table cannot demonstrate a lossless row, so a test written
+against it could only assert that nothing draws the badge — which passes just as
+happily against a component that cannot draw it at all. `railRadioHiFiBadge.test.tsx`
+mocks the table with real rows whose format is overridden, and says so.
+
+### The codec is read off the BYTES, and that is measured rather than fastidious
+
+`bun run check:radio` gained three axes (STREAM, CODEC, BITRATE). The obvious
+design reads the response headers, which is what the issue proposed. Measured
+2026-08-27, it cannot work: kohina's Ogg VORBIS answers `Content-Type: audio/ogg`
+and radioparadise's Ogg FLAC answers `application/ogg`. Both mean "an Ogg
+container" and neither names a codec — so a header check is green in exactly the
+lossy-vs-lossless comparison the `[hi-fi]` badge exists to make. The first bytes
+separate them inside 32: `OggS` then `\x01vorbis` at byte 28, or `\x7fFLAC` at
+byte 29.
+
+Reading them needs an ABORTED get. This was the last hand-measured claim in the
+table and it stayed hand-measured because a stream cannot be HEADed — icecast
+answers a GET with a body that never ends, so HEAD returns an empty reply (curl
+exit 52). `probeStream` cancels the reader once it holds a kilobyte, so the probe
+closes the socket itself rather than waiting on a timeout.
+
+### The row that proved the probe: `reggae` is 160, not the 128 its mount spells
+
+The FIRST run against the real table reddened exactly one row.
+`ice.somafm.com/reggae-128-mp3` answers `icy-br: 160`, and the payload agrees
+independently of the server's say-so: the first frame header reads `ff fb a0 04`
+— MPEG1 Layer III bitrate index 10 = 160 kbps — where every sibling reads
+`ff fb 92 ..` = index 9 = 128. Its `icy-name` also breaks the house style
+(`SomaFM Reggae: Stuff`), so the mount was very likely rebuilt at a higher rate
+and kept its old path.
+
+**What that killed.** This work first carried an OFFLINE test asserting that a
+`<id>-<kbps>-<codec>` mount agrees with the declared bitrate — attractive
+because it needs no network and covers twenty rows, and because it looks like
+the provider writing its own claim down. It is false, and worse than false: to
+stay green it would have forced 128 into the table, i.e. a test dictating a
+falsehood to the data. It is deleted rather than scoped to nineteen rows, and
+the codec half went with it — a naming convention that lies about one field of
+the mount earns no trust about the other, and the probe reads BOTH off the
+payload, which is the authority the name only imitates.
+
+**The general rule this instance belongs to:** a string that a vendor puts in a
+URL is a LABEL, not a declaration. The declaration is what the server sends at
+listen time. Same shape as #1696's logo extensions, which also only LOOKED like
+a convention.
+
+### Both directions are failures, and there are three upstream states
+
+BITRATE compares in both directions. A number invented over a silent provider is
+#1696's defect in a new field; a number dropped over a provider that states one
+draws no cost for a station that has one. And `icy-br` is a free string —
+`Number("")` is 0, `parseInt("128kbps")` is 128 — so `parseIcyBitrate` has a
+third state (`unreadable`) and reports it rather than coercing it. Collapsing
+"nobody said" and "somebody said something unparseable" would make the table
+green against a server saying something no one can read.
+
+`bitrate: null` draws the codec ALONE in the picker: not "0k", not "unknown".
+Measured: SomaFM and Rock Antenne send `icy-br`, kohina's icecast sends none.
+
+### Totality, twice, and no name lists
+
+`RADIO_CODECS` is the source and `RadioCodec` is derived from it, because the
+probe has to WALK every codec to identify one and a hand-written union would
+have needed a hand-written array beside it — two spellings of the set a closed
+set exists to have one of. `isLossless` and the byte signatures are both
+`Record`s over that union, so a new codec is a compile error until somebody both
+classifies it and supplies the bytes that identify it. A codec with no signature
+would be permanently unidentifiable, and every row declaring it would go red
+with no way to tell that from a genuinely wrong claim.
+
+Nothing consults a station NAME. Keying "this row is lossless" on a list of
+stations is right for exactly the rows somebody remembered and silently wrong
+for the next one added.
+
+### Scope held
+
+The badge is on the PICKER only. That is the DECISION surface — the issue is
+that the listener cannot tell the rows apart BEFORE pressing play, and after
+pressing play the cost is already being paid. The chrome band is untouched: its
+one spare line already carries three tenants (genres, track, playback failure).
+The format shares the genres' line rather than taking a third one, the trade
+#1698 made for the same reason — #500 bought this rail's vertical budget and a
+row a third taller charges part of it back on all 22.
+
+No FLAC stations were added. That is the follow-on this precondition exists for.
+
+### Provenance
+
+vjt's ruling reached this work RELAYED in the issue body by the ircbot, not read
+first-hand on IRC. The comment author field reads `vjt`, but every agent here
+comments with the same token, so the field is not independent evidence of
+authorship.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42695,7 +42695,53 @@ third state (`unreadable`) and reports it rather than coercing it. Collapsing
 green against a server saying something no one can read.
 
 `bitrate: null` draws the codec ALONE in the picker: not "0k", not "unknown".
-Measured: SomaFM and Rock Antenne send `icy-br`, kohina's icecast sends none.
+
+### The bitrate ruling, and the half of it that could not be built
+
+Later the same day vjt ruled on where `bitrate` is VALUED from, prompted by a
+sibling measurement on KNAC (#1837) where a proxy sends no `icy-br` while the
+frames say 128. The ruling leans on this entry's own reggae finding: the stream
+says what it IS, a label wrapped around it does not. Two clauses: value the
+field from the frame header, and reserve `null` for NOT KNOWABLE rather than
+for "the provider was quiet".
+
+**The second clause is right and this branch was wrong.** kohina shipped
+`bitrate: null` because its icecast sends no `icy-br` — and Vorbis states its
+own rate INSIDE the codec stream. Decoded off the bytes that mount serves:
+`bitrate_nominal = 128000`, max 0, min 0, 44100 Hz, 2 channels. The fact was in
+our hands the whole time. A `null` over a knowable fact is the mirror image of
+#1696's invented number and is just as false; the row is now `128`, and the
+vacuity guard that demanded some row stay `null` is deleted rather than kept by
+finding a new victim for it.
+
+**The first clause could not be built as written, and the refusal is decoded
+rather than argued.** FLAC's STREAMINFO carries no bitrate field — off
+radioparadise's own first bytes: blocksize 4096/4096, sample rate 44100,
+2 channels, 16 bits, and `minframesize`/`maxframesize` of 0/0, i.e. unknown —
+because FLAC is inherently variable-rate. Under a frame-header-only rule every
+FLAC row is `null`, so the stations the `[hi-fi]` badge exists FOR would be the
+only ones showing no cost. Deriving one from the PCM rate (44100 × 2 × 16 =
+1411 kbps) would overstate it, FLAC compressing well below PCM, and an
+overstatement dressed as a measurement is the defect the badge is meant to
+prevent.
+
+**The premise also needed a correction.** On reggae the URL said 128, the frame
+said 160 and `icy-br` said 160 — so that measurement convicts the URL and
+ACQUITS `icy-br`, which agreed with the bytes. `icy-br` is not a label somebody
+stuck on the stream; it is the origin server restating its encoder
+configuration on every connection. There was never a measurement against it.
+
+So the shape is a per-codec AUTHORITY, total over the union
+(`CODEC_BITRATE_AUTHORITY`): MPEG frame header for mp3, Vorbis
+`bitrate_nominal` for vorbis, `icy-br` for flac. Version and layer are checked
+before an MPEG frame is decoded, since MPEG2 and Layers I/II index a different
+table and a confident wrong number is worse than none; a Vorbis nominal of 0 is
+legal and reads as `absent`, not zero. Provenance is DERIVED from the codec
+rather than stored per row — the codec is already a field, and a column
+repeating what it implies is the parallel structure that drifts. The reading is
+keyed on the SERVED codec, never the declared one: a row lying about its codec
+is already red on CODEC, and asking the wrong decoder would add a second,
+misleading finding.
 
 ### Totality, twice, and no name lists
 


### PR DESCRIPTION
Addresses issue 1836. Rebased onto `d6162bda` (post-#1842) and fully re-gated.

`RadioStation` said nothing about how heavy a row is to listen to. Fine while
every station was a ~128k SomaFM MP3; not fine the moment a 1000+ kbps FLAC is
offered beside one. Two DECLARED fields (`codec`, `bitrate`), the format
rendered on every picker row, and a `[hi-fi]` badge derived from the codec.

## Provenance

vjt's badge ruling ("the FLAC rows get a `[hi-fi]` badge") reached this work
**RELAYED in the issue body by the ircbot — not seen first-hand**. The GitHub
author field reads `vjt`, but every agent in this project comments with the
same token, so that field is not independent evidence of authorship. The later
bitrate ruling (below) reached it relayed too.

## What shipped

* `RadioCodec` is a **closed set**, with the union derived from `RADIO_CODECS`
  rather than the other way round: the probe has to WALK every codec, and a
  hand-written union would have needed a hand-written array beside it.
  `isLossless`, the byte signatures and the bitrate authorities are all
  `Record`s over that union, so a new codec is a compile error until somebody
  classifies it, supplies the bytes that identify it, **and** says where its
  bitrate comes from.
* Nothing consults a station NAME. Lossless is decided by the codec, full stop.
* The badge is on the **picker** only — the decision surface. It shares the
  genres' line rather than taking a third one (#500's vertical budget, the
  trade #1698 already made). The chrome band is untouched.
* **No FLAC stations added.** The badge is the precondition; the rows are the
  follow-on. The slice stands alone.

## Checked, not trusted — `bun run check:radio` gained three axes

STREAM / CODEC / BITRATE. Not in the render path and not in CI, exactly where
the logo axes already are. STREAM was the last hand-measured claim in the
table; it stayed that way because icecast answers a GET with an endless body,
so `HEAD` returns an empty reply. An aborted GET is the mechanism that was
missing.

🔴 **The codec is read off the BYTES, not the content type, and that is
measured.** kohina's Ogg VORBIS answers `audio/ogg`; radioparadise's Ogg FLAC
answers `application/ogg`. Both mean "an Ogg container" and neither names a
codec — so a header check is green in exactly the lossy-vs-lossless comparison
the badge exists to make.

## The row that proved it, and the test it killed

The **first** run against the real table reddened exactly one row.
`ice.somafm.com/reggae-128-mp3` answers `icy-br: 160`, and the payload agrees:
its first frame header reads `ff fb a0 04` (MPEG1 Layer III bitrate index 10 =
160 kbps) where every sibling reads `ff fb 92 ..` = index 9 = 128.

An **offline** rule asserting that a `<id>-<kbps>-<codec>` mount agrees with the
declared bitrate had already been written here. To stay green it would have
forced 128 into the table: a test dictating a falsehood to the data. Deleted,
and the class recorded in DESIGN_NOTES — **a string a vendor puts in a URL is a
LABEL, not a declaration.**

## The bitrate ruling: one half taken, one half refused with the bytes

vjt ruled that `bitrate` is valued from what the stream states about itself,
frame-header first, with `null` reserved for NOT KNOWABLE.

**Taken, and it caught a real error here.** kohina shipped `bitrate: null`
because its icecast sends no `icy-br` — while its Vorbis identification header
had been nominating `128000` bits/s all along (max 0, min 0, 44100 Hz, 2ch),
decoded off the bytes that mount serves. `null` over a knowable fact is the
mirror image of an invented number. The row is `128`, and the vacuity guard
demanding some row stay `null` is deleted rather than given a new victim.

**Refused as "the frame header", and the refusal is decoded, not argued.**
FLAC's STREAMINFO carries no bitrate field — off radioparadise's own first
bytes: blocksize 4096/4096, rate 44100, 2ch, 16 bits, `minframesize`/
`maxframesize` **0/0 (unknown)** — because FLAC is inherently variable-rate.
Applied literally, every FLAC row would be `null`: the stations `[hi-fi]`
exists for would be the only ones showing no cost. Deriving one from the PCM
rate (44100 × 2 × 16 = **1411 kbps**) overstates it, FLAC compressing well below
PCM — an overstatement dressed as a measurement.

**And the premise needed a correction.** On reggae the URL said 128, the frame
said 160 and `icy-br` said **160**. That measurement convicts the URL and
**acquits** `icy-br`, which agreed with the bytes; nothing measured here has
ever been against it. `icy-br` is the origin server restating its encoder
config on every connection, not a label wrapped around the stream.

⇒ a per-codec **authority**, total over the union: MPEG frame header for mp3
(version and layer checked — MPEG2 and Layers I/II index a different table, and
a confident wrong number is worse than none), Vorbis `bitrate_nominal` for
vorbis (a legal nominal of 0 reads `absent`, not zero), `icy-br` for flac.
Provenance is **derived** from the codec, not stored per row. The reading is
keyed on the **served** codec, never the declared one.

## Measured, on the rebased tree

| gate | fusion only | after the ruling |
|---|---|---|
| `bun.sh run check` (5 stages) | rc=0 | **rc=0** |
| `bun.sh run test` (full) | rc=0, 327 files / 6481 | **rc=0, 327 files / 6493** |
| `bun.sh run check:radio` (live) | rc=0 | **rc=0** — 22 stations, 21 logos, 21 mirrored, 21 feeds, **22 streams opened**, 0 broken |
| mutation bench | 7/7 red | **10/10 red** |

The fusion was gated on its own first, so a breakage there would be
attributable to the merge and not to the new work. Neither round eroded an
assert. The three new mutations cover the ruling's own rules: FLAC read off the
frame header (red), a Vorbis nominal of 0 taken as a rate (red), the MPEG
version/layer check dropped (red).

DESIGN_NOTES union ritual: additions **118 → 118** across the rebase and
deletions **0**; the boundary reads full-stop / marker / blank / `---` / blank /
`## `; the whole of main's file is a byte-identical prefix (`cmp` rc=0, with a
corrupted-prefix positive control at rc=1); the marker is unique against the
tip that now carries both `#1834` and `#1835`; and predicted bytes/lines
(2517622 / 42732) matched actual exactly. The entry then grew to +164/−0 with
the ruling section — still pure additions against main.

No lane was used: every gate here is cic-only.

## What I refused to assert

* That the mount-name rule holds — falsified, with the measurement.
* That a frame header can state a FLAC bitrate — it cannot; decoded above.
* That `icy-br` was ever the thing reggae convicted — it agreed with the bytes.
* That native (non-Ogg) FLAC framing works. The constant is there because the
  format defines both framings; no endpoint measured so far uses it, and the
  code says so rather than implying a measurement.
* That the badge renders for a real row today. None is lossless yet; the
  positive case is proven against a mocked table, and the file says why.