### PR TITLE
cic: a copy control on the media viewer's text arm (issue 1839)

### DIFF
--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -8,6 +8,8 @@ import {
   Show,
   Switch,
 } from "solid-js";
+import { copyText } from "./lib/clipboard";
+import { errorMessage } from "./lib/friendlyApiError";
 import { closeMediaViewer, type MediaViewerState, mediaViewerState } from "./lib/mediaViewer";
 import { bindDismissGesture, type DismissDirections } from "./lib/mediaViewerGesture";
 import { createOverlayLock } from "./lib/overlayScrollLock";
@@ -22,7 +24,7 @@ import {
   toggleZoom,
 } from "./lib/pinchZoom";
 import { maybeEscapePwaClick } from "./lib/platform";
-import { fetchTextResource, TEXT_VIEW_MAX_BYTES } from "./lib/textResource";
+import { fetchTextResource, TEXT_VIEW_MAX_BYTES, type TextResource } from "./lib/textResource";
 
 // In-app media viewer modal — media-link cluster (2026-06-11).
 //
@@ -317,11 +319,18 @@ const TextPane: Component<{
   // top. Not a signal: the reader is a touchstart handler, and the element
   // identity never changes for the life of the mount.
   paneRef: (el: HTMLDivElement | undefined) => void;
+  // issue 1839 — the fetched resource itself, for the header's copy control.
+  // The RESOURCE and not the DOM: the pane is two <pre> elements, so anything
+  // scraped off it carries the gutter's line numbers. Published rather than
+  // re-fetched, and published from the same settled value the pane renders, so
+  // the clipboard and the screen cannot disagree about what the file is.
+  onSource: (source: TextResource | undefined) => void;
 }> = (props) => {
   const abort = new AbortController();
   onCleanup(() => {
     abort.abort();
     props.paneRef(undefined);
+    props.onSource(undefined);
   });
 
   const [source] = createResource(
@@ -344,6 +353,13 @@ const TextPane: Component<{
 
   const settled = (): ReturnType<typeof source> | undefined =>
     source.state === "ready" ? source() : undefined;
+
+  // Same `source.state` gate as the effect above, for the same reason: reading
+  // an errored resource rethrows. An effect and not a call from the render
+  // body — publishing during render would mutate a parent signal mid-commit.
+  createEffect(() => {
+    props.onSource(settled());
+  });
 
   const gutter = (count: number): string =>
     Array.from({ length: count }, (_, i) => String(i + 1)).join("\n");
@@ -392,6 +408,7 @@ const MediaViewerBody: Component<{
   state: MediaViewerState;
   onScale: (scale: number) => void;
   onTextPaneRef: (el: HTMLDivElement | undefined) => void;
+  onTextSource: (source: TextResource | undefined) => void;
 }> = (props) => {
   const [status, setStatus] = createSignal<MediaLoadStatus>("loading");
   // Transitions only leave "loading" (review fix): a transient
@@ -465,6 +482,7 @@ const MediaViewerBody: Component<{
                 onLoad={ready}
                 onError={failed}
                 paneRef={props.onTextPaneRef}
+                onSource={props.onTextSource}
               />
             </Match>
           </Switch>
@@ -475,6 +493,13 @@ const MediaViewerBody: Component<{
     </div>
   );
 };
+
+// issue 1839 — what the last copy attempt did. A closed set, not a string:
+// the three arms render three different sentences and nothing else may reach
+// the status line. `truncated` is deliberately NOT a member — it already lives
+// on the fetched resource, and a second copy of it here would be a parallel
+// structure to keep in step (CLAUDE.md: derive, don't duplicate).
+type CopyOutcome = { kind: "idle" } | { kind: "copied" } | { kind: "failed"; message: string };
 
 // #1438 — the modal is centered by a CSS `transform: translate(-50%, -50%)`,
 // and an inline transform REPLACES that declaration wholesale. The drag offset
@@ -517,6 +542,61 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
   // free under the one that can be measured: at fit the dismiss still received
   // 11 cancelable moves out of 11, exactly as it does under `none`.
   const isImage = props.state.kind === "image";
+
+  // issue 1839 — the copy control's two pieces of state. Both ARE rendered
+  // from (unlike `scale` and `textPane` above), so both are signals: the
+  // button exists only once there is a resource to take, and the status line
+  // says what the last attempt did.
+  const [textSource, setTextSource] = createSignal<TextResource | undefined>(undefined);
+  const [copyOutcome, setCopyOutcome] = createSignal<CopyOutcome>({ kind: "idle" });
+
+  // Gating on the RESOURCE and not on `isText` is strictly stronger than the
+  // issue asks: it also keeps the button off a pane that is still fetching or
+  // that 404'd, where it would copy nothing and report success.
+  const copySource = async (): Promise<void> => {
+    const loaded = textSource();
+    if (loaded === undefined) return;
+    try {
+      // `lines` is what the source <pre> renders, so the clipboard gets the
+      // file — the gutter is a SECOND <pre> built from the same array and is
+      // never part of this value. Reading the DOM instead is the bug this
+      // whole control is written around.
+      await copyText(loaded.lines.join("\n"));
+      setCopyOutcome({ kind: "copied" });
+    } catch (value) {
+      setCopyOutcome({ kind: "failed", message: errorMessage(value) });
+    }
+  };
+
+  // The ONE feedback channel, and it always speaks.
+  //
+  // A truncated copy hands over a PREFIX: `TEXT_VIEW_MAX_BYTES` caps the fetch,
+  // so a config file that arrived cut goes to the clipboard cut, and the reader
+  // has nothing on the pasteboard to tell them. The pane's own truncation
+  // banner is about what is on SCREEN; this is about what is in the CLIPBOARD,
+  // and only the second one leaves the modal.
+  //
+  // A FAILURE is not silent either, and that is a decision, not an
+  // inheritance. `copyText` throws when `navigator.clipboard` is undefined —
+  // the plain-http LAN deploy, which this project supports. `ShareSessionModal`
+  // swallows that because its artifact sits in a selectable input; the
+  // suggestion that this arm is the same shape does not survive the reason the
+  // button exists: on a phone the pane owns the drag as a scroll, so
+  // "select it by hand" is exactly the fight the control was added to end. All
+  // three `copyText` callers today surface the failure (two inline, one toast);
+  // silent-and-inert here would be the first that does not.
+  //
+  // No timer clears it. A confirmation that evaporates is a truncation warning
+  // the reader can miss, and the state dies with the modal anyway — the keyed
+  // <Show> remounts this component per open.
+  const copyStatus = (): string | undefined => {
+    const outcome = copyOutcome();
+    if (outcome.kind === "idle") return undefined;
+    if (outcome.kind === "failed") return outcome.message;
+    return textSource()?.truncated === true
+      ? `copied the first ${TEXT_VIEW_MAX_BYTES / 1024} KiB — the rest was never fetched; "open in browser" for all of it`
+      : "copied the source";
+  };
 
   const paint = (el: HTMLElement, dy: number): void => {
     el.style.transform = draggedTransform(dy);
@@ -578,17 +658,28 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
         }}
       >
         <div class="media-viewer-header">
-          <a
-            href={props.state.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="media-viewer-open-external"
-            onClick={(e) => {
-              maybeEscapePwaClick(e, props.state.href);
-            }}
-          >
-            open in browser
-          </a>
+          {/* The take-it-away verbs are grouped so the ✕ keeps the far edge
+              whether or not the copy control is there — with three flat
+              children `space-between` would push "open in browser" to the
+              middle on the text arm and nowhere else. */}
+          <div class="media-viewer-header-actions">
+            <Show when={textSource() !== undefined}>
+              <button type="button" class="media-viewer-copy" onClick={() => void copySource()}>
+                copy
+              </button>
+            </Show>
+            <a
+              href={props.state.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="media-viewer-open-external"
+              onClick={(e) => {
+                maybeEscapePwaClick(e, props.state.href);
+              }}
+            >
+              open in browser
+            </a>
+          </div>
           <button
             type="button"
             class="media-viewer-close"
@@ -598,6 +689,17 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
             ✕
           </button>
         </div>
+        {/* Inserted on the outcome rather than pre-mounted empty: an always-
+            present region would need `display: none` while idle not to reserve
+            a row, which takes it out of the accessibility tree anyway — so the
+            pre-mount buys nothing and costs a permanently-empty node. */}
+        <Show when={copyStatus()}>
+          {(message) => (
+            <p class="muted media-viewer-copy-status" role="status">
+              {message()}
+            </p>
+          )}
+        </Show>
         <MediaViewerBody
           state={props.state}
           onScale={(next) => {
@@ -606,6 +708,7 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
           onTextPaneRef={(el) => {
             textPane = el;
           }}
+          onTextSource={setTextSource}
         />
       </div>
     </>

--- a/cicchetto/src/__tests__/MediaViewerModal.test.tsx
+++ b/cicchetto/src/__tests__/MediaViewerModal.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { closeMediaViewer, mediaViewerState, openMediaViewer } from "../lib/mediaViewer";
 import {
   __resetForTest,
@@ -37,6 +37,35 @@ vi.mock("../lib/platform", async (importOriginal) => {
 
 const IMAGE_URL = "https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz";
 const VIDEO_URL = "https://grappa.example/uploads/zyxwvutsrqponmlkjihgfedcba";
+const TEXT_URL = "https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz.txt";
+
+// Response-shaped stub, same reason as textResource.test.ts: the component
+// depends on `res.body.getReader()`, and the platform's own Response is not
+// what is under test here. Module-scoped because the #1764 pane suite and the
+// #1839 copy suite need the same fetch, and two copies of it could drift into
+// two different notions of what the viewer is looking at.
+const stubBody = (text: string): void => {
+  const chunk = new TextEncoder().encode(text);
+  vi.stubGlobal("fetch", () =>
+    Promise.resolve({
+      ok: true,
+      status: 206,
+      body: {
+        getReader: () => {
+          let sent = false;
+          return {
+            read: () => {
+              if (sent) return Promise.resolve({ done: true });
+              sent = true;
+              return Promise.resolve({ done: false, value: chunk });
+            },
+            cancel: () => Promise.resolve(),
+          };
+        },
+      },
+    }),
+  );
+};
 
 beforeEach(() => {
   closeMediaViewer();
@@ -550,34 +579,6 @@ describe("MediaViewerModal — native pan for the zoomed image (#1805)", () => {
 // truncation is VISIBLE, and that a scrolled pane does not lose its scroll to
 // the dismiss gesture.
 describe("MediaViewerModal — text source viewer (#1764)", () => {
-  const TEXT_URL = "https://grappa.example/uploads/abcdefghijklmnopqrstuvwxyz.txt";
-
-  // Response-shaped stub, same reason as textResource.test.ts: the component
-  // depends on `res.body.getReader()`, and the platform's own Response is not
-  // what is under test here.
-  const stubBody = (text: string): void => {
-    const chunk = new TextEncoder().encode(text);
-    vi.stubGlobal("fetch", () =>
-      Promise.resolve({
-        ok: true,
-        status: 206,
-        body: {
-          getReader: () => {
-            let sent = false;
-            return {
-              read: () => {
-                if (sent) return Promise.resolve({ done: true });
-                sent = true;
-                return Promise.resolve({ done: false, value: chunk });
-              },
-              cancel: () => Promise.resolve(),
-            };
-          },
-        },
-      }),
-    );
-  };
-
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -719,5 +720,132 @@ describe("MediaViewerModal — text source viewer (#1764)", () => {
     const { container } = render(() => <MediaViewerModal />);
     openMediaViewer(IMAGE_URL, "image");
     expect(container.querySelector(".media-viewer-modal--text")).toBeNull();
+  });
+});
+
+// issue 1839 — a copy control on the text arm's header. Selecting a long source
+// pane by hand is a fight on a phone (the pane owns the drag as a scroll), so
+// the button is the whole affordance; what is asserted here is the three ways
+// it can be shipped wrong and look right:
+//
+//   - copying the DOM instead of the resource. The pane is a gutter <pre> and a
+//     source <pre> side by side, so `textContent` off the pane carries the line
+//     NUMBERS. The fixtures below are deliberately digit-free, which makes a
+//     gutter leak provable rather than eyeballed.
+//   - copying a TRUNCATED view without saying so. `TEXT_VIEW_MAX_BYTES` caps
+//     the fetch, and a silent prefix of a config file is the failure worth
+//     designing against.
+//   - swallowing a clipboard failure. `navigator.clipboard` is
+//     `[SecureContext]`-only and undefined on the plain-http LAN deploys this
+//     project supports, which is not a hypothetical arm.
+describe("MediaViewerModal — copy the source (issue 1839)", () => {
+  const restoreClipboard: Array<() => void> = [];
+
+  const withClipboard = (value: unknown): void => {
+    const original = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", { value, configurable: true });
+    restoreClipboard.push(() => {
+      if (original === undefined) Reflect.deleteProperty(navigator, "clipboard");
+      else Object.defineProperty(navigator, "clipboard", original);
+    });
+  };
+
+  const stubClipboard = (): Mock<(t: string) => Promise<void>> => {
+    const writeText = vi.fn<(t: string) => Promise<void>>(() => Promise.resolve());
+    withClipboard({ writeText });
+    return writeText;
+  };
+
+  afterEach(() => {
+    for (const restore of restoreClipboard.splice(0)) restore();
+    vi.unstubAllGlobals();
+  });
+
+  const openTextAndCopy = async (container: HTMLElement, href: string): Promise<void> => {
+    openMediaViewer(href, "text");
+    await waitFor(() => {
+      expect(container.querySelector(".media-viewer-text-source")).not.toBeNull();
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+  };
+
+  it("puts the SOURCE on the clipboard — the gutter's line numbers stay out of it", async () => {
+    stubBody("alpha\nbeta\ngamma\n");
+    const writeText = stubClipboard();
+    const { container } = render(() => <MediaViewerModal />);
+    await openTextAndCopy(container, TEXT_URL);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const payload = writeText.mock.calls[0]?.[0] ?? "";
+    expect(payload).toBe("alpha\nbeta\ngamma");
+    // The gutter really is rendered, and really does carry digits — without
+    // this the negative below would pass against an empty pane.
+    expect(container.querySelector(".media-viewer-text-gutter")?.textContent).toBe("1\n2\n3");
+    // The fixture has no digits of its own, so ANY digit in the payload is a
+    // number that came off the gutter. This is the assertion a `textContent`
+    // scrape of the pane fails.
+    expect(payload).not.toMatch(/[0-9]/);
+  });
+
+  it("says the clipboard holds only a slice when the fetch was cut at the cap", async () => {
+    stubBody("x".repeat(TEXT_VIEW_MAX_BYTES + 1));
+    const writeText = stubClipboard();
+    const { container } = render(() => <MediaViewerModal />);
+    await openTextAndCopy(container, TEXT_URL);
+
+    // The slice is still delivered — refusing to copy would be worse than
+    // copying and saying so.
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toMatch(new RegExp(`first ${TEXT_VIEW_MAX_BYTES / 1024} KiB`));
+  });
+
+  it("does NOT claim a slice when the whole file arrived", async () => {
+    stubBody("alpha\nbeta\n");
+    stubClipboard();
+    const { container } = render(() => <MediaViewerModal />);
+    await openTextAndCopy(container, TEXT_URL);
+
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toMatch(/copied/i);
+    expect(status.textContent).not.toMatch(/first/i);
+  });
+
+  it("names a missing clipboard API instead of failing inert", async () => {
+    stubBody("alpha\nbeta\n");
+    withClipboard(undefined);
+    const { container } = render(() => <MediaViewerModal />);
+    await openTextAndCopy(container, TEXT_URL);
+
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toMatch(/secure \(HTTPS\)/);
+    // The source stays on screen: the way out the message names is real.
+    expect(container.querySelector(".media-viewer-text-source")?.textContent).toBe("alpha\nbeta");
+  });
+
+  it("names a rejected write too (denied permission)", async () => {
+    stubBody("alpha\nbeta\n");
+    withClipboard({ writeText: () => Promise.reject(new Error("NotAllowedError")) });
+    const { container } = render(() => <MediaViewerModal />);
+    await openTextAndCopy(container, TEXT_URL);
+
+    const status = await screen.findByRole("status");
+    expect(status.textContent).toMatch(/NotAllowedError/);
+  });
+
+  it("offers no copy control on the image arm — the header is shared chrome", () => {
+    render(() => <MediaViewerModal />);
+    openMediaViewer(IMAGE_URL, "image");
+    expect(screen.queryByRole("button", { name: /^copy$/i })).toBeNull();
+  });
+
+  it("offers no copy control when the text fetch failed — there is nothing to take", async () => {
+    vi.stubGlobal("fetch", () => Promise.resolve({ ok: false, status: 404, body: null }));
+    render(() => <MediaViewerModal />);
+    openMediaViewer(TEXT_URL, "text");
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).not.toBeNull();
+    });
+    expect(screen.queryByRole("button", { name: /^copy$/i })).toBeNull();
   });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -13346,9 +13346,44 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   background: var(--bg-alt);
 }
 
+/* issue 1839 — the take-it-away verbs, grouped so the ✕ keeps the far edge
+   whatever the arm: the header is `space-between`, and a third flat child
+   would have parked "open in browser" in the middle of the text arm only. */
+.media-viewer-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
 .media-viewer-open-external {
   color: var(--accent);
   font-size: 0.9rem;
+}
+
+/* Reads as the sibling of the "open in browser" link, because that is what it
+   is: the second way to take the file out of the viewer. A <button> and not an
+   anchor — it performs an action rather than going anywhere. */
+.media-viewer-copy {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+/* What the LAST copy put on the clipboard — a full file, a slice cut at
+   TEXT_VIEW_MAX_BYTES, or the reason the write failed. Its own band between
+   the header and the body: the pane's truncation banner speaks about what is
+   on SCREEN, this one about what left the modal, and the two must not read as
+   one line. Colour comes from the shared .muted utility. */
+.media-viewer-copy-status {
+  flex: none;
+  margin: 0;
+  padding: 0.25rem 1rem 0.5rem;
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--border);
 }
 
 .media-viewer-close {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -42932,3 +42932,93 @@ client becoming the player, and that is deliberately not this work.
 The reachability of this row depends on a third party with no fallback, and
 that is written into the row rather than discovered later. Every other station
 here streams from its own provider's infrastructure.
+<!-- entry #1839 -->
+
+---
+
+## 2026-08-27 — #1839: a copy control whose failure is loud, and the "same shape" argument that did not survive
+
+The media viewer's `.txt`/`.md` arm (#1764) shows a source and gave no way to
+take it — a fight on a phone, where the pane owns the drag as a scroll and a
+selection drag competes with it. The header grew a `copy`. Three things in it
+are decisions rather than mechanics.
+
+### The clipboard payload is the RESOURCE, never the pane
+
+The pane is TWO `<pre>` elements — a gutter and the source — so anything read
+off the DOM carries the line numbers. The value copied is
+`loaded().lines.join("\n")`, the same array the source `<pre>` renders and the
+gutter NUMBERS, so screen and clipboard cannot disagree about what the file is.
+
+Measured, not argued: with the copy verb mutated to `textPane?.textContent`,
+the fixture `alpha/beta/gamma` reached the clipboard as
+`1\n2\n3alpha\nbeta\ngamma`. The fixture is deliberately digit-free, so the
+assertion is that the payload matches no `[0-9]` at all — a gutter leak of any
+shape fails it, not only the shape that was mutated.
+
+The resource is published UPWARD (`TextPane` → `MediaViewerDialog`) rather than
+re-derived in the header, for the same reason the pane numbers the array it
+renders: a second read is a second answer.
+
+### The clipboard failure is VISIBLE, and that reverses what the issue proposed
+
+`lib/clipboard.ts` throws when `navigator.clipboard` is `undefined` — the
+plain-http LAN deploy, since the API is `[SecureContext]`-only. Its header
+declares a split: `ShareSessionModal` keeps a silent catch because its artifact
+stays in a visible, selectable input, so the failure is self-correcting. The
+issue suggested the text viewer is "the same shape" and that silent-and-inert
+is arguably right here too.
+
+It is not the same shape, and the reason is the issue's own first paragraph.
+The self-correcting argument rests on "select it by hand" being available; this
+control exists PRECISELY because on a phone that is the fight. A silent failure
+would leave the operator holding the one affordance already known not to work,
+with nothing to tell them the tap did nothing. It is also the
+no-silent-swallow-at-boundaries rule, at a boundary.
+
+Counted rather than asserted: every `copyText` caller today surfaces the
+failure — `TotpSettings` and `PasskeySettings` inline, `messageMenu` as a toast
+— three of three. `ShareSessionModal` is not a fourth: it never routes through
+the helper, it calls `navigator.clipboard.writeText` directly. The silent
+posture on offer would have been the FIRST silent `copyText` caller, adopted on
+the arm with the weakest fallback.
+
+The channel is one status line under the header rather than a toast: the viewer
+sits at `z-index: 1101` over its own backdrop, and the toast surface's stacking
+against it was never measured — a failure message rendering behind the modal is
+the same silence, reached by a different route.
+
+### Truncation is stated where the COPY happens, not only where the reading does
+
+`TEXT_VIEW_MAX_BYTES` caps the fetch and the pane already banners a cut file.
+That banner is about what is on SCREEN; the copy is what LEAVES the modal, and
+a prefix of a config file pasted somewhere else carries no banner with it. The
+same status line therefore names the slice, with the cap read from the
+production constant so the sentence cannot drift from the cap.
+
+Nothing clears the line on a timer. A confirmation that evaporates is a
+truncation warning the reader can miss, and the state dies with the modal
+anyway: the keyed `<Show>` remounts the dialog per open.
+
+`truncated` is NOT stored in the copy outcome. It already lives on the fetched
+resource; a second copy would be a parallel structure to keep in step, and the
+resource cannot change under a mounted pane.
+
+### The gate on the button is stronger than the one asked for
+
+The issue asks for the control behind `isText`, since the header is shared
+chrome. It is gated on the RESOURCE being present instead, which additionally
+keeps it off a pane that is still fetching or that 404'd — where it would have
+copied an empty string and reported success.
+
+### What was NOT established
+
+No browser ran. The claims above are pinned in jsdom against a Response-shaped
+stub, and four mutants were run to show the assertions bite (DOM scrape,
+truncation unsaid, failure swallowed, button unconditional — each killed by
+exactly the tests written for it, 1/1/2/2 failures). What jsdom cannot answer:
+whether the status line is legible at the header's width on a phone, whether
+the tap target is comfortable, and whether a real `NotAllowedError` on iOS
+carries a message worth showing verbatim. The plain-http arm in particular is
+reasoned from the `[SecureContext]` contract and from `lib/clipboard.ts`, not
+observed on a LAN deploy.


### PR DESCRIPTION
The media viewer's `.txt`/`.md` arm (#1764) shows a source and gave no way to
take it. This adds a `copy` to the viewer header, on that arm only.

## The clipboard policy, chosen and stated

The issue asked whoever took this to pick a clipboard-failure policy and write
down which, rather than inherit one. **Picked: the failure is VISIBLE.**

`lib/clipboard.ts` throws when `navigator.clipboard` is `undefined` — the
plain-http LAN deploy, since the API is `[SecureContext]`-only. The issue
suggested this arm is `ShareSessionModal`'s shape (artifact stays on screen, so
the failure self-corrects) and that silent-and-inert is arguably right here too.
It is not the same shape, and the reason is the issue's own first paragraph:
the self-correcting argument rests on "select it by hand" being available, and
this control exists precisely because on a phone that is the fight. A silent
failure leaves the operator with the one affordance already known not to work.

Counted rather than asserted: all three `copyText` callers today surface the
failure — `TotpSettings` and `PasskeySettings` inline, `messageMenu` as a toast.
`ShareSessionModal` is not a fourth; it never routes through the helper, it
calls `navigator.clipboard.writeText` directly. The silent posture would have
been the first silent `copyText` caller.

One status line under the header carries all three outcomes (copied / copied a
slice / the failure reason). Not a toast: the modal sits at `z-index: 1101` over
its own backdrop and the toast surface's stacking against it was never measured.
No timer clears it — a confirmation that evaporates is a truncation warning the
reader can miss.

## The payload is the resource, not the DOM

The pane is two `<pre>` elements, gutter and source, so a `textContent` scrape
carries the line numbers. Copied value is `loaded().lines.join("\n")`, published
upward from `TextPane`. **Measured:** with the verb mutated to
`textPane?.textContent`, the `alpha/beta/gamma` fixture reached the clipboard as
`1\n2\n3alpha\nbeta\ngamma`. The fixture is digit-free on purpose, so the
assertion is that no `[0-9]` survives into the payload.

## Truncation is not silent

`TEXT_VIEW_MAX_BYTES` caps the fetch. The pane's existing banner is about what
is on SCREEN; the clipboard is what leaves the modal, and a prefix of a config
file pasted elsewhere carries no banner. The status line names the slice, with
the cap read from the production constant.

## Gate

Behind the RESOURCE being present, not merely `isText` — which additionally
keeps the button off a pane still fetching or one that 404'd, where it would
have copied an empty string and reported success.

## Gates run

- `bun.sh run check` — 5 stages, 0 failed (lock drift, test location, biome, tsc src, tsc e2e)
- `bun.sh run test` — 327 files, 6500 tests passed
- `scripts/design-notes-gate.sh` — post-commit, `1 new entry heading(s), separator and marker present.`
- TDD red observed before the implementation: 5 failed / 49 passed on the target file
- Four mutants, each killed by exactly its own test: DOM scrape (1 failure),
  truncation unsaid (1), failure swallowed (2), button unconditional (2)

## Not established

No browser ran — everything is jsdom against a Response-shaped stub. Legibility
of the status line at header width on a phone, tap-target comfort, and the real
iOS `NotAllowedError` message are unverified. The plain-http arm is reasoned
from the `[SecureContext]` contract and from `lib/clipboard.ts`, not observed on
a LAN deploy. No server change; nothing new is fetched.