### PR TITLE
cicchetto: ask before a gallery pick reaches the wire (1883)

### DIFF
--- a/cicchetto/e2e/fixtures/uploadJourney.ts
+++ b/cicchetto/e2e/fixtures/uploadJourney.ts
@@ -8,9 +8,11 @@
 //
 // Layering (so the litterbox path can reuse the modal half without
 // the embedded-host POST half):
-//   pickFile()        — feed the hidden picker, wait for the privacy
-//                       modal. Heading is a REQUIRED param: it names
-//                       the active upload host (embedded grappa vs
+//   sendPickedFiles() — answer the 1883 send-confirm the picker now
+//                       raises between selection and dispatch.
+//   pickFile()        — feed the hidden picker, Send, then wait for the
+//                       privacy modal. Heading is a REQUIRED param: it
+//                       names the active upload host (embedded grappa vs
 //                       litterbox.catbox.moe) and a wrong-host modal
 //                       must fail loudly, not match loosely.
 //   uploadViaPicker() — pickFile + Continue + pin POST /api/uploads
@@ -45,10 +47,27 @@ export interface UploadResponse {
 export const EMBEDDED_MODAL_HEADING = /Upload to .+grappa/i;
 export const LITTERBOX_MODAL_HEADING = /Upload to litterbox\.catbox\.moe/i;
 
-// Feed the hidden file input (no OS dialog under setInputFiles) and
-// wait for the privacy modal. Fresh context per test → the modal
-// fires every time. Returns the modal locator for the caller to
-// Continue or Cancel.
+// 1883 — the picker's own confirm, raised BEFORE the privacy modal and
+// before anything reaches the orchestrator. Every picker-driven journey
+// passes through it, so it lives here rather than being restated: a
+// spec that forgot it would hang on the privacy modal instead of
+// failing on the step it actually skipped.
+//
+// Asserted, not just clicked: the dialog must be the SEND one (a bare
+// `confirm-modal` click would also be satisfied by whatever other
+// confirm happened to be open) and it must be gone afterwards.
+export async function sendPickedFiles(page: Page): Promise<void> {
+  const confirm = page.getByTestId("confirm-modal");
+  await expect(confirm).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("confirm-modal-confirm")).toHaveText("Send");
+  await page.getByTestId("confirm-modal-confirm").click();
+  await expect(confirm).toBeHidden({ timeout: 5_000 });
+}
+
+// Feed the hidden file input (no OS dialog under setInputFiles),
+// authorise the 1883 send-confirm, and wait for the privacy modal.
+// Fresh context per test → both modals fire every time. Returns the
+// PRIVACY modal locator for the caller to Continue or Cancel.
 export async function pickFile(
   page: Page,
   file: PickerFile,
@@ -56,6 +75,7 @@ export async function pickFile(
 ): Promise<Locator> {
   const picker = page.locator("input[data-file-picker]");
   await picker.setInputFiles(file);
+  await sendPickedFiles(page);
 
   const modal = page.getByRole("dialog", { name: modalHeading });
   await expect(modal).toBeVisible({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/issue1883-picker-send-confirm.spec.ts
+++ b/cicchetto/e2e/tests/issue1883-picker-send-confirm.spec.ts
@@ -1,0 +1,152 @@
+// 1883 — a gallery pick asks before it publishes.
+//
+// The defect: picking a file reached the wire with nothing in between.
+// `onPickerChange` handed `input.files` straight to `triggerUploads`, and the
+// only gate — the privacy modal — is one-shot per host, so for every operator
+// who had ever ticked "remember" the sequence was tap paperclip -> tap photo
+// -> it is public. On a phone the gallery grid is dense; a mis-tap picks the
+// wrong photo and there is no undo.
+//
+// Why this has to be a real browser and not jsdom: the thing under test is
+// whether an upload HAPPENS, and the only honest witness to that is the
+// network. Every assertion here is either a POST counter over the real
+// same-origin `/api/uploads` or a row that actually landed in scrollback
+// after the IRC echo. A jsdom test can prove the orchestrator was not called;
+// it cannot prove nothing left the machine.
+//
+// The counter pattern (and its positive control) is the one ux-6-b-embedded
+// established: a same-origin `page.route()` stub would block cic's own
+// bootstrap, so requests are counted instead, and a zero is only evidence
+// once the SAME predicate has been shown to count a real upload.
+
+import type { Page } from "@playwright/test";
+import { TINY_PNG_HEX } from "../fixtures/bytes";
+import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+import { EMBEDDED_MODAL_HEADING, sendPickedFiles } from "../fixtures/uploadJourney";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+const png = (name: string) => ({
+  name,
+  mimeType: "image/png",
+  buffer: Buffer.from(TINY_PNG_HEX, "hex"),
+});
+
+const txt = (name: string) => ({
+  name,
+  mimeType: "text/plain",
+  buffer: Buffer.from("1883\n", "utf8"),
+});
+
+// Count real POSTs to the embedded upload host. Returns a reader, so the
+// assertion sites read as `uploads()` rather than a mutable let.
+function countUploadPosts(page: Page): () => number {
+  let hits = 0;
+  page.on("request", (req) => {
+    if (req.method() === "POST" && req.url().endsWith("/api/uploads")) hits += 1;
+  });
+  return () => hits;
+}
+
+// The privacy modal is one-shot per host and is NOT what this spec is about;
+// pre-acking it puts the browser in the exact state of the returning operator
+// the issue describes — the one for whom nothing at all stood in the way.
+async function asReturningOperator(page: Page): Promise<void> {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await page.evaluate(() =>
+    localStorage.setItem("image-upload-privacy-acknowledged:embedded", "1"),
+  );
+}
+
+test("1883 — the returning operator is asked, and Cancel publishes nothing", async ({ page }) => {
+  const uploads = countUploadPosts(page);
+  await asReturningOperator(page);
+
+  await page.locator("input[data-file-picker]").setInputFiles(png("gallery-mistap.png"));
+
+  // The confirm shows WHAT is about to be sent and WHERE. This is the whole
+  // cure: a mis-tap is only recoverable if the operator can see it is one.
+  const confirm = page.getByTestId("confirm-modal");
+  await expect(confirm).toBeVisible({ timeout: 5_000 });
+  await expect(confirm).toContainText("gallery-mistap.png");
+  // The destination is named, and it is the dialog's accessible name — the
+  // one string a screen reader announces on open.
+  await expect(confirm).toHaveAttribute("aria-label", `Send to ${CHANNEL}?`);
+  // An image previews as a picture, from the operator's own bytes.
+  await expect(page.getByTestId("confirm-modal-attachment-thumb")).toHaveAttribute("src", /^blob:/);
+
+  await page.getByTestId("confirm-modal-cancel").click();
+  await expect(confirm).toBeHidden({ timeout: 5_000 });
+
+  // Nothing went anywhere: no POST, and the privacy modal — the next step in
+  // the old journey — never opened either.
+  await page.waitForTimeout(500);
+  expect(uploads()).toBe(0);
+  await expect(page.getByRole("dialog", { name: EMBEDDED_MODAL_HEADING })).toHaveCount(0);
+  await expect(scrollbackLine(page, "privmsg", "📸")).toHaveCount(0);
+
+  // POSITIVE CONTROL, deliberately after the zero. A mistyped path, a
+  // `.endsWith` that stopped matching after a route change, or a listener on
+  // the wrong page all leave the counter at 0 with the guard broken — green in
+  // both worlds. Drive the same journey to Send: the real POST goes through
+  // the very predicate asserted empty above, so a blind counter reds here.
+  await page.locator("input[data-file-picker]").setInputFiles(png("control.png"));
+  await sendPickedFiles(page);
+  await expect.poll(uploads, { timeout: 15_000 }).toBe(1);
+  await expect(scrollbackLine(page, "privmsg", "📸").first()).toBeVisible({ timeout: 15_000 });
+});
+
+test("1883 — a removed file is not sent; the rest of the batch is", async ({ page }) => {
+  const uploads = countUploadPosts(page);
+  await asReturningOperator(page);
+
+  // Two files, one image and one document, so the row rendering is exercised
+  // on BOTH shapes: a thumbnail for the picture, name + size for the text.
+  await page.locator("input[data-file-picker]").setInputFiles([png("keep.png"), txt("drop.txt")]);
+
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(2);
+  // The non-image row carries no picture — it is named and sized instead.
+  await expect(page.getByTestId("confirm-modal-attachment-thumb")).toHaveCount(1);
+  await expect(page.getByTestId("confirm-modal-attachments")).toContainText("drop.txt");
+
+  await page.getByRole("button", { name: /remove drop\.txt/i }).click();
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(1);
+  await expect(page.getByTestId("confirm-modal-attachments")).not.toContainText("drop.txt");
+  // Removing a file is not answering the question — the dialog is still up.
+  await expect(page.getByTestId("confirm-modal")).toBeVisible();
+
+  await sendPickedFiles(page);
+
+  // Exactly ONE upload: the kept file. The batch counter would have shown
+  // "(1/2)" and posted twice if the removal had only hidden a row.
+  await expect.poll(uploads, { timeout: 20_000 }).toBe(1);
+  await expect(scrollbackLine(page, "privmsg", "📸").first()).toBeVisible({ timeout: 15_000 });
+  // Settle: give a second POST every chance to appear before claiming there
+  // was none. Without this the `toBe(1)` above could simply be early.
+  await page.waitForTimeout(1_000);
+  expect(uploads()).toBe(1);
+});
+
+test("1883 — removing the last file closes the dialog and uploads nothing", async ({ page }) => {
+  const uploads = countUploadPosts(page);
+  await asReturningOperator(page);
+
+  await page.locator("input[data-file-picker]").setInputFiles(png("only.png"));
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(1);
+
+  await page.getByRole("button", { name: /remove only\.png/i }).click();
+
+  // An empty dialog asking "send these?" has nothing to affirm, so it closes —
+  // the same answer as Cancel, reached a different way.
+  await expect(page.getByTestId("confirm-modal")).toBeHidden({ timeout: 5_000 });
+  await page.waitForTimeout(500);
+  expect(uploads()).toBe(0);
+
+  // POSITIVE CONTROL — same counter, same page, a journey that must count.
+  await page.locator("input[data-file-picker]").setInputFiles(png("control.png"));
+  await sendPickedFiles(page);
+  await expect.poll(uploads, { timeout: 15_000 }).toBe(1);
+});

--- a/cicchetto/e2e/tests/issue1883-picker-send-confirm.spec.ts
+++ b/cicchetto/e2e/tests/issue1883-picker-send-confirm.spec.ts
@@ -76,7 +76,18 @@ test("1883 — the returning operator is asked, and Cancel publishes nothing", a
   // one string a screen reader announces on open.
   await expect(confirm).toHaveAttribute("aria-label", `Send to ${CHANNEL}?`);
   // An image previews as a picture, from the operator's own bytes.
-  await expect(page.getByTestId("confirm-modal-attachment-thumb")).toHaveAttribute("src", /^blob:/);
+  const thumb = page.getByTestId("confirm-modal-attachment-thumb");
+  await expect(thumb).toHaveAttribute("src", /^blob:/);
+  // And it DECODED. The `src` above is set by cic and says nothing about what
+  // the browser did with it: measured on this very stack, the prod CSP's
+  // `img-src` refused the object URL (`blockedURI: blob`) and the row rendered
+  // an empty box with the attribute intact — green here, broken on screen, in
+  // the one dialog whose entire job is showing WHICH photo. `naturalWidth`
+  // is the same witness `media-link-cross-host-modal` uses for the #1240
+  // widening, and it is what a CSP revert has to red on.
+  await expect
+    .poll(() => thumb.evaluate((el) => (el as HTMLImageElement).naturalWidth), { timeout: 5_000 })
+    .toBeGreaterThan(0);
 
   await page.getByTestId("confirm-modal-cancel").click();
   await expect(confirm).toBeHidden({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-cross-host-modal.spec.ts
@@ -118,8 +118,12 @@ test("cross-host https image link opens the media viewer, href unchanged, bytes 
   // carry the widened token — pin it here so a plug revert reddens this
   // spec with a legible message instead of a bare naturalWidth of 0.
   const csp = (await page.request.get("/")).headers()["content-security-policy"];
+  // Whole directive, not just the `https:` token this spec is about: any
+  // shorter spelling is a PREFIX of the longer one, so a `toContain` on the
+  // fragment would stay green through a revert. (1883 inserted `blob:` for
+  // the picker confirm's own thumbnail — a different journey, same string.)
   expect(csp, "server-served CSP must widen img-src for cross-host images").toContain(
-    "img-src 'self' data: https:",
+    "img-src 'self' data: blob: https:",
   );
 
   const link = await foreignLink(page, IMAGE_URL);

--- a/cicchetto/e2e/tests/nginx-csp-range-parity.spec.ts
+++ b/cicchetto/e2e/tests/nginx-csp-range-parity.spec.ts
@@ -42,8 +42,11 @@ const LOAD_BEARING_DIRECTIVES = [
   // #1240 — same prefix trap: the old "img-src 'self' data:" pin is a
   // PREFIX of the widened value, so it must be pinned WITH the `https:`
   // token or a revert would sail through `toContain`. Losing it opens the
-  // cross-host image viewer as an EMPTY modal.
-  "img-src 'self' data: https:",
+  // cross-host image viewer as an EMPTY modal. 1883 added `blob:` in the
+  // middle for the picker confirm's thumbnail — pinned as the WHOLE value
+  // for the third time and the same reason: every shorter spelling of this
+  // directive is a prefix of the longer one.
+  "img-src 'self' data: blob: https:",
   "worker-src 'self' blob:",
   "frame-ancestors 'none'",
   "base-uri 'self'",

--- a/cicchetto/e2e/tests/uploads3-multifile.spec.ts
+++ b/cicchetto/e2e/tests/uploads3-multifile.spec.ts
@@ -21,6 +21,7 @@ import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
+import { sendPickedFiles } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -36,13 +37,17 @@ test("uploads-3 #118 — multi-file picker uploads ALL files sequentially → tw
     localStorage.setItem("image-upload-privacy-acknowledged:embedded", "1"),
   );
 
-  // Stage TWO PNGs on the (now `multiple`) picker → triggerUploads([a, b]).
+  // Stage TWO PNGs on the (now `multiple`) picker → the 1883 send-confirm →
+  // triggerUploads([a, b]). The confirm lists the WHOLE batch, so both names
+  // are on screen before either byte moves.
   const png = Buffer.from(TINY_PNG_HEX, "hex");
   const picker = page.locator("input[data-file-picker]");
   await picker.setInputFiles([
     { name: "multi-a.png", mimeType: "image/png", buffer: png },
     { name: "multi-b.png", mimeType: "image/png", buffer: png },
   ]);
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(2);
+  await sendPickedFiles(page);
 
   // Both upload sequentially → two 📸 PRIVMSGs land after the IRC echo.
   const rows = scrollbackLine(page, "privmsg", "📸");

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -30,6 +30,7 @@ import { frameBudgetBaseForNetwork } from "./lib/isupport";
 import { createNetworkReconnect } from "./lib/networkReconnect";
 import { networkBySlug } from "./lib/networks";
 import { routeClipboardPaste, routePastedInput } from "./lib/pasteRoute";
+import { pickerUpload } from "./lib/pickerUpload";
 import {
   claimAxis,
   type DragAxis,
@@ -42,7 +43,6 @@ import {
   cancelUpload,
   dismissUpload,
   retryUpload,
-  triggerUploads,
   uploadBatch,
   uploadState,
 } from "./lib/uploadOrchestrator";
@@ -530,11 +530,15 @@ const ComposeBox: Component<Props> = (props) => {
     const input = e.currentTarget as HTMLInputElement;
     // Picker path does NOT pre-filter by category: normalizeUploadFile in
     // the orchestrator relabels iOS .m4r ringtones (octet-stream → audio)
-    // that categoryOf would otherwise drop.
+    // that categoryOf would otherwise drop. `pickerUpload` preserves that —
+    // it is deliberately NOT `dropUpload`, which does filter.
     const files = input.files ? Array.from(input.files) : [];
-    if (files.length > 0) {
-      triggerUploads(key(), props.networkSlug, props.channelName, files);
-    }
+    // 1883 — the picker asks first. A gallery tap used to reach the wire with
+    // nothing in between, so a mis-tap on a dense thumbnail grid published the
+    // wrong photo with no undo. `pickerUpload` opens the confirm and reaches
+    // the orchestrator only on Send; drop and paste keep going straight
+    // through (a drag has a visible target, a paste is typed).
+    pickerUpload(files, props.networkSlug, props.channelName);
     // Reset so picking the same file twice still fires `change`.
     input.value = "";
   };

--- a/cicchetto/src/ConfirmModal.tsx
+++ b/cicchetto/src/ConfirmModal.tsx
@@ -1,6 +1,7 @@
-import { type Component, createEffect, Show } from "solid-js";
+import { type Component, createEffect, For, onCleanup, Show } from "solid-js";
 import {
   acceptConfirm,
+  type ConfirmAttachment,
   chooseAlternative,
   confirmRequest,
   dismissConfirm,
@@ -17,6 +18,72 @@ import { createOverlayLock } from "./lib/overlayScrollLock";
 // firing. Only the explicit affirmative button runs the carried action.
 // Structure mirrors DeleteAccountModal (backdrop-nested dialog + overlay
 // scroll-lock), the closest existing confirm-shaped modal.
+//
+// 1883 — an OPTIONAL attachment list sits between the body and the buttons,
+// for requests whose question is about FILES. It is the same chrome, not a
+// second modal: the file-upload confirm gets the same scrim, the same Esc, the
+// same Cancel-first focus order as every other confirm in cic, and cic gains
+// no new overlay to keep consistent. The rows arrive pre-formatted (see
+// ConfirmAttachment) — this component decides layout and object-URL lifetime,
+// nothing else.
+
+// One attachment row. Its OWN component so the object URL can be minted and
+// revoked by the row's lifecycle: `onCleanup` here fires when the row leaves —
+// whether that is a per-file removal, a Send, or a dismiss — which is the only
+// place that knows the URL is finished with. Doing it in the store would need
+// a dismiss hook the store deliberately does not have; doing it in the caller
+// would leak on every path it forgot.
+const AttachmentRow: Component<{
+  item: ConfirmAttachment;
+  onRemove: (id: string) => void;
+}> = (props) => {
+  // Read once, not reactively: `<For>` hands each row a stable item object, so
+  // a row's blob never changes under it — a re-mint would only churn URLs.
+  const blob = props.item.thumbnail;
+  const src = blob === null ? null : URL.createObjectURL(blob);
+  if (src !== null) onCleanup(() => URL.revokeObjectURL(src));
+
+  return (
+    <li class="confirm-modal-attachment" data-testid="confirm-modal-attachment">
+      <Show
+        when={src}
+        fallback={
+          <span class="confirm-modal-attachment-icon" aria-hidden="true">
+            {/* No picture to show — a neutral placeholder keeps the rows the
+                same height so a mixed batch does not read as ragged. */}
+            &#9744;
+          </span>
+        }
+      >
+        {(url) => (
+          <img
+            class="confirm-modal-attachment-thumb"
+            data-testid="confirm-modal-attachment-thumb"
+            src={url()}
+            // The filename beside it is the accessible label; announcing the
+            // picture too would read the same file twice.
+            alt=""
+          />
+        )}
+      </Show>
+      <span class="confirm-modal-attachment-text">
+        <span class="confirm-modal-attachment-name">{props.item.label}</span>
+        <span class="confirm-modal-attachment-detail">{props.item.detail}</span>
+      </span>
+      <button
+        type="button"
+        class="confirm-modal-attachment-remove"
+        // Named per file: three bare × buttons are indistinguishable to a
+        // screen reader, and picking the wrong one is the very mistake this
+        // dialog exists to catch.
+        aria-label={`Remove ${props.item.label}`}
+        onClick={() => props.onRemove(props.item.id)}
+      >
+        &times;
+      </button>
+    </li>
+  );
+};
 
 const ConfirmModal: Component = () => {
   let cancelBtn: HTMLButtonElement | undefined;
@@ -66,6 +133,18 @@ const ConfirmModal: Component = () => {
             <p class="confirm-modal-body" data-testid="confirm-modal-body">
               {req().body}
             </p>
+            {/* 1883 — the file list, when the request carries one. Between
+                the question and the buttons: the operator reads what is
+                about to happen, sees WHAT it happens to, then answers. */}
+            <Show when={req().attachments}>
+              {(atts) => (
+                <ul class="confirm-modal-attachments" data-testid="confirm-modal-attachments">
+                  <For each={atts().items()}>
+                    {(item) => <AttachmentRow item={item} onRemove={atts().onRemove} />}
+                  </For>
+                </ul>
+              )}
+            </Show>
             <div class="confirm-modal-actions">
               <button
                 ref={cancelBtn}

--- a/cicchetto/src/ThemeGallery.tsx
+++ b/cicchetto/src/ThemeGallery.tsx
@@ -228,6 +228,7 @@ const ThemeGallery: Component<Props> = (props) => {
       confirmLabel: "Delete",
       onConfirm: () => void remove(theme),
       alternative: null,
+      attachments: null,
     });
 
   // #333 — split the merged list into "your themes" (owned copies/creates)

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -1307,22 +1307,56 @@ describe("ComposeBox", () => {
       expect(input).toBeNull();
     });
 
-    it("selecting a file via the picker calls triggerUpload with file + slug + channel", async () => {
-      const orch = await import("../lib/uploadOrchestrator");
-      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    // 1883 — the picker no longer reaches the orchestrator by itself. It
+    // stages the pick behind a confirm; the orchestrator is reached only when
+    // the operator says Send. What is asserted here is the WIRING (the picked
+    // file reaches the guard, and nothing is uploaded before an answer) — the
+    // guard's own behaviour is pickerUpload.test.ts's job.
+    const pickFile = (file: File): void => {
       const input = document.querySelector(
         "input[type='file'][data-file-picker]",
       ) as HTMLInputElement;
-      const file = sampleImage();
-      Object.defineProperty(input, "files", {
-        value: [file],
-        configurable: true,
-      });
+      Object.defineProperty(input, "files", { value: [file], configurable: true });
       fireEvent.change(input);
+    };
+
+    it("selecting a file via the picker asks first and uploads NOTHING yet — 1883", async () => {
+      const orch = await import("../lib/uploadOrchestrator");
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+
+      pickFile(sampleImage());
+
+      const req = confirmRequest();
+      expect(req).not.toBeNull();
+      // Pin WHICH dialog opened — without this the case passes against any
+      // build that happens to have some confirm pending.
+      expect(req?.confirmLabel).toBe("Send");
+      expect(req?.attachments?.items().map((a) => a.label)).toEqual(["screenshot.png"]);
+      expect(orch.triggerUploads).not.toHaveBeenCalled();
+    });
+
+    it("confirming the picker dialog uploads the file with slug + channel — 1883", async () => {
+      const orch = await import("../lib/uploadOrchestrator");
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const file = sampleImage();
+
+      pickFile(file);
+      acceptConfirm();
 
       expect(orch.triggerUploads).toHaveBeenCalledWith(expect.any(String), "freenode", "#a", [
         file,
       ]);
+    });
+
+    it("cancelling the picker dialog uploads nothing — 1883", async () => {
+      const orch = await import("../lib/uploadOrchestrator");
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+
+      pickFile(sampleImage());
+      expect(confirmRequest()?.confirmLabel).toBe("Send");
+      dismissConfirm();
+
+      expect(orch.triggerUploads).not.toHaveBeenCalled();
     });
 
     // #351 — the compose form is NO LONGER a drop target. Drag-drop was

--- a/cicchetto/src/__tests__/ConfirmModal.test.tsx
+++ b/cicchetto/src/__tests__/ConfirmModal.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import ConfirmModal from "../ConfirmModal";
-import { dismissConfirm, requestConfirm } from "../lib/confirmDialog";
+import { type ConfirmAttachment, dismissConfirm, requestConfirm } from "../lib/confirmDialog";
 import {
   __resetForTest,
   overlayEscapeDepth,
@@ -32,6 +32,7 @@ describe("ConfirmModal (#195)", () => {
       confirmLabel: "Yes",
       onConfirm: vi.fn(),
       alternative: null,
+      attachments: null,
     });
     expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
     expect(screen.getByTestId("confirm-modal-body").textContent).toBe(
@@ -44,7 +45,14 @@ describe("ConfirmModal (#195)", () => {
   it("the affirmative button fires the action and closes", () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+    requestConfirm({
+      title: "t",
+      body: "b",
+      confirmLabel: "Yes",
+      onConfirm,
+      alternative: null,
+      attachments: null,
+    });
     fireEvent.click(screen.getByTestId("confirm-modal-confirm"));
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("confirm-modal")).toBeNull();
@@ -53,7 +61,14 @@ describe("ConfirmModal (#195)", () => {
   it("Cancel dismisses WITHOUT firing the action", () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+    requestConfirm({
+      title: "t",
+      body: "b",
+      confirmLabel: "Yes",
+      onConfirm,
+      alternative: null,
+      attachments: null,
+    });
     fireEvent.click(screen.getByTestId("confirm-modal-cancel"));
     expect(onConfirm).not.toHaveBeenCalled();
     expect(screen.queryByTestId("confirm-modal")).toBeNull();
@@ -62,7 +77,14 @@ describe("ConfirmModal (#195)", () => {
   it("backdrop click dismisses WITHOUT firing the action", () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+    requestConfirm({
+      title: "t",
+      body: "b",
+      confirmLabel: "Yes",
+      onConfirm,
+      alternative: null,
+      attachments: null,
+    });
     fireEvent.click(screen.getByTestId("confirm-modal-backdrop"));
     expect(onConfirm).not.toHaveBeenCalled();
     expect(screen.queryByTestId("confirm-modal")).toBeNull();
@@ -74,7 +96,14 @@ describe("ConfirmModal (#195)", () => {
   it("Escape dismisses WITHOUT firing the action (shared overlay stack)", async () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+    requestConfirm({
+      title: "t",
+      body: "b",
+      confirmLabel: "Yes",
+      onConfirm,
+      alternative: null,
+      attachments: null,
+    });
     await waitFor(() => expect(overlayEscapeDepth()).toBe(1));
     expect(runTopmostOverlayEscape()).toBe(true);
     await waitFor(() => expect(screen.queryByTestId("confirm-modal")).toBeNull());
@@ -95,6 +124,7 @@ describe("ConfirmModal (#195)", () => {
         confirmLabel: "Yes",
         onConfirm: vi.fn(),
         alternative: null,
+        attachments: null,
       });
       expect(screen.queryByTestId("confirm-modal-alternative")).toBeNull();
     });
@@ -109,6 +139,7 @@ describe("ConfirmModal (#195)", () => {
         confirmLabel: "Paste",
         onConfirm,
         alternative: { label: "Upload as .txt", onSelect },
+        attachments: null,
       });
       const btn = screen.getByTestId("confirm-modal-alternative");
       expect(btn.textContent).toBe("Upload as .txt");
@@ -116,6 +147,103 @@ describe("ConfirmModal (#195)", () => {
       expect(onSelect).toHaveBeenCalledTimes(1);
       expect(onConfirm).not.toHaveBeenCalled();
       expect(screen.queryByTestId("confirm-modal")).toBeNull();
+    });
+  });
+
+  // 1883 — the OPTIONAL attachment list. A question about files cannot be
+  // asked in a sentence: "Send this?" is only answerable if the operator can
+  // see WHICH file. Text-only requests must be untouched — the list appears
+  // only when the request carries one.
+  describe("1883 — the attachment list", () => {
+    const attachment = (over: Partial<ConfirmAttachment>): ConfirmAttachment => ({
+      id: "a1",
+      label: "cat.png",
+      detail: "12 KB",
+      thumbnail: null,
+      ...over,
+    });
+
+    const withAttachments = (items: ConfirmAttachment[], onRemove: (id: string) => void): void => {
+      requestConfirm({
+        title: "Send to #a?",
+        body: "b",
+        confirmLabel: "Send",
+        onConfirm: vi.fn(),
+        alternative: null,
+        attachments: { items: () => items, onRemove },
+      });
+    };
+
+    it("is absent when the request carries no attachments", () => {
+      render(() => <ConfirmModal />);
+      requestConfirm({
+        title: "t",
+        body: "b",
+        confirmLabel: "Yes",
+        onConfirm: vi.fn(),
+        alternative: null,
+        attachments: null,
+      });
+      expect(screen.queryByTestId("confirm-modal-attachments")).toBeNull();
+    });
+
+    it("renders one row per attachment, with its label and detail", () => {
+      render(() => <ConfirmModal />);
+      withAttachments(
+        [
+          attachment({ id: "a1", label: "cat.png", detail: "12 KB" }),
+          attachment({ id: "a2", label: "spec.pdf", detail: "2 KB" }),
+        ],
+        vi.fn(),
+      );
+      expect(screen.getAllByTestId("confirm-modal-attachment")).toHaveLength(2);
+      expect(screen.getByText("spec.pdf")).toBeInTheDocument();
+      expect(screen.getByText("2 KB")).toBeInTheDocument();
+    });
+
+    it("renders a thumbnail for a row that carries a blob, and none for one that does not", () => {
+      render(() => <ConfirmModal />);
+      withAttachments(
+        [
+          attachment({
+            id: "a1",
+            label: "cat.png",
+            thumbnail: new Blob(["x"], { type: "image/png" }),
+          }),
+          attachment({ id: "a2", label: "spec.pdf", thumbnail: null }),
+        ],
+        vi.fn(),
+      );
+      const thumbs = screen.getAllByTestId("confirm-modal-attachment-thumb");
+      expect(thumbs).toHaveLength(1);
+      // A real object URL, not a data: placeholder — the row is showing the
+      // operator's own bytes back to them.
+      expect(thumbs[0]?.getAttribute("src")).toMatch(/^blob:/);
+    });
+
+    it("the remove button reports the row's id and does NOT resolve the dialog", () => {
+      const onRemove = vi.fn();
+      render(() => <ConfirmModal />);
+      withAttachments([attachment({ id: "a2", label: "drop.png" })], onRemove);
+
+      fireEvent.click(screen.getByRole("button", { name: /remove drop\.png/i }));
+
+      expect(onRemove).toHaveBeenCalledWith("a2");
+      // Removing a file is not answering the question — the dialog stays.
+      expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
+    });
+
+    it("revokes a row's object URL when the dialog closes", () => {
+      const revoke = vi.spyOn(URL, "revokeObjectURL");
+      render(() => <ConfirmModal />);
+      withAttachments([attachment({ thumbnail: new Blob(["x"], { type: "image/png" }) })], vi.fn());
+      const src = screen.getByTestId("confirm-modal-attachment-thumb").getAttribute("src");
+      expect(src).toMatch(/^blob:/);
+
+      dismissConfirm();
+
+      expect(revoke).toHaveBeenCalledWith(src);
+      revoke.mockRestore();
     });
   });
 });

--- a/cicchetto/src/__tests__/cardEscape.test.tsx
+++ b/cicchetto/src/__tests__/cardEscape.test.tsx
@@ -146,6 +146,7 @@ const leaveChannelRequest = (onConfirm: () => void): ConfirmRequest => ({
   confirmLabel: "Yes",
   onConfirm,
   alternative: null,
+  attachments: null,
 });
 
 let handlers: KeybindingHandlers;

--- a/cicchetto/src/__tests__/confirmDialog.test.ts
+++ b/cicchetto/src/__tests__/confirmDialog.test.ts
@@ -17,14 +17,28 @@ describe("confirmDialog store (#195)", () => {
 
   it("requestConfirm sets the pending request without firing the action", () => {
     const onConfirm = vi.fn();
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+    requestConfirm({
+      title: "t",
+      body: "b",
+      confirmLabel: "Yes",
+      onConfirm,
+      alternative: null,
+      attachments: null,
+    });
     expect(confirmRequest()).toMatchObject({ title: "t", body: "b", confirmLabel: "Yes" });
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
   it("acceptConfirm fires the action once and clears the request", () => {
     const onConfirm = vi.fn();
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+    requestConfirm({
+      title: "t",
+      body: "b",
+      confirmLabel: "Yes",
+      onConfirm,
+      alternative: null,
+      attachments: null,
+    });
     acceptConfirm();
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(confirmRequest()).toBeNull();
@@ -32,7 +46,14 @@ describe("confirmDialog store (#195)", () => {
 
   it("dismissConfirm clears the request WITHOUT firing the action (safe default)", () => {
     const onConfirm = vi.fn();
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+    requestConfirm({
+      title: "t",
+      body: "b",
+      confirmLabel: "Yes",
+      onConfirm,
+      alternative: null,
+      attachments: null,
+    });
     dismissConfirm();
     expect(onConfirm).not.toHaveBeenCalled();
     expect(confirmRequest()).toBeNull();
@@ -52,6 +73,7 @@ describe("confirmDialog store (#195)", () => {
       confirmLabel: "Yes",
       onConfirm: first,
       alternative: null,
+      attachments: null,
     });
     requestConfirm({
       title: "2",
@@ -59,6 +81,7 @@ describe("confirmDialog store (#195)", () => {
       confirmLabel: "Yes",
       onConfirm: second,
       alternative: null,
+      attachments: null,
     });
     expect(confirmRequest()?.title).toBe("2");
     acceptConfirm();
@@ -84,6 +107,7 @@ describe("confirmDialog store (#195)", () => {
         confirmLabel: "Yes",
         onConfirm,
         alternative: alt(onSelect),
+        attachments: null,
       });
       chooseAlternative();
       expect(onSelect).toHaveBeenCalledTimes(1);
@@ -101,6 +125,7 @@ describe("confirmDialog store (#195)", () => {
         confirmLabel: "Yes",
         onConfirm,
         alternative: alt(onSelect),
+        attachments: null,
       });
       acceptConfirm();
       expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -116,6 +141,7 @@ describe("confirmDialog store (#195)", () => {
         confirmLabel: "Yes",
         onConfirm,
         alternative: alt(onSelect),
+        attachments: null,
       });
       dismissConfirm();
       expect(onConfirm).not.toHaveBeenCalled();
@@ -125,7 +151,14 @@ describe("confirmDialog store (#195)", () => {
 
     it("chooseAlternative on a request that carries none is a safe no-op", () => {
       const onConfirm = vi.fn();
-      requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+      requestConfirm({
+        title: "t",
+        body: "b",
+        confirmLabel: "Yes",
+        onConfirm,
+        alternative: null,
+        attachments: null,
+      });
       expect(() => chooseAlternative()).not.toThrow();
       expect(onConfirm).not.toHaveBeenCalled();
       // The request survives: nothing was chosen, so nothing was resolved.

--- a/cicchetto/src/__tests__/pickerUpload.test.ts
+++ b/cicchetto/src/__tests__/pickerUpload.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// 1883 — the gallery-pick confirm. Between "the native picker returned a
+// file" and "the bytes are on their way to the channel" there is now one
+// deliberate step: a confirm that SHOWS what is about to be sent and where.
+//
+// The orchestrator is the boundary (mocked): what this file proves is
+// exactly WHEN it is reached and with WHAT — never before the operator has
+// said Send, and never with a file they took back. `channelKey` is mocked
+// to the same `${slug} ${name}` shape dropUpload.test.ts uses so the
+// assertions read plainly.
+
+vi.mock("../lib/uploadOrchestrator", () => ({
+  triggerUploads: vi.fn(),
+}));
+
+vi.mock("../lib/channelKey", () => ({
+  channelKey: (slug: string, name: string) => `${slug} ${name}`,
+}));
+
+import {
+  acceptConfirm,
+  type ConfirmAttachment,
+  confirmRequest,
+  dismissConfirm,
+} from "../lib/confirmDialog";
+import { pickerUpload } from "../lib/pickerUpload";
+import { triggerUploads } from "../lib/uploadOrchestrator";
+
+const png = (name: string): File =>
+  new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], name, { type: "image/png" });
+const pdf = (name: string): File =>
+  new File([new Uint8Array(2048)], name, { type: "application/pdf" });
+// iOS labels a .m4r ringtone octet-stream; `categoryOf` rejects that MIME.
+// The picker deliberately does NOT pre-filter — `normalizeUploadFile` in the
+// orchestrator is what rescues it (ComposeBox.onPickerChange's contract).
+const ringtone = (): File =>
+  new File([new Uint8Array(8)], "ring.m4r", { type: "application/octet-stream" });
+
+const attachments = (): ConfirmAttachment[] => confirmRequest()?.attachments?.items() ?? [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dismissConfirm();
+});
+
+describe("pickerUpload — the confirm step (1883)", () => {
+  it("an empty pick opens no dialog and uploads nothing", () => {
+    pickerUpload([], "freenode", "#a");
+    expect(confirmRequest()).toBeNull();
+    expect(triggerUploads).not.toHaveBeenCalled();
+  });
+
+  it("a pick opens a confirm and uploads NOTHING until it is answered", () => {
+    pickerUpload([png("cat.png")], "freenode", "#a");
+    const req = confirmRequest();
+    expect(req).not.toBeNull();
+    // The destination is on screen — this is the whole point of the step. It
+    // lives in the title, which is also the dialog's aria-label.
+    expect(req?.title).toContain("#a");
+    expect(req?.confirmLabel).toBe("Send");
+    expect(triggerUploads).not.toHaveBeenCalled();
+  });
+
+  it("the confirm lists every picked file by name and size", () => {
+    pickerUpload([png("cat.png"), pdf("spec.pdf")], "freenode", "#a");
+    expect(attachments().map((a) => a.label)).toEqual(["cat.png", "spec.pdf"]);
+    // Size is spelled by the ONE cap/size formatter (#411), not re-invented.
+    expect(attachments()[1]?.detail).toBe("2 KB");
+  });
+
+  it("an image carries a thumbnail source; a non-image carries none", () => {
+    const cat = png("cat.png");
+    pickerUpload([cat, pdf("spec.pdf")], "freenode", "#a");
+    expect(attachments()[0]?.thumbnail).toBe(cat);
+    expect(attachments()[1]?.thumbnail).toBeNull();
+  });
+
+  it("Send uploads exactly the picked files to the picked window", () => {
+    const a = png("a.png");
+    const b = png("b.png");
+    pickerUpload([a, b], "freenode", "#a");
+
+    acceptConfirm();
+
+    expect(triggerUploads).toHaveBeenCalledWith("freenode #a", "freenode", "#a", [a, b]);
+  });
+
+  it("Cancel / Esc / backdrop upload NOTHING", () => {
+    pickerUpload([png("oops.png")], "freenode", "#a");
+
+    dismissConfirm();
+
+    expect(triggerUploads).not.toHaveBeenCalled();
+    expect(confirmRequest()).toBeNull();
+  });
+
+  it("removing one file drops it from the batch — Send posts only the rest", () => {
+    const keep = png("keep.png");
+    const drop = png("drop.png");
+    pickerUpload([keep, drop], "freenode", "#a");
+
+    const removed = attachments()[1];
+    expect(removed?.label).toBe("drop.png");
+    confirmRequest()?.attachments?.onRemove(removed?.id ?? "");
+
+    expect(attachments().map((a) => a.label)).toEqual(["keep.png"]);
+    acceptConfirm();
+    expect(triggerUploads).toHaveBeenCalledWith("freenode #a", "freenode", "#a", [keep]);
+  });
+
+  it("removing the LAST file closes the dialog and uploads nothing", () => {
+    pickerUpload([png("only.png")], "freenode", "#a");
+
+    confirmRequest()?.attachments?.onRemove(attachments()[0]?.id ?? "");
+
+    expect(confirmRequest()).toBeNull();
+    expect(triggerUploads).not.toHaveBeenCalled();
+  });
+
+  it("two picks with the same filename stay separately removable", () => {
+    const first = png("IMG_0001.png");
+    const second = png("IMG_0001.png");
+    pickerUpload([first, second], "freenode", "#a");
+
+    const ids = attachments().map((a) => a.id);
+    expect(new Set(ids).size).toBe(2);
+    confirmRequest()?.attachments?.onRemove(ids[0] ?? "");
+
+    acceptConfirm();
+    expect(triggerUploads).toHaveBeenCalledWith("freenode #a", "freenode", "#a", [second]);
+  });
+
+  it("does NOT pre-filter by category — an iOS .m4r still reaches the orchestrator", () => {
+    const m4r = ringtone();
+    pickerUpload([m4r], "freenode", "#a");
+    expect(attachments()).toHaveLength(1);
+
+    acceptConfirm();
+
+    expect(triggerUploads).toHaveBeenCalledWith("freenode #a", "freenode", "#a", [m4r]);
+  });
+
+  it("a second pick replaces the pending confirm rather than stacking one", () => {
+    pickerUpload([png("first.png")], "freenode", "#a");
+    pickerUpload([png("second.png")], "freenode", "#b");
+    expect(attachments().map((a) => a.label)).toEqual(["second.png"]);
+
+    acceptConfirm();
+
+    expect(triggerUploads).toHaveBeenCalledTimes(1);
+    expect(triggerUploads).toHaveBeenCalledWith("freenode #b", "freenode", "#b", [
+      expect.objectContaining({ name: "second.png" }),
+    ]);
+  });
+});

--- a/cicchetto/src/lib/channelJoin.ts
+++ b/cicchetto/src/lib/channelJoin.ts
@@ -134,5 +134,6 @@ export function confirmJoinChannel(networkSlug: string, rawChannel: string): voi
     confirmLabel: "Join",
     onConfirm: () => void performJoin(networkSlug, rawChannel),
     alternative: null,
+    attachments: null,
   });
 }

--- a/cicchetto/src/lib/commands/fanout.ts
+++ b/cicchetto/src/lib/commands/fanout.ts
@@ -70,6 +70,7 @@ export const fanOutCommand: CommandHandler<"ame" | "amsg"> = async (cmd, ctx) =>
         });
       },
       alternative: null,
+      attachments: null,
     });
     return { ok: `/${cmd.kind}: ${targets.length} channels — confirm to send` };
   }

--- a/cicchetto/src/lib/confirmDialog.ts
+++ b/cicchetto/src/lib/confirmDialog.ts
@@ -24,6 +24,17 @@ import { createSignal } from "solid-js";
 // a .txt upload" is not a yes and not a no, it is a different route to the
 // same intent — and the store stays domain-agnostic by carrying a second
 // closure rather than learning about uploads.
+//
+// 1883 added an OPTIONAL attachment list, for the same reason and on the same
+// terms: a question about FILES cannot be asked in a sentence. "Send this?" is
+// answerable only if the operator can see WHICH file, and a mis-tapped gallery
+// thumbnail is indistinguishable from the right one by name alone. The store
+// stays domain-agnostic the same way `alternative` does — it carries a
+// pre-formatted row (label, detail, an optional blob to render) and a removal
+// closure, and knows nothing about uploads, MIME categories or byte
+// formatting. The MODAL owns the object-URL lifecycle for the blob, because
+// the row's own mount/unmount is the only thing that knows when the URL stops
+// being needed.
 
 // The third door. `null` on a request means a plain two-button yes/no dialog.
 export type ConfirmAlternative = {
@@ -31,6 +42,36 @@ export type ConfirmAlternative = {
   label: string;
   // Fired ONLY when the operator picks this door — never on confirm/dismiss.
   onSelect: () => void;
+};
+
+// One row of the attachment list. Everything domain-shaped (the filename, the
+// byte spelling, whether this thing can be shown as a picture) is decided by
+// the CALLER and arrives here already resolved.
+export type ConfirmAttachment = {
+  // Stable identity for the row and its remove button. Filenames are NOT
+  // unique — a gallery multi-select routinely yields two `IMG_0001.png`.
+  id: string;
+  // Primary line — the filename.
+  label: string;
+  // Secondary line — e.g. a formatted size. The caller formats it; carrying a
+  // raw number here would put a spelling decision in a store that has no
+  // business making one.
+  detail: string;
+  // Non-null → render it as a thumbnail. A Blob rather than a URL string so
+  // the modal can own `createObjectURL`/`revokeObjectURL` around the row's
+  // lifetime; a caller-minted URL would have to be revoked from a dismiss path
+  // this store deliberately does not expose.
+  thumbnail: Blob | null;
+};
+
+export type ConfirmAttachments = {
+  // Reactive on purpose: a removal must re-render the list WITHOUT replacing
+  // the request (which would re-run the modal's open transition and steal
+  // focus back to Cancel).
+  items: () => ConfirmAttachment[];
+  // Remove one row. What an empty set means is the caller's decision, not the
+  // store's — the picker guard closes the dialog, a future caller might not.
+  onRemove: (id: string) => void;
 };
 
 export type ConfirmRequest = {
@@ -47,6 +88,9 @@ export type ConfirmRequest = {
   // whether its dialog has a third door, so a reader never has to check the
   // type to find out that a two-button modal was intended.
   alternative: ConfirmAlternative | null;
+  // Same explicit-`null` contract as `alternative`, and for the same reason:
+  // a text-only dialog says so in its own call site.
+  attachments: ConfirmAttachments | null;
 };
 
 const [confirmRequest, setConfirmRequest] = createSignal<ConfirmRequest | null>(null);

--- a/cicchetto/src/lib/lifecycle.ts
+++ b/cicchetto/src/lib/lifecycle.ts
@@ -158,6 +158,7 @@ export function confirmDetach(onDone: () => void): void {
     confirmLabel: "Switch account",
     onConfirm: () => void detach().then(onDone),
     alternative: null,
+    attachments: null,
   });
 }
 
@@ -173,6 +174,7 @@ export function confirmQuit(onDone: () => void): void {
     confirmLabel: "Quit IRC",
     onConfirm: () => void quit().then(onDone),
     alternative: null,
+    attachments: null,
   });
 }
 

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -234,6 +234,7 @@ function routeGuardedText(
           label: PASTE_UPLOAD_LABEL,
           onSelect: () => uploadPastedText(text, networkSlug, channelName),
         },
+        attachments: null,
       });
       return;
     case "over-limit":
@@ -248,6 +249,7 @@ function routeGuardedText(
         // No third door here: the paste door is what the cap closed, so
         // uploading IS the affirmative and there is nothing else to offer.
         alternative: null,
+        attachments: null,
       });
       return;
     case "insert":

--- a/cicchetto/src/lib/pickerUpload.ts
+++ b/cicchetto/src/lib/pickerUpload.ts
@@ -1,0 +1,119 @@
+import { createSignal } from "solid-js";
+import { channelKey } from "./channelKey";
+import { type ConfirmAttachment, dismissConfirm, requestConfirm } from "./confirmDialog";
+import { formatBytes } from "./formatBytes";
+import { categoryOf } from "./uploadCategory";
+import { triggerUploads } from "./uploadOrchestrator";
+
+// 1883 — the file-picker's confirm step.
+//
+// Picking a photo from the gallery used to reach the wire with no stop
+// anywhere: `onPickerChange` handed `input.files` straight to
+// `triggerUploads`. The only gate was the privacy modal, which is one-shot per
+// host — so for every operator who has ticked "remember", the sequence was
+// tap paperclip -> tap photo -> it is public. On a phone the gallery grid is
+// dense and the thumbnails are small; a mis-tap picks the wrong photo and
+// there is no undo, because the bytes are already on someone else's server and
+// the link is already in the channel.
+//
+// This module is that missing step, and it is the PICKER's door only. Drop
+// (DropUploadZone) and paste (pasteRoute) keep going straight through
+// `dropUpload`: a drag onto a visible target is a gesture the operator aimed,
+// and Ctrl-V is one they typed. A gallery tap is neither — the OS chose the
+// grid, and the only thing between two adjacent thumbnails is a few
+// millimetres. Extending the guard to those doors later is a call to
+// `pickerUpload` from them; nothing here is picker-shaped except the call
+// site (the name mirrors `dropUpload`, its sibling door, not a restriction).
+//
+// Deliberately NOT in `triggerUploads`: the orchestrator owns the queue, and a
+// batch the operator has not authorised yet has no business being in it — it
+// would take the channel's single upload slot, show an "(i/N)" counter for
+// files that may never be sent, and make "cancel" mean two different things.
+// The question is asked BEFORE the queue, and only the answer enters it.
+//
+// Deliberately NOT `dropUpload`, either, even though the shape is close: the
+// picker path does NOT pre-filter by `categoryOf`, because iOS labels a .m4r
+// ringtone `application/octet-stream` and `normalizeUploadFile` inside the
+// orchestrator is what rescues it. Reusing `dropUpload` here would silently
+// re-introduce that filter and drop the file before the rescue could run.
+//
+// There is no "don't ask again". A remembered opt-out is exactly the shape of
+// the privacy flag that produced this defect: a gate that every returning
+// operator has already switched off is not a gate. If the friction proves too
+// high the answer is fewer taps, not a way to disarm it permanently.
+
+// Row identity. Filenames are not unique (a gallery multi-select routinely
+// yields two `IMG_0001.png`) and neither is the File object across two picks
+// of the same photo, so the id is minted here and never derived.
+let nextAttachmentId = 0;
+
+type StagedFile = { id: string; file: File };
+
+/**
+ * Ask before uploading. Opens a confirm listing `files` with the destination
+ * named, and calls `triggerUploads` with whatever survives — the full set on
+ * Send, nothing at all on Cancel/Esc/backdrop, the remainder if rows were
+ * removed. An empty `files` opens no dialog.
+ *
+ * Fire-and-forget: everything observable flows through the confirm store and,
+ * after Send, through the orchestrator's own upload state.
+ */
+export function pickerUpload(files: File[], networkSlug: string, channelName: string): void {
+  if (files.length === 0) return;
+
+  const [staged, setStaged] = createSignal<StagedFile[]>(
+    files.map((file) => {
+      nextAttachmentId += 1;
+      return { id: `picked-${nextAttachmentId}`, file };
+    }),
+  );
+
+  requestConfirm({
+    // The destination goes in the TITLE, which is also the dialog's
+    // `aria-label` — the one string a screen reader announces on open, and the
+    // one fact a mis-tap most needs to see. Target-neutral "to X" rather than
+    // "in the channel": `channelName` is a nick on a query window.
+    title: `Send to ${channelName}?`,
+    // Count-free on purpose: the rows below ARE the count, and a number baked
+    // into this string would start lying the moment a row is removed (the
+    // request is not re-issued on removal — see ConfirmAttachments.items).
+    body: "Each file below is uploaded and its link is posted there. This cannot be taken back.",
+    confirmLabel: "Send",
+    onConfirm: () => {
+      triggerUploads(
+        channelKey(networkSlug, channelName),
+        networkSlug,
+        channelName,
+        staged().map((s) => s.file),
+      );
+    },
+    // No third door: there is no other route to "post this file here". Cancel
+    // and Send are the whole question.
+    alternative: null,
+    attachments: {
+      items: (): ConfirmAttachment[] => staged().map(toAttachment),
+      onRemove: (id: string): void => {
+        const rest = staged().filter((s) => s.id !== id);
+        setStaged(rest);
+        // Removing the last row is the same answer as Cancel — an empty dialog
+        // asking "send these?" has nothing to affirm. Dismiss rather than
+        // leaving a Send button that would be a no-op.
+        if (rest.length === 0) dismissConfirm();
+      },
+    },
+  });
+}
+
+// A picture is the only preview worth showing: for every other category the
+// bytes say nothing a human can check at a glance, and the name is what
+// distinguishes `contract-final.pdf` from `contract-draft.pdf`. The blob is
+// handed over raw — ConfirmModal mints and revokes the object URL, because the
+// row's unmount is the only event that knows when it stops being needed.
+function toAttachment(staged: StagedFile): ConfirmAttachment {
+  return {
+    id: staged.id,
+    label: staged.file.name,
+    detail: formatBytes(staged.file.size),
+    thumbnail: categoryOf(staged.file.type) === "image" ? staged.file : null,
+  };
+}

--- a/cicchetto/src/lib/windowClose.ts
+++ b/cicchetto/src/lib/windowClose.ts
@@ -173,6 +173,7 @@ export function confirmLeaveChannel(networkSlug: string, channelName: string): v
     confirmLabel: "Yes",
     onConfirm: () => closeChannelWindow(networkSlug, channelName),
     alternative: null,
+    attachments: null,
   });
 }
 
@@ -186,5 +187,6 @@ export function confirmDisconnectNetwork(networkSlug: string): void {
     confirmLabel: "Yes",
     onConfirm: () => disconnectNetwork(networkSlug),
     alternative: null,
+    attachments: null,
   });
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5599,6 +5599,94 @@ button.topic-bar-windows-opener {
   cursor: pointer;
 }
 
+/* 1883 — the file list on an upload confirm. Capped and scrollable: a gallery
+   multi-select can be a dozen files, and a dialog that grows past the viewport
+   pushes its own Cancel button off screen — on a phone that turns the guard
+   into a trap. `overscroll-behavior` keeps a flick inside the list from
+   scrolling the pane underneath. */
+.confirm-modal-attachments {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 40vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.confirm-modal-attachment {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--border);
+  padding: 0.375rem;
+  min-width: 0;
+}
+
+/* Fixed box for BOTH the thumbnail and its placeholder, so a mixed batch
+   (photo + pdf) keeps every row the same height and the filenames line up. */
+.confirm-modal-attachment-thumb,
+.confirm-modal-attachment-icon {
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-modal-attachment-thumb {
+  /* `cover` and not `contain`: a preview is for recognising the picture, and
+     a letterboxed 2.5rem thumbnail of a portrait photo is a sliver. */
+  object-fit: cover;
+  border: 1px solid var(--border);
+}
+
+.confirm-modal-attachment-icon {
+  color: var(--muted);
+}
+
+.confirm-modal-attachment-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+/* Ellipsis rather than wrap: a camera filename is long and uninformative in
+   the middle, and a wrapped one would push the remove button around. */
+.confirm-modal-attachment-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.confirm-modal-attachment-detail {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+/* Bare glyph, not a bordered button: the row is not an action, the × is.
+   Sized to the 2.25rem touch floor the other icon buttons use. */
+.confirm-modal-attachment-remove {
+  flex: 0 0 auto;
+  background: transparent;
+  color: var(--muted);
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  line-height: 1;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  cursor: pointer;
+}
+
+.confirm-modal-attachment-remove:hover {
+  color: var(--fg);
+}
+
 /* M-cluster M-7 — admin pane. Replaces channel content in the main
    pane (Shell.tsx) when adminOpen() === true. Full-height,
    full-width within `.shell-main`. M-8/M-9/M-10/M-11 will add tabs

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44530,3 +44530,47 @@ capability guard. Measured: the cic gate green on this branch — `bun run check
 NOT measured: any claim about how often the defect fires in the field, and any
 claim about the confirm's effect on upload latency. The object-URL revoke is
 proven by a spy in `ConfirmModal.test.tsx`, NOT by an observed memory figure.
+
+### The thumbnail needed a CSP token, and 29 e2e specs said so at once
+
+The e2e suite came back with 29 failures across all four shards, in three
+families that looked unrelated: the three new specs, the existing picker
+journeys (i2b, ux-6-b, uploads3, #418), and — the surprising one — the media
+viewer and preview-scroll specs, which are not picker-shaped at all. One
+mechanism, read off the artefact rather than reasoned from the code:
+`violatedDirective: img-src, blockedURI: blob`. Every one of those specs runs
+through `mediaViewer.uploadImageAndGetLink` or `uploadJourney.pickFile`, so
+every one of them now opens a confirm carrying an `<img src="blob:…">` — and
+`fixtures/test.ts`'s `_cspGuard` is an `auto` fixture that fails a spec at
+teardown for ANY violation collected during it. The journeys themselves all
+completed; the guard is what reddened them. The discriminating control was
+already in the run: `media-link-modal-viewer.spec.ts:78` drives the SAME picker
+journey with an AUDIO file — no thumbnail, no violation, green.
+
+`img-src 'self' data: https:` became `img-src 'self' data: blob: https:`. This
+is the same token, arriving for the same reason, as the `blob:` that
+`media-src` has carried since the video-duration probe: a preview of the
+operator's OWN file, minted by `URL.createObjectURL`, off the wire entirely.
+The security argument for admitting it is narrow and worth stating: a `blob:`
+URL can only be minted by same-origin script and can never name a foreign
+host, so it is not an exfiltration channel — while `https:`, which this
+directive has admitted since #1240, is the token that would carry an
+image-beacon anywhere. Two client-side cures were rejected: a `data:` URL
+(already admitted, but it is the whole file base64'd in memory, ~1.33× per row,
+for a 2.5rem picture) and a `<canvas>` (CSP-free, but it trades one token for a
+decode-and-draw path nobody else in cic uses).
+
+Four pins had to move with it, and the shape of three of them is the lesson:
+the plug's golden literal, `nginx-csp-range-parity.spec.ts`, and
+`media-link-cross-host-modal.spec.ts` each pin the WHOLE directive value, not
+the token they care about, precisely because every shorter spelling of
+`img-src` is a PREFIX of the longer one and `toContain` would sail through a
+revert. Inserting `blob:` in the middle is the third time that trap has been
+paid for.
+
+The e2e assertion this branch shipped — `toHaveAttribute("src", /^blob:/)` —
+was green in exactly the world where the feature was broken: cic sets the
+attribute, the browser refuses the resource, the row renders an empty box. It
+now also polls `naturalWidth > 0`, the same witness `media-link-cross-host-modal`
+uses for #1240. **A `src` attribute is not evidence that an image loaded; under
+a CSP it is barely evidence of anything.**

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44453,3 +44453,80 @@ geometry assertion to buy nothing.
 The retagged titles still read "iOS" in places: the retag inserts a tag
 and rewrites no prose, and renaming them would break every `--grep` and
 doc reference that quotes a title.
+<!-- entry #1883 -->
+
+---
+
+## 2026-08-31 — 1883: the gallery pick asks before it publishes
+
+`onPickerChange` handed `input.files` straight to `triggerUploads`. The only
+thing between a tap and a public URL was the privacy modal, and that modal is
+one-shot per host: `startUpload` reads `localStorage[privacyKey(host)]` and, if
+the operator ever ticked "remember", dispatches immediately. So for every
+returning operator the whole sequence was tap paperclip → tap photo → it is
+public. On a phone the gallery grid is dense and the thumbnails are small; a
+mis-tap has no undo, because by the time it is visible the bytes are on the
+upload host and the link is in the channel.
+
+The cure is one step, `lib/pickerUpload.ts`, between selection and dispatch: a
+confirm that SHOWS the batch — thumbnail for a picture, name + size for
+anything else — names the destination, and offers Send / Cancel with per-file
+removal. It reuses `ConfirmModal`, which grew an OPTIONAL attachment list for
+it (`ConfirmRequest.attachments`, explicit-`null` at every call site like
+`alternative` since #816). No new overlay: the upload confirm inherits the same
+scrim, the same Esc, the same Cancel-first focus order as every other confirm
+in cic.
+
+### Where the step sits, and why not one layer down
+
+Not inside `triggerUploads`. The orchestrator owns the per-channel queue, and a
+batch nobody has authorised yet has no business being in it — it would hold the
+channel's single upload slot, render an `(i/N)` counter for files that may never
+be sent, and make `cancelUpload` mean two different things. The question is
+asked BEFORE the queue; only the answer enters it.
+
+Not `dropUpload` either, though the shape is close, and this is the trap worth
+recording: `dropUpload` filters by `categoryOf`, and the picker path
+deliberately does NOT. iOS labels a `.m4r` ringtone `application/octet-stream`,
+which `categoryOf` rejects; `normalizeUploadFile` inside the orchestrator is
+what rescues it. Reusing the drop entry point here would have re-introduced that
+filter and dropped the file one layer above its own rescue, silently.
+
+### Two open questions the issue left, answered as ASSUMPTIONS
+
+Both are reversible in one call site, and neither was ruled on.
+
+**Always-on, no "don't ask again".** A remembered opt-out is exactly the shape
+of the flag that produced the defect: a gate every returning operator has
+already switched off is not a gate. If the friction proves too high the answer
+is fewer taps, not a permanent disarm.
+
+**Picker only.** Drop and paste keep going straight through `dropUpload`: a drag
+onto a visible target is a gesture the operator aimed, and Ctrl-V is one they
+typed. A gallery tap is neither — the OS chose the grid, and two adjacent
+thumbnails are millimetres apart. Extending the guard is a call to
+`pickerUpload` from those doors; nothing in the module is picker-shaped except
+its call site.
+
+### A fourth door the issue does not name
+
+`lib/shareTargetDelivery.ts` (#1103, Web Share Target) also reaches
+`dropUpload`, and it is the one path where the operator picks neither the file
+in cic NOR the destination: the share arrives from another app on a cold boot,
+and `resolveShareDestination` sends it to the LAST FOCUSED window. That is a
+closer relative of the gallery tap than drag-and-drop is — the gesture that
+starts it IS a gallery share — and it is out of scope here only because the
+issue does not name it and the assumption above says picker. Read as a gap, not
+as a decision.
+
+### What was measured, and what was not
+
+Measured: `URL.createObjectURL` IS available under vitest's jsdom environment
+(`typeof === "function"`, returns a `blob:` URL) — jsdom's own lib ships no such
+symbol, so the thumbnail path is exercisable in unit tests and needs no
+capability guard. Measured: the cic gate green on this branch — `bun run check`
+5/5 stages, `bun run test` 330 files / 6586 tests.
+
+NOT measured: any claim about how often the defect fires in the field, and any
+claim about the confirm's effect on upload latency. The object-URL revoke is
+proven by a spy in `ConfirmModal.test.tsx`, NOT by an observed memory figure.

--- a/lib/grappa_web/plugs/security_headers.ex
+++ b/lib/grappa_web/plugs/security_headers.ex
@@ -98,16 +98,28 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
       dynamic style tags during interactive renders; rejecting `'unsafe-inline'`
       would break the irssi-shape theme system. hCaptcha loads its own sheet
       from `assets.hcaptcha.com`.
-    * `img-src 'self' data: https:` — `'self'` + `data:` for favicons, manifest
-      icons and SolidJS inline `data:` SVGs; `https:` (#1240) so the media
-      viewer's `<img>` can load a CROSS-HOST image link (an upload minted by
-      another grappa instance, or a litterbox URL) that `mediaLink.ts`
+    * `img-src 'self' data: blob: https:` — `'self'` + `data:` for favicons,
+      manifest icons and SolidJS inline `data:` SVGs; `https:` (#1240) so the
+      media viewer's `<img>` can load a CROSS-HOST image link (an upload minted
+      by another grappa instance, or a litterbox URL) that `mediaLink.ts`
       `externalMediaLink` admits client-side. Without it the classifier change
       is worse than a no-op — the modal opens EMPTY. Scheme-scoped to https,
       never http, so no mixed content; vjt granted `*` explicitly, and `https:`
       is the narrower spelling of the same practical grant (an http image on an
       https page is refused as mixed content either way) that keeps this
       directive shaped like its `media-src` sibling.
+      `blob:` (1883) is that sibling's OTHER token, arriving here for the same
+      reason it arrived there: the upload confirm previews the operator's OWN
+      picked file as a thumbnail, off the wire entirely, via
+      `URL.createObjectURL` (ConfirmModal.tsx) — the exact shape of the
+      video-duration probe `media-src blob:` already carries. Measured, not
+      argued: without it Chromium refuses the thumbnail with
+      `violatedDirective: img-src, blockedURI: blob`, the confirm renders an
+      empty box, and 29 e2e specs red on the `_cspGuard` fixture. It buys an
+      attacker nothing this directive was still holding: a `blob:` URL is
+      minted only by same-origin script, cannot name a foreign host, and so
+      cannot exfiltrate — while `https:`, already admitted above, is the token
+      that would carry an image-beacon anywhere.
     * `font-src 'self'` — system fonts only.
     * `manifest-src 'self'` — PWA install manifest.
     * `media-src 'self' blob: https:` — `blob:` for the video-upload duration
@@ -144,7 +156,7 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
 
   import Plug.Conn
 
-  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com https://kohina.brona.dk; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com https://kohina.brona.dk; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: blob: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   # HTTP header names are lower-cased (HTTP/2 + Plug convention); the VALUES
   # are byte-identical to the retired nginx snippet.

--- a/test/grappa_web/plugs/security_headers_test.exs
+++ b/test/grappa_web/plugs/security_headers_test.exs
@@ -22,9 +22,10 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
 
   # The plug's Content-Security-Policy SSOT (was byte-identical to the
   # deleted nginx snippet; #607 widened media-src to https:, #1240 img-src,
-  # #1695 added ONE connect-src host). If the app must change the policy,
-  # change it in ONE place (the plug) and update this pin deliberately.
-  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com https://kohina.brona.dk; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  # #1695 added ONE connect-src host, 1883 added `blob:` to img-src). If the
+  # app must change the policy, change it in ONE place (the plug) and update
+  # this pin deliberately.
+  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe https://api.somafm.com https://kohina.brona.dk; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data: blob: https:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   defp sent(status) do
     :get
@@ -142,6 +143,32 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
       assert Enum.any?(directives()["media-src"], &(&1 == "https:")),
              "the scheme filter matched nothing anywhere — it cannot be trusted to " <>
                "have checked connect-src either."
+    end
+  end
+
+  describe "1883 — the picked-file thumbnail on img-src" do
+    # The upload confirm previews the operator's OWN file before anything is
+    # sent, as an `<img>` on a `URL.createObjectURL` blob (ConfirmModal.tsx).
+    # Measured in the e2e stack before the token existed: Chromium refused it
+    # with `violatedDirective: img-src, blockedURI: blob`, so the dialog whose
+    # whole job is showing WHICH photo showed an empty box — and the browser
+    # says so only in a console nobody reads in prod.
+    test "img-src admits blob:" do
+      assert MapSet.member?(directives()["img-src"], "blob:"),
+             "img-src must admit blob: — the picker confirm's thumbnail is an " <>
+               "object URL over the operator's own file, never a fetch."
+    end
+
+    # `blob:` is an ADDITION, not a replacement. The RULE at the top of the
+    # plug's moduledoc is that naming a directive replaces the `default-src`
+    # fallback wholesale, so a "tidy" rewrite that drops one of the other three
+    # tokens while adding this one would pass the test above and silently take
+    # out favicons (`data:`) or the cross-host viewer (`https:`, #1240).
+    test "the other img-src sources survive the addition" do
+      missing = MapSet.difference(MapSet.new(["'self'", "data:", "https:"]), directives()["img-src"])
+
+      assert MapSet.equal?(missing, MapSet.new()),
+             "img-src lost " <> inspect(MapSet.to_list(missing)) <> " — blob: is an addition."
     end
   end
 


### PR DESCRIPTION
Addresses issue 1883 (cicchetto: a gallery pick uploads instantly — no preview, no confirm, no undo).

## The defect

`ComposeBox.onPickerChange` handed `input.files` straight to `triggerUploads`. The only thing between a tap and a public URL was the privacy modal, and that modal is one-shot per host — `uploadOrchestrator.startUpload` reads `localStorage[privacyKey(host)]` and dispatches immediately once the operator has ticked "remember". For every returning operator the whole sequence was **tap paperclip → tap photo → it is public**, with no undo: by the time the mistake is visible the bytes are on the upload host and the link is in the channel.

## The cure

A new `cicchetto/src/lib/pickerUpload.ts` sits between selection and dispatch. It opens a confirm that shows the batch — thumbnail for a picture, name + size for anything else — names the destination in the dialog's title (which is also its `aria-label`), and offers **Send / Cancel** with per-file removal. Removing the last row closes the dialog: an empty question has nothing to affirm.

`ConfirmModal` is reused, not duplicated. It grew an **optional** attachment list (`ConfirmRequest.attachments`, explicit-`null` at every call site exactly as `alternative` has been since #816), so the upload confirm inherits the same scrim, the same Esc, the same Cancel-first focus order as every other confirm in cic. No new overlay.

### Two layering calls worth reviewing

**Not inside `triggerUploads`.** The orchestrator owns the per-channel queue, and a batch nobody has authorised has no business in it: it would hold the channel's single upload slot, render an `(i/N)` counter for files that may never be sent, and give `cancelUpload` two meanings. The question is asked *before* the queue; only the answer enters it.

**Not `dropUpload`, though the shape is close.** `dropUpload` filters by `categoryOf`; the picker path deliberately does not, because iOS labels a `.m4r` ringtone `application/octet-stream` and `normalizeUploadFile` *inside* the orchestrator is what rescues it. Reusing the drop door here would have dropped the file one layer above its own rescue, silently. There is a test pinning that.

## 🔶 Two ASSUMPTIONS, not decisions — reversible, and neither has been ruled on

The issue leaves both of these open. They are stated here as **assumptions the reviewer may overturn**, and each was built so that reversing it is a small change.

**A) Always-on. No "don't ask again".** A remembered opt-out is exactly the shape of the flag that produced this defect — a gate every returning operator has already switched off is not a gate, and the issue body says so itself. If the friction proves too high the answer is fewer taps, not a permanent disarm. *Reversing it* means a `localStorage` read in `pickerUpload` and a checkbox in the modal, i.e. the shape `acknowledgePrivacy` already has.

**B) Picker only.** Drop (`DropUploadZone`) and paste (`pasteRoute`) keep going straight through `dropUpload`: a drag onto a visible target is a gesture the operator aimed, and Ctrl-V is one they typed. A gallery tap is neither — the OS chose the grid, and two adjacent thumbnails are millimetres apart. *Reversing it* is a call to `pickerUpload` from those two doors; nothing in the module is picker-shaped except its call site (the name mirrors its sibling `dropUpload`, it is not a restriction).

## 🔶 A fourth ingress the issue does not name — reported, not acted on

`cicchetto/src/lib/shareTargetDelivery.ts` (#1103, Web Share Target) also reaches `dropUpload`, and it is the **one path where the operator picks neither the file in cic nor the destination**: the share arrives from another app on a cold boot, and `resolveShareDestination` delivers it to the LAST FOCUSED window with no confirmation at all. By gesture that is a *closer* relative of the gallery tap than drag-and-drop is — the thing that starts it is often a gallery share. It is untouched here only because assumption (B) says picker and the issue does not name it. Recorded as a gap in DESIGN_NOTES, flagged here, **not decided**.

## Gates — rc read from a redirected file, never a pipe

| gate | rc | result |
|---|---|---|
| `scripts/bun.sh run check` | `0` | 5 stages ran, 0 failed — lock drift `drift=0`, test location, biome (src + e2e), tsc (src), tsc (e2e) |
| `scripts/bun.sh run test` | `0` | 330 test files, 6586 tests, all passed |
| `scripts/design-notes-gate.sh origin/main` | `0` | `1 new entry heading(s), separator and marker present` (post-commit run, not the empty "nothing to check") |

The worktree's cloned `node_modules` was reconciled with `bun install --frozen-lockfile` (rc=0) **before** any gate ran — it installed 20 packages, so the clone was genuinely stale and a green measured before that would not have been attributable to this branch.

**The e2e has NOT been run yet** — it needs the exclusive STACK lane. `cicchetto/e2e/tests/issue1883-picker-send-confirm.spec.ts` is written and type-checks (tsc (e2e) green); it counts real POSTs to the same-origin `/api/uploads`, and every zero carries the positive control that `ux-6-b-embedded` established — the same journey driven to Send, so a counter that cannot count reds instead of passing green.

## What I REFUSED to assert

- **How often this fires in the field.** No measurement exists here. The issue quotes a #grappa report; that is a report, not a rate.
- **Any latency or memory cost of the extra step.** Not measured. The object-URL revoke is proven by a spy in `ConfirmModal.test.tsx` — it is evidence that `revokeObjectURL` is *called with the right URL*, not that any leak was observed or closed.
- **That the e2e passes.** It has not been run: that needs the STACK lane. `tsc -p e2e/tsconfig.json` green proves it compiles and nothing more.
- **That the ~10 picker-driven specs routed through the shared `pickFile` fixture still pass.** The single fixture edit is intended to cover them, and the reasoning is in the commit; only a real run can settle it.
- **That the touch ergonomics are right on a phone.** Sizes follow the existing 2.25rem touch floor; no device was measured.
- **That assumption (B) is correct for the share-target path.** The measurement above establishes only that the path EXISTS and is unguarded — not what it should do.

One thing that *was* measured rather than assumed: `URL.createObjectURL` is available under vitest's jsdom environment (`typeof === "function"`, returns a real `blob:` URL), even though jsdom's own lib ships no such symbol. That is why the thumbnail path needs no capability guard and is exercisable in unit tests.
