### PR TITLE
copy(credits): rewrite the prose sets to vjt's review, ceiling to 300

### DIFF
--- a/cicchetto/src/lib/creditsProse.ts
+++ b/cicchetto/src/lib/creditsProse.ts
@@ -31,24 +31,33 @@ export type ProseSet = {
   readonly paragraphs: readonly string[];
 };
 
-/** The longest a set may be before the roll outruns a reader. */
-export const PROSE_SET_MAX_WORDS = 150;
+/**
+ * The longest a set may be before the roll outruns a reader.
+ *
+ * Raised from 150 after the first pass of copy review: several sets were
+ * saying the technical half of a thing and leaving the half a non-technical
+ * reader needs on the floor, because the bound had no room for it. 300 buys
+ * that room. It is still a bound — the roll travels a fixed distance in a
+ * fixed time, and a set that outgrows this does not scroll slower, it scrolls
+ * past.
+ */
+export const PROSE_SET_MAX_WORDS = 300;
 
 export const CREDITS_PROSE: readonly ProseSet[] = [
   {
     title: "information wants to be free",
     paragraphs: [
-      "Information wants to be free. It always did. The wire does not care what you send down it. Only the owner of the wire cares.",
-      "So do not hand your words to an owner. Type them into a room. Let them be read, quoted, logged, grepped.",
-      "A message you cannot copy is not a message. It is a rental.",
+      "Information wants to be free. The line gets quoted as if it meant free of charge. It never did. It means that something known costs nothing to pass on, and that every wall built to stop it is somebody's business model rather than a law of nature.",
+      "Copyleft is that sentence written down as a licence: take this, change it, pass it on, and pass on the same permission you were given. It is the difference between a garden you are allowed to walk in and a garden you are allowed to plant in. The walled kind can be pleasant. It is still not yours, and the gate only opens one way.",
+      "The wire does not care what you send down it. Only the owner of the wire cares. So write where nobody owns the wire.",
     ],
   },
   {
     title: "free software",
     paragraphs: [
       "Free software is not free of charge. It is free of landlords.",
-      "Every line of this is readable. Changeable. Runnable on a five-euro machine that answers to you, in a country you picked, under a name you invented.",
-      "There is no account here for a company to close. Fork it and the network outlives you.",
+      "Eric Raymond gave the two ways of building it their names: the cathedral and the bazaar. The cathedral is raised behind a closed door by appointed hands and handed down finished. The bazaar is a crowd, in the open, arguing in public, everybody free to take the work home and bring back something better. The bazaar should not work. It wrote this protocol, and most of what your bank runs on.",
+      "Every line of this is readable, changeable, runnable on a five-euro machine that answers to you, in a country you picked, under a name you invented. There is no account here for a company to close. Fork it and the community outlives you.",
     ],
   },
   {
@@ -63,8 +72,8 @@ export const CREDITS_PROSE: readonly ProseSet[] = [
     title: "text is the feature",
     paragraphs: [
       "Text is the feature, not the limit.",
-      "A screen reader reads a channel line by line and loses nothing. A grep finds a conversation from 2003. A train tunnel renders it in bytes. Your head does the rest, the way it did for MUDs.",
-      "More pixels per second is not more signal.",
+      "A screen reader speaks a channel out loud, line by line, and loses nothing on the way. A search box finds a conversation from 2003 before you have finished typing the word you remember. A phone with one bar in a tunnel still delivers it, because a sentence weighs almost nothing. Your head supplies the rest, the way it does with a novel.",
+      "More features, more images, more little sounds: none of that is more signal. It is more distraction, handed to you as though it were generosity.",
     ],
   },
   {
@@ -76,58 +85,58 @@ export const CREDITS_PROSE: readonly ProseSet[] = [
     ],
   },
   {
-    title: "whose infrastructure",
+    title: "the room you rent",
     paragraphs: [
-      "You cannot read the code of the app you talk to your friends in. You cannot change it, you cannot run it yourself, and you cannot take it with you.",
-      "You rent a seat on somebody else's stage, and they keep the right to rearrange the stage while you sit on it.",
-      "IRC runs on a cheap server, a handful of text files and a small program. That asymmetry is not decoration. It is the whole game.",
+      "You cannot read the code of the app you talk to your friends in. You cannot change it, you cannot run it yourself, and you cannot take it with you when you go.",
+      "You rent a room in somebody else's building. Rearranging it is not on offer. You move around inside the limits they set, and they redraw those limits whenever it suits them: no notice, no appeal, no forwarding address for the conversations that were in there.",
+      "IRC runs on a cheap server, a handful of text files and a small program. Anyone can stand one up in an afternoon and hold the keys to it. That asymmetry is not decoration. It is the whole game.",
     ],
   },
   {
     title: "teaching a server to lie",
     paragraphs: [
-      "2001. Azzurra ran a commercial IRC server, because it shipped a Java applet, and the applet was how half the users got in.",
-      "The applet sent GUEST on connect and waited for the right numerics back. That was the protection.",
-      "So we taught Bahamut to answer CR1.8.4-SEC with a straight face, and dropped the commercial server. The applet never noticed.",
+      "2001. Azzurra was paying for a commercial IRC server it did not want, and could not drop, because of the little chat window on the website: click, type a name, you are in, nothing to install. Half the network arrived that way.",
+      "That window was fussy about its host. On connecting it asked the server what it was, and it would only go on if the answer came back word for word as the product it had been sold with: CR1.8.4-SEC.",
+      "So we taught our own free server to give exactly that answer, with a straight face, and dropped the commercial one. The window never noticed. Neither did the people typing into it.",
     ],
   },
   {
     title: "you existed only while connected",
     paragraphs: [
-      "On IRC in 2002 you existed only while connected. Ping timeout: 180 seconds, and your name was up for grabs.",
-      "People left tower PCs humming all night, phone line tied up, to hold a nickname while they slept. The luckier ones rented a psyBNC.",
-      "Your identity required physical infrastructure. This bouncer is that tower PC, minus the noise.",
+      "On IRC you exist only while connected. Close the window and the room carries on without you: nothing is kept, nothing is waiting when you come back, and whatever was said while you were away was said to the people who were there. That is not a gap in the protocol. It is what the protocol is, in 1988 and still in 2026.",
+      "So people left tower PCs running all night, phone line tied up, purely to stay in the room. The luckier ones rented a psyBNC: a small program on somebody's always-on machine that held the connection in your place and handed you the transcript when you got back.",
+      "grappa is that program, grown up and pointed at everyone rather than at the fifteen people who knew how to install one. It holds the line, keeps the conversation, and lets you walk away from the desk. Being present stops being a function of your electricity bill.",
     ],
   },
   {
     title: "netsplit",
     paragraphs: [
-      "A netsplit is when the network forgets it is one network. Two halves, both convinced they are the real one, the same nickname alive in each.",
-      "IRC's answer was scorched earth: disconnect both users and let them sort it out. The attacker reconnected instantly. The victim came back to find the name gone.",
-      "The fix was a timestamp. Oldest claim wins. Twenty-four years later it still holds.",
+      "A netsplit is the moment the network forgets it is one network. A link between two servers dies and each half carries on convinced it is the whole thing: same channels, same names, two of everything, neither aware of the other.",
+      "From the inside it looks like the room being cut in half in one line. *** Netsplit hub.azzurra.chat <-> irc.azzurra.chat — and half the people you were mid-argument with are simply gone. Ninety seconds later: *** Netjoin, and they all walk back in at once and finish the sentence, having spent the interval in a room that was also #sniffo, with the same topic, and no idea you were missing.",
+      "The ugly part came at the seam. The same nickname was alive on both sides, and IRC settled it by killing both claims — the attacker who caused the split reconnected instantly, the person who had held the name for years came back to find it gone. The fix was a timestamp: oldest claim wins. Twenty-four years later it still holds.",
     ],
   },
   {
     title: "twenty-one",
     paragraphs: [
       "At twenty-one I forked an IRC server to teach it IPv6 and SSL. At night. For a network that paid nobody.",
-      "The CVS repository is still on SourceForge. 171 commits, three authors, February 2002 to January 2006.",
-      "It still compiles, and not because I wrote it well: Sonic and morph kept their hands on it for twenty years. Left alone it would have rotted like everything else from 2002.",
+      "The CVS repository is still on SourceForge: 171 commits, three authors, February 2002 to January 2006. It still compiles today, which is not a compliment to my code.",
+      "It compiles because Sonic and morph kept their hands on it, on and off, for twenty years — not heroics, not a commit a day, just two volunteers who kept answering for a thing nobody was paying them to keep alive, until Bahamut and Azzurra were still standing in 2026. Open source does not survive because the code is good. It survives because somebody keeps turning up.",
     ],
   },
   {
     title: "the trail goes cold",
     paragraphs: [
-      "In 2002 I started writing IRC services from scratch. 954 commits. I left the network before they were finished.",
-      "A developer in Latvia picked them up, wrote 192 commits, and then the trail goes cold. I never learned their name.",
-      "That is open source. You put it down, somebody else picks it up, and the thing keeps walking without you.",
+      "In 2002 I started writing IRC services from scratch — the programs that hold your nickname while you are away, so that a name is yours rather than whoever types it first. 954 commits. I left the network before they were finished.",
+      "Aidas Kasparas picked them up from Latvia, signing his work monas, and wrote 192 commits more. Then that trail goes cold as well. Nobody runs the code today.",
+      "But while the two of us were on it the trail was hot, and what each of us kept was never the software: it was the hands-on knowledge of having built the thing, which does not go cold at all. The process was the product. It usually is.",
     ],
   },
   {
     title: "#sniffo",
     paragraphs: [
       "The channel was called #sniffo. Inline skating and funny faces. Nothing pharmaceutical.",
-      "Three teenagers on a Monopoli-Milan-Bologna axis met there, then drove across the country to sit in the same room with the case open and the CRTs on.",
+      "What gathered there was a loosely-knit group of nerds on the Milan-Bologna-Monopoli axis, which is most of the length of the country. Nobody organised it and nobody counted. In time they started driving that axis for real, to sit in the same room with the cases open and the CRTs on, arguing about the same code they had been arguing about in text all year.",
       "Twenty-five years later the channel is still there. So are they.",
     ],
   },
@@ -144,23 +153,23 @@ export const CREDITS_PROSE: readonly ProseSet[] = [
     paragraphs: [
       "I found IRC in a magazine. Paper, a newsstand, an article about an Italian network.",
       "I connected, picked a name, opened a channel with friends. User, then contributor, then operator, then writing the server itself. None of it planned.",
-      "No algorithm was involved. Somebody wrote something down and somebody else read it.",
+      "That is the trick open source keeps pulling, and no algorithm is involved anywhere in it: somebody writes something down, somebody else reads it and ends up contributing, and a great many people who will never touch the code get the benefit of both. One article in a magazine, and here we still are.",
     ],
   },
   {
     title: "eighteen years",
     paragraphs: [
-      "In 2008 a friend told me: get yourself a Facebook, it is like IRC but it does so much more.",
-      "He was right. It did so much more. Then it did stories, and reels, and an algorithm, and eighteen years went past.",
-      "I came back in 2026. Same people, same channels, same names. Nobody had monetised anything.",
+      "In 2008 a friend told me: come to the social network, it is like IRC but it does so much more.",
+      "He was right. It did so much more. Then it did stories, and reels, and an algorithm deciding which friend I saw today, and eighteen years went past.",
+      "I came back to IRC in 2026, and by an absurd route: doing digital archaeology with an AI on code I had left rotting in time capsules, SourceForge CVS repositories nobody had touched since 2006. I rejoined Azzurra. Hypnotize queried me within minutes, and I was back on the operators' channel as though twenty years had not happened. Same people, same channels, same names. Nobody had monetised anything.",
     ],
   },
   {
     title: "how this channel filled up",
     paragraphs: [
       "In April there was one person in this channel. Me, plus a bot I had wired up the week before.",
-      "Then guly joined. Then peluche, who stayed. Then nextime sent the first contributions from outside. Then Hypnotize, then Sonic, then Lucy, building Resentin against the same API.",
-      "Nobody was recruited. They read something somewhere and typed /join.",
+      "Then guly joined. Then peluche, who stayed, and who has been on every build since — the one who finds in ten minutes, by using the thing like a person rather than like its author, what no test suite was ever going to catch. Then nextime sent the first contributions from outside. Then Hypnotize, then Sonic, then morph, who arrived for the server he had been maintaining for twenty years and fell for the client instead. Then Lucy, building Resentin against the same API, because the API is open and nobody had to ask.",
+      "Nobody was recruited. They read something somewhere and typed /join. Now we're thirty.",
     ],
   },
 ];


### PR DESCRIPTION
Rewrites the sixteen `CREDITS_PROSE` sets against the review vjt dictated on #grappa
(2026-09-06, 01:15–01:33), and raises `PROSE_SET_MAX_WORDS` from 150 to 300.

The bound moved because most of the corrections were the same one: the technical half
of a story was on the page and the half a non-technical reader needs was not, since at
150 words there was no room for both. It is still a bound — the roll travels a fixed
distance in a fixed time — and `creditsProse.test.ts` still pins it. Longest set after
the rewrite is 173 words.

Set by set:

| set | change |
|---|---|
| information wants to be free | says copyleft, which is what the phrase means |
| free software | Raymond, cathedral and bazaar; the *community* outlives you |
| old software that works | unchanged |
| text is the feature | no grep, no train tunnel; more features = more distraction |
| the pseudonym | unchanged, explicitly |
| **the room you rent** (retitled) | you cannot rearrange the stage, you move inside limits |
| teaching a server to lie | the applet explained as the chat window on the site |
| you existed only while connected | you could not read or take part; psyBNC explained; grappa named |
| netsplit | expanded, with an ad-hoc split/join log |
| twenty-one | volunteers keeping it alive — morph and Sonic |
| the trail goes cold | Aidas Kasparas, nick monas; the trail was *hot*, the process was the product |
| #sniffo | loosely-knit group of nerds on the Milan-Bologna-Monopoli axis, no numbers |
| the bot | unchanged |
| found in a magazine | somebody writes, another contributes, many benefit |
| eighteen years | social network unnamed; back to IRC via CVS archaeology |
| how this channel filled up | peluche and morph in context, and the closing count |

The title of set 6 was rejected without a replacement being dictated: **the room you rent**
is my pick, say the word and it changes.

Not in scope: The Mentor's manifesto, its dedicated music and the crossfades. Those are the
finale, tracked in #1931, and the manifesto sits outside this ceiling by design.
