### PR TITLE
credits: enter from the bottom edge, and make the soundtrack a suite

### DIFF
--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -9,6 +9,7 @@ import {
   toggleCreditsMuted,
 } from "./lib/creditsModal";
 import { creditsRainLook } from "./lib/creditsRain";
+import { creditsRollPass } from "./lib/creditsRoll";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import MatrixRain from "./MatrixRain";
 
@@ -43,6 +44,18 @@ const CreditsModal: Component = () => {
 
   const credits = buildCredits();
 
+  // #1807 — the roll's own animation is the ONLY clock. `MatrixRain` calls
+  // `look` once per drawn frame from inside the loop it already runs, and
+  // `creditsRainLook` answers by reading this element's animation phase, so
+  // the burst can never drift away from the interlude it belongs to. Assigned
+  // during element creation, which is before any `onMount` — including the
+  // one that starts the rain — so the loop never sees it unset.
+  //
+  // #1920 reads the same element for the SUITE's cursor (`creditsRollPass`),
+  // which is why the declaration sits above the audio effect: both readers
+  // close over it, neither runs before it is assigned.
+  let roll: HTMLDivElement | undefined;
+
   // ── soundtrack lifecycle ────────────────────────────────────────────────
   // Tied to the OPEN signal, not to this component's mount: Shell mounts the
   // component for the whole session, so an onMount-scoped context would be
@@ -69,7 +82,13 @@ const CreditsModal: Component = () => {
     // `untrack`: the initial mute state is an INPUT to construction, not a
     // dependency of it. Tracked, a mute toggle would re-run this effect for
     // nothing — the separate effect below is what carries a live toggle.
-    arpeggio = startCreditsArpeggio(new Ctor(), untrack(creditsMuted));
+    //
+    // #1920 — the third argument is what makes the soundtrack turn over when
+    // the titles come back round. It is a THUNK read from the scheduler's own
+    // pump, not a signal: the roll's pass lives in the CSS animation, which
+    // Solid cannot observe, and polling it into a signal would be the second
+    // clock `creditsRain` was careful not to introduce.
+    arpeggio = startCreditsArpeggio(new Ctor(), untrack(creditsMuted), () => creditsRollPass(roll));
   });
 
   createEffect(() => {
@@ -83,14 +102,6 @@ const CreditsModal: Component = () => {
 
   const versionLabel = (): string => bootBundleVersionAccessor() ?? "version unknown";
   const dateLabel = (): string | null => creditsDateLabel(credits.date);
-
-  // #1807 — the roll's own animation is the ONLY clock. `MatrixRain` calls
-  // `look` once per drawn frame from inside the loop it already runs, and
-  // `creditsRainLook` answers by reading this element's animation phase, so
-  // the burst can never drift away from the interlude it belongs to. Assigned
-  // during element creation, which is before any `onMount` — including the
-  // one that starts the rain — so the loop never sees it unset.
-  let roll: HTMLDivElement | undefined;
 
   return (
     <Show when={creditsModalOpen()}>

--- a/cicchetto/src/__tests__/creditsAudio.test.ts
+++ b/cicchetto/src/__tests__/creditsAudio.test.ts
@@ -4,6 +4,7 @@ import {
   BAR_S,
   type CreditsEvent,
   creditsBar,
+  MOVEMENT_COUNT,
   PEAK_GAIN,
   PHRASE_S,
   startCreditsArpeggio,
@@ -53,8 +54,14 @@ type StubOscillator = {
   disconnect: ReturnType<typeof vi.fn>;
   start: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
+  setPeriodicWave: ReturnType<typeof vi.fn>;
+  /** The wave this oscillator was given, or `null` while it is a `type`. */
+  wave: StubWave | null;
   onended: (() => void) | null;
 };
+
+/** What `createPeriodicWave` hands back — the coefficients, kept for #1920. */
+type StubWave = { real: Float32Array; imag: Float32Array };
 
 type StubBufferSource = {
   buffer: unknown;
@@ -74,13 +81,26 @@ function stubParam(): StubParam {
   };
 }
 
-function makeCtx() {
+/**
+ * @param periodicWaves whether this engine can build a `PeriodicWave` at all.
+ *   `false` is a real browser (and jsdom, and a context that refuses), and the
+ *   pulse widths #1920 added have to degrade to the square rather than to
+ *   silence there.
+ */
+function makeCtx(periodicWaves = true) {
   const oscillators: StubOscillator[] = [];
   const bufferSources: StubBufferSource[] = [];
   const gains: { gain: StubParam; connect: ReturnType<typeof vi.fn> }[] = [];
+  const waves: StubWave[] = [];
   const close = vi.fn();
   const resume = vi.fn();
   const startedAt = Date.now();
+
+  const createPeriodicWave = (real: Float32Array, imag: Float32Array): StubWave => {
+    const wave: StubWave = { real, imag };
+    waves.push(wave);
+    return wave;
+  };
 
   const ctx = {
     // Seconds since this context was made, off the faked `Date` — see the
@@ -107,6 +127,15 @@ function makeCtx() {
         disconnect: vi.fn(),
         start: vi.fn(),
         stop: vi.fn(),
+        setPeriodicWave: vi.fn((wave: StubWave) => {
+          // A real oscillator reports `"custom"` once a wave is set, and the
+          // timbre assertions below read `type` — so the stub has to do the
+          // same or a periodic-wave voice would still look like whatever it
+          // was constructed as.
+          node.type = "custom";
+          node.wave = wave;
+        }),
+        wave: null,
         onended: null,
       };
       oscillators.push(node);
@@ -127,9 +156,18 @@ function makeCtx() {
       bufferSources.push(node);
       return node;
     },
+    ...(periodicWaves ? { createPeriodicWave } : {}),
   };
 
-  return { ctx: ctx as unknown as AudioContext, oscillators, bufferSources, gains, close, resume };
+  return {
+    ctx: ctx as unknown as AudioContext,
+    oscillators,
+    bufferSources,
+    gains,
+    waves,
+    close,
+    resume,
+  };
 }
 
 /** How many lead notes one bar carries — read off the score, never hardcoded. */
@@ -358,19 +396,28 @@ describe("the credits phrase (#1916)", () => {
     // float ULP. Measured before that was fixed — the bound read 2.61 instead
     // of 1.41, i.e. it counted two leads and two basses that were, in reality,
     // 10⁻¹⁵ s apart.
-    const timeline: CreditsEvent[] = [];
-    for (let bar = 0; bar < BAR_COUNT * 2; bar += 1) {
-      for (const event of creditsBar(bar)) {
-        timeline.push({ ...event, at: bar * BAR_S + event.at });
+    // #1920 — measured across EVERY movement, not just the opening one. The
+    // suite spends its headroom differently per movement (a harmony line in
+    // two of them, sixteenths in a third), so "the arrangement is under the
+    // ceiling" is a claim about the loudest movement and nothing less.
+    const worstOf = (movement: number): number => {
+      const timeline: CreditsEvent[] = [];
+      for (let bar = 0; bar < BAR_COUNT * 2; bar += 1) {
+        for (const event of creditsBar(bar, movement)) {
+          timeline.push({ ...event, at: bar * BAR_S + event.at });
+        }
       }
-    }
+      return Math.max(
+        ...timeline.map((anchor) =>
+          timeline
+            .filter((event) => event.at <= anchor.at && anchor.at < event.at + event.decayS)
+            .reduce((sum, event) => sum + event.peak, 0),
+        ),
+      );
+    };
 
     const worstInstant = Math.max(
-      ...timeline.map((anchor) =>
-        timeline
-          .filter((event) => event.at <= anchor.at && anchor.at < event.at + event.decayS)
-          .reduce((sum, event) => sum + event.peak, 0),
-      ),
+      ...Array.from({ length: MOVEMENT_COUNT }, (_unused, m) => worstOf(m)),
     );
 
     // The positive control. A single voice, or an arrangement whose voices
@@ -401,5 +448,218 @@ describe("the credits phrase (#1916)", () => {
     vi.advanceTimersByTime(250);
 
     expect(oscillators.length).toBeLessThanOrEqual(oneBar * 2);
+  });
+});
+
+describe("the credits suite (#1920)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  /** Every event of one whole movement, laid on a single timeline. */
+  const movementEvents = (movement: number): CreditsEvent[] => {
+    const out: CreditsEvent[] = [];
+    for (let bar = 0; bar < BAR_COUNT; bar += 1) {
+      for (const event of creditsBar(bar, movement)) {
+        out.push({ ...event, at: bar * BAR_S + event.at });
+      }
+    }
+    return out;
+  };
+
+  const voicesOf = (movement: number): Set<string> =>
+    new Set(movementEvents(movement).map((event) => event.voice));
+
+  it("is several movements long, and each one is its own music", () => {
+    // The complaint is "the second pass sounds exactly like the first", so
+    // what has to be proven is that the passes DIFFER. Proven on the score
+    // rather than on a frequency list: rewriting a movement costs nothing
+    // here, deleting the variety costs a red test.
+    expect(MOVEMENT_COUNT).toBeGreaterThan(1);
+
+    const shapes = new Set(
+      Array.from({ length: MOVEMENT_COUNT }, (_unused, m) =>
+        JSON.stringify(movementEvents(m).map((e) => [e.voice, e.hz, e.at, e.duty])),
+      ),
+    );
+    expect(shapes.size).toBe(MOVEMENT_COUNT);
+
+    // ...and the suite wraps rather than running out.
+    expect(creditsBar(0, MOVEMENT_COUNT)).toEqual(creditsBar(0));
+  });
+
+  it("keeps every movement the same number of bars", () => {
+    // `BAR_COUNT` and `PHRASE_S` are exported as if they described the whole
+    // suite. They do — but only while the movements agree, and a movement that
+    // ran long would be heard truncated at the roll's cycle anyway.
+    for (let m = 0; m < MOVEMENT_COUNT; m += 1) {
+      expect(creditsBar(BAR_COUNT, m)).toEqual(creditsBar(0, m));
+    }
+  });
+
+  it("carries more voices than the lead-bass-drums #1916 shipped", () => {
+    // "più voci" was the ask. The union across the suite must be strictly
+    // bigger than what one movement carries, or the extra channels are
+    // declared and never sounded.
+    const union = new Set<string>();
+    for (let m = 0; m < MOVEMENT_COUNT; m += 1) {
+      for (const voice of voicesOf(m)) union.add(voice);
+    }
+    expect(union).toContain("lead");
+    expect(union).toContain("bass");
+    expect(union).toContain("harmony");
+    expect(union).toContain("arp");
+    expect(union.size).toBeGreaterThan(voicesOf(0).size);
+  });
+
+  it("never sounds the harmony and the arpeggio at once — they are ONE channel", () => {
+    // The chip model is the reason the two are mutually exclusive rather than
+    // both playing: a second pulse channel can do one or the other. A movement
+    // carrying both would sound fuller and be a lie about the instrument, and
+    // it would also blow the gain budget the loudness test measures.
+    for (let m = 0; m < MOVEMENT_COUNT; m += 1) {
+      const voices = voicesOf(m);
+      expect(voices.has("harmony") && voices.has("arp")).toBe(false);
+    }
+  });
+
+  it("keeps the harmony under the lead, in key, at every step", () => {
+    // A "harmony" derived by transposing blindly would be in the right place
+    // and the wrong key. Every harmony note must be a chord tone below the
+    // lead note sounding at the same instant — the pitch-class check is what
+    // says "in key", the comparison is what says "underneath".
+    for (let m = 0; m < MOVEMENT_COUNT; m += 1) {
+      const events = movementEvents(m);
+      const harmonies = events.filter((e) => e.voice === "harmony");
+      for (const harmony of harmonies) {
+        const lead = events.find((e) => e.voice === "lead" && e.at === harmony.at);
+        expect(lead?.hz).toBeDefined();
+        expect(harmony.hz ?? 0).toBeLessThan(lead?.hz ?? 0);
+      }
+    }
+  });
+
+  it("follows the roll: the movement turns over when the titles come back round", () => {
+    // THE thing #1920 exists for. The scheduler could walk a perfect suite
+    // while ignoring the accessor entirely, and every assertion above would
+    // still be green.
+    let pass = 0;
+    const { ctx, oscillators } = makeCtx();
+    startCreditsArpeggio(ctx, false, () => pass);
+
+    vi.advanceTimersByTime(PHRASE_S * 1000);
+    const opening = oscillators.map((osc) => osc.frequency.value);
+    expect(opening.length).toBeGreaterThan(0);
+
+    // The roll wraps. The next bar armed must come from movement one.
+    pass = 1;
+    const beforeSwitch = oscillators.length;
+    vi.advanceTimersByTime(BAR_S * 2 * 1000);
+    const after = oscillators.slice(beforeSwitch).map((osc) => osc.frequency.value);
+
+    expect(after.length).toBeGreaterThan(0);
+    // Not "some note differs": the whole bar has to be a bar the opening
+    // movement never plays, which is what a progression change means.
+    const openingBars = Array.from({ length: BAR_COUNT }, (_unused, b) =>
+      JSON.stringify(creditsBar(b, 0).map((e) => e.hz)),
+    );
+    const armed = JSON.stringify(creditsBar(0, 1).map((e) => e.hz));
+    expect(openingBars).not.toContain(armed);
+    expect(after.some((hz) => !opening.includes(hz))).toBe(true);
+  });
+
+  it("re-enters the new movement at its FIRST bar, not wherever the old one was", () => {
+    // Otherwise the turn-over lands mid-phrase and reads as a glitch rather
+    // than as a new movement. `creditsBar(0, 1)`'s lead is the tell.
+    let pass = 0;
+    const { ctx, oscillators } = makeCtx();
+    startCreditsArpeggio(ctx, false, () => pass);
+
+    // Three bars into the opening movement, so "bar 0" cannot be a coincidence.
+    vi.advanceTimersByTime(BAR_S * 3 * 1000);
+    pass = 1;
+    const mark = oscillators.length;
+    vi.advanceTimersByTime(BAR_S * 1000);
+
+    const armedLead = oscillators
+      .slice(mark)
+      .filter((osc) => osc.type === "custom" || osc.type === "square")
+      .map((osc) => osc.frequency.value);
+    const wanted = creditsBar(0, 1)
+      .filter((e) => e.voice === "lead")
+      .map((e) => e.hz ?? 0);
+
+    for (const hz of wanted) expect(armedLead).toContain(hz);
+  });
+
+  it("survives an accessor that throws or answers with nonsense", () => {
+    // The accessor reaches into the DOM for an animation that may not be
+    // there. A throw inside the pump would kill the timer and take the whole
+    // soundtrack with it, silently — and NaN would index no movement at all.
+    const { ctx, oscillators } = makeCtx();
+    startCreditsArpeggio(ctx, false, () => {
+      throw new Error("no animation");
+    });
+    vi.advanceTimersByTime(BAR_S * 2 * 1000);
+    expect(oscillators.length).toBeGreaterThan(0);
+
+    const nonsense = makeCtx();
+    startCreditsArpeggio(nonsense.ctx, false, () => Number.NaN);
+    vi.advanceTimersByTime(BAR_S * 2 * 1000);
+    expect(nonsense.oscillators.length).toBeGreaterThan(0);
+    expect(nonsense.oscillators.every((osc) => Number.isFinite(osc.frequency.value))).toBe(true);
+  });
+
+  it("renders the narrow pulse widths as periodic waves", () => {
+    // "più chiptune" is mostly this: a 25% or 12.5% pulse is what hardware
+    // sounds like, and `OscillatorNode` has no such type. Sampled at a pass
+    // that uses one, so a suite that declared widths and never built a wave
+    // fails here.
+    let pass = 0;
+    const { ctx, oscillators, waves } = makeCtx();
+    startCreditsArpeggio(ctx, false, () => pass);
+    pass = 1;
+    vi.advanceTimersByTime(BAR_S * 2 * 1000);
+
+    expect(waves.length).toBeGreaterThan(0);
+    expect(oscillators.some((osc) => osc.type === "custom")).toBe(true);
+
+    // Built ONCE per width and shared: a wave per note would be hundreds of
+    // identical immutable objects a minute.
+    const distinct = new Set(oscillators.filter((o) => o.wave !== null).map((o) => o.wave));
+    expect(distinct.size).toBeLessThanOrEqual(waves.length);
+    expect(waves.length).toBeLessThanOrEqual(4);
+  });
+
+  it("leaves the opening movement on the built-in square", () => {
+    // Movement one is #1916's phrase and #1916's timbre, deliberately: the
+    // first pass of the titles is the one everybody sees, and a 50% pulse
+    // rebuilt from 24 harmonics is a ringing approximation of a wave the
+    // engine already has exactly.
+    const { ctx, oscillators, waves } = makeCtx();
+    startCreditsArpeggio(ctx, false);
+    vi.advanceTimersByTime(BAR_S * 2 * 1000);
+
+    expect(waves.length).toBe(0);
+    expect(new Set(oscillators.map((osc) => osc.type))).toEqual(new Set(["square", "triangle"]));
+  });
+
+  it("falls back to the square when the engine cannot build a wave", () => {
+    // An engine with no `createPeriodicWave` (and a context that refuses one)
+    // must lose the WIDTH, not the note. Silence here would be a movement that
+    // simply stops playing on older Safari.
+    let pass = 0;
+    const { ctx, oscillators } = makeCtx(false);
+    startCreditsArpeggio(ctx, false, () => pass);
+    pass = 2;
+    vi.advanceTimersByTime(BAR_S * 2 * 1000);
+
+    expect(oscillators.length).toBeGreaterThan(0);
+    expect(oscillators.every((osc) => osc.type === "square" || osc.type === "triangle")).toBe(true);
   });
 });

--- a/cicchetto/src/__tests__/creditsRain.test.ts
+++ b/cicchetto/src/__tests__/creditsRain.test.ts
@@ -6,7 +6,7 @@ import {
   creditsRainLook,
   rollIsParked,
 } from "../lib/creditsRain";
-import { ruleBody, themeCss } from "./helpers/themeCss";
+import { mediaGatedBlocks, ruleBody, themeCss } from "./helpers/themeCss";
 
 // #1807 — the credits rain reads as rain, and the burst rides the roll's own
 // clock.
@@ -158,13 +158,51 @@ describe("credits roll timing (#1807 — the stylesheet owns the interlude)", ()
     expect(interlude).toBeLessThanOrEqual(7);
   });
 
-  it("holds it OFF-SCREEN, and re-enters from the bottom", () => {
+  it("holds it OFF-SCREEN, and re-enters from the bottom EDGE", () => {
     // Not a pause mid-list: the parked transform is the one that has the roll
-    // fully above the fold, and the cycle restarts from fully below it — the
-    // same entrance as the first pass.
+    // fully above the fold, and the cycle restarts from below the bottom of
+    // the WINDOW — the same entrance as the first pass.
+    //
+    // #1920: this test used to pin `translateY(100%)` here while its own name
+    // claimed "from the bottom", and the two disagreed. A percentage translate
+    // resolves against the element's own border box, so 100% parks the roll's
+    // top edge at its own height — below the fold only for a roll TALLER than
+    // the window. With nine contributors it is a few hundred px against a
+    // ~1000px viewport, so every cycle began with the titles already halfway
+    // up the screen (vjt, #grappa: "riappaiono in mezzo allo schermo").
+    //
+    // So the assertion is on the UNIT, not on a number: the entrance has to be
+    // viewport-relative or the defect is back, and no roll height can make a
+    // `%` entrance correct on every window.
     const all = stops();
-    expect(all[0]?.transform).toBe("translateY(100%)");
+    expect(all[0]?.transform).toMatch(/^translateY\(100d?vh\)$/);
     expect(all.at(-1)?.transform).toBe("translateY(-100%)");
+  });
+
+  it("keeps the exit self-relative, because clearing the top is about the ROLL", () => {
+    // The asymmetry is deliberate and worth a test of its own, since it reads
+    // like an oversight: the roll leaves when it has travelled its OWN height
+    // past the top edge, which is a fact about the roll, while it arrives from
+    // the window's bottom, which is a fact about the window. Swapping either
+    // for the other's unit breaks a different size of roll.
+    const all = stops();
+    const exits = all.filter((stop) => stop.transform.includes("-100%"));
+    expect(exits.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("carries a vh fallback for engines with no dynamic-viewport units", () => {
+    // #205's posture, applied to the roll: biome forbids the classic
+    // `transform: translateY(100vh); transform: translateY(100dvh)` duplicate,
+    // so the fallback is a whole re-declaration of the animation under
+    // `@supports not (height: 100dvh)`. Without it, Safari < 15.4 drops the
+    // 0% stop entirely and the roll starts at translate zero — which is
+    // mid-screen, i.e. exactly the bug this issue closed.
+    const fallback = mediaGatedBlocks(
+      /@supports\s*not\s*\(\s*height\s*:\s*100dvh\s*\)\s*\{/g,
+      "@supports not (height: 100dvh)",
+    ).find((block) => block.includes("@keyframes credits-roll"));
+    expect(fallback, "no dvh fallback for @keyframes credits-roll").toBeDefined();
+    expect(fallback).toMatch(/transform:\s*translateY\(100vh\)/);
   });
 
   it("did not slow the titles down to buy the interlude", () => {

--- a/cicchetto/src/__tests__/creditsRoll.test.ts
+++ b/cicchetto/src/__tests__/creditsRoll.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { creditsRollPass } from "../lib/creditsRoll";
+
+// #1920 — the suite's cursor: which pass of the credit roll is on screen.
+//
+// jsdom runs no animation, so this is exercised against a fake
+// `getAnimations` exactly as `creditsRain.test.ts` exercises the phase reader.
+// What that leaves unproven is the same thing it leaves unproven there — that
+// a REAL `credits-roll` exposes `currentIteration` — and it is unproven for a
+// good reason: it is a Web Animations API guarantee, not ours.
+//
+// What IS worth pinning here is the degradation. Every fallback below is a
+// live case (before mount, reduced motion, jsdom), and each one must answer
+// "first pass" rather than throw: an easter egg that crashes the audio
+// scheduler because it could not read an animation is worse than one whose
+// music does not change.
+
+/** An element answering `getAnimations()` the way a running roll would. */
+function fakeRoll(currentIteration: number | null): HTMLElement {
+  return {
+    getAnimations: () => [{ effect: { getComputedTiming: () => ({ currentIteration }) } }],
+  } as unknown as HTMLElement;
+}
+
+describe("creditsRollPass (#1920)", () => {
+  it("counts the completed cycles of the roll", () => {
+    expect(creditsRollPass(fakeRoll(0))).toBe(0);
+    expect(creditsRollPass(fakeRoll(1))).toBe(1);
+    expect(creditsRollPass(fakeRoll(7))).toBe(7);
+  });
+
+  it("floors a partial iteration to the pass it is inside", () => {
+    // `currentIteration` is an integer per spec, but `getComputedTiming` is
+    // free to hand back a float on an effect with a non-integer iteration
+    // count, and a fractional movement index would wrap to a different
+    // movement halfway through a bar.
+    expect(creditsRollPass(fakeRoll(2.99))).toBe(2);
+  });
+
+  it("stays on the first pass when there is no animation to read", () => {
+    // Three real cases, one answer: before the roll mounts, under
+    // `prefers-reduced-motion` (where the roll is a plain scrollable column
+    // with no animation at all), and in jsdom.
+    expect(creditsRollPass(undefined)).toBe(0);
+    expect(creditsRollPass({ getAnimations: () => [] } as unknown as HTMLElement)).toBe(0);
+    expect(creditsRollPass(document.createElement("div"))).toBe(0);
+  });
+
+  it("stays on the first pass rather than passing a non-number through", () => {
+    // `currentIteration` is null before the animation starts playing. Handed
+    // on unguarded it would reach the scheduler's modulo and come back NaN,
+    // which indexes no movement at all — a silent soundtrack from a
+    // millisecond of timing.
+    expect(creditsRollPass(fakeRoll(null))).toBe(0);
+    expect(creditsRollPass(fakeRoll(Number.POSITIVE_INFINITY))).toBe(0);
+    expect(creditsRollPass(fakeRoll(Number.NaN))).toBe(0);
+    expect(creditsRollPass(fakeRoll(-1))).toBe(0);
+  });
+});

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -184,6 +184,11 @@ export function nestedRuleBodies(selector: string): string[] {
  * for `(pointer: coarse)` (CLAUDE.md "implement once, reuse everywhere") — a
  * second copy of the depth counter is a second place to get an unbalanced
  * sheet wrong.
+ *
+ * The scan is brace-matching and knows nothing about `@media`, so `opener` may
+ * be ANY at-rule prelude — #1920 reads `@supports not (height: 100dvh)` with
+ * it, which is the only way to reach an `@keyframes` nested inside a gate
+ * (`nestedRuleBodies`' `[^{}]` classes cannot span the inner block).
  */
 export function mediaGatedBlocks(opener: RegExp, label: string): string[] {
   if (!opener.global) {

--- a/cicchetto/src/lib/creditsAudio.ts
+++ b/cicchetto/src/lib/creditsAudio.ts
@@ -25,22 +25,42 @@
 // #1916 — the arrangement, and why it is DATA. What shipped in #1773 was one
 // 1.92 s bar (eight triangle notes over a static A2 sine) re-armed verbatim
 // for as long as the modal stayed open, which reads as a ringtone rather than
-// a soundtrack. Four things changed, all inside the same contract above:
+// a soundtrack. The phrase became a `bars` ARRAY walked in order (Am → F → C →
+// G), the lead became a `square` with the triangle demoted to a MOVING bass
+// line, one noise channel took the backbeat, and bars went on a LOOKAHEAD
+// cursor rather than being re-based on `ctx.currentTime` at every re-arm.
 //
-//  - The phrase is a `BARS` ARRAY walked in order (Am → F → C → G), so the
-//    loop point is PHRASE_S out rather than one bar. Lengthening it is adding
-//    entries to that array — no code moves. Four bars is an assumption, not a
-//    ruling; see the PR and DESIGN_NOTES.
-//  - The lead is a `square` and the triangle is demoted to a bass line that
-//    MOVES with the chord, replacing the drone. That swap is most of what
-//    makes a chiptune sound like a chiptune.
-//  - One noise channel for percussion, and only one: a snare REPLACES the hat
-//    on the backbeat instead of sounding over it, which is both how a
-//    two-pulse-plus-noise chip actually behaves and what keeps the mix peak
-//    inside the pre-#1916 budget (see PEAK_GAIN).
-//  - Bars are placed on a LOOKAHEAD cursor (`nextBarAt`) rather than re-based
-//    on `ctx.currentTime` at every re-arm, so timer jitter no longer smears
-//    the phrase. See `pump` for the one hazard that introduces.
+// #1920 — the phrase becomes a SUITE, and the roll picks the movement.
+//
+// #1916's four bars still repeated verbatim for as long as the modal stayed
+// open — about four and a half times per 34 s roll cycle, and identically on
+// every cycle, so the second pass of the titles sounded exactly like the
+// first. vjt asked for the music to TURN OVER when the titles come back round,
+// and for more of it: "più variegata più chiptune più voci".
+//
+// Three changes, all inside the contract above:
+//
+//  - `MOVEMENTS` replaces `BARS`. Each movement carries its own progression,
+//    its own pulse WIDTH, its own drum pattern, and its own second-channel
+//    duty (a harmony line, an arpeggio, or nothing). Adding a movement is
+//    adding an entry to that array.
+//  - The movement is chosen by `movementAt()`, which the modal wires to the
+//    roll's own animation (`creditsRoll.creditsRollPass`) — ONE CLOCK, the
+//    same doctrine `creditsRain.rollIsParked` follows. The switch lands on a
+//    BAR boundary because the pump only ever arms whole bars.
+//  - The channel model is now the four an NES actually has: two pulses, one
+//    triangle, one noise. That constraint is the reason `harmony` and `arp`
+//    are mutually exclusive per movement rather than both playing — they are
+//    the SAME channel, and a chip that could sound both would not be a chip.
+//    The pulse width is a `PeriodicWave` (25% and 12.5% duties), which is the
+//    single change that most makes this sound like hardware rather than like
+//    an oscillator; 50% stays the built-in `square`, so movement one is
+//    bit-for-bit the timbre #1916 shipped.
+//
+// The gain budget did NOT move: `PEAK_GAIN` is unchanged and the per-voice
+// peaks below were re-cut so that the worst instant of the busiest movement
+// still lands under the pre-#1916 ceiling. `creditsAudio.test.ts` measures
+// that across every movement rather than trusting this paragraph.
 
 /** A running soundtrack. Both verbs are idempotent. */
 export type CreditsArpeggio = {
@@ -76,11 +96,64 @@ type Octave = "1" | "2" | "3" | "4" | "5" | "6";
 /** Scientific pitch notation — `A2`, `C#5`. */
 type Note = `${PitchClass}${Octave}`;
 
-/** Equal temperament off A4 = 440 Hz (MIDI 69). `A2` → 110, `C4` → 261.63. */
-function hzOf(note: Note): number {
+/** MIDI note number. `A4` → 69, `C4` → 60. */
+function midiOf(note: Note): number {
   const octave = Number(note.slice(-1));
   const pitchClass = note.slice(0, -1) as PitchClass;
-  return 440 * 2 ** (((octave + 1) * 12 + SEMITONE[pitchClass] - 69) / 12);
+  return (octave + 1) * 12 + SEMITONE[pitchClass];
+}
+
+/** Equal temperament off A4 = 440 Hz (MIDI 69). */
+function hzOfMidi(midi: number): number {
+  return 440 * 2 ** ((midi - 69) / 12);
+}
+
+function hzOf(note: Note): number {
+  return hzOfMidi(midiOf(note));
+}
+
+const PITCH_CLASS_COUNT = 12;
+
+function pitchClassOf(midi: number): number {
+  return ((midi % PITCH_CLASS_COUNT) + PITCH_CLASS_COUNT) % PITCH_CLASS_COUNT;
+}
+
+/**
+ * The nearest note BELOW `midi` that belongs to `chord`, or `null` if the
+ * chord has no member in the octave underneath.
+ *
+ * This is how the harmony line is derived rather than written out: the lead
+ * already walks chord tones, so "the chord tone below" tracks it in thirds and
+ * fourths that are in key by construction. Writing a second `Eight<Note>` per
+ * bar would be the same information typed twice, and the copy that drifts is
+ * always the one nobody hums.
+ */
+function chordToneBelow(midi: number, chord: Chord): number | null {
+  // Widened to `number[]` on purpose: `SEMITONE`'s values are a literal union,
+  // and an array of it would make `includes` reject the computed pitch class
+  // this asks about.
+  const classes: number[] = chord.map((name) => SEMITONE[name]);
+  for (let candidate = midi - 1; candidate >= midi - PITCH_CLASS_COUNT; candidate -= 1) {
+    if (classes.includes(pitchClassOf(candidate))) return candidate;
+  }
+  return null;
+}
+
+/**
+ * The chord spelled upward from `root` in `octave`: root, third, fifth, root
+ * again an octave up. Each tone is the next occurrence ABOVE the previous one,
+ * so a chord whose third is a lower pitch class than its root (A minor: A, C,
+ * E) still comes out ascending.
+ */
+function arpeggioFrom(chord: Chord, octave: number): number[] {
+  const notes: number[] = [midiOf(`${chord[0]}${octave}` as Note)];
+  for (let i = 1; i <= chord.length; i += 1) {
+    const wanted = SEMITONE[chord[i % chord.length] as PitchClass];
+    let next = (notes[notes.length - 1] ?? 0) + 1;
+    while (pitchClassOf(next) !== wanted) next += 1;
+    notes.push(next);
+  }
+  return notes;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,44 +162,207 @@ function hzOf(note: Note): number {
 
 type Eight<T> = readonly [T, T, T, T, T, T, T, T];
 type Four<T> = readonly [T, T, T, T];
+/** Root, third, fifth. The second channel is derived from this, not written. */
+type Chord = readonly [PitchClass, PitchClass, PitchClass];
 
 /** One bar: eight eighth-notes of lead over four quarter-notes of bass. */
 type Bar = {
   readonly lead: Eight<Note>;
   readonly bass: Four<Note>;
+  readonly chord: Chord;
 };
-
-// Am → F → C → G, the i–VI–III–VII everyone already knows, which is the point:
-// the roll is a joke and the tune should land as one. Each lead bar walks the
-// chord up, back down, and exits on a step towards the next chord's root. The
-// bass is root · root · fifth · root, staying inside 87–165 Hz so it sits
-// under the lead instead of fighting it.
-//
-// Adding bars five to eight is adding entries HERE. Nothing below counts to
-// four.
-const BARS: readonly [Bar, ...Bar[]] = [
-  { lead: ["A4", "C5", "E5", "A5", "E5", "C5", "A4", "B4"], bass: ["A2", "A2", "E3", "A2"] },
-  { lead: ["F4", "A4", "C5", "F5", "C5", "A4", "F4", "G4"], bass: ["F2", "F2", "C3", "F2"] },
-  { lead: ["E4", "G4", "C5", "E5", "C5", "G4", "E4", "F4"], bass: ["C3", "C3", "G2", "C3"] },
-  { lead: ["D4", "G4", "B4", "D5", "B4", "G4", "D4", "E4"], bass: ["G2", "G2", "D3", "G2"] },
-];
 
 type Drum = "hat" | "snare";
 
-// ONE noise channel, so the backbeat snare takes the hat's slot rather than
-// stacking on it — see the header. Indices 2 and 6 are beats 2 and 4.
-const DRUMS: Eight<Drum | null> = ["hat", "hat", "snare", "hat", "hat", "hat", "snare", "hat"];
+/**
+ * What the second pulse channel does in a movement. `"harmony"` shadows the
+ * lead a chord tone below; `"arp"` runs sixteenths up the chord; `"none"`
+ * leaves the channel silent, which is what movement one shipped with.
+ *
+ * The three are mutually exclusive because they are ONE channel — see the
+ * header. This is the type that says so.
+ */
+type SecondChannel = "none" | "harmony" | "arp";
+
+type Movement = {
+  /** Names the movement in the score; not user-visible. */
+  readonly name: string;
+  readonly bars: readonly [Bar, ...Bar[]];
+  /**
+   * Pulse width of the LEAD channel. `0.5` is a plain square (the built-in
+   * type); anything else is rendered with a `PeriodicWave`.
+   */
+  readonly duty: number;
+  readonly second: SecondChannel;
+  /** Pulse width of the second channel, when it plays. */
+  readonly secondDuty: number;
+  readonly drums: Eight<Drum | null>;
+};
+
+// The suite. Four movements of four bars, all in A minor's orbit so the seams
+// are steps rather than key changes: the roll is a joke and the tune should
+// land as one, four times over.
+//
+// Movement one is #1916's phrase, note for note and timbre for timbre, and
+// that is deliberate — the first pass of the titles is the one everybody sees,
+// and #1920 is not a reason to relitigate a tune nobody complained about.
+// The variation is what happens on passes two, three and four.
+//
+// Each lead bar walks its chord up, back down, and exits on a step towards the
+// next chord's root. Every bass line stays inside 87–165 Hz so it sits under
+// the lead instead of fighting it.
+const MOVEMENTS: readonly [Movement, ...Movement[]] = [
+  {
+    // Pass one: Am → F → C → G, the i–VI–III–VII everyone already knows.
+    name: "opening",
+    duty: 0.5,
+    second: "none",
+    secondDuty: 0.25,
+    drums: ["hat", "hat", "snare", "hat", "hat", "hat", "snare", "hat"],
+    bars: [
+      {
+        lead: ["A4", "C5", "E5", "A5", "E5", "C5", "A4", "B4"],
+        bass: ["A2", "A2", "E3", "A2"],
+        chord: ["A", "C", "E"],
+      },
+      {
+        lead: ["F4", "A4", "C5", "F5", "C5", "A4", "F4", "G4"],
+        bass: ["F2", "F2", "C3", "F2"],
+        chord: ["F", "A", "C"],
+      },
+      {
+        lead: ["E4", "G4", "C5", "E5", "C5", "G4", "E4", "F4"],
+        bass: ["C3", "C3", "G2", "C3"],
+        chord: ["C", "E", "G"],
+      },
+      {
+        lead: ["D4", "G4", "B4", "D5", "B4", "G4", "D4", "E4"],
+        bass: ["G2", "G2", "D3", "G2"],
+        chord: ["G", "B", "D"],
+      },
+    ],
+  },
+  {
+    // Pass two: down a fourth into Dm → B♭ → F → C, the second pulse comes in
+    // underneath the lead, and the width narrows to 25% — the nasal one.
+    name: "harmony",
+    duty: 0.25,
+    second: "harmony",
+    secondDuty: 0.25,
+    drums: ["hat", null, "snare", "hat", "hat", null, "snare", "hat"],
+    bars: [
+      {
+        lead: ["D4", "F4", "A4", "D5", "A4", "F4", "D4", "E4"],
+        bass: ["D3", "D3", "A2", "D3"],
+        chord: ["D", "F", "A"],
+      },
+      {
+        lead: ["A#4", "D5", "F5", "A#5", "F5", "D5", "A#4", "C5"],
+        bass: ["A#2", "A#2", "F2", "A#2"],
+        chord: ["A#", "D", "F"],
+      },
+      {
+        lead: ["F4", "A4", "C5", "F5", "C5", "A4", "F4", "G4"],
+        bass: ["F2", "F2", "C3", "F2"],
+        chord: ["F", "A", "C"],
+      },
+      {
+        lead: ["E4", "G4", "C5", "E5", "C5", "G4", "E4", "D4"],
+        bass: ["C3", "C3", "G2", "C3"],
+        chord: ["C", "E", "G"],
+      },
+    ],
+  },
+  {
+    // Pass three: the Andalusian descent Am → G → F → E, half-time drums, and
+    // the second channel switches from a harmony to sixteenths at 12.5% —
+    // the thinnest width, which is what makes a chip arpeggio glitter rather
+    // than thicken.
+    name: "descent",
+    duty: 0.125,
+    second: "arp",
+    secondDuty: 0.125,
+    drums: ["hat", null, null, null, "snare", null, null, "hat"],
+    bars: [
+      {
+        lead: ["A4", "C5", "E5", "A5", "E5", "C5", "A4", "G4"],
+        bass: ["A2", "A2", "E3", "A2"],
+        chord: ["A", "C", "E"],
+      },
+      {
+        lead: ["G4", "B4", "D5", "G5", "D5", "B4", "G4", "F4"],
+        bass: ["G2", "G2", "D3", "G2"],
+        chord: ["G", "B", "D"],
+      },
+      {
+        lead: ["F4", "A4", "C5", "F5", "C5", "A4", "F4", "E4"],
+        bass: ["F2", "F2", "C3", "F2"],
+        chord: ["F", "A", "C"],
+      },
+      {
+        // The V of a minor key wants its major third: G#, not G. That one
+        // accidental is the whole reason this progression sounds like an
+        // ending rather than like a loop.
+        lead: ["E4", "G#4", "B4", "E5", "B4", "G#4", "E4", "A4"],
+        bass: ["E3", "E3", "B2", "E3"],
+        chord: ["E", "G#", "B"],
+      },
+    ],
+  },
+  {
+    // Pass four: C → G → Am → F, the major-key turn, harmony back on, hats on
+    // every eighth and a snare on three as well as on two and four. The lead
+    // sits an octave up from where it started the suite: this is the one that
+    // is allowed to be loud, and then it wraps back to "opening".
+    name: "finale",
+    duty: 0.25,
+    second: "harmony",
+    secondDuty: 0.5,
+    drums: ["hat", "hat", "snare", "hat", "snare", "hat", "snare", "hat"],
+    bars: [
+      {
+        lead: ["G4", "C5", "E5", "G5", "E5", "C5", "G4", "A4"],
+        bass: ["C3", "C3", "G2", "C3"],
+        chord: ["C", "E", "G"],
+      },
+      {
+        lead: ["B4", "D5", "G5", "B5", "G5", "D5", "B4", "A4"],
+        bass: ["G2", "G2", "D3", "G2"],
+        chord: ["G", "B", "D"],
+      },
+      {
+        lead: ["A4", "C5", "E5", "A5", "E5", "C5", "A4", "B4"],
+        bass: ["A2", "A2", "E3", "A2"],
+        chord: ["A", "C", "E"],
+      },
+      {
+        lead: ["A4", "C5", "F5", "A5", "F5", "C5", "A4", "G4"],
+        bass: ["F2", "F2", "C3", "F2"],
+        chord: ["F", "A", "C"],
+      },
+    ],
+  },
+];
 
 /** One eighth note. 0.24 s ⇒ 125 BPM, unchanged from #1773. */
 const STEP_S = 0.24;
 /** Bar length, in seconds. */
 export const BAR_S = 8 * STEP_S;
-/** How many bars before the phrase repeats. */
-export const BAR_COUNT = BARS.length;
-/** How long the whole phrase runs before it loops. THE number #1916 asked for. */
+/** How many movements the suite walks before it wraps back to the first. */
+export const MOVEMENT_COUNT = MOVEMENTS.length;
+/**
+ * How many bars a movement runs. Every movement is the same length on
+ * purpose — the roll's cycle is the loop point, not the phrase's, so a
+ * movement that ran long would only ever be heard truncated. Pinned by a test
+ * rather than by this comment.
+ */
+export const BAR_COUNT = MOVEMENTS[0].bars.length;
+/** How long ONE movement runs before it repeats. */
 export const PHRASE_S = BAR_COUNT * BAR_S;
 
 const BASS_S = 2 * STEP_S;
+/** The second channel's sixteenths, when it is running an arpeggio. */
+const ARP_S = STEP_S / 2;
 const HAT_S = 0.03;
 const SNARE_S = 0.12;
 
@@ -141,18 +377,38 @@ const SNARE_S = 0.12;
 // declares its envelope peak RELATIVE to it, so the worst instant this mix can
 // produce is `PEAK_GAIN × (sum of the peaks of whatever overlaps)`. #1773's
 // worst instant was a lead note (1) over the drone (0.025 / 0.06 = 0.4167) —
-// 1.4167, i.e. 0.085 absolute. The numbers below are chosen so the new worst
-// instant (lead + bass + snare = 1.41) stays under that, and
-// `creditsAudio.test.ts` measures it from this data rather than trusting the
-// arithmetic in this comment.
+// 1.4167, i.e. 0.085 absolute, and that is still the ceiling.
+//
+// #1920 spends the headroom differently rather than asking for more of it: a
+// lead that has a second pulse channel under it comes DOWN from 1 by exactly
+// what that channel takes, and a lead that does not keeps its old level. So
+// the busiest instant is the same either way — lead + harmony + bass + snare
+// (0.74 + 0.26 + 0.24 + 0.12) and lead + bass + snare (1 + 0.24 + 0.12) both
+// land on 1.36, under the 1.4167 that #1916 sat at 1.41 against.
+// `creditsAudio.test.ts` measures that off the score, across every movement,
+// rather than trusting the arithmetic in this comment.
 // ---------------------------------------------------------------------------
 
 /** Master gain. Deliberate, and not to be raised — see above. */
 export const PEAK_GAIN = 0.06;
-const LEAD_PEAK = 1;
-const BASS_PEAK = 0.28;
+/**
+ * The lead's peak when a second pulse channel is sounding under it. The
+ * headroom it gives up is exactly what that channel spends.
+ */
+const LEAD_PEAK = 0.74;
+/**
+ * ...and its peak when nothing is. A movement with a silent second channel
+ * has no one to make room for, so it keeps #1916's level — which matters for
+ * the OPENING movement specifically: it is the pass everybody hears, it is
+ * unchanged in pitch and in timbre, and there is no reason for #1920 to have
+ * made it quieter as a side effect of what happens on pass two.
+ */
+const LEAD_SOLO_PEAK = 1;
+const HARMONY_PEAK = 0.26;
+const ARP_PEAK = 0.2;
+const BASS_PEAK = 0.24;
 const HAT_PEAK = 0.05;
-const SNARE_PEAK = 0.13;
+const SNARE_PEAK = 0.12;
 
 /** Ramp constant for the mute toggle. An instant gain jump clicks. */
 const MUTE_RAMP_S = 0.02;
@@ -166,13 +422,19 @@ const ATTACK_S = 0.006;
 // The score, expanded to events
 // ---------------------------------------------------------------------------
 
-export type CreditsVoice = "lead" | "bass" | "hat" | "snare";
+export type CreditsVoice = "lead" | "harmony" | "arp" | "bass" | "hat" | "snare";
 
 /** One scheduled sound. Times are relative to the START OF ITS BAR. */
 export type CreditsEvent = {
   readonly voice: CreditsVoice;
   /** Oscillator pitch, or `null` for the noise voices. */
   readonly hz: number | null;
+  /**
+   * Pulse width for the two pulse channels, `null` for everything else. `0.5`
+   * is the built-in `square`; the other widths need a `PeriodicWave`, which is
+   * why this is data on the event rather than a branch in the renderer.
+   */
+  readonly duty: number | null;
   readonly at: number;
   /** How long the source runs before it is stopped. */
   readonly durS: number;
@@ -189,31 +451,83 @@ export type CreditsEvent = {
   readonly peak: number;
 };
 
+/** Wrap an index into `[0, length)`, negatives included. */
+function wrap(index: number, length: number): number {
+  return ((index % length) + length) % length;
+}
+
+/** The movement at suite position `index`, which wraps. */
+function movementAtIndex(index: number): Movement {
+  // `?? MOVEMENTS[0]` is unreachable after the wrap; it is how a non-empty
+  // tuple is spelled under `noUncheckedIndexedAccess` without a throw.
+  return MOVEMENTS[wrap(index, MOVEMENT_COUNT)] ?? MOVEMENTS[0];
+}
+
 /**
- * The events of bar `index`, which wraps — `creditsBar(BAR_COUNT)` is bar 0
- * again. Pure: the scheduler renders these, and the test measures them.
+ * The events of bar `index` of movement `movement`. Both indices wrap, so
+ * `creditsBar(BAR_COUNT)` is bar 0 again and `creditsBar(0, MOVEMENT_COUNT)`
+ * is the opening movement again.
+ *
+ * Pure: the scheduler renders these, and the test measures them.
  */
-export function creditsBar(index: number): readonly CreditsEvent[] {
-  // `?? BARS[0]` is unreachable after the modulo; it is how a non-empty tuple
-  // is spelled under `noUncheckedIndexedAccess` without a throw.
-  const bar = BARS[((index % BAR_COUNT) + BAR_COUNT) % BAR_COUNT] ?? BARS[0];
+export function creditsBar(index: number, movement = 0): readonly CreditsEvent[] {
+  const score = movementAtIndex(movement);
+  const bar = score.bars[wrap(index, score.bars.length)] ?? score.bars[0];
   const events: CreditsEvent[] = [];
+  const leadPeak = score.second === "none" ? LEAD_SOLO_PEAK : LEAD_PEAK;
 
   bar.lead.forEach((note, i) => {
     events.push({
       voice: "lead",
       hz: hzOf(note),
+      duty: score.duty,
       at: i * STEP_S,
       durS: STEP_S,
       decayS: STEP_S * DECAY_FRACTION,
-      peak: LEAD_PEAK,
+      peak: leadPeak,
     });
   });
+
+  if (score.second === "harmony") {
+    bar.lead.forEach((note, i) => {
+      const below = chordToneBelow(midiOf(note), bar.chord);
+      // A lead note with no chord tone under it inside an octave simply gets
+      // no shadow that step. Skipping beats transposing it somewhere in-key
+      // but wrong.
+      if (below === null) return;
+      events.push({
+        voice: "harmony",
+        hz: hzOfMidi(below),
+        duty: score.secondDuty,
+        at: i * STEP_S,
+        durS: STEP_S,
+        decayS: STEP_S * DECAY_FRACTION,
+        peak: HARMONY_PEAK,
+      });
+    });
+  }
+
+  if (score.second === "arp") {
+    const figure = arpeggioFrom(bar.chord, 4);
+    const steps = Math.round(BAR_S / ARP_S);
+    for (let i = 0; i < steps; i += 1) {
+      events.push({
+        voice: "arp",
+        hz: hzOfMidi(figure[i % figure.length] ?? figure[0] ?? 0),
+        duty: score.secondDuty,
+        at: i * ARP_S,
+        durS: ARP_S,
+        decayS: ARP_S * DECAY_FRACTION,
+        peak: ARP_PEAK,
+      });
+    }
+  }
 
   bar.bass.forEach((note, i) => {
     events.push({
       voice: "bass",
       hz: hzOf(note),
+      duty: null,
       at: i * BASS_S,
       durS: BASS_S,
       decayS: BASS_S * DECAY_FRACTION,
@@ -221,12 +535,13 @@ export function creditsBar(index: number): readonly CreditsEvent[] {
     });
   });
 
-  DRUMS.forEach((drum, i) => {
+  score.drums.forEach((drum, i) => {
     if (drum === null) return;
     const durS = drum === "hat" ? HAT_S : SNARE_S;
     events.push({
       voice: drum,
       hz: null,
+      duty: null,
       at: i * STEP_S,
       durS,
       decayS: durS * DECAY_FRACTION,
@@ -247,6 +562,14 @@ const NOISE_S = 1;
 const LOOKAHEAD_S = 0.35;
 /** How often the main thread checks whether the next bar is due. */
 const PUMP_MS = 100;
+/**
+ * Harmonics summed into a pulse `PeriodicWave`. Enough for the width to be
+ * audible as a width (a 12.5% pulse needs its eighth harmonic to be a 12.5%
+ * pulse at all), few enough that a high lead note does not alias: the top note
+ * in the suite is B5 at ~988 Hz, and 24 × 988 is under half of even a 48 kHz
+ * rate.
+ */
+const PULSE_HARMONICS = 24;
 
 function makeNoiseBuffer(ctx: AudioContext): AudioBuffer {
   const frames = Math.max(1, Math.floor(ctx.sampleRate * NOISE_S));
@@ -257,11 +580,44 @@ function makeNoiseBuffer(ctx: AudioContext): AudioBuffer {
 }
 
 /**
+ * A pulse wave of the given duty cycle, or `null` if this context cannot make
+ * one (jsdom's stub, or an engine that refuses).
+ *
+ * The Fourier series of a duty-`d` pulse has sine coefficients
+ * `(2 / nπ)·sin(nπd)`; at `d = 0.5` every even term vanishes and it is a
+ * square, which is why 50% never comes through here. Normalisation is left ON
+ * so the rendered peak stays ≤ 1 — the gain budget above is stated in those
+ * terms and a de-normalised wave would quietly break it.
+ */
+function pulseWave(ctx: AudioContext, duty: number): PeriodicWave | null {
+  if (typeof ctx.createPeriodicWave !== "function") return null;
+  const real = new Float32Array(PULSE_HARMONICS + 1);
+  const imag = new Float32Array(PULSE_HARMONICS + 1);
+  for (let n = 1; n <= PULSE_HARMONICS; n += 1) {
+    imag[n] = (2 / (n * Math.PI)) * Math.sin(n * Math.PI * duty);
+  }
+  try {
+    return ctx.createPeriodicWave(real, imag);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Start the soundtrack on `ctx`, which this function then OWNS — `stop()`
  * closes it. Never throws: a browser that refuses a node leaves the modal
  * silent rather than broken.
+ *
+ * @param movementAt reads which pass of the credit roll is on screen; the
+ *   suite follows it, so the music turns over exactly when the titles do. The
+ *   default keeps the opening movement forever, which is what a caller with no
+ *   roll to read (and every test that does not care) wants.
  */
-export function startCreditsArpeggio(ctx: AudioContext, muted: boolean): CreditsArpeggio {
+export function startCreditsArpeggio(
+  ctx: AudioContext,
+  muted: boolean,
+  movementAt: () => number = () => 0,
+): CreditsArpeggio {
   const master = ctx.createGain();
   master.gain.value = muted ? 0 : PEAK_GAIN;
   master.connect(ctx.destination);
@@ -270,11 +626,24 @@ export function startCreditsArpeggio(ctx: AudioContext, muted: boolean): Credits
   // future — `onended` cannot be relied on for that, because a note that has
   // not started yet never ends.
   const voices: AudioScheduledSourceNode[] = [];
+  const waves = new Map<number, PeriodicWave | null>();
   let noise: AudioBuffer | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
   let barIndex = 0;
+  let movement = 0;
   let nextBarAt = 0;
+
+  // Built once per width and cached: a `PeriodicWave` is immutable and shared
+  // by every oscillator that uses it, so making one per note would be a few
+  // hundred allocations a minute for an identical object.
+  const waveFor = (duty: number): PeriodicWave | null => {
+    const cached = waves.get(duty);
+    if (cached !== undefined) return cached;
+    const built = pulseWave(ctx, duty);
+    waves.set(duty, built);
+    return built;
+  };
 
   // Called once the source has been STARTED: `stop()` on a source that never
   // started is an InvalidStateError, and the two sources start differently
@@ -316,12 +685,33 @@ export function startCreditsArpeggio(ctx: AudioContext, muted: boolean): Credits
     }
 
     const osc = ctx.createOscillator();
-    // THE chiptune swap (#1916): pulse lead, triangle bass.
-    osc.type = event.voice === "lead" ? "square" : "triangle";
+    // THE chip channel model (#1916, widened by #1920): pulses on top, one
+    // triangle underneath. A width other than 50% needs a `PeriodicWave`, and
+    // an engine that will not give us one falls back to the square rather than
+    // to silence.
+    const wave = event.duty === null || event.duty === 0.5 ? null : waveFor(event.duty);
+    if (wave !== null) {
+      osc.setPeriodicWave(wave);
+    } else {
+      osc.type = event.duty === null ? "triangle" : "square";
+    }
     osc.frequency.value = event.hz ?? 0;
     osc.connect(env);
     osc.start(at);
     keep(osc, env, at + event.durS);
+  };
+
+  // The roll's pass, defended. A caller whose accessor throws or answers with
+  // a NaN must not take the modal's audio down with it, nor jump the suite to
+  // a movement that does not exist: either way the music simply stays where it
+  // was, which is inaudible as a failure.
+  const readMovement = (): number => {
+    try {
+      const next = movementAt();
+      return Number.isFinite(next) ? next : movement;
+    } catch {
+      return movement;
+    }
   };
 
   // Bars are placed against `ctx.currentTime` and never against a timer: a
@@ -336,7 +726,16 @@ export function startCreditsArpeggio(ctx: AudioContext, muted: boolean): Credits
     // and it is exactly the case the gain budget above cannot defend against.
     if (nextBarAt < ctx.currentTime) nextBarAt = ctx.currentTime;
     while (nextBarAt < ctx.currentTime + LOOKAHEAD_S) {
-      for (const event of creditsBar(barIndex)) scheduleEvent(event, nextBarAt);
+      // Read the roll's pass HERE, one bar before it is heard: the movement
+      // can therefore only change on a bar line, never mid-phrase. Restarting
+      // `barIndex` is what makes the new movement enter at its OWN first bar
+      // instead of wherever the outgoing one had got to.
+      const wanted = wrap(readMovement(), MOVEMENT_COUNT);
+      if (wanted !== movement) {
+        movement = wanted;
+        barIndex = 0;
+      }
+      for (const event of creditsBar(barIndex, movement)) scheduleEvent(event, nextBarAt);
       barIndex += 1;
       nextBarAt += BAR_S;
     }
@@ -372,6 +771,7 @@ export function startCreditsArpeggio(ctx: AudioContext, muted: boolean): Credits
         voice.disconnect();
       }
       voices.length = 0;
+      waves.clear();
       master.disconnect();
       void ctx.close();
     },

--- a/cicchetto/src/lib/creditsRoll.ts
+++ b/cicchetto/src/lib/creditsRoll.ts
@@ -1,0 +1,40 @@
+// #1920 — which PASS of the credit roll is on screen right now.
+//
+// Sibling of `creditsRain.rollIsParked`, and here for the same reason: the
+// `.credits-roll` CSS animation is the modal's ONE clock, so anything that has
+// to change "when the titles come back round" reads the phase off that
+// animation rather than counting a second time in JS. A `setInterval` at
+// 34 s would be a second clock that drifts in exactly the case that matters —
+// a backgrounded tab freezes rAF and the animation with it, while timers keep
+// running, so the soundtrack would turn over while the roll stood still.
+//
+// Kept OUT of `creditsRain.ts` on purpose: that module is the rain's look, and
+// this is the soundtrack's cursor. They happen to read the same element.
+
+/**
+ * How many times the roll has restarted since the modal opened — 0 during the
+ * first pass, 1 once the titles have re-entered from the bottom, and so on.
+ *
+ * Degrades to 0 rather than throwing, and that degradation is a real case
+ * rather than a defensive one: `getAnimations` is absent in jsdom, and absent
+ * FOR REAL under `prefers-reduced-motion`, where the roll is a plain
+ * scrollable column with no animation to have a pass of. A soundtrack that
+ * stays on its first movement is the right answer there.
+ *
+ * @param roll the `.credits-roll` element, or `undefined` before it mounts
+ */
+export function creditsRollPass(roll: HTMLElement | undefined): number {
+  if (roll === undefined) return 0;
+
+  const effect = roll.getAnimations?.()[0]?.effect ?? null;
+  if (effect === null) return 0;
+
+  // `currentIteration` is the animation's own count of completed cycles, so
+  // no duration arithmetic happens here and retiming the roll needs no edit.
+  // It is `null` before the animation starts and can be Infinity-adjacent on
+  // an effect with no iteration duration; both fall back to the first pass.
+  const iteration = effect.getComputedTiming().currentIteration;
+  if (typeof iteration !== "number" || !Number.isFinite(iteration)) return 0;
+
+  return Math.max(0, Math.floor(iteration));
+}

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14547,10 +14547,18 @@ audio.media-viewer-media {
   left: 0;
   right: 0;
   /* Starts fully below the fold and ends fully above it, so the loop has no
-     visible seam. #1773 ran the whole 28s cycle as travel; #1807 keeps the
-     travel at 27.88s (0.82 x 34s — the titles roll at exactly the speed they
-     did) and spends the remaining 6.12s with the roll PARKED off the top.
-     That tail is the interlude of pure rain the issue asked for.
+     visible seam. #1773 ran the whole 28s cycle as travel; #1807 kept the
+     travel at 27.88s (0.82 x 34s) and spends the remaining 6.12s with the roll
+     PARKED off the top. That tail is the interlude of pure rain the issue
+     asked for.
+
+     #1920 note on SPEED: the cycle is still 34s, but the entrance now starts a
+     viewport away rather than a roll-height away, so the distance covered in
+     those 27.88s grew and the titles travel faster than they did. That is the
+     cost of entering from the bottom on a short roll and it is accepted, not
+     overlooked — the alternative is measuring the distance in JS and setting
+     the duration from it, i.e. a layout read per resize to hold one number
+     steady that nobody has complained about.
 
      Lengthening the cycle rather than adding a JS pause is what keeps the
      frame budget at zero AND keeps one clock: `creditsRain.rollIsParked`
@@ -14569,16 +14577,51 @@ audio.media-viewer-media {
 /* The last two stops carry the SAME transform on purpose: that hold is the
    interlude, and its start (82%) is the only place the number lives. The roll
    re-enters from the bottom afterwards, which is the same entrance as the
-   first pass rather than a resume mid-list. */
+   first pass rather than a resume mid-list.
+
+   #1920 — the ENTRANCE is viewport-relative and the EXIT is self-relative, and
+   the mismatch is the point rather than an oversight. A percentage translate
+   resolves against the element's OWN border box: `.credits-roll` is absolute
+   with no `top`, so its static position puts its top edge at y=0 and
+   `translateY(100%)` parked it at y = its own height. That is below the fold
+   only for a roll TALLER than the viewport — with the nine contributors this
+   repo bakes it is a few hundred px against a ~1000px window, so every cycle
+   began with the titles already sitting halfway up the screen. vjt reported it
+   as "i credits riappaiono in mezzo allo schermo": the loop was the visible
+   half of a defect the first pass had too.
+
+   `100dvh` puts the top edge on the bottom EDGE, which is what "from the
+   bottom" means, at any roll height. The exit stays `-100%` because clearing
+   the top is a fact about the roll's own height, not the window's. `dvh`
+   rather than `vh` for the reason #205 records at `#root`: `100vh` is iOS
+   Safari's URL-bar-hidden LAYOUT viewport, which would start the roll below
+   the visible bottom and eat the first seconds of the entrance. */
 @keyframes credits-roll {
   0% {
-    transform: translateY(100%);
+    transform: translateY(100dvh);
   }
   82% {
     transform: translateY(-100%);
   }
   100% {
     transform: translateY(-100%);
+  }
+}
+
+/* #205's dvh fallback, applied to the roll: engines without dynamic-viewport
+   units (Safari < 15.4) redefine the whole animation rather than carry a
+   duplicate declaration, which biome forbids. Same shape, `vh` entrance. */
+@supports not (height: 100dvh) {
+  @keyframes credits-roll {
+    0% {
+      transform: translateY(100vh);
+    }
+    82% {
+      transform: translateY(-100%);
+    }
+    100% {
+      transform: translateY(-100%);
+    }
   }
 }
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -45840,3 +45840,118 @@ revocable from the UI), and now that upload preferences have a home in settings
 the reset belongs next to the opt-in. Deliberately out of scope for this slice.
 
 _Deploy: **HOT — `--cic` only.** Client ordering; no server change._
+<!-- entry #1920 -->
+
+---
+
+## 2026-09-05 — #1920: the credit roll enters from the bottom, and the soundtrack becomes a suite
+
+Two reports from vjt on #grappa against staging `b06262041`, one a defect and
+one an ask, shipped together because they are the same loop seen twice: what
+happens when the titles come back round.
+
+### The entrance was measured against the wrong box
+
+> «i credits riappaiono in mezzo allo schermo dopo esser scrollati tutti su,
+> dovrebbero ri-apparire dal fondo»
+
+`@keyframes credits-roll` opened on `transform: translateY(100%)`. **A
+percentage translate resolves against the element's OWN border box**, and
+`.credits-roll` is `position: absolute` with `left`/`right` but no `top`, so
+its static position puts its top edge at y=0 of `.credits-viewport`.
+`translateY(100%)` therefore parked that edge at y = the roll's own height —
+below the fold ONLY for a roll taller than the window.
+
+It is not. With the nine contributors this repo bakes, the roll is a few
+hundred px against a ~1000px viewport, so every cycle began with the titles
+already fully on screen, halfway up. The exit was never wrong: `-100%` is
+exactly the roll's own height past the top, which is what "cleared" means for
+the roll.
+
+So the fix is an ASYMMETRY, and it reads like an oversight unless it is
+written down: **the entrance is viewport-relative (`100dvh`) and the exit
+stays self-relative (`-100%`)**, because arriving is a fact about the window
+and leaving is a fact about the roll. `dvh` rather than `vh` for the reason
+#205 records at `#root` — `100vh` is iOS Safari's URL-bar-hidden LAYOUT
+viewport, which would start the roll below the visible bottom and eat the
+first seconds of the entrance — with #205's `@supports not (height: 100dvh)`
+re-declaration carrying the `vh` fallback, since biome forbids the classic
+duplicate-property spelling.
+
+**The test that should have caught this was the one that encoded it.**
+`creditsRain.test.ts` asserted `all[0]?.transform === "translateY(100%)"`
+under the name *"holds it OFF-SCREEN, and re-enters from the bottom"*. The
+name and the value disagreed and the value won for two issues. It now asserts
+on the UNIT (`/^translateY\(100d?vh\)$/`) rather than on a number: no roll
+height makes a `%` entrance correct on every window, so pinning the unit is
+pinning the claim.
+
+**Accepted cost, stated so it is not rediscovered as a bug.** The cycle is
+still 34s while the distance covered grew, so the titles travel faster than
+they did — on a short roll, noticeably. The alternative is measuring the
+distance in JS and setting the duration from it, i.e. a layout read per
+resize to hold steady a number nobody has complained about. Declined.
+
+### One bar became four movements, and the ROLL picks which
+
+> «e dovrebbe cambiare la musichetta quando ri-appaiono» /
+> «più variegata più chiptune più voci»
+
+#1916 made the phrase four bars and left it looping verbatim: about four and a
+half repeats per 34s cycle, identical on every cycle. `MOVEMENTS` replaces
+`BARS` — four movements of four bars, each with its own progression, pulse
+width, drum pattern and second-channel role — and the movement index comes
+from `creditsRoll.creditsRollPass(roll)`, which reads `currentIteration` off
+the roll's own CSS animation.
+
+**ONE CLOCK, the same doctrine `creditsRain.rollIsParked` follows.** A
+`setInterval` at 34s would be a second clock, and it would disagree exactly
+where it matters: a backgrounded tab freezes rAF and the animation with it
+while timers keep running, so the music would turn over while the titles stood
+still. The accessor is read inside the scheduler's own pump, one bar ahead of
+what is heard, so the switch can only land on a bar line; `barIndex` resets
+with it, so the incoming movement enters at ITS first bar rather than wherever
+the outgoing one had got to.
+
+**The channel model is the NES's, and that is what makes `harmony` and `arp`
+mutually exclusive.** Two pulses, one triangle, one noise. The lead owns pulse
+one; the second pulse does a harmony line OR sixteenths, never both, because
+it is one channel and a chip that could sound both would not be a chip. The
+harmony is DERIVED rather than written out — the nearest chord tone below the
+lead note, which tracks it in thirds and fourths that are in key by
+construction; a second `Eight<Note>` per bar would be the same information
+typed twice, and the copy that drifts is always the one nobody hums.
+
+**"Più chiptune" is mostly the pulse WIDTH.** `OscillatorNode` has no 25% or
+12.5% type, so those are `PeriodicWave`s built from the duty-`d` series
+`(2/nπ)·sin(nπd)`, 24 harmonics, cached per width and normalisation left ON so
+the rendered peak stays ≤ 1 (the gain budget is stated in those terms). 50%
+stays the built-in `square`, so the OPENING movement is #1916's timbre exactly
+rather than a ringing 24-harmonic approximation of a wave the engine already
+has. An engine with no `createPeriodicWave` loses the width, never the note.
+
+### The gain budget did not move, and that is the constraint the rest bends around
+
+`PEAK_GAIN` is untouched, and the ceiling is still #1773's worst instant
+(1.4167 × master). More voices had to be paid for out of existing headroom, so
+a lead WITH a second channel under it comes down to 0.74 by exactly what that
+channel takes, and a lead without one keeps 1. Both arrangements land on 1.36
+— under #1916's 1.41, so this is quieter at its worst, not louder — and the
+opening movement is therefore not quieter than what shipped, which would have
+been an odd thing to trade for an improvement to pass two.
+
+`creditsAudio.test.ts` measures that across EVERY movement rather than
+trusting the arithmetic above: the per-movement peak is the claim, and a suite
+whose loudest movement is untested is a suite with no bound at all.
+
+### What is NOT proven here
+
+The vitest suite could not be run on the host that wrote this (`nowhere`,
+node 20: jsdom's undici needs `webidl.util.markAsUncloneable`, node ≥22). Types
+(`tsc --noEmit`) and lint (`biome check`) are green locally, and the score's
+arithmetic — the per-movement loudness bound, the harmony staying below the
+lead, the movements being distinct, the suite wrapping — was measured directly
+off an esbuild bundle of the module. **The unit suite's verdict is CI's**, and
+nothing here should be read as a claim that it passed locally.
+
+_Deploy: **HOT — `--cic` only.** Client-side; no server change._


### PR DESCRIPTION
Closes #1920.

## 1. The roll re-entered mid-screen

`@keyframes credits-roll` opened on `transform: translateY(100%)`. A percentage
translate resolves against the element's **own** border box, and `.credits-roll`
is `position: absolute` with no `top`, so its static position puts the top edge
at y=0 and `translateY(100%)` parked it at y = the roll's own height. That is
below the fold only for a roll TALLER than the window — with the nine
contributors this repo bakes it is a few hundred px against ~1000, so every
cycle began with the titles already on screen, halfway up.

The entrance is now viewport-relative (`100dvh`, with #205's
`@supports not (height: 100dvh)` re-declaration carrying the `vh` fallback);
the exit stays `-100%`, because clearing the top is a fact about the roll's own
height, not the window's. The asymmetry is deliberate and has its own test.

**The test that should have caught this encoded it**: it asserted
`translateY(100%)` under the name *"re-enters from the bottom"*. It now pins the
UNIT rather than a number — no roll height makes a `%` entrance right on every
window.

**Accepted cost, stated up front:** the cycle is still 34s over a longer
distance, so the titles travel faster than they did. The alternative is a layout
read per resize to set the duration in JS; declined.

## 2. The soundtrack now turns over with the titles

`MOVEMENTS` replaces `BARS` — four movements of four bars, each with its own
progression, pulse width, drum pattern and second-channel role. The movement
index comes from `creditsRoll.creditsRollPass(roll)`, which reads
`currentIteration` off the roll's own CSS animation: **one clock**, the doctrine
`creditsRain.rollIsParked` already follows. A timer would drift in a
backgrounded tab, where rAF stops and timers do not. The accessor is read in the
scheduler's pump one bar ahead of what is heard, so the switch lands on a bar
line and the incoming movement enters at its own first bar.

- **More voices:** `lead`, `harmony`, `arp`, `bass`, `hat`, `snare`.
- **The channel model is the NES's** — two pulses, one triangle, one noise —
  which is *why* `harmony` and `arp` are mutually exclusive per movement: they
  are the same channel.
- **The harmony is derived**, not written out: the nearest chord tone below the
  lead, in key by construction.
- **More chiptune** is mostly the pulse WIDTH: 25% / 12.5% are `PeriodicWave`s
  from the duty-`d` series, cached per width, falling back to `square` where the
  engine cannot build one. 50% stays the built-in square, so the opening
  movement keeps #1916's timbre exactly.

## Gain budget

`PEAK_GAIN` does not move and the ceiling is still #1773's worst instant. A lead
with a second channel under it gives up exactly what that channel takes; one
without keeps its old level, so the **opening movement is not quieter than what
shipped**. Both arrangements peak at 1.36 against 1.4167 — quieter at the worst
than #1916's 1.41 — and the test measures that per movement.

## What I did and did not run

- `tsc --noEmit`: green.
- `biome check` on the touched files: green.
- The score's arithmetic (per-movement loudness bound, harmony below the lead at
  every step, movements distinct, suite wraps) measured directly off an esbuild
  bundle of the module.
- **The vitest suite did not run locally.** The host is on node 20 and jsdom's
  undici needs `webidl.util.markAsUncloneable` (node ≥22), so the unit gate's
  verdict here is CI's, not mine.
