### PR TITLE
deploy: kustomize manifests (kubectl apply -k) for the release image

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,6 +83,88 @@ Elastic IP). Nothing is retained.
 > at a git ref and execs it — it is never inlined). Operator runbook for the AWS
 > box: [`docs/OPERATIONS.md`](docs/OPERATIONS.md).
 
+## Kubernetes (`kubectl apply -k`)
+
+> **Support status: community-maintained, and NOT tested in CI.** Nothing in
+> this repository exercises Kubernetes — no kind cluster, no `apply -k` smoke
+> job, no `/healthz` wait. These manifests are reviewed by reading, not by
+> running, and they can rot without anything going red. Every other path on
+> this page is exercised somewhere; this one is not.
+
+Kustomize manifests for the pre-built release image live in the repository
+root:
+
+```
+kustomization.yaml     # the plain install path — imports base/
+base/
+  kustomization.yaml
+  deployment.yaml      # 1 replica, Recreate, /healthz probes
+  service.yaml         # ClusterIP :4000, plain HTTP
+  pvc.yaml             # RWO, mounted at /data
+  secret.yaml          # OPTIONAL, shipped commented out
+  networkpolicy.yaml   # read its header before applying it
+overlays/default/
+  kustomization.yaml   # PHX_HOST patch + Ingress example + IRC egress rule
+```
+
+**Install:** set `PHX_HOST` — the public hostname clients reach — then apply.
+
+```sh
+# Edit the PHX_HOST value in base/deployment.yaml, then:
+kubectl apply -k .
+```
+
+Or, without editing `base/`, use the overlay (it patches `PHX_HOST` from its
+own `kustomization.yaml` and carries the Ingress example):
+
+```sh
+# Edit overlays/default/kustomization.yaml, then:
+kubectl apply -k overlays/default
+```
+
+`PHX_HOST` is the **only** value you must supply. Everything else the image
+either bakes (`DATABASE_PATH`, `UPLOADS_STORAGE_ROOT`, `CIC_DIST_ROOT`, `PORT`)
+or generates on first boot onto the `/data` volume — `SECRET_KEY_BASE`,
+`SECRET_SIGNING_SALT`, `RELEASE_COOKIE`, `GRAPPA_ENCRYPTION_KEY` and the VAPID
+pair — before creating the database directory and the uploads root and running
+pending migrations. Left empty, the container **refuses to boot**, on purpose.
+Supplying your own key material instead is optional; see the commented
+`base/secret.yaml`.
+
+There is **one** Deployment and **one** Service because the cicchetto PWA is
+served by the same BEAM that runs the bouncer. TLS terminates in front of the
+pod, exactly as on every other path.
+
+**Read `base/networkpolicy.yaml`'s header before applying on a cluster that is
+not already default-deny.** A NetworkPolicy that selects a pod makes everything
+it does not list *denied*, and an incomplete egress list does not look like a
+firewall problem: grappa reports itself up, `/healthz` stays green, and every
+network sits in `connecting` forever. If your IRC server is private —
+in-cluster, on the LAN, behind a VPN — the base policy denies it and you must
+add the rule the overlay carries.
+
+**Updates on this path are always COLD**, for the same reason as the Docker
+image path: the release image ships no `CodeReloader`, so there is nothing to
+hot-swap. Moving the image tag is not enough on its own — the pod has to be
+recreated:
+
+```sh
+kubectl set image deployment/grappa grappa=ghcr.io/vjt/grappa:vX.Y.Z
+# or, when the tag itself moved (e.g. :latest):
+kubectl rollout restart deployment/grappa
+```
+
+The Deployment uses `strategy: Recreate`, not a rolling update, because SQLite
+is a single-writer store and a rolling update would briefly run two pods on one
+volume. So the old pod is fully gone before its replacement starts: **IRC
+sessions drop for the seconds of the recreate.** The database and uploads on
+the volume are untouched.
+
+> **Back up the `/data` volume whole.** It holds the database, the uploads
+> *and* `/data/grappa.env`, which holds `GRAPPA_ENCRYPTION_KEY` — the key that
+> decrypts every stored upstream credential. Restoring the database without it
+> restores nothing usable.
+
 ## Prerequisites
 
 - **Docker Engine** with the **Compose v2** plugin (`docker compose

--- a/base/deployment.yaml
+++ b/base/deployment.yaml
@@ -1,0 +1,173 @@
+# grappa — the whole application, in one pod.
+#
+# ONE Deployment and ONE Service, not two: the cicchetto PWA is served by the
+# same BEAM that runs the bouncer. `Dockerfile.release` bakes
+# `CIC_DIST_ROOT=/app/cicchetto-dist`, `config/runtime.exs` reads it into
+# `:cic_dist_root`, and `GrappaWeb.SpaController` + the endpoint's
+# `:serve_cic_static` plug serve the bundle from there. There is no separate
+# frontend image to deploy.
+#
+# SUPPORT STATUS: community-maintained, not tested in CI. See the repository
+# root `kustomization.yaml`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grappa
+  labels:
+    app.kubernetes.io/name: grappa
+spec:
+  # ONE replica, and never an HPA. The database is SQLite (`ecto_sqlite3`) with
+  # a single writer at the file lock; two pods on one volume corrupt state.
+  replicas: 1
+
+  # `Recreate`, not the default `RollingUpdate`, for the same reason: a rolling
+  # update briefly runs the old and the new pod at once, both holding /data.
+  # The cost is the honest one — the pod is fully gone before its replacement
+  # starts, so IRC sessions drop for the seconds of the recreate.
+  strategy:
+    type: Recreate
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grappa
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grappa
+    spec:
+      securityContext:
+        # The image runs as the non-root user `grappa` (`USER grappa` in
+        # Dockerfile.release), and a freshly provisioned PVC is normally
+        # root-owned 0755 — so without this the entrypoint dies on its first
+        # write with "cannot create /data/grappa.env — is /data writable by
+        # this container?".
+        #
+        # The VALUE is arbitrary and does not have to match the image's group:
+        # the kubelet chowns the volume to this GID *and* adds it to the pod's
+        # supplementary groups, so whatever uid the image runs as gains write
+        # access. Storage drivers that ignore fsGroup (some NFS provisioners)
+        # need the directory pre-chowned instead.
+        fsGroup: 1000
+        # Avoid a recursive chown of the whole volume on every pod start once
+        # the root already has the right group.
+        fsGroupChangePolicy: OnRootMismatch
+
+        # 🔴 Do NOT add `runAsNonRoot: true` here. The image's `USER grappa` is
+        # a NAME, not a numeric uid, and the kubelet cannot verify a
+        # non-numeric user is non-root: the pod fails with
+        # CreateContainerConfigError before it ever starts. The image is
+        # already non-root; this flag would only break it.
+
+      containers:
+        - name: grappa
+          # `latest` follows every release. Pin the tag you actually reviewed
+          # (ghcr.io/vjt/grappa:vX.Y.Z) if you would rather choose when to move.
+          # Moving the tag is NOT enough on its own — see the cold-update note
+          # in INSTALL.md.
+          image: ghcr.io/vjt/grappa:latest
+          imagePullPolicy: IfNotPresent
+
+          ports:
+            - name: http
+              containerPort: 4000
+              protocol: TCP
+
+          env:
+            # 🔴 THE ONE VALUE YOU MUST SET, and the only one. Everything else
+            # the image either bakes (`DATABASE_PATH=/data/grappa.db`,
+            # `UPLOADS_STORAGE_ROOT=/data/uploads`, `CIC_DIST_ROOT`,
+            # `GRAPPA_SUBSTRATE`, `PORT=4000`) or generates on first boot
+            # (`infra/docker/release-entrypoint.sh` writes SECRET_KEY_BASE,
+            # SECRET_SIGNING_SALT, RELEASE_COOKIE, GRAPPA_ENCRYPTION_KEY and the
+            # VAPID pair into /data/grappa.env, creates the database directory
+            # and the uploads root, then runs pending migrations).
+            #
+            # Left empty the container REFUSES TO BOOT, on purpose: a wrong
+            # PHX_HOST mints dead upload links into permanent IRC scrollback and
+            # rejects every WebSocket handshake, so `config/runtime.exs` raises
+            # rather than guessing. Nothing can invent your hostname.
+            - name: PHX_HOST
+              value: ""
+
+            # Cached peer CTCP AVATAR images. Set here because the image does
+            # NOT bake it: `config/runtime.exs` defaults
+            # PEER_AVATARS_STORAGE_ROOT to the RELATIVE `runtime/peer_avatars`,
+            # which resolves against WORKDIR /app — i.e. the container's
+            # ephemeral layer, wiped on every pod recreate. It is only a cache
+            # (`Grappa.Avatars.Reaper` mkdir_p's it at boot and the images
+            # re-fetch), so this is durability, not correctness; the alternative
+            # is re-downloading every peer avatar after each restart.
+            - name: PEER_AVATARS_STORAGE_ROOT
+              value: /data/peer_avatars
+
+          # OPTIONAL, and absent by default — `optional: true` means the pod
+          # starts fine when no such Secret exists. Create `grappa-secrets`
+          # (see the commented `secret.yaml`) only if you want to supply your
+          # own key material: the entrypoint's rule is OPERATOR ENV WINS, so a
+          # value present here is used as-is and never overwritten, and a value
+          # absent here is generated onto /data and reused byte-for-byte on
+          # every later boot.
+          envFrom:
+            - secretRef:
+                name: grappa-secrets
+                optional: true
+
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+          # `GET /healthz` is mounted OUTSIDE both router pipelines
+          # (`scope "/" do pipe_through [] ... get "/healthz"` in
+          # `GrappaWeb.Router`), so it answers under any auth state — no bearer
+          # token, no session.
+          #
+          # 🔴 It is a DEEP check, not a ping: `Grappa.Health.check/0` runs
+          # `Repo.query("SELECT 1")` and asserts the singleton ETS tables exist,
+          # and returns 503 naming the failing check. That is exactly right for
+          # readiness and needs a slack leash on liveness — a transient SQLite
+          # lock or a saturated connection pool must not get the pod killed.
+          # Hence the failure thresholds below: ~3 minutes of *sustained*
+          # failure before a restart, rather than the 30 seconds a naive
+          # liveness probe would allow.
+          startupProbe:
+            # First boot runs pending migrations and seeds the built-in theme
+            # gallery before the endpoint listens; on a slow node that is
+            # minutes, not seconds. The startup probe is what buys that time
+            # without loosening the two probes below.
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
+            timeoutSeconds: 5
+
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 5
+
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 5
+
+          resources:
+            # Requests only, deliberately. A CPU limit throttles the BEAM's
+            # schedulers at exactly the moments it has work, and a memory limit
+            # turns a burst into an OOMKill of the single writer. Set limits if
+            # your cluster requires them, with headroom you have measured.
+            requests:
+              cpu: 100m
+              memory: 512Mi
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: grappa-data

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,0 +1,28 @@
+# grappa — base resources. One file per component, no transformers.
+#
+# Labels are written out on every object rather than injected by a
+# `commonLabels`/`labels` transformer on purpose: the transformer's spelling and
+# its `includeSelectors` default have moved between kustomize releases, and
+# `kubectl apply -k` ships whatever kustomize its own version embedded. Explicit
+# labels read the same on every one of them.
+#
+# SUPPORT STATUS: community-maintained, not tested in CI. See the repository
+# root `kustomization.yaml` for what that means.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - service.yaml
+  - deployment.yaml
+  - networkpolicy.yaml
+
+  # OPTIONAL — `secret.yaml` is a template, shipped entirely commented out. The
+  # release image generates every secret it needs on first boot onto the /data
+  # volume and never rotates one it already wrote, so an operator who does not
+  # want to manage key material supplies nothing. Uncomment BOTH this line and
+  # the body of `secret.yaml` (kustomize fails loudly on a resource file with no
+  # `kind:` if you uncomment only one) to supply your own values instead.
+  # The Deployment already references it with `optional: true`, so no other edit
+  # is needed.
+  # - secret.yaml

--- a/base/networkpolicy.yaml
+++ b/base/networkpolicy.yaml
@@ -1,0 +1,176 @@
+# grappa — NetworkPolicy. Read this header before you apply it.
+#
+# ─── WHAT THIS OBJECT DOES DEPENDS ON YOUR CLUSTER ──────────────────────────
+#
+# On a cluster that already runs a default-deny policy, this is the ALLOW list
+# that makes grappa work at all.
+#
+# On a permissive cluster it is the opposite: a NetworkPolicy that selects a
+# pod and declares `policyTypes: [Ingress, Egress]` makes everything not listed
+# below DENIED for that pod. Applying it therefore RESTRICTS a pod that was
+# previously unrestricted.
+#
+# Either way the failure mode is the nasty one, which is why this file is
+# mostly prose: an incomplete egress list does not look like a firewall
+# problem. grappa reports itself up, `/healthz` stays green, and every network
+# sits in `connecting` forever — indistinguishable, from the operator's chair,
+# from an upstream outage.
+#
+# ─── THE MEASURED EGRESS SET ────────────────────────────────────────────────
+#
+# Enumerated from the code, not from a wishlist. Every outbound call site in
+# `lib/`, by name:
+#
+#   DNS         `Grappa.IRC.Client` (`:inet_res.lookup/3` for AAAA,
+#               `:inet.getaddr/2`), `Grappa.Net.PtrResolver.resolve/1`
+#               (`:inet_res.resolve/5`), `Grappa.Net.Ssrf.resolve_safe/1`
+#               (`:inet.getaddrs/2`). Both UDP and TCP 53 — a truncated
+#               answer retries over TCP, and a UDP-only rule turns that into
+#               an intermittent resolution failure.
+#
+#   IRC         `Grappa.IRC.Client.default_connect/5` → `:gen_tcp.connect/4`
+#               (plaintext) or `:ssl.connect/4` (TLS). Operator-chosen hosts on
+#               operator-chosen ports — 6697 typically, 6667 on some networks,
+#               anything on others. This is the whole point of the product.
+#
+#   Web push    `Grappa.Push.Sender.deliver/2` → `ExNudge.send_notification/3`
+#               (HTTPoison), HTTPS 443. The endpoint host comes from the
+#               browser's own subscription (Mozilla / Google / Apple), so it is
+#               not knowable in advance. Blocked, push notifications silently
+#               never arrive.
+#
+#   Image fetch `Grappa.Net.ImageFetcher.Req.fetch/1` → `Req.get/2`. NOT named
+#               in the issue's egress list, and load-bearing for two features:
+#               theme background images (`Grappa.Themes.BackgroundImage`) and
+#               cached peer CTCP AVATAR images (`Grappa.Avatars`). Accepts any
+#               `http`/`https` URL, so any port the URL carries — not just 443.
+#               Already SSRF-guarded application-side: `Grappa.Net.Ssrf`
+#               resolves the host and refuses every non-public address, so the
+#               private-range denials below MIRROR a guard the code already
+#               enforces rather than adding a new constraint.
+#
+#   Captcha     `Grappa.Admission.Captcha.SiteVerifyHttp.verify/4` → `Req.post/2`,
+#               HTTPS 443 to hCaptcha or Cloudflare Turnstile. Also not named in
+#               the issue. Dormant unless `GRAPPA_CAPTCHA_PROVIDER` is set —
+#               it defaults to `disabled` in `config/runtime.exs`.
+#
+#   IdP         Does not exist yet. grappa carries no OIDC client today; it
+#               arrives with issue 1911. Nothing here needs a rule for it.
+#
+#   Reverse DNS Named in the issue as a candidate, and REFUSED with the
+#               measurement: `Grappa.Net.PtrResolver` issues an ordinary PTR
+#               query through `:inet_res` to the cluster resolver. It never
+#               dials the address it is naming, so it needs no rule beyond DNS.
+#
+# ─── WHY THE PUBLIC RULE IS ALL PORTS, NOT 443 ──────────────────────────────
+#
+# Because IRC is the product and its ports are the operator's. A 443-only
+# egress rule in `base/` would ship a bouncer that cannot bounce, on every
+# cluster that applied it, with the silent-failure signature described above.
+# Pinning the IRC hosts here is equally impossible — nobody knows them at the
+# time this file is written.
+#
+# So the base posture is: everything grappa can legitimately reach on the
+# public internet is allowed on any port, and everything INSIDE the cluster or
+# on a private network is denied. That is the boundary worth enforcing here —
+# it is lateral movement, not the port number, that a NetworkPolicy buys you.
+#
+# 🔴 THE ONE RULE AN OPERATOR MUST EDIT: if your IRC server is private —
+# in-cluster, on the LAN, behind a VPN, anywhere in the ranges excluded below —
+# base DENIES it and every network will sit in `connecting`. Add an egress rule
+# for it. `overlays/default/kustomization.yaml` carries the template, together
+# with the tightened per-host variant for operators who do want to enumerate
+# their networks.
+#
+# 🔴 SECOND EDIT WORTH CHECKING: the `except:` list below assumes the
+# conventional private ranges. If your cluster's pod or service CIDR lies
+# outside them (some managed clusters use public-range addressing), the pod can
+# reach the cluster and the denial you think you have is not there.
+#
+# SUPPORT STATUS: community-maintained, not tested in CI. See the repository
+# root `kustomization.yaml`.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grappa
+  labels:
+    app.kubernetes.io/name: grappa
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grappa
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # TCP 4000 from the ingress controller's namespace, and nothing else.
+    # Nothing in the cluster has business reaching this pod directly.
+    #
+    # EDIT the namespace name to match your controller — `ingress-nginx` is the
+    # ingress-nginx chart's default. `kubernetes.io/metadata.name` is the label
+    # the API server sets on every namespace automatically, so no extra
+    # labelling is needed.
+    #
+    # (The release also opens epmd on 4369 for Erlang distribution, since the
+    # release boots with a node name. Denying it here is correct and costs
+    # nothing: `bin/grappa remote` runs inside the pod, over loopback, which
+    # NetworkPolicy does not police.)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 4000
+
+  egress:
+    # ── DNS ──────────────────────────────────────────────────────────────
+    # UDP *and* TCP 53 to the cluster resolver. `k8s-app: kube-dns` is the
+    # label CoreDNS carries in a stock cluster even though the name says
+    # kube-dns; check yours if name resolution fails from the pod.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # ── The public internet, any port ────────────────────────────────────
+    # IRC upstreams, web push vendors, theme/avatar image fetches, captcha
+    # site-verify. See the header for why this is not narrowed to 443.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8          # RFC 1918
+              - 172.16.0.0/12       # RFC 1918
+              - 192.168.0.0/16      # RFC 1918
+              - 100.64.0.0/10       # RFC 6598 CGNAT — pod/node CIDR on some clouds
+              - 169.254.0.0/16      # link-local, and the cloud metadata service
+              - 127.0.0.0/8         # loopback
+
+    # ── The public internet over IPv6, any port ──────────────────────────
+    # Not decoration: `Grappa.IRC.Client` looks up AAAA records
+    # (`:inet_res.lookup(host, :in, :aaaa)`) and connects over v6 when that is
+    # what the network publishes. On a dual-stack cluster without this rule, a
+    # v6-only IRC network is silently unreachable while v4 ones work — the
+    # hardest shape of this failure to diagnose.
+    #
+    # Harmless on a v4-only cluster (there is no v6 traffic to match). If your
+    # CNI rejects an IPv6 ipBlock outright it will say so at apply time, which
+    # is the loud failure; delete this rule then.
+    - to:
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - fc00::/7            # unique local
+              - fe80::/10           # link-local
+              - ::1/128             # loopback

--- a/base/pvc.yaml
+++ b/base/pvc.yaml
@@ -1,0 +1,40 @@
+# grappa — the one volume, and the one thing worth backing up.
+#
+# /data holds THREE things, and the third is why losing this volume is not a
+# recoverable event:
+#
+#   * the SQLite database (`DATABASE_PATH=/data/grappa.db`, baked in the image),
+#   * the uploads root (`UPLOADS_STORAGE_ROOT=/data/uploads`, likewise), and
+#   * the generated secrets (`/data/grappa.env`, written by
+#     `infra/docker/release-entrypoint.sh` on first boot).
+#
+# GRAPPA_ENCRYPTION_KEY lives in that third file and decrypts every stored
+# upstream credential. Restoring the database without it restores nothing
+# usable. Back the volume up whole.
+#
+# ReadWriteOnce, and not by accident: SQLite is a single-writer store and the
+# Deployment is pinned to one replica with `strategy: Recreate` to match.
+# RWX would only make it possible to get this wrong.
+#
+# SUPPORT STATUS: community-maintained, not tested in CI. See the repository
+# root `kustomization.yaml`.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grappa-data
+  labels:
+    app.kubernetes.io/name: grappa
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # Scrollback plus uploads. 10Gi is a starting point, not a measurement:
+      # the database grows with message volume and the uploads root with
+      # whatever your users post. Size it for your install, and prefer a
+      # storage class that can expand.
+      storage: 10Gi
+
+  # Left unset on purpose — the cluster's default StorageClass is used. Name
+  # yours here if you do not have a default, or if you want a specific one.
+  # storageClassName: ""

--- a/base/secret.yaml
+++ b/base/secret.yaml
@@ -1,0 +1,61 @@
+# grappa — OPTIONAL Secret template. Shipped entirely commented out, and NOT
+# listed in `base/kustomization.yaml`'s `resources:`.
+#
+# You almost certainly do not need this. On first boot
+# `infra/docker/release-entrypoint.sh` generates every value below onto the
+# /data volume (`/data/grappa.env`, mode 0600) and reuses it byte-for-byte on
+# every later boot — it never rotates a secret it already wrote. The rule is
+# OPERATOR ENV WINS: a variable present in the container env is used as-is and
+# the generator never touches it; a variable absent (or empty) is generated.
+#
+# So supply this Secret only if you want to own the key material — because you
+# restore /data from a backup taken elsewhere, because your cluster policy
+# forbids self-generated secrets, or because you already have a VAPID pair
+# your installed PWA clients are subscribed against.
+#
+# 🔴 GRAPPA_ENCRYPTION_KEY decrypts every stored upstream credential. Changing
+# it after the fact does not re-encrypt anything — it makes every stored
+# NickServ/SASL password unreadable. Set it once, before first boot, or never.
+#
+# To use it: uncomment the body below AND the `- secret.yaml` line in
+# `base/kustomization.yaml`. The Deployment already references it with
+# `optional: true`, so nothing else changes. Uncommenting only one of the two
+# fails loudly (kustomize on a resource file with no `kind:`), which is the
+# intended failure.
+#
+# Generate the values the same way the packaged hosts do
+# (`infra/packaging/gen-secrets.sh`), openssl only:
+#
+#   SECRET_KEY_BASE        openssl rand -base64 48
+#   SECRET_SIGNING_SALT    openssl rand -base64 32
+#   RELEASE_COOKIE         openssl rand -hex 32
+#   GRAPPA_ENCRYPTION_KEY  openssl rand -base64 32     (Cloak wants 32 bytes)
+#   VAPID_PUBLIC_KEY  }    an ECDSA P-256 pair, base64url-unpadded (RFC 8292).
+#   VAPID_PRIVATE_KEY }    `mix grappa.gen_vapid`, or the openssl recipe in
+#                          infra/packaging/gen-secrets.sh — it is fiddly, and
+#                          letting the entrypoint generate the pair is the
+#                          easier road unless you are migrating existing
+#                          subscriptions.
+#
+# Committing real values here puts them in git. Prefer `kubectl create secret
+# generic grappa-secrets --from-env-file=...`, an External Secrets operator, or
+# a SOPS-encrypted overlay — the Deployment's `optional: true` reference finds
+# the Secret by NAME regardless of how it got there.
+#
+# SUPPORT STATUS: community-maintained, not tested in CI. See the repository
+# root `kustomization.yaml`.
+
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: grappa-secrets
+#   labels:
+#     app.kubernetes.io/name: grappa
+# type: Opaque
+# stringData:
+#   SECRET_KEY_BASE: ""
+#   SECRET_SIGNING_SALT: ""
+#   RELEASE_COOKIE: ""
+#   GRAPPA_ENCRYPTION_KEY: ""
+#   VAPID_PUBLIC_KEY: ""
+#   VAPID_PRIVATE_KEY: ""

--- a/base/service.yaml
+++ b/base/service.yaml
@@ -1,0 +1,30 @@
+# grappa — the single Service in front of the single pod.
+#
+# Plain HTTP on 4000. TLS terminates in front of this, exactly as on every
+# other deploy path: the container serves cleartext and owns its own CSP and
+# security headers (`GrappaWeb.Plugs.SecurityHeaders`).
+#
+# WebSockets need nothing here — `/socket` is an ordinary HTTP upgrade on the
+# same port. Session affinity is likewise unnecessary: there is one pod, so
+# there is nothing to be sticky to.
+#
+# ClusterIP and not LoadBalancer/NodePort: reaching this from outside the
+# cluster is the Ingress's job (see `overlays/default/kustomization.yaml`).
+#
+# SUPPORT STATUS: community-maintained, not tested in CI. See the repository
+# root `kustomization.yaml`.
+apiVersion: v1
+kind: Service
+metadata:
+  name: grappa
+  labels:
+    app.kubernetes.io/name: grappa
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grappa
+  ports:
+    - name: http
+      port: 4000
+      targetPort: http
+      protocol: TCP

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45253,3 +45253,90 @@ raw bytes, and every other consumer of a body is unchanged. And the report's
 own reach is one bot on one network: the rule generalises because the mechanism
 is the regex word class rather than any bot's habits, but no survey of senders
 was run to say how many lines in the corpus were affected.
+<!-- entry #1912 -->
+
+---
+
+## 2026-09-05 — #1912: the Kubernetes manifests, and the egress list that would have bricked the bouncer
+
+Kustomize manifests for the release image, at the repository root: a root
+`kustomization.yaml` importing `base/` (Deployment, Service, PVC, an optional
+Secret template, a NetworkPolicy) plus `overlays/default/` for the PHX_HOST
+patch, an Ingress example and the IRC-egress rule. Root and not `infra/k8s/`
+because that is what was asked for; the layout is not the interesting part.
+
+**Shipped untested, on purpose, and the header says so.** The open question was
+whether to add a kind-based smoke job to CI. We took the other branch — a
+support-status header in every file stating the path is community-maintained
+and not exercised by CI. The two options are not symmetric: a header is
+reversible in one commit, a Kubernetes target in CI is owned forever. The cost
+is real and named rather than hidden: these manifests are reviewed by reading,
+and they can rot without anything going red.
+
+**The egress set was measured from the code, not copied from the request.** The
+list that came with the ask named DNS, IRC, web push and (once OIDC lands) the
+IdP. Enumerating every outbound call site in `lib/` found two more it did not:
+`Grappa.Net.ImageFetcher.Req.fetch/1` (`Req.get/2`), which is load-bearing for
+theme backgrounds and cached peer CTCP AVATAR images, and
+`Grappa.Admission.Captcha.SiteVerifyHttp.verify/4` (`Req.post/2`), dormant until
+`GRAPPA_CAPTCHA_PROVIDER` is set. One candidate was refused with the
+measurement: reverse-DNS is not separate egress —
+`Grappa.Net.PtrResolver.resolve/1` issues a PTR query through `:inet_res` to the
+cluster resolver and never dials the address it is naming, so the DNS rule
+already covers it. DNS itself needs UDP *and* TCP 53, because a truncated answer
+retries over TCP and a UDP-only rule turns that into intermittent resolution
+failure.
+
+**Why `base/` allows any port to the public internet rather than 443.** A
+NetworkPolicy that selects a pod and declares `policyTypes: [Ingress, Egress]`
+makes everything it does not list denied — so on a permissive cluster the object
+does not *describe* a posture, it *creates* one. A 443-only base would therefore
+ship a bouncer that cannot reach IRC to every cluster that applied it, and IRC
+ports are the operator's (6697, 6667, anything). Pinning the hosts in `base/` is
+impossible for the same reason. The boundary that is worth enforcing here is not
+the port but the direction: everything public is allowed on any port, everything
+private or in-cluster is denied — which is also, exactly, the posture
+`Grappa.Net.Ssrf` already enforces application-side for the image fetcher. The
+per-network tightening, and the rule an operator with a private ircd MUST add,
+ship commented in the overlay; a NetworkPolicy is purely additive, so that patch
+REPLACES `spec.egress` rather than extending it (measured by rendering it, not
+assumed).
+
+The failure mode is why this is prose and not a bullet list: an incomplete
+egress allowlist does not look like a firewall problem. grappa reports itself
+up, `/healthz` stays green, and every network sits in `connecting` forever —
+indistinguishable, from the operator's chair, from an upstream outage.
+
+**Three image-shaped traps Kubernetes exposes that no other substrate does.**
+`Dockerfile.release` says `USER grappa`, a NAME: adding the reflexive
+`runAsNonRoot: true` makes the kubelet refuse the pod outright, because it
+cannot verify a non-numeric user is non-root. A freshly provisioned PVC is
+root-owned, so without an `fsGroup` the non-root entrypoint dies on its first
+write to `/data` — and the value is arbitrary, since the kubelet chowns the
+volume to that GID *and* adds it to the pod's supplementary groups. And
+`PEER_AVATARS_STORAGE_ROOT` is the one state root the release image does NOT
+bake: `config/runtime.exs` defaults it to the relative `runtime/peer_avatars`,
+which resolves against WORKDIR `/app` — the container's ephemeral layer, not the
+volume. It is only a cache, so this is durability rather than correctness, but
+it means the claim "everything in `/data`" is true of the database, the uploads
+and the secrets, and not of the avatars.
+
+**`/healthz` is a deep check, and the probes are set accordingly.** It sits
+outside both router pipelines (`pipe_through []`) and answers under any auth
+state, which is what makes it usable at all — but `Grappa.Health.check/0` runs
+`Repo.query("SELECT 1")` and asserts the singleton ETS tables exist. That is
+right for readiness and needs a long leash on liveness: a transient SQLite lock
+must not get the single writer killed. Hence ~3 minutes of sustained failure
+before a restart, and a startup probe to cover first-boot migrations plus theme
+seeding.
+
+**What this does NOT settle.** Nothing was applied to a cluster. The manifests
+render (`kubectl kustomize` on both the root and the overlay, and on the
+commented Secret, Ingress and IRC-egress templates with their comments stripped),
+which proves they parse and compose; it proves nothing about admission, about
+whether any particular CNI accepts an IPv6 `ipBlock`, or about whether the pod
+actually boots. `kubectl apply --dry-run=client` could not stand in for that —
+it fetches the OpenAPI schema from an API server, and there is none here. The
+Kanidm example the request asked for is absent and stays absent until the OIDC
+client exists (#1911): a Kanidm deployed next to a grappa with no OIDC client
+has nothing to talk to.

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,37 @@
+# grappa — Kubernetes install, the plain path.
+#
+#   kubectl apply -k .
+#
+# after setting PHX_HOST in `base/deployment.yaml`. That is the whole
+# procedure; everything else the release image generates for itself on first
+# boot (see `base/deployment.yaml` for the measurement).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# SUPPORT STATUS: COMMUNITY-MAINTAINED, NOT TESTED IN CI.
+#
+# Nothing in this repository's CI exercises Kubernetes. There is no kind
+# cluster, no `apply -k` smoke job, no `/healthz` wait — so these manifests are
+# reviewed by reading, not by running, and they can rot without anything going
+# red. Every other deploy path (Docker Compose, the .deb/.rpm, the CloudFormation
+# one-click) is exercised somewhere; this one is not. Treat it as a starting
+# point you own, not as a supported product surface.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# What this composes:
+#
+#   base/          Deployment + Service + PVC + NetworkPolicy (+ an optional
+#                  Secret template, shipped commented out).
+#   overlays/default/
+#                  The same base with PHX_HOST patched from the overlay instead
+#                  of edited in place, an Ingress example, and the tightened
+#                  IRC-egress rule an operator fills in. Apply it with
+#                  `kubectl apply -k overlays/default` INSTEAD of this file.
+#
+# No namespace is pinned: this lands wherever your context points. Use
+# `kubectl apply -k . -n grappa` (and create the namespace first) if you want it
+# elsewhere.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base

--- a/overlays/default/kustomization.yaml
+++ b/overlays/default/kustomization.yaml
@@ -1,0 +1,167 @@
+# grappa — the worked example overlay.
+#
+#   kubectl apply -k overlays/default
+#
+# Same `base/`, but PHX_HOST is patched from HERE instead of edited in place,
+# which is the shape you want if you track this repository and keep your own
+# values in a fork or a sibling overlay. Everything else in this file is
+# commented: an Ingress example, and the IRC-egress rule.
+#
+# SUPPORT STATUS: community-maintained, not tested in CI. See the repository
+# root `kustomization.yaml`.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  # ── PHX_HOST ────────────────────────────────────────────────────────────
+  # The one value nothing can invent, and the only one you must set. A
+  # strategic-merge patch on `env` merges by the entry's `name`, so this
+  # replaces PHX_HOST alone and leaves the rest of the container untouched.
+  #
+  # It is the PUBLIC hostname clients reach — the name on your TLS certificate
+  # and in the Ingress rule below, not the Service name. Get it wrong and
+  # uploads mint dead links into permanent IRC scrollback and every WebSocket
+  # handshake is rejected by the `check_origin` gate.
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: grappa
+      spec:
+        template:
+          spec:
+            containers:
+              - name: grappa
+                env:
+                  - name: PHX_HOST
+                    value: grappa.example.org
+
+  # ── IRC egress ──────────────────────────────────────────────────────────
+  # 🔴 THE RULE AN OPERATOR EDITS. Two reasons to uncomment it:
+  #
+  #   1. Your IRC server is PRIVATE — in-cluster, on the LAN, behind a VPN.
+  #      `base/networkpolicy.yaml` denies every private range, so grappa will
+  #      sit in `connecting` forever and look like an upstream outage. This is
+  #      the rule that lets it out.
+  #
+  #   2. You want to TIGHTEN the base posture from "any public host, any port"
+  #      down to the networks you actually use.
+  #
+  # A NetworkPolicy is purely additive — you cannot narrow one by adding
+  # another — so this REPLACES the base egress list rather than extending it.
+  # A strategic-merge patch does exactly that here: `spec.egress` has no merge
+  # key, so the list below is substituted wholesale. Which means it must
+  # restate DNS too, or name resolution dies with it.
+  #
+  # Fill in your own hosts. `ipBlock` takes CIDRs, not names: NetworkPolicy
+  # cannot match a DNS name, so resolve your networks first and accept that a
+  # round-robin IRC network moving addresses will need this list revisited.
+  #
+  # - patch: |-
+  #     apiVersion: networking.k8s.io/v1
+  #     kind: NetworkPolicy
+  #     metadata:
+  #       name: grappa
+  #     spec:
+  #       egress:
+  #         # DNS — restated, because this list replaces the base one.
+  #         - to:
+  #             - namespaceSelector:
+  #                 matchLabels:
+  #                   kubernetes.io/metadata.name: kube-system
+  #               podSelector:
+  #                 matchLabels:
+  #                   k8s-app: kube-dns
+  #           ports:
+  #             - protocol: UDP
+  #               port: 53
+  #             - protocol: TCP
+  #               port: 53
+  #         # Your IRC networks. 6697 is TLS, 6667 is plaintext; some networks
+  #         # listen on neither.
+  #         - to:
+  #             - ipBlock:
+  #                 cidr: 198.51.100.0/24
+  #           ports:
+  #             - protocol: TCP
+  #               port: 6697
+  #             - protocol: TCP
+  #               port: 6667
+  #         # Web push vendors, captcha site-verify, theme + avatar image
+  #         # fetches. Drop this block only if you are prepared to lose push
+  #         # notifications and remote images — see base/networkpolicy.yaml.
+  #         - to:
+  #             - ipBlock:
+  #                 cidr: 0.0.0.0/0
+  #                 except:
+  #                   - 10.0.0.0/8
+  #                   - 172.16.0.0/12
+  #                   - 192.168.0.0/16
+  #                   - 100.64.0.0/10
+  #                   - 169.254.0.0/16
+  #                   - 127.0.0.0/8
+  #           ports:
+  #             - protocol: TCP
+  #               port: 443
+
+# ── Ingress example ───────────────────────────────────────────────────────
+# Commented, because an Ingress cannot ship working: the host, the
+# `ingressClassName` and the TLS secret are all yours. Copy this into a file of
+# its own (`overlays/default/ingress.yaml`), add it to `resources:` above, and
+# fill it in.
+#
+# WebSockets: nothing special is required for the `/socket` upgrade on
+# ingress-nginx — it proxies an upgrade by default. What DOES bite is the
+# proxy read timeout, 60s by default, which tears down an idle Channels socket
+# once a minute; the annotation below raises it. Other controllers (Traefik,
+# HAProxy, Contour) spell their timeouts differently — check yours rather than
+# assuming this annotation carried over.
+#
+# No session affinity is needed or wanted. There is exactly one pod, and there
+# is nothing to be sticky to.
+#
+# TLS terminates HERE. The container serves plain HTTP on 4000 and owns its own
+# CSP and security headers (`GrappaWeb.Plugs.SecurityHeaders`) — do not add a
+# second set at the proxy.
+#
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: grappa
+#   labels:
+#     app.kubernetes.io/name: grappa
+#   annotations:
+#     # Keep idle Channels WebSockets alive past the 60s default.
+#     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+#     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+#     # Match the 128MiB body ceiling the BEAM itself enforces
+#     # (`Plug.Parsers` in GrappaWeb.Endpoint), or large uploads 413 at the
+#     # proxy before the app's own per-type caps ever apply.
+#     nginx.ingress.kubernetes.io/proxy-body-size: "128m"
+# spec:
+#   ingressClassName: nginx
+#   tls:
+#     - hosts:
+#         - grappa.example.org
+#       secretName: grappa-tls
+#   rules:
+#     - host: grappa.example.org
+#       http:
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: grappa
+#                 port:
+#                   name: http
+
+# ── Kanidm ────────────────────────────────────────────────────────────────
+# The issue asked for a Kanidm example in this overlay. It is NOT here, and
+# deliberately: grappa carries no OIDC client today, so a Kanidm deployed
+# alongside it would have nothing to talk to. It arrives with #1911, together
+# with the IdP egress rule (discovery + JWKS + token endpoint, HTTPS 443) that
+# `base/networkpolicy.yaml` therefore does not carry either.


### PR DESCRIPTION
Kustomize manifests for the release image, per issue 1912 — a root
`kustomization.yaml` importing `base/` (one file per component) plus
`overlays/default/`, and a Kubernetes section in `INSTALL.md`.

> Deliberately no closing keyword anywhere in this body. This PR does not
> settle the open question in that issue.

```
kustomization.yaml       # the plain path — imports base/
base/kustomization.yaml
base/deployment.yaml     # 1 replica, Recreate, /healthz probes
base/service.yaml        # ClusterIP :4000, plain HTTP
base/pvc.yaml            # RWO at /data
base/secret.yaml         # OPTIONAL — shipped commented out, not in resources:
base/networkpolicy.yaml
overlays/default/kustomization.yaml   # PHX_HOST patch + Ingress + IRC egress
```

## CI: expect 4 checks, not 5

The diff is new YAML plus `INSTALL.md` plus `docs/DESIGN_NOTES.md`. None of
those paths appear in `integration.yml`'s filter, so **the `integration`
workflow does not start**. `ci.yml` has no path filter and contributes its four
jobs: `test + lint + audit`, `shottino (build + tests)`, `dialyzer`,
`cicchetto (types + lint + unit)`. A green 4/4 here is not the usual 5/5 — read
it as four.

## The five claims, each confirmed or refused with the measurement

Answered by name, not by line number.

**1. `/healthz` is outside both pipelines and answers under any auth state —
CONFIRMED, with a qualification that changed the manifest.** `GrappaWeb.Router`
mounts it in a scope whose `pipe_through` is the empty list, and nothing in the
endpoint's plug stack ahead of the router authenticates
(`Plug.RequestId` → `Plugs.RemoteIpFromProxy` → `Plugs.SecurityHeaders` →
static → parsers → session → router).

The qualification: it is a **deep** check, not a ping. `Grappa.Health.check/0`
runs `Repo.query("SELECT 1")` and asserts the singleton ETS tables exist, and
`GrappaWeb.HealthController` returns 503 naming the failing check. Right for
readiness; wrong for a twitchy liveness probe, because a transient SQLite lock
or an exhausted pool would then get the single writer killed. Hence
`failureThreshold: 6` / `periodSeconds: 30` on liveness (~3 minutes of
*sustained* failure) and a `startupProbe` at 60×5s to cover first-boot
migrations plus theme seeding.

**2. `PHX_HOST` is the only mandatory env — CONFIRMED, and it holds for two
different reasons that both had to be checked.** `infra/docker/release-entrypoint.sh`
generates all six values, not four: `SECRET_KEY_BASE`, `SECRET_SIGNING_SALT`,
`RELEASE_COOKIE`, `GRAPPA_ENCRYPTION_KEY`, `VAPID_PUBLIC_KEY`,
`VAPID_PRIVATE_KEY` — into `/data/grappa.env` via `infra/packaging/gen-secrets.sh`,
under `umask 077`, filling only blanks and never rotating. It `mkdir -p`s the
database parent and the uploads root before that, and it runs
`Grappa.Release.migrate()` (plus a non-fatal `seed_themes()`) when
`GRAPPA_AUTO_MIGRATE` is unset-or-1 **and** argv is one of
`start|start_iex|daemon|daemon_iex` — the image's `CMD ["start"]` satisfies
that.

The second reason: `config/runtime.exs` also raises on a missing
`DATABASE_PATH`. It never fires here because `Dockerfile.release` bakes
`DATABASE_PATH`, `UPLOADS_STORAGE_ROOT`, `CIC_DIST_ROOT`, `GRAPPA_SUBSTRATE` and
`PORT` as image `ENV`, and a Kubernetes `env:` block adds to image ENV rather
than replacing it. So the Secret stays genuinely optional — referenced with
`optional: true`, which means the pod starts when it does not exist.

**3. One pod serves the cic bundle too — CONFIRMED.** `Dockerfile.release` sets
`CIC_DIST_ROOT=/app/cicchetto-dist`; `config/runtime.exs` reads it into
`:cic_dist_root`; the endpoint's `:serve_cic_static` plug and
`GrappaWeb.SpaController` both take the root from `Grappa.Cic.Bundle.root/0`.
One Deployment, one Service.

**4. Port 4000, plain HTTP — CONFIRMED.** `EXPOSE 4000` and `PORT=4000` in the
image, `Service` on 4000, TLS terminated in front. No WebSocket-specific
Service config is needed; no session affinity either, there being one pod.

**5. `replicas: 1` + `Recreate`, never an HPA; `/data` carries DB + uploads +
secrets — CONFIRMED, and one thing on that volume is NOT there.**
`PEER_AVATARS_STORAGE_ROOT` is the one state root the image does **not** bake:
`config/runtime.exs` defaults it to the relative `runtime/peer_avatars`, which
is interpreted against WORKDIR `/app` — the container's ephemeral layer, wiped
on every pod recreate. It is only a cache of peer CTCP AVATAR images
(`Grappa.Avatars.Reaper` creates the directory at boot and the images
re-download), so this is durability rather than correctness, but the Deployment
sets it to `/data/peer_avatars` explicitly rather than let the claim
"everything is on `/data`" be quietly false.

## The egress set, measured

Enumerated from every outbound call site in `lib/`, not copied from the issue's
list.

| Destination | Call site | In the issue's list? |
|---|---|---|
| DNS, UDP **and** TCP 53 | `Grappa.IRC.Client` (`:inet_res.lookup/3`, `:inet.getaddr/2`), `Grappa.Net.PtrResolver.resolve/1` (`:inet_res.resolve/5`), `Grappa.Net.Ssrf.resolve_safe/1` (`:inet.getaddrs/2`) | yes |
| IRC upstream, any port | `Grappa.IRC.Client.default_connect/5` → `:gen_tcp.connect/4` / `:ssl.connect/4` | yes |
| Web push, HTTPS 443 | `Grappa.Push.Sender.deliver/2` → `ExNudge.send_notification/3` (HTTPoison) | yes |
| **Remote image fetch, http/https, any port** | `Grappa.Net.ImageFetcher.Req.fetch/1` → `Req.get/2`, called by `Grappa.Themes.BackgroundImage` and `Grappa.Avatars` | **no — added** |
| **Captcha site-verify, HTTPS 443** | `Grappa.Admission.Captcha.SiteVerifyHttp.verify/4` → `Req.post/2` | **no — added** (dormant unless `GRAPPA_CAPTCHA_PROVIDER` is set; it defaults to `disabled`) |
| IdP | does not exist — grappa carries no OIDC client today | listed as "once issue 1911 lands"; no rule shipped |
| Reverse DNS | `Grappa.Net.PtrResolver` — **REFUSED as separate egress** | it is a PTR query through `:inet_res` to the cluster resolver; it never dials the address it names, so the DNS rule already covers it |

Two details that are load-bearing and easy to get wrong: DNS needs **TCP** 53 as
well as UDP (a truncated answer retries over TCP, and a UDP-only rule makes that
an intermittent failure), and the policy ships an **IPv6** `ipBlock` because
`Grappa.IRC.Client` looks up AAAA records — on a dual-stack cluster a v6-only
network would otherwise be silently unreachable while v4 ones worked.

## 🔴 Where I deviated from the issue's egress list, and why

The second comment asks for HTTPS 443 plus a per-network IRC rule. **`base/`
instead allows any port to the public internet, and denies every private range.**
The reasoning is a property of the object, not a preference:

- A NetworkPolicy that selects a pod and declares `policyTypes: [Ingress, Egress]`
  makes everything it does not list **denied**. On a permissive cluster this
  object does not describe a posture, it *creates* one — so a 443-only `base/`
  would ship a bouncer that cannot reach IRC to every cluster that applied it,
  with exactly the failure signature the comment itself warns about (`/healthz`
  green, every network stuck in `connecting`).
- IRC ports are the operator's (6697, 6667, other), and the hosts are unknowable
  at authoring time — so there is no correct fixed allowlist to write in `base/`.
- The private-range denials mirror a guard the application already enforces:
  `Grappa.Net.Ssrf` refuses every non-public address for the image fetcher.

So `base/` carries no IRC allowlist, exactly as the brief required. The
per-network tightening **and** the rule an operator with a private/in-cluster
ircd must add both ship commented in `overlays/default/kustomization.yaml`, with
the loud note. Because a NetworkPolicy is purely additive, that patch **replaces**
`spec.egress` rather than extending it — verified by rendering, not assumed.

Two things the header tells an operator to check: the `except:` list assumes the
conventional private ranges (a cluster with public-range pod CIDRs does not get
the denial it thinks it has), and `kubernetes.io/metadata.name: ingress-nginx`
is a default to edit.

## Three image-shaped traps Kubernetes exposes and no other substrate does

- 🔴 **No `runAsNonRoot: true`.** `Dockerfile.release` says `USER grappa`, a
  *name*; the kubelet cannot verify a non-numeric user is non-root and fails the
  pod with `CreateContainerConfigError`. The image is already non-root — the flag
  would only break it. There is a comment saying so, because the next reader will
  want to add it.
- **`fsGroup` is required**, not hygiene: a freshly provisioned PVC is root-owned
  and the entrypoint's first write to `/data` would die. The value is arbitrary —
  the kubelet chowns the volume to that GID *and* adds it to the pod's
  supplementary groups. `fsGroupChangePolicy: OnRootMismatch` avoids a recursive
  chown on every start. Storage drivers that ignore `fsGroup` need the directory
  pre-chowned; that is in the comment.
- **`PEER_AVATARS_STORAGE_ROOT`** — see claim 5.

## What is NOT in this PR, and is declared rather than silently dropped

- 🚫 **The Kanidm example in the overlay.** grappa carries no OIDC client, so a
  Kanidm next to it has nothing to talk to. The overlay ends with a commented
  paragraph saying it arrives with issue 1911, together with the IdP egress rule
  that `base/networkpolicy.yaml` therefore also omits. **Declared assumption**, not
  a measurement: I did not audit issue 1911's state beyond the fact that no OIDC
  client exists in `lib/` today.
- 🚫 **The kind-based CI smoke job.** Left to vjt, see below. Every file carries
  the alternative the issue offered: an explicit community-maintained /
  not-tested-in-CI header, and `INSTALL.md` leads with it in a blockquote so a
  reader who copies one command does not have to reach a file header to learn it.

## The one open product question, isolated and NOT decided

**Does a kind-based smoke job go into CI?** The issue frames the trade honestly —
without it the manifests rot silently; with it we own a Kubernetes target
forever. This PR takes the reversible branch (the header) so that the manifests
can ship today, and does not pre-empt the answer: adding the job later costs
nothing that has been spent here. That call is vjt's.

Everything else in this PR is a **constraint already decided**, not a choice I
made: root rather than `infra/k8s/`; one file per component under `base/` with a
`default` overlay; one Deployment and one Service; one replica with `Recreate`;
one RWO PVC at `/data`; `PHX_HOST` as the only mandatory env with an optional
Secret; `/healthz` for both probes; a NetworkPolicy in `base/`; the IRC egress
rule as an operator-edited overlay knob.

## Validation — exactly what was run, and what was not

`kubectl` is present (client v1.34.1, embedded Kustomize v5.7.1); `kustomize`
and `kind` are not, and nothing was installed.

Run, all `rc=0`:

- `kubectl kustomize .` — the root path renders Service, PVC, Deployment,
  NetworkPolicy.
- `kubectl kustomize overlays/default` — same, with `PHX_HOST` patched to
  `grappa.example.org`, confirming the strategic-merge patch merges the `env`
  list by `name` and leaves `PEER_AVATARS_STORAGE_ROOT` alone.
- The commented **IRC-egress patch**, mechanically uncommented into a throwaway
  overlay and rendered: `spec.egress` came back as the three rules from the patch
  and the base's any-port and IPv6 rules were **gone** — proving the claim in the
  comment that it replaces rather than extends. Throwaway overlay deleted.
- The commented **Secret** and **Ingress** templates, likewise uncommented and
  rendered through kustomize (which parses and validates them): both come back as
  well-formed objects with the expected keys.
- `scripts/design-notes-gate.sh` against `origin/main`: *1 new entry heading(s),
  separator and marker present.*

**Not run, and not claimed:**

- `kubectl apply --dry-run=client -k .` **fails here** and could not stand in for
  schema validation: it fetches the OpenAPI schema from an API server
  (`dial tcp [::1]:8080: connection refused`). There is no cluster.
- Nothing was applied anywhere. No pod was booted. So the rendering proves parse
  and composition and says nothing about admission, about whether a given CNI
  accepts an IPv6 `ipBlock`, or about whether grappa comes up under these
  manifests.
- PyYAML is absent on this host, so the YAML parsing above is kustomize's, not a
  second independent parser's.
- No Elixir gate was run locally: the diff contains no `.ex`, and the shared
  `_build` is not mine to occupy for a YAML change. CI's four jobs are the check.

## What I refused to assert

- **That these manifests work.** They render. Nobody has run them. Every file
  says so and `INSTALL.md` says so first.
- **That the egress list is complete.** It is complete with respect to every
  outbound call site I could enumerate in `lib/` — `Req`, `HTTPoison`/`ExNudge`,
  `:gen_tcp`/`:ssl`, `:inet_res`/`:inet`. A dependency dialling out on its own
  would not appear in that sweep.
- **That `fsGroup: 1000` is right for every cluster.** It is right for every CSI
  driver that honours `fsGroup`; the comment names the ones that do not rather
  than pretending the problem is solved.
- **That 10Gi is a size.** It is a placeholder, and the PVC comment says as much
  instead of implying a measurement nobody took.
- **That the ingress-nginx annotations carry to other controllers.** They are
  named as ingress-nginx's spelling, with a note to check yours.
- **README.** It enumerates deploy paths in prose and now under-describes them by
  one. I left it alone rather than widen the diff; say the word and it is a
  one-clause follow-up.
