### PR TITLE
cic: fold nicks per-network, not always ASCII (issue 1861, points 1 + 3)

### DIFF
--- a/cicchetto/src/ArchiveModal.tsx
+++ b/cicchetto/src/ArchiveModal.tsx
@@ -9,6 +9,7 @@ import {
   visibleArchiveForNetwork,
 } from "./lib/archive";
 import { token } from "./lib/auth";
+import { casemappingForSlug } from "./lib/casemapping";
 import { type ChannelKey, channelKey } from "./lib/channelKey";
 import { mentionCounts } from "./lib/mentions";
 import { networks } from "./lib/networks";
@@ -76,7 +77,7 @@ const ArchiveModal: Component = () => {
   // the window. Own self-PART events no longer appear here either, because
   // #532 A drops them from the server `events` count.
   const unreadKey = (slug: string, target: string): ChannelKey =>
-    channelKey(slug, normalizeNick(target));
+    channelKey(slug, normalizeNick(target, casemappingForSlug(slug)));
 
   const close = () => {
     setArchiveModalOpen(false);

--- a/cicchetto/src/MembersPane.tsx
+++ b/cicchetto/src/MembersPane.tsx
@@ -2,6 +2,7 @@ import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { ownNickForNetwork } from "./lib/api";
 import { channelKey } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
+import { casemappingForNetwork } from "./lib/isupport";
 import { memberSigil } from "./lib/memberSigil";
 import { type MemberEntry, membersByChannel, sortMembers } from "./lib/members";
 import { networkBySlug, networks, user } from "./lib/networks";
@@ -123,7 +124,7 @@ const MembersPane: Component<Props> = (props) => {
     if (!net) return [];
     const nick = ownNickForNetwork(net, me);
     if (!nick) return [];
-    const entry = list().find((m) => nickEquals(m.nick, nick));
+    const entry = list().find((m) => nickEquals(m.nick, nick, casemappingForNetwork(net.id)));
     return entry?.modes ?? [];
   };
 

--- a/cicchetto/src/PeerAwayBanner.tsx
+++ b/cicchetto/src/PeerAwayBanner.tsx
@@ -1,4 +1,5 @@
 import { type Component, Show } from "solid-js";
+import { casemappingForSlug } from "./lib/casemapping";
 import { normalizeNick } from "./lib/nickEquals";
 import { dismissPeerAway, peerAwayBySlug } from "./lib/peerAway";
 import NickText from "./NickText";
@@ -24,7 +25,7 @@ export type Props = {
 
 const PeerAwayBanner: Component<Props> = (props) => {
   const message = (): string | undefined => {
-    const peerKey = normalizeNick(props.peer);
+    const peerKey = normalizeNick(props.peer, casemappingForSlug(props.networkSlug));
     return peerAwayBySlug()[props.networkSlug]?.[peerKey];
   };
 

--- a/cicchetto/src/RegistrationWizardModal.tsx
+++ b/cicchetto/src/RegistrationWizardModal.tsx
@@ -10,6 +10,7 @@ import {
   Show,
   Switch,
 } from "solid-js";
+import { casemappingForSlug } from "./lib/casemapping";
 import { friendlyError } from "./lib/friendlyError";
 import { identifiedForNetwork } from "./lib/identity";
 import { networkBySlug, networkIdBySlug } from "./lib/networks";
@@ -120,7 +121,10 @@ const RegistrationWizardModal: Component = () => {
           const s = st();
           const nick = template()?.servicesNick ?? "NickServ";
           return serviceMirrorRows(s.networkSlug, nick).filter(
-            (m) => m.id > s.stepSinceId && m.kind === "notice" && nickEquals(m.sender, nick),
+            (m) =>
+              m.id > s.stepSinceId &&
+              m.kind === "notice" &&
+              nickEquals(m.sender, nick, casemappingForSlug(s.networkSlug)),
           );
         };
 

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -12,6 +12,7 @@ import {
 } from "solid-js";
 import LusersCard from "./LusersCard";
 import { isContentKind, ownNickForNetwork, type ScrollbackMessage } from "./lib/api";
+import { casemappingForSlug } from "./lib/casemapping";
 import { acceptInvite, confirmJoinChannel } from "./lib/channelJoin";
 import { channelKey, decodeChannelKey } from "./lib/channelKey";
 import { statusmsgDescription } from "./lib/channelModes";
@@ -714,11 +715,12 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   // event, not a frozen send, so the current grade is the correct glyph.
   const prefixFor = (nick: string): "@" | "%" | "+" | "" => {
     if (!msg.channel) return "";
-    if (isContentKind(msg.kind) && nickEquals(nick, msg.sender)) {
+    const casemapping = casemappingForSlug(handlers.networkSlug);
+    if (isContentKind(msg.kind) && nickEquals(nick, msg.sender, casemapping)) {
       return snapshotSenderPrefix(msg.meta);
     }
     const key = channelKey(handlers.networkSlug, msg.channel);
-    return senderPrefix(membersByChannel()[key], nick);
+    return senderPrefix(membersByChannel()[key], nick, casemapping);
   };
 
   // C7.6: sender button for content kinds — left-click (→ query) or
@@ -1415,7 +1417,10 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (!nick) return [];
     const members = membersByChannel()[key()];
     if (!members) return [];
-    return members.find((m) => nickEquals(m.nick, nick))?.modes ?? [];
+    return (
+      members.find((m) => nickEquals(m.nick, nick, casemappingForSlug(props.networkSlug)))?.modes ??
+      []
+    );
   };
 
   // C7.6: left-click a nick → open query window + switch focus.
@@ -1537,6 +1542,10 @@ const ScrollbackPane: Component<Props> = (props) => {
     // `/part → /join` cycle. `isOwnPresenceEvent` is the shared
     // single-source predicate (see lib/ownPresenceEvent.ts).
     const ownNick = userNick();
+    // #1861 — resolved ONCE for the whole projection: the fold is a property
+    // of the network, not of a row, and the two predicates below plus the
+    // own-JOIN anchor scan all have to agree on it.
+    const casemapping = casemappingForSlug(props.networkSlug);
     const unreadCount =
       cursor !== null && sessionTop !== null
         ? msgs.filter(
@@ -1544,7 +1553,7 @@ const ScrollbackPane: Component<Props> = (props) => {
               m.id > cursor &&
               m.id <= sessionTop &&
               !isOperatorActionEcho(m) &&
-              !isOwnPresenceEvent(m, ownNick),
+              !isOwnPresenceEvent(m, ownNick, casemapping),
           ).length
         : 0;
     // #947 — the LABEL, which is not always the count above. `unreadCount`
@@ -1598,7 +1607,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         msg.id > cursor &&
         msg.id <= sessionTop &&
         !isOperatorActionEcho(msg) &&
-        !isOwnPresenceEvent(msg, ownNick)
+        !isOwnPresenceEvent(msg, ownNick, casemapping)
       ) {
         result.push({ type: "unread-marker", count: unreadLabel, id: "unread-marker" });
         markerInjected = true;
@@ -1681,7 +1690,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         for (const m of allMsgs) {
           if (
             m.kind === "join" &&
-            nickEquals(m.sender, ownNick) &&
+            nickEquals(m.sender, ownNick, casemapping) &&
             (anchor === null ||
               m.server_time > anchor.server_time ||
               (m.server_time === anchor.server_time && m.id > anchor.id))
@@ -1742,7 +1751,8 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (autoFocusedJoins.has(key())) return false;
     const msgs = messages();
     if (!msgs) return false;
-    return msgs.some((m) => m.kind === "join" && nickEquals(m.sender, nick));
+    const casemapping = casemappingForSlug(props.networkSlug);
+    return msgs.some((m) => m.kind === "join" && nickEquals(m.sender, nick, casemapping));
   });
 
   // UX-3 Z3 R4 — actual-overflow gate. CSS-only fix is impossible:

--- a/cicchetto/src/ServiceModal.tsx
+++ b/cicchetto/src/ServiceModal.tsx
@@ -1,4 +1,5 @@
 import { type Component, createEffect, createSignal, For, Show } from "solid-js";
+import { casemappingForSlug } from "./lib/casemapping";
 import { friendlyError } from "./lib/friendlyError";
 import { nickEquals } from "./lib/nickEquals";
 import { createOverlayLock } from "./lib/overlayScrollLock";
@@ -57,7 +58,10 @@ const ServiceModal: Component = () => {
         // NOTICEs append and appear here whichever window they land in.
         const lines = () =>
           serviceMirrorRows(st.networkSlug, st.service).filter(
-            (m) => m.id > st.sinceId && m.kind === "notice" && nickEquals(m.sender, st.service),
+            (m) =>
+              m.id > st.sinceId &&
+              m.kind === "notice" &&
+              nickEquals(m.sender, st.service, casemappingForSlug(st.networkSlug)),
           );
 
         const send = (): void => {

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -32,6 +32,7 @@ import { channelKey } from "./lib/channelKey";
 import { getDraft, tabComplete } from "./lib/compose";
 import { appendToCompose } from "./lib/composeAppend";
 import { placeCaretInView } from "./lib/composeCaret";
+import { casemappingForNetwork } from "./lib/isupport";
 import { install, registerHandlers, uninstall } from "./lib/keybindings";
 import { loadLastFocused } from "./lib/lastFocusedChannel";
 import { mentionsBundleBySlug } from "./lib/mentionsWindow";
@@ -568,7 +569,9 @@ const Shell: Component = () => {
       const net = networkBySlug(slug);
       if (net) {
         const qs = queryWindowsByNetwork()[net.id] ?? [];
-        const match = qs.find((q) => nickEquals(q.targetNick, saved.channelName));
+        const match = qs.find((q) =>
+          nickEquals(q.targetNick, saved.channelName, casemappingForNetwork(net.id)),
+        );
         if (match !== undefined) {
           setSelectedChannel({
             networkSlug: slug,

--- a/cicchetto/src/WhoModal.tsx
+++ b/cicchetto/src/WhoModal.tsx
@@ -1,5 +1,6 @@
 import { type Component, For, Show } from "solid-js";
 import type { WhoUser } from "./lib/api";
+import { casemappingForSlug } from "./lib/casemapping";
 import { channelKey } from "./lib/channelKey";
 import { memberSigil } from "./lib/memberSigil";
 import { membersByChannel } from "./lib/members";
@@ -112,7 +113,7 @@ const rosterMembership = (
 ): Membership | null | undefined => {
   const list = membersByChannel()[channelKey(slug, channel)];
   if (list === undefined) return undefined;
-  const member = list.find((m) => nickEquals(m.nick, nick));
+  const member = list.find((m) => nickEquals(m.nick, nick, casemappingForSlug(slug)));
   if (member === undefined) return undefined;
   const sigil = memberSigil(member.modes);
   return sigil === " " ? null : sigil;

--- a/cicchetto/src/__tests__/ArchiveModal.test.tsx
+++ b/cicchetto/src/__tests__/ArchiveModal.test.tsx
@@ -29,6 +29,9 @@ vi.mock("../lib/mentions", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: () => [
     { id: 1, slug: "freenode", inserted_at: "", updated_at: "" },
     { id: 2, slug: "libera", inserted_at: "", updated_at: "" },
@@ -45,7 +48,7 @@ vi.mock("../lib/queryWindows", async () => {
   return {
     openQueryWindowState: vi.fn(),
     canonicalQueryNick: (_networkId: number, nick: string) =>
-      mockOpenQueryNicks().find((open) => nickEquals(open, nick)) ?? nick,
+      mockOpenQueryNicks().find((open) => nickEquals(open, nick, "ascii")) ?? nick,
   };
 });
 

--- a/cicchetto/src/__tests__/BanlistModal.test.tsx
+++ b/cicchetto/src/__tests__/BanlistModal.test.tsx
@@ -30,10 +30,16 @@ vi.mock("../lib/channelEditPerm", () => ({
 // switcher renders; the single-list case gets its own test.
 const isupportMock = vi.hoisted(() => ({ listModesQueryable: ["b", "e", "I"] }));
 vi.mock("../lib/isupport", () => ({
+  // #1861 — the nick fold is per-network now; the store-reading half
+  // lives here. `"ascii"` is the production posture (bahamut/Azzurra).
+  casemappingForNetwork: () => "ascii" as const,
   isupportForNetwork: () => ({ listModesQueryable: isupportMock.listModesQueryable }),
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: vi.fn(() => [
     { id: 1, slug: "bahamut", nick: "vjt", inserted_at: "x", updated_at: "y" },
   ]),

--- a/cicchetto/src/__tests__/BottomBar.test.tsx
+++ b/cicchetto/src/__tests__/BottomBar.test.tsx
@@ -24,6 +24,9 @@ const pseudoRowsMock = vi.hoisted(() =>
 );
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: () => [
     { id: 1, slug: "freenode", inserted_at: "", updated_at: "" },
     { id: 2, slug: "libera", inserted_at: "", updated_at: "" },

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -34,6 +34,9 @@ let mockFramePreview: { messages: number; remainingBytes: number | null } | null
 let mockFrameBudgetBase: number | null = 393;
 
 vi.mock("../lib/isupport", () => ({
+  // #1861 — the nick fold is per-network now; the store-reading half
+  // lives here. `"ascii"` is the production posture (bahamut/Azzurra).
+  casemappingForNetwork: () => "ascii" as const,
   frameBudgetBaseForNetwork: () => mockFrameBudgetBase,
 }));
 
@@ -94,6 +97,9 @@ vi.mock("../lib/windowState", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   // Bucket F H4: ComposeBox narrows on `kind === "user"` before
   // reading connection_state. Tests exercise the user branch (the
   // greyed cascade only applies to user subjects' credential rows;

--- a/cicchetto/src/__tests__/CrtSplash.test.tsx
+++ b/cicchetto/src/__tests__/CrtSplash.test.tsx
@@ -23,6 +23,9 @@ const networksMock = vi.fn<() => unknown>(() => undefined);
 const channelsBySlugMock = vi.fn<() => unknown>(() => undefined);
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   user: () => userMock(),
   networks: () => networksMock(),
   channelsBySlug: () => channelsBySlugMock(),

--- a/cicchetto/src/__tests__/MembersPane.test.tsx
+++ b/cicchetto/src/__tests__/MembersPane.test.tsx
@@ -47,7 +47,10 @@ vi.mock("../lib/networks", () => {
     inserted_at: "x",
   }));
   const networkBySlug = (slug: string) => networks()?.find((n) => n.slug === slug);
-  return { networks, user, networkBySlug };
+  const networkIdBySlug = (slug: string) => networkBySlug(slug)?.id;
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  return { networks, user, networkBySlug, networkIdBySlug };
 });
 
 // UserContextMenu is mounted by MembersPane on right-click; stub it so

--- a/cicchetto/src/__tests__/ModeModal.test.tsx
+++ b/cicchetto/src/__tests__/ModeModal.test.tsx
@@ -39,7 +39,10 @@ vi.mock("../lib/networks", () => {
     inserted_at: "x",
   }));
   const networkBySlug = (slug: string) => networks()?.find((n) => n.slug === slug);
-  return { networks, user, networkBySlug };
+  const networkIdBySlug = (slug: string) => networkBySlug(slug)?.id;
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  return { networks, user, networkBySlug, networkIdBySlug };
 });
 
 // ownNickForNetwork resolves the per-network IRC nick — return the seeded

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -52,6 +52,9 @@ vi.mock("../lib/notificationPrefs", () => ({
 
 const adminHolder = { value: false };
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   isAdmin: () => adminHolder.value,
   // #986 — pulled in transitively by lib/lifecycle (updateIdentity refetches
   // /me). Unused by the rail, but a named import must resolve.

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -28,6 +28,9 @@ vi.mock("../lib/selection", async () => {
 });
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networkBySlug: (slug: string) => networkBySlugMock(slug),
 }));
 

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -152,6 +152,11 @@ vi.mock("../lib/networks", async () => {
   const [refetchVersion, setRefetchVersion] = createSignal(0);
   networksHolder.bump = () => setRefetchVersion((v) => v + 1);
   return {
+    // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+    // through this map, so the mock has to carry it. No id is needed here:
+    // an undefined lookup resolves to the `:ascii` default, which is what
+    // every assertion in this file already assumed.
+    networkIdBySlug: () => undefined,
     user: () => meHolder.current,
     // #211 phase 7 — the identity editor + delete-confirm read the visitor's
     // network rows (anchor nick + per-network ident/realname seed). Stub a

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -140,6 +140,9 @@ vi.mock("@solidjs/router", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: () => [{ id: 1, slug: "freenode", nick: "vjt", inserted_at: "", updated_at: "" }],
   channelsBySlug: () => channelsHolder.current,
   user: () => userHolder.current,

--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -25,6 +25,9 @@ let mockUser: { kind: "user" | "visitor"; [k: string]: unknown } | null = {
 };
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: () => [
     {
       // Bucket F H4: Network is now a discriminated union; the Sidebar

--- a/cicchetto/src/__tests__/UserContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/UserContextMenu.test.tsx
@@ -43,6 +43,9 @@ vi.mock("../lib/ctcpQuery", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: vi.fn(() => [{ id: 42, slug: "freenode", inserted_at: "x", updated_at: "y" }]),
 }));
 

--- a/cicchetto/src/__tests__/WatchlistsSettings.test.tsx
+++ b/cicchetto/src/__tests__/WatchlistsSettings.test.tsx
@@ -23,7 +23,12 @@ vi.mock("../lib/api", () => ({
 
 vi.mock("../lib/auth", () => ({ token: () => "tok" }));
 
-vi.mock("../lib/networks", () => ({ networks: () => networksData }));
+vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
+  networks: () => networksData,
+}));
 
 vi.mock("../lib/notifyWatch", () => ({
   watchByNetwork: () => watchData,

--- a/cicchetto/src/__tests__/activeWindowsStep.test.ts
+++ b/cicchetto/src/__tests__/activeWindowsStep.test.ts
@@ -33,6 +33,9 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: () => [{ id: 1, slug: "net" }],
   channelsBySlug: () => ({ net: h.channels }),
 }));

--- a/cicchetto/src/__tests__/archive.test.ts
+++ b/cicchetto/src/__tests__/archive.test.ts
@@ -18,6 +18,9 @@ vi.mock("../lib/api", () => ({
 // filter. Default mocks return empty live sets; per-test overrides
 // thread the active windows in via `vi.doMock` + `vi.resetModules`.
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   channelsBySlug: () => ({}),
 }));
 

--- a/cicchetto/src/__tests__/channelEditPerm.test.ts
+++ b/cicchetto/src/__tests__/channelEditPerm.test.ts
@@ -26,7 +26,10 @@ vi.mock("../lib/networks", () => {
     inserted_at: "x",
   }));
   const networkBySlug = (slug: string) => networks()?.find((n) => n.slug === slug);
-  return { networks, user, networkBySlug };
+  const networkIdBySlug = (slug: string) => networkBySlug(slug)?.id;
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  return { networks, user, networkBySlug, networkIdBySlug };
 });
 
 // ownNickForNetwork resolves the per-network IRC nick — return the seeded

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -270,6 +270,9 @@ const isupportMock = vi.hoisted(() => ({
   listModesQueryable: ["b", "z"],
   chanmodesA: ["b", "z"],
   chantypes: ["#", "&", "+", "!"] as readonly string[],
+  // #1861 — the network's advertised CASEMAPPING, which tab-completion now
+  // folds by. Default `"ascii"`: bahamut/Azzurra, all of production.
+  casemapping: "ascii" as "ascii" | "rfc1459" | "rfc1459_strict",
 }));
 vi.mock("../lib/isupport", () => ({
   isupportForNetwork: () => ({
@@ -286,6 +289,8 @@ vi.mock("../lib/isupport", () => ({
   // network. Mocked alongside the mode set so a test can narrow the class
   // (see the CHANTYPES describe below) instead of assuming the RFC one.
   chantypesForNetwork: () => isupportMock.chantypes,
+  // #1861 — and which fold it applies to identifiers, for tab-completion.
+  casemappingForNetwork: () => isupportMock.casemapping,
 }));
 
 vi.mock("../lib/modeModal", () => ({
@@ -332,6 +337,11 @@ beforeEach(() => {
   // wipe localStorage gets or one test's draft seeds the next one's boot.
   sessionStorage.clear();
   vi.clearAllMocks();
+  // #1861 — the hoisted isupport mock is a module-lifetime object, so a test
+  // that switches the network's fold would leak it into every test after it.
+  // Reset to the production posture (bahamut/Azzurra) here; the rfc1459 tests
+  // opt in explicitly.
+  isupportMock.casemapping = "ascii";
 });
 
 describe("compose draft state", () => {
@@ -2967,16 +2977,51 @@ describe("compose tabComplete (members-only, irssi-exact)", () => {
     expect(compose.tabComplete(k, "al", 2, true)).toBeNull();
   });
 
-  it("folds case (not the bracket range) on the prefix match (#525)", async () => {
+  it("folds case (not the bracket range) on the prefix match, on :ascii (#525)", async () => {
     // #525 CASEMAPPING=ascii: `[` is NOT folded, so a member `Foo[1]` and
     // the typed `foo[` are the SAME nick (case-only) and completion
     // matches on the common `nick[away]` shape. A brace `foo{` is a
     // DIFFERENT nick — but since #1003 it still REACHES `Foo[1]` on the
     // decoration level, behind the literals; see the cousin test below.
+    isupportMock.casemapping = "ascii";
     await setMembers(["Foo[1]"]);
     const compose = await import("../lib/compose");
     const r = compose.tabComplete(k, "foo[", 4, true);
     expect(r?.newInput).toBe("Foo[1]: ");
+  });
+
+  // #1861 — the SAME question, keyed per casemapping rather than globally.
+  // On `:ascii` the literal level must NOT match `foo{` against `Foo[1]`
+  // (the #525 posture, and the reason the loose decoration level exists at
+  // all); on `:rfc1459` the two spellings are one nick, so the LITERAL level
+  // matches and the completion no longer depends on #1003's fallback.
+  it("does NOT literal-match a brace prefix against a bracket member on :ascii (#525)", async () => {
+    isupportMock.casemapping = "ascii";
+    // Two members: the bracket twin, plus a decoration-free nick that the
+    // loose level would ALSO reach. A literal match would return `Foo[1]`
+    // first; the loose level orders alphabetically, so seeing `Foo[1]` here
+    // does not by itself prove which level matched — assert the fold table
+    // through `normalizeNick`, which is the thing under test.
+    const { normalizeNick } = await import("../lib/nickEquals");
+    expect(normalizeNick("Foo[1]", "ascii")).toBe("foo[1]");
+    expect(normalizeNick("foo{1}", "ascii")).toBe("foo{1}");
+    await setMembers(["Foo[1]"]);
+    const compose = await import("../lib/compose");
+    // Reaches it anyway, via the #1003 decoration level — behind literals.
+    expect(compose.tabComplete(k, "foo{", 4, true)?.newInput).toBe("Foo[1]: ");
+  });
+
+  it("literal-matches a brace prefix against a bracket member on :rfc1459 (#1861)", async () => {
+    isupportMock.casemapping = "rfc1459";
+    const { normalizeNick } = await import("../lib/nickEquals");
+    expect(normalizeNick("Foo[1]", "rfc1459")).toBe("foo{1}");
+    expect(normalizeNick("foo{1}", "rfc1459")).toBe("foo{1}");
+    // `_zzz_` strips to `zzz` and so is NOT reachable from the `foo{` prefix
+    // on either level; it is here only to keep the candidate list from being
+    // a single element, so "the one member came back" cannot pass vacuously.
+    await setMembers(["Foo[1]", "_zzz_"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "foo{", 4, true)?.newInput).toBe("Foo[1]: ");
   });
 
   it("appends ': ' at line start", async () => {
@@ -6284,6 +6329,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "aliasList.aliases()",
             "api.ownNickForNetwork({"kind":"user","id":1,"slug":"freenode","inserted_at":"","updated_at":""}, {"kind":"user","name":"vjt"})",
             "networks.networkBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
             "networks.networkIdBySlug("freenode")",
             "networks.user()",
           ],

--- a/cicchetto/src/__tests__/home.test.ts
+++ b/cicchetto/src/__tests__/home.test.ts
@@ -36,6 +36,9 @@ const { userAccessor, setUserAccessor, bindSignal } = vi.hoisted(() => {
 });
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   user: () => userAccessor(),
 }));
 

--- a/cicchetto/src/__tests__/inviteLink.test.ts
+++ b/cicchetto/src/__tests__/inviteLink.test.ts
@@ -26,6 +26,9 @@ vi.mock("../lib/channelJoin", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networkBySlug: vi.fn((slug: string) =>
     slug === "azzurra" ? { id: 1, slug: "azzurra", kind: "user" } : undefined,
   ),

--- a/cicchetto/src/__tests__/isupport.test.ts
+++ b/cicchetto/src/__tests__/isupport.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 // keyed by network id (ISUPPORT is per-network, not per-channel).
 
 import {
+  casemappingForNetwork,
   DEFAULT_ISUPPORT,
   frameBudgetBaseForNetwork,
   type IsupportEntry,
@@ -126,10 +127,9 @@ describe("isupport widening (#1255)", () => {
   });
 
   it("carries a network whose fold is NOT ascii", () => {
-    // solanum/Libera advertise rfc1459, where `foo[1]` and `foo{1}` are the
-    // SAME identity. cic cannot act on that yet — `asciiFold` is one fold,
-    // pinned to the server's #525 posture — but the fact now reaches the
-    // client instead of being dropped at ingress.
+    // solanum/Libera/Rizon advertise rfc1459, where `foo[1]` and `foo{1}` are
+    // the SAME identity. Since #1861 cic ACTS on it: `casemappingForNetwork`
+    // below feeds `normalizeNick`/`nickEquals`.
     const entry = isupportEntryFromWire({ ...WIRE_PAYLOAD, casemapping: "rfc1459" });
     expect(entry.casemapping).toBe("rfc1459");
   });
@@ -145,6 +145,26 @@ describe("isupport widening (#1255)", () => {
     expect(entry.nicklen).toBeNull();
     expect(entry.channellen).toBeNull();
     expect(entry.topiclen).toBeNull();
+  });
+
+  // #1861 — the store-reading half of the nick fold. Sibling of
+  // `chantypesForNetwork`, and the ONLY door the fold call sites use.
+  it("casemappingForNetwork reports the seeded fold, per network", () => {
+    seedIsupport(41, isupportEntryFromWire({ ...WIRE_PAYLOAD, casemapping: "rfc1459" }));
+    seedIsupport(42, isupportEntryFromWire({ ...WIRE_PAYLOAD, casemapping: "rfc1459_strict" }));
+    seedIsupport(43, isupportEntryFromWire({ ...WIRE_PAYLOAD, casemapping: "ascii" }));
+
+    expect(casemappingForNetwork(41)).toBe("rfc1459");
+    expect(casemappingForNetwork(42)).toBe("rfc1459_strict");
+    expect(casemappingForNetwork(43)).toBe("ascii");
+  });
+
+  it("casemappingForNetwork defaults to ascii for an unseeded network and a null id", () => {
+    // The narrower fold on both misses: pre-005, a parked session, or no
+    // active network at all. Guessing `ascii` merges no identity the ircd
+    // keeps apart, which is why it is the safe default in BOTH directions.
+    expect(casemappingForNetwork(44)).toBe("ascii");
+    expect(casemappingForNetwork(null)).toBe("ascii");
   });
 
   it("seeds the widened facts per network, keeping networks independent", () => {

--- a/cicchetto/src/__tests__/isupport.test.ts
+++ b/cicchetto/src/__tests__/isupport.test.ts
@@ -16,6 +16,8 @@ import {
   isupportForNetwork,
   seedIsupport,
 } from "../lib/isupport";
+import { nickEquals } from "../lib/nickEquals";
+import { narrowIsupportChanged } from "../lib/wireNarrow";
 
 // A full `isupport_changed` payload, as the server builds it. Tests override
 // the one field they exercise so a new wire fact cannot be added here
@@ -175,5 +177,71 @@ describe("isupport widening (#1255)", () => {
     expect(isupportForNetwork(32).chantypes).toEqual(["#", "&", "!"]);
     // An unseeded network still gets the RFC set, not a neighbour's.
     expect(isupportForNetwork(33).chantypes).toEqual(["#", "&", "+", "!"]);
+  });
+});
+
+// #1861 — the COMPOSITION, driven from a raw wire payload rather than from
+// the store shape. Every link in the chain has its own test; this is the one
+// that fails if two of them stop composing:
+//
+//   005 CASEMAPPING=rfc1459  (measured live off the e2e solanum node,
+//                             `azzurra2` — see DESIGN_NOTES 2026-08-29)
+//     → Grappa.Session.ISupport.parse_casemapping/1   (isupport_test.exs)
+//     → the isupport_changed wire payload              (wire_test.exs)
+//     → narrowIsupportChanged                          (HERE, real narrower)
+//     → isupportEntryFromWire → seedIsupport           (HERE)
+//     → casemappingForNetwork                          (HERE)
+//     → nickEquals                                     (HERE)
+//
+// It uses the REAL narrower on a raw `Record<string, unknown>`, so a wire
+// rename or a narrowing regression reds here instead of surviving behind a
+// hand-built store entry.
+describe("isupport → nick fold composition (#1861)", () => {
+  const rawWire = (networkId: number, casemapping: string): Record<string, unknown> => ({
+    ...WIRE_PAYLOAD,
+    network_id: networkId,
+    casemapping,
+  });
+
+  it("an rfc1459 005 makes the two spellings of one nick compare EQUAL", () => {
+    const narrowed = narrowIsupportChanged(rawWire(51, "rfc1459"));
+    // Positive control: the narrower accepted the payload at all. Without
+    // this a future required-field addition would turn the whole case into a
+    // vacuous pass via the `?? DEFAULT_ISUPPORT` fallback below.
+    expect(narrowed).not.toBeNull();
+    if (narrowed === null) return;
+    expect(narrowed.casemapping).toBe("rfc1459");
+
+    seedIsupport(51, isupportEntryFromWire(narrowed));
+
+    const cm = casemappingForNetwork(51);
+    expect(cm).toBe("rfc1459");
+    // The reported pair, off a real Rizon session.
+    expect(nickEquals("[EWG]-L0VE", "{ewg}-l0ve", cm)).toBe(true);
+  });
+
+  it("an ascii 005 keeps them DISTINCT — the #525 posture, all of production", () => {
+    const narrowed = narrowIsupportChanged(rawWire(52, "ascii"));
+    expect(narrowed).not.toBeNull();
+    if (narrowed === null) return;
+
+    seedIsupport(52, isupportEntryFromWire(narrowed));
+
+    const cm = casemappingForNetwork(52);
+    expect(cm).toBe("ascii");
+    expect(nickEquals("[EWG]-L0VE", "{ewg}-l0ve", cm)).toBe(false);
+    // …while the case fold still applies, so this is not "no fold at all".
+    expect(nickEquals("[EWG]-L0VE", "[ewg]-l0ve", cm)).toBe(true);
+  });
+
+  it("a casemapping the server never models degrades to ascii, not to a throw", () => {
+    // `narrowCasemapping` is the guard; the point here is that an unknown
+    // token cannot silently widen the fold on a production network.
+    const narrowed = narrowIsupportChanged(rawWire(53, "strict-rfc7700"));
+    expect(narrowed).not.toBeNull();
+    if (narrowed === null) return;
+
+    seedIsupport(53, isupportEntryFromWire(narrowed));
+    expect(casemappingForNetwork(53)).toBe("ascii");
   });
 });

--- a/cicchetto/src/__tests__/lifecycle.test.ts
+++ b/cicchetto/src/__tests__/lifecycle.test.ts
@@ -40,6 +40,9 @@ vi.mock("../lib/quit", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   refetchUser: vi.fn(),
 }));
 

--- a/cicchetto/src/__tests__/members.test.ts
+++ b/cicchetto/src/__tests__/members.test.ts
@@ -64,16 +64,20 @@ describe("members.applyPresenceEvent", () => {
 
     members.seedFromTest(key, [{ nick: "vjt", modes: ["@"] }]);
 
-    members.applyPresenceEvent(key, {
-      id: 1,
-      network: "freenode",
-      channel: "#grappa",
-      server_time: 0,
-      kind: "join",
-      sender: "alice",
-      body: null,
-      meta: {},
-    });
+    members.applyPresenceEvent(
+      key,
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 0,
+        kind: "join",
+        sender: "alice",
+        body: null,
+        meta: {},
+      },
+      "ascii",
+    );
 
     expect(members.membersByChannel()[key]).toEqual([
       { nick: "vjt", modes: ["@"] },
@@ -90,16 +94,20 @@ describe("members.applyPresenceEvent", () => {
       { nick: "alice", modes: [] },
     ]);
 
-    members.applyPresenceEvent(key, {
-      id: 2,
-      network: "freenode",
-      channel: "#grappa",
-      server_time: 0,
-      kind: "part",
-      sender: "alice",
-      body: null,
-      meta: {},
-    });
+    members.applyPresenceEvent(
+      key,
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 0,
+        kind: "part",
+        sender: "alice",
+        body: null,
+        meta: {},
+      },
+      "ascii",
+    );
 
     expect(members.membersByChannel()[key]).toEqual([{ nick: "vjt", modes: ["@"] }]);
   });
@@ -113,16 +121,20 @@ describe("members.applyPresenceEvent", () => {
       { nick: "alice", modes: [] },
     ]);
 
-    members.applyPresenceEvent(key, {
-      id: 3,
-      network: "freenode",
-      channel: "#grappa",
-      server_time: 0,
-      kind: "quit",
-      sender: "alice",
-      body: "bye",
-      meta: {},
-    });
+    members.applyPresenceEvent(
+      key,
+      {
+        id: 3,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 0,
+        kind: "quit",
+        sender: "alice",
+        body: "bye",
+        meta: {},
+      },
+      "ascii",
+    );
 
     expect(members.membersByChannel()[key]).toEqual([{ nick: "vjt", modes: ["@"] }]);
   });
@@ -133,16 +145,20 @@ describe("members.applyPresenceEvent", () => {
 
     members.seedFromTest(key, [{ nick: "alice", modes: ["@"] }]);
 
-    members.applyPresenceEvent(key, {
-      id: 4,
-      network: "freenode",
-      channel: "#grappa",
-      server_time: 0,
-      kind: "nick_change",
-      sender: "alice",
-      body: null,
-      meta: { new_nick: "alice_" },
-    });
+    members.applyPresenceEvent(
+      key,
+      {
+        id: 4,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 0,
+        kind: "nick_change",
+        sender: "alice",
+        body: null,
+        meta: { new_nick: "alice_" },
+      },
+      "ascii",
+    );
 
     expect(members.membersByChannel()[key]).toEqual([{ nick: "alice_", modes: ["@"] }]);
   });
@@ -156,16 +172,20 @@ describe("members.applyPresenceEvent", () => {
       { nick: "alice", modes: [] },
     ]);
 
-    members.applyPresenceEvent(key, {
-      id: 5,
-      network: "freenode",
-      channel: "#grappa",
-      server_time: 0,
-      kind: "kick",
-      sender: "vjt",
-      body: "behave",
-      meta: { target: "alice" },
-    });
+    members.applyPresenceEvent(
+      key,
+      {
+        id: 5,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 0,
+        kind: "kick",
+        sender: "vjt",
+        body: "behave",
+        meta: { target: "alice" },
+      },
+      "ascii",
+    );
 
     expect(members.membersByChannel()[key]).toEqual([{ nick: "vjt", modes: ["@"] }]);
   });
@@ -179,16 +199,20 @@ describe("members.applyPresenceEvent", () => {
       { nick: "bob", modes: [] },
     ]);
 
-    members.applyPresenceEvent(key, {
-      id: 6,
-      network: "freenode",
-      channel: "#grappa",
-      server_time: 0,
-      kind: "mode",
-      sender: "vjt",
-      body: null,
-      meta: { modes: "+ov", args: ["alice", "bob"] },
-    });
+    members.applyPresenceEvent(
+      key,
+      {
+        id: 6,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 0,
+        kind: "mode",
+        sender: "vjt",
+        body: null,
+        meta: { modes: "+ov", args: ["alice", "bob"] },
+      },
+      "ascii",
+    );
 
     expect(members.membersByChannel()[key]).toEqual([
       { nick: "alice", modes: ["@"] },
@@ -202,16 +226,20 @@ describe("members.applyPresenceEvent", () => {
 
     members.seedFromTest(key, [{ nick: "vjt", modes: ["@"] }]);
 
-    members.applyPresenceEvent(key, {
-      id: 7,
-      network: "freenode",
-      channel: "#grappa",
-      server_time: 0,
-      kind: "privmsg",
-      sender: "alice",
-      body: "hi",
-      meta: {},
-    });
+    members.applyPresenceEvent(
+      key,
+      {
+        id: 7,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 0,
+        kind: "privmsg",
+        sender: "alice",
+        body: "hi",
+        meta: {},
+      },
+      "ascii",
+    );
 
     expect(members.membersByChannel()[key]).toEqual([{ nick: "vjt", modes: ["@"] }]);
   });
@@ -231,16 +259,20 @@ describe("members.applyPresenceEvent", () => {
       // JOIN with original casing.
       members.seedFromTest(key, [{ nick: "Alice", modes: [] }]);
 
-      members.applyPresenceEvent(key, {
-        id: 100,
-        network: "freenode",
-        channel: "#grappa",
-        server_time: 0,
-        kind: "part",
-        sender: "alice", // lower-case PART
-        body: null,
-        meta: {},
-      });
+      members.applyPresenceEvent(
+        key,
+        {
+          id: 100,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 0,
+          kind: "part",
+          sender: "alice", // lower-case PART
+          body: null,
+          meta: {},
+        },
+        "ascii",
+      );
 
       // Pre-fix: ["Alice"] (phantom). Post-fix: [].
       expect(members.membersByChannel()[key]).toEqual([]);
@@ -252,16 +284,20 @@ describe("members.applyPresenceEvent", () => {
 
       members.seedFromTest(key, [{ nick: "Bob", modes: ["@"] }]);
 
-      members.applyPresenceEvent(key, {
-        id: 101,
-        network: "freenode",
-        channel: "#grappa",
-        server_time: 0,
-        kind: "quit",
-        sender: "BOB",
-        body: "bye",
-        meta: {},
-      });
+      members.applyPresenceEvent(
+        key,
+        {
+          id: 101,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 0,
+          kind: "quit",
+          sender: "BOB",
+          body: "bye",
+          meta: {},
+        },
+        "ascii",
+      );
 
       expect(members.membersByChannel()[key]).toEqual([]);
     });
@@ -275,16 +311,20 @@ describe("members.applyPresenceEvent", () => {
         { nick: "Alice", modes: [] },
       ]);
 
-      members.applyPresenceEvent(key, {
-        id: 102,
-        network: "freenode",
-        channel: "#grappa",
-        server_time: 0,
-        kind: "kick",
-        sender: "vjt",
-        body: "behave",
-        meta: { target: "alice" }, // lower-case
-      });
+      members.applyPresenceEvent(
+        key,
+        {
+          id: 102,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 0,
+          kind: "kick",
+          sender: "vjt",
+          body: "behave",
+          meta: { target: "alice" }, // lower-case
+        },
+        "ascii",
+      );
 
       expect(members.membersByChannel()[key]).toEqual([{ nick: "vjt", modes: ["@"] }]);
     });
@@ -295,16 +335,20 @@ describe("members.applyPresenceEvent", () => {
 
       members.seedFromTest(key, [{ nick: "Alice", modes: ["+"] }]);
 
-      members.applyPresenceEvent(key, {
-        id: 103,
-        network: "freenode",
-        channel: "#grappa",
-        server_time: 0,
-        kind: "nick_change",
-        sender: "alice",
-        body: null,
-        meta: { new_nick: "Alyssa" },
-      });
+      members.applyPresenceEvent(
+        key,
+        {
+          id: 103,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 0,
+          kind: "nick_change",
+          sender: "alice",
+          body: null,
+          meta: { new_nick: "Alyssa" },
+        },
+        "ascii",
+      );
 
       expect(members.membersByChannel()[key]).toEqual([{ nick: "Alyssa", modes: ["+"] }]);
     });
@@ -318,16 +362,20 @@ describe("members.applyPresenceEvent", () => {
 
       // A racy JOIN echo arrives lower-cased — the dedup must catch it
       // (otherwise we get two rows for the same person).
-      members.applyPresenceEvent(key, {
-        id: 104,
-        network: "freenode",
-        channel: "#grappa",
-        server_time: 0,
-        kind: "join",
-        sender: "alice",
-        body: null,
-        meta: {},
-      });
+      members.applyPresenceEvent(
+        key,
+        {
+          id: 104,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: 0,
+          kind: "join",
+          sender: "alice",
+          body: null,
+          meta: {},
+        },
+        "ascii",
+      );
 
       expect(members.membersByChannel()[key]).toEqual([{ nick: "Alice", modes: [] }]);
     });

--- a/cicchetto/src/__tests__/modeApply.test.ts
+++ b/cicchetto/src/__tests__/modeApply.test.ts
@@ -8,31 +8,31 @@ const m = (entries: Record<string, string[]>): ChannelMembers =>
 describe("applyModeString", () => {
   it("+o grants @ to a target nick", () => {
     const before = m({ alice: [] });
-    const after = applyModeString(before, "+o", ["alice"]);
+    const after = applyModeString(before, "+o", ["alice"], "ascii");
     expect(after).toEqual([{ nick: "alice", modes: ["@"] }]);
   });
 
   it("+v grants + to a target nick", () => {
     const before = m({ bob: [] });
-    const after = applyModeString(before, "+v", ["bob"]);
+    const after = applyModeString(before, "+v", ["bob"], "ascii");
     expect(after).toEqual([{ nick: "bob", modes: ["+"] }]);
   });
 
   it("+h grants % to a target nick (bucket J — halfop)", () => {
     const before = m({ carol: [] });
-    const after = applyModeString(before, "+h", ["carol"]);
+    const after = applyModeString(before, "+h", ["carol"], "ascii");
     expect(after).toEqual([{ nick: "carol", modes: ["%"] }]);
   });
 
   it("-h revokes % from a target nick (bucket J — halfop)", () => {
     const before = m({ carol: ["%"] });
-    const after = applyModeString(before, "-h", ["carol"]);
+    const after = applyModeString(before, "-h", ["carol"], "ascii");
     expect(after).toEqual([{ nick: "carol", modes: [] }]);
   });
 
   it("+ohv pairs three args by position: alice@, bob%, carol+ (bucket J — halfop)", () => {
     const before = m({ alice: [], bob: [], carol: [] });
-    const after = applyModeString(before, "+ohv", ["alice", "bob", "carol"]);
+    const after = applyModeString(before, "+ohv", ["alice", "bob", "carol"], "ascii");
     expect(after).toEqual([
       { nick: "alice", modes: ["@"] },
       { nick: "bob", modes: ["%"] },
@@ -42,13 +42,13 @@ describe("applyModeString", () => {
 
   it("-o revokes @ from a target nick", () => {
     const before = m({ alice: ["@"] });
-    const after = applyModeString(before, "-o", ["alice"]);
+    const after = applyModeString(before, "-o", ["alice"], "ascii");
     expect(after).toEqual([{ nick: "alice", modes: [] }]);
   });
 
   it("+ov pairs args by position: alice gets @, bob gets +", () => {
     const before = m({ alice: [], bob: [] });
-    const after = applyModeString(before, "+ov", ["alice", "bob"]);
+    const after = applyModeString(before, "+ov", ["alice", "bob"], "ascii");
     expect(after).toEqual([
       { nick: "alice", modes: ["@"] },
       { nick: "bob", modes: ["+"] },
@@ -57,7 +57,7 @@ describe("applyModeString", () => {
 
   it("preserves unrelated members + their existing modes", () => {
     const before = m({ alice: [], bob: ["+"], carol: ["@"] });
-    const after = applyModeString(before, "+o", ["alice"]);
+    const after = applyModeString(before, "+o", ["alice"], "ascii");
     expect(after).toEqual([
       { nick: "alice", modes: ["@"] },
       { nick: "bob", modes: ["+"] },
@@ -67,19 +67,19 @@ describe("applyModeString", () => {
 
   it("ignores non-(ov) mode chars (e.g. +n channel-modes have no per-user effect)", () => {
     const before = m({ alice: ["@"] });
-    const after = applyModeString(before, "+n", []);
+    const after = applyModeString(before, "+n", [], "ascii");
     expect(after).toEqual(before);
   });
 
   it("unknown target nick is a no-op (defensive)", () => {
     const before = m({ alice: [] });
-    const after = applyModeString(before, "+o", ["nonexistent"]);
+    const after = applyModeString(before, "+o", ["nonexistent"], "ascii");
     expect(after).toEqual([{ nick: "alice", modes: [] }]);
   });
 
   it("toggles the same mode without duplication", () => {
     const before = m({ alice: ["@"] });
-    const after = applyModeString(before, "+o", ["alice"]); // already op
+    const after = applyModeString(before, "+o", ["alice"], "ascii"); // already op
     expect(after).toEqual([{ nick: "alice", modes: ["@"] }]);
   });
 
@@ -88,7 +88,7 @@ describe("applyModeString", () => {
   // store row; pre-fix bare `===` silently dropped the mode change.
   it("matches the target nick case-insensitively", () => {
     const before = m({ Alice: [] });
-    const after = applyModeString(before, "+o", ["alice"]);
+    const after = applyModeString(before, "+o", ["alice"], "ascii");
     expect(after).toEqual([{ nick: "Alice", modes: ["@"] }]);
   });
 });

--- a/cicchetto/src/__tests__/nickColor.test.ts
+++ b/cicchetto/src/__tests__/nickColor.test.ts
@@ -156,38 +156,38 @@ describe("senderPrefix", () => {
     Object.entries(entries).map(([nick, modes]) => ({ nick, modes }));
 
   it("returns @ for an op", () => {
-    expect(senderPrefix(m({ alice: ["@"] }), "alice")).toBe("@");
+    expect(senderPrefix(m({ alice: ["@"] }), "alice", "ascii")).toBe("@");
   });
 
   it("returns % for a halfop", () => {
-    expect(senderPrefix(m({ bob: ["%"] }), "bob")).toBe("%");
+    expect(senderPrefix(m({ bob: ["%"] }), "bob", "ascii")).toBe("%");
   });
 
   it("returns + for a voiced member", () => {
-    expect(senderPrefix(m({ carol: ["+"] }), "carol")).toBe("+");
+    expect(senderPrefix(m({ carol: ["+"] }), "carol", "ascii")).toBe("+");
   });
 
   it("returns empty string for a plain member", () => {
-    expect(senderPrefix(m({ dave: [] }), "dave")).toBe("");
+    expect(senderPrefix(m({ dave: [] }), "dave", "ascii")).toBe("");
   });
 
   it("returns empty string for a non-member (sender from a different channel)", () => {
-    expect(senderPrefix(m({ alice: ["@"] }), "stranger")).toBe("");
+    expect(senderPrefix(m({ alice: ["@"] }), "stranger", "ascii")).toBe("");
   });
 
   it("returns empty string when members list is undefined (unknown channel)", () => {
-    expect(senderPrefix(undefined, "alice")).toBe("");
+    expect(senderPrefix(undefined, "alice", "ascii")).toBe("");
   });
 
   it("returns the HIGHEST precedence prefix when a member has multiple modes (@ > % > +)", () => {
-    expect(senderPrefix(m({ alice: ["@", "+"] }), "alice")).toBe("@");
-    expect(senderPrefix(m({ bob: ["%", "+"] }), "bob")).toBe("%");
-    expect(senderPrefix(m({ carol: ["+"] }), "carol")).toBe("+");
+    expect(senderPrefix(m({ alice: ["@", "+"] }), "alice", "ascii")).toBe("@");
+    expect(senderPrefix(m({ bob: ["%", "+"] }), "bob", "ascii")).toBe("%");
+    expect(senderPrefix(m({ carol: ["+"] }), "carol", "ascii")).toBe("+");
   });
 
   it("is case-insensitive for the nick lookup (Alice/alice match)", () => {
-    expect(senderPrefix(m({ Alice: ["@"] }), "alice")).toBe("@");
-    expect(senderPrefix(m({ alice: ["@"] }), "Alice")).toBe("@");
+    expect(senderPrefix(m({ Alice: ["@"] }), "alice", "ascii")).toBe("@");
+    expect(senderPrefix(m({ alice: ["@"] }), "Alice", "ascii")).toBe("@");
   });
 });
 

--- a/cicchetto/src/__tests__/nickEquals.test.ts
+++ b/cicchetto/src/__tests__/nickEquals.test.ts
@@ -36,56 +36,107 @@ describe("asciiFold — single client fold, mirror of server canonical_nick/1", 
   });
 });
 
-describe("normalizeNick", () => {
-  it("lower-cases ASCII", () => {
-    expect(normalizeNick("Alice")).toBe("alice");
-    expect(normalizeNick("VJT-Grappa")).toBe("vjt-grappa");
+// #1861 — the per-network half. `normalizeNick`/`nickEquals` now take the
+// network's advertised CASEMAPPING and fold the four "national" characters
+// accordingly, mirroring the server's `Identifier.normalize_casemapping/2`
+// + `canonical_target/2` composition. The table below is the drift gate
+// against `national_byte/2`; the `:ascii` rows are the #525 posture and
+// MUST keep `[ ] \ ~` distinct from `{ } | ^`, because that is what
+// bahamut/Azzurra — all of production — implements.
+describe("normalizeNick — per-casemapping fold (#1861)", () => {
+  describe("ascii (bahamut / Azzurra — all of production)", () => {
+    it("lower-cases ASCII", () => {
+      expect(normalizeNick("Alice", "ascii")).toBe("alice");
+      expect(normalizeNick("VJT-Grappa", "ascii")).toBe("vjt-grappa");
+    });
+
+    // #525 — case folds, the bracket range does NOT (mirrors the ircd's
+    // CASEMAPPING=ascii). Reversing this breaks Azzurra.
+    it("folds case only, not the bracket range", () => {
+      expect(normalizeNick("Foo[1]", "ascii")).toBe("foo[1]");
+      expect(normalizeNick("A\\B~C", "ascii")).toBe("a\\b~c");
+    });
+
+    it("is idempotent", () => {
+      const once = normalizeNick("Alice", "ascii");
+      expect(normalizeNick(once, "ascii")).toBe(once);
+    });
   });
 
-  // #525 — normalizeNick is layered on asciiFold: case folds, the bracket
-  // range does NOT (mirrors the ircd's CASEMAPPING=ascii).
-  it("folds case only, not the bracket range", () => {
-    expect(normalizeNick("Foo[1]")).toBe("foo[1]");
-    expect(normalizeNick("A\\B~C")).toBe("a\\b~c");
+  describe("rfc1459 (solanum / Rizon — `[ ] \\ ~` fold to `{ } | ^`)", () => {
+    it("folds the full national set alongside A-Z", () => {
+      expect(normalizeNick("Foo[1]", "rfc1459")).toBe("foo{1}");
+      expect(normalizeNick("A\\B~C", "rfc1459")).toBe("a|b^c");
+      expect(normalizeNick("[EWG]-L0VE", "rfc1459")).toBe("{ewg}-l0ve");
+    });
+
+    it("leaves the fold TARGETS alone, so it is idempotent", () => {
+      expect(normalizeNick("{ewg}-l0ve", "rfc1459")).toBe("{ewg}-l0ve");
+      const once = normalizeNick("Foo[Bar]~Baz\\", "rfc1459");
+      expect(normalizeNick(once, "rfc1459")).toBe(once);
+    });
+
+    it("is byte-level: does NOT Unicode-fold non-ASCII", () => {
+      expect(normalizeNick("CAFÉ", "rfc1459")).toBe("cafÉ");
+    });
   });
 
-  it("is idempotent", () => {
-    const once = normalizeNick("Alice");
-    expect(normalizeNick(once)).toBe(once);
+  describe("rfc1459_strict (the bracket trio only — RFC 1459 predates the tilde rule)", () => {
+    it("folds [ ] \\ but leaves ~ alone", () => {
+      expect(normalizeNick("A\\B~C", "rfc1459_strict")).toBe("a|b~c");
+      expect(normalizeNick("Foo[1]", "rfc1459_strict")).toBe("foo{1}");
+      expect(normalizeNick("x~y", "rfc1459_strict")).toBe("x~y");
+    });
   });
 });
 
 describe("nickEquals", () => {
   it("returns true for casing variants", () => {
-    expect(nickEquals("Alice", "alice")).toBe(true);
-    expect(nickEquals("alice", "ALICE")).toBe(true);
-    expect(nickEquals("VjT-Grappa", "vjt-grappa")).toBe(true);
+    expect(nickEquals("Alice", "alice", "ascii")).toBe(true);
+    expect(nickEquals("alice", "ALICE", "ascii")).toBe(true);
+    expect(nickEquals("VjT-Grappa", "vjt-grappa", "ascii")).toBe(true);
   });
 
   it("returns true for identical nicks", () => {
-    expect(nickEquals("alice", "alice")).toBe(true);
+    expect(nickEquals("alice", "alice", "ascii")).toBe(true);
   });
 
   // #525 — case folds, but bracket-vs-brace does NOT: `foo[1]` and
   // `foo{1}` are DISTINCT nicks to the ircd (CASEMAPPING=ascii), so cic
   // keeps them apart too (reverses the #364 over-fold that merged them).
-  it("keeps bracket-vs-brace nicks distinct, folds case only", () => {
-    expect(nickEquals("Foo[1]", "foo[1]")).toBe(true);
-    expect(nickEquals("Foo[1]", "foo{1}")).toBe(false);
-    expect(nickEquals("a\\b", "a|b")).toBe(false);
-    expect(nickEquals("x~y", "x^y")).toBe(false);
+  it("keeps bracket-vs-brace nicks distinct on :ascii, folds case only", () => {
+    expect(nickEquals("Foo[1]", "foo[1]", "ascii")).toBe(true);
+    expect(nickEquals("Foo[1]", "foo{1}", "ascii")).toBe(false);
+    expect(nickEquals("a\\b", "a|b", "ascii")).toBe(false);
+    expect(nickEquals("x~y", "x^y", "ascii")).toBe(false);
+  });
+
+  // #1861 — the SAME pair on an rfc1459 network is ONE person. This is the
+  // reported symptom: `[EWG]-L0VE` and `{ewg}-l0ve` on Rizon.
+  it("collapses bracket-vs-brace nicks on :rfc1459", () => {
+    expect(nickEquals("Foo[1]", "foo{1}", "rfc1459")).toBe(true);
+    expect(nickEquals("[EWG]-L0VE", "{ewg}-l0ve", "rfc1459")).toBe(true);
+    expect(nickEquals("a\\b", "a|b", "rfc1459")).toBe(true);
+    expect(nickEquals("x~y", "x^y", "rfc1459")).toBe(true);
+  });
+
+  it("keeps ~ apart on :rfc1459_strict while folding the bracket trio", () => {
+    expect(nickEquals("Foo[1]", "foo{1}", "rfc1459_strict")).toBe(true);
+    expect(nickEquals("a\\b", "a|b", "rfc1459_strict")).toBe(true);
+    expect(nickEquals("x~y", "x^y", "rfc1459_strict")).toBe(false);
   });
 
   it("returns false for distinct nicks", () => {
-    expect(nickEquals("alice", "bob")).toBe(false);
-    expect(nickEquals("vjt", "vjt-grappa")).toBe(false);
+    expect(nickEquals("alice", "bob", "ascii")).toBe(false);
+    expect(nickEquals("vjt", "vjt-grappa", "ascii")).toBe(false);
+    expect(nickEquals("alice", "bob", "rfc1459")).toBe(false);
   });
 
   it("returns false when either side is null/undefined", () => {
-    expect(nickEquals(null, "alice")).toBe(false);
-    expect(nickEquals("alice", null)).toBe(false);
-    expect(nickEquals(null, null)).toBe(false);
-    expect(nickEquals(undefined, "alice")).toBe(false);
-    expect(nickEquals("alice", undefined)).toBe(false);
+    expect(nickEquals(null, "alice", "ascii")).toBe(false);
+    expect(nickEquals("alice", null, "ascii")).toBe(false);
+    expect(nickEquals(null, null, "ascii")).toBe(false);
+    expect(nickEquals(undefined, "alice", "ascii")).toBe(false);
+    expect(nickEquals("alice", undefined, "ascii")).toBe(false);
   });
 });

--- a/cicchetto/src/__tests__/ownPresenceEvent.test.ts
+++ b/cicchetto/src/__tests__/ownPresenceEvent.test.ts
@@ -15,58 +15,80 @@ const baseMsg: ScrollbackMessage = {
 
 describe("isOwnPresenceEvent", () => {
   it("returns true for kind:'join' from own nick", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "alice" }, "alice")).toBe(true);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "alice" }, "alice", "ascii"),
+    ).toBe(true);
   });
 
   it("returns true for kind:'part' from own nick", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "part", sender: "alice" }, "alice")).toBe(true);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "part", sender: "alice" }, "alice", "ascii"),
+    ).toBe(true);
   });
 
   it("returns true for kind:'quit' from own nick", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "quit", sender: "alice" }, "alice")).toBe(true);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "quit", sender: "alice" }, "alice", "ascii"),
+    ).toBe(true);
   });
 
   it("returns true for kind:'nick_change' from own nick", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "nick_change", sender: "alice" }, "alice")).toBe(
-      true,
-    );
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "nick_change", sender: "alice" }, "alice", "ascii"),
+    ).toBe(true);
   });
 
   it("returns true for kind:'mode' from own nick", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "mode", sender: "alice" }, "alice")).toBe(true);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "mode", sender: "alice" }, "alice", "ascii"),
+    ).toBe(true);
   });
 
   it("returns true for kind:'kick' from own nick (operator kicked)", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "kick", sender: "alice" }, "alice")).toBe(true);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "kick", sender: "alice" }, "alice", "ascii"),
+    ).toBe(true);
   });
 
   it("returns false for presence kind from peer nick", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "bob" }, "alice")).toBe(false);
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "part", sender: "bob" }, "alice")).toBe(false);
+    expect(isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "bob" }, "alice", "ascii")).toBe(
+      false,
+    );
+    expect(isOwnPresenceEvent({ ...baseMsg, kind: "part", sender: "bob" }, "alice", "ascii")).toBe(
+      false,
+    );
   });
 
   it("returns false for content kinds even from own nick", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "privmsg", sender: "alice" }, "alice")).toBe(
-      false,
-    );
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "notice", sender: "alice" }, "alice")).toBe(
-      false,
-    );
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "action", sender: "alice" }, "alice")).toBe(
-      false,
-    );
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "privmsg", sender: "alice" }, "alice", "ascii"),
+    ).toBe(false);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "notice", sender: "alice" }, "alice", "ascii"),
+    ).toBe(false);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "action", sender: "alice" }, "alice", "ascii"),
+    ).toBe(false);
   });
 
   it("returns false when ownNick is null (no comparison possible)", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "alice" }, null)).toBe(false);
+    expect(isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "alice" }, null, "ascii")).toBe(
+      false,
+    );
   });
 
   it("is case-insensitive (RFC 2812 nicks via nickEquals)", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "Alice" }, "alice")).toBe(true);
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "part", sender: "ALICE" }, "alice")).toBe(true);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "join", sender: "Alice" }, "alice", "ascii"),
+    ).toBe(true);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "part", sender: "ALICE" }, "alice", "ascii"),
+    ).toBe(true);
   });
 
   it("kind:'topic' is NOT in the presence set (delivered via topic_changed WS event)", () => {
-    expect(isOwnPresenceEvent({ ...baseMsg, kind: "topic", sender: "alice" }, "alice")).toBe(false);
+    expect(
+      isOwnPresenceEvent({ ...baseMsg, kind: "topic", sender: "alice" }, "alice", "ascii"),
+    ).toBe(false);
   });
 });

--- a/cicchetto/src/__tests__/pseudoChannels.test.ts
+++ b/cicchetto/src/__tests__/pseudoChannels.test.ts
@@ -26,7 +26,12 @@ const state = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/windowState", () => ({ windowStateByChannel: () => state.ws }));
-vi.mock("../lib/networks", () => ({ channelsBySlug: () => state.cbs }));
+vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
+  channelsBySlug: () => state.cbs,
+}));
 vi.mock("../lib/queryWindows", () => ({ queryWindowsByNetwork: () => state.qw }));
 // The form factor is an environment boundary (matchMedia); mocking the
 // signal is what lets one jsdom run exercise both navs.

--- a/cicchetto/src/__tests__/pushTarget.test.ts
+++ b/cicchetto/src/__tests__/pushTarget.test.ts
@@ -19,6 +19,9 @@ vi.mock("../lib/selection", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: vi.fn(() => [{ id: 1, slug: "libera", kind: "user", connection_state: "connected" }]),
   channelsBySlug: vi.fn(() => ({
     libera: [{ id: 10, name: "#sniffo" }],

--- a/cicchetto/src/__tests__/queryWindows.test.ts
+++ b/cicchetto/src/__tests__/queryWindows.test.ts
@@ -126,17 +126,59 @@ describe("queryWindows state", () => {
     expect(socket.pushOpenQueryWindow).toHaveBeenCalledWith(1, "dave");
   });
 
-  // #525 — dedup folds CASE only (server keys on canonical_nick/1 =
-  // CASEMAPPING=ascii). `Foo[1]` and `foo{1}` are DISTINCT windows, so a
-  // second open on the brace twin is NOT a dup and DOES round-trip.
-  it("openQueryWindowState does NOT dedup a bracket-vs-brace nick (#525)", async () => {
+  // #525/#1861 — the bracket-vs-brace pair is keyed PER CASEMAPPING, not
+  // globally. On `:ascii` (bahamut/Azzurra, all of production) the ircd
+  // keeps `Foo[1]` and `foo{1}` apart and so must cic; on `:rfc1459`
+  // (solanum/Rizon) they are ONE person and the second open is a dup.
+  // Weakening the `:ascii` half instead of splitting it would break Azzurra.
+  it("openQueryWindowState does NOT dedup a bracket-vs-brace nick on :ascii (#525)", async () => {
     const socket = await import("../lib/socket");
+    const { DEFAULT_ISUPPORT, seedIsupport } = await import("../lib/isupport");
     const { setQueryWindowsByNetwork, openQueryWindowState } = await import("../lib/queryWindows");
+    seedIsupport(1, { ...DEFAULT_ISUPPORT, casemapping: "ascii" });
     setQueryWindowsByNetwork({
       1: [{ targetNick: "Foo[1]", openedAt: "2026-05-04T10:00:00Z" }],
     });
     openQueryWindowState(1, "foo{1}", "2026-05-04T12:00:00Z");
     expect(socket.pushOpenQueryWindow).toHaveBeenCalledWith(1, "foo{1}");
+  });
+
+  it("openQueryWindowState DOES dedup a bracket-vs-brace nick on :rfc1459 (#1861)", async () => {
+    const socket = await import("../lib/socket");
+    const { DEFAULT_ISUPPORT, seedIsupport } = await import("../lib/isupport");
+    const { setQueryWindowsByNetwork, openQueryWindowState } = await import("../lib/queryWindows");
+    seedIsupport(1, { ...DEFAULT_ISUPPORT, casemapping: "rfc1459" });
+    setQueryWindowsByNetwork({
+      1: [{ targetNick: "[EWG]-L0VE", openedAt: "2026-05-04T10:00:00Z" }],
+    });
+    openQueryWindowState(1, "{ewg}-l0ve", "2026-05-04T12:00:00Z");
+    expect(socket.pushOpenQueryWindow).not.toHaveBeenCalled();
+  });
+
+  // The per-network scoping is the point: an rfc1459 seed on network 2 must
+  // not soften network 1's `:ascii` fold.
+  it("the rfc1459 fold does not leak across networks (#1861)", async () => {
+    const socket = await import("../lib/socket");
+    const { DEFAULT_ISUPPORT, seedIsupport } = await import("../lib/isupport");
+    const { setQueryWindowsByNetwork, openQueryWindowState } = await import("../lib/queryWindows");
+    seedIsupport(2, { ...DEFAULT_ISUPPORT, casemapping: "rfc1459" });
+    setQueryWindowsByNetwork({
+      1: [{ targetNick: "Foo[1]", openedAt: "2026-05-04T10:00:00Z" }],
+    });
+    openQueryWindowState(1, "foo{1}", "2026-05-04T12:00:00Z");
+    expect(socket.pushOpenQueryWindow).toHaveBeenCalledWith(1, "foo{1}");
+  });
+
+  // An unseeded network (no 005 yet) folds `:ascii` — the server's own
+  // pre-005 default, and the narrower fold, so a guess merges nobody.
+  it("an unseeded network folds :ascii (#1861)", async () => {
+    const socket = await import("../lib/socket");
+    const { setQueryWindowsByNetwork, openQueryWindowState } = await import("../lib/queryWindows");
+    setQueryWindowsByNetwork({
+      7: [{ targetNick: "Foo[1]", openedAt: "2026-05-04T10:00:00Z" }],
+    });
+    openQueryWindowState(7, "foo{1}", "2026-05-04T12:00:00Z");
+    expect(socket.pushOpenQueryWindow).toHaveBeenCalledWith(7, "foo{1}");
   });
 
   // Nick case-sensitivity fix (post-U): canonicalQueryNick resolves
@@ -156,8 +198,10 @@ describe("queryWindows state", () => {
       expect(canonicalQueryNick(1, "grappa")).toBe("grappa");
     });
 
-    it("resolves case-only; a bracket-vs-brace nick is a DISTINCT window (#525)", async () => {
+    it("on :ascii resolves case-only; bracket-vs-brace is a DISTINCT window (#525)", async () => {
+      const { DEFAULT_ISUPPORT, seedIsupport } = await import("../lib/isupport");
       const { setQueryWindowsByNetwork, canonicalQueryNick } = await import("../lib/queryWindows");
+      seedIsupport(1, { ...DEFAULT_ISUPPORT, casemapping: "ascii" });
       setQueryWindowsByNetwork({
         1: [{ targetNick: "Foo[1]", openedAt: "2026-05-04T10:00:00Z" }],
       });
@@ -166,6 +210,21 @@ describe("queryWindows state", () => {
       // `foo{1}` is a DIFFERENT nick to the ircd (CASEMAPPING=ascii) — no
       // window matches, so the input is returned unchanged.
       expect(canonicalQueryNick(1, "foo{1}")).toBe("foo{1}");
+    });
+
+    it("on :rfc1459 resolves the brace twin onto the stored bracket casing (#1861)", async () => {
+      const { DEFAULT_ISUPPORT, seedIsupport } = await import("../lib/isupport");
+      const { setQueryWindowsByNetwork, canonicalQueryNick } = await import("../lib/queryWindows");
+      seedIsupport(1, { ...DEFAULT_ISUPPORT, casemapping: "rfc1459" });
+      setQueryWindowsByNetwork({
+        1: [{ targetNick: "[EWG]-L0VE", openedAt: "2026-05-04T10:00:00Z" }],
+      });
+      // The reported symptom: the incoming DM spells the peer `{ewg}-l0ve`,
+      // the open window spells it `[EWG]-L0VE`, and on Rizon they are one
+      // person — so the focus resolves onto the existing window instead of
+      // keying a second, dead one.
+      expect(canonicalQueryNick(1, "{ewg}-l0ve")).toBe("[EWG]-L0VE");
+      expect(canonicalQueryNick(1, "[ewg]-l0ve")).toBe("[EWG]-L0VE");
     });
 
     it("returns the input unchanged when no window matches", async () => {

--- a/cicchetto/src/__tests__/reconnect.test.ts
+++ b/cicchetto/src/__tests__/reconnect.test.ts
@@ -23,7 +23,12 @@ vi.mock("../lib/api", () => ({
     patchNetworkMock(t, slug, body),
 }));
 vi.mock("../lib/auth", () => ({ token: () => tokenMock() }));
-vi.mock("../lib/networks", () => ({ networks: () => networksMock() }));
+vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
+  networks: () => networksMock(),
+}));
 
 import { reconnectConnectedNetworks } from "../lib/reconnect";
 

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1142,13 +1142,18 @@ describe("subscribe — WS join effect", () => {
       // matters. Assert the call count includes the privmsg too.
       expect(members.applyPresenceEvent).toHaveBeenCalledTimes(7);
       const key = channelKey("freenode", "#grappa");
+      // #1861 — the third argument is the network's fold, which the store
+      // cannot resolve for itself (it is ChannelKey-keyed). `freenode` is
+      // unseeded here, so it is the `:ascii` default.
       expect(members.applyPresenceEvent).toHaveBeenCalledWith(
         key,
         expect.objectContaining({ id: 10, kind: "join" }),
+        "ascii",
       );
       expect(members.applyPresenceEvent).toHaveBeenCalledWith(
         key,
         expect.objectContaining({ id: 14, kind: "mode" }),
+        "ascii",
       );
     });
 

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -24,6 +24,9 @@ vi.mock("../lib/socket", () => ({
 }));
 
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   user: vi.fn(() => ({ kind: "user", id: "u1", name: "vjt", is_admin: false, inserted_at: "x" })),
   refetchChannels: vi.fn(),
   refetchNetworks: vi.fn(),

--- a/cicchetto/src/__tests__/windowClose.test.ts
+++ b/cicchetto/src/__tests__/windowClose.test.ts
@@ -50,6 +50,9 @@ vi.mock(import("../lib/auth"), async (importOriginal) => {
 
 const mockNetworks: { kind: string; slug: string }[] = [];
 vi.mock("../lib/networks", () => ({
+  // #1861 — casemappingForSlug (lib/casemapping.ts) resolves the fold
+  // through this map, so the mock has to carry it.
+  networkIdBySlug: () => undefined,
   networks: () => mockNetworks,
 }));
 

--- a/cicchetto/src/lib/archive.ts
+++ b/cicchetto/src/lib/archive.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { type ArchiveEntry, listArchive } from "./api";
 import { token } from "./auth";
 import { identityScopedStore } from "./identityScopedStore";
+import { casemappingForNetwork } from "./isupport";
 import { channelsBySlug } from "./networks";
 import { normalizeNick } from "./nickEquals";
 import { navPseudoChannelsForNetwork } from "./pseudoChannels";
@@ -152,20 +153,28 @@ export const setArchiveModalOpen = exports_.setArchiveModalOpen;
 export function visibleArchiveForNetwork(slug: string, networkId: number): ArchiveEntry[] {
   const entries = archivedBySlug()[slug] ?? [];
   if (entries.length === 0) return entries;
-  // #372: fold every comparison key under ASCII casemapping (`normalizeNick`
-  // — the single client mirror of the server fold, A-Z only; #525). A
-  // service that replied as `DebugServ` archives under that casing while
-  // the open window is `debugserv`; a raw `Set.has` would leave the
-  // archived split visible. Folding both sides collapses the casing so an
-  // active window suppresses its archived variant. Idempotent on channel
-  // names (already server-canonical) and ASCII-only (non-ASCII case
-  // variants stay distinct, matching the ircd + the server's fold).
-  const liveChannels = new Set((channelsBySlug()?.[slug] ?? []).map((c) => normalizeNick(c.name)));
+  // #372: fold every comparison key with `normalizeNick` — the single client
+  // mirror of the server fold. A service that replied as `DebugServ` archives
+  // under that casing while the open window is `debugserv`; a raw `Set.has`
+  // would leave the archived split visible. Folding both sides collapses the
+  // casing so an active window suppresses its archived variant. Idempotent on
+  // channel names (already server-canonical) and never Unicode-folding
+  // (non-ASCII case variants stay distinct, matching the ircd).
+  //
+  // #1861: the fold is this NETWORK's. Every key here comes from cic's own
+  // state, so both sides of each compare move together; on `:ascii` (all of
+  // production) the behaviour is byte-for-byte what #372 shipped.
+  const casemapping = casemappingForNetwork(networkId);
+  const liveChannels = new Set(
+    (channelsBySlug()?.[slug] ?? []).map((c) => normalizeNick(c.name, casemapping)),
+  );
   const liveQueries = new Set(
-    (queryWindowsByNetwork()[networkId] ?? []).map((qw) => normalizeNick(qw.targetNick)),
+    (queryWindowsByNetwork()[networkId] ?? []).map((qw) =>
+      normalizeNick(qw.targetNick, casemapping),
+    ),
   );
   // Reuse the ONE shared pseudo-row projection — folding its names
-  // (ASCII, #372/#525) for the archive's own compare. See the block comment
+  // (#372/#525/#1861) for the archive's own compare. See the block comment
   // above for why this MUST NOT re-derive from raw windowState.
   //
   // #402: subtract what the nav of THIS form factor actually draws, not the
@@ -174,10 +183,10 @@ export function visibleArchiveForNetwork(slug: string, networkId: number): Archi
   // there left the window with no surface at all. `navPseudoChannelsForNetwork`
   // owns that narrowing for the navs too, so the two cannot drift.
   const pseudoNames = new Set(
-    navPseudoChannelsForNetwork(slug, networkId).map((row) => normalizeNick(row.name)),
+    navPseudoChannelsForNetwork(slug, networkId).map((row) => normalizeNick(row.name, casemapping)),
   );
   return entries.filter((entry) => {
-    const folded = normalizeNick(entry.target);
+    const folded = normalizeNick(entry.target, casemapping);
     if (pseudoNames.has(folded)) return false;
     if (entry.kind === "channel") return !liveChannels.has(folded);
     return !liveQueries.has(folded);

--- a/cicchetto/src/lib/casemapping.ts
+++ b/cicchetto/src/lib/casemapping.ts
@@ -1,0 +1,29 @@
+// #1861 — the slug-keyed door to the network's advertised CASEMAPPING.
+//
+// `isupport.ts` owns the fact and keys it by network ID, like every other
+// 005 fact. Most of cic, however, is keyed by network SLUG (ChannelKey,
+// the selection, the per-slug caches), so the fold resolution needs the
+// `slug → id → casemapping` hop. That hop was open-coded once already for
+// CHANTYPES= (`compose.sigilsFor`); a nick fold is needed in a dozen
+// modules, so it lives here instead of a dozen private copies.
+//
+// It is its OWN module rather than a function in `isupport.ts` because
+// this is the only edge that needs `networks.ts`: keeping it out of
+// `isupport.ts` leaves that store a leaf (chantypes + moduleRoot +
+// wireTypes) and keeps the pure fold in `nickEquals.ts` free of the
+// solid-js resource graph.
+
+import { type Casemapping, casemappingForNetwork } from "./isupport";
+import { networkIdBySlug } from "./networks";
+
+/**
+ * How the network behind `slug` folds identifiers, or `"ascii"` when the
+ * slug names no known network (boot before the networks resource lands, a
+ * stale selection, a pseudo-window).
+ *
+ * `"ascii"` is the safe fallback in both directions: it is the pre-005
+ * default the server itself uses, and it is the NARROWER fold, so a wrong
+ * guess never merges two identities the ircd keeps apart.
+ */
+export const casemappingForSlug = (slug: string): Casemapping =>
+  casemappingForNetwork(networkIdBySlug(slug) ?? null);

--- a/cicchetto/src/lib/channelEditPerm.ts
+++ b/cicchetto/src/lib/channelEditPerm.ts
@@ -1,7 +1,7 @@
 import { ownNickForNetwork } from "./api";
 import type { ChannelKey } from "./channelKey";
 import { editorSigils } from "./channelModes";
-import { isupportForNetwork } from "./isupport";
+import { casemappingForNetwork, isupportForNetwork } from "./isupport";
 import { membersByChannel } from "./members";
 import { networkBySlug, user } from "./networks";
 import { nickEquals } from "./nickEquals";
@@ -41,7 +41,9 @@ export function ownHoldsChannelEditorSigil(
   if (!net || !me) return false;
   const nick = ownNickForNetwork(net, me);
   if (!nick) return false;
-  const entry = (membersByChannel()[key] ?? []).find((m) => nickEquals(m.nick, nick));
+  const entry = (membersByChannel()[key] ?? []).find((m) =>
+    nickEquals(m.nick, nick, casemappingForNetwork(networkId)),
+  );
   const modes = entry?.modes ?? [];
   const editors = editorSigils(isupportForNetwork(networkId));
   return modes.some((m) => editors.has(m));

--- a/cicchetto/src/lib/commands/mode.ts
+++ b/cicchetto/src/lib/commands/mode.ts
@@ -1,5 +1,6 @@
 import { ownNickForNetwork } from "../api";
 import { openBanlistModal } from "../banlistModal";
+import { casemappingForSlug } from "../casemapping";
 import { isChannelName } from "../chantypes";
 import { type IsupportEntry, isupportForNetwork } from "../isupport";
 import { openModeModal } from "../modeModal";
@@ -140,13 +141,13 @@ export const umodeViewCommand: CommandHandler<"umode-view"> = async (_cmd, ctx) 
  * there is no viewer for another user's). Resolve via `ownNickForNetwork`
  * (visitor → me.nick; user → per-credential net.nick) — the same canonical
  * resolver the /whois self-default uses; `nickEquals` for the
- * case-insensitive compare (ASCII, #121/#525). A non-self target is a friendly
+ * case-insensitive compare (per-network fold, #121/#525/#1861). A non-self target is a friendly
  * error rather than a phantom modal.
  */
 export const umodeTargetViewCommand: CommandHandler<"umode-target-view"> = async (cmd, ctx) => {
   const net = networkBySlug(ctx.networkSlug);
   const own = net ? ownNickForNetwork(net, user()) : null;
-  if (own && nickEquals(cmd.target, own)) {
+  if (own && nickEquals(cmd.target, own, casemappingForSlug(ctx.networkSlug))) {
     openUmodeModal(ctx.networkSlug);
     return { ok: true };
   }

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -2,6 +2,7 @@ import { createEffect, createSignal, on } from "solid-js";
 import { aliases } from "./aliasList";
 import { ownNickForNetwork } from "./api";
 import { token } from "./auth";
+import { casemappingForSlug } from "./casemapping";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { isChannelName } from "./chantypes";
 import type { CommandContext, DispatchOutcome, SubmitResult } from "./commands/context";
@@ -79,7 +80,7 @@ import { joinedChannelsOnNetwork } from "./joinedChannels";
 import { membersByChannel } from "./members";
 import { splitMessageLines } from "./messageLines";
 import { networkBySlug, networkIdBySlug, user } from "./networks";
-import { asciiFold } from "./nickEquals";
+import { normalizeNick } from "./nickEquals";
 import { ensureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 // #1225 — the seam sends a PRIVMSG to the window OR relays a NOTICE/CTCP to a
@@ -102,11 +103,11 @@ const sigilsFor = (slug: string): readonly string[] =>
 
 // #1003 — IRC nicks wear decoration (`_omino_`, `bob^`, `gio-vanni`), so
 // Tab must reach `_omino_` from the bare `omi`. Deliberately NOT taught to
-// `asciiFold`: that helper is protocol IDENTITY (the cic mirror of
-// `Grappa.IRC.Identifier.canonical_nick/1`, shared with nickColor /
-// notifyWatch / channelKey / pingCorrelation), and folding `_` there would
-// make `foo` and `f_o_o` the SAME person for highlight, colour and
-// presence. This one is local to the completion matcher, where a wrong
+// `normalizeNick`/`asciiFold`: those are protocol IDENTITY (the cic mirror
+// of `Grappa.IRC.Identifier.canonical_target/1` and `/2`, shared with
+// nickColor / notifyWatch / channelKey / pingCorrelation), and folding `_`
+// there would make `foo` and `f_o_o` the SAME person for highlight, colour
+// and presence. This one is local to the completion matcher, where a wrong
 // guess costs a second Tab, not an identity merge.
 const stripNickDecoration = (s: string): string => s.replace(/[[\]\\`_^{|}-]/g, "");
 
@@ -1345,7 +1346,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // #1255 — completing a CHANNEL vs a NICK is decided by this network's
     // advertised sigils, not the RFC class: on a `CHANTYPES=#` network a
     // `&foo` token completes against members, not channels.
-    const tabSigils = sigilsFor(decodeChannelKey(key)?.slug ?? "");
+    const tabSlug = decodeChannelKey(key)?.slug ?? "";
+    const tabSigils = sigilsFor(tabSlug);
+    // #1861 — the same per-network resolution for the nick fold. A key that
+    // does not decode leaves the slug empty, which resolves to `:ascii`.
+    const tabCasemapping = casemappingForSlug(tabSlug);
 
     const continuing =
       tabCycle !== null &&
@@ -1373,21 +1378,24 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       typedWord = input.slice(start, cursor);
       if (typedWord.length === 0) return null;
       anchorStart = start;
-      // ASCII fold (not a bare toLowerCase) so `Foo` completes a member
-      // `foo` — bahamut is CASEMAPPING=ascii (#525), folding `A-Z` ONLY.
-      // `[ ] \ ~` are NOT folded, so for IDENTITY `foo{` and `Foo[1]` stay
-      // DISTINCT nicks. toLowerCase is avoided because it Unicode-over-folds
-      // non-ASCII (`CAFÉ`→`café`), not the brackets. Mirror of
-      // `Grappa.IRC.Identifier.canonical_nick/1`.
+      // Fold with the NETWORK's casemapping (not a bare toLowerCase) so
+      // `Foo` completes a member `foo`. On bahamut (`CASEMAPPING=ascii`,
+      // #525) that folds `A-Z` ONLY: `[ ] \ ~` are NOT folded, so for
+      // IDENTITY `foo{` and `Foo[1]` stay DISTINCT nicks. On an rfc1459
+      // network (#1861) they are the SAME nick and the literal level says
+      // so. toLowerCase is avoided because it Unicode-over-folds non-ASCII
+      // (`CAFÉ`→`café`), not the brackets. Mirror of
+      // `Grappa.IRC.Identifier.canonical_target/2`.
       //
       // Careful, this is only HALF the completion rule (#1003): the second
-      // level below counts `{ | }` as decoration alongside `[ ] \`, so
-      // `foo{<TAB>` CAN reach `Foo[1]` — strictly BEHIND every literal
-      // match, never displacing one. That is not an identity merge and does
-      // not soften #525: nothing here is a key, and what gets inserted is
-      // always the real nick. Keep both halves stated — a reader who sees
-      // only this paragraph will "fix" the second level as a leftover.
-      prefix = asciiFold(typedWord);
+      // level below counts `{ | }` as decoration alongside `[ ] \`, so on
+      // an `:ascii` network `foo{<TAB>` CAN still reach `Foo[1]` — strictly
+      // BEHIND every literal match, never displacing one. That is not an
+      // identity merge and does not soften #525: nothing here is a key, and
+      // what gets inserted is always the real nick. Keep both halves stated
+      // — a reader who sees only this paragraph will "fix" the second level
+      // as a leftover.
+      prefix = normalizeNick(typedWord, tabCasemapping);
       // ": " only when the word is the first token on the line — and only
       // for a NICK. A channel is a topic of conversation, never an
       // addressee, so `#chan: ` would be wrong at line start (#30).
@@ -1403,7 +1411,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       ? joinedChannelsOnNetwork(key)
       : (membersByChannel()[key] ?? []).map((m) => m.nick);
     const byName = (a: string, b: string) => a.localeCompare(b);
-    const literal = candidates.filter((c) => asciiFold(c).startsWith(prefix)).sort(byName);
+    const literal = candidates
+      .filter((c) => normalizeNick(c, tabCasemapping).startsWith(prefix))
+      .sort(byName);
     // Second level (#1003), nicks only: the same prefix test with the
     // decoration removed from BOTH sides. It runs AFTER the literal
     // matches — the order IS the behaviour, so with `omino` and `_oMiNo_`
@@ -1418,7 +1428,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         : candidates
             .filter(
               (c) =>
-                !literal.includes(c) && stripNickDecoration(asciiFold(c)).startsWith(looseWord),
+                !literal.includes(c) &&
+                stripNickDecoration(normalizeNick(c, tabCasemapping)).startsWith(looseWord),
             )
             .sort(byName);
     const matches = [...literal, ...loose];

--- a/cicchetto/src/lib/isupport.ts
+++ b/cicchetto/src/lib/isupport.ts
@@ -60,10 +60,11 @@ export type IsupportEntry = {
   // to the RFC 2812 class, so a network that omits the token behaves
   // exactly as the open-coded literals did.
   chantypes: string[];
-  // #1255 — how the ircd folds identifiers. cic still folds ASCII-only
-  // (`nickEquals.asciiFold`, pinned to the server's #525 posture); this
-  // carries the per-network fact that used to die at ingress, so a
-  // divergence on an rfc1459 network is at least KNOWABLE client-side.
+  // #1255 — how the ircd folds identifiers. #1861 gave it a consumer:
+  // `casemappingForNetwork` below feeds `normalizeNick`/`nickEquals`, so a
+  // nick KEY now folds the way THIS network folds it instead of ASCII
+  // everywhere. (The channel-key fold in `channelKey.ts` is still
+  // ASCII-only — see the survivor list in `nickEquals.ts`.)
   casemapping: Casemapping;
   // #1255 — advertised cap per type-A (list) mode letter, e.g.
   // `{b: 100, e: 100, I: 100}`. Empty when the network advertised none:
@@ -193,6 +194,22 @@ export function chantypesForNetwork(networkId: number | null): readonly string[]
 export function prefixForNetwork(networkId: number | null): Record<string, string> {
   if (networkId === null) return DEFAULT_ISUPPORT.prefix;
   return isupportForNetwork(networkId).prefix;
+}
+
+/**
+ * How this network folds identifiers (#1861), or the bahamut/Azzurra
+ * default `"ascii"` for an unseeded network / a null id. Sibling of
+ * `chantypesForNetwork` — the store-reading half of the nick fold, whose
+ * pure half is `normalizeNick`/`nickEquals` in `nickEquals.ts`.
+ *
+ * `"ascii"` is the honest default here, unlike `frameBudgetBaseForNetwork`'s
+ * `null`: it is what `Grappa.Session.ISupport.default/0` uses pre-005, it
+ * is what every production network advertises, and it is the NARROWER fold
+ * — guessing it merges no identity the ircd keeps apart.
+ */
+export function casemappingForNetwork(networkId: number | null): Casemapping {
+  if (networkId === null) return DEFAULT_ISUPPORT.casemapping;
+  return isupportForNetwork(networkId).casemapping;
 }
 
 /**

--- a/cicchetto/src/lib/members.ts
+++ b/cicchetto/src/lib/members.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import type { ScrollbackMessage } from "./api";
 import type { ChannelKey } from "./channelKey";
 import { identityScopedStore } from "./identityScopedStore";
+import type { Casemapping } from "./isupport";
 import type { ChannelMembers } from "./memberTypes";
 import { applyModeString } from "./modeApply";
 import { nickEquals } from "./nickEquals";
@@ -48,7 +49,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     setMembersByChannel((prev) => ({ ...prev, [key]: list }));
   };
 
-  const applyPresenceEvent = (key: ChannelKey, msg: ScrollbackMessage): void => {
+  // #1861 — the casemapping is passed IN rather than resolved here: this
+  // store is keyed by ChannelKey and never learns a network id, and the
+  // dispatcher (`subscribe.ts`) already holds the network. Same
+  // fact-as-data shape `chantypes.ts` uses for CHANTYPES=.
+  const applyPresenceEvent = (
+    key: ChannelKey,
+    msg: ScrollbackMessage,
+    casemapping: Casemapping,
+  ): void => {
     setMembersByChannel((prev) => {
       const current = prev[key] ?? [];
 
@@ -57,19 +66,19 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // Skip if already present (out-of-order JOIN after 353 NAMES).
           // Case-insensitive (RFC 2812 §2.2) — server may emit JOIN with
           // differently-cased nick than the prior NAMES snapshot.
-          if (current.some((m) => nickEquals(m.nick, msg.sender))) return prev;
+          if (current.some((m) => nickEquals(m.nick, msg.sender, casemapping))) return prev;
           return { ...prev, [key]: [...current, { nick: msg.sender, modes: [] }] };
         }
         case "part":
         case "quit": {
-          const next = current.filter((m) => !nickEquals(m.nick, msg.sender));
+          const next = current.filter((m) => !nickEquals(m.nick, msg.sender, casemapping));
           if (next.length === current.length) return prev;
           return { ...prev, [key]: next };
         }
         case "kick": {
           const target = typeof msg.meta.target === "string" ? msg.meta.target : null;
           if (!target) return prev;
-          const next = current.filter((m) => !nickEquals(m.nick, target));
+          const next = current.filter((m) => !nickEquals(m.nick, target, casemapping));
           if (next.length === current.length) return prev;
           return { ...prev, [key]: next };
         }
@@ -77,7 +86,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           const newNick = typeof msg.meta.new_nick === "string" ? msg.meta.new_nick : null;
           if (!newNick) return prev;
           const next = current.map((m) =>
-            nickEquals(m.nick, msg.sender) ? { ...m, nick: newNick } : m,
+            nickEquals(m.nick, msg.sender, casemapping) ? { ...m, nick: newNick } : m,
           );
           return { ...prev, [key]: next };
         }
@@ -87,7 +96,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
             ? (msg.meta.args.filter((a) => typeof a === "string") as string[])
             : [];
           if (!modes) return prev;
-          const next = applyModeString(current, modes, args);
+          const next = applyModeString(current, modes, args, casemapping);
           return { ...prev, [key]: next };
         }
         case "privmsg":

--- a/cicchetto/src/lib/modeApply.ts
+++ b/cicchetto/src/lib/modeApply.ts
@@ -1,3 +1,4 @@
+import type { Casemapping } from "./isupport";
 import type { ChannelMembers } from "./memberTypes";
 import { nickEquals } from "./nickEquals";
 
@@ -27,6 +28,7 @@ export function applyModeString(
   members: ChannelMembers,
   modeStr: string,
   args: readonly string[],
+  casemapping: Casemapping,
 ): ChannelMembers {
   if (modeStr.length === 0) return members;
 
@@ -63,7 +65,7 @@ export function applyModeString(
       // Pre-fix bare `===` would silently no-op a MODE event whose target
       // arg arrived in a different casing than the JOIN/NAMES that
       // populated the members store.
-      if (!nickEquals(entry.nick, target)) return entry;
+      if (!nickEquals(entry.nick, target, casemapping)) return entry;
       const has = entry.modes.includes(prefix);
       if (sign === "+" && has) return entry;
       if (sign === "-" && !has) return entry;

--- a/cicchetto/src/lib/nickColor.ts
+++ b/cicchetto/src/lib/nickColor.ts
@@ -1,3 +1,4 @@
+import type { Casemapping } from "./isupport";
 import type { ChannelMembers } from "./memberTypes";
 import { asciiFold, nickEquals } from "./nickEquals";
 
@@ -93,6 +94,14 @@ export const NICK_PALETTE_SIZE = 32;
 // djb2 hash, classic 5381 seed + 33 multiplier. Folded modulo
 // NICK_PALETTE_SIZE at the boundary; intermediate keeps full 32-bit
 // width via Math.imul to avoid sign-bit weirdness from `* 33`.
+//
+// #1861 — deliberately still `asciiFold`, NOT the per-network
+// `normalizeNick`. This is a palette hash, not an identity key: on an
+// rfc1459 network `Foo[1]` and `foo{1}` are one person and get two
+// colours, which is cosmetic. Making it network-aware would need the
+// network id at every render site and would re-colour existing rows
+// (the `ux-5-bc2-nick-render` e2e spec pins `djb2(asciiFold(nick))`),
+// for no identity correctness. See the survivor list in `nickEquals.ts`.
 export const nickColorIndex = (nick: string): number => {
   const folded = asciiFold(nick);
   let hash = 5381;
@@ -114,9 +123,10 @@ export const nickColorVar = (nick: string): string => `var(--nick-color-${nickCo
 export const senderPrefix = (
   members: ChannelMembers | undefined,
   nick: string,
+  casemapping: Casemapping,
 ): "@" | "%" | "+" | "" => {
   if (!members) return "";
-  const entry = members.find((m) => nickEquals(m.nick, nick));
+  const entry = members.find((m) => nickEquals(m.nick, nick, casemapping));
   if (!entry) return "";
   if (entry.modes.includes("@")) return "@";
   if (entry.modes.includes("%")) return "%";

--- a/cicchetto/src/lib/nickEquals.ts
+++ b/cicchetto/src/lib/nickEquals.ts
@@ -1,23 +1,43 @@
 // Case-insensitive IRC nickname comparison — the SINGLE client-side
 // nick fold + equality helper.
 //
-// ## One fold, pinned to the server (#525)
+// ## Two tiers, and which one a call site wants (#525 + #1861)
+//
+// `asciiFold` is the plain `A-Z` byte fold: the client mirror of the
+// server's arity-1 `Grappa.IRC.Identifier.canonical_target/1`.
+// `normalizeNick`/`nickEquals` are the NETWORK-AWARE tier: they take the
+// casemapping the ircd advertised in 005 and mirror the server's
+// `normalize_casemapping/2` ∘ `canonical_target/1` composition, i.e. the
+// arity-2 `canonical_target/2` that #537 introduced.
+//
+// On `:ascii` the two tiers are byte-for-byte identical, so on
+// bahamut/Azzurra — all of production — nothing about this file's output
+// changed with #1861.
+//
+// ## Why the network tier had to exist (#1861)
+//
+// `CASEMAPPING=rfc1459` (solanum, Rizon's plexus/hybrid) declares `{ } | ^`
+// the lowercase of `[ ] \ ~`, so `[EWG]-L0VE` and `{ewg}-l0ve` are ONE
+// person there. cic folded ASCII-only with no network in scope at all —
+// `normalizeNick`/`nickEquals` took a single string — so no call site could
+// fold per-network even when it held the network id. The sidebar rendered
+// two query windows for one peer and the conversation split.
+//
+// The fold tables below MIRROR the server's `national_byte/2`; they are not
+// re-derived from the RFCs. `nickEquals.test.ts` enumerates them as the
+// drift gate, the client twin of the server's own pin test.
+//
+// ## One fold, pinned to the server (#525) — still true, per tier
 //
 // Azzurra runs bahamut, which advertises AND implements
-// `CASEMAPPING=ascii` — it folds ONLY `A-Z`, leaving `[ ] \ ~`
-// untouched. The server's single source of truth is
-// `Grappa.IRC.Identifier.canonical_nick/1` (byte-level ASCII).
-// `asciiFold` below is the ONE client mirror of that fold;
-// `normalizeNick` and `nickEquals` are layered on it so the whole cic
-// codebase folds nicks exactly as the server does — no two-policy drift
-// class. `nickEquals.test.ts` enumerates the fold table as a drift gate.
-//
-// #525 corrected the fold: #121/#364 assumed `CASEMAPPING=rfc1459` and
-// ALSO folded `[ ] \ ~` → `{ } | ^`, which OVER-folded — a `foo[1]` /
-// `foo{1}` pair the ircd keeps DISTINCT collapsed onto one key (members
-// dropped a present, talking user from the list when their bracket twin
-// quit; DM windows + own-nick checks merged two identities). The fold
-// now matches the ircd exactly: `A-Z` only.
+// `CASEMAPPING=ascii` — it folds ONLY `A-Z`, leaving `[ ] \ ~` untouched.
+// #525 corrected the fold: #121/#364 assumed `CASEMAPPING=rfc1459`
+// UNIVERSALLY and ALSO folded `[ ] \ ~` → `{ } | ^`, which OVER-folded on
+// bahamut — a `foo[1]` / `foo{1}` pair the ircd keeps DISTINCT collapsed
+// onto one key (members dropped a present, talking user from the list when
+// their bracket twin quit; DM windows + own-nick checks merged two
+// identities). #1861 does NOT reinstate that: the national fold happens
+// ONLY when the network said `rfc1459`, and `:ascii` stays `A-Z` only.
 //
 // Bucket F H3 (retained): pre-fix members.ts and ScrollbackPane.tsx
 // used bare `===` for nick comparison, producing phantom member entries
@@ -26,28 +46,110 @@
 // banners, and ownModes lookup misses. Per CLAUDE.md "Total
 // consistency or nothing" every nick comparison in cic goes through
 // this helper.
+//
+// ## The `asciiFold` sites that deliberately did NOT move (#1861)
+//
+// A call site keeps the ASCII tier when its other side is a key some OTHER
+// component already folded ASCII — folding harder on one end only would
+// FORK what agrees today. Named here so a reader greps `asciiFold`, finds
+// survivors, and knows they were considered:
+//
+//   * `channelKey.ts` (`canonicalChannel`) — mirrors the key the SERVER
+//     stores and broadcasts. The server DOES normalise channel/DM keys
+//     per-network at ingress (#537 axis 2), so this one is a genuine
+//     remaining gap rather than a must-stay; it is not fixed here because
+//     threading a casemapping through every `channelKey(slug, name)` call
+//     is the channel axis this issue scopes out, and getting it half-right
+//     is worse than leaving it uniform.
+//   * `pushTriggers.ts` — `prefs.private_messages_only` is a SERVER-stored
+//     list folded with the arity-1 `Identifier.canonical_target/1`
+//     (`user_settings.ex`, `list_fold/1`). cic must fold identically or the
+//     client-side push preview disagrees with the server's own trigger.
+//   * `notifyWatch.ts` — the presence map keys "arrive server-folded"
+//     (`presence_snapshot`); `presenceFor` must reproduce the server's fold,
+//     not a better one.
+//   * `nickColor.ts` (`djb2(asciiFold(nick))`) — a palette hash, not an
+//     identity key. Two spellings of one rfc1459 identity get two colours;
+//     that is cosmetic and pinned by an e2e spec.
+//   * `pingCorrelation.ts` — correlation keys carry a token/verb as well as
+//     the nick, and both ends are built by cic. Same class of gap as
+//     `channelKey`, no identity fork.
 
-// ASCII-byte-level fold — the single client mirror of
-// `Grappa.IRC.Identifier.canonical_nick/1`. Folds ONLY `A-Z` by char
-// code (bahamut is `CASEMAPPING=ascii`, #525); `[ ] \ ~` and every
-// multibyte (non-ASCII) sequence pass through untouched, byte-for-byte
-// with the server's `fold_ascii_byte/1` (JS `toLowerCase()` is
-// Unicode-aware and would over-fold, e.g. `CAFÉ`→`café`, forking keys
-// the server keeps distinct).
+import type { Casemapping } from "./isupport";
+
+// ASCII-byte-level fold — the client mirror of the server's arity-1
+// `Grappa.IRC.Identifier.canonical_target/1`. Folds ONLY `A-Z` by char
+// code; `[ ] \ ~` and every multibyte (non-ASCII) sequence pass through
+// untouched, byte-for-byte with the server's `fold_ascii_byte/1` (JS
+// `toLowerCase()` is Unicode-aware and would over-fold, e.g.
+// `CAFÉ`→`café`, forking keys the server keeps distinct).
+//
+// Callers that hold a network id want `normalizeNick`/`nickEquals`
+// instead; this stays exported for the sites listed in the module doc,
+// whose counterpart key is ASCII-folded elsewhere.
 export const asciiFold = (nick: string): string =>
   nick.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 32));
 
-// Normalize a nick to its case-folded comparison form. Use directly
-// when storing a nick into a Map/Set keyed for case-insensitive lookup;
-// for binary equality checks prefer `nickEquals`.
-export const normalizeNick = (nick: string): string => asciiFold(nick);
+// The rfc1459 "national character" fold — the client mirror of the
+// server's `national_byte/2`. `foldTilde` distinguishes `rfc1459` (folds
+// `~`→`^`, the RFC 2812 rule) from `rfc1459_strict` (bracket trio only:
+// RFC 1459 predates the tilde rule).
+//
+// Char-level rather than byte-level, which is the same thing here: all
+// four sources are `< 0x80` and JS strings are UTF-16, so a non-ASCII
+// code unit can never equal one of them. Idempotent, because the fold
+// TARGETS (`{ } | ^`) are not in the source set.
+const nationalFold = (nick: string, foldTilde: boolean): string =>
+  nick.replace(foldTilde ? /[[\]\\~]/g : /[[\]\\]/g, (c) => {
+    switch (c) {
+      case "[":
+        return "{";
+      case "]":
+        return "}";
+      case "\\":
+        return "|";
+      default:
+        return "^";
+    }
+  });
 
-// Case-insensitive nick equality. Returns false when either side is
-// null or undefined — the existing call sites (members.ts presence
-// dispatch, ScrollbackPane self-banner / ownModes) all guard on
-// non-null nicks at the outer scope; this internal null-safety just
-// makes the helper composable.
-export const nickEquals = (a: string | null | undefined, b: string | null | undefined): boolean => {
+/**
+ * Fold a nick to its comparison form under `casemapping` — the client
+ * mirror of the server's `Identifier.canonical_target/2`.
+ *
+ * Use directly when storing a nick into a Map/Set keyed for
+ * case-insensitive lookup; for binary equality checks prefer
+ * `nickEquals`. The casemapping is `casemappingForNetwork(networkId)`
+ * (`isupport.ts`) at every store-reading call site, and a plain parameter
+ * at the pure ones — the same shape `chantypes.ts` uses for `CHANTYPES=`.
+ *
+ * Required, not defaulted: a silent `"ascii"` default would let a call
+ * site that forgot the network look correct on Azzurra and fork on Rizon,
+ * which is precisely the bug this replaced.
+ */
+export const normalizeNick = (nick: string, casemapping: Casemapping): string => {
+  switch (casemapping) {
+    case "ascii":
+      return asciiFold(nick);
+    case "rfc1459":
+      return asciiFold(nationalFold(nick, true));
+    case "rfc1459_strict":
+      return asciiFold(nationalFold(nick, false));
+  }
+};
+
+/**
+ * Case-insensitive nick equality under `casemapping`. Returns false when
+ * either side is null or undefined — the existing call sites (members.ts
+ * presence dispatch, ScrollbackPane self-banner / ownModes) all guard on
+ * non-null nicks at the outer scope; this internal null-safety just makes
+ * the helper composable.
+ */
+export const nickEquals = (
+  a: string | null | undefined,
+  b: string | null | undefined,
+  casemapping: Casemapping,
+): boolean => {
   if (a == null || b == null) return false;
-  return normalizeNick(a) === normalizeNick(b);
+  return normalizeNick(a, casemapping) === normalizeNick(b, casemapping);
 };

--- a/cicchetto/src/lib/ownPresenceEvent.ts
+++ b/cicchetto/src/lib/ownPresenceEvent.ts
@@ -26,6 +26,7 @@
 // two surfaces.
 
 import type { ScrollbackMessage } from "./api";
+import type { Casemapping } from "./isupport";
 import { nickEquals } from "./nickEquals";
 
 const PRESENCE_KINDS = new Set<ScrollbackMessage["kind"]>([
@@ -37,8 +38,12 @@ const PRESENCE_KINDS = new Set<ScrollbackMessage["kind"]>([
   "kick",
 ]);
 
-export const isOwnPresenceEvent = (message: ScrollbackMessage, ownNick: string | null): boolean => {
+export const isOwnPresenceEvent = (
+  message: ScrollbackMessage,
+  ownNick: string | null,
+  casemapping: Casemapping,
+): boolean => {
   if (ownNick === null) return false;
   if (!PRESENCE_KINDS.has(message.kind)) return false;
-  return nickEquals(message.sender, ownNick);
+  return nickEquals(message.sender, ownNick, casemapping);
 };

--- a/cicchetto/src/lib/peerAway.ts
+++ b/cicchetto/src/lib/peerAway.ts
@@ -1,9 +1,10 @@
 import { createSignal } from "solid-js";
+import { casemappingForSlug } from "./casemapping";
 import { identityScopedStore } from "./identityScopedStore";
 import { normalizeNick } from "./nickEquals";
 
 // P-0b — peer-away ephemeral store. Holds at most one away message per
-// (network slug, peer-nick lowercased) pair. Populated by the
+// (network slug, peer-nick folded under this network's CASEMAPPING) pair. Populated by the
 // `peer_away` push event on the user-level Phoenix Channel topic
 // (broadcast by Session.Server's apply_effects arm when a standalone
 // 301 RPL_AWAY arrives — i.e. the operator /msg'd a peer who is away
@@ -32,7 +33,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => setPeerAwayBySlug({}));
 
   const setPeerAway = (networkSlug: string, peer: string, message: string): void => {
-    const peerKey = normalizeNick(peer);
+    const peerKey = normalizeNick(peer, casemappingForSlug(networkSlug));
     setPeerAwayBySlug((prev) => ({
       ...prev,
       [networkSlug]: { ...(prev[networkSlug] ?? {}), [peerKey]: message },
@@ -40,7 +41,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   };
 
   const dismissPeerAway = (networkSlug: string, peer: string): void => {
-    const peerKey = normalizeNick(peer);
+    const peerKey = normalizeNick(peer, casemappingForSlug(networkSlug));
     setPeerAwayBySlug((prev) => {
       const networkEntries = prev[networkSlug];
       if (!networkEntries || !(peerKey in networkEntries)) return prev;

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -81,7 +81,15 @@ export function shouldNotify(
   // on every outgoing message that happens to contain their nick. The server
   // has had this step since #532 C (`triggers.ex` `own_row?/2`); this port
   // did not, and the shared fixture had no row that could see the gap.
-  if (nickEquals(message.sender, ownNick)) return false;
+  //
+  // #1861 — pinned to `"ascii"`, deliberately. This whole predicate is a
+  // faithful transcription of the SERVER's `Push.Triggers`, and every fold
+  // over there is the arity-1 `Identifier.canonical_target/1` (`own_row?/2`,
+  // `dm?/2`, the two allow-lists). Folding harder here than the server folds
+  // would make cic's in-app notification decision disagree with the push the
+  // server actually sends on an rfc1459 network. When the server's triggers
+  // become network-aware, this moves WITH them, not before.
+  if (nickEquals(message.sender, ownNick, "ascii")) return false;
 
   // Fold BOTH sides, mirroring the server's `dm?/2`. The `channel` KEY is
   // folded at the persist boundary (`Message.canonicalize_channel/1`, #537)

--- a/cicchetto/src/lib/queryWindows.ts
+++ b/cicchetto/src/lib/queryWindows.ts
@@ -1,4 +1,5 @@
 import { createSignal, untrack } from "solid-js";
+import { casemappingForNetwork } from "./isupport";
 import { moduleRoot } from "./moduleRoot";
 import { nickEquals } from "./nickEquals";
 import { pushCloseQueryWindow, pushOpenQueryWindow } from "./socket";
@@ -65,8 +66,23 @@ const exports = moduleRoot(() => {
    * local mutation (cic NEVER originates state).
    *
    * Skips the server round-trip when the window is already open
-   * (case-insensitive dedup) — server-side upsert is a no-op in that
-   * case anyway and would broadcast a redundant identical list.
+   * (case-insensitive dedup, per this network's CASEMAPPING) —
+   * server-side upsert is a no-op in that case anyway and would
+   * broadcast a redundant identical list.
+   *
+   * #1861 — the dedup folds the way THIS network folds. On `:ascii`
+   * (bahamut/Azzurra) that is unchanged: `Foo[1]` and `foo{1}` stay two
+   * windows because the ircd keeps them two people. On `:rfc1459`
+   * (solanum, Rizon) `[EWG]-L0VE` and `{ewg}-l0ve` are ONE person and now
+   * resolve onto one row instead of pushing a second `open`.
+   *
+   * ⚠️ The SERVER's uniqueness is still ASCII: the partial unique indexes
+   * are on `(subject, network_id, lower(target_nick))`, and SQLite's
+   * `lower()` cannot express the bracket fold. So this gate is what keeps
+   * the duplicate from being created through the cic door; a second row
+   * arriving from anywhere else (an older client, a direct API call, rows
+   * already in the table) is still possible until that index question is
+   * decided — see the issue 1861 discussion of the storage shape.
    *
    * `openedAt` is unused now that state is server-derived; kept in
    * the signature for caller compatibility (UserContextMenu /
@@ -79,7 +95,8 @@ const exports = moduleRoot(() => {
    */
   const openQueryWindowState = (networkId: number, targetNick: string, _openedAt: string): void => {
     const existing = untrack(queryWindowsByNetwork)[networkId] ?? [];
-    const alreadyOpen = existing.some((w) => nickEquals(w.targetNick, targetNick));
+    const casemapping = casemappingForNetwork(networkId);
+    const alreadyOpen = existing.some((w) => nickEquals(w.targetNick, targetNick, casemapping));
     if (alreadyOpen) return;
     pushOpenQueryWindow(networkId, targetNick);
   };
@@ -88,13 +105,13 @@ const exports = moduleRoot(() => {
    * Returns the canonical casing for `nick` if a query window for it is
    * already open on `networkId`, otherwise returns `nick` unchanged.
    *
-   * IRC nicks are case-insensitive (CASEMAPPING=ascii, #121/#525); the
-   * server-side `Grappa.QueryWindows` row is unique on `(subject,
-   * network_id, lower(target_nick))` and the stored `target_nick`
-   * preserves the first-opened casing. cic mirrors that via `nickEquals`
-   * (the shared ASCII fold, A-Z only — `[ ] \ ~` untouched): the row's
-   * `targetNick` value is the canonical casing for sidebar/scrollback
-   * ChannelKey derivation.
+   * IRC nicks are case-insensitive (#121/#525); the server-side
+   * `Grappa.QueryWindows` row is unique on `(subject, network_id,
+   * lower(target_nick))` and the stored `target_nick` preserves the
+   * first-opened casing. cic matches via `nickEquals` under this
+   * network's CASEMAPPING (#1861): `A-Z` everywhere, plus `[ ] \ ~` →
+   * `{ } | ^` on an rfc1459 network. The row's `targetNick` value is the
+   * canonical casing for sidebar/scrollback ChannelKey derivation.
    *
    * Without this helper, typing `/q GRAPPA` when a `grappa` window
    * already exists would `setSelectedChannel({channelName: "GRAPPA"})`,
@@ -109,7 +126,9 @@ const exports = moduleRoot(() => {
    */
   const canonicalQueryNick = (networkId: number, nick: string): string => {
     const existing = untrack(queryWindowsByNetwork)[networkId] ?? [];
-    const match = existing.find((w) => nickEquals(w.targetNick, nick));
+    const match = existing.find((w) =>
+      nickEquals(w.targetNick, nick, casemappingForNetwork(networkId)),
+    );
     return match ? match.targetNick : nick;
   };
 

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -1,5 +1,6 @@
 import { createSignal, untrack } from "solid-js";
 import type { WhoisBundle } from "./api";
+import { casemappingForSlug } from "./casemapping";
 import { identityScopedStore } from "./identityScopedStore";
 import { networkIdBySlug } from "./networks";
 import { normalizeNick } from "./nickEquals";
@@ -116,7 +117,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // when the bundle lands or is refreshed. Case-folded (#525) so `Alice`
   // and `alice` share one cache entry, matching the ircd + server fold.
   const railWhoisFor = (slug: string, nick: string): WhoisBundle | undefined =>
-    byNick()[slug]?.[normalizeNick(nick)]?.bundle ?? undefined;
+    byNick()[slug]?.[normalizeNick(nick, casemappingForSlug(slug))]?.bundle ?? undefined;
 
   // Called by `RailContext` when the query card comes ON SCREEN (#782), which
   // is the ONLY caller. A nick we already know short-circuits FOREVER (no
@@ -129,7 +130,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // (vjt has been told this twice and wants the on-screen fetch regardless;
   // it is the argument for never asking MORE than once, not for not asking.)
   const requestRailWhois = (slug: string, nick: string): void => {
-    const key = normalizeNick(nick);
+    const key = normalizeNick(nick, casemappingForSlug(slug));
     const now = Date.now();
     const entry = untrack(() => byNick()[slug]?.[key]);
     if (entry) {
@@ -158,7 +159,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // retry window governs when the rail may ask again. Origin routing is the
   // caller's job in `userTopic.ts`, off the server-marked `source`.
   const ingestRailWhois = (slug: string, target: string, bundle: WhoisBundle): void => {
-    const key = normalizeNick(target);
+    const key = normalizeNick(target, casemappingForSlug(slug));
     put(slug, key, { at: Date.now(), bundle });
   };
 
@@ -184,8 +185,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // Merge rule mirrors `renameReadCursorChannel`: an entry already under the
   // new nick wins (it is the fresher observation of that identity).
   const renameRailWhois = (slug: string, oldNick: string, newNick: string): void => {
-    const oldKey = normalizeNick(oldNick);
-    const newKey = normalizeNick(newNick);
+    const casemapping = casemappingForSlug(slug);
+    const oldKey = normalizeNick(oldNick, casemapping);
+    const newKey = normalizeNick(newNick, casemapping);
     if (oldKey === newKey) return;
     setByNick((prev) => {
       const net = prev[slug];

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -1,8 +1,10 @@
 import { createEffect, createMemo, createSignal, on, untrack } from "solid-js";
 import { isContentKind, ownNickForNetwork } from "./api";
 import { token } from "./auth";
+import { casemappingForSlug } from "./casemapping";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { identityScopedStore } from "./identityScopedStore";
+import { casemappingForNetwork } from "./isupport";
 import { saveLastFocused } from "./lastFocusedChannel";
 import { membersByChannel } from "./members";
 import { evictFromMru, pickLiveMru, recordFocus } from "./mru";
@@ -239,7 +241,8 @@ const exports = identityScopedStore((onIdentityChange) => {
       const net = networkBySlug(slug);
       if (net) {
         const qs = qwbn[net.id] ?? [];
-        if (qs.some((q) => nickEquals(q.targetNick, name))) return true;
+        const casemapping = casemappingForNetwork(net.id);
+        if (qs.some((q) => nickEquals(q.targetNick, name, casemapping))) return true;
       }
       return false;
     };
@@ -256,7 +259,8 @@ const exports = identityScopedStore((onIdentityChange) => {
         const net = networkBySlug(slug);
         if (net) {
           const qs = qwbn[net.id] ?? [];
-          const match = qs.find((q) => nickEquals(q.targetNick, name));
+          const casemapping = casemappingForNetwork(net.id);
+          const match = qs.find((q) => nickEquals(q.targetNick, name, casemapping));
           if (match !== undefined) {
             return { networkSlug: slug, channelName: match.targetNick, kind: "query" };
           }
@@ -308,7 +312,8 @@ const exports = identityScopedStore((onIdentityChange) => {
         const net = networkBySlug(sel.networkSlug);
         if (net) {
           const qs = queryWindowsByNetwork()[net.id] ?? [];
-          if (qs.some((q) => nickEquals(q.targetNick, sel.channelName))) return true;
+          const casemapping = casemappingForNetwork(net.id);
+          if (qs.some((q) => nickEquals(q.targetNick, sel.channelName, casemapping))) return true;
         }
         return false;
       }
@@ -463,7 +468,8 @@ const exports = identityScopedStore((onIdentityChange) => {
       // window where own content is legitimate payload — a note-to-self —
       // so it is NOT excluded there (#396). Mirrors the server self-window
       // carve-out in `Scrollback.exclude_own_authored/3`.
-      const isSelfWindow = nickEquals(decoded.name, ownNick);
+      const casemapping = casemappingForNetwork(net?.id ?? null);
+      const isSelfWindow = nickEquals(decoded.name, ownNick, casemapping);
 
       let msgs = 0;
       let evts = 0;
@@ -479,12 +485,12 @@ const exports = identityScopedStore((onIdentityChange) => {
           // outside the self-window it must not inflate the badge (the
           // content-row twin of the #532 A own-presence exclusion, mirrored
           // server-side in `Scrollback.exclude_own_authored/3`). `sender` is
-          // compared via the ASCII nick fold (#372 `nickEquals`) — display
-          // stays raw, the MATCH folds. Belt-and-braces over the optimistic
+          // compared via the network's nick fold (#372/#1861 `nickEquals`) —
+          // display stays raw, the MATCH folds. Belt-and-braces over the optimistic
           // send-time cursor advance (scrollback.ts), which has gaps (the #50
           // empty-pane gate; a cross-device / out-of-order cursor landing
           // below your own line).
-          if (!isSelfWindow && nickEquals(row.sender, ownNick)) continue;
+          if (!isSelfWindow && nickEquals(row.sender, ownNick, casemapping)) continue;
           msgs++;
         } else {
           evts++;
@@ -865,7 +871,8 @@ const exports = identityScopedStore((onIdentityChange) => {
       const net = networkBySlug(sel.networkSlug);
       if (!net) return false;
       const queries = qwbn[net.id] ?? [];
-      return queries.some((q) => nickEquals(q.targetNick, sel.channelName));
+      const casemapping = casemappingForNetwork(net.id);
+      return queries.some((q) => nickEquals(q.targetNick, sel.channelName, casemapping));
     })();
 
     const wasLive = lastSeenLive.get(selKey) ?? false;
@@ -918,16 +925,16 @@ const exports = identityScopedStore((onIdentityChange) => {
   // no-such-nick. Per-device, cic-owned focus (mirrors members.ts renaming
   // a member); the window LIST itself stays server-authoritative
   // (`query_windows_list`). No-op unless the CURRENT selection is the
-  // (slug, oldNick) query. `nickEquals` (ASCII fold, A-Z only; #121/#525)
-  // so a case-shift casing still matches; caller (subscribe.ts) only invokes this for a genuine
-  // rename (old ≢ new).
+  // (slug, oldNick) query. `nickEquals` under this network's CASEMAPPING
+  // (#121/#525/#1861) so a case-shift casing still matches; caller
+  // (subscribe.ts) only invokes this for a genuine rename (old ≢ new).
   const followQueryNick = (slug: string, oldNick: string, newNick: string): void => {
     const sel = untrack(selectedChannel);
     if (
       sel !== null &&
       sel.kind === "query" &&
       sel.networkSlug === slug &&
-      nickEquals(sel.channelName, oldNick)
+      nickEquals(sel.channelName, oldNick, casemappingForSlug(slug))
     ) {
       setSelectedChannel({ networkSlug: slug, channelName: newNick, kind: "query" });
     }

--- a/cicchetto/src/lib/shareTargetDelivery.ts
+++ b/cicchetto/src/lib/shareTargetDelivery.ts
@@ -1,5 +1,6 @@
 import { createEffect, untrack } from "solid-js";
 import { dropUpload } from "./dropUpload";
+import { casemappingForNetwork } from "./isupport";
 import { loadLastFocused } from "./lastFocusedChannel";
 import { moduleRoot } from "./moduleRoot";
 import { channelsBySlug, networkBySlug, user } from "./networks";
@@ -177,7 +178,9 @@ function liveSources(userId: string): ShareDestinationSources {
     queryExists: (slug, nick) => {
       const net = networkBySlug(slug);
       if (net === undefined) return false;
-      return (queryWindowsByNetwork()[net.id] ?? []).some((q) => nickEquals(q.targetNick, nick));
+      return (queryWindowsByNetwork()[net.id] ?? []).some((q) =>
+        nickEquals(q.targetNick, nick, casemappingForNetwork(net.id)),
+      );
     },
   };
 }

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -4,11 +4,12 @@ import { assertNever, type ChannelEvent, listMembers, ownNickForNetwork } from "
 import { socketUserName, token } from "./auth";
 import { incrementBadge, setBadge } from "./badge";
 import { playBeep } from "./beep";
+import { casemappingForSlug } from "./casemapping";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { dropChannelTopicState, seedModes, seedTopic } from "./channelTopic";
 import { isDocumentVisible } from "./documentVisibility";
 import { highlightPatterns } from "./highlightList";
-import { isupportEntryFromWire, seedIsupport } from "./isupport";
+import { casemappingForNetwork, isupportEntryFromWire, seedIsupport } from "./isupport";
 import { applyPresenceEvent, seedMembers } from "./members";
 import { setServerMention } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
@@ -381,7 +382,8 @@ moduleRoot(() => {
     // by kind: presence kinds (join/part/quit/nick_change/mode/kick)
     // mutate the per-channel member list; content kinds are no-ops
     // there. Dispatching every event keeps routing local to members.ts.
-    applyPresenceEvent(key, message);
+    const casemapping = casemappingForSlug(slug);
+    applyPresenceEvent(key, message, casemapping);
 
     // BUG5b / CP29 R-6: own-action presence events (join/part/quit/
     // nick_change/mode/kick from own nick) must never bump unread — the
@@ -399,7 +401,7 @@ moduleRoot(() => {
     // gate for the mention bump path (own /me to a channel that
     // contains your nick mustn't beep / badge yourself) and the early-
     // return short-circuits the dm-listener auto-open logic below.
-    if (isOwnPresenceEvent(message, ownNick)) return;
+    if (isOwnPresenceEvent(message, ownNick, casemapping)) return;
 
     // Server-numeric-derived NOTICE: routed to the window the operator's
     // own action targeted (e.g. /msg <nick> → ERR_NOSUCHNICK 401, persisted
@@ -649,7 +651,9 @@ moduleRoot(() => {
           // BUG5a: own PART → drop the windowState entry. Selection
           // redirection is owned by the close-watcher in selection.ts
           // (UX-4-E), which fires off the channels_changed broadcast.
-          const ownPart = message.kind === "part" && nickEquals(message.sender, ownNick);
+          const casemapping = casemappingForSlug(slug);
+          const ownPart =
+            message.kind === "part" && nickEquals(message.sender, ownNick, casemapping);
           if (ownPart) {
             // CP15 B5: own-PART projects to absence in the windowState
             // map. Server intentionally does NOT broadcast `kind:
@@ -672,7 +676,13 @@ moduleRoot(() => {
           // above, the #372/#373 nick migration below, and every non-presence
           // kind. `shouldDrop` is false for our own nick and for
           // nick_change/mode by construction.
-          if (!presencePause.shouldDrop(key, message.kind, nickEquals(message.sender, ownNick))) {
+          if (
+            !presencePause.shouldDrop(
+              key,
+              message.kind,
+              nickEquals(message.sender, ownNick, casemapping),
+            )
+          ) {
             routeMessage(slug, key, name, message, ownNick);
           }
 
@@ -687,13 +697,14 @@ moduleRoot(() => {
           // idempotent no-ops when nothing matches (a plain member rename
           // with no query window). Own self-rename (sender == ownNick) is
           // skipped — own nick rides own_nick_changed, not a query window.
-          if (message.kind === "nick_change" && !nickEquals(message.sender, ownNick)) {
+          if (message.kind === "nick_change" && !nickEquals(message.sender, ownNick, casemapping)) {
             const newNick =
               typeof message.meta.new_nick === "string" ? message.meta.new_nick : null;
-            // Guard genuine rename: a case-only shift (old ≡ new under
-            // the ASCII fold, #121/#525) needs no key move (canonicalQueryNick already resolves
-            // casing) and the server row stays put (`:noop`).
-            if (newNick !== null && !nickEquals(message.sender, newNick)) {
+            // Guard genuine rename: a case-only shift (old ≡ new under this
+            // network's fold, #121/#525/#1861) needs no key move
+            // (canonicalQueryNick already resolves casing) and the server row
+            // stays put (`:noop`).
+            if (newNick !== null && !nickEquals(message.sender, newNick, casemapping)) {
               // The scrollback + cursor caches are keyed by the query
               // window's STORED casing, which can differ from the NICK
               // line's sender casing (#372: window opened `guest`, peer is
@@ -859,7 +870,10 @@ moduleRoot(() => {
             routeMessage(slug, senderKey, peer, message, ownNick);
             return;
           }
-          if (message.kind === "notice" && !nickEquals(message.sender, ownNick)) {
+          if (
+            message.kind === "notice" &&
+            !nickEquals(message.sender, ownNick, casemappingForNetwork(networkId))
+          ) {
             // Peer-to-peer NOTICE on the own-nick topic — i.e. landed at
             // `channel == ownNick` because the sender targeted our nick
             // directly. CP23 cluster `code-reload` shipped the canonical
@@ -1181,7 +1195,7 @@ moduleRoot(() => {
     const net = nets.find((n) => n.slug === slug);
     if (!net) return Promise.resolve();
     const ownNick = ownNickForSlug(slug);
-    if (nickEquals(target, ownNick)) return Promise.resolve();
+    if (nickEquals(target, ownNick, casemappingForSlug(slug))) return Promise.resolve();
     const key = channelKey(slug, target);
     const pending = queryJoinAcks.get(key);
     if (pending) return pending;

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -8,6 +8,7 @@ import { applyAutoAwayDebounceFromWire } from "./autoAway";
 import { setAwayState } from "./awayStatus";
 import { setBanlistBundle } from "./banlistCard";
 import { setServerBundleHash, setServerBundleVersion } from "./bundleHash";
+import { casemappingForSlug } from "./casemapping";
 import { onDirectoryComplete, onDirectoryFailed, onDirectoryProgress } from "./channelDirectory";
 import { channelKey } from "./channelKey";
 import { diagPush } from "./diagLog";
@@ -138,12 +139,14 @@ import { validate } from "./wireValidate";
 // #606 — is the rail currently showing the query whose partner is `target`
 // on `network`? Used to decide whether a `source: user` whois_bundle (an
 // operator /whois) should ALSO refresh the rail card. `nickEquals` folds
-// (#525) so a case-shift still matches. Read outside any reactive scope
+// (#525/#1861) so a case-shift still matches. Read outside any reactive scope
 // (a channel event callback), so this is a plain current-value read.
 function railIsShowingNick(network: string, target: string): boolean {
   const sel = selectedChannel();
   return (
-    sel?.kind === "query" && sel.networkSlug === network && nickEquals(sel.channelName, target)
+    sel?.kind === "query" &&
+    sel.networkSlug === network &&
+    nickEquals(sel.channelName, target, casemappingForSlug(network))
   );
 }
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43374,3 +43374,146 @@ and fails at 3, 4, 5 and 10**, always with `no such column:
 runs, so today's deploy path sits **one step below the threshold** — not
 exposed, with no margin. It is why this bench migrates on its own
 one-connection repo before handing the file to the pool-10 one.
+<!-- entry #1861 -->
+
+---
+
+## 2026-08-29 — #1861: cic folds nicks per-network; the DB half is a separate decision
+
+`CASEMAPPING=rfc1459` declares `{ } | ^` the lowercase of `[ ] \ ~`, so on
+solanum (Libera) and the plexus/hybrid Rizon runs, `[EWG]-L0VE` and
+`{ewg}-l0ve` are one person. A live Rizon session on production grappa showed
+two query windows for that one peer, side by side in the channel rail, with
+incoming traffic landing in whichever of the two matched the casing that
+arrived.
+
+### What moved: the client fold got a network
+
+`normalizeNick`/`nickEquals` did not take a network **at all** — a single
+string in, ASCII fold out — so no call site could fold per-network even when
+it held the network id. That is the shape #537 fixed server-side (axis 2,
+`canonical_target/2`) and never reached cic, which had no per-network fold to
+reach for.
+
+Two tiers now. `asciiFold` stays the plain `A-Z` byte fold, the mirror of the
+server's arity-1 `Identifier.canonical_target/1`. `normalizeNick(nick, cm)`
+and `nickEquals(a, b, cm)` mirror the arity-2 composition. The rfc1459 and
+rfc1459-strict tables are transcribed from the server's `national_byte/2`
+rather than re-derived from the RFCs, and `nickEquals.test.ts` enumerates
+them as the drift gate — the client twin of `IdentifierTest`'s pin.
+
+On `:ascii` the two tiers are byte-for-byte identical, so bahamut/Azzurra —
+all of production — is untouched. **The #525 posture was SPLIT, not
+weakened**: the tests that pinned `Foo[1]` ≠ `foo{1}` as universal now pin it
+per casemapping, `:ascii` unchanged and `:rfc1459` collapsing. Softening the
+ascii half would have merged two identities the ircd keeps apart on every
+network we actually run.
+
+The casemapping is a REQUIRED parameter, never defaulted. A silent `"ascii"`
+fallback would let a call site that forgot the network look correct on Azzurra
+and fork on Rizon, which is the bug being replaced. Store-reading sites resolve
+through `casemappingForNetwork` (`isupport.ts`, sibling of
+`chantypesForNetwork`) or `casemappingForSlug` (the new `casemapping.ts`, for
+cic's slug-keyed half); the pure modules — `modeApply`, `ownPresenceEvent`,
+`members`, `nickColor` — take it as DATA, the shape `chantypes.ts` already
+uses for `CHANTYPES=`.
+
+### Five `asciiFold` sites deliberately did not move
+
+The rule is not "fold harder everywhere". A site keeps the ASCII tier when the
+OTHER side of its comparison is a key some other component already folded
+ASCII — folding harder on one end only forks what agrees today.
+
+  * `pushTriggers` — a faithful transcription of `Grappa.Push.Triggers`, where
+    every fold (`own_row?/2`, `dm?/2`, both allow-lists) is the arity-1 one.
+    Pinned with a literal `"ascii"` and a comment saying it moves WITH the
+    server, not before it.
+  * `notifyWatch` — the presence map keys arrive server-folded; `presenceFor`
+    must reproduce the server's fold, not a better one.
+  * `nickColor` — a palette hash, not an identity key. Two spellings of one
+    rfc1459 identity get two colours; that is cosmetic, and an e2e pins
+    `djb2(asciiFold(nick))`.
+  * `channelKey` / `pingCorrelation` — the same class of remaining gap on the
+    CHANNEL axis, which this slice does not open. `channelKey` is the real one:
+    the server DOES normalise channel/DM keys per-network at ingress, so cic's
+    ASCII `canonicalChannel` is a genuine divergence on rfc1459. Threading a
+    casemapping through every `channelKey(slug, name)` is a second pass of the
+    same size, and half of it is worse than none.
+
+The list lives in `nickEquals.ts` so a reader who greps `asciiFold`, finds
+survivors, and reaches for a "cleanup" finds the reason first.
+
+### What did NOT move, and why it is a decision rather than an omission
+
+**`QueryWindows` stays on the arity-1 fold, and moving it is not free.** The
+tempting change — swap `Identifier.canonical_target/1` for `/2` in `close/4`,
+`exists?/3` and `window_query/3` — is a REGRESSION, not a partial fix. Every
+one of those folds a parameter that is then compared against
+`Identifier.nick_fold/1`, which is SQL `lower()`. Measured, not argued:
+
+```
+sqlite> select lower('[EWG]-L0VE'), lower('{ewg}-l0ve'),
+   ...>        (lower('[EWG]-L0VE') = lower('{ewg}-l0ve'));
+[ewg]-l0ve|{ewg}-l0ve|0
+```
+
+(positive control in the same statement: `lower('ABC') = 'abc'`.)
+
+`lower()` cannot express the bracket fold, so an arity-2 parameter fold against
+an ASCII column fold MISSES: `close(subject, net, "[EWG]-L0VE")` would stop
+finding the row it closes today. The two partial unique expression indexes on
+`(<subject_id>, network_id, lower(target_nick))` are the same story from the
+write side — under `lower()` the two spellings are two keys, so **the database
+itself happily stores both rows**.
+
+Which means the client fold above is **necessary and not sufficient**, and the
+distinction is worth stating precisely rather than rounding off:
+
+  * it closes the door where **cic** was about to mint the second row — a
+    second `/query` or nick-click on the twin spelling while the first window
+    is open (`openQueryWindowState`), and the focus resolution that used to
+    key a dead window (`canonicalQueryNick`);
+  * it does NOT close the door where the **server** mints it.
+    `Session.Server.maybe_open_query_window/2` (#422) auto-opens a window on
+    every inbound DM, keyed by the peer's RAW `dm_with`, idempotent only under
+    the ASCII index. Query the brace twin first, let the peer speak, and the
+    server holds two rows and broadcasts both — and cic renders what the
+    server sends, because cic never originates state.
+
+Closing that half needs a decision the slice was not authorised to take: a
+stored folded-key column written by the app, versus a per-network fold applied
+before insert. Both drag a migration, and both run into the byte-pinned index
+invariant (index expression, `conflict_target/1` fragment and `nick_fold/1`
+must stay character-identical or SQLite stops using the index). Merging the
+duplicate rows that already exist depends on the same decision. Carried back
+as a proposal.
+
+### The rfc1459 e2e: reachable, and what is still unproven
+
+**Measured rather than assumed, in both directions.** The e2e testnet DOES
+carry an rfc1459 network: the `azzurra2` node is solanum (#221), and a raw
+probe of its 005 returns
+
+```
+:solanum2.azzurra2.chat 005 probe1 CHANLIMIT=#&:50 PREFIX=(ov)@+ ...
+    NETWORK=azzurra2 STATUSMSG=@+ CASEMAPPING=rfc1459 NICKLEN=31 ...
+```
+
+with 001 RPL_WELCOME captured in the same session as the positive control. So
+"no rfc1459 e2e is possible" would have been false.
+
+No browser e2e was written all the same, and the reason is that the thing an
+e2e would pin end-to-end is the FULL symptom, which cannot go green while the
+server half above is undecided — an honest spec of the reported bug would be
+RED, and a spec narrowed to the half that IS fixed pins what the per-casemapping
+vitest pins, at the cost of a new isolated seed subject on `azzurra2` (a second
+blast radius on top of a 61-file client pass).
+
+What that leaves unproven is one composition, and it is named rather than
+waved at: no test drives a real solanum 005 through the live socket into cic's
+fold. Every LINK has one — `parse_casemapping/1` (`isupport_test.exs`), the
+wire payload (`wire_test.exs`), the fold table (`identifier_test.exs`), and
+now the cic side end to end from a RAW wire payload through the real
+`narrowIsupportChanged` → `isupportEntryFromWire` → `seedIsupport` →
+`casemappingForNetwork` → `nickEquals` (`isupport.test.ts`). What is untested
+is the wire between them, on a live rfc1459 session.


### PR DESCRIPTION
## What

`CASEMAPPING=rfc1459` declares `{ } | ^` the lowercase of `[ ] \ ~`, so on
solanum (Libera) and the plexus/hybrid Rizon runs, `[EWG]-L0VE` and
`{ewg}-l0ve` are one person. cic folded plain ASCII with **no network in
scope at all** — `normalizeNick`/`nickEquals` took a single string, so no
call site could fold per-network even when it held the network id.

This threads the network's advertised fold through the client nick fold, and
re-keys the tests that pinned the ASCII posture as universal so they pin it
**per casemapping** instead. Addresses points 1 and 3 of issue 1861; points 2
and 4 are carried back as a proposal (below), not built.

## How

Two tiers, and the split is the point.

- `asciiFold` stays the plain `A-Z` byte fold — the mirror of the server's
  arity-1 `Identifier.canonical_target/1`.
- `normalizeNick(nick, casemapping)` / `nickEquals(a, b, casemapping)` are the
  network-aware tier, mirroring the server's `normalize_casemapping/2`
  composition (arity-2). The rfc1459 / rfc1459-strict tables are **transcribed
  from `national_byte/2`**, not re-derived from the RFCs; `nickEquals.test.ts`
  enumerates them as the drift gate.
- `casemappingForNetwork` (`isupport.ts`, sibling of `chantypesForNetwork`) and
  `casemappingForSlug` (new `casemapping.ts`, for cic's slug-keyed half) are
  the two resolution doors. The pure modules — `modeApply`, `ownPresenceEvent`,
  `members`, `nickColor` — take the fold as DATA, the shape `chantypes.ts`
  already uses for `CHANTYPES=`.
- The parameter is **required, never defaulted**: a silent `"ascii"` fallback
  would let a call site that forgot the network look correct on Azzurra and
  fork on Rizon, which is the bug being replaced.

On `:ascii` the two tiers are byte-for-byte identical, so bahamut/Azzurra — all
of production — is untouched.

**The #525 posture was SPLIT, not weakened.** `Foo[1]` ≠ `foo{1}` still holds
on `:ascii`; the rfc1459 counterparts are new tests beside it, in
`queryWindows.test.ts` and `compose.test.ts`.

### Five `asciiFold` sites deliberately did not move

A site keeps the ASCII tier when the other side of its comparison is a key some
other component already folded ASCII — folding harder on one end only forks what
agrees today. `nickEquals.ts` names each with its reason: `pushTriggers` and
`notifyWatch` (server-mirroring), `nickColor` (a palette hash, not an identity),
`channelKey` and `pingCorrelation` (the same class of remaining gap on the
CHANNEL axis, which this slice does not open).

## Necessary, not sufficient — stated rather than rounded off

The client fold closes the door where **cic** was about to mint the second row
(a second `/query` on the twin spelling, and the focus resolution that used to
key a dead window). It does **not** close the door where the **server** mints
it: `Session.Server.maybe_open_query_window/2` auto-opens a window on every
inbound DM keyed by the peer's RAW `dm_with`, idempotent only under the ASCII
index.

**Moving `QueryWindows` to `canonical_target/2` alone is a REGRESSION, not a
partial fix** — measured:

```
sqlite> select lower('[EWG]-L0VE'), lower('{ewg}-l0ve'),
   ...>        (lower('[EWG]-L0VE') = lower('{ewg}-l0ve'));
[ewg]-l0ve|{ewg}-l0ve|0
```

Every arity-1 fold in that module feeds a parameter compared against
`Identifier.nick_fold/1` (SQL `lower()`), which cannot express the bracket
fold — so an arity-2 parameter fold against an ASCII column fold MISSES, and
`close/4` would stop finding the row it closes today. Same story on the write
side: the partial unique indexes are `lower()`-shaped, so the DB stores both
rows.

Closing that half needs the storage decision issue 1861 point 2 names (a stored
folded-key column vs a per-network fold before insert), which drags a migration
and the byte-pinned index invariant. Point 4 (merging duplicates already in the
table) depends on it. Both carried back.

## The rfc1459 e2e

**Measured in both directions.** The testnet DOES carry an rfc1459 network — a
raw probe of the `azzurra2` solanum node's 005 returns
`CASEMAPPING=rfc1459` (001 RPL_WELCOME captured in the same session as the
positive control). So "no rfc1459 e2e is possible" would have been false.

No browser e2e was written all the same: an honest spec of the reported symptom
would be RED while the server half is undecided, and a spec narrowed to the half
that IS fixed pins what the per-casemapping vitest already pins, at the cost of a
new isolated seed subject on `azzurra2`.

**What stays unproven, named rather than waved at:** no test drives a real
solanum 005 through a live socket into cic's fold. Every LINK has one —
`parse_casemapping/1` (`isupport_test.exs`), the wire payload (`wire_test.exs`),
the fold table (`identifier_test.exs`), and now the cic side end to end from a
RAW wire payload through the real `narrowIsupportChanged` →
`isupportEntryFromWire` → `seedIsupport` → `casemappingForNetwork` →
`nickEquals` (`isupport.test.ts`). The wire between them, on a live rfc1459
session, is untested.

## Gates (local, this worktree)

| gate | result |
|---|---|
| `scripts/bun.sh run check` | `rc=0` — 5 stages ran, 0 failed (lock drift `drift=0`) |
| `scripts/bun.sh run test` | `rc=0` — 327/327 files, 6529/6529 tests |
| `scripts/design-notes-gate.sh origin/main` | `rc=0` — *1 new entry heading(s), separator and marker present* (post-commit run) |

`scripts/check.sh` was **not** run: it is Elixir-only and this branch touches
no `lib/`, `test/`, `config/` or `priv/`. No `integration.sh` / e2e run — no
e2e spec changed.
