### PR TITLE
config(#1945): anchor the storage roots absolutely instead of at the BEAM's CWD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,27 +125,41 @@ POOL_SIZE=10
 # the release image both thread ${PORT} end to end.
 PORT=4000
 
+# The three storage roots below are COMMENTED OUT on purpose since #1945:
+# unset, each one now takes an ABSOLUTE default, and compose.yaml's own
+# `${VAR:-/app/…}` fallbacks put them exactly where this file used to name
+# them. Set one only to move it somewhere else, and set it ABSOLUTE when you
+# do — a relative value is resolved against the BEAM's working directory,
+# which the init system chooses, not you. It happens to be `/app` under
+# Docker; it is `/` under the FreeBSD jail's rc.d script, and that is how a
+# v1.5.0 cold deploy came to die of `eacces` before it could serve a request.
+# Prod logs a warning naming the directory if you set a relative one anyway.
+
 # UX-6-B1 (2026-05-20): embedded image uploader storage directory.
-# Defaults to `runtime/uploads` (sibling of the sqlite DB; covered by
-# the existing `./runtime:/app/runtime` bind-mount). Override only if
-# disk-policy requires a separate volume. Cap admin-tunes per-file +
-# global-disk ceilings live in `server_settings` table (admin REST).
-UPLOADS_STORAGE_ROOT=runtime/uploads
+# Defaults to the sibling of the sqlite DB — `Path.dirname(DATABASE_PATH)`
+# + `/uploads`, i.e. `/app/runtime/uploads` here, covered by the existing
+# `./runtime:/app/runtime` bind-mount. Override only if disk-policy requires
+# a separate volume. Cap admin-tunes per-file + global-disk ceilings live in
+# `server_settings` table (admin REST).
+# UPLOADS_STORAGE_ROOT=/app/runtime/uploads
 
 # M3b: cached PEER CTCP AVATAR images — a separate trust domain from
 # uploads (see `Grappa.Avatars` moduledoc), its own sibling directory
 # under the same bind-mount. Rows here self-expire (TTL'd cache, not a
 # permanent asset), so there's no admin-tunable cap knob to cross-ref.
-PEER_AVATARS_STORAGE_ROOT=runtime/peer_avatars
+# Same anchor as the uploads root: `/app/runtime/peer_avatars` here.
+# PEER_AVATARS_STORAGE_ROOT=/app/runtime/peer_avatars
 
 # #399: directory holding the built cicchetto SPA (index.html + assets/
 # + backgrounds/ + fonts/ + service-worker.js + manifest). The embedded
 # Phoenix web server serves it via Plug.Static + a SPA history-mode
 # fallback + the security-header plug, so a plain service start yields a
 # fully working instance — #485 dropped the nginx container and grappa
-# self-serves the frontend. Defaults to `runtime/cicchetto-dist` (the dir
-# every cic build writes). A packaged install points this at its data dir.
-CIC_DIST_ROOT=runtime/cicchetto-dist
+# self-serves the frontend. This one is CODE, not data, so it gets no
+# DATABASE_PATH anchor: unset, `config/config.exs`'s absolute expansion of
+# `runtime/cicchetto-dist` (the dir every cic build writes) stands. A
+# packaged install points this at its own data dir.
+# CIC_DIST_ROOT=/app/runtime/cicchetto-dist
 
 # NOTE (#228, 2026-07-14): the outbound v6 source-address pool is no
 # longer an env var. GRAPPA_OUTBOUND_V6_POOL was REMOVED — the rotation

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -205,8 +205,19 @@ RUN chmod 0755 /app/release-entrypoint.sh /app/gen-secrets.sh
 # (#862), and anything the operator supplies wins and is never overwritten.
 # PHX_HOST is the one exception: it cannot be invented, so a bare
 # `docker run` still RAISES in config/runtime.exs for that alone.
+#
+# PEER_AVATARS_STORAGE_ROOT is named here as of #1945, and it is a data
+# root like UPLOADS_STORAGE_ROOT above: unset, the cache used to land in
+# `/app/runtime/peer_avatars` — inside the container LAYER, outside this
+# image's only volume — so the documented `pull` + `up -d` upgrade threw it
+# away on every release. `config/runtime.exs` now derives exactly this path
+# from DATABASE_PATH when the var is absent, so the line is belt to that
+# braces; it is here because an operator reading `docker image inspect`
+# should see where the third root goes, next to the other two, rather than
+# having to know the derivation.
 ENV DATABASE_PATH=/data/grappa.db \
     UPLOADS_STORAGE_ROOT=/data/uploads \
+    PEER_AVATARS_STORAGE_ROOT=/data/peer_avatars \
     CIC_DIST_ROOT=/app/cicchetto-dist \
     GRAPPA_SUBSTRATE=docker \
     PORT=4000

--- a/base/deployment.yaml
+++ b/base/deployment.yaml
@@ -90,14 +90,18 @@ spec:
             - name: PHX_HOST
               value: ""
 
-            # Cached peer CTCP AVATAR images. Set here because the image does
-            # NOT bake it: `config/runtime.exs` defaults
-            # PEER_AVATARS_STORAGE_ROOT to the RELATIVE `runtime/peer_avatars`,
-            # which resolves against WORKDIR /app — i.e. the container's
-            # ephemeral layer, wiped on every pod recreate. It is only a cache
+            # Cached peer CTCP AVATAR images. This value is now REDUNDANT and
+            # kept for explicitness: since #1945 the image bakes
+            # PEER_AVATARS_STORAGE_ROOT=/data/peer_avatars, and even unset
+            # `config/runtime.exs` derives that same path from DATABASE_PATH
+            # (`/data/grappa.db` → `/data/peer_avatars`). It was written by
+            # hand here first, to dodge the RELATIVE `runtime/peer_avatars`
+            # default that resolved against WORKDIR /app — the container's
+            # ephemeral layer, wiped on every pod recreate. That hand-written
+            # value is literally what the derivation computes, which is how
+            # #1945 chose the anchor. It is only a cache
             # (`Grappa.Avatars.Reaper` mkdir_p's it at boot and the images
-            # re-fetch), so this is durability, not correctness; the alternative
-            # is re-downloading every peer avatar after each restart.
+            # re-fetch), so this was durability, not correctness.
             - name: PEER_AVATARS_STORAGE_ROOT
               value: /data/peer_avatars
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,9 +9,13 @@ config :grappa,
 # hash/version live-read both resolve against this ONE root, so the
 # embedded web server self-serves the frontend (a plain
 # `bin/grappa start` works without nginx). Base default is the
-# `runtime/cicchetto-dist` build anchor (dev inherits); `config/test.exs`
-# points at a committed fixture bundle; `config/runtime.exs` (prod) reads
-# `CIC_DIST_ROOT` so a packaged install (deb/rpm/Arch) can relocate it.
+# `runtime/cicchetto-dist` build anchor, EXPANDED ABSOLUTE against this
+# file's directory (dev inherits); `config/test.exs` points at a committed
+# fixture bundle; `config/runtime.exs` reads `CIC_DIST_ROOT` so a packaged
+# install (deb/rpm/Arch) can relocate it — and since #1945 it overrides this
+# value ONLY when that variable is set, because an unset root used to be
+# clobbered with a CWD-relative literal, which is strictly worse than the
+# absolute path on this line.
 # Read ONCE at boot into `:persistent_term` via `Grappa.Cic.Bundle.boot/1`.
 config :grappa, :cic_dist_root, Path.expand("../runtime/cicchetto-dist", __DIR__)
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -94,24 +94,83 @@ if phx_host do
   config :grappa, :http_host_aliases, http_host_aliases
 end
 
+# #1945 — every storage root this file derives resolves ABSOLUTELY, or it
+# is the operator's own path and says so out loud. NONE of them is left to
+# the BEAM's CWD.
+#
+# The CWD is not a value any operator sets or sees: it is whatever the init
+# system left the process in. The v1.5.0 cold deploy on the production jail
+# is what that cost — `rc.d/grappa` starts the release with
+# `su -m grappa -c '.../bin/grappa daemon'` and NO WorkingDirectory, so the
+# CWD is `/`, the unset PEER_AVATARS_STORAGE_ROOT default
+# `runtime/peer_avatars` resolved to `/runtime/peer_avatars`, and
+# `Grappa.Avatars.Reaper.init/1`'s `File.mkdir_p!` died of eacces INSIDE the
+# supervision tree. A boot crash, not a degraded feature.
+# `Grappa.Uploads.Reaper.init/1` carries the same bang and escaped only
+# because the jail's env file happens to set UPLOADS_STORAGE_ROOT.
+#
+# The second failure mode is quieter and worse: on the release image
+# `WORKDIR /app` is writable by the `grappa` user, so `mkdir_p!` SUCCEEDS
+# and the peer-avatar cache lands in the container LAYER, outside the
+# `/data` volume, where the documented `pull` + `up -d` upgrade discards it.
+# A crash at least tells you.
+#
+# So an UNSET root takes an absolute default (see each site below), and an
+# empty value counts as unset — `System.get_env(x) || default` used to keep
+# `""`, because the empty string is truthy, and `File.mkdir_p!("")` is not a
+# directory. A value the operator DID set is kept verbatim: a relative one
+# under Docker's `WORKDIR /app` is a working configuration `.env.example`
+# shipped for a year, and re-anchoring it would silently relocate an
+# existing uploads directory. In prod it earns a warning naming the CWD it
+# will be read against — same belt-and-braces posture as the captcha
+# warning further down — so the resolution stops being invisible.
+storage_root = fn var, value, default ->
+  case value do
+    unset when unset in [nil, ""] ->
+      default
+
+    root ->
+      if config_env() == :prod and Path.type(root) != :absolute do
+        require Logger
+
+        Logger.warning(
+          "#{var} is set to a RELATIVE path (#{inspect(root)}) — it resolves against the " <>
+            "BEAM's current working directory (#{File.cwd!()}), which the init system chooses, " <>
+            "not the operator. Set it to an absolute path."
+        )
+      end
+
+      root
+  end
+end
+
 # #399 / #485 — the built cicchetto SPA dist the embedded web server
 # self-serves (Plug.Static + SPA history-fallback) AND re-reads to
 # broadcast the refresh-banner hash (Grappa.Cic.Bundle). Stashed into
 # `:persistent_term` via Grappa.Cic.Bundle.boot/1 at app start (boot
 # time only — a change needs a BEAM restart, not a hot reload).
-# Defaults to the `runtime/cicchetto-dist` build anchor, resolved against
-# the BEAM's CWD (like UPLOADS_STORAGE_ROOT below). That relative default
-# is ONLY correct where the CWD is the repo root: Docker (WORKDIR /app,
-# and compose sets CIC_DIST_ROOT explicitly anyway) and native systemd
-# (WorkingDirectory=<repo>). The FreeBSD jail is the exception (#526) —
-# rc.d/grappa starts the release via `su -m grappa -c '.../bin/grappa
-# daemon'` and sets NO WorkingDirectory, so the CWD is NOT the repo root;
-# the jail MUST set an absolute CIC_DIST_ROOT in grappa.env (exactly like
-# it already does for DATABASE_PATH / UPLOADS_STORAGE_ROOT for the same
-# reason). Unset on the jail, the relative default missed the dist and
-# /admin/cic-bundle-changed returned 204 with no banner broadcast —
-# issue #526. A packaged install (deb/rpm/Arch) likewise sets
-# CIC_DIST_ROOT to an absolute data path.
+#
+# UNSET, this derives NOTHING and leaves `config/config.exs`'s
+# `Path.expand("../runtime/cicchetto-dist", __DIR__)` standing (#1945).
+# That is the whole no-clobber arm: the dist is CODE, not data, so it gets
+# no DATABASE_PATH anchor like the two roots below — a packaged install
+# puts it in /usr/share/grappa while the DB is in /var/lib/grappa — and it
+# does not need one, because the base config already computes an ABSOLUTE
+# path. What this block used to do was overwrite that absolute anchor with
+# the relative literal `runtime/cicchetto-dist`, in every env except :test,
+# making the effective default strictly worse than the one it replaced.
+# The build anchor is a BUILD-TIME expansion, so it is right exactly where
+# the release is built in place (the jail's `mix release --overwrite` in
+# /home/grappa/grappa, native systemd, Docker) and irrelevant elsewhere,
+# since every cross-built package sets CIC_DIST_ROOT explicitly.
+#
+# The FreeBSD jail is what made this concrete (#526) — rc.d/grappa starts
+# the release via `su -m grappa -c '.../bin/grappa daemon'` and sets NO
+# WorkingDirectory, so the CWD is NOT the repo root; unset, the relative
+# default missed the dist and /admin/cic-bundle-changed returned 204 with
+# no banner broadcast. An absolute CIC_DIST_ROOT in grappa.env is still the
+# explicit cure and still documented; it is no longer the only thing
+# between that deployment and a silent 404.
 #
 # Broadened from prod-only (its #399 origin) to every env EXCEPT :test so
 # the e2e harness serves the SPA too: #485 made the e2e nginx a DUMB proxy,
@@ -128,10 +187,15 @@ end
 # it here would clobber the fixture and SpaServingTest would serve an empty
 # dist (the 7-failure regression this exclusion prevents).
 if config_env() != :test do
-  cic_dist_root =
-    System.get_env("CIC_DIST_ROOT") || "runtime/cicchetto-dist"
-
-  config :grappa, :cic_dist_root, cic_dist_root
+  # `nil` default = "there is no default HERE" — config/config.exs owns it.
+  # The var name is written twice on purpose: the second read is the literal
+  # `test/grappa/config/env_registry_drift_test.exs` derives the registry
+  # from, so hiding it inside the closure would drop the var out of the
+  # registry and read as a dead knob in compose.yaml.
+  case storage_root.("CIC_DIST_ROOT", System.get_env("CIC_DIST_ROOT"), nil) do
+    nil -> :ok
+    cic_dist_root -> config :grappa, :cic_dist_root, cic_dist_root
+  end
 end
 
 if config_env() == :prod do
@@ -139,12 +203,55 @@ if config_env() == :prod do
     System.get_env("DATABASE_PATH") ||
       raise "environment variable DATABASE_PATH is missing"
 
+  # #1945 — the deployment's DATA root, and the anchor every storage default
+  # below hangs off: the directory the sqlite database lives in. It is the
+  # one absolute path prod already mandates, and it is what those defaults
+  # always MEANT — `runtime/uploads` was documented as "the sibling of the
+  # sqlite DB", which is exactly this, without borrowing the CWD to say it.
+  #
+  # Measured against every substrate that ships, the derived default equals
+  # the value already in force wherever the old one worked, and differs only
+  # where it was broken: compose.yaml (`/app/runtime/grappa_<env>.db` →
+  # `/app/runtime/uploads` + `/app/runtime/peer_avatars`, both byte-identical
+  # to its own `:-` fallbacks) and the release image (`/data/grappa.db` →
+  # `/data/uploads`, byte-identical to the ENV it bakes) are unmoved;
+  # `base/deployment.yaml` sets `/data/peer_avatars` BY HAND to dodge the
+  # ephemeral relative default, and that hand-written value is what this
+  # computes. Pinned by test/grappa/config/storage_roots_config_test.exs so
+  # a future divergence is a red gate, not a surprise on someone's volume.
+  #
+  # A relative DATABASE_PATH would make the anchor relative too, so it is
+  # refused rather than propagated: such a deployment is CWD-bound end to
+  # end (`Grappa.Repo.init/2` mkdir_p's this same dirname), and no shipped
+  # template writes one. This is the explanatory error the eacces was not.
+  data_root =
+    case Path.type(database_path) do
+      :absolute ->
+        Path.dirname(database_path)
+
+      _ ->
+        raise """
+        environment variable DATABASE_PATH is set to a RELATIVE path: #{inspect(database_path)}
+
+        It is resolved against the BEAM's current working directory
+        (#{File.cwd!()}), which the init system chooses — the FreeBSD rc.d
+        script starts the release with no `cd` at all — and it anchors the
+        uploads and peer-avatar directories as well as the database itself.
+
+        Set DATABASE_PATH to an absolute path (e.g. /var/lib/grappa/grappa.db).
+        """
+    end
+
   # UX-6-B1 (2026-05-20): embedded image uploader storage dir. Read
   # at boot, stashed in :persistent_term via Grappa.Uploads.boot/1.
-  # Defaults to `runtime/uploads` (the sibling of the sqlite DB) so
-  # the existing bind-mount covers it without a compose.yaml edit.
+  # Defaults to the sibling of the sqlite DB, so the existing bind-mount
+  # (or /data volume) covers it without a compose.yaml edit.
   uploads_storage_root =
-    System.get_env("UPLOADS_STORAGE_ROOT") || "runtime/uploads"
+    storage_root.(
+      "UPLOADS_STORAGE_ROOT",
+      System.get_env("UPLOADS_STORAGE_ROOT"),
+      Path.join(data_root, "uploads")
+    )
 
   config :grappa, :uploads_storage_root, uploads_storage_root
 
@@ -174,9 +281,15 @@ if config_env() == :prod do
   # M3b — cached peer CTCP AVATAR images. Read at boot, stashed in
   # :persistent_term via Grappa.Avatars.boot/1. Sibling of the uploads
   # dir, its own subdirectory (a separate trust domain — see
-  # `Grappa.Avatars` moduledoc).
+  # `Grappa.Avatars` moduledoc). THE #1945 root: this is the one no
+  # substrate set, so it is the one that ate the jail's boot and the
+  # release image's avatar cache.
   peer_avatars_storage_root =
-    System.get_env("PEER_AVATARS_STORAGE_ROOT") || "runtime/peer_avatars"
+    storage_root.(
+      "PEER_AVATARS_STORAGE_ROOT",
+      System.get_env("PEER_AVATARS_STORAGE_ROOT"),
+      Path.join(data_root, "peer_avatars")
+    )
 
   config :grappa, :peer_avatars_storage_root, peer_avatars_storage_root
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46577,3 +46577,129 @@ _Deploy: **COLD** on every substrate. Measured, not reasoned:
 (positive control: a `lib/` path returns `{:hot, []}`). Same class as #1938,
 and for the same reason — a dep's beams live outside the app ebin that
 `HotReload.reload_modified/0` walks._
+<!-- entry #1945 -->
+
+---
+
+## 2026-09-06 — #1945: storage roots stop being resolved against a CWD nobody chose
+
+The v1.5.0 cold deploy on the production jail did not start. `rc.d/grappa`
+launches the release with `su -m grappa -c '.../bin/grappa daemon'` and sets no
+WorkingDirectory, so the CWD is `/`; `PEER_AVATARS_STORAGE_ROOT` was unset, its
+default was the relative `runtime/peer_avatars`, and
+`Grappa.Avatars.Reaper.init/1`'s `File.mkdir_p!` therefore tried `/runtime/peer_avatars`
+and died of `eacces` inside the supervision tree. A boot crash, not a degraded
+feature. The host was unblocked by setting the variable by hand, which is a
+per-host workaround: any operator upgrading without it hits the same wall.
+
+### The defect is the CWD dependency, not the missing variable
+
+Three roots had the same shape — `:cic_dist_root`, `:uploads_storage_root`,
+`:peer_avatars_storage_root` — and `Grappa.Uploads.Reaper.init/1` carries the
+same bang as the avatar one. Uploads escaped only because the jail's env file
+happens to set its variable.
+
+The CWD is not a value an operator sets or sees: it is whatever the init system
+left the process in. So a default that reads it is a default nobody chose, and
+the three regimes it produces have nothing to do with each other — repo root
+under Docker's `WORKDIR /app` and native systemd's `WorkingDirectory=`, `/`
+under the jail, and the container's ephemeral layer under the release image.
+
+**The second failure mode is quieter and strictly worse.** Measured on
+`ghcr.io/vjt/grappa:latest`: the release image boots CLEAN, no `eacces`,
+`/healthz` 200 — because `/app` is owned by the `grappa` user, so `mkdir_p!`
+SUCCEEDS and the peer-avatar cache lands in `/app/runtime/peer_avatars`, inside
+the container layer and outside the only volume the image declares
+(`compose.release.yaml` mounts `grappa-data:/data`, and the image baked
+`DATABASE_PATH`, `UPLOADS_STORAGE_ROOT`, `CIC_DIST_ROOT` but not the fourth).
+The documented upgrade — `pull` then `up -d` — threw the cache away every
+release, silently. A crash at least tells you.
+
+### Two anchors, because the roots have two meanings
+
+One rule (nothing resolves against the CWD), two ways to honour it, and the
+split is the domain boundary rather than a compromise:
+
+* **DATA** — uploads and peer avatars now default to
+  `Path.join(Path.dirname(DATABASE_PATH), name)`. This is not a new convention:
+  `runtime/uploads` was already DOCUMENTED as "the sibling of the sqlite DB".
+  The old default only approximated that sentence by borrowing the CWD; the new
+  one computes it. `DATABASE_PATH` is the one absolute path prod already
+  mandates, which is what makes it the anchor.
+* **CODE** — the built SPA dist gets no data anchor (a packaged install puts it
+  in `/usr/share/grappa` while the DB is in `/var/lib/grappa`), and needs none:
+  `config/config.exs` already expands an ABSOLUTE build anchor, and the actual
+  defect there was `runtime.exs` **clobbering** it with a relative literal in
+  every env except `:test` — runtime config runs LAST. Unset now derives
+  nothing. On the jail, where `mix release --overwrite` runs in
+  `/home/grappa/grappa`, that build anchor expands to exactly the path #526
+  tells the operator to write by hand.
+
+**An operator-supplied value is kept verbatim, deliberately.** Re-anchoring a
+relative one would silently move an existing uploads directory
+(`/app/runtime/uploads` → `/app/runtime/runtime/uploads`), and a relative root
+under Docker is a WORKING configuration that `.env.example` shipped for a year.
+What changes is that prod now logs a warning naming the directory the value
+will be read against, so the resolution stops being invisible. Same
+belt-and-braces posture as the captcha warning in the same file.
+
+A relative `DATABASE_PATH` is refused outright, because the anchor cannot
+deliver an absolute root from one and such a deployment is CWD-bound end to end
+anyway (`Grappa.Repo.init/2` mkdir_p's the same dirname). That is a fourth key,
+touched knowingly: it is the anchor's precondition, and no shipped template
+writes a relative one.
+
+### What the measurement says that the issue text did not
+
+**The derived default equals the value already in force wherever the old one
+worked, and differs only where it was broken.** Not argued — pinned, in
+`test/grappa/config/storage_roots_config_test.exs`, by reading what each
+substrate declares and requiring the derivation to reproduce it:
+`compose.yaml`'s `${UPLOADS_STORAGE_ROOT:-/app/runtime/uploads}` and
+`${PEER_AVATARS_STORAGE_ROOT:-/app/runtime/peer_avatars}` against its own
+`/app/runtime/grappa_<env>.db`, and `Dockerfile.release`'s baked `/data/uploads`
+against `/data/grappa.db`. The compose half of that pin was GREEN before a line
+of the cure existed, which is the evidence for the claim. `base/deployment.yaml`
+is the third witness: it sets `/data/peer_avatars` BY HAND to dodge the
+ephemeral relative default, and that hand-written value is character-for-
+character what the derivation computes. Three hosts independently wrote the
+anchor the default should always have had.
+
+**Two corrections to the report this entry closes out.** (1) The issue proposes
+the DATABASE_PATH anchor "and apply the same treatment to all three roots" — the
+third root cannot take it, for the reason above, so the class is closed by two
+anchors rather than one. (2) The measured follow-up states that "the
+absolute-default fix alone is not enough" for the Docker path and that
+`PEER_AVATARS_STORAGE_ROOT` must be set in the image env AND in
+`compose.release.yaml` "next to the other two roots". Measured: the image bakes
+an absolute `DATABASE_PATH=/data/grappa.db`, so the derived default IS
+`/data/peer_avatars`, inside the volume — the anchor alone does close that path.
+And `compose.release.yaml` names no storage root at all; the other two are baked
+in the image, not composed. The image ENV line was added anyway, for parity and
+so `docker image inspect` shows the third root without the reader having to know
+the derivation; `compose.release.yaml` was deliberately left alone, since adding
+the only storage-root override to a file whose stated design is "the image
+bootstraps itself" would be the inconsistency, not the cure.
+
+An empty value now counts as unset. It did not before: `System.get_env(x) || default`
+keeps `""` because the empty string is truthy, so an empty variable configured an
+empty root and `File.mkdir_p!("")` is not a directory. The file's own comment
+claimed "Empty / unset = the CWD default"; only half of that was ever true.
+
+### What this does NOT claim
+
+Nothing here was measured on the jail — that host is unreachable from the
+worker, so the crash chain is read from the issue and from `rc.d/grappa`, never
+observed. The release-image behaviour is likewise the reporter's measurement,
+re-derived here only from the files (`Dockerfile.release`, `compose.release.yaml`,
+`infra/docker/release-entrypoint.sh`), not from a container that was run. And
+the warning path is pinned as "a warning naming the variable is emitted", not as
+"an operator will see it in a release boot log", which depends on the handler
+state at `runtime.exs` evaluation time and was not tested.
+
+_Deploy: **COLD** on every substrate. Measured, not reasoned:
+`Preflight.classify_paths(<the changed set>, s)` returns
+`{:cold, [config: ["config/runtime.exs", "config/config.exs"]]}` for `:jail`,
+`:linux` and `:docker` alike (positive control: the `lib/` comment-only paths
+alone return `{:hot, []}`). The release image also has to be REBUILT for the
+baked ENV to move — the config change alone does not reach it._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1961,6 +1961,54 @@ D** — see **Running the published image** below.
   with the degraded credit roll, which is correct for a source build and is
   what the smoke script's probe 5 will (rightly) fail on.
 
+### UPGRADE NOTE — v1.5.0 lost the peer-avatar cache on every Docker update (#1945)
+
+**Who this is for: anyone who ran `v1.5.0` on Docker.** Exactly that release —
+measured, the peer-avatar cache first shipped in it (`Grappa.Avatars.Reaper`
+was added 2026-08-29 and `v1.5.0` is the first tag containing it), so no
+earlier version had a cache to lose. Nothing to do if you are upgrading from
+`v1.4.x` or below straight past it.
+
+**What happened.** `config/runtime.exs` defaulted `PEER_AVATARS_STORAGE_ROOT`
+to the RELATIVE `runtime/peer_avatars`, and the image bakes neither that
+variable nor a `WORKDIR` outside `/app`. So the cache resolved to
+`/app/runtime/peer_avatars` — the container's own layer, **outside the only
+volume the image declares** (`compose.release.yaml` mounts `grappa-data:/data`,
+and `Dockerfile.release` bakes `DATABASE_PATH=/data/grappa.db` +
+`UPLOADS_STORAGE_ROOT=/data/uploads`, never the third root). The documented
+update procedure is `pull` then `up -d`, which RECREATES the container, and a
+recreate discards the layer. Every Docker update since `v1.5.0` therefore threw
+the cache away, silently: no error, no log line, nothing in `/healthz`.
+
+Note the asymmetry with the FreeBSD jail, where the same default did not lose
+data — it prevented the node from booting at all (`/runtime/peer_avatars`,
+`eacces`, `Avatars.Reaper.init/1`). Docker's `/app` is writable by the `grappa`
+user, so the same defect took the quiet branch. A crash at least tells you.
+
+**Blast radius: a cache, not state.** `peer_avatars` rows are TTL'd and the
+images re-fetch over CTCP AVATAR as peers are seen again; there is no
+soft-delete or public-URL contract to strand (see the `Grappa.Avatars`
+moduledoc). Nothing else lived there. So the loss is bandwidth and a cold
+cache, not lost user data — but it was real, and it repeated on every update.
+
+**What to do: nothing, on the next update.** From this release the root
+defaults to the sibling of the sqlite database
+(`Path.dirname(DATABASE_PATH)` + `/peer_avatars` = `/data/peer_avatars` on the
+image), and the image bakes that path explicitly as well. Both put it on the
+`grappa-data` volume, where a recreate cannot reach it. If you had set
+`PEER_AVATARS_STORAGE_ROOT` yourself it is still honoured verbatim — check it
+points under `/data` if you want it to survive, and make it ABSOLUTE: a
+relative value is read against the BEAM's working directory, which the init
+system chooses, and prod now logs a warning naming that directory when you set
+one.
+
+The stale `/app/runtime/peer_avatars` inside a running `v1.5.0` container is
+already unreachable-in-practice; it disappears with the container on the next
+recreate and needs no cleanup.
+
+`CIC_DIST_ROOT=/app/cicchetto-dist` is deliberately NOT on the volume and is
+correct as it stands: it is build output shipped inside the image, not state.
+
 ### Running the published image (`docker run` / `curl | bash`) — #503 unit D
 
 A checkout-less host runs the release image above with plain `docker` — no

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1622,13 +1622,19 @@ hash baked into the page the browser loaded. Server deploys never
 auto-trigger a cic refresh.
 
 **`CIC_DIST_ROOT` must be set absolute on the jail (issue #526).** The
-BEAM reads the built `index.html` from `CIC_DIST_ROOT` (default
-`runtime/cicchetto-dist`, repo-root-relative) to compute the broadcast
-hash. That relative default only works where the process CWD is the repo
-root — true under Docker (`WORKDIR /app`) and native systemd
+BEAM reads the built `index.html` from `CIC_DIST_ROOT` to compute the
+broadcast hash. Until #1945 the default was the repo-root-RELATIVE
+`runtime/cicchetto-dist`, which only works where the process CWD is the
+repo root — true under Docker (`WORKDIR /app`) and native systemd
 (`WorkingDirectory=<repo>`), but NOT the jail: `rc.d/grappa` starts the
 release with `su -m grappa -c '.../bin/grappa daemon'` and sets no
-WorkingDirectory. So `grappa.env` MUST carry
+WorkingDirectory. Since #1945 an unset `CIC_DIST_ROOT` no longer overrides
+`config/config.exs`'s ABSOLUTE build anchor, which on the jail — where
+`mix release --overwrite` runs in `/home/grappa/grappa` — expands to
+exactly the path below. Setting it explicitly is still the documented
+posture and still the only correct answer for a cross-built package, but
+it is no longer the only thing between this deployment and a silent 404.
+So `grappa.env` SHOULD carry
 `CIC_DIST_ROOT=/home/grappa/grappa/runtime/cicchetto-dist` (absolute,
 alongside `DATABASE_PATH` / `UPLOADS_STORAGE_ROOT` for the same reason);
 unset, `/admin/cic-bundle-changed` returns **204** and no banner is ever

--- a/infra/docker/release-entrypoint.sh
+++ b/infra/docker/release-entrypoint.sh
@@ -26,12 +26,19 @@ GRAPPA_MAX_PROCS=$((GRAPPA_MAX_USERS * 100))
 ERL_ZFLAGS="${ERL_ZFLAGS:+$ERL_ZFLAGS }+Q ${GRAPPA_MAX_PORTS} +P ${GRAPPA_MAX_PROCS} +SDcpu ${GRAPPA_DIRTY_SCHEDULERS} +SDio ${GRAPPA_DIRTY_SCHEDULERS}"
 export ERL_ZFLAGS
 
-# The sqlite DB parent + the uploads dir must exist and be writable before boot
-# — exqlite opens but does NOT create the parent dir. A root-owned bind mount
-# is the operator's to chown; failing loud here beats a cryptic "unable to open
-# database file" at first write.
+# The sqlite DB parent + the two data roots must exist and be writable before
+# boot — exqlite opens but does NOT create the parent dir. A root-owned bind
+# mount is the operator's to chown; failing loud here beats a cryptic "unable
+# to open database file" at first write.
+#
+# The peer-avatar root joined this list with #1945: its fallback mirrors the
+# one config/runtime.exs derives (the sibling of the database), so the shell
+# and the BEAM cannot disagree about where the third root is when the var is
+# unset.
 data_dir="$(dirname "${DATABASE_PATH:-/data/grappa.db}")"
-mkdir -p "$data_dir" "${UPLOADS_STORAGE_ROOT:-/data/uploads}"
+mkdir -p "$data_dir" \
+    "${UPLOADS_STORAGE_ROOT:-/data/uploads}" \
+    "${PEER_AVATARS_STORAGE_ROOT:-$data_dir/peer_avatars}"
 
 # ── First-boot secret bootstrap (#862) ──────────────────────────────────────
 #

--- a/lib/grappa/avatars/reaper.ex
+++ b/lib/grappa/avatars/reaper.ex
@@ -76,6 +76,12 @@ defmodule Grappa.Avatars.Reaper do
   def init(opts) do
     interval = Keyword.get(opts, :interval_ms, @default_interval_ms)
     storage_root = Keyword.fetch!(opts, :storage_root)
+    # The bang is deliberate: an unwritable cache root is a misconfigured
+    # deployment, and this runs inside the supervision tree, so it takes the
+    # boot down rather than serve an instance that cannot cache. That is only
+    # a sound trade while the root is ABSOLUTE — `config/runtime.exs` used to
+    # hand us a CWD-relative default, and on the jail (CWD `/`) this exact
+    # line is what killed the v1.5.0 cold deploy with eacces (#1945).
     :ok = File.mkdir_p!(storage_root)
 
     schedule_tick(interval)

--- a/lib/grappa/uploads/reaper.ex
+++ b/lib/grappa/uploads/reaper.ex
@@ -22,13 +22,18 @@ defmodule Grappa.Uploads.Reaper do
   ## Storage root
 
   The on-disk directory is `:storage_root` passed via start opts.
-  Production callers pass `runtime/uploads` (set in the application
-  supervisor); tests inject a per-test temp dir + clean it via
-  `on_exit/1`.
+  Production callers pass `:uploads_storage_root` (set in the application
+  supervisor), which `config/runtime.exs` resolves to an ABSOLUTE path —
+  the sibling of the sqlite database unless `UPLOADS_STORAGE_ROOT` says
+  otherwise; tests inject a per-test temp dir + clean it via `on_exit/1`.
 
-  The Reaper performs `File.mkdir_p/1` on `storage_root` in
+  The Reaper performs `File.mkdir_p!/1` on `storage_root` in
   `init/1` so a fresh deploy doesn't need a separate bootstrap
   step — same module owns both the read + write of the directory.
+  The bang is deliberate and load-bearing: an unwritable root is a
+  misconfigured deployment, not a degraded feature. It is also why a
+  CWD-relative default was a BOOT CRASH rather than a missing image
+  (#1945) — the root must be absolute for that trade to be sound.
 
   ## AdminEvents
 

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -99,7 +99,7 @@ if [ "$SRC_ROOT" != "$REPO_ROOT" ]; then
         -v "$SRC_ROOT/.formatter.exs:/app/.formatter.exs:ro"
         -v "$SRC_ROOT/.credo.exs:/app/.credo.exs:ro"
         -v "$SRC_ROOT/.sobelow-conf:/app/.sobelow-conf:ro"
-        # The next four mounts are all DRIFT-PIN inputs: root-level files a
+        # The next five mounts are all DRIFT-PIN inputs: root-level files a
         # test reads to assert doc-matches-reality. Without an override a
         # worktree run reads MAIN's copy and the fix can never go GREEN
         # before merge. RO — the tests only read them.
@@ -108,6 +108,10 @@ if [ "$SRC_ROOT" != "$REPO_ROOT" ]; then
         #   compose.yaml + .env.example → env_registry_drift_test.exs (#369 X1)
         -v "$SRC_ROOT/compose.yaml:/app/compose.yaml:ro"
         -v "$SRC_ROOT/.env.example:/app/.env.example:ro"
+        #   Dockerfile.release → storage_roots_config_test.exs (#1945). Measured
+        #   the hard way: the pin read MAIN's copy and stayed RED against a
+        #   worktree that had already added the missing ENV line.
+        -v "$SRC_ROOT/Dockerfile.release:/app/Dockerfile.release:ro"
         #   bin/         → operator_help_drift_test.exs (#1086)
         -v "$SRC_ROOT/bin:/app/bin:ro"
         #   cicchetto/e2e/ → keepalive_idle_ordering_test.exs (#1030). The

--- a/test/grappa/config/cic_dist_root_config_test.exs
+++ b/test/grappa/config/cic_dist_root_config_test.exs
@@ -46,10 +46,17 @@ defmodule Grappa.Config.CicDistRootConfigTest do
     assert cic_dist_root(:dev) == "/app/cicchetto-dist"
   end
 
-  test "unset CIC_DIST_ROOT falls back to the CWD default under MIX_ENV=dev" do
+  test "unset CIC_DIST_ROOT derives nothing — config/config.exs keeps the root" do
+    # This assertion used to read `== "runtime/cicchetto-dist"`, and that
+    # relative literal was the #1945 defect: runtime.exs runs LAST, so it
+    # CLOBBERED the absolute build anchor `config/config.exs` computes with
+    # a path resolved against the BEAM's CWD — whatever the init system left
+    # us in. Unset now means "no opinion here"; the base config's absolute
+    # value stands, and `Grappa.Config.StorageRootsConfigTest` pins the
+    # composed result the two files produce together.
     System.delete_env("CIC_DIST_ROOT")
 
-    assert cic_dist_root(:dev) == "runtime/cicchetto-dist"
+    assert cic_dist_root(:dev) == nil
   end
 
   test "MIX_ENV=test is left to config/test.exs — runtime.exs must NOT set it" do

--- a/test/grappa/config/storage_roots_config_test.exs
+++ b/test/grappa/config/storage_roots_config_test.exs
@@ -1,0 +1,279 @@
+defmodule Grappa.Config.StorageRootsConfigTest do
+  @moduledoc """
+  #1945 — no storage root `config/runtime.exs` derives may be resolved
+  against the BEAM's CWD.
+
+  The CWD is not a value any operator sets or sees: it is whatever the init
+  system left the process in. The v1.5.0 cold deploy on the production jail
+  is what that cost — `rc.d/grappa` starts the release with
+  `su -m grappa -c '.../bin/grappa daemon'` and no WorkingDirectory, so the
+  CWD is `/`, the unset `PEER_AVATARS_STORAGE_ROOT` default
+  `runtime/peer_avatars` resolved to `/runtime/peer_avatars`, and
+  `Grappa.Avatars.Reaper.init/1`'s `File.mkdir_p!` died of `eacces` inside
+  the supervision tree. That is a boot crash, not a degraded feature, and
+  `Grappa.Uploads.Reaper.init/1` carries the same bang.
+
+  It is a CLASS, not a key: `:uploads_storage_root`,
+  `:peer_avatars_storage_root` and `:cic_dist_root` all defaulted to a
+  CWD-relative literal. The second failure mode is quieter and worse — on
+  the release image `WORKDIR /app` is writable, so `mkdir_p!` SUCCEEDS and
+  the peer-avatar cache lands in the container layer, outside the `/data`
+  volume, where the documented `pull` + `up -d` upgrade throws it away.
+
+  The cure has one rule and two anchors, because the roots have two
+  meanings:
+
+    * DATA (uploads, peer avatars) hangs off `Path.dirname(DATABASE_PATH)`
+      — the one absolute path prod already mandates, and exactly what
+      "sibling of the sqlite DB" always meant.
+    * CODE (the built SPA dist) has no data anchor, so an unset
+      `CIC_DIST_ROOT` simply stops CLOBBERING the absolute build anchor
+      `config/config.exs` already computes.
+
+  An operator-supplied value is honored verbatim in both cases —
+  re-anchoring a relative one would silently relocate an existing uploads
+  directory — but a relative one earns a warning in prod naming the CWD it
+  will be read against.
+
+  The last two tests are drift pins rather than unit assertions: they read
+  what each shipping substrate ALREADY declares and require the derivation
+  to reproduce it, so "the new default equals the value already in force"
+  is a gate rather than a claim in a commit message.
+
+  `async: false` — mutates the process-global OS env via `System.put_env`.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  @config_exs Path.expand("../../../config/config.exs", __DIR__)
+  @runtime_exs Path.expand("../../../config/runtime.exs", __DIR__)
+  @dockerfile_release Path.expand("../../../Dockerfile.release", __DIR__)
+  @compose Path.expand("../../../compose.yaml", __DIR__)
+
+  # The prod block raises on every missing secret, so a `Config.Reader` read
+  # needs the full mandatory set. Values are shaped only as far as the file
+  # inspects them (same set as `Grappa.RepoWalCheckpointTest`), MINUS
+  # DATABASE_PATH: this suite varies that one.
+  @prod_secrets %{
+    "PHX_HOST" => "grappa.example.test",
+    "SECRET_KEY_BASE" => String.duplicate("s", 64),
+    "RELEASE_COOKIE" => String.duplicate("c", 64),
+    "SECRET_SIGNING_SALT" => String.duplicate("t", 32),
+    "GRAPPA_ENCRYPTION_KEY" => Base.encode64(String.duplicate("k", 32)),
+    "VAPID_PUBLIC_KEY" => String.duplicate("p", 87),
+    "VAPID_PRIVATE_KEY" => String.duplicate("q", 43)
+  }
+
+  @root_vars ["UPLOADS_STORAGE_ROOT", "PEER_AVATARS_STORAGE_ROOT", "CIC_DIST_ROOT"]
+
+  # An absolute DATABASE_PATH in the packaged-install shape. Nothing writes
+  # here — `Config.Reader` only builds the keyword list.
+  @database_path "/var/lib/grappa/grappa.db"
+
+  @root_keys [:uploads_storage_root, :peer_avatars_storage_root, :cic_dist_root]
+
+  # Run `fun` with EXACTLY `overrides` on top of the mandatory secrets: every
+  # root var absent from `overrides` is DELETED, never inherited. The test
+  # container's own environment sets all three (compose.yaml forwards them),
+  # so an unset-default assertion that skipped this would be reading the
+  # container instead of the file.
+  defp with_env(overrides, fun) do
+    desired = Map.merge(@prod_secrets, overrides)
+    names = Enum.uniq(["DATABASE_PATH" | @root_vars] ++ Map.keys(desired))
+    previous = Map.new(names, &{&1, System.get_env(&1)})
+
+    Enum.each(names, fn name ->
+      case Map.fetch(desired, name) do
+        {:ok, value} -> System.put_env(name, value)
+        :error -> System.delete_env(name)
+      end
+    end)
+
+    try do
+      fun.()
+    after
+      Enum.each(previous, fn
+        {name, nil} -> System.delete_env(name)
+        {name, value} -> System.put_env(name, value)
+      end)
+    end
+  end
+
+  # `:grappa`'s config as a prod boot assembles it: the compile-time layer
+  # (`config/config.exs`, which a release bakes) with the runtime layer on
+  # top. Reading runtime.exs ALONE would miss the base `:cic_dist_root` the
+  # no-clobber arm exists to preserve.
+  defp prod_grappa(overrides) do
+    with_env(overrides, fn ->
+      @config_exs
+      |> Config.Reader.read!(env: :prod)
+      |> Config.Reader.merge(Config.Reader.read!(@runtime_exs, env: :prod))
+      |> Keyword.fetch!(:grappa)
+    end)
+  end
+
+  defp baked_cic_dist_root do
+    @config_exs
+    |> Config.Reader.read!(env: :prod)
+    |> get_in([:grappa, :cic_dist_root])
+  end
+
+  # First capture group, or nil. Every caller asserts non-nil BEFORE
+  # comparing: a regex that stopped matching must fail as a broken pin, not
+  # pass as an agreement between two nils.
+  defp capture(regex, text) do
+    case Regex.run(regex, text, capture: :all_but_first) do
+      [value] -> value
+      nil -> nil
+    end
+  end
+
+  describe "absolute by construction — nothing resolves against the CWD" do
+    test "every prod storage root is absolute when the operator sets none" do
+      grappa = prod_grappa(%{"DATABASE_PATH" => @database_path})
+
+      for key <- @root_keys do
+        root = Keyword.fetch!(grappa, key)
+
+        assert Path.type(root) == :absolute,
+               "#{key} defaulted to #{inspect(root)} — a relative root is read against " <>
+                 "the BEAM's CWD, which the init system chooses"
+      end
+    end
+
+    test "the two DATA roots default to siblings of the sqlite database" do
+      # Not a new convention: `runtime/uploads` was already DOCUMENTED as
+      # "the sibling of the sqlite DB". This computes what that sentence
+      # says instead of borrowing the CWD to approximate it.
+      grappa = prod_grappa(%{"DATABASE_PATH" => @database_path})
+
+      assert Keyword.fetch!(grappa, :uploads_storage_root) == "/var/lib/grappa/uploads"
+      assert Keyword.fetch!(grappa, :peer_avatars_storage_root) == "/var/lib/grappa/peer_avatars"
+    end
+
+    test "an unset CIC_DIST_ROOT leaves config.exs's absolute build anchor untouched" do
+      # The dist is CODE, not data — packaged installs put it in
+      # /usr/share/grappa while the DB is in /var/lib/grappa — so it gets no
+      # DATABASE_PATH anchor. It does not need one: config/config.exs
+      # already expands an absolute build anchor, and the defect was
+      # runtime.exs OVERWRITING it with a relative literal, in every env
+      # except :test.
+      baked = baked_cic_dist_root()
+
+      # Positive control: the thing being preserved must itself be absolute.
+      assert Path.type(baked) == :absolute
+
+      grappa = prod_grappa(%{"DATABASE_PATH" => @database_path})
+      assert Keyword.fetch!(grappa, :cic_dist_root) == baked
+    end
+
+    test "an EMPTY value is treated as unset, never as an empty root" do
+      # `System.get_env("X") || default` keeps "" — the empty string is
+      # truthy in Elixir — so an empty var used to configure an empty root,
+      # and `File.mkdir_p!("")` is not a directory. The file's own comment
+      # claimed "Empty / unset = the CWD default"; only half of that was
+      # true.
+      grappa =
+        prod_grappa(%{
+          "DATABASE_PATH" => @database_path,
+          "UPLOADS_STORAGE_ROOT" => "",
+          "PEER_AVATARS_STORAGE_ROOT" => "",
+          "CIC_DIST_ROOT" => ""
+        })
+
+      assert Keyword.fetch!(grappa, :uploads_storage_root) == "/var/lib/grappa/uploads"
+      assert Keyword.fetch!(grappa, :peer_avatars_storage_root) == "/var/lib/grappa/peer_avatars"
+      assert Keyword.fetch!(grappa, :cic_dist_root) == baked_cic_dist_root()
+    end
+  end
+
+  describe "operator-supplied roots" do
+    test "an absolute root is honored verbatim" do
+      grappa =
+        prod_grappa(%{
+          "DATABASE_PATH" => @database_path,
+          "UPLOADS_STORAGE_ROOT" => "/srv/uploads",
+          "PEER_AVATARS_STORAGE_ROOT" => "/srv/avatars",
+          "CIC_DIST_ROOT" => "/usr/share/grappa/cicchetto-dist"
+        })
+
+      assert Keyword.fetch!(grappa, :uploads_storage_root) == "/srv/uploads"
+      assert Keyword.fetch!(grappa, :peer_avatars_storage_root) == "/srv/avatars"
+      assert Keyword.fetch!(grappa, :cic_dist_root) == "/usr/share/grappa/cicchetto-dist"
+    end
+
+    test "a relative root is kept verbatim and warns, naming the variable" do
+      # Deliberately NOT re-anchored: `runtime/uploads` under Docker's
+      # `WORKDIR /app` is a WORKING configuration that .env.example shipped
+      # for a year, and joining it to the data root would silently move an
+      # existing uploads directory to /app/runtime/runtime/uploads. The
+      # value stands; what changes is that the CWD resolution stops being
+      # invisible.
+      log =
+        capture_log(fn ->
+          grappa =
+            prod_grappa(%{
+              "DATABASE_PATH" => @database_path,
+              "UPLOADS_STORAGE_ROOT" => "runtime/uploads"
+            })
+
+          assert Keyword.fetch!(grappa, :uploads_storage_root) == "runtime/uploads"
+        end)
+
+      assert log =~ "UPLOADS_STORAGE_ROOT"
+    end
+  end
+
+  describe "the anchor's precondition" do
+    test "a RELATIVE DATABASE_PATH is refused with a message naming it" do
+      # The anchor cannot deliver an absolute root from a relative DB path,
+      # and a deployment with one is CWD-bound anyway (`Grappa.Repo.init/2`
+      # mkdir_p's its parent). Refusing here is the explanatory error the
+      # eacces never was. No shipped template writes a relative one.
+      assert_raise RuntimeError, ~r/DATABASE_PATH/, fn ->
+        prod_grappa(%{"DATABASE_PATH" => "runtime/grappa_prod.db"})
+      end
+    end
+  end
+
+  describe "substrate drift pins — the derivation must reproduce what ships" do
+    test "the release image: each baked root is what the derivation computes" do
+      dockerfile = File.read!(@dockerfile_release)
+
+      database_path = capture(~r/ENV DATABASE_PATH=(\S+)/, dockerfile)
+      uploads = capture(~r/UPLOADS_STORAGE_ROOT=(\S+)/, dockerfile)
+      avatars = capture(~r/PEER_AVATARS_STORAGE_ROOT=(\S+)/, dockerfile)
+
+      # Positive control on the extraction itself.
+      assert database_path, "Dockerfile.release no longer bakes ENV DATABASE_PATH"
+      assert uploads, "Dockerfile.release no longer bakes UPLOADS_STORAGE_ROOT"
+
+      # The peer-avatar root is the #1945 data-loss leg: unset, the cache
+      # landed in the container layer and every `pull` + `up -d` discarded
+      # it. The image must name it, next to the other two.
+      assert avatars, "Dockerfile.release does not bake PEER_AVATARS_STORAGE_ROOT"
+
+      data_root = Path.dirname(database_path)
+      assert Path.join(data_root, "uploads") == uploads
+      assert Path.join(data_root, "peer_avatars") == avatars
+    end
+
+    test "the dev compose stack: each fallback is what the derivation computes" do
+      compose = File.read!(@compose)
+
+      database_path = capture(~r/DATABASE_PATH: (\S+)/, compose)
+      uploads = capture(~r/UPLOADS_STORAGE_ROOT:-([^}]+)\}/, compose)
+      avatars = capture(~r/PEER_AVATARS_STORAGE_ROOT:-([^}]+)\}/, compose)
+
+      assert database_path, "compose.yaml no longer sets DATABASE_PATH"
+      assert uploads, "compose.yaml no longer defaults UPLOADS_STORAGE_ROOT"
+      assert avatars, "compose.yaml no longer defaults PEER_AVATARS_STORAGE_ROOT"
+
+      # `${MIX_ENV:-dev}` sits in the BASENAME, so the data root is literal.
+      data_root = Path.dirname(database_path)
+      assert Path.join(data_root, "uploads") == uploads
+      assert Path.join(data_root, "peer_avatars") == avatars
+    end
+  end
+end


### PR DESCRIPTION
Addresses issue 1945.

## The defect

The v1.5.0 cold deploy on the production jail never started. `rc.d/grappa`
launches the release with `su -m grappa -c '.../bin/grappa daemon'` and sets no
WorkingDirectory, so the CWD is `/`; `PEER_AVATARS_STORAGE_ROOT` was unset, its
default was the relative `runtime/peer_avatars`, and
`Grappa.Avatars.Reaper.init/1`'s `File.mkdir_p!` therefore tried
`/runtime/peer_avatars` and died of `eacces` inside the supervision tree.

The root cause is the CWD dependency, not the missing variable. The CWD is
whatever the init system left the process in — not a value an operator sets or
sees — so a default that reads it is a default nobody chose. Three roots had
that shape (`:cic_dist_root`, `:uploads_storage_root`,
`:peer_avatars_storage_root`), and `Grappa.Uploads.Reaper` carries the same bang
as the avatar one; it escaped only because the jail's env file happens to set
its variable.

## Design — mine, and it departs from the issue text in two places

**Two anchors, not one**, because the roots have two meanings:

* **DATA** (uploads, peer avatars) defaults to
  `Path.join(Path.dirname(DATABASE_PATH), name)`. Not a new convention:
  `runtime/uploads` was already documented as *"the sibling of the sqlite DB"*.
  The old default only approximated that sentence by borrowing the CWD; this
  computes it. `DATABASE_PATH` is the one absolute path prod already mandates,
  which is what makes it the anchor.
* **CODE** (the SPA dist) gets no data anchor — a packaged install puts it in
  `/usr/share/grappa` while the DB is in `/var/lib/grappa` — and needs none:
  `config/config.exs` already expands an **absolute** build anchor, and the
  actual defect there was `runtime.exs` **clobbering** it with a relative
  literal in every env except `:test`, since runtime config runs last. Unset now
  derives nothing.

So the issue's "apply the same treatment to all three roots" is answered by two
treatments, one rule: nothing resolves against the CWD.

**An operator-supplied value stays verbatim.** Re-anchoring a relative one would
silently move an existing uploads directory to `/app/runtime/runtime/uploads`,
and a relative root under Docker's `WORKDIR /app` is a *working* configuration
that `.env.example` shipped for a year. Prod logs a warning naming the directory
the value will be read against instead — same belt-and-braces posture as the
captcha warning in the same file.

**A relative `DATABASE_PATH` is refused** with an explanatory message. This is a
fourth key, touched knowingly: the anchor cannot produce an absolute root from a
relative DB path, and such a deployment is CWD-bound end to end anyway
(`Repo.init/2` mkdir_p's the same dirname). Measured: no shipped template writes
a relative one.

**An empty value now counts as unset.** It did not before — `System.get_env(x) || default`
keeps `""` because the empty string is truthy, so an empty variable configured an
empty root and `File.mkdir_p!("")` is not a directory. The file's own comment
claimed "Empty / unset = the CWD default"; only half of that was ever true.

## The Docker leg, and where the measurement disagrees with the report

Measured, not taken on trust:

* `Dockerfile.release` bakes `DATABASE_PATH=/data/grappa.db`,
  `UPLOADS_STORAGE_ROOT=/data/uploads`, `CIC_DIST_ROOT=/app/cicchetto-dist`,
  `GRAPPA_SUBSTRATE`, `PORT` — and **not** `PEER_AVATARS_STORAGE_ROOT`. Confirmed.
* `compose.release.yaml` mounts only `grappa-data:/data` and sets only
  `PHX_HOST`. Confirmed.

Two corrections:

1. **"The absolute-default fix alone is not enough for this path" does not
   hold.** The image bakes an *absolute* `DATABASE_PATH`, so the derived default
   is `/data/peer_avatars` — inside the volume. The anchor alone closes the
   silent-data-loss path on the release image. The `ENV` line was added anyway,
   for parity with the other two roots and so `docker image inspect` shows where
   the third one goes without the reader having to know the derivation.
2. **`compose.release.yaml` was deliberately left alone.** It names no storage
   root at all — the other two are baked in the image, not composed — so there
   is no "next to the other two roots" there to add one next to, and adding the
   only such override to a file whose stated design is *"the image bootstraps
   itself"* would be the inconsistency.

`infra/docker/release-entrypoint.sh` gains the same root in its `mkdir -p` list,
with the fallback the BEAM derives, so the shell and the app cannot disagree
about where it lives when the variable is unset.

## The claim "nothing moves where it worked", as a gate

`test/grappa/config/storage_roots_config_test.exs` pins the class (every root
absolute, both data roots siblings of the DB, empty-is-unset, verbatim
pass-through, the `DATABASE_PATH` refusal) and, separately, pins the
compatibility claim by reading what each substrate already declares and
requiring the derivation to reproduce it:

| substrate | declares | derivation computes |
|---|---|---|
| `compose.yaml` | `${UPLOADS_STORAGE_ROOT:-/app/runtime/uploads}`, `${PEER_AVATARS_STORAGE_ROOT:-/app/runtime/peer_avatars}` | same, from `/app/runtime/grappa_<env>.db` |
| `Dockerfile.release` | `/data/uploads` (baked), `/data/peer_avatars` (added here) | same, from `/data/grappa.db` |
| `base/deployment.yaml` | `/data/peer_avatars`, written BY HAND to dodge the ephemeral relative default | same |

The compose half of that pin was **green before a line of the cure existed** —
that is the evidence for the claim, not a sentence in a commit message. Three
hosts had independently hand-written the anchor the default should always have
had.

`cic_dist_root_config_test.exs`'s `"falls back to the CWD default"` assertion was
the bug written down, so it now asserts the no-clobber contract.

## Gates

All rc taken from a file, never from a pipe.

* baseline `scripts/check.sh` on the untouched worktree at `35e9fca61`: **rc=0**
* `scripts/check.sh` on this branch: **rc=0** — `8 doctests, 65 properties, 7129
  tests, 0 failures`; doctor `Total errors: 0`; bats `1..719`, 719 `ok`, 0 `not ok`;
  `wireTypes.ts`/`wireSchema.ts` in sync; `priv/wire/shape.pin: wire shape and
  protocol 11 agree.`
* `scripts/design-notes-gate.sh origin/main`: **rc=0** — `1 new entry heading(s),
  separator and marker present.` (run post-commit, so not the vacuous
  "nothing to check" green)
* One intermediate run failed on `Grappa.Repo.LockWatchTest` with a 60 s
  `ExUnit.TimeoutError` inside `CaptureServer.log`. Established as **not this
  branch**: the same suite was rc=0 on the untouched tree at the same base, the
  file iso-reruns `38 tests, 0 failures` in 15.1 s, and nothing here touches it.
  The following full run was green.

`scripts/_lib.sh` gains one mount: `Dockerfile.release` joins the existing
DRIFT-PIN block. Measured the hard way — the new pin stayed RED against a
worktree that already carried the ENV line, because the container was reading
MAIN's copy while the sibling `compose.yaml` assertion passed.

## Deploy

**COLD** on every substrate, measured rather than reasoned:
`Preflight.classify_paths(<changed set>, s)` returns
`{:cold, [config: ["config/runtime.exs", "config/config.exs"]]}` for `:jail`,
`:linux` and `:docker` alike (positive control: the `lib/` comment-only paths
alone return `{:hot, []}`). The release image additionally has to be rebuilt for
the baked ENV to move.

## What this does NOT claim

* Nothing was run on the jail — that host is unreachable from the worker. The
  crash chain is read from the issue and from `infra/freebsd/rc.d/grappa`, never
  observed.
* The release-image behaviour is the reporter's measurement. It is re-derived
  here from the files only; no container was run.
* The warning is pinned as *emitted*, not as *operator-visible in a release boot
  log* — that depends on the logger handler state at `runtime.exs` evaluation
  time and was not tested.
* 13 files is above the usual bar. Each is the cure, its test, or a document the
  cure falsified; nothing was widened beyond the three roots plus the anchor's
  precondition.
