### PR TITLE
e2e: run the whole mobile suite on chromium-mobile too (issue 1878)

### DIFF
--- a/cicchetto/e2e/playwright.config.ts
+++ b/cicchetto/e2e/playwright.config.ts
@@ -2,8 +2,35 @@ import { defineConfig, devices } from "@playwright/test";
 
 // Grappa e2e Playwright config.
 //
-// Default browser project: chromium. iOS-shaped specs (M3, M6, BUG7)
-// opt in to webkit + iPhone 15 device via the @webkit tag.
+// TAG VOCABULARY — ONE TAG IS ONE PROJECT OPT-IN (issue 1878):
+//
+//     @webkit  -> also runs on `webkit-iphone-15`
+//     @touch   -> also runs on `chromium-pixel-touch`
+//     both     -> runs on BOTH
+//     neither  -> runs on `chromium`, the desktop default
+//
+// The two tags are ORTHOGONAL, not a partition. A mobile behaviour that has
+// to hold on two engines carries BOTH, which is what issue 1878 did to the
+// mobile suite: every `@webkit` entry that is not iOS-bound gained `@touch`
+// alongside it rather than in place of it. Read a tag as "which project",
+// never as "which platform the behaviour is about" — a spec keeps its
+// `@webkit` when it gains `@touch`, so `--grep @webkit` still collects
+// exactly what it collected before, and the eight iOS-bound entries that
+// hold `@webkit` alone (six assert `html.is-ios` is PRESENT and read the
+// cascade hanging off it, two ride `navigator.standalone`) are the only
+// ones the widening skipped. Their Android twins are separate test code,
+// not a retag.
+//
+// 🔴 Why ORTHOGONAL and not "@touch means mobile, on both projects", which
+// is what issue 1878 proposed: `@touch` already existed, meaning
+// chromium-only, and two specs rely on that. Widening
+// `webkit-iphone-15` to `grep: /@webkit|@touch/` would drag
+// `issue1869-android-longpress-selection.spec.ts` onto WebKit, where its
+// `expect(standing?.isIos).toBe(false)` is false by construction — a RED,
+// not a vacuous green — and would drag `issue1831-tap-send-modal-survives`
+// onto the one engine its own header forbids in capitals, having measured
+// that the pre-cure code passes there. Orthogonal tags need no such
+// exception, and cost no config change at all.
 //
 // Base URL is wired via E2E_BASE_URL — set on the playwright-runner
 // container in cicchetto/e2e/compose.yaml. Local-host runs need to
@@ -68,10 +95,15 @@ export default defineConfig({
           args: ["--ignore-certificate-errors"],
         },
       },
-      // Mirror of webkit-iphone-15's grep — only specs WITHOUT
-      // `@webkit` run on the desktop project. Without this gate,
-      // `@webkit`-tagged specs (BUG7 + variants) attempt `tap()` on a
-      // non-touch context and throw "The page does not support tap".
+      // The complement of the two touch projects' greps: a spec that has
+      // opted into either of them does NOT also run here. Without this
+      // gate a touch-tagged spec attempts `tap()` on a non-touch context
+      // and throws "The page does not support tap".
+      //
+      // It must name EVERY touch project's tag, so a fourth project means
+      // an edit here as well — that coupling is the price of the desktop
+      // project being defined by subtraction, and it is deliberate: the
+      // alternative is tagging ~650 desktop entries.
       grepInvert: /@webkit|@touch/,
     },
     {
@@ -87,8 +119,28 @@ export default defineConfig({
       // Also the closer engine family to the reported device (Android), though
       // that device runs Gecko and this is Blink — see the spec header.
       //
-      // `grep: /@touch/` keeps it to the specs that need it; without that it
-      // would re-run the whole suite on a third project.
+      // `grep: /@touch/` collects the MOBILE suite, never the whole suite.
+      // Issue 1878 widened what that means — from the handful of specs that
+      // needed a synthesised click to every mobile entry that is not
+      // iOS-bound — because a mobile spec running on one engine says "you
+      // did not break Safari", not "the mobile UI works". #1869 (a long-press
+      // opening two menus on Android) is the shape of bug the old partition
+      // left uncovered: the behaviour was gated on `html.is-ios`, which
+      // simply is not there off Safari.
+      //
+      // The device stays `Pixel 7` rather than the `Pixel 5` issue 1878
+      // names. Both are chromium with `isMobile` + `hasTouch`; churning it
+      // would re-measure every geometry assertion to buy nothing.
+      //
+      // 🔴 WHAT THIS PROJECT IS NOT, now that it carries the mobile suite and
+      // the overclaim gets cheap: a Pixel device descriptor is CHROMIUM with
+      // `isMobile` + `hasTouch`. It is not an Android WebView, and it is not
+      // Firefox Android. It covers the #1869 family — behaviour gated on
+      // `html.is-ios`, which silently vanishes off Safari. It would NOT have
+      // caught #717, where Firefox Android hung on the splash of an installed
+      // PWA, because Playwright's firefox has no touch emulation and Gecko is
+      // not reachable from this harness at all. "Runs on chromium-mobile" is
+      // the claim; "Android coverage" is not.
       name: "chromium-pixel-touch",
       use: {
         ...devices["Pixel 7"],

--- a/cicchetto/e2e/reporters/coldStartLedger.ts
+++ b/cicchetto/e2e/reporters/coldStartLedger.ts
@@ -4,7 +4,7 @@
 //
 // ## What lies, and why documenting it would not have been enough
 //
-// The suite runs `workers: 1`, `fullyParallel: false`, two projects. Exactly
+// The suite runs `workers: 1`, `fullyParallel: false`, three projects. Exactly
 // one test per worker pays the browser launch; every later test in that
 // worker runs against an already-running browser. So "did this test pay the
 // cold start?" is an INPUT to the test — decided by filename sort order plus

--- a/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
@@ -54,7 +54,7 @@ const MESSAGE_BODY = `BUG7-ios: own-msg visibility @ ${crypto.randomUUID().slice
 // in lockstep by hand — same as issue168 / issue580).
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 
-test("@webkit BUG7 — own message visible in scrollback after iOS-shaped compose-send", async ({
+test("@webkit @touch BUG7 — own message visible in scrollback after iOS-shaped compose-send", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
@@ -37,7 +37,7 @@ const MESSAGE_BODY = `BUG7-M6-ios: DM own-msg @ ${crypto.randomUUID().slice(0, 8
 // in lockstep by hand — same as issue168 / issue580).
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 
-test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input", async ({
+test("@webkit @touch BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/bughunt-1-b-archive-mobile-seed.spec.ts
+++ b/cicchetto/e2e/tests/bughunt-1-b-archive-mobile-seed.spec.ts
@@ -42,7 +42,9 @@ test.afterEach(async () => {
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL);
 });
 
-test("@webkit BUGHUNT-1 B — mobile rail archive shows the row on expand", async ({ page }) => {
+test("@webkit @touch BUGHUNT-1 B — mobile rail archive shows the row on expand", async ({
+  page,
+}) => {
   const vjt = specUser();
   await loginAs(page, vjt);
 

--- a/cicchetto/e2e/tests/ios-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ios-z-cluster-journey.spec.ts
@@ -60,7 +60,9 @@ test.afterEach(async () => {
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
 });
 
-test("@webkit iOS-Z cluster — viewport + safe-area + close× + font-size", async ({ page }) => {
+test("@webkit @touch iOS-Z cluster — viewport + safe-area + close× + font-size", async ({
+  page,
+}) => {
   const vjt = specUser();
   await loginAs(page, vjt);
 

--- a/cicchetto/e2e/tests/issue1039-hamburger-corner.spec.ts
+++ b/cicchetto/e2e/tests/issue1039-hamburger-corner.spec.ts
@@ -73,7 +73,7 @@ async function boxOf(locator: Locator, what: string): Promise<Box> {
 
 test.setTimeout(120_000);
 
-test("@webkit #1039 — the ☰ occupies the same rectangle on a channel and on a query window", async ({
+test("@webkit @touch #1039 — the ☰ occupies the same rectangle on a channel and on a query window", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
+++ b/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
@@ -129,7 +129,9 @@ test("#1040 — a channel window keeps #500's collapsed launcher, floating above
 // containment assert would be measuring the slide as much as the layout. The
 // flow-vs-popover shape is pinned on the desktop test above; what is
 // form-factor-specific is that the drawer opens straight onto the actions.
-test("@webkit #1040 — the mobile rail drawer opens straight onto the actions", async ({ page }) => {
+test("@webkit @touch #1040 — the mobile rail drawer opens straight onto the actions", async ({
+  page,
+}) => {
   const vjt = specUser();
   await loginAs(page, vjt);
   await expect(page.locator(".home-pane")).toBeVisible({ timeout: 15_000 });

--- a/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
@@ -106,7 +106,7 @@ async function reportCorner(
 
 test.setTimeout(90_000);
 
-test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ actually closes the directory", async ({
+test("@webkit @touch #1050 — the /list window drops the floating ☰, and its ✕ actually closes the directory", async ({
   page,
 }, testInfo) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
@@ -164,7 +164,7 @@ async function assertCardCloseWinsItsCorner(page: PWPage): Promise<void> {
   }
 }
 
-test("@webkit #1051 — with no background theme the card's ✕ is the topmost element at its own coordinates", async ({
+test("@webkit @touch #1051 — with no background theme the card's ✕ is the topmost element at its own coordinates", async ({
   page,
 }) => {
   await loginAs(page, specUser());
@@ -177,7 +177,7 @@ test("@webkit #1051 — with no background theme the card's ✕ is the topmost e
   await assertCardCloseWinsItsCorner(page);
 });
 
-test("@webkit #1051 — with a background theme active the card's ✕ still wins its own corner", async ({
+test("@webkit @touch #1051 — with a background theme active the card's ✕ still wins its own corner", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -216,7 +216,7 @@ test("@webkit #1051 — with a background theme active the card's ✕ still wins
 // also swaps declares exactly the 27 colour vars the custom payload overrides,
 // so the flip is inert on everything except the layer under test; PHASE A
 // measures that rather than asserting it.
-test("@webkit #1051 — the wallpaper still paints, and still paints behind the conversation", async ({
+test("@webkit @touch #1051 — the wallpaper still paints, and still paints behind the conversation", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
+++ b/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
@@ -92,7 +92,7 @@ test("#1073 the admin bar carries live stats, on one line, in the shared band", 
   await expect(pane.locator(".topic-bar [data-testid$='-refresh']")).toHaveCount(0);
 });
 
-test("#1073 @webkit on a phone the stats keep the ☰ at the far end", async ({ page }) => {
+test("#1073 @webkit @touch on a phone the stats keep the ☰ at the far end", async ({ page }) => {
   await adminLogin(page, getSeededAdmin());
   const pane = await openAdminConsole(page);
 

--- a/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
+++ b/cicchetto/e2e/tests/issue1157-admin-actions-collapse.spec.ts
@@ -48,7 +48,7 @@ async function userRowKey(page: Page): Promise<string> {
   return testId.replace("admin-session-row-", "");
 }
 
-test("#1157 @webkit a phone gives the row's verbs one control, and it is the menu", async ({
+test("#1157 @webkit @touch a phone gives the row's verbs one control, and it is the menu", async ({
   page,
 }) => {
   await adminLogin(page, getSeededAdmin());
@@ -66,7 +66,7 @@ test("#1157 @webkit a phone gives the row's verbs one control, and it is the men
   await expect(page.getByTestId(`admin-session-terminate-${key}`)).toHaveCount(0);
 });
 
-test("#1157 @webkit the dropdown arms a verb rather than running it", async ({ page }) => {
+test("#1157 @webkit @touch the dropdown arms a verb rather than running it", async ({ page }) => {
   await adminLogin(page, getSeededAdmin());
   await openAdminSessionsTab(page);
   const key = await userRowKey(page);

--- a/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
+++ b/cicchetto/e2e/tests/issue1223-admin-card-affordances.spec.ts
@@ -92,6 +92,20 @@ async function boxOf(locator: Locator, what: string): Promise<Box> {
   return box;
 }
 
+// 🔴 NO `@touch`, and UNLIKE its three siblings in this file — this is the one
+// entry issue 1878 could not port and could not explain. MEASURED on
+// `chromium-pixel-touch`: `touchscreen.tap(383, 413.66)` on the 412x839
+// viewport, aimed at the heading's dead space exactly as below, comes back
+// with the `confirmDetach` modal ("Switch account") open and NO
+// `admin-session-detail-*` in the DOM at all. Green on `webkit-iphone-15`,
+// where the same coordinates open the row.
+//
+// The mechanism is NOT established and is deliberately not guessed at here.
+// It has the SHAPE of the #1831 class — chromium's tap synthesises the compat
+// mouse events and hit-tests the click against the layout as it stands at
+// RELEASE, which webkit never produces at all — but that was not measured for
+// this spec. If it is that, the red is a product defect on Android and not a
+// harness one, so the tag is withheld rather than the spec weakened.
 test("#1223 @webkit on a phone the whole card heading opens the row, not just the nick", async ({
   page,
 }) => {
@@ -205,7 +219,7 @@ test("#1223 on a wide panel the facts stay two columns", async ({ page }) => {
 // panel — rather than a check that a particular selector is hidden: that is
 // the property vjt read off the screen, and it survives the next tab growing
 // a column.
-test("#1223 @webkit on a phone no field is on the card and in the panel at once", async ({
+test("#1223 @webkit @touch on a phone no field is on the card and in the panel at once", async ({
   page,
 }) => {
   const admin = getSeededAdmin();
@@ -255,7 +269,7 @@ test("#1223 @webkit on a phone no field is on the card and in the panel at once"
 // answers "is it big enough", which invites a threshold argument, while vjt
 // reported empty space at the edges and the honest claim is that there is
 // none of it.
-test("#1223 @webkit on a phone the detail panel spans its table, with no gutters", async ({
+test("#1223 @webkit @touch on a phone the detail panel spans its table, with no gutters", async ({
   page,
 }) => {
   const admin = getSeededAdmin();
@@ -319,7 +333,7 @@ test("#1223 @webkit on a phone the detail panel spans its table, with no gutters
 // so a token on two lines reports two distinct `top`s. Pseudo-elements are
 // not in the DOM and cannot be ranged, which is exactly right here: the
 // label track is not part of the value.
-test("#1223 @webkit on a phone no panel value is broken mid-token", async ({ page }) => {
+test("#1223 @webkit @touch on a phone no panel value is broken mid-token", async ({ page }) => {
   const admin = getSeededAdmin();
   const visitor = await mintVisitor(`token1223-${Date.now()}`);
 

--- a/cicchetto/e2e/tests/issue1228-settings-drawer-phone-overflow.spec.ts
+++ b/cicchetto/e2e/tests/issue1228-settings-drawer-phone-overflow.spec.ts
@@ -171,7 +171,7 @@ async function measure(page: Page): Promise<Measurement> {
   }, WITNESSES);
 }
 
-test("@webkit #1228 — a long conversation name does not push the notifications sub-page off the drawer", async ({
+test("@webkit @touch #1228 — a long conversation name does not push the notifications sub-page off the drawer", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue123-compose-swipe-velocity.spec.ts
+++ b/cicchetto/e2e/tests/issue123-compose-swipe-velocity.spec.ts
@@ -263,7 +263,7 @@ test("issue123 — nested-scroll handoff: native scroll owns the drag until the 
   await expect(ta).toHaveValue(sent, { timeout: 2_000 });
 });
 
-test("@webkit issue123 — compose textarea is touch-action: pan-y + overscroll-behavior: contain", async ({
+test("@webkit @touch issue123 — compose textarea is touch-action: pan-y + overscroll-behavior: contain", async ({
   page,
 }) => {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");

--- a/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
+++ b/cicchetto/e2e/tests/issue1244-admin-density.spec.ts
@@ -163,7 +163,7 @@ for (const width of [393, 440]) {
     // only come from the width under test.
     test.use({ viewport: { width, height: 956 } });
 
-    test(`#1244 @webkit at ${width}px a card field is one row while its value is short`, async ({
+    test(`#1244 @webkit @touch at ${width}px a card field is one row while its value is short`, async ({
       page,
     }) => {
       const admin = getSeededAdmin();
@@ -231,7 +231,7 @@ for (const width of [393, 440]) {
       }
     });
 
-    test(`#1244 @webkit at ${width}px a panel fact is one row while its value is short`, async ({
+    test(`#1244 @webkit @touch at ${width}px a panel fact is one row while its value is short`, async ({
       page,
     }) => {
       const admin = getSeededAdmin();
@@ -312,7 +312,7 @@ for (const width of [393, 440]) {
 test.describe("#1244 the nesting around a record card", () => {
   test.use({ viewport: { width: 440, height: 956 } });
 
-  test("#1244 @webkit a record card sits inside one frame, not three", async ({ page }) => {
+  test("#1244 @webkit @touch a record card sits inside one frame, not three", async ({ page }) => {
     const admin = getSeededAdmin();
     const visitor = await mintVisitor(`frame1244-${Date.now()}`);
 

--- a/cicchetto/e2e/tests/issue1250-ime-paste-flood-guard.spec.ts
+++ b/cicchetto/e2e/tests/issue1250-ime-paste-flood-guard.spec.ts
@@ -203,7 +203,7 @@ test("#1250 — a REAL paste is reported once to the guard: one dialog, and the 
 
 // The same measurement on the other shipped engine. The ordering is a browser
 // contract, so one engine's answer is not the answer.
-test("#1250 — a REAL paste is reported once to the guard: one dialog, and the measured order @webkit", async ({
+test("#1250 — a REAL paste is reported once to the guard: one dialog, and the measured order @webkit @touch", async ({
   page,
 }, testInfo) => {
   await realPasteOrderJourney(page, testInfo);

--- a/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1438-viewer-swipe-dismiss.spec.ts
@@ -135,7 +135,7 @@ test("#1438 — mid-drag the modal moves by the finger's travel, centering intac
   expect(after - before).toBeCloseTo(90, 0);
 });
 
-test("@webkit #1438 — the IMAGE viewer container re-opens the pan, and still dismisses (iPhone 15)", async ({
+test("@webkit @touch #1438 — the IMAGE viewer container re-opens the pan, and still dismisses (iPhone 15)", async ({
   page,
 }) => {
   test.slow();

--- a/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
+++ b/cicchetto/e2e/tests/issue1445-directory-pull-refresh.spec.ts
@@ -601,7 +601,7 @@ test("#1658 — the rows follow the finger and the slot rides above them, at eve
   }
 });
 
-test("@webkit #1658 — WebKit carries the rows AND keeps the slot off them (iPhone 15)", async ({
+test("@webkit @touch #1658 — WebKit carries the rows AND keeps the slot off them (iPhone 15)", async ({
   page,
 }) => {
   test.slow();
@@ -665,7 +665,7 @@ test("@webkit #1658 — WebKit carries the rows AND keeps the slot off them (iPh
   }
 });
 
-test("@webkit #1445 — the directory list refuses its own overscroll and declares its one pan axis (iPhone 15)", async ({
+test("@webkit @touch #1445 — the directory list refuses its own overscroll and declares its one pan axis (iPhone 15)", async ({
   page,
 }) => {
   test.slow();

--- a/cicchetto/e2e/tests/issue1702-media-session-metadata.spec.ts
+++ b/cicchetto/e2e/tests/issue1702-media-session-metadata.spec.ts
@@ -109,7 +109,7 @@ type Probe = {
 
 test.setTimeout(90_000);
 
-test("@webkit #1702 — the lock screen is told the track, the station and the artwork", async ({
+test("@webkit @touch #1702 — the lock screen is told the track, the station and the artwork", async ({
   page,
 }) => {
   await page.addInitScript(

--- a/cicchetto/e2e/tests/issue1766-hide-bottom-bar.spec.ts
+++ b/cicchetto/e2e/tests/issue1766-hide-bottom-bar.spec.ts
@@ -69,7 +69,7 @@ async function hideTheBar(page: Parameters<typeof loginAs>[0]): Promise<void> {
   await closeSettings(page);
 }
 
-test("@webkit mobile: turning the bar off removes it and leaves a working door", async ({
+test("@webkit @touch mobile: turning the bar off removes it and leaves a working door", async ({
   page,
 }) => {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
@@ -112,7 +112,7 @@ test("@webkit mobile: turning the bar off removes it and leaves a working door",
   await expect(page.getByTestId("show-bottom-bar-toggle")).not.toBeChecked();
 });
 
-test("@webkit mobile: the preference is remembered by the ACCOUNT, not the device", async ({
+test("@webkit @touch mobile: the preference is remembered by the ACCOUNT, not the device", async ({
   page,
 }) => {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
@@ -232,7 +232,7 @@ async function inkOf(
   return ink;
 }
 
-test("@webkit mobile: the two doors are a `#` and a ☰ at one ink size, and the left one is off the channel name", async ({
+test("@webkit @touch mobile: the two doors are a `#` and a ☰ at one ink size, and the left one is off the channel name", async ({
   page,
 }) => {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");

--- a/cicchetto/e2e/tests/issue204-foolproof-login.spec.ts
+++ b/cicchetto/e2e/tests/issue204-foolproof-login.spec.ts
@@ -153,7 +153,7 @@ test.describe("#204 foolproof login", () => {
 // condition (3) is iPad/mobile-first tap targets; this verifies the
 // main-form view + Advanced disclosure actually render + tap on a real
 // mobile WebKit viewport, where chromium/jsdom are blind to mobile CSS.
-test.describe("#204 foolproof login @webkit mobile", () => {
+test.describe("#204 foolproof login @webkit @touch mobile", () => {
   test("main-form view renders and Advanced reveals realname/ident on iPhone", async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem("cic.installChoice", "browser");

--- a/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
+++ b/cicchetto/e2e/tests/issue213-pinch-zoom.spec.ts
@@ -330,7 +330,7 @@ test("#1805 — a real one-finger drag moves the visible portion of the zoomed i
   expect(Math.abs(after.dy + after.scrollTop)).toBeLessThan(2);
 });
 
-test("@webkit #1805 — the zoomable modal image and its scroller declare the pan (iPhone 15)", async ({
+test("@webkit @touch #1805 — the zoomable modal image and its scroller declare the pan (iPhone 15)", async ({
   page,
 }) => {
   test.slow();
@@ -356,7 +356,7 @@ test("@webkit #1805 — the zoomable modal image and its scroller declare the pa
   expect(style.overscroll).toBe("contain");
 });
 
-test("@webkit #1805 — zooming creates a real scrollable area, and scrolling moves the picture (iPhone 15)", async ({
+test("@webkit @touch #1805 — zooming creates a real scrollable area, and scrolling moves the picture (iPhone 15)", async ({
   page,
 }) => {
   test.slow();

--- a/cicchetto/e2e/tests/issue230-mobile-touch-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-mobile-touch-underfill-loadmore.spec.ts
@@ -182,7 +182,7 @@ test.describe("issue #230 (mobile) — touch-drag-down loads older history when 
     expect(await scrollbackLines(page).count()).toBe(initialCount);
   });
 
-  test("@webkit issue230 mobile — underfilled .scrollback is touch-action: none + overscroll-behavior: contain", async ({
+  test("@webkit @touch issue230 mobile — underfilled .scrollback is touch-action: none + overscroll-behavior: contain", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
+++ b/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
@@ -114,7 +114,7 @@ test("desktop: Alt+A / button jumps DM (tier 0) before channel (tier 1), then au
   }
 });
 
-test("@webkit mobile: bottom-bar affordance jumps DM before channel, then auto-hides", async ({
+test("@webkit @touch mobile: bottom-bar affordance jumps DM before channel, then auto-hides", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue237-topic-inline-on-join.spec.ts
+++ b/cicchetto/e2e/tests/issue237-topic-inline-on-join.spec.ts
@@ -89,7 +89,7 @@ test("#237 — full channel topic prints inline in scrollback on join and on cha
   await topicInlineOnJoinAndChange(page);
 });
 
-test("#237 @webkit — full channel topic prints inline on the mobile viewport too", async ({
+test("#237 @webkit @touch — full channel topic prints inline on the mobile viewport too", async ({
   page,
 }) => {
   await topicInlineOnJoinAndChange(page);

--- a/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
+++ b/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
@@ -116,7 +116,7 @@ test.describe("#243 — re-tap active channel jumps scrollback to bottom", () =>
     await scrollUpThenRetapLandsAtBottom(page);
   });
 
-  test("@webkit mobile: re-tapping the active bottom-bar entry jumps to the newest message", async ({
+  test("@webkit @touch mobile: re-tapping the active bottom-bar entry jumps to the newest message", async ({
     page,
   }) => {
     await scrollUpThenRetapLandsAtBottom(page);

--- a/cicchetto/e2e/tests/issue244-directory-tap-foreground.spec.ts
+++ b/cicchetto/e2e/tests/issue244-directory-tap-foreground.spec.ts
@@ -148,7 +148,7 @@ test.describe("#244 directory tap foregrounds the joined window", () => {
     }
   });
 
-  test("MOBILE @webkit — tapping an unjoined /list row foregrounds its window (BottomBar branch)", async ({
+  test("MOBILE @webkit @touch — tapping an unjoined /list row foregrounds its window (BottomBar branch)", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue245-scroll-remeasure-on-resize.spec.ts
+++ b/cicchetto/e2e/tests/issue245-scroll-remeasure-on-resize.spec.ts
@@ -86,7 +86,7 @@ async function setVisualViewportHeight(page: Page, px: number): Promise<void> {
     .toBe(`${px}px`);
 }
 
-test("@webkit #245 — .scrollback re-measures overflow (touch-action) on visualViewport resize", async ({
+test("@webkit @touch #245 — .scrollback re-measures overflow (touch-action) on visualViewport resize", async ({
   page,
 }) => {
   const admin = getSeededAdmin();

--- a/cicchetto/e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts
+++ b/cicchetto/e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts
@@ -91,7 +91,7 @@ test.describe("#253 — keyboard/viewport resize must not yank a scrolled-up rea
     await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
   });
 
-  test("@webkit #253 — a scrolled-up reader keeps their scrollTop when the keyboard opens", async ({
+  test("@webkit @touch #253 — a scrolled-up reader keeps their scrollTop when the keyboard opens", async ({
     page,
   }) => {
     test.slow();
@@ -169,7 +169,7 @@ test.describe("#253 — keyboard/viewport resize must not yank a scrolled-up rea
     expect(Math.abs(during - before.top)).toBeLessThanOrEqual(5);
   });
 
-  test("@webkit #253 — an at-bottom reader stays pinned to the tail when the keyboard opens", async ({
+  test("@webkit @touch #253 — an at-bottom reader stays pinned to the tail when the keyboard opens", async ({
     page,
   }) => {
     test.slow();

--- a/cicchetto/e2e/tests/issue254-own-echo-live.spec.ts
+++ b/cicchetto/e2e/tests/issue254-own-echo-live.spec.ts
@@ -138,7 +138,7 @@ test("#254 — /msg to a fresh query window subscribes BEFORE the send POST (own
   }
 });
 
-test("@webkit #254 — /msg to a fresh query window subscribes BEFORE the send POST on iOS", async ({
+test("@webkit @touch #254 — /msg to a fresh query window subscribes BEFORE the send POST on iOS", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -241,7 +241,7 @@ test("#254 — own channel message renders live after an iOS-style suspend/resum
   await assertOwnChannelMsgRendersAfterWake(page, `i254c-${crypto.randomUUID().slice(0, 8)}`);
 });
 
-test("@webkit #254 — own channel message renders live after iOS suspend/resume", async ({
+test("@webkit @touch #254 — own channel message renders live after iOS suspend/resume", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue255-close-x-touch-action.spec.ts
+++ b/cicchetto/e2e/tests/issue255-close-x-touch-action.spec.ts
@@ -66,7 +66,7 @@ test("#255 — desktop .sidebar-close aligns touch-action to the sidebar's pan-y
   expect(ta).toBe("pan-y");
 });
 
-test("#255 @webkit — mobile .bottom-bar-close aligns touch-action to the bottom-bar's pan-x axis", async ({
+test("#255 @webkit @touch — mobile .bottom-bar-close aligns touch-action to the bottom-bar's pan-x axis", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
+++ b/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
@@ -153,7 +153,9 @@ async function joinChannelWhenReady(token: string, slug: string, channel: string
   throw new Error(`joinChannelWhenReady: ${slug}/${channel} never became joinable (last: ${last})`);
 }
 
-test("@webkit #260 — the network header carries the sticky-left CSS contract", async ({ page }) => {
+test("@webkit @touch #260 — the network header carries the sticky-left CSS contract", async ({
+  page,
+}) => {
   // Deterministic, isolated anchor: the computed style the browser
   // consults to pin the header. Seeded vjt has ONE network → one header;
   // read-only (no JOINs), so no shared-stack poisoning.
@@ -188,7 +190,7 @@ test("@webkit #260 — the network header carries the sticky-left CSS contract",
   expect(contract.background).toBe(contract.barBackground);
 });
 
-test("@webkit #260 — the sticky header pins under scroll and the next network displaces it", async ({
+test("@webkit @touch #260 — the sticky header pins under scroll and the next network displaces it", async ({
   page,
 }) => {
   // Two full connect chains + several JOINs across two live upstreams —

--- a/cicchetto/e2e/tests/issue262-topic-clamp-mobile.spec.ts
+++ b/cicchetto/e2e/tests/issue262-topic-clamp-mobile.spec.ts
@@ -47,7 +47,7 @@ async function boundingHeight(locator: import("@playwright/test").Locator): Prom
   return box.height;
 }
 
-test("#262/#307 @webkit — a long topic clamps to 2 lines with a native ellipsis (not a bare max-height clip)", async ({
+test("#262/#307 @webkit @touch — a long topic clamps to 2 lines with a native ellipsis (not a bare max-height clip)", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue264-next-active-btn-mobile.spec.ts
+++ b/cicchetto/e2e/tests/issue264-next-active-btn-mobile.spec.ts
@@ -107,7 +107,7 @@ function isRound(borderRadius: string, width: number): boolean {
   return Number.parseFloat(first) >= width / 2 - 1;
 }
 
-test("#264 @webkit — mobile next-active button is a keyboard-safe circle (≥44px, corner badge)", async ({
+test("#264 @webkit @touch — mobile next-active button is a keyboard-safe circle (≥44px, corner badge)", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
+++ b/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
@@ -112,7 +112,7 @@ test("desktop: #265 next-active count includes the message (DM) window, excludes
   }
 });
 
-test("@webkit mobile: #265 bottom-bar next-active count excludes the event-only channel", async ({
+test("@webkit @touch mobile: #265 bottom-bar next-active count excludes the event-only channel", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue278-next-active-send-overlap.spec.ts
+++ b/cicchetto/e2e/tests/issue278-next-active-send-overlap.spec.ts
@@ -77,7 +77,7 @@ function fmt(r: Rect): string {
   return `[x ${r.x.toFixed(0)}, y ${r.y.toFixed(0)}, w ${r.width.toFixed(0)}, h ${r.height.toFixed(0)} → right ${(r.x + r.width).toFixed(0)}, bottom ${(r.y + r.height).toFixed(0)}]`;
 }
 
-test("#278 @webkit — with the keyboard open the next-active circle does not overlap the send button and stays reachable", async ({
+test("#278 @webkit @touch — with the keyboard open the next-active circle does not overlap the send button and stays reachable", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue280-button-coexist.spec.ts
+++ b/cicchetto/e2e/tests/issue280-button-coexist.spec.ts
@@ -124,7 +124,7 @@ test.afterEach(async () => {
 });
 
 test.describe("#280 — next-active + scroll-to-bottom coexist cleanly", () => {
-  test("@webkit — both buttons coexist without overlap, same size, and next-active stays constant relative to the message container across keyboard open", async ({
+  test("@webkit @touch — both buttons coexist without overlap, same size, and next-active stays constant relative to the message container across keyboard open", async ({
     page,
   }) => {
     const vjt = specUser();
@@ -256,7 +256,7 @@ test.describe("#280 — next-active + scroll-to-bottom coexist cleanly", () => {
     }
   });
 
-  test("@webkit — badge is BLUE (normal class) when the next target is a plain channel message", async ({
+  test("@webkit @touch — badge is BLUE (normal class) when the next target is a plain channel message", async ({
     page,
   }) => {
     const vjt = specUser();
@@ -293,7 +293,7 @@ test.describe("#280 — next-active + scroll-to-bottom coexist cleanly", () => {
     }
   });
 
-  test("@webkit — badge is RED (priority class) when the next target carries a mention", async ({
+  test("@webkit @touch — badge is RED (priority class) when the next target carries a mention", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
+++ b/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
@@ -101,7 +101,7 @@ async function setViewportVarsNoResize(page: Page, px: number): Promise<void> {
     .toBe(`${px}px`);
 }
 
-test("@webkit #285 reopen — .scrollback base is fail-open pan-y and the lock gate re-measures on a container height change with NO resize event", async ({
+test("@webkit @touch #285 reopen — .scrollback base is fail-open pan-y and the lock gate re-measures on a container height change with NO resize event", async ({
   page,
 }) => {
   const admin = getSeededAdmin();

--- a/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
+++ b/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
@@ -171,7 +171,7 @@ test.afterEach(async () => {
 });
 
 test.describe("#289 — mobile floating buttons are translucent (text shows through)", () => {
-  test("@webkit — next-active + scroll-to-bottom are translucent yet clearly tappable", async ({
+  test("@webkit @touch — next-active + scroll-to-bottom are translucent yet clearly tappable", async ({
     page,
   }) => {
     const vjt = specUser();
@@ -236,7 +236,7 @@ test.describe("#289 — mobile floating buttons are translucent (text shows thro
 // is asserted first — if the project did NOT emulate a hover-less pointer
 // this contract could not witness the fix.
 test.describe("#302 — mobile float buttons don't latch :hover 'selected' after tap", () => {
-  test("@webkit — hover-less pointer keeps next-active + scroll-to-bottom at base (no latch)", async ({
+  test("@webkit @touch — hover-less pointer keeps next-active + scroll-to-bottom at base (no latch)", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
+++ b/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
@@ -46,7 +46,9 @@ test.describe("#291 — home launcher in the rail actions drawer", () => {
     await setAdminFlag(admin.token, vjtUserId, false);
   });
 
-  test("@webkit home launcher: all rail buttons ≥44px, tap returns to home", async ({ page }) => {
+  test("@webkit @touch home launcher: all rail buttons ≥44px, tap returns to home", async ({
+    page,
+  }) => {
     const admin = getSeededAdmin();
     await setAdminFlag(admin.token, vjtUserId, true);
 

--- a/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
+++ b/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
@@ -57,7 +57,7 @@ test.describe("#299 — admin reachable from the rail actions drawer", () => {
     await setAdminFlag(getSeededAdmin().token, vjtUserId, false);
   });
 
-  test("@webkit rail holds themes launcher; admin still present, ≥44px, and tappable", async ({
+  test("@webkit @touch rail holds themes launcher; admin still present, ≥44px, and tappable", async ({
     page,
   }) => {
     await setAdminFlag(getSeededAdmin().token, vjtUserId, true);
@@ -103,7 +103,7 @@ test.describe("#299 — admin reachable from the rail actions drawer", () => {
     await expect(page.getByTestId("admin-pane")).toBeVisible({ timeout: 5_000 });
   });
 
-  test("@webkit themes still reachable via the cog → themes nav row", async ({ page }) => {
+  test("@webkit @touch themes still reachable via the cog → themes nav row", async ({ page }) => {
     // Themes is not admin-gated — base vjt reaches it. Proves the rail's cog →
     // themes nav row reaches the themes sub-page (no launcher stranded it).
     await loginAs(page, specUser());

--- a/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
+++ b/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
@@ -71,7 +71,7 @@ async function reopenGalleryDesktop(page: PWPage): Promise<void> {
 }
 
 test.describe("#299 — theme cards (tap-select + progressive disclosure)", () => {
-  test("@webkit tapping a card reveals exactly one ≥44px action row", async ({ page }) => {
+  test("@webkit @touch tapping a card reveals exactly one ≥44px action row", async ({ page }) => {
     await loginAs(page, specUser());
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
     await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -188,6 +188,15 @@ test.describe("#310 — scroll-to-bottom button persists the read cursor (mobile
   // Declared through the `{ tag }` option rather than in the title, so the
   // title stays greppable exactly as `docs/TESTING.md` and #1543 spell it
   // (`--grep` matches tags too).
+  // 🔴 NO `@touch` — the PREMISE is calibrated to this device's viewport, not
+  // to an engine. `tapButtonPersistsCursorAndHolds` seeds the read cursor 25
+  // rows from the tail so the activation parks ABOVE the fold, and then
+  // asserts that as a precondition. On `chromium-pixel-touch` (412x839) that
+  // poll reads 0 and the test dies on its own premise before reaching the
+  // #310 contract — MEASURED during the issue 1878 retag; on iPhone 15
+  // (393x852) it reads over the 50px threshold, as it has all along. Porting
+  // this wants a seed derived from the pane's height rather than a constant,
+  // which is test code and not a retag.
   test("@webkit tapping the button advances the cursor to the tail and does not snap back", {
     tag: WARM_START_TAG,
   }, async ({ page }) => {

--- a/cicchetto/e2e/tests/issue327-bottombar-scroll-into-view.spec.ts
+++ b/cicchetto/e2e/tests/issue327-bottombar-scroll-into-view.spec.ts
@@ -67,7 +67,7 @@ const TARGET_LINE = "327 far-off-screen unread line";
 // per-run-unique).
 let peerSeq = 0;
 
-test("#327 @webkit — tapping next-active scrolls a far-off-screen unread tab fully into the bottom bar", async ({
+test("#327 @webkit @touch — tapping next-active scrolls a far-off-screen unread tab fully into the bottom bar", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue332-mobile-themes-wrap-glyph.spec.ts
+++ b/cicchetto/e2e/tests/issue332-mobile-themes-wrap-glyph.spec.ts
@@ -51,7 +51,9 @@ const THEMES_GLYPH = "\u{1F3A8}"; // 🎨 — the themes launcher glyph
 test.setTimeout(60_000);
 
 test.describe("#332/#473 — rail themes launcher: full-width labelled row + deep-link + ⚙️ cog emoji", () => {
-  test("@webkit themes launcher deep-links to the themes gallery sub-page", async ({ page }) => {
+  test("@webkit @touch themes launcher deep-links to the themes gallery sub-page", async ({
+    page,
+  }) => {
     await loginAs(page, specUser());
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
     await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
@@ -73,7 +75,7 @@ test.describe("#332/#473 — rail themes launcher: full-width labelled row + dee
     await expect(page.getByTestId("theme-gallery")).toBeVisible({ timeout: 5_000 });
   });
 
-  test("@webkit themes launcher is a full-width row showing both its glyph and 'themes' label", async ({
+  test("@webkit @touch themes launcher is a full-width row showing both its glyph and 'themes' label", async ({
     page,
   }) => {
     await loginAs(page, specUser());
@@ -121,7 +123,9 @@ test.describe("#332/#473 — rail themes launcher: full-width labelled row + dee
     expect(btnBox.width).toBeGreaterThanOrEqual(railBox.width * 0.8);
   });
 
-  test("@webkit settings cog renders the ⚙️ emoji, not the bare ⚙ glyph", async ({ page }) => {
+  test("@webkit @touch settings cog renders the ⚙️ emoji, not the bare ⚙ glyph", async ({
+    page,
+  }) => {
     await loginAs(page, specUser());
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
     await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();

--- a/cicchetto/e2e/tests/issue350-link-tap-keyboard.spec.ts
+++ b/cicchetto/e2e/tests/issue350-link-tap-keyboard.spec.ts
@@ -37,6 +37,13 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 const LINK_URL = `https://example.com/issue350-${Date.now()}`;
 const MESSAGE_BODY = `tap target: ${LINK_URL}`;
 
+// 🔴 NO `@touch` — iOS-BOUND, and issue 1878's exception list missed it.
+// `keepKeyboard.handleMouseDown` opens with `if (!isIos()) return`
+// (`src/lib/keepKeyboard.ts`), so off Safari the whole mechanism is inert and
+// `md.defaultPrevented` is false: MEASURED red on `chromium-pixel-touch`
+// during the 1878 retag. The census that built that list grepped for the
+// `html.is-ios` CSS class and this spec exercises the JS gate instead, which
+// is why it read as portable. The Android twin is separate test code.
 test("@webkit iOS — a short tap on a scrollback link keeps the keyboard (mousedown focus-shift prevented, compose stays focused)", async ({
   page,
 }) => {

--- a/cicchetto/e2e/tests/issue358-daynight-theme.spec.ts
+++ b/cicchetto/e2e/tests/issue358-daynight-theme.spec.ts
@@ -39,7 +39,7 @@ async function openThemesSubPage(page: import("@playwright/test").Page): Promise
 }
 
 test.describe("#358 — day/night theme pairing", () => {
-  test("@webkit the gallery layer swaps with the OS color scheme (server-owned pair)", async ({
+  test("@webkit @touch the gallery layer swaps with the OS color scheme (server-owned pair)", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue361-mobile-list-launcher.spec.ts
+++ b/cicchetto/e2e/tests/issue361-mobile-list-launcher.spec.ts
@@ -33,7 +33,7 @@ const MIN_TAP_TARGET_PX = 44;
 test.setTimeout(60_000);
 
 test.describe("#361 — rooms launcher in the rail actions drawer", () => {
-  test("@webkit rooms launcher: ≥44px, leads the rail after home, tap opens the $list directory", async ({
+  test("@webkit @touch rooms launcher: ≥44px, leads the rail after home, tap opens the $list directory", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue402-mobile-window-surfaces.spec.ts
+++ b/cicchetto/e2e/tests/issue402-mobile-window-surfaces.spec.ts
@@ -72,7 +72,7 @@ test.afterEach(async () => {
   await partChannel(vjt.token, NETWORK_SLUG, GATED_CHANNEL).catch(() => {});
 });
 
-test("@webkit #402 — a failed-JOIN window with scrollback stays reachable from exactly one mobile surface", async ({
+test("@webkit @touch #402 — a failed-JOIN window with scrollback stays reachable from exactly one mobile surface", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue405-fresh-account-journey.spec.ts
+++ b/cicchetto/e2e/tests/issue405-fresh-account-journey.spec.ts
@@ -133,7 +133,7 @@ test.describe("#405 fresh non-admin account first-login journey", () => {
 // Mobile-webkit smoke (@webkit → iPhone-15 project). The empty-networks
 // home + the user-vs-guest branch render on the mobile layout too, where
 // chromium/jsdom are blind to mobile CSS (feedback_cicchetto_browser_smoke).
-test.describe("#405 fresh account @webkit mobile", () => {
+test.describe("#405 fresh account @webkit @touch mobile", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem("cic.installChoice", "browser");

--- a/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
+++ b/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
@@ -215,7 +215,7 @@ test.describe("#473 — RailActions drawer + grouped ArchiveModal", () => {
     await expect(page.locator(".topic-bar")).toContainText(CHANNEL, { timeout: 5_000 });
   });
 
-  test("@webkit mobile — drawer hosts every labelled button; PART → rail archive → grouped modal row", async ({
+  test("@webkit @touch mobile — drawer hosts every labelled button; PART → rail archive → grouped modal row", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
+++ b/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
@@ -134,7 +134,9 @@ test.describe("#605 server-window rail width cap", () => {
 test.describe("#605 server-window rail width cap (webkit)", () => {
   test.use({ viewport: IPAD_PRO_11_PORTRAIT, isMobile: false, hasTouch: false });
 
-  test("@webkit a long connection.server can't starve the centre on WebKit", async ({ page }) => {
+  test("@webkit @touch a long connection.server can't starve the centre on WebKit", async ({
+    page,
+  }) => {
     await assertServerRailCapped(page);
   });
 });

--- a/cicchetto/e2e/tests/issue66-keyboard-overlap.spec.ts
+++ b/cicchetto/e2e/tests/issue66-keyboard-overlap.spec.ts
@@ -43,7 +43,7 @@ const FAKE_VISIBLE_PX = 300;
 // Per-run unique tag so retries / parallel rows in #spec-wN don't collide.
 const MESSAGE_BODY = `issue66 keyboard-overlap @ ${crypto.randomUUID().slice(0, 8)}`;
 
-test("@webkit issue66 — composer + last message stay inside the keyboard-shrunk viewport", async ({
+test("@webkit @touch issue66 — composer + last message stay inside the keyboard-shrunk viewport", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue71-inc2-mobile-rail-openers.spec.ts
+++ b/cicchetto/e2e/tests/issue71-inc2-mobile-rail-openers.spec.ts
@@ -27,7 +27,7 @@ const OPENER_GLYPH = "\u{2630}"; // ☰ — identical glyph in both openers (pal
 test.setTimeout(60_000);
 
 test.describe("#71 INC-2 — mobile rail openers (Opt A)", () => {
-  test("@webkit non-channel (home): ☰ rail opener → drawer → cog opens settings", async ({
+  test("@webkit @touch non-channel (home): ☰ rail opener → drawer → cog opens settings", async ({
     page,
   }) => {
     const vjt = specUser();
@@ -57,7 +57,7 @@ test.describe("#71 INC-2 — mobile rail openers (Opt A)", () => {
     await expect(page.locator(".settings-drawer.open")).toBeVisible({ timeout: 5_000 });
   });
 
-  test("@webkit channel: TopicBar ☰ opens the SAME drawer + cog (ONE drawer, ONE glyph)", async ({
+  test("@webkit @touch channel: TopicBar ☰ opens the SAME drawer + cog (ONE drawer, ONE glyph)", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
@@ -200,7 +200,7 @@ test.describe("#75 — theme editor (producer path)", () => {
     await expect.poll(() => readAccent(page), { timeout: 5_000 }).toBe(accentPreOpen);
   });
 
-  test("@webkit editor opens + live-previews + cancels on mobile", async ({ page }) => {
+  test("@webkit @touch editor opens + live-previews + cancels on mobile", async ({ page }) => {
     await loginAs(page, specUser());
     await openThemesGalleryMobile(page);
 
@@ -241,7 +241,7 @@ test.describe("#75 — theme editor (producer path)", () => {
     await page.getByTestId("theme-editor-cancel-btn").click();
   });
 
-  test("@webkit #963 — font select is legible on the iPhone leg too", async ({ page }) => {
+  test("@webkit @touch #963 — font select is legible on the iPhone leg too", async ({ page }) => {
     await loginAs(page, specUser());
     await openThemesGalleryMobile(page);
 

--- a/cicchetto/e2e/tests/issue75-themes-gallery.spec.ts
+++ b/cicchetto/e2e/tests/issue75-themes-gallery.spec.ts
@@ -40,7 +40,7 @@ async function openThemesSubPage(page: import("@playwright/test").Page): Promise
 }
 
 test.describe("#75 — themes gallery consumer flow", () => {
-  test("@webkit 🎨 launcher opens the themes sub-page with the built-in gallery", async ({
+  test("@webkit @touch 🎨 launcher opens the themes sub-page with the built-in gallery", async ({
     page,
   }) => {
     const vjt = specUser();
@@ -65,7 +65,7 @@ test.describe("#75 — themes gallery consumer flow", () => {
     await expect(page.locator(".theme-card-name").filter({ hasText: /^sux$/ })).toBeVisible();
   });
 
-  test("@webkit tapping a card flips --bg live and persists across reload via the server", async ({
+  test("@webkit @touch tapping a card flips --bg live and persists across reload via the server", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/issue881-mobile-nonjoined-rail-doors.spec.ts
+++ b/cicchetto/e2e/tests/issue881-mobile-nonjoined-rail-doors.spec.ts
@@ -67,7 +67,7 @@ test.afterEach(async () => {
   await partChannel(vjt.token, NETWORK_SLUG, GATED_CHANNEL).catch(() => {});
 });
 
-test("@webkit #881 — a non-joined channel window keeps every rail door, and still no members list", async ({
+test("@webkit @touch #881 — a non-joined channel window keeps every rail door, and still no members list", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue902-invite-banner-mobile.spec.ts
+++ b/cicchetto/e2e/tests/issue902-invite-banner-mobile.spec.ts
@@ -72,7 +72,7 @@ test.afterEach(async () => {
   }
 });
 
-test("@webkit #902 — an inbound INVITE reaches a phone via the banner, not the BottomBar", async ({
+test("@webkit @touch #902 — an inbound INVITE reaches a phone via the banner, not the BottomBar", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
@@ -94,7 +94,7 @@ test("desktop: the toggle hides the button and Alt+A STILL jumps", async ({ page
   }
 });
 
-test("@webkit mobile: the same toggle hides the overlay placement", async ({ page }) => {
+test("@webkit @touch mobile: the same toggle hides the overlay placement", async ({ page }) => {
   const vjt = specUser();
   const peerNick = "act914-m";
   await loginAs(page, vjt);

--- a/cicchetto/e2e/tests/issue962-settings-drawer-row-squash.spec.ts
+++ b/cicchetto/e2e/tests/issue962-settings-drawer-row-squash.spec.ts
@@ -102,7 +102,7 @@ test("#962 — settings nav rows keep their content height when the drawer overf
   await assertRowsKeepTheirContentHeight(page);
 });
 
-test("@webkit #962 — settings nav rows keep their content height when the drawer overflows (iPhone)", async ({
+test("@webkit @touch #962 — settings nav rows keep their content height when the drawer overflows (iPhone)", async ({
   page,
 }) => {
   await seedXxlFontSize(page);

--- a/cicchetto/e2e/tests/issue984-query-rail-scroll-owner.spec.ts
+++ b/cicchetto/e2e/tests/issue984-query-rail-scroll-owner.spec.ts
@@ -116,7 +116,7 @@ test("#984 — a tall query WHOIS card keeps the rail launcher reachable", async
   }
 });
 
-test("@webkit #984 — the query rail scroller carries pan-y, and so does its subtree", async ({
+test("@webkit @touch #984 — the query rail scroller carries pan-y, and so does its subtree", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
+++ b/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
@@ -46,7 +46,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(90_000);
 
-test("@webkit #985 — a mobile query window spends no band on the ☰, and the float stays legible and reachable", async ({
+test("@webkit @touch #985 — a mobile query window spends no band on the ☰, and the float stays legible and reachable", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
+++ b/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
@@ -228,7 +228,7 @@ async function reportReadings(
 
 test.setTimeout(120_000);
 
-test("@webkit #988 — the actions menu opens with `home` visible at every viewport height", async ({
+test("@webkit @touch #988 — the actions menu opens with `home` visible at every viewport height", async ({
   page,
 }, testInfo) => {
   const vjt = specUser();
@@ -271,7 +271,7 @@ test("@webkit #988 — the actions menu opens with `home` visible at every viewp
   ).toBe(true);
 });
 
-test("@webkit #988 — `home` stays visible at XXL text with the viewport at its shortest", async ({
+test("@webkit @touch #988 — `home` stays visible at XXL text with the viewport at its shortest", async ({
   page,
 }, testInfo) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
@@ -112,7 +112,7 @@ test("upload link on a server-advertised host alias opens the in-app viewer re-r
   await aliasModalJourney(page);
 });
 
-test("upload link on a server-advertised host alias opens the in-app viewer re-rooted to the page origin (#324) @webkit", async ({
+test("upload link on a server-advertised host alias opens the in-app viewer re-rooted to the page origin (#324) @webkit @touch", async ({
   page,
 }) => {
   await aliasModalJourney(page);

--- a/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
+++ b/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
@@ -65,7 +65,7 @@ test.beforeEach(async () => {
 });
 
 test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands at bottom", () => {
-  test("@webkit tap scroll-to-bottom, bounce to empty query and back, lands at bottom", async ({
+  test("@webkit @touch tap scroll-to-bottom, bounce to empty query and back, lands at bottom", async ({
     page,
   }) => {
     const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
+++ b/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
@@ -51,7 +51,7 @@ test.afterEach(async () => {
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL);
 });
 
-test("@webkit UX-2 — rail archive opens the grouped modal + delete drops entry", async ({
+test("@webkit @touch UX-2 — rail archive opens the grouped modal + delete drops entry", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
+++ b/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
@@ -97,7 +97,7 @@ async function findRulePadding(
   }, selector);
 }
 
-test("@webkit UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do NOT", async ({
+test("@webkit @touch UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do NOT", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-3-oct-keyboard-stack.spec.ts
+++ b/cicchetto/e2e/tests/ux-3-oct-keyboard-stack.spec.ts
@@ -33,7 +33,7 @@
 import { loginAs } from "../fixtures/cicchettoPage";
 import { expect, specUser, test } from "../fixtures/test";
 
-test("@webkit UX-3 OCT — viewport meta carries interactive-widget=resizes-content", async ({
+test("@webkit @touch UX-3 OCT — viewport meta carries interactive-widget=resizes-content", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -50,7 +50,7 @@ test("@webkit UX-3 OCT — viewport meta carries interactive-widget=resizes-cont
   expect(viewportContent).toContain("viewport-fit=cover");
 });
 
-test("@webkit UX-3 OCT — installViewportHeightTracker writes --viewport-height on <html>", async ({
+test("@webkit @touch UX-3 OCT — installViewportHeightTracker writes --viewport-height on <html>", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -76,7 +76,7 @@ test("@webkit UX-3 OCT — installViewportHeightTracker writes --viewport-height
   expect(Math.abs(px - vpHeight)).toBeLessThan(1);
 });
 
-test("@webkit UX-3 OCT — installScrollPin snaps window back to (0, 0) on programmatic scroll", async ({
+test("@webkit @touch UX-3 OCT — installScrollPin snaps window back to (0, 0) on programmatic scroll", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -112,7 +112,7 @@ test("@webkit UX-3 OCT — installScrollPin snaps window back to (0, 0) on progr
   });
 });
 
-test("@webkit UX-3 OCT — .shell-mobile reads var(--viewport-height) with 100dvh fallback", async ({
+test("@webkit @touch UX-3 OCT — .shell-mobile reads var(--viewport-height) with 100dvh fallback", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
@@ -135,7 +135,7 @@ test.afterEach(async () => {
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
 });
 
-test("@webkit UX-4-Z cluster — case-fix + home + sidebar collapse + close-fallback + *serv route + members sort + scroll-on-activate + settings + upload-TTL persistence + admin window (parity matrix)", async ({
+test("@webkit @touch UX-4-Z cluster — case-fix + home + sidebar collapse + close-fallback + *serv route + members sort + scroll-on-activate + settings + upload-TTL persistence + admin window (parity matrix)", async ({
   page,
   context,
 }) => {

--- a/cicchetto/e2e/tests/ux-5-a-hamburger-dedupe.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-a-hamburger-dedupe.spec.ts
@@ -71,7 +71,7 @@ test("ux-5-a desktop — ZERO chrome hamburgers; TopicBar hamburger CSS-hidden o
   await expect(page.locator(".rail-actions-menu [data-testid='action-cluster-cog']")).toBeVisible();
 });
 
-test("@webkit ux-5-a mobile — exactly ONE visible hamburger (TopicBar members) on channel; ZERO on home", async ({
+test("@webkit @touch ux-5-a mobile — exactly ONE visible hamburger (TopicBar members) on channel; ZERO on home", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-5-bd-bottom-safe-area-floor.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bd-bottom-safe-area-floor.spec.ts
@@ -87,7 +87,7 @@ async function readDeclaredCssValue(
   );
 }
 
-test("@webkit ux-5-bd — .settings-drawer padding uses 1.5rem env() bottom floor", async ({
+test("@webkit @touch ux-5-bd — .settings-drawer padding uses 1.5rem env() bottom floor", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -105,7 +105,7 @@ test("@webkit ux-5-bd — .settings-drawer padding uses 1.5rem env() bottom floo
   expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
-test("@webkit ux-5-bd — .settings-drawer computed padding-bottom >= 1.5rem floor (non-notched)", async ({
+test("@webkit @touch ux-5-bd — .settings-drawer computed padding-bottom >= 1.5rem floor (non-notched)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -130,7 +130,7 @@ test("@webkit ux-5-bd — .settings-drawer computed padding-bottom >= 1.5rem flo
   expect(paddingBottom).toBeGreaterThanOrEqual(1.5 * rootEm);
 });
 
-test("@webkit ux-5-bd — .archive-modal padding uses 1.5rem env() bottom floor", async ({
+test("@webkit @touch ux-5-bd — .archive-modal padding uses 1.5rem env() bottom floor", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -145,7 +145,7 @@ test("@webkit ux-5-bd — .archive-modal padding uses 1.5rem env() bottom floor"
   expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
-test("@webkit ux-5-bd — .archive-modal computed padding-bottom >= 1.5rem floor (non-notched)", async ({
+test("@webkit @touch ux-5-bd — .archive-modal computed padding-bottom >= 1.5rem floor (non-notched)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -172,7 +172,7 @@ test("@webkit ux-5-bd — .archive-modal computed padding-bottom >= 1.5rem floor
   expect(paddingBottom).toBeGreaterThanOrEqual(1.5 * rootEm);
 });
 
-test("@webkit ux-5-bd — .image-upload-modal padding uses 1.5rem env() bottom floor", async ({
+test("@webkit @touch ux-5-bd — .image-upload-modal padding uses 1.5rem env() bottom floor", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -189,7 +189,7 @@ test("@webkit ux-5-bd — .image-upload-modal padding uses 1.5rem env() bottom f
   expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
-test("@webkit ux-5-bd — .shell-members padding-bottom uses 1.5rem env() floor (BM launcher footer trap)", async ({
+test("@webkit @touch ux-5-bd — .shell-members padding-bottom uses 1.5rem env() floor (BM launcher footer trap)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -212,7 +212,7 @@ test("@webkit ux-5-bd — .shell-members padding-bottom uses 1.5rem env() floor 
   expect(pad).toContain("max(1.5rem, var(--safe-area-inset-bottom))");
 });
 
-test("@webkit ux-5-bd — .shell-members computed padding-bottom >= 1.5rem floor (non-notched)", async ({
+test("@webkit @touch ux-5-bd — .shell-members computed padding-bottom >= 1.5rem floor (non-notched)", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
@@ -75,7 +75,7 @@ test("ux-5-bm desktop — members aside carries the RailActions drawer", async (
   );
 });
 
-test("@webkit ux-5-bm mobile-channel — topic-bar hosts hamburger only; drawer hosts settings+archive launchers; mutex enforced", async ({
+test("@webkit @touch ux-5-bm mobile-channel — topic-bar hosts hamburger only; drawer hosts settings+archive launchers; mutex enforced", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -161,7 +161,7 @@ test("@webkit ux-5-bm mobile-channel — topic-bar hosts hamburger only; drawer 
 // mutex test). The `toggleMembersPanel` close-siblings arm itself is
 // pinned at the unit level by `src/__tests__/mobilePanel.test.ts`.
 
-test("@webkit ux-5-bm mobile-non-channel — home keeps its own ☰ door to the rail", async ({
+test("@webkit @touch ux-5-bm mobile-non-channel — home keeps its own ☰ door to the rail", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-5-bo-mobile-settings-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bo-mobile-settings-scroll.spec.ts
@@ -64,7 +64,7 @@ async function computedTouchAction(page: import("@playwright/test").Page, select
   });
 }
 
-test("@webkit ux-5-bo — settings drawer asserts touch-action: pan-y + overscroll-behavior: contain", async ({
+test("@webkit @touch ux-5-bo — settings drawer asserts touch-action: pan-y + overscroll-behavior: contain", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -89,7 +89,7 @@ test("@webkit ux-5-bo — settings drawer asserts touch-action: pan-y + overscro
   expect(styles.overscrollBehaviorY).toBe("contain");
 });
 
-test("@webkit ux-5-bo — settings drawer has an internal scroll authority (overflow-y: auto precondition)", async ({
+test("@webkit @touch ux-5-bo — settings drawer has an internal scroll authority (overflow-y: auto precondition)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -117,7 +117,7 @@ test("@webkit ux-5-bo — settings drawer has an internal scroll authority (over
   expect(drawerScroll).toBeGreaterThan(0);
 });
 
-test("@webkit ux-5-bo — archive modal asserts touch-action: pan-y + overscroll-behavior: contain", async ({
+test("@webkit @touch ux-5-bo — archive modal asserts touch-action: pan-y + overscroll-behavior: contain", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -151,7 +151,7 @@ test("@webkit ux-5-bo — archive modal asserts touch-action: pan-y + overscroll
   expect(styles.overscrollBehaviorY).toBe("contain");
 });
 
-test("@webkit ux-5-bo — home pane asserts touch-action: pan-y (same .shell-mobile trap)", async ({
+test("@webkit @touch ux-5-bo — home pane asserts touch-action: pan-y (same .shell-mobile trap)", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
@@ -121,7 +121,7 @@ test("ux-5-bt desktop — #71 INC-2: NO chrome row; topic-bar + rail cog; sideba
   expect(headerBtnJustify).toBe("flex-start");
 });
 
-test("@webkit ux-5-bt mobile — channel: NO standalone .shell-chrome row (#473 moved chrome buttons into the RailActions drawer)", async ({
+test("@webkit @touch ux-5-bt mobile — channel: NO standalone .shell-chrome row (#473 moved chrome buttons into the RailActions drawer)", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
@@ -96,7 +96,7 @@ async function readDeclaredHeight(
   );
 }
 
-test("@webkit ux-5-bv — .shell-members reads var(--viewport-height) with 100dvh fallback", async ({
+test("@webkit @touch ux-5-bv — .shell-members reads var(--viewport-height) with 100dvh fallback", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -108,7 +108,7 @@ test("@webkit ux-5-bv — .shell-members reads var(--viewport-height) with 100dv
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — .settings-drawer reads var(--viewport-height) with 100dvh fallback", async ({
+test("@webkit @touch ux-5-bv — .settings-drawer reads var(--viewport-height) with 100dvh fallback", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -120,7 +120,7 @@ test("@webkit ux-5-bv — .settings-drawer reads var(--viewport-height) with 100
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — .archive-modal caps max-height to var(--viewport-height)", async ({
+test("@webkit @touch ux-5-bv — .archive-modal caps max-height to var(--viewport-height)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -132,7 +132,7 @@ test("@webkit ux-5-bv — .archive-modal caps max-height to var(--viewport-heigh
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — .image-upload-modal caps max-height to var(--viewport-height)", async ({
+test("@webkit @touch ux-5-bv — .image-upload-modal caps max-height to var(--viewport-height)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -144,7 +144,9 @@ test("@webkit ux-5-bv — .image-upload-modal caps max-height to var(--viewport-
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — .home-pane caps max-height to var(--viewport-height)", async ({ page }) => {
+test("@webkit @touch ux-5-bv — .home-pane caps max-height to var(--viewport-height)", async ({
+  page,
+}) => {
   const vjt = specUser();
   await loginAs(page, vjt);
 
@@ -154,7 +156,7 @@ test("@webkit ux-5-bv — .home-pane caps max-height to var(--viewport-height)",
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — .admin-pane caps max-height to var(--viewport-height)", async ({
+test("@webkit @touch ux-5-bv — .admin-pane caps max-height to var(--viewport-height)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -166,7 +168,7 @@ test("@webkit ux-5-bv — .admin-pane caps max-height to var(--viewport-height)"
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — .admin-tab-panel caps max-height to var(--viewport-height)", async ({
+test("@webkit @touch ux-5-bv — .admin-tab-panel caps max-height to var(--viewport-height)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -178,7 +180,7 @@ test("@webkit ux-5-bv — .admin-tab-panel caps max-height to var(--viewport-hei
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — mobile members drawer auto-closes when operator taps a member nick", async ({
+test("@webkit @touch ux-5-bv — mobile members drawer auto-closes when operator taps a member nick", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-6-a-mobile-members-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-a-mobile-members-scroll.spec.ts
@@ -55,7 +55,7 @@ async function computedTouchAction(page: import("@playwright/test").Page, select
   });
 }
 
-test("@webkit ux-6-a — mobile members pane (the actual scroller) asserts touch-action: pan-y + overscroll-behavior: contain", async ({
+test("@webkit @touch ux-6-a — mobile members pane (the actual scroller) asserts touch-action: pan-y + overscroll-behavior: contain", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -80,7 +80,7 @@ test("@webkit ux-6-a — mobile members pane (the actual scroller) asserts touch
   expect(styles.overscrollBehaviorY).toBe("contain");
 });
 
-test("@webkit ux-6-a — opening members drawer adds html.overlay-open; closing removes it", async ({
+test("@webkit @touch ux-6-a — opening members drawer adds html.overlay-open; closing removes it", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -105,7 +105,7 @@ test("@webkit ux-6-a — opening members drawer adds html.overlay-open; closing 
   await expect.poll(hasOverlayClass).toBe(false);
 });
 
-test("@webkit ux-6-a — html.overlay-open suspends root touch-action so gesture-escalation can't reach installScrollPin", async ({
+test("@webkit @touch ux-6-a — html.overlay-open suspends root touch-action so gesture-escalation can't reach installScrollPin", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -148,7 +148,7 @@ test("@webkit ux-6-a — html.overlay-open suspends root touch-action so gesture
   await page.evaluate(() => document.documentElement.classList.remove("overlay-open"));
 });
 
-test("@webkit ux-6-a v2 — descendants of .members-pane share the scroller's touch-action: pan-y (universal-selector carve-out)", async ({
+test("@webkit @touch ux-6-a v2 — descendants of .members-pane share the scroller's touch-action: pan-y (universal-selector carve-out)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -189,7 +189,7 @@ test("@webkit ux-6-a v2 — descendants of .members-pane share the scroller's to
   expect(ulTouchAction).toBe("pan-y");
 });
 
-test("@webkit ux-6-a v2 — members-pane nick-text renders with no inline color (sigil keeps mode color)", async ({
+test("@webkit @touch ux-6-a v2 — members-pane nick-text renders with no inline color (sigil keeps mode color)", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -221,7 +221,7 @@ test("@webkit ux-6-a v2 — members-pane nick-text renders with no inline color 
   expect(inlineColor).toBe("");
 });
 
-test("@webkit ux-6-a v2 — .member-name:hover underline is gated on (hover: hover) — no spurious underline on touch-only viewports", async ({
+test("@webkit @touch ux-6-a v2 — .member-name:hover underline is gated on (hover: hover) — no spurious underline on touch-only viewports", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
@@ -56,7 +56,7 @@ test.describe("UX-6-C / #473 — admin launcher in the rail actions drawer", () 
     await setAdminFlag(admin.token, vjtUserId, false);
   });
 
-  test("@webkit admin on mobile — rail actions drawer hosts admin button; tap opens AdminPane", async ({
+  test("@webkit @touch admin on mobile — rail actions drawer hosts admin button; tap opens AdminPane", async ({
     page,
   }) => {
     const admin = getSeededAdmin();
@@ -101,7 +101,7 @@ test.describe("UX-6-C / #473 — admin launcher in the rail actions drawer", () 
     await expect(pane.getByRole("heading", { name: /admin console/i })).toBeVisible();
   });
 
-  test("@webkit non-admin on mobile — rail actions drawer hides the admin button", async ({
+  test("@webkit @touch non-admin on mobile — rail actions drawer hides the admin button", async ({
     page,
   }) => {
     // No promote: vjt stays non-admin for this arm. Per the gate

--- a/cicchetto/e2e/tests/ux-6-e-narrow-server-dedup.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-e-narrow-server-dedup.spec.ts
@@ -23,7 +23,7 @@ import { loginAs } from "../fixtures/cicchettoPage";
 import { NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specUser, test } from "../fixtures/test";
 
-test("@webkit UX-6-E — narrow mode renders one network entry; no standalone 'Server' tab", async ({
+test("@webkit @touch UX-6-E — narrow mode renders one network entry; no standalone 'Server' tab", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -50,7 +50,9 @@ test("@webkit UX-6-E — narrow mode renders one network entry; no standalone 'S
   await expect(standaloneServer).toHaveCount(0);
 });
 
-test("@webkit UX-6-E — clicking the network-header focuses the server window", async ({ page }) => {
+test("@webkit @touch UX-6-E — clicking the network-header focuses the server window", async ({
+  page,
+}) => {
   const vjt = specUser();
   await loginAs(page, vjt);
 
@@ -66,7 +68,7 @@ test("@webkit UX-6-E — clicking the network-header focuses the server window",
   await expect(header).toHaveClass(/selected/, { timeout: 5_000 });
 });
 
-test("@webkit UX-6-E — network-header has a disconnect × sibling, mirroring sidebar", async ({
+test("@webkit @touch UX-6-E — network-header has a disconnect × sibling, mirroring sidebar", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-6-f-send-button-glyph.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-f-send-button-glyph.spec.ts
@@ -41,7 +41,7 @@ const MESSAGE_BODY = `ux-6-f-arrow-glyph-${Date.now()}`;
 
 test.setTimeout(60_000);
 
-test("@webkit ux-6-f mobile — send button is accessible by name + visible label is SVG glyph + tap submits", async ({
+test("@webkit @touch ux-6-f mobile — send button is accessible by name + visible label is SVG glyph + tap submits", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -259,7 +259,7 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     await expect(page.getByTestId("admin-pane")).toBeVisible({ timeout: 5_000 });
   }
 
-  test("@webkit admin on mobile — no surface can be panned sideways", async ({ page }) => {
+  test("@webkit @touch admin on mobile — no surface can be panned sideways", async ({ page }) => {
     const admin = getSeededAdmin();
     const visitor = await mintVisitor(`ux6g-${Date.now()}`);
     let vhostId: number | null = null;
@@ -353,7 +353,7 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     }
   });
 
-  test("@webkit admin on mobile — the pane still permits pan-x", async ({ page }) => {
+  test("@webkit @touch admin on mobile — the pane still permits pan-x", async ({ page }) => {
     await openAdminPane(page);
 
     // Kept from the original fix and deliberately NOT deleted along with
@@ -394,7 +394,9 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
   // wrap` stops being one row. Neither is visible to the width oracle
   // above: the first because a `hidden` box is not in its scope, the
   // second because a wrapped strip does not overflow.
-  test("@webkit admin on mobile — the tab strip is one row, and it pans", async ({ page }) => {
+  test("@webkit @touch admin on mobile — the tab strip is one row, and it pans", async ({
+    page,
+  }) => {
     await openAdminPane(page);
 
     const strip = await page.getByTestId("admin-pane").evaluate((pane) => {
@@ -438,7 +440,7 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     ).toBeGreaterThan(strip.clientW + 1);
   });
 
-  test("@webkit admin on mobile — vertical scroll inside the pane still works", async ({
+  test("@webkit @touch admin on mobile — vertical scroll inside the pane still works", async ({
     page,
   }) => {
     await openAdminPane(page);
@@ -454,7 +456,7 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     expect(paneTouch, "admin-pane touch-action must allow pan-x").toMatch(/pan-x/);
   });
 
-  test("@webkit admin on mobile — opening a row's detail does not move the row", async ({
+  test("@webkit @touch admin on mobile — opening a row's detail does not move the row", async ({
     page,
   }) => {
     await openAdminPane(page);

--- a/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
@@ -61,7 +61,7 @@ test.afterEach(async () => {
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL);
 });
 
-test("@webkit UX-Z cluster — Dynamic Island clearance + RailActions archive + delete (registered class)", async ({
+test("@webkit @touch UX-Z cluster — Dynamic Island clearance + RailActions archive + delete (registered class)", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44319,3 +44319,137 @@ all. No e2e spec asserts anything on this screen: `grep` over
 and every `Retry`/`Reload` hit in the suite is prose in a comment about a page
 reload. Nothing was updated there because there is nothing there, and a
 Playwright spec was not fabricated for a copy change.
+<!-- entry #1878 -->
+
+---
+
+## 2026-08-30 — #1878: one tag is one project, and three specs said no
+
+The mobile suite ran on ONE engine. `@webkit` sent a spec to
+`webkit-iphone-15` and the desktop project's `grepInvert` kept it off
+`chromium`, so a green said "you did not break Safari" rather than "the
+mobile UI works". #1869 — a long-press opening two menus on Android — is
+the shape of bug that leaves uncovered: the behaviour was gated on
+`html.is-ios`, which is simply not there off Safari.
+
+The cure is 134 entries in 80 spec files gaining `@touch` **alongside**
+their `@webkit`, so they also run on `chromium-pixel-touch`. No project
+definition changed. That is the whole diff, plus comments.
+
+### Why ALONGSIDE and not INSTEAD, which is what the issue proposed
+
+The issue asked for `@webkit` → `@touch` as a REPLACEMENT, with
+`webkit-iphone-15` widened to `grep: /@webkit|@touch/` so that `@touch`
+would mean "mobile, on both projects". It was written against a working
+copy predating #1831, and #1831 had already introduced `@touch` meaning
+`chromium-pixel-touch` ONLY. Widening the webkit project would therefore
+have dragged the two specs that already carry it onto WebKit:
+
+* `issue1869-android-longpress-selection.spec.ts` asserts
+  `expect(standing?.isIos).toBe(false)`. On `webkit-iphone-15` that is
+  false by construction — a **RED**, not a vacuous green, on a spec that
+  landed on `main` the same day.
+* `issue1831-tap-send-modal-survives.spec.ts` carries a capitalised
+  instruction in its own header not to do this, backed by a measurement:
+  WebKit's injected tap dispatches `pointerdown / touchstart / pointerup`
+  and stops — no click at all — so the pre-cure code passes there.
+
+So the vocabulary is orthogonal instead: **one tag is one project
+opt-in.** `@webkit` → `webkit-iphone-15`, `@touch` →
+`chromium-pixel-touch`, both tags → both projects, neither → `chromium`.
+A spec that must hold on two engines says so twice. This needs no config
+change at all, and it leaves `--grep @webkit` collecting exactly the set
+it collected before — the widening ADDED a tag, it did not move one.
+
+The cost is the desktop project staying defined by subtraction: its
+`grepInvert` must name every touch project's tag, so a fourth project
+edits it too. The alternative is tagging the ~650 untagged desktop
+entries, which is worse.
+
+### The exception list is 11 entries in 10 files, not 8 in 7
+
+Eight were named by the issue and hold up. Six assert `html.is-ios` is
+PRESENT and then read the cascade hanging off it
+(`issue250-android-nick-select`, `issue508-ios-select-tappable`,
+`issue589-ios-admin-select`, `issue79-ios-select-keyboard-open`,
+`text-selection-restored`, `ux-6-d-keyboard-pattern` — the last tags its
+`describe`, so five tests ride it). Two ride `navigator.standalone`, an
+iOS-pre-17 API (`issue259-install-hint`).
+
+Three more were found by RUNNING the retagged suite on the touch project,
+and each fails for a different reason. This is the part a census could
+not have produced:
+
+* `issue350-link-tap-keyboard` is **iOS-bound and the census missed it**.
+  `keepKeyboard.handleMouseDown` opens with `if (!isIos()) return`
+  (`src/lib/keepKeyboard.ts`), so off Safari the mechanism is inert and
+  the asserted `defaultPrevented` is false. The list was built by
+  grepping for the `html.is-ios` CSS class; this spec exercises the JS
+  gate, and no grep for the class can see it. **The general rule: the
+  iOS surface has two doors, a class in the cascade and `isIos()` in
+  the handlers, and a census that knows only the first under-reports.**
+* `issue310-scroll-to-bottom-btn-cursor`'s mobile arm dies on **its own
+  premise, which is calibrated to a viewport and not to an engine**. It
+  seeds the read cursor 25 rows from the tail so the activation parks
+  above the fold, then asserts that precondition; on 412x839 the poll
+  reads 0 where on 393x852 it reads over the 50px threshold. Porting it
+  wants a seed derived from the pane's height, which is test code.
+* `issue1223-admin-card-affordances`'s heading-tap arm fails **and the
+  mechanism is NOT established.** Measured: `touchscreen.tap(383,
+  413.66)`, aimed at the heading's dead space, comes back with the
+  `confirmDetach` modal open and no `admin-session-detail-*` in the DOM
+  at all; the same coordinates open the row on WebKit. It has the SHAPE
+  of the #1831 class — chromium synthesises the compat mouse events and
+  hit-tests the click against the layout as it stands at RELEASE, which
+  WebKit never produces — but that was not measured here and is not
+  claimed. If it is that, the red is a product defect on Android rather
+  than a harness one, which is why the tag is withheld and the spec is
+  not weakened. Its three siblings in the same file port green.
+
+### What the numbers were, and why the issue's did not reproduce
+
+The issue's five figures — 434 spec files, 789 `test(`, 145 tagged
+entries (142 `test` + 3 `test.describe`), 87 files — reproduce EXACTLY at
+`e4a22a9a6`, the last commit before #1831 landed on 2026-08-28. On the
+tip they read 436 / 793 / 145 / 87. Nothing was wrong; the copy was two
+days old, which is also why the issue describes two projects when there
+have been three since #1831. Worth recording because the tag count is the
+one that did NOT move, so a reader spot-checking that single figure would
+conclude the whole census still held.
+
+A static `test(` census is not the collected total either: seven spec
+files build cases in a loop, so Playwright collects 803 where the static
+count reads 793. The two instruments agree per-file on the other 429,
+which is what makes either of them quotable.
+
+### The delta, per project
+
+Taken the same way on both sides — `scripts/integration.sh --list` on the
+base tree, the run's own `[project]` result lines after:
+
+| project | before | after |
+|---|---|---|
+| `chromium` | 648 | 648 |
+| `chromium-pixel-touch` | 4 | **140** |
+| `webkit-iphone-15` | 151 | 151 |
+| total | 803 | 939 |
+
++136, every one of them on the new leg, and the other two projects
+byte-for-byte the same set. That last part is the check worth keeping:
+the desktop count moving at all would mean an entry had silently left or
+joined the untagged set.
+
+### What this project is not
+
+`devices["Pixel 7"]` is chromium with `isMobile` + `hasTouch`. It is not
+an Android WebView and it is not Firefox Android. It covers the #1869
+family; it would NOT have caught #717 (Firefox Android hanging on the
+splash of an installed PWA), because Playwright's firefox has no touch
+emulation and Gecko is unreachable from this harness at all. The device
+stays `Pixel 7` rather than the `Pixel 5` the issue names — both are
+chromium with the same two flags, and churning it would re-measure every
+geometry assertion to buy nothing.
+
+The retagged titles still read "iOS" in places: the retag inserts a tag
+and rewrites no prose, and renaming them would break every `--grep` and
+doc reference that quotes a title.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -464,15 +464,32 @@ stack (`cicchetto/e2e/compose.yaml`):
 * **playwright-runner**: official Playwright base, runs `npx playwright test` against `https://nginx-test` from inside the docker network.
 
 Cold bring-up: ~30s, suite ~3 min — both wall-clock figures inherited
-from an earlier run, not re-measured. Size of the suite, counted statically on
-`cicchetto/e2e/tests/*.spec.ts` (not from a run): **411 spec files**
-declaring **755** cases (750 `test(` + 5 `test.skip(`, line-anchored).
-That is a floor, not the collected total — 101 of those files build
-cases inside a loop, and the two Playwright projects **partition** the
-set rather than duplicate it (`chromium` is `grepInvert: /@webkit/`,
-`webkit-iphone-15` is `grep: /@webkit/`). For collected counts, read
-what a real run reports; the figures quoted in trap 4 below are runtime
-numbers and were not re-measured here.
+from an earlier run, not re-measured.
+
+**Do not quote a suite size from this file — take it from the tool.**
+`scripts/integration.sh --list` prints `Total: N tests in M files` plus
+one `[project] › file:line › title` line per collected test, which is
+the only count that reflects the loops (7 spec files build cases inside
+one, so a static `test(` census reads low) and the only one that splits
+by project. A static census answers a different question and every
+figure ever written down here has rotted within days.
+
+The three Playwright projects do **not** partition the suite any more
+(issue 1878). Each tag is an opt-in to ONE project and a spec may carry
+both:
+
+| tag in the title | project it opts into |
+|---|---|
+| `@webkit` | `webkit-iphone-15` (`devices["iPhone 15"]`) |
+| `@touch` | `chromium-pixel-touch` (`devices["Pixel 7"]`) |
+| both | both — the mobile suite's default since issue 1878 |
+| neither | `chromium` (`devices["Desktop Chrome"]`), by `grepInvert` |
+
+So `--grep @webkit` still collects exactly the set it always did: the
+widening ADDED `@touch`, it did not move `@webkit`. Eight entries in
+seven files stay `@webkit`-only because they are iOS-bound by
+construction — six assert `html.is-ios` is present, two ride
+`navigator.standalone`.
 
 E2E test outputs land in `cicchetto/e2e/test-results/` (failure
 artifacts: screenshot, video, trace.zip) and
@@ -768,17 +785,28 @@ the hard way on 2026-07-27.
    `feedback_bg_task_exit_code_masked_by_chain` (an `exit 0` that is
    really a trailing `echo`); evidence bar is `feedback_landed_claim_evidence`.
 
-4. **`--project chromium` is NOT the ship gate — it drops every
-   `@webkit` spec.** The suite partitions across two Playwright projects;
-   `webkit-iphone-15` carries the `@webkit`-tagged specs that chromium
-   never collects (~419 tests chromium-only vs ~526+ for the full
-   two-project run). `--project chromium` is an **iso-rerun tool**, not a
-   green light. Before claiming a green e2e, **reconcile the collected
-   COUNT against the baseline** — a run that collected 419 when the
-   baseline is 526+ silently skipped 100+ specs. "N ≥ 1 collected" is a
-   smoke check that Playwright found *something*, NOT a check that it
-   collected the *right* set. See `feedback_e2e_user_class_parity_matrix`
-   + `feedback_playwright_webkit_not_ios_scroll`.
+4. **`--project <one>` is NOT the ship gate — it drops every spec the
+   other two projects carry.** `chromium` never collects a tagged spec
+   at all (`grepInvert`), and since issue 1878 the two touch projects
+   overlap heavily rather than dividing the mobile specs between them,
+   so no single project is a superset of any other. `--project` is an
+   **iso-rerun tool**, not a green light.
+
+   Before claiming a green e2e, **reconcile the collected COUNT against
+   a baseline you took the same way** — `scripts/integration.sh --list`
+   on the base ref, then on yours. Do not carry a number in from this
+   file or from an older report: the totals move whenever a spec file
+   lands. "N ≥ 1 collected" is a smoke check that Playwright found
+   *something*, NOT a check that it collected the *right* set. See
+   `feedback_e2e_user_class_parity_matrix` +
+   `feedback_playwright_webkit_not_ios_scroll`.
+
+   🔴 And do not read `chromium-pixel-touch` as "Android coverage". A
+   Pixel device descriptor is chromium with `isMobile` + `hasTouch` — not
+   an Android WebView, not Firefox Android. It covers the #1869 family
+   (behaviour gated on `html.is-ios`, which is absent off Safari). It
+   would not have caught #717: Playwright's firefox has no touch
+   emulation, so Gecko is unreachable from this harness.
 
 5. **A fresh worktree's `cicchetto/e2e/infra` submodule is EMPTY — and
    the repair everyone reaches for (rsync) POISONS git.** Worktrees


### PR DESCRIPTION
Addresses issue 1878, steps 1–3 only. Step 4 (the Android twins for the
`is-ios` specs and the `display-mode: standalone` variant of the install
hint) is a separate follow-up and is not here.

## What changed

134 entries in 80 spec files gain `@touch` **alongside** their `@webkit`,
so the mobile suite runs on `chromium-pixel-touch` as well as on
`webkit-iphone-15`. No project definition changed — every non-comment
edit in the diff is one ` @touch` inserted into a test title.

## Three findings the issue's text does not carry

**1. Steps 1 and 3 already landed, in a different shape.** The issue says
`playwright.config.ts` "has exactly two projects". It has had three since
`fcee984a0` (#1831, 2026-08-28): `chromium-pixel-touch`,
`devices["Pixel 7"]`, `grep: /@touch/`, with the desktop project's
`grepInvert` already widened to `/@webkit|@touch/`. So `@touch` exists,
and the third project exists. What was missing is only the retag.

**2. The issue's five numbers reproduce exactly — on a two-day-old
commit.** Re-measured with an independent parser (title literal of every
`test(` / `test.describe(` opener, comments stripped, known-answer
positive and negative fixtures inside the tool):

| | issue | `e4a22a9a6` (last commit before #1831) | `origin/main` tip |
|---|---|---|---|
| spec files | 434 | **434** | 436 |
| `test(` openers | 789 | **789** | 793 |
| tagged entries | 145 (142 + 3) | **145 (142 + 3)** | 145 (142 + 3) |
| files holding one | 87 | **87** | 87 |

Five for five at `e4a22a9a6`. Nothing was wrong; the working copy was two
days old. Recorded because the tag count is the one that did NOT move — a
reader spot-checking only that figure would conclude the whole census
still held. Separately, a static `test(` count is not the collected total:
7 spec files build cases in a loop, so Playwright collects **803** where
the static count reads 793 (the two instruments agree per-file on the
other 429).

**3. Step 3 as literally specified would have gone RED on `main`.** The
issue proposes `@webkit` → `@touch` as a replacement plus widening
`webkit-iphone-15` to `grep: /@webkit|@touch/`. That drags the specs that
already carry `@touch` onto WebKit, and
`issue1869-android-longpress-selection.spec.ts` asserts
`expect(standing?.isIos).toBe(false)` — false by construction on iPhone
15. Not a vacuous green: a failure, on a spec that landed the same day.
`issue1831-tap-send-modal-survives.spec.ts` forbids the same move in
capitals in its own header, having measured that the pre-cure code passes
there.

So the tags are **orthogonal** instead — one tag is one project opt-in:

| tag | project |
|---|---|
| `@webkit` | `webkit-iphone-15` |
| `@touch` | `chromium-pixel-touch` |
| both | both |
| neither | `chromium`, via `grepInvert` |

`--grep @webkit` still collects exactly the set it collected before: the
widening added a tag, it did not move one. And it needs no config change.

## The exception list is 11 entries in 10 files, not 8 in 7

The issue's 7 files hold up (6 assert `html.is-ios` is present, 1 rides
`navigator.standalone`). Running the retagged suite on the touch project
found three more, each for a different reason:

* **`issue350-link-tap-keyboard`** — iOS-bound, and the census could not
  have seen it. `keepKeyboard.handleMouseDown` opens `if (!isIos())
  return`, so off Safari the mechanism is inert. The exception list was
  built by grepping the `html.is-ios` CSS class; this spec exercises the
  JS gate. The iOS surface has two doors and a class grep knows one.
* **`issue310-scroll-to-bottom-btn-cursor`** (mobile arm) — dies on its
  own PREMISE, which is calibrated to a viewport rather than an engine:
  the 25-rows-from-tail seed parks above the fold on 393x852 and not on
  412x839. Porting it wants a height-derived seed, which is test code.
* **`issue1223-admin-card-affordances`** (heading-tap arm) — fails, and
  **the mechanism is not established.** Measured: `touchscreen.tap(383,
  413.66)` aimed at the heading's dead space returns the `confirmDetach`
  modal open and no `admin-session-detail-*` in the DOM; the same
  coordinates open the row on WebKit. It has the shape of the #1831 class
  (chromium hit-tests the synthesised click against the layout as it
  stands at release; WebKit produces no click at all) but that was not
  measured here and is not claimed. If it is that, the red is a product
  defect on Android, so the tag is withheld rather than the spec
  weakened. Its three siblings in the same file port green.

Each holdback carries its reason as a comment at the test.

## Caveat, not softened

`devices["Pixel 7"]` is **chromium with `isMobile` + `hasTouch`, not a
real Android WebView and not Firefox Android**. It covers the #1869
family (behaviour gated on `html.is-ios` that silently vanishes off
Safari). It would **not** have caught #717, which was Firefox Android
hanging on the splash of an installed PWA — Playwright's firefox has no
touch emulation, so Gecko is unreachable from this harness. Selling this
project as "Android coverage" would be false. Worth having, worth not
overselling.

The device stays `Pixel 7` rather than the `Pixel 5` the issue names:
both are chromium with the same two flags, and churning it would
re-measure every geometry assertion to buy nothing.

## Gates

Every one run from this worktree, redirected to a file with the rc
captured separately (a `| tail` would have masked it).

| gate | rc | note |
|---|---|---|
| `scripts/bun.sh run check` | **0** | 5/5 stages (lock drift, test location, biome src+e2e, tsc src, tsc e2e) |
| `scripts/bun.sh run test` | **0** | 6568 vitest tests, 329 files |
| `scripts/integration.sh --project chromium-pixel-touch` | 1 | pre-flight, 140/143 — the 3 reds are the holdbacks above |
| `scripts/integration.sh` (FULL) | **1** | 936 passed, 1 skipped, **2 failed**, 36.3 min |
| `scripts/integration.sh --project chromium --repeat-each 3 --grep …` | **0** | 6/6 — both failures iso-rerun green |
| `scripts/design-notes-gate.sh` | **0** | `1 new entry heading(s), separator and marker present.` |
| `scripts/union-rebase.sh` | **0** | `docs/DESIGN_NOTES.md: +134 -0 — contribution intact` |

### The delta, per project

Taken the same way on both sides — `--list` on the base tree, the run's
own `[project]` result lines after:

| project | before | after |
|---|---|---|
| `chromium` | 648 | 648 |
| `chromium-pixel-touch` | 4 | **140** |
| `webkit-iphone-15` | 151 | 151 |
| total | 803 | 939 |

### The two full-suite reds, attributed

Both on `[chromium]`, the desktop project, whose collected set is **648
before and 648 after** — this diff cannot move it. Neither is in a spec
this branch edits (`issue1445`'s file is touched, but only two `@webkit`
titles in its mobile arms; `slash-commands-bundle.spec.ts` is not in the
diff at all). Both iso-rerun green 3/3.

1. `issue1445-directory-pull-refresh.spec.ts:545` died in `loginAs`
   waiting for the shell. Its `error-context.md` is stamped
   `2026-08-30T23:59:29+0200` — **21:59:29 UTC, the same second** the
   server logged `db write unavailable: SQLite write lock held by
   another writer for 32710ms … returning :db_unavailable` and `db lock
   stall RESOLVED … after 32715ms`. The run's own #1429 census puts a
   32.7 s gap on `grappa-test` at 21:58:56.755 → 21:59:29.464, and the
   33.2 s test lived entirely inside it. Established on THIS run's
   artefacts, not on a borrowed signature.
2. `slash-commands-bundle.spec.ts:152` (`/q` closes the query window)
   left the sidebar entry standing. The server log shows `DELETE FROM
   "query_windows" … slash-q-peer-d32dabbf` at `22:18:26.176` and an
   `INSERT INTO "query_windows"` for the same nick at `22:18:26.180` —
   the close raced a concurrent re-open, 4 ms apart. The census shows no
   gap at that time, so the lock-stall explanation does **not** stretch
   to cover this one and is not claimed to.

The `#1584` cold-start reporter emitted no violations, and the touch
project's new cold seat is `bug7-ios-own-msg-visible.spec.ts`.

### What was measured on which base

The 36.3-minute full suite ran at base `03b0ff858`. `origin/main` then
moved to `9cb9a5445` (two commits touching
`cicchetto/src/BootErrorBoundary.tsx`, its test, and `default.css`), and
this branch is rebased onto that. The cic gates above were re-run after
the rebase and are green on the merged tree; the e2e suite was not re-run
locally, so `integration` CI on this PR is the first e2e signal that
covers those two commits.
