### PR TITLE
cic: name what each boot-failure recovery button restarts (#1877)

### DIFF
--- a/cicchetto/src/BootErrorBoundary.tsx
+++ b/cicchetto/src/BootErrorBoundary.tsx
@@ -61,13 +61,32 @@ const BootFailure: Component<{ error: unknown; onRetry: () => void }> = (props) 
         Could not load Grappa.
       </p>
       <p class="boot-failure-detail">{failureText(props.error)}</p>
+      {/* #1877 — THE LABEL NAMES WHAT IT RESTARTS. "Retry" and "Reload" both
+            read as "try again" to anyone who has not read this file, and a
+            self-hoster who hit this screen on iOS reported not knowing which to
+            press. The two are not interchangeable: this one is three fetches
+            with the bundle untouched (press it when the network came back), the
+            one below throws the running app away (press it when the app itself
+            is suspect). So each label names its OBJECT — the load, or the app.
+
+            The distinction goes in the LABEL and not in a line of copy under
+            each button, which the issue offers as the alternative. Two reasons.
+            The screen is deliberately bare (see the header) and the label costs
+            no new element; and the accessible name is what the reporter's
+            VoiceOver reads out when it lands on the control, whereas a sibling
+            paragraph is announced separately or not at all unless it is wired
+            through `aria-describedby` — machinery for a hint that would still
+            leave the button itself saying "try again". The situational advice
+            such a line would carry ("if the network just came back") is instead
+            in the ORDER: primary first, the muted fallback second (the
+            `.boot-failure-reload` rule in themes/default.css). */}
       <button
         type="button"
         class="boot-failure-retry"
         data-testid="boot-failure-retry"
         onClick={() => props.onRetry()}
       >
-        Retry
+        Retry loading
       </button>
       {/* The escape hatch of last resort. The boundary wraps Shell for the
             whole session, so it also catches throws with nothing to do with the
@@ -122,10 +141,16 @@ const BootFailure: Component<{ error: unknown; onRetry: () => void }> = (props) 
           window.location.reload();
         }}
       >
-        {/* `performRefresh` can take up to ~2s waiting on controllerchange.
+        {/* "Restart app", not "Reload" (#1877): the sibling above retries the
+              LOAD, this one throws the running app away — either onto a fresh
+              bundle or onto the same one. Both branches restart it, so the
+              label is honest for both, and it shares no word with "Retry
+              loading" for the reader who is scanning rather than reading.
+
+              `performRefresh` can take up to ~2s waiting on controllerchange.
               On a dead-boot screen a button that appears to do nothing is
               exactly what sends the user back to force-killing the app. */}
-        {reloading() ? "Reloading…" : "Reload"}
+        {reloading() ? "Restarting…" : "Restart app"}
       </button>
     </div>
   );

--- a/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
+++ b/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
@@ -151,6 +151,26 @@ describe("BootErrorBoundary (#717 — a failed boot must not freeze on the splas
     expect(screen.queryByTestId("crt-splash")).toBeNull();
   });
 
+  // #1877 — the two buttons ARE the recovery ladder, and "Retry"/"Reload" both
+  // read as "try again" to anyone who has not read the source. The names must
+  // say WHICH THING each one restarts: the load (three fetches, no navigation)
+  // or the app (a bundle refresh or a page reload). Asserted as the ACCESSIBLE
+  // name rather than the text node because that is what the reporter's iOS
+  // VoiceOver reads out, and it is the property a hint paragraph parked under
+  // the button would NOT have changed.
+  it("names what each recovery button restarts, so the two are not both 'try again'", async () => {
+    localStorage.setItem("grappa-token", "tokA");
+    const api = await import("../lib/api");
+    const pending = deferredMe(api);
+
+    await renderBootTree();
+    pending.reject(new Error("network down"));
+    await screen.findByTestId("boot-failure");
+
+    expect(screen.getByTestId("boot-failure-retry")).toHaveAccessibleName("Retry loading");
+    expect(screen.getByTestId("boot-failure-reload")).toHaveAccessibleName("Restart app");
+  });
+
   it("leaves a healthy boot untouched", async () => {
     localStorage.setItem("grappa-token", "tokA");
     const api = await import("../lib/api");
@@ -307,6 +327,11 @@ describe("BootErrorBoundary reload — purge needs proof the server answers", ()
 
     expect(performRefresh).toHaveBeenCalledTimes(1);
     expect(reloadSpy).not.toHaveBeenCalled();
+
+    // #1877 — the in-flight label is part of the same naming: this branch is
+    // the one that can sit for ~2s waiting on `controllerchange`, so the button
+    // must say it is restarting rather than keep offering the restart.
+    expect(screen.getByTestId("boot-failure-reload")).toHaveAccessibleName("Restarting…");
   });
 
   // Both conditions are required: a status came back earlier, but the link has

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -12163,8 +12163,9 @@ button.topic-bar-windows-opener {
   cursor: pointer;
 }
 
-/* Reload is the fallback-of-the-fallback, not the primary action — muted so
-   Retry reads as the thing to try first. */
+/* The restart is the fallback-of-the-fallback, not the primary action — muted
+   so the retry above reads as the thing to try first. Named by ROLE, not by
+   label: the two labels were renamed once already (#1877). */
 .boot-failure-reload {
   border-color: var(--muted);
   color: var(--muted);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44262,3 +44262,60 @@ inside the gate together, nothing selection-related may remain on
 scrollback `user-select: text` outside the latch. That last one is the
 defect itself stated as a rule. `hoverGatedBlocks` was generalised to
 `mediaGatedBlocks` rather than copied.
+<!-- entry #1877 -->
+
+---
+
+## 2026-08-30 — #1877: the boot-failure buttons name what they restart, and that copy cannot live in the #411 SSOT
+
+`BootErrorBoundary`'s recovery screen (#717) offered `Retry` and `Reload`.
+The two do genuinely different things — `Retry` is three fetches with the
+bundle untouched (`refetchUser` / `refetchNetworks` / `refetchChannels`, then
+`reset()`), `Reload` throws the running app away, onto a fresh bundle via
+`requestBundleRefreshNow("user")` when an `ApiError` proves the server
+answered and onto the same one otherwise — but both words read as "try again"
+to anyone who has not read the file. A self-hoster who hit the screen on iOS
+reported not knowing which to press.
+
+They are now `Retry loading` and `Restart app` (`Restarting…` in flight).
+Each names its OBJECT: the load, or the app. Neither shares a word with the
+other, which is what a scanning reader gets, and `Restart app` is honest for
+both of the reload branches because both of them do restart it.
+
+**The distinction goes in the LABEL, not in a line of copy under each
+button.** The issue offered either shape. Two reasons for this one. The
+screen is deliberately bare — it is a recovery affordance and #687 owns the
+staged boot log, so every element added here is a step toward the second
+screen that issue exists to avoid, and a label costs none. And the ACCESSIBLE
+NAME is what the reporter's platform reads out when focus lands on the
+control: a sibling paragraph is announced separately or not at all unless it
+is wired through `aria-describedby`, which is machinery bought to leave the
+button itself still saying "try again". The situational advice such a line
+would have carried ("press this one if the network came back") is in the
+ORDER instead — primary first, the muted fallback second, which the
+`.boot-failure-reload` rule already encodes. That rule's comment now names the
+two by ROLE rather than by label, since the labels have been renamed once and
+a comment citing a string is the thing that rots.
+
+**It does NOT go through `friendlyApiError`, and the issue's suggestion that
+it should is the one thing here that was measured and declined.** That
+module's contract is `friendlyApiError(err: ApiError): string` — a switch over
+`ErrorTokensRestErrorToken`, the GENERATED closed union of the server's REST
+error tokens, with `assertNever` in the default arm making exhaustiveness a
+`tsc` failure. A button label has no wire token to key on, so hosting it there
+means a second, un-keyed export inside a module whose entire point is
+token → copy totality. The strings stay where `Could not load Grappa.`
+already lives: inline in the component that renders them.
+`lib/homeSessionCopy.ts` is the precedent for extracting cic copy into a
+module, and it earns that by being a pure function over server-supplied data
+with a test of its own — two static labels are neither.
+
+**Coverage.** Pinned in `BootErrorBoundary.test.tsx` as the accessible name
+of each button, which is the property under repair, and separately for the
+in-flight label on the `ApiError`-purge branch — the one that can sit for ~2 s
+waiting on `controllerchange`, and previously had no assertion on its text at
+all. No e2e spec asserts anything on this screen: `grep` over
+`cicchetto/e2e/` finds no `boot-failure` testid, no `Could not load Grappa.`,
+and every `Retry`/`Reload` hit in the suite is prose in a comment about a page
+reload. Nothing was updated there because there is nothing there, and a
+Playwright spec was not fabricated for a copy change.


### PR DESCRIPTION
## The defect

The #717 boot-failure screen offers two buttons that do genuinely different
things — `Retry` refetches the three boot resources with the bundle untouched,
`Reload` throws the running app away (a service-worker bundle refresh when an
`ApiError` proves the server answered, a bare `location.reload()` otherwise) —
and both words read as "try again" to anyone who has not read the source. A
self-hoster who hit the screen on iOS reported not knowing which to press.

## The form I chose, and why

The issue offers two shapes: **a line of copy under each button**, or **more
specific labels**. I chose **labels**.

🔴 **This changes user-visible button text**, so stating it plainly:

| before | after |
| --- | --- |
| `Retry` | `Retry loading` |
| `Reload` | `Restart app` |
| `Reloading…` (in flight) | `Restarting…` |

Each label names its OBJECT — the load, or the app — and the two share no word,
which is what a scanning reader gets. `Restart app` is honest for both reload
branches, since both of them restart it.

Why labels and not a hint line:

1. **The screen is deliberately bare.** #687 owns the staged boot log, and a
   second explanatory layer is exactly what that issue exists to avoid. A label
   costs no new element; two hint paragraphs do.
2. **The accessible name is what the reporter's platform speaks** when focus
   lands on the control. A sibling paragraph is announced separately or not at
   all unless wired through `aria-describedby` — machinery bought to leave the
   button itself still saying "try again". The bug was reported from an iOS
   PWA; that is the property under repair.

The situational advice a hint line would have carried ("press this one if the
network came back") is in the ORDER instead: primary first, muted fallback
second, which the `.boot-failure-reload` rule already encodes.

## Declined: the strings do not go in `friendlyApiError`

The issue names the #411 SSOT as the home for this copy. Measured, it cannot
be: that module's contract is `friendlyApiError(err: ApiError): string`, a
switch over `ErrorTokensRestErrorToken` — the GENERATED closed union of the
server's REST error tokens, with `assertNever` in the default arm making
exhaustiveness a `tsc` failure. A static button label has no wire token to key
on, so hosting it there means an un-keyed second export inside a module whose
entire point is token → copy totality. The labels stay inline next to
`Could not load Grappa.`, where the screen's other copy already lives.
`lib/homeSessionCopy.ts` is the precedent for extracting cic copy into a
module, and it earns one by being a pure function over server-supplied data
with its own test — two static labels are neither.

## Coverage

TDD, RED first: both new assertions failed against the old labels for the
right reason (`Expected "Retry loading" / Received "Retry"`,
`Expected "Restarting…" / Received "Reloading…"`), then green.

- `BootErrorBoundary.test.tsx` pins the **accessible name** of each button —
  the property under repair, and the one a hint paragraph would NOT have
  changed.
- It also pins the **in-flight label** on the `ApiError`-purge branch, which is
  the branch that can sit ~2 s waiting on `controllerchange` and had no
  assertion on its text before this.

**e2e: nothing to update, and nothing fabricated.** `grep` over
`cicchetto/e2e/` finds no `boot-failure` testid (rc=1), no
`Could not load Grappa.` (rc=1), and every `Retry`/`Reload` hit in the suite is
prose in a comment about a page reload — verified with a positive control so a
dead grep could not report "clean". No spec asserts anything on this screen. I
did not write a Playwright spec for a copy change; say the word if you want one.

## Gates (cic-only — no COMPILE lane, no STACK lane)

| gate | rc |
| --- | --- |
| `scripts/bun.sh run check` | **0** — 5 stages, 0 failed (lock drift, test location, biome src+e2e, tsc src, tsc e2e) |
| `scripts/bun.sh run test` | **0** — 329 files, 6568 tests passed |

`scripts/bun.sh install --frozen-lockfile` was run first: the cloned
`node_modules` was stale by 20 packages, so the pre-reconcile tree was not the
tree under test.

## DESIGN_NOTES

One entry, marker `<!-- entry #1877 -->` verified absent from the CURRENT
`origin/main` tip (281 markers there, none mine).
`scripts/design-notes-gate.sh origin/main` post-commit prints
`1 new entry heading(s), separator and marker present.`

`scripts/union-rebase.sh` reports `+57 -0 — contribution intact`, but it says
itself that the branch was already on top of `origin/main`, so **the union
driver never ran and that comparison is vacuous by construction**. What IS
measured: `origin/main`'s `DESIGN_NOTES.md` is a strict byte PREFIX of this
branch's (first 2603947 bytes identical, `cmp` rc=0), the remaining 3555 bytes
are exactly the new entry, and the boundary shape on the real file reads
`…rather than copied.` / marker / blank / `---` / blank / `## `. Both `cmp`
checks were paired with a perturbation control that made them fail.