### PR TITLE
cic: realign biome.json $schema with the pinned CLI (2.5.11)

### DIFF
--- a/cicchetto/biome.json
+++ b/cicchetto/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
`cicchetto/package.json` pins `@biomejs/biome` at **2.5.11**, while `cicchetto/biome.json` still declared the **2.5.8** schema. Editors validated the config against a schema the pinned CLI no longer describes the same way.

This moves the single `$schema` line to 2.5.11.

**Supersedes #1866**, which moved the same line to 2.5.10 — correct when it was opened on 2026-08-29, one release short by the time it was reviewed.

Verified:
- `https://biomejs.dev/schemas/2.5.11/schema.json` returns `200`.
- The pinned CLI reads the config clean: `biome check` on a source file reports no diagnostics.

Reported and authored on IRC at vjt's request; commit author is vjt.
