### PR TITLE
CI: cross a version seam in the release smoke, plus a hostile-substrate matrix (1952)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1406,19 +1406,29 @@ jobs:
         with:
           # Same reasoning as the docker job: the pushed TAG on a release, the
           # DISPATCHED BRANCH on a dry-run, the REPAIRED TAG on a repair.
-          # submodules:false + fetch-depth 1 — the driver is shell over infra/
-          # and reads no git history.
+          # submodules:false — the driver is shell over infra/.
+          #
+          # fetch-tags, not fetch-depth 0 (#1952): the upgrade probe needs the
+          # TAG LIST to derive the release below this one, and nothing here
+          # needs the commits behind them. `git tag -l` on a depth-1 checkout
+          # answers nothing at all, and `previous_release_tag.sh` refuses that
+          # state by name rather than resolving it to "there is no previous
+          # release".
           submodules: false
           ref: ${{ env.REPAIR_TAG }}
+          fetch-tags: true
 
       - name: Resolve version (repo-root VERSION file = SSOT)
         id: ver
         run: echo "version=$(infra/packaging/version.sh)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to ghcr.io
-        # The two publishing paths pull from the registry; the dry-run builds
-        # locally and never authenticates.
-        if: ${{ github.event_name == 'push' || env.IMAGE_REPAIR == 'true' }}
+        # EVERY path, since #1952 — the dry-run used to build its candidate
+        # locally and never touch the registry, but the upgrade probe's fixture
+        # is the PREVIOUS RELEASE and that only exists on ghcr. Anonymous pulls
+        # of a public package would mostly work and would fail on the day the
+        # package turns private or the unauthenticated rate limit bites, which
+        # is a failure with nothing to do with the release under test.
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -1475,11 +1485,45 @@ jobs:
           cache-from: type=gha,scope=release
           provenance: false
 
+      - name: Resolve the release BELOW this one and pull its image
+        id: prev
+        # #1952 — the upgrade probe's fixture. Derived, never pinned: a
+        # hardcoded previous makes this gate cross the wrong seam one release
+        # after it is written.
+        #
+        # The guard reads the DRIVER, not the event. On a repair the checked-out
+        # tree is the OLD TAG's, and a tag that predates the upgrade probe ships
+        # a driver with no fixture to feed — fetching one for it would fail on
+        # ghcr for a release whose predecessor was never published as an image,
+        # turning an unrelated repair red. "Does the tree under test ask for a
+        # fixture" is the exact question, and the driver is where the answer is
+        # written; the same reading is why this step needs none of the #1686
+        # scaffolding dance the docker job performs, since a tree carrying the
+        # driver carries the resolver too.
+        run: |
+          if ! grep -q GRAPPA_PREVIOUS_IMAGE scripts/smoke-release-image.sh; then
+            echo "::notice::this tree's smoke driver predates the upgrade probe (#1952) — there is no previous-release fixture to fetch"
+            exit 0
+          fi
+          prev_tag="$(infra/packaging/previous_release_tag.sh "v${{ steps.ver.outputs.version }}")"
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          image="ghcr.io/${owner}/grappa:${prev_tag}"
+          # The same honest subject as the candidate pull above: the exact ref
+          # a box running the previous release resolved when it was installed.
+          docker pull "$image"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "version=${prev_tag#v}" >> "$GITHUB_OUTPUT"
+
       - name: Deploy the image for real and probe it
         env:
           # Whichever path ran; the other's output is empty.
           GRAPPA_IMAGE: ${{ steps.pull.outputs.image || 'grappa-release:smoke' }}
           GRAPPA_SMOKE_VERSION: ${{ steps.ver.outputs.version }}
+          # Empty ONLY on a repair of a tag whose driver predates the probe —
+          # that driver reads neither, and the current one refuses to run
+          # without both.
+          GRAPPA_PREVIOUS_IMAGE: ${{ steps.prev.outputs.image }}
+          GRAPPA_SMOKE_PREVIOUS_VERSION: ${{ steps.prev.outputs.version }}
         run: scripts/smoke-release-image.sh
 
   publish:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47284,3 +47284,165 @@ state-shape axis was measured too, not assumed: `long_lived_module_files/0` has
 34 members and the intersection with this slice is empty. **`VERSION` still
 classifies COLD on the release substrates — this slice moves no
 classification.**_
+<!-- entry #1952 -->
+
+---
+
+## 2026-09-07 — #1952: the release smoke crosses a version seam, and one flag was enough to keep the image from booting
+
+`scripts/smoke-release-image.sh` is a good gate that never changes version.
+Measured in the file before this work: every probe runs `$GRAPPA_IMAGE`
+alone, both volumes are destroyed before the run, and probe 3 — the closest
+thing to an upgrade — `docker restart`s the SAME image. So the shape that
+broke #1945 in the field, an existing box running the previous release and
+updated in place, had no coverage at all. That is the shape a self-hoster's
+automated update takes, and it is how the failure reached a user.
+
+Three things land: an upgrade probe from the previous release, an assertion
+that boot-time writes land in the volume, and a hostile-substrate matrix.
+The matrix found a real defect on its first run, which is recorded below
+along with the two shapes that were refused.
+
+### The previous release is DERIVED, and the comparison is not git's
+
+`infra/packaging/previous_release_tag.sh` answers "the highest RELEASE tag
+strictly below this one". It is the third script in that directory to read a
+tag and it reuses both rules the other two own: `prerelease_flag.sh` is the
+ONE pre-release classifier (#1636), and a repository tag it refuses is
+SKIPPED while the tag under test is refused outright — `latest_tag_gate.sh`'s
+posture (#1686), for its reason.
+
+What it does NOT reuse is `git tag --sort=-v:refname`, and the reason is a
+constraint the other two do not have: **the version under test need not be a
+tag.** On a `docker_validation` dry-run the smoke job runs from a branch
+whose `VERSION` has never been tagged, and git can only order refs it holds.
+A three-field numeric compare answers it for any version string. It is a
+comparison and not a second classifier — every string reaching it has already
+passed the shared classifier's shape floor. `test -lt`, never `$((…))`: a
+field with a leading zero shape-passes there and is an invalid octal constant
+to POSIX arithmetic.
+
+A dead end is a REFUSAL, never an empty line: the caller interpolates the
+answer into an image ref, where empty becomes `:` and fails far from the
+cause. The two dead ends are told apart because they need different fixes —
+no `v*` tag at all is a shallow clone that never fetched them (which is why
+the smoke checkout now takes `fetch-tags`), while tags with none below is the
+first release of a line.
+
+### `docker diff` is the oracle, and the bar is EMPTY because that is measured
+
+#1945's second half was silent rather than loud: the peer avatars were
+written to `/app/runtime/peer_avatars`, inside the container layer and
+outside `grappa-data`, so a cold update deleted them with no error anywhere.
+`docker diff` fits exactly — it reports the read-write layer and by
+construction never reports what is under a mount, so a root that landed in
+the volume is invisible and one that missed it is an `A` line. Nothing has to
+be enumerated in advance, which is what makes it a class gate rather than a
+second list of the three roots #1945 happened to fix.
+
+**No allowlist is written, because the measurement says there is nothing to
+allow.** A full boot of `ghcr.io/vjt/grappa:v1.5.1` — entrypoint, secret
+bootstrap, migrator, theme seeder, Phoenix up and answering — leaves the
+container layer with literally nothing in it. No `/app/tmp`, no `/tmp`, no
+cookie file. An allowlist authored ahead of the first entry it needs is a
+hole with a comment on it.
+
+The same reading on the release BEFORE it is the evidence the probe bites.
+`v1.5.0` answers three lines, two of them the defect itself:
+
+    A /app/runtime
+    A /app/runtime/peer_avatars
+    C /app
+
+An empty diff is also exactly what a BLIND oracle produces, so the probe
+plants that same path afterwards and requires docker to see it. Without that
+control the clean reading proves nothing.
+
+### One flag, and the image does not come up
+
+The matrix's cwd shape is the honest stand-in for the production jail, where
+#1945 actually happened: rc.d starts the release with `su -m grappa` and no
+`cd`, so the cwd is `/`. Docker bakes `WORKDIR /app` and makes it writable by
+the runtime user, which is exactly why the same class of defect is SILENT
+there and FATAL in the jail. Measured on stock `v1.5.1`:
+
+    docker run --workdir / ...
+    /app/release-entrypoint.sh: line 126: bin/grappa: not found
+    grappa: MIGRATION FAILED — refusing to start.
+    exited/1
+
+Three commands in the entrypoint run `bin/grappa` and all three spelled it
+RELATIVELY. `--workdir`, or a Kubernetes `workingDir:`, is set without a
+thought. **This is #1945's own rule one layer over: the cure there stopped
+deriving DATA paths from the cwd; the cure here stops deriving the release's
+OWN path from it.** `cd "$(dirname "$0")"` is a no-op wherever things already
+worked. It ships in this slice and not in a follow-up because a gate that is
+red by construction has two futures, and the second is somebody weakening the
+oracle to make it green.
+
+**Blast radius, verified rather than assumed:** the only installer of
+`infra/docker/release-entrypoint.sh` is `Dockerfile.release`. `infra/freebsd/`
+and `infra/linux/` contain zero references; `infra/packaging/`'s single hit is
+a comment. The one non-Dockerfile consumer, `infra/release/grappa.sh`, IS
+installed into every release including the jail's, and is doubly barred:
+it requires `GRAPPA_SUBSTRATE = docker` exactly, and the path it would exec is
+never created outside the image because `install_operator_cli/1` copies only
+`infra/release/grappa.sh`. Production (the m42 bastille jail) runs `mix
+release` and does not read this file.
+
+### An exit status is not a fact about the fault
+
+The second defect the measurement surfaced is a different one and got its own
+cure: the operator was told `MIGRATION FAILED`, with a paragraph about rolling
+the schema back, while nothing had opened the database. That is the
+log-honesty rule verbatim — a fast path describing work it did not do.
+
+The first spelling keyed on exit 127 and the bats case written for it is what
+killed that: **on one missing file the number is not stable.** `sh -c
+'bin/nothere'` answers 127, the image's busybox ash prints `not found`, and
+this script's own `if ! bin/grappa …` under `set -e` on bash-as-sh hands back
+**1** — indistinguishable from a migration that ran and failed. So the guard
+is a PRECONDITION, `test -x`, which answers the same on every shell, placed
+once at the top because a tree with no runnable `bin/grappa` cannot migrate,
+cannot seed and cannot boot.
+
+### Two hostile shapes refused, both by measurement
+
+**A volume over `/app`** removes the release itself, so a probe asserting that
+shape answers 200 would assert a falsehood.
+
+**An arbitrary uid (`--user 65534`) cannot be set up.** Docker re-seeds an
+EMPTY named volume from the image on every mount, ownership included:
+`chown -R 65534:65534 /data` in a helper container reads back as `65534:65534`
+inside that container and as the image's `100:101` in the next one. Only a
+pre-populated volume survives it, which is a fixture built to dodge a docker
+behaviour rather than a substrate anybody runs — and the property it would
+test (nothing outside `/data` need be writable) is what the read-only shape
+asserts directly.
+
+**The read-only recipe is one tmpfs, measured, not assumed.** Naked
+`--read-only` dies with `mktemp: : Read-only file system` before it reaches
+the secret bootstrap; `--read-only --tmpfs /tmp` boots. `/app/tmp` is not in
+it because the release never writes there — the same fact the empty container
+layer reports from the other side.
+
+### The gate the gate needs
+
+`release.yml` fires on a `v*` tag push and on `workflow_dispatch`, so nothing
+added to its `smoke` job is ever executed by a pull request: the first real
+run is the release. #1951 is that story verbatim, a rotted pattern failing the
+release runs of BOTH v1.5.0 and v1.5.1 — a red check an operator learns to
+ignore. The mitigation it landed is the one taken here: bats over the LOGIC at
+PR time (`test/infra/release_upgrade_probe_test.bats`), against real git
+repositories with real tag sets rather than a stubbed `git`, so what stays
+untested until a real tag is only the part that genuinely needs a booted
+container.
+
+Every RED case carries a positive control on the same predicate. One of them
+earned its keep immediately, catching a fixture bug in this very slice: the
+temp repositories were keyed on the test number, so a case building two of
+them to contrast had the second silently eat the first.
+
+_Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
+release image, so it reaches an operator only through a new image. The m42
+jail runs `mix release` and does not read it; nothing else here leaves CI._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1947,6 +1947,36 @@ D** — see **Running the published image** below.
   is `scripts/smoke-release-image.sh`, runnable by hand — probes, mutation
   evidence and the explicit non-coverage list are in
   `docs/TESTING.md` § "The release-image smoke".
+- **It crosses a VERSION SEAM, and boots where the cwd is hostile (#1952).**
+  Until then every probe was a FIRST boot on an empty volume of ONE image, so
+  the shape that breaks a self-hoster — an existing box on the previous
+  release, updated in place — had no coverage; that is the shape #1945 reached
+  a user through. The job now also resolves the release BELOW this one
+  (`infra/packaging/previous_release_tag.sh`, never a pinned tag), pulls it,
+  boots it on a fresh volume and starts the candidate on that same volume:
+  `/healthz`, the reported version, the exact number of migrations that had to
+  run, `/data/grappa.env` unrotated ACROSS the version change, and an account
+  written under the old release still there. It then asserts that the boot
+  wrote **nothing** into the container layer (`docker diff`, which never
+  reports what is under a mount — measured empty on a healthy release and
+  three lines on v1.5.0, two of them #1945 itself), and boots the candidate
+  under `--read-only --tmpfs /tmp` and under `--workdir /`.
+  ⚠️ **The previous image is now REQUIRED**, on the same no-skip footing as
+  the candidate: a run that quietly fell back to the same-version probes would
+  report exactly the green this closed. The one exception is a repair dispatch
+  of a tag whose driver predates the probe — the resolve step reads the
+  checked-out driver, not the event, and stands down when that tree asks for no
+  fixture.
+- **Running the image `--read-only`** needs one tmpfs and nothing else:
+
+  ```sh
+  docker run --read-only --tmpfs /tmp -v grappa-data:/data -e PHX_HOST=… ghcr.io/vjt/grappa:vX.Y.Z
+  ```
+
+  Measured (#1952): naked `--read-only` dies on `mktemp: : Read-only file
+  system` before the secret bootstrap. `/app/tmp` is deliberately NOT in the
+  recipe — the release writes nothing under `/app`, and the smoke's
+  container-layer probe is what keeps that true.
 - **Local build** (validate the Dockerfile without CI):
 
   ```sh
@@ -4856,6 +4886,38 @@ They ride in the repair scaffolding checkout for that reason; measured not to
 change the artifact, since `Dockerfile.release` COPYs only `version.sh` and
 `gen-secrets.sh` out of `infra/packaging`. Gate:
 `test/infra/release_latest_gate_test.bats`.
+
+### `previous_release_tag.sh` — the release the smoke upgrades FROM (#1952)
+
+The third tag reader in this directory, and the one the `smoke` job uses to
+find its upgrade fixture. Verdict on **stdout**, reason on **stderr**, same
+split as its two siblings:
+
+    previous_release_tag.sh v1.5.2      -> v1.5.1
+    previous_release_tag.sh v1.3.0-rc2  -> v1.2.0   (a candidate upgrades from
+                                                     the last stable)
+    previous_release_tag.sh v1.3        -> refused, exit 2
+
+**The highest release STRICTLY BELOW, which is not "the tag before this
+one".** A backport cut after a newer minor (`v0.7.5` landing after `v0.8.0`,
+the case `latest_tag_gate.sh` already reasons about) sits between them in
+creation order and below both in version order.
+
+**It reuses `prerelease_flag.sh` and does NOT reuse git's version sort.** The
+classifier is shared for the reason above — one rule, one owner. The sort is
+not, and the constraint is specific: **the version under test need not be a
+tag.** On a `docker_validation` dry-run the job runs from a branch whose
+`VERSION` has never been tagged, and git can only order refs it holds. The
+three-field numeric compare answers it for any version string; it sees only
+strings the classifier has already shape-checked, so it is a comparison and
+not a second classifier.
+
+**A dead end is a refusal, never an empty line** — the caller interpolates the
+answer into an image ref, where empty becomes `:` and fails far from the
+cause. The two dead ends carry different messages because they need different
+fixes: no `v*` tag at all is a shallow clone that never fetched them (hence
+`fetch-tags` on the smoke checkout), while tags with none below is the first
+release of a line. Gate: `test/infra/release_upgrade_probe_test.bats`.
 
 ### The packaged operator CLI and the migrate path (#419)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -83,9 +83,14 @@ scripts/bats.sh test/bin/grappa_test.bats
 # Release image — deploy it for real and probe it (#1162).
 # Read the number from VERSION rather than hardcoding one: a literal
 # here goes stale at the next release and nothing fails when it does.
+# The PREVIOUS release is derived for the same reason (#1952) — the
+# upgrade probe needs it, and the driver refuses to run without it.
 V=$(cat VERSION)                         # 1.2.0 as of this line
+P=$(infra/packaging/previous_release_tag.sh "v$V")   # e.g. v1.5.1
 docker pull ghcr.io/vjt/grappa:v$V
+docker pull ghcr.io/vjt/grappa:$P
 GRAPPA_IMAGE=ghcr.io/vjt/grappa:v$V GRAPPA_SMOKE_VERSION=$V \
+GRAPPA_PREVIOUS_IMAGE=ghcr.io/vjt/grappa:$P GRAPPA_SMOKE_PREVIOUS_VERSION=${P#v} \
   scripts/smoke-release-image.sh
 
 # E2E (Playwright + real testnet)
@@ -365,7 +370,7 @@ The authoritative source is the comment block at the top of each
 * **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = the lock-drift stage (#1571) + biome + tsc over `src` AND `e2e`. `install`, `add`, etc. forward to bun.
 * **`scripts/bats.sh`** → host-side bats v1.9.0 (submodule at `vendor/bats-core`) against `test/bin/`, `test/infra/` and `test/scripts/`. NOT containerised — bats tests host-side bash (`bin/grappa`, the deploy scripts, the cloud installer). There is no compose involvement in the runner: the container is reached only transitively, when a test exercises a verb that shells out to docker, and those tests stub `docker` on `PATH` rather than touching a real one. So this gate needs no stack up.
 * **`scripts/release-image.sh`** → the RELEASE image (`Dockerfile.release`), not the compose dev stack. `build` buildx-loads it locally; `fresh-boot` wipes the scratch volume and bare-runs it with nothing but `PHX_HOST` (the documented one-liner — the point is that everything else must come from the image and the volume); `warm-boot` does the same on the EXISTING volume; `oneshot <args…>` runs a throwaway container against that volume; `logs` / `down [--volume]` clean up. This is the reproduction for #862 and #867, both of which were found by hand-typing docker commands because no wrapper reached this artifact.
-* **`scripts/smoke-release-image.sh`** → brings a box up from `$GRAPPA_IMAGE` through the real `infra/docker/get.sh` → `deploy.sh` release path (`GRAPPA_RAW_BASE=file://<checkout>`, so get.sh's mirror list is under test too), then probes it over HTTP and tears everything down. Dedicated container/volume names (`grappa-smoke*`), so it cannot eat an operator box. Requires the image to be present locally — **an unavailable image fails the run, it never skips it**. See "The release-image smoke" below.
+* **`scripts/smoke-release-image.sh`** → brings a box up from `$GRAPPA_IMAGE` through the real `infra/docker/get.sh` → `deploy.sh` release path (`GRAPPA_RAW_BASE=file://<checkout>`, so get.sh's mirror list is under test too), then probes it over HTTP and tears everything down. Since #1952 it also upgrades `$GRAPPA_PREVIOUS_IMAGE` in place to the candidate and boots the candidate on hostile substrates. Dedicated container/volume names (`grappa-smoke*`), so it cannot eat an operator box. Requires BOTH images to be present locally — **an unavailable image fails the run, it never skips it**, and that now includes the upgrade fixture: a run that quietly fell back to five same-version probes is the state #1952 closed. See "The release-image smoke" below.
 * **`scripts/integration.sh`** → `scripts/testnet.sh up` → `docker compose run --rm playwright-runner npx playwright test "$@"` → trap-on-exit `scripts/testnet.sh down`. `KEEP_STACK=1` opts out of tear-down.
 * **`scripts/testnet.sh`** → manages the stack standalone. `up` boots hub + leaves + services + grappa-test + nginx-test + seeder. `down` tears down + wipes `runtime/e2e/`. `probe` connects an oper-up client to leaf4 for `/links` + `/stats l`.
 
@@ -417,6 +422,10 @@ rotted once, and the script is the roster):
 | a restart keeps `/data/grappa.env` | drop the `[ ! -f "$secrets_file" ]` guard from the entrypoint | hash changes |
 | the shipped bundle carries a populated credit roll (#1834) | build the image with no `--build-arg GRAPPA_CREDITS`, i.e. the pre-#1834 recipe | the degraded `{"sha":null,"date":null,"contributors":[]}`, quoted in the failure |
 | …and the probe can still SEE one | rename the payload's `"sha"` key in a shipped chunk | "neither shape present" — it fails blind rather than passing quietly |
+| the boot writes nothing outside `/data` (#1952) | point `GRAPPA_IMAGE` at `v1.5.0`, the last release with the #1945 default | `A /app/runtime`, `A /app/runtime/peer_avatars`, `C /app` |
+| …and `docker diff` can still SEE a layer write | none needed — the probe plants `/app/runtime` itself and re-reads | an empty diff is what a blind oracle gives, so this control is not optional |
+| the image boots with a cwd it did not choose (#1952) | `--workdir /` on any image predating this slice | `bin/grappa: not found`, `MIGRATION FAILED`, `exited/1` |
+| the upgrade fixture really is the OLDER release | point `GRAPPA_PREVIOUS_IMAGE` at the candidate's own ref | refused before any container starts |
 
 Two of those are worth knowing on their own. **A missing hashed chunk is
 served as the SPA shell with 200 and `content-type: text/html`** —
@@ -443,12 +452,45 @@ passing that arg too — see § "The published release image" in
 `docs/OPERATIONS.md`. The asymmetry is the point: the naked build must
 keep degrading honestly, the shipped image must not.
 
+**The version seam, and the two hostile shapes that are NOT run (#1952).**
+The upgrade probe boots the previous release on a fresh volume, writes
+state through it, stops it and starts the candidate on that same volume —
+previous → candidate only, since a downgrade is a different question with
+a different answer. How many migrations must run is DERIVED from the two
+images (the previous booted on an empty volume, so what is applied there
+is exactly its own set) rather than naming a migration that would go
+stale. Refused, and each for a measured reason rather than a preference:
+
+* **a volume over `/app`** removes the release itself, so asserting that
+  it answers 200 would assert a falsehood;
+* **an arbitrary uid (`--user 65534`)** cannot be set up. Docker re-seeds
+  an EMPTY named volume from the image on every mount, ownership
+  included, so `chown -R 65534 /data` in a helper container reads back as
+  `65534` inside it and as the image's `100:101` in the next one. The
+  property it would test is what the read-only shape asserts directly.
+
+**The read-only recipe is `--read-only --tmpfs /tmp`, and nothing more.**
+Naked, the boot dies on `mktemp: : Read-only file system` before it
+reaches the secret bootstrap. `/app/tmp` is deliberately absent: the
+release writes nothing under `/app`, which is the same fact the
+empty-container-layer probe reports from the other side.
+
 What it deliberately does NOT cover: one architecture (whatever the host
 runs — the arm64 leg of the manifest is proven by the build, not here);
 no IRC at all (no upstream connect, SASL or scrollback — that is
 `scripts/integration.sh`'s job, against the SOURCE image); no TLS front
 door or real `PHX_HOST`; and the `update` verb (only `install` plus a
 bare-run restart).
+
+⚠️ **Nothing in this job runs on a pull request.** `release.yml` fires on
+a `v*` tag push and on `workflow_dispatch`, so a probe added here is
+first executed by the release itself — which is how #1951's rotted
+pattern came to fail the release runs of both v1.5.0 and v1.5.1. The
+standing mitigation is bats over the LOGIC at PR time:
+`test/infra/release_upgrade_probe_test.bats` (the previous-tag resolver
+and the wiring that feeds it) and `test/infra/release_image_credits_test.bats`
+(probe 5's oracle). Adding a probe here means adding its PR-time half
+there.
 
 ## The e2e stack
 

--- a/infra/docker/release-entrypoint.sh
+++ b/infra/docker/release-entrypoint.sh
@@ -13,6 +13,66 @@
 
 set -e
 
+# THE RELEASE ROOT IS WHERE THIS FILE LIVES, NOT WHERE THE CALLER STOOD (#1952).
+#
+# Three commands below run `bin/grappa` — the migrator, the theme seeder and
+# the final exec — and all three used to spell it RELATIVELY, which resolves
+# against a working directory nobody in this script chose. `Dockerfile.release`
+# bakes `WORKDIR /app` and this file lands at `/app/release-entrypoint.sh`, so
+# on every path that works today `cd` here is a NO-OP: same directory, byte for
+# byte the same behaviour. It is the paths that do NOT work today that this is
+# for.
+#
+# MEASURED, on ghcr.io/vjt/grappa:v1.5.1 with `docker run --workdir /`:
+#
+#     /app/release-entrypoint.sh: line 126: bin/grappa: not found
+#     grappa: MIGRATION FAILED — refusing to start.
+#     exited/1
+#
+# One flag — the kind a hardened compose file or a Kubernetes `workingDir:`
+# sets without a thought — and the container never comes up. That is issue 1945
+# wearing a different hat: a path resolved against a cwd the init system
+# chooses rather than the operator, which is exactly how the production jail's
+# `su -m grappa` with no `cd` turned an unset storage root into a boot crash.
+# The cure there was to stop deriving data paths from the cwd; the cure here is
+# to stop deriving the release's OWN path from it.
+#
+# `$0` is what the kernel was told to execute — `/app/release-entrypoint.sh`
+# from the image's ENTRYPOINT, or `<release>/bin/../release-entrypoint.sh` when
+# `infra/release/grappa.sh` re-enters this script for a docker-exec'd account
+# verb (#1683). `dirname` of either lands on the release root; `cd` resolves the
+# `..` on the way. The BEAM inherits that cwd, so a relative default anywhere
+# downstream resolves where it always did instead of wherever the operator's
+# shell happened to be.
+cd "$(dirname "$0")"
+
+# …and having chosen the directory, SAY SO IF THE RELEASE IS NOT IN IT (#1952).
+#
+# Three commands below run `bin/grappa`; the first of them is the migrator, and
+# what the script used to say when that command could not be executed was
+# `MIGRATION FAILED — refusing to start`, followed by a paragraph about rolling
+# the schema back. Measured under `docker run --workdir /`: the operator is
+# told the database broke while nothing had opened it. CLAUDE.md's log-honesty
+# rule is exactly this — a fast path states what it OBSERVED, not the work it
+# did not do.
+#
+# A PRECONDITION and not an exit-status arm, because the status is not a fact
+# about the fault. Measured on one missing file: `sh -c 'bin/nothere'` answers
+# 127 from an interactive-style invocation, the image's busybox ash prints
+# `not found`, and this script's own `if ! bin/grappa …` under `set -e` on
+# bash-as-sh hands back **1** — indistinguishable from a migration that ran and
+# failed. `test -x` asks the question directly and answers it the same way on
+# every shell.
+#
+# One check, at the top, for all three call sites: a release tree with no
+# runnable `bin/grappa` cannot migrate, cannot seed and cannot boot, so there
+# is nothing further worth attempting and no verb worth excepting.
+if [ ! -x bin/grappa ]; then
+    echo "grappa: no runnable bin/grappa under $(pwd) — this release tree is broken." >&2
+    echo "grappa: NOTHING has been migrated and the database is untouched." >&2
+    exit 1
+fi
+
 : "${GRAPPA_MAX_USERS:=100}"
 default_schedulers="$(nproc)"
 if [ "$default_schedulers" -lt 10 ]; then

--- a/infra/packaging/previous_release_tag.sh
+++ b/infra/packaging/previous_release_tag.sh
@@ -1,0 +1,175 @@
+#!/bin/sh
+# previous_release_tag.sh — echo the release tag an operator would be upgrading
+# FROM: the highest RELEASE tag that sorts strictly BELOW the tag under test.
+#
+#   previous_release_tag.sh v1.5.2      -> v1.5.1
+#   previous_release_tag.sh v1.3.0-rc2  -> v1.2.0   (a candidate upgrades from
+#                                                    the last stable, not from
+#                                                    its own sibling candidate)
+#   previous_release_tag.sh v0.6.1      -> v0.6.0
+#   previous_release_tag.sh v1.3        -> refused, exit 2
+#
+# The VERDICT goes to stdout as a bare tag, the REASON to stderr — the same
+# split `prerelease_flag.sh` uses for its token and `latest_tag_gate.sh` for
+# its yes/no.
+#
+# WHY THIS EXISTS (GH #1952). `release.yml`'s smoke job boots the candidate
+# image and probes it, and every probe it has ever run has been a FIRST boot
+# on an empty volume of ONE image. The shape that breaks a self-hoster — an
+# existing box, running the previous release, updated in place — was never
+# crossed, which is how #1945 reached a user's container. Probing it needs the
+# previous release's image ref, and that ref must be DERIVED: hardcode it and
+# the gate tests the wrong seam one release after it is written.
+#
+# STRICTLY BELOW, AND THAT IS THE WHOLE DEFINITION. Not "the tag before this
+# one in the list" — a backport cut after a newer minor (v0.7.5 landing after
+# v0.8.0, the case `latest_tag_gate.sh` already reasons about) sits between
+# them in creation order and below both in version order.
+#
+# PRE-RELEASES ARE NEVER THE ANSWER, whatever they outrank. The upgrade under
+# test is the one an operator's automated update performs, and that update
+# follows the published stable line; a candidate is a tag most boxes never
+# ran. The classifier is `prerelease_flag.sh` — the ONE pre-release classifier
+# in this directory (#1636), measured against `Version.parse/1` — and it is
+# not written a second time here for the reason `latest_tag_gate.sh` states:
+# `v1.4.0+foo-bar` carries a hyphen inside its BUILD metadata and is a
+# release, so a hand-rolled `grep -v -- -` would be wrong on it.
+#
+# WHY A NUMERIC COMPARISON AND NOT `git tag --sort=-v:refname`. The tag under
+# test is not necessarily a tag at all. On a `docker_validation` dry-run the
+# smoke job runs from a BRANCH whose `VERSION` has never been tagged, and git
+# can only order refs it holds — so "where does this version fall among the
+# tags" is a question its sort cannot be asked. The three-field compare below
+# answers it for any version string, tagged or not.
+#
+# It is a COMPARISON, not a second classifier: every string it sees has
+# already been through `prerelease_flag.sh`, whose shape floor refuses
+# anything without three dot-separated all-digit fields. `test -lt` and not
+# `$((...))` on purpose — a field with a leading zero (`1.03.0` shape-passes
+# there) is an invalid octal constant to POSIX arithmetic and would abort the
+# script, while `test` reads it as the decimal it is.
+#
+# A TAG THIS CANNOT CLASSIFY IS SKIPPED, NOT FATAL — the same posture, and the
+# same reasoning, as `latest_tag_gate.sh`: a stray `nightly-2026-08-01` must
+# not become a permanent veto, and a tag the classifier refuses never had an
+# image published under it, so it cannot be the release anybody is upgrading
+# from. The tag UNDER TEST is the opposite case and is refused outright.
+#
+# NO TAG BELOW IS A REFUSAL, NEVER AN EMPTY LINE. The caller pulls an image
+# from what this prints; printing nothing would resolve to `:v` and fail
+# somewhere far from the cause. The two ways to get here are told apart in the
+# message, because they need different fixes: a checkout with NO `v*` tags is
+# a shallow clone that never fetched them (the caller's bug), while a checkout
+# full of tags and none below the candidate is the first release of a line.
+#
+# Caller: the `smoke` job of `.github/workflows/release.yml`. Gate:
+# `test/infra/release_upgrade_probe_test.bats`.
+#
+# POSIX sh, like its siblings `version.sh` / `prerelease_flag.sh` /
+# `latest_tag_gate.sh` — the derived dash-parse gate (scripts/posix-parse.sh)
+# keys on line 1.
+#
+# Why: docs/OPERATIONS.md § "Packaging (infra/packaging/)".
+set -eu
+
+die() {
+	printf 'previous_release_tag.sh: %s\n' "$1" >&2
+	exit 2
+}
+
+classify="$(dirname "$0")/prerelease_flag.sh"
+
+tag="${1:-}"
+
+[ -n "${tag}" ] || die 'no tag given (usage: previous_release_tag.sh vX.Y.Z)'
+
+# The floor. Without a classifier every tag reads as a release, pre-releases
+# included, and the answer could be a candidate nobody deployed.
+[ -x "${classify}" ] || die "classifier ${classify} is missing — refusing to pick an upgrade source without it"
+
+# The tag under test is refused rather than skipped: the permissive answer
+# here is the one that probes the wrong seam.
+"${classify}" "${tag}" >/dev/null ||
+	die "cannot classify ${tag} — refusing to pick the release below a tag nobody can read"
+
+# core_of TAG -> X.Y.Z. The leading `v` is the tag's, the `+build` and the
+# `-pre` are semver's, and the order of the two strips is semver's too: build
+# metadata comes AFTER the pre-release, so a `+` reached first means the
+# hyphen behind it belongs to the build. Same order, same reason, as
+# `prerelease_flag.sh` — which has already guaranteed what is left is three
+# all-digit fields.
+core_of() {
+	_core="${1#v}"
+	case "${_core}" in
+	*+*) _core="${_core%%+*}" ;;
+	esac
+	case "${_core}" in
+	*-*) _core="${_core%%-*}" ;;
+	esac
+	printf '%s\n' "${_core}"
+}
+
+# strictly_below A B — true when release core A sorts strictly below core B.
+#
+# Every `[` sits in an `if` condition and every exit is an explicit `return`:
+# a bare failing `[` would be a whole command failing under `set -eu`, which
+# aborts the script instead of answering "no".
+strictly_below() {
+	_a_major="${1%%.*}"
+	_a_rest="${1#*.}"
+	_a_minor="${_a_rest%%.*}"
+	_a_patch="${_a_rest#*.}"
+	_b_major="${2%%.*}"
+	_b_rest="${2#*.}"
+	_b_minor="${_b_rest%%.*}"
+	_b_patch="${_b_rest#*.}"
+
+	if [ "${_a_major}" -ne "${_b_major}" ]; then
+		if [ "${_a_major}" -lt "${_b_major}" ]; then return 0; else return 1; fi
+	fi
+	if [ "${_a_minor}" -ne "${_b_minor}" ]; then
+		if [ "${_a_minor}" -lt "${_b_minor}" ]; then return 0; else return 1; fi
+	fi
+	if [ "${_a_patch}" -lt "${_b_patch}" ]; then return 0; else return 1; fi
+}
+
+tag_core="$(core_of "${tag}")"
+
+# Captured, not inlined into the `for` word list: a failure there would split
+# into zero words and read as "no tags", which is a different diagnosis.
+tags="$(git tag -l 'v*')" ||
+	die 'git tag -l failed — this must run inside the release checkout'
+
+# Word splitting is what iterates below, and it is safe: `git check-ref-format`
+# forbids whitespace in a refname, so no tag can split into two.
+best=''
+best_core=''
+for candidate in ${tags}; do
+	if ! candidate_flag="$("${classify}" "${candidate}" 2>/dev/null)"; then
+		printf 'skipping %s — the classifier refuses it, so no release was ever published under it\n' "${candidate}" >&2
+		continue
+	fi
+	if [ "${candidate_flag}" != '--prerelease=false' ]; then
+		printf 'skipping %s — a pre-release is not the release an operator upgrades FROM\n' "${candidate}" >&2
+		continue
+	fi
+
+	candidate_core="$(core_of "${candidate}")"
+	if ! strictly_below "${candidate_core}" "${tag_core}"; then
+		continue
+	fi
+	if [ -z "${best}" ] || strictly_below "${best_core}" "${candidate_core}"; then
+		best="${candidate}"
+		best_core="${candidate_core}"
+	fi
+done
+
+if [ -z "${best}" ]; then
+	if [ -z "${tags}" ]; then
+		die "this checkout holds no v* tag at all — a shallow clone fetches none, and the release below ${tag} cannot be derived without them"
+	fi
+	die "no release tag sorts below ${tag} — every v* tag here is above it or is a pre-release, so there is no published release to upgrade FROM"
+fi
+
+printf '%s is the release below %s\n' "${best}" "${tag}" >&2
+printf '%s\n' "${best}"

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -18,13 +18,25 @@
 # itself a shipped-deploy bug).
 #
 #   usage:  docker pull ghcr.io/vjt/grappa:vX.Y.Z
+#           docker pull ghcr.io/vjt/grappa:v<previous>
 #           GRAPPA_IMAGE=ghcr.io/vjt/grappa:vX.Y.Z \
+#           GRAPPA_PREVIOUS_IMAGE=ghcr.io/vjt/grappa:v<previous> \
 #           GRAPPA_SMOKE_VERSION=X.Y.Z \
+#           GRAPPA_SMOKE_PREVIOUS_VERSION=<previous> \
 #             scripts/smoke-release-image.sh
 #
-#   GRAPPA_IMAGE          (required) the image ref under test, already local.
-#   GRAPPA_SMOKE_VERSION  (required) the version the running node must report.
-#   GRAPPA_SMOKE_PUBLISH  host:port to publish on (default 127.0.0.1:14000).
+#   GRAPPA_IMAGE                   (required) the image ref under test, already local.
+#   GRAPPA_SMOKE_VERSION           (required) the version the running node must report.
+#   GRAPPA_PREVIOUS_IMAGE          (required) the release BEFORE it, already local —
+#                                  the image probe 6 upgrades FROM. Resolved by
+#                                  infra/packaging/previous_release_tag.sh, never
+#                                  hardcoded: a pinned previous makes this gate test
+#                                  the wrong seam one release after it is written.
+#   GRAPPA_SMOKE_PREVIOUS_VERSION  (required) the version THAT image must report before
+#                                  the upgrade — the control that the fixture really is
+#                                  the older release and not a second copy of the
+#                                  candidate, which would make probe 6 assert nothing.
+#   GRAPPA_SMOKE_PUBLISH           host:port to publish on (default 127.0.0.1:14000).
 #
 # ⚠️ Probe 5 asserts a RELEASE build. An image from a plain
 #    `docker build -f Dockerfile.release .` legitimately bakes the degraded
@@ -45,6 +57,23 @@
 #   * no TLS front door, no reverse proxy, no real PHX_HOST — the box is
 #     probed on the published loopback port.
 #   * `update` is not exercised, only `install` + a bare-run restart.
+#   * ONE direction only: previous -> candidate. A downgrade is a different
+#     question with a different answer (a migration that ran is not undone by
+#     booting the older image) and is not smuggled in here (#1952).
+#   * no volume mounted OVER /app. The release IS /app, so hiding it removes
+#     the thing under test, and a probe asserting that shape answers 200 would
+#     be asserting a falsehood.
+#   * no arbitrary-uid shape (`--user 65534`), and this one is a MEASUREMENT
+#     rather than a judgement: the setup cannot be made to hold. Docker
+#     re-seeds an EMPTY named volume from the image on every mount, ownership
+#     included, so `chown -R 65534 /data` in a helper container reads back as
+#     65534 inside that container and as the image's 100:101 in the next one.
+#     Only a pre-populated volume survives it, which is a fixture built to
+#     dodge a docker behaviour rather than a substrate anybody runs — and the
+#     property it would test (nothing outside /data need be writable) is what
+#     the read-only shape asserts directly.
+#     Both are named here because they are the two hostile shapes #1952 lists
+#     that this driver deliberately does not run.
 
 set -euo pipefail
 
@@ -57,6 +86,8 @@ pass() { printf '\033[1;32mok\033[0m  %s\n' "$*"; }
 
 : "${GRAPPA_IMAGE:?set GRAPPA_IMAGE to the image ref under test}"
 : "${GRAPPA_SMOKE_VERSION:?set GRAPPA_SMOKE_VERSION to the version the node must report}"
+: "${GRAPPA_PREVIOUS_IMAGE:?set GRAPPA_PREVIOUS_IMAGE to the release image probe 6 upgrades FROM}"
+: "${GRAPPA_SMOKE_PREVIOUS_VERSION:?set GRAPPA_SMOKE_PREVIOUS_VERSION to the version that image must report}"
 PUBLISH="${GRAPPA_SMOKE_PUBLISH:-127.0.0.1:14000}"
 
 # Dedicated names, never the operator defaults (`grappa` / `grappa-data`): the
@@ -65,10 +96,34 @@ BOX=grappa-smoke
 BOX_VOLUME=grappa-smoke-data
 BARE=grappa-smoke-bare
 BARE_VOLUME=grappa-smoke-bare-data
+# The version seam (#1952). TWO container names on ONE volume: the previous
+# release writes the state, the candidate inherits it. Naming them separately
+# is what keeps both logs readable in the teardown dump — the interesting
+# failure is "the candidate did not come up", and the OLD container's log is
+# half the evidence for why.
+UP_OLD=grappa-smoke-upgrade-old
+UP_NEW=grappa-smoke-upgrade-new
+UP_VOLUME=grappa-smoke-upgrade-data
+# The hostile-substrate matrix (#1952). One name reused across the shapes,
+# each on its own fresh volume, because they run one at a time and a shared
+# name keeps the teardown list finite.
+HOSTILE=grappa-smoke-hostile
+HOSTILE_VOLUME=grappa-smoke-hostile-data
+
+# The account created under the PREVIOUS release, read back after the upgrade
+# through the same operator door — see probe 6.
+UP_CARRIER=release-smoke-upgrade-carrier
 
 command -v docker >/dev/null 2>&1 || die "docker not found."
 docker image inspect "$GRAPPA_IMAGE" >/dev/null 2>&1 \
     || die "$GRAPPA_IMAGE is not present locally — 'docker pull' it first. An unavailable image fails this job; it never skips it."
+# Same posture for the upgrade fixture, and for the same reason: an absent
+# previous image must fail this run, never quietly reduce it to the five
+# same-version probes it already had.
+docker image inspect "$GRAPPA_PREVIOUS_IMAGE" >/dev/null 2>&1 \
+    || die "$GRAPPA_PREVIOUS_IMAGE is not present locally — 'docker pull' it first. The upgrade probe has no fixture without it, and a smoke run that silently skips the version seam is the state #1952 exists to end."
+[ "$GRAPPA_IMAGE" != "$GRAPPA_PREVIOUS_IMAGE" ] \
+    || die "GRAPPA_PREVIOUS_IMAGE is the same ref as GRAPPA_IMAGE — probe 6 would 'upgrade' an image to itself and prove nothing."
 
 SMOKE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/grappa-smoke.XXXXXX")"
 
@@ -77,15 +132,15 @@ teardown() {
     if [ "$status" -ne 0 ]; then
         # The server half of the failure: a probe that failed on the HTTP side
         # says nothing about why. 200 lines, not 30.
-        for c in "$BOX" "$BARE"; do
+        for c in "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE"; do
             if docker inspect "$c" >/dev/null 2>&1; then
                 printf '\n----- docker logs %s (tail 200) -----\n' "$c" >&2
                 docker logs --tail 200 "$c" >&2 || true
             fi
         done
     fi
-    docker rm -f "$BOX" "$BARE" >/dev/null 2>&1 || true
-    docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" >/dev/null 2>&1 || true
+    docker rm -f "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE" >/dev/null 2>&1 || true
+    docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
     rm -rf "$SMOKE_HOME"
     exit "$status"
 }
@@ -93,18 +148,35 @@ trap teardown EXIT
 
 # A crashed earlier run leaves the box behind, and `install` refuses to run
 # onto an existing container. Clear the dedicated names before, not just after.
-docker rm -f "$BOX" "$BARE" >/dev/null 2>&1 || true
-docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" >/dev/null 2>&1 || true
+docker rm -f "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE" >/dev/null 2>&1 || true
+docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
 
-# wait_healthz CONTAINER — poll /healthz from INSIDE, so this works for the
-# bare container too (no published port).
+# wait_healthz CONTAINER WHAT — poll /healthz from INSIDE, so this works for
+# the bare container too (no published port). WHAT names the shape being
+# waited on, not the container: since #1952 the same driver waits on six
+# boots, and "grappa-smoke-hostile never answered" would not say WHICH hostile
+# substrate it was. Both arguments are required — a defaulted label is a
+# failure message that degrades exactly when it is needed.
 wait_healthz() {
     deadline=$((SECONDS + 300))
     until docker exec "$1" curl -fsS -o /dev/null http://localhost:4000/healthz 2>/dev/null; do
-        [ "$SECONDS" -lt "$deadline" ] || die "$1 never answered /healthz"
+        [ "$SECONDS" -lt "$deadline" ] || die "$2 ($1) never answered /healthz"
         printf '.'; sleep 2
     done
     printf '\n'
+}
+
+# migration_count IMAGE — how many migration files that image SHIPS.
+#
+# Read out of the release's own priv directory, with the vsn in the path left
+# to a glob: spelling it would be a second copy of VERSION, and this has to
+# work on an image whose version is precisely the one we do not want to state
+# twice. A throwaway container with the entrypoint overridden, so nothing
+# boots and no volume is touched.
+migration_count() {
+    docker run --rm --entrypoint sh "$1" \
+        -c 'ls -1 lib/grappa-*/priv/repo/migrations/*.exs 2>/dev/null | wc -l' \
+        | tr -cd '0-9'
 }
 
 say "installing via infra/docker/get.sh (release mode) from $GRAPPA_IMAGE"
@@ -191,12 +263,12 @@ pass "/api/config reports $GRAPPA_SMOKE_VERSION"
 say "probe 3: bare 'docker run' bootstraps secrets, and a restart reuses them"
 docker run -d --name "$BARE" -e PHX_HOST=localhost \
     -v "${BARE_VOLUME}:/data" "$GRAPPA_IMAGE" >/dev/null
-wait_healthz "$BARE"
+wait_healthz "$BARE" "the bare first boot"
 before="$(docker exec "$BARE" sha256sum /data/grappa.env | cut -d' ' -f1)"
 [ -n "$before" ] || die "no /data/grappa.env after first boot — the bootstrap never ran"
 
 docker restart "$BARE" >/dev/null
-wait_healthz "$BARE"
+wait_healthz "$BARE" "the bare restart"
 after="$(docker exec "$BARE" sha256sum /data/grappa.env | cut -d' ' -f1)"
 [ "$before" = "$after" ] \
     || die "the restart ROTATED /data/grappa.env ($before -> $after) — every stored credential is now undecryptable"
@@ -295,5 +367,249 @@ roll_sha="$(grep -oE '\{"sha":"[0-9a-f]+"' "$shipped_js" | head -n1 | sed 's/.*"
 # it would report 1 for any roll of any size. Count MATCHES.
 roll_people="$(grep -oE "$contributor_row" "$shipped_js" | wc -l | tr -d ' ')"
 pass "the shipped bundle credits commit ${roll_sha} and ${roll_people} contributor row(s)"
+
+# ---- probe 6: the VERSION SEAM — the previous release, upgraded in place ----
+#
+# #1952. Every probe above runs ONE image on state that image itself created:
+# probe 3 is the closest thing to an upgrade and it restarts the SAME image, so
+# the version seam is never crossed. The shape that broke #1945 in the field is
+# the other one — an existing box, running the previous release, updated in
+# place — and it is the shape a self-hoster's automated update takes.
+#
+# So: boot `$GRAPPA_PREVIOUS_IMAGE` on a fresh volume, let it bootstrap, write
+# state through it, stop it, and start the CANDIDATE on that same volume. The
+# direction is one-way on purpose (see the non-coverage list at the top).
+say "probe 6: $GRAPPA_SMOKE_PREVIOUS_VERSION boots, then $GRAPPA_SMOKE_VERSION inherits its volume"
+
+# Derived BEFORE anything boots, and from the images rather than from the
+# repository: how many migrations each one ships. The difference is exactly
+# how many the upgrade must run, because the previous image booted on an EMPTY
+# volume and auto-migrated, so what is applied down there is precisely its own
+# set. This is the #1945 canary without naming a migration — naming one
+# (`CreatePeerAvatars`) would go stale the release after it is written.
+cand_migrations="$(migration_count "$GRAPPA_IMAGE")"
+prev_migrations="$(migration_count "$GRAPPA_PREVIOUS_IMAGE")"
+# The anti-hollow-green guard, same posture as probe 5's third branch: zero
+# files means the release's priv layout moved and the count is blind, not that
+# a release ships no schema.
+# An `if` and not `A && B || die`: with that spelling the die runs when A is
+# TRUE and B is false AND when A is false, which reads the same here and stops
+# reading the same the moment a third clause joins (SC2015).
+if [ -z "$cand_migrations" ] || [ "$cand_migrations" -le 0 ]; then
+    die "found NO migration files in $GRAPPA_IMAGE under lib/grappa-*/priv/repo/migrations — the release layout moved and this probe is now blind"
+fi
+if [ -z "$prev_migrations" ] || [ "$prev_migrations" -le 0 ]; then
+    die "found NO migration files in $GRAPPA_PREVIOUS_IMAGE under lib/grappa-*/priv/repo/migrations — the release layout moved and this probe is now blind"
+fi
+expected_migrations=$((cand_migrations - prev_migrations))
+[ "$expected_migrations" -ge 0 ] \
+    || die "$GRAPPA_IMAGE ships FEWER migrations ($cand_migrations) than $GRAPPA_PREVIOUS_IMAGE ($prev_migrations) — a migration was deleted, and the upgrade this probe models cannot be reasoned about"
+
+docker run -d --name "$UP_OLD" -e PHX_HOST=localhost \
+    -v "${UP_VOLUME}:/data" "$GRAPPA_PREVIOUS_IMAGE" >/dev/null
+wait_healthz "$UP_OLD" "the PREVIOUS release ($GRAPPA_SMOKE_PREVIOUS_VERSION)"
+
+# The control that makes every assertion below mean something: the fixture is
+# really the older release. Without it, a resolver that handed back the
+# candidate's own ref would turn probe 6 into a second copy of probe 3 and
+# report a green upgrade across no seam at all.
+old_config="$(docker exec "$UP_OLD" curl -fsS --max-time 20 http://localhost:4000/api/config)" \
+    || die "the previous release did not answer /api/config"
+grep -Fq "\"version\":\"$GRAPPA_SMOKE_PREVIOUS_VERSION\"" <<<"$old_config" \
+    || die "the upgrade fixture does not report $GRAPPA_SMOKE_PREVIOUS_VERSION — this is not the release the candidate is being upgraded FROM: $old_config"
+
+up_env_before="$(docker exec "$UP_OLD" sha256sum /data/grappa.env | cut -d' ' -f1)"
+[ -n "$up_env_before" ] || die "no /data/grappa.env after the previous release's first boot"
+
+# The state that must survive, written through the operator door rather than
+# poked into the database: an account. Read back after the upgrade by EXIT
+# STATUS (a duplicate name is refused), never by matching an error string —
+# `Grappa.Release.cli/1` documents the status as the contract, and a message
+# is free to be reworded.
+printf 'release-smoke-password\n' \
+    | docker exec -i "$UP_OLD" bin/grappa create-user "$UP_CARRIER" >/dev/null \
+    || die "could not create the carrier account under $GRAPPA_SMOKE_PREVIOUS_VERSION — the upgrade probe has no state to carry across the seam"
+
+# SIGTERM and a real shutdown window, not a kill: the candidate is about to
+# open this database, and a half-checkpointed WAL would make any failure below
+# a story about the teardown instead of about the upgrade.
+docker stop -t 30 "$UP_OLD" >/dev/null
+
+docker run -d --name "$UP_NEW" -e PHX_HOST=localhost \
+    -v "${UP_VOLUME}:/data" "$GRAPPA_IMAGE" >/dev/null
+wait_healthz "$UP_NEW" "the CANDIDATE ($GRAPPA_SMOKE_VERSION) on the previous release's volume"
+
+up_log="$(docker logs "$UP_NEW" 2>&1)"
+# Positive control for the migration assertion, and it comes first: the
+# entrypoint says this line before it runs the migrator. Missing, the count
+# below would read 0 for "auto-migrate was off" and for "the log moved"
+# exactly as it does for "there was nothing to run" — three states, one
+# number. Refuse rather than pick.
+grep -Fq 'checking for pending migrations' <<<"$up_log" \
+    || die "the candidate's boot log never says it checked for pending migrations — GRAPPA_AUTO_MIGRATE is off or the entrypoint changed, and the migration assertion below cannot see anything"
+# `|| true` INSIDE the substitution: `grep -c` prints a legitimate 0 and then
+# exits 1, and 0 is an answer here, not a failure.
+ran_migrations="$(grep -c '== Running ' <<<"$up_log" || true)"
+[ "$ran_migrations" -eq "$expected_migrations" ] \
+    || die "the upgrade ran $ran_migrations migration(s); $GRAPPA_IMAGE ships $cand_migrations and $GRAPPA_PREVIOUS_IMAGE ships $prev_migrations, so $expected_migrations had to run"
+
+new_config="$(docker exec "$UP_NEW" curl -fsS --max-time 20 http://localhost:4000/api/config)" \
+    || die "the candidate did not answer /api/config after the upgrade"
+grep -Fq "\"version\":\"$GRAPPA_SMOKE_VERSION\"" <<<"$new_config" \
+    || die "after the upgrade the node still does not report $GRAPPA_SMOKE_VERSION: $new_config"
+
+# Probe 3's assertion, across the seam it could not reach. A rotated
+# GRAPPA_ENCRYPTION_KEY is silent data loss — every stored credential stops
+# decrypting — and an upgrade is exactly when a first-boot bootstrap might
+# mistake a populated volume for an empty one.
+up_env_after="$(docker exec "$UP_NEW" sha256sum /data/grappa.env | cut -d' ' -f1)"
+[ "$up_env_before" = "$up_env_after" ] \
+    || die "the UPGRADE rotated /data/grappa.env ($up_env_before -> $up_env_after) — every credential stored under $GRAPPA_SMOKE_PREVIOUS_VERSION is now undecryptable"
+
+# POSITIVE control before the verdict: the account door works on the candidate
+# for a name nobody has taken. Without it, a `create-user` broken into always
+# failing would make the refusal below look like a surviving row.
+printf 'release-smoke-password\n' \
+    | docker exec -i "$UP_NEW" bin/grappa create-user "${UP_CARRIER}-fresh" >/dev/null \
+    || die "create-user fails on the candidate for a FRESH name — the door is broken, so it cannot be asked whether the old row survived"
+if printf 'release-smoke-password\n' \
+    | docker exec -i "$UP_NEW" bin/grappa create-user "$UP_CARRIER" >/dev/null 2>&1; then
+    die "the candidate created $UP_CARRIER a SECOND time — the account written under $GRAPPA_SMOKE_PREVIOUS_VERSION is gone, so the volume's database did not survive the upgrade"
+fi
+pass "$GRAPPA_SMOKE_PREVIOUS_VERSION -> $GRAPPA_SMOKE_VERSION: $ran_migrations migration(s) ran, the secrets file held, and the account written under the old release is still there"
+
+# ---- probe 7: nothing the boot created lives OUTSIDE the volume ------------
+#
+# #1945's second half was silent, not loud. With the old default the peer
+# avatars were written to `/app/runtime/peer_avatars` — inside the container
+# LAYER, outside `grappa-data` — so a cold update deleted them with no error
+# anywhere. A crash at least tells you; this one only shows up as missing data
+# later.
+#
+# `docker diff` is the oracle that fits exactly: it reports the container's
+# read-write LAYER and, by construction, never reports what is under a mount.
+# So a data root that landed in the volume is invisible here and one that
+# missed it is an `A` line. Nothing has to be enumerated in advance, which is
+# what makes this a class gate rather than a second list of the three roots
+# #1945 happened to fix.
+#
+# THE BAR IS AN EMPTY DIFF, AND THAT IS A MEASUREMENT, NOT AN IDEAL. On
+# ghcr.io/vjt/grappa:v1.5.1 a full boot — entrypoint, secret bootstrap,
+# migrator, theme seeder, Phoenix up and answering — leaves the container layer
+# with LITERALLY NOTHING in it. There is no release scratch to carve out: no
+# /app/tmp, no /tmp, no cookie file. So no allowlist is written here, because
+# an allowlist authored ahead of the first entry it needs is a hole with a
+# comment on it.
+#
+# The same reading on the release BEFORE it is the evidence that this probe
+# bites. v1.5.0 answers three lines, and two of them are #1945 itself:
+#
+#     A /app/runtime
+#     A /app/runtime/peer_avatars
+#     C /app
+#
+# The next legitimate layer write — should one ever exist — belongs in a human
+# decision, not in a pattern widened on the day it first went red.
+say "probe 7: the upgraded boot wrote nothing outside /data"
+layer="$SMOKE_HOME/upgrade-layer.diff"
+docker diff "$UP_NEW" > "$layer" || die "docker diff refused to report $UP_NEW's layer"
+
+if [ -s "$layer" ]; then
+    printf '\n----- docker diff %s -----\n' "$UP_NEW" >&2
+    cat "$layer" >&2
+    die "the boot touched the CONTAINER LAYER, outside the /data volume — a cold update throws that away silently, which is #1945's second half. Measured expectation for a healthy release: no lines at all."
+fi
+
+# POSITIVE control, and the ONLY thing standing between the reading above and
+# a hollow green: an empty diff is also exactly what a BLIND oracle produces.
+# So plant #1945's own path and require `docker diff` to see it. Last, because
+# it dirties the container deliberately.
+docker exec "$UP_NEW" mkdir -p /app/runtime/peer_avatars \
+    || die "could not plant the layer canary — probe 7's own control cannot run"
+canary="$SMOKE_HOME/canary-layer.diff"
+docker diff "$UP_NEW" > "$canary"
+grep -Eq '^A /app/runtime$' "$canary" \
+    || die "docker diff does not report a directory just created in $UP_NEW's layer — the oracle is BLIND, and the empty reading above proved nothing"
+pass "the boot left the container layer empty, and a planted /app/runtime is still seen"
+
+# ---- probe 8: the candidate boots on hostile substrates --------------------
+#
+# #1952's class gate. #1945 fixed three storage roots; the next relative
+# default lands the same way unless something boots in a shape where the
+# process cannot write next to itself. Every probe above runs the image the
+# way `docker run` leaves it — WORKDIR /app, writable, as the baked `grappa`
+# user — which is the ONE shape in which a relative default silently works.
+#
+# Each shape below is a real deployment, gets its own fresh volume, and is
+# asked exactly one question: does it answer /healthz. The failures they are
+# hunting are the same one wearing different clothes — a path resolved against
+# something the operator, not the application, chose.
+say "probe 8: the candidate boots where the cwd is hostile"
+
+# hostile_boot SHAPE ARM-CHECK EXTRA-FLAG... — one shape, from a fresh volume,
+# asked one question.
+#
+# ARM-CHECK is a `docker inspect` format string that must come back `true`:
+# the proof that the hostile condition is actually IN FORCE. Without it a flag
+# that docker silently stopped honouring, or a typo in one, turns this probe
+# into a fifth ordinary boot reporting green — the same hollow-green shape
+# probe 7's canary exists to refuse, and the reason each shape carries its own
+# rather than one shared assertion.
+#
+# Each shape gets a FIRST boot of its own: one that only works because the
+# previous shape already created the state is not the shape an operator meets.
+hostile_boot() {
+    local shape="$1" arm_check="$2"; shift 2
+    docker rm -f "$HOSTILE" >/dev/null 2>&1 || true
+    docker volume rm "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+
+    docker run -d --name "$HOSTILE" -e PHX_HOST=localhost \
+        -v "${HOSTILE_VOLUME}:/data" "$@" "$GRAPPA_IMAGE" >/dev/null \
+        || die "the '$shape' substrate: docker refused to start the container at all"
+
+    local armed
+    armed="$(docker inspect -f "$arm_check" "$HOSTILE")"
+    [ "$armed" = true ] \
+        || die "the '$shape' substrate was never actually applied — docker reports '$armed' for $arm_check, so whatever this boot proves, it is not that shape"
+
+    wait_healthz "$HOSTILE" "the '$shape' substrate"
+    pass "'$shape' is in force and answered /healthz"
+    docker rm -f "$HOSTILE" >/dev/null 2>&1 || true
+    docker volume rm "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+}
+
+# ── shape 1: a read-only root filesystem ────────────────────────────────────
+#
+# The hardened-compose shape (`read_only: true`), and the one that states the
+# image's contract out loud: /data is the only thing the application writes.
+#
+# ONE tmpfs, and it is measured rather than assumed. Naked `--read-only` dies
+# with `mktemp: : Read-only file system` before it reaches the secret
+# bootstrap; `--read-only --tmpfs /tmp` boots. `/app/tmp` is NOT in the recipe
+# because the release never writes there — which is the same fact probe 7
+# measures from the other side, an empty container layer.
+hostile_boot 'read-only rootfs' '{{.HostConfig.ReadonlyRootfs}}' \
+    --read-only --tmpfs /tmp:rw,mode=1777
+
+# ── shape 2: a working directory the process did not choose ─────────────────
+#
+# The honest stand-in for the production jail, where #1945 actually happened:
+# rc.d starts the release with `su -m grappa` and no `cd` at all, so the cwd is
+# `/`. Docker bakes `WORKDIR /app` and makes it writable by the runtime user,
+# which is exactly why the same class of defect is SILENT here and FATAL
+# there. This shape removes that difference, and one `--workdir` is all it
+# takes — the flag a hardened compose file or a Kubernetes `workingDir:` sets
+# without a thought.
+#
+# MEASURED RED before the cure that ships with it: on stock v1.5.1 this exits 1
+# with `bin/grappa: not found`, because the entrypoint resolved the release
+# RELATIVELY. `infra/docker/release-entrypoint.sh` now takes its directory from
+# `$0`, which is a no-op on every path that already worked.
+#
+# The arm check is `.Config.WorkingDir` and not a `docker exec pwd`: the
+# interesting failures here EXIT, and a shape that has to be alive to prove it
+# was applied cannot report on the boot that died.
+hostile_boot 'cwd the process did not choose (/)' '{{eq .Config.WorkingDir "/"}}' \
+    --workdir /
 
 say "release image $GRAPPA_IMAGE deployed and answered every probe 🎉"

--- a/test/infra/release_entrypoint_migrate_test.bats
+++ b/test/infra/release_entrypoint_migrate_test.bats
@@ -293,3 +293,87 @@ SEED_CALL="eval Grappa.Release.seed_themes()"
         *) printf 'ERL_ZFLAGS=%s lost the #503 caps\n' "$zflags" >&2; return 1 ;;
     esac
 }
+
+# ---------------------------------------------------------------------------
+# #1952 — the release root is where this script LIVES, not where the caller
+# stood.
+#
+# Three commands in this file run `bin/grappa` and all three used to spell it
+# relatively, so the entrypoint only worked from a cwd nothing in it chose.
+# Measured on the published image, `docker run --workdir /` gave
+# `bin/grappa: not found` and `exited/1` — one flag a hardened compose file or
+# a Kubernetes `workingDir:` sets without a thought. It is issue 1945's shape:
+# a path resolved against a working directory the init system picks.
+#
+# The cases below prove the cure by SHIFT — the same call from the same
+# foreign cwd, against the entrypoint with the fix and against one with the
+# fix cut back out. A green that is not contrasted with the red it replaced
+# says nothing about which line is load-bearing.
+
+# The entrypoint invoked BY ABSOLUTE PATH from somewhere else entirely, which
+# is what `docker run --workdir /` does.
+entrypoint_from_elsewhere() {
+    local script="$1"; shift
+    local elsewhere="$BATS_TEST_TMPDIR/elsewhere"
+    mkdir -p "$elsewhere"
+    cd "$elsewhere" && "$script" "$@"
+}
+
+@test "#1952 — the entrypoint finds the release from its OWN directory, not the caller's cwd" {
+    run entrypoint_from_elsewhere "$APP/release-entrypoint.sh" start
+    [ "$status" -eq 0 ]
+    grep -qF "$MIGRATE_CALL" "$CALL_LOG"
+
+    # RED half, and it is what makes the green above mean something: the same
+    # script with the one `cd` line cut out, from the same foreign cwd.
+    local without="$BATS_TEST_TMPDIR/no-cd-entrypoint.sh"
+    sed '/^cd "\$(dirname "\$0")"$/d' "$APP/release-entrypoint.sh" > "$without"
+    chmod 0755 "$without"
+
+    # Guard the MUTATION before trusting the failure it produces. If the sed
+    # matched nothing the two files are identical, and a red below would be
+    # reporting something else entirely.
+    refute cmp -s "$APP/release-entrypoint.sh" "$without"
+
+    : > "$CALL_LOG"
+    run entrypoint_from_elsewhere "$without" start
+    [ "$status" -ne 0 ]
+    refute grep -qF "$MIGRATE_CALL" "$CALL_LOG"
+}
+
+@test "#1952 — a release tree with no runnable bin/grappa says THAT, not that a migration failed" {
+    # The second defect the measurement surfaced, and it is a different one:
+    # the operator was told MIGRATION FAILED while nothing had touched the
+    # schema. A fast path states what it OBSERVED.
+    rm -f "$APP/bin/grappa"
+    run entrypoint start
+
+    [ "$status" -eq 1 ]
+    grep -qF 'no runnable bin/grappa' <<<"$output"
+    grep -qF 'NOTHING has been migrated' <<<"$output"
+    refute grep -qF 'MIGRATION FAILED' <<<"$output"
+
+    # Present but not executable is the same fault wearing the other POSIX
+    # number, and the operator needs the same sentence. This is why the guard
+    # is `test -x` and not an exit-status arm: measured, the status for these
+    # two differs by shell (`sh -c` answers 127, this script under `set -e` on
+    # bash-as-sh hands back 1) while the observable fact does not.
+    printf '#!/bin/sh\nexit 0\n' > "$APP/bin/grappa"
+    chmod 0644 "$APP/bin/grappa"
+    run entrypoint start
+
+    [ "$status" -eq 1 ]
+    grep -qF 'no runnable bin/grappa' <<<"$output"
+    refute grep -qF 'MIGRATION FAILED' <<<"$output"
+}
+
+@test "#1952 — POSITIVE control: a migrator that RAN and failed still says MIGRATION FAILED" {
+    # Without this, a script broken into always taking the 127 arm would report
+    # the case above as a pass while having lost the real failure message.
+    export MIGRATE_RC=1
+    run entrypoint start
+
+    [ "$status" -ne 0 ]
+    grep -qF 'MIGRATION FAILED' <<<"$output"
+    refute grep -qF 'no runnable bin/grappa' <<<"$output"
+}

--- a/test/infra/release_upgrade_probe_test.bats
+++ b/test/infra/release_upgrade_probe_test.bats
@@ -1,0 +1,273 @@
+#!/usr/bin/env bats
+#
+# #1952 — the release smoke crosses a VERSION SEAM, and the previous release it
+# crosses it from is DERIVED.
+#
+# THE COVERAGE PROBLEM THIS FILE SOLVES. `release.yml` fires on `push: tags:
+# v*` and on `workflow_dispatch`, and the upgrade probe lives inside its
+# `smoke` job — so no pull request ever executes it. The first real run of
+# anything added there is the release itself, which is the worst possible
+# place to discover a broken gate: #1951 is that exact story, a probe whose
+# pattern had rotted failing the release runs of v1.5.0 AND v1.5.1. The
+# mitigation it landed is the one used here — bats that exercise the LOGIC at
+# PR time, so what remains untested until the release is only the part that
+# genuinely needs a booted container.
+#
+# What these cases CAN claim:
+#   * `previous_release_tag.sh` resolves the release below a version, against
+#     real git repositories with real tag sets;
+#   * the driver REFUSES to run without an upgrade fixture, rather than
+#     quietly reducing itself to the five same-version probes it had;
+#   * `release.yml` derives that fixture, pulls it, and hands it over.
+#
+# What they CANNOT claim, and it is deliberate: that the upgrade BOOTS. That
+# needs two published images and a docker daemon, and it stays the smoke job's
+# job on a real tag. The seam is the same one `release_image_credits_test.bats`
+# draws between reading the recipe and reading the artifact.
+
+load ../bats_helpers
+
+setup() {
+    REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    RESOLVER="$REPO_SRC/infra/packaging/previous_release_tag.sh"
+    CLASSIFIER="$REPO_SRC/infra/packaging/prerelease_flag.sh"
+    SMOKE="$REPO_SRC/scripts/smoke-release-image.sh"
+    WORKFLOW="$REPO_SRC/.github/workflows/release.yml"
+}
+
+# A throwaway repository carrying exactly the tags named, and PRODUCTION's own
+# two scripts beside each other in it (the resolver resolves its classifier as
+# `dirname $0`, so they must stay siblings). Real tags on a real repository,
+# never a stubbed `git`: the thing under test is a reading of git's tag list,
+# and a stub would only prove that the stub agrees with itself.
+tag_repo() {
+    # A fresh directory per CALL, not per case: a case building two repos to
+    # contrast them would otherwise have the second overwrite the first, and
+    # the positive control at the end would read the wrong tag set. (Measured
+    # — the first spelling keyed on $BATS_TEST_NUMBER and did exactly that.)
+    local root; root="$(mktemp -d "$BATS_TEST_TMPDIR/repo.XXXXXX")"
+    mkdir -p "$root/pkg"
+    cp "$RESOLVER" "$CLASSIFIER" "$root/pkg/"
+
+    git -C "$root" init -q
+    git -C "$root" -c user.email=b@t -c user.name=b commit -q --allow-empty -m seed
+    local tag
+    for tag in "$@"; do
+        git -C "$root" tag "$tag"
+    done
+    printf '%s\n' "$root"
+}
+
+# The resolver, run FROM that repository — its tag list is the input.
+#
+# TWO helpers, because the script splits its answer across the two streams the
+# way `latest_tag_gate.sh` does: the VERDICT on stdout, the REASON on stderr.
+# `run` merges them, so a case asserting `$output` = a tag would be comparing
+# against the reason line glued to the answer — green or red for reasons that
+# have nothing to do with the resolution.
+resolve_in() {
+    local root="$1"; shift
+    ( cd "$root" && ./pkg/previous_release_tag.sh "$@" 2>/dev/null )
+}
+
+# The same call with the reason kept, for the cases that assert on it.
+resolve_said() {
+    local root="$1"; shift
+    ( cd "$root" && ./pkg/previous_release_tag.sh "$@" 2>&1 )
+}
+
+@test "#1952 — the previous release is the highest tag strictly BELOW the one under test" {
+    local root; root="$(tag_repo v1.4.0 v1.4.1 v1.5.0 v1.5.1)"
+
+    run resolve_in "$root" v1.5.2
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.5.1 ]
+
+    # Not "the tag before this one in creation order", and not "the highest
+    # tag": asked about a release in the middle, it answers the one below THAT.
+    run resolve_in "$root" v1.5.0
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.4.1 ]
+}
+
+@test "#1952 — a backport cut AFTER a newer minor still resolves by version, not by creation order" {
+    # v0.7.5 is tagged last and sorts below v0.8.0. An implementation reading
+    # "the tag before this one" off the end of the list would answer v0.7.5
+    # for v0.8.1 — an image nobody upgrading to v0.8.1 was running.
+    local root; root="$(tag_repo v0.7.0 v0.8.0 v0.8.1 v0.7.5)"
+
+    run resolve_in "$root" v0.8.1
+    [ "$status" -eq 0 ]
+    [ "$output" = v0.8.0 ]
+
+    # And the backport's OWN previous is the release below it, not the newer
+    # minor sitting above.
+    run resolve_in "$root" v0.7.5
+    [ "$status" -eq 0 ]
+    [ "$output" = v0.7.0 ]
+}
+
+@test "#1952 — a pre-release is never the release an operator upgrades FROM" {
+    local root; root="$(tag_repo v1.2.0 v1.3.0-rc1 v1.3.0-rc2)"
+
+    # The candidates outrank v1.2.0 and are still not the answer: they are
+    # tags most boxes never ran, and the upgrade under test is the one an
+    # automated update performs along the stable line.
+    run resolve_in "$root" v1.3.0
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.2.0 ]
+
+    # A CANDIDATE upgrades from the last stable too — not from its own sibling
+    # candidate, which is the reading `--sort=-v:refname` would hand back.
+    run resolve_in "$root" v1.3.0-rc2
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.2.0 ]
+}
+
+@test "#1952 — build metadata is not a pre-release, and its hyphen does not make one" {
+    # `1.4.0+foo-bar` carries a hyphen INSIDE its build metadata and is a
+    # RELEASE — the row that decided prerelease_flag.sh's implementation, and
+    # the row a hand-rolled `grep -v -- -` gets wrong. It must be eligible.
+    local root; root="$(tag_repo v1.3.0 v1.4.0+foo-bar)"
+
+    run resolve_in "$root" v1.5.0
+    [ "$status" -eq 0 ]
+    [ "$output" = 'v1.4.0+foo-bar' ]
+}
+
+@test "#1952 — the version under test need not be a tag at all" {
+    # The `docker_validation` dry-run runs from a BRANCH whose VERSION has
+    # never been tagged. git can only order refs it holds, which is why the
+    # resolver compares numerically instead of asking git where this falls.
+    local root; root="$(tag_repo v1.5.0 v1.5.1)"
+
+    run resolve_in "$root" v1.6.0
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.5.1 ]
+}
+
+@test "#1952 — a tag the classifier cannot read is skipped, not fatal" {
+    # A stray tag must not become a permanent veto over every future release;
+    # it also never had an image published under it, so it cannot be the
+    # answer. Both halves are asserted: the run SUCCEEDS, and the stray is not
+    # what it returns.
+    local root; root="$(tag_repo v1.4.0 nightly-2026-08-01 v1.5.0)"
+
+    run resolve_in "$root" v1.6.0
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.5.0 ]
+}
+
+@test "#1952 — RED: an unresolvable previous is a refusal, never an empty line" {
+    # The caller interpolates this into an image ref. An empty answer would
+    # resolve to `ghcr.io/<owner>/grappa:` and fail somewhere far from here,
+    # so both dead ends exit 2 — and they are told apart, because a shallow
+    # checkout and a first-of-its-line need different fixes.
+    local with_tags; with_tags="$(tag_repo v1.5.0 v1.5.1)"
+    run resolve_said "$with_tags" v1.5.0
+    [ "$status" -eq 2 ]
+    grep -Fq 'no release tag sorts below' <<<"$output"
+
+    local bare; bare="$(tag_repo)"
+    run resolve_said "$bare" v1.5.0
+    [ "$status" -eq 2 ]
+    grep -Fq 'no v* tag at all' <<<"$output"
+
+    # POSITIVE control: the same resolver, the same repository, a version that
+    # DOES have a release below it. Without it a resolver broken into always
+    # refusing would report both refusals above as a pass.
+    run resolve_in "$with_tags" v1.5.2
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.5.1 ]
+}
+
+@test "#1952 — RED: a tag the classifier refuses UNDER TEST is refused outright" {
+    # The opposite case from the stray above: skipping the tag being asked
+    # about would mean guessing which release it sits after, and the
+    # permissive answer is the one that probes the wrong seam.
+    local root; root="$(tag_repo v1.4.0 v1.5.0)"
+
+    run resolve_said "$root" v1.5
+    [ "$status" -eq 2 ]
+    grep -Fq 'cannot classify' <<<"$output"
+
+    run resolve_said "$root" 1.5.1
+    [ "$status" -eq 2 ]
+    grep -Fq 'cannot classify' <<<"$output"
+
+    # POSITIVE control, same reason as above.
+    run resolve_in "$root" v1.5.1
+    [ "$status" -eq 0 ]
+    [ "$output" = v1.5.0 ]
+}
+
+@test "#1952 — RED: without its classifier the resolver refuses rather than treating every tag as a release" {
+    # A missing classifier degrades into "no tag is ever a pre-release", which
+    # would hand back a release candidate as the thing to upgrade from.
+    local root; root="$(tag_repo v1.2.0 v1.3.0-rc2)"
+    rm -f "$root/pkg/prerelease_flag.sh"
+
+    run resolve_said "$root" v1.3.0
+    [ "$status" -eq 2 ]
+    grep -Fq 'classifier' <<<"$output"
+}
+
+# ---------------------------------------------------------------------------
+# The wiring. Three separate channels, and cutting any one of them leaves the
+# release smoke crossing no version seam while every check stays green.
+
+@test "#1952 — the smoke driver REFUSES to run without an upgrade fixture" {
+    # `:?` and not a `:-` default: a driver that ran five same-version probes
+    # when the fixture was missing would report exactly the green #1952 exists
+    # to end.
+    grep -qE '^: "\$\{GRAPPA_PREVIOUS_IMAGE:\?' "$SMOKE" || {
+        printf 'scripts/smoke-release-image.sh does not REQUIRE GRAPPA_PREVIOUS_IMAGE.\n' >&2
+        grep -n 'GRAPPA_PREVIOUS_IMAGE' "$SMOKE" >&2 || true
+        return 1
+    }
+    grep -qE '^: "\$\{GRAPPA_SMOKE_PREVIOUS_VERSION:\?' "$SMOKE" || {
+        printf 'the driver does not REQUIRE GRAPPA_SMOKE_PREVIOUS_VERSION — without it\n' >&2
+        printf 'nothing checks that the fixture is the OLDER release, and an upgrade\n' >&2
+        printf 'from the candidate to itself would pass.\n' >&2
+        return 1
+    }
+}
+
+@test "#1952 — release.yml derives the previous tag, pulls it, and hands both values to the driver" {
+    grep -qF 'infra/packaging/previous_release_tag.sh' "$WORKFLOW" || {
+        printf 'release.yml no longer calls previous_release_tag.sh — nothing else in\n' >&2
+        printf 'the job knows which release the candidate is being upgraded FROM.\n' >&2
+        return 1
+    }
+    grep -qE '^ +GRAPPA_PREVIOUS_IMAGE: \$\{\{ steps\.[a-z_]+\.outputs\.image \}\}$' "$WORKFLOW" || {
+        printf 'release.yml does not hand GRAPPA_PREVIOUS_IMAGE to the smoke driver.\n' >&2
+        printf 'Resolving the tag and not passing it means the driver refuses to run.\n' >&2
+        grep -n 'GRAPPA_PREVIOUS_IMAGE' "$WORKFLOW" >&2 || true
+        return 1
+    }
+    grep -qE '^ +GRAPPA_SMOKE_PREVIOUS_VERSION: \$\{\{ steps\.[a-z_]+\.outputs\.version \}\}$' "$WORKFLOW" || {
+        printf 'release.yml does not hand GRAPPA_SMOKE_PREVIOUS_VERSION over.\n' >&2
+        grep -n 'GRAPPA_SMOKE_PREVIOUS_VERSION' "$WORKFLOW" >&2 || true
+        return 1
+    }
+}
+
+@test "#1952 — the smoke job fetches tags, or the resolver has nothing to read" {
+    # `git tag -l` on the depth-1 checkout this job used to take answers
+    # NOTHING, and the resolver would refuse every run. The fix belongs in the
+    # checkout, so it is pinned there.
+    local smoke_job
+    smoke_job="$(awk '/^  smoke:/ { inside = 1; next } /^  [a-z]+:$/ { inside = 0 } inside' "$WORKFLOW")"
+
+    # Guard the extractor before trusting it: an empty slice would make every
+    # grep below vacuously fail, or vacuously pass under a negation.
+    grep -qF 'smoke-release-image.sh' <<<"$smoke_job" || {
+        printf 'the smoke job slice came out empty or wrong — this case is reading nothing.\n' >&2
+        return 1
+    }
+    grep -qE '^ +fetch-tags: true$' <<<"$smoke_job" || {
+        printf 'the smoke job checkout does not fetch tags; previous_release_tag.sh\n' >&2
+        printf 'would refuse every run with "this checkout holds no v* tag at all".\n' >&2
+        return 1
+    }
+}


### PR DESCRIPTION
Adds the three things issue 1952 asks for: an upgrade probe across a version seam, a hostile-substrate matrix, and an assertion that boot-time writes land in the volume. Everything below was measured on the published `ghcr.io/vjt/grappa` images, not reasoned about.

## ⚠️ This carries PRODUCTION code, and it is deliberate

`infra/docker/release-entrypoint.sh` takes two changes: `cd "$(dirname "$0")"` at the top, and a `test -x bin/grappa` precondition. **The hostile-substrate matrix cannot pass without the first one**, and a gate that is red by construction has two futures — red forever, or somebody weakening the oracle to make it green.

It is issue 1945's own class, one layer over. Measured on stock `v1.5.1`:

```
docker run --workdir / ...
/app/release-entrypoint.sh: line 126: bin/grappa: not found
grappa: MIGRATION FAILED — refusing to start.
exited/1
```

Three commands in that script run `bin/grappa` and all three spelled it relatively, so the entrypoint only ever worked from a working directory nothing in it had chosen. `--workdir`, or a Kubernetes `workingDir:`, is set without a thought. The cure in 1945 stopped deriving DATA paths from the cwd; this one stops deriving the release's OWN path from it. `cd "$(dirname "$0")"` is a no-op wherever things already worked — the image bakes `WORKDIR /app` and the file lands in it.

**Blast radius, verified rather than assumed.** The only installer of that file is `Dockerfile.release`. `infra/freebsd/` and `infra/linux/` contain zero references; `infra/packaging/`'s single hit is a comment. The one non-Dockerfile consumer, `infra/release/grappa.sh`, IS installed into every release including the jail's, and is doubly barred: it requires `GRAPPA_SUBSTRATE = docker` exactly (the jail is `jail` or unset), and the path it would exec is never created outside the image because `install_operator_cli/1` copies only `infra/release/grappa.sh`. **Production — the m42 bastille jail — runs `mix release` and does not read this file.**

The cure is proved by SHIFT, both outcomes, same flag, same harness, the two images differing only in that file (`sha256` `c7e88472…` vs `b881773f…`):

| entrypoint | `--workdir /` | result |
|---|---|---|
| stock v1.5.1 | `bin/grappa: not found` → `MIGRATION FAILED` | `exited/1`, healthz=no |
| cured | — | `running/0`, **healthz=YES** |

`--read-only --tmpfs /tmp` stays green on the cured image too, so the `cd` does not break the other shape.

### The second defect is a different one

The operator was told `MIGRATION FAILED`, with a paragraph about rolling the schema back, while nothing had opened the database — the log-honesty rule verbatim. The first spelling of the cure keyed on exit 127, and the bats case written for it is what killed that: **on one missing file the number is not stable.** `sh -c 'bin/nothere'` answers 127, busybox ash prints `not found`, and this script's own `if ! bin/grappa …` under `set -e` on bash-as-sh hands back **1** — indistinguishable from a migration that ran and failed. So the guard is a precondition, `test -x`, which answers the same on every shell, placed once at the top because a tree with no runnable `bin/grappa` cannot migrate, seed or boot.

## What was measured

Upgrade `v1.5.0` → `v1.5.1` on one volume: healthy in 3s, `/api/config` moves to the new number, `/data/grappa.env` identical byte for byte (`07d69135…` both sides), both tags ship 96 migrations so zero had to run and zero did, and the account created under the old release still refuses a duplicate afterwards.

`docker diff` on a healthy boot of `v1.5.1` is **empty** — no `/app/tmp`, no `/tmp`, no cookie file. So no allowlist is written: one authored ahead of the first entry it needs is a hole with a comment on it. The same reading on `v1.5.0` is three lines, two of them the defect itself:

```
A /app/runtime
A /app/runtime/peer_avatars
C /app
```

That is 1945's silent half, live in a published image, and it is the evidence this probe bites.

Read-only needs exactly one tmpfs: naked `--read-only` dies on `mktemp: : Read-only file system`; `--read-only --tmpfs /tmp` boots. `/app/tmp` is deliberately absent — the release writes nothing under `/app`, the same fact the empty layer reports from the other side. That recipe is now in `docs/OPERATIONS.md`.

## What I refused to assert

- **That the upgrade probe runs in CI before a real tag.** It does not, and cannot. `release.yml` fires on `push: tags: v*` and on `workflow_dispatch`, so **no pull request executes any of this** — the first real run is the release. The mitigation is 1951's: 12 bats over the LOGIC at PR time, against real git repositories with real tag sets. What stays unproven until a tag is the part that genuinely needs a booted container, and I ran that part by hand instead of claiming it.
- **A volume mounted over `/app`** — one of the four shapes the issue lists. The release IS `/app`, so hiding it removes the thing under test; asserting that shape answers 200 would assert a falsehood.
- **An arbitrary uid (`--user 65534`)** — the other one. Not a judgement, a measurement: the setup cannot be made to hold. Docker re-seeds an EMPTY named volume from the image on every mount, ownership included, so `chown -R 65534:65534 /data` in a helper container reads back as `65534:65534` inside it and as the image's `100:101` in the next one. Only a pre-populated volume survives that, which is a fixture built to dodge a docker behaviour rather than a substrate anybody runs — and the property it would test is what the read-only shape asserts directly.
- **That an ancient repair dispatch is unaffected.** A repair of a tag whose predecessor was never published as an image would fail on the pull. Modern tags all have one; the resolve step stands down entirely for tags whose driver predates this work, reading the DRIVER rather than the event.
- **That anything here was measured on amd64.** The host is arm64. The properties measured are cwd, permission and filesystem semantics, which are architecture-independent, but I did not run this on the architecture CI uses.

## Gates

| gate | result |
|---|---|
| `scripts/bats.sh` (full) | **rc=0**, 748 ok, 0 not ok |
| `scripts/shellcheck.sh` | **rc=0**, 83 scripts |
| `scripts/posix-parse.sh` | **rc=0**, 34 scripts |
| `scripts/design-notes-gate.sh` | **rc=0**, 1 entry, separator + marker present |
| `union-rebase.sh` onto `5e5384846` | **rc=0**, contribution intact both sides, boundary shape and preceding entry's tail read on the real file |

Not run: `scripts/check.sh` (no Elixir touched) and `scripts/integration.sh` (no e2e or app code touched).
