### PR TITLE
observability(1960): one prefix for one lock, named while it holds

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -135,10 +135,14 @@ config :grappa, :session, connection_stable_ms: 60_000
 #
 #   * enabled — arms both the watchdog timer and the write-path seam. OFF
 #     costs one :persistent_term read per write transaction and nothing more.
-#   * stall_threshold_ms — how long a holder must hold, WITH a queue behind
-#     it, before it is reported. Well under the 30_000 busy_timeout so the
-#     report lands while the stall is happening, not after the victims have
-#     already timed out.
+#   * stall_threshold_ms — how long a holder must hold before it is reported.
+#     🔴 There is no "WITH a queue behind it" any more (issue 1960): the watch
+#     table has one producer, so "no waiter registered" meant "no waiter that
+#     went through `Repo.immediate_transaction/1`" and silenced five of the
+#     nine prod stalls of 2026-09-06. ONE threshold now governs both edges of
+#     an episode and all three verdicts. Well under the 30_000 busy_timeout so
+#     the report lands while the stall is happening, not after the victims
+#     have already timed out.
 #   * tick_ms — watchdog scan cadence.
 config :grappa, :lock_watch,
   enabled: true,
@@ -411,22 +415,27 @@ config :logger, :console,
     # many writers are queued behind it. Without these two keys the backend
     # drops the structured half of a stall report, leaving only the prose —
     # and the log line IS the door that reaches CI container logs.
+    # `:held_ms` is now the CLOSING bracket's alone (issue 1960) — it is the
+    # one edge where a hold is the thing measured.
     :held_ms,
     :waiters,
-    # #1687 — the unattributed arm's own measurement. Deliberately NOT
-    # `:held_ms`: nothing in that report observed a hold, and reusing the key
-    # would smuggle the claim back into the structured half after the prose
-    # was written to leave it out. An operator aggregating `held_ms` must not
-    # find waits mixed into it.
-    :longest_wait_ms,
-    # #1901 — the NIF census's own two, and neither reuses a key above for the
-    # same reason #1687 refused `:held_ms`. `:waiters` counts writers PROVABLY
-    # blocked; a census counted no queue, it photographed a cohort of which
-    # one member is the holder. `:longest_wait_ms` names a WAIT; the longest
-    # parked process may be the writer that was never waiting at all. An
-    # operator aggregating either key must not find census rows mixed in.
+    # 🔴 issue 1960 — the opening line's own two, and the pair replaces
+    # `:longest_wait_ms` + `:longest_parked_ms`. The reason those existed is
+    # the #1687 ruling: nothing in an unattributed report observed a hold, so
+    # reusing `:held_ms` would have smuggled the claim back into the
+    # structured half after the prose was written to leave it out. ONE folded
+    # line cannot solve that with three keys — it solves it with a key that
+    # claims nothing (`:elapsed_ms`) plus the key that says what it measured
+    # (`:attribution`). An operator aggregating `elapsed_ms` MUST filter on
+    # `attribution`, which is exactly the discipline the three keys enforced
+    # by being separate, now stated instead of implied.
+    :attribution,
+    :elapsed_ms,
+    # #1901 — how many processes were inside the SQLite NIF past the
+    # threshold. Still its own key and NOT folded into `:waiters`: that one
+    # counts writers PROVABLY blocked at the seam, while this counts a cohort
+    # of which one member is the holder and none can be singled out.
     :parked,
-    :longest_parked_ms,
     :pid,
     :unexpected,
     # Bootstrap summary: how many credentials we enumerated and how

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47446,3 +47446,169 @@ them to contrast had the second silently eat the first.
 _Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
 release image, so it reaches an operator only through a new image. The m42
 jail runs `mix release` and does not read it; nothing else here leaves CI._
+<!-- entry #1960 -->
+
+---
+
+## 2026-09-07 — #1960: one prefix for one phenomenon, and the holder named WHILE it holds
+
+`Grappa.Repo.LockWatch` printed four literals for one lock — `db lock stall`,
+`… UNATTRIBUTED`, `… NIF CENSUS`, `… RESOLVED` — and picked the arm by
+attributability, so consecutive ticks could describe one episode under two
+different words and an operator had to correlate them by timestamp. Worse, it
+was **silent while the lock was held** on exactly the episodes that hurt.
+
+Measured on prod (jail `grappa-new`, 1.5.0, all rotations of
+`runtime/log/erlang.log*`), 2026-09-06: `2` named-while-holding, `4`
+UNATTRIBUTED, `11` NIF CENSUS, `7` RESOLVED — **two** announcements against
+nine stall episodes, and **five** RESOLVED lines carrying
+`NEVER announced while it held` with holds of 31.0 s, 31.3 s, 31.3 s, 62.7 s
+and 94.1 s. Each already knew its write path
+(`UserSocket.detach_client_source_capture/2` → `Vhosts.record_client_source/2`;
+`Session.Server.init/1` → `apply_effects/2`). The 22:09–22:12 pair is the run
+that starved the pool and preceded the 22:13 shutdown.
+
+### The gate was never a contention test
+
+`report_stalls(_, [])` returned `:ok` for a holder past the threshold whenever
+no WAITER was registered, on the reasoning that a slow uncontended transaction
+is not a stall. That reasoning is sound and the gate does not implement it: the
+watch table has ONE producer (`Repo.immediate_transaction/1`), so "no waiter
+registered" means "no waiter that went through the seam", and this system's
+dominant writer is an autocommit `Repo.insert` — 324 679 `messages insert`
+against thousands for everything the seam covers (#1901's own measurement).
+The gate reads a 0.1 % sample and calls it silence.
+
+🔴 **The decisive argument is that the codebase had already ruled the other
+way and only on one edge.** #1888 made the CLOSING bracket fire on
+`announced or past_threshold?` — no waiter conjunct. So a 31 s uncontended
+hold already printed a RESOLVED line and refused to print an opening one. The
+asymmetry was the defect; ONE threshold policy over both edges is the fix, and
+"remove the short circuit" is #1960's own smallest-change proposal.
+
+What replaces the gate is not "print more", it is the line stating what it
+observed: every report now carries `H holder(s) / W waiter(s) registered at
+the seam, P process(es) parked inside Exqlite.Sqlite3NIF`. An uncontended hold
+prints `0 waiter(s)` instead of printing nothing — the reader SEES the absence
+of contention rather than inferring it from the absence of a line, which is
+the log-honesty rule applied to a fast path that was skipping the work.
+
+### The ladder, and why `none` outranks `cohort`
+
+One event, one prefix, one `attribution` field: `:named` (the seam registered a
+holder past the threshold) > `:none` (registered WRITERS queued past it, holder
+not attributable) > `:cohort` (nothing at the seam, only processes parked
+inside the NIF). The order is claim strength, not preference. A registered
+waiter is a writer we KNOW is blocked and whose own frame separates a lock-wait
+from a pool-wait — measured live while building this: a `:none` subject
+sampled at `DBConnection.Holder.checkout_call/5`, which is the #1687
+decomposition visible in one frame. A NIF resident is a physical observation
+that may equally be a healthy two-millisecond write.
+
+🔴 **Nothing is lost by the ordering, because the ROSTER rides every verdict.**
+Keying the roster on `:cohort` would have made it available exactly when the
+seam knows LEAST, which is backwards. Measured on the real fixture: a `:none`
+line with `parked=1` prints the full roster and the
+`0 holder(s) and 1 waiter(s) of them registered at the BEGIN IMMEDIATE seam`
+clause. This is why `lock_watch_test.exs`'s "a writer the seam DOES know is
+counted as such" moved from the census verdict to `:none` and kept every one
+of its assertions.
+
+🔴 **The honest verb is per-arm and lives in ONE place** (`subject_clause/3`).
+`has held RESERVED` appears on `:named` and nowhere else. A shared template
+with a shared verb is precisely how a fold re-commits the claim
+`terminal_message/3` in `Grappa.Repo.BusyRetry` was twice rewritten to stop
+making, so the template carries the arm's verb rather than a neutral one.
+
+### The census noise was a race, and the sample IS the cure
+
+8 of the 11 census lines reported a longest-parked between 2.0 s and 3.1 s —
+normal write latency at `stall_threshold_ms: 2_000`, not a stall — and their
+rosters named processes that were not in the NIF at all:
+`#PID<0.2456.0> 32024ms :gen_statem.loop_hibernate/3`,
+`#PID<0.3110.0> 2120ms DBConnection.Holder.checkout_call/5`. The sweep matched
+on `current_function` and `sample/2` re-read the process later; between the two
+reads it had left, so the census printed a cohort whose frames contradicted its
+own headline.
+
+`nif_sample/2` now decides from the SAME `Process.info/2` read it builds the
+sample from, so the decision can never disagree with the frame that gets
+printed — a third read would let it. **An entirely-departed cohort produces NO
+line.** That is the noise cure and it is deliberately not a bigger threshold:
+the arm is silent because there is nothing true left to say, which is a
+different fact from being under a threshold, and only one of the two is worth
+an operator's trust.
+
+One level down, `sample/2` folded `:current_stacktrace` into the same read.
+The frame under `at …` and the frames under `stack:` used to come from two
+signals and could describe two different instants — the same race, one layer
+in.
+
+### The output contract of the #1429 census does NOT move
+
+`scripts/log-gap-scan.awk` keeps `lockstall`, `lockstall_unattributed` and
+`lockstall_nif` as SUMMARY fields and re-keys their INPUT onto
+`attribution=named|none|cohort`. The discrimination those three counters exist
+to express — a holder was NAMED, versus a queue measured with nobody to blame,
+versus neither established and a cohort photographed — is exactly what the
+field spells out, so the census keeps counting and nothing downstream of the
+summary line has to learn a new name.
+
+The three `sig()` samples and the three bats pins were replaced with lines
+**captured from real emissions** through the production path, not composed by
+hand: the awk's own doc requires verbatim call-site copies, and a pin that
+merely satisfies the regex is a fiction that passes.
+
+### Verified, not cited: the #1715 Logger cache key is PER MODULE
+
+The cure adds `Logger.warning` call sites inside `Grappa.Repo.LockWatch`, and
+rule #1715 says a module that may log DURING a write-lock wait must buy its
+Logger cache key at boot or the observer becomes the first casualty of the wait
+it observes. That the key is per MODULE and not per CALL SITE was asserted in a
+comment; a guard comment can be factually wrong and the price of being wrong
+here is the whole instrument, so it was measured instead — diffing the entire
+`persistent_term` keyspace around each call, MIX_ENV=test, OTP 28:
+
+| call | new keys |
+|---|---|
+| `A.site_one` | `+1` — `{:logger_config, Probe1960.A}` |
+| `A.site_two` (same module, different call site) | **`+0`** |
+| `A.site_one` again | `+0` |
+| `B.site_one` (different module) | `+1` |
+| `C.prime` — `Logger.debug(fn -> "" end)`, the prime's own call | `+1` |
+| `C.real` — `Logger.warning` AFTER that debug prime | **`+0`** |
+
+So the key is `{logger_config, Module}`, the existing
+`prime_logger_module_cache/0` covers any number of new call sites in this
+module, and — the second row that mattered — the prime's `debug` writes the
+same key a later `warning` would, so it is not purged into a no-op in this
+build. No new priming, and the conclusion now rests on a measurement.
+
+### Known limits, stated so they are not rediscovered as bugs
+
+* **While a named episode is armed the cohort gets no line of its own**, so
+  victims that pile into the NIF after the announcing tick are not enumerated
+  until the closing bracket. That is the price of one report per episode; the
+  alternative is a second line about an episode already announced, which is
+  the correlate-by-timestamp reading this issue removes.
+* **The parked count is threshold-filtered like everything else.** A `:named`
+  line during the first seconds of a stall can read `0 process(es) parked`
+  while victims are already in the NIF but under `stall_threshold_ms`. One
+  threshold policy was the requirement; a second, lower one for the count
+  would be a knob nobody asked for.
+* **A pid that is both a registered waiter and parked in the NIF is sampled
+  twice** on a firing tick, under two different clocks (seam elapsed vs NIF
+  elapsed). Deduplicating would mean lying about one of the two measurements.
+  The per-tick SWEEP — the cost #1767 bounded at 0.7–2 µs per process — is
+  untouched; this is on the emitting path only, behind the threshold.
+* **`lock_stall_row.elapsed_ms` is a hold ONLY on `:resolved` and on
+  `:detected` with `attribution: :named`.** It is a WAIT on `:none` and a time
+  parked in a NIF on `:cohort`. That is the #1687 ruling generalised: never
+  name the column `held_ms`, and make `phase` + `attribution` total so the
+  pair disambiguates it.
+
+### Refused
+
+Touching the threshold, `busy_timeout`, the pool or the `BEGIN IMMEDIATE`
+posture — 1767 and 1888 are open and are vjt's calls. This is the
+OBSERVABILITY face and it does not cure the stall it reports.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -5407,8 +5407,9 @@ The handler folds **three** signal families:
   against the baseline.
 - **the D1 write-path spans** into `send_privmsg` / `persist` / `contention`
   rows.
-- **`[:grappa, :repo, :lock_stall, :detected | :resolved | :unattributed]`**
-  (#1420, #1687) into the bounded `lock stalls` ring — the WRITE-LOCK HOLDER.
+- **`[:grappa, :repo, :lock_stall, :detected | :resolved]`**
+  (#1420, #1687, #1901, issue 1960) into the bounded `lock stalls` ring — the
+  WRITE-LOCK HOLDER.
 
 ### Reading a write-lock stall (#1420)
 
@@ -5419,16 +5420,42 @@ its victims — the 30.1 s `busy_timeout` rows of everybody queued behind it.
 `Grappa.Repo.LockWatch` reads at the `BEGIN IMMEDIATE` seam instead, which
 separates the **holder** from the **waiters**.
 
-A **named** stall is reported only when a holder has held past
-`:lock_watch, :stall_threshold_ms` **with at least one waiter queued behind
-it** — a slow uncontended write is not a stall. It appears twice: a `detected`
-row carrying the holder's sampled **stacktrace** plus the queue, and a
-`resolved` row carrying the total hold.
+🔴 **One prefix, one field — read `attribution=` first (issue 1960).** There
+used to be four log literals (`db lock stall`, `… UNATTRIBUTED`,
+`… NIF CENSUS`, `… RESOLVED`) for one phenomenon, which an operator had to
+correlate by timestamp. There are now two: `db lock stall:` opens an episode
+and `db lock stall RESOLVED:` closes it, and the opening line carries
+`attribution=` saying how far the instrument could go towards naming the
+holder:
 
-An **`unattributed`** row (#1687) is a queue past the threshold that named
-nobody — every autocommit single-statement write takes the same file lock and
-registers no holder here. It carries the WAITERS' stacks and explicit nils
-where a holder would be, and gets no `resolved` bracket: there is no hold to
+| `attribution=` | what the line's SUBJECT is | what it does NOT claim |
+|---|---|---|
+| `named` | the holder the seam registered, past the threshold | — |
+| `none` | the longest WRITER queued at the seam | that anybody held; a wait is pool checkout **plus** `busy_timeout` |
+| `cohort` | the longest process parked inside `Exqlite.Sqlite3NIF` | which of the cohort holds the lock — nothing BEAM-visible separates them |
+
+The word **`has held RESERVED`** appears on `attribution=named` and nowhere
+else. If you are reading it, a hold was measured.
+
+**Every line then carries the same three seam numbers, in the same order** —
+`H holder(s) / W waiter(s) registered at the seam, P process(es) parked inside
+Exqlite.Sqlite3NIF` — and the roster whenever `P > 0`. That is the contention
+evidence, and it is what replaced the old gate.
+
+🔴 **The gate that is gone, and why (issue 1960).** A named stall used to be
+reported only **with at least one waiter queued behind it**. That is not a
+contention test: the watch table has ONE producer, so it means "no waiter that
+went through `Repo.immediate_transaction/1`", and this system's dominant
+writer is an autocommit `Repo.insert`. Measured on 2026-09-06 (jail
+`grappa-new`, 1.5.0): nine stall episodes, **two** announced while holding,
+**five** closed carrying `NEVER announced while it held` — each with the
+holder's pid and write path already in hand. The closing bracket had never
+required a queue (#1888); the opening line was the asymmetry. **So an
+uncontended hold past the threshold now prints a line saying `0 waiter(s)`,
+instead of printing nothing** — the reader sees the absence of contention
+rather than inferring it from the absence of a line.
+
+An `attribution=none` episode gets no `resolved` bracket: there is no hold to
 total.
 
 Two doors, and for an incident they answer different questions:
@@ -5453,7 +5480,12 @@ are deliberately different words for different facts:
 | block | when it is sampled | what it names |
 |-------|--------------------|---------------|
 | `holder at …` | while the holder is still parked | the frame it PAUSED in |
+| `longest waiter at …` | while it is still queued | the frame it is BLOCKED in |
+| `longest parked at …` | while it is inside the NIF | the NIF call it is executing |
 | `write path …` | as the transaction is released | the caller that OPENED it |
+
+The first three are the same block under three labels, chosen by
+`attribution` — a `bin/grappa db-latency` row never calls a waiter a holder.
 
 So a `write path` block answers *who was writing*, never *where it stuck* —
 do not read a release-time frame as a pause site. Every row also carries
@@ -5467,9 +5499,9 @@ a `DBConnection` checkout frame means a pool-topology deadlock; anything else
 is a third answer nobody has predicted yet. That distinction is the whole
 reason the instrument exists — before it, both looked identical from the logs.
 
-### The `nif_census` row (#1901) — the only one taken without the seam
+### `attribution=cohort` (#1901) — the verdict taken without the seam
 
-Both phases above read the watch table, and that table has ONE producer
+Both verdicts above read the watch table, and that table has ONE producer
 (`Repo.immediate_transaction/1`). Measured on the live node, `messages insert`
 — an autocommit single statement — is 324 679 writes while every source the
 seam covers is in the thousands, so the instrument was watching the rare tail
@@ -5477,13 +5509,14 @@ of the write load. That is why all four episodes of #1888 produced zero lines:
 `grep -h "db lock stall" runtime/log/erlang.log.*` returned 0 while six
 victims timed out at ~31 s.
 
-The `nif_census` phase does not read the table. Every tick it walks
-`Process.list/0` and keeps whoever is inside `Exqlite.Sqlite3NIF`, timed from
-the first tick that saw them there. Its log line is
-`db lock stall NIF CENSUS:` and it is counted as `lockstall_nif` by
-`scripts/log-gap-scan.awk` — the ONLY lock counter that can be non-zero while
-`lockstall`, `lockstall_resolved` and `lockstall_unattributed` are all zero,
-which is the shape every #1888 episode had.
+The cohort verdict does not read the table. Every tick walks `Process.list/0`
+and keeps whoever is inside `Exqlite.Sqlite3NIF`, timed from the first tick
+that saw them there. It is counted as `lockstall_nif` by
+`scripts/log-gap-scan.awk` (which since issue 1960 keys on
+`attribution=cohort`, the same counter under a different door) — the ONLY lock
+counter that can be non-zero while `lockstall`, `lockstall_resolved` and
+`lockstall_unattributed` are all zero, which is the shape every #1888 episode
+had.
 
 🔴 **It names the cohort, never the holder, and the difference is the whole
 reading.** exqlite's busy handler sleeps INSIDE the same dirty-IO NIF the
@@ -5496,12 +5529,29 @@ BEAM-visible separates them. So the row carries:
 | `parked=N` | N processes were inside the SQLite NIF past the threshold |
 | `registered=Hh/Ww` | how many of those N the seam could already name |
 | the roster | every pid, its elapsed and its frame |
-| `holder=unattributed` | the instrument declines to pick one, deliberately |
+| `attribution=cohort` | the instrument declines to pick one, deliberately |
 
 `registered=0h/0w` is the #1901 finding in one field: the writer holding the
-lock never touched the seam. `waiters=not counted` sits next to `parked=N` on
-purpose — a census counted no queue, and reading the roster length as a queue
-would assert N blocked writers where nobody measured one.
+lock never touched the seam. `waiters=0` sits next to `parked=N` on purpose —
+the cohort counted no queue, and reading the roster length as a queue would
+assert N blocked writers where nobody measured one.
+
+🔴 **The roster is VERIFIED, and an empty one prints nothing (issue 1960).**
+The sweep that decides who is inside the NIF and the sample that prints them
+are two instants. Measured on 2026-09-06: 8 of 11 census lines carried a
+headline about `Exqlite.Sqlite3NIF` over a roster whose own frames said
+`:gen_statem.loop_hibernate/3` (32 s) and `DBConnection.Holder.checkout_call/5`
+(2.1 s) — processes that had already left. Each entry is now re-read at sample
+time and dropped if it is no longer in the NIF, so **a cohort that has entirely
+left produces no line at all.** If you see a `cohort` line, everything in its
+roster was inside the NIF when the roster was built. Note this is *not* a
+threshold change: the arm is silent because there is nothing true left to say.
+
+🔴 **The roster rides EVERY verdict, not only this one.** If a `named` or
+`none` line reports `P > 0` parked processes, it carries the same roster. The
+parked population is the contention evidence that survives the seam being
+blind, so withholding it from the verdicts where the seam knows MORE would be
+backwards.
 
 **How to get the holder out of it anyway.** Cross the roster against the
 `fault=busy_locked` terminals in the same window: those name the VICTIMS, and

--- a/lib/grappa/db_latency.ex
+++ b/lib/grappa/db_latency.ex
@@ -48,25 +48,24 @@ defmodule Grappa.DbLatency do
         - **mechanism 3 (pure insert / index write-amplification):** the
           `persist` row `mean_ms` on its own, watched as the table grows.
 
-    * **`[:grappa, :repo, :lock_stall, :detected | :resolved |
-      :unattributed]`** (#1420, #1687) —
+    * **`[:grappa, :repo, :lock_stall, :detected | :resolved]`** (#1420,
+      #1687, #1901, issue 1960) —
       the write-lock HOLDER, which neither family above can see. Both of
       them are completion-driven, so a process sitting idle inside
       `BEGIN IMMEDIATE` emits nothing while it sits and only its victims
       show up (as 30.1s `busy_timeout` rows). `Grappa.Repo.LockWatch`
-      reads at the seam instead and hands over the holder's sampled stack
-      plus the queue behind it; here they are kept as a bounded ring, so
-      the existing CLI and admin doors surface them with no new noun.
-      `:unattributed` is the same ring for the episodes that seam CANNOT
-      name — an autocommit writer holds the same file lock and never
-      registers — and it carries the queue's stacks with explicit nils
-      where the holder would be. `:nif_census` (#1901) is the fourth phase
-      and the only one taken WITHOUT reading the seam at all: the roster of
-      processes sitting inside `Exqlite.Sqlite3NIF`, which is how the
-      autocommit writers that dominate this system's write volume become
-      visible to any door. Filing any of them elsewhere would mean an
-      operator asking what the write lock did has to already know that a
-      differently-shaped answer exists somewhere else.
+      reads at the seam instead and hands over the subject's sampled stack
+      plus both populations behind it; here they are kept as a bounded ring,
+      so the existing CLI and admin doors surface them with no new noun.
+      🔴 **TWO events, not four (issue 1960).** `:unattributed` and
+      `:nif_census` were separate phases for what is one phenomenon — the
+      same write lock, described with different confidence — and an operator
+      had to correlate four differently-shaped rows by timestamp. They fold
+      into `:detected` carrying an `attribution` of `:named` / `:none` /
+      `:cohort`; `t:Grappa.Repo.LockWatch.attribution/0` is the SSOT for what
+      each means. Filing any of them elsewhere would mean an operator asking
+      what the write lock did has to already know that a differently-shaped
+      answer exists somewhere else.
 
   ## Reading a window
 
@@ -108,9 +107,7 @@ defmodule Grappa.DbLatency do
     [:grappa, :session, :send_privmsg, :stop],
     [:grappa, :scrollback, :persist, :contention],
     [:grappa, :repo, :lock_stall, :detected],
-    [:grappa, :repo, :lock_stall, :resolved],
-    [:grappa, :repo, :lock_stall, :unattributed],
-    [:grappa, :repo, :lock_stall, :nif_census]
+    [:grappa, :repo, :lock_stall, :resolved]
   ]
 
   # #1420 — the lock-stall ring is bounded: these rows carry sampled
@@ -120,6 +117,39 @@ defmodule Grappa.DbLatency do
   @lock_stall_ring 20
 
   @type op :: :select | :insert | :update | :delete | :count | :other
+
+  @typedoc """
+  One telemetry event name this handler attaches at `init/1`.
+
+  Spelled as the concrete atom union and not `[atom(), ...]` on Dialyzer's
+  instruction: `@events` is a compile-time constant, so the success typing IS
+  this union.
+
+  🔴 It was NOT flagged before issue 1960, and that was luck rather than
+  correctness — measured while folding the four lock-stall events into two.
+  The old list carried 14 distinct atoms, above the width at which Dialyzer
+  widens a union to `atom()`; dropping to 12 put it under, and the
+  `:underspecs` warning that had been latent since #357 appeared. A contract
+  that is only exact while a list stays LONG is not a contract, so it is now
+  written out — and a new event that forgets this type is red, which is the
+  same discipline the independent `@events` copy in `db_latency_test.exs`
+  already imposes.
+  """
+  @type event :: [
+          :contention
+          | :detected
+          | :grappa
+          | :lock_stall
+          | :persist
+          | :query
+          | :repo
+          | :resolved
+          | :scrollback
+          | :send_privmsg
+          | :session
+          | :stop,
+          ...
+        ]
 
   @typedoc """
   One `{source, op}` bucket. Everything but `queue_ms` comes from a
@@ -171,59 +201,73 @@ defmodule Grappa.DbLatency do
         }
 
   @typedoc """
-  One write-lock stall episode (#1420). `:detected` carries the holder's
-  sampled stack and the queue behind it; `:resolved` brackets the same
+  The verdict column of a ring row: `nil` on `:resolved`, where the question
+  does not arise. Named so consumers can spec against it without restating the
+  union — `Grappa.Operator` renders three different labels off exactly this
+  value, and a fourth verdict must break its spec, not its output.
+  """
+  @type lock_stall_row_attribution :: Grappa.Repo.LockWatch.attribution() | nil
+
+  @typedoc """
+  One write-lock stall episode (#1420). `:detected` carries the subject's
+  sampled stack and both populations behind it; `:resolved` brackets the same
   episode with the TOTAL hold and no samples (by then there is nothing left
   to sample). Newest first.
 
-  `:unattributed` (#1687) is the third phase and the reason two fields are
-  nilable: a queue past the threshold that LockWatch could name nobody for.
-  Its `holder_pid` and `held_ms` are `nil` — the explicit-null honesty
-  signal, not a gap to paper over. A `held_ms: 0` would assert a hold of
-  zero was measured, and nothing in that episode measured a hold at all; its
-  own figure is the longest WAIT, which rides the telemetry measurements and
-  is derivable from `waiters` rather than duplicated here. It gets no
-  `:resolved` bracket, because there is no hold to total.
+  🔴 **TWO phases, not four (issue 1960).** `:unattributed` (#1687) and
+  `:nif_census` (#1901) were separate phases describing the same lock with
+  different confidence, and the honesty each of them expressed with a
+  differently-shaped row is now ONE field: `attribution`, `:named` / `:none`
+  / `:cohort`, whose SSOT is `t:Grappa.Repo.LockWatch.attribution/0`. That
+  removes the nils those phases existed to carry — a `:none` row no longer
+  needs `holder_pid: nil` to say nobody was named, because `attribution`
+  says it — and it is what lets ONE row carry the seam queue AND the NIF
+  roster instead of forcing a reader to line two rows up by timestamp.
 
-  #1888 adds three fields, on the same rule — a phase that did not observe a
-  thing carries an explicit `nil` for it rather than a plausible value:
+  `elapsed_ms` is the subject's own measurement and is deliberately not
+  called `held_ms`: it is a HOLD only on `:resolved` and on `:detected` with
+  `attribution: :named`, a WAIT on `:none` and a time parked in a NIF on
+  `:cohort`. `phase` and `attribution` are both always present, so the pair
+  is total — this is the #1687 ruling (never smuggle a hold claim in through
+  a field name) generalised to one column instead of three.
+
+  The remaining nilable fields follow the same rule they always have — a
+  phase that did not observe a thing carries an explicit `nil` for it rather
+  than a plausible value:
 
     * `observed_at` — the instant the EMITTER observed the episode, on every
       phase. Without it a ring row cannot be lined up against `erlang.log`,
       which is the only artefact that dates a freeze, and the ring is exactly
       the door that survives a log that went quiet.
-    * `caller` — WHO held the lock, on `:resolved` only. It is not a holder
+    * `caller` — WHO held the lock, on `:resolved` only (#1888). It is not a
       `sample()` and the two must not be read as one: a sample names the
-      frame the holder PAUSED in, this names the write path that opened the
-      transaction. `holder` therefore stays `nil` on a `:resolved` row, as it
-      always has.
+      frame the subject PAUSED in, this names the write path that opened the
+      transaction. `subject` therefore stays `nil` on a `:resolved` row.
     * `announced` — whether the watchdog got to report the episode WHILE it
       held. `false` means this row is the only record of it, which is the
-      #1888 case; `nil` on the two phases where the question does not arise.
+      #1888 case; `nil` on the phase where the question does not arise.
+    * `waiter_count` — nil on `:resolved` for the same reason: a closing
+      bracket counts no queue, and a `0` would assert an empty one was
+      measured.
+    * `holders` — how many holders the seam had registered at ANY elapsed,
+      which is how a reader tells "the seam saw nobody" (`0`) from "the seam
+      saw a holder that has not crossed the threshold" (positive).
+    * `registered_holders` / `registered_waiters` — how many of `parked` the
+      seam could already name, so an operator can tell "widen coverage" from
+      "the seam already told you".
 
-  `waiter_count` is nilable for the same reason: a closing bracket counts no
-  queue, and the `0` it used to carry asserted an empty one was measured.
-
-  #1901 adds the fourth phase, `:nif_census`, and with it `parked` plus two
-  counts. It is the arm that does not read the seam at all — it reports every
-  process sitting inside `Exqlite.Sqlite3NIF` past the threshold — so on that
-  row EVERY seam-derived field is nil, including `holder_pid`, and that is a
-  stronger statement than `:unattributed`'s: a holder is certainly IN
-  `parked`, and nothing BEAM-visible says which entry it is.
-  `registered_holders` / `registered_waiters` count how many of the parked
-  processes the seam could already name, so an operator can tell "widen
-  coverage" from "the other two arms already told you". `parked` follows
-  `waiters` in being a plain list defaulting to `[]` rather than a nilable:
-  an empty roster and no roster are the same fact here, since a census with
-  nobody in it emits nothing at all.
+  `waiters` and `parked` are plain lists defaulting to `[]` rather than
+  nilables: an empty roster and no roster are the same fact here.
   """
   @type lock_stall_row :: %{
-          phase: :detected | :resolved | :unattributed | :nif_census,
+          phase: :detected | :resolved,
+          attribution: lock_stall_row_attribution(),
           observed_at: String.t(),
-          holder_pid: String.t() | nil,
-          held_ms: non_neg_integer() | nil,
+          subject_pid: String.t() | nil,
+          elapsed_ms: non_neg_integer() | nil,
           waiter_count: non_neg_integer() | nil,
-          holder: map() | nil,
+          holders: non_neg_integer() | nil,
+          subject: map() | nil,
           caller: map() | nil,
           announced: boolean() | nil,
           waiters: [map()],
@@ -282,7 +326,7 @@ defmodule Grappa.DbLatency do
   independent copy of the set as the oracle and asserts it equals this one, so
   the drift is a named failure rather than a missing row.
   """
-  @spec attached_events() :: nonempty_list(nonempty_list(atom()))
+  @spec attached_events() :: [event(), ...]
   def attached_events, do: @events
 
   ## ----- GenServer callbacks ------------------------------------------
@@ -369,94 +413,57 @@ defmodule Grappa.DbLatency do
     end
   end
 
+  # issue 1960 — ONE opening clause for all three verdicts. What used to be
+  # three fold clauses differing only in which columns they nil'd out is now
+  # one row plus `attribution`, and the honesty each of those clauses spelled
+  # out in prose is carried by that field: a `:none` row does not have to say
+  # "no holder" by leaving a column empty, and a `:cohort` row does not have
+  # to say "the holder is in here somewhere" by nil'ing every seam column.
+  # `subject_pid` is never synthesised — it is the process the emitter NAMED,
+  # and `attribution` says what naming it means.
   defp fold([:grappa, :repo, :lock_stall, :detected], measurements, metadata, state) do
     push_stall(state, %{
       phase: :detected,
+      attribution: metadata.attribution,
       observed_at: metadata.observed_at,
-      holder_pid: metadata.holder.pid,
-      held_ms: measurements.held_ms,
+      subject_pid: metadata.subject.pid,
+      elapsed_ms: measurements.elapsed_ms,
       waiter_count: measurements.waiter_count,
-      holder: metadata.holder,
+      holders: metadata.holders,
+      subject: metadata.subject,
       caller: nil,
       announced: nil,
       waiters: metadata.waiters,
-      parked: [],
-      registered_holders: nil,
-      registered_waiters: nil
-    })
-  end
-
-  # #1687 — the episode that named nobody. It reaches the SAME ring and the
-  # same two doors as the other two: an operator asking "what did the write
-  # lock do" must not have to know that a third, differently-shaped answer
-  # exists somewhere else. What it does NOT do is synthesise a holder to fit
-  # the row shape — the nils are the finding.
-  defp fold([:grappa, :repo, :lock_stall, :unattributed], measurements, metadata, state) do
-    push_stall(state, %{
-      phase: :unattributed,
-      observed_at: metadata.observed_at,
-      holder_pid: nil,
-      held_ms: nil,
-      waiter_count: measurements.waiter_count,
-      holder: nil,
-      caller: nil,
-      announced: nil,
-      waiters: metadata.waiters,
-      parked: [],
-      registered_holders: nil,
-      registered_waiters: nil
+      parked: metadata.parked,
+      registered_holders: metadata.registered_holders,
+      registered_waiters: metadata.registered_waiters
     })
   end
 
   # #1888 — the closing bracket, which since that issue also fires for an
   # episode the watchdog never announced. `caller` is the identity such a row
-  # carries INSTEAD of a holder sample (there is no pause site left to sample
+  # carries INSTEAD of a subject sample (there is no pause site left to sample
   # by then), and `announced: false` is the finding: this row is the only
-  # record that episode left anywhere.
+  # record that episode left anywhere. `attribution` is nil because the
+  # question does not arise at release — the row IS the holder's own.
   defp fold([:grappa, :repo, :lock_stall, :resolved], measurements, metadata, state) do
     push_stall(state, %{
       phase: :resolved,
+      attribution: nil,
       observed_at: metadata.observed_at,
-      holder_pid: metadata.holder_pid,
-      held_ms: measurements.held_ms,
+      subject_pid: metadata.holder_pid,
+      elapsed_ms: measurements.held_ms,
       # nil, not 0: nothing in a closing bracket counted a queue, and a zero
       # would assert an empty one was measured.
       waiter_count: nil,
-      holder: nil,
+      holders: nil,
+      subject: nil,
       caller: metadata.caller,
       announced: metadata.announced,
       waiters: [],
       parked: [],
       registered_holders: nil,
       registered_waiters: nil
-    })
-  end
-
-  # #1901 — the arm that reads `Process.list/0` rather than the seam, so it is
-  # the one phase where `holder_pid` being nil is not a gap the instrument
-  # might have closed: a holder IS among `parked`, and exqlite's busy handler
-  # sleeping inside the same dirty-IO NIF as the writer that holds the lock
-  # makes the cohort indivisible from the BEAM's side. Synthesising a
-  # `holder_pid` to fill the column would turn the one honest thing this row
-  # says into a guess. `registered_holders` / `registered_waiters` are what
-  # separate "the seam is blind here" from "the other two arms already spoke".
-  defp fold([:grappa, :repo, :lock_stall, :nif_census], _, metadata, state) do
-    push_stall(state, %{
-      phase: :nif_census,
-      observed_at: metadata.observed_at,
-      holder_pid: nil,
-      held_ms: nil,
-      # nil, not `parked_count`: nothing here observed a QUEUE. The count of
-      # parked processes is a different measurement and rides its own field,
-      # exactly as #1687 refused to reuse `held_ms` for a longest WAIT.
-      waiter_count: nil,
-      holder: nil,
-      caller: nil,
-      announced: nil,
-      waiters: [],
-      parked: metadata.parked,
-      registered_holders: metadata.registered_holders,
-      registered_waiters: metadata.registered_waiters
     })
   end
 

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -1037,8 +1037,9 @@ defmodule Grappa.Operator do
 
     Enum.each(snapshot.lock_stalls, fn stall ->
       IO.puts(
-        "#{stall.phase}\tat=#{stall.observed_at}\tholder=#{lock_stall_field(stall.holder_pid)}" <>
-          "\theld_ms=#{lock_stall_field(stall.held_ms)}" <>
+        "#{stall.phase}#{attribution_column(stall.attribution)}\tat=#{stall.observed_at}" <>
+          "\tsubject=#{lock_stall_field(stall.subject_pid)}" <>
+          "\telapsed_ms=#{lock_stall_field(stall.elapsed_ms)}" <>
           "\twaiters=#{waiters_column(stall.waiter_count)}" <>
           "#{announced_column(stall.announced)}#{parked_column(stall)}"
       )
@@ -1049,9 +1050,18 @@ defmodule Grappa.Operator do
     :ok
   end
 
-  # #1687 — an `:unattributed` row has no holder and no hold, and the column
-  # has to SAY so. Interpolating the nil would print `holder=`, which reads
-  # as a formatting slip rather than as the finding it is.
+  # issue 1960 — the verdict rides next to the phase, because on a `:detected`
+  # row it is what says whether `subject=` names a HOLDER, the longest queued
+  # writer, or the longest process parked in the NIF. Absent on `:resolved`,
+  # where the question does not arise: printing `attribution=` there would
+  # invite a reader to interpret the blank.
+  @spec attribution_column(DbLatency.lock_stall_row_attribution()) :: String.t()
+  defp attribution_column(nil), do: ""
+  defp attribution_column(attribution), do: "/#{attribution}"
+
+  # #1687 — a row with nothing named has no subject and no measurement, and
+  # the column has to SAY so. Interpolating the nil would print `subject=`,
+  # which reads as a formatting slip rather than as the finding it is.
   @spec lock_stall_field(String.t() | non_neg_integer() | nil) :: String.t()
   defp lock_stall_field(nil), do: "unattributed"
   defp lock_stall_field(value), do: to_string(value)
@@ -1079,13 +1089,13 @@ defmodule Grappa.Operator do
   # there, so that behaviour is preserved by the data, not by a clause.
   #
   # 🔴 The clause this replaces was `%{holder: nil} -> []`, which would have
-  # thrown away an `:unattributed` row's ENTIRE payload: those waiters and
+  # thrown away an unattributed row's ENTIRE payload: those waiters and
   # their stacks are the only thing such an episode can honestly show, and
   # they are what separates "blocked on the lock" from "queued for a
   # connection".
   @spec lock_stall_detail_lines(DbLatency.lock_stall_row()) :: [String.t()]
-  defp lock_stall_detail_lines(%{holder: holder, caller: caller, waiters: waiters, parked: parked}) do
-    holder_lines(holder) ++
+  defp lock_stall_detail_lines(%{subject: subject, caller: caller, waiters: waiters, parked: parked} = stall) do
+    subject_lines(stall.attribution, subject) ++
       caller_lines(caller) ++
       Enum.map(waiters, &"  waiter #{&1.pid} waiting #{&1.elapsed_ms}ms at #{&1.current_function}") ++
       Enum.map(parked, &"  parked #{&1.pid} in the NIF #{&1.elapsed_ms}ms at #{&1.current_function}")
@@ -1119,13 +1129,31 @@ defmodule Grappa.Operator do
       Enum.map(caller.stacktrace, &"    #{&1}")
   end
 
-  @spec holder_lines(map() | nil) :: [String.t()]
-  defp holder_lines(nil), do: []
+  # 🔴 issue 1960 — the LABEL is chosen by the verdict, and that is the whole
+  # reason this takes an attribution. One row shape now carries three
+  # subjects, and rendering all three under the old `holder at` wording would
+  # hand an operator a HOLDER to blame on the two verdicts that never observed
+  # a hold — the same claim `subject_clause/3` in `Grappa.Repo.LockWatch`
+  # refuses to make in the log line this row mirrors.
+  @spec subject_lines(DbLatency.lock_stall_row_attribution(), map() | nil) :: [String.t()]
+  defp subject_lines(_, nil), do: []
 
-  defp holder_lines(holder) do
-    ["  holder at #{holder.current_function} (#{holder.status}, mailbox #{holder.message_queue_len})"] ++
-      Enum.map(holder.stacktrace, &"    #{&1}")
+  defp subject_lines(attribution, subject) do
+    [
+      "  #{subject_label(attribution)} at #{subject.current_function} " <>
+        "(#{subject.status}, mailbox #{subject.message_queue_len})"
+    ] ++
+      Enum.map(subject.stacktrace, &"    #{&1}")
   end
+
+  # No `nil` clause, and Dialyzer is right to insist: a row with no
+  # attribution is a `:resolved` one, whose `subject` is nil, so
+  # `subject_lines/2`'s first clause has already returned. A `nil` arm here
+  # would be an unreachable label for a block that is never rendered.
+  @spec subject_label(:named | :none | :cohort) :: String.t()
+  defp subject_label(:named), do: "holder"
+  defp subject_label(:none), do: "longest waiter"
+  defp subject_label(:cohort), do: "longest parked"
 
   @doc """
   #357 — zero the `Grappa.DbLatency` counters (`bin/grappa

--- a/lib/grappa/repo/lock_watch.ex
+++ b/lib/grappa/repo/lock_watch.ex
@@ -57,15 +57,43 @@ defmodule Grappa.Repo.LockWatch do
 
   ## What it reports, and when
 
-  A watchdog tick scans the table and reports a NAMED stall only when a
-  holder has held for at least `stall_threshold_ms` **AND at least one
-  waiter is queued behind it**. A slow-but-uncontended transaction is not a
-  stall, and reporting one would bury the signal it exists to find.
+  🔴 **One phenomenon, one prefix, one report (issue 1960).** A tick emits at
+  most one kind of line, `db lock stall:`, and an `attribution=` field says how
+  far the instrument could go towards naming the holder — `named`, `none` or
+  `cohort`, in that order of claim strength (see `t:attribution/0`). Before
+  that fold there were four literals (`db lock stall`, `… UNATTRIBUTED`,
+  `… NIF CENSUS`, `… RESOLVED`) which an operator had to correlate by
+  timestamp, and the arm was chosen by attributability, so consecutive ticks
+  could describe one episode under two different words.
 
-  ### The unattributed arm (#1687)
+  ### The gate that made a named holder silent (issue 1960)
 
-  A queue past the threshold that named nobody is reported too, as its own
-  line. This arm exists because the first one is blind by construction:
+  🔴 A holder past `stall_threshold_ms` used to be reported only **with at
+  least one waiter queued behind it**, on the reasoning that a
+  slow-but-uncontended transaction is not a stall. **Measured in prod on
+  2026-09-06 (jail `grappa-new`, 1.5.0), that gate is not a contention test at
+  all.** The watch table has ONE producer, so the only writers it can see are
+  the rare tail of this system's write load; every autocommit writer queued
+  behind that holder is invisible to it. Nine stall episodes that day produced
+  **two** announcements while holding, and five closed carrying
+  `NEVER announced while it held` — each of them with the holder's pid and
+  write path already in hand (`Vhosts.record_client_source/2`,
+  `Session.Server.init/1`), printed only at release, i.e. exactly when the
+  operator no longer needs it.
+
+  The closing bracket had already settled the question in the other direction:
+  since #1888 it fires on `announced or past_threshold?`, with no waiter
+  conjunct. **The opening line requiring a queue was the asymmetry**, and one
+  threshold policy over both edges is what removes it. What replaces the gate
+  is not silence but honesty: the line always states the three seam numbers —
+  holders registered, waiters registered, processes parked in the NIF — so a
+  reader sees the contention evidence (or its absence) instead of inferring it
+  from whether a line exists.
+
+  ### The `:none` verdict (#1687)
+
+  A queue past the threshold that named nobody is reported too. This verdict
+  exists because the first one is blind by construction:
   `observe/1` has a single producer, so ONLY a writer that went through
   `Grappa.Repo.immediate_transaction/1` can ever be tagged `:holding`. Every
   autocommit single-statement write — `Grappa.Scrollback.persist_row/1`
@@ -94,9 +122,11 @@ defmodule Grappa.Repo.LockWatch do
   blocked on the lock, one inside `DBConnection.Holder` is queued for a
   connection. Asserting a cause the frame never measured is the exact defect
   `terminal_message/3` in `Grappa.Repo.BusyRetry` was twice rewritten to
-  stop committing (#1420, #1421); this arm does not re-commit it here.
+  stop committing (#1420, #1421); this verdict does not re-commit it here, and
+  since issue 1960 neither does the shared line template — `subject_clause/3`
+  is where the arm's honest verb lives, and only `:named` may say "held".
 
-  ### One report per episode, on either arm
+  ### One report per episode, on every verdict
 
   The row's `reported?` flag arms on the first report and disarms on release
   — otherwise a 30 s stall prints 30 times. Release emits a second,
@@ -127,24 +157,24 @@ defmodule Grappa.Repo.LockWatch do
   What it carries is a `t:caller/0` and NOT a `t:sample/0` — see that type for
   why the two must not be folded together.
 
-  Both arms share that one flag, and the unattributed arm arms it on WAITER
-  rows rather than a holder's. So `acquired/0` CLEARS it on promotion: a pid
+  Both seam verdicts share that one flag, and `:none` arms it on WAITER rows
+  rather than a holder's. So `acquired/0` CLEARS it on promotion: a pid
   reported once while queued would otherwise carry an armed flag into its own
-  hold and never be reportable as the holder it went on to become. An
-  unattributed episode gets no closing bracket — there was no hold to total,
-  and inventing one is the claim this arm exists to avoid.
+  hold and never be reportable as the holder it went on to become. A `:none`
+  episode gets no closing bracket — there was no hold to total, and inventing
+  one is the claim this verdict exists to avoid.
 
-  ### The NIF census (#1901)
+  ### The `:cohort` verdict (#1901)
 
-  🔴 **Both arms above read the watch TABLE, and the table has one producer,
-  so between them they observe the RARE tail of this system's write load.**
+  🔴 **Both verdicts above read the watch TABLE, and the table has one
+  producer, so between them they observe the RARE tail of this write load.**
   Measured on the live node (`Grappa.Operator.db_latency_text!/0`, cumulative
   since boot): `messages insert` — `Grappa.Scrollback.persist_row/1`, an
   autocommit single statement — is **324 679** writes, while every source the
   seam does cover (auth, settings, themes, push, reap) is in the thousands.
   The dominant writer of this system has never owned a row here.
 
-  So the third arm does not read the table at all. At each tick it walks
+  So the third verdict does not read the table at all. Each tick walks
   `Process.list/0` and keeps the processes whose `current_function` is inside
   `Exqlite.Sqlite3NIF`, timing them from the first tick that saw them there.
   That reaches any writer, registered or not, because the property it reads is
@@ -158,25 +188,37 @@ defmodule Grappa.Repo.LockWatch do
   same physics that makes the cohort visible makes it INDIVISIBLE: the writer
   holding the lock and the writers blocked behind it are all inside
   `Exqlite.Sqlite3NIF`, all reading `status: :running`, and nothing
-  BEAM-visible separates them. This arm therefore reports the COHORT — every
-  parked process, its elapsed, its `current_function` and the longest one's
-  stack — plus how many of them the seam already knows as holders and as
-  waiters. Naming the holder outright is what registering the autocommit
-  writes (#1901 axis 2, deliberately deferred) would buy, and asserting it
-  from here is the class of claim `terminal_message/3` in
-  `Grappa.Repo.BusyRetry` was twice rewritten to stop making.
+  BEAM-visible separates them. So it reports the COHORT — every parked
+  process, its elapsed, its `current_function` and the longest one's stack —
+  plus how many of them the seam already knows as holders and as waiters.
+  Naming the holder outright is what registering the autocommit writes (#1901
+  axis 2, deliberately deferred) would buy, and asserting it from here is the
+  class of claim `terminal_message/3` in `Grappa.Repo.BusyRetry` was twice
+  rewritten to stop making.
+
+  🔴 **The roster is VERIFIED at sample time (issue 1960).** The sweep that
+  decides who is inside the NIF and the sample that prints them are two
+  instants, and in prod the gap between them was wide enough to matter:
+  measured on 2026-09-06, 8 of 11 census lines printed a headline about
+  `Exqlite.Sqlite3NIF` over a roster whose own frames said
+  `:gen_statem.loop_hibernate/3` (at 32 s) and
+  `DBConnection.Holder.checkout_call/5` (at 2.1 s) — processes that had left.
+  `nif_sample/2` now decides from the SAME read it builds the sample from, and
+  a cohort that has entirely left produces NO line. That is why the noise cure
+  is not a bigger threshold: the arm is silent because there is nothing true
+  left to say, which is a different fact from being under a threshold.
 
   Two further limits, stated so a later reader does not have to rediscover
   them:
 
     * a transaction parked BETWEEN statements is not inside a NIF, so this
-      arm cannot see it. That case is the FIRST arm's, and it is covered
+      verdict cannot see it. That case is `:named`'s, and it is covered
       exactly when the writer went through the seam;
     * `elapsed` is measured from the first TICK that saw the process there,
       never from its real entry into the NIF, so it is a LOWER bound
       understated by up to one `tick_ms`. A census that wanted the true
       instant would have to instrument the write path, which is the cost this
-      arm exists to avoid.
+      verdict exists to avoid.
 
   Readers park in the same NIF, so a slow `SELECT` is in the cohort too. That
   is deliberate: the arm reports what it observed, and a reader holding a long
@@ -258,6 +300,17 @@ defmodule Grappa.Repo.LockWatch do
   @depth_key {__MODULE__, :depth}
   @stack_frames 12
 
+  # issue 1960 — ONE `Process.info/2` read per sample, and `:current_stacktrace`
+  # rides in it rather than costing a second signal. That is not only cheaper:
+  # the two reads used to be able to disagree, so a printed frame could belong
+  # to a different instant than the `current_function` above it — the same race
+  # the census fix below is about, one level down.
+  @sample_keys [:current_function, :status, :message_queue_len, :dictionary, :current_stacktrace]
+
+  @detected_event [:grappa, :repo, :lock_stall, :detected]
+  @resolved_event [:grappa, :repo, :lock_stall, :resolved]
+  @events [@detected_event, @resolved_event]
+
   # #1901 — the module every SQLite call in this system passes through, and
   # the census's whole discriminator. A literal and not a config knob: it is
   # not an operator choice, it is which driver `Grappa.Repo` is built on, and
@@ -268,6 +321,19 @@ defmodule Grappa.Repo.LockWatch do
 
   @typedoc "Role of a row in the watch table."
   @type role :: :waiting | :holding
+
+  @typedoc """
+  A telemetry event name this module emits.
+
+  Spelled as the concrete atom union and not `[atom(), ...]` on Dialyzer's
+  instruction: `@events` is a compile-time constant, so the success typing IS
+  this union and a wider spec is an `:underspecs` warning. The checker is
+  right — a reader of `[atom(), ...]` learns strictly less than the function
+  already promises, and the pin in `db_latency_test.exs` derives the sink's
+  attached set from this list, so the two events being visible in the type is
+  the point rather than an accident.
+  """
+  @type event :: [:grappa | :repo | :lock_stall | :detected | :resolved, ...]
 
   @typedoc "One watch-table row: who, in which role, since when, already reported?"
   @type row :: {pid(), role(), integer(), boolean()}
@@ -313,47 +379,65 @@ defmodule Grappa.Repo.LockWatch do
         }
 
   @typedoc """
-  A detected stall: one holder, the queue behind it, and the instant it was
-  observed (#1888 — the ring row it becomes is otherwise impossible to line up
-  against `erlang.log`, which is the only artefact that dates a freeze).
+  Where the SUBJECT of a report came from, i.e. how far the instrument can go
+  towards naming whoever holds the write lock (issue 1960).
+
+    * `:named`  — the seam registered a holder past the threshold. This is the
+      only value under which the record claims a HOLD.
+    * `:none`   — no holder past the threshold, but registered WRITERS are
+      queued past it. They are provably ours and their stacks separate a
+      lock-wait from a pool-wait; who blocks them is not attributable here.
+    * `:cohort` — nothing registered at the seam at all, only processes parked
+      inside `Exqlite.Sqlite3NIF`. The population is physical and indivisible.
+
+  🔴 The ORDER is `named > none > cohort`, and it is a claim-strength ordering,
+  not a preference. A registered waiter is a writer we KNOW is blocked and can
+  tell apart from a pool queue by its own frame; a NIF resident is a physical
+  observation that may equally be a healthy two-millisecond write. Nothing is
+  lost by the ordering: the roster rides EVERY report, so the cohort is
+  reported whichever arm supplied the subject.
+  """
+  @type attribution :: :named | :none | :cohort
+
+  @typedoc """
+  One report — the single record all three former arms fold into (issue 1960).
+
+  🔴 There is no `holder` key, and its absence is what lets one type carry
+  three verdicts without a nil in sight. `t:unattributed/0` refused the key
+  because no holder was observed and `t:nif_census/0` refused it because one
+  certainly WAS in `parked` and could not be singled out; a union of the two
+  would have had to carry it as `nil` and re-open both questions. `subject`
+  plus `attribution` is total instead: `attribution` says what the subject IS,
+  so a record claims a hold exactly when it measured one.
+
+  `elapsed_ms` lives on the subject and is deliberately NOT called `held_ms` —
+  the #1687 ruling, generalised: on `:none` it is a WAIT and on `:cohort` a
+  time parked in a NIF, and reusing the hold field would smuggle back through
+  the schema the claim the prose is careful to leave out.
+
+  `holders` counts the holders the seam has registered at ANY elapsed, which
+  is how a reader tells "the seam saw nobody" (`0`) from "the seam saw a holder
+  that has not crossed the threshold" (positive) on a `:none` report.
+  `registered_holders` / `registered_waiters` qualify `parked` and only
+  `parked`: how many of THOSE the seam could already name.
+
+  ## The two populations, and the one threshold over both
+
+    * `waiters` — every registered waiter, sampled. The count is the whole
+      queue and is NOT threshold-filtered: a waiter queued for five
+      milliseconds is still blocked behind the holder, and filtering it out
+      would understate the contention the line exists to evidence. The
+      threshold selects who may be a SUBJECT, never who counts as contention.
+    * `parked` — the NIF cohort past the threshold, VERIFIED: each entry was
+      re-read at sample time and still inside `Exqlite.Sqlite3NIF`. Entries
+      that had left are dropped rather than printed under a NIF headline.
   """
   @type stall :: %{
           observed_at: String.t(),
-          holder: sample(),
+          attribution: attribution(),
+          subject: sample(),
+          holders: non_neg_integer(),
           waiters: [sample()],
-          waiter_count: non_neg_integer()
-        }
-
-  @typedoc """
-  A queue nobody can be blamed for (#1687): writers past the threshold with
-  no holder this instrument can name. `holders_registered` is the honesty
-  field — `0` says the seam saw no holder at all (the autocommit case),
-  a positive value says one is registered but has not crossed the
-  threshold. There is deliberately no `holder` key: a record cannot carry a
-  field for a thing that was never observed.
-  """
-  @type unattributed :: %{
-          observed_at: String.t(),
-          waiters: [sample()],
-          holders_registered: non_neg_integer()
-        }
-
-  @typedoc """
-  A census of the processes parked INSIDE `Exqlite.Sqlite3NIF` past the
-  threshold (#1901) — the arm that reaches the autocommit writers the seam
-  cannot see.
-
-  🔴 There is deliberately no `holder` key, and the reason is stronger than
-  the one `t:unattributed/0` gives for its own absence. There, no holder was
-  observed. Here one certainly IS in `parked`, and the instrument cannot say
-  WHICH: exqlite's busy handler sleeps inside the same dirty-IO NIF the writer
-  holding the lock is executing in, so the holder and its victims are one
-  indistinguishable cohort from the BEAM's side. `registered_holders` and
-  `registered_waiters` are the honesty fields — how many of these the seam
-  could already name — and the remainder is the population #1901 is about.
-  """
-  @type nif_census :: %{
-          observed_at: String.t(),
           parked: [sample()],
           registered_holders: non_neg_integer(),
           registered_waiters: non_neg_integer()
@@ -416,32 +500,29 @@ defmodule Grappa.Repo.LockWatch do
   end
 
   @doc """
-  One detection pass at the given threshold. The watchdog's tick calls this;
-  it is public so an operator (or a test) can take the reading on demand
-  instead of waiting for a tick.
-  """
-  @spec scan(non_neg_integer()) :: :ok
-  def scan(stall_threshold_ms) when is_integer(stall_threshold_ms) and stall_threshold_ms >= 0 do
-    detect(now_ms(), stall_threshold_ms)
-  end
+  One detection pass at the given threshold, and the ONLY one (issue 1960 —
+  it is what `scan/1` and `census/2` folded into).
 
-  @doc """
-  One NIF-census pass (#1901): report the processes that have been inside
-  `Exqlite.Sqlite3NIF` for at least `stall_threshold_ms`, and return the clock
-  to hand the NEXT pass.
+  The two used to be separate calls in a fixed order, because the census had
+  to run second so a pid the seam had just named counted as registered rather
+  than as a writer nobody could see. One pass makes that ordering constraint
+  disappear instead of documenting it, reads the watch table ONCE where the
+  census used to re-read it through `lock_roles/0`, and is what lets a single
+  report carry both populations.
 
-  Public for the same reason `scan/1` is — an operator, or a test, can take
-  the reading on demand instead of waiting for a tick — but unlike `scan/1` it
-  is not idempotent in its argument: the returned map IS the elapsed
-  measurement. Calling it with a fresh `%{}` every time restarts every clock
-  at zero, so nothing can ever cross a non-zero threshold. The watchdog
+  Public so an operator (or a test) can take the reading on demand instead of
+  waiting for a tick. It is NOT idempotent in its argument, and that is
+  inherited from `census/2`: the returned map IS the elapsed measurement for
+  the NIF cohort. Calling it with a fresh `%{}` every time restarts every
+  clock at zero, so nothing can ever cross a non-zero threshold. The watchdog
   threads it through `handle_info/2`; a caller driving it by hand must thread
   it too.
   """
-  @spec census(nif_watch(), non_neg_integer()) :: nif_watch()
-  def census(seen, stall_threshold_ms)
+  @spec scan(nif_watch(), non_neg_integer()) :: nif_watch()
+  def scan(seen, stall_threshold_ms)
       when is_map(seen) and is_integer(stall_threshold_ms) and stall_threshold_ms >= 0 do
     now = now_ms()
+    {holders, waiters} = partition(rows(), now)
 
     # `Map.get(seen, pid, {now, false})` is the whole state machine: a pid
     # already being watched keeps its original instant AND its reported flag,
@@ -449,15 +530,21 @@ defmodule Grappa.Repo.LockWatch do
     # simply absent from the rebuilt map. No deletion path, so none to leak.
     carried = Map.new(parked_in_nif(), &{&1, Map.get(seen, &1, {now, false})})
 
-    due =
-      for {pid, {since, false}} <- carried, now - since >= stall_threshold_ms, do: {pid, now - since}
-
-    report_nif_census(due)
-
-    Enum.reduce(due, carried, fn {pid, _}, acc ->
-      Map.update!(acc, pid, fn {since, _} -> {since, true} end)
-    end)
+    detect(now, holders, waiters, carried, stall_threshold_ms)
   end
+
+  @doc """
+  The telemetry events this module emits.
+
+  Exposed for the same reason `Grappa.DbLatency.attached_events/0` is, and it
+  is the other half of that pin: that sink's `fold/4` has NO catch-all, so an
+  event it attaches with no emitter left folds NOTHING, IN SILENCE — the
+  failure mode #1901 hit while it was being built. Deriving the sink's
+  lock-stall set from THIS list is what turns a pruned emitter into a red
+  test instead of a ring that quietly stops filling.
+  """
+  @spec emitted_events() :: [event(), ...]
+  def emitted_events, do: @events
 
   # Entering `BEGIN IMMEDIATE`. The caller is a WAITER until `acquired/0`.
   #
@@ -584,7 +671,7 @@ defmodule Grappa.Repo.LockWatch do
     )
 
     :telemetry.execute(
-      [:grappa, :repo, :lock_stall, :resolved],
+      @resolved_event,
       %{held_ms: held_ms},
       %{observed_at: now_iso8601(), holder_pid: caller.pid, caller: caller, announced: announced}
     )
@@ -707,15 +794,14 @@ defmodule Grappa.Repo.LockWatch do
     {:ok, state}
   end
 
-  # `scan/1` FIRST, and the order is not cosmetic: it is the arm that can NAME
-  # a holder, and a pid it reports in this tick is one the census then counts
-  # as already-registered rather than as a writer nobody can see. Running the
-  # census first would report the same episode as unattributable one tick
-  # before the instrument attributed it.
+  # ONE pass (issue 1960). This used to be `scan/1` then `census/2`, in that
+  # order and for a reason — the naming arm had to run first so a pid it
+  # reported counted as registered rather than as a writer nobody could see.
+  # A single pass reads one instant for both populations, so there is no
+  # ordering left to get wrong.
   @impl GenServer
   def handle_info(:tick, state) do
-    scan(state.stall_threshold_ms)
-    nif_watch = census(state.nif_watch, state.stall_threshold_ms)
+    nif_watch = scan(state.nif_watch, state.stall_threshold_ms)
     Process.send_after(self(), :tick, state.tick_ms)
     {:noreply, %{state | nif_watch: nif_watch}}
   end
@@ -771,144 +857,294 @@ defmodule Grappa.Repo.LockWatch do
 
   ## ----- Detection -----------------------------------------------------
 
-  # A NAMED stall is a holder past the threshold WITH a queue behind it.
-  # Neither half alone qualifies: a lone slow transaction blocks nobody.
+  # 🔴 ONE report, three verdicts, and the fork is the SAME one the three arms
+  # used to make between them — only now it chooses a field instead of a
+  # prefix (issue 1960).
   #
-  # The `else` is the #1687 arm, and it is a fallback rather than a second
-  # independent test on purpose — the two are mutually exclusive, so a real
-  # stall is reported once, by its own name, and never also as an anonymous
-  # queue. It fires in both shapes the first arm walks away from: no holder
-  # registered at all (the autocommit case that produced the prod episode),
-  # and a holder registered but still under the threshold while the queue
-  # behind it is already past it. Both are the same defect — writers
-  # demonstrably stuck, instrument silent — so they get the same cure and one
-  # metadata field tells them apart.
-  @spec detect(integer(), non_neg_integer()) :: :ok
-  defp detect(now, threshold_ms) do
-    {holders, waiters} = partition(rows(), now)
+  # The ladder is claim strength: a holder the seam named, else writers the
+  # seam knows are queued, else the physical NIF population. See
+  # `t:attribution/0` for why a registered waiter outranks a NIF resident.
+  #
+  # 🔴 Each rung forks on ATTRIBUTABLE, not on "did we print something", and
+  # that split is load-bearing exactly as it was before the fold. Choosing the
+  # rung by the REPORTABLE set instead would make an already-announced episode
+  # fall through to the next rung on the very next tick and describe a holder
+  # that is past the threshold as an unattributable queue — the instrument
+  # lying in the act of being more talkative. Nameable-at-all and
+  # not-yet-named-this-episode are two different questions, and only the first
+  # one chooses the rung.
+  #
+  # 🔴 Known limit, deliberate: while a named episode is armed the cohort gets
+  # no line of its own, so victims that pile into the NIF AFTER the announcing
+  # tick are not enumerated until the closing bracket. That is the price of one
+  # report per episode, and the alternative — a second line about an episode
+  # already announced — is the correlate-by-timestamp reading this issue exists
+  # to remove.
+  @spec detect(integer(), [{pid(), non_neg_integer()}], [{pid(), non_neg_integer()}], nif_watch(), non_neg_integer()) ::
+          nif_watch()
+  defp detect(now, holders, waiters, carried, threshold_ms) do
+    parked_due = due(carried, now, threshold_ms)
 
-    # 🔴 The fork is ATTRIBUTABLE, not "did we print something". Splitting on
-    # the reportable set instead would make an already-announced episode fall
-    # through to the second arm on the very next tick and print "none past
-    # the threshold" about a holder that is past it — the instrument lying in
-    # the act of being more talkative. Nameable-at-all and
-    # not-yet-named-this-episode are two different questions, and only the
-    # first one chooses the arm.
-    if attributable(holders, threshold_ms) == [] do
-      report_unattributed(unreported_past(waiters, threshold_ms), length(holders))
-    else
-      report_stalls(unreported_past(holders, threshold_ms), waiters)
+    cond do
+      past(holders, threshold_ms) != [] ->
+        report_each(:named, unreported_past(holders, threshold_ms), holders, waiters, parked_due, carried)
+
+      past(waiters, threshold_ms) != [] ->
+        report_each(:none, unreported_past(waiters, threshold_ms), holders, waiters, parked_due, carried)
+
+      true ->
+        report_cohort(fresh(carried, now, threshold_ms), holders, waiters, carried)
     end
-
-    :ok
   end
 
-  # Holders past the threshold, whether or not this episode already named
-  # them. This is the "can anyone be blamed at all?" question.
-  @spec attributable([{pid(), non_neg_integer()}], non_neg_integer()) :: [{pid(), non_neg_integer()}]
-  defp attributable(holders, threshold_ms) do
-    Enum.filter(holders, fn {_, elapsed} -> elapsed >= threshold_ms end)
-  end
+  # Rows past the threshold, whether or not this episode already named them.
+  # This is the "can anyone be blamed at all?" question.
+  @spec past([{pid(), non_neg_integer()}], non_neg_integer()) :: [{pid(), non_neg_integer()}]
+  defp past(rows, threshold_ms), do: Enum.filter(rows, fn {_, elapsed} -> elapsed >= threshold_ms end)
 
   # Rows past the threshold that this episode has not reported yet — the
-  # "what is left to say?" question. Shared by both arms so they cannot
+  # "what is left to say?" question. Shared by both seam rungs so they cannot
   # drift on either half of the predicate.
   @spec unreported_past([{pid(), non_neg_integer()}], non_neg_integer()) :: [{pid(), non_neg_integer()}]
   defp unreported_past(rows, threshold_ms) do
     Enum.filter(rows, fn {pid, elapsed} -> elapsed >= threshold_ms and unreported?(pid) end)
   end
 
-  @spec report_stalls([{pid(), non_neg_integer()}], [{pid(), non_neg_integer()}]) :: :ok
-  defp report_stalls([], _), do: :ok
-  defp report_stalls(_, []), do: :ok
-
-  defp report_stalls(stalled, waiters) do
-    waiter_samples = Enum.map(waiters, fn {pid, elapsed} -> sample(pid, elapsed) end)
-    Enum.each(stalled, &report(&1, waiter_samples))
+  # The NIF cohort past the threshold — every member, reported or not, because
+  # the roster rides EVERY report and an already-reported parked process is
+  # still part of the population the line evidences.
+  @spec due(nif_watch(), integer(), non_neg_integer()) :: [{pid(), non_neg_integer()}]
+  defp due(carried, now, threshold_ms) do
+    for {pid, {since, _}} <- carried, now - since >= threshold_ms, do: {pid, now - since}
   end
 
-  @spec report({pid(), non_neg_integer()}, [sample()]) :: :ok
-  defp report({pid, elapsed}, waiter_samples) do
-    # Arm the flag BEFORE emitting: an emit that raced the next tick would
-    # double-report the same episode.
-    _ = :ets.update_element(@table, pid, [{4, true}])
+  # The subset of `due/3` this episode has not reported — what decides whether
+  # the cohort rung has anything left to say.
+  @spec fresh(nif_watch(), integer(), non_neg_integer()) :: [{pid(), non_neg_integer()}]
+  defp fresh(carried, now, threshold_ms) do
+    for {pid, {since, false}} <- carried, now - since >= threshold_ms, do: {pid, now - since}
+  end
 
-    holder = sample(pid, elapsed)
+  # A seam rung: one line per subject that has not been announced yet, or
+  # silence when this episode has already spoken. Sampling happens ONLY on the
+  # emitting path — an armed episode costs nothing per tick.
+  #
+  # The attribution is narrowed to the two SEAM verdicts rather than the full
+  # `t:attribution/0`, on Dialyzer's instruction and correctly: `:cohort` reads
+  # no table, has exactly one subject, and must verify its roster BEFORE it may
+  # fire at all — three differences that are why it has `report_cohort/4` of
+  # its own instead of a third caller here.
+  @spec report_each(
+          :named | :none,
+          [{pid(), non_neg_integer()}],
+          [{pid(), non_neg_integer()}],
+          [{pid(), non_neg_integer()}],
+          [{pid(), non_neg_integer()}],
+          nif_watch()
+        ) :: nif_watch()
+  defp report_each(_, [], _, _, _, carried), do: carried
 
+  defp report_each(attribution, subjects, holders, waiters, parked_due, carried) do
+    parked = sample_parked(parked_due)
+    waiter_samples = sample_all(waiters)
+
+    Enum.each(subjects, fn {pid, elapsed} ->
+      # Arm the flag BEFORE emitting: an emit that raced the next tick would
+      # double-report the same episode. A ~170s prod episode at
+      # `tick_ms: 1_000` would otherwise print ~170 identical warnings, which
+      # an operator reads exactly the way they read none.
+      _ = :ets.update_element(@table, pid, [{4, true}])
+      report(attribution, sample(pid, elapsed), length(holders), waiter_samples, parked)
+    end)
+
+    mark_parked_reported(carried, parked)
+  end
+
+  # The cohort rung — the one that reads no table at all (#1901).
+  #
+  # 🔴 The roster is VERIFIED before it is allowed to trigger anything, and
+  # that ordering is the cure for defect 2 of issue 1960. `sample_parked/1`
+  # drops every entry whose own read no longer lands inside the NIF, so a
+  # cohort that has entirely left produces NO line rather than a headline about
+  # `Exqlite.Sqlite3NIF` over a roster of `:gen_statem.loop_hibernate/3` and
+  # `DBConnection.Holder.checkout_call/5` frames — which is what 8 of the 11
+  # census lines measured in prod on 2026-09-06 actually were.
+  @spec report_cohort(
+          [{pid(), non_neg_integer()}],
+          [{pid(), non_neg_integer()}],
+          [{pid(), non_neg_integer()}],
+          nif_watch()
+        ) ::
+          nif_watch()
+  defp report_cohort([], _, _, carried), do: carried
+
+  defp report_cohort(candidates, holders, waiters, carried) do
+    case sample_parked(candidates) do
+      [] ->
+        carried
+
+      [longest | _] = parked ->
+        # The registered waiters are all UNDER the threshold on this rung, so
+        # their stacks are not the payload — but their COUNT is contention
+        # evidence, and the seam clause carries the same three numbers on every
+        # verdict. Sampling them keeps `waiters` meaning one thing across the
+        # three, and the population the seam can see is small by construction
+        # (that is #1901's whole finding).
+        report(:cohort, longest, length(holders), sample_all(waiters), parked)
+        mark_parked_reported(carried, parked)
+    end
+  end
+
+  @spec sample_all([{pid(), non_neg_integer()}]) :: [sample()]
+  defp sample_all(rows), do: Enum.map(rows, fn {pid, elapsed} -> sample(pid, elapsed) end)
+
+  # A parked process that appeared in a roster we PRINTED has been reported,
+  # whichever rung printed it — otherwise the cohort rung would describe the
+  # same processes again on the next tick under its own verdict.
+  @spec mark_parked_reported(nif_watch(), [sample()]) :: nif_watch()
+  defp mark_parked_reported(carried, parked) do
+    printed = MapSet.new(parked, & &1.pid)
+
+    Map.new(carried, fn
+      {pid, {since, reported?}} ->
+        {pid, {since, reported? or MapSet.member?(printed, inspect(pid))}}
+    end)
+  end
+
+  # The one door, for all three verdicts. Same prefix, same three seam numbers
+  # in the same order on every line, and the SUBJECT clause carries the arm's
+  # honest verb — only `:named` says a hold was observed.
+  #
+  # `status` rides in the PROSE, next to `current_function`, and not in the
+  # metadata beside the measurements: those are numbers an operator
+  # aggregates, while these two are one answer split in half — WHERE the
+  # subject is, and whether it is running there at all. Separating them across
+  # the message/metadata line is what made the reading hard.
+  @spec report(attribution(), sample(), non_neg_integer(), [sample()], [sample()]) :: :ok
+  defp report(attribution, subject, holders, waiters, parked) do
     stall = %{
       observed_at: now_iso8601(),
-      holder: holder,
-      waiters: waiter_samples,
-      waiter_count: length(waiter_samples)
+      attribution: attribution,
+      subject: subject,
+      holders: holders,
+      waiters: waiters,
+      parked: parked,
+      registered_holders: registered(parked, :holders),
+      registered_waiters: registered(parked, :waiters)
     }
 
-    # `status` rides in the PROSE, next to `current_function`, and not in the
-    # metadata beside `held_ms`/`waiters`: those two are measurements an
-    # operator aggregates, while these two are one answer split in half —
-    # WHERE the holder is, and whether it is running there at all. Separating
-    # them across the message/metadata line is what made the reading hard.
     Logger.warning(
-      "db lock stall: holder #{holder.pid} has held RESERVED for #{holder.elapsed_ms}ms " <>
-        "with #{stall.waiter_count} waiter(s) queued — holder status=#{inspect(holder.status)} " <>
-        "at #{holder.current_function}, stack: #{Enum.join(holder.stacktrace, " <- ")}",
-      held_ms: holder.elapsed_ms,
-      waiters: stall.waiter_count
+      "db lock stall: attribution=#{attribution}, #{subject_clause(attribution, subject, holders)} — " <>
+        "#{seam_clause(holders, length(waiters), length(parked))}" <>
+        "#{roster_tail(parked, stall)}; subject #{subject.pid} " <>
+        "status=#{inspect(subject.status)} at #{subject.current_function}, " <>
+        "stack: #{Enum.join(subject.stacktrace, " <- ")}",
+      attribution: attribution,
+      elapsed_ms: subject.elapsed_ms,
+      waiters: length(waiters),
+      parked: length(parked)
     )
 
     :telemetry.execute(
-      [:grappa, :repo, :lock_stall, :detected],
-      %{held_ms: holder.elapsed_ms, waiter_count: stall.waiter_count},
+      @detected_event,
+      %{elapsed_ms: subject.elapsed_ms, waiter_count: length(waiters), parked_count: length(parked)},
       stall
     )
   end
 
-  # #1687 — the queue nobody can be blamed for. Same two doors as `report/2`,
-  # and deliberately the same SHAPE of line, so an operator scanning the log
-  # reads them as one instrument with two verdicts rather than two tools.
+  # The arm's honest verb, and the ONE place a hold may be claimed.
   #
-  # It carries the LONGEST waiter's stack for the same reason `report/2`
-  # carries the holder's: it is the one frame that says which of the two
-  # topologies this is. The measurement is named `longest_wait_ms` and not
-  # `held_ms` — nothing here observed a hold, and reusing the hold field
-  # would smuggle the claim back in through the schema after the prose had
-  # been careful to leave it out.
-  @spec report_unattributed([{pid(), non_neg_integer()}], non_neg_integer()) :: :ok
-  defp report_unattributed([], _), do: :ok
-
-  defp report_unattributed(queued, holders_registered) do
-    # Arm BEFORE emitting, exactly as `report/2` does: a 170-second prod
-    # episode at `tick_ms: 1_000` would otherwise print the same warning ~170
-    # times, which an operator reads the same way as never printing it.
-    Enum.each(queued, fn {pid, _} -> :ets.update_element(@table, pid, [{4, true}]) end)
-
-    samples = Enum.map(queued, fn {pid, elapsed} -> sample(pid, elapsed) end)
-    longest = Enum.max_by(samples, & &1.elapsed_ms)
-    report = %{observed_at: now_iso8601(), waiters: samples, holders_registered: holders_registered}
-
-    Logger.warning(
-      "db lock stall UNATTRIBUTED: #{length(samples)} writer(s) queued past the threshold, " <>
-        "longest #{longest.elapsed_ms}ms — #{holder_clause(holders_registered)}, so the holder is " <>
-        "NOT attributable at the BEGIN IMMEDIATE seam; longest waiter #{longest.pid} " <>
-        "status=#{inspect(longest.status)} at #{longest.current_function}, " <>
-        "stack: #{Enum.join(longest.stacktrace, " <- ")}",
-      waiters: length(samples),
-      longest_wait_ms: longest.elapsed_ms
-    )
-
-    :telemetry.execute(
-      [:grappa, :repo, :lock_stall, :unattributed],
-      %{waiter_count: length(samples), longest_wait_ms: longest.elapsed_ms},
-      report
-    )
+  # 🔴 `:none` and `:cohort` must never reach the word "held": the victims'
+  # elapsed decomposes into pool checkout PLUS `busy_timeout` (#1687, measured
+  # in prod), so a wait is not evidence of anybody's hold, and on `:cohort`
+  # exqlite's busy handler sleeping inside the same dirty-IO NIF as the writer
+  # holding the lock makes the population indivisible from the BEAM's side.
+  # Asserting a cause the frame never measured is the defect
+  # `terminal_message/3` in `Grappa.Repo.BusyRetry` was twice rewritten to stop
+  # committing; the fold does not re-commit it in a shared template.
+  @spec subject_clause(attribution(), sample(), non_neg_integer()) :: String.t()
+  defp subject_clause(:named, subject, _) do
+    "holder #{subject.pid} has held RESERVED for #{subject.elapsed_ms}ms"
   end
 
-  # The two sub-cases, named apart because they call for different next
-  # moves: `0` means the writer holding the lock never passed the seam (widen
-  # coverage, or accept the blindness knowingly), while a positive count
-  # means the seam DID see a holder and the queue is simply older than it.
+  defp subject_clause(:none, subject, holders) do
+    "longest writer queued at the seam for #{subject.elapsed_ms}ms — #{holder_clause(holders)}, " <>
+      "so the holder is NOT attributable at the BEGIN IMMEDIATE seam"
+  end
+
+  defp subject_clause(:cohort, subject, _) do
+    "longest process parked inside #{inspect(@nif_module)} for #{subject.elapsed_ms}ms — " <>
+      "nothing registered at the seam, and nothing BEAM-visible says which of the cohort holds the lock"
+  end
+
+  # The two sub-cases of an unattributable queue, named apart because they call
+  # for different next moves: `0` means the writer holding the lock never
+  # passed the seam (widen coverage, or accept the blindness knowingly), while
+  # a positive count means the seam DID see a holder and the queue is simply
+  # older than it.
   @spec holder_clause(non_neg_integer()) :: String.t()
   defp holder_clause(0), do: "no holder registered"
   defp holder_clause(n), do: "#{n} holder(s) registered, none past the threshold"
+
+  # The three seam numbers, in the same order on every line whatever the
+  # verdict — this is what replaces correlating three prefixes by timestamp.
+  @spec seam_clause(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: String.t()
+  defp seam_clause(holders, waiters, parked) do
+    "#{holders} holder(s) / #{waiters} waiter(s) registered at the seam, " <>
+      "#{parked} process(es) parked inside #{inspect(@nif_module)}"
+  end
+
+  # 🔴 The roster is why the cohort line is longer than its siblings, and it is
+  # the deliverable rather than verbosity (#1901). The acceptance test is that
+  # the log NAMES the process holding the lock; this verdict cannot label which
+  # of the cohort that is, so it names every one of them — pid, elapsed and
+  # frame — and pays the full twelve-frame stack only for the longest. An
+  # operator who has the roster can cross it against the `fault=busy_locked`
+  # terminals the victims emit and read the holder off the difference; an
+  # operator with one sample cannot.
+  #
+  # 🔴 It rides on whether the cohort EXISTS, not on which verdict was
+  # reached, and that is deliberate: the parked population is the contention
+  # evidence that survives the seam being blind, so a `:named` line that
+  # happens to have twenty victims in the NIF should name them too. Keying it
+  # on `:cohort` would have made the roster available exactly when the seam
+  # knows least, which is backwards. On a healthy node the list is empty and
+  # the tail costs a pattern match.
+  @spec roster_tail([sample()], stall()) :: String.t()
+  defp roster_tail([], _), do: ""
+
+  defp roster_tail(parked, stall) do
+    "; #{seam_roster_clause(stall.registered_holders, stall.registered_waiters, length(parked))}" <>
+      "; roster: #{roster(parked)}"
+  end
+
+  # How much of the PARKED roster the seam could already name — a different
+  # question from `seam_clause/3`'s, which counts the whole registered
+  # population. All-zero is the #1901 finding in one phrase: this system's
+  # dominant writer holds the file lock without ever touching the seam, so
+  # widening coverage is the only thing that would name it. A positive count
+  # says the seam DID see some of them, and the remainder is what it missed.
+  @spec seam_roster_clause(non_neg_integer(), non_neg_integer(), pos_integer()) :: String.t()
+  defp seam_roster_clause(0, 0, total) do
+    "none of them registered at the BEGIN IMMEDIATE seam, so all #{total} are writers it cannot name"
+  end
+
+  defp seam_roster_clause(holders, waiters, total) do
+    "#{holders} holder(s) and #{waiters} waiter(s) of them registered at the BEGIN IMMEDIATE " <>
+      "seam, #{total - holders - waiters} not"
+  end
+
+  # How many of the parked cohort the seam already knows, in the named role.
+  # Reads the table through `lock_roles/0`, which shares `rows/0`'s dead-row
+  # reaping with every other reader.
+  @spec registered([sample()], :holders | :waiters) :: non_neg_integer()
+  defp registered([], _), do: 0
+
+  defp registered(parked, role) do
+    pids = MapSet.new(parked, & &1.pid)
+
+    lock_roles() |> Map.fetch!(role) |> Enum.count(&MapSet.member?(pids, inspect(&1)))
+  end
 
   ## ----- The NIF census (#1901) -----------------------------------------
 
@@ -930,73 +1166,38 @@ defmodule Grappa.Repo.LockWatch do
         do: pid
   end
 
-  # Same two doors and the same SHAPE of line as the other two arms, so an
-  # operator scanning `erlang.log` reads three verdicts from one instrument
-  # rather than three tools. The prefix is `db lock stall NIF CENSUS:` and it
-  # is LOAD-BEARING for the same reason theirs are: `scripts/log-gap-scan.awk`
-  # counts the #1429 census off these literals and
-  # `test/scripts/log_gap_scan_test.bats` pins them verbatim.
+  # 🔴 The roster, VERIFIED — defect 2 of issue 1960, and the sample IS the
+  # verification. `parked_in_nif/0`'s sweep and this read are two instants, and
+  # in prod the gap between them was wide enough that 8 of 11 census lines
+  # printed a cohort whose frames contradicted their own headline:
+  # `:gen_statem.loop_hibernate/3` at 32 s, `DBConnection.Holder.checkout_call/5`
+  # at 2.1 s. `nif_sample/2` decides from the SAME read it builds the sample
+  # from, so a process that has left is DROPPED rather than printed — and the
+  # decision can never disagree with the frame that gets printed, which a third
+  # read would let it do.
   #
-  # 🔴 The ROSTER is why this line is longer than its siblings, and it is the
-  # deliverable rather than verbosity. #1901's acceptance test is that the log
-  # NAMES the process holding the lock; this arm cannot label which of the
-  # cohort that is, so it names every one of them — pid, elapsed and frame —
-  # and pays the full twelve-frame stack only for the longest. An operator who
-  # has the roster can cross it against the `fault=busy_locked` terminals the
-  # victims emit and read the holder off the difference; an operator with one
-  # sample cannot.
-  @spec report_nif_census([{pid(), non_neg_integer()}]) :: :ok
-  defp report_nif_census([]), do: :ok
-
-  defp report_nif_census(due) do
-    samples =
-      due |> Enum.map(fn {pid, elapsed} -> sample(pid, elapsed) end) |> Enum.sort_by(& &1.elapsed_ms, :desc)
-
-    longest = hd(samples)
-    %{holders: holders, waiters: waiters} = lock_roles()
-    due_pids = MapSet.new(due, &elem(&1, 0))
-    registered_holders = Enum.count(holders, &MapSet.member?(due_pids, &1))
-    registered_waiters = Enum.count(waiters, &MapSet.member?(due_pids, &1))
-
-    report = %{
-      observed_at: now_iso8601(),
-      parked: samples,
-      registered_holders: registered_holders,
-      registered_waiters: registered_waiters
-    }
-
-    Logger.warning(
-      "db lock stall NIF CENSUS: #{length(samples)} process(es) parked inside " <>
-        "#{inspect(@nif_module)} past the threshold, longest #{longest.elapsed_ms}ms — " <>
-        "#{seam_clause(registered_holders, registered_waiters, length(samples))}; " <>
-        "roster: #{roster(samples)}; longest #{longest.pid} status=#{inspect(longest.status)} " <>
-        "at #{longest.current_function}, stack: #{Enum.join(longest.stacktrace, " <- ")}",
-      parked: length(samples),
-      longest_parked_ms: longest.elapsed_ms
-    )
-
-    :telemetry.execute(
-      [:grappa, :repo, :lock_stall, :nif_census],
-      %{parked_count: length(samples), longest_parked_ms: longest.elapsed_ms},
-      report
-    )
+  # An empty result is a real and frequent outcome (the whole cohort left), and
+  # its caller answers it with silence. That is the noise cure: the line is not
+  # suppressed by a bigger threshold, it is suppressed by having nothing true
+  # left to say.
+  @spec sample_parked([{pid(), non_neg_integer()}]) :: [sample()]
+  defp sample_parked(candidates) do
+    candidates
+    |> Enum.map(fn {pid, elapsed} -> nif_sample(pid, elapsed) end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort_by(& &1.elapsed_ms, :desc)
   end
 
-  # The two sub-cases, named apart because they call for different next moves
-  # — the same split `holder_clause/1` makes one arm up. All-zero is the #1901
-  # finding in one phrase: this system's dominant writer holds the file lock
-  # without ever touching the seam, so widening coverage (axis 2) is the only
-  # thing that would name it. A positive count says the seam DID see some of
-  # them, and the remainder is what it missed.
-  @spec seam_clause(non_neg_integer(), non_neg_integer(), pos_integer()) :: String.t()
-  defp seam_clause(0, 0, total) do
-    "none of them registered at the BEGIN IMMEDIATE seam, so all #{total} are writers it cannot name"
+  @spec nif_sample(pid(), non_neg_integer()) :: sample() | nil
+  defp nif_sample(pid, elapsed_ms) do
+    case Process.info(pid, @sample_keys) do
+      nil -> nil
+      info -> if in_nif?(info), do: build_sample(pid, elapsed_ms, info), else: nil
+    end
   end
 
-  defp seam_clause(holders, waiters, total) do
-    "#{holders} holder(s) and #{waiters} waiter(s) of them registered at the BEGIN IMMEDIATE " <>
-      "seam, #{total - holders - waiters} not"
-  end
+  @spec in_nif?(keyword()) :: boolean()
+  defp in_nif?(info), do: match?({@nif_module, _, _}, Keyword.get(info, :current_function))
 
   # Pid, elapsed and frame for every parked process — no stacks, which ride
   # the telemetry door in full. The frame is in because it is the one field
@@ -1054,9 +1255,14 @@ defmodule Grappa.Repo.LockWatch do
   # here (the holder can die between the scan and the sample), so it folds
   # to an explicit empty sample rather than crashing the watchdog.
   @spec sample(pid(), non_neg_integer()) :: sample()
-  defp sample(pid, elapsed_ms) do
-    info = Process.info(pid, [:current_function, :status, :message_queue_len, :dictionary])
+  defp sample(pid, elapsed_ms), do: build_sample(pid, elapsed_ms, Process.info(pid, @sample_keys))
 
+  # ONE read, every field (issue 1960). The stacktrace used to cost a second
+  # `Process.info/2`, so the frame printed under `at …` and the frames printed
+  # after `stack:` were sampled at two different instants and could describe
+  # two different places. They cannot now.
+  @spec build_sample(pid(), non_neg_integer(), keyword() | nil) :: sample()
+  defp build_sample(pid, elapsed_ms, info) do
     %{
       pid: inspect(pid),
       elapsed_ms: elapsed_ms,
@@ -1064,23 +1270,21 @@ defmodule Grappa.Repo.LockWatch do
       status: info && Keyword.get(info, :status),
       message_queue_len: info && Keyword.get(info, :message_queue_len),
       initial_call: format_mfa(initial_call(info)),
-      stacktrace: stacktrace(pid)
+      stacktrace: format_frames(frames(info))
     }
   end
+
+  # `nil` for a dead pid folds to no frames, exactly as the dedicated
+  # `Process.info(pid, :current_stacktrace)` call it replaces did.
+  @spec frames(keyword() | nil) :: [tuple()]
+  defp frames(nil), do: []
+  defp frames(info), do: Keyword.get(info, :current_stacktrace, [])
 
   @spec initial_call(keyword() | nil) :: mfa() | nil
   defp initial_call(nil), do: nil
 
   defp initial_call(info) do
     info |> Keyword.get(:dictionary, []) |> Keyword.get(:"$initial_call")
-  end
-
-  @spec stacktrace(pid()) :: [String.t()]
-  defp stacktrace(pid) do
-    case Process.info(pid, :current_stacktrace) do
-      {:current_stacktrace, frames} -> format_frames(frames)
-      nil -> []
-    end
   end
 
   # #1888 — the release-time identity, read from the releasing process's OWN

--- a/scripts/log-gap-scan.awk
+++ b/scripts/log-gap-scan.awk
@@ -66,7 +66,9 @@
 #   * known answer — each sample raises its OWN counter exactly once, and
 #     no other (so a pattern that swallows a sibling's line is caught:
 #     `db lock stall` matches the RESOLVED line too, which is the exact
-#     trap these three counters walked into).
+#     trap these counters walked into — and since issue 1960 folded the
+#     three opening arms onto ONE prefix, it is the whole reason they key
+#     on `attribution=` and not on the prefix).
 #   * invented line — a line no signature describes raises nothing.
 #   * complete set — every registered signature reaches the SUMMARY line
 #     with its known answer, and the SUMMARY declares no `key=` field that
@@ -117,23 +119,20 @@ function count_signatures(line) {
     # control below is what proves the guard lets them through.
     if (index(line, "lock") > 0) {
         if (line ~ /write lock held by another writer/) CNT["lockheld"]++
-        if (line ~ /db lock stall: holder /) CNT["lockstall"]++
+        # 🔴 issue 1960 — the three opening arms became ONE prefix carrying an
+        # `attribution=` field, so the INPUT of these three counters moved from
+        # three literals to one literal plus a value. The OUTPUT contract does
+        # NOT move: the #1429 census reads `lockstall`, `lockstall_unattributed`
+        # and `lockstall_nif` off the summary line, and the discrimination they
+        # express — a holder was NAMED, versus a queue was measured with nobody
+        # to blame, versus neither was established and a cohort was
+        # photographed — is exactly what `attribution` now spells out. Folding
+        # them into one counter would let an episode the instrument could not
+        # attribute be read off the artefact as one it did.
+        if (line ~ /db lock stall: attribution=named/) CNT["lockstall"]++
+        if (line ~ /db lock stall: attribution=none/) CNT["lockstall_unattributed"]++
+        if (line ~ /db lock stall: attribution=cohort/) CNT["lockstall_nif"]++
         if (line ~ /db lock stall RESOLVED/) CNT["lockstall_resolved"]++
-        # #1687 — the third LockWatch edge. Its own counter, not folded into
-        # `lockstall`: that one means "a holder was NAMED", and the whole
-        # point of this one is that nobody could be. Folding them would let
-        # an episode the instrument could not attribute be read off the
-        # artefact as one it did.
-        if (line ~ /db lock stall UNATTRIBUTED/) CNT["lockstall_unattributed"]++
-        # #1901 — LockWatch's fourth edge, and the only one taken WITHOUT
-        # reading the BEGIN IMMEDIATE seam: a roster of the processes sitting
-        # inside the SQLite NIF. Its own counter for the reason the two above
-        # have theirs, one step further out — `lockstall` means a holder was
-        # NAMED and `lockstall_unattributed` means a QUEUE was measured with
-        # nobody to blame, while this one means neither was established and a
-        # cohort was photographed instead. Folding it into either would let a
-        # census be read off the artefact as an attribution.
-        if (line ~ /db lock stall NIF CENSUS/) CNT["lockstall_nif"]++
     }
 }
 
@@ -245,13 +244,16 @@ BEGIN {
     #                      counts the non-scrollback write paths, which emit
     #                      no `dropped` line of their own.
     #   lockheld           — Repo.BusyRetry, busy_locked arm (#1420).
-    #   lockstall{,_resolved} — Grappa.Repo.LockWatch's two episode edges.
-    #   lockstall_unattributed — LockWatch's third edge (#1687): a queue past
+    #   lockstall{,_resolved} — Grappa.Repo.LockWatch's two episode edges. Since
+    #                      issue 1960 `lockstall` counts `attribution=named`:
+    #                      one prefix, one field, same meaning as before —
+    #                      a holder was NAMED.
+    #   lockstall_unattributed — `attribution=none` (#1687): a queue past
     #                      the threshold that named nobody. It counted ZERO
     #                      through the whole 2026-08-22 prod episode because
     #                      the line did not exist; a census blind to it reads
     #                      exactly like a clean run.
-    #   lockstall_nif      — LockWatch's fourth edge (#1901): the roster of
+    #   lockstall_nif      — `attribution=cohort` (#1901): the roster of
     #                      processes inside `Exqlite.Sqlite3NIF` past the
     #                      threshold. It is the ONLY lock signature that does
     #                      not depend on a writer having gone through the
@@ -275,21 +277,27 @@ BEGIN {
         "db write unavailable: SQLite write lock held by another writer for 30067ms" \
         " across 1 attempts (1500ms retry budget) — returning :db_unavailable")
     sig("lockstall", \
-        "db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2" \
-        " waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: …")
+        "db lock stall: attribution=named, holder #PID<0.512.0> has held RESERVED for" \
+        " 30123ms — 1 holder(s) / 2 waiter(s) registered at the seam, 0 process(es) parked" \
+        " inside Exqlite.Sqlite3NIF; subject #PID<0.512.0> status=:runnable at" \
+        " :gen_server.loop/7, stack: …")
     sig("lockstall_resolved", \
         "db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms")
     sig("lockstall_unattributed", \
-        "db lock stall UNATTRIBUTED: 3 writer(s) queued past the threshold, longest" \
-        " 31303ms — no holder registered, so the holder is NOT attributable at the" \
-        " BEGIN IMMEDIATE seam; longest waiter #PID<0.512.0> status=:waiting at" \
+        "db lock stall: attribution=none, longest writer queued at the seam for 31303ms —" \
+        " no holder registered, so the holder is NOT attributable at the BEGIN IMMEDIATE" \
+        " seam — 0 holder(s) / 3 waiter(s) registered at the seam, 0 process(es) parked" \
+        " inside Exqlite.Sqlite3NIF; subject #PID<0.512.0> status=:waiting at" \
         " :gen_server.loop/7, stack: …")
     sig("lockstall_nif", \
-        "db lock stall NIF CENSUS: 2 process(es) parked inside Exqlite.Sqlite3NIF past the" \
-        " threshold, longest 31402ms — none of them registered at the BEGIN IMMEDIATE seam," \
-        " so all 2 are writers it cannot name; roster: #PID<0.512.0> 31402ms" \
-        " Exqlite.Sqlite3NIF.step/2, #PID<0.513.0> 30011ms Exqlite.Sqlite3NIF.execute/2;" \
-        " longest #PID<0.512.0> status=:running at Exqlite.Sqlite3NIF.step/2, stack: …")
+        "db lock stall: attribution=cohort, longest process parked inside" \
+        " Exqlite.Sqlite3NIF for 31402ms — nothing registered at the seam, and nothing" \
+        " BEAM-visible says which of the cohort holds the lock — 0 holder(s) / 0 waiter(s)" \
+        " registered at the seam, 2 process(es) parked inside Exqlite.Sqlite3NIF; none of" \
+        " them registered at the BEGIN IMMEDIATE seam, so all 2 are writers it cannot name;" \
+        " roster: #PID<0.512.0> 31402ms Exqlite.Sqlite3NIF.step/2, #PID<0.513.0> 30011ms" \
+        " Exqlite.Sqlite3NIF.execute/2; subject #PID<0.512.0> status=:running at" \
+        " Exqlite.Sqlite3NIF.step/2, stack: …")
 
     # Deliberately ordinary: a real line from the same stream that names
     # none of the signatures. It DOES carry the word "lock" so the

--- a/test/grappa/db_latency_test.exs
+++ b/test/grappa/db_latency_test.exs
@@ -16,6 +16,7 @@ defmodule Grappa.DbLatencyTest do
   use ExUnit.Case, async: false
 
   alias Grappa.DbLatency
+  alias Grappa.Repo.LockWatch
 
   @handler_id "grappa-db-latency"
 
@@ -32,14 +33,91 @@ defmodule Grappa.DbLatencyTest do
     [:grappa, :session, :send_privmsg, :stop],
     [:grappa, :scrollback, :persist, :contention],
     [:grappa, :repo, :lock_stall, :detected],
-    [:grappa, :repo, :lock_stall, :resolved],
-    [:grappa, :repo, :lock_stall, :unattributed],
-    [:grappa, :repo, :lock_stall, :nif_census]
+    [:grappa, :repo, :lock_stall, :resolved]
   ]
 
   # Native-unit duration for a whole number of milliseconds, via the
   # production conversion (never hardcode the native tick rate).
   defp ms(n), do: System.convert_time_unit(n, :millisecond, :native)
+
+  # 🔴 issue 1960 — the three verdicts share ONE event, so their payloads share
+  # one shape and differ only where the verdict differs. Written out as
+  # literals, INDEPENDENTLY of `Grappa.Repo.LockWatch`, on the same reasoning
+  # as `@events` above: deriving them from the emitter would make every
+  # assertion below a tautology, and the shape is exactly what this file is
+  # for. Realistic values throughout — a stall this sink has actually seen in
+  # prod, not zeroes that pass while validating nothing.
+  defp detected_measurements, do: %{elapsed_ms: 2_400, waiter_count: 2, parked_count: 0}
+
+  defp named_metadata do
+    %{
+      observed_at: "2026-09-01T10:06:57.328000Z",
+      attribution: :named,
+      subject: %{pid: "#PID<0.111.0>", elapsed_ms: 2_400, stacktrace: ["Foo.bar/1"]},
+      holders: 1,
+      waiters: [%{pid: "#PID<0.222.0>"}, %{pid: "#PID<0.333.0>"}],
+      parked: [],
+      registered_holders: 0,
+      registered_waiters: 0
+    }
+  end
+
+  defp none_measurements, do: %{elapsed_ms: 31_303, waiter_count: 3, parked_count: 0}
+
+  defp none_metadata do
+    %{
+      observed_at: "2026-09-01T10:07:28.554000Z",
+      attribution: :none,
+      subject: %{pid: "#PID<0.222.0>", elapsed_ms: 31_303, stacktrace: ["Exqlite.Sqlite3NIF.step/2"]},
+      holders: 0,
+      waiters: [
+        %{pid: "#PID<0.222.0>", elapsed_ms: 31_303, stacktrace: ["Exqlite.Sqlite3NIF.step/2"]},
+        %{pid: "#PID<0.333.0>", elapsed_ms: 2_100},
+        %{pid: "#PID<0.444.0>", elapsed_ms: 2_050}
+      ],
+      parked: [],
+      registered_holders: 0,
+      registered_waiters: 0
+    }
+  end
+
+  defp cohort_measurements, do: %{elapsed_ms: 31_402, waiter_count: 0, parked_count: 2}
+
+  defp cohort_metadata do
+    parked = [
+      %{
+        pid: "#PID<0.222.0>",
+        elapsed_ms: 31_402,
+        current_function: "Exqlite.Sqlite3NIF.step/2",
+        stacktrace: ["Grappa.Scrollback.persist_row/1"]
+      },
+      %{pid: "#PID<0.333.0>", elapsed_ms: 30_011, current_function: "Exqlite.Sqlite3NIF.execute/2"}
+    ]
+
+    %{
+      observed_at: "2026-09-01T10:07:28.554000Z",
+      attribution: :cohort,
+      subject: hd(parked),
+      holders: 0,
+      waiters: [],
+      parked: parked,
+      registered_holders: 0,
+      registered_waiters: 1
+    }
+  end
+
+  defp resolved_metadata do
+    %{
+      observed_at: "2026-09-01T10:07:28.554000Z",
+      holder_pid: "#PID<0.111.0>",
+      announced: true,
+      caller: %{
+        pid: "#PID<0.111.0>",
+        initial_call: "Grappa.Session.Server.init/1",
+        stacktrace: ["Grappa.Repo.immediate_transaction/1"]
+      }
+    }
+  end
 
   defp query_row(snapshot, source, op) do
     Enum.find(snapshot.queries, fn r -> r.source == source and r.op == op end)
@@ -259,40 +337,25 @@ defmodule Grappa.DbLatencyTest do
     end
 
     test "[:grappa, :repo, :lock_stall, :*] folds both brackets of an episode, newest first" do
-      :telemetry.execute(
-        [:grappa, :repo, :lock_stall, :detected],
-        %{held_ms: 2_400, waiter_count: 2},
-        %{
-          observed_at: "2026-09-01T10:06:57.328000Z",
-          holder: %{pid: "#PID<0.111.0>", stacktrace: ["Foo.bar/1"]},
-          waiters: [%{pid: "#PID<0.222.0>"}, %{pid: "#PID<0.333.0>"}]
-        }
-      )
-
-      :telemetry.execute(
-        [:grappa, :repo, :lock_stall, :resolved],
-        %{held_ms: 30_120},
-        %{
-          observed_at: "2026-09-01T10:07:28.554000Z",
-          holder_pid: "#PID<0.111.0>",
-          announced: true,
-          caller: %{
-            pid: "#PID<0.111.0>",
-            initial_call: "Grappa.Session.Server.init/1",
-            stacktrace: ["Grappa.Repo.immediate_transaction/1"]
-          }
-        }
-      )
+      :telemetry.execute([:grappa, :repo, :lock_stall, :detected], detected_measurements(), named_metadata())
+      :telemetry.execute([:grappa, :repo, :lock_stall, :resolved], %{held_ms: 30_120}, resolved_metadata())
 
       assert [resolved, detected] = DbLatency.snapshot().lock_stalls
 
       # Newest first: an operator reading a live incident wants the last
       # thing that happened at the top, not to scroll a boot-long history.
       assert resolved.phase == :resolved
-      assert resolved.held_ms == 30_120
-      assert resolved.holder == nil
+      assert resolved.elapsed_ms == 30_120
+      assert resolved.subject == nil
 
-      # #1888 — `holder` stays nil (a `sample()` means "sampled while it
+      # issue 1960 — `attribution` is nil on the closing bracket, and that is
+      # not an omission: at release the row IS the holder's own, so the
+      # question the field answers does not arise. A mutant that defaults it
+      # to `:named` would let a reader believe the watchdog attributed an
+      # episode it may never have announced at all.
+      assert resolved.attribution == nil
+
+      # #1888 — `subject` stays nil (a `sample()` means "sampled while it
       # stalled", and by release there is no pause site left to sample) while
       # `caller` carries the write path that held the lock. Two different
       # facts, two different keys: folding them would let a release-time stack
@@ -305,8 +368,9 @@ defmodule Grappa.DbLatencyTest do
       assert resolved.waiter_count == nil
 
       assert detected.phase == :detected
+      assert detected.attribution == :named
       assert detected.waiter_count == 2
-      assert detected.holder.stacktrace == ["Foo.bar/1"]
+      assert detected.subject.stacktrace == ["Foo.bar/1"]
       assert length(detected.waiters) == 2
 
       # The instant, on both edges: a ring row that cannot be aligned with
@@ -315,38 +379,38 @@ defmodule Grappa.DbLatencyTest do
       assert detected.observed_at == "2026-09-01T10:06:57.328000Z"
     end
 
-    test "[:grappa, :repo, :lock_stall, :unattributed] folds with an explicit nil where the holder would be" do
-      :telemetry.execute(
-        [:grappa, :repo, :lock_stall, :unattributed],
-        %{waiter_count: 3, longest_wait_ms: 31_303},
-        %{
-          observed_at: "2026-09-01T10:07:28.554000Z",
-          holders_registered: 0,
-          waiters: [
-            %{pid: "#PID<0.222.0>", elapsed_ms: 31_303, stacktrace: ["Exqlite.Sqlite3NIF.step/2"]},
-            %{pid: "#PID<0.333.0>", elapsed_ms: 2_100},
-            %{pid: "#PID<0.444.0>", elapsed_ms: 2_050}
-          ]
-        }
-      )
+    # 🔴 issue 1960 replaced the `:unattributed` PHASE with an `attribution`
+    # field, and this test is the same claim it always made: a queue past the
+    # threshold that could name nobody must not acquire a holder on its way
+    # into the ring. What changed is where the honesty lives — the row no
+    # longer says "nobody was named" by leaving `holder_pid` empty, it says it
+    # in a field, which is stronger because an empty column and an unset
+    # column are indistinguishable to a reader.
+    test "[:grappa, :repo, :lock_stall, :detected] with attribution :none names nobody as the holder" do
+      :telemetry.execute([:grappa, :repo, :lock_stall, :detected], none_measurements(), none_metadata())
 
       assert [row] = DbLatency.snapshot().lock_stalls
 
-      assert row.phase == :unattributed
+      assert row.phase == :detected
+      assert row.attribution == :none
       assert row.waiter_count == 3
 
-      # 🔴 The two nils are the POINT, not an omission. CLAUDE.md's admin rule
-      # — an explicit null is the honesty signal, never papered over with a
-      # computed field — lands exactly here: a `held_ms: 0` would assert a
-      # measured hold of zero, and a synthesised `holder_pid` would name
-      # somebody. A mutant that defaults either one dies on these two lines.
-      assert row.holder_pid == nil
-      assert row.held_ms == nil
-      assert row.holder == nil
+      # 🔴 The honesty pair. CLAUDE.md's admin rule — an explicit null is the
+      # signal, never papered over with a computed field — lands here: a
+      # synthesised holder would name somebody nothing measured, and
+      # `holders: 0` is the number that says the SEAM saw no holder at all
+      # (as opposed to seeing one that had not crossed the threshold).
+      assert row.holders == 0
+      assert row.subject.pid == "#PID<0.222.0>"
 
-      # #1888 — the same rule for the two fields the closing bracket adds.
-      # Nothing here released a hold, so there is no write path to name and no
-      # announcement to report; both stay explicitly absent.
+      # `elapsed_ms` is the subject's, and on this verdict it is a WAIT. The
+      # column carries no hold claim of its own — that is the #1687 ruling,
+      # and `attribution` above is what makes reading it unambiguous.
+      assert row.elapsed_ms == 31_303
+
+      # #1888 — the two fields only a closing bracket can answer. Nothing here
+      # released a hold, so there is no write path to name and no announcement
+      # to report; both stay explicitly absent.
       assert row.caller == nil
       assert row.announced == nil
 
@@ -357,57 +421,75 @@ defmodule Grappa.DbLatencyTest do
       assert hd(row.waiters).stacktrace == ["Exqlite.Sqlite3NIF.step/2"]
     end
 
-    test "[:grappa, :repo, :lock_stall, :nif_census] folds the roster, and names nobody as the holder" do
-      :telemetry.execute(
-        [:grappa, :repo, :lock_stall, :nif_census],
-        %{parked_count: 2, longest_parked_ms: 31_402},
-        %{
-          observed_at: "2026-09-01T10:07:28.554000Z",
-          registered_holders: 0,
-          registered_waiters: 1,
-          parked: [
-            %{
-              pid: "#PID<0.222.0>",
-              elapsed_ms: 31_402,
-              current_function: "Exqlite.Sqlite3NIF.step/2",
-              stacktrace: ["Grappa.Scrollback.persist_row/1"]
-            },
-            %{pid: "#PID<0.333.0>", elapsed_ms: 30_011, current_function: "Exqlite.Sqlite3NIF.execute/2"}
-          ]
-        }
-      )
+    test "[:grappa, :repo, :lock_stall, :detected] with attribution :cohort folds the roster" do
+      :telemetry.execute([:grappa, :repo, :lock_stall, :detected], cohort_measurements(), cohort_metadata())
 
       assert [row] = DbLatency.snapshot().lock_stalls
 
-      assert row.phase == :nif_census
+      assert row.phase == :detected
+      assert row.attribution == :cohort
       assert row.observed_at == "2026-09-01T10:07:28.554000Z"
 
-      # 🔴 `holder_pid: nil` is a STRONGER statement here than on the
-      # `:unattributed` row, and a mutant that fills it in — say with the
-      # longest-parked pid, which is the plausible guess — dies here. On this
-      # phase a holder is certainly among `parked`; the instrument simply
+      # 🔴 `:cohort` is a STRONGER refusal than `:none`, and a mutant that
+      # promotes the longest-parked process to a holder — the plausible guess,
+      # and the one #1901's acceptance criterion invites — dies on this
+      # equality. A holder is certainly among `parked`; the instrument simply
       # cannot say which, because exqlite's busy handler sleeps inside the
-      # same dirty-IO NIF the lock holder is executing in.
-      assert row.holder_pid == nil
-      assert row.held_ms == nil
-      assert row.holder == nil
+      # same dirty-IO NIF the lock holder is executing in. Naming the SUBJECT
+      # is not naming the holder, and `attribution` is what keeps the two
+      # apart in the row as the prose keeps them apart in the line.
+      assert row.subject.pid == "#PID<0.222.0>"
+      assert row.holders == 0
       assert row.caller == nil
       assert row.announced == nil
 
-      # A census counts no QUEUE. `parked_count` is a different measurement
+      # The cohort counts no QUEUE. `parked_count` is a different measurement
       # and rides the measurements map, exactly as #1687 refused to reuse
-      # `held_ms` for a longest WAIT. A mutant that copies `parked_count` in
-      # here reports two blocked writers where nobody measured one.
-      assert row.waiter_count == nil
+      # `held_ms` for a longest WAIT. A mutant that copies `parked_count` into
+      # the queue column reports two blocked writers where nobody measured one.
+      assert row.waiter_count == 0
       assert row.waiters == []
 
       # The roster IS the payload, and the counts are what tell an operator
-      # whether to widen coverage or to scroll up to a line the other two
-      # arms already printed.
+      # whether to widen coverage or to read the seam numbers on the same line.
       assert length(row.parked) == 2
       assert hd(row.parked).stacktrace == ["Grappa.Scrollback.persist_row/1"]
       assert row.registered_holders == 0
       assert row.registered_waiters == 1
+    end
+
+    # 🔴 THE VOID CONTROL (issue 1960, and it is why this test is not a
+    # duplicate of the drift test below).
+    #
+    # `fold/4` has NO catch-all, so the two failure modes are asymmetric and
+    # only one of them is loud. An event attached with no clause CRASHES the
+    # singleton — noisy, findable. A clause left attached with no EMITTER
+    # folds nothing, in silence, and the ring quietly stops filling: exactly
+    # what happened while #1901 was being built. Pruning two emitters here is
+    # the move that can reproduce it, so both directions get a control.
+    test "no lock-stall event is attached without an emitter, and none is emitted without a fold" do
+      # NEGATIVE — derived from the EMITTER, so an event this sink attaches
+      # after LockWatch stops emitting it is red rather than silent.
+      attached = Enum.filter(DbLatency.attached_events(), &match?([:grappa, :repo, :lock_stall, _], &1))
+
+      assert Enum.sort(attached) == Enum.sort(LockWatch.emitted_events())
+
+      # POSITIVE — every one of them, driven with a realistic payload, lands a
+      # ring row. That is what a set equality alone cannot show: the event can
+      # be attached, present in `@events`, and still fold nothing.
+      for {event, measurements, metadata} <- [
+            {[:grappa, :repo, :lock_stall, :detected], detected_measurements(), named_metadata()},
+            {[:grappa, :repo, :lock_stall, :resolved], %{held_ms: 30_120}, resolved_metadata()}
+          ] do
+        :ok = DbLatency.reset()
+        :telemetry.execute(event, measurements, metadata)
+
+        # `match?/2` and not `assert [_] = …`: a match assertion discards the
+        # custom message, and the whole value of this control is that the
+        # failure NAMES the event that folded nothing.
+        assert match?([_], DbLatency.snapshot().lock_stalls),
+               "#{inspect(event)} is attached but folded no ring row"
+      end
     end
 
     test "the lock-stall ring is bounded, keeping the newest episodes" do
@@ -429,8 +511,8 @@ defmodule Grappa.DbLatencyTest do
       # These rows carry sampled stacktraces; unbounded, they would grow the
       # singleton's heap for as long as the node lives.
       assert length(stalls) == 20
-      assert hd(stalls).held_ms == 25
-      assert List.last(stalls).held_ms == 6
+      assert hd(stalls).elapsed_ms == 25
+      assert List.last(stalls).elapsed_ms == 6
     end
 
     test "reset/0 zeroes accumulated state" do

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -289,8 +289,8 @@ defmodule Grappa.OperatorTest do
           @db_latency_handler_id,
           [
             [:grappa, :repo, :query],
-            [:grappa, :repo, :lock_stall, :resolved],
-            [:grappa, :repo, :lock_stall, :nif_census]
+            [:grappa, :repo, :lock_stall, :detected],
+            [:grappa, :repo, :lock_stall, :resolved]
           ],
           &DbLatency.handle_telemetry/4,
           nil
@@ -358,8 +358,13 @@ defmodule Grappa.OperatorTest do
 
       output = capture_io(fn -> assert :ok = Operator.db_latency_text!() end)
 
-      assert output =~ "resolved\tat=2026-09-01T10:07:28.554000Z\tholder=#PID<0.512.0>"
-      assert output =~ "held_ms=31295"
+      # issue 1960 — `attribution` is absent on a closing bracket, so the phase
+      # column carries no suffix. A mutant that prints `resolved/named` there
+      # would tell an operator the watchdog attributed an episode that, per the
+      # `announced=NO` below, it never announced at all.
+      assert output =~ "resolved\tat=2026-09-01T10:07:28.554000Z\tsubject=#PID<0.512.0>"
+      assert output =~ "elapsed_ms=31295"
+      refute output =~ "resolved/"
 
       # `waiters=0` would assert a queue was counted and found empty; the
       # closing bracket counts none. `announced=NO` is the #1888 finding: this
@@ -375,24 +380,44 @@ defmodule Grappa.OperatorTest do
       refute output =~ "holder at"
     end
 
-    test "a NIF census renders its roster and refuses to name a holder (#1901)" do
+    test "a cohort verdict renders its roster and refuses to name a holder (#1901)" do
       # The CLI is the door an operator reaches for mid-incident, and this
-      # phase carries nil in every seam-derived column. Until it is rendered
+      # verdict carries nil in every seam-derived column. Until it is rendered
       # once in a test, the first `bin/grappa db-latency` of a real freeze is
       # where a nil would surface — as a crash, during the exact incident the
-      # arm was added to diagnose. That is the #1888 lesson applied one phase
+      # arm was added to diagnose. That is the #1888 lesson applied one verdict
       # later rather than relearned.
+      parked = [
+        %{
+          pid: "#PID<0.222.0>",
+          elapsed_ms: 31_402,
+          current_function: "Exqlite.Sqlite3NIF.step/2",
+          status: :running,
+          message_queue_len: 0,
+          stacktrace: []
+        },
+        %{
+          pid: "#PID<0.333.0>",
+          elapsed_ms: 30_011,
+          current_function: "Exqlite.Sqlite3NIF.execute/2",
+          status: :running,
+          message_queue_len: 0,
+          stacktrace: []
+        }
+      ]
+
       :telemetry.execute(
-        [:grappa, :repo, :lock_stall, :nif_census],
-        %{parked_count: 2, longest_parked_ms: 31_402},
+        [:grappa, :repo, :lock_stall, :detected],
+        %{elapsed_ms: 31_402, waiter_count: 0, parked_count: 2},
         %{
           observed_at: "2026-09-01T10:07:28.554000Z",
+          attribution: :cohort,
+          subject: hd(parked),
+          holders: 0,
+          waiters: [],
+          parked: parked,
           registered_holders: 0,
-          registered_waiters: 1,
-          parked: [
-            %{pid: "#PID<0.222.0>", elapsed_ms: 31_402, current_function: "Exqlite.Sqlite3NIF.step/2"},
-            %{pid: "#PID<0.333.0>", elapsed_ms: 30_011, current_function: "Exqlite.Sqlite3NIF.execute/2"}
-          ]
+          registered_waiters: 1
         }
       )
 
@@ -401,21 +426,30 @@ defmodule Grappa.OperatorTest do
 
       output = capture_io(fn -> assert :ok = Operator.db_latency_text!() end)
 
-      assert output =~ "nif_census\tat=2026-09-01T10:07:28.554000Z\tholder=unattributed"
+      # issue 1960 — the verdict is a suffix on the phase column, so `detected`
+      # alone no longer says what was attributed. A mutant that drops the
+      # suffix renders three different findings under one indistinguishable
+      # label, which is the correlate-by-timestamp reading the fold removed.
+      assert output =~ "detected/cohort\tat=2026-09-01T10:07:28.554000Z\tsubject=#PID<0.222.0>"
 
       # `parked=` and `waiters=` are two different questions and the row has
       # to keep them apart: two processes were in the NIF, and NOBODY counted
       # a queue. A mutant rendering the roster length as `waiters=` reads as
-      # two blocked writers, which is a claim this phase never made.
-      assert output =~ "waiters=not counted"
+      # two blocked writers, which is a claim this verdict never made.
+      assert output =~ "waiters=0"
       assert output =~ "parked=2"
       assert output =~ "registered=0h/1w"
 
-      # The roster itself, under its own wording — "parked ... in the NIF",
-      # never the DETECTED block's "holder at", which names a pause site the
-      # instrument attributed to one process.
+      # The roster itself, under its own wording — "parked ... in the NIF".
       assert output =~ "parked #PID<0.222.0> in the NIF 31402ms at Exqlite.Sqlite3NIF.step/2"
       assert output =~ "parked #PID<0.333.0> in the NIF 30011ms at Exqlite.Sqlite3NIF.execute/2"
+
+      # 🔴 The load-bearing negative, and issue 1960 makes it harder to keep
+      # than it was. One row shape now serves three verdicts, so the SUBJECT
+      # block is rendered here too — and rendering it under the old `holder at`
+      # wording would hand an operator a holder to blame on the one verdict
+      # that explicitly cannot name one. The label has to follow the verdict.
+      assert output =~ "longest parked at Exqlite.Sqlite3NIF.step/2"
       refute output =~ "holder at"
     end
   end

--- a/test/grappa/repo/lock_watch_report_test.exs
+++ b/test/grappa/repo/lock_watch_report_test.exs
@@ -48,9 +48,13 @@ defmodule Grappa.Repo.LockWatchReportTest do
 
     await_roles(holder, waiter)
 
-    log = capture_log(fn -> LockWatch.scan(0) end)
+    log = capture_log(fn -> LockWatch.scan(%{}, 0) end)
 
-    assert log =~ "db lock stall: holder #{inspect(holder)}"
+    # issue 1960 — the prefix is now one literal for one phenomenon and the
+    # verdict rides an `attribution=` field. Pinning both is strictly more than
+    # the old `"db lock stall: holder …"`: a mutant that keeps the prose but
+    # mislabels the verdict now dies here too.
+    assert log =~ "db lock stall: attribution=named, holder #{inspect(holder)}"
 
     # A mutant that drops the field — i.e. the message as it stood before
     # #1420b — dies here and nowhere else. The value is `:waiting` and not
@@ -60,15 +64,50 @@ defmodule Grappa.Repo.LockWatchReportTest do
     assert log =~ "status=:waiting"
   end
 
-  test "the UNATTRIBUTED warning refuses to name a holder, and says which kind of silence it is" do
+  # 🔴 issue 1960, defect 1 — the five prod episodes of 2026-09-06 that closed
+  # with `NEVER announced while it held`. `report_stalls(_, [])` returned `:ok`
+  # for a holder past the threshold whenever no WAITER was registered, and the
+  # watch table has one producer (`Repo.immediate_transaction/1`), so every
+  # autocommit writer queued behind that holder is invisible to the gate. The
+  # instrument had the pid and the stack in hand and printed nothing until
+  # release — i.e. exactly when the operator no longer needs it.
+  #
+  # The closing bracket already reports on the hold ALONE (#1888:
+  # `close_episode/1` fires on `announced or past_threshold?`, with no waiter
+  # conjunct). The opening line requiring a queue was the asymmetry, and one
+  # threshold policy is what removes it.
+  test "a holder past the threshold is announced WHILE it holds, with no waiter registered at the seam" do
+    holder = start_role(:holder)
+
+    await_holder_only(holder)
+
+    log = capture_log(fn -> LockWatch.scan(%{}, 0) end)
+
+    assert log =~ "db lock stall: attribution=named"
+    assert log =~ "holder #{inspect(holder)}"
+    assert log =~ "has held RESERVED"
+
+    # The honesty half, and it is what keeps the cure from being "print
+    # something". Nothing was queued at the seam and nothing was parked in the
+    # NIF, so the line must SAY zero rather than imply a queue it never
+    # measured — a mutant that hardcodes the old "with N waiter(s) queued"
+    # prose against an empty queue dies here.
+    assert log =~ "1 holder(s) / 0 waiter(s) registered at the seam"
+    assert log =~ "0 process(es) parked inside Exqlite.Sqlite3NIF"
+  end
+
+  test "the unattributed verdict refuses to name a holder, and says which kind of silence it is" do
     waiter = start_role(:waiter)
 
     await_queue_only(waiter)
 
-    log = capture_log(fn -> LockWatch.scan(0) end)
+    log = capture_log(fn -> LockWatch.scan(%{}, 0) end)
 
-    # #1687 — in prod this was the empty string for ~170 seconds.
-    assert log =~ "db lock stall UNATTRIBUTED: 1 writer(s) queued past the threshold"
+    # #1687 — in prod this was the empty string for ~170 seconds. issue 1960
+    # moved the count out of the headline and into the seam clause every
+    # verdict carries, so both halves are pinned: the verdict AND the number.
+    assert log =~ "db lock stall: attribution=none, longest writer queued at the seam for"
+    assert log =~ "0 holder(s) / 1 waiter(s) registered at the seam"
     assert log =~ "no holder registered"
 
     # 🔴 The load-bearing negative. The issue's own wording ("holder
@@ -82,8 +121,10 @@ defmodule Grappa.Repo.LockWatchReportTest do
 
     # What it CAN vouch for: which waiter, and where it is parked — the one
     # field that separates "blocked on the lock" from "queued for a
-    # connection" without guessing between them.
-    assert log =~ "longest waiter #{inspect(waiter)}"
+    # connection" without guessing between them. The role that used to be in
+    # the words `longest waiter` is now the `attribution=none` asserted above,
+    # so the pair says what the single literal said.
+    assert log =~ "subject #{inspect(waiter)}"
     assert log =~ "status=:waiting"
   end
 
@@ -106,7 +147,7 @@ defmodule Grappa.Repo.LockWatchReportTest do
     # between the reading and the scan on the next line.
     {holder_ms, waiter_ms} = await_gap(holder, waiter, 100)
 
-    log = capture_log(fn -> LockWatch.scan(holder_ms + 50) end)
+    log = capture_log(fn -> LockWatch.scan(%{}, holder_ms + 50) end)
 
     assert waiter_ms > holder_ms + 100
 
@@ -115,7 +156,7 @@ defmodule Grappa.Repo.LockWatchReportTest do
     # described, cannot tell an operator whether the seam is working. These
     # two sub-cases call for opposite next moves: widen coverage, versus
     # nothing at all because the queue is simply older than the holder.
-    assert log =~ "db lock stall UNATTRIBUTED"
+    assert log =~ "db lock stall: attribution=none"
     assert log =~ "1 holder(s) registered, none past the threshold"
     refute log =~ "no holder registered"
   end
@@ -152,6 +193,26 @@ defmodule Grappa.Repo.LockWatchReportTest do
   defp park do
     receive do
       :never -> :ok
+    end
+  end
+
+  # issue 1960 — the mirror of `await_queue_only/1`: a holder with NOTHING
+  # queued behind it. Same discipline; the `send` proves the process reached
+  # `observe/1`, not that its ETS row has been promoted to `:holding` yet.
+  defp await_holder_only(holder), do: await_holder_only(holder, 300)
+
+  defp await_holder_only(holder, 0) do
+    flunk("holder never settled: #{inspect(LockWatch.inspect_lock())} (#{inspect(holder)})")
+  end
+
+  defp await_holder_only(holder, attempts) do
+    %{holders: holders, waiters: waiters} = LockWatch.inspect_lock()
+
+    if waiters == [] and Enum.map(holders, & &1.pid) == [inspect(holder)] do
+      :ok
+    else
+      Process.sleep(10)
+      await_holder_only(holder, attempts - 1)
     end
   end
 

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -17,7 +17,7 @@ defmodule Grappa.Repo.LockWatchTest do
 
   ## Why the detection pass is driven, not awaited
 
-  `LockWatch.scan/1` is called directly instead of waiting for the
+  `LockWatch.scan/2` is called directly instead of waiting for the
   watchdog's tick. A test that sleeps past a tick interval measures the
   scheduler as much as the code; driving the pass makes the assertions
   deterministic under `--repeat-each`. The barrier before each scan is a
@@ -40,9 +40,7 @@ defmodule Grappa.Repo.LockWatchTest do
   end
 
   @detected [:grappa, :repo, :lock_stall, :detected]
-  @unattributed [:grappa, :repo, :lock_stall, :unattributed]
   @resolved [:grappa, :repo, :lock_stall, :resolved]
-  @nif_census [:grappa, :repo, :lock_stall, :nif_census]
 
   # 🔴 TWO CLOCKS BOUND EVERY TEST HERE, AND THEY HAVE TO BE ORDERED.
   #
@@ -139,24 +137,21 @@ defmodule Grappa.Repo.LockWatchTest do
     handler = "lock-watch-test-#{System.unique_integer([:positive])}"
     test_pid = self()
 
-    # Every door on ONE handler, tagged by event: a test that asserts the
-    # attributed line fired must also be able to REFUTE the unattributed one
-    # (and vice versa). Two separate handlers would let a mutant that emits
-    # both pass every assertion in the file. #1888 adds the closing bracket
-    # for the same reason — a test that asserts an episode brackets must be
-    # able to refute that it brackets when it should not. #1901 adds the NIF
-    # census on the same reasoning: it is a THIRD verdict about the same lock,
-    # and a mutant routing a seam-attributable stall through it (or the other
-    # way round) has to die on a refutation somewhere.
+    # Both edges of an episode on ONE handler, tagged by event. Since issue
+    # 1960 the three OPENING arms are one event carrying `attribution`, so the
+    # discrimination that used to be "which message arrived" is now "which
+    # value the message carries" — the same mutants have to die, and they die
+    # on an equality rather than on a `refute_receive`. Keeping the closing
+    # bracket on the same handler is unchanged and for the original reason: a
+    # test that asserts an episode brackets must be able to refute that it
+    # brackets when it should not.
     :ok =
       :telemetry.attach_many(
         handler,
-        [@detected, @unattributed, @resolved, @nif_census],
+        [@detected, @resolved],
         fn
           @detected, measurements, metadata, _ -> send(test_pid, {:stall, measurements, metadata})
-          @unattributed, measurements, metadata, _ -> send(test_pid, {:unattributed, measurements, metadata})
           @resolved, measurements, metadata, _ -> send(test_pid, {:resolved, measurements, metadata})
-          @nif_census, measurements, metadata, _ -> send(test_pid, {:nif_census, measurements, metadata})
         end,
         nil
       )
@@ -177,14 +172,14 @@ defmodule Grappa.Repo.LockWatchTest do
 
       await_roles(holder, [waiter])
 
-      LockWatch.scan(0)
+      LockWatch.scan(%{}, 0)
 
       assert_receive {:stall, measurements, stall}, 1_000
 
       # M1 — a mutant that reports the longest-queued WAITER as the holder
       # (the two roles are symmetric in the table; only the tag separates
       # them) has to survive both of these to live.
-      assert stall.holder.pid == inspect(holder)
+      assert stall.subject.pid == inspect(holder)
       assert [waiter_sample] = stall.waiters
       assert waiter_sample.pid == inspect(waiter)
 
@@ -192,21 +187,23 @@ defmodule Grappa.Repo.LockWatchTest do
       # holder at all, so there is nothing to report and this never arrives;
       # a mutant that promotes TOO EARLY (before the transaction opens)
       # promotes the blocked writer too, and the waiter count goes to zero.
-      assert stall.waiter_count == 1
+      assert length(stall.waiters) == 1
       assert measurements.waiter_count == 1
-      assert is_integer(measurements.held_ms)
+      assert is_integer(measurements.elapsed_ms)
 
       # M4 — a mutant sampling `self()` (the scanning process) instead of
       # the holder's pid still produces a well-formed record, and only the
       # CONTENT of the stack tells the two apart. This frame is the reason
       # the holder is stuck, which is the datum #1420 says is missing.
-      assert Enum.any?(stall.holder.stacktrace, &(&1 =~ "park_until_released"))
+      assert Enum.any?(stall.subject.stacktrace, &(&1 =~ "park_until_released"))
 
-      # #1687 — the two arms are mutually exclusive by construction. A mutant
-      # that emits the unattributed line unconditionally (rather than only
-      # when nothing was named) would double-report every real stall, and the
+      # #1687, as issue 1960 restates it — the three verdicts are mutually
+      # exclusive by construction, and the discrimination moved from the event
+      # NAME to the `attribution` field. A mutant that labels a
+      # seam-attributable stall as an anonymous queue (or as a NIF cohort)
+      # would double-report every real stall under two claims, and the
       # operator would learn to ignore both.
-      refute_receive {:unattributed, _, _}, 100
+      assert stall.attribution == :named
 
       send(holder, :release)
       assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
@@ -228,7 +225,7 @@ defmodule Grappa.Repo.LockWatchTest do
       # M5 — a mutant that drops the `elapsed >= threshold` comparison
       # reports immediately and dies here. The holder has been holding for
       # milliseconds, not the ten seconds demanded.
-      LockWatch.scan(10_000)
+      LockWatch.scan(%{}, 10_000)
 
       refute_receive {:stall, _, _}, 300
 
@@ -239,7 +236,22 @@ defmodule Grappa.Repo.LockWatchTest do
       Supervisor.stop(repo)
     end
 
-    test "a slow but UNCONTENDED holder is not a stall" do
+    # 🔴 THIS TEST IS THE INVERSION OF ITS OWN FORMER SELF, AND THE REASON IS
+    # ISSUE 1960's DEFECT 1 — read the two halves before touching it.
+    #
+    # It used to be "a slow but UNCONTENDED holder is not a stall" and it
+    # refuted the report. That encoded `report_stalls(_, [])`, and the gate it
+    # protected is not a contention test: the watch table has ONE producer, so
+    # "no waiter registered" means "no waiter that went through
+    # `Repo.immediate_transaction/1`", which on this system is 0.1 % of the
+    # write load. Measured in prod on 2026-09-06: five episodes closed with
+    # `NEVER announced while it held`, each with the holder's pid and write
+    # path already in hand.
+    #
+    # What replaces the gate is not "print more": it is the line SAYING what
+    # it observed. So this test now asserts both halves — that the holder is
+    # announced, and that the record does not invent a queue behind it.
+    test "an uncontended holder past the threshold is announced, and says the queue was empty" do
       repo = start_tmp_repo()
 
       {holder, holder_ref} = start_writer(1, :park)
@@ -247,13 +259,26 @@ defmodule Grappa.Repo.LockWatchTest do
 
       await_roles(holder, [])
 
-      # M3 — a mutant that emits on a slow holder without checking for a
-      # queue behind it fires here. Nobody is blocked: this transaction is
-      # slow, and slow is not a stall. Reporting it would bury the signal
-      # the instrument exists to find under every long write in the system.
-      LockWatch.scan(0)
+      LockWatch.scan(%{}, 0)
 
-      refute_receive {:stall, _, _}, 300
+      assert_receive {:stall, measurements, stall}, 1_000
+
+      assert stall.attribution == :named
+      assert stall.subject.pid == inspect(holder)
+
+      # M3, inverted and STRONGER than the refutation it replaces. The old
+      # test could be satisfied by an instrument that says nothing; this one
+      # can only be satisfied by one that says the true thing. A mutant that
+      # buys the announcement by inventing contention — reporting the holder
+      # itself as its own waiter, or carrying the old "with N waiter(s)
+      # queued" prose over an empty list — dies on these two.
+      assert stall.waiters == []
+      assert measurements.waiter_count == 0
+
+      # And the honesty field that makes the empty queue readable rather than
+      # ambiguous: the seam DID see this holder, so `holders` is 1. A `0` here
+      # would say the seam was blind, which is a different episode entirely.
+      assert stall.holders == 1
 
       send(holder, :release)
       assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
@@ -277,17 +302,19 @@ defmodule Grappa.Repo.LockWatchTest do
       # three-minute episode and put NOT ONE line in `erlang.log.5`, so the
       # #1429 census and the operator both read a healthy system. Pinning the
       # telemetry alone would leave exactly the door that was dark, dark.
-      log = capture_log(fn -> LockWatch.scan(0) end)
+      log = capture_log(fn -> LockWatch.scan(%{}, 0) end)
 
-      assert log =~ "db lock stall UNATTRIBUTED"
+      assert log =~ "db lock stall: attribution=none"
       assert log =~ "no holder registered"
 
-      assert_receive {:unattributed, measurements, report}, 1_000
+      assert_receive {:stall, measurements, report}, 1_000
+
+      assert report.attribution == :none
 
       # M6 — a mutant reporting the holder-less queue with a fabricated holder
       # (the shape the issue's own wording invites) dies here: there is no
       # holder to name, and the record says so rather than guessing.
-      assert report.holders_registered == 0
+      assert report.holders == 0
 
       # M7 — a mutant sampling `self()` (the scanning process) instead of the
       # queued writers still produces a well-formed record; only the pid tells
@@ -298,11 +325,14 @@ defmodule Grappa.Repo.LockWatchTest do
       assert is_integer(sample.elapsed_ms)
 
       assert measurements.waiter_count == 1
-      assert is_integer(measurements.longest_wait_ms)
+      assert is_integer(measurements.elapsed_ms)
 
       # M8 — the queue is NOT a named stall. A mutant that routes this through
-      # the attributed door would put a `holder` key on a record that has none.
-      refute_receive {:stall, _, _}, 100
+      # the attributed verdict would claim a HOLD nobody measured; since issue
+      # 1960 that claim lives in `attribution`, asserted above, and in the
+      # prose, asserted here. The word is the one `subject_clause/3` reserves
+      # for `:named`.
+      refute log =~ "has held RESERVED"
 
       send(blind, :release)
       assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
@@ -321,13 +351,13 @@ defmodule Grappa.Repo.LockWatchTest do
 
       await_roles(nil, [waiter])
 
-      # M9 — the mirror of M5 on the new arm. A mutant that drops the
+      # M9 — the mirror of M5 on the queue verdict. A mutant that drops the
       # threshold comparison for waiters turns every transient queue behind
       # every autocommit write into a warning, which on the hot path is a log
       # flood, not a signal.
-      LockWatch.scan(10_000)
+      LockWatch.scan(%{}, 10_000)
 
-      refute_receive {:unattributed, _, _}, 300
+      refute_receive {:stall, _, _}, 300
 
       send(blind, :release)
       assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
@@ -346,14 +376,14 @@ defmodule Grappa.Repo.LockWatchTest do
 
       await_roles(nil, [waiter])
 
-      LockWatch.scan(0)
-      assert_receive {:unattributed, _, _}, 1_000
+      LockWatch.scan(%{}, 0)
+      assert_receive {:stall, _, %{attribution: :none}}, 1_000
 
       # M10 — the prod episode ran ~170s at `tick_ms: 1_000`. A mutant that
       # forgets to arm the row's `reported?` flag prints ~170 identical
       # warnings for one episode, which is the same as printing none.
-      LockWatch.scan(0)
-      refute_receive {:unattributed, _, _}, 300
+      LockWatch.scan(%{}, 0)
+      refute_receive {:stall, _, _}, 300
 
       send(blind, :release)
       assert_receive {:DOWN, ^blind_ref, :process, ^blind, :normal}, 5_000
@@ -371,8 +401,8 @@ defmodule Grappa.Repo.LockWatchTest do
       {writer, writer_ref} = start_writer(2, :park)
       await_roles(nil, [writer])
 
-      LockWatch.scan(0)
-      assert_receive {:unattributed, _, _}, 1_000
+      LockWatch.scan(%{}, 0)
+      assert_receive {:stall, _, %{attribution: :none}}, 1_000
 
       # The unregistered writer lets go; the pid that was just reported as a
       # WAITER now takes RESERVED itself.
@@ -383,7 +413,7 @@ defmodule Grappa.Repo.LockWatchTest do
       {queued, queued_ref} = start_writer(3, :straight_through)
       await_roles(writer, [queued])
 
-      LockWatch.scan(0)
+      LockWatch.scan(%{}, 0)
 
       # 🔴 M11, and it is the whole reason this test exists. `acquired/0`
       # promotes the row's role and restarts its clock but leaves the
@@ -393,7 +423,8 @@ defmodule Grappa.Repo.LockWatchTest do
       # that already worked. The flag has to clear on promotion, because the
       # promotion starts a new episode with a new clock.
       assert_receive {:stall, _, stall}, 1_000
-      assert stall.holder.pid == inspect(writer)
+      assert stall.attribution == :named
+      assert stall.subject.pid == inspect(writer)
 
       send(writer, :release)
       assert_receive {:DOWN, ^writer_ref, :process, ^writer, :normal}, 5_000
@@ -427,7 +458,7 @@ defmodule Grappa.Repo.LockWatchTest do
   # the NIF and MUST NOT appear. That is the honest limit of this arm stated
   # as an assertion — it sees a writer inside a NIF call, not a transaction
   # parked between statements.
-  describe "the NIF census — the writers the seam cannot see (#1901)" do
+  describe "the NIF cohort — the writers the seam cannot see (#1901)" do
     test "names a writer parked inside the SQLite NIF that owns no row at the seam" do
       repo = start_tmp_repo()
 
@@ -441,12 +472,14 @@ defmodule Grappa.Repo.LockWatchTest do
       # `grep -h "db lock stall" runtime/log/erlang.log.*` returned 0 while
       # six victims timed out at ~31 s. Pinning the telemetry alone would
       # leave exactly the door that failed, failing.
-      log = capture_log(fn -> LockWatch.census(%{}, 0) end)
+      log = capture_log(fn -> LockWatch.scan(%{}, 0) end)
 
-      assert log =~ "db lock stall NIF CENSUS"
+      assert log =~ "db lock stall: attribution=cohort"
       assert log =~ "none of them registered at the BEGIN IMMEDIATE seam"
 
-      assert_receive {:nif_census, measurements, report}, 1_000
+      assert_receive {:stall, measurements, report}, 1_000
+
+      assert report.attribution == :cohort
 
       # N1 — the whole deliverable. A mutant that reads the watch table (as
       # both older arms do) finds nothing here: this writer registered
@@ -476,13 +509,16 @@ defmodule Grappa.Repo.LockWatchTest do
       assert Enum.any?(sample.stacktrace, &(&1 =~ "Exqlite"))
 
       assert measurements.parked_count == length(report.parked)
-      assert is_integer(measurements.longest_parked_ms)
+      assert is_integer(measurements.elapsed_ms)
 
-      # N5 — the three arms are distinct verdicts. A mutant that also routes
-      # this through either older door would double-report the same episode
-      # under two different claims about attribution.
-      refute_receive {:stall, _, _}, 100
-      refute_receive {:unattributed, _, _}, 100
+      # N5 — the three verdicts are distinct, and since issue 1960 the
+      # distinction is a field rather than an event name. A mutant that labels
+      # this cohort as a named holder (or as a seam queue) would claim an
+      # attribution nothing here established; the equality above is where it
+      # dies. The prose half: the two words reserved for the verdicts this is
+      # NOT must be absent.
+      refute log =~ "has held RESERVED"
+      refute log =~ "longest writer queued at the seam"
 
       # BOTH, and `unseen` before it is even unblocked: the moment `blind`
       # lets go, `unseen` takes RESERVED and parks in `park_until_released/0`
@@ -509,9 +545,20 @@ defmodule Grappa.Repo.LockWatchTest do
       await_roles(nil, [waiter])
       await_parked_in_nif(waiter)
 
-      log = capture_log(fn -> LockWatch.census(%{}, 0) end)
+      log = capture_log(fn -> LockWatch.scan(%{}, 0) end)
 
-      assert_receive {:nif_census, _, report}, 1_000
+      assert_receive {:stall, _, report}, 1_000
+
+      # 🔴 issue 1960 changed the VERDICT here and not the finding, and the
+      # difference is worth stating. This waiter is registered at the seam AND
+      # parked in the NIF, so before the fold two arms could each have claimed
+      # it and the census won by running second. Under one ladder the seam
+      # queue outranks the cohort (see `t:Grappa.Repo.LockWatch.attribution/0`):
+      # a registered waiter is a writer we KNOW is blocked, while a NIF
+      # resident may be a healthy two-millisecond write. Nothing is lost —
+      # the roster rides every verdict, which is what the three assertions
+      # below still measure.
+      assert report.attribution == :none
 
       # N6 — the counts are the difference between "widen coverage" and
       # "the seam already told you". A mutant that hard-codes them to zero
@@ -544,9 +591,9 @@ defmodule Grappa.Repo.LockWatchTest do
       # ever see a pid at elapsed 0, so a mutant that drops the threshold
       # comparison turns every millisecond-long insert on the system into a
       # warning at every tick: a log flood, which reads the same as silence.
-      seen = LockWatch.census(%{}, 10_000)
+      seen = LockWatch.scan(%{}, 10_000)
 
-      refute_receive {:nif_census, _, _}, 300
+      refute_receive {:stall, _, _}, 300
 
       # N8 — and the clock it started has to SURVIVE, or the threshold can
       # never be crossed on any later pass. A mutant that returns a fresh map
@@ -578,15 +625,15 @@ defmodule Grappa.Repo.LockWatchTest do
       {unseen, unseen_ref} = start_unobserved_writer(2)
       await_parked_in_nif(unseen)
 
-      {seen, _} = with_log(fn -> LockWatch.census(%{}, 0) end)
-      assert_receive {:nif_census, _, _}, 1_000
+      {seen, _} = with_log(fn -> LockWatch.scan(%{}, 0) end)
+      assert_receive {:stall, _, %{attribution: :cohort}}, 1_000
 
       # N9 — the #1888 episodes ran ~31 s at `tick_ms: 1_000` and the #1687
       # one ~170 s. A mutant that forgets to carry the reported flag prints
       # one identical warning per tick for the whole freeze, which is how the
-      # other two arms would have drowned their own signal.
-      LockWatch.census(seen, 0)
-      refute_receive {:nif_census, _, _}, 300
+      # other two verdicts would have drowned their own signal.
+      LockWatch.scan(seen, 0)
+      refute_receive {:stall, _, _}, 300
 
       # BOTH, and `unseen` before it is even unblocked: the moment `blind`
       # lets go, `unseen` takes RESERVED and parks in `park_until_released/0`
@@ -694,16 +741,18 @@ defmodule Grappa.Repo.LockWatchTest do
     end
 
     test "an ANNOUNCED hold brackets exactly as it did before, and says it was announced" do
-      # A queue behind the holder is the second half `report_stalls/2`
-      # requires. Without it the detection pass walks away and this test would
-      # measure the unannounced arm again, passing for the wrong reason.
+      # A queue behind the holder is no longer REQUIRED for the announcement
+      # (issue 1960 removed that gate — see the uncontended-holder test above),
+      # but it is kept here on purpose: this test's claim is about the closing
+      # bracket of an episode that WAS announced, and the fixture that produced
+      # the original reading is the one that keeps producing it.
       waiter = queue_a_waiter()
 
       log =
         capture_log(fn ->
           LockWatch.observe(fn acquired ->
             acquired.()
-            LockWatch.scan(0)
+            LockWatch.scan(%{}, 0)
             :ok
           end)
         end)
@@ -769,7 +818,7 @@ defmodule Grappa.Repo.LockWatchTest do
       capture_log(fn ->
         LockWatch.observe(fn acquired ->
           acquired.()
-          LockWatch.scan(0)
+          LockWatch.scan(%{}, 0)
           :ok
         end)
       end)

--- a/test/scripts/log_gap_scan_test.bats
+++ b/test/scripts/log_gap_scan_test.bats
@@ -25,10 +25,14 @@ setup() {
     # prose fails here rather than reporting a confident zero.
     #   lock_watch.ex — the two edges of one stall episode
     #   busy_retry.ex — the four terminal arms, one per fault kind
-    LOCKSTALL_LINE='db lock stall: holder #PID<0.512.0> has held RESERVED for 30123ms with 2 waiter(s) queued — holder status=:runnable at :gen_server.loop/7, stack: a <- b'
+    # 🔴 issue 1960 — the three OPENING lines now share one prefix and differ
+    # by `attribution=`, so these three pins are what proves the counters key
+    # on the field. A pin that kept an old prefix would pass against a scanner
+    # that no longer matches production at all.
+    LOCKSTALL_LINE='db lock stall: attribution=named, holder #PID<0.512.0> has held RESERVED for 30123ms — 1 holder(s) / 2 waiter(s) registered at the seam, 0 process(es) parked inside Exqlite.Sqlite3NIF; subject #PID<0.512.0> status=:runnable at :gen_server.loop/7, stack: a <- b'
     LOCKRESOLVED_LINE='db lock stall RESOLVED: holder #PID<0.512.0> released RESERVED after 30456ms'
-    LOCKUNATTR_LINE='db lock stall UNATTRIBUTED: 3 writer(s) queued past the threshold, longest 31303ms — no holder registered, so the holder is NOT attributable at the BEGIN IMMEDIATE seam; longest waiter #PID<0.512.0> status=:waiting at :gen_server.loop/7, stack: a <- b'
-    LOCKNIF_LINE='db lock stall NIF CENSUS: 2 process(es) parked inside Exqlite.Sqlite3NIF past the threshold, longest 31402ms — none of them registered at the BEGIN IMMEDIATE seam, so all 2 are writers it cannot name; roster: #PID<0.512.0> 31402ms Exqlite.Sqlite3NIF.step/2, #PID<0.513.0> 30011ms Exqlite.Sqlite3NIF.execute/2; longest #PID<0.512.0> status=:running at Exqlite.Sqlite3NIF.step/2, stack: a <- b'
+    LOCKUNATTR_LINE='db lock stall: attribution=none, longest writer queued at the seam for 31303ms — no holder registered, so the holder is NOT attributable at the BEGIN IMMEDIATE seam — 0 holder(s) / 3 waiter(s) registered at the seam, 0 process(es) parked inside Exqlite.Sqlite3NIF; subject #PID<0.512.0> status=:waiting at :gen_server.loop/7, stack: a <- b'
+    LOCKNIF_LINE='db lock stall: attribution=cohort, longest process parked inside Exqlite.Sqlite3NIF for 31402ms — nothing registered at the seam, and nothing BEAM-visible says which of the cohort holds the lock — 0 holder(s) / 0 waiter(s) registered at the seam, 2 process(es) parked inside Exqlite.Sqlite3NIF; none of them registered at the BEGIN IMMEDIATE seam, so all 2 are writers it cannot name; roster: #PID<0.512.0> 31402ms Exqlite.Sqlite3NIF.step/2, #PID<0.513.0> 30011ms Exqlite.Sqlite3NIF.execute/2; subject #PID<0.512.0> status=:running at Exqlite.Sqlite3NIF.step/2, stack: a <- b'
     LOCKHELD_LINE='db write unavailable: SQLite write lock held by another writer for 30067ms across 1 attempts (1500ms retry budget) — returning :db_unavailable'
     SATURATED_LINE='db write unavailable: SQLite pool saturated for 1512ms across 14 attempts (1500ms retry budget) — returning :db_unavailable'
     # #1657 — the third arm. The elapsed is ~15s because a cancellation is
@@ -306,7 +310,7 @@ corrupted_scanner() {
     # known-answer control's cross-talk arm is what names both signatures
     # instead of quietly reporting an episode that never opened.
     local mutated
-    mutated="$(corrupted_scanner 's|/db lock stall: holder /|/db lock stall/|')"
+    mutated="$(corrupted_scanner 's|/db lock stall: attribution=named/|/db lock stall/|')"
 
     run awk -v SVC=svc -v THRESH=10 -f "$mutated" </dev/null
     [ "$status" -eq 3 ]


### PR DESCRIPTION
## What this changes

`Grappa.Repo.LockWatch` printed **four literals for one phenomenon** — `db lock
stall`, `db lock stall UNATTRIBUTED`, `db lock stall NIF CENSUS`, `RESOLVED` —
and picked the arm by how well it could attribute the wait. Reading a live
incident therefore meant correlating two or three differently-worded lines by
timestamp to learn they described the same lock.

The three **opening** arms are now one event under one prefix, `db lock stall:`,
carrying `attribution=named|none|cohort`. The discrimination moves from *which
line appeared* to *which value a field carries*. `RESOLVED` is untouched: it is
the closing bracket of an episode, a different axis from how well the opening
was attributed.

`attribution` is a **ladder of claim strength**, not a category set:
`named` (the seam knows the holder — the verb is `has held RESERVED`) >
`none` (writers registered, none holding) >
`cohort` (nobody registered; all we have is who sits in the NIF).
`subject_clause/3` keeps the verb per-arm so a weaker verdict cannot borrow a
stronger arm's wording. The parked roster now rides on **every** verdict, not
only the cohort one — it is evidence about the same lock whatever the seam
managed to name.

Two defects fall out of the fold rather than being patched around it:

1. **5 of 9 stalls were never announced.** `report_stalls(_, [])` bailed out
   when a holder had no queue behind it — the exact case an operator most wants
   named. It is gone; such a holder is now announced *and* says the queue was
   empty rather than inventing one.
2. **The census raced its own sample.** `nif_sample/2` now decides from the
   *same* `Process.info/2` read it builds the sample from, so a process that
   left the NIF between sweep and read is dropped rather than printed with a
   frame contradicting its own headline. An empty roster produces **no line**.
   That is the noise cure: not a bigger threshold, but having nothing true left
   to say.

`scan/1` + `census/2` fold into `scan/2`. They ran in a fixed order for a reason
(naming first, so a pid it named counted as registered rather than as a writer
nobody could see); one pass reads one instant for both populations and makes
that ordering constraint disappear instead of documenting it.

---

## The three measurements

### (a) `fold/4` has no catch-all — no event may land in the void

`Grappa.DbLatency.fold/4` has **six clauses, every one a literal event list, no
catch-all** (`lib/grappa/db_latency.ex:384,396,400,404,424,449`). An event that
is *attached* but has no *emitter* therefore folds **nothing, in silence** —
which is the failure mode this module hit while #1901 was being built. The pin
is `LockWatch.emitted_events/0` ≡ the attached lock-stall subset
(`test/grappa/db_latency_test.exs:475`), with the whole attached set pinned
against the test's own literal at `:547`.

Falsified in **both** directions, not just asserted:

- **NEGATIVE control** — put `[:grappa, :repo, :lock_stall, :unattributed]` back
  into `@events` with no emitter left for it. Result: **2 reds**, and mine names
  the orphaned event by name.
- **POSITIVE control** — mutate the `:resolved` clause to swallow silently.
  Result: red, `no match of right hand side value: []`.

Both mutations reverted; `grep -rc unreachable_mutant lib/ test/` is `0`
everywhere.

### (b) #1715 — the Logger cache key is per MODULE, verified from code

The brief asked me to confirm from **code**, not from a runtime probe, that the
`persistent_term` key bought by a module's first log line is
`{logger_config, Module}` and not one key per call site — because if it were
per call site the project's priming design would change.

**It is per module.** Disassembled from the shipped OTP 28 BEAM
(`kernel-10.6.3.3`):

`:logger_config.allow/2`
```
{:put_tuple2, {:x, 0}, {:list, [atom: :logger_config, x: 1]}}
{:call_ext, 2, {:extfunc, :persistent_term, :get, 2}}
{:move, {:literal, {:logger_config, :"$primary_config$"}}, {:x, 0}}
{:call_ext, 2, {:extfunc, :persistent_term, :get, 2}}
{:put_tuple2, {:x, 1}, {:list, [atom: :logger_config, y: 1]}}
{:call_ext, 2, {:extfunc, :persistent_term, :put, 2}}
```
The key is a 2-tuple built from `allow/2`'s **second argument**. Nothing in the
instruction stream carries call-site identity — no line, no fun ref, no tag.

`Logger.__should_log__/2` closes the chain — it passes the **module**:
```
{:move, {:x, 1}, {:y, 0}}                                  # save arg2 (module)
{:call, 1, {Logger, :elixir_level_to_erlang_level, 1}}
{:move, {:y, 0}, {:x, 1}}                                  # restore module into x1
{:call_ext, 2, {:extfunc, :logger_config, :allow, 2}}
```
`allow/1` reads the primary config and never writes, so the module-scoped `/2`
is the only arity that puts.

**Conclusion: the project's premise holds and nothing changes.** This
independently confirms the earlier runtime probe (a full `persistent_term`
keyspace diff: a second call site in the same module cost `+0` keys; a different
module cost `+1`; a `Logger.debug` prime bought the same key a later `warning`
would have). No new priming is needed. That probe has been deleted.

### (c) Every existing test I turned red — which of the two

For each: did the assert describe the **old** behaviour and did the cure
legitimately change it (permissible), or was the assert **weakened** to buy
green (not permissible)?

| Test | Verdict |
|---|---|
| `lock_watch_test` "a slow but UNCONTENDED holder is not a stall" | **Inverted — legitimate, and now STRONGER.** It encoded defect 1. The old test was satisfied by *silence*; the new one demands the line **and** that it not invent a queue (`waiters == []`, `waiter_count == 0`, `holders == 1`). Renamed "an uncontended holder past the threshold is announced, and says the queue was empty". |
| the `refute_receive {:unattributed, …}` / `{:nif_census, …}` pair | **Legitimate, equal strength.** Discrimination moved from the event NAME to the FIELD: now `assert stall.attribution == :named\|:none\|:cohort`. The same mutant dies — on an equality instead of a refute. |
| prefix literals `db lock stall UNATTRIBUTED`, `NIF CENSUS` | **Legitimate, never wider.** Where the old literal also carried a COUNT (`1 writer(s) queued past the threshold`), the count is re-asserted separately (`0 holder(s) / 1 waiter(s) registered at the seam`). |
| `stall.holder`→`stall.subject`, `holders_registered`→`holders`, `held_ms`/`longest_wait_ms`/`longest_parked_ms`→`elapsed_ms` | **Renames.** No assertion strength moved. |
| `refute log =~ "held"` in the unattributed arm | **Untouched and still green** — verified in the run, not assumed. The weaker verdict still cannot borrow the strong arm's verb. |
| "a writer the seam DOES know is counted as such" | **Legitimate.** Moved from a census verdict to `:none` (the ladder), but kept **every** assert it had — roster, `registered_waiters == 1`, "registered at the BEGIN IMMEDIATE seam". This is the roster riding every verdict. |
| `operator_test` "a NIF census renders its roster" → "a cohort verdict…" | **Legitimate, strictly more.** Same asserts plus one new (`longest parked at …`), because one row shape now serves three verdicts and the label must follow the verdict. |

No assert was weakened to buy green.

---

## What I refuse to assert

- **That this reduces the number of lines production prints.** Not measured.
  m42 is unreachable from the agent, so there is no prod number here at all.
- **That defect 2 is entirely a race.** The 2000 ms threshold is **unchanged**
  and I did not touch it — #1767/#1888 are vjt's posts.
- **That one `Process.info/2` with `:current_stacktrace` in the key list is
  cheaper than two calls.** Not measured. The strong claim is **coherence** —
  the decision cannot disagree with the frame it prints, because it is one read
  — not speed.
- **Anything about behaviour under a real VM freeze.** The #1715 probe measures
  key granularity, not blocking.

### Checks that were VACUOUS on this shape

- **`assert log =~ "0 process(es) parked inside Exqlite.Sqlite3NIF"` in
  `lock_watch_report_test`.** That file has no SQLite and nobody is ever in the
  NIF, so it could not have come out otherwise. It pins the prose, not the
  census.
- **`refute output =~ "resolved/"` in `operator_test`.** No path builds that
  string; it dies only to a mutant that adds a default to `attribution`.
- **The RESURRECTION half of the two-sided union-rebase test.** Measured: between
  my merge base and `origin/main` exactly one commit touches `DESIGN_NOTES.md`
  (`888e64726`, **+162 −0**). The precondition — the base deliberately deleting
  text my branch predates — did not exist, so that half could not have fired.
  Only the "additions go DOWN" half was live.

---

## Gate evidence

- `scripts/check.sh` (full): **`rc=0`**, `8 doctests, 65 properties, 7152 tests,
  0 failures`, `not ok` count `0`.
- `scripts/design-notes-gate.sh`: `rc=0` — *1 new entry heading(s), separator and
  marker present.*
- **DESIGN_NOTES rebase ritual, predicted before and measured after:** predicted
  `47448 + 166 = 47614`; measured **47614**. Contribution numstat byte-identical
  across the rebase (`+166 −0`), previous entry's tail byte-identical, marker
  unique against the base **tip** (0 occurrences there, 1 in my file). Boundary
  shape read on the real file: full stop / marker / blank / `---` / blank /
  `## `, no blank before the marker.
- An earlier full run went red on `LockWatchTest` (`lock_watch_test.exs:165`,
  ExUnit 60 s timeout inside `Process.list/0`). **Attribution is the
  orchestrator's, established on PR #1967**: that module reddened with four
  different tests in one night on a clean base with a zero-Elixir diff — it is
  the module that is unstable, not this slice. My own contribution to that
  picture: the whole file runs **38 tests, 0 failures in 16.3 s** in isolation,
  including the test that requires a process genuinely parked inside
  `Exqlite.Sqlite3NIF` — so `Process.list/0` is **not** in the class of
  operations #1715 blocks.

## Scope

12 files. Awk census counters are re-keyed onto `attribution=` while their
**output names are deliberately unchanged** (`lockstall`,
`lockstall_unattributed`, `lockstall_nif`), so every existing consumer of the
scan keeps reading the same three numbers. The emitter, the sink and the awk
ship in one commit on purpose: separated, a pruned emitter or a left-behind awk
counts zero in silence.

Refs issue 1960.
