### PR TITLE
credits: show contributors as nick (Name), drop bots from the roll

### DIFF
--- a/cicchetto/e2e/tests/issue1773-credits-roll-bakes-git-facts.spec.ts
+++ b/cicchetto/e2e/tests/issue1773-credits-roll-bakes-git-facts.spec.ts
@@ -38,7 +38,14 @@
 import { loginAs, openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { expect, specUser, test } from "../fixtures/test";
 
-type BakedContributor = { readonly name: string; readonly commits: number };
+type BakedContributor = {
+  readonly name: string;
+  // #1927 — the handle the roll credits, from `infra/packaging/contributors`.
+  // `null` (or absent, in a payload baked before the field existed) for a
+  // contributor the table does not name; the roll then paints the bare name.
+  readonly nick?: string | null;
+  readonly commits: number;
+};
 type BakedCredits = {
   readonly sha: string | null;
   readonly date: string | null;
@@ -125,13 +132,47 @@ test("#1773 — the credits roll paints the sha, date and contributors the build
   // The whole list and its ORDER, not a spot check: `git shortlog -sn` ranks
   // by commit count, and a roll that renamed, reordered or truncated the list
   // is exactly as wrong as an empty one.
+  //
+  // Since #1927 a row reads `nick (Name)`, with the parenthetical dropped when
+  // the handle IS the name or when there is no handle at all. The expectation
+  // is built from the payload rather than hardcoded, so it stays true of a
+  // build whose table has since grown a line.
   const painted = await page.getByTestId("credits-person").evaluateAll((rows) =>
     rows.map((row) => ({
       name: row.querySelector(".credits-person-name")?.textContent ?? "",
       commits: Number(row.querySelector(".credits-person-count")?.textContent ?? "NaN"),
     })),
   );
-  expect(painted).toEqual(baked.contributors.map((c) => ({ name: c.name, commits: c.commits })));
+  expect(painted).toEqual(
+    baked.contributors.map((c) => ({
+      name:
+        c.nick === undefined || c.nick === null || c.nick === c.name
+          ? c.name
+          : `${c.nick} (${c.name})`,
+      commits: c.commits,
+    })),
+  );
+
+  // ── and the real name is the ITALIC half of the pair ─────────────────────
+  // The pairing is the feature; without this, a build that stopped emitting
+  // the `<em>` would still satisfy the text comparison above.
+  const withNick = baked.contributors.filter(
+    (c) => c.nick !== undefined && c.nick !== null && c.nick !== c.name,
+  );
+  expect(
+    withNick.length,
+    "this checkout's contributor table must name at least one person, or the italic assertion below is vacuous",
+  ).toBeGreaterThan(0);
+  const italics = await page
+    .getByTestId("credits-person")
+    .evaluateAll((rows) =>
+      rows.map((row) => row.querySelector("em.credits-person-realname")?.textContent ?? null),
+    );
+  expect(italics).toEqual(
+    baked.contributors.map((c) =>
+      c.nick === undefined || c.nick === null || c.nick === c.name ? null : c.name,
+    ),
+  );
 
   // And the empty-state line is ABSENT — it is the fallback the degraded
   // build shows, and seeing it here would mean the list rendered from nothing.

--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -262,7 +262,21 @@ const CreditsModal: Component = () => {
                 >
                   {(person) => (
                     <li class="credits-person" data-testid="credits-person">
-                      <span class="credits-person-name">{person.name}</span>
+                      <span class="credits-person-name">
+                        {person.nick ?? person.name}
+                        {/*
+                          The real name is a parenthetical to the handle, and
+                          only when it says something the handle does not: for
+                          Lucy, or for a bot committing under its own handle,
+                          the two are the same string and "Lucy (Lucy)" would
+                          be noise. Nobody in the table, no nick — the bare
+                          name above is already the whole row.
+                        */}
+                        <Show when={person.nick !== null && person.nick !== person.name}>
+                          {" "}
+                          (<em class="credits-person-realname">{person.name}</em>)
+                        </Show>
+                      </span>
                       <span class="credits-person-count">{person.commits}</span>
                     </li>
                   )}

--- a/cicchetto/src/__tests__/CreditsModal.test.tsx
+++ b/cicchetto/src/__tests__/CreditsModal.test.tsx
@@ -80,8 +80,12 @@ const POPULATED: BuildCredits = {
   sha: "a453325e",
   date: "2026-08-25T23:15:06+02:00",
   contributors: [
-    { name: "Marcello Barnaba", commits: 5102 },
-    { name: "Stefy Lanza", commits: 147 },
+    { name: "Marcello Barnaba", nick: "vjt", commits: 5102 },
+    { name: "Stefy Lanza", nick: "nextime", commits: 147 },
+    // The two degenerate rows of #1927: a handle that IS the name, and a
+    // contributor missing from the nick table entirely. Both render bare.
+    { name: "Lucy", nick: "Lucy", commits: 26 },
+    { name: "Ada Lovelace", nick: null, commits: 3 },
   ],
 };
 
@@ -143,13 +147,29 @@ describe("CreditsModal (#1773)", () => {
     expect(screen.getByTestId("credits-date").textContent).toBe("2026-08-25");
 
     const people = screen.getAllByTestId("credits-person");
-    expect(people).toHaveLength(2);
-    expect(people[0]?.textContent).toContain("Marcello Barnaba");
+    expect(people).toHaveLength(4);
+    // Handle first, real name as an italic parenthetical (#1927).
+    expect(people[0]?.querySelector(".credits-person-name")?.textContent).toBe(
+      "vjt (Marcello Barnaba)",
+    );
+    expect(people[0]?.querySelector("em.credits-person-realname")?.textContent).toBe(
+      "Marcello Barnaba",
+    );
     // The COUNT, not just the name: a roll that lists everyone with no
     // numbers is the same DOM shape and a different feature.
     expect(people[0]?.textContent).toContain("5102");
-    expect(people[1]?.textContent).toContain("Stefy Lanza");
+    expect(people[1]?.querySelector(".credits-person-name")?.textContent).toBe(
+      "nextime (Stefy Lanza)",
+    );
     expect(people[1]?.textContent).toContain("147");
+
+    // Nick equal to the name, and no nick at all: one identifier, no
+    // parentheses, nothing in italics. "Lucy (Lucy)" is the bug this asserts
+    // against.
+    expect(people[2]?.querySelector(".credits-person-name")?.textContent).toBe("Lucy");
+    expect(people[2]?.querySelector("em")).toBeNull();
+    expect(people[3]?.querySelector(".credits-person-name")?.textContent).toBe("Ada Lovelace");
+    expect(people[3]?.querySelector("em")).toBeNull();
   });
 
   it("says the build carries no history rather than rolling an empty list", () => {

--- a/cicchetto/src/__tests__/buildCredits.test.ts
+++ b/cicchetto/src/__tests__/buildCredits.test.ts
@@ -27,12 +27,23 @@ describe("coerceBuildCredits (#1773)", () => {
       sha: "a453325e",
       date: "2026-08-25T23:15:06+02:00",
       contributors: [
-        { name: "Marcello Barnaba", commits: 5102 },
-        { name: "Stefy Lanza", commits: 147 },
+        { name: "Marcello Barnaba", nick: "vjt", commits: 5102 },
+        { name: "Stefy Lanza", nick: "nextime", commits: 147 },
       ],
     };
 
     expect(coerceBuildCredits(JSON.stringify(payload))).toEqual(payload);
+  });
+
+  it("reads a payload baked before nicks existed as nickless, not as broken", () => {
+    // A bundle built by an older credits.sh carries no `nick` field at all
+    // (#1927). Those contributors are still contributors — the roll shows
+    // their bare names, exactly as it did before the field was added.
+    const preNick = '{"sha":null,"date":null,"contributors":[{"name":"Ada Lovelace","commits":3}]}';
+
+    expect(coerceBuildCredits(preNick).contributors).toEqual([
+      { name: "Ada Lovelace", nick: null, commits: 3 },
+    ]);
   });
 
   it("accepts the no-git payload as data, not as a fault", () => {
@@ -63,16 +74,22 @@ describe("coerceBuildCredits (#1773)", () => {
       sha: null,
       date: null,
       contributors: [
-        { name: "Ada Lovelace", commits: 3 },
-        { name: "", commits: 9 },
+        { name: "Ada Lovelace", nick: "ada", commits: 3 },
+        { name: "", nick: "ghost", commits: 9 },
         { name: "No Count" },
         { name: "Negative", commits: -1 },
         { name: "Fractional", commits: 1.5 },
+        // A nick that is not a usable string costs the handle, not the row:
+        // the name and the count are still true.
+        { name: "Bad Nick", nick: 42, commits: 7 },
         "not an object",
       ],
     });
 
-    expect(coerceBuildCredits(mixed).contributors).toEqual([{ name: "Ada Lovelace", commits: 3 }]);
+    expect(coerceBuildCredits(mixed).contributors).toEqual([
+      { name: "Ada Lovelace", nick: "ada", commits: 3 },
+      { name: "Bad Nick", nick: null, commits: 7 },
+    ]);
   });
 
   it("degrades to the empty payload on anything that is not a credits object", () => {

--- a/cicchetto/src/lib/buildCredits.ts
+++ b/cicchetto/src/lib/buildCredits.ts
@@ -22,9 +22,18 @@
 // meta, which `Grappa.Cic.Bundle` parses out of the deployed dist), so the
 // meta channel buys nothing here.
 
-/** One credited author and the number of non-merge commits they authored. */
+/**
+ * One credited author and the number of non-merge commits they authored.
+ *
+ * `nick` is the handle the project knows them by, mapped from the git author
+ * name by the static table at `infra/packaging/contributors` (#1927). It is
+ * `null` for anyone absent from that table — a new contributor lands in the
+ * history before anyone edits it, and that must degrade to a bare name, not
+ * fail a build.
+ */
 export type Contributor = {
   readonly name: string;
+  readonly nick: string | null;
   readonly commits: number;
 };
 
@@ -63,11 +72,18 @@ function presence(value: unknown): string | null {
 
 function contributor(entry: unknown): Contributor | null {
   if (typeof entry !== "object" || entry === null) return null;
-  const { name, commits } = entry as { name?: unknown; commits?: unknown };
+  const { name, nick, commits } = entry as {
+    name?: unknown;
+    nick?: unknown;
+    commits?: unknown;
+  };
   const named = presence(name);
   if (named === null) return null;
   if (typeof commits !== "number" || !Number.isInteger(commits) || commits < 0) return null;
-  return { name: named, commits };
+  // A missing or unusable `nick` costs the handle, not the contributor: a
+  // payload baked by an older credits.sh has no such field at all, and that
+  // build still deserves its roll.
+  return { name: named, nick: presence(nick), commits };
 }
 
 /**

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14671,13 +14671,27 @@ audio.media-viewer-media {
   color: var(--muted);
 }
 
+/* A hair of depth under the handle so it reads ahead of the real name without
+   going bold — bold in a monospace pastiche shouts, and the roll is a whisper.
+   The accent glow is repeated on purpose: `text-shadow` REPLACES the inherited
+   list rather than adding to it, so leaving it out would strip the nick of the
+   glow `.credits-roll` gives every other line. */
+.credits-person-name {
+  text-shadow:
+    0 0 0.5rem var(--accent),
+    0 1px 1px rgb(0 0 0 / 55%);
+}
+
 /* The real name behind the handle (#1927). Italic said outright rather than
    left to the `em` default: the roll is a monospace pastiche whose stack has
    no guaranteed italic face, so this is the line to look at when it renders
-   upright. Muted for the same reason the count is — the handle is the row. */
+   upright. Muted for the same reason the count is — the handle is the row.
+   The drop shadow stops at the handle: it is what separates the two, so the
+   name inside falls back to the roll's plain glow. */
 .credits-person-realname {
   font-style: italic;
   color: var(--muted);
+  text-shadow: 0 0 0.5rem var(--accent);
 }
 
 /* #1924 — the prose that rides between one pass of the names and the next,

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14673,13 +14673,15 @@ audio.media-viewer-media {
 
 /* A hair of depth under the handle so it reads ahead of the real name without
    going bold — bold in a monospace pastiche shouts, and the roll is a whisper.
-   The accent glow is repeated on purpose: `text-shadow` REPLACES the inherited
-   list rather than adding to it, so leaving it out would strip the nick of the
-   glow `.credits-roll` gives every other line. */
+   The offset shadow is the THEME's accent faded, never a fixed black: on a
+   green theme it drops green, which is the whole point of a themed roll.
+   The glow is repeated on purpose: `text-shadow` REPLACES the inherited list
+   rather than adding to it, so leaving it out would strip the nick of the glow
+   `.credits-roll` gives every other line. */
 .credits-person-name {
   text-shadow:
     0 0 0.5rem var(--accent),
-    0 1px 1px rgb(0 0 0 / 55%);
+    0 1px 1px color-mix(in oklab, var(--accent) 55%, transparent);
 }
 
 /* The real name behind the handle (#1927). Italic said outright rather than

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14671,6 +14671,15 @@ audio.media-viewer-media {
   color: var(--muted);
 }
 
+/* The real name behind the handle (#1927). Italic said outright rather than
+   left to the `em` default: the roll is a monospace pastiche whose stack has
+   no guaranteed italic face, so this is the line to look at when it renders
+   upright. Muted for the same reason the count is — the handle is the row. */
+.credits-person-realname {
+  font-style: italic;
+  color: var(--muted);
+}
+
 /* #1924 — the prose that rides between one pass of the names and the next,
    in the column and directly under them, so it enters through the bottom of
    the viewport while the list is still leaving through the top.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4428,7 +4428,20 @@ there. It echoes ONE line of JSON with the three facts the credits easter
 egg needs and a browser cannot have:
 
     {"sha":"a1d57bd3","date":"2026-08-27T12:22:32+02:00",
-     "contributors":[{"name":"…","commits":5193},…]}
+     "contributors":[{"name":"…","nick":"…","commits":5193},…]}
+
+**The `nick` is a lookup, not a git fact (#1927).** The roll credits people
+as `nick (Name)`, and a commit carries no handle — resolving one would mean
+the GitHub API, which this script cannot reach from a FreeBSD jail or from a
+release tarball. So the mapping is static data at
+`infra/packaging/contributors`: one `<git author name><TAB><handle>` line per
+person, `#` comments allowed, read by the same awk run that builds the
+payload. **Add a line there when a new contributor appears** — an author the
+table does not name gets `nick:null` and is rendered by their bare name,
+which is a missing credit and never a failed build. The same awk drops any
+author whose name ends in `[bot]`, GitHub's suffix for App identities:
+filtering where the list is BORN keeps rows the roll will never show from
+travelling inside the bundle.
 
 Every cic-build entrypoint that exports `GRAPPA_VERSION` exports
 `GRAPPA_CREDITS` beside it, from this script, and `cicchetto/vite.config.ts`

--- a/infra/packaging/contributors
+++ b/infra/packaging/contributors
@@ -1,0 +1,32 @@
+# contributors — git author name → the handle to credit them by (#1927).
+#
+# The credit roll reads `nick (Name)`, and the nick is the handle the project
+# actually knows the person by. It cannot be derived from the commit: a git
+# author is a name and an email, and the GitHub handle behind them is only
+# resolvable through the API — which credits.sh must not need, since it runs
+# in a FreeBSD jail and from a release tarball with no `.git` and no network
+# (see the header of credits.sh). So the mapping is static data, kept here.
+#
+# Format: one contributor per line, `<git author name><TAB><nick>`. Lines that
+# are blank or start with `#` are comments. An author who is NOT listed simply
+# gets no nick and is rendered by name alone — an unknown contributor must
+# never be a build failure, same contract as every other probe in credits.sh.
+#
+# The default nick is the person's GitHub handle. Where the project knows
+# someone by another handle, that one wins — this file records the owner's
+# call, not GitHub's opinion. Both such overrides are marked below.
+#
+# Match the author name EXACTLY as `git shortlog -sn --no-merges HEAD` prints
+# it; if someone starts committing under a second name, add a second line
+# pointing at the same nick rather than rewriting history.
+
+Marcello Barnaba	vjt
+Stefy Lanza	nextime
+Alessio Bonforti	Hypnotize
+# Override: his GitHub handle is @gmsrc, but the project calls him peluche.
+Gabriele Marrone	peluche
+Lucy	Lucy
+vjt-claude	vjt-claude
+Pasquale Minervini	deadbeef
+# Override: GitHub handle differs; Sonic is the handle he is known by here.
+Michele Vacca	Sonic

--- a/infra/packaging/credits.sh
+++ b/infra/packaging/credits.sh
@@ -2,7 +2,7 @@
 # credits.sh — echo the build's git credits payload, as ONE line of JSON.
 #
 #   {"sha":"a453325e","date":"2026-08-25T18:04:11+02:00",
-#    "contributors":[{"name":"…","commits":903},…]}
+#    "contributors":[{"name":"…","nick":"…","commits":903},…]}
 #
 # Sibling of version.sh, and deliberately shaped like it: the cic build runs
 # in containers that mount ONLY ./cicchetto (cicchetto/vite.config.ts:30-39),
@@ -74,10 +74,23 @@ if [ -e "${REPO_ROOT}/.git" ]; then
 	shortlog="$(git -C "${REPO_ROOT}" shortlog -sn --no-merges HEAD 2>/dev/null || true)"
 fi
 
-# ONE awk pass builds the whole payload: the contributor rows come in on
-# stdin, the two scalars on -v. LC_ALL=C keeps substr/length byte-oriented, so
-# a multi-byte name is copied through byte by byte and reassembles exactly —
-# awk never reorders what it concatenates.
+# The nick table (#1927) — `<author name>\t<handle>`, documented in its own
+# header. OPTIONAL by construction: a tree without it, or one where it cannot
+# be read, yields every contributor with `nick:null` and the roll falls back to
+# bare names. Same posture as every probe above — degrade, never abort.
+NICKS="${SCRIPT_DIR}/contributors"
+[ -r "${NICKS}" ] || NICKS=/dev/null
+
+# ONE awk run builds the whole payload: the nick table comes in as the first
+# operand, the contributor rows on stdin, the two scalars on -v. LC_ALL=C keeps
+# substr/length byte-oriented, so a multi-byte name is copied through byte by
+# byte and reassembles exactly — awk never reorders what it concatenates.
+#
+# The two inputs are told apart by the `pass=` assignments BETWEEN the operands
+# (POSIX: command-line assignments take effect in operand order), not by the
+# usual `NR == FNR` idiom — that one silently misreads the second file as the
+# first whenever the first is EMPTY, which here is the everyday case of a
+# missing table (/dev/null) and would parse the shortlog as nick mappings.
 printf '%s' "${shortlog}" | LC_ALL=C awk -v sha="${sha}" -v head_date="${date}" '
 	# JSON string literal. Character-by-character rather than gsub: the
 	# replacement text of gsub gives `\` and `&` their own meanings, which is
@@ -106,6 +119,36 @@ printf '%s' "${shortlog}" | LC_ALL=C awk -v sha="${sha}" -v head_date="${date}" 
 		return s == "" ? "null" : jsonstr(s)
 	}
 
+	# Blanks around either field (and a CR, if the table was ever edited on
+	# Windows) would otherwise become part of the key or of the nick — an
+	# invisible edit that silently stops matching, or ships a handle with a
+	# space in it. git strips leading and trailing blanks from an author name
+	# itself, so nothing legitimate is lost here.
+	function trim(s) {
+		sub(/^[ \t\r]+/, "", s)
+		sub(/[ \t\r]+$/, "", s)
+		return s
+	}
+
+	function nickof(name) {
+		return (name in nick) ? jsonstr(nick[name]) : "null"
+	}
+
+	# First operand: the nick table. `<author name>\t<handle>`, `#` comments and
+	# blank lines skipped. A malformed line is dropped rather than guessed at —
+	# a typo must cost one missing nick, not a broken payload.
+	pass == 1 {
+		if ($0 ~ /^[ \t]*(#|$)/) {
+			next
+		}
+		tab = index($0, "\t")
+		if (tab == 0) {
+			next
+		}
+		nick[trim(substr($0, 1, tab - 1))] = trim(substr($0, tab + 1))
+		next
+	}
+
 	{
 		# `shortlog -sn` emits "<count>\t<name>"; a line without the tab is
 		# not a contributor row and is dropped rather than guessed at.
@@ -113,10 +156,22 @@ printf '%s' "${shortlog}" | LC_ALL=C awk -v sha="${sha}" -v head_date="${date}" 
 		if (tab == 0) {
 			next
 		}
+		name = substr($0, tab + 1)
+		# Bots are dropped where the list is BORN, not hidden in the renderer:
+		# what the roll will never show has no business travelling in the
+		# bundle. `[bot]` is the suffix GitHub gives every App identity, so
+		# dependabot[bot] (#1927, the one that outranked half the humans by
+		# commit count) and its future siblings go the same way. A human whose
+		# name genuinely ends in "[bot]" does not exist; a bot we DO want to
+		# credit — vjt-claude — commits under a plain name and is unaffected.
+		if (length(name) > 5 && substr(name, length(name) - 4) == "[bot]") {
+			next
+		}
 		if (n > 0) {
 			rows = rows ","
 		}
-		rows = rows "{\"name\":" jsonstr(substr($0, tab + 1)) ",\"commits\":" ($1 + 0) "}"
+		rows = rows "{\"name\":" jsonstr(name) ",\"nick\":" nickof(name) \
+			",\"commits\":" ($1 + 0) "}"
 		n++
 	}
 
@@ -124,4 +179,4 @@ printf '%s' "${shortlog}" | LC_ALL=C awk -v sha="${sha}" -v head_date="${date}" 
 		printf "{\"sha\":%s,\"date\":%s,\"contributors\":[%s]}\n",
 			jsonornull(sha), jsonornull(head_date), rows
 	}
-'
+' pass=1 "${NICKS}" pass=2 -

--- a/test/infra/credits_payload_test.bats
+++ b/test/infra/credits_payload_test.bats
@@ -29,7 +29,15 @@
 #      env var, and a multi-line payload would arrive mangled;
 #   6. one person gets ONE credit — `.mailmap` collapses the identities a
 #      contributor has committed under, and the roll must show the collapsed
-#      list rather than the same person two or three times (#1808).
+#      list rather than the same person two or three times (#1808);
+#   7. the NICK is looked up, and its absence is NOT a fault — the roll reads
+#      `nick (Name)`, the mapping lives in the static table
+#      `infra/packaging/contributors`, and a contributor missing from it (or a
+#      missing table entirely, which is every tree built before it shipped)
+#      degrades to `nick:null` rather than to a broken build (#1927);
+#   8. bot identities are dropped where the list is BORN — `dependabot[bot]`
+#      outranked half the humans by commit count, and filtering it in the
+#      renderer instead would still ship it inside the bundle (#1927).
 #
 # The sandbox repos are built here rather than measured against this checkout:
 # the real history changes every commit, so a case reading it could only
@@ -92,7 +100,7 @@ init_repo() {
     [ "$status" -eq 0 ]
     # Descending by count, which is what `shortlog -sn` orders by and what a
     # credit roll wants — the exact string, so a re-ordering fails too.
-    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","commits":3},{"name":"Grace Hopper","commits":1}]'* ]]
+    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","nick":null,"commits":3},{"name":"Grace Hopper","nick":null,"commits":1}]'* ]]
 }
 
 @test "the sha and the date are the ones HEAD actually carries" {
@@ -126,8 +134,8 @@ init_repo() {
 
     [ "$status" -eq 0 ]
     refute grep -q 'Mergebot' <<< "$output"
-    [[ "$output" == *'{"name":"Ada Lovelace","commits":2}'* ]]
-    [[ "$output" == *'{"name":"Grace Hopper","commits":1}'* ]]
+    [[ "$output" == *'{"name":"Ada Lovelace","nick":null,"commits":2}'* ]]
+    [[ "$output" == *'{"name":"Grace Hopper","nick":null,"commits":1}'* ]]
 }
 
 @test "a name carrying a quote or a backslash is escaped, not emitted raw" {
@@ -148,7 +156,7 @@ init_repo() {
     [ "$status" -eq 0 ]
     # Single-quoted pattern: bash takes every character literally, so this is
     # the payload's exact bytes — two escaped quotes, one escaped backslash.
-    [[ "$output" == *'{"name":"A \"B\" C\\D","commits":1}'* ]]
+    [[ "$output" == *'{"name":"A \"B\" C\\D","nick":null,"commits":1}'* ]]
 }
 
 @test "no git is an honest empty payload, not a failure (AUR tarball, Dockerfile.release)" {
@@ -208,7 +216,7 @@ init_repo() {
     [ "$status" -eq 0 ]
     # Three commits on ONE row. The exact string, like the case at the top of
     # this file: a partial collapse (two rows for Ada) is as wrong as none.
-    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","commits":3},{"name":"Grace Hopper","commits":1}]'* ]]
+    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","nick":null,"commits":3},{"name":"Grace Hopper","nick":null,"commits":1}]'* ]]
 }
 
 @test "#1808 — every alias this repo's .mailmap collapses resolves to one identity" {
@@ -248,10 +256,10 @@ init_repo() {
     # Anti-hollow-green: a checkout with no readable git yields the honest
     # empty payload, against which every `refute` below holds vacuously. The
     # canonical names must be PRESENT before their aliases may be absent.
-    [[ "$output" == *'{"name":"Marcello Barnaba","commits":'* ]]
-    [[ "$output" == *'{"name":"Gabriele Marrone","commits":'* ]]
-    [[ "$output" == *'{"name":"vjt-claude","commits":'* ]]
-    [[ "$output" == *'{"name":"Stefy Lanza","commits":'* ]]
+    [[ "$output" == *'{"name":"Marcello Barnaba","nick":"vjt","commits":'* ]]
+    [[ "$output" == *'{"name":"Gabriele Marrone","nick":"peluche","commits":'* ]]
+    [[ "$output" == *'{"name":"vjt-claude","nick":"vjt-claude","commits":'* ]]
+    [[ "$output" == *'{"name":"Stefy Lanza","nick":"nextime","commits":'* ]]
     refute grep -q '"name":"vjt"' <<< "$output"
     refute grep -q '"name":"gabrielemarrone"' <<< "$output"
     refute grep -q '"name":"claude"' <<< "$output"
@@ -275,4 +283,161 @@ init_repo() {
 
     [ "$status" -eq 0 ]
     [ "$output" = 'vjt-claude <marcello.barnaba@gmail.com>' ]
+}
+
+# ── #1927 — nick (Name), and no bots in a roll of people ────────────────────
+#
+# The roll credits people by the handle the project knows them by, with the
+# real name as an italic parenthetical. A git commit carries no handle, and
+# resolving one through the GitHub API is out of reach here by design (this
+# script runs in a FreeBSD jail and from a release tarball, with no network),
+# so the mapping is static data at `infra/packaging/contributors` — read by
+# the same awk run that builds the payload.
+#
+# Every case below is about the DEGRADE as much as the lookup: an unmapped
+# contributor, a malformed line and a missing table must each cost one nick,
+# never the build. The sandbox has no table unless a case writes one, which is
+# why every assertion further up this file reads `"nick":null`.
+
+write_nicks() {
+    printf '%s\n' "$@" > "$REPO/infra/packaging/contributors"
+}
+
+@test "#1927 — the table maps an author name to the handle the roll credits" {
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "Ada Lovelace" "ada@example.invalid" "two"
+    commit_as "Grace Hopper" "grace@example.invalid" "three"
+    write_nicks "$(printf 'Ada Lovelace\tada')" "$(printf 'Grace Hopper\tamazing_grace')"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","nick":"ada","commits":2},{"name":"Grace Hopper","nick":"amazing_grace","commits":1}]'* ]]
+}
+
+@test "#1927 — a contributor absent from the table keeps the credit, loses the nick" {
+    # The everyday case: someone lands in the history before anyone edits the
+    # table. Dropping them, or failing, would make the table a gate on
+    # contributing.
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "Grace Hopper" "grace@example.invalid" "two"
+    write_nicks "$(printf 'Ada Lovelace\tada')"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'{"name":"Ada Lovelace","nick":"ada","commits":1}'* ]]
+    [[ "$output" == *'{"name":"Grace Hopper","nick":null,"commits":1}'* ]]
+}
+
+@test "#1927 — comments, blanks and a tabless line cost one mapping, not the payload" {
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "Grace Hopper" "grace@example.invalid" "two"
+    # A comment, an indented comment, a blank line, and the typo that matters:
+    # a row written with SPACES where the format wants a tab. It is dropped
+    # rather than guessed at — guessing would map "Grace" to "Hopper amazing".
+    write_nicks \
+        '# the header this file really carries' \
+        '   # indented, still a comment' \
+        '' \
+        'Grace Hopper amazing_grace' \
+        "$(printf 'Ada Lovelace\tada')"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'{"name":"Ada Lovelace","nick":"ada","commits":1}'* ]]
+    [[ "$output" == *'{"name":"Grace Hopper","nick":null,"commits":1}'* ]]
+}
+
+@test "#1927 — trailing blanks in the table are not part of the nick" {
+    # An invisible edit that would otherwise ship a handle nobody can match
+    # against anything on screen.
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    write_nicks "$(printf 'Ada Lovelace \t ada \t')"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'{"name":"Ada Lovelace","nick":"ada","commits":1}'* ]]
+}
+
+@test "#1927 — an EMPTY table is not read as the shortlog it precedes" {
+    # The `NR == FNR` idiom would take the FIRST stdin line as a table row here
+    # — an empty first file makes the two indistinguishable — and the roll
+    # would silently lose its top contributor. The `pass=` assignments between
+    # the operands are what keeps them apart; this case dies if they go.
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "Ada Lovelace" "ada@example.invalid" "two"
+    commit_as "Grace Hopper" "grace@example.invalid" "three"
+    : > "$REPO/infra/packaging/contributors"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"contributors":[{"name":"Ada Lovelace","nick":null,"commits":2},{"name":"Grace Hopper","nick":null,"commits":1}]'* ]]
+}
+
+@test "#1927 — a nick carrying a JSON metacharacter is escaped like a name" {
+    # The table is hand-edited data reaching the same payload the names do, so
+    # it goes through the same escaper. Raw, one quote here is a broken build.
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    write_nicks "$(printf 'Ada Lovelace\tA "B" C\\D')"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'{"name":"Ada Lovelace","nick":"A \"B\" C\\D","commits":1}'* ]]
+}
+
+@test "#1927 — a [bot] identity never reaches the payload" {
+    init_repo
+    commit_as "Ada Lovelace" "ada@example.invalid" "one"
+    commit_as "dependabot[bot]" "49699333+dependabot[bot]@users.noreply.github.com" "bump"
+    commit_as "dependabot[bot]" "49699333+dependabot[bot]@users.noreply.github.com" "bump again"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Gone entirely — not present with a null nick, not present last. The
+    # anti-hollow-green half: the human it outranked is still there, so this
+    # cannot pass on an empty payload.
+    [[ "$output" == *'{"name":"Ada Lovelace","nick":null,"commits":1}'* ]]
+    refute grep -q 'dependabot' <<< "$output"
+}
+
+@test "#1927 — a name that merely CONTAINS [bot] is a contributor, not a bot" {
+    # The filter keys on the trailing `[bot]` GitHub appends to App identities.
+    # A substring match would eat a human, and silently.
+    init_repo
+    commit_as "Bot[bot]tomley" "human@example.invalid" "one"
+    commit_as "[bot]" "short@example.invalid" "two"
+
+    run "$SANDBOX_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'{"name":"Bot[bot]tomley","nick":null,"commits":1}'* ]]
+    # Exactly `[bot]` and nothing else is five characters: too short to be an
+    # App identity (`<app>[bot]`), so it is a name and it stays.
+    [[ "$output" == *'{"name":"[bot]","nick":null,"commits":1}'* ]]
+}
+
+@test "#1927 — this checkout's own table names every contributor in its roll" {
+    # Reads THIS repo, like the #1808 mapping case: the table is a committed
+    # artefact, so it can be asserted exactly. A contributor who lands without
+    # a table entry shows up here as a null nick — that is the reminder to add
+    # the line, and it is deliberately louder than the silent bare-name render.
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    # Anti-hollow-green: a checkout with no readable git yields the empty
+    # payload, against which the refute below holds vacuously.
+    [[ "$output" == *'{"name":"Marcello Barnaba","nick":"vjt","commits":'* ]]
+    refute grep -q '"nick":null' <<< "$output"
 }


### PR DESCRIPTION
Closes #1927.

The roll credits people by the handle the project knows them by, with the real
name as an italic parenthetical: `nick (*Name*)`. It falls back to the bare
identifier when the handle IS the name (Lucy, vjt-claude) or when there is no
handle at all.

* `infra/packaging/contributors` — the static mapping, `<author name><TAB><handle>`.
  A commit carries no handle, and resolving one means the GitHub API, which
  `credits.sh` cannot reach from a FreeBSD jail or a release tarball, so the
  table is data in-tree. An unlisted author degrades to `nick:null` and renders
  bare — a missing credit, never a failed build.
* `credits.sh` reads it in the same awk run, and drops any author whose name
  ends in `[bot]` (GitHub's App-identity suffix), so `dependabot[bot]` leaves
  the roll where the list is born rather than being hidden in the renderer.
* `buildCredits.ts` carries `nick` through with the same per-field degrade the
  rest of the payload already has: a bundle baked by an older `credits.sh` has
  no such field, and its contributors are still contributors.

### Verified

`test/infra/credits_payload_test.bats` — 18/18 green locally, nine of them new:
the lookup, an unlisted author, comments/blank/tabless lines, trailing blanks,
JSON metacharacters in a nick, the `[bot]` filter and its near-miss (a name
that merely *contains* `[bot]` is a person), this checkout's own table, and the
empty-table case that dies if the `pass=` operand assignments are ever replaced
by `NR == FNR`.

The vitest suite does not run on this host (node 20; jsdom's undici wants
`webidl.util.markAsUncloneable`, node >= 22), so the `CreditsModal` /
`buildCredits` specs and the e2e are on CI. `biome check` and `tsc --noEmit`
are clean locally.
