### PR TITLE
perf(scrollback): seek the folded index on the DM-peer rename UPDATE

### DIFF
--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1518,7 +1518,38 @@ defmodule Grappa.Scrollback do
 
       if count > 0 do
         # `dm_with` is the DISPLAY column → set the RAW new nick.
+        #
+        # The leading `where_dm_peer/2` is REDUNDANT BY LOGIC and there for
+        # the query planner alone: `lower(dm_with) = folded` already implies
+        # `lower(COALESCE(dm_with, channel)) = folded` (the fold can only
+        # match a NON-NULL `dm_with`, and COALESCE returns it whenever it is
+        # non-null), so the row-set is identical with or without it. What it
+        # buys is the index: the only folded index on `messages` is
+        # `messages_{visitor,user}_id_network_id_dm_coalesce_fold_id_kind_index`
+        # on `lower(COALESCE(dm_with, channel))`, and SQLite matches an
+        # expression index only against the SAME expression — `lower(dm_with)`
+        # alone is a different string, so the plan degraded to a SCAN of the
+        # subject's whole history behind the `(visitor_id, network_id)` prefix.
+        #
+        # 🔴 Measured on a raw copy of prod (2026-09-06, 2 GB db, 2.88M rows,
+        # `page_size = 65536`), one peer rename inside `BEGIN IMMEDIATE`:
+        #
+        #   subject       rows    UPDATE dm_with          plan
+        #   25k history   116     352 ms  →   2.8 ms      SCAN → SEARCH
+        #   205k history   73    1704 ms  →   1.9 ms      SCAN → SEARCH
+        #
+        # The 1704 ms was 1591 ms of `sys` — 64 KiB page reads, not CPU. This
+        # holds SQLite's single write lock, and `NickMigration.peer_renamed/5`
+        # runs it once per session per peer NICK, so a reconnect-looping peer
+        # pays it on every bounce.
+        #
+        # The `channel` arm below needs no such conjunct: its predicate rides
+        # `messages_{visitor,user}_id_network_id_channel_id_kind_index` as a
+        # COVERING index (15-55 ms, no table lookup), and the coalesce fold is
+        # NOT implied there — a row with `dm_with` set and a divergent
+        # `channel` (7740 of them in prod) would be silently skipped.
         base
+        |> where_dm_peer(folded_old)
         |> where([m], Identifier.nick_fold(m.dm_with) == ^folded_old)
         |> Repo.update_all(set: [dm_with: new_nick])
 

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -193,6 +193,30 @@ defmodule Grappa.ScrollbackTest do
     captured
   end
 
+  # The plural twin of `capture_one_query/1`, for a production function that
+  # is deliberately MULTI-statement (`rename_dm_peer/4` emits a count plus two
+  # `update_all`s). Returns them in emission order, so a test can pick the one
+  # whose plan it means to pin instead of pinning whichever came last.
+  defp capture_queries(fun) do
+    ref = make_ref()
+    test_pid = self()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:grappa, :repo, :query],
+      fn _, _, meta, _ -> send(test_pid, {ref, meta.query, meta.params}) end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach({__MODULE__, ref})
+    end
+
+    drain_queries(ref, [])
+  end
+
   defp drain_queries(ref, acc) do
     receive do
       {^ref, sql, params} -> drain_queries(ref, [{sql, params} | acc])
@@ -2886,6 +2910,57 @@ defmodule Grappa.ScrollbackTest do
       # AFTER: both rows read under the NEW window; the OLD nick reads empty.
       assert sorted_ids.(read_dm(user, net, "NickTemporaneo", own)) == both
       assert read_dm(user, net, "Guest87449", own) == []
+    end
+
+    # 🔴 The `dm_with` UPDATE holds SQLite's single write lock, and
+    # `NickMigration.peer_renamed/5` runs it once per session per peer NICK —
+    # so a peer in a reconnect loop pays it on every bounce. Measured on a raw
+    # copy of prod (2026-09-06, 2 GB, 2.88M rows, `page_size = 65536`): with
+    # the plan degraded to a SCAN behind the `(user_id, network_id)` prefix it
+    # cost 352 ms on a 25k-row history and 1704 ms on a 205k-row one (1591 ms
+    # of it `sys` — 64 KiB page reads); as a SEARCH, 2.8 ms and 1.9 ms.
+    #
+    # What makes the difference is ONE redundant conjunct: SQLite matches an
+    # expression index only against the same expression text, so
+    # `lower(dm_with) = ?` alone can never reach the folded index, which is on
+    # `lower(COALESCE(dm_with, channel))`. This test pins the seek, not the
+    # timing — the row-set is identical either way, which is exactly why the
+    # regression would otherwise be invisible to every other test here.
+    test "the dm_with UPDATE seeks the folded coalesce index (it must not SCAN)",
+         %{user: user, network: net} do
+      # Enough history that the planner has a real choice to get wrong: on a
+      # table of a handful of rows SQLite may pick a SCAN whatever the index.
+      for i <- 1..300 do
+        {:ok, _} =
+          Scrollback.persist_event(sample(user, net, 400 + i, %{channel: "#chan", sender: "someone", dm_with: nil}))
+      end
+
+      {:ok, _} =
+        Scrollback.persist_event(sample(user, net, 900, %{channel: "Guest87449", sender: "vjt", dm_with: "Guest87449"}))
+
+      queries = capture_queries(fn -> Scrollback.rename_dm_peer({:user, user.id}, net.id, "Guest87449", "Nuovo") end)
+
+      {sql, params} =
+        Enum.find(queries, fn {sql, _} -> String.starts_with?(sql, "UPDATE") and sql =~ ~s("dm_with" =) end) ||
+          flunk("no dm_with UPDATE captured; got:\n#{Enum.map_join(queries, "\n", &elem(&1, 0))}")
+
+      # The conjunct must reach the SQL byte-identically to the index's own
+      # expression — `Identifier.nick_fold_sql/1` is the single source both
+      # sides render from, and one byte of drift silently loses the index.
+      assert sql =~ Identifier.nick_fold_sql(~s|COALESCE(m0."dm_with", m0."channel")|),
+             "the dm_with UPDATE lost the coalesce-fold conjunct:\n#{sql}"
+
+      {:ok, %{rows: rows}} = Repo.query("EXPLAIN QUERY PLAN " <> sql, params)
+      plan = rows |> List.flatten() |> Enum.map_join("\n", &to_string/1)
+
+      assert plan =~ "messages_user_id_network_id_dm_coalesce_fold_id_kind_index",
+             "the dm_with UPDATE must run on the folded coalesce index:\n#{plan}"
+
+      # The seek term is the whole point: without `<expr>=?` the plan is the
+      # same index used as a SCAN behind `(user_id, network_id)` — which is
+      # the exact shape that cost 1704 ms in prod.
+      assert plan =~ "<expr>=?", "the dm_with UPDATE degraded to a prefix scan:\n#{plan}"
+      refute plan =~ "SCAN messages", "the dm_with UPDATE must not full-scan messages:\n#{plan}"
     end
 
     test "does NOT rename the own-nick inbound channel column", %{user: user, network: net} do


### PR DESCRIPTION
## What

`Scrollback.rename_dm_peer/4`'s `dm_with` UPDATE could not use the folded index, so it scanned the subject's whole message history while holding SQLite's single write lock. One redundant conjunct makes it a seek.

## Why it matters

The statement runs inside `Grappa.NickMigration.peer_renamed/5`'s `BEGIN IMMEDIATE`, once per session per peer NICK. A peer in a reconnect loop drives it on every bounce, and every other writer queues behind it for up to the 30s `busy_timeout`.

Found while investigating a prod episode on 2026-09-06: at 15:02 every client on the box dropped at once with `Read/Dead Error`. `Grappa.Repo.LockWatch` attributed the hold — `#PID<0.3903.0>` held RESERVED for 31.5s — and the same pid logged `query window followed peer NICK ... rows_migrated=116` 100ms after the release, which is what named this transaction.

## The defect

The only folded index on `messages` is `messages_{visitor,user}_id_network_id_dm_coalesce_fold_id_kind_index`, on `lower(COALESCE(dm_with, channel))`. The query rendered `lower(dm_with) = ?`. SQLite matches an expression index only against the *same expression text*, so the plan fell back to the `(subject, network_id)` prefix and scanned everything behind it:

```
SEARCH messages USING INDEX ..._dm_coalesce_fold_id_kind_index (visitor_id=? AND network_id=?)
```

## Measured

Raw copy of prod (2 GB, 2 883 784 rows, `page_size = 65536`, WAL, `synchronous = 1`), one peer rename inside `BEGIN IMMEDIATE`, `ROLLBACK` between runs:

| subject history | rows moved | `UPDATE dm_with` before | after | plan |
|---|---|---|---|---|
| 25 030 rows | 116 | 352 ms | **2.8 ms** | SCAN → SEARCH |
| 205 706 rows | 73 | 1704 ms | **1.9 ms** | SCAN → SEARCH |

The 1704 ms was 1591 ms of `sys` — 64 KiB page reads, not CPU.

## Why no migration

`lower(dm_with) = ?` already implies `lower(COALESCE(dm_with, channel)) = ?`: the fold can only match a non-null `dm_with`, and COALESCE returns it whenever it is non-null. The row-set is identical, so this is a query-side change only — existing deployments get the speedup on upgrade, with no schema change and no extra write amplification on the 9 indexes `messages` already carries.

## Why the `channel` arm is left alone

It already rides `messages_{visitor,user}_id_network_id_channel_id_kind_index` as a COVERING index (15-55 ms, no table lookup), and the coalesce fold is **not** implied there: a row with `dm_with` set and a divergent `channel` would be silently skipped. Prod has 7740 such rows.

## Not claimed

This does **not** explain the full 31.5s hold. The whole rename transaction measures under 2s warm, on the worst subject in prod. The plausible but **unmeasured** bridge is that same `sys` time: under real contention those page reads cost far more than on a warm copy. Stated here so nobody reads the fix as a closed root-cause.

## Test

A plan test on the statement production actually emits (captured from Ecto telemetry, so there is no second copy to drift). It asserts the conjunct reaches the SQL byte-identically to the index expression via `Identifier.nick_fold_sql/1`, and that the plan carries the `<expr>=?` seek term rather than degrading to a prefix scan. Verified to fail with the conjunct removed — the row-set is identical either way, which is why every other test in the file stays green through the regression.
