### PR TITLE
cicchetto: realign biome.json $schema with the CLI it configures

### DIFF
--- a/cicchetto/biome.json
+++ b/cicchetto/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Why

The tooling bump in `a0f360b41` moved `@biomejs/biome` from 2.5.8 to 2.5.10 and left `cicchetto/biome.json`'s `$schema` pointing at the 2.5.8 document. Those two are a pair by design — `$schema` names the contract the config is written against, and biome validates its own config against the version of the CLI reading it — so every run now opens with:

```
biome.json:2:14 deserialize ━━━
  i The configuration schema version does not match the CLI version 2.5.10
```

The reason to close it is not the line of noise. It is that whoever edits this config next gets completion and validation from the schema the running biome actually implements, rather than one two patch releases behind; and that a standing "your config is out of date" notice is exactly the kind of permanent yellow that teaches readers to skim past the diagnostics that do matter.

One line, `cicchetto/biome.json` only.

## What I measured, and what I am NOT claiming

Run locally with biome **2.5.10** actually installed (the cloned `node_modules` had a stale 2.5.8 and was reconciled with `install --frozen-lockfile` first — otherwise the mismatch disappears for the wrong reason and the whole measurement is worthless):

| | before (main) | after |
|---|---|---|
| `bun run check` rc | 0 | 0 |
| stage summary | 5 stages ran, 0 failed | 5 stages ran, 0 failed |
| `Found N warnings` | 59 | **59** |
| `Found N infos` | 5 | **4** |
| schema-mismatch diagnostic | 1 | **0** |

Per-file diagnostic counts are byte-identical across the two runs (`diff` of the two `uniq -c` tables is empty). In particular the recommended-preset warnings on `BottomBar.test.tsx` (10), `toasts.test.ts` (4), `notifyWatch.test.ts` (4), `ScrollbackPane.test.tsx` (2) and `shareTarget.test.ts` (1) are **unchanged** — they are baseline, they are warnings rather than errors, and biome has never failed the gate on them.

So, stated plainly: **this does not turn anything from red to green.** The cic job was already passing on main before this change, and `bun run check` was already `rc=0`. The red on main lives in the `test + lint + audit` job, which this PR does not touch.