### PR TITLE
feat(162): /ignore — a per-network mask list, dropped at the door

### DIFF
--- a/cicchetto/src/IgnoresSettings.tsx
+++ b/cicchetto/src/IgnoresSettings.tsx
@@ -1,0 +1,139 @@
+import { type Component, createSignal, For, onMount, Show } from "solid-js";
+import type { Network } from "./lib/api";
+import { token } from "./lib/auth";
+import { friendlyError } from "./lib/friendlyError";
+import { addIgnore, delIgnore, ignoresBySlug, refreshIgnores } from "./lib/ignoreList";
+import { networks } from "./lib/networks";
+
+// #162 — the ignore-list settings SUB-PAGE. One block per network (the list
+// is per network, like presence notify): the masks with a × to remove, and
+// an add-input scoped to that network. Same authoritative state the
+// `/ignore` verbs use (`ignoreList.ts` mirrors every REST answer) — cic never
+// originates state; a × here hits the same DELETE the `/unignore` verb does.
+//
+// Shaped after `WatchlistsSettings` (#356) on purpose, down to the list
+// classes: an operator who has pruned a watch list should not have to learn
+// a second look for pruning an ignore list.
+
+const IgnoreNetworkBlock: Component<{ net: Network }> = (props) => {
+  const [draft, setDraft] = createSignal("");
+  const [error, setError] = createSignal<string | null>(null);
+  const [busy, setBusy] = createSignal(false);
+  const masks = () => ignoresBySlug()[props.net.slug] ?? [];
+
+  // No broadcast for this list — fetch on open so the block shows the
+  // server's current masks, not a stale mirror from an earlier session.
+  onMount(() => {
+    const t = token();
+    if (!t) return;
+    void refreshIgnores(t, props.net.slug).catch((err) => setError(friendlyError(err)));
+  });
+
+  const onAdd = async (e: Event) => {
+    e.preventDefault();
+    const t = token();
+    const mask = draft().trim();
+    if (!t || mask === "" || busy()) return;
+    setError(null);
+    setBusy(true);
+    try {
+      await addIgnore(t, props.net.slug, mask);
+      setDraft("");
+    } catch (err) {
+      setError(friendlyError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRemove = async (mask: string) => {
+    const t = token();
+    if (!t) return;
+    setError(null);
+    try {
+      await delIgnore(t, props.net.slug, mask);
+    } catch (err) {
+      setError(friendlyError(err));
+    }
+  };
+
+  return (
+    <div class="watchlists-network" data-testid={`ignores-network-${props.net.slug}`}>
+      <h5 class="watchlists-network-slug">{props.net.slug}</h5>
+      <Show
+        when={masks().length > 0}
+        fallback={<p class="watchlists-empty">nothing ignored on {props.net.slug}.</p>}
+      >
+        <ul class="watchlists-list" data-testid={`ignores-list-${props.net.slug}`}>
+          <For each={masks()}>
+            {(mask) => (
+              <li class="watchlists-item">
+                <span class="watchlists-keyword">{mask}</span>
+                <button
+                  type="button"
+                  class="watchlists-remove"
+                  aria-label={`Stop ignoring ${mask} on ${props.net.slug}`}
+                  onClick={() => void onRemove(mask)}
+                >
+                  ×
+                </button>
+              </li>
+            )}
+          </For>
+        </ul>
+      </Show>
+      <form class="watchlists-add" onSubmit={(e) => void onAdd(e)}>
+        <input
+          type="text"
+          autocapitalize="none"
+          autocorrect="off"
+          spellcheck={false}
+          placeholder="add a nick or nick!user@host"
+          value={draft()}
+          data-testid={`ignores-add-${props.net.slug}`}
+          onInput={(e) => setDraft(e.currentTarget.value)}
+        />
+        <button type="submit" class="watchlists-add-btn" disabled={busy()}>
+          add
+        </button>
+      </form>
+      <Show when={error()}>{(msg) => <p class="watchlists-error">{msg()}</p>}</Show>
+    </div>
+  );
+};
+
+const IgnoresSettings: Component<{ onBack: () => void }> = (props) => {
+  return (
+    <section class="settings-subpage ignores-subpage" data-testid="ignores-subpage">
+      <header class="settings-subpage-header">
+        <button
+          type="button"
+          class="settings-back"
+          data-testid="ignores-back"
+          aria-label="back to settings"
+          onClick={props.onBack}
+        >
+          ‹ back
+        </button>
+        <h3>ignore list</h3>
+      </header>
+
+      <div class="settings-section" data-testid="ignores-section">
+        <h4 class="settings-section-heading">ignored masks</h4>
+        <p class="settings-section-blurb">
+          messages from these are dropped before they reach you — no scrollback, no badge, no push.
+          a bare nick means <code>nick!*@*</code>; <code>*</code> and <code>?</code> are wildcards.
+          per network, same list as <code>/ignore</code>.
+        </p>
+        <Show
+          when={(networks() ?? []).length > 0}
+          fallback={<p class="watchlists-empty">no networks yet.</p>}
+        >
+          <For each={networks() ?? []}>{(net) => <IgnoreNetworkBlock net={net} />}</For>
+        </Show>
+      </div>
+    </section>
+  );
+};
+
+export default IgnoresSettings;

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -25,6 +25,7 @@ import {
   topicShowLine,
 } from "./lib/channelTopic";
 import { isChannelName } from "./lib/chantypes";
+import { type CommandOutputEntry, commandOutputByWindow } from "./lib/commandOutput";
 import { stripCtcpAction } from "./lib/ctcpAction";
 import { isDocumentVisible } from "./lib/documentVisibility";
 import { highlightPatterns } from "./lib/highlightList";
@@ -1182,7 +1183,16 @@ type MessageRow = { type: "message"; msg: ScrollbackMessage };
 // subsequent server-message arrivals (vjt prod report). Interleaving
 // by wallclock `at` (epoch ms, same unit as ScrollbackMessage's
 // server_time) puts each ack at its arrival position in the timeline.
-type InviteAckRow = { type: "invite-ack"; entry: InviteAckEntry; channel: string; id: string };
+// The three EPHEMERAL row kinds (invite-ack, `/topic` answer, verb answer)
+// carry their wallclock `at`: the weave below anchors a later one on an
+// earlier one exactly as it anchors on a message (#162 ordering fix).
+type InviteAckRow = {
+  type: "invite-ack";
+  entry: InviteAckEntry;
+  channel: string;
+  id: string;
+  at: number;
+};
 // #237: on-JOIN inline topic line — a PRESENTATIONAL row (string id, NOT a
 // ScrollbackMessage), so it never enters the unread/cursor/ring-cap math. It is
 // derived from the `topicByChannel` store and anchored after the own-JOIN row.
@@ -1196,8 +1206,45 @@ type TopicRow = { type: "topic-join"; line: TopicJoinLine; id: string };
 // this one is operator-requested, may repeat, sits at the moment it was
 // asked, and carries a FROZEN snapshot. Same look, different lifecycle —
 // collapsing them into one variant with a flag would fuse those.
-type TopicShowRow = { type: "topic-show"; line: TopicShowLine; id: string };
-type Row = SeparatorRow | UnreadMarkerRow | MessageRow | InviteAckRow | TopicRow | TopicShowRow;
+type TopicShowRow = { type: "topic-show"; line: TopicShowLine; id: string; at: number };
+// #162 — one line of a slash verb's in-window answer: an optional accent
+// label, the text, and whether it is an indented member of a list.
+type CommandOutputRow = {
+  type: "command-output";
+  label: string | null;
+  text: string;
+  indent: boolean;
+  id: string;
+  at: number;
+};
+type Row =
+  | SeparatorRow
+  | UnreadMarkerRow
+  | MessageRow
+  | InviteAckRow
+  | TopicRow
+  | TopicShowRow
+  | CommandOutputRow;
+
+/**
+ * The wallclock a row can be anchored on when weaving ephemeral rows into
+ * the timeline: a message's `server_time`, an ephemeral row's own `at`, and
+ * nothing for the rows that carry no time of their own (separators, the
+ * unread marker, the on-JOIN topic line, which sits where its JOIN row is).
+ */
+function rowTime(row: Row | undefined): number | null {
+  if (row === undefined) return null;
+  switch (row.type) {
+    case "message":
+      return row.msg.server_time;
+    case "invite-ack":
+    case "topic-show":
+    case "command-output":
+      return row.at;
+    default:
+      return null;
+  }
+}
 
 const ScrollbackPane: Component<Props> = (props) => {
   let listRef!: HTMLDivElement;
@@ -1604,7 +1651,14 @@ const ScrollbackPane: Component<Props> = (props) => {
     // operator typed it. Every window kind can carry one: `/topic #chan` is
     // legal from a query or the $server window too.
     const topicShowEntries: TopicShowEntry[] = topicShowByWindow()[key()] ?? [];
-    if (msgs.length === 0 && inviteAckEntries.length === 0 && topicShowEntries.length === 0)
+    // #162 — the plain-text verb answers for THIS window, same keying rule.
+    const commandOutputEntries: CommandOutputEntry[] = commandOutputByWindow()[key()] ?? [];
+    if (
+      msgs.length === 0 &&
+      inviteAckEntries.length === 0 &&
+      topicShowEntries.length === 0 &&
+      commandOutputEntries.length === 0
+    )
       return [];
     // Freeze contract: read the FROZEN snapshot, not live getReadCursor.
     const cursor = markerCursorId();
@@ -1710,33 +1764,6 @@ const ScrollbackPane: Component<Props> = (props) => {
       result.push({ type: "message", msg });
       prevTime = msg.server_time;
     }
-    // 2026-06-01: weave invite-ack rows into the timeline by wallclock
-    // `at` vs message `server_time`. Forward pass: insertion index is
-    // the position of the FIRST message-row whose `server_time > entry.at`,
-    // or the end of the list when no such message exists. Invite-ack
-    // rows skip the unread-marker / day-separator logic on purpose —
-    // they're ephemeral operator-action echoes, not server-persisted
-    // rows. Stable across re-renders: sorted by `(at, ts)` first so
-    // same-ms acks keep insertion order via the closure-monotonic `ts`.
-    if (inviteAckEntries.length > 0) {
-      inviteAckEntries.sort((a, b) => a.entry.at - b.entry.at || a.entry.ts - b.entry.ts);
-      for (const { entry, channel } of inviteAckEntries) {
-        let insertAt = result.length;
-        for (let i = 0; i < result.length; i += 1) {
-          const r = result[i];
-          if (r?.type === "message" && r.msg.server_time > entry.at) {
-            insertAt = i;
-            break;
-          }
-        }
-        result.splice(insertAt, 0, {
-          type: "invite-ack",
-          entry,
-          channel,
-          id: `invite-ack-${entry.ts}`,
-        });
-      }
-    }
     // #237 — inline topic-on-JOIN. irssi prints the topic to the window when
     // YOU join; we mirror it by anchoring a presentational topic row right
     // after the operator's own-JOIN row, derived from the `topicByChannel`
@@ -1793,26 +1820,71 @@ const ScrollbackPane: Component<Props> = (props) => {
         }
       }
     }
-    // #1914 — the `/topic` answers, interleaved by wallclock `at` exactly like
-    // invite-acks: an answer belongs at the moment it was asked, not pinned to
-    // the bottom where later arrivals would make it look like a reply to them.
-    // Sorted on a COPY — `topicShowEntries` is the store's own array.
-    if (topicShowEntries.length > 0) {
-      for (const entry of [...topicShowEntries].sort((a, b) => a.at - b.at || a.ts - b.ts)) {
-        let insertAt = result.length;
-        for (let i = 0; i < result.length; i += 1) {
-          const r = result[i];
-          if (r?.type === "message" && r.msg.server_time > entry.at) {
-            insertAt = i;
-            break;
-          }
-        }
-        result.splice(insertAt, 0, {
+    // Weave the EPHEMERAL rows — invite-acks (2026-06-01), `/topic` answers
+    // (#1914), verb answers (#162) — into the timeline by wallclock `at` vs
+    // message `server_time`, in ONE pass ascending by `(at, ts)`. They skip
+    // the unread-marker / day-separator logic on purpose: operator-action
+    // echoes, not server-persisted rows.
+    //
+    // ONE pass, and every spliced row carries its `at`, because three passes
+    // that each anchored only on MESSAGE rows had a measured ordering bug:
+    // `/ignore` then `/topic` printed the topic ABOVE the ignore rows. The
+    // `/topic` pass ran after the `/ignore` pass, saw no message later than
+    // itself, and went to the END — past rows it never looked at. The same
+    // shape reversed two `/topic` answers as soon as a message landed after
+    // both (equal insertion index, second splice lands first). Anchoring on
+    // any timed row — a message OR an already-woven ephemeral — closes both:
+    // a row goes before the first row whose time is LATER than its own, so
+    // an earlier-asked answer already in place stays above (#162).
+    //
+    // `ts` is each store's own monotonic counter, so it orders lines WITHIN
+    // one store (the rows of one `/ignore`, same `at`) and is only a
+    // tiebreak across stores inside a single millisecond.
+    const ephemeral: Array<{ at: number; ts: number; row: Row }> = [];
+    for (const { entry, channel } of inviteAckEntries) {
+      ephemeral.push({
+        at: entry.at,
+        ts: entry.ts,
+        row: { type: "invite-ack", entry, channel, id: `invite-ack-${entry.ts}`, at: entry.at },
+      });
+    }
+    for (const entry of topicShowEntries) {
+      ephemeral.push({
+        at: entry.at,
+        ts: entry.ts,
+        row: {
           type: "topic-show",
           line: topicShowLine(entry.channel, entry.topic),
           id: `topic-show-${entry.ts}`,
-        });
+          at: entry.at,
+        },
+      });
+    }
+    for (const entry of commandOutputEntries) {
+      ephemeral.push({
+        at: entry.at,
+        ts: entry.ts,
+        row: {
+          type: "command-output",
+          label: entry.label,
+          text: entry.text,
+          indent: entry.indent,
+          id: `command-output-${entry.ts}`,
+          at: entry.at,
+        },
+      });
+    }
+    ephemeral.sort((a, b) => a.at - b.at || a.ts - b.ts);
+    for (const { at, row } of ephemeral) {
+      let insertAt = result.length;
+      for (let i = 0; i < result.length; i += 1) {
+        const time = rowTime(result[i]);
+        if (time !== null && time > at) {
+          insertAt = i;
+          break;
+        }
       }
+      result.splice(insertAt, 0, row);
     }
     return result;
   });
@@ -4174,6 +4246,25 @@ const ScrollbackPane: Component<Props> = (props) => {
                     <Show when={row.line.meta}>
                       <span class="scrollback-topic-join-meta"> — {row.line.meta}</span>
                     </Show>
+                  </div>
+                );
+              }
+              if (row.type === "command-output") {
+                // #162 — a slash verb's answer, one line per row. Wears the
+                // join line's classes for the same reason the `/topic` answer
+                // does: an informational line the operator asked for, kept out
+                // of the unread/cursor math by its own testid.
+                return (
+                  <div
+                    class="scrollback-topic-join"
+                    classList={{ "scrollback-command-output-indent": row.indent }}
+                    data-testid="command-output-line"
+                    data-kind="command-output"
+                  >
+                    <Show when={row.label !== null}>
+                      <span class="scrollback-topic-join-label">{row.label}</span>{" "}
+                    </Show>
+                    <span class="scrollback-body">{row.text}</span>
                   </div>
                 );
               }

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -11,6 +11,7 @@ import {
 import AliasSettings from "./AliasSettings";
 import BundleReadout from "./BundleReadout";
 import DeleteAccountModal from "./DeleteAccountModal";
+import IgnoresSettings from "./IgnoresSettings";
 import InlineConfirmButton from "./InlineConfirmButton";
 import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
@@ -1249,6 +1250,24 @@ const SettingsDrawer: Component<Props> = (props) => {
             <span class="settings-nav-row-text">
               <span class="settings-nav-row-label">watch lists</span>
               <span class="settings-nav-row-subtitle">presence notify and keyword highlight</span>
+            </span>
+            <span class="settings-nav-row-chevron" aria-hidden="true">
+              ›
+            </span>
+          </button>
+
+          {/* #162 — ignore list sub-page nav row (per-network masks whose
+              messages are dropped at delivery). Sits right after watch lists:
+              the two are the "who do I want to hear from" pair. */}
+          <button
+            type="button"
+            class="settings-nav-row"
+            data-testid="ignores-settings-entry"
+            onClick={() => setSettingsPage("ignores")}
+          >
+            <span class="settings-nav-row-text">
+              <span class="settings-nav-row-label">ignore list</span>
+              <span class="settings-nav-row-subtitle">masks whose messages are dropped</span>
             </span>
             <span class="settings-nav-row-chevron" aria-hidden="true">
               ›
@@ -2567,6 +2586,13 @@ const SettingsDrawer: Component<Props> = (props) => {
             directly (like the retired home WatchedPanel), so no data props. */}
         <Show when={settingsPage() === "watchlists"}>
           <WatchlistsSettings onBack={() => setSettingsPage("main")} />
+        </Show>
+
+        {/* #162 — ignore list sub-page (per-network masks). Self-contained:
+            reads the ignoreList store directly and refreshes it on open, the
+            same shape as the watch lists page. */}
+        <Show when={settingsPage() === "ignores"}>
+          <IgnoresSettings onBack={() => setSettingsPage("main")} />
         </Show>
 
         {/* #385 — aliases sub-page (user-defined command aliases).

--- a/cicchetto/src/__tests__/IgnoresSettings.test.tsx
+++ b/cicchetto/src/__tests__/IgnoresSettings.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #162 — the ignore-list settings sub-page. Self-contained: reads the
+// ignoreList store and calls its verbs on mutation. Mock those boundaries;
+// assert the VISIBLE outcome (the masks render per network, × removes
+// through the store, the add-form adds through the store, the list is
+// refreshed on open because nothing broadcasts it).
+
+const addIgnoreMock = vi.fn().mockResolvedValue({ masks: [], mask: "x!*@*", outcome: "added" });
+const delIgnoreMock = vi
+  .fn()
+  .mockResolvedValue({ masks: [], mask: "spambot!*@*", outcome: "removed" });
+const refreshIgnoresMock = vi.fn().mockResolvedValue([]);
+
+let networksData: Array<{ kind: string; id: number; slug: string; nick: string }> = [];
+let ignoresData: Record<string, string[]> = {};
+
+vi.mock("../lib/auth", () => ({ token: () => "tok" }));
+
+vi.mock("../lib/networks", () => ({
+  networkIdBySlug: () => undefined,
+  networks: () => networksData,
+}));
+
+vi.mock("../lib/ignoreList", () => ({
+  ignoresBySlug: () => ignoresData,
+  refreshIgnores: (t: string, slug: string) => refreshIgnoresMock(t, slug),
+  addIgnore: (t: string, slug: string, mask: string) => addIgnoreMock(t, slug, mask),
+  delIgnore: (t: string, slug: string, mask: string) => delIgnoreMock(t, slug, mask),
+}));
+
+import IgnoresSettings from "../IgnoresSettings";
+import { ApiError } from "../lib/api";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  networksData = [
+    { kind: "user", id: 1, slug: "freenode", nick: "vjt" },
+    { kind: "user", id: 2, slug: "ircnet", nick: "vjt" },
+  ];
+  ignoresData = { freenode: ["spambot!*@*", "*!*@*.evil.example"] };
+});
+
+describe("IgnoresSettings (#162)", () => {
+  it("renders the sub-page with one block per network", () => {
+    render(() => <IgnoresSettings onBack={() => {}} />);
+    expect(screen.getByTestId("ignores-subpage")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /ignore list/i })).toBeInTheDocument();
+    expect(screen.getByTestId("ignores-network-freenode")).toBeInTheDocument();
+    expect(screen.getByTestId("ignores-network-ircnet")).toBeInTheDocument();
+  });
+
+  it("‹ back fires onBack", () => {
+    const onBack = vi.fn();
+    render(() => <IgnoresSettings onBack={onBack} />);
+    fireEvent.click(screen.getByTestId("ignores-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("refreshes every network's list on mount (no broadcast, must fetch)", () => {
+    render(() => <IgnoresSettings onBack={() => {}} />);
+    expect(refreshIgnoresMock).toHaveBeenCalledWith("tok", "freenode");
+    expect(refreshIgnoresMock).toHaveBeenCalledWith("tok", "ircnet");
+  });
+
+  it("shows the masks of a network and × removes through the store, by network", () => {
+    render(() => <IgnoresSettings onBack={() => {}} />);
+    expect(screen.getByText("spambot!*@*")).toBeInTheDocument();
+    expect(screen.getByText("*!*@*.evil.example")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: /stop ignoring spambot!\*@\* on freenode/i }),
+    );
+    expect(delIgnoreMock).toHaveBeenCalledWith("tok", "freenode", "spambot!*@*");
+  });
+
+  it("the per-network add-form adds through the store, scoped to that network", () => {
+    render(() => <IgnoresSettings onBack={() => {}} />);
+    const input = screen.getByTestId("ignores-add-ircnet") as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "troll" } });
+    fireEvent.submit(input.closest("form") as HTMLFormElement);
+    expect(addIgnoreMock).toHaveBeenCalledWith("tok", "ircnet", "troll");
+  });
+
+  it("a network with nothing ignored says so and still offers the add-form", () => {
+    render(() => <IgnoresSettings onBack={() => {}} />);
+    expect(screen.getByText(/nothing ignored on ircnet/)).toBeInTheDocument();
+    expect(screen.getByTestId("ignores-add-ircnet")).toBeInTheDocument();
+    expect(screen.queryByTestId("ignores-list-ircnet")).not.toBeInTheDocument();
+  });
+
+  it("a rejected mask surfaces the server's reason instead of vanishing", async () => {
+    // The 422 the server answers for a bad mask, so the page shows the same
+    // friendly line the compose box does.
+    addIgnoreMock.mockRejectedValueOnce(new ApiError(422, "invalid_mask"));
+    render(() => <IgnoresSettings onBack={() => {}} />);
+    const input = screen.getByTestId("ignores-add-freenode") as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "a b" } });
+    fireEvent.submit(input.closest("form") as HTMLFormElement);
+    expect(await screen.findByText(/not valid/)).toBeInTheDocument();
+  });
+});

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -312,6 +312,9 @@ import { type ChannelKey, channelKey } from "../lib/channelKey";
 // entry so ScrollbackPane derives the #237 on-JOIN topic-join line; the #325
 // block proves that line survives the #222 presence-hide filter.
 import { seedTopic } from "../lib/channelTopic";
+// #1914 — the REAL `/topic` answer store, for the same reason: the pane is
+// its only reader, and what these tests assert IS that it reads it.
+import { appendCommandOutput } from "../lib/commandOutput";
 // #1302 — the REAL ISUPPORT store (not mocked): the badge derives its level
 // names from the network's own PREFIX, so what these tests seed here IS the
 // input the derivation reads. Network id 1 is what the mocked
@@ -332,8 +335,6 @@ import {
 // advances the read cursor without needing the button to render (jsdom's
 // zero-geometry keeps `atBottom` true, so the button never mounts).
 import { requestScrollToBottom } from "../lib/scrollToBottomCommand";
-// #1914 — the REAL `/topic` answer store, for the same reason: the pane is
-// its only reader, and what these tests assert IS that it reads it.
 import { appendTopicShow } from "../lib/topicShow";
 import { dismissWhoisCard, setWhoisBundle } from "../lib/whoisCard";
 import ScrollbackPane, {
@@ -6970,6 +6971,93 @@ describe("ScrollbackPane", () => {
 
       expect(getDraft(KEY)).toBe("<alice> hello << ");
     });
+  });
+});
+
+// #162 — a slash verb's answer prints INTO the window, one row per line. The
+// pane's half: the `commandOutput` entries become rows at the moment they were
+// given. Own channels per test for the same reason the #1914 block below
+// spells out: the store is a module singleton whose only emptier is an
+// identity rotation.
+describe("#162 command output rows", () => {
+  let n = 0;
+  const freshChannel = (): string => {
+    n += 1;
+    return `#t162-${n}`;
+  };
+  const keyFor = (chan: string) => `freenode ${chan}` as ChannelKey;
+  const msg = (chan: string, id: number, server_time: number): ScrollbackMessage => ({
+    id,
+    network: "freenode",
+    channel: chan,
+    server_time,
+    kind: "privmsg",
+    sender: "alice",
+    body: "hello",
+    meta: {},
+  });
+  const mount = (chan: string) =>
+    render(() => <ScrollbackPane networkSlug="freenode" channelName={chan} kind="channel" />);
+
+  beforeEach(() => {
+    setUserNick("vjt");
+    mockMembersByChannel.mockReturnValue({});
+  });
+
+  it("renders the header row, then one indented row per member, in order", () => {
+    const chan = freshChannel();
+    appendCommandOutput(keyFor(chan), [
+      { label: "Ignore list for freenode:", text: "", indent: false },
+      { label: null, text: "spambot!*@*", indent: true },
+      { label: null, text: "*!*@*.evil.example", indent: true },
+    ]);
+    setScrollback({ [keyFor(chan)]: [msg(chan, 1, 1000)] });
+    mount(chan);
+
+    const rows = screen.getAllByTestId("command-output-line");
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent("Ignore list for freenode:");
+    expect(rows[0]).not.toHaveClass("scrollback-command-output-indent");
+    expect(rows[1]).toHaveTextContent("spambot!*@*");
+    expect(rows[1]).toHaveClass("scrollback-command-output-indent");
+    expect(rows[2]).toHaveTextContent("*!*@*.evil.example");
+    expect(rows[2]).toHaveClass("scrollback-command-output-indent");
+  });
+
+  // The bug Gabriele hit: `/ignore` then `/topic` printed the topic ABOVE the
+  // ignore rows. Each ephemeral kind used to be woven in its own pass anchored
+  // only on messages, so the later-asked `/topic` never saw the `/ignore` rows
+  // and went past them. A message AFTER both is what exposed it.
+  it("keeps ask order across kinds — a /topic asked after /ignore renders below it", () => {
+    const chan = freshChannel();
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValueOnce(2000);
+    appendCommandOutput(keyFor(chan), [{ label: "Ignore:", text: "added x!*@*", indent: false }]);
+    now.mockReturnValueOnce(2500);
+    appendTopicShow(keyFor(chan), chan, { text: "beta", set_by: "vjt", set_at: null });
+    now.mockRestore();
+    setScrollback({ [keyFor(chan)]: [msg(chan, 1, 1000), msg(chan, 2, 3000)] });
+    mount(chan);
+
+    const kinds = Array.from(
+      document.querySelectorAll('[data-kind="command-output"], [data-kind="topic-show"]'),
+    ).map((el) => el.getAttribute("data-kind"));
+    expect(kinds).toEqual(["command-output", "topic-show"]);
+  });
+
+  // An empty window is exactly where an operator types a verb first; the
+  // early-return for "nothing to show" must not swallow the answer.
+  it("renders in a window with no messages at all", () => {
+    const chan = freshChannel();
+    appendCommandOutput(keyFor(chan), [
+      { label: "Unignore:", text: "removed spambot!*@*", indent: false },
+    ]);
+    setScrollback({ [keyFor(chan)]: [] });
+    mount(chan);
+
+    expect(screen.getByTestId("command-output-line")).toHaveTextContent(
+      "Unignore: removed spambot!*@*",
+    );
   });
 });
 

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -1697,6 +1697,7 @@ describe("SettingsDrawer (#460 — settings index)", () => {
       "themes-settings-entry",
       "push-settings-entry",
       "watchlists-settings-entry",
+      "ignores-settings-entry",
       "aliases-settings-entry",
       "perform-settings-entry",
     ]);
@@ -1708,6 +1709,7 @@ describe("SettingsDrawer (#460 — settings index)", () => {
       "themes-settings-entry",
       "push-settings-entry",
       "watchlists-settings-entry",
+      "ignores-settings-entry",
       "aliases-settings-entry",
       "perform-settings-entry",
       "vhost-settings-entry",
@@ -1716,10 +1718,10 @@ describe("SettingsDrawer (#460 — settings index)", () => {
 
   it("every index nav row carries a non-empty subtitle (self-explaining index)", async () => {
     const { container } = wrap(true);
-    // Wait for the async vhost row so all eight rows are present.
+    // Wait for the async vhost row so all nine rows are present.
     await waitFor(() => screen.getByTestId("vhost-settings-entry"));
     const rows = Array.from(container.querySelectorAll(".settings-nav-row"));
-    expect(rows.length).toBe(8);
+    expect(rows.length).toBe(9);
     for (const row of rows) {
       const subtitle = row.querySelector(".settings-nav-row-subtitle");
       expect(subtitle).not.toBeNull();

--- a/cicchetto/src/__tests__/commandOutput.test.ts
+++ b/cicchetto/src/__tests__/commandOutput.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelKey } from "../lib/channelKey";
+
+// #162 — the in-window verb answer store. What is worth pinning: one entry
+// per LINE sharing one `at` (the lines of an answer never interleave with a
+// message), ask-order accumulation, and window keying.
+
+vi.mock("../lib/auth", () => ({ token: () => "tok" }));
+
+const k = (name: string) => `freenode ${name}` as ChannelKey;
+
+describe("commandOutput store", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  const header = { label: "Ignore list for freenode:", text: "", indent: false };
+  const member = (text: string) => ({ label: null, text, indent: true });
+
+  it("appends one entry per line, in order, all stamped with one `at`", async () => {
+    const { appendCommandOutput, commandOutputByWindow } = await import("../lib/commandOutput");
+    appendCommandOutput(k("#a"), [header, member("spambot!*@*"), member("*!*@*.evil.example")]);
+
+    const rows = commandOutputByWindow()[k("#a")] ?? [];
+    expect(rows.map((r) => [r.label, r.text, r.indent])).toEqual([
+      ["Ignore list for freenode:", "", false],
+      [null, "spambot!*@*", true],
+      [null, "*!*@*.evil.example", true],
+    ]);
+    expect(new Set(rows.map((r) => r.at)).size).toBe(1);
+    expect(rows[2]?.ts).toBeGreaterThan(rows[0]?.ts ?? 0);
+  });
+
+  it("accumulates across invocations — asking twice prints twice", async () => {
+    const { appendCommandOutput, commandOutputByWindow } = await import("../lib/commandOutput");
+    appendCommandOutput(k("#a"), [{ label: "Ignore:", text: "first", indent: false }]);
+    appendCommandOutput(k("#a"), [{ label: "Unignore:", text: "second", indent: false }]);
+
+    const rows = commandOutputByWindow()[k("#a")] ?? [];
+    expect(rows.map((r) => `${r.label} ${r.text}`)).toEqual(["Ignore: first", "Unignore: second"]);
+  });
+
+  it("keys on the submitting window, so two windows never share rows", async () => {
+    const { appendCommandOutput, commandOutputByWindow } = await import("../lib/commandOutput");
+    appendCommandOutput(k("#a"), [member("x")]);
+
+    expect(commandOutputByWindow()[k("#a")]).toHaveLength(1);
+    expect(commandOutputByWindow()[k("#b")]).toBeUndefined();
+  });
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { channelKey } from "../lib/channelKey";
+import { type ChannelKey, channelKey } from "../lib/channelKey";
 import type { SlashCommand } from "../lib/slashCommands";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "../lib/windowKinds";
 import { BLANK_BODY_ERROR, serverAcceptsBody } from "./serverBodyPredicate";
@@ -49,6 +49,12 @@ vi.mock("../lib/api", () => {
     patchNetwork: vi.fn(),
     // #356 — /notify + /watch presence add hits this REST helper.
     postNotifyAdd: vi.fn().mockResolvedValue(undefined),
+    // #162 — every ignore mutation answers with the resulting list.
+    getIgnores: vi.fn().mockResolvedValue(["spambot!*@*"]),
+    postIgnore: vi
+      .fn()
+      .mockResolvedValue({ masks: ["spambot!*@*"], mask: "spambot!*@*", outcome: "added" }),
+    deleteIgnore: vi.fn().mockResolvedValue({ masks: [], mask: "spambot!*@*", outcome: "removed" }),
     // Required by networks.ts (transitively imported via compose.ts → networks.ts)
     listNetworks: vi.fn().mockResolvedValue([]),
     listChannels: vi.fn().mockResolvedValue([]),
@@ -5127,6 +5133,107 @@ describe("compose submit — watch-family verbs (#356)", () => {
     expect(result).toMatchObject({ ok: expect.stringContaining("highlight") });
   });
 
+  // #162 — /ignore <mask> and /unignore <mask>. The answer lands IN THE
+  // WINDOW (`commandOutput`), never as the compose notice: one labelled row
+  // naming ITS OWN outcome on the NORMALISED mask (`/unignore spambot`
+  // removes `spambot!*@*`). A bare /ignore opens the settings sub-page.
+  const outputLines = async (k: ChannelKey): Promise<Array<[string | null, string, boolean]>> => {
+    const { commandOutputByWindow } = await import("../lib/commandOutput");
+    return (commandOutputByWindow()[k] ?? []).map((e) => [e.label, e.text, e.indent]);
+  };
+
+  it("/ignore <mask> posts the mask and prints what was added into the window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ignore spambot");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.postIgnore).toHaveBeenCalledWith("tok", "freenode", "spambot");
+    expect(result).toEqual({ ok: true });
+    expect(await outputLines(k)).toEqual([["Ignore:", "added spambot!*@*", false]]);
+  });
+
+  it("/ignore of a mask already on the list says so instead of posing as a first add", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    vi.mocked(api.postIgnore).mockResolvedValueOnce({
+      masks: ["spambot!*@*"],
+      mask: "spambot!*@*",
+      outcome: "already_ignored",
+    });
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ignore SPAMBOT");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toEqual({ ok: true });
+    expect(await outputLines(k)).toEqual([["Ignore:", "spambot!*@* is already ignored", false]]);
+  });
+
+  it("/unignore <mask> prints the normalised mask it removed, and only that", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/unignore spambot");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(api.deleteIgnore).toHaveBeenCalledWith("tok", "freenode", "spambot");
+    expect(result).toEqual({ ok: true });
+    expect(await outputLines(k)).toEqual([["Unignore:", "removed spambot!*@*", false]]);
+  });
+
+  it("/unignore of a mask that was never ignored says so", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    vi.mocked(api.deleteIgnore).mockResolvedValueOnce({
+      masks: ["spambot!*@*"],
+      mask: "nobody!*@*",
+      outcome: "not_ignored",
+    });
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/unignore nobody");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toEqual({ ok: true });
+    expect(await outputLines(k)).toEqual([["Unignore:", "nobody!*@* was not ignored", false]]);
+  });
+
+  // Bare /ignore takes the bare-/hilight door: open the sub-page, print
+  // nothing, touch no REST.
+  it("bare /ignore opens the ignore-list settings sub-page without mutating", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const nav = await import("../lib/settingsNav");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ignore");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(nav.requestOpenSettings).toHaveBeenCalledWith("ignores");
+    expect(api.getIgnores).not.toHaveBeenCalled();
+    expect(api.postIgnore).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
+    expect(await outputLines(k)).toEqual([]);
+  });
+
+  // 422 `invalid_mask` must surface as the inline error, never a green line.
+  it("/ignore with a mask the server refuses surfaces the error", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    vi.mocked(api.postIgnore).mockRejectedValueOnce(new api.ApiError(422, "invalid_mask"));
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ignore nick@host!user");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toMatchObject({ error: expect.any(String) });
+    expect(compose.getDraft(k)).toBe("/ignore nick@host!user");
+  });
+
   it("/notify <nick> calls postNotifyAdd and returns a green confirmation naming the nick", async () => {
     localStorage.setItem("grappa-token", "tok");
     const api = await import("../lib/api");
@@ -5563,6 +5670,7 @@ const DISPATCH_CASE_LABELS = [
   "disconnect",
   "error",
   "info",
+  "ignore",
   "invite",
   "join",
   "kb",
@@ -5667,6 +5775,7 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: SlashCommand["kind"]; draft: string
   { kind: "nick", draft: "/nick bob" },
   { kind: "away", draft: "/away brb" },
   { kind: "notify", draft: "/notify bob" },
+  { kind: "ignore", draft: "/ignore spambot" },
   { kind: "watchlist", draft: "/hilight badger" },
   { kind: "whois", draft: "/whois bob" },
   { kind: "whowas", draft: "/whowas bob" },
@@ -5798,12 +5907,12 @@ describe("#1396 — dispatch characterization over every arm", () => {
       misparsed,
     }).toMatchInlineSnapshot(`
       {
-        "arms": 62,
+        "arms": 63,
         "armsWithNoDraft": [],
         "draftsNamingNoArm": [],
         "duplicated": [],
         "misparsed": [],
-        "rows": 62,
+        "rows": 63,
       }
     `);
   });
@@ -6002,6 +6111,17 @@ describe("#1396 — dispatch characterization over every arm", () => {
           ],
           "result": {
             "error": "unknown command: /nosuchverb",
+          },
+        },
+        "ignore": {
+          "effects": [
+            "aliasList.aliases()",
+            "api.postIgnore("tok", "freenode", "spambot")",
+            "networks.networkIdBySlug("freenode")",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "ok": true,
           },
         },
         "info": {
@@ -6595,7 +6715,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "aliasList.aliases()",
           "networks.networkIdBySlug("freenode")",
         ],
-        "arms": 62,
+        "arms": 63,
         "indistinguishablePairs": [
           [
             "ame",

--- a/cicchetto/src/__tests__/friendlyApiError.test.ts
+++ b/cicchetto/src/__tests__/friendlyApiError.test.ts
@@ -70,6 +70,7 @@ const CASES: Array<{ code: string; matches: RegExp; info?: Record<string, unknow
   { code: "too_many_attempts", matches: /too many login attempts/i },
   // #247 (review 2026-07-19 R1) — /notify watch-list cap.
   { code: "list_full", matches: /watch list.*is full/i },
+  { code: "invalid_mask", matches: /ignore mask.*not valid/i },
   // #364 bucket H (cross-surface S3) — FallbackController tokens that
   // reached operator-visible alerts as raw `<status> <code>` because
   // KnownApiErrorCode had no arm, despite the server comments promising

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1370,6 +1370,56 @@ describe("parseSlash — /oper", () => {
 // irssi-direct: `/notify <nick> …` adds; /watch is a presence ALIAS (was a
 // keyword alias pre-#356); a BARE form opens the watch-lists settings
 // section (removal lives there, per-entry ×).
+// #162 — /ignore + /unignore, the server-honoured mask list. irssi-direct:
+// one mask per call; a bare /ignore opens the ignore-list settings sub-page
+// (like bare /hilight). Levels are deliberately NOT parsed
+// (v1 drops content only), so a second token is ignored, not a second mask.
+describe("parseSlash — /ignore + /unignore (#162)", () => {
+  it("/ignore <mask> → ignore add", () => {
+    expect(parseSlash("/ignore spambot")).toEqual({
+      kind: "ignore",
+      action: "add",
+      mask: "spambot",
+    });
+  });
+
+  it("/ignore keeps a full nick!user@host mask verbatim — normalisation is the server's", () => {
+    expect(parseSlash("/ignore *!*@Evil.Example")).toEqual({
+      kind: "ignore",
+      action: "add",
+      mask: "*!*@Evil.Example",
+    });
+  });
+
+  it("/ignore takes ONE mask; a trailing token is not a second one", () => {
+    expect(parseSlash("/ignore spambot PUBLIC")).toEqual({
+      kind: "ignore",
+      action: "add",
+      mask: "spambot",
+    });
+  });
+
+  it("bare /ignore → open the ignore-list settings sub-page", () => {
+    expect(parseSlash("/ignore")).toEqual({ kind: "open-settings", section: "ignores" });
+  });
+
+  it("/unignore <mask> → ignore del", () => {
+    expect(parseSlash("/unignore spambot")).toEqual({
+      kind: "ignore",
+      action: "del",
+      mask: "spambot",
+    });
+  });
+
+  it("bare /unignore is a parser error, not a silent list", () => {
+    expect(parseSlash("/unignore")).toEqual({
+      kind: "error",
+      verb: "unignore",
+      message: "/unignore requires a mask",
+    });
+  });
+});
+
 describe("parseSlash — /notify + /watch presence (#356: irssi-direct, bare → settings)", () => {
   it("/notify <nick> → notify add", () => {
     expect(parseSlash("/notify Foo")).toEqual({ kind: "notify", action: "add", nicks: ["Foo"] });

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2748,6 +2748,62 @@ export async function deleteNotifyNick(
   if (!res.ok) throw await readError(res);
 }
 
+// #162 — /ignore mask-list REST surface (`GrappaWeb.IgnoresController`).
+// Every mutation answers with the RESULTING list, so the caller renders that
+// and reconciles nothing; an idempotent re-add is indistinguishable from a
+// first add on the wire.
+
+export type IgnoresResponse = { masks: string[] };
+// #162 — a mutation answers the resulting list (the session re-sync), the
+// NORMALISED mask it acted on (`/unignore spambot` removes `spambot!*@*`,
+// which the operator never typed), and what it did. The verb prints the
+// outcome on that mask and nothing else.
+export type IgnoreAddResponse = {
+  masks: string[];
+  mask: string;
+  outcome: "added" | "already_ignored";
+};
+export type IgnoreRemoveResponse = {
+  masks: string[];
+  mask: string;
+  outcome: "removed" | "not_ignored";
+};
+
+export async function getIgnores(token: string, networkSlug: string): Promise<string[]> {
+  const res = await fetch(`/networks/${encodeURIComponent(networkSlug)}/ignores`, {
+    headers: buildHeaders(token),
+  });
+  if (!res.ok) throw await readError(res);
+  return ((await res.json()) as IgnoresResponse).masks;
+}
+
+export async function postIgnore(
+  token: string,
+  networkSlug: string,
+  mask: string,
+): Promise<IgnoreAddResponse> {
+  const res = await fetch(`/networks/${encodeURIComponent(networkSlug)}/ignores`, {
+    method: "POST",
+    headers: buildHeaders(token),
+    body: JSON.stringify({ mask }),
+  });
+  if (!res.ok) throw await readError(res);
+  return (await res.json()) as IgnoreAddResponse;
+}
+
+export async function deleteIgnore(
+  token: string,
+  networkSlug: string,
+  mask: string,
+): Promise<IgnoreRemoveResponse> {
+  const res = await fetch(
+    `/networks/${encodeURIComponent(networkSlug)}/ignores/${encodeURIComponent(mask)}`,
+    { method: "DELETE", headers: buildHeaders(token) },
+  );
+  if (!res.ok) throw await readError(res);
+  return (await res.json()) as IgnoreRemoveResponse;
+}
+
 // #356 — the `clearNotify` REST client (for the dropped `/notify clear`
 // subverb) was removed: presence removal is now per-entry (the settings ×
 // → deleteNotifyNick). The server DELETE-all route stays (the e2e cleanup

--- a/cicchetto/src/lib/commandOutput.ts
+++ b/cicchetto/src/lib/commandOutput.ts
@@ -1,0 +1,88 @@
+import { createSignal } from "solid-js";
+import type { ChannelKey } from "./channelKey";
+import { identityScopedStore } from "./identityScopedStore";
+
+// #162 — the in-window answer of a slash verb. Append-only list of plain
+// text lines per SUBMITTING window key, one entry per LINE.
+//
+// Why a store, and why a THIRD one next to `inviteAck` and `topicShow`: a
+// verb that answers a question (`/ignore` — what is ignored here?) or
+// reports what it did (`/unignore spambot` — removed `spambot!*@*`, a mask
+// the operator never typed) belongs in the window, irssi-style, where the
+// answer stays as a log of what was asked and when. The `{ ok: string }`
+// compose notice is a transient strip under the composer that auto-dismisses
+// and shows one line: it cannot carry a list, and it cannot carry history
+// (Gabriele's ruling, 2026-09-06). `topicShow` is the same idea for one
+// structured answer (the topic renders with its setter meta); this one is
+// the plain-text general case, so a future verb reaches for it rather than
+// growing a fourth store.
+//
+// Display rules, shared with the two siblings:
+//   * Keyed by the SUBMITTING window. The answer lands where the operator
+//     typed, which is where they are looking.
+//   * One row per line, rows accumulate in ask order. Asking twice prints
+//     twice: a log, not a last-write-wins banner.
+//   * NOT persisted — an answer to a question just asked, not audit log.
+//   * Interleaved by wallclock `at` in the pane's `rows()` memo, so the
+//     answer sits at the moment it was given rather than pinned to the
+//     bottom where later arrivals would read as replies to it.
+//
+// Identity-scoped: cleared on logout / token rotation, like every other
+// client-side buffer.
+
+/**
+ * One line of an answer, as the handler shapes it. A `label` renders in the
+ * accent style of `Topic for #chan:` (so `Ignore list for azzurra:`,
+ * `Unignore:`), an `indent`ed line is a member of the list the label opened
+ * — one mask per row under the header, irssi-style (Gabriele, 2026-09-06).
+ */
+export type CommandOutputLine = {
+  label: string | null;
+  text: string;
+  indent: boolean;
+};
+
+export type CommandOutputEntry = CommandOutputLine & {
+  /**
+   * Monotonic insertion sequence (closure-local counter, NOT a clock).
+   * Tiebreaker for lines of one invocation, which all share an `at`.
+   */
+  ts: number;
+  /** Wallclock epoch ms — the sort key against `ScrollbackMessage.server_time`. */
+  at: number;
+};
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const [commandOutputByWindow, setCommandOutputByWindow] = createSignal<
+    Record<ChannelKey, CommandOutputEntry[]>
+  >({});
+
+  let seq = 0;
+
+  onIdentityChange(() => {
+    setCommandOutputByWindow({});
+    seq = 0;
+  });
+
+  const appendCommandOutput = (
+    windowKey: ChannelKey,
+    lines: readonly CommandOutputLine[],
+  ): void => {
+    // One `at` for the whole invocation: the lines are one answer and must
+    // never interleave with a message that lands between two of them.
+    const at = Date.now();
+    const entries = lines.map((line): CommandOutputEntry => {
+      seq += 1;
+      return { ...line, ts: seq, at };
+    });
+    setCommandOutputByWindow((prev) => ({
+      ...prev,
+      [windowKey]: [...(prev[windowKey] ?? []), ...entries],
+    }));
+  };
+
+  return { commandOutputByWindow, appendCommandOutput };
+});
+
+export const commandOutputByWindow = exports_.commandOutputByWindow;
+export const appendCommandOutput = exports_.appendCommandOutput;

--- a/cicchetto/src/lib/commands/session.ts
+++ b/cicchetto/src/lib/commands/session.ts
@@ -1,7 +1,10 @@
 import { patchNetwork, postNick, postNotifyAdd } from "../api";
+import { appendCommandOutput, type CommandOutputLine } from "../commandOutput";
 import { friendlyError } from "../friendlyError";
+import { addIgnore, delIgnore } from "../ignoreList";
 import { clearMentionsBundle } from "../mentionsWindow";
 import { quitAll } from "../quit";
+import type { SlashCommand } from "../slashCommands";
 import { pushAwaySet, pushAwayUnset, pushOper, pushRecover } from "../socket";
 import type { CommandHandler } from "./context";
 
@@ -104,6 +107,53 @@ export const recoverCommand: CommandHandler<"recover"> = async (cmd, ctx) => {
  * resolves, so reading watchByNetwork() here would race. Removal is the
  * settings × (bare /notify opens it). Per-network: the active window's network.
  */
+/**
+ * #162 — `/ignore <mask>` and `/unignore <mask>`. Both address the network
+ * by SLUG over REST; the id check keeps the "network must exist" contract
+ * the other network verbs hold and discards the value, as `notifyCommand`
+ * below does. A BARE `/ignore` never reaches here: the parser turns it into
+ * `open-settings` → the ignore-list sub-page, the door bare `/hilight`
+ * takes (the list with its per-entry × lives there).
+ *
+ * The answer is printed INTO THE WINDOW (`commandOutput.ts`), never as the
+ * transient compose notice: one row naming ITS OWN outcome on the mask the
+ * server normalised — `Unignore: removed spambot!*@*` for `/unignore
+ * spambot`, a mask the operator never typed — and nothing else; an
+ * idempotent re-add says `already ignored` rather than posing as a first
+ * add. The window keeps the rows, so what was asked and done stays readable
+ * as history (Gabriele, 2026-09-06).
+ *
+ * Every call goes through `ignoreList.ts`, the store the ignore-list
+ * settings sub-page reads, so a verb typed here updates a sub-page that is
+ * open — one state, the pattern `/hilight` + the watch-lists page set.
+ */
+export const ignoreCommand: CommandHandler<"ignore"> = async (cmd, ctx) => {
+  const net = ctx.requireNetworkId(ctx.networkSlug, "ignore");
+  if (typeof net !== "number") return net;
+
+  appendCommandOutput(ctx.key, await ignoreLines(cmd, ctx.token, ctx.networkSlug));
+  return { ok: true };
+};
+
+const ignoreLines = async (
+  cmd: Extract<SlashCommand, { kind: "ignore" }>,
+  token: string,
+  slug: string,
+): Promise<CommandOutputLine[]> => {
+  switch (cmd.action) {
+    case "add": {
+      const r = await addIgnore(token, slug, cmd.mask);
+      const text = r.outcome === "added" ? `added ${r.mask}` : `${r.mask} is already ignored`;
+      return [{ label: "Ignore:", text, indent: false }];
+    }
+    case "del": {
+      const r = await delIgnore(token, slug, cmd.mask);
+      const text = r.outcome === "removed" ? `removed ${r.mask}` : `${r.mask} was not ignored`;
+      return [{ label: "Unignore:", text, indent: false }];
+    }
+  }
+};
+
 export const notifyCommand: CommandHandler<"notify"> = async (cmd, ctx) => {
   // The id is not used — this arm addresses the network by SLUG over REST — but
   // the network must still exist, so the check is kept and the value

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -57,6 +57,7 @@ import { serviceModalCommand } from "./commands/services";
 import {
   awayCommand,
   disconnectCommand,
+  ignoreCommand,
   nickCommand,
   notifyCommand,
   operCommand,
@@ -1134,6 +1135,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // ---------------------------------------------------------------
         case "watchlist": {
           result = await watchlistCommand(cmd, ctx);
+          break;
+        }
+        case "ignore": {
+          result = await ignoreCommand(cmd, ctx);
           break;
         }
         case "notify": {

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -269,6 +269,11 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // per-network cap (`Grappa.Notify.max_entries/0`). A bounded
       // resource, not a rate — the recourse is pruning, not waiting.
       return "Your watch list for this network is full. Remove an entry first.";
+    case "invalid_mask":
+      // #162 — `/ignore` mask rejected by `Grappa.IRC.Mask.normalize/1`
+      // (empty, whitespace, or not `nick!user@host`). A bare nick is
+      // fine — it becomes `nick!*@*` server-side — so name the shape.
+      return "That ignore mask is not valid. Use a nick or nick!user@host.";
     // #364 bucket H (cross-surface S3) — four FallbackController tokens
     // whose server comments assert cic copy exists, but KnownApiErrorCode
     // had no arm, so they leaked the raw `<status> <code>` string into

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -270,7 +270,7 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // resource, not a rate — the recourse is pruning, not waiting.
       return "Your watch list for this network is full. Remove an entry first.";
     case "invalid_mask":
-      // #162 — `/ignore` mask rejected by `Grappa.IRC.Mask.normalize/1`
+      // #162 — `/ignore` mask rejected by `Grappa.IRC.Mask.normalize/2`
       // (empty, whitespace, or not `nick!user@host`). A bare nick is
       // fine — it becomes `nick!*@*` server-side — so name the shape.
       return "That ignore mask is not valid. Use a nick or nick!user@host.";

--- a/cicchetto/src/lib/ignoreList.ts
+++ b/cicchetto/src/lib/ignoreList.ts
@@ -1,0 +1,73 @@
+// #162 — cic-side single source of truth for the per-network ignore list.
+//
+// Same shape as `highlightList.ts`, for the same reason: the list is server
+// `user_settings` with NO broadcast, and every REST mutation answers the
+// authoritative post-mutation list (`{masks, mask, outcome}`). Mirroring that
+// answer here means the `/ignore` verbs and the ignore-list settings
+// sub-page read ONE state that cannot drift — the sub-page refreshes on
+// open, and an `/ignore` typed in the compose box updates the list an open
+// sub-page is showing.
+//
+// Keyed by network SLUG, which is how the REST surface and the server-side
+// `user_settings.data.ignores` map address it.
+//
+// cic NEVER originates state here: the signal only ever holds what the last
+// server round-trip returned. Identity-scoped, so a logout / account switch
+// clears the previous account's masks instead of rendering them for the next
+// one until a refresh.
+
+import { createSignal } from "solid-js";
+import {
+  deleteIgnore,
+  getIgnores,
+  type IgnoreAddResponse,
+  type IgnoreRemoveResponse,
+  postIgnore,
+} from "./api";
+import { identityScopedStore } from "./identityScopedStore";
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const [ignoresBySlug, setIgnoresBySlug] = createSignal<Record<string, string[]>>({});
+
+  onIdentityChange(() => setIgnoresBySlug({}));
+
+  const mirror = (slug: string, masks: string[]): void => {
+    setIgnoresBySlug((prev) => ({ ...prev, [slug]: masks }));
+  };
+
+  // Fetch one network's list (sub-page open, bare `/ignore`). Mirror + return.
+  const refreshIgnores = async (token: string, slug: string): Promise<string[]> => {
+    const masks = await getIgnores(token, slug);
+    mirror(slug, masks);
+    return masks;
+  };
+
+  // Add a mask; mirror the list and return the whole answer — the verb
+  // prints the outcome on the NORMALISED mask, not the list.
+  const addIgnore = async (
+    token: string,
+    slug: string,
+    mask: string,
+  ): Promise<IgnoreAddResponse> => {
+    const r = await postIgnore(token, slug, mask);
+    mirror(slug, r.masks);
+    return r;
+  };
+
+  const delIgnore = async (
+    token: string,
+    slug: string,
+    mask: string,
+  ): Promise<IgnoreRemoveResponse> => {
+    const r = await deleteIgnore(token, slug, mask);
+    mirror(slug, r.masks);
+    return r;
+  };
+
+  return { ignoresBySlug, refreshIgnores, addIgnore, delIgnore };
+});
+
+export const ignoresBySlug = exports_.ignoresBySlug;
+export const refreshIgnores = exports_.refreshIgnores;
+export const addIgnore = exports_.addIgnore;
+export const delIgnore = exports_.delIgnore;

--- a/cicchetto/src/lib/settingsNav.ts
+++ b/cicchetto/src/lib/settingsNav.ts
@@ -54,6 +54,7 @@ export type SettingsSubPage =
   | "themes"
   | "push"
   | "watchlists"
+  | "ignores"
   | "aliases"
   | "perform";
 

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -229,12 +229,16 @@ export type SlashCommand =
   // NOT the keyword highlight list above). irssi-direct: `/notify <nick> …`
   // adds. Removal is via the settings ×; a bare form opens settings.
   | { kind: "notify"; action: "add"; nicks: string[] }
+  // #162 — /ignore + /unignore, the server-honoured mask list. irssi-direct:
+  // `/ignore <mask>` adds (a bare nick means nick!*@*), `/unignore <mask>`
+  // removes, and a BARE `/ignore` lists what is set for this network.
+  | { kind: "ignore"; action: "add" | "del"; mask: string }
   // #356/#385 — a BARE verb that opens a settings sub-page instead of
   // printing inline (watch-family → watch lists; bare /alias → aliases).
   // Opening the drawer IS the feedback. `section` widens as sub-pages gain
   // bare-verb deep-links; it must stay assignable to settingsNav's
   // SettingsSubPage.
-  | { kind: "open-settings"; section: "watchlists" | "aliases" }
+  | { kind: "open-settings"; section: "watchlists" | "aliases" | "ignores" }
   // #385 — user-defined command aliases. `/alias <name> <expansion>` defines
   // one, `/unalias <name>` removes one. The define carries the parsed name +
   // expansion; compose.ts round-trips them through the aliasList store.
@@ -296,6 +300,25 @@ function parseNickReason(kind: NickReasonKind, verb: string, rest: string): Slas
   const nick = sp === -1 ? rest : rest.slice(0, sp);
   const reason = sp === -1 ? "" : rest.slice(sp + 1).trim();
   return { kind, nick, reason };
+}
+
+// #162 — /ignore and /unignore. One token: the mask. `/ignore` alone lists.
+// Trailing tokens are ignored, the no-arg family's posture — a second token
+// is not a second mask, and irssi's `<levels>` argument is deliberately not
+// parsed here (v1 ignores content only; see the server filter).
+// #162 — `/ignore <mask>` adds; a BARE `/ignore` opens the ignore-list
+// settings sub-page, the same door bare `/hilight` and `/notify` take (the
+// list with its per-entry × is right there; Gabriele's ruling, 2026-09-06).
+function parseIgnore(_verb: string, rest: string): SlashCommand {
+  const [mask] = tokens(rest);
+  if (mask === undefined) return { kind: "open-settings", section: "ignores" };
+  return { kind: "ignore", action: "add", mask };
+}
+
+function parseUnignore(verb: string, rest: string): SlashCommand {
+  const [mask] = tokens(rest);
+  if (mask === undefined) return { kind: "error", verb, message: "/unignore requires a mask" };
+  return { kind: "ignore", action: "del", mask };
 }
 
 // #356 — presence-watch parser, shared by /notify + /watch (alias).
@@ -917,6 +940,8 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   // #356 — presence watch (classic IRC WATCH/MONITOR = presence).
   // /notify is canonical; /watch is now a presence ALIAS (was a keyword
   // alias pre-#356). Both: irssi-direct add, or bare → open settings.
+  ignore: (verb, rest) => parseIgnore(verb, rest),
+  unignore: (verb, rest) => parseUnignore(verb, rest),
   notify: (verb, rest) => parseNotify(verb, rest),
   watch: (verb, rest) => parseNotify(verb, rest),
 

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -140,7 +140,12 @@ let _socket: Socket | null = null;
 // longer do: this bundle speaks 13 and still serves a v9 server. That gap is
 // the two axes behaving as designed, not drift to be tidied away — raising
 // the floor is the #1654 question and is not answered here.
-export const CLIENT_PROTOCOL_VERSION = 13;
+//
+// 13 → 14 (#162): the first bump under the #1973 pin, and it worked as
+// designed — `protocol_test.exs` went red at the commit that moved
+// `@protocol_version` (the `invalid_mask` token) without this line, so the
+// two moved together instead of this file lagging for another three weeks.
+export const CLIENT_PROTOCOL_VERSION = 14;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1646,6 +1646,7 @@ export const S_ErrorTokensRestErrorToken = {
     { l: "too_many_attempts" },
     { l: "theme_cap_reached" },
     { l: "list_full" },
+    { l: "invalid_mask" },
     { l: "not_raster" },
     { l: "too_large" },
     { l: "ssrf_blocked" },

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1666,6 +1666,7 @@ export const ERROR_TOKENS_REST_ERROR_TOKEN = [
   "too_many_attempts",
   "theme_cap_reached",
   "list_full",
+  "invalid_mask",
   "not_raster",
   "too_large",
   "ssrf_blocked",

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3817,6 +3817,14 @@ button.topic-bar-windows-opener {
   color: var(--muted);
 }
 
+/* #162: a member row of a slash verb's list answer (`Ignore list for
+   azzurra:` then one mask per row), indented under its header the way irssi
+   indents a list under its title. `ch` so the indent tracks the monospace
+   grid rather than the font size. */
+.scrollback-command-output-indent {
+  padding-left: 4ch;
+}
+
 .scrollback-time {
   color: var(--muted);
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48492,6 +48492,18 @@ as a history of what was asked and done (Gabriele's rulings, 2026-09-06:
 name what was removed; drop the trailing list; print in the window; then
 the bare verb opens settings rather than printing the list).
 
+**The ignore list is read at the SPAWN BOUNDARY, not in `init/1`.** First
+CI run after the review fixes: `JoinSeedCostTest` (the #1759 join-storm
+count, which deliberately counts every query in the VM) read one stray
+`user_settings` query at W=1 and failed its linearity law. The stray was
+`UserSettings.get_ignores/2` inside `Session.Server.init/1`: a `:transient`
+respawn re-runs `init/1` with the same opts, so an init-time read fires on
+every crash — and the storm fixture's session respawns mid-window. Moved to
+`start_session/3` beside `auto_away_debounce_ms` and `show_peer_profiles`
+(`Map.put_new_lazy(:ignores, …)`), the repo's spawn-boundary pattern, which
+a respawn does not re-run. Same edge those two carry: a restart holds the
+spawn-time value until the next `ignores_changed`.
+
 **Review fixes (vjt on #1984, 2026-09-07), all three taken as fixes.** (1)
 Masks are compiled ONCE — `Mask.compile_all/1` in `Session.Server` at init
 and on every `ignores_changed` — and the router matches the compiled list;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48465,3 +48465,117 @@ day a generator turned that flag on.
 
 _Deploy: **test-only** — no production module, no migration, no `VERSION` bump,
 no cic bundle, no wire change._
+<!-- entry #162a -->
+
+---
+
+## 2026-09-06 — #162a: /ignore, dropped at the door
+
+**Shipped:** a per-subject, per-network `/ignore` mask list, honoured
+server-side. `Grappa.IRC.Mask` (the `nick!user@host` glob matcher grappa never
+had), an `"ignores"` key in `user_settings.data` with `get_ignores/2` +
+`add_ignore/3` + `remove_ignore/3`, `/networks/:network_id/ignores` REST, the
+list carried on `Session.Server` state and re-synced on mutation, and the
+filter itself at the head of `EventRouter.route/2`. cic gets `/ignore <mask>`,
+`/unignore <mask>`; a BARE `/ignore` opens the ignore-list settings
+sub-page, the door bare `/hilight` and `/notify` take (#356) — the list with
+its per-entry × lives there, so there is no in-window list verb. A mutation's
+answer prints INTO THE WINDOW, irssi-style, through a new plain-text sibling
+of `topicShow` / `inviteAck` (`cicchetto/src/lib/commandOutput.ts`, one row
+per line with an optional accent label and an indent flag, interleaved by
+wallclock like the other two): one row naming its own outcome on the
+NORMALISED mask (`Unignore: removed spambot!*@*`, labelled like `Topic for
+#chan:` — `/unignore spambot` acts on a mask the operator never typed, so
+the reply must name it) and nothing else. Not the transient compose notice,
+which auto-dismisses and holds one line: the rows stay, so the window reads
+as a history of what was asked and done (Gabriele's rulings, 2026-09-06:
+name what was removed; drop the trailing list; print in the window; then
+the bare verb opens settings rather than printing the list).
+
+**Settings sub-page.** The list is also editable under settings → "ignore
+list" (`cicchetto/src/IgnoresSettings.tsx`), one block per network with × to
+remove and an add-input, shaped after the watch-lists page (#356) down to
+the list classes. Backed by `lib/ignoreList.ts`, a mirror store in the
+`highlightList.ts` mould (no broadcast → refresh on open, every REST answer
+mirrored), and the `/ignore` verbs go through the SAME store, so a verb typed
+in the compose box updates a sub-page that is open — one state, never two.
+
+**A third ephemeral kind exposed an ordering bug in the first two.** `/ignore`
+then `/topic` printed the topic ABOVE the ignore rows. `ScrollbackPane`'s
+`rows()` memo wove invite-acks, `/topic` answers and now verb answers into
+the timeline in three separate passes, each anchoring only on MESSAGE rows
+(`server_time > at`): the `/topic` pass ran after the `/ignore` pass, saw no
+later message, and went to the END — past rows it never looked at. The same
+shape reverses two `/topic` answers once a message lands after both (equal
+insertion index, the second splice lands first) — latent since #1914, never
+seen because nobody asked `/topic` twice under a live channel. Fixed by ONE
+pass over all ephemeral entries sorted by `(at, ts)`, with every woven row
+carrying its `at` so a later answer anchors on an earlier one exactly as on a
+message (`rowTime/1`). Pinned by a pane test that asks `/ignore` then
+`/topic` under a message later than both.
+
+### Drop, not hide, not re-route — and why the pick was easy
+
+#162's body says drop. Lucy's variant re-routes to the server window as a flat
+silent line; the issue records the tension and that someone has to pick. Picked
+drop, on vjt's ruling that ignored is ignored — no un-hide, no back and forth —
+which also makes the second ruling on the issue free: **an ignored message must
+produce no push**, and with no persist effect there is no row, no broadcast and
+no trigger, so *"ignored mask sends a DM, subscription exists, zero pushes
+emitted"* holds by construction rather than by a second gate beside
+`muted_targets` in `should_notify?/5`. If the re-route variant wins later, the
+storage, matching, REST and commands all survive; only the delivery arm changes.
+
+### Its own structure, beside `muted_targets`, not inside it
+
+vjt's ruling, and mechanical rather than aesthetic: a mute is "this ROOM is
+noisy" and only suppresses attention; an ignore is "this PERSON is a problem"
+and stops the message existing. The read-path difference is total — mute has
+never needed a filter, ignore is nothing but one — so one shared shape would
+carry a field meaningless on half its rows. Same conventions (network in the
+key for the #1038 reason, `canonical_target/1` fold), separate key. irssi's own
+`NO_ACT` level is what `muted_targets` already is, arrived at independently,
+which is the strongest evidence these are two features and not one with a flag.
+
+### The filter's four deliberate exclusions
+
+Content only — PRIVMSG and NOTICE (ACTION rides PRIVMSG); presence verbs are
+governed by the presence filter and dropping a JOIN here would desync the
+members map. Never our own lines. Never a services or server sender
+(`Mentions.mentionable_sender?/1`, #1674): a `*!*@*` mask must not eat
+NickServ telling you your password is wrong. Never an origin with no nick.
+
+### Forward-only settled the mask question for free
+
+Scrollback stores `sender` as a NICK, never `nick!user@host`, so a mask can
+never be applied to stored history. Under #162's forward-only ruling that never
+bites: matching happens at delivery, where the prefix carries the full triple
+(`Message.sender_origin/1`). A cloaked or absent user/host satisfies only a `*`
+pattern, never a concrete one — an ignore on a host must not fire for a sender
+whose host we cannot see.
+
+### Two bugs the unit tests caught before the PR
+
+1. `normalize/1` accepted `"a b"` — `safe_line_token?/1` guards CR/LF/NUL, not
+   whitespace, and a mask is one token. Rejected explicitly.
+2. The glob's absolute anchors (`\A`/`\z`) reached the source as a bare `A`/`z`
+   through a layer that eats backslashes, so the matcher silently matched
+   nothing — every positive `matches?/4` case red at once. Replaced with
+   `^`/`$`, which need no escaping and bind to the string ends here (no part can
+   carry a newline). The comment on the regex says why.
+
+### Not in v1
+
+irssi's `<levels>` argument (`/ignore nick PUBLIC`) — content-only for now, and
+the vocabulary to grow it is `Message.kinds/0`. irssi's `-replies` — grappa
+does not track what a message replies to. A settings-drawer list — the bare
+`/ignore` prints it.
+
+_Deploy: **HOT** — no migration (a JSON key in the existing column).
+`protocol_version` 13 → 14 (13 went to #1850 while this branch was out — same mechanism, a token moving the pin), and not by judgement: the routes alone are the
+v10/v11 shape (REST endpoints sit outside the generated schema), but the 422
+`invalid_mask` token joins `rest_error_token`, a closed set
+`gen_wire_types` renders into cic's `KnownApiErrorCode` union — the pin
+moved, `ErrorTokensDriftTest` went red, and this paragraph had already
+written the bump off before either spoke. `min_protocol_version` stays 1:
+no pre-v14 bundle knows `/ignore`, so none can earn the token._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48474,7 +48474,7 @@ no cic bundle, no wire change._
 **Shipped:** a per-subject, per-network `/ignore` mask list, honoured
 server-side. `Grappa.IRC.Mask` (the `nick!user@host` glob matcher grappa never
 had), an `"ignores"` key in `user_settings.data` with `get_ignores/2` +
-`add_ignore/3` + `remove_ignore/3`, `/networks/:network_id/ignores` REST, the
+`add_ignore/4` + `remove_ignore/4`, `/networks/:network_id/ignores` REST, the
 list carried on `Session.Server` state and re-synced on mutation, and the
 filter itself at the head of `EventRouter.route/2`. cic gets `/ignore <mask>`,
 `/unignore <mask>`; a BARE `/ignore` opens the ignore-list settings
@@ -48491,6 +48491,24 @@ which auto-dismisses and holds one line: the rows stay, so the window reads
 as a history of what was asked and done (Gabriele's rulings, 2026-09-06:
 name what was removed; drop the trailing list; print in the window; then
 the bare verb opens settings rather than printing the list).
+
+**Review fixes (vjt on #1984, 2026-09-07), all three taken as fixes.** (1)
+Masks are compiled ONCE — `Mask.compile_all/1` in `Session.Server` at init
+and on every `ignores_changed` — and the router matches the compiled list;
+the first cut compiled up to three regexes per mask per inbound line, on
+exactly the users who use the feature. (2) The fold is the NETWORK's, not
+ASCII-only: `Mask.normalize/2` takes the casemapping (the controller reads
+`Session.casemapping/2`, the `/notify` door), so a stored mask sits in that
+network's folded space, and the delivery match folds only the SUBJECT nick
+with `state.isupport`'s casemapping — the #537 ingress rule applied to one
+more key. The review asked for this to be documented as an accepted rfc1459
+gap; Gabriele ruled it fixed instead, since casemapping is implemented and
+the "accepted gap" reads as older than that fact. Compiled masks are
+casemapping-independent, so nothing recompiles on 005; the one remaining
+edge is the pre-005 write, the same one the autojoin plan carries. (3)
+`\A`/`\z` instead of `^`/`$`, with a test that a trailing newline on the
+subject does not match — and every positive assertion in `MaskTest` pins
+the backslashes themselves.
 
 **Settings sub-page.** The list is also editable under settings → "ignore
 list" (`cicchetto/src/IgnoresSettings.tsx`), one block per network with × to

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -181,7 +181,11 @@ defmodule Grappa.HotReload.LongLivedModules do
     Grappa.Session.WhoisAccum,
     Grappa.Session.WhowasAccum,
     Grappa.Session.WindowState,
-    Grappa.IRC.FakeLag
+    Grappa.IRC.FakeLag,
+    # #162 — `Session.Server` holds the ignore list COMPILED, a list of
+    # `%Grappa.IRC.Mask{}`; a field-add to that struct is a state-shape
+    # change for every live session, so its file is on the preflight's list.
+    Grappa.IRC.Mask
   ]
 
   @typedoc """
@@ -230,6 +234,7 @@ defmodule Grappa.HotReload.LongLivedModules do
           | Grappa.Session.WhowasAccum
           | Grappa.Session.WindowState
           | Grappa.IRC.FakeLag
+          | Grappa.IRC.Mask
 
   @doc """
   Returns the list of long-lived `GenServer` modules whose state

--- a/lib/grappa/irc.ex
+++ b/lib/grappa/irc.ex
@@ -34,6 +34,8 @@ defmodule Grappa.IRC do
       Identity,
       JoinFailure,
       LineSplit,
+      # #162 — nick!user@host glob masks for /ignore
+      Mask,
       Message,
       MircFormat
     ]

--- a/lib/grappa/irc/mask.ex
+++ b/lib/grappa/irc/mask.ex
@@ -1,0 +1,156 @@
+defmodule Grappa.IRC.Mask do
+  @moduledoc """
+  `nick!user@host` glob masks (#162) — the shape every IRC client uses for
+  `/ignore`, and the one thing grappa had no matcher for (ban masks travel as
+  opaque strings).
+
+  ## Grammar
+
+  A mask is `nick!user@host` where each of the three parts is a glob: `*`
+  matches any run of characters (including none) and `?` matches exactly one.
+  A bare token with no `!` or `@` is a NICK mask and normalises to `nick!*@*`
+  — so `/ignore spambot` means "that nick from anywhere", which is what an
+  operator typing it expects.
+
+  ## Folding
+
+  The nick part folds through `Identifier.canonical_target/1` on both sides,
+  because a mask is a KEY-shaped comparison (the same reason every other nick
+  compare folds). User and host fold ASCII-lowercase too: idents and hostnames
+  are case-insensitive on the wire, and `*!*@Evil.Example` must catch
+  `evil.example`.
+
+  ## Why glob and not regex
+
+  `*` and `?` are what irssi, mIRC and every ircd's ban list speak. A regex
+  door would be a second matching language for the same thing, and it is the
+  one an operator would have to learn rather than already know.
+  """
+
+  alias Grappa.IRC.Identifier
+
+  @typedoc "A validated, normalised mask: always `nick!user@host`."
+  @type t :: String.t()
+
+  # RFC 2812 caps a mask at what fits on a line; anything past this is not a
+  # mask an operator typed, it is garbage or an attack on the regex.
+  @max_mask_bytes 200
+
+  @doc """
+  Normalises operator input into a full `nick!user@host` mask, or rejects it.
+
+  * `"spambot"`         → `{:ok, "spambot!*@*"}`
+  * `"*!*@evil.example"` → `{:ok, "*!*@evil.example"}`
+  * `""`, spaces, CR/LF, too long, or `!`/`@` in the wrong order → `:error`
+  """
+  @spec normalize(String.t()) :: {:ok, t()} | :error
+  def normalize(input) when is_binary(input) do
+    trimmed = String.trim(input)
+
+    cond do
+      trimmed == "" ->
+        :error
+
+      byte_size(trimmed) > @max_mask_bytes ->
+        :error
+
+      not Identifier.safe_line_token?(trimmed) ->
+        :error
+
+      # `safe_line_token?/1` only guards CR/LF/NUL (the CRLF-injection class);
+      # a mask is additionally ONE whitespace-delimited token, so an embedded
+      # space or tab is not a mask — it is two things the operator did not
+      # mean to join.
+      Regex.match?(~r/\s/u, trimmed) ->
+        :error
+
+      not String.contains?(trimmed, ["!", "@"]) ->
+        {:ok, fold_mask(trimmed <> "!*@*")}
+
+      true ->
+        # `nick!user@host` — exactly one `!` before exactly one `@`, and the
+        # nick part must not be empty (an empty user/host is legal: `*!@*`
+        # is odd but harmless, it simply never matches a real prefix).
+        case Regex.run(~r/\A([^!@]+)!([^!@]*)@([^!@]*)\z/, trimmed) do
+          [_, _, _, _] -> {:ok, fold_mask(trimmed)}
+          nil -> :error
+        end
+    end
+  end
+
+  def normalize(_), do: :error
+
+  @doc """
+  Does `mask` match the origin `{nick, user, host}`?
+
+  `user` and `host` may be `nil` — an ircd that cloaks or a prefix that
+  carried only a nick. A `nil` part matches only a wildcard-only pattern
+  (`*`), never a concrete one: an ignore on `*!*@evil.example` must not fire
+  for a sender whose host we simply cannot see.
+  """
+  @spec matches?(t(), String.t(), String.t() | nil, String.t() | nil) :: boolean()
+  def matches?(mask, nick, user, host) when is_binary(mask) and is_binary(nick) do
+    case String.split(mask, ["!", "@"], parts: 3) do
+      [mn, mu, mh] ->
+        glob?(mn, Identifier.canonical_target(nick)) and
+          glob?(mu, fold_or_nil(user)) and
+          glob?(mh, fold_or_nil(host))
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
+  True when ANY mask in `masks` matches the origin — the per-message question
+  the delivery filter asks. An empty list never matches.
+  """
+  @spec any_match?([t()], String.t(), String.t() | nil, String.t() | nil) :: boolean()
+  def any_match?([], _, _, _), do: false
+
+  def any_match?(masks, nick, user, host) when is_list(masks) do
+    Enum.any?(masks, &matches?(&1, nick, user, host))
+  end
+
+  # ---------------------------------------------------------------------------
+
+  # Fold every part: the nick through the identifier fold, user/host plain
+  # ASCII-lowercase. Same result today (both are byte-level A–Z), but routing
+  # the nick through `canonical_target/1` keeps it on the one fold the rest of
+  # the codebase pins.
+  defp fold_mask(mask) do
+    [n, u, h] = String.split(mask, ["!", "@"], parts: 3)
+    Identifier.canonical_target(n) <> "!" <> ascii_down(u) <> "@" <> ascii_down(h)
+  end
+
+  defp fold_or_nil(nil), do: nil
+  defp fold_or_nil(s) when is_binary(s), do: ascii_down(s)
+
+  defp ascii_down(s), do: for(<<c <- s>>, into: "", do: <<if(c in ?A..?Z, do: c + 32, else: c)>>)
+
+  # Glob against a possibly-absent subject. `*` alone is the only pattern that
+  # matches an absent part; see `matches?/4`.
+  defp glob?("*", _), do: true
+  defp glob?(_, nil), do: false
+  defp glob?(pattern, subject), do: Regex.match?(glob_to_regex(pattern), subject)
+
+  defp glob_to_regex(pattern) do
+    body =
+      pattern
+      |> String.split(~r/[*?]/, include_captures: true, trim: true)
+      |> Enum.map_join(fn
+        "*" -> ".*"
+        "?" -> "."
+        literal -> Regex.escape(literal)
+      end)
+
+    # `^`/`$` rather than the absolute anchors: without the multiline flag they
+    # bind to the string ends, and every part here is a single wire token with
+    # no newline in it (the prefix parser and `safe_line_token?/1` see to
+    # that), so `$`'s trailing-newline tolerance can never matter. Chosen over
+    # the absolute anchors because those need a backslash in a string literal,
+    # and a lost backslash there reads as a bare letter and silently matches
+    # nothing — which is exactly how the first cut of this shipped.
+    Regex.compile!("^" <> body <> "$")
+  end
+end

--- a/lib/grappa/irc/mask.ex
+++ b/lib/grappa/irc/mask.ex
@@ -14,11 +14,34 @@ defmodule Grappa.IRC.Mask do
 
   ## Folding
 
-  The nick part folds through `Identifier.canonical_target/1` on both sides,
-  because a mask is a KEY-shaped comparison (the same reason every other nick
-  compare folds). User and host fold ASCII-lowercase too: idents and hostnames
-  are case-insensitive on the wire, and `*!*@Evil.Example` must catch
-  `evil.example`.
+  A mask is a KEY-shaped comparison, so it folds the way every other nick key
+  does (#537): the nick part goes through `Identifier.canonical_target/2` with
+  the NETWORK's casemapping, on both sides. `normalize/2` is the ingress door
+  — the caller supplies the casemapping (`Grappa.Session.casemapping/2` at the
+  web edge), so a stored mask already sits in that network's folded space: on
+  `CASEMAPPING=rfc1459` (solanum/Libera) `/ignore Foo[1]` stores `foo{1}!*@*`
+  and catches the sender the ircd itself calls `foo{1}`; on `:ascii` (all of
+  prod) the national chars are untouched and `foo[1]` / `foo{1}` stay two
+  people. At delivery `matches?/5` folds the SUBJECT nick with the session's
+  casemapping (`state.isupport`), never the pattern — the pattern was folded
+  when it was written. The known ingress gap applies here as it does to the
+  pre-connect autojoin plan: a mask written before the 005 arrived was folded
+  `:ascii`.
+
+  User and host fold plain ASCII-lowercase: idents and hostnames are
+  case-insensitive on the wire and carry no national-char fold, and
+  `*!*@Evil.Example` must catch `evil.example`.
+
+  ## Compiled once
+
+  `compile/1` turns a stored mask into a `t:compiled/0` — its three parts as
+  precompiled regexes, or `:any` for a bare `*` so the common `nick!*@*` shape
+  runs one regex, not three. `Session.Server` compiles the list when it loads
+  it and on every `ignores_changed`; the delivery filter matches against the
+  compiled list. The first cut compiled per match — up to three regexes per
+  mask per inbound line, on exactly the users who use the feature (review,
+  #1984). The compiled form is casemapping-independent (see Folding), so it
+  never goes stale when the 005 lands.
 
   ## Why glob and not regex
 
@@ -32,95 +55,136 @@ defmodule Grappa.IRC.Mask do
   @typedoc "A validated, normalised mask: always `nick!user@host`."
   @type t :: String.t()
 
+  @typedoc """
+  One compiled part: `:any` for a bare `*`, `:never` for a part of a mask
+  that failed to parse (a stored string that is not `nick!user@host` matches
+  nothing rather than raising — the storage door normalises, so this is
+  corruption, and a session must not die of a settings row), else the regex.
+  """
+  @type part :: :any | :never | Regex.t()
+
+  @typedoc "A mask compiled for matching; `source` is the string it came from."
+  @type compiled :: %__MODULE__{source: t(), nick: part(), user: part(), host: part()}
+
+  @enforce_keys [:source, :nick, :user, :host]
+  defstruct [:source, :nick, :user, :host]
+
   # RFC 2812 caps a mask at what fits on a line; anything past this is not a
   # mask an operator typed, it is garbage or an attack on the regex.
   @max_mask_bytes 200
 
   @doc """
-  Normalises operator input into a full `nick!user@host` mask, or rejects it.
+  Normalises operator input into a full `nick!user@host` mask under the
+  network's casemapping, or rejects it.
 
-  * `"spambot"`         → `{:ok, "spambot!*@*"}`
-  * `"*!*@evil.example"` → `{:ok, "*!*@evil.example"}`
+  * `"spambot"`          → `{:ok, "spambot!*@*"}`
+  * `"*!*@evil.example"`  → `{:ok, "*!*@evil.example"}`
+  * `"Foo[1]"` on `:rfc1459` → `{:ok, "foo{1}!*@*"}`; on `:ascii` → `"foo[1]!*@*"`
   * `""`, spaces, CR/LF, too long, or `!`/`@` in the wrong order → `:error`
   """
-  @spec normalize(String.t()) :: {:ok, t()} | :error
-  def normalize(input) when is_binary(input) do
+  @spec normalize(String.t(), Identifier.casemapping()) :: {:ok, t()} | :error
+  def normalize(input, casemapping) when is_binary(input) and is_atom(casemapping) do
     trimmed = String.trim(input)
 
-    cond do
-      trimmed == "" ->
-        :error
-
-      byte_size(trimmed) > @max_mask_bytes ->
-        :error
-
-      not Identifier.safe_line_token?(trimmed) ->
-        :error
-
-      # `safe_line_token?/1` only guards CR/LF/NUL (the CRLF-injection class);
-      # a mask is additionally ONE whitespace-delimited token, so an embedded
-      # space or tab is not a mask — it is two things the operator did not
-      # mean to join.
-      Regex.match?(~r/\s/u, trimmed) ->
-        :error
-
-      not String.contains?(trimmed, ["!", "@"]) ->
-        {:ok, fold_mask(trimmed <> "!*@*")}
-
-      true ->
-        # `nick!user@host` — exactly one `!` before exactly one `@`, and the
-        # nick part must not be empty (an empty user/host is legal: `*!@*`
-        # is odd but harmless, it simply never matches a real prefix).
-        case Regex.run(~r/\A([^!@]+)!([^!@]*)@([^!@]*)\z/, trimmed) do
-          [_, _, _, _] -> {:ok, fold_mask(trimmed)}
-          nil -> :error
-        end
+    with :ok <- one_token(trimmed), {:ok, full} <- full_shape(trimmed) do
+      {:ok, fold_mask(full, casemapping)}
     end
   end
 
-  def normalize(_), do: :error
+  def normalize(_, _), do: :error
+
+  # Is this ONE token an operator could have typed? `safe_line_token?/1` only
+  # guards CR/LF/NUL (the CRLF-injection class); a mask is additionally one
+  # whitespace-delimited token, so an embedded space or tab is not a mask —
+  # it is two things the operator did not mean to join.
+  @spec one_token(String.t()) :: :ok | :error
+  defp one_token(""), do: :error
+
+  defp one_token(t) do
+    cond do
+      byte_size(t) > @max_mask_bytes -> :error
+      not Identifier.safe_line_token?(t) -> :error
+      Regex.match?(~r/\s/u, t) -> :error
+      true -> :ok
+    end
+  end
+
+  # A bare nick becomes `nick!*@*`; otherwise `nick!user@host` — exactly one
+  # `!` before exactly one `@`, and the nick part must not be empty (an empty
+  # user/host is legal: `*!@*` is odd but harmless, it simply never matches a
+  # real prefix).
+  @spec full_shape(String.t()) :: {:ok, String.t()} | :error
+  defp full_shape(t) do
+    cond do
+      not String.contains?(t, ["!", "@"]) -> {:ok, t <> "!*@*"}
+      Regex.match?(~r/\A([^!@]+)!([^!@]*)@([^!@]*)\z/, t) -> {:ok, t}
+      true -> :error
+    end
+  end
 
   @doc """
-  Does `mask` match the origin `{nick, user, host}`?
+  Compiles a stored mask for matching. A string that is not `nick!user@host`
+  compiles to a mask that matches nothing (see `t:part/0`).
+  """
+  @spec compile(t()) :: compiled()
+  def compile(mask) when is_binary(mask) do
+    case String.split(mask, ["!", "@"], parts: 3) do
+      [n, u, h] -> %__MODULE__{source: mask, nick: part(n), user: part(u), host: part(h)}
+      _ -> %__MODULE__{source: mask, nick: :never, user: :never, host: :never}
+    end
+  end
+
+  @doc "Compiles every mask of a list — the session's load and re-sync door."
+  @spec compile_all([t()]) :: [compiled()]
+  def compile_all(masks) when is_list(masks), do: Enum.map(masks, &compile/1)
+
+  @doc """
+  Does the compiled `mask` match the origin `{nick, user, host}` on a network
+  with this `casemapping`?
 
   `user` and `host` may be `nil` — an ircd that cloaks or a prefix that
   carried only a nick. A `nil` part matches only a wildcard-only pattern
   (`*`), never a concrete one: an ignore on `*!*@evil.example` must not fire
   for a sender whose host we simply cannot see.
   """
-  @spec matches?(t(), String.t(), String.t() | nil, String.t() | nil) :: boolean()
-  def matches?(mask, nick, user, host) when is_binary(mask) and is_binary(nick) do
-    case String.split(mask, ["!", "@"], parts: 3) do
-      [mn, mu, mh] ->
-        glob?(mn, Identifier.canonical_target(nick)) and
-          glob?(mu, fold_or_nil(user)) and
-          glob?(mh, fold_or_nil(host))
-
-      _ ->
-        false
-    end
+  @spec matches?(
+          compiled(),
+          String.t(),
+          String.t() | nil,
+          String.t() | nil,
+          Identifier.casemapping()
+        ) :: boolean()
+  def matches?(%__MODULE__{nick: n, user: u, host: h}, nick, user, host, casemapping)
+      when is_binary(nick) and is_atom(casemapping) do
+    part?(n, Identifier.canonical_target(nick, casemapping)) and
+      part?(u, fold_or_nil(user)) and
+      part?(h, fold_or_nil(host))
   end
 
   @doc """
-  True when ANY mask in `masks` matches the origin — the per-message question
-  the delivery filter asks. An empty list never matches.
+  True when ANY compiled mask in `masks` matches the origin — the per-message
+  question the delivery filter asks. An empty list never matches.
   """
-  @spec any_match?([t()], String.t(), String.t() | nil, String.t() | nil) :: boolean()
-  def any_match?([], _, _, _), do: false
+  @spec any_match?(
+          [compiled()],
+          String.t(),
+          String.t() | nil,
+          String.t() | nil,
+          Identifier.casemapping()
+        ) :: boolean()
+  def any_match?([], _, _, _, _), do: false
 
-  def any_match?(masks, nick, user, host) when is_list(masks) do
-    Enum.any?(masks, &matches?(&1, nick, user, host))
+  def any_match?(masks, nick, user, host, casemapping) when is_list(masks) do
+    Enum.any?(masks, &matches?(&1, nick, user, host, casemapping))
   end
 
   # ---------------------------------------------------------------------------
 
-  # Fold every part: the nick through the identifier fold, user/host plain
-  # ASCII-lowercase. Same result today (both are byte-level A–Z), but routing
-  # the nick through `canonical_target/1` keeps it on the one fold the rest of
-  # the codebase pins.
-  defp fold_mask(mask) do
+  # Fold every part: the nick through the network-aware identifier fold,
+  # user/host plain ASCII-lowercase (no national chars in an ident or a host).
+  defp fold_mask(mask, casemapping) do
     [n, u, h] = String.split(mask, ["!", "@"], parts: 3)
-    Identifier.canonical_target(n) <> "!" <> ascii_down(u) <> "@" <> ascii_down(h)
+    Identifier.canonical_target(n, casemapping) <> "!" <> ascii_down(u) <> "@" <> ascii_down(h)
   end
 
   defp fold_or_nil(nil), do: nil
@@ -128,11 +192,15 @@ defmodule Grappa.IRC.Mask do
 
   defp ascii_down(s), do: for(<<c <- s>>, into: "", do: <<if(c in ?A..?Z, do: c + 32, else: c)>>)
 
-  # Glob against a possibly-absent subject. `*` alone is the only pattern that
-  # matches an absent part; see `matches?/4`.
-  defp glob?("*", _), do: true
-  defp glob?(_, nil), do: false
-  defp glob?(pattern, subject), do: Regex.match?(glob_to_regex(pattern), subject)
+  defp part("*"), do: :any
+  defp part(pattern), do: glob_to_regex(pattern)
+
+  # Glob a compiled part against a possibly-absent subject. `:any` alone
+  # matches an absent part; see `matches?/5`.
+  defp part?(:any, _), do: true
+  defp part?(:never, _), do: false
+  defp part?(_, nil), do: false
+  defp part?(%Regex{} = re, subject), do: Regex.match?(re, subject)
 
   defp glob_to_regex(pattern) do
     body =
@@ -144,13 +212,12 @@ defmodule Grappa.IRC.Mask do
         literal -> Regex.escape(literal)
       end)
 
-    # `^`/`$` rather than the absolute anchors: without the multiline flag they
-    # bind to the string ends, and every part here is a single wire token with
-    # no newline in it (the prefix parser and `safe_line_token?/1` see to
-    # that), so `$`'s trailing-newline tolerance can never matter. Chosen over
-    # the absolute anchors because those need a backslash in a string literal,
-    # and a lost backslash there reads as a bare letter and silently matches
-    # nothing — which is exactly how the first cut of this shipped.
-    Regex.compile!("^" <> body <> "$")
+    # The ABSOLUTE anchors. `$` also matches before a trailing newline, and
+    # the subject side is attacker-controlled: nothing reaches here with a
+    # newline today, but that is one refactor away from being false, and the
+    # weaker anchor has no test that could notice (review, #1984). The
+    # backslashes are pinned by `MaskTest` — a lost one reads as a bare letter
+    # and silently matches nothing, which is how the first cut shipped.
+    Regex.compile!("\\A" <> body <> "\\z")
   end
 end

--- a/lib/grappa/irc/message.ex
+++ b/lib/grappa/irc/message.ex
@@ -138,6 +138,18 @@ defmodule Grappa.IRC.Message do
   def sender_nick(nil), do: @anonymous_sender
 
   @doc """
+  The full origin of a nick-prefixed line as `{nick, user, host}` — the
+  triple `Grappa.IRC.Mask.matches?/4` compares against (#162). `nil` for a
+  server-prefixed or prefix-less line: a server has no user@host and is never
+  a candidate for an ignore.
+  """
+  @spec sender_origin(t()) :: {String.t(), String.t() | nil, String.t() | nil} | nil
+  def sender_origin(%__MODULE__{prefix: {:nick, nick, user, host}}) when is_binary(nick),
+    do: {nick, user, host}
+
+  def sender_origin(%__MODULE__{}), do: nil
+
+  @doc """
   Returns the value of an IRCv3 message-tag, or `nil` when the tag is
   absent. A tag-only entry (`@account`, no `=`) yields `""`, the same as
   `@account=` — IRCv3 message-tags §3.2 gives both an absent value, so a

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -289,7 +289,16 @@ defmodule Grappa.Protocol do
   # un-bumped addition makes the reading false forever after.
   #
   # @min_protocol_version stays at 1: nothing a client can reach changed.
-  @protocol_version 13
+  # v14 (#162) — `/ignore`. The REST surface gains `/networks/:id/ignores`
+  # and `FallbackController` a 422 `invalid_mask` token. The routes alone
+  # would be a v10/v11-style bump; what moves the pin is the token, because
+  # `rest_error_token` is a closed set that `gen_wire_types` renders into
+  # cic's `KnownApiErrorCode` union and its runtime literal list.
+  #
+  # @min_protocol_version stays at 1: no bundle predating v14 knows the
+  # `/ignore` verb, so none can send the request that earns the new token —
+  # the only frame an old client could fail to read is one it cannot cause.
+  @protocol_version 14
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -300,7 +309,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 13
+  @spec version() :: 14
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -314,6 +314,15 @@ defmodule Grappa.Session do
           # exactly like `auto_away_debounce_ms`. Kept in sync with the
           # `Grappa.Session.Server.init_opts/0` twin.
           optional(:show_peer_profiles) => boolean(),
+          # #162 — the subject's `/ignore` masks on this network, as stored
+          # (strings; the Server compiles them). Resolved at the spawn
+          # boundary below like the two above, and for a reason a respawn
+          # makes concrete: a `:transient` restart re-runs `init/1` with the
+          # SAME opts and does not re-run this boundary, so a read placed in
+          # `init/1` fires again on every crash — which is exactly what
+          # `JoinSeedCostTest` counted as a stray query inside a join storm.
+          # Kept in sync with the `Grappa.Session.Server.init_opts/0` twin.
+          optional(:ignores) => [String.t()],
           optional(:refresh_plan) => Server.refresh_plan_check(),
           # GH #189 — on-connect perform list + its `$oper_pass` secret,
           # decrypted plaintext from the credential (nil when unset). Set by
@@ -367,6 +376,11 @@ defmodule Grappa.Session do
       end)
       |> Map.put_new_lazy(:show_peer_profiles, fn ->
         UserSettings.get_show_peer_profiles(subject)
+      end)
+      # #162 — same choke point: the ignore list read ONCE at spawn, never in
+      # `init/1` (see the `:ignores` opt above for why a respawn cares).
+      |> Map.put_new_lazy(:ignores, fn ->
+        UserSettings.get_ignores(subject, Map.fetch!(opts, :network_slug))
       end)
 
     DynamicSupervisor.start_child(
@@ -1978,7 +1992,7 @@ defmodule Grappa.Session do
   #162 — pushes the current `/ignore` mask list to the live session for
   `(subject, network_id)` so the delivery filter picks it up immediately.
   No live session is a normal `:ok`: the next spawn reads the list from
-  `UserSettings` at init.
+  `UserSettings` at the spawn boundary (`start_session/3`).
   """
   @spec ignores_changed(subject(), integer(), [String.t()]) :: :ok
   def ignores_changed(subject, network_id, masks)

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1975,6 +1975,28 @@ defmodule Grappa.Session do
   end
 
   @doc """
+  #162 — pushes the current `/ignore` mask list to the live session for
+  `(subject, network_id)` so the delivery filter picks it up immediately.
+  No live session is a normal `:ok`: the next spawn reads the list from
+  `UserSettings` at init.
+  """
+  @spec ignores_changed(subject(), integer(), [String.t()]) :: :ok
+  def ignores_changed(subject, network_id, masks)
+      when is_subject(subject) and is_integer(network_id) and is_list(masks) do
+    case call_session(subject, network_id, {:ignores_changed, masks}) do
+      :ok ->
+        :ok
+
+      {:error, :no_session} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("ignores_changed sync failed", reason: inspect(reason))
+        :ok
+    end
+  end
+
+  @doc """
   #247 — live watch-list sync after a `Grappa.Notify` mutation while a
   session is up: sends the MONITOR/WATCH add/remove lines and updates
   the session's presence map. `added`/`removed` are display-form nick

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -121,7 +121,7 @@ defmodule Grappa.Session.EventRouter do
   @type state :: %{
           # #162: optional so a bare unit-test state still routes; the filter
           # reads it with a `[]` default. Session.Server always sets it.
-          optional(:ignores) => [String.t()],
+          optional(:ignores) => [Mask.compiled()],
           required(:subject) => Session.subject(),
           required(:network_id) => integer(),
           required(:nick) => String.t(),
@@ -374,8 +374,10 @@ defmodule Grappa.Session.EventRouter do
   end
 
   # #162 — the /ignore delivery filter. Pure: reads `state.ignores`, which
-  # Session.Server loads at init and re-syncs on mutation, so nothing here
-  # touches the DB on the inbound hot path.
+  # Session.Server loads at init and re-syncs on mutation — already COMPILED
+  # (`Mask.compile_all/1`), so nothing here touches the DB or builds a regex
+  # on the inbound hot path. The subject nick folds with THIS network's
+  # casemapping (#537); the masks were folded with it when they were written.
   #
   # Scope, deliberately narrow for v1:
   #   * CONTENT only — PRIVMSG and NOTICE (ACTION rides PRIVMSG). Presence
@@ -401,7 +403,7 @@ defmodule Grappa.Session.EventRouter do
       {masks, {nick, user, host}} ->
         not nick_eq?(nick, state.nick) and
           Mentions.mentionable_sender?(nick) and
-          Mask.any_match?(masks, nick, user, host)
+          Mask.any_match?(masks, nick, user, host, casemapping(state))
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -95,9 +95,9 @@ defmodule Grappa.Session.EventRouter do
   in `Session.Server.handle_info` — out of this router's scope.
   """
 
-  alias Grappa.IRC.{CTCP, Identifier, JoinFailure, Message}
+  alias Grappa.IRC.{CTCP, Identifier, JoinFailure, Mask, Message}
+  alias Grappa.{Mentions, Scrollback, Session}
   alias Grappa.RateLimit.TokenBucket
-  alias Grappa.{Scrollback, Session}
 
   alias Grappa.Session.{
     IdentityState,
@@ -119,6 +119,9 @@ defmodule Grappa.Session.EventRouter do
   `optional(any()) => any()` to admit them without enforcing them.
   """
   @type state :: %{
+          # #162: optional so a bare unit-test state still routes; the filter
+          # reads it with a `[]` default. Session.Server always sets it.
+          optional(:ignores) => [String.t()],
           required(:subject) => Session.subject(),
           required(:network_id) => integer(),
           required(:nick) => String.t(),
@@ -353,15 +356,56 @@ defmodule Grappa.Session.EventRouter do
   """
   @spec route(Message.t(), state()) :: {:cont, state(), [effect()]}
   def route(%Message{} = msg, state) do
-    isupport = Map.get(state, :isupport, ISupport.default())
+    if ignored?(msg, state) do
+      # #162 — dropped at the door. No persist effect, so no row, no
+      # broadcast, and no push: the "zero pushes emitted" requirement on the
+      # issue holds by construction rather than by a second gate.
+      {:cont, state, []}
+    else
+      isupport = Map.get(state, :isupport, ISupport.default())
 
-    {msg, statusmsg_level} = strip_statusmsg_target(msg, ISupport.statusmsg(isupport))
+      {msg, statusmsg_level} = strip_statusmsg_target(msg, ISupport.statusmsg(isupport))
 
-    msg
-    |> canonicalize_channel_params(ISupport.casemapping(isupport))
-    |> do_route(state)
-    |> tag_statusmsg(statusmsg_level)
+      msg
+      |> canonicalize_channel_params(ISupport.casemapping(isupport))
+      |> do_route(state)
+      |> tag_statusmsg(statusmsg_level)
+    end
   end
+
+  # #162 — the /ignore delivery filter. Pure: reads `state.ignores`, which
+  # Session.Server loads at init and re-syncs on mutation, so nothing here
+  # touches the DB on the inbound hot path.
+  #
+  # Scope, deliberately narrow for v1:
+  #   * CONTENT only — PRIVMSG and NOTICE (ACTION rides PRIVMSG). Presence
+  #     verbs (JOIN/PART/QUIT/NICK) are not dropped: the issue lists them as
+  #     "optionally", and they are already governed by the presence filter.
+  #     Dropping a JOIN here would also desync the members map.
+  #   * Never our own lines (own_nick) — an ignore on a mask that happens to
+  #     match yourself must not silence you to yourself.
+  #   * Never a services or server sender (`Mentions.mentionable_sender?/1`,
+  #     #1674): NickServ telling you your password is wrong is not chatter,
+  #     and a mask like `*!*@*` must not eat it.
+  #   * An origin with no nick (server prefix, prefix-less line) is never a
+  #     candidate — `sender_origin/1` is nil there.
+  @spec ignored?(Message.t(), state()) :: boolean()
+  defp ignored?(%Message{command: cmd} = msg, state) when cmd in [:privmsg, :notice] do
+    case {Map.get(state, :ignores, []), Message.sender_origin(msg)} do
+      {[], _} ->
+        false
+
+      {_, nil} ->
+        false
+
+      {masks, {nick, user, host}} ->
+        not nick_eq?(nick, state.nick) and
+          Mentions.mentionable_sender?(nick) and
+          Mask.any_match?(masks, nick, user, host)
+    end
+  end
+
+  defp ignored?(_, _), do: false
 
   # Rewrites `msg.params` so every channel-shape param is canonicalised
   # to lowercase. The position of the channel param differs per command

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -440,6 +440,10 @@ defmodule Grappa.Session.Server do
           # above; omitted opt (test seam) defaults to `false` — silent
           # unless a test explicitly opts in.
           optional(:show_peer_profiles) => boolean(),
+          # #162 — stored `/ignore` masks, resolved at the spawn boundary
+          # (`Grappa.Session.start_session/3`); compiled in `init/1`. Kept
+          # in sync with the `Grappa.Session.start_session/3` opts twin.
+          optional(:ignores) => [String.t()],
           # GH #189 — on-connect perform list + its `$oper_pass` secret,
           # decrypted plaintext from the credential (nil when unset). Run at 001
           # before the built-in identify and before autojoin. The `$nickserv_pass`
@@ -1194,12 +1198,16 @@ defmodule Grappa.Session.Server do
       # #216: default capability table until 005 arrives — MODES/LINELEN
       # included since #1390.
       isupport: ISupport.default(),
-      # #162: /ignore masks, read once at spawn so the very first inbound
-      # line is filtered — an ignore set while the session was parked must
-      # hold from the first message after reconnect, not from the next sync.
-      # #162 — compiled ONCE here and on every `:ignores_changed`, never per
-      # message: the delivery filter runs on every inbound line.
-      ignores: Mask.compile_all(UserSettings.get_ignores(opts.subject, opts.network_slug)),
+      # #162: /ignore masks, read at the SPAWN BOUNDARY (`start_session/3`,
+      # like `auto_away_debounce_ms` and `show_peer_profiles`) so the very
+      # first inbound line is filtered — an ignore set while the session was
+      # parked holds from the first message after reconnect. Not read here:
+      # a `:transient` respawn re-runs `init/1` and a query in it would fire
+      # on every crash (measured by `JoinSeedCostTest` as a stray read inside
+      # a join storm). Compiled ONCE here and on every `:ignores_changed`,
+      # never per message. Absent = a unit test built the Server directly
+      # (the boundary was bypassed), the same contract as its two siblings.
+      ignores: Mask.compile_all(Map.get(opts, :ignores, [])),
       # #247: /notify presence map — seeded at the end-of-MOTD arm.
       presence: %{},
       presence_armed: false,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -647,6 +647,11 @@ defmodule Grappa.Session.Server do
           # /notify must work on ircds that support WATCH but don't
           # advertise it).
           presence_mechanism: ISupport.presence_mechanism() | nil,
+          # #162: the /ignore masks for THIS network, normalised `nick!user@host`
+          # globs. Loaded from UserSettings at init and re-synced on every
+          # mutation, so EventRouter's delivery filter stays a pure read of
+          # state — no IO on the inbound hot path.
+          ignores: [String.t()],
           # #1946: the ISON polling loop. `presence_poll_ref` is the armed
           # timer (nil when the mechanism is not `:ison`, or when the watch
           # list is empty — an empty list arms nothing at all).
@@ -1189,6 +1194,10 @@ defmodule Grappa.Session.Server do
       # #216: default capability table until 005 arrives — MODES/LINELEN
       # included since #1390.
       isupport: ISupport.default(),
+      # #162: /ignore masks, read once at spawn so the very first inbound
+      # line is filtered — an ignore set while the session was parked must
+      # hold from the first message after reconnect, not from the next sync.
+      ignores: UserSettings.get_ignores(opts.subject, opts.network_slug),
       # #247: /notify presence map — seeded at the end-of-MOTD arm.
       presence: %{},
       presence_armed: false,
@@ -2490,6 +2499,13 @@ defmodule Grappa.Session.Server do
   def handle_call({:notify_changed, added, removed}, _, state)
       when is_list(added) and is_list(removed) do
     {:reply, :ok, sync_presence(state, added, removed)}
+  end
+
+  # #162 — the ignore list changed (REST add/remove). The controller hands over
+  # the whole resulting list rather than a diff: it is small, bounded, and a
+  # replace cannot drift from the DB the way an incremental patch could.
+  def handle_call({:ignores_changed, masks}, _, state) when is_list(masks) do
+    {:reply, :ok, Map.put(state, :ignores, masks)}
   end
 
   @doc """

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -91,7 +91,7 @@ defmodule Grappa.Session.Server do
     UserSettings
   }
 
-  alias Grappa.IRC.{AuthFSM, Client, CTCP, Identifier, LineSplit, Message}
+  alias Grappa.IRC.{AuthFSM, Client, CTCP, Identifier, LineSplit, Mask, Message}
   alias Grappa.Net.SourceAliasManager
   alias Grappa.PubSub.Topic
   alias Grappa.Push.Triggers, as: PushTriggers
@@ -651,7 +651,7 @@ defmodule Grappa.Session.Server do
           # globs. Loaded from UserSettings at init and re-synced on every
           # mutation, so EventRouter's delivery filter stays a pure read of
           # state — no IO on the inbound hot path.
-          ignores: [String.t()],
+          ignores: [Mask.compiled()],
           # #1946: the ISON polling loop. `presence_poll_ref` is the armed
           # timer (nil when the mechanism is not `:ison`, or when the watch
           # list is empty — an empty list arms nothing at all).
@@ -1197,7 +1197,9 @@ defmodule Grappa.Session.Server do
       # #162: /ignore masks, read once at spawn so the very first inbound
       # line is filtered — an ignore set while the session was parked must
       # hold from the first message after reconnect, not from the next sync.
-      ignores: UserSettings.get_ignores(opts.subject, opts.network_slug),
+      # #162 — compiled ONCE here and on every `:ignores_changed`, never per
+      # message: the delivery filter runs on every inbound line.
+      ignores: Mask.compile_all(UserSettings.get_ignores(opts.subject, opts.network_slug)),
       # #247: /notify presence map — seeded at the end-of-MOTD arm.
       presence: %{},
       presence_armed: false,
@@ -2505,7 +2507,7 @@ defmodule Grappa.Session.Server do
   # the whole resulting list rather than a diff: it is small, bounded, and a
   # replace cannot drift from the DB the way an incremental patch could.
   def handle_call({:ignores_changed, masks}, _, state) when is_list(masks) do
-    {:reply, :ok, Map.put(state, :ignores, masks)}
+    {:reply, :ok, Map.put(state, :ignores, Mask.compile_all(masks))}
   end
 
   @doc """

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -71,8 +71,8 @@ defmodule Grappa.UserSettings do
   | `"upload_confirm_enabled"` | `boolean()`        | `get_upload_confirm_enabled/1`, |
   |                        |                        | `put_upload_confirm_enabled/2`  |
   |                        |                        | (#1883)                         |
-  | `"ignores"`            | `ignores()`            | `get_ignores/2`, `add_ignore/3`,|
-  |                        |                        | `remove_ignore/3` (#162)        |
+  | `"ignores"`            | `ignores()`            | `get_ignores/2`, `add_ignore/4`,|
+  |                        |                        | `remove_ignore/4` (#162)        |
   | `"vhost_selection"`    | `list(String.t())`     | `get_vhost_selection/1`,        |
   |                        |                        | `put_vhost_selection/2`         |
   | `"active_theme_id"`    | `pos_integer() \\| nil`| `get_active_theme_id/1`,        |
@@ -1048,12 +1048,12 @@ defmodule Grappa.UserSettings do
   """
   @type ignore_outcome :: :added | :already_ignored | :removed | :not_ignored
 
-  @spec add_ignore(Subject.t(), String.t(), String.t()) ::
+  @spec add_ignore(Subject.t(), String.t(), String.t(), Identifier.casemapping()) ::
           {:ok, :added | :already_ignored, String.t(), [String.t()]}
           | {:error, :invalid_mask | :list_full | Ecto.Changeset.t() | :db_unavailable}
-  def add_ignore({_, _} = subject, network_slug, raw_mask)
-      when is_binary(network_slug) and is_binary(raw_mask) do
-    with {:ok, mask} <- normalize_mask(raw_mask) do
+  def add_ignore({_, _} = subject, network_slug, raw_mask, casemapping)
+      when is_binary(network_slug) and is_binary(raw_mask) and is_atom(casemapping) do
+    with {:ok, mask} <- normalize_mask(raw_mask, casemapping) do
       add_normalized(subject, network_slug, mask, get_ignores(subject, network_slug))
     end
   end
@@ -1077,12 +1077,12 @@ defmodule Grappa.UserSettings do
   removes `spambot!*@*`). Idempotent: removing an absent mask is
   `{:ok, :not_ignored, mask, list}`.
   """
-  @spec remove_ignore(Subject.t(), String.t(), String.t()) ::
+  @spec remove_ignore(Subject.t(), String.t(), String.t(), Identifier.casemapping()) ::
           {:ok, :removed | :not_ignored, String.t(), [String.t()]}
           | {:error, :invalid_mask | Ecto.Changeset.t() | :db_unavailable}
-  def remove_ignore({_, _} = subject, network_slug, raw_mask)
-      when is_binary(network_slug) and is_binary(raw_mask) do
-    with {:ok, mask} <- normalize_mask(raw_mask) do
+  def remove_ignore({_, _} = subject, network_slug, raw_mask, casemapping)
+      when is_binary(network_slug) and is_binary(raw_mask) and is_atom(casemapping) do
+    with {:ok, mask} <- normalize_mask(raw_mask, casemapping) do
       remove_normalized(subject, network_slug, mask, get_ignores(subject, network_slug))
     end
   end
@@ -1100,8 +1100,12 @@ defmodule Grappa.UserSettings do
     with {:ok, _} <- put_ignores(subject, slug, next), do: {:ok, next}
   end
 
-  defp normalize_mask(raw) do
-    case Grappa.IRC.Mask.normalize(raw) do
+  # The #537 ingress fold: the caller names the network's casemapping (the
+  # web edge reads it off `Grappa.Session.casemapping/2`), so the stored mask
+  # already sits in that network's folded space and the delivery match only
+  # has to fold the subject.
+  defp normalize_mask(raw, casemapping) do
+    case Grappa.IRC.Mask.normalize(raw, casemapping) do
       {:ok, mask} -> {:ok, mask}
       :error -> {:error, :invalid_mask}
     end

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -71,6 +71,8 @@ defmodule Grappa.UserSettings do
   | `"upload_confirm_enabled"` | `boolean()`        | `get_upload_confirm_enabled/1`, |
   |                        |                        | `put_upload_confirm_enabled/2`  |
   |                        |                        | (#1883)                         |
+  | `"ignores"`            | `ignores()`            | `get_ignores/2`, `add_ignore/3`,|
+  |                        |                        | `remove_ignore/3` (#162)        |
   | `"vhost_selection"`    | `list(String.t())`     | `get_vhost_selection/1`,        |
   |                        |                        | `put_vhost_selection/2`         |
   | `"active_theme_id"`    | `pos_integer() \\| nil`| `get_active_theme_id/1`,        |
@@ -975,6 +977,155 @@ defmodule Grappa.UserSettings do
     # explicit `false` row would be a second spelling of the default. Same
     # rule as `put_show_peer_profiles/2`.
     update_data(subject, &put_or_delete(&1, @upload_confirm_enabled_key, value || nil))
+  end
+
+  # ---------------------------------------------------------------------------
+  # ignores accessors (#162 — the /ignore mask list, honoured server-side)
+  # ---------------------------------------------------------------------------
+
+  @ignores_key "ignores"
+
+  # Cap per (subject, network). Same reasoning as @aliases_max_count — a
+  # user-writable list needs a boundary, and no human ignores a hundred people.
+  @ignores_max_per_network 100
+
+  @typedoc """
+  The `/ignore` list (#162): `network_slug => [mask]`, every mask a normalised
+  `nick!user@host` glob (`Grappa.IRC.Mask`).
+
+  Its OWN key, deliberately NOT a field inside `notification_prefs` beside
+  `muted_targets` — vjt's ruling on #162. The two look alike (both deny, both
+  network-keyed, both fold the same way) but answer different questions: a
+  mute is "this ROOM is noisy" and only suppresses attention; an ignore is
+  "this PERSON is a problem" and drops the message before it exists. One
+  shared shape would carry a field meaningless on half its rows.
+
+  Keyed by the network SLUG rather than a composite `channel_key`: an ignore
+  has no target — it applies everywhere the sender speaks on that network.
+  The network is in the key for the #1038 reason (the same nick on two
+  networks is two people).
+  """
+  @type ignores :: %{String.t() => [String.t()]}
+
+  @doc """
+  The ignore masks for `subject` on `network_slug`. Never fails: an absent
+  row, absent key, or malformed value reads as `[]` — an unreadable ignore
+  list must fail OPEN (messages delivered), never closed (a user silently
+  ignoring everyone).
+  """
+  @spec get_ignores(Subject.t(), String.t()) :: [String.t()]
+  def get_ignores({_, _} = subject, network_slug) when is_binary(network_slug) do
+    case fetch_existing_or_nil(subject) do
+      nil -> []
+      %Settings{data: data} -> masks_for(data[@ignores_key], network_slug)
+    end
+  end
+
+  # Lenient readers, one shape each: a value that is not the map/list we wrote
+  # reads as "nothing ignored" rather than raising on the inbound hot path.
+  defp masks_for(%{} = by_network, slug), do: by_network |> Map.get(slug) |> only_binaries()
+  defp masks_for(_, _), do: []
+
+  defp only_binaries(masks) when is_list(masks), do: Enum.filter(masks, &is_binary/1)
+  defp only_binaries(_), do: []
+
+  @doc """
+  Adds one mask for `subject` on `network_slug`. Idempotent: an already
+  present (normalised, so `Spambot` and `spambot!*@*` are the same) mask is a
+  no-op success. Rejects an unparseable mask with `{:error, :invalid_mask}`
+  and a full list with `{:error, :list_full}`.
+
+  Returns the resulting list so the caller can sync a live session. Newest
+  first — the list is small, order is not a contract, and a prepend is the
+  idiomatic write.
+  """
+  @typedoc """
+  What a mutation did, next to the normalised mask it did it to and the list
+  it left behind. The verb reports the outcome on the NORMALISED mask
+  (`removed spambot!*@*`) because `/unignore spambot` acts on a mask the
+  operator never typed, and an idempotent re-add is only honest if it says
+  `already ignored`; the list is for the session re-sync, not the reply.
+  """
+  @type ignore_outcome :: :added | :already_ignored | :removed | :not_ignored
+
+  @spec add_ignore(Subject.t(), String.t(), String.t()) ::
+          {:ok, :added | :already_ignored, String.t(), [String.t()]}
+          | {:error, :invalid_mask | :list_full | Ecto.Changeset.t() | :db_unavailable}
+  def add_ignore({_, _} = subject, network_slug, raw_mask)
+      when is_binary(network_slug) and is_binary(raw_mask) do
+    with {:ok, mask} <- normalize_mask(raw_mask) do
+      add_normalized(subject, network_slug, mask, get_ignores(subject, network_slug))
+    end
+  end
+
+  defp add_normalized(subject, slug, mask, current) do
+    cond do
+      mask in current ->
+        {:ok, :already_ignored, mask, current}
+
+      length(current) >= @ignores_max_per_network ->
+        {:error, :list_full}
+
+      true ->
+        with {:ok, next} <- persist_ignores(subject, slug, [mask | current]),
+             do: {:ok, :added, mask, next}
+    end
+  end
+
+  @doc """
+  Removes one mask (normalised before comparing, so `/unignore spambot`
+  removes `spambot!*@*`). Idempotent: removing an absent mask is
+  `{:ok, :not_ignored, mask, list}`.
+  """
+  @spec remove_ignore(Subject.t(), String.t(), String.t()) ::
+          {:ok, :removed | :not_ignored, String.t(), [String.t()]}
+          | {:error, :invalid_mask | Ecto.Changeset.t() | :db_unavailable}
+  def remove_ignore({_, _} = subject, network_slug, raw_mask)
+      when is_binary(network_slug) and is_binary(raw_mask) do
+    with {:ok, mask} <- normalize_mask(raw_mask) do
+      remove_normalized(subject, network_slug, mask, get_ignores(subject, network_slug))
+    end
+  end
+
+  defp remove_normalized(subject, slug, mask, current) do
+    if mask in current do
+      with {:ok, next} <- persist_ignores(subject, slug, List.delete(current, mask)),
+           do: {:ok, :removed, mask, next}
+    else
+      {:ok, :not_ignored, mask, current}
+    end
+  end
+
+  defp persist_ignores(subject, slug, next) do
+    with {:ok, _} <- put_ignores(subject, slug, next), do: {:ok, next}
+  end
+
+  defp normalize_mask(raw) do
+    case Grappa.IRC.Mask.normalize(raw) do
+      {:ok, mask} -> {:ok, mask}
+      :error -> {:error, :invalid_mask}
+    end
+  end
+
+  # An empty per-network list deletes that network's key, and an empty map
+  # deletes the whole key — a fresh subject already reads `[]`, so an explicit
+  # empty would be a second spelling of the default (the put_or_delete rule).
+  defp put_ignores(subject, network_slug, masks) do
+    update_data(subject, fn data ->
+      by_network =
+        case data[@ignores_key] do
+          %{} = m -> m
+          _ -> %{}
+        end
+
+      next =
+        case masks do
+          [] -> Map.delete(by_network, network_slug)
+          _ -> Map.put(by_network, network_slug, masks)
+        end
+
+      put_or_delete(data, @ignores_key, if(next == %{}, do: nil, else: next))
+    end)
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/grappa_web/controllers/fallback_controller.ex
+++ b/lib/grappa_web/controllers/fallback_controller.ex
@@ -88,6 +88,7 @@ defmodule GrappaWeb.FallbackController do
            | :too_many_attempts
            | :theme_cap_reached
            | :list_full
+           | :invalid_mask
            | :not_raster
            | :too_large
            | :ssrf_blocked
@@ -298,6 +299,15 @@ defmodule GrappaWeb.FallbackController do
     conn
     |> put_status(:unprocessable_entity)
     |> json(%{error: "list_full"})
+  end
+
+  # #162 — an /ignore mask that does not parse as `nick!user@host` (bad
+  # `!`/`@` order, CR/LF, empty, oversized). 422 like `:list_full`: the request
+  # is well-formed, the value is refused — cic renders "not a valid mask".
+  def call(conn, {:error, :invalid_mask}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "invalid_mask"})
   end
 
   # #75 themes background pipeline — the source (upload or fetched URL) is not

--- a/lib/grappa_web/controllers/ignores_controller.ex
+++ b/lib/grappa_web/controllers/ignores_controller.ex
@@ -1,0 +1,78 @@
+defmodule GrappaWeb.IgnoresController do
+  @moduledoc """
+  REST surface for the `/ignore` mask list (GH #162) —
+  `/networks/:network_id/ignores`.
+
+  Thin per CLAUDE.md: parse params, call `Grappa.UserSettings` (the DB-owned
+  list) + `Grappa.Session.ignores_changed/3` (live sync), render. The same
+  context functions back the cic `/ignore` + `/unignore` commands — one
+  authoritative list, two faces.
+
+  ## The list is the reply, every time
+
+  `POST` and `DELETE` both answer with the resulting list rather than the one
+  mask touched. A client that renders the list has nothing to reconcile, and
+  an idempotent re-add (already present → 200, same list) is indistinguishable
+  from a first add on the wire, which is the point of idempotence.
+
+  ## Live sync contract
+
+  Every mutation pushes the WHOLE resulting list to the live session
+  (`Session.ignores_changed/3`), which replaces `state.ignores`. No session
+  running is a normal `:ok` — the next spawn reads the list at init.
+
+  Iso boundary: `Plugs.ResolveNetwork` collapses unknown-slug /
+  not-your-network to 404 before any action runs, same as `/notify`.
+  """
+  use GrappaWeb, :controller
+
+  alias Grappa.{Session, UserSettings}
+  alias GrappaWeb.Subject, as: WebSubject
+
+  @doc "`GET /networks/:network_id/ignores` — the masks for this subject on this network."
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _) do
+    network = conn.assigns.network
+    json(conn, %{masks: UserSettings.get_ignores(session_subject(conn), network.slug)})
+  end
+
+  @doc """
+  `POST /networks/:network_id/ignores` — add one mask. Body `{"mask": "..."}`;
+  a bare nick normalises to `nick!*@*`. 201 with `{masks, mask, outcome}` —
+  the resulting list, the normalised mask, and `added` / `already_ignored`;
+  422 `invalid_mask` / `list_full` via FallbackController.
+  """
+  @spec create(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :bad_request | :invalid_mask | :list_full | term()}
+  def create(conn, %{"mask" => mask}) when is_binary(mask) and mask != "" do
+    subject = session_subject(conn)
+    network = conn.assigns.network
+
+    with {:ok, outcome, mask, masks} <- UserSettings.add_ignore(subject, network.slug, mask) do
+      :ok = Session.ignores_changed(subject, network.id, masks)
+
+      conn
+      |> put_status(:created)
+      |> json(%{masks: masks, mask: mask, outcome: outcome})
+    end
+  end
+
+  def create(_, _), do: {:error, :bad_request}
+
+  @doc """
+  `DELETE /networks/:network_id/ignores/:mask` — remove one mask (normalised
+  before comparing, idempotent). 200 with the resulting list either way.
+  """
+  @spec remove(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :invalid_mask | term()}
+  def remove(conn, %{"mask" => mask}) when is_binary(mask) and mask != "" do
+    subject = session_subject(conn)
+    network = conn.assigns.network
+
+    with {:ok, outcome, mask, masks} <- UserSettings.remove_ignore(subject, network.slug, mask) do
+      :ok = Session.ignores_changed(subject, network.id, masks)
+      json(conn, %{masks: masks, mask: mask, outcome: outcome})
+    end
+  end
+
+  defp session_subject(conn), do: WebSubject.to_session(conn.assigns.current_subject)
+end

--- a/lib/grappa_web/controllers/ignores_controller.ex
+++ b/lib/grappa_web/controllers/ignores_controller.ex
@@ -48,7 +48,12 @@ defmodule GrappaWeb.IgnoresController do
     subject = session_subject(conn)
     network = conn.assigns.network
 
-    with {:ok, outcome, mask, masks} <- UserSettings.add_ignore(subject, network.slug, mask) do
+    # #537 ingress: the mask folds with THIS network's casemapping, read off
+    # the live session (`:ascii` when none — the same door `/notify` uses).
+    casemapping = Session.casemapping(subject, network.id)
+
+    with {:ok, outcome, mask, masks} <-
+           UserSettings.add_ignore(subject, network.slug, mask, casemapping) do
       :ok = Session.ignores_changed(subject, network.id, masks)
 
       conn
@@ -68,7 +73,10 @@ defmodule GrappaWeb.IgnoresController do
     subject = session_subject(conn)
     network = conn.assigns.network
 
-    with {:ok, outcome, mask, masks} <- UserSettings.remove_ignore(subject, network.slug, mask) do
+    casemapping = Session.casemapping(subject, network.id)
+
+    with {:ok, outcome, mask, masks} <-
+           UserSettings.remove_ignore(subject, network.slug, mask, casemapping) do
       :ok = Session.ignores_changed(subject, network.id, masks)
       json(conn, %{masks: masks, mask: mask, outcome: outcome})
     end

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -98,6 +98,9 @@ defmodule GrappaWeb.ErrorTokens do
           | :too_many_attempts
           | :theme_cap_reached
           | :list_full
+          # #162 — 422: a `/ignore` mask that `Grappa.IRC.Mask.normalize/1`
+          # rejects (empty, whitespace, CRLF, bad `nick!user@host` order).
+          | :invalid_mask
           | :not_raster
           | :too_large
           | :ssrf_blocked

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -622,6 +622,14 @@ defmodule GrappaWeb.Router do
     post "/notify", NotifyController, :create
     delete "/notify/:nick", NotifyController, :remove
     delete "/notify", NotifyController, :clear
+
+    # #162 — /ignore mask list, honoured server-side. Same scope as /notify
+    # (per-network, `:resolve_network` collapses unknown/not-yours to 404) and
+    # inherits the `/networks` client-usable prefix in RouterScopeTest, so no
+    # allowlist edit — unlike a `/me` route, which is exact-listed.
+    get "/ignores", IgnoresController, :index
+    post "/ignores", IgnoresController, :create
+    delete "/ignores/:mask", IgnoresController, :remove
   end
 
   # Test-only FORCE read-cursor surface. Compile-gated to dev/test Mix

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 13
-shape_digest = sha256:4afc40e5880783d55c69d0f2a4bc0338d418061fde9a0538c45de8b907ee9876
+protocol_version = 14
+shape_digest = sha256:f3c18a4c920e1bbf97d9fa7af80d1970fb3bbe47ef6e062d7f6f92817b4bf3c0

--- a/test/grappa/irc/mask_test.exs
+++ b/test/grappa/irc/mask_test.exs
@@ -1,100 +1,151 @@
 defmodule Grappa.IRC.MaskTest do
   @moduledoc """
   `Grappa.IRC.Mask` (#162) — the `nick!user@host` glob matcher behind /ignore.
-  Two properties carry the feature: a bare nick means "from anywhere", and an
-  origin part we cannot see never satisfies a concrete pattern.
+  Three properties carry the feature: a bare nick means "from anywhere", an
+  origin part we cannot see never satisfies a concrete pattern, and the fold
+  is the NETWORK's (#537) — `Foo[1]` and `foo{1}` are one person on rfc1459
+  and two on ascii.
   """
   use ExUnit.Case, async: true
 
   alias Grappa.IRC.Mask
 
-  describe "normalize/1" do
+  defp m(mask), do: Mask.compile(mask)
+
+  describe "normalize/2" do
     test "a bare nick becomes nick!*@*, folded" do
-      assert Mask.normalize("SpamBot") == {:ok, "spambot!*@*"}
+      assert Mask.normalize("SpamBot", :ascii) == {:ok, "spambot!*@*"}
     end
 
     test "a full mask is kept, every part folded" do
-      assert Mask.normalize("*!*@Evil.Example") == {:ok, "*!*@evil.example"}
-      assert Mask.normalize("Nick!~User@Host") == {:ok, "nick!~user@host"}
+      assert Mask.normalize("*!*@Evil.Example", :ascii) == {:ok, "*!*@evil.example"}
+      assert Mask.normalize("Nick!~User@Host", :ascii) == {:ok, "nick!~user@host"}
     end
 
     test "surrounding whitespace is trimmed" do
-      assert Mask.normalize("  spambot  ") == {:ok, "spambot!*@*"}
+      assert Mask.normalize("  spambot  ", :ascii) == {:ok, "spambot!*@*"}
+    end
+
+    # The #537 ingress rule applied to one more key: the nick part folds with
+    # the network's casemapping, so the stored mask already sits in that
+    # network's folded space. User and host never fold national chars.
+    test "the nick part folds with the network's casemapping" do
+      assert Mask.normalize("Foo[1]", :rfc1459) == {:ok, "foo{1}!*@*"}
+      assert Mask.normalize("Foo[1]", :ascii) == {:ok, "foo[1]!*@*"}
+      assert Mask.normalize("Foo~1", :rfc1459) == {:ok, "foo^1!*@*"}
+      assert Mask.normalize("Foo~1", :rfc1459_strict) == {:ok, "foo~1!*@*"}
+      assert Mask.normalize("Foo[1]!~[u]@[h]", :rfc1459) == {:ok, "foo{1}!~[u]@[h]"}
     end
 
     test "rejects empty, embedded whitespace, and line breaks" do
-      assert Mask.normalize("") == :error
-      assert Mask.normalize("   ") == :error
-      assert Mask.normalize("a b") == :error
-      assert Mask.normalize("a\r\nb") == :error
+      assert Mask.normalize("", :ascii) == :error
+      assert Mask.normalize("   ", :ascii) == :error
+      assert Mask.normalize("a b", :ascii) == :error
+      assert Mask.normalize("a\r\nb", :ascii) == :error
     end
 
     test "rejects ! and @ in the wrong order or count" do
-      assert Mask.normalize("nick@host!user") == :error
-      assert Mask.normalize("a!b!c@d") == :error
-      assert Mask.normalize("!user@host") == :error
+      assert Mask.normalize("nick@host!user", :ascii) == :error
+      assert Mask.normalize("a!b!c@d", :ascii) == :error
+      assert Mask.normalize("!user@host", :ascii) == :error
     end
 
     test "rejects a mask longer than a line could carry" do
-      assert Mask.normalize(String.duplicate("a", 201)) == :error
+      assert Mask.normalize(String.duplicate("a", 201), :ascii) == :error
     end
 
     test "rejects non-binaries" do
-      assert Mask.normalize(nil) == :error
-      assert Mask.normalize(42) == :error
+      assert Mask.normalize(nil, :ascii) == :error
+      assert Mask.normalize(42, :ascii) == :error
     end
   end
 
-  describe "matches?/4" do
+  describe "compile/1" do
+    test "a bare * part compiles to :any — no regex for the common shape" do
+      assert %Mask{nick: %Regex{}, user: :any, host: :any} = Mask.compile("spambot!*@*")
+      assert %Mask{nick: :any, user: :any, host: %Regex{}} = Mask.compile("*!*@evil.example")
+    end
+
+    test "a string that is not nick!user@host compiles to a mask that matches nothing" do
+      compiled = Mask.compile("garbage")
+      assert %Mask{nick: :never} = compiled
+      refute Mask.matches?(compiled, "garbage", nil, nil, :ascii)
+    end
+
+    test "compile_all/1 keeps order and source" do
+      assert Enum.map(Mask.compile_all(["a!*@*", "b!*@*"]), & &1.source) == ["a!*@*", "b!*@*"]
+    end
+  end
+
+  describe "matches?/5" do
     test "a nick mask matches that nick from any user@host" do
-      assert Mask.matches?("spambot!*@*", "spambot", "~x", "h.example")
-      assert Mask.matches?("spambot!*@*", "SpamBot", nil, nil)
+      assert Mask.matches?(m("spambot!*@*"), "spambot", "~x", "h.example", :ascii)
+      assert Mask.matches?(m("spambot!*@*"), "SpamBot", nil, nil, :ascii)
     end
 
     test "a nick mask does not match a different nick" do
-      refute Mask.matches?("spambot!*@*", "spambot2", "~x", "h.example")
+      refute Mask.matches?(m("spambot!*@*"), "spambot2", "~x", "h.example", :ascii)
     end
 
     test "* spans any run, ? exactly one character" do
-      assert Mask.matches?("spam*!*@*", "spambot", nil, nil)
-      assert Mask.matches?("spa?bot!*@*", "spambot", nil, nil)
-      refute Mask.matches?("spa?bot!*@*", "spammbot", nil, nil)
+      assert Mask.matches?(m("spam*!*@*"), "spambot", nil, nil, :ascii)
+      assert Mask.matches?(m("spa?bot!*@*"), "spambot", nil, nil, :ascii)
+      refute Mask.matches?(m("spa?bot!*@*"), "spammbot", nil, nil, :ascii)
     end
 
     test "a host mask matches any nick from that host, case-insensitively" do
-      assert Mask.matches?("*!*@evil.example", "alice", "~a", "Evil.Example")
-      refute Mask.matches?("*!*@evil.example", "alice", "~a", "good.example")
+      assert Mask.matches?(m("*!*@evil.example"), "alice", "~a", "Evil.Example", :ascii)
+      refute Mask.matches?(m("*!*@evil.example"), "alice", "~a", "good.example", :ascii)
     end
 
     # The rule that keeps a cloaked ircd from turning a targeted ignore into
     # a blanket one: an absent part satisfies only `*`, never a real pattern.
     test "a concrete user/host pattern never matches an absent part" do
-      refute Mask.matches?("*!*@evil.example", "alice", nil, nil)
-      refute Mask.matches?("*!~bad@*", "alice", nil, "h")
-      assert Mask.matches?("alice!*@*", "alice", nil, nil)
+      refute Mask.matches?(m("*!*@evil.example"), "alice", nil, nil, :ascii)
+      refute Mask.matches?(m("*!~bad@*"), "alice", nil, "h", :ascii)
+      assert Mask.matches?(m("alice!*@*"), "alice", nil, nil, :ascii)
     end
 
     test "regex metacharacters in a mask are literal" do
-      assert Mask.matches?("a.b!*@*", "a.b", nil, nil)
-      refute Mask.matches?("a.b!*@*", "axb", nil, nil)
-      refute Mask.matches?("[a]!*@*", "a", nil, nil)
+      assert Mask.matches?(m("a.b!*@*"), "a.b", nil, nil, :ascii)
+      refute Mask.matches?(m("a.b!*@*"), "axb", nil, nil, :ascii)
+      refute Mask.matches?(m("[a]!*@*"), "a", nil, nil, :ascii)
     end
 
-    test "a malformed mask matches nothing rather than raising" do
-      refute Mask.matches?("garbage", "garbage", nil, nil)
+    # The subject folds with the SESSION's casemapping, the pattern was folded
+    # at write time: on rfc1459 the stored `foo{1}` catches a `Foo[1]` sender;
+    # on ascii the two spellings stay distinct in both directions.
+    test "the subject nick folds with the session's casemapping (#537)" do
+      {:ok, on_rfc} = Mask.normalize("Foo[1]", :rfc1459)
+      assert Mask.matches?(m(on_rfc), "Foo[1]", nil, nil, :rfc1459)
+      assert Mask.matches?(m(on_rfc), "foo{1}", nil, nil, :rfc1459)
+
+      {:ok, on_ascii} = Mask.normalize("Foo[1]", :ascii)
+      assert Mask.matches?(m(on_ascii), "FOO[1]", nil, nil, :ascii)
+      refute Mask.matches?(m(on_ascii), "foo{1}", nil, nil, :ascii)
+    end
+
+    # The absolute anchors, pinned from both sides (review, #1984): `\z` must
+    # refuse a subject with a trailing newline, which `$` would accept — and a
+    # lost backslash would turn `\A` into a literal `A` and match NOTHING,
+    # which every positive assertion in this file catches.
+    test "anchors are absolute — a trailing newline is not the end of the nick" do
+      refute Mask.matches?(m("alice!*@*"), "alice\n", nil, nil, :ascii)
+      refute Mask.matches?(m("*!*@evil.example"), "alice", nil, "evil.example\n", :ascii)
+      assert Mask.matches?(m("alice!*@*"), "alice", nil, nil, :ascii)
     end
   end
 
-  describe "any_match?/4" do
+  describe "any_match?/5" do
     test "empty list never matches" do
-      refute Mask.any_match?([], "anyone", "u", "h")
+      refute Mask.any_match?([], "anyone", "u", "h", :ascii)
     end
 
     test "true when any mask in the list matches" do
-      masks = ["alice!*@*", "*!*@evil.example"]
-      assert Mask.any_match?(masks, "bob", "~b", "evil.example")
-      assert Mask.any_match?(masks, "alice", nil, nil)
-      refute Mask.any_match?(masks, "carol", "~c", "good.example")
+      masks = Mask.compile_all(["alice!*@*", "*!*@evil.example"])
+      assert Mask.any_match?(masks, "bob", "~b", "evil.example", :ascii)
+      assert Mask.any_match?(masks, "alice", nil, nil, :ascii)
+      refute Mask.any_match?(masks, "carol", "~c", "good.example", :ascii)
     end
   end
 end

--- a/test/grappa/irc/mask_test.exs
+++ b/test/grappa/irc/mask_test.exs
@@ -1,0 +1,100 @@
+defmodule Grappa.IRC.MaskTest do
+  @moduledoc """
+  `Grappa.IRC.Mask` (#162) — the `nick!user@host` glob matcher behind /ignore.
+  Two properties carry the feature: a bare nick means "from anywhere", and an
+  origin part we cannot see never satisfies a concrete pattern.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.IRC.Mask
+
+  describe "normalize/1" do
+    test "a bare nick becomes nick!*@*, folded" do
+      assert Mask.normalize("SpamBot") == {:ok, "spambot!*@*"}
+    end
+
+    test "a full mask is kept, every part folded" do
+      assert Mask.normalize("*!*@Evil.Example") == {:ok, "*!*@evil.example"}
+      assert Mask.normalize("Nick!~User@Host") == {:ok, "nick!~user@host"}
+    end
+
+    test "surrounding whitespace is trimmed" do
+      assert Mask.normalize("  spambot  ") == {:ok, "spambot!*@*"}
+    end
+
+    test "rejects empty, embedded whitespace, and line breaks" do
+      assert Mask.normalize("") == :error
+      assert Mask.normalize("   ") == :error
+      assert Mask.normalize("a b") == :error
+      assert Mask.normalize("a\r\nb") == :error
+    end
+
+    test "rejects ! and @ in the wrong order or count" do
+      assert Mask.normalize("nick@host!user") == :error
+      assert Mask.normalize("a!b!c@d") == :error
+      assert Mask.normalize("!user@host") == :error
+    end
+
+    test "rejects a mask longer than a line could carry" do
+      assert Mask.normalize(String.duplicate("a", 201)) == :error
+    end
+
+    test "rejects non-binaries" do
+      assert Mask.normalize(nil) == :error
+      assert Mask.normalize(42) == :error
+    end
+  end
+
+  describe "matches?/4" do
+    test "a nick mask matches that nick from any user@host" do
+      assert Mask.matches?("spambot!*@*", "spambot", "~x", "h.example")
+      assert Mask.matches?("spambot!*@*", "SpamBot", nil, nil)
+    end
+
+    test "a nick mask does not match a different nick" do
+      refute Mask.matches?("spambot!*@*", "spambot2", "~x", "h.example")
+    end
+
+    test "* spans any run, ? exactly one character" do
+      assert Mask.matches?("spam*!*@*", "spambot", nil, nil)
+      assert Mask.matches?("spa?bot!*@*", "spambot", nil, nil)
+      refute Mask.matches?("spa?bot!*@*", "spammbot", nil, nil)
+    end
+
+    test "a host mask matches any nick from that host, case-insensitively" do
+      assert Mask.matches?("*!*@evil.example", "alice", "~a", "Evil.Example")
+      refute Mask.matches?("*!*@evil.example", "alice", "~a", "good.example")
+    end
+
+    # The rule that keeps a cloaked ircd from turning a targeted ignore into
+    # a blanket one: an absent part satisfies only `*`, never a real pattern.
+    test "a concrete user/host pattern never matches an absent part" do
+      refute Mask.matches?("*!*@evil.example", "alice", nil, nil)
+      refute Mask.matches?("*!~bad@*", "alice", nil, "h")
+      assert Mask.matches?("alice!*@*", "alice", nil, nil)
+    end
+
+    test "regex metacharacters in a mask are literal" do
+      assert Mask.matches?("a.b!*@*", "a.b", nil, nil)
+      refute Mask.matches?("a.b!*@*", "axb", nil, nil)
+      refute Mask.matches?("[a]!*@*", "a", nil, nil)
+    end
+
+    test "a malformed mask matches nothing rather than raising" do
+      refute Mask.matches?("garbage", "garbage", nil, nil)
+    end
+  end
+
+  describe "any_match?/4" do
+    test "empty list never matches" do
+      refute Mask.any_match?([], "anyone", "u", "h")
+    end
+
+    test "true when any mask in the list matches" do
+      masks = ["alice!*@*", "*!*@evil.example"]
+      assert Mask.any_match?(masks, "bob", "~b", "evil.example")
+      assert Mask.any_match?(masks, "alice", nil, nil)
+      refute Mask.any_match?(masks, "carol", "~c", "good.example")
+    end
+  end
+end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -11,7 +11,7 @@ defmodule Grappa.Session.EventRouterTest do
   """
   use ExUnit.Case, async: true
 
-  alias Grappa.IRC.{JoinFailure, Message, Parser}
+  alias Grappa.IRC.{JoinFailure, Mask, Message, Parser}
 
   alias Grappa.Session.{
     Deps,
@@ -7204,11 +7204,28 @@ defmodule Grappa.Session.EventRouterTest do
   # The four exclusions are each pinned, because each is a way a mask could
   # silence something it must not.
   describe "/ignore delivery filter (#162)" do
-    # No default argument: none of these cases needs one, and a `\` default
-    # is a backslash in source — which the tooling between the editor and the
-    # file has been eating in this change. Two clauses would be the shape if
-    # a case ever needed overrides.
-    defp ignoring(masks), do: base_state(%{ignores: masks})
+    # The state carries the masks COMPILED, as `Session.Server` hands them
+    # over — the router never sees a string.
+    defp ignoring(masks), do: base_state(%{ignores: Mask.compile_all(masks)})
+
+    # #537 — the subject folds with the SESSION's casemapping. On rfc1459 the
+    # mask `/ignore Foo[1]` was stored as `foo{1}!*@*` (the ingress fold), and
+    # a sender spelled `Foo[1]` is the same person to that ircd, so it drops.
+    # On ascii the same stored string is a different key from `foo[1]`.
+    test "on rfc1459 a sender folds to the stored mask across the national chars" do
+      from_brackets = msg(:privmsg, ["#chan", "x"], {:nick, "Foo[1]", "u", "h"})
+
+      on_rfc =
+        base_state(%{
+          isupport: %{ISupport.default() | casemapping: :rfc1459},
+          ignores: Mask.compile_all(["foo{1}!*@*"])
+        })
+
+      on_ascii = ignoring(["foo{1}!*@*"])
+
+      assert {:cont, _, []} = EventRouter.route(from_brackets, on_rfc)
+      assert {:cont, _, [{:persist, :privmsg, _}]} = EventRouter.route(from_brackets, on_ascii)
+    end
 
     test "a PRIVMSG from an ignored nick is dropped — no effects at all" do
       privmsg = msg(:privmsg, ["#chan", "buy my coins"], {:nick, "spambot", "u", "h"})

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -7198,4 +7198,95 @@ defmodule Grappa.Session.EventRouterTest do
 
   defp unwrap_ann({:ann_type, _, [{:var, _, _}, type]}), do: type
   defp unwrap_ann(type), do: type
+
+  # #162 — the /ignore delivery filter at the head of `route/2`. A dropped
+  # message produces NO effects: no persist, so no row, no broadcast, no push.
+  # The four exclusions are each pinned, because each is a way a mask could
+  # silence something it must not.
+  describe "/ignore delivery filter (#162)" do
+    # No default argument: none of these cases needs one, and a `\` default
+    # is a backslash in source — which the tooling between the editor and the
+    # file has been eating in this change. Two clauses would be the shape if
+    # a case ever needed overrides.
+    defp ignoring(masks), do: base_state(%{ignores: masks})
+
+    test "a PRIVMSG from an ignored nick is dropped — no effects at all" do
+      privmsg = msg(:privmsg, ["#chan", "buy my coins"], {:nick, "spambot", "u", "h"})
+      assert {:cont, _, []} = EventRouter.route(privmsg, ignoring(["spambot!*@*"]))
+    end
+
+    test "the same PRIVMSG with no ignores persists as usual" do
+      privmsg = msg(:privmsg, ["#chan", "hello"], {:nick, "spambot", "u", "h"})
+      assert {:cont, _, [{:persist, :privmsg, _}]} = EventRouter.route(privmsg, ignoring([]))
+    end
+
+    test "a host mask drops any nick from that host, and only that host" do
+      from_evil = msg(:privmsg, ["#chan", "x"], {:nick, "alice", "~a", "evil.example"})
+      from_good = msg(:privmsg, ["#chan", "x"], {:nick, "alice", "~a", "good.example"})
+      state = ignoring(["*!*@evil.example"])
+
+      assert {:cont, _, []} = EventRouter.route(from_evil, state)
+      assert {:cont, _, [{:persist, :privmsg, _}]} = EventRouter.route(from_good, state)
+    end
+
+    test "a DM from an ignored nick is dropped too — the filter is not per-target" do
+      dm = msg(:privmsg, ["vjt", "psst"], {:nick, "spambot", "u", "h"})
+      assert {:cont, _, []} = EventRouter.route(dm, ignoring(["spambot!*@*"]))
+    end
+
+    test "NOTICE from an ignored nick is dropped; ACTION rides PRIVMSG and is too" do
+      notice = msg(:notice, ["#chan", "ad"], {:nick, "spambot", "u", "h"})
+      action = msg(:privmsg, ["#chan", "ACTION waves"], {:nick, "spambot", "u", "h"})
+      state = ignoring(["spambot!*@*"])
+
+      assert {:cont, _, []} = EventRouter.route(notice, state)
+      assert {:cont, _, []} = EventRouter.route(action, state)
+    end
+
+    # Exclusion 1 — presence verbs are NOT dropped: they are governed by the
+    # presence filter, and eating a JOIN here would desync the members map.
+    test "a JOIN from an ignored nick still routes" do
+      join = msg(:join, ["#chan"], {:nick, "spambot", "u", "h"})
+      {:cont, after_join, _} = EventRouter.route(join, ignoring(["spambot!*@*"]))
+      assert Map.has_key?(after_join.members["#chan"], "spambot")
+    end
+
+    # Exclusion 2 — never our own lines, even under a mask that matches us.
+    test "our own PRIVMSG is never dropped, whatever the masks say" do
+      own = msg(:privmsg, ["#chan", "hi"], {:nick, "vjt", "u", "h"})
+      assert {:cont, _, [{:persist, :privmsg, _}]} = EventRouter.route(own, ignoring(["*!*@*"]))
+    end
+
+    # Exclusion 3 — services and the server are never chatter.
+    test "a services NOTICE is never dropped, even by a catch-all mask" do
+      nickserv = msg(:notice, ["vjt", "Password incorrect."], {:nick, "NickServ", "services", "azzurra.chat"})
+      assert {:cont, _, [_ | _]} = EventRouter.route(nickserv, ignoring(["*!*@*"]))
+    end
+
+    # Exclusion 4 — an origin with no nick is never a candidate.
+    test "a server-prefixed line is untouched by the filter" do
+      notice = msg(:notice, ["vjt", "*** Looking up your hostname"], {:server, "irc.example"})
+      # Compare EFFECTS, not the whole tuple: the two states differ by the
+      # `ignores` key itself, so tuple equality would fail for that reason alone.
+      {:cont, _, with_mask} = EventRouter.route(notice, ignoring(["*!*@*"]))
+      {:cont, _, without} = EventRouter.route(notice, ignoring([]))
+      assert with_mask == without
+      assert with_mask != []
+    end
+
+    # The cloaking rule from Mask: an absent host satisfies only `*`.
+    test "a host mask does not fire for a sender whose host is cloaked away" do
+      cloaked = msg(:privmsg, ["#chan", "x"], {:nick, "alice", nil, nil})
+
+      assert {:cont, _, [{:persist, :privmsg, _}]} =
+               EventRouter.route(cloaked, ignoring(["*!*@evil.example"]))
+    end
+
+    # A state with no :ignores key at all (older tests, a pre-#162 process)
+    # must route normally — the filter reads it with a [] default.
+    test "a state without an :ignores key routes normally" do
+      privmsg = msg(:privmsg, ["#chan", "hello"], {:nick, "spambot", "u", "h"})
+      assert {:cont, _, [{:persist, :privmsg, _}]} = EventRouter.route(privmsg, base_state())
+    end
+  end
 end

--- a/test/grappa/session/ignores_spawn_test.exs
+++ b/test/grappa/session/ignores_spawn_test.exs
@@ -1,0 +1,74 @@
+defmodule Grappa.Session.IgnoresSpawnTest do
+  @moduledoc """
+  #162 — the ignore list reaches a session at the SPAWN BOUNDARY
+  (`Grappa.Session.start_session/3`), compiled, and is re-synced compiled on
+  `ignores_changed/3`. Pinned end-to-end against the `Grappa.IRCServer` fake
+  because the wiring is one `Map.put_new_lazy` beside two siblings that had
+  no pin of their own — and because the first CI run showed what an
+  init-time read costs (`JoinSeedCostTest`): the assertion here is on the
+  spawned process's state, which is the same whether the read happened in
+  `init/1` or at the boundary, so a second assertion pins the boundary
+  itself — a caller-supplied `:ignores` wins, exactly as `auto_away_debounce_ms`
+  does.
+
+  `async: false` for the same reason as `Grappa.Session.ServerTest`:
+  `SessionRegistry` / `SessionSupervisor` are singletons.
+  """
+  use Grappa.DataCase, async: false
+  import Grappa.AuthFixtures
+
+  alias Grappa.IRC.Mask
+  alias Grappa.{IRCServer, Session, UserSettings}
+  alias Grappa.Networks.{Credentials, SessionPlan}
+
+  defp setup_user_and_network(port) do
+    user = user_fixture(name: "ign-#{System.unique_integer([:positive])}")
+
+    {network, _} =
+      network_with_server(port: port, slug: "ign-#{System.unique_integer([:positive])}")
+
+    credential = credential_fixture(user, network, %{})
+    {user, network, credential}
+  end
+
+  test "a spawned session carries its stored masks, compiled, from the first line" do
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+    {user, network, _} = setup_user_and_network(port)
+    subject = {:user, user.id}
+    {:ok, :added, _, _} = UserSettings.add_ignore(subject, network.slug, "SpamBot", :ascii)
+
+    pid = start_session_for(user, network)
+    :ok = IRCServer.await_handshake(server, 1_000)
+
+    assert [%Mask{source: "spambot!*@*", user: :any, host: :any}] = :sys.get_state(pid).ignores
+  end
+
+  test "a caller-supplied :ignores wins at the boundary, like its two siblings" do
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+    {user, network, _} = setup_user_and_network(port)
+    subject = {:user, user.id}
+    {:ok, :added, _, _} = UserSettings.add_ignore(subject, network.slug, "stored", :ascii)
+
+    {:ok, plan} = SessionPlan.resolve(Credentials.get_credential!(user, network))
+    {:ok, pid} = Session.start_session(subject, network.id, Map.put(plan, :ignores, ["given!*@*"]))
+    on_exit(fn -> Session.stop_session(subject, network.id) end)
+    :ok = IRCServer.await_handshake(server, 1_000)
+
+    assert [%Mask{source: "given!*@*"}] = :sys.get_state(pid).ignores
+  end
+
+  test "ignores_changed/3 re-syncs the live session with the list compiled" do
+    {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+    {user, network, _} = setup_user_and_network(port)
+    subject = {:user, user.id}
+
+    pid = start_session_for(user, network)
+    :ok = IRCServer.await_handshake(server, 1_000)
+    assert [] = :sys.get_state(pid).ignores
+
+    :ok = Session.ignores_changed(subject, network.id, ["*!*@evil.example"])
+
+    assert [%Mask{source: "*!*@evil.example", nick: :any, user: :any, host: %Regex{}}] =
+             :sys.get_state(pid).ignores
+  end
+end

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -1301,6 +1301,106 @@ defmodule Grappa.UserSettingsTest do
   end
 
   # ---------------------------------------------------------------------------
+  # ignores accessors (#162 — the /ignore mask list)
+  # ---------------------------------------------------------------------------
+
+  describe "get_ignores/2" do
+    test "reads [] when no row, no key, or a malformed value" do
+      assert UserSettings.get_ignores({:user, Ecto.UUID.generate()}, "azzurra") == []
+
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+      assert UserSettings.get_ignores({:user, user.id}, "azzurra") == []
+
+      # A malformed value must fail OPEN — never a user silently ignoring everyone.
+      Repo.update!(Settings.changeset(settings, %{data: %{"ignores" => "garbage"}}))
+      assert UserSettings.get_ignores({:user, user.id}, "azzurra") == []
+
+      Repo.update!(Settings.changeset(settings, %{data: %{"ignores" => %{"azzurra" => "nope"}}}))
+      assert UserSettings.get_ignores({:user, user.id}, "azzurra") == []
+    end
+
+    test "is keyed by network — an ignore on one network does not leak to another" do
+      user = user_fixture()
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+
+      assert UserSettings.get_ignores({:user, user.id}, "azzurra") == ["spambot!*@*"]
+      assert UserSettings.get_ignores({:user, user.id}, "ircnet") == []
+    end
+  end
+
+  describe "add_ignore/3" do
+    test "normalises a bare nick and returns the resulting list" do
+      user = user_fixture()
+
+      assert {:ok, :added, "spambot!*@*", ["spambot!*@*"]} =
+               UserSettings.add_ignore({:user, user.id}, "azzurra", "SpamBot")
+    end
+
+    test "is idempotent across spellings of the same mask" do
+      user = user_fixture()
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+
+      assert {:ok, :already_ignored, "spambot!*@*", ["spambot!*@*"]} =
+               UserSettings.add_ignore({:user, user.id}, "azzurra", "SPAMBOT!*@*")
+    end
+
+    test "rejects an unparseable mask" do
+      user = user_fixture()
+      assert {:error, :invalid_mask} = UserSettings.add_ignore({:user, user.id}, "azzurra", "a b")
+      assert UserSettings.get_ignores({:user, user.id}, "azzurra") == []
+    end
+
+    test "refuses past the per-network cap" do
+      user = user_fixture()
+
+      for i <- 1..100 do
+        {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "n#{i}")
+      end
+
+      assert {:error, :list_full} = UserSettings.add_ignore({:user, user.id}, "azzurra", "one-more")
+      # The cap is per network: another network is untouched.
+      assert {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "ircnet", "fine")
+    end
+
+    test "preserves sibling settings keys" do
+      user = user_fixture()
+      {:ok, _} = UserSettings.put_upload_ttl_seconds({:user, user.id}, 3600)
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+
+      assert UserSettings.get_upload_ttl_seconds({:user, user.id}) == 3600
+    end
+  end
+
+  describe "remove_ignore/3" do
+    test "removes by normalised mask and returns the resulting list" do
+      user = user_fixture()
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "*!*@evil.example")
+
+      assert {:ok, :removed, "spambot!*@*", ["*!*@evil.example"]} =
+               UserSettings.remove_ignore({:user, user.id}, "azzurra", "SPAMBOT")
+    end
+
+    test "is idempotent — removing an absent mask is still ok" do
+      user = user_fixture()
+
+      assert {:ok, :not_ignored, "nobody!*@*", []} =
+               UserSettings.remove_ignore({:user, user.id}, "azzurra", "nobody")
+    end
+
+    # The put_or_delete rule: an empty list is ABSENCE, not a stored [].
+    test "an emptied network drops its key, and an emptied map drops the ignores key" do
+      user = user_fixture()
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+      {:ok, _, _, _} = UserSettings.remove_ignore({:user, user.id}, "azzurra", "spambot")
+
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+      refute Map.has_key?(settings.data, "ignores")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # show_peer_profiles accessor (M2)
   # ---------------------------------------------------------------------------
 

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -1322,7 +1322,7 @@ defmodule Grappa.UserSettingsTest do
 
     test "is keyed by network — an ignore on one network does not leak to another" do
       user = user_fixture()
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot", :ascii)
 
       assert UserSettings.get_ignores({:user, user.id}, "azzurra") == ["spambot!*@*"]
       assert UserSettings.get_ignores({:user, user.id}, "ircnet") == []
@@ -1334,20 +1334,20 @@ defmodule Grappa.UserSettingsTest do
       user = user_fixture()
 
       assert {:ok, :added, "spambot!*@*", ["spambot!*@*"]} =
-               UserSettings.add_ignore({:user, user.id}, "azzurra", "SpamBot")
+               UserSettings.add_ignore({:user, user.id}, "azzurra", "SpamBot", :ascii)
     end
 
     test "is idempotent across spellings of the same mask" do
       user = user_fixture()
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot", :ascii)
 
       assert {:ok, :already_ignored, "spambot!*@*", ["spambot!*@*"]} =
-               UserSettings.add_ignore({:user, user.id}, "azzurra", "SPAMBOT!*@*")
+               UserSettings.add_ignore({:user, user.id}, "azzurra", "SPAMBOT!*@*", :ascii)
     end
 
     test "rejects an unparseable mask" do
       user = user_fixture()
-      assert {:error, :invalid_mask} = UserSettings.add_ignore({:user, user.id}, "azzurra", "a b")
+      assert {:error, :invalid_mask} = UserSettings.add_ignore({:user, user.id}, "azzurra", "a b", :ascii)
       assert UserSettings.get_ignores({:user, user.id}, "azzurra") == []
     end
 
@@ -1355,18 +1355,18 @@ defmodule Grappa.UserSettingsTest do
       user = user_fixture()
 
       for i <- 1..100 do
-        {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "n#{i}")
+        {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "n#{i}", :ascii)
       end
 
-      assert {:error, :list_full} = UserSettings.add_ignore({:user, user.id}, "azzurra", "one-more")
+      assert {:error, :list_full} = UserSettings.add_ignore({:user, user.id}, "azzurra", "one-more", :ascii)
       # The cap is per network: another network is untouched.
-      assert {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "ircnet", "fine")
+      assert {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "ircnet", "fine", :ascii)
     end
 
     test "preserves sibling settings keys" do
       user = user_fixture()
       {:ok, _} = UserSettings.put_upload_ttl_seconds({:user, user.id}, 3600)
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot", :ascii)
 
       assert UserSettings.get_upload_ttl_seconds({:user, user.id}) == 3600
     end
@@ -1375,25 +1375,25 @@ defmodule Grappa.UserSettingsTest do
   describe "remove_ignore/3" do
     test "removes by normalised mask and returns the resulting list" do
       user = user_fixture()
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "*!*@evil.example")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot", :ascii)
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "*!*@evil.example", :ascii)
 
       assert {:ok, :removed, "spambot!*@*", ["*!*@evil.example"]} =
-               UserSettings.remove_ignore({:user, user.id}, "azzurra", "SPAMBOT")
+               UserSettings.remove_ignore({:user, user.id}, "azzurra", "SPAMBOT", :ascii)
     end
 
     test "is idempotent — removing an absent mask is still ok" do
       user = user_fixture()
 
       assert {:ok, :not_ignored, "nobody!*@*", []} =
-               UserSettings.remove_ignore({:user, user.id}, "azzurra", "nobody")
+               UserSettings.remove_ignore({:user, user.id}, "azzurra", "nobody", :ascii)
     end
 
     # The put_or_delete rule: an empty list is ABSENCE, not a stored [].
     test "an emptied network drops its key, and an emptied map drops the ignores key" do
       user = user_fixture()
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot")
-      {:ok, _, _, _} = UserSettings.remove_ignore({:user, user.id}, "azzurra", "spambot")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, "azzurra", "spambot", :ascii)
+      {:ok, _, _, _} = UserSettings.remove_ignore({:user, user.id}, "azzurra", "spambot", :ascii)
 
       {:ok, settings} = UserSettings.get_or_init({:user, user.id})
       refute Map.has_key?(settings.data, "ignores")

--- a/test/grappa_web/controllers/ignores_controller_test.exs
+++ b/test/grappa_web/controllers/ignores_controller_test.exs
@@ -28,7 +28,7 @@ defmodule GrappaWeb.IgnoresControllerTest do
     end
 
     test "reflects the stored list", %{conn: conn, user: user, network: network} do
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "spambot")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "spambot", :ascii)
 
       assert json_response(get(conn, "/networks/#{network.slug}/ignores"), 200) ==
                %{"masks" => ["spambot!*@*"]}
@@ -68,8 +68,8 @@ defmodule GrappaWeb.IgnoresControllerTest do
   describe "DELETE /networks/:network_id/ignores/:mask" do
     test "removes by normalised mask and answers the resulting list",
          %{conn: conn, user: user, network: network} do
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "spambot")
-      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "*!*@evil.example")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "spambot", :ascii)
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "*!*@evil.example", :ascii)
 
       conn = delete(conn, "/networks/#{network.slug}/ignores/SPAMBOT")
 

--- a/test/grappa_web/controllers/ignores_controller_test.exs
+++ b/test/grappa_web/controllers/ignores_controller_test.exs
@@ -1,0 +1,87 @@
+defmodule GrappaWeb.IgnoresControllerTest do
+  @moduledoc """
+  `/networks/:network_id/ignores` (#162). The list is the reply on every
+  verb, the iso boundary is the shared `:resolve_network` 404, and the two
+  refusal tokens the fallback renders are pinned by shape.
+  """
+  use GrappaWeb.ConnCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.UserSettings
+
+  setup %{conn: conn} do
+    {user, session} = user_and_session()
+    network = network_fixture(slug: "azzurra")
+    _ = credential_fixture(user, network)
+    {:ok, conn: put_bearer(conn, session.id), user: user, network: network}
+  end
+
+  describe "GET /networks/:network_id/ignores" do
+    test "401 without bearer", %{network: network} do
+      conn = get(build_conn(), "/networks/#{network.slug}/ignores")
+      assert json_response(conn, 401) == %{"error" => "unauthorized"}
+    end
+
+    test "empty list when nothing is ignored", %{conn: conn, network: network} do
+      assert json_response(get(conn, "/networks/#{network.slug}/ignores"), 200) == %{"masks" => []}
+    end
+
+    test "reflects the stored list", %{conn: conn, user: user, network: network} do
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "spambot")
+
+      assert json_response(get(conn, "/networks/#{network.slug}/ignores"), 200) ==
+               %{"masks" => ["spambot!*@*"]}
+    end
+  end
+
+  describe "POST /networks/:network_id/ignores" do
+    test "201 with the resulting list; a bare nick normalises", %{conn: conn, network: network} do
+      conn = post(conn, "/networks/#{network.slug}/ignores", %{"mask" => "SpamBot"})
+
+      assert json_response(conn, 201) ==
+               %{"masks" => ["spambot!*@*"], "mask" => "spambot!*@*", "outcome" => "added"}
+    end
+
+    test "an idempotent re-add answers the same list", %{conn: conn, network: network} do
+      _ = post(conn, "/networks/#{network.slug}/ignores", %{"mask" => "spambot"})
+      conn = post(conn, "/networks/#{network.slug}/ignores", %{"mask" => "spambot!*@*"})
+
+      assert json_response(conn, 201) ==
+               %{"masks" => ["spambot!*@*"], "mask" => "spambot!*@*", "outcome" => "already_ignored"}
+    end
+
+    test "422 invalid_mask on an unparseable mask", %{conn: conn, network: network} do
+      conn = post(conn, "/networks/#{network.slug}/ignores", %{"mask" => "nick@host!user"})
+      assert json_response(conn, 422) == %{"error" => "invalid_mask"}
+    end
+
+    test "400 on a missing or empty mask", %{conn: conn, network: network} do
+      assert json_response(post(conn, "/networks/#{network.slug}/ignores", %{}), 400) ==
+               %{"error" => "bad_request"}
+
+      assert json_response(post(conn, "/networks/#{network.slug}/ignores", %{"mask" => ""}), 400) ==
+               %{"error" => "bad_request"}
+    end
+  end
+
+  describe "DELETE /networks/:network_id/ignores/:mask" do
+    test "removes by normalised mask and answers the resulting list",
+         %{conn: conn, user: user, network: network} do
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "spambot")
+      {:ok, _, _, _} = UserSettings.add_ignore({:user, user.id}, network.slug, "*!*@evil.example")
+
+      conn = delete(conn, "/networks/#{network.slug}/ignores/SPAMBOT")
+
+      assert json_response(conn, 200) ==
+               %{"masks" => ["*!*@evil.example"], "mask" => "spambot!*@*", "outcome" => "removed"}
+    end
+
+    test "is idempotent — an absent mask still answers the list", %{conn: conn, network: network} do
+      conn = delete(conn, "/networks/#{network.slug}/ignores/nobody")
+
+      assert json_response(conn, 200) ==
+               %{"masks" => [], "mask" => "nobody!*@*", "outcome" => "not_ignored"}
+    end
+  end
+end


### PR DESCRIPTION
Closes #162. Implements the drop-at-delivery design — the one the issue body specifies — with the two open questions resolved as recorded on the issue.

## What it does

`/ignore <mask>`, `/unignore <mask>`; a bare `/ignore` opens the new **settings → ignore list** sub-page. A bare nick means `nick!*@*`; full `nick!user@host` globs work (`*` and `?`). Per subject, per network, persisted, honoured **server-side**: a matching PRIVMSG or NOTICE is dropped at the head of `EventRouter.route/2`, so there is no row, no broadcast, and no push.

## Drop, not hide, not re-route

#162's body says drop; Lucy's variant re-routes to the server window. Dropped on the ruling that ignored is ignored — no un-hide. That also makes the issue's second ruling free: with no persist effect there is no trigger, so **"ignored mask sends a DM, subscription exists, zero pushes emitted" holds by construction**, not by a second gate beside `muted_targets` in `should_notify?/5`. If the re-route variant is preferred later, only the delivery arm changes — storage, matching, REST and commands all survive.

## Its own structure, beside `muted_targets`

Ruled separate, and the reason is mechanical: a mute is "this ROOM is noisy" and suppresses attention; an ignore is "this PERSON is a problem" and stops the message existing. One shared shape would carry a field meaningless on every mute row. Same conventions (network in the key per #1038, `canonical_target/1` fold), separate `"ignores"` key in `user_settings.data`. No migration.

## The filter's four exclusions, each pinned by a test

- **Content only** — PRIVMSG/NOTICE (ACTION rides PRIVMSG). JOIN/PART/QUIT stay: they are the presence filter's, and eating a JOIN here would desync the members map.
- **Never our own lines**, even under a mask that matches us.
- **Never a services or server sender** (`Mentions.mentionable_sender?/1`, #1674) — a `*!*@*` mask must not eat NickServ telling you your password is wrong.
- **Never an origin with no nick.** And a cloaked user/host satisfies only `*`, never a concrete pattern.

Forward-only (#162's first ruling) settled the mask question: scrollback stores the nick only, so masks can never reach history — but matching happens at delivery, where the prefix carries the full triple (`Message.sender_origin/1`).

## cic: the answer goes in the window, the list goes in settings

Three rulings from interactive testing, in order:

1. A mutation prints **its own outcome on the normalised mask**, and nothing else: `Unignore: removed spambot!*@*`. `/unignore spambot` acts on a mask the operator never typed, so the reply must name it; an idempotent re-add says `already ignored` rather than posing as a first add. For that the REST mutations now answer `{masks, mask, outcome}`.
2. It prints **into the window**, irssi-style, not as the transient compose notice. New `lib/commandOutput.ts`, a plain-text sibling of `topicShow` / `inviteAck` (one row per line, optional accent label, indent flag), woven into the timeline by wallclock like the other two. The rows stay, so the pane reads as a history of what was asked and done.
3. **Bare `/ignore` opens settings**, the door bare `/hilight` and `/notify` already take. New `IgnoresSettings.tsx` sub-page, one block per network with × and an add-input, shaped after the watch-lists page down to the list classes. The verbs and the page share `lib/ignoreList.ts` (the `highlightList` mould: no broadcast → refresh on open, every REST answer mirrored), so a verb typed while the page is open updates it.

### A latent ordering bug in the ephemeral rows, found by the third kind

`/ignore` then `/topic` printed the topic **above** the ignore rows. `ScrollbackPane`'s `rows()` wove invite-acks, `/topic` answers and now verb answers in three separate passes, each anchoring only on message rows: the later pass never saw the earlier pass's rows and went to the end. The same shape reverses two `/topic` answers once a message lands after both — latent since #1914. Now one pass over all ephemeral entries sorted by `(at, ts)`, every woven row carrying its `at` so a later answer anchors on an earlier one as it does on a message (`rowTime/1`). Pinned by a pane test that asks `/ignore` then `/topic` under a later message.

## Pieces

| | |
|---|---|
| `Grappa.IRC.Mask` | the `nick!user@host` glob matcher grappa never had |
| `UserSettings` | `get_ignores/2`, `add_ignore/3`, `remove_ignore/3` → `{:ok, outcome, mask, masks}`; cap 100 per network |
| `Session.Server` | list on state, loaded at init, `{:ignores_changed, masks}` re-sync |
| `EventRouter.route/2` | the drop, pure — reads state, no IO on the hot path |
| REST | `GET/POST/DELETE /networks/:network_id/ignores` — inherits the `/networks` client-usable prefix; 422 `invalid_mask` |
| `GrappaWeb.ErrorTokens` | `invalid_mask` registered (the drift test caught the omission) |
| cic | verbs, `commandOutput` rows, `ignoreList` store, `IgnoresSettings` sub-page, the ephemeral-row weave fix |

## Not in v1

irssi's `<levels>` argument (the vocabulary to grow it is `Message.kinds/0`) and `-replies` (grappa does not track what a message replies to).

## Wire

**`protocol_version` 13 → 14** (13 went to #1850 while this branch was out — same mechanism). Not by judgement: the routes alone would be a v10/v11-style bump, but `invalid_mask` joins `rest_error_token`, a closed set `gen_wire_types` renders into cic's `KnownApiErrorCode` union, so the pin moved and `wire_pin --check` demanded it. `min_protocol_version` stays 1: no bundle predating v14 knows the `/ignore` verb, so none can earn the token. The REST mutation answers gained `mask` + `outcome` (additive, outside the generated schema, covered by the same bump).

## Gates, all run locally on the rebased tree

| gate | result |
|---|---|
| `mix compile --force --warnings-as-errors` | clean |
| `mix test` | 7212 tests, 65 properties on the final rebased tree, run alone: 2 reds — `LongLivedModulesMembershipTest` (real: `%Mask{}` in session state → registered as a state helper, fixed) and `LockWatchReportTest` (load; 4/4 alone) |
| `mix credo --strict` | no issues (6808 mods/funs) |
| `mix dialyzer` | 0 errors |
| `mix grappa.wire_pin --check` | protocol 14, shape agrees |
| `bun run check` | 5 stages, 0 failed |
| cic `CLIENT_PROTOCOL_VERSION` | 14, in the same commit (#1973 pin) |
| cic vitest | 6785 passed, 9 failed in 5 files — all green in isolation (the known cross-file pollution) |
| `design-notes-gate.sh` | pass; `#162a` unique against origin/main |
| `union-rebase.sh` | first pass: conflict in `protocol.ex` + `shape.pin` (both sides bumped to 13) resolved by hand to 14, DESIGN_NOTES `+114 −0` before and after; later passes over the #1988 hotfix and the 1.5.3 release clean, `+132 −0` |

`integration` cannot run on the dev host; audited instead — no e2e spec drives `/ignore`, and the notify spec runs on azzurra-testnet where nothing is ignored.

Verified by hand on azzurra and IRCnet (`#sbiffo`) as `peluche-test-162`: drop, list, settings page, bare-verb door, and the `/ignore`-then-`/topic` order.

**Deploy:** no migration; cic bundle rebuild. `Grappa.IRC.Mask` is a `%struct{}` held in `Session.Server` state (the compiled ignore list), so it is registered as a preflight state helper and the preflight classifies `mask.ex` changes from here on. Functionally hot-safe for this landing: the router reads `ignores` with a default, so a live session predating the swap simply has none until its next `ignores_changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDCsdiDSVDJQSaqM4Yjoht
