### PR TITLE
release smoke: run the two hostile shapes the matrix was missing (1952, leg 2)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47446,3 +47446,133 @@ them to contrast had the second silently eat the first.
 _Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
 release image, so it reaches an operator only through a new image. The m42
 jail runs `mix release` and does not read it; nothing else here leaves CI._
+<!-- entry #1952b -->
+
+---
+
+## 2026-09-07 — #1952b: the two hostile shapes the first pass refused, and the reading that made one of them look impossible
+
+The hostile-substrate matrix #1952 asks for is FOUR shapes. The first pass
+shipped two — `--read-only` and `--workdir /` — and named the other two in the
+driver's non-coverage list, one as a judgement and one as a measurement. Both
+are now run. This entry is mostly about why the refusals were wrong, because
+the mistake is reusable and the fix is not.
+
+### An arbitrary uid: the mechanism was right, the conclusion did not follow
+
+The refusal read: docker re-seeds an EMPTY named volume from the image on every
+mount, ownership included, so a helper container's `chown -R 65534 /data` reads
+back as `65534` inside that container and as the image's `100:101` in the next
+one — therefore the shape cannot be set up.
+
+The first clause is TRUE and re-measured here: create a volume, chown it,
+mount it again, and the image's owner is back. The second clause does not
+follow from it, because the re-seed only applies **while the volume is empty**.
+One zero-byte file inside and the ownership sticks:
+
+| fixture | next container reads |
+| --- | --- |
+| empty volume, `chown 65534` from a helper | `100:101` — re-seeded |
+| one file inside, `chown -R 65534` | `65534:65534`, and writable |
+| control: virgin volume, `--user 65534` writes | `permission denied` |
+
+So the shape is constructible, and the fixture is not a trick to dodge docker:
+handing storage to the uid it will run as is what an arbitrary-uid deployment
+does anyway — a Kubernetes `fsGroup`, an operator's `chown` on the host path.
+The general rule the miss illustrates: **a measured mechanism plus an
+inference is not a measurement.** "I could not build it" and "it cannot be
+built" are different claims, and only the first was in evidence.
+
+What the shape then found is the strongest red in the file, because it is
+#1945 verbatim rather than a cousin of it. Same fixture, same flags, the two
+releases apart:
+
+```
+v1.5.1   running/0, /healthz in 2s
+v1.5.0   exited/1
+         ** (File.Error) could not make directory (with -p)
+            "runtime/peer_avatars": permission denied
+                (grappa 1.5.0) lib/grappa/avatars/reaper.ex:79
+```
+
+The path in that error is RELATIVE. `/app` is writable by the baked user and
+by nobody else, which is exactly why the same defect is silent on every other
+docker shape. The control that makes the pair mean something: v1.5.0 with the
+baked user on an ordinary volume boots healthy, so the red belongs to the uid
+and not to the release.
+
+### A volume over /app: one sentence, two substrates, opposite answers
+
+The refusal read: the release IS `/app`, so mounting over it removes the thing
+under test. That is TRUE OF A BIND MOUNT AND FALSE OF A NAMED VOLUME, and the
+issue's words ("a volume mounted over `/app`") name the second.
+
+* empty **bind** mount — the container is not merely unable to boot, it cannot
+  be CREATED: `stat /app/release-entrypoint.sh: no such file or directory`,
+  status `created/127`. It stays in the non-coverage list, now with that
+  measurement attached.
+* named **volume** — docker copies the image's `/app` into it at first mount,
+  permissions and the setgid bit included, and the container boots. Both
+  v1.5.0 and v1.5.1 answer `/healthz`.
+
+Which is the problem with the shape: **boot alone does not discriminate**, so
+a probe asserting only `/healthz` here would be a fifth ordinary boot. What
+discriminates is the release root itself. `docker diff` — probe 7's oracle for
+"the boot wrote nothing outside /data" — never reports what is under a mount,
+and on this substrate answers **zero lines for v1.5.0**, whose #1945 defect
+creates `runtime/peer_avatars` right there. So shape 3 reads the same property
+through the window the mount leaves open: `ls -1A` on the volume after the
+boot must equal `ls -1A` on the `/app` the image ships. Measured, the same
+comparison the driver runs:
+
+```
+[ -s shipped ]  → non-empty (the blindness guard)
+cmp             → DIFFER
+diff            → 7a8 > runtime
+```
+
+### What this probe's green does NOT mean, and it needs saying
+
+Mounting a volume over `/app` is not thereby supported. The copy-up happens
+ONCE, while the volume is empty: pull a new image, recreate the container, and
+the volume still holds the OLD release. Measured — a container started from
+`:v1.5.1` on a volume seeded by v1.5.0 reports `.Config.Image = …:v1.5.1` to
+`docker inspect` and version `1.5.0` to `/api/config`. Silent stale code across
+exactly the upgrade this issue exists for. The driver therefore removes that
+volume before the run AND in the teardown, since a leaked one would make the
+NEXT smoke boot a release nobody built while reporting the tag it was asked
+for.
+
+### A mutation test that landed somewhere else, and was worth keeping
+
+To prove shape 3's oracle is not blind, an image was built from v1.5.1 with
+#1945's shape reintroduced — a relative `mkdir -p runtime/peer_avatars` in the
+entrypoint, guarded by a `cmp` proving the `sed` had matched. Run through the
+driver it died at **probe 7**, not shape 3: the mutation writes on every boot,
+and `docker diff` on the ordinary container sees it first. That is the right
+behaviour and the wrong experiment — the two oracles overlap on the ordinary
+substrate, and shape 3's exists only for the one where probe 7 cannot look. The
+isolating evidence is the direct run above, against a volume a real v1.5.0
+booted on.
+
+### Shape of the driver
+
+`hostile_boot` now takes the `uid:gid` its `/data` volume must be handed to as
+a REQUIRED third argument — no default, because that ownership is half of what
+a shape means, and a call that forgets it puts a docker flag where the owner
+belongs. Three of the four pass the image's own owner, read out of the image
+with `stat -c %u:%g /data` rather than spelled: a literal `100:101` here is a
+second copy of a Dockerfile fact, wrong the day `adduser -S` picks another
+number. The arbitrary uid is guarded against BEING that owner, or the shape
+would be an ordinary boot wearing a `--user` flag.
+
+`test/infra/release_hostile_matrix_test.bats` is the PR-time half, for the same
+reason the upgrade probe has one: nothing in the `smoke` job runs on a pull
+request. It folds the driver's backslash-continuations and EVALUATES each
+`hostile_boot` call with the function replaced by a recorder, so the assertions
+read the real argument lists through the real quoting — a shape that dropped
+its owner argument shows up as a flag in `$3`, which is the mistake a grep
+cannot see. It carries its own negative control on that predicate.
+
+_Deploy: **nothing** — the driver and its bats run in CI and by hand; no
+runtime code changed, and no substrate reads either file._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1947,7 +1947,7 @@ D** — see **Running the published image** below.
   is `scripts/smoke-release-image.sh`, runnable by hand — probes, mutation
   evidence and the explicit non-coverage list are in
   `docs/TESTING.md` § "The release-image smoke".
-- **It crosses a VERSION SEAM, and boots where the cwd is hostile (#1952).**
+- **It crosses a VERSION SEAM, and boots on hostile substrates (#1952).**
   Until then every probe was a FIRST boot on an empty volume of ONE image, so
   the shape that breaks a self-hoster — an existing box on the previous
   release, updated in place — had no coverage; that is the shape #1945 reached
@@ -1959,8 +1959,19 @@ D** — see **Running the published image** below.
   written under the old release still there. It then asserts that the boot
   wrote **nothing** into the container layer (`docker diff`, which never
   reports what is under a mount — measured empty on a healthy release and
-  three lines on v1.5.0, two of them #1945 itself), and boots the candidate
-  under `--read-only --tmpfs /tmp` and under `--workdir /`.
+  three lines on v1.5.0, two of them #1945 itself), and boots the candidate on
+  FOUR hostile substrates (#1952b): `--read-only --tmpfs /tmp`, `--workdir /`,
+  a named volume mounted over `/app`, and `--user 65534`. Each carries a
+  `docker inspect` check proving the flag is actually in force, and the `/app`
+  shape additionally compares the release root after the boot against the one
+  the image ships — `docker diff` cannot see under a mount, and answers zero
+  lines for v1.5.0 there while the volume grows `runtime`.
+  ⚠️ **Do not read the `/app` shape's green as "mounting a volume over `/app`
+  is supported".** Docker seeds such a volume from the image ONCE, while it is
+  empty: recreate the container on a newer image and it boots the OLD release
+  while `docker inspect` reports the new tag (measured, `:v1.5.1` on a
+  v1.5.0-seeded volume serving `1.5.0` from `/api/config`). Mount volumes at
+  `/data`, never at `/app`.
   ⚠️ **The previous image is now REQUIRED**, on the same no-skip footing as
   the candidate: a run that quietly fell back to the same-version probes would
   report exactly the green this closed. The one exception is a repair dispatch

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -452,22 +452,56 @@ passing that arg too — see § "The published release image" in
 `docs/OPERATIONS.md`. The asymmetry is the point: the naked build must
 keep degrading honestly, the shipped image must not.
 
-**The version seam, and the two hostile shapes that are NOT run (#1952).**
-The upgrade probe boots the previous release on a fresh volume, writes
-state through it, stops it and starts the candidate on that same volume —
-previous → candidate only, since a downgrade is a different question with
-a different answer. How many migrations must run is DERIVED from the two
-images (the previous booted on an empty volume, so what is applied there
-is exactly its own set) rather than naming a migration that would go
-stale. Refused, and each for a measured reason rather than a preference:
+**The version seam (#1952).** The upgrade probe boots the previous
+release on a fresh volume, writes state through it, stops it and starts
+the candidate on that same volume — previous → candidate only, since a
+downgrade is a different question with a different answer. How many
+migrations must run is DERIVED from the two images (the previous booted
+on an empty volume, so what is applied there is exactly its own set)
+rather than naming a migration that would go stale.
 
-* **a volume over `/app`** removes the release itself, so asserting that
-  it answers 200 would assert a falsehood;
-* **an arbitrary uid (`--user 65534`)** cannot be set up. Docker re-seeds
-  an EMPTY named volume from the image on every mount, ownership
-  included, so `chown -R 65534 /data` in a helper container reads back as
-  `65534` inside it and as the image's `100:101` in the next one. The
-  property it would test is what the read-only shape asserts directly.
+**All FOUR hostile shapes now run (#1952b).** Each gets a first boot of
+its own on a fresh volume, and each carries a `docker inspect` ARM CHECK
+that must come back `true` — without it, a flag docker silently stopped
+honouring turns the shape into an ordinary boot reporting green. Two of
+them arrived later than the others and are worth reading before touching
+either:
+
+* **an arbitrary uid (`--user 65534`)** was first refused as
+  unconstructible, on a mechanism that is real and an inference that is
+  not. Docker re-seeds an EMPTY named volume's ownership from the image
+  on every mount — but only while it is empty, so one zero-byte file
+  inside makes a `chown -R` stick. `hostile_boot` therefore takes the
+  `uid:gid` its `/data` must be handed to as a required argument.
+  Measured, the same fixture on the two releases: v1.5.1 `/healthz` in
+  2s, v1.5.0 `exited/1` on `(File.Error) could not make directory (with
+  -p) "runtime/peer_avatars"` — #1945 verbatim, and note the RELATIVE
+  path. Control: v1.5.0 with the baked user on an ordinary volume boots
+  healthy, so the red is the uid and not the release.
+* **a volume over `/app`** boots, and that is not the same sentence for
+  both readings of it. An empty BIND mount leaves no release to run and
+  the container cannot even be created (`created/127`); a NAMED volume
+  is seeded from the image at first mount and comes up. Boot alone does
+  not discriminate — both releases answer `/healthz` — so this shape
+  also compares the release root after the boot against the one the
+  image ships (`ls -1A`, hidden entries included, with a non-empty
+  guard and a planted-`runtime/` canary). It must: `docker diff`, the
+  oracle for "the boot wrote nothing outside `/data`", never reports
+  what is under a mount and answers **zero lines** for v1.5.0 on this
+  substrate, while the volume grows `runtime`.
+  ⚠️ **A green here does NOT mean the shape is supported.** The copy-up
+  happens once, while the volume is empty; recreate the container on a
+  newer image and it still boots the OLD release — measured, `:v1.5.1`
+  on a v1.5.0-seeded volume reports the new tag to `docker inspect` and
+  `1.5.0` to `/api/config`. That is why the driver destroys that volume
+  before the run AND in the teardown.
+
+`test/infra/release_hostile_matrix_test.bats` is the PR-time half —
+nothing in the `smoke` job runs on a pull request, so a shape deleted or
+left unarmed would surface only on a release. It folds the driver's line
+continuations and EVALUATES each `hostile_boot` call with the function
+replaced by a recorder, so it reads the real argument lists rather than
+grepping for them.
 
 **The read-only recipe is `--read-only --tmpfs /tmp`, and nothing more.**
 Naked, the boot dies on `mktemp: : Read-only file system` before it

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -60,20 +60,13 @@
 #   * ONE direction only: previous -> candidate. A downgrade is a different
 #     question with a different answer (a migration that ran is not undone by
 #     booting the older image) and is not smuggled in here (#1952).
-#   * no volume mounted OVER /app. The release IS /app, so hiding it removes
-#     the thing under test, and a probe asserting that shape answers 200 would
-#     be asserting a falsehood.
-#   * no arbitrary-uid shape (`--user 65534`), and this one is a MEASUREMENT
-#     rather than a judgement: the setup cannot be made to hold. Docker
-#     re-seeds an EMPTY named volume from the image on every mount, ownership
-#     included, so `chown -R 65534 /data` in a helper container reads back as
-#     65534 inside that container and as the image's 100:101 in the next one.
-#     Only a pre-populated volume survives it, which is a fixture built to
-#     dodge a docker behaviour rather than a substrate anybody runs — and the
-#     property it would test (nothing outside /data need be writable) is what
-#     the read-only shape asserts directly.
-#     Both are named here because they are the two hostile shapes #1952 lists
-#     that this driver deliberately does not run.
+#   * an EMPTY BIND MOUNT over /app is not a shape and cannot be one: docker
+#     never copies the image's content into a bind mount, so the release is
+#     simply gone. Measured — the container does not fail to boot, it fails to
+#     be CREATED: `stat /app/release-entrypoint.sh: no such file or directory`,
+#     status `created/127`. The named-volume reading of the same words IS
+#     covered, as shape 3 below; the two are different substrates wearing one
+#     sentence, and only one of them has an application in it to test.
 
 set -euo pipefail
 
@@ -109,6 +102,17 @@ UP_VOLUME=grappa-smoke-upgrade-data
 # name keeps the teardown list finite.
 HOSTILE=grappa-smoke-hostile
 HOSTILE_VOLUME=grappa-smoke-hostile-data
+# Shape 3's SECOND volume, the one mounted over the release root itself.
+#
+# ⚠️ THIS ONE MUST NEVER SURVIVE A RUN, and it is the only volume here whose
+# leak is worse than untidy. Docker seeds a named volume from the image ONCE,
+# while it is empty; a leftover /app volume is not empty, so the next run's
+# container mounts LAST RUN'S RELEASE over the candidate's and boots it.
+# Measured: a container started from `:v1.5.1` on a volume seeded by v1.5.0
+# reports `.Config.Image = …:v1.5.1` to `docker inspect` and version `1.5.0` to
+# /api/config. The whole smoke would then probe an image nobody built, and say
+# nothing about it — so it is removed before the run AND in the teardown.
+HOSTILE_APP_VOLUME=grappa-smoke-hostile-app
 
 # The account created under the PREVIOUS release, read back after the upgrade
 # through the same operator door — see probe 6.
@@ -140,7 +144,7 @@ teardown() {
         done
     fi
     docker rm -f "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE" >/dev/null 2>&1 || true
-    docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+    docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" "$HOSTILE_APP_VOLUME" >/dev/null 2>&1 || true
     rm -rf "$SMOKE_HOME"
     exit "$status"
 }
@@ -149,14 +153,16 @@ trap teardown EXIT
 # A crashed earlier run leaves the box behind, and `install` refuses to run
 # onto an existing container. Clear the dedicated names before, not just after.
 docker rm -f "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE" >/dev/null 2>&1 || true
-docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" "$HOSTILE_APP_VOLUME" >/dev/null 2>&1 || true
 
 # wait_healthz CONTAINER WHAT — poll /healthz from INSIDE, so this works for
 # the bare container too (no published port). WHAT names the shape being
-# waited on, not the container: since #1952 the same driver waits on six
-# boots, and "grappa-smoke-hostile never answered" would not say WHICH hostile
-# substrate it was. Both arguments are required — a defaulted label is a
-# failure message that degrades exactly when it is needed.
+# waited on, not the container: since #1952 the same driver waits on the boots
+# of several different shapes, and "grappa-smoke-hostile never answered" would
+# not say WHICH hostile substrate it was. Both arguments are required — a
+# defaulted label is a failure message that degrades exactly when it is needed.
+# The count is deliberately not spelled here: it went from two to four in one
+# follow-up, and a number in a comment is a thing to forget.
 wait_healthz() {
     deadline=$((SECONDS + 300))
     until docker exec "$1" curl -fsS -o /dev/null http://localhost:4000/healthz 2>/dev/null; do
@@ -544,10 +550,24 @@ pass "the boot left the container layer empty, and a planted /app/runtime is sti
 # asked exactly one question: does it answer /healthz. The failures they are
 # hunting are the same one wearing different clothes — a path resolved against
 # something the operator, not the application, chose.
-say "probe 8: the candidate boots where the cwd is hostile"
+say "probe 8: the candidate boots on hostile substrates"
 
-# hostile_boot SHAPE ARM-CHECK EXTRA-FLAG... — one shape, from a fresh volume,
-# asked one question.
+# The uid:gid the IMAGE gives /data, READ OUT OF THE IMAGE rather than spelled.
+# Every shape but the arbitrary-uid one runs as the baked user, so this is the
+# ownership their storage must carry — and writing `100:101` here would be a
+# second copy of a Dockerfile fact, silently wrong the day `adduser -S` picks
+# another number.
+IMAGE_DATA_OWNER="$(docker run --rm --entrypoint sh "$GRAPPA_IMAGE" -c 'stat -c "%u:%g" /data')"
+[ -n "$IMAGE_DATA_OWNER" ] \
+    || die "could not read /data's owner out of $GRAPPA_IMAGE — every shape below would then hand its volume to nobody in particular"
+
+# The arbitrary uid shape 4 runs as. 65534 is `nobody` on every distro and the
+# number Kubernetes' own `runAsUser:` examples use, but the POINT is that it is
+# not the image's: see the guard on that below.
+HOSTILE_UID=65534
+
+# hostile_boot SHAPE ARM-CHECK DATA-OWNER EXTRA-FLAG... — one shape, from a
+# fresh volume, asked one question.
 #
 # ARM-CHECK is a `docker inspect` format string that must come back `true`:
 # the proof that the hostile condition is actually IN FORCE. Without it a flag
@@ -556,12 +576,37 @@ say "probe 8: the candidate boots where the cwd is hostile"
 # probe 7's canary exists to refuse, and the reason each shape carries its own
 # rather than one shared assertion.
 #
+# DATA-OWNER is the `uid:gid` the /data volume is handed to before the boot,
+# and it is REQUIRED of every shape rather than defaulted, because it is the
+# storage contract that shape's operator has to satisfy — stating it is half of
+# what the shape means. Three of the four pass the image's own owner, which
+# makes the chown a no-op and keeps ONE code path with no branch in it.
+#
+# WHY A MARKER FILE RIDES WITH THE CHOWN, and it is a measurement about docker
+# rather than a trick: docker re-seeds an EMPTY named volume from the image on
+# every mount, ownership included. Measured — create a volume, `chown 65534`
+# it from a helper, and the NEXT container reads the image's owner back. One
+# file inside is enough to make the volume non-empty, and then the ownership
+# sticks. The negative control is the shape without it: a virgin volume under
+# `--user 65534` dies with `mkdir: can't create directory '/data/uploads':
+# Permission denied`. The file is zero bytes, is not grappa state, and is what
+# a real arbitrary-uid deployment provides for itself — a Kubernetes `fsGroup`,
+# or an operator's `chown` on the host path.
+#
 # Each shape gets a FIRST boot of its own: one that only works because the
 # previous shape already created the state is not the shape an operator meets.
 hostile_boot() {
-    local shape="$1" arm_check="$2"; shift 2
+    local shape="$1" arm_check="$2" data_owner="$3"; shift 3
     docker rm -f "$HOSTILE" >/dev/null 2>&1 || true
     docker volume rm "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+
+    # `--user 0:0` because chown is root's; `--entrypoint sh` because nothing
+    # must boot here. The owner arrives as an ARGUMENT, never interpolated into
+    # the `-c` string.
+    docker run --rm --user 0:0 -v "${HOSTILE_VOLUME}:/data" --entrypoint sh \
+        "$GRAPPA_IMAGE" -c 'touch /data/.hostile-fixture && chown -R "$1" /data' \
+        sh "$data_owner" >/dev/null \
+        || die "the '$shape' substrate: could not hand /data to $data_owner, so the boot below would be testing the wrong storage"
 
     docker run -d --name "$HOSTILE" -e PHX_HOST=localhost \
         -v "${HOSTILE_VOLUME}:/data" "$@" "$GRAPPA_IMAGE" >/dev/null \
@@ -588,7 +633,7 @@ hostile_boot() {
 # bootstrap; `--read-only --tmpfs /tmp` boots. `/app/tmp` is NOT in the recipe
 # because the release never writes there — which is the same fact probe 7
 # measures from the other side, an empty container layer.
-hostile_boot 'read-only rootfs' '{{.HostConfig.ReadonlyRootfs}}' \
+hostile_boot 'read-only rootfs' '{{.HostConfig.ReadonlyRootfs}}' "$IMAGE_DATA_OWNER" \
     --read-only --tmpfs /tmp:rw,mode=1777
 
 # ── shape 2: a working directory the process did not choose ─────────────────
@@ -609,7 +654,112 @@ hostile_boot 'read-only rootfs' '{{.HostConfig.ReadonlyRootfs}}' \
 # The arm check is `.Config.WorkingDir` and not a `docker exec pwd`: the
 # interesting failures here EXIT, and a shape that has to be alive to prove it
 # was applied cannot report on the boot that died.
-hostile_boot 'cwd the process did not choose (/)' '{{eq .Config.WorkingDir "/"}}' \
+hostile_boot 'cwd the process did not choose (/)' '{{eq .Config.WorkingDir "/"}}' "$IMAGE_DATA_OWNER" \
     --workdir /
+
+# ── shape 3: a volume mounted OVER the release root ─────────────────────────
+#
+# The release lives at /app, and this shape mounts a named volume there. It is
+# not a hypothetical: it is what a Kubernetes PVC pointed one path to the left
+# does, and what a compose file that "persists the app" does.
+#
+# THE SHAPE IS CONSTRUCTIBLE AND IT BOOTS, and that took measuring rather than
+# reasoning, because the obvious reading — mounting over /app hides the release,
+# so there is nothing left to test — is TRUE OF A BIND MOUNT AND FALSE OF A
+# NAMED VOLUME. Docker copies the image's content into an empty named volume at
+# first mount (the release, its permissions, the setgid bit on /app), so the
+# container comes up; an empty bind mount gets no copy and cannot even be
+# created. The non-coverage list at the top of this file carries that second
+# reading, since only one of the two has an application in it.
+#
+# 🔴 A GREEN HERE DOES NOT MEAN THE SHAPE IS SUPPORTED, and the difference is
+# measured: the copy-up happens ONCE, while the volume is empty. Pull a new
+# image, recreate the container, and the volume still holds the OLD release —
+# `docker inspect` reports the new tag and /api/config reports the old version.
+# This probe boots on a volume it created seconds earlier, which is the only
+# state in which the shape is honest.
+#
+# WHAT IT ASSERTS BEYOND /healthz, and why it must: `docker diff` — probe 7's
+# oracle for "the boot wrote nothing outside /data" — is blind by construction
+# under a mount, and reports ZERO LINES for this container even when the boot
+# wrote into the release root. Measured on v1.5.0, whose #1945 defect creates
+# `runtime/peer_avatars` relative to the cwd: `docker diff` says nothing, and
+# the VOLUME grows an eighth entry. So the same property is read through the
+# window this shape leaves open — the release root after the boot must be
+# exactly the release root the image ships.
+hostile_boot 'a volume mounted over the release root (/app)' \
+    '{{range .Mounts}}{{if eq .Destination "/app"}}true{{end}}{{end}}' \
+    "$IMAGE_DATA_OWNER" \
+    -v "${HOSTILE_APP_VOLUME}:/app"
+
+# The container is gone; the /app volume it booted from is not, which is what
+# makes this readable at all. `ls -1A` on both sides: hidden entries count,
+# since a boot is as free to write `/app/.state` as `/app/runtime`.
+app_shipped="$SMOKE_HOME/app-root-shipped.list"
+app_after="$SMOKE_HOME/app-root-after-boot.list"
+docker run --rm --entrypoint sh "$GRAPPA_IMAGE" -c 'ls -1A /app | sort' > "$app_shipped" \
+    || die "could not list the release root the image ships"
+docker run --rm -v "${HOSTILE_APP_VOLUME}:/mnt/app" --entrypoint sh "$GRAPPA_IMAGE" \
+    -c 'ls -1A /mnt/app | sort' > "$app_after" \
+    || die "could not list the release root the '/app volume' boot left behind"
+
+# The anti-hollow-green guard, before the comparison rather than after: two
+# empty listings compare EQUAL, and that is exactly what a mount that silently
+# resolved nowhere would produce.
+[ -s "$app_shipped" ] \
+    || die "the image ships an EMPTY /app — the listing is blind and the comparison below cannot fail"
+
+if ! cmp -s "$app_shipped" "$app_after"; then
+    printf '\n----- release root: shipped vs after the boot -----\n' >&2
+    diff "$app_shipped" "$app_after" >&2 || true
+    die "the boot wrote into the RELEASE ROOT, which on this substrate is a mounted volume and therefore invisible to probe 7's docker diff. On v1.5.0 the extra entry was 'runtime', #1945 exactly."
+fi
+
+# POSITIVE control, and the only thing between the reading above and a hollow
+# green: the same two listings, with #1945's own path planted in the volume.
+# `--user 0:0` because the volume root belongs to the image's user, and this
+# helper is writing into it from outside.
+docker run --rm --user 0:0 -v "${HOSTILE_APP_VOLUME}:/mnt/app" --entrypoint sh \
+    "$GRAPPA_IMAGE" -c 'mkdir -p /mnt/app/runtime/peer_avatars' >/dev/null \
+    || die "could not plant the release-root canary — shape 3's own control cannot run"
+app_canary="$SMOKE_HOME/app-root-canary.list"
+docker run --rm -v "${HOSTILE_APP_VOLUME}:/mnt/app" --entrypoint sh "$GRAPPA_IMAGE" \
+    -c 'ls -1A /mnt/app | sort' > "$app_canary" \
+    || die "could not re-list the release root after planting the canary"
+if cmp -s "$app_shipped" "$app_canary"; then
+    die "a directory planted in the /app volume does not show up in the listing — the comparison is BLIND, and the equality above proved nothing"
+fi
+pass "the '/app volume' boot left the release root exactly as the image ships it, and a planted runtime/ is still seen"
+docker volume rm "$HOSTILE_APP_VOLUME" >/dev/null 2>&1 || true
+
+# ── shape 4: an arbitrary non-root uid ──────────────────────────────────────
+#
+# `--user 65534` — a Kubernetes `runAsUser:`, a hardened compose `user:`, an
+# OpenShift project that assigns a uid nobody chose. The image bakes its own
+# `grappa` user and every other probe here runs as it, so this is the one shape
+# that asks whether anything depends on being THAT user rather than merely
+# being a user with writable storage.
+#
+# MEASURED, and it is the strongest red in this file because it is #1945
+# verbatim rather than a cousin of it. Identical fixture, identical flags, the
+# two releases apart:
+#
+#   v1.5.1   running/0, /healthz in 2s
+#   v1.5.0   exited/1
+#            ** (File.Error) could not make directory (with -p)
+#               "runtime/peer_avatars": permission denied
+#                   (grappa 1.5.0) lib/grappa/avatars/reaper.ex:79
+#
+# Note the path in that error is RELATIVE. /app is writable by the baked user
+# and by nobody else, which is why the same defect is silent on every other
+# docker shape and fatal here. The control that makes the pair mean something:
+# v1.5.0 on this SAME image with the baked user and an ordinary volume boots
+# healthy, so the red belongs to the uid and not to the release.
+[ "${HOSTILE_UID}:${HOSTILE_UID}" != "$IMAGE_DATA_OWNER" ] \
+    || die "the image's own /data owner IS ${HOSTILE_UID}:${HOSTILE_UID} — this shape would be an ordinary boot wearing a --user flag, and would assert nothing"
+hostile_boot "an arbitrary non-root uid (--user ${HOSTILE_UID})" \
+    "{{eq .Config.User \"${HOSTILE_UID}:${HOSTILE_UID}\"}}" \
+    "${HOSTILE_UID}:${HOSTILE_UID}" \
+    --user "${HOSTILE_UID}:${HOSTILE_UID}"
 
 say "release image $GRAPPA_IMAGE deployed and answered every probe 🎉"

--- a/test/infra/release_hostile_matrix_test.bats
+++ b/test/infra/release_hostile_matrix_test.bats
@@ -1,0 +1,287 @@
+#!/usr/bin/env bats
+#
+# #1952 — the release smoke's HOSTILE-SUBSTRATE MATRIX, the second half of the
+# issue's ask ("this is the class gate").
+#
+# THE SAME COVERAGE PROBLEM `release_upgrade_probe_test.bats` opens with, and
+# it is why this file exists at all: probe 8 lives inside `release.yml`'s
+# `smoke` job, which fires only on `push: tags: v*` and on `workflow_dispatch`.
+# No pull request ever boots a container in that matrix. So a shape that is
+# deleted, renamed into nothing, or left unarmed goes unnoticed until a release
+# — and a matrix that has quietly lost half its shapes reports the same green
+# as one that has all of them.
+#
+# What these cases CAN claim: that the four shapes #1952 names are wired, that
+# each one is ARMED (carries the `docker inspect` check proving the hostile
+# condition is actually in force), that each declares the storage ownership its
+# operator has to provide, that the shape which blinds probe 7's `docker diff`
+# brings its own oracle AND its own canary, and that the volume whose leak
+# would make the NEXT run boot stale code is cleaned on both ends.
+#
+# What they CANNOT claim, and it is deliberate: that any of it BOOTS. Four
+# container boots against two published images is the smoke job's work on a
+# real tag. The seam is the one `release_image_credits_test.bats` draws between
+# reading the recipe and reading the artifact.
+#
+# HOW THE ARGUMENT CASES WORK, because grep would not have been enough here.
+# The driver's `hostile_boot` calls are folded onto one line each and then
+# EVALUATED with `hostile_boot` redefined as a recorder. That runs the real
+# argument lists through the real quoting, so a shape whose owner argument is
+# missing shows up as a flag sitting in `$3` — which is exactly the mistake a
+# `grep -q hostile_boot` cannot see.
+
+load ../bats_helpers
+
+setup() {
+    REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SMOKE="$REPO_SRC/scripts/smoke-release-image.sh"
+}
+
+# The driver with backslash-continuations folded away: one logical line per
+# statement, quoting untouched. Every case below reads this rather than the
+# raw file, because three of the four shapes span several physical lines and a
+# line-oriented grep sees only their first.
+folded() {
+    sed -e :a -e '/\\$/N; s/\\\n[[:space:]]*/ /; ta' "$SMOKE"
+}
+
+# The `hostile_boot` INVOCATIONS — column zero, followed by a quote. The
+# function's own definition line (`hostile_boot() {`) has a parenthesis there
+# instead, so it does not match.
+shape_calls() {
+    folded | grep -E "^hostile_boot ['\"]"
+}
+
+# Evaluate every invocation with `hostile_boot` replaced by a recorder that
+# prints the field named by $1 for each call. The driver's own two variables
+# are supplied with stand-in values: the cases assert the SHAPE of what is
+# passed, never the value the release run would compute.
+each_call_field() {
+    local field="$1"
+    local IMAGE_DATA_OWNER=100:101
+    local HOSTILE_UID=65534
+    local HOSTILE_APP_VOLUME=grappa-smoke-hostile-app
+    # shellcheck disable=SC2317  # called via eval below
+    hostile_boot() {
+        case "$field" in
+            shape) printf '%s\n' "$1" ;;
+            arm)   printf '%s\n' "$2" ;;
+            owner) printf '%s\n' "$3" ;;
+            flags) shift 3; printf '%s\n' "$*" ;;
+        esac
+    }
+    local line
+    while IFS= read -r line; do
+        eval "$line"
+    done < <(shape_calls)
+}
+
+@test "#1952 — the extractor really reads the driver's shape calls" {
+    # The positive control every case below leans on. An extractor that came
+    # back empty would make each of them vacuously true, and this file would
+    # report green over a matrix with no shapes left in it at all.
+    run shape_calls
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+
+    # Folding is what makes the multi-line shapes visible. Unfolded, the `-v`
+    # of the /app shape sits on a physical line of its own and no call line
+    # carries it.
+    grep -Fq 'HOSTILE_APP_VOLUME' <<<"$output" || {
+        printf 'the continuation folding is not working — a shape call spanning\n' >&2
+        printf 'several lines came out truncated, so every assertion here is blind.\n' >&2
+        printf '%s\n' "$output" >&2
+        return 1
+    }
+}
+
+@test "#1952 — all FOUR hostile shapes the issue lists are wired" {
+    # By FLAG, not by prose: the label of a shape is free to be reworded, the
+    # flag that makes it that shape is not. One call each.
+    local calls; calls="$(shape_calls)"
+
+    grep -Fq -- '--read-only' <<<"$calls" || { printf 'no read-only rootfs shape.\n' >&2; return 1; }
+    grep -Fq -- '--workdir /' <<<"$calls" || { printf 'no hostile-cwd shape.\n' >&2; return 1; }
+    grep -Fq -- '${HOSTILE_APP_VOLUME}:/app' <<<"$calls" || {
+        printf 'nothing mounts a volume over the release root — the shape that\n' >&2
+        printf 'blinds probe 7 is gone, and with it the only reader of that\n' >&2
+        printf 'property on this substrate.\n' >&2
+        return 1
+    }
+    grep -Eq -- '--user "\$\{HOSTILE_UID\}' <<<"$calls" || {
+        printf 'no arbitrary-uid shape. That is the one that reproduces #1945\n' >&2
+        printf 'verbatim (File.Error on the RELATIVE "runtime/peer_avatars").\n' >&2
+        return 1
+    }
+
+    # And exactly four, so a fifth arriving without a case here is a red rather
+    # than a silent addition to a matrix nobody re-reads.
+    [ "$(wc -l <<<"$calls" | tr -d ' ')" -eq 4 ]
+}
+
+@test "#1952 — every shape is ARMED: none of them boots without a docker-inspect check" {
+    # An unarmed shape is an ordinary boot wearing a flag. It reports the same
+    # green whether docker honoured the flag or dropped it.
+    run each_call_field arm
+    [ "$status" -eq 0 ]
+    [ "$(wc -l <<<"$output" | tr -d ' ')" -eq 4 ]
+
+    local arm
+    while IFS= read -r arm; do
+        [[ "$arm" == *'{{'*'}}'* ]] || {
+            printf 'a shape passes something that is not a docker inspect template\n' >&2
+            printf 'as its arm check: %s\n' "$arm" >&2
+            return 1
+        }
+    done <<<"$output"
+}
+
+@test "#1952 — every shape declares the ownership its storage must carry" {
+    # The argument that would be silently wrong if a new shape copied an older
+    # call and dropped a field: `hostile_boot` shifts THREE, so a missing owner
+    # puts a flag in its place and the fixture chowns /data to `--read-only`.
+    run each_call_field owner
+    [ "$status" -eq 0 ]
+    [ "$(wc -l <<<"$output" | tr -d ' ')" -eq 4 ]
+
+    local owner
+    while IFS= read -r owner; do
+        [[ "$owner" =~ ^[0-9]+:[0-9]+$ ]] || {
+            printf 'a shape passes %s where the /data owner belongs — a shape that\n' "$owner" >&2
+            printf 'forgot the argument shows up here as one of its flags.\n' >&2
+            return 1
+        }
+    done <<<"$output"
+
+    # NEGATIVE CONTROL: the same recorder over a call that DID forget the
+    # owner. Without it, a check that accepted everything would read as a pass.
+    local IMAGE_DATA_OWNER=100:101
+    # shellcheck disable=SC2317  # called via eval below
+    hostile_boot() { printf '%s\n' "$3"; }
+    local got; got="$(eval "hostile_boot 'forgot' '{{.X}}' --read-only --tmpfs /tmp")"
+    refute test "$(printf '%s' "$got")" = "$(printf '%s' "$IMAGE_DATA_OWNER")"
+    [[ "$got" =~ ^[0-9]+:[0-9]+$ ]] && {
+        printf 'the owner check cannot fail: a call with no owner yielded %s\n' "$got" >&2
+        return 1
+    }
+    [ "$got" = '--read-only' ]
+}
+
+@test "#1952 — every shape still carries flags after its three fixed arguments" {
+    # A shape with nothing after the owner is not a substrate, it is the
+    # ordinary boot probes 1-7 already run.
+    run each_call_field flags
+    [ "$status" -eq 0 ]
+
+    local flags
+    while IFS= read -r flags; do
+        [ -n "$flags" ] || {
+            printf 'a shape passes no docker flags at all — it boots the image the\n' >&2
+            printf 'way every other probe does and asserts nothing new.\n' >&2
+            return 1
+        }
+    done <<<"$output"
+}
+
+@test "#1952 — the /app volume is destroyed on BOTH ends, or the next run boots stale code" {
+    # The one leak here that is worse than untidy. Docker seeds a named volume
+    # from the image only while it is EMPTY, so a leftover /app volume makes
+    # the next run mount the previous release over the candidate — measured, a
+    # container started from :v1.5.1 on a v1.5.0-seeded volume reports the new
+    # tag to `docker inspect` and the OLD version to /api/config.
+    local cleanups
+    cleanups="$(grep -cE '^\s*docker volume rm .*HOSTILE_APP_VOLUME' "$SMOKE" || true)"
+    [ "$cleanups" -ge 2 ] || {
+        printf 'the /app volume is removed %s time(s); it must be cleared BEFORE the\n' "$cleanups" >&2
+        printf 'run (a crashed earlier run leaves it behind) and in the teardown.\n' >&2
+        grep -n 'HOSTILE_APP_VOLUME' "$SMOKE" >&2 || true
+        return 1
+    }
+
+    # And one of them is in the teardown, which is the arm that runs when a
+    # probe FAILS — precisely the run after which a leftover volume is waiting.
+    local teardown
+    teardown="$(awk '/^teardown\(\) \{/ { inside = 1 } inside { print } inside && /^\}/ { exit }' "$SMOKE")"
+    grep -Fq 'docker rm -f' <<<"$teardown" || {
+        printf 'the teardown slice came out empty or wrong — this case reads nothing.\n' >&2
+        return 1
+    }
+    grep -Fq 'HOSTILE_APP_VOLUME' <<<"$teardown" || {
+        printf 'the teardown does not remove the /app volume. A failing run would\n' >&2
+        printf 'leave it behind, and the next run would boot whatever release it\n' >&2
+        printf 'still holds while reporting the tag it was asked for.\n' >&2
+        return 1
+    }
+}
+
+@test "#1952 — the shape that blinds docker diff brings its own oracle AND its own canary" {
+    # `docker diff` reports the container's read-write layer and never what is
+    # under a mount, so on the /app-volume shape it answers zero lines even
+    # when the boot wrote into the release root (measured on v1.5.0, whose
+    # #1945 defect creates runtime/peer_avatars there). The property is read
+    # instead by comparing the release root against the one the image ships.
+    grep -Fq 'ls -1A /app | sort' "$SMOKE" || {
+        printf 'nothing lists the release root the IMAGE ships, so there is no\n' >&2
+        printf 'baseline to compare the post-boot volume against.\n' >&2
+        return 1
+    }
+
+    # TWO comparisons, in opposite directions, and both are required: the
+    # verdict fails when the listings DIFFER, the canary fails when they
+    # AGREE after a directory has been planted. A verdict with no canary is
+    # the hollow green — an oracle that cannot see anything reports equality
+    # forever.
+    grep -Fq 'if ! cmp -s "$app_shipped" "$app_after"' "$SMOKE" || {
+        printf 'the release-root verdict is missing or spelled differently — the\n' >&2
+        printf '/app-volume shape then asserts nothing but /healthz.\n' >&2
+        return 1
+    }
+    grep -Fq 'if cmp -s "$app_shipped" "$app_canary"' "$SMOKE" || {
+        printf 'the release-root comparison has no CANARY. An empty or blind\n' >&2
+        printf 'listing compares equal to itself, which is the same reading a\n' >&2
+        printf 'clean boot produces.\n' >&2
+        return 1
+    }
+    grep -Fq 'mkdir -p /mnt/app/runtime' "$SMOKE" || {
+        printf 'the canary does not plant #1945\x27s own path into the volume.\n' >&2
+        return 1
+    }
+}
+
+@test "#1952 — the arbitrary uid is read as arbitrary, and /data's owner is read from the IMAGE" {
+    # The shape asserts nothing the moment its uid IS the image's own, so the
+    # driver refuses that state rather than reporting a green boot.
+    grep -Fq '[ "${HOSTILE_UID}:${HOSTILE_UID}" != "$IMAGE_DATA_OWNER" ]' "$SMOKE" || {
+        printf 'nothing stops the arbitrary uid from being the image\x27s baked one.\n' >&2
+        printf 'A Dockerfile that moved the user to 65534 would turn the shape into\n' >&2
+        printf 'an ordinary boot wearing a --user flag, still green.\n' >&2
+        return 1
+    }
+
+    # And the owner the other three shapes hand their volume to is READ from
+    # the image, never spelled: a literal in CODE is a second copy of a
+    # Dockerfile fact, wrong the day `adduser -S` picks another number.
+    grep -Fq "stat -c \"%u:%g\" /data" "$SMOKE" || {
+        printf 'IMAGE_DATA_OWNER is not read out of the image.\n' >&2
+        return 1
+    }
+
+    # COMMENTS ARE EXEMPT, deliberately: today's value is a MEASUREMENT and
+    # writing it down is what makes the comment worth reading — the driver
+    # says `100:101` exactly once, in the sentence explaining why it must not
+    # appear anywhere else. Stripping whole-line comments is what separates
+    # the two, and the case failed on precisely this before it did.
+    #
+    # The subject is the fixture's own `chown`, not the whole file: a blanket
+    # `[0-9]+:[0-9]+` over the driver would match the default publish address
+    # `127.0.0.1:14000` and report a violation that is not one.
+    local chown_lines
+    chown_lines="$(grep -v '^[[:space:]]*#' "$SMOKE" | grep -F 'chown' || true)"
+    [ -n "$chown_lines" ] || {
+        printf 'the driver has no chown left in it — the shapes no longer hand\n' >&2
+        printf 'their /data volume to anybody, and the arbitrary-uid boot would\n' >&2
+        printf 'die on a volume docker re-seeded to the image owner.\n' >&2
+        return 1
+    }
+    refute grep -Eq '[0-9]+:[0-9]+' <<<"$chown_lines"
+}


### PR DESCRIPTION
Issue 1952 asks for an upgrade probe **and** a hostile-substrate matrix of
FOUR shapes, and calls the second half "the class gate". The first pass
shipped two shapes and wrote the other two into the driver's non-coverage
list. Two quarters are not a class gate, so here are the other two.

## The two refusals, and why both were wrong

**An arbitrary uid** was refused as unconstructible. The mechanism cited is
real and re-measured here — docker re-seeds an EMPTY named volume's
ownership from the image on every mount, so a helper's `chown -R 65534
/data` reads back as the image's owner. The conclusion does not follow: the
re-seed applies only *while the volume is empty*.

| fixture | what the next container reads |
| --- | --- |
| empty volume, `chown 65534` from a helper | `100:101` — re-seeded |
| one zero-byte file inside, `chown -R 65534` | `65534:65534`, and writable |
| control: virgin volume, uid 65534 writes | `permission denied` |

"I could not build it" and "it cannot be built" are different claims, and
only the first was ever in evidence.

**A volume over `/app`** was refused because mounting over the release root
removes the release. That is true of a BIND mount and false of a NAMED
volume, and the issue's words name the second. Both readings are now
measured; only one has an application left in it to test.

## What the shapes found

`--user 65534` reproduces **1945 verbatim**, not a cousin of it. Same
fixture, same flags, the two releases apart:

```
v1.5.1   running/0, /healthz in 2s
v1.5.0   exited/1
         ** (File.Error) could not make directory (with -p)
            "runtime/peer_avatars": permission denied
                (grappa 1.5.0) lib/grappa/avatars/reaper.ex:79
```

The path is RELATIVE. `/app` is writable by the baked user and by nobody
else, which is exactly why the defect is silent on every other docker
shape. Control: v1.5.0 with the baked user on an ordinary volume boots
healthy, so the red belongs to the uid and not to the release.

The `/app` volume shape **boots on both releases**, so `/healthz` alone
does not discriminate. What does is the release root. `docker diff` — the
oracle probe 7 uses for "the boot wrote nothing outside `/data`" — never
reports what is under a mount, and answers **zero lines** for v1.5.0 here
while the volume grows `runtime`. So the shape reads the same property
through the window the mount leaves open: `ls -1A` on the volume after the
boot must equal `ls -1A` on the `/app` the image ships. Measured against a
volume a real v1.5.0 booted on:

```
[ -s shipped ]  -> non-empty (the blindness guard)
cmp             -> DIFFER
diff            -> 7a8 > runtime
```

⚠️ **A green there does not mean the shape is supported.** The copy-up
happens once, while the volume is empty; recreate the container on a newer
image and it still boots the OLD release — `:v1.5.1` on a v1.5.0-seeded
volume reports the new tag to `docker inspect` and `1.5.0` to
`/api/config`. Hence that volume is destroyed before the run AND in the
teardown; leaked, it would make the next smoke probe an image nobody built.

## Shape of the change

`hostile_boot` takes the `uid:gid` its `/data` must be handed to as a
required third argument — no default, because that ownership is half of
what a shape means and a call that forgets it puts a docker flag where the
owner belongs. Three shapes pass the image's own owner, read out of the
image with `stat -c %u:%g /data` rather than spelled; the fourth is guarded
against BEING that owner.

## Evidence

* **the driver, end to end, against a cured v1.5.1** (stock v1.5.1 predates
  the entrypoint cure, so shape 2 is red on it by construction): probes 1–7
  green and all four shapes green, canary included —
  `ok 'a volume mounted over the release root (/app)' is in force and
  answered /healthz` / `ok the '/app volume' boot left the release root
  exactly as the image ships it, and a planted runtime/ is still seen` /
  `ok 'an arbitrary non-root uid (--user 65534)' is in force and answered
  /healthz`.
* **arm checks discriminate**: on a container started without the flags,
  `.Config.User` reads `false` and the `/app`-mount template reads empty —
  neither is the `true` the driver demands.
* **a mutation run that landed elsewhere, and is reported rather than
  buried**: an image with 1945's shape reintroduced (guarded by a `cmp`
  proving the `sed` matched) died at probe 7, not at shape 3. The mutant
  writes on every boot and `docker diff` sees it first. Right behaviour,
  wrong experiment — the isolating evidence is the direct run above.
* **bats**: `scripts/bats.sh` whole suite `rc=0`, **756 ok / 0 not ok**
  (the earlier body said 763; that number was never measured — the full-suite
  run predating the fix to my own case read 755 ok / 1 not ok, and the re-run
  after it is the 756). Every
  one of the eight new cases was mutation-tested against the real driver
  and killed exactly the case meant to catch it; the driver was compared
  byte-for-byte with its backup afterwards.
* `scripts/shellcheck.sh` rc=0 (83 scripts), `scripts/posix-parse.sh` rc=0
  (34), `scripts/design-notes-gate.sh` rc=0 (`1 new entry heading(s),
  separator and marker present`).
* `scripts/union-rebase.sh` rc=0 — **and its comparison is VACUOUS by its
  own report**, since the branch is already on top of `origin/main` and the
  driver never ran. The contribution to cross-check after any rebase and
  after the merge is `docs/DESIGN_NOTES.md +130 -0`.

Not run, and correctly so: `scripts/check.sh` (no Elixir touched),
`scripts/integration.sh` (no e2e or app code touched).
