### PR TITLE
cic: lowercase the sidebar home label to match the rail (issue 1939)

### DIFF
--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -185,7 +185,7 @@ test.describe("BUGHUNT-2 cursor — forward-only contract", () => {
     // fires programmatic scrollIntoView. The input-event gate (B1)
     // must see no preceding pointerdown/wheel/touchmove/keydown and
     // SKIP arming the 500ms settle timer.
-    await page.getByRole("button", { name: "Home", exact: true }).click();
+    await page.getByRole("button", { name: "home", exact: true }).click();
     await page.waitForTimeout(200);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
     await page.waitForTimeout(SETTLE_WAIT_LONG_MS);

--- a/cicchetto/e2e/tests/issue160-virtual-tab-no-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue160-virtual-tab-no-cursor.spec.ts
@@ -82,7 +82,7 @@ test.describe("#160 virtual-tab read-cursor suppression", () => {
 
     // Select the Home tab — disposes the ScrollbackPane. Pre-fix, the
     // onCleanup POSTed a read-cursor for $home (404).
-    await page.getByRole("button", { name: "Home", exact: true }).click();
+    await page.getByRole("button", { name: "home", exact: true }).click();
     // Past the scroll-settle debounce (500ms) + POST round-trip slop.
     await page.waitForTimeout(1200);
 

--- a/cicchetto/e2e/tests/issue356-notify-highlight-feedback.spec.ts
+++ b/cicchetto/e2e/tests/issue356-notify-highlight-feedback.spec.ts
@@ -104,7 +104,7 @@ test("#356 — bare /notify and bare /hilight open the watch-lists section; home
   // Home no longer shows the standalone watched list (moved to settings).
   await page
     .locator(".sidebar-channel-name")
-    .filter({ hasText: /^Home$/ })
+    .filter({ hasText: /^home$/ })
     .click();
   await expect(page.locator(".watched-panel")).toHaveCount(0);
   await expect(page.getByTestId(`watched-panel-${NETWORK_SLUG}`)).toHaveCount(0);

--- a/cicchetto/e2e/tests/ux-5-b-home-emoji.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-b-home-emoji.spec.ts
@@ -56,10 +56,12 @@ test("ux-5-b — home sidebar row renders the 🏠 emoji icon", async ({ page })
   expect(box.height).toBeGreaterThan(0);
 
   // Belt-and-suspenders: the emoji span lives INSIDE the home button
-  // (sibling of the "Home" label span), not as a stray standalone
+  // (sibling of the "home" label span), not as a stray standalone
   // element. Catches a regression that moves the emoji outside the
   // button or that drops the .sidebar-home-btn parent.
   const homeBtn = page.locator(".sidebar-home-section .sidebar-home-btn");
   await expect(homeBtn.locator(".sidebar-home-emoji")).toHaveCount(1);
-  await expect(homeBtn).toContainText("Home");
+  // Lowercase since issue 1939 — `toContainText` is case-sensitive, so this
+  // also pins the label casing the sidebar shares with the rail.
+  await expect(homeBtn).toContainText("home");
 });

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -241,7 +241,7 @@ const Sidebar: Component<Props> = (props) => {
             <span class="sidebar-home-emoji" aria-hidden="true">
               🏠
             </span>
-            <span class="sidebar-channel-name">Home</span>
+            <span class="sidebar-channel-name">home</span>
           </button>
         </li>
       </ul>

--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -1117,9 +1117,13 @@ describe("Sidebar", () => {
       render(() => <Sidebar />);
       const current = screen.getAllByRole("button", { current: true });
       expect(current).toHaveLength(1);
-      // The home row's LABEL is "Home" (the `$home` slug is the routing key,
-      // never shown) — assert what a screen reader would read out.
-      expect(current[0]).toHaveTextContent("Home");
+      // The home row's LABEL is "home" (the `$home` slug is the routing key,
+      // never shown) — assert what a screen reader would read out. Lowercase
+      // since issue 1939: every other sidebar label (`admin`, `channels`,
+      // `mentions`) and the rail's own action for THIS window
+      // (RailActions.tsx `home`) already spell it that way. Case-sensitive
+      // on purpose — a title-cased regression must redden here.
+      expect(current[0]).toHaveTextContent("home");
     });
 
     it("current-ness follows the selection onto the network's server row", () => {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46428,3 +46428,73 @@ _Deploy: **COLD** on every substrate. Measured, not reasoned:
 `{:cold, [mix_deps: ["mix.lock"]]}` for `:jail`, `:linux` and `:docker` alike,
 and a dep's beams live outside the app ebin that `HotReload.reload_modified/0`
 walks._
+<!-- entry #1939 -->
+
+---
+
+## 2026-09-06 — #1939: the sidebar was the only place that title-cased a window label
+
+A user on #grappa reported that the desktop sidebar spells the home window
+`Home` while everything around it is lowercase. Measured in `cicchetto/src`
+before the change: `Sidebar.tsx` renders `Home`, `admin`, `channels` and
+`mentions`; `RailActions.tsx` renders `home`, `admin`, `rooms`, `mentions`,
+`player`, `radio`, `themes`, `archive`, `settings`, `refresh`, `denoise`,
+`mute`, `switch account`, `quit`, `actions`. So `Home` was not one convention
+among two — it was a single literal disagreeing with every sibling in its own
+component AND with the rail's spelling of the very same window.
+
+**The rule this settles: a window label rendered in cic chrome is lowercase,
+and when a window is reachable from more than one surface the surfaces spell
+it identically.** irssi's own window list is lowercase; the rail was already
+right; the sidebar was the outlier and moved.
+
+### `ScrollbackPane.tsx` keeps its `"Home"`, and it is not an exception
+
+The reported string appears a second time, in `ScrollbackPane.tsx`. It is
+NOT a label: it is a member of `SCROLL_KEYS`, the set matched against
+`KeyboardEvent.key` in the pane's keydown handler to decide whether a key
+press counts as an operator scroll for the settle-arm gate. `Home` there is
+the DOM key name of the Home key, next to `PageUp`, `End` and `ArrowUp`.
+Lowercasing it would silently stop the Home key from arming the gate. The
+general shape worth keeping: a capitalised string in a UI file is a label
+only if something renders it — follow it to its consumer before treating a
+casing convention as applying to it.
+
+### The four e2e assertions that moved with the label
+
+`cursor-forward-only`, `issue160-virtual-tab-no-cursor`,
+`issue356-notify-highlight-feedback` and `ux-5-b-home-emoji` each pin the
+rendered text, and all four matchers are case-sensitive
+(`getByRole(..., { exact: true })`, `hasText: /^Home$/`, `toContainText`), so
+they had to move in the same commit or go red on a label they themselves
+document. The two `getByRole("button", { name: "home", exact: true })` calls
+stay page-wide and stay unambiguous: the rail's home button also contains the
+text `home`, but it carries `aria-label="open home"`, and an `aria-label`
+takes precedence over element contents when the accessible name is computed,
+so it is not a second match. `gotoHome()` in `issue496-home-restyle` and
+`registration-wizard` was never affected — both click `.sidebar-home-btn`.
+
+### What was declined
+
+A test asserting "every static sidebar label is lowercase". It cannot be
+written without a hand-maintained enumeration of the static rows
+(`.sidebar-home-btn`, `.sidebar-admin-btn`, `.sidebar-list-row`,
+`.sidebar-mentions-row`), because the `.sidebar-channel-name` class that
+carries the labels ALSO carries data the convention does not govern —
+network slugs, channel names, query nicks. That enumeration is exactly the
+parallel structure that needs housekeeping and drifts, and it is heavier
+than the one-literal defect it would guard. The convention is recorded here
+instead; the existing per-row assertions are case-sensitive and each reddens
+on its own row.
+
+### What is NOT established here
+
+* **Nothing was seen and no e2e ran.** This slice had no browser and no e2e
+  lane. The four spec edits are typechecked (`tsc -p e2e/tsconfig.json`) and
+  argued from Playwright's documented matching semantics; they are not
+  executed here.
+* **Only the sidebar literal moved.** Prose in comments and test titles that
+  calls the window "Home" was left alone — it names the window, not the
+  label, and rewriting it across the tree buys nothing the reader needs.
+
+_Deploy: **HOT — `--cic` only.** Client-side; no server change._


### PR DESCRIPTION
Addresses issue 1939.

## What the defect was

The desktop sidebar spelled the home window `Home` while every label around it
is lowercase. Measured in `cicchetto/src` on the base commit:

- `Sidebar.tsx` — `Home`, `admin`, `channels`, `mentions`
- `RailActions.tsx` — `home`, `admin`, `rooms`, `mentions`, `player`, `radio`,
  `themes`, `archive`, `settings`, `refresh`, `denoise`, `mute`,
  `switch account`, `quit`, `actions`

So this was not two conventions meeting. One literal disagreed with its own
siblings **and** with the rail's spelling of the very same window. The rail is
the one that was right; the sidebar moved.

## `ScrollbackPane.tsx` was NOT touched — the measurement

The issue asked to establish whether `ScrollbackPane.tsx`'s `"Home"` is a
user-visible label or something internal. **It is internal.** Measured:

- `ScrollbackPane.tsx:206` — `const SCROLL_KEYS = new Set<string>([...])`,
  and `"Home"` is a member of that set, sitting between `"PageDown"` and
  `"End"`.
- `ScrollbackPane.tsx:3590` — the only consumer: `if (SCROLL_KEYS.has(e.key))`
  in the keydown handler.

`"Home"` there is the DOM name of the Home key (`KeyboardEvent.key`), not a
label. Lowercasing it would quietly stop that key from arming the
scroll-settle gate. Left alone, deliberately.

## e2e — grepped, and four specs moved

`git grep -n 'Home' -- cicchetto/e2e` (positive control on the same run:
`git grep -n 'sidebar-channel-name' -- cicchetto/e2e`, 12 hits, so the tool
was working). Four specs pin the rendered text with **case-sensitive**
matchers and are updated in the same commit:

| spec | matcher |
|---|---|
| `cursor-forward-only.spec.ts:188` | `getByRole("button", { name: "Home", exact: true })` |
| `issue160-virtual-tab-no-cursor.spec.ts:85` | same |
| `issue356-notify-highlight-feedback.spec.ts:107` | `hasText: /^Home$/` |
| `ux-5-b-home-emoji.spec.ts:64` | `toContainText("Home")` |

The two page-wide `getByRole(..., { name: "home", exact: true })` calls stay
unambiguous: the rail's home button also contains the text `home`
(`RailActions.tsx:370`), but it carries `aria-label="open home"`
(`RailActions.tsx:353`), and an `aria-label` wins the accessible-name
computation over element contents — so it is not a second match.
`gotoHome()` in `issue496-home-restyle` and `registration-wizard` was never
affected: both click `.sidebar-home-btn`.

Everything else matching `Home` under `cicchetto/e2e` is prose in comments and
test titles, plus `/Add to Home Screen/` in `issue259-install-hint` (an iOS
OS string, unrelated).

## Gates (rc read from a file, never from a pipe)

Run from the worktree, on the rebased head `7a12acc51`:

- `scripts/bun.sh run check` — **rc=0**, `5 stages ran, 0 failed`
  (lock drift / test location / biome / tsc src / tsc e2e)
- `scripts/bun.sh run test` — **rc=0**, `336 passed (336)` files,
  `6752 passed (6752)` tests
- `scripts/design-notes-gate.sh` — **rc=0**,
  `1 new entry heading(s), separator and marker present.`
  (run POST-commit; the pre-commit run is the empty green)
- `scripts/union-rebase.sh` — **rc=0**,
  `docs/DESIGN_NOTES.md: +70 -0 — contribution intact`

Baseline on the untouched worktree was identical (`336`/`6752`, both rc=0), so
the counts are attributable.

TDD: the vitest assertion was flipped first and measured RED —
`Expected element to have text content: home / Received: 🏠Home`, rc=1,
1 failed / 79 passed — then the label moved and it went GREEN, 80/80.

## What I declined to build

A test asserting "every static sidebar label is lowercase". It cannot be
written without a hand-maintained enumeration of the static rows
(`.sidebar-home-btn`, `.sidebar-admin-btn`, `.sidebar-list-row`,
`.sidebar-mentions-row`), because the `.sidebar-channel-name` class that
carries the labels **also** carries data the convention does not govern —
network slugs, channel names, query nicks. That enumeration is the
drift-prone parallel structure CLAUDE.md's design discipline warns about, and
it is heavier than the one-literal defect it would guard. The convention is
recorded in `DESIGN_NOTES` instead.

## What is NOT established

**No browser and no e2e run.** This slice had no e2e lane. The four spec edits
are typechecked (`tsc --noEmit -p e2e/tsconfig.json`, green) and argued from
Playwright's documented matching semantics — they are **not executed here**.

Known base reds inherited, not mine: `JoinSeedCostTest` on `ci`, and
`LockWatchTest` (intermittent).
