### PR TITLE
credits(#1931): the ending — spent deck, the manifesto, a pulsing heart and a way out

### DIFF
--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -478,14 +478,14 @@ const CreditsModal: Component = () => {
 
             {/* #1931 — the manifesto, between the last set and the ending.
                 Its own block rather than a seventeenth prose set: it is ~570
-                words against a 150-word cap, and the cheap way to fit it would
+                words against a 300-word cap, and the cheap way to fit it would
                 be to raise the cap, which would silently un-bound all sixteen
                 sets the cap exists to keep readable.
 
-                🔴 The TEXT is a placeholder pending vjt's written licence
-                clearance — see `creditsFinale.ts`. The attribution renders
-                beside it now rather than later, because a credit added in a
-                follow-up is a credit that never ships. */}
+                The text ships on vjt's own clearance (2026-09-06) — see
+                `creditsFinale.ts` for the decision and whose it was. The
+                attribution renders beside it, not after it, because a credit
+                added in a follow-up is a credit that never ships. */}
             <Show when={stage() === "manifesto"}>
               <div class="credits-manifesto" data-testid="credits-manifesto">
                 <p class="credits-manifesto-text">{CREDITS_MANIFESTO}</p>

--- a/cicchetto/src/CreditsModal.tsx
+++ b/cicchetto/src/CreditsModal.tsx
@@ -9,8 +9,15 @@ import {
 } from "solid-js";
 import { buildCredits, creditsDateLabel } from "./lib/buildCredits";
 import { bootBundleVersionAccessor } from "./lib/bundleHash";
-import { type CreditsArpeggio, startCreditsArpeggio } from "./lib/creditsAudio";
+import { type CreditsArpeggio, type CreditsPiece, startCreditsArpeggio } from "./lib/creditsAudio";
 import { CREDITS_COW, CREDITS_SPECIAL_THANKS } from "./lib/creditsBlock";
+import {
+  CREDITS_CLOSE_LABEL,
+  CREDITS_FINALE_LINE,
+  CREDITS_HEART,
+  CREDITS_MANIFESTO,
+  CREDITS_MANIFESTO_ATTRIBUTION,
+} from "./lib/creditsFinale";
 import {
   closeCreditsModal,
   creditsModalOpen,
@@ -48,6 +55,22 @@ import MatrixRain from "./MatrixRain";
 // no git — the AUR source tarball and the release image both do — and a roll
 // that renders an empty line there reads as a bug in the modal rather than as
 // the truth about the build.
+
+/**
+ * Where the credits are in their sequence (#1931).
+ *
+ * A closed set rather than a number: "the deck is spent" and "this is the
+ * ending" are states, not counts, and expressing them as arithmetic on the
+ * pass index would make two different facts share one variable.
+ */
+type CreditsStage = "block" | "prose" | "manifesto" | "finale";
+
+/** Which piece of the soundtrack belongs under each stage. */
+function pieceFor(stage: CreditsStage): CreditsPiece {
+  if (stage === "manifesto") return "manifesto";
+  if (stage === "finale") return "cadence";
+  return "suite";
+}
 
 const CreditsModal: Component = () => {
   createOverlayLock(() => creditsModalOpen(), ".credits-modal", closeCreditsModal);
@@ -93,16 +116,65 @@ const CreditsModal: Component = () => {
   const deck = createProseDeck();
   const [prose, setProse] = createSignal<ProseSet | null>(null);
 
-  // Which pass is on screen, for the ONE thing that needs to know: the names
-  // are shown once and never again (vjt, #grappa 2026-09-05 — "mostriamo i
-  // credits una volta sola, chi se ne frega di ri-vederli"). Every later pass
-  // is prose alone.
+  // ── the sequence, and where in it we are (#1931) ────────────────────────
+  // vjt's order, end to end: the block (names, cow, thanks) → prose sets until
+  // the deck has dealt every one → the manifesto → the credits once more, with
+  // a pulsing heart, a closing line and a button. The roll's own
+  // `animationiteration` walks it; there is no clock here.
   //
-  // Set from `creditsRollPass`, i.e. from the animation's own
-  // `currentIteration`, rather than incremented here. The event is the TRIGGER
-  // and the animation stays the VALUE — a counter of my own would be a second
-  // tally that can disagree with the clock everything else reads.
-  const [pass, setPass] = createSignal(0);
+  // A STAGE rather than the pass counter this replaces. The pass number could
+  // say "show the names" (pass zero) and nothing else: it cannot express "the
+  // deck is spent", which is the trigger the ending hangs off, and it cannot
+  // tell the manifesto from the finale. Both of those would have become
+  // arithmetic on a number that means something else.
+  const [stage, setStage] = createSignal<CreditsStage>("block");
+
+  // The deck reported its bag empty and the ending has not run yet.
+  //
+  // Session-scoped (a plain `let` in a component Shell mounts once), for the
+  // same reason the deck itself is: vjt wants the ending reachable ACROSS
+  // several viewings, so closing the modal one set short must not throw the
+  // progress away. It is a pending NOTIFICATION and not a copy of
+  // `deck.exhausted()` — the deck reports an edge on the draw that empties the
+  // bag, and the ending is two turnovers later, so something has to hold it in
+  // between. Cleared when the finale arrives, which is what lets a NEW opening
+  // after a completed run start a fresh run instead of ending immediately.
+  let endingDue = false;
+
+  /**
+   * One turn of the roll. The ORDER of these branches is the guarantee vjt
+   * asked for — that the ending can never appear before the last set.
+   *
+   * The finale holds: once it is up, later turnovers do nothing, because the
+   * roll is stopped and there is nothing after the end.
+   */
+  const advance = (): void => {
+    const now = stage();
+    if (now === "finale") return;
+    if (now === "manifesto") {
+      setStage("finale");
+      // Consumed HERE and not on the way in: while it is set, a reopening
+      // resumes the ending rather than restarting the sequence. Clearing it
+      // is what tells the next opening that this run is over.
+      endingDue = false;
+      return;
+    }
+    if (endingDue) {
+      // No draw. The bag is spent, and drawing here would refill it and hand
+      // out a seventeenth set nobody asked for, one turn before the end.
+      setStage("manifesto");
+      return;
+    }
+    setProse(deck.draw());
+    setStage("prose");
+    // Read AFTER the draw, which is the only moment the edge exists: the deck
+    // reports the bag empty for exactly the window between this draw and the
+    // next one.
+    if (deck.exhausted()) endingDue = true;
+  };
+
+  /** Is the sequence over? The roll stops, and the rain settles with it. */
+  const ended = (): boolean => stage() === "finale";
 
   createEffect(() => {
     // #1929 — CLEARED on open, not drawn. The first pass is the block (names,
@@ -111,11 +183,15 @@ const CreditsModal: Component = () => {
     // replaces it before it is ever on screen. Drawing lazily is what keeps
     // the deck's no-repeat promise honest.
     //
-    // The pass resets with it: `Show` builds a fresh element on every open, so
-    // its animation genuinely starts over, and carrying the old count would
+    // The stage resets with it: `Show` builds a fresh element on every open, so
+    // its animation genuinely starts over, and carrying the old stage would
     // hide the block from the second viewing onwards.
+    //
+    // #1931 — `endingDue` deliberately does NOT reset here. That flag is the
+    // deck's progress, and the deck is session-scoped precisely so the ending
+    // can be reached across several openings.
     if (creditsModalOpen()) {
-      setPass(0);
+      setStage("block");
       setProse(null);
     }
   });
@@ -158,6 +234,19 @@ const CreditsModal: Component = () => {
   createEffect(() => {
     const muted = creditsMuted();
     arpeggio?.setMuted(muted);
+  });
+
+  // #1931 — the soundtrack follows the SEQUENCE, and this one is a signal
+  // rather than the thunk `movementAt` is. The distinction is real: the roll's
+  // pass lives in a CSS animation Solid cannot observe, so reading it has to
+  // be a poll from the scheduler's own pump; the stage is Solid state that
+  // changes exactly when the sequence moves, so an effect is the honest
+  // mechanism and a poll would be the invented clock.
+  //
+  // `setPiece` is idempotent, which is what makes this safe against the
+  // re-runs an effect gets for reasons of its own.
+  createEffect(() => {
+    arpeggio?.setPiece(pieceFor(stage()));
   });
 
   // A logout unmounts Shell with the modal still open; without this the
@@ -213,9 +302,10 @@ const CreditsModal: Component = () => {
             #1807 lengthened the cycle and parked the translate before its
             end; that tail IS the interlude, and it is read back off this
             element rather than counted a second time in JS. */}
-        <div class="credits-viewport">
+        <div class="credits-viewport" classList={{ "credits-viewport-ended": ended() }}>
           <div
             class="credits-roll"
+            classList={{ "credits-roll-ended": ended() }}
             data-testid="credits-roll"
             ref={(node) => {
               roll = node;
@@ -230,8 +320,7 @@ const CreditsModal: Component = () => {
               // turn the paragraph over on its own schedule.
               node.addEventListener("animationiteration", (event) => {
                 if (event.target !== node) return;
-                setPass(creditsRollPass(node));
-                setProse(deck.draw());
+                advance();
               });
             }}
           >
@@ -252,10 +341,19 @@ const CreditsModal: Component = () => {
                 The DOM swap still rides `animationiteration`, i.e. it lands a
                 full interlude after the fade has finished: by then the block
                 is transparent AND parked off the top, so what is removed has
-                been invisible twice over. */}
-            <Show when={pass() === 0}>
+                been invisible twice over.
+
+                #1931 — and the block COMES BACK for the finale, which is why
+                the condition is a stage and not a pass number. It comes back
+                WITHOUT `credits-block-fading`: the fade is a one-shot with
+                `forwards`, so a re-mounted element would restart it and
+                dissolve the ending the reader is being shown. That is also
+                what keeps `creditsRain.blockIsFading` answering "no" here —
+                there is no animation on the element to read. */}
+            <Show when={stage() === "block" || ended()}>
               <div
                 class="credits-block"
+                classList={{ "credits-block-fading": !ended() }}
                 data-testid="credits-block"
                 ref={(node) => {
                   block = node;
@@ -350,6 +448,50 @@ const CreditsModal: Component = () => {
                 <p class="credits-coda">
                   an always-on IRC bouncer, and a client that looks like irssi
                 </p>
+
+                {/* #1931 — the ending, INSIDE the block that came back rather
+                    than beside it: vjt's sequence is "credits di nuovo + cuore
+                    + riga + bottone", one last screen and not two. */}
+                <Show when={ended()}>
+                  <p class="credits-heart" data-testid="credits-heart" aria-hidden="true">
+                    {CREDITS_HEART}
+                  </p>
+                  <p class="credits-finale-line" data-testid="credits-finale-line">
+                    {CREDITS_FINALE_LINE}
+                  </p>
+                  {/* Closes through `closeCreditsModal`, the SAME function the
+                      overlay lock is given and the ✕ in the chrome calls. A
+                      second closing path would be a second place for the
+                      scroll-lock refcount to be got wrong, which is the live
+                      #1772 bug this modal already had once. */}
+                  <button
+                    type="button"
+                    class="credits-close-cta"
+                    data-testid="credits-close-cta"
+                    onClick={closeCreditsModal}
+                  >
+                    {CREDITS_CLOSE_LABEL}
+                  </button>
+                </Show>
+              </div>
+            </Show>
+
+            {/* #1931 — the manifesto, between the last set and the ending.
+                Its own block rather than a seventeenth prose set: it is ~570
+                words against a 150-word cap, and the cheap way to fit it would
+                be to raise the cap, which would silently un-bound all sixteen
+                sets the cap exists to keep readable.
+
+                🔴 The TEXT is a placeholder pending vjt's written licence
+                clearance — see `creditsFinale.ts`. The attribution renders
+                beside it now rather than later, because a credit added in a
+                follow-up is a credit that never ships. */}
+            <Show when={stage() === "manifesto"}>
+              <div class="credits-manifesto" data-testid="credits-manifesto">
+                <p class="credits-manifesto-text">{CREDITS_MANIFESTO}</p>
+                <p class="credits-manifesto-attribution" data-testid="credits-manifesto-credit">
+                  {CREDITS_MANIFESTO_ATTRIBUTION}
+                </p>
               </div>
             </Show>
 
@@ -358,10 +500,16 @@ const CreditsModal: Component = () => {
 
                 #1929 — but NOT during the first pass any more. The block is
                 the first thing and the prose is what comes after it, so the
-                gate is on the pass and not merely on there being a set: the
+                gate is on the stage and not merely on there being a set: the
                 two used to share the column, and the block would otherwise be
-                trailed by a paragraph it is supposed to hand over to. */}
-            <Show when={pass() > 0 && prose()}>
+                trailed by a paragraph it is supposed to hand over to.
+
+                #1931 — the same gate now also keeps the last set off the
+                manifesto's screen and off the ending's. `prose()` outlives the
+                stage that drew it, on purpose: it is what the reader was last
+                shown, and clearing it would be state kept for the benefit of
+                a condition that can already read the stage. */}
+            <Show when={stage() === "prose" && prose()}>
               {(set) => (
                 <div class="credits-prose" data-testid="credits-prose">
                   <h3 class="credits-prose-title" data-testid="credits-prose-title">

--- a/cicchetto/src/__tests__/CreditsModal.test.tsx
+++ b/cicchetto/src/__tests__/CreditsModal.test.tsx
@@ -4,11 +4,18 @@ import CreditsModal from "../CreditsModal";
 import type { BuildCredits } from "../lib/buildCredits";
 import { CREDITS_SPECIAL_THANKS } from "../lib/creditsBlock";
 import {
+  CREDITS_FINALE_LINE,
+  CREDITS_HEART,
+  CREDITS_MANIFESTO_ATTRIBUTION,
+} from "../lib/creditsFinale";
+import {
   closeCreditsModal,
+  creditsModalOpen,
   creditsMuted,
   openCreditsModal,
   toggleCreditsMuted,
 } from "../lib/creditsModal";
+import { CREDITS_PROSE } from "../lib/creditsProse";
 import { __resetForTest, overlayCount, runTopmostOverlayEscape } from "../lib/overlayScrollLock";
 
 // #1773 — the credits easter egg.
@@ -59,6 +66,12 @@ class StubAudioContext {
         setValueAtTime: (): void => {},
         exponentialRampToValueAtTime: (): void => {},
         setTargetAtTime: (): void => {},
+        // #1931 — the crossfade's verbs. This stub exists to let the modal's
+        // lifecycle run, so it models whatever the real `AudioParam` has that
+        // `creditsAudio` reaches for; the crossfade's BEHAVIOUR is measured in
+        // `creditsAudio.test.ts`, against the stub that records calls.
+        linearRampToValueAtTime: (): void => {},
+        cancelScheduledValues: (): void => {},
       },
       connect: (): void => {},
       disconnect: (): void => {},
@@ -301,5 +314,180 @@ describe("CreditsModal (#1773)", () => {
     closeCreditsModal();
     openCreditsModal();
     expect(screen.getByTestId("credits-mute").getAttribute("aria-pressed")).toBe("true");
+  });
+});
+
+describe("the credits END (#1931)", () => {
+  // The sequence vjt dictated, end to end: block → prose until the deck is
+  // spent → manifesto → the credits again with a heart, a line and a button.
+  //
+  // jsdom has no `getAnimations`, so the roll would read every pass as the
+  // first and no turnover could be observed. Stubbing it is what makes the
+  // sequence reachable here at all; the stopping of the roll and the pulse are
+  // CSS and belong to `creditsFinaleCss.test.ts`.
+  const turnTheRollOver = (times: number): void => {
+    const roll = screen.getByTestId("credits-roll");
+    for (let i = 0; i < times; i += 1) {
+      roll.dispatchEvent(new Event("animationiteration", { bubbles: true }));
+    }
+  };
+
+  /** Turn it over until the ending is up, or give up loudly. */
+  const runToTheEnd = (): number => {
+    const ceiling = CREDITS_PROSE.length + 4;
+    for (let turns = 1; turns <= ceiling; turns += 1) {
+      turnTheRollOver(1);
+      if (screen.queryByTestId("credits-heart") !== null) return turns;
+    }
+    throw new Error(`the ending never arrived in ${ceiling} turns`);
+  };
+
+  it("shows no ending until every set has been dealt", () => {
+    // 🔴 The failure mode that would ruin the whole thing: an early "that's
+    // all, folks". Asserted on EVERY turn up to the last set rather than on a
+    // sample, because the interesting bug is an off-by-one.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    for (let turn = 1; turn <= CREDITS_PROSE.length; turn += 1) {
+      turnTheRollOver(1);
+      expect(screen.queryByTestId("credits-heart"), `heart on turn ${turn}`).toBeNull();
+      expect(screen.queryByTestId("credits-close-cta"), `button on turn ${turn}`).toBeNull();
+    }
+  });
+
+  it("puts the manifesto between the last set and the ending", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+
+    // The turn after the last set is the manifesto, and it is alone there.
+    turnTheRollOver(CREDITS_PROSE.length + 1);
+    expect(screen.getByTestId("credits-manifesto")).toBeTruthy();
+    expect(screen.queryByTestId("credits-prose")).toBeNull();
+    expect(screen.queryByTestId("credits-heart")).toBeNull();
+
+    // ...and the turn after THAT is the ending, with the manifesto gone.
+    turnTheRollOver(1);
+    expect(screen.queryByTestId("credits-manifesto")).toBeNull();
+    expect(screen.getByTestId("credits-heart")).toBeTruthy();
+  });
+
+  it("ships the manifesto's attribution with it, never bare", () => {
+    // The text is a placeholder pending vjt's written clearance, but the
+    // credit is a condition of ever showing it — so it is wired now, and this
+    // is what stops the slot being filled in later without one.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    turnTheRollOver(CREDITS_PROSE.length + 1);
+
+    const credit = screen.getByTestId("credits-manifesto-credit");
+    expect(screen.getByTestId("credits-manifesto").contains(credit)).toBe(true);
+    expect(credit.textContent).toBe(CREDITS_MANIFESTO_ATTRIBUTION);
+  });
+
+  it("brings the credits back for the ending, with the heart, the line and the button", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    runToTheEnd();
+
+    // "the credits come back": the same block, not a new screen.
+    const block = screen.getByTestId("credits-block");
+    expect(screen.getByTestId("credits-title")).toBeTruthy();
+    expect(block.contains(screen.getByTestId("credits-cow"))).toBe(true);
+    expect(block.contains(screen.getByTestId("credits-heart"))).toBe(true);
+    expect(screen.getByTestId("credits-heart").textContent).toBe(CREDITS_HEART);
+    expect(screen.getByTestId("credits-finale-line").textContent).toBe(CREDITS_FINALE_LINE);
+    expect(screen.getByTestId("credits-close-cta")).toBeTruthy();
+  });
+
+  it("does not re-arm the fade on the block that came back", () => {
+    // The fade is `1 forwards`. A re-mounted block still carrying its class
+    // would dissolve the ending as it arrives — invisible in review, and
+    // fatal to the one screen the reader is meant to act on.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    expect(screen.getByTestId("credits-block").classList.contains("credits-block-fading")).toBe(
+      true,
+    );
+
+    runToTheEnd();
+
+    expect(screen.getByTestId("credits-block").classList.contains("credits-block-fading")).toBe(
+      false,
+    );
+  });
+
+  it("stops the roll once the ending is up, so the button stays reachable", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    runToTheEnd();
+
+    expect(screen.getByTestId("credits-roll").classList.contains("credits-roll-ended")).toBe(true);
+  });
+
+  it("closes through the same path everything else closes through", () => {
+    // Not "the modal disappears": the assertion is on `creditsModalOpen`, the
+    // signal `createOverlayLock` and the ✕ both drive. A second closing
+    // mechanism is a second place for the scroll-lock refcount to go wrong.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    runToTheEnd();
+
+    fireEvent.click(screen.getByTestId("credits-close-cta"));
+
+    expect(creditsModalOpen()).toBe(false);
+    expect(screen.queryByTestId("credits-modal")).toBeNull();
+  });
+
+  it("holds on the ending rather than looping back round", () => {
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    runToTheEnd();
+
+    turnTheRollOver(3);
+
+    expect(screen.getByTestId("credits-heart")).toBeTruthy();
+    expect(screen.queryByTestId("credits-prose")).toBeNull();
+  });
+
+  it("reaches the ending ACROSS several viewings, because the deck is the session's", () => {
+    // vjt's intent, and the reason the deck is not rebuilt per open: someone
+    // who watches a few sets, closes, and comes back should be closer to the
+    // end, not back at the start. Closing one turn short and reopening must
+    // therefore land on the ending rather than deal a seventeenth set.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    turnTheRollOver(CREDITS_PROSE.length);
+    expect(screen.queryByTestId("credits-manifesto")).toBeNull();
+
+    closeCreditsModal();
+    openCreditsModal();
+
+    // The block again — a fresh opening always opens on the credits...
+    expect(screen.getByTestId("credits-block")).toBeTruthy();
+    expect(screen.queryByTestId("credits-heart")).toBeNull();
+    // ...and then straight into the ending, because the bag is still spent.
+    turnTheRollOver(1);
+    expect(screen.getByTestId("credits-manifesto")).toBeTruthy();
+    turnTheRollOver(1);
+    expect(screen.getByTestId("credits-heart")).toBeTruthy();
+  });
+
+  it("starts a fresh run on the opening AFTER a finished one", () => {
+    // The other side of the same rule, and the one a latch gets wrong: once
+    // the ending has run, the sequence is over — reopening deals prose again
+    // rather than replaying the ending for ever, which would make sixteen sets
+    // unreachable for the rest of the session.
+    render(() => <CreditsModal />);
+    openCreditsModal();
+    runToTheEnd();
+
+    closeCreditsModal();
+    openCreditsModal();
+    turnTheRollOver(1);
+
+    expect(screen.getByTestId("credits-prose")).toBeTruthy();
+    expect(screen.queryByTestId("credits-heart")).toBeNull();
+    expect(screen.queryByTestId("credits-manifesto")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/CreditsModal.test.tsx
+++ b/cicchetto/src/__tests__/CreditsModal.test.tsx
@@ -373,9 +373,9 @@ describe("the credits END (#1931)", () => {
   });
 
   it("ships the manifesto's attribution with it, never bare", () => {
-    // The text is a placeholder pending vjt's written clearance, but the
-    // credit is a condition of ever showing it — so it is wired now, and this
-    // is what stops the slot being filled in later without one.
+    // The credit is the condition on which the text is here at all, so it is
+    // asserted at the RENDER and not only at the constant: a slot that shows
+    // the words without the credit is the failure, and only this level sees it.
     render(() => <CreditsModal />);
     openCreditsModal();
     turnTheRollOver(CREDITS_PROSE.length + 1);

--- a/cicchetto/src/__tests__/creditsAudio.test.ts
+++ b/cicchetto/src/__tests__/creditsAudio.test.ts
@@ -4,6 +4,8 @@ import {
   BAR_S,
   type CreditsEvent,
   creditsBar,
+  creditsCadence,
+  creditsManifestoBar,
   MOVEMENT_COUNT,
   PEAK_GAIN,
   PHRASE_S,
@@ -45,6 +47,13 @@ type StubParam = {
   setValueAtTime: ReturnType<typeof vi.fn>;
   exponentialRampToValueAtTime: ReturnType<typeof vi.fn>;
   setTargetAtTime: ReturnType<typeof vi.fn>;
+  // #1931 — the crossfade's two verbs. A LINEAR ramp, not the exponential one
+  // the note envelopes use: a crossfade needs a definite end (the point both
+  // ramps have to share), and `setTargetAtTime` only ever approaches its
+  // target. `cancelScheduledValues` is what a teardown mid-fade has to reach
+  // for, so the stub has to model it or the case cannot be tested at all.
+  linearRampToValueAtTime: ReturnType<typeof vi.fn>;
+  cancelScheduledValues: ReturnType<typeof vi.fn>;
 };
 
 type StubOscillator = {
@@ -73,12 +82,20 @@ type StubBufferSource = {
 };
 
 function stubParam(): StubParam {
-  return {
+  const param: StubParam = {
     value: 0,
-    setValueAtTime: vi.fn(),
+    setValueAtTime: vi.fn((next: number) => {
+      // The stub tracks `value` through `setValueAtTime` because the crossfade
+      // reads a bus's CURRENT level to start its ramp from, and a stub whose
+      // value never moves would let a fade-from-the-wrong-level pass.
+      param.value = next;
+    }),
     exponentialRampToValueAtTime: vi.fn(),
     setTargetAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+    cancelScheduledValues: vi.fn(),
   };
+  return param;
 }
 
 /**
@@ -743,5 +760,208 @@ describe("the credits suite (#1920)", () => {
 
     expect(oscillators.length).toBeGreaterThan(0);
     expect(oscillators.every((osc) => osc.type === "square" || osc.type === "triangle")).toBe(true);
+  });
+});
+
+describe("the soundtrack's three pieces, crossfaded (#1931)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  /** The per-piece buses, in creation order under the master at `gains[0]`. */
+  const buses = (gains: { gain: StubParam }[]) => ({
+    master: gains[0],
+    suite: gains[1],
+    manifesto: gains[2],
+    cadence: gains[3],
+  });
+
+  it("opens on the suite, with the other two buses silent", () => {
+    // Three buses under one master rather than one bus retargeted: a crossfade
+    // needs both pieces audible AT THE SAME TIME, which a single gain cannot
+    // express. The positive half of the assertion matters as much as the
+    // negative — all-zero buses would pass a "the others are silent" check and
+    // ship a mute easter egg.
+    const { ctx, gains } = makeCtx();
+
+    startCreditsArpeggio(ctx, false);
+
+    const bus = buses(gains);
+    expect(bus.suite?.gain.value).toBe(1);
+    expect(bus.manifesto?.gain.value).toBe(0);
+    expect(bus.cadence?.gain.value).toBe(0);
+  });
+
+  it("dissolves between pieces instead of cutting, over ONE shared window", () => {
+    // vjt: "musichette crossfade". The two ramps have to END AT THE SAME
+    // INSTANT, or the pair is a dip to silence and back rather than a
+    // dissolve — and a dip is exactly what the abrupt teardown already did.
+    const { ctx, gains } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+
+    arpeggio.setPiece("manifesto");
+
+    const bus = buses(gains);
+    const out = bus.suite?.gain.linearRampToValueAtTime.mock.calls ?? [];
+    const inn = bus.manifesto?.gain.linearRampToValueAtTime.mock.calls ?? [];
+    expect(out.length).toBe(1);
+    expect(inn.length).toBe(1);
+    expect(out[0]?.[0]).toBe(0);
+    expect(inn[0]?.[0]).toBe(1);
+    // Same end time, and it is genuinely LATER than now — a ramp landing at
+    // `currentTime` is a cut written in three lines.
+    expect(out[0]?.[1]).toBe(inn[0]?.[1]);
+    expect(out[0]?.[1]).toBeGreaterThan(ctx.currentTime);
+  });
+
+  it("keeps both pieces sounding through the dissolve", () => {
+    // The outgoing piece's already-armed notes ring on their own bus while it
+    // fades, and the incoming enters AT ONCE rather than at the next bar line
+    // — otherwise the fade runs out over silence and the "crossfade" is a gap.
+    const { ctx, oscillators } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+    const before = oscillators.length;
+    expect(before).toBeGreaterThan(0);
+
+    arpeggio.setPiece("manifesto");
+
+    expect(oscillators.length).toBeGreaterThan(before);
+  });
+
+  it("is idempotent: asking for the piece already playing fades nothing", () => {
+    const { ctx, gains } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+
+    arpeggio.setPiece("suite");
+
+    expect(buses(gains).suite?.gain.linearRampToValueAtTime).not.toHaveBeenCalled();
+  });
+
+  it("MUTES cleanly mid-dissolve", () => {
+    // 🔴 The hard constraint. The mute is the reader's only defence and it has
+    // to work at the one moment two pieces are sounding at once. It acts on
+    // the MASTER, which is why it does — a mute implemented per-bus would have
+    // to fight the crossfade's own ramps on those same params.
+    const { ctx, gains } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+    arpeggio.setPiece("cadence");
+
+    arpeggio.setMuted(true);
+
+    const calls = buses(gains).master?.gain.setTargetAtTime.mock.calls ?? [];
+    expect(calls[calls.length - 1]?.[0]).toBe(0);
+  });
+
+  it("TEARS DOWN cleanly mid-dissolve, cancelling the ramps still to come", () => {
+    // 🔴 The other half. A close during the fade leaves ramps scheduled into
+    // the future on three buses; without cancelling them the graph is being
+    // told to come back up while it is being dismantled. Closing the context
+    // would mask it — which is exactly why this asserts the cancel and not
+    // just the close.
+    const { ctx, gains, oscillators, close } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+    arpeggio.setPiece("cadence");
+
+    arpeggio.stop();
+
+    const bus = buses(gains);
+    for (const [name, node] of [
+      ["suite", bus.suite],
+      ["manifesto", bus.manifesto],
+      ["cadence", bus.cadence],
+    ] as const) {
+      expect(node?.gain.cancelScheduledValues, `${name} bus`).toHaveBeenCalled();
+    }
+    expect(oscillators.every((osc) => osc.stop.mock.calls.length > 0)).toBe(true);
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("stops arming once the cadence has played: it is an ending, not a loop", () => {
+    // The suite loops for as long as the modal is open. The cadence is the
+    // last thing heard, so a cadence on a loop would turn the ending into a
+    // ringtone — the exact defect #1916 was filed for.
+    const { ctx, oscillators } = makeCtx();
+    const arpeggio = startCreditsArpeggio(ctx, false);
+    arpeggio.setPiece("cadence");
+    vi.advanceTimersByTime(BAR_S * 1000);
+    const afterOneBar = oscillators.length;
+
+    vi.advanceTimersByTime(BAR_S * 6 * 1000);
+
+    expect(oscillators.length).toBe(afterOneBar);
+  });
+
+  it("plays a cadence of four or five notes, and no percussion", () => {
+    // The issue's own shape: "four or five notes ... that reads as an ending
+    // without quoting one". Drums would make it a bar of the suite.
+    const lead = creditsCadence().filter((event) => event.voice === "lead");
+    expect(lead.length).toBeGreaterThanOrEqual(4);
+    expect(lead.length).toBeLessThanOrEqual(5);
+    expect(creditsCadence().some((event) => event.voice === "hat")).toBe(false);
+    expect(creditsCadence().some((event) => event.voice === "snare")).toBe(false);
+  });
+
+  it("rises and then falls, so it lands rather than stops", () => {
+    // What makes four notes an ENDING. Asserted on the contour rather than on
+    // the pitches: any transposition of it still has to go up and come back.
+    const hz = creditsCadence()
+      .filter((event) => event.voice === "lead")
+      .sort((a, b) => a.at - b.at)
+      .map((event) => event.hz ?? 0);
+    const peak = hz.indexOf(Math.max(...hz));
+    expect(peak, "the cadence never rises").toBeGreaterThan(0);
+    expect(peak, "the cadence never comes back down").toBeLessThan(hz.length - 1);
+    expect(hz[hz.length - 1]).toBeLessThan(Math.max(...hz));
+  });
+
+  it("gives the manifesto music of its own, not a movement of the suite", () => {
+    // "un pezzo SUO, distinto sia dall'arpeggio del roll sia dalla cadenza
+    // finale". Compared as the RENDERED bar, so a manifesto that merely
+    // renamed a movement would still be caught.
+    const fingerprint = (events: readonly CreditsEvent[]): string =>
+      events
+        .map((e) => `${e.voice}@${e.at.toFixed(3)}:${(e.hz ?? 0).toFixed(1)}`)
+        .sort()
+        .join("|");
+
+    const manifesto = fingerprint(creditsManifestoBar(0));
+    for (let movement = 0; movement < MOVEMENT_COUNT; movement += 1) {
+      for (let bar = 0; bar < BAR_COUNT; bar += 1) {
+        expect(manifesto, `movement ${movement} bar ${bar}`).not.toBe(
+          fingerprint(creditsBar(bar, movement)),
+        );
+      }
+    }
+    expect(manifesto).not.toBe(fingerprint(creditsCadence()));
+  });
+
+  it("keeps the new pieces inside the gain budget the suite already respects", () => {
+    // The ceiling is not per-piece: during a crossfade two buses sound at once,
+    // so the worst instant is bounded by the LOUDEST piece only while the
+    // fade is what keeps their sum in hand. This pins the per-piece half —
+    // that neither newcomer is louder than a bar of the suite.
+    const worst = (events: readonly CreditsEvent[]): number => {
+      const edges = events.flatMap((e) => [e.at, e.at + e.decayS]);
+      return Math.max(
+        ...edges.map((t) =>
+          events
+            .filter((e) => e.at <= t && t < e.at + e.decayS)
+            .reduce((sum, e) => sum + e.peak, 0),
+        ),
+      );
+    };
+    const suiteWorst = Math.max(
+      ...Array.from({ length: MOVEMENT_COUNT }, (_, m) =>
+        Math.max(...Array.from({ length: BAR_COUNT }, (_, b) => worst(creditsBar(b, m)))),
+      ),
+    );
+    expect(worst(creditsManifestoBar(0))).toBeLessThanOrEqual(suiteWorst);
+    expect(worst(creditsCadence())).toBeLessThanOrEqual(suiteWorst);
+    expect(PEAK_GAIN).toBe(0.06);
   });
 });

--- a/cicchetto/src/__tests__/creditsFinale.test.ts
+++ b/cicchetto/src/__tests__/creditsFinale.test.ts
@@ -104,15 +104,23 @@ describe("the manifesto slot (#1931 — BLOCKED on written clearance)", () => {
     // cap exists to keep readable.
     //
     // Pinned as a NUMBER rather than as "the sets still pass": every set could
-    // still pass a cap raised to 600. This is the move being forbidden.
+    // still pass a cap raised to 600. This is the move being forbidden. The
+    // pin does not care WHY the number moves — it cannot read intent — so it
+    // makes any move an argued diff instead of a quiet edit.
     //
-    // ⚠️ The number is 150, MEASURED. The issue says "PROSE_SET_MAX_WORDS
-    // (300 after the raise)" and no such raise exists: `git log -S
-    // 'PROSE_SET_MAX_WORDS = 300'` on this file returns nothing, while the
-    // same search for `= 150` returns the commit that introduced it
-    // (31fa3bd92). The manifesto is therefore ~3.8x the cap rather than ~1.9x,
-    // which makes the case for a separate block stronger, not weaker.
-    expect(PROSE_SET_MAX_WORDS).toBe(150);
+    // ⚠️ RETRACTION. This assertion read 150 and the comment said the issue's
+    // "PROSE_SET_MAX_WORDS (300 after the raise)" described a raise that never
+    // happened. The measurement was right and the conclusion was wrong: the
+    // raise existed as an unlanded PR, not as a commit, so searching history
+    // could not see it. It landed while this branch waited (the copy rewrite),
+    // and the cap is 300. The manifesto is ~1.9x the cap, not ~3.8x — the
+    // margin the issue always claimed, and still ample enough that fitting the
+    // manifesto in would take a raise nobody could make silently.
+    //
+    // The general lesson, since this is the second thing here to be caught by
+    // it: `git log -S` answers "is it in the history of THIS ref", never "does
+    // it exist". Against work in flight those are different questions.
+    expect(PROSE_SET_MAX_WORDS).toBe(300);
     // ...and the manifesto is not in the pool it bounds. A set added there
     // would be capped; this block deliberately is not, so it must not be one.
     expect(CREDITS_PROSE.some((set) => set.paragraphs.includes(CREDITS_MANIFESTO))).toBe(false);

--- a/cicchetto/src/__tests__/creditsFinale.test.ts
+++ b/cicchetto/src/__tests__/creditsFinale.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  CREDITS_CLOSE_LABEL,
+  CREDITS_FINALE_LINE,
+  CREDITS_HEART,
+  CREDITS_MANIFESTO,
+  CREDITS_MANIFESTO_ATTRIBUTION,
+  manifestoAwaitingClearance,
+} from "../lib/creditsFinale";
+import { CREDITS_PROSE, PROSE_SET_MAX_WORDS } from "../lib/creditsProse";
+
+// #1931 — the finale's content, and the two pieces of it that are NOT ours.
+//
+// Two constants here are PLACEHOLDERS awaiting vjt, and that is the whole
+// reason this file exists as a test rather than as a comment: a placeholder
+// nobody can find is a placeholder that ships. Each one is pinned to a single
+// named constant, and the tests below assert the shape a replacement has to
+// keep rather than the words, so filling one in is a one-line edit that stays
+// green — and forgetting to fill it in is visible from here.
+
+describe("the heart (#1931)", () => {
+  it("is the ASCII <3 and not an emoji", () => {
+    // vjt: "il cuore e' <3, non un'emoji" — this is a terminal-flavoured
+    // client, and a rendered ♥ is a different joke. Asserted by CODE POINT,
+    // because the two are indistinguishable in a diff at a glance.
+    expect(CREDITS_HEART).toBe("<3");
+    for (const char of CREDITS_HEART) {
+      expect(char.codePointAt(0), `${char} is outside ASCII`).toBeLessThan(0x80);
+    }
+  });
+});
+
+describe("the closing line (#1931 — vjt's words, not ours)", () => {
+  it("is one line, behind one named constant", () => {
+    // The wording is dictated and has not arrived. What IS pinned is that it
+    // stays a single line: the finale lays it out under the heart, and a
+    // paragraph there would push the close button off a phone.
+    expect(CREDITS_FINALE_LINE).not.toContain("\n");
+    expect(CREDITS_FINALE_LINE.trim()).toBe(CREDITS_FINALE_LINE);
+    expect(CREDITS_FINALE_LINE.length).toBeGreaterThan(0);
+  });
+
+  it("does not quote Looney Tunes", () => {
+    // The issue's own reason: "That's all Folks!" is a Warner Bros. TRADEMARK
+    // and trademarks do not expire. Cadence, not quotation — so the one string
+    // the finale must never carry is that one.
+    expect(CREDITS_FINALE_LINE.toLowerCase()).not.toContain("that's all folks");
+    expect(CREDITS_FINALE_LINE.toLowerCase()).not.toContain("looney");
+    expect(CREDITS_FINALE_LINE.toLowerCase()).not.toContain("porky");
+  });
+});
+
+describe("the close button (#1931)", () => {
+  it("says what it does, in one short label", () => {
+    expect(CREDITS_CLOSE_LABEL.length).toBeGreaterThan(0);
+    expect(CREDITS_CLOSE_LABEL).not.toContain("\n");
+  });
+});
+
+describe("the manifesto slot (#1931 — BLOCKED on written clearance)", () => {
+  // "The Conscience of a Hacker", The Mentor, Phrack 7:3 (1986). vjt's
+  // instruction is verbatim: *do not include it until vjt confirms in writing
+  // on #grappa*. It is 1986, never dedicated to the public domain and never
+  // put under a free licence; forty years of universal reproduction is custom,
+  // not permission.
+  //
+  // So the BLOCK is built and the TEXT is not. These tests are the tripwire.
+
+  it("is still a placeholder, and says so out loud", () => {
+    expect(manifestoAwaitingClearance()).toBe(true);
+  });
+
+  it("carries none of the manifesto's actual words", () => {
+    // The opening and the two most-quoted lines. If any of these appear, the
+    // text has been pasted in and this test is the thing that says so before
+    // a licence question ships in a `.deb`.
+    const forbidden = [
+      "another one got caught today",
+      "this is our world now",
+      "the world of the electron and the switch",
+      "my crime is that of curiosity",
+      "you may stop this individual",
+    ];
+    const haystack = CREDITS_MANIFESTO.toLowerCase();
+    for (const line of forbidden) {
+      expect(haystack, `the manifesto text is in the tree: "${line}"`).not.toContain(line);
+    }
+  });
+
+  it("already names the author and the source it would ship with", () => {
+    // Prepared NOW rather than when the text lands: the attribution is a
+    // condition of shipping it at all, and a slot that arrives without one is
+    // how it ends up shipping without one.
+    expect(CREDITS_MANIFESTO_ATTRIBUTION).toContain("Loyd Blankenship");
+    expect(CREDITS_MANIFESTO_ATTRIBUTION).toContain("Phrack");
+    expect(CREDITS_MANIFESTO_ATTRIBUTION).toContain("1986");
+  });
+
+  it("does not buy its length by raising the prose word cap", () => {
+    // ~570 words against the ceiling the ordinary sets live under. vjt accepts
+    // the length for THIS block and only this one, which is exactly WHY it is
+    // a block of its own — the cheap alternative is to raise the cap until the
+    // manifesto fits, and that silently un-bounds all sixteen sets that the
+    // cap exists to keep readable.
+    //
+    // Pinned as a NUMBER rather than as "the sets still pass": every set could
+    // still pass a cap raised to 600. This is the move being forbidden.
+    //
+    // ⚠️ The number is 150, MEASURED. The issue says "PROSE_SET_MAX_WORDS
+    // (300 after the raise)" and no such raise exists: `git log -S
+    // 'PROSE_SET_MAX_WORDS = 300'` on this file returns nothing, while the
+    // same search for `= 150` returns the commit that introduced it
+    // (31fa3bd92). The manifesto is therefore ~3.8x the cap rather than ~1.9x,
+    // which makes the case for a separate block stronger, not weaker.
+    expect(PROSE_SET_MAX_WORDS).toBe(150);
+    // ...and the manifesto is not in the pool it bounds. A set added there
+    // would be capped; this block deliberately is not, so it must not be one.
+    expect(CREDITS_PROSE.some((set) => set.paragraphs.includes(CREDITS_MANIFESTO))).toBe(false);
+  });
+});

--- a/cicchetto/src/__tests__/creditsFinale.test.ts
+++ b/cicchetto/src/__tests__/creditsFinale.test.ts
@@ -5,18 +5,18 @@ import {
   CREDITS_HEART,
   CREDITS_MANIFESTO,
   CREDITS_MANIFESTO_ATTRIBUTION,
-  manifestoAwaitingClearance,
 } from "../lib/creditsFinale";
 import { CREDITS_PROSE, PROSE_SET_MAX_WORDS } from "../lib/creditsProse";
 
-// #1931 — the finale's content, and the two pieces of it that are NOT ours.
+// #1931 — the finale's content.
 //
-// Two constants here are PLACEHOLDERS awaiting vjt, and that is the whole
-// reason this file exists as a test rather than as a comment: a placeholder
-// nobody can find is a placeholder that ships. Each one is pinned to a single
-// named constant, and the tests below assert the shape a replacement has to
-// keep rather than the words, so filling one in is a one-line edit that stays
-// green — and forgetting to fill it in is visible from here.
+// Two constants here were PLACEHOLDERS awaiting vjt, and that is why this file
+// exists as a test rather than as a comment: a placeholder nobody can find is
+// a placeholder that ships. Both were settled on 2026-09-06 — the closing line
+// approved as written (with `folks` for `friends`), the manifesto cleared for
+// inclusion by the repository's owner. The tests below no longer guard an
+// empty slot; they pin what ships, and the one thing that has not changed is
+// that the words live behind ONE named constant each.
 
 describe("the heart (#1931)", () => {
   it("is the ASCII <3 and not an emoji", () => {
@@ -30,11 +30,12 @@ describe("the heart (#1931)", () => {
   });
 });
 
-describe("the closing line (#1931 — vjt's words, not ours)", () => {
+describe("the closing line (#1931 — approved by vjt, 2026-09-06)", () => {
   it("is one line, behind one named constant", () => {
-    // The wording is dictated and has not arrived. What IS pinned is that it
-    // stays a single line: the finale lays it out under the heart, and a
-    // paragraph there would push the close button off a phone.
+    // The words are settled; what is pinned here is the SHAPE, which is what
+    // a later reword can still break. It stays a single line: the finale lays
+    // it out under the heart, and a paragraph there would push the close
+    // button off a phone.
     expect(CREDITS_FINALE_LINE).not.toContain("\n");
     expect(CREDITS_FINALE_LINE.trim()).toBe(CREDITS_FINALE_LINE);
     expect(CREDITS_FINALE_LINE.length).toBeGreaterThan(0);
@@ -57,43 +58,44 @@ describe("the close button (#1931)", () => {
   });
 });
 
-describe("the manifesto slot (#1931 — BLOCKED on written clearance)", () => {
-  // "The Conscience of a Hacker", The Mentor, Phrack 7:3 (1986). vjt's
-  // instruction is verbatim: *do not include it until vjt confirms in writing
-  // on #grappa*. It is 1986, never dedicated to the public domain and never
-  // put under a free licence; forty years of universal reproduction is custom,
-  // not permission.
+describe("the manifesto (#1931 — cleared by vjt, 2026-09-06)", () => {
+  // "The Conscience of a Hacker", The Mentor (Loyd Blankenship), Phrack 7:3,
+  // 8 January 1986.
   //
-  // So the BLOCK is built and the TEXT is not. These tests are the tripwire.
+  // These tests were a TRIPWIRE while the text was blocked: they asserted the
+  // slot was still empty and failed if the real lines appeared. vjt cleared it
+  // as the repository's owner, so the tripwire is gone and what remains pins
+  // what SHIPS. The three properties below are the ones a careless edit
+  // actually breaks.
 
-  it("is still a placeholder, and says so out loud", () => {
-    expect(manifestoAwaitingClearance()).toBe(true);
-  });
-
-  it("carries none of the manifesto's actual words", () => {
-    // The opening and the two most-quoted lines. If any of these appear, the
-    // text has been pasted in and this test is the thing that says so before
-    // a licence question ships in a `.deb`.
-    const forbidden = [
-      "another one got caught today",
-      "this is our world now",
-      "the world of the electron and the switch",
-      "my crime is that of curiosity",
-      "you may stop this individual",
-    ];
-    const haystack = CREDITS_MANIFESTO.toLowerCase();
-    for (const line of forbidden) {
-      expect(haystack, `the manifesto text is in the tree: "${line}"`).not.toContain(line);
-    }
-  });
-
-  it("already names the author and the source it would ship with", () => {
-    // Prepared NOW rather than when the text lands: the attribution is a
-    // condition of shipping it at all, and a slot that arrives without one is
-    // how it ends up shipping without one.
+  it("carries the text, and the credit that is a condition of carrying it", () => {
+    // Together, deliberately: the attribution is not decoration, it is the
+    // term on which the text is here. A future edit that drops the credit
+    // while keeping the words is the failure this pairing exists to catch.
+    expect(CREDITS_MANIFESTO.toLowerCase()).toContain("another one got caught today");
+    expect(CREDITS_MANIFESTO.toLowerCase()).toContain("i am a hacker, and this is my manifesto");
     expect(CREDITS_MANIFESTO_ATTRIBUTION).toContain("Loyd Blankenship");
     expect(CREDITS_MANIFESTO_ATTRIBUTION).toContain("Phrack");
     expect(CREDITS_MANIFESTO_ATTRIBUTION).toContain("1986");
+  });
+
+  it("keeps the Phrack header art, backslashes and all", () => {
+    // `String.raw`, not a plain template literal. In a plain one `\/` is an
+    // escape for `/`, so the header would silently arrive as `//The
+    // Conscience of a Hacker///` — a corruption with no error anywhere and
+    // nothing in a diff to catch the eye.
+    expect(CREDITS_MANIFESTO).toContain(String.raw`\/\The Conscience of a Hacker/\/`);
+  });
+
+  it("has no leading whitespace on any line", () => {
+    // vjt asked for the indent to go, and the slot renders `white-space:
+    // pre-wrap` in a 64ch column: what was pasted in carried a runaway
+    // auto-indent (past 100 columns) that wraps into noise on a phone. One
+    // rule, applied to every line, so there is no second level to drift.
+    const indented = CREDITS_MANIFESTO.split("\n").filter((line) => /^\s+/.test(line));
+    expect(indented, "lines still carrying an indent").toEqual([]);
+    // ...and the paragraph breaks that do the structuring instead are still there.
+    expect(CREDITS_MANIFESTO).toContain("\n\n");
   });
 
   it("does not buy its length by raising the prose word cap", () => {

--- a/cicchetto/src/__tests__/creditsFinaleCss.test.ts
+++ b/cicchetto/src/__tests__/creditsFinaleCss.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { mediaGatedBlocks, ruleBody, themeCss } from "./helpers/themeCss";
+
+// #1931 — the stylesheet's half of the ending, and the two things in it that
+// cannot be read off the component.
+//
+// The ending STOPS the roll. That is not a flourish: everything in this modal
+// travels, so a close button that scrolls off the top is a button the reader
+// waits a full 34s cycle for. Stopping it is also what settles the rain around
+// the heart, and it does that with no code at all — both readers in
+// `creditsRain` ask the roll's animation what phase it is in, and an element
+// with `animation: none` has none to report, which they already answer
+// "steady" to. So "the rain must not fight the heart" is satisfied by the same
+// declaration that keeps the button reachable, rather than by a third clock.
+
+/** The declarations `prefers-reduced-motion` gives one selector, if any. */
+function reducedMotionBody(selector: string): string {
+  const blocks = mediaGatedBlocks(/@media \(prefers-reduced-motion: reduce\) \{/g, "reduced-motion");
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`);
+  for (const block of blocks) {
+    const found = block.match(re)?.[1];
+    if (found !== undefined) return found;
+  }
+  throw new Error(`no reduced-motion rule for ${selector}`);
+}
+
+/** `prop: value` pairs of a rule body, order-independent. */
+function declarations(body: string): string[] {
+  return body
+    .split(";")
+    .map((line) => line.trim().replace(/\s+/g, " "))
+    .filter(Boolean)
+    .sort();
+}
+
+describe("the ending stops the roll (#1931)", () => {
+  it("parks it the same way reduced-motion already does, declaration for declaration", () => {
+    // CSS cannot share a rule across a media boundary, so these two carry the
+    // same text twice. This is what keeps the copies in step — a comment
+    // asking the next reader to remember is what let them drift in the first
+    // place. Compared as a SET, so reordering them is not a failure.
+    expect(declarations(ruleBody(".credits-roll-ended"))).toEqual(
+      declarations(reducedMotionBody(".credits-roll")),
+    );
+    expect(declarations(ruleBody(".credits-viewport-ended"))).toEqual(
+      declarations(reducedMotionBody(".credits-viewport")),
+    );
+  });
+
+  it("actually turns the travel off, rather than merely restyling it", () => {
+    // The positive control for the pair above: if BOTH sides were edited to
+    // something that still animates, the equality test would go on passing
+    // while the close button sailed off the top.
+    expect(ruleBody(".credits-roll-ended")).toMatch(/animation:\s*none/);
+    expect(ruleBody(".credits-roll-ended")).toMatch(/position:\s*static/);
+    // ...and the travelling roll still travels, or there is nothing to stop.
+    expect(ruleBody(".credits-roll")).toMatch(/animation:\s*credits-roll\s/);
+  });
+
+  it("keeps the block's fade OFF the block itself", () => {
+    // The block comes back for the finale. The fade is `1 forwards`, so a
+    // re-mounted element carrying it would dissolve the ending as it arrives —
+    // which is why the animation lives on a second class the finale omits.
+    expect(ruleBody(".credits-block")).not.toMatch(/animation:/);
+    expect(ruleBody(".credits-block-fading")).toMatch(/animation:[^;]*credits-block-fade/);
+  });
+});
+
+describe("the pulsing heart (#1931)", () => {
+  it("pulses", () => {
+    expect(ruleBody(".credits-heart")).toMatch(/animation:[^;]*credits-heart-pulse/);
+  });
+
+  it("stops pulsing under prefers-reduced-motion, like the rest of the modal", () => {
+    // The issue asks for this by name. A heart that keeps beating through a
+    // reduce request is the one element in the modal that ignores it.
+    expect(reducedMotionBody(".credits-heart")).toMatch(/animation:\s*none/);
+  });
+
+  it("beats rather than throbs", () => {
+    // Two peaks and a rest inside one cycle — a heartbeat, not a sine. A
+    // single-peak keyframe set reads as a loading spinner, and that is the
+    // difference the animation exists for.
+    const frames = /@keyframes credits-heart-pulse\s*\{([\s\S]*?)\n\}/.exec(themeCss)?.[1];
+    expect(frames, "@keyframes credits-heart-pulse not found").toBeDefined();
+    const scales = [...(frames ?? "").matchAll(/scale\(([\d.]+)\)/g)].map((m) => Number(m[1]));
+    expect(scales.filter((s) => s > 1).length).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...scales)).toBeGreaterThan(1);
+  });
+});

--- a/cicchetto/src/__tests__/creditsFinaleCss.test.ts
+++ b/cicchetto/src/__tests__/creditsFinaleCss.test.ts
@@ -15,7 +15,10 @@ import { mediaGatedBlocks, ruleBody, themeCss } from "./helpers/themeCss";
 
 /** The declarations `prefers-reduced-motion` gives one selector, if any. */
 function reducedMotionBody(selector: string): string {
-  const blocks = mediaGatedBlocks(/@media \(prefers-reduced-motion: reduce\) \{/g, "reduced-motion");
+  const blocks = mediaGatedBlocks(
+    /@media \(prefers-reduced-motion: reduce\) \{/g,
+    "reduced-motion",
+  );
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`);
   for (const block of blocks) {

--- a/cicchetto/src/__tests__/creditsProse.test.ts
+++ b/cicchetto/src/__tests__/creditsProse.test.ts
@@ -128,3 +128,72 @@ describe("createProseDeck (#1924)", () => {
     expect(deck.draw()).toBeNull();
   });
 });
+
+describe("the deck reports its own exhaustion (#1931)", () => {
+  // The credits now END, and the trigger for the ending is THIS: the bag has
+  // dealt every set once. Not a pass counter and not a timer — both of those
+  // would be a second tally that can disagree with what the reader has
+  // actually been shown, which is the one thing the ending must not get wrong.
+
+  it("is not exhausted before it has dealt anything", () => {
+    // A fresh bag is empty in the same sense a dealt-out one is — the refill
+    // is lazy — so "the bag array is empty" alone cannot be the reading. This
+    // is the case that separates the two.
+    expect(createProseDeck().exhausted()).toBe(false);
+  });
+
+  it("stays unexhausted while sets are still to come", () => {
+    const deck = createProseDeck();
+    for (let i = 0; i < CREDITS_PROSE.length - 1; i += 1) {
+      deck.draw();
+      expect(deck.exhausted(), `after draw ${i + 1}`).toBe(false);
+    }
+  });
+
+  it("reports exhaustion exactly once per full bag", () => {
+    // Twice through the pool: the reading must go true on the draw that empties
+    // the bag and false again on the next one, which is the refill. A reading
+    // that latched would send every later pass to the ending.
+    const deck = createProseDeck();
+    const draws = CREDITS_PROSE.length * 2;
+    const exhaustedAt: number[] = [];
+    for (let i = 1; i <= draws; i += 1) {
+      deck.draw();
+      if (deck.exhausted()) exhaustedAt.push(i);
+    }
+    expect(exhaustedAt).toEqual([CREDITS_PROSE.length, CREDITS_PROSE.length * 2]);
+  });
+
+  it("counts the whole pool, not a lucky early repeat", () => {
+    // The property the ending depends on: when it reports exhausted, EVERY set
+    // has been on screen. Asserted by collecting them rather than by counting.
+    const deck = createProseDeck();
+    const seen = new Set<string>();
+    let draws = 0;
+    while (!deck.exhausted() && draws <= CREDITS_PROSE.length) {
+      const set = deck.draw();
+      if (set !== null) seen.add(set.title);
+      draws += 1;
+    }
+    expect(deck.exhausted()).toBe(true);
+    expect(seen.size).toBe(CREDITS_PROSE.length);
+  });
+
+  it("is exhausted by its one set when that is all it has", () => {
+    const deck = createProseDeck([{ title: "only", paragraphs: ["only"] }]);
+    expect(deck.exhausted()).toBe(false);
+    deck.draw();
+    expect(deck.exhausted()).toBe(true);
+  });
+
+  it("an empty pool is never exhausted, because it has nothing to deal", () => {
+    // The failure this forbids is the loud one: a pool filtered down to
+    // nothing would otherwise read as "everything has been shown" on the very
+    // first pass and cut straight to the ending.
+    const deck = createProseDeck([]);
+    expect(deck.exhausted()).toBe(false);
+    deck.draw();
+    deck.draw();
+    expect(deck.exhausted()).toBe(false);
+  });
+});

--- a/cicchetto/src/__tests__/creditsRain.test.ts
+++ b/cicchetto/src/__tests__/creditsRain.test.ts
@@ -335,7 +335,12 @@ describe("the first block's fade (#1929 — the stylesheet owns the seam)", () =
     // Two animations, one cycle. If they ever declared different durations the
     // dissolve would slide against the travel a little more on every pass, and
     // nothing else in the modal would notice.
-    expect(animationSeconds(".credits-block", "credits-block-fade")).toBe(
+    //
+    // #1931 moved the declaration off `.credits-block` onto a second class the
+    // finale omits — the block comes back for the ending, and a re-mounted
+    // `1 forwards` would dissolve it as it arrives. The property pinned here is
+    // unchanged; only the selector carrying it moved.
+    expect(animationSeconds(".credits-block-fading", "credits-block-fade")).toBe(
       animationSeconds(".credits-roll", "credits-roll"),
     );
   });
@@ -364,7 +369,7 @@ describe("the first block's fade (#1929 — the stylesheet owns the seam)", () =
     // `infinite` here would dim every later pass, and `forwards` is what keeps
     // the block invisible through the parked tail rather than snapping it back
     // to opaque for the last six seconds.
-    const declared = ruleBody(".credits-block");
+    const declared = ruleBody(".credits-block-fading");
     expect(declared).toMatch(/animation:[^;]*\bcredits-block-fade\b[^;]*\b1\b/);
     expect(declared).toMatch(/animation:[^;]*\bforwards\b/);
     expect(declared).not.toMatch(/animation:[^;]*\binfinite\b/);

--- a/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
+++ b/cicchetto/src/__tests__/safeAreaInsetToken.test.ts
@@ -137,6 +137,14 @@ const CENSUS = [
   ".credits-chrome | right: max(0.5rem, var(--safe-area-inset-right))",
   ".credits-chrome | top: max(0.5rem, var(--safe-area-inset-top))",
   ".credits-roll | padding: max(3rem, var(--safe-area-inset-top)) 1.5rem max(3rem, var(--safe-area-inset-bottom))",
+  // #1931 — the ending parks the roll, and it parks it by reusing the
+  // `prefers-reduced-motion` posture above declaration for declaration
+  // (`creditsFinaleCss.test.ts` pins the pair as a set). So this row is the
+  // deliberate SECOND copy of the row above, floor included: a static roll
+  // reaches the physical edges whichever of the two reasons stopped it, and
+  // giving the ending a different floor would inset the same column by a
+  // different amount depending on how the reader got there.
+  ".credits-roll-ended | padding: max(3rem, var(--safe-area-inset-top)) 1.5rem max(3rem, var(--safe-area-inset-bottom))",
   ".delete-account-modal | padding: max(0.75rem, var(--safe-area-inset-top)) 1rem max(1.5rem, var(--safe-area-inset-bottom))",
   ".diag-float | top: max(0.5rem, var(--safe-area-inset-top))",
   ".error-banners | padding-top: var(--safe-area-inset-top)",

--- a/cicchetto/src/lib/creditsAudio.ts
+++ b/cicchetto/src/lib/creditsAudio.ts
@@ -100,10 +100,47 @@
 // the worst instant is the same lead + second channel + bass + snare it was.
 // The test that measures it walks the score, so it re-measures this by itself.
 
-/** A running soundtrack. Both verbs are idempotent. */
+// #1931 — the soundtrack becomes a SEQUENCE, because the credits now end.
+//
+// Three pieces, in the order the modal walks them: the `suite` above under the
+// roll and the prose, a `manifesto` theme under the block that precedes the
+// ending, and a one-shot `cadence` under the pulsing heart. vjt asked for the
+// joins to be "musichette crossfade" — dissolved, not cut, which is what the
+// old teardown-and-restart did.
+//
+// That is why there are now THREE gain buses under the master rather than one.
+// A crossfade needs both pieces audible at the same instant, and one bus
+// retargeted cannot express that: it can only dip to silence and come back,
+// which is the cut with extra steps. The pieces' notes are scheduled onto
+// their own bus at arm time, so the outgoing piece's already-armed bar keeps
+// ringing while its bus ramps down and the incoming enters AT ONCE — not at
+// the next bar line, which would run the fade out over silence.
+//
+// The MASTER is untouched by all of this, and that is the load-bearing part of
+// the design rather than an accident of layering: `setMuted` and `stop` have
+// to work mid-dissolve, when two buses are sounding and three carry ramps
+// scheduled into the future. Mute acts on the master, so it silences whatever
+// the crossfade happens to be doing without having to fight it on the same
+// params; the teardown cancels the pending ramps on every bus before it drops
+// the graph, so nothing is being told to come back up while it is dismantled.
+// Both cases are pinned by tests, at the exact moment of the fade.
+//
+// The cadence is ONE-SHOT. The suite loops for as long as the modal is open;
+// an ending on a loop is a ringtone, which is the defect #1916 was filed for.
+
+/** Which piece of the sequence is playing. */
+export type CreditsPiece = "suite" | "manifesto" | "cadence";
+
+/** A running soundtrack. Every verb is idempotent. */
 export type CreditsArpeggio = {
   /** Fade to silence (or back), without tearing down the graph. */
   readonly setMuted: (muted: boolean) => void;
+  /**
+   * Dissolve to another piece. Asking for the piece already playing does
+   * nothing — the modal drives this from a signal that re-fires for reasons of
+   * its own, and a re-fire must not restart the music.
+   */
+  readonly setPiece: (piece: CreditsPiece) => void;
   /** Silence it, drop every node, and CLOSE the context handed to `start`. */
   readonly stop: () => void;
 };
@@ -505,6 +542,70 @@ const MOVEMENTS: readonly [Movement, ...Movement[]] = [
 ];
 
 /**
+ * The manifesto's own theme (#1931).
+ *
+ * Deliberately not a fifth movement of the suite: it plays under ~570 words
+ * somebody is READING, so it has to stay out of the way in a manner none of
+ * the four does. Quarter-note grid with every note held through three of the
+ * four slots, the thinnest pulse in the file, and — the thing that separates
+ * it at a glance — NO PERCUSSION AT ALL. Nothing marching under the text.
+ *
+ * The progression is the Andalusian descent the "descent" movement also walks,
+ * because it is the one shape in A minor that reads as gravity rather than as
+ * a loop; what makes this a different piece is everything else — no drums, no
+ * second channel, one note a bar in the lead and a bass that never restrikes.
+ */
+const MANIFESTO_MOVEMENT: Movement = {
+  name: "manifesto",
+  duty: 0.125,
+  second: "none",
+  secondDuty: 0.125,
+  // One slot, empty: the type wants a non-empty tuple, and this is how "no
+  // percussion" is spelled in it rather than by making the field optional.
+  drums: [null],
+  bars: [
+    { lead: ["A4", "-", "-", "E4"], bass: ["A2", "-", "-", "-"], chord: ["A", "C", "E"] },
+    { lead: ["G4", "-", "-", "D4"], bass: ["G2", "-", "-", "-"], chord: ["G", "B", "D"] },
+    { lead: ["F4", "-", "-", "C4"], bass: ["F2", "-", "-", "-"], chord: ["F", "A", "C"] },
+    // The V wants its major third in a minor key — the same G# the suite's
+    // "descent" leans on, and the reason this stops rather than circles.
+    { lead: ["E4", "-", "-", "B3"], bass: ["E3", "-", "-", "-"], chord: ["E", "G#", "B"] },
+  ],
+};
+
+/**
+ * The closing cadence (#1931) — ONE bar, five notes, played once.
+ *
+ * 🔴 ORIGINAL, and that is a licence constraint rather than a stylistic one.
+ * The Looney Tunes outro is "The Merry-Go-Round Broke Down" (1937), whose US
+ * copyright runs to 2033, and "That's all Folks!" is a Warner Bros. TRADEMARK,
+ * which does not expire at all. So this quotes nothing: what it borrows is the
+ * SHAPE an ending has — rise, turn, land — which is not anybody's property.
+ *
+ * A4 → C5 → E5 up, D5 → A4 back down, the last note held through two slots so
+ * it settles instead of stopping. The bass walks the plagal iv–i underneath
+ * (F2 under the turn, A2 under the landing), which is the "amen" motion and is
+ * why four rising notes read as finished rather than as interrupted.
+ *
+ * No drums, for the reason the manifesto has none: a backbeat here would make
+ * it bar five of the suite.
+ */
+const CADENCE_BAR: Movement = {
+  name: "cadence",
+  duty: 0.5,
+  second: "none",
+  secondDuty: 0.25,
+  drums: [null],
+  bars: [
+    {
+      lead: ["A4", "C5", "E5", "-", "D5", "-", "A4", "-"],
+      bass: ["A2", null, "E3", null, "F2", null, "A2", "-"],
+      chord: ["A", "C", "E"],
+    },
+  ],
+};
+
+/**
  * One eighth note. 0.24 s ⇒ 125 BPM, unchanged from #1773.
  *
  * Since #1922 this is no longer the note length — each line divides `BAR_S` by
@@ -576,6 +677,15 @@ const SNARE_PEAK = 0.12;
 
 /** Ramp constant for the mute toggle. An instant gain jump clicks. */
 const MUTE_RAMP_S = 0.02;
+/**
+ * How long one piece takes to dissolve into the next (#1931).
+ *
+ * Just under half a bar. Long enough to hear as a dissolve rather than as a
+ * cut, short enough that the outgoing bar — already armed, and at most one bar
+ * long — is still sounding for the whole of it, which is what makes the
+ * overlap real instead of a fade into a gap.
+ */
+const CROSSFADE_S = 0.9;
 /** Exponential ramps cannot reach zero; this is the working silence. */
 const GAIN_FLOOR = 0.0001;
 /** Fraction of a note spent decaying — the rest is the gap that articulates it. */
@@ -672,7 +782,34 @@ function movementAtIndex(index: number): Movement {
  * Pure: the scheduler renders these, and the test measures them.
  */
 export function creditsBar(index: number, movement = 0): readonly CreditsEvent[] {
-  const score = movementAtIndex(movement);
+  return barEvents(movementAtIndex(movement), index);
+}
+
+/**
+ * Bar `index` of the manifesto's theme (#1931). Wraps, like the suite's: the
+ * text takes as long as it takes to read, so the piece under it loops.
+ */
+export function creditsManifestoBar(index: number): readonly CreditsEvent[] {
+  return barEvents(MANIFESTO_MOVEMENT, index);
+}
+
+/**
+ * The closing cadence (#1931), in full. Takes no index because it does not
+ * loop — that is the whole point of it, and a parameter would invite one.
+ */
+export function creditsCadence(): readonly CreditsEvent[] {
+  return barEvents(CADENCE_BAR, 0);
+}
+
+/**
+ * One bar of any score, expanded to events. Pure: the scheduler renders these
+ * and the tests measure them.
+ *
+ * Split out of `creditsBar` by #1931 so the manifesto theme and the cadence
+ * are rendered by the SAME code as the suite rather than by a second copy of
+ * it — the copy that drifts is the one nobody listens to.
+ */
+function barEvents(score: Movement, index: number): readonly CreditsEvent[] {
   const bar = score.bars[wrap(index, score.bars.length)] ?? score.bars[0];
   const events: CreditsEvent[] = [];
   const leadPeak = score.second === "none" ? LEAD_SOLO_PEAK : LEAD_PEAK;
@@ -778,6 +915,28 @@ const PUMP_MS = 100;
  */
 const PULSE_HARMONICS = 24;
 
+/**
+ * Ramp one bus to `to`, arriving `CROSSFADE_S` after `now` (#1931).
+ *
+ * The three lines are the standard "freeze where you are, then ramp" idiom and
+ * the order matters: the CURRENT value is read first (the `AudioParam` getter
+ * reports the live automated value, not the last one anybody assigned), then
+ * the future is cleared, then that value is pinned at `now` so the new ramp
+ * has a defined starting point. Skipping the pin makes the ramp start from
+ * whatever the last scheduled event left behind, which mid-dissolve is not
+ * where the bus actually is — the fade would jump before it slid.
+ *
+ * `linearRampToValueAtTime`, not the `setTargetAtTime` the mute uses:
+ * `setTargetAtTime` approaches its target asymptotically and never arrives, so
+ * two of them cannot share the instant that makes a pair of ramps a crossfade.
+ */
+function fadeBus(bus: GainNode, to: number, now: number): void {
+  const from = bus.gain.value;
+  bus.gain.cancelScheduledValues(now);
+  bus.gain.setValueAtTime(from, now);
+  bus.gain.linearRampToValueAtTime(to, now + CROSSFADE_S);
+}
+
 function makeNoiseBuffer(ctx: AudioContext): AudioBuffer {
   const frames = Math.max(1, Math.floor(ctx.sampleRate * NOISE_S));
   const buffer = ctx.createBuffer(1, frames, ctx.sampleRate);
@@ -829,6 +988,19 @@ export function startCreditsArpeggio(
   master.gain.value = muted ? 0 : PEAK_GAIN;
   master.connect(ctx.destination);
 
+  // #1931 — one bus per piece, all under the master. Unit gains: the master
+  // owns the volume (and therefore the mute), these own only WHO is heard, so
+  // a crossfade never has to know what the level is.
+  const buses: Record<CreditsPiece, GainNode> = {
+    suite: ctx.createGain(),
+    manifesto: ctx.createGain(),
+    cadence: ctx.createGain(),
+  };
+  for (const [name, bus] of Object.entries(buses) as [CreditsPiece, GainNode][]) {
+    bus.gain.value = name === "suite" ? 1 : 0;
+    bus.connect(master);
+  }
+
   // Every source is kept so `stop()` can silence one scheduled a beat into the
   // future — `onended` cannot be relied on for that, because a note that has
   // not started yet never ends.
@@ -840,6 +1012,7 @@ export function startCreditsArpeggio(
   let barIndex = 0;
   let movement = 0;
   let nextBarAt = 0;
+  let piece: CreditsPiece = "suite";
 
   // Built once per width and cached: a `PeriodicWave` is immutable and shared
   // by every oscillator that uses it, so making one per note would be a few
@@ -866,7 +1039,7 @@ export function startCreditsArpeggio(
     };
   };
 
-  const scheduleEvent = (event: CreditsEvent, base: number): void => {
+  const scheduleEvent = (event: CreditsEvent, base: number, bus: GainNode): void => {
     const at = base + event.at;
     // A browser that refused the buffer gets no percussion; the tuned voices
     // still play. Checked BEFORE the gain node so the refusal costs no node.
@@ -878,7 +1051,10 @@ export function startCreditsArpeggio(
     env.gain.setValueAtTime(GAIN_FLOOR, at);
     env.gain.exponentialRampToValueAtTime(event.peak, at + Math.min(ATTACK_S, event.durS * 0.2));
     env.gain.exponentialRampToValueAtTime(GAIN_FLOOR, at + event.decayS);
-    env.connect(master);
+    // The bus of the piece that ARMED this note, captured by the caller — not
+    // whichever piece happens to be current when it sounds. That is what lets
+    // the outgoing piece ring on through its own fade.
+    env.connect(bus);
 
     if (event.hz === null && noise !== null) {
       const burst = ctx.createBufferSource();
@@ -933,16 +1109,31 @@ export function startCreditsArpeggio(
     // and it is exactly the case the gain budget above cannot defend against.
     if (nextBarAt < ctx.currentTime) nextBarAt = ctx.currentTime;
     while (nextBarAt < ctx.currentTime + LOOKAHEAD_S) {
-      // Read the roll's pass HERE, one bar before it is heard: the movement
-      // can therefore only change on a bar line, never mid-phrase. Restarting
-      // `barIndex` is what makes the new movement enter at its OWN first bar
-      // instead of wherever the outgoing one had got to.
-      const wanted = wrap(readMovement(), MOVEMENT_COUNT);
-      if (wanted !== movement) {
-        movement = wanted;
-        barIndex = 0;
+      // #1931 — the cadence is one bar and then silence. `break` rather than
+      // `return` so the timer below stays alive: it costs nothing and it keeps
+      // the pump answerable if a piece is ever selected after this one.
+      if (piece === "cadence" && barIndex > 0) break;
+
+      let events: readonly CreditsEvent[];
+      if (piece === "suite") {
+        // Read the roll's pass HERE, one bar before it is heard: the movement
+        // can therefore only change on a bar line, never mid-phrase.
+        // Restarting `barIndex` is what makes the new movement enter at its
+        // OWN first bar instead of wherever the outgoing one had got to.
+        const wanted = wrap(readMovement(), MOVEMENT_COUNT);
+        if (wanted !== movement) {
+          movement = wanted;
+          barIndex = 0;
+        }
+        events = creditsBar(barIndex, movement);
+      } else if (piece === "manifesto") {
+        events = creditsManifestoBar(barIndex);
+      } else {
+        events = creditsCadence();
       }
-      for (const event of creditsBar(barIndex, movement)) scheduleEvent(event, nextBarAt);
+
+      const bus = buses[piece];
+      for (const event of events) scheduleEvent(event, nextBarAt, bus);
       barIndex += 1;
       nextBarAt += BAR_S;
     }
@@ -962,13 +1153,47 @@ export function startCreditsArpeggio(
   return {
     setMuted: (next: boolean): void => {
       if (stopped) return;
+      // On the MASTER, deliberately: it sits above every bus, so this silences
+      // a crossfade in flight without touching — or being fought by — the
+      // ramps the crossfade has scheduled on the buses themselves.
       master.gain.setTargetAtTime(next ? 0 : PEAK_GAIN, ctx.currentTime, MUTE_RAMP_S);
     },
+
+    setPiece: (next: CreditsPiece): void => {
+      if (stopped || next === piece) return;
+      const now = ctx.currentTime;
+      // Both ramps land on the SAME instant, which is what makes the pair a
+      // dissolve rather than a dip to silence and back.
+      fadeBus(buses[piece], 0, now);
+      fadeBus(buses[next], 1, now);
+
+      piece = next;
+      barIndex = 0;
+      // The incoming piece enters AT ONCE rather than at the next bar line,
+      // which can be most of a bar away — the fade would otherwise run out
+      // over silence. The outgoing bar is already armed on its own bus and
+      // keeps ringing, so the two genuinely overlap.
+      nextBarAt = now;
+      if (timer !== null) clearTimeout(timer);
+      timer = null;
+      pump();
+    },
+
     stop: (): void => {
       if (stopped) return;
       stopped = true;
       if (timer !== null) clearTimeout(timer);
       timer = null;
+      // Cancel BEFORE dropping the graph. Mid-dissolve there are ramps
+      // scheduled into the future on three buses, and leaving them in place
+      // tells the graph to come back up while it is being dismantled. Closing
+      // the context would mask it in practice — which is exactly why this is
+      // explicit and has a test of its own.
+      const at = ctx.currentTime;
+      master.gain.cancelScheduledValues(at);
+      for (const bus of Object.values(buses)) {
+        bus.gain.cancelScheduledValues(at);
+      }
       for (const voice of voices) {
         try {
           voice.stop();
@@ -979,6 +1204,7 @@ export function startCreditsArpeggio(
       }
       voices.length = 0;
       waves.clear();
+      for (const bus of Object.values(buses)) bus.disconnect();
       master.disconnect();
       void ctx.close();
     },

--- a/cicchetto/src/lib/creditsFinale.ts
+++ b/cicchetto/src/lib/creditsFinale.ts
@@ -6,62 +6,134 @@
 // special thanks), this one owns the content of the LAST. Between them run the
 // `creditsProse` sets, which are the only part of the sequence that repeats.
 //
-// 🔴 TWO CONSTANTS HERE ARE PLACEHOLDERS AWAITING vjt, and neither is the
-// implementer's to write:
-//
-//   CREDITS_FINALE_LINE   the "that's all, folks!" in cypherpunk register.
-//                         The issue says outright that the exact wording is
-//                         vjt's call. What ships below is a stand-in.
-//   CREDITS_MANIFESTO     "The Conscience of a Hacker". BLOCKED on more than
-//                         wording — see below.
-//
-// Each sits behind ONE named constant, in ONE place, pinned by
-// `creditsFinale.test.ts`, so filling either in is a one-line edit. The tests
-// assert the SHAPE a replacement has to keep, never the words, and they are
-// what makes a forgotten placeholder visible instead of shipped.
+// Both texts here were placeholders while this branch waited on vjt. Both are
+// now his: the closing line is his wording, and the manifesto is in on his
+// written say-so (2026-09-06). See `CREDITS_MANIFESTO` for what that decision
+// was and who made it.
 
 /** The heart, in ASCII. */
 export const CREDITS_HEART = "<3";
 
 /**
- * 🔴 PLACEHOLDER — awaiting vjt's wording.
+ * ✅ APPROVED BY vjt, 2026-09-06 — no longer a placeholder.
  *
- * The brief asks for Looney Tunes CADENCE and cypherpunk REGISTER: the shape
- * of an ending anybody recognises, saying something this project would say.
- * What it must never be is the quotation itself — "That's all Folks!" is a
- * Warner Bros. trademark, and a trademark does not expire with the copyright
- * on the tune. `creditsFinale.test.ts` forbids the quotation by name.
+ * It stood behind a named constant because the issue said the exact words
+ * were vjt's call. They ended up being the implementer's, approved with one
+ * word of his own: `folks` for `friends`, which is the Looney Tunes cadence
+ * the issue asked for arriving in the one place it can arrive without
+ * quoting the mark. The constant stays the single edit point.
+ *
+ * The cadence is Looney Tunes, the words are not — "That's all Folks!" is a
+ * Warner Bros. trademark and a trademark does not expire with the copyright
+ * on the tune. `creditsFinale.test.ts` forbids the quotation by name, and
+ * this line clears it: the recognisable SHAPE without the mark.
  *
  * One line, no newline: the finale lays it out between the heart and the
  * close button, and a paragraph there pushes the button off a phone.
  */
-export const CREDITS_FINALE_LINE = "and that's the whole of the wire, friends.";
+export const CREDITS_FINALE_LINE = "and that's the whole of the wire, folks.";
 
 /** What the finale's own close control says. */
 export const CREDITS_CLOSE_LABEL = "click here to close";
 
 /**
- * 🔴 PLACEHOLDER — and this one is BLOCKED on permission, not on wording.
+ * "The Conscience of a Hacker" — The Mentor (Loyd Blankenship), *Phrack*
+ * Vol. 1 Issue 7 Phile 3, 8 January 1986. Shown immediately before the heart.
  *
- * The finale is supposed to show "The Conscience of a Hacker" (The Mentor —
- * Loyd Blankenship, *Phrack* Vol. 1 Issue 7 Phile 3, 8 January 1986)
- * immediately before the heart. vjt's instruction is verbatim: **do not
- * include it until vjt confirms in writing on #grappa.**
+ * 🟢 SHIPPED ON vjt'S EXPLICIT DECISION, 2026-09-06, and recorded here because
+ * it reverses an instruction that is still in this repository's history. The
+ * standing order had been *"do not include it until vjt confirms in writing on
+ * #grappa"*, the reason being that the text is from 1986, was never dedicated
+ * to the public domain and was never put under a free licence — forty years of
+ * universal reproduction is CUSTOM, not PERMISSION. vjt cleared it as the
+ * repository's owner, stating that the project is open source and that he will
+ * comply with a takedown if one is ever asked for. That is his call to make
+ * and it is his name on it; this comment exists so the next reader finds the
+ * decision rather than re-deriving the block.
  *
- * The reason is not squeamishness. The text is from 1986, was never dedicated
- * to the public domain and was never put under a free licence. It has been
- * reproduced everywhere for forty years, but that is CUSTOM and not
- * PERMISSION — and grappa ships a public PWA and a `.deb`, which is the same
- * reason `creditsAudio.ts` synthesises its music instead of sampling any.
+ * `CREDITS_MANIFESTO_ATTRIBUTION` renders beside this text and is not optional
+ * — it was written before the words arrived precisely so the credit could not
+ * become a follow-up nobody files.
  *
- * So the BLOCK is built and the TEXT is not: swapping this constant for the
- * real thing is the entire change, and `CREDITS_MANIFESTO_ATTRIBUTION` below
- * is already rendered beside it so the credit cannot arrive as an
- * afterthought. `creditsFinale.test.ts` fails if the manifesto's own words
- * turn up here before that happens.
+ * `String.raw`, not a plain template literal: the Phrack header art is
+ * `\/\The Conscience of a Hacker/\/` and a plain literal reads `\/` as an
+ * escape for `/`, silently eating the backslashes.
+ *
+ * The leading whitespace of the original is NOT reproduced. What was pasted in
+ * carried a monotonically growing indent (0, 8, 16, ... past 100 columns) that
+ * is an editor auto-indent artifact rather than Phrack's layout, and the slot
+ * renders `white-space: pre-wrap` inside a 64ch column, where those columns
+ * wrap into noise on a phone. Every line is therefore flush left — one rule,
+ * applied uniformly, with the paragraph breaks doing the structuring. The
+ * words are untouched.
  */
-export const CREDITS_MANIFESTO =
-  "— the manifesto goes here, once its licence is settled in writing —";
+export const CREDITS_MANIFESTO = String.raw`\/\The Conscience of a Hacker/\/
+
+by
+
++++The Mentor+++
+
+Written on January 8, 1986
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+Another one got caught today, it's all over the papers.  "Teenager
+Arrested in Computer Crime Scandal", "Hacker Arrested after Bank Tampering"...
+Damn kids.  They're all alike.
+
+But did you, in your three-piece psychology and 1950's technobrain,
+ever take a look behind the eyes of the hacker?  Did you ever wonder what
+made him tick, what forces shaped him, what may have molded him?
+I am a hacker, enter my world...
+Mine is a world that begins with school... I'm smarter than most of
+the other kids, this crap they teach us bores me...
+Damn underachiever.  They're all alike.
+
+I'm in junior high or high school.  I've listened to teachers explain
+for the fifteenth time how to reduce a fraction.  I understand it.  "No, Ms.
+Smith, I didn't show my work.  I did it in my head..."
+Damn kid.  Probably copied it.  They're all alike.
+
+I made a discovery today.  I found a computer.  Wait a second, this is
+cool.  It does what I want it to.  If it makes a mistake, it's because I
+screwed it up.  Not because it doesn't like me...
+Or feels threatened by me...
+Or thinks I'm a smart ass...
+Or doesn't like teaching and shouldn't be here...
+Damn kid.  All he does is play games.  They're all alike.
+
+And then it happened... a door opened to a world... rushing through
+the phone line like heroin through an addict's veins, an electronic pulse is
+sent out, a refuge from the day-to-day incompetencies is sought... a board is
+found.
+"This is it... this is where I belong..."
+I know everyone here... even if I've never met them, never talked to
+them, may never hear from them again... I know you all...
+Damn kid.  Tying up the phone line again.  They're all alike...
+
+You bet your ass we're all alike... we've been spoon-fed baby food at
+school when we hungered for steak... the bits of meat that you did let slip
+through were pre-chewed and tasteless.  We've been dominated by sadists, or
+ignored by the apathetic.  The few that had something to teach found us will-
+ing pupils, but those few are like drops of water in the desert.
+
+This is our world now... the world of the electron and the switch, the
+beauty of the baud.  We make use of a service already existing without paying
+for what could be dirt-cheap if it wasn't run by profiteering gluttons, and
+you call us criminals.  We explore... and you call us criminals.  We seek
+after knowledge... and you call us criminals.  We exist without skin color,
+without nationality, without religious bias... and you call us criminals.
+You build atomic bombs, you wage wars, you murder, cheat, and lie to us
+and try to make us believe it's for our own good, yet we're the criminals.
+
+Yes, I am a criminal.  My crime is that of curiosity.  My crime is
+that of judging people by what they say and think, not what they look like.
+My crime is that of outsmarting you, something that you will never forgive me
+for.
+
+I am a hacker, and this is my manifesto.  You may stop this individual,
+but you can't stop us all... after all, we're all alike.
+
++++The Mentor+++`;
 
 /**
  * The credit the manifesto ships WITH, written now rather than later.
@@ -72,15 +144,3 @@ export const CREDITS_MANIFESTO =
  */
 export const CREDITS_MANIFESTO_ATTRIBUTION =
   "The Mentor (Loyd Blankenship) — Phrack Vol. 1, Issue 7, Phile 3, 8 January 1986";
-
-/**
- * Is the manifesto still the placeholder above?
- *
- * Exported so the tripwire is a function of the constant rather than a second
- * copy of the placeholder string sitting in a test — the failure mode of a
- * duplicated sentinel is that somebody fills the constant in and the test goes
- * on comparing against its own stale copy, reporting green.
- */
-export function manifestoAwaitingClearance(): boolean {
-  return CREDITS_MANIFESTO.startsWith("—");
-}

--- a/cicchetto/src/lib/creditsFinale.ts
+++ b/cicchetto/src/lib/creditsFinale.ts
@@ -1,0 +1,86 @@
+// #1931 — the credits' ENDING: what is shown once the prose deck has dealt
+// every set it has.
+//
+// Sibling of `creditsBlock.ts`, and split from it along the same line that
+// file draws: `creditsBlock` owns the content of the FIRST block (the cow, the
+// special thanks), this one owns the content of the LAST. Between them run the
+// `creditsProse` sets, which are the only part of the sequence that repeats.
+//
+// 🔴 TWO CONSTANTS HERE ARE PLACEHOLDERS AWAITING vjt, and neither is the
+// implementer's to write:
+//
+//   CREDITS_FINALE_LINE   the "that's all, folks!" in cypherpunk register.
+//                         The issue says outright that the exact wording is
+//                         vjt's call. What ships below is a stand-in.
+//   CREDITS_MANIFESTO     "The Conscience of a Hacker". BLOCKED on more than
+//                         wording — see below.
+//
+// Each sits behind ONE named constant, in ONE place, pinned by
+// `creditsFinale.test.ts`, so filling either in is a one-line edit. The tests
+// assert the SHAPE a replacement has to keep, never the words, and they are
+// what makes a forgotten placeholder visible instead of shipped.
+
+/** The heart, in ASCII. */
+export const CREDITS_HEART = "<3";
+
+/**
+ * 🔴 PLACEHOLDER — awaiting vjt's wording.
+ *
+ * The brief asks for Looney Tunes CADENCE and cypherpunk REGISTER: the shape
+ * of an ending anybody recognises, saying something this project would say.
+ * What it must never be is the quotation itself — "That's all Folks!" is a
+ * Warner Bros. trademark, and a trademark does not expire with the copyright
+ * on the tune. `creditsFinale.test.ts` forbids the quotation by name.
+ *
+ * One line, no newline: the finale lays it out between the heart and the
+ * close button, and a paragraph there pushes the button off a phone.
+ */
+export const CREDITS_FINALE_LINE = "and that's the whole of the wire, friends.";
+
+/** What the finale's own close control says. */
+export const CREDITS_CLOSE_LABEL = "click here to close";
+
+/**
+ * 🔴 PLACEHOLDER — and this one is BLOCKED on permission, not on wording.
+ *
+ * The finale is supposed to show "The Conscience of a Hacker" (The Mentor —
+ * Loyd Blankenship, *Phrack* Vol. 1 Issue 7 Phile 3, 8 January 1986)
+ * immediately before the heart. vjt's instruction is verbatim: **do not
+ * include it until vjt confirms in writing on #grappa.**
+ *
+ * The reason is not squeamishness. The text is from 1986, was never dedicated
+ * to the public domain and was never put under a free licence. It has been
+ * reproduced everywhere for forty years, but that is CUSTOM and not
+ * PERMISSION — and grappa ships a public PWA and a `.deb`, which is the same
+ * reason `creditsAudio.ts` synthesises its music instead of sampling any.
+ *
+ * So the BLOCK is built and the TEXT is not: swapping this constant for the
+ * real thing is the entire change, and `CREDITS_MANIFESTO_ATTRIBUTION` below
+ * is already rendered beside it so the credit cannot arrive as an
+ * afterthought. `creditsFinale.test.ts` fails if the manifesto's own words
+ * turn up here before that happens.
+ */
+export const CREDITS_MANIFESTO =
+  "— the manifesto goes here, once its licence is settled in writing —";
+
+/**
+ * The credit the manifesto ships WITH, written now rather than later.
+ *
+ * A slot that arrives without an attribution is how a text ends up shipping
+ * without one: the words are the interesting part to paste in, the credit is
+ * the part that gets left for a follow-up nobody files.
+ */
+export const CREDITS_MANIFESTO_ATTRIBUTION =
+  "The Mentor (Loyd Blankenship) — Phrack Vol. 1, Issue 7, Phile 3, 8 January 1986";
+
+/**
+ * Is the manifesto still the placeholder above?
+ *
+ * Exported so the tripwire is a function of the constant rather than a second
+ * copy of the placeholder string sitting in a test — the failure mode of a
+ * duplicated sentinel is that somebody fills the constant in and the test goes
+ * on comparing against its own stale copy, reporting green.
+ */
+export function manifestoAwaitingClearance(): boolean {
+  return CREDITS_MANIFESTO.startsWith("—");
+}

--- a/cicchetto/src/lib/creditsProse.ts
+++ b/cicchetto/src/lib/creditsProse.ts
@@ -178,6 +178,24 @@ export const CREDITS_PROSE: readonly ProseSet[] = [
 export type ProseDeck = {
   /** The set for the pass that is starting now, or `null` from an empty pool. */
   draw(): ProseSet | null;
+  /**
+   * Has the current bag dealt every set it holds? (#1931)
+   *
+   * TRUE for exactly the window between the draw that empties the bag and the
+   * next one, which refills it — so a caller reading this once per pass sees
+   * it once per full bag, and the credits' ending fires once per bag rather
+   * than on every pass thereafter.
+   *
+   * This is DERIVED, never tallied. The bag, the last index dealt and the pool
+   * size already say it between them; a `dealt` counter alongside them would
+   * be a second account of the same fact, and the one that drifts is always
+   * the one the ending reads.
+   *
+   * `false` from an empty pool: nothing has been shown, so nothing has been
+   * exhausted — the reading a bare `bag.length === 0` gets wrong, and it gets
+   * it wrong in the direction that cuts straight to the ending on pass one.
+   */
+  exhausted(): boolean;
 };
 
 /**
@@ -237,6 +255,13 @@ export function createProseDeck(
       const index = bag.pop() as number;
       last = index;
       return sets[index] as ProseSet;
+    },
+
+    exhausted(): boolean {
+      // `last !== null` is what separates a bag that has been dealt out from
+      // one that has never been filled: the refill is lazy, so both leave
+      // `bag` empty and only "something has been dealt" tells them apart.
+      return sets.length > 0 && last !== null && bag.length === 0;
     },
   };
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14896,7 +14896,7 @@ audio.media-viewer-media {
 
    ⚠️ These two rules deliberately carry the same declarations as the media
    query above. CSS has no way to share them across a media boundary, so
-   `creditsFinale.css.test.ts` pins that the pair agrees rather than a comment
+   `creditsFinaleCss.test.ts` pins that the pair agrees rather than a comment
    asking the next reader to keep them in step. */
 .credits-viewport-ended {
   overflow-y: auto;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -14647,6 +14647,17 @@ audio.media-viewer-media {
   flex-direction: inherit;
   align-items: inherit;
   gap: inherit;
+}
+
+/* #1931 split the FADE off the block's layout, and it is not tidiness: the
+   block comes back for the finale, and the fade is a one-shot with `forwards`,
+   so a re-mounted element carrying it would dissolve the ending the reader is
+   being shown. Two classes is how "the same box, but this time it stays" is
+   said without a second box.
+
+   It also keeps `creditsRain.blockIsFading` honest for free — the finale's
+   block has no animation on it at all, so the reader has nothing to misread. */
+.credits-block-fading {
   animation: credits-block-fade 34s linear 1 forwards;
 }
 
@@ -14861,4 +14872,128 @@ audio.media-viewer-media {
     animation: none;
     padding: max(3rem, var(--safe-area-inset-top)) 1.5rem max(3rem, var(--safe-area-inset-bottom));
   }
+
+  /* #1931 — the heart pulses, so it is motion and it stops here with the
+     rest. A `<3` that merely sits there is still the joke. */
+  .credits-heart {
+    animation: none;
+  }
+}
+
+/* #1931 — THE END OF THE SEQUENCE, and it is the reduced-motion posture reused
+   rather than a new one: a static, scrollable column.
+
+   The reason is the close button. Everything in this modal travels, and a
+   button that scrolls off the top is a button you wait 34s for — so when the
+   ending arrives the roll STOPS, and the way to stop it that already exists in
+   this stylesheet is the one the media query above uses.
+
+   Stopping it also settles the rain with no code at all: both readers in
+   `creditsRain` ask the roll's animation what phase it is in, and an element
+   with `animation: none` reports none, which they already answer "steady" to
+   (pinned by `creditsRain.test.ts`'s no-animation case). That is how the rain
+   is kept from fighting the heart WITHOUT a third clock.
+
+   ⚠️ These two rules deliberately carry the same declarations as the media
+   query above. CSS has no way to share them across a media boundary, so
+   `creditsFinale.css.test.ts` pins that the pair agrees rather than a comment
+   asking the next reader to keep them in step. */
+.credits-viewport-ended {
+  overflow-y: auto;
+  pointer-events: auto;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
+.credits-roll-ended {
+  position: static;
+  animation: none;
+  padding: max(3rem, var(--safe-area-inset-top)) 1.5rem max(3rem, var(--safe-area-inset-bottom));
+}
+
+/* The heart. Big, ASCII, and beating — the pulse is what makes `<3` read as a
+   heart rather than as two characters. `ease-in-out` with a rest between beats
+   rather than a sine: a continuous throb reads as a loading spinner. */
+.credits-heart {
+  margin: 2rem 0 0.5rem;
+  font-family: var(--font-mono);
+  font-size: min(4rem, 18vw);
+  line-height: 1;
+  color: var(--accent);
+  text-shadow: 0 0 1.5rem var(--accent);
+  animation: credits-heart-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes credits-heart-pulse {
+  0%,
+  60%,
+  100% {
+    transform: scale(1);
+  }
+
+  15% {
+    transform: scale(1.18);
+  }
+
+  30% {
+    transform: scale(1.02);
+  }
+
+  45% {
+    transform: scale(1.12);
+  }
+}
+
+.credits-finale-line {
+  margin: 0 0 1.5rem;
+  max-width: min(58ch, 88vw);
+  font-size: 1.1em;
+  color: var(--fg);
+}
+
+/* A real `button`, styled to sit in the roll: the ending is reachable by
+   keyboard and announced as a control, which a clickable `div` is not. */
+.credits-close-cta {
+  margin: 0 0 2rem;
+  padding: 0.6rem 1.4rem;
+  font: inherit;
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.credits-close-cta:hover,
+.credits-close-cta:focus-visible {
+  color: var(--bg);
+  background: var(--accent);
+}
+
+/* The manifesto's own screen. LEFT-aligned and capped in `ch` for the reason
+   `.credits-prose` records: it is the longest thing in the modal by a factor
+   of four, and a centred wall of it costs the reader the start of every
+   line. */
+.credits-manifesto {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: min(64ch, 88vw);
+  text-align: left;
+  font-size: 0.95em;
+  line-height: 1.6;
+}
+
+.credits-manifesto-text {
+  margin: 0;
+  white-space: pre-wrap;
+  color: var(--fg);
+}
+
+/* Quieter than the text and never omitted — see `creditsFinale.ts`. */
+.credits-manifesto-attribution {
+  margin: 0;
+  font-size: 0.85em;
+  font-style: italic;
+  color: var(--muted);
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46150,3 +46150,165 @@ contained to `creditsRainLook`.
   is not measured either, and the two are not claimed to cancel.
 
 _Deploy: **HOT — `--cic` only.** Client-side; no server change._
+<!-- entry #1931 -->
+
+---
+
+## 2026-09-06 — #1931: the credits end — a spent deck, a manifesto, a pulsing heart and a way out
+
+The credit roll never finished. `createProseDeck()` is an infinite shuffle
+bag, so once the sixteen prose sets had been dealt it reshuffled and started
+again. vjt's brief is that the sequence should have an ENDING, and an addendum
+dictated the same evening put a fourth thing in it. End to end:
+
+    block (roll + cow + thanks, #1929)
+      → prose sets until the bag is spent
+      → the manifesto, under music of its own
+      → the credits AGAIN + a pulsing <3 + a closing line + a close button
+
+### The trigger is the deck, and the deck now says so
+
+The ending fires when every set has been dealt once — not on a pass counter
+and not on a timer. Both of those are a second tally of what the reader has
+actually been shown, and the one thing an ending must not get wrong is
+arriving early.
+
+`ProseDeck.exhausted()` is DERIVED rather than counted: the bag, the last
+index dealt and the pool size already say it between them, so a `dealt` field
+would be a parallel account of one fact and the copy that drifts is always the
+one the ending reads. The subtlety is the `last !== null` conjunct — the
+refill is lazy, so a bag that has never been filled and one that has been
+dealt out are the same empty array. Without it an empty pool reads as
+"everything has been shown" and cuts to the ending on pass one. That case has
+a test.
+
+### A stage, not a pass number
+
+`CreditsModal` had `pass()`, set from the roll's own `currentIteration`. It
+could express "show the names" and nothing else. It could not express "the
+deck is spent", and it could not tell the manifesto from the finale — both
+would have become arithmetic on a number that means something different, which
+is exactly how an early "that's all, folks" gets written.
+
+So the modal carries a closed set: `"block" | "prose" | "manifesto" |
+"finale"`, walked by `advance()` on the roll's `animationiteration`. The BRANCH
+ORDER inside it is the guarantee, and the test asserts the heart's absence on
+every one of the sixteen turns before the end rather than on a sample, because
+the interesting failure here is an off-by-one.
+
+`endingDue` is one session-scoped boolean and it is **not** a copy of
+`deck.exhausted()`. The deck reports an EDGE — the draw that empties the bag —
+and the ending is two turnovers later, so something has to hold the news in
+between. Clearing it when the finale arrives is what makes both reopen cases
+right, and they pull in opposite directions:
+
+* close one set short and come back → you land on the ending. The deck is
+  session-scoped on purpose, so progress across viewings is not thrown away.
+* come back after a FINISHED run → you get prose again. A latch that stayed
+  set would replay the ending for ever and put all sixteen sets out of reach
+  for the rest of the session.
+
+### The roll STOPS, and that is what settles the rain
+
+Everything in this modal travels. A close button that scrolls off the top is a
+button the reader waits a full 34 s cycle for — so when the ending arrives the
+roll is parked, reusing the posture `prefers-reduced-motion` already has in
+this stylesheet (`position: static; animation: none`) rather than inventing a
+second one.
+
+The reuse pays a second time, and this is the answer to "the rain must not
+fight the heart, and no third clock": **both readers in `creditsRain` ask the
+roll's animation what phase it is in, and an element with `animation: none`
+has none to report** — which they already answer "steady" to, pinned since
+#1807 by the no-animation case. The rain settles with no new code, no new
+dial, and nothing in `creditsRain.ts` touched.
+
+The fade splits off `.credits-block` onto `.credits-block-fading`, because the
+block COMES BACK for the finale and the fade is `1 forwards`: a re-mounted
+element still carrying it would dissolve the ending as it arrives. Invisible
+in review, fatal to the one screen the reader is meant to act on.
+
+CSS cannot share declarations across a media boundary, so the ended rules and
+the reduced-motion rules carry the same text twice. A test compares them
+declaration for declaration, with a positive control that the travel is
+genuinely off — a comment asking the next reader to keep two rules in step is
+what lets rules drift.
+
+### Three pieces of music on one graph, dissolved rather than cut
+
+vjt: *"musichette crossfade"*. The soundtrack gains a manifesto theme and a
+closing cadence beside the suite, and the joins are dissolves.
+
+That is why there are now three gain buses under the master. A crossfade needs
+both pieces audible at the same instant, which one retargeted bus cannot
+express — it can only dip to silence and come back, which is the cut with
+extra steps. Notes connect to the bus of the piece that ARMED them, so the
+outgoing bar rings on while its bus ramps down, and the incoming piece enters
+at `currentTime` instead of at the next bar line, which can be most of a bar
+away and would run the fade out over silence.
+
+`linearRampToValueAtTime`, not the `setTargetAtTime` the mute uses:
+setTargetAtTime approaches asymptotically and never arrives, so two of them
+cannot share the landing instant that makes a pair of ramps a crossfade.
+
+**The master is deliberately outside all of it**, and that is load-bearing
+rather than incidental layering. Mute and teardown have to work MID-DISSOLVE,
+when two buses sound and three carry ramps scheduled into the future. Mute
+acts above the buses, so it silences the fade without fighting it on the same
+params; the teardown cancels the pending ramps on every bus before dropping
+the graph. Closing the context would mask a missing cancel in practice — which
+is why the test asserts the cancel and not the close, at the exact moment of
+the fade.
+
+The cadence is ONE-SHOT. An ending on a loop is a ringtone, which is the
+defect #1916 was filed for.
+
+### What is licensed, and what is therefore NOT in the tree
+
+* **The tune quotes nothing.** The Looney Tunes outro is "The Merry-Go-Round
+  Broke Down" (1937) — US copyright to 2033 — and "That's all Folks!" is a
+  Warner Bros. trademark, which does not expire at all. The cadence borrows
+  the SHAPE of an ending (rise, turn, land, over a plagal iv–i) which is
+  nobody's property. A test pins the contour rather than the pitches, so the
+  tune can be rewritten without touching it, and forbids the trademarked
+  string by name.
+* 🔴 **The manifesto's TEXT is not here.** "The Conscience of a Hacker" (The
+  Mentor — Loyd Blankenship, *Phrack* Vol. 1 Issue 7 Phile 3, 8 January 1986)
+  is from 1986, was never dedicated to the public domain and was never put
+  under a free licence. Forty years of universal reproduction is custom, not
+  permission, and grappa ships a public PWA and a `.deb`. vjt's instruction is
+  verbatim: *do not include it until vjt confirms in writing*. So the BLOCK is
+  built and the text is a placeholder behind one named constant, with a test
+  that fails if the manifesto's own opening lines appear. Its ATTRIBUTION
+  renders now, beside the empty slot, because a credit left to a follow-up is
+  a credit that never ships.
+* 🔴 **The closing line is a placeholder too**, for a smaller reason: the
+  wording is vjt's call, not the implementer's.
+* **The manifesto is its own block and not a seventeenth prose set.** It is
+  ~570 words against a cap of 150, and the cheap way to fit it is to raise the
+  cap — which silently un-bounds all sixteen sets the cap exists to keep
+  readable. `PROSE_SET_MAX_WORDS` is therefore pinned BY NUMBER, so raising it
+  is a red test rather than a quiet edit.
+
+⚠️ **Measured, correcting the issue:** the issue states the cap is "300 after
+the raise". There was no raise. `git log -S 'PROSE_SET_MAX_WORDS = 300'` on
+`creditsProse.ts` returns nothing, while the same search for `= 150` returns
+`31fa3bd92`, the commit that introduced it. The manifesto is ~3.8× the cap
+rather than ~1.9×, which strengthens the case for a separate block.
+
+### What is NOT established here
+
+* **Nothing was seen.** No browser and no handset in this session, so every
+  visual claim is arithmetic and unit tests. That the heart reads as a
+  heartbeat rather than as a spinner, that the dissolves sound like dissolves,
+  and that the stopped roll leaves the button somewhere sensible on a phone,
+  are a human's verdict on a real screen.
+* **The crossfade is measured as SCHEDULING, not as sound.** The tests assert
+  which ramps are scheduled on which bus and when; no test renders audio. An
+  `OfflineAudioContext` would measure the mix, and this does not use one.
+* **The gain budget is pinned per piece, not across a dissolve.** Each new
+  piece is proven no louder than the loudest bar of the suite; during the
+  overlap two buses sound at once, and the argument that the fade keeps their
+  sum in hand is arithmetic, not a measurement.
+
+_Deploy: **HOT — `--cic` only.** Client-side; no server change._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46272,18 +46272,41 @@ defect #1916 was filed for.
   nobody's property. A test pins the contour rather than the pitches, so the
   tune can be rewritten without touching it, and forbids the trademarked
   string by name.
-* 🔴 **The manifesto's TEXT is not here.** "The Conscience of a Hacker" (The
-  Mentor — Loyd Blankenship, *Phrack* Vol. 1 Issue 7 Phile 3, 8 January 1986)
-  is from 1986, was never dedicated to the public domain and was never put
-  under a free licence. Forty years of universal reproduction is custom, not
-  permission, and grappa ships a public PWA and a `.deb`. vjt's instruction is
-  verbatim: *do not include it until vjt confirms in writing*. So the BLOCK is
-  built and the text is a placeholder behind one named constant, with a test
-  that fails if the manifesto's own opening lines appear. Its ATTRIBUTION
-  renders now, beside the empty slot, because a credit left to a follow-up is
-  a credit that never ships.
-* 🔴 **The closing line is a placeholder too**, for a smaller reason: the
-  wording is vjt's call, not the implementer's.
+* **The manifesto's TEXT ships, on vjt's own clearance.** "The Conscience of a
+  Hacker" (The Mentor — Loyd Blankenship, *Phrack* Vol. 1 Issue 7 Phile 3, 8
+  January 1986) is from 1986, was never dedicated to the public domain and was
+  never put under a free licence; forty years of universal reproduction is
+  CUSTOM, not permission, and grappa ships a public PWA and a `.deb`. So the
+  slot was built empty first, behind one named constant, with a tripwire test
+  that failed if the manifesto's own opening lines appeared — the standing
+  instruction being *do not include it until vjt confirms in writing*. **He
+  confirmed on 2026-09-06**, as the repository's owner, on the stated grounds
+  that the project is open source and that he will comply with a takedown if
+  one is ever asked for. The tripwire is therefore gone and its tests now pin
+  what SHIPS: the words, the credit beside them, and the two ways the paste
+  can be corrupted silently (below). **The decision is recorded with whose it
+  was on purpose** — the block is still in this file's history, and a reader
+  who finds it must be able to see what lifted it rather than re-derive it.
+* **The attribution is not decoration, it is the term.** It was written before
+  the words arrived, and the render-level test asserts the credit is inside
+  the same block as the text — the constant-level pin cannot see a markup edit
+  that drops one and keeps the other.
+* 🔴 **Two silent corruptions of the pasted text, both pinned.** (1) The Phrack
+  header art is `\/\The Conscience of a Hacker/\/`, and in a plain template
+  literal `\/` is an escape for `/` — the backslashes vanish with no error and
+  nothing in a diff to catch the eye. `String.raw` is why they survive. (2)
+  What was pasted in carried a monotonically growing indent (0, 8, 16, … past
+  100 columns), an editor auto-indent artifact rather than Phrack's layout,
+  and the slot renders `white-space: pre-wrap` in a 64ch column where that
+  wraps into noise on a phone. Every line is flush left — ONE rule applied
+  uniformly, rather than a reconstruction of the original two-level shape,
+  which the mangled indent no longer contains enough information to recover.
+  The words are untouched; the paragraph breaks do the structuring.
+* **The closing line was a placeholder for a smaller reason** — the wording was
+  vjt's call, not the implementer's. It resolved the other way round: vjt
+  approved the implementer's line on 2026-09-06 and changed one word,
+  `friends` → `folks`, which is the Looney Tunes cadence landing in the one
+  place it can land without quoting the mark.
 * **The manifesto is its own block and not a seventeenth prose set.** It is
   ~570 words against a cap of 300, and the cheap way to fit it is to raise the
   cap — which silently un-bounds all sixteen sets the cap exists to keep

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46285,16 +46285,33 @@ defect #1916 was filed for.
 * 🔴 **The closing line is a placeholder too**, for a smaller reason: the
   wording is vjt's call, not the implementer's.
 * **The manifesto is its own block and not a seventeenth prose set.** It is
-  ~570 words against a cap of 150, and the cheap way to fit it is to raise the
+  ~570 words against a cap of 300, and the cheap way to fit it is to raise the
   cap — which silently un-bounds all sixteen sets the cap exists to keep
   readable. `PROSE_SET_MAX_WORDS` is therefore pinned BY NUMBER, so raising it
-  is a red test rather than a quiet edit.
+  is a red test rather than a quiet edit. The pin cannot read intent and does
+  not try to: it makes ANY move an argued diff.
 
-⚠️ **Measured, correcting the issue:** the issue states the cap is "300 after
-the raise". There was no raise. `git log -S 'PROSE_SET_MAX_WORDS = 300'` on
-`creditsProse.ts` returns nothing, while the same search for `= 150` returns
-`31fa3bd92`, the commit that introduced it. The manifesto is ~3.8× the cap
-rather than ~1.9×, which strengthens the case for a separate block.
+⚠️ **A retraction, and the rule it cost.** This entry first carried a
+"measured correction to the issue": the issue calls the cap "300 after the
+raise", and `git log -S 'PROSE_SET_MAX_WORDS = 300'` on `creditsProse.ts`
+returned nothing while `= 150` returned `31fa3bd92`, so the raise was declared
+never to have happened. **The search was right and the inference was wrong.**
+The raise existed as an OPEN PR, not as a commit — it landed a few hours later
+as the copy rewrite, and the cap is 300. The manifesto is ~1.9× the cap, the
+ratio the issue always claimed.
+
+**The rule: `git log -S` answers "is this in the history of THIS ref", never
+"does this exist".** Those are the same question only when nothing is in
+flight, which is exactly the condition a concurrent worktree cannot assume.
+The failure is silent and reads as rigour — an empty search result looks like
+evidence of absence and is quoted as one. When a search over history is about
+to contradict a written spec, the missing half is the open PRs; the honest
+form of the claim names the ref it was measured against and its date.
+
+The pin itself was not the mistake and did not change shape: it moved from
+`toBe(150)` to `toBe(300)` and still forbids the one move the block exists to
+prevent. What changed is that its comment no longer accuses the issue of
+inventing a number.
 
 ### What is NOT established here
 


### PR DESCRIPTION
Builds the ending of the credits sequence for issue 1931 — deck exhaustion as the
trigger, the manifesto slot, the pulsing `<3`, the closing button, and a
crossfaded three-piece score.

## Both texts are settled — vjt's, on 2026-09-06

This PR was opened with two deliberately empty constants. Both are now filled,
by the person whose call they were.

**`CREDITS_MANIFESTO`** — "The Conscience of a Hacker" (The Mentor / Loyd
Blankenship, *Phrack* Vol. 1 Issue 7 Phile 3, 8 January 1986) **ships**. The
standing order had been *"do not include it until vjt confirms in writing"*: the
text is from 1986, was never dedicated to the public domain and was never put
under a free licence, and forty years of universal reproduction is custom rather
than permission — with a public PWA and a `.deb` downstream. vjt cleared it as
the repository's owner, on the stated grounds that the project is open source
and that he will comply with a takedown if one is ever asked for. The decision
is recorded in the module, in the DESIGN_NOTES entry and in the commit, with
whose it was — the block is still in this repository's history, and a reader who
finds it must be able to see what lifted it.

`manifestoAwaitingClearance()` and the two tests guarding an empty slot are gone;
they had one job and it is done. What replaces them pins what ships, including
**two ways this paste corrupts silently**:

- the Phrack header art is `\/\The Conscience of a Hacker/\/`, and in a plain
  template literal `\/` is an escape for `/` — the backslashes would vanish with
  no error and nothing in a diff to notice. `String.raw`, with a test that reads
  the art back.
- what was pasted in carried a monotonically growing indent (0, 8, 16, … past
  100 columns), an editor auto-indent artifact rather than Phrack's layout, and
  the slot renders `white-space: pre-wrap` in a 64ch column where that wraps into
  noise on a phone. Every line is now flush left — one rule applied uniformly,
  not a reconstruction of the original two-level shape, which the mangled indent
  no longer carries enough information to recover. The words are untouched.

The attribution needed no edit, which is the point of having written it first.
It is now asserted at the RENDER as well as at the constant: a markup change that
keeps the words and drops the credit is invisible to a constant-level pin, and
the credit is the term on which the text is here.

**`CREDITS_FINALE_LINE`** — resolved the other way round from how it was framed.
vjt approved the implementer's line rather than replacing it, changing one word:
`friends` → `folks`. It reads `and that's the whole of the wire, folks.` — the
Looney Tunes cadence in the one place it can land without quoting the mark, and
the test forbidding "that's all folks" by name still passes.

## The sequence, end to end

    roll + cowsay + special thanks   (#1929, already on main)
      -> prose sets until the bag is exhausted
      -> MANIFESTO slot (its own piece of music)
      -> credits again + pulsing <3 + closing line + close button (final cadence)

## What is built

- **Trigger is exhaustion, not a counter and not a timer.** `ProseDeck.exhausted()`
  in `creditsProse.ts` is DERIVED from the bag, `last`, and `sets.length` — no
  parallel state to keep in step. The deck stays SESSION-scoped, so the ending is
  reachable across several openings of the modal; that is pinned, as is the
  failure mode that would ruin it (the ending must never arrive before the last
  set).
- **Audio: three pieces on one graph.** `creditsAudio.ts` grows `suite` /
  `manifesto` / `cadence`, three `GainNode`s under the existing master, and
  `setPiece()` crossfades with overlapping linear ramps instead of the old hard
  `stopArpeggio()` teardown. The cadence is original, 4–5 notes, one-shot, on the
  same oscillator path — no sample, no asset, no fetch. `barEvents()` is extracted
  so all three pieces render through ONE path. The hard constraint has its own
  tests: **mute mid-fade** and **teardown mid-fade**, the latter asserting
  `cancelScheduledValues` on every bus.
- **No third clock.** The modal replaces `pass()` with a
  `"block" | "prose" | "manifesto" | "finale"` stage machine that advances on the
  roll's own `animationiteration`. The ending STOPS the roll
  (`.credits-roll-ended`, reusing the `prefers-reduced-motion` posture), which is
  also what settles the rain around the heart with no code at all: both readers in
  `creditsRain` ask the roll's animation what phase it is in, and an element with
  `animation: none` reports none — a case those readers already answer "steady"
  to. So "the rain must not fight the heart" is satisfied by the same declaration
  that keeps the close button reachable.
- **The button closes through `closeCreditsModal`**, the same function the overlay
  lock is handed and the ✕ calls — not a second closing mechanism.
- **The heart is ASCII `<3`**, and it stops under `prefers-reduced-motion` like the
  rest of the modal. Two peaks and a rest per cycle, pinned, because a single-peak
  keyframe set reads as a loading spinner.

## A retraction — a claim of mine that the copy rewrite falsified

This PR previously carried a "measured correction to the issue": the issue puts
`PROSE_SET_MAX_WORDS` at "300 after the raise", and `git log -S
'PROSE_SET_MAX_WORDS = 300'` on `creditsProse.ts` returned nothing while `= 150`
returned `31fa3bd92` — so I wrote that no such raise existed and that the
manifesto was ~3.8x the cap rather than ~1.9x.

**The search was right and the inference was wrong.** The raise existed as an
OPEN PR, not as a commit, and a search over history cannot see one. It has since
landed as the copy rewrite; the cap is 300 and the manifesto is ~1.9x it — the
ratio the issue claimed all along. The retraction is recorded in the DESIGN_NOTES
entry, in the test comment that carried the claim, and in its own commit.

The rule it cost, which is the part worth keeping: **`git log -S` answers "is
this in the history of THIS ref", never "does this exist"**, and those coincide
only when nothing is in flight — precisely what a concurrent worktree may not
assume. It reads as rigour, which is what makes it dangerous: an empty search
result looks like evidence of absence and gets quoted as one.

The pin did not change shape. `expect(PROSE_SET_MAX_WORDS).toBe(150)` became
`toBe(300)` and still forbids the one move the separate manifesto block exists
to prevent — raising the cap until the manifesto fits, which would silently
un-bound all sixteen ordinary sets. The pin cannot read intent and does not try
to; it makes ANY move an argued diff. Pinning "the sets still pass" instead
would be a weakening, since every set would pass a cap of 600.
`creditsProse.test.ts` needed no edit: it bounds the sets by the constant, not
by a literal, so it followed the raise on its own.

## Gates

Rebased onto `192ada3a5`. Baseline re-measured on that same commit in a
throwaway detached worktree (now torn down), so the comparison is against the
base this PR actually sits on. Both runs whole, rc read from files, never
through a pipe.

| gate | baseline @ `192ada3a5` | this branch |
|---|---|---|
| `scripts/bun.sh run check` | rc=0, 5 stages / 0 failed, 58 warnings / 4 infos | rc=0, 5 stages / 0 failed, **58 warnings / 4 infos** |
| `scripts/bun.sh run test` | rc=0, 335 files / 6715 tests | rc=0, **337 files / 6756 tests** |

Zero warnings added. +2 test files, +41 tests. The copy rewrite added neither
tests nor warnings, so these numbers are unchanged from the pre-rebase baseline.

### The rebase, and the thing it could have done silently

The overlap between the copy rewrite and this branch is exactly one file,
`cicchetto/src/lib/creditsProse.ts` (`comm -12` of the two changed-file sets,
with a positive control). The rebase produced **no conflict**, which is the
condition under which a "take mine" resolution reverts someone else's work
without a marker to notice. Predictions were written down BEFORE rebasing and
each has a divergent value under the revert:

| | predicted | a silent revert | measured after |
|---|---|---|---|
| `creditsProse.ts` bytes | 17265 | 12567 | **17265** |
| contribution numstat | 25 / 0 | ~59 / 43 | **25 / 0** |
| `PROSE_SET_MAX_WORDS` | 300 | 150 | **300** |

Independently: all **43/43** lines the copy rewrite ADDED are present in this
tree, and **0/34** of the lines it REMOVED came back.

### DESIGN_NOTES

`scripts/union-rebase.sh` reports `+202 -0 — contribution intact`, and
`design-notes-gate.sh` post-commit gives rc=0, `1 new entry heading(s),
separator and marker present.` Marker `<!-- entry #1931 -->` is unique against
the current tip (0 occurrences; positive control `#1929` -> 1). Boundary shape
read on the file: full stop / marker / blank / `---` / blank / `##`.

Append-only is proved two-sided: `head -c K` of this file against the base's
whole file passes at **K = 2710547** and fails at both **K-1** and **K+1**, so
the boundary is exactly the base's EOF. Controls: a copy with one byte altered
in the prefix fails, and the base compared with itself passes.

## What is NOT claimed

- **Nobody has SEEN any of this.** No browser, no phone. Every visual claim here is
  arithmetic plus unit tests. That the heart beats like a heart rather than like a
  spinner, that the crossfades sound like crossfades, and that the close button
  lands somewhere sensible on a phone with the roll parked, are verdicts for a
  human in front of a real screen.
- **The crossfade is measured as SCHEDULING, not as sound.** The tests assert which
  ramps are scheduled on which bus and when. Nothing renders audio; that would want
  an `OfflineAudioContext`, which is not used here.
- **The gain budget is pinned PER PIECE, not across a fade.** During the overlap two
  buses sound together, and that the sum stays in hand is arithmetic, not a
  measurement.
- **Two of the DESIGN_NOTES checks are VACUOUS on this shape, and I am not passing them off as green.** (1) `union-rebase.sh`'s two-sided invariant is half vacuous here: this contribution is pure append, so `deletions == 0` holds by construction and can never fail — only the additions side is live. (2) Even that side is weak, because the base does not touch `DESIGN_NOTES.md` at all (sha256 of the file is identical at the merge base and at the base tip), so `merge=union` was never invoked and the replay was a plain patch application. Neither the eating nor the resurrection mode could be triggered by THIS move. The `head -c` boundary test above is what actually discriminates on this shape, which is why it is there.
