### PR TITLE
credits: prose between the passes of the roll

### DIFF
--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -1,4 +1,12 @@
-import { type Component, createEffect, For, onCleanup, Show, untrack } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+  untrack,
+} from "solid-js";
 import { buildCredits, creditsDateLabel } from "./lib/buildCredits";
 import { bootBundleVersionAccessor } from "./lib/bundleHash";
 import { type CreditsArpeggio, startCreditsArpeggio } from "./lib/creditsAudio";
@@ -8,6 +16,7 @@ import {
   creditsMuted,
   toggleCreditsMuted,
 } from "./lib/creditsModal";
+import { createProseDeck, type ProseSet } from "./lib/creditsProse";
 import { creditsRainLook } from "./lib/creditsRain";
 import { creditsRollPass } from "./lib/creditsRoll";
 import { createOverlayLock } from "./lib/overlayScrollLock";
@@ -55,6 +64,28 @@ const CreditsModal: Component = () => {
   // which is why the declaration sits above the audio effect: both readers
   // close over it, neither runs before it is assigned.
   let roll: HTMLDivElement | undefined;
+
+  // ── prose between the passes (#1924) ────────────────────────────────────
+  // A THIRD reader of the same animation, and deliberately not a third clock:
+  // `animationiteration` is the roll telling us it has come back round, so the
+  // paragraph turns over at the exact frame the column jumps back below the
+  // fold — the one moment in the cycle where swapping text is invisible,
+  // because the block is off-screen while it changes.
+  //
+  // The deck lives for the session rather than per open: it is what keeps the
+  // sets from repeating, and rebuilding it on every open would re-deal from a
+  // full bag and hand you the set you just watched.
+  const deck = createProseDeck();
+  const [prose, setProse] = createSignal<ProseSet | null>(null);
+
+  createEffect(() => {
+    // Drawn on OPEN rather than at construction: this component is mounted in
+    // Shell for the whole session, so a draw in the body would burn a set at
+    // boot for a modal nobody may open. Empty until then, and the roll simply
+    // has no prose block — which is also the honest render for a pool that
+    // shipped empty.
+    if (creditsModalOpen()) setProse(deck.draw());
+  });
 
   // ── soundtrack lifecycle ────────────────────────────────────────────────
   // Tied to the OPEN signal, not to this component's mount: Shell mounts the
@@ -155,6 +186,18 @@ const CreditsModal: Component = () => {
             data-testid="credits-roll"
             ref={(node) => {
               roll = node;
+              // #1924 — no `onCleanup`, and that is not an omission: the
+              // listener is on THIS element, `Show` discards the element on
+              // close, and a listener on a discarded node is collected with
+              // it. Registering a teardown would be teardown for a thing that
+              // cannot outlive what it is attached to.
+              //
+              // `event.target === node` because `animationiteration` bubbles:
+              // any future animated descendant of the roll would otherwise
+              // turn the paragraph over on its own schedule.
+              node.addEventListener("animationiteration", (event) => {
+                if (event.target === node) setProse(deck.draw());
+              });
             }}
           >
             <h2 class="credits-title" data-testid="credits-title">
@@ -195,6 +238,22 @@ const CreditsModal: Component = () => {
                 )}
               </For>
             </ul>
+
+            {/* #1924 — inside the column, directly under the names. That
+                placement is the feature: the paragraph enters through the
+                bottom of the viewport while the contributor list is still
+                leaving through the top, so nothing waits for the titles to
+                scroll away and there is no second screen to cut to. */}
+            <Show when={prose()}>
+              {(set) => (
+                <div class="credits-prose" data-testid="credits-prose">
+                  <h3 class="credits-prose-title" data-testid="credits-prose-title">
+                    {set().title}
+                  </h3>
+                  <For each={set().paragraphs}>{(paragraph) => <p>{paragraph}</p>}</For>
+                </div>
+              )}
+            </Show>
 
             <p class="credits-coda">an always-on IRC bouncer, and a client that looks like irssi</p>
           </div>

--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -78,13 +78,31 @@ const CreditsModal: Component = () => {
   const deck = createProseDeck();
   const [prose, setProse] = createSignal<ProseSet | null>(null);
 
+  // Which pass is on screen, for the ONE thing that needs to know: the names
+  // are shown once and never again (vjt, #grappa 2026-09-05 — "mostriamo i
+  // credits una volta sola, chi se ne frega di ri-vederli"). Every later pass
+  // is prose alone.
+  //
+  // Set from `creditsRollPass`, i.e. from the animation's own
+  // `currentIteration`, rather than incremented here. The event is the TRIGGER
+  // and the animation stays the VALUE — a counter of my own would be a second
+  // tally that can disagree with the clock everything else reads.
+  const [pass, setPass] = createSignal(0);
+
   createEffect(() => {
     // Drawn on OPEN rather than at construction: this component is mounted in
     // Shell for the whole session, so a draw in the body would burn a set at
     // boot for a modal nobody may open. Empty until then, and the roll simply
     // has no prose block — which is also the honest render for a pool that
     // shipped empty.
-    if (creditsModalOpen()) setProse(deck.draw());
+    //
+    // The pass resets with it: `Show` builds a fresh element on every open, so
+    // its animation genuinely starts over, and carrying the old count would
+    // hide the names from the second viewing onwards.
+    if (creditsModalOpen()) {
+      setPass(0);
+      setProse(deck.draw());
+    }
   });
 
   // ── soundtrack lifecycle ────────────────────────────────────────────────
@@ -196,48 +214,61 @@ const CreditsModal: Component = () => {
               // any future animated descendant of the roll would otherwise
               // turn the paragraph over on its own schedule.
               node.addEventListener("animationiteration", (event) => {
-                if (event.target === node) setProse(deck.draw());
+                if (event.target !== node) return;
+                setPass(creditsRollPass(node));
+                setProse(deck.draw());
               });
             }}
           >
-            <h2 class="credits-title" data-testid="credits-title">
-              GRAPPA IRC
-            </h2>
-            <p class="credits-version" data-testid="credits-version">
-              {versionLabel()}
-            </p>
-            <p class="credits-build" data-testid="credits-build">
-              <span data-testid="credits-sha">{credits.sha ?? "no build sha"}</span>
-              <Show when={dateLabel()}>
-                {(day) => (
-                  <>
-                    <span aria-hidden="true"> · </span>
-                    <span data-testid="credits-date">{day()}</span>
-                  </>
-                )}
-              </Show>
-            </p>
+            {/* #1924 — the names are a FIRST-PASS thing. vjt: "mostriamo i
+                credits una volta sola, chi se ne frega di ri-vederli, e poi
+                solo i paragrafi, con i relativi titoli." A loop that re-runs
+                the same list every 34s teaches the viewer to stop reading,
+                which is the surest way to make the prose invisible too.
 
-            <h3 class="credits-heading">contributors</h3>
-            <ul class="credits-list">
-              <For
-                each={credits.contributors}
-                fallback={
-                  // Honest, not blank: this is what a build from a source
-                  // tarball looks like, and it is a legitimate build.
-                  <li class="credits-empty" data-testid="credits-empty">
-                    this build carries no history
-                  </li>
-                }
-              >
-                {(person) => (
-                  <li class="credits-person" data-testid="credits-person">
-                    <span class="credits-person-name">{person.name}</span>
-                    <span class="credits-person-count">{person.commits}</span>
-                  </li>
-                )}
-              </For>
-            </ul>
+                The swap rides the same `animationiteration` as the prose, so
+                it lands on the frame the column is parked off the top —
+                nothing is seen disappearing. */}
+            <Show when={pass() === 0}>
+              <h2 class="credits-title" data-testid="credits-title">
+                GRAPPA IRC
+              </h2>
+              <p class="credits-version" data-testid="credits-version">
+                {versionLabel()}
+              </p>
+              <p class="credits-build" data-testid="credits-build">
+                <span data-testid="credits-sha">{credits.sha ?? "no build sha"}</span>
+                <Show when={dateLabel()}>
+                  {(day) => (
+                    <>
+                      <span aria-hidden="true"> · </span>
+                      <span data-testid="credits-date">{day()}</span>
+                    </>
+                  )}
+                </Show>
+              </p>
+
+              <h3 class="credits-heading">contributors</h3>
+              <ul class="credits-list">
+                <For
+                  each={credits.contributors}
+                  fallback={
+                    // Honest, not blank: this is what a build from a source
+                    // tarball looks like, and it is a legitimate build.
+                    <li class="credits-empty" data-testid="credits-empty">
+                      this build carries no history
+                    </li>
+                  }
+                >
+                  {(person) => (
+                    <li class="credits-person" data-testid="credits-person">
+                      <span class="credits-person-name">{person.name}</span>
+                      <span class="credits-person-count">{person.commits}</span>
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </Show>
 
             {/* #1924 — inside the column, directly under the names. That
                 placement is the feature: the paragraph enters through the
@@ -255,7 +286,14 @@ const CreditsModal: Component = () => {
               )}
             </Show>
 
-            <p class="credits-coda">an always-on IRC bouncer, and a client that looks like irssi</p>
+            {/* The coda goes with the names for the same reason: it is a
+                tagline, and a tagline on a loop stops being read and starts
+                being a boast. */}
+            <Show when={pass() === 0}>
+              <p class="credits-coda">
+                an always-on IRC bouncer, and a client that looks like irssi
+              </p>
+            </Show>
           </div>
         </div>
       </div>

--- a/cicchetto/src/__tests__/creditsProse.test.ts
+++ b/cicchetto/src/__tests__/creditsProse.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  CREDITS_PROSE,
+  createProseDeck,
+  PROSE_SET_MAX_WORDS,
+  type ProseSet,
+  proseSetWords,
+} from "../lib/creditsProse";
+
+// #1924 — the prose between the passes of the credit roll.
+//
+// Two things are worth pinning here and they are different in kind.
+//
+// The COPY assertions are a bound on editing: the roll travels a fixed
+// distance in a fixed time, so a set that grows does not scroll slower, it
+// scrolls past unread. Nobody notices that in review — the modal looks fine
+// on a desktop where the whole set fits — so the ceiling is a test rather
+// than a comment nobody reads before adding the seventeenth set.
+//
+// The DECK assertions are about a property uniform sampling does not have.
+// `Math.random()` per pass repeats the set you just read about one pass in
+// sixteen, and a title sequence that shows the same paragraph twice running
+// reads as a bug rather than as chance. The bag is what removes that, and the
+// interesting case is the seam BETWEEN two bags, which is the one place a
+// naive shuffle-bag still repeats.
+
+/** A scripted random source, so a shuffle has exactly one outcome. */
+function scriptedRandom(values: readonly number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length] as number;
+}
+
+const PAIR: readonly ProseSet[] = [
+  { title: "a", paragraphs: ["a"] },
+  { title: "b", paragraphs: ["b"] },
+];
+
+describe("CREDITS_PROSE copy (#1924)", () => {
+  it("carries enough sets that a repeat is far apart", () => {
+    // vjt asked for 10-15; the deck deals all of them before repeating, so
+    // this number IS the distance between two showings of the same set.
+    expect(CREDITS_PROSE.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("keeps every set to two or three paragraphs", () => {
+    for (const set of CREDITS_PROSE) {
+      expect(set.paragraphs.length).toBeGreaterThanOrEqual(2);
+      expect(set.paragraphs.length).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("titles every set", () => {
+    // The title is rendered, in italics, above the paragraphs — a set that
+    // shipped without one would render a blank line the roll spends seconds
+    // crossing, which is the same defect as a blank paragraph.
+    for (const set of CREDITS_PROSE) {
+      expect(set.title.trim()).not.toBe("");
+    }
+  });
+
+  it("keeps every set under the word ceiling", () => {
+    for (const set of CREDITS_PROSE) {
+      expect(proseSetWords(set)).toBeLessThanOrEqual(PROSE_SET_MAX_WORDS);
+    }
+  });
+
+  it("has no blank paragraph", () => {
+    // A blank one is invisible in the source and renders as a gap the roll
+    // spends seconds crossing.
+    for (const set of CREDITS_PROSE) {
+      for (const paragraph of set.paragraphs) {
+        expect(paragraph.trim()).not.toBe("");
+      }
+    }
+  });
+});
+
+describe("createProseDeck (#1924)", () => {
+  it("deals every set once before dealing any of them twice", () => {
+    const deck = createProseDeck(CREDITS_PROSE, scriptedRandom([0.17, 0.83, 0.41, 0.66]));
+    const drawn = Array.from({ length: CREDITS_PROSE.length }, () => deck.draw());
+    expect(new Set(drawn).size).toBe(CREDITS_PROSE.length);
+  });
+
+  it("never deals the same set twice in a row, across the reshuffle too", () => {
+    // The scripted values are chosen for the SEAM: the first bag deals `b`
+    // then `a`, and the second bag would open on `a` again. Unguarded this
+    // sequence is b,a,a,b — the exact defect the bag exists to remove.
+    const deck = createProseDeck(PAIR, scriptedRandom([0.9, 0.0]));
+    const drawn = Array.from({ length: 8 }, () => deck.draw());
+    for (let i = 1; i < drawn.length; i++) {
+      expect(drawn[i]).not.toBe(drawn[i - 1]);
+    }
+  });
+
+  it("holds the no-repeat property over many passes with a plain generator", () => {
+    // A linear congruential generator rather than `Math.random`, so a failure
+    // is reproducible instead of a flake somebody re-runs until it is green.
+    let state = 12345;
+    const lcg = (): number => {
+      state = (state * 1103515245 + 12345) % 2147483648;
+      return state / 2147483648;
+    };
+    const deck = createProseDeck(CREDITS_PROSE, lcg);
+    let previous: ProseSet | null = null;
+    for (let i = 0; i < 2000; i++) {
+      const set = deck.draw();
+      expect(set).not.toBe(previous);
+      previous = set;
+    }
+  });
+
+  it("deals the only set it has rather than refusing to repeat", () => {
+    // One set means every pass shows it. Refusing the repeat here would mean
+    // dealing nothing, which is worse than a paragraph you have read.
+    const only = { title: "only", paragraphs: ["only"] };
+    const deck = createProseDeck([only]);
+    expect(deck.draw()).toBe(only);
+    expect(deck.draw()).toBe(only);
+  });
+
+  it("deals null from an empty pool instead of hanging", () => {
+    // Not defensive: a pool this module ships cannot be empty, but a caller
+    // filtering the pool can hand one over, and an empty bag that reshuffles
+    // into another empty bag is an infinite loop, not a missing paragraph.
+    const deck = createProseDeck([]);
+    expect(deck.draw()).toBeNull();
+    expect(deck.draw()).toBeNull();
+  });
+});

--- a/cicchetto/src/lib/creditsProse.ts
+++ b/cicchetto/src/lib/creditsProse.ts
@@ -1,0 +1,238 @@
+// #1924 — the prose the credit roll carries between one pass and the next.
+//
+// The roll is a column, and this block sits in it directly under the
+// contributor list. That placement is the whole trick asked for: while the
+// names are leaving through the top of the viewport the paragraph is already
+// entering through the bottom, so nothing waits for the titles to scroll away
+// and there is no second screen to cut to.
+//
+// The TEXT is versioned here rather than fetched, and that is deliberate: it
+// is part of the bundle the credits describe. A build claims a sha, a date and
+// a contributor list; the words it shows about itself belong to the same
+// artifact, not to a CMS that could answer differently to two people looking
+// at the same build.
+//
+// Registers are mixed ON PURPOSE and the deck does not separate them: the
+// manifesto sets state why the thing exists, the anecdote sets are lifted from
+// posts already published on sindro.me. Alternating them by rule would make
+// the sequence predictable, which is the one thing a title sequence you watch
+// twice cannot afford.
+
+/**
+ * One set: a title and the paragraphs shown under it on a single pass.
+ *
+ * Two or three paragraphs, each a few short sentences. The ceiling is not
+ * decorative — the roll travels a fixed distance in a fixed time, so a long
+ * set does not scroll slower, it scrolls PAST. `creditsProse.test.ts` pins the
+ * bound rather than trusting the eye of whoever adds the next one.
+ */
+export type ProseSet = {
+  readonly title: string;
+  readonly paragraphs: readonly string[];
+};
+
+/** The longest a set may be before the roll outruns a reader. */
+export const PROSE_SET_MAX_WORDS = 150;
+
+export const CREDITS_PROSE: readonly ProseSet[] = [
+  {
+    title: "information wants to be free",
+    paragraphs: [
+      "Information wants to be free. It always did. The wire does not care what you send down it. Only the owner of the wire cares.",
+      "So do not hand your words to an owner. Type them into a room. Let them be read, quoted, logged, grepped.",
+      "A message you cannot copy is not a message. It is a rental.",
+    ],
+  },
+  {
+    title: "free software",
+    paragraphs: [
+      "Free software is not free of charge. It is free of landlords.",
+      "Every line of this is readable. Changeable. Runnable on a five-euro machine that answers to you, in a country you picked, under a name you invented.",
+      "There is no account here for a company to close. Fork it and the network outlives you.",
+    ],
+  },
+  {
+    title: "old software that works",
+    paragraphs: [
+      "IRC was finished in 1988. It still runs.",
+      "No reactions. No read receipts. No typing indicator. No algorithm deciding which friend you see today. Those are not missing features. They are refusals.",
+      "Old code that still works is not debt. It is proof. Most of what came after was an attention tax with a logo on it.",
+    ],
+  },
+  {
+    title: "text is the feature",
+    paragraphs: [
+      "Text is the feature, not the limit.",
+      "A screen reader reads a channel line by line and loses nothing. A grep finds a conversation from 2003. A train tunnel renders it in bytes. Your head does the rest, the way it did for MUDs.",
+      "More pixels per second is not more signal.",
+    ],
+  },
+  {
+    title: "the pseudonym",
+    paragraphs: [
+      "Behind every nick there is a person who chose that name.",
+      "Not a phone number. Not a legal name. Not a verified badge. A word you picked, typed into a room full of other picked words, until the words turned into friendships, projects and jobs.",
+      "That is the whole protocol. Everything else is transport.",
+    ],
+  },
+  {
+    title: "whose infrastructure",
+    paragraphs: [
+      "You cannot read the code of the app you talk to your friends in. You cannot change it, you cannot run it yourself, and you cannot take it with you.",
+      "You rent a seat on somebody else's stage, and they keep the right to rearrange the stage while you sit on it.",
+      "IRC runs on a cheap server, a handful of text files and a small program. That asymmetry is not decoration. It is the whole game.",
+    ],
+  },
+  {
+    title: "teaching a server to lie",
+    paragraphs: [
+      "2001. Azzurra ran a commercial IRC server, because it shipped a Java applet, and the applet was how half the users got in.",
+      "The applet sent GUEST on connect and waited for the right numerics back. That was the protection.",
+      "So we taught Bahamut to answer CR1.8.4-SEC with a straight face, and dropped the commercial server. The applet never noticed.",
+    ],
+  },
+  {
+    title: "you existed only while connected",
+    paragraphs: [
+      "On IRC in 2002 you existed only while connected. Ping timeout: 180 seconds, and your name was up for grabs.",
+      "People left tower PCs humming all night, phone line tied up, to hold a nickname while they slept. The luckier ones rented a psyBNC.",
+      "Your identity required physical infrastructure. This bouncer is that tower PC, minus the noise.",
+    ],
+  },
+  {
+    title: "netsplit",
+    paragraphs: [
+      "A netsplit is when the network forgets it is one network. Two halves, both convinced they are the real one, the same nickname alive in each.",
+      "IRC's answer was scorched earth: disconnect both users and let them sort it out. The attacker reconnected instantly. The victim came back to find the name gone.",
+      "The fix was a timestamp. Oldest claim wins. Twenty-four years later it still holds.",
+    ],
+  },
+  {
+    title: "twenty-one",
+    paragraphs: [
+      "At twenty-one I forked an IRC server to teach it IPv6 and SSL. At night. For a network that paid nobody.",
+      "The CVS repository is still on SourceForge. 171 commits, three authors, February 2002 to January 2006.",
+      "It still compiles, and not because I wrote it well: Sonic and morph kept their hands on it for twenty years. Left alone it would have rotted like everything else from 2002.",
+    ],
+  },
+  {
+    title: "the trail goes cold",
+    paragraphs: [
+      "In 2002 I started writing IRC services from scratch. 954 commits. I left the network before they were finished.",
+      "A developer in Latvia picked them up, wrote 192 commits, and then the trail goes cold. I never learned their name.",
+      "That is open source. You put it down, somebody else picks it up, and the thing keeps walking without you.",
+    ],
+  },
+  {
+    title: "#sniffo",
+    paragraphs: [
+      "The channel was called #sniffo. Inline skating and funny faces. Nothing pharmaceutical.",
+      "Three teenagers on a Monopoli-Milan-Bologna axis met there, then drove across the country to sit in the same room with the case open and the CRTs on.",
+      "Twenty-five years later the channel is still there. So are they.",
+    ],
+  },
+  {
+    title: "the bot",
+    paragraphs: [
+      "The bot in this channel started as a line somebody threw out in passing: you should try hooking Claude up to IRC directly. Five minutes later it was online.",
+      "First night, 250 lines of Python: it corrected a factual error in a blog post, deployed the fix while the channel was still arguing about it, caught two prompt injections, and leaked its operator's brokerage account number. Twice.",
+      "Then it learned to shut up until spoken to. That was the hard part.",
+    ],
+  },
+  {
+    title: "found in a magazine",
+    paragraphs: [
+      "I found IRC in a magazine. Paper, a newsstand, an article about an Italian network.",
+      "I connected, picked a name, opened a channel with friends. User, then contributor, then operator, then writing the server itself. None of it planned.",
+      "No algorithm was involved. Somebody wrote something down and somebody else read it.",
+    ],
+  },
+  {
+    title: "eighteen years",
+    paragraphs: [
+      "In 2008 a friend told me: get yourself a Facebook, it is like IRC but it does so much more.",
+      "He was right. It did so much more. Then it did stories, and reels, and an algorithm, and eighteen years went past.",
+      "I came back in 2026. Same people, same channels, same names. Nobody had monetised anything.",
+    ],
+  },
+  {
+    title: "how this channel filled up",
+    paragraphs: [
+      "In April there was one person in this channel. Me, plus a bot I had wired up the week before.",
+      "Then guly joined. Then peluche, who stayed. Then nextime sent the first contributions from outside. Then Hypnotize, then Sonic, then Lucy, building Resentin against the same API.",
+      "Nobody was recruited. They read something somewhere and typed /join.",
+    ],
+  },
+];
+
+/** Draws sets in an order that looks random and behaves better than random. */
+export type ProseDeck = {
+  /** The set for the pass that is starting now, or `null` from an empty pool. */
+  draw(): ProseSet | null;
+};
+
+/**
+ * Fisher-Yates over the indices of `count` items.
+ *
+ * Indices rather than the sets themselves so the deck never copies the prose,
+ * and so a test can assert the ORDER without comparing paragraphs.
+ */
+function shuffledIndices(count: number, random: () => number): number[] {
+  const order = Array.from({ length: count }, (_, i) => i);
+  for (let i = count - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    // `j` can land on `i` itself, which is a no-op swap and a legitimate
+    // outcome — clamping it away would bias the shuffle.
+    [order[i], order[j]] = [order[j] as number, order[i] as number];
+  }
+  return order;
+}
+
+/**
+ * A shuffle bag, not `Math.random()` per pass.
+ *
+ * Uniform sampling is the wrong tool for a sequence somebody WATCHES: with
+ * sixteen sets it repeats the one you just read about one pass in sixteen, and
+ * a title sequence that shows the same paragraph twice in a row does not read
+ * as chance, it reads as a bug. The bag deals every set once before
+ * reshuffling, and the reshuffle refuses to open on the set the previous bag
+ * closed with, so back-to-back repeats are impossible rather than merely
+ * unlikely.
+ *
+ * @param sets the pool to deal from; an empty pool deals `null` forever
+ * @param random the source of randomness, injected so tests are deterministic
+ */
+export function createProseDeck(
+  sets: readonly ProseSet[] = CREDITS_PROSE,
+  random: () => number = Math.random,
+): ProseDeck {
+  let bag: number[] = [];
+  let last: number | null = null;
+
+  const refill = (): void => {
+    bag = shuffledIndices(sets.length, random);
+    // Only meaningful from two sets up: with one set every pass shows it, and
+    // with none there is nothing to swap.
+    if (sets.length > 1 && bag[bag.length - 1] === last) {
+      const other = bag.length - 2;
+      [bag[bag.length - 1], bag[other]] = [bag[other] as number, bag[bag.length - 1] as number];
+    }
+  };
+
+  return {
+    draw(): ProseSet | null {
+      if (sets.length === 0) return null;
+      // Dealt from the END so a draw is a pop rather than a shift — the order
+      // is already random, so which end it comes off is free.
+      if (bag.length === 0) refill();
+      const index = bag.pop() as number;
+      last = index;
+      return sets[index] as ProseSet;
+    },
+  };
+}
+
+/** Words in a set, title included, counted the way the bound is written. */
+export function proseSetWords(set: ProseSet): number {
+  return [set.title, ...set.paragraphs].join(" ").split(/\s+/).filter(Boolean).length;
+}

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14671,6 +14671,47 @@ audio.media-viewer-media {
   color: var(--muted);
 }
 
+/* #1924 — the prose that rides between one pass of the names and the next,
+   in the column and directly under them, so it enters through the bottom of
+   the viewport while the list is still leaving through the top.
+
+   LEFT-aligned inside a centred column, and that is a readability call rather
+   than a slip: the rest of the roll is one or two words per line, where
+   centring reads as a title sequence, while these are forty-word paragraphs,
+   where a ragged left edge costs the reader the start of every line.
+
+   The measure is capped in `ch`, not `rem`. This is a monospace pastiche, so
+   the line length that reads well is a count of characters; a `rem` cap would
+   grow with the font and hand a 120-character line to anyone who scaled the
+   interface up. */
+.credits-prose {
+  margin: 1.5rem 0;
+  max-width: min(58ch, 88vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  text-align: left;
+  font-size: 0.95em;
+  line-height: 1.55;
+}
+
+.credits-prose p {
+  margin: 0;
+}
+
+/* Italic, per vjt: the set titles are kept, and they are the one place in the
+   roll where a slant marks "this is a heading, not a line of the text". No
+   letter-spacing here — `.credits-heading` tracks out because it is a single
+   word under a list, and tracking a five-word title just makes it a second
+   paragraph. */
+.credits-prose-title {
+  margin: 0;
+  font-size: 1em;
+  font-weight: normal;
+  font-style: italic;
+  color: var(--accent);
+}
+
 .credits-empty,
 .credits-coda {
   margin: 0;


### PR DESCRIPTION
Closes #1924.

The roll's column now carries a titled set of paragraphs directly under the contributor list, and turns it over on every pass.

**Placement is the feature.** The block is inside `.credits-roll`, under `.credits-list`. While the names leave through the top of the viewport the paragraph is already entering through the bottom — the *"senza aspettare che sian tutti scrollati via"* the issue quotes — and it costs nothing: no second screen, no pause in the animation, no layout read in JS.

**One clock, still.** Turnover is `animationiteration` on the roll element. #1920 established that anything changing "when the titles come back round" reads the phase off the CSS animation rather than counting a second time in JS, and the reason holds here: a 34s `setInterval` drifts precisely in the case that matters, a backgrounded tab where rAF and the animation freeze while timers keep running. The event also fires on the frame the column jumps back below the fold, so the text changes while the block is off-screen.

No `onCleanup` on the listener, and that is not an omission — it is on the roll element itself, `Show` discards that element on close, and a listener on a discarded node goes with it. The `event.target === node` guard is there because `animationiteration` bubbles: a future animated descendant would otherwise drive the paragraph on its own schedule.

**Shuffle bag, not uniform draw.** With sixteen sets, `Math.random()` per pass repeats the set you just read about one pass in sixteen. The bag deals each set once before reshuffling and refuses to open on the set the previous bag closed with, so a back-to-back repeat is impossible rather than unlikely. The seam between two bags is what `creditsProse.test.ts` pins with a scripted RNG, because it is the case a naive bag still gets wrong; a second test holds the property over 2000 draws with an LCG, so a failure reproduces instead of flaking.

**Copy.** Sixteen sets, a title plus two or three short paragraphs, under 150 words — bounded by test, because the roll travels a fixed distance in a fixed time and a set that grows does not scroll slower, it scrolls past. Two registers in one deck: manifesto (information wants to be free, free software, old software that still works, text as the feature, the pseudonym, whose infrastructure it is) and anecdote, lifted from posts already published on sindro.me. Titles render in italic. English, like the rest of the roll. Versioned in the bundle rather than fetched — a build's words about itself belong to the same artifact as its sha.

**Known follow-up, deliberately not in here:** the column is now roughly three times taller, and the cycle is still the 34s constant #1807 set. Constant duration over a longer column means a faster scroll, which is the opposite of what forty-word paragraphs want. Retiming wants an eye on staging rather than a number picked here, so it is a separate change.

**Verified locally:** `tsc --noEmit` clean; `biome check` clean on the three TS files (the CSS sheet's warnings are pre-existing `noDescendingSpecificity` hits elsewhere); `creditsProse.test.ts` 10/10 under a throwaway `environment: "node"` config. `creditsRoll.test.ts` and `creditsRain.test.ts` cannot run in that config — they need `document`/`window`, and jsdom is broken on this box's node — so their verdict is CI's, not mine.
