### PR TITLE
docs: name the two programs that answer to bin/grappa (issue 1875)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -229,15 +229,35 @@ login screen.
 ## Create your first user
 
 A fresh install has no accounts and connects to no networks until you say
-so.
+so. Which command you run depends on which of the two paths above you took —
+the from-source stack has Mix in it, the pre-built image does not.
+
+**From-source stack** (the clone-and-build path):
 
 ```sh
 docker compose -f compose.yaml run --rm grappa \
   mix grappa.create_user --name you --password 'change-me'
 ```
 
+**Pre-built image** (`get.sh` or `compose.release.yaml`). A release ships no
+Mix, so there is no `grappa.create_user` task to run; the image carries its own
+three-verb operator CLI as `bin/grappa` instead. The account name is
+**positional** — a flag in that slot is rejected, not taken as the name:
+
+```sh
+docker exec -it grappa bin/grappa create-user you --admin
+```
+
+`grappa` there is the container name (`GRAPPA_CONTAINER` overrides it).
+Omitting `--password` makes it prompt on the terminal, so the secret stays out
+of shell history — that is what the `-it` is for. On a `.deb` / AUR box the
+same program is just `sudo grappa create-user you --admin`. `bin/grappa help`
+lists the three verbs and their arguments.
+
 Then log in via the web UI. To connect the bouncer to an IRC network, see
-**"Bind a network"** in [README.md](README.md).
+**"Bind a network"** in [README.md](README.md) — it gives both forms, since
+the verbs differ too (`bind-network` from a checkout, `add-network` on a
+packaged release).
 
 ## A throwaway box for testing (staging)
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ Optional, opt-in, per-channel — and **never touches grappa or the IRC wire**: 
 
 ## Usage
 
-grappa runs as a single container against a sqlite DB. There is no config file — every `(user, network)` binding lives in the DB and is read by `Grappa.Bootstrap` at boot. The operator interface is `bin/grappa`:
+grappa runs as a single container against a sqlite DB. There is no config file — every `(user, network)` binding lives in the DB and is read by `Grappa.Bootstrap` at boot. The operator interface is `bin/grappa`.
+
+> **Two different programs answer to that name.** Check which one you have before copying a command below. A **source checkout** carries the repo-root `bin/grappa`, a docker-compose wrapper with the full verb table. A **packaged release** carries a much smaller one: `mix release` moves the generated boot script aside and installs the dispatcher from [`infra/release/grappa.sh`](infra/release/grappa.sh) in its place (the `install_operator_cli/1` step in `mix.exs`), so the ghcr.io image, the `.deb`, the AUR package and a bastille / systemd install all get the **release CLI**. A release ships no Mix, so every `grappa.*` mix task — most of the verbs below — is simply not there, and asking for one gets you the boot script's own `ERROR: Unknown command …`.
+
+**Source checkout** — run from the clone:
 
 ```sh
 bin/grappa help                # every verb (boot-time + live-state + debug)
@@ -116,7 +120,21 @@ bin/grappa list-visitors       # live-state verb (RPC into the running BEAM)
 bin/grappa remote-shell        # iex --remsh into the live node
 ```
 
-Boot-time verbs run as mix tasks in the container; live-state verbs attach to the running BEAM over Erlang distribution, so they introspect or mutate the actual supervised state (no second BEAM, no port collision). Developer scripts — gates, tests, shells — live in `scripts/*.sh`; how to run the test suites is documented in `docs/TESTING.md`; the full operator + deploy runbook is `docs/OPERATIONS.md`. The design of per-client derived outbound source addresses — written for the staff of networks a grappa instance connects to, rather than for developers — is `docs/DERIVED_SOURCE_ADDRESSES.md` (not yet implemented; #454, #543).
+Boot-time verbs run as mix tasks in the container; live-state verbs attach to the running BEAM over Erlang distribution, so they introspect or mutate the actual supervised state (no second BEAM, no port collision).
+
+**Packaged release** — three account verbs, plus whatever the release boot script already knew:
+
+```sh
+grappa help                                        # the three verbs and their arguments
+grappa create-user NAME [--admin] [--password PW]
+grappa add-network USER NETWORK --server HOST:PORT --nick NICK --auth METHOD [...]
+grappa remove-network USER NETWORK
+grappa start | daemon | eval | rpc | remote | stop | pid | version
+```
+
+How you reach that program depends on the substrate: `sudo grappa …` on a `.deb` / AUR box, `docker exec -it grappa bin/grappa …` against the container `infra/docker/deploy.sh` installs (named `grappa` unless `GRAPPA_CONTAINER` says otherwise), `.../rel/grappa/bin/grappa …` in a jail or under systemd. Anything outside the list above — `list-visitors`, `add-server`, `set-network-caps`, `seed-scrollback`, `remote-shell` … — has **no verb here**: live state is reachable through the release's own `rpc` / `remote` (`grappa rpc 'Grappa.Operator.list_visitors_text!()'` is the twin of `bin/grappa list-visitors`), and the per-network caps live in the admin console's **Networks** tab.
+
+Developer scripts — gates, tests, shells — live in `scripts/*.sh`; how to run the test suites is documented in `docs/TESTING.md`; the full operator + deploy runbook is `docs/OPERATIONS.md`. The design of per-client derived outbound source addresses — written for the staff of networks a grappa instance connects to, rather than for developers — is `docs/DERIVED_SOURCE_ADDRESSES.md` (not yet implemented; #454, #543).
 
 ### First deploy
 
@@ -145,6 +163,8 @@ On later deploys `scripts/deploy.sh` auto-detects hot-safe changes (running-modu
 
 ### Bind a network
 
+**From a source checkout** — three verbs, all flags named:
+
 ```sh
 bin/grappa create-user --name vjt --password "correct horse battery staple"
 bin/grappa add-server  --network azzurra --host irc.azzurra.chat --port 6697 --tls
@@ -153,9 +173,20 @@ bin/grappa bind-network --user vjt --network azzurra \
   --autojoin '#italia,#hacking'
 ```
 
-- `--auth`: `auto | sasl | server_pass | nickserv_identify | none`.
-- `--source <IPv4|IPv6>` (on `add-server`) pins a per-network fallback outbound IP; a per-subject vhost pin/selection (admin panel → Vhosts tab, #228) overrides it. The auto-rotation pool is DB-driven (curated `in_pool` vhosts), no env var.
-- `bin/grappa set-network-caps --network azzurra --max-visitor-sessions N --max-user-sessions N` sets independent visitor/user admission caps (omit for unlimited; visitor saturation never blocks operator login).
+**On a packaged release** — the same thing in two verbs, because `add-network` creates the network and the server itself. `create-user` takes the name **positionally** and rejects a flag in that slot (`create-user --name vjt` errors with *"create-user needs an account name, got the flag --name"*):
+
+```sh
+grappa create-user vjt --password "correct horse battery staple"
+grappa add-network vjt azzurra --server irc.azzurra.chat:6697 \
+  --nick vjt --password 'NICKSERV_PASS' --auth nickserv_identify \
+  --autojoin '#italia,#hacking'
+```
+
+- `--auth`: `auto | sasl | server_pass | nickserv_identify | none`, on both forms.
+- TLS: explicit `--tls` on the checkout's `add-server`; on `add-network` it **defaults to on for port 6697** and off otherwise, with `--tls` / `--no-tls` to override.
+- Omit `--password` on the release `create-user` and it prompts on the terminal, so the secret stays out of shell history — pass `-it` if you are going through `docker exec`.
+- `--source <IPv4|IPv6>` (on the checkout's `add-server`, or `--source` on the release's `add-network`) pins a per-network fallback outbound IP; a per-subject vhost pin/selection (admin panel → Vhosts tab, #228) overrides it. The auto-rotation pool is DB-driven (curated `in_pool` vhosts), no env var.
+- `bin/grappa set-network-caps --network azzurra --max-visitor-sessions N --max-user-sessions N` sets independent visitor/user admission caps (omit for unlimited; visitor saturation never blocks operator login). It is a mix task, so a packaged release has no such verb — set the caps from the admin console's **Networks** tab instead.
 
 Re-run `scripts/deploy.sh` and Bootstrap picks up the binding on boot — or attach via `remote-shell` and drive the spawn orchestrator directly for no downtime.
 
@@ -169,13 +200,18 @@ Operators get a multi-tab admin pane in cicchetto, gated on `User.is_admin` (RES
 - **Events** — real-time admin-event tail over the `grappa:admin:events` topic; **disk-backed** (#215) so it survives a restart.
 - **Session Log** — the persisted IRC session-lifecycle log (#215): connect / register / NickServ `+r` / disconnect (with reason + duration + clean-vs-error) / reconnect-backoff, per `(user|visitor, network)` session. Every lifecycle transition also lands as a greppable, structured Logger line (`session=<kind>:<uuid>:<network_id> event=disconnected reason=… duration_ms=… clean=…`), so a 2am `grep <nick>` of the server log finally explains a drop.
 
-The admin UI's Promote button needs an existing admin, so bootstrap the **first** admin with `--admin` on `create-user`:
+The admin UI's Promote button needs an existing admin, so bootstrap the **first** admin with `--admin` on `create-user` — in whichever of the two shapes your install has:
 
 ```sh
-bin/grappa create-user --name vjt --password '…' --admin
+bin/grappa create-user --name vjt --password '…' --admin   # source checkout
+grappa create-user vjt --admin                             # packaged release (prompts for the password)
 ```
 
-After that, promote/demote everyone else from the **Admin → Users** tab. (To promote an already-existing user from the shell: `bin/grappa remote-shell --batch -e 'Grappa.Accounts.get_user_by_name!("vjt") |> Grappa.Accounts.update_admin_flags(%{is_admin: true})'`.)
+After that, promote/demote everyone else from the **Admin → Users** tab. To promote an already-existing user from the shell, the expression is the same on both; only the way in differs — `bin/grappa remote-shell --batch -e '<expr>'` from a checkout, the release's own `rpc` on a packaged install:
+
+```sh
+grappa rpc 'Grappa.Accounts.get_user_by_name!("vjt") |> Grappa.Accounts.update_admin_flags(%{is_admin: true})'
+```
 
 ### Themes
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44110,3 +44110,58 @@ platform delivers one, never that the platform delivers it. The known
 limitation `resumeProbe` records applies unchanged: a document thawed with
 neither a visibility transition nor a `pageshow` is not covered, because there
 is nothing to observe.
+<!-- entry #1875 -->
+
+---
+
+## 2026-08-30 — #1875: the operator CLI splits on "packaged", not on "the image"
+
+A self-hoster on `ghcr.io/vjt/grappa:latest` followed the README's own
+recommended path and hit verbs that are not there. Two different programs
+answer to `bin/grappa` and the README named only one of them.
+
+### The axis is the release, not the container
+
+The issue framed it as image-vs-checkout. Measured, that is too narrow, and
+writing it that way would have shipped a second half-truth. `install_operator_cli/1`
+is a **`mix release` step** — `steps: [:assemble, &install_operator_cli/1, …]`
+in `mix.exs` — which renames the generated boot script to `bin/grappa-release`
+and `File.cp!`s `infra/release/grappa.sh` into its place. Nothing about that is
+Docker. `Dockerfile.release`'s only part in it is a `COPY` of the source file
+into the build context so the step can find it; the overwrite is the release
+assembly, and it therefore happens for the `.deb`, the AUR package, a bastille
+jail and a systemd install exactly as it does for the image — the four doors
+`grappa.sh`'s own moduledoc enumerates. The reader most exposed to the narrow
+framing is the one INSTALL.md's AWS one-click path serves, since that installs
+the `.deb`. So both documents say **packaged release**, never "the image", and
+name the per-substrate way in (`sudo grappa`, `docker exec … bin/grappa`,
+`…/rel/grappa/bin/grappa`) separately from the verb set.
+
+### Label in place, rather than a section per substrate
+
+The issue offered both. Labelled blocks with the equivalent alongside won
+because the surrounding operator prose is substrate-**neutral** — the `--auth`
+value set, the vhost/`--source` precedence, what a session cap means — and two
+sections would have duplicated all of it, giving one explanation two places to
+rot. The split is real only at the verb line, so that is the only place that
+forks: `bind-network` + `add-server` + `create-user --name` on a checkout,
+`add-network` + positional `create-user` on a release, with the caps verb
+declared absent (it is a mix task; the admin console's Networks tab is the
+answer there) rather than quietly dropped.
+
+### Two of the report's citations did not survive
+
+Neither changes the conclusion, and both would have misled the next reader.
+The `@usage` block said to be liftable from `infra/release/grappa.sh` is not
+in that file — it has no heredoc at all; the usage text is `@usage` in
+`lib/grappa/release/cli.ex`, reached because the shell dispatcher rewrites
+`help` into the `eval` that calls `Grappa.Release.cli/1`. And `Dockerfile.release`
+does not overwrite the boot script, per the paragraph above.
+
+### Left alone deliberately
+
+`infra/docker/deploy.sh`'s release-mode install banner prints the web UI, the
+env file, the volume and the update/stop verbs, and never says how to make an
+account — the source-mode banner is the only one carrying that hint. That is
+plausibly where the reporter ran out of road, but it is code and this is a
+docs change, so it is recorded here and not touched.


### PR DESCRIPTION
Docs-only. Addresses issue 1875.

## The problem

`README.md` documented one `bin/grappa`. Two different programs answer to that name, and a self-hoster who follows the path README itself recommends lands on the one where most of the documented verbs do not exist.

## What changed

- **`README.md` — "Usage"**: states the split up front, then gives the verb list twice, labelled: **source checkout** (the existing block, unchanged) and **packaged release** (the three account verbs plus the boot script's own `start | daemon | eval | rpc | remote | stop | pid | version`). Names how you reach the second per substrate, and says explicitly that `list-visitors` / `add-server` / `set-network-caps` / `remote-shell` have no verb there, with the replacements (`rpc` / `remote`, and the admin console's Networks tab for caps).
- **`README.md` — "Bind a network"**: the checkout's three verbs kept, the release's two added alongside (`add-network` creates the network and the server itself). Bullets note the positional `create-user`, the TLS default difference, and the terminal password prompt.
- **`README.md` — first admin + promote-from-shell**: both forms; the promote expression is identical on the two, only the way in differs (`remote-shell --batch -e` vs `rpc`).
- **`INSTALL.md` — "Create your first user"**: it never said `bin/grappa`, but it gave only the `compose.yaml` + `mix` recipe immediately after selling the pre-built-image path, and then sent the reader to README's checkout-only "Bind a network". Second recipe added; the cross-reference now says both forms exist.
- **`docs/DESIGN_NOTES.md`**: one entry, for the axis decision below.

## Two claims in the issue that did not survive verification

Neither changes the conclusion; both would mislead the next reader.

1. *"`infra/release/grappa.sh`'s own `@usage` block … can be lifted verbatim."* — that file has **no** `@usage` and no heredoc at all. The usage text is the `@usage` attribute in `lib/grappa/release/cli.ex`, reached because the shell dispatcher rewrites `help` into the `eval` that calls `Grappa.Release.cli/1`.
2. *"`File.cp!`'d over the release boot script (`Dockerfile.release:104` …)"* — `Dockerfile.release`'s line there is a `COPY` of the source file **into the build context** so the release step can find it. The overwrite is `install_operator_cli/1` in `mix.exs`, registered as a `mix release` step.

## The axis is wider than the issue framed it

The issue says "release image". Because the overwrite is a **release step** and not a Docker layer, the `.deb`, the AUR package, a bastille jail and a systemd install all ship the same dispatcher — the four doors `grappa.sh`'s own moduledoc enumerates. Documenting the fix as "on the image" would have written the next half-truth, aimed squarely at the reader `INSTALL.md`'s AWS one-click path serves, since that installs the `.deb`. Both files therefore say **packaged release** throughout.

## Structure choice

Labelled blocks with the equivalent alongside, not a section per substrate: the surrounding operator prose (the `--auth` value set, the `--source` precedence, what a session cap means) is substrate-neutral, and two sections would duplicate it and give one explanation two places to rot. Only the verb line genuinely forks, so only it does.

## Verification

Every verb written was checked against the program that owns it — the `VERBS` table in `bin/grappa` for the checkout; the dispatcher `case` in `infra/release/grappa.sh` plus the `@usage` in `lib/grappa/release/cli.ex` for the release. No verb is invented. `set-network-caps` is declared **absent** on a release rather than silently dropped, because it is a mix task.

## Gates

- `scripts/design-notes-gate.sh`, post-commit: `rc=0`, `1 new entry heading(s), separator and marker present` — a counted green, not "nothing to check". Boundary shape read byte-level on the file (marker as first appended line, no blank before it).
- Not run, and why: no `.ex`/`.exs`/`mix.*` touched and nothing under `test/` or `scripts/` reads `README.md` / `INSTALL.md` (measured: 0 hits, positive control 230 files matching `grappa` in the same trees), so `scripts/check.sh` has no surface here; nothing under `cicchetto/`, so the bun gates have none; `integration.yml` is path-filtered and a docs change does not match it; no shell script or workflow touched, and the bats corpus lives under `test/`, covered by the same measurement.

## Noted, not touched

`infra/docker/deploy.sh`'s **release-mode** install banner prints the web UI, env file, volume and update/stop verbs, and never says how to create an account — only the source-mode banner carries that hint. That is plausibly where the reporter ran out of road. It is code, not a doc, so it is recorded in the DESIGN_NOTES entry and left alone.