### PR TITLE
credits(1929): one block for the roll, the cow and the thanks, then a fade into denser rain

### DIFF
--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -10,6 +10,7 @@ import {
 import { buildCredits, creditsDateLabel } from "./lib/buildCredits";
 import { bootBundleVersionAccessor } from "./lib/bundleHash";
 import { type CreditsArpeggio, startCreditsArpeggio } from "./lib/creditsAudio";
+import { CREDITS_COW, CREDITS_SPECIAL_THANKS } from "./lib/creditsBlock";
 import {
   closeCreditsModal,
   creditsModalOpen,
@@ -65,6 +66,20 @@ const CreditsModal: Component = () => {
   // close over it, neither runs before it is assigned.
   let roll: HTMLDivElement | undefined;
 
+  // #1929 — the first block's own element, and the second thing the rain
+  // reads. It carries `credits-block-fade`, so its phase is what tells
+  // `creditsRainLook` the dissolve has started; the roll's phase alone cannot,
+  // because the roll is still travelling at that point.
+  //
+  // A SEPARATE ref rather than a subtree lookup: `roll.getAnimations({subtree:
+  // true})` would return both animations and the existing readers index `[0]`,
+  // so the two would start depending on an unspecified order.
+  //
+  // Reassigned to `undefined` when the block goes, because after the first
+  // pass there genuinely is no block — a stale reference would keep the rain
+  // bursting off a dead element's filled-forwards animation.
+  let block: HTMLDivElement | undefined;
+
   // ── prose between the passes (#1924) ────────────────────────────────────
   // A THIRD reader of the same animation, and deliberately not a third clock:
   // `animationiteration` is the roll telling us it has come back round, so the
@@ -90,18 +105,18 @@ const CreditsModal: Component = () => {
   const [pass, setPass] = createSignal(0);
 
   createEffect(() => {
-    // Drawn on OPEN rather than at construction: this component is mounted in
-    // Shell for the whole session, so a draw in the body would burn a set at
-    // boot for a modal nobody may open. Empty until then, and the roll simply
-    // has no prose block — which is also the honest render for a pool that
-    // shipped empty.
+    // #1929 — CLEARED on open, not drawn. The first pass is the block (names,
+    // cow, thanks) and carries no prose at all, so a set drawn here would be
+    // dealt out of the bag and never seen: the first `animationiteration`
+    // replaces it before it is ever on screen. Drawing lazily is what keeps
+    // the deck's no-repeat promise honest.
     //
     // The pass resets with it: `Show` builds a fresh element on every open, so
     // its animation genuinely starts over, and carrying the old count would
-    // hide the names from the second viewing onwards.
+    // hide the block from the second viewing onwards.
     if (creditsModalOpen()) {
       setPass(0);
-      setProse(deck.draw());
+      setProse(null);
     }
   });
 
@@ -167,7 +182,7 @@ const CreditsModal: Component = () => {
         <MatrixRain
           class="credits-rain"
           testId="credits-matrix-rain"
-          look={() => creditsRainLook(roll)}
+          look={() => creditsRainLook(roll, block)}
         />
 
         <div class="credits-chrome">
@@ -226,70 +241,127 @@ const CreditsModal: Component = () => {
                 the same list every 34s teaches the viewer to stop reading,
                 which is the surest way to make the prose invisible too.
 
-                The swap rides the same `animationiteration` as the prose, so
-                it lands on the frame the column is parked off the top —
-                nothing is seen disappearing. */}
-            <Show when={pass() === 0}>
-              <h2 class="credits-title" data-testid="credits-title">
-                GRAPPA IRC
-              </h2>
-              <p class="credits-version" data-testid="credits-version">
-                {versionLabel()}
-              </p>
-              <p class="credits-build" data-testid="credits-build">
-                <span data-testid="credits-sha">{credits.sha ?? "no build sha"}</span>
-                <Show when={dateLabel()}>
-                  {(day) => (
-                    <>
-                      <span aria-hidden="true"> · </span>
-                      <span data-testid="credits-date">{day()}</span>
-                    </>
-                  )}
-                </Show>
-              </p>
+                #1929 — and they are not alone in it: the titles, the
+                contributors, the cow and the special thanks are ONE block, the
+                first one, which ends in a fade. So the wrapper is not
+                decorative — it is the element carrying `credits-block-fade`,
+                and it is what dissolves and what the rain reads. Putting that
+                animation on the roll instead would fade the prose too, for
+                ever, since the roll outlives the block.
 
-              <h3 class="credits-heading">contributors</h3>
-              <ul class="credits-list">
-                <For
-                  each={credits.contributors}
-                  fallback={
-                    // Honest, not blank: this is what a build from a source
-                    // tarball looks like, and it is a legitimate build.
-                    <li class="credits-empty" data-testid="credits-empty">
-                      this build carries no history
-                    </li>
-                  }
-                >
-                  {(person) => (
-                    <li class="credits-person" data-testid="credits-person">
-                      <span class="credits-person-name">
-                        {person.nick ?? person.name}
-                        {/*
-                          The real name is a parenthetical to the handle, and
-                          only when it says something the handle does not: for
-                          Lucy, or for a bot committing under its own handle,
-                          the two are the same string and "Lucy (Lucy)" would
-                          be noise. Nobody in the table, no nick — the bare
-                          name above is already the whole row.
-                        */}
-                        <Show when={person.nick !== null && person.nick !== person.name}>
-                          {" "}
-                          (<em class="credits-person-realname">{person.name}</em>)
-                        </Show>
-                      </span>
-                      <span class="credits-person-count">{person.commits}</span>
-                    </li>
-                  )}
-                </For>
-              </ul>
+                The DOM swap still rides `animationiteration`, i.e. it lands a
+                full interlude after the fade has finished: by then the block
+                is transparent AND parked off the top, so what is removed has
+                been invisible twice over. */}
+            <Show when={pass() === 0}>
+              <div
+                class="credits-block"
+                data-testid="credits-block"
+                ref={(node) => {
+                  block = node;
+                  // A detached element reports no animations, so a stale ref
+                  // would already answer "not fading" — this is here to make
+                  // the lifetime explicit rather than to rely on that.
+                  onCleanup(() => {
+                    block = undefined;
+                  });
+                }}
+              >
+                <h2 class="credits-title" data-testid="credits-title">
+                  GRAPPA IRC
+                </h2>
+                <p class="credits-version" data-testid="credits-version">
+                  {versionLabel()}
+                </p>
+                <p class="credits-build" data-testid="credits-build">
+                  <span data-testid="credits-sha">{credits.sha ?? "no build sha"}</span>
+                  <Show when={dateLabel()}>
+                    {(day) => (
+                      <>
+                        <span aria-hidden="true"> · </span>
+                        <span data-testid="credits-date">{day()}</span>
+                      </>
+                    )}
+                  </Show>
+                </p>
+
+                <h3 class="credits-heading">contributors</h3>
+                <ul class="credits-list">
+                  <For
+                    each={credits.contributors}
+                    fallback={
+                      // Honest, not blank: this is what a build from a source
+                      // tarball looks like, and it is a legitimate build.
+                      <li class="credits-empty" data-testid="credits-empty">
+                        this build carries no history
+                      </li>
+                    }
+                  >
+                    {(person) => (
+                      <li class="credits-person" data-testid="credits-person">
+                        <span class="credits-person-name">
+                          {person.nick ?? person.name}
+                          {/*
+                            The real name is a parenthetical to the handle, and
+                            only when it says something the handle does not: for
+                            Lucy, or for a bot committing under its own handle,
+                            the two are the same string and "Lucy (Lucy)" would
+                            be noise. Nobody in the table, no nick — the bare
+                            name above is already the whole row.
+                          */}
+                          <Show when={person.nick !== null && person.nick !== person.name}>
+                            {" "}
+                            (<em class="credits-person-realname">{person.name}</em>)
+                          </Show>
+                        </span>
+                        <span class="credits-person-count">{person.commits}</span>
+                      </li>
+                    )}
+                  </For>
+                </ul>
+
+                {/* Azzurra's own Super Cow, from bahamut's `/info`. A `pre`
+                    because it is fixed-width art: the glyphs mean nothing
+                    except in the columns they were drawn in. */}
+                <pre class="credits-cow" data-testid="credits-cow">
+                  {CREDITS_COW}
+                </pre>
+
+                {/* Dictated by vjt, verbatim — see `creditsBlock.ts`. The
+                    dash is `aria-hidden` for the reason the build separator
+                    above is: it is punctuation between two fields, and a
+                    screen reader announcing it reads as a word. */}
+                <h3 class="credits-heading">special thanks</h3>
+                <ul class="credits-thanks">
+                  <For each={CREDITS_SPECIAL_THANKS}>
+                    {(entry) => (
+                      <li data-testid="credits-thanks">
+                        <span class="credits-thanks-who">{entry.who}</span>
+                        <span aria-hidden="true"> — </span>
+                        <span class="credits-thanks-why">{entry.why}</span>
+                      </li>
+                    )}
+                  </For>
+                </ul>
+
+                {/* The coda closes the block for the same reason it used to
+                    close the names: it is a tagline, and a tagline on a loop
+                    stops being read and starts being a boast. */}
+                <p class="credits-coda">
+                  an always-on IRC bouncer, and a client that looks like irssi
+                </p>
+              </div>
             </Show>
 
-            {/* #1924 — inside the column, directly under the names. That
-                placement is the feature: the paragraph enters through the
-                bottom of the viewport while the contributor list is still
-                leaving through the top, so nothing waits for the titles to
-                scroll away and there is no second screen to cut to. */}
-            <Show when={prose()}>
+            {/* #1924 — inside the column, so a paragraph enters through the
+                bottom of the viewport rather than cutting to a second screen.
+
+                #1929 — but NOT during the first pass any more. The block is
+                the first thing and the prose is what comes after it, so the
+                gate is on the pass and not merely on there being a set: the
+                two used to share the column, and the block would otherwise be
+                trailed by a paragraph it is supposed to hand over to. */}
+            <Show when={pass() > 0 && prose()}>
               {(set) => (
                 <div class="credits-prose" data-testid="credits-prose">
                   <h3 class="credits-prose-title" data-testid="credits-prose-title">
@@ -298,15 +370,6 @@ const CreditsModal: Component = () => {
                   <For each={set().paragraphs}>{(paragraph) => <p>{paragraph}</p>}</For>
                 </div>
               )}
-            </Show>
-
-            {/* The coda goes with the names for the same reason: it is a
-                tagline, and a tagline on a loop stops being read and starts
-                being a boast. */}
-            <Show when={pass() === 0}>
-              <p class="credits-coda">
-                an always-on IRC bouncer, and a client that looks like irssi
-              </p>
             </Show>
           </div>
         </div>

--- a/cicchetto/src/__tests__/CreditsModal.test.tsx
+++ b/cicchetto/src/__tests__/CreditsModal.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CreditsModal from "../CreditsModal";
 import type { BuildCredits } from "../lib/buildCredits";
+import { CREDITS_SPECIAL_THANKS } from "../lib/creditsBlock";
 import {
   closeCreditsModal,
   creditsMuted,
@@ -170,6 +171,60 @@ describe("CreditsModal (#1773)", () => {
     expect(people[2]?.querySelector("em")).toBeNull();
     expect(people[3]?.querySelector(".credits-person-name")?.textContent).toBe("Ada Lovelace");
     expect(people[3]?.querySelector("em")).toBeNull();
+  });
+
+  // #1929 — the roll, the cow and the special thanks are ONE block, the first
+  // one, and the prose sets begin only after it has gone.
+  //
+  // `getAnimations` is absent in jsdom, so `creditsRollPass` would read every
+  // pass as the first and the swap could never be observed. Stubbing it on the
+  // roll is what makes the SECOND pass reachable here at all; the fade itself
+  // is CSS and belongs to `creditsRain.test.ts`, which reads the stylesheet.
+  const turnTheRollOver = (): void => {
+    const roll = screen.getByTestId("credits-roll");
+    Object.defineProperty(roll, "getAnimations", {
+      configurable: true,
+      value: () => [{ effect: { getComputedTiming: () => ({ currentIteration: 1 }) } }],
+    });
+    roll.dispatchEvent(new Event("animationiteration", { bubbles: true }));
+  };
+
+  it("shows the cow and every dictated thanks inside the first block", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    // The cow is IN the block, not beside it: the block is what fades, so
+    // anything outside it would survive the dissolve and sit on the rain.
+    const block = screen.getByTestId("credits-block");
+    expect(block.contains(screen.getByTestId("credits-cow"))).toBe(true);
+    expect(screen.getByTestId("credits-cow").textContent).toContain("Super Cow Powers");
+
+    // Every line, not a sample: the list is dictated, so a render that drops
+    // one is the failure mode worth catching.
+    const thanks = screen.getAllByTestId("credits-thanks");
+    expect(thanks).toHaveLength(CREDITS_SPECIAL_THANKS.length);
+    for (const entry of CREDITS_SPECIAL_THANKS) {
+      expect(thanks.some((line) => line.textContent?.includes(entry.who))).toBe(true);
+      expect(thanks.some((line) => line.textContent?.includes(entry.why))).toBe(true);
+    }
+  });
+
+  it("carries no prose during the first block, and nothing but prose after it", () => {
+    // The seam #1929 asked for, as an outcome rather than as a timing: on the
+    // first pass the block is alone, and once the roll comes round the block
+    // is gone and a paragraph set has taken its place.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    expect(screen.getByTestId("credits-block")).toBeTruthy();
+    expect(screen.queryByTestId("credits-prose")).toBeNull();
+
+    turnTheRollOver();
+
+    expect(screen.queryByTestId("credits-block")).toBeNull();
+    expect(screen.queryByTestId("credits-cow")).toBeNull();
+    expect(screen.queryAllByTestId("credits-thanks")).toHaveLength(0);
+    expect(screen.getByTestId("credits-prose")).toBeTruthy();
   });
 
   it("says the build carries no history rather than rolling an empty list", () => {

--- a/cicchetto/src/__tests__/creditsBlock.test.ts
+++ b/cicchetto/src/__tests__/creditsBlock.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { CREDITS_COW, CREDITS_SPECIAL_THANKS, cowSaying } from "../lib/creditsBlock";
+
+// #1929 — the cow and the special thanks, the two halves of the first block
+// that are DICTATED rather than derived.
+//
+// Both are content someone handed us, so the tests here are pins rather than
+// behaviour checks, and that is the point: the failure they exist to catch is
+// a future tidy-up "improving" a list vjt wrote out by hand, or a cow that
+// drifted off the ASCII it was copied from. There is nothing to compute, so
+// there is nothing to assert except sameness — and sameness against the
+// ORIGINAL, never against a second copy of ourselves.
+
+/** What bahamut's own cow says, so the generator can be fed the original. */
+const BAHAMUT_SAYS = "This bahamut has Super Cow Powers !";
+
+/**
+ * bahamut's eight lines exactly as its `/info` prints them, transcribed from
+ * `azzurra/bahamut src/version.c.SH:145-152`. The source is a shell heredoc
+ * generating C, so every backslash is written there as four; this is what
+ * reaches a terminal after both collapses.
+ *
+ * One quoted string per line rather than one template literal, for TWO
+ * reasons that both bite silently:
+ *
+ *   * the two rules END IN A SPACE, and trailing whitespace inside a
+ *     multi-line template is invisible in review and eaten by half the tools
+ *     that touch a file — inside quotes it survives, and it can be seen;
+ *   * the tail line ends in a BACKSLASH, and `String.raw` does not save you
+ *     from that: `\` still escapes the closing backtick at the tokenizer, so
+ *     the template silently swallows the rest of the file.
+ *
+ * Hence `\\` per backslash, in ordinary quotes.
+ */
+const BAHAMUT_COW = [
+  " _____________________________________ ",
+  "< This bahamut has Super Cow Powers ! >",
+  " ------------------------------------- ",
+  "        \\   ^__^",
+  "         \\  (oo)\\_______",
+  "            (__)\\       )\\/\\",
+  "                ||----w |",
+  "                ||     ||",
+].join("\n");
+
+const lines = (): readonly string[] => CREDITS_COW.split("\n");
+
+describe("the cowsay (#1929 — bahamut's cow, speaking for grappa)", () => {
+  it("reproduces bahamut's cow EXACTLY when fed bahamut's sentence", () => {
+    // The positive control on the balloon builder, and the assertion that
+    // earns the right to generate the box instead of transcribing it: given
+    // the original sentence, the generator emits the original eight lines,
+    // underscore for underscore. If it did not, every claim below about "the
+    // same cow" would be a claim about a lookalike.
+    expect(cowSaying(BAHAMUT_SAYS)).toBe(BAHAMUT_COW);
+  });
+
+  it("keeps bahamut's cow body byte-for-byte", () => {
+    // The ASCII is REUSED, not redrawn. A cow that merely looks similar is a
+    // different cow, and the whole point of the reference is that this is the
+    // one Azzurra's /info has been printing for twenty years.
+    const body = BAHAMUT_COW.split("\n").slice(3).join("\n");
+    expect(CREDITS_COW.endsWith(body)).toBe(true);
+  });
+
+  it("speaks for grappa, and no longer for bahamut", () => {
+    expect(CREDITS_COW).toContain("This grappa has Super Cow Powers !");
+    expect(CREDITS_COW).not.toContain("bahamut");
+  });
+
+  it("keeps the balloon square around whatever the cow says", () => {
+    // The three balloon lines must be the same width or the box is visibly
+    // broken. This is the assertion that makes editing the text safe: change
+    // the sentence and the rules follow, because they are measured from it.
+    const [top, said, bottom] = lines();
+    expect(top).toBeDefined();
+    expect(said).toBeDefined();
+    expect(bottom).toBeDefined();
+    expect(top?.length).toBe(said?.length);
+    expect(bottom?.length).toBe(said?.length);
+  });
+
+  it("draws the balloon the way cowsay does, one line and no wrap", () => {
+    const [top, said, bottom] = lines();
+    // Bahamut's own shape: a space-flanked rule of underscores, the text
+    // between `< ` and ` >`, a space-flanked rule of dashes.
+    expect(top).toMatch(/^ _+ $/);
+    expect(bottom).toMatch(/^ -+ $/);
+    expect(said).toMatch(/^< .* >$/);
+  });
+
+  it("is a `pre` block's worth of lines, not a paragraph", () => {
+    // Three balloon lines plus five body lines. A cow that lost a line still
+    // renders, which is why the count is pinned and not inferred.
+    expect(lines()).toHaveLength(8);
+  });
+});
+
+describe("the special thanks (#1929 — dictated, copied verbatim)", () => {
+  // vjt dictated this list in the issue. It is reproduced here in full and in
+  // order, so that changing the shipped list without changing this file is a
+  // RED — which is exactly the friction wanted around someone else's words.
+  const DICTATED: readonly (readonly [string, string])[] = [
+    ["Hypnotize, Mezmerize, Sonic, scorpion, joep", "for keeping Azzurra standing"],
+    ["DeepSET / Johnny^Lizard", "for embracing grappa and spreading it far and wide"],
+    ["tsk", "for suggesting Erlang"],
+    ["peluche", "most assiduous betatester"],
+    ["nextime", "for shottino"],
+    ["Lucy", "for resentin"],
+    ["Sonic", "for bicchierino"],
+    [
+      "morph",
+      "for spreading grappa, bringing people back, and throwing himself at the ircd and the services again",
+    ],
+    ["the whole #sniffo crew", "for still being here"],
+  ];
+
+  it("carries every name that was dictated, in the order it was dictated", () => {
+    expect(CREDITS_SPECIAL_THANKS.map((entry) => [entry.who, entry.why])).toEqual(
+      DICTATED.map((entry) => [...entry]),
+    );
+  });
+
+  it("thanks Sonic TWICE, because that is what was dictated", () => {
+    // Sonic is named once among the people keeping Azzurra standing and once
+    // for bicchierino. They are two different thanks for two different things
+    // and collapsing them would be editing vjt's words — the exact "helpful"
+    // cleanup this test exists to fail.
+    const sonicLines = CREDITS_SPECIAL_THANKS.filter((entry) => entry.who.includes("Sonic"));
+    expect(sonicLines).toHaveLength(2);
+  });
+
+  it("says nothing this codebase invented", () => {
+    // A guard against a name being ADDED. The count is the cheapest total
+    // statement about the list, and the one an insertion cannot slip past.
+    expect(CREDITS_SPECIAL_THANKS).toHaveLength(DICTATED.length);
+  });
+});

--- a/cicchetto/src/__tests__/creditsRain.test.ts
+++ b/cicchetto/src/__tests__/creditsRain.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { ADM_RAIN_LOOK } from "../AdminDebugTab";
 import {
+  blockIsFading,
   CREDITS_RAIN_BURST_LOOK,
   CREDITS_RAIN_LOOK,
   creditsRainLook,
   rollIsParked,
 } from "../lib/creditsRain";
+import type { MatrixRainLook } from "../MatrixRain";
 import { mediaGatedBlocks, ruleBody, themeCss } from "./helpers/themeCss";
 
 // #1807 — the credits rain reads as rain, and the burst rides the roll's own
@@ -52,6 +54,36 @@ const PARKS_AT_082: readonly FakeStop[] = [
   { computedOffset: 1, transform: PARKED },
 ];
 
+/**
+ * The look with no block in play. Every case that predates #1929 is about the
+ * roll alone, and spelling that out beats threading an `undefined` through
+ * each of them.
+ */
+const lookOf = (roll: HTMLElement | undefined): MatrixRainLook => creditsRainLook(roll, undefined);
+
+type FadeStop = { readonly computedOffset: number; readonly opacity: string };
+
+/** The `.credits-block` counterpart of `fakeRoll`, carrying the fade. */
+function fakeBlock(progress: number | null, stops: readonly FadeStop[]): HTMLElement {
+  return {
+    getAnimations: () => [
+      {
+        effect: {
+          getComputedTiming: () => ({ progress }),
+          getKeyframes: () => stops,
+        },
+      },
+    ],
+  } as unknown as HTMLElement;
+}
+
+const FADES_FROM_070: readonly FadeStop[] = [
+  { computedOffset: 0, opacity: "1" },
+  { computedOffset: 0.7, opacity: "1" },
+  { computedOffset: 0.82, opacity: "0" },
+  { computedOffset: 1, opacity: "0" },
+];
+
 describe("credits rain look (#1807)", () => {
   it("is louder than the panel the effect was tuned for, on every knob", () => {
     // The defect was that the credits rain read as a faint texture. Each
@@ -73,16 +105,16 @@ describe("credits rain look (#1807)", () => {
   });
 
   it("stays on the steady look while the titles are travelling", () => {
-    expect(creditsRainLook(fakeRoll(0, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
-    expect(creditsRainLook(fakeRoll(0.5, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
-    expect(creditsRainLook(fakeRoll(0.8199, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf(fakeRoll(0, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf(fakeRoll(0.5, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf(fakeRoll(0.8199, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
   });
 
   it("bursts for exactly the stretch the roll spends parked", () => {
     // The boundary belongs to the interlude: the instant the translate stops
     // moving there is nothing on screen but rain.
-    expect(creditsRainLook(fakeRoll(0.82, PARKS_AT_082))).toBe(CREDITS_RAIN_BURST_LOOK);
-    expect(creditsRainLook(fakeRoll(0.99, PARKS_AT_082))).toBe(CREDITS_RAIN_BURST_LOOK);
+    expect(lookOf(fakeRoll(0.82, PARKS_AT_082))).toBe(CREDITS_RAIN_BURST_LOOK);
+    expect(lookOf(fakeRoll(0.99, PARKS_AT_082))).toBe(CREDITS_RAIN_BURST_LOOK);
   });
 
   it("takes the park offset from the keyframes rather than from a constant", () => {
@@ -94,8 +126,8 @@ describe("credits rain look (#1807)", () => {
       { computedOffset: 0.95, transform: PARKED },
       { computedOffset: 1, transform: PARKED },
     ];
-    expect(creditsRainLook(fakeRoll(0.9, parksLate))).toBe(CREDITS_RAIN_LOOK);
-    expect(creditsRainLook(fakeRoll(0.96, parksLate))).toBe(CREDITS_RAIN_BURST_LOOK);
+    expect(lookOf(fakeRoll(0.9, parksLate))).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf(fakeRoll(0.96, parksLate))).toBe(CREDITS_RAIN_BURST_LOOK);
   });
 
   it("never bursts when there is no interlude to be inside of", () => {
@@ -112,35 +144,115 @@ describe("credits rain look (#1807)", () => {
     // Three real cases, one answer: before the roll mounts, under
     // `prefers-reduced-motion` (where the roll is a plain scrollable column),
     // and in jsdom. None of them is an error, and none of them may throw.
-    expect(creditsRainLook(undefined)).toBe(CREDITS_RAIN_LOOK);
-    expect(creditsRainLook({ getAnimations: () => [] } as unknown as HTMLElement)).toBe(
-      CREDITS_RAIN_LOOK,
-    );
-    expect(creditsRainLook(document.createElement("div"))).toBe(CREDITS_RAIN_LOOK);
-    expect(creditsRainLook(fakeRoll(null, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf(undefined)).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf({ getAnimations: () => [] } as unknown as HTMLElement)).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf(document.createElement("div"))).toBe(CREDITS_RAIN_LOOK);
+    expect(lookOf(fakeRoll(null, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
   });
 });
 
-describe("credits roll timing (#1807 — the stylesheet owns the interlude)", () => {
-  const cycleSeconds = (): number => {
-    const declared = /animation:\s*credits-roll\s+([\d.]+)s/.exec(ruleBody(".credits-roll"));
-    const seconds = Number(declared?.[1]);
-    expect(Number.isFinite(seconds)).toBe(true);
-    return seconds;
-  };
+describe("credits rain through the first block's fade (#1929)", () => {
+  it("bursts while the block dissolves, with the roll still travelling", () => {
+    // The whole point of the change. At 0.75 the roll is nowhere near parked,
+    // so the #1807 reader alone answers "steady" — and the screen is a block
+    // fading into rain, which is exactly when the rain should be loudest.
+    expect(lookOf(fakeRoll(0.75, PARKS_AT_082))).toBe(CREDITS_RAIN_LOOK);
+    expect(creditsRainLook(fakeRoll(0.75, PARKS_AT_082), fakeBlock(0.75, FADES_FROM_070))).toBe(
+      CREDITS_RAIN_BURST_LOOK,
+    );
+  });
 
-  /** The `@keyframes credits-roll` stops, as `{ at, transform }`. The block
-      has nested braces, so it is matched up to the first `}` at column 0. */
-  const stops = (): { at: number; transform: string }[] => {
-    const block = /@keyframes credits-roll\s*\{([\s\S]*?)\n\}/.exec(themeCss)?.[1];
-    expect(block, "@keyframes credits-roll not found in default.css").toBeDefined();
-    const parsed = [...(block ?? "").matchAll(/(\d+)%\s*\{\s*transform:\s*([^;]+);/g)].map((m) => ({
-      at: Number(m[1]) / 100,
-      transform: (m[2] ?? "").trim(),
-    }));
-    expect(parsed.length).toBeGreaterThanOrEqual(2);
-    return parsed;
-  };
+  it("stays steady before the dissolve starts", () => {
+    // The boundary belongs to the fade: at the last fully-opaque stop the
+    // block is about to start going, and that is the surge.
+    expect(creditsRainLook(fakeRoll(0.69, PARKS_AT_082), fakeBlock(0.69, FADES_FROM_070))).toBe(
+      CREDITS_RAIN_LOOK,
+    );
+    expect(creditsRainLook(fakeRoll(0.7, PARKS_AT_082), fakeBlock(0.7, FADES_FROM_070))).toBe(
+      CREDITS_RAIN_BURST_LOOK,
+    );
+  });
+
+  it("takes the dissolve's start from the keyframes rather than from a constant", () => {
+    // Same promise `parkOffset` makes: retime the fade in the stylesheet and
+    // the surge follows, with nothing in TS to edit.
+    const fadesLate: readonly FadeStop[] = [
+      { computedOffset: 0, opacity: "1" },
+      { computedOffset: 0.9, opacity: "1" },
+      { computedOffset: 1, opacity: "0" },
+    ];
+    expect(blockIsFading(fakeBlock(0.8, fadesLate))).toBe(false);
+    expect(blockIsFading(fakeBlock(0.95, fadesLate))).toBe(true);
+  });
+
+  it("never claims a dissolve when there is no window to be inside of", () => {
+    // A fade that is transparent from the first stop, and one that never
+    // stops being opaque. Neither is a dissolve, and reading either as one
+    // would leave the rain bursting for a whole pass.
+    const alreadyGone: readonly FadeStop[] = [
+      { computedOffset: 0, opacity: "0" },
+      { computedOffset: 1, opacity: "0" },
+    ];
+    const neverFades: readonly FadeStop[] = [
+      { computedOffset: 0, opacity: "1" },
+      { computedOffset: 1, opacity: "1" },
+    ];
+    expect(blockIsFading(fakeBlock(0.5, alreadyGone))).toBe(false);
+    expect(blockIsFading(fakeBlock(0.99, neverFades))).toBe(false);
+  });
+
+  it("degrades to no-dissolve when there is no block to read", () => {
+    // Four real cases: before the modal mounts, after the first pass has
+    // taken the block away, under `prefers-reduced-motion` (no animation at
+    // all), and in jsdom. None may throw, and none may burst.
+    expect(blockIsFading(undefined)).toBe(false);
+    expect(blockIsFading({ getAnimations: () => [] } as unknown as HTMLElement)).toBe(false);
+    expect(blockIsFading(document.createElement("div"))).toBe(false);
+    expect(blockIsFading(fakeBlock(null, FADES_FROM_070))).toBe(false);
+  });
+});
+
+/**
+ * How long `<selector>` declares `<name>` to run, in seconds.
+ *
+ * #1929 hoisted this out of the roll's own describe: the fade has to be
+ * checked against the roll's duration, so two callers need it and neither may
+ * carry a tweaked copy.
+ */
+function animationSeconds(selector: string, name: string): number {
+  const declared = new RegExp(`animation:\\s*${name}\\s+([\\d.]+)s`).exec(ruleBody(selector));
+  const seconds = Number(declared?.[1]);
+  expect(Number.isFinite(seconds), `no ${name} duration on ${selector}`).toBe(true);
+  return seconds;
+}
+
+/**
+ * The stops of `@keyframes <name>`, as `{ at, value }` for ONE property. The
+ * block has nested braces, so it is matched up to the first `}` at column 0.
+ */
+function keyframeStops(name: string, property: string): { at: number; value: string }[] {
+  const block = new RegExp(`@keyframes ${name}\\s*\\{([\\s\\S]*?)\\n\\}`).exec(themeCss)?.[1];
+  expect(block, `@keyframes ${name} not found in default.css`).toBeDefined();
+  const parsed = [
+    ...(block ?? "").matchAll(new RegExp(`(\\d+)%\\s*\\{\\s*${property}:\\s*([^;]+);`, "g")),
+  ].map((m) => ({ at: Number(m[1]) / 100, value: (m[2] ?? "").trim() }));
+  expect(parsed.length, `@keyframes ${name} has no ${property} stops`).toBeGreaterThanOrEqual(2);
+  return parsed;
+}
+
+/** Where `@keyframes credits-roll` stops travelling — the interlude's start. */
+function rollParksAt(): number {
+  const all = keyframeStops("credits-roll", "transform");
+  const park = all.find((stop) => stop.value === all.at(-1)?.value);
+  expect(park?.at, "the last two stops must share a transform, or there is no hold").toBeLessThan(
+    1,
+  );
+  return park?.at ?? 1;
+}
+
+describe("credits roll timing (#1807 — the stylesheet owns the interlude)", () => {
+  const cycleSeconds = (): number => animationSeconds(".credits-roll", "credits-roll");
+  const stops = (): { at: number; value: string }[] => keyframeStops("credits-roll", "transform");
 
   it("parks the roll off the top for the 5-7s of pure rain the issue asked for", () => {
     const all = stops();
@@ -148,7 +260,7 @@ describe("credits roll timing (#1807 — the stylesheet owns the interlude)", ()
     expect(last?.at).toBe(1);
 
     // The hold starts at the FIRST stop already carrying the final transform.
-    const park = all.find((stop) => stop.transform === last?.transform);
+    const park = all.find((stop) => stop.value === last?.value);
     expect(park?.at, "the last two stops must share a transform, or there is no hold").toBeLessThan(
       1,
     );
@@ -175,8 +287,8 @@ describe("credits roll timing (#1807 — the stylesheet owns the interlude)", ()
     // viewport-relative or the defect is back, and no roll height can make a
     // `%` entrance correct on every window.
     const all = stops();
-    expect(all[0]?.transform).toMatch(/^translateY\(100d?vh\)$/);
-    expect(all.at(-1)?.transform).toBe("translateY(-100%)");
+    expect(all[0]?.value).toMatch(/^translateY\(100d?vh\)$/);
+    expect(all.at(-1)?.value).toBe("translateY(-100%)");
   });
 
   it("keeps the exit self-relative, because clearing the top is about the ROLL", () => {
@@ -186,7 +298,7 @@ describe("credits roll timing (#1807 — the stylesheet owns the interlude)", ()
     // the window's bottom, which is a fact about the window. Swapping either
     // for the other's unit breaks a different size of roll.
     const all = stops();
-    const exits = all.filter((stop) => stop.transform.includes("-100%"));
+    const exits = all.filter((stop) => stop.value.includes("-100%"));
     expect(exits.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -210,7 +322,51 @@ describe("credits roll timing (#1807 — the stylesheet owns the interlude)", ()
     // cycle, so the travel — and therefore how long a reader has to read each
     // name — is where it was.
     const all = stops();
-    const park = all.find((stop) => stop.transform === all.at(-1)?.transform);
+    const park = all.find((stop) => stop.value === all.at(-1)?.value);
     expect(cycleSeconds() * (park?.at ?? 1)).toBeCloseTo(28, 0);
+  });
+});
+
+describe("the first block's fade (#1929 — the stylesheet owns the seam)", () => {
+  const fadeStops = (): { at: number; value: string }[] =>
+    keyframeStops("credits-block-fade", "opacity");
+
+  it("runs on the roll's clock, not on one of its own", () => {
+    // Two animations, one cycle. If they ever declared different durations the
+    // dissolve would slide against the travel a little more on every pass, and
+    // nothing else in the modal would notice.
+    expect(animationSeconds(".credits-block", "credits-block-fade")).toBe(
+      animationSeconds(".credits-roll", "credits-roll"),
+    );
+  });
+
+  it("finishes dissolving exactly where the roll finishes travelling", () => {
+    // The seam. The block must be gone by the time the interlude starts, or
+    // the "pure rain" stretch has a half-transparent block sitting in it.
+    const gone = fadeStops().find((stop) => Number(stop.value) === 0);
+    expect(gone?.at, "the fade never reaches opacity 0").toBeDefined();
+    expect(gone?.at).toBe(rollParksAt());
+  });
+
+  it("leaves a dissolve long enough to read as a fade, not as a cut", () => {
+    // 3-6s of it. A shorter window is a cut with extra steps; a longer one
+    // eats the names.
+    const all = fadeStops();
+    const opaqueUntil = all.filter((stop) => Number(stop.value) === 1).at(-1)?.at;
+    expect(opaqueUntil, "the fade is transparent from its first stop").toBeGreaterThan(0);
+    const dissolve =
+      animationSeconds(".credits-roll", "credits-roll") * (rollParksAt() - (opaqueUntil ?? 0));
+    expect(dissolve).toBeGreaterThanOrEqual(3);
+    expect(dissolve).toBeLessThanOrEqual(6);
+  });
+
+  it("runs ONCE and holds, so the prose that follows is never faded", () => {
+    // `infinite` here would dim every later pass, and `forwards` is what keeps
+    // the block invisible through the parked tail rather than snapping it back
+    // to opaque for the last six seconds.
+    const declared = ruleBody(".credits-block");
+    expect(declared).toMatch(/animation:[^;]*\bcredits-block-fade\b[^;]*\b1\b/);
+    expect(declared).toMatch(/animation:[^;]*\bforwards\b/);
+    expect(declared).not.toMatch(/animation:[^;]*\binfinite\b/);
   });
 });

--- a/cicchetto/src/lib/creditsBlock.ts
+++ b/cicchetto/src/lib/creditsBlock.ts
@@ -1,0 +1,99 @@
+// #1929 — the DICTATED half of the credits' first block: the cow and the
+// special thanks.
+//
+// Both are content rather than behaviour, and both were handed down rather
+// than derived, so this module is data with one small function in it. It is a
+// module and not JSX because content that someone else wrote should be
+// testable without rendering a modal — see `creditsBlock.test.ts`, where the
+// list is pinned against the issue and the cow against the ircd it came from.
+//
+// Sibling of `creditsProse.ts`, which owns the paragraph sets that run AFTER
+// this block. The split is the block boundary itself: what is here is shown
+// once, on the first pass; what is there is shown on every pass afterwards.
+
+/** One line of the special thanks: who, and what for. */
+export type SpecialThanks = {
+  readonly who: string;
+  readonly why: string;
+};
+
+/**
+ * The cow's body, transcribed verbatim from Azzurra's bahamut —
+ * `azzurra/bahamut src/version.c.SH:148-152`, the `/info` infotext whose
+ * balloon reads "This bahamut has Super Cow Powers !".
+ *
+ * REUSED, not redrawn. The whole reason to put a cow here is that it is the
+ * cow Azzurra's `/info` has been printing for twenty years; an ASCII animal
+ * that merely resembles it would be a different joke told to nobody.
+ *
+ * The source is a shell heredoc generating C, so every backslash is written
+ * there as four — two collapses later, this is what reaches a terminal.
+ * `String.raw` keeps the escapes looking like what they are.
+ */
+const COW_BODY = String.raw`        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||`;
+
+/**
+ * What our cow says. bahamut's sentence with bahamut's name taken out of it —
+ * the issue asks for the ASCII verbatim "with the text changed to speak for
+ * grappa instead", and the smallest change that does that is the name.
+ */
+const COW_SAYS = "This grappa has Super Cow Powers !";
+
+/**
+ * A cowsay balloon around ONE line, in bahamut's exact geometry: a
+ * space-flanked rule, the text between `< ` and ` >`, another rule.
+ *
+ * Built rather than transcribed so the rules can never disagree with the
+ * sentence — the failure mode of a hand-drawn box is that someone edits the
+ * words and the underscores stay the old length. Fed bahamut's own sentence
+ * it reproduces bahamut's own balloon byte-for-byte, which is what
+ * `creditsBlock.test.ts` checks before trusting it with ours.
+ *
+ * ONE line only. Real cowsay wraps at 40 columns and grows the balloon into a
+ * multi-line box with `/` and `\` shoulders; nothing here says a sentence
+ * that long, and half a wrapping implementation is worse than none.
+ *
+ * @param said the single line the cow speaks
+ */
+export function cowSaying(said: string): string {
+  const rule = (fill: string): string => ` ${fill.repeat(said.length + 2)} `;
+  return [rule("_"), `< ${said} >`, rule("-"), COW_BODY].join("\n");
+}
+
+/** The cow as it is rendered in the credits, balloon and all. */
+export const CREDITS_COW: string = cowSaying(COW_SAYS);
+
+/**
+ * The special thanks, exactly as vjt dictated them on issue 1929.
+ *
+ * 🔴 COPIED VERBATIM. Nothing here is ours to improve: no name added, none
+ * removed, no wording tightened, no "tidier" order. **Sonic is thanked twice
+ * on purpose** — once among the people keeping Azzurra standing and once for
+ * bicchierino — and deduplicating him would be editing someone else's words.
+ * The test pins the whole list against the issue for exactly that reason.
+ *
+ * `who` and `why` are separate fields rather than one sentence so the roll can
+ * lay them out as a list; the em-dash that joins them in the issue text is
+ * presentation and lives in the stylesheet's business, not here.
+ */
+export const CREDITS_SPECIAL_THANKS: readonly SpecialThanks[] = [
+  { who: "Hypnotize, Mezmerize, Sonic, scorpion, joep", why: "for keeping Azzurra standing" },
+  {
+    who: "DeepSET / Johnny^Lizard",
+    why: "for embracing grappa and spreading it far and wide",
+  },
+  { who: "tsk", why: "for suggesting Erlang" },
+  { who: "peluche", why: "most assiduous betatester" },
+  { who: "nextime", why: "for shottino" },
+  { who: "Lucy", why: "for resentin" },
+  { who: "Sonic", why: "for bicchierino" },
+  {
+    who: "morph",
+    why: "for spreading grappa, bringing people back, and throwing himself at the ircd and the services again",
+  },
+  { who: "the whole #sniffo crew", why: "for still being here" },
+];

--- a/cicchetto/src/lib/creditsRain.ts
+++ b/cicchetto/src/lib/creditsRain.ts
@@ -44,6 +44,13 @@ export const CREDITS_RAIN_LOOK: MatrixRainLook = {
  * column to light. It is rendered here as more of each column being lit
  * (brighter glyph, longer streak) rather than as more columns, and that is a
  * substitution, not the same thing.
+ *
+ * #1929 reuses this look for the FIRST block's fade rather than introducing a
+ * third one, and that is a deliberate reuse of the two-look model rather than
+ * an interpolation between them: "the rain thickens" is satisfied by reaching
+ * this look as the dissolve begins. A ramp would mean lerping four knobs
+ * (one of them an rgba string) to render a four-second nuance, which is more
+ * mechanism than the effect is worth — see DESIGN_NOTES.
  */
 export const CREDITS_RAIN_BURST_LOOK: MatrixRainLook = {
   glyphAlpha: 0.45,
@@ -54,13 +61,79 @@ export const CREDITS_RAIN_BURST_LOOK: MatrixRainLook = {
 
 /**
  * The look for RIGHT NOW, given the element carrying the `credits-roll`
- * animation. Handed to `MatrixRain` as its `look` prop, so it is called from
- * inside the frame loop that already exists.
+ * animation and the one carrying `credits-block-fade`. Handed to `MatrixRain`
+ * as its `look` prop, so it is called from inside the frame loop that already
+ * exists.
+ *
+ * #1929 — TWO reasons to burst now, and they are the same reason: there is
+ * nothing left on screen to compete with the rain. The interlude is that state
+ * arrived at by the roll parking; the fade is it arrived at by the first block
+ * dissolving. The rain thickens THROUGH the dissolve rather than after it,
+ * which is what makes the block hand over to the prose instead of just
+ * stopping.
  *
  * @param roll the `.credits-roll` element, or `undefined` before it mounts
+ * @param block the `.credits-block` element, or `undefined` before it mounts
+ *   and after the first pass has taken it away
  */
-export function creditsRainLook(roll: HTMLElement | undefined): MatrixRainLook {
-  return rollIsParked(roll) ? CREDITS_RAIN_BURST_LOOK : CREDITS_RAIN_LOOK;
+export function creditsRainLook(
+  roll: HTMLElement | undefined,
+  block: HTMLElement | undefined,
+): MatrixRainLook {
+  return rollIsParked(roll) || blockIsFading(block) ? CREDITS_RAIN_BURST_LOOK : CREDITS_RAIN_LOOK;
+}
+
+/**
+ * Is the first block dissolving — i.e. has `credits-block-fade` reached the
+ * stretch where its opacity is on the way down?
+ *
+ * Same posture as `rollIsParked`, deliberately: the phase is READ off the
+ * animation that performs the fade, so the rain cannot surge at a different
+ * moment than the block dissolves. Retime the dissolve in the stylesheet and
+ * the surge moves with it, with nothing here to edit.
+ *
+ * Degrades to "not fading" for the same three real cases as its sibling, plus
+ * a fourth of its own: after the first pass the block is gone from the DOM,
+ * and `undefined` is then the honest answer rather than a missing element.
+ */
+export function blockIsFading(block: HTMLElement | undefined): boolean {
+  if (block === undefined) return false;
+
+  const effect = block.getAnimations?.()[0]?.effect ?? null;
+  if (effect === null) return false;
+
+  const progress = effect.getComputedTiming().progress;
+  if (typeof progress !== "number") return false;
+
+  const startsAt = fadeOffset(effect);
+  return startsAt !== null && progress >= startsAt;
+}
+
+/**
+ * The offset at which the block STARTS losing opacity, read off the fade's own
+ * keyframes — the last stop that is still fully opaque.
+ *
+ * Read rather than declared, for the reason `parkOffset` is: a constant here
+ * would be a second copy of a number living in `@keyframes
+ * credits-block-fade`, and the two would drift the first time anyone retimed
+ * the dissolve.
+ *
+ * `null` when there is no dissolve to be inside of — a fade whose first stop
+ * is already transparent, or one that never stops being opaque.
+ */
+function fadeOffset(effect: AnimationEffect): number | null {
+  const keyframed = effect as AnimationEffect & {
+    readonly getKeyframes?: () => readonly ComputedKeyframe[];
+  };
+  const frames = keyframed.getKeyframes?.();
+  if (frames === undefined) return null;
+
+  let opaqueUntil: number | null = null;
+  for (const frame of frames) {
+    if (frame.opacity !== "1") break;
+    opaqueUntil = frame.computedOffset;
+  }
+  return opaqueUntil !== null && opaqueUntil > 0 && opaqueUntil < 1 ? opaqueUntil : null;
 }
 
 /**

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14625,6 +14625,56 @@ audio.media-viewer-media {
   }
 }
 
+/* #1929 — the FIRST block (titles, contributors, the cow, the special thanks)
+   and the fade that ends it. Everything after this block is prose, and the
+   fade is the seam between the two.
+
+   The layout properties are `inherit`ed rather than restated: this element
+   exists only to carry an animation, and a second copy of the roll's column
+   metrics would be a number to keep in step for nothing.
+
+   ONE CLOCK, still. The fade is a CSS animation on the same 34s as the roll
+   and starting with it, so it cannot drift from the travel it is timed
+   against — a JS `setTimeout` at "about thirty seconds" would be a second
+   clock, and it would disagree in the case that always breaks these: a
+   backgrounded tab freezes the animation and keeps the timer running.
+
+   `1 forwards`, not `infinite`: the block fades once and stays gone. The
+   element is removed at the first `animationiteration` anyway (the roll swaps
+   to prose), so `forwards` is only holding opacity 0 across the parked tail. */
+.credits-block {
+  display: flex;
+  flex-direction: inherit;
+  align-items: inherit;
+  gap: inherit;
+  animation: credits-block-fade 34s linear 1 forwards;
+}
+
+/* The fade REACHES ZERO at 82%, which is the offset `@keyframes credits-roll`
+   parks at — the block finishes dissolving exactly as it finishes leaving, so
+   the interlude that follows is pure rain with nothing half-visible in it.
+   Those two numbers must agree, and `creditsRain.test.ts` reads both out of
+   this stylesheet and fails if they ever stop agreeing.
+
+   The 70% start is the only number here that is its own: it buys ~4s of
+   dissolve, which is long enough to read as a fade rather than as a cut.
+   `creditsRain` reads it back off these keyframes instead of copying it, so
+   retiming the dissolve moves the rain's surge with it. */
+@keyframes credits-block-fade {
+  0% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+  }
+  82% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 .credits-title {
   margin: 0 0 0.25rem;
   font-size: 1.8em;
@@ -14694,6 +14744,52 @@ audio.media-viewer-media {
   font-style: italic;
   color: var(--muted);
   text-shadow: 0 0 0.5rem var(--accent);
+}
+
+/* #1929 — bahamut's Super Cow, reused verbatim (see `creditsBlock.ts`).
+
+   `pre`, not `pre-wrap`: this is 38 columns of fixed-width art, and wrapping
+   it does not degrade it, it destroys it. So the art never wraps and the FONT
+   gives way instead — `min()` caps the size at 0.8em on anything roomy and
+   scales it down by viewport below that, which is what keeps the cow whole on
+   a 320px phone where 38 columns at 0.8em would not fit.
+
+   ⚠️ Sized by arithmetic (38 columns x ~0.6em advance against the 88vw the
+   rest of the roll keeps for itself), NOT verified on a real handset — this
+   session has no device and no browser to launch one in. */
+.credits-cow {
+  margin: 0 0 1.5rem;
+  font-family: var(--font-mono);
+  font-size: min(0.8em, 3vw);
+  line-height: 1.15;
+  white-space: pre;
+  color: var(--muted);
+  text-shadow: none;
+}
+
+/* LEFT-aligned inside the centred column, for the reason `.credits-prose`
+   records: a forty-word reason centred costs the reader the start of every
+   line. Same `ch` cap, same argument — the measure that reads well in a
+   monospace pastiche is a count of characters, not a multiple of the font. */
+.credits-thanks {
+  margin: 0 0 1.5rem;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: min(58ch, 88vw);
+  text-align: left;
+  font-size: 0.95em;
+  line-height: 1.5;
+}
+
+.credits-thanks-who {
+  color: var(--accent);
+}
+
+.credits-thanks-why {
+  color: var(--muted);
 }
 
 /* #1924 — the prose that rides between one pass of the names and the next,

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46139,6 +46139,14 @@ contained to `creditsRainLook`.
   so a taller block is a quicker block. The block gained the cow and the thanks
   and LOST the prose to the second pass, which nets out at roughly +15% travel
   distance by line count — not measured, and not obviously worth the layout
-  read per resize that #1920 already declined.
+  read per resize that #1920 already declined. **Re-derived against #1927,
+  which landed under this branch:** dropping `[bot]` authors takes the
+  contributor list from 9 rows to 8 (`git shortlog -sn --no-merges`, measured
+  on `3037acb14` — `dependabot[bot]`, 49 commits, is the only one), so the
+  estimate was computed over one row more than the roll now carries. Direction
+  unchanged and the shift is inside the imprecision the word "roughly" was
+  already carrying; the countervailing term — `nick (Name)` being a longer
+  string that may wrap to a second line on a narrow viewport, ADDING height —
+  is not measured either, and the two are not claimed to cancel.
 
 _Deploy: **HOT — `--cic` only.** Client-side; no server change._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46038,3 +46038,107 @@ executed. Types and lint are green locally. **Everything outside
 `creditsAudio.test.ts` is still CI's verdict.**
 
 _Deploy: **HOT — `--cic` only.** Client-side; no server change._
+<!-- entry #1929 -->
+
+---
+
+## 2026-09-06 — #1929: the roll, the cow and the special thanks are one block, and a fade hands over to the prose
+
+The credit roll ended where the names ended. vjt's brief is that the names, a
+cowsay and a special-thanks list are **one block — the first one** — and that
+the paragraph sets #1924 introduced begin only on the other side of a fade out,
+with the matrix rain thickening through it.
+
+### One block, and what that buys
+
+`.credits-block` is a new wrapper inside `.credits-roll` holding the titles, the
+contributors, the cow, the thanks and the coda. It is not decorative: it is the
+element carrying the fade, so it is what dissolves and what the rain reads. The
+animation could not go on the roll itself — the roll outlives the block and
+carries the prose afterwards, so a `forwards` fade there would dim every
+paragraph set for ever.
+
+The prose is now gated on `pass() > 0` rather than merely on a set existing. The
+two used to share the first pass, in the same column, which is exactly the
+adjacency the issue says is wrong: the block is supposed to hand over to the
+prose, not be trailed by it. The set is also drawn LAZILY now — on open the
+signal is cleared instead of dealt from, because a set drawn for the first pass
+would be replaced by the first `animationiteration` without ever being on
+screen, quietly spending one of the deck's no-repeat draws.
+
+### The cow is bahamut's, reused rather than redrawn
+
+`azzurra/bahamut src/version.c.SH:145-152` — the `/info` infotext that reads
+`This bahamut has Super Cow Powers !`. The body is transcribed byte-for-byte;
+only the sentence changes, to `This grappa has Super Cow Powers !`. That is the
+smallest edit that makes it speak for grappa, and choosing it rather than
+writing a new joke is the whole point: an ASCII animal that merely resembles
+Azzurra's would be a different joke told to nobody.
+
+The BALLOON is generated from the sentence rather than transcribed, so the
+rules can never disagree with the text — the failure mode of a hand-drawn box
+is that someone shortens the words and the underscores stay the old length.
+That generator is only trusted because it is checked against the original:
+fed bahamut's own sentence it emits bahamut's own eight lines, underscore for
+underscore, and the test asserts exactly that before any claim about "the same
+cow" is made. It handles ONE line and does not wrap; real cowsay breaks at 40
+columns into a multi-line box with shoulders, and half of that would be worse
+than none.
+
+### The special thanks are dictated, and the test says so
+
+Copied verbatim from the issue, in the order given. **Sonic is thanked twice**
+— once among the people keeping Azzurra standing, once for bicchierino — and a
+test pins that, because deduplicating him is precisely the helpful cleanup a
+later reader will reach for. The list is pinned in full and by length: the
+first catches an edit, the second catches an insertion.
+
+### The fade rides the roll's clock, and the rain reads it
+
+`@keyframes credits-block-fade` runs on the same 34s as `credits-roll`, once,
+with `forwards`. It holds opacity until 70% and reaches zero at **82%, which is
+the offset the roll parks at** — the block finishes dissolving exactly as it
+finishes leaving, so the interlude that follows is pure rain with nothing
+half-visible in it. Those two numbers must agree and neither is copied into TS:
+`creditsRain.test.ts` reads both out of the stylesheet and fails if they part.
+Both pins were falsified before being believed — moving the fade end to 80%
+reds the seam test, and declaring the fade at 30s reds the clock test.
+
+No wall-clock timer anywhere, and that constraint is the same one #1807 and
+#1920 wrote down: a `setTimeout` at "about thirty seconds" is a second clock,
+and it disagrees in the case that always breaks these — a backgrounded tab
+freezes rAF and the animation with it while timers keep running.
+
+`creditsRainLook` now takes the block as well as the roll and bursts when
+EITHER says there is nothing left to compete with: the roll parked, or the
+block dissolving. `blockIsFading` reads the fade's start off its own keyframes
+the way `rollIsParked` reads the park offset, so retiming the dissolve moves
+the rain's surge with it.
+
+**The rain reaches the existing burst look at the dissolve's start; it does not
+ramp into it.** That is a deliberate reuse of #1807's two-look model rather
+than a new one. A gradual thickening would mean interpolating four knobs —
+one of them an `rgba` string needing a parser — to render a four-second
+nuance, which is more mechanism than the effect is worth. If vjt wants the
+thickening gradual rather than immediate, that is the change, and it is
+contained to `creditsRainLook`.
+
+### What is NOT established here
+
+* **Nothing was seen.** There is no browser and no handset in this session, so
+  every visual claim is arithmetic and unit tests. That the fade reads as a
+  dissolve rather than as a cut, and that the rain surge lands where it should,
+  is a human's verdict on a real screen.
+* **The cow's fit on a narrow phone is computed, not observed.** 38 columns at
+  `min(0.8em, 3vw)` against the 88vw the rest of the roll keeps; `white-space:
+  pre` because wrapping fixed-width art does not degrade it, it destroys it.
+  The `min()` is what should keep it whole at 320px, and it has not been seen
+  at 320px.
+* **The first pass now travels faster, and by how much is an estimate.** The
+  cycle is a fixed 34s over a distance of one viewport plus the roll's height,
+  so a taller block is a quicker block. The block gained the cow and the thanks
+  and LOST the prose to the second pass, which nets out at roughly +15% travel
+  distance by line count — not measured, and not obviously worth the layout
+  read per resize that #1920 already declined.
+
+_Deploy: **HOT — `--cic` only.** Client-side; no server change._


### PR DESCRIPTION
Addresses issue 1929 — the roll, the cowsay and the special thanks become one block, and a fade
hands over to the paragraph sets.

The content of the paragraph sets is out of scope, as the issue says.

## One block

`.credits-block` is a new wrapper inside `.credits-roll` holding the titles, the contributors, the
cow, the special thanks and the coda. It is not decorative: it is the element carrying the fade, so
it is what dissolves and what the rain reads. The animation could not go on the roll — the roll
outlives the block and carries the prose afterwards, so a `forwards` fade there would dim every
paragraph set for ever. Its layout properties are `inherit`ed rather than restated.

The prose is now gated on `pass() > 0` rather than merely on a set existing. The two used to share
the first pass in the same column, which is the adjacency the issue calls wrong. The set is also
drawn LAZILY — cleared on open instead of dealt from — because a set drawn for the first pass is
replaced by the first `animationiteration` without ever being on screen, quietly spending one of
the deck's no-repeat draws.

## The cow is bahamut's, reused rather than redrawn

From `azzurra/bahamut src/version.c.SH:145-152` — the `/info` infotext reading
`This bahamut has Super Cow Powers !`. The body is transcribed byte-for-byte; only the sentence
changes, to `This grappa has Super Cow Powers !`.

The BALLOON is generated from the sentence rather than transcribed with it, so the rules cannot
disagree with the text. The generator earns that only through its positive control: **fed
bahamut's own sentence it emits bahamut's own eight lines, underscore for underscore**, and the
test asserts exactly that before any other claim about "the same cow" is made.

## The special thanks are dictated

Copied verbatim from the issue, in the order given. **Sonic is thanked twice** — once among the
people keeping Azzurra standing, once for bicchierino — and a test pins that, because collapsing
him is exactly the helpful cleanup a later reader reaches for. The list is pinned in full AND by
length: one catches an edit, the other catches an insertion.

## The fade, on the animation's own clock

`@keyframes credits-block-fade` runs on the same 34s as `credits-roll`, once, with `forwards`. It
holds opacity until 70% and reaches zero at **82%, the offset the roll parks at** — the block
finishes dissolving exactly as it finishes leaving, so the interlude that follows is pure rain
with nothing half-visible in it.

Neither number is copied into TS: the tests read both out of the stylesheet. **Both pins were
falsified before being believed** — moving the fade end 82% → 80% reds the seam test, and
declaring the fade at 30s reds the clock test.

No wall-clock timer. `creditsRainLook` now takes the block as well as the roll and bursts when
EITHER says there is nothing left to compete with; `blockIsFading` reads the fade's start off its
own keyframes the way `rollIsParked` reads the park offset.

⚠️ **The rain REACHES the existing burst look at the dissolve's start; it does not ramp into it.**
That is a deliberate reuse of #1807's two-look model — a gradual thickening means interpolating
four knobs, one an `rgba` string needing a parser, for a four-second nuance. If the thickening
should be gradual, that change is contained to `creditsRainLook`.

## Gates

- `bun run check`: **rc=0**, `5 stages ran, 0 failed` (lock drift `drift=0`, test location, biome,
  tsc src, tsc e2e). `Found 58 warnings` / `4 infos` — byte-identical to the pre-work baseline on
  `origin/main`, so this branch adds none.
- `bun run test`: **rc=0**, `335 passed (335)` files / `6714 passed (6714)` tests. Baseline was
  334 / 6694, so +1 file and +20 tests.
- `design-notes-gate.sh origin/main`: rc=0, `1 new entry heading(s), separator and marker present.`

## Deploy: HOT — `--cic` only

Client-side only. No server file is touched: the diff is `cicchetto/src/**` plus
`docs/DESIGN_NOTES.md`.

## What is NOT established

**Nothing here was seen.** There is no browser and no handset in this session, so that the fade
reads as a dissolve rather than as a cut, that the rain surge lands where it should, and that the
cow fits a 320px screen are arithmetic and unit tests — not observations. The cow is sized by
`min(0.8em, 3vw)` against 38 columns and `white-space: pre`, computed rather than checked.

The first pass also travels faster now: the cycle is a fixed 34s over one viewport plus the roll's
height, so a taller block is a quicker block. The block gained the cow and the thanks and LOST the
prose to the second pass, netting roughly +15% distance **by line count, not measured**.
