### PR TITLE
cic: a scrollback record row takes no live mode glyph (issue 1950)

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -400,17 +400,82 @@ export class IrcPeer {
   // alone — `raw_modes.includes(rawModes.replace(/^[+-]/, ''))` would
   // be a stricter check, but for our use sites (single-letter modes)
   // the literal echo is reliable enough.
+  //
+  // ⚠️ The caller must be chanop. On this testnet that means the caller
+  // FOUNDED the channel (`NO_CHANOPS_WHEN_SPLIT` is sed-deleted from
+  // `config.h` in `infra/bahamut/Dockerfile`, so the first JOINer
+  // auto-ops) — every green `.mode()` call site does exactly that.
+  // /OPER is NOT a substitute; see `oper()` and `samode()`.
   async mode(channel: string, rawModes: string, extraArg?: string): Promise<void> {
-    const modeEcho = onceMatching(
+    const modeEcho = this.channelModeEcho(channel, rawModes, extraArg, "mode");
+    this.client.mode(channel, rawModes, extraArg);
+    await modeEcho;
+  }
+
+  // Set channel modes by OPER OVERRIDE, for a caller who is not chanop.
+  // Resolves on the same echo `mode` waits for, because bahamut's
+  // `m_samode` relays the result through the very `sendto_channel_butserv`
+  // call `m_mode` uses — `:<setter> MODE <chan> <modes> <params>`. The
+  // frame going OUT is the only difference between the two verbs, which is
+  // why they share the wait rather than each growing their own copy.
+  //
+  // Preconditions, both mandatory and both loud when missing:
+  //   1. `oper(...)`      — `m_samode` gates on `IsPrivileged(cptr)`.
+  //   2. `umode("+A")`    — and on `IsAdmin(cptr) || IsSAdmin(cptr)`. That
+  //      arm returns 0 SILENTLY, so a missing `+A` costs a MODE_TIMEOUT_MS
+  //      wait with no server error to read. `+a` (SAdmin) is unreachable:
+  //      `m_umode` lists `a` among the modes a client may never set itself.
+  //
+  // Emits a GLOBOPS notice server-side. Harmless here (no spec reads the
+  // oper notice stream), but it is why this is a separate named verb and
+  // not a quiet fallback inside `mode()`: a test should say when it is
+  // overriding.
+  async samode(channel: string, rawModes: string, extraArg?: string): Promise<void> {
+    const modeEcho = this.channelModeEcho(channel, rawModes, extraArg, "samode");
+    this.client.raw(
+      extraArg ? ["SAMODE", channel, rawModes, extraArg] : ["SAMODE", channel, rawModes],
+    );
+    await modeEcho;
+  }
+
+  // The echo shared by `mode` and `samode`. Kept private: a caller that
+  // wants to WITNESS someone else's mode change wants `waitForLine`, which
+  // filters on `from_server` — this one matches the peer's own action too.
+  private channelModeEcho(
+    channel: string,
+    rawModes: string,
+    extraArg: string | undefined,
+    verb: string,
+  ): Promise<IrcEventMap["mode"]> {
+    return onceMatching(
       this.client,
       "mode",
       (event: { target: string; raw_modes: string }) =>
         event.target === channel && event.raw_modes === rawModes,
       MODE_TIMEOUT_MS,
-      `mode ${channel} ${rawModes}${extraArg ? ` ${extraArg}` : ""}`,
+      `${verb} ${channel} ${rawModes}${extraArg ? ` ${extraArg}` : ""}`,
     );
-    this.client.mode(channel, rawModes, extraArg);
-    await modeEcho;
+  }
+
+  // Set OWN user modes. Resolves on upstream's echo, which bahamut sends
+  // as `:<nick> MODE <nick> :<modes>` (`send_umode_out` → `send_umode`
+  // with `ALL_UMODES`, and `UMODE_A` is in it — a mode outside that mask
+  // would apply SILENTLY and this would time out).
+  //
+  // Shares the `mode` EVENT with the channel verbs above but not their
+  // wait: irc-framework routes every MODE through one handler keyed on
+  // `params[0]`, so the discriminator here is the nick, not the channel.
+  async umode(rawModes: string): Promise<void> {
+    const umodeEcho = onceMatching(
+      this.client,
+      "mode",
+      (event: { target: string; raw_modes: string }) =>
+        event.target === this.nick && event.raw_modes === rawModes,
+      MODE_TIMEOUT_MS,
+      `umode ${this.nick} ${rawModes}`,
+    );
+    this.client.raw(["MODE", this.nick, rawModes]);
+    await umodeEcho;
   }
 
   // Set a channel topic. Resolves once upstream echoes the `topic`
@@ -484,18 +549,29 @@ export class IrcPeer {
     this.client.raw(["KILL", targetNick, reason]);
   }
 
-  // /OPER up to ircop. Required to bypass bahamut's "no ops on new
-  // channels in split-mode" gate that otherwise locks every freshly
-  // created channel out of any kind of mode-setting (including +i, +k,
-  // +o). Resolves on 381 RPL_YOUREOPER.
+  // /OPER up to ircop. Resolves on 381 RPL_YOUREOPER.
   //
-  // Reason this matters for e2e: the testnet leaf isn't S2S-linked to
-  // the hub at the time peer clients connect (255 reports `0 servers`),
-  // so bahamut keeps the leaf in split-mode permanently — fresh JOINers
-  // never auto-op. Without ircop bypass, the peer can JOIN but cannot
-  // MODE +i / MODE +o anyone, including itself. With +O (and the
-  // configured `OaARD` flagset on the leaf's O: line), ircops issue
-  // MODE / SAMODE freely on any channel they're in.
+  // 🔴 WHAT THIS DOES NOT BUY, corrected 2026-09-07 against bahamut's own
+  // source after the text below sent two readers the wrong way (#1950).
+  // It used to claim the leaf is permanently split so "fresh JOINers never
+  // auto-op", and that an ircop can therefore "issue MODE / SAMODE freely
+  // on any channel they're in". Both halves were false:
+  //
+  //   1. Fresh JOINers DO auto-op. `infra/bahamut/Dockerfile` sed-deletes
+  //      `#define NO_CHANOPS_WHEN_SPLIT` from `config.h` precisely so that
+  //      split-mode stops withholding chanop, and every `.mode()` call
+  //      site in the suite relies on it by having its peer join first.
+  //   2. /OPER does NOT unlock plain MODE. `m_mode` grants override on
+  //      `IsULine || ((IsSAdmin || IsAdmin) && !MyClient(sptr)) ||
+  //      IsUmodez` — the `!MyClient` conjunct switches the admin arm off
+  //      for anyone connected to THIS server, and `IsUmodez` is out of
+  //      reach (`m_umode` refuses `+z` from clients). So an opered peer
+  //      that is not chanop gets 482 and no echo, i.e. a MODE_TIMEOUT_MS
+  //      wait that looks exactly like a hung fixture.
+  //
+  // The override door is `samode()`, which needs this call AND
+  // `umode("+A")`. What /OPER alone is genuinely for: oper-only verbs
+  // (`kill()`, #554) and oper-visible state (#367's WHOIS role text).
   //
   // #367 — we wait on the raw `381` wire-line, NOT an `rpl_youreoper`
   // named event: irc-framework does not surface 381 as a typed event, so

--- a/cicchetto/e2e/tests/issue1950-record-row-no-live-glyph.spec.ts
+++ b/cicchetto/e2e/tests/issue1950-record-row-no-live-glyph.spec.ts
@@ -1,0 +1,136 @@
+// issue 1950 — a scrollback RECORD row must never re-prefix itself.
+//
+// The defect: `ScrollbackPane`'s `prefixFor` derived the sender glyph of every
+// non-content row from the LIVE members store, so a nick who was opped AFTER
+// the event retroactively acquired an `@` on their own history. The reporter
+// saw both halves of it on Azzurra:
+//
+//     20:30:23 * @Mezmerize [mezmerize@staff.azzurra.chat] has joined #italia
+//     20:31:21 * @ULIAK [~ULIAK@5uo2.l.time4vps.cloud] has quit (Read/Dead Error: ...)
+//
+// The join line is wrong on the protocol outright — JOIN carries no grade, the
+// `@` always arrives afterwards in a separate MODE — and it bites hardest the
+// people with ChanServ auto-op, who read every one of their own joins as
+// `@nick`. The part/quit line is the same defect with a later re-render as its
+// trigger. It is the class #25 removed from CONTENT rows (which read the
+// server's send-time `meta.sender_prefix` snapshot), left standing on the
+// record rows.
+//
+// Why this needs a real stack, and what would go green without it:
+//   1. the unit test seeds the members store by hand. Only the live stack
+//      proves the store is genuinely populated by the SAME MODE the server
+//      relayed — the positive control below reads the glyph off the members
+//      pane, which is the store's other consumer.
+//   2. the members store is repopulated from a fresh NAMES on RELOAD, while
+//      the rows come back from persisted scrollback over REST. Those are two
+//      different doors, and a fix that only held while the live session was
+//      warm would pass the first half of this spec and fail the second.
+//
+// Platform note: the defect is a members-store read inside the row renderer,
+// with no touch, viewport or engine dependency, so desktop chromium IS the
+// defect's own platform rather than a proxy for it.
+//
+// Shape:
+//   1. an op peer founds a fresh per-run channel → the founder auto-ops (@)
+//   2. the operator (vjt-grappa) joins it, so cic witnesses what follows
+//   3. the subject peer joins  → a JOIN row, subject plain at that instant
+//   4. the subject peer parts  → a PART row, subject plain at that instant
+//   5. the subject peer rejoins and the op peer ops it → subject is @ NOW
+//   6. neither historical row may carry a glyph — live, and after a reload
+//
+// Parity matrix: UI shape contract, subject-shape-agnostic. Registered seed
+// (vjt + autojoin) suffices.
+
+import {
+  composeSend,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.setTimeout(120_000);
+
+test("issue 1950 — a historical join/part row keeps no glyph after the nick is opped", async ({
+  page,
+}) => {
+  // Per-run unique channel + peer nicks: a module-level constant makes the
+  // spec un-`--repeat-each`-able (a second pass would re-found a channel it
+  // already parted and race a 433 on the peer nicks).
+  const suffix = crypto.randomUUID().slice(0, 5);
+  const channel = `#s1950-${suffix}`;
+  const opNick = `o1950${suffix}`;
+  const subjectNick = `s1950${suffix}`;
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  // Focus the autojoin channel first to confirm login + WS-ready and mount
+  // the compose box before issuing the /join (issue240 boot order — after
+  // login cic lands on Home, which renders no ComposeBox).
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  const opPeer = await IrcPeer.connect({ nick: opNick });
+  let subject: IrcPeer | null = null;
+  try {
+    // The founding JOINer auto-ops on the testnet leaf (NO_CHANOPS_WHEN_SPLIT
+    // undef'd), so this peer holds @ and can op the subject later.
+    await opPeer.join(channel);
+
+    await composeSend(page, `/join ${channel}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    // The two record rows, both produced while the subject is a PLAIN member.
+    subject = await IrcPeer.connect({ nick: subjectNick });
+    await subject.join(channel);
+    const joinRows = scrollbackLine(page, "join", subjectNick);
+    await expect(joinRows).toHaveCount(1, { timeout: 15_000 });
+
+    await subject.part(channel, "issue 1950 — leaving plain");
+    const partRow = scrollbackLine(page, "part", subjectNick);
+    await expect(partRow).toHaveCount(1, { timeout: 15_000 });
+
+    // Now the trigger: the subject comes back and is opped. Everything the
+    // rows above describe already happened; nothing about them changed.
+    await subject.join(channel);
+    await expect(joinRows).toHaveCount(2, { timeout: 15_000 });
+    await opPeer.mode(channel, "+o", subjectNick);
+
+    // POSITIVE CONTROL — the members store really did take the `@`. Without
+    // it every "no glyph" assertion below would pass on an empty store, i.e.
+    // on nothing. The members pane is the store's other consumer, so this
+    // reads the same state `prefixFor` used to read.
+    const memberGlyph = page
+      .locator(".members-pane .member-name", { hasText: subjectNick })
+      .locator(".nick-prefix");
+    await expect(memberGlyph).toHaveText("@", { timeout: 15_000 });
+
+    // LIVE: `prefixFor` is read inside a JSX prop, so Solid re-runs it when
+    // the members signal changes — pre-fix the rows re-prefix in place, with
+    // no reload needed.
+    await expect(joinRows.locator(".nick-prefix")).toHaveCount(0);
+    await expect(partRow.locator(".nick-prefix")).toHaveCount(0);
+
+    // RELOADED: the rows now arrive from persisted scrollback over REST and
+    // the members store from a fresh NAMES. Different doors, same contract.
+    await page.reload();
+    await expect(page.locator(".sidebar-network-header").first()).toBeVisible({ timeout: 10_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    await expect(memberGlyph).toHaveText("@", { timeout: 15_000 });
+    await expect(joinRows).toHaveCount(2, { timeout: 15_000 });
+    await expect(joinRows.locator(".nick-prefix")).toHaveCount(0);
+    await expect(partRow).toHaveCount(1);
+    await expect(partRow.locator(".nick-prefix")).toHaveCount(0);
+  } finally {
+    if (subject) await subject.disconnect("issue1950 done");
+    await opPeer.disconnect("issue1950 done");
+    // `/join` persists the channel into vjt's autojoin set; PART restores
+    // pre-test state. Idempotent — swallow 404 if the test bailed early.
+    await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue1950-record-row-no-live-glyph.spec.ts
+++ b/cicchetto/e2e/tests/issue1950-record-row-no-live-glyph.spec.ts
@@ -166,7 +166,18 @@ test("issue 1950 — a historical join/part row keeps no glyph after the nick is
 // chanop, so a setter who lacks the grade cannot normally produce the row at
 // all. The reporter could because he is Azzurra staff — the earlier field
 // line shows `mezmerize@staff.azzurra.chat`. The testnet is the SAME ircd
-// (bahamut), so the spec buys the same standing the same way, with /OPER.
+// (bahamut), so the spec buys the same standing the same way, out of band.
+//
+// 🔴 THE JOIN ORDER IS MATERIAL — do not "fix" a red here by making `staff`
+// join first. Sixteen of the suite's seventeen `.mode()` sites have their
+// peer join first because that is how a peer gets chanop on this testnet
+// (auto-op, `NO_CHANOPS_WHEN_SPLIT` deleted from the image), and copying
+// that shape here would silently delete the scenario: a `staff` who joined
+// first ALREADY holds `@` when the row is written, and the row would then be
+// bare-vs-decorated for a reason the reporter's line is not about. The
+// assertion is not "a mode row is bare"; it is "a mode row is bare EVEN
+// WHEN its setter demonstrably could not have held the glyph at the time".
+// Joining second is what makes the second clause true, so it stays.
 test("issue 1950 — the mode row that grants an op renders its setter bare", async ({ page }) => {
   const suffix = crypto.randomUUID().slice(0, 5);
   const channel = `#m1950-${suffix}`;
@@ -194,10 +205,18 @@ test("issue 1950 — the mode row that grants an op renders its setter bare", as
     await staff.join(channel);
     await expect(scrollbackLine(page, "join", staffNick)).toHaveCount(1, { timeout: 15_000 });
 
-    // The self-op. `IrcPeer.mode` awaits this peer's OWN echo, so a refused
-    // override fails as a named MODE timeout rather than a silent skip.
+    // The self-op, through the only door bahamut leaves open to a member
+    // who is not chanop. Plain MODE is NOT that door and never can be:
+    // `m_mode` gates override on `(IsSAdmin || IsAdmin) && !MyClient(sptr)`,
+    // and a peer connected to this very leaf IS MyClient — so /OPER alone
+    // earns a 482 and a fixture timeout. SAMODE has no such conjunct; it
+    // wants `IsPrivileged` (the /OPER) plus `IsAdmin` (umode `+A`, which
+    // sticks because the leaf's O: line carries the `A` oflag). All three
+    // steps await their own echo, so whichever one a config change breaks
+    // fails by name instead of surfacing as a mystery MODE timeout.
     await staff.oper(OPER_NAME, OPER_PASS);
-    await staff.mode(channel, "+o", staffNick);
+    await staff.umode("+A");
+    await staff.samode(channel, "+o", staffNick);
 
     // POSITIVE CONTROL — the members store really did take the `@`. Without
     // it the absence below would be the absence of nothing. The members pane

--- a/cicchetto/e2e/tests/issue1950-record-row-no-live-glyph.spec.ts
+++ b/cicchetto/e2e/tests/issue1950-record-row-no-live-glyph.spec.ts
@@ -30,13 +30,20 @@
 // with no touch, viewport or engine dependency, so desktop chromium IS the
 // defect's own platform rather than a proxy for it.
 //
-// Shape:
+// Two tests, one contract, because the rows reach the glyph by two different
+// arguments and each needs its own fixture.
+//
+// Shape (presence rows):
 //   1. an op peer founds a fresh per-run channel → the founder auto-ops (@)
 //   2. the operator (vjt-grappa) joins it, so cic witnesses what follows
 //   3. the subject peer joins  → a JOIN row, subject plain at that instant
 //   4. the subject peer parts  → a PART row, subject plain at that instant
 //   5. the subject peer rejoins and the op peer ops it → subject is @ NOW
 //   6. neither historical row may carry a glyph — live, and after a reload
+//
+// Shape (the `mode` row — see the second test's own header for WHY it needed
+// /OPER to build): a plain member self-ops, and the row that GRANTS the `@`
+// must not be painted with it.
 //
 // Parity matrix: UI shape contract, subject-shape-agnostic. Registered seed
 // (vjt + autojoin) suffices.
@@ -54,6 +61,14 @@ import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
 test.setTimeout(120_000);
+
+// Testnet O: line — `conf.leaf*.tmpl` interpolates OPER_NICK / OPER_PASS,
+// whose compose defaults are these. Local constants, matching the two specs
+// that already need them (issue367, issue554); they are triplicated now and
+// belong in `seedData`, but hoisting them would edit two specs this change
+// has no business touching.
+const OPER_NAME = "testoper";
+const OPER_PASS = "testoperpass";
 
 test("issue 1950 — a historical join/part row keeps no glyph after the nick is opped", async ({
   page,
@@ -131,6 +146,88 @@ test("issue 1950 — a historical join/part row keeps no glyph after the nick is
     await opPeer.disconnect("issue1950 done");
     // `/join` persists the channel into vjt's autojoin set; PART restores
     // pre-test state. Idempotent — swallow 404 if the test bailed early.
+    await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+  }
+});
+
+// The `mode` row was the last carve-out, argued as honest because "its subject
+// IS the grade change". The reporter closed it with a line that refutes itself
+// without any knowledge of the channel's history:
+//
+//     20:58:09 * @Mezmerize sets mode +o Mezmerize on #grappa
+//
+// Setter and target are the same nick, so the `@` the setter is painted with
+// is the one THIS LINE grants — it provably was not held when the event
+// happened. Every other `mode` row has the same defect, just without the
+// self-evidence: a setter deopped since reads plain on the line where they
+// were opping people.
+//
+// Why this reproduces here and not on a plain channel op: setting `+o` needs
+// chanop, so a setter who lacks the grade cannot normally produce the row at
+// all. The reporter could because he is Azzurra staff — the earlier field
+// line shows `mezmerize@staff.azzurra.chat`. The testnet is the SAME ircd
+// (bahamut), so the spec buys the same standing the same way, with /OPER.
+test("issue 1950 — the mode row that grants an op renders its setter bare", async ({ page }) => {
+  const suffix = crypto.randomUUID().slice(0, 5);
+  const channel = `#m1950-${suffix}`;
+  const founderNick = `m1950f${suffix}`;
+  const staffNick = `m1950s${suffix}`;
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  // Someone has to hold the channel open while cic joins; the founding JOINer
+  // auto-ops on the testnet leaf (the image drops `NO_CHANOPS_WHEN_SPLIT`).
+  // This peer never sets a mode — it exists so the channel is not empty.
+  const founder = await IrcPeer.connect({ nick: founderNick });
+  let staff: IrcPeer | null = null;
+  try {
+    await founder.join(channel);
+
+    await composeSend(page, `/join ${channel}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    // Joins SECOND, so it is a PLAIN member — the whole premise of the repro.
+    staff = await IrcPeer.connect({ nick: staffNick });
+    await staff.join(channel);
+    await expect(scrollbackLine(page, "join", staffNick)).toHaveCount(1, { timeout: 15_000 });
+
+    // The self-op. `IrcPeer.mode` awaits this peer's OWN echo, so a refused
+    // override fails as a named MODE timeout rather than a silent skip.
+    await staff.oper(OPER_NAME, OPER_PASS);
+    await staff.mode(channel, "+o", staffNick);
+
+    // POSITIVE CONTROL — the members store really did take the `@`. Without
+    // it the absence below would be the absence of nothing. The members pane
+    // is the store's other consumer, and the one surface where a CURRENT
+    // grade is the right thing to show.
+    const memberGlyph = page
+      .locator(".members-pane .member-name", { hasText: staffNick })
+      .locator(".nick-prefix");
+    await expect(memberGlyph).toHaveText("@", { timeout: 15_000 });
+
+    // The row this very MODE produced. Matching on the mode text as well as
+    // the nick keeps it off the founder's own join-time channel modes.
+    const modeRow = scrollbackLine(page, "mode", new RegExp(`sets mode \\+o ${staffNick}\\b`));
+    await expect(modeRow).toHaveCount(1, { timeout: 15_000 });
+    await expect(modeRow.locator(".nick-prefix")).toHaveCount(0);
+
+    // RELOADED: the row now arrives from persisted scrollback over REST and
+    // the members store from a fresh NAMES. Different doors, same contract —
+    // and the control has to hold on the far side too, or the reloaded
+    // absence is once again an absence of nothing.
+    await page.reload();
+    await expect(page.locator(".sidebar-network-header").first()).toBeVisible({ timeout: 10_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    await expect(memberGlyph).toHaveText("@", { timeout: 15_000 });
+    await expect(modeRow).toHaveCount(1, { timeout: 15_000 });
+    await expect(modeRow.locator(".nick-prefix")).toHaveCount(0);
+  } finally {
+    if (staff) await staff.disconnect("issue1950 mode done");
+    await founder.disconnect("issue1950 mode done");
     await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
   }
 });

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -82,7 +82,7 @@ import { SERVER_WINDOW_NAME, type WindowKind } from "./lib/windowKinds";
 import MessageContextMenu from "./MessageContextMenu";
 import { MircBody } from "./MircText";
 import NextActiveButton from "./NextActiveButton";
-import NickText from "./NickText";
+import NickText, { type PrefixGlyph } from "./NickText";
 import PeerAwayBanner from "./PeerAwayBanner";
 import UserContextMenu from "./UserContextMenu";
 import WhoisCard from "./WhoisCard";
@@ -718,9 +718,21 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   // a row persisted before #25 landed) renders no glyph — never a
   // live-derived guess, which would reintroduce the bug.
   //
-  // Everything else — presence-row senders (join/part/quit/mode) and the
-  // kick TARGET — keeps the live members join: those describe a "now"
-  // event, not a frozen send, so the current grade is the correct glyph.
+  // #1950 narrowed what is left. The live members join used to cover every
+  // non-content row on the rationale that those describe a "now" event — but
+  // a scrollback row is never "now", it is a RECORD, and re-deriving the
+  // glyph at render time re-prefixed a nick's own history the moment they
+  // were opped. `join` was the plainest case (JOIN carries no grade on the
+  // wire at all, so `@nick has joined` cannot ever have been true) and the
+  // field report `* @ULIAK [...] has quit (...)` was the same defect on a
+  // `quit`. Those rows now go through `recordSenderSpan` and take no glyph;
+  // see its comment for the set and for what stays live.
+  //
+  // What still reads live here: `mode` (its subject IS the grade), the
+  // `server_event` / `renderRawEvent` senders (WALLOPS/GLOBOPS/KILL/CHGHOST/
+  // INVITE — server-scoped rows whose sender is usually not a channel member
+  // at all, left untouched by #1950), and `action`, which is a CONTENT kind
+  // and so takes the snapshot branch above.
   const prefixFor = (nick: string): "@" | "%" | "+" | "" => {
     if (!msg.channel) return "";
     const casemapping = casemappingForSlug(handlers.networkSlug);
@@ -754,20 +766,48 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
     </button>
   );
 
-  // Variant used by `renderRawEvent` (WALLOPS/GLOBOPS/KILL/CHGHOST/
-  // INVITE) — no surrounding brackets, just the colored nick. Kept as
-  // a separate closure so the bracket-vs-bare distinction is explicit
-  // at the call site (no magic-default-arg).
-  const bareSenderSpan = (nick: string): JSX.Element => (
+  // Bracket-less variant of `senderSpan` — just the colored nick. Kept as a
+  // separate closure so the bracket-vs-bare distinction is explicit at the
+  // call site (no magic-default-arg).
+  //
+  // #1950 split it in two along that same rule: the glyph is a PARAMETER of
+  // the shared button, never a default, so each call site has to say which
+  // reading of the grade it wants. One button definition, two named readings.
+  const bareSpanWithPrefix = (nick: string, prefix: PrefixGlyph): JSX.Element => (
     <button
       type="button"
       class="scrollback-sender scrollback-inline-button nick-clickable"
       onClick={() => handlers.onNickClick(nick)}
       onContextMenu={(e: MouseEvent) => handlers.onNickContextMenu(nick, e)}
     >
-      <NickText nick={nick} prefix={prefixFor(nick)} />
+      <NickText nick={nick} prefix={prefix} />
     </button>
   );
+
+  // LIVE reading — the sender's grade as of this render. Used by
+  // `renderRawEvent` (WALLOPS/GLOBOPS/KILL/CHGHOST/INVITE), `server_event`
+  // and `mode`; `action` routes here too and lands on the #25 snapshot
+  // branch inside `prefixFor` because it is a CONTENT kind.
+  const bareSenderSpan = (nick: string): JSX.Element => bareSpanWithPrefix(nick, prefixFor(nick));
+
+  // #1950 — RECORD reading: no glyph at all.
+  //
+  // A record row (join / part / quit / nick_change / topic / kick, sender
+  // AND kick victim) reports an event at an instant that has passed. Reading
+  // the members store there answers "what grade does this nick hold NOW",
+  // which is a different question and re-prefixes the row retroactively the
+  // moment the nick is opped — the bug #25 removed from content rows.
+  //
+  // And the answer is NOT a snapshot: for a `join` there is nothing to
+  // snapshot, since JOIN carries no grade on the wire (the `@` always
+  // arrives afterwards in a separate MODE, from a human op or ChanServ
+  // auto-op), and a kick victim is out of the channel by definition. Where
+  // the event has no grade, the correct glyph is none.
+  //
+  // `mode` deliberately keeps the live reading: a mode row's whole subject
+  // is the grade, so the sender's current status is the honest thing to show
+  // and there is no retroactivity to remove.
+  const recordSenderSpan = (nick: string): JSX.Element => bareSpanWithPrefix(nick, "");
 
   switch (msg.kind) {
     case "privmsg": {
@@ -919,7 +959,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
     case "join":
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)}
+          * {recordSenderSpan(msg.sender)}
           {userhostSuffix(msg)} has joined {msg.channel}
         </span>
       );
@@ -927,7 +967,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       const reason = reasonOf(msg);
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)}
+          * {recordSenderSpan(msg.sender)}
           {userhostSuffix(msg)} has left {msg.channel}
           {reasonSuffix(reason)}
         </span>
@@ -937,7 +977,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       const reason = reasonOf(msg);
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)}
+          * {recordSenderSpan(msg.sender)}
           {userhostSuffix(msg)} has quit{reasonSuffix(reason)}
         </span>
       );
@@ -946,7 +986,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       const newNick = typeof msg.meta.new_nick === "string" ? msg.meta.new_nick : "?";
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)} is now known as <NickText nick={newNick} />
+          * {recordSenderSpan(msg.sender)} is now known as <NickText nick={newNick} />
         </span>
       );
     }
@@ -989,12 +1029,13 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // reached with an "undefined" to print.
       if (hasNoTopic(msg.body)) {
         return (
-          <span class="scrollback-body">* {bareSenderSpan(msg.sender)} cleared the topic</span>
+          <span class="scrollback-body">* {recordSenderSpan(msg.sender)} cleared the topic</span>
         );
       }
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)} changed topic: <MircBody body={msg.body ?? ""} emphasis />
+          * {recordSenderSpan(msg.sender)} changed topic:{" "}
+          <MircBody body={msg.body ?? ""} emphasis />
         </span>
       );
     case "kick": {
@@ -1002,8 +1043,8 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       const reason = reasonOf(msg);
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)} kicked{" "}
-          <NickText nick={target} prefix={prefixFor(target)} /> from {msg.channel}
+          * {recordSenderSpan(msg.sender)} kicked <NickText nick={target} prefix="" /> from{" "}
+          {msg.channel}
           {reasonSuffix(reason)}
         </span>
       );

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -42,7 +42,7 @@ import { bindMessageContextMenu } from "./lib/messageContextMenu";
 import { bindMessageGestures } from "./lib/messageGestures";
 import { closeMessageMenu, openMessageMenu } from "./lib/messageMenu";
 import { networkIdBySlug, networks, user } from "./lib/networks";
-import { senderPrefix, snapshotSenderPrefix } from "./lib/nickColor";
+import { snapshotSenderPrefix } from "./lib/nickColor";
 import { nickEquals } from "./lib/nickEquals";
 import { isOperatorActionEcho } from "./lib/operatorActionEcho";
 import { overlayCount } from "./lib/overlayScrollLock";
@@ -718,29 +718,45 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   // a row persisted before #25 landed) renders no glyph — never a
   // live-derived guess, which would reintroduce the bug.
   //
-  // #1950 narrowed what is left. The live members join used to cover every
+  // #1950 removed the rest of it. The live members join used to cover every
   // non-content row on the rationale that those describe a "now" event — but
   // a scrollback row is never "now", it is a RECORD, and re-deriving the
   // glyph at render time re-prefixed a nick's own history the moment they
   // were opped. `join` was the plainest case (JOIN carries no grade on the
   // wire at all, so `@nick has joined` cannot ever have been true) and the
   // field report `* @ULIAK [...] has quit (...)` was the same defect on a
-  // `quit`. Those rows now go through `recordSenderSpan` and take no glyph;
-  // see its comment for the set and for what stays live.
+  // `quit`.
   //
-  // What still reads live here: `mode` (its subject IS the grade), the
-  // `server_event` / `renderRawEvent` senders (WALLOPS/GLOBOPS/KILL/CHGHOST/
-  // INVITE — server-scoped rows whose sender is usually not a channel member
-  // at all, left untouched by #1950), and `action`, which is a CONTENT kind
-  // and so takes the snapshot branch above.
-  const prefixFor = (nick: string): "@" | "%" | "+" | "" => {
+  // `mode` was argued as the one honest survivor and it fell to a repro that
+  // refutes itself: `* @Mezmerize sets mode +o Mezmerize on #grappa`. The `@`
+  // is GRANTED by that line, so the setter demonstrably did not hold it when
+  // the event happened. Nothing about a `mode` row is exempt — it records who
+  // set the mode THEN, so a setter deopped since reads plain on the line where
+  // they were opping people, and one opped since reads `@` on a line from when
+  // they were not.
+  //
+  // So this is now total, and the totality is what makes it a rule rather than
+  // a list: **the only glyph a scrollback row may carry is the #25 snapshot on
+  // a CONTENT row.** There is no live members read left in this module. Two
+  // arms used to be safe by ACCIDENT rather than by rule and are now safe by
+  // rule — measured, both were red before this change:
+  //
+  //   * the #154(b) user-MODE row on the synthetic `$server` window: no member
+  //     list exists for that key, so the live read happened to return "";
+  //   * `renderRawEvent` / `server_event` (WALLOPS/GLOBOPS/KILL/CHGHOST/
+  //     INVITE), which land on `$server` for the same reason — except an
+  //     INVITE into a channel we are ALREADY in, which is keyed on that real
+  //     channel and did paint the inviter's live grade.
+  //
+  // The members list keeps the live reading, because it is the one surface
+  // where "now" is genuinely the subject.
+  const prefixFor = (nick: string): PrefixGlyph => {
     if (!msg.channel) return "";
     const casemapping = casemappingForSlug(handlers.networkSlug);
     if (isContentKind(msg.kind) && nickEquals(nick, msg.sender, casemapping)) {
       return snapshotSenderPrefix(msg.meta);
     }
-    const key = channelKey(handlers.networkSlug, msg.channel);
-    return senderPrefix(membersByChannel()[key], nick, casemapping);
+    return "";
   };
 
   // C7.6: sender button for content kinds — left-click (→ query) or
@@ -784,29 +800,30 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
     </button>
   );
 
-  // LIVE reading — the sender's grade as of this render. Used by
-  // `renderRawEvent` (WALLOPS/GLOBOPS/KILL/CHGHOST/INVITE), `server_event`
-  // and `mode`; `action` routes here too and lands on the #25 snapshot
-  // branch inside `prefixFor` because it is a CONTENT kind.
-  const bareSenderSpan = (nick: string): JSX.Element => bareSpanWithPrefix(nick, prefixFor(nick));
+  // CONTENT reading, bracket-less — the #25 send-time snapshot, for the one
+  // kind that renders without brackets: `action`. Routes through `prefixFor`,
+  // whose content branch is the only glyph source left in this module.
+  const contentSenderSpan = (nick: string): JSX.Element =>
+    bareSpanWithPrefix(nick, prefixFor(nick));
 
   // #1950 — RECORD reading: no glyph at all.
   //
-  // A record row (join / part / quit / nick_change / topic / kick, sender
-  // AND kick victim) reports an event at an instant that has passed. Reading
-  // the members store there answers "what grade does this nick hold NOW",
-  // which is a different question and re-prefixes the row retroactively the
-  // moment the nick is opped — the bug #25 removed from content rows.
+  // A record row reports an event at an instant that has passed. Reading the
+  // members store there answers "what grade does this nick hold NOW", which is
+  // a different question, and re-prefixes the row retroactively the moment the
+  // nick is opped — the bug #25 removed from content rows.
   //
   // And the answer is NOT a snapshot: for a `join` there is nothing to
-  // snapshot, since JOIN carries no grade on the wire (the `@` always
-  // arrives afterwards in a separate MODE, from a human op or ChanServ
-  // auto-op), and a kick victim is out of the channel by definition. Where
-  // the event has no grade, the correct glyph is none.
+  // snapshot, since JOIN carries no grade on the wire (the `@` always arrives
+  // afterwards in a separate MODE, from a human op or ChanServ auto-op), and a
+  // kick victim is out of the channel by definition. Where the event has no
+  // grade, the correct glyph is none.
   //
-  // `mode` deliberately keeps the live reading: a mode row's whole subject
-  // is the grade, so the sender's current status is the honest thing to show
-  // and there is no retroactivity to remove.
+  // The set is EVERY non-content row: join / part / quit / nick_change /
+  // topic / kick (sender AND victim) / mode — including the #154(b) user-MODE
+  // on `$server` — plus every `renderRawEvent` and `server_event` sender. That
+  // is the whole switch below except `action`, which is why the rule is stated
+  // here once instead of enumerated at each arm.
   const recordSenderSpan = (nick: string): JSX.Element => bareSpanWithPrefix(nick, "");
 
   switch (msg.kind) {
@@ -921,7 +938,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // render takes precedence when raw_verb is present.
       const meta = msg.meta as RawEvent | undefined;
       if (meta && typeof meta.raw_verb === "string") {
-        return renderRawEvent(meta, msg, bareSenderSpan, handlers);
+        return renderRawEvent(meta, msg, recordSenderSpan, handlers);
       }
       // #569 — numeric rows carry meta.numeric + meta.raw_params (no
       // raw_verb). Render the whole param list (own-nick dropped) so
@@ -952,7 +969,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
     case "action":
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)}{" "}
+          * {contentSenderSpan(msg.sender)}{" "}
           <MircBody body={stripCtcpAction(msg.body)} emphasis onChannelClick={onChannelClick} />
         </span>
       );
@@ -1004,14 +1021,14 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       if (msg.channel === SERVER_WINDOW_NAME) {
         return (
           <span class="scrollback-body">
-            * {bareSenderSpan(msg.sender)} sets user mode {modes}
+            * {recordSenderSpan(msg.sender)} sets user mode {modes}
             {args}
           </span>
         );
       }
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)} sets mode {modes}
+          * {recordSenderSpan(msg.sender)} sets mode {modes}
           {args} on {msg.channel}
         </span>
       );
@@ -1057,7 +1074,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // keeps its raw_verb fallback for cold-deploy backfill misses.
       const meta = msg.meta as RawEvent | undefined;
       if (meta && typeof meta.raw_verb === "string") {
-        return renderRawEvent(meta, msg, bareSenderSpan, handlers);
+        return renderRawEvent(meta, msg, recordSenderSpan, handlers);
       }
       // No raw_verb. This used to be described here as a server bug
       // rendered defensively; since issue 1832 it is also the ORDINARY
@@ -1073,7 +1090,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // banner keeps its colours).
       return (
         <span class="scrollback-body">
-          *** {bareSenderSpan(msg.sender)} <MircBody body={msg.body ?? ""} />
+          *** {recordSenderSpan(msg.sender)} <MircBody body={msg.body ?? ""} />
         </span>
       );
     }

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1641,24 +1641,45 @@ describe("ScrollbackPane", () => {
   // record rows. There is nothing to snapshot here: a record row's correct
   // glyph is always none.
   //
-  // `mode` is the one deliberate survivor — its subject IS the grade change,
-  // so the live read is the honest one — and its case below doubles as the
-  // POSITIVE CONTROL for the whole block: it proves this fixture really does
-  // carry `@`, so every absence asserted above is the absence of a glyph the
-  // store could have supplied, not of a glyph nobody had.
+  // `mode` was argued as a survivor — "its subject IS the grade change, so the
+  // live read is honest" — and the reporter closed that too, with a repro that
+  // refutes itself on its face:
+  //
+  //     20:58:09 * @Mezmerize sets mode +o Mezmerize on #grappa
+  //
+  // The `@` is being GRANTED by that very line, so the setter provably did not
+  // hold it when the event happened. No knowledge of the channel's history is
+  // needed to see the render is wrong. The general form is the same as every
+  // other record row: a `mode` row states who set the mode THEN, and painting
+  // the setter with their grade at render time re-prefixes history — someone
+  // deopped since reads plain on the line where they were opping people.
+  //
+  // So the perimeter is total: no live-derived glyph on ANY scrollback row,
+  // and `prefixFor` keeps only its #25 snapshot branch. Nothing is carved out,
+  // which is why the raw-event arms are pinned here too — including the one
+  // case where their live read produced a visible glyph rather than "" by
+  // construction (an INVITE into a channel we are already in).
   describe("#1950 record rows carry no live-derived mode glyph", () => {
     // channelKey is mocked to `${slug} ${name}`.
     const RECORD_KEY = "freenode #glyph" as ChannelKey;
+    const SERVER_KEY = "freenode $server" as ChannelKey;
 
     // Three members — far below LARGE_CHANNEL_THRESHOLD, so the #222 presence
     // filter leaves join/part/quit/nick_change rendered with the pref unset.
     // `alice` and `carol` hold @ RIGHT NOW; that is the whole premise.
+    //
+    // The `$server` entry is DELIBERATELY unrealistic — a synthetic server
+    // window has no member list, which is exactly why the user-MODE arm used
+    // to be safe by accident rather than by rule. Seeding one is what makes
+    // that case's assertion falsifiable instead of vacuous: it proves the arm
+    // cannot read the store even when the store has something to say.
     const oppedMembers = () => ({
       [RECORD_KEY]: [
         { nick: "alice", modes: ["@"] },
         { nick: "carol", modes: ["@"] },
         { nick: "dave", modes: [] },
       ],
+      [SERVER_KEY]: [{ nick: "alice", modes: ["@"] }],
     });
 
     const recordRow = (
@@ -1676,43 +1697,115 @@ describe("ScrollbackPane", () => {
       ...extra,
     });
 
-    const renderRow = (msg: ScrollbackMessage): HTMLElement => {
+    const renderRow = (msg: ScrollbackMessage, channelName: string): HTMLElement => {
       mockMembersByChannel.mockReturnValue(oppedMembers());
-      setScrollback({ [RECORD_KEY]: [msg] });
-      render(() => <ScrollbackPane networkSlug="freenode" channelName="#glyph" kind="channel" />);
+      setScrollback({ [`freenode ${channelName}` as ChannelKey]: [msg] });
+      render(() => (
+        <ScrollbackPane networkSlug="freenode" channelName={channelName} kind="channel" />
+      ));
       return screen.getByTestId("scrollback-line");
     };
 
     afterEach(() => {
       clearChannelPresencePref(RECORD_KEY);
+      clearChannelPresencePref(SERVER_KEY);
       setScrollback({});
     });
 
-    const cases: { name: string; msg: ScrollbackMessage }[] = [
-      { name: "join", msg: recordRow("join", {}) },
-      { name: "part", msg: recordRow("part", { body: "brb" }) },
-      { name: "quit", msg: recordRow("quit", { body: "Read/Dead Error: Input/output error" }) },
-      { name: "nick_change", msg: recordRow("nick_change", { meta: { new_nick: "alice2" } }) },
-      { name: "topic", msg: recordRow("topic", { body: "the new topic" }) },
+    const cases: { name: string; channelName: string; msg: ScrollbackMessage }[] = [
+      { name: "join", channelName: "#glyph", msg: recordRow("join", {}) },
+      { name: "part", channelName: "#glyph", msg: recordRow("part", { body: "brb" }) },
+      {
+        name: "quit",
+        channelName: "#glyph",
+        msg: recordRow("quit", { body: "Read/Dead Error: Input/output error" }),
+      },
+      {
+        name: "nick_change",
+        channelName: "#glyph",
+        msg: recordRow("nick_change", { meta: { new_nick: "alice2" } }),
+      },
+      { name: "topic", channelName: "#glyph", msg: recordRow("topic", { body: "the new topic" }) },
       // `kick` carries TWO live glyphs — the kicker through the sender span
       // and the VICTIM through its own NickText. A victim is out of the
       // channel the instant the event lands, so an `@` on them can only have
       // come from a later rejoin-and-reop. Both must be gone.
-      { name: "kick", msg: recordRow("kick", { sender: "carol", meta: { target: "alice" } }) },
+      {
+        name: "kick",
+        channelName: "#glyph",
+        msg: recordRow("kick", { sender: "carol", meta: { target: "alice" } }),
+      },
+      // A channel MODE set by someone who holds @ now. Even where the live
+      // glyph happens to be TRUE, it is still derived from "now" on a row that
+      // reports "then" — the contract is about the derivation, not the value.
+      {
+        name: "mode (channel)",
+        channelName: "#glyph",
+        msg: recordRow("mode", { meta: { modes: "+o", args: ["dave"] } }),
+      },
+      // The reporter's own line: `* @Mezmerize sets mode +o Mezmerize`. Setter
+      // and target are one nick, so the row itself is the evidence the setter
+      // held nothing at the time — the `@` is what this line grants.
+      {
+        name: "mode (self-op — the row that grants the glyph it was painted with)",
+        channelName: "#glyph",
+        msg: recordRow("mode", { meta: { modes: "+o", args: ["alice"] } }),
+      },
+      // #154(b) user-MODE on the synthetic server window. Its live read
+      // returned "" only because a `$server` key is never populated; with the
+      // key seeded above, the OLD code paints an `@` on a row that has no
+      // channel grade to speak of at all.
+      {
+        name: "mode (user mode on $server)",
+        channelName: "$server",
+        msg: recordRow("mode", { channel: "$server", meta: { modes: "+i" } }),
+      },
+      // The raw-event residual this fix retires: an INVITE persisted on a
+      // channel we are ALREADY in, so `membersByChannel()` DOES have an entry
+      // and the inviter's live grade reached the row. Every other raw verb
+      // lands on `$server` and returned "" by construction — which is an
+      // accident of routing, not a rule, and is why the rule now lives in
+      // `prefixFor` instead.
+      {
+        name: "server_event INVITE into a channel we are already in",
+        channelName: "#glyph",
+        msg: recordRow("server_event", {
+          sender: "carol",
+          meta: { raw_verb: "INVITE", raw_sender: "carol", raw_params: ["grappa", "#glyph"] },
+        }),
+      },
     ];
 
-    for (const { name, msg } of cases) {
+    for (const { name, channelName, msg } of cases) {
       it(`renders a ${name} row with no mode glyph although the nick holds @ now`, () => {
-        const line = renderRow(msg);
+        const line = renderRow(msg, channelName);
+        // The row rendered and names the nick — otherwise the absence below
+        // would be the absence of a row, not the absence of a glyph.
+        expect(line.textContent).toContain(msg.sender);
         expect(line.querySelectorAll(".nick-prefix")).toHaveLength(0);
       });
     }
 
-    it("POSITIVE CONTROL — a mode row still takes the live glyph from that same fixture", () => {
-      const line = renderRow(recordRow("mode", { meta: { modes: "+o", args: ["dave"] } }));
-      const glyph = line.querySelector(".scrollback-sender .nick-prefix");
-      expect(glyph).not.toBeNull();
-      expect(glyph?.textContent).toBe("@");
+    // The block's own positive control. It can no longer be a `mode` row —
+    // that row is now one of the absences — so it is the ONE glyph path this
+    // fix deliberately leaves standing: #25's send-time snapshot on a CONTENT
+    // row, rendered through the same component, the same fixture and the same
+    // `.nick-prefix` selector the ten assertions above read.
+    //
+    // What it proves: a glyph CAN reach the DOM here, so those ten absences
+    // are not an artefact of a mocked-away NickText or a stale selector.
+    // What it does NOT prove: that the LIVE store would have supplied one —
+    // after this fix nothing in the module reads it, so no in-block assertion
+    // can. That half is carried by the pre-fix RED measurement recorded in
+    // the commit body, which is the only place it can honestly live.
+    it("POSITIVE CONTROL — a content row still shows its #25 snapshot glyph here", () => {
+      const line = renderRow(
+        recordRow("privmsg", { body: "hello", meta: { sender_prefix: "@" } }),
+        "#glyph",
+      );
+      const glyphs = line.querySelectorAll(".scrollback-sender .nick-prefix");
+      expect(glyphs).toHaveLength(1);
+      expect(glyphs[0]?.textContent).toBe("@");
     });
   });
 

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1623,6 +1623,99 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #1950 — a scrollback row is a RECORD of a past event, never a view of
+  // "now", so no nick on one may take its glyph from the LIVE members store.
+  //
+  // `prefixFor`'s live branch re-derived the glyph at every render, so a nick
+  // opped AFTER the event retroactively re-prefixed their own history. On a
+  // `join` it states something that cannot ever have been true — JOIN carries
+  // no grade on the wire; the `@` arrives later in a separate MODE — and
+  // anyone with ChanServ auto-op reads every one of their own joins as
+  // `@nick`. On a `part`/`quit`/`kick` the row was reported in the field as
+  // `* @ULIAK [...] has quit (...)`, which is the same defect wearing the
+  // "they were still in the store" mask: any later re-render of that row,
+  // after the nick rejoined and was re-opped, re-prefixes it.
+  //
+  // This is exactly the class #25 removed from CONTENT rows (which read the
+  // server's send-time `meta.sender_prefix` snapshot), left standing on the
+  // record rows. There is nothing to snapshot here: a record row's correct
+  // glyph is always none.
+  //
+  // `mode` is the one deliberate survivor — its subject IS the grade change,
+  // so the live read is the honest one — and its case below doubles as the
+  // POSITIVE CONTROL for the whole block: it proves this fixture really does
+  // carry `@`, so every absence asserted above is the absence of a glyph the
+  // store could have supplied, not of a glyph nobody had.
+  describe("#1950 record rows carry no live-derived mode glyph", () => {
+    // channelKey is mocked to `${slug} ${name}`.
+    const RECORD_KEY = "freenode #glyph" as ChannelKey;
+
+    // Three members — far below LARGE_CHANNEL_THRESHOLD, so the #222 presence
+    // filter leaves join/part/quit/nick_change rendered with the pref unset.
+    // `alice` and `carol` hold @ RIGHT NOW; that is the whole premise.
+    const oppedMembers = () => ({
+      [RECORD_KEY]: [
+        { nick: "alice", modes: ["@"] },
+        { nick: "carol", modes: ["@"] },
+        { nick: "dave", modes: [] },
+      ],
+    });
+
+    const recordRow = (
+      kind: ScrollbackMessage["kind"],
+      extra: Partial<ScrollbackMessage>,
+    ): ScrollbackMessage => ({
+      id: 1,
+      network: "freenode",
+      channel: "#glyph",
+      server_time: 1_700_000_000_000,
+      kind,
+      sender: "alice",
+      body: null,
+      meta: {},
+      ...extra,
+    });
+
+    const renderRow = (msg: ScrollbackMessage): HTMLElement => {
+      mockMembersByChannel.mockReturnValue(oppedMembers());
+      setScrollback({ [RECORD_KEY]: [msg] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#glyph" kind="channel" />);
+      return screen.getByTestId("scrollback-line");
+    };
+
+    afterEach(() => {
+      clearChannelPresencePref(RECORD_KEY);
+      setScrollback({});
+    });
+
+    const cases: { name: string; msg: ScrollbackMessage }[] = [
+      { name: "join", msg: recordRow("join", {}) },
+      { name: "part", msg: recordRow("part", { body: "brb" }) },
+      { name: "quit", msg: recordRow("quit", { body: "Read/Dead Error: Input/output error" }) },
+      { name: "nick_change", msg: recordRow("nick_change", { meta: { new_nick: "alice2" } }) },
+      { name: "topic", msg: recordRow("topic", { body: "the new topic" }) },
+      // `kick` carries TWO live glyphs — the kicker through the sender span
+      // and the VICTIM through its own NickText. A victim is out of the
+      // channel the instant the event lands, so an `@` on them can only have
+      // come from a later rejoin-and-reop. Both must be gone.
+      { name: "kick", msg: recordRow("kick", { sender: "carol", meta: { target: "alice" } }) },
+    ];
+
+    for (const { name, msg } of cases) {
+      it(`renders a ${name} row with no mode glyph although the nick holds @ now`, () => {
+        const line = renderRow(msg);
+        expect(line.querySelectorAll(".nick-prefix")).toHaveLength(0);
+      });
+    }
+
+    it("POSITIVE CONTROL — a mode row still takes the live glyph from that same fixture", () => {
+      const line = renderRow(recordRow("mode", { meta: { modes: "+o", args: ["dave"] } }));
+      const glyph = line.querySelector(".scrollback-sender .nick-prefix");
+      expect(glyph).not.toBeNull();
+      expect(glyph?.textContent).toBe("@");
+    });
+  });
+
   // C7.2: Muted-events rendering.
   describe("muted-event rendering (C7.2)", () => {
     it("applies .scrollback-muted class to JOIN events", () => {

--- a/cicchetto/src/__tests__/nickColor.test.ts
+++ b/cicchetto/src/__tests__/nickColor.test.ts
@@ -1,11 +1,9 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import type { ChannelMembers } from "../lib/memberTypes";
 import {
   NICK_PALETTE_SIZE,
   nickColorIndex,
   nickColorVar,
-  senderPrefix,
   snapshotSenderPrefix,
 } from "../lib/nickColor";
 
@@ -148,46 +146,6 @@ describe("nickColorVar", () => {
   it("agrees with nickColorIndex for the embedded index", () => {
     const idx = nickColorIndex("vjt");
     expect(nickColorVar("vjt")).toBe(`var(--nick-color-${idx})`);
-  });
-});
-
-describe("senderPrefix", () => {
-  const m = (entries: Record<string, string[]>): ChannelMembers =>
-    Object.entries(entries).map(([nick, modes]) => ({ nick, modes }));
-
-  it("returns @ for an op", () => {
-    expect(senderPrefix(m({ alice: ["@"] }), "alice", "ascii")).toBe("@");
-  });
-
-  it("returns % for a halfop", () => {
-    expect(senderPrefix(m({ bob: ["%"] }), "bob", "ascii")).toBe("%");
-  });
-
-  it("returns + for a voiced member", () => {
-    expect(senderPrefix(m({ carol: ["+"] }), "carol", "ascii")).toBe("+");
-  });
-
-  it("returns empty string for a plain member", () => {
-    expect(senderPrefix(m({ dave: [] }), "dave", "ascii")).toBe("");
-  });
-
-  it("returns empty string for a non-member (sender from a different channel)", () => {
-    expect(senderPrefix(m({ alice: ["@"] }), "stranger", "ascii")).toBe("");
-  });
-
-  it("returns empty string when members list is undefined (unknown channel)", () => {
-    expect(senderPrefix(undefined, "alice", "ascii")).toBe("");
-  });
-
-  it("returns the HIGHEST precedence prefix when a member has multiple modes (@ > % > +)", () => {
-    expect(senderPrefix(m({ alice: ["@", "+"] }), "alice", "ascii")).toBe("@");
-    expect(senderPrefix(m({ bob: ["%", "+"] }), "bob", "ascii")).toBe("%");
-    expect(senderPrefix(m({ carol: ["+"] }), "carol", "ascii")).toBe("+");
-  });
-
-  it("is case-insensitive for the nick lookup (Alice/alice match)", () => {
-    expect(senderPrefix(m({ Alice: ["@"] }), "alice", "ascii")).toBe("@");
-    expect(senderPrefix(m({ alice: ["@"] }), "Alice", "ascii")).toBe("@");
   });
 });
 

--- a/cicchetto/src/lib/nickColor.ts
+++ b/cicchetto/src/lib/nickColor.ts
@@ -1,6 +1,4 @@
-import type { Casemapping } from "./isupport";
-import type { ChannelMembers } from "./memberTypes";
-import { asciiFold, nickEquals } from "./nickEquals";
+import { asciiFold } from "./nickEquals";
 
 // UX-5 bucket BC2 — colored nicks (xchat-style) + scrollback-side
 // mode-prefix glyph lookup.
@@ -74,20 +72,29 @@ import { asciiFold, nickEquals } from "./nickEquals";
 //
 // ## Scrollback sender prefix
 //
-// Members-pane nicks already carry the prefix via `memberSigil`
-// (op `@`, halfop `%`, voiced `+`, plain ` `). Scrollback PRIVMSG
-// senders are bare `{nick}` interpolations — no per-message mode
-// flag on the wire (scrollback `messages` table is mode-agnostic;
-// modes belong to the live members store). The `senderPrefix`
-// helper looks up the CURRENT membership for (channel, nick) and
-// returns the highest-precedence prefix glyph for inline render in
-// `<sender>` / `*sender` lines.
+// Members-pane nicks carry the CURRENT prefix via `memberSigil` (op `@`,
+// halfop `%`, voiced `+`, plain ` `), and that pane is the only surface
+// where a live grade belongs — "now" is genuinely its subject.
 //
-// Returns empty string `""` (not " ") for plain / unknown members:
-// scrollback senders live inside `<...>` brackets and any space
-// would render as `< nick>` with a visible gap. The members-pane
-// padding-space (`memberSigil` returns " ") only makes sense in a
-// column layout where prefix-aligned glyphs share width.
+// A scrollback row is not. It is a RECORD of a past event, so the only
+// glyph it may show is `snapshotSenderPrefix` below: the grade the SERVER
+// captured at send time into `meta.sender_prefix`, on a CONTENT row.
+//
+// #1950 deleted this module's live counterpart, `senderPrefix(members,
+// nick, casemapping)`, which looked the grade up in the members store at
+// render time. Its last caller was `ScrollbackPane`'s `prefixFor`, and
+// re-deriving there re-prefixed a nick's own history the instant they were
+// opped — `* @nick has joined` (JOIN carries no grade on the wire at all),
+// `* @nick has quit`, and `* @nick sets mode +o nick`, a line that GRANTS
+// the `@` it was painted with. There is no correct use of a live members
+// read on a scrollback row, so the helper is gone rather than left
+// available: an exported function with no caller is an invitation.
+//
+// Returns empty string `""` (not " ") for a plain / unknown sender:
+// scrollback senders live inside `<...>` brackets and any space would
+// render as `< nick>` with a visible gap. The members-pane padding-space
+// (`memberSigil` returns " ") only makes sense in a column layout where
+// prefix-aligned glyphs share width.
 
 export const NICK_PALETTE_SIZE = 32;
 
@@ -115,24 +122,6 @@ export const nickColorIndex = (nick: string): number => {
 };
 
 export const nickColorVar = (nick: string): string => `var(--nick-color-${nickColorIndex(nick)})`;
-
-// Highest-precedence channel-mode prefix glyph for a (members, nick)
-// pair. Mirrors the precedence in `memberSigil` (@ > % > +) — both
-// derive from the same `MemberEntry.modes` array, just diverge on
-// what to return for the plain case.
-export const senderPrefix = (
-  members: ChannelMembers | undefined,
-  nick: string,
-  casemapping: Casemapping,
-): "@" | "%" | "+" | "" => {
-  if (!members) return "";
-  const entry = members.find((m) => nickEquals(m.nick, nick, casemapping));
-  if (!entry) return "";
-  if (entry.modes.includes("@")) return "@";
-  if (entry.modes.includes("%")) return "%";
-  if (entry.modes.includes("+")) return "+";
-  return "";
-};
 
 // #25: glyph for a CONTENT row's own sender, read from the server's
 // send-time snapshot (`meta.sender_prefix`) instead of live member

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48055,11 +48055,86 @@ reporter's, quoted from the issue; what was measured is the renderer, in jsdom
 for the eleven cases and against the live stack for the two-door
 (live vs. reload) contract in `issue1950-record-row-no-live-glyph.spec.ts`.
 
-The e2e `mode` case needs `/OPER` to exist at all: setting `+o` requires
-chanop, so a setter who lacks the grade cannot normally produce the row. The
-reporter could because he is Azzurra staff (`mezmerize@staff.azzurra.chat` in
-the field line above) and the testnet runs the same ircd, bahamut — so the
-spec buys the same standing the same way. That is a property of the FIXTURE,
-not of the defect: the defect needs no oper, only a setter whose grade moved.
+The e2e `mode` case needs out-of-band standing to exist at all: setting `+o`
+requires chanop, so a setter who lacks the grade cannot normally produce the
+row. The reporter could because he is Azzurra staff
+(`mezmerize@staff.azzurra.chat` in the field line above) and the testnet runs
+the same ircd, bahamut — so the spec buys the same standing the same way. That
+is a property of the FIXTURE, not of the defect: the defect needs no oper,
+only a setter whose grade moved.
+
+### /OPER is not the standing — the fixture asked the wrong door
+
+The paragraph above first read "so the spec buys the same standing the same
+way, with /OPER", and the spec did exactly that: `oper()` on the line above
+`mode()`. It went red on `IrcPeer: timeout waiting for mode … (5000ms)`, and
+the reason is structural rather than incidental. bahamut's `m_mode` grants the
+override on
+
+```c
+IsULine || ((IsSAdmin || IsAdmin) && !MyClient(sptr)) || IsUmodez
+```
+
+and **`!MyClient` switches the admin arm off for anyone connected to the very
+server being asked** — which is every e2e peer. `IsUmodez` is unreachable:
+`m_umode` lists `z` (with `a`, `j`, `S`, `r`) among the modes a client may
+never set on itself. So an opered non-chanop lands on `chanop = 0`,
+`set_mode` raises `SM_ERR_NOPRIVS`, and the peer gets a 482 with no echo.
+**No quantity of /OPER was ever going to be enough**, and raising the 5 s
+budget would only have bought a slower red.
+
+The door that opens is `SAMODE`, which carries no `!MyClient` conjunct: it
+gates on `IsPrivileged` (the /OPER) plus `IsAdmin || IsSAdmin`. Umode `+A` is
+reachable because the leaf's O: line is `OaARD` and `s_conf.c`'s
+`oper_access[]` maps `A` to `OFLAG_ADMIN`, which is what lets the `MyClient`
+clamp `if (IsAdmin && !OPIsAdmin) ClearAdmin` spare it. `+a` stays out of
+reach and is not needed. Nothing downstream changes: `m_samode` relays through
+the same `sendto_channel_butserv` call `m_mode` uses, so the wire line is a
+plain `:<setter> MODE <chan> +o <nick>` and the row grappa stores is the row
+the spec was always asserting on.
+
+**The generalisable part is the comment, not the verb.** `oper()`'s docstring
+claimed ircops "issue MODE / SAMODE freely on any channel they're in" — true
+of the second and false of the first — and separately that the leaf is
+permanently split so "fresh JOINers never auto-op", which
+`infra/bahamut/Dockerfile:26` contradicts on purpose by sed-deleting
+`NO_CHANOPS_WHEN_SPLIT` from `config.h`. Sixteen of the suite's seventeen
+`.mode()` sites are green precisely because their peer joins FIRST and
+auto-ops. Two readers were sent down the MODE path by that comment before it
+was measured against the source; it is corrected in place.
+
+### Why the setter still joins second
+
+The cheap repair is to make the setter the founding JOINer, like the other
+sixteen sites. It is refused, and the spec now says so at the join. The claim
+is not "a mode row renders bare" but "a mode row renders bare **even when its
+setter demonstrably could not have held the glyph at the time**" — which is
+what makes `* @Mezmerize sets mode +o Mezmerize` self-refuting without any
+knowledge of the channel's history. A setter who joined first already holds
+`@` when the row is written, so reordering keeps the assertion passing while
+quietly deleting the thing it asserts. **Join order is load-bearing here; at
+the other sixteen sites it is the opposite — there it is the only way the peer
+gets chanop at all.**
+
+### The oracle, measured
+
+A repaired test that cannot fail is worse than a red one, so the fix was run
+against a deliberately un-cured tree. In a detached scratch worktree,
+`cicchetto/src/ScrollbackPane.tsx` and `cicchetto/src/lib/nickColor.ts` were
+reverted to their pre-#1950 blobs while the new tests were kept:
+
+| tree | `ScrollbackPane.test.tsx` |
+|---|---|
+| cured (HEAD) | **234 passed**, 0 failed |
+| pre-cure mutant | **10 failed**, 224 passed |
+
+All ten failures are the `#1950 record rows carry no live-derived mode glyph`
+block and all ten fail on the same assertion — `.nick-prefix` length 0, got 2
+— across join, part, quit, kick, topic, nick_change, the channel `mode` row,
+the **self-op `mode` row**, the user mode on `$server`, and the
+already-in-channel INVITE `server_event`. The mutation was proven real before
+the run (`export const senderPrefix` back in `nickColor.ts`, its call back in
+`prefixFor`) and proven gone after it, with a positive control showing the
+same grep finds the helper in the pre-cure blob.
 
 _Deploy: **cic bundle only** — no server module, no migration, no wire change._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48137,4 +48137,21 @@ the run (`export const senderPrefix` back in `nickColor.ts`, its call back in
 `prefixFor`) and proven gone after it, with a positive control showing the
 same grep finds the helper in the pre-cure blob.
 
+The same displacement was run on the STACK, because jsdom proves the renderer
+discriminates and only the live stack proves it through the reload door:
+
+| tree | `issue1950-record-row-no-live-glyph.spec.ts` |
+|---|---|
+| pre-cure mutant | both tests **RED**, on the glyph assertion |
+| cured | both tests **GREEN** (5.6 s, 5.1 s) |
+
+The red is the one that had to be checked, and it is the right red: `:73:1`
+fails at line 130 with `.nick-prefix` expected 0, **got 2** (both join rows
+re-prefixed), and `:181:1` at line 234 with expected 0, **got 1**. That second
+number is also the proof the SAMODE path works end to end — the assertion one
+line above it, `expect(modeRow).toHaveCount(1)`, PASSED, so the row
+`sets mode +o <staff>` was really created, relayed and persisted by the very
+sequence the fixture now issues. A cure that had not worked would have failed
+earlier, as a `samode`/`umode` timeout, and the red would have proven nothing.
+
 _Deploy: **cic bundle only** — no server module, no migration, no wire change._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47940,7 +47940,7 @@ re-prefixing old lines — and *everything else* re-derived the glyph from the
 LIVE members store at every render, on the stated rationale that those rows
 "describe a *now* event, so the current grade is the correct glyph".
 
-That rationale is false for every row it covered except one. **A scrollback
+That rationale is false for every row it covered. **A scrollback
 row is never "now": it is a RECORD.** Reading the live store answers "what
 grade does this nick hold at the moment you happen to be looking", which is a
 different question from "what was true when this happened", and the difference
@@ -47965,46 +47965,101 @@ anyway because the sender is gone from the store".
 ### The rule, and why the answer is not a snapshot
 
 Where the event HAS no grade — a join, a kick victim — there is nothing to
-snapshot and the correct value is always empty. So the cure is a second named
-reading of the sender button rather than a second server column:
-`bareSpanWithPrefix/2` holds the one `<button>`, `bareSenderSpan/1` passes
-`prefixFor(nick)` (live) and `recordSenderSpan/1` passes `""`. The glyph is a
-PARAMETER, never a default, so each call site states which reading it wants —
-the same no-magic-default-arg rule the bare/bracketed split already followed.
-`prefixFor` itself is untouched.
+snapshot and the correct value is always empty. So the cure is a named reading
+of the sender button rather than a second server column: `bareSpanWithPrefix/2`
+holds the one `<button>`, `contentSenderSpan/1` passes `prefixFor(nick)` and
+`recordSenderSpan/1` passes `""`. The glyph is a PARAMETER, never a default,
+so each call site states which reading it wants — the same no-magic-default-arg
+rule the bare/bracketed split already followed.
 
-`mode` is the ONE deliberate survivor, and deliberately, not by inheriting the
-default: a mode row's whole subject IS the grade, so the sender's current
-status is the honest thing to show and there is no retroactivity to remove.
+**The rule that settles it: the ONLY glyph a scrollback row may carry is the
+#25 send-time snapshot, on a CONTENT row.** `prefixFor` keeps that branch and
+nothing else; there is no live members read left in `ScrollbackPane`. The
+members pane keeps one, because it is the single surface where "now" is
+actually the subject.
+
+### The `mode` carve-out this entry first defended, and why it fell
+
+This entry originally read *"`mode` is the ONE deliberate survivor … a mode
+row's whole subject IS the grade, so the sender's current status is the honest
+thing to show"*. That is retracted. The reporter closed it with a repro that
+refutes itself on its face:
+
+```
+20:58:09 * @Mezmerize sets mode +o Mezmerize on #grappa
+```
+
+The `@` is GRANTED by that very line, so the setter provably did not hold it
+when the event happened — no knowledge of the channel's history is needed to
+see the render is wrong. The general form has nothing to do with self-ops: a
+`mode` row records who set the mode THEN, so a setter deopped since reads plain
+on the line where they were opping people, and one opped since reads `@` on a
+line from when they were not. "Its subject is the grade" describes the row's
+CONTENT; the glyph is about its SENDER, and those are two different people as
+often as not.
+
+Losing the exception made the fix SMALLER, not bigger — one branch deleted
+instead of one branch conditioned.
 
 ### Measured
 
-Seven cases on the untouched tree, `bun.sh run test -t "#1950"`: **6 red, 1
-green**. Red — `join`, `part`, `quit`, `nick_change`, `topic`, `kick`; the
-`kick` row failed with **2** glyphs, not one, because it renders the kicker
-through the sender span AND the victim through its own `NickText` (the comment
-on `prefixFor` named that target as intentionally live). Green — the `mode`
-case, which is the block's POSITIVE CONTROL: it reads `@` off the very fixture
-the six absences are asserted against, so those absences are the absence of a
-glyph the store COULD have supplied rather than of a glyph nobody had.
+Two rounds on the untouched tree, `ScrollbackPane.test.tsx`.
 
-### What this does NOT claim, and what it acquits
+Round 1, seven cases: **6 red, 1 green**. Red — `join`, `part`, `quit`,
+`nick_change`, `topic`, `kick`; the `kick` row failed with **2** glyphs, not
+one, because it renders the kicker through the sender span AND the victim
+through its own `NickText`. Green — the `mode` case, which round 1 used as the
+block's POSITIVE CONTROL.
 
-The `server_event` / `renderRawEvent` senders (WALLOPS, GLOBOPS, KILL, ERROR,
-CHGHOST, vendor verbs) are left on the live reading, and that is an acquittal
-measured in `EventRouter`, not an omission: `route_unhandled_command/2`
-persists every one of them on the synthetic `$server` window, and
-`membersByChannel()` has no entry for `$server`, so `senderPrefix/3` returns
-`""` there by construction. The single raw verb routed to a REAL channel is
-the #78 inbound INVITE — and an `:invited` window is by definition not joined,
-so it carries no member list either. **Residual, stated so nobody rediscovers
-it as a new bug:** an INVITE to a channel we are ALREADY in, whose inviter is
-opped, would still render `*** @nick invited you to #chan`. It is one row,
-behind a re-invite, and it was left alone rather than swept in silently.
+That control could not survive round 2, since `mode` is now one of the
+absences. Its replacement is the one glyph path deliberately left standing:
+a CONTENT row rendering its #25 snapshot, through the same component, fixture
+and `.nick-prefix` selector. It proves a glyph CAN reach the DOM here, so the
+ten absences are not an artefact of a mocked-away `NickText`. It does NOT
+prove the LIVE store would have supplied one — after this fix nothing in the
+module reads it, so no in-block assertion can, and that half is carried by the
+red measurement below rather than pretended at.
+
+Round 2 (this extension), four more cases: **4 red, 0 green**, one glyph each
+(`mode` channel, `mode` self-op, `mode` on `$server`, `server_event` INVITE).
+Two of them are the interesting ones, because round 1's own text had ACQUITTED
+them:
+
+* `mode` on `$server` (#154(b) user modes). Round 1 reasoned it was safe
+  because no member list exists for that key. True, and irrelevant: seed one
+  and the old code paints an `@` on a row that has no channel grade at all. It
+  was safe by ROUTING ACCIDENT, not by rule. The unit fixture seeds a
+  deliberately unrealistic `$server` member list for exactly this reason — a
+  vacuous assertion would have passed either way.
+* the `server_event` INVITE into a channel we are ALREADY in. Round 1 listed
+  this as a stated residual, reasoned from `EventRouter` rather than measured.
+  It was real: red, one glyph. It is now fixed as a consequence of the total
+  rule, not as a carve-in.
+
+Counts, `bun.sh run test`: 6759 → **6755**. That is +4 new cases and −8 for
+the deleted `senderPrefix` unit tests, and the arithmetic closes exactly.
+
+### The helper is deleted, not just unused
+
+With the live branch gone, `nickColor.senderPrefix/3` had zero production
+callers — its only remaining consumers were its own eight unit tests. It is
+removed rather than left exported: there is no correct use of a live members
+read on a scrollback row, and an exported helper that says otherwise in its
+own doc comment is how the next session reintroduces this. `memberSigil`
+remains the members-pane path and is untouched.
+
+### What this does NOT claim
 
 Nothing here was measured on production. The Azzurra lines above are the
 reporter's, quoted from the issue; what was measured is the renderer, in jsdom
-for the seven cases and against the live stack for the two-door
+for the eleven cases and against the live stack for the two-door
 (live vs. reload) contract in `issue1950-record-row-no-live-glyph.spec.ts`.
+
+The e2e `mode` case needs `/OPER` to exist at all: setting `+o` requires
+chanop, so a setter who lacks the grade cannot normally produce the row. The
+reporter could because he is Azzurra staff (`mezmerize@staff.azzurra.chat` in
+the field line above) and the testnet runs the same ircd, bahamut — so the
+spec buys the same standing the same way. That is a property of the FIXTURE,
+not of the defect: the defect needs no oper, only a setter whose grade moved.
 
 _Deploy: **cic bundle only** — no server module, no migration, no wire change._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47927,3 +47927,84 @@ the pin is a test and reaches CI only. Ship the bundle with a server built
 from the same commit: a `--cic`-only push of this bundle onto the current
 `1.5.1` BEAM will log the mismatch, and after this change that log is telling
 the truth._
+<!-- entry #1950 -->
+
+---
+
+## 2026-09-06 — #1950: a scrollback row is a RECORD, so its nicks take no live glyph
+
+`ScrollbackPane`'s `prefixFor` had two branches: CONTENT rows
+(privmsg/notice/action) read the server's send-time `meta.sender_prefix`
+snapshot — that is #25, which stopped a MODE change from retroactively
+re-prefixing old lines — and *everything else* re-derived the glyph from the
+LIVE members store at every render, on the stated rationale that those rows
+"describe a *now* event, so the current grade is the correct glyph".
+
+That rationale is false for every row it covered except one. **A scrollback
+row is never "now": it is a RECORD.** Reading the live store answers "what
+grade does this nick hold at the moment you happen to be looking", which is a
+different question from "what was true when this happened", and the difference
+is visible the instant the nick is opped.
+
+The reporter saw both halves of it on Azzurra:
+
+```
+20:30:23 * @Mezmerize [mezmerize@staff.azzurra.chat] has joined #italia
+20:31:21 * @ULIAK [~ULIAK@5uo2.l.time4vps.cloud] has quit (Read/Dead Error: Input/output error)
+```
+
+The join line is wrong on the protocol outright — **JOIN carries no grade**;
+the `@` always arrives afterwards in a separate MODE, from a human op or from
+ChanServ auto-op a fraction of a second later — so `@nick has joined` states
+something that cannot ever have been true. It bites hardest exactly the people
+who look at it most: anyone with auto-op reads every one of their own joins as
+`@nick`. The quit line is the same defect with a later re-render as its
+trigger, and it also killed the issue's own guess that part/quit "render empty
+anyway because the sender is gone from the store".
+
+### The rule, and why the answer is not a snapshot
+
+Where the event HAS no grade — a join, a kick victim — there is nothing to
+snapshot and the correct value is always empty. So the cure is a second named
+reading of the sender button rather than a second server column:
+`bareSpanWithPrefix/2` holds the one `<button>`, `bareSenderSpan/1` passes
+`prefixFor(nick)` (live) and `recordSenderSpan/1` passes `""`. The glyph is a
+PARAMETER, never a default, so each call site states which reading it wants —
+the same no-magic-default-arg rule the bare/bracketed split already followed.
+`prefixFor` itself is untouched.
+
+`mode` is the ONE deliberate survivor, and deliberately, not by inheriting the
+default: a mode row's whole subject IS the grade, so the sender's current
+status is the honest thing to show and there is no retroactivity to remove.
+
+### Measured
+
+Seven cases on the untouched tree, `bun.sh run test -t "#1950"`: **6 red, 1
+green**. Red — `join`, `part`, `quit`, `nick_change`, `topic`, `kick`; the
+`kick` row failed with **2** glyphs, not one, because it renders the kicker
+through the sender span AND the victim through its own `NickText` (the comment
+on `prefixFor` named that target as intentionally live). Green — the `mode`
+case, which is the block's POSITIVE CONTROL: it reads `@` off the very fixture
+the six absences are asserted against, so those absences are the absence of a
+glyph the store COULD have supplied rather than of a glyph nobody had.
+
+### What this does NOT claim, and what it acquits
+
+The `server_event` / `renderRawEvent` senders (WALLOPS, GLOBOPS, KILL, ERROR,
+CHGHOST, vendor verbs) are left on the live reading, and that is an acquittal
+measured in `EventRouter`, not an omission: `route_unhandled_command/2`
+persists every one of them on the synthetic `$server` window, and
+`membersByChannel()` has no entry for `$server`, so `senderPrefix/3` returns
+`""` there by construction. The single raw verb routed to a REAL channel is
+the #78 inbound INVITE — and an `:invited` window is by definition not joined,
+so it carries no member list either. **Residual, stated so nobody rediscovers
+it as a new bug:** an INVITE to a channel we are ALREADY in, whose inviter is
+opped, would still render `*** @nick invited you to #chan`. It is one row,
+behind a re-invite, and it was left alone rather than swept in silently.
+
+Nothing here was measured on production. The Azzurra lines above are the
+reporter's, quoted from the issue; what was measured is the renderer, in jsdom
+for the seven cases and against the live stack for the two-door
+(live vs. reload) contract in `issue1950-record-row-no-live-glyph.spec.ts`.
+
+_Deploy: **cic bundle only** — no server module, no migration, no wire change._


### PR DESCRIPTION
## What was wrong

`ScrollbackPane`'s `prefixFor` split on the wrong axis. CONTENT rows
(privmsg/notice/action) read the server's send-time `meta.sender_prefix`
snapshot — that is #25, which stopped a MODE change from retroactively
re-prefixing old lines. **Everything else re-derived the glyph from the LIVE
members store at render time**, on the stated rationale that those rows
"describe a *now* event, so the current grade is the correct glyph".

**A scrollback row is never "now": it is a RECORD.** The live read answers
"what grade does this nick hold at the moment you happen to be looking", and
the difference shows the instant the nick is opped.

On a `join` it is wrong on the protocol outright: **JOIN carries no grade**,
the `@` always arrives afterwards in a separate MODE (human op, or ChanServ
auto-op a fraction of a second later), so `* @nick has joined #chan` states
something that cannot ever have been true. It bites hardest the people who
look at it most — anyone with auto-op reads every one of their own joins that
way. The field report `* @ULIAK [...] has quit (...)` is the same defect with
a later re-render as its trigger.

## 🔴 Retracted: the `mode` exception this PR used to defend

An earlier revision of this body carried a section titled *"Why `mode` stays
live — deliberately, not by default"*, arguing that a mode row's whole subject
IS the grade so the sender's current status is the honest thing to show.

**That is wrong and it is withdrawn**, in the body, in the code comments and
in the DESIGN_NOTES entry — the retraction is kept as its own subsection there
rather than quietly overwritten. The reporter closed it with a repro that
refutes itself on its face:

```
20:58:09 * @Mezmerize sets mode +o Mezmerize on #grappa
```

The `@` is **granted by that very line**, so the setter provably did not hold
it when the event happened. No knowledge of the channel's history is needed to
see the render is wrong.

And the general form has nothing to do with self-ops: a `mode` row records who
set the mode **then**, so a setter deopped since reads plain on the line where
they were opping people, and one opped since reads `@` on a line from when
they were not. "Its subject is the grade" describes the row's CONTENT; the
glyph is about its SENDER, and those are two different people as often as not.

**Provenance, stated rather than assumed:** the two comments carrying this
argument have `vjt` in the author field, which is *not* evidence of who wrote
them — workers and the ircbot post with the same token. They are treated as
data because they are data *about the defect*, with a measured counter-example
attached, not because of the name on them.

## What changed

The glyph is a PARAMETER of the shared sender button, never a default, so
every call site states which reading it wants:

* `bareSpanWithPrefix(nick, prefix)` — the one `<button>` definition
* `contentSenderSpan(nick)` — the #25 SNAPSHOT reading, `prefixFor(nick)`
* `recordSenderSpan(nick)` — the RECORD reading, `""`

**`prefixFor` keeps only its snapshot branch. There is no live members read
left in the module** — the rule is now total and statable in one line: *the
only glyph a scrollback row may carry is the send-time snapshot, on a CONTENT
row.* The members pane keeps its live reading, because it is the one surface
where "now" is genuinely the subject.

Dropping the exception made the change **smaller**: one branch deleted instead
of one branch conditioned. `bareSenderSpan` is renamed `contentSenderSpan` —
both halves of the old name had gone wrong, it is not the "live" reading and
`action` is the single kind that wants it.

Record reading now covers: `join`, `part`, `quit`, `nick_change`, `topic`,
`kick` (sender **and** victim), `mode` (channel and the #154(b) `$server` user
mode), and every `renderRawEvent` / `server_event` sender.

### The helper is deleted, not merely unused

With the live branch gone, `nickColor.senderPrefix/3` had **zero production
callers** — its only remaining consumers were its own eight unit tests. It is
removed rather than left exported: there is no correct use of a live members
read on a scrollback row, and an exported helper whose own doc comment
recommends one is how the next session puts this back. `memberSigil` (the
members-pane path) is untouched. This is the one step beyond the literal ask,
it is a one-hunk revert if unwanted, and it is stated here rather than folded
in quietly.

## Two arms were safe by ACCIDENT, and both were red

The previous round's body and DESIGN_NOTES entry *acquitted* the raw-event
arms by reasoning from `EventRouter`'s routing. Measured, that reasoning was
false on two counts — both red on the untouched tree, one glyph each:

| arm | why it was thought safe | what the measurement said |
|---|---|---|
| `mode` on `$server` (#154(b) user modes) | no member list exists for that key, so the live read returns `""` | seed one and the old code paints `@` on a row with **no channel grade at all** |
| `server_event` INVITE into a channel we are **already in** | listed as a stated residual, reasoned not measured | real: red, one glyph |

That second row is the residual this PR previously wrote down as *"say the
word and it is a one-argument change"*. **It is not a product decision taken
on anyone's behalf — it falls out mechanically.**

The residual is fed by the exact `senderPrefix(membersByChannel()…)` branch
that the perimeter — *no live-derived glyph on any scrollback row, no
exception to carve out* — sends out of the module. Measured, not argued: with
that branch removed and every arm routed back through `prefixFor`, all four
round-2 cases stay green (`234 passed (234)`). `server_event` is not a content
kind, so the stripped `prefixFor` returns `""` for it. **The live-branch
removal alone is what retires the residual**; the `recordSenderSpan` rename at
those call sites is naming hygiene, not the mechanism.

So the row simply stops carrying a live glyph, which is precisely what the
perimeter asks for — nothing is lost, the same defect is cured there too. And
the argument is `mode`'s, verbatim: *"X invited you"* describes a PAST EVENT,
so X's grade **now** is not its subject.

**Who decided what, stated exactly:** my working brief carried two
instructions that could not both hold — "the live call leaves the module
entirely" and "leave the INVITE residual alone". That contradiction was mine
to raise and the orchestrator's to resolve, and she resolved it, owning the
brief's error. **vjt never took a decision about that row**, and this PR does
not claim he did.

The sharper lesson, recorded in DESIGN_NOTES: **safe by routing accident is
not safe by rule**, and the difference is invisible until something seeds the
key the reasoning assumed empty.

## Measurement

### Round 1 (already on the branch)

Seven cases on the untouched tree: **6 red, 1 green**. Red — `join`, `part`,
`quit`, `nick_change`, `topic`, `kick`; the `kick` case failed with **2**
glyphs, not one (kicker + victim). Green — the `mode` case, which served as
that round's positive control.

### Round 2 (this extension)

Four more cases, pre-fix on the branch tip: **4 red, 0 green**, one glyph each.

```
FAIL  ... > renders a mode (channel) row with no mode glyph although the nick holds @ now
FAIL  ... > renders a mode (self-op — the row that grants the glyph it was painted with) row ...
FAIL  ... > renders a mode (user mode on $server) row ...
FAIL  ... > renders a server_event INVITE into a channel we are already in row ...
AssertionError: expected <span …(1)></span> to have a length of +0 but got 1
Tests  4 failed | 230 passed (234)
```

Post-fix, same file: `Tests 234 passed (234)`. Same total, so the four reds
went green and nothing else moved.

### The positive control had to move

It used to **be** the `mode` row, reading `@` off the same fixture the
absences were asserted against. That row is now one of the absences. Its
replacement is the one glyph path deliberately left standing — a CONTENT row
rendering its #25 snapshot, through the same component, fixture and
`.nick-prefix` selector, asserted **by cardinality** so an empty control
cannot masquerade as a pass.

Stated precisely, because half of it is a non-measure: it proves a glyph CAN
reach the DOM here, so the ten absences are not an artefact of a mocked-away
`NickText` or a stale selector. **It does NOT prove the live store would have
supplied one** — after this change nothing in the module reads it, so no
in-block assertion can. That half is carried by the red measurement above and
nowhere else. Each absence case additionally asserts the row names its sender,
so an absent glyph cannot be an absent row.

The `$server` case uses a **deliberately unrealistic fixture** — a synthetic
server window has no member list — and that is the point. Without a seeded
entry the assertion passes on the broken code as readily as on the cured one.

## Gates

| gate | baseline | this extension |
|---|---|---|
| `bun.sh run check` | rc=0, 5/5 stages, 59 warnings / 4 infos | rc=0, 5/5 stages, **59 warnings / 4 infos** |
| `bun.sh run test` | rc=0, 336 files / 6759 tests | rc=0, 336 files / **6755** tests |

**6759 → 6755 reconciles exactly**: `+4` new cases, `−8` for the deleted
`senderPrefix` unit tests.

`scripts/design-notes-gate.sh`: rc=0, `1 new entry heading(s), separator and
marker present.` — a positive claim, not a vacuous "nothing to check".

Rebased with `scripts/union-rebase.sh` onto `5284d6a`:
`docs/DESIGN_NOTES.md: +81 -0 — contribution intact`, and the pre/post numstat
files compared identical. The DESIGN_NOTES contribution is now `+136 −0`
(the entry was rewritten in place, so deletions against the base stay zero and
the marker stays unique against `origin/main`'s tip).

## Not measured — and what I decline to assert

1. **The e2e has never been executed.** `issue1950-record-row-no-live-glyph.spec.ts`
   passes `tsc (e2e)` + biome and nothing more. It has **not** been proven red
   pre-fix, for either test. It needs the exclusive stack lane; that lane has
   been requested and not yet allocated.
2. **The `/OPER` route for the self-op is unverified.** The spec's second test
   needs a plain member to issue `MODE +o` on itself, which requires standing
   the protocol does not otherwise give. The claim that the testnet's `OaARD`
   O-line permits it comes from prose in `e2e/fixtures/ircClient.ts`, not from
   a run. `IrcPeer.mode` awaits the peer's own echo, so a refused override
   surfaces as a named MODE timeout rather than a silent skip — but until the
   lane run, "the repro is constructible here" is a prediction, not a result.
3. **Nothing was measured on production.** The Azzurra lines are the
   reporter's, quoted. What was measured is the renderer, in jsdom.
4. **I do not claim the current CI red belongs to this branch or to its
   absence.** Shard 3/4 died on runner infrastructure — `failed to resolve
   source metadata for docker.io/library/debian:trixie`, ~50 s, zero tests run.
   I did not re-run it and did not chase it.
5. **A stale comment I found and did not touch.** `ircClient.ts`'s `oper()`
   doc says the testnet leaf is permanently split so "fresh JOINers never
   auto-op". The image build drops `NO_CHANOPS_WHEN_SPLIT`
   (`e2e/infra/bahamut/Dockerfile:26`) and three specs already `join` then
   `mode` with no prior `oper()`, so the prose reads stale — but I established
   that from the build recipe and call sites, **not** from a live 005 or a
   MODE, and it is not this PR's file to correct.
6. **`OPER_NAME` / `OPER_PASS` are now triplicated** across three specs and
   belong in `seedData`. Left alone: hoisting them would edit two specs this
   change has no business touching.

Deploy posture: **cic bundle only** — no server module, no migration, no wire
change, no `protocol_version` movement.
