### PR TITLE
feat(1044): give the server PASS and the NickServ secret one slot each

### DIFF
--- a/bin/grappa
+++ b/bin/grappa
@@ -341,7 +341,11 @@ bind-network --user <name> --network <slug> --server <host:port>
                                nickserv_identify | none
     Optional:
         --tls / --no-tls       force the TLS posture (default: sniffed)
-        --password <secret>    NickServ / server password
+        --password <secret>    NickServ password (the post-001 identify)
+        --server-pass <secret> server PASS for a gated network. A
+                               DIFFERENT secret from --password; both
+                               may be given at once (#1044). Single
+                               wire token: no spaces
         --autojoin <list>      comma-separated channel list
         --realname <text>      IRC realname field
         --sasl-user <name>     SASL account when it differs from the nick
@@ -441,7 +445,11 @@ update-network-credential --user <name> --network <slug> [options]
         --network <slug>       network the credential belongs to
     Optional:
         --nick <nick>          nick to use upstream
-        --password <secret>    NickServ / server password
+        --password <secret>    NickServ password (the post-001 identify)
+        --server-pass <secret> server PASS for a gated network. A
+                               DIFFERENT secret from --password;
+                               rotating one leaves the other alone
+                               (#1044). Single wire token: no spaces
         --auth <mode>          auto | sasl | server_pass |
                                nickserv_identify | none
         --autojoin <list>      REPLACES the channel list (comma-

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44574,3 +44574,113 @@ attribute, the browser refuses the resource, the row renders an empty box. It
 now also polls `naturalWidth > 0`, the same witness `media-link-cross-host-modal`
 uses for #1240. **A `src` attribute is not evidence that an image loaded; under
 a CSP it is barely evidence of anything.**
+<!-- entry #1044 -->
+
+---
+
+## 2026-09-01 — 1044: one secret slot, several roles — and the read half nobody had written
+
+A self-hoster bound a network with `--auth server_pass` for hostmasking and
+found the only place left for the NickServ password was the on-connect
+perform list, in cleartext. One credential, one secret slot, and an
+`auth_method` deciding which single role it was spent on.
+
+The column that fixes it had already landed and was HALF dead. Measured on
+`origin/main 725788267`: `server_pass_encrypted` exists, the wide changeset
+casts it, `validate_server_pass_is_user_only/1` guards it and
+`put_encrypted_server_pass/1` writes it — while `upstream_server_pass` was
+**0 hits** in `lib/` (positive control: `upstream_oper_pass`, 3). So
+`grappa.repair_passwords`'s "never read and never written" was half false,
+and the issue's own account of what was missing was too generous: only the
+READ was.
+
+### Two roles, two arms — not one guard over both methods
+
+`maybe_send_pass/1` used to be a single clause guarding
+`m in [:auto, :server_pass]` over `:password`. It is now one clause each,
+and the split is the design rather than a refactor. On `:server_pass` the
+PASS token is the NETWORK'S GATE secret; on `:auto` it is the services
+secret handed off to NickServ (Bahamut/Azzurra), the same value SASL would
+carry. Those are two roles that happened to share a wire line, and #124's
+property is one home per ROLE. `:auto` therefore does NOT move, and a
+gate-secret-plus-handoff credential is out of scope, named here so the next
+reader does not read the asymmetry as an oversight.
+
+S30's single-token rule follows the SLOT that lands on the PASS line, not
+the method: the NickServ secret beside it keeps the CR/LF/NUL floor,
+because it leaves as a PRIVMSG trailing param where a space is legal.
+
+### The read cutover needed a data migration, and there was no third option
+
+The slot was opened EMPTY (`remove` + `add`, deliberately, so a retired
+NickServ secret could not be relabelled as a server password). So every
+`:server_pass` row in existence still kept its PASS in
+`password_encrypted`, and the instant `AuthFSM` reads the new slot those
+rows send no PASS at all — a refused handshake, not a degraded one.
+
+"Read the slot, fall back to the password column" is shorter and needs no
+migration. It is also precisely the two-homes-for-one-role split brain
+#124 is named after, so it was never available. The bytes move once, by
+migration, and the predicate is four conjuncts: the method, `user_id IS
+NOT NULL` (the slot is user-only), `server_pass_encrypted IS NULL` (a row
+written through the post-#1044 door already has both secrets in their right
+homes — and this is also what makes the migration idempotent), and a
+non-null source.
+
+**Measured before it was written, because the whole migration rests on it:
+a Cloak AES-GCM ciphertext is portable between two `EncryptedBinary`
+columns by a raw SQL copy.** Positive control, a same-column round trip
+returning the plaintext; the measurement, a raw copy into the other column
+still decrypting through the schema; negative control, one byte flipped,
+which must NOT decrypt — it loads as the atom `:error` rather than raising,
+which is worth knowing on its own. The property is pinned by the
+migration's test, which drives the moved value back out through the SCHEMA:
+comparing blobs would have been green on undecryptable garbage.
+
+### `identify_expected?/1` stopped reading `auth_method`, and that is the subtle half
+
+Widening the #347 autojoin defer from `:nickserv_identify` to "either
+method" reintroduces the #509 KNOWN EDGE that #124 removed: the common
+gate-only credential has no NickServ secret, expects no identify, and would
+wait out the whole fallback window for a `+r` that is never coming.
+
+The method could answer "is an identify expected" only while exactly ONE
+method staged a secret. Two do now, so the question moved to the secret
+itself — a boolean derived at init from the same `pending_password_from_opts/1`
+that stages it, because `pending_password` is cleared one-shot before the
+defer decision runs. It carries a hot-reload fallback clause and that is
+NOT redundant: session state here is a plain MAP, not a struct, so
+`Deploy.Preflight` (which refuses a hot deploy on a changed `defstruct`)
+has nothing to read and would let one through.
+
+The two halves of the widened method set live in different boundaries
+(`Networks` deps `Session`; the reverse closes a cycle) and cannot call
+each other, so `Credential.nickserv_secret_methods/0` is exported as DATA
+and a test DRIVES that list against live sessions. Falsified before being
+trusted: adding `:sasl` to the list turns it red naming the method.
+
+### The version bumped on the rule, not on the gate
+
+`/networks/:id/server_pass` renders its shape in a controller, and the wire
+pin's digest spans the artefacts generated from `Grappa.*.Wire` typespecs —
+so the digest is BYTE-IDENTICAL across this slice and `mix grappa.wire_pin
+--check` would have stayed green with the number still. It moved anyway:
+reason (1) of the 2026-08-21 ruling applies literally, since a cic bundle
+growing a gate-secret editor REQUIRES the route and gets a 404 from any
+older server. Recorded because the next person to add a REST-only surface
+will find the gate silent and needs to know that silence is not permission.
+
+### Corrected in passing
+
+Three comments in `lib/` described a `password_set` field on the credential
+wire. There is no such field, and `networks_controller_test` asserts there
+is not — the password door is write-only including its set-ness. The
+comments now say so, since they were the signposts pointing at where
+`server_pass_set`'s sibling supposedly lived.
+
+The column's validation also TIGHTENED: it was `safe_line_token`
+(CR/LF/NUL) while `AuthFSM` gates the same value with S30's single-token
+rule, so a gate secret with a space saved 200 and then refused every
+connect — the ircd keeps the first token and answers 464 with nothing in
+the log. A write door that accepts what the reader will reject is the
+silent-swallow the boundary rule forbids.

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -372,14 +372,19 @@ defmodule Grappa.IRC.AuthFSM do
   # predicate. #1044 made the distinction load-bearing: with two secrets on
   # one row, a copy-pasted gate is how the wrong rule ends up on the wrong
   # slot.
-  @spec validate_pass_token(term(), opt_key()) :: :ok | {:error, {:invalid_line_token, opt_key()}}
+  # The field union is the two slots that can carry a PASS-bound secret, not
+  # the whole `opt_key()`: Dialyzer measures the narrower one off the call
+  # sites and rejects the wider spec as a supertype. Narrowing it here means
+  # a third caller has to name its field, which is the right friction.
+  @spec validate_pass_token(term(), :password | :server_pass) ::
+          :ok | {:error, {:invalid_line_token, :password | :server_pass}}
   defp validate_pass_token(token, field) do
     if Identifier.safe_oper_token?(token),
       do: :ok,
       else: {:error, {:invalid_line_token, field}}
   end
 
-  @spec validate_line_token(term(), opt_key()) :: :ok | {:error, {:invalid_line_token, opt_key()}}
+  @spec validate_line_token(term(), :password) :: :ok | {:error, {:invalid_line_token, :password}}
   defp validate_line_token(token, field) do
     if Identifier.safe_line_token?(token),
       do: :ok,

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -52,7 +52,9 @@ defmodule Grappa.IRC.AuthFSM do
   ## Auth methods (mirror `Grappa.Networks.Credential`)
 
       :none               -> NICK, USER
-      :server_pass        -> PASS, NICK, USER
+      :server_pass        -> PASS (from the dedicated `:server_pass` slot,
+                             #1044 — NOT `:password`, which on such a row is
+                             the NickServ secret), NICK, USER
       :nickserv_identify  -> NICK, USER (the built-in IDENTIFY is NOT emitted
                              here — Grappa.Session.Server sends it at 001,
                              AFTER the on-connect perform list, so it can be
@@ -120,7 +122,13 @@ defmodule Grappa.IRC.AuthFSM do
           required(:realname) => String.t(),
           required(:sasl_user) => String.t(),
           required(:auth_method) => auth_method(),
-          optional(:password) => String.t() | nil
+          optional(:password) => String.t() | nil,
+          # GH #1044 — the SERVER `PASS` secret, held apart from `:password`.
+          # A password-gated network wants a gate secret AND a NickServ one at
+          # the same time, so the two roles get one slot each: on
+          # `:server_pass` the PASS line reads THIS, and `:password` keeps its
+          # NickServ meaning (emitted post-001 by the host, never here).
+          optional(:server_pass) => String.t() | nil
         }
 
   @typedoc """
@@ -131,13 +139,14 @@ defmodule Grappa.IRC.AuthFSM do
   matching its success typing, which is the only automatic check binding the
   DATA copy of the key set to a declared one.
   """
-  @type opt_key :: :auth_method | :ident | :nick | :password | :realname | :sasl_user
+  @type opt_key ::
+          :auth_method | :ident | :nick | :password | :realname | :sasl_user | :server_pass
 
   # `t:opts/0` as DATA, so a caller holding a WIDER map can hand `new/1`
   # exactly this FSM's domain instead of its own. Kept adjacent to the type
   # because the two must name the same keys: a field added to one and not the
   # other silently stops being forwarded.
-  @opt_keys [:nick, :ident, :realname, :sasl_user, :auth_method, :password]
+  @opt_keys [:nick, :ident, :realname, :sasl_user, :auth_method, :password, :server_pass]
 
   @doc """
   The keys `t:opts/0` declares, for callers whose own opts map is a
@@ -166,6 +175,7 @@ defmodule Grappa.IRC.AuthFSM do
           realname: String.t(),
           sasl_user: String.t(),
           password: String.t() | nil,
+          server_pass: String.t() | nil,
           auth_method: auth_method(),
           phase: phase(),
           caps_buffer: [String.t()],
@@ -192,11 +202,13 @@ defmodule Grappa.IRC.AuthFSM do
     :auth_method,
     :phase
   ]
-  # `:password` is the only secret on the struct — `@derive Inspect`
-  # excludes it so SASL-report dumps + IEx `:sys.get_state/1` (transitively
-  # via the host Client struct) introspection never leak plaintext.
-  # CLAUDE.md "Credentials ... never logged."
-  @derive {Inspect, except: [:password]}
+  # `:password` and `:server_pass` are the struct's secrets — `@derive
+  # Inspect` excludes BOTH so SASL-report dumps + IEx `:sys.get_state/1`
+  # (transitively via the host Client struct) introspection never leak
+  # plaintext. CLAUDE.md "Credentials ... never logged." #1044 added the
+  # second one: a new secret field that is not listed here leaks on the
+  # first crash dump.
+  @derive {Inspect, except: [:password, :server_pass]}
   defstruct [
     :nick,
     :orig_nick,
@@ -204,6 +216,7 @@ defmodule Grappa.IRC.AuthFSM do
     :realname,
     :sasl_user,
     :password,
+    :server_pass,
     :auth_method,
     :phase,
     :nick_cap,
@@ -233,7 +246,8 @@ defmodule Grappa.IRC.AuthFSM do
   @spec new(opts()) ::
           {:ok, t()}
           | {:error, {:missing_password, auth_method()}}
-          | {:error, {:invalid_line_token, :nick | :ident | :realname | :sasl_user | :password}}
+          | {:error, {:missing_server_pass, :server_pass}}
+          | {:error, {:invalid_line_token, :nick | :ident | :realname | :sasl_user | :password | :server_pass}}
   def new(%{auth_method: m} = opts) when m in @auth_methods do
     with :ok <- validate_password_present(opts),
          :ok <- validate_line_safe(opts) do
@@ -247,6 +261,7 @@ defmodule Grappa.IRC.AuthFSM do
          realname: opts.realname,
          sasl_user: opts.sasl_user,
          password: Map.get(opts, :password),
+         server_pass: Map.get(opts, :server_pass),
          auth_method: m,
          phase: :pre_register,
          caps_buffer: []
@@ -283,6 +298,20 @@ defmodule Grappa.IRC.AuthFSM do
 
   defp validate_password_present(%{auth_method: :none}), do: :ok
 
+  # GH #1044 — `:server_pass` is the one method whose required secret is NOT
+  # `:password`. The PASS line reads the dedicated slot, so that is what must
+  # be present; `:password` on such a row is the NickServ secret, which the
+  # FSM never emits and must therefore never demand (a gate-only credential
+  # legitimately carries none). The error names the slot that is missing
+  # rather than reusing `:missing_password`, which since #1044 would point
+  # the operator at the OTHER secret.
+  defp validate_password_present(%{auth_method: :server_pass} = opts) do
+    case Map.get(opts, :server_pass) do
+      pw when is_binary(pw) and pw != "" -> :ok
+      _ -> {:error, {:missing_server_pass, :server_pass}}
+    end
+  end
+
   defp validate_password_present(%{password: pw}) when is_binary(pw) and pw != "",
     do: :ok
 
@@ -308,26 +337,53 @@ defmodule Grappa.IRC.AuthFSM do
 
   defp validate_password_line_safe(%{auth_method: :none}), do: :ok
 
-  # S30 — :server_pass and :auto ship the password as the SINGLE PASS wire
-  # token (RFC 2812 §3.1.1). safe_line_token? (CR/LF/NUL only) let a space or
-  # tab through, which the server splits off → the password silently
-  # truncates to the first token → 464 ERR_PASSWDMISMATCH + a restart loop
-  # with no breadcrumb. Gate the PASS-bound password with the stricter
-  # single-token predicate OPER already uses. `validate_password_present/1`
-  # has already guaranteed a non-empty binary here.
-  defp validate_password_line_safe(%{auth_method: m, password: pw})
-       when m in [:server_pass, :auto] do
-    if Identifier.safe_oper_token?(pw),
-      do: :ok,
-      else: {:error, {:invalid_line_token, :password}}
+  # GH #1044 — on `:server_pass` the two secrets take DIFFERENT gates, because
+  # they land on different wire shapes. The `server_pass` becomes the single
+  # PASS token, so it takes S30's strict single-token rule below; the
+  # `password` is the NickServ secret, which leaves as a PRIVMSG trailing
+  # param where a space is legal, so it only takes the CR/LF/NUL floor. It is
+  # checked here even though the FSM never emits it: it crosses this boundary,
+  # and the self-defending posture applies to everything that does.
+  defp validate_password_line_safe(%{auth_method: :server_pass} = opts) do
+    with :ok <- validate_pass_token(Map.get(opts, :server_pass), :server_pass) do
+      case Map.get(opts, :password) do
+        pw when is_binary(pw) and pw != "" -> validate_line_token(pw, :password)
+        _ -> :ok
+      end
+    end
   end
+
+  # S30 — :auto ships the password as the SINGLE PASS wire token (RFC 2812
+  # §3.1.1). safe_line_token? (CR/LF/NUL only) let a space or tab through,
+  # which the server splits off → the password silently truncates to the first
+  # token → 464 ERR_PASSWDMISMATCH + a restart loop with no breadcrumb. Gate
+  # the PASS-bound password with the stricter single-token predicate OPER
+  # already uses. `validate_password_present/1` has already guaranteed a
+  # non-empty binary here.
+  defp validate_password_line_safe(%{auth_method: :auto, password: pw}),
+    do: validate_pass_token(pw, :password)
 
   # :sasl (base64-encoded payload) and :nickserv_identify keep the
   # CR/LF/NUL-only line-token gate — a space is legal in those.
-  defp validate_password_line_safe(%{password: pw}) do
-    if Identifier.safe_line_token?(pw),
+  defp validate_password_line_safe(%{password: pw}), do: validate_line_token(pw, :password)
+
+  # The two gates, named once each so the per-method arms above read as the
+  # POLICY (which secret takes which rule) rather than restating the
+  # predicate. #1044 made the distinction load-bearing: with two secrets on
+  # one row, a copy-pasted gate is how the wrong rule ends up on the wrong
+  # slot.
+  @spec validate_pass_token(term(), opt_key()) :: :ok | {:error, {:invalid_line_token, opt_key()}}
+  defp validate_pass_token(token, field) do
+    if Identifier.safe_oper_token?(token),
       do: :ok,
-      else: {:error, {:invalid_line_token, :password}}
+      else: {:error, {:invalid_line_token, field}}
+  end
+
+  @spec validate_line_token(term(), opt_key()) :: :ok | {:error, {:invalid_line_token, opt_key()}}
+  defp validate_line_token(token, field) do
+    if Identifier.safe_line_token?(token),
+      do: :ok,
+      else: {:error, {:invalid_line_token, field}}
   end
 
   @doc """
@@ -392,8 +448,19 @@ defmodule Grappa.IRC.AuthFSM do
     ]
   end
 
-  defp maybe_send_pass({%__MODULE__{auth_method: m, password: pw} = state, sends})
-       when m in [:auto, :server_pass] and is_binary(pw) and pw != "" do
+  # GH #1044 — one arm per ROLE, and the two are deliberately not merged.
+  # On `:server_pass` the PASS token is the network's gate secret, which has
+  # its own slot; on `:auto` it is the services secret handed off to NickServ
+  # (Bahamut/Azzurra), which is the same secret SASL would carry and so lives
+  # in `:password`. Reading one slot with the other's method as a fallback is
+  # exactly the two-homes-for-one-role split brain #124 cured.
+  defp maybe_send_pass({%__MODULE__{auth_method: :server_pass, server_pass: pw} = state, sends})
+       when is_binary(pw) and pw != "" do
+    {state, ["PASS #{pw}\r\n" | sends]}
+  end
+
+  defp maybe_send_pass({%__MODULE__{auth_method: :auto, password: pw} = state, sends})
+       when is_binary(pw) and pw != "" do
     {state, ["PASS #{pw}\r\n" | sends]}
   end
 

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -196,6 +196,10 @@ defmodule Grappa.IRC.Client do
           required(:sasl_user) => String.t(),
           required(:auth_method) => AuthFSM.auth_method(),
           optional(:password) => String.t() | nil,
+          # GH #1044 — the server `PASS` secret. Narrowed into the FSM's own
+          # closed opts map by the `Map.take(opts, AuthFSM.opt_keys())` in
+          # `init/1`, like every other registration field.
+          optional(:server_pass) => String.t() | nil,
           optional(:source_address) => String.t() | nil,
           # #100 liveness watchdog — test seam. Production omits both and
           # inherits the `@liveness_*_ms` config defaults; tests inject tiny

--- a/lib/grappa/irc/identity.ex
+++ b/lib/grappa/irc/identity.ex
@@ -103,6 +103,31 @@ defmodule Grappa.IRC.Identity do
   end
 
   @doc """
+  `validate_change/3` callback for a value whose ONLY destiny is a single
+  wire token — `Identifier.safe_oper_token?/1`, so a space or tab is
+  rejected alongside CR/LF/NUL.
+
+  GH #1044. The stricter sibling of `safe_line_token/2` above, and the
+  distinction is about the SHAPE the value lands in rather than how secret
+  it is: a trailing param may hold spaces, a bare token may not. The server
+  `PASS` is the case that needed it — the receiving ircd splits the line and
+  keeps the FIRST token, so a space silently truncates the secret and the
+  handshake comes back 464 with nothing in the log to explain it. `AuthFSM`
+  applies the same predicate at the wire, and applying it only there would
+  let the write door answer 200 to a value that then refuses every connect.
+
+  An empty string is rejected too (`safe_oper_token?/1` requires non-empty),
+  so a changeset that means "clear this field" must map `""` to `nil`
+  BEFORE this runs rather than casting it through.
+  """
+  @spec safe_oper_token(atom(), String.t()) :: [{atom(), String.t()}]
+  def safe_oper_token(field, value) when is_binary(value) do
+    if Identifier.safe_oper_token?(value),
+      do: [],
+      else: [{field, "must be a single token: no spaces, tabs, CR, LF or NUL"}]
+  end
+
+  @doc """
   Returns `ident` when a binary, else the `nick` fallback (GH #152). The
   ident defaults to the nick so the USER line stays `USER <nick> …` for a
   subject that never set a distinct ident.

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -865,40 +865,51 @@ defmodule Grappa.Networks.Credential do
     end)
   end
 
-  # Either a new plaintext `:password` arrives in this changeset, OR the
-  # row already carries a stored `password_encrypted` from a prior bind
-  # AND the auth_method isn't being changed. Validating only the virtual
-  # field would force every update of an unrelated attribute (nick,
-  # autojoin) to re-supply the password. But silently inheriting an
-  # existing password across an auth_method CHANGE would let an operator
-  # accidentally promote a NickServ-IDENTIFY password into a SASL
-  # credential — different upstream auth surface, almost certainly a
-  # typo. So when auth_method is in `cs.changes`, we require a fresh
-  # `:password`.
+  # Either a new plaintext secret arrives in this changeset, OR the row
+  # already carries a stored one from a prior bind AND the auth_method isn't
+  # being changed. Validating only the virtual field would force every update
+  # of an unrelated attribute (nick, autojoin) to re-supply the secret. But
+  # silently inheriting an existing one across an auth_method CHANGE would let
+  # an operator accidentally promote a NickServ-IDENTIFY password into a SASL
+  # credential — different upstream auth surface, almost certainly a typo. So
+  # when auth_method is in `cs.changes`, we require a fresh one.
+  #
+  # GH #1044 — WHICH secret is required depends on the method, because since
+  # #1044 a row can carry two. `:server_pass` spends the dedicated
+  # `server_pass` slot on the PASS line and leaves `password` free to mean
+  # NickServ, so requiring `password` there would demand a secret the
+  # handshake never sends — and, after the one-time move of the legacy rows,
+  # would reject a bare nick rename on every gate-only credential that
+  # legitimately has no NickServ secret at all. Every other method still
+  # requires `password`; the pairing is a table rather than a branch so a new
+  # method cannot silently inherit the wrong one.
   @spec validate_password_for_auth_method(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp validate_password_for_auth_method(cs) do
     case get_field(cs, :auth_method) do
-      :none ->
+      :none -> cs
+      :server_pass -> validate_secret_present(cs, :server_pass, :server_pass_encrypted)
+      _ -> validate_secret_present(cs, :password, :password_encrypted)
+    end
+  end
+
+  @spec validate_secret_present(Ecto.Changeset.t(), atom(), atom()) :: Ecto.Changeset.t()
+  defp validate_secret_present(cs, virtual, stored_field) do
+    new_secret = get_field(cs, virtual)
+    stored = get_field(cs, stored_field)
+    auth_method_changed? = Map.has_key?(cs.changes, :auth_method)
+
+    cond do
+      is_binary(new_secret) and byte_size(new_secret) > 0 ->
         cs
 
-      _ ->
-        new_pw = get_field(cs, :password)
-        stored = get_field(cs, :password_encrypted)
-        auth_method_changed? = Map.has_key?(cs.changes, :auth_method)
+      auth_method_changed? ->
+        add_error(cs, virtual, "must be re-supplied when auth_method changes")
 
-        cond do
-          is_binary(new_pw) and byte_size(new_pw) > 0 ->
-            cs
+      is_binary(stored) and byte_size(stored) > 0 ->
+        cs
 
-          auth_method_changed? ->
-            add_error(cs, :password, "must be re-supplied when auth_method changes")
-
-          is_binary(stored) and byte_size(stored) > 0 ->
-            cs
-
-          true ->
-            add_error(cs, :password, "required for auth_method != :none")
-        end
+      true ->
+        add_error(cs, virtual, "required for auth_method != :none")
     end
   end
 
@@ -980,6 +991,40 @@ defmodule Grappa.Networks.Credential do
   def upstream_oper_pass(%__MODULE__{oper_pass_encrypted: pw}), do: pw
 
   @doc """
+  GH #1044 — returns the post-Cloak-load plaintext server `PASS` secret, or
+  `nil` when unset. Same accessor contract as `upstream_password/1`: the
+  `:server_pass_encrypted` field name describes the on-disk representation;
+  after `Repo.one!` it carries the DECRYPTED plaintext.
+
+  This is the SINGLE read source for the server-PASS role, and it is
+  deliberately not a fallback chain onto `upstream_password/1`. A row whose
+  `auth_method` is `:server_pass` and whose slot is empty has no gate secret,
+  full stop — `Grappa.IRC.AuthFSM.new/1` refuses it with
+  `{:missing_server_pass, :server_pass}` rather than reaching for the other
+  column. Two sources for one role is the split brain #124 is named after,
+  and the pre-#1044 rows that DID keep their PASS in `password_encrypted`
+  were moved once, by migration, precisely so no reader has to guess.
+  """
+  @spec upstream_server_pass(t()) :: binary() | nil
+  def upstream_server_pass(%__MODULE__{server_pass_encrypted: pw}), do: pw
+
+  # GH #1044 — the methods on which `password_encrypted` means NickServ. The
+  # set is DATA and named once, because `Session.Server`'s
+  # `pending_password_from_opts/1` has to agree with it key for key and the
+  # two live in different boundaries (Networks deps Session; the reverse would
+  # close a cycle), so neither can call the other. `Grappa.Session.ServerTest`
+  # measures them against each other.
+  @nickserv_secret_methods [:nickserv_identify, :server_pass]
+
+  @doc """
+  GH #1044 — the `auth_method` values on which `password_encrypted` carries
+  the NickServ secret. Exported so the Session-side twin can be pinned
+  against this list instead of restating it.
+  """
+  @spec nickserv_secret_methods() :: [auth_method(), ...]
+  def nickserv_secret_methods, do: @nickserv_secret_methods
+
+  @doc """
   GH #581 — the NickServ secret VALUE this credential recovers an identity
   with, or `nil` when none is on file. The SINGLE SOURCE OF TRUTH for BOTH
   the `/recover` action (`Session.Server` IDENTIFYs with this value) AND the
@@ -988,7 +1033,8 @@ defmodule Grappa.Networks.Credential do
 
   Mirrors EXACTLY the resolution `Session.Server`'s `nickserv_secret/1`
   applies, but over the PERSISTENT credential rather than the one-shot
-  session state: a `:nickserv_identify` upstream password, and nothing else.
+  session state: the upstream password of a row whose method leaves that
+  column meaning NickServ, and nothing else.
 
   #124 collapsed this to ONE source. It used to be a two-source precedence
   with the #509 `$nickserv_pass` column winning ahead of the password. Two
@@ -999,6 +1045,16 @@ defmodule Grappa.Networks.Credential do
   here or anywhere. `Session.Server`'s `nickserv_secret/1` collapsed in the
   SAME commit: the two are documented as required to stay identical, so they
   can only move together.
+
+  GH #1044 WIDENS THE METHOD SET AND NOT THE SOURCE, and the distinction is
+  the whole of #124's property. `:server_pass` joins `:nickserv_identify`
+  because on such a row the gate secret has moved to its own slot, which
+  leaves `password_encrypted` meaning NickServ exactly as it does everywhere
+  else. There is still ONE column read for this role and no fallback chain —
+  `server_pass_encrypted` is never consulted here, which is what keeps #509
+  from coming back through the new column. `Session.Server`'s
+  `pending_password_from_opts/1` carries the identical gate and moved in the
+  same commit.
 
   The secret must be non-empty — an empty secret is "nothing to identify
   with" (same `pw != ""` posture as the live gate and
@@ -1012,7 +1068,7 @@ defmodule Grappa.Networks.Credential do
   """
   @spec recover_secret(t()) :: binary() | nil
   def recover_secret(%__MODULE__{} = cred) do
-    if cred.auth_method == :nickserv_identify and secret_present?(upstream_password(cred)),
+    if cred.auth_method in @nickserv_secret_methods and secret_present?(upstream_password(cred)),
       do: upstream_password(cred),
       else: nil
   end

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -430,10 +430,14 @@ defmodule Grappa.Networks.Credential do
     |> validate_change(:realname, &Identity.safe_line_token/2)
     |> validate_change(:sasl_user, &Identity.safe_line_token/2)
     |> validate_change(:password, &Identity.safe_line_token/2)
-    # GH #1044 — the server PASS is a single-line wire token (`PASS <secret>`),
-    # so it gets the same CR/LF/NUL guard as `:password`: a newline here would
-    # split the outbound frame and inject a second command.
-    |> validate_change(:server_pass, &Identity.safe_line_token/2)
+    # GH #1044 — the server PASS is the SINGLE token of a `PASS <secret>` line,
+    # so it takes the STRICTER gate: a newline would split the outbound frame
+    # and inject a second command, and a space would be split off by the
+    # receiving ircd, truncating the secret to its first token and earning a
+    # 464 with no breadcrumb. Same predicate `AuthFSM` applies at the wire —
+    # enforcing it only there would let this door store a value that then
+    # refuses every connect.
+    |> validate_change(:server_pass, &Identity.safe_oper_token/2)
     |> validate_server_pass_is_user_only()
     |> validate_change(:auth_command_template, &Identity.safe_line_token/2)
     |> validate_change(:autojoin_channels, &validate_autojoin_channels/2)
@@ -629,6 +633,46 @@ defmodule Grappa.Networks.Credential do
     # re-interpolated into `PRIVMSG NickServ :IDENTIFY` on the next connect.
     |> validate_change(:password, &Identity.safe_line_token/2)
     |> put_encrypted_password()
+  end
+
+  @doc """
+  GH #1044 — narrow changeset for the server `PASS` slot alone, the write
+  door that gives the gate secret somewhere to live other than the NickServ
+  column. Mirror of `password_changeset/2` (one secret, nothing else
+  touched); the wide `changeset/2` also accepts the field, for the bind path
+  that sets everything at once.
+
+  `empty_values: []` keeps a blank `""` a real change (default `cast/3`
+  would drop it as "missing"), so the editor can CLEAR the slot —
+  `put_encrypted_server_pass/1` maps `""` to `nil` (SQL NULL). OMITTING the
+  key keeps whatever is stored, the leave-blank-to-keep semantics every
+  secret field here uses.
+
+  USER-ONLY, enforced by the same `validate_server_pass_is_user_only/1` the
+  wide changeset applies: a visitor's `auth_method` is DERIVED from its one
+  secret and never reaches `:server_pass`, so the value would be stored
+  where nothing could ever spend it. The guard has to be repeated on this
+  door rather than assumed from the other — a narrow changeset that skipped
+  it would be a hole in exactly the surface an HTTP client can reach.
+  """
+  @spec server_pass_changeset(t(), map()) :: Ecto.Changeset.t()
+  def server_pass_changeset(%__MODULE__{} = credential, attrs) when is_map(attrs) do
+    credential
+    |> cast(attrs, [:server_pass], empty_values: [])
+    |> validate_server_pass_token()
+    |> validate_server_pass_is_user_only()
+    |> put_encrypted_server_pass()
+  end
+
+  # `""` is the CLEAR verb and must reach `put_encrypted_server_pass/1`
+  # untouched; `safe_oper_token/2` rejects an empty string (it is not a
+  # token), so the two would contradict each other without this gate.
+  @spec validate_server_pass_token(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp validate_server_pass_token(cs) do
+    case get_change(cs, :server_pass) do
+      "" -> cs
+      _ -> validate_change(cs, :server_pass, &Identity.safe_oper_token/2)
+    end
   end
 
   @doc """
@@ -949,6 +993,17 @@ defmodule Grappa.Networks.Credential do
   # has already invalidated the changeset on the visitor branch, so a valid
   # changeset carrying this change is a user credential by construction.
   @spec put_encrypted_server_pass(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  # `""` is the CLEAR verb, and it stores SQL NULL rather than an empty blob —
+  # same mapping `put_encrypted_perform_field/3` applies to its two fields.
+  # An empty string would otherwise read back as "a secret is set" through
+  # `upstream_server_pass/1`, and `AuthFSM` would then refuse a credential the
+  # editor showed as configured. Only the narrow `server_pass_changeset/2`
+  # can reach this arm: the wide changeset's default `cast/3` drops `""` as
+  # missing before it ever becomes a change.
+  defp put_encrypted_server_pass(%{valid?: true, changes: %{server_pass: ""}} = cs) do
+    put_change(cs, :server_pass_encrypted, nil)
+  end
+
   defp put_encrypted_server_pass(%{valid?: true, changes: %{server_pass: pw}} = cs)
        when is_binary(pw) do
     put_change(cs, :server_pass_encrypted, pw)

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -1025,6 +1025,36 @@ defmodule Grappa.Networks.Credentials do
   end
 
   @doc """
+  GH #1044 — sets or clears the server `PASS` slot for `credential`.
+
+  Takes an already-fetched credential (the caller's lookup was subject-scoped,
+  so ownership is asserted) and routes through the narrow
+  `Credential.server_pass_changeset/2`. `""` clears; omitting the key is a
+  valid no-op (leave-blank-to-keep).
+
+  Like the perform list and UNLIKE the password, there is NO live verb: the
+  secret is spent on the `PASS` line during registration, so it cannot be
+  applied to a connection that is already up. An edit persists and takes
+  effect on the next (re)connect, when `SessionPlan` re-resolves the plan.
+  Bouncing a working session to install a gate secret it did not need would
+  be a worse trade than the wait.
+
+  A visitor credential is REFUSED by the changeset's user-only guard rather
+  than silently storing a value nothing can spend; a concurrent unbind
+  surfaces as `{:error, :not_found}`.
+  """
+  @spec update_server_pass(Credential.t(), map()) ::
+          {:ok, Credential.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def update_server_pass(%Credential{} = credential, attrs) when is_map(attrs) do
+    case credential |> Credential.server_pass_changeset(attrs) |> Repo.update() do
+      {:ok, updated} -> {:ok, updated}
+      {:error, _} = err -> err
+    end
+  rescue
+    Ecto.StaleEntryError -> {:error, :not_found}
+  end
+
+  @doc """
   Rotates the stored upstream NickServ password for `(user_id, network_id)`.
 
   #131: the id-keyed write `Session.Server`'s `credential_committer`

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -311,6 +311,13 @@ defmodule Grappa.Networks.SessionPlan do
       sasl_user: Credential.effective_sasl_user(cred),
       auth_method: cred.auth_method,
       password: Credential.upstream_password(cred),
+      # GH #1044 — the server `PASS` secret, in its own key because it is its
+      # own role. On a `:server_pass` row the PASS wire token reads THIS and
+      # `password` above keeps the NickServ meaning it has on every visitor
+      # row; on `:auto` the PASS token is the services handoff and still comes
+      # from `password`. Both travel on every plan (a nil slot is the common
+      # case) so the FSM never has to ask which shape of plan it got.
+      server_pass: Credential.upstream_server_pass(cred),
       # GH #189 — on-connect perform list + its `$oper_pass` secret. Both
       # decrypted-on-load plaintext (accessors), nil when unset. Threaded into
       # Session.Server state and expanded + run at 001, before the built-in

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -225,7 +225,22 @@ defmodule Grappa.Protocol do
   # `MIN_SERVER_PROTOCOL_VERSION` rises when the bundle starts REQUIRING
   # a newer field, and cic renders the profile only when present. It
   # stays at 2.
-  @protocol_version 9
+  # v10 (#1044) — the server `PASS` gets its own credential slot, and with
+  # it a write door: `GET`/`PUT /networks/:network_id/server_pass`, carrying
+  # `server_pass_set` and never the secret.
+  #
+  # ⚠️ `mix grappa.wire_pin` did NOT demand this bump, and that is exactly
+  # why it is written down. The digest spans the GENERATED artefacts, which
+  # come from `Grappa.*.Wire` typespecs; a REST endpoint whose shape lives in
+  # a controller is invisible to it. So the gate stays green either way and
+  # the number moves on the RULE, not on the tooling: reason (1) applies
+  # literally here — a cic bundle that grows a gate-secret editor REQUIRES
+  # this route and gets a 404 from any server predating it, which is the
+  # new-client-to-old-server direction the number exists to express.
+  #
+  # @min_protocol_version stays at 1: the route is purely additive and no
+  # existing client asks for it, so every v1..v9 bundle is served unchanged.
+  @protocol_version 10
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -236,7 +251,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 9
+  @spec version() :: 10
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/release/cli.ex
+++ b/lib/grappa/release/cli.ex
@@ -63,6 +63,7 @@ defmodule Grappa.Release.CLI do
     auth: :string,
     tls: :boolean,
     password: :string,
+    server_pass: :string,
     autojoin: :string,
     realname: :string,
     sasl_user: :string,
@@ -100,13 +101,17 @@ defmodule Grappa.Release.CLI do
           from the terminal, so it stays out of shell history.
 
       add-network USER NETWORK --server HOST:PORT --nick NICK --auth METHOD
-                  [--tls | --no-tls] [--password PW] [--autojoin '#a,#b']
+                  [--tls | --no-tls] [--password PW] [--server-pass PW]
+                  [--autojoin '#a,#b']
                   [--realname NAME] [--sasl-user USER] [--source IP]
                   [--services-flavor FLAVOR]
           Gives USER access to NETWORK, creating the network and the
           server when they do not exist yet. --auth is one of
           auto|sasl|server_pass|nickserv_identify|none. TLS defaults to
           on for port 6697, off otherwise.
+          --password is the NickServ secret; --server-pass is the server
+          PASS a gated network demands before registration. They are
+          different secrets and may both be given (#1044).
 
       remove-network USER NETWORK
           Revokes that access and stops any live session for it.
@@ -337,6 +342,10 @@ defmodule Grappa.Release.CLI do
     settings = %{
       nick: Keyword.fetch!(opts, :nick),
       password: Keyword.get(opts, :password),
+      # #1044 — the server `PASS`, independent of `--password` (the NickServ
+      # secret). A password-gated network needs both at once; the mix-task
+      # twin `grappa.bind_network` carries the same pair.
+      server_pass: Keyword.get(opts, :server_pass),
       auth_method: auth_method,
       autojoin_channels: parse_autojoin(Keyword.get(opts, :autojoin)),
       realname: Keyword.get(opts, :realname),

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -251,6 +251,13 @@ defmodule Grappa.Session do
           required(:sasl_user) => String.t(),
           required(:auth_method) => AuthFSM.auth_method(),
           required(:password) => String.t() | nil,
+          # GH #1044 — the server `PASS`, the credential's second secret.
+          # OPTIONAL, like `:tls_verify` below and for the same reason: a plan
+          # map built before this slice (a live process across a hot reload, a
+          # hand-built test plan) carries no such key, and `client_opts/1`
+          # reads it with a nil default — which is what every row meant before
+          # the slot was read at all.
+          optional(:server_pass) => String.t() | nil,
           required(:autojoin_channels) => [String.t()],
           required(:host) => String.t(),
           required(:port) => :inet.port_number(),

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -367,6 +367,12 @@ defmodule Grappa.Session.Server do
           required(:sasl_user) => String.t(),
           required(:auth_method) => AuthFSM.auth_method(),
           required(:password) => String.t() | nil,
+          # GH #1044 — the server `PASS` secret, the second of the credential's
+          # two. OPTIONAL for the same reason as `:tls_verify` above: a live
+          # pre-#1044 plan map survives a hot reload without it, and
+          # `client_opts/1` reads it with a nil default, which is the posture
+          # every row had before the slot existed.
+          optional(:server_pass) => String.t() | nil,
           required(:autojoin_channels) => [String.t()],
           required(:host) => String.t(),
           required(:port) => :inet.port_number(),
@@ -546,6 +552,10 @@ defmodule Grappa.Session.Server do
           pending_auth_timer: reference() | nil,
           pending_registration_secret: String.t() | nil,
           pending_password: String.t() | nil,
+          # GH #1044 — whether a NickServ secret was staged at init. Survives
+          # the one-shot clearing of `pending_password` above, which is the
+          # only reason it exists; see `identify_expected?/1`.
+          nickserv_secret_staged?: boolean(),
           # GH #189 — the on-connect perform list (raw text) + its `$oper_pass`
           # secret, decrypted plaintext threaded from the credential at boot.
           # Read at 001 by `run_perform_and_identify/1`. nil when unset.
@@ -1109,6 +1119,13 @@ defmodule Grappa.Session.Server do
       pending_auth_timer: nil,
       pending_registration_secret: nil,
       pending_password: pending_password_from_opts(opts),
+      # GH #1044 — the STABLE record of "a NickServ secret was staged", which
+      # `pending_password` stops being the moment the one-shot identify clears
+      # it. Derived from the same function on the same opts, so the two cannot
+      # disagree; read by `identify_expected?/1` to decide the #347 autojoin
+      # defer. Two methods stage a secret now, so the method alone no longer
+      # carries this fact.
+      nickserv_secret_staged?: pending_password_from_opts(opts) != nil,
       perform_list: Map.get(opts, :perform_list),
       oper_pass: Map.get(opts, :oper_pass),
       # #1398 — the subject tag decides WHICH closures are due, so the
@@ -1297,9 +1314,19 @@ defmodule Grappa.Session.Server do
   # the identify. Anon visitors (`auth_method: :none`) and SASL/server-pass
   # users keep `pending_password = nil`; an empty-string password is treated
   # as absent (nothing to identify with, so `$nickserv_pass` stays unbound).
+  #
+  # GH #1044 widened the METHOD set, not the source. `:server_pass` joins
+  # `:nickserv_identify` because the gate secret moved to its own slot on such
+  # a row, which leaves `:password` meaning NickServ exactly as it does
+  # everywhere else — so a self-hoster on a password-gated network finally
+  # gets both. `:server_pass` is precisely the one the sentence above used to
+  # exclude; SASL still keeps `pending_password = nil` (it spends `:password`
+  # on the SASL payload, so that column is not a NickServ secret there).
+  # `Grappa.Networks.Credential.nickserv_secret_methods/0` is the same list on
+  # the persistent side, and the two are pinned against each other by test.
   @spec pending_password_from_opts(init_opts()) :: String.t() | nil
-  defp pending_password_from_opts(%{auth_method: :nickserv_identify, password: pw})
-       when is_binary(pw) and pw != "",
+  defp pending_password_from_opts(%{auth_method: m, password: pw})
+       when m in [:nickserv_identify, :server_pass] and is_binary(pw) and pw != "",
        do: pw
 
   defp pending_password_from_opts(_), do: nil
@@ -4889,7 +4916,13 @@ defmodule Grappa.Session.Server do
       realname: opts.realname,
       sasl_user: opts.sasl_user,
       auth_method: opts.auth_method,
-      password: opts.password
+      password: opts.password,
+      # GH #1044 — the server `PASS` secret. `Map.get` rather than
+      # `opts.server_pass`: a plan map built before this slice (a live process
+      # surviving a hot reload, a hand-built test plan) has no such key, and
+      # the honest answer for its absence is "no gate secret", which is what
+      # every pre-#1044 row meant anyway.
+      server_pass: Map.get(opts, :server_pass)
     }
   end
 
@@ -6558,18 +6591,36 @@ defmodule Grappa.Session.Server do
 
   defp maybe_autojoin_or_defer(state), do: fire_autojoin(state)
 
-  # GH #347 / #509 / #124 — an identify is expected at 001 (so autojoin must
-  # wait for the +r echo) whenever an effective NickServ secret exists. Since
-  # #124 that is exactly ONE condition: `:nickserv_identify`, whose
-  # `pending_password` was staged from the credential password. It subsumes the
-  # "perform list consumed `$nickserv_pass`" case — consumption requires an
-  # effective secret, and there is only this one source of it. We test the
-  # STABLE `auth_method` (the origin of `pending_password`) rather than
-  # `pending_password` itself, since `run_perform_and_identify/1` has already
-  # cleared it one-shot by the time this runs.
+  # GH #347 / #509 / #124 / #1044 — an identify is expected at 001 (so autojoin
+  # must wait for the +r echo) whenever an effective NickServ secret exists. It
+  # subsumes the "perform list consumed `$nickserv_pass`" case — consumption
+  # requires an effective secret, and there is only one source of it.
+  #
+  # We cannot test `pending_password` itself: `run_perform_and_identify/1` has
+  # already cleared it one-shot by the time this runs. #124 could therefore
+  # test `auth_method`, which WAS the stable origin of that value while
+  # exactly one method staged it. Since #1044 two do, and the method alone no
+  # longer answers the question — a `:server_pass` row with no NickServ secret
+  # (the common gate-only credential) must NOT defer, or every one of them
+  # waits out the fallback window for a `+r` that is never coming. That is the
+  # #509 KNOWN EDGE, and reintroducing it by widening the method test is the
+  # trap this field exists to avoid.
+  #
+  # So the stable origin is recorded directly: one boolean, derived at init
+  # from the SAME `pending_password_from_opts/1` that stages the secret, so it
+  # cannot drift from it.
+  #
+  # The second clause is the hot-reload shim this file applies to every new
+  # state key, and it is NOT redundant here: `state` is a plain MAP, not a
+  # struct, so `Deploy.Preflight` — which refuses a hot deploy on a changed
+  # `defstruct` — has nothing to read and would let one through. A plain
+  # module reload does not rewrite live process state, so a session that
+  # started before this slice reaches this function without the key. Its
+  # honest answer is the pre-#1044 rule, which is exactly what that session's
+  # `pending_password` was staged under.
   @spec identify_expected?(t()) :: boolean()
-  defp identify_expected?(%{auth_method: :nickserv_identify}), do: true
-  defp identify_expected?(_), do: false
+  defp identify_expected?(%{nickserv_secret_staged?: staged?}), do: staged?
+  defp identify_expected?(%{auth_method: m}), do: m == :nickserv_identify
 
   # Single funnel for the two deferred-autojoin triggers (#347): the +r
   # self-MODE echo and the `:autojoin_defer` fallback timer.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -6610,17 +6610,21 @@ defmodule Grappa.Session.Server do
   # from the SAME `pending_password_from_opts/1` that stages the secret, so it
   # cannot drift from it.
   #
-  # The second clause is the hot-reload shim this file applies to every new
-  # state key, and it is NOT redundant here: `state` is a plain MAP, not a
-  # struct, so `Deploy.Preflight` — which refuses a hot deploy on a changed
-  # `defstruct` — has nothing to read and would let one through. A plain
-  # module reload does not rewrite live process state, so a session that
-  # started before this slice reaches this function without the key. Its
-  # honest answer is the pre-#1044 rule, which is exactly what that session's
-  # `pending_password` was staged under.
+  # `Map.get/3` rather than `state.nickserv_secret_staged?`, and rather than a
+  # second function clause: this is the hot-reload shim the file applies to
+  # every new state key (`Map.get(state, :isupport, …)`, `Map.get(state,
+  # :umodes, [])`). It is NOT redundant here — `state` is a plain MAP, so
+  # `Deploy.Preflight`, which refuses a hot deploy on a changed `defstruct`,
+  # has nothing to read and would let one through, and a module reload does
+  # not rewrite live process state. A second clause expresses the same thing
+  # but Dialyzer proves it unreachable FROM THE TYPE (`t()` declares the key
+  # required) and reports `pattern_match_cov`, so the shim has to be a lookup
+  # rather than a pattern. The default is the pre-#1044 rule, which is exactly
+  # what such a session's `pending_password` was staged under.
   @spec identify_expected?(t()) :: boolean()
-  defp identify_expected?(%{nickserv_secret_staged?: staged?}), do: staged?
-  defp identify_expected?(%{auth_method: m}), do: m == :nickserv_identify
+  defp identify_expected?(state) do
+    Map.get(state, :nickserv_secret_staged?, state.auth_method == :nickserv_identify)
+  end
 
   # Single funnel for the two deferred-autojoin triggers (#347): the +r
   # self-MODE echo and the `:autojoin_defer` fallback timer.

--- a/lib/grappa_web/controllers/networks_controller.ex
+++ b/lib/grappa_web/controllers/networks_controller.ex
@@ -368,8 +368,9 @@ defmodule GrappaWeb.NetworksController do
   new value — which is the entire point of the field. A parked / no-session
   edit persists only.
 
-  Body: `{password}` — required, non-blank. 200 with the updated credential
-  (carrying `password_set: true`, never the value); 400 on a missing or blank
+  Body: `{password}` — required, non-blank. 200 with the updated credential,
+  which says nothing about the stored secret: not the value, and deliberately
+  not even its set-ness (pinned by the write-only test). 400 on a missing or blank
   password; 422 when services would refuse it (spaces / under 5 / over 32 bytes
   / control codes / equal to the nick); 404 if the credential vanished; 401
   without a Bearer.
@@ -407,8 +408,10 @@ defmodule GrappaWeb.NetworksController do
   credential vanished; 401 without a Bearer.
 
   #124 removed the `nickserv_pass_set` sibling: `$nickserv_pass` expands from
-  the credential password now, whose set-ness is reported by the identity
-  surface (`password_set`), not here.
+  the credential password now, whose set-ness no surface reports at all — the
+  password door is write-only end to end. #1044's server `PASS` has its own
+  `GET /networks/:network_id/server_pass`, not a key here: that secret belongs
+  to registration, not to the perform list.
   """
   @spec perform(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :not_found}
   def perform(conn, _) do
@@ -449,9 +452,71 @@ defmodule GrappaWeb.NetworksController do
     end
   end
 
+  @doc """
+  GH #1044 — GET the server `PASS` set-ness for this `(subject, network)`.
+
+  Returns `{server_pass_set}` and never the value: write-only, exactly like
+  `$oper_pass` on the perform surface. 404 if the credential vanished; 401
+  without a Bearer.
+  """
+  @spec server_pass(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :not_found}
+  def server_pass(conn, _) do
+    subject = conn.assigns.current_subject
+    network = conn.assigns.network
+
+    with {:ok, credential} <- fetch_credential(subject, network) do
+      render(conn, :server_pass, server_pass: server_pass_wire(credential))
+    end
+  end
+
+  @doc """
+  GH #1044 — PUT the server `PASS`, the secret a password-gated network
+  demands before registration.
+
+  A sibling of `/password` rather than a key on it, and for the reason the
+  whole issue exists: they are two different secrets with two different
+  destinations, and one field editing both is the state this replaces.
+
+  Body: `{server_pass}` — `""` clears, omitting the key keeps the stored one
+  (leave-blank-to-keep). Persists ONLY: the secret is spent during
+  registration, so a live session picks it up on its next (re)connect — this
+  endpoint deliberately does not bounce a working connection the way
+  `/password` does, since that one changes what an ALREADY-registered
+  session would do next.
+
+  200 with `{server_pass_set}`; 422 on a value that is not a single wire
+  token (spaces / CR / LF / NUL) or on a visitor credential, which cannot
+  spend this secret at all; 404 if the credential vanished; 401 without a
+  Bearer.
+  """
+  @spec update_server_pass(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :not_found | Ecto.Changeset.t()}
+  def update_server_pass(conn, params) do
+    subject = conn.assigns.current_subject
+    network = conn.assigns.network
+
+    with {:ok, credential} <- fetch_credential(subject, network),
+         {:ok, updated} <- Credentials.update_server_pass(credential, server_pass_attrs(params)) do
+      render(conn, :server_pass, server_pass: server_pass_wire(updated))
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
+
+  # #1044 — pick ONLY the secret from the body (string keys), dropping the
+  # `:network_id` route param and any stray key before the changeset casts.
+  # Mirror of `perform_attrs/1`.
+  @spec server_pass_attrs(map()) :: map()
+  defp server_pass_attrs(params), do: Map.take(params, ["server_pass"])
+
+  # #1044 — the wire shape: set-ness only. The secret is NEVER serialised,
+  # the same write-only posture `$oper_pass` has on the perform surface.
+  @spec server_pass_wire(Credential.t()) :: %{server_pass_set: boolean()}
+  defp server_pass_wire(%Credential{} = credential) do
+    %{server_pass_set: Credential.upstream_server_pass(credential) != nil}
+  end
 
   # Only `:connected` and `:parked` are user-settable. `:failed` is
   # server-set only (k-line / permanent SASL — S1.4 lenient triggers);

--- a/lib/grappa_web/controllers/networks_json.ex
+++ b/lib/grappa_web/controllers/networks_json.ex
@@ -63,12 +63,24 @@ defmodule GrappaWeb.NetworksJSON do
 
   #124 dropped the `nickserv_pass_set` sibling. `$oper_pass` keeps its flag
   because it remains a perform-owned secret; the NickServ one moved to the
-  credential password and is reported as `password_set` on the credential wire
-  shape instead.
+  credential password, whose set-ness this surface deliberately does not
+  report (see `NetworksController.update_password/2` — the response says
+  nothing about the stored secret, not even whether there is one).
   """
   @spec perform(%{perform: %{perform_list: String.t() | nil, oper_pass_set: boolean()}}) ::
           %{perform_list: String.t() | nil, oper_pass_set: boolean()}
   def perform(%{perform: %{perform_list: perform_list, oper_pass_set: oper_pass_set}}) do
     %{perform_list: perform_list, oper_pass_set: oper_pass_set}
+  end
+
+  @doc """
+  GH #1044 — the server `PASS` wire shape: set-ness and nothing else. Passed
+  straight through from the controller's `server_pass_wire/1`; the secret
+  never reaches here, the same write-only posture `oper_pass_set` has above.
+  """
+  @spec server_pass(%{server_pass: %{server_pass_set: boolean()}}) ::
+          %{server_pass_set: boolean()}
+  def server_pass(%{server_pass: %{server_pass_set: server_pass_set}}) do
+    %{server_pass_set: server_pass_set}
   end
 end

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -558,6 +558,15 @@ defmodule GrappaWeb.Router do
     # ResolveNetwork pipeline, so ownership is asserted the same way.
     put "/password", NetworksController, :update_password
 
+    # #1044 — the server PASS a password-gated network demands before
+    # registration. A sibling of `/password` rather than a key on it: two
+    # different secrets with two different destinations, which is the whole
+    # point of the issue (one field editing both is the state it replaces).
+    # Write-only like `/perform`'s `$oper_pass` — GET reports set-ness only.
+    # Same ResolveNetwork pipeline, so ownership is asserted the same way.
+    get "/server_pass", NetworksController, :server_pass
+    put "/server_pass", NetworksController, :update_server_pass
+
     get "/channels", ChannelsController, :index
     post "/channels", ChannelsController, :create
     delete "/channels/:channel_id", ChannelsController, :delete

--- a/lib/mix/tasks/grappa.bind_network.ex
+++ b/lib/mix/tasks/grappa.bind_network.ex
@@ -37,6 +37,24 @@ defmodule Mix.Tasks.Grappa.BindNetwork do
   (`sasl`) target different on-the-wire surfaces. `--autojoin` is a
   comma-separated list of channel names.
 
+  ## The two password flags (#1044)
+
+  `--password` is the NickServ secret; `--server-pass` is the server `PASS`
+  a password-gated network demands before it will register you. They are
+  independent, and both may be given at once — which is the point: before
+  #1044 one credential held one secret, so an operator who needed the gate
+  had to keep the NickServ password in the on-connect perform list, in
+  cleartext.
+
+      --auth server_pass --server-pass '<gate secret>' \\
+        --password '<NickServ password>'
+
+  On `--auth server_pass` the `PASS` line carries `--server-pass` and
+  `--password` drives the post-001 identify. On `--auth auto` the handoff
+  spends `--password` on `PASS` itself, so `--server-pass` has no role
+  there. `--server-pass` must be a single wire token: no spaces (the ircd
+  would split it and keep the first), no CR/LF/NUL.
+
   ## TLS default — port-sniffed
 
   When neither `--tls` nor `--no-tls` is passed, the TLS posture is
@@ -72,6 +90,7 @@ defmodule Mix.Tasks.Grappa.BindNetwork do
     tls: :boolean,
     nick: :string,
     password: :string,
+    server_pass: :string,
     auth: :string,
     autojoin: :string,
     realname: :string,
@@ -122,6 +141,10 @@ defmodule Mix.Tasks.Grappa.BindNetwork do
     settings = %{
       nick: nick,
       password: Keyword.get(opts, :password),
+      # #1044 — the server `PASS`, a DIFFERENT secret from `--password`. On a
+      # password-gated network both are needed at once, so the two flags are
+      # independent rather than one flag the auth method reinterprets.
+      server_pass: Keyword.get(opts, :server_pass),
       auth_method: OptionParsing.parse_auth(auth),
       autojoin_channels: OptionParsing.parse_autojoin(Keyword.get(opts, :autojoin)),
       realname: Keyword.get(opts, :realname),

--- a/lib/mix/tasks/grappa.repair_passwords.ex
+++ b/lib/mix/tasks/grappa.repair_passwords.ex
@@ -64,9 +64,15 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   credential any more, so a run that DOES find one is the signal of a new
   bug rather than routine maintenance. The output says so.
 
-  The `server_pass_encrypted` slot (#1044) is never read and never written:
-  it holds a different role's secret and was never fed by the `SET PASSWD`
-  capture path, so it is not part of this corruption.
+  The `server_pass_encrypted` slot (#1044) is never read NOR written HERE: it
+  holds a different role's secret and is not fed by the `SET PASSWD` capture
+  path, so it is not part of this corruption. What #1044 did change is which
+  rows are IN scope — on a `:server_pass` credential `password_encrypted` now
+  means NickServ, so such a row can be corrupted exactly like a
+  `:nickserv_identify` one and is judged by the same chain. The method set
+  comes from `Credential.nickserv_secret_methods/0` rather than being spelled
+  again here: a second copy is how this task would come to disagree with the
+  session about which column holds whose secret.
   """
   use Boundary,
     top_level?: true,
@@ -140,7 +146,14 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   # `newpass` that still holds one, so such a rotation never took upstream
   # and NEITHER token is known to be the live password.
   @spec classify_concatenation(String.t(), String.t() | nil, Credential.auth_method()) :: verdict()
-  defp classify_concatenation(password, nick, :nickserv_identify) do
+  defp classify_concatenation(password, nick, auth_method) when is_atom(auth_method) do
+    if auth_method in Credential.nickserv_secret_methods(),
+      do: classify_nickserv_concatenation(password, nick),
+      else: {:report, :ambiguous_auth_method}
+  end
+
+  @spec classify_nickserv_concatenation(String.t(), String.t() | nil) :: verdict()
+  defp classify_nickserv_concatenation(password, nick) do
     case String.split(password, " ") do
       # Exactly two tokens is the single-rotation case, and it is the only
       # deterministic one. "Keep the LAST token" and "keep the second" agree
@@ -151,8 +164,6 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
       _ -> {:report, :multiple_rotations}
     end
   end
-
-  defp classify_concatenation(_, _, _), do: {:report, :ambiguous_auth_method}
 
   # A repair that services would themselves refuse is not a repair — it just
   # exchanges one silently-never-identifying value for another.
@@ -171,8 +182,11 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   # `Credentials.update_credential_password/2` applies at the #124 door.
   @spec classify_unusable(NSInterceptor.vet_reject_reason(), Credential.auth_method()) ::
           :healthy | {:report, {:unusable, NSInterceptor.vet_reject_reason()}}
-  defp classify_unusable(reason, :nickserv_identify), do: {:report, {:unusable, reason}}
-  defp classify_unusable(_, _), do: :healthy
+  defp classify_unusable(reason, auth_method) do
+    if auth_method in Credential.nickserv_secret_methods(),
+      do: {:report, {:unusable, reason}},
+      else: :healthy
+  end
 
   @impl Mix.Task
   def run(args) do

--- a/lib/mix/tasks/grappa.update_network_credential.ex
+++ b/lib/mix/tasks/grappa.update_network_credential.ex
@@ -38,6 +38,7 @@ defmodule Mix.Tasks.Grappa.UpdateNetworkCredential do
     network: :string,
     nick: :string,
     password: :string,
+    server_pass: :string,
     auth: :string,
     autojoin: :string,
     realname: :string,
@@ -60,7 +61,11 @@ defmodule Mix.Tasks.Grappa.UpdateNetworkCredential do
 
     attrs =
       opts
-      |> Keyword.take([:nick, :password, :realname, :sasl_user])
+      # #1044 — `:server_pass` rides the same wide changeset as the rest; it
+      # is a DIFFERENT secret from `:password`, so rotating one must never
+      # touch the other. Omitting a key keeps the stored value, which is what
+      # makes that true here.
+      |> Keyword.take([:nick, :password, :server_pass, :realname, :sasl_user])
       |> Map.new()
       |> maybe_put_auth(opts)
       |> maybe_put_autojoin(opts)

--- a/priv/repo/migrations/20260831235021_move_legacy_server_pass_to_its_own_slot.exs
+++ b/priv/repo/migrations/20260831235021_move_legacy_server_pass_to_its_own_slot.exs
@@ -1,0 +1,90 @@
+defmodule Grappa.Repo.Migrations.MoveLegacyServerPassToItsOwnSlot do
+  @moduledoc """
+  GH #1044 — move the gate secret of every PRE-#1044 `:server_pass` credential
+  out of `password_encrypted` and into `server_pass_encrypted`.
+
+  ## Why this has to exist
+
+  The sibling migration (`*_swap_nickserv_pass_slot_for_server_pass`) opened
+  the new slot EMPTY, deliberately. Every `:server_pass` row written before it
+  therefore still keeps its server `PASS` in `password_encrypted` — which is
+  the column #1044 assigns to the NickServ role. The read cutover (`AuthFSM`
+  taking the PASS token from the dedicated slot) turns those rows into
+  credentials that send no PASS at all: a refused handshake, not a degraded
+  one.
+
+  ## Why a move and not a read-side fallback
+
+  "Read the slot, fall back to the password column" is shorter and needs no
+  migration. It is also the two-homes-for-one-role split brain that #124 is
+  named after: the operator repairs one column and the other keeps driving
+  the wire. #124's property — for every role exactly ONE place it is read
+  from, with no fallback chain — is a stated invariant, so the bytes move
+  once and every reader afterwards has a single source.
+
+  ## The predicate, conjunct by conjunct
+
+    * `auth_method = 'server_pass'` — the only method whose `password_encrypted`
+      ever meant "server PASS". On `:auto` the PASS token is the services
+      handoff and legitimately stays in `password_encrypted`; on `:sasl` /
+      `:nickserv_identify` / `:none` the column was never a gate secret.
+    * `user_id IS NOT NULL` — the slot is user-only. A visitor's `auth_method`
+      is DERIVED from the presence of its one secret and never reaches
+      `:server_pass`, so no visitor row is in scope; the conjunct is the belt
+      that keeps a future write path from silently un-identifying one.
+    * `server_pass_encrypted IS NULL` — a row whose slot is already populated
+      was written through the post-#1044 changeset, so its `password_encrypted`
+      is ALREADY the NickServ secret. Overwriting it would destroy that secret
+      and duplicate the gate one. This conjunct is also what makes the
+      migration idempotent.
+    * `password_encrypted IS NOT NULL` — nothing to move otherwise.
+
+  ## Copying a ciphertext between columns
+
+  The values are Cloak AES-GCM blobs and the move is a raw column-to-column
+  copy, which is sound only because the ciphertext carries no per-column
+  binding (no AAD naming the field, no column-derived key). That was MEASURED
+  before this migration was written, with both controls — a same-column round
+  trip, and a single corrupted byte that must fail to decrypt — and the
+  property is pinned by the migration's own test, which drives the moved value
+  back out through the schema rather than comparing blobs.
+
+  ## COLD
+
+  A migration under `priv/repo/migrations` makes the slice cold by
+  construction. This one is DATA-only (no shape change), but it must not run
+  against a node still serving the pre-cutover code: that code reads the PASS
+  from `password_encrypted`, which this empties.
+
+  `down/0` moves back exactly the set `up/0` produces. It cannot be a perfect
+  inverse and does not claim to be: a row left at (slot set, password NULL) is
+  indistinguishable from one a post-#1044 operator created that way on
+  purpose, so the rollback returns such rows to the pre-#1044 shape rather
+  than to whatever they were five minutes ago.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE network_credentials
+       SET server_pass_encrypted = password_encrypted,
+           password_encrypted = NULL
+     WHERE auth_method = 'server_pass'
+       AND user_id IS NOT NULL
+       AND server_pass_encrypted IS NULL
+       AND password_encrypted IS NOT NULL
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE network_credentials
+       SET password_encrypted = server_pass_encrypted,
+           server_pass_encrypted = NULL
+     WHERE auth_method = 'server_pass'
+       AND user_id IS NOT NULL
+       AND password_encrypted IS NULL
+       AND server_pass_encrypted IS NOT NULL
+    """)
+  end
+end

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 9
+protocol_version = 10
 shape_digest = sha256:9c97bd9b75bf362ac22c9dc727c4012b45062c88f6156daf6d73a79859394946

--- a/test/grappa/irc/auth_fsm_test.exs
+++ b/test/grappa/irc/auth_fsm_test.exs
@@ -63,9 +63,26 @@ defmodule Grappa.IRC.AuthFSMTest do
                AuthFSM.new(base_opts(%{auth_method: :nickserv_identify, password: ""}))
     end
 
-    test ":server_pass with valid password is accepted" do
-      assert {:ok, %AuthFSM{password: "swordfish", auth_method: :server_pass}} =
-               AuthFSM.new(base_opts(%{auth_method: :server_pass, password: "swordfish"}))
+    # GH #1044 — on `:server_pass` the secret the FSM needs is the SERVER one,
+    # carried in its own `:server_pass` opt. `:password` on such a row is the
+    # NickServ secret and the FSM never emits it (the built-in IDENTIFY is
+    # post-001, host-side), so it is neither required nor read here.
+    test ":server_pass with a valid server_pass is accepted" do
+      assert {:ok, %AuthFSM{server_pass: "swordfish", auth_method: :server_pass}} =
+               AuthFSM.new(base_opts(%{auth_method: :server_pass, server_pass: "swordfish"}))
+    end
+
+    test ":server_pass without a server_pass is rejected, naming the slot that is missing" do
+      # NOT `{:missing_password, :server_pass}`: since #1044 a `:server_pass`
+      # row can carry BOTH secrets, so an error naming "password" would point
+      # the operator at the other one.
+      assert {:error, {:missing_server_pass, :server_pass}} =
+               AuthFSM.new(base_opts(%{auth_method: :server_pass, password: "ns-secret"}))
+    end
+
+    test ":server_pass with an empty-string server_pass is rejected" do
+      assert {:error, {:missing_server_pass, :server_pass}} =
+               AuthFSM.new(base_opts(%{auth_method: :server_pass, server_pass: ""}))
     end
 
     test ":auto with valid password is accepted" do
@@ -117,9 +134,23 @@ defmodule Grappa.IRC.AuthFSMTest do
                AuthFSM.new(base_opts(%{auth_method: :sasl, password: "swo\x00rd"}))
     end
 
-    test ":server_pass with CRLF in password rejected at new/1 (irc/S5)" do
+    test ":server_pass with CRLF in server_pass rejected at new/1 (irc/S5)" do
+      assert {:error, {:invalid_line_token, :server_pass}} =
+               AuthFSM.new(base_opts(%{auth_method: :server_pass, server_pass: "p\r\nQUIT :pwn"}))
+    end
+
+    # #1044 — the OTHER secret on the same row still has to be line-safe. It
+    # never reaches the handshake, but it crosses this boundary, and the FSM
+    # is self-defending by design (the Phase-6 facade may bypass the schema).
+    test ":server_pass with CRLF in the NickServ password rejected at new/1" do
       assert {:error, {:invalid_line_token, :password}} =
-               AuthFSM.new(base_opts(%{auth_method: :server_pass, password: "p\r\nQUIT :pwn"}))
+               AuthFSM.new(
+                 base_opts(%{
+                   auth_method: :server_pass,
+                   server_pass: "swordfish",
+                   password: "p\r\nQUIT :pwn"
+                 })
+               )
     end
 
     test ":nickserv_identify with CRLF in password rejected at new/1 (irc/S5)" do
@@ -130,9 +161,23 @@ defmodule Grappa.IRC.AuthFSMTest do
     # S30 — PASS is a single wire token (RFC 2812 §3.1.1). A space/tab in a
     # :server_pass / :auto password would split it, silently truncating
     # server-side to the first token → 464 + restart loop with no breadcrumb.
-    test ":server_pass with a space in password rejected at new/1 (S30)" do
-      assert {:error, {:invalid_line_token, :password}} =
-               AuthFSM.new(base_opts(%{auth_method: :server_pass, password: "sword fish"}))
+    test ":server_pass with a space in server_pass rejected at new/1 (S30)" do
+      assert {:error, {:invalid_line_token, :server_pass}} =
+               AuthFSM.new(base_opts(%{auth_method: :server_pass, server_pass: "sword fish"}))
+    end
+
+    # #1044 — S30's single-token rule is about the PASS wire line, so it binds
+    # the slot that LANDS there and no other. The NickServ secret on the same
+    # row goes out as a PRIVMSG trailing param, where a space is legal.
+    test ":server_pass with a space in the NickServ password is still accepted (#1044)" do
+      assert {:ok, %AuthFSM{auth_method: :server_pass}} =
+               AuthFSM.new(
+                 base_opts(%{
+                   auth_method: :server_pass,
+                   server_pass: "swordfish",
+                   password: "sword fish"
+                 })
+               )
     end
 
     test ":auto with a tab in password rejected at new/1 (S30)" do
@@ -211,7 +256,7 @@ defmodule Grappa.IRC.AuthFSMTest do
     end
 
     test ":server_pass -> PASS BEFORE NICK + USER, no CAP" do
-      state = new!(%{auth_method: :server_pass, password: "swordfish"})
+      state = new!(%{auth_method: :server_pass, server_pass: "swordfish"})
       assert {%AuthFSM{phase: :pre_register}, sends} = AuthFSM.initial_handshake(state)
 
       assert send_lines(sends) == [
@@ -219,6 +264,35 @@ defmodule Grappa.IRC.AuthFSMTest do
                "NICK vjt",
                "USER vjt 0 * :Vincenzo"
              ]
+    end
+
+    # GH #1044, the whole point of the second slot: a password-gated network
+    # wants BOTH secrets at once, and the PASS line must carry the server one.
+    # If the FSM ever read `:password` here, the NickServ secret would be sent
+    # to the network's front door — a wrong secret on the wire, and the
+    # handshake fails outright rather than degrading.
+    test ":server_pass carrying BOTH secrets sends the SERVER one on PASS" do
+      state =
+        new!(%{auth_method: :server_pass, server_pass: "gate-secret", password: "ns-secret"})
+
+      assert {%AuthFSM{}, sends} = AuthFSM.initial_handshake(state)
+      lines = send_lines(sends)
+
+      assert hd(lines) == "PASS gate-secret"
+      refute Enum.any?(lines, &String.contains?(&1, "ns-secret"))
+    end
+
+    # The `:auto` arm is deliberately NOT moved: there the PASS token IS the
+    # services secret (the Bahamut/Azzurra PASS-handoff), which is a different
+    # role from the network gate `:server_pass` names. One role, one slot.
+    test ":auto reads the password, never the server_pass slot (#1044)" do
+      state = new!(%{auth_method: :auto, password: "handoff", server_pass: "gate-secret"})
+
+      assert {%AuthFSM{}, sends} = AuthFSM.initial_handshake(state)
+      lines = send_lines(sends)
+
+      assert hd(lines) == "PASS handoff"
+      refute Enum.any?(lines, &String.contains?(&1, "gate-secret"))
     end
 
     test ":sasl -> CAP LS 302 + NICK + USER (no PASS); phase advances to :awaiting_cap_ls" do
@@ -620,7 +694,8 @@ defmodule Grappa.IRC.AuthFSMTest do
       for {method, opts} <- [
             {:none, %{auth_method: :none}},
             {:sasl, %{auth_method: :sasl, password: "s3cret"}},
-            {:server_pass, %{auth_method: :server_pass, password: "s3cret"}},
+            # #1044 — `:server_pass` takes its secret from its own slot.
+            {:server_pass, %{auth_method: :server_pass, server_pass: "s3cret"}},
             {:auto, %{auth_method: :auto, password: "s3cret"}}
           ] do
         state = new!(opts)
@@ -773,7 +848,8 @@ defmodule Grappa.IRC.AuthFSMTest do
       for opts <- [
             %{auth_method: :none},
             %{auth_method: :sasl, password: "s3cret"},
-            %{auth_method: :server_pass, password: "s3cret"},
+            # #1044 — `:server_pass` takes its secret from its own slot.
+            %{auth_method: :server_pass, server_pass: "s3cret"},
             %{auth_method: :auto, password: "s3cret"}
           ] do
         state = new!(opts)

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -1133,7 +1133,8 @@ defmodule Grappa.IRC.ClientTest do
       _ =
         start_client(port, %{
           auth_method: :server_pass,
-          password: "swordfish"
+          # #1044 — the PASS token comes from the dedicated slot.
+          server_pass: "swordfish"
         })
 
       :ok = IRCServer.await_handshake(server, 1_000)

--- a/test/grappa/migrations/move_legacy_server_pass_to_its_own_slot_test.exs
+++ b/test/grappa/migrations/move_legacy_server_pass_to_its_own_slot_test.exs
@@ -1,0 +1,217 @@
+defmodule Grappa.Migrations.MoveLegacyServerPassToItsOwnSlotTest do
+  @moduledoc """
+  GH #1044 — the DATA step that makes the read cutover safe.
+
+  The sibling migration (`*_swap_nickserv_pass_slot_for_server_pass`) opened
+  `server_pass_encrypted` EMPTY. Every `:server_pass` row written before that
+  therefore still keeps its gate secret in `password_encrypted`, which is the
+  column #1044 hands to the NickServ role. The moment `AuthFSM` starts reading
+  the PASS token from the new slot, those rows send nothing and their
+  handshake is refused.
+
+  A read-side fallback onto the old column would paper over it and is exactly
+  what #124's one-home-per-role property forbids, so the bytes move ONCE,
+  here, and every reader afterwards has a single place to look.
+
+  ## The claim that is easy to get wrong
+
+  The move is a raw SQL column-to-column copy of a Cloak ciphertext. That is
+  only sound if the ciphertext carries no per-column binding, and the test
+  below drives the value back out through the SCHEMA (which decrypts on load)
+  rather than comparing blobs: comparing blobs would pass just as happily if
+  the result were undecryptable garbage.
+
+  `async: false` for the same reason as its sibling: the second describe
+  issues DDL-adjacent rewinds of a shared table.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Networks.Credential
+  alias Grappa.Repo
+
+  # Matched by SUFFIX, not by version — a rebase renumbers the file and a stale
+  # literal would make `Ecto.Migrator.down/4` answer `:already_down`, i.e. a
+  # test that rewinds nothing and then asserts against an untouched table.
+  @migration_glob "priv/repo/migrations/*_move_legacy_server_pass_to_its_own_slot.exs"
+
+  defp secrets(id) do
+    %{rows: [[server_pass, password]]} =
+      Repo.query!(
+        "SELECT server_pass_encrypted, password_encrypted FROM network_credentials WHERE id = ?",
+        [id]
+      )
+
+    {server_pass, password}
+  end
+
+  # Stage a PRE-#1044 row: the gate secret sitting in the NickServ column,
+  # the new slot empty. Written through the schema so the value is a REAL
+  # Cloak ciphertext, then moved across by raw SQL — which is what the
+  # migration does, and the only way the decryptability claim means anything.
+  defp legacy_server_pass_row(user, network, secret) do
+    {:ok, cred} =
+      %Credential{}
+      |> Credential.changeset(%{
+        user_id: user.id,
+        network_id: network.id,
+        nick: "vjt",
+        auth_method: :server_pass,
+        server_pass: secret
+      })
+      |> Repo.insert()
+
+    {slot, _} = secrets(cred.id)
+
+    Repo.query!(
+      "UPDATE network_credentials SET password_encrypted = ?, server_pass_encrypted = NULL WHERE id = ?",
+      [slot, cred.id]
+    )
+
+    cred
+  end
+
+  # The test database is migrated at setup, so the version is already in
+  # `schema_migrations` and a bare `up/2` answers `:already_up` — a call that
+  # runs nothing and then asserts against untouched rows. Rewind first, then
+  # replay forwards over the staged row, exercising the real migrator path.
+  #
+  # The rewind is a no-op on every fixture in this file BY THE PREDICATE, not
+  # by luck: `down/0` only matches (slot set, password NULL), and none of the
+  # staged rows are in that shape until `up/0` has run.
+  defp run_migration! do
+    assert :ok = Ecto.Migrator.down(Repo, migration_version!(), load_migration!(), log: false)
+    assert :ok = Ecto.Migrator.up(Repo, migration_version!(), load_migration!(), log: false)
+  end
+
+  setup do
+    user = user_fixture()
+    {network, _} = network_with_server(port: 6667)
+    %{user: user, network: network}
+  end
+
+  describe "the legacy row" do
+    test "the gate secret MOVES to its own slot and leaves the NickServ one empty", ctx do
+      cred = legacy_server_pass_row(ctx.user, ctx.network, "gate-secret")
+
+      run_migration!()
+
+      {slot, password} = secrets(cred.id)
+
+      refute is_nil(slot)
+      assert is_nil(password)
+    end
+
+    test "the moved bytes still DECRYPT — the ciphertext is not column-bound", ctx do
+      cred = legacy_server_pass_row(ctx.user, ctx.network, "gate-secret")
+
+      run_migration!()
+
+      # Through the schema, not the blob: a raw-blob comparison would be green
+      # on an undecryptable value, which is the failure this guards.
+      assert Credential.upstream_server_pass(Repo.get!(Credential, cred.id)) == "gate-secret"
+    end
+
+    test "running it twice moves nothing further (idempotent)", ctx do
+      cred = legacy_server_pass_row(ctx.user, ctx.network, "gate-secret")
+
+      run_migration!()
+      after_first = secrets(cred.id)
+
+      assert :already_up =
+               Ecto.Migrator.up(Repo, migration_version!(), load_migration!(), log: false)
+
+      assert secrets(cred.id) == after_first
+    end
+  end
+
+  describe "what the move must NOT touch" do
+    test "a :nickserv_identify row keeps its secret where it is", ctx do
+      {:ok, cred} =
+        %Credential{}
+        |> Credential.changeset(%{
+          user_id: ctx.user.id,
+          network_id: ctx.network.id,
+          nick: "vjt",
+          auth_method: :nickserv_identify,
+          password: "ns-secret"
+        })
+        |> Repo.insert()
+
+      run_migration!()
+
+      {slot, _} = secrets(cred.id)
+
+      assert is_nil(slot)
+      assert Credential.upstream_password(Repo.get!(Credential, cred.id)) == "ns-secret"
+    end
+
+    # The row shape #1044 exists to produce: a gate secret AND a NickServ one,
+    # already in their right homes. The migration must recognise it as done
+    # and not overwrite the NickServ secret with a copy of the gate one.
+    test "a row already carrying BOTH secrets is left exactly as it is", ctx do
+      {:ok, cred} =
+        %Credential{}
+        |> Credential.changeset(%{
+          user_id: ctx.user.id,
+          network_id: ctx.network.id,
+          nick: "vjt",
+          auth_method: :server_pass,
+          password: "ns-secret",
+          server_pass: "gate-secret"
+        })
+        |> Repo.insert()
+
+      run_migration!()
+
+      reloaded = Repo.get!(Credential, cred.id)
+
+      assert Credential.upstream_server_pass(reloaded) == "gate-secret"
+      assert Credential.upstream_password(reloaded) == "ns-secret"
+    end
+
+    # A visitor's `auth_method` is DERIVED from the presence of its one secret
+    # and never reaches `:server_pass`, so no visitor row is in scope. The
+    # `user_id IS NOT NULL` conjunct is the belt: if a future write path ever
+    # produced such a row, moving its secret would silently un-identify the
+    # visitor.
+    test "a visitor row is out of scope", ctx do
+      visitor = visitor_fixture(nick: "guest1", network_slug: ctx.network.slug)
+
+      {:ok, _} =
+        Grappa.Networks.Credentials.commit_visitor_password(
+          visitor.id,
+          ctx.network.id,
+          "ns-secret"
+        )
+
+      run_migration!()
+
+      {:ok, cred} = Grappa.Networks.Credentials.get_visitor_credential(visitor.id, ctx.network.id)
+
+      {slot, _} = secrets(cred.id)
+
+      assert is_nil(slot)
+      assert Credential.recover_secret(cred) == "ns-secret"
+    end
+  end
+
+  defp load_migration! do
+    Code.require_file(migration_file!())
+    Grappa.Repo.Migrations.MoveLegacyServerPassToItsOwnSlot
+  end
+
+  defp migration_file! do
+    [path] = File.cwd!() |> Path.join(@migration_glob) |> Path.wildcard()
+    path
+  end
+
+  defp migration_version! do
+    migration_file!()
+    |> Path.basename()
+    |> String.split("_", parts: 2)
+    |> hd()
+    |> String.to_integer()
+  end
+end

--- a/test/grappa/networks/credential_test.exs
+++ b/test/grappa/networks/credential_test.exs
@@ -159,9 +159,14 @@ defmodule Grappa.Networks.CredentialTest do
              })
     end
 
-    test "false for :server_pass with only an upstream password (spent on PASS, not NickServ)" do
+    # INVERTED by #1044, and the inversion is the feature. While one slot held
+    # both roles, a `:server_pass` row's password WAS spent on the PASS line,
+    # so it could not also be a NickServ secret. Now the gate secret has its
+    # own column and this one means NickServ here like it does everywhere
+    # else — so such a credential IS recoverable.
+    test "true for :server_pass — its password is the NickServ secret since #1044" do
       cred = %Credential{auth_method: :server_pass, password_encrypted: "shibboleth"}
-      refute Credential.has_nickserv_secret?(cred)
+      assert Credential.has_nickserv_secret?(cred)
     end
 
     test "#1044 — the server-PASS slot does not grant the gate" do
@@ -190,8 +195,18 @@ defmodule Grappa.Networks.CredentialTest do
       assert Credential.recover_secret(%Credential{auth_method: :none}) == nil
     end
 
-    test "nil for :server_pass with only an upstream password (spent on PASS, not NickServ)" do
+    # INVERTED by #1044 — see the sibling in `has_nickserv_secret?/1` above.
+    # The method set widened; the SOURCE did not, which is what keeps #124's
+    # property intact and is pinned by the two tests below.
+    test "returns the :server_pass upstream password — NickServ's since #1044" do
       cred = %Credential{auth_method: :server_pass, password_encrypted: "shibboleth"}
+      assert Credential.recover_secret(cred) == "shibboleth"
+    end
+
+    # SASL is the method that must NOT join the set: it spends `:password` on
+    # the SASL payload, so that column is not a NickServ secret there.
+    test "nil for :sasl — its password is spent on the SASL payload" do
+      cred = %Credential{auth_method: :sasl, password_encrypted: "shibboleth"}
       assert Credential.recover_secret(cred) == nil
     end
 

--- a/test/grappa/networks/server_pass_slot_test.exs
+++ b/test/grappa/networks/server_pass_slot_test.exs
@@ -24,9 +24,9 @@ defmodule Grappa.Networks.ServerPassSlotTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.Networks.{Credential, Credentials}
+  alias Grappa.Networks.{Credential, Credentials, SessionPlan}
   alias Grappa.Repo
-  alias Grappa.Visitors.SessionPlan
+  alias Grappa.Visitors.SessionPlan, as: VisitorSessionPlan
 
   defp uniq, do: System.unique_integer([:positive])
 
@@ -45,6 +45,11 @@ defmodule Grappa.Networks.ServerPassSlotTest do
   end
 
   defp reload(%Credential{id: id}), do: Repo.get!(Credential, id)
+
+  defp reload_by_ids(user_id, network_id) do
+    {:ok, cred} = Credentials.get_credential_by_ids(user_id, network_id)
+    cred
+  end
 
   describe "the user branch owns the slot" do
     test "a server_pass on the wide changeset lands in the column, encrypted at rest" do
@@ -117,6 +122,60 @@ defmodule Grappa.Networks.ServerPassSlotTest do
     end
   end
 
+  describe "the read side — accessor and plan" do
+    test "upstream_server_pass/1 returns the post-Cloak-load plaintext" do
+      user = user_fixture(name: "vjt-#{uniq()}")
+      net = network()
+
+      {:ok, cred} =
+        Credentials.bind_credential(user, net, %{
+          nick: "vjt",
+          auth_method: :server_pass,
+          server_pass: "hunter2"
+        })
+
+      assert Credential.upstream_server_pass(reload(cred)) == "hunter2"
+    end
+
+    test "upstream_server_pass/1 is nil when the slot was never written" do
+      user = user_fixture(name: "vjt-#{uniq()}")
+      net = network()
+
+      {:ok, cred} =
+        Credentials.bind_credential(user, net, %{
+          nick: "vjt",
+          auth_method: :nickserv_identify,
+          password: "ns-secret"
+        })
+
+      assert is_nil(Credential.upstream_server_pass(reload(cred)))
+    end
+
+    # The middle link, and the one nothing else watches: the accessor test
+    # proves the column round-trips and the AuthFSM test proves the PASS line
+    # reads the slot, but only this proves the value TRAVELS from the row the
+    # operator configured to the plan the session is built from. A plan that
+    # dropped it would leave both neighbours green while every gated network
+    # failed its handshake.
+    test "the plan carries BOTH secrets, each in its own key" do
+      user = user_fixture(name: "vjt-#{uniq()}")
+      net = network()
+
+      {:ok, _} =
+        Credentials.bind_credential(user, net, %{
+          nick: "vjt",
+          auth_method: :server_pass,
+          password: "ns-secret",
+          server_pass: "gate-secret"
+        })
+
+      {:ok, plan} = SessionPlan.resolve(reload_by_ids(user.id, net.id))
+
+      assert plan.server_pass == "gate-secret"
+      assert plan.password == "ns-secret"
+    end
+  end
+
   describe "the visitor branch is untouched (#1044's explicit constraint)" do
     setup do
       net = network()
@@ -180,7 +239,7 @@ defmodule Grappa.Networks.ServerPassSlotTest do
           server_pass: "hunter2"
         })
 
-      {:ok, plan} = SessionPlan.resolve(visitor, net)
+      {:ok, plan} = VisitorSessionPlan.resolve(visitor, net)
 
       # The plan is what the session is actually built from: a visitor's
       # auth_method is DERIVED from the one secret, and #1044 must not shift it.

--- a/test/grappa/networks/server_pass_slot_test.exs
+++ b/test/grappa/networks/server_pass_slot_test.exs
@@ -229,6 +229,18 @@ defmodule Grappa.Networks.ServerPassSlotTest do
       assert Credential.recover_secret(stored) == "ns-secret"
     end
 
+    # The narrow write door (#1044's REST endpoint) has to carry the guard
+    # itself. Inheriting it from the wide changeset is not a thing a changeset
+    # can do, and this is precisely the surface an HTTP client reaches.
+    test "the NARROW server_pass changeset refuses a visitor too", %{net: net, visitor: visitor} do
+      {:ok, cred} = Credentials.get_visitor_credential(visitor.id, net.id)
+
+      {:error, changeset} = Credentials.update_server_pass(cred, %{"server_pass" => "hunter2"})
+
+      assert %{server_pass: ["is only valid on a user credential"]} = errors_on(changeset)
+      assert is_nil(raw_slot(cred))
+    end
+
     test "the session plan still identifies with the NickServ secret", %{
       net: net,
       visitor: visitor

--- a/test/grappa/networks/wire_test.exs
+++ b/test/grappa/networks/wire_test.exs
@@ -367,6 +367,9 @@ defmodule Grappa.Networks.WireTest do
         Credentials.bind_credential(user, network, %{
           nick: "vjt",
           auth_method: :server_pass,
+          # #1044 — the row carries both secrets, which makes the accessor
+          # claim sharper: it reads ITS column and not the neighbouring one.
+          server_pass: "gate-secret",
           password: "shibboleth"
         })
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -339,13 +339,16 @@ defmodule Grappa.Session.ServerTest do
         credential_fixture(user, network, %{
           nick: "vjt-grappa",
           auth_method: :server_pass,
-          password: "loadbearing-secret",
+          # #1044 — the PASS token comes from the dedicated slot, so THAT is
+          # the value whose arrival proves DB-driven init threaded a
+          # Cloak-decrypted secret all the way to the socket.
+          server_pass: "loadbearing-secret",
           autojoin_channels: ["#sniffo"]
         })
 
       pid = start_session_for(user, network)
 
-      # PASS line proves the credential password reached IRC.Client
+      # PASS line proves the credential secret reached IRC.Client
       # decrypted by Cloak — without DB-driven init this would be `nil`.
       assert {:ok, "PASS loadbearing-secret\r\n"} =
                IRCServer.wait_for_line(server, &String.starts_with?(&1, "PASS"), 1_000)
@@ -1988,22 +1991,68 @@ defmodule Grappa.Session.ServerTest do
       updated
     end
 
-    test "a :server_pass credential does NOT identify — the second secret is gone" do
+    # GH #1044 INVERTS the pre-existing claim here, deliberately, and this is
+    # the test the whole issue was filed for. A self-hoster on a
+    # password-gated network needs the gate PASS *and* a NickServ identify;
+    # before #1044 one credential could hold only one secret, so the second
+    # had to go into the perform list in CLEARTEXT. Now both are on the row,
+    # each in its own column, and both reach the wire in one connect.
+    #
+    # What did NOT change is #124's property, and the sibling test below is
+    # where it still lives: `server_pass_encrypted` is never a NickServ
+    # source. The identify below comes from `password_encrypted` — the same
+    # single source it comes from on every other method.
+    test "a :server_pass credential sends the gate PASS *and* identifies (#1044)" do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
           nick: "grappa-test",
           auth_method: :server_pass,
-          password: "server-pw",
+          password: "ns-secret",
+          server_pass: "gate-secret",
           autojoin_channels: []
         })
 
-      # Pre-#124 this exact row identified from the dedicated field. The
-      # password is spent on PASS and the second slot is NOT a NickServ source
-      # (#1044 gave it a different role), so nothing may reach NickServ.
-      cred = seed_server_pass_slot(credential, "ns-secret")
-      pid = nickserv_plan(user, network, cred, 60_000)
+      pid = nickserv_plan(user, network, credential, 60_000)
+
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      # The gate secret, on the front door, before registration.
+      assert "PASS gate-secret\r\n" in IRCServer.sent_lines(server)
+
+      IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :IDENTIFY ns-secret\r\n"),
+          1_000
+        )
+
+      # Neither secret may appear where the other belongs.
+      refute "PASS ns-secret\r\n" in IRCServer.sent_lines(server)
+      refute "PRIVMSG NickServ :IDENTIFY gate-secret\r\n" in IRCServer.sent_lines(server)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The #124 property, restated against the NEW column and still holding:
+    # a value in `server_pass_encrypted` is not a NickServ source. Without a
+    # `password_encrypted` there is simply nothing to identify with, and the
+    # gate secret must not be pressed into that role.
+    test "the server-PASS slot is never a NickServ source (#124's property, kept)" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+
+      {user, network, credential} =
+        setup_user_and_network(port, %{
+          nick: "grappa-test",
+          auth_method: :server_pass,
+          server_pass: "gate-secret",
+          autojoin_channels: []
+        })
+
+      pid = nickserv_plan(user, network, credential, 60_000)
 
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
@@ -2062,7 +2111,7 @@ defmodule Grappa.Session.ServerTest do
         setup_user_and_network(port, %{
           nick: "grappa-test",
           auth_method: :server_pass,
-          password: "server-pw",
+          server_pass: "gate-secret",
           autojoin_channels: []
         })
 
@@ -2134,26 +2183,75 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test "autojoin fires immediately for :server_pass carrying only the server-PASS slot" do
+    # The #347 defer pair, and since #1044 the two halves are told apart by the
+    # SECRET, not by the method — which is the whole reason
+    # `identify_expected?/1` stopped reading `auth_method`. A LONG (60s)
+    # fallback is load-bearing in BOTH: with the production ~0.5s default a
+    # wrongful defer would still fire inside the 1s assertion window and the
+    # "fires immediately" half would pass either way.
+    # GH #1044 — the two halves of the NickServ-secret gate live in different
+    # boundaries and cannot call each other (Networks deps Session; the
+    # reverse closes a cycle), so `pending_password_from_opts/1` restates the
+    # list `Credential.nickserv_secret_methods/0` owns. This is the test that
+    # keeps the restatement honest: it DRIVES the exported list, so adding a
+    # method there without teaching the session about it goes red here rather
+    # than silently leaving that method unable to identify.
+    #
+    # `pending_password` is read before 001, which is the only window it
+    # exists in — `run_perform_and_identify/1` clears it one-shot.
+    for method <- Grappa.Networks.Credential.auth_methods() do
+      staged? = method in Grappa.Networks.Credential.nickserv_secret_methods()
+
+      test "#{inspect(method)} stages a pending_password: #{staged?}" do
+        method = unquote(method)
+        {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+
+        {user, network, credential} =
+          setup_user_and_network(port, Map.put(secret_attrs(method), :nick, "grappa-test"))
+
+        pid = nickserv_plan(user, network, credential, 60_000)
+        :ok = IRCServer.await_handshake(server, 1_000)
+
+        assert is_binary(:sys.get_state(pid).pending_password) ==
+                 unquote(staged?),
+               "#{inspect(method)} disagrees with Credential.nickserv_secret_methods/0"
+
+        :ok = GenServer.stop(pid, :normal, 1_000)
+      end
+    end
+
+    # A credential of each method, carrying every secret that method needs to
+    # be valid PLUS a `password` wherever the column is free to hold one.
+    defp secret_attrs(:none), do: %{auth_method: :none, autojoin_channels: []}
+
+    defp secret_attrs(:server_pass) do
+      %{
+        auth_method: :server_pass,
+        server_pass: "gate-secret",
+        password: "ns-secret",
+        autojoin_channels: []
+      }
+    end
+
+    defp secret_attrs(method) do
+      %{auth_method: method, password: "ns-secret", autojoin_channels: []}
+    end
+
+    test ":server_pass with ONLY the gate secret fires autojoin immediately on 001" do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
           nick: "grappa-test",
           auth_method: :server_pass,
-          password: "server-pw",
+          server_pass: "gate-secret",
           autojoin_channels: ["#sniffo"]
         })
 
-      # #509 made this row DEFER behind the +r gate, because it expected an
-      # identify. #124 narrowed `identify_expected?/1` back to `auth_method`
-      # alone, so no identify is coming and waiting for a `+r` that will never
-      # arrive would strand the JOIN for the full fallback window. The 60s
-      # fallback below is load-bearing: with the production ~0.5s default a
-      # wrongful defer would still fire inside the 1s window and this test
-      # would pass either way.
-      cred = seed_server_pass_slot(credential, "ns-secret")
-      pid = nickserv_plan(user, network, cred, 60_000)
+      # This is the common gate-only credential, and the #509 KNOWN EDGE in
+      # person: widening the defer to the METHOD would make every one of these
+      # wait out the fallback window for a `+r` that is never coming.
+      pid = nickserv_plan(user, network, credential, 60_000)
 
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
@@ -2164,27 +2262,37 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test ":server_pass with NO nickserv secret still fires autojoin immediately on 001 (unregressed)" do
+    test ":server_pass WITH a NickServ secret defers autojoin until +r (#347, via #1044)" do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
 
       {user, network, credential} =
         setup_user_and_network(port, %{
           nick: "grappa-test",
           auth_method: :server_pass,
-          password: "server-pw",
+          server_pass: "gate-secret",
+          password: "ns-secret",
           autojoin_channels: ["#sniffo"]
         })
 
-      # A LONG (60s) fallback is load-bearing: it proves the JOIN fired on 001
-      # itself, not on the deferred-autojoin fallback timer. With the production
-      # ~0.5s default a wrongful defer would still fire inside the 1s assertion
-      # window and this "fires immediately" test would pass either way (mirror).
+      # Such a row identifies now, so #347's reason to wait applies to it for
+      # the first time: JOINing on 001 races the identify and a `+R` channel
+      # answers 477.
       pid = nickserv_plan(user, network, credential, 60_000)
 
       :ok = IRCServer.await_handshake(server, 1_000)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
-      # No identify expected → no defer; the JOIN lands on 001 as before #509.
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :IDENTIFY ns-secret\r\n"),
+          1_000
+        )
+
+      refute Enum.any?(IRCServer.sent_lines(server), &String.starts_with?(&1, "JOIN"))
+
+      IRCServer.feed(server, ":irc.test.org MODE grappa-test :+r\r\n")
+
       assert {:ok, "JOIN #sniffo\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "JOIN #sniffo\r\n"), 1_000)
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -44,7 +44,7 @@ defmodule Grappa.Session.ServerTest do
     WSPresence
   }
 
-  alias Grappa.Networks.{Credentials, SessionPlan}
+  alias Grappa.Networks.{Credential, Credentials, SessionPlan}
 
   alias Grappa.Session.{
     AwayState,
@@ -1808,7 +1808,7 @@ defmodule Grappa.Session.ServerTest do
     defp put_perform_list(credential, text) do
       {:ok, updated} =
         credential
-        |> Grappa.Networks.Credential.perform_changeset(%{perform_list: text})
+        |> Credential.perform_changeset(%{perform_list: text})
         |> Repo.update()
 
       updated
@@ -1985,7 +1985,7 @@ defmodule Grappa.Session.ServerTest do
     defp seed_server_pass_slot(credential, pass) do
       {:ok, updated} =
         credential
-        |> Grappa.Networks.Credential.changeset(%{server_pass: pass})
+        |> Credential.changeset(%{server_pass: pass})
         |> Repo.update()
 
       updated
@@ -2199,8 +2199,8 @@ defmodule Grappa.Session.ServerTest do
     #
     # `pending_password` is read before 001, which is the only window it
     # exists in — `run_perform_and_identify/1` clears it one-shot.
-    for method <- Grappa.Networks.Credential.auth_methods() do
-      staged? = method in Grappa.Networks.Credential.nickserv_secret_methods()
+    for method <- Credential.auth_methods() do
+      staged? = method in Credential.nickserv_secret_methods()
 
       test "#{inspect(method)} stages a pending_password: #{staged?}" do
         method = unquote(method)

--- a/test/grappa_web/controllers/networks_controller_test.exs
+++ b/test/grappa_web/controllers/networks_controller_test.exs
@@ -1116,6 +1116,112 @@ defmodule GrappaWeb.NetworksControllerTest do
     end
   end
 
+  describe "GET + PUT /networks/:network_id/server_pass (#1044)" do
+    defp server_pass_setup(attrs) do
+      vjt = user_fixture(name: "vjt-sp-#{u()}")
+      session = session_fixture(vjt)
+      slug = "net-sp-#{u()}"
+      {network, _} = network_with_server(port: 9_999, slug: slug)
+
+      cred =
+        credential_fixture(
+          vjt,
+          network,
+          Map.merge(%{nick: "vjt-irc", password: "fixture-pw"}, attrs)
+        )
+
+      {vjt, session, network, slug, cred}
+    end
+
+    defp server_pass_conn(conn, session) do
+      conn
+      |> put_bearer(session.id)
+      |> put_req_header("content-type", "application/json")
+    end
+
+    test "GET reports the slot as unset by default", %{conn: conn} do
+      {_, session, _, slug, _} = server_pass_setup(%{auth_method: :nickserv_identify})
+
+      body =
+        conn
+        |> server_pass_conn(session)
+        |> get("/networks/#{slug}/server_pass")
+        |> json_response(200)
+
+      assert body["server_pass_set"] == false
+    end
+
+    test "PUT stores the secret and reports it set, never echoing the value", %{conn: conn} do
+      {vjt, session, network, slug, _} = server_pass_setup(%{auth_method: :nickserv_identify})
+
+      body =
+        conn
+        |> server_pass_conn(session)
+        |> put("/networks/#{slug}/server_pass", %{server_pass: "gate-secret"})
+        |> json_response(200)
+
+      # Write-only end to end: the set-ness travels, the secret never does.
+      assert body["server_pass_set"] == true
+      refute Map.has_key?(body, "server_pass")
+      refute inspect(body) =~ "gate-secret"
+
+      {:ok, reloaded} = Credentials.get_credential(vjt, network)
+      assert Credential.upstream_server_pass(reloaded) == "gate-secret"
+    end
+
+    # The door exists so the gate secret has somewhere to go OTHER than the
+    # NickServ column — so the neighbouring secret must come out untouched.
+    test "PUT leaves the NickServ secret alone", %{conn: conn} do
+      {vjt, session, network, slug, _} =
+        server_pass_setup(%{auth_method: :nickserv_identify, password: "ns-secret"})
+
+      assert conn
+             |> server_pass_conn(session)
+             |> put("/networks/#{slug}/server_pass", %{server_pass: "gate-secret"})
+             |> json_response(200)
+
+      {:ok, reloaded} = Credentials.get_credential(vjt, network)
+      assert Credential.upstream_password(reloaded) == "ns-secret"
+      assert reloaded.auth_method == :nickserv_identify
+    end
+
+    test "an empty string CLEARS the slot", %{conn: conn} do
+      {vjt, session, network, slug, _} =
+        server_pass_setup(%{auth_method: :server_pass, server_pass: "gate-secret"})
+
+      body =
+        conn
+        |> server_pass_conn(session)
+        |> put("/networks/#{slug}/server_pass", %{server_pass: ""})
+        |> json_response(200)
+
+      assert body["server_pass_set"] == false
+
+      {:ok, reloaded} = Credentials.get_credential(vjt, network)
+      assert is_nil(Credential.upstream_server_pass(reloaded))
+    end
+
+    # S30: the value is re-interpolated into the single PASS wire token, so a
+    # space would truncate it server-side and a newline would inject a command.
+    test "a CRLF secret is a 422", %{conn: conn} do
+      {_, session, _, slug, _} = server_pass_setup(%{auth_method: :nickserv_identify})
+
+      assert conn
+             |> server_pass_conn(session)
+             |> put("/networks/#{slug}/server_pass", %{server_pass: "a\r\nJOIN #evil"})
+             |> json_response(422)
+    end
+
+    test "requires a Bearer", %{conn: conn} do
+      {_, _, _, slug, _} = server_pass_setup(%{auth_method: :nickserv_identify})
+
+      assert conn
+             |> put_req_header("content-type", "application/json")
+             |> put("/networks/#{slug}/server_pass", %{server_pass: "gate-secret"})
+             |> json_response(401)
+    end
+  end
+
   describe "GET + PUT /networks/:network_id/perform (#189)" do
     test "GET returns the perform list + oper_pass_set (empty by default)", %{conn: conn} do
       vjt = user_fixture(name: "vjt-perf-#{u()}")

--- a/test/grappa_web/controllers/networks_controller_test.exs
+++ b/test/grappa_web/controllers/networks_controller_test.exs
@@ -1036,18 +1036,27 @@ defmodule GrappaWeb.NetworksControllerTest do
       assert Credential.recover_secret(reloaded) == "newsecret"
     end
 
-    test ":server_pass keeps its method — the password is spent on PASS", %{conn: conn} do
-      # The field edits THE secret for the network, whatever the method spends
-      # it on. Promoting here would silently redirect a server password to
-      # NickServ and break a working handshake.
+    test ":server_pass keeps its method, and the field edits the NickServ secret", %{conn: conn} do
+      # The field edits the secret this column holds, and #1044 settled what
+      # that is on a `:server_pass` row: the NickServ one, because the gate
+      # secret moved to its own slot. Promoting the METHOD here would still be
+      # wrong (it would change what the handshake does), which is the half
+      # this test has always guarded — what changed is that the edited value
+      # no longer goes on the PASS line, so the gate secret must come out
+      # untouched.
       {vjt, session, network, slug, _} =
-        password_setup(%{auth_method: :server_pass, password: "old-server-pw"})
+        password_setup(%{
+          auth_method: :server_pass,
+          password: "old-ns-pw",
+          server_pass: "gate-secret"
+        })
 
-      assert json_response(put_password(conn, session, slug, %{password: "new-server-pw"}), 200)
+      assert json_response(put_password(conn, session, slug, %{password: "new-ns-pw"}), 200)
 
       {:ok, reloaded} = Credentials.get_credential(vjt, network)
       assert reloaded.auth_method == :server_pass
-      assert Credential.upstream_password(reloaded) == "new-server-pw"
+      assert Credential.upstream_password(reloaded) == "new-ns-pw"
+      assert Credential.upstream_server_pass(reloaded) == "gate-secret"
     end
 
     test "a blank or missing password is a 400, never a silent clear", %{conn: conn} do

--- a/test/mix/tasks/grappa/repair_passwords_test.exs
+++ b/test/mix/tasks/grappa/repair_passwords_test.exs
@@ -35,13 +35,19 @@ defmodule Mix.Tasks.Grappa.RepairPasswordsTest do
 
   defp bind(user, network, password, auth_method) do
     {:ok, credential} =
-      Credentials.bind_credential(user, network, %{
-        nick: "vjt",
-        password: password,
-        auth_method: auth_method
-      })
+      Credentials.bind_credential(user, network, attrs(password, auth_method))
 
     credential
+  end
+
+  # #1044 — a `:server_pass` row needs its OWN slot filled to be valid; its
+  # `password` is the NickServ secret, which is the value under test here.
+  defp attrs(password, :server_pass) do
+    %{nick: "vjt", password: password, auth_method: :server_pass, server_pass: "gate-secret"}
+  end
+
+  defp attrs(password, auth_method) do
+    %{nick: "vjt", password: password, auth_method: auth_method}
   end
 
   defp reload(%Credential{id: id}), do: Repo.get!(Credential, id)
@@ -92,10 +98,31 @@ defmodule Mix.Tasks.Grappa.RepairPasswordsTest do
       assert RepairPasswords.classify(credential) == {:report, :ambiguous_auth_method}
     end
 
-    test "a :server_pass credential with spaces is reported", %{user: user, network: network} do
+    # #1044 moved this row INTO scope, and the reason is the whole slice: on a
+    # `:server_pass` credential the gate secret now lives in its own column, so
+    # `password_encrypted` means NickServ here exactly as it does on
+    # `:nickserv_identify` — and can be corrupted by the same in-session
+    # rotation. Three tokens is still ambiguous, but ambiguous about WHICH
+    # rotation, not about whose secret it is.
+    test "a :server_pass credential's NickServ secret is judged by the NickServ chain", %{
+      user: user,
+      network: network
+    } do
       credential = bind(user, network, @sasl_passphrase, :server_pass)
 
-      assert RepairPasswords.classify(credential) == {:report, :ambiguous_auth_method}
+      assert RepairPasswords.classify(credential) == {:report, :multiple_rotations}
+    end
+
+    # The discriminating half: a single rotation on such a row is REPAIRABLE.
+    # Pre-#1044 it was dismissed as `:ambiguous_auth_method`, which is what
+    # the task must no longer say now that the column's meaning is settled.
+    test "a single rotation on a :server_pass credential is repairable", %{
+      user: user,
+      network: network
+    } do
+      credential = bind(user, network, "oldpass newpass", :server_pass)
+
+      assert RepairPasswords.classify(credential) == {:repairable, "newpass"}
     end
 
     test "a :none credential with spaces is reported", %{user: user, network: network} do


### PR DESCRIPTION
This is the work for issue 1044 ("one secret slot, several roles: server
PASS vs NickServ"). No closing keyword here on purpose — the issue stays
open and the orchestrator owns its lifecycle.

## The problem

`network_credentials.password_encrypted` served two unrelated roles at once:
the on-connect server `PASS` (a gate token, often a hostmask/vhost key) and
the NickServ secret. A self-hoster who binds a network with
`--auth server_pass` therefore has no place left to put the NickServ
password — the two roles collide in one column.

## What this does

**One column per role.** `server_pass_encrypted` joins
`password_encrypted`; the former is the gate token, the latter stays the
NickServ/SASL secret. `Credential.upstream_server_pass/1` reads the new slot
with **no fallback** onto the password column — a fallback would be exactly
the split-brain of issue 124.

**Read path**, by name: `SessionPlan.base_plan` sets `server_pass:`,
`Session.Server.client_opts` forwards it, `AuthFSM` gains the
`:server_pass` opt, and `maybe_send_pass` grows two arms — `:server_pass`
reads the new slot, while `:auto` deliberately keeps reading `:password`
because there the `PASS` is the services handoff, a different role and not
an oversight.

**Identify path**: `pending_password_from_opts/1` and
`Credential.recover_secret/1` widen the set of *methods* (not the source)
via `Credential.nickserv_secret_methods/0`, exported as data.
`identify_expected?/1` no longer reads `auth_method`; it reads a new state
field `nickserv_secret_staged?` derived at init, because reading the method
there would reintroduce the known edge of issue 509. The two twin lists are
pinned by a data-driven test in `server_test.exs` — falsified for real
(adding `:sasl` to one list turns it red with
`":sasl disagrees with ..."`, then reverted).

**Write doors.** `PUT`/`GET /networks/:network_id/server_pass` (write-only;
the read returns only `server_pass_set`), `Credentials.update_server_pass/2`
with a narrow `Credential.server_pass_changeset/2` (`""` clears to `NULL`,
and the user-only guard is repeated on the narrow changeset), plus
`--server-pass` on `mix grappa.bind_network`, `release/cli.ex`
(`add-network`), `mix grappa.update_network_credential`, and the inline help
of `bin/grappa` (two parity gates check that help).

**Validation tightened**: the column was checked with `safe_line_token`
(CR/LF/NUL); it now uses `Identity.safe_oper_token/2`, which also rejects
spaces, on *both* changesets. The AuthFSM applies S30 on the wire, and a
write door that accepts what the reader will reject is the silent-swallow
the boundary rule forbids.

`mix grappa.repair_passwords` was aligned to the same method list —
otherwise two definitions drift and the task reports "clean" on a genuinely
corrupt `:server_pass` credential.

## Data migration

`priv/repo/migrations/20260831235021_move_legacy_server_pass_to_its_own_slot.exs`
(generated with `mix ecto.gen.migration`, never a hand-typed stamp) moves the
legacy `PASS` from `password_encrypted` to `server_pass_encrypted` under a
four-conjunct predicate: `auth_method = 'server_pass' AND user_id IS NOT
NULL AND server_pass_encrypted IS NULL AND password_encrypted IS NOT NULL`.
The third conjunct is also what makes it idempotent. Six tests cover moves,
decryption, idempotence, and the three rows it must not touch
(`nickserv_identify`, an already-correct row, visitors).

The migration rests on a measured property: a Cloak ciphertext (AES.GCM,
`AES.GCM.V1`) is copyable **raw** between two `EncryptedBinary` columns.
Measured in a scratch test with a positive control (same-column round trip),
the measurement itself (raw SQL copy, re-read through the schema), and a
negative control (last byte XOR `0x01` fails to decrypt — and loads as the
atom `:error` rather than raising, a side fact worth knowing). The scratch
test was deleted; the property is now pinned durably by the migration test,
which re-reads the moved value *through the schema* rather than comparing
blobs — a blob comparison would be green on undecryptable garbage too.

Companion fix: `validate_password_for_auth_method/1` in `credential.ex` now
picks *which* secret to require from the method (`server_pass` requires
`:server_pass`, everything else `:password`) via `validate_secret_present/3`.
Without it, after the migration a plain nick rename on a gate-only row was
rejected.

## Deploy classification: COLD

The slice carries a migration under `priv/repo/migrations`, which makes it
cold by construction. The substantive reason is stronger than the mechanical
criterion: the migration **empties `password_encrypted`** on `:server_pass`
rows, and the pre-cutover code reads the `PASS` from exactly there. A node
still serving the old code after the migration has run sends no `PASS` at
all and gets its handshake refused. It must be stopped first, not hot
reloaded.

## Declared: the protocol_version bump 9 -> 10

Commit `e6363d18c` bumps `@protocol_version` and is deliberately isolated so
it can be reverted on its own. **The gate did not ask for it.** The wire pin
digest is byte-identical before and after (`sha256:9c97bd9b...`), because it
covers only the artefacts generated from the `Grappa.*.Wire` typespecs, and a
new REST route renders its shape in a controller — so the pin is blind there
by construction. The bump applies reason (1) of the 2026-08-21 ruling: the
number is only worth comparing against if it is total, and one un-bumped
addition makes "server >= N has everything N had" false forever after.
`@min_protocol_version` stays at 1 — the other axis did not move.

This reading was raised explicitly and **ratified by the orchestrator**; it
is recorded here so that contesting it costs one line of review rather than
an archaeology session.

## Gates

Run from the worktree, exit codes read directly (never from a task
notification):

- `scripts/check.sh` -> rc=0 — credo: 6648 mods/funs, no issues; suite: 8
  doctests, 62 properties, 7047 tests, 0 failures; dialyzer: 0 errors; wire
  pin: "wire shape and protocol 10 agree."
- `scripts/design-notes-gate.sh` -> rc=0 — "1 new entry heading(s),
  separator and marker present."
- `scripts/union-rebase.sh` -> rc=0 — the branch was already on top of
  `origin/main`, so the tool reports the comparison as vacuous by
  construction rather than as a pass; `docs/DESIGN_NOTES.md` came through
  `+110 -0`, identical to the pre-pin.

**Not run, and not claimed:** `scripts/integration.sh`, the e2e suite, and
the cic-only gates. The lane for those was not granted.

Two earlier `check.sh` rounds were red on two *different* tests this branch
never touches (`JoinSeedCostTest` query count; `LockWatchTest` hitting
`ExUnit.TimeoutError` at 60s on a genuine lock contention). Both green in
isolation, full suite green three times since: the disjunction between rounds
makes them load flakes, not regressions.

## Three false claims found in main along the way

1. "never read and never written" in `mix grappa.repair_passwords` is half
   false — the slot has been *written* by the wide changeset since commit
   `36a8dba0c`. It was dead in **reads** only.
2. The issue text understated the state of play: the context-level write door
   (`bind_credential`) already existed end to end. What was missing was REST
   and CLI.
3. `password_set` **does not exist and never has.** Three comments in `lib/`
   cited it as a field of the credential wire shape, while
   `networks_controller_test` asserts the opposite
   (`refute Map.has_key?(body, "password_set")`). A defect of main, not of
   this issue; the three comments are corrected here.
