### PR TITLE
union: the three 1.5.2 hotfixes, gated together

### DIFF
--- a/cicchetto/src/BundleReadout.tsx
+++ b/cicchetto/src/BundleReadout.tsx
@@ -1,0 +1,109 @@
+import type { Component } from "solid-js";
+import {
+  type BundleSkew,
+  bootBundleHashAccessor,
+  bootBundleVersionAccessor,
+  bundleSkew,
+  serverBundleHash,
+  serverBundleVersion,
+} from "./lib/bundleHash";
+
+// Issue 1974 — "which bundle am I running, and which one does the server say
+// is deployed?", answered in one place.
+//
+// All four facts already existed in `lib/bundleHash`; what did not exist was
+// anywhere to read them. Before this, `bootBundleVersionAccessor` surfaced in
+// the credits roll and the refresh toast, and the server side surfaced
+// nowhere at all — so the one question a person chasing a stale
+// service-worker cache actually asks had no answer in the UI.
+//
+// UNGATED, by vjt's ruling (relayed 2026-09-07): the readout lives on the
+// settings drawer's main index, not in `AdminDebugTab`. The people who get
+// served a stale bundle are ordinary PWA users, and the failure this makes
+// visible — `bundleHash.ts` `performRefresh`'s header, where the SW keeps
+// serving the OLD precached `index.html` for a reload or three — is only
+// observable by watching the running hash NOT move across presses. An
+// admin-gated panel cannot host that observation for the population that
+// hits it.
+//
+// NOT the credits modal, which is the only other ungated surface carrying any
+// of this: it is an easter egg by its own declaration (`lib/creditsModal.ts`
+// header), it is a full-viewport animated end-titles roll with a soundtrack,
+// and it renders ONE of the four values as a line that scrolls past.
+//
+// NO refresh control of its own. Three already exist (`errorBanners.ts` →
+// `requestBundleRefreshNow("user")`, `BootErrorBoundary.tsx`, and #674's
+// auto-refresh with #775's toast), and the first of those renders on the
+// ungated banner stack under EXACTLY the condition that makes a refresh
+// actionable here — `shouldShowRefreshBanner()`, which is now literally
+// `bundleSkew(...) === "skewed"`. A fourth door would be a second affordance
+// for the same verb, live in the same state, three lines apart.
+
+/** Every cell degrades to a word rather than to a blank. */
+const UNKNOWN_CELL = "unknown";
+
+/**
+ * The verdict line, one per member of the closed set.
+ *
+ * A `Record` and not a chain of ternaries, so adding a fourth `BundleSkew`
+ * member is a compile error here rather than a silently empty line.
+ */
+const SKEW_COPY: Record<BundleSkew, string> = {
+  aligned: "up to date — this tab is running the deployed build",
+  skewed: "out of date — this tab is still running an older build",
+  unknown: "not compared — the server has not announced a build yet",
+};
+
+const cell = (value: string | null): string => value ?? UNKNOWN_CELL;
+
+const BundleReadout: Component = () => {
+  // Computed from the SAME two reads the table prints, not from a second
+  // signal read: the verdict and the values it is a verdict about can then
+  // never disagree, which on a diagnosis surface is the whole point.
+  const skew = (): BundleSkew => bundleSkew(bootBundleHashAccessor(), serverBundleHash());
+
+  return (
+    <section
+      class="settings-section settings-section-card settings-build"
+      data-testid="settings-build"
+      data-skew={skew()}
+    >
+      <h4 class="settings-section-heading">build</h4>
+      {/* A real table, not a stack of lines: the reader's question is a
+          COMPARISON down a column, and the trivial-rebuild case #292 names —
+          same semver, different hash — is only legible when the two hashes sit
+          one above the other. The hashes are printed WHOLE; `versionLabel`
+          truncates to `SHORT_HASH_LEN` (7) to keep a sentence readable, and
+          vite's hash is 8 characters, so borrowing that formatter would drop
+          the last character of the two values being compared. */}
+      <table class="settings-build-table">
+        <thead>
+          <tr>
+            <td class="settings-build-corner" />
+            <th scope="col">running</th>
+            <th scope="col">deployed</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">version</th>
+            <td data-testid="settings-build-running-version">
+              {cell(bootBundleVersionAccessor())}
+            </td>
+            <td data-testid="settings-build-deployed-version">{cell(serverBundleVersion())}</td>
+          </tr>
+          <tr>
+            <th scope="row">build hash</th>
+            <td data-testid="settings-build-running-hash">{cell(bootBundleHashAccessor())}</td>
+            <td data-testid="settings-build-deployed-hash">{cell(serverBundleHash())}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="settings-section-blurb" data-testid="settings-build-skew">
+        {SKEW_COPY[skew()]}
+      </p>
+    </section>
+  );
+};
+
+export default BundleReadout;

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -9,6 +9,7 @@ import {
   Show,
 } from "solid-js";
 import AliasSettings from "./AliasSettings";
+import BundleReadout from "./BundleReadout";
 import DeleteAccountModal from "./DeleteAccountModal";
 import InlineConfirmButton from "./InlineConfirmButton";
 import { windowCandidates } from "./lib/activeWindows";
@@ -1393,6 +1394,19 @@ const SettingsDrawer: Component<Props> = (props) => {
               who built this, and out of what
             </span>
           </button>
+
+          {/* Issue 1974 — running bundle vs deployed bundle. UNGATED on vjt's
+            ruling: the person served a stale service-worker cache is an
+            ordinary PWA user, so the readout cannot live behind the admin
+            gate in `AdminDebugTab`. This is the drawer's only ungated,
+            always-reachable surface that is not an easter egg.
+
+            Below `credits` and not among the nav rows, because it is neither
+            an entry nor a setting: it PUSHES nothing and it CHANGES nothing.
+            The #1773 contract that credits is "LAST of the drawer's own
+            entries" is untouched — a readout is not an entry, and the two sit
+            together on purpose as the drawer's "about this build" tail. */}
+          <BundleReadout />
 
           {/* UX-4 bucket L — bottom "done" button. Same close verb as
             the top × — mobile thumb-reach surface. Sits below logout

--- a/cicchetto/src/__tests__/BundleReadout.test.tsx
+++ b/cicchetto/src/__tests__/BundleReadout.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The four accessors are module-init constants in a real browser (`<script
+// src>` and `<meta>` are read once), and jsdom has neither tag — so the boot
+// side is permanently null here unless it is stubbed. Same seam and same
+// reason as `Toasts.test.tsx`, which stubs the same two boot accessors.
+//
+// `importOriginal` is spread so `bundleSkew` stays the REAL function: it is
+// the pure verdict under test, and mocking it would leave the readout's
+// aligned/skewed/unknown line asserting only against itself.
+const bundle = vi.hoisted(() => ({
+  bootHash: null as string | null,
+  bootVersion: null as string | null,
+  serverHash: null as string | null,
+  serverVersion: null as string | null,
+}));
+
+vi.mock("../lib/bundleHash", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/bundleHash")>()),
+  bootBundleHashAccessor: () => bundle.bootHash,
+  bootBundleVersionAccessor: () => bundle.bootVersion,
+  serverBundleHash: () => bundle.serverHash,
+  serverBundleVersion: () => bundle.serverVersion,
+}));
+
+import BundleReadout from "../BundleReadout";
+
+// Real vite output shape, measured on `cicchetto/dist/index.html`:
+// `/assets/index-DyH3fZLf.js` — an EIGHT-character hash. The fixtures below
+// keep that width on purpose; the truncation assertion depends on it.
+const BOOT_HASH = "DyH3fZLf";
+const SERVER_HASH = "Ab12Cd34";
+
+const text = (testId: string): string => screen.getByTestId(testId).textContent?.trim() ?? "";
+
+describe("BundleReadout (issue 1974 — running bundle vs deployed bundle)", () => {
+  beforeEach(() => {
+    bundle.bootHash = null;
+    bundle.bootVersion = null;
+    bundle.serverHash = null;
+    bundle.serverVersion = null;
+  });
+
+  it("renders all FOUR facts — boot version+hash and server version+hash — side by side", () => {
+    bundle.bootHash = BOOT_HASH;
+    bundle.bootVersion = "0.16.0";
+    bundle.serverHash = SERVER_HASH;
+    bundle.serverVersion = "0.16.1";
+    render(() => <BundleReadout />);
+
+    // The whole point of the issue: four values, in one place, at once.
+    // Asserted per cell rather than on the section's concatenated text, so a
+    // regression that drops one side cannot hide behind the other three.
+    expect(text("settings-build-running-version")).toBe("0.16.0");
+    expect(text("settings-build-running-hash")).toBe(BOOT_HASH);
+    expect(text("settings-build-deployed-version")).toBe("0.16.1");
+    expect(text("settings-build-deployed-hash")).toBe(SERVER_HASH);
+  });
+
+  it("prints the build hash WHOLE, not the banner's 7-char short form", () => {
+    // `versionLabel`/`formatRefreshBanner` truncate to SHORT_HASH_LEN = 7 so a
+    // sentence stays readable. A readout exists to be COMPARED against another
+    // hash, and vite's hash is 8 characters — reusing that formatter here
+    // would silently drop the last one of the two values being compared.
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = SERVER_HASH;
+    render(() => <BundleReadout />);
+
+    expect(text("settings-build-running-hash")).toHaveLength(BOOT_HASH.length);
+    expect(text("settings-build-deployed-hash")).toHaveLength(SERVER_HASH.length);
+  });
+
+  it("reads 'aligned' when the two hashes agree", () => {
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = BOOT_HASH;
+    render(() => <BundleReadout />);
+
+    expect(screen.getByTestId("settings-build").getAttribute("data-skew")).toBe("aligned");
+    expect(text("settings-build-skew").length).toBeGreaterThan(0);
+  });
+
+  it("reads 'skewed' when the two hashes disagree (the stale-bundle case)", () => {
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = SERVER_HASH;
+    render(() => <BundleReadout />);
+
+    expect(screen.getByTestId("settings-build").getAttribute("data-skew")).toBe("skewed");
+  });
+
+  it("reads 'unknown' before the server has announced a build — NOT 'aligned'", () => {
+    // The third state is load-bearing: until the user-topic join lands its
+    // `bundle_hash`, nothing has been compared. Painting that as "up to date"
+    // would state a fact nobody measured, which is the failure the readout
+    // exists to stop.
+    bundle.bootHash = BOOT_HASH;
+    bundle.serverHash = null;
+    render(() => <BundleReadout />);
+
+    expect(screen.getByTestId("settings-build").getAttribute("data-skew")).toBe("unknown");
+  });
+
+  it("degrades an unknown cell to a word, never to a blank", () => {
+    // A build genuinely can carry no semver (a bundle built before #292, or a
+    // server that omits the wire key), and an empty cell reads as a broken
+    // readout rather than as the truth about the build — the same posture
+    // CreditsModal takes with "version unknown".
+    bundle.bootHash = BOOT_HASH;
+    bundle.bootVersion = null;
+    bundle.serverHash = null;
+    bundle.serverVersion = null;
+    render(() => <BundleReadout />);
+
+    expect(text("settings-build-running-version")).toBe("unknown");
+    expect(text("settings-build-deployed-version")).toBe("unknown");
+    expect(text("settings-build-deployed-hash")).toBe("unknown");
+    // The one fact we DO have still shows — a degraded neighbour must not
+    // blank the cell that is known.
+    expect(text("settings-build-running-hash")).toBe(BOOT_HASH);
+  });
+});

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -1796,6 +1796,39 @@ describe("SettingsDrawer (#460 — settings index)", () => {
     expect(screen.getByTestId("share-session-entry")).toBeInTheDocument();
     expect(screen.getByTestId("settings-drawer-done")).toBeInTheDocument();
   });
+
+  // Issue 1974 — the running-vs-deployed bundle readout. The ruling that
+  // decided this issue is about REACHABILITY, so that is what these pin: the
+  // four cells' contents belong to `BundleReadout.test.tsx`.
+  it("issue 1974 — the bundle readout renders on the main index with NO subject at all (ungated)", () => {
+    // `beforeEach` leaves `meHolder`/`subjectHolder` null: no user, no admin.
+    // A readout behind either gate finds nothing here — which is precisely
+    // the `AdminDebugTab` posture the ruling rejected, because the population
+    // served a stale service-worker cache is ordinary PWA users.
+    wrap(true);
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+    // All four cells, not just the card: a mounted-but-empty readout would
+    // satisfy the line above and answer none of the question.
+    expect(screen.getByTestId("settings-build-running-version")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-build-running-hash")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-build-deployed-version")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-build-deployed-hash")).toBeInTheDocument();
+  });
+
+  it("issue 1974 — a visitor sees the bundle readout too (not a user-kind gate either)", () => {
+    subjectHolder.current = { kind: "visitor", id: "v1", nick: "alice" };
+    wrap(true);
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+  });
+
+  it("issue 1974 — the readout belongs to the index: a sub-page replaces it, back restores it", () => {
+    wrap(true);
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+    openSub("display-settings-entry");
+    expect(screen.queryByTestId("settings-build")).toBeNull();
+    fireEvent.click(screen.getByTestId("display-back"));
+    expect(screen.getByTestId("settings-build")).toBeInTheDocument();
+  });
 });
 
 // #476 / #478 — the per-network identity editor is available to BOTH subjects

--- a/cicchetto/src/__tests__/bundleHash.test.ts
+++ b/cicchetto/src/__tests__/bundleHash.test.ts
@@ -3,6 +3,7 @@ import {
   __resetBundleHashForTests,
   bootBundleHashAccessor,
   bootBundleVersionAccessor,
+  bundleSkew,
   formatRefreshBanner,
   performRefresh,
   serverBundleHash,
@@ -45,6 +46,38 @@ describe("bundleHash", () => {
     }
     setServerBundleHash("definitely-different-hash-xxx");
     expect(shouldShowRefreshBanner()).toBe(true);
+  });
+
+  // Issue 1974 — the three-way verdict the readout renders. Pure, so every
+  // arm is reachable here; `shouldShowRefreshBanner` above can only ever
+  // observe the "skewed" one, which is why it could be a boolean and this
+  // cannot.
+  describe("bundleSkew (issue 1974)", () => {
+    it("is 'aligned' when the two hashes are the same", () => {
+      expect(bundleSkew("DyH3fZLf", "DyH3fZLf")).toBe("aligned");
+    });
+
+    it("is 'skewed' when the two hashes differ", () => {
+      expect(bundleSkew("DyH3fZLf", "Ab12Cd34")).toBe("skewed");
+    });
+
+    it("is 'unknown' — NOT 'aligned' — when either side is null", () => {
+      // Both null is the state every page is in before the user-topic join
+      // lands its `bundle_hash`. Collapsing that into "aligned" would let the
+      // readout claim agreement between a value and nothing.
+      expect(bundleSkew(null, "Ab12Cd34")).toBe("unknown");
+      expect(bundleSkew("DyH3fZLf", null)).toBe("unknown");
+      expect(bundleSkew(null, null)).toBe("unknown");
+    });
+
+    it("is exactly what shouldShowRefreshBanner tests for (one comparison, not two)", () => {
+      // The banner predicate is now defined as `bundleSkew(...) === "skewed"`.
+      // Pinned because the failure mode of re-inlining the comparison is a
+      // readout and a banner that disagree about whether this tab is stale.
+      setServerBundleHash("definitely-different-hash-xxx");
+      const boot = bootBundleHashAccessor();
+      expect(shouldShowRefreshBanner()).toBe(bundleSkew(boot, serverBundleHash()) === "skewed");
+    });
   });
 
   describe("bundle version signals (#292)", () => {

--- a/cicchetto/src/lib/bundleHash.ts
+++ b/cicchetto/src/lib/bundleHash.ts
@@ -81,13 +81,39 @@ export function setServerBundleVersion(version: string | null): void {
   setServerBundleVersionInternal(version);
 }
 
+/**
+ * Whether the bundle this tab booted is the one the server says is deployed.
+ *
+ * A closed set of three, not a boolean, and `"unknown"` is the load-bearing
+ * member (issue 1974): until the user-topic join lands its `bundle_hash`, or
+ * on a page with no parseable `<script src>`, the two sides have not been
+ * compared at all. The banner predicate below only ever needed "is there
+ * skew", so it could collapse that into `false`; a READOUT cannot, because
+ * painting an uncompared pair as "up to date" states a fact nobody measured.
+ */
+export type BundleSkew = "aligned" | "skewed" | "unknown";
+
+/**
+ * Pure verdict over the two hashes — same pure/wrapper split this module
+ * already uses for `formatRefreshBanner` vs `refreshBannerMessage`, so a
+ * caller that RENDERS both hashes can compute the verdict from exactly the
+ * values it printed rather than from a second, independent signal read.
+ */
+export function bundleSkew(bootHash: string | null, serverHash: string | null): BundleSkew {
+  if (bootHash === null || serverHash === null) return "unknown";
+  return bootHash === serverHash ? "aligned" : "skewed";
+}
+
 // True iff (1) we know what we booted with, (2) the server has told us
 // what's live, and (3) they differ. nulls on either side = unknown =
 // don't pester the user; the next push will resolve the question.
+//
+// Derived from `bundleSkew` rather than restating its comparison: two copies
+// of "are these the same bundle" is one copy too many, and the readout and
+// the banner disagreeing about it is precisely the confusion a diagnosis
+// surface must not create.
 export function shouldShowRefreshBanner(): boolean {
-  const boot = bootBundleHash();
-  const server = serverBundleHashSignal();
-  return boot !== null && server !== null && boot !== server;
+  return bundleSkew(bootBundleHash(), serverBundleHashSignal()) === "skewed";
 }
 
 // #292 — refresh bar "current vs available" version display.

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -91,17 +91,56 @@ let _socket: Socket | null = null;
 // refuse every server that accepts it. The pair moves together or neither
 // moves.
 //
+// 9 → 13. The same defect as 2 → 9, recurring for the same reason: nothing
+// pinned this number to `Grappa.Protocol.version/0` — only to its FLOOR,
+// which is 1 and which everything satisfies. In the seven days after 9
+// landed the server bumped four times (10, the server_pass route; 11, the
+// upload-confirm settings door; 12, the ISON presence fallback; 13, the
+// stale_code_path refusal) and this constant did not move, so every boot of
+// every current bundle logged `protocol mismatch: this bundle speaks 9, the
+// server speaks 11` against production. A true statement about a stale
+// constant, again — and this time it cost someone real work: a tester
+// narrowing an unrelated report read it in the console and offered it as the
+// likely cause.
+//
+// The bundle already SPOKE 13 and merely declared 9. `wireSchema.ts` carries
+// v12's `presence_changed.source: "ison"` and v13's `stale_code_path`
+// refusal token; the number was the only thing lagging.
+//
+// Measured, because the shape of the recurrence is the argument for the new
+// pin rather than for more diligence: 12 bumps of `@protocol_version`
+// against 3 writes of this constant, two of which were catch-ups (2 → 9
+// swallowed seven bumps at once). Since cic first declared a version the two
+// have been equal for roughly 8 days out of 22 — the stale value is the
+// NORMAL state of this file, not an accident that better attention would
+// have avoided.
+//
+// Why it is not cosmetic, and why the cure is a pin and not a habit:
+// `noteServerProtocol` below warns on ANY inequality and its only silence is
+// exact equality, so a lagging constant fires "protocol mismatch" on every
+// healthy boot of a deploy whose bundle and BEAM came from the SAME commit.
+// That is the one signal for a service-worker-cached PWA skewed against the
+// BEAM (see its own note), and a signal that fires on every healthy boot
+// cannot carry that meaning. `protocol_test.exs` now pins
+// `cic_protocol_version() == Protocol.version()`, so the next bump that
+// forgets this file is red at the commit that forgets it, and an inequality
+// at RUNTIME means what it is supposed to mean: the two artefacts came from
+// different commits.
+//
 // Raising THIS one is safe in the direction that can bite: the handshake
 // refuses a client BELOW `Grappa.Protocol.min_version/0`, which is 1, and
 // never one above. `protocol_test.exs` pins that from the other side
-// (`cic_protocol_version() >= Protocol.min_version()`).
+// (`cic_protocol_version() >= Protocol.min_version()`) and, since #1973, the
+// equality against `version/0` as well.
 //
 // This is what cic SPEAKS. What it REQUIRES of the server is a separate
 // constant in `serverProtocol.ts` (`MIN_SERVER_PROTOCOL_VERSION`), and the
 // two are deliberately not the same number — a later bundle may speak v5
-// and still cope with a v2 server. They coincide today; that is a fact about
-// today, not a merge of the two axes.
-export const CLIENT_PROTOCOL_VERSION = 9;
+// and still cope with a v2 server. They coincided until this bump and no
+// longer do: this bundle speaks 13 and still serves a v9 server. That gap is
+// the two axes behaving as designed, not drift to be tidied away — raising
+// the floor is the #1654 question and is not answered here.
+export const CLIENT_PROTOCOL_VERSION = 13;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -10157,6 +10157,40 @@ button.topic-bar-windows-opener {
   font-size: 0.85rem;
 }
 
+/* Issue 1974 — running-vs-deployed bundle readout, at the tail of the
+ * settings index. It borrows `.settings-section-card` wholesale (heading +
+ * bordered bg-alt card) rather than minting a look of its own; the only thing
+ * it needs beyond the shared idiom is the 2×2 matrix and the per-verdict
+ * accent below. */
+.settings-build-table {
+  border-collapse: collapse;
+  /* Not `width: 100%`: the cells hold an 8-char hash and a semver, and
+   * stretching them to the drawer's full width puts the two values the reader
+   * is comparing as far apart as the layout allows. */
+  width: auto;
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+.settings-build-table :where(th, td) {
+  padding: 0.1rem 0.75rem 0.1rem 0;
+  font-weight: normal;
+  /* The hash is the thing being compared character by character, so it must
+   * never wrap mid-token into two visually different-looking values. */
+  white-space: nowrap;
+}
+
+.settings-build-table :where(thead th, tbody th) {
+  color: var(--muted);
+}
+
+/* The verdict line carries the colour, not the card: a bordered box that
+ * turns red the moment a deploy lands would read as an error the user has to
+ * act on, and being one build behind is not one. */
+.settings-build[data-skew="skewed"] .settings-section-blurb {
+  color: var(--accent);
+}
+
 /* #462 — the per-network identity editor had NO rule of its own. What the
    issue reports as "unstyled inputs" is already fixed: #497/#508's global
    input treatment gives the three fields their 44px height, the app's

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47446,3 +47446,79 @@ them to contrast had the second silently eat the first.
 _Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
 release image, so it reaches an operator only through a new image. The m42
 jail runs `mix release` and does not read it; nothing else here leaves CI._
+<!-- entry #1973 -->
+
+---
+
+## 2026-09-07 — #1973: the client protocol constant lags by construction, so the cure is a pin and not more diligence
+
+`cicchetto`'s `CLIENT_PROTOCOL_VERSION` said 9 while `Grappa.Protocol`'s
+`@protocol_version` said 13, so every boot of every current bundle logged
+`protocol mismatch: this bundle speaks 9, the server speaks 11` against
+production. The same defect the constant's own note already records for
+`2 → 9` — *"a true statement about a stale constant, not about a real
+incompatibility"* — and it came back because nothing pinned the two numbers
+to each other in this direction.
+
+**The recurrence is structural, and that is the argument.** Measured on
+`origin/main`: 12 bumps of `@protocol_version` (1 → 13, 2026-07-27 →
+2026-09-06) against 3 writes of the cic constant, two of which were
+catch-ups — `2 → 9` swallowed seven bumps at once. Since cic first declared
+a version (2026-08-16) the two have been equal for roughly 8 days out of 22.
+The stale value is the NORMAL state of that file. A rule saying "remember to
+bump both" has now been written twice and obeyed neither time.
+
+**Why the three existing pins all stayed green: every one of them is
+one-sided, and none of them looks at `version/0`.**
+`protocol_test.exs` asserted `cic >= Protocol.min_version()` (`9 >= 1`) and
+cic's floor `<= Protocol.version()` (`9 <= 13`); `serverProtocol.test.ts`
+asserted `MIN_SERVER <= CLIENT` (`9 <= 9`). Nothing compared cic against what
+the server actually SPEAKS. The new pin is
+`cic_protocol_version() == Protocol.version()`, and equality rather than `>=`
+because the two are one contract version by definition: cic below is a stale
+constant, cic above is a bundle claiming a shape no server ever emitted, and
+`>=` waves one of them through. It is deliberately NOT the
+`MIN_SERVER_PROTOCOL_VERSION` axis — what cic SPEAKS says nothing about what
+it REQUIRES, and after this bump the two no longer coincide (13 vs 9), which
+is those axes working rather than drifting.
+
+### The objection that had to be measured before the cure, and how it resolved
+
+`noteServerProtocol` is a pure inequality: its only silence is exact
+equality, so it warns for `server < CLIENT` and `server > CLIENT` alike.
+Raising the constant to 13 while production speaks 11 therefore does not
+silence the warn — it reverses its sign. The question raised before any edit
+was whether the cure merely relocates the lie.
+
+It does not, and the distinction is between the two configurations rather
+than between the two directions. Today's warn fires with ZERO skew: prod
+serves the `v1.5.1` bundle (declares 9, measured at the tag) against the
+`v1.5.1` server (speaks 11), both artefacts from one commit, and that is what
+makes the message a lie. After the bump and the pin, bundle and BEAM built
+from the same commit are equal by construction, so an inequality at runtime
+means the two artefacts came from DIFFERENT commits — which is exactly the
+`--cic`-only skew the warn was written to surface. `13` against a `11` server
+is reachable only that way.
+
+Measured while resolving it, and worth keeping because it bounds the claim:
+the two deltas between 11 and 13 cannot hurt a newer bundle talking to an
+older server. v12's break was measured in the OPPOSITE direction (an old
+bundle drops `presence_changed` on the unknown `source: "ison"` enum member;
+a bundle knowing the wider set accepts a server that never sends it), and
+v13's `stale_code_path` token is loopback-gated, so no browser is ever handed
+it. That acquits those two deltas specifically — it is not a general proof
+that a newer bundle tolerates an older server, which #1393d repealed
+outright.
+
+vjt's call (2026-09-07): keep the condition as it is. Narrowing the warn to
+`server < CLIENT` would reverse a deliberate choice — the note on the
+function already says the newer-server direction is additive and tolerated
+and keeps warning anyway, because on a service-worker-cached PWA the skew
+FACT is the signal. The floor (`MIN_SERVER_PROTOCOL_VERSION`,
+`min_protocol_version`) is the #1654 question and is untouched here.
+
+_Deploy: **cic bundle** — one integer literal and comments in `socket.ts`;
+the pin is a test and reaches CI only. Ship the bundle with a server built
+from the same commit: a `--cic`-only push of this bundle onto the current
+`1.5.1` BEAM will log the mismatch, and after this change that log is telling
+the truth._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47446,3 +47446,112 @@ them to contrast had the second silently eat the first.
 _Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
 release image, so it reaches an operator only through a new image. The m42
 jail runs `mix release` and does not read it; nothing else here leaves CI._
+<!-- entry #1974 -->
+
+---
+
+## 2026-09-07 — issue 1974: where "which bundle am I running?" gets answered
+
+The four facts were already collected. `cicchetto/src/lib/bundleHash.ts` has
+carried `bootBundleHashAccessor`, `bootBundleVersionAccessor`,
+`serverBundleHash` and `serverBundleVersion` since #292; the skew between them
+already drives the refresh banner. What did not exist was anywhere to READ
+them. Measured before touching anything: `bootBundleVersionAccessor` reached
+exactly two surfaces — the credits roll and #775's update toast — and the two
+server-side accessors reached NO production code at all, only tests and the
+e2e window hook. So a person chasing a stale service-worker cache had one of
+the four numbers, in an easter egg, and none of the server side.
+
+### The ruling, and why it is not `AdminDebugTab`
+
+The issue left one thing open — which panel — and vjt ruled it UNGATED
+(relayed 2026-09-07, not observed first-hand). `AdminDebugTab` is the panel
+named for diagnosis and it stays exactly as it is.
+
+The argument that decided it is a population argument: whoever gets served a
+stale bundle is an ordinary PWA user, so a readout behind `is_admin` answers
+the question for everyone except the people who have it. The second half is
+sharper. The failure worth seeing is the one `performRefresh`'s own header
+documents (`bundleHash.ts`, the UX-6-I comment): the service worker keeps
+serving the OLD precached `index.html`, so a refresh press can land back on
+the same bundle — the "three presses to update" vjt measured on iPhone. That
+is only observable by watching the running hash NOT move across presses, and
+an admin-gated panel cannot host that observation for the population that
+hits it.
+
+Within "ungated", the placement is the settings drawer's main index, at the
+tail beside `credits`. The drawer is the one ungated, always-reachable
+surface both subject kinds get; it is not the credits modal, which declares
+itself an easter egg (`lib/creditsModal.ts` header), is a full-viewport
+animated end-titles roll with a soundtrack, and renders one of the four
+values as a line that scrolls past. It is deliberately NOT a
+`.settings-nav-row`: a nav row pushes a sub-page and wears a chevron saying
+so, and this pushes nothing and changes nothing. #1773's contract that
+`credits` is the LAST of the drawer's own ENTRIES is therefore untouched — a
+readout is not an entry.
+
+### Why the boolean had to become a closed set of three
+
+`shouldShowRefreshBanner()` folded "we have not compared yet" into the same
+`false` as "these agree". For a banner that is right: both mean do-not-pester.
+For a readout it is a lie, and precisely the lie the surface exists to
+prevent — before the user-topic join lands its `bundle_hash`, nothing has been
+compared, and rendering that as "up to date" asserts a fact nobody measured.
+
+So the comparison moved into a pure `bundleSkew(bootHash, serverHash) ->
+"aligned" | "skewed" | "unknown"`, and the banner predicate is now literally
+`bundleSkew(...) === "skewed"`. Pure-plus-caller rather than a signal-reading
+`bundleSkew()` with no arguments: the readout renders both hashes, so it
+computes the verdict from exactly the two values it printed and the two can
+never disagree. The module already used this shape — `formatRefreshBanner`
+(pure) beside `refreshBannerMessage` (signal-reading wrapper).
+
+### Two things deliberately NOT built
+
+**No fourth refresh button.** Three already exist: `errorBanners.ts:282` →
+`requestBundleRefreshNow("user")`, `BootErrorBoundary.tsx:138`, and #674's
+auto-refresh announced by #775's toast. The first of those renders on the
+ungated banner stack under `shouldShowRefreshBanner()` — which is now, by
+definition, the same condition that makes a refresh actionable in the
+readout. A control here would be the same verb twice, live in the same state,
+a drawer apart.
+
+**No build id or ISO date.** The version and the hash are already baked; a
+third carrier is exactly the drift #538 closed
+(`cicchetto/src/lib/buildCredits.ts:13-15`).
+
+### The hash prints whole, and that is a measurement
+
+`versionLabel`/`formatRefreshBanner` truncate to `SHORT_HASH_LEN = 7` so a
+sentence stays readable, and reusing them here was the obvious move. Measured
+against a real build instead: `cicchetto/dist/index.html` points at
+`/assets/index-DyH3fZLf.js` — an EIGHT-character hash. Borrowing the banner's
+formatter would drop the last character of the two values the reader opened
+the panel to compare. The readout therefore renders four cells rather than
+two composed labels, which also makes the trivial-rebuild case #292 names
+(same semver, different hash) legible as a column.
+
+### What was proven, and what was not
+
+Red-then-green on a new `BundleReadout.test.tsx` (six cases), plus three
+reachability cases in `SettingsDrawer.test.tsx` and four on the pure
+predicate. Four mutants, each killing what it was predicted to kill and
+nothing else: the deployed-version cell reading the boot accessor (1 test),
+the `unknown` arm returning `aligned` (2 — one per file, the pure fn and the
+render), `cell()` truncating to 7 (3), and unmounting the readout from the
+drawer (3 — the drawer cases only, so the mount is pinned separately from the
+component). Negative control: rewording all three verdict strings kills
+nothing, so the tests pin structure and values rather than prose.
+
+NOT established, and worth stating rather than implying: nothing here was
+observed in a real browser or on a real PWA install. The "three presses"
+behaviour this readout is meant to make visible remains #292/UX-6-I's
+measurement, not one taken in this slice — jsdom has neither a service worker
+nor a precache. The readout is also reachable only by an AUTHENTICATED
+subject; a bundle stale enough to break login is `BootErrorBoundary`'s
+territory and keeps its own refresh.
+
+_Deploy: **cic bundle only** — no server code, no wire change, no
+`protocol_version` movement. `serverBundleVersion` was already on the wire
+(`api.ts` `bundle_hash` event); this slice is the first production code to
+read it._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47446,3 +47446,133 @@ them to contrast had the second silently eat the first.
 _Deploy: **cold** — `infra/docker/release-entrypoint.sh` is baked into the
 release image, so it reaches an operator only through a new image. The m42
 jail runs `mix release` and does not read it; nothing else here leaves CI._
+<!-- entry #1952b -->
+
+---
+
+## 2026-09-07 — #1952b: the two hostile shapes the first pass refused, and the reading that made one of them look impossible
+
+The hostile-substrate matrix #1952 asks for is FOUR shapes. The first pass
+shipped two — `--read-only` and `--workdir /` — and named the other two in the
+driver's non-coverage list, one as a judgement and one as a measurement. Both
+are now run. This entry is mostly about why the refusals were wrong, because
+the mistake is reusable and the fix is not.
+
+### An arbitrary uid: the mechanism was right, the conclusion did not follow
+
+The refusal read: docker re-seeds an EMPTY named volume from the image on every
+mount, ownership included, so a helper container's `chown -R 65534 /data` reads
+back as `65534` inside that container and as the image's `100:101` in the next
+one — therefore the shape cannot be set up.
+
+The first clause is TRUE and re-measured here: create a volume, chown it,
+mount it again, and the image's owner is back. The second clause does not
+follow from it, because the re-seed only applies **while the volume is empty**.
+One zero-byte file inside and the ownership sticks:
+
+| fixture | next container reads |
+| --- | --- |
+| empty volume, `chown 65534` from a helper | `100:101` — re-seeded |
+| one file inside, `chown -R 65534` | `65534:65534`, and writable |
+| control: virgin volume, `--user 65534` writes | `permission denied` |
+
+So the shape is constructible, and the fixture is not a trick to dodge docker:
+handing storage to the uid it will run as is what an arbitrary-uid deployment
+does anyway — a Kubernetes `fsGroup`, an operator's `chown` on the host path.
+The general rule the miss illustrates: **a measured mechanism plus an
+inference is not a measurement.** "I could not build it" and "it cannot be
+built" are different claims, and only the first was in evidence.
+
+What the shape then found is the strongest red in the file, because it is
+#1945 verbatim rather than a cousin of it. Same fixture, same flags, the two
+releases apart:
+
+```
+v1.5.1   running/0, /healthz in 2s
+v1.5.0   exited/1
+         ** (File.Error) could not make directory (with -p)
+            "runtime/peer_avatars": permission denied
+                (grappa 1.5.0) lib/grappa/avatars/reaper.ex:79
+```
+
+The path in that error is RELATIVE. `/app` is writable by the baked user and
+by nobody else, which is exactly why the same defect is silent on every other
+docker shape. The control that makes the pair mean something: v1.5.0 with the
+baked user on an ordinary volume boots healthy, so the red belongs to the uid
+and not to the release.
+
+### A volume over /app: one sentence, two substrates, opposite answers
+
+The refusal read: the release IS `/app`, so mounting over it removes the thing
+under test. That is TRUE OF A BIND MOUNT AND FALSE OF A NAMED VOLUME, and the
+issue's words ("a volume mounted over `/app`") name the second.
+
+* empty **bind** mount — the container is not merely unable to boot, it cannot
+  be CREATED: `stat /app/release-entrypoint.sh: no such file or directory`,
+  status `created/127`. It stays in the non-coverage list, now with that
+  measurement attached.
+* named **volume** — docker copies the image's `/app` into it at first mount,
+  permissions and the setgid bit included, and the container boots. Both
+  v1.5.0 and v1.5.1 answer `/healthz`.
+
+Which is the problem with the shape: **boot alone does not discriminate**, so
+a probe asserting only `/healthz` here would be a fifth ordinary boot. What
+discriminates is the release root itself. `docker diff` — probe 7's oracle for
+"the boot wrote nothing outside /data" — never reports what is under a mount,
+and on this substrate answers **zero lines for v1.5.0**, whose #1945 defect
+creates `runtime/peer_avatars` right there. So shape 3 reads the same property
+through the window the mount leaves open: `ls -1A` on the volume after the
+boot must equal `ls -1A` on the `/app` the image ships. Measured, the same
+comparison the driver runs:
+
+```
+[ -s shipped ]  → non-empty (the blindness guard)
+cmp             → DIFFER
+diff            → 7a8 > runtime
+```
+
+### What this probe's green does NOT mean, and it needs saying
+
+Mounting a volume over `/app` is not thereby supported. The copy-up happens
+ONCE, while the volume is empty: pull a new image, recreate the container, and
+the volume still holds the OLD release. Measured — a container started from
+`:v1.5.1` on a volume seeded by v1.5.0 reports `.Config.Image = …:v1.5.1` to
+`docker inspect` and version `1.5.0` to `/api/config`. Silent stale code across
+exactly the upgrade this issue exists for. The driver therefore removes that
+volume before the run AND in the teardown, since a leaked one would make the
+NEXT smoke boot a release nobody built while reporting the tag it was asked
+for.
+
+### A mutation test that landed somewhere else, and was worth keeping
+
+To prove shape 3's oracle is not blind, an image was built from v1.5.1 with
+#1945's shape reintroduced — a relative `mkdir -p runtime/peer_avatars` in the
+entrypoint, guarded by a `cmp` proving the `sed` had matched. Run through the
+driver it died at **probe 7**, not shape 3: the mutation writes on every boot,
+and `docker diff` on the ordinary container sees it first. That is the right
+behaviour and the wrong experiment — the two oracles overlap on the ordinary
+substrate, and shape 3's exists only for the one where probe 7 cannot look. The
+isolating evidence is the direct run above, against a volume a real v1.5.0
+booted on.
+
+### Shape of the driver
+
+`hostile_boot` now takes the `uid:gid` its `/data` volume must be handed to as
+a REQUIRED third argument — no default, because that ownership is half of what
+a shape means, and a call that forgets it puts a docker flag where the owner
+belongs. Three of the four pass the image's own owner, read out of the image
+with `stat -c %u:%g /data` rather than spelled: a literal `100:101` here is a
+second copy of a Dockerfile fact, wrong the day `adduser -S` picks another
+number. The arbitrary uid is guarded against BEING that owner, or the shape
+would be an ordinary boot wearing a `--user` flag.
+
+`test/infra/release_hostile_matrix_test.bats` is the PR-time half, for the same
+reason the upgrade probe has one: nothing in the `smoke` job runs on a pull
+request. It folds the driver's backslash-continuations and EVALUATES each
+`hostile_boot` call with the function replaced by a recorder, so the assertions
+read the real argument lists through the real quoting — a shape that dropped
+its owner argument shows up as a flag in `$3`, which is the mistake a grep
+cannot see. It carries its own negative control on that predicate.
+
+_Deploy: **nothing** — the driver and its bats run in CI and by hand; no
+runtime code changed, and no substrate reads either file._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1947,7 +1947,7 @@ D** — see **Running the published image** below.
   is `scripts/smoke-release-image.sh`, runnable by hand — probes, mutation
   evidence and the explicit non-coverage list are in
   `docs/TESTING.md` § "The release-image smoke".
-- **It crosses a VERSION SEAM, and boots where the cwd is hostile (#1952).**
+- **It crosses a VERSION SEAM, and boots on hostile substrates (#1952).**
   Until then every probe was a FIRST boot on an empty volume of ONE image, so
   the shape that breaks a self-hoster — an existing box on the previous
   release, updated in place — had no coverage; that is the shape #1945 reached
@@ -1959,8 +1959,19 @@ D** — see **Running the published image** below.
   written under the old release still there. It then asserts that the boot
   wrote **nothing** into the container layer (`docker diff`, which never
   reports what is under a mount — measured empty on a healthy release and
-  three lines on v1.5.0, two of them #1945 itself), and boots the candidate
-  under `--read-only --tmpfs /tmp` and under `--workdir /`.
+  three lines on v1.5.0, two of them #1945 itself), and boots the candidate on
+  FOUR hostile substrates (#1952b): `--read-only --tmpfs /tmp`, `--workdir /`,
+  a named volume mounted over `/app`, and `--user 65534`. Each carries a
+  `docker inspect` check proving the flag is actually in force, and the `/app`
+  shape additionally compares the release root after the boot against the one
+  the image ships — `docker diff` cannot see under a mount, and answers zero
+  lines for v1.5.0 there while the volume grows `runtime`.
+  ⚠️ **Do not read the `/app` shape's green as "mounting a volume over `/app`
+  is supported".** Docker seeds such a volume from the image ONCE, while it is
+  empty: recreate the container on a newer image and it boots the OLD release
+  while `docker inspect` reports the new tag (measured, `:v1.5.1` on a
+  v1.5.0-seeded volume serving `1.5.0` from `/api/config`). Mount volumes at
+  `/data`, never at `/app`.
   ⚠️ **The previous image is now REQUIRED**, on the same no-skip footing as
   the candidate: a run that quietly fell back to the same-version probes would
   report exactly the green this closed. The one exception is a repair dispatch

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -452,22 +452,56 @@ passing that arg too — see § "The published release image" in
 `docs/OPERATIONS.md`. The asymmetry is the point: the naked build must
 keep degrading honestly, the shipped image must not.
 
-**The version seam, and the two hostile shapes that are NOT run (#1952).**
-The upgrade probe boots the previous release on a fresh volume, writes
-state through it, stops it and starts the candidate on that same volume —
-previous → candidate only, since a downgrade is a different question with
-a different answer. How many migrations must run is DERIVED from the two
-images (the previous booted on an empty volume, so what is applied there
-is exactly its own set) rather than naming a migration that would go
-stale. Refused, and each for a measured reason rather than a preference:
+**The version seam (#1952).** The upgrade probe boots the previous
+release on a fresh volume, writes state through it, stops it and starts
+the candidate on that same volume — previous → candidate only, since a
+downgrade is a different question with a different answer. How many
+migrations must run is DERIVED from the two images (the previous booted
+on an empty volume, so what is applied there is exactly its own set)
+rather than naming a migration that would go stale.
 
-* **a volume over `/app`** removes the release itself, so asserting that
-  it answers 200 would assert a falsehood;
-* **an arbitrary uid (`--user 65534`)** cannot be set up. Docker re-seeds
-  an EMPTY named volume from the image on every mount, ownership
-  included, so `chown -R 65534 /data` in a helper container reads back as
-  `65534` inside it and as the image's `100:101` in the next one. The
-  property it would test is what the read-only shape asserts directly.
+**All FOUR hostile shapes now run (#1952b).** Each gets a first boot of
+its own on a fresh volume, and each carries a `docker inspect` ARM CHECK
+that must come back `true` — without it, a flag docker silently stopped
+honouring turns the shape into an ordinary boot reporting green. Two of
+them arrived later than the others and are worth reading before touching
+either:
+
+* **an arbitrary uid (`--user 65534`)** was first refused as
+  unconstructible, on a mechanism that is real and an inference that is
+  not. Docker re-seeds an EMPTY named volume's ownership from the image
+  on every mount — but only while it is empty, so one zero-byte file
+  inside makes a `chown -R` stick. `hostile_boot` therefore takes the
+  `uid:gid` its `/data` must be handed to as a required argument.
+  Measured, the same fixture on the two releases: v1.5.1 `/healthz` in
+  2s, v1.5.0 `exited/1` on `(File.Error) could not make directory (with
+  -p) "runtime/peer_avatars"` — #1945 verbatim, and note the RELATIVE
+  path. Control: v1.5.0 with the baked user on an ordinary volume boots
+  healthy, so the red is the uid and not the release.
+* **a volume over `/app`** boots, and that is not the same sentence for
+  both readings of it. An empty BIND mount leaves no release to run and
+  the container cannot even be created (`created/127`); a NAMED volume
+  is seeded from the image at first mount and comes up. Boot alone does
+  not discriminate — both releases answer `/healthz` — so this shape
+  also compares the release root after the boot against the one the
+  image ships (`ls -1A`, hidden entries included, with a non-empty
+  guard and a planted-`runtime/` canary). It must: `docker diff`, the
+  oracle for "the boot wrote nothing outside `/data`", never reports
+  what is under a mount and answers **zero lines** for v1.5.0 on this
+  substrate, while the volume grows `runtime`.
+  ⚠️ **A green here does NOT mean the shape is supported.** The copy-up
+  happens once, while the volume is empty; recreate the container on a
+  newer image and it still boots the OLD release — measured, `:v1.5.1`
+  on a v1.5.0-seeded volume reports the new tag to `docker inspect` and
+  `1.5.0` to `/api/config`. That is why the driver destroys that volume
+  before the run AND in the teardown.
+
+`test/infra/release_hostile_matrix_test.bats` is the PR-time half —
+nothing in the `smoke` job runs on a pull request, so a shape deleted or
+left unarmed would surface only on a release. It folds the driver's line
+continuations and EVALUATES each `hostile_boot` call with the function
+replaced by a recorder, so it reads the real argument lists rather than
+grepping for them.
 
 **The read-only recipe is `--read-only --tmpfs /tmp`, and nothing more.**
 Naked, the boot dies on `mktemp: : Read-only file system` before it

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -60,20 +60,13 @@
 #   * ONE direction only: previous -> candidate. A downgrade is a different
 #     question with a different answer (a migration that ran is not undone by
 #     booting the older image) and is not smuggled in here (#1952).
-#   * no volume mounted OVER /app. The release IS /app, so hiding it removes
-#     the thing under test, and a probe asserting that shape answers 200 would
-#     be asserting a falsehood.
-#   * no arbitrary-uid shape (`--user 65534`), and this one is a MEASUREMENT
-#     rather than a judgement: the setup cannot be made to hold. Docker
-#     re-seeds an EMPTY named volume from the image on every mount, ownership
-#     included, so `chown -R 65534 /data` in a helper container reads back as
-#     65534 inside that container and as the image's 100:101 in the next one.
-#     Only a pre-populated volume survives it, which is a fixture built to
-#     dodge a docker behaviour rather than a substrate anybody runs — and the
-#     property it would test (nothing outside /data need be writable) is what
-#     the read-only shape asserts directly.
-#     Both are named here because they are the two hostile shapes #1952 lists
-#     that this driver deliberately does not run.
+#   * an EMPTY BIND MOUNT over /app is not a shape and cannot be one: docker
+#     never copies the image's content into a bind mount, so the release is
+#     simply gone. Measured — the container does not fail to boot, it fails to
+#     be CREATED: `stat /app/release-entrypoint.sh: no such file or directory`,
+#     status `created/127`. The named-volume reading of the same words IS
+#     covered, as shape 3 below; the two are different substrates wearing one
+#     sentence, and only one of them has an application in it to test.
 
 set -euo pipefail
 
@@ -109,6 +102,17 @@ UP_VOLUME=grappa-smoke-upgrade-data
 # name keeps the teardown list finite.
 HOSTILE=grappa-smoke-hostile
 HOSTILE_VOLUME=grappa-smoke-hostile-data
+# Shape 3's SECOND volume, the one mounted over the release root itself.
+#
+# ⚠️ THIS ONE MUST NEVER SURVIVE A RUN, and it is the only volume here whose
+# leak is worse than untidy. Docker seeds a named volume from the image ONCE,
+# while it is empty; a leftover /app volume is not empty, so the next run's
+# container mounts LAST RUN'S RELEASE over the candidate's and boots it.
+# Measured: a container started from `:v1.5.1` on a volume seeded by v1.5.0
+# reports `.Config.Image = …:v1.5.1` to `docker inspect` and version `1.5.0` to
+# /api/config. The whole smoke would then probe an image nobody built, and say
+# nothing about it — so it is removed before the run AND in the teardown.
+HOSTILE_APP_VOLUME=grappa-smoke-hostile-app
 
 # The account created under the PREVIOUS release, read back after the upgrade
 # through the same operator door — see probe 6.
@@ -140,7 +144,7 @@ teardown() {
         done
     fi
     docker rm -f "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE" >/dev/null 2>&1 || true
-    docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+    docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" "$HOSTILE_APP_VOLUME" >/dev/null 2>&1 || true
     rm -rf "$SMOKE_HOME"
     exit "$status"
 }
@@ -149,14 +153,16 @@ trap teardown EXIT
 # A crashed earlier run leaves the box behind, and `install` refuses to run
 # onto an existing container. Clear the dedicated names before, not just after.
 docker rm -f "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE" >/dev/null 2>&1 || true
-docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" "$HOSTILE_APP_VOLUME" >/dev/null 2>&1 || true
 
 # wait_healthz CONTAINER WHAT — poll /healthz from INSIDE, so this works for
 # the bare container too (no published port). WHAT names the shape being
-# waited on, not the container: since #1952 the same driver waits on six
-# boots, and "grappa-smoke-hostile never answered" would not say WHICH hostile
-# substrate it was. Both arguments are required — a defaulted label is a
-# failure message that degrades exactly when it is needed.
+# waited on, not the container: since #1952 the same driver waits on the boots
+# of several different shapes, and "grappa-smoke-hostile never answered" would
+# not say WHICH hostile substrate it was. Both arguments are required — a
+# defaulted label is a failure message that degrades exactly when it is needed.
+# The count is deliberately not spelled here: it went from two to four in one
+# follow-up, and a number in a comment is a thing to forget.
 wait_healthz() {
     deadline=$((SECONDS + 300))
     until docker exec "$1" curl -fsS -o /dev/null http://localhost:4000/healthz 2>/dev/null; do
@@ -544,10 +550,24 @@ pass "the boot left the container layer empty, and a planted /app/runtime is sti
 # asked exactly one question: does it answer /healthz. The failures they are
 # hunting are the same one wearing different clothes — a path resolved against
 # something the operator, not the application, chose.
-say "probe 8: the candidate boots where the cwd is hostile"
+say "probe 8: the candidate boots on hostile substrates"
 
-# hostile_boot SHAPE ARM-CHECK EXTRA-FLAG... — one shape, from a fresh volume,
-# asked one question.
+# The uid:gid the IMAGE gives /data, READ OUT OF THE IMAGE rather than spelled.
+# Every shape but the arbitrary-uid one runs as the baked user, so this is the
+# ownership their storage must carry — and writing `100:101` here would be a
+# second copy of a Dockerfile fact, silently wrong the day `adduser -S` picks
+# another number.
+IMAGE_DATA_OWNER="$(docker run --rm --entrypoint sh "$GRAPPA_IMAGE" -c 'stat -c "%u:%g" /data')"
+[ -n "$IMAGE_DATA_OWNER" ] \
+    || die "could not read /data's owner out of $GRAPPA_IMAGE — every shape below would then hand its volume to nobody in particular"
+
+# The arbitrary uid shape 4 runs as. 65534 is `nobody` on every distro and the
+# number Kubernetes' own `runAsUser:` examples use, but the POINT is that it is
+# not the image's: see the guard on that below.
+HOSTILE_UID=65534
+
+# hostile_boot SHAPE ARM-CHECK DATA-OWNER EXTRA-FLAG... — one shape, from a
+# fresh volume, asked one question.
 #
 # ARM-CHECK is a `docker inspect` format string that must come back `true`:
 # the proof that the hostile condition is actually IN FORCE. Without it a flag
@@ -556,12 +576,37 @@ say "probe 8: the candidate boots where the cwd is hostile"
 # probe 7's canary exists to refuse, and the reason each shape carries its own
 # rather than one shared assertion.
 #
+# DATA-OWNER is the `uid:gid` the /data volume is handed to before the boot,
+# and it is REQUIRED of every shape rather than defaulted, because it is the
+# storage contract that shape's operator has to satisfy — stating it is half of
+# what the shape means. Three of the four pass the image's own owner, which
+# makes the chown a no-op and keeps ONE code path with no branch in it.
+#
+# WHY A MARKER FILE RIDES WITH THE CHOWN, and it is a measurement about docker
+# rather than a trick: docker re-seeds an EMPTY named volume from the image on
+# every mount, ownership included. Measured — create a volume, `chown 65534`
+# it from a helper, and the NEXT container reads the image's owner back. One
+# file inside is enough to make the volume non-empty, and then the ownership
+# sticks. The negative control is the shape without it: a virgin volume under
+# `--user 65534` dies with `mkdir: can't create directory '/data/uploads':
+# Permission denied`. The file is zero bytes, is not grappa state, and is what
+# a real arbitrary-uid deployment provides for itself — a Kubernetes `fsGroup`,
+# or an operator's `chown` on the host path.
+#
 # Each shape gets a FIRST boot of its own: one that only works because the
 # previous shape already created the state is not the shape an operator meets.
 hostile_boot() {
-    local shape="$1" arm_check="$2"; shift 2
+    local shape="$1" arm_check="$2" data_owner="$3"; shift 3
     docker rm -f "$HOSTILE" >/dev/null 2>&1 || true
     docker volume rm "$HOSTILE_VOLUME" >/dev/null 2>&1 || true
+
+    # `--user 0:0` because chown is root's; `--entrypoint sh` because nothing
+    # must boot here. The owner arrives as an ARGUMENT, never interpolated into
+    # the `-c` string.
+    docker run --rm --user 0:0 -v "${HOSTILE_VOLUME}:/data" --entrypoint sh \
+        "$GRAPPA_IMAGE" -c 'touch /data/.hostile-fixture && chown -R "$1" /data' \
+        sh "$data_owner" >/dev/null \
+        || die "the '$shape' substrate: could not hand /data to $data_owner, so the boot below would be testing the wrong storage"
 
     docker run -d --name "$HOSTILE" -e PHX_HOST=localhost \
         -v "${HOSTILE_VOLUME}:/data" "$@" "$GRAPPA_IMAGE" >/dev/null \
@@ -588,7 +633,7 @@ hostile_boot() {
 # bootstrap; `--read-only --tmpfs /tmp` boots. `/app/tmp` is NOT in the recipe
 # because the release never writes there — which is the same fact probe 7
 # measures from the other side, an empty container layer.
-hostile_boot 'read-only rootfs' '{{.HostConfig.ReadonlyRootfs}}' \
+hostile_boot 'read-only rootfs' '{{.HostConfig.ReadonlyRootfs}}' "$IMAGE_DATA_OWNER" \
     --read-only --tmpfs /tmp:rw,mode=1777
 
 # ── shape 2: a working directory the process did not choose ─────────────────
@@ -609,7 +654,112 @@ hostile_boot 'read-only rootfs' '{{.HostConfig.ReadonlyRootfs}}' \
 # The arm check is `.Config.WorkingDir` and not a `docker exec pwd`: the
 # interesting failures here EXIT, and a shape that has to be alive to prove it
 # was applied cannot report on the boot that died.
-hostile_boot 'cwd the process did not choose (/)' '{{eq .Config.WorkingDir "/"}}' \
+hostile_boot 'cwd the process did not choose (/)' '{{eq .Config.WorkingDir "/"}}' "$IMAGE_DATA_OWNER" \
     --workdir /
+
+# ── shape 3: a volume mounted OVER the release root ─────────────────────────
+#
+# The release lives at /app, and this shape mounts a named volume there. It is
+# not a hypothetical: it is what a Kubernetes PVC pointed one path to the left
+# does, and what a compose file that "persists the app" does.
+#
+# THE SHAPE IS CONSTRUCTIBLE AND IT BOOTS, and that took measuring rather than
+# reasoning, because the obvious reading — mounting over /app hides the release,
+# so there is nothing left to test — is TRUE OF A BIND MOUNT AND FALSE OF A
+# NAMED VOLUME. Docker copies the image's content into an empty named volume at
+# first mount (the release, its permissions, the setgid bit on /app), so the
+# container comes up; an empty bind mount gets no copy and cannot even be
+# created. The non-coverage list at the top of this file carries that second
+# reading, since only one of the two has an application in it.
+#
+# 🔴 A GREEN HERE DOES NOT MEAN THE SHAPE IS SUPPORTED, and the difference is
+# measured: the copy-up happens ONCE, while the volume is empty. Pull a new
+# image, recreate the container, and the volume still holds the OLD release —
+# `docker inspect` reports the new tag and /api/config reports the old version.
+# This probe boots on a volume it created seconds earlier, which is the only
+# state in which the shape is honest.
+#
+# WHAT IT ASSERTS BEYOND /healthz, and why it must: `docker diff` — probe 7's
+# oracle for "the boot wrote nothing outside /data" — is blind by construction
+# under a mount, and reports ZERO LINES for this container even when the boot
+# wrote into the release root. Measured on v1.5.0, whose #1945 defect creates
+# `runtime/peer_avatars` relative to the cwd: `docker diff` says nothing, and
+# the VOLUME grows an eighth entry. So the same property is read through the
+# window this shape leaves open — the release root after the boot must be
+# exactly the release root the image ships.
+hostile_boot 'a volume mounted over the release root (/app)' \
+    '{{range .Mounts}}{{if eq .Destination "/app"}}true{{end}}{{end}}' \
+    "$IMAGE_DATA_OWNER" \
+    -v "${HOSTILE_APP_VOLUME}:/app"
+
+# The container is gone; the /app volume it booted from is not, which is what
+# makes this readable at all. `ls -1A` on both sides: hidden entries count,
+# since a boot is as free to write `/app/.state` as `/app/runtime`.
+app_shipped="$SMOKE_HOME/app-root-shipped.list"
+app_after="$SMOKE_HOME/app-root-after-boot.list"
+docker run --rm --entrypoint sh "$GRAPPA_IMAGE" -c 'ls -1A /app | sort' > "$app_shipped" \
+    || die "could not list the release root the image ships"
+docker run --rm -v "${HOSTILE_APP_VOLUME}:/mnt/app" --entrypoint sh "$GRAPPA_IMAGE" \
+    -c 'ls -1A /mnt/app | sort' > "$app_after" \
+    || die "could not list the release root the '/app volume' boot left behind"
+
+# The anti-hollow-green guard, before the comparison rather than after: two
+# empty listings compare EQUAL, and that is exactly what a mount that silently
+# resolved nowhere would produce.
+[ -s "$app_shipped" ] \
+    || die "the image ships an EMPTY /app — the listing is blind and the comparison below cannot fail"
+
+if ! cmp -s "$app_shipped" "$app_after"; then
+    printf '\n----- release root: shipped vs after the boot -----\n' >&2
+    diff "$app_shipped" "$app_after" >&2 || true
+    die "the boot wrote into the RELEASE ROOT, which on this substrate is a mounted volume and therefore invisible to probe 7's docker diff. On v1.5.0 the extra entry was 'runtime', #1945 exactly."
+fi
+
+# POSITIVE control, and the only thing between the reading above and a hollow
+# green: the same two listings, with #1945's own path planted in the volume.
+# `--user 0:0` because the volume root belongs to the image's user, and this
+# helper is writing into it from outside.
+docker run --rm --user 0:0 -v "${HOSTILE_APP_VOLUME}:/mnt/app" --entrypoint sh \
+    "$GRAPPA_IMAGE" -c 'mkdir -p /mnt/app/runtime/peer_avatars' >/dev/null \
+    || die "could not plant the release-root canary — shape 3's own control cannot run"
+app_canary="$SMOKE_HOME/app-root-canary.list"
+docker run --rm -v "${HOSTILE_APP_VOLUME}:/mnt/app" --entrypoint sh "$GRAPPA_IMAGE" \
+    -c 'ls -1A /mnt/app | sort' > "$app_canary" \
+    || die "could not re-list the release root after planting the canary"
+if cmp -s "$app_shipped" "$app_canary"; then
+    die "a directory planted in the /app volume does not show up in the listing — the comparison is BLIND, and the equality above proved nothing"
+fi
+pass "the '/app volume' boot left the release root exactly as the image ships it, and a planted runtime/ is still seen"
+docker volume rm "$HOSTILE_APP_VOLUME" >/dev/null 2>&1 || true
+
+# ── shape 4: an arbitrary non-root uid ──────────────────────────────────────
+#
+# `--user 65534` — a Kubernetes `runAsUser:`, a hardened compose `user:`, an
+# OpenShift project that assigns a uid nobody chose. The image bakes its own
+# `grappa` user and every other probe here runs as it, so this is the one shape
+# that asks whether anything depends on being THAT user rather than merely
+# being a user with writable storage.
+#
+# MEASURED, and it is the strongest red in this file because it is #1945
+# verbatim rather than a cousin of it. Identical fixture, identical flags, the
+# two releases apart:
+#
+#   v1.5.1   running/0, /healthz in 2s
+#   v1.5.0   exited/1
+#            ** (File.Error) could not make directory (with -p)
+#               "runtime/peer_avatars": permission denied
+#                   (grappa 1.5.0) lib/grappa/avatars/reaper.ex:79
+#
+# Note the path in that error is RELATIVE. /app is writable by the baked user
+# and by nobody else, which is why the same defect is silent on every other
+# docker shape and fatal here. The control that makes the pair mean something:
+# v1.5.0 on this SAME image with the baked user and an ordinary volume boots
+# healthy, so the red belongs to the uid and not to the release.
+[ "${HOSTILE_UID}:${HOSTILE_UID}" != "$IMAGE_DATA_OWNER" ] \
+    || die "the image's own /data owner IS ${HOSTILE_UID}:${HOSTILE_UID} — this shape would be an ordinary boot wearing a --user flag, and would assert nothing"
+hostile_boot "an arbitrary non-root uid (--user ${HOSTILE_UID})" \
+    "{{eq .Config.User \"${HOSTILE_UID}:${HOSTILE_UID}\"}}" \
+    "${HOSTILE_UID}:${HOSTILE_UID}" \
+    --user "${HOSTILE_UID}:${HOSTILE_UID}"
 
 say "release image $GRAPPA_IMAGE deployed and answered every probe 🎉"

--- a/test/grappa/protocol_test.exs
+++ b/test/grappa/protocol_test.exs
@@ -58,6 +58,58 @@ defmodule Grappa.ProtocolTest do
     end
   end
 
+  # #1973 — the OTHER direction, and the one every pin in this file was blind
+  # to: cic falling behind `version/0`.
+  #
+  # The three pins that exist all point one way and all stayed green while the
+  # constant rotted. `>= min_version()` above is `9 >= 1`; the server floor
+  # below is `9 <= 13`; cic's own `MIN_SERVER <= CLIENT`
+  # (`serverProtocol.test.ts`) is `9 <= 9`. Nothing compared cic against what
+  # the server actually SPEAKS, which is the number socket.ts says it is
+  # declaring ("The number is the CONTRACT version", socket.ts:71-75).
+  #
+  # Measured drift on `origin/main` at the time of writing: 12 bumps of
+  # `@protocol_version` (1 → 13, 2026-07-27 → 2026-09-06) against 3 writes of
+  # `CLIENT_PROTOCOL_VERSION`, two of which were catch-ups — the 2 → 9 one
+  # skipped seven bumps at once. Since cic first declared a version
+  # (2026-08-16) the two constants have been equal for roughly 8 days out of
+  # 22. The stale value is the normal state, not the accident.
+  #
+  # Why that is not cosmetic: `noteServerProtocol` (socket.ts:441-451) warns on
+  # ANY inequality, in either direction, and its only silence is exact
+  # equality. A constant that lags therefore fires "protocol mismatch" on every
+  # healthy boot of a deploy whose bundle and BEAM came from the SAME commit —
+  # which destroys the one signal that a service-worker-cached PWA is skewed
+  # against the BEAM (socket.ts:428-433). It has already misled a tester once.
+  # With this pin, an inequality at runtime means the two artefacts came from
+  # different commits, which is exactly what the warn is for.
+  #
+  # Why EQUALITY and not `>=`: the two numbers are the same contract by
+  # definition, so there is no direction to tolerate. cic below `version/0` is
+  # a stale constant; cic above it is a bundle claiming a shape no server has
+  # ever emitted. Both are the same defect — the declaration not matching the
+  # wire — and `>=` would wave one of them through. This is deliberately NOT
+  # the axis of `MIN_SERVER_PROTOCOL_VERSION`, which stays a separate number
+  # precisely because a bundle may speak v13 and still cope with a v9 server
+  # (serverProtocol.ts:45-49); pinning what cic SPEAKS says nothing about what
+  # it REQUIRES.
+  describe "what cicchetto declares vs what the server SPEAKS (#1973)" do
+    test "cicchetto's declared version IS the protocol the server speaks" do
+      # Fails on any bump of `@protocol_version` that does not carry the cic
+      # constant with it — i.e. on the commit that introduces the drift, rather
+      # than on the browser console of whoever notices months later.
+      cic = cic_protocol_version()
+      server = Protocol.version()
+
+      assert cic == server,
+             "cicchetto declares CLIENT_PROTOCOL_VERSION = #{cic} " <>
+               "(#{@cic_socket}) while the server speaks #{server}. " <>
+               "These are one contract version, not two: bump the cic " <>
+               "constant in the same change that bumps @protocol_version, " <>
+               "and extend its note the way `2 -> 9` did."
+    end
+  end
+
   # 🔴 THIS IS NOT THE GATE #1654 ASKS FOR. It is the half of it that can be
   # written against facts the repo holds today, shipped as such.
   #

--- a/test/infra/release_hostile_matrix_test.bats
+++ b/test/infra/release_hostile_matrix_test.bats
@@ -1,0 +1,287 @@
+#!/usr/bin/env bats
+#
+# #1952 — the release smoke's HOSTILE-SUBSTRATE MATRIX, the second half of the
+# issue's ask ("this is the class gate").
+#
+# THE SAME COVERAGE PROBLEM `release_upgrade_probe_test.bats` opens with, and
+# it is why this file exists at all: probe 8 lives inside `release.yml`'s
+# `smoke` job, which fires only on `push: tags: v*` and on `workflow_dispatch`.
+# No pull request ever boots a container in that matrix. So a shape that is
+# deleted, renamed into nothing, or left unarmed goes unnoticed until a release
+# — and a matrix that has quietly lost half its shapes reports the same green
+# as one that has all of them.
+#
+# What these cases CAN claim: that the four shapes #1952 names are wired, that
+# each one is ARMED (carries the `docker inspect` check proving the hostile
+# condition is actually in force), that each declares the storage ownership its
+# operator has to provide, that the shape which blinds probe 7's `docker diff`
+# brings its own oracle AND its own canary, and that the volume whose leak
+# would make the NEXT run boot stale code is cleaned on both ends.
+#
+# What they CANNOT claim, and it is deliberate: that any of it BOOTS. Four
+# container boots against two published images is the smoke job's work on a
+# real tag. The seam is the one `release_image_credits_test.bats` draws between
+# reading the recipe and reading the artifact.
+#
+# HOW THE ARGUMENT CASES WORK, because grep would not have been enough here.
+# The driver's `hostile_boot` calls are folded onto one line each and then
+# EVALUATED with `hostile_boot` redefined as a recorder. That runs the real
+# argument lists through the real quoting, so a shape whose owner argument is
+# missing shows up as a flag sitting in `$3` — which is exactly the mistake a
+# `grep -q hostile_boot` cannot see.
+
+load ../bats_helpers
+
+setup() {
+    REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SMOKE="$REPO_SRC/scripts/smoke-release-image.sh"
+}
+
+# The driver with backslash-continuations folded away: one logical line per
+# statement, quoting untouched. Every case below reads this rather than the
+# raw file, because three of the four shapes span several physical lines and a
+# line-oriented grep sees only their first.
+folded() {
+    sed -e :a -e '/\\$/N; s/\\\n[[:space:]]*/ /; ta' "$SMOKE"
+}
+
+# The `hostile_boot` INVOCATIONS — column zero, followed by a quote. The
+# function's own definition line (`hostile_boot() {`) has a parenthesis there
+# instead, so it does not match.
+shape_calls() {
+    folded | grep -E "^hostile_boot ['\"]"
+}
+
+# Evaluate every invocation with `hostile_boot` replaced by a recorder that
+# prints the field named by $1 for each call. The driver's own two variables
+# are supplied with stand-in values: the cases assert the SHAPE of what is
+# passed, never the value the release run would compute.
+each_call_field() {
+    local field="$1"
+    local IMAGE_DATA_OWNER=100:101
+    local HOSTILE_UID=65534
+    local HOSTILE_APP_VOLUME=grappa-smoke-hostile-app
+    # shellcheck disable=SC2317  # called via eval below
+    hostile_boot() {
+        case "$field" in
+            shape) printf '%s\n' "$1" ;;
+            arm)   printf '%s\n' "$2" ;;
+            owner) printf '%s\n' "$3" ;;
+            flags) shift 3; printf '%s\n' "$*" ;;
+        esac
+    }
+    local line
+    while IFS= read -r line; do
+        eval "$line"
+    done < <(shape_calls)
+}
+
+@test "#1952 — the extractor really reads the driver's shape calls" {
+    # The positive control every case below leans on. An extractor that came
+    # back empty would make each of them vacuously true, and this file would
+    # report green over a matrix with no shapes left in it at all.
+    run shape_calls
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+
+    # Folding is what makes the multi-line shapes visible. Unfolded, the `-v`
+    # of the /app shape sits on a physical line of its own and no call line
+    # carries it.
+    grep -Fq 'HOSTILE_APP_VOLUME' <<<"$output" || {
+        printf 'the continuation folding is not working — a shape call spanning\n' >&2
+        printf 'several lines came out truncated, so every assertion here is blind.\n' >&2
+        printf '%s\n' "$output" >&2
+        return 1
+    }
+}
+
+@test "#1952 — all FOUR hostile shapes the issue lists are wired" {
+    # By FLAG, not by prose: the label of a shape is free to be reworded, the
+    # flag that makes it that shape is not. One call each.
+    local calls; calls="$(shape_calls)"
+
+    grep -Fq -- '--read-only' <<<"$calls" || { printf 'no read-only rootfs shape.\n' >&2; return 1; }
+    grep -Fq -- '--workdir /' <<<"$calls" || { printf 'no hostile-cwd shape.\n' >&2; return 1; }
+    grep -Fq -- '${HOSTILE_APP_VOLUME}:/app' <<<"$calls" || {
+        printf 'nothing mounts a volume over the release root — the shape that\n' >&2
+        printf 'blinds probe 7 is gone, and with it the only reader of that\n' >&2
+        printf 'property on this substrate.\n' >&2
+        return 1
+    }
+    grep -Eq -- '--user "\$\{HOSTILE_UID\}' <<<"$calls" || {
+        printf 'no arbitrary-uid shape. That is the one that reproduces #1945\n' >&2
+        printf 'verbatim (File.Error on the RELATIVE "runtime/peer_avatars").\n' >&2
+        return 1
+    }
+
+    # And exactly four, so a fifth arriving without a case here is a red rather
+    # than a silent addition to a matrix nobody re-reads.
+    [ "$(wc -l <<<"$calls" | tr -d ' ')" -eq 4 ]
+}
+
+@test "#1952 — every shape is ARMED: none of them boots without a docker-inspect check" {
+    # An unarmed shape is an ordinary boot wearing a flag. It reports the same
+    # green whether docker honoured the flag or dropped it.
+    run each_call_field arm
+    [ "$status" -eq 0 ]
+    [ "$(wc -l <<<"$output" | tr -d ' ')" -eq 4 ]
+
+    local arm
+    while IFS= read -r arm; do
+        [[ "$arm" == *'{{'*'}}'* ]] || {
+            printf 'a shape passes something that is not a docker inspect template\n' >&2
+            printf 'as its arm check: %s\n' "$arm" >&2
+            return 1
+        }
+    done <<<"$output"
+}
+
+@test "#1952 — every shape declares the ownership its storage must carry" {
+    # The argument that would be silently wrong if a new shape copied an older
+    # call and dropped a field: `hostile_boot` shifts THREE, so a missing owner
+    # puts a flag in its place and the fixture chowns /data to `--read-only`.
+    run each_call_field owner
+    [ "$status" -eq 0 ]
+    [ "$(wc -l <<<"$output" | tr -d ' ')" -eq 4 ]
+
+    local owner
+    while IFS= read -r owner; do
+        [[ "$owner" =~ ^[0-9]+:[0-9]+$ ]] || {
+            printf 'a shape passes %s where the /data owner belongs — a shape that\n' "$owner" >&2
+            printf 'forgot the argument shows up here as one of its flags.\n' >&2
+            return 1
+        }
+    done <<<"$output"
+
+    # NEGATIVE CONTROL: the same recorder over a call that DID forget the
+    # owner. Without it, a check that accepted everything would read as a pass.
+    local IMAGE_DATA_OWNER=100:101
+    # shellcheck disable=SC2317  # called via eval below
+    hostile_boot() { printf '%s\n' "$3"; }
+    local got; got="$(eval "hostile_boot 'forgot' '{{.X}}' --read-only --tmpfs /tmp")"
+    refute test "$(printf '%s' "$got")" = "$(printf '%s' "$IMAGE_DATA_OWNER")"
+    [[ "$got" =~ ^[0-9]+:[0-9]+$ ]] && {
+        printf 'the owner check cannot fail: a call with no owner yielded %s\n' "$got" >&2
+        return 1
+    }
+    [ "$got" = '--read-only' ]
+}
+
+@test "#1952 — every shape still carries flags after its three fixed arguments" {
+    # A shape with nothing after the owner is not a substrate, it is the
+    # ordinary boot probes 1-7 already run.
+    run each_call_field flags
+    [ "$status" -eq 0 ]
+
+    local flags
+    while IFS= read -r flags; do
+        [ -n "$flags" ] || {
+            printf 'a shape passes no docker flags at all — it boots the image the\n' >&2
+            printf 'way every other probe does and asserts nothing new.\n' >&2
+            return 1
+        }
+    done <<<"$output"
+}
+
+@test "#1952 — the /app volume is destroyed on BOTH ends, or the next run boots stale code" {
+    # The one leak here that is worse than untidy. Docker seeds a named volume
+    # from the image only while it is EMPTY, so a leftover /app volume makes
+    # the next run mount the previous release over the candidate — measured, a
+    # container started from :v1.5.1 on a v1.5.0-seeded volume reports the new
+    # tag to `docker inspect` and the OLD version to /api/config.
+    local cleanups
+    cleanups="$(grep -cE '^\s*docker volume rm .*HOSTILE_APP_VOLUME' "$SMOKE" || true)"
+    [ "$cleanups" -ge 2 ] || {
+        printf 'the /app volume is removed %s time(s); it must be cleared BEFORE the\n' "$cleanups" >&2
+        printf 'run (a crashed earlier run leaves it behind) and in the teardown.\n' >&2
+        grep -n 'HOSTILE_APP_VOLUME' "$SMOKE" >&2 || true
+        return 1
+    }
+
+    # And one of them is in the teardown, which is the arm that runs when a
+    # probe FAILS — precisely the run after which a leftover volume is waiting.
+    local teardown
+    teardown="$(awk '/^teardown\(\) \{/ { inside = 1 } inside { print } inside && /^\}/ { exit }' "$SMOKE")"
+    grep -Fq 'docker rm -f' <<<"$teardown" || {
+        printf 'the teardown slice came out empty or wrong — this case reads nothing.\n' >&2
+        return 1
+    }
+    grep -Fq 'HOSTILE_APP_VOLUME' <<<"$teardown" || {
+        printf 'the teardown does not remove the /app volume. A failing run would\n' >&2
+        printf 'leave it behind, and the next run would boot whatever release it\n' >&2
+        printf 'still holds while reporting the tag it was asked for.\n' >&2
+        return 1
+    }
+}
+
+@test "#1952 — the shape that blinds docker diff brings its own oracle AND its own canary" {
+    # `docker diff` reports the container's read-write layer and never what is
+    # under a mount, so on the /app-volume shape it answers zero lines even
+    # when the boot wrote into the release root (measured on v1.5.0, whose
+    # #1945 defect creates runtime/peer_avatars there). The property is read
+    # instead by comparing the release root against the one the image ships.
+    grep -Fq 'ls -1A /app | sort' "$SMOKE" || {
+        printf 'nothing lists the release root the IMAGE ships, so there is no\n' >&2
+        printf 'baseline to compare the post-boot volume against.\n' >&2
+        return 1
+    }
+
+    # TWO comparisons, in opposite directions, and both are required: the
+    # verdict fails when the listings DIFFER, the canary fails when they
+    # AGREE after a directory has been planted. A verdict with no canary is
+    # the hollow green — an oracle that cannot see anything reports equality
+    # forever.
+    grep -Fq 'if ! cmp -s "$app_shipped" "$app_after"' "$SMOKE" || {
+        printf 'the release-root verdict is missing or spelled differently — the\n' >&2
+        printf '/app-volume shape then asserts nothing but /healthz.\n' >&2
+        return 1
+    }
+    grep -Fq 'if cmp -s "$app_shipped" "$app_canary"' "$SMOKE" || {
+        printf 'the release-root comparison has no CANARY. An empty or blind\n' >&2
+        printf 'listing compares equal to itself, which is the same reading a\n' >&2
+        printf 'clean boot produces.\n' >&2
+        return 1
+    }
+    grep -Fq 'mkdir -p /mnt/app/runtime' "$SMOKE" || {
+        printf 'the canary does not plant #1945\x27s own path into the volume.\n' >&2
+        return 1
+    }
+}
+
+@test "#1952 — the arbitrary uid is read as arbitrary, and /data's owner is read from the IMAGE" {
+    # The shape asserts nothing the moment its uid IS the image's own, so the
+    # driver refuses that state rather than reporting a green boot.
+    grep -Fq '[ "${HOSTILE_UID}:${HOSTILE_UID}" != "$IMAGE_DATA_OWNER" ]' "$SMOKE" || {
+        printf 'nothing stops the arbitrary uid from being the image\x27s baked one.\n' >&2
+        printf 'A Dockerfile that moved the user to 65534 would turn the shape into\n' >&2
+        printf 'an ordinary boot wearing a --user flag, still green.\n' >&2
+        return 1
+    }
+
+    # And the owner the other three shapes hand their volume to is READ from
+    # the image, never spelled: a literal in CODE is a second copy of a
+    # Dockerfile fact, wrong the day `adduser -S` picks another number.
+    grep -Fq "stat -c \"%u:%g\" /data" "$SMOKE" || {
+        printf 'IMAGE_DATA_OWNER is not read out of the image.\n' >&2
+        return 1
+    }
+
+    # COMMENTS ARE EXEMPT, deliberately: today's value is a MEASUREMENT and
+    # writing it down is what makes the comment worth reading — the driver
+    # says `100:101` exactly once, in the sentence explaining why it must not
+    # appear anywhere else. Stripping whole-line comments is what separates
+    # the two, and the case failed on precisely this before it did.
+    #
+    # The subject is the fixture's own `chown`, not the whole file: a blanket
+    # `[0-9]+:[0-9]+` over the driver would match the default publish address
+    # `127.0.0.1:14000` and report a violation that is not one.
+    local chown_lines
+    chown_lines="$(grep -v '^[[:space:]]*#' "$SMOKE" | grep -F 'chown' || true)"
+    [ -n "$chown_lines" ] || {
+        printf 'the driver has no chown left in it — the shapes no longer hand\n' >&2
+        printf 'their /data volume to anybody, and the arbitrary-uid boot would\n' >&2
+        printf 'die on a volume docker re-seeded to the image owner.\n' >&2
+        return 1
+    }
+    refute grep -Eq '[0-9]+:[0-9]+' <<<"$chown_lines"
+}


### PR DESCRIPTION
Integration branch for the 1.5.2 cut: the three hotfix PRs merged together and
gated **as a union**, which is the thing three separate green PRs never check.

Rolled up (by **merge**, not cherry-pick, so authorship and the original SHAs
survive — and each head stays an ancestor of main):

- **#1967** — release smoke: the two hostile shapes the matrix was missing
- **#1976** — a bundle readout in the settings drawer
- **#1978** — the client protocol constant, and the pin that holds it

**Why a union and not three sequential rebases.** All three append to the tail of
`docs/DESIGN_NOTES.md`. GitHub does not apply the `merge=union` driver to its
merge-ref, so every merge would have turned the other two `CONFLICTING` again —
three rebase/CI cycles, two of them paying a full `integration` (both touch
`cicchetto/src/**`). One gate here instead of three.

It is also the honest gate rather than merely the cheap one: #1976 adds a bundle
skew readout and #1978 moves `CLIENT_PROTOCOL_VERSION` 9 to 13. Zero files in
common, but both land on the same version-and-skew surface, and nothing had ever
gated them together.

**Conflict resolution, measured rather than eyeballed:**

- `docs/DESIGN_NOTES.md` — the union driver resolved the bodies silently
  (`rc=0`, zero conflicted files), which is exactly when a green proves nothing.
  Arithmetic predicted *before* the merges: `47614 + 130 + 109 + 76 = 47929`
  lines and `2792128 + 6810 + 6081 + 4429 = 2809448` bytes. Measured after:
  **47929 / 2809448**, both exact. Nothing eaten, nothing resurrected.
- `docs/OPERATIONS.md` — the one file where a branch and main both edited, and it
  has **no** union driver, so ort did a real 3-way. Verified line by line in both
  directions: 14/14 of the branch's added lines and 67/67 of main's are present,
  with a positive control (a line known to be in the file) and a negative one (an
  invented line, correctly absent).
- Entry boundaries per the #1271 convention, read on the file: each marker sits
  flush against the previous entry's last line, then blank / `---` / blank /
  heading. All three markers unique, no duplicate marker anywhere in the file,
  invented marker absent. `scripts/design-notes-gate.sh` reports
  `3 new entry heading(s), separator and marker present` — the non-vacuous line,
  not the "nothing to check" green.

**What I did not verify:** the union's runtime behaviour beyond what CI runs here.
The three were individually green on the older base; this is the first time they
are measured together.
