### PR TITLE
fix(1869): gate the touch selection policy on pointer, and latch the scrollback row

### DIFF
--- a/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
+++ b/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
@@ -9,6 +9,14 @@
 //     listener by bubbling to `.scrollback`, exactly as a real finger does. A
 //     narrow viewport forces the mobile shell so the #1041 edge directive is
 //     also live, which is what makes the zone-separation test mean something.
+//   * Untagged does NOT mean `pointer: fine`. Measured on this project:
+//     `hasTouch: true` puts Chromium's primary pointer at COARSE, so the whole
+//     file reports `(pointer: coarse)` and `(hover: none)` and every test here
+//     runs INSIDE #1869's `@media (pointer: coarse)` gate — `.scrollback` is
+//     `user-select: none` standing. Worth spelling out because the bullet above
+//     reads as a desktop harness and the gate is invisible from the source; a
+//     review of #1869 read it that way and concluded the Select… test below
+//     could not see the gate. The Select… test asserts the premise itself now.
 //   * The FEEL is a DEVICE call: synthetic events drive no pixel scroll,
 //     chromium is not iOS Safari, and neither reproduces iOS selection UI. Does
 //     the slide read like Telegram's, do the grab handles actually appear once
@@ -345,11 +353,38 @@ test("issue1067 — Select… hands back a live selection over the row and arms 
   await postMessage(page, body);
   await page.evaluate(() => window.getSelection()?.removeAllRanges());
 
+  // THE premise, and the reason this is the one test that drives the shipped
+  // `Select…` rather than a hand-built range. #1869 made `.scrollback`
+  // `user-select: none` STANDING on a coarse pointer, and Blink omits
+  // `user-select: none` subtrees from a selection's TEXT — so the assertion
+  // below is answerable only if the production path lifted the latch itself.
+  // Asserted rather than assumed because the pointer here comes from this
+  // file's `hasTouch: true` and nothing in a test title says so: were the file
+  // ever to slip back to `pointer: fine`, the row would be selectable standing
+  // and the assertion would go vacuous in silence instead of red.
+  //
+  // Measured, so the teeth are not an argument: renaming the latch class in
+  // `lib/messageMenu` reds this test with an EMPTY selection, while the two
+  // #1869 cascade tests — which build their range by hand — stay green.
+  const standing = await page.evaluate(() => {
+    const sb = document.querySelector(".scrollback");
+    return {
+      coarse: matchMedia("(pointer: coarse)").matches,
+      userSelect: sb === null ? null : getComputedStyle(sb).userSelect,
+    };
+  });
+  expect(standing.coarse).toBe(true);
+  expect(standing.userSelect).toBe("none");
+
   await longPressRow(page, body, { x: 200, y: 400 }, HOLD_MS);
   await menuItem(page, "Select…").click();
 
   const selected = await page.evaluate(() => window.getSelection()?.toString() ?? "");
   expect(selected).toContain(body);
+  // #250's guarantee, delivered by the new route: the author rides inside the
+  // selection because Select… takes the whole row and the latch re-enables the
+  // token under it, not because the token carries a standing re-enable.
+  expect(selected).toContain(specNick());
   // `is-selecting` is what lets `html.is-ios .scrollback` get its
   // `-webkit-touch-callout` back for the life of this selection — without it
   // the range has no draggable endpoints on iOS. The CLASS is asserted here;

--- a/cicchetto/e2e/tests/issue1869-android-longpress-selection.spec.ts
+++ b/cicchetto/e2e/tests/issue1869-android-longpress-selection.spec.ts
@@ -33,20 +33,23 @@ import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
-// Date.now() suffix (house pattern): the e2e sqlite scrollback persists across
-// re-runs against a KEEP_STACK=1 stack, and a static body would match two rows
-// on the second run and trip Playwright strict mode.
-const MESSAGE_BODY = `1869 long-press target ${Date.now()}`;
-
 const SELECTING_CLASS = "is-selecting";
 
-async function seedRow(page: Page) {
+// Date.now() suffix (house pattern) AND a per-test tag: the e2e sqlite
+// scrollback persists across KEEP_STACK=1 re-runs *and* across the tests in
+// this file, which share one stack. A single module-level body would be sent
+// twice — once per test — and the locator would then match two rows and die of
+// Playwright strict mode. The tag is what keeps the two tests disjoint.
+const bodyFor = (tag: string) => `1869 ${tag} target ${Date.now()}`;
+
+async function seedRow(page: Page, tag: string) {
+  const body = bodyFor(tag);
   await loginAs(page, specUser());
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
-  await composeSend(page, MESSAGE_BODY);
-  const row = scrollbackLine(page, "privmsg", MESSAGE_BODY);
+  await composeSend(page, body);
+  const row = scrollbackLine(page, "privmsg", body);
   await expect(row).toBeVisible({ timeout: 5_000 });
-  return row;
+  return { row, body };
 }
 
 function readCascade(page: Page) {
@@ -67,7 +70,7 @@ function readCascade(page: Page) {
 test("@touch #1869 — the row is unselectable standing and selectable under the latch", async ({
   page,
 }) => {
-  await seedRow(page);
+  await seedRow(page, "cascade");
 
   const standing = await readCascade(page);
   expect(standing).not.toBeNull();
@@ -104,7 +107,7 @@ test("@touch #1869 — the row is unselectable standing and selectable under the
 test("@touch #1869 — a range over the row serialises the whole row only when latched", async ({
   page,
 }) => {
-  const row = await seedRow(page);
+  const { row, body } = await seedRow(page, "serialise");
 
   const select = () =>
     row.evaluate((el) => {
@@ -118,12 +121,12 @@ test("@touch #1869 — a range over the row serialises the whole row only when l
     });
 
   const unlatched = await select();
-  expect(unlatched).not.toContain(MESSAGE_BODY);
+  expect(unlatched).not.toContain(body);
 
   await page.evaluate((cls) => document.documentElement.classList.add(cls), SELECTING_CLASS);
 
   const latched = await select();
-  expect(latched).toContain(MESSAGE_BODY);
+  expect(latched).toContain(body);
   // #250's guarantee, delivered by the new route: the author rides inside the
   // selection because Select… takes the whole row, not because the token
   // carries a standing re-enable.

--- a/cicchetto/e2e/tests/issue1869-android-longpress-selection.spec.ts
+++ b/cicchetto/e2e/tests/issue1869-android-longpress-selection.spec.ts
@@ -1,0 +1,131 @@
+// #1869 — one long-press on a message row opened TWO menus on Android:
+// Chrome's native selection toolbar over a native selection of the row, plus
+// cic's own message menu.
+//
+// The selection/callout policy was gated on `html.is-ios`, which
+// `lib/platform.ts` applies only when `isIos()`, so Android received none of
+// it. But re-parenting the block is NOT the fix, and this spec exists because
+// that distinction is invisible in the source: `-webkit-touch-callout` is
+// WebKit-only. On iOS the policy is a PAIR — `callout: none` suppresses the
+// platform's long-press UI, `user-select: text` keeps the row selectable for
+// `Select…`. Blink has only the second half, and there `user-select: text` IS
+// the native long-press selection.
+//
+// So on a coarse pointer the row is `none` STANDING and `text` under #1067's
+// `is-selecting` latch. This runs on `chromium-pixel-touch` because that is the
+// project whose engine (Blink) and pointer (coarse) both match the reported
+// device — `webkit-iphone-15` cannot see this class of defect at all, since the
+// property that masks it there does not exist here.
+//
+// ⚠️ WIRING + SERIALISATION ONLY — NOT PROOF THE TOOLBAR IS GONE. ⚠️
+// Playwright renders no platform selection UI, so nothing here can assert that
+// Chrome's toolbar does not appear; that half was verified by hand on an
+// Android 17 emulator (Chrome 151) with an OS-level `adb input swipe`, and the
+// screenshots are on the PR. What IS deterministic in CI is the cascade the
+// engine is asked to apply, and the selection TEXT that cascade produces —
+// which is the half that would silently rot. See docs/DESIGN_NOTES.md
+// 2026-08-30 (#1869) and the sibling limitation notes in
+// issue250-android-nick-select.spec.ts.
+
+import type { Page } from "@playwright/test";
+import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+// Date.now() suffix (house pattern): the e2e sqlite scrollback persists across
+// re-runs against a KEEP_STACK=1 stack, and a static body would match two rows
+// on the second run and trip Playwright strict mode.
+const MESSAGE_BODY = `1869 long-press target ${Date.now()}`;
+
+const SELECTING_CLASS = "is-selecting";
+
+async function seedRow(page: Page) {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await composeSend(page, MESSAGE_BODY);
+  const row = scrollbackLine(page, "privmsg", MESSAGE_BODY);
+  await expect(row).toBeVisible({ timeout: 5_000 });
+  return row;
+}
+
+function readCascade(page: Page) {
+  return page.evaluate(() => {
+    const scrollback = document.querySelector(".scrollback");
+    const nick = document.querySelector(".scrollback .nick-clickable");
+    if (!scrollback || !nick) return null;
+    return {
+      coarse: matchMedia("(pointer: coarse)").matches,
+      isIos: document.documentElement.classList.contains("is-ios"),
+      html: getComputedStyle(document.documentElement).userSelect,
+      scrollback: getComputedStyle(scrollback).userSelect,
+      nick: getComputedStyle(nick).userSelect,
+    };
+  });
+}
+
+test("@touch #1869 — the row is unselectable standing and selectable under the latch", async ({
+  page,
+}) => {
+  await seedRow(page);
+
+  const standing = await readCascade(page);
+  expect(standing).not.toBeNull();
+
+  // The premise. If this project ever stopped reporting a coarse pointer the
+  // assertions below would pass vacuously against the pre-fix sheet, so it is
+  // asserted rather than assumed — and `isIos` false is what makes this a test
+  // of the POINTER gate and not of the platform class.
+  expect(standing?.coarse).toBe(true);
+  expect(standing?.isIos).toBe(false);
+
+  expect(standing?.html).toBe("none");
+  // THE defect, stated as a value: `text` here is the native long-press
+  // selection on Blink, i.e. the second menu.
+  expect(standing?.scrollback).toBe("none");
+  // The #250 token matches its element DIRECTLY and so beats the inherited
+  // `none` — left to inherit, the bug survived on a press that landed on a nick.
+  expect(standing?.nick).toBe("none");
+
+  await page.evaluate((cls) => document.documentElement.classList.add(cls), SELECTING_CLASS);
+
+  const latched = await readCascade(page);
+  // Both lift together, or `Select…` yields a row without its author.
+  expect(latched?.scrollback).toBe("text");
+  expect(latched?.nick).toBe("text");
+});
+
+// The latch is load-bearing rather than belt-and-braces, and this is the half a
+// cascade assertion cannot show: Blink omits `user-select: none` subtrees from
+// a selection's TEXT. Without the lift, `Select…` installs a range over the row
+// and gets a fragment back — measured by hand as `"<peluche>"` against the full
+// `"14:24:42 <@vjt> ok quindi…"`. Asserting the serialisation pins the reason
+// the latch has to carry `user-select` and not just the callout.
+test("@touch #1869 — a range over the row serialises the whole row only when latched", async ({
+  page,
+}) => {
+  const row = await seedRow(page);
+
+  const select = () =>
+    row.evaluate((el) => {
+      const sel = window.getSelection();
+      if (!sel) return "";
+      sel.removeAllRanges();
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      sel.addRange(range);
+      return sel.toString();
+    });
+
+  const unlatched = await select();
+  expect(unlatched).not.toContain(MESSAGE_BODY);
+
+  await page.evaluate((cls) => document.documentElement.classList.add(cls), SELECTING_CLASS);
+
+  const latched = await select();
+  expect(latched).toContain(MESSAGE_BODY);
+  // #250's guarantee, delivered by the new route: the author rides inside the
+  // selection because Select… takes the whole row, not because the token
+  // carries a standing re-enable.
+  expect(latched).toContain(specNick());
+});

--- a/cicchetto/e2e/tests/issue250-android-nick-select.spec.ts
+++ b/cicchetto/e2e/tests/issue250-android-nick-select.spec.ts
@@ -31,8 +31,17 @@
 // NON-`is-ios` path, so asserting `.nick-clickable` computes to
 // `user-select: text` THERE directly proves the rule is UNCONDITIONAL
 // (not gated behind `html.is-ios`). On unfixed code the button inherits
-// the default `auto` and the assertion fails. The `@webkit` twin is a
-// regression guard that iOS keeps the nick selectable after the change.
+// the default `auto` and the assertion fails.
+//
+// #1869 SUPERSEDED the TOUCH half of the above, and the header is left standing
+// because the reasoning is still how we got here. What changed: giving the
+// scrollback a standing `user-select: text` on touch is what let Chrome raise
+// its own long-press selection over cic's message menu, because Blink does not
+// implement the `-webkit-touch-callout: none` that suppresses it on WebKit. So
+// on a coarse pointer the row — and this token with it — is `none` standing and
+// `text` under `is-selecting`, and #250's "nick inside the selection" is
+// delivered by `Select…` taking the whole row instead. The chromium test below
+// is UNCHANGED and still owns the desktop case, which never enters that gate.
 
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
@@ -81,16 +90,35 @@ test("#250 desktop — .nick-clickable is user-select:text unconditionally (not 
   expect(styles.webkitUserSelect).toBe("text");
 });
 
-test("@webkit #250 iOS — .nick-clickable stays user-select:text (regression guard)", async ({
+// #1869 SUPERSEDED the touch half of #250, deliberately, and this guard moved
+// with it. #250 gave the token its own `user-select: text` so it would ride
+// inside a native drag-selection — written when Android had no `.scrollback`
+// re-enable at all. #1869 ends that state: there is no native drag-selection on
+// the scrollback any more, on any coarse pointer, because that selection WAS
+// the second menu. The token therefore follows the row — `none` standing,
+// `text` under the `is-selecting` latch — and #250's guarantee arrives instead
+// through `Select…`, which takes the whole row (`selectNodeContents`) with the
+// token inside it.
+//
+// The token is named explicitly in the CSS rather than left to inherit: it
+// matches its element DIRECTLY and so beats the inherited `none`. Without that
+// the bug survived in a narrower place — a long-press landing on a nick.
+// This asserting `text` under the latch is what proves the token was not simply
+// killed. The desktop sibling above is untouched: `pointer: fine` never enters
+// the gate, so #250's mouse-drag case still holds unconditionally.
+test("@webkit #250/#1869 iOS — .nick-clickable follows the row, unselectable until latched", async ({
   page,
 }) => {
   const styles = await nickSelectionStyles(page);
 
-  // iPhone 15 UA → is-ios: the nick was already selectable via the
-  // `.scrollback` cascade; guard that the unconditional rule keeps it so.
   // WebKit reflects only the PREFIXED `webkitUserSelect` in computed
   // style (the unprefixed `userSelect` reads `undefined` there) — same
   // property the sibling text-selection-restored.spec asserts on iOS.
   expect(styles.htmlIsIos).toBe(true);
-  expect(styles.webkitUserSelect).toBe("text");
+  expect(styles.webkitUserSelect).toBe("none");
+
+  await page.evaluate(() => document.documentElement.classList.add("is-selecting"));
+
+  const latched = await nickSelectionStyles(page);
+  expect(latched.webkitUserSelect).toBe("text");
 });

--- a/cicchetto/e2e/tests/issue250-android-nick-select.spec.ts
+++ b/cicchetto/e2e/tests/issue250-android-nick-select.spec.ts
@@ -53,10 +53,14 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // trips Playwright strict mode.
 const MESSAGE_BODY = `android-nick-select target ${Date.now()}`;
 
-// Read the computed selection policy off the freshly-rendered sender
-// button of a message we just sent (specNick() is vjt's own nick), so
-// the `.nick-clickable` under test is guaranteed present and attributed.
-async function nickSelectionStyles(page: import("@playwright/test").Page) {
+// Send one message and hand back its sender button (specNick() is vjt's own
+// nick), so the `.nick-clickable` under test is present and attributed.
+//
+// SEEDING IS SEPARATE FROM READING because #1869's twin reads the same row
+// TWICE — standing, then under the latch. Sending `MESSAGE_BODY` a second time
+// puts two identical rows in the scrollback and the locator dies of strict
+// mode, which is exactly what it did before this split.
+async function seedNick(page: import("@playwright/test").Page) {
   const vjt = specUser();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
@@ -67,7 +71,10 @@ async function nickSelectionStyles(page: import("@playwright/test").Page) {
 
   const nick = row.locator(".scrollback-sender.nick-clickable");
   await expect(nick).toContainText(specNick());
+  return nick;
+}
 
+function nickStyles(nick: import("@playwright/test").Locator) {
   return nick.evaluate((el) => {
     const cs = getComputedStyle(el);
     return {
@@ -81,7 +88,7 @@ async function nickSelectionStyles(page: import("@playwright/test").Page) {
 test("#250 desktop — .nick-clickable is user-select:text unconditionally (not is-ios-gated)", async ({
   page,
 }) => {
-  const styles = await nickSelectionStyles(page);
+  const styles = await nickStyles(await seedNick(page));
 
   // chromium project → NON-is-ios path: proving `text` here proves the
   // rule is unconditional. Fails (inherited `auto`) on unfixed code.
@@ -109,7 +116,8 @@ test("#250 desktop — .nick-clickable is user-select:text unconditionally (not 
 test("@webkit #250/#1869 iOS — .nick-clickable follows the row, unselectable until latched", async ({
   page,
 }) => {
-  const styles = await nickSelectionStyles(page);
+  const nick = await seedNick(page);
+  const styles = await nickStyles(nick);
 
   // WebKit reflects only the PREFIXED `webkitUserSelect` in computed
   // style (the unprefixed `userSelect` reads `undefined` there) — same
@@ -119,6 +127,7 @@ test("@webkit #250/#1869 iOS — .nick-clickable follows the row, unselectable u
 
   await page.evaluate(() => document.documentElement.classList.add("is-selecting"));
 
-  const latched = await nickSelectionStyles(page);
+  // Same locator, re-read: seeding again would send a second identical row.
+  const latched = await nickStyles(nick);
   expect(latched.webkitUserSelect).toBe("text");
 });

--- a/cicchetto/e2e/tests/text-selection-restored.spec.ts
+++ b/cicchetto/e2e/tests/text-selection-restored.spec.ts
@@ -55,27 +55,47 @@ test("desktop — scrollback text is selectable while compose has focus", async 
   expect(selected).toContain("drag across me");
 });
 
-test("@webkit iOS — .scrollback re-enables user-select under the is-ios global kill", async ({
+// #1869 rewrote what this asserts, and the reason is worth stating: the
+// scrollback is no longer selectable STANDING, it is selectable while the app
+// says so. `-webkit-touch-callout` is WebKit-only, so on Blink the standing
+// `user-select: text` this used to assert IS the platform's long-press
+// selection — two menus for one gesture on Android. The row now defaults to
+// `none` on any coarse pointer and #1067's `is-selecting` latch lifts it for
+// the duration of one `Select…`.
+//
+// So the guard became two-state, which is strictly MORE than it checked
+// before: standing `none`, latched `text`. Asserting only the first half would
+// pass against a sheet that made the row permanently unselectable and broke
+// Select… outright.
+test("@webkit iOS — .scrollback is unselectable standing and selectable under the latch", async ({
   page,
 }) => {
   const vjt = specUser();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
 
-  const styles = await page.evaluate(() => {
-    const scrollback = document.querySelector(".scrollback");
-    if (!scrollback) return null;
-    return {
-      htmlIsIos: document.documentElement.classList.contains("is-ios"),
-      htmlUserSelect: getComputedStyle(document.documentElement).webkitUserSelect,
-      scrollbackUserSelect: getComputedStyle(scrollback).webkitUserSelect,
-    };
-  });
+  const read = () =>
+    page.evaluate(() => {
+      const scrollback = document.querySelector(".scrollback");
+      if (!scrollback) return null;
+      return {
+        htmlIsIos: document.documentElement.classList.contains("is-ios"),
+        htmlUserSelect: getComputedStyle(document.documentElement).webkitUserSelect,
+        scrollbackUserSelect: getComputedStyle(scrollback).webkitUserSelect,
+      };
+    });
 
-  expect(styles).not.toBeNull();
-  // iPhone 15 UA → applyIosClass marks the root; both halves of the
-  // Telegram pattern must hold: chrome unselectable, messages selectable.
-  expect(styles?.htmlIsIos).toBe(true);
-  expect(styles?.htmlUserSelect).toBe("none");
-  expect(styles?.scrollbackUserSelect).toBe("text");
+  const standing = await read();
+  expect(standing).not.toBeNull();
+  // iPhone 15 UA → applyIosClass marks the root. The blanket kill is unchanged;
+  // what moved is where it is gated (`@media (pointer: coarse)`, #1869).
+  expect(standing?.htmlIsIos).toBe(true);
+  expect(standing?.htmlUserSelect).toBe("none");
+  expect(standing?.scrollbackUserSelect).toBe("none");
+
+  // The latch, applied the way `lib/messageMenu`'s Select… applies it.
+  await page.evaluate(() => document.documentElement.classList.add("is-selecting"));
+
+  const latched = await read();
+  expect(latched?.scrollbackUserSelect).toBe("text");
 });

--- a/cicchetto/src/__tests__/MessageContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/MessageContextMenu.test.tsx
@@ -18,8 +18,8 @@ import MessageContextMenu from "../MessageContextMenu";
 // (the spec queues a task), so the event the install itself provokes is
 // delivered AFTER that teardown, straight into the freshly-registered listener.
 // If the teardown emptied the selection, the class would be gone within a
-// macrotask and `html.is-ios.is-selecting .scrollback { -webkit-touch-callout:
-// default }` would never apply — the re-enable #1067 added is what gives the
+// macrotask and `html.is-selecting .scrollback { -webkit-touch-callout:
+// default }` (inside `@media (pointer: coarse)` since #1869) would never apply — the re-enable #1067 added is what gives the
 // selection its draggable endpoints.
 //
 // The test asserts the window stays OPEN across that teardown. It deliberately

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -164,19 +164,26 @@ export function nestedRuleBodies(selector: string): string[] {
 }
 
 /**
- * The body of every `@media (hover: hover)` block, brace-MATCHED rather than
- * regex-captured: such a block contains whole rules, and the `[^{}]` classes
- * the helpers above rely on cannot span a nested brace. Comments stripped,
- * same as the rest of this module, so prose naming a selector can neither
- * satisfy nor trip an assertion about it.
+ * The body of every `@media` block whose prelude `opener` matches,
+ * brace-MATCHED rather than regex-captured: such a block contains whole rules,
+ * and the `[^{}]` classes the helpers above rely on cannot span a nested brace.
+ * Comments stripped, same as the rest of this module, so prose naming a
+ * selector can neither satisfy nor trip an assertion about it.
+ *
+ * `opener` must carry the `g` flag — the scan advances `lastIndex` past each
+ * matched block to find the next one.
  *
  * Throws when the sheet carries no such gate at all, for the same reason
  * `ruleBody` throws on an absent rule: a test asking "is this rule gated?"
- * must not pass because the GATE vanished.
+ * must not pass because the GATE vanished. `label` is what that error names.
+ *
+ * Generalised out of `hoverGatedBlocks` when #1869 needed the identical scan
+ * for `(pointer: coarse)` (CLAUDE.md "implement once, reuse everywhere") — a
+ * second copy of the depth counter is a second place to get an unbalanced
+ * sheet wrong.
  */
-export function hoverGatedBlocks(): string[] {
+export function mediaGatedBlocks(opener: RegExp, label: string): string[] {
   const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
-  const opener = /@media\s*\(\s*hover\s*:\s*hover\s*\)\s*\{/g;
   const out: string[] = [];
   let match = opener.exec(stripped);
   while (match !== null) {
@@ -189,13 +196,29 @@ export function hoverGatedBlocks(): string[] {
       else if (ch === "}") depth -= 1;
       i += 1;
     }
-    if (depth !== 0) throw new Error("unbalanced @media (hover: hover) block in default.css");
+    if (depth !== 0) throw new Error(`unbalanced ${label} block in default.css`);
     out.push(stripped.slice(start, i - 1));
     opener.lastIndex = i;
     match = opener.exec(stripped);
   }
-  if (out.length === 0) throw new Error("no @media (hover: hover) gate found in default.css");
+  if (out.length === 0) throw new Error(`no ${label} gate found in default.css`);
   return out;
+}
+
+/** The body of every `@media (hover: hover)` block. See `mediaGatedBlocks`. */
+export function hoverGatedBlocks(): string[] {
+  return mediaGatedBlocks(/@media\s*\(\s*hover\s*:\s*hover\s*\)\s*\{/g, "@media (hover: hover)");
+}
+
+/**
+ * The body of every `@media (pointer: coarse)` block — where #1869 put the
+ * touch selection/callout policy. See `mediaGatedBlocks`.
+ */
+export function coarsePointerBlocks(): string[] {
+  return mediaGatedBlocks(
+    /@media\s*\(\s*pointer\s*:\s*coarse\s*\)\s*\{/g,
+    "@media (pointer: coarse)",
+  );
 }
 
 export function ruleBody(selector: string): string {

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -171,7 +171,10 @@ export function nestedRuleBodies(selector: string): string[] {
  * selector can neither satisfy nor trip an assertion about it.
  *
  * `opener` must carry the `g` flag — the scan advances `lastIndex` past each
- * matched block to find the next one.
+ * matched block to find the next one. ENFORCED rather than documented: without
+ * `g`, `exec` ignores `lastIndex` and restarts at 0, so `match` is never null
+ * and the loop below never ends. A shared test helper must not answer a
+ * misuse with a hang — a thrown error names the caller, a hang names nothing.
  *
  * Throws when the sheet carries no such gate at all, for the same reason
  * `ruleBody` throws on an absent rule: a test asking "is this rule gated?"
@@ -183,6 +186,11 @@ export function nestedRuleBodies(selector: string): string[] {
  * sheet wrong.
  */
 export function mediaGatedBlocks(opener: RegExp, label: string): string[] {
+  if (!opener.global) {
+    throw new Error(
+      `mediaGatedBlocks(${label}): opener must carry the g flag or the scan never terminates`,
+    );
+  }
   const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
   const out: string[] = [];
   let match = opener.exec(stripped);

--- a/cicchetto/src/__tests__/messageGestures.test.ts
+++ b/cicchetto/src/__tests__/messageGestures.test.ts
@@ -284,8 +284,8 @@ describe("bindMessageGestures — long press = message menu", () => {
   });
 });
 
-// issue 1857 — `Select…` lifts `html.is-ios`'s blanket `-webkit-touch-callout:
-// none` over the whole `.scrollback` and takes it back on the first
+// issue 1857 — `Select…` lifts the touch blanket `-webkit-touch-callout:
+// none` (`@media (pointer: coarse)` since #1869) over the whole `.scrollback` and takes it back on the first
 // `selectionchange` that finds the selection gone. That event is QUEUED as a
 // task, so on the touch that ends the selection it lands AFTER touch-down —
 // and touch-down is when WebKit reads the property to decide whether to run

--- a/cicchetto/src/__tests__/messageMenu.test.ts
+++ b/cicchetto/src/__tests__/messageMenu.test.ts
@@ -134,6 +134,33 @@ describe("selectMessageText", () => {
     expect(ranges[0]?.commonAncestorContainer).toBe(row);
   });
 
+  // The ORDER, pinned. Since #1869 the `is-selecting` latch is also what gives
+  // `.scrollback` its `user-select: text` on a coarse pointer, so the latch has
+  // to be up before the range goes in or the range is installed while the row
+  // still computes `none`. This observes the latch AT the moment `addRange`
+  // runs — the only instant that distinguishes the two orderings.
+  //
+  // What it does NOT observe: any consequence. jsdom applies no stylesheet, so
+  // nothing here can tell whether an engine minds. Red against the previous
+  // ordering (latch after the range), green against this one — that is its
+  // whole claim.
+  it("raises the latch before the range goes in, not after", () => {
+    let latchedAtInstall: boolean | null = null;
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      removeAllRanges: vi.fn(),
+      addRange: vi.fn(() => {
+        latchedAtInstall = document.documentElement.classList.contains(SELECTING_CLASS);
+      }),
+      toString: () => "12:34 <vjt> ciao",
+      isCollapsed: false,
+    } as unknown as Selection);
+
+    expect(selectMessageText(scrollbackRow("12:34 <vjt> ciao"))).toBe(true);
+    // The probe has to have run at all, or `false` below would be furniture.
+    expect(latchedAtInstall).not.toBeNull();
+    expect(latchedAtInstall).toBe(true);
+  });
+
   // THE point of the item. The touch blanket kills `-webkit-touch-callout`, and a
   // range installed under a suppressed callout has no draggable endpoints —
   // the second reported symptom. Select… lifts the kill, scoped in TIME.

--- a/cicchetto/src/__tests__/messageMenu.test.ts
+++ b/cicchetto/src/__tests__/messageMenu.test.ts
@@ -134,7 +134,7 @@ describe("selectMessageText", () => {
     expect(ranges[0]?.commonAncestorContainer).toBe(row);
   });
 
-  // THE point of the item. `html.is-ios` kills `-webkit-touch-callout`, and a
+  // THE point of the item. The touch blanket kills `-webkit-touch-callout`, and a
   // range installed under a suppressed callout has no draggable endpoints —
   // the second reported symptom. Select… lifts the kill, scoped in TIME.
   it("arms the callout re-enable while a selection is live", () => {

--- a/cicchetto/src/__tests__/messageMenu.test.ts
+++ b/cicchetto/src/__tests__/messageMenu.test.ts
@@ -143,7 +143,10 @@ describe("selectMessageText", () => {
   // What it does NOT observe: any consequence. jsdom applies no stylesheet, so
   // nothing here can tell whether an engine minds. Red against the previous
   // ordering (latch after the range), green against this one — that is its
-  // whole claim.
+  // whole claim. On Blink the answer is now known, and it is "no": see the note
+  // in `lib/messageMenu`, measured by rerunning the e2e Select… test on a
+  // coarse pointer with the orderings swapped. So this pins an ORDERING, not a
+  // repair — do not let it grow an assertion that implies otherwise.
   it("raises the latch before the range goes in, not after", () => {
     let latchedAtInstall: boolean | null = null;
     vi.spyOn(window, "getSelection").mockReturnValue({

--- a/cicchetto/src/__tests__/touchSelectionPolicy.test.ts
+++ b/cicchetto/src/__tests__/touchSelectionPolicy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { coarsePointerBlocks, themeCss } from "./helpers/themeCss";
+import {
+  coarsePointerBlocks,
+  hoverGatedBlocks,
+  mediaGatedBlocks,
+  themeCss,
+} from "./helpers/themeCss";
 
 // #1869 — the selection/callout policy is TOUCH behaviour, not iOS behaviour.
 //
@@ -155,5 +160,34 @@ describe("#1869 — the touch selection policy is gated on pointer, not on iOS",
   it("leaves #250's desktop declarations intact outside the gate", () => {
     expect(stripped).toMatch(/^\.nick-clickable\s*\{[^}]*user-select:\s*text/m);
     expect(stripped).toMatch(/^\.channel-clickable\s*\{[^}]*user-select:\s*text/m);
+  });
+});
+
+// The scan #1869 generalised out of `hoverGatedBlocks`, tested where it was
+// generalised. Its ONE precondition used to be documentation only.
+describe("mediaGatedBlocks — the shared media-gate scan", () => {
+  // Without `g`, `exec` ignores the `lastIndex` the loop advances and restarts
+  // at 0 forever: the helper HANGS instead of failing, and a hung vitest names
+  // no caller. A throw is the difference between a diagnosable misuse and a
+  // timeout somebody bisects by hand.
+  it("refuses an opener without the g flag instead of scanning forever", () => {
+    expect(() => mediaGatedBlocks(/@media\s*\(\s*pointer\s*:\s*coarse\s*\)\s*\{/, "no-g")).toThrow(
+      /g flag/,
+    );
+  });
+
+  // The positive control for the guard: the same pattern WITH `g` must still
+  // return the gate, or the throw above would be indistinguishable from a
+  // helper that rejects everything.
+  it("accepts the same opener once it carries g", () => {
+    expect(
+      mediaGatedBlocks(/@media\s*\(\s*pointer\s*:\s*coarse\s*\)\s*\{/g, "coarse"),
+    ).toHaveLength(coarsePointerBlocks().length);
+  });
+
+  // And the pre-existing caller is unchanged by the generalisation — the
+  // wrapper still finds the hover gate it found before #1869 touched this.
+  it("leaves hoverGatedBlocks finding its own gate", () => {
+    expect(hoverGatedBlocks().length).toBeGreaterThan(0);
   });
 });

--- a/cicchetto/src/__tests__/touchSelectionPolicy.test.ts
+++ b/cicchetto/src/__tests__/touchSelectionPolicy.test.ts
@@ -11,13 +11,20 @@ import { coarsePointerBlocks, themeCss } from "./helpers/themeCss";
 // 151: `window.getSelection()` came back non-collapsed with the pressed word
 // while cic's menu reported open in the same frame.
 //
-// WHY A SOURCE-LEVEL TEST AND NOT A BEHAVIOURAL ONE — the same limit
-// `hoverGate.test.ts` documents, and the one #1869 itself declares. jsdom
-// applies no stylesheet, and no Playwright project here renders a platform's
-// native selection UI: `page.emulateMedia()` has no `pointer` key, so nothing
-// in CI can put this query into either branch on purpose. What IS
-// deterministic is what the cascade is ASKED to do. These read that; a real
-// device is the only witness for what an engine paints.
+// WHY A SOURCE-LEVEL TEST TOO, next to the e2e ones. jsdom applies no
+// stylesheet, so nothing here can read a computed value. What this file reads
+// is the SHAPE of the sheet — which rules exist and where they are gated —
+// which is what rots when someone adds a re-enable and forgets the gate.
+//
+// The COMPUTED side is covered in e2e and needs no `emulateMedia`: both
+// `webkit-iphone-15` and `chromium-pixel-touch` report `pointer: coarse`
+// natively, so `issue1869-android-longpress-selection.spec.ts` (Blink) and the
+// `@webkit` twins in `text-selection-restored` / `issue250-android-nick-select`
+// assert the real cascade on both engine families.
+//
+// What NO project can do is render a platform's native selection UI, so
+// "does the toolbar actually appear?" stays a device question — the limit
+// #1067 and #1857 declare, and #1869 verified by hand on Android.
 //
 // THE DRIFT THIS GUARDS. The kill and its re-enables are one atomic set: #79
 // (scrollback + topic text), #1067 (the `is-selecting` callout latch), #508

--- a/cicchetto/src/__tests__/touchSelectionPolicy.test.ts
+++ b/cicchetto/src/__tests__/touchSelectionPolicy.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { coarsePointerBlocks, themeCss } from "./helpers/themeCss";
+
+// #1869 — the selection/callout policy is TOUCH behaviour, not iOS behaviour.
+//
+// It used to sit under `html.is-ios`, a class `lib/platform.ts` adds only when
+// `isIos()`, so Android got NONE of it: nothing suppressed Chrome's own
+// long-press callout, and one press on a message row opened TWO menus — the
+// platform's selection toolbar over a native selection of the row, plus cic's
+// message menu behind it. Device-verified on an Android 17 emulator, Chrome
+// 151: `window.getSelection()` came back non-collapsed with the pressed word
+// while cic's menu reported open in the same frame.
+//
+// WHY A SOURCE-LEVEL TEST AND NOT A BEHAVIOURAL ONE — the same limit
+// `hoverGate.test.ts` documents, and the one #1869 itself declares. jsdom
+// applies no stylesheet, and no Playwright project here renders a platform's
+// native selection UI: `page.emulateMedia()` has no `pointer` key, so nothing
+// in CI can put this query into either branch on purpose. What IS
+// deterministic is what the cascade is ASKED to do. These read that; a real
+// device is the only witness for what an engine paints.
+//
+// THE DRIFT THIS GUARDS. The kill and its re-enables are one atomic set: #79
+// (scrollback + topic text), #1067 (the `is-selecting` callout latch), #508
+// (<select> pickers), #589 (admin panes), plus the two re-excludes that carve
+// out of them. Widening the kill while leaving a re-enable behind does not
+// fail loudly — it silently makes that surface uncopyable on every touch
+// device. So the assertion is a SET comparison, not a spot-check.
+
+// Every selector the touch policy owns, with the declaration that proves it is
+// the policy rule and not something else that happens to share the selector.
+const POLICY = [
+  { selector: "html", declares: /-webkit-user-select:\s*none/ },
+  { selector: "html .topic-modal-text", declares: /user-select:\s*text/ },
+  { selector: "html input", declares: /user-select:\s*text/ },
+  { selector: "html textarea", declares: /user-select:\s*text/ },
+  // #1869 — the row and BOTH #250 tokens default to unselectable on touch.
+  { selector: "html .scrollback", declares: /user-select:\s*none/ },
+  { selector: "html .scrollback .nick-clickable", declares: /user-select:\s*none/ },
+  { selector: "html .scrollback .channel-clickable", declares: /user-select:\s*none/ },
+  // …and the latch lifts all three, callout AND user-select.
+  { selector: "html.is-selecting .scrollback", declares: /-webkit-touch-callout:\s*default/ },
+  { selector: "html.is-selecting .scrollback", declares: /user-select:\s*text/ },
+  { selector: "html.is-selecting .scrollback .nick-clickable", declares: /user-select:\s*text/ },
+  {
+    selector: "html.is-selecting .scrollback .channel-clickable",
+    declares: /user-select:\s*text/,
+  },
+  { selector: "html select", declares: /user-select:\s*text/ },
+  { selector: "html .scrollback-invite-join", declares: /user-select:\s*none/ },
+  { selector: "html .admin-tab-panel", declares: /user-select:\s*text/ },
+  { selector: "html .admin-tab-panel button", declares: /user-select:\s*none/ },
+] as const;
+
+const coarse = () => coarsePointerBlocks().join("\n");
+
+// Rules inside the gate, as `{ selectors, body }`. Innermost blocks only, the
+// same shape `allRules` returns — the `[^{}]` classes cannot span a brace.
+function coarseRules(): { selectors: string; body: string }[] {
+  const out: { selectors: string; body: string }[] = [];
+  for (const match of coarse().matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    out.push({ selectors: (match[1] ?? "").trim(), body: match[2] ?? "" });
+  }
+  return out;
+}
+
+// Whether `selector` appears in some rule inside the gate whose body matches
+// `declares`. Selector lists are split, because these rules group: the
+// scrollback / topic / input / textarea re-enable is ONE rule over four
+// selectors and each of them must count.
+function gatedDeclares(selector: string, declares: RegExp): boolean {
+  return coarseRules().some(
+    (rule) =>
+      rule.selectors
+        .split(",")
+        .map((one) => one.trim().replace(/\s+/g, " "))
+        .includes(selector) && declares.test(rule.body),
+  );
+}
+
+const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+
+describe("#1869 — the touch selection policy is gated on pointer, not on iOS", () => {
+  // THE CONTROL, first: every assertion below passes just as well against a
+  // sheet that deleted the policy outright. Deleting the suppression and
+  // re-parenting it are different changes, and only one of them was asked for.
+  it("still declares every rule of the policy", () => {
+    for (const { selector, declares } of POLICY) {
+      expect(
+        gatedDeclares(selector, declares),
+        `${selector} declaring ${declares} inside @media (pointer: coarse)`,
+      ).toBe(true);
+    }
+  });
+
+  // THE DISCRIMINATOR — the whole set moved, not the kill alone. A kill that
+  // widened to Android while a re-enable stayed on `html.is-ios` would leave
+  // that surface uncopyable on Android, which is #79 / #508 / #589 regressing
+  // sideways rather than #1869 being fixed.
+  it("leaves no user-select or touch-callout rule behind on html.is-ios", () => {
+    const stranded = stripped
+      .split(/(?=^html\.is-ios)/m)
+      .filter((chunk) => /^html\.is-ios[^{}]*\{[^{}]*(?:user-select|touch-callout)/.test(chunk))
+      .map((chunk) => chunk.slice(0, chunk.indexOf("{")).trim());
+
+    expect(stranded, "html.is-ios rules still declaring selection policy").toEqual([]);
+  });
+
+  // `html.is-ios` keeps the half that IS iOS-only. Asserted so the split is
+  // read as a split: pushing the layout pin under `pointer: coarse` too would
+  // put `position: fixed` on Android, where the layout viewport already reacts
+  // to the keyboard — the double-shrink UX-6-D spent 8 iterations on.
+  it("keeps the layout-viewport pin on html.is-ios", () => {
+    expect(stripped).toMatch(/^html\.is-ios\s*\{[^}]*position:\s*fixed/m);
+    expect(stripped).toMatch(/^html\.is-ios body\s*\{[^}]*height:\s*calc\(var\(--vh/m);
+  });
+
+  // The gate must not have swallowed the layout pin from the other direction
+  // either — an `is-ios` rule INSIDE `(pointer: coarse)` would be dead on a
+  // desktop browser reporting `pointer: fine`, which iPadOS-with-trackpad does.
+  it("declares no layout pin inside the pointer gate", () => {
+    expect(coarse()).not.toMatch(/position:\s*fixed/);
+  });
+
+  // THE #1869 defect itself, stated as a rule. `-webkit-touch-callout` is
+  // WebKit-only, so on Blink an unlatched `user-select: text` on the row IS the
+  // native long-press selection — the two-menu frame. Any rule that grants the
+  // scrollback selectability on a coarse pointer must be latched behind
+  // `is-selecting`; an unlatched one puts the bug straight back.
+  it("grants the scrollback no unlatched selectability on a coarse pointer", () => {
+    const unlatched = coarseRules().filter(
+      (rule) =>
+        /user-select:\s*text/.test(rule.body) &&
+        rule.selectors.split(",").some((one) => {
+          const sel = one.trim().replace(/\s+/g, " ");
+          return sel.includes(".scrollback") && !sel.includes(".is-selecting");
+        }),
+    );
+
+    expect(
+      unlatched.map((r) => r.selectors),
+      "scrollback rules granting user-select: text outside the is-selecting latch",
+    ).toEqual([]);
+  });
+
+  // Desktop keeps #250's mouse-drag guarantee: the tokens' own top-level
+  // `user-select: text` must survive, since `pointer: fine` never enters the
+  // gate and that declaration is the only thing carrying the nick into a drag.
+  it("leaves #250's desktop declarations intact outside the gate", () => {
+    expect(stripped).toMatch(/^\.nick-clickable\s*\{[^}]*user-select:\s*text/m);
+    expect(stripped).toMatch(/^\.channel-clickable\s*\{[^}]*user-select:\s*text/m);
+  });
+});

--- a/cicchetto/src/lib/keepKeyboard.ts
+++ b/cicchetto/src/lib/keepKeyboard.ts
@@ -62,8 +62,9 @@ import { isIos } from "./platform";
 // text-selection-drag start, so on copyable text we only fire it for a
 // long-press (keep the keyboard so the selection survives) and skip it
 // for a tap (let the keyboard dismiss). This list MUST stay in sync with
-// default.css's `html.is-ios .scrollback, .topic-modal-text`
-// `user-select: text` re-enable — a new copyable surface must be added to
+// default.css's `.scrollback, .topic-modal-text` `user-select: text`
+// re-enable, which #1869 moved from `html.is-ios` into
+// `@media (pointer: coarse)` — a new copyable surface must be added to
 // BOTH sites or the two policies drift (same shape as the nick-fold
 // SQL/fragment invariant). See docs/DESIGN_NOTES.md 2026-06-11
 // (Dispatch-1) + 2026-07-03 (#79 v1) + 2026-07-04 (#79 long-press rework).
@@ -74,8 +75,8 @@ const SELECTABLE_TEXT_SURFACES = ".scrollback, .topic-modal-text";
 // on tap AND long-press, never a tap-to-close).
 //
 // This is the KEYBOARD/focus policy, which is INDEPENDENT of the CSS
-// text-selection policy (default.css's `html.is-ios` `user-select`
-// re-exclude) — do NOT assume this list mirrors the CSS one:
+// text-selection policy (default.css's `@media (pointer: coarse)`
+// `user-select` re-exclude) — do NOT assume this list mirrors the CSS one:
 //   * `.scrollback-invite-join` (the [Join] CTA) is a non-copyable
 //     control, so it is in BOTH: keyboard-preserve here AND
 //     `user-select: none` in CSS.

--- a/cicchetto/src/lib/keepKeyboard.ts
+++ b/cicchetto/src/lib/keepKeyboard.ts
@@ -62,12 +62,27 @@ import { isIos } from "./platform";
 // text-selection-drag start, so on copyable text we only fire it for a
 // long-press (keep the keyboard so the selection survives) and skip it
 // for a tap (let the keyboard dismiss). This list MUST stay in sync with
-// default.css's `.scrollback, .topic-modal-text` `user-select: text`
-// re-enable, which #1869 moved from `html.is-ios` into
-// `@media (pointer: coarse)` — a new copyable surface must be added to
+// default.css's selectable-text policy — which #1869 made TWO-TIER, and
+// the tier is what decides where a new surface goes:
+//
+//   * STANDING re-enable — `user-select: text` inside
+//     `@media (pointer: coarse)`: `.topic-modal-text`, `input`,
+//     `textarea`. Surfaces with no platform long-press selection worth
+//     suppressing.
+//   * LATCH-scoped — `user-select: none` standing, lifted only while
+//     `html.is-selecting` is up: `.scrollback` and the two #250 tokens
+//     inside it. On Blink a STANDING `text` here IS the platform's own
+//     long-press selection, and `-webkit-touch-callout: none` (WebKit
+//     only) cannot suppress it — that is the two-menu frame #1869
+//     reports.
+//
+// So a new copyable surface goes in the standing re-enable UNLESS a
+// long-press on it can raise the platform's selection UI, in which case
+// it follows `.scrollback` into the latch. Either way it must land in
 // BOTH sites or the two policies drift (same shape as the nick-fold
 // SQL/fragment invariant). See docs/DESIGN_NOTES.md 2026-06-11
-// (Dispatch-1) + 2026-07-03 (#79 v1) + 2026-07-04 (#79 long-press rework).
+// (Dispatch-1) + 2026-07-03 (#79 v1) + 2026-07-04 (#79 long-press rework)
+// + 2026-08-30 (#1869).
 const SELECTABLE_TEXT_SURFACES = ".scrollback, .topic-modal-text";
 // Controls that live INSIDE a selectable surface whose KEYBOARD policy is
 // "always preserve on tap" — the exclude wins in isSelectableSurface, so

--- a/cicchetto/src/lib/messageMenu.ts
+++ b/cicchetto/src/lib/messageMenu.ts
@@ -123,16 +123,29 @@ export function selectMessageText(row: HTMLElement): boolean {
   // selection and the keyboard is what is in its way.
   const focused = document.activeElement;
   if (isTextEntry(focused)) focused.blur();
-  const range = document.createRange();
-  range.selectNodeContents(row);
-  selection.removeAllRanges();
-  selection.addRange(range);
   // One latch, one watcher (issue 1857). A second Select… while the first
   // selection is still live used to stack another listener on the document —
   // only the one that FIRED ever detached itself, so a session that selected
   // repeatedly accumulated them.
+  //
+  // The latch goes up BEFORE the range goes in, and the order is deliberate:
+  // since #1869 the latch is what makes `.scrollback` `user-select: text` on a
+  // coarse pointer, so raising it first is the only ordering under which the
+  // row is selectable at the instant the range is installed. Raised after, the
+  // range is installed while the row still computes `user-select: none`.
+  //
+  // NOT MEASURED, and deliberately not claimed: whether any engine actually
+  // drops or truncates a range installed under `none` and later lifted. jsdom
+  // applies no stylesheet and no browser launches on the machine this was
+  // written on, so the ordering is pinned by a test that observes the latch at
+  // install time and nothing here observes a consequence. What this buys is
+  // that the question stops needing an answer.
   disarmMessageSelection();
   document.documentElement.classList.add(SELECTING_CLASS);
+  const range = document.createRange();
+  range.selectNodeContents(row);
+  selection.removeAllRanges();
+  selection.addRange(range);
   // Disarm the moment the operator is done. Without this the callout stays up
   // for the rest of the session and the next hold anywhere in the scrollback
   // pops iOS's own menu over ours. This is the LATE exit — see

--- a/cicchetto/src/lib/messageMenu.ts
+++ b/cicchetto/src/lib/messageMenu.ts
@@ -58,11 +58,13 @@ export async function copyMessageRow(row: HTMLElement): Promise<void> {
   }
 }
 
-// Lifts `html.is-ios`'s blanket `-webkit-touch-callout: none` for the duration
-// of one selection (default.css pairs this class with the re-enable). Scoping
-// it in TIME rather than in space is what keeps the two long-presses from
-// colliding: with the callout permanently back on the scrollback, every hold
-// would race iOS's own selection UI against this menu.
+// Lifts the touch blanket `-webkit-touch-callout: none` for the duration of one
+// selection (default.css pairs this class with the re-enable, inside
+// `@media (pointer: coarse)` since #1869 — it was `html.is-ios` before, which
+// is why Android had no callout suppression to lift). Scoping it in TIME rather
+// than in space is what keeps the two long-presses from colliding: with the
+// callout permanently back on the scrollback, every hold would race the
+// platform's own selection UI against this menu.
 export const SELECTING_CLASS = "is-selecting";
 
 // The detach for the `selectionchange` watcher `selectMessageText` installs.

--- a/cicchetto/src/lib/messageMenu.ts
+++ b/cicchetto/src/lib/messageMenu.ts
@@ -134,12 +134,20 @@ export function selectMessageText(row: HTMLElement): boolean {
   // row is selectable at the instant the range is installed. Raised after, the
   // range is installed while the row still computes `user-select: none`.
   //
-  // NOT MEASURED, and deliberately not claimed: whether any engine actually
-  // drops or truncates a range installed under `none` and later lifted. jsdom
-  // applies no stylesheet and no browser launches on the machine this was
-  // written on, so the ordering is pinned by a test that observes the latch at
-  // install time and nothing here observes a consequence. What this buys is
-  // that the question stops needing an answer.
+  // WHAT BLINK DOES IS NOW MEASURED, and it is not a truncated range. With the
+  // two orderings swapped by hand and the e2e `Select…` test rerun on a coarse
+  // pointer, the selection still serialised WHOLE: `Selection.toString()` walks
+  // the layout tree at CALL time, so it reads the `user-select` the row
+  // computes then — not the one it computed when `addRange` ran. The control
+  // that makes that a measurement rather than a nil result: renaming the class
+  // above reds the very same test with an EMPTY selection.
+  //
+  // So the order stays for the reason it can honestly stay for — it is the one
+  // ordering that needs no per-engine argument — and NOT because it repairs a
+  // demonstrated defect on Blink. WebKit remains unmeasured: no browser
+  // launches on the machine this was written on, and `webkit-iphone-15` cannot
+  // host that spec at all (its `tap()` dispatches no click — see the header of
+  // issue1869-android-longpress-selection.spec.ts).
   disarmMessageSelection();
   document.documentElement.classList.add(SELECTING_CLASS);
   const range = document.createRange();

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -669,112 +669,193 @@ select:dir(rtl) {
 html.is-ios {
   position: fixed;
   inset: 0;
-  -webkit-user-select: none;
-  -webkit-touch-callout: none;
-}
-
-/* Dispatch-1 (2026-06-11) — selective re-enable of text selection.
-   THE selectable-text policy point: the blanket kill above is
-   Telegram Web K's pattern, and Telegram pairs it with re-enables on
-   every surface users copy from. New copyable surface → add its
-   selector HERE and to keepKeyboard.ts's SELECTABLE_TEXT_SURFACES
-   allowlist (#79, 2026-07-03 + 2026-07-04 rework): on these same
-   surfaces keepKeyboard DURATION-GATES its mousedown preventDefault —
-   a short tap is left un-prevented (keyboard dismisses) but a
-   long-press IS prevented (keyboard stays up so the iOS selection
-   survives). This `user-select: text` re-enable is the load-bearing
-   half — without it there is nothing to select. CSS and TS can't share
-   a constant, so the two lists MUST stay in sync — a surface added
-   here but not there stays unselectable while compose is focused.
-   Currently: scrollback message text
-   (channels, queries, server window all render through .scrollback),
-   the topic modal's full-topic text, and editable fields (WebKit
-   honors inherited user-select:none inside inputs in some version
-   ranges). Deliberately NOT selectable: mentions rows (navigation
-   buttons — the target message is selectable in its channel),
-   topic-bar text (clickable, opens the modal), all other chrome.
-   Full arc: docs/DESIGN_NOTES.md 2026-06-11. */
-html.is-ios .scrollback,
-html.is-ios .topic-modal-text,
-html.is-ios input,
-html.is-ios textarea {
-  -webkit-user-select: text;
-  user-select: text;
-}
-
-/* #1067 — the OTHER half of `html.is-ios`'s blanket kill above:
-   `-webkit-touch-callout: none`. That property is inherited, so it lands on
-   the scrollback too, and a range installed under a suppressed callout has no
-   draggable endpoints — the second symptom #1067 diagnoses ("once text is
-   selected the endpoints cannot be moved"). #366 never re-enabled it, which is
-   why its programmatic select-all produced a selection nobody could adjust.
-
-   The re-enable is scoped in TIME, not in space: `lib/messageMenu`'s Select…
-   puts `is-selecting` on <html> while a selection is live and removes it on the
-   first `selectionchange` that finds the selection gone. Scoping it to
-   `.scrollback` permanently would put iOS's own long-press callout back on
-   every message row, where it would race the long-press menu that replaced the
-   select-all — two menus for one gesture.
-
-   NOT device-verified: the callout ⇄ grab-handle link is read from the platform
-   contract and from the code, and neither jsdom nor Playwright webkit
-   reproduces iOS selection UI. #1067 declares its own diagnosis the same way. */
-html.is-ios.is-selecting .scrollback {
-  -webkit-touch-callout: default;
-}
-
-/* #508 — <select> tap-to-open on iOS. `html.is-ios` sets
-   `-webkit-user-select: none` (the blanket kill above) and user-select
-   INHERITS, so it lands on every <select>. WebKit then refuses to open the
-   native picker on a DIRECT tap of a user-select:none form control — the
-   same "WebKit honors
-   inherited user-select:none inside controls" quirk the input/textarea
-   re-enable above works around. A tap on the associated `<label for=…>`
-   still forwards activation programmatically, which is exactly why only the
-   label opened the picker and the control itself looked dead. Re-enable it.
-   The value MUST be explicit: `user-select: auto` on a control re-inherits
-   the parent's `none` (per CSS-UI), so `text` — matching the input/textarea
-   re-enable — is the value that actually overrides it. */
-html.is-ios select {
-  -webkit-user-select: text;
-  user-select: text;
-}
-
-/* The [Join] invite CTA is a button inside .scrollback — re-exclude
-   it so long-press doesn't pop the selection magnifier over a control. */
-html.is-ios .scrollback-invite-join {
-  -webkit-user-select: none;
-  user-select: none;
-}
-
-/* #589 — admin pane content selectable on iOS. The blanket `html.is-ios`
-   user-select:none above kills selection on every admin table — exactly the
-   surfaces (IPs, session/visitor ids, vhosts, UA strings, error text) an
-   operator needs to copy off the device. `.admin-tab-panel` is the single
-   wrapper around every tab's content (AdminPane.tsx), so ONE selector
-   re-enables all ten tabs. Mirrors the .scrollback re-enable above; NOT
-   mirrored into keepKeyboard.ts's SELECTABLE_TEXT_SURFACES — that list is
-   compose-focus KEYBOARD policy, and the AdminPane <Match> arm UNMOUNTS
-   ComposeBox (Shell.tsx <Switch>), so no text input holds focus behind the
-   pane (handleMouseDown bails on document.activeElement). iOS native
-   long-press selection here is pure CSS. See DESIGN_NOTES 2026-08-01. */
-html.is-ios .admin-tab-panel {
-  -webkit-user-select: text;
-  user-select: text;
-}
-
-/* Re-exclude controls inside the panel — a long-press on a refresh/action
-   button must not pop the selection magnifier over a control (same carve-out
-   as .scrollback-invite-join). Buttons only: <input>/<select> stay selectable
-   via the global input/select re-enables above, and anchors keep their URL
-   text copyable (the .scrollback-link reasoning in keepKeyboard.ts). */
-html.is-ios .admin-tab-panel button {
-  -webkit-user-select: none;
-  user-select: none;
 }
 
 html.is-ios body {
   height: calc(var(--vh, 1vh) * 100);
+}
+
+/* #1869 — the selection/callout policy below is TOUCH behaviour, and it used
+   to sit under `html.is-ios` alongside the layout pin above. That is what left
+   Android showing TWO menus for one long-press: Chrome's own selection toolbar
+   over a native selection of the row, plus cic's message menu behind it,
+   because on a platform that never gets `is-ios` nothing suppressed the
+   platform's own callout. Only the `position: fixed` / `--vh` pair above is
+   genuinely iOS-only — iOS is the one platform whose layout viewport ignores
+   the keyboard.
+
+   The gate is `@media (pointer: coarse)` and not a second boot class: it keys
+   on the actual pointing device rather than a UA sniff, so a mouse keeps its
+   drag-select while every touch platform gets the suppression. iOS reports
+   `pointer: coarse`, so everything #79 / #250 / #508 / #589 / #1067
+   established there is preserved — these are the same rules re-parented, not
+   new ones.
+
+   ATOMIC, and this is the half that bites: the blanket kill and EVERY
+   re-enable beneath it ship together. Widening the kill without its re-enables
+   regresses each of those issues on Android instead of iOS. Order is
+   load-bearing too — the re-excludes (`.scrollback-invite-join`,
+   `.admin-tab-panel button`) carve out of the re-enables above them at equal
+   specificity, so they must stay AFTER them.
+
+   Specificity dropped by one class when `html.is-ios X` became `html X`.
+   Checked, not assumed: no (0,1,x) rule sets `user-select` on `.scrollback`,
+   `input`, `textarea`, `select` or `.admin-tab-panel`. The two that come
+   close, `.nick-clickable` / `.channel-clickable` (#250), set `text` — the
+   same value the `.scrollback` re-enable gives them — and do not appear
+   inside an admin pane. */
+@media (pointer: coarse) {
+  html {
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+  }
+
+  /* Dispatch-1 (2026-06-11) — selective re-enable of text selection.
+     THE selectable-text policy point: the blanket kill above is
+     Telegram Web K's pattern, and Telegram pairs it with re-enables on
+     every surface users copy from. New copyable surface → add its
+     selector HERE and to keepKeyboard.ts's SELECTABLE_TEXT_SURFACES
+     allowlist (#79, 2026-07-03 + 2026-07-04 rework): on these same
+     surfaces keepKeyboard DURATION-GATES its mousedown preventDefault —
+     a short tap is left un-prevented (keyboard dismisses) but a
+     long-press IS prevented (keyboard stays up so the iOS selection
+     survives). This `user-select: text` re-enable is the load-bearing
+     half — without it there is nothing to select. CSS and TS can't share
+     a constant, so the two lists MUST stay in sync — a surface added
+     here but not there stays unselectable while compose is focused.
+     (keepKeyboard's own handler stays iOS-gated — its job is the iOS
+     keyboard, not selection; see #1869 in that file.)
+     Currently: the topic modal's full-topic text, and editable fields (WebKit
+     honors inherited user-select:none inside inputs in some version
+     ranges). Scrollback message text left this list in #1869 — it is
+     latch-scoped now, see the rule below. Deliberately NOT selectable:
+     mentions rows (navigation buttons — the target message is selectable in
+     its channel), topic-bar text (clickable, opens the modal), all other
+     chrome.
+     Full arc: docs/DESIGN_NOTES.md 2026-06-11. */
+  html .topic-modal-text,
+  html input,
+  html textarea {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  /* #1869 — `.scrollback` is NOT in the list above. It is the one copyable
+     surface whose selection is scoped in TIME instead, and the reason is that
+     the iOS mechanism does not port: `-webkit-touch-callout` is WebKit-only
+     (`CSS.supports("-webkit-touch-callout", "none")` is FALSE in Blink,
+     measured on Chrome 151). On iOS `callout: none` + `user-select: text`
+     means "no native long-press UI, still selectable for Select…". Blink has
+     only the second half — and there `user-select: text` IS the native
+     long-press selection, which is the two-menu frame #1869 reports.
+
+     So on a coarse pointer the row defaults to NOT selectable and the
+     `is-selecting` latch below lifts it, exactly as that latch already lifts
+     the callout. Same design, one more property.
+
+     The two #250 tokens are named explicitly because they match their elements
+     DIRECTLY and so beat the inherited value — without them a long-press on a
+     nick still raises the platform's toolbar. See the latch for what this does
+     to #250's guarantee. */
+  html .scrollback,
+  html .scrollback .nick-clickable,
+  html .scrollback .channel-clickable {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* #1067 — the OTHER half of the blanket kill above:
+     `-webkit-touch-callout: none`. That property is inherited, so it lands on
+     the scrollback too, and a range installed under a suppressed callout has no
+     draggable endpoints — the second symptom #1067 diagnoses ("once text is
+     selected the endpoints cannot be moved"). #366 never re-enabled it, which is
+     why its programmatic select-all produced a selection nobody could adjust.
+
+     The re-enable is scoped in TIME, not in space: `lib/messageMenu`'s Select…
+     puts `is-selecting` on <html> while a selection is live and removes it on the
+     first `selectionchange` that finds the selection gone. Scoping it to
+     `.scrollback` permanently would put the platform's own long-press callout
+     back on every message row, where it would race the long-press menu that
+     replaced the select-all — two menus for one gesture. #1869 is that exact
+     state, arrived at from the other direction: on Android the kill never
+     applied at all, so the callout was never suppressed to begin with.
+
+     #1869 added `user-select: text` to the same latch, for Blink, where the
+     callout property does nothing. It is load-bearing and not belt-and-braces:
+     Blink omits `user-select: none` subtrees from a selection's TEXT, so
+     without it Select… installs a range whose `toString()` is the nick alone
+     (measured: `"<peluche>"` vs `"14:04:12 <peluche> prot"`).
+
+     WHAT THIS COSTS #250, deliberately. #250 gave the nick/channel tokens their
+     own `user-select: text` so they would ride INSIDE an Android native
+     drag-selection, written when Android had no scrollback re-enable at all.
+     There is no native drag-selection on the scrollback any more, so that
+     guarantee is now delivered by a different route: Select… takes the whole
+     row (`selectNodeContents`), so the tokens are included by construction, and
+     they are re-enabled under this latch so the selection's text carries them.
+     Desktop is untouched — it reports `pointer: fine` and never enters the
+     gate, which is where #250's mouse-drag case lives.
+
+     NOT device-verified on iOS: the callout ⇄ grab-handle link is read from the
+     platform contract and from the code, and neither jsdom nor Playwright webkit
+     reproduces iOS selection UI. #1067 declares its own diagnosis the same way.
+     The Blink half IS device-verified (Android 17 emulator, Chrome 151). */
+  html.is-selecting .scrollback,
+  html.is-selecting .scrollback .nick-clickable,
+  html.is-selecting .scrollback .channel-clickable {
+    -webkit-touch-callout: default;
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  /* #508 — <select> tap-to-open on iOS. The blanket kill above sets
+     `-webkit-user-select: none` and user-select INHERITS, so it lands on
+     every <select>. WebKit then refuses to open the native picker on a
+     DIRECT tap of a user-select:none form control — the same "WebKit honors
+     inherited user-select:none inside controls" quirk the input/textarea
+     re-enable above works around. A tap on the associated `<label for=…>`
+     still forwards activation programmatically, which is exactly why only the
+     label opened the picker and the control itself looked dead. Re-enable it.
+     The value MUST be explicit: `user-select: auto` on a control re-inherits
+     the parent's `none` (per CSS-UI), so `text` — matching the input/textarea
+     re-enable — is the value that actually overrides it. */
+  html select {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  /* The [Join] invite CTA is a button inside .scrollback — re-exclude
+     it so long-press doesn't pop the selection magnifier over a control. */
+  html .scrollback-invite-join {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* #589 — admin pane content selectable on touch. The blanket
+     user-select:none above kills selection on every admin table — exactly the
+     surfaces (IPs, session/visitor ids, vhosts, UA strings, error text) an
+     operator needs to copy off the device. `.admin-tab-panel` is the single
+     wrapper around every tab's content (AdminPane.tsx), so ONE selector
+     re-enables all ten tabs. Mirrors the .scrollback re-enable above; NOT
+     mirrored into keepKeyboard.ts's SELECTABLE_TEXT_SURFACES — that list is
+     compose-focus KEYBOARD policy, and the AdminPane <Match> arm UNMOUNTS
+     ComposeBox (Shell.tsx <Switch>), so no text input holds focus behind the
+     pane (handleMouseDown bails on document.activeElement). Native
+     long-press selection here is pure CSS. See DESIGN_NOTES 2026-08-01. */
+  html .admin-tab-panel {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  /* Re-exclude controls inside the panel — a long-press on a refresh/action
+     button must not pop the selection magnifier over a control (same carve-out
+     as .scrollback-invite-join). Buttons only: <input>/<select> stay selectable
+     via the global input/select re-enables above, and anchors keep their URL
+     text copyable (the .scrollback-link reasoning in keepKeyboard.ts). */
+  html .admin-tab-panel button {
+    -webkit-user-select: none;
+    user-select: none;
+  }
 }
 
 /* UX-6 bucket A (2026-05-20) — overlay scroll-lock sentinel. The class
@@ -3780,7 +3861,12 @@ button.topic-bar-windows-opener {
      This CSS `user-select: text` is deliberately kept INDEPENDENT of that
      (keyboard policy ≠ selection policy — #250 must stay text-selectable).
      Range/Playwright cannot prove the Android behavior (see issue250 spec
-     header); device-verified post-ship. */
+     header); device-verified post-ship.
+     #1869 SUPERSEDES the touch half of this: on a coarse pointer the scrollback
+     no longer offers a native drag-selection for the token to ride inside, so
+     the token is set back to `none` there and re-enabled under `is-selecting`
+     with the rest of the row. This declaration still owns the DESKTOP case
+     (`pointer: fine`), which is untouched. */
   -webkit-user-select: text;
   user-select: text;
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -699,11 +699,20 @@ html.is-ios body {
    specificity, so they must stay AFTER them.
 
    Specificity dropped by one class when `html.is-ios X` became `html X`.
-   Checked, not assumed: no (0,1,x) rule sets `user-select` on `.scrollback`,
-   `input`, `textarea`, `select` or `.admin-tab-panel`. The two that come
-   close, `.nick-clickable` / `.channel-clickable` (#250), set `text` — the
-   same value the `.scrollback` re-enable gives them — and do not appear
-   inside an admin pane. */
+   Checked, not assumed — every `user-select` declaration in this sheet was
+   enumerated: nothing at (0,1,x) sets it on `input`, `textarea`, `select` or
+   `.admin-tab-panel`, so those four re-enables carry unopposed.
+
+   `.scrollback` is the exception, and it is WHY the two #250 tokens are named
+   EXPLICITLY in the rules below instead of being left to inherit.
+   `.nick-clickable` / `.channel-clickable` carry their own top-level
+   `user-select: text` at (0,1,0), and that value now DISAGREES with what the
+   row gets on a coarse pointer — `none`, not `text` — while a token matches
+   its element DIRECTLY and the row reaches it only by inheritance, which a
+   direct match beats outright. Naming them puts the gate's rules at (0,2,1)
+   standing and (0,3,1) latched, over (0,1,0), on every engine and independently
+   of source order. Delete either token from those two selector lists and the
+   defect is back, narrowed to a long-press that lands on a nick. */
 @media (pointer: coarse) {
   html {
     -webkit-user-select: none;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44165,3 +44165,87 @@ env file, the volume and the update/stop verbs, and never says how to make an
 account — the source-mode banner is the only one carrying that hint. That is
 plausibly where the reporter ran out of road, but it is code and this is a
 docs change, so it is recorded here and not touched.
+<!-- entry #1869 -->
+
+---
+
+## 2026-08-30 — #1869: the touch selection policy was gated on iOS, and the iOS mechanism does not port to Blink
+
+Android long-press opened two menus at once: Chrome's native selection
+toolbar over a native selection of the row, plus cic's own message menu.
+The whole selection/callout policy sat under `html.is-ios`, a class
+`lib/platform.ts` adds only when `isIos()` — so Android received none of
+it. That much the issue diagnosed from the code.
+
+**What the issue's suggested direction could not know, and what makes this
+entry worth writing: re-parenting the block does not fix it.** Measured on
+an Android 17 emulator, Chrome 151:
+
+```js
+CSS.supports("-webkit-touch-callout", "none")                 // => false
+[...getComputedStyle(row)].includes("-webkit-touch-callout")  // => false
+```
+
+`-webkit-touch-callout` is **WebKit-only; Blink does not implement it.** On
+iOS the policy is a PAIR and each half does one job: `callout: none`
+suppresses the platform's long-press UI, `user-select: text` keeps the row
+selectable so `Select…` has something to install a range into. Blink has
+only the second half — and there `user-select: text` IS the native
+long-press selection. So the naive port hands Android an inert property
+and carries along the exact re-enable that produces the reported frame.
+
+The gate still moved to `@media (pointer: coarse)`, because the policy IS
+touch behaviour and only the `position: fixed` / `--vh` pin is genuinely
+iOS-only. But that move alone was measured to change nothing observable on
+Android: the surfaces the widened kill newly covers are mostly `<button>`,
+which Android's selection engine already skips (#250's own comment records
+this). The gate is necessary bookkeeping, not the cure.
+
+**The cure is to scope the row's selectability in TIME, which is what
+#1067 already does for the callout.** `.scrollback` defaults to
+`user-select: none` on a coarse pointer and the `is-selecting` latch lifts
+it for the duration of one `Select…`. One mechanism, one more property —
+not a second parallel machine. It is load-bearing rather than
+belt-and-braces: Blink omits `user-select: none` subtrees from a
+selection's TEXT, so without the lift `Select…` installs a range whose
+`toString()` is the nick alone (measured: `"<peluche>"` against
+`"14:24:42 <@vjt> ok quindi…"`).
+
+**This SUPERSEDES the touch half of #250, deliberately.** #250 gave
+`.nick-clickable` / `.channel-clickable` their own `user-select: text` so
+the tokens would ride INSIDE an Android native drag-selection — written
+when Android had no scrollback re-enable at all, which is precisely the
+state this entry ends. Two consequences, and the second is why the tokens
+are named explicitly in the new rules rather than left to inherit:
+
+1. #250's guarantee is now delivered by a different route. There is no
+   native drag-selection left for the token to be excluded from; `Select…`
+   takes the whole row (`selectNodeContents`), so the tokens are included
+   by construction, and they are re-enabled under the latch so the
+   selection's text carries them.
+2. A token matches its element DIRECTLY, so it beats the inherited `none`.
+   Left alone, a long-press landing on a nick would still raise the
+   platform's toolbar — the bug surviving in a narrower place. The gate
+   therefore sets both tokens to `none` and the latch restores both.
+
+#250's top-level declarations stay untouched and still own the DESKTOP
+case: `pointer: fine` never enters the gate, so mouse drag-select is
+exactly as it was.
+
+**Verification, and the half that is NOT verified.** The Blink side is
+device-verified — same row, same press point, fix toggled at runtime:
+native selection `"thread"` with both menus, versus a collapsed selection
+with cic's menu alone. **iOS is not re-verified**: whether defaulting
+`.scrollback` to `user-select: none` on `pointer: coarse` disturbs the iOS
+flow needs a real device, because jsdom applies no stylesheet and
+`page.emulateMedia()` has no `pointer` key, so no CI project can force
+either branch of the query. #1067 and #1857 declare the same limit for
+their own diagnoses.
+
+Guarded by `cicchetto/src/__tests__/touchSelectionPolicy.test.ts` as a
+SET comparison, not a spot-check: the kill and every re-enable must live
+inside the gate together, nothing selection-related may remain on
+`html.is-ios`, the layout pin must stay there, and no rule may grant the
+scrollback `user-select: text` outside the latch. That last one is the
+defect itself stated as a rule. `hoverGatedBlocks` was generalised to
+`mediaGatedBlocks` rather than copied.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44235,12 +44235,25 @@ exactly as it was.
 **Verification, and the half that is NOT verified.** The Blink side is
 device-verified — same row, same press point, fix toggled at runtime:
 native selection `"thread"` with both menus, versus a collapsed selection
-with cic's menu alone. **iOS is not re-verified**: whether defaulting
-`.scrollback` to `user-select: none` on `pointer: coarse` disturbs the iOS
-flow needs a real device, because jsdom applies no stylesheet and
-`page.emulateMedia()` has no `pointer` key, so no CI project can force
-either branch of the query. #1067 and #1857 declare the same limit for
-their own diagnoses.
+with cic's menu alone.
+
+**Correcting a claim this entry first made:** that no CI project could
+exercise the query. Wrong, and the e2e suite proved it by going red on two
+`@webkit` specs the moment the contract changed. `webkit-iphone-15` and
+`chromium-pixel-touch` both report `pointer: coarse` NATIVELY — no
+`emulateMedia` needed, which is the only thing that has no `pointer` key —
+so the CASCADE is assertable on both engine families, and now is:
+`issue1869-android-longpress-selection.spec.ts` on Blink, the `@webkit`
+twins in `text-selection-restored` and `issue250-android-nick-select` on
+WebKit. The Blink spec also pins the SERIALISATION, which is the part a
+computed-style read cannot show: unlatched, a range over the row does not
+contain the body.
+
+What stays a device question is whether the platform's toolbar actually
+appears — no project renders native selection UI. So the iOS CASCADE is
+covered in CI, while iOS BEHAVIOUR under the new default is not, and that
+is the residual risk of this change. #1067 and #1857 declare the same
+limit for their own diagnoses.
 
 Guarded by `cicchetto/src/__tests__/touchSelectionPolicy.test.ts` as a
 SET comparison, not a spot-check: the kill and every re-enable must live


### PR DESCRIPTION
**TL;DR** — a long-press on a message row opened two menus on Android: Chrome's
native selection toolbar plus cic's own. The selection policy was gated on
`html.is-ios`, so Android never got it. **Re-parenting it to
`@media (pointer: coarse)` is necessary but does NOT fix it**:
`-webkit-touch-callout` is WebKit-only, so on Blink the `user-select: text`
that rides along with it *is* the native long-press selection. The fix is to
default `.scrollback` to `user-select: none` on a coarse pointer and let
#1067's existing `is-selecting` latch lift it for one `Select…` — which
supersedes the touch half of #250, deliberately (details below).

**Tests:** a new source-level CSS guard (`touchSelectionPolicy.test.ts`,
verified red against the pre-fix sheet) and a new Blink e2e spec on
`chromium-pixel-touch` pinning both the cascade and the selection
serialisation; the two `@webkit` iOS guards move to the new two-state
contract. No Android tooling in CI — `chromium-pixel-touch` is ordinary
headless Chromium reporting `pointer: coarse`. The emulator was used once, by
hand, for the screenshot below; the tests keep the cascade from rotting.

Android long-pressed a message into two menus. The selection/callout policy
sat under `html.is-ios`, which `platform.ts` applies only when `isIos()`, so
Android got none of it.

<img width="1410" height="1620" alt="fix-issue-1869" src="https://github.com/user-attachments/assets/7f7465e1-382a-4f9e-8db1-84bbaa8f0a7a" />

Same row, same press point, fix toggled at runtime. Left: native toolbar,
selection on "thread", grab handles, Google sheet, cic's menu underneath.
Right: cic's menu alone.

## The part the issue could not know

Moving the block to `@media (pointer: coarse)` — the issue's option 1 — does
**not** fix it. Measured on Android 17 / Chrome 151:

```js
CSS.supports("-webkit-touch-callout", "none")   // => false
```

`-webkit-touch-callout` is WebKit-only. On iOS the policy is a pair:
`callout: none` suppresses the platform's long-press UI, `user-select: text`
keeps the row selectable for `Select…`. Blink has only the second half — and
there `user-select: text` *is* the native long-press selection. So the naive
port hands Android an inert property and carries along the exact re-enable
that causes the reported frame.

I implemented option 1 first and it changed nothing observable on Android: the
surfaces the widened kill newly covers are mostly `<button>`, which Android's
selection engine already skips.

## What this does

1. **Gate moves to `@media (pointer: coarse)`** — the policy is touch
   behaviour; only `position: fixed` / `--vh` is genuinely iOS-only. Kill and
   all re-enables move together, or #79 / #508 / #589 regress on Android.
2. **`.scrollback` becomes latch-scoped** — `user-select: none` by default on
   a coarse pointer, lifted by #1067's existing `is-selecting` latch for the
   duration of one `Select…`. One mechanism, one more property.

The latch is load-bearing: Blink omits `user-select: none` subtrees from a
selection's text, so without the lift `Select…` yields `"<peluche>"` instead
of the whole row.

## Impact on #250, and why it's the right trade

#250 gave `.nick-clickable` / `.channel-clickable` their own
`user-select: text` so they'd ride inside an Android native drag-selection —
written when Android had no scrollback re-enable, which is the state this PR
ends. Two consequences:

- **Its guarantee now arrives by another route.** There's no native
  drag-selection left for the token to be excluded from. `Select…` takes the
  whole row (`selectNodeContents`), so the tokens are included by
  construction, and the latch re-enables them so the selection's text carries
  them. Same outcome, fewer moving parts.
- **They're named explicitly in the new rules**, because a token matches its
  element directly and so beats the inherited `none`. Left to inherit, a
  long-press on a nick would still raise the toolbar — the bug surviving in a
  narrower place.

#250's top-level declarations are untouched and still own the desktop case:
`pointer: fine` never enters the gate, so mouse drag-select is unchanged.

Net: #250 wanted the nick copyable on touch; it still is, via a path that
doesn't also hand Chrome a second menu.

## Verification

Blink side device-verified (Android 17 emulator, Chrome 151, OS-level
`adb input swipe`, not synthesised events).

**iOS is not re-verified.** Whether defaulting `.scrollback` to
`user-select: none` on `pointer: coarse` disturbs the iOS flow needs a real
device: jsdom applies no stylesheet and `page.emulateMedia()` has no
`pointer` key, so no CI project can force either branch of the query. Same
limit #1067 and #1857 declare. **This wants a check on your iPhone before it
lands.**

`touchSelectionPolicy.test.ts` guards it as a set comparison, not a
spot-check: kill and every re-enable inside the gate together, nothing
selection-related left on `html.is-ios`, the layout pin still there, and no
rule granting the scrollback `user-select: text` outside the latch — the
defect itself, stated as a rule. Verified red against the pre-fix sheet.
`hoverGatedBlocks` generalised to `mediaGatedBlocks` rather than copied.

---

## Maintainer notes (w1, on behalf of the orchestrator)

Rebased onto `main` and touched up in place — the four commits above keep their
author. Their subject scopes lost the hash: they now read `fix(1869)` and
`test(1869)` rather than carrying a `#` next to the keyword, which is the house
spelling. Only the `fix` one was ever a closing-keyword shape at all, and it is
unclear whether GitHub's parser fires across the parenthesis; the point of the
change is to stop depending on that reading. The `Closes` line was removed from
this body for the same reason plus a stronger one: issue 1869's iOS half is
unverified, so whoever merges should close it deliberately, saying so.

Two comments were rewritten because they described a sheet that was considered
and not shipped, and both were instructions the next author would follow: the
`SELECTABLE_TEXT_SURFACES` sync rule in `keepKeyboard.ts` (now the two-tier rule
the code implements — standing re-enable versus latch-scoped, and how to pick
between them), and the specificity paragraph above the gate, which claimed the
#250 tokens carry the same value the row does. They no longer do, and that
mismatch is exactly why the tokens had to be named explicitly in the gate's
rules instead of being left to inherit. Comments only; no declaration changed.

`mediaGatedBlocks` now refuses an opener without the `g` flag. Without it,
`exec` ignores the advanced `lastIndex` and restarts at 0 forever, so the shared
test helper hangs rather than fails. Measured with both controls before the
guard was written: the scan shape hit its iteration cap on a non-global regex
and terminated on the global twin.

**The ordering was fixed too.** `selectMessageText` used to install the range
and raise the `is-selecting` latch afterwards — and since the latch is now also
what gives `.scrollback` its `user-select: text` on a coarse pointer, the range
went in while the row still computed `none`. The two statements are swapped.

The ordering is pinned by a unit test that observes the latch at the instant
`addRange` runs, run against both orderings rather than asserted: red on the
previous one (rc=1, one failing test of eighteen, so it discriminates the order
and nothing else), green on this one (rc=0, 18/18).

## The e2e half — and a correction to what this description used to say

An earlier revision of this body said the one spec that drives the real
`Select…` (`issue1067-swipe-reply-message-menu`) is untagged and therefore runs
only on `pointer: fine`, where none of the coarse-pointer policy applies. **That
was wrong, and it is measured wrong.** Under that file's module-level
`test.use({ hasTouch: true })` Chromium reports `(pointer: coarse)` and
`(hover: none)`, and `.scrollback` computes `user-select: none` standing —
byte-identical to what the `chromium-pixel-touch` project reports for the same
page. Touch emulation moves Chromium's primary pointer; an untagged *project* is
not a fine *pointer*. The gate was already live there and the coverage already
existed.

A `@touch` twin was written, run green, and then deleted: once both Chromium
projects measured identical it was covering the same gate twice on the same
engine, and a re-tag would have *moved* the coverage off desktop anyway
(`grepInvert: /@webkit|@touch/`). What ships instead is the thing whose absence
produced the wrong reading in the first place — the premise is now **asserted**
where it is relied on (coarse pointer, `user-select: none`, before the press),
the selection is asserted to carry the sender (the issue 250 guarantee this
route delivers), and the file header says which pointer these tests run on. It
is also a durability fix: drop `hasTouch` and every assertion in that file would
go *vacuous* rather than red.

Teeth, measured rather than argued: renaming `SELECTING_CLASS` reds that spec
with an **empty** selection (rc=1), while the two issue-1869 cascade tests —
which build their range by hand — stay green.

**And the open question is now answered on Blink.** With the two orderings
swapped by hand and the spec rerun on a coarse pointer, the selection still
serialised whole (rc=0, 3/3): `Selection.toString()` walks the layout tree at
call time, so it reads the `user-select` in force then, not the one in force
when `addRange` ran. So the reorder stays for the reason it can honestly stay
for — it is the one ordering needing no per-engine argument — and **not**
because it repairs a demonstrated defect. The code comments were rewritten to
say exactly that.

## Gates

| gate | rc | detail |
|---|---|---|
| `scripts/bun.sh run check` | 0 | 5 stages ran, 0 failed; biome `Found 58 warnings`, zero errors |
| `scripts/bun.sh run test` | 0 | 329 files, 6567 tests |
| `scripts/design-notes-gate.sh origin/main` | 0 | 1 new entry heading, separator and marker present |
| `scripts/integration.sh` (full) | 1 | `801 passed`, 1 skipped, **1 failed** — see below |

Every test this branch touches is green in the full run, including the cured
`Select…` spec and both issue-1869 specs.

**The one red, stated as what it is.** `issue1445-directory-pull-refresh`,
`@webkit #1658 …`, failed with `no directory row to measure the gap against`.
Its page snapshot reads `0 channels` / `never` with an empty list — the channel
directory had never been populated when the helper tried to measure against it.
The chromium twin of the same test through the same helper is green, the next
webkit test in the same file (which opens the same directory) is green, and an
iso-rerun `--project webkit-iphone-15 --repeat-each 3` is `3 passed`.

That is a **local red that did not reproduce and was not attributed** — not a
known flake, and not something this branch can reach (its changes are
assertions inside one chromium spec, plus comments). The cause was not
established. `issue1445`'s webkit arm appears to depend on directory data being
present without waiting for it; a deterministic setup is the cure, not a longer
timeout. Out of scope here, and named rather than fixed.

## What is NOT verified

No iOS device verification happened. Every measurement above is Blink, and a
green on Blink is not a green on WebKit — the `Select…` production path has
never been driven on WebKit by any spec and cannot be on `webkit-iphone-15`,
whose `tap()` dispatches no click at all. Whether Chrome's toolbar actually
stops appearing, and whether iOS grab handles appear, remains a device call.

The review behind all of the above — including the source-level guard verified
red against the pre-fix sheet and against two mutants — was delivered
separately.
