### PR TITLE
fix(cic): dismiss a modal backdrop on the press it began, not on any click

### DIFF
--- a/cicchetto/e2e/playwright.config.ts
+++ b/cicchetto/e2e/playwright.config.ts
@@ -72,7 +72,30 @@ export default defineConfig({
       // `@webkit` run on the desktop project. Without this gate,
       // `@webkit`-tagged specs (BUG7 + variants) attempt `tap()` on a
       // non-touch context and throw "The page does not support tap".
-      grepInvert: /@webkit/,
+      grepInvert: /@webkit|@touch/,
+    },
+    {
+      // issue 1831 — the ONLY project whose touch produces the compat mouse
+      // events a real tap produces. Measured, because it is the whole reason
+      // this project exists: on `webkit-iphone-15` a `tap()` dispatches
+      // `pointerdown / touchstart / pointerup` and STOPS — no touchend, no
+      // mousedown/mouseup, no click at all — so a spec about what a
+      // synthesised click hits is unanswerable there and goes green whatever
+      // the code does. On chromium + touch the same tap dispatches all six,
+      // and the click hit-tests against the layout as it stands THEN.
+      //
+      // Also the closer engine family to the reported device (Android), though
+      // that device runs Gecko and this is Blink — see the spec header.
+      //
+      // `grep: /@touch/` keeps it to the specs that need it; without that it
+      // would re-run the whole suite on a third project.
+      name: "chromium-pixel-touch",
+      use: {
+        ...devices["Pixel 7"],
+        // Same self-signed nginx-test cert story as the desktop project.
+        launchOptions: { args: ["--ignore-certificate-errors"] },
+      },
+      grep: /@touch/,
     },
     {
       name: "webkit-iphone-15",

--- a/cicchetto/e2e/tests/issue1831-tap-send-modal-survives.spec.ts
+++ b/cicchetto/e2e/tests/issue1831-tap-send-modal-survives.spec.ts
@@ -1,0 +1,108 @@
+// issue 1831 — a modal opened from the compose line must survive the TAP that
+// opened it.
+//
+// The claim under test is a PLATFORM one, which is why it cannot live in
+// jsdom. `banlistCommand` has no `await` ahead of `openBanlistModal`, so the
+// scrim is in the DOM before the browser dispatches the tap's compat mouse
+// events. Those are synthesised after the touch ends and hit-tested against
+// the layout as it stands THEN — so the click can land on a backdrop that did
+// not exist when the finger went down, and a backdrop dismissing on any click
+// dismisses in the gesture that opened it. The unit tests in
+// BanlistModal.test.tsx DISPATCH that sequence; only an engine can be asked
+// whether it PRODUCES it.
+//
+// It does. Measured here on chromium + touch, recording every event at the
+// document in capture phase while tapping send with `/banlist` typed, against
+// the PRE-CURE code:
+//
+//     pointerdown -> polygon              (the send button's arrow glyph)
+//     touchstart  -> polygon
+//     pointerup   -> polygon
+//     mousedown   -> div.modal-backdrop   <- the scrim, mounted during pointerup
+//     mouseup     -> div.modal-backdrop
+//     click       -> div.modal-backdrop
+//     …and the banlist modal count was 0.
+//
+// The press lands on the button and the click lands on the SCRIM. That is the
+// defect, entire, on a real engine.
+//
+// 🔴 WHY THIS RUNS ON `chromium-pixel-touch` AND NOT ON `webkit-iphone-15`,
+// which was tried first and is the wrong instrument. The same probe there
+// records `pointerdown / touchstart / pointerup` and STOPS: no touchend, no
+// mousedown, no mouseup, NO CLICK. Playwright's injected touch produces no
+// compat mouse events on that engine at all, so a spec about what a
+// synthesised click hits is unanswerable — and, measured, the pre-cure code
+// went GREEN there on both arms. Do not "simplify" this back onto the webkit
+// project: it passes without touching the defect.
+//
+// The pair below is deliberate, and the control is the load-bearing half:
+//
+//   * ENTER — the gesture the whole suite already uses (`composeSend` presses
+//     Enter). A keydown synthesises no click, so this arm is green on both
+//     sides of the cure; its job is to fail loudly if the STACK broke rather
+//     than the mechanism.
+//   * TAP — the same command through the send button. Red before the cure,
+//     green after. Everything but the GESTURE is held fixed: same command,
+//     same window, same bundle, same engine.
+//
+// That is also the local evidence bearing on the reporter's tab-vs-PWA
+// asymmetry, which has never been shown to hold the gesture fixed. Here the
+// gesture ALONE splits the outcome.
+//
+// PLATFORM LIMIT, stated rather than buried: the reported device is Android
+// FIREFOX and this is Blink. Playwright's firefox does not support touch
+// emulation, so Gecko is not reachable from this harness. This measures that
+// an engine does it, and which gesture does it — not that Gecko does.
+
+import { composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("@touch issue 1831 — /banlist sent with Enter opens the ban list (gesture control)", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  await composeSend(page, "/banlist");
+
+  // The modal itself is the assertion — its CONTENTS are not this spec's
+  // business (#536 already pins that a queried ban renders). An empty or
+  // still-loading list is a perfectly good open modal.
+  await expect(page.getByTestId("banlist-modal")).toBeVisible({ timeout: 15_000 });
+});
+
+test("@touch issue 1831 — /banlist sent by TAPPING send opens the ban list and it stays", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+
+  // Tap, never click. A `click()` synthesises a mouse sequence whose
+  // `mousedown` PRECEDES the modal mount, so the click resolves to the common
+  // ancestor of button and scrim instead of to the scrim — the case that never
+  // reproduced, and the reason a mouse never saw this bug.
+  await ta.tap();
+  await ta.pressSequentially("/banlist", { delay: 20 });
+  await page.getByRole("button", { name: /send message/i }).tap();
+
+  // Dispatch signal first, so a red below is a MODAL failure and not a submit
+  // that never happened.
+  await expect(ta).toHaveValue("", { timeout: 5_000 });
+
+  const modal = page.getByTestId("banlist-modal");
+  await expect(modal).toBeVisible({ timeout: 15_000 });
+
+  // …and still there once the gesture has fully settled. The defect dismissed
+  // it within the same tap, so `toBeVisible` alone already catches it; this
+  // second look separates "opened and stayed" from "the assertion won a race".
+  await page.waitForTimeout(1_000);
+  await expect(modal).toBeVisible();
+});

--- a/cicchetto/src/BanlistModal.tsx
+++ b/cicchetto/src/BanlistModal.tsx
@@ -1,4 +1,5 @@
 import { type Component, createSignal, For, Show } from "solid-js";
+import { createBackdropDismiss } from "./lib/backdropDismiss";
 import { banlistCardBySlug } from "./lib/banlistCard";
 import { banlistModalState, closeBanlistModal, openBanlistModal } from "./lib/banlistModal";
 import { type BanMaskForm, buildBanMask } from "./lib/banMask";
@@ -188,6 +189,11 @@ const BanlistModal: Component = () => {
   // Overlay refcount so the covered pane freezes + #232 shared Esc-to-close.
   createOverlayLock(() => banlistModalState() !== null, ".banlist-modal", closeBanlistModal);
 
+  // issue 1831 — the scrim dismisses on the press it began, not on any click
+  // that happens to land on it. See lib/backdropDismiss.ts for the tap that
+  // used to close this modal in the same gesture that opened it.
+  const backdropDismiss = createBackdropDismiss(closeBanlistModal);
+
   return (
     <Show when={target()}>
       {(t) => (
@@ -195,7 +201,8 @@ const BanlistModal: Component = () => {
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
         <div
           class="modal-backdrop modal-backdrop-viewport banlist-modal-backdrop"
-          onClick={closeBanlistModal}
+          onPointerDown={backdropDismiss.onPointerDown}
+          onClick={backdropDismiss.onClick}
         >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div

--- a/cicchetto/src/ModeModal.tsx
+++ b/cicchetto/src/ModeModal.tsx
@@ -1,4 +1,5 @@
 import { type Component, createSignal, For, Show } from "solid-js";
+import { createBackdropDismiss } from "./lib/backdropDismiss";
 import { ownHoldsChannelEditorSigil } from "./lib/channelEditPerm";
 import { channelKey } from "./lib/channelKey";
 import { type AvailableMode, availableModes, sanitizeModeParam } from "./lib/channelModes";
@@ -208,6 +209,12 @@ const ModeModal: Component = () => {
   // close verb the × / backdrop use).
   createOverlayLock(() => modeModalState() !== null, ".mode-modal", closeModeModal);
 
+  // issue 1831 — the scrim dismisses on the press it began, not on any click
+  // that happens to land on it. Bare `/mode` and the TopicBar modes button
+  // call the SAME `openModeModal`; only the first mounted this scrim under a
+  // finger whose synthesised click had not been dispatched yet.
+  const backdropDismiss = createBackdropDismiss(closeModeModal);
+
   return (
     <Show when={target()} keyed>
       {(t) => (
@@ -215,7 +222,8 @@ const ModeModal: Component = () => {
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
         <div
           class="modal-backdrop modal-backdrop-viewport mode-modal-backdrop"
-          onClick={closeModeModal}
+          onPointerDown={backdropDismiss.onPointerDown}
+          onClick={backdropDismiss.onClick}
         >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div

--- a/cicchetto/src/__tests__/BanlistModal.test.tsx
+++ b/cicchetto/src/__tests__/BanlistModal.test.tsx
@@ -41,7 +41,7 @@ vi.mock("../lib/networks", () => ({
 
 import BanlistModal from "../BanlistModal";
 import { setBanlistBundle } from "../lib/banlistCard";
-import { closeBanlistModal, openBanlistModal } from "../lib/banlistModal";
+import { banlistModalState, closeBanlistModal, openBanlistModal } from "../lib/banlistModal";
 
 const BUNDLE = {
   network: "bahamut",
@@ -202,5 +202,62 @@ describe("BanlistModal", () => {
     const modal = screen.getByTestId("banlist-modal");
     expect(modal.textContent).not.toContain("*!*@banned.host");
     expect(modal.textContent).toContain("Loading");
+  });
+
+  // issue 1831 — a modal opened SYNCHRONOUSLY from a compose-line submit
+  // mounts its backdrop under the finger before the browser has dispatched
+  // the tap's synthesised `click`. `banlistCommand` reaches
+  // `openBanlistModal` with no `await` ahead of it, so the backdrop exists by
+  // the time the compat mouse events are hit-tested; they hit-test against
+  // the NEW layout, land on the backdrop, and the dismiss fires in the same
+  // gesture that opened it. Symptom: "the modal is opened and does not
+  // appear". The send button's own click swallow (#925/#1059) cannot help —
+  // it only guards clicks that still reach the BUTTON, and this one does not.
+  //
+  // The cure is the doctrine #925 already applied to that button: activation
+  // rides the POINTER, not the click. A dismiss that never saw the press
+  // which began the interaction is not a dismiss. Structural, not a timing
+  // guard — #1059 already ruled that deferring by a frame "makes the guard
+  // timing-dependent, which is the shape of the bug, not of its remedy".
+  describe("backdrop dismiss is armed by the press, not by the click (issue 1831)", () => {
+    const backdropIn = (container: HTMLElement): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(".banlist-modal-backdrop");
+      if (el === null) throw new Error("no banlist backdrop rendered");
+      return el;
+    };
+
+    it("ignores a click the backdrop never received a pointerdown for", () => {
+      setBanlistBundle("bahamut", BUNDLE);
+      openBanlistModal("bahamut", "#bofh", "b");
+      const { container } = render(() => <BanlistModal />);
+
+      fireEvent.click(backdropIn(container));
+
+      expect(banlistModalState()).not.toBeNull();
+      expect(screen.queryByTestId("banlist-modal")).not.toBeNull();
+    });
+
+    it("still dismisses on a press and release that both land on the backdrop", () => {
+      setBanlistBundle("bahamut", BUNDLE);
+      openBanlistModal("bahamut", "#bofh", "b");
+      const { container } = render(() => <BanlistModal />);
+
+      const backdrop = backdropIn(container);
+      fireEvent.pointerDown(backdrop);
+      fireEvent.click(backdrop);
+
+      expect(banlistModalState()).toBeNull();
+    });
+
+    it("a press that starts INSIDE the dialog does not dismiss on release", () => {
+      setBanlistBundle("bahamut", BUNDLE);
+      openBanlistModal("bahamut", "#bofh", "b");
+      const { container } = render(() => <BanlistModal />);
+
+      fireEvent.pointerDown(screen.getByTestId("banlist-modal"));
+      fireEvent.click(backdropIn(container));
+
+      expect(banlistModalState()).not.toBeNull();
+    });
   });
 });

--- a/cicchetto/src/__tests__/ModeModal.test.tsx
+++ b/cicchetto/src/__tests__/ModeModal.test.tsx
@@ -49,7 +49,7 @@ vi.mock("../lib/api", () => ({
 }));
 
 import { DEFAULT_ISUPPORT, seedIsupport } from "../lib/isupport";
-import { closeModeModal, openModeModal } from "../lib/modeModal";
+import { closeModeModal, modeModalState, openModeModal } from "../lib/modeModal";
 import ModeModal from "../ModeModal";
 
 const KEY = "bahamut #bofh";
@@ -256,6 +256,59 @@ describe("ModeModal", () => {
       expect(getByText("sekret")).toBeTruthy();
       expect(queryByTestId("mode-param-input-k")).toBeNull();
       expect(queryByTestId("mode-param-set-k")).toBeNull();
+    });
+  });
+
+  // issue 1831 — same defect, same cure as BanlistModal: bare `/mode` reaches
+  // `openModeModal` with no `await` ahead of it, so the backdrop is mounted
+  // before the tap's synthesised `click` is hit-tested and that click dismisses
+  // the modal the same gesture opened. This is ALSO the pair the reporter's
+  // own observation splits: the TopicBar modes button calls the very same
+  // `openModeModal` and works, because there the synthesised click is consumed
+  // by the button it was pressed on — the difference is the press target, not
+  // the modal.
+  describe("backdrop dismiss is armed by the press, not by the click (issue 1831)", () => {
+    const backdropIn = (container: HTMLElement): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(".mode-modal-backdrop");
+      if (el === null) throw new Error("no mode backdrop rendered");
+      return el;
+    };
+
+    const openOne = (): void => {
+      mockModes[KEY] = { modes: ["n", "t"], params: {} };
+      mockMembers[KEY] = [{ nick: "vjt-grappa", modes: ["@"] }];
+      openModeModal("bahamut", "#bofh");
+    };
+
+    it("ignores a click the backdrop never received a pointerdown for", () => {
+      openOne();
+      const { container, queryByTestId } = render(() => <ModeModal />);
+
+      fireEvent.click(backdropIn(container));
+
+      expect(modeModalState()).not.toBeNull();
+      expect(queryByTestId("mode-modal")).not.toBeNull();
+    });
+
+    it("still dismisses on a press and release that both land on the backdrop", () => {
+      openOne();
+      const { container } = render(() => <ModeModal />);
+
+      const backdrop = backdropIn(container);
+      fireEvent.pointerDown(backdrop);
+      fireEvent.click(backdrop);
+
+      expect(modeModalState()).toBeNull();
+    });
+
+    it("a press that starts INSIDE the dialog does not dismiss on release", () => {
+      openOne();
+      const { container, getByTestId } = render(() => <ModeModal />);
+
+      fireEvent.pointerDown(getByTestId("mode-modal"));
+      fireEvent.click(backdropIn(container));
+
+      expect(modeModalState()).not.toBeNull();
     });
   });
 });

--- a/cicchetto/src/lib/backdropDismiss.ts
+++ b/cicchetto/src/lib/backdropDismiss.ts
@@ -1,0 +1,78 @@
+import type { JSX } from "solid-js";
+
+// issue 1831 — dismiss-on-backdrop, armed by the PRESS instead of by the click.
+//
+// The bug this exists to make impossible. A modal opened synchronously from
+// the compose line — `/banlist` and bare `/mode` both reach their
+// `open*Modal` with no `await` ahead of them — mounts a full-region backdrop
+// while the finger is still on the send button. A touch dispatches its compat
+// mouse events (`mousedown`, `mouseup`, `click`) AFTER the touch ends, and
+// each is hit-tested against the layout as it stands THEN: the backdrop is
+// already there, so the click lands on it and the dismiss fires in the same
+// gesture that opened the modal. The operator sees nothing happen.
+//
+// The send button cannot defend against this. Its own click swallow
+// (#925/#1059) only guards a click that still reaches the BUTTON, and this
+// one no longer does — the target moved out from under it.
+//
+// Why this shape and not a timer. #1059 already ruled on the alternative, for
+// the twin problem on the button: deferring the guard by a frame "makes the
+// guard timing-dependent, which is the shape of the bug, not of its remedy".
+// A press-armed dismiss is structural — a backdrop that never received the
+// pointerdown beginning the interaction cannot be dismissed by its click,
+// whatever the timing.
+//
+// It is the same doctrine #925 wrote for the send button: ACTIVATION RIDES
+// THE POINTER, NOT THE CLICK. This is the dismissal half of it.
+//
+// A mouse never reproduced the bug and is unaffected by the cure: `mousedown`
+// fires on the button BEFORE the modal opens, so the click resolves to the
+// common ancestor of a button and a backdrop rather than to the backdrop, and
+// a genuine mouse click on the scrim still carries its own pointerdown.
+//
+// Not a singleton: `armed` is per-backdrop interaction state, so each modal
+// calls this once for its own scrim.
+//
+// Spread the pair at your peril — pass the two handlers as explicit props.
+// `{...dismiss}` compiles and behaves identically, but biome then cannot see
+// a click handler on the element and quietly retires the `a11y` suppressions
+// the scrim carries (measured: four `suppressions/unused` the moment the
+// literal `onClick` left the JSX). Losing a lint by accident is the sort of
+// thing that is only ever noticed much later.
+export type BackdropDismiss = {
+  onPointerDown: JSX.EventHandler<HTMLDivElement, PointerEvent>;
+  onClick: JSX.EventHandler<HTMLDivElement, MouseEvent>;
+};
+
+export const createBackdropDismiss = (close: () => void): BackdropDismiss => {
+  let armed = false;
+
+  return {
+    // The target test lives HERE and not on the click, and the asymmetry is
+    // measured rather than stylistic. A dialog inside the scrim stops the
+    // CLICK from bubbling but not the POINTERDOWN, so a press that begins
+    // inside the modal reaches this handler with `target` set to the dialog:
+    // assignment (never `||=`) DISARMS on it, which is also what makes a drag
+    // begun inside the modal and released over the scrim harmless. That is
+    // the same "released inside" discipline the send button hit-tests for.
+    onPointerDown: (e) => {
+      armed = e.target === e.currentTarget;
+    },
+    // Always disarm, dismiss only if this click completes an interaction the
+    // backdrop itself began. Clearing unconditionally means an aborted press
+    // cannot leave the scrim primed for the next stray click.
+    //
+    // No target test on this side: the arming already subsumes it. An inner
+    // click can only arrive here having been preceded by an inner press,
+    // which disarmed — so the guard would hold even for a dialog that forgot
+    // its own `stopPropagation`. Kept honest by measurement, not by taste:
+    // adding `&& e.target === e.currentTarget` back is a mutant no test in
+    // this suite can kill (34/34 still green with it), and untestable
+    // defensive code is the shape that hides the next bug.
+    onClick: () => {
+      const beganHere = armed;
+      armed = false;
+      if (beganHere) close();
+    },
+  };
+};

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43100,3 +43100,88 @@ immediately — "never pause" written that way pauses every channel the instant
 it blurs. The kill has to be a branch that never arms the window. Both #1848
 arms would catch that mutant; both were also confirmed to die when the flag is
 flipped back on, so neither is a mirror.
+<!-- entry #1831b -->
+
+---
+
+## 2026-08-28 — #1831b: a backdrop dismiss rides the press, not the click
+
+The device probes on issue 1831 killed all three candidates in the issue body
+and left one state standing: **the modal is opened and does not appear.**
+`/dio` prints `unknown command` in the installed PWA, so the compose error
+banner is visible there; `banlistCommand`'s three failure arms each return an
+`{error}`, so an error would have been seen; none was, therefore the handler
+ran to its end and called `openBanlistModal`.
+
+### The mechanism
+
+`banlistCommand` and `modeViewCommand` are `async`, but neither has an `await`
+ahead of its `open*Modal` call, and neither does the `submit` chain that
+reaches them from the compose form. An async function runs synchronously to
+its first `await`, so **the backdrop is in the DOM before the browser has
+dispatched the tap's compat mouse events.** Those are synthesised after the
+touch ENDS and hit-tested against the layout as it stands then — the scrim,
+which is `position: fixed; top: 0` with `height: var(--viewport-height)`, i.e.
+covering the keyboard-aware visible region the send button sits in. The click
+lands on the backdrop, whose `onClick` was `close*Modal`, and the modal is
+dismissed by the same gesture that opened it.
+
+The send button cannot defend against this, and the reason is worth keeping:
+its click swallow (#925/#1059) guards a click that still reaches the BUTTON.
+This one does not — the target moved out from under it while the finger was
+down. That is also why the TopicBar modes button works while bare `/mode`
+does not, calling the very same `openModeModal`: there the synthesised click
+is consumed by the button that was pressed, because no scrim mounted over it.
+
+### The cure, and why not a timer
+
+`lib/backdropDismiss.ts` — `createBackdropDismiss(close)` returns the
+`onPointerDown`/`onClick` pair a scrim spreads onto itself. The press arms;
+the click dismisses only if it completes an interaction the backdrop itself
+began. A ghost click carries no press on the scrim, so it cannot dismiss.
+
+This is #925's doctrine applied to the dismissal half: **activation rides the
+POINTER, not the click.** A frame's deferral was available and is deliberately
+not what shipped — #1059 already ruled on that shape for the twin problem on
+the button, "it makes the guard timing-dependent, which is the shape of the
+bug, not of its remedy". Press-arming is structural and holds at any timing.
+
+### What the mutants settled, including one that changed the code
+
+Three mutations, scoped to the two suites (34 tests):
+
+| mutant | result |
+|---|---|
+| `armed = true` (drop the pointerdown target test) | **2 failed** — load-bearing |
+| dismiss without consulting `armed` | **4 failed**, exactly the pre-cure red |
+| drop `&& e.target === e.currentTarget` from the click | **34/34 still green** |
+
+The third **survived**, so the clause came out rather than acquiring a test
+written to justify it. Measuring why it survived is the useful part: the
+arming already subsumes it, since an inner click can only arrive having been
+preceded by an inner press, which disarmed. The target test is needed on the
+POINTERDOWN and only there — a dialog stops the click from bubbling but not
+the pointerdown, so a press inside the modal does reach the scrim's handler
+and must disarm it. Untestable defensive code is the shape that hides the
+next bug; the asymmetry is now a comment instead of a dead conjunct.
+
+### What this does NOT explain, and is not claimed to
+
+The reporter says the same commands work in a normal browser tab on the same
+device. **This mechanism is touch-specific, not standalone-specific**, so on
+its own it predicts both surfaces failing. Nobody has established that the
+same GESTURE was used on both (an on-screen Enter is a keydown and synthesises
+no click at all, and would work on either surface). The asymmetry is therefore
+an open residual, not something the cure accounts for.
+
+`(display-mode: standalone)` remains non-emulable in Playwright — measured
+against `playwright-core@1.62.1`'s `emulateMedia`, which accepts exactly
+`{colorScheme, contrast, forcedColors, media, reducedMotion}`, with
+`colorScheme` as the positive control. The touch axis, unlike the standalone
+one, IS reachable locally: a real browser with `hasTouch` synthesises the
+click this entry turns on. That proof is not in this change — the jsdom tests
+dispatch the sequence rather than provoke it, so they pin the CURE's contract
+and not the platform behaviour that makes it necessary.
+
+Applied to `BanlistModal` and `ModeModal`, the two the issue names. Fourteen
+other scrims carry the same `onClick={close}` shape and are untouched here.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43183,5 +43183,80 @@ click this entry turns on. That proof is not in this change — the jsdom tests
 dispatch the sequence rather than provoke it, so they pin the CURE's contract
 and not the platform behaviour that makes it necessary.
 
-Applied to `BanlistModal` and `ModeModal`, the two the issue names. Fourteen
-other scrims carry the same `onClick={close}` shape and are untouched here.
+### The defect is a CLASS, and this fixes two of it — deliberately
+
+Sixteen production components mount a scrim that dismisses on a bare click.
+Measured, not estimated, over `cicchetto/src`:
+
+```
+for f in $(grep -rl "modal-backdrop" --include='*.tsx' . | grep -v __tests__); do
+  grep -A3 "modal-backdrop" "$f" | grep -q "onClick=" && echo "$f"
+done            # → 16 files
+```
+
+`ArchiveModal`, `BanlistModal`, `ConfirmModal`, `DeleteAccountModal`,
+`LinksModal`, `ModeModal`, `NamesModal`, `PrivacyModal`, `RecoverModal`,
+`RegistrationWizardModal`, `ServerReplyModal`, `ServiceModal`,
+`ShareSessionModal`, `TopicBar`, `UmodeModal`, `WhoModal`. Every one of them
+is dismissable by a click it never saw the press for; only the two that the
+issue names are cured here.
+
+**So the tree now carries two patterns, and that is a decision rather than an
+oversight.** CLAUDE.md's own "total consistency or nothing" says half-migrated
+is worse than untouched, and the cost is accepted with that read in view: the
+sweep is a CLASS change and this is a bug fix, and folding sixteen components
+into it would leave a reviewer unable to tell the cure from the sweep.
+
+The sweep is the right end state, and it is not free. Three existing suites
+assert today that a bare click dismisses — `ArchiveModal.test.tsx`,
+`ConfirmModal.test.tsx`, `DeleteAccountModal.test.tsx`, each firing
+`fireEvent.click(backdrop)` with no press before it. Those are not collateral;
+each is a decision about what its scrim should do, and they are owed one at a
+time rather than in the tail of somebody else's cure. (`MediaViewerModal`,
+`SettingsDrawer` and `UserContextMenu` also click a backdrop in their tests
+and are NOT in the sixteen — their scrims are a different shape, `role=button`
+or a drawer. An earlier count of "four" here was mine and was wrong; the
+tighter measure above is what stands.)
+
+### A real engine was asked, and it answered — after the first instrument lied
+
+`e2e/tests/issue1831-tap-send-modal-survives.spec.ts` puts the question to a
+browser instead of to jsdom, as a discriminating PAIR: the same `/banlist`, in
+the same window, sent once with ENTER and once by TAPPING the send button.
+Enter synthesises no click and is green on both sides of the cure; the tap is
+the arm the defect owns. Everything but the GESTURE is held fixed.
+
+Measured on `chromium-pixel-touch`, against the PRE-CURE code, recording every
+event at the document in capture phase:
+
+```
+pointerdown -> polygon              (the send button's arrow glyph)
+touchstart  -> polygon
+pointerup   -> polygon
+mousedown   -> div.modal-backdrop   <- the scrim, mounted during pointerup
+mouseup     -> div.modal-backdrop
+click       -> div.modal-backdrop
+banlist modal count: 0
+```
+
+The press lands on the button and the click lands on the SCRIM. The pair then
+reads pre-cure **Enter ✓ / tap ✘** (rc=1) and post-cure **✓ ✓** (rc=0), so the
+spec is a regression pin and not a mirror.
+
+🔴 **The first instrument was the wrong one, and it produced a green that
+meant nothing.** This was run first on `webkit-iphone-15`, the config's
+existing touch project, and BOTH arms passed with the cure removed. The same
+probe explains why: there a `tap()` dispatches `pointerdown / touchstart /
+pointerup` and stops — no touchend, no mousedown, no mouseup, **no click at
+all**. Playwright's injected touch produces no compat mouse events on that
+engine, so a question about what a synthesised click hits is unanswerable
+there and goes green whatever the code does. **A green from an instrument that
+cannot express the defect is not weak evidence, it is none** — and had the
+run stopped at "2 passed" it would have been reported as the cure being
+unnecessary. Hence the third project, `grep: /@touch/`-scoped so it does not
+re-run the suite, with the desktop project's `grepInvert` widened to match.
+
+Platform limit, stated rather than buried: the reported device is Android
+**Firefox** and this is Blink. Playwright's firefox does not support touch
+emulation, so Gecko is not reachable from this harness. What is established is
+that an engine does this, and which gesture does it — not that Gecko does.


### PR DESCRIPTION
Issue 1831 — the slice the device probes made possible.

## What the probes settled, and what was left

The two probe comments killed all three candidates in the issue body. `/dio`
prints `unknown command` in the installed PWA, so the compose error banner is
visible in standalone; `banlistCommand`'s three failure arms each return an
`{error}`; none was seen. The handler therefore ran to its end and called
`openBanlistModal`. One state was left standing: **the modal is opened and
does not appear.**

## The mechanism

Neither `banlistCommand` nor `modeViewCommand` has an `await` ahead of its
`open*Modal`, and neither does the `submit` chain that reaches them from the
compose form. An async function runs synchronously to its first `await`, so
the scrim is in the DOM before the browser dispatches the tap's compat mouse
events. Those are synthesised after the touch ENDS and hit-tested against the
layout as it stands then — `.modal-backdrop` is `position: fixed; top: 0`
with `height: var(--viewport-height)`, i.e. covering the keyboard-aware
region the send button sits in. The click lands on the scrim, whose `onClick`
was the close verb, and the modal is dismissed by the gesture that opened it.

The send button cannot defend against this: its click swallow (#925/#1059)
guards a click that still reaches the BUTTON, and this one no longer does.
That is also why TopicBar's modes button works while bare `/mode` does not,
calling the very same `openModeModal` — there the synthesised click is
consumed by the button that was pressed, because no scrim mounted over it.

## Measured on a real engine, not argued

`e2e/tests/issue1831-tap-send-modal-survives.spec.ts`. Recording every event
at the document in capture phase, tapping send with `/banlist` typed, against
the PRE-CURE code on chromium + touch:

```
pointerdown -> polygon              (the send button's arrow glyph)
touchstart  -> polygon
pointerup   -> polygon
mousedown   -> div.modal-backdrop   <- the scrim, mounted during pointerup
mouseup     -> div.modal-backdrop
click       -> div.modal-backdrop
banlist modal count: 0
```

The press lands on the button, the click lands on the scrim, the modal is
gone. The spec is a discriminating PAIR — the same `/banlist` sent with ENTER
and with a TAP, so the only variable is the gesture:

| | pre-cure | post-cure |
|---|---|---|
| Enter (control) | ✓ | ✓ |
| Tap send | **✘** | ✓ |
| run rc | 1 | 0 |

🔴 **The first instrument was the wrong one and produced an empty green.**
Run first on `webkit-iphone-15`, the config's existing touch project, both
arms passed *with the cure removed*. The probe says why: there a `tap()`
dispatches `pointerdown / touchstart / pointerup` and stops — no touchend, no
mousedown, no mouseup, no click at all. Playwright's injected touch produces
no compat mouse events on that engine, so the question is unanswerable there
and goes green whatever the code does. Stopping at "2 passed" would have
reported the cure as unnecessary. Hence a third project, `grep: /@touch/`-
scoped so it does not re-run the suite.

**Platform limit, stated not buried:** the reported device is Android
FIREFOX; this is Blink. Playwright's firefox has no touch emulation, so Gecko
is not reachable from this harness. Established: an engine does this, and
which gesture does it. Not established: that Gecko does.

## The cure

`lib/backdropDismiss.ts` — the press arms the scrim, and a click dismisses
only if it completes an interaction the scrim itself began. It is #925's own
doctrine applied to the dismissal half: activation rides the POINTER, not the
click. Structural rather than a timing guard, because #1059 already ruled on
that alternative for the twin problem: deferring by a frame "makes the guard
timing-dependent, which is the shape of the bug, not of its remedy".

## Mutation results

Three mutants against the two unit suites (34 tests):

| mutant | result |
|---|---|
| `armed = true` (drop the pointerdown target test) | 2 failed — load-bearing |
| dismiss without consulting `armed` | 4 failed, exactly the pre-cure red |
| drop the click-side target test | **34/34 still green — survived** |

The survivor came OUT rather than acquiring a test written to justify it: the
arming already subsumes it, since an inner click can only arrive preceded by
an inner press, which disarmed. The target test is needed on the pointerdown
and only there, because a dialog stops the click bubbling but not the
pointerdown.

Related, found by the same measurement: spreading the handler pair retires
biome's a11y suppressions on the scrim (four `suppressions/unused` the moment
the literal `onClick` left the JSX), so the handlers are passed as explicit
props and the lint posture is unchanged.

## The defect is a CLASS, and this fixes two of it — deliberately

Sixteen production components mount a scrim that dismisses on a bare click.
Measured over `cicchetto/src`, not estimated:

```
for f in $(grep -rl "modal-backdrop" --include='*.tsx' . | grep -v __tests__); do
  grep -A3 "modal-backdrop" "$f" | grep -q "onClick=" && echo "$f"
done            # → 16 files
```

`ArchiveModal`, `BanlistModal`, `ConfirmModal`, `DeleteAccountModal`,
`LinksModal`, `ModeModal`, `NamesModal`, `PrivacyModal`, `RecoverModal`,
`RegistrationWizardModal`, `ServerReplyModal`, `ServiceModal`,
`ShareSessionModal`, `TopicBar`, `UmodeModal`, `WhoModal`.

**This PR cures 2 — the two the issue names — so the tree now carries two
patterns, and that is a decision rather than an oversight.** CLAUDE.md's own
"total consistency or nothing" says half-migrated is worse than untouched;
the cost is accepted with that read in view, because the sweep is a CLASS
change and folding sixteen components into a bug fix would leave a reviewer
unable to tell the cure from the sweep.

The sweep is the right end state and it is not free: three existing suites
assert today that a bare click dismisses — `ArchiveModal.test.tsx`,
`ConfirmModal.test.tsx`, `DeleteAccountModal.test.tsx` — and each is a
decision about what its scrim should do, owed one at a time. (`MediaViewerModal`,
`SettingsDrawer` and `UserContextMenu` also click a backdrop in their tests
and are NOT among the sixteen; an earlier count of "four" was mine and was
wrong.)

## What this still does NOT claim

The reporter says the same commands work in a normal browser tab on the same
device. The mechanism is **gesture-specific, not standalone-specific**, so on
its own it predicts both surfaces failing for a tap and neither failing for
an Enter. Nobody has established which gesture was used on each surface. The
pair above is the local evidence that the gesture ALONE splits the outcome;
the asymmetry itself remains an open residual, recorded as such in
DESIGN_NOTES rather than papered over.

## Gates, rc read from a file

| gate | rc | detail |
|---|---|---|
| `bun.sh run check` | 0 | 5/5 stages, incl. stage 1 lock drift |
| `bun.sh run test` | 0 | 327 files, 6512 tests |
| e2e `--project chromium-pixel-touch --grep "issue 1831"` | 0 | 2 passed; **1 failed / 1 passed pre-cure** |
| `design-notes-gate.sh` | 0 | `1 new entry heading(s), separator and marker present` |
| `union-rebase.sh` | 0 | `+85 -0 — contribution intact` |