### PR TITLE
/notify: ISON polling fallback for ircds with neither MONITOR nor WATCH

### DIFF
--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1372,7 +1372,9 @@ export type WireUserEvent =
       nick: string;
       presence: "online" | "offline";
       initial: boolean;
-      source: "monitor" | "watch";
+      // #1946 — `ison` is the polling fallback for ircds with neither MONITOR
+      // nor WATCH (IRCnet). Pinned equal to codegen by wireTypesAssert.ts.
+      source: "monitor" | "watch" | "ison";
       ts: string;
     }
   | { kind: "presence_error"; network_id: number; reason: "list_full"; detail: string }

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1183,7 +1183,7 @@ export const S_SessionWirePresenceChangedPayload = {
     nick: "s",
     presence: { e: ["online", "offline"] },
     initial: "b",
-    source: { e: ["monitor", "watch"] },
+    source: { e: ["monitor", "watch", "ison"] },
     ts: "s",
   },
 } as const;

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1066,7 +1066,7 @@ export type SessionWirePresenceChangedPayload = {
   nick: string;
   presence: "online" | "offline";
   initial: boolean;
-  source: "monitor" | "watch";
+  source: "monitor" | "watch" | "ison";
   ts: string;
 };
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46703,3 +46703,92 @@ _Deploy: **COLD** on every substrate. Measured, not reasoned:
 `:linux` and `:docker` alike (positive control: the `lib/` comment-only paths
 alone return `{:hot, []}`). The release image also has to be REBUILT for the
 baked ENV to move — the config change alone does not reach it._
+<!-- entry #1946 -->
+
+---
+
+## 2026-09-06 — #1946: ISON presence fallback, and two seam bugs only live testing found
+
+**`/notify` was inert on IRCnet.** Its ircd (2.11.2, RFC 2810–2813 lineage)
+implements neither MONITOR nor WATCH — confirmed in `common/parse.c`'s message
+table and in a live 005 that carries neither token. So the 005-independent arm
+probed WATCH, took a `421`, downgraded to MONITOR, took a second `421`, and
+resolved `:none`, where `arm_commands/2` returns `[]` and every watched nick
+stays `:unknown` until reconnect.
+
+#247 had already named this exact condition: *"ISON fallback can be phase 2 if a
+network without MONITOR/WATCH ever matters."* It now matters.
+
+### ISON is the terminal fallback, NOT a fourth probe rung
+
+MONITOR and WATCH are optional extensions, so probing them is meaningful — a
+`421` is a real answer. ISON is RFC 1459/2812 mandatory: there is nothing to
+discover, so it is *used* rather than probed. `:none` survives only for the
+ircd that refuses even ISON, because no-silent-drops says the impossible case
+still needs a name.
+
+The 005 hint keeps winning when present, and the optimistic WATCH probe stays —
+its reason (bahamut forks that support WATCH without advertising it) is
+untouched.
+
+### The reply budget is the correctness problem, not the request budget
+
+IRCnet's `m_ison` fills its reply buffer and then `break`s
+(`if (len + i > sizeof(buf) - 4) break;`), dropping the tail with no error and
+no marker. The reply carries only the **online** nicks, so a chunk sized
+against the REQUEST can still overflow the reply — and every dropped nick then
+reads as offline, fabricating "X went offline" pushes.
+
+Hence `@ison_reply_budget 360` (below the 400 used for MONITOR/WATCH), sized so
+the reply fits even if every queried nick is online. And hence the sweep rule:
+**N chunks must yield N × 303, or the sweep is discarded and nothing is
+diffed.** Absence of evidence must never become an offline transition.
+
+### Cadence is budgeted against a measured penalty
+
+In this ircd a handler's return value IS its penalty in seconds
+(`cptr->since += ret`); `m_ison` returns **1**, the cheapest tier (`m_whois` 2,
+`m_who` up to MAXPENALTY), plus a pre-dispatch base of `1 + len/100`. So a full
+ISON line costs ~2 penalty-seconds and the interval scales with chunk count:
+30 s floor, +10 s per chunk. An empty watch list arms **no timer at all** —
+most sessions watch nobody and must pay nothing.
+
+### Deviation from the issue's design, and why
+
+The issue said `:ison` should get no `arm_commands/2` clause, so nobody could
+"arm" a poll and wait forever for a push. Built that way it crashes: the live
+`/notify add` path calls `arm_commands/2` with whatever mechanism the session
+resolved, and a `FunctionClauseError` there takes down a working session over a
+nick the next sweep would have picked up anyway. It returns `[]` instead, and
+`sync_presence/3` re-schedules the timer — which it must regardless, since
+0 → N has to create the timer `poll_interval_ms(0)` refused.
+
+### 🔴 Two bugs that unit tests could not have caught
+
+Both live at the server↔client seam, and both were found by running the thing
+against real IRCnet:
+
+1. **`Wire.presence_changed/6` had no `:ison` clause** — guarded
+   `source in [:monitor, :watch]`. Thirty seconds after the downgrade the first
+   sweep produced `source: :ison` and the session crashed with a
+   `FunctionClauseError`, then `:transient`-restarted into the same wall.
+2. **`source` is a CLOSED SET on the wire**, and widening it server-side while
+   an old bundle was live made cic drop every presence frame with *"This client
+   could not read a presence_changed update from the server and discarded it"*.
+   That is the validator working: `wireSchema.ts` carried
+   `{ e: ["monitor", "watch"] }`.
+
+So a closed set gaining a member IS a wire-shape change, in the
+new-server-to-old-client direction, and it is **measured** here rather than
+argued. Protocol went **11 → 12** and — unlike v10 and v11 — `mix
+grappa.wire_pin` *demanded* it: `source` lives in a `Session.Wire` typespec, so
+it reaches the generated artefacts and the digest actually moved
+(`9c97bd9b…` → `4e6ee9e6…`). `@min_protocol_version` stays 1: an old client
+drops presence frames and keeps every other pane, and only on the one network
+that needs ISON at all.
+
+Regenerating the artefacts was not sufficient on its own — `src/lib/api.ts`
+carries a hand-written copy of the payload that `wireTypesAssert.ts` pins equal
+to codegen, so `tsc` stayed red until that was widened too.
+
+_Deploy: **COLD** — server behaviour + wire version. cic rides with it._

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -256,7 +256,24 @@ defmodule Grappa.Protocol do
   # @min_protocol_version stays at 1: purely additive, and the client treats a
   # failed read as the server's own default (`false`), so every v1..v10 bundle
   # is served unchanged.
-  @protocol_version 11
+  # v12 (#1946) — the `/notify` presence fallback for ircds with neither
+  # MONITOR nor WATCH (IRCnet). `presence_changed.source` gains a third value,
+  # `"ison"`.
+  #
+  # ⚠️ Unlike v10 and v11, `mix grappa.wire_pin` DOES demand this one: `source`
+  # is a closed set in a `Grappa.Session.Wire` typespec, so it lands in the
+  # generated artefacts and moves the digest. And the break is not theoretical
+  # — it was MEASURED on the running dev stack before the bump: an old bundle
+  # against the new server logged "This client could not read a
+  # presence_changed update from the server and discarded it", because
+  # `wireSchema.ts` drops a payload whose enum value is outside the set it
+  # knows. New-server-to-old-client, which is the additive direction, and it
+  # still breaks — a closed set gaining a member is a wire-shape change.
+  #
+  # @min_protocol_version stays at 1: an old client drops presence_changed
+  # frames it cannot read and keeps every other pane, so it is degraded rather
+  # than unserviceable — and only on the one network that needs ISON at all.
+  @protocol_version 12
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -267,7 +284,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 11
+  @spec version() :: 12
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -308,9 +308,10 @@ defmodule Grappa.Session.EventRouter do
           | {:umode_changed, modes :: [String.t()]}
           | {:supported_umodes_changed, modes :: [String.t()]}
           | {:session_identity_changed, :acquired | :lost}
-          | {:presence_changed, nick :: String.t(), :online | :offline, Presence.change_kind(), :monitor | :watch}
+          | {:presence_changed, nick :: String.t(), :online | :offline, Presence.change_kind(),
+             :monitor | :watch | :ison}
           | {:presence_error, :list_full, detail :: String.t()}
-          | {:presence_command_unknown, :monitor | :watch}
+          | {:presence_command_unknown, :monitor | :watch | :ison}
           | {:peer_nick_renamed, old_nick :: String.t(), new_nick :: String.t()}
           | {:own_nick_renamed, old_nick :: String.t(), new_nick :: String.t()}
 
@@ -1974,6 +1975,28 @@ defmodule Grappa.Session.EventRouter do
     fold_presence_reports(state, [nick], :offline, :watch)
   end
 
+  # 303 RPL_ISON (#1946): `:server 303 own_nick :nick1 nick2 `. The reply to
+  # ONE line of a polling sweep — the ISON fallback for ircds with neither
+  # MONITOR nor WATCH (IRCnet). It carries only the nicks that ARE online, and
+  # it does not echo the request, so a single reply means nothing on its own:
+  # the sweep is the unit, and it is complete only when as many 303s have
+  # arrived as lines were sent.
+  #
+  # So this clause ACCUMULATES and does not classify. It unions the names into
+  # the in-flight sweep and, on the last expected reply, derives one report per
+  # tracked nick by MEMBERSHIP and folds them through the same
+  # `Presence.apply_report/3` every mechanism uses.
+  #
+  # A 303 with no sweep in flight (an operator's `/quote ISON`, or a straggler
+  # after a discarded sweep) is dropped: deriving offline from a reply we did
+  # not size would invent departures.
+  defp do_route(%Message{command: {:numeric, 303}, params: params}, state) do
+    case Map.get(state, :presence_sweep) do
+      nil -> {:cont, state, []}
+      sweep -> absorb_ison_reply(state, sweep, List.last(params))
+    end
+  end
+
   # 602 RPL_WATCHOFF: ack of `WATCH -nick`. Content-free — the map entry
   # was already dropped when the removal was sent. Handled (vs falling
   # through) so the delegation in NumericRouter has an owner and the ack
@@ -2029,8 +2052,18 @@ defmodule Grappa.Session.EventRouter do
   # other 421 stays purely matrix-routed ($server notice; 421 is
   # deny-listed, not delegated, so that persist happens either way).
   defp do_route(%Message{command: {:numeric, 421}, params: [_, cmd | _]}, state)
-       when cmd in ["WATCH", "MONITOR"] do
-    mech = if cmd == "WATCH", do: :watch, else: :monitor
+       when cmd in ["WATCH", "MONITOR", "ISON"] do
+    mech =
+      case cmd do
+        "WATCH" -> :watch
+        "MONITOR" -> :monitor
+        # #1946 — ISON is RFC 1459/2812 mandatory, so this rung should be
+        # unreachable. It exists because no-silent-drops says the impossible
+        # case still needs a name: an ircd that refuses ISON resolves `:none`
+        # and logs it, rather than polling into the void forever.
+        "ISON" -> :ison
+      end
+
     {:cont, state, [{:presence_command_unknown, mech}]}
   end
 
@@ -5101,7 +5134,7 @@ defmodule Grappa.Session.EventRouter do
   # dedupes). `Map.get(state, :presence, %{})` — a pre-arm report (or a
   # pure unit-test state without the field) folds against the empty map
   # and emits nothing.
-  @spec fold_presence_reports(state(), [String.t()], :online | :offline, :monitor | :watch) ::
+  @spec fold_presence_reports(state(), [String.t()], :online | :offline, :monitor | :watch | :ison) ::
           {:cont, state(), [effect()]}
   defp fold_presence_reports(state, nicks, presence, source) do
     {map, effects} =
@@ -5116,6 +5149,45 @@ defmodule Grappa.Session.EventRouter do
       end)
 
     {:cont, Map.put(state, :presence, map), Enum.reverse(effects)}
+  end
+
+  # #1946 — one 303 folded into the in-flight sweep. Returns early (still
+  # accumulating) or, on the final expected reply, derives the whole map.
+  #
+  # The sweep is CLEARED either way at completion, so a late duplicate 303
+  # lands on the `nil` branch above rather than re-deriving a second time.
+  @spec absorb_ison_reply(state(), map(), String.t() | nil) :: {:cont, state(), [effect()]}
+  defp absorb_ison_reply(state, sweep, trailing) do
+    online = sweep.online ++ Presence.fold_ison_names(trailing)
+    received = sweep.received + 1
+
+    if received < sweep.expected do
+      {:cont, Map.put(state, :presence_sweep, %{sweep | online: online, received: received}), []}
+    else
+      state
+      |> Map.put(:presence_sweep, nil)
+      |> fold_sweep_reports(online)
+    end
+  end
+
+  # Derive + fold a COMPLETE sweep. One report per tracked nick, classified by
+  # the shared `apply_report/3` so baseline-vs-transition, dedupe and the
+  # never-invent-an-entry rule are identical to MONITOR and WATCH.
+  @spec fold_sweep_reports(state(), [String.t()]) :: {:cont, state(), [effect()]}
+  defp fold_sweep_reports(state, online) do
+    map = Map.get(state, :presence, %{})
+
+    {next_map, effects} =
+      map
+      |> Presence.sweep_reports(online)
+      |> Enum.reduce({map, []}, fn {nick, presence}, {acc, eff} ->
+        case Presence.apply_report(acc, nick, presence) do
+          :unchanged -> {acc, eff}
+          {:changed, kind, next} -> {next, [{:presence_changed, nick, presence, kind, :ison} | eff]}
+        end
+      end)
+
+    {:cont, Map.put(state, :presence, next_map), Enum.reverse(effects)}
   end
 
   # A 730/731 trailing target list: comma-separated, each entry a bare

--- a/lib/grappa/session/isupport.ex
+++ b/lib/grappa/session/isupport.ex
@@ -72,13 +72,26 @@ defmodule Grappa.Session.ISupport do
   @type presence_limit :: pos_integer() | :unlimited
 
   @typedoc """
-  The presence-watch mechanism this network advertises for `/notify`
-  (#247): IRCv3 `MONITOR` (solanum/Libera, OFTC), legacy `WATCH`
-  (bahamut/Azzurra), or `:none`. MONITOR wins when both are advertised.
-  ISON polling (the no-mechanism fallback) is out of v1 scope — a
-  `:none` network simply gets no live presence.
+  What 005 can ADVERTISE for `/notify` (#247): IRCv3 `MONITOR`
+  (solanum/Libera, OFTC), legacy `WATCH` (bahamut/Azzurra), or `:none`.
+  MONITOR wins when both are advertised.
+
+  `:ison` is deliberately absent — no ircd advertises ISON, because RFC
+  1459/2812 makes it mandatory, so it can never be the answer to "what did
+  005 say?". (This typedoc previously said ISON polling was out of scope and
+  that a `:none` network "simply gets no live presence"; #1946 made that
+  false.)
   """
-  @type presence_mechanism :: {:monitor, presence_limit()} | {:watch, presence_limit()} | :none
+  @type advertised_mechanism ::
+          {:monitor, presence_limit()} | {:watch, presence_limit()} | :none
+
+  @typedoc """
+  What a SESSION can resolve to — the advertised set plus `:ison`, which is
+  reached only through the 421 fallback chain (#1946). Two types rather than
+  one because they answer different questions, and collapsing them would let
+  `presence_mechanism/1` claim a return value it can never produce.
+  """
+  @type presence_mechanism :: advertised_mechanism() | :ison
 
   @typedoc """
   How the upstream ircd folds identifiers (nicks AND channels), from the
@@ -378,13 +391,18 @@ defmodule Grappa.Session.ISupport do
   NOT "don't arm": per review 2026-07-19 the arm must work
   005-independently, so `Session.Server.arm_presence/1` treats `:none`
   as "probe WATCH optimistically" and downgrades via the 421 fallback
-  chain (WATCH → MONITOR → `:none`). ISON polling stays out of v1.
+  chain (WATCH → MONITOR → `:ison`, #1946).
+
+  `:ison` is NEVER returned from here — no ircd advertises ISON in 005,
+  because RFC 1459/2812 makes it mandatory. It is reached only through
+  that chain, and it is a FALLBACK rather than a probe rung for the same
+  reason: there is nothing to discover.
 
   Reads via `Map.get` (not pattern match on the keys) for the same
   hot-reload safety as `statusmsg/1`: a live isupport table seeded
   before #247 has no `:monitor`/`:watch` keys and must not KeyError.
   """
-  @spec presence_mechanism(t()) :: presence_mechanism()
+  @spec presence_mechanism(t()) :: advertised_mechanism()
   def presence_mechanism(isupport) when is_map(isupport) do
     cond do
       limit = Map.get(isupport, :monitor) -> {:monitor, limit}

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -800,6 +800,7 @@ defmodule Grappa.Session.NumericRouter do
                         # 602 RPL_WATCHOFF    (WATCH removal ack)
                         # 604 RPL_NOWON       (WATCH baseline: online)
                         # 605 RPL_NOWOFF      (WATCH baseline: offline)
+                        # 303 RPL_ISON        (ISON poll — #1946)
                         730,
                         731,
                         600,
@@ -807,6 +808,19 @@ defmodule Grappa.Session.NumericRouter do
                         602,
                         604,
                         605,
+                        # #1946 — 303 joins the presence family. Previously
+                        # unrouted and left to the catch-all, which was
+                        # defensible while nothing polled: the moduledoc note
+                        # above reasoned it was only `/quote`-reachable and
+                        # that its trailing (`"nick "`, with the space every
+                        # ircd appends) fails `valid_nick?/1` so it could not
+                        # misroute to a query window. Both stay true; what
+                        # changed is that the ISON fallback now SENDS it on a
+                        # timer, so an undelegated 303 would persist a
+                        # `$server` :notice row every sweep — the presence
+                        # equivalent of the 333 unix-timestamp leak this list
+                        # exists to stop.
+                        303,
                         # #992 — ADMIN (256 RPL_ADMINME, 257 RPL_ADMINLOC1,
                         # 258 RPL_ADMINLOC2, 259 RPL_ADMINEMAIL) plus its two
                         # OWN error terminators. /admin became a native verb,

--- a/lib/grappa/session/presence.ex
+++ b/lib/grappa/session/presence.ex
@@ -56,6 +56,30 @@ defmodule Grappa.Session.Presence do
   # arithmetic.
   @line_budget 400
 
+  # #1946 — the ISON budget, and it is SMALLER than @line_budget on purpose.
+  #
+  # For MONITOR/WATCH the 512-byte cap binds on the line WE send. For ISON it
+  # binds on the line the SERVER sends back, and IRCnet's `m_ison` fills its
+  # reply buffer and then `break`s — dropping the tail with no error and no
+  # marker (`ircd/s_user.c`: `if (len + i > sizeof(buf) - 4) break;`). The
+  # reply carries only the ONLINE nicks, so a chunk sized against the REQUEST
+  # can still overflow the reply, and every dropped nick would read as
+  # offline. That fabricates "X went offline".
+  #
+  # So the chunk must fit even if EVERY queried nick comes back online:
+  #   508 usable  −  worst-case `:<servername 63> 303 <mynick> :` prefix (~86)
+  #   ≈ 420 bytes of names, minus slack.
+  # At NICKLEN=15 that is ~24 nicks per line; short nicks pack more, because
+  # the chunker measures bytes rather than counting.
+  @ison_reply_budget 360
+
+  # Cadence constants (#1946). The estimate is only used to SCALE the interval
+  # — the actual chunking is by bytes, so a list of short nicks packs tighter
+  # and simply polls more cheaply than this predicts.
+  @nicks_per_chunk_estimate 24
+  @min_poll_interval_ms 30_000
+  @per_chunk_interval_ms 10_000
+
   # ---------------------------------------------------------------------------
   # Command building
   # ---------------------------------------------------------------------------
@@ -75,6 +99,13 @@ defmodule Grappa.Session.Presence do
   def arm_commands(_, []), do: []
   def arm_commands({:monitor, _}, nicks), do: monitor_commands("+", nicks)
   def arm_commands({:watch, _}, nicks), do: watch_commands("+", nicks)
+  # #1946 — ISON arms NOTHING: it is a poll, and the sweep is driven by
+  # `poll_commands/1` on a timer. An empty list rather than no clause at all,
+  # deliberately: the live `/notify add` path calls this with whatever
+  # mechanism the session resolved, and a FunctionClauseError there would take
+  # down a working session over a nick the next sweep picks up anyway.
+  def arm_commands(:ison, _), do: []
+
   def arm_commands(:none, _), do: []
 
   @doc """
@@ -92,7 +123,106 @@ defmodule Grappa.Session.Presence do
   def remove_commands(_, []), do: []
   def remove_commands({:monitor, _}, nicks), do: monitor_commands("-", nicks)
   def remove_commands({:watch, _}, nicks), do: watch_commands("-", nicks)
+  # #1946 — ISON arms NOTHING: it is a poll, and the sweep is driven by
+  # `poll_commands/1` on a timer. An empty list rather than no clause at all,
+  # deliberately: the live `/notify add` path calls this with whatever
+  # mechanism the session resolved, and a FunctionClauseError there would take
+  # down a working session over a nick the next sweep picks up anyway.
+  def remove_commands(:ison, _), do: []
+
   def remove_commands(:none, _), do: []
+
+  @doc """
+  The ISON lines for one polling sweep over `nicks` (#1946).
+
+  Deliberately NOT an `arm_commands/2` clause. MONITOR and WATCH are
+  arm-and-receive: you register once and the server pushes. ISON is
+  poll-and-diff — there is nothing to arm, and the caller must re-send this
+  every cycle. Folding it into `arm_commands/2` would put two different verbs
+  behind one name and let a caller "arm" ISON and then wait forever for a push
+  that never comes.
+
+  Chunked against `@ison_reply_budget` (the REPLY cap, see there), so a sweep
+  over a large list is several lines. The COUNT matters to the caller: the
+  server does not echo the request in `303`, so completeness can only be
+  established by counting replies against `length(poll_commands(nicks))`.
+
+  Empty list → no commands. A session watching nobody must send nothing.
+  """
+  @spec poll_commands([String.t()]) :: [String.t()]
+  def poll_commands([]), do: []
+
+  def poll_commands(nicks) when is_list(nicks) do
+    nicks
+    # the server appends one space after every name it returns
+    |> chunk_by_budget(1, @ison_reply_budget)
+    |> Enum.map(fn chunk -> "ISON " <> Enum.join(chunk, " ") end)
+  end
+
+  @doc """
+  Derives one presence report per tracked nick from a completed ISON sweep
+  (#1946).
+
+  `online` is the folded union of every `303` reply in the sweep, as a list. Presence is
+  derived by MEMBERSHIP: MONITOR/WATCH state what changed, ISON states only who
+  is present, so absence from the union IS the offline report — and that is
+  precisely why the caller must never call this on an incomplete sweep.
+
+  Returns `[{folded_nick, :online | :offline}]` over the WHOLE map, for the
+  caller to fold through `apply_report/3`. That keeps one classifier for all
+  three mechanisms: baseline-vs-transition, dedupe, and the "never invent an
+  entry" rule stay in `apply_report/3` rather than being re-derived here.
+  """
+  @spec sweep_reports(state_map(), [String.t()]) :: [{String.t(), :online | :offline}]
+  def sweep_reports(map, online) when is_map(map) and is_list(online) do
+    # The set is built HERE and never escapes. An earlier spelling carried a
+    # `MapSet.t()` on `Session.Server`'s state type, which dialyzer rejects:
+    # MapSet is opaque, so embedding one in a map type leaks the opacity across
+    # every module that touches the state. A plain list crosses the boundary;
+    # the set stays a local optimisation.
+    set = MapSet.new(online)
+
+    Enum.map(map, fn {key, _} ->
+      {key, if(MapSet.member?(set, key), do: :online, else: :offline)}
+    end)
+  end
+
+  @doc """
+  Folds the names from one `303 RPL_ISON` trailing into a folded LIST (#1946).
+
+  The trailing is space-separated and IRCnet appends a trailing space after
+  every name, so `trim: true` is load-bearing rather than tidy.
+  """
+  @spec fold_ison_names(String.t() | nil) :: [String.t()]
+  def fold_ison_names(nil), do: []
+
+  def fold_ison_names(trailing) when is_binary(trailing) do
+    trailing
+    |> String.split(" ", trim: true)
+    |> Enum.map(&Identifier.canonical_target/1)
+  end
+
+  @doc """
+  Sweep interval in ms for a watch list of `count` nicks (#1946), or `nil` when
+  there is nothing to watch.
+
+  Budgeted against IRCnet's penalty system, measured in its source: a handler's
+  return value IS its penalty in seconds (`cptr->since += ret`), `m_ison`
+  returns 1, and the pre-dispatch base is `1 + len/100` — so a full ISON line
+  costs roughly 2 penalty-seconds. One sweep is one line per chunk, hence the
+  scaling: a 1-chunk list at 30 s spends ~7% of its budget, a 6-chunk list at
+  30 s would spend ~40%, which is too hot to sustain.
+
+  `nil` for an empty list is the whole point — most sessions watch nobody and
+  must pay nothing, so the caller arms no timer at all.
+  """
+  @spec poll_interval_ms(non_neg_integer()) :: pos_integer() | nil
+  def poll_interval_ms(0), do: nil
+
+  def poll_interval_ms(count) when is_integer(count) and count > 0 do
+    chunks = ceil(count / @nicks_per_chunk_estimate)
+    max(@min_poll_interval_ms, chunks * @per_chunk_interval_ms)
+  end
 
   # ---------------------------------------------------------------------------
   # State map
@@ -192,7 +322,7 @@ defmodule Grappa.Session.Presence do
   defp monitor_commands(sign, nicks) do
     nicks
     # comma joiner: 1 byte of overhead per packed nick
-    |> chunk_by_budget(1)
+    |> chunk_by_budget(1, @line_budget)
     |> Enum.map(fn chunk -> "MONITOR #{sign} #{Enum.join(chunk, ",")}" end)
   end
 
@@ -201,7 +331,7 @@ defmodule Grappa.Session.Presence do
   defp watch_commands(sign, nicks) do
     nicks
     # separator " " + sign prefix per target = 2 bytes of overhead
-    |> chunk_by_budget(2)
+    |> chunk_by_budget(2, @line_budget)
     |> Enum.map(fn chunk ->
       "WATCH " <> Enum.map_join(chunk, " ", fn nick -> sign <> nick end)
     end)
@@ -211,15 +341,15 @@ defmodule Grappa.Session.Presence do
   # budget. `overhead` is the per-nick joining cost (comma vs
   # space+sign). A single nick longer than the budget still ships alone
   # — the server rejects it, we don't silently drop it.
-  @spec chunk_by_budget([String.t()], pos_integer()) :: [[String.t()]]
-  defp chunk_by_budget(nicks, overhead) do
+  @spec chunk_by_budget([String.t()], pos_integer(), pos_integer()) :: [[String.t()]]
+  defp chunk_by_budget(nicks, overhead, budget) do
     {chunks, last, _} =
       Enum.reduce(nicks, {[], [], 0}, fn nick, {chunks, current, size} ->
         cost = byte_size(nick) + overhead
 
         cond do
           current == [] -> {chunks, [nick], cost}
-          size + cost > @line_budget -> {[Enum.reverse(current) | chunks], [nick], cost}
+          size + cost > budget -> {[Enum.reverse(current) | chunks], [nick], cost}
           true -> {chunks, [nick | current], size + cost}
         end
       end)

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -647,6 +647,26 @@ defmodule Grappa.Session.Server do
           # /notify must work on ircds that support WATCH but don't
           # advertise it).
           presence_mechanism: ISupport.presence_mechanism() | nil,
+          # #1946: the ISON polling loop. `presence_poll_ref` is the armed
+          # timer (nil when the mechanism is not `:ison`, or when the watch
+          # list is empty — an empty list arms nothing at all).
+          # `presence_sweep` is the in-flight sweep: how many `303` replies
+          # are still expected and the union of the names seen so far. It is
+          # nil between sweeps, and a sweep still in flight when the next tick
+          # fires is DISCARDED rather than merged — an incomplete sweep must
+          # diff nothing.
+          presence_poll_ref: reference() | nil,
+          presence_sweep:
+            %{
+              expected: pos_integer(),
+              received: non_neg_integer(),
+              # A LIST, not a MapSet: MapSet is opaque, and embedding one in
+              # this map type leaks that opacity into every function that
+              # returns state (dialyzer rejects it). The set is built inside
+              # `Presence.sweep_reports/2`, where it never crosses a boundary.
+              online: [String.t()]
+            }
+            | nil,
           # #229: per-session USER-mode set (the operator's own umodes on
           # this network) — a sorted list of single-letter strings. Seeded
           # by the 221 RPL_UMODEIS reply to the bare `MODE <selfnick>` query
@@ -1173,6 +1193,9 @@ defmodule Grappa.Session.Server do
       presence: %{},
       presence_armed: false,
       presence_mechanism: nil,
+      # #1946: no ISON timer and no sweep until the 421 chain resolves `:ison`.
+      presence_poll_ref: nil,
+      presence_sweep: nil,
       # #229: empty umode set until the 221 RPL_UMODEIS reply arrives.
       umodes: [],
       # #388: no services account until an `ACCOUNT` or a self 330 says so.
@@ -2934,6 +2957,14 @@ defmodule Grappa.Session.Server do
   # session-lifecycle event. The two former clauses (notify vs bare)
   # collapsed into one path + `maybe_notify_session_phase/2` so the emit is
   # not duplicated / missed on either.
+  # #1946 — one ISON sweep. Only ever armed when the mechanism resolved to
+  # `:ison` and the watch list is non-empty (`schedule_presence_poll/1`), so a
+  # tick here always has work.
+  @impl GenServer
+  def handle_info(:presence_poll, state) do
+    {:noreply, run_presence_sweep(state)}
+  end
+
   def handle_info(:irc_connected, state) do
     state = %{state | connected_at: DateTime.utc_now()}
     SessionLog.emit(:connected, state, [])
@@ -5558,12 +5589,29 @@ defmodule Grappa.Session.Server do
           Map.put(state, :presence_mechanism, {:monitor, :unlimited})
 
         {:monitor, {:monitor, _}} ->
-          Logger.info(
-            "presence: MONITOR also unknown — no watch mechanism on this ircd; " <>
+          # #1946 — the terminal fallback is ISON, not `:none`. MONITOR and
+          # WATCH are optional extensions, so a 421 is a real answer about
+          # them; ISON is RFC 1459/2812 mandatory, so there is nothing left to
+          # discover and it is used rather than probed. This is the rung that
+          # makes /notify work on IRCnet.
+          Logger.info("presence: MONITOR also unknown — falling back to ISON polling")
+
+          state
+          |> Map.put(:presence_mechanism, :ison)
+          |> start_presence_poll()
+
+        {:ison, :ison} ->
+          # Unreachable in practice (see the ISON rung of EventRouter's 421
+          # clause); named so an ircd that refuses ISON stops polling and says
+          # so, instead of sweeping into the void forever.
+          Logger.warning(
+            "presence: ISON unknown too — no presence mechanism on this ircd; " <>
               "watched nicks stay :unknown until reconnect"
           )
 
-          Map.put(state, :presence_mechanism, :none)
+          state
+          |> cancel_presence_poll()
+          |> Map.put(:presence_mechanism, :none)
 
         _ ->
           state
@@ -7367,6 +7415,93 @@ defmodule Grappa.Session.Server do
     |> Map.put(:presence_mechanism, mechanism)
   end
 
+  # #1946 — the ISON polling loop. Three small functions rather than one, so
+  # each has exactly one reason to exist.
+  #
+  # ## Why a timer here, and not a process
+  #
+  # The presence map is already this GenServer's state and the socket is
+  # already its own, so a separate process would need both handed to it and
+  # would widen the crash boundary for nothing. `Process.send_after/3` into our
+  # own mailbox keeps per-session state in the per-session process, which is
+  # the alignment rule.
+  #
+  # ## Why the interval scales
+  #
+  # A sweep costs roughly 2 penalty-seconds per line on IRCnet (measured in its
+  # source; see `Presence.poll_interval_ms/1`), so a longer list must poll less
+  # often or it eats its own flood budget.
+  #
+  # ## Why an empty list arms nothing
+  #
+  # Most sessions watch nobody. `poll_interval_ms/1` returns `nil` there and no
+  # timer exists at all — not a timer that wakes to discover it has no work.
+  @spec start_presence_poll(t()) :: t()
+  defp start_presence_poll(state) do
+    state
+    |> cancel_presence_poll()
+    |> schedule_presence_poll()
+  end
+
+  @spec schedule_presence_poll(t()) :: t()
+  defp schedule_presence_poll(state) do
+    case state |> Map.get(:presence, %{}) |> map_size() |> Presence.poll_interval_ms() do
+      nil ->
+        Map.put(state, :presence_poll_ref, nil)
+
+      interval ->
+        ref = Process.send_after(self(), :presence_poll, interval)
+        Map.put(state, :presence_poll_ref, ref)
+    end
+  end
+
+  @spec cancel_presence_poll(t()) :: t()
+  defp cancel_presence_poll(state) do
+    case Map.get(state, :presence_poll_ref) do
+      nil ->
+        state
+
+      ref ->
+        # Discarded, not matched: `cancel_timer/1` answers `false` for a timer
+        # that already fired or was already cancelled, and that is a normal
+        # race here (a tick in the mailbox while a live /notify re-schedules),
+        # not a fault. An earlier spelling returned that `false` AS the state.
+        _ = Process.cancel_timer(ref)
+        Map.put(state, :presence_poll_ref, nil)
+    end
+  end
+
+  # One sweep: send every chunk, record how many replies to expect, re-arm.
+  #
+  # A sweep still in flight when the next tick fires is DISCARDED rather than
+  # merged — an incomplete sweep must diff nothing, because ISON's reply
+  # carries only the online nicks and IRCnet truncates the tail in silence
+  # (`Presence.poll_commands/1` documents the buffer). Deriving offline from a
+  # partial answer would invent departures, so the rule is: complete, or
+  # nothing.
+  @spec run_presence_sweep(t()) :: t()
+  defp run_presence_sweep(state) do
+    nicks = state |> Map.get(:presence, %{}) |> Map.keys()
+
+    case Presence.poll_commands(nicks) do
+      [] ->
+        state |> Map.put(:presence_sweep, nil) |> schedule_presence_poll()
+
+      commands ->
+        for line <- commands do
+          maybe_log_send_failure("presence_poll", Client.send_raw(state.client, line))
+        end
+
+        state
+        |> Map.put(:presence_sweep, %{
+          expected: length(commands),
+          received: 0,
+          online: []
+        })
+        |> schedule_presence_poll()
+    end
+  end
+
   @spec send_arm_burst(t(), ISupport.presence_mechanism(), [String.t()]) :: :ok
   defp send_arm_burst(_, _, []), do: :ok
 
@@ -7401,7 +7536,14 @@ defmodule Grappa.Session.Server do
       |> Presence.track(added)
       |> Presence.untrack(removed)
 
-    Map.put(state, :presence, next_map)
+    next_state = Map.put(state, :presence, next_map)
+
+    # #1946 — on ISON the cadence is a function of the LIST SIZE, and the
+    # empty list arms no timer at all. So a live add/del must re-schedule:
+    # going 0 → N has to create the timer `poll_interval_ms(0)` refused, and
+    # crossing a chunk boundary has to slow the sweep down before it starts
+    # eating the flood budget. Cheap and idempotent — one cancel, one arm.
+    if mechanism == :ison, do: start_presence_poll(next_state), else: next_state
   end
 
   # #378 — see the `{:peer_nick_renamed, _, _}` arm. `Map.get` with a default

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -257,7 +257,7 @@ defmodule Grappa.Session.Wire do
           nick: String.t(),
           presence: :online | :offline,
           initial: boolean(),
-          source: :monitor | :watch,
+          source: :monitor | :watch | :ison,
           ts: String.t()
         }
 
@@ -1068,12 +1068,12 @@ defmodule Grappa.Session.Wire do
           String.t(),
           :online | :offline,
           boolean(),
-          :monitor | :watch,
+          :monitor | :watch | :ison,
           DateTime.t()
         ) :: presence_changed_payload()
   def presence_changed(network_id, nick, presence, initial, source, %DateTime{} = ts)
       when is_integer(network_id) and is_binary(nick) and presence in [:online, :offline] and
-             is_boolean(initial) and source in [:monitor, :watch] do
+             is_boolean(initial) and source in [:monitor, :watch, :ison] do
     %{
       kind: :presence_changed,
       network_id: network_id,

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 11
-shape_digest = sha256:9c97bd9b75bf362ac22c9dc727c4012b45062c88f6156daf6d73a79859394946
+protocol_version = 12
+shape_digest = sha256:4e6ee9e64c05d3a9f9db0fecbfc2f7f6dae1f4c1cd184684d8d0fb6c97229a09

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -254,7 +254,11 @@ defmodule Grappa.Session.EventRouterPropertyTest do
         {:presence_changed, nick, presence, _, source} ->
           assert is_binary(nick)
           assert presence in [:online, :offline]
-          assert source in [:monitor, :watch]
+          # #1946 — the full closed set. `:ison` is unreachable from this
+          # generator (a sweep only exists when `presence_sweep` is set, which
+          # it never generates), but the assertion states what a VALID source
+          # is, not what this generator happens to produce.
+          assert source in [:monitor, :watch, :ison]
 
         {:presence_error, reason, detail} ->
           assert reason == :list_full

--- a/test/grappa/session/presence_test.exs
+++ b/test/grappa/session/presence_test.exs
@@ -143,4 +143,115 @@ defmodule Grappa.Session.PresenceTest do
       assert Presence.reset(map, "bob") == map
     end
   end
+
+  # #1946 — the ISON fallback. The three properties worth pinning are the ones
+  # a wrong implementation gets wrong SILENTLY: the reply budget, the
+  # membership derivation, and the cadence.
+  describe "poll_commands/1 (#1946)" do
+    test "an empty watch list sends nothing at all" do
+      assert Presence.poll_commands([]) == []
+    end
+
+    test "one line for a small list, in ISON syntax" do
+      assert Presence.poll_commands(["alice", "bob"]) == ["ISON alice bob"]
+    end
+
+    # The budget is on the REPLY, not the request: IRCnet's m_ison fills its
+    # buffer and `break`s, dropping the tail with no error. A chunk that would
+    # overflow the reply when every nick is online turns those nicks offline.
+    test "chunks so the REPLY fits even when every queried nick is online" do
+      nicks = for i <- 1..60, do: String.duplicate("n", 14) <> Integer.to_string(rem(i, 10))
+      lines = Presence.poll_commands(nicks)
+
+      assert length(lines) > 1
+
+      for line <- lines do
+        names = String.replace_prefix(line, "ISON ", "")
+        # worst case: the server echoes every name back, each with the trailing
+        # space m_ison appends, under a prefix of up to ~86 bytes.
+        # +86 is the worst-case `:<servername> 303 <mynick> :` reply prefix.
+        assert byte_size(names) + 86 < 508
+      end
+    end
+
+    test "every nick appears exactly once across the chunks" do
+      nicks = for i <- 1..60, do: "nick#{i}"
+
+      packed =
+        nicks
+        |> Presence.poll_commands()
+        |> Enum.flat_map(&String.split(&1, " ", trim: true))
+        |> Enum.reject(&(&1 == "ISON"))
+
+      assert Enum.sort(packed) == Enum.sort(nicks)
+    end
+  end
+
+  describe "fold_ison_names/1 (#1946)" do
+    test "folds and drops the trailing space every ircd appends" do
+      assert Presence.fold_ison_names("Alice Bob ") == ["alice", "bob"]
+    end
+
+    test "an empty or absent trailing is an empty set, not a crash" do
+      assert Presence.fold_ison_names("") == []
+      assert Presence.fold_ison_names(nil) == []
+    end
+  end
+
+  describe "sweep_reports/2 (#1946)" do
+    # ISON says only who is PRESENT, so absence from the union IS the offline
+    # report. That is the whole mechanism, and the reason an incomplete sweep
+    # must never be diffed.
+    test "derives online by membership and offline by absence, over the whole map" do
+      map = Presence.seed(["alice", "bob", "carol"])
+
+      reports = Presence.sweep_reports(map, ["alice", "carol"])
+
+      assert Enum.sort(reports) == [{"alice", :online}, {"bob", :offline}, {"carol", :online}]
+    end
+
+    test "reports nothing for an empty map" do
+      assert Presence.sweep_reports(%{}, ["alice"]) == []
+    end
+
+    # The classifier is shared with MONITOR/WATCH, so a sweep gets the same
+    # baseline rule for free: first answer is :initial, a later flip is a
+    # :transition.
+    test "feeding sweep_reports through apply_report gives baseline then transition" do
+      map = Presence.seed(["alice"])
+
+      assert [{"alice", :online}] = Presence.sweep_reports(map, ["alice"])
+      assert {:changed, :initial, map} = Presence.apply_report(map, "alice", :online)
+
+      assert [{"alice", :offline}] = Presence.sweep_reports(map, [])
+      assert {:changed, :transition, _} = Presence.apply_report(map, "alice", :offline)
+    end
+  end
+
+  describe "poll_interval_ms/1 (#1946)" do
+    test "an empty list arms no timer" do
+      assert Presence.poll_interval_ms(0) == nil
+    end
+
+    test "a small list polls at the floor" do
+      assert Presence.poll_interval_ms(1) == 30_000
+      assert Presence.poll_interval_ms(24) == 30_000
+    end
+
+    # The penalty is per LINE, so a list that needs more lines must sweep less
+    # often or it eats its own flood budget.
+    test "the interval grows with the number of chunks" do
+      small = Presence.poll_interval_ms(24)
+      large = Presence.poll_interval_ms(200)
+
+      assert large > small
+    end
+
+    test "is monotonic in the list size" do
+      sizes = [1, 24, 25, 60, 128, 400]
+      intervals = Enum.map(sizes, &Presence.poll_interval_ms/1)
+
+      assert intervals == Enum.sort(intervals)
+    end
+  end
 end


### PR DESCRIPTION
Closes #1946. Implements the design agreed there, with one deviation and two bugs the design did not anticipate — both found by running it against real IRCnet, neither reachable from unit tests.

## What was broken

`/notify` was inert on IRCnet. The ircd has neither mechanism, so the 005-independent arm probed WATCH → `421` → MONITOR → `421` → `:none`, where `arm_commands/2` returns `[]` and every watched nick stays `:unknown` until reconnect. Confirmed live:

```
presence: WATCH unknown on this ircd — falling back to MONITOR (3 watched nicks)
presence: MONITOR also unknown — falling back to ISON polling      ← new
```

## Design

**ISON is the terminal fallback, not a fourth probe rung.** MONITOR and WATCH are optional, so a `421` is a real answer about them; ISON is RFC 1459/2812 mandatory, so it is used rather than probed. `:none` survives only for an ircd that refuses even ISON (no-silent-drops). The 005 hint still wins when present, and the optimistic WATCH probe stays — its reason (bahamut forks supporting WATCH unadvertised) is untouched.

**The reply budget is the correctness problem.** IRCnet's `m_ison` fills its reply buffer and `break`s, dropping the tail with no error:

```c
if (len + i > sizeof(buf) - 4) { break; }   /* leave room for " \r\n\0" */
```

The reply carries only the **online** nicks, so a chunk sized against the REQUEST can overflow the reply and turn live users offline — fabricating "X went offline" pushes. Hence `@ison_reply_budget 360` (vs 400 for MONITOR/WATCH), sized so the reply fits even if every queried nick is online, and the sweep rule: **N chunks must yield N × 303, or the sweep is discarded and nothing is diffed.**

**Cadence from a measured penalty.** In this ircd a handler's return value IS its penalty in seconds (`cptr->since += ret`); `m_ison` returns 1, the cheapest tier. A full line costs ~2 penalty-seconds, so: 30 s floor, +10 s per chunk, and an empty watch list arms **no timer at all**.

## Deviation from the issue

The issue said `:ison` should get no `arm_commands/2` clause. Built that way it crashes: the live `/notify add` path calls it with whatever mechanism the session resolved, and a `FunctionClauseError` there kills a working session over a nick the next sweep picks up anyway. It returns `[]` instead, and `sync_presence/3` re-schedules the timer — which it must regardless, since 0 → N has to create the timer `poll_interval_ms(0)` refused.

## Two bugs only live testing found

1. **`Wire.presence_changed/6` had no `:ison` clause.** Thirty seconds after the downgrade the first sweep crashed the session with a `FunctionClauseError`, which then `:transient`-restarted into the same wall.
2. **`source` is a CLOSED SET on the wire.** Widening it server-side against a live old bundle made cic drop every presence frame — *"This client could not read a presence_changed update from the server and discarded it"* — because `wireSchema.ts` carried `{ e: ["monitor", "watch"] }`.

So a closed set gaining a member is a wire-shape change, in the new-server-to-old-client direction, **measured rather than argued**. Protocol **11 → 12**, and unlike v10/v11 `wire_pin` demanded it — `source` lives in a `Session.Wire` typespec, so the digest actually moved (`9c97bd9b…` → `4e6ee9e6…`). `@min_protocol_version` stays 1: an old client drops presence frames and keeps every other pane, only on the network that needs ISON at all.

Regenerating was not sufficient: `src/lib/api.ts` carries a hand-written copy that `wireTypesAssert.ts` pins equal to codegen, so `tsc` stayed red until that was widened too.

## Verified by hand

Live on IRCnet (`open.ircnet.net`, `#sbiffo`) and Azzurra side by side: the chain downgrades, sweeps run on the timer (`command=ISON` ×6 in the first minutes), dots light, and Azzurra is untouched — it still resolves WATCH from 005 and never reaches the new rung.

## Gates

All run locally on the rebased tree:

| gate | result |
|---|---|
| `mix test` | **7142 tests, 0 failures** |
| `mix credo --strict` | no issues (6728 mods/funs) |
| `mix dialyzer` | **0 errors, passed successfully** |
| `mix grappa.wire_pin --check` | agrees at protocol 12 |
| `bun run check` | 5 stages, 0 failed |
| `scripts/design-notes-gate.sh` | pass |
| `scripts/union-rebase.sh` | `+89 -0 — contribution intact` |
| cic vitest | 7 fails, all 4 files green in isolation (known cross-file pollution; identical set pre- and post-rebase) |

`integration` cannot run on the dev host, so it was audited instead: `e2e/tests/issue247-notify-watch.spec.ts` runs on azzurra-testnet (bahamut, advertises WATCH) and never reaches the ISON rung.

**Deploy: COLD** — server behaviour + wire version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDCsdiDSVDJQSaqM4Yjoht