### PR TITLE
observability(1888): bracket the stall the watchdog never announced

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44684,3 +44684,115 @@ rule, so a gate secret with a space saved 200 and then refused every
 connect — the ircd keeps the first token and answers 464 with nothing in
 the log. A write door that accepts what the reader will reject is the
 silent-swallow the boundary rule forbids.
+<!-- entry #1888 -->
+
+---
+
+## 2026-09-01 — #1888: the closing bracket speaks when the opening line never did
+
+Prod froze for 31 s on 2026-09-01 (jail `grappa-new`, release
+`1.4.1-997711ac`): no request served, on any network, then everything
+resumed at once. The issue asks first for the write-lock HOLDER to be
+logged, "because today the warning says how long we waited but not who was
+writing."
+
+### The premise was incomplete, measured
+
+`Grappa.Repo.LockWatch` is ARMED in prod — `config/config.exs` declares
+`enabled: true, stall_threshold_ms: 2_000, tick_ms: 1_000` and neither
+`prod.exs` nor `runtime.exs` overrides it. It already derives the holder's
+identity (`sample/2`: pid, `current_function`, `status`,
+`message_queue_len`, `initial_call`, 12 frames) and already reports a queue
+that names nobody (#1687's `report_unattributed/2`). Both of those shipped
+INSIDE the running release — `cf5a612f2` (2026-08-23) and `c048d2bff`
+(2026-08-24) are ancestors of `997711ac` (2026-08-27), tested with
+`git merge-base --is-ancestor`.
+
+So the instrument was not missing. It was silent, and its silence was
+indistinguishable from a healthy system.
+
+### What actually had no door
+
+`close_episode/1` matched `reported?: true` and nothing else. An episode
+the watchdog never announced therefore closed with **no log line, no
+telemetry and no ring row** — the instrument's silence meant both "nothing
+happened" and "something happened and I could not say so". That ambiguity
+is what this entry removes, and the bracket is where it is cheapest to
+remove: by then the lock is RELEASED, so nothing on that path can be
+blocked by the stall it describes — which is exactly the trap the detection
+path lives in (#1715).
+
+Three changes, all on the closing bracket:
+
+1. **It fires for any hold past `stall_threshold_ms`**, announced or not,
+   and the line SAYS which. An announced episode has an opening line above
+   it carrying the holder's sampled stack; an unannounced one is the only
+   record that episode left, and an operator needs to know which they hold.
+2. **It carries a `t:caller/0`, NOT a `t:sample/0`.** A sample is taken
+   while the holder is parked, so `current_function` names the frame it
+   paused IN; by release there is no pause site left. What survives is the
+   write PATH — which caller opened the transaction — read from the
+   releasing process's own state (`$initial_call` plus its own stack, no
+   signal, no suspend). Folding the two shapes would let a release-time
+   frame be read as a pause site, and the renderer keeps them apart too
+   (`holder at …` vs `write path …`).
+3. **Every phase stamps `observed_at`**, at EMIT and not at fold: the fold
+   happens behind a cast in `Grappa.DbLatency`, so a stamp taken there
+   would be "when the aggregator got round to it", skewed by exactly the
+   load an incident produces. Without an instant a ring row cannot be lined
+   up against `erlang.log`, and the ring is the door that survives a log
+   that went quiet.
+
+`waiter_count` on a `:resolved` row went from `0` to `nil` in the same
+pass: a closing bracket counts no queue, and the zero asserted a
+measurement nobody took.
+
+### Costs, and the one that is new
+
+One extra `:persistent_term` READ per write-transaction release — the
+threshold, published once by `init/1`. A read and not a write on purpose:
+the WRITE is what blocks on a thread-progress barrier (#1715). Everything
+else runs only once the hold has already crossed the threshold. Absent the
+key (watchdog never booted, or mid-restart) `past_threshold?/1` answers
+false rather than guessing, which is byte-for-byte the pre-#1888 behaviour.
+
+### Two measurements worth keeping, and one hypothesis killed
+
+**`busy_timeout: 30_000` does NOT explain the four observed durations.**
+`BusyRetry.run/1` starts its clock before `op.()` and computes `elapsed_ms`
+in the `rescue`, so the printed figure is checkout + wait + propagation.
+30_000 is a LOWER bound; 31214 / 31295 / 31345 / 31397 ms leave 1.2–1.4 s
+unattributed, with a residual spread of 183 ms that is too tight for
+queueing noise. Only the weak form survives: `busy_timeout` is the dominant
+term.
+
+**#1888 has a one-term shape; #1687 had two.** LockWatch's own moduledoc
+records a prod decomposition measured 2026-08-22 — "~31 s of DBConnection
+checkout PLUS ~31 s of `busy_timeout`", the whole of that issue's 62 s.
+#1888's ~31.3 s is one `busy_timeout` plus ~1.3 s. These are two different
+shapes, not one episode and a shorter version of it.
+
+### Refused
+
+- That the UNATTRIBUTED line is absent from the jail's `erlang.log`. Only
+  the issue BODY was measured (0 hits on all three LockWatch signatures,
+  positive control 2, negative 0), and the body is a curated extract; the
+  issue's own census grepped only `write lock held by another writer`, so
+  the signature was never looked for. Absence in an extract is not absence.
+- That `prime_logger_module_cache/0` never ran on that node. It runs ONLY
+  in `init/1`, and the issue reports 41 days of uptime against a release
+  dated five days earlier — but "41 days" is an assertion in the body, not
+  a measurement of ours.
+- The mechanism behind the simultaneity at unfreeze: five
+  `db_conn_N … longer than 15000ms` disconnects plus one `Exqlite.Error
+  interrupted`, all inside a 30 ms window at 12:07:28.55, rather than at
+  15 s into the stall. That is the SHAPE of "nobody was scheduled" rather
+  than "each expired on its own", and it is recorded as an observation. Its
+  causal chain is #1715's, whose last link is inferred and never reproduced
+  on a bench.
+- Whether the write lock was held by a writer this seam cannot see. 129
+  bare `Repo.insert/update/delete/*_all` call sites live in 24 files under
+  `lib/` on `origin/main`, and an autocommit statement takes the same file
+  lock with no row here. Widening the seam to cover them is a separate
+  slice, deliberately not taken in this one: without the bracket above, it
+  would produce a row whose only door is the one under suspicion.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -5252,8 +5252,8 @@ The handler folds **three** signal families:
   against the baseline.
 - **the D1 write-path spans** into `send_privmsg` / `persist` / `contention`
   rows.
-- **`[:grappa, :repo, :lock_stall, :detected | :resolved]`** (#1420) into the
-  bounded `lock stalls` ring — the WRITE-LOCK HOLDER.
+- **`[:grappa, :repo, :lock_stall, :detected | :resolved | :unattributed]`**
+  (#1420, #1687) into the bounded `lock stalls` ring — the WRITE-LOCK HOLDER.
 
 ### Reading a write-lock stall (#1420)
 
@@ -5264,11 +5264,17 @@ its victims — the 30.1 s `busy_timeout` rows of everybody queued behind it.
 `Grappa.Repo.LockWatch` reads at the `BEGIN IMMEDIATE` seam instead, which
 separates the **holder** from the **waiters**.
 
-A stall is reported only when a holder has held past
+A **named** stall is reported only when a holder has held past
 `:lock_watch, :stall_threshold_ms` **with at least one waiter queued behind
-it** — a slow uncontended write is not a stall. Each episode appears twice: a
-`detected` row carrying the holder's sampled **stacktrace** plus the queue, and
-a `resolved` row carrying the total hold.
+it** — a slow uncontended write is not a stall. It appears twice: a `detected`
+row carrying the holder's sampled **stacktrace** plus the queue, and a
+`resolved` row carrying the total hold.
+
+An **`unattributed`** row (#1687) is a queue past the threshold that named
+nobody — every autocommit single-statement write takes the same file lock and
+registers no holder here. It carries the WAITERS' stacks and explicit nils
+where a holder would be, and gets no `resolved` bracket: there is no hold to
+total.
 
 Two doors, and for an incident they answer different questions:
 
@@ -5277,6 +5283,28 @@ Two doors, and for an incident they answer different questions:
   evidence is a log after the fact.
 - **`bin/grappa db-latency` / `GET /admin/db_latency`** — the last 20 episodes,
   newest first, for a node you can still reach.
+
+**🔴 Read the `announced` column first (#1888).** A `resolved` row with
+`announced=NO` means the watchdog never got to report that episode WHILE it
+held — so this row is the ONLY record of it anywhere, and there is no
+`detected` line above it to scroll back to. That is not hypothetical: the
+2026-09-01 prod episode froze the node for 31 s with the observer armed and
+emitted nothing of its own on either door between 12:06:57 and 12:07:28, and
+before #1888 an unannounced episode closed in total silence too.
+
+Such a row carries a **`write path`** block instead of a holder block. The two
+are deliberately different words for different facts:
+
+| block | when it is sampled | what it names |
+|-------|--------------------|---------------|
+| `holder at …` | while the holder is still parked | the frame it PAUSED in |
+| `write path …` | as the transaction is released | the caller that OPENED it |
+
+So a `write path` block answers *who was writing*, never *where it stuck* —
+do not read a release-time frame as a pause site. Every row also carries
+`at=<ISO8601>`, which is what lets a ring row be lined up against
+`erlang.log`; the ring survives a log that went quiet, and without the instant
+there is no way to match the two.
 
 **What the stack tells you.** The holder's frames are the answer to "why is it
 not proceeding": a `Logger` frame means the transaction is blocked on logging;

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -156,13 +156,35 @@ defmodule Grappa.DbLatency do
   own figure is the longest WAIT, which rides the telemetry measurements and
   is derivable from `waiters` rather than duplicated here. It gets no
   `:resolved` bracket, because there is no hold to total.
+
+  #1888 adds three fields, on the same rule — a phase that did not observe a
+  thing carries an explicit `nil` for it rather than a plausible value:
+
+    * `observed_at` — the instant the EMITTER observed the episode, on every
+      phase. Without it a ring row cannot be lined up against `erlang.log`,
+      which is the only artefact that dates a freeze, and the ring is exactly
+      the door that survives a log that went quiet.
+    * `caller` — WHO held the lock, on `:resolved` only. It is not a holder
+      `sample()` and the two must not be read as one: a sample names the
+      frame the holder PAUSED in, this names the write path that opened the
+      transaction. `holder` therefore stays `nil` on a `:resolved` row, as it
+      always has.
+    * `announced` — whether the watchdog got to report the episode WHILE it
+      held. `false` means this row is the only record of it, which is the
+      #1888 case; `nil` on the two phases where the question does not arise.
+
+  `waiter_count` is nilable for the same reason: a closing bracket counts no
+  queue, and the `0` it used to carry asserted an empty one was measured.
   """
   @type lock_stall_row :: %{
           phase: :detected | :resolved | :unattributed,
+          observed_at: String.t(),
           holder_pid: String.t() | nil,
           held_ms: non_neg_integer() | nil,
-          waiter_count: non_neg_integer(),
+          waiter_count: non_neg_integer() | nil,
           holder: map() | nil,
+          caller: map() | nil,
+          announced: boolean() | nil,
           waiters: [map()]
         }
 
@@ -291,10 +313,13 @@ defmodule Grappa.DbLatency do
   defp fold([:grappa, :repo, :lock_stall, :detected], measurements, metadata, state) do
     push_stall(state, %{
       phase: :detected,
+      observed_at: metadata.observed_at,
       holder_pid: metadata.holder.pid,
       held_ms: measurements.held_ms,
       waiter_count: measurements.waiter_count,
       holder: metadata.holder,
+      caller: nil,
+      announced: nil,
       waiters: metadata.waiters
     })
   end
@@ -307,21 +332,34 @@ defmodule Grappa.DbLatency do
   defp fold([:grappa, :repo, :lock_stall, :unattributed], measurements, metadata, state) do
     push_stall(state, %{
       phase: :unattributed,
+      observed_at: metadata.observed_at,
       holder_pid: nil,
       held_ms: nil,
       waiter_count: measurements.waiter_count,
       holder: nil,
+      caller: nil,
+      announced: nil,
       waiters: metadata.waiters
     })
   end
 
+  # #1888 — the closing bracket, which since that issue also fires for an
+  # episode the watchdog never announced. `caller` is the identity such a row
+  # carries INSTEAD of a holder sample (there is no pause site left to sample
+  # by then), and `announced: false` is the finding: this row is the only
+  # record that episode left anywhere.
   defp fold([:grappa, :repo, :lock_stall, :resolved], measurements, metadata, state) do
     push_stall(state, %{
       phase: :resolved,
+      observed_at: metadata.observed_at,
       holder_pid: metadata.holder_pid,
       held_ms: measurements.held_ms,
-      waiter_count: 0,
+      # nil, not 0: nothing in a closing bracket counted a queue, and a zero
+      # would assert an empty one was measured.
+      waiter_count: nil,
       holder: nil,
+      caller: metadata.caller,
+      announced: metadata.announced,
       waiters: []
     })
   end

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -1032,8 +1032,9 @@ defmodule Grappa.Operator do
 
     Enum.each(snapshot.lock_stalls, fn stall ->
       IO.puts(
-        "#{stall.phase}\tholder=#{lock_stall_field(stall.holder_pid)}" <>
-          "\theld_ms=#{lock_stall_field(stall.held_ms)}\twaiters=#{stall.waiter_count}"
+        "#{stall.phase}\tat=#{stall.observed_at}\tholder=#{lock_stall_field(stall.holder_pid)}" <>
+          "\theld_ms=#{lock_stall_field(stall.held_ms)}" <>
+          "\twaiters=#{waiters_column(stall.waiter_count)}#{announced_column(stall.announced)}"
       )
 
       Enum.each(lock_stall_detail_lines(stall), &IO.puts/1)
@@ -1049,6 +1050,23 @@ defmodule Grappa.Operator do
   defp lock_stall_field(nil), do: "unattributed"
   defp lock_stall_field(value), do: to_string(value)
 
+  # #1888 — a closing bracket counts no queue, and the column has to SAY that
+  # rather than print `waiters=` (reads as a formatting slip) or `waiters=0`
+  # (asserts a measurement nobody took). `lock_stall_field/1` is the wrong
+  # voice here: its `unattributed` names the #1687 finding, not an uncounted
+  # column.
+  @spec waiters_column(non_neg_integer() | nil) :: String.t()
+  defp waiters_column(nil), do: "not counted"
+  defp waiters_column(count), do: to_string(count)
+
+  # Only the closing bracket can answer this, so the column appears only
+  # there. Printing `announced=` on the two phases where the question does not
+  # arise would invite the reader to interpret a nil as a "no".
+  @spec announced_column(boolean() | nil) :: String.t()
+  defp announced_column(nil), do: ""
+  defp announced_column(true), do: "\tannounced=yes"
+  defp announced_column(false), do: "\tannounced=NO"
+
   # The two blocks are separate because the phases carry different halves.
   # A `:resolved` row has neither (the episode is over, nothing left to
   # inspect) and still renders as its header line alone — `waiters` is `[]`
@@ -1060,9 +1078,23 @@ defmodule Grappa.Operator do
   # they are what separates "blocked on the lock" from "queued for a
   # connection".
   @spec lock_stall_detail_lines(DbLatency.lock_stall_row()) :: [String.t()]
-  defp lock_stall_detail_lines(%{holder: holder, waiters: waiters}) do
+  defp lock_stall_detail_lines(%{holder: holder, caller: caller, waiters: waiters}) do
     holder_lines(holder) ++
+      caller_lines(caller) ++
       Enum.map(waiters, &"  waiter #{&1.pid} waiting #{&1.elapsed_ms}ms at #{&1.current_function}")
+  end
+
+  # #1888 — the write path a `:resolved` row names. Labelled "write path" and
+  # not "holder at", deliberately: this stack was taken as the transaction
+  # ENDED, so it says which caller opened it and says nothing about where the
+  # holder paused. Rendering it under the holder's wording would hand an
+  # operator a frame to blame that was never measured.
+  @spec caller_lines(map() | nil) :: [String.t()]
+  defp caller_lines(nil), do: []
+
+  defp caller_lines(caller) do
+    ["  write path #{caller.pid} (#{caller.initial_call})"] ++
+      Enum.map(caller.stacktrace, &"    #{&1}")
   end
 
   @spec holder_lines(map() | nil) :: [String.t()]

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -103,6 +103,30 @@ defmodule Grappa.Repo.LockWatch do
   `:resolved` event carrying the TOTAL hold, so a NAMED episode has both an
   opening and a closing bracket.
 
+  ### The bracket that speaks when the opening line never did (#1888)
+
+  🔴 That closing bracket used to require `reported?: true`, which made it
+  useless in the one case it is now for. **Measured in prod on 2026-09-01
+  (grappa 1.4.1, jail `grappa-new`): a 31 s freeze — no request served, on any
+  network — with this observer ARMED (`enabled: true` in `config/config.exs`,
+  overridden nowhere) and not one line of its own between 12:06:57.328 and
+  12:07:28.554.** Whatever kept the detection pass from speaking, the episode
+  then closed in TOTAL silence too: no log line, no telemetry, no ring row.
+  An instrument whose silence means both *"nothing happened"* and *"something
+  happened and I could not say so"* has stopped reporting.
+
+  So a hold past `stall_threshold_ms` now brackets whether or not it was ever
+  announced, and the line SAYS which — an announced episode has an opening
+  line above it carrying the holder's sampled stack, an unannounced one is the
+  only record that episode left, and an operator needs to know which they are
+  holding. The bracket is also where the ambiguity is cheapest to remove: by
+  then the lock is RELEASED, so nothing on this path can be blocked by the
+  stall it describes, which is exactly the trap the detection path lives in
+  (#1715).
+
+  What it carries is a `t:caller/0` and NOT a `t:sample/0` — see that type for
+  why the two must not be folded together.
+
   Both arms share that one flag, and the unattributed arm arms it on WAITER
   rows rather than a holder's. So `acquired/0` CLEARS it on promotion: a pid
   reported once while queued would otherwise carry an armed flag into its own
@@ -146,6 +170,15 @@ defmodule Grappa.Repo.LockWatch do
   suspends its target) runs ONLY once a stall has already been detected,
   on a process that is by definition already stopped.
 
+  #1888 adds ONE more `:persistent_term` read per write-transaction RELEASE
+  (the threshold the bracket compares against). It is a read and not a write
+  on purpose: a `persistent_term` WRITE is the thing that blocks on a
+  thread-progress barrier (#1715), and the only write is the one `init/1`
+  pays at boot. Everything else the bracket does — the caller's
+  `$initial_call`, its own stack — runs only once the hold has already crossed
+  the threshold, and reads the releasing process's OWN state, so it neither
+  signals nor suspends anybody.
+
   Off by default; `config :grappa, :lock_watch, enabled: true` arms it.
   `config/test.exs` leaves it OFF — its own tests arm it explicitly.
   """
@@ -156,6 +189,7 @@ defmodule Grappa.Repo.LockWatch do
 
   @table :grappa_repo_lock_watch
   @enabled_key {__MODULE__, :enabled}
+  @threshold_key {__MODULE__, :stall_threshold_ms}
   @depth_key {__MODULE__, :depth}
   @stack_frames 12
 
@@ -187,8 +221,31 @@ defmodule Grappa.Repo.LockWatch do
           stacktrace: [String.t()]
         }
 
-  @typedoc "A detected stall: one holder, the queue behind it."
+  @typedoc """
+  Who held the lock, read from the holder's OWN process at release (#1888).
+
+  🔴 Deliberately NOT a `t:sample/0`, and the distinction is the whole point.
+  A sample is taken while the holder is still parked, so `current_function`
+  and `status` name the frame it paused IN. By release there is no pause site
+  left, and reusing that shape would let a release-time stack be read as the
+  place the writer stalled — a claim this frame cannot make. What does survive
+  release is the write PATH: which caller opened the transaction. That is all
+  this carries, and it is what #1888 asks for ("pid + stacktrace or a label
+  for the operation").
+  """
+  @type caller :: %{
+          pid: String.t(),
+          initial_call: String.t(),
+          stacktrace: [String.t()]
+        }
+
+  @typedoc """
+  A detected stall: one holder, the queue behind it, and the instant it was
+  observed (#1888 — the ring row it becomes is otherwise impossible to line up
+  against `erlang.log`, which is the only artefact that dates a freeze).
+  """
   @type stall :: %{
+          observed_at: String.t(),
           holder: sample(),
           waiters: [sample()],
           waiter_count: non_neg_integer()
@@ -203,6 +260,7 @@ defmodule Grappa.Repo.LockWatch do
   field for a thing that was never observed.
   """
   @type unattributed :: %{
+          observed_at: String.t(),
           waiters: [sample()],
           holders_registered: non_neg_integer()
         }
@@ -308,7 +366,7 @@ defmodule Grappa.Repo.LockWatch do
     :ok
   end
 
-  # Transaction over. Closes the episode, and brackets it if it was reported.
+  # Transaction over. Closes the episode, and brackets it if it earned one.
   @spec released() :: :ok
   defp released do
     case depth() do
@@ -323,23 +381,79 @@ defmodule Grappa.Repo.LockWatch do
     :ok
   end
 
+  # 🔴 #1888 widened WHAT earns a bracket, and the widening is the deliverable.
+  # Until then the only clause that spoke required `reported?: true`, so an
+  # episode the watchdog never announced closed in TOTAL silence — no log line,
+  # no telemetry, no ring row. That is the shape #1888 reports from prod: this
+  # observer armed (`enabled: true` in `config/config.exs`, unoverridden), a
+  # 31 s freeze, and not one line of its own on either door. An instrument
+  # whose silence means BOTH "nothing happened" and "something happened and I
+  # could not say so" is not reporting.
+  #
+  # The bracket is where that ambiguity is cheapest to remove, because by the
+  # time this runs the lock is already RELEASED — so nothing this frame does
+  # can be blocked by the stall it is describing, which is precisely the trap
+  # the detection path lives in (#1715).
   @spec close_episode([row()]) :: :ok
-  defp close_episode([{_, :holding, since, true}]) do
+  defp close_episode([{_, :holding, since, announced}]) do
     held_ms = now_ms() - since
 
+    if announced or past_threshold?(held_ms) do
+      report_resolved(held_ms, announced)
+    end
+
+    :ok
+  end
+
+  defp close_episode(_), do: :ok
+
+  # The threshold is published by the watchdog at `init/1`, so a release that
+  # lands on a node where it never booted — or inside a supervisor restart —
+  # has none to compare against. `:unknown` answers FALSE rather than guessing
+  # one, which is exactly the pre-#1888 behaviour: an announced episode still
+  # brackets, because `reported?` already proves it crossed a threshold. A
+  # literal default here would either bracket every write transaction on the
+  # node or none of them, and both are wrong silently.
+  @spec past_threshold?(non_neg_integer()) :: boolean()
+  defp past_threshold?(held_ms) do
+    case :persistent_term.get(@threshold_key, :unknown) do
+      threshold_ms when is_integer(threshold_ms) -> held_ms >= threshold_ms
+      :unknown -> false
+    end
+  end
+
+  # 🔴 The `db lock stall RESOLVED:` prefix is LOAD-BEARING and unchanged. The
+  # #1429 census counts `lockstall_resolved` off it (`scripts/log-gap-scan.awk`)
+  # and `test/scripts/log_gap_scan_test.bats` pins the phrase verbatim, so
+  # everything #1888 adds rides in the TAIL and both keep counting with no edit
+  # — the same discipline `terminal_message/3` in `Grappa.Repo.BusyRetry`
+  # states for its own prose.
+  @spec report_resolved(non_neg_integer(), boolean()) :: :ok
+  defp report_resolved(held_ms, announced) do
+    caller = caller_identity()
+
     Logger.warning(
-      "db lock stall RESOLVED: holder #{inspect(self())} released RESERVED after #{held_ms}ms",
+      "db lock stall RESOLVED: holder #{caller.pid} released RESERVED after #{held_ms}ms — " <>
+        "#{announced_clause(announced)}; write path #{caller.initial_call}, " <>
+        "stack: #{Enum.join(caller.stacktrace, " <- ")}",
       held_ms: held_ms
     )
 
     :telemetry.execute(
       [:grappa, :repo, :lock_stall, :resolved],
       %{held_ms: held_ms},
-      %{holder_pid: inspect(self())}
+      %{observed_at: now_iso8601(), holder_pid: caller.pid, caller: caller, announced: announced}
     )
   end
 
-  defp close_episode(_), do: :ok
+  # Which of the two an operator is reading decides where they look next: an
+  # announced episode has an opening line above it carrying the holder's
+  # SAMPLED stack, while an unannounced one is the only record that episode
+  # ever left. The clause is the difference between "scroll up" and "there is
+  # nothing up there to find".
+  @spec announced_clause(boolean()) :: String.t()
+  defp announced_clause(true), do: "announced while it held"
+  defp announced_clause(false), do: "NEVER announced while it held"
 
   ## ----- Public API ---------------------------------------------------
 
@@ -392,6 +506,26 @@ defmodule Grappa.Repo.LockWatch do
     def put_test_enabled(enabled?) when is_boolean(enabled?) do
       :persistent_term.put(@enabled_key, enabled?)
     end
+
+    @doc false
+    # #1888 — publish (or WITHDRAW) the threshold the closing bracket compares
+    # against, without restarting the watchdog. `nil` erases the key, which is
+    # the only way to reach `past_threshold?/1`'s `:unknown` arm: the arm that
+    # keeps a node whose watchdog never booted on the pre-#1888 behaviour. A
+    # test that could not reach it would leave that arm unbought.
+    #
+    # Gated to :test beside `put_test_enabled/1`, and tests MUST withdraw
+    # `on_exit` for the same reason — a threshold left published is
+    # failure-at-a-distance for every later test.
+    @spec put_test_stall_threshold(non_neg_integer() | nil) :: :ok
+    def put_test_stall_threshold(nil) do
+      _ = :persistent_term.erase(@threshold_key)
+      :ok
+    end
+
+    def put_test_stall_threshold(ms) when is_integer(ms) and ms >= 0 do
+      :persistent_term.put(@threshold_key, ms)
+    end
   end
 
   ## ----- GenServer callbacks ------------------------------------------
@@ -412,6 +546,13 @@ defmodule Grappa.Repo.LockWatch do
     # table is owned here so a supervisor restart rebuilds it clean.
     _ = :ets.new(@table, [:named_table, :public, :set, write_concurrency: true])
     :persistent_term.put(@enabled_key, state.enabled)
+
+    # #1888 — the closing bracket runs in the RELEASING caller's process, not
+    # here, so it cannot read `state`. Published once at boot for the same
+    # reason `@enabled_key` is: a `:persistent_term` read is lock-free and
+    # cheap, while the WRITE is the thing that blocks on a thread-progress
+    # barrier (#1715) — and this is the only write.
+    :persistent_term.put(@threshold_key, state.stall_threshold_ms)
 
     _ = if state.enabled, do: Process.send_after(self(), :tick, state.tick_ms)
 
@@ -540,7 +681,12 @@ defmodule Grappa.Repo.LockWatch do
 
     holder = sample(pid, elapsed)
 
-    stall = %{holder: holder, waiters: waiter_samples, waiter_count: length(waiter_samples)}
+    stall = %{
+      observed_at: now_iso8601(),
+      holder: holder,
+      waiters: waiter_samples,
+      waiter_count: length(waiter_samples)
+    }
 
     # `status` rides in the PROSE, next to `current_function`, and not in the
     # metadata beside `held_ms`/`waiters`: those two are measurements an
@@ -583,7 +729,7 @@ defmodule Grappa.Repo.LockWatch do
 
     samples = Enum.map(queued, fn {pid, elapsed} -> sample(pid, elapsed) end)
     longest = Enum.max_by(samples, & &1.elapsed_ms)
-    report = %{waiters: samples, holders_registered: holders_registered}
+    report = %{observed_at: now_iso8601(), waiters: samples, holders_registered: holders_registered}
 
     Logger.warning(
       "db lock stall UNATTRIBUTED: #{length(samples)} writer(s) queued past the threshold, " <>
@@ -680,14 +826,62 @@ defmodule Grappa.Repo.LockWatch do
   @spec stacktrace(pid()) :: [String.t()]
   defp stacktrace(pid) do
     case Process.info(pid, :current_stacktrace) do
+      {:current_stacktrace, frames} -> format_frames(frames)
+      nil -> []
+    end
+  end
+
+  # #1888 — the release-time identity, read from the releasing process's OWN
+  # state. That is what makes it cheap enough to sit on the release path at
+  # all: `Process.get/1` is a local dictionary read and
+  # `Process.info(self(), …)` needs no signal and suspends nobody, unlike
+  # `sample/2`, which crosses to another process. Both still run ONLY past the
+  # threshold — see `close_episode/1`.
+  @spec caller_identity() :: caller()
+  defp caller_identity do
+    %{
+      pid: inspect(self()),
+      initial_call: format_mfa(Process.get(:"$initial_call")),
+      stacktrace: caller_frames()
+    }
+  end
+
+  # The head of a release-time stack is the observer's own plumbing —
+  # `Process.info/2` under `caller_frames/0` under `report_resolved/2` under
+  # `close_episode/1` under `released/0` under `observe/1` — and an operator
+  # who has to read six frames of observer before the first frame of the thing
+  # observed reads none of them. What survives is everything ABOVE the
+  # outermost `__MODULE__` frame, which puts `Repo.immediate_transaction/1` at
+  # the head: both the seam and the proof that this was a WRITE transaction.
+  #
+  # 🔴 Dropping WHILE the frame is `__MODULE__` does not do this, measured: the
+  # innermost frame is `Process.info/2`, which belongs to `Process`, so the
+  # drop stops on the very first frame and keeps the whole observer. Taking
+  # from the END until the last `__MODULE__` frame needs no module allowlist
+  # and cannot rot as the private call chain changes shape.
+  @spec caller_frames() :: [String.t()]
+  defp caller_frames do
+    case Process.info(self(), :current_stacktrace) do
       {:current_stacktrace, frames} ->
         frames
-        |> Enum.take(@stack_frames)
-        |> Enum.map(&(&1 |> Exception.format_stacktrace_entry() |> String.trim()))
+        |> Enum.reverse()
+        |> Enum.take_while(&(not match?({__MODULE__, _, _, _}, &1)))
+        |> Enum.reverse()
+        |> format_frames()
 
       nil ->
         []
     end
+  end
+
+  # Capped and pre-formatted: these strings ride telemetry into a JSON admin
+  # response, so every frame must be JSON-encodable at the point it is built,
+  # not later.
+  @spec format_frames([tuple()]) :: [String.t()]
+  defp format_frames(frames) do
+    frames
+    |> Enum.take(@stack_frames)
+    |> Enum.map(&(&1 |> Exception.format_stacktrace_entry() |> String.trim()))
   end
 
   @spec format_mfa(mfa() | nil) :: String.t()
@@ -707,6 +901,15 @@ defmodule Grappa.Repo.LockWatch do
 
   @spec depth() :: non_neg_integer()
   defp depth, do: Process.get(@depth_key, 0)
+
+  # #1888 — stamped at EMIT, never at fold. `Grappa.DbLatency` folds behind a
+  # cast in another process, so a stamp taken there would be "when the
+  # aggregator got round to it" — a different fact wearing the same name, and
+  # skewed by exactly the load an incident produces. An ISO8601 STRING and not
+  # a `DateTime`: like every other field here it rides telemetry into a JSON
+  # admin response and must be encodable where it is built.
+  @spec now_iso8601() :: String.t()
+  defp now_iso8601, do: DateTime.to_iso8601(DateTime.utc_now())
 
   @spec now_ms() :: integer()
   defp now_ms, do: System.monotonic_time(:millisecond)

--- a/test/grappa/db_latency_test.exs
+++ b/test/grappa/db_latency_test.exs
@@ -196,6 +196,7 @@ defmodule Grappa.DbLatencyTest do
         [:grappa, :repo, :lock_stall, :detected],
         %{held_ms: 2_400, waiter_count: 2},
         %{
+          observed_at: "2026-09-01T10:06:57.328000Z",
           holder: %{pid: "#PID<0.111.0>", stacktrace: ["Foo.bar/1"]},
           waiters: [%{pid: "#PID<0.222.0>"}, %{pid: "#PID<0.333.0>"}]
         }
@@ -204,7 +205,16 @@ defmodule Grappa.DbLatencyTest do
       :telemetry.execute(
         [:grappa, :repo, :lock_stall, :resolved],
         %{held_ms: 30_120},
-        %{holder_pid: "#PID<0.111.0>"}
+        %{
+          observed_at: "2026-09-01T10:07:28.554000Z",
+          holder_pid: "#PID<0.111.0>",
+          announced: true,
+          caller: %{
+            pid: "#PID<0.111.0>",
+            initial_call: "Grappa.Session.Server.init/1",
+            stacktrace: ["Grappa.Repo.immediate_transaction/1"]
+          }
+        }
       )
 
       assert [resolved, detected] = DbLatency.snapshot().lock_stalls
@@ -215,10 +225,27 @@ defmodule Grappa.DbLatencyTest do
       assert resolved.held_ms == 30_120
       assert resolved.holder == nil
 
+      # #1888 — `holder` stays nil (a `sample()` means "sampled while it
+      # stalled", and by release there is no pause site left to sample) while
+      # `caller` carries the write path that held the lock. Two different
+      # facts, two different keys: folding them would let a release-time stack
+      # be read as the frame the holder paused in.
+      assert resolved.caller.initial_call == "Grappa.Session.Server.init/1"
+      assert resolved.announced == true
+
+      # `waiter_count` is nil, not 0: nothing in a closing bracket counted a
+      # queue, and a 0 would assert an empty one was measured.
+      assert resolved.waiter_count == nil
+
       assert detected.phase == :detected
       assert detected.waiter_count == 2
       assert detected.holder.stacktrace == ["Foo.bar/1"]
       assert length(detected.waiters) == 2
+
+      # The instant, on both edges: a ring row that cannot be aligned with
+      # `erlang.log` cannot be matched to the freeze it belongs to.
+      assert resolved.observed_at == "2026-09-01T10:07:28.554000Z"
+      assert detected.observed_at == "2026-09-01T10:06:57.328000Z"
     end
 
     test "[:grappa, :repo, :lock_stall, :unattributed] folds with an explicit nil where the holder would be" do
@@ -226,6 +253,7 @@ defmodule Grappa.DbLatencyTest do
         [:grappa, :repo, :lock_stall, :unattributed],
         %{waiter_count: 3, longest_wait_ms: 31_303},
         %{
+          observed_at: "2026-09-01T10:07:28.554000Z",
           holders_registered: 0,
           waiters: [
             %{pid: "#PID<0.222.0>", elapsed_ms: 31_303, stacktrace: ["Exqlite.Sqlite3NIF.step/2"]},
@@ -249,6 +277,12 @@ defmodule Grappa.DbLatencyTest do
       assert row.held_ms == nil
       assert row.holder == nil
 
+      # #1888 — the same rule for the two fields the closing bracket adds.
+      # Nothing here released a hold, so there is no write path to name and no
+      # announcement to report; both stay explicitly absent.
+      assert row.caller == nil
+      assert row.announced == nil
+
       # The waiters ARE the payload: they are the only thing this episode can
       # honestly show, and the stack is what separates "blocked on the lock"
       # from "queued for a connection".
@@ -261,7 +295,12 @@ defmodule Grappa.DbLatencyTest do
         :telemetry.execute(
           [:grappa, :repo, :lock_stall, :resolved],
           %{held_ms: n},
-          %{holder_pid: "#PID<0.#{n}.0>"}
+          %{
+            observed_at: "2026-09-01T10:07:#{String.pad_leading("#{n}", 2, "0")}.000000Z",
+            holder_pid: "#PID<0.#{n}.0>",
+            announced: false,
+            caller: %{pid: "#PID<0.#{n}.0>", initial_call: "unknown", stacktrace: []}
+          }
         )
       end
 

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -287,7 +287,7 @@ defmodule Grappa.OperatorTest do
       :ok =
         :telemetry.attach_many(
           @db_latency_handler_id,
-          [[:grappa, :repo, :query]],
+          [[:grappa, :repo, :query], [:grappa, :repo, :lock_stall, :resolved]],
           &DbLatency.handle_telemetry/4,
           nil
         )
@@ -313,6 +313,48 @@ defmodule Grappa.OperatorTest do
       assert output =~ "messages\tinsert\t1"
       assert output =~ "# spans (D1 write-path)"
       assert output =~ "# contention"
+    end
+
+    test "an unannounced closing bracket renders its instant, its verdict and its write path (#1888)" do
+      # The CLI door is the one an operator actually reaches for mid-incident,
+      # and until #1888 nothing pinned its lock-stall block at all — so a nil
+      # in a new column would have surfaced as a crash in `bin/grappa
+      # db-latency` during the exact incident it was added to diagnose.
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :resolved],
+        %{held_ms: 31_295},
+        %{
+          observed_at: "2026-09-01T10:07:28.554000Z",
+          holder_pid: "#PID<0.512.0>",
+          announced: false,
+          caller: %{
+            pid: "#PID<0.512.0>",
+            initial_call: "Grappa.Session.Server.init/1",
+            stacktrace: ["Grappa.Repo.immediate_transaction/1", "Grappa.Scrollback.persist/1"]
+          }
+        }
+      )
+
+      # Drain the cast before rendering.
+      _ = DbLatency.snapshot()
+
+      output = capture_io(fn -> assert :ok = Operator.db_latency_text!() end)
+
+      assert output =~ "resolved\tat=2026-09-01T10:07:28.554000Z\tholder=#PID<0.512.0>"
+      assert output =~ "held_ms=31295"
+
+      # `waiters=0` would assert a queue was counted and found empty; the
+      # closing bracket counts none. `announced=NO` is the #1888 finding: this
+      # row is the only record the episode left.
+      assert output =~ "waiters=not counted"
+      assert output =~ "announced=NO"
+
+      # The identity, under its own wording. "holder at" is the DETECTED
+      # block's voice and names a pause site; this stack was taken at release
+      # and names the caller instead.
+      assert output =~ "write path #PID<0.512.0> (Grappa.Session.Server.init/1)"
+      assert output =~ "    Grappa.Scrollback.persist/1"
+      refute output =~ "holder at"
     end
   end
 

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -41,6 +41,7 @@ defmodule Grappa.Repo.LockWatchTest do
 
   @detected [:grappa, :repo, :lock_stall, :detected]
   @unattributed [:grappa, :repo, :lock_stall, :unattributed]
+  @resolved [:grappa, :repo, :lock_stall, :resolved]
 
   # 🔴 TWO CLOCKS BOUND EVERY TEST HERE, AND THEY HAVE TO BE ORDERED.
   #
@@ -137,17 +138,20 @@ defmodule Grappa.Repo.LockWatchTest do
     handler = "lock-watch-test-#{System.unique_integer([:positive])}"
     test_pid = self()
 
-    # Both doors on ONE handler, tagged by event: a test that asserts the
+    # Every door on ONE handler, tagged by event: a test that asserts the
     # attributed line fired must also be able to REFUTE the unattributed one
     # (and vice versa). Two separate handlers would let a mutant that emits
-    # both pass every assertion in the file.
+    # both pass every assertion in the file. #1888 adds the closing bracket
+    # for the same reason — a test that asserts an episode brackets must be
+    # able to refute that it brackets when it should not.
     :ok =
       :telemetry.attach_many(
         handler,
-        [@detected, @unattributed],
+        [@detected, @unattributed, @resolved],
         fn
           @detected, measurements, metadata, _ -> send(test_pid, {:stall, measurements, metadata})
           @unattributed, measurements, metadata, _ -> send(test_pid, {:unattributed, measurements, metadata})
+          @resolved, measurements, metadata, _ -> send(test_pid, {:resolved, measurements, metadata})
         end,
         nil
       )
@@ -415,6 +419,165 @@ defmodule Grappa.Repo.LockWatchTest do
       assert Enum.any?(holders, &(&1.pid == me))
 
       assert %{holders: [], waiters: []} = LockWatch.inspect_lock()
+    end
+  end
+
+  describe "the closing bracket, when the watchdog never spoke (#1888)" do
+    # The premise these four tests are bought against, and it is the whole
+    # reason the bracket had to change: before #1888 `close_episode/1` matched
+    # `reported?: true` and NOTHING else, so an episode the watchdog never
+    # announced left no trace on either door. That is the exact shape #1888
+    # reports from prod — a 31 s freeze with the observer armed and not one
+    # line of its own in the log — and it makes the instrument's silence
+    # indistinguishable between "no stall happened" and "the stall happened
+    # and I could not say so".
+    #
+    # The threshold is driven to 0 rather than waited out: `stall_threshold_ms`
+    # is a wall clock, and a test that sleeps past 2_000ms to cross it measures
+    # the runner. 0 is a coherent operator setting (see the `t()` typedoc) and
+    # the file's other tests already drive detection rather than await it.
+    setup do
+      LockWatch.put_test_stall_threshold(0)
+      on_exit(fn -> LockWatch.put_test_stall_threshold(nil) end)
+      :ok
+    end
+
+    test "a hold nobody announced still brackets, and names the write path that held it" do
+      # Held from a Task, not from the test process, and that is not
+      # incidental. `$initial_call` is written by `proc_lib`, so every holder
+      # this instrument meets in prod has one — `Session.Server`, a Phoenix
+      # channel, a `Task.Supervisor` child, a reaper — while a bare ExUnit test
+      # process does NOT (measured: it reads `unknown`). Holding from the test
+      # process would have bought the assertion against the one topology that
+      # never occurs.
+      # Started INSIDE the capture, not before it: the bracket is emitted by
+      # the task's own `released/0`, which runs before the task returns, so a
+      # task spawned ahead of `with_log/1` can have logged and finished before
+      # the capture handler is even installed.
+      {task_pid, log} =
+        with_log(fn ->
+          task = Task.async(&hold_and_return/0)
+          assert {:held, _} = Task.await(task)
+          task.pid
+        end)
+
+      assert_receive {:resolved, %{held_ms: held_ms}, meta}
+      assert is_integer(held_ms) and held_ms >= 0
+
+      # The finding, not a formatting detail: this episode was never announced
+      # while it held, and the row has to SAY so — otherwise an operator reads
+      # a bracket and assumes the opening line is somewhere above it in a log
+      # that never carried one.
+      assert meta.announced == false
+      assert log =~ "db lock stall RESOLVED"
+      assert log =~ "NEVER announced"
+
+      # The identity #1888 asks for. It is the CALLER — who opened the write
+      # transaction — and deliberately not a `sample()`: by release time there
+      # is no pause site left to sample, and reusing the holder's shape would
+      # smuggle back a claim the frame cannot make.
+      assert meta.caller.pid == inspect(task_pid)
+      assert meta.caller.initial_call == "Grappa.Repo.LockWatchTest.hold_and_return/0"
+
+      # LockWatch's own plumbing is dropped from the stack, so the FIRST frame
+      # an operator reads is the write path itself. Without the drop the head
+      # is `Process.info/2` under four frames of observer — which is exactly
+      # what the first cut of this printed.
+      assert [first | _] = meta.caller.stacktrace
+      assert first =~ "Grappa.Repo.LockWatchTest.hold_and_return/0"
+      refute Enum.any?(meta.caller.stacktrace, &(&1 =~ "lock_watch.ex"))
+      refute Enum.any?(meta.caller.stacktrace, &(&1 =~ "Process.info"))
+    end
+
+    test "an ANNOUNCED hold brackets exactly as it did before, and says it was announced" do
+      # A queue behind the holder is the second half `report_stalls/2`
+      # requires. Without it the detection pass walks away and this test would
+      # measure the unannounced arm again, passing for the wrong reason.
+      waiter = queue_a_waiter()
+
+      log =
+        capture_log(fn ->
+          LockWatch.observe(fn acquired ->
+            acquired.()
+            LockWatch.scan(0)
+            :ok
+          end)
+        end)
+
+      release_waiter(waiter)
+
+      assert_receive {:stall, _, _}
+      assert_receive {:resolved, _, meta}
+
+      assert meta.announced == true
+      assert log =~ "db lock stall RESOLVED"
+      refute log =~ "NEVER announced"
+    end
+
+    test "a hold UNDER the threshold that nobody announced brackets nothing" do
+      # The negative control for the arm above. A bracket on every write
+      # transaction would bury the signal in exactly the way `report_stalls/2`
+      # refuses to, and would make the ring useless within seconds of boot.
+      LockWatch.put_test_stall_threshold(60_000)
+
+      log =
+        capture_log(fn ->
+          LockWatch.observe(fn acquired ->
+            acquired.()
+            :ok
+          end)
+        end)
+
+      refute_receive {:resolved, _, _}, 200
+      refute log =~ "db lock stall RESOLVED"
+    end
+
+    test "with no threshold published at all, only an announced hold brackets" do
+      # The graceful-degradation contract of the `:persistent_term` seam: the
+      # watchdog publishes the threshold at `init/1`, so a node where it never
+      # booted (or has just been restarted) has no threshold to compare
+      # against. Guessing one would invent a verdict; the honest fallback is
+      # the pre-#1888 behaviour, which needs no threshold because `reported?`
+      # already proves the episode crossed it.
+      LockWatch.put_test_stall_threshold(nil)
+
+      LockWatch.observe(fn acquired ->
+        acquired.()
+        :ok
+      end)
+
+      refute_receive {:resolved, _, _}, 200
+    end
+  end
+
+  describe "the instant an episode was observed (#1888)" do
+    test "every phase carries it, so a ring row can be aligned with the log" do
+      # `Grappa.DbLatency`'s ring is the door that survives a log that went
+      # quiet — but a row with no instant cannot be matched against
+      # `erlang.log`, which is the only artefact that dates the freeze. Stamped
+      # at EMIT rather than at fold: the fold happens in another process behind
+      # a cast, and `recorded_at` would be a different fact wearing this name.
+      LockWatch.put_test_stall_threshold(0)
+      on_exit(fn -> LockWatch.put_test_stall_threshold(nil) end)
+
+      waiter = queue_a_waiter()
+
+      capture_log(fn ->
+        LockWatch.observe(fn acquired ->
+          acquired.()
+          LockWatch.scan(0)
+          :ok
+        end)
+      end)
+
+      release_waiter(waiter)
+
+      assert_receive {:stall, _, detected}
+      assert_receive {:resolved, _, resolved}
+
+      for meta <- [detected, resolved] do
+        assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(meta.observed_at)
+      end
     end
   end
 
@@ -1336,6 +1499,46 @@ defmodule Grappa.Repo.LockWatchTest do
     receive do
       :release -> :ok
     end
+  end
+
+  # #1888 — a NAMED write path, so the bracket has a caller frame to name.
+  #
+  # 🔴 The trailing tuple is load-bearing and not decoration: with
+  # `observe/1` in tail position the BEAM elides this function's frame
+  # entirely, and the stack the bracket captures starts at
+  # `Task.Supervised.invoke_mfa/2` — measured, first cut of this test. A
+  # non-tail call keeps the frame, which is what makes "the head of the stack
+  # is the write path" assertable at all.
+  defp hold_and_return do
+    result = LockWatch.observe(fn acquired -> acquired.() end)
+    {:held, result}
+  end
+
+  # #1888 — a process parked inside `observe/1` BEFORE it reaches `acquired`,
+  # i.e. a genuine `:waiting` row, which is the second half `report_stalls/2`
+  # requires. It touches no SQLite: those tests measure the CLOSING bracket,
+  # and the real `RESERVED` acquisition is what the TmpRepo tests above buy.
+  #
+  # The pid comes back so the caller can release it INSIDE the same test. This
+  # file is `async: false` but its tests share one ETS table, so a waiter left
+  # parked would queue itself behind the next test's holder and turn an
+  # unattributed assertion into an attributed one at a distance.
+  defp queue_a_waiter do
+    pid = spawn(fn -> LockWatch.observe(fn _ -> park_until_released() end) end)
+
+    await_roles(nil, [pid])
+    pid
+  end
+
+  # Released and AWAITED, not just signalled: the row is deleted by the
+  # waiter's own `released/0`, so returning before it has run would leak the
+  # very row the helper exists to clean up.
+  defp release_waiter(pid) do
+    ref = Process.monitor(pid)
+    send(pid, :release)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}
+    await_roles(nil, [])
   end
 
   # `holder` is `nil` for the #1687 topology — a queue whose holder owns no


### PR DESCRIPTION
Addresses point 1 of issue 1888 — *identify who holds the write lock* — and
only point 1. Points 2 and 3 of that issue are untouched.

## The defect

Prod froze for 31 s on 2026-09-01 with `Grappa.Repo.LockWatch` **armed**:
`config/config.exs` declares `enabled: true, stall_threshold_ms: 2_000`, and
neither `prod.exs` nor `runtime.exs` overrides it. Both #1687's unattributed
arm and #1715's logger prime shipped *inside* the running release
(`cf5a612f2` and `c048d2bff` are ancestors of `997711ac`). The instrument was
not missing. It emitted nothing, and its silence was indistinguishable from a
healthy node.

`close_episode/1` matched `reported?: true` and nothing else, so an episode
the watchdog never announced closed with no log line, no telemetry and no
ring row. An instrument whose silence means both *"nothing happened"* and
*"something happened and I could not say so"* has stopped reporting.

## The change

All three parts sit on **LockWatch's closing bracket**, which is where the
ambiguity is cheapest to remove: by then the lock is **released**, so nothing
on that path can be blocked by the stall it describes — the trap the
detection path lives in (#1715).

1. **A hold past `stall_threshold_ms` brackets whether or not it was ever
   announced**, and the line says which (`announced` true/false). An
   announced episode has an opening line above it with the holder's sampled
   stack; an unannounced one is the only record that episode left.
2. **The bracket carries a `t:caller/0`, deliberately not a `t:sample/0`.**
   A sample names the frame the holder *paused* in; by release there is no
   pause site left, and what survives is the write **path**, read from the
   releasing process's own state (no signal, no suspend). The renderer keeps
   the two apart — `write path …` vs `holder at …` — for that reason.
3. **Every phase stamps `observed_at` at EMIT, never at fold.** `DbLatency`
   folds behind a cast, so a stamp taken there means *"when the aggregator
   got round to it"*, skewed by exactly the load an incident produces.
   Without it a ring row cannot be lined up against `erlang.log`.

Plus: `waiter_count` on a `:resolved` row goes `0` → `nil`. A closing bracket
counts no queue, and the zero asserted a measurement nobody took.

**Cost:** one extra `:persistent_term` **read** per write-transaction
release. A read and not a write on purpose — the write is what blocks on a
thread-progress barrier (#1715), and the only one is `init/1`'s. With the key
absent, `past_threshold?/1` answers `false` rather than guessing, which is
byte-for-byte the pre-change behaviour.

The `db lock stall RESOLVED:` prefix is **unchanged**, so the #1429 census
(`scripts/log-gap-scan.awk`) and its bats pins keep counting with no edit —
everything new rides in the tail of the line.

## Deliberately out of this slice, and why the order is B-then-A

Not done here: widening the seam to the **129** bare
`Repo.insert/update/delete/*_all` call sites across 24 files under `lib/` on
`origin/main`, which take the same file lock and register no holder.

That slice depends on this one, and the reason is not sequencing preference.
There are two live hypotheses for the silence: (i) the holder was never
registered, or (ii) the logging door itself was mute during the stall. Under
(ii) the holder's identity survives the episode **only** if it reaches the
`DbLatency` ring — and before this change a ring row carried no emit-time
stamp, so it could not be lined up against `erlang.log` afterwards. Widening
the seam first would therefore produce a row whose only exit is the very door
we are accusing of being mute. This change gives that row a second exit and a
timestamp; only then is the wider seam worth taking.

## Deploy classification: COLD

**COLD**, and the reason is version skew on a ring that outlives a hot
reload — not anything about the ETS table.

An earlier draft of this section claimed the diff changed what the seam
writes to the watchdog's ETS table. That was wrong and is retracted: this
diff touches **no** `:ets.` line (0 of the 225 changed lines in
`lock_watch.ex`), and the 12 `:ets.` sites are identical before and after.
The row `{pid, state, ts, reported?}` is unchanged. Also retracted: the
supervision-tree argument — the diff does not touch `application.ex`, so the
`LockWatch`-before-`Repo` ordering is not in play.

### The real reason: old rows survive the reload, the new reader does not survive them

`@type lock_stall_row` is a **bare map**, not a struct, and the ring lives in
`Grappa.DbLatency`'s GenServer state (`defstruct lock_stalls: []`). This diff
adds three keys to that row — `observed_at`, `caller`, `announced` — so a row
written before the reload has 6 keys and a row written after has 9.

Nothing bridges the two:

| candidate normalizer | measured | verdict |
|---|---|---|
| `to_snapshot/1` rebuilds rows | `db_latency.ex:437` → `lock_stalls: state.lock_stalls`, verbatim | no |
| a `code_change/3` migrates them | **0** occurrences of `def code_change` in all of `lib/` (positive control: 95 `def handle_call`) | no |
| hot reload restarts the process | `HotReload.reload_one/2` is `:code.soft_purge/1` + `:code.load_abs/1`; nothing stops a process, restarts a child, or restarts the app — `soft_purge` is chosen precisely so live processes are **not** killed | no |
| the ring evicts them | `@lock_stall_ring 20`, `Enum.take([row \| state.lock_stalls], 20)`; issue 1888 counts 4 stalls in ~26 h, so 20 slots hold pre-reload rows ~indefinitely | no — this makes it worse |
| `reset/0` clears them | `handle_call(:reset, _, _) → %__MODULE__{}` does clear, but it is operator-invoked | no — a manual recovery, not a normalizer |

So after a hot reload the ring holds rows the new reader cannot read, and
there are **three** exposures, not one:

* `operator.ex:1035` — `stall.observed_at`, dot access → **`KeyError`**;
* `operator.ex:1037` — `stall.announced`, dot access (same interpolation,
  reached only if the first one somehow passed);
* `operator.ex:1081` — `lock_stall_detail_lines(%{holder:, caller:,
  waiters:})` is a **single clause** with no fallback, and `caller` is new →
  **`FunctionClauseError`**.

The first one wins: it is inside the `Enum.each` fn opened at
`operator.ex:1033`, and `lock_stall_detail_lines/1` is only called at
`:1040`, after that `IO.puts`. So `bin/grappa db-latency` — the tool this
change exists to feed — raises on the first stale row.

### The two doors fail differently, and the quiet one is worse

`GET /admin/db_latency` is `json(conn, DbLatency.snapshot())`
(`db_latency_controller.ex:35`): no dot access, no pattern match. It does
**not** crash. It serves the stale 6-key rows as JSON, silently missing
exactly the `observed_at` this change exists to add. The argument above for
why the ring matters is that it is the door that survives a log that went
quiet — under version skew that door survives and lies, which is the
silent-swallow shape rather than a mitigation of it.

### Secondary, and narrower

The new `fold/4` reads `metadata.observed_at` in all three arms
(`db_latency.ex:317`, `:338`, `:355`), and `fold/4` runs **inside** the
`DbLatency` GenServer (handler casts at `:257` → `handle_cast` at `:261`).
During the window between the two modules being loaded, an old `LockWatch`
emitting into a new fold raises `KeyError` *in the aggregator*, which crashes
it and destroys the whole ring. This needs a stall to land inside a
millisecond-wide window, so it is the secondary argument; the persisted-ring
skew above is deterministic on the next operator read.

No defensive `Map.get` was added to soften any of this into a HOT deploy: a
defensive arm on an already-cold batch buys nothing and leaves behind a path
that hides the next version skew.

## Gates

Measured from the worktree, on this commit:

* `scripts/test.sh test/grappa/repo/lock_watch_test.exs test/grappa/db_latency_test.exs` → rc=0, 48 tests, 0 failures
* `scripts/test.sh test/grappa/operator_test.exs` → rc=0, 35 tests, 0 failures
* `scripts/design-notes-gate.sh` → rc=0, *"1 new entry heading(s), separator and marker present."*
* `scripts/check.sh` → see the report on the PR; ExUnit leg was 8 doctests, 62 properties, 7053 tests, 0 failures

Refs issue 1888.
