### PR TITLE
release: probe 5's row pattern learns the nick key, and gets pinned (issue 1951)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -46930,3 +46930,76 @@ its controls rather than printed beside them: `compose.release.yaml` on
 `:docker` and `VERSION` on `:jail` had to come back COLD, `docs/compose.notes.md`
 and `VERSION` on `:docker` HOT — all four held before any verdict was
 emitted._
+<!-- entry #1951 -->
+
+---
+
+## 2026-09-06 — #1951: the probe was fine, the ORACLE went stale — so the oracle got a test
+
+`deploy + probe the release image (amd64)` was the only red check on the
+release runs of BOTH `v1.5.0` and `v1.5.1`, twice with the same words:
+
+```
+the shipped chunks carry NEITHER a populated credit roll nor the degraded one —
+the payload's spelling changed and this probe is now blind (#1834)
+```
+
+Nothing shipped wrong. That message is #1834's anti-hollow-green branch doing
+exactly its job: neither shape matched, and rather than pass quietly it died.
+The payload's spelling HAD moved, and the mover was #1927 — `credits.sh` grew
+a third key per contributor (`nick`) while probe 5's `contributor_row` still
+spelled two, so it could never match, `populated_roll` (built on top of it)
+could never match, and the third branch was the only one left.
+
+### `nick` is not always a string, and that is the half a careless fix misses
+
+`credits.sh`'s `nickof()` returns the BARE `null` token for an author absent
+from `infra/packaging/contributors`, and the table itself is optional by
+construction — a tree that cannot read it falls back to `/dev/null` and emits
+`null` for EVERY row. A pattern accepting only `"nick":"handle"` would be
+blind to half the field in this repo and to all of it in a checkout without
+the table. The cure carries both spellings and nothing else:
+
+```sh
+contributor_row='\{"name":"[^"]*","nick":(null|"[^"]*"),"commits":[0-9]+\}'
+```
+
+### Deliberately strict, because the failure mode is the cure's mirror image
+
+The tempting fix is a looser pattern. It is the wrong one: probe 5's value is
+its THIRD outcome, and a regex that matches anything deletes that outcome
+while reporting green. Measured over six payload classes with the driver's own
+patterns — real roll with quoted nicks → passes (8 rows); real roll with bare
+`null` nicks, from the same script run without its table → passes (12 rows);
+degraded roll → dies on the degraded branch; pre-#1927 two-key row → dies on
+"neither shape"; a row whose `commits` is quoted → dies; a bundle with no roll
+at all → dies. Both directions, not just the one the issue was about.
+
+### The real lesson: nothing was reading the reader
+
+`test/infra/release_image_credits_test.bats` already read the RECIPE — that
+the build arg is declared, that the fallback survives, that the workflow
+supplies it. Nothing read the PATTERN the artifact is read WITH, so the one
+component whose whole job is to notice drift was itself free to drift, and it
+took two releases to notice because it only runs on a tag.
+
+Four cases now pin it, in that same file, against payloads the REAL
+`credits.sh` produces — never hand-typed, since a hand-typed copy drifting
+from the deriver IS the defect. They read the driver's own assignments out of
+it rather than restating them, for the same reason, and the extractor carries
+its own positive control: an empty ERE matches everything, so a reformat that
+put those lines out of grep's reach would otherwise turn the whole block
+green. Cost is nil and it runs on every PR, where the tag-only probe does not.
+
+### What this does NOT claim
+
+It was never run against a ghcr image. The assertion is oracle-vs-payload, on
+the string `credits.sh` emits — which vite re-serialises through
+`JSON.parse/stringify`, so it is canonical, but it is not the shipped chunk.
+Whether the payload REACHES the bundle stays probe 5's claim, on a real image,
+and the two halves are complementary on purpose. The healthy roll on the prod
+bundle for `v1.5.0` (8 contributor rows, three-key shape) is the issue
+reporter's measurement, not one taken here.
+
+_Deploy: **no deploy** — CI/release tooling only, nothing in the image or the
+release itself changes._

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -260,7 +260,23 @@ degraded_roll='{"sha":null,"date":null,"contributors":[]}'
 # One contributor row. Absent from a degraded bundle and present once per
 # credited author in a populated one — measured 0 vs 9 on the two dists #1834
 # built to check exactly this.
-contributor_row='\{"name":"[^"]*","commits":[0-9]+\}'
+#
+# #1951 — the middle key is #1927's `nick`, and it is NOT always a quoted
+# string: `credits.sh`'s `nickof()` emits the BARE `null` token for an author
+# missing from `infra/packaging/contributors`, and a tree that has no table at
+# all emits `null` for every row. The alternation carries both spellings —
+# accepting only the quoted one would leave this probe blind to half the field
+# and, on a tree without the table, to all of it.
+#
+# Deliberately STRICT, not permissive: it admits exactly the two shapes the
+# deriver can emit, so the "neither shape present" branch below still fires
+# the next time the payload's spelling moves. Loosening it to match anything
+# would restore the hollow green that branch exists to refuse — which is the
+# opposite of the bug. Pinned by `test/infra/release_image_credits_test.bats`
+# against payloads `credits.sh` really produces, so the next spelling change
+# lands on a PR-time red instead of on the release run: this pattern going
+# stale is what made probe 5 the only red check on v1.5.0 and v1.5.1.
+contributor_row='\{"name":"[^"]*","nick":(null|"[^"]*"),"commits":[0-9]+\}'
 # The whole populated payload, head-anchored: a real sha, a real date, and at
 # least one contributor. All three, because each degrades on its own — a roll
 # that names the commit and credits nobody is still an empty roll.

--- a/test/infra/release_image_credits_test.bats
+++ b/test/infra/release_image_credits_test.bats
@@ -36,6 +36,8 @@ setup() {
     REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
     DOCKERFILE="$REPO_SRC/Dockerfile.release"
     WORKFLOW="$REPO_SRC/.github/workflows/release.yml"
+    SMOKE="$REPO_SRC/scripts/smoke-release-image.sh"
+    CREDITS="$REPO_SRC/infra/packaging/credits.sh"
 }
 
 # The `cic` stage only — an `ARG` is scoped to the stage that declares it, so
@@ -158,5 +160,136 @@ RUN GRAPPA_CREDITS="${GRAPPA_CREDITS:-$(sh infra/packaging/credits.sh)}" \
     && bun run build
 EOF
     run falls_back_to_credits_sh "$ok"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# #1951 — probe 5's ORACLE, not the image.
+#
+# The block above reads the recipe; probe 5 of `scripts/smoke-release-image.sh`
+# reads the artifact. Nothing read the PATTERN probe 5 reads the artifact WITH,
+# and that is what rotted: #1927 gave every contributor row a third key
+# (`nick`), the driver's `contributor_row` still spelled two, and probe 5 went
+# blind. It failed honestly — the anti-hollow-green branch fired rather than
+# passing quietly — but it failed on the release runs of BOTH v1.5.0 and
+# v1.5.1, which is a red check an operator has to learn to ignore. That is the
+# state the guard exists to prevent.
+#
+# So these cases pin the ORACLE against payloads the REAL `credits.sh`
+# produces. What they cannot claim is that the payload reaches a ghcr image —
+# that needs an image, and it stays probe 5's job. The seam is deliberate:
+# this half runs on every PR for free, that half runs where an image exists.
+
+# The driver's OWN definitions, read out of it rather than restated. A test
+# carrying its own copy of the regex cannot fail when the driver's copy rots,
+# which is precisely the defect that got here.
+load_probe5_patterns() {
+    eval "$(grep -E '^(degraded_roll|contributor_row|populated_roll)=' "$SMOKE")"
+    # Positive control for the EXTRACTOR itself: a reformat that puts these
+    # assignments out of grep's reach would silently leave every pattern empty,
+    # and an empty ERE matches everything — a green that proves nothing.
+    [ -n "$degraded_roll" ] && [ -n "$contributor_row" ] && [ -n "$populated_roll" ]
+}
+
+# A REAL payload, from production's own deriver. Never hand-typed: the whole
+# defect is a hand-typed copy drifting from what the deriver emits.
+real_roll_with_nicks() {
+    "$CREDITS"
+}
+
+# The same deriver, reached where its nick table is not: `credits.sh` resolves
+# the table next to itself and falls back to /dev/null when it is unreadable,
+# so every contributor comes out with the BARE `null` token. This is the other
+# half of the field, and a regex that only accepts the quoted spelling is blind
+# to it — on a tree without the table, blind to all of it.
+real_roll_without_nicks() {
+    local root="$BATS_TEST_TMPDIR/nonick"
+    mkdir -p "$root/pkg/dir"
+    # `credits.sh` takes SCRIPT_DIR from `dirname "$0"` (the symlink's own
+    # path, not its target) and REPO_ROOT from SCRIPT_DIR/../.. — so the
+    # script is production's, the history is this repo's, and only the table
+    # is missing.
+    ln -sf "$CREDITS" "$root/pkg/dir/credits.sh"
+    ln -sf "$REPO_SRC/.git" "$root/.git"
+    "$root/pkg/dir/credits.sh"
+}
+
+@test "#1951 — probe 5's row pattern matches a real credits.sh row with a QUOTED nick" {
+    load_probe5_patterns
+    local roll; roll="$(real_roll_with_nicks)"
+
+    grep -qE '"nick":"[^"]*"' <<< "$roll" || skip "this tree's nick table credits nobody — nothing to assert"
+
+    grep -qE "$populated_roll" <<< "$roll" || {
+        printf 'populated_roll does not match a healthy payload — probe 5 is blind.\n' >&2
+        printf 'pattern: %s\n' "$populated_roll" >&2
+        printf 'payload: %s\n' "$roll" >&2
+        return 1
+    }
+    # Not just "the head matched": the row pattern must FIND rows, because the
+    # driver counts them with it too.
+    [ "$(grep -oE "$contributor_row" <<< "$roll" | wc -l | tr -d ' ')" -gt 0 ]
+}
+
+@test "#1951 — and one with the BARE null nick, which is the other half of the field" {
+    load_probe5_patterns
+    local roll; roll="$(real_roll_without_nicks)"
+
+    # Guard the fixture, not the code: if this ever stops producing the null
+    # spelling the case must die loudly rather than assert on the wrong shape.
+    grep -qF '"nick":null' <<< "$roll" || {
+        printf 'the no-table run did not produce a bare `null` nick — fixture is wrong:\n' >&2
+        printf '%s\n' "$roll" >&2
+        return 1
+    }
+
+    grep -qE "$populated_roll" <<< "$roll" || {
+        printf 'populated_roll rejects a payload whose nicks are the bare null token.\n' >&2
+        printf 'A tree without infra/packaging/contributors emits ONLY this shape, so\n' >&2
+        printf 'probe 5 would be blind to all of it.\n' >&2
+        printf 'pattern: %s\n' "$populated_roll" >&2
+        printf 'payload: %s\n' "$roll" >&2
+        return 1
+    }
+    [ "$(grep -oE "$contributor_row" <<< "$roll" | wc -l | tr -d ' ')" -gt 0 ]
+}
+
+@test "#1951 — RED: the pre-#1927 two-key row and a junk row do NOT pass the populated branch" {
+    load_probe5_patterns
+
+    # The shape the driver was still spelling. Accepting it would mean the
+    # pattern went permissive instead of current.
+    local two_key='{"sha":"abc1234","date":"2026-01-01T00:00:00+00:00","contributors":[{"name":"Someone","commits":9}]}'
+    run grep -qE "$populated_roll" <<< "$two_key"
+    [ "$status" -ne 0 ]
+
+    # `commits` quoted is not `commits` numeric. A pattern loose enough to take
+    # this is loose enough to take anything, which is the hollow green the
+    # third branch of probe 5 exists to refuse.
+    local junk='{"sha":"abc1234","date":"2026-01-01T00:00:00+00:00","contributors":[{"name":"Someone","nick":"x","commits":"9"}]}'
+    run grep -qE "$populated_roll" <<< "$junk"
+    [ "$status" -ne 0 ]
+
+    # POSITIVE control: the same predicate, same invocation, on the real
+    # payload. Without it a pattern broken into always-false would report both
+    # rejections above as a pass.
+    local roll; roll="$(real_roll_with_nicks)"
+    run grep -qE "$populated_roll" <<< "$roll"
+    [ "$status" -eq 0 ]
+}
+
+@test "#1951 — the anti-hollow-green guard stays armed: a degraded roll is still not populated" {
+    load_probe5_patterns
+
+    # The exact payload credits.sh emits with no repo. Probe 5 dies on this by
+    # a DIFFERENT branch (the -F match below), and it must never reach the
+    # populated one — a fix that made the degraded roll look populated would
+    # ship an empty credit roll under a green check.
+    run grep -qE "$populated_roll" <<< "$degraded_roll"
+    [ "$status" -ne 0 ]
+
+    # POSITIVE control for the branch that DOES own this payload, so the
+    # rejection above is a rejection and not a dead detector.
+    run grep -qF "$degraded_roll" <<< "$degraded_roll"
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## The image was fine; the oracle went stale

`deploy + probe the release image (amd64)` was the **only** red check on the
release runs of **both** `v1.5.0` and `v1.5.1`, twice with the same words:

```
the shipped chunks carry NEITHER a populated credit roll nor the degraded one —
the payload's spelling changed and this probe is now blind (#1834)
```

That is #1834's anti-hollow-green branch doing exactly its job: neither shape
matched, and rather than pass quietly it died. The spelling HAD moved, and
#1927 moved it — `infra/packaging/credits.sh` grew a third key per contributor
(`nick`) while probe 5's `contributor_row` still spelled two. It could never
match; `populated_roll` is built on top of it, so it could never match either;
the third branch was the only one left.

Verified on the tree rather than taken from the issue: `contributor_row` had
two keys, and `nick` appeared **0** times in `scripts/smoke-release-image.sh`
(positive control for that grep: `contributor_row`, **3** hits).

## `nick` is not always a string

`nickof()` returns the **bare `null` token** for an author absent from
`infra/packaging/contributors`, and the table is optional by construction — a
tree that cannot read it falls back to `/dev/null` and emits `null` for
**every** row. A pattern accepting only the quoted spelling is blind to half
the field here and to all of it in a checkout without the table.

```sh
contributor_row='\{"name":"[^"]*","nick":(null|"[^"]*"),"commits":[0-9]+\}'
```

One line in the driver, plus the comment that ties it to #1927. **No
restructuring** — issue 1952 extends this same file with an upgrade probe and
has to rebase on top of this.

## Deliberately STRICT, not permissive

The tempting fix is a looser pattern, and it is the wrong one: probe 5's value
IS its third outcome, and a regex that matches anything deletes that outcome
while reporting green — worse than the bug. Measured over six payload classes
using the driver's **own** patterns:

| payload | branch taken |
|---|---|
| real roll, quoted nicks (`credits.sh`) | **passes** — 8 contributor rows |
| real roll, bare `null` nicks (same script, no table) | **passes** — 12 contributor rows |
| degraded roll (`{"sha":null,…,"contributors":[]}`) | dies — degraded branch |
| pre-#1927 two-key row | dies — "neither shape", guard armed |
| row whose `commits` is quoted | dies — "neither shape", guard armed |
| a bundle with **no roll at all** | dies — "neither shape", guard armed |

Both real payloads come from running `credits.sh` itself, never hand-typed —
the second by reaching it through a symlink whose sibling table is absent,
which is production's own `/dev/null` fallback path.

## The actual lesson: nothing was reading the reader

`test/infra/release_image_credits_test.bats` already read the **recipe** — arg
declared, fallback kept, workflow supplies it. Nothing read the **pattern the
artifact is read with**, so the one component whose job is noticing drift was
free to drift, and it only runs on a tag — which is why it cost two releases.

Four cases now pin it, in that same file:

* the row pattern matches a real `credits.sh` row with a **quoted** nick
* …and one with the **bare null** nick
* **RED**: the pre-#1927 two-key row and a `commits`-quoted junk row do **not**
  pass the populated branch — with a positive control on the real payload, so
  a predicate broken into always-false cannot report both rejections as a pass
* the **guard stays armed**: a degraded roll is still not populated, with a
  positive control on the branch that does own it

They read the driver's own assignments out of it instead of restating them,
because a test carrying its own copy of the regex cannot fail when the
driver's copy rots — which is this defect. The extractor carries its own
positive control: an empty ERE matches everything, so a reformat that put
those assignments out of grep's reach would otherwise turn the block green.

## Gates

| gate | rc | detail |
|---|---|---|
| `scripts/bats.sh` (full) | 0 | plan `1..723`, **723 ok / 0 not ok / 0 skips** |
| `scripts/bats.sh test/infra/release_image_credits_test.bats` | 0 | 9 ok / 0 not ok (post-rebase) |
| `scripts/shellcheck.sh` | 0 | 82 derived scripts |
| `scripts/posix-parse.sh` | 0 | 33 sh-dialect scripts (the driver is bash, outside this set) |
| `scripts/design-notes-gate.sh` | 0 | `1 new entry heading(s), separator and marker present.` (post-commit **and** post-rebase) |
| `scripts/union-rebase.sh` | 0 | `docs/DESIGN_NOTES.md: +73 -0 — contribution intact` |

Before the fix the same scoped bats file was **6 ok / 3 not ok** — the three
that depend on the new pattern, including the head-anchored match failing
against a healthy payload. That is the defect, reproduced.

## Not measured

Never run against a ghcr image. This is **oracle-vs-payload**: the string
`credits.sh` emits, which `vite.config.ts` re-serialises through
`JSON.parse/stringify` and is therefore canonical — but it is not the shipped
chunk. Whether the payload REACHES the bundle stays probe 5's claim, on a real
image. The healthy roll measured on the prod bundle for `v1.5.0` is the issue
reporter's measurement, not one taken here.