### PR TITLE
cic: build the grapheme segmenter lazily behind a guard, with a code-point fallback

### DIFF
--- a/cicchetto/src/__tests__/frameBudget.test.ts
+++ b/cicchetto/src/__tests__/frameBudget.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { frameBudgetForTarget, frameCount, framePreview, utf8ByteLength } from "../lib/frameBudget";
 
 // #1108 — the compose box warns, BEFORE sending, that the draft no longer
@@ -160,5 +160,114 @@ describe("frameBudget — framePreview", () => {
 
   it("reports nothing to send for an empty draft", () => {
     expect(framePreview([], 10)).toEqual({ messages: 0, remainingBytes: null });
+  });
+});
+
+// #1870 — `Intl.Segmenter` landed in Firefox 125, and this module used to
+// construct one at TOP LEVEL. `ComposeBox` imports `frameBudgetForTarget`, so
+// on Firefox 115 ESR the `TypeError` fired while the main bundle was still
+// evaluating: nothing mounted, and a frame counter cost the whole app a WHITE
+// PAGE. The build target (`es2022`, vite.config.ts) cannot catch that —
+// `Intl.Segmenter` is a LIBRARY feature, not syntax, so no transpile step
+// ever looks at it.
+//
+// Two properties, deliberately separate: the module must EVALUATE where the
+// API is absent, and its one segmenting call site must still answer a
+// defensible number.
+//
+// ⚠️ What these tests do NOT prove: that Firefox 115 renders the page. There
+// is no FF115 here and Playwright ships no build of it, so the white page
+// itself stays a diagnosis from the stack trace in the report, never an
+// observation. What is pinned is the code-level property that diagnosis
+// names, in the only runtime this repo has.
+describe("frameBudget — where Intl.Segmenter is absent (#1870)", () => {
+  const realSegmenter = Intl.Segmenter;
+
+  // The pairs where the fallback and the segmenter DISAGREE, stated together
+  // so the price of the fallback is one table rather than a claim: a code
+  // point is not a grapheme, and these are the two ways that shows.
+  const divergences = [
+    {
+      what: "a combining sequence",
+      // "e" + U+0301 is ONE 3-byte grapheme, so at a 2-byte budget the
+      // segmenter emits it whole as its own oversized frame; the fallback
+      // sees a 1-byte "e" and a 2-byte mark and breaks between them.
+      // Written as an ESCAPE, never as a literal: an editor that stores the
+      // precomposed U+00E9 instead makes this 2 bytes, which fits the budget
+      // whole — both paths would then answer 1 and agree for the wrong reason.
+      body: "e\u0301",
+      budget: 2,
+      withSegmenter: 1,
+      fallback: 2,
+    },
+    {
+      what: "a ZWJ emoji cluster",
+      // 25 bytes, ONE grapheme — and seven code points (four emoji, three
+      // joiners), which at a 4-byte budget is seven frames.
+      body: "👩‍👩‍👧‍👦",
+      budget: 4,
+      withSegmenter: 1,
+      fallback: 7,
+    },
+  ] as const;
+
+  afterEach(() => {
+    Object.defineProperty(Intl, "Segmenter", {
+      value: realSegmenter,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+    vi.resetModules();
+  });
+
+  // A module instance that has NEVER seen the constructor — the state an
+  // FF115 tab boots in, as opposed to one that lost it half way through.
+  async function importWithoutSegmenter() {
+    vi.resetModules();
+    Reflect.deleteProperty(Intl, "Segmenter");
+    // The removal is the premise of every assertion below: if the property
+    // were not configurable, these tests would pass while measuring the
+    // segmenter path.
+    expect(Intl.Segmenter).toBeUndefined();
+    return import("../lib/frameBudget");
+  }
+
+  it("evaluates instead of throwing while the bundle is loading", async () => {
+    const module = await importWithoutSegmenter();
+    expect(typeof module.frameCount).toBe("function");
+  });
+
+  it("keeps a surrogate pair whole in the fallback split", async () => {
+    const { frameCount: countWithout } = await importWithoutSegmenter();
+    // `Array.from` iterates CODE POINTS, so each 4-byte pizza stays one unit
+    // and two of them at a 4-byte budget are two frames — the same answer the
+    // segmenter gives. A UTF-16 unit walk would see four 3-byte lone
+    // surrogates and report FOUR, which is what this case exists to reject.
+    expect(countWithout("🍕🍕", 4)).toBe(2);
+    expect(frameCount("🍕🍕", 4)).toBe(2);
+  });
+
+  for (const example of divergences) {
+    it(`splits ${example.what} the segmenter would have kept whole`, async () => {
+      const { frameCount: countWithout } = await importWithoutSegmenter();
+      // DECLARED WRONG, deliberately. It costs an advisory COUNT and never a
+      // byte — the split that reaches the wire is still the server's — and
+      // only on a browser that cannot segment at all. The alternative was
+      // shipping no number there, or no app at all.
+      expect(countWithout(example.body, example.budget)).toBe(example.fallback);
+      expect(example.fallback).not.toBe(example.withSegmenter);
+    });
+  }
+
+  it("is byte-for-byte unchanged where the segmenter exists", async () => {
+    vi.resetModules();
+    // Positive control: this arm is only meaningful while the constructor is
+    // really there, and `afterEach` above is what put it back.
+    expect(typeof Intl.Segmenter).toBe("function");
+    const { frameCount: countWith } = await import("../lib/frameBudget");
+    for (const example of divergences) {
+      expect(countWith(example.body, example.budget)).toBe(example.withSegmenter);
+    }
   });
 });

--- a/cicchetto/src/lib/frameBudget.ts
+++ b/cicchetto/src/lib/frameBudget.ts
@@ -37,7 +37,42 @@ import { CTCP_DELIMITER, stripCtcpAction } from "./ctcpAction";
 const CTCP_ACTION_ENVELOPE_BYTES =
   utf8ByteLength(`${CTCP_DELIMITER}ACTION `) + utf8ByteLength(CTCP_DELIMITER);
 
-const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+// #1870 — resolved on FIRST USE, never at import. `Intl.Segmenter` landed in
+// Firefox 125; on 115 ESR the constructor is absent, and this used to be a
+// top-level `new`. `ComposeBox` imports this module, so the `TypeError` fired
+// while the main bundle was still EVALUATING and React never mounted: a frame
+// counter cost the whole app a white page. The build target (`es2022`) cannot
+// catch that — `Intl.Segmenter` is a LIBRARY feature, not syntax, so no
+// transpile step ever looks at it.
+//
+// `undefined` is "not asked yet" and `null` is "asked, absent": one feature
+// test per page, and no ICU segmenter built for a session that never
+// overflows a frame.
+let graphemeSegmenter: Intl.Segmenter | null | undefined;
+
+/**
+ * `body` split into the units the chunker charges bytes for — extended
+ * grapheme clusters where the platform can segment, CODE POINTS where it
+ * cannot.
+ *
+ * The fallback keeps surrogate pairs whole (that is what `Array.from`
+ * iterates) and is deliberately wrong about exactly two things: a combining
+ * sequence and a ZWJ emoji cluster can be counted as several units and so
+ * reported as splitting across frames. That is a cost this mirror is allowed
+ * to pay — it moves an ADVISORY number, never a byte, because the split that
+ * reaches the wire is still `LineSplit`'s — and only on a browser whose own
+ * `Intl` cannot do better anyway.
+ */
+function graphemesOf(body: string): string[] {
+  if (graphemeSegmenter === undefined) {
+    graphemeSegmenter =
+      typeof Intl.Segmenter === "function"
+        ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+        : null;
+  }
+  if (graphemeSegmenter === null) return Array.from(body);
+  return [...graphemeSegmenter.segment(body)].map((s) => s.segment);
+}
 
 /**
  * Bytes `s` occupies once UTF-8 encoded — what IRC framing counts, as opposed
@@ -132,7 +167,7 @@ export function framePreview(bodies: readonly string[], budget: number): FramePr
 // boundary and the overflowing grapheme is RE-READ against the carry-over,
 // which may already leave no room for it.
 function chunkCount(body: string, budget: number): number {
-  const graphemes = [...graphemeSegmenter.segment(body)].map((s) => s.segment);
+  const graphemes = graphemesOf(body);
   let chunks = 0;
   let current: string[] = [];
   let size = 0;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -43949,3 +43949,58 @@ than a scoping one. `state.network_slug` is already on the state (the
 sibling wire call one line up uses it), so the change is small — it is
 the coverage and the visible-behaviour flip that make it somebody's
 decision rather than this branch's.
+<!-- entry #1870 -->
+
+---
+
+## 2026-08-30 — #1870: a LIBRARY feature at module top level is a white page, not a missing feature
+
+Firefox 115 ESR renders `irc.sindro.me` blank — no splash, no login form,
+nothing mounted. The console names one frame: `Intl.Segmenter is not a
+constructor`, `frameBudget.ts:40`. That line built the grapheme segmenter at
+module TOP LEVEL; `ComposeBox` imports `frameBudgetForTarget`, so the
+constructor ran while the main bundle was still EVALUATING and the throw took
+React's mount with it. A frame counter — two advisory numbers under a compose
+box — cost the whole application.
+
+**The build target cannot catch this class, and that is the general rule worth
+keeping.** `vite.config.ts` targets `es2022`, and `Intl.Segmenter` is a LIBRARY
+feature rather than syntax: no transpile step and no `target` setting ever
+looks at it, and the bundle is byte-identical whether the browser has the API
+or not. A missing SYNTAX feature is a build-time fact; a missing LIBRARY
+feature is a runtime one, and WHERE it is touched decides whether it costs one
+feature or the app. Module top level is the one place where it costs the app,
+because the module graph is evaluated before anything renders.
+
+The cure is two independent halves, separate on purpose. (1) The segmenter is
+resolved on FIRST USE behind `typeof Intl.Segmenter === "function"`, so an
+absent API degrades the counter instead of the mount; `undefined` means
+not-asked-yet and `null` asked-and-absent, which also stops an ICU segmenter
+being built for a session that never overflows a frame. (2) The one call site
+(`chunkCount`) falls back to `Array.from(body)` — a CODE POINT split.
+
+**What the fallback gets wrong is DECLARED, not discovered.** `Array.from`
+iterates code points, so surrogate pairs stay whole: two 🍕 at a 4-byte budget
+count 2 frames on both paths, where a UTF-16 unit walk would say 4. A
+combining sequence and a ZWJ emoji cluster are NOT whole — `e`+U+0301 at a
+2-byte budget reads 2 frames where the segmenter reads 1, and the family emoji
+at 4 bytes reads 7 where the segmenter reads 1. Both live in the test file as a
+table that states the two answers side by side, so the price is a fixture
+rather than a claim. It is affordable for a reason specific to THIS module and
+not transferable: the count is an advisory MIRROR of `Grappa.IRC.LineSplit`,
+and the split that actually reaches the wire is still the server's, so the
+fallback can move a number on screen and never a byte on the wire. A module
+whose client-side answer WERE the outcome would not get this fallback.
+
+**Not measured, by anyone: that Firefox 115 renders white.** There is no FF115
+on the worker host and Playwright ships no build of it, so the white page stays
+a diagnosis read off a user's stack trace, never an observation. What IS
+measured is the code-level property that diagnosis names: with `Intl.Segmenter`
+deleted from `Intl`, importing the module used to throw the reported
+`TypeError` at the reported line, and now does not — the reproduction carries
+its own positive control, asserting the property is really gone before it
+concludes anything from its absence.
+
+Left to vjt and deliberately untouched: whether FF115 ESR is a support target
+at all. If it is not, telling the operator so is a product decision and a
+different change; this entry only stops one absent API from being a blank page.


### PR DESCRIPTION
Follows the report in issue 1870.

## What was wrong

`cicchetto/src/lib/frameBudget.ts` constructed `new Intl.Segmenter(...)` at
module TOP LEVEL. `ComposeBox` imports `frameBudgetForTarget` from that module,
so on any browser without the constructor — Firefox 115 ESR; the API landed in
Firefox 125 — the `TypeError` fired while the main bundle was still EVALUATING
and nothing mounted. A frame counter cost the whole application a blank page.

The build target cannot catch this class: `vite.config.ts` targets `es2022`,
and `Intl.Segmenter` is a LIBRARY feature rather than syntax, so no transpile
step and no `target` setting ever looks at it. The bundle is byte-identical
whether the browser has the API or not. A missing SYNTAX feature is a
build-time fact; a missing LIBRARY feature is a runtime one, and WHERE it is
touched decides whether it costs one feature or the app.

## What changed

Two independent halves, separate on purpose.

1. **No throw at import.** The segmenter is resolved on FIRST USE behind
   `typeof Intl.Segmenter === "function"`. `undefined` means not-asked-yet and
   `null` asked-and-absent, so the feature test runs once and no ICU segmenter
   is built for a session that never overflows a frame.
2. **A fallback for the one call site.** `chunkCount` falls back to
   `Array.from(body)` — a CODE POINT split.

**What the fallback gets wrong is declared, not discovered.** `Array.from`
iterates code points, so surrogate pairs stay whole (two 🍕 at a 4-byte budget
count 2 frames on both paths; a UTF-16 unit walk would say 4). A combining
sequence and a ZWJ emoji cluster are NOT whole: `e`+U+0301 at a 2-byte budget
reads 2 frames where the segmenter reads 1, and the family emoji at 4 bytes
reads 7 where the segmenter reads 1. Both are pinned as a table stating the two
answers side by side. That price is payable in THIS module and is not a general
licence: the count is an advisory MIRROR of `Grappa.IRC.LineSplit`, and the
split that reaches the wire is still the server's, so the fallback can move a
number on screen and never a byte on the wire.

Where the segmenter exists, behaviour is unchanged — the pre-existing suite
plus an explicit arm asserting the segmenter's answers for the same inputs.

## Tests

- The module IMPORTS with `Intl.Segmenter` deleted (it threw at
  `frameBudget.ts:40` before, the exact line the report names).
- The fallback keeps a surrogate pair whole.
- The two declared divergences, each paired with the segmenter's answer.
- An arm pinning the segmenter path, with a positive control that the
  constructor is really back before it concludes anything.

The removal of `Intl.Segmenter` is itself asserted before each fallback
assertion, so a non-configurable property would fail the test rather than
silently measure the segmenter path.

## What this does NOT prove

**That Firefox 115 renders the page.** There is no FF115 on the worker host and
Playwright ships no build of it, so a real end-to-end run is impossible and no
green spec is offered in its place. The white page stays a diagnosis read off a
user's stack trace; what is measured is the code-level property that diagnosis
names.

## Out of scope, deliberately

Whether FF115 ESR is a support target at all, and any unsupported-browser
notice that would follow. That is a product decision, not this branch's.

## Gates

- `scripts/bun.sh run check` — `rc=0`, 5 stages ran, 0 failed (lock drift, test
  location, biome, tsc src, tsc e2e).
- `scripts/bun.sh run test` — `rc=0`, 327 files / 6550 tests passed.
- `scripts/design-notes-gate.sh` post-commit — `rc=0`, "1 new entry heading(s),
  separator and marker present".
- Server-side gates are not implicated: no `.ex`, no `priv/wire`, no protocol
  file is touched.