### PR TITLE
observability(1901): sample the NIF for the writes the seam never sees, and keep the outlier a mean erases

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -415,6 +415,14 @@ config :logger, :console,
     # was written to leave it out. An operator aggregating `held_ms` must not
     # find waits mixed into it.
     :longest_wait_ms,
+    # #1901 — the NIF census's own two, and neither reuses a key above for the
+    # same reason #1687 refused `:held_ms`. `:waiters` counts writers PROVABLY
+    # blocked; a census counted no queue, it photographed a cohort of which
+    # one member is the holder. `:longest_wait_ms` names a WAIT; the longest
+    # parked process may be the writer that was never waiting at all. An
+    # operator aggregating either key must not find census rows mixed in.
+    :parked,
+    :longest_parked_ms,
     :pid,
     :unexpected,
     # Bootstrap summary: how many credentials we enumerated and how

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45629,13 +45629,22 @@ divergence. Separately, `bin/grappa db-latency` has been printing four
 contention values under four names since #1657 shipped a fifth
 (`interrupted`); the header now carries it.
 
-_Deploy: **COLD**, and NOT for the reason the file-path test gives — the diff
-touches no `config/`, no migration, no `mix.exs`, no `infra/`, no
-`application.ex`. Measured through `Grappa.Deploy.Preflight.classify_state_shape/2`
-against `origin/main` (349145af), with an added-field/identical pair as the
-positive and negative control: 3 of 34 tracked long-lived files changed
-state shape — `lock_watch.ex` (`defstruct` gains `:nif_watch`),
-`db_latency.ex` (the accumulators become `Distribution`s) and the new
-`db_latency/distribution.ex`. A hot reload would leave the running
-`DbLatency` holding `%{n:, total:, outcomes:}` while the new `add_span/3`
-expects `%{dist:, outcomes:}`._
+_Deploy: **COLD**, and the state-shape check is what establishes it — not the
+touched-paths heuristic. Measured through
+`Grappa.Deploy.Preflight.classify_state_shape/2` against `origin/main`
+(349145af), with an added-field/identical pair as the positive and negative
+control: **3 of 34** tracked long-lived files changed state shape —
+`lock_watch.ex` (`defstruct` gains `:nif_watch`), `db_latency.ex` (the
+accumulators become `Distribution`s) and the new `db_latency/distribution.ex`.
+A hot reload would leave the running `DbLatency` holding
+`%{n:, total:, outcomes:}` while the new `add_span/3` expects
+`%{dist:, outcomes:}`.
+
+🔴 Worth recording because it nearly went the other way: for the first four
+commits this diff touched NO `config/`, no migration, no `mix.exs`, no
+`infra/` and no `application.ex`, so a paths-only reading answered HOT while
+the state-shape check already answered COLD. `config/config.exs` entered only
+at the end, and for a reason unrelated to deploy safety — Credo requires a
+Logger metadata key to be declared in the allowlist, and the census emits two.
+A verdict that would have been right by accident is not the same as one that
+was measured._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45513,3 +45513,129 @@ frozen at 0 makes a lookahead scheduler CORRECTLY decide there is nothing to
 arm — a stub that cannot advance is a different module under test.
 
 _Deploy: **HOT — `--cic` only.** No server change, no wire change._
+<!-- entry #1901 -->
+
+---
+
+## 2026-09-05 — #1901: LockWatch reads the NIF, because the seam only sees the rare writes
+
+`Grappa.Repo.LockWatch` had two arms and both read the same ETS table, whose
+only producer is `Repo.immediate_transaction/1`. Measured on the live node
+via `Grappa.Operator.db_latency_text!/0`: `messages insert` —
+`Scrollback.persist_row/1`, an autocommit single statement — is **324 679**
+writes, while every source the seam covers (auth, settings, themes, push,
+reap) is in the thousands. The instrument was watching the rare tail of the
+write load. That is why four stalls with six victims (#1888) produced
+`grep -h "db lock stall" runtime/log/erlang.log.* -> 0`.
+
+### The third arm reads a physical property, not a cooperative one
+
+At each tick the census walks `Process.list/0` and keeps whoever is inside
+`Exqlite.Sqlite3NIF`, timed from the first tick that saw them there. Read in
+the dependency, not assumed: `execute/2` and `step/2` are registered
+`ERL_NIF_DIRTY_JOB_IO_BOUND` (`deps/exqlite/c_src/sqlite3_nif.c:2066,2077`)
+and exqlite installs its OWN busy handler which SLEEPS inside the NIF
+(`:332`) instead of returning to Elixir to retry — so a writer blocked on the
+file lock stays visible in `current_function` for the whole `busy_timeout`.
+No enumeration of write paths to maintain, and nothing added to the write
+path itself.
+
+The clock lives in the watchdog's state as `%{pid => {since, reported?}}` and
+is REBUILT from `Process.list/0` every pass, so a process that leaves the NIF
+drops out with no housekeeping. That is the design-discipline rule (1) —
+derive, do not maintain a parallel structure — applied to the one piece of
+state this arm genuinely needs.
+
+### 🔴 What it refuses to say, and why that is not a shortfall
+
+The issue's acceptance criterion asks for a line that NAMES the process
+holding `RESERVED`. The same physics that makes the cohort visible makes it
+INDIVISIBLE: the holder and every victim are inside the same dirty-IO NIF,
+all reading `status: :running`, and nothing BEAM-visible separates them. So
+the arm reports the ROSTER — every pid, elapsed and frame, with the full
+twelve-frame stack for the longest — and the count of how many of them the
+seam could already name. `registered=0h/0w` is the finding in one field.
+
+Naming the holder outright is exactly what axis 2 (registering the autocommit
+writes at `observe/1`) would buy, and it is deliberately not built. Asserting
+it from here would be the class of claim `BusyRetry.terminal_message/3` was
+twice rewritten to stop making (#1420, #1421).
+
+Two limits stated in the moduledoc so they are not rediscovered as bugs: a
+transaction parked BETWEEN statements is not in a NIF and only the first arm
+can see it; and `elapsed` runs from the first TICK, so it is a LOWER bound
+understated by up to one `tick_ms`.
+
+### The cost is the one paid when nothing is wrong, so it was measured
+
+Dev image, warm, 20 passes per point: 0.7-2 us per process, i.e. **1 550 us
+at 2 000 processes** and 5 237 us at 8 000. At `tick_ms: 1_000` that is
+0.16 % of one scheduler on a 2 000-process node. It does NOT scale with write
+volume, which is the argument against axis 2's three ETS operations on each
+of those 324 679 inserts.
+
+### The CI stack that prompted the design was measured, and it is not a block
+
+A red `LockWatchTest` in PR #1917's CI died at 60 s with the sample inside
+`LockWatch.format_frames/1` -> `Exception.format_stacktrace_entry/1` ->
+`:application_controller.get_application_module/2`, which reads as the census
+formatting stacks through a global gen_server. **Measured here, it is not
+one:** with `application_controller` SUSPENDED via `:erlang.suspend_process/1`,
+`:application.get_application/1` answers in **38 us** and the whole
+twelve-frame format door in **286 us** (against 242 us with it running).
+`get_application_module/2` is a pure list walk over the result of an
+`ets:match` on the public `ac_tab`; it never sends a message. This reproduces
+#1747's own reading (9 us, same conclusion) on different hardware, and it is
+why the census formats stacks from the tick without routing around anything.
+What the CI red shares with its siblings is a RATE, not a place — this
+branch's own baseline run showed the same file taking 135 s for ONE test
+under the full suite and **8.6 s for all 34** in isolation, with #1767's
+filmer reporting 1 of 539 turns taken.
+
+### Axis 3: a mean cannot represent the event the instrument exists to catch
+
+`Grappa.DbLatency` folded every family to `n / total_ms / mean_ms`. A 31 s
+write inside 324 679 samples moves the mean by **0.1 ms** — under the
+rounding the CLI prints. `Grappa.DbLatency.Distribution` keeps the same two
+exact numbers plus an exact `max` and a fixed-bucket histogram, applied to
+`queries`, `persist` AND `send_privmsg` (giving it to one would leave
+mechanisms 1 and 3 of #357 reading a mean and nothing else).
+
+Bounds run 0.5 ms to 30 s so that `busy_timeout` is a bucket EDGE: a writer
+that exhausted it lands in the last finite bucket, and the overflow then
+means "worse than the driver's own patience".
+
+**The quantiles are UPPER BOUNDS and the type says so.** Interpolating inside
+a bucket prints a decimal nobody measured, and a reader comparing two windows
+would read interpolation noise as movement. The property test holds only the
+direction that matters — never understates — against a sort-and-rank oracle
+that shares no code with the histogram. Its first cut also asserted
+`<= the observed max` and that was FALSE: one 2 ms sample reports
+`p50_ms == 2.5`, the ceiling of its bucket. The test was wrong, not the
+structure.
+
+`queue_ms` stays a bare cumulative sum, recorded as a KNOWN GAP rather than a
+judgement: #1687 measured a victim's 62 s as ~31 s of DBConnection checkout
+PLUS ~31 s of `busy_timeout`, so the pool axis hides an outlier exactly as
+the execution axis did.
+
+### Two drifts found while passing through
+
+`Grappa.DbLatencyTest` hand-copied the production `@events` list, so the new
+emitter reached a new `fold/4` clause with a GREEN suite and an empty ring.
+The copy stays — deriving it would make the boot-wiring test tautological —
+and `DbLatency.attached_events/0` plus one equality assertion now name the
+divergence. Separately, `bin/grappa db-latency` has been printing four
+contention values under four names since #1657 shipped a fifth
+(`interrupted`); the header now carries it.
+
+_Deploy: **COLD**, and NOT for the reason the file-path test gives — the diff
+touches no `config/`, no migration, no `mix.exs`, no `infra/`, no
+`application.ex`. Measured through `Grappa.Deploy.Preflight.classify_state_shape/2`
+against `origin/main` (349145af), with an added-field/identical pair as the
+positive and negative control: 3 of 34 tracked long-lived files changed
+state shape — `lock_watch.ex` (`defstruct` gains `:nif_watch`),
+`db_latency.ex` (the accumulators become `Distribution`s) and the new
+`db_latency/distribution.ex`. A hot reload would leave the running
+`DbLatency` holding `%{n:, total:, outcomes:}` while the new `add_span/3`
+expects `%{dist:, outcomes:}`._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -5312,10 +5312,89 @@ a `DBConnection` checkout frame means a pool-topology deadlock; anything else
 is a third answer nobody has predicted yet. That distinction is the whole
 reason the instrument exists — before it, both looked identical from the logs.
 
+### The `nif_census` row (#1901) — the only one taken without the seam
+
+Both phases above read the watch table, and that table has ONE producer
+(`Repo.immediate_transaction/1`). Measured on the live node, `messages insert`
+— an autocommit single statement — is 324 679 writes while every source the
+seam covers is in the thousands, so the instrument was watching the rare tail
+of the write load. That is why all four episodes of #1888 produced zero lines:
+`grep -h "db lock stall" runtime/log/erlang.log.*` returned 0 while six
+victims timed out at ~31 s.
+
+The `nif_census` phase does not read the table. Every tick it walks
+`Process.list/0` and keeps whoever is inside `Exqlite.Sqlite3NIF`, timed from
+the first tick that saw them there. Its log line is
+`db lock stall NIF CENSUS:` and it is counted as `lockstall_nif` by
+`scripts/log-gap-scan.awk` — the ONLY lock counter that can be non-zero while
+`lockstall`, `lockstall_resolved` and `lockstall_unattributed` are all zero,
+which is the shape every #1888 episode had.
+
+🔴 **It names the cohort, never the holder, and the difference is the whole
+reading.** exqlite's busy handler sleeps INSIDE the same dirty-IO NIF the
+writer holding the lock is executing in, so the holder and its victims all
+read `Exqlite.Sqlite3NIF.step/2` with `status=:running` and nothing
+BEAM-visible separates them. So the row carries:
+
+| field | what it says |
+|-------|--------------|
+| `parked=N` | N processes were inside the SQLite NIF past the threshold |
+| `registered=Hh/Ww` | how many of those N the seam could already name |
+| the roster | every pid, its elapsed and its frame |
+| `holder=unattributed` | the instrument declines to pick one, deliberately |
+
+`registered=0h/0w` is the #1901 finding in one field: the writer holding the
+lock never touched the seam. `waiters=not counted` sits next to `parked=N` on
+purpose — a census counted no queue, and reading the roster length as a queue
+would assert N blocked writers where nobody measured one.
+
+**How to get the holder out of it anyway.** Cross the roster against the
+`fault=busy_locked` terminals in the same window: those name the VICTIMS, and
+whatever is in the roster and not among them is the short list. The frame
+helps too — `Exqlite.Sqlite3NIF.execute/2` under `handle_begin/2` is a writer
+blocked ACQUIRING a transaction, while `step/2` is one already executing a
+statement.
+
+**Two limits, so a later reader does not mistake them for bugs.** A
+transaction parked BETWEEN statements is not inside a NIF and this phase
+cannot see it (that case is the `detected` phase's, and only if the writer
+went through the seam); and `elapsed` is measured from the first TICK that
+saw the process, so it is a LOWER bound understated by up to one `tick_ms`.
+Readers park in the same NIF, so a slow `SELECT` appears in the roster too —
+deliberately: a long read transaction is a real participant in the
+contention.
+
+**Cost, measured** (dev image, warm, 20 passes per point): 0.7-2 us per
+process per pass, i.e. 1.55 ms at 2 000 processes — 0.16 % of one scheduler
+at `tick_ms: 1_000`. It is the one part of `LockWatch` paid when nothing is
+wrong, and it does NOT scale with write volume, which is the argument against
+instrumenting the 324 679 inserts instead.
+
 **Off-switch:** `config :grappa, :lock_watch, enabled: false`. Disabled, the
 write path pays one `:persistent_term` read per write transaction and does no
 ETS work. It is **off in `:test`** (under the Sandbox's `pool_size: 1` every
 write transaction is a holder).
+
+**Reading the latency columns (#1901).** Every duration family carries
+`n / total_ms / queue_ms / mean_ms / max_ms / p50_ms / p95_ms / p99_ms`.
+
+- `n`, `total_ms`, `mean_ms` and **`max_ms` are exact.**
+- 🔴 **The three quantiles are UPPER BOUNDS, not interpolations.** `p95_ms` is
+  the smallest histogram bucket bound covering at least 95 % of the samples,
+  so the true value is inside that bucket, at or below the number printed.
+  Read `p99_ms = 30000.00` as *"at most 1 % of writes were slower than 30 s"*.
+  A quantile that lands past the largest bound (30 s, i.e. `busy_timeout`)
+  reads the exact `max_ms` instead, because the overflow bucket has no
+  ceiling. Bounds and rationale: `Grappa.DbLatency.Distribution`.
+- **Read `max_ms` first during an incident.** The mean cannot show you a
+  stall: at the live node's 324 679 `messages insert` samples, a 31-second
+  write moves `mean_ms` by 0.1 ms — under the rounding this table prints.
+  That is why every #1888 episode was invisible here, and it is what the
+  `max_ms` / quantile columns were added for.
+- **`queue_ms` is still a cumulative sum only** — a known gap, not a
+  judgement. #1687 measured a victim's 62 s as ~31 s of DBConnection checkout
+  PLUS ~31 s of `busy_timeout`, so a queue-time outlier hides in a sum
+  exactly as an execution-time one hid in a mean.
 
 **Taking a 25s under-load sample:** `bin/grappa db-latency-reset` → wait 25s
 **under genuine daytime load** → `bin/grappa db-latency`. Counters are
@@ -5339,7 +5418,10 @@ baseline table, never a summary number**:
   `persist` `mean_ms`. A large gap = the sender's own `handle_call` queued
   behind a busy channel's synchronous inbound inserts.
 - **mechanism 2 (single-writer contention):** the `contention` row —
-  `queue_timeout` / `busy_locked` counts + `dropped`.
+  `queue_timeout` / `busy_locked` / `interrupted` counts + `dropped`. (The
+  `interrupted` column shipped with #1657 and the CLI header never learned
+  about it until #1901; a pre-#1901 `bin/grappa db-latency` printed four
+  values under four names while the row carried five.)
 - **mechanism 3 (pure insert / index write-amplification):** the `persist`
   row `mean_ms`, watched as the table grows.
 

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -60,8 +60,12 @@ defmodule Grappa.DbLatency do
       `:unattributed` is the same ring for the episodes that seam CANNOT
       name — an autocommit writer holds the same file lock and never
       registers — and it carries the queue's stacks with explicit nils
-      where the holder would be. Filing it elsewhere would mean an operator
-      asking what the write lock did has to already know that a third,
+      where the holder would be. `:nif_census` (#1901) is the fourth phase
+      and the only one taken WITHOUT reading the seam at all: the roster of
+      processes sitting inside `Exqlite.Sqlite3NIF`, which is how the
+      autocommit writers that dominate this system's write volume become
+      visible to any door. Filing any of them elsewhere would mean an
+      operator asking what the write lock did has to already know that a
       differently-shaped answer exists somewhere else.
 
   ## Reading a window
@@ -103,7 +107,8 @@ defmodule Grappa.DbLatency do
     [:grappa, :scrollback, :persist, :contention],
     [:grappa, :repo, :lock_stall, :detected],
     [:grappa, :repo, :lock_stall, :resolved],
-    [:grappa, :repo, :lock_stall, :unattributed]
+    [:grappa, :repo, :lock_stall, :unattributed],
+    [:grappa, :repo, :lock_stall, :nif_census]
   ]
 
   # #1420 — the lock-stall ring is bounded: these rows carry sampled
@@ -175,9 +180,22 @@ defmodule Grappa.DbLatency do
 
   `waiter_count` is nilable for the same reason: a closing bracket counts no
   queue, and the `0` it used to carry asserted an empty one was measured.
+
+  #1901 adds the fourth phase, `:nif_census`, and with it `parked` plus two
+  counts. It is the arm that does not read the seam at all — it reports every
+  process sitting inside `Exqlite.Sqlite3NIF` past the threshold — so on that
+  row EVERY seam-derived field is nil, including `holder_pid`, and that is a
+  stronger statement than `:unattributed`'s: a holder is certainly IN
+  `parked`, and nothing BEAM-visible says which entry it is.
+  `registered_holders` / `registered_waiters` count how many of the parked
+  processes the seam could already name, so an operator can tell "widen
+  coverage" from "the other two arms already told you". `parked` follows
+  `waiters` in being a plain list defaulting to `[]` rather than a nilable:
+  an empty roster and no roster are the same fact here, since a census with
+  nobody in it emits nothing at all.
   """
   @type lock_stall_row :: %{
-          phase: :detected | :resolved | :unattributed,
+          phase: :detected | :resolved | :unattributed | :nif_census,
           observed_at: String.t(),
           holder_pid: String.t() | nil,
           held_ms: non_neg_integer() | nil,
@@ -185,7 +203,10 @@ defmodule Grappa.DbLatency do
           holder: map() | nil,
           caller: map() | nil,
           announced: boolean() | nil,
-          waiters: [map()]
+          waiters: [map()],
+          parked: [map()],
+          registered_holders: non_neg_integer() | nil,
+          registered_waiters: non_neg_integer() | nil
         }
 
   @type snapshot :: %{
@@ -224,6 +245,20 @@ defmodule Grappa.DbLatency do
   @doc "Zero every counter — call before opening a fresh sample window."
   @spec reset() :: :ok
   def reset, do: GenServer.call(__MODULE__, :reset)
+
+  @doc """
+  The telemetry events this handler binds at `init/1`.
+
+  Exposed because `fold/4` has NO catch-all clause: an event added to
+  `@events` without a matching clause crashes the singleton, and a clause
+  added without the event folds nothing — and the second failure is silent,
+  which is how it presented while #1901 was being built (a new emitter, a
+  green suite, and an empty ring). `Grappa.DbLatencyTest` keeps its own
+  independent copy of the set as the oracle and asserts it equals this one, so
+  the drift is a named failure rather than a missing row.
+  """
+  @spec attached_events() :: [[atom()]]
+  def attached_events, do: @events
 
   ## ----- GenServer callbacks ------------------------------------------
 
@@ -320,7 +355,10 @@ defmodule Grappa.DbLatency do
       holder: metadata.holder,
       caller: nil,
       announced: nil,
-      waiters: metadata.waiters
+      waiters: metadata.waiters,
+      parked: [],
+      registered_holders: nil,
+      registered_waiters: nil
     })
   end
 
@@ -339,7 +377,10 @@ defmodule Grappa.DbLatency do
       holder: nil,
       caller: nil,
       announced: nil,
-      waiters: metadata.waiters
+      waiters: metadata.waiters,
+      parked: [],
+      registered_holders: nil,
+      registered_waiters: nil
     })
   end
 
@@ -360,7 +401,38 @@ defmodule Grappa.DbLatency do
       holder: nil,
       caller: metadata.caller,
       announced: metadata.announced,
-      waiters: []
+      waiters: [],
+      parked: [],
+      registered_holders: nil,
+      registered_waiters: nil
+    })
+  end
+
+  # #1901 — the arm that reads `Process.list/0` rather than the seam, so it is
+  # the one phase where `holder_pid` being nil is not a gap the instrument
+  # might have closed: a holder IS among `parked`, and exqlite's busy handler
+  # sleeping inside the same dirty-IO NIF as the writer that holds the lock
+  # makes the cohort indivisible from the BEAM's side. Synthesising a
+  # `holder_pid` to fill the column would turn the one honest thing this row
+  # says into a guess. `registered_holders` / `registered_waiters` are what
+  # separate "the seam is blind here" from "the other two arms already spoke".
+  defp fold([:grappa, :repo, :lock_stall, :nif_census], measurements, metadata, state) do
+    push_stall(state, %{
+      phase: :nif_census,
+      observed_at: metadata.observed_at,
+      holder_pid: nil,
+      held_ms: nil,
+      # nil, not `parked_count`: nothing here observed a QUEUE. The count of
+      # parked processes is a different measurement and rides its own field,
+      # exactly as #1687 refused to reuse `held_ms` for a longest WAIT.
+      waiter_count: nil,
+      holder: nil,
+      caller: nil,
+      announced: nil,
+      waiters: [],
+      parked: metadata.parked,
+      registered_holders: metadata.registered_holders,
+      registered_waiters: metadata.registered_waiters
     })
   end
 

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -99,6 +99,8 @@ defmodule Grappa.DbLatency do
 
   use GenServer
 
+  alias Grappa.DbLatency.Distribution
+
   @handler_id "grappa-db-latency"
   @events [
     [:grappa, :repo, :query],
@@ -119,19 +121,40 @@ defmodule Grappa.DbLatency do
 
   @type op :: :select | :insert | :update | :delete | :count | :other
 
+  @typedoc """
+  One `{source, op}` bucket. Everything but `queue_ms` comes from a
+  `t:Grappa.DbLatency.Distribution.reading/0`, so `max_ms` is exact and the
+  three quantiles are UPPER bounds — see that module for why an interpolated
+  quantile was refused.
+
+  🔴 `queue_ms` stays a plain cumulative sum, and that is a KNOWN GAP rather
+  than a judgement that the pool axis does not matter. #1687 measured a
+  victim's 62 s as ~31 s of DBConnection checkout PLUS ~31 s of
+  `busy_timeout`, so a queue-time outlier is exactly as invisible in a mean
+  as an execution-time one. #1901 asks for the execution axis; giving the
+  queue its own histogram is the same change again and has not been made.
+  """
   @type query_row :: %{
           source: String.t() | nil,
           op: op(),
           n: non_neg_integer(),
           total_ms: float(),
           queue_ms: float(),
-          mean_ms: float()
+          mean_ms: float(),
+          max_ms: float(),
+          p50_ms: float(),
+          p95_ms: float(),
+          p99_ms: float()
         }
 
   @type span_row :: %{
           n: non_neg_integer(),
           total_ms: float(),
           mean_ms: float(),
+          max_ms: float(),
+          p50_ms: float(),
+          p95_ms: float(),
+          p99_ms: float(),
           outcomes: %{atom() => non_neg_integer()}
         }
 
@@ -217,18 +240,20 @@ defmodule Grappa.DbLatency do
           lock_stalls: [lock_stall_row()]
         }
 
-  # Internal accumulators carry NATIVE time units (integer sums); the
-  # native → millisecond conversion happens once, at snapshot time.
+  # Internal accumulators carry NATIVE time units; the native → millisecond
+  # conversion happens once, at snapshot time. Since #1901 the duration half
+  # of every family is a `Distribution` rather than an `{n, total}` pair —
+  # same exactness for those two, plus the max and the tail a mean erases.
   defstruct queries: %{},
-            send_privmsg: %{n: 0, total: 0, outcomes: %{}},
-            persist: %{n: 0, total: 0, outcomes: %{}},
+            send_privmsg: %{dist: %Distribution{}, outcomes: %{}},
+            persist: %{dist: %Distribution{}, outcomes: %{}},
             contention: %{n: 0, queue_timeout: 0, busy_locked: 0, interrupted: 0, dropped: 0},
             lock_stalls: []
 
   @type t :: %__MODULE__{
-          queries: %{{String.t() | nil, op()} => %{n: non_neg_integer(), total: integer(), queue: integer()}},
-          send_privmsg: %{n: non_neg_integer(), total: integer(), outcomes: %{atom() => non_neg_integer()}},
-          persist: %{n: non_neg_integer(), total: integer(), outcomes: %{atom() => non_neg_integer()}},
+          queries: %{{String.t() | nil, op()} => %{dist: Distribution.t(), queue: integer()}},
+          send_privmsg: %{dist: Distribution.t(), outcomes: %{atom() => non_neg_integer()}},
+          persist: %{dist: Distribution.t(), outcomes: %{atom() => non_neg_integer()}},
           contention: contention_row(),
           lock_stalls: [lock_stall_row()]
         }
@@ -314,11 +339,10 @@ defmodule Grappa.DbLatency do
   @spec fold([atom()], map(), map(), t()) :: t()
   defp fold([:grappa, :repo, :query], measurements, metadata, state) do
     key = {Map.get(metadata, :source), classify_op(Map.get(metadata, :query))}
-    prev = Map.get(state.queries, key, %{n: 0, total: 0, queue: 0})
+    prev = Map.get(state.queries, key, %{dist: %Distribution{}, queue: 0})
 
     updated = %{
-      n: prev.n + 1,
-      total: prev.total + native(measurements, :total_time),
+      dist: Distribution.add(prev.dist, native(measurements, :total_time)),
       queue: prev.queue + native(measurements, :queue_time)
     }
 
@@ -416,7 +440,7 @@ defmodule Grappa.DbLatency do
   # `holder_pid` to fill the column would turn the one honest thing this row
   # says into a guess. `registered_holders` / `registered_waiters` are what
   # separate "the seam is blind here" from "the other two arms already spoke".
-  defp fold([:grappa, :repo, :lock_stall, :nif_census], measurements, metadata, state) do
+  defp fold([:grappa, :repo, :lock_stall, :nif_census], _measurements, metadata, state) do
     push_stall(state, %{
       phase: :nif_census,
       observed_at: metadata.observed_at,
@@ -445,8 +469,7 @@ defmodule Grappa.DbLatency do
   @spec add_span(map(), map(), map()) :: map()
   defp add_span(acc, measurements, metadata) do
     %{
-      n: acc.n + 1,
-      total: acc.total + native(measurements, :duration),
+      dist: Distribution.add(acc.dist, native(measurements, :duration)),
       outcomes: Map.update(acc.outcomes, Map.get(metadata, :outcome), 1, &(&1 + 1))
     }
   end
@@ -489,15 +512,10 @@ defmodule Grappa.DbLatency do
   defp to_snapshot(state) do
     queries =
       state.queries
-      |> Enum.map(fn {{source, op}, %{n: n, total: total, queue: queue}} ->
-        %{
-          source: source,
-          op: op,
-          n: n,
-          total_ms: to_ms(total),
-          queue_ms: to_ms(queue),
-          mean_ms: mean_ms(total, n)
-        }
+      |> Enum.map(fn {{source, op}, %{dist: dist, queue: queue}} ->
+        dist
+        |> Distribution.reading()
+        |> Map.merge(%{source: source, op: op, queue_ms: Distribution.to_ms(queue)})
       end)
       |> Enum.sort_by(& &1.total_ms, :desc)
 
@@ -511,14 +529,7 @@ defmodule Grappa.DbLatency do
   end
 
   @spec span_snapshot(map()) :: span_row()
-  defp span_snapshot(%{n: n, total: total, outcomes: outcomes}) do
-    %{n: n, total_ms: to_ms(total), mean_ms: mean_ms(total, n), outcomes: outcomes}
+  defp span_snapshot(%{dist: dist, outcomes: outcomes}) do
+    dist |> Distribution.reading() |> Map.put(:outcomes, outcomes)
   end
-
-  @spec to_ms(integer()) :: float()
-  defp to_ms(native), do: System.convert_time_unit(native, :native, :microsecond) / 1000.0
-
-  @spec mean_ms(integer(), non_neg_integer()) :: float()
-  defp mean_ms(_, 0), do: 0.0
-  defp mean_ms(total, n), do: to_ms(total) / n
 end

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -282,7 +282,7 @@ defmodule Grappa.DbLatency do
   independent copy of the set as the oracle and asserts it equals this one, so
   the drift is a named failure rather than a missing row.
   """
-  @spec attached_events() :: [[atom()]]
+  @spec attached_events() :: nonempty_list(nonempty_list(atom()))
   def attached_events, do: @events
 
   ## ----- GenServer callbacks ------------------------------------------
@@ -440,7 +440,7 @@ defmodule Grappa.DbLatency do
   # `holder_pid` to fill the column would turn the one honest thing this row
   # says into a guess. `registered_holders` / `registered_waiters` are what
   # separate "the seam is blind here" from "the other two arms already spoke".
-  defp fold([:grappa, :repo, :lock_stall, :nif_census], _measurements, metadata, state) do
+  defp fold([:grappa, :repo, :lock_stall, :nif_census], _, metadata, state) do
     push_stall(state, %{
       phase: :nif_census,
       observed_at: metadata.observed_at,

--- a/lib/grappa/db_latency/distribution.ex
+++ b/lib/grappa/db_latency/distribution.ex
@@ -45,6 +45,15 @@ defmodule Grappa.DbLatency.Distribution do
   sample count, against the unbounded list a reservoir or a keep-the-last-N
   would need. Nothing here allocates per sample.
 
+  ## Constructing one
+
+  `%Grappa.DbLatency.Distribution{}` — there is no `new/0`. Dialyzer flagged
+  the first cut of one as a `contract_supertype` (its success typing was the
+  literal zero struct), which is the type checker saying the function adds
+  nothing over the literal. `Grappa.DbLatency` builds its accumulators from
+  the literal in its own `defstruct` defaults, so a second constructor would
+  be a second thing to keep in step.
+
   ## Units
 
   `total` and `max` are kept in NATIVE units and converted once, at
@@ -102,9 +111,6 @@ defmodule Grappa.DbLatency.Distribution do
           p95_ms: float(),
           p99_ms: float()
         }
-
-  @spec new() :: t()
-  def new, do: %__MODULE__{}
 
   @doc """
   Fold one measurement, in NATIVE units.
@@ -167,7 +173,7 @@ defmodule Grappa.DbLatency.Distribution do
   defp quantile_ms(dist, q), do: walk(@bounds, dist, ceil(q * dist.n), 0)
 
   @spec walk([pos_integer()], t(), pos_integer(), non_neg_integer()) :: float()
-  defp walk([], dist, _rank, _seen), do: to_ms(dist.max)
+  defp walk([], dist, _, _), do: to_ms(dist.max)
 
   defp walk([bound | rest], dist, rank, seen) do
     seen = seen + Map.get(dist.buckets, bound, 0)

--- a/lib/grappa/db_latency/distribution.ex
+++ b/lib/grappa/db_latency/distribution.ex
@@ -1,0 +1,181 @@
+defmodule Grappa.DbLatency.Distribution do
+  @moduledoc """
+  A bounded latency distribution: exact `n`, `total` and `max`, plus a
+  fixed-bucket histogram for quantiles (#1901 axis 3).
+
+  ## Why a mean was not enough, measured
+
+  Every family in `Grappa.DbLatency` used to fold to `n / total_ms / mean_ms`,
+  and on the live node `messages insert` reads **324 679** samples at a mean
+  of 30.12 ms. A single 31-second write inside that population moves the mean
+  by `31_000 / 324_679`, i.e. **0.1 ms** — under the rounding the CLI prints.
+  So the four write-lock stalls of issue 1888, the exact events the whole
+  telemetry surface exists to catch, left no arithmetic trace anywhere: the
+  operator could read the table during the freeze and see nothing.
+
+  `max_ms` alone would fix that one number and nothing else, so this keeps the
+  SHAPE: `max` says the worst thing that happened, the quantiles say whether it
+  was one accident or the tail moving.
+
+  ## What the quantiles are, exactly, and what they are not
+
+  🔴 **Every quantile here is an UPPER BOUND on the true one, never an
+  interpolation.** `p95_ms` is the smallest bucket bound that covers at least
+  95 % of the samples — so the true p95 is somewhere in that bucket, at or
+  below the number printed. This is deliberate and it is the honest option:
+  interpolating inside a bucket would print a decimal nobody measured, and a
+  reader comparing two windows would be reading interpolation noise as
+  movement. When the quantile falls in the overflow bucket (past the largest
+  bound) the reading is the exact `max_ms`, which is the tightest bound this
+  structure holds.
+
+  Read `p99_ms == 30_000.0` as *"at most 1 % of samples were slower than 30 s"*
+  and `max_ms` as the only exact statement about the worst case.
+
+  ## Bounds, and why these
+
+  Fixed, in MICROSECONDS, roughly 1-2-5 per decade from 0.5 ms to 30 s. The
+  bottom is where this system's healthy writes live (the issue's own table has
+  five sources under 2 ms) and the top is `busy_timeout`, so a write that
+  exhausted it lands in the last finite bucket rather than the overflow — the
+  overflow then means *"worse than the driver's own patience"*, which is a
+  distinct and interesting fact rather than a saturation artefact.
+
+  Memory is bounded and small: at most 16 counters per family regardless of
+  sample count, against the unbounded list a reservoir or a keep-the-last-N
+  would need. Nothing here allocates per sample.
+
+  ## Units
+
+  `total` and `max` are kept in NATIVE units and converted once, at
+  `reading/1` — the discipline `Grappa.DbLatency` already had. Only the
+  histogram converts per sample, because a bucket bound has to be a fixed
+  wall-clock duration and `:native` is not one. `to_ms/1` is public because it
+  is this context's single native-to-millisecond conversion: `DbLatency`'s
+  `queue_ms` rides it too rather than carrying a second copy.
+  """
+
+  # Upper bounds in microseconds. `:overflow` is the implicit last bucket and
+  # is not listed: it has no bound, which is the whole reason `reading/1`
+  # falls back to the exact `max` there instead of printing one.
+  @bounds [
+    500,
+    1_000,
+    2_500,
+    5_000,
+    10_000,
+    25_000,
+    50_000,
+    100_000,
+    250_000,
+    500_000,
+    1_000_000,
+    2_500_000,
+    5_000_000,
+    10_000_000,
+    30_000_000
+  ]
+
+  defstruct n: 0, total: 0, max: 0, buckets: %{}
+
+  @typedoc """
+  `total` and `max` are NATIVE units; `buckets` is keyed by the microsecond
+  upper bound the sample fell in, or `:overflow` past the largest one.
+  """
+  @type t :: %__MODULE__{
+          n: non_neg_integer(),
+          total: integer(),
+          max: integer(),
+          buckets: %{(pos_integer() | :overflow) => pos_integer()}
+        }
+
+  @typedoc """
+  The millisecond projection. `n`, `total_ms`, `mean_ms` and `max_ms` are
+  exact; the three quantiles are UPPER BOUNDS — see the moduledoc.
+  """
+  @type reading :: %{
+          n: non_neg_integer(),
+          total_ms: float(),
+          mean_ms: float(),
+          max_ms: float(),
+          p50_ms: float(),
+          p95_ms: float(),
+          p99_ms: float()
+        }
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Fold one measurement, in NATIVE units.
+
+  A negative duration is impossible from a monotonic span and is not guarded
+  against: it would land in the first bucket and understate `max`, which is
+  the same failure a guard would produce more slowly.
+  """
+  @spec add(t(), integer()) :: t()
+  def add(%__MODULE__{} = dist, native) when is_integer(native) do
+    bound = bucket(System.convert_time_unit(native, :native, :microsecond))
+
+    %{
+      dist
+      | n: dist.n + 1,
+        total: dist.total + native,
+        max: max(dist.max, native),
+        buckets: Map.update(dist.buckets, bound, 1, &(&1 + 1))
+    }
+  end
+
+  @doc """
+  Project to milliseconds. An empty distribution reads all zeros rather than
+  raising — an unused bucket is a real state (the source was never queried in
+  this window) and the CLI renders it beside the used ones.
+  """
+  @spec reading(t()) :: reading()
+  def reading(%__MODULE__{} = dist) do
+    %{
+      n: dist.n,
+      total_ms: to_ms(dist.total),
+      mean_ms: mean_ms(dist.total, dist.n),
+      max_ms: to_ms(dist.max),
+      p50_ms: quantile_ms(dist, 0.50),
+      p95_ms: quantile_ms(dist, 0.95),
+      p99_ms: quantile_ms(dist, 0.99)
+    }
+  end
+
+  @doc "This context's single native-to-millisecond conversion."
+  @spec to_ms(integer()) :: float()
+  def to_ms(native), do: System.convert_time_unit(native, :native, :microsecond) / 1000.0
+
+  # The smallest bound that covers this sample. `Enum.find/3` over 15 sorted
+  # integers is a linear scan and that is deliberate: a binary search over a
+  # compile-time list of this size buys nothing measurable and costs the
+  # reader the one property that matters here — that the bucket a sample
+  # lands in is obviously the smallest bound at or above it.
+  @spec bucket(integer()) :: pos_integer() | :overflow
+  defp bucket(microseconds), do: Enum.find(@bounds, :overflow, &(microseconds <= &1))
+
+  # 🔴 An UPPER bound, by construction: walk the bounds in order until the
+  # cumulative count reaches the rank, and report THAT bound. The true
+  # quantile is somewhere inside that bucket. Exhausting the list means the
+  # rank sits in the overflow bucket, where the tightest bound available is
+  # the exact `max` — never a bound, because the overflow bucket has none.
+  @spec quantile_ms(t(), float()) :: float()
+  defp quantile_ms(%__MODULE__{n: 0}, _), do: 0.0
+
+  defp quantile_ms(dist, q), do: walk(@bounds, dist, ceil(q * dist.n), 0)
+
+  @spec walk([pos_integer()], t(), pos_integer(), non_neg_integer()) :: float()
+  defp walk([], dist, _rank, _seen), do: to_ms(dist.max)
+
+  defp walk([bound | rest], dist, rank, seen) do
+    seen = seen + Map.get(dist.buckets, bound, 0)
+
+    if seen >= rank, do: bound / 1000.0, else: walk(rest, dist, rank, seen)
+  end
+
+  @spec mean_ms(integer(), non_neg_integer()) :: float()
+  defp mean_ms(_, 0), do: 0.0
+  defp mean_ms(total, n), do: to_ms(total) / n
+end

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -165,6 +165,11 @@ defmodule Grappa.HotReload.LongLivedModules do
   # module's file is covered by listing its parent and must NOT get its own
   # entry. See the "What goes here" note above.
   @state_helpers [
+    # #1901 — a field of `Grappa.DbLatency`'s per-family accumulators. Its
+    # `defstruct` gaining a field is exactly as hot-unsafe as the parent's,
+    # and the #1473 membership test walks the parent's `t` typespec to find
+    # it, so this entry is derived rather than a judgement call.
+    Grappa.DbLatency.Distribution,
     Grappa.Session.AwayState,
     Grappa.Session.Deps,
     Grappa.Session.DirectoryIngest,
@@ -212,7 +217,8 @@ defmodule Grappa.HotReload.LongLivedModules do
   `long_lived` module. Keep in sync with `@state_helpers`.
   """
   @type state_helper ::
-          Grappa.Session.AwayState
+          Grappa.DbLatency.Distribution
+          | Grappa.Session.AwayState
           | Grappa.Session.Deps
           | Grappa.Session.DirectoryIngest
           | Grappa.Session.GhostRecovery

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -997,7 +997,11 @@ defmodule Grappa.Operator do
             Integer.to_string(row.n),
             fmt_ms(row.total_ms),
             fmt_ms(row.queue_ms),
-            fmt_ms(row.mean_ms)
+            fmt_ms(row.mean_ms),
+            fmt_ms(row.max_ms),
+            fmt_ms(row.p50_ms),
+            fmt_ms(row.p95_ms),
+            fmt_ms(row.p99_ms)
           ],
           "\t"
         )
@@ -1019,6 +1023,7 @@ defmodule Grappa.Operator do
           Integer.to_string(c.n),
           Integer.to_string(c.queue_timeout),
           Integer.to_string(c.busy_locked),
+          Integer.to_string(c.interrupted),
           Integer.to_string(c.dropped)
         ],
         "\t"
@@ -1157,19 +1162,39 @@ defmodule Grappa.Operator do
       "memory_kb"
     ]
 
+  # #1901 — `max_ms` and the three quantiles sit AFTER `mean_ms` rather than
+  # replacing it: the mean is what mechanisms 1 and 3 of #357 are read from
+  # (`send_privmsg.mean_ms − persist.mean_ms`), and removing it to tidy the
+  # table would break a reading that is documented above and in OPERATIONS.
+  # The quantiles are bucket UPPER bounds — `Grappa.DbLatency.Distribution`
+  # says why they are not interpolated.
   defp query_latency_columns,
-    do: ["source", "op", "n", "total_ms", "queue_ms", "mean_ms"]
+    do: ["source", "op", "n", "total_ms", "queue_ms", "mean_ms", "max_ms", "p50_ms", "p95_ms", "p99_ms"]
 
   defp span_latency_columns,
-    do: ["span", "n", "total_ms", "mean_ms", "outcomes"]
+    do: ["span", "n", "total_ms", "mean_ms", "max_ms", "p50_ms", "p95_ms", "p99_ms", "outcomes"]
 
+  # #1657 shipped the `interrupted` counter and this header never learned
+  # about it, so `bin/grappa db-latency` has been printing four values under
+  # four names while the row carried five — a shipped signal that reached no
+  # operator. The row printer below gains it in the same place.
   defp contention_columns,
-    do: ["n", "queue_timeout", "busy_locked", "dropped"]
+    do: ["n", "queue_timeout", "busy_locked", "interrupted", "dropped"]
 
   @spec span_row_text(String.t(), Grappa.DbLatency.span_row()) :: String.t()
-  defp span_row_text(label, %{n: n, total_ms: total, mean_ms: mean, outcomes: outcomes}) do
+  defp span_row_text(label, row) do
     Enum.join(
-      [label, Integer.to_string(n), fmt_ms(total), fmt_ms(mean), fmt_outcomes(outcomes)],
+      [
+        label,
+        Integer.to_string(row.n),
+        fmt_ms(row.total_ms),
+        fmt_ms(row.mean_ms),
+        fmt_ms(row.max_ms),
+        fmt_ms(row.p50_ms),
+        fmt_ms(row.p95_ms),
+        fmt_ms(row.p99_ms),
+        fmt_outcomes(row.outcomes)
+      ],
       "\t"
     )
   end

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -1034,7 +1034,8 @@ defmodule Grappa.Operator do
       IO.puts(
         "#{stall.phase}\tat=#{stall.observed_at}\tholder=#{lock_stall_field(stall.holder_pid)}" <>
           "\theld_ms=#{lock_stall_field(stall.held_ms)}" <>
-          "\twaiters=#{waiters_column(stall.waiter_count)}#{announced_column(stall.announced)}"
+          "\twaiters=#{waiters_column(stall.waiter_count)}" <>
+          "#{announced_column(stall.announced)}#{parked_column(stall)}"
       )
 
       Enum.each(lock_stall_detail_lines(stall), &IO.puts/1)
@@ -1078,10 +1079,26 @@ defmodule Grappa.Operator do
   # they are what separates "blocked on the lock" from "queued for a
   # connection".
   @spec lock_stall_detail_lines(DbLatency.lock_stall_row()) :: [String.t()]
-  defp lock_stall_detail_lines(%{holder: holder, caller: caller, waiters: waiters}) do
+  defp lock_stall_detail_lines(%{holder: holder, caller: caller, waiters: waiters, parked: parked}) do
     holder_lines(holder) ++
       caller_lines(caller) ++
-      Enum.map(waiters, &"  waiter #{&1.pid} waiting #{&1.elapsed_ms}ms at #{&1.current_function}")
+      Enum.map(waiters, &"  waiter #{&1.pid} waiting #{&1.elapsed_ms}ms at #{&1.current_function}") ++
+      Enum.map(parked, &"  parked #{&1.pid} in the NIF #{&1.elapsed_ms}ms at #{&1.current_function}")
+  end
+
+  # #1901 — the census counts a ROSTER, not a queue, and the two must not be
+  # read off the same column: `waiters=` says how many writers were provably
+  # blocked, while this says how many processes were inside the SQLite NIF,
+  # one of which IS the holder and none of which can be singled out.
+  # Conditional for the same reason `announced_column/1` is — printing
+  # `parked=0` on the three phases that never took a census would invite the
+  # reader to interpret it as "the NIF was empty".
+  @spec parked_column(DbLatency.lock_stall_row()) :: String.t()
+  defp parked_column(%{parked: []}), do: ""
+
+  defp parked_column(%{parked: parked} = stall) do
+    "\tparked=#{length(parked)}" <>
+      "\tregistered=#{stall.registered_holders}h/#{stall.registered_waiters}w"
   end
 
   # #1888 — the write path a `:resolved` row names. Labelled "write path" and

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -134,6 +134,54 @@ defmodule Grappa.Repo.LockWatch do
   unattributed episode gets no closing bracket — there was no hold to total,
   and inventing one is the claim this arm exists to avoid.
 
+  ### The NIF census (#1901)
+
+  🔴 **Both arms above read the watch TABLE, and the table has one producer,
+  so between them they observe the RARE tail of this system's write load.**
+  Measured on the live node (`Grappa.Operator.db_latency_text!/0`, cumulative
+  since boot): `messages insert` — `Grappa.Scrollback.persist_row/1`, an
+  autocommit single statement — is **324 679** writes, while every source the
+  seam does cover (auth, settings, themes, push, reap) is in the thousands.
+  The dominant writer of this system has never owned a row here.
+
+  So the third arm does not read the table at all. At each tick it walks
+  `Process.list/0` and keeps the processes whose `current_function` is inside
+  `Exqlite.Sqlite3NIF`, timing them from the first tick that saw them there.
+  That reaches any writer, registered or not, because the property it reads is
+  physical: `execute/2` and `step/2` are declared
+  `ERL_NIF_DIRTY_JOB_IO_BOUND` (`deps/exqlite/c_src/sqlite3_nif.c:2066,2077`)
+  and exqlite's own busy handler SLEEPS INSIDE the NIF rather than returning
+  to Elixir to retry (`:332`), so a writer blocked on the file lock stays
+  visible in `current_function` for the whole `busy_timeout`.
+
+  🔴 **What it cannot do, and the line says so rather than guessing.** The
+  same physics that makes the cohort visible makes it INDIVISIBLE: the writer
+  holding the lock and the writers blocked behind it are all inside
+  `Exqlite.Sqlite3NIF`, all reading `status: :running`, and nothing
+  BEAM-visible separates them. This arm therefore reports the COHORT — every
+  parked process, its elapsed, its `current_function` and the longest one's
+  stack — plus how many of them the seam already knows as holders and as
+  waiters. Naming the holder outright is what registering the autocommit
+  writes (#1901 axis 2, deliberately deferred) would buy, and asserting it
+  from here is the class of claim `terminal_message/3` in
+  `Grappa.Repo.BusyRetry` was twice rewritten to stop making.
+
+  Two further limits, stated so a later reader does not have to rediscover
+  them:
+
+    * a transaction parked BETWEEN statements is not inside a NIF, so this
+      arm cannot see it. That case is the FIRST arm's, and it is covered
+      exactly when the writer went through the seam;
+    * `elapsed` is measured from the first TICK that saw the process there,
+      never from its real entry into the NIF, so it is a LOWER bound
+      understated by up to one `tick_ms`. A census that wanted the true
+      instant would have to instrument the write path, which is the cost this
+      arm exists to avoid.
+
+  Readers park in the same NIF, so a slow `SELECT` is in the cohort too. That
+  is deliberate: the arm reports what it observed, and a reader holding a long
+  read transaction is a real participant in the contention.
+
   ## Deriving the holder's identity instead of storing it
 
   No caller label is stored, and `immediate_transaction/1` grows no label
@@ -170,6 +218,23 @@ defmodule Grappa.Repo.LockWatch do
   suspends its target) runs ONLY once a stall has already been detected,
   on a process that is by definition already stopped.
 
+  🔴 #1901's census breaks that last sentence and it is the one cost in this
+  module that is paid when nothing is wrong: one `Process.list/0` plus one
+  `Process.info(pid, :current_function)` per process, per tick, unconditionally.
+  Measured on this repo's dev image, warm, 20 passes per point:
+
+      500 procs   1 057us/pass      2 000 procs   1 550us/pass
+      1 000 procs 1 036us/pass      4 000 procs   3 042us/pass
+                                    8 000 procs   5 237us/pass
+
+  i.e. ~0.7-2us per process, so at `tick_ms: 1_000` a 2 000-process node
+  spends **0.16 % of one scheduler** on it. Nothing about that scales with
+  write VOLUME, which is the property that makes it cheaper than the
+  alternative it replaces: axis 2 of #1901 would put three ETS operations on
+  every one of those 324 679 inserts. Sampling only the crossed processes
+  keeps the expensive half — `sample/2` and its twelve formatted frames —
+  behind the threshold, exactly as the other two arms do.
+
   #1888 adds ONE more `:persistent_term` read per write-transaction RELEASE
   (the threshold the bracket compares against). It is a read and not a write
   on purpose: a `persistent_term` WRITE is the thing that blocks on a
@@ -192,6 +257,14 @@ defmodule Grappa.Repo.LockWatch do
   @threshold_key {__MODULE__, :stall_threshold_ms}
   @depth_key {__MODULE__, :depth}
   @stack_frames 12
+
+  # #1901 — the module every SQLite call in this system passes through, and
+  # the census's whole discriminator. A literal and not a config knob: it is
+  # not an operator choice, it is which driver `Grappa.Repo` is built on, and
+  # a wrong value here fails silently (an empty census reads exactly like a
+  # healthy node). It is referenced only as an atom in a pattern, so it adds
+  # no call edge for the Boundary checker to see.
+  @nif_module Exqlite.Sqlite3NIF
 
   @typedoc "Role of a row in the watch table."
   @type role :: :waiting | :holding
@@ -265,7 +338,43 @@ defmodule Grappa.Repo.LockWatch do
           holders_registered: non_neg_integer()
         }
 
-  defstruct [:stall_threshold_ms, :tick_ms, :enabled]
+  @typedoc """
+  A census of the processes parked INSIDE `Exqlite.Sqlite3NIF` past the
+  threshold (#1901) — the arm that reaches the autocommit writers the seam
+  cannot see.
+
+  🔴 There is deliberately no `holder` key, and the reason is stronger than
+  the one `t:unattributed/0` gives for its own absence. There, no holder was
+  observed. Here one certainly IS in `parked`, and the instrument cannot say
+  WHICH: exqlite's busy handler sleeps inside the same dirty-IO NIF the writer
+  holding the lock is executing in, so the holder and its victims are one
+  indistinguishable cohort from the BEAM's side. `registered_holders` and
+  `registered_waiters` are the honesty fields — how many of these the seam
+  could already name — and the remainder is the population #1901 is about.
+  """
+  @type nif_census :: %{
+          observed_at: String.t(),
+          parked: [sample()],
+          registered_holders: non_neg_integer(),
+          registered_waiters: non_neg_integer()
+        }
+
+  @typedoc """
+  The census's carry-forward clock: for each process currently inside
+  `Exqlite.Sqlite3NIF`, the instant a tick FIRST saw it there and whether this
+  episode has already been reported.
+
+  Rebuilt from `Process.list/0` on every pass rather than maintained, so a
+  process that leaves the NIF drops out with no housekeeping and no reaper —
+  the parallel-structure-that-drifts this design is required to avoid. It
+  lives in the watchdog's own state and NOT in the ETS table: the table is
+  written by every caller's own process at the seam, and a per-tick observer's
+  scratch space has no business being public, nor of being read by a
+  `released/0` running in somebody else's process.
+  """
+  @type nif_watch :: %{pid() => {integer(), boolean()}}
+
+  defstruct [:stall_threshold_ms, :tick_ms, :enabled, :nif_watch]
 
   @type t :: %__MODULE__{
           # non_neg, not pos: a threshold of 0 means "report every contended
@@ -274,7 +383,8 @@ defmodule Grappa.Repo.LockWatch do
           # clock. `tick_ms` stays pos: a zero tick is a busy loop.
           stall_threshold_ms: non_neg_integer(),
           tick_ms: pos_integer(),
-          enabled: boolean()
+          enabled: boolean(),
+          nif_watch: nif_watch()
         }
 
   ## ----- Write-path seam ----------------------------------------------
@@ -313,6 +423,40 @@ defmodule Grappa.Repo.LockWatch do
   @spec scan(non_neg_integer()) :: :ok
   def scan(stall_threshold_ms) when is_integer(stall_threshold_ms) and stall_threshold_ms >= 0 do
     detect(now_ms(), stall_threshold_ms)
+  end
+
+  @doc """
+  One NIF-census pass (#1901): report the processes that have been inside
+  `Exqlite.Sqlite3NIF` for at least `stall_threshold_ms`, and return the clock
+  to hand the NEXT pass.
+
+  Public for the same reason `scan/1` is — an operator, or a test, can take
+  the reading on demand instead of waiting for a tick — but unlike `scan/1` it
+  is not idempotent in its argument: the returned map IS the elapsed
+  measurement. Calling it with a fresh `%{}` every time restarts every clock
+  at zero, so nothing can ever cross a non-zero threshold. The watchdog
+  threads it through `handle_info/2`; a caller driving it by hand must thread
+  it too.
+  """
+  @spec census(nif_watch(), non_neg_integer()) :: nif_watch()
+  def census(seen, stall_threshold_ms)
+      when is_map(seen) and is_integer(stall_threshold_ms) and stall_threshold_ms >= 0 do
+    now = now_ms()
+
+    # `Map.get(seen, pid, {now, false})` is the whole state machine: a pid
+    # already being watched keeps its original instant AND its reported flag,
+    # a new one starts its clock now, and a pid that has left the NIF is
+    # simply absent from the rebuilt map. No deletion path, so none to leak.
+    carried = Map.new(parked_in_nif(), &{&1, Map.get(seen, &1, {now, false})})
+
+    due =
+      for {pid, {since, false}} <- carried, now - since >= stall_threshold_ms, do: {pid, now - since}
+
+    report_nif_census(due)
+
+    Enum.reduce(due, carried, fn {pid, _}, acc ->
+      Map.update!(acc, pid, fn {since, _} -> {since, true} end)
+    end)
   end
 
   # Entering `BEGIN IMMEDIATE`. The caller is a WAITER until `acquired/0`.
@@ -535,7 +679,11 @@ defmodule Grappa.Repo.LockWatch do
     state = %__MODULE__{
       stall_threshold_ms: Keyword.fetch!(opts, :stall_threshold_ms),
       tick_ms: Keyword.fetch!(opts, :tick_ms),
-      enabled: Keyword.fetch!(opts, :enabled)
+      enabled: Keyword.fetch!(opts, :enabled),
+      # #1901 — empty, never seeded from a first pass here: a boot-time
+      # census would time every process from BEFORE the Repo exists and
+      # report the pool's first statements as a stall.
+      nif_watch: %{}
     }
 
     # Before anything else: buy this module's Logger cache key while no
@@ -559,11 +707,17 @@ defmodule Grappa.Repo.LockWatch do
     {:ok, state}
   end
 
+  # `scan/1` FIRST, and the order is not cosmetic: it is the arm that can NAME
+  # a holder, and a pid it reports in this tick is one the census then counts
+  # as already-registered rather than as a writer nobody can see. Running the
+  # census first would report the same episode as unattributable one tick
+  # before the instrument attributed it.
   @impl GenServer
   def handle_info(:tick, state) do
     scan(state.stall_threshold_ms)
+    nif_watch = census(state.nif_watch, state.stall_threshold_ms)
     Process.send_after(self(), :tick, state.tick_ms)
-    {:noreply, state}
+    {:noreply, %{state | nif_watch: nif_watch}}
   end
 
   @impl GenServer
@@ -755,6 +909,104 @@ defmodule Grappa.Repo.LockWatch do
   @spec holder_clause(non_neg_integer()) :: String.t()
   defp holder_clause(0), do: "no holder registered"
   defp holder_clause(n), do: "#{n} holder(s) registered, none past the threshold"
+
+  ## ----- The NIF census (#1901) -----------------------------------------
+
+  # Every process currently executing inside the SQLite driver's NIF. The
+  # discriminator is `current_function` and NOT `:status` or
+  # `:current_stacktrace` (#1888): a dirty NIF reads `:running` whether it is
+  # doing work or sleeping out a busy handler, and a stacktrace costs the
+  # twelve-frame format this pass runs over EVERY process on the node.
+  #
+  # `Process.info/2` does not block on a process parked in a dirty NIF —
+  # measured at 2-78us across four topologies in `lock_watch_test.exs`
+  # (#1767) — which is what makes an unconditional per-tick sweep affordable
+  # at all. `nil` for a pid that died between `Process.list/0` and here is a
+  # real outcome and simply fails the match.
+  @spec parked_in_nif() :: [pid()]
+  defp parked_in_nif do
+    for pid <- Process.list(),
+        match?({:current_function, {@nif_module, _, _}}, Process.info(pid, :current_function)),
+        do: pid
+  end
+
+  # Same two doors and the same SHAPE of line as the other two arms, so an
+  # operator scanning `erlang.log` reads three verdicts from one instrument
+  # rather than three tools. The prefix is `db lock stall NIF CENSUS:` and it
+  # is LOAD-BEARING for the same reason theirs are: `scripts/log-gap-scan.awk`
+  # counts the #1429 census off these literals and
+  # `test/scripts/log_gap_scan_test.bats` pins them verbatim.
+  #
+  # 🔴 The ROSTER is why this line is longer than its siblings, and it is the
+  # deliverable rather than verbosity. #1901's acceptance test is that the log
+  # NAMES the process holding the lock; this arm cannot label which of the
+  # cohort that is, so it names every one of them — pid, elapsed and frame —
+  # and pays the full twelve-frame stack only for the longest. An operator who
+  # has the roster can cross it against the `fault=busy_locked` terminals the
+  # victims emit and read the holder off the difference; an operator with one
+  # sample cannot.
+  @spec report_nif_census([{pid(), non_neg_integer()}]) :: :ok
+  defp report_nif_census([]), do: :ok
+
+  defp report_nif_census(due) do
+    samples =
+      due |> Enum.map(fn {pid, elapsed} -> sample(pid, elapsed) end) |> Enum.sort_by(& &1.elapsed_ms, :desc)
+
+    longest = hd(samples)
+    %{holders: holders, waiters: waiters} = lock_roles()
+    due_pids = MapSet.new(due, &elem(&1, 0))
+    registered_holders = Enum.count(holders, &MapSet.member?(due_pids, &1))
+    registered_waiters = Enum.count(waiters, &MapSet.member?(due_pids, &1))
+
+    report = %{
+      observed_at: now_iso8601(),
+      parked: samples,
+      registered_holders: registered_holders,
+      registered_waiters: registered_waiters
+    }
+
+    Logger.warning(
+      "db lock stall NIF CENSUS: #{length(samples)} process(es) parked inside " <>
+        "#{inspect(@nif_module)} past the threshold, longest #{longest.elapsed_ms}ms — " <>
+        "#{seam_clause(registered_holders, registered_waiters, length(samples))}; " <>
+        "roster: #{roster(samples)}; longest #{longest.pid} status=#{inspect(longest.status)} " <>
+        "at #{longest.current_function}, stack: #{Enum.join(longest.stacktrace, " <- ")}",
+      parked: length(samples),
+      longest_parked_ms: longest.elapsed_ms
+    )
+
+    :telemetry.execute(
+      [:grappa, :repo, :lock_stall, :nif_census],
+      %{parked_count: length(samples), longest_parked_ms: longest.elapsed_ms},
+      report
+    )
+  end
+
+  # The two sub-cases, named apart because they call for different next moves
+  # — the same split `holder_clause/1` makes one arm up. All-zero is the #1901
+  # finding in one phrase: this system's dominant writer holds the file lock
+  # without ever touching the seam, so widening coverage (axis 2) is the only
+  # thing that would name it. A positive count says the seam DID see some of
+  # them, and the remainder is what it missed.
+  @spec seam_clause(non_neg_integer(), non_neg_integer(), pos_integer()) :: String.t()
+  defp seam_clause(0, 0, total) do
+    "none of them registered at the BEGIN IMMEDIATE seam, so all #{total} are writers it cannot name"
+  end
+
+  defp seam_clause(holders, waiters, total) do
+    "#{holders} holder(s) and #{waiters} waiter(s) of them registered at the BEGIN IMMEDIATE " <>
+      "seam, #{total - holders - waiters} not"
+  end
+
+  # Pid, elapsed and frame for every parked process — no stacks, which ride
+  # the telemetry door in full. The frame is in because it is the one field
+  # that separates a writer blocked acquiring a transaction
+  # (`Exqlite.Sqlite3NIF.execute/2`, under `handle_begin/2`) from one already
+  # executing a statement (`step/2`), and that reading costs nothing here.
+  @spec roster([sample()]) :: String.t()
+  defp roster(samples) do
+    Enum.map_join(samples, ", ", &"#{&1.pid} #{&1.elapsed_ms}ms #{&1.current_function}")
+  end
 
   ## ----- Sampling -------------------------------------------------------
 

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -125,6 +125,15 @@ function count_signatures(line) {
         # an episode the instrument could not attribute be read off the
         # artefact as one it did.
         if (line ~ /db lock stall UNATTRIBUTED/) CNT["lockstall_unattributed"]++
+        # #1901 — LockWatch's fourth edge, and the only one taken WITHOUT
+        # reading the BEGIN IMMEDIATE seam: a roster of the processes sitting
+        # inside the SQLite NIF. Its own counter for the reason the two above
+        # have theirs, one step further out — `lockstall` means a holder was
+        # NAMED and `lockstall_unattributed` means a QUEUE was measured with
+        # nobody to blame, while this one means neither was established and a
+        # cohort was photographed instead. Folding it into either would let a
+        # census be read off the artefact as an attribution.
+        if (line ~ /db lock stall NIF CENSUS/) CNT["lockstall_nif"]++
     }
 }
 
@@ -138,7 +147,7 @@ function summary_line(svc, nlines, mg, mat) {
     return sprintf(SUMFMT, svc, nlines, mg, mat, THRESH, ngap, \
         CNT["db30"], CNT["idle30"], CNT["dropped"], CNT["saturated"], \
         CNT["interrupted"], CNT["orphaned"], CNT["lockheld"], CNT["lockstall"], \
-        CNT["lockstall_resolved"], CNT["lockstall_unattributed"])
+        CNT["lockstall_resolved"], CNT["lockstall_unattributed"], CNT["lockstall_nif"])
 }
 
 function bail(msg) {
@@ -210,7 +219,7 @@ BEGIN {
     SUMFMT = "%s\tSUMMARY\tlines=%d\tmaxgap=%.1f\tmaxgap_at=%s\tgaps_ge_%d=%d" \
         "\tdb30=%d\tidle30=%d\tdropped=%d\tsaturated=%d\tinterrupted=%d" \
         "\torphaned=%d\tlockheld=%d\tlockstall=%d\tlockstall_resolved=%d" \
-        "\tlockstall_unattributed=%d\n"
+        "\tlockstall_unattributed=%d\tlockstall_nif=%d\n"
 
     # Samples copied from the emitting call site. Keep them verbatim: a
     # sample edited to fit the pattern turns the control into a mirror.
@@ -242,6 +251,13 @@ BEGIN {
     #                      through the whole 2026-08-22 prod episode because
     #                      the line did not exist; a census blind to it reads
     #                      exactly like a clean run.
+    #   lockstall_nif      — LockWatch's fourth edge (#1901): the roster of
+    #                      processes inside `Exqlite.Sqlite3NIF` past the
+    #                      threshold. It is the ONLY lock signature that does
+    #                      not depend on a writer having gone through the
+    #                      BEGIN IMMEDIATE seam, which is why it is the one
+    #                      that can be non-zero while all three above are
+    #                      zero — the shape all four #1888 episodes had.
     sig("db30", "QUERY OK source=\"messages\" db=30064.1ms queue=0.1ms")
     sig("idle30", "client #PID<0.700.0> checked out, idle=30062.4ms")
     sig("dropped", "scrollback row dropped for #bofh: :persist_unavailable")
@@ -268,6 +284,12 @@ BEGIN {
         " 31303ms — no holder registered, so the holder is NOT attributable at the" \
         " BEGIN IMMEDIATE seam; longest waiter #PID<0.512.0> status=:waiting at" \
         " :gen_server.loop/7, stack: …")
+    sig("lockstall_nif", \
+        "db lock stall NIF CENSUS: 2 process(es) parked inside Exqlite.Sqlite3NIF past the" \
+        " threshold, longest 31402ms — none of them registered at the BEGIN IMMEDIATE seam," \
+        " so all 2 are writers it cannot name; roster: #PID<0.512.0> 31402ms" \
+        " Exqlite.Sqlite3NIF.step/2, #PID<0.513.0> 30011ms Exqlite.Sqlite3NIF.execute/2;" \
+        " longest #PID<0.512.0> status=:running at Exqlite.Sqlite3NIF.step/2, stack: …")
 
     # Deliberately ordinary: a real line from the same stream that names
     # none of the signatures. It DOES carry the word "lock" so the

--- a/test/grappa/db_latency/distribution_test.exs
+++ b/test/grappa/db_latency/distribution_test.exs
@@ -15,7 +15,7 @@ defmodule Grappa.DbLatency.DistributionTest do
   defp ms(n), do: System.convert_time_unit(n, :millisecond, :native)
 
   defp fold(durations_ms) do
-    Enum.reduce(durations_ms, Distribution.new(), &Distribution.add(&2, ms(&1)))
+    Enum.reduce(durations_ms, %Distribution{}, &Distribution.add(&2, ms(&1)))
   end
 
   # The exact quantile of a sample, by rank, computed independently of the
@@ -32,7 +32,7 @@ defmodule Grappa.DbLatency.DistributionTest do
       # A source nobody queried in this window is a real state, and the CLI
       # renders it beside the used ones. A mutant that divides by `n` for the
       # mean, or takes `hd/1` of an empty bucket list, dies here.
-      assert Distribution.reading(Distribution.new()) == %{
+      assert Distribution.reading(%Distribution{}) == %{
                n: 0,
                total_ms: 0.0,
                mean_ms: 0.0,
@@ -70,7 +70,7 @@ defmodule Grappa.DbLatency.DistributionTest do
       healthy = List.duplicate(1, 1_000)
 
       before = Distribution.reading(fold(healthy))
-      after_stall = Distribution.reading(fold(healthy ++ [31_000]))
+      after_stall = Distribution.reading(fold([31_000 | healthy]))
 
       # The mean moves — by ~31 ms at this scale, by 0.1 ms at production
       # scale — and in NEITHER case does it say a 31-second write happened.
@@ -95,7 +95,7 @@ defmodule Grappa.DbLatency.DistributionTest do
     test "a quantile is the smallest bucket bound covering that share, never an interpolation" do
       # 99 samples at 1 ms and 1 at 400 ms: the true p99 is 1 ms, and the
       # smallest bound covering 99 % is 1 ms. The p50 is the same bound.
-      reading = Distribution.reading(fold(List.duplicate(1, 99) ++ [400]))
+      reading = Distribution.reading(fold([400 | List.duplicate(1, 99)]))
 
       assert reading.p50_ms == 1.0
       assert reading.p99_ms == 1.0

--- a/test/grappa/db_latency/distribution_test.exs
+++ b/test/grappa/db_latency/distribution_test.exs
@@ -1,0 +1,196 @@
+defmodule Grappa.DbLatency.DistributionTest do
+  @moduledoc """
+  #1901 axis 3 — the accumulator that keeps an outlier a mean erases.
+
+  No sandbox and no singleton: this is a pure data structure, so it is the
+  one part of the `Grappa.DbLatency` surface that can be `async: true`.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Grappa.DbLatency.Distribution
+
+  # Native-unit duration for a whole number of milliseconds, via the
+  # production conversion (never hardcode the native tick rate).
+  defp ms(n), do: System.convert_time_unit(n, :millisecond, :native)
+
+  defp fold(durations_ms) do
+    Enum.reduce(durations_ms, Distribution.new(), &Distribution.add(&2, ms(&1)))
+  end
+
+  # The exact quantile of a sample, by rank, computed independently of the
+  # production histogram. This is the ORACLE the property below compares
+  # against — deriving it from `@bounds` would make the test a mirror.
+  defp exact_quantile_ms(durations_ms, q) do
+    sorted = Enum.sort(durations_ms)
+
+    Enum.at(sorted, min(max(ceil(q * length(sorted)) - 1, 0), length(sorted) - 1))
+  end
+
+  describe "an empty distribution" do
+    test "reads all zeros rather than raising" do
+      # A source nobody queried in this window is a real state, and the CLI
+      # renders it beside the used ones. A mutant that divides by `n` for the
+      # mean, or takes `hd/1` of an empty bucket list, dies here.
+      assert Distribution.reading(Distribution.new()) == %{
+               n: 0,
+               total_ms: 0.0,
+               mean_ms: 0.0,
+               max_ms: 0.0,
+               p50_ms: 0.0,
+               p95_ms: 0.0,
+               p99_ms: 0.0
+             }
+    end
+  end
+
+  describe "the exact halves" do
+    test "n, total, mean and max are exact, not bucketed" do
+      reading = Distribution.reading(fold([1, 3, 8]))
+
+      assert reading.n == 3
+      assert_in_delta reading.total_ms, 12.0, 0.5
+      assert_in_delta reading.mean_ms, 4.0, 0.5
+
+      # 🔴 `max` is the ONLY exact statement this structure makes about the
+      # worst case, so a mutant that reports the top bucket's BOUND (10.0 ms
+      # here, the smallest bound covering 8 ms) instead of the measurement
+      # dies on this delta. The whole point of #1901 is a number an operator
+      # can quote.
+      assert_in_delta reading.max_ms, 8.0, 0.5
+    end
+  end
+
+  describe "the defect this exists for" do
+    test "a 31s write inside 1000 healthy ones moves the mean by nothing and the max by everything" do
+      # The issue's own arithmetic, at 1/324th the scale so the test is
+      # instant: `messages insert` reads 324 679 samples, and a 31 s write
+      # inside that population moves the mean by 31_000/324_679 = 0.1 ms,
+      # under the rounding the CLI prints. Same shape here.
+      healthy = List.duplicate(1, 1_000)
+
+      before = Distribution.reading(fold(healthy))
+      after_stall = Distribution.reading(fold(healthy ++ [31_000]))
+
+      # The mean moves — by ~31 ms at this scale, by 0.1 ms at production
+      # scale — and in NEITHER case does it say a 31-second write happened.
+      # That is the invisibility the issue measures, reproduced.
+      assert after_stall.mean_ms > before.mean_ms
+
+      # 🔴 These two lines ARE the deliverable. The max names the event
+      # exactly, and the p99 stays where the healthy population is — which is
+      # the second half of the reading: one accident, not a moving tail.
+      assert_in_delta after_stall.max_ms, 31_000.0, 1.0
+      assert after_stall.p99_ms <= 1.0
+
+      # And the tail DOES move when the population moves, so the p99 above is
+      # not simply insensitive. A mutant pinning every quantile to the
+      # smallest bound passes the line above and dies on this one.
+      moved = Distribution.reading(fold(List.duplicate(1, 900) ++ List.duplicate(900, 100)))
+      assert moved.p99_ms >= 900.0
+    end
+  end
+
+  describe "the quantile contract" do
+    test "a quantile is the smallest bucket bound covering that share, never an interpolation" do
+      # 99 samples at 1 ms and 1 at 400 ms: the true p99 is 1 ms, and the
+      # smallest bound covering 99 % is 1 ms. The p50 is the same bound.
+      reading = Distribution.reading(fold(List.duplicate(1, 99) ++ [400]))
+
+      assert reading.p50_ms == 1.0
+      assert reading.p99_ms == 1.0
+
+      # 🔴 The printed value is a BOUND, so it is a round bucket edge and not
+      # a measured decimal. A mutant that interpolates inside the bucket
+      # prints something like 1.03 and dies here, which is the point: an
+      # operator comparing two windows would otherwise read interpolation
+      # noise as movement.
+      assert reading.p95_ms == 1.0
+    end
+
+    test "a quantile past the largest bound reads the exact max, because that bucket has none" do
+      # 30 s is the last finite bound (`busy_timeout`), so 45 s overflows.
+      # There is no bound to report there, and the tightest thing the
+      # structure holds is the measurement itself.
+      reading = Distribution.reading(fold([45_000]))
+
+      assert_in_delta reading.max_ms, 45_000.0, 1.0
+      assert reading.p99_ms == reading.max_ms
+
+      # A mutant that clamps the overflow to the largest bound reports 30 s
+      # for a 45 s write — the exact under-report this arm exists to end.
+      refute reading.p99_ms == 30_000.0
+    end
+
+    test "a write that exhausts busy_timeout lands in the last FINITE bucket, not the overflow" do
+      # The bound set is chosen so `busy_timeout` (30 s, every env today) is
+      # a bucket edge: a writer that gave up exactly there is the expected
+      # terminal state, while the overflow means "worse than the driver's own
+      # patience", which is a different and more interesting fact.
+      reading = Distribution.reading(fold([30_000]))
+
+      assert reading.p99_ms == 30_000.0
+      assert_in_delta reading.max_ms, 30_000.0, 1.0
+    end
+  end
+
+  describe "the upper-bound property" do
+    property "a quantile never understates the true one, and never by more than one bucket" do
+      # 🔴 The first assertion IS the contract, and it only runs in one
+      # direction on purpose: a bucketed quantile may OVERSTATE (it reports
+      # the bucket's ceiling) but must never understate, or an operator
+      # reading `p99_ms` would believe 99 % of writes were faster than they
+      # were. The oracle sorts and ranks; it shares no code with the
+      # histogram.
+      #
+      # 🔴 "<= the observed max" was the FIRST cut of the second assertion
+      # and it is FALSE — measured, first run: one 2 ms sample reports
+      # `p50_ms == 2.5`, the ceiling of the bucket 2 ms falls in, which
+      # exceeds the max by design. What is true, and worth pinning because it
+      # is the resolution the operator is buying, is that a reported quantile
+      # is within ONE bucket of the truth: at most 3x it, the coarsest step
+      # in the bound set (10 s -> 30 s). In the overflow bucket there is no
+      # ceiling and the reading is the exact max, which is the other arm.
+      check all(
+              durations <- list_of(integer(1..60_000), min_length: 1, max_length: 200),
+              q <- member_of([{0.50, :p50_ms}, {0.95, :p95_ms}, {0.99, :p99_ms}])
+            ) do
+        {quantile, key} = q
+        reading = Distribution.reading(fold(durations))
+        reported = Map.fetch!(reading, key)
+        truth = exact_quantile_ms(durations, quantile)
+
+        assert reported >= truth * 0.999,
+               "#{key} understated the true quantile: got #{reported}, true #{truth}"
+
+        assert reported <= max(truth * 3.0, reading.max_ms),
+               "#{key} is more than one bucket above the truth: got #{reported}, true #{truth}"
+      end
+    end
+
+    property "the three quantiles are monotone in q" do
+      # Structural, and independent of the bound set: the walk is over a
+      # cumulative count, so a larger rank can only stop at the same bound or
+      # a later one. A mutant that reads the buckets unsorted, or that walks
+      # from the wrong end, breaks this without breaking the bound above.
+      check all(durations <- list_of(integer(1..60_000), min_length: 1, max_length: 200)) do
+        reading = Distribution.reading(fold(durations))
+
+        assert reading.p50_ms <= reading.p95_ms
+        assert reading.p95_ms <= reading.p99_ms
+      end
+    end
+
+    property "n and total are exact for any sample" do
+      # The bucketing must not leak into the two numbers that were always
+      # exact. A mutant that folds `total` from bucket midpoints (a plausible
+      # "simplification") dies across the whole input space.
+      check all(durations <- list_of(integer(1..5_000), min_length: 1, max_length: 100)) do
+        reading = Distribution.reading(fold(durations))
+
+        assert reading.n == length(durations)
+        assert_in_delta reading.total_ms, Enum.sum(durations) * 1.0, length(durations) * 0.5
+      end
+    end
+  end
+end

--- a/test/grappa/db_latency_test.exs
+++ b/test/grappa/db_latency_test.exs
@@ -18,6 +18,14 @@ defmodule Grappa.DbLatencyTest do
   alias Grappa.DbLatency
 
   @handler_id "grappa-db-latency"
+
+  # 🔴 An INDEPENDENT copy of the production set, on purpose, and the
+  # `attached_events/0` equality assertion below is what keeps it from
+  # rotting. Deriving it from `DbLatency.attached_events/0` would make the
+  # boot-wiring test tautological; leaving it underived and UNCHECKED is what
+  # broke while #1901 was being built — a new emitter reached a new `fold/4`
+  # clause, the suite stayed green, and the ring was silently empty because
+  # this list never learned about the event.
   @events [
     [:grappa, :repo, :query],
     [:grappa, :scrollback, :persist, :stop],
@@ -25,7 +33,8 @@ defmodule Grappa.DbLatencyTest do
     [:grappa, :scrollback, :persist, :contention],
     [:grappa, :repo, :lock_stall, :detected],
     [:grappa, :repo, :lock_stall, :resolved],
-    [:grappa, :repo, :lock_stall, :unattributed]
+    [:grappa, :repo, :lock_stall, :unattributed],
+    [:grappa, :repo, :lock_stall, :nif_census]
   ]
 
   # Native-unit duration for a whole number of milliseconds, via the
@@ -290,6 +299,59 @@ defmodule Grappa.DbLatencyTest do
       assert hd(row.waiters).stacktrace == ["Exqlite.Sqlite3NIF.step/2"]
     end
 
+    test "[:grappa, :repo, :lock_stall, :nif_census] folds the roster, and names nobody as the holder" do
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :nif_census],
+        %{parked_count: 2, longest_parked_ms: 31_402},
+        %{
+          observed_at: "2026-09-01T10:07:28.554000Z",
+          registered_holders: 0,
+          registered_waiters: 1,
+          parked: [
+            %{
+              pid: "#PID<0.222.0>",
+              elapsed_ms: 31_402,
+              current_function: "Exqlite.Sqlite3NIF.step/2",
+              stacktrace: ["Grappa.Scrollback.persist_row/1"]
+            },
+            %{pid: "#PID<0.333.0>", elapsed_ms: 30_011, current_function: "Exqlite.Sqlite3NIF.execute/2"}
+          ]
+        }
+      )
+
+      assert [row] = DbLatency.snapshot().lock_stalls
+
+      assert row.phase == :nif_census
+      assert row.observed_at == "2026-09-01T10:07:28.554000Z"
+
+      # 🔴 `holder_pid: nil` is a STRONGER statement here than on the
+      # `:unattributed` row, and a mutant that fills it in — say with the
+      # longest-parked pid, which is the plausible guess — dies here. On this
+      # phase a holder is certainly among `parked`; the instrument simply
+      # cannot say which, because exqlite's busy handler sleeps inside the
+      # same dirty-IO NIF the lock holder is executing in.
+      assert row.holder_pid == nil
+      assert row.held_ms == nil
+      assert row.holder == nil
+      assert row.caller == nil
+      assert row.announced == nil
+
+      # A census counts no QUEUE. `parked_count` is a different measurement
+      # and rides the measurements map, exactly as #1687 refused to reuse
+      # `held_ms` for a longest WAIT. A mutant that copies `parked_count` in
+      # here reports two blocked writers where nobody measured one.
+      assert row.waiter_count == nil
+      assert row.waiters == []
+
+      # The roster IS the payload, and the counts are what tell an operator
+      # whether to widen coverage or to scroll up to a line the other two
+      # arms already printed.
+      assert length(row.parked) == 2
+      assert hd(row.parked).stacktrace == ["Grappa.Scrollback.persist_row/1"]
+      assert row.registered_holders == 0
+      assert row.registered_waiters == 1
+    end
+
     test "the lock-stall ring is bounded, keeping the newest episodes" do
       for n <- 1..25 do
         :telemetry.execute(
@@ -333,6 +395,16 @@ defmodule Grappa.DbLatencyTest do
       :telemetry.detach(@handler_id)
       on_exit(fn -> :telemetry.detach(@handler_id) end)
       :ok
+    end
+
+    test "the production event set and this file's expectation of it have not drifted" do
+      # The two failures this catches are asymmetric and BOTH are quiet.
+      # A production event with no clause in this file's `@events` never
+      # reaches an assertion, so a fold bug ships green; an entry here with no
+      # production event makes every test in the aggregation describe fold
+      # nothing, which reads as "the emitter is broken" and sends the reader
+      # to the wrong module. Naming the difference costs one assertion.
+      assert Enum.sort(DbLatency.attached_events()) == Enum.sort(@events)
     end
 
     test "attach_telemetry: true attaches the handler to every measured event" do

--- a/test/grappa/db_latency_test.exs
+++ b/test/grappa/db_latency_test.exs
@@ -128,6 +128,64 @@ defmodule Grappa.DbLatencyTest do
       assert_in_delta row.mean_ms, 6.0, 0.5
     end
 
+    test "an outlier survives the fold into a bucket a mean would erase (#1901)" do
+      # The end-to-end half of `Grappa.DbLatency.DistributionTest`: the unit
+      # test buys the arithmetic, this buys that the arithmetic actually
+      # reaches `snapshot/0` through the real telemetry fold. Until #1901 the
+      # bucket kept `{n, total}` only, so this 31 s write left the table
+      # reading 0.1 ms slower and nothing else.
+      for _ <- 1..99 do
+        :telemetry.execute(
+          [:grappa, :repo, :query],
+          %{total_time: ms(1), queue_time: ms(0)},
+          %{source: "messages", query: ~s|INSERT INTO "messages" ("body") VALUES (?)|}
+        )
+      end
+
+      :telemetry.execute(
+        [:grappa, :repo, :query],
+        %{total_time: ms(31_000), queue_time: ms(0)},
+        %{source: "messages", query: ~s|INSERT INTO "messages" ("body") VALUES (?)|}
+      )
+
+      row = query_row(DbLatency.snapshot(), "messages", :insert)
+
+      assert row.n == 100
+
+      # The mean is the number that hides it: 100 samples, 99 of them 1 ms.
+      # At production scale (324 679 samples) this moves by 0.1 ms.
+      assert_in_delta row.mean_ms, 310.99, 5.0
+
+      # 🔴 And the two that do not. A mutant that keeps the histogram but
+      # takes `max` from the bucket BOUND reports 30 000 ms for a 31 000 ms
+      # write; one that drops the histogram entirely has no max at all.
+      assert_in_delta row.max_ms, 31_000.0, 50.0
+
+      # The tail says it was one accident rather than a shifted population —
+      # the second half of the reading, and the reason a bare `max_ms` was
+      # not enough on its own.
+      assert row.p95_ms <= 1.0
+    end
+
+    test "the span families carry the same shape, so neither axis is half-migrated" do
+      # `persist` and `send_privmsg` fold the same way and hide an outlier
+      # the same way, so they get the same accumulator. A mutant that gives
+      # the histogram to `queries` only leaves the two write-path spans —
+      # mechanisms 1 and 3 of #357 — reading a mean and nothing else.
+      :telemetry.execute([:grappa, :scrollback, :persist, :stop], %{duration: ms(1)}, %{outcome: :ok})
+      :telemetry.execute([:grappa, :scrollback, :persist, :stop], %{duration: ms(9_000)}, %{outcome: :ok})
+      :telemetry.execute([:grappa, :session, :send_privmsg, :stop], %{duration: ms(4_000)}, %{outcome: :ok})
+
+      snapshot = DbLatency.snapshot()
+
+      assert_in_delta snapshot.persist.max_ms, 9_000.0, 20.0
+      assert snapshot.persist.p99_ms >= 9_000.0
+      assert_in_delta snapshot.send_privmsg.max_ms, 4_000.0, 20.0
+
+      # The outcome tally is untouched by the change of accumulator.
+      assert snapshot.persist.outcomes[:ok] == 2
+    end
+
     test "queries are returned sorted by total_ms descending" do
       :telemetry.execute(
         [:grappa, :repo, :query],

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -287,7 +287,11 @@ defmodule Grappa.OperatorTest do
       :ok =
         :telemetry.attach_many(
           @db_latency_handler_id,
-          [[:grappa, :repo, :query], [:grappa, :repo, :lock_stall, :resolved]],
+          [
+            [:grappa, :repo, :query],
+            [:grappa, :repo, :lock_stall, :resolved],
+            [:grappa, :repo, :lock_stall, :nif_census]
+          ],
           &DbLatency.handle_telemetry/4,
           nil
         )
@@ -354,6 +358,50 @@ defmodule Grappa.OperatorTest do
       # and names the caller instead.
       assert output =~ "write path #PID<0.512.0> (Grappa.Session.Server.init/1)"
       assert output =~ "    Grappa.Scrollback.persist/1"
+      refute output =~ "holder at"
+    end
+
+    test "a NIF census renders its roster and refuses to name a holder (#1901)" do
+      # The CLI is the door an operator reaches for mid-incident, and this
+      # phase carries nil in every seam-derived column. Until it is rendered
+      # once in a test, the first `bin/grappa db-latency` of a real freeze is
+      # where a nil would surface — as a crash, during the exact incident the
+      # arm was added to diagnose. That is the #1888 lesson applied one phase
+      # later rather than relearned.
+      :telemetry.execute(
+        [:grappa, :repo, :lock_stall, :nif_census],
+        %{parked_count: 2, longest_parked_ms: 31_402},
+        %{
+          observed_at: "2026-09-01T10:07:28.554000Z",
+          registered_holders: 0,
+          registered_waiters: 1,
+          parked: [
+            %{pid: "#PID<0.222.0>", elapsed_ms: 31_402, current_function: "Exqlite.Sqlite3NIF.step/2"},
+            %{pid: "#PID<0.333.0>", elapsed_ms: 30_011, current_function: "Exqlite.Sqlite3NIF.execute/2"}
+          ]
+        }
+      )
+
+      # Drain the cast before rendering.
+      _ = DbLatency.snapshot()
+
+      output = capture_io(fn -> assert :ok = Operator.db_latency_text!() end)
+
+      assert output =~ "nif_census\tat=2026-09-01T10:07:28.554000Z\tholder=unattributed"
+
+      # `parked=` and `waiters=` are two different questions and the row has
+      # to keep them apart: two processes were in the NIF, and NOBODY counted
+      # a queue. A mutant rendering the roster length as `waiters=` reads as
+      # two blocked writers, which is a claim this phase never made.
+      assert output =~ "waiters=not counted"
+      assert output =~ "parked=2"
+      assert output =~ "registered=0h/1w"
+
+      # The roster itself, under its own wording — "parked ... in the NIF",
+      # never the DETECTED block's "holder at", which names a pause site the
+      # instrument attributed to one process.
+      assert output =~ "parked #PID<0.222.0> in the NIF 31402ms at Exqlite.Sqlite3NIF.step/2"
+      assert output =~ "parked #PID<0.333.0> in the NIF 30011ms at Exqlite.Sqlite3NIF.execute/2"
       refute output =~ "holder at"
     end
   end

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -317,6 +317,20 @@ defmodule Grappa.OperatorTest do
       assert output =~ "messages\tinsert\t1"
       assert output =~ "# spans (D1 write-path)"
       assert output =~ "# contention"
+
+      # #1901 — the columns an operator reads an outlier off. `mean_ms` stays
+      # where it was rather than being replaced: mechanisms 1 and 3 of #357
+      # are read from it, and tidying it away would break a documented
+      # reading. A mutant that renames or reorders the header without
+      # touching the row printer puts the numbers under the wrong names.
+      assert output =~ "mean_ms\tmax_ms\tp50_ms\tp95_ms\tp99_ms"
+      assert output =~ "span\tn\ttotal_ms\tmean_ms\tmax_ms\tp50_ms\tp95_ms\tp99_ms\toutcomes"
+
+      # #1657 shipped this counter and the header never learned about it, so
+      # the CLI printed four values under four names while the row carried
+      # five. A header and a row printer that disagree silently mislabel
+      # every column after the gap.
+      assert output =~ "n\tqueue_timeout\tbusy_locked\tinterrupted\tdropped"
     end
 
     test "an unannounced closing bracket renders its instant, its verdict and its write path (#1888)" do

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -42,6 +42,7 @@ defmodule Grappa.Repo.LockWatchTest do
   @detected [:grappa, :repo, :lock_stall, :detected]
   @unattributed [:grappa, :repo, :lock_stall, :unattributed]
   @resolved [:grappa, :repo, :lock_stall, :resolved]
+  @nif_census [:grappa, :repo, :lock_stall, :nif_census]
 
   # 🔴 TWO CLOCKS BOUND EVERY TEST HERE, AND THEY HAVE TO BE ORDERED.
   #
@@ -143,15 +144,19 @@ defmodule Grappa.Repo.LockWatchTest do
     # (and vice versa). Two separate handlers would let a mutant that emits
     # both pass every assertion in the file. #1888 adds the closing bracket
     # for the same reason — a test that asserts an episode brackets must be
-    # able to refute that it brackets when it should not.
+    # able to refute that it brackets when it should not. #1901 adds the NIF
+    # census on the same reasoning: it is a THIRD verdict about the same lock,
+    # and a mutant routing a seam-attributable stall through it (or the other
+    # way round) has to die on a refutation somewhere.
     :ok =
       :telemetry.attach_many(
         handler,
-        [@detected, @unattributed, @resolved],
+        [@detected, @unattributed, @resolved, @nif_census],
         fn
           @detected, measurements, metadata, _ -> send(test_pid, {:stall, measurements, metadata})
           @unattributed, measurements, metadata, _ -> send(test_pid, {:unattributed, measurements, metadata})
           @resolved, measurements, metadata, _ -> send(test_pid, {:resolved, measurements, metadata})
+          @nif_census, measurements, metadata, _ -> send(test_pid, {:nif_census, measurements, metadata})
         end,
         nil
       )
@@ -393,6 +398,205 @@ defmodule Grappa.Repo.LockWatchTest do
       send(writer, :release)
       assert_receive {:DOWN, ^writer_ref, :process, ^writer, :normal}, 5_000
       assert_receive {:DOWN, ^queued_ref, :process, ^queued, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+  end
+
+  # 🔴 THE TOPOLOGY THESE FOUR TESTS BUY, AND WHY IT IS NOT THE ONE ABOVE.
+  #
+  # Every test up to here drives the watch TABLE: a writer is a holder or a
+  # waiter because `observe/1` said so. #1901 is about the writers that never
+  # reach `observe/1` at all — `Scrollback.persist_row/1` and its ~120
+  # autocommit peers, which the issue measures at 324 679 inserts against
+  # thousands for the whole seam. The census reads `Process.list/0` instead,
+  # so what it needs from a fixture is a process genuinely parked INSIDE
+  # `Exqlite.Sqlite3NIF`, with no row anywhere.
+  #
+  # `start_unobserved_writer/1` gives exactly that when a holder already owns
+  # the file lock: its `BEGIN IMMEDIATE TRANSACTION` reaches
+  # `Exqlite.Sqlite3NIF.execute/2` (`deps/exqlite/lib/exqlite/connection.ex:307`
+  # -> `sqlite3.ex:175`), which is registered `ERL_NIF_DIRTY_JOB_IO_BOUND`
+  # (`c_src/sqlite3_nif.c:2066`), and exqlite's own busy handler sleeps INSIDE
+  # that NIF (`c_src/sqlite3_nif.c:332`) rather than returning to Elixir to
+  # retry. So the writer sits in the NIF for the whole `busy_timeout` and
+  # `current_function` names it for as long as it does.
+  #
+  # 🔴 The parked HOLDER is the negative control and it is load-bearing: it is
+  # parked in `park_until_released/0`, a plain `receive`, so it is NOT inside
+  # the NIF and MUST NOT appear. That is the honest limit of this arm stated
+  # as an assertion — it sees a writer inside a NIF call, not a transaction
+  # parked between statements.
+  describe "the NIF census — the writers the seam cannot see (#1901)" do
+    test "names a writer parked inside the SQLite NIF that owns no row at the seam" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      {unseen, unseen_ref} = start_unobserved_writer(2)
+      await_parked_in_nif(unseen)
+
+      # The LOG is the door that was dark through all four #1888 episodes:
+      # `grep -h "db lock stall" runtime/log/erlang.log.*` returned 0 while
+      # six victims timed out at ~31 s. Pinning the telemetry alone would
+      # leave exactly the door that failed, failing.
+      log = capture_log(fn -> LockWatch.census(%{}, 0) end)
+
+      assert log =~ "db lock stall NIF CENSUS"
+      assert log =~ "none of them registered at the BEGIN IMMEDIATE seam"
+
+      assert_receive {:nif_census, measurements, report}, 1_000
+
+      # N1 — the whole deliverable. A mutant that reads the watch table (as
+      # both older arms do) finds nothing here: this writer registered
+      # nowhere. Only a reading taken from `Process.list/0` can name it.
+      assert inspect(unseen) in pids(report.parked)
+
+      # N2 — the negative control. A mutant that reports every process, or
+      # every process with an open transaction, drags the parked holder in.
+      # It holds RESERVED and is NOT in a NIF, and this arm must not pretend
+      # otherwise.
+      refute inspect(blind) in pids(report.parked)
+      refute inspect(self()) in pids(report.parked)
+
+      # N3 — the honesty fields. `0` says the seam saw none of these
+      # processes at all, which is the #1901 finding in one number. A mutant
+      # that synthesises a holder (the shape the acceptance criterion
+      # invites) has to put a pid somewhere, and there is no field for one.
+      assert report.registered_holders == 0
+      assert report.registered_waiters == 0
+      refute Map.has_key?(report, :holder)
+
+      # N4 — a mutant sampling `self()` instead of the parked pid still
+      # produces a well-formed record; only the CONTENT of the stack tells
+      # them apart, and this frame is the reason the writer is stuck.
+      assert [sample] = Enum.filter(report.parked, &(&1.pid == inspect(unseen)))
+      assert sample.current_function =~ "Exqlite.Sqlite3NIF"
+      assert Enum.any?(sample.stacktrace, &(&1 =~ "Exqlite"))
+
+      assert measurements.parked_count == length(report.parked)
+      assert is_integer(measurements.longest_parked_ms)
+
+      # N5 — the three arms are distinct verdicts. A mutant that also routes
+      # this through either older door would double-report the same episode
+      # under two different claims about attribution.
+      refute_receive {:stall, _, _}, 100
+      refute_receive {:unattributed, _, _}, 100
+
+      # BOTH, and `unseen` before it is even unblocked: the moment `blind`
+      # lets go, `unseen` takes RESERVED and parks in `park_until_released/0`
+      # exactly as its fixture is written to. A `:release` sent early simply
+      # waits in its mailbox, while one sent late never arrives — measured,
+      # first cut of these tests: three reds, all of them this.
+      send(blind, :release)
+      send(unseen, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:DOWN, ^unseen_ref, :process, ^unseen, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a writer the seam DOES know is counted as such, not as an unseen one" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      # This one goes through `observe/1`, so it owns a `:waiting` row while
+      # it blocks in the very same NIF call.
+      {waiter, waiter_ref} = start_writer(2, :straight_through)
+      await_roles(nil, [waiter])
+      await_parked_in_nif(waiter)
+
+      log = capture_log(fn -> LockWatch.census(%{}, 0) end)
+
+      assert_receive {:nif_census, _, report}, 1_000
+
+      # N6 — the counts are the difference between "widen coverage" and
+      # "the seam already told you". A mutant that hard-codes them to zero
+      # (the shape the first test alone would let live) reports a registered
+      # waiter as a writer nobody can see, and an operator reading it would
+      # go looking for an instrument that is already there.
+      assert inspect(waiter) in pids(report.parked)
+      assert report.registered_waiters == 1
+      assert report.registered_holders == 0
+      assert log =~ "registered at the BEGIN IMMEDIATE seam"
+      refute log =~ "none of them registered"
+
+      send(blind, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "a process that has not been in the NIF long enough is not reported" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      {unseen, unseen_ref} = start_unobserved_writer(2)
+      await_parked_in_nif(unseen)
+
+      # N7 — the mirror of M5/M9 on the third arm. The first pass can only
+      # ever see a pid at elapsed 0, so a mutant that drops the threshold
+      # comparison turns every millisecond-long insert on the system into a
+      # warning at every tick: a log flood, which reads the same as silence.
+      seen = LockWatch.census(%{}, 10_000)
+
+      refute_receive {:nif_census, _, _}, 300
+
+      # N8 — and the clock it started has to SURVIVE, or the threshold can
+      # never be crossed on any later pass. A mutant that returns a fresh map
+      # (or the one it was handed) re-clocks the pid at every tick and the
+      # arm is permanently silent — the exact failure #1901 reports, rebuilt
+      # inside its own cure.
+      assert {since, false} = Map.fetch!(seen, unseen)
+      assert is_integer(since)
+
+      # BOTH, and `unseen` before it is even unblocked: the moment `blind`
+      # lets go, `unseen` takes RESERVED and parks in `park_until_released/0`
+      # exactly as its fixture is written to. A `:release` sent early simply
+      # waits in its mailbox, while one sent late never arrives — measured,
+      # first cut of these tests: three reds, all of them this.
+      send(blind, :release)
+      send(unseen, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:DOWN, ^unseen_ref, :process, ^unseen, :normal}, 10_000
+
+      Supervisor.stop(repo)
+    end
+
+    test "one line per cohort, not one per watchdog tick" do
+      repo = start_tmp_repo()
+
+      {blind, blind_ref} = start_unobserved_writer(1)
+      assert_receive {:holding, ^blind}, 5_000
+
+      {unseen, unseen_ref} = start_unobserved_writer(2)
+      await_parked_in_nif(unseen)
+
+      {seen, _} = with_log(fn -> LockWatch.census(%{}, 0) end)
+      assert_receive {:nif_census, _, _}, 1_000
+
+      # N9 — the #1888 episodes ran ~31 s at `tick_ms: 1_000` and the #1687
+      # one ~170 s. A mutant that forgets to carry the reported flag prints
+      # one identical warning per tick for the whole freeze, which is how the
+      # other two arms would have drowned their own signal.
+      LockWatch.census(seen, 0)
+      refute_receive {:nif_census, _, _}, 300
+
+      # BOTH, and `unseen` before it is even unblocked: the moment `blind`
+      # lets go, `unseen` takes RESERVED and parks in `park_until_released/0`
+      # exactly as its fixture is written to. A `:release` sent early simply
+      # waits in its mailbox, while one sent late never arrives — measured,
+      # first cut of these tests: three reds, all of them this.
+      send(blind, :release)
+      send(unseen, :release)
+      assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
+      assert_receive {:DOWN, ^unseen_ref, :process, ^unseen, :normal}, 10_000
 
       Supervisor.stop(repo)
     end
@@ -1560,6 +1764,32 @@ defmodule Grappa.Repo.LockWatchTest do
 
   defp expected_holders(nil), do: []
   defp expected_holders(holder), do: [holder]
+
+  # #1901 — the census barrier. A writer reaches `Exqlite.Sqlite3NIF` a
+  # scheduling moment AFTER it is spawned, and `start_unobserved_writer/1`
+  # cannot send a "now blocked" message: the whole point of that fixture is
+  # that it is stuck before its first statement runs. So the condition is
+  # polled on the ONE fact the census itself reads, and on the same wall-clock
+  # budget as `await_roles/2` — see `@barrier_budget_ms` for why an attempt
+  # count is not a budget.
+  #
+  # The `flunk` names the function it DID find, because the two ways this can
+  # fail read identically from the outside: a runner too slow to schedule the
+  # writer at all, and a writer that reached SQLite by some path that does not
+  # park in the NIF. Only the observed frame separates them.
+  # The one-line `match?` is a FIXTURE PRECONDITION, not a copy of the logic
+  # under test: it asserts this writer reached the state the census exists to
+  # find. The census's own predicate runs over `Process.list/0` and is what the
+  # assertions in the body buy.
+  defp await_parked_in_nif(pid) do
+    await_until(
+      fn -> match?({:current_function, {Exqlite.Sqlite3NIF, _, _}}, Process.info(pid, :current_function)) end,
+      @barrier_budget_ms
+    )
+  rescue
+    error in ExUnit.AssertionError ->
+      flunk("#{error.message} — #{inspect(pid)} is at #{inspect(Process.info(pid, :current_function))}")
+  end
 
   defp pids(samples), do: Enum.map(samples, & &1.pid)
 

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -28,6 +28,7 @@ setup() {
     LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
     LOCKUNATTR_LINE='db lock stall UNATTRIBUTED: 3 writer(s) queued past the threshold, longest 31303ms — no holder registered, so the holder is NOT attributable at the BEGIN IMMEDIATE seam; longest waiter #PID<0.512.0> status=:waiting at :gen_server.loop/7, stack: a <- b'
+    LOCKNIF_LINE='db lock stall NIF CENSUS: 2 process(es) parked inside Exqlite.Sqlite3NIF past the threshold, longest 31402ms — none of them registered at the BEGIN IMMEDIATE seam, so all 2 are writers it cannot name; roster: #PID<0.512.0> 31402ms Exqlite.Sqlite3NIF.step/2, #PID<0.513.0> 30011ms Exqlite.Sqlite3NIF.execute/2; longest #PID<0.512.0> status=:running at Exqlite.Sqlite3NIF.step/2, stack: a <- b'
     LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for 30067ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
     SATURATED_LINE='db write unavailable: SQLite pool saturated for 1512ms across 14 attempts (1500ms retry budget) — returning :db_unavailable'
     # #1657 — the third arm. The elapsed is ~15s because a cancellation is
@@ -183,6 +184,40 @@ stamp() {
     # instrument explicitly declined to make.
     grep -q 'lockstall=0' <<<"$out"
     grep -q 'lockstall_resolved=0' <<<"$out"
+}
+
+# --- #1901: the census that reads the NIF, not the seam --------------------
+#
+# All four #1888 episodes had the shape the three counters above cannot
+# express: writers demonstrably stuck, nobody registered at the seam, and no
+# queue the seam could measure either — so `lockstall`, `lockstall_resolved`
+# AND `lockstall_unattributed` all read zero while the node was frozen for
+# 31 s. This is the counter that can be non-zero in exactly that state.
+
+@test "a NIF CENSUS is counted, and not as any of the three seam verdicts" {
+    local out
+    out="$( stamp '12:00:00.' "$LOCKNIF_LINE" | scan 10 )"
+
+    grep -q 'lockstall_nif=1' <<<"$out"
+    # The discrimination, and it runs in both directions. `lockstall` means a
+    # holder was NAMED and `lockstall_unattributed` means a queue was MEASURED
+    # with nobody to blame; a census established neither, it photographed a
+    # cohort. Folding it into either would let an artefact report an
+    # attribution the instrument explicitly declined to make.
+    grep -q 'lockstall=0' <<<"$out"
+    grep -q 'lockstall_resolved=0' <<<"$out"
+    grep -q 'lockstall_unattributed=0' <<<"$out"
+}
+
+@test "a NAMED stall does not score as a NIF census" {
+    local out
+    out="$( {
+        stamp '12:00:00.' "$LOCKSTALL_LINE"
+        stamp '12:00:30.' "$LOCKRESOLVED_LINE"
+        stamp '12:00:31.' "$LOCKUNATTR_LINE"
+    } | scan 60 )"
+
+    grep -q 'lockstall_nif=0' <<<"$out"
 }
 
 @test "a NAMED stall does not score as unattributed" {


### PR DESCRIPTION
Addresses issue 1901 — `LockWatch` is blind to the autocommit writes that dominate the write load.

Axis 1 and axis 3 of that issue. **Axis 2 is deliberately not built** — the issue itself defers it.

## Why the existing instrument saw nothing

`LockWatch`'s two arms both read the watch table, and that table has exactly one producer:
`Repo.immediate_transaction/1`. Measured on the live node, `messages insert`
(`Scrollback.persist_row/1` — autocommit, single statement) is **324 679 writes**, while every
source the seam covers is in the thousands. The instrument was watching the rare tail of the write
load and missing the dominant one. That is why four write-lock stalls with six victims produced
zero lines of its own.

## Axis 1 — sample the NIF, not the seam

A third arm reads `Process.list/0` and keeps whoever is executing inside `Exqlite.Sqlite3NIF`,
timed from the first tick that saw them there. The property is physical rather than cooperative:
`execute/2` and `step/2` are declared `ERL_NIF_DIRTY_JOB_IO_BOUND` and exqlite's busy handler sleeps
INSIDE the NIF instead of returning to Elixir to retry, so a writer blocked on the file lock stays
visible in `current_function` for the whole `busy_timeout`. No enumeration of write paths to
maintain, and nothing added to the write path itself.

Same log-line shape as the two existing arms, same bounded ring, same `bin/grappa db-latency` block,
same `GET /admin/db_latency` response, and its own `lockstall_nif` counter in the #1429 log census
(its own counter rather than a fold into either sibling: `lockstall` means a holder was NAMED,
`lockstall_unattributed` means a queue was MEASURED with nobody to blame, this one means neither and
a cohort was photographed instead).

**It names the COHORT, never the holder, and that is deliberate.** The same physics that makes the
arm work makes the cohort indivisible — holder and victims are all inside the NIF, all reading
`:running`, and nothing visible from the BEAM separates them. So `holder_pid` and `waiter_count`
stay nil: filling them with the plausible guess (the longest-parked pid) would convert the only
honest thing the row says into a fabrication. Closing that gap for real is axis 2.

Cost, measured rather than argued (dev image, warm, 20 passes per point): 0.7–2 us per process per
pass — 1.55 ms at 2 000 processes, **0.16 % of one scheduler** at `tick_ms: 1_000`. It does not
scale with write volume, which is the argument against instrumenting the 324 679 inserts instead.

## Axis 3 — keep the outlier a mean erases

`Grappa.DbLatency` folded every duration family to `n / total_ms / mean_ms`. A single 31 s write
inside 324 679 samples moves the mean by `31_000/324_679` = **0.1 ms**, under the rounding the CLI
prints — so an operator could read the table DURING the freeze and see a healthy system.

`Grappa.DbLatency.Distribution` adds an exact `max` plus a 16-bucket fixed histogram (0.5 ms … 30 s,
so `busy_timeout` is a bucket EDGE and a writer that exhausted it lands in the last finite bucket —
the overflow then means "worse than the driver's own patience", a distinct fact rather than a
saturation artefact). 16 counters per family regardless of sample count; nothing allocates per
sample.

Quantiles are **UPPER BOUNDS, never interpolations**, and the type says so — interpolating would
print a decimal nobody measured, and a reader comparing two windows would read interpolation noise
as movement. A property test holds "never understates" against a sort-and-rank oracle that shares no
code with the histogram. `queue_ms` stays a bare sum and the typedoc calls that a KNOWN GAP.

## Two drifts fixed in passing

- `Grappa.DbLatencyTest` hand-copied production's `@events` list. `fold/4` has no catch-all, so its
  two failure modes are asymmetric and both quiet: an event with no clause crashes the singleton, a
  clause with no event folds nothing. The second happened while writing this — new emitter, new
  clause, green suite, empty ring. The copy stays (it is the oracle; deriving it would make the
  boot-wiring test tautological) but `DbLatency.attached_events/0` plus an equality assertion now
  NAME the divergence.
- `bin/grappa db-latency` printed four values under four names on the `contention` line while the
  row carried five — `interrupted` was added by #1657 and the header never learned about it,
  silently mislabelling every column after the gap.

## Gates

`scripts/check.sh` on this HEAD: **`check rc=0`**.

- credo (strict): `6699 mods/funs, found no issues.`
- doctor: `Doctor validation has passed!`
- test: `8 doctests, 65 properties, 7107 tests, 0 failures`
- dialyzer: `Total errors: 0, Skipped: 0, Unnecessary Skips: 0`
- wire drift: `wireTypes.ts is in sync.` / `wireSchema.ts is in sync.`
- wire pin: `priv/wire/shape.pin: wire shape and protocol 10 agree.`
- bats: `1..710`, 710 `ok` / 0 `not ok`
- `design-notes-gate.sh origin/main`: rc=0, `1 new entry heading(s), separator and marker present.`

## Deploy: COLD

Measured through `Grappa.Deploy.Preflight.classify_state_shape/2` against `origin/main`, with a
positive control (add a field → `:cold`) and a negative one (identical → `:hot`): 3 of 34 tracked
files change state shape — `lock_watch.ex` (`defstruct` gains `:nif_watch`), `db_latency.ex`
(accumulators → `Distribution`), and the new `db_latency/distribution.ex`.
