### PR TITLE
credits jingle: a four-bar chiptune phrase, with the loudness as a test (#1916)

### DIFF
--- a/cicchetto/src/__tests__/creditsAudio.test.ts
+++ b/cicchetto/src/__tests__/creditsAudio.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { startCreditsArpeggio } from "../lib/creditsAudio";
+import {
+  BAR_COUNT,
+  BAR_S,
+  type CreditsEvent,
+  creditsBar,
+  PEAK_GAIN,
+  PHRASE_S,
+  startCreditsArpeggio,
+} from "../lib/creditsAudio";
 
 // #1773 — the credit roll's synthesised soundtrack.
 //
@@ -14,6 +22,22 @@ import { startCreditsArpeggio } from "../lib/creditsAudio";
 // jsdom has no WebAudio at all. The AudioContext is handed in rather than
 // constructed by the module precisely so this file can supply one; the
 // component does the feature test.
+//
+// #1916 — a third thing joins them: the arrangement is now several bars long,
+// and "several bars" is the kind of claim that rots into "one bar" the moment
+// someone tidies the scheduler. So the progression is proven at both ends —
+// as data (`creditsBar`) and as what the scheduler actually arms over time.
+// The melody itself is still NOT pinned: no test below names a frequency or a
+// step length, so the tune can be rewritten without touching this file. What
+// is pinned is the shape (bars differ, the phrase is the loop point), the
+// timbre swap that #1916 exists for, and the LOUDNESS.
+//
+// The stub context's clock is a real clock. It has to be: the scheduler places
+// bars against `ctx.currentTime` with a lookahead window, so a `currentTime`
+// frozen at 0 would make it correctly decide there is nothing to arm yet, and
+// every progression assertion below would be measuring the stub instead of the
+// module. `vi.useFakeTimers()` fakes `Date` along with the timers, so the two
+// advance together under `vi.advanceTimersByTime`.
 
 type StubParam = {
   value: number;
@@ -32,6 +56,15 @@ type StubOscillator = {
   onended: (() => void) | null;
 };
 
+type StubBufferSource = {
+  buffer: unknown;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  onended: (() => void) | null;
+};
+
 function stubParam(): StubParam {
   return {
     value: 0,
@@ -43,13 +76,21 @@ function stubParam(): StubParam {
 
 function makeCtx() {
   const oscillators: StubOscillator[] = [];
+  const bufferSources: StubBufferSource[] = [];
   const gains: { gain: StubParam; connect: ReturnType<typeof vi.fn> }[] = [];
   const close = vi.fn();
   const resume = vi.fn();
+  const startedAt = Date.now();
 
   const ctx = {
-    currentTime: 0,
+    // Seconds since this context was made, off the faked `Date` — see the
+    // header. A real AudioContext's clock runs; a stub whose clock does not is
+    // a different module under test.
+    get currentTime(): number {
+      return (Date.now() - startedAt) / 1000;
+    },
     state: "running" as AudioContextState,
+    sampleRate: 48_000,
     destination: {} as AudioDestinationNode,
     close,
     resume,
@@ -71,9 +112,39 @@ function makeCtx() {
       oscillators.push(node);
       return node;
     },
+    createBuffer: (_channels: number, frames: number, _rate: number) => ({
+      getChannelData: () => new Float32Array(frames),
+    }),
+    createBufferSource: () => {
+      const node: StubBufferSource = {
+        buffer: null,
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        onended: null,
+      };
+      bufferSources.push(node);
+      return node;
+    },
   };
 
-  return { ctx: ctx as unknown as AudioContext, oscillators, gains, close, resume };
+  return { ctx: ctx as unknown as AudioContext, oscillators, bufferSources, gains, close, resume };
+}
+
+/** How many lead notes one bar carries — read off the score, never hardcoded. */
+const LEAD_STEPS = creditsBar(0).filter((event) => event.voice === "lead").length;
+
+/** The lead line the scheduler has actually armed so far, chopped into bars. */
+function leadBars(oscillators: readonly StubOscillator[]): number[][] {
+  const pitches = oscillators
+    .filter((osc) => osc.type === "square")
+    .map((osc) => osc.frequency.value);
+  const bars: number[][] = [];
+  for (let i = 0; i + LEAD_STEPS <= pitches.length; i += LEAD_STEPS) {
+    bars.push(pitches.slice(i, i + LEAD_STEPS));
+  }
+  return bars;
 }
 
 describe("startCreditsArpeggio (#1773)", () => {
@@ -183,5 +254,152 @@ describe("startCreditsArpeggio (#1773)", () => {
     startCreditsArpeggio(ctx, false);
 
     expect(resume).toHaveBeenCalled();
+  });
+});
+
+describe("the credits phrase (#1916)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("is several distinct bars long, and the PHRASE is the loop point", () => {
+    // The complaint #1916 records is "it repeats too soon", so the thing to
+    // prove is that the repeat is a phrase away and that the bars in between
+    // are not each other. Proven on the score rather than on a frequency
+    // list, so rewriting the tune costs nothing here.
+    expect(BAR_COUNT).toBeGreaterThan(1);
+
+    const shapes = new Set(
+      Array.from({ length: BAR_COUNT }, (_unused, i) =>
+        JSON.stringify(creditsBar(i).map((event) => [event.voice, event.hz, event.at])),
+      ),
+    );
+    expect(shapes.size).toBe(BAR_COUNT);
+
+    // ...and bar BAR_COUNT is bar 0 again: the wrap, which is what makes it a
+    // phrase rather than a one-shot that runs out.
+    expect(creditsBar(BAR_COUNT)).toEqual(creditsBar(0));
+  });
+
+  it("loops seconds out rather than the ~2 s that got it filed", () => {
+    // A floor, not a pin: #1916 asked for "longer", the orchestrator's call
+    // was ~8 s, and any future shortening back towards the 1.92 s bar this
+    // replaced should have to argue with a red test first.
+    expect(PHRASE_S).toBeCloseTo(BAR_COUNT * BAR_S);
+    expect(PHRASE_S).toBeGreaterThan(7);
+  });
+
+  it("arms the bars in order instead of re-arming the first one", () => {
+    // The scheduler half. `creditsBar` could walk a perfect progression while
+    // the pump asked it for bar 0 every time, and every assertion above would
+    // still be green.
+    const { ctx, oscillators } = makeCtx();
+    startCreditsArpeggio(ctx, false);
+
+    vi.advanceTimersByTime((PHRASE_S + BAR_S) * 1000);
+
+    const bars = leadBars(oscillators);
+    expect(bars.length).toBeGreaterThan(BAR_COUNT);
+    expect(bars[1]).not.toEqual(bars[0]);
+    expect(bars[BAR_COUNT]).toEqual(bars[0]);
+  });
+
+  it("carries the lead on a pulse and the bass on the triangle", () => {
+    // THE swap #1916 is about, and nothing else in the suite would notice a
+    // revert to the #1773 triangle-over-sine-drone voicing.
+    const { ctx, oscillators } = makeCtx();
+    startCreditsArpeggio(ctx, false);
+
+    const types = new Set(oscillators.map((osc) => osc.type));
+    expect(types).toEqual(new Set(["square", "triangle"]));
+
+    // And the pulse is the one ON TOP: a swap that put the square underneath
+    // would satisfy the set above while sounding like a fog horn.
+    const lead = oscillators.filter((o) => o.type === "square").map((o) => o.frequency.value);
+    const bass = oscillators.filter((o) => o.type === "triangle").map((o) => o.frequency.value);
+    expect(Math.min(...lead)).toBeGreaterThan(Math.max(...bass));
+  });
+
+  it("gives the percussion its own noise source, and stop() drops those too", () => {
+    // A `createBufferSource` is not an `OscillatorNode`, so the teardown case
+    // in the suite above walks straight past it: an untorn-down noise channel
+    // would be exactly the leak that test exists to catch, and invisible to it.
+    const { ctx, bufferSources } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+    expect(bufferSources.length).toBeGreaterThan(0);
+
+    arpeggio.stop();
+
+    for (const burst of bufferSources) {
+      expect(burst.stop).toHaveBeenCalled();
+      expect(burst.disconnect).toHaveBeenCalled();
+    }
+  });
+
+  it("cannot get louder than the bar it replaced", () => {
+    // MEASURED off the shipped score, not read off the comment in the module.
+    //
+    // Method: expand two whole phrases to events (two, so the loop seam is
+    // inside the window), lay them on one timeline, and take the worst
+    // instant — the sum of the envelope PEAKS of everything AUDIBLE there.
+    // That is an UPPER BOUND on the rendered waveform rather than the waveform
+    // itself, because |sine|, |square| and |triangle| are all ≤ 1; nothing
+    // here renders audio, and neither jsdom nor node has an
+    // OfflineAudioContext to render it with. It is computed the same way for
+    // both sides of the comparison, so the bound is what is being compared.
+    //
+    // `decayS`, not `durS`: a note's source outlives its envelope, and summing
+    // over the source's life makes every note overlap its successor by one
+    // float ULP. Measured before that was fixed — the bound read 2.61 instead
+    // of 1.41, i.e. it counted two leads and two basses that were, in reality,
+    // 10⁻¹⁵ s apart.
+    const timeline: CreditsEvent[] = [];
+    for (let bar = 0; bar < BAR_COUNT * 2; bar += 1) {
+      for (const event of creditsBar(bar)) {
+        timeline.push({ ...event, at: bar * BAR_S + event.at });
+      }
+    }
+
+    const worstInstant = Math.max(
+      ...timeline.map((anchor) =>
+        timeline
+          .filter((event) => event.at <= anchor.at && anchor.at < event.at + event.decayS)
+          .reduce((sum, event) => sum + event.peak, 0),
+      ),
+    );
+
+    // The positive control. A single voice, or an arrangement whose voices
+    // never overlap, would clear the ceiling below while proving nothing.
+    expect(worstInstant).toBeGreaterThan(1);
+
+    // #1773's worst instant, from the constants it shipped with: a lead note
+    // at full envelope (peak 1) over the continuous A2 drone
+    // (DRONE_GAIN / PEAK_GAIN = 0.025 / 0.06), times the master.
+    const pre1916MixPeak = 0.06 * (1 + 0.025 / 0.06);
+    expect(PEAK_GAIN * worstInstant).toBeLessThanOrEqual(pre1916MixPeak);
+  });
+
+  it("does not dump the missed bars at once when the tab was asleep", () => {
+    // A backgrounded tab freezes `setTimeout` while the audio clock keeps
+    // running. Without the resync in `pump`, the catch-up loop arms every bar
+    // it missed, all with start times in the PAST, which WebAudio renders
+    // immediately — fifteen bars at once, and the gain budget measured above
+    // says nothing at all about that instant.
+    const { ctx, oscillators } = makeCtx();
+    startCreditsArpeggio(ctx, false);
+    const oneBar = oscillators.length;
+    expect(oneBar).toBeGreaterThan(0);
+
+    // `setSystemTime` moves the clock WITHOUT running the timers — which is
+    // precisely what a sleeping tab does to them.
+    vi.setSystemTime(Date.now() + 30_000);
+    vi.advanceTimersByTime(250);
+
+    expect(oscillators.length).toBeLessThanOrEqual(oneBar * 2);
   });
 });

--- a/cicchetto/src/lib/creditsAudio.ts
+++ b/cicchetto/src/lib/creditsAudio.ts
@@ -1,4 +1,4 @@
-// #1773 — the credit roll's soundtrack: a synthesised arpeggio, with ZERO
+// #1773 — the credit roll's soundtrack: a synthesised chiptune, with ZERO
 // audio assets in the tree.
 //
 // WHY SYNTHESISED, and why this is not a preference. The issue asked for
@@ -21,6 +21,26 @@
 // untestable; and an easter egg that leaves a live audio graph behind a
 // closed modal is the battery bug this file's sibling rAF loop was careful
 // not to be.
+//
+// #1916 — the arrangement, and why it is DATA. What shipped in #1773 was one
+// 1.92 s bar (eight triangle notes over a static A2 sine) re-armed verbatim
+// for as long as the modal stayed open, which reads as a ringtone rather than
+// a soundtrack. Four things changed, all inside the same contract above:
+//
+//  - The phrase is a `BARS` ARRAY walked in order (Am → F → C → G), so the
+//    loop point is PHRASE_S out rather than one bar. Lengthening it is adding
+//    entries to that array — no code moves. Four bars is an assumption, not a
+//    ruling; see the PR and DESIGN_NOTES.
+//  - The lead is a `square` and the triangle is demoted to a bass line that
+//    MOVES with the chord, replacing the drone. That swap is most of what
+//    makes a chiptune sound like a chiptune.
+//  - One noise channel for percussion, and only one: a snare REPLACES the hat
+//    on the backbeat instead of sounding over it, which is both how a
+//    two-pulse-plus-noise chip actually behaves and what keeps the mix peak
+//    inside the pre-#1916 budget (see PEAK_GAIN).
+//  - Bars are placed on a LOOKAHEAD cursor (`nextBarAt`) rather than re-based
+//    on `ctx.currentTime` at every re-arm, so timer jitter no longer smears
+//    the phrase. See `pump` for the one hazard that introduces.
 
 /** A running soundtrack. Both verbs are idempotent. */
 export type CreditsArpeggio = {
@@ -30,20 +50,211 @@ export type CreditsArpeggio = {
   readonly stop: () => void;
 };
 
-// A minor, because "epic" in eight notes is a minor arpeggio and everyone
-// knows it: A3 · C4 · E4 · A4 · B4 · A4 · E4 · C4, over an A2 drone.
-const SEQUENCE_HZ = [220, 261.63, 329.63, 440, 493.88, 440, 329.63, 261.63] as const;
-const DRONE_HZ = 110;
-const STEP_S = 0.24;
-const LOOP_S = SEQUENCE_HZ.length * STEP_S;
+// ---------------------------------------------------------------------------
+// Pitch — note names rather than a wall of Hz, so the score below reads as a
+// score. `Note` is a template-literal type, so a typo is a compile error and
+// not a semitone nobody notices.
+// ---------------------------------------------------------------------------
 
+const SEMITONE = {
+  C: 0,
+  "C#": 1,
+  D: 2,
+  "D#": 3,
+  E: 4,
+  F: 5,
+  "F#": 6,
+  G: 7,
+  "G#": 8,
+  A: 9,
+  "A#": 10,
+  B: 11,
+} as const;
+
+type PitchClass = keyof typeof SEMITONE;
+type Octave = "1" | "2" | "3" | "4" | "5" | "6";
+/** Scientific pitch notation — `A2`, `C#5`. */
+type Note = `${PitchClass}${Octave}`;
+
+/** Equal temperament off A4 = 440 Hz (MIDI 69). `A2` → 110, `C4` → 261.63. */
+function hzOf(note: Note): number {
+  const octave = Number(note.slice(-1));
+  const pitchClass = note.slice(0, -1) as PitchClass;
+  return 440 * 2 ** (((octave + 1) * 12 + SEMITONE[pitchClass] - 69) / 12);
+}
+
+// ---------------------------------------------------------------------------
+// The score
+// ---------------------------------------------------------------------------
+
+type Eight<T> = readonly [T, T, T, T, T, T, T, T];
+type Four<T> = readonly [T, T, T, T];
+
+/** One bar: eight eighth-notes of lead over four quarter-notes of bass. */
+type Bar = {
+  readonly lead: Eight<Note>;
+  readonly bass: Four<Note>;
+};
+
+// Am → F → C → G, the i–VI–III–VII everyone already knows, which is the point:
+// the roll is a joke and the tune should land as one. Each lead bar walks the
+// chord up, back down, and exits on a step towards the next chord's root. The
+// bass is root · root · fifth · root, staying inside 87–165 Hz so it sits
+// under the lead instead of fighting it.
+//
+// Adding bars five to eight is adding entries HERE. Nothing below counts to
+// four.
+const BARS: readonly [Bar, ...Bar[]] = [
+  { lead: ["A4", "C5", "E5", "A5", "E5", "C5", "A4", "B4"], bass: ["A2", "A2", "E3", "A2"] },
+  { lead: ["F4", "A4", "C5", "F5", "C5", "A4", "F4", "G4"], bass: ["F2", "F2", "C3", "F2"] },
+  { lead: ["E4", "G4", "C5", "E5", "C5", "G4", "E4", "F4"], bass: ["C3", "C3", "G2", "C3"] },
+  { lead: ["D4", "G4", "B4", "D5", "B4", "G4", "D4", "E4"], bass: ["G2", "G2", "D3", "G2"] },
+];
+
+type Drum = "hat" | "snare";
+
+// ONE noise channel, so the backbeat snare takes the hat's slot rather than
+// stacking on it — see the header. Indices 2 and 6 are beats 2 and 4.
+const DRUMS: Eight<Drum | null> = ["hat", "hat", "snare", "hat", "hat", "hat", "snare", "hat"];
+
+/** One eighth note. 0.24 s ⇒ 125 BPM, unchanged from #1773. */
+const STEP_S = 0.24;
+/** Bar length, in seconds. */
+export const BAR_S = 8 * STEP_S;
+/** How many bars before the phrase repeats. */
+export const BAR_COUNT = BARS.length;
+/** How long the whole phrase runs before it loops. THE number #1916 asked for. */
+export const PHRASE_S = BAR_COUNT * BAR_S;
+
+const BASS_S = 2 * STEP_S;
+const HAT_S = 0.03;
+const SNARE_S = 0.12;
+
+// ---------------------------------------------------------------------------
+// Gain budget
+//
 // Quiet on purpose: this opens without being asked for, on a surface someone
 // may be showing a colleague. Loud enough to be a joke, not loud enough to be
 // an incident.
-const PEAK_GAIN = 0.06;
-const DRONE_GAIN = 0.025;
-// Ramp constant for the mute toggle. An instant gain jump clicks.
+//
+// `PEAK_GAIN` is the master and is UNCHANGED from #1773. Every voice below
+// declares its envelope peak RELATIVE to it, so the worst instant this mix can
+// produce is `PEAK_GAIN × (sum of the peaks of whatever overlaps)`. #1773's
+// worst instant was a lead note (1) over the drone (0.025 / 0.06 = 0.4167) —
+// 1.4167, i.e. 0.085 absolute. The numbers below are chosen so the new worst
+// instant (lead + bass + snare = 1.41) stays under that, and
+// `creditsAudio.test.ts` measures it from this data rather than trusting the
+// arithmetic in this comment.
+// ---------------------------------------------------------------------------
+
+/** Master gain. Deliberate, and not to be raised — see above. */
+export const PEAK_GAIN = 0.06;
+const LEAD_PEAK = 1;
+const BASS_PEAK = 0.28;
+const HAT_PEAK = 0.05;
+const SNARE_PEAK = 0.13;
+
+/** Ramp constant for the mute toggle. An instant gain jump clicks. */
 const MUTE_RAMP_S = 0.02;
+/** Exponential ramps cannot reach zero; this is the working silence. */
+const GAIN_FLOOR = 0.0001;
+/** Fraction of a note spent decaying — the rest is the gap that articulates it. */
+const DECAY_FRACTION = 0.9;
+const ATTACK_S = 0.006;
+
+// ---------------------------------------------------------------------------
+// The score, expanded to events
+// ---------------------------------------------------------------------------
+
+export type CreditsVoice = "lead" | "bass" | "hat" | "snare";
+
+/** One scheduled sound. Times are relative to the START OF ITS BAR. */
+export type CreditsEvent = {
+  readonly voice: CreditsVoice;
+  /** Oscillator pitch, or `null` for the noise voices. */
+  readonly hz: number | null;
+  readonly at: number;
+  /** How long the source runs before it is stopped. */
+  readonly durS: number;
+  /**
+   * How long the envelope takes to reach silence — always shorter than
+   * `durS`, and the gap between the two is what articulates one note from the
+   * next. It is a FIELD rather than a fraction applied at render time because
+   * it is the note's audible span, and that is what a loudness measurement has
+   * to sum over: measuring against `durS` instead makes two adjacent notes
+   * "overlap" by one float ULP and doubles the answer.
+   */
+  readonly decayS: number;
+  /** Envelope peak RELATIVE to the master gain: 1 means `PEAK_GAIN`. */
+  readonly peak: number;
+};
+
+/**
+ * The events of bar `index`, which wraps — `creditsBar(BAR_COUNT)` is bar 0
+ * again. Pure: the scheduler renders these, and the test measures them.
+ */
+export function creditsBar(index: number): readonly CreditsEvent[] {
+  // `?? BARS[0]` is unreachable after the modulo; it is how a non-empty tuple
+  // is spelled under `noUncheckedIndexedAccess` without a throw.
+  const bar = BARS[((index % BAR_COUNT) + BAR_COUNT) % BAR_COUNT] ?? BARS[0];
+  const events: CreditsEvent[] = [];
+
+  bar.lead.forEach((note, i) => {
+    events.push({
+      voice: "lead",
+      hz: hzOf(note),
+      at: i * STEP_S,
+      durS: STEP_S,
+      decayS: STEP_S * DECAY_FRACTION,
+      peak: LEAD_PEAK,
+    });
+  });
+
+  bar.bass.forEach((note, i) => {
+    events.push({
+      voice: "bass",
+      hz: hzOf(note),
+      at: i * BASS_S,
+      durS: BASS_S,
+      decayS: BASS_S * DECAY_FRACTION,
+      peak: BASS_PEAK,
+    });
+  });
+
+  DRUMS.forEach((drum, i) => {
+    if (drum === null) return;
+    const durS = drum === "hat" ? HAT_S : SNARE_S;
+    events.push({
+      voice: drum,
+      hz: null,
+      at: i * STEP_S,
+      durS,
+      decayS: durS * DECAY_FRACTION,
+      peak: drum === "hat" ? HAT_PEAK : SNARE_PEAK,
+    });
+  });
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Scheduling
+// ---------------------------------------------------------------------------
+
+/** Seconds of noise held in the shared buffer bursts are cut out of. */
+const NOISE_S = 1;
+/** How far ahead of the audio clock a bar is armed. */
+const LOOKAHEAD_S = 0.35;
+/** How often the main thread checks whether the next bar is due. */
+const PUMP_MS = 100;
+
+function makeNoiseBuffer(ctx: AudioContext): AudioBuffer {
+  const frames = Math.max(1, Math.floor(ctx.sampleRate * NOISE_S));
+  const buffer = ctx.createBuffer(1, frames, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < frames; i += 1) data[i] = Math.random() * 2 - 1;
+  return buffer;
+}
 
 /**
  * Start the soundtrack on `ctx`, which this function then OWNS — `stop()`
@@ -55,60 +266,88 @@ export function startCreditsArpeggio(ctx: AudioContext, muted: boolean): Credits
   master.gain.value = muted ? 0 : PEAK_GAIN;
   master.connect(ctx.destination);
 
-  const drone = ctx.createOscillator();
-  const droneGain = ctx.createGain();
-  drone.type = "sine";
-  drone.frequency.value = DRONE_HZ;
-  droneGain.gain.value = DRONE_GAIN / PEAK_GAIN;
-  drone.connect(droneGain);
-  droneGain.connect(master);
-
-  // Every note oscillator is kept so `stop()` can silence one scheduled a
-  // beat into the future — `onended` cannot be relied on for that, because a
-  // note that has not started yet never ends.
-  const voices: OscillatorNode[] = [drone];
+  // Every source is kept so `stop()` can silence one scheduled a beat into the
+  // future — `onended` cannot be relied on for that, because a note that has
+  // not started yet never ends.
+  const voices: AudioScheduledSourceNode[] = [];
+  let noise: AudioBuffer | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
+  let barIndex = 0;
+  let nextBarAt = 0;
 
-  const scheduleNote = (hz: number, at: number): void => {
-    const osc = ctx.createOscillator();
-    const env = ctx.createGain();
-    osc.type = "triangle";
-    osc.frequency.value = hz;
-    // Pluck: near-instant attack, exponential decay over the step. Exponential
-    // because a linear fade on a plucked tone reads as a cut.
-    env.gain.setValueAtTime(0.0001, at);
-    env.gain.exponentialRampToValueAtTime(1, at + 0.01);
-    env.gain.exponentialRampToValueAtTime(0.0001, at + STEP_S * 0.9);
-    osc.connect(env);
-    env.connect(master);
-    osc.start(at);
-    osc.stop(at + STEP_S);
-    voices.push(osc);
-    osc.onended = (): void => {
-      const i = voices.indexOf(osc);
+  // Called once the source has been STARTED: `stop()` on a source that never
+  // started is an InvalidStateError, and the two sources start differently
+  // (an oscillator takes a time, a burst takes a time and an offset).
+  const keep = (source: AudioScheduledSourceNode, env: GainNode, stopAt: number): void => {
+    source.stop(stopAt);
+    voices.push(source);
+    source.onended = (): void => {
+      const i = voices.indexOf(source);
       if (i !== -1) voices.splice(i, 1);
-      osc.disconnect();
+      source.disconnect();
       env.disconnect();
     };
   };
 
-  // One loop is scheduled ahead at a time, then re-armed. A per-note timer
-  // would put the rhythm on the main thread's mercy; scheduling the whole bar
-  // against `ctx.currentTime` keeps it on the audio clock, where it belongs.
-  const scheduleLoop = (): void => {
+  const scheduleEvent = (event: CreditsEvent, base: number): void => {
+    const at = base + event.at;
+    // A browser that refused the buffer gets no percussion; the tuned voices
+    // still play. Checked BEFORE the gain node so the refusal costs no node.
+    if (event.hz === null && noise === null) return;
+
+    const env = ctx.createGain();
+    // Pluck: near-instant attack, exponential decay over the note. Exponential
+    // because a linear fade on a plucked tone reads as a cut.
+    env.gain.setValueAtTime(GAIN_FLOOR, at);
+    env.gain.exponentialRampToValueAtTime(event.peak, at + Math.min(ATTACK_S, event.durS * 0.2));
+    env.gain.exponentialRampToValueAtTime(GAIN_FLOOR, at + event.decayS);
+    env.connect(master);
+
+    if (event.hz === null && noise !== null) {
+      const burst = ctx.createBufferSource();
+      burst.buffer = noise;
+      burst.connect(env);
+      // Cut each burst from a different place in the buffer, or every hat is
+      // byte-identical and the row reads as a machine gun rather than a hat.
+      burst.start(at, Math.random() * Math.max(0, NOISE_S - event.durS));
+      keep(burst, env, at + event.durS);
+      return;
+    }
+
+    const osc = ctx.createOscillator();
+    // THE chiptune swap (#1916): pulse lead, triangle bass.
+    osc.type = event.voice === "lead" ? "square" : "triangle";
+    osc.frequency.value = event.hz ?? 0;
+    osc.connect(env);
+    osc.start(at);
+    keep(osc, env, at + event.durS);
+  };
+
+  // Bars are placed against `ctx.currentTime` and never against a timer: a
+  // per-note timer would put the rhythm on the main thread's mercy. The timer
+  // only asks "is the next bar within the lookahead window yet".
+  const pump = (): void => {
     if (stopped) return;
-    const base = ctx.currentTime;
-    SEQUENCE_HZ.forEach((hz, i) => {
-      scheduleNote(hz, base + i * STEP_S);
-    });
-    timer = setTimeout(scheduleLoop, LOOP_S * 1000);
+    // A backgrounded tab freezes setTimeout while the audio clock keeps
+    // running. Without this resync the catch-up below would arm every missed
+    // bar at once with start times in the PAST — which WebAudio renders
+    // immediately, i.e. all together. That is the one way this can get loud,
+    // and it is exactly the case the gain budget above cannot defend against.
+    if (nextBarAt < ctx.currentTime) nextBarAt = ctx.currentTime;
+    while (nextBarAt < ctx.currentTime + LOOKAHEAD_S) {
+      for (const event of creditsBar(barIndex)) scheduleEvent(event, nextBarAt);
+      barIndex += 1;
+      nextBarAt += BAR_S;
+    }
+    timer = setTimeout(pump, PUMP_MS);
   };
 
   try {
     if (ctx.state === "suspended") void ctx.resume();
-    drone.start();
-    scheduleLoop();
+    noise = makeNoiseBuffer(ctx);
+    nextBarAt = ctx.currentTime;
+    pump();
   } catch {
     // A browser that refuses to start the graph gets a silent modal, not a
     // broken one. Nothing below depends on the loop having armed.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45410,3 +45410,106 @@ not. Rows are ephemeral and identity-scoped — lost on refresh, like an
 invite-ack — and presentational, so they stay out of the unread/cursor math.
 
 _Deploy: **HOT — `--cic` only.** No server change, no wire change._
+<!-- entry #1916 -->
+
+---
+
+## 2026-09-05 — #1916: the credits jingle becomes a phrase, and the loudness becomes a test
+
+`cicchetto/src/lib/creditsAudio.ts` — the credit roll's soundtrack, shipped in
+#1773 — was eight `triangle` notes over a static A2 sine, re-armed verbatim
+every 1.92 s. The field complaint ("it repeats too soon") was right in
+substance, and the fix is longer and more chiptune. What is worth recording is
+not the tune; it is the three things the work settled.
+
+### The arrangement is DATA, and the loop length is an assumption
+
+`BARS` is an array of bars walked in order (Am → F → C → G) and `creditsBar/1`
+expands one to typed `CreditsEvent`s; the scheduler renders those events and
+never reads the score. Going from four bars to eight is four more entries in
+that array — no code moves. That shape was chosen precisely because **the loop
+length was the issue's one open question and it was never ruled on**: four bars
+/ 7.68 s is the orchestrator's declared assumption, not vjt's call, and the
+array is what makes reversing it cheap.
+
+The chiptune register is three swaps the issue offered — `square` lead,
+`triangle` demoted to a bass line that MOVES with the chord (the drone is gone,
+not joined), one noise channel for percussion — and one it did not. **The snare
+TAKES the hat's slot rather than stacking on it.** That is how a
+two-pulse-plus-noise chip behaves, and it is also load-bearing for the budget
+below: hat and snare can never sound together, so only one of them is ever in
+the worst instant.
+
+### The loudness ceiling is measured off the shipped score, and the first measurement was wrong
+
+`PEAK_GAIN` is untouched at 0.06 and every voice declares its envelope peak
+RELATIVE to it, so the worst instant this mix can produce is `PEAK_GAIN × (the
+sum of the peaks of whatever is audible at once)`. The test expands two whole
+phrases (two, so the loop seam is inside the window), lays them on one timeline
+and takes that maximum: **1.41 against #1773's 1.4167 — 0.0846 absolute against
+0.085.**
+
+That measurement is why this is a note and not a comment. The hand arithmetic
+said 1.41; **the first run of the test said 2.61**, and the difference was not
+music. Summing over each note's SOURCE lifetime (`durS`) makes every note
+overlap its successor, because `bar*BAR_S + 7*STEP_S + STEP_S` and
+`(bar+1)*BAR_S` are the same instant computed two ways and therefore differ by
+one float ULP — so the bound counted two leads and two basses that were 10⁻¹⁵ s
+apart. The cure is in the DATA rather than in the test: `CreditsEvent.decayS`
+is the note's AUDIBLE span (its envelope reaches the floor there; the source
+runs on to `durS` to leave the articulating gap), it is what the scheduler
+already ramps against, and it is what a loudness sum has to use. **General
+rule: an overlap test over scheduled events must span the ENVELOPE, not the
+source — adjacent-and-touching is the common case, and float equality is not
+where you want it decided.**
+
+### What was NOT measured, stated so nobody reads more into the number
+
+The ceiling above is an **upper bound on the rendered waveform, not the
+waveform**: it sums envelope peaks, and |sine|, |square| and |triangle| are all
+≤ 1. Nothing renders audio anywhere in this repo's test suites — jsdom has no
+WebAudio and node has no `OfflineAudioContext` — so no true sample peak was
+taken, for either side. The bound is computed identically for both, which is
+what makes the comparison sound; it is not a claim about absolute headroom.
+
+Peak is also the wrong axis for "will this embarrass someone on a screen
+share", and swapping a triangle for a square at equal peak raises RMS by 4.8 dB
+on its own. So, computed analytically off the constants (**by hand, not by a
+test**): the old mix's mean square was 0.1031 and the new one's is 0.0502 — the
+new arrangement is **3.1 dB QUIETER in RMS** despite the brighter lead, because
+the continuous A2 drone was **84 %** of #1773's loudness and it is gone. If
+that ever needs to be a gate it needs the envelope integral, which means either
+duplicating the envelope shape in the test or rendering for real.
+
+### The lookahead scheduler, and the one way it can get loud
+
+Bars are now placed on a cursor (`nextBarAt`) advanced by exactly `BAR_S` on
+the audio clock, rather than re-based on `ctx.currentTime` at every re-arm, so
+timer jitter no longer smears the phrase. That swap brings a hazard the old
+shape did not have: **a backgrounded tab freezes `setTimeout` while the audio
+clock keeps running**, so the catch-up loop would arm every missed bar with a
+start time in the PAST — which WebAudio renders immediately, i.e. all of them
+simultaneously. Fifteen bars at once, and the gain budget above says nothing
+whatsoever about that instant. `pump` resyncs the cursor to `ctx.currentTime`
+before catching up; a test that sleeps the clock 30 s without running the
+timers proves it, and the unfixed version dies on it.
+
+### Declined, with the reason
+
+**No e2e.** The visible behaviour here is AUDIO, and Playwright cannot assert
+it: the only in-browser purchase available is monkeypatching `window.AudioContext`
+and inspecting the calls, which asserts the stub and duplicates the unit tests
+through a browser and an exclusive lane. An empty green would be worse than the
+gap. **No `createPeriodicWave` duty-cycle pulse** (12.5 % / 25 %, the NES
+register): `square` is most of the effect and the periodic wave is a third node
+class and a third stub method for the remainder. **No filter on the noise
+channel** — hat and snare are separated by envelope length, which is what the
+NES noise channel has too.
+
+The existing tests were not weakened: none of them pinned a frequency or a step
+length before and none does now, so the tune stays rewritable. The stub context
+gained a real clock (a getter over the faked `Date`) because a `currentTime`
+frozen at 0 makes a lookahead scheduler CORRECTLY decide there is nothing to
+arm — a stub that cannot advance is a different module under test.
+
+_Deploy: **HOT — `--cic` only.** No server change, no wire change._


### PR DESCRIPTION
Re: #1916 — the credit roll's soundtrack was one 1.92 s bar (eight `triangle`
notes over a static A2 sine) re-armed verbatim for as long as the modal stayed
open. It is now a four-bar phrase with a pulse lead, a moving bass and a noise
channel.

## 🔴 The open question was NOT ruled on — 8 s is an assumption

The issue asks "4 bars (~8 s) or 8 (~16 s)?" and nobody answered it.
**Four bars / 7.68 s is the ORCHESTRATOR's declared assumption, not a ruling
from @vjt, and it is reversible.** The arrangement is an array of bars
(`BARS` in `creditsAudio.ts`) walked in order; `creditsBar/1` expands one to
typed events and the scheduler renders those events without ever reading the
score. **Going to eight bars / ~15.4 s is four more entries in that array** —
no code moves, and the tests derive their counts from the data, so none of
them has to change either.

7.68 s and not 8.00: `STEP_S` stays at 0.24 (125 BPM, unchanged from #1773),
so a bar is 1.92 s and four of them are 7.68. Retuning the tempo to land on a
round number was not worth changing the feel for.

## What changed

- **The lead is `square`; the triangle is demoted to a BASS LINE that moves
  with the chord.** The A2 drone is replaced, not joined. Progression is the
  Am → F → C → G the issue suggested.
- **One noise channel** for percussion, and one on purpose: the backbeat snare
  **takes the hat's slot** instead of stacking on it. That is how a
  two-pulse-plus-noise chip behaves, and it is load-bearing for the budget
  below — hat and snare can never sound together.
- **Bars are placed on a lookahead cursor** against `ctx.currentTime` (advanced
  by exactly `BAR_S`) instead of re-based at every re-arm, so timer jitter no
  longer smears the phrase. Still zero `setTimeout`-per-note; the timer only
  asks "is the next bar due yet".
- `AudioContext` is still injected, `stop()` still closes it and still drops
  every source including ones scheduled into the future — the noise bursts are
  `AudioBufferSourceNode`s, which the pre-existing teardown test walks straight
  past, so that gap has its own new test.

## Volume: measured, not estimated — and my first measurement was wrong

`PEAK_GAIN` is untouched at `0.06`. Every voice declares its envelope peak
RELATIVE to it, so the worst instant is `PEAK_GAIN × Σ(peaks of what is audible
at once)`. The new test `cannot get louder than the bar it replaced` expands
**two whole phrases** (two, so the loop seam is inside the window), lays them
on one timeline and takes that maximum:

| | worst instant (relative) | absolute |
|---|---|---|
| #1773 (lead 1 + drone 0.025/0.06) | 1.4167 | **0.0850** |
| this PR (lead 1 + bass 0.28 + snare 0.13) | 1.4100 | **0.0846** |

**The hand arithmetic said 1.41; the first run of the test said 2.61.** Not
music — float. Summing over each note's SOURCE lifetime makes every note
overlap its successor, because `bar*BAR_S + 7*STEP_S + STEP_S` and
`(bar+1)*BAR_S` are the same instant computed two ways and differ by one ULP.
The cure went into the data, not the test: `CreditsEvent.decayS` is the note's
AUDIBLE span (the envelope reaches the floor there; the source runs on to
`durS` to leave the articulating gap) and it is what the scheduler already
ramps against.

## What I am NOT claiming

- **No audio was rendered.** The ceiling above is an upper bound on envelope
  peaks (|sine|, |square|, |triangle| ≤ 1), not a sample peak. jsdom has no
  WebAudio and node has no `OfflineAudioContext`. The bound is computed
  identically for both sides, which is what makes the comparison sound — it is
  not a statement about absolute headroom.
- **The RMS figure is hand-computed, not a test.** Peak is the wrong axis for
  "will this embarrass someone on a screen share", and a square at equal peak
  is +4.8 dB RMS over a triangle on its own. Computed analytically off the
  constants: old mean square 0.1031, new 0.0502 — **3.1 dB quieter overall**,
  because the continuous drone was **84 %** of #1773's loudness and it is gone.
  Making that a gate needs the envelope integral, i.e. either duplicating the
  envelope shape in the test or rendering for real. Neither is in this PR.
- **No e2e, deliberately.** The visible behaviour here is AUDIO. The only
  in-browser purchase is monkeypatching `window.AudioContext` and inspecting
  the calls — which asserts the stub, duplicates the unit tests, and costs the
  exclusive lane. An empty green would be worse than the gap. The two existing
  credits specs cover the modal's visual parts and are untouched.
- **Declined from the issue's suggestion list:** no `createPeriodicWave`
  duty-cycle pulse (12.5 %/25 %) — `square` is most of the effect and the
  periodic wave is a third node class for the remainder; no filter on the noise
  channel — hat and snare are separated by envelope length, which is also all
  the NES noise channel has.

## The hazard the lookahead brought with it

A backgrounded tab freezes `setTimeout` while the audio clock runs on, so the
catch-up loop would arm **every missed bar with a start time in the past** —
which WebAudio renders immediately, i.e. all at once. Fifteen bars stacked, and
the gain budget above says nothing whatsoever about that instant. `pump`
resyncs the cursor before catching up; a test that sleeps the clock 30 s
without running the timers proves it.

## Tests

Existing tests were **not weakened**: none pinned a frequency or a step length
before and none does now, so the tune stays rewritable. The stub context gained
a real clock (a getter over the faked `Date`) — a `currentTime` frozen at 0
makes a lookahead scheduler CORRECTLY decide there is nothing to arm, so the
old stub would have been measuring itself.

Six new tests. Mutation bench, run in a detached scratch worktree at this
branch's head — **7 mutants planted, 7 killed:**

| mutant | dies on |
|---|---|
| `pump` always asks for bar 0 | arms the bars in order |
| resync line deleted | does not dump the missed bars at once |
| `BASS_PEAK` 0.28 → 0.5 | cannot get louder than the bar it replaced |
| lead back to `triangle` | carries the lead on a pulse (+1) |
| noise bursts never enter `voices[]` | percussion … stop() drops those too |
| 4 bars → 3 | loops seconds out rather than ~2 s |
| 4 bars → 1 (the pre-#1916 shape) | 3 tests |

## Gates

Solo-cic, no lane needed.

- `scripts/bun.sh run check` — **rc=0**, 5 stages ran, 0 failed (lock drift ·
  test location · biome · tsc src · tsc e2e)
- `scripts/bun.sh run test` — **rc=0**, 333 files, 6653 tests passed
- `scripts/design-notes-gate.sh` — **rc=0**, "1 new entry heading(s), separator
  and marker present"

Deploy is HOT, `--cic` only. No server change, no wire change.