### PR TITLE
fix(issue 1977): project mIRC formatting out of the push title and body

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -47927,3 +47927,87 @@ the pin is a test and reaches CI only. Ship the bundle with a server built
 from the same commit: a `--cic`-only push of this bundle onto the current
 `1.5.1` BEAM will log the mismatch, and after this change that log is telling
 the truth._
+<!-- entry #1977 -->
+
+---
+
+## 2026-09-07 — #1977: the push was the one door still shipping the wire bytes, and the title took the same class
+
+Push notifications rendered the raw IRC body. `\x03` is non-printing, so the OS
+notification renderer drops the byte and leaves its decimal operands sitting in
+the text as ordinary digits: the lock-screen capture filed from `#allnitecafe`
+read `04QUACK` where the wire carried `\x03` `0` `4` `QUACK`.
+
+The projection already existed and had one caller too few. `Grappa.Mentions`
+runs `MircFormat.plain_text/1` before matching so a padded body cannot dodge or
+forge a mention, and cic parses the same bytes into styled runs for the message
+list. The same message was therefore de-formatted for matching, parsed for
+rendering, and shipped raw only to the notification — and that asymmetry, not
+the control byte, was the defect.
+
+The cure is in `Grappa.Push.Payload.build/3` rather than in the service worker:
+the server keeps one matcher and one projection, payloads already delivered stay
+consistent with the ones that follow, and no second parser ships inside the SW
+bundle. Interpreting instead of stripping was never on the table — the Web
+Notifications API takes plain text, so there is no styled-run surface to render
+into.
+
+### The title takes the same input class, and the asymmetry is measured
+
+`title` is built from `sender` and `channel`, so it needed deciding rather than
+assuming. Measured on this branch, executed rather than read off a regex:
+
+  * `Identifier.valid_nick?` on a `\x03`-bearing nick answers **false**, and so
+    does `valid_sender?` — the nick charset holds no control byte and the host
+    arm excludes `\x00-\x1f` outright. Positive controls `"alice"` and
+    `"irc.azzurra.chat"` both answer true. The one arm that would accept a
+    control byte is `<meta>`, and that shape is minted server-side for
+    non-IRC rows, never read off the wire.
+  * `Identifier.valid_channel?` on a `\x03`-bearing channel answers **true**.
+    The channel regex excludes only whitespace, comma and BELL; the negative
+    control `"#all nite"` is false, so that true is not vacuous.
+  * `Parser.parse/1` hands such a target back intact — `strip_unsafe_bytes/1`
+    removes `\x00 \r \n` and nothing else — and `canonical_target/1` folds
+    `A-Z` and passes every other byte through. A `\x03` in a channel name
+    therefore survives ingress, persist and fold.
+
+So a nick cannot carry it and a channel can. The projection sits on the COMPOSED
+title rather than on the channel alone: one door serves both arms, and the
+sender arm costs nothing because the projection is provably a no-op on any
+string the nick charset admits.
+
+### What does NOT get projected, and why that is the same rule
+
+`tag` and `url` keep the channel KEY exactly as stored. `tag` is the OS dedup
+key and `url` is a deep link cic resolves back to a window; projecting either
+would coalesce the banner against a surface that does not exist and land the
+click on a channel nobody is in. Two rendered fields project, two key fields do
+not — the key/display split, applied at one door.
+
+The issue left the dedup tag unmeasured ("probably untouched, but I did not
+check it"). It is untouched by the BODY: `dedup_key` reads `sender` or
+`channel` and never `body`, so no amount of formatting in a message can perturb
+the dedup surface — now pinned by an assert in the same test that pins the body.
+The second half is the part the report did not anticipate: the tag is not
+`\x03`-free in general, because a `\x03`-bearing CHANNEL puts it there, and
+deliberately so, since the tag is a key.
+
+The stripper is the mIRC one and not a control-byte purge: CTCP framing
+(`\x01`) round-trips verbatim per the wire-format rule, so an ACTION row still
+reaches the payload framed. That is pinned too, because `build/3` now runs a
+stripper and the next reader is entitled to know which one.
+
+### Refused
+
+No change to the service worker or to `pushPayload.ts` — the server projection
+makes both unnecessary, and a client-side stripper would be the second parser
+1908 spent its whole argument avoiding. No claim about payloads already
+delivered: they were sent raw and are gone, and nothing here rewrites stored
+rows. Whether a `\x03`-bearing channel is reachable on bahamut SPECIFICALLY was
+not measured — the ingress chain admits it, which is the fact the cure needs,
+and the ircd's own opinion would not make the projection wrong.
+
+_Deploy: **HOT** on all three substrates — measured via
+`Preflight.classify_paths/2` over the changed paths: `{:hot, []}` for `:docker`,
+`:jail` and `:linux`. Positive control: `VERSION` answers
+`{:cold, [version: ["VERSION"]]}` on jail and linux._

--- a/lib/grappa/push/payload.ex
+++ b/lib/grappa/push/payload.ex
@@ -14,13 +14,51 @@ defmodule Grappa.Push.Payload do
 
   ## Title / body
 
-    * **DM** (`channel == own_nick`): `title = sender`, body =
-      message body verbatim. Notification shape mirrors how mobile
-      messengers surface a 1:1 chat — sender on top line, content on
-      second.
+    * **DM** (`channel == own_nick`): `title = sender`, body = the
+      message body. Notification shape mirrors how mobile messengers
+      surface a 1:1 chat — sender on top line, content on second.
     * **Channel** (everything else): `title = "<sender> in <channel>"`,
-      body = message body verbatim. Reader sees both who spoke and
-      where in one glance.
+      body = the message body. Reader sees both who spoke and where in
+      one glance.
+
+  ## The two rendered fields are PROJECTED; the two key fields are not (issue 1977)
+
+  `title` and `body` go through `Grappa.IRC.MircFormat.plain_text/1` —
+  the de-formatted view, "the text a reader saw". `tag` and `url` do NOT.
+
+  The projection is not cosmetic. `\\x03` is non-printing, so the OS
+  notification renderer drops the byte and leaves its decimal operands in
+  the text as ordinary digits: a coloured line reached a lock screen as
+  `04QUACK` for a wire `\\x03` `0` `4` `QUACK`. Every other surface already
+  projects — `Grappa.Mentions` calls `plain_text/1` before matching so a
+  padded body cannot dodge or forge a mention, and cic parses the same
+  bytes into styled runs for the message list. Push was the one door that
+  shipped them raw, and that asymmetry WAS the defect. Interpreting rather
+  than stripping is not available here: the Web Notifications API takes
+  plain text, there is no styled-run surface to render into.
+
+  The projection sits on the COMPOSED title rather than on `channel`
+  alone, and that is a measurement rather than caution. A nick cannot
+  carry `\\x03`: `Identifier.valid_nick?/1`'s charset holds no control
+  byte, and the host arm of `valid_sender?/1` excludes `\\x00-\\x1f`
+  outright (its `<meta>` arm would accept one, but that shape is minted
+  here, never read off the wire). A CHANNEL can —
+  `Identifier.valid_channel?/1` excludes only
+  whitespace, comma and BELL; `Parser.strip_unsafe_bytes/1` removes only
+  `\\x00 \\r \\n`; and `canonical_target/1` folds `A-Z` and passes every
+  other byte through, so a `\\x03` in a channel name survives ingress,
+  persist and fold intact. One projection over the whole string covers
+  both arms with one door, and costs nothing on the sender arm because it
+  is provably a no-op on a valid nick.
+
+  `tag` and `url` keep the channel KEY as stored — the key/display split.
+  `tag` is the OS dedup key and `url` is a deep link cic resolves back to
+  a window; projecting either would coalesce the banner against a surface
+  that does not exist and land the click on a channel nobody is in.
+
+  The stripper is the mIRC one, not a control-byte purge: CTCP framing
+  (`\\x01`) round-trips verbatim per CLAUDE.md's wire-format rule, so an
+  ACTION row still reaches the payload framed.
 
   ## Presence transitions (#378)
 
@@ -64,7 +102,7 @@ defmodule Grappa.Push.Payload do
   trivial to test.
   """
 
-  alias Grappa.IRC.Identifier
+  alias Grappa.IRC.{Identifier, MircFormat}
   alias Grappa.Scrollback.Message
 
   @typedoc """
@@ -106,7 +144,6 @@ defmodule Grappa.Push.Payload do
           Identifier.canonical_target(own_nick)
 
     sender = message.sender || ""
-    body = message.body || ""
 
     {title, dedup_key, deep_link_target} =
       if dm? do
@@ -116,8 +153,8 @@ defmodule Grappa.Push.Payload do
       end
 
     %{
-      title: title,
-      body: body,
+      title: MircFormat.plain_text(title),
+      body: MircFormat.plain_text(message.body || ""),
       tag: "#{network_slug}:#{dedup_key}",
       url: build_url(network_slug, deep_link_target)
     }

--- a/test/grappa/push/payload_test.exs
+++ b/test/grappa/push/payload_test.exs
@@ -7,8 +7,11 @@ defmodule Grappa.Push.PayloadTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  alias Grappa.IRC.MircFormat
   alias Grappa.Push.Payload
   alias Grappa.Scrollback.Message
+
+  @color "\x03"
 
   defp msg(opts) do
     %Message{
@@ -102,6 +105,104 @@ defmodule Grappa.Push.PayloadTest do
     test "shape is always the four required atom keys" do
       payload = Payload.build(msg(channel: "#sniffo"), "libera", "vjt")
       assert Enum.sort(Map.keys(payload)) == [:body, :tag, :title, :url]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # build/3 — mIRC formatting projection (issue 1977)
+  # ---------------------------------------------------------------------------
+
+  describe "build/3 — mIRC formatting projection (issue 1977)" do
+    # `\x03` is non-printing, so the OS notification renderer DROPS the byte
+    # and leaves its decimal operands sitting in the text as ordinary digits —
+    # the lock-screen capture that filed 1977 read `04QUACK` where the wire
+    # carried `\x03` `0` `4` `QUACK`. The expectations below are LITERALS
+    # (what the reader saw), not a re-derivation through the projection: a
+    # `== MircFormat.plain_text(body)` assert alone would survive the
+    # projection being dropped from `build/3` if the input happened to be
+    # clean. The one lockstep assert that DOES call production carries its own
+    # `refute` against the raw input for exactly that reason.
+    test "a colour-padded body reaches the payload as the text a human read" do
+      body = @color <> "15QUACK" <> @color <> "04,08 quack" <> @color
+
+      payload = Payload.build(msg(channel: "#allnitecafe", body: body), "azzurra", "vjt")
+
+      assert payload.body == "QUACK quack"
+
+      # 1977 left this unmeasured ("probably untouched, but I did not check
+      # it"). It is: `dedup_key` reads `sender` or `channel`, never `body`, so
+      # no amount of formatting in the body can perturb the OS dedup surface.
+      assert payload.tag == "azzurra:#allnitecafe"
+      assert payload.title == "alice in #allnitecafe"
+    end
+
+    test "a DM body is projected on the same door" do
+      payload =
+        Payload.build(
+          msg(channel: "vjt", sender: "alice", dm_with: "alice", body: @color <> "15ping"),
+          "libera",
+          "vjt"
+        )
+
+      assert payload.title == "alice"
+      assert payload.body == "ping"
+    end
+
+    # The title takes the same input class as the body. A nick cannot carry
+    # `\x03` — `Identifier.valid_nick?/1`'s charset has no control byte and
+    # `valid_sender?/1`'s host arm excludes `\x00-\x1f` outright — but a
+    # CHANNEL can: `@channel_regex` excludes only whitespace, comma and BELL,
+    # the parser strips only `\x00 \r \n`, and `canonical_target/1` folds
+    # `A-Z` and passes every other byte through. So the projection is on the
+    # composed title rather than on the channel alone: one door for both arms,
+    # and the sender arm costs nothing because the projection is provably a
+    # no-op on a valid nick.
+    test "a colour-padded channel does not leak digits into the title" do
+      payload =
+        Payload.build(
+          msg(channel: "#" <> @color <> "04allnitecafe", sender: "peluche"),
+          "azzurra",
+          "vjt"
+        )
+
+      assert payload.title == "peluche in #allnitecafe"
+    end
+
+    # The projection is a DISPLAY rule, so it stops at the two fields the OS
+    # renders. `tag` is an OS dedup key and `url` is a deep link cic resolves
+    # back to a window — both must carry the channel KEY as stored, or the
+    # banner coalesces against the wrong surface and the click lands on a
+    # channel that does not exist.
+    test "the tag and the deep link keep the RAW channel key" do
+      channel = "#" <> @color <> "04allnitecafe"
+
+      payload = Payload.build(msg(channel: channel), "azzurra", "vjt")
+
+      assert payload.tag == "azzurra:" <> channel
+      assert payload.url == "/?network=azzurra&channel=%23%0304allnitecafe"
+    end
+
+    test "the projection IS MircFormat.plain_text/1, not a private copy" do
+      body = @color <> "04,08QUACK" <> "\x02bold\x0F"
+
+      payload = Payload.build(msg(channel: "#allnitecafe", body: body), "azzurra", "vjt")
+
+      assert payload.body == MircFormat.plain_text(body)
+      # Non-vacuity: the input MUST be one the projection actually changes,
+      # else the assert above passes on an unprojected `build/3`.
+      refute payload.body == body
+    end
+
+    # CLAUDE.md's charset rule: CTCP framing is NOT formatting and round-trips
+    # verbatim. `build/3` now runs a stripper over the body, so pin here that
+    # the stripper is the mIRC one and not a general control-byte purge — an
+    # ACTION row must still reach the payload framed.
+    test "CTCP framing survives the projection" do
+      body = "\x01ACTION " <> @color <> "04waves\x01"
+
+      payload = Payload.build(msg(channel: "#allnitecafe", body: body), "azzurra", "vjt")
+
+      assert payload.body == "\x01ACTION waves\x01"
     end
   end
 


### PR DESCRIPTION
Push notifications rendered the raw IRC body. `\x03` is non-printing, so the OS
notification renderer drops the byte and leaves its decimal operands sitting in
the text as ordinary digits — a coloured line from `#allnitecafe` reached a lock
screen as `04QUACK` where the wire carried `\x03` `0` `4` `QUACK`. See issue 1977.

The projection already existed and had one caller too few. `Grappa.Mentions`
runs `MircFormat.plain_text/1` before matching so a padded body cannot dodge or
forge a mention, and cic parses the same bytes into styled runs for the message
list. The same message was de-formatted for matching, parsed for rendering, and
shipped raw only to the notification — that asymmetry, not the control byte, was
the defect.

Cured in `Grappa.Push.Payload.build/3` rather than in the service worker: the
server keeps one matcher and one projection, payloads already delivered stay
consistent with the ones that follow, and no second parser ships in the SW
bundle. Interpreting instead of stripping is not available — the Web
Notifications API takes plain text, so there is no styled-run surface.

## The title takes the same input class — measured, not assumed

Executed against the predicates, not read off the regexes:

| probe | result | control |
|---|---|---|
| `valid_nick?` on a `\x03`-bearing nick | **false** | pos ctrl `"alice"` → true |
| `valid_sender?` on the same | **false** | pos ctrl `"irc.azzurra.chat"` → true |
| `valid_channel?` on a `\x03`-bearing channel | **true** | pos ctrl `"#allnitecafe"` → true; neg ctrl `"#all nite"` → false |
| `canonical_target/1` over it | preserved | — |
| `Parser.parse/1` target | `<<35, 3, 48, 52, …>>` — survives; `strip_unsafe_bytes/1` removes only `\x00 \r \n` | — |

A nick cannot carry it and a channel can, end to end through ingress, persist
and fold. So the projection sits on the **composed** title rather than on the
channel alone: one door for both arms, and the sender arm costs nothing because
the projection is provably a no-op on any string the nick charset admits. The
one `valid_sender?` arm that would accept a control byte is `<meta>`, and that
shape is minted server-side for non-IRC rows, never read off the wire.

## What does NOT get projected

`tag` and `url` keep the channel KEY as stored — the key/display split.
Projecting either would coalesce the banner against a surface that does not
exist and land the click on a channel nobody is in.

The issue left the dedup tag unmeasured ("probably untouched, but I did not
check it"). Both halves are now answered:

- untouched by the **body** — `dedup_key` reads `sender` or `channel` and never
  `body`, so no formatting in a message can perturb dedup. Pinned by an assert
  in the same test that pins the body;
- but not `\x03`-free in general — a `\x03`-bearing **channel** puts it there,
  deliberately, because the tag is a key. Pinned by its own test.

The stripper is the mIRC one and not a control-byte purge: CTCP framing (`\x01`)
round-trips verbatim per the wire-format rule, pinned too.

## Red then green

Before the cure, with the real shape from the report (`\x03` `1` `5` + text):
`1 property, 23 tests, 5 failures`, rc=2 — the coloured body, the DM body, the
`\x03`-bearing channel title, the `MircFormat` lockstep and the CTCP pin all
red. The sixth new test — "the tag and the deep link keep the RAW channel key" —
passed already in that run: it is the invariant that must NOT change, and it is
the negative control for the whole slice.

After: `24 tests, 0 failures`. Neighbourhood (`test/grappa/push/` +
`mirc_format_test` + `mentions_test`): `2 properties, 254 tests, 0 failures`.

The lockstep test calls production (`MircFormat.plain_text/1`) and carries a
`refute payload.body == body` beside it, so the assert cannot pass vacuously on
an unprojected `build/3`. Every other expectation is a literal — what the reader
saw — not a re-derivation through the projection.

## Gates

`scripts/check.sh` rc=0 on the rebased head, every stage naming itself: credo
`6766 mods/funs, found no issues`; `mix deps.audit` `No vulnerabilities found`;
sobelow; doctor `validation has passed!`; ExUnit `8 doctests, 65 properties,
7158 tests, 0 failures`; dialyzer `Total errors: 0`; `wireTypes.ts` /
`wireSchema.ts` in sync; `priv/wire/shape.pin: wire shape and protocol 13
agree`; bats `1..748`, 748 ok / 0 not ok.

No `protocol_version` bump is due, and that is measured rather than asserted:
the push payload keeps its four keys and is not part of the generated wire, so
the pin agrees at protocol 13.

`scripts/design-notes-gate.sh` rc=0, naming `1 new entry heading(s), separator
and marker present`. `scripts/union-rebase.sh` rc=0 and non-vacuous — it pinned
against the previous base and rebased onto a moved `origin/main`, reporting
`docs/DESIGN_NOTES.md: +84 -0 — contribution intact`.

Deploy verdict measured with `Preflight.classify_paths/2` over the changed
paths: `{:hot, []}` on `:docker`, `:jail` and `:linux`. Positive control:
`VERSION` answers `{:cold, [version: ["VERSION"]]}` on jail and linux.

## Refused

- Whether a `\x03`-bearing channel is reachable on bahamut **specifically** was
  not measured. The ingress chain admits it, which is the fact the cure needs;
  the ircd's own opinion would not make the projection wrong.
- No claim about payloads already delivered — they went out raw and are gone,
  and nothing here rewrites stored rows.
- No integration / e2e / testnet run: no lane for it, and the slice is
  server-side only with cic untouched.
- No real-browser check of how the notification renders after the cure. What is
  measured is the value of the field handed to the OS, not the pixel.
