### PR TITLE
deploy(#1851): cure the two sources of dirt the deploy makes itself

### DIFF
--- a/cicchetto/.gitignore
+++ b/cicchetto/.gitignore
@@ -4,3 +4,13 @@ dist/
 *.log
 .env
 .env.local
+
+# bun.lock is the canonical lock (see docs/OPERATIONS.md § "cic_build.sh —
+# bun here, npm only on FreeBSD"). package-lock.json is a build artefact of
+# ONE substrate: FreeBSD pkg has no bun port, so infra/freebsd/jail_cic_build.sh
+# falls back to `npm install`, which regenerates this file INSIDE the prod
+# checkout. Untracked and unignored, it made `git status --porcelain` non-empty
+# forever, and Grappa.Version.GitProbe reads that at compile time — so every
+# jail release reported the unreleased `X.Y.Z-<sha>` instead of the bare tag
+# #391 promises (#1851; measured on 1.4.0, 1.4.1 and 1.5.0).
+package-lock.json

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47003,3 +47003,141 @@ reporter's measurement, not one taken here.
 
 _Deploy: **no deploy** — CI/release tooling only, nothing in the image or the
 release itself changes._
+<!-- entry #1851 -->
+
+---
+
+## 2026-09-06 — #1851: the jail's tree is dirty BY CONSTRUCTION, so every release reports `X.Y.Z-<sha>`
+
+Production reported a suffixed version on three releases running —
+`1.4.0-596d5ea0`, `1.4.1-997711ac`, `1.5.0-35e9fca6`. **`Grappa.Version` is
+not the defect and was not touched.** An unclean tree at compile time IS an
+unreleased build, and the suffix saying so is #391 working exactly as
+designed. The defect is one layer up: the deploy machinery MANUFACTURES the
+uncleanliness, so the signal is on permanently and discriminates nothing — a
+genuinely unreleased build looks identical to a released one, and the tag the
+operator just cut disagrees with `CTCP VERSION`.
+
+`git status --short` in the jail, both entries written by the deploy and
+never by a human:
+
+     M cicchetto/e2e/infra
+    ?? cicchetto/package-lock.json
+
+### Two entries, two causes — and the issue's "option A" splits in half
+
+The issue framed A as one cure ("stop the build from dirtying the
+checkout"). It is two, at two different layers, and forcing one mechanism
+onto both would have been wrong in one of them.
+
+**`cicchetto/package-lock.json` is a build artefact of one substrate's
+toolchain.** FreeBSD pkg has no bun port, so `jail_cic_build.sh` falls back
+to `npm install`, which regenerates the file inside the checkout. `bun.lock`
+is canonical and OPERATIONS.md already said so; nothing else reads the npm
+lock. A generated path that lands in the tree belongs in `.gitignore`, next
+to `dist/` and `.vite/`. That is the cause removed at the layer that owns
+it — git is told what the file IS; nothing stopped looking.
+
+**`cicchetto/e2e/infra` is the pull failing to finish.** `git pull
+--ff-only` advances the SUPERPROJECT and leaves every submodule working tree
+exactly where it was, and nothing downstream ever syncs it back — so ONE
+gitlink bump dirties a deploy checkout permanently. The pin last moved on
+2026-08-23 (`f2b93f2bf`), which is when the jail's tree went dirty and
+stayed. The cure is `--recurse-submodules=on-demand` on every deploy pull:
+three `substrate_pull` hooks (jail, linux, docker) and the two standalone
+jail rails.
+
+### Why `on-demand` and not the bare flag — measured, on a throwaway bench
+
+| pull spelling | gitlink moved | gitlink still | tree after |
+|---|---|---|---|
+| `--ff-only` (before) | rc 0 | rc 0 | **DIRTY** |
+| `--recurse-submodules` (`=yes`) | rc 0 | **rc 1** w/ remote down | clean |
+| `--recurse-submodules=on-demand` | rc 0 | rc 0 | clean |
+
+The bare flag means `=yes`, which fetches every submodule on EVERY pull. A
+box that cannot reach the submodule remote would go from "deploys fine until
+the gitlink moves" to "never deploys" — and the submodule here is behind a
+`git@` SSH URL that production has no reason to hold a key for.
+
+`on-demand` IS git's own fetch default, so the FETCH half of the pull is
+byte-for-byte what it already does and only the CHECKOUT half is new. **The
+flag therefore cannot introduce a failure the current pull does not already
+have** — measured directly: with the remote unreachable AND the new
+submodule objects absent, the old pull and the new one fail identically
+(rc 1, the same `Errors during submodule fetch`, superproject un-advanced).
+It is also a no-op where the submodule was never initialised, which is what
+a plain `git clone` leaves behind, so it does not drag a test-only testnet
+onto a production box that does not have one.
+
+### The two cures that were measured and REJECTED
+
+**`ignore = all` in `.gitmodules`** cleans `git status` — and also makes
+`git add cicchetto/e2e/infra` stage *nothing*. Measured: `git diff --cached
+--name-only` comes back empty after the add, so a deliberate bump like
+`f2b93f2bf` becomes uncommittable through the normal gesture. Not "a bump
+you might not notice": one you cannot make. `ignore = dirty` does not apply
+at all — the dirt is `(new commits)`, which `dirty` deliberately still
+reports.
+
+**Teaching `GitProbe` an allowlist of deploy-noise paths** (the issue's
+option B) turns "clean" from a fact into a policy that rots, and leaves the
+checkout genuinely diverged from the commit it claims to be. The version
+string would read `X.Y.Z` while the tree was not `X.Y.Z`. That is a worse
+lie than the one being fixed.
+
+### The THIRD source, already cured — and the rule it leaves
+
+The deploy writes `runtime/last-deployed-sha` INTO the checkout on every
+run. It is not dirt today only because the repo's root `.gitignore` already
+carries `/runtime/*`. It surfaced as a red in the new bats case, whose
+throwaway upstream carried no `.gitignore` at all — the fixture was lying by
+omission, and mirroring the real rule was fidelity, not accommodation.
+
+**The general rule this leaves: any path a deploy WRITES into the checkout
+must be checked against `.gitignore`, or it poisons the version string the
+same way.** Three such paths exist today; two were covered, one was not.
+
+### What the tests pin, and what killed them
+
+`test/infra/deploy_checkout_dirt_test.bats` is new and owns the CLASS: the
+ignore rule (with both controls — `package.json` must NOT be ignored,
+`bun.lock` must stay tracked) and a census of every non-comment `git pull
+--ff-only` in `infra/`, gated on a minimum hit count so an empty census
+cannot report a green. `deploy_jail_test.bats` owns the BEHAVIOUR, because
+it already has a throwaway upstream and clone and can pull across a real
+gitlink bump; its two cases are a pair, the second planting genuine dirt and
+demanding it still shows, because "the tree is clean" alone is
+indistinguishable from a cure that blinded `git status`.
+
+Three mutants, three kills, one assertion each: dropping the flag from the
+jail pull kills both behavioural cases naming ` M sub`; dropping the ignore
+line kills exactly one census case; dropping the flag from
+`jail_git_pull.sh` — a door the behavioural test cannot reach — kills only
+the census, naming the door.
+
+### What this does NOT claim
+
+**Nothing was run on the jail. Production is not ours to touch and the box
+was not reachable from here.** Every measurement above is local: a throwaway
+git bench for the pull semantics, the repo's own bats set for the cures.
+
+Two consequences are stated rather than hidden. The exact SHAPE of the jail's
+submodule dirt was never measured — `git status --short` prints ` M` for
+`(new commits)`, `(modified content)` and `(untracked content)` alike, and
+the issue records only the short form. The cure addresses `(new commits)`,
+which is *structurally guaranteed* to be present (the pin moved, nothing on
+that box moves the submodule worktree), but if content dirt is ALSO there it
+survives — correctly, since that would be real dirt somebody made. And the
+claim that the jail already holds the objects the checkout needs is an
+INFERENCE, not a measurement: a pull whose on-demand submodule fetch fails
+exits 1 and aborts `substrate_pull` under `set -e`, and v1.5.0 is live, so
+the jail's pull across `f2b93f2bf` must have fetched successfully. Sound, but
+inferred.
+
+_Deploy: **classification NOT measured** — the `Preflight.classify_paths`
+oneshot needs the compile lane, which this slice did not hold. Read from the
+source rather than run: the slice touches `infra/**`, `test/**`, `docs/**`
+and `cicchetto/.gitignore`, and no `compose.*` path and no `VERSION`, which
+are the two literals that force COLD. Treat it as unverified until the
+oneshot is run._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -3406,6 +3406,25 @@ base-select and validation, the nothing-to-do predicate, the preflight
 verdict→mode mapping, the reload `"failed":[]` honesty check, the
 healthcheck loop, and the marker write. Every one of those is a
 documented invariant that previously lived — and drifted — per script.
+**Every `substrate_pull` spells the pull `git pull --ff-only
+--recurse-submodules=on-demand`, and the flag is load-bearing (#1851).** A
+bare `--ff-only` advances the superproject and leaves every submodule
+working tree where it was, and nothing downstream syncs it back — so one
+gitlink bump leaves a deploy checkout dirty FOREVER.
+`Grappa.Version.GitProbe` reads `git status --porcelain` at compile time, so
+that stale gitlink is what made three consecutive prod releases report the
+unreleased `X.Y.Z-<sha>` instead of the bare tag #391 promises. `on-demand`
+and not the bare flag, measured: the bare form is `=yes` and fetches every
+submodule on EVERY pull, so a box that cannot reach the submodule remote
+would stop deploying entirely; `on-demand` is git's own fetch default, so
+only the CHECKOUT half of the pull is new and the flag cannot introduce a
+failure the pull does not already have. It is a no-op on a checkout that
+never initialised the submodule, which is what a plain `git clone` leaves —
+production does not get a test-only testnet dragged onto it. **The general
+rule behind it: any path a deploy WRITES into the checkout must be covered
+by `.gitignore`, or it poisons the reported version the same way** —
+`runtime/last-deployed-sha` is one, already covered by `/runtime/*`.
+
 The consumer supplies hooks (`substrate_pull`, `substrate_build`,
 `substrate_reload`, `substrate_migrate`, `substrate_restart`, …); the
 hook list in the file header is the API, because hook names are only
@@ -3723,7 +3742,7 @@ The current set:
 | `jail_db_query.sh` / `jail_db_write.sh` | sqlite3 against the prod DB as `grappa` |
 | `jail_import_db.sh` | swap a DB file in (service must be stopped) |
 | `jail_dns_check.sh` | resolve a hostname *from inside the BEAM* — the OS resolver can be fine while Erlang's `:inet_res` still holds a stale cache |
-| `jail_git_pull.sh` | `git pull --ff-only` in the jail checkout |
+| `jail_git_pull.sh` | `git pull --ff-only --recurse-submodules=on-demand` in the jail checkout |
 
 ### The rails' contract — three shapes, all deliberate
 
@@ -4270,6 +4289,13 @@ shared library's — § "The shared deploy library (infra/lib/)" and
   `package-lock.json` is a FreeBSD-only regenerated artefact.** Someone
   reading the jail script without knowing this will "fix" the npm
   fallback and break the jail build.
+  **It is gitignored, and that is not tidiness (#1851).** The fallback
+  writes it INSIDE the checkout, so while it was untracked and unignored
+  every jail deploy left `git status --porcelain` non-empty — which
+  `Grappa.Version.GitProbe` reads at compile time, so the release reported
+  `X.Y.Z-<sha>` instead of the bare tag. Do not un-ignore it and do not
+  commit it: it is generated, it is one substrate's, and nothing reads it
+  but that fallback.
 - **PATH must include `~grappa/.local/bin`.** bun lives there
   (`install_toolchain.sh` puts it there), and `sudo -u … bash -c`
   otherwise falls back to the system default PATH, which does not — the

--- a/infra/freebsd/deploy.sh
+++ b/infra/freebsd/deploy.sh
@@ -78,7 +78,11 @@ run_as_grappa() {
 # Why: docs/OPERATIONS.md § "The FreeBSD jail rails (infra/freebsd/)".
 substrate_pull() {
 	PREV_SHA=$(run_as_grappa 'git rev-parse HEAD' | tail -1)
-	run_as_grappa 'git pull --ff-only && git log --oneline -3'
+	# --recurse-submodules=on-demand completes the pull: without it a gitlink
+	# bump leaves this checkout dirty forever and every release reports
+	# X.Y.Z-<sha>. Why + why not the bare flag: infra/lib/deploy_common.sh,
+	# above the substrate_pull call (#1851).
+	run_as_grappa 'git pull --ff-only --recurse-submodules=on-demand && git log --oneline -3'
 	NEW_SHA=$(run_as_grappa 'git rev-parse HEAD' | tail -1)
 }
 

--- a/infra/freebsd/jail_deploy_cic.sh
+++ b/infra/freebsd/jail_deploy_cic.sh
@@ -25,11 +25,18 @@ set -eu
 REPO_ROOT="${REPO_ROOT:-/home/grappa/grappa}"
 RELOAD_URL="${RELOAD_URL:-http://127.0.0.1:4000/admin/cic-bundle-changed}"
 
-echo "[deploy-cic] git pull --ff-only"
+# --recurse-submodules=on-demand completes the pull: without it a gitlink bump
+# leaves this checkout dirty forever, and the NEXT server deploy compiles from
+# a dirty tree and reports X.Y.Z-<sha>. A cic-only deploy runs no compile, so
+# it does not pay the price itself — it hands it to whoever deploys next, which
+# is exactly why the flag belongs on every door and not only the compiling one.
+# Why + why not the bare flag: infra/lib/deploy_common.sh, above the
+# substrate_pull call (#1851).
+echo "[deploy-cic] git pull --ff-only --recurse-submodules=on-demand"
 su -l grappa -c "
 	set -eu
 	cd '${REPO_ROOT}'
-	git pull --ff-only
+	git pull --ff-only --recurse-submodules=on-demand
 	git log --oneline -3
 "
 

--- a/infra/freebsd/jail_git_pull.sh
+++ b/infra/freebsd/jail_git_pull.sh
@@ -8,6 +8,10 @@ set -eu
 exec su -l grappa -c '
 set -eu
 cd /home/grappa/grappa
-git pull --ff-only
+# --recurse-submodules=on-demand completes the pull: without it a gitlink
+# bump leaves this checkout dirty forever and every release reports
+# X.Y.Z-<sha>. Why + why not the bare flag: infra/lib/deploy_common.sh,
+# above the substrate_pull call (#1851).
+git pull --ff-only --recurse-submodules=on-demand
 git log --oneline -3
 '

--- a/infra/lib/deploy_common.sh
+++ b/infra/lib/deploy_common.sh
@@ -417,7 +417,33 @@ deploy_main() {
 		_deploy_defer_hot_error
 	fi
 
-	deploy_log "git pull --ff-only"
+	# #1851 — every substrate_pull spells this `git pull --ff-only
+	# --recurse-submodules=on-demand`, and the flag is load-bearing.
+	#
+	# A bare `--ff-only` advances the SUPERPROJECT and leaves every submodule
+	# working tree exactly where it was, so a single gitlink bump dirties a
+	# deploy checkout PERMANENTLY — nothing downstream ever syncs it back.
+	# `Grappa.Version.GitProbe` snapshots `git status --porcelain` at compile
+	# time, so that stale gitlink turned three consecutive prod releases into
+	# the unreleased form (`1.4.0-596d5ea0`, `1.4.1-997711ac`,
+	# `1.5.0-35e9fca6`) and left #391's "this build is NOT the tag" signal
+	# permanently on, discriminating nothing.
+	#
+	# `=on-demand` and NOT a bare `--recurse-submodules`, measured: the bare
+	# form is `=yes`, which fetches every submodule on EVERY pull, so a box
+	# that cannot reach the submodule remote goes from "deploys fine until
+	# the gitlink moves" to "never deploys". `on-demand` IS git's own fetch
+	# default, so the FETCH half of the pull is byte-for-byte what it already
+	# does and only the CHECKOUT half is new — the flag cannot introduce a
+	# failure the current pull does not already have (measured: with the
+	# submodule remote unreachable and its objects absent, both spellings
+	# exit 1 with the same "Errors during submodule fetch" and leave the
+	# superproject un-advanced).
+	#
+	# It is also a no-op on a checkout that never initialised the submodule,
+	# which is what a plain `git clone` leaves behind — so it does NOT drag a
+	# test-only testnet onto a production box that does not have one.
+	deploy_log "git pull --ff-only --recurse-submodules=on-demand"
 	substrate_pull
 
 	if [ "$DEPLOY_FEATURE_PREV_SHA_CARRY" = 1 ]; then

--- a/infra/lib/deploy_docker.sh
+++ b/infra/lib/deploy_docker.sh
@@ -122,7 +122,12 @@ substrate_pull() {
 	# A bare `git pull --ff-only` failure under `set -e` aborts with no
 	# explanation, and a diverged branch is not something an operator can
 	# read out of an exit code.
-	git pull --ff-only || die "pull is not a fast-forward — the branch diverged. Resolve it by hand."
+	#
+	# --recurse-submodules=on-demand completes the pull: without it a gitlink
+	# bump leaves this checkout dirty forever and every release reports
+	# X.Y.Z-<sha>. Why + why not the bare flag: infra/lib/deploy_common.sh,
+	# above the substrate_pull call (#1851).
+	git pull --ff-only --recurse-submodules=on-demand || die "pull is not a fast-forward — the branch diverged. Resolve it by hand."
 	NEW_SHA="$(git rev-parse HEAD)"
 }
 

--- a/infra/linux/deploy.sh
+++ b/infra/linux/deploy.sh
@@ -60,7 +60,11 @@ run_as_grappa() {
 
 substrate_pull() {
 	PREV_SHA=$(run_as_grappa 'git rev-parse HEAD' | tail -1)
-	run_as_grappa 'git pull --ff-only && git log --oneline -3'
+	# --recurse-submodules=on-demand completes the pull: without it a gitlink
+	# bump leaves this checkout dirty forever and every release reports
+	# X.Y.Z-<sha>. Why + why not the bare flag: infra/lib/deploy_common.sh,
+	# above the substrate_pull call (#1851).
+	run_as_grappa 'git pull --ff-only --recurse-submodules=on-demand && git log --oneline -3'
 	NEW_SHA=$(run_as_grappa 'git rev-parse HEAD' | tail -1)
 }
 

--- a/test/infra/deploy_checkout_dirt_test.bats
+++ b/test/infra/deploy_checkout_dirt_test.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+#
+# #1851 — a production checkout that is dirty BY CONSTRUCTION makes every
+# release report the unreleased form `X.Y.Z-<sha>`.
+#
+# `Grappa.Version.GitProbe.facts/1` snapshots `git status --porcelain` at
+# COMPILE time, and `Grappa.Version.derive/2` folds a dirty tree into the
+# #391 suffix. That suffix is the signal "this build is NOT the tag", and it
+# is correct — the defect is upstream of it: the deploy machinery itself
+# leaves two entries in the jail's `git status`, so the signal is always on
+# and therefore discriminates nothing. Measured on prod across three
+# releases (`1.4.0-596d5ea0`, `1.4.1-997711ac`, `1.5.0-35e9fca6`).
+#
+# The two sources are DIFFERENT and take DIFFERENT cures; this suite pins
+# both at the level each one lives at:
+#
+#   1. `cicchetto/package-lock.json` — untracked. The FreeBSD cic build has
+#      an `npm install` fallback (no bun port on FreeBSD) that regenerates
+#      it INSIDE the checkout. It is a build artefact of one substrate's
+#      toolchain, never a source of truth (`bun.lock` is canonical — see
+#      docs/OPERATIONS.md § "cic_build.sh — bun here, npm only on FreeBSD"),
+#      so it belongs in `.gitignore` like every other generated path.
+#
+#   2. `cicchetto/e2e/infra` — a submodule reported modified. `git pull
+#      --ff-only` advances the superproject and leaves every submodule
+#      working tree exactly where it was, so ONE gitlink bump dirties a
+#      deploy checkout permanently. The cure completes the pull.
+#
+# What each case proves is stated on the case. The BEHAVIOURAL proof for (2)
+# — that the flag actually leaves a real checkout clean after a real pull
+# across a real gitlink bump — lives in deploy_jail_test.bats, which already
+# owns a throwaway upstream + clone; this suite pins the CLASS (every door
+# carries it) so a sixth pull site cannot be added without one.
+
+load ../bats_helpers
+
+setup() {
+    REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+}
+
+# --- source 1: the untracked build artefact --------------------------------
+
+@test "#1851: the FreeBSD cic build's package-lock.json is ignored by the repo" {
+    # Deliberately measured against the REAL checkout, not a fixture: the
+    # claim IS that this repository's own ignore rules cover the artefact its
+    # own deploy writes. A fixture would prove something about the fixture.
+    git -C "$REPO" check-ignore -q cicchetto/package-lock.json
+}
+
+@test "#1851: package.json is NOT ignored — the rule is scoped, and check-ignore is looking" {
+    # Negative control for the case above. Without it a `check-ignore` that
+    # matched everything (or a `.gitignore` with a stray `*`) would read as a
+    # pass, and a green would prove only that the command ran.
+    refute git -C "$REPO" check-ignore -q cicchetto/package.json
+}
+
+@test "#1851: bun.lock stays tracked — the canonical lock is not collateral" {
+    # The cure must ignore the npm artefact WITHOUT touching the lock the
+    # whole toolchain is pinned on. `ls-files` answers from the index, so a
+    # rule broad enough to swallow `bun.lock` would show up here as an empty
+    # answer even though the file is on disk.
+    [ "$(git -C "$REPO" ls-files cicchetto/bun.lock)" = "cicchetto/bun.lock" ]
+}
+
+# --- source 2: the submodule left stale by the pull ------------------------
+
+@test "#1851: every deploy pull completes itself with --recurse-submodules=on-demand" {
+    # The class guard. Comment lines are excluded (they narrate, they do not
+    # pull); log lines are NOT, because a deploy that announces a command it
+    # did not run is the log-honesty failure CLAUDE.md bans.
+    #
+    # `on-demand` and not a bare `--recurse-submodules`: measured, the bare
+    # form fetches every submodule on EVERY pull, so a box that cannot reach
+    # the submodule remote goes from "deploys fine until the gitlink moves"
+    # to "never deploys". `on-demand` is git's own fetch default, so the
+    # FETCH half of the pull is byte-for-byte what it does today and only the
+    # CHECKOUT half is new — the flag cannot introduce a failure the current
+    # pull does not already have.
+    cd "$REPO"
+    doors="$(git grep -n -- 'git pull --ff-only' -- infra/ | grep -vE ':[[:space:]]*#')"
+
+    # Positive control: an empty census passes every per-line assertion
+    # below and would report a green that proves nothing.
+    count="$(printf '%s\n' "$doors" | grep -c 'git pull --ff-only')"
+    [ "$count" -ge 5 ]
+
+    missing=""
+    while IFS= read -r line; do
+        case "$line" in
+            *--recurse-submodules=on-demand*) ;;
+            *) missing="${missing}${line}"$'\n' ;;
+        esac
+    done <<< "$doors"
+
+    [ -z "$missing" ] || {
+        printf 'pull sites missing --recurse-submodules=on-demand:\n%s' "$missing" >&2
+        false
+    }
+}

--- a/test/infra/deploy_jail_test.bats
+++ b/test/infra/deploy_jail_test.bats
@@ -630,6 +630,120 @@ EOF
     refute grep -q "still RUNNING" <<<"$output"
 }
 
+# --- #1851: the deploy must leave the checkout it just built CLEAN ----------
+#
+# `Grappa.Version.GitProbe` snapshots `git status --porcelain` at compile
+# time, so anything the deploy machinery leaves behind in the working tree
+# turns every release into the unreleased form `X.Y.Z-<sha>` (#391). `git
+# pull --ff-only` advances the superproject and leaves every submodule
+# working tree where it was, so ONE gitlink bump dirties the checkout
+# permanently — measured on the prod jail across three releases.
+#
+# These two cases are a pair and must be read as one: the first says the
+# cure cleans the tree, the second says it did NOT do so by blinding the
+# probe. A green on the first alone is indistinguishable from a cure that
+# silenced `git status` altogether, which would destroy the very signal
+# #391 exists for.
+
+# Give $UPSTREAM a submodule and $REPO_ROOT an in-sync populated copy, then
+# echo the submodule commit the next bump moves to. Callers must have
+# exported the file-transport allowance first (see the cases).
+seed_submodule() {
+    local suborigin="$BATS_TEST_TMPDIR/subupstream" first
+    git init -q -b main "$suborigin"
+    git -C "$suborigin" config user.email test@grappa.local
+    git -C "$suborigin" config user.name "bats"
+    echo one > "$suborigin/f"
+    git -C "$suborigin" add -A
+    git -C "$suborigin" commit -qm one
+    first="$(git -C "$suborigin" rev-parse HEAD)"
+    echo two > "$suborigin/f"
+    git -C "$suborigin" add -A
+    git -C "$suborigin" commit -qm two
+
+    git -C "$UPSTREAM" submodule add -q "$suborigin" sub
+    git -C "$UPSTREAM/sub" checkout -q "$first"
+    git -C "$UPSTREAM" add -A
+    git -C "$UPSTREAM" commit -qm "add sub pinned at its first commit"
+
+    git -C "$REPO_ROOT" pull -q --ff-only
+    git -C "$REPO_ROOT" submodule update -q --init
+
+    git -C "$suborigin" rev-parse HEAD
+}
+
+# Move the upstream's gitlink to $1 — the gesture that dirties every
+# already-deployed checkout.
+bump_submodule() {
+    git -C "$UPSTREAM/sub" fetch -q origin
+    git -C "$UPSTREAM/sub" checkout -q "$1"
+    git -C "$UPSTREAM" add sub
+    git -C "$UPSTREAM" commit -qm "bump the submodule gitlink"
+}
+
+# The deploy writes runtime/last-deployed-sha INTO the checkout, so it is a
+# THIRD would-be source of permanent dirt — already cured, by the repo's own
+# `/runtime/*` ignore rule. The throwaway upstream carries no .gitignore at
+# all, so without this it reports `?? runtime/last-deployed-sha` and the
+# fixture lies about the shape of the thing under test. Mirroring the real
+# rule is fixture FIDELITY, not a way to make the assertion pass: the general
+# lesson is that any new deploy-written path must be checked against
+# .gitignore or it poisons the version string the same way (#1851).
+mirror_runtime_ignore() {
+    printf '/runtime/*\n!/runtime/.gitkeep\n' > "$UPSTREAM/.gitignore"
+    git -C "$UPSTREAM" add .gitignore
+    git -C "$UPSTREAM" commit -qm "ignore the deploy marker, as the real repo does"
+}
+
+# The submodule remote is a filesystem path, which the CVE-2022-39253
+# mitigation blocks by default. Exported (not a per-repo config) so it
+# reaches the git the deploy runs through the `su` stub as well.
+allow_file_transport() {
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0=protocol.file.allow
+    export GIT_CONFIG_VALUE_0=always
+}
+
+@test "#1851: a deploy pull across a submodule gitlink bump leaves the checkout CLEAN" {
+    allow_file_transport
+    mirror_runtime_ignore
+    target="$(seed_submodule)"
+    # Assert the PRE-state: the tree is clean before the gesture, so a green
+    # below cannot be a tree that was never dirty in the first place.
+    [ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]
+    bump_submodule "$target"
+
+    run_deploy --force-cold
+    [ "$status" -eq 0 ]
+    # THE assertion — this is exactly what GitProbe snapshots at compile
+    # time, so an empty answer here is a bare `X.Y.Z` on the next release.
+    # Printed on failure: "the tree is dirty" is useless without the entry,
+    # which is the whole lesson of the issue this case comes from.
+    porcelain="$(git -C "$REPO_ROOT" status --porcelain)"
+    [ -z "$porcelain" ] || {
+        printf 'checkout STILL dirty after the deploy:\n%s\n' "$porcelain" >&2
+        false
+    }
+}
+
+@test "#1851: the cure cleans the tree without blinding it — real dirt still shows" {
+    allow_file_transport
+    mirror_runtime_ignore
+    target="$(seed_submodule)"
+    bump_submodule "$target"
+    # A stray untracked file is the OTHER half of the prod symptom (the cic
+    # build's package-lock.json), and it is genuine dirt: the probe must go
+    # on reporting it, or the #391 suffix has been cured to death.
+    : > "$REPO_ROOT/an-operators-stray-file.json"
+
+    run_deploy --force-cold
+    [ "$status" -eq 0 ]
+    [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]
+    [[ "$(git -C "$REPO_ROOT" status --porcelain)" == *"an-operators-stray-file.json"* ]]
+    # ...and the submodule is NOT what is dirtying it any more.
+    refute grep -q ' M sub' <<<"$(git -C "$REPO_ROOT" status --porcelain)"
+}
+
 @test "#1656: a consumer with no liveness hook reports UNKNOWN, never DOWN" {
     # infra/docker/get.sh mirrors the lib and the consumer as separate files,
     # so new-lib/old-consumer is reachable on an operator's box. An undefined


### PR DESCRIPTION
Issue #1851. The jail's working tree is dirty by construction, so every
release reports `X.Y.Z-<sha>` instead of the bare tag.

`Grappa.Version` is **not** the defect and is not touched here. An unclean
tree at compile time IS an unreleased build, and the suffix saying so is
#391 working. The defect is one layer up: the deploy machinery manufactures
the uncleanliness, so the signal is permanently on and discriminates
nothing.

## Two entries, two causes, two cures

The issue framed "option A" as one cure. It is two, at two different
layers, and forcing one mechanism onto both would have been wrong in one.

**`cicchetto/package-lock.json`** — untracked. `jail_cic_build.sh` falls
back to `npm install` (no bun port on FreeBSD), which regenerates it inside
the checkout. `bun.lock` is canonical and OPERATIONS.md already said so. A
generated path belongs in `.gitignore`, next to `dist/` and `.vite/`.

**`cicchetto/e2e/infra`** — the pull failing to finish. `git pull --ff-only`
advances the superproject and leaves every submodule working tree where it
was; nothing downstream syncs it back, so ONE gitlink bump dirties a deploy
checkout permanently. The pin last moved on 2026-08-23 (`f2b93f2bf`). Cure:
`--recurse-submodules=on-demand` on every deploy pull — three
`substrate_pull` hooks (jail, linux, docker) and the two standalone jail
rails, plus the two log lines, which move with the commands.

## Why `on-demand` and not the bare flag — measured on a throwaway bench

| pull spelling | gitlink moved | gitlink still, remote down | tree after |
|---|---|---|---|
| `--ff-only` (before) | rc 0 | rc 0 | **DIRTY** |
| `--recurse-submodules` (`=yes`) | rc 0 | **rc 1** | clean |
| `--recurse-submodules=on-demand` | rc 0 | rc 0 | clean |

The bare flag is `=yes` and fetches every submodule on EVERY pull, so a box
that cannot reach the submodule remote goes from "deploys fine until the
gitlink moves" to "never deploys" — and this submodule sits behind a `git@`
SSH URL production has no reason to hold a key for.

`on-demand` IS git's own fetch default, so the FETCH half is byte-for-byte
what the pull already does and only the CHECKOUT half is new. **The flag
therefore cannot introduce a failure the current pull does not already
have** — measured directly: with the remote unreachable AND the new objects
absent, old and new fail identically (rc 1, the same `Errors during
submodule fetch`, superproject un-advanced). It is a no-op where the
submodule was never initialised, which is what a plain `git clone` leaves,
so production does not get a test-only testnet dragged onto it.

## Two cures measured and REJECTED

- **`ignore = all` in `.gitmodules`** cleans the status and also makes
  `git add cicchetto/e2e/infra` stage *nothing* (`git diff --cached
  --name-only` comes back empty). A deliberate bump like `f2b93f2bf` becomes
  uncommittable through the normal gesture. `ignore = dirty` does not apply:
  the dirt is `(new commits)`, which `dirty` deliberately still reports.
- **A deploy-noise allowlist inside `GitProbe`** (the issue's option B)
  makes "clean" a policy that rots, and would report `X.Y.Z` for a checkout
  that genuinely is not `X.Y.Z` — a worse lie than the one being fixed.

## A third source, already covered

The deploy writes `runtime/last-deployed-sha` into the checkout. It is not
dirt today only because the root `.gitignore` carries `/runtime/*`. It
surfaced as a red in the new bats case, whose throwaway upstream had no
`.gitignore` — the fixture was lying by omission. The general rule is now in
OPERATIONS.md: **any path a deploy WRITES into the checkout must be covered
by `.gitignore`, or it poisons the reported version the same way.**

## Tests

`test/infra/deploy_checkout_dirt_test.bats` (new) owns the CLASS: the ignore
rule with both controls (`package.json` must NOT be ignored, `bun.lock` must
stay tracked) and a census of every non-comment `git pull --ff-only` in
`infra/`, gated on a minimum hit count so an empty census cannot report a
green.

`test/infra/deploy_jail_test.bats` owns the BEHAVIOUR — it already has a
throwaway upstream and clone and can pull across a real gitlink bump. Its
two cases are a pair: the second plants genuine dirt and demands it still
shows, because "the tree is clean" alone is indistinguishable from a cure
that blinded `git status`.

**Gates**
- Full `scripts/bats.sh`: **733/733, 0 failures**, taken on this exact head
  (`5284d6a9`) after the rebase.
- **Three mutants, three kills, one assertion each.** Flag removed from the
  jail pull → both behavioural cases die naming ` M sub`. Ignore line
  removed → exactly one census case dies. Flag removed from
  `jail_git_pull.sh`, a door the behavioural test cannot reach → only the
  census dies, naming the door.
- `union-rebase.sh` onto `ca8b68533`: `+138 -0`, the preceding entry
  byte-identical under `cmp` (with a negative control proving `cmp` can
  fail).

## Measurement limits — stated, not filled in

**Nothing was run on the jail.** Production is not ours and the box was not
reachable from here. Every measurement is local: a throwaway git bench for
the pull semantics, the repo's own bats set for the cures.

- The exact **shape** of the jail's submodule dirt was never measured.
  `git status --short` prints ` M` for `(new commits)`, `(modified content)`
  and `(untracked content)` alike, and the issue records only the short
  form. The cure addresses `(new commits)`, which is structurally guaranteed
  to be present; if content dirt is also there it survives — correctly, as
  that would be dirt somebody made.
- That the jail already holds the objects its checkout needs is an
  **inference**, not a measurement: a pull whose on-demand submodule fetch
  fails exits 1 and aborts `substrate_pull` under `set -e`, and v1.5.0 is
  live, so the pull across `f2b93f2bf` must have fetched. Sound, but
  inferred.
- **The #391 two-sided signal proof has NOT been run.**
  `version_test.exs` + `version_git_probe_test.exs` already pin both sides
  (clean tag → bare; dirty tree → suffix) and neither is touched by this
  branch, but running them needs the compile lane, which this slice did not
  hold. The bats pair covers the same claim at the level of the probe's
  INPUT (`git status --porcelain`), not at `derive/2`.
- The `_Deploy:_` footer on the DESIGN_NOTES entry is marked **NOT
  measured** for the same reason: the `Preflight.classify_paths` oneshot
  needs the compile lane. Read from source rather than run — the slice
  touches no `compose.*` path and no `VERSION`, the two literals that force
  COLD.
