### PR TITLE
fix(1908): a colour code eats the word boundary a watchlist term needs

### DIFF
--- a/cicchetto/src/__tests__/mentionMatch.test.ts
+++ b/cicchetto/src/__tests__/mentionMatch.test.ts
@@ -116,6 +116,82 @@ describe("matchesWatchlist — a punctuated edge still anchors (#1786)", () => {
   });
 });
 
+// issue 1908 — a colour code glued to the term deletes the boundary the term
+// needs, so a watchlist keyword never matches a bot that colours its output.
+//
+// The defect is NOT "control bytes in the body". `\x02` and friends carry no
+// arguments and are not word characters, so `\b` still has its transition on
+// both sides of the term — measured in the field on `rex`, a bold-only bot
+// whose 139 bold lines match fine. It is specifically the COLOUR byte dragging
+// its numeric arguments into the text: `\x03` `1` `5` before `QUACK` reads to
+// the regex as `...15QUACK`, and the digits ARE word characters.
+//
+// The cure is a projection, not an anchor change: match against
+// `mircPlainText(body)`, the SAME `parseMircFormat` the render uses, so there
+// is no second stripper to drift from. The #1786 anchor rule is untouched.
+//
+// THE TRUTH TABLE BELOW IS SHARED with `test/grappa/mentions_test.exs` — a
+// case added here without its server twin is exactly how the two ports drift,
+// and here that drift would put the visual highlight and the OS push back into
+// disagreement, which is the divergence #370 closed.
+describe("matchesWatchlist — mIRC formatting is stripped before matching (1908)", () => {
+  it("matches through a colour code glued to the term — the field case", () => {
+    // The duck bot's real body: \x03 1 5 immediately before the Q.
+    expect(matchesWatchlist("\x0315QUACK!", null, ["QUACK"])).toBe(true);
+  });
+
+  it("strips every colour-code spelling from the report", () => {
+    for (const args of ["04", "4", "04,01", "99", "00"]) {
+      expect(matchesWatchlist(`\x03${args}QUACK!`, null, ["QUACK"])).toBe(true);
+    }
+  });
+
+  it("leaves a bare colour byte harmless, as it already was", () => {
+    expect(matchesWatchlist("\x03QUACK!", null, ["QUACK"])).toBe(true);
+  });
+
+  it("keeps matching the plain line from the same bot — no regression", () => {
+    expect(matchesWatchlist("\\o< *quack* The duck waddles away safely.", null, ["QUACK"])).toBe(
+      true,
+    );
+  });
+
+  it("keeps bold harmless: the contrast bot matches on every edge", () => {
+    const body = "Title: \x02Merry Sky Weather Forecast\x02";
+    for (const term of ["Merry", "Weather", "Forecast"]) {
+      expect(matchesWatchlist(body, null, [term])).toBe(true);
+    }
+  });
+
+  it("removes the argument-free attribute bytes too", () => {
+    expect(matchesWatchlist("\x0fQUACK!", null, ["QUACK"])).toBe(true);
+  });
+
+  // ── the discriminating case ────────────────────────────────────────────
+  // Everything above also passes if the "cure" were to loosen the anchor
+  // instead of stripping. This one does not: after a genuine strip the body is
+  // `QUACK!`, so a term that includes the colour ARGUMENTS must now MISS. A
+  // loosened anchor would keep matching it against the raw bytes.
+  it("strips rather than loosening — a term spelling the colour args now misses", () => {
+    expect(matchesWatchlist("\x0315QUACK!", null, ["15QUACK"])).toBe(false);
+  });
+
+  // ── the rules that must NOT move ───────────────────────────────────────
+  it("keeps the #1786 discriminating pair, formatted or not", () => {
+    expect(matchesWatchlist("foo!list", null, ["!list"])).toBe(false);
+    expect(matchesWatchlist("\x0315foo!list", null, ["!list"])).toBe(false);
+  });
+
+  it("still refuses a substring match on a formatted body", () => {
+    expect(matchesWatchlist("\x0315QUACKING!", null, ["QUACK!"])).toBe(false);
+  });
+
+  it("does not remove digits that are real text", () => {
+    // The projection consumes digits only as colour ARGUMENTS.
+    expect(matchesWatchlist("15 ducks seen", null, ["15"])).toBe(true);
+  });
+});
+
 // #1674 — the SENDER half of the mention rule. Mirror of
 // `Grappa.Mentions.mentionable_sender?/1`. Keyed on the sender because
 // neither of the alternatives survives: excluding `:notice` silences a

--- a/cicchetto/src/lib/mentionMatch.ts
+++ b/cicchetto/src/lib/mentionMatch.ts
@@ -22,6 +22,7 @@
 // RFC 2812 nick chars include `[`, `]`, `\` etc.; the regex metacharacter
 // escape covers the cases that would otherwise blow up the RegExp constructor.
 
+import { mircPlainText } from "./mircFormat";
 import { isServerSender, isServicesSender } from "./servicesSender";
 
 // #1786 — the anchor is conditional on the term's OWN edge, and that is a fix
@@ -55,11 +56,34 @@ const matchesTerm = (body: string | null, term: string | null): boolean => {
   return new RegExp(`${prefix}${escaped}${suffix}`, "i").test(body);
 };
 
+// issue 1908 — the predicate reads the RENDERED text, because that is the text
+// the operator read when they typed the keyword into the settings pane.
+//
+// The failure the projection closes is narrower than "control bytes in the
+// body", and the narrow reading is the load-bearing one. `\x02` `\x0f` `\x16`
+// `\x1d` `\x1f` carry no arguments and are not word characters, so `\b` keeps
+// its transition on both sides of a term and a bold-only sender always matched
+// fine (measured on `rex`: 139 bold lines, zero misses). The COLOUR byte is
+// different — it drags up to four numeric arguments into the text, and digits
+// ARE word characters, so `\x0315QUACK!` reads to the regex as `...15QUACK!`
+// and the term's left anchor has no transition left to sit on. A stripper that
+// removed the control bytes alone would leave this bug fully intact.
+//
+// `mircPlainText` is that projection and it consumes the arguments (measured,
+// not assumed): it runs the SAME `parseMircFormat` the renderer uses, so there
+// is no second stripper to drift from the one that decides what is on screen.
+//
+// Stripped ONCE per call rather than inside `matchesTerm`, which runs per term.
+// Mirror of `Grappa.Mentions`' projection at `body_matches?/2`; the two ports
+// change together or the visual highlight and the OS push disagree again.
 export const matchesWatchlist = (
   body: string | null,
   ownNick: string | null,
   patterns: string[],
-): boolean => [ownNick, ...patterns].some((term) => matchesTerm(body, term));
+): boolean => {
+  const text = body === null ? null : mircPlainText(body);
+  return [ownNick, ...patterns].some((term) => matchesTerm(text, term));
+};
 
 // #1674 — the SENDER half of the mention rule. Mirror of
 // `Grappa.Mentions.mentionable_sender?/1`: being told something by a robot

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45153,3 +45153,103 @@ this: Chrome's abusive-notification heuristic replaces the toast with a
 notification" to get the real one back), and `Browser.grantPermissions` alone
 left `Notification.permission` at `denied` on Android — `Browser.setPermission`
 did the job.
+<!-- entry #1908 -->
+
+---
+
+## 2026-09-04 — #1908: the colour code is the bug, not the control byte
+
+A watchlist keyword never fired on a game bot's `QUACK!` line while the same
+word typed by a human highlighted fine. The reported shape invites the
+generalisation "formatting breaks watchlists", and that generalisation is
+wrong in a way that would have shipped a cure leaving the bug fully intact.
+
+**What actually breaks it.** `matchesWatchlist` and `Grappa.Mentions` both ran
+their word-boundary regex against the RAW wire body, while the operator picks
+the keyword by reading the RENDERED text. The argument-free attribute bytes are
+harmless there: `\x02` `\x0f` `\x11` `\x16` `\x1d` `\x1e` `\x1f` are not word
+characters, so `\b` still has its transition on both sides of a term. The
+COLOUR byte is not: it drags up to four decimal digits into the text, and
+digits ARE word characters, so `\x03` `1` `5` before `QUACK` reads to the regex
+as `...15QUACK` and the term's left anchor has nothing to sit on.
+
+**The contrast case is what pins it, and it is field evidence rather than
+argument.** A URL-title bot on another network formats *every* line and matches
+fine — 872 stored lines, 139 carrying `\x02`, zero carrying `\x03`, and terms
+sitting flush against the bold on both edges all match. Without that half, "a
+formatted line failed" is the only datum and a stripper that removed control
+bytes WITHOUT their arguments would look correct while leaving `15` glued to
+the `Q`.
+
+Colour 15 is light grey and 99 is the default colour: both render as ordinary
+text, which is why nothing on screen suggested formatting was involved and why
+the first theory was case folding.
+
+**Measured, and it killed a premise this slice was handed.** The working
+hypothesis going in was that `mircPlainText()` might strip the control bytes
+without their arguments, and that the real cure would therefore be inside the
+parser. It is not: the shipped `parseMircFormat` already consumes `\x03` plus
+up to two digits plus an optional `,` plus two more, and all nine spellings
+(`15` `04` `4` `04,01` `99` `00`, bare, stray comma, three digits) reduce to
+`QUACK!`. Positive control: the bold byte IS removed, so the instrument is
+alive. Negative control: a bare `15QUACK!` comes back untouched, so it is not
+deleting digits — it consumes them only as arguments. The cure on the client is
+therefore one line: CALL the projection. Reading the parser suggests the same
+conclusion; measuring it is what makes it a fact, and the premise it retired
+was the expensive half of the slice.
+
+**Why the server gets a second implementation, knowingly.** cic's projection is
+derived from the renderer's own parser, which is exactly why it cannot drift
+from what is on screen. The server has no renderer to derive anything from, and
+porting a run-producing parser there would be dead weight — nothing server-side
+styles a message. So `Grappa.IRC.MircFormat.plain_text/1` is a second
+implementation of the consumption rule, and the honest thing is to name that
+rather than pretend the ports share code. What holds them together is the same
+discipline #1786's anchor rule runs under: two shared tables, one for the
+consumption rule (`test/grappa/irc/mirc_format_test.exs`) and one for the
+mention truth table (`test/grappa/mentions_test.exs` and its client twin), each
+carrying the note that a case added on one side without the other IS the drift.
+
+Two details in that rule are load-bearing and neither is obvious. The comma is
+consumed only when digits follow it, so `\x034,foo` keeps `,foo` as literal
+text — mIRC's behaviour, and a naive `\x03\d{0,2}(,\d{0,2})?` would eat the
+bare comma and diverge. And the digit classes are spelled `[0-9]` with no
+`unicode` option, because the client's `isDigit` is a bare `0x30..0x39` range
+test: a `\d` under `unicode` would consume an Arabic-Indic digit the client
+leaves as text, and the two ports would disagree on a body neither author will
+ever type by hand. Byte semantics are also the honest ones for IRC, and they
+are safe on UTF-8 because every sequence removed is ASCII and a continuation
+byte is never below `0x80`.
+
+**One funnel per port, chosen so a later door inherits the fix.** Server-side
+the projection sits in the private `body_matches?/2`, which every mention door
+already reaches: the OS push through `mentioned?/3`, the sidebar badge through
+`matchers/2` + `matches?/2`, and the mentions-while-away bundle through
+`aggregate_mentions/6`. Client-side it sits in `matchesWatchlist` — once per
+call, not inside the per-term `matchesTerm` — which is the single predicate
+behind the visual highlight, the mentions window and the push mirror. Both ports
+change together by construction; splitting them is how the visual highlight and
+the OS push diverged before #370.
+
+The projection is a MATCH-time view only. `aggregate_mentions/6` still returns
+the stored row with its control bytes intact, because cic renders the colours
+from it — pinned by its own test, since a strip that leaked into the returned
+row would be invisible to every predicate test.
+
+**The test that separates the cure from the cheap wrong one.** Every case above
+also passes if the anchor is LOOSENED instead of the body being stripped. One
+case does not: after a genuine strip the body is `QUACK!`, so a term spelling
+the colour ARGUMENTS (`15QUACK`) must now MISS, where a loosened anchor would
+keep matching it against the raw bytes. That case was measured red-before-green
+on both ports in the direction that matters — it is the only one that failed
+with `got true, expected false` rather than the reverse.
+
+**What this does NOT settle.** The cost was not measured: the projection is one
+regex pass per body per predicate call, and on the bulk badge fold that is one
+extra pass per row. It is the same complexity class as the matching already
+being done there and it was left unbenchmarked, deliberately, rather than
+guessed at. Nor does it touch what is STORED or RENDERED — scrollback keeps the
+raw bytes, and every other consumer of a body is unchanged. And the report's
+own reach is one bot on one network: the rule generalises because the mechanism
+is the regex word class rather than any bot's habits, but no survey of senders
+was run to say how many lines in the corpus were affected.

--- a/lib/grappa/irc.ex
+++ b/lib/grappa/irc.ex
@@ -8,8 +8,11 @@ defmodule Grappa.IRC do
   (`Grappa.IRC.AuthFSM`), identifier validators
   (`Grappa.IRC.Identifier`), the shared IRC-registration identity tuple
   validators (`Grappa.IRC.Identity`, #211 phase 2), the measured
-  JOIN-failure numeric set (`Grappa.IRC.JoinFailure`, #1345), and CTCP
-  framing classification (`Grappa.IRC.CTCP`). Phase 6's IRCv3 listener facade
+  JOIN-failure numeric set (`Grappa.IRC.JoinFailure`, #1345), CTCP
+  framing classification (`Grappa.IRC.CTCP`), and the mIRC formatting
+  projection (`Grappa.IRC.MircFormat`, issue 1908 — the de-formatted view
+  of a body, kept in lockstep with cic's `mircFormat.ts`).
+  Phase 6's IRCv3 listener facade
   reuses the parser + message struct directly and reuses the AuthFSM
   SHAPE (pure FSM with `(state, [iodata])` step contract) for a peer
   server-side registration FSM. The module set is intentionally
@@ -23,5 +26,15 @@ defmodule Grappa.IRC do
   use Boundary,
     top_level?: true,
     deps: [Grappa.OutboundV6Pool],
-    exports: [AuthFSM, Client, CTCP, Identifier, Identity, JoinFailure, LineSplit, Message]
+    exports: [
+      AuthFSM,
+      Client,
+      CTCP,
+      Identifier,
+      Identity,
+      JoinFailure,
+      LineSplit,
+      Message,
+      MircFormat
+    ]
 end

--- a/lib/grappa/irc/mirc_format.ex
+++ b/lib/grappa/irc/mirc_format.ex
@@ -1,0 +1,81 @@
+defmodule Grappa.IRC.MircFormat do
+  @moduledoc """
+  The de-formatted projection of an IRC body — every mIRC formatting
+  control sequence removed, only the visible characters left.
+
+  IRC has no markup spec; mIRC's de-facto control-char set is what every
+  modern client and most IRCds emit. This module does NOT model that set
+  the way a renderer must — it answers one question, "what did the reader
+  actually see", and it exists because a predicate that reads the raw wire
+  bytes answers a different question than the operator was asked.
+
+  ## Why this exists (issue 1908)
+
+  A watchlist keyword never matched a bot that colours its output.
+  `Grappa.Mentions` ran its word-boundary regex against the RAW body while
+  the operator configured the keyword by reading the RENDERED text.
+
+  The failure is narrower than "control bytes in the body", and the narrow
+  reading is the load-bearing one. The argument-free bytes below are not
+  word characters, so `\\b` keeps its transition on both sides of a term and
+  a bold-only sender always matched fine — measured in the field on a
+  URL-title bot with 139 bold lines and zero misses. The COLOUR byte is
+  different: it drags up to four decimal digits into the text, and digits
+  ARE word characters, so `\\x03` `1` `5` before `QUACK` reads to the regex
+  as `...15QUACK` and the term's left anchor has no transition left to sit
+  on. **A stripper that removed the control bytes without their arguments
+  would leave that bug fully intact.**
+
+  ## The consumption rule, and why it is spelled this way
+
+  Mirror of `cicchetto/src/lib/mircFormat.ts`'s `parseMircFormat`, which
+  cic reaches through `mircPlainText/1`. The client cannot be reused here
+  and the server has no renderer to derive a projection from, so a second
+  implementation exists by necessity. What keeps the two from drifting is
+  the shared consumption table in `test/grappa/irc/mirc_format_test.exs`
+  plus the shared mention truth table in `test/grappa/mentions_test.exs` —
+  the same lockstep discipline #1786's anchor rule runs under. A change to
+  either side's rule MUST land in both.
+
+    * the argument-free attribute bytes — bold `\\x02`, reset `\\x0F`,
+      monospace `\\x11`, reverse `\\x16`, italic `\\x1D`, strikethrough
+      `\\x1E`, underline `\\x1F` — are dropped on sight;
+    * the colour byte `\\x03` takes UP TO TWO decimal digits, then
+      optionally a comma AND one-to-two more. The comma is consumed only
+      when digits follow it, so `\\x034,foo` leaves `,foo` as literal text
+      — mIRC's own behaviour, and the client parser's documented lookahead;
+    * the hex-colour byte `\\x04` is all-or-nothing on six hex digits; a
+      partial run is not consumed and stays as text;
+    * CTCP framing `\\x01` is NOT formatting and is preserved verbatim
+      (CLAUDE.md's wire-format rule; the client parser says the same).
+
+  The digit classes are written `[0-9]` rather than `\\d`, and the pattern
+  carries no `unicode` option. That is deliberate: the client's `isDigit`
+  is a bare `0x30..0x39` range test, so an Arabic-Indic digit is ordinary
+  text there. A `\\d` under `unicode` would consume it and the two ports
+  would silently disagree on a body neither author will ever type by hand.
+  Byte semantics are also the honest ones here — CLAUDE.md's "IRC is
+  bytes" — and they are safe on UTF-8 input because every sequence removed
+  is ASCII, and a UTF-8 continuation byte is never below `0x80`.
+  """
+
+  # Written with the `x` (extended) flag so each alternative can carry the
+  # rule it implements: this pattern IS the lockstep contract with the client
+  # parser, and a reader has to be able to check it against that file.
+  @formatting ~r/
+      [\x02\x0F\x11\x16\x1D\x1E\x1F]                        # argument-free attributes
+    | \x03 (?: [0-9]{1,2} (?: , [0-9]{1,2} )? )?            # palette colour, fg[,bg]
+    | \x04 (?: [0-9A-Fa-f]{6} (?: , [0-9A-Fa-f]{6} )? )?    # hex colour, all-or-nothing
+  /x
+
+  @doc """
+  Returns `body` with every mIRC formatting sequence removed — the text a
+  reader saw on screen.
+
+  Total on binaries and never raises: a body carrying no formatting comes
+  back unchanged, and an unterminated or malformed sequence consumes only
+  what the rule above says it consumes.
+  """
+  @spec plain_text(String.t()) :: String.t()
+  def plain_text(body) when is_binary(body), do: Regex.replace(@formatting, body, "")
+end

--- a/lib/grappa/mentions.ex
+++ b/lib/grappa/mentions.ex
@@ -108,7 +108,7 @@ defmodule Grappa.Mentions do
 
   import Ecto.Query
 
-  alias Grappa.IRC.Identifier
+  alias Grappa.IRC.{Identifier, MircFormat}
   alias Grappa.Repo
   alias Grappa.Scrollback.Message
 
@@ -320,10 +320,30 @@ defmodule Grappa.Mentions do
 
   # Returns true if body matches ANY compiled pattern.
   # `nil` body (e.g. for presence kinds that slip through) never matches.
+  #
+  # issue 1908 — the match runs against the DE-FORMATTED body, because that is
+  # the text the operator read when they typed the keyword into the settings
+  # pane. This is the ONE place the projection is applied, deliberately: every
+  # server-side mention door reaches the predicate through here — the OS push
+  # via `mentioned?/3`, the sidebar badge via `matchers/2` + `matches?/2`, and
+  # the mentions-while-away bundle via `aggregate_mentions/6` — so a door added
+  # later inherits it instead of having to remember it.
+  #
+  # The defect is narrower than "control bytes in the body" and the narrow
+  # reading is what forces a projection rather than an anchor change: `\x02`
+  # and the other argument-free bytes are not word characters, so a bold-only
+  # sender always matched fine. The COLOUR byte drags its numeric arguments
+  # into the text, and digits ARE word characters, so `\x0315QUACK!` reads as
+  # `...15QUACK!` and the term's left `\b` has no transition to sit on. See
+  # `Grappa.IRC.MircFormat` for the consumption rule and its client twin.
+  #
+  # A MATCH-time view only: what `aggregate_mentions/6` returns is the stored
+  # row, control bytes intact, because cic renders the colours from it.
   @spec body_matches?(String.t() | nil, [Regex.t()]) :: boolean()
   defp body_matches?(nil, _), do: false
 
   defp body_matches?(body, compiled) do
-    Enum.any?(compiled, &Regex.match?(&1, body))
+    plain = MircFormat.plain_text(body)
+    Enum.any?(compiled, &Regex.match?(&1, plain))
   end
 end

--- a/test/grappa/irc/mirc_format_test.exs
+++ b/test/grappa/irc/mirc_format_test.exs
@@ -1,0 +1,159 @@
+defmodule Grappa.IRC.MircFormatTest do
+  @moduledoc """
+  Tests for `Grappa.IRC.MircFormat.plain_text/1` — the server-side
+  de-formatted projection of an IRC body (issue 1908).
+
+  THE TABLE BELOW IS THE CONSUMPTION RULE, and it is SHARED with
+  `cicchetto/src/lib/mircFormat.ts`'s `parseMircFormat`. The server cannot
+  reuse the client parser, so a second implementation exists by necessity;
+  what keeps the two from drifting is this table plus the mention truth
+  table in `test/grappa/mentions_test.exs`. A case changed here without its
+  client twin is how the visual highlight and the OS push start disagreeing
+  about which messages notify.
+
+  The rule the client parser implements, verb for verb:
+
+    * the argument-free attribute bytes are dropped on sight;
+    * the colour byte takes UP TO TWO decimal digits, then optionally a
+      comma AND one-to-two more — the comma is consumed only when digits
+      follow it, so a stray comma stays as literal text;
+    * the hex-colour byte is all-or-nothing on six hex digits; a partial
+      run is not consumed and stays as text;
+    * CTCP framing is NOT formatting and is preserved verbatim.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.IRC.MircFormat
+
+  # Spelled as byte literals rather than "\\x03" escapes: Elixir's `\\xHH`
+  # takes up to two hex digits, so the escaped form reads ambiguously in
+  # exactly the place where digits-glued-to-the-byte IS the defect under test.
+  # Same spelling as `Grappa.IRC.CTCP`'s `<<0x01, ...>>`.
+  @color <<0x03>>
+  @hex_color <<0x04>>
+  @ctcp <<0x01>>
+
+  describe "plain_text/1 — text that must survive untouched" do
+    test "plain text is returned verbatim" do
+      assert MircFormat.plain_text("QUACK!") == "QUACK!"
+    end
+
+    test "an empty body stays empty" do
+      assert MircFormat.plain_text("") == ""
+    end
+
+    test "digits that are real text are NOT removed" do
+      # The negative control for the whole module: the projection consumes
+      # digits only as colour ARGUMENTS. If this ever goes red the stripper
+      # has started eating content.
+      assert MircFormat.plain_text("15 ducks seen") == "15 ducks seen"
+      assert MircFormat.plain_text("15QUACK!") == "15QUACK!"
+    end
+
+    test "CTCP framing is preserved — it is not formatting" do
+      # CLAUDE.md's wire-format rule: `\\x01` round-trips verbatim, and the
+      # client parser deliberately treats it as plain text for the same
+      # reason. An ACTION body must come out of here still framed.
+      body = @ctcp <> "ACTION waves" <> @ctcp
+      assert MircFormat.plain_text(body) == body
+    end
+  end
+
+  describe "plain_text/1 — the argument-free attribute bytes" do
+    test "every toggle and the reset are dropped on sight" do
+      for {name, byte} <- [
+            bold: <<0x02>>,
+            reset: <<0x0F>>,
+            monospace: <<0x11>>,
+            reverse: <<0x16>>,
+            italic: <<0x1D>>,
+            strikethrough: <<0x1E>>,
+            underline: <<0x1F>>
+          ] do
+        assert MircFormat.plain_text(byte <> "QUACK!" <> byte) == "QUACK!",
+               "#{name} byte survived the projection"
+      end
+    end
+  end
+
+  describe "plain_text/1 — the colour byte takes its arguments with it" do
+    test "one and two digit foreground codes" do
+      assert MircFormat.plain_text(@color <> "4QUACK!") == "QUACK!"
+      assert MircFormat.plain_text(@color <> "15QUACK!") == "QUACK!"
+      assert MircFormat.plain_text(@color <> "04QUACK!") == "QUACK!"
+      assert MircFormat.plain_text(@color <> "99QUACK!") == "QUACK!"
+      assert MircFormat.plain_text(@color <> "00QUACK!") == "QUACK!"
+    end
+
+    test "foreground and background" do
+      assert MircFormat.plain_text(@color <> "04,01QUACK!") == "QUACK!"
+      assert MircFormat.plain_text(@color <> "4,1QUACK!") == "QUACK!"
+    end
+
+    test "a bare colour byte consumes nothing but itself" do
+      assert MircFormat.plain_text(@color <> "QUACK!") == "QUACK!"
+    end
+
+    test "only TWO digits are arguments — a third is text" do
+      assert MircFormat.plain_text(@color <> "045QUACK!") == "5QUACK!"
+    end
+
+    test "a stray comma with no digits after it stays literal" do
+      # mIRC's own rule, and the client parser's documented lookahead: the
+      # comma is only part of the code when a background code follows.
+      assert MircFormat.plain_text(@color <> "4,foo") == ",foo"
+    end
+
+    test "a comma directly after a bare colour byte stays literal" do
+      assert MircFormat.plain_text(@color <> ",01QUACK!") == ",01QUACK!"
+    end
+
+    test "non-ASCII digits are NOT colour arguments" do
+      # The client's `isDigit` is a bare 0x30-0x39 range test, so an
+      # Arabic-Indic digit is ordinary text there. A server regex compiled
+      # with the `unicode` option would consume it and the two ports would
+      # silently disagree on a body neither author will ever type by hand.
+      arabic_one = "١"
+      assert MircFormat.plain_text(@color <> arabic_one <> "QUACK!") == arabic_one <> "QUACK!"
+    end
+  end
+
+  describe "plain_text/1 — the hex colour byte is all-or-nothing" do
+    test "a full six-hex foreground is consumed" do
+      assert MircFormat.plain_text(@hex_color <> "FF0000QUACK!") == "QUACK!"
+    end
+
+    test "six-hex foreground and background" do
+      assert MircFormat.plain_text(@hex_color <> "FF0000,00FF00QUACK!") == "QUACK!"
+    end
+
+    test "a PARTIAL hex run is not consumed and stays as text" do
+      assert MircFormat.plain_text(@hex_color <> "FF00QUACK!") == "FF00QUACK!"
+    end
+
+    test "a partial BACKGROUND leaves the comma and the digits as text" do
+      assert MircFormat.plain_text(@hex_color <> "FF0000,00FFQUACK!") == ",00FFQUACK!"
+    end
+
+    test "a bare hex-colour byte consumes nothing but itself" do
+      assert MircFormat.plain_text(@hex_color <> "QUACK!") == "QUACK!"
+    end
+  end
+
+  describe "plain_text/1 — the field case" do
+    test "the duck bot's real line reduces to its visible text" do
+      body =
+        @color <>
+          "15" <>
+          <<0x0F>> <>
+          " " <>
+          <<0x02>> <>
+          "\\_O<" <>
+          <<0x0F>> <>
+          "  " <>
+          @color <> "15QUACK!" <> <<0x0F>>
+
+      assert MircFormat.plain_text(body) == " \\_O<  QUACK!"
+    end
+  end
+end

--- a/test/grappa/mentions_test.exs
+++ b/test/grappa/mentions_test.exs
@@ -487,6 +487,128 @@ defmodule Grappa.MentionsTest do
     end
   end
 
+  # issue 1908 — a colour code glued to the term deletes the boundary the term
+  # needs, so a watchlist keyword never matches a bot that colours its output.
+  #
+  # The defect is NOT "control bytes in the body". `\x02` and friends carry no
+  # arguments and are not word characters, so `\b` still has its transition on
+  # both sides of the term — measured in the field on `rex`, a bold-only bot
+  # whose 139 bold lines match fine. It is specifically the COLOUR byte
+  # dragging its numeric arguments into the text: `\x03` `1` `5` before `QUACK`
+  # reads to the regex as `...15QUACK`, and the digits ARE word characters.
+  #
+  # So the cure is a projection, not an anchor change: match against the body
+  # with the formatting removed. The anchor rule of #1786 is untouched.
+  #
+  # THE TRUTH TABLE BELOW IS SHARED with
+  # `cicchetto/src/__tests__/mentionMatch.test.ts` — a case added here without
+  # its client twin is exactly how the two ports drift, and here that drift
+  # would put the OS push and the visual highlight back into disagreement,
+  # which is the divergence #370 closed.
+  #
+  # Bytes are spelled `<<0x03>>` rather than `"\x0315"`: Elixir's `\xHH` takes
+  # up to two hex digits, so the escaped spelling reads ambiguously in exactly
+  # the place where digits-glued-to-the-byte IS the defect. Same spelling as
+  # `Grappa.IRC.CTCP`'s `<<0x01, ...>>`.
+  @color <<0x03>>
+  @bold <<0x02>>
+  @reset <<0x0F>>
+
+  describe "mentioned?/3 — mIRC formatting is stripped before matching (1908)" do
+    test "a colour code glued to the term still matches — the field case" do
+      # The duck bot's real body: `\x03` `1` `5` immediately before the Q.
+      assert Mentions.mentioned?(@color <> "15QUACK!", "", ["QUACK"])
+    end
+
+    test "every colour-code spelling from the report is stripped" do
+      for args <- ["04", "4", "04,01", "99", "00"] do
+        assert Mentions.mentioned?(@color <> args <> "QUACK!", "", ["QUACK"]),
+               "colour args #{inspect(args)} still eat the word boundary"
+      end
+    end
+
+    test "a bare colour byte with no arguments was already harmless and stays so" do
+      assert Mentions.mentioned?(@color <> "QUACK!", "", ["QUACK"])
+    end
+
+    test "the plain line from the same bot keeps matching — no regression" do
+      assert Mentions.mentioned?("\\o< *quack* The duck waddles away safely.", "", ["QUACK"])
+    end
+
+    test "bold stays harmless: the contrast bot matches on every edge" do
+      body = "Title: " <> @bold <> "Merry Sky Weather Forecast" <> @bold
+
+      for term <- ["Merry", "Weather", "Forecast"] do
+        assert Mentions.mentioned?(body, "", [term]), "bold broke term #{term}"
+      end
+    end
+
+    test "the argument-free attribute bytes are removed too" do
+      assert Mentions.mentioned?(@reset <> "QUACK!", "", ["QUACK"])
+    end
+
+    # ── the discriminating case ───────────────────────────────────────────
+    # Everything above also passes if the "cure" were to loosen the anchor
+    # instead of stripping. This one does not: after a genuine strip the body
+    # is `QUACK!`, so a term that includes the colour ARGUMENTS must now MISS.
+    # A loosened anchor would keep matching it against the raw bytes.
+    test "stripping is a projection, not a loosened anchor" do
+      refute Mentions.mentioned?(@color <> "15QUACK!", "", ["15QUACK"])
+    end
+
+    # ── the rules that must NOT move ──────────────────────────────────────
+    test "the #1786 discriminating pair survives the strip, formatted or not" do
+      refute Mentions.mentioned?("foo!list", "", ["!list"])
+      refute Mentions.mentioned?(@color <> "15foo!list", "", ["!list"])
+    end
+
+    test "substring matching is still refused on a formatted body" do
+      refute Mentions.mentioned?(@color <> "15QUACKING!", "", ["QUACK!"])
+    end
+
+    test "digits that are real text are NOT removed" do
+      # The projection consumes digits only as colour ARGUMENTS. A body that
+      # merely starts with digits keeps them, so a digit-bearing term matches.
+      assert Mentions.mentioned?("15 ducks seen", "", ["15"])
+    end
+  end
+
+  # The push door and the badge door reach the predicate by different verbs
+  # (`mentioned?/3` vs the pre-compiled `matchers/2` + `matches?/2`), and the
+  # away bundle by a third (`aggregate_mentions/6`). All three must strip, or
+  # the OS push, the sidebar badge and the mentions window disagree about the
+  # same row — so each door is pinned on its own rather than trusted to share
+  # a private helper.
+  describe "every mention door strips the formatting (1908)" do
+    test "matches?/2 with pre-compiled matchers — the badge door" do
+      matchers = Mentions.matchers("", ["QUACK"])
+      assert Mentions.matches?(@color <> "15QUACK!", matchers)
+    end
+
+    test "aggregate_mentions/6 — the mentions-while-away door", %{user: user, network: network} do
+      insert!(msg(user, network, body: @color <> "15QUACK!"))
+      insert!(msg(user, network, body: "nothing to see here"))
+
+      bodies =
+        user.id
+        |> Mentions.aggregate_mentions(network.id, @away_start, @away_end, ["QUACK"], "")
+        |> Enum.map(& &1.body)
+
+      assert bodies == [@color <> "15QUACK!"]
+    end
+
+    test "aggregate_mentions/6 returns the row VERBATIM, formatting intact",
+         %{user: user, network: network} do
+      # The projection is a MATCH-time view. What comes back is the stored
+      # body, control bytes and all — cic renders the colours from it.
+      insert!(msg(user, network, body: @color <> "15QUACK!"))
+
+      [row] = Mentions.aggregate_mentions(user.id, network.id, @away_start, @away_end, ["QUACK"], "")
+
+      assert row.body == @color <> "15QUACK!"
+    end
+  end
+
   describe "mentioned?/3 — guards + degenerate inputs" do
     test "nil body never matches" do
       refute Mentions.mentioned?(nil, "vjt", ["oncall"])


### PR DESCRIPTION
A watchlist keyword never fired on a bot that colours its output, while the same
word typed by a human highlighted fine. Both mention predicates ran their
word-boundary regex against the RAW wire body, and the operator picks the keyword
by reading the RENDERED text.

## The defect is narrower than "control bytes in the body"

And the narrow reading is what decides the cure. The argument-free attribute
bytes are not word characters, so a term keeps its `\b` transition on both sides
— which is why a bold-only sender always matched fine. The colour byte drags up
to four decimal digits into the text, and digits ARE word characters, so `\x03`
`1` `5` before `QUACK` reads to the regex as `...15QUACK` and the left anchor has
nothing to sit on.

A stripper that removed the control bytes WITHOUT their arguments would have
looked correct and left the bug fully intact.

## A premise this slice was handed, and the measurement that killed it

The brief said to verify that `mircPlainText()` consumes the colour byte's
arguments, on the theory that if it did not, the real cure would be inside the
parser. **Measured: it already consumes them, so the brief's hypothesis is
retired and the client cure is one line — CALL the projection.**

All nine spellings reduce to `QUACK!`: `15` `04` `4` `04,01` `99` `00`, the bare
byte, a stray comma (`\x034,foo` → `,foo`), and three digits (`\x03045QUACK!` →
`5QUACK!`, only two are arguments).

- **Positive control** — the instrument is alive and does remove bytes: the bold
  byte is stripped.
- **Negative control** — it is not merely deleting digits: a bare `15QUACK!`
  comes back untouched, so digits are consumed only as ARGUMENTS.

Reading the parser suggests the same conclusion; measuring it is what makes it a
fact, and it is the half of the slice that was expected to be expensive.

## Shape

- **cic** — strip once in `matchesWatchlist`, not inside the per-term
  `matchesTerm`. One predicate already feeds the visual highlight, the mentions
  window and the push mirror, so one change covers every sink.
- **server** — the projection sits in the private `body_matches?/2`, the funnel
  every mention door already reaches: the OS push via `mentioned?/3`, the sidebar
  badge via `matchers/2` + `matches?/2`, the mentions-while-away bundle via
  `aggregate_mentions/6`. A door added later inherits it instead of having to
  remember it.
- It is a MATCH-time view only. `aggregate_mentions/6` still returns the stored
  row with its bytes intact, because cic renders the colours from it — pinned by
  its own test, since a strip leaking into the returned row would be invisible to
  every predicate test.

### A second stripper, named rather than pretended away

cic's projection is derived from the renderer's own parser, which is exactly why
it cannot drift from what is on screen. The server has no renderer to derive
anything from, and porting a run-producing parser there would be dead weight. So
`Grappa.IRC.MircFormat` is a second implementation of the consumption rule. What
holds the ports together is the discipline the anchor rule already runs under:
two shared tables, one for the consumption rule and one for the mention truth
table, each carrying the note that a case added on one side without the other IS
the drift.

Two details in that rule are load-bearing and neither is obvious. The comma is
consumed only when digits follow it, so `\x034,foo` keeps `,foo` as literal text
— a naive `\x03\d{0,2}(,\d{0,2})?` would eat the bare comma and diverge. And the
digit classes are `[0-9]` with no `unicode` option, because the client's
`isDigit` is a bare `0x30..0x39` range test: a `\d` under `unicode` would consume
an Arabic-Indic digit the client leaves as text.

## The test that separates this from the cheap wrong cure

Every case here also passes if the anchor is LOOSENED instead of the body being
stripped. One does not: after a genuine strip the body is `QUACK!`, so a term
spelling the colour ARGUMENTS (`15QUACK`) must now MISS. It is the only case that
failed red-before-green with `got true, expected false` rather than the reverse.
Pinned on both ports.

## What this does not settle

The cost was not benchmarked. The projection is one regex pass per body per
predicate call, and on the bulk badge fold that is one extra pass per row — the
same complexity class as the matching already done there, but left measured-by
nobody rather than guessed at.

Nothing about what is STORED or RENDERED changes, and no survey of senders was
run: the rule generalises because the mechanism is the regex word class, not
because a corpus was counted.

No e2e spec is included. The visual highlight on a coloured body is a
user-visible outcome and probably deserves one; it needs the e2e lane.
