### PR TITLE
cicchetto: tell a gone upload apart from a broken one, and stop sending readers to raw JSON

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -660,8 +660,18 @@ export async function adminDeleteUploadBySlug(adminToken: string, slug: string):
 // `Endpoint.url/0` is configured with, and the runner reaches grappa by its
 // compose service name. Re-rooting keeps this working wherever the deployment
 // thinks it lives, and the path is the whole of what identifies the upload.
-export async function publicUploadStatus(uploadUrl: string): Promise<number> {
-  const res = await fetch(`${GRAPPA_BASE_URL}${new URL(uploadUrl).pathname}`);
+//
+// `method` is REQUIRED rather than defaulted to GET, because the two verbs
+// answer two different questions and a caller has to say which one it is
+// asking. GET is "is the route gone"; HEAD is "does the verb the viewer's
+// probe actually uses reach that same answer" — `Plug.Head` is supposed to
+// rewrite HEAD to GET above the router, and a default would let a spec assert
+// the first while believing it had checked the second.
+export async function publicUploadStatus(
+  uploadUrl: string,
+  method: "GET" | "HEAD",
+): Promise<number> {
+  const res = await fetch(`${GRAPPA_BASE_URL}${new URL(uploadUrl).pathname}`, { method });
   return res.status;
 }
 

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -612,6 +612,59 @@ export async function listSessionLogSessions(
   return body.session_log_sessions;
 }
 
+// issue 1889 — remove an upload the way an operator removes one, so a spec can
+// drive the REAL 404 the viewer has to tell apart from a broken load.
+// `Admin.UploadsController.delete` unlinks the file first and then soft-deletes
+// the row, which is exactly the state the incident describes; faking it with a
+// `page.route` fulfil would prove the branch and not the behaviour.
+//
+// Two hops because the admin surface keys uploads by `id` while everything a
+// spec can see — the URL in the scrollback, the POST response — carries the
+// `slug`. The listing INCLUDES soft-deleted rows (it is the operator's audit
+// trail), so resolving by slug is unambiguous only before a second upload
+// reuses it, which the 26-char base32 slug rules out.
+export async function adminDeleteUploadBySlug(adminToken: string, slug: string): Promise<void> {
+  const listRes = await fetch(`${GRAPPA_BASE_URL}/admin/uploads`, {
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!listRes.ok) {
+    throw new Error(
+      `grappaApi.adminDeleteUploadBySlug: GET /admin/uploads → ${listRes.status} ${await listRes.text()}`,
+    );
+  }
+  const body = (await listRes.json()) as { uploads: Array<{ id: string; slug: string }> };
+  const row = body.uploads.find((u) => u.slug === slug);
+  // Loud rather than idempotent, deliberately: a spec that reaches the click
+  // without having deleted anything would assert the GONE text against a live
+  // upload and fail somewhere far from the cause.
+  if (row === undefined) {
+    throw new Error(`grappaApi.adminDeleteUploadBySlug: no upload row for slug ${slug}`);
+  }
+
+  const delRes = await fetch(`${GRAPPA_BASE_URL}/admin/uploads/${encodeURIComponent(row.id)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!delRes.ok) {
+    throw new Error(
+      `grappaApi.adminDeleteUploadBySlug: DELETE ${row.id} → ${delRes.status} ${await delRes.text()}`,
+    );
+  }
+}
+
+// issue 1889 — what the PUBLIC upload route answers now, as a precondition a
+// spec can assert before it goes looking for the client's reaction to it.
+//
+// Takes the minted absolute URL and re-roots its path onto `GRAPPA_BASE_URL`
+// rather than fetching it as given: the mint carries whatever host
+// `Endpoint.url/0` is configured with, and the runner reaches grappa by its
+// compose service name. Re-rooting keeps this working wherever the deployment
+// thinks it lives, and the path is the whole of what identifies the upload.
+export async function publicUploadStatus(uploadUrl: string): Promise<number> {
+  const res = await fetch(`${GRAPPA_BASE_URL}${new URL(uploadUrl).pathname}`);
+  return res.status;
+}
+
 // M-cluster M-8 — operator-side delete via admin bearer. Mirrors
 // `Grappa.Operator.delete_visitor/1`. Used by e2e tests that mint
 // a visitor and need teardown cleanup on early-assertion-failure

--- a/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
+++ b/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
@@ -234,12 +234,21 @@ test("a DELETED upload reads as gone, not as a broken load (issue 1889)", async 
   const { slug, url, link } = await uploadImageAndGetLink(page, "gone-upload.png");
   await adminDeleteUploadBySlug(getSeededAdmin().token, slug);
 
-  // Precondition, asserted rather than assumed: without it a delete that
-  // silently did nothing would surface as "the client did not react", which is
-  // a different bug in a different file. Read from the RUNNER against the
-  // public route, so it is the server's own answer and not the browser's
-  // (which may have cached, and whose failure is the thing under test).
-  expect(await publicUploadStatus(url)).toBe(404);
+  // Preconditions, asserted rather than assumed, and read from the RUNNER
+  // against the public route so they are the server's own answer and not the
+  // browser's (which may have cached, and whose failure is the thing under
+  // test). Without them a delete that silently did nothing would surface as
+  // "the client did not react", which is a different bug in a different file.
+  expect(await publicUploadStatus(url, "GET")).toBe(404);
+
+  // The SECOND one is the load-bearing measurement, and it is asserted here
+  // rather than inferred from this spec's outcome. The viewer's probe asks
+  // with HEAD; a 404 is the only thing that earns "gone"; and `Plug.Head`
+  // rewriting HEAD to GET above the router is the reason the two are supposed
+  // to agree. If they ever stop agreeing the cure goes INERT — the probe would
+  // never see a 404 — and no unit test could tell, because there the 404 is
+  // fabricated. So the wire is asked directly, with the verb the client uses.
+  expect(await publicUploadStatus(url, "HEAD")).toBe(404);
 
   const viewer = await openMediaViewer(page, link);
 

--- a/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
+++ b/cicchetto/e2e/tests/media-link-modal-viewer.spec.ts
@@ -30,13 +30,14 @@
 // Unit tests pin the rewrite; device dogfood is the final word.
 
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { adminDeleteUploadBySlug, publicUploadStatus } from "../fixtures/grappaApi";
 import {
   closeMediaViewer,
   mediaViewer,
   openMediaViewer,
   uploadImageAndGetLink,
 } from "../fixtures/mediaViewer";
-import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededAdmin, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
 
@@ -210,6 +211,50 @@ test("viewer load states: failure text on unfetchable media, spinner until bytes
   await expect(spinner).toBeHidden({ timeout: 10_000 });
   const img = viewer.locator("img.media-viewer-media");
   await expect(img).toHaveJSProperty("complete", true, { timeout: 10_000 });
+});
+
+test("a DELETED upload reads as gone, not as a broken load (issue 1889)", async ({ page }) => {
+  // The incident, end to end and with nothing faked: a real upload, removed
+  // the way an operator removes one, clicked from the row it left behind.
+  //
+  // No `page.route` anywhere. The 404 is the server's own — the admin verb
+  // unlinks the file and soft-deletes the row — because the thing under test
+  // is precisely that cic now believes the SERVER instead of guessing from a
+  // silent element error. A fulfilled fake would exercise the branch and prove
+  // nothing about the route it is about.
+  //
+  // The delete happens BEFORE the first open, deliberately: a successfully
+  // fetched image is served from memory cache on a later click (the same
+  // hazard the load-states spec above orders its phases around), and a cached
+  // hit would neither fail nor be probed.
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  const { slug, url, link } = await uploadImageAndGetLink(page, "gone-upload.png");
+  await adminDeleteUploadBySlug(getSeededAdmin().token, slug);
+
+  // Precondition, asserted rather than assumed: without it a delete that
+  // silently did nothing would surface as "the client did not react", which is
+  // a different bug in a different file. Read from the RUNNER against the
+  // public route, so it is the server's own answer and not the browser's
+  // (which may have cached, and whose failure is the thing under test).
+  expect(await publicUploadStatus(url)).toBe(404);
+
+  const viewer = await openMediaViewer(page, link);
+
+  // The visible outcome, which is the whole point — not "the probe was
+  // called". The generic line is REPLACED: it is the sentence that sent two
+  // operators looking for a client bug.
+  await expect(viewer.getByText(/gone/i)).toBeVisible({ timeout: 10_000 });
+  await expect(viewer.getByText(/failed to load/i)).toBeHidden();
+  await expect(viewer.getByRole("status")).toBeHidden();
+
+  // …and the escape hatch that would have shown them `{"error":"not_found"}`
+  // as raw JSON is not there to click.
+  await expect(viewer.getByRole("link", { name: /open in browser/i })).toBeHidden();
+
+  await closeMediaViewer(viewer);
 });
 
 test("plain web link is NOT intercepted — keeps the default anchor", async ({ page }) => {

--- a/cicchetto/src/MediaViewerModal.tsx
+++ b/cicchetto/src/MediaViewerModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "solid-js";
 import { copyText } from "./lib/clipboard";
 import { errorMessage } from "./lib/friendlyApiError";
+import { probeMediaAvailability } from "./lib/mediaAvailability";
 import { closeMediaViewer, type MediaViewerState, mediaViewerState } from "./lib/mediaViewer";
 import { bindDismissGesture, type DismissDirections } from "./lib/mediaViewerGesture";
 import { createOverlayLock } from "./lib/overlayScrollLock";
@@ -68,7 +69,13 @@ import { fetchTextResource, TEXT_VIEW_MAX_BYTES, type TextResource } from "./lib
 // ONE global keydown listener app-wide. Backdrop is a <button>
 // (UserContextMenu pattern) so close-on-outside needs no a11y lint suppressions.
 
-type MediaLoadStatus = "loading" | "ready" | "failed";
+// issue 1889 — `gone` is a REFINEMENT of `failed`, not a fifth thing that can
+// happen to a load: the element failed either way, and the only difference is
+// that the server was asked afterwards and answered 404. Kept in the same
+// closed set rather than in a second signal so the body has ONE thing to
+// render from — a parallel "is it gone" boolean beside the status would be two
+// values to keep in step for one paragraph of text.
+type MediaLoadStatus = "loading" | "ready" | "failed" | "gone";
 
 // Max gap (ms, event-timeStamp domain) between two single-finger taps for a
 // double-tap zoom toggle. 300ms is the platform double-tap convention.
@@ -404,21 +411,82 @@ const TextPane: Component<{
 // 404 can't spin forever. The failed media element is unmounted —
 // a broken <img> would render its alt text (the raw URL) under the
 // failure line.
+//
+// issue 1889 — that failure text used to be ONE sentence for two situations.
+// A deleted or expired upload 404s, and "failed to load — try open in
+// browser" both blames the reader's browser and sends them to a route that
+// answers `{"error":"not_found"}` as JSON. So on failure this component asks
+// the server what it thinks (lib/mediaAvailability.ts) and, on a read 404 and
+// only then, refines `failed` into `gone`.
 const MediaViewerBody: Component<{
   state: MediaViewerState;
   onScale: (scale: number) => void;
   onTextPaneRef: (el: HTMLDivElement | undefined) => void;
   onTextSource: (source: TextResource | undefined) => void;
+  // issue 1889 — true once the probe has confirmed the server has nothing at
+  // this link. The header's "open in browser" anchor is suppressed on it.
+  onGone: (gone: boolean) => void;
 }> = (props) => {
   const [status, setStatus] = createSignal<MediaLoadStatus>("loading");
-  // Transitions only leave "loading" (review fix): a transient
+
+  // issue 1889 — the probe is cancelled when the viewer closes mid-flight
+  // (TextPane precedent, one component up). An abort resolves to "unknown", so
+  // a viewer that is already gone cannot come back and rewrite its own text.
+  const abort = new AbortController();
+  onCleanup(() => {
+    abort.abort();
+  });
+
+  // ELEMENT events only ever leave "loading" (review fix): a transient
   // mid-playback error must not unmount a ready element, and a suspend
   // arriving after a failure must not resurrect a dead one.
-  const settle = (next: MediaLoadStatus) => (): void => {
-    if (status() === "loading") setStatus(next);
+  const ready = (): void => {
+    if (status() === "loading") setStatus("ready");
   };
-  const ready = settle("ready");
-  const failed = settle("failed");
+
+  // The failure arm is no longer symmetric with `ready`, and that asymmetry is
+  // the point of issue 1889: recording the failure is only half of it, because
+  // "the element could not render this" and "the server does not have this any
+  // more" are the same event to an <img> and two different sentences to the
+  // reader. So the same handler that settles the failure asks the server which
+  // one it was. Fired from HERE and not from an effect on `status()`: the
+  // probe belongs to the transition that started it, exactly once per open,
+  // and an effect would re-run on the transition it is itself about to cause.
+  const failed = (): void => {
+    if (status() !== "loading") return;
+    setStatus("failed");
+    void refineFailure();
+  };
+
+  // The ONLY writer of "gone", and the only new arc in the machine:
+  // `failed → gone`, never from "loading" and never from "ready". The status
+  // is re-read AFTER the await because the arc is a refinement of the failure
+  // this probe was started by — it is the transition rule, stated where it is
+  // enforced, not a defensive re-check.
+  //
+  // 🔴 `probeMediaAvailability` answers "unknown" for every way it can itself
+  // fail, so there is no arm here that turns a broken network into "gone".
+  const refineFailure = async (): Promise<void> => {
+    const availability = await probeMediaAvailability(
+      props.state.href,
+      window.location.origin,
+      abort.signal,
+    );
+    if (availability === "gone" && status() === "failed") setStatus("gone");
+  };
+
+  // issue 1889 — the header's "open in browser" anchor lives one component up,
+  // and it has to go away on a gone upload. Published as the single BIT the
+  // parent needs rather than the whole status: handing `MediaViewerDialog` the
+  // enum would invite a second state machine up there, and there is exactly
+  // one question it has to answer.
+  //
+  // Derived in an effect, so it cannot drift from the status it mirrors — the
+  // `onTextSource` precedent below, and for the same reason: publishing from
+  // the render body would mutate a parent signal mid-commit.
+  createEffect(() => {
+    props.onGone(status() === "gone");
+  });
 
   // video/audio readiness: loadedmetadata is the normal terminator
   // (duration + dimensions; loadeddata never fires under
@@ -436,7 +504,7 @@ const MediaViewerBody: Component<{
         <div role="status" aria-label="Loading media" class="media-viewer-spinner" />
       </Show>
       <Show
-        when={status() === "failed"}
+        when={status() === "failed" || status() === "gone"}
         fallback={
           <Switch>
             <Match when={props.state.kind === "image"}>
@@ -488,7 +556,27 @@ const MediaViewerBody: Component<{
           </Switch>
         }
       >
-        <p class="muted media-viewer-error">failed to load — try "open in browser"</p>
+        {/* issue 1889 — a GONE upload gets its own sentence, and the
+            difference is not cosmetic: the generic line names the reader's
+            browser as the thing that failed and then sends them to a route
+            that serves `{"error":"not_found"}` as JSON. Two operators went
+            hunting a client bug on that advice.
+
+            What this sentence deliberately does NOT say: WHICH of the causes
+            it was, and WHEN. `UploadsController.show/2` answers the same 404
+            for a malformed slug, a missing row, a soft-deleted row, an expired
+            row and a row whose file is gone from disk — it gives no oracle, on
+            purpose, and that stays. So "expired or removed" names the two
+            likely causes without claiming to know, and no wording here may
+            ever grow an "expired at HH:MM". */}
+        <Show
+          when={status() === "gone"}
+          fallback={<p class="muted media-viewer-error">failed to load — try "open in browser"</p>}
+        >
+          <p class="muted media-viewer-error">
+            gone — the server has no file at this link (expired or removed)
+          </p>
+        </Show>
       </Show>
     </div>
   );
@@ -549,6 +637,12 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
   // says what the last attempt did.
   const [textSource, setTextSource] = createSignal<TextResource | undefined>(undefined);
   const [copyOutcome, setCopyOutcome] = createSignal<CopyOutcome>({ kind: "idle" });
+
+  // issue 1889 — has the body's probe confirmed the upload is gone? A signal
+  // because the header RENDERS from it, and fresh per open like everything
+  // else here: the keyed <Show> remounts this component for every viewer
+  // state, so there is no stale "gone" to carry into the next open.
+  const [gone, setGone] = createSignal(false);
 
   // Gating on the RESOURCE and not on `isText` is strictly stronger than the
   // issue asks: it also keeps the button off a pane that is still fetching or
@@ -668,17 +762,33 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
                 copy
               </button>
             </Show>
-            <a
-              href={props.state.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="media-viewer-open-external"
-              onClick={(e) => {
-                maybeEscapePwaClick(e, props.state.href);
-              }}
-            >
-              open in browser
-            </a>
+            {/* issue 1889 — suppressed once the probe has confirmed the
+                server has nothing at this link, and ONLY then. This is an
+                INTERPRETATION of the issue, declared rather than assumed: the
+                issue says of the 404 case *'No "open in browser" suggestion:
+                that route returns JSON, not an image'*, and the header anchor
+                is that same suggestion in another form — it lands on the same
+                route and shows the reader `{"error":"not_found"}`, which is
+                what sent two operators after a client bug.
+
+                Least surprise decides the rest: a line that says the file is
+                gone, sitting beside a LIVE control that opens it, contradicts
+                itself. Deliberately NOT extended to the generic `failed`
+                state, where "maybe it is your browser, try it over there" is
+                still a live hypothesis and the advice still earns its place. */}
+            <Show when={!gone()}>
+              <a
+                href={props.state.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="media-viewer-open-external"
+                onClick={(e) => {
+                  maybeEscapePwaClick(e, props.state.href);
+                }}
+              >
+                open in browser
+              </a>
+            </Show>
           </div>
           <button
             type="button"
@@ -709,6 +819,7 @@ const MediaViewerDialog: Component<{ state: MediaViewerState }> = (props) => {
             textPane = el;
           }}
           onTextSource={setTextSource}
+          onGone={setGone}
         />
       </div>
     </>

--- a/cicchetto/src/__tests__/MediaViewerModal.test.tsx
+++ b/cicchetto/src/__tests__/MediaViewerModal.test.tsx
@@ -291,6 +291,137 @@ describe("MediaViewerModal — loading state", () => {
   });
 });
 
+// issue 1889 — a deleted or expired upload 404s, and the viewer used to render
+// that exactly like a broken image: "failed to load — try open in browser",
+// where "open in browser" lands on the same route and serves
+// `{"error":"not_found"}` as JSON. Two operators went hunting a client bug.
+//
+// The probe's own decision table lives in mediaAvailability.test.ts against a
+// bare function. What is pinned HERE is the wiring only this component can get
+// wrong: that the failure transition asks at all, that a 404 changes what the
+// reader is told, and — the constraint that matters most — that nothing short
+// of a read 404 ever does.
+describe("MediaViewerModal — gone vs broken (issue 1889)", () => {
+  // The probe is same-origin gated, so the href has to BE same-origin for the
+  // component to reach the fetch at all. Built from the live origin rather
+  // than spelled out: jsdom's URL is config, not a fact this suite owns.
+  const OWN_UPLOAD_URL = `${window.location.origin}/uploads/abcdefghijklmnopqrstuvwxyz.png`;
+
+  const stubProbe = (respond: () => Promise<unknown>): Mock => {
+    const fetchMock = vi.fn(respond);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("a 404 on the failed upload says it is GONE, not that the load failed", async () => {
+    stubProbe(() => Promise.resolve({ status: 404 }));
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(OWN_UPLOAD_URL, "image");
+    container.querySelector("img")?.dispatchEvent(new Event("error"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/gone/i)).not.toBeNull();
+    });
+    // The generic line is REPLACED, not joined: it is the sentence that sent
+    // two operators after a client bug, and "open in browser" is bad advice
+    // for a route that answers JSON.
+    expect(screen.queryByText(/failed to load/i)).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  // 🔴 The hard constraint, from three directions. Saying "gone" when the
+  // upload is fine is worse than the generic message this change replaces.
+  it("a 200 keeps the generic text — the element failed for some other reason", async () => {
+    const fetchMock = stubProbe(() => Promise.resolve({ status: 200 }));
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(OWN_UPLOAD_URL, "image");
+    container.querySelector("img")?.dispatchEvent(new Event("error"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(screen.getByText(/failed to load/i)).not.toBeNull();
+    expect(screen.queryByText(/gone/i)).toBeNull();
+  });
+
+  it("a probe that never answers keeps the generic text — a dead network is not a deleted upload", async () => {
+    const fetchMock = stubProbe(() => Promise.reject(new TypeError("Failed to fetch")));
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(OWN_UPLOAD_URL, "image");
+    container.querySelector("img")?.dispatchEvent(new Event("error"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(screen.getByText(/failed to load/i)).not.toBeNull();
+    expect(screen.queryByText(/gone/i)).toBeNull();
+  });
+
+  it("a cross-host failure is never probed at all — connect-src would refuse it", async () => {
+    // Not merely "answers unknown": the request must not be ISSUED, because a
+    // blocked fetch is a securitypolicyviolation and the e2e _cspGuard fixture
+    // fails any spec whose journey raises one.
+    const fetchMock = stubProbe(() => Promise.resolve({ status: 404 }));
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer("https://elsewhere.example/pic.png", "image");
+    container.querySelector("img")?.dispatchEvent(new Event("error"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).not.toBeNull();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("a media element that LOADS is never probed — the refinement belongs to the failure", async () => {
+    const fetchMock = stubProbe(() => Promise.resolve({ status: 404 }));
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(OWN_UPLOAD_URL, "image");
+    container.querySelector("img")?.dispatchEvent(new Event("load"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByText(/gone/i)).toBeNull();
+  });
+
+  // The header anchor is the SAME advice in another form: it lands on the same
+  // route and shows the reader `{"error":"not_found"}`. A line saying the file
+  // is gone beside a live control that opens it contradicts itself.
+  it("takes 'open in browser' away once the upload is known gone", async () => {
+    stubProbe(() => Promise.resolve({ status: 404 }));
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(OWN_UPLOAD_URL, "image");
+    expect(screen.getByRole("link", { name: /open in browser/i })).not.toBeNull();
+
+    container.querySelector("img")?.dispatchEvent(new Event("error"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("link", { name: /open in browser/i })).toBeNull();
+    });
+  });
+
+  it("KEEPS 'open in browser' on a generic failure — there the advice is still live", async () => {
+    // The suppression is scoped to `gone` on purpose. On an ordinary failed
+    // load "maybe it is your browser, try it over there" is still a real
+    // hypothesis, and the escape hatch still earns its place.
+    const fetchMock = stubProbe(() => Promise.reject(new TypeError("Failed to fetch")));
+    const { container } = render(() => <MediaViewerModal />);
+    openMediaViewer(OWN_UPLOAD_URL, "image");
+    container.querySelector("img")?.dispatchEvent(new Event("error"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(screen.getByText(/failed to load/i)).not.toBeNull();
+    expect(screen.getByRole("link", { name: /open in browser/i })).not.toBeNull();
+  });
+});
+
 // #1438 — swipe up or down to dismiss. The binder's decision table (which
 // drags commit, which spring back, what it refuses to claim) is pinned in
 // mediaViewerGesture.test.ts against a bare element; what is asserted HERE is

--- a/cicchetto/src/__tests__/mediaAvailability.test.ts
+++ b/cicchetto/src/__tests__/mediaAvailability.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { probeMediaAvailability } from "../lib/mediaAvailability";
+
+// issue 1889 — the probe that separates a GONE upload from a broken one.
+//
+// The asymmetry is the whole test suite: "gone" must be earned by a 404 that
+// was actually read off the wire, while EVERY other outcome — including every
+// way the probe itself can break — must collapse to "unknown" so the viewer
+// keeps its generic text. Telling a reader "this upload is gone" because our
+// own request failed is a worse lie than the message this change replaces.
+
+const ORIGIN = "https://grappa.example";
+const OWN_HREF = `${ORIGIN}/uploads/abcdefghijklmnopqrstuvwxyz.png`;
+
+// Records every call so the cross-origin cases can assert the ABSENCE of a
+// request, not merely the answer: the point there is that the CSP is never
+// given a chance to refuse, and an answer alone cannot show that.
+function stubFetch(respond: (href: string, init: RequestInit | undefined) => Promise<unknown>): {
+  calls: { href: string; init: RequestInit | undefined }[];
+} {
+  const calls: { href: string; init: RequestInit | undefined }[] = [];
+  vi.stubGlobal("fetch", (href: string, init?: RequestInit) => {
+    calls.push({ href, init });
+    return respond(href, init);
+  });
+  return { calls };
+}
+
+const status = (code: number) => () => Promise.resolve({ status: code });
+
+const live = (): AbortSignal => new AbortController().signal;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("probeMediaAvailability", () => {
+  it("reads a 404 as gone", async () => {
+    stubFetch(status(404));
+    await expect(probeMediaAvailability(OWN_HREF, ORIGIN, live())).resolves.toBe("gone");
+  });
+
+  it("asks with HEAD, not GET — the bytes were already refused once", async () => {
+    // The element that failed has no status to read, so the status has to be
+    // asked for; asking with GET would re-download a body we are not going to
+    // render, including in the 200-but-undecodable case this probe exists to
+    // tell apart from a 404.
+    const { calls } = stubFetch(status(404));
+    await probeMediaAvailability(OWN_HREF, ORIGIN, live());
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.href).toBe(OWN_HREF);
+    expect(calls[0]?.init?.method).toBe("HEAD");
+  });
+
+  it("passes the caller's abort signal, so a closing viewer cancels the probe", async () => {
+    const controller = new AbortController();
+    const { calls } = stubFetch(status(404));
+    await probeMediaAvailability(OWN_HREF, ORIGIN, controller.signal);
+
+    expect(calls[0]?.init?.signal).toBe(controller.signal);
+  });
+
+  // 🔴 The hard constraint. Every arm below is a way the probe can fail to
+  // learn anything, and NONE of them may produce "gone".
+  describe("never says gone without a 404 it actually read", () => {
+    it("a 200 is unknown — the element failed for some other reason", async () => {
+      stubFetch(status(200));
+      await expect(probeMediaAvailability(OWN_HREF, ORIGIN, live())).resolves.toBe("unknown");
+    });
+
+    it("a 500 is unknown — the server is broken, not empty", async () => {
+      stubFetch(status(500));
+      await expect(probeMediaAvailability(OWN_HREF, ORIGIN, live())).resolves.toBe("unknown");
+    });
+
+    it("a 403 is unknown — refused is not absent", async () => {
+      stubFetch(status(403));
+      await expect(probeMediaAvailability(OWN_HREF, ORIGIN, live())).resolves.toBe("unknown");
+    });
+
+    it("a rejected fetch is unknown — a dead network must not read as a deleted upload", async () => {
+      stubFetch(() => Promise.reject(new TypeError("Failed to fetch")));
+      await expect(probeMediaAvailability(OWN_HREF, ORIGIN, live())).resolves.toBe("unknown");
+    });
+
+    it("an abort is unknown — closing the viewer mid-probe answers nothing", async () => {
+      const controller = new AbortController();
+      stubFetch(() => Promise.reject(new DOMException("Aborted", "AbortError")));
+      controller.abort();
+      await expect(probeMediaAvailability(OWN_HREF, ORIGIN, controller.signal)).resolves.toBe(
+        "unknown",
+      );
+    });
+  });
+
+  // Same-origin is a CSP gate, not an optimisation: `connect-src 'self'` is
+  // deliberately not widened to `https:` (unlike img-src / media-src), so a
+  // cross-host probe is refused by the policy AND raises a
+  // securitypolicyviolation the e2e _cspGuard fixture fails specs on. The
+  // absence of the request is therefore the contract, not just the answer.
+  describe("never probes off the page origin", () => {
+    it("a foreign host answers unknown without issuing a request", async () => {
+      const { calls } = stubFetch(status(404));
+      await expect(
+        probeMediaAvailability("https://elsewhere.example/pic.png", ORIGIN, live()),
+      ).resolves.toBe("unknown");
+      expect(calls).toEqual([]);
+    });
+
+    it("the SAME host on a different scheme is still off-origin", async () => {
+      // `mediaLink.sameHostHref` compares HOST and is scheme-agnostic on
+      // purpose (legacy http:// upload links live forever in scrollback), but
+      // `'self'` is scheme + host + port — reusing host equality here would
+      // admit a probe the CSP then refuses.
+      const { calls } = stubFetch(status(404));
+      await expect(
+        probeMediaAvailability("http://grappa.example/uploads/x.png", ORIGIN, live()),
+      ).resolves.toBe("unknown");
+      expect(calls).toEqual([]);
+    });
+
+    it("an unparseable href answers unknown without issuing a request", async () => {
+      const { calls } = stubFetch(status(404));
+      await expect(probeMediaAvailability("not a url", ORIGIN, live())).resolves.toBe("unknown");
+      expect(calls).toEqual([]);
+    });
+  });
+});

--- a/cicchetto/src/lib/mediaAvailability.ts
+++ b/cicchetto/src/lib/mediaAvailability.ts
@@ -1,0 +1,106 @@
+// Media availability probe — issue 1889.
+//
+// Pure module (no SolidJS, no DOM beyond `fetch`) — same separation as
+// `mediaLink.ts` and `textResource.ts`: this owns "what did the server say
+// about this URL", `MediaViewerModal.tsx` owns what the reader is told.
+//
+// ## Why this exists
+//
+// An upload link posted in channel keeps its href forever, but the bytes do
+// not: the row is soft-deleted (admin delete, reaper expiry) or hard-deleted,
+// and from that moment `GET /uploads/<slug>.<ext>` answers 404. The viewer
+// used to render that exactly like a broken image — "failed to load — try
+// open in browser" — and that advice is wrong twice over: the browser did not
+// fail, and "open in browser" lands on the same route, which serves
+// `{"error":"not_found"}` as JSON. Two operators went looking for a client bug
+// because of it.
+//
+// ## Why a separate request, and why HEAD
+//
+// The `error` event of `<img>` / `<video>` / `<audio>` carries NO status —
+// there is no response to read off the element that failed. Only the `text`
+// arm fetches, and it already discards the status inside `fetchTextResource`.
+// So the status has to be asked for, and one probe for all four kinds beats
+// one probe plus a special case: the round-trip is paid ONLY on the failure
+// path, which is cold.
+//
+// HEAD rather than GET because the question is "does the server still have
+// this?", not "give me the bytes": a 200-but-undecodable response (corrupt
+// image, wrong mime) must not be downloaded a second time to be told it is
+// not a 404. `Plug.Head` sits above the router in the endpoint, so HEAD shares
+// the GET route and returns the SAME status the element saw — there is no
+// second server code path to keep in step.
+//
+// ## Same-origin is a GATE, not an optimisation
+//
+// `connect-src` is `'self'` plus the captcha hosts and two audio hosts — it is
+// deliberately NOT widened to `https:`, unlike `img-src` / `media-src`
+// (GrappaWeb.Plugs.SecurityHeaders). So a cross-host probe would be REFUSED by
+// the policy: no answer, plus a `securitypolicyviolation` the e2e `_cspGuard`
+// fixture fails specs on. This is the same boundary that keeps `.txt` /`.md`
+// admitted-host only (see `mediaLink.ts`) — reused, not invented.
+//
+// It costs nothing in coverage: `classifyMediaLink` RE-ROOTS an admitted host
+// (page origin ∪ the #324 deployment aliases) onto the page origin, so every
+// own upload arrives here same-origin by construction, and a genuinely foreign
+// host keeps its absolute href and is excluded — which is right, because
+// another deployment's 404 is not ours to interpret.
+//
+// ORIGIN equality, deliberately not the HOST equality `mediaLink.sameHostHref`
+// does. That one is scheme-agnostic on purpose (legacy `http://` upload links
+// in permanent scrollback) and then re-roots; `'self'` is scheme + host + port,
+// so host equality would admit a probe the CSP then refuses. The near-miss is
+// exactly the kind of reuse that would look right and fail in production only.
+
+/**
+ * What the server said about a media URL that failed to load.
+ *
+ * `"gone"` is a POSITIVE answer — a 404 was actually read off the wire.
+ * `"unknown"` is everything else, including every way the probe itself can
+ * fail. A closed set of two rather than a status number: the only distinction
+ * the reader is owed is "the server says there is nothing here" vs "we do not
+ * know", and a number would invite a third caller to invent a third sentence.
+ */
+export type MediaAvailability = "gone" | "unknown";
+
+/**
+ * Ask the server whether a media URL is still there.
+ *
+ * 🔴 A failure of the PROBE never produces `"gone"`. Network down, CSP
+ * refusal, an abort when the viewer closes mid-flight, a response we cannot
+ * make sense of — all answer `"unknown"`, and the caller keeps today's generic
+ * failure text. Telling a reader "this is gone" because OUR request failed is
+ * a worse lie than the generic message this whole change exists to replace.
+ *
+ * @param href the viewer-safe href from `classifyMediaLink` — re-rooted on the
+ *   page origin for an admitted host, unchanged (and therefore skipped here)
+ *   for a foreign one.
+ * @param origin `window.location.origin` at the call site — injected so this
+ *   module stays pure and table-testable.
+ * @param signal aborts the probe when the viewer closes mid-flight.
+ */
+export async function probeMediaAvailability(
+  href: string,
+  origin: string,
+  signal: AbortSignal,
+): Promise<MediaAvailability> {
+  // Checked BEFORE the request, not after a rejection: a cross-host probe is a
+  // CSP violation event, and the e2e guard fails on those whether or not we
+  // handle the resulting error.
+  if (!isSameOrigin(href, origin)) return "unknown";
+
+  try {
+    const response = await fetch(href, { method: "HEAD", signal });
+    return response.status === 404 ? "gone" : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function isSameOrigin(href: string, origin: string): boolean {
+  try {
+    return new URL(href).origin === origin;
+  } catch {
+    return false;
+  }
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44796,3 +44796,95 @@ shapes, not one episode and a shorter version of it.
   lock with no row here. Widening the seam to cover them is a separate
   slice, deliberately not taken in this one: without the bracket above, it
   would produce a row whose only door is the one under suspicion.
+<!-- entry #1889 -->
+
+---
+
+## 2026-09-01 — 1889: a 404 is a fact the client can read, and refused to
+
+`cicchetto`'s media viewer rendered a deleted or expired upload exactly like
+a broken image: `failed to load — try "open in browser"`. Both halves are
+wrong for that case. The browser did not fail, and "open in browser" lands
+on the same route, which serves `{"error":"not_found"}` as JSON. Two
+operators reported it independently, and the message sent both of them
+looking for a client bug.
+
+### Why the status had to be asked for
+
+The `error` event of `<img>` / `<video>` / `<audio>` carries no status.
+There is no response to read off the element that failed, so the option of
+"use the failed element's own response" — which the issue left open — does
+not exist for three of the four viewer kinds. Only the `text` arm fetches,
+and it discards the status inside `fetchTextResource`. That measurement is
+what made the choice, not a preference.
+
+`HEAD`, not `GET`: the question is whether the server still has the file,
+and a 200-but-undecodable response (corrupt image, wrong mime) must not be
+downloaded a second time to be told it is not a 404. `Plug.Head` sits above
+the router in the endpoint, so HEAD shares the GET route and answers with
+the same status the element saw — one server path, not two. One probe for
+all four kinds rather than one probe plus a special case for `text`: the
+round-trip is paid only on the failure path, which is cold.
+
+### Same-origin is a CSP gate, and it was already there
+
+`connect-src` is `'self'` plus the captcha hosts and two audio hosts. It is
+deliberately NOT widened to `https:`, unlike `img-src` / `media-src` — an
+element source can only be rendered, whereas `fetch` can read a response
+body. So a cross-host probe is refused by the policy and raises a
+`securitypolicyviolation` that the e2e `_cspGuard` fixture fails specs on.
+This is the same boundary that keeps `.txt` / `.md` admitted-host only
+(#1764); reusing it beat inventing a scope rule.
+
+It costs no coverage. `classifyMediaLink` re-roots an admitted host (page
+origin ∪ the #324 deployment aliases) onto the page origin, so every own
+upload arrives at the viewer same-origin by construction, and a genuinely
+foreign host keeps its absolute href — another deployment's 404 is not ours
+to interpret anyway.
+
+ORIGIN equality, deliberately not the HOST equality `mediaLink.sameHostHref`
+uses. That one is scheme-agnostic on purpose (legacy `http://` upload links
+live forever in scrollback) and then re-roots; `'self'` is scheme + host +
+port. Reusing host equality here would look right and admit a probe the CSP
+then refuses.
+
+### The rule that matters more than the feature
+
+🔴 **A failure of the probe never produces "gone".** Dead network, CSP
+refusal, an abort when the viewer closes mid-flight, a response we cannot
+read — all answer `unknown`, and the reader keeps the generic text. Saying
+"your upload is gone" because OUR request broke is a worse lie than the
+message this change replaces. Enforced by the return type being a closed
+two-member set where `gone` is earned only by a 404 read off the wire, and
+asserted on two planes: a table over the probe, and the visible outcome in
+the viewer.
+
+### What this message can never say, on purpose
+
+`UploadsController.show/2` answers the same 404 for **five** distinct
+causes: a malformed slug, a missing row, a soft-deleted row, an expired row,
+and a row whose file is gone from disk. It gives no oracle, and that is
+correct and stays. So the client can say the file is not there, and can
+never say which of the five, never say *expired at HH:MM*, and cannot even
+separate "removed" from "a slug that never existed". `(expired or removed)`
+names the two likely causes without claiming to know. The noun is neutral
+rather than "this upload" because classifier rule 3 admits any same-origin
+media, not only `/uploads/`.
+
+### The interpretation, declared
+
+The header's "open in browser" anchor is suppressed in `gone`, and only
+there. The issue says of the 404 case *"No `open in browser` suggestion:
+that route returns JSON, not an image"*, and the anchor is that same
+suggestion in another form — same route, same raw JSON, the exact trap that
+cost two operators their afternoon. Least surprise finishes it: a line
+saying the file is gone, beside a live control that opens it, contradicts
+itself. On a generic `failed` the advice stays, because there "maybe it is
+your browser, try it over there" is still a live hypothesis.
+
+### Scope
+
+Client only. The server behaviour — row gone ⇒ 404, no oracle — is correct
+and untouched. The disk-side half of the same incident (account deletion
+cascades the rows but never unlinks the files) is a separate issue and is
+not addressed here.


### PR DESCRIPTION
Client-side only, per the scope in issue 1889. The server behaviour — row gone ⇒ 404, no oracle — is correct and untouched; the disk-side half of the same incident is a separate issue and is not addressed here.

## The defect

A deleted or expired upload 404s, and the media viewer rendered that exactly like a broken image:

```
failed to load — try "open in browser"
```

Both halves are wrong for this case. The browser did not fail, and "open in browser" lands on the same route, which serves `{"error":"not_found"}` as JSON. Two operators reported it independently, and the message sent both of them looking for a client bug.

## The probe, and the alternative a measurement killed

The issue left the probe shape to the implementer — HEAD, or the failed element's own response. **The second one does not exist**, and that is a measurement rather than a preference: the `error` event of `<img>` / `<video>` / `<audio>` carries no status, so there is nothing to read off three of the four viewer kinds. Only the `text` arm fetches, and it discards the status inside `fetchTextResource`. Recording it here because the next reader will reach for the cheaper-looking option and has no way to see it was measured away rather than skipped.

So: **`HEAD`**, in one place, for all four kinds.

- `HEAD` not `GET` — the question is whether the server still has the file, and a 200-but-undecodable response (corrupt image, wrong mime) must not be downloaded a second time to be told it is not a 404. `Plug.Head` sits above the router in the endpoint, so HEAD shares the GET route and answers with the same status the element saw: one server path, not two.
- One probe for all four kinds rather than one probe plus a `text` special case. The round-trip is paid only on the failure path, which is cold.

## Same-origin is a CSP gate, not an optimisation

`connect-src` is `'self'` plus the captcha hosts and two audio hosts, deliberately **not** widened to `https:` the way `img-src` / `media-src` are. A cross-host probe would be refused by the policy and would raise a `securitypolicyviolation` that the e2e `_cspGuard` fixture fails specs on. This reuses the boundary that already keeps `.txt` / `.md` admitted-host only (#1764) instead of inventing a scope rule.

It costs no coverage: `classifyMediaLink` re-roots an admitted host (page origin ∪ the #324 aliases) onto the page origin, so every own upload arrives same-origin by construction.

ORIGIN equality, deliberately **not** the HOST equality `mediaLink.sameHostHref` uses — that one is scheme-agnostic on purpose (legacy `http://` upload links live forever in scrollback) and then re-roots, while `'self'` is scheme + host + port. Reusing host equality here would look right and admit a probe the CSP then refuses.

## 🔴 A failure of the probe never produces "gone"

Dead network, CSP refusal, an abort when the viewer closes mid-flight, a response we cannot read — all answer `unknown`, and the reader keeps today's generic text. Telling someone their upload is gone because *our* request broke is a worse lie than the message this change replaces.

Enforced by the return type (a closed two-member set where `gone` is earned only by a 404 actually read off the wire), and asserted on two planes rather than deduced from that type: a table over the probe (200 / 403 / 500 / rejected fetch / abort), and the **visible outcome** in the viewer (`a 200 keeps the generic text`, `a probe that never answers keeps the generic text`).

## What the new message can never say — a deliberate limit, not a follow-up

`UploadsController.show/2` answers the same 404 for **five** distinct causes: a malformed slug, a missing row, a soft-deleted row, an expired row, and a row whose file is gone from disk. It gives no oracle, and that is correct and stays.

So the client can say the file is not there, and can never say which of the five, never say *expired at HH:MM*, and **cannot even separate "removed" from "a slug that never existed"**. The wording is:

```
gone — the server has no file at this link (expired or removed)
```

`(expired or removed)` names the two likely causes without claiming to know. The noun is neutral rather than "this upload" because classifier rule 3 admits any same-origin media, not only `/uploads/`.

## The one interpretation, declared

The header's **"open in browser" anchor is suppressed in `gone`, and only there.** This goes past the issue's literal words, so it is stated rather than assumed.

The issue says of the 404 case:

> `404` … → "this upload is no longer available (expired or removed)".
> **No "open in browser" suggestion: that route returns JSON, not an image.**

The header anchor is that same suggestion in another form — same route, same raw JSON, the exact trap that cost two operators their afternoon. Least surprise finishes the argument: a line saying the file is gone, beside a live control that opens it, contradicts itself.

Scoped to `gone` on purpose: on a generic `failed`, "maybe it is your browser, try it over there" is still a live hypothesis and the escape hatch keeps earning its place. Isolated to one published bit and one `<Show>`, so it reverts small if read differently.

## Shape

`gone` joins the closed `MediaLoadStatus` set as a **refinement** of `failed`, not as a fifth thing that can happen to a load — the element failed either way, and the only difference is that the server was asked afterwards. One set rather than a second "is it gone" signal beside the status: two values to keep in step for one paragraph of text is a parallel structure that will drift. Element events still only ever leave `loading`; the single new arc is `failed → gone`, written only by the probe that that failure started.

## Tests

**e2e** — a real upload through the real picker, removed the way an operator removes one (`DELETE /admin/uploads/:id`, which unlinks the file and then soft-deletes the row), clicked from the row it left behind. **No `page.route` anywhere**: the thing under test is that cic now believes the *server*, so a fulfilled fake would exercise the branch and prove nothing about the route it is about. Asserted on the visible outcome — gone text present, generic line absent, no spinner, no clickable escape to raw JSON — never on "the probe was called".

Two ordering choices are load-bearing: the delete happens *before* the first open (a successfully fetched image is served from memory cache on a later click and would neither fail nor be probed), and the 404 is asserted as a precondition from the runner so a delete that silently did nothing surfaces as itself.

**unit** — the probe's decision table against a bare function; the wiring only the component can get wrong against the component.
