### PR TITLE
cic: make the declared protocol version true, and pin it so it stays

### DIFF
--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -91,17 +91,56 @@ let _socket: Socket | null = null;
 // refuse every server that accepts it. The pair moves together or neither
 // moves.
 //
+// 9 → 13. The same defect as 2 → 9, recurring for the same reason: nothing
+// pinned this number to `Grappa.Protocol.version/0` — only to its FLOOR,
+// which is 1 and which everything satisfies. In the seven days after 9
+// landed the server bumped four times (10, the server_pass route; 11, the
+// upload-confirm settings door; 12, the ISON presence fallback; 13, the
+// stale_code_path refusal) and this constant did not move, so every boot of
+// every current bundle logged `protocol mismatch: this bundle speaks 9, the
+// server speaks 11` against production. A true statement about a stale
+// constant, again — and this time it cost someone real work: a tester
+// narrowing an unrelated report read it in the console and offered it as the
+// likely cause.
+//
+// The bundle already SPOKE 13 and merely declared 9. `wireSchema.ts` carries
+// v12's `presence_changed.source: "ison"` and v13's `stale_code_path`
+// refusal token; the number was the only thing lagging.
+//
+// Measured, because the shape of the recurrence is the argument for the new
+// pin rather than for more diligence: 12 bumps of `@protocol_version`
+// against 3 writes of this constant, two of which were catch-ups (2 → 9
+// swallowed seven bumps at once). Since cic first declared a version the two
+// have been equal for roughly 8 days out of 22 — the stale value is the
+// NORMAL state of this file, not an accident that better attention would
+// have avoided.
+//
+// Why it is not cosmetic, and why the cure is a pin and not a habit:
+// `noteServerProtocol` below warns on ANY inequality and its only silence is
+// exact equality, so a lagging constant fires "protocol mismatch" on every
+// healthy boot of a deploy whose bundle and BEAM came from the SAME commit.
+// That is the one signal for a service-worker-cached PWA skewed against the
+// BEAM (see its own note), and a signal that fires on every healthy boot
+// cannot carry that meaning. `protocol_test.exs` now pins
+// `cic_protocol_version() == Protocol.version()`, so the next bump that
+// forgets this file is red at the commit that forgets it, and an inequality
+// at RUNTIME means what it is supposed to mean: the two artefacts came from
+// different commits.
+//
 // Raising THIS one is safe in the direction that can bite: the handshake
 // refuses a client BELOW `Grappa.Protocol.min_version/0`, which is 1, and
 // never one above. `protocol_test.exs` pins that from the other side
-// (`cic_protocol_version() >= Protocol.min_version()`).
+// (`cic_protocol_version() >= Protocol.min_version()`) and, since #1973, the
+// equality against `version/0` as well.
 //
 // This is what cic SPEAKS. What it REQUIRES of the server is a separate
 // constant in `serverProtocol.ts` (`MIN_SERVER_PROTOCOL_VERSION`), and the
 // two are deliberately not the same number — a later bundle may speak v5
-// and still cope with a v2 server. They coincide today; that is a fact about
-// today, not a merge of the two axes.
-export const CLIENT_PROTOCOL_VERSION = 9;
+// and still cope with a v2 server. They coincided until this bump and no
+// longer do: this bundle speaks 13 and still serves a v9 server. That gap is
+// the two axes behaving as designed, not drift to be tidied away — raising
+// the floor is the #1654 question and is not answered here.
+export const CLIENT_PROTOCOL_VERSION = 13;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47446,3 +47446,79 @@ them to contrast had the second silently eat the first.
 _Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
 release image, so it reaches an operator only through a new image. The m42
 jail runs `mix release` and does not read it; nothing else here leaves CI._
+<!-- entry #1973 -->
+
+---
+
+## 2026-09-07 — #1973: the client protocol constant lags by construction, so the cure is a pin and not more diligence
+
+`cicchetto`'s `CLIENT_PROTOCOL_VERSION` said 9 while `Grappa.Protocol`'s
+`@protocol_version` said 13, so every boot of every current bundle logged
+`protocol mismatch: this bundle speaks 9, the server speaks 11` against
+production. The same defect the constant's own note already records for
+`2 → 9` — *"a true statement about a stale constant, not about a real
+incompatibility"* — and it came back because nothing pinned the two numbers
+to each other in this direction.
+
+**The recurrence is structural, and that is the argument.** Measured on
+`origin/main`: 12 bumps of `@protocol_version` (1 → 13, 2026-07-27 →
+2026-09-06) against 3 writes of the cic constant, two of which were
+catch-ups — `2 → 9` swallowed seven bumps at once. Since cic first declared
+a version (2026-08-16) the two have been equal for roughly 8 days out of 22.
+The stale value is the NORMAL state of that file. A rule saying "remember to
+bump both" has now been written twice and obeyed neither time.
+
+**Why the three existing pins all stayed green: every one of them is
+one-sided, and none of them looks at `version/0`.**
+`protocol_test.exs` asserted `cic >= Protocol.min_version()` (`9 >= 1`) and
+cic's floor `<= Protocol.version()` (`9 <= 13`); `serverProtocol.test.ts`
+asserted `MIN_SERVER <= CLIENT` (`9 <= 9`). Nothing compared cic against what
+the server actually SPEAKS. The new pin is
+`cic_protocol_version() == Protocol.version()`, and equality rather than `>=`
+because the two are one contract version by definition: cic below is a stale
+constant, cic above is a bundle claiming a shape no server ever emitted, and
+`>=` waves one of them through. It is deliberately NOT the
+`MIN_SERVER_PROTOCOL_VERSION` axis — what cic SPEAKS says nothing about what
+it REQUIRES, and after this bump the two no longer coincide (13 vs 9), which
+is those axes working rather than drifting.
+
+### The objection that had to be measured before the cure, and how it resolved
+
+`noteServerProtocol` is a pure inequality: its only silence is exact
+equality, so it warns for `server < CLIENT` and `server > CLIENT` alike.
+Raising the constant to 13 while production speaks 11 therefore does not
+silence the warn — it reverses its sign. The question raised before any edit
+was whether the cure merely relocates the lie.
+
+It does not, and the distinction is between the two configurations rather
+than between the two directions. Today's warn fires with ZERO skew: prod
+serves the `v1.5.1` bundle (declares 9, measured at the tag) against the
+`v1.5.1` server (speaks 11), both artefacts from one commit, and that is what
+makes the message a lie. After the bump and the pin, bundle and BEAM built
+from the same commit are equal by construction, so an inequality at runtime
+means the two artefacts came from DIFFERENT commits — which is exactly the
+`--cic`-only skew the warn was written to surface. `13` against a `11` server
+is reachable only that way.
+
+Measured while resolving it, and worth keeping because it bounds the claim:
+the two deltas between 11 and 13 cannot hurt a newer bundle talking to an
+older server. v12's break was measured in the OPPOSITE direction (an old
+bundle drops `presence_changed` on the unknown `source: "ison"` enum member;
+a bundle knowing the wider set accepts a server that never sends it), and
+v13's `stale_code_path` token is loopback-gated, so no browser is ever handed
+it. That acquits those two deltas specifically — it is not a general proof
+that a newer bundle tolerates an older server, which #1393d repealed
+outright.
+
+vjt's call (2026-09-07): keep the condition as it is. Narrowing the warn to
+`server < CLIENT` would reverse a deliberate choice — the note on the
+function already says the newer-server direction is additive and tolerated
+and keeps warning anyway, because on a service-worker-cached PWA the skew
+FACT is the signal. The floor (`MIN_SERVER_PROTOCOL_VERSION`,
+`min_protocol_version`) is the #1654 question and is untouched here.
+
+_Deploy: **cic bundle** — one integer literal and comments in `socket.ts`;
+the pin is a test and reaches CI only. Ship the bundle with a server built
+from the same commit: a `--cic`-only push of this bundle onto the current
+`1.5.1` BEAM will log the mismatch, and after this change that log is telling
+the truth._

--- a/test/grappa/protocol_test.exs
+++ b/test/grappa/protocol_test.exs
@@ -58,6 +58,58 @@ defmodule Grappa.ProtocolTest do
     end
   end
 
+  # #1973 — the OTHER direction, and the one every pin in this file was blind
+  # to: cic falling behind `version/0`.
+  #
+  # The three pins that exist all point one way and all stayed green while the
+  # constant rotted. `>= min_version()` above is `9 >= 1`; the server floor
+  # below is `9 <= 13`; cic's own `MIN_SERVER <= CLIENT`
+  # (`serverProtocol.test.ts`) is `9 <= 9`. Nothing compared cic against what
+  # the server actually SPEAKS, which is the number socket.ts says it is
+  # declaring ("The number is the CONTRACT version", socket.ts:71-75).
+  #
+  # Measured drift on `origin/main` at the time of writing: 12 bumps of
+  # `@protocol_version` (1 → 13, 2026-07-27 → 2026-09-06) against 3 writes of
+  # `CLIENT_PROTOCOL_VERSION`, two of which were catch-ups — the 2 → 9 one
+  # skipped seven bumps at once. Since cic first declared a version
+  # (2026-08-16) the two constants have been equal for roughly 8 days out of
+  # 22. The stale value is the normal state, not the accident.
+  #
+  # Why that is not cosmetic: `noteServerProtocol` (socket.ts:441-451) warns on
+  # ANY inequality, in either direction, and its only silence is exact
+  # equality. A constant that lags therefore fires "protocol mismatch" on every
+  # healthy boot of a deploy whose bundle and BEAM came from the SAME commit —
+  # which destroys the one signal that a service-worker-cached PWA is skewed
+  # against the BEAM (socket.ts:428-433). It has already misled a tester once.
+  # With this pin, an inequality at runtime means the two artefacts came from
+  # different commits, which is exactly what the warn is for.
+  #
+  # Why EQUALITY and not `>=`: the two numbers are the same contract by
+  # definition, so there is no direction to tolerate. cic below `version/0` is
+  # a stale constant; cic above it is a bundle claiming a shape no server has
+  # ever emitted. Both are the same defect — the declaration not matching the
+  # wire — and `>=` would wave one of them through. This is deliberately NOT
+  # the axis of `MIN_SERVER_PROTOCOL_VERSION`, which stays a separate number
+  # precisely because a bundle may speak v13 and still cope with a v9 server
+  # (serverProtocol.ts:45-49); pinning what cic SPEAKS says nothing about what
+  # it REQUIRES.
+  describe "what cicchetto declares vs what the server SPEAKS (#1973)" do
+    test "cicchetto's declared version IS the protocol the server speaks" do
+      # Fails on any bump of `@protocol_version` that does not carry the cic
+      # constant with it — i.e. on the commit that introduces the drift, rather
+      # than on the browser console of whoever notices months later.
+      cic = cic_protocol_version()
+      server = Protocol.version()
+
+      assert cic == server,
+             "cicchetto declares CLIENT_PROTOCOL_VERSION = #{cic} " <>
+               "(#{@cic_socket}) while the server speaks #{server}. " <>
+               "These are one contract version, not two: bump the cic " <>
+               "constant in the same change that bumps @protocol_version, " <>
+               "and extend its note the way `2 -> 9` did."
+    end
+  end
+
   # 🔴 THIS IS NOT THE GATE #1654 ASKS FOR. It is the half of it that can be
   # written against facts the repo holds today, shipped as such.
   #


### PR DESCRIPTION
Addresses issue 1973.

`CLIENT_PROTOCOL_VERSION` said `9` while `Grappa.Protocol.version/0` said
`13`, so every boot of every current bundle logged `protocol mismatch: this
bundle speaks 9, the server speaks 11` against production. Same defect the
constant's own note already records for `2 -> 9`, back again because nothing
pinned the two numbers to each other in this direction.

## What is here

1. `CLIENT_PROTOCOL_VERSION` 9 -> 13, with the note extended the way `2 -> 9`
   was.
2. The pin that is the half preventing recurrence:
   `cic_protocol_version() == Protocol.version()` in `protocol_test.exs`.
3. A `DESIGN_NOTES` entry recording the measurement and the ruling.

The floor (`MIN_SERVER_PROTOCOL_VERSION` / `min_protocol_version`) is
untouched — that is the separate issue 1654 question.

## Why equality, and why the three existing pins stayed green

All three are one-sided and none looks at `version/0`:

| pin | assertion | value |
|---|---|---|
| `protocol_test.exs:57` | `cic >= Protocol.min_version()` | `9 >= 1` |
| `protocol_test.exs:97` | cic floor `<= Protocol.version()` | `9 <= 13` |
| `serverProtocol.test.ts:66` | `MIN_SERVER <= CLIENT` | `9 <= 9` |

Measured rather than argued: on the pre-cure tree the new pin was the ONLY
red of the seven in that file — the two one-sided pins passed with the defect
present.

Equality rather than `>=` because the two numbers are one contract version by
definition: cic below is a stale constant, cic above is a bundle claiming a
shape no server has emitted. This is deliberately not the
`MIN_SERVER_PROTOCOL_VERSION` axis — what cic SPEAKS says nothing about what
it REQUIRES, and after this bump those two no longer coincide (13 vs 9),
which is the axes working rather than drifting.

## Why a pin and not more diligence

Measured on `origin/main`: 12 bumps of `@protocol_version` (1 -> 13,
2026-07-27 -> 2026-09-06) against 3 writes of the cic constant, two of them
catch-ups (`2 -> 9` swallowed seven bumps at once). Since cic first declared a
version the two have been equal for roughly 8 days out of 22. The stale value
is the normal state of that file.

## The objection that was measured before the edit

`noteServerProtocol` is a pure inequality, so raising the constant to 13 does
not silence the warn against a server at 11 — it reverses its sign. That was
measured and ruled on before any change: `13` against an `11` server requires
bundle and BEAM from DIFFERENT commits, which is exactly the `--cic`-only skew
the warn exists to report, whereas today's warn fires with ZERO skew (prod
serves the `v1.5.1` bundle, declaring 9, against the `v1.5.1` server, speaking
11 — both from one tag). The condition is therefore unchanged; narrowing it to
`server < CLIENT` would reverse the deliberate choice recorded on the function
itself.

## Gates

| gate | result |
|---|---|
| new pin, PRE-cure tree | RED — `7 tests, 1 failure`, and the failure is the new assertion |
| new pin, POST-cure tree | GREEN — `7 tests, 0 failures` |
| `scripts/check.sh` | rc=0 — `8 doctests, 65 properties, 7151 tests, 0 failures`; bats `0 not ok` |
| `scripts/bun.sh run check` | rc=0 — 5 stages, 0 failed |
| `scripts/bun.sh run test` | 6752 passed on a same-commit detached bench (see below) |
| `scripts/design-notes-gate.sh` | rc=0 — names `1 new entry heading` |
| `scripts/union-rebase.sh` | rc=0, and VACUOUS by its own first line: the branch is already on top of `origin/main`, so the driver never ran |

The first full vitest run in the branch worktree had one red —
`compose.test.ts > setDraft writes per-channel`, `Test timed out in 5000ms` on
a bare `await import(...)`, zero assertions. That is the known intermittent
timeout class. Attributed by re-running the SAME commit on a fresh detached
bench worktree: `336 files / 6752 tests, 0 failed`, at load average 107.8
against the 23.8 the red run started from. Not claimed as structurally
excluded — `socket.ts` IS transitively reachable from `compose.ts`
(`compose -> commands/mode -> socket`), so the bench run is what attributes
it, not the import graph.

No merge from here.