### PR TITLE
cic: resync the network tree on app resume, not only on a socket edge

### DIFF
--- a/cicchetto/src/__tests__/resumeResync.test.ts
+++ b/cicchetto/src/__tests__/resumeResync.test.ts
@@ -1,0 +1,200 @@
+import { createRoot, createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installResumeResync, type ResumeWindowLike } from "../lib/resumeResync";
+
+// #1873 — a channel joined on another device is missing from an Android PWA
+// that was merely RESUMED, and appears only after a kill-and-reopen.
+//
+// `channelsBySlug` had exactly two refresh doors: the live `channels_changed`
+// broadcast, and a defensive resync gated on the socket transitioning INTO
+// "open" from a non-open state (`subscribe.ts`). A frozen process receives
+// neither — the broadcast is fanned out best-effort with no live subscriber,
+// and `socketHealth` is a RECORD of the last phoenix callback, so with the
+// process suspended nothing can write it and the state reads "open" across
+// the whole absence. No edge, no refetch; the kill-and-reopen heals it
+// because that is a real boot.
+//
+// This module is the third door: the app-resume signal. The contract tested
+// here is deliberately narrow — WHEN the resync verb runs — because what it
+// resyncs is `networks.ts`'s business and the socket-edge arm's already.
+//
+// ⚠️ NOT tested here, and not testable here: that an Android PWA freeze
+// produces these events at all. There is no Android on this host and the OS
+// freeze cannot be simulated; a synthetic `visibilitychange` is a synthetic
+// `visibilitychange`. What is pinned is the contract the resume path obeys
+// once the platform delivers one.
+
+/** The bfcache seam, with both halves drivable. */
+function fakeWindow(): { win: ResumeWindowLike; pagehide: () => void; pageshow: () => void } {
+  const handlers = new Map<string, () => void>();
+  return {
+    win: {
+      addEventListener: (event, h) => {
+        handlers.set(event, h);
+      },
+    },
+    pagehide: () => handlers.get("pagehide")?.(),
+    pageshow: () => handlers.get("pageshow")?.(),
+  };
+}
+
+describe("resumeResync — when the resync runs", () => {
+  it("does not resync at boot, on the initial pageshow or the initial visible state", () => {
+    const resync = vi.fn();
+    const [visible] = createSignal(true);
+    const { win, pageshow } = fakeWindow();
+
+    // Signals are driven OUTSIDE the root: `createRoot` runs its body inside
+    // ONE Solid update cycle, so an effect queued in there does not run until
+    // the root returns and a transition made inside is observed only at its
+    // final value. Same shape as `documentVisibility.test.ts`.
+    const dispose = createRoot((disposeRoot) => {
+      installResumeResync({ isVisible: visible, resync, win });
+      return disposeRoot;
+    });
+    // The initial load fires `pageshow` too — with no `pagehide` before it.
+    // Boot already fetched the tree, so a resync here would be a second
+    // identical request on every cold load.
+    pageshow();
+    expect(resync).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("resyncs when the document comes back after being away", () => {
+    const resync = vi.fn();
+    const [visible, setVisible] = createSignal(true);
+    const { win } = fakeWindow();
+
+    const dispose = createRoot((disposeRoot) => {
+      installResumeResync({ isVisible: visible, resync, win });
+      return disposeRoot;
+    });
+    setVisible(false);
+    expect(resync).not.toHaveBeenCalled();
+    setVisible(true);
+    expect(resync).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it("counts a visibility return and a pageshow for ONE resume as one resync", () => {
+    // Overlapping triggers are the normal case, not an edge: a PWA resume can
+    // deliver both. Two requests for one resume is exactly the doubling this
+    // door must not introduce.
+    const resync = vi.fn();
+    const [visible, setVisible] = createSignal(true);
+    const { win, pagehide, pageshow } = fakeWindow();
+
+    const dispose = createRoot((disposeRoot) => {
+      installResumeResync({ isVisible: visible, resync, win });
+      return disposeRoot;
+    });
+    // The real order for a PWA that is frozen and restored: it leaves twice
+    // over (one departure, two events) and comes back twice over.
+    pagehide();
+    setVisible(false);
+    setVisible(true);
+    pageshow();
+    expect(resync).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it("resyncs again on the NEXT resume — the coalescing is not a latch", () => {
+    const resync = vi.fn();
+    const [visible, setVisible] = createSignal(true);
+    const { win } = fakeWindow();
+
+    const dispose = createRoot((disposeRoot) => {
+      installResumeResync({ isVisible: visible, resync, win });
+      return disposeRoot;
+    });
+    setVisible(false);
+    setVisible(true);
+    setVisible(false);
+    setVisible(true);
+    expect(resync).toHaveBeenCalledTimes(2);
+    dispose();
+  });
+
+  it("resyncs on a bfcache restore whose visibility never moved", () => {
+    // The case the bfcache pair exists for: the document is frozen and
+    // restored with its computed visibility unchanged, so the signal never
+    // fires and the visibility arm alone would never see the resume. The
+    // `pagehide` this document observed is what separates it from a boot.
+    const resync = vi.fn();
+    const [visible] = createSignal(true);
+    const { win, pagehide, pageshow } = fakeWindow();
+
+    const dispose = createRoot((disposeRoot) => {
+      installResumeResync({ isVisible: visible, resync, win });
+      return disposeRoot;
+    });
+    pagehide();
+    pageshow();
+    expect(resync).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it("does not resync while the document goes away and stays away", () => {
+    const resync = vi.fn();
+    const [visible, setVisible] = createSignal(true);
+    const { win } = fakeWindow();
+
+    const dispose = createRoot((disposeRoot) => {
+      installResumeResync({ isVisible: visible, resync, win });
+      return disposeRoot;
+    });
+    setVisible(false);
+    setVisible(false);
+    expect(resync).not.toHaveBeenCalled();
+    dispose();
+  });
+});
+
+// The arm above runs against a hand-made signal, which proves the contract and
+// nothing about the wiring. This one runs against the REAL visibility SSOT
+// (`documentVisibility.ts` — the same accessor `main.tsx` injects) driven by
+// real DOM events, so a change to what that module considers a transition is
+// caught here rather than in production.
+describe("resumeResync — against the real visibility SSOT", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const setVisibility = (state: "visible" | "hidden"): void => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => state,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  };
+
+  it("resyncs once when a backgrounded document is brought back", async () => {
+    const { isDocumentVisible } = await import("../lib/documentVisibility");
+    const resync = vi.fn();
+    const { win } = fakeWindow();
+
+    const dispose = createRoot((disposeRoot) => {
+      installResumeResync({ isVisible: isDocumentVisible, resync, win });
+      return disposeRoot;
+    });
+    // Positive control: the signal really is wired to the DOM here, so a zero
+    // below would mean the door is shut rather than the events absent.
+    expect(isDocumentVisible()).toBe(true);
+    setVisibility("hidden");
+    expect(isDocumentVisible()).toBe(false);
+    expect(resync).not.toHaveBeenCalled();
+
+    setVisibility("visible");
+    expect(resync).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+});

--- a/cicchetto/src/lib/resumeResync.ts
+++ b/cicchetto/src/lib/resumeResync.ts
@@ -1,0 +1,121 @@
+import { type Accessor, createEffect, on } from "solid-js";
+
+// #1873 — the THIRD door onto the network/channel tree: app resume.
+//
+// A channel joined on another device was missing from an Android PWA that had
+// merely been resumed, and appeared only after a kill-and-reopen. Before this
+// module `channelsBySlug` had exactly two refresh doors, and a frozen process
+// walks through neither:
+//
+//   * the live `channels_changed` broadcast — fanned out best-effort, with no
+//     live subscriber to receive it while the process is suspended;
+//   * `subscribe.ts`'s defensive resync, gated on the socket transitioning
+//     INTO "open" from a non-open state.
+//
+// The second one is the interesting miss, and the reason this is not "add a
+// listener": `socketHealth` is a RECORD of the last phoenix callback, written
+// only by `onOpen` / `onError` / `onClose`. Nothing polls, so a suspended
+// process cannot write it and the state necessarily reads whatever it read
+// when it went under. Two regimes follow, and the cure differs:
+//
+//   * the socket survived the absence — no callback ever fires, no edge ever
+//     arrives, and the defensive resync NEVER runs. Here this door is the
+//     whole cure.
+//   * the socket died — the tear is observed on the thaw (or forced by #254's
+//     visibilitychange kick, which gates on the LIVE readyState rather than
+//     on `socketHealth`), the state leaves "open", the reconnect lands, and
+//     the edge fires. Here this door is a FLOOR: it puts the HTTP fetch on
+//     the wire immediately instead of after a WS round trip, and HTTP does
+//     not wait for the socket.
+//
+// WHY A MODULE AND NOT A LISTENER IN `subscribe.ts`. The resume seam already
+// exists and has two consumers with this exact shape — `installStaleResumeReload`
+// (#695/#674) and `installResumeProbe` (#697): the visibility SSOT
+// (`documentVisibility.ts`, one set of listeners for visibilitychange AND
+// window focus/blur) injected as a signal, plus `pageshow` for the restore
+// the signal cannot see, both mounted from `main.tsx`. A raw
+// `document.addEventListener("visibilitychange")` inside `subscribe.ts` would
+// be a parallel registration of a signal that already exists — the thing #192
+// removed when it made presence read the SSOT instead of its own listener.
+//
+// ONE RESYNC PER RESUME. A resume can deliver a visibility transition AND a
+// `pageshow`; the second must not put a second identical request on the wire.
+// The guard is a single flag meaning "a resume is owed a resync", raised when
+// the document leaves and cleared by the resync itself — derived from the
+// transition rather than tracked in parallel with it, and never a latch that
+// could disable the door for the document's remaining life.
+//
+// ⚠️ KNOWN LIMITATION, same one `resumeProbe` records: a platform that thaws a
+// document with NEITHER a visibility transition NOR a `pageshow` is not
+// covered, because there is nothing to observe. An absent resync then is that
+// gap, not evidence that the door is shut.
+
+/**
+ * The bfcache seam, taken as a PAIR. `pagehide` is what makes `pageshow`
+ * unambiguous: the initial load fires `pageshow` with no `pagehide` before
+ * it, so gating the return on a departure this document actually observed
+ * costs nothing at boot and needs no `persisted` flag to tell them apart.
+ */
+export interface ResumeWindowLike {
+  addEventListener(event: "pagehide" | "pageshow", handler: () => void): void;
+}
+
+export interface ResumeResyncDeps {
+  /**
+   * The visibility SSOT (`documentVisibility.ts` — visibilitychange AND
+   * window focus/blur). Consumed as a signal rather than re-registering
+   * parallel listeners.
+   */
+  isVisible: Accessor<boolean>;
+  /**
+   * Re-derive the tree from the server. `refetchNetworks` + `refetchChannels`
+   * in production — the same pair `subscribe.ts`'s socket-edge arm runs,
+   * injected so this module stays free of the resource singletons.
+   */
+  resync: () => void;
+  win: ResumeWindowLike;
+}
+
+/**
+ * Arm the resume resync: one `deps.resync()` per resume, none at boot.
+ *
+ * No uninstall path, like its two siblings — a real listener outlives its
+ * test, so unit tests pass a fake window rather than the real one.
+ */
+export function installResumeResync(deps: ResumeResyncDeps): void {
+  // "A resume is owed a resync." Raised when the document leaves, cleared by
+  // the resync, so overlapping triggers collapse to one and the next absence
+  // re-arms without a timer or a stamp.
+  let owed = false;
+
+  const resumed = (): void => {
+    if (!owed) return;
+    owed = false;
+    deps.resync();
+  };
+
+  // The bfcache pair, symmetric with the two visibility directions above and
+  // below: a departure raises the debt, a return settles it. Both pairs write
+  // ONE flag on purpose — a restore that also moved the visibility signal
+  // raises the same debt twice and pays it once, which is what keeps a resume
+  // that delivers three events from putting three requests on the wire.
+  //
+  // Registered rather than derived from `persisted`, because a document
+  // restored WITHOUT a visibility transition (the case this pair exists for)
+  // is invisible to the signal, and one restored WITH one must not resync
+  // twice. The departure the document itself observed answers both.
+  deps.win.addEventListener("pagehide", () => {
+    owed = true;
+  });
+  deps.win.addEventListener("pageshow", resumed);
+
+  createEffect(
+    on(deps.isVisible, (visible) => {
+      // The first run is the mount, where `visible` is true and nothing is
+      // owed — so boot resolves to a no-op without a `prev === undefined`
+      // special case.
+      if (visible) resumed();
+      else owed = true;
+    }),
+  );
+}

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -28,10 +28,12 @@ import { applyFontSizeFromStorage } from "./lib/fontSize";
 import { installGlobalPaste } from "./lib/globalPaste";
 import { HIDDEN_TICK_MS, installHiddenProbe } from "./lib/hiddenProbe";
 import { installKeyboardPreserve } from "./lib/keepKeyboard";
+import { refetchChannels, refetchNetworks } from "./lib/networks";
 import { applyIosClass, isStandalonePwa } from "./lib/platform";
 import { installPushResubscribe } from "./lib/pushResubscribe";
 import { applyDeepLinkFromUrl, installPushTargetListener } from "./lib/pushTarget";
 import { browserProbePerformance, installResumeProbe } from "./lib/resumeProbe";
+import { installResumeResync } from "./lib/resumeResync";
 import { applySharedFilesFromUrl } from "./lib/shareTargetDelivery";
 import { applySidebarWidthsFromStorage } from "./lib/sidebarWidths";
 import { notifyClientClosing, reportVisibility } from "./lib/socket";
@@ -323,6 +325,21 @@ moduleRoot(() => {
     now: () => performance.now(),
     raf: (cb) => void requestAnimationFrame(cb),
     perf: browserProbePerformance(),
+    win: window,
+  });
+  // #1873 — the THIRD refresh door onto the network/channel tree. The other
+  // two are the live `channels_changed` broadcast and `subscribe.ts`'s resync
+  // on a non-open → open socket edge; a process the OS froze walks through
+  // neither, so a channel joined on another device stayed invisible until a
+  // kill-and-reopen. Same resume seam as the two installers above — the
+  // visibility SSOT injected as a signal, no parallel listener — and the same
+  // pair the socket edge refetches, so the two doors cannot drift.
+  installResumeResync({
+    isVisible: isDocumentVisible,
+    resync: () => {
+      refetchNetworks();
+      refetchChannels();
+    },
     win: window,
   });
   // #1061 — background-burn instrument. The mirror image of the resume probe:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44004,3 +44004,109 @@ concludes anything from its absence.
 Left to vjt and deliberately untouched: whether FF115 ESR is a support target
 at all. If it is not, telling the operator so is a product decision and a
 different change; this entry only stops one absent API from being a blank page.
+<!-- entry #1873 -->
+
+---
+
+## 2026-08-30 — #1873: a frozen process observes no edge, so the resume IS the third door
+
+A channel joined on another device was missing from an Android PWA that had
+merely been RESUMED, and appeared only after a kill-and-reopen. `channelsBySlug`
+had exactly two refresh doors: the live `channels_changed` broadcast, and
+`subscribe.ts`'s defensive resync gated on the socket transitioning INTO
+`"open"` from a non-open state. A process the OS freezes walks through neither
+— the broadcast is fanned out best-effort with no live subscriber, and on
+resume there is no edge to observe — while a kill-and-reopen heals it because
+that is a real boot through `bootFetch`.
+
+### Why `socketHealth` cannot answer this, and what follows
+
+The obvious question is whether the socket really reads a stale `"open"` after
+a freeze, or whether it is torn down and the edge simply arrives late — the two
+lead to different cures. Measured structurally rather than assumed: the health
+signal has exactly four writers (`recordSocketOpen` / `recordSocketError` /
+`recordSocketClose` / `recordConnectAttempt`), wired ONLY to phoenix's
+`onOpen` / `onError` / `onClose` at `socket.ts:196-198`. Nothing polls and
+nothing probes, so **a suspended process cannot write it**: the state is a
+RECORD of the last callback and necessarily reads whatever it read when the
+process went under. It is not a liveness test, and `kickReconnect` already
+knows that — its guard is `s.isConnected()`, the live `readyState`, not this
+signal.
+
+So both regimes are real, and the resume door means something different in
+each:
+
+* **the socket survived the absence** — no callback fires, no edge ever
+  arrives, and the defensive resync NEVER runs. The resume door is the whole
+  cure.
+* **the socket died** — the tear is observed on the thaw (or forced by #254's
+  visibilitychange kick), the state leaves `"open"`, the reconnect lands and
+  the edge fires. The resume door is a FLOOR: it puts the HTTP fetch on the
+  wire immediately rather than after a WS round trip, and HTTP does not wait
+  for the socket.
+
+Which regime an actual Android freeze produces is NOT established here — there
+is no Android on the worker host and an OS freeze cannot be simulated. The
+design is deliberately correct in both rather than betting on one.
+
+### The seam already existed, and the answer was not "add a listener"
+
+`documentVisibility.ts` is the visibility SSOT (visibilitychange AND window
+focus/blur, one set of listeners) and two consumers already have exactly the
+shape this needed — `installStaleResumeReload` (#695/#674) and
+`installResumeProbe` (#697): the signal injected as a dependency, the bfcache
+seam taken separately, both mounted from `main.tsx`. A raw
+`document.addEventListener("visibilitychange")` inside `subscribe.ts` would
+have been a parallel registration of a signal that already exists — the thing
+#192 removed when it made presence read the SSOT instead of its own listener.
+So `lib/resumeResync.ts` is a third consumer of the same seam, not a fourth
+listener.
+
+### `pagehide` is what makes `pageshow` unambiguous
+
+The first cut gated `pageshow` on `PageTransitionEvent.persisted` to tell a
+restore from the initial load. Its own test killed it: a resume that delivers
+BOTH a visibility transition and a `pageshow` then resynced TWICE, because the
+`pageshow` arm manufactured a second resume after the first had been serviced.
+`persisted` separates boot from restore but says nothing about whether this
+restore was already handled.
+
+The fix is symmetry. A departure raises the debt (`pagehide`, or the
+visibility signal going false), a return settles it (`pageshow`, or the signal
+going true), and BOTH pairs write ONE flag — so a resume that delivers three
+events raises the same debt three times and pays it once. The initial load
+fires `pageshow` with no `pagehide` before it, so boot is a no-op by
+construction and the `persisted` flag is not needed at all. No timer, no
+threshold, no stamp: the coalescing is derived from the transition rather than
+tracked beside it, and it re-arms on the next absence rather than latching.
+
+### Measured and NOT fixed here: the resync pair fetches the channels twice
+
+`channelsBySlug` is a `createResource` keyed on `networks`, which is keyed on
+`user`. Counted on a bench with a mocked api layer: `refetchNetworks()` ALONE
+takes `listChannels` from 1 to 2 — the cascade already refetches the channels —
+and the socket-edge arm's pair (`refetchNetworks(); refetchChannels();`) takes
+it from 1 to 3. So every defensive resync issues **two** identical
+`GET /networks/:slug/channels` per network, one of them redundant, and the
+resume door inherits that because it deliberately calls the SAME pair rather
+than a second, drifting definition of "resync".
+
+Left as-is on purpose: dropping the explicit `refetchChannels()` would make
+both arms depend on a cascade that is one edit away from being invisible, and
+the two arms diverging is a worse failure than one extra GET. It is a
+pre-existing property of the reconnect path, not something this change
+introduced — but it is now on a trigger that fires on every resume, which is
+what makes it worth writing down. `api.ts:1806` says the `/me` request
+coalescing was NOT extended to `listChannels` because it has "no repeating
+unattended trigger": that premise is exactly what this change repeals.
+
+### What is not proven
+
+That an Android PWA freeze delivers these events at all, and that gmsrc's
+session was in either regime. There is no Android here, Playwright ships no
+Android PWA, and a synthetic `visibilitychange` is a synthetic
+`visibilitychange` — it proves the contract the resume path obeys once the
+platform delivers one, never that the platform delivers it. The known
+limitation `resumeProbe` records applies unchanged: a document thawed with
+neither a visibility transition nor a `pageshow` is not covered, because there
+is nothing to observe.


### PR DESCRIPTION
Follows the report in issue 1873.

## What was wrong

`channelsBySlug` had exactly two refresh doors: the live `channels_changed`
broadcast, and `subscribe.ts`'s defensive resync gated on the socket
transitioning INTO `"open"` from a non-open state. A process the OS freezes
walks through neither — the broadcast is fanned out best-effort with no live
subscriber, and on resume there is no edge to observe. A kill-and-reopen heals
it because that is a real boot through `bootFetch`.

## The crux, measured rather than assumed

The report asks whether `socketHealth()` reports a stale `"open"` after a
freeze or whether the socket is torn down and the edge simply arrives late,
because the two lead to different cures. Measured structurally: the signal has
exactly four writers (`recordSocketOpen` / `recordSocketError` /
`recordSocketClose` / `recordConnectAttempt`), wired ONLY to phoenix's
`onOpen` / `onError` / `onClose` at `socket.ts:196-198`. Nothing polls and
nothing probes, so a suspended process **cannot** write it: the state is a
RECORD of the last callback, never a liveness test. `kickReconnect` already
knows this — its guard is `s.isConnected()`, the live `readyState`.

Both regimes are therefore real, and this door means something different in
each:

* **socket survived the absence** — no callback fires, no edge ever arrives,
  the defensive resync NEVER runs. This door is the whole cure.
* **socket died** — the tear is observed on the thaw (or forced by #254's
  visibilitychange kick), the state leaves `"open"`, the reconnect lands and
  the edge fires. This door is a FLOOR: the HTTP fetch goes on the wire
  immediately instead of after a WS round trip, and HTTP does not wait for the
  socket.

Which regime a real Android freeze produces is NOT established — see below.
The design is correct in both rather than betting on one.

## Riding the existing seam, not adding a listener

`documentVisibility.ts` is the visibility SSOT (visibilitychange AND window
focus/blur, one set of listeners), and two consumers already have exactly this
shape: `installStaleResumeReload` (#695/#674) and `installResumeProbe` (#697)
take the signal as an injected dependency and are mounted from `main.tsx`. A
raw `document.addEventListener("visibilitychange")` inside `subscribe.ts`
would be a parallel registration of a signal that already exists — the thing
#192 removed when it made presence read the SSOT instead of its own listener.

So `lib/resumeResync.ts` is a third consumer of that seam. The verb it runs is
the same `refetchNetworks()` + `refetchChannels()` pair the socket-edge arm
runs, so the two doors cannot drift.

## The bfcache half is a PAIR, and the test is why

The first cut gated `pageshow` on `PageTransitionEvent.persisted`. Its own test
killed it: a resume delivering BOTH a visibility transition and a `pageshow`
resynced TWICE, because the `pageshow` arm manufactured a second resume after
the first was serviced. `persisted` separates boot from restore, but says
nothing about whether this restore was already handled.

The shape is now symmetric: a departure raises one debt flag (`pagehide`, or
the signal going false), a return settles it (`pageshow`, or the signal going
true). Three events for one resume raise the same debt three times and pay it
once. Boot fires `pageshow` with no `pagehide` before it, so it is a no-op by
construction and `persisted` is not needed at all. No timer, no threshold, no
stamp — the coalescing is derived from the transition, and re-arms on the next
absence rather than latching.

## Tests

Seven, in two arms. The first pins the contract against a hand-made signal
(no resync at boot or on the initial `pageshow`; one resync per resume; three
events for one resume collapse to one; the next resume resyncs again; a
bfcache restore whose visibility never moved is covered; going away and
staying away resyncs nothing). The second runs the module against the **real**
visibility SSOT driven by real DOM events, with a positive control that the
signal is actually wired before concluding anything from a zero.

They discriminate, and that was measured with two mutants rather than
asserted:

| mutant | result |
|---|---|
| visibility arm disarmed | 3 failed / 4 passed — including the real-SSOT arm |
| coalescing guard removed | 7 failed / 7 |

The pre-cure red is honest but weak on its own: the module did not exist, so
the suite failed to resolve the import (`Failed to resolve import
"../lib/resumeResync"`). The mutants above are the real evidence that a wrong
implementation is caught.

## Measured and deliberately NOT fixed here

`channelsBySlug` is a `createResource` keyed on `networks`. Counted on a bench
with a mocked api layer: `refetchNetworks()` **alone** takes `listChannels`
from 1 to 2 (the cascade already refetches the channels), and the socket-edge
arm's pair takes it from 1 to 3. So every defensive resync issues **two**
identical `GET /networks/:slug/channels` per network, one redundant, and this
door inherits it because it calls the same pair on purpose.

Left as-is: dropping the explicit `refetchChannels()` would make both arms
depend on a cascade one edit away from being invisible, and the arms diverging
is worse than one extra GET. It is pre-existing on the reconnect path — but it
now rides a trigger that fires on every resume, and it repeals the stated
premise at `api.ts:1806` for withholding request coalescing from
`listChannels` ("no repeating unattended trigger"). Worth its own issue; not
taken inside this slice.

## What this does NOT prove

**That an Android PWA freeze delivers these events at all**, or which regime
gmsrc's session was in. There is no Android on the worker host, Playwright
ships no Android PWA, and an OS freeze cannot be simulated. No e2e spec is
offered in its place: a synthetic `visibilitychange` proves the contract the
unit tests already prove, and nothing about the platform. The known limitation
`resumeProbe` records applies unchanged — a document thawed with neither a
visibility transition nor a `pageshow` is not covered, because there is
nothing to observe.

## Gates

- `scripts/bun.sh run check` — `rc=0`, 5 stages ran, 0 failed.
- `scripts/bun.sh run test` — `rc=0`, 328 files / 6557 tests passed (+1 file,
  +7 tests against the base).
- `scripts/design-notes-gate.sh` post-commit — `rc=0`, "1 new entry
  heading(s), separator and marker present".
- No server-side file is touched.