### PR TITLE
cic: give the iOS callout latch a synchronous exit at the gesture door (issue 1857)

### DIFF
--- a/cicchetto/src/__tests__/messageContextMenu.test.ts
+++ b/cicchetto/src/__tests__/messageContextMenu.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { bindMessageContextMenu } from "../lib/messageContextMenu";
+import { disarmMessageSelection, SELECTING_CLASS } from "../lib/messageMenu";
 
 // #1115 — the scrollback's DESKTOP door to the message menu. #1067 gave the
 // menu one opener, a touch long-press, so a mouse user got the browser's own
@@ -44,6 +45,7 @@ beforeEach(() => {
 afterEach(() => {
   dispose();
   document.body.innerHTML = "";
+  disarmMessageSelection(); // issue 1857 — the latch is <html>, outside <body>
   vi.restoreAllMocks(); // the live-selection test spies on window.getSelection
 });
 
@@ -128,6 +130,45 @@ describe("bindMessageContextMenu — what it refuses to claim", () => {
     stubSelection(true);
     rightClick(body, 412, 268);
     expect(onContextMenu).toHaveBeenCalledTimes(1);
+  });
+});
+
+// issue 1857 — the same stale latch the touch door disarms. This door is not
+// mouse-only in practice: `lib/platform.ts` puts `is-ios` on iPadOS in
+// desktop-mode too (the `Mac` UA + `maxTouchPoints > 0` clause), and an iPad
+// trackpad's secondary click arrives here as `contextmenu`. A door that opens
+// the menu without ending the latch leaves the callout up over the whole
+// scrollback for the next press.
+describe("bindMessageContextMenu — a stale callout re-enable (issue 1857)", () => {
+  it("lifts it when no selection is live any more", () => {
+    document.documentElement.classList.add(SELECTING_CLASS);
+    stubSelection(true);
+
+    rightClick(body, 412, 268);
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+  });
+
+  // Same carve-out as the touch door: a live selection is what the re-enable
+  // is FOR, and this door is standing down to the browser's own menu over it.
+  it("keeps it armed while a selection is live", () => {
+    document.documentElement.classList.add(SELECTING_CLASS);
+    stubSelection(false);
+
+    rightClick(body, 412, 268);
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(true);
+  });
+
+  it("lifts it on a right-click we hand straight back (a link)", () => {
+    document.documentElement.classList.add(SELECTING_CLASS);
+    stubSelection(true);
+
+    const e = rightClick(link, 100, 100);
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+    expect(onContextMenu).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
   });
 });
 

--- a/cicchetto/src/__tests__/messageGestures.test.ts
+++ b/cicchetto/src/__tests__/messageGestures.test.ts
@@ -9,6 +9,7 @@ import {
   SWIPE_MAX_SLIDE_PX,
   SWIPING_CLASS,
 } from "../lib/messageGestures";
+import { disarmMessageSelection, SELECTING_CLASS } from "../lib/messageMenu";
 import { fireTouch } from "./helpers/touchEvents";
 
 // #1067 — the scrollback's ONE touch-gesture owner: a left→right swipe on a
@@ -78,6 +79,7 @@ beforeEach(() => {
 afterEach(() => {
   dispose();
   document.body.innerHTML = "";
+  disarmMessageSelection(); // issue 1857 — the latch is <html>, outside <body>
   vi.restoreAllMocks(); // the live-selection test spies on window.getSelection
   vi.useRealTimers();
 });
@@ -279,6 +281,89 @@ describe("bindMessageGestures — long press = message menu", () => {
     dispose();
     vi.advanceTimersByTime(LONG_PRESS_MS + 100);
     expect(onLongPress).not.toHaveBeenCalled();
+  });
+});
+
+// issue 1857 — `Select…` lifts `html.is-ios`'s blanket `-webkit-touch-callout:
+// none` over the whole `.scrollback` and takes it back on the first
+// `selectionchange` that finds the selection gone. That event is QUEUED as a
+// task, so on the touch that ends the selection it lands AFTER touch-down —
+// and touch-down is when WebKit reads the property to decide whether to run
+// its own long-press selection UI. The reported frame is both menus at once:
+// iOS's callout bar over a stale range plus ours over the row just pressed.
+//
+// So the latch has a second, SYNCHRONOUS exit, taken here at the top of the
+// gesture. jsdom proves the disarm — class gone, watcher detached, and the
+// escape hatch below still intact. It does NOT prove that WebKit re-reads
+// `-webkit-touch-callout` after `touchstart` and therefore suppresses its own
+// callout for THIS gesture: jsdom has no CSS engine and Playwright webkit does
+// not render iOS selection UI, the same limit #1067 and default.css declare.
+describe("bindMessageGestures — a stale callout re-enable (issue 1857)", () => {
+  function armLatch(): void {
+    document.documentElement.classList.add(SELECTING_CLASS);
+  }
+
+  function stubSelection(collapsed: boolean): void {
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: collapsed,
+      toString: () => (collapsed ? "" : "some selected text"),
+    } as unknown as Selection);
+  }
+
+  it("lifts it at touch-down when no selection is live any more", () => {
+    armLatch();
+    stubSelection(true);
+
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+  });
+
+  // Not "when the menu opens": the 500ms have not run yet, and by the time they
+  // have, WebKit's own recogniser has long since read the property.
+  it("lifts it at touch-down, not when the menu finally opens", () => {
+    armLatch();
+    stubSelection(true);
+
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+  });
+
+  // THE carve-out. A live selection is the operator dragging the grab handles
+  // the re-enable exists to give them; disarming there would suppress the
+  // callout mid-adjustment and take the escape hatch away.
+  it("keeps it armed while a selection is still live", () => {
+    armLatch();
+    stubSelection(false);
+
+    fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(true);
+  });
+
+  // The latch is on <html> and iOS's callout is on the whole `.scrollback`, so
+  // a stale one is stale wherever the finger lands. A press that arms nothing
+  // — an inline control, a stray node, an edge zone — still ends it.
+  it("lifts it on a touch that arms no gesture at all (inline control)", () => {
+    armLatch();
+    stubSelection(true);
+
+    fireTouch(link, "touchstart", { clientX: CENTER_X, clientY: 300 });
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+    vi.advanceTimersByTime(LONG_PRESS_MS + 100);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("lifts it on a touch in the edge zone #1041 owns", () => {
+    armLatch();
+    stubSelection(true);
+
+    fireTouch(body, "touchstart", { clientX: 5, clientY: 300 });
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
   });
 });
 

--- a/cicchetto/src/__tests__/messageMenu.test.ts
+++ b/cicchetto/src/__tests__/messageMenu.test.ts
@@ -5,6 +5,7 @@ import {
   closeMessageMenu,
   copyMessageRow,
   copyToasts,
+  disarmMessageSelection,
   dismissCopyToast,
   messageMenu,
   openMessageMenu,
@@ -43,6 +44,10 @@ beforeEach(() => {
   document.body.innerHTML = "";
   document.documentElement.className = "";
   closeMessageMenu();
+  // The latch is module state, not DOM state: a test that armed it and never
+  // saw its selection die leaves a `selectionchange` watcher on the document
+  // for the next one. Clearing the class alone would not detach it.
+  disarmMessageSelection();
   for (const t of copyToasts()) dismissCopyToast(t.id);
 });
 
@@ -234,5 +239,83 @@ describe("selectMessageText", () => {
     expect(selectMessageText(row)).toBe(true);
     expect(addRange).toHaveBeenCalledTimes(1);
     expect(ranges[0]?.commonAncestorContainer).toBe(row);
+  });
+});
+
+// issue 1857 — the latch's SECOND exit. `selectionchange` is queued as a task,
+// so it disarms after the gesture that needed the callout suppressed has
+// already begun; the gesture doors take this one instead, synchronously.
+describe("disarmMessageSelection", () => {
+  function stubSelection(text: string): Selection {
+    const stub = {
+      removeAllRanges: vi.fn(),
+      addRange: vi.fn(),
+      toString: () => text,
+      isCollapsed: text === "",
+    } as unknown as Selection;
+    vi.spyOn(window, "getSelection").mockReturnValue(stub);
+    return stub;
+  }
+
+  it("lifts the callout re-enable that Select… armed", () => {
+    stubSelection("12:34 <vjt> ciao");
+    selectMessageText(scrollbackRow("12:34 <vjt> ciao"));
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(true);
+
+    disarmMessageSelection();
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+  });
+
+  // The callers reach it only past their own `selection.isCollapsed` guard, so
+  // there is no range left to drop and a `removeAllRanges()` here could only
+  // land on a caret — including one the compose field owns. That is the exact
+  // blur/focus/selection interaction #1106 and #79 paid for; the disarm buys
+  // the class back and nothing else.
+  it("leaves the selection itself untouched", () => {
+    const selection = stubSelection("");
+    document.documentElement.classList.add(SELECTING_CLASS);
+
+    disarmMessageSelection();
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+    expect(selection.removeAllRanges).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when nothing armed it", () => {
+    stubSelection("");
+    expect(() => {
+      disarmMessageSelection();
+    }).not.toThrow();
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
+  });
+
+  // One latch ⇒ one watcher. Every Select… used to add a `selectionchange`
+  // listener that only the FIRING one ever removed, so a session that selected
+  // repeatedly accumulated them on the document.
+  it("keeps exactly one selectionchange watcher across repeated Select…", () => {
+    const add = vi.spyOn(document, "addEventListener");
+    const remove = vi.spyOn(document, "removeEventListener");
+    stubSelection("12:34 <vjt> ciao");
+    const row = scrollbackRow("12:34 <vjt> ciao");
+
+    selectMessageText(row);
+    selectMessageText(row);
+    selectMessageText(row);
+
+    const attached =
+      add.mock.calls.filter(([type]) => type === "selectionchange").length -
+      remove.mock.calls.filter(([type]) => type === "selectionchange").length;
+    expect(attached).toBe(1);
+  });
+
+  it("still disarms on the selectionchange that finds the selection gone", () => {
+    stubSelection("12:34 <vjt> ciao");
+    selectMessageText(scrollbackRow("12:34 <vjt> ciao"));
+    stubSelection("");
+
+    document.dispatchEvent(new Event("selectionchange"));
+
+    expect(document.documentElement.classList.contains(SELECTING_CLASS)).toBe(false);
   });
 });

--- a/cicchetto/src/lib/messageContextMenu.ts
+++ b/cicchetto/src/lib/messageContextMenu.ts
@@ -24,6 +24,7 @@
 // the exclude below).
 import { SELECTABLE_TEXT_EXCLUDE } from "./keepKeyboard";
 import { MESSAGE_ROW_SELECTOR } from "./messageGestures";
+import { disarmMessageSelection } from "./messageMenu";
 import type { Point } from "./swipe";
 
 export type MessageContextMenuParams = {
@@ -37,13 +38,6 @@ export function bindMessageContextMenu(
   const onContextMenu = (e: MouseEvent): void => {
     const target = e.target instanceof Element ? e.target : null;
     if (target === null) return;
-    // The inline controls own their own right-click: the nick opens
-    // UserContextMenu, and a link's native menu (open in new tab, copy link
-    // address) beats anything we could offer. The SAME exclude the touch owner
-    // and keepKeyboard use, so the three policies cannot drift. Returning
-    // WITHOUT preventDefault is load-bearing — the nick's Solid-delegated
-    // handler runs after us and must inherit a live event.
-    if (target.closest(SELECTABLE_TEXT_EXCLUDE) !== null) return;
     // A live selection means the operator wants the browser's own copy /
     // search / spellcheck menu over that selection — the same stand-down the
     // touch owner takes mid-selection. Deliberately ANY live selection, not
@@ -51,6 +45,25 @@ export function bindMessageContextMenu(
     // and "covers the cursor" is not something the platforms agree on.
     const selection = window.getSelection();
     if (selection !== null && !selection.isCollapsed) return;
+    // issue 1857 — and past that stand-down, a callout re-enable still latched
+    // on <html> is stale. This door is not mouse-only in practice: `platform.ts`
+    // puts `is-ios` on iPadOS in desktop-mode, where a trackpad's secondary
+    // click arrives here, so a stale latch left by this door is the same
+    // two-menus-for-one-press the touch owner disarms against.
+    //
+    // Ahead of the exclude below — and that is why the selection stand-down
+    // moved above it — for the touch owner's reason: the latch is a
+    // document-level fact and the callout it lifts covers the whole
+    // scrollback, so a press we hand straight back still ends it. Both guards
+    // are side-effect-free early returns, so their order is free.
+    disarmMessageSelection();
+    // The inline controls own their own right-click: the nick opens
+    // UserContextMenu, and a link's native menu (open in new tab, copy link
+    // address) beats anything we could offer. The SAME exclude the touch owner
+    // and keepKeyboard use, so the three policies cannot drift. Returning
+    // WITHOUT preventDefault is load-bearing — the nick's Solid-delegated
+    // handler runs after us and must inherit a live event.
+    if (target.closest(SELECTABLE_TEXT_EXCLUDE) !== null) return;
     const row = target.closest<HTMLElement>(MESSAGE_ROW_SELECTOR);
     if (row === null) return;
     e.preventDefault();

--- a/cicchetto/src/lib/messageGestures.ts
+++ b/cicchetto/src/lib/messageGestures.ts
@@ -26,6 +26,7 @@
 // a function ref with undefined at unmount the way React does — #308 landmine
 // 3 — so cleanup is explicit).
 import { LONG_PRESS_MS, SELECTABLE_TEXT_EXCLUDE } from "./keepKeyboard";
+import { disarmMessageSelection } from "./messageMenu";
 import { type Point, swipeDirection } from "./swipe";
 import { horizontalClaim, touchZone } from "./touchGesture";
 
@@ -133,6 +134,16 @@ export function bindMessageGestures(el: HTMLElement, params: MessageGestureParam
     // until the selection is dismissed.
     const selection = window.getSelection();
     if (selection !== null && !selection.isCollapsed) return;
+    // issue 1857 — past that stand-down there is provably no selection, so a
+    // callout re-enable still latched on <html> is stale and covers the WHOLE
+    // scrollback. Release it HERE, at touch-down: `selectMessageText`'s own
+    // `selectionchange` disarm is queued as a task and lands after WebKit has
+    // already read the property for this gesture, which is how the reported
+    // frame ends up with iOS's callout bar and our menu up together.
+    //
+    // Before the excludes and the zone check on purpose: the latch is a
+    // document-level fact, so a press that arms nothing still ends it.
+    disarmMessageSelection();
     // The inline controls (#350 link, #354 nick, #648 channel, the [Join] CTA)
     // already own their own press meaning — the same exclude keepKeyboard uses,
     // so the two policies cannot drift.

--- a/cicchetto/src/lib/messageMenu.ts
+++ b/cicchetto/src/lib/messageMenu.ts
@@ -65,6 +65,34 @@ export async function copyMessageRow(row: HTMLElement): Promise<void> {
 // would race iOS's own selection UI against this menu.
 export const SELECTING_CLASS = "is-selecting";
 
+// The detach for the `selectionchange` watcher `selectMessageText` installs.
+// Module scope for two reasons: the latch is ONE class on ONE <html>, so a
+// second watcher for it is a leak by construction; and the disarm below has to
+// be reachable from outside the closure that armed it.
+let detachSelectionWatch: (() => void) | null = null;
+
+// issue 1857 — the latch's SECOND exit, and the one the gesture doors take.
+//
+// The `selectionchange` disarm inside `selectMessageText` is queued as a task,
+// so on the touch that ends a selection it lands AFTER touch-down — and
+// touch-down is when WebKit reads `-webkit-touch-callout` to decide whether to
+// run its own long-press selection UI. The reported symptom is both menus at
+// once: iOS's callout bar over the stale range and ours over the row just
+// pressed. A latch that can only be released asynchronously cannot be released
+// in time, so the doors release it themselves, synchronously, at the top of
+// the gesture.
+//
+// It does NOT touch the selection. Every caller reaches it only past its own
+// `selection.isCollapsed` stand-down, so there is no range left to drop, and a
+// `removeAllRanges()` there could only land on a caret — including one the
+// compose field owns, which is precisely the blur/focus/selection interaction
+// #1106 and #79 paid for. Idempotent: with nothing armed it is a no-op.
+export function disarmMessageSelection(): void {
+  detachSelectionWatch?.();
+  detachSelectionWatch = null;
+  document.documentElement.classList.remove(SELECTING_CLASS);
+}
+
 // Hand the operator a real, adjustable native selection over the row and get
 // out of the way. Returns whether a selection could be installed.
 //
@@ -97,16 +125,23 @@ export function selectMessageText(row: HTMLElement): boolean {
   range.selectNodeContents(row);
   selection.removeAllRanges();
   selection.addRange(range);
+  // One latch, one watcher (issue 1857). A second Select… while the first
+  // selection is still live used to stack another listener on the document —
+  // only the one that FIRED ever detached itself, so a session that selected
+  // repeatedly accumulated them.
+  disarmMessageSelection();
   document.documentElement.classList.add(SELECTING_CLASS);
   // Disarm the moment the operator is done. Without this the callout stays up
   // for the rest of the session and the next hold anywhere in the scrollback
-  // pops iOS's own menu over ours.
+  // pops iOS's own menu over ours. This is the LATE exit — see
+  // `disarmMessageSelection` for why the gesture doors cannot wait for it.
   const onSelectionChange = (): void => {
     const live = window.getSelection();
     if (live !== null && live.toString() !== "") return;
-    document.documentElement.classList.remove(SELECTING_CLASS);
-    document.removeEventListener("selectionchange", onSelectionChange);
+    disarmMessageSelection();
   };
   document.addEventListener("selectionchange", onSelectionChange);
+  detachSelectionWatch = (): void =>
+    document.removeEventListener("selectionchange", onSelectionChange);
   return true;
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43517,3 +43517,99 @@ now the cic side end to end from a RAW wire payload through the real
 `narrowIsupportChanged` → `isupportEntryFromWire` → `seedIsupport` →
 `casemappingForNetwork` → `nickEquals` (`isupport.test.ts`). What is untested
 is the wire between them, on a live rfc1459 session.
+<!-- entry #1857 -->
+
+---
+
+## 2026-08-29 — #1857: a latch that can only be released asynchronously cannot be released in time
+
+`html.is-ios` kills `-webkit-touch-callout` across the app, and #1067 bought it
+back for the duration of one selection: `selectMessageText` puts `is-selecting`
+on `<html>`, `default.css` pairs that class with `-webkit-touch-callout:
+default` on `.scrollback`, and a `selectionchange` listener takes it away again
+on the first event that finds the selection gone. That comment already named
+the failure mode of a latch outliving its selection — *"the next hold anywhere
+in the scrollback pops iOS's own menu over ours"* — and an iPhone-PWA frame
+reported exactly it: our menu over one row, iOS's callout bar over a live range
+on another.
+
+### The mechanism is a RACE, not a leak — and that decides WHERE the cure goes
+
+The report reads the cause as the app menu opening *"without necessarily
+collapsing the existing range"*. Measured against the code, it cannot: BOTH
+doors to that menu stand down on `!selection.isCollapsed` — `onStart` in
+`lib/messageGestures.ts` and the handler in `lib/messageContextMenu.ts`. While
+the DOM reports a live selection our menu does not open at all.
+
+What is left is a race. WebKit collapses the old selection at touch-down, so
+our `touchstart` handler correctly sees `isCollapsed`; the `selectionchange`
+that would strip the class is QUEUED as a task and lands afterwards; and
+touch-down is when WebKit reads `-webkit-touch-callout` to decide whether to
+run its own long-press selection UI. The property is therefore still `default`
+for the recogniser that is starting, and `LONG_PRESS_MS` later our own menu
+opens on top of what it produced.
+
+That distinction is not pedantry — it rules out the call site the report
+suggests. Disarming from the long-press HANDLER, i.e. when the menu opens, runs
+a full 500 ms after the property was read. The disarm belongs at the TOP of the
+gesture, in the door, which is the earliest moment JavaScript hears about the
+touch at all.
+
+### `disarmMessageSelection()` deliberately does not touch the selection
+
+The shape proposed was `getSelection()?.removeAllRanges()` plus the class
+removal. The range half is dropped. Every caller reaches the disarm only past
+its own `isCollapsed` stand-down, so there is no range left to drop; what a
+`removeAllRanges()` would still reach is a CARET, including one the compose
+field owns. That is the blur/focus/selection interaction #1106 and #79 paid
+for, and re-entering it for a mutation with no established need is a bad trade.
+The verb removes the class and detaches the watcher, and nothing else.
+
+### Rejected: re-removing `-webkit-user-select: none` from `html.is-ios`
+
+The second direction that was on the table. It is aimed at the wrong property.
+The callout is `-webkit-touch-callout`, and `is-selecting` re-enables THAT on
+`.scrollback`; dropping the `user-select` kill would leave the stale
+`-webkit-touch-callout: default` exactly where it is, so the reported frame
+survives the change. It also carries a blast radius the defect does not need —
+the blanket `user-select` kill is load-bearing for #508 (`<select>`
+tap-to-open), #589 (admin panes), #250 (`.nick-clickable`) and the
+`.scrollback-invite-join` re-exclude, each written as a re-enable against it.
+The report's own body says the cause is not a missing suppression.
+
+### One latch, one watcher
+
+Found on the way through, in the same add/remove pair: `selectMessageText`
+added a `selectionchange` listener on EVERY call and only the one that FIRED
+ever detached itself, so a session that selected repeatedly accumulated them on
+the document. The module now holds the detach and arms through it, which is
+also what lets the doors reach a disarm from outside the closure that armed it.
+
+### The desktop door is not mouse-only
+
+`bindMessageContextMenu` takes the same disarm. `lib/platform.ts` puts `is-ios`
+on iPadOS in desktop-mode (the `Mac` UA + `maxTouchPoints > 0` clause), where a
+trackpad's secondary click arrives as `contextmenu` — so a door that opens the
+menu without ending the latch keeps the defect alive on that hardware. Its
+selection stand-down moved ABOVE the inline-control exclude so the disarm sits
+ahead of both: the latch is a document-level fact and the callout it lifts
+covers the whole scrollback, so a press handed straight back to the browser
+still ends it. Both guards are side-effect-free early returns, so the order was
+free, and the two doors now read the same.
+
+### What is NOT measured
+
+The disarm is proven in jsdom: the class goes at touch-down and at right-click,
+the watcher is detached, exactly one watcher survives repeated `Select…`, and
+the live-selection carve-out still stands down. Four mutants, four kills, each
+by the test written for it — removing the disarm from either door, moving it
+ahead of the stand-down, and restoring the watcher stack.
+
+What jsdom cannot show is the half that matters on the device: that WebKit
+re-reads `-webkit-touch-callout` after `touchstart` and therefore suppresses
+its own callout for the gesture already in flight. jsdom has no CSS engine and
+Playwright webkit does not render iOS selection UI — the same limit #1067 and
+`default.css` already declare for this property, and the reason no e2e arm was
+written rather than a hollow one. The frame is device evidence for the symptom;
+the cure is reasoned from the platform contract and verified only down to the
+class.


### PR DESCRIPTION
Addresses issue 1857 — on iOS a long-press could put cicchetto's message menu
and iOS's own callout bar up at the same time, the callout carrying a live
selection on a **different** row.

## Which direction I took, and why

vjt's comment left both directions open. I took **(1) — clear the `is-selecting`
latch when the gesture starts** — and I reject (2).

**(2) is aimed at the wrong property.** Re-removing `-webkit-user-select: none`
from `html.is-ios` does not touch `-webkit-touch-callout`, which is what
`is-selecting` re-enables on `.scrollback` (`default.css`,
`html.is-ios.is-selecting .scrollback`). The stale `-webkit-touch-callout:
default` survives the change, so the reported frame does too. It also carries a
blast radius the defect does not need: the blanket `user-select` kill is
load-bearing for #508 (`<select>` tap-to-open), #589 (admin panes), #250
(`.nick-clickable`) and the `.scrollback-invite-join` re-exclude, each written
as a re-enable *against* it. The issue's own body already says the cause is not
a missing suppression.

## Challenge to the reported mechanism — it changes WHERE the cure goes

The issue reads the cause as the app menu opening *"without necessarily
collapsing the existing range"*. **Measured against the code, that cannot
happen.** Both doors to the menu already stand down on
`!selection.isCollapsed`:

- `onStart` in `lib/messageGestures.ts`
- the handler in `lib/messageContextMenu.ts`

While the DOM reports a live selection, our menu does not open at all.

What is left is a **race**. WebKit collapses the old selection at touch-down, so
our `touchstart` handler correctly sees `isCollapsed`; the `selectionchange`
that would strip the class is **queued as a task** and lands afterwards; and
touch-down is when WebKit reads `-webkit-touch-callout` to decide whether to run
its own long-press UI. The property is still `default` for the recogniser that
is starting, and `LONG_PRESS_MS` later our menu opens on top of what it made.

That rules out the call site the issue suggests. Disarming from the **long-press
handler** — when the menu opens — runs a full 500 ms after the property was
read. The disarm belongs at the **top of the gesture**, in the door: the
earliest moment JavaScript hears about the touch.

## The change

`disarmMessageSelection()` in `lib/messageMenu.ts` — removes `SELECTING_CLASS`
and detaches the `selectionchange` watcher. Idempotent. Kept in `messageMenu.ts`
so the latch's arm and disarm stay in one module.

**It deliberately does not touch the selection**, against the issue's suggested
`getSelection()?.removeAllRanges()`. Every caller reaches it only past its own
`isCollapsed` stand-down, so there is no range left to drop; what
`removeAllRanges()` would still reach is a **caret**, including one the compose
field owns. That is the blur/focus/selection interaction #1106 and #79 paid for,
and re-entering it for a mutation with no established need is a bad trade.

Two things ride along, both the same add/remove pair:

- **One latch, one watcher.** `selectMessageText` added a `selectionchange`
  listener on *every* call and only the one that FIRED detached itself, so a
  session that selected repeatedly accumulated them on the document. The module
  now holds the detach and arms through it.
- **The desktop door takes the disarm too.** `lib/platform.ts` puts `is-ios` on
  iPadOS in desktop-mode (the `Mac` UA + `maxTouchPoints > 0` clause), where a
  trackpad's secondary click arrives as `contextmenu`. Its selection stand-down
  moved *above* the inline-control exclude so the disarm sits ahead of both —
  the latch is a document-level fact and the callout covers the whole
  scrollback, so a press handed straight back to the browser still ends it. Both
  guards are side-effect-free early returns, so the order was free.

## Evidence

**Measured**

| gate | result |
|---|---|
| `scripts/bun.sh run check` | `rc=0` — check summary: 5 stages ran, 0 failed |
| `scripts/bun.sh run test` (full) | `rc=0` — 327 files, 6525 tests passed |
| `scripts/design-notes-gate.sh origin/main` (post-commit) | `rc=0` — `1 new entry heading(s), separator and marker present.` |

**Red observed first**: the scoped suite failed `rc=1` on
`disarmMessageSelection is not a function` before the implementation existed.

**Mutation bench — 4 mutants, 4 kills**, each by the test written for it:

| mutant | killed by |
|---|---|
| touch door never disarms | 4 tests in `bindMessageGestures — a stale callout re-enable` |
| desktop door never disarms | 2 tests in `bindMessageContextMenu — a stale callout re-enable` |
| touch door disarms *before* the live-selection stand-down | `keeps it armed while a selection is still live` |
| `Select…` stacks a second watcher again | `keeps exactly one selectionchange watcher across repeated Select…` |

13 tests added.

## What is NOT proven

**The device half.** jsdom shows the class goes at touch-down and at
right-click, the watcher is detached, one watcher survives repeated `Select…`,
and the live-selection carve-out still stands down. It cannot show that **WebKit
re-reads `-webkit-touch-callout` after `touchstart`** and therefore suppresses
its own callout for the gesture already in flight. jsdom has no CSS engine and
Playwright webkit does not render iOS selection UI — the same limit #1067 and
`default.css` already declare for this property.

**No e2e arm was written**, deliberately: a spec that cannot observe iOS
selection UI would be a green that proves nothing. A hollow green is worth less
than a stated gap.

**The reported frame is device evidence for the symptom only.** The race above
is read from the code and from the platform contract, not reproduced.

Lane: none taken — cic-only gates.
