### PR TITLE
infra: fold four production lessons into the TLS front example (issue 1863)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43613,3 +43613,82 @@ Playwright webkit does not render iOS selection UI — the same limit #1067 and
 written rather than a hollow one. The frame is device evidence for the symptom;
 the cure is reasoned from the platform contract and verified only down to the
 class.
+<!-- entry #1863 -->
+
+---
+
+## 2026-08-29 — #1863: an example config is a claim about the code, and three of its claims were stale
+
+`infra/nginx-tls-frontend.example.conf` is the only edge guidance a
+self-hoster gets, and it had drifted from the app it describes. Folding in
+what the production front learned meant checking every fact first, and three
+did not survive the check.
+
+### `X-Forwarded-Proto` is INERT against this codebase
+
+The file's own header said the header was *"load-bearing — Phoenix maps it
+back to scheme=https for check_origin and generated URLs"*. Neither half
+holds. Grepped over the whole tree: `force_ssl` appears in no `config/` or
+`lib/` file (its single repo hit is a sentence in this log), and there is no
+`Plug.SSL` and no `Plug.RewriteOn` anywhere — so nothing rewrites
+`conn.scheme`. The https:// links come from
+`url: [host:, scheme: "https", port: 443]` in `config/runtime.exs`, and
+`check_origin`'s canonical entry is the scheme-agnostic `"//#{phx_host}"`.
+The only `X-Forwarded-*` grappa reads is the For/Real-IP pair, through
+`GrappaWeb.Plugs.RemoteIpFromProxy`.
+
+The line is kept — it costs nothing and is what a future scheme-sensitive
+plug needs — but it is now labelled a convention. **A comment that promises
+a mechanism is worse than no comment: it survives the mechanism.** The same
+correction is applied to the `:80` `/socket` rescue, whose rationale had
+been hung on `force_ssl` bouncing the upgrade. The rescue stands on its own
+without it: a browser fails a WebSocket handshake on anything that is not
+`101` and does not chase the `Location`, so a blanket `return 301` on port
+80 is unfollowable by a reconnecting socket (#193).
+
+### The cold-boot burst is smaller than reported, and permanent
+
+The brief described cic fanning out a channel list per network **plus a
+`/messages` page per channel**. That was the shape of the #1679 incident
+(31 x `503` against a default `burst=50`, seven networks, 81+ requests
+presented — vjt's measurement on the production front, 2026-08-22). It is
+not what the client does at this tip: the #1859 entry, landed the same day
+as this one, reads `selection.ts` and records that cold boot fetches
+`/messages` for the **one** restored window and does not walk the channel
+list. What remains is `me + networks + N x channels` — still scaling with
+bound NETWORKS rather than with activity, which is the operator-facing
+point, but it is `1 + N` and not `1 + N + M`.
+
+The second correction is the one that changes the posture. The brief called
+the nginx override *"mitigation, not a fix"*, with the cure pending in
+`GET /boot`. `/boot` exists server-side (`BootController`), but the client
+cutover was **measured and rejected** in #1859 — 11.7x dearer for identical
+rows, 208x more DB work at boot. So the burst is not provisional and the
+edge guidance is not a stopgap: it is the standing advice.
+
+### The gate: `nginx -t`, with the negative control that makes it mean something
+
+No test loads this file, and there is no honest e2e for it. There IS a cheap
+real gate: wrap it in a minimal `events{} / http{}`, substitute the
+placeholders and a throwaway self-signed cert, and run `nginx -t` in a
+one-shot `nginx:alpine`. Three variants, and the last two are what make the
+first worth reporting — as-shipped **passes**; the documented uncomment path
+(zone + format in `http { }`, `limit_req` / `access_log` / the `:80`
+`/socket` block enabled) **passes**; and a negative control that moves
+`log_format` into the `server` block **fails**, with
+`"log_format" directive is not allowed here`.
+
+That third run is not decoration. `limit_req_zone` and `log_format` are
+http-context only, while this file is a pair of `server` blocks an operator
+drops into `sites-enabled/`. Shipping either directive live would hand a
+self-hoster an `[emerg]` on reload, so both are shipped commented WITH the
+context they belong in — and the control is the evidence that the warning
+is real rather than folklore.
+
+### What is NOT proven
+
+The production numbers (`rate=200r/s`, `burst=400`, 149 served req/s) are
+vjt's readings off the m42 front, reported here and not reproduced. Nothing
+in this change was exercised against a live proxy: `nginx -t` proves the
+file parses and that the uncomment path parses, and says nothing about
+whether 400 is the right burst for anybody else's deployment.

--- a/infra/nginx-tls-frontend.example.conf
+++ b/infra/nginx-tls-frontend.example.conf
@@ -23,8 +23,118 @@
 # Also set, in the stack's .env, so Phoenix accepts the wss:// origin and
 # mints correct links:
 #   PHX_HOST=<your-domain>          # e.g. grappa.example.org
-# X-Forwarded-Proto $scheme (set below) is load-bearing — Phoenix maps it
-# back to scheme=https for check_origin and generated URLs.
+#
+# A SECOND hostname pointed at this same instance needs a SECOND env var,
+# not proxy surgery:
+#   EXTRA_CHECK_ORIGINS=https://<other-domain>[,https://<third>]
+# Comma-separated, FULL origin form, NO trailing slash. `config/runtime.exs`
+# folds it into the Endpoint's `check_origin` list alongside PHX_HOST, and
+# derives the #324 HTTP host-alias set from the same two inputs.
+#
+# 🔴 The symptom when it is missing looks EXACTLY like a broken proxy, which
+# is why it belongs in this file. The browser loops on WebSocket close code
+# 1006 with no visible cause: Phoenix rejects the handshake because
+# `Origin: https://<other-domain>` is not in `check_origin`, and the REST
+# side keeps working, so the app half-loads. Two tells, both from the dead
+# socket rather than from HTTP:
+#   - no channel topic — `cicchetto/src/lib/subscribe.ts` carries
+#     `topic_changed` over the socket into `channelTopic.seedTopic` so the
+#     topic bar needs no REST round-trip; and
+#   - your own messages never appear — `cicchetto/src/lib/socket.ts` states
+#     the server echo is the sole render path (no optimistic local render),
+#     so the POST succeeds and nothing is drawn.
+# Add the missing `proxy_http_version 1.1` + Upgrade/Connection headers by
+# all means (they are necessary), but they are not what fixes THIS.
+#
+# 🔴 THE WRONG CURE, named so nobody rediscovers it: rewriting the `Origin`
+# header for /socket in this proxy. It works, and it silently disables
+# origin checking for every client — a same-browser attacker page then
+# passes the gate the operator believes is up. Use EXTRA_CHECK_ORIGINS.
+# (Second-host tracking: #225.)
+#
+# X-Forwarded-Proto $scheme (set below) is a CONVENTION here, not a
+# load-bearing header: as of this writing grappa configures no `force_ssl`,
+# no `Plug.SSL` and no `Plug.RewriteOn`, and the only X-Forwarded-* header
+# it reads is the For/Real-IP pair (`GrappaWeb.Plugs.RemoteIpFromProxy`,
+# wired in `GrappaWeb.Endpoint`). The https:// links Phoenix mints come
+# from `url: [host:, scheme: "https", port: 443]` in `config/runtime.exs`,
+# and `check_origin`'s `//host` entry is scheme-agnostic by construction.
+# It is kept because it costs nothing and is what a future scheme-sensitive
+# plug would need.
+#
+# TWO DIRECTIVES BELOW LIVE IN `http { }`, NOT HERE. `limit_req_zone` and
+# `log_format` are http-context only, so if you drop this file into a
+# `sites-enabled/` include (which is inside `http { }` but not AT it), the
+# zone and the format go in your `nginx.conf` and only the `limit_req` /
+# `access_log` lines stay here. Both are shipped commented out for exactly
+# that reason: an active `limit_req zone=ratelimit` with no zone defined
+# fails `nginx -t` outright.
+
+# ---------------------------------------------------------------------------
+# GOES IN `http { }`, NOT IN A server BLOCK
+#
+# Both directives here are http-context only. Copy them into your
+# `nginx.conf` (alongside the other http-level settings) and uncomment the
+# matching lines further down in this file.
+# ---------------------------------------------------------------------------
+#
+# (1) Rate limiting — the burst has to be sized for NETWORKS, not for users.
+#
+# cicchetto's cold boot issues `GET /me`, `GET /networks`, and then one
+# `GET /networks/<slug>/channels` PER BOUND NETWORK. That count tracks how
+# many networks the account has, not how active the operator is: a refresh
+# on an idle seven-network account presents the same burst as a busy one,
+# and the whole burst arrives in parallel.
+#
+# Measured on the production front (vjt, 2026-08-22 — reported here, not
+# reproduced by this file): a seven-network account against a default
+# `burst=50` took **31 x 503**, with ZERO `Sent 503` in the application log
+# — nginx rejected them and grappa never saw them. burst + rejections put
+# **81+ requests** in the window (DESIGN_NOTES #1679; the arithmetic is in
+# `docs/CLIENT_PROTOCOL.md` §6a, which tells client authors the same thing
+# from the other side). The PWA surfaces those as a bare "load failed",
+# with nothing in the UI pointing at the edge. On an earlier occasion the
+# same shape tripped a fail2ban jail and got the client's IP banned.
+#
+# `nodelay` is deliberate: delaying an interactive fetch down to the zone
+# rate is the same stall to the user as rejecting it, and the zone rate
+# still caps SUSTAINED load. Values below are the production front's
+# (vjt's); pick your own, but size the burst off your network count.
+#
+# limit_req_zone $binary_remote_addr zone=ratelimit:1m rate=200r/s;
+# limit_req zone=ratelimit burst=50;          # global floor
+#
+# This is mitigation, not a cure. A `GET /boot` endpoint exists server-side
+# (#1679) to collapse the fan-out into one request, but the client cutover
+# was MEASURED AND REJECTED (#1859): the bulk read costs 11.7x more for
+# identical rows and 208x more DB work at boot on SQLite. So the per-network
+# burst is not going away, and an operator who copies this file onto a
+# default `burst=50` front will meet the 503s at around three networks.
+#
+# (2) A separate access log for the WebSocket handshake.
+#
+# Worth its own file for two reasons. It keeps handshake churn out of the
+# REST log while you are debugging reconnects; and it is what makes a
+# fail2ban filter on the handshake 403 possible without the same filter
+# also globbing every REST request.
+#
+# It is SAFE to log: since #95 the bearer rides the `Sec-WebSocket-Protocol`
+# subprotocol, and #202 dropped the legacy `?token=` query fallback, so the
+# upgrade URL carries no secret. The format below belts that anyway by
+# logging `$uri` instead of `$request` — `$uri` is the normalised path with
+# the query string already stripped, so a future query-string fallback could
+# not leak into this file by accident.
+#
+# Derived from this repo's own `main` format (`infra/snippets/log-format.conf`,
+# which is the SSOT for the substrates that include it) with that one
+# substitution; it is NOT a verbatim copy of the production front's line.
+#
+# log_format ws '$remote_addr - $remote_user [$time_local] '
+#               '"$request_method $uri $server_protocol" '
+#               '$status $body_bytes_sent "$http_referer" '
+#               '"$http_user_agent" "$http_x_forwarded_for" '
+#               'rt=$request_time urt=$upstream_response_time us=$upstream_status '
+#               'rid=$sent_http_x_request_id msec=$msec';
 
 upstream grappa_stack {
   # The grappa container's published host port (GRAPPA_PUBLISH). Same host
@@ -67,6 +177,12 @@ server {
   # Must be >= the BEAM's body ceiling (Plug.Parsers 128 MiB, #485).
   client_max_body_size 128m;
 
+  # The per-vhost burst override that sizes for the cold-boot fan-out — see
+  # the `http { }` block at the top of this file for the zone it needs and
+  # for why the number tracks bound NETWORKS. Uncomment together with the
+  # `limit_req_zone` up there; on its own it fails `nginx -t`.
+  # limit_req zone=ratelimit burst=400 nodelay;
+
   # Phoenix Channels WebSocket. Since #95 the bearer rides the
   # Sec-WebSocket-Protocol subprotocol (and #202 dropped the legacy
   # ?token= query-string fallback), so nothing sensitive appears in the
@@ -83,6 +199,12 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_read_timeout 86400s;
     proxy_send_timeout 86400s;
+
+    # Send the handshake to its own file, so reconnect churn stops drowning
+    # the REST log and a fail2ban filter on the 403 can be scoped to WS
+    # alone. Uncomment together with the `log_format ws` at the top of this
+    # file; on its own it fails `nginx -t` with "unknown log format".
+    # access_log /var/log/nginx/grappa-socket.log ws;
   }
 
   # NOTE: no `/service-worker.js` no-cache block here — the BEAM owns it
@@ -114,6 +236,48 @@ server {
   listen 80;
   listen [::]:80;
   server_name <your-domain>;
+
+  # A BLANKET 301 HERE CAN STRAND CLIENTS ON THE SPLASH SCREEN (#193).
+  #
+  # A browser does not follow a redirect on a WebSocket handshake — per RFC
+  # 6455 a client fails the connection on anything that is not `101`, and no
+  # engine chases the Location. So a socket that reconnects over `ws://`
+  # (plaintext, :80) gets the 301, cannot follow it, and retries into the
+  # same 301 forever: the app never finishes booting and shows nothing but
+  # the splash. Observed after a BEAM restart, when some clients came back
+  # on the plaintext scheme.
+  #
+  # The belt: proxy /socket here too, ABOVE the catch-all redirect, so a
+  # stray ws:// upgrade completes instead of bouncing. It must sit before
+  # `location /` — nginx picks the longest prefix, so the ordering is
+  # documentation rather than mechanism, but keep it readable.
+  #
+  # Shipped commented out: it is a rescue for a client bug, not something
+  # every deployment wants permanently open on :80. Uncomment if operators
+  # report a stuck splash after a restart.
+  #
+  # location /socket {
+  #   proxy_pass http://grappa_stack;
+  #   proxy_http_version 1.1;
+  #   proxy_set_header Upgrade $http_upgrade;
+  #   proxy_set_header Connection "upgrade";
+  #   proxy_set_header Host $host;
+  #   proxy_set_header X-Real-IP $remote_addr;
+  #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  #   proxy_set_header X-Forwarded-Proto https;
+  #   proxy_read_timeout 86400s;
+  #   proxy_send_timeout 86400s;
+  # }
+  #
+  # NOTE on `X-Forwarded-Proto https` (hardcoded, not `$scheme`, and only
+  # here): the production front carries it and it is kept for parity, but
+  # grappa as configured today reads NO X-Forwarded-Proto — no `force_ssl`,
+  # no `Plug.SSL`, no `Plug.RewriteOn` anywhere in `config/` or `lib/`. It
+  # is therefore INERT against this codebase, and the rescue above does not
+  # depend on it. It matters the moment anything scheme-sensitive is turned
+  # on in front of, or inside, the app: without it that layer sees a
+  # plaintext hop and bounces the very upgrade this block exists to rescue.
+
   location / {
     return 301 https://$host$request_uri;
   }


### PR DESCRIPTION
Addresses issue 1863 — `infra/nginx-tls-frontend.example.conf` was copied from
the production front before the front learned four things. All four are folded
in. Scope: that file plus one `docs/DESIGN_NOTES.md` entry. Nothing else.

## What went in

**(1) A rate-limit burst sized for NETWORKS, not for users.** `limit_req_zone`
(http context) + a per-vhost `limit_req … burst=400 nodelay` override, both
commented, with the arithmetic that explains the number and `nodelay`'s
rationale.

**(2) A separate `/socket` access log.** A `ws` `log_format` (http context) +
`access_log … ws` inside `location /socket`, both commented. Safe to write
since #95 moved the bearer to the `Sec-WebSocket-Protocol` subprotocol and #202
dropped the `?token=` fallback; the format belts that anyway by logging `$uri`,
which is the normalised path with the query already stripped.

**(3) The `:80` `/socket` belt (#193),** shipped commented with its rationale,
so an operator debugging a stuck splash finds it instead of rediscovering it.

**(4) `EXTRA_CHECK_ORIGINS` for a second vhost,** in the env section at the top
— **with the wrong cure named**: rewriting `Origin` in the proxy for `/socket`
works and silently disables origin checking for every client. Both tells of the
dead socket are named too, since both read as proxy bugs: no channel topic
(`subscribe.ts` carries `topic_changed` over the socket) and no echo of your own
messages (`socket.ts`: the server echo is the sole render path).

Out of scope by the issue's own declaration and not touched: any fail2ban /
firewall-level banning.

## 🔴 Three cited facts did not survive verification

Verified by behaviour and cited by **name**, never by line number — one of the
three had already drifted a line while the issue was open.

**(a) `GrappaWeb.RemoteIPFromProxy` does not exist.** The module is
`GrappaWeb.Plugs.RemoteIpFromProxy` (lowercase `p`). `git grep RemoteIPFromProxy`
over the whole tree: **0 hits**; the correct spelling: 7 files. Not copied.

**(b) `X-Forwarded-Proto` is INERT against this codebase.** The issue hangs the
`:80` belt on *"without it Phoenix force_ssl bounces the upgrade"*. Grepped:
`force_ssl` appears in **no** `config/` or `lib/` file (its one repo hit is a
sentence in `DESIGN_NOTES`), and there is no `Plug.SSL` and no `Plug.RewriteOn`
anywhere — nothing rewrites `conn.scheme`. The https:// links come from
`url: [host:, scheme: "https", port: 443]` in `config/runtime.exs`, and
`check_origin`'s canonical entry is the scheme-agnostic `"//#{phx_host}"`.

The file's **own pre-existing header** made the same claim (*"Phoenix maps it
back to scheme=https for check_origin and generated URLs"*). Both are corrected
to "convention, not mechanism". The header lines are **kept** — they cost
nothing and are what a future scheme-sensitive plug needs. The `:80` rescue
stands without them: a browser fails a WebSocket handshake on anything that is
not `101` and does not chase the `Location`, so a blanket `return 301` is
unfollowable by a reconnecting socket. That is the whole of #193.

**(c) The cold-boot fan-out is smaller than briefed, and the burst is
permanent.** The issue says cic fetches a channel list per network *"plus one
`/messages` per channel, in parallel"*. That was the #1679 incident's shape. It
is **not** what the client does at this tip: the `#1859` entry — landed today,
one commit below this branch's base — reads `selection.ts` and records that cold
boot fetches `/messages` for the **one** restored window and does not walk the
channel list. What remains is `me + networks + N × channels`, still scaling with
bound networks, which is the operator-facing point — but `1 + N`, not
`1 + N + M`. The file says the smaller, true thing.

And the issue calls the override *"mitigation, not a fix … see #1859 for the
server-side half that already exists and is unused"*. `GET /boot` does exist
(`BootController`), but **#1859 is CLOSED and the cutover was measured and
rejected** — 11.7× dearer for identical rows, 208× more DB work at boot. So this
is standing advice, not a stopgap, and the file says so.

## Structural correction: two directives could not go where the issue put them

`limit_req_zone` and `log_format` are **http-context only**, and this file is a
pair of `server` blocks an operator drops into `sites-enabled/`. Shipping either
one live hands a self-hoster an `[emerg]` on reload. Both now sit in a clearly
labelled `# GOES IN http { }` block at the top, commented, with the matching
in-block lines commented too and each saying which other line to uncomment with
it.

## Evidence

**Measured.** There is no test that loads an example conf, but there is one real
gate — `nginx -t` in a one-shot `nginx:alpine`, over a minimal `events{}/http{}`
wrapper with the placeholders substituted and a throwaway self-signed cert.
Three variants, and the last two are what make the first worth reporting:

| variant | expected | result |
|---|---|---|
| V1 — as shipped (everything new commented) | pass | `rc=0`, *syntax is ok* |
| V2 — the documented uncomment path (zone + format in `http{}`, `limit_req` / `access_log` / the `:80` `/socket` block enabled) | pass | `rc=0`, *syntax is ok* |
| **V3 — negative control**: `log_format` moved into the `server` block | **fail** | `rc=1`, `[emerg] "log_format" directive is not allowed here` |

V3 is the reason V1 and V2 mean anything: it proves the harness discriminates,
and it is the direct evidence for the http-context claim above.

`scripts/design-notes-gate.sh origin/main`, **post-commit**: `rc=0` —
`1 new entry heading(s), separator and marker present.` Marker uniqueness
re-checked against `origin/main`'s tip immediately before the push (0 hits;
positive control `#1859` = 1).

Closing-keyword scan over all commit messages: 0 matches, with the regex
validated by a positive and a negative control first.

**Read, not measured.** The behaviour of `EXTRA_CHECK_ORIGINS`, the `check_origin`
assembly, the two cic symptoms, and the #95 / #202 / #193 / #225 references are
read from the code and from the issue titles — each verified to exist, none
executed.

## What is NOT proven

- **The production numbers are vjt's, not mine.** `rate=200r/s`, `burst=400`,
  149 served req/s: readings off the m42 front, reported and attributed, not
  reproduced here. What I *did* corroborate in-repo is the 31 × 503 / `burst=50`
  / seven-network / 81+-requests arithmetic (DESIGN_NOTES `#1679` and
  `docs/CLIENT_PROTOCOL.md` §6a).
- **Nothing here ran against a live proxy.** `nginx -t` proves the file parses
  and that the uncomment path parses. It says nothing about whether 400 is the
  right burst for anybody else's deployment, nothing about the `:80` belt
  actually rescuing a stuck client, and nothing about the `ws` log line's
  contents at runtime.
- **The `ws` format is derived, not transcribed.** It is this repo's own `main`
  format (`infra/snippets/log-format.conf`) with `$request` replaced by
  method + `$uri` + protocol. The issue's snippet was truncated and I did not
  invent the missing fields.

Lane: none taken. No Elixir, no cic — the only container used was a one-shot
`docker run --rm nginx:alpine nginx -t` (no compose project, no published
ports).
