### PR TITLE
peer avatars: honour the profile opt-out on the capture path, and scope the cache lookup to its network

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43853,3 +43853,99 @@ editing the assertion, and it fails only on the state main was in. The test
 carries its own positive control (a current credential must read, or a typo in
 the fixture would let a floor raise "fix" a defect that is not there) and a
 negative control. Every other narrower in the bundle is still on trust.
+<!-- entry #1865a -->
+
+---
+
+## 2026-08-30 — #1865a: the peer-profile opt-in has two halves, and the cache lookup has two keys
+
+Two follow-ups to the KVIrc-style profile work (entry #1280), both of the
+same shape: a scope the code DOCUMENTED but did not ENFORCE.
+
+### The opt-in governs what we ask AND what we learn
+
+`show_peer_profiles` gated `maybe_query_userinfo/2` and
+`maybe_query_avatar/2` — the ASK half — and nothing on the CAPTURE half.
+A CTCP reply is not evidence that we asked: nothing stops a peer sending
+one unprompted, and both capture arms ran on it. For a subject with the
+feature switched OFF that meant `peer_profile_cache` filled up anyway,
+and on the AVATAR arm it also meant `dispatch_avatar_fetch/3` spending an
+outbound HTTP round trip on a URL supplied by the peer, plus a
+`peer_avatars` row and a file on disk. Measured end to end before the
+fix: a raw wire NOTICE fed into a live `Session.Server` whose state read
+`show_peer_profiles: false` and whose `peer_profile_cache` was empty
+produced an arrival at a real listener, a cached row and a file.
+
+The fix is one door — `maybe_capture_peer_profile/3`, the mirror of
+`maybe_query_peer_profile/2` — with the flag read ONCE there, and the two
+arms reachable only through it. A wrapper rather than a check in each arm
+because the failure was precisely that one of two symmetric halves was
+forgotten; a single gate cannot be half-applied by the next person to add
+a third field.
+
+**Scope of the gate, deliberately narrow: it governs what the session
+LEARNS, never what it SHOWS.** The `:persist` row for the notice is built
+after the capture returns and is untouched, so a CTCP reply still lands
+verbatim in `$server` whatever the opt-in says. A test pins that arm on
+the opted-OUT default on purpose — refusing to learn from a reply must
+never quietly turn into refusing to display it.
+
+**Named and NOT done here, because each is a wider decision than
+honouring a setting that already exists:**
+
+1. *Solicited-only capture.* The capture-side dedup asks
+   `is_nil(Map.get(entry, :avatar_slug))`, whereas its outbound twin asks
+   `Map.has_key?/2`. Under `Map.get/2` an ABSENT key and a "we asked, no
+   answer yet" key are indistinguishable, so for a subject who HAS opted
+   in, a reply from a peer we never queried is still actioned. Aligning
+   the two would close that; it also changes what the feature does for
+   the opted-in majority, which is a product call and not a scoping one.
+2. *A ceiling on the fetch fan-out.* `Grappa.TaskSupervisor` carries no
+   `max_children`; 500 concurrent children were accepted in one run with
+   no refusal, and no limit was searched for. Whether these fetches want
+   their own bounded supervisor is a supervision-tree decision.
+3. *`Grappa.Avatars.fetch_and_cache/3` can raise.* Its `@spec` is `:: :ok`
+   and its docstring promises every failure is swallowed, but `Repo.insert`
+   raises `Ecto.ConstraintError` on a foreign-key violation and no clause
+   catches it. Reproduced only from a synthetic `network_id`; the
+   production path (a `networks` row deleted while a fetch is in flight)
+   is read off the schema, not observed.
+
+### A slug is not a scope
+
+`Avatars.get_by_slug/1` matched on `slug` and `expires_at` only.
+`Grappa.Avatars` is keyed `(network_id, nick_key)` throughout — `get/2`
+has been network-scoped since day one — and the serving route is mounted
+under `/networks/:network_id/...` behind `ResolveNetwork`, whose whole
+job is to prove the caller holds a credential on THAT network. The
+action's own doc says "ownership: any live credential on this network".
+The lookup did not carry the network, so the second half of that sentence
+was aspirational: what the gate proved and what the query enforced were
+different sets.
+
+Now `get_by_slug/2`, taking the resolved network's id and adding the
+conjunct, with the controller passing `conn.assigns.network.id`. Not a
+default argument (CLAUDE.md forbids them precisely so a caller cannot
+silently keep the unscoped behaviour); the arity change makes every call
+site declare which network it means, and there was only one.
+
+The `:not_found` collapse is unchanged and now covers a fourth case —
+"exists, but not on your network" — for the same no-oracle reason the
+other three collapse.
+
+**Found while measuring this, named and NOT fixed here:
+`Session.Server`'s `peer_avatar_route/2` builds
+`/networks/#{state.network_id}/peer_avatar/#{slug}` — an INTEGER id —
+while `ResolveNetwork` reads that path segment as a SLUG
+(`Networks.get_network_by_slug/1`), so the URL the server hands the
+client cannot resolve and the card's image 404s.** Measured in both
+directions on one row with its file present on disk: the integer form
+404s, the slug form is a 200 with `content-type: image/png` — the same
+row, the same credential, the same request otherwise. Nothing pinned the
+emitted shape, in either direction, which is why it survived; a fix
+therefore owes a test of the URL itself, and it turns an image that
+never rendered into one that does, which is a behaviour change rather
+than a scoping one. `state.network_slug` is already on the state (the
+sibling wire call one line up uses it), so the change is small — it is
+the coverage and the visible-behaviour flip that make it somebody's
+decision rather than this branch's.

--- a/lib/grappa/avatars.ex
+++ b/lib/grappa/avatars.ex
@@ -279,15 +279,30 @@ defmodule Grappa.Avatars do
   end
 
   @doc """
-  Looks up a row by slug for the authenticated serving route. Returns
-  `:not_found` for a bad slug shape, a missing row, or an expired one —
-  collapsed to one variant so the serving route leaks no oracle.
+  Looks up a row by `(network_id, slug)` for the authenticated serving
+  route. Returns `:not_found` for a bad slug shape, a missing row, an
+  expired one, or a row belonging to a DIFFERENT network — collapsed to
+  one variant so the serving route leaks no oracle.
+
+  `network_id` is not redundant with the slug. The serving route is
+  mounted under `/networks/:network_id/...` behind `ResolveNetwork`,
+  which proves the caller holds a credential on THAT network and nothing
+  more; the action's own contract is "any live credential on this
+  network". A slug-only lookup would have made every cached row on the
+  deployment readable from any one network the caller is bound to, which
+  is a wider grant than the route's own gate proves — so the conjunct
+  here is what makes the documented scope true rather than aspirational.
+  Mirrors `get/2`, which has been `(network_id, nick_key)`-scoped from
+  the start.
   """
-  @spec get_by_slug(String.t()) :: {:ok, PeerAvatar.t()} | {:error, :not_found}
-  def get_by_slug(slug) when is_binary(slug) do
+  @spec get_by_slug(integer(), String.t()) :: {:ok, PeerAvatar.t()} | {:error, :not_found}
+  def get_by_slug(network_id, slug) when is_integer(network_id) and is_binary(slug) do
     if Regex.match?(@slug_regex, slug) do
       now = DateTime.utc_now()
-      query = from a in PeerAvatar, where: a.slug == ^slug and a.expires_at > ^now
+
+      query =
+        from a in PeerAvatar,
+          where: a.network_id == ^network_id and a.slug == ^slug and a.expires_at > ^now
 
       case Repo.one(query) do
         nil -> {:error, :not_found}

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2608,10 +2608,7 @@ defmodule Grappa.Session.EventRouter do
     # `ctcp_meta/1` (no separate silent-bookkeeping path). The ONLY thing
     # M2 adds is a side-effect extraction of `Gender=` into
     # `peer_profile_cache`, alongside the unchanged persist.
-    state2 =
-      state
-      |> maybe_capture_peer_userinfo(sender, body)
-      |> maybe_capture_peer_avatar(sender, body)
+    state2 = maybe_capture_peer_profile(state, sender, body)
 
     {state3, eff} =
       build_persist(
@@ -3279,12 +3276,46 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
+  # The CAPTURE half of the peer-profile feature, and the mirror of
+  # `maybe_query_peer_profile/2` (the ASK half): one door so a caller
+  # doesn't have to know both fields exist, and — the reason this
+  # wrapper exists rather than two piped calls — ONE place where the
+  # `show_peer_profiles` opt-in is honoured.
+  #
+  # The opt-in gate belongs on BOTH halves, not just the ask. A reply is
+  # not proof we asked: a peer can send a CTCP reply nobody solicited,
+  # and until the gate was here, one arriving for a subject who had
+  # switched the feature OFF still populated `peer_profile_cache` — and,
+  # on the AVATAR arm, still spent an outbound HTTP fetch of a URL the
+  # peer chose. Gating only the ask left the opt-out half-honoured, which
+  # is the "two patterns" CLAUDE.md rejects: a reader of
+  # `maybe_query_avatar/2` would reasonably conclude the whole feature
+  # was off.
+  #
+  # Scope, deliberately: this governs what the session LEARNS, never what
+  # it SHOWS. The `:persist` row for the notice is built by the caller
+  # after this returns and is untouched — a CTCP reply stays visible in
+  # `$server` whatever the opt-in says, exactly as before.
+  @spec maybe_capture_peer_profile(state(), String.t(), binary()) :: state()
+  defp maybe_capture_peer_profile(state, sender, body) do
+    if Map.get(state, :show_peer_profiles, false) do
+      state
+      |> maybe_capture_peer_userinfo(sender, body)
+      |> maybe_capture_peer_avatar(sender, body)
+    else
+      state
+    end
+  end
+
   # M2 — side-effect extraction for an inbound CTCP USERINFO reply: if
   # `body` carries a parseable `Gender=` field, fold it into
   # `peer_profile_cache[fold(sender)]`. A no-op (returns `state`
   # unchanged) for any other CTCP verb, a plain non-CTCP notice, or a
   # USERINFO reply with no recognisable Gender= — the cache is
   # best-effort, never a parse failure surfaced to the user.
+  #
+  # Reached only through `maybe_capture_peer_profile/3`, which owns the
+  # `show_peer_profiles` gate — do not call this directly.
   @spec maybe_capture_peer_userinfo(state(), String.t(), binary()) :: state()
   defp maybe_capture_peer_userinfo(state, sender, body) do
     case CTCP.verb_args(body) do
@@ -3465,6 +3496,11 @@ defmodule Grappa.Session.EventRouter do
   # implements) is silently dropped. Marks `avatar_slug: :pending`
   # BEFORE the fetch completes so a second reply (channel + private, or
   # a repeat) doesn't dispatch a second fetch for the same nick.
+  #
+  # Reached only through `maybe_capture_peer_profile/3`, which owns the
+  # `show_peer_profiles` gate — do not call this directly. That gate is
+  # load-bearing HERE and not merely tidy: this arm is the only one in
+  # the capture half that spends an outbound network request.
   @spec maybe_capture_peer_avatar(state(), String.t(), binary()) :: state()
   defp maybe_capture_peer_avatar(state, sender, body) do
     case CTCP.verb_args(body) do

--- a/lib/grappa_web/controllers/networks_controller.ex
+++ b/lib/grappa_web/controllers/networks_controller.ex
@@ -315,10 +315,17 @@ defmodule GrappaWeb.NetworksController do
   `:authn` + `:resolve_network` gate every other `/networks/:network_id/*`
   route already has (ownership: any live credential on this network).
 
-  200 with the image bytes; 404 for a bad slug, a missing/expired row,
-  or a row whose file went missing (no oracle — same collapse
-  `UploadsController.show/2` uses); 401 without a Bearer; 403/404 (via
-  `:resolve_network`) for a network the caller has no credential on.
+  The lookup is scoped to the RESOLVED network, not to the slug alone —
+  `:resolve_network` proves a credential on the network in the path and
+  nothing beyond it, so `Avatars.get_by_slug/2` takes that network's id
+  and the "ownership on this network" clause above is enforced rather
+  than merely intended.
+
+  200 with the image bytes; 404 for a bad slug, a missing/expired row, a
+  row cached for a different network, or a row whose file went missing
+  (no oracle — same collapse `UploadsController.show/2` uses); 401
+  without a Bearer; 403/404 (via `:resolve_network`) for a network the
+  caller has no credential on.
 
   `path` comes from `Avatars.storage_path/1`, which validates the slug
   against `^[a-z2-7]{26}$` before joining it — same guard
@@ -329,7 +336,7 @@ defmodule GrappaWeb.NetworksController do
   @sobelow_skip ["Traversal.FileModule", "XSS.SendResp"]
   @spec peer_avatar(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def peer_avatar(conn, %{"slug" => slug}) when is_binary(slug) do
-    with {:ok, row} <- Avatars.get_by_slug(slug),
+    with {:ok, row} <- Avatars.get_by_slug(conn.assigns.network.id, slug),
          path = Avatars.storage_path(row.slug),
          {:ok, bytes} <- File.read(path) do
       conn

--- a/test/grappa/avatars_test.exs
+++ b/test/grappa/avatars_test.exs
@@ -79,13 +79,13 @@ defmodule Grappa.AvatarsTest do
     assert Repo.aggregate(PeerAvatar, :count) == 1
   end
 
-  describe "get_by_slug/1" do
-    test "returns :not_found for a malformed slug" do
-      assert {:error, :not_found} = Avatars.get_by_slug("not-a-real-slug")
+  describe "get_by_slug/2" do
+    test "returns :not_found for a malformed slug", ctx do
+      assert {:error, :not_found} = Avatars.get_by_slug(ctx.network_id, "not-a-real-slug")
     end
 
-    test "returns :not_found for an unknown slug" do
-      assert {:error, :not_found} = Avatars.get_by_slug("aaaaaaaaaaaaaaaaaaaaaaaaaa")
+    test "returns :not_found for an unknown slug", ctx do
+      assert {:error, :not_found} = Avatars.get_by_slug(ctx.network_id, "aaaaaaaaaaaaaaaaaaaaaaaaaa")
     end
 
     test "returns the row for a live cached slug", ctx do
@@ -93,7 +93,25 @@ defmodule Grappa.AvatarsTest do
       assert :ok = Avatars.fetch_and_cache(ctx.network_id, "findable", "http://peer.example/av.png")
       row = Avatars.get(ctx.network_id, "findable")
 
-      assert {:ok, ^row} = Avatars.get_by_slug(row.slug)
+      assert {:ok, ^row} = Avatars.get_by_slug(ctx.network_id, row.slug)
+    end
+
+    # The serving route is mounted under `/networks/:network_id/...` and its
+    # own doc scopes ownership to "any live credential on THIS network". The
+    # slug alone is not that scope: a caller resolved onto network A must not
+    # be handed a row cached for network B.
+    test "returns :not_found for a slug cached on a DIFFERENT network", ctx do
+      expect(Grappa.Net.ImageFetcherMock, :fetch, fn _ -> {:ok, ctx.png, "image/png"} end)
+      assert :ok = Avatars.fetch_and_cache(ctx.network_id, "elsewhere", "http://peer.example/av.png")
+      row = Avatars.get(ctx.network_id, "elsewhere")
+
+      other_network_id = network_fixture().id
+      refute other_network_id == ctx.network_id
+
+      assert {:error, :not_found} = Avatars.get_by_slug(other_network_id, row.slug)
+      # Positive control: the row IS live and IS reachable from its own
+      # network, so the :not_found above is the scope and not an expiry.
+      assert {:ok, ^row} = Avatars.get_by_slug(ctx.network_id, row.slug)
     end
 
     test "returns :not_found for an expired row", ctx do
@@ -105,7 +123,7 @@ defmodule Grappa.AvatarsTest do
       |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -1, :second))
       |> Repo.update!()
 
-      assert {:error, :not_found} = Avatars.get_by_slug(row.slug)
+      assert {:error, :not_found} = Avatars.get_by_slug(ctx.network_id, row.slug)
       assert Avatars.get(ctx.network_id, "stale") == nil
     end
   end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -688,7 +688,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a CTCP USERINFO reply NOTICE captures Gender= into peer_profile_cache" do
-      state = base_state()
+      state = base_state(%{show_peer_profiles: true})
       body = <<0x01, "USERINFO Age=30; Gender=F; Location=Italy", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -696,6 +696,39 @@ defmodule Grappa.Session.EventRouterTest do
       assert new_state.peer_profile_cache == %{"alice" => %{gender: :female}}
     end
 
+    # The peer-profile cache is an OPT-IN feature: `maybe_query_userinfo/2`
+    # and `maybe_query_avatar/2` both refuse to ASK when the subject has not
+    # opted in. The capture half has to refuse to LEARN on the same terms —
+    # otherwise a peer who answers a question we never asked populates a
+    # cache the subject switched off, and for AVATAR that answer also costs
+    # an outbound fetch of a URL the peer chose.
+    test "opted OUT, a CTCP USERINFO reply leaves peer_profile_cache untouched" do
+      state = base_state(%{show_peer_profiles: false})
+      body = <<0x01, "USERINFO Age=30; Gender=F; Location=Italy", 0x01>>
+      m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
+
+      assert {:cont, new_state, _} = EventRouter.route(m, state)
+      assert new_state.peer_profile_cache == %{}
+    end
+
+    test "opted OUT, a CTCP AVATAR reply neither marks the cache nor dispatches a fetch" do
+      state = base_state(%{show_peer_profiles: false})
+      body = <<0x01, "AVATAR http://peer.example/av.png", 0x01>>
+      m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
+
+      assert {:cont, new_state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+      # `:pending` is the observable proof a fetch was dispatched — the task
+      # is detached, so the cache mark is what this layer can assert on.
+      assert new_state.peer_profile_cache == %{}
+      # …and the row is still visible, framing intact: the opt-in governs the
+      # cache, never the transcript.
+      assert attrs.channel == "$server"
+      assert attrs.body == body
+    end
+
+    # Deliberately left on the OPTED-OUT default: the visible scrollback row
+    # is not part of the opt-in. Refusing to LEARN from a CTCP reply must
+    # never turn into refusing to SHOW it.
     test "a CTCP USERINFO reply still persists the normal visible row (not silent)" do
       state = base_state()
       body = <<0x01, "USERINFO Gender=M", 0x01>>
@@ -710,7 +743,7 @@ defmodule Grappa.Session.EventRouterTest do
 
     test "CTCP USERINFO Gender= parsing is case-insensitive for M/F/X" do
       for {letter, expected} <- [{"m", :male}, {"F", :female}, {"x", :nonbinary}] do
-        state = base_state()
+        state = base_state(%{show_peer_profiles: true})
         body = <<0x01, "USERINFO Gender=#{letter}", 0x01>>
         m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -720,7 +753,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a CTCP USERINFO reply with no Gender= field leaves peer_profile_cache untouched" do
-      state = base_state()
+      state = base_state(%{show_peer_profiles: true})
       body = <<0x01, "USERINFO Age=30; Location=Italy", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -729,7 +762,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a CTCP USERINFO reply with an unrecognised Gender= value leaves peer_profile_cache untouched" do
-      state = base_state()
+      state = base_state(%{show_peer_profiles: true})
       body = <<0x01, "USERINFO Gender=Q", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -746,7 +779,7 @@ defmodule Grappa.Session.EventRouterTest do
     # this file's; asserting on ITS outcome here would need cross-process
     # Mox wiring for no real coverage gain.
     test "a CTCP AVATAR reply with an http(s) URL marks the cache :pending and dispatches a fetch" do
-      state = base_state()
+      state = base_state(%{show_peer_profiles: true})
       body = <<0x01, "AVATAR http://peer.example/av.png", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -755,7 +788,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a CTCP AVATAR reply accepts https too" do
-      state = base_state()
+      state = base_state(%{show_peer_profiles: true})
       body = <<0x01, "AVATAR https://peer.example/av.png", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -764,7 +797,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a CTCP AVATAR reply with a bare filename (the legacy DCC offer) is refused, never dispatched" do
-      state = base_state()
+      state = base_state(%{show_peer_profiles: true})
       body = <<0x01, "AVATAR myface.png 4096", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -775,7 +808,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a CTCP AVATAR reply with a non-http scheme (e.g. file://) is refused" do
-      state = base_state()
+      state = base_state(%{show_peer_profiles: true})
       body = <<0x01, "AVATAR file:///etc/passwd", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -784,7 +817,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a second CTCP AVATAR reply while a fetch is already :pending does not re-dispatch" do
-      state = base_state(%{peer_profile_cache: %{"alice" => %{avatar_slug: :pending}}})
+      state = base_state(%{show_peer_profiles: true, peer_profile_cache: %{"alice" => %{avatar_slug: :pending}}})
       body = <<0x01, "AVATAR http://peer.example/second.png", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 
@@ -794,7 +827,7 @@ defmodule Grappa.Session.EventRouterTest do
     end
 
     test "a second CTCP AVATAR reply for an already-cached (real slug) nick does not re-dispatch" do
-      state = base_state(%{peer_profile_cache: %{"alice" => %{avatar_slug: "existingslug"}}})
+      state = base_state(%{show_peer_profiles: true, peer_profile_cache: %{"alice" => %{avatar_slug: "existingslug"}}})
       body = <<0x01, "AVATAR http://peer.example/second.png", 0x01>>
       m = msg(:notice, ["vjt", body], {:nick, "alice", "u", "h"})
 

--- a/test/grappa_web/controllers/networks_controller_test.exs
+++ b/test/grappa_web/controllers/networks_controller_test.exs
@@ -1341,6 +1341,49 @@ defmodule GrappaWeb.NetworksControllerTest do
     |> Repo.update!()
   end
 
+  describe "GET /networks/:network_id/peer_avatar/:slug" do
+    # The route is nested under `:resolve_network`, so the caller is already
+    # proven to hold a credential on the network in the PATH. The lookup must
+    # be scoped to that same network — a slug is a bearer of nothing on its
+    # own, and the action's own doc scopes ownership to "this network".
+    test "404s for a slug cached on a network the caller is not resolved onto", %{conn: conn} do
+      vjt = user_fixture(name: "vjt-avatar-#{u()}")
+      session = session_fixture(vjt)
+
+      {mine, _} = network_with_server(port: 6667, slug: "avatar-mine-#{u()}")
+      {theirs, _} = network_with_server(port: 6668, slug: "avatar-theirs-#{u()}")
+      _ = credential_fixture(vjt, mine)
+      _ = credential_fixture(vjt, theirs)
+
+      Mox.stub(Grappa.Net.ImageFetcherMock, :fetch, fn _ ->
+        {:ok, Grappa.UploadFixtures.bytes(:gps_png), "image/png"}
+      end)
+
+      assert :ok = Grappa.Avatars.fetch_and_cache(theirs.id, "somepeer", "http://peer.example/av.png")
+      row = Grappa.Avatars.get(theirs.id, "somepeer")
+      on_exit(fn -> File.rm(Grappa.Avatars.storage_path(row.slug)) end)
+      assert File.exists?(Grappa.Avatars.storage_path(row.slug))
+
+      cross =
+        conn
+        |> put_bearer(session.id)
+        |> get("/networks/#{mine.slug}/peer_avatar/#{row.slug}")
+
+      assert json_response(cross, 404)
+
+      # Positive control: the very same slug, served from ITS OWN network,
+      # is a 200 — so the 404 above is the network scope and not a missing
+      # file, an expired row, or a broken route.
+      own =
+        build_conn()
+        |> put_bearer(session.id)
+        |> get("/networks/#{theirs.slug}/peer_avatar/#{row.slug}")
+
+      assert response(own, 200)
+      assert Plug.Conn.get_resp_header(own, "content-type") == ["image/png"]
+    end
+  end
+
   # U-0 helper — drive the per-network circuit to `:open` by directly
   # writing the ETS row with a far-future `cooled_at_ms`. We bypass
   # `NetworkCircuit.record_failure/1` because the test config sets


### PR DESCRIPTION
Two follow-ups to the KVIrc-style profile work (issue 1865, DESIGN_NOTES
entry #1280). Both are the same shape: **a scope the code documented in
prose but did not carry in the branch or the query.** No new feature, no
new setting, no wire change.

## 1. The opt-in governs what we ask AND what we learn

`show_peer_profiles` gated the ASK half — `maybe_query_userinfo/2` and
`maybe_query_avatar/2` — and nothing on the CAPTURE half. A CTCP reply is
not evidence that we asked: nothing obliges a peer to wait for a query
before sending one, and both capture arms ran on whatever arrived. For a
subject who had switched the feature OFF that still populated
`peer_profile_cache`, and on the AVATAR arm it still spent an outbound
fetch of a peer-supplied URL plus a cached row and a file on disk.

The gate now lives in one place — `maybe_capture_peer_profile/3`, the
mirror of `maybe_query_peer_profile/2` — with both arms reachable only
through it. A wrapper rather than a check inside each arm precisely
because the defect was one of two symmetric halves being forgotten.

**Deliberately narrow: this governs what the session LEARNS, never what
it SHOWS.** The `:persist` row is built after capture returns and is
untouched, so a CTCP reply still lands verbatim in `$server` whatever the
opt-in says. One test stays on the opted-OUT default to pin exactly that.

## 2. A slug is not a scope

`Avatars.get_by_slug/1` matched on `slug` + `expires_at` and nothing
else, while every other door into this context is keyed
`(network_id, nick_key)` — `get/2` has been network-scoped from the
start. The serving route sits under `/networks/:network_id/...` behind
`ResolveNetwork`, whose job is to prove the caller holds a credential on
THAT network, and the action's own doc already claimed *"ownership: any
live credential on this network"*. The query did not carry the network,
so what the gate proved and what the lookup enforced were different sets.

`get_by_slug/2` takes the resolved network's id and adds the conjunct;
the controller passes `conn.assigns.network.id`. An arity change rather
than a default argument, per CLAUDE.md — a default would let a future
call site keep the unscoped behaviour by saying nothing, which is the
silence being removed. One call site existed.

## Tests first, and they failed first

Captured red before any production edit:

- opted-out USERINFO reply — `left: %{"alice" => %{gender: :female}}`,
  `right: %{}`
- opted-out AVATAR reply — `left: %{"alice" => %{avatar_slug: :pending}}`,
  `right: %{}`
- `get_by_slug/2 is undefined` across the context cases
- the controller case, through the real route

Each negative assertion carries a positive control in the same test, so a
`:not_found` is the scope and not an expiry, a missing file, or a broken
route: the context case re-reads the same row from its own network, and
the controller case gets a 200 with `content-type: image/png` for the
same slug on the network it belongs to.

The pre-existing capture cases move to an explicitly opted-IN fixture —
they were riding `base_state()`'s opted-out default, so each was
asserting the parser while the feature was nominally off. No assertion
was weakened.

## Deliberately NOT done — named in the DESIGN_NOTES entry, not decided here

1. **Solicited-only capture.** The capture-side dedup asks
   `is_nil(Map.get(entry, :avatar_slug))` where its outbound twin asks
   `Map.has_key?/2`; under `Map.get/2` an absent key and a "asked, no
   answer yet" key are indistinguishable. Aligning them also changes what
   the feature does for the opted-IN majority — a product call.
2. **A ceiling on the fetch fan-out.** `Grappa.TaskSupervisor` carries no
   `max_children`; 500 concurrent children were accepted in one run with
   no refusal, and no limit was searched for. A supervision-tree call.
3. **`Avatars.fetch_and_cache/3` can raise.** Its `@spec` is `:: :ok` and
   its docstring promises every failure is swallowed, but `Repo.insert`
   raises `Ecto.ConstraintError` on a foreign-key violation and no clause
   catches it. Reproduced only from a synthetic `network_id`; the
   production trigger is read off the schema, not observed.
4. **`peer_avatar_route/2` emits an integer id where `ResolveNetwork`
   reads a slug**, so the avatar URL the server hands the client cannot
   resolve. Measured both ways on one row with its file on disk: integer
   form 404, slug form 200. Nothing pinned the emitted shape in either
   direction. `state.network_slug` is already on the state, so the change
   is small — but it owes a test of the URL itself and it flips an image
   that never rendered into one that does, which is a behaviour change
   rather than a scoping one.

## Gates

`scripts/check.sh` green end to end on this tree: **7015 tests / 0
failures**, Credo `6617 mods/funs, found no issues`, Dialyzer
`Total errors: 0`, Sobelow clean, `deps.audit` `No vulnerabilities
found`, `gen_wire_types --check` + `wire_pin --check` in sync, bats
`1..708` with no `not ok`, doctor passed.

The only edit after that run was 17 further lines of prose in the
DESIGN_NOTES entry (item 4 above); `mix docs` was re-run on the amended
tree — rc 0, and none of the 182 pre-existing ExDoc warnings name any
anchor the new text adds. `design-notes-gate.sh` on the committed diff:
`1 new entry heading(s), separator and marker present`; DESIGN_NOTES
contributes 96 additions and 0 deletions.

No wire-shape change, so no `protocol_version` bump.