### PR TITLE
cic: switch the #1680/#1769 presence pause off until #1847 lands

### DIFF
--- a/cicchetto/e2e/tests/issue1769-presence-suppressed-on-the-socket.spec.ts
+++ b/cicchetto/e2e/tests/issue1769-presence-suppressed-on-the-socket.spec.ts
@@ -142,6 +142,26 @@ test.afterEach(async () => {
 test("issue #1769 — a paused channel stops RECEIVING peer presence, while messages and the focused channel keep arriving", async ({
   page,
 }) => {
+  // #1848 — SUSPENDED, not broken. The pause it exercises ships OFF
+  // (`PRESENCE_PAUSE_ENABLED = false` in `src/lib/presencePause.ts`) until
+  // #1847 re-anchors the scrollback, so cic never re-joins with
+  // `{"presence": false}` and every arm past CONTROL 1 below asserts a
+  // suppression that is deliberately not happening.
+  //
+  // Skipped rather than weakened: the arms are correct and must come back
+  // UNTOUCHED with the flag. There is no fixture that could rescue them here
+  // — the switch is a build-time constant with no runtime seam, deliberately
+  // (a seam is exactly the "second way to say the same thing" #1769 refused),
+  // so an e2e driving a real bundle cannot turn it on. The unit-level twin in
+  // `src/__tests__/subscribe.test.ts` DOES keep running against the flag on,
+  // via `vi.doMock`; what is suspended here is only the live-socket proof.
+  //
+  // Restore by deleting this call in the same commit that flips the flag.
+  test.skip(
+    true,
+    "#1848 — presence pause is switched off until #1847; nothing re-joins with {presence:false}",
+  );
+
   const frames = recordFrames(page);
 
   // install() pauses the page clock; resume() lets it tick again immediately,

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1,5 +1,5 @@
 import { createEffect, createRoot, createSignal, on } from "solid-js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
 import { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs } from "../lib/userSettings";
 
@@ -4433,16 +4433,47 @@ describe("subscribe — the DM listener releases its own-nick topic on a rename 
 // through `routeMessage`). The per-channel Phoenix topic is NOT left — it
 // also carries the messages themselves (`Grappa.Session.Persistor` broadcasts
 // them there), so leaving it would make the window blind rather than quiet.
-describe("subscribe — presence pause on unfocused channels (#1680)", () => {
-  // Solid queues effects on the microtask queue, not on timers, so draining
-  // microtasks flushes the selection effect even with fake timers installed.
-  const flushEffects = async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-  };
+// Solid queues effects on the microtask queue, not on timers, so draining
+// microtasks flushes the selection effect even with fake timers installed.
+// Shared by the #1680 describe (flag ON) and the #1848 one (flag OFF).
+const flushEffects = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
 
-  const focus = (store: Awaited<ReturnType<typeof loadStores>>, channelName: string) =>
-    store.setSelectedChannel({ networkSlug: "freenode", channelName, kind: "channel" });
+const focus = (store: Awaited<ReturnType<typeof loadStores>>, channelName: string) =>
+  store.setSelectedChannel({ networkSlug: "freenode", channelName, kind: "channel" });
+
+describe("subscribe — presence pause on unfocused channels (#1680)", () => {
+  // #1848 — the pause SHIPS OFF (`PRESENCE_PAUSE_ENABLED = false`) until
+  // #1847 re-anchors the scrollback. Every arm below assumes a pause actually
+  // happens, so every arm turns the flag back on here rather than being
+  // deleted or rewritten: this describe is the guarantee that the one-line
+  // revert still works, and #1680's coverage survives the stopgap intact.
+  //
+  // The fixture is per-describe, not per-test, on purpose. Gating only the
+  // three arms that assert a DROP would leave the two carve-out arms ("still
+  // processes a peer NICK / our OWN part ON A PAUSED CHANNEL") passing
+  // trivially against a channel that was never paused — mirrors, green
+  // whatever the carve-out does.
+  //
+  // `vi.doMock` over the real module (spread, one key overridden) rather than
+  // a production setter: the flag stays a `const` with no runtime seam. The
+  // `afterEach` is load-bearing — a `doMock` registration SURVIVES
+  // `vi.resetModules` (see the #868 bleed note further up this file), so
+  // without it every downstream test in this file would silently run with the
+  // pause ON.
+  beforeEach(() => {
+    vi.doMock("../lib/presencePause", async () => {
+      const actual =
+        await vi.importActual<typeof import("../lib/presencePause")>("../lib/presencePause");
+      return { ...actual, PRESENCE_PAUSE_ENABLED: true };
+    });
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../lib/presencePause");
+  });
 
   it("stops a peer JOIN from touching a channel left alone past the cooldown", async () => {
     localStorage.setItem("grappa-token", "tok");
@@ -4703,6 +4734,99 @@ describe("subscribe — presence pause on unfocused channels (#1680)", () => {
       "#grappa",
       expect.any(Function),
       { presence: true },
+    );
+  });
+});
+
+// #1848 — the switch is OFF, and these two arms are what "off" MEANS.
+//
+// This describe sits AFTER the #1680 one on purpose. That one turns the flag
+// on through a `vi.doMock`, and a `doMock` registration survives
+// `vi.resetModules` (see the #868 bleed note further up this file). If its
+// `afterEach` ever stops un-mocking, these two go red — the bleed detector is
+// the placement, not a comment. No fixture here: the production default IS
+// off, and a test that had to arrange it would not be testing the default.
+//
+// Both arms also catch the trap the issue names: a kill switch written as
+// `PRESENCE_COOLDOWN_MS = Infinity` clamps to a 1 ms `setTimeout`, so it
+// pauses everything the instant a channel blurs — the bug, maximally.
+describe("subscribe — presence pause kill switch is OFF (#1848)", () => {
+  // The reported symptom, asserted where it was reported: a HOLE IN THE LOG.
+  // `applyPresenceEvent` alone would not have caught it — the members map is
+  // rebuilt on focus, the scrollback row is gone for good.
+  it("delivers a peer JOIN to the scrollback of a channel left alone past the cooldown", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const members = await import("../lib/members");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 10);
+    vi.useRealTimers();
+
+    vi.mocked(members.applyPresenceEvent).mockClear();
+    fireMessageEvent("#grappa", { id: 4007, kind: "join", sender: "carol" });
+
+    const rows = store.scrollbackByChannel()[channelKey("freenode", "#grappa")] ?? [];
+    expect(rows.some((r: { id: number }) => r.id === 4007)).toBe(true);
+    // The members delta is the other consumer the pause used to swallow.
+    expect(members.applyPresenceEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // The #1769 half of the same switch. Killing the arming has to kill BOTH
+  // cuts, and this one is invisible from the client's own state: the events
+  // simply never cross the socket, so nothing local looks wrong.
+  it("never asks the server to suppress presence while the switch is off", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    const socket = await import("../lib/socket");
+    const { PRESENCE_COOLDOWN_MS } = await import("../lib/presenceCooldown");
+
+    vi.useFakeTimers();
+    focus(store, "#grappa");
+    await flushEffects();
+    focus(store, "#cicchetto");
+    await flushEffects();
+    vi.advanceTimersByTime(PRESENCE_COOLDOWN_MS * 10);
+    vi.useRealTimers();
+
+    // POSITIVE CONTROL, first: a `not.toHaveBeenCalledWith` passes for free
+    // on a harness that never joined anything at all. Prove the channel was
+    // joined the ordinary way before claiming it was never re-joined the
+    // suppressed way.
+    expect(socket.joinChannel).toHaveBeenCalledWith(
+      "alice",
+      "freenode",
+      "#grappa",
+      expect.any(Function),
+      { presence: true },
+    );
+    expect(socket.joinChannel).not.toHaveBeenCalledWith(
+      "alice",
+      "freenode",
+      "#grappa",
+      expect.any(Function),
+      { presence: false },
     );
   });
 });

--- a/cicchetto/src/lib/presencePause.ts
+++ b/cicchetto/src/lib/presencePause.ts
@@ -61,6 +61,34 @@ import type { ScrollbackMessage } from "./api";
 import type { ChannelKey } from "./channelKey";
 import { createPresenceCooldown } from "./presenceCooldown";
 
+// 🔴 THE PAUSE IS OFF. Flip this back to `true` when #1847 lands.
+//
+// #1848, vjt's call on IRC 2026-08-27. #1680/#1769 are producing visible holes
+// in the log: a peer JOIN/PART/QUIT on a channel left unfocused never reaches
+// the scrollback, and only a hard refresh brings it back. The members map is
+// rebuilt on focus; the missing ROWS are gone for good. Correctness wins over
+// the event-rate saving until #1847 re-anchors the scrollback, and then this
+// line goes back to `true` — that is the whole revert.
+//
+// It gates the ARMING, at the one wiring site in `subscribe.ts` that reports
+// focus. Nothing else changes: the machinery below, `presenceCooldown.ts`, the
+// `{presence:_}` join param and the server's filter all stay. With no channel
+// ever blurred INTO a window, `pausedKeys` stays empty, so `shouldDrop` is
+// false by construction and `onPause` never fires — the dispatch-edge drop and
+// the `{presence:false}` re-join die together, from one place.
+//
+// 🔴 NOT a large cooldown. `setTimeout` takes a 32-bit signed delay, so
+// `Infinity` (or anything past 2^31-1) is clamped — measured on node 20, to
+// 1 ms — and fires almost immediately. "Never pause" written that way pauses
+// every channel the instant it blurs: the bug, maximally. The kill has to be a
+// branch that never arms the window, which is what this is.
+//
+// What it costs, stated not hidden: #1680's measurement was 21,917 of 26,588
+// rows in 15 minutes on a 7-network account being presence for windows nobody
+// reads. Expect the event rate and the main-thread cost back at the pre-#1680
+// baseline for as long as this reads `false`.
+export const PRESENCE_PAUSE_ENABLED = false;
+
 // The paused-channel drop set: a strict SUBSET of the presence kinds, chosen
 // by "has no consumer other than the members map". Kept as its own literal
 // rather than derived from `SUPPRESSED_PRESENCE_KINDS` because the two answer

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -27,7 +27,7 @@ import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
 import { resolveCtcpReply, resolvePing } from "./pingCorrelation";
 import { PRESENCE_COOLDOWN_MS } from "./presenceCooldown";
-import { createPresencePause } from "./presencePause";
+import { createPresencePause, PRESENCE_PAUSE_ENABLED } from "./presencePause";
 import { shouldNotify } from "./pushTriggers";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
@@ -211,6 +211,16 @@ moduleRoot(() => {
   // absorb. (Issue open question 1, answered this way and recorded as an
   // assumption rather than a measurement.)
   createEffect(() => {
+    // #1848 — the kill switch bites HERE, and only here. This is the only
+    // caller of `focus`, and `focus` is the only thing that arms a window
+    // (`presenceCooldown.blurred`), so returning before it is what "the pause
+    // is off" means: nothing is ever added to `pausedKeys`, so `shouldDrop`
+    // below is false by construction and `onPause` never re-joins with
+    // `{presence: false}`. Both cuts, one branch. See
+    // `PRESENCE_PAUSE_ENABLED` in `presencePause.ts` for the why and the
+    // revert. The guard sits BEFORE the signal read on purpose: with the
+    // switch off this effect runs once, tracks nothing and never wakes again.
+    if (!PRESENCE_PAUSE_ENABLED) return;
     const sel = selectedChannel();
     presencePause.focus(
       sel && sel.kind === "channel" ? channelKey(sel.networkSlug, sel.channelName) : null,

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43022,3 +43022,81 @@ the tap target is comfortable, and whether a real `NotAllowedError` on iOS
 carries a message worth showing verbatim. The plain-http arm in particular is
 reasoned from the `[SecureContext]` contract and from `lib/clipboard.ts`, not
 observed on a LAN deploy.
+<!-- entry #1848 -->
+
+---
+
+## 2026-08-27 — #1848: switching a feature off without letting its tests go quiet
+
+The #1680/#1769 presence pause ships OFF as a stopgap until #1847 re-anchors
+the scrollback (vjt's call on IRC, 2026-08-27: a log with silent holes beats a
+busy main thread, and the holes are real — a peer JOIN/PART/QUIT on a channel
+left unfocused never reached the scrollback, recoverable only by a hard
+refresh). The switch itself is one named constant,
+`PRESENCE_PAUSE_ENABLED` in `presencePause.ts`, gating the ONE call to
+`presencePause.focus` in `subscribe.ts`. That call is the only thing that arms
+a cooldown window, so killing it kills both cuts at once: `pausedKeys` stays
+empty, `shouldDrop` is false by construction, and `onPause` never re-joins
+with `{presence: false}`. The machinery is untouched — this is a switch, not a
+removal.
+
+Three decisions here outlive the stopgap, because they are what the revert
+will have to undo.
+
+### The flag lives in `presencePause.ts`, not inline at the wiring site
+
+The issue asked for the constant AT the wiring site, in `subscribe.ts`. It is
+one module over, and the reason is testability rather than taste: `subscribe.ts`
+is a side-effect module that installs its root on import, so a constant
+declared inside it can never be flipped by a test. The seven #1680 arms in
+`subscribe.test.ts` all assume a pause actually happens; with an inline
+constant the only ways to keep them are to delete them or to rewrite them
+against the OFF behaviour, and both throw away the coverage that protects the
+one-line revert. Exported from `presencePause.ts` it is a `vi.doMock` away,
+with no runtime seam added to production. A test-only setter was rejected for
+the same reason #1769 rejected a flip-it-in-place verb: it is a second way to
+say the same thing, and it makes the constant mutable to buy nothing.
+
+### The flag-on fixture is per-DESCRIBE, not per-test
+
+Only three of the seven arms assert a DROP. Gating just those looks
+sufficient and is not: the two carve-out arms ("still processes a peer NICK /
+our OWN part ON A PAUSED CHANNEL") would keep passing against a channel that
+was never paused, which is a mirror — green whatever the carve-out does. The
+general rule: when a feature is switched off, every test whose SETUP depends
+on the feature needs the fixture, not just the ones whose ASSERTION does.
+
+The `afterEach` that un-mocks is load-bearing, not hygiene: a `vi.doMock`
+registration survives `vi.resetModules`, so without it every later test in the
+file would silently run with the pause on. The new #1848 describe is placed
+AFTER the #1680 one so that a bleed shows up as a red rather than as nothing.
+
+### The e2e proof is suspended, and cannot be rescued by a fixture
+
+`issue1769-presence-suppressed-on-the-socket.spec.ts` drives a real bundle, and
+the switch is a build-time constant with no runtime seam — deliberately — so
+there is no way to turn it on from a spec. It is skipped with the reason
+attached and restored by deleting one call in the commit that flips the flag.
+Note what this costs honestly: the live-socket proof is the only place the
+`{presence: false}` re-join is observed against a real server, and the unit
+twin cannot replace it (`fireMessageEvent` drives the installed handler
+directly, so there is no socket there to have a gap). For as long as the flag
+is off, that arm is a promise rather than a measurement.
+
+### What switching it off costs
+
+#1680's own measurement, restated so nobody has to rediscover it: 21,917 of
+26,588 rows in 15 minutes on a 7-network account were presence for windows
+nobody was reading. Expect the event rate and the main-thread cost back at the
+pre-#1680 baseline until #1847 lands. That trade was made with the number in
+hand.
+
+### The trap, named because it is the obvious wrong answer
+
+`PRESENCE_COOLDOWN_MS = Infinity` is the one-character version and it does the
+exact opposite of what it reads as: `setTimeout` takes a 32-bit signed delay,
+so anything past 2^31-1 is clamped (to 1 ms on node 20) and fires almost
+immediately — "never pause" written that way pauses every channel the instant
+it blurs. The kill has to be a branch that never arms the window. Both #1848
+arms would catch that mutant; both were also confirmed to die when the flag is
+flipped back on, so neither is a mirror.


### PR DESCRIPTION
Stopgap for issue 1848: the #1680/#1769 presence pause ships **OFF** until #1847
re-anchors the scrollback. Client-only — the server half is inert by
construction, since `presence_suppressed` is decided per-join from the
`{presence: false}` param, so if no client asks for suppression the server
stops suppressing without a deploy of its own.

## The lever

One named constant, `PRESENCE_PAUSE_ENABLED` in `presencePause.ts`, gating the
ONE call to `presencePause.focus` in `subscribe.ts`. That call is the only
thing that arms a cooldown window, so the branch kills both cuts at once:

- nothing enters `pausedKeys`, so `shouldDrop` is false by construction and the
  dispatch-edge drop stops biting;
- `onPause` never fires, so no socket ever re-joins with `{presence: false}`
  and the server-side filter never engages either.

It is a **branch that never arms the window**, not a large cooldown —
`setTimeout` clamps a 32-bit signed delay, so `Infinity` fires almost
immediately and would pause every channel the instant it blurs.

Nothing is deleted: `presencePause.ts`, `presenceCooldown.ts`, the
`{presence:_}` join param and the server filter all stay, tests included.

## Where I deviated from the issue text, and why

The issue asked for the constant **at** the wiring site in `subscribe.ts`. It
is one module over. `subscribe.ts` installs its root on import, so a constant
declared inside it can never be flipped by a test — and all seven #1680 arms
assume a pause happens, so an inline constant leaves only "delete them" or
"rewrite them against OFF", both of which throw away the coverage protecting
the one-line revert. Exported from `presencePause.ts` it is a `vi.doMock`
away, with **no runtime seam added to production**. A test-only setter was
rejected for the same reason #1769 rejected a flip-it-in-place verb.

The flag-on fixture is **per-describe, not per-test**: only three arms assert a
DROP, but the two carve-out arms ("still processes a peer NICK / our OWN part
ON A PAUSED CHANNEL") would otherwise keep passing against a channel that was
never paused — mirrors. The `afterEach` un-mock is load-bearing, because a
`vi.doMock` registration survives `vi.resetModules`.

## Tests

Two new arms pin what OFF means, placed after the #1680 describe so a fixture
bleed shows as a red:

- a peer JOIN past the cooldown reaches the **scrollback** — the reported
  symptom asserted where it was reported; `applyPresenceEvent` alone would not
  have caught it, since the members map is rebuilt on focus and the rows are
  not;
- no join frame ever carries `{presence: false}`, with the ordinary
  `{presence: true}` join asserted **first** as a positive control (a
  `not.toHaveBeenCalledWith` passes for free on a harness that joined nothing).

Both were observed RED before the switch existed, and both die again when the
flag is flipped back on — so neither is a mirror.

## Suspended coverage, stated not hidden

`issue1769-presence-suppressed-on-the-socket.spec.ts` is skipped with the
reason attached. It drives a real bundle and the switch is a build-time
constant with no runtime seam, so no fixture can turn it on. That spec is the
only place the `{presence: false}` re-join is observed against a real server;
while the flag is off, that arm is a promise rather than a measurement.
Restored by deleting one call in the commit that flips the flag.

## What this costs

#1680's own measurement: 21,917 of 26,588 rows in 15 minutes on a 7-network
account were presence for windows nobody was reading. Expect the event rate and
the main-thread cost back at the pre-#1680 baseline for as long as the flag is
off. #1847 is what ends the trade.

## Gates measured on this tree

- `scripts/bun.sh run check` — **rc=0**, 5 stages, 0 failed (lock drift, test
  location, biome, tsc src, tsc e2e).
- `scripts/bun.sh run test` — **rc=0**, 327 files, **6506 passed**.
- `scripts/design-notes-gate.sh` — **rc=0**, `1 new entry heading(s), separator
  and marker present.`

NOT run, and out of this lane: the e2e / integration suite (STACK) and the
Elixir gates (`scripts/check.sh`) — no server code is touched.
