### PR TITLE
cic(1974): read the running bundle against the deployed one, ungated

### DIFF
--- a/cicchetto/src/BundleReadout.tsx
+++ b/cicchetto/src/BundleReadout.tsx
@@ -1,0 +1,109 @@
+import type { Component } from "solid-js";
+import {
+  type BundleSkew,
+  bootBundleHashAccessor,
+  bootBundleVersionAccessor,
+  bundleSkew,
+  serverBundleHash,
+  serverBundleVersion,
+} from "./lib/bundleHash";
+
+// Issue 1974 — "which bundle am I running, and which one does the server say
+// is deployed?", answered in one place.
+//
+// All four facts already existed in `lib/bundleHash`; what did not exist was
+// anywhere to read them. Before this, `bootBundleVersionAccessor` surfaced in
+// the credits roll and the refresh toast, and the server side surfaced
+// nowhere at all — so the one question a person chasing a stale
+// service-worker cache actually asks had no answer in the UI.
+//
+// UNGATED, by vjt's ruling (relayed 2026-09-07): the readout lives on the
+// settings drawer's main index, not in `AdminDebugTab`. The people who get
+// served a stale bundle are ordinary PWA users, and the failure this makes
+// visible — `bundleHash.ts` `performRefresh`'s header, where the SW keeps
+// serving the OLD precached `index.html` for a reload or three — is only
+// observable by watching the running hash NOT move across presses. An
+// admin-gated panel cannot host that observation for the population that
+// hits it.
+//
+// NOT the credits modal, which is the only other ungated surface carrying any
+// of this: it is an easter egg by its own declaration (`lib/creditsModal.ts`
+// header), it is a full-viewport animated end-titles roll with a soundtrack,
+// and it renders ONE of the four values as a line that scrolls past.
+//
+// NO refresh control of its own. Three already exist (`errorBanners.ts` →
+// `requestBundleRefreshNow("user")`, `BootErrorBoundary.tsx`, and #674's
+// auto-refresh with #775's toast), and the first of those renders on the
+// ungated banner stack under EXACTLY the condition that makes a refresh
+// actionable here — `shouldShowRefreshBanner()`, which is now literally
+// `bundleSkew(...) === "skewed"`. A fourth door would be a second affordance
+// for the same verb, live in the same state, three lines apart.
+
+/** Every cell degrades to a word rather than to a blank. */
+const UNKNOWN_CELL = "unknown";
+
+/**
+ * The verdict line, one per member of the closed set.
+ *
+ * A `Record` and not a chain of ternaries, so adding a fourth `BundleSkew`
+ * member is a compile error here rather than a silently empty line.
+ */
+const SKEW_COPY: Record<BundleSkew, string> = {
+  aligned: "up to date — this tab is running the deployed build",
+  skewed: "out of date — this tab is still running an older build",
+  unknown: "not compared — the server has not announced a build yet",
+};
+
+const cell = (value: string | null): string => value ?? UNKNOWN_CELL;
+
+const BundleReadout: Component = () => {
+  // Computed from the SAME two reads the table prints, not from a second
+  // signal read: the verdict and the values it is a verdict about can then
+  // never disagree, which on a diagnosis surface is the whole point.
+  const skew = (): BundleSkew => bundleSkew(bootBundleHashAccessor(), serverBundleHash());
+
+  return (
+    <section
+      class="settings-section settings-section-card settings-build"
+      data-testid="settings-build"
+      data-skew={skew()}
+    >
+      <h4 class="settings-section-heading">build</h4>
+      {/* A real table, not a stack of lines: the reader's question is a
+          COMPARISON down a column, and the trivial-rebuild case #292 names —
+          same semver, different hash — is only legible when the two hashes sit
+          one above the other. The hashes are printed WHOLE; `versionLabel`
+          truncates to `SHORT_HASH_LEN` (7) to keep a sentence readable, and
+          vite's hash is 8 characters, so borrowing that formatter would drop
+          the last character of the two values being compared. */}
+      <table class="settings-build-table">
+        <thead>
+          <tr>
+            <td class="settings-build-corner" />
+            <th scope="col">running</th>
+            <th scope="col">deployed</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">version</th>
+            <td data-testid="settings-build-running-version">
+              {cell(bootBundleVersionAccessor())}
+            </td>
+            <td data-testid="settings-build-deployed-version">{cell(serverBundleVersion())}</td>
+          </tr>
+          <tr>
+            <th scope="row">build hash</th>
+            <td data-testid="settings-build-running-hash">{cell(bootBundleHashAccessor())}</td>
+            <td data-testid="settings-build-deployed-hash">{cell(serverBundleHash())}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="settings-section-blurb" data-testid="settings-build-skew">
+        {SKEW_COPY[skew()]}
+      </p>
+    </section>
+  );
+};
+
+export default BundleReadout;

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -9,6 +9,7 @@ import {
   Show,
 } from "solid-js";
 import AliasSettings from "./AliasSettings";
+import BundleReadout from "./BundleReadout";
 import DeleteAccountModal from "./DeleteAccountModal";
 import InlineConfirmButton from "./InlineConfirmButton";
 import { windowCandidates } from "./lib/activeWindows";
@@ -1393,6 +1394,19 @@ const SettingsDrawer: Component<Props> = (props) => {
               who built this, and out of what
             </span>
           </button>
+
+          {/* Issue 1974 — running bundle vs deployed bundle. UNGATED on vjt's
+            ruling: the person served a stale service-worker cache is an
+            ordinary PWA user, so the readout cannot live behind the admin
+            gate in `AdminDebugTab`. This is the drawer's only ungated,
+            always-reachable surface that is not an easter egg.
+
+            Below `credits` and not among the nav rows, because it is neither
+            an entry nor a setting: it PUSHES nothing and it CHANGES nothing.
+            The #1773 contract that credits is "LAST of the drawer's own
+            entries" is untouched — a readout is not an entry, and the two sit
+            together on purpose as the drawer's "about this build" tail. */}
+          <BundleReadout />
 
           {/* UX-4 bucket L — bottom "done" button. Same close verb as
             the top × — mobile thumb-reach surface. Sits below logout

--- a/cicchetto/src/__tests__/BundleReadout.test.tsx
+++ b/cicchetto/src/__tests__/BundleReadout.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The four accessors are module-init constants in a real browser (`<script
+// src>` and `<meta>` are read once), and jsdom has neither tag — so the boot
+// side is permanently null here unless it is stubbed. Same seam and same
+// reason as `Toasts.test.tsx`, which stubs the same two boot accessors.
+//
+// `importOriginal` is spread so `bundleSkew` stays the REAL function: it is
+// the pure verdict under test, and mocking it would leave the readout's
+// aligned/skewed/unknown line asserting only against itself.
+const bundle = vi.hoisted(() => ({
+  bootHash: null as string | null,
+  bootVersion: null as string | null,
+  serverHash: null as string | null,
+  serverVersion: null as string | null,
+}));
+
+vi.mock("../lib/bundleHash", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/bundleHash")>()),
+  bootBundleHashAccessor: () => bundle.bootHash,
+  bootBundleVersionAccessor: () => bundle.bootVersion,
+  serverBundleHash: () => bundle.serverHash,
+  serverBundleVersion: () => bundle.serverVersion,
+}));
+
+import BundleReadout from "../BundleReadout";
+
+// Real vite output shape, measured on `cicchetto/dist/index.html`:
+// `/assets/index-DyH3fZLf.js` — an EIGHT-character hash. The fixtures below
+// keep that width on purpose; the truncation assertion depends on it.
+const BOOT_HASH = "DyH3fZLf";
+const SERVER_HASH = "Ab12Cd34";
+
+const text = (testId: string): string => screen.getByTestId(testId).textContent?.trim() ?? "";
+
+describe("BundleReadout (issue 1974 — running bundle vs deployed bundle)", () => {
+  beforeEach(() => {
+    bundle.bootHash = null;
+    bundle.bootVersion = null;
+    bundle.serverHash = null;
+    bundle.serverVersion = null;
+  });
+
+  it("renders all FOUR facts — boot version+hash and server version+hash — side by side", () => {
+    bundle.bootHash = BOOT_HASH;
+    bundle.bootVersion = "0.16.0";
+    bundle.serverHash = SERVER_HASH;
+    bundle.serverVersion = "0.16.1";
+    render(() => <BundleReadout />);
+
+    // The whole point of the issue: four values, in one place, at once.
+    // Asserted per cell rather than on the section's concatenated text, so a
+    // regression that drops one side cannot hide behind the other three.
+    expect(text("settings-build-running-version")).toBe("0.16.0");
+    expect(text("settings-build-running-hash")).toBe(BOOT_HASH);
+    expect(text("settings-build-deployed-version")).toBe("0.16.1");
+    expect(text("settings-build-deployed-hash")).toBe(SERVER_HASH);
+  });
+
+  it("prints the build hash WHOLE, not the banner's 7-char short form", () => {
+    // `versionLabel`/`formatRefreshBanner` truncate to SHORT_HASH_LEN = 7 so a
+    // sentence stays readable. A readout exists to be COMPARED against another
+    // hash, and vite's hash is 8 characters — reusing that formatter here
+    // would silently drop the last one of the two values being compared.
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = SERVER_HASH;
+    render(() => <BundleReadout />);
+
+    expect(text("settings-build-running-hash")).toHaveLength(BOOT_HASH.length);
+    expect(text("settings-build-deployed-hash")).toHaveLength(SERVER_HASH.length);
+  });
+
+  it("reads 'aligned' when the two hashes agree", () => {
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = BOOT_HASH;
+    render(() => <BundleReadout />);
+
+    expect(screen.getByTestId("settings-build").getAttribute("data-skew")).toBe("aligned");
+    expect(text("settings-build-skew").length).toBeGreaterThan(0);
+  });
+
+  it("reads 'skewed' when the two hashes disagree (the stale-bundle case)", () => {
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = SERVER_HASH;
+    render(() => <BundleReadout />);
+
+    expect(screen.getByTestId("settings-build").getAttribute("data-skew")).toBe("skewed");
+  });
+
+  it("reads 'unknown' before the server has announced a build — NOT 'aligned'", () => {
+    // The third state is load-bearing: until the user-topic join lands its
+    // `bundle_hash`, nothing has been compared. Painting that as "up to date"
+    // would state a fact nobody measured, which is the failure the readout
+    // exists to stop.
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = null;
+    render(() => <BundleReadout />);
+
+    expect(screen.getByTestId("settings-build").getAttribute("data-skew")).toBe("unknown");
+  });
+
+  it("degrades an unknown cell to a word, never to a blank", () => {
+    // A build genuinely can carry no semver (a bundle built before #292, or a
+    // server that omits the wire key), and an empty cell reads as a broken
+    // readout rather than as the truth about the build — the same posture
+    // CreditsModal takes with "version unknown".
+    bundle.bootHash = BOOT_HASH;
+    bundle.bootVersion = null;
+    bundle.serverHash = null;
+    bundle.serverVersion = null;
+    render(() => <BundleReadout />);
+
+    expect(text("settings-build-running-version")).toBe("unknown");
+    expect(text("settings-build-deployed-version")).toBe("unknown");
+    expect(text("settings-build-deployed-hash")).toBe("unknown");
+    // The one fact we DO have still shows — a degraded neighbour must not
+    // blank the cell that is known.
+    expect(text("settings-build-running-hash")).toBe(BOOT_HASH);
+  });
+});

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -1796,6 +1796,39 @@ describe("SettingsDrawer (#460 — settings index)", () => {
     expect(screen.getByTestId("share-session-entry")).toBeInTheDocument();
     expect(screen.getByTestId("settings-drawer-done")).toBeInTheDocument();
   });
+
+  // Issue 1974 — the running-vs-deployed bundle readout. The ruling that
+  // decided this issue is about REACHABILITY, so that is what these pin: the
+  // four cells' contents belong to `BundleReadout.test.tsx`.
+  it("issue 1974 — the bundle readout renders on the main index with NO subject at all (ungated)", () => {
+    // `beforeEach` leaves `meHolder`/`subjectHolder` null: no user, no admin.
+    // A readout behind either gate finds nothing here — which is precisely
+    // the `AdminDebugTab` posture the ruling rejected, because the population
+    // served a stale service-worker cache is ordinary PWA users.
+    wrap(true);
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+    // All four cells, not just the card: a mounted-but-empty readout would
+    // satisfy the line above and answer none of the question.
+    expect(screen.getByTestId("settings-build-running-version")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-build-running-hash")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-build-deployed-version")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-build-deployed-hash")).toBeInTheDocument();
+  });
+
+  it("issue 1974 — a visitor sees the bundle readout too (not a user-kind gate either)", () => {
+    subjectHolder.current = { kind: "visitor", id: "v1", nick: "alice" };
+    wrap(true);
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+  });
+
+  it("issue 1974 — the readout belongs to the index: a sub-page replaces it, back restores it", () => {
+    wrap(true);
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+    openSub("display-settings-entry");
+    expect(screen.queryByTestId("settings-build")).toBeNull();
+    fireEvent.click(screen.getByTestId("display-back"));
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+  });
 });
 
 // #476 / #478 — the per-network identity editor is available to BOTH subjects

--- a/cicchetto/src/__tests__/bundleHash.test.ts
+++ b/cicchetto/src/__tests__/bundleHash.test.ts
@@ -3,6 +3,7 @@ import {
   __resetBundleHashForTests,
   bootBundleHashAccessor,
   bootBundleVersionAccessor,
+  bundleSkew,
   formatRefreshBanner,
   performRefresh,
   serverBundleHash,
@@ -45,6 +46,38 @@ describe("bundleHash", () => {
     }
     setServerBundleHash("definitely-different-hash-xxx");
     expect(shouldShowRefreshBanner()).toBe(true);
+  });
+
+  // Issue 1974 — the three-way verdict the readout renders. Pure, so every
+  // arm is reachable here; `shouldShowRefreshBanner` above can only ever
+  // observe the "skewed" one, which is why it could be a boolean and this
+  // cannot.
+  describe("bundleSkew (issue 1974)", () => {
+    it("is 'aligned' when the two hashes are the same", () => {
+      expect(bundleSkew("DyH3fZLf", "DyH3fZLf")).toBe("aligned");
+    });
+
+    it("is 'skewed' when the two hashes differ", () => {
+      expect(bundleSkew("DyH3fZLf", "Ab12Cd34")).toBe("skewed");
+    });
+
+    it("is 'unknown' — NOT 'aligned' — when either side is null", () => {
+      // Both null is the state every page is in before the user-topic join
+      // lands its `bundle_hash`. Collapsing that into "aligned" would let the
+      // readout claim agreement between a value and nothing.
+      expect(bundleSkew(null, "Ab12Cd34")).toBe("unknown");
+      expect(bundleSkew("DyH3fZLf", null)).toBe("unknown");
+      expect(bundleSkew(null, null)).toBe("unknown");
+    });
+
+    it("is exactly what shouldShowRefreshBanner tests for (one comparison, not two)", () => {
+      // The banner predicate is now defined as `bundleSkew(...) === "skewed"`.
+      // Pinned because the failure mode of re-inlining the comparison is a
+      // readout and a banner that disagree about whether this tab is stale.
+      setServerBundleHash("definitely-different-hash-xxx");
+      const boot = bootBundleHashAccessor();
+      expect(shouldShowRefreshBanner()).toBe(bundleSkew(boot, serverBundleHash()) === "skewed");
+    });
   });
 
   describe("bundle version signals (#292)", () => {

--- a/cicchetto/src/lib/bundleHash.ts
+++ b/cicchetto/src/lib/bundleHash.ts
@@ -81,13 +81,39 @@ export function setServerBundleVersion(version: string | null): void {
   setServerBundleVersionInternal(version);
 }
 
+/**
+ * Whether the bundle this tab booted is the one the server says is deployed.
+ *
+ * A closed set of three, not a boolean, and `"unknown"` is the load-bearing
+ * member (issue 1974): until the user-topic join lands its `bundle_hash`, or
+ * on a page with no parseable `<script src>`, the two sides have not been
+ * compared at all. The banner predicate below only ever needed "is there
+ * skew", so it could collapse that into `false`; a READOUT cannot, because
+ * painting an uncompared pair as "up to date" states a fact nobody measured.
+ */
+export type BundleSkew = "aligned" | "skewed" | "unknown";
+
+/**
+ * Pure verdict over the two hashes — same pure/wrapper split this module
+ * already uses for `formatRefreshBanner` vs `refreshBannerMessage`, so a
+ * caller that RENDERS both hashes can compute the verdict from exactly the
+ * values it printed rather than from a second, independent signal read.
+ */
+export function bundleSkew(bootHash: string | null, serverHash: string | null): BundleSkew {
+  if (bootHash === null || serverHash === null) return "unknown";
+  return bootHash === serverHash ? "aligned" : "skewed";
+}
+
 // True iff (1) we know what we booted with, (2) the server has told us
 // what's live, and (3) they differ. nulls on either side = unknown =
 // don't pester the user; the next push will resolve the question.
+//
+// Derived from `bundleSkew` rather than restating its comparison: two copies
+// of "are these the same bundle" is one copy too many, and the readout and
+// the banner disagreeing about it is precisely the confusion a diagnosis
+// surface must not create.
 export function shouldShowRefreshBanner(): boolean {
-  const boot = bootBundleHash();
-  const server = serverBundleHashSignal();
-  return boot !== null && server !== null && boot !== server;
+  return bundleSkew(bootBundleHash(), serverBundleHashSignal()) === "skewed";
 }
 
 // #292 — refresh bar "current vs available" version display.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -10157,6 +10157,40 @@ button.topic-bar-windows-opener {
   font-size: 0.85rem;
 }
 
+/* Issue 1974 — running-vs-deployed bundle readout, at the tail of the
+ * settings index. It borrows `.settings-section-card` wholesale (heading +
+ * bordered bg-alt card) rather than minting a look of its own; the only thing
+ * it needs beyond the shared idiom is the 2×2 matrix and the per-verdict
+ * accent below. */
+.settings-build-table {
+  border-collapse: collapse;
+  /* Not `width: 100%`: the cells hold an 8-char hash and a semver, and
+   * stretching them to the drawer's full width puts the two values the reader
+   * is comparing as far apart as the layout allows. */
+  width: auto;
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+.settings-build-table :where(th, td) {
+  padding: 0.1rem 0.75rem 0.1rem 0;
+  font-weight: normal;
+  /* The hash is the thing being compared character by character, so it must
+   * never wrap mid-token into two visually different-looking values. */
+  white-space: nowrap;
+}
+
+.settings-build-table :where(thead th, tbody th) {
+  color: var(--muted);
+}
+
+/* The verdict line carries the colour, not the card: a bordered box that
+ * turns red the moment a deploy lands would read as an error the user has to
+ * act on, and being one build behind is not one. */
+.settings-build[data-skew="skewed"] .settings-section-blurb {
+  color: var(--accent);
+}
+
 /* #462 — the per-network identity editor had NO rule of its own. What the
    issue reports as "unstyled inputs" is already fixed: #497/#508's global
    input treatment gives the three fields their 44px height, the app's

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47446,3 +47446,112 @@ them to contrast had the second silently eat the first.
 _Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
 release image, so it reaches an operator only through a new image. The m42
 jail runs `mix release` and does not read it; nothing else here leaves CI._
+<!-- entry #1974 -->
+
+---
+
+## 2026-09-07 — issue 1974: where "which bundle am I running?" gets answered
+
+The four facts were already collected. `cicchetto/src/lib/bundleHash.ts` has
+carried `bootBundleHashAccessor`, `bootBundleVersionAccessor`,
+`serverBundleHash` and `serverBundleVersion` since #292; the skew between them
+already drives the refresh banner. What did not exist was anywhere to READ
+them. Measured before touching anything: `bootBundleVersionAccessor` reached
+exactly two surfaces — the credits roll and #775's update toast — and the two
+server-side accessors reached NO production code at all, only tests and the
+e2e window hook. So a person chasing a stale service-worker cache had one of
+the four numbers, in an easter egg, and none of the server side.
+
+### The ruling, and why it is not `AdminDebugTab`
+
+The issue left one thing open — which panel — and vjt ruled it UNGATED
+(relayed 2026-09-07, not observed first-hand). `AdminDebugTab` is the panel
+named for diagnosis and it stays exactly as it is.
+
+The argument that decided it is a population argument: whoever gets served a
+stale bundle is an ordinary PWA user, so a readout behind `is_admin` answers
+the question for everyone except the people who have it. The second half is
+sharper. The failure worth seeing is the one `performRefresh`'s own header
+documents (`bundleHash.ts`, the UX-6-I comment): the service worker keeps
+serving the OLD precached `index.html`, so a refresh press can land back on
+the same bundle — the "three presses to update" vjt measured on iPhone. That
+is only observable by watching the running hash NOT move across presses, and
+an admin-gated panel cannot host that observation for the population that
+hits it.
+
+Within "ungated", the placement is the settings drawer's main index, at the
+tail beside `credits`. The drawer is the one ungated, always-reachable
+surface both subject kinds get; it is not the credits modal, which declares
+itself an easter egg (`lib/creditsModal.ts` header), is a full-viewport
+animated end-titles roll with a soundtrack, and renders one of the four
+values as a line that scrolls past. It is deliberately NOT a
+`.settings-nav-row`: a nav row pushes a sub-page and wears a chevron saying
+so, and this pushes nothing and changes nothing. #1773's contract that
+`credits` is the LAST of the drawer's own ENTRIES is therefore untouched — a
+readout is not an entry.
+
+### Why the boolean had to become a closed set of three
+
+`shouldShowRefreshBanner()` folded "we have not compared yet" into the same
+`false` as "these agree". For a banner that is right: both mean do-not-pester.
+For a readout it is a lie, and precisely the lie the surface exists to
+prevent — before the user-topic join lands its `bundle_hash`, nothing has been
+compared, and rendering that as "up to date" asserts a fact nobody measured.
+
+So the comparison moved into a pure `bundleSkew(bootHash, serverHash) ->
+"aligned" | "skewed" | "unknown"`, and the banner predicate is now literally
+`bundleSkew(...) === "skewed"`. Pure-plus-caller rather than a signal-reading
+`bundleSkew()` with no arguments: the readout renders both hashes, so it
+computes the verdict from exactly the two values it printed and the two can
+never disagree. The module already used this shape — `formatRefreshBanner`
+(pure) beside `refreshBannerMessage` (signal-reading wrapper).
+
+### Two things deliberately NOT built
+
+**No fourth refresh button.** Three already exist: `errorBanners.ts:282` →
+`requestBundleRefreshNow("user")`, `BootErrorBoundary.tsx:138`, and #674's
+auto-refresh announced by #775's toast. The first of those renders on the
+ungated banner stack under `shouldShowRefreshBanner()` — which is now, by
+definition, the same condition that makes a refresh actionable in the
+readout. A control here would be the same verb twice, live in the same state,
+a drawer apart.
+
+**No build id or ISO date.** The version and the hash are already baked; a
+third carrier is exactly the drift #538 closed
+(`cicchetto/src/lib/buildCredits.ts:13-15`).
+
+### The hash prints whole, and that is a measurement
+
+`versionLabel`/`formatRefreshBanner` truncate to `SHORT_HASH_LEN = 7` so a
+sentence stays readable, and reusing them here was the obvious move. Measured
+against a real build instead: `cicchetto/dist/index.html` points at
+`/assets/index-DyH3fZLf.js` — an EIGHT-character hash. Borrowing the banner's
+formatter would drop the last character of the two values the reader opened
+the panel to compare. The readout therefore renders four cells rather than
+two composed labels, which also makes the trivial-rebuild case #292 names
+(same semver, different hash) legible as a column.
+
+### What was proven, and what was not
+
+Red-then-green on a new `BundleReadout.test.tsx` (six cases), plus three
+reachability cases in `SettingsDrawer.test.tsx` and four on the pure
+predicate. Four mutants, each killing what it was predicted to kill and
+nothing else: the deployed-version cell reading the boot accessor (1 test),
+the `unknown` arm returning `aligned` (2 — one per file, the pure fn and the
+render), `cell()` truncating to 7 (3), and unmounting the readout from the
+drawer (3 — the drawer cases only, so the mount is pinned separately from the
+component). Negative control: rewording all three verdict strings kills
+nothing, so the tests pin structure and values rather than prose.
+
+NOT established, and worth stating rather than implying: nothing here was
+observed in a real browser or on a real PWA install. The "three presses"
+behaviour this readout is meant to make visible remains #292/UX-6-I's
+measurement, not one taken in this slice — jsdom has neither a service worker
+nor a precache. The readout is also reachable only by an AUTHENTICATED
+subject; a bundle stale enough to break login is `BootErrorBoundary`'s
+territory and keeps its own refresh.
+
+_Deploy: **cic bundle only** — no server code, no wire change, no
+`protocol_version` movement. `serverBundleVersion` was already on the wire
+(`api.ts` `bundle_hash` event); this slice is the first production code to
+read it._


### PR DESCRIPTION
Addresses issue 1974 — the running bundle and the deployed one, side by side.
No closing keyword on purpose; the orchestrator owns that.

## What was missing (measured, not assumed)

All four facts already lived in `cicchetto/src/lib/bundleHash.ts`. What was
missing was the place to read them. Census over `origin/main`:

| accessor | production readers before this PR |
|---|---|
| `bootBundleVersionAccessor` | 2 — `CreditsModal.tsx:586`, `Toasts.tsx:60` |
| `bootBundleHashAccessor` | 2 — `Toasts.tsx:60`, `bundleRefreshNotice.ts:172` |
| `serverBundleHash` | **0** (internal to `bundleHash.ts` + the e2e window hook) |
| `serverBundleVersion` | **0** |

Positive control on that grep: the same command finds the `bootBundle*` call
sites the issue names, so an empty result for the server side is a measured
zero and not a broken pattern.

## The ruling this implements

🔴 **Relayed to me by the orchestrator, not observed first-hand.** The issue's
open question ("which panel") is closed as **UNGATED**, and `AdminDebugTab`
stays exactly as it is — nothing was added there.

## Where, inside "ungated" — the part that was mine

The **settings drawer's main index**, at the tail beside `credits`.

* It is the one ungated, always-reachable surface both subject kinds get. The
  three `SettingsDrawer.test.tsx` cases pin exactly that: rendered with **no
  subject at all** (so not admin-gated), rendered for a **visitor** (so not
  user-kind-gated), and belonging to the index rather than a sub-page.
* **Not `CreditsModal`.** It declares itself an easter egg in its own source
  (`lib/creditsModal.ts:4`, `CreditsModal.tsx` header), it is a full-viewport
  animated end-titles roll with a synthesised soundtrack, and it renders
  **one of the four** values (`bootBundleVersionAccessor`) as a line that
  scrolls past.
* **Not `DiagFloat`.** It is the other candidate a search turns up and it is
  not ungated in practice: `localStorage.cic_diag`-flagged, and since UX-6 D12
  its toggle lives in `AdminDebugTab` (`SettingsDrawer.tsx:583-590`).
* Deliberately **not** a `.settings-nav-row` — a nav row pushes a sub-page and
  wears a chevron saying so; this pushes nothing and changes nothing. #1773's
  contract that `credits` is the LAST of the drawer's own *entries* is
  untouched: a readout is not an entry.

## What is in

Four cells, boot vs server, in a 2×2 with the two hashes stacked so the
trivial-rebuild case #292 names (same semver, different hash) reads as a
column — plus a one-line verdict.

`shouldShowRefreshBanner()` folded "not compared yet" into the same `false` as
"they agree". Correct for a banner, a lie for a readout. So the comparison is
now a pure `bundleSkew(bootHash, serverHash) -> "aligned" | "skewed" |
"unknown"`, and the banner predicate is redefined as
`bundleSkew(...) === "skewed"` — derived, not duplicated, so the readout and
the banner cannot disagree about whether this tab is stale.

## What is deliberately out

* **No fourth refresh button.** Three exist (`errorBanners.ts:282`,
  `BootErrorBoundary.tsx:138`, #674's auto with #775's toast), and the first
  renders on the ungated banner stack under `shouldShowRefreshBanner()` — by
  construction the same condition that would make a control here actionable.
  Same verb twice, same state, a drawer apart.
* **No build id / ISO date** — the drift #538 closed
  (`lib/buildCredits.ts:13-15`).
* **`socket.ts:104` and `protocol_test.exs` untouched** (issue 1973 is w2's);
  `MIN_SERVER_PROTOCOL_VERSION` untouched (issue 1654).

## One reuse rejected, on a measurement

Reusing `versionLabel`/`formatRefreshBanner` was the obvious move; they
truncate to `SHORT_HASH_LEN = 7`. Measured against a real build:
`cicchetto/dist/index.html` points at `/assets/index-DyH3fZLf.js` — an
**8-character** hash. Borrowing that formatter would drop the last character
of the two values the reader opened the panel to compare, so the readout
prints the hashes whole.

## Evidence

**Red before, green after.** `src/__tests__/BundleReadout.test.tsx` failed to
resolve `../BundleReadout` (`1 failed`, `no tests`) before the component
existed; `6 passed` after.

**Gates, on this tree.** `scripts/bun.sh run check` — 5 stages, 0 failed
(biome went red first on import order + one wrap; `check:fix` applied, and the
full test run below is on the formatted tree). `scripts/bun.sh run test` —
**337 files / 6765 tests passed**. `scripts/design-notes-gate.sh` — rc=0,
`1 new entry heading(s), separator and marker present`.

**Mutation — four mutants, each killing what was predicted and only that:**

| mutant | predicted | killed |
|---|---|---|
| deployed-version cell reads the boot accessor | 1 | 1 (`renders all FOUR facts`) |
| `bundleSkew` `unknown` arm returns `"aligned"` | 2 | 2 — one per file (pure fn + render) |
| `cell()` truncates to 7 | 3 | 3 |
| `<BundleReadout />` removed from the drawer | 3 | 3 — drawer cases only, component cases survive |

**Negative control:** rewording all three verdict strings kills **nothing**
(154 passed) — the tests pin structure and values, not prose. Working tree
verified empty (`git status --porcelain`) after every restore.

**Marker uniqueness:** `grep -Fxc '<!-- entry #1974 -->'` = 1 in the file, 0 on
`origin/main`'s tip and 0 across `docs/design_notes/`. Positive control
(`#1952`) = 1; negative control (`#999999`) = 0.

## What I refuse to claim

* **No real-browser or real-PWA observation.** Everything above is jsdom +
  static measurement. The "three presses to update" behaviour this readout
  exists to make visible stays #292/UX-6-I's measurement — jsdom has neither a
  service worker nor a precache — so I have **not** shown that a tester can
  now watch the running hash fail to move. I have shown the four values render
  and the verdict is correct for all three states.
* **No e2e.** A real-browser oracle here needs a built `dist` and the e2e
  runner (a lane), which this cic-only slice does not hold. Nothing in the
  existing `bundle-refresh-banner.spec.ts` was touched or re-run.
* **Reachability is for an AUTHENTICATED subject.** The drawer is behind
  login. A bundle stale enough to break login is `BootErrorBoundary`'s
  territory and keeps its own refresh; I did not extend the readout there and
  am not claiming that case is covered.
* **The base did not move.** `origin/main` is `f0e3dc8c6` both at branch time
  and at push time, so no rebase was performed — a `union-rebase.sh` run here
  would have been vacuous (already on top) rather than evidence.
* **The ruling is second-hand**, as stated above.
