### PR TITLE
cic(1914): /topic answers in the window, not in red

### DIFF
--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -16,7 +16,14 @@ import { casemappingForSlug } from "./lib/casemapping";
 import { acceptInvite, confirmJoinChannel } from "./lib/channelJoin";
 import { channelKey, decodeChannelKey } from "./lib/channelKey";
 import { statusmsgDescription } from "./lib/channelModes";
-import { hasNoTopic, type TopicJoinLine, topicByChannel, topicJoinLine } from "./lib/channelTopic";
+import {
+  hasNoTopic,
+  type TopicJoinLine,
+  type TopicShowLine,
+  topicByChannel,
+  topicJoinLine,
+  topicShowLine,
+} from "./lib/channelTopic";
 import { isChannelName } from "./lib/chantypes";
 import { stripCtcpAction } from "./lib/ctcpAction";
 import { isDocumentVisible } from "./lib/documentVisibility";
@@ -69,6 +76,7 @@ import { setCursorIfAdvances, setSelectedChannel } from "./lib/selection";
 import type { Point } from "./lib/swipe";
 import { isMobile } from "./lib/theme";
 import { formatTimestamp } from "./lib/timeFormat";
+import { type TopicShowEntry, topicShowByWindow } from "./lib/topicShow";
 import { dismissWhoisCard, whoisCardBySlug } from "./lib/whoisCard";
 import { SERVER_WINDOW_NAME, type WindowKind } from "./lib/windowKinds";
 import MessageContextMenu from "./MessageContextMenu";
@@ -1124,7 +1132,14 @@ type InviteAckRow = { type: "invite-ack"; entry: InviteAckEntry; channel: string
 // from `ScrollbackMessage.kind === "topic"` (the persisted mid-session change
 // row) so the two never blur — distinct rows, distinct code paths.
 type TopicRow = { type: "topic-join"; line: TopicJoinLine; id: string };
-type Row = SeparatorRow | UnreadMarkerRow | MessageRow | InviteAckRow | TopicRow;
+// #1914: the `/topic` answer — a SECOND presentational topic row, and a
+// separate variant on purpose. `topic-join` is unsolicited, at most one per
+// window, anchored to the own-JOIN and derived LIVE from `topicByChannel`;
+// this one is operator-requested, may repeat, sits at the moment it was
+// asked, and carries a FROZEN snapshot. Same look, different lifecycle —
+// collapsing them into one variant with a flag would fuse those.
+type TopicShowRow = { type: "topic-show"; line: TopicShowLine; id: string };
+type Row = SeparatorRow | UnreadMarkerRow | MessageRow | InviteAckRow | TopicRow | TopicShowRow;
 
 const ScrollbackPane: Component<Props> = (props) => {
   let listRef!: HTMLDivElement;
@@ -1526,7 +1541,13 @@ const ScrollbackPane: Component<Props> = (props) => {
         }
       }
     }
-    if (msgs.length === 0 && inviteAckEntries.length === 0) return [];
+    // #1914 — the `/topic` answers for THIS window. Keyed by the submitting
+    // window (not the target channel), so a `/topic #other` answers where the
+    // operator typed it. Every window kind can carry one: `/topic #chan` is
+    // legal from a query or the $server window too.
+    const topicShowEntries: TopicShowEntry[] = topicShowByWindow()[key()] ?? [];
+    if (msgs.length === 0 && inviteAckEntries.length === 0 && topicShowEntries.length === 0)
+      return [];
     // Freeze contract: read the FROZEN snapshot, not live getReadCursor.
     const cursor = markerCursorId();
     const sessionTop = sessionTopId();
@@ -1712,6 +1733,27 @@ const ScrollbackPane: Component<Props> = (props) => {
           }
           result.splice(insertAt, 0, { type: "topic-join", line: tjl, id: "topic-join" });
         }
+      }
+    }
+    // #1914 — the `/topic` answers, interleaved by wallclock `at` exactly like
+    // invite-acks: an answer belongs at the moment it was asked, not pinned to
+    // the bottom where later arrivals would make it look like a reply to them.
+    // Sorted on a COPY — `topicShowEntries` is the store's own array.
+    if (topicShowEntries.length > 0) {
+      for (const entry of [...topicShowEntries].sort((a, b) => a.at - b.at || a.ts - b.ts)) {
+        let insertAt = result.length;
+        for (let i = 0; i < result.length; i += 1) {
+          const r = result[i];
+          if (r?.type === "message" && r.msg.server_time > entry.at) {
+            insertAt = i;
+            break;
+          }
+        }
+        result.splice(insertAt, 0, {
+          type: "topic-show",
+          line: topicShowLine(entry.channel, entry.topic),
+          id: `topic-show-${entry.ts}`,
+        });
       }
     }
     return result;
@@ -4073,6 +4115,39 @@ const ScrollbackPane: Component<Props> = (props) => {
                     </span>
                     <Show when={row.line.meta}>
                       <span class="scrollback-topic-join-meta"> — {row.line.meta}</span>
+                    </Show>
+                  </div>
+                );
+              }
+              if (row.type === "topic-show") {
+                // #1914 — the `/topic` answer. Wears the join line's classes on
+                // purpose: it is the same fact, and an operator who has seen one
+                // should not have to learn a second look for the other. Its own
+                // testid keeps the two separable in tests and, like the join
+                // line, keeps it out of the unread/cursor math and row counts.
+                // `text: null` is the "no topic set" answer — printed, because
+                // the operator ASKED and silence would read as a broken verb.
+                return (
+                  <div
+                    class="scrollback-topic-join"
+                    data-testid="topic-show-line"
+                    data-kind="topic-show"
+                  >
+                    <Show
+                      when={row.line.text !== null}
+                      fallback={
+                        <span class="scrollback-topic-join-label">
+                          No topic set for {row.line.channel}
+                        </span>
+                      }
+                    >
+                      <span class="scrollback-topic-join-label">Topic for {row.line.channel}:</span>{" "}
+                      <span class="scrollback-body">
+                        <MircBody body={row.line.text ?? ""} emphasis />
+                      </span>
+                      <Show when={row.line.meta}>
+                        <span class="scrollback-topic-join-meta"> — {row.line.meta}</span>
+                      </Show>
                     </Show>
                   </div>
                 );

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -332,6 +332,9 @@ import {
 // advances the read cursor without needing the button to render (jsdom's
 // zero-geometry keeps `atBottom` true, so the button never mounts).
 import { requestScrollToBottom } from "../lib/scrollToBottomCommand";
+// #1914 — the REAL `/topic` answer store, for the same reason: the pane is
+// its only reader, and what these tests assert IS that it reads it.
+import { appendTopicShow } from "../lib/topicShow";
 import { dismissWhoisCard, setWhoisBundle } from "../lib/whoisCard";
 import ScrollbackPane, {
   resetAutoFocusedJoinsForTest,
@@ -6781,5 +6784,119 @@ describe("ScrollbackPane", () => {
 
       expect(getDraft(KEY)).toBe("<alice> hello << ");
     });
+  });
+});
+
+// #1914 — `/topic` prints the topic INTO the window. The command handler drops
+// a frozen snapshot into `topicShow`; the pane's `rows()` memo turns it into a
+// presentational row at the moment it was asked. These pin the pane's half.
+//
+// Each test takes its OWN channel, because `topicShow` is a module singleton
+// with no reset seam: its only emptier is an identity rotation, and adding a
+// test-only door to production code to work around a shared fixture would be
+// the tail wagging the dog. Distinct keys make the isolation structural.
+describe("#1914 /topic answer row", () => {
+  const topic = { text: "beta — https://grappa.chat", set_by: "vjt", set_at: null };
+  let n = 0;
+
+  const msg = (chan: string, id: number, server_time: number): ScrollbackMessage => ({
+    id,
+    network: "freenode",
+    channel: chan,
+    server_time,
+    kind: "privmsg",
+    sender: "alice",
+    body: "hello",
+    meta: {},
+  });
+
+  // Returns the fresh channel name so the caller can seed + assert against it.
+  const freshChannel = (): string => {
+    n += 1;
+    return `#t1914-${n}`;
+  };
+  const keyFor = (chan: string) => `freenode ${chan}` as ChannelKey;
+  const mount = (chan: string) =>
+    render(() => <ScrollbackPane networkSlug="freenode" channelName={chan} kind="channel" />);
+
+  beforeEach(() => {
+    setUserNick("vjt");
+    mockMembersByChannel.mockReturnValue({});
+  });
+
+  it("renders the topic text and the setter meta", () => {
+    const chan = freshChannel();
+    appendTopicShow(keyFor(chan), chan, topic);
+    setScrollback({ [keyFor(chan)]: [msg(chan, 1, 1000)] });
+    mount(chan);
+
+    const row = screen.getByTestId("topic-show-line");
+    expect(row).toHaveTextContent(`Topic for ${chan}:`);
+    expect(row).toHaveTextContent("beta — https://grappa.chat");
+    expect(row).toHaveTextContent("set by vjt");
+  });
+
+  // The operator ASKED. Silence would read as a broken verb, so the empty
+  // topic gets an answer of its own rather than no row at all.
+  it("answers 'No topic set' rather than rendering nothing", () => {
+    const chan = freshChannel();
+    appendTopicShow(keyFor(chan), chan, { text: null, set_by: null, set_at: null });
+    setScrollback({ [keyFor(chan)]: [msg(chan, 1, 1000)] });
+    mount(chan);
+
+    expect(screen.getByTestId("topic-show-line")).toHaveTextContent(`No topic set for ${chan}`);
+  });
+
+  // An empty window is exactly where an operator types /topic first; the early
+  // "no rows" return in the memo must not swallow the answer.
+  it("renders in a window with no messages at all", () => {
+    const chan = freshChannel();
+    appendTopicShow(keyFor(chan), chan, topic);
+    setScrollback({ [keyFor(chan)]: [] });
+    mount(chan);
+
+    expect(screen.getByTestId("topic-show-line")).toBeInTheDocument();
+  });
+
+  // Asking twice prints twice — it is a log of what was asked, not a banner.
+  it("prints one row per invocation", () => {
+    const chan = freshChannel();
+    appendTopicShow(keyFor(chan), chan, topic);
+    appendTopicShow(keyFor(chan), chan, topic);
+    setScrollback({ [keyFor(chan)]: [msg(chan, 1, 1000)] });
+    mount(chan);
+
+    expect(screen.getAllByTestId("topic-show-line")).toHaveLength(2);
+  });
+
+  // Presentational, like the #237 join line: it must stay out of the row
+  // counts and the read-cursor walk, so it is not a `scrollback-line` and
+  // carries no `data-msg-id`.
+  it("is presentational — no scrollback-line testid, no message id", () => {
+    const chan = freshChannel();
+    appendTopicShow(keyFor(chan), chan, topic);
+    setScrollback({ [keyFor(chan)]: [msg(chan, 1, 1000)] });
+    mount(chan);
+
+    const row = screen.getByTestId("topic-show-line");
+    expect(row.dataset.msgId).toBeUndefined();
+    expect(screen.getAllByTestId("scrollback-line")).toHaveLength(1);
+  });
+
+  // Interleaved by wallclock, like an invite-ack: the answer belongs where it
+  // was asked, not pinned under whatever arrived afterwards.
+  it("sits before a message that arrived after the ask", () => {
+    const chan = freshChannel();
+    appendTopicShow(keyFor(chan), chan, topic);
+    const at = Date.now();
+    setScrollback({
+      [keyFor(chan)]: [msg(chan, 1, at - 10_000), msg(chan, 2, at + 10_000)],
+    });
+    mount(chan);
+
+    const rows = Array.from(
+      document.querySelectorAll("[data-testid='scrollback-line'],[data-testid='topic-show-line']"),
+    ).map((r) => r.getAttribute("data-testid"));
+    expect(rows).toEqual(["scrollback-line", "topic-show-line", "scrollback-line"]);
   });
 });

--- a/cicchetto/src/__tests__/channelTopic.test.ts
+++ b/cicchetto/src/__tests__/channelTopic.test.ts
@@ -32,6 +32,7 @@ import {
   type TopicEntry,
   topicJoinLine,
   topicJoinMeta,
+  topicShowLine,
 } from "../lib/channelTopic";
 
 describe("channelTopic store", () => {
@@ -307,5 +308,45 @@ describe("topicJoinMeta", () => {
   it("falls back to the raw set-at string when it is unparseable", () => {
     const meta = topicJoinMeta(entry({ text: "hi", set_by: "vjt", set_at: "not-a-date" }));
     expect(meta).toBe("set by vjt at not-a-date");
+  });
+});
+
+// #1914 — the `/topic` answer line. The contrast with `topicJoinLine` above is
+// the point of every case here: the join line stays SILENT when there is
+// nothing worth printing, this one always answers, because the operator asked.
+describe("topicShowLine", () => {
+  it("carries the topic text verbatim, control bytes included", () => {
+    const raw = "bold 4red";
+    expect(topicShowLine("#chan", entry({ text: raw })).text).toBe(raw);
+  });
+
+  it("names the channel as spelled — it is a label, never a key", () => {
+    expect(topicShowLine("#Chan", entry({ text: "hi" })).channel).toBe("#Chan");
+  });
+
+  it("appends the setter/time meta when the 333 supplied it", () => {
+    const line = topicShowLine("#chan", entry({ text: "hi", set_by: "vjt" }));
+    expect(line.meta).toBe("set by vjt");
+  });
+
+  it("answers 'no topic' for 331's null — where topicJoinLine prints nothing", () => {
+    expect(topicShowLine("#chan", entry({ text: null })).text).toBeNull();
+    expect(topicJoinLine("#chan", entry({ text: null }))).toBeNull();
+  });
+
+  it("answers 'no topic' for the empty string an explicit TOPIC clear wrote", () => {
+    expect(topicShowLine("#chan", entry({ text: "" })).text).toBeNull();
+  });
+
+  it("drops a stale setter alongside a cleared topic (no orphan meta)", () => {
+    const line = topicShowLine("#chan", entry({ text: "", set_by: "vjt", set_at: null }));
+    expect(line.text).toBeNull();
+    expect(line.meta).toBeNull();
+  });
+
+  it("treats a whitespace-only topic as PRESENT — the wire carried it", () => {
+    // Deliberate divergence from topicJoinLine, which trims and stays silent.
+    expect(topicShowLine("#chan", entry({ text: "   " })).text).toBe("   ");
+    expect(topicJoinLine("#chan", entry({ text: "   " }))).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -4648,14 +4648,65 @@ describe("compose submit — /topic branches", () => {
     expect(compose.getDraft(k)).toBe("/topic -delete");
   });
 
-  it("/topic bare returns inline error (C3 wires the inline render)", async () => {
+  // #1914 — this used to assert the `TODO(C3)` stub's own error string
+  // ("inline render wired in C3"), i.e. it PINNED the defect: the one verb an
+  // operator uses to READ the topic answered in red with a ticket name. The
+  // replacement asserts the behaviour instead — the topic lands in the window.
+  it("/topic bare appends the cached topic to the submitting window", async () => {
     localStorage.setItem("grappa-token", "tok");
+    const { seedTopic } = await import("../lib/channelTopic");
+    const { topicShowByWindow } = await import("../lib/topicShow");
     const compose = await import("../lib/compose");
     const k = channelKey("freenode", "#a");
+    seedTopic(channelKey("freenode", "#a"), {
+      text: "beta — https://grappa.chat",
+      set_by: "vjt",
+      set_at: "2026-09-05T09:11:40.000Z",
+    });
     compose.setDraft(k, "/topic");
     const result = await compose.submit(k, "freenode", "#a");
 
-    expect(result).toMatchObject({ error: expect.stringContaining("C3") });
+    expect(result).toEqual({ ok: true });
+    const entries = topicShowByWindow()[k] ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      channel: "#a",
+      topic: { text: "beta — https://grappa.chat", set_by: "vjt" },
+    });
+  });
+
+  // The answer lands where the operator TYPED it, not in the target window —
+  // irssi's rule. Pinned because keying it on the target channel is the
+  // plausible-looking alternative that silently answers off-screen.
+  it("/topic #other answers in the submitting window, not the target", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const { seedTopic } = await import("../lib/channelTopic");
+    const { topicShowByWindow } = await import("../lib/topicShow");
+    const compose = await import("../lib/compose");
+    const here = channelKey("freenode", "#a");
+    const other = channelKey("freenode", "#other");
+    seedTopic(other, { text: "elsewhere", set_by: null, set_at: null });
+    compose.setDraft(here, "/topic #other");
+    const result = await compose.submit(here, "freenode", "#a");
+
+    expect(result).toEqual({ ok: true });
+    expect(topicShowByWindow()[here] ?? []).toHaveLength(1);
+    expect(topicShowByWindow()[other] ?? []).toHaveLength(0);
+  });
+
+  // No fabricated empty topic for a channel we hold no cache for (#975 drops
+  // the entry on own-PART): absence means "not in that channel", and saying
+  // "no topic set" there would be a confident lie.
+  it("/topic on an uncached channel errors instead of printing an empty topic", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const { topicShowByWindow } = await import("../lib/topicShow");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/topic #never-joined");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toMatchObject({ error: expect.stringContaining("#never-joined") });
+    expect(topicShowByWindow()[k] ?? []).toHaveLength(0);
   });
 });
 
@@ -6358,7 +6409,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "selection.selectedChannel()",
           ],
           "result": {
-            "error": "/topic #a (bare) — inline render wired in C3 (TopicBar)",
+            "error": "/topic #a — no topic known; join #a first",
           },
         },
         "umode": {

--- a/cicchetto/src/__tests__/topicShow.test.ts
+++ b/cicchetto/src/__tests__/topicShow.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelKey } from "../lib/channelKey";
+import type { TopicEntry } from "../lib/channelTopic";
+
+// #1914 — the `/topic` answer store. Two properties carry the design and are
+// the only ones worth pinning: the snapshot is FROZEN at invocation, and rows
+// accumulate in ask-order rather than collapsing last-write-wins.
+
+vi.mock("../lib/auth", () => ({ token: () => "tok" }));
+
+const k = (name: string) => `freenode ${name}` as ChannelKey;
+const entry = (over: Partial<TopicEntry> = {}): TopicEntry => ({
+  text: "beta",
+  set_by: "vjt",
+  set_at: "2026-09-05T09:11:40.000Z",
+  ...over,
+});
+
+describe("topicShow store", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("appends one entry per invocation, in ask order", async () => {
+    const { appendTopicShow, topicShowByWindow } = await import("../lib/topicShow");
+    appendTopicShow(k("#a"), "#a", entry({ text: "first" }));
+    appendTopicShow(k("#a"), "#a", entry({ text: "second" }));
+
+    const rows = topicShowByWindow()[k("#a")] ?? [];
+    expect(rows.map((r) => r.topic.text)).toEqual(["first", "second"]);
+  });
+
+  it("gives every entry a strictly increasing sequence, for same-ms ties", async () => {
+    const { appendTopicShow, topicShowByWindow } = await import("../lib/topicShow");
+    appendTopicShow(k("#a"), "#a", entry());
+    appendTopicShow(k("#a"), "#a", entry());
+
+    const rows = topicShowByWindow()[k("#a")] ?? [];
+    expect(rows[1]?.ts).toBeGreaterThan(rows[0]?.ts ?? 0);
+  });
+
+  // The whole reason the entry copies the fields instead of holding the key:
+  // a topic change after the answer was printed must not rewrite what the
+  // operator already read.
+  it("freezes the snapshot — a later topic change cannot rewrite a printed row", async () => {
+    const { appendTopicShow, topicShowByWindow } = await import("../lib/topicShow");
+    const live = entry({ text: "before" });
+    appendTopicShow(k("#a"), "#a", live);
+    live.text = "after";
+
+    expect(topicShowByWindow()[k("#a")]?.[0]?.topic.text).toBe("before");
+  });
+
+  it("keys on the submitting window, so two windows never share rows", async () => {
+    const { appendTopicShow, topicShowByWindow } = await import("../lib/topicShow");
+    appendTopicShow(k("#a"), "#other", entry());
+
+    expect(topicShowByWindow()[k("#a")]).toHaveLength(1);
+    expect(topicShowByWindow()[k("#other")]).toBeUndefined();
+  });
+
+  it("records the channel AS SPELLED — the row prints it, never keys on it", async () => {
+    const { appendTopicShow, topicShowByWindow } = await import("../lib/topicShow");
+    appendTopicShow(k("#a"), "#Sbiffo", entry());
+
+    expect(topicShowByWindow()[k("#a")]?.[0]?.channel).toBe("#Sbiffo");
+  });
+});

--- a/cicchetto/src/lib/channelTopic.ts
+++ b/cicchetto/src/lib/channelTopic.ts
@@ -199,3 +199,40 @@ function formatTopicSetAt(setAt: string): string {
   if (Number.isNaN(parsed.getTime())) return setAt;
   return parsed.toLocaleString();
 }
+
+// #1914 — the `/topic` answer line. Sibling of `topicJoinLine` above, and the
+// difference between them is the whole reason it is a second function rather
+// than a flag: the JOIN line is UNSOLICITED, so it prints nothing when there
+// is nothing worth printing; this one answers a question the operator just
+// asked, so it must always say something true — including "no topic set",
+// which is an answer and not an absence.
+//
+// `text: null` carries that case. Both `hasNoTopic` shapes (331's `null` and
+// an operator's `TOPIC #chan :` empty string) collapse into it here, because
+// the operator asked what the topic IS and both mean "there isn't one"; the
+// distinction between them is a wire fact, not a fact about the channel.
+
+/** The renderable `/topic` answer: `text: null` means "no topic set". */
+export type TopicShowLine = {
+  channel: string;
+  /** Full topic text VERBATIM (mIRC control bytes preserved for MircBody),
+   * or `null` when the channel has no topic. */
+  text: string | null;
+  meta: string | null;
+};
+
+/**
+ * Maps a channel + its frozen topic entry to the `/topic` answer line. Never
+ * returns null — an answer is always printed, unlike `topicJoinLine`.
+ *
+ * A whitespace-only topic is a topic the wire carried (the `hasNoTopic`
+ * posture), so it renders as one rather than collapsing to "no topic set".
+ */
+export function topicShowLine(channel: string, entry: TopicEntry): TopicShowLine {
+  const text = entry.text ?? null;
+  return {
+    channel,
+    text: hasNoTopic(text) ? null : text,
+    meta: hasNoTopic(text) ? null : topicJoinMeta(entry),
+  };
+}

--- a/cicchetto/src/lib/commands/topic.ts
+++ b/cicchetto/src/lib/commands/topic.ts
@@ -1,17 +1,38 @@
 import { postTopic } from "../api";
+import { channelKey } from "../channelKey";
+import { topicByChannel } from "../channelTopic";
 import { pushChannelTopicClear } from "../socket";
+import { appendTopicShow } from "../topicShow";
 import type { CommandHandler } from "./context";
 
 /**
- * Bare `/topic` or `/topic #chan` — render the cached topic inline. The
- * cached topic lives in `channelTopic.ts`; rendering is pure UI.
+ * #1914 — bare `/topic` or `/topic #chan`: print the topic INTO THE WINDOW,
+ * irssi-style, from the cache `channelTopic.ts` already holds.
  *
- * TODO(C3): wire to TopicBar's cached topic for inline render.
+ * This was a `TODO(C3)` stub that returned an inline ERROR string, so the one
+ * verb an operator reaches for to READ the topic answered in red with the name
+ * of an unfinished ticket. The topic was never unavailable — the join-time
+ * `332`/`333` seed `topicByChannel` on every JOIN and every change — it just
+ * had no door into scrollback.
+ *
+ * The answer lands as an ephemeral row in the SUBMITTING window (see
+ * `topicShow.ts` for why the snapshot is frozen and why it is keyed there),
+ * NOT as a `{ ok: string }` compose notice: the notice auto-dismisses, and a
+ * topic long enough to be unreadable in the TopicBar — the complaint that
+ * opened #1914 — is exactly the one a transient green strip cannot carry.
+ *
+ * An uncached channel is an honest error, never a fabricated empty topic: the
+ * cache is dropped on own-PART (#975), so absence means "not in that channel",
+ * which `/topic` alone cannot fix. Querying upstream for a channel we are not
+ * in would need a server verb — out of scope for a client-only change.
  */
 export const topicShowCommand: CommandHandler<"topic-show"> = async (cmd, ctx) => {
   const ch = cmd.channel ?? ctx.getActiveChannel();
   if (!ch) return { error: "/topic requires a channel — switch to one or use /topic #chan" };
-  return { error: `/topic ${ch} (bare) — inline render wired in C3 (TopicBar)` };
+  const entry = topicByChannel()[channelKey(ctx.networkSlug, ch)];
+  if (!entry) return { error: `/topic ${ch} — no topic known; join ${ch} first` };
+  appendTopicShow(ctx.key, ch, entry);
+  return { ok: true };
 };
 
 /**

--- a/cicchetto/src/lib/topicShow.ts
+++ b/cicchetto/src/lib/topicShow.ts
@@ -1,0 +1,82 @@
+import { createSignal } from "solid-js";
+import type { ChannelKey } from "./channelKey";
+import type { TopicEntry } from "./channelTopic";
+import { identityScopedStore } from "./identityScopedStore";
+
+// #1914 — `/topic` (bare, or `/topic #chan`) ephemeral store. Append-only
+// list of frozen topic snapshots per SUBMITTING window key.
+//
+// Why a store at all: the operator asked to SEE the topic, and irssi answers
+// in the window, not in a toast. A command handler cannot reach into
+// `ScrollbackPane`, so the request lands here and the pane's `rows()` memo
+// interleaves it by wallclock `at` — the same shape `inviteAck.ts` uses for
+// the other client-rendered inline row, and for the same reason (a sibling
+// render pinned to the bottom lies about when the line was produced).
+//
+// Display rules, mirroring `inviteAck`:
+//   * Keyed by the SUBMITTING window, not the target channel. `/topic #other`
+//     typed in `#sbiffo` answers in `#sbiffo`, because that is where the
+//     operator is looking — irssi's rule.
+//   * One row per invocation. Asking twice prints twice; that is a log of
+//     what the operator asked and when, not a last-write-wins banner.
+//   * NOT persisted — an answer to a question the operator just asked, not
+//     audit log. Lost on refresh, like an invite-ack.
+//
+// **The snapshot is FROZEN, deliberately.** The entry copies `text` /
+// `set_by` / `set_at` out of `topicByChannel` at invocation time rather than
+// holding the channel key and re-reading it at render time. A later TOPIC
+// change would otherwise retroactively rewrite a line the operator already
+// read — the same lie `meta.sender_prefix` freezes away at send time (#25),
+// and the caveat #237's derived join line had to document rather than fix.
+//
+// Identity-scoped: cleared on logout / token rotation, like every other
+// client-side buffer.
+
+export type TopicShowEntry = {
+  /** The target channel AS SPELLED — this is a label, never a key. */
+  channel: string;
+  /** Frozen copy of the cached topic at invocation time. */
+  topic: TopicEntry;
+  /**
+   * Monotonic insertion sequence (closure-local counter, NOT a clock).
+   * Tiebreaker for two invocations inside the same millisecond.
+   */
+  ts: number;
+  /** Wallclock epoch ms — the sort key against `ScrollbackMessage.server_time`. */
+  at: number;
+};
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const [topicShowByWindow, setTopicShowByWindow] = createSignal<
+    Record<ChannelKey, TopicShowEntry[]>
+  >({});
+
+  let seq = 0;
+
+  onIdentityChange(() => {
+    setTopicShowByWindow({});
+    seq = 0;
+  });
+
+  const appendTopicShow = (windowKey: ChannelKey, channel: string, topic: TopicEntry): void => {
+    seq += 1;
+    const entry: TopicShowEntry = {
+      channel,
+      // Copy the fields rather than the reference: `seedTopic` replaces the
+      // whole entry object today, but a future in-place update must not be
+      // able to reach a line already printed.
+      topic: { text: topic.text, set_by: topic.set_by, set_at: topic.set_at },
+      ts: seq,
+      at: Date.now(),
+    };
+    setTopicShowByWindow((prev) => ({
+      ...prev,
+      [windowKey]: [...(prev[windowKey] ?? []), entry],
+    }));
+  };
+
+  return { topicShowByWindow, appendTopicShow };
+});
+
+export const topicShowByWindow = exports_.topicShowByWindow;
+export const appendTopicShow = exports_.appendTopicShow;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45340,3 +45340,73 @@ it fetches the OpenAPI schema from an API server, and there is none here. The
 Kanidm example the request asked for is absent and stays absent until the OIDC
 client exists (#1911): a Kanidm deployed next to a grappa with no OIDC client
 has nothing to talk to.
+<!-- entry #1914 -->
+
+---
+
+## 2026-09-05 — #1914: `/topic` answers in the window (cic, client-only)
+
+**Symptom.** Typing `/topic` (bare, or `/topic #chan`) printed a red inline
+error: `/topic #sbiffo (bare) — inline render wired in C3 (TopicBar)`. That is
+the `TODO(C3)` stub's OWN string — `topicShowCommand` had never been written,
+and `compose.test.ts` asserted the stub's message, so the suite PINNED the
+defect. A test that encodes a bug prevents anyone from finding the bug; it is
+why this survived from C3 to #1914.
+
+**The topic was never unavailable.** `channelTopic.topicByChannel` is seeded by
+the join-time `332`/`333` on every JOIN and by `topic_changed` on every change,
+and #237 already derives an on-JOIN inline line from it. What was missing was a
+door from the COMMAND side into scrollback.
+
+### The issue asked for something else, and it is not built
+
+#1914 as filed asks the SERVER to persist a typed JOIN-time topic row, and
+states cicchetto "is missing" the join-time line. That premise is not accurate:
+#237 (2026-07-15) ships that line — presentational, derived, anchored after the
+own-JOIN row — and that entry explicitly REJECTED the server-persisted variant
+("option b … a server change AND exactly the reconnect-spam the server
+avoids"). Reversing it needs vjt, not a slice. Two gaps therefore remain open
+under #1914 and neither is addressed here:
+
+* No persisted JOIN-time row, so scrolling back to an OLD join still shows no
+  topic-at-that-time.
+* #237's line still requires the operator's own-JOIN row to be inside the
+  loaded page. On a bouncer it usually is not, which is the likeliest reason
+  the topic reads as "topic-bar only" in daily use.
+
+### Three choices worth the ink
+
+**Not `{ ok: string }`.** The dispatcher renders a string `ok` as the
+auto-dismissing green `.compose-box-notice` (#356). The complaint that opened
+#1914 is a topic too long to read in the TopicBar — a transient strip cannot
+carry it either. It had to be a buffer row.
+
+**The snapshot is FROZEN at invocation.** `topicShow.ts` copies `text` /
+`set_by` / `set_at` out of the store rather than holding the channel key and
+re-reading at render. Re-deriving would let a later TOPIC change retroactively
+rewrite a line the operator already read — the same lie `meta.sender_prefix`
+freezes away at send time (#25), and precisely the caveat #237's live-derived
+line had to DOCUMENT rather than fix ("shows the CURRENT cached topic, not a
+frozen topic-at-join snapshot").
+
+**A second row variant, not a flag on `topic-join`.** Same look, disjoint
+lifecycle: unsolicited vs asked, at most one vs one per invocation, live vs
+frozen, anchored to the own-JOIN vs interleaved at the ask. One variant with a
+flag fuses four differences into a boolean. Reuse the verbs (the `inviteAck`
+interleave-by-wallclock mechanism, the `scrollback-topic-join` classes), not
+the nouns.
+
+### Boundaries, stated so they are not rediscovered as bugs
+
+An UNCACHED channel is an honest error (`no topic known; join #chan first`),
+never a fabricated "no topic set": #975 drops the entry on own-PART, so absence
+means "not in that channel", and asking upstream would need a server verb.
+An EMPTY topic does print `No topic set for #chan` — both `hasNoTopic` shapes
+(331's `null` and an operator's empty `TOPIC #chan :`) collapse there, because
+the operator asked what the topic IS and both mean there isn't one. That
+diverges from `topicJoinLine`, which stays silent on the same input, and the
+divergence is the point: an unsolicited line may say nothing, an ANSWER may
+not. Rows are ephemeral and identity-scoped — lost on refresh, like an
+invite-ack — and presentational, so they stay out of the unread/cursor math.
+
+_Deploy: **HOT — `--cic` only.** No server change, no wire change._


### PR DESCRIPTION
Closes part of #1914 — see **What this does NOT do** before merging.

## The bug

Typing `/topic` (bare, or `/topic #chan`) printed a red inline error:

```
/topic #sbiffo (bare) — inline render wired in C3 (TopicBar)
```

That is the `TODO(C3)` stub's own string. `topicShowCommand` had never been
written — and `compose.test.ts` **asserted that string**, so the suite pinned
the defect. That is why it survived from C3 to now.

The topic was never unavailable: `channelTopic.topicByChannel` is seeded by the
join-time 332/333 on every JOIN and by `topic_changed` on every change. It had
no door from the command side into scrollback.

## Before / after

Before:
<img width="393" height="80" alt="1914-before-topic-red-error" src="https://github.com/user-attachments/assets/979353c9-ad81-4abf-a4b9-dee0da58dcad" />

After:
<img width="1461" height="204" alt="1914-after-zoom" src="https://github.com/user-attachments/assets/ed9cf9c9-69eb-4cd9-9643-78fd73fb28ca" />

## What this does NOT do — and it needs your call

**#1914 as filed asks for something this PR deliberately does not build**, and
the issue's premise is not accurate. It says cicchetto "is missing" the
join-time line. #237 (2026-07-15) ships that line — presentational, derived
from `topicByChannel`, anchored after the own-JOIN row — and that DESIGN_NOTES
entry **explicitly rejected** the server-persisted variant the issue now asks
for:

> Option b (persist a join-time `:topic` row server-side) rejected: a server
> change AND exactly the reconnect-spam the server avoids.

Reversing that is your ruling, not a decision to take inside a slice. So two
gaps stay open under #1914:

1. **No persisted JOIN-time row.** Scrolling back to an old join still shows no
   topic-at-that-time.
2. **#237's line still needs the own-JOIN row inside the loaded page.** On a
   bouncer it usually is not — which is the likeliest reason the topic reads as
   "topic-bar only" in daily use. That one is a small client-only follow-up if
   you want it.

Tell me which of the two to take next and I will open it separately.

## Three choices worth naming

- **Not `{ ok: string }`.** That renders as the auto-dismissing green
  `.compose-box-notice` (#356). The complaint behind #1914 is a topic too long
  to read in the TopicBar — a transient strip cannot carry it either.
- **The snapshot is FROZEN at invocation.** `topicShow.ts` copies
  `text`/`set_by`/`set_at` rather than re-reading the store at render time, so a
  later TOPIC change cannot retroactively rewrite a line already read. Same rule
  as `meta.sender_prefix` (#25), and it closes the caveat #237's live-derived
  line had to document instead.
- **A second row variant, not a flag on `topic-join`.** Same look, disjoint
  lifecycle: unsolicited vs asked, one vs many, live vs frozen, own-JOIN-anchored
  vs interleaved at the ask. Reuse the verbs (the `inviteAck` interleave, the
  `scrollback-topic-join` classes), not the nouns.

## Boundaries

- Uncached channel → honest error (`no topic known; join #chan first`), never a
  fabricated "no topic set". #975 drops the entry on own-PART, so absence means
  "not in that channel"; asking upstream would need a server verb.
- Empty topic → `No topic set for #chan`. Both `hasNoTopic` shapes collapse
  there. Diverges from `topicJoinLine`, which stays silent — deliberately: an
  unsolicited line may say nothing, an answer may not.
- Rows are ephemeral + identity-scoped (lost on refresh, like an invite-ack) and
  presentational, so they stay out of the unread/cursor math.
- Keyed on the **submitting** window, so `/topic #other` answers where you typed
  it — irssi's rule.

## Gates

- `biome check` clean, `tsc --noEmit` + vite build clean.
- Full cic vitest suite: **exit 0**.
- `scripts/design-notes-gate.sh`: pass.
- No Elixir touched, no wire change — **HOT, `--cic` only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDCsdiDSVDJQSaqM4Yjoht