### PR TITLE
uploads: unlink the bytes the FK cascade leaves behind

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44888,3 +44888,87 @@ Client only. The server behaviour — row gone ⇒ 404, no oracle — is correct
 and untouched. The disk-side half of the same incident (account deletion
 cascades the rows but never unlinks the files) is a separate issue and is
 not addressed here.
+<!-- entry #1890 -->
+
+---
+
+## 2026-09-01 — #1890: the cascade takes the rows and leaves the bytes
+
+Account deletion removed a subject's `uploads` ROWS and left the FILES on
+disk. `uploads.user_id` / `uploads.visitor_id` carry `ON DELETE CASCADE`, and
+nothing on any deletion path called `File.rm/1`. The bytes then became
+unreachable (row gone ⇒ 404), invisible to `Grappa.Uploads.Reaper` (which
+sweeps ROWS and unlinks from them), and uncounted by `live_bytes_sum/0`
+(row-derived) — so the global-cap accounting drifted from real disk usage
+with no signal anywhere.
+
+### The fix goes at the chokepoints, not at the door the issue named
+
+The issue named `AccountDeletion.delete_account/1`. Measured, that is one of
+**five** doors that destroy a subject, and the smallest: `Operator.delete_user/2`
+and `Operator.delete_visitor/2` (admin), `Visitors.purge_if_anon/1` (anon
+co-terminus), and — the one with by far the highest cadence —
+`Grappa.Visitors.Reaper`'s **60-second** sweep of expired visitors. Repairing
+the self-delete door alone would have left the automatic door leaking on a
+one-minute tick.
+
+All five funnel through exactly two functions, so the unlink sits there:
+`Accounts.delete_user/1` and `Visitors.destroy_visitor/1`. `destroy_visitor/1`
+and not `Visitors.delete/1`, because `purge_if_anon/1` reaches the former
+without passing the latter.
+
+`Uploads.delete_all_for_subject/1` replaces the former
+`delete_all_for_user/1`, whose `@doc` declared it test-support-only and
+asserted that "production lifecycle uses `soft_delete/2`" — a sentence that
+becomes false the instant production calls it. It takes `Subject.t()` (the
+bare-id tuple both call sites already hold) and queries through the existing
+`Subject.subject_where/2`, so the two arms differ only in an FK column and no
+second query idiom is introduced. Its one previous caller, the test harness,
+moved with it: no half-migration, no two spellings of one verb.
+
+### Why a failed unlink is logged rather than discarded or retried
+
+`Uploads.Reaper.unlink_then_soft_delete/3` can afford to leave a row alone
+when `File.rm/1` fails, because **the row IS its retry token** and the next
+sweep tries again. On the deletion path the row is about to be destroyed, so
+no retry token will ever exist — the reaper's third arm is structurally
+unavailable here, and a discarded error is a permanent leak that nothing can
+later detect.
+
+So the three outcomes stay apart. `:ok` proceeds. `{:error, :enoent}` is NOT
+a failure and is deliberately kept OUT of the log — it is the expected
+idempotent case (the reaper or a prior partial run got there first), and
+logging it would drown the one line that matters. `{:error, reason}` logs the
+slug and **continues**: a read-only disk must not hold someone's right to be
+deleted hostage, and the log line is the only surrogate for the retry token
+being destroyed. The metadata shape mirrors the reaper's own failure line
+(`upload_id` / `slug` / `error`), all three already in the Logger allowlist,
+so this costs no `config/` edit.
+
+On the visitor side the call sits INSIDE the existing `Repo.BusyRetry.run/1`
+block, beside the published-theme re-home — which is the same figure: a
+pre-delete step disposing of something the cascade would otherwise destroy
+without cleaning up. Inside and not before, so a sustained SQLITE_BUSY still
+degrades to `{:error, :db_unavailable}` for every caller rather than raising
+past it; re-running is safe because the second pass finds no rows and an
+already-unlinked file answers `:enoent`.
+
+### Measured, and deliberately not claimed
+
+`storage_path/2` has been `Path.join(storage_root, slug)` — no extension —
+since the commit that introduced it (`61269ebe7`); the only other commit
+touching that name merely added a caller, and no commit in the file's history
+ever composed a filename with an extension. So unlinking by slug cannot miss
+a historically differently-named file.
+
+Peer avatars are NOT in this class: `peer_avatars.network_id` references
+`networks`, which carries no owner column, so destroying a subject never
+cascades them. Theme background images ARE covered, because
+`Themes.BackgroundImage` stores them through `Uploads.create/3`.
+
+Not claimed: that self-delete is the dominant source of orphans. The visitor
+reaper has the higher cadence and passes through the same hole, but neither
+the expiry rate nor how many expiring visitors hold uploads was measured —
+that is structure, not magnitude. Nor is the volume of already-orphaned bytes
+on production established; the defect is proved from the code, and the
+one-off sweep for existing orphans is a separate deliverable.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -87,6 +87,11 @@ defmodule Grappa.Accounts do
       Grappa.EncryptedBinary,
       Grappa.IRC,
       Grappa.Repo,
+      # Issue 1890 — `delete_user/1` unlinks the departing user's upload
+      # bytes before the FK cascade drops the rows that name them. The
+      # CONTEXT and not the `Upload` leaf: what is needed here is the
+      # verb, not the struct.
+      Grappa.Uploads,
       Grappa.Visitors.Visitor
     ],
     exports: [Wire, AdminWire, Login, TOTP, TOTPRecoveryCode, Passkey, WebAuthn]
@@ -96,7 +101,7 @@ defmodule Grappa.Accounts do
   alias Grappa.Accounts.{Passkey, RecoveryCodes, Revocations, Session, TOTP, TOTPRecoveryCode, User}
   alias Grappa.Ecto.Like
   alias Grappa.IRC.Identifier
-  alias Grappa.Repo
+  alias Grappa.{Repo, Uploads}
   alias Grappa.Visitors.Visitor
 
   require Identifier
@@ -463,6 +468,14 @@ defmodule Grappa.Accounts do
         if current.is_admin and other_admins_count(id) == 0 do
           {:error, :last_admin}
         else
+          # Issue 1890 — BEFORE the delete, because the `uploads.user_id`
+          # CASCADE below takes the ROWS and nothing takes the FILES, and
+          # once the rows are gone no record of which slugs to unlink
+          # survives anywhere. Every door that destroys a user funnels
+          # through here (self-delete, admin delete, the test harness), so
+          # this is the one place the unlink has to sit.
+          :ok = Uploads.delete_all_for_subject({:user, id})
+
           {:ok, _} = Repo.delete(user)
           # The CASCADE takes the `accounts_sessions` rows with the user row,
           # so the socket teardown has to be announced here: nothing

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -237,7 +237,7 @@ if Mix.env() in [:dev, :test] do
       :ok = QueryWindows.close_all_for_user(user.id)
       :ok = Push.subscription_clear_all_for_user(user.id)
       :ok = UserSettings.reset_for_user(user.id)
-      :ok = Uploads.delete_all_for_user(user.id)
+      :ok = Uploads.delete_all_for_subject({:user, user.id})
       # S1 (#364) — drain the #247 watch list too. Without this, a spec's
       # `/notify add` rows survive the reset baseline AND re-arm MONITOR/WATCH
       # on the respawned Session.Server (which reads Notify.list/2 at

--- a/lib/grappa/uploads.ex
+++ b/lib/grappa/uploads.ex
@@ -33,6 +33,10 @@ defmodule Grappa.Uploads do
       `expires_at <= now()` AND `deleted_at IS NULL`.
     * `soft_delete/2` — flips `deleted_at`. The caller MUST `File.rm/1`
       the on-disk file FIRST (Reaper does this in `sweep/0`).
+    * `delete_all_for_subject/1` — HARD-deletes a departing subject's
+      uploads, bytes first. Called from the two chokepoints every
+      subject-destroying door funnels through, because the FK cascade
+      takes the rows and leaves the files (issue 1890).
     * `storage_path/2` — joins `storage_root` + slug, base32-validates
       the slug. Used by `create/3` to write, by the controller to
       read, by Reaper to unlink.
@@ -84,6 +88,8 @@ defmodule Grappa.Uploads do
 
   alias Grappa.{Repo, Subject}
   alias Grappa.Uploads.{ContentType, MetadataStrip, Upload}
+
+  require Logger
 
   @slug_byte_size 16
   @slug_regex ~r/\A[a-z2-7]{26}\z/
@@ -426,28 +432,69 @@ defmodule Grappa.Uploads do
   end
 
   @doc """
-  Test-support: HARD-deletes every `uploads` row for `user_id` and
-  removes the corresponding on-disk files. Intended for
-  `Grappa.TestSupport.SubjectReset` only — production lifecycle uses
-  `soft_delete/2` (which the reaper sweeps in
-  `Grappa.Uploads.Reaper.sweep/2`).
+  HARD-delete every upload owned by `subject` — the on-disk bytes FIRST,
+  the row after. Returns `:ok`; idempotent when the subject owns none.
 
-  Iterates per-row to mirror the admin DELETE controller pattern
-  (`File.rm(path)` then row removal). Idempotent if the user has no
-  rows. `File.rm/1` result discarded — a file already swept by the
-  reaper is the expected idempotent case.
+  Called from the two chokepoints that every subject-destroying door
+  funnels through — `Grappa.Accounts.delete_user/1` and
+  `Grappa.Visitors.destroy_visitor/1` — because `uploads.user_id` /
+  `uploads.visitor_id` carry `ON DELETE CASCADE`, which takes the ROWS
+  and leaves the FILES (issue 1890). Routing it at the chokepoints and
+  not at the self-delete door is deliberate: five doors reach those two
+  functions, and the highest-cadence one is `Grappa.Visitors.Reaper`'s
+  60-second sweep, not self-delete.
+
+  ## Why the unlink cannot fail silently here
+
+  `Grappa.Uploads.Reaper` can afford to leave a row alone when
+  `File.rm/1` fails: the ROW IS ITS RETRY TOKEN, and the next sweep
+  tries again. On this path the row is about to be destroyed, so no
+  retry token will ever exist — a discarded error becomes a permanent
+  leak that nothing can later detect, which is the silent-swallow
+  CLAUDE.md forbids at a boundary. So the three outcomes stay apart:
+
+    * `:ok` — unlinked.
+    * `{:error, :enoent}` — NOT a failure, the expected idempotent case
+      (the reaper or a prior partial run got there first). Logging it
+      would drown the one line below that matters.
+    * `{:error, reason}` — logged with the slug, and the deletion
+      CONTINUES. A read-only disk must not hold someone's right to be
+      deleted hostage; the log line is the only surrogate for the retry
+      token being destroyed, and the slug is what makes the leaked
+      bytes findable afterwards.
   """
-  @spec delete_all_for_user(Ecto.UUID.t()) :: :ok
-  def delete_all_for_user(user_id) when is_binary(user_id) do
+  @spec delete_all_for_subject(Subject.t()) :: :ok
+  def delete_all_for_subject(subject) do
     storage_root = storage_root()
-    query = from(u in Upload, where: u.user_id == ^user_id)
-    rows = Repo.all(query)
 
-    Enum.each(rows, fn %Upload{slug: slug} = up ->
-      _ = File.rm(storage_path(storage_root, slug))
-      Repo.delete!(up)
-    end)
+    Upload
+    |> Subject.subject_where(subject)
+    |> Repo.all()
+    |> Enum.each(&unlink_then_delete(&1, storage_root))
 
+    :ok
+  end
+
+  @spec unlink_then_delete(Upload.t(), Path.t()) :: :ok
+  defp unlink_then_delete(%Upload{slug: slug} = up, storage_root) do
+    case File.rm(storage_path(storage_root, slug)) do
+      :ok ->
+        :ok
+
+      {:error, :enoent} ->
+        :ok
+
+      {:error, reason} ->
+        # Same metadata shape as `Grappa.Uploads.Reaper`'s failure line —
+        # one greppable message, the identifiers as structured fields.
+        Logger.error("upload orphaned: unlink failed, row deleted anyway",
+          upload_id: up.id,
+          slug: slug,
+          error: inspect(reason)
+        )
+    end
+
+    _ = Repo.delete!(up)
     :ok
   end
 end

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -79,6 +79,10 @@ defmodule Grappa.Visitors do
       Grappa.SpawnOrchestrator,
       Grappa.Subject,
       Grappa.Themes,
+      # Issue 1890 — `destroy_visitor/1` unlinks the visitor's upload bytes
+      # before the FK cascade drops the rows that name them. The CONTEXT and
+      # not the `Upload` leaf: what is needed here is the verb, not the struct.
+      Grappa.Uploads,
       Grappa.UserSettings,
       # #645 — Login records the client source prefix before it spawns, so a
       # first-time visitor is not held by mode-2 addressing.
@@ -90,7 +94,7 @@ defmodule Grappa.Visitors do
   import Ecto.Query
 
   alias Grappa.Accounts.Revocations
-  alias Grappa.{Admission, Networks, Repo, Session, SpawnOrchestrator, Themes, UserSettings}
+  alias Grappa.{Admission, Networks, Repo, Session, SpawnOrchestrator, Themes, Uploads, UserSettings}
   alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.Visitors.{SessionPlan, Visitor}
 
@@ -841,6 +845,18 @@ defmodule Grappa.Visitors do
     outcome =
       Repo.BusyRetry.run(fn ->
         Themes.rehome_visitor_published_to_system(visitor.id)
+        # Issue 1890 — the second pre-delete step, and the same shape as the
+        # re-home above: something the `visitor_id` CASCADE would otherwise
+        # destroy without disposing of it. Here it is the upload FILES —
+        # the cascade takes the rows and leaves the bytes, and once the rows
+        # are gone nothing names the slugs to unlink.
+        #
+        # INSIDE the retry, not before it, so a sustained SQLITE_BUSY still
+        # degrades to `{:error, :db_unavailable}` for every caller instead
+        # of raising past it. Re-running it is safe: the second pass finds
+        # no rows, and a file already unlinked answers `:enoent`, which
+        # `delete_all_for_subject/1` treats as the idempotent case.
+        :ok = Uploads.delete_all_for_subject({:visitor, visitor.id})
         {:ok, _} = Repo.delete(visitor)
         {:ok, :deleted}
       end)

--- a/test/grappa/uploads_subject_deletion_test.exs
+++ b/test/grappa/uploads_subject_deletion_test.exs
@@ -1,0 +1,153 @@
+defmodule Grappa.UploadsSubjectDeletionTest do
+  # `async: false`: these exercise the PRODUCTION chokepoints, which read the
+  # storage root from `:persistent_term` (`Uploads.boot/1`) rather than from a
+  # per-call `:storage_root` opt. Booting a per-test root is global state, so
+  # this module cannot share the scheduler with anything that reads it — the
+  # same posture `GrappaWeb.Admin.UploadsControllerTest` already takes.
+  use Grappa.DataCase, async: false
+
+  import ExUnit.CaptureLog
+  import Grappa.AuthFixtures, only: [user_fixture: 1, visitor_fixture: 1]
+
+  alias Grappa.{Accounts, Uploads, Visitors}
+
+  setup do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "grappa_subject_deletion_test_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(root)
+
+    original_root = Uploads.storage_root()
+    :ok = Uploads.boot(root)
+
+    on_exit(fn ->
+      :ok = Uploads.boot(original_root)
+      File.rm_rf!(root)
+    end)
+
+    %{root: root}
+  end
+
+  defp upload_for(subject, root) do
+    {:ok, row} =
+      Uploads.create(
+        "bytes-that-must-not-survive-#{System.unique_integer([:positive])}",
+        %{
+          subject: subject,
+          mime: "text/plain",
+          expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+        },
+        storage_root: root
+      )
+
+    {row, Uploads.storage_path(root, row.slug)}
+  end
+
+  describe "Accounts.delete_user/1 — the user chokepoint" do
+    test "the bytes are gone from the disk, not merely the row", %{root: root} do
+      user = user_fixture([])
+      {row, path} = upload_for({:user, user.id}, root)
+
+      # Pre-state asserted before the gesture: without this the post-assert
+      # would pass on a file that was never written.
+      assert File.exists?(path)
+
+      assert :ok = Accounts.delete_user(user)
+
+      refute File.exists?(path)
+      assert Uploads.get_by_id(row.id) == {:error, :not_found}
+    end
+
+    test "another user's bytes are untouched", %{root: root} do
+      user = user_fixture([])
+      other = user_fixture([])
+      {_, path} = upload_for({:user, user.id}, root)
+      {other_row, other_path} = upload_for({:user, other.id}, root)
+
+      assert :ok = Accounts.delete_user(user)
+
+      refute File.exists?(path)
+      assert File.exists?(other_path)
+      assert {:ok, _} = Uploads.get_by_id(other_row.id)
+    end
+
+    test "a user with no uploads deletes cleanly" do
+      user = user_fixture([])
+      assert :ok = Accounts.delete_user(user)
+    end
+  end
+
+  describe "Visitors.delete/1 — the visitor chokepoint" do
+    test "the bytes are gone from the disk", %{root: root} do
+      visitor = visitor_fixture([])
+      {row, path} = upload_for({:visitor, visitor.id}, root)
+
+      assert File.exists?(path)
+
+      assert :ok = Visitors.delete(visitor.id)
+
+      refute File.exists?(path)
+      assert Uploads.get_by_id(row.id) == {:error, :not_found}
+    end
+  end
+
+  describe "a failing unlink" do
+    # The failure is forced by putting a DIRECTORY where the file belongs:
+    # `File.rm/1` refuses on every platform we run on. The errno differs
+    # (BSD `:eperm`, Linux `:eisdir`), so nothing here asserts WHICH — the
+    # production arm treats every non-`:enoent` reason the same way, and
+    # pinning the errno would make this red on the other kernel.
+    #
+    # Read-only-parent (`chmod`) was rejected: CI runs the container as root,
+    # and root ignores the permission bits, so that setup would pass the test
+    # vacuously on exactly the platform that gates the merge.
+    defp break_unlink!(path) do
+      File.rm!(path)
+      File.mkdir!(path)
+      assert {:error, _} = File.rm(path)
+    end
+
+    test "does not stop the account deletion", %{root: root} do
+      user = user_fixture([])
+      {row, path} = upload_for({:user, user.id}, root)
+      break_unlink!(path)
+
+      capture_log(fn -> assert :ok = Accounts.delete_user(user) end)
+
+      # The account is gone even though its bytes could not be unlinked —
+      # a read-only disk must not hold someone's deletion hostage.
+      assert Accounts.get_user(user.id) == nil
+      assert Uploads.get_by_id(row.id) == {:error, :not_found}
+    end
+
+    test "says so in the log, with the slug that leaked", %{root: root} do
+      user = user_fixture([])
+      {row, path} = upload_for({:user, user.id}, root)
+      break_unlink!(path)
+
+      log = capture_log(fn -> assert :ok = Accounts.delete_user(user) end)
+
+      # The row is the reaper's retry token and it is about to be destroyed,
+      # so this line is the ONLY surviving record of which bytes leaked. It
+      # has to carry the slug, or it names no file.
+      assert log =~ "upload orphaned"
+      assert log =~ row.slug
+    end
+
+    test "an already-missing file is NOT reported as a failure", %{root: root} do
+      user = user_fixture([])
+      {_, path} = upload_for({:user, user.id}, root)
+      File.rm!(path)
+
+      log = capture_log(fn -> assert :ok = Accounts.delete_user(user) end)
+
+      # `:enoent` is the expected idempotent case (the reaper got there
+      # first, or a prior partial run did). Logging it as a failure would
+      # drown the signal the test above depends on.
+      refute log =~ "upload orphaned"
+    end
+  end
+end

--- a/test/grappa/uploads_test.exs
+++ b/test/grappa/uploads_test.exs
@@ -403,7 +403,7 @@ defmodule Grappa.UploadsTest do
     end
   end
 
-  describe "delete_all_for_user/1" do
+  describe "delete_all_for_subject/1" do
     test "deletes every uploads row for the user AND removes their files", %{root: root} do
       user = user_fixture([])
       other = user_fixture([])
@@ -449,7 +449,7 @@ defmodule Grappa.UploadsTest do
       :ok = Uploads.boot(root)
       on_exit(fn -> :ok = Uploads.boot(original_root) end)
 
-      assert :ok = Uploads.delete_all_for_user(user.id)
+      assert :ok = Uploads.delete_all_for_subject({:user, user.id})
 
       # Rows for user gone; other user's row + file preserved
       assert Uploads.get_by_id(u1.id) == {:error, :not_found}
@@ -462,9 +462,9 @@ defmodule Grappa.UploadsTest do
       assert File.exists?(uo_path)
     end
 
-    test "is idempotent when user has no uploads" do
+    test "is idempotent when the subject has no uploads" do
       user = user_fixture([])
-      assert :ok = Uploads.delete_all_for_user(user.id)
+      assert :ok = Uploads.delete_all_for_subject({:user, user.id})
     end
   end
 


### PR DESCRIPTION
Deleting a subject removed its `uploads` ROWS and left the FILES on disk.
`uploads.user_id` / `uploads.visitor_id` carry `ON DELETE CASCADE`, and no
deletion path called `File.rm/1`. The bytes then became unreachable (row gone
=> 404), invisible to `Grappa.Uploads.Reaper` (which sweeps ROWS and unlinks
from them), and uncounted by `live_bytes_sum/0` (row-derived) — so the
global-cap accounting drifted from real disk usage with no signal at all.

Refs issue 1890.

## The unlink goes at the CHOKEPOINTS, not at the door the issue named

Measured, `AccountDeletion.delete_account/1` — the self-delete door the issue
describes — is one of **five** doors that destroy a subject, and the smallest
of them:

| door | kind |
|---|---|
| `Grappa.Accounts.AccountDeletion.delete_account/1` | user self-delete |
| `Grappa.Accounts.Operator.delete_user/2` | admin |
| `Grappa.Accounts.Operator.delete_visitor/2` | admin |
| `Grappa.Visitors.purge_if_anon/1` | logout of an anonymous visitor |
| `Grappa.Visitors.Reaper` | automatic, 60-second sweep of expired visitors |

Repairing self-delete alone would have left the *automatic* door leaking on a
one-minute tick. All five funnel through exactly two functions, so that is
where the unlink sits: **`Accounts.delete_user/1`** and
**`Visitors.destroy_visitor/1`** — the latter and not `Visitors.delete/1`,
because `purge_if_anon/1` reaches `destroy_visitor/1` without passing through
`delete/1`.

## `delete_all_for_user/1` → `delete_all_for_subject/1`

The replaced verb's own `@doc` declared it *test-support-only* and asserted
that "production lifecycle uses `soft_delete/2`" — a sentence that becomes
false the instant production calls it. `delete_all_for_subject/1` takes the
bare-id `Subject.t()` (`{:user, uuid}` / `{:visitor, uuid}`) that both call
sites already hold and queries through the existing `Subject.subject_where/2`,
so the two arms differ only in an FK column and no second query idiom appears.
Its one previous caller (`Grappa.TestSupport.SubjectReset`) moved with it.

One reference to the old name survives **on purpose**, and the reason is a
measurement. The `add_avatar_upload_id_to_network_credentials` migration
justifies its `on_delete: :nilify_all` in a COMMENT naming *"test-support
`Uploads.delete_all_for_user/1`, a future admin hard-purge"* — stale in both
halves after this change (the function is renamed **and** it is no longer
test-support). Repointing that comment was written, measured, and then
**reverted**: `Grappa.Deploy.Preflight` keys its `:migration` reason on the
changed PATH and classifies the file's SOURCE through an allowlist, so it
cannot tell a comment from a DDL op. Measured on the real classifier, same
diff otherwise:

| tree | jail | linux | docker |
|---|---|---|---|
| without the comment edit | `rc=0` HOT | `rc=0` HOT | `rc=0` HOT |
| with the comment edit | `rc=3` COLD | `rc=3` COLD | `rc=3` COLD |

A prose repair is not worth restarting production for, so the citation is
left to ride along with a change that is cold anyway. **This branch therefore
classifies HOT on all three substrates** — measured on the final sha with
`Grappa.Deploy.Preflight.cli/1`, not asserted: no `config/`, no migration, no
`application.ex`, no `mix.exs`, no `VERSION`, and no long-lived module's state
block (`Visitors.Reaper` / `Uploads.Reaper` / `Accounts.Reaper` live in
`*/reaper.ex`; this touches the sibling context modules).

That avatar FK is also the **only** foreign key pointing at `uploads`, measured
over both idioms this repo uses (`references(:uploads` in the Ecto DSL and
raw-SQL `REFERENCES "uploads"`, the latter with a positive control because
`uploads`' own FKs are declared in raw SQL inside an `execute`), and it
nilifies — so the `Repo.delete!/1` in the new helper cannot raise on a
constraint.

## Three outcomes, and why a failed unlink is LOGGED and not discarded

`Reaper.unlink_then_soft_delete/3` can afford to leave a row alone when
`File.rm/1` fails, because **the ROW IS ITS RETRY TOKEN** and the next sweep
tries again. On this path the row is about to be destroyed, so no retry token
will ever exist — the reaper's third arm is structurally unavailable here, and
a discarded error becomes a permanent leak nothing can later detect (the
silent-swallow CLAUDE.md forbids at a boundary). Hence:

* `:ok` — unlinked, proceed.
* `{:error, :enoent}` — **not** a failure. The expected idempotent case (the
  reaper or a prior partial run got there first). Deliberately kept OUT of the
  log: it would drown the line that matters.
* `{:error, reason}` — logged with the slug, and the deletion **continues**. A
  read-only disk must not hold someone's right to be deleted hostage, and that
  line is the only surrogate for the retry token being destroyed.

Metadata mirrors the reaper's own failure line (`upload_id` / `slug` /
`error`), all three already in the Logger allowlist — **no `config/` edit**.

## Visitor leg placement

The call sits **inside** the existing `Repo.BusyRetry.run/1` block, beside the
published-theme re-home — the same figure: a pre-delete step disposing of what
the cascade would otherwise destroy without cleaning up. Inside and not
before, so a sustained `SQLITE_BUSY` still degrades to
`{:error, :db_unavailable}` for every caller instead of raising past it.
Re-running is safe: the second pass finds no rows, and an already-unlinked
file answers `:enoent`.

## Tests

`test/grappa/uploads_subject_deletion_test.exs` (new, 7 tests) covers both
chokepoints, cross-subject isolation, the empty case, and all three unlink
outcomes. Written FIRST and run RED: 4 of 7 failed on
`refute File.exists?(path)` → *"Expected false or nil, got true"*, i.e. the
reported defect reproduced at **both** bottlenecks before the fix.

The unlink-failure arm is forced by placing a **directory** where the file
should be. `chmod`-read-only was rejected: CI runs the container as root, root
ignores the mode bits, and the test would have passed vacuously on exactly the
platform that gates the merge. The errno differs between BSD and Linux, so the
test asserts that the deletion still completed and that the slug was logged,
not *which* errno.
The new file is `async: false` and does `boot` + restore, because
`Uploads.storage_root/0` reads `:persistent_term` and raises if `boot/1` never
ran (same posture as `GrappaWeb.Admin.UploadsControllerTest`).

## What this slice does NOT cover

* **Orphans already on disk in production are not swept.** No back-fill, and
  not even a task that lists them — deliberately out of slice.
* **Peer avatars are not in this class**, measured: `peer_avatars.network_id`
  references `networks`, which is `slug` + timestamps with no owner column.
* Theme background images **are** covered: `Themes.BackgroundImage` stores them
  through `Uploads.create/3`, so they are `uploads` rows.
* A door that deletes a `users` / `visitors` row in raw SQL would not be seen
  by this change. The five doors above are the callers **in `lib/`** of the two
  verbs, not a full call graph.
* Nothing here measures **how many** orphans exist, or that self-delete is the
  main source of them. The visitor reaper has the highest cadence and goes
  through the same hole, but neither the expiry rate nor how many expiring
  visitors own uploads was measured: this is structure, not magnitude.
