### PR TITLE
#1850: turn the silent stale-code-path reload into a 409 the deploy sees

### DIFF
--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -463,6 +463,14 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // copy: a restart is what the other token asks for and the wrong
       // move for this one, which needs the duplicate resolved in the repo.
       return "Two migration files claim the same version; nothing was applied.";
+    case "stale_code_path":
+      // #1850 — 409 from the same loopback-gated POST /admin/reload, so
+      // likewise unreachable from a browser; the arm exists because the
+      // union is exhaustive. Copy matches the contract-migration arm's
+      // ASK (a full restart) without borrowing its REASON: nothing is
+      // wrong with the database here, the new code simply is not on the
+      // path the running node reads.
+      return "The server needs a full restart to pick up the new code.";
     case "client_token_scope":
       // #1196 — 403 for a per-client token on a credential-management
       // route. cic authenticates with a browser session, so this arm is

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1684,6 +1684,7 @@ export const S_ErrorTokensRestErrorToken = {
     { l: "session_plan_resolve_failed" },
     { l: "contract_migrations_pending" },
     { l: "duplicate_migration_versions" },
+    { l: "stale_code_path" },
     { l: "invalid_message" },
     { l: "anon_collision" },
     { l: "nick_in_use" },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1704,6 +1704,7 @@ export const ERROR_TOKENS_REST_ERROR_TOKEN = [
   "session_plan_resolve_failed",
   "contract_migrations_pending",
   "duplicate_migration_versions",
+  "stale_code_path",
   "invalid_message",
   "anon_collision",
   "nick_in_use",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47141,3 +47141,146 @@ source rather than run: the slice touches `infra/**`, `test/**`, `docs/**`
 and `cicchetto/.gitignore`, and no `compose.*` path and no `VERSION`, which
 are the two literals that force COLD. Treat it as unverified until the
 oneshot is run._
+<!-- entry #1850 -->
+
+---
+
+## 2026-09-06 — #1850: the reload that answers "nothing to do" when it means "I read the wrong tree"
+
+A `VERSION`-only bump is COLD on the two `mix release` substrates because the
+code path carries the vsn: `lib/grappa-<vsn>/ebin`, and `:code.lib_dir/1`
+resolves to the **boot** directory forever. `Grappa.Deploy.Preflight.version?/1`
+already PREVENTS that (#1287). What nothing did was **detect** it, and the issue
+text said so outright: *"That miss cannot be reported, only prevented."*
+
+**That claim is false, and this entry is the mechanism.** The live node knows
+the vsn in its own code path, and the release on disk names the vsn it last
+assembled. Comparing the two is exact, needs no heuristic, and is observable
+from precisely one place — inside the running BEAM, which is where
+`Grappa.HotReload.audit_code_path/1` now sits.
+
+### Why detection is not redundant with prevention
+
+Preflight classifies a DIFF, on the deploying host, before the POST. Three
+things escape it, and they are the same three that escape the pending-migration
+verdict (`migrate_and_reload/2`'s moduledoc already argues this for migrations —
+the argument transfers whole):
+
+* `--force-hot` skips preflight entirely.
+* A diff range that does not contain the bump has nothing to classify.
+* Prevention leaves no trace when it is bypassed; the reload's own
+  `{"reloaded":[],"failed":[]}` is indistinguishable from "nothing to do".
+
+Production served the old BEAM under the new git history for ~6.5 hours on
+2026-08-13 through that third shape, and the deploy printed success.
+
+### The measurement that killed the first design
+
+The obvious oracle is "is there more than one `lib/grappa-*` sibling?". It is
+wrong, and a real `mix release --overwrite` says so. Measured 2026-09-06 in an
+isolated build cache (`GRAPPA_CACHE_ID`), two consecutive assembles of this
+tree:
+
+    VERSION=1.5.1   lib/grappa-1.5.1                     start_erl.data: 16.4.0.4 1.5.1
+    VERSION=9.9.9   lib/grappa-1.5.1 + lib/grappa-9.9.9  start_erl.data: 16.4.0.4 9.9.9
+
+`--overwrite` **does not prune**: the boot dir survives with its mtime
+untouched (22:26:03 vs the new dir's 22:26:10), and `releases/` keeps both
+version subdirectories. Stale lib dirs therefore accumulate for the life of the
+install, so sibling-counting would refuse **every** hot deploy on a jail that
+has ever been bumped — a permanent false COLD, which is exactly the
+session-dropping class this whole area exists to avoid.
+
+What DOES move is `<rel>/releases/start_erl.data`. That is the oracle. (There
+is no `RELEASES` file at all: `mix release` does not write one, only
+`release_handler` does — worth knowing before anyone reaches for it.)
+
+### Shape
+
+`audit_code_path/1` is pure-ish and total, three arms:
+
+* basename carries no `grappa-<vsn>` → `:ok`. This is Docker and every source
+  checkout (`_build/<env>/lib/grappa`), where the fresh beams always land where
+  the node already looks. **Inert by construction, not by a substrate flag** —
+  the same posture `Preflight` takes when it excludes `:docker` from
+  `version?/1` by measurement rather than omission.
+* vsn matches `start_erl.data` → `:ok`, leftovers or not.
+* anything else → `{:error, {:stale_code_path, %{booted:, built:, lib_dir:}}}`.
+
+Unreadable or malformed metadata under a versioned path refuses rather than
+passing. A versioned path asserts "this is a mix release", so the metadata is
+expected; reading `:ok` out of its absence would restore the silence the audit
+exists to break. Same bias as `Preflight`'s "in doubt, COLD", and it costs
+nothing real: every shipped layout writes the file.
+
+It runs BEFORE the migration audit in `migrate_and_reload/2`. If the beams are
+in the wrong tree the deploy is going cold anyway, so committing DDL first buys
+nothing and muddies the "nothing ran" all three refusals now promise.
+`POST /admin/reload` answers 409 `stale_code_path` with both numbers, and
+`infra/lib/deploy_common.sh` names it as cause 3 — `curl -f` discards the body,
+so the script has to enumerate rather than guess.
+
+### The bug the test caught, kept because it generalises
+
+`built_vsn/1` first read `Path.join([lib_dir, "..", "..", "releases", …])`. The
+vanished-boot-dir case went red: `..` is resolved by the OS at open time and is
+ENOENT when a component is missing — and a missing component is exactly the
+case under test. The refusal still fired, but `built` came back `nil`, losing
+the one fact the operator most needs. `Path.dirname/1` twice is lexical and
+correct. **General rule: when a path is being computed ABOUT a directory that
+may not exist, `..` is the wrong operator.**
+
+### Wire
+
+`GrappaWeb.ErrorTokens` is a generated-artefact source, so the new token lands
+in `REST_ERROR_TOKENS` / `wireSchema.ts` and moves the digest —
+`mix grappa.wire_pin` demanded protocol **13**, it was not a judgement call.
+v12's measured client break does NOT reproduce: the endpoint is loopback-gated,
+so no bundle will ever be handed this token. The number moves because the shape
+moved and the floor must stay TOTAL. `min_protocol_version` stays 1.
+
+### What this is NOT
+
+**It is reportability, not the cure.** #1850 asks for a direction among
+appup/relup (A), freezing the OTP app vsn (B), and compiling the hot branch into
+the live vsn's ebin (C). This entry picks none of them: a release cut still
+cold-restarts prod. It converts a silent 6.5-hour class into a refusal the
+operator sees, which every one of A/B/C wants anyway.
+
+One thing measured in passing, because it cheapens C: the issue worries that C
+leaves "the node reporting the old number while running new code". For
+`Grappa.Version.base/0` that does not happen — it is a compile-time constant
+inside `Version.beam` (`version.ex:156`), so a reload that loads that beam
+reports the NEW number, which is the code actually running. What stays old
+under C is the directory name and `Application.spec(:grappa, :vsn)`, and
+`version.ex:37-39` records that nothing else in the tree reads the latter.
+
+### What was not measured, and what is not asserted
+
+* **Neither release substrate was exercised.** No jail, no systemd host. The
+  release LAYOUT was measured on a real `mix release --overwrite`, which is a
+  property of Mix and not of FreeBSD; the *deploy* on those substrates was not.
+* The 2026-08-13 production incident is quoted from the record, not re-measured.
+* The wiring `migrate_and_reload/2 → audit_code_path/1` is a one-liner
+  composition and is **not** covered by a test that makes it FIRE: forcing drift
+  needs a versioned `:code.lib_dir(:grappa)`, which a source-checkout test run
+  does not have, and a seam for it would be a seam over a gated verb. Its
+  INERTNESS is gated — the migration suites drive `migrate_and_reload/2` and
+  would go red if the audit refused wrongly. This is the same posture already
+  declared for `reload_modified/0` in `hot_reload_test.exs`.
+* Not asserted: that this prevents any restart (it does not); that
+  `start_erl.data` is written by substrates other than `mix release`; that a
+  package install (`cp -a` of the release root) behaves identically — it should,
+  it was not run.
+
+_Deploy: **HOT** on every substrate, and measured rather than reasoned.
+`Preflight.classify_paths/3` over this slice's 11 changed paths returns
+`{:hot, []}` for `:docker`, `:jail` and `:linux` alike, and the verdict was
+gated on its controls before being emitted: `config/config.exs` COLD on all
+three, `VERSION` COLD on `:jail`/`:linux` and HOT on `:docker`, `compose.yaml`
+COLD on `:docker` only, an unreadable migration COLD on all three; and
+`docs/compose.notes.md` plus `infra/lib/deploy_common.sh` HOT everywhere. The
+state-shape axis was measured too, not assumed: `long_lived_module_files/0` has
+34 members and the intersection with this slice is empty. **`VERSION` still
+classifies COLD on the release substrates — this slice moves no
+classification.**_

--- a/infra/lib/deploy_common.sh
+++ b/infra/lib/deploy_common.sh
@@ -378,6 +378,13 @@ _deploy_hot() {
 		printf '[deploy]   HTTP 409, cause 1: a pending migration is CONTRACT → run a cold deploy\n' >&2
 		printf '[deploy]   HTTP 409, cause 2: two files claim one migration version — a\n' >&2
 		printf '[deploy]   cold deploy will not help, the duplicate must be resolved in the repo\n' >&2
+		# Since #1850 a third cause, and it is the one that used to be
+		# SILENT: on a release substrate the beams just built are in
+		# lib/grappa-<new>/ebin while the daemon still reads its boot
+		# directory, so the reload would have loaded nothing and said so
+		# in a shape indistinguishable from "nothing to do".
+		printf '[deploy]   HTTP 409, cause 3: the daemon reads lib/grappa-<booted>/ebin and this\n' >&2
+		printf '[deploy]   build wrote lib/grappa-<new>/ebin (a VERSION bump) → run a cold deploy\n' >&2
 		exit 1
 	fi
 

--- a/lib/grappa/hot_reload.ex
+++ b/lib/grappa/hot_reload.ex
@@ -284,7 +284,7 @@ defmodule Grappa.HotReload do
     end
   end
 
-  defp compare_vsn(_lib_dir, vsn, vsn), do: :ok
+  defp compare_vsn(_, vsn, vsn), do: :ok
 
   defp compare_vsn(lib_dir, booted, built),
     do: {:error, {:stale_code_path, %{booted: booted, built: built, lib_dir: lib_dir}}}
@@ -314,7 +314,7 @@ defmodule Grappa.HotReload do
     release_root = lib_dir |> Path.dirname() |> Path.dirname()
 
     with {:ok, contents} <- File.read(Path.join([release_root, "releases", "start_erl.data"])),
-         [_erts_vsn, vsn] <- contents |> String.trim() |> String.split(" ", trim: true) do
+         [_, vsn] <- contents |> String.trim() |> String.split(" ", trim: true) do
       vsn
     else
       _ -> nil

--- a/lib/grappa/hot_reload.ex
+++ b/lib/grappa/hot_reload.ex
@@ -68,15 +68,31 @@ defmodule Grappa.HotReload do
         }
 
   @typedoc """
+  What the running node loads from, versus what the build just wrote.
+
+  `booted` is the vsn carried in the live node's own code path; `built` is
+  the vsn the release metadata on disk names, `nil` when it could not be
+  read. `lib_dir` is the directory `reload_modified/0` would have walked.
+  """
+  @type code_path_drift :: %{
+          booted: String.t(),
+          built: String.t() | nil,
+          lib_dir: Path.t()
+        }
+
+  @typedoc """
   Refusal to migrate. Either the named migration files are pending and at
-  least one of their ops is contract (or unprovable), or a version is
-  claimed by two files (#1348). Nothing ran, in both cases — and the two
-  need OPPOSITE operator moves: the first is what a cold deploy is for,
-  the second is a repo defect a cold deploy walks straight back into.
+  least one of their ops is contract (or unprovable), a version is
+  claimed by two files (#1348), or the fresh beams landed in a lib
+  directory the running node never reads (#1850). Nothing ran, in all
+  three cases — and they need DIFFERENT operator moves: the first and the
+  third are what a cold deploy is for, the second is a repo defect a cold
+  deploy walks straight back into.
   """
   @type refusal ::
           {:contract_migrations, [Path.t()]}
           | {:duplicate_migration_versions, [MigrationAudit.duplicate()]}
+          | {:stale_code_path, code_path_drift()}
 
   @doc """
   Apply pending migrations on the live pool, THEN reload modules (#41).
@@ -140,6 +156,19 @@ defmodule Grappa.HotReload do
   @spec migrate_and_reload(module(), (-> result())) ::
           {:ok, migrate_result()} | {:error, refusal()}
   def migrate_and_reload(repo, reload_fn) when is_atom(repo) and is_function(reload_fn, 0) do
+    # The CODE-PATH audit runs before even the migration audit (#1850). If
+    # the build wrote its beams into a sibling directory, every module this
+    # call could load is already stale, so migrating first would commit DDL
+    # under code that a cold restart is about to replace anyway — and the
+    # 200 that followed would tell the deploy script "hot deploy complete"
+    # over a node that loaded nothing.
+    case audit_code_path(app_lib_dir()) do
+      :ok -> audit_migrations(repo, reload_fn)
+      {:error, _} = stale -> stale
+    end
+  end
+
+  defp audit_migrations(repo, reload_fn) do
     # The audit runs FIRST, and not only because a duplicate is the worse
     # defect: `pending_migration_files/1` below matches `[path] =
     # Path.wildcard(…)` per pending version, so a duplicate that is still
@@ -197,6 +226,102 @@ defmodule Grappa.HotReload do
   end
 
   @doc """
+  Refuse a hot reload whose fresh beams landed somewhere the running node
+  does not read (#1850).
+
+  Takes the lib directory the node resolves for `:grappa` — the parent of
+  the ebin `reload_modified/0` walks — and answers `:ok` or
+  `{:error, {:stale_code_path, drift}}`.
+
+  ## The silence this breaks
+
+  On the two `mix release` substrates the code path is
+  `lib/grappa-<vsn>/ebin`, and `:code.lib_dir/1` resolves it to the **boot**
+  directory forever. A `VERSION`-only bump moves the build's output to
+  `lib/grappa-<new>/ebin`, so `reload_modified/0` walks the stale tree,
+  diffs it against itself and answers `%{reloaded: [], failed: []}` — a
+  shape indistinguishable from "nothing to do". `Grappa.Deploy.Preflight`
+  PREVENTS that by classifying a `VERSION` diff COLD, but prevention is
+  not detection: `--force-hot` skips preflight entirely, and a diff range
+  that misses the bump has nothing to classify. Production served the old
+  BEAM under the new git history for ~6.5 hours on 2026-08-13 that way,
+  and the deploy printed success. Same posture as
+  `migrate_and_reload/2`'s pending-migration gate: the last line of
+  defence belongs HERE, where the code path is actually observable.
+
+  ## Why the release metadata, and not the sibling directories
+
+  Measured on a real `mix release --overwrite` (2026-09-06, isolated build
+  cache): a bump leaves the old `lib/grappa-<old>` **in place**, mtime
+  untouched, and adds `lib/grappa-<new>` beside it. Stale lib dirs
+  therefore accumulate forever, and "more than one `grappa-*` sibling"
+  would refuse every hot deploy on a jail that has ever been bumped —
+  a permanent false COLD.
+
+  What DOES move is `<rel>/releases/start_erl.data`, rewritten to
+  `"<erts_vsn> <release_vsn>"` on every assemble (`16.4.0.4 1.5.1` →
+  `16.4.0.4 9.9.9` across the two measured builds). Comparing it against
+  the vsn in the node's own code path is exact and carries no heuristic.
+
+  ## Inert where the layout cannot drift
+
+  Docker execs `mix phx.server` over a bind-mounted tree, where the lib
+  dir is `_build/<env>/lib/grappa` — no vsn in the path, so there is
+  nothing to compare and the fresh beams always land where the node is
+  already looking. That case returns `:ok` from the FIRST clause, by
+  construction rather than by a substrate flag.
+
+  A versioned path whose `start_erl.data` cannot be read or parsed
+  refuses. The path says "this is a mix release", so the metadata is
+  expected; reading `:ok` out of its absence would restore exactly the
+  silence this audit exists to break.
+  """
+  @spec audit_code_path(Path.t()) :: :ok | {:error, {:stale_code_path, code_path_drift()}}
+  def audit_code_path(lib_dir) when is_binary(lib_dir) do
+    case booted_vsn(lib_dir) do
+      nil -> :ok
+      booted -> compare_vsn(lib_dir, booted, built_vsn(lib_dir))
+    end
+  end
+
+  defp compare_vsn(_lib_dir, vsn, vsn), do: :ok
+
+  defp compare_vsn(lib_dir, booted, built),
+    do: {:error, {:stale_code_path, %{booted: booted, built: built, lib_dir: lib_dir}}}
+
+  # The vsn a `mix release` layout carries in the code path itself
+  # (`lib/grappa-1.5.1`); `nil` for the unversioned Docker / source-checkout
+  # layout (`_build/<env>/lib/grappa`).
+  defp booted_vsn(lib_dir) do
+    case Path.basename(lib_dir) do
+      "grappa-" <> vsn -> vsn
+      _ -> nil
+    end
+  end
+
+  # The vsn the release metadata names — what the last `mix release
+  # --overwrite` produced. `nil` when the file is missing or is not the
+  # documented `"<erts_vsn> <release_vsn>"` pair, which is a refusal (see
+  # the @doc): on a versioned path, unreadable metadata is doubt, not
+  # absence of drift.
+  defp built_vsn(lib_dir) do
+    # `Path.dirname/1` twice, NOT `Path.join([lib_dir, "..", "..", …])`:
+    # dirname is lexical, while `..` is resolved by the OS at open time and
+    # is ENOENT when a path component is missing. The component missing is
+    # exactly the case that matters — a boot dir the build removed — and
+    # the naive form lost the new vsn there while still refusing. Caught by
+    # `code_path_audit_test.exs`'s vanished-boot-dir case, not reasoned out.
+    release_root = lib_dir |> Path.dirname() |> Path.dirname()
+
+    with {:ok, contents} <- File.read(Path.join([release_root, "releases", "start_erl.data"])),
+         [_erts_vsn, vsn] <- contents |> String.trim() |> String.split(" ", trim: true) do
+      vsn
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
   Walk the grappa app's ebin and reload every new or changed module.
   The .beam files must already be fresh on disk — that's the deploy
   script's job (see `GrappaWeb.AdminController` moduledoc for the
@@ -204,8 +329,14 @@ defmodule Grappa.HotReload do
   """
   @spec reload_modified() :: result()
   def reload_modified do
-    :grappa |> :code.lib_dir() |> to_string() |> Path.join("ebin") |> reload_from()
+    app_lib_dir() |> Path.join("ebin") |> reload_from()
   end
+
+  # The one derivation of the running node's grappa lib directory — the
+  # ebin `reload_modified/0` walks lives under it, and `audit_code_path/1`
+  # reads the vsn off it. `:code.lib_dir/1` resolves to the BOOT directory,
+  # which is the whole point of the audit.
+  defp app_lib_dir, do: :grappa |> :code.lib_dir() |> to_string()
 
   @doc """
   Reload every beam under `ebin_dir` that is new (module not loaded)

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -273,7 +273,23 @@ defmodule Grappa.Protocol do
   # @min_protocol_version stays at 1: an old client drops presence_changed
   # frames it cannot read and keeps every other pane, so it is degraded rather
   # than unserviceable — and only on the one network that needs ISON at all.
-  @protocol_version 12
+  # v13 (#1850) — `POST /admin/reload` gains a third refusal token,
+  # `stale_code_path`: the beams a hot deploy just built are in a lib
+  # directory the running node never reads.
+  #
+  # ⚠️ Same mechanism as v12 and NOT the same consequence, and the difference
+  # is worth stating rather than inheriting. `GrappaWeb.ErrorTokens` is a
+  # generated-artefact source, so a token lands in `REST_ERROR_TOKENS` /
+  # `wireSchema.ts` and MOVES THE DIGEST — `mix grappa.wire_pin --check` demands
+  # the bump, it is not a judgement call. But v12's measured break does NOT
+  # reproduce here: the endpoint is loopback-gated, so no browser can reach it
+  # and no bundle, old or new, will ever be handed this token. The number moves
+  # because the shape moved and the floor must stay TOTAL — a client reading
+  # `server >= N` as "has everything N had" is entitled to that, and one
+  # un-bumped addition makes the reading false forever after.
+  #
+  # @min_protocol_version stays at 1: nothing a client can reach changed.
+  @protocol_version 13
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -284,7 +300,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 12
+  @spec version() :: 13
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa_web/controllers/admin_controller.ex
+++ b/lib/grappa_web/controllers/admin_controller.ex
@@ -22,6 +22,15 @@ defmodule GrappaWeb.AdminController do
       two files claim one version (#1348); nothing ran. Same status, but
       the OPPOSITE next move: a cold deploy migrates through the same
       defect, so the repo has to be fixed first.
+    * `409` `%{"error" => "stale_code_path", "booted" => vsn, "built" =>
+      vsn | null, "code_path" => dir}` — the fresh beams landed in a lib
+      directory this node does not read (#1850); nothing ran. A cold
+      deploy is the fix, as with the contract arm. This one is checked
+      BEFORE the migration audit, and it is a DETECTION rather than a
+      prevention: `Grappa.Deploy.Preflight` already classifies a `VERSION`
+      diff COLD, but `--force-hot` skips preflight and a reload that walks
+      the stale tree answers `{"reloaded":[],"failed":[]}` — the silence
+      that served old code for ~6.5h on 2026-08-13.
     * a raising migration is NOT rescued: it 5xxes, the transaction
       rolls back, and no module is reloaded.
 
@@ -154,6 +163,24 @@ defmodule GrappaWeb.AdminController do
         conn
         |> put_status(:conflict)
         |> json(%{error: "duplicate_migration_versions", duplicates: duplicates})
+
+      {:error, {:stale_code_path, drift}} ->
+        # 409 a third time, nothing ran again — and nothing in the repo is
+        # wrong (#1850). The build wrote its beams into a lib directory
+        # this node does not read, so a reload could only ever have loaded
+        # stale code and reported `{"reloaded":[],"failed":[]}` doing it.
+        # A cold deploy IS the fix (it boots the new vsn), same as the
+        # contract-migration arm and unlike the duplicate-version one —
+        # the body names both numbers so the operator can see which tree
+        # the node is on and which one the build produced.
+        conn
+        |> put_status(:conflict)
+        |> json(%{
+          error: "stale_code_path",
+          booted: drift.booted,
+          built: drift.built,
+          code_path: drift.lib_dir
+        })
     end
   end
 

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -142,6 +142,12 @@ defmodule GrappaWeb.ErrorTokens do
           # OPPOSITE next move (#1348): two files claim one migration
           # version, and a cold deploy migrates through the same defect.
           | :duplicate_migration_versions
+          # Operator-facing, same endpoint, same "nothing ran", and back to
+          # the cold deploy as the fix (#1850) — but for a reason that has
+          # nothing to do with the repo: the build wrote its beams into
+          # `lib/grappa-<new>/ebin` while the node still reads the boot
+          # directory, so the reload could only have loaded stale code.
+          | :stale_code_path
           | :invalid_message
           | :anon_collision
           | :nick_in_use

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 12
-shape_digest = sha256:4e6ee9e64c05d3a9f9db0fecbfc2f7f6dae1f4c1cd184684d8d0fb6c97229a09
+protocol_version = 13
+shape_digest = sha256:4afc40e5880783d55c69d0f2a4bc0338d418061fde9a0538c45de8b907ee9876

--- a/test/grappa/hot_reload/code_path_audit_test.exs
+++ b/test/grappa/hot_reload/code_path_audit_test.exs
@@ -1,0 +1,133 @@
+defmodule Grappa.HotReload.CodePathAuditTest do
+  # Pure filesystem inspection — no code-server mutation, no repo.
+  use ExUnit.Case, async: true
+
+  alias Grappa.HotReload
+
+  # ---- fixtures -------------------------------------------------------
+  #
+  # Both shapes are transcribed from a MEASURED `mix release --overwrite`
+  # run (2026-09-06, isolated build cache), not invented: a release rooted
+  # at `<rel>` carries `<rel>/lib/grappa-<vsn>/ebin` plus
+  # `<rel>/releases/start_erl.data` holding `"<erts_vsn> <release_vsn>"`.
+  # The bind-mounted Docker tree carries neither the vsn in the path nor a
+  # `releases/` dir at all.
+
+  defp tmp_root(tag) do
+    root = Path.join(System.tmp_dir!(), "code_path_#{tag}_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    root
+  end
+
+  # A `mix release` tree: one lib dir per `vsn` in `lib_vsns`, and a
+  # start_erl.data naming `built`. Returns the release root.
+  defp release_tree!(root, lib_vsns, built) do
+    Enum.each(lib_vsns, &File.mkdir_p!(Path.join([root, "lib", "grappa-#{&1}", "ebin"])))
+    File.mkdir_p!(Path.join(root, "releases"))
+
+    if built do
+      File.write!(Path.join([root, "releases", "start_erl.data"]), "16.4.0.4 #{built}\n")
+    end
+
+    root
+  end
+
+  defp lib_dir(root, vsn), do: Path.join([root, "lib", "grappa-#{vsn}"])
+
+  # ---- negative controls: the audit MUST stay silent -------------------
+
+  test "Docker's unversioned bind-mounted layout is inert — no vsn in the lib path" do
+    root = tmp_root("docker")
+    # `/app/_build/<env>/lib/grappa` — the measured Docker shape. No
+    # `releases/` dir, no vsn suffix, so there is nothing to compare and
+    # the fresh beams land where the node already looks.
+    unversioned = Path.join([root, "_build", "dev", "lib", "grappa", "ebin"])
+    File.mkdir_p!(unversioned)
+
+    assert HotReload.audit_code_path(Path.dirname(unversioned)) == :ok
+  end
+
+  test "a release whose booted vsn is the one just built is clean" do
+    root = tmp_root("aligned")
+    release_tree!(root, ["1.5.1"], "1.5.1")
+
+    assert HotReload.audit_code_path(lib_dir(root, "1.5.1")) == :ok
+  end
+
+  test "a STALE leftover lib dir alongside the booted one is not drift" do
+    # The false positive the measurement forced out of the design:
+    # `mix release --overwrite` does NOT prune, so every past vsn's lib
+    # dir accumulates forever. Counting siblings would refuse every hot
+    # deploy on a jail that has ever been bumped. The booted vsn IS the
+    # built vsn here, so the node is loading exactly the fresh tree.
+    root = tmp_root("leftover")
+    release_tree!(root, ["1.4.0", "1.5.0", "1.5.1"], "1.5.1")
+
+    assert HotReload.audit_code_path(lib_dir(root, "1.5.1")) == :ok
+  end
+
+  # ---- positive controls: the audit MUST refuse ------------------------
+
+  test "the 2026-08-13 repro: the build wrote a sibling the booted node never reads" do
+    # Measured shape after a VERSION-only bump: the boot dir survives
+    # untouched, the fresh beams land in a sibling, and start_erl.data
+    # moves to the new number. Today the reload walks the stale tree,
+    # diffs it against itself and answers `{"reloaded":[],"failed":[]}` —
+    # indistinguishable from "nothing to do", which is what served the
+    # old BEAM for ~6.5 hours.
+    root = tmp_root("drift")
+    release_tree!(root, ["1.5.1", "9.9.9"], "9.9.9")
+
+    assert {:error, {:stale_code_path, drift}} = HotReload.audit_code_path(lib_dir(root, "1.5.1"))
+    assert drift.booted == "1.5.1"
+    assert drift.built == "9.9.9"
+    assert drift.lib_dir == lib_dir(root, "1.5.1")
+  end
+
+  test "a boot dir the build deleted refuses too, and names the vsn that replaced it" do
+    # The same defect from the other side: nothing guarantees the boot
+    # dir survives, and a node walking a path that no longer exists finds
+    # zero beams — the same silent `{"reloaded":[],"failed":[]}`.
+    root = tmp_root("vanished")
+    release_tree!(root, ["9.9.9"], "9.9.9")
+
+    assert {:error, {:stale_code_path, drift}} = HotReload.audit_code_path(lib_dir(root, "1.5.1"))
+    assert drift.booted == "1.5.1"
+    assert drift.built == "9.9.9"
+  end
+
+  test "an unreadable start_erl.data refuses rather than guessing — in doubt, cold" do
+    # A versioned lib path says "this is a mix release", so the release
+    # metadata is expected to be there. Reading `:ok` out of its absence
+    # would restore exactly the silence this audit exists to break.
+    root = tmp_root("nometa")
+    release_tree!(root, ["1.5.1"], nil)
+
+    assert {:error, {:stale_code_path, drift}} = HotReload.audit_code_path(lib_dir(root, "1.5.1"))
+    assert drift.booted == "1.5.1"
+    assert drift.built == nil
+  end
+
+  test "a malformed start_erl.data refuses and reports what it could not parse" do
+    root = tmp_root("garbage")
+    release_tree!(root, ["1.5.1"], "1.5.1")
+    File.write!(Path.join([root, "releases", "start_erl.data"]), "not-a-pair\n")
+
+    assert {:error, {:stale_code_path, drift}} = HotReload.audit_code_path(lib_dir(root, "1.5.1"))
+    assert drift.built == nil
+  end
+
+  # ---- the refusal must survive the wire -------------------------------
+
+  test "the drift payload is JSON-encodable — it is a 409 body, not a log line" do
+    root = tmp_root("json")
+    release_tree!(root, ["1.5.1", "9.9.9"], "9.9.9")
+
+    {:error, {:stale_code_path, drift}} = HotReload.audit_code_path(lib_dir(root, "1.5.1"))
+
+    decoded = drift |> Jason.encode!() |> Jason.decode!()
+    assert decoded["booted"] == "1.5.1"
+    assert decoded["built"] == "9.9.9"
+  end
+end


### PR DESCRIPTION
## 🛑 Read this first: the scope is narrower than the issue's Ask

Issue #1850 asks for a **direction** among three (appup/relup, freezing the OTP
app vsn, compiling the hot branch into the live vsn's ebin) and says so
explicitly: *"Pick a direction before anyone writes code."* **This branch picks
none of them.** A release cut still cold-restarts prod, and every IRC session
still drops on a `VERSION` bump.

What it delivers is the piece that needs no ruling and that all three
directions want anyway: **the miss stops being silent.** So issue #1850 does not
receive its CURE here — it receives REPORTABILITY. The declared order was that
the four issues gate `1.5.2` "with the deploy fixes"; narrowing that scope is
**not the author's call to make**, it is being raised with vjt separately. This
section exists so the narrowing is on the record rather than discovered later.

## What was wrong

On the two `mix release` substrates the code path carries the vsn —
`lib/grappa-<vsn>/ebin` — and `:code.lib_dir/1` resolves to the **boot**
directory forever. A `VERSION`-only bump therefore writes the fresh beams into a
sibling the node never reads, so `HotReload.reload_modified/0` diffs the stale
tree against itself and answers `{"reloaded":[],"failed":[]}` — a shape
indistinguishable from *"nothing to do"*. Prod served the old BEAM under the new
git history for ~6.5h on 2026-08-13 that way, and the deploy printed success.

`Preflight.version?/1` already **prevents** this (#1287). Prevention is not
detection, and three things escape it:

* `--force-hot` skips preflight entirely;
* a diff range that does not contain the bump has nothing to classify;
* when it is bypassed it leaves no trace, because the reload's own reply is the
  same reply as a no-op.

## The claim in the issue that this branch falsified

> *"That miss cannot be reported, only prevented."*

**It can.** The live node knows the vsn in its own code path, and the release on
disk names the vsn it last assembled. `Grappa.HotReload.audit_code_path/1`
compares the two and refuses with `{:error, {:stale_code_path, drift}}`;
`POST /admin/reload` returns 409 carrying both numbers, and
`infra/lib/deploy_common.sh` names it as cause 3 (`curl -f` discards the body,
so the script must enumerate).

## The measurement that killed the first design

The obvious oracle — *"is there more than one `lib/grappa-*` sibling?"* — is
wrong. Two consecutive `mix release --overwrite` runs of this tree, in an
isolated build cache:

| | `lib/grappa-*` | `releases/start_erl.data` |
|---|---|---|
| `VERSION=1.5.1` | `grappa-1.5.1` | `16.4.0.4 1.5.1` |
| `VERSION=9.9.9` | `grappa-1.5.1` **+** `grappa-9.9.9` | `16.4.0.4 **9.9.9**` |

`--overwrite` **does not prune** — the boot dir survives with its mtime
untouched (`22:26:03` vs the new dir's `22:26:10`), and `releases/` keeps both
subdirectories. Stale lib dirs accumulate for the life of the install, so
sibling-counting would have refused **every** hot deploy on a jail that had ever
been bumped: a permanent false COLD, i.e. the session-dropping direction. What
*does* move is `start_erl.data`. That is the oracle. (There is no `RELEASES`
file: `mix release` writes none, only `release_handler` does.)

A second thing the tests caught rather than reasoning produced: `Path.join([dir,
"..", "..", …])` is resolved by the OS at open time and is ENOENT when a
component is missing — and the missing component is exactly the
deleted-boot-dir case. `Path.dirname/1` twice is lexical and correct.

## Deploy classification — measured, both directions

The slice is **HOT on all three substrates**, and the verdict was gated on its
controls before being emitted, via `Preflight.classify_paths/3` (content-blind
source fn):

```
slice (11 paths)                      docker/jail/linux => {:hot, []}

POSITIVE CONTROLS (must be :cold)
  config/config.exs                   all three         => {:cold, [config: …]}
  VERSION                             jail, linux       => {:cold, [version: ["VERSION"]]}
                                      docker            => {:hot, []}
  compose.yaml                        docker            => {:cold, [image_substrate: …]}
  priv/repo/migrations/…_x.exs        all three         => {:cold, [migration: …]}

NEGATIVE CONTROLS (must stay :hot)
  docs/compose.notes.md               all three         => {:hot, []}
  infra/lib/deploy_common.sh          all three         => {:hot, []}
```

State-shape axis measured too, not assumed: `long_lived_module_files/0` has
**34** members (cardinality checked, so the zero below is not an empty control)
and the intersection with this slice is **empty**.

**`VERSION` still classifies COLD on `:jail` and `:linux`. This branch moves no
classification** — that was the hard constraint, and it is measured rather than
argued. No `compose.*` path is touched, so the `docker_image?/1` prefix trap
does not fire either.

## Wire

`GrappaWeb.ErrorTokens` is a generated-artefact source, so the new token lands
in `REST_ERROR_TOKENS` / `wireSchema.ts` and **moves the digest**:
`mix grappa.wire_pin` demanded protocol **13**, which makes the bump a
measurement and not a judgement call. Unlike v12 the client break does not
reproduce — the endpoint is loopback-gated, so no bundle can ever be handed this
token — but the floor only means something if it is TOTAL.
`min_protocol_version` stays 1.

## Gates

* `scripts/check.sh` → **rc=0**. Includes `mix ci.check` (compile
  `--warnings-as-errors`, format, credo `--strict`, sobelow, deps.audit, doctor,
  **7150 tests / 8 doctests / 65 properties, 0 failures**, **dialyzer: 0
  errors**, docs), `gen_wire_types --check`, `wire_pin --check`, and the bats
  suite (**723 ok, 0 not ok**).
* cic: `bun install` (nude — no `Saved lockfile`, so the lock is consistent),
  `bun run check`, `bun run test` — all rc=0.
* Working tree verified clean **before and after** the green gate: the tree that
  went green is the tree committed.
* Rebased onto `origin/main` immediately before opening, via
  `scripts/union-rebase.sh`. The DESIGN_NOTES contribution was pinned first and
  predicted to stay `+143 -0`; post-rebase it is `+143 -0`, the preceding
  entry's tail is byte-identical to its pre-rebase capture, and the boundary
  shape (marker / blank / `---` / blank / `##`) was read off the real file.
  Marker `<!-- entry #1850 -->` re-checked for uniqueness against the tip
  **after** it moved, with positive controls.

## What was NOT measured

* **Neither release substrate was exercised.** No FreeBSD jail, no systemd host —
  those are production and not reachable from here. The release **layout** was
  measured on a real `mix release --overwrite`, which is a property of Mix
  rather than of FreeBSD; the **deploy** on those substrates was not, and the
  409 has never been seen by a real `substrate_reload`.
* The 2026-08-13 production incident is quoted from the record, not re-measured.
* The wiring `migrate_and_reload/2 → audit_code_path/1` has **no test that makes
  it FIRE**: forcing drift needs a versioned `:code.lib_dir(:grappa)`, which a
  source-checkout test run does not have, and a seam for it would be a seam over
  a gated verb. Its **inertness** is gated — the migration suites drive
  `migrate_and_reload/2` and would go red if the audit refused wrongly. Same
  posture already declared for `reload_modified/0` in `hot_reload_test.exs`.

## What I refused to assert

* That this **fixes** #1850. It does not; it makes the failure visible. The
  A/B/C pick is not made here.
* That the 409 works end-to-end on the jail or the systemd host. Unproven on the
  real substrate, and a green local suite is not evidence for a substrate the
  suite never ran on.
* That option **C** is safe to ship. Its cost turns out lower than the issue
  states — `Grappa.Version.base/0` is a compile-time constant in `Version.beam`
  (`version.ex:156`), so a reload that loads that beam reports the NEW number,
  which is the code actually running; only the directory name and
  `Application.spec(:grappa, :vsn)` stay stale, and `version.ex:37-39` records
  that nothing else in the tree reads the latter. That lowers C's price; it does
  not make an unexercised hot branch on FreeBSD safe on the night of a cold.
* That a package install (`cp -a` of the release root) behaves identically under
  this audit. It should. It was not run.
* That stale `lib/grappa-*` directories are harmless to leave lying around. This
  branch only proves they accumulate; whether they should be reaped is a
  separate question nobody has asked yet.

`lib/grappa/version.ex` is **not touched** (adjacent slice #1851 owns that file).
