### PR TITLE
cic: raise the server protocol floor to 9 so it stops claiming a shape it rejects

### DIFF
--- a/cicchetto/src/__tests__/serverProtocol.test.ts
+++ b/cicchetto/src/__tests__/serverProtocol.test.ts
@@ -8,6 +8,7 @@ import {
   shouldShowServerOutdatedBanner,
 } from "../lib/serverProtocol";
 import { CLIENT_PROTOCOL_VERSION } from "../lib/socket";
+import { narrowCredentialResponse } from "../lib/wireNarrow";
 
 // #1393d — the client-side server floor.
 //
@@ -63,5 +64,106 @@ describe("serverProtocol — the client-side floor (#1393d)", () => {
   // pinned here.
   it("never requires a server newer than the protocol this bundle speaks", () => {
     expect(MIN_SERVER_PROTOCOL_VERSION).toBeLessThanOrEqual(CLIENT_PROTOCOL_VERSION);
+  });
+});
+
+// #1654's open half, for the one narrower where the field → version fact
+// EXISTS rather than having to be invented.
+//
+// `serverProtocol.ts` states the obligation and says nothing enforces it, and
+// `protocol_test.exs` says the same from the Elixir side and explains why:
+// catching "forgot to raise the floor" in general needs a ledger of WHICH
+// protocol version introduced each field, and `priv/wire/shape.pin` holds a
+// digest of the CURRENT shape, not a history. That is still true. This does
+// not build the ledger; it uses the ONE entry the repo already wrote down —
+// `Grappa.Protocol`'s v9 note names `age`, `gender`, `location`, `languages`,
+// `custom` and `avatar_url` as joining the credential payload at 9 — and ties
+// the two facts for that shape alone.
+//
+// Stated as an IMPLICATION, deliberately, and NOT as a pin on the constant.
+// A pin (`expect(MIN).toBe(9)`) would test the number; this tests the RULE,
+// and it stays honest under EITHER cure: relax the narrower so a pre-profile
+// credential reads, and the antecedent is false and the floor is free to sit
+// wherever it likes; leave the narrower strict, and the floor has to say so.
+// What it forbids is the state main is in today — strict narrower, floor that
+// claims to accept a server that cannot satisfy it.
+describe("the floor vs the credential shape the narrower demands (#1654)", () => {
+  // The protocol version at which the six profile fields joined
+  // `Grappa.Networks.Wire.credential_json/0`. Not derivable from anything the
+  // bundle ships: the pin next door carries the CURRENT number, which equals
+  // this one only until the next bump. Hand-carried from the server's own
+  // `@protocol_version 9` note, which is where that fact is written.
+  const PROFILE_FIELDS_PROTOCOL_VERSION = 9;
+
+  // Exactly the keys `credential_json/0` declared BEFORE the profile fields —
+  // i.e. the whole body a protocol-8 server puts on the wire, not a trimmed
+  // sample. Measured against the generated schema at the merge base, and it
+  // is the same 13 keys the e2e vhost stub was serving when it went red.
+  const PRE_PROFILE_CREDENTIAL = {
+    network: "azzurra",
+    nick: "e2e-p282",
+    ident: null,
+    realname: null,
+    sasl_user: null,
+    auth_method: "none",
+    auth_command_template: null,
+    autojoin_channels: [],
+    connection_state: "parked",
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "2026-08-16T00:00:00Z",
+    updated_at: "2026-08-16T00:00:00Z",
+  };
+
+  // The same body a CURRENT server sends: the six fields present and null,
+  // which is what `credential_to_json/1` renders for a credential carrying no
+  // profile. Null, not populated — a fixture that only proves the happy shape
+  // would not catch a narrower that rejects the absent-value case.
+  const CURRENT_CREDENTIAL = {
+    ...PRE_PROFILE_CREDENTIAL,
+    age: null,
+    gender: null,
+    location: null,
+    languages: null,
+    custom: null,
+    avatar_url: null,
+  };
+
+  // `narrowCredentialResponse` THROWS rather than returning null (REST cannot
+  // answer with null the way the WS narrowers do), so "can this bundle read
+  // it" is a try/catch, not a truthiness check.
+  function readsCleanly(raw: unknown): boolean {
+    try {
+      narrowCredentialResponse(raw);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // POSITIVE CONTROL. Without it, a typo in either fixture makes
+  // `readsCleanly` answer false for a reason that has nothing to do with the
+  // profile fields, and the implication below would then be satisfiable by
+  // raising the floor over a defect that is not there.
+  it("reads a credential from a CURRENT server — the fixtures are sane", () => {
+    expect(readsCleanly(CURRENT_CREDENTIAL)).toBe(true);
+  });
+
+  // NEGATIVE CONTROL: `readsCleanly` is not simply answering true.
+  it("does not read something that is not a credential at all", () => {
+    expect(readsCleanly("not a credential")).toBe(false);
+  });
+
+  it("never claims a floor below the oldest credential shape it can read", () => {
+    const readsPreProfile = readsCleanly(PRE_PROFILE_CREDENTIAL);
+    const floorCoversIt = MIN_SERVER_PROTOCOL_VERSION >= PROFILE_FIELDS_PROTOCOL_VERSION;
+
+    expect(
+      readsPreProfile || floorCoversIt,
+      `this bundle rejects the credential a protocol-${PROFILE_FIELDS_PROTOCOL_VERSION - 1} ` +
+        `server sends, yet declares MIN_SERVER_PROTOCOL_VERSION = ${MIN_SERVER_PROTOCOL_VERSION}. ` +
+        "Per serverProtocol.ts: either relax the narrower so the older body reads, " +
+        `or raise the floor to ${PROFILE_FIELDS_PROTOCOL_VERSION}.`,
+    ).toBe(true);
   });
 });

--- a/cicchetto/src/lib/serverProtocol.ts
+++ b/cicchetto/src/lib/serverProtocol.ts
@@ -51,21 +51,45 @@ import { type Accessor, createSignal } from "solid-js";
 // Mirrors `Grappa.Protocol.min_version/0`'s naming, pointed at the peer this
 // side is judging.
 //
-// 🔴 THE OBLIGATION, and nothing enforces it. Narrowing any guard to REQUIRE
-// a field introduced by protocol version N obliges you to raise this number
-// to N in the same change. Measured, not assumed: no test ties this constant
-// to `Grappa.Protocol.version/0`, and no line anywhere says that tightening a
-// narrower costs a floor raise — so nothing will remind you. Forget it and a
-// bundle needing a v5 field goes on accepting a v2–v4 server, drops every
-// envelope missing that field and shows NO banner: the silent mode this
-// module was written to end, reintroduced by the module itself.
+// 🔴 THE OBLIGATION. Narrowing any guard to REQUIRE a field introduced by
+// protocol version N obliges you to raise this number to N in the same
+// change. Forget it and a bundle needing a v5 field goes on accepting a
+// v2–v4 server, drops every envelope missing that field and shows NO banner:
+// the silent mode this module was written to end, reintroduced by the module
+// itself.
 //
-// Named debt, not an oversight (DESIGN_NOTES 2026-08-21, #1393d): a real gate
-// needs the field → version-that-introduced-it history, and
-// `priv/wire/shape.pin` holds a digest, not a history. Inventing that history
-// inside this slice would be an unmeasured mechanism, so it is a separate
-// issue rather than a hurried one here.
-export const MIN_SERVER_PROTOCOL_VERSION = 2;
+// It was forgotten exactly once and it went exactly that way. The #1280
+// per-network profile put `age`, `gender`, `location`, `languages`, `custom`
+// and `avatar_url` on `Grappa.Networks.Wire.credential_json/0` at protocol 9
+// and generated them REQUIRED (no `q:` in `wireSchema.ts`, unlike the
+// `optional(:gender)` its own sibling `Session.Wire.member/0` carries), while
+// this number stayed at 2. Measured on the artefact rather than argued: the
+// e2e vhost stub was serving the 13-key body of a protocol-8 server, the
+// trace shows `narrowCredentialResponse` throwing `WireShapeError` on it, one
+// PATCH on the wire instead of two, and the network left PARKED with the
+// reconnect leg never issued. No banner, because 8 >= 2.
+//
+// Hence 9, and hence `CLIENT_PROTOCOL_VERSION` moving with it — the pinned
+// `MIN_SERVER <= CLIENT` invariant is what makes the pair move together, and
+// 2 was in any case stale against a server that has been at 9 since #1280.
+//
+// This does NOT make the bundle tolerant; it makes it HONEST. A protocol-8
+// server still cannot have its credential read here — the banner now says so
+// instead of the operator finding out from a network that parks and stays
+// parked. Relaxing the narrower (the six fields `optional(:…)` on the server
+// typespec, the #1766 `show_bottom_bar?` shape) is the OTHER cure and the one
+// that removes the condition rather than announcing it; it is a server-side
+// change that moves the shape digest and therefore costs a protocol bump of
+// its own, which is why it is not folded in here.
+//
+// Still named debt (DESIGN_NOTES 2026-08-21, #1393d): the GENERAL gate needs
+// the field → version-that-introduced-it history, and `priv/wire/shape.pin`
+// holds a digest of the current shape, not a history. What exists now is one
+// entry of that ledger, written where the fact already was — the credential
+// shape is tied to this constant by an implication test in
+// `serverProtocol.test.ts`, which passes under EITHER cure and fails only on
+// the state above. Every other narrower is still on trust.
+export const MIN_SERVER_PROTOCOL_VERSION = 9;
 
 // `null` until the user-topic join reply lands (or if it carries no number
 // at all — a server old enough to predate #447's join-reply field, which is

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -79,11 +79,29 @@ let _socket: Socket | null = null;
 // new event kind or field is free and never moves it") is gone with its
 // server-side twin: the wire version now moves on EVERY shape change.
 //
+// 2 → 9. Two reasons and the first alone is sufficient. (1) The number is the
+// CONTRACT version, and the server has been at 9 since the #1280 profile
+// fields landed; 2 had simply stopped tracking it across the intervening
+// bumps, which is why every boot logged `protocol mismatch: this bundle
+// speaks 2, the server speaks 9` — a true statement about a stale constant,
+// not about a real incompatibility. (2) `MIN_SERVER_PROTOCOL_VERSION` had to
+// rise to 9 to stop lying about the credential shape this bundle requires
+// (see its own note), and `MIN_SERVER <= CLIENT` is pinned in
+// `serverProtocol.test.ts` — a bundle requiring more than it speaks would
+// refuse every server that accepts it. The pair moves together or neither
+// moves.
+//
+// Raising THIS one is safe in the direction that can bite: the handshake
+// refuses a client BELOW `Grappa.Protocol.min_version/0`, which is 1, and
+// never one above. `protocol_test.exs` pins that from the other side
+// (`cic_protocol_version() >= Protocol.min_version()`).
+//
 // This is what cic SPEAKS. What it REQUIRES of the server is a separate
 // constant in `serverProtocol.ts` (`MIN_SERVER_PROTOCOL_VERSION`), and the
 // two are deliberately not the same number — a later bundle may speak v5
-// and still cope with a v2 server.
-export const CLIENT_PROTOCOL_VERSION = 2;
+// and still cope with a v2 server. They coincide today; that is a fact about
+// today, not a merge of the two axes.
+export const CLIENT_PROTOCOL_VERSION = 9;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43762,3 +43762,94 @@ inline), check whether a MORE SPECIFIC existing surface (here, the
 already-built WHOIS card) fits the actual use case before reaching for
 an invariant exception — the exception may turn out to be unnecessary,
 not just narrow.
+<!-- entry #1654a -->
+
+---
+
+## 2026-08-30 — #1654a: the client-side floor stops lying about the credential shape it demands
+
+`MIN_SERVER_PROTOCOL_VERSION` 2 → 9, `CLIENT_PROTOCOL_VERSION` 2 → 9, and one
+implication test tying the first to the shape the narrower actually requires.
+
+**The obligation, and how it was missed.** `serverProtocol.ts` carries it in
+red: narrowing any guard to REQUIRE a field introduced by protocol version N
+obliges raising that constant to N in the same change. #1280 narrowed three
+guards at once — `age`, `gender`, `location`, `languages`, `custom` and
+`avatar_url` joined `Grappa.Networks.Wire.credential_json/0` and its two
+`network_with_nick` siblings at protocol 9, and the codegen emitted them
+REQUIRED because the typespec declares them `required(:k)` and `walkObject`
+rejects an absent required key ("a REQUIRED key that is absent is a shape
+mismatch, not a tolerance"). The floor stayed at 2. Note the asymmetry inside
+that one change: `Grappa.Session.Wire.member/0` DID get `optional(:gender)`
+and so generated `q: ["gender"]`, so the mechanism was in hand and applied on
+one surface out of four.
+
+**Measured on the artefact, not argued.** The e2e vhost stub was serving the
+13-key body of a protocol-8 server — its key set is *set-equal* to what the
+generated schema declared before #1280, so the run was an accidental and
+faithful new-client → old-server compatibility test. It failed: the Playwright
+trace shows exactly one PATCH on the wire (`{"connection_state":"parked"}`)
+where the spec expects two, the console carries
+`[reconnect] bounce failed: WireShapeError`, and `bounceNetwork` awaits the
+park before issuing the connect leg — so the network is left PARKED and never
+comes back. No banner, because `8 >= 2`. That is precisely the silent mode the
+module was written to end, reintroduced by the module itself, and it is the
+same mechanism CLAUDE.md already records from the other direction under #1626
+("cic's generated `wireSchema` rejects an object missing a required key, so an
+old bundle throws every archive response away").
+
+**Two cures; this is the one the repo's text forces.** Raising the floor makes
+the bundle's declaration TRUE. Marking the six fields `optional(:…)` on the
+server typespec — the #1766 `show_bottom_bar?` shape — would instead make the
+bundle TOLERANT, so the older body reads and nothing breaks. The second is the
+better outcome and it is not what shipped here, for a reason that is about
+provenance rather than taste: the imperative in the repo names the first, twice
+(`serverProtocol.ts` and `protocol_test.exs` restate it verbatim), while #1766
+and #1626 are *recorded choices* with rationales, not obligations. The
+tolerance cure is also not cic-only — it moves the shape digest that
+`mix grappa.wire_pin --check` covers, and by the #1393d rule a shape change
+costs a protocol bump of its own. Raising the floor is a strictly smaller
+change that discharges the written obligation; relaxing the narrower is a
+server-side follow-up worth taking on its own merits.
+
+**Say plainly what this does not do: it fixes the SIGNAL, not the CONDITION.**
+A protocol-8 server still cannot have its credential read by this bundle. What
+changes is that the operator is told, instead of discovering it from a network
+that parks and stays parked. The three affected verbs are
+`PATCH /networks/:slug`, `PATCH /networks/:slug/identity` and
+`PUT /networks/:slug/password`; `GET /networks` is NOT affected, because only
+`S_NetworksWireCredentialJson` is wired into a narrower — the two
+`network_with_nick` shapes got the same required fields but no narrower imports
+them.
+
+**Who actually sees the banner, measured.** `shouldShowServerOutdatedBanner()`
+fires iff the server NAMED a number below the floor; an unknown number is not
+treated as old. Bundle and server both come from `origin/main` and the BEAM
+serves the SPA, so the only sustained way to be below 9 is a bundle shipped
+ahead of its server — which is a first-class operator verb,
+`scripts/deploy-m42.sh --cic`, documented as "cic-only bundle deploy, NO BEAM
+restart". In that window the banner is TRUE and its message already names the
+actionable half ("the BEAM was not restarted"). It is the alarm working, not a
+false alarm.
+
+**Why `CLIENT_PROTOCOL_VERSION` had to move with it.** `MIN_SERVER <= CLIENT`
+is pinned in `serverProtocol.test.ts` — a bundle requiring more than it speaks
+would refuse every server that accepts it. Raising the spoken number is safe in
+the direction that can bite (the handshake refuses a client BELOW
+`Grappa.Protocol.min_version/0`, which is 1, never one above) and it was in any
+case stale: the server has been at 9 since #1280, which is why every boot
+logged `protocol mismatch: this bundle speaks 2, the server speaks 9`. The two
+constants stay separate — they coincide today, and that is a fact about today.
+
+**The gate, and its honest limit.** `protocol_test.exs` explains why the
+GENERAL gate cannot be built: it needs a ledger of which protocol version
+introduced each field, and `priv/wire/shape.pin` holds a digest of the current
+shape, not a history. That is still true and no ledger is invented here. What
+exists now is ONE entry of it, written where the fact already was — the
+server's own v9 note names the six fields — expressed as an implication:
+either the narrower reads a pre-profile credential, or the floor is at least 9.
+It passes under EITHER cure, so applying the tolerance later does not require
+editing the assertion, and it fails only on the state main was in. The test
+carries its own positive control (a current credential must read, or a typo in
+the fixture would let a floor raise "fix" a defect that is not there) and a
+negative control. Every other narrower in the bundle is still on trust.


### PR DESCRIPTION
Discharges the obligation that the KVIrc profile work (issue 1280, merged as
PR 1865) left open. Two constants and one implication test; cic-side files
only.

## What was wrong

`serverProtocol.ts` carries an obligation in red: *narrowing any guard to
REQUIRE a field introduced by protocol version N obliges you to raise this
number to N in the same change.* `protocol_test.exs` restates it verbatim from
the Elixir side.

Issue 1280 narrowed three guards at once — `age`, `gender`, `location`,
`languages`, `custom` and `avatar_url` joined
`Grappa.Networks.Wire.credential_json/0` and its two `network_with_nick`
siblings at protocol 9, generated REQUIRED because the typespec declares them
`required(:k)` and `walkObject` rejects an absent required key. The floor
stayed at 2.

The asymmetry sits inside that one change: `Session.Wire.member/0` **did** get
`optional(:gender)` and generated `q: ["gender"]`. The mechanism was in hand
and applied on one surface out of four.

## Measured on the artefact, not argued

The e2e vhost stub was serving the 13-key body of a protocol-8 server — its
key set is *set-equal* to what the generated schema declared before the
profile fields — so that run was an accidental, faithful new-client →
old-server test. It failed:

- the Playwright trace shows **one** PATCH on the wire
  (`{"connection_state":"parked"}`) where the spec expects two;
- the console carries `[reconnect] bounce failed: WireShapeError`;
- `bounceNetwork` awaits the park before issuing the connect leg, so the
  network is left **PARKED** and never comes back;
- no banner, because `8 >= 2`.

That is the silent mode the module was written to end, reintroduced by the
module itself.

## Why this cure and not the other one

There were two. Marking the six fields `optional(:…)` on the server typespec
(the issue 1766 `show_bottom_bar?` shape) makes the bundle **tolerant** — the
better outcome — and is deliberately not what ships here:

- **Provenance.** The imperative in the repo names the floor raise, twice and
  verbatim. Issues 1766 and 1626 are *recorded choices with rationales*, not
  obligations.
- **Blast radius.** The tolerance cure is not cic-only: it moves the shape
  digest `mix grappa.wire_pin --check` covers, and by the 1393d rule a shape
  change costs a protocol bump of its own.

It is worth taking on its own merits, server-side, separately.

## Said plainly: this fixes the SIGNAL, not the CONDITION

A protocol-8 server still cannot have its credential read by this bundle. What
changes is that the operator is **told**, instead of finding out from a network
that parks and stays parked.

Affected verbs: `PATCH /networks/:slug`, `PATCH /networks/:slug/identity`,
`PUT /networks/:slug/password`. **`GET /networks` is not affected** — only
`S_NetworksWireCredentialJson` is wired into a narrower; the two
`network_with_nick` shapes got the same required fields but no narrower
imports them.

## Who sees the banner, measured

`shouldShowServerOutdatedBanner()` fires only when the server **named** a
number below the floor; unknown is not treated as old. Bundle and server both
come from `origin/main` and the BEAM serves the SPA, so the only sustained way
to be below 9 is a bundle shipped ahead of its server — a first-class operator
verb, `scripts/deploy-m42.sh --cic`, documented as *"cic-only bundle deploy,
NO BEAM restart"*. In that window the banner is TRUE and its message already
names the actionable half ("the BEAM was not restarted"). The alarm working,
not a false alarm.

## Why `CLIENT_PROTOCOL_VERSION` moves too

`MIN_SERVER <= CLIENT` is pinned in `serverProtocol.test.ts` — a bundle
requiring more than it speaks would refuse every server that accepts it.
Raising the spoken number is safe in the direction that can bite: the
handshake refuses a client **below** `Grappa.Protocol.min_version/0`, which is
1, never one above. It was stale anyway — the server has been at 9 since issue
1280, which is why every boot logged `protocol mismatch: this bundle speaks 2,
the server speaks 9`.

## The test, and its honest limit

`protocol_test.exs` explains why the GENERAL gate cannot be built: it needs a
ledger of which protocol version introduced each field, and
`priv/wire/shape.pin` holds a digest of the current shape, not a history. **No
ledger is invented here.** What exists now is ONE entry of it, using the fact
the repo already wrote down (the server's own v9 note names the six fields),
expressed as an implication:

> either the narrower reads a pre-profile credential, **or** the floor is at
> least 9.

It passes under **either** cure, so applying the tolerance later needs no edit
to the assertion; it fails only on the state main is in today. It carries a
positive control (a current credential must read — otherwise a typo in a
fixture would let a floor raise "fix" a defect that is not there) and a
negative control. Every other narrower in the bundle is still on trust.

## Gates run

| gate | result |
|---|---|
| `scripts/bun.sh run check` (biome + tsc src/e2e + lock drift) | `rc=0` |
| `scripts/bun.sh run test` (full cic suite) | `rc=0` — 327 files, 6545 tests |
| `scripts/design-notes-gate.sh origin/main` | `rc=0` — 1 entry, separator and marker present |
| RED proof before the cure | the implication test failed with its actionable message; both controls green |

DESIGN_NOTES contribution, pinned for the merge: **91 additions, 0 deletions**.

## Not run, and flagged rather than assumed

`test/grappa/protocol_test.exs` **reads both constants out of cic's source**
(`cicchetto/src` is mounted into the Elixir test container). Its two relevant
assertions are `cic_protocol_version() >= Protocol.min_version()` → `9 >= 1`
and `cic_min_server_protocol_version() <= Protocol.version()` → `9 <= 9`, so
both hold arithmetically — but the Elixir suite needs the compile lane and I
did not run it. Flagging rather than claiming it green.