### PR TITLE
cic: keep the radio playing across the 768px shell breakpoint

### DIFF
--- a/cicchetto/e2e/tests/issue1896-rotation-keeps-audio-element.spec.ts
+++ b/cicchetto/e2e/tests/issue1896-rotation-keeps-audio-element.spec.ts
@@ -1,0 +1,203 @@
+// #1896 — rotating a phone across the 768px breakpoint must not re-tune the radio.
+//
+// Reported from a Galaxy S24 Ultra: with a station playing, every rotation —
+// both directions — drops the audio for a fraction of a second and then starts
+// it again on its own. The mechanism is not audio at all, it is the shell:
+// `isMobile()` is `matchMedia("(max-width: 768px)")` and Shell branches on it
+// with a `<Show>`, i.e. TWO complete subtrees rather than one laid out two ways.
+// A phone whose landscape CSS width clears 768 flips that signal when it turns,
+// Solid destroys one subtree and builds the other, and the player used to be
+// mounted inside BOTH — so the `<audio>` on the far side was a different
+// element. Its open effect then ran as a first tune, and for a STREAM
+// `mustRefetch()` is true (#1700: a stream has no position to resume to,
+// re-tuning IS its resume), so it re-fetched: a new HTTP connection, heard as
+// the gap, with the autoplay behind the "restarts on its own".
+//
+// WHAT THIS SPEC MEASURES, and why each instrument is here.
+//
+//   * ELEMENT IDENTITY, marked rather than inferred. A rebuilt `<audio>` is
+//     indistinguishable from the original by tag, testid or property — only a
+//     mark written onto the live object before the crossing separates them, and
+//     the element is what holds the connection.
+//   * THE TRANSPORT CALLS, counted from an init script. Identity alone would
+//     still pass if something re-assigned `.src` on the surviving element, and
+//     `.src` is what re-opens the connection: assigning it re-invokes the media
+//     load algorithm even for an unchanged URL. So the two are counted and must
+//     not move across a crossing.
+//
+// And three controls, because each of them is a way for this to go green while
+// proving nothing:
+//
+//   * the counters must be NON-ZERO before the first crossing — an instrument
+//     that never fired reports "unchanged" perfectly;
+//   * the shell must actually have SWITCHED branch at every crossing, asserted
+//     on the root class — a resize that stays on one side of 768 changes
+//     nothing and would satisfy every assertion below;
+//   * the bar must be back on screen AFTER each crossing. An element that
+//     survives into a shell with no transport driving it is not the fix.
+//
+// WHAT IT DOES NOT ESTABLISH, stated because the green is easy to over-read.
+// Not a device rotation: this is `setViewportSize` in desktop Chromium, so it
+// reproduces the BREAKPOINT CROSSING (the same `matchMedia` edge, the same JSX
+// flip) and not an orientation change on a handset. The S24 Ultra's real
+// landscape CSS width was never read off the handset either — 844x390 below is
+// a phone-shaped viewport chosen to straddle 768, not a measurement of the
+// reporter's device. The desktop project is deliberate: the defect is in the
+// shell's regime signal and its DOM, neither of which is touch- or
+// engine-specific, and the untagged project is where the login/rail helpers
+// this spec leans on are proven.
+//
+// NO THIRD-PARTY NETWORK, the #682/#1701 posture: the stream is served from
+// local bytes by `page.route`, scoped to the station's real URL so a change
+// that stops requesting it fails here rather than passing quietly.
+
+import type { Page } from "@playwright/test";
+import { silentMp3 } from "../fixtures/bytes";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Literals rather than an import from `src/lib/radioStations`, matching #682
+// and #1701: a table edit that drops or renames this station must fail HERE
+// instead of being followed silently.
+const STATION_ID = "groovesalad";
+const STATION_STREAM = "https://ice.somafm.com/groovesalad-128-mp3";
+
+// A phone, portrait and landscape. Both sides of 768 by a wide margin — the
+// crossing must be unambiguous, because a viewport that lands NEAR the
+// breakpoint turns a branch assertion into a coin toss on a scrollbar.
+const PORTRAIT = { width: 390, height: 844 };
+const LANDSCAPE = { width: 844, height: 390 };
+
+type TransportCounts = { plays: number; srcSets: number };
+
+// Count the two calls that re-open a connection, from before the app's first
+// script runs. Wrapping the prototype rather than watching the element: the
+// point of this spec is that there is only ever ONE element, and an instrument
+// bound to a particular one could not tell a rebuild from a re-tune.
+async function installTransportCounter(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const w = window as unknown as { __transport1896: TransportCounts };
+    const counts = { plays: 0, srcSets: 0 };
+    w.__transport1896 = counts;
+
+    const proto = HTMLMediaElement.prototype;
+    const play = proto.play;
+    proto.play = function patchedPlay(this: HTMLMediaElement) {
+      counts.plays += 1;
+      return play.call(this);
+    };
+
+    // `src` is an IDL attribute of HTMLMediaElement, so the descriptor lives on
+    // that prototype and every <audio> reaches it through the chain. Throwing
+    // when it is absent rather than skipping: a silently un-instrumented setter
+    // would report zero re-tunes for the rest of the run.
+    const descriptor = Object.getOwnPropertyDescriptor(proto, "src");
+    const setSrc = descriptor?.set;
+    if (descriptor === undefined || setSrc === undefined) {
+      throw new Error("#1896 counter: HTMLMediaElement.prototype has no `src` setter");
+    }
+    Object.defineProperty(proto, "src", {
+      ...descriptor,
+      set(this: HTMLMediaElement, value: string) {
+        counts.srcSets += 1;
+        setSrc.call(this, value);
+      },
+    });
+  });
+}
+
+const transportCounts = (page: Page): Promise<TransportCounts> =>
+  page.evaluate(() => (window as unknown as { __transport1896: TransportCounts }).__transport1896);
+
+// Login + channel join on the testnet, a station tune, and three reflows.
+test.setTimeout(120_000);
+
+test("#1896 — crossing 768px keeps the same <audio> element and never re-tunes", async ({
+  page,
+}) => {
+  test.slow();
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  await installTransportCounter(page);
+  await page.route("https://ice.somafm.com/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "audio/mpeg", body: silentMp3(8) });
+  });
+
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  // Tune at the project's own (desktop) viewport, where `openRailMenu` takes
+  // its proven path. WHERE the tune happens is not what this spec is about —
+  // the subject is what a CROSSING does to an already-tuned player, and the
+  // first resize below is itself one.
+  await openRailMenu(page);
+  await page.getByTestId("rail-action-radio").click();
+  await expect(page.getByTestId("rail-radio-picker")).toBeVisible();
+  await page.getByTestId(`rail-radio-station-${STATION_ID}`).click();
+
+  const audio = page.getByTestId("audio-mini-player-el");
+  await expect(audio).toHaveJSProperty("src", STATION_STREAM);
+  await expect(page.getByTestId("audio-mini-player")).toBeVisible({ timeout: 15_000 });
+
+  // The picker holds an overlay lock and covers the rail; close it so the
+  // resizes below are a plain regime change and nothing else.
+  await page.getByTestId("rail-radio-picker-close").click();
+  await expect(page.getByTestId("rail-radio-picker")).toBeHidden();
+
+  // CONTROL — the instrument is alive. Everything after this reads "unchanged",
+  // which a counter that never incremented satisfies perfectly.
+  const tuned = await transportCounts(page);
+  expect(tuned.srcSets, "the tune must have gone through the `src` setter").toBeGreaterThan(0);
+  expect(tuned.plays, "the tune must have called play()").toBeGreaterThan(0);
+
+  // Mark the live object. `toHaveJSProperty` on a fresh element would match the
+  // same src just as well — only something written onto THIS object separates
+  // "the element survived" from "an identical one was built".
+  await audio.evaluate((el) => {
+    el.setAttribute("data-rotation-probe", "survived");
+  });
+
+  // Three crossings: into the phone's portrait shell, out to its landscape one
+  // (the rotation the report is about), and back. Both directions, because the
+  // report says both directions.
+  const crossings = [
+    { label: "desktop → portrait phone", size: PORTRAIT, mobileAfter: true },
+    { label: "portrait → landscape (the rotation)", size: LANDSCAPE, mobileAfter: false },
+    { label: "landscape → portrait (rotated back)", size: PORTRAIT, mobileAfter: true },
+  ];
+
+  for (const crossing of crossings) {
+    await page.setViewportSize(crossing.size);
+
+    // CONTROL — the branch really flipped. Without this a resize that never
+    // crossed 768 would satisfy every assertion that follows.
+    await expect(
+      page.locator(".shell-mobile"),
+      `${crossing.label}: the shell must have switched branch`,
+    ).toHaveCount(crossing.mobileAfter ? 1 : 0);
+
+    // One element, and the SAME one. The attribute rides on the object; a
+    // rebuilt <audio> comes back without it.
+    await expect(audio, `${crossing.label}: exactly one player`).toHaveCount(1);
+    await expect(
+      audio,
+      `${crossing.label}: the element must be the one that was playing`,
+    ).toHaveAttribute("data-rotation-probe", "survived");
+
+    // No re-tune: neither the connection-opening assignment nor the autoplay
+    // behind the "restarts on its own" may have happened again.
+    expect(
+      await transportCounts(page),
+      `${crossing.label}: the transport must not have been driven again`,
+    ).toEqual(tuned);
+
+    // And the bar came with it — a surviving element nobody can stop is not a fix.
+    await expect(
+      page.getByTestId("audio-mini-player"),
+      `${crossing.label}: the transport must be docked in the new shell`,
+    ).toBeVisible({ timeout: 15_000 });
+  }
+});

--- a/cicchetto/src/AudioDock.tsx
+++ b/cicchetto/src/AudioDock.tsx
@@ -1,0 +1,55 @@
+import { type Component, createSignal, onCleanup } from "solid-js";
+
+// #1896 — WHERE the docked player's chrome belongs, held apart from WHERE the
+// player is MOUNTED, because on this shell the two cannot be the same place.
+//
+// The mobile/desktop split is a JSX branch (`<Show when={isMobile()}>` in
+// Shell), not a CSS toggle, and rotating a phone whose landscape CSS width
+// clears 768px crosses it. Solid destroys one subtree and builds the other, so
+// anything mounted inside a branch is a NEW object on the far side of a
+// rotation. For `<audio>` that means a new element, an open effect running as a
+// first tune, and — for a STREAM, where `mustRefetch()` is true — a fresh HTTP
+// connection to the station: the audible gap the report describes, with the
+// autoplay behind it.
+//
+// So the player is mounted ONCE, above the branch, and each branch renders one
+// of these in its place: an empty marker that says "the bar goes here". The
+// player portals its chrome into whichever marker is live. The element never
+// moves; only the chrome does, and the chrome holds no transport state.
+//
+// WHY A SIGNAL AND NOT A PROP. Shell could thread a setter down, but the two
+// docks sit in different arms of the same `<Show>` and each would have to
+// repeat the register/retract pair inline — the copy-paste-with-tweaks this
+// module exists to avoid. The dock is also a fact about the DOM, not about the
+// identity: unlike the audio store it is deliberately NOT identity-scoped, so
+// it does not belong in `lib/audioPlayer.ts` beside the source.
+//
+// Two docks never coexist: they are in the two arms of one `<Show>`, and inside
+// each arm in the single `<Match>` that renders a chat window. The retraction
+// is nevertheless CONDITIONAL — a dock clears the signal only if it is still
+// the one registered — so the pair of writes a flip produces cannot end with
+// the outgoing branch erasing the incoming branch's registration, whichever
+// order Solid disposes and builds in. That is one comparison, and it makes the
+// contract independent of a scheduling detail rather than dependent on today's.
+
+const [dockEl, setDockEl] = createSignal<HTMLElement | undefined>(undefined);
+
+/**
+ * The live dock element, or `undefined` on a window kind that renders none
+ * (home / list / mentions / admin, which have no compose column to dock to).
+ */
+export const audioDock = dockEl;
+
+/** The slot the player's chrome is portalled into. Renders nothing of its own. */
+const AudioDock: Component = () => (
+  <div
+    class="audio-dock"
+    data-testid="audio-dock"
+    ref={(el) => {
+      setDockEl(el);
+      onCleanup(() => setDockEl((current) => (current === el ? undefined : current)));
+    }}
+  />
+);
+
+export default AudioDock;

--- a/cicchetto/src/AudioMiniPlayer.tsx
+++ b/cicchetto/src/AudioMiniPlayer.tsx
@@ -1,4 +1,6 @@
 import { type Component, createEffect, createSignal, on, onCleanup, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { audioDock } from "./AudioDock";
 import {
   activeAudio,
   audioFailureLabel,
@@ -34,6 +36,16 @@ import { nowPlayingLabel } from "./lib/nowPlaying";
 // runs — wrapping the element itself in <Show> would race ref-assignment
 // against the effect on the open transition.
 //
+// #1896 — and the component itself is now mounted unconditionally too, ONCE,
+// above Shell's `<Show when={isMobile()}>`. That branch is a JSX split and not
+// a CSS one, so a phone crossing 768px on rotation used to destroy the subtree
+// holding this element and build a fresh one in the other regime — a new
+// `<audio>`, a first-tune effect, and for a stream a new HTTP connection. The
+// element does not move any more; the CHROME travels instead, portalled into
+// whichever `<AudioDock />` is live (see that module for the whole argument).
+// The bar is therefore rendered only when a dock exists, which is exactly the
+// window kinds that have a compose column to dock to.
+//
 // #682 — LIVE mode. This bar was written for a FILE, and an internet-radio
 // station is not one: an Icecast stream has no end, so a position slider and
 // a "cur / dur" read are both meaningless against it. Live mode is DERIVED
@@ -60,18 +72,29 @@ import { nowPlayingLabel } from "./lib/nowPlaying";
 // slot would still have to clear the 44px tap floor, so it would give back
 // almost none of the vertical space that motivated hiding.
 //
-// #1701 — what unmounting ACTUALLY does, measured, because the first bullet
+// #1701 — what unmounting ACTUALLY did, measured, because the first bullet
 // above used to end "(which is why leaving chat for home already stops
-// playback)" and that is not what happens. The source is MODULE state
+// playback)" and that was not what happened. The source is MODULE state
 // (`lib/audioPlayer.ts`) and outlives the component, so leaving a scrollback
-// window for home / list / mentions / admin destroys the element — and coming
-// back RE-MOUNTS it: the `on(activeAudio, …)` effect below runs on its first
-// execution, reassigns `.src` and calls `play()`. The semantics are
-// kill-and-re-tune, not stop. A station re-buffers (#1700's `mustRefetch` says
-// re-tuning IS the correct resume for one), and an UPLOAD restarts from the
-// beginning, unasked — that half is a defect in its own right and is not this
-// file's to fix. Recorded here so the next reader reasons about the code
-// rather than about this comment.
+// window for home / list / mentions / admin destroyed the element — and coming
+// back RE-MOUNTED it: the `on(activeAudio, …)` effect below ran on its first
+// execution, reassigned `.src` and called `play()`. The semantics were
+// kill-and-re-tune, not stop. A station re-buffered (#1700's `mustRefetch` says
+// re-tuning IS the correct resume for one), and an UPLOAD restarted from the
+// beginning, unasked — "a defect in its own right and not this file's to fix",
+// as this paragraph used to close.
+//
+// #1896 CLOSED IT, and not as a bonus: the hoist that stops a ROTATION tearing
+// the element down necessarily lifts the component above the `<Switch>` too,
+// because the regime `<Show>` encloses it. There is one arithmetic here, not
+// two decisions — you cannot mount above the branch and remain inside the
+// window-kind Match. So a window switch no longer touches the element at all;
+// what changes is only whether a DOCK exists to portal the chrome into. On
+// home / list / mentions the audio keeps playing with no bar on screen, which
+// is the state #1697 already ships deliberately (`playerHidden`), and the doors
+// out of it are the same ones: `RailRadio` + `RailActions` live in
+// `.shell-members`, OUTSIDE the `<Switch>`, so stop and un-hide are reachable
+// on every window kind in both regimes.
 //
 // Where "stop" genuinely lives, and neither of the two depends on where this
 // component is mounted: `closeAudio` (the ✕ — it clears the source, and the
@@ -155,6 +178,13 @@ const AudioMiniPlayer: Component = () => {
 
   // #1734 — the element is about to be destroyed; the transport's position is
   // about to go with it. One write, at the only instant that has the fact.
+  //
+  // #1896 narrowed WHEN that happens without changing what it must do. The
+  // component no longer dies on a window switch or a rotation, so the last
+  // destruction in a session is Shell's own teardown (logout / identity
+  // change). Kept, and kept correct: a destruction that still happens is
+  // exactly the one this was written for, and the effect above still cannot
+  // tell a first tune from a re-mount without it.
   onCleanup(() => {
     if (audioEl === undefined || activeAudio() === null) return;
     rememberResumePoint({
@@ -310,29 +340,44 @@ const AudioMiniPlayer: Component = () => {
           }
         }}
       />
-      <Show when={activeAudio() !== null && !playerHidden()}>
-        <div class="audio-mini-player" data-testid="audio-mini-player">
-          <button
-            type="button"
-            class="audio-mini-player-toggle"
-            data-testid="audio-mini-player-toggle"
-            onClick={togglePlay}
-            aria-label={playing() ? "pause" : "play"}
+      {/* #1896 — the chrome goes to the DOCK, the element stays here.
+          Gated on a dock EXISTING rather than letting Portal fall back to
+          `document.body`: a bar appended to the end of the document would be
+          unstyled and unplaceable, and "no dock" is a real state (home / list /
+          mentions render no compose column). The container Portal creates is
+          classed through its `ref` so the stylesheet can take both wrappers out
+          of layout — see `.audio-dock` in default.css. */}
+      <Show when={audioDock()}>
+        {(dock) => (
+          <Portal
+            mount={dock()}
+            ref={(container: HTMLDivElement) => {
+              container.className = "audio-dock-portal";
+            }}
           >
-            {playing() ? "⏸" : "▶"}
-          </button>
-          {/* #682 — the source's name, when it has one. An upload passes
+            <Show when={activeAudio() !== null && !playerHidden()}>
+              <div class="audio-mini-player" data-testid="audio-mini-player">
+                <button
+                  type="button"
+                  class="audio-mini-player-toggle"
+                  data-testid="audio-mini-player-toggle"
+                  onClick={togglePlay}
+                  aria-label={playing() ? "pause" : "play"}
+                >
+                  {playing() ? "⏸" : "▶"}
+                </button>
+                {/* #682 — the source's name, when it has one. An upload passes
               null and this renders nothing; a radio station passes its title,
               which on mobile is the ONLY place naming it (the rail that holds
               the station chrome is a drawer slid off-screen while playing). */}
-          <Show when={activeAudio()?.label}>
-            {(label) => (
-              <span class="audio-mini-player-label" data-testid="audio-mini-player-label">
-                {label()}
-              </span>
-            )}
-          </Show>
-          {/* #1744 — THE NOTICE TAKES THE TRACK'S SLOT. The feed polls
+                <Show when={activeAudio()?.label}>
+                  {(label) => (
+                    <span class="audio-mini-player-label" data-testid="audio-mini-player-label">
+                      {label()}
+                    </span>
+                  )}
+                </Show>
+                {/* #1744 — THE NOTICE TAKES THE TRACK'S SLOT. The feed polls
               `tunedStation()`, which is derived from the SOURCE and knows
               nothing about whether the element decoded it — so a live-updating
               track name keeps scrolling over silence, which is the single
@@ -341,10 +386,10 @@ const AudioMiniPlayer: Component = () => {
               slot rather than adding one.
               The LABEL above deliberately stays. "connection lost" with nothing
               beside it does not tell the operator which station to re-pick. */}
-          <Show
-            when={playbackFailure()}
-            fallback={
-              /* #1698 — what the station is playing, on the surface a phone can
+                <Show
+                  when={playbackFailure()}
+                  fallback={
+                    /* #1698 — what the station is playing, on the surface a phone can
                  actually see. The rail carries the same fact, and on mobile the
                  rail is `translateX(100%)` off-screen while the station plays —
                  the identical argument that put the label above here in #682,
@@ -352,29 +397,29 @@ const AudioMiniPlayer: Component = () => {
                  absent for a station whose feed has gone quiet: the store's
                  `nowPlayingLabel` is null on every arm but `playing`, so the
                  stale rule reaches this row without this row knowing about it. */
-              <Show when={nowPlayingLabel()}>
-                {(track) => (
-                  <span class="audio-mini-player-track" data-testid="audio-mini-player-track">
-                    {track()}
-                  </span>
-                )}
-              </Show>
-            }
-          >
-            {(failure) => (
-              /* `role="status"`: this appears without the operator having done
+                    <Show when={nowPlayingLabel()}>
+                      {(track) => (
+                        <span class="audio-mini-player-track" data-testid="audio-mini-player-track">
+                          {track()}
+                        </span>
+                      )}
+                    </Show>
+                  }
+                >
+                  {(failure) => (
+                    /* `role="status"`: this appears without the operator having done
                  anything, so an assistive technology must be able to learn
                  about it without polling the bar. */
-              <span
-                class="audio-mini-player-error"
-                data-testid="audio-mini-player-error"
-                role="status"
-              >
-                {`⚠ ${audioFailureLabel(failure())}`}
-              </span>
-            )}
-          </Show>
-          {/* THE READOUT, and #1744 gives it a third arm: NONE.
+                    <span
+                      class="audio-mini-player-error"
+                      data-testid="audio-mini-player-error"
+                      role="status"
+                    >
+                      {`⚠ ${audioFailureLabel(failure())}`}
+                    </span>
+                  )}
+                </Show>
+                {/* THE READOUT, and #1744 gives it a third arm: NONE.
               Measured on a source the browser refuses (MediaError code 4):
               `loadedmetadata` never arrives, so `duration` stays at a finite 0,
               so `live()` answers false and this row drew the FILE readout over
@@ -383,40 +428,40 @@ const AudioMiniPlayer: Component = () => {
               exist, and the live arm is no better: an elapsed counter frozen at
               a "live" badge says the stream is still on. A failed source has no
               readout, so it is given none. */}
-          <Show when={playbackFailure() === null}>
-            <Show
-              when={!live()}
-              fallback={
-                <>
-                  <span class="audio-mini-player-live" data-testid="audio-mini-player-live">
-                    live
-                  </span>
-                  {/* Elapsed since tune-in, NOT a position: there is no total
+                <Show when={playbackFailure() === null}>
+                  <Show
+                    when={!live()}
+                    fallback={
+                      <>
+                        <span class="audio-mini-player-live" data-testid="audio-mini-player-live">
+                          live
+                        </span>
+                        {/* Elapsed since tune-in, NOT a position: there is no total
                       to divide it by, so it is shown alone rather than as one
                       half of a "cur / dur" pair with a hollow denominator. */}
-                  <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
-                    {formatTime(current())}
-                  </span>
-                </>
-              }
-            >
-              <input
-                type="range"
-                class="audio-mini-player-seek"
-                data-testid="audio-mini-player-seek"
-                min="0"
-                max={duration() || 0}
-                step="any"
-                value={current()}
-                onInput={onSeek}
-                aria-label="seek"
-              />
-              <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
-                {formatTime(current())} / {formatTime(duration())}
-              </span>
-            </Show>
-          </Show>
-          {/* Same-origin download: the `download` attribute forces a save
+                        <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
+                          {formatTime(current())}
+                        </span>
+                      </>
+                    }
+                  >
+                    <input
+                      type="range"
+                      class="audio-mini-player-seek"
+                      data-testid="audio-mini-player-seek"
+                      min="0"
+                      max={duration() || 0}
+                      step="any"
+                      value={current()}
+                      onInput={onSeek}
+                      aria-label="seek"
+                    />
+                    <span class="audio-mini-player-time" data-testid="audio-mini-player-time">
+                      {formatTime(current())} / {formatTime(duration())}
+                    </span>
+                  </Show>
+                </Show>
+                {/* Same-origin download: the `download` attribute forces a save
               (overriding the server's `inline` Content-Disposition) and
               inherits the server-sent filename — cic has no filename on the
               wire (slug only), so no `download` value is set.
@@ -440,42 +485,45 @@ const AudioMiniPlayer: Component = () => {
               is #682's own second reason spelled as a test rather than
               inferred from the first — out of scope here, and named so it is
               not rediscovered as new. */}
-          <Show when={!live()}>
-            <a
-              class="audio-mini-player-download"
-              data-testid="audio-mini-player-download"
-              href={activeAudio()?.href}
-              download=""
-              aria-label="download"
-            >
-              ⬇
-            </a>
-          </Show>
-          {/* #1697 — HIDE, beside the ✕ and never merged with it. The ✕ is the
+                <Show when={!live()}>
+                  <a
+                    class="audio-mini-player-download"
+                    data-testid="audio-mini-player-download"
+                    href={activeAudio()?.href}
+                    download=""
+                    aria-label="download"
+                  >
+                    ⬇
+                  </a>
+                </Show>
+                {/* #1697 — HIDE, beside the ✕ and never merged with it. The ✕ is the
               STOP verb, and on a phone it is the only reachable one while the
               rail that holds the station chrome is slid off-screen; collapsing
               the two would cost the operator the ability to stop. The glyph is
               a chevron down (the surface leaves downward, past the compose
               box), and the accessible name says what survives the gesture. */}
-          <button
-            type="button"
-            class="audio-mini-player-hide"
-            data-testid="audio-mini-player-hide"
-            onClick={hidePlayer}
-            aria-label="hide player, keep playing"
-          >
-            ⌄
-          </button>
-          <button
-            type="button"
-            class="audio-mini-player-close"
-            data-testid="audio-mini-player-close"
-            onClick={closeAudio}
-            aria-label="close"
-          >
-            ✕
-          </button>
-        </div>
+                <button
+                  type="button"
+                  class="audio-mini-player-hide"
+                  data-testid="audio-mini-player-hide"
+                  onClick={hidePlayer}
+                  aria-label="hide player, keep playing"
+                >
+                  ⌄
+                </button>
+                <button
+                  type="button"
+                  class="audio-mini-player-close"
+                  data-testid="audio-mini-player-close"
+                  onClick={closeAudio}
+                  aria-label="close"
+                >
+                  ✕
+                </button>
+              </div>
+            </Show>
+          </Portal>
+        )}
       </Show>
     </>
   );

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -12,6 +12,7 @@ import {
 import { Portal } from "solid-js/web";
 import AdminPane from "./AdminPane";
 import ArchiveModal from "./ArchiveModal";
+import AudioDock from "./AudioDock";
 import AudioMiniPlayer from "./AudioMiniPlayer";
 import BanlistModal from "./BanlistModal";
 import BottomBar from "./BottomBar";
@@ -613,94 +614,95 @@ const Shell: Component = () => {
   });
 
   return (
-    <Show
-      when={isMobile()}
-      fallback={
-        // ── Desktop three-pane layout (unchanged from pre-C6) ─────────
-        <div
-          class="shell"
-          classList={{ "shell-no-members": !isActiveChannelJoined(selectedChannel()) }}
-        >
-          <ErrorBanners />
-          <Toasts />
-          <PrivacyModal />
-          <MediaViewerModal />
-          <NamesModal />
-          <ThemeEditor />
-          <WhoModal />
-          <LinksModal />
-          <ModeModal />
-          <BanlistModal />
-          <UmodeModal />
-          <ServerReplyModal />
-          <ServiceModal />
-          <RegistrationWizardModal />
-          <RecoverModal />
-          <ShareSessionModal />
-          {/* #1773 — the credits easter egg. Mounted here, not in the settings
+    <>
+      <Show
+        when={isMobile()}
+        fallback={
+          // ── Desktop three-pane layout (unchanged from pre-C6) ─────────
+          <div
+            class="shell"
+            classList={{ "shell-no-members": !isActiveChannelJoined(selectedChannel()) }}
+          >
+            <ErrorBanners />
+            <Toasts />
+            <PrivacyModal />
+            <MediaViewerModal />
+            <NamesModal />
+            <ThemeEditor />
+            <WhoModal />
+            <LinksModal />
+            <ModeModal />
+            <BanlistModal />
+            <UmodeModal />
+            <ServerReplyModal />
+            <ServiceModal />
+            <RegistrationWizardModal />
+            <RecoverModal />
+            <ShareSessionModal />
+            {/* #1773 — the credits easter egg. Mounted here, not in the settings
               drawer that opens it: `.settings-drawer` animates on `transform`,
               which makes it the containing block for any `position: fixed`
               descendant, so a full-screen modal rendered from inside would be
               clipped to the drawer. Self-gated on `creditsModalOpen()`. */}
-          <CreditsModal />
-          <ConfirmModal />
-          {/* #473 — ArchiveModal is the single archive surface on BOTH form
+            <CreditsModal />
+            <ConfirmModal />
+            {/* #473 — ArchiveModal is the single archive surface on BOTH form
               factors. Mounted here on desktop (was mobile-only); the desktop
               Sidebar `<details class="sidebar-archive">` it replaces is
               removed. Self-gated on `archiveModalOpen()` — renders nothing
               when closed. Opened from the RailActions drawer archive button. */}
-          <ArchiveModal />
-          <aside class="shell-sidebar">
-            <Sidebar />
-            {/* GH #235 — "jump to next active window" affordance, pinned
+            <ArchiveModal />
+            <aside class="shell-sidebar">
+              <Sidebar />
+              {/* GH #235 — "jump to next active window" affordance, pinned
                 bottom-left of the sidebar. Self-hides when nothing is
                 unread. */}
-            <NextActiveButton variant="desktop" />
-            {/* UX-5 bucket BS — drag handle on the inner edge of the
+              <NextActiveButton variant="desktop" />
+              {/* UX-5 bucket BS — drag handle on the inner edge of the
                 left sidebar. Desktop-only (mobile branch never mounts
                 it). Width persists to localStorage via
                 lib/sidebarWidths.ts; CSS var --sidebar-width drives the
                 .shell grid template. */}
-            <ResizeHandle side="left" />
-          </aside>
+              <ResizeHandle side="left" />
+            </aside>
 
-          <Show when={membersOpen()}>
-            <div
-              class="shell-drawer-backdrop open"
-              onClick={() => setMembersOpen(false)}
-              aria-hidden="true"
-            />
-          </Show>
+            <Show when={membersOpen()}>
+              <div
+                class="shell-drawer-backdrop open"
+                onClick={() => setMembersOpen(false)}
+                aria-hidden="true"
+              />
+            </Show>
 
-          <section class="shell-main">
-            {/* #71 INC-2 (R1) — the always-present desktop ShellChrome row was
+            <section class="shell-main">
+              {/* #71 INC-2 (R1) — the always-present desktop ShellChrome row was
                 REMOVED. Its settings cog moved into the permanent right rail
                 (#473: the RailActions drawer mounted in `.shell-members` below),
                 which is reachable from every window kind — so the "cog reachable
                 from every window" rule the row used to satisfy now holds via the
                 rail. Removing the row frees the top of `.shell-main` for the
                 topic (the raised topic clamp, default.css). */}
-            {/* #134 — the Switch fallback only renders when
+              {/* #134 — the Switch fallback only renders when
                 selectedChannel() is null, i.e. the cold-load window
                 before the auto-select effect lands on $home. That IS the
                 loading state, so the fallback is the retro CRT splash;
                 CrtSplash self-gates on the same loading predicate and
                 hands off (renders null) once load completes. */}
-            <Switch fallback={<CrtSplash />}>
-              <Match when={isAdminPaneVisible()}>
-                {/* UX-4 bucket N — AdminPane mount driven by selection +
+              <Switch fallback={<CrtSplash />}>
+                <Match when={isAdminPaneVisible()}>
+                  {/* UX-4 bucket N — AdminPane mount driven by selection +
                     isAdmin guard. #1073 deleted the pane's close × and its
                     `onClose` with it: selection is what unmounts this pane,
                     and the rail the ☰ opens already carries `home`. The
                     demote-redirect effect still lands on that same window. */}
-                <AdminPane
-                  onOpenRail={() =>
-                    toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
-                  }
-                />
-              </Match>
-              <Match when={kindHasScrollback(selKind())}>
-                {/* BUGHUNT-3 D — channel + query + server share ONE Match
+                  <AdminPane
+                    onOpenRail={() =>
+                      toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
+                    }
+                  />
+                </Match>
+                <Match when={kindHasScrollback(selKind())}>
+                  {/* BUGHUNT-3 D — channel + query + server share ONE Match
                     so ScrollbackPane stays mounted across kind transitions
                     (channel↔query↔server). The pane's `on(key, prevKey)`
                     effect at ScrollbackPane.tsx:~1142 owns the leave-arm
@@ -711,7 +713,7 @@ const Shell: Component = () => {
                     be stale at the dispose tick). TopicBar is gated
                     inside on the channel-only kind to preserve its
                     channel-window-only contract. */}
-                {/* #351 — the whole conversation pane is one drag-and-drop
+                  {/* #351 — the whole conversation pane is one drag-and-drop
                     file-upload target. DropUploadZone wraps the vertical
                     TopicBar + ScrollbackPane + ComposeBox stack; a file
                     dropped anywhere over it uploads via the SAME shared
@@ -719,21 +721,319 @@ const Shell: Component = () => {
                     It's a transparent pass-through flex column, so the
                     scrollback still grows (flex:1) and compose keeps its
                     natural height — layout is unchanged. */}
+                  <DropUploadZone
+                    networkSlug={selectedChannel()?.networkSlug ?? ""}
+                    channelName={selectedChannel()?.channelName ?? ""}
+                  >
+                    <Show when={selKind() === "channel"}>
+                      <TopicBar
+                        networkSlug={selectedChannel()?.networkSlug ?? ""}
+                        channelName={selectedChannel()?.channelName ?? ""}
+                        onToggleMembers={() => setMembersOpen((v) => !v)}
+                        /* #1766 — desktop has a permanent sidebar, so there is
+                         no window-list door to open and nothing to hide. The
+                         band's ☰ is `display: none` up here anyway; passing
+                         `null` means the button is never MOUNTED rather than
+                         mounted-and-hidden. */
+                        leading={null}
+                      />
+                    </Show>
+                    <ScrollbackPane
+                      networkSlug={selectedChannel()?.networkSlug ?? ""}
+                      channelName={selectedChannel()?.channelName ?? ""}
+                      kind={(selKind() as "channel" | "query" | "server") ?? "channel"}
+                    />
+                    <ComposeBox
+                      networkSlug={selectedChannel()?.networkSlug ?? ""}
+                      channelName={selectedChannel()?.channelName ?? ""}
+                    />
+                    {/* GH #115 — the docked audio mini-player's SLOT, BELOW
+                      compose (#1701). #1896 turned the mount into a dock: the
+                      player itself is mounted once below this <Show>, and only
+                      its chrome is portalled in here, so neither a window
+                      switch nor a rotation across 768px can tear the <audio>
+                      element down. Still inside DropUploadZone, so #351's
+                      whole-pane drop target keeps covering the strip. */}
+                    <AudioDock />
+                  </DropUploadZone>
+                </Match>
+                <Match when={selKind() === "mentions"}>
+                  {/* C8.1 — mentions window. Rendered instead of ScrollbackPane+ComposeBox.
+                    onMentionClicked will navigate to channel + scroll-to-timestamp (C8.2). */}
+                  <MentionsWindow
+                    bundle={
+                      mentionsBundleBySlug()[selectedChannel()?.networkSlug ?? ""] ?? {
+                        network_slug: selectedChannel()?.networkSlug ?? "",
+                        away_started_at: "",
+                        away_ended_at: "",
+                        away_reason: null,
+                        messages: [],
+                      }
+                    }
+                    ownNick={ownNickForSlug(selectedChannel()?.networkSlug ?? "")}
+                    onMentionClicked={handleMentionClicked}
+                    onClose={() => closeToPreviousWindow(selectedChannel()?.networkSlug ?? "")}
+                  />
+                </Match>
+                <Match when={selKind() === "home"}>
+                  {/* UX-4 bucket B — home pane. No TopicBar, no
+                    ComposeBox, no MembersPane (sibling <aside>
+                    already self-gates on isActiveChannelJoined). */}
+                  <HomePane />
+                </Match>
+                <Match when={selKind() === "list"}>
+                  {/* #84 E3 — channel directory pane. No TopicBar, no
+                    ComposeBox, no MembersPane. The $list window is a
+                    view+action pane (browse + join), not a chat pane. */}
+                  <DirectoryPane networkSlug={selectedChannel()?.networkSlug ?? ""} />
+                </Match>
+              </Switch>
+            </section>
+
+            {/* #71 INC-2 (R1) — the right rail is now PERMANENT (decoupled from
+              the members panel). `.shell-no-members` no longer drops this
+              column; it narrows it to fit the rail buttons (default.css), so
+              they are reachable on every window kind. #473 — MembersPane is
+              conditional content at the top; the RailActions drawer (all the
+              labelled buttons) floors at the bottom. */}
+            <aside class="shell-members" classList={{ open: membersOpen() }}>
+              {/* UX-5 bucket BS — drag handle on the inner edge of the
+                right (members) sidebar. Mounted unconditionally even
+                when isActiveChannelJoined(...) is false (the column
+                narrows via .shell-no-members in CSS); the handle is
+                inside the aside so it's hidden together. */}
+              <ResizeHandle side="right" />
+              <Show when={isActiveChannelJoined(selectedChannel()) && selectedChannel()}>
+                {(sel) => (
+                  <MembersPane networkSlug={sel().networkSlug} channelName={sel().channelName} />
+                )}
+              </Show>
+              {/* #474 — the per-window-kind rail context surface (server info
+                today; a /whois card is the deferred follow-on), grafted as a
+                SIBLING of the drawer below. Renders nothing on kinds with no
+                context, so the drawer still floors the rail.
+                #782 — `onScreen` is unconditionally true here: this rail is a
+                PERMANENT grid column (#71 INC-2, `.shell-no-members` narrows
+                it but never drops it), and a query window renders no
+                MembersPane above the card, so it cannot be scrolled out of
+                view either. */}
+              <RailContext onScreen={true} />
+              {/* #473 — the ONE unified rail action drawer, floored at the bottom
+                (CSS `.rail-actions { margin-top: auto }`). Supersedes the desktop
+                top ActionCluster (cog + denoise) and, crucially, brings the
+                window-nav launchers (home / rooms / themes / admin) the desktop
+                rail never had — the desktop rail was "a cog and a monkey" (#473).
+                The mobile drawer mounts the SAME component (below). Archive is
+                now a first-class always-on RailActions button opening the single
+                grouped ArchiveModal (mounted above) — the desktop Sidebar
+                `<details>` and the mobile footer chip it replaced are removed. */}
+              {/* #682 — the radio surface, mounted UNCONDITIONALLY like the drawer
+              below it and deliberately NOT as a `RailContext` arm: that
+              component grafts by the active window's KIND and would drop the
+              panel the moment the operator switched to a query. Idle it renders
+              nothing at all, so #500's vertical budget is untouched until a
+              station is tuned; its picker overlays the whole rail. */}
+              <RailRadio />
+              <RailActions setters={{ membersOpen, setMembersOpen, setSettingsOpen }} />
+            </aside>
+
+            <SettingsDrawer open={settingsOpen()} onClose={() => setSettingsOpen(false)} />
+          </div>
+        }
+      >
+        {/* ── Mobile layout ──────────────────────────────────────────────
+          Spec #10 mobile reshape. Vertical order top→bottom:
+            TopicBar (single hamburger — members only; no channel hamburger)
+            Scrollback (1fr)
+            ComposeBox
+            BottomBar (window picker, horizontal scroll, UNDER compose)
+          Members pane: slide-in-from-right drawer toggled by the single
+          hamburger in TopicBar (aria-label "open members sidebar").
+          Channel sidebar (.shell-sidebar) is not part of this layout —
+          channels are navigated via BottomBar. This is a full JSX branch,
+          not a CSS-display toggle, so the sidebar DOM is absent entirely.
+          #1041 mounts it TRANSIENTLY below, as a `position: fixed` left
+          drawer that exists only while the left-edge swipe has it on
+          screen: it never takes a grid track and it is gone again the
+          moment it hides, so "absent unless on screen" still holds.
+      */}
+        <div
+          class="shell shell-mobile"
+          // #308 INC-A — right-edge swipe (right→center) opens the members drawer;
+          // #1041 — left-edge swipe (left→center) opens the channel sidebar. Both
+          // are ADDITIVE second doors onto a rail (the BottomBar stays the primary
+          // nav — #71 ruling). Bound at element level with a non-passive touchmove
+          // + explicit onCleanup (Solid delegates touch to a passive document
+          // listener, and function refs are not re-invoked at unmount — #308
+          // landmines 1 + 3). Claims late, so a vertical drag is left entirely to
+          // native scroll (the hard constraint). Mobile-only: the ref lives in the
+          // isMobile() JSX branch, so it attaches only here.
+          ref={(el) =>
+            onCleanup(
+              bindEdgeGesture(el, {
+                viewportWidth: () => window.innerWidth,
+                // #1041 — the sidebar joins the panel mutex from THIS side, at the
+                // call site. Once a left drawer can be up, its backdrop is a child
+                // of `.shell-mobile`, so a right-edge touch that lands on it
+                // bubbles here and arms this arm with the other drawer still on
+                // screen. Honour the gesture and retire the sidebar rather than
+                // refuse it (the left arm's posture): a pull toward the members
+                // rail means "show me the members", and a silently dropped
+                // directional gesture is the surprising reading. `closeSidebar` is
+                // a no-op when nothing is mounted, so the plain #308 case is
+                // untouched. It runs FIRST so both animations start on the same
+                // frame — one drawer leaves as the other arrives.
+                onOpenMembers: () => {
+                  closeSidebar();
+                  openMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen });
+                },
+                // #1041 — refuse the gesture while ANY overlay is up rather than
+                // teaching the mobilePanel mutex a fourth member. A backdrop or a
+                // modal is a child of `.shell-mobile`, so its touches still bubble
+                // to this listener and a left swipe would otherwise stack a second
+                // drawer under an open one. `overlayCount()` is the state that
+                // already answers "is something covering the shell" for every
+                // present AND future overlay — derive it, don't mirror it. Read
+                // outside a tracking scope, so this subscribes to nothing.
+                // The asymmetry with the members arm above is deliberate: that arm
+                // faces ONE sibling drawer it can retire, this one faces every
+                // modal in the shell — and "close whatever is covering me" is not
+                // a swipe's decision to make.
+                onOpenSidebar: () => {
+                  if (overlayCount() > 0) return;
+                  openSidebar();
+                },
+              }),
+            )
+          }
+        >
+          {/* UX-6 D6 — DiagFloat lives in a Portal mounted on document.body
+            so it is anchored to the layout viewport independent of this
+            subtree (visible above the on-screen keyboard during
+            convergence probing). NB: `.shell-mobile` is NOT a
+            transform/containing block today (verified #264 — see
+            DESIGN_NOTES); the Portal keeps DiagFloat robust should one
+            ever be added. `position: fixed` descendants (e.g.
+            `.next-active-btn-mobile`) likewise anchor to the viewport —
+            do NOT add a `transform` to `.shell-mobile` without revisiting
+            #264's keyboard-ride. */}
+          <Portal>
+            <DiagFloat />
+          </Portal>
+          <ErrorBanners />
+          <Toasts />
+          <PrivacyModal />
+          <MediaViewerModal />
+          <NamesModal />
+          <ThemeEditor />
+          <WhoModal />
+          <LinksModal />
+          <UmodeModal />
+          <ModeModal />
+          <BanlistModal />
+          <ServerReplyModal />
+          <ServiceModal />
+          <RegistrationWizardModal />
+          <RecoverModal />
+          <ShareSessionModal />
+          {/* #1773 — see the desktop branch above for why it is mounted here. */}
+          <CreditsModal />
+          <ConfirmModal />
+          <Show when={membersOpen()}>
+            <div
+              class="shell-drawer-backdrop open"
+              onClick={() => setMembersOpen(false)}
+              aria-hidden="true"
+            />
+          </Show>
+
+          <section class="shell-main">
+            {/* Mobile-non-channel windows (home / mentions / admin / server /
+              list) render the standalone .shell-chrome row. #71 INC-2 (R1):
+              its settings cog became the ☰ RAIL OPENER — the cog itself moved
+              into the rail (#473: the `.shell-members` drawer's RailActions).
+              This is the opener for non-channel windows (channel windows open the
+              same drawer via the TopicBar hamburger — ONE drawer, one ☰ glyph,
+              per the Opt-A ruling). Mobile-channel still suppresses this row so
+              the scrollback reclaims the ~32px. Earlier history of this surface
+              in the bucket commits (UX-4 L, UX-5 A, UX-5 BT, UX-5 BM). */}
+            {/* Admin redesign (2026-08-07) — the admin kind is excluded too. The
+              row would hold nothing but the ☰ and sit directly above the pane's
+              own "admin console" header: two chrome bands for one title on a
+              phone. AdminPane renders the SAME `RailOpenerButton` inline in that
+              header instead, so the opener stays reachable on the admin window
+              (bucket L, asserted in ux-4-z-cluster-journey) and the testid stays
+              singular — the two mounts are mutually exclusive by this gate. */}
+            {/* #1050 — `list` is the third exclusion, for the same collision the
+              admin note above describes but with the opposite remedy. The
+              directory pane's close ✕ is the LAST child of its header, i.e. the
+              top-right corner the #985 float lands in at z-index 41, so the ☰
+              won the hit test and the tap that should leave the directory
+              opened the rail instead. Admin re-homed the button into its own
+              pane header; here the owner's call is that this window does not
+              want the rail at all, so the row simply goes. Bucket L ("settings
+              reachable from every window kind") is knowingly relaxed for this
+              ONE kind — every other non-channel kind keeps the float. Whole-row
+              and not a `display: none` on the glyph: the row is what carries
+              the z-index, and its zero-height box would stay over the header.
+              Reads `selKind()` — the same memo the mobile `<Match>` below
+              switches on — rather than re-deriving the kind here. */}
+            <Show when={selKind() !== "channel" && selKind() !== "list" && !isAdminPaneVisible()}>
+              <ShellChrome
+                leading={windowsRailOpener()}
+                onOpenRail={() =>
+                  toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
+                }
+              />
+            </Show>
+            {/* #134 — CRT loading splash (mobile). Same loading-only
+              contract as desktop: the fallback is the cold-load state. */}
+            <Switch fallback={<CrtSplash />}>
+              <Match when={isAdminPaneVisible()}>
+                <AdminPane
+                  onOpenRail={() =>
+                    toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
+                  }
+                />
+              </Match>
+              <Match when={kindHasScrollback(selKind())}>
+                {/* BUGHUNT-3 D — channel + query + server share ONE Match
+                  so ScrollbackPane stays mounted across kind transitions.
+                  See desktop branch comment for details. */}
+                {/* #351 — whole-pane drag-and-drop upload target (mobile).
+                  Same DropUploadZone wrapper as desktop; see that branch's
+                  comment. It wraps the channel-gated TopicBar Show plus the
+                  scrollback + compose stack, so a drop over the topic header,
+                  the scrollback, or the compose strip all upload identically. */}
                 <DropUploadZone
                   networkSlug={selectedChannel()?.networkSlug ?? ""}
                   channelName={selectedChannel()?.channelName ?? ""}
                 >
                   <Show when={selKind() === "channel"}>
+                    {/* C6.3 / UX-5 bucket A: TopicBar's
+                      `.topic-bar-hamburger` is the single
+                      members-drawer toggle on mobile (CSS-hidden
+                      on desktop via @media). ShellChrome above no
+                      longer renders its own hamburger.
+                      UX-5 bucket BM (2026-05-20) — `inlineChromeSlot`
+                      dropped on mobile-channel: archive + cog
+                      buttons moved INTO the members drawer footer
+                      (see below). TopicBar's right edge now hosts
+                      ONLY the hamburger. onToggleMembers routes
+                      through `toggleMembersPanel` to enforce the
+                      members | settings | archive | none mutex —
+                      opening members closes the sibling surfaces. */}
                     <TopicBar
                       networkSlug={selectedChannel()?.networkSlug ?? ""}
                       channelName={selectedChannel()?.channelName ?? ""}
-                      onToggleMembers={() => setMembersOpen((v) => !v)}
-                      /* #1766 — desktop has a permanent sidebar, so there is
-                         no window-list door to open and nothing to hide. The
-                         band's ☰ is `display: none` up here anyway; passing
-                         `null` means the button is never MOUNTED rather than
-                         mounted-and-hidden. */
-                      leading={null}
+                      onToggleMembers={() =>
+                        toggleMembersPanel({
+                          membersOpen,
+                          setMembersOpen,
+                          setSettingsOpen,
+                        })
+                      }
+                      leading={windowsRailOpener()}
                     />
                   </Show>
                   <ScrollbackPane
@@ -745,18 +1045,14 @@ const Shell: Component = () => {
                     networkSlug={selectedChannel()?.networkSlug ?? ""}
                     channelName={selectedChannel()?.channelName ?? ""}
                   />
-                  {/* GH #115 — docked audio mini-player, BELOW compose (#1701).
-                      Inside this Match so it survives channel↔query↔server
-                      switches (the kindHasScrollback Match stays mounted);
-                      leaving chat for home/list/mentions stops playback.
-                      Still inside DropUploadZone, so #351's whole-pane drop
-                      target keeps covering the strip. */}
-                  <AudioMiniPlayer />
+                  {/* GH #115 — the docked audio mini-player's SLOT. #1701 moved
+                    it BELOW compose, so on mobile it lands between the compose
+                    box and the BottomBar (a sibling of `.shell-main`, further
+                    down). #1896 — a dock, not a mount: see the desktop arm. */}
+                  <AudioDock />
                 </DropUploadZone>
               </Match>
               <Match when={selKind() === "mentions"}>
-                {/* C8.1 — mentions window. Rendered instead of ScrollbackPane+ComposeBox.
-                    onMentionClicked will navigate to channel + scroll-to-timestamp (C8.2). */}
                 <MentionsWindow
                   bundle={
                     mentionsBundleBySlug()[selectedChannel()?.networkSlug ?? ""] ?? {
@@ -773,57 +1069,117 @@ const Shell: Component = () => {
                 />
               </Match>
               <Match when={selKind() === "home"}>
-                {/* UX-4 bucket B — home pane. No TopicBar, no
-                    ComposeBox, no MembersPane (sibling <aside>
-                    already self-gates on isActiveChannelJoined). */}
+                {/* UX-4 bucket B — home pane on mobile. Same HomePane
+                  component as desktop; layout is the only branch
+                  difference. */}
                 <HomePane />
               </Match>
               <Match when={selKind() === "list"}>
-                {/* #84 E3 — channel directory pane. No TopicBar, no
-                    ComposeBox, no MembersPane. The $list window is a
-                    view+action pane (browse + join), not a chat pane. */}
+                {/* #84 E3 — channel directory pane on mobile. Same
+                  DirectoryPane component as desktop. */}
                 <DirectoryPane networkSlug={selectedChannel()?.networkSlug ?? ""} />
               </Match>
             </Switch>
           </section>
 
-          {/* #71 INC-2 (R1) — the right rail is now PERMANENT (decoupled from
-              the members panel). `.shell-no-members` no longer drops this
-              column; it narrows it to fit the rail buttons (default.css), so
-              they are reachable on every window kind. #473 — MembersPane is
-              conditional content at the top; the RailActions drawer (all the
-              labelled buttons) floors at the bottom. */}
+          {/* #1766 — the window bar is opt-OUT (default shown). A MOUNT gate and
+            not `display: none`: BottomBar carries no internal display guard by
+            design, and a CSS-hidden bar would keep running #327's double-rAF
+            scroll-into-view work against a strip nobody can see. Turning it
+            off is survivable because #1041's left-edge swipe exists — and
+            because `windowsRailOpener()` above gives that swipe an
+            affordance, which is what keeps this short of the drawer-only
+            navigation #71's second ruling refused. */}
+          <Show when={getShowBottomBar()}>
+            <BottomBar />
+          </Show>
+
+          {/* GH #235 — "jump to next active window" affordance (mobile).
+            #280: on scrollback windows (channel/query/server) it renders
+            INSIDE ScrollbackPane's float stack — stacked with
+            scroll-to-bottom, anchored to the message container. Here it
+            covers the NON-scrollback windows (home / mentions / list /
+            admin), which have no pane to anchor to and no scroll-to-bottom
+            to collide with, keeping the viewport-fixed placement.
+            Mutually exclusive via `kindHasScrollback` so exactly one
+            mobile next-active mounts. Self-hides when nothing is unread. */}
+          <Show when={!kindHasScrollback(selKind())}>
+            <NextActiveButton variant="mobile" />
+          </Show>
+
+          {/* #473 — ArchiveModal is the single archive surface on BOTH form
+            factors (also mounted in the desktop branch above). Opened from the
+            RailActions drawer archive button; self-gated on `archiveModalOpen()`
+            — renders nothing when closed. */}
+          <ArchiveModal />
+
+          {/* #1041 — the mobile channel sidebar, opened by the left-edge swipe.
+            Its own backdrop instance (the members drawer above has a separate
+            one): each drawer owns the surface that dismisses IT, so a tap can
+            never close the wrong one. Rendered only while the sidebar exists,
+            and it fades on the same 200ms as the panel. */}
+          <Show when={sidebarMounted()}>
+            <div
+              class="shell-drawer-backdrop"
+              classList={{ open: sidebarSlidIn() }}
+              onClick={closeSidebar}
+              aria-hidden="true"
+            />
+            {/* Same `.shell-sidebar` element the desktop grid mounts — the mobile
+              @media block turns it into a fixed left drawer. `<Sidebar />` is
+              mounted BARE here: NextActiveButton already has a mobile variant
+              elsewhere in this branch, and ResizeHandle is desktop-only.
+              #1041 restores Sidebar's `onSelect` prop, dropped in UX-5 bucket A
+              on the grounds that no drawer was left to close — a premise this
+              issue expires. Picking a window dismisses the drawer; the prop
+              fires on EVERY row activation, including a re-tap of the already
+              selected row (which a selection-watching effect would miss). */}
+            <aside
+              class="shell-sidebar"
+              classList={{ open: sidebarSlidIn() }}
+              onTransitionEnd={(e) => {
+                // Dispose at the END of the exit slide, never at the class flip.
+                // Descendants bubble their own transitions through here, hence
+                // the target check; the timer in closeSidebar covers the case
+                // where this never fires at all.
+                if (e.target !== e.currentTarget || e.propertyName !== "transform") return;
+                if (!sidebarSlidIn()) disposeSidebar();
+              }}
+            >
+              <Sidebar onSelect={closeSidebar} />
+            </aside>
+          </Show>
+
+          {/* #473 — the mobile members drawer IS the right rail, reachable on
+            EVERY window (channel: TopicBar ☰; non-channel: ShellChrome ☰ above —
+            ONE drawer). It mounts the SAME `RailActions` drawer as the desktop
+            rail: the post-#71 split (top ActionCluster cog + denoise, plus the
+            old footer's window-nav launchers AND its archive chip) folds into
+            ONE bottom drawer. The mobile-only `.mobile-panel-actions` footer is
+            gone — archive is now a first-class RailActions button. */}
           <aside class="shell-members" classList={{ open: membersOpen() }}>
-            {/* UX-5 bucket BS — drag handle on the inner edge of the
-                right (members) sidebar. Mounted unconditionally even
-                when isActiveChannelJoined(...) is false (the column
-                narrows via .shell-no-members in CSS); the handle is
-                inside the aside so it's hidden together. */}
-            <ResizeHandle side="right" />
             <Show when={isActiveChannelJoined(selectedChannel()) && selectedChannel()}>
               {(sel) => (
-                <MembersPane networkSlug={sel().networkSlug} channelName={sel().channelName} />
+                <MembersPane
+                  networkSlug={sel().networkSlug}
+                  channelName={sel().channelName}
+                  onMemberSelect={() => setMembersOpen(false)}
+                />
               )}
             </Show>
-            {/* #474 — the per-window-kind rail context surface (server info
-                today; a /whois card is the deferred follow-on), grafted as a
-                SIBLING of the drawer below. Renders nothing on kinds with no
-                context, so the drawer still floors the rail.
-                #782 — `onScreen` is unconditionally true here: this rail is a
-                PERMANENT grid column (#71 INC-2, `.shell-no-members` narrows
-                it but never drops it), and a query window renders no
-                MembersPane above the card, so it cannot be scrolled out of
-                view either. */}
-            <RailContext onScreen={true} />
-            {/* #473 — the ONE unified rail action drawer, floored at the bottom
-                (CSS `.rail-actions { margin-top: auto }`). Supersedes the desktop
-                top ActionCluster (cog + denoise) and, crucially, brings the
-                window-nav launchers (home / rooms / themes / admin) the desktop
-                rail never had — the desktop rail was "a cog and a monkey" (#473).
-                The mobile drawer mounts the SAME component (below). Archive is
-                now a first-class always-on RailActions button opening the single
-                grouped ArchiveModal (mounted above) — the desktop Sidebar
-                `<details>` and the mobile footer chip it replaced are removed. */}
+            {/* #474 — per-window-kind rail context (server info today), grafted
+              as a SIBLING of the drawer below; renders nothing off a server
+              window. Same component the desktop rail mounts.
+              #782 — this drawer is MOUNTED whether open or shut (closed is
+              `transform: translateX(100%)`, not an unmount), so `membersOpen`
+              is the only honest answer to "is the card on screen": without it
+              every mobile session would spend a WHOIS on a card behind the
+              right edge. */}
+            <RailContext onScreen={membersOpen()} />
+            {/* #473 — the ONE unified rail action drawer, floored at the bottom.
+              Same component + same handler set the desktop rail mounts (the
+              drawer-closing arm of the mobilePanel helpers is meaningful here on
+              mobile and a harmless no-op on the permanent desktop rail). */}
             {/* #682 — the radio surface, mounted UNCONDITIONALLY like the drawer
               below it and deliberately NOT as a `RailContext` arm: that
               component grafts by the active window's KIND and would drop the
@@ -836,359 +1192,20 @@ const Shell: Component = () => {
 
           <SettingsDrawer open={settingsOpen()} onClose={() => setSettingsOpen(false)} />
         </div>
-      }
-    >
-      {/* ── Mobile layout ──────────────────────────────────────────────
-          Spec #10 mobile reshape. Vertical order top→bottom:
-            TopicBar (single hamburger — members only; no channel hamburger)
-            Scrollback (1fr)
-            ComposeBox
-            BottomBar (window picker, horizontal scroll, UNDER compose)
-          Members pane: slide-in-from-right drawer toggled by the single
-          hamburger in TopicBar (aria-label "open members sidebar").
-          Channel sidebar (.shell-sidebar) is not part of this layout —
-          channels are navigated via BottomBar. This is a full JSX branch,
-          not a CSS-display toggle, so the sidebar DOM is absent entirely.
-          #1041 mounts it TRANSIENTLY below, as a `position: fixed` left
-          drawer that exists only while the left-edge swipe has it on
-          screen: it never takes a grid track and it is gone again the
-          moment it hides, so "absent unless on screen" still holds.
-      */}
-      <div
-        class="shell shell-mobile"
-        // #308 INC-A — right-edge swipe (right→center) opens the members drawer;
-        // #1041 — left-edge swipe (left→center) opens the channel sidebar. Both
-        // are ADDITIVE second doors onto a rail (the BottomBar stays the primary
-        // nav — #71 ruling). Bound at element level with a non-passive touchmove
-        // + explicit onCleanup (Solid delegates touch to a passive document
-        // listener, and function refs are not re-invoked at unmount — #308
-        // landmines 1 + 3). Claims late, so a vertical drag is left entirely to
-        // native scroll (the hard constraint). Mobile-only: the ref lives in the
-        // isMobile() JSX branch, so it attaches only here.
-        ref={(el) =>
-          onCleanup(
-            bindEdgeGesture(el, {
-              viewportWidth: () => window.innerWidth,
-              // #1041 — the sidebar joins the panel mutex from THIS side, at the
-              // call site. Once a left drawer can be up, its backdrop is a child
-              // of `.shell-mobile`, so a right-edge touch that lands on it
-              // bubbles here and arms this arm with the other drawer still on
-              // screen. Honour the gesture and retire the sidebar rather than
-              // refuse it (the left arm's posture): a pull toward the members
-              // rail means "show me the members", and a silently dropped
-              // directional gesture is the surprising reading. `closeSidebar` is
-              // a no-op when nothing is mounted, so the plain #308 case is
-              // untouched. It runs FIRST so both animations start on the same
-              // frame — one drawer leaves as the other arrives.
-              onOpenMembers: () => {
-                closeSidebar();
-                openMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen });
-              },
-              // #1041 — refuse the gesture while ANY overlay is up rather than
-              // teaching the mobilePanel mutex a fourth member. A backdrop or a
-              // modal is a child of `.shell-mobile`, so its touches still bubble
-              // to this listener and a left swipe would otherwise stack a second
-              // drawer under an open one. `overlayCount()` is the state that
-              // already answers "is something covering the shell" for every
-              // present AND future overlay — derive it, don't mirror it. Read
-              // outside a tracking scope, so this subscribes to nothing.
-              // The asymmetry with the members arm above is deliberate: that arm
-              // faces ONE sibling drawer it can retire, this one faces every
-              // modal in the shell — and "close whatever is covering me" is not
-              // a swipe's decision to make.
-              onOpenSidebar: () => {
-                if (overlayCount() > 0) return;
-                openSidebar();
-              },
-            }),
-          )
-        }
-      >
-        {/* UX-6 D6 — DiagFloat lives in a Portal mounted on document.body
-            so it is anchored to the layout viewport independent of this
-            subtree (visible above the on-screen keyboard during
-            convergence probing). NB: `.shell-mobile` is NOT a
-            transform/containing block today (verified #264 — see
-            DESIGN_NOTES); the Portal keeps DiagFloat robust should one
-            ever be added. `position: fixed` descendants (e.g.
-            `.next-active-btn-mobile`) likewise anchor to the viewport —
-            do NOT add a `transform` to `.shell-mobile` without revisiting
-            #264's keyboard-ride. */}
-        <Portal>
-          <DiagFloat />
-        </Portal>
-        <ErrorBanners />
-        <Toasts />
-        <PrivacyModal />
-        <MediaViewerModal />
-        <NamesModal />
-        <ThemeEditor />
-        <WhoModal />
-        <LinksModal />
-        <UmodeModal />
-        <ModeModal />
-        <BanlistModal />
-        <ServerReplyModal />
-        <ServiceModal />
-        <RegistrationWizardModal />
-        <RecoverModal />
-        <ShareSessionModal />
-        {/* #1773 — see the desktop branch above for why it is mounted here. */}
-        <CreditsModal />
-        <ConfirmModal />
-        <Show when={membersOpen()}>
-          <div
-            class="shell-drawer-backdrop open"
-            onClick={() => setMembersOpen(false)}
-            aria-hidden="true"
-          />
-        </Show>
+      </Show>
 
-        <section class="shell-main">
-          {/* Mobile-non-channel windows (home / mentions / admin / server /
-              list) render the standalone .shell-chrome row. #71 INC-2 (R1):
-              its settings cog became the ☰ RAIL OPENER — the cog itself moved
-              into the rail (#473: the `.shell-members` drawer's RailActions).
-              This is the opener for non-channel windows (channel windows open the
-              same drawer via the TopicBar hamburger — ONE drawer, one ☰ glyph,
-              per the Opt-A ruling). Mobile-channel still suppresses this row so
-              the scrollback reclaims the ~32px. Earlier history of this surface
-              in the bucket commits (UX-4 L, UX-5 A, UX-5 BT, UX-5 BM). */}
-          {/* Admin redesign (2026-08-07) — the admin kind is excluded too. The
-              row would hold nothing but the ☰ and sit directly above the pane's
-              own "admin console" header: two chrome bands for one title on a
-              phone. AdminPane renders the SAME `RailOpenerButton` inline in that
-              header instead, so the opener stays reachable on the admin window
-              (bucket L, asserted in ux-4-z-cluster-journey) and the testid stays
-              singular — the two mounts are mutually exclusive by this gate. */}
-          {/* #1050 — `list` is the third exclusion, for the same collision the
-              admin note above describes but with the opposite remedy. The
-              directory pane's close ✕ is the LAST child of its header, i.e. the
-              top-right corner the #985 float lands in at z-index 41, so the ☰
-              won the hit test and the tap that should leave the directory
-              opened the rail instead. Admin re-homed the button into its own
-              pane header; here the owner's call is that this window does not
-              want the rail at all, so the row simply goes. Bucket L ("settings
-              reachable from every window kind") is knowingly relaxed for this
-              ONE kind — every other non-channel kind keeps the float. Whole-row
-              and not a `display: none` on the glyph: the row is what carries
-              the z-index, and its zero-height box would stay over the header.
-              Reads `selKind()` — the same memo the mobile `<Match>` below
-              switches on — rather than re-deriving the kind here. */}
-          <Show when={selKind() !== "channel" && selKind() !== "list" && !isAdminPaneVisible()}>
-            <ShellChrome
-              leading={windowsRailOpener()}
-              onOpenRail={() =>
-                toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
-              }
-            />
-          </Show>
-          {/* #134 — CRT loading splash (mobile). Same loading-only
-              contract as desktop: the fallback is the cold-load state. */}
-          <Switch fallback={<CrtSplash />}>
-            <Match when={isAdminPaneVisible()}>
-              <AdminPane
-                onOpenRail={() =>
-                  toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
-                }
-              />
-            </Match>
-            <Match when={kindHasScrollback(selKind())}>
-              {/* BUGHUNT-3 D — channel + query + server share ONE Match
-                  so ScrollbackPane stays mounted across kind transitions.
-                  See desktop branch comment for details. */}
-              {/* #351 — whole-pane drag-and-drop upload target (mobile).
-                  Same DropUploadZone wrapper as desktop; see that branch's
-                  comment. It wraps the channel-gated TopicBar Show plus the
-                  scrollback + compose stack, so a drop over the topic header,
-                  the scrollback, or the compose strip all upload identically. */}
-              <DropUploadZone
-                networkSlug={selectedChannel()?.networkSlug ?? ""}
-                channelName={selectedChannel()?.channelName ?? ""}
-              >
-                <Show when={selKind() === "channel"}>
-                  {/* C6.3 / UX-5 bucket A: TopicBar's
-                      `.topic-bar-hamburger` is the single
-                      members-drawer toggle on mobile (CSS-hidden
-                      on desktop via @media). ShellChrome above no
-                      longer renders its own hamburger.
-                      UX-5 bucket BM (2026-05-20) — `inlineChromeSlot`
-                      dropped on mobile-channel: archive + cog
-                      buttons moved INTO the members drawer footer
-                      (see below). TopicBar's right edge now hosts
-                      ONLY the hamburger. onToggleMembers routes
-                      through `toggleMembersPanel` to enforce the
-                      members | settings | archive | none mutex —
-                      opening members closes the sibling surfaces. */}
-                  <TopicBar
-                    networkSlug={selectedChannel()?.networkSlug ?? ""}
-                    channelName={selectedChannel()?.channelName ?? ""}
-                    onToggleMembers={() =>
-                      toggleMembersPanel({
-                        membersOpen,
-                        setMembersOpen,
-                        setSettingsOpen,
-                      })
-                    }
-                    leading={windowsRailOpener()}
-                  />
-                </Show>
-                <ScrollbackPane
-                  networkSlug={selectedChannel()?.networkSlug ?? ""}
-                  channelName={selectedChannel()?.channelName ?? ""}
-                  kind={(selKind() as "channel" | "query" | "server") ?? "channel"}
-                />
-                <ComposeBox
-                  networkSlug={selectedChannel()?.networkSlug ?? ""}
-                  channelName={selectedChannel()?.channelName ?? ""}
-                />
-                {/* GH #115 — docked audio mini-player. #1701 moved it BELOW
-                    compose, so on mobile it lands between the compose box and
-                    the BottomBar (a sibling of `.shell-main`, further down). */}
-                <AudioMiniPlayer />
-              </DropUploadZone>
-            </Match>
-            <Match when={selKind() === "mentions"}>
-              <MentionsWindow
-                bundle={
-                  mentionsBundleBySlug()[selectedChannel()?.networkSlug ?? ""] ?? {
-                    network_slug: selectedChannel()?.networkSlug ?? "",
-                    away_started_at: "",
-                    away_ended_at: "",
-                    away_reason: null,
-                    messages: [],
-                  }
-                }
-                ownNick={ownNickForSlug(selectedChannel()?.networkSlug ?? "")}
-                onMentionClicked={handleMentionClicked}
-                onClose={() => closeToPreviousWindow(selectedChannel()?.networkSlug ?? "")}
-              />
-            </Match>
-            <Match when={selKind() === "home"}>
-              {/* UX-4 bucket B — home pane on mobile. Same HomePane
-                  component as desktop; layout is the only branch
-                  difference. */}
-              <HomePane />
-            </Match>
-            <Match when={selKind() === "list"}>
-              {/* #84 E3 — channel directory pane on mobile. Same
-                  DirectoryPane component as desktop. */}
-              <DirectoryPane networkSlug={selectedChannel()?.networkSlug ?? ""} />
-            </Match>
-          </Switch>
-        </section>
-
-        {/* #1766 — the window bar is opt-OUT (default shown). A MOUNT gate and
-            not `display: none`: BottomBar carries no internal display guard by
-            design, and a CSS-hidden bar would keep running #327's double-rAF
-            scroll-into-view work against a strip nobody can see. Turning it
-            off is survivable because #1041's left-edge swipe exists — and
-            because `windowsRailOpener()` above gives that swipe an
-            affordance, which is what keeps this short of the drawer-only
-            navigation #71's second ruling refused. */}
-        <Show when={getShowBottomBar()}>
-          <BottomBar />
-        </Show>
-
-        {/* GH #235 — "jump to next active window" affordance (mobile).
-            #280: on scrollback windows (channel/query/server) it renders
-            INSIDE ScrollbackPane's float stack — stacked with
-            scroll-to-bottom, anchored to the message container. Here it
-            covers the NON-scrollback windows (home / mentions / list /
-            admin), which have no pane to anchor to and no scroll-to-bottom
-            to collide with, keeping the viewport-fixed placement.
-            Mutually exclusive via `kindHasScrollback` so exactly one
-            mobile next-active mounts. Self-hides when nothing is unread. */}
-        <Show when={!kindHasScrollback(selKind())}>
-          <NextActiveButton variant="mobile" />
-        </Show>
-
-        {/* #473 — ArchiveModal is the single archive surface on BOTH form
-            factors (also mounted in the desktop branch above). Opened from the
-            RailActions drawer archive button; self-gated on `archiveModalOpen()`
-            — renders nothing when closed. */}
-        <ArchiveModal />
-
-        {/* #1041 — the mobile channel sidebar, opened by the left-edge swipe.
-            Its own backdrop instance (the members drawer above has a separate
-            one): each drawer owns the surface that dismisses IT, so a tap can
-            never close the wrong one. Rendered only while the sidebar exists,
-            and it fades on the same 200ms as the panel. */}
-        <Show when={sidebarMounted()}>
-          <div
-            class="shell-drawer-backdrop"
-            classList={{ open: sidebarSlidIn() }}
-            onClick={closeSidebar}
-            aria-hidden="true"
-          />
-          {/* Same `.shell-sidebar` element the desktop grid mounts — the mobile
-              @media block turns it into a fixed left drawer. `<Sidebar />` is
-              mounted BARE here: NextActiveButton already has a mobile variant
-              elsewhere in this branch, and ResizeHandle is desktop-only.
-              #1041 restores Sidebar's `onSelect` prop, dropped in UX-5 bucket A
-              on the grounds that no drawer was left to close — a premise this
-              issue expires. Picking a window dismisses the drawer; the prop
-              fires on EVERY row activation, including a re-tap of the already
-              selected row (which a selection-watching effect would miss). */}
-          <aside
-            class="shell-sidebar"
-            classList={{ open: sidebarSlidIn() }}
-            onTransitionEnd={(e) => {
-              // Dispose at the END of the exit slide, never at the class flip.
-              // Descendants bubble their own transitions through here, hence
-              // the target check; the timer in closeSidebar covers the case
-              // where this never fires at all.
-              if (e.target !== e.currentTarget || e.propertyName !== "transform") return;
-              if (!sidebarSlidIn()) disposeSidebar();
-            }}
-          >
-            <Sidebar onSelect={closeSidebar} />
-          </aside>
-        </Show>
-
-        {/* #473 — the mobile members drawer IS the right rail, reachable on
-            EVERY window (channel: TopicBar ☰; non-channel: ShellChrome ☰ above —
-            ONE drawer). It mounts the SAME `RailActions` drawer as the desktop
-            rail: the post-#71 split (top ActionCluster cog + denoise, plus the
-            old footer's window-nav launchers AND its archive chip) folds into
-            ONE bottom drawer. The mobile-only `.mobile-panel-actions` footer is
-            gone — archive is now a first-class RailActions button. */}
-        <aside class="shell-members" classList={{ open: membersOpen() }}>
-          <Show when={isActiveChannelJoined(selectedChannel()) && selectedChannel()}>
-            {(sel) => (
-              <MembersPane
-                networkSlug={sel().networkSlug}
-                channelName={sel().channelName}
-                onMemberSelect={() => setMembersOpen(false)}
-              />
-            )}
-          </Show>
-          {/* #474 — per-window-kind rail context (server info today), grafted
-              as a SIBLING of the drawer below; renders nothing off a server
-              window. Same component the desktop rail mounts.
-              #782 — this drawer is MOUNTED whether open or shut (closed is
-              `transform: translateX(100%)`, not an unmount), so `membersOpen`
-              is the only honest answer to "is the card on screen": without it
-              every mobile session would spend a WHOIS on a card behind the
-              right edge. */}
-          <RailContext onScreen={membersOpen()} />
-          {/* #473 — the ONE unified rail action drawer, floored at the bottom.
-              Same component + same handler set the desktop rail mounts (the
-              drawer-closing arm of the mobilePanel helpers is meaningful here on
-              mobile and a harmless no-op on the permanent desktop rail). */}
-          {/* #682 — the radio surface, mounted UNCONDITIONALLY like the drawer
-              below it and deliberately NOT as a `RailContext` arm: that
-              component grafts by the active window's KIND and would drop the
-              panel the moment the operator switched to a query. Idle it renders
-              nothing at all, so #500's vertical budget is untouched until a
-              station is tuned; its picker overlays the whole rail. */}
-          <RailRadio />
-          <RailActions setters={{ membersOpen, setMembersOpen, setSettingsOpen }} />
-        </aside>
-
-        <SettingsDrawer open={settingsOpen()} onClose={() => setSettingsOpen(false)} />
-      </div>
-    </Show>
+      {/* GH #115 / #1896 — THE player, mounted once, OUTSIDE the regime branch.
+          The two arms above are a JSX split and not a CSS toggle, so a phone
+          crossing 768px on rotation destroys one whole subtree and builds the
+          other: a player mounted inside an arm came back as a NEW <audio>
+          element, which for a stream means re-tuning — a new HTTP connection,
+          heard as a gap and a restart. Mounted here it is untouched by the
+          flip, and its chrome travels to whichever <AudioDock /> is live.
+          AFTER the <Show> on purpose: the branch (and therefore its dock) is
+          built first, so the player finds a dock on its very first render
+          instead of docking a tick later. */}
+      <AudioMiniPlayer />
+    </>
   );
 };
 

--- a/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
+++ b/cicchetto/src/__tests__/AudioMiniPlayer.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AudioDock from "../AudioDock";
 import AudioMiniPlayer from "../AudioMiniPlayer";
 import {
   activeAudio,
@@ -15,6 +16,20 @@ import type { RadioStation } from "../lib/radioStations";
 // the player drives so the component mounts without "Not implemented".
 // Real playback is e2e/device territory (Playwright + iPhone dogfood);
 // these tests pin the bar's show/hide + control wiring only.
+// #1896 — the bar is PORTALLED into a dock now (the element is mounted once
+// above Shell's regime branch so a rotation cannot tear it down), so a player
+// rendered on its own has nowhere to put its chrome and every test here mounts
+// the pair. The dock comes FIRST: its `ref` registers during that element's
+// creation, so the player's first render already sees one and the bar is in the
+// DOM synchronously, exactly as it was before this issue.
+const renderPlayer = () =>
+  render(() => (
+    <>
+      <AudioDock />
+      <AudioMiniPlayer />
+    </>
+  ));
+
 let playSpy: ReturnType<typeof vi.spyOn>;
 let pauseSpy: ReturnType<typeof vi.spyOn>;
 let loadSpy: ReturnType<typeof vi.spyOn>;
@@ -71,12 +86,12 @@ afterEach(() => {
 
 describe("AudioMiniPlayer", () => {
   it("renders no bar when no audio is active", () => {
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     expect(screen.queryByTestId("audio-mini-player")).toBeNull();
   });
 
   it("shows the bar and starts playback when an audio link is played", () => {
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://grappa.example/uploads/abc", null);
 
     expect(screen.getByTestId("audio-mini-player")).toBeInTheDocument();
@@ -84,7 +99,7 @@ describe("AudioMiniPlayer", () => {
   });
 
   it("close button stops playback and hides the bar", () => {
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://grappa.example/uploads/abc", null);
 
     screen.getByTestId("audio-mini-player-close").click();
@@ -98,7 +113,7 @@ describe("AudioMiniPlayer", () => {
     // Structure only — actual play/pause + seek behavior depends on
     // real media state jsdom does not implement; that is pinned by the
     // Playwright e2e + iPhone dogfood, not here.
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://grappa.example/uploads/abc", null);
 
     expect(screen.getByTestId("audio-mini-player-toggle")).toBeInTheDocument();
@@ -110,7 +125,7 @@ describe("AudioMiniPlayer", () => {
     // Same-origin `download` anchor: forces a save (overriding the
     // server's `inline` disposition) and inherits the server's
     // Content-Disposition filename — no value needed.
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://grappa.example/uploads/abc", null);
 
     const dl = screen.getByTestId("audio-mini-player-download");
@@ -135,7 +150,7 @@ describe("AudioMiniPlayer", () => {
   };
 
   it("a finite duration keeps the seek control and the download link", () => {
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://grappa.example/uploads/abc", null);
 
     loadMetadataWithDuration(212);
@@ -146,7 +161,7 @@ describe("AudioMiniPlayer", () => {
   });
 
   it("an endless stream drops the seek control — there is nothing to scrub", () => {
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
 
     loadMetadataWithDuration(Number.POSITIVE_INFINITY);
@@ -159,7 +174,7 @@ describe("AudioMiniPlayer", () => {
     // Two independent reasons, either one sufficient: the resource has no
     // end, so the save never finishes; and `download` is ignored outright on
     // a cross-origin href, so the anchor would navigate away from the app.
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
 
     loadMetadataWithDuration(Number.POSITIVE_INFINITY);
@@ -171,7 +186,7 @@ describe("AudioMiniPlayer", () => {
     // `duration` is NaN whenever the element cannot state a length. Seeking
     // is exactly as meaningless there as against Infinity, so the predicate
     // is "not a finite number" rather than "=== Infinity".
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://ice.somafm.com/dronezone-128-mp3", "Drone Zone");
 
     loadMetadataWithDuration(Number.NaN);
@@ -185,14 +200,14 @@ describe("AudioMiniPlayer", () => {
     // (`transform: translateX(100%)`), so while a station plays this docked
     // bar is the ONLY thing on screen naming it. Without the label the phone
     // cannot answer "what am I listening to".
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://ice.somafm.com/groovesalad-128-mp3", "Groove Salad");
 
     expect(screen.getByTestId("audio-mini-player-label")).toHaveTextContent("Groove Salad");
   });
 
   it("renders no label slot for an unlabelled source", () => {
-    render(() => <AudioMiniPlayer />);
+    renderPlayer();
     playAudio("https://grappa.example/uploads/abc", null);
 
     expect(screen.queryByTestId("audio-mini-player-label")).toBeNull();
@@ -212,7 +227,7 @@ describe("AudioMiniPlayer", () => {
     const STATION = "https://ice.somafm.com/groovesalad-128-mp3";
 
     it("hiding removes the bar but leaves the source loaded and untouched", () => {
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       playSpy.mockClear();
       pauseSpy.mockClear();
@@ -230,7 +245,7 @@ describe("AudioMiniPlayer", () => {
       // flag. That re-fires `on(activeAudio)`, which reassigns `audioEl.src`
       // and calls `play()` again — a visible re-buffer of a live stream, which
       // is precisely the thing "hide ≠ stop" forbids.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       playSpy.mockClear();
       pauseSpy.mockClear();
@@ -242,7 +257,7 @@ describe("AudioMiniPlayer", () => {
     });
 
     it("the bar comes back with the same source still attached", () => {
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       screen.getByTestId("audio-mini-player-hide").click();
       playSpy.mockClear();
@@ -258,7 +273,7 @@ describe("AudioMiniPlayer", () => {
       // Guards against the tempting simplification of folding them: the ✕ is
       // the STOP verb (#115) and the phone's only reachable one while the rail
       // is slid off-screen.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
 
       expect(screen.getByTestId("audio-mini-player-hide")).toBeInTheDocument();
@@ -269,7 +284,7 @@ describe("AudioMiniPlayer", () => {
     });
 
     it("a new source re-shows a hidden bar rather than playing behind it", () => {
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       screen.getByTestId("audio-mini-player-hide").click();
 
@@ -307,7 +322,7 @@ describe("AudioMiniPlayer", () => {
       const station = RADIO_STATIONS[0];
       if (station === undefined) throw new Error("the curated table must carry a station");
 
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       tuneStation(station);
 
       // #1701 — wait for the STUBBED TEXT, not for the element.
@@ -339,7 +354,7 @@ describe("AudioMiniPlayer", () => {
     it("shows no track slot for an audio upload", () => {
       // An upload is not a station and has no feed. The slot must be absent
       // rather than empty — an empty span still takes its gap.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio("https://grappa.example/uploads/abc", null);
 
       expect(screen.queryByTestId("audio-mini-player-track")).toBeNull();
@@ -441,7 +456,7 @@ describe("AudioMiniPlayer", () => {
       // The reported symptom. `play()` on an element whose media resource is
       // gone resolves and produces silence; only `load()` goes back for a new
       // one.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       loadMetadataWithDuration(Number.POSITIVE_INFINITY);
       fire("play");
@@ -459,7 +474,7 @@ describe("AudioMiniPlayer", () => {
       // reload": a file HAS a position, resuming at `currentTime` is the whole
       // point of pausing one, and re-fetching would throw that away along with
       // whatever is already buffered.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(UPLOAD, null);
       loadMetadataWithDuration(212);
       fire("play");
@@ -477,7 +492,7 @@ describe("AudioMiniPlayer", () => {
       // the same rule covers it. This is the half the issue called the broader
       // form, and it costs nothing to include: `error !== null` is exactly
       // "cannot continue from here".
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(UPLOAD, null);
       loadMetadataWithDuration(212);
       fire("play");
@@ -494,7 +509,7 @@ describe("AudioMiniPlayer", () => {
       // Half the reason nobody noticed the bug: with no `error` handler the bar
       // kept showing ⏸ over silence, so the transport looked like it had
       // worked.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       fire("play");
       expect(toggle()).toHaveAttribute("aria-label", "pause");
@@ -510,7 +525,7 @@ describe("AudioMiniPlayer", () => {
       // state there would flip the button to ▶ over audio that is still
       // coming, which is the same lie in the other direction. Only `error` is
       // terminal, and only `error` is listened to.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       fire("play");
 
@@ -531,7 +546,7 @@ describe("AudioMiniPlayer", () => {
       // What it does NOT establish: that a real browser leaves `paused` false
       // after a dropped stream. That is a spec reading, and the device verdict
       // is owed either way.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       fire("play");
       interrupt();
@@ -546,7 +561,7 @@ describe("AudioMiniPlayer", () => {
     });
 
     it("still pauses a healthy source, and does not re-fetch to do it", () => {
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       loadMetadataWithDuration(Number.POSITIVE_INFINITY);
       fire("play");
@@ -623,12 +638,12 @@ describe("AudioMiniPlayer", () => {
 
     it("a FILE that was playing comes back at its position, still playing", () => {
       playAudio(UPLOAD, null);
-      const first = render(() => <AudioMiniPlayer />);
+      const first = renderPlayer();
       settleAt(180, 42, true);
       playSpy.mockClear();
 
       first.unmount();
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       metadataArrives(180);
 
       expect(element().currentTime).toBe(42);
@@ -639,12 +654,12 @@ describe("AudioMiniPlayer", () => {
       // The half that separates "resume" from "restart something": a re-mount
       // the operator did not ask for must not start audio they had stopped.
       playAudio(UPLOAD, null);
-      const first = render(() => <AudioMiniPlayer />);
+      const first = renderPlayer();
       settleAt(180, 42, false);
       playSpy.mockClear();
 
       first.unmount();
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       metadataArrives(180);
 
       expect(element().currentTime).toBe(42);
@@ -657,12 +672,12 @@ describe("AudioMiniPlayer", () => {
       // not draw a seek slider across an endless source while the re-mounted
       // element waits for metadata it will never usefully answer.
       playAudio(STATION, "Groove Salad");
-      const first = render(() => <AudioMiniPlayer />);
+      const first = renderPlayer();
       settleAt(Number.POSITIVE_INFINITY, 42, true);
       playSpy.mockClear();
 
       first.unmount();
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
 
       expect(playSpy).toHaveBeenCalled();
       expect(screen.getByTestId("audio-mini-player-live")).toBeInTheDocument();
@@ -675,11 +690,11 @@ describe("AudioMiniPlayer", () => {
       // exists belongs to the source that is active. This test is what keeps
       // that invariant from being quietly broken by a fourth writer.
       playAudio(UPLOAD, null);
-      const first = render(() => <AudioMiniPlayer />);
+      const first = renderPlayer();
       settleAt(180, 42, true);
       first.unmount();
 
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio("https://grappa.example/uploads/second", null);
       metadataArrives(90);
 
@@ -750,7 +765,7 @@ describe("AudioMiniPlayer", () => {
     };
 
     it("names the failure on the bar", () => {
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
 
       failWith(2);
@@ -764,7 +779,7 @@ describe("AudioMiniPlayer", () => {
       // The distinction the operator acts on: a lost connection is worth
       // pressing play for, a source this browser cannot decode never will be.
       // Kohina on iOS < 18.4 is the second kind, permanently.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
 
       failWith(4);
@@ -779,7 +794,7 @@ describe("AudioMiniPlayer", () => {
       // instead of sitting beside it: with no metadata `duration` is a finite
       // 0, so the bar would otherwise draw a scrubber and a `0:00 / 0:00`
       // clock over a source that produced no audio at all.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       expect(screen.getByTestId("audio-mini-player-seek")).toBeInTheDocument();
 
@@ -796,7 +811,7 @@ describe("AudioMiniPlayer", () => {
       // cannot decode is exactly the upload the operator wants to save and open
       // in something that can. It is not a claim about playback — it is what
       // to do about the notice beside it.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(UPLOAD, null);
 
       failWith(4);
@@ -813,7 +828,7 @@ describe("AudioMiniPlayer", () => {
       // what is unchanged from before this issue: a stream that failed BEFORE
       // metadata reads `duration = 0`, which is finite, so it is not live as
       // far as this predicate can see.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       metadataArrives(Number.POSITIVE_INFINITY);
 
@@ -827,7 +842,7 @@ describe("AudioMiniPlayer", () => {
       // keeps `duration = Infinity`, so it wears the live badge and an elapsed
       // counter that has stopped counting — a clock that says the stream is
       // still on.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       metadataArrives(Number.POSITIVE_INFINITY);
       expect(screen.getByTestId("audio-mini-player-live")).toBeInTheDocument();
@@ -842,7 +857,7 @@ describe("AudioMiniPlayer", () => {
     it("keeps naming the source — the failure is ABOUT something", () => {
       // The label survives on purpose. "connection lost" with nothing beside it
       // does not tell the operator which station to re-pick.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
 
       failWith(2);
@@ -864,7 +879,7 @@ describe("AudioMiniPlayer", () => {
           json: async () => ({ songs: [{ title: "A Land Unknown", artist: "Trestal" }] }),
         } as unknown as Response),
       );
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       // #1701's barrier, for its reason: keyed on the STUBBED TEXT, so it
       // cannot return on whichever answer happened to land first.
@@ -885,7 +900,7 @@ describe("AudioMiniPlayer", () => {
     // URL. Here that would mean the error handler RESTARTING the source, which
     // for a codec failure is an infinite retry loop nobody asked for.
     it("reporting the failure does not re-tune the source", () => {
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       playSpy.mockClear();
       loadSpy.mockClear();
@@ -901,7 +916,7 @@ describe("AudioMiniPlayer", () => {
       // The retry is #1700's, unchanged — `mustRefetch` still decides to
       // `load()`. What is new is that the notice describes the LAST ATTEMPT, so
       // it must go when a new one starts.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       failWith(2);
 
@@ -916,7 +931,7 @@ describe("AudioMiniPlayer", () => {
       // Without the clear above, the second failure would write the same value
       // to the same signal, nothing would re-render, and the operator would tap
       // play and watch the bar do nothing at all.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       failWith(4);
       toggle().click();
@@ -930,7 +945,7 @@ describe("AudioMiniPlayer", () => {
     });
 
     it("tuning something else clears the previous source's failure", () => {
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       failWith(4);
 
@@ -956,7 +971,7 @@ describe("AudioMiniPlayer", () => {
       const ogg = RADIO_STATIONS.find((s) => s.streamUrl.endsWith(".ogg"));
       if (ogg === undefined) throw new Error("the table no longer carries an ogg station");
 
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(ogg.streamUrl, ogg.title);
 
       failWith(4);
@@ -975,7 +990,7 @@ describe("AudioMiniPlayer", () => {
       // playing", which is true, and #1700 already made pressing it re-fetch.
       // What was missing was the operator knowing there was something to retry,
       // and that is the span above, not a fourth glyph.
-      render(() => <AudioMiniPlayer />);
+      renderPlayer();
       playAudio(STATION, "Groove Salad");
       element().dispatchEvent(new Event("play"));
 

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -66,7 +66,30 @@ const selectionState = vi.hoisted(() => {
 });
 
 // Mutable isMobile ref so individual tests can flip to mobile mode.
-const mobileState = vi.hoisted(() => ({ value: false }));
+//
+// #1896 — a REAL Solid signal (lazy-init, same reason and shape as
+// `userHolder` below), because the regime is no longer only a start-up
+// condition: rotating a phone CROSSES the breakpoint mid-session, and a plain
+// object stored the new value without notifying the `<Show when={isMobile()}>`
+// that switches the two shells. Every pre-#1896 site assigns `.value` before
+// its `render(() => <Shell />)` (measured: 40 assignments, 0 after a render),
+// so making it notify changes nothing for them and is the only way to mount a
+// shell and then rotate it.
+const mobileState = vi.hoisted(() => {
+  let sig: [() => boolean, (v: boolean) => boolean] | null = null;
+  const ensure = () => {
+    if (sig === null) sig = createSignal<boolean>(false);
+    return sig;
+  };
+  return {
+    get value() {
+      return ensure()[0]();
+    },
+    set value(v: boolean) {
+      ensure()[1](v);
+    },
+  };
+});
 // UX-4 bucket M (2026-05-19) — bearer state for the post-login bootstrap
 // effect that loads the upload-TTL preference. Default null = no token
 // yet; tests that exercise the bootstrap set it before mount.
@@ -1620,14 +1643,41 @@ describe("#1701 — the docked player sits below the compose box", () => {
     expect(compose, "the compose box must be mounted").not.toBeNull();
     if (compose === null) return;
 
+    // #1896 — `closest`, not `parentElement`, and the change is forced rather
+    // than chosen: the bar is portalled into `<AudioDock />` now, so between it
+    // and the column sit the dock and the container Solid's <Portal> builds.
+    // The RULING is unchanged and so is what this rejects — a player hoisted
+    // out to a sibling of `.shell-main` has no `.drop-upload-zone` ancestor at
+    // all, which is the shape the original assertion was written against. What
+    // it can no longer see on its own is the two wrappers turning "flex item of
+    // the column" into "grandchild of it", so the sibling assertion below reads
+    // that off the stylesheet: `display: contents` is what keeps document
+    // ancestry and LAYOUT saying the same thing here.
     expect(
-      player.parentElement,
-      "the bar shares the compose box's column — hoisting it out puts it under the bottom bar",
+      player.closest(".drop-upload-zone"),
+      "the bar sits in the compose box's column — hoisting it out puts it under the bottom bar",
     ).toBe(compose.parentElement);
     expect(
       compose.compareDocumentPosition(player) & Node.DOCUMENT_POSITION_FOLLOWING,
       "the bar must come AFTER the compose box, not before it",
     ).toBeTruthy();
+  });
+
+  it("the boxes the dock adds are out of layout, so the bar is still a flex item of that column", () => {
+    // #1896 — the other half of the assertion above. Two wrappers now stand
+    // between `.drop-upload-zone` and `.audio-mini-player`; `display: contents`
+    // removes them from layout so the column lays the bar out directly. Read
+    // off the CSS text for the reason `audioMiniPlayerLayout` gives: jsdom
+    // applies no stylesheet, so a DOM assertion cannot see this at all.
+    //
+    // Asserted through the GROUP, spelled verbatim, the way that file reads its
+    // unshrinkable-controls rule: `nestedRuleBodies` matches the selector list
+    // exactly, so dropping either member throws `CSS rule not found` instead of
+    // quietly measuring a rule that no longer covers both wrappers. One wrapper
+    // left in layout is enough to make the bar a grandchild of the column.
+    const bodies = nestedRuleBodies(".audio-dock,\n.audio-dock-portal");
+    expect(bodies.length, "the dock pair must be declared in exactly one block").toBe(1);
+    expect(bodies[0]).toMatch(/display:\s*contents/);
   });
 
   it("that column is a plain top-to-bottom flex, so document order IS visual order", () => {
@@ -1636,6 +1686,85 @@ describe("#1701 — the docked player sits below the compose box", () => {
     const bodies = nestedRuleBodies(".drop-upload-zone");
     expect(bodies.length, ".drop-upload-zone must be declared in exactly one block").toBe(1);
     expect(bodies[0]).toMatch(/flex-direction:\s*column/);
+  });
+});
+
+// #1896 — ROTATION. The two shells are a JSX branch, not a CSS toggle, and a
+// phone whose landscape CSS width clears 768px crosses it every time it is
+// turned. Solid then destroys one subtree and builds the other, and the player
+// used to be mounted INSIDE both — so the `<audio>` on the far side was a
+// different element, its open effect ran as a first tune, and for a STREAM
+// `mustRefetch()` is true: a new HTTP connection to the station. That is the
+// audible gap the reporter heard, and the autoplay is the "restarts on its own".
+//
+// WHY THE ELEMENT'S IDENTITY IS THE ASSERTION AND NOT `play()` CALL COUNTS.
+// Counting `play()` would pass just as well for a rebuilt element that happened
+// not to autoplay — a green that says nothing about the transport surviving.
+// The element is what holds the connection, so the element is what must be the
+// same object. It is marked before the flip rather than compared by tag: a
+// fresh `<audio>` is `toBeInstanceOf`-identical to the old one and `querySelector`
+// would happily hand back the replacement.
+//
+// The three controls around it are load-bearing:
+//   * the bar must be MOUNTED before the flip (an absent player trivially
+//     survives one);
+//   * the branch must actually have SWITCHED (a resize that does not cross the
+//     breakpoint is the false green this whole file is about);
+//   * the chrome must be present again AFTER the flip — the element surviving
+//     is worthless if the transport it drives went with the old subtree.
+describe("#1896 — crossing the mobile breakpoint does not rebuild the audio element", () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
+    vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    closeAudio();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["portrait → landscape", true],
+    ["landscape → portrait", false],
+  ])("%s keeps the SAME <audio> element and re-docks the bar", async (_turn, startMobile) => {
+    mobileState.value = startMobile;
+    selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+    // An UPLOAD href, for the same reason #1701's sibling gives: a station href
+    // would tune `nowPlaying`'s poll at a third party from a unit test.
+    playAudio("https://grappa.example/uploads/abc", null);
+    const { container } = render(() => <Shell />);
+
+    const before = await waitFor(() => {
+      const el = container.querySelector("audio");
+      expect(el, "the player must be mounted for a rotation to mean anything").not.toBeNull();
+      expect(
+        container.querySelector(".audio-mini-player"),
+        "the transport must be docked before the flip",
+      ).not.toBeNull();
+      return el as HTMLAudioElement;
+    });
+    before.dataset.rotationProbe = "survived";
+
+    // THE ROTATION.
+    mobileState.value = !startMobile;
+
+    // Control: the branch really did switch. Without this the assertions below
+    // would pass on a rotation that never crossed the breakpoint.
+    expect(
+      container.querySelector(startMobile ? ".shell-mobile" : ".shell:not(.shell-mobile)"),
+      "the shell that was live before the flip must be gone",
+    ).toBeNull();
+
+    const after = container.querySelector("audio");
+    expect(after, "there must still be exactly one player").not.toBeNull();
+    expect(container.querySelectorAll("audio").length).toBe(1);
+    expect(after, "the element must be the SAME object, not a fresh one").toBe(before);
+    expect((after as HTMLAudioElement).dataset.rotationProbe).toBe("survived");
+    expect(
+      container.querySelector(".audio-mini-player"),
+      "the transport must have followed into the other shell's dock",
+    ).not.toBeNull();
   });
 });
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4397,6 +4397,24 @@ button.topic-bar-windows-opener {
    `env(safe-area-inset-bottom)` against the DEVICE, not the shrunken visual
    viewport, so an inset added HERE double-counts against `--viewport-height`
    and reopens the ~34px gap above the keyboard. */
+
+/* #1896 — the two boxes that now sit between the compose column and the bar:
+   the dock Shell renders in place of the old mount, and the container Solid's
+   <Portal> creates inside it. `display: contents` removes BOTH from layout, so
+   `.audio-mini-player` stays a direct FLEX ITEM of `.drop-upload-zone` — which
+   is what #1701's ruling ("inside the compose box's own flex column, after it")
+   is about. Without this the bar would be a block inside a block inside the
+   column: identical today, because the wrappers are full-width and auto-height
+   and the column declares no `gap`, and silently wrong the first time either of
+   those changes. Taking the boxes out of layout removes the class of bug rather
+   than the instance of it.
+   Both selectors are needed and neither is redundant: the dock is ours and the
+   portal container is Solid's, classed through the <Portal ref>. */
+.audio-dock,
+.audio-dock-portal {
+  display: contents;
+}
+
 .audio-mini-player {
   display: flex;
   align-items: center;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -44972,3 +44972,88 @@ the expiry rate nor how many expiring visitors hold uploads was measured —
 that is structure, not magnitude. Nor is the volume of already-orphaned bytes
 on production established; the defect is proved from the code, and the
 one-off sweep for existing orphans is a separate deliverable.
+<!-- entry #1896 -->
+
+---
+
+## 2026-09-01 — #1896: the shell's regime branch was tearing the radio down
+
+A user on a Galaxy S24 Ultra reported that rotating the phone with the radio
+playing drops the audio for a fraction of a second and then restarts it, every
+rotation, both directions. The issue read the chain out of the source and said
+so; this entry records that it was then **reproduced in-process** before
+anything was changed, and what the cure costs.
+
+### The chain, re-measured on `origin/main` before touching anything
+
+`isMobile()` is `matchMedia("(max-width: 768px)")` (`theme.ts`, `MOBILE_QUERY`)
+and `Shell` branches on it with a `<Show>` carrying two complete subtrees, each
+of which mounted its own `<AudioMiniPlayer />`. A phone whose landscape CSS
+width clears 768 flips that signal when it turns, Solid destroys one subtree and
+builds the other, and the `<audio>` on the far side is a different element. Its
+`on(activeAudio, …)` effect then runs as a first tune, and for a stream
+`mustRefetch()` is true (#1700 — a stream has no position to resume to,
+re-tuning IS its resume), so it re-fetches. The new HTTP connection is the gap;
+the `play()` beside it is the "restarts on its own".
+
+Reproduced, not argued: the new `Shell.test` case mounts the shell, marks the
+live `<audio>` object, flips the regime signal, and finds a different element on
+the other side. That required making the suite's `isMobile` mock a real signal —
+the regime had only ever been a start-up condition in tests, which is precisely
+why no existing test could see a rotation. Every pre-existing site assigns it
+before its `render`, measured (40 assignments, 0 after a render), so nothing
+else changed behaviour.
+
+### The cure, and why it is the element that must not move
+
+One `<AudioMiniPlayer />`, mounted once ABOVE the regime `<Show>`. Each branch
+renders an `<AudioDock />` where the player used to be, and the player portals
+its CHROME into whichever dock is live. The `<audio>` element never moves at
+all.
+
+Moving the element with the chrome — one `<Portal>` around the whole component —
+was rejected on the spec: a media element removed from a document has its
+internal pause steps queued after "await a stable state", so a same-task
+re-insertion probably survives. Probably is not a contract to ship playback on,
+and there is no need to: the chrome holds no transport state, so only the chrome
+has to travel.
+
+Two wrappers now stand between `.drop-upload-zone` and `.audio-mini-player` (the
+dock, and the container `<Portal>` builds inside it). Both are `display:
+contents`, so the bar remains a direct flex ITEM of the compose column — #1701's
+ruling. Without that the layout is identical today, because both wrappers are
+full-width and auto-height and the column declares no `gap`, and silently wrong
+the first time either of those changes. #1701's Shell assertion moved from
+`parentElement` to `closest(".drop-upload-zone")` for the same reason, and the
+CSS-text guard beside it is what keeps the weaker DOM assertion honest.
+
+### The consequence, named rather than discovered later
+
+The hoist necessarily lifts the player above the window-kind `<Switch>` too,
+because the regime `<Show>` encloses it. There is one arithmetic here, not two
+decisions: you cannot mount above the branch and remain inside the `<Match>`.
+
+So the #1701 kill-and-re-tune on a window switch is gone as well — including the
+half that file called "a defect in its own right and not this file's to fix", an
+upload restarting from the beginning when the operator visits home. What changes
+in exchange is that on home / list / mentions the audio now keeps playing with no
+bar on screen. That state is not new: #1697 ships it deliberately as
+`playerHidden`, and the doors out of it are the same ones — `RailRadio` and
+`RailActions` live in `.shell-members`, OUTSIDE the `<Switch>`, so stop and
+un-hide are reachable on every window kind in both regimes. Verified, not
+assumed.
+
+#1734's resume point is kept and unchanged. It now fires only on Shell's own
+teardown rather than on every window switch, which narrows WHEN it runs without
+touching what it must do.
+
+### Not established
+
+Not reproduced on hardware, and no device was rotated: the e2e crosses the
+breakpoint with `setViewportSize` in desktop Chromium, which is the same
+`matchMedia` edge and the same JSX flip, not an orientation change. The S24
+Ultra's real landscape CSS width was never read off the handset — the phone-shaped
+viewports in the spec straddle 768 by construction, they are not a measurement of
+the reporter's device. And nothing here says the audible gap is the ONLY thing a
+rotation costs: the flip rebuilds the whole subtree, and the audio element is the
+casualty that was measured.


### PR DESCRIPTION
Addresses issue 1896.

## What was wrong

The mobile/desktop split is a JSX branch and not a CSS toggle, so a phone whose
landscape CSS width clears 768px crosses it on every rotation. Solid destroys
one subtree and builds the other, and `<AudioMiniPlayer />` was mounted inside
BOTH: the `<audio>` on the far side of a turn was a different element, its open
effect ran as a first tune, and for a stream `mustRefetch()` is true (#1700 — a
stream has no position to resume to, re-tuning IS its resume). The new HTTP
connection is the audible gap the reporter heard; the `play()` beside it is the
"restarts on its own".

The issue said the chain was read out of the source and not reproduced. It is
reproduced now, in-process, before anything was changed: the new `Shell.test`
case marks the live `<audio>` object, flips the regime signal, and finds a
different element on the other side. That needed the suite's `isMobile` mock to
become a real signal — the regime had only ever been a start-up condition in
tests, which is exactly why nothing could see a rotation. Measured that every
pre-existing site assigns it before its `render` (40 assignments, 0 after one).

## What changed

One player, mounted above the regime `<Show>`. Each branch renders an
`<AudioDock />` where the mount used to be, and the player portals its CHROME
into whichever dock is live. The element itself never moves.

Portalling the whole component instead was rejected on the spec: a media element
removed from a document has its pause steps queued after "await a stable state",
so a same-task re-insertion probably survives — probably is not a contract to
ship playback on, and the chrome holds no transport state, so only the chrome
need travel.

The dock and the container `<Portal>` builds inside it are both `display:
contents`, so the bar stays a direct flex ITEM of the compose column (#1701's
ruling). Identical today without it — the wrappers are full-width, auto-height
and the column declares no `gap` — and silently wrong the first time any of
those changes. #1701's own Shell assertion moves from `parentElement` to
`closest(".drop-upload-zone")` for the same reason, with a CSS-text guard beside
it so the weaker DOM assertion stays honest.

## The consequence, named

The hoist necessarily lifts the player above the window-kind `<Switch>` too,
because the regime `<Show>` encloses it — one arithmetic, not two decisions. So
#1701's kill-and-re-tune on a window switch goes with it, including the upload
that restarted from the beginning on a visit to home. In exchange the audio now
keeps playing with no bar on home / list / mentions. Not a new state (#1697
ships it as `playerHidden`), and `RailRadio` + `RailActions` are mounted in
`.shell-members`, outside the `<Switch>`, so stop and un-hide stay reachable on
every window kind in both regimes. Verified, not assumed.

`#1734`'s resume point is kept and unchanged; it now fires only on Shell's own
teardown rather than on every window switch.

## Tests

- `Shell.test.tsx` — two rotation cases (both directions) asserting element
  identity, plus three controls: the bar must be mounted before the flip, the
  branch must actually have switched, and the chrome must be re-docked after.
- `Shell.test.tsx` — CSS-text guard on the dock pair's `display: contents`.
- `AudioMiniPlayer.test.tsx` — the 47 render sites go through one helper that
  mounts a dock beside the player; the dock comes first so the bar is in the DOM
  synchronously, as before.
- New e2e `issue1896-rotation-keeps-audio-element.spec.ts` — crosses the
  breakpoint three times in a real browser, asserting a marked element identity
  and unchanged `play()` / `.src`-setter counts taken from an init script, with
  the counters proven non-zero first, the branch proven switched at each
  crossing, and the bar proven docked after each one.

## Not established

Not reproduced on hardware, and no device was rotated: the e2e is a viewport
resize in desktop Chromium, so it reproduces the `matchMedia` edge and the JSX
flip, not an orientation change. The S24 Ultra's real landscape CSS width was
never read off the handset — the phone-shaped viewports straddle 768 by
construction. And nothing here claims the audible gap is the only thing a
rotation costs: the flip rebuilds the whole subtree, and the audio element is
the casualty that was measured.