### PR TITLE
cic(1982): arm every compose-reachable scrim on the press, not on the click

### DIFF
--- a/cicchetto/e2e/tests/issue1982-tap-send-overlay-survives.spec.ts
+++ b/cicchetto/e2e/tests/issue1982-tap-send-overlay-survives.spec.ts
@@ -1,0 +1,167 @@
+// issue 1982 — an overlay opened from the compose line must survive the TAP
+// that opened it, on EVERY overlay that line can open, not just the two
+// issue 1831 happened to reach.
+//
+// The mechanism is issue 1831's, entire, and is not restated here: a command
+// that reaches its opener with no `await` ahead of it mounts a full-region
+// scrim while the finger is still on the send button; the tap's compat mouse
+// events are synthesised after the touch ends and hit-tested against the
+// layout as it stands THEN, so the click lands on the scrim and a
+// dismiss-on-any-click fires in the gesture that opened the overlay. See
+// `issue1831-tap-send-modal-survives.spec.ts` and `lib/backdropDismiss.ts`.
+//
+// What this spec adds is the SET. The compose command path reaches exactly
+// five overlays — measured, by grepping every opener referenced from
+// `lib/commands/` and `lib/compose.ts`:
+//
+//     openBanlistModal      BanlistModal     cured by 1831
+//     openModeModal         ModeModal        cured by 1831
+//     openUmodeModal        UmodeModal       NOT cured  <- covered below
+//     openServiceModal      ServiceModal     NOT cured
+//     requestOpenSettings   SettingsDrawer   NOT cured  <- covered below, as reported
+//
+// 1831 cured two of the five and the other three kept the defect. #1982 is
+// what the third one looks like when a user finds it. So the arms below drive
+// TWO DIFFERENT VERBS through TWO DIFFERENT PARSERS onto two different
+// settings sub-pages: a green that only ever exercised `/notify` would show
+// that one string had been patched, not that the class had been closed.
+//
+// 🔴 WHY BOTH VERBS LAND ON THE DRAWER, when the stronger spec would put the
+// second one on a different overlay. It was tried, with `/umode` → UmodeModal,
+// and the arm was a FALSE GREEN: it passed against the PRE-CURE tree. A
+// document-level capture probe on that tree says why, and the answer is
+// geometry, not mechanism:
+//
+//     /notify   pointerdown -> polygon                        (send button glyph)
+//               click       -> div.settings-drawer-backdrop.open
+//               …drawer dismissed inside the gesture.  THE DEFECT.
+//
+//     /umode    pointerdown -> polygon
+//               click       -> div.mode-modal-body            (the DIALOG, not the scrim)
+//               …modal survives.
+//
+// On a Pixel 7 the umode toggle list is tall enough that the centred dialog
+// covers the point the send button occupied, and the dialog's own
+// `stopPropagation` eats the click before any scrim sees it. UmodeModal is
+// still defective by construction — its scrim dismissed on a bare click, and a
+// network advertising few umodes yields a short dialog that leaves the scrim
+// exposed — but that is NOT reproducible at this viewport, and an arm that
+// cannot fail is worth less than no arm. Do not re-add it without first
+// re-running that probe.
+//
+// So the honest split: SettingsDrawer has engine evidence, UmodeModal and
+// ServiceModal have unit evidence only (`src/__tests__/`). ServiceModal could
+// not be driven here at all — a bare `/ns` needs services this testnet does
+// not run.
+//
+// 🔴 WHY `@touch` AND ONLY `@touch`. `chromium-pixel-touch` is the only
+// project whose `tap()` produces the compat mouse events a real tap produces;
+// on `webkit-iphone-15` the same tap dispatches `pointerdown / touchstart /
+// pointerup` and stops, so a spec about what a synthesised click hits is
+// unanswerable there and goes green whatever the code does. That is measured
+// in `playwright.config.ts:110-117` and was measured again on the pre-cure
+// tree for 1831. Do not add a `@webkit` twin: it would pass without touching
+// the defect.
+//
+// PLATFORM LIMIT, stated rather than buried: this is Blink with `isMobile` +
+// `hasTouch`. The device in the report is a Samsung phone running Chrome —
+// the same engine family, which is a closer match than 1831 had (that report
+// was Android Firefox, and Gecko is not reachable from this harness at all).
+// It is still not "Android coverage": it measures that an engine does this,
+// and which gesture does it.
+//
+// The pair per verb is deliberate and the control is the load-bearing half:
+//
+//   * ENTER — a keydown synthesises no trailing click, so this arm is green on
+//     both sides of the cure. Its job is to fail loudly if the STACK broke
+//     rather than the mechanism, which is what makes a red TAP arm mean the
+//     mechanism.
+//   * TAP — the same verb through the send button. Red before the cure, green
+//     after. Everything but the GESTURE is held fixed.
+
+import { composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test.setTimeout(90_000);
+
+// Type into the compose line and activate the SEND BUTTON with a tap.
+//
+// Tap, never click. A `click()` synthesises a mouse sequence whose `mousedown`
+// PRECEDES the overlay mount, so the click resolves to the common ancestor of
+// button and scrim instead of to the scrim — the case that never reproduced,
+// and the reason a mouse never saw this bug.
+const tapSend = async (page: Parameters<typeof composeSend>[0], body: string): Promise<void> => {
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+  await ta.tap();
+  await ta.pressSequentially(body, { delay: 20 });
+  await page.getByRole("button", { name: /send message/i }).tap();
+  // Dispatch signal first, so a red below is an OVERLAY failure and not a
+  // submit that never happened.
+  await expect(ta).toHaveValue("", { timeout: 5_000 });
+};
+
+test("@touch issue 1982 — bare /notify sent with Enter opens the watch lists (gesture control)", async ({
+  page,
+}) => {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  await composeSend(page, "/notify");
+
+  await expect(page.getByTestId("watchlists-subpage")).toBeVisible({ timeout: 15_000 });
+});
+
+test("@touch issue 1982 — bare /notify sent by TAPPING send opens the watch lists and they stay", async ({
+  page,
+}) => {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  await tapSend(page, "/notify");
+
+  const subpage = page.getByTestId("watchlists-subpage");
+  await expect(subpage).toBeVisible({ timeout: 15_000 });
+
+  // …and still there once the gesture has fully settled. The defect dismissed
+  // the drawer within the same tap, and its opacity transition is 200ms, so it
+  // never painted at all; `toBeVisible` alone already catches that. This
+  // second look separates "opened and stayed" from "the assertion won a race".
+  await page.waitForTimeout(1_000);
+  await expect(subpage).toBeVisible();
+});
+
+test("@touch issue 1982 — bare /alias sent with Enter opens the aliases page (gesture control)", async ({
+  page,
+}) => {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  await composeSend(page, "/alias");
+
+  await expect(page.getByTestId("aliases-subpage")).toBeVisible({ timeout: 15_000 });
+});
+
+// The second verb. `/alias` is not in the watch family, is parsed by
+// `parseAlias` and not `parseNotify`, and deep-links to a DIFFERENT sub-page —
+// so a cure that had special-cased the reported verb, its parser or its
+// section leaves this arm red. It reaches the same scrim on purpose: that is
+// the only scrim this harness can put under the send button (see the probe in
+// the header).
+test("@touch issue 1982 — bare /alias sent by TAPPING send opens the aliases page and it stays", async ({
+  page,
+}) => {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+
+  await tapSend(page, "/alias");
+
+  const subpage = page.getByTestId("aliases-subpage");
+  await expect(subpage).toBeVisible({ timeout: 15_000 });
+
+  await page.waitForTimeout(1_000);
+  await expect(subpage).toBeVisible();
+});

--- a/cicchetto/src/ServiceModal.tsx
+++ b/cicchetto/src/ServiceModal.tsx
@@ -1,4 +1,5 @@
 import { type Component, createEffect, createSignal, For, Show } from "solid-js";
+import { createBackdropDismiss } from "./lib/backdropDismiss";
 import { casemappingForSlug } from "./lib/casemapping";
 import { friendlyError } from "./lib/friendlyError";
 import { nickEquals } from "./lib/nickEquals";
@@ -35,6 +36,16 @@ const ServiceModal: Component = () => {
   // same wiring as ServerReplyModal / ModeModal. A new pane-covering modal
   // MUST push the overlay refcount or the iOS scroll-freeze mis-counts.
   createOverlayLock(() => state() !== null, ".service-modal-body", close);
+
+  // issue 1982 — the scrim dismisses on the press it began, not on any click
+  // that happens to land on it. `serviceModalCommand` opens FIRST and awaits
+  // `sendBodyLines` after (an ordering #1518 pinned: the $server high-water
+  // mark must be taken before the POST), so a tap on send provably mounts this
+  // backdrop before the tap's synthesised click is hit-tested. Same defect and
+  // same cure as issue 1831 on BanlistModal and ModeModal — see
+  // lib/backdropDismiss.ts. Created at component scope, not inside the keyed
+  // `Show`, so switching services cannot reset the arm mid-gesture.
+  const backdropDismiss = createBackdropDismiss(close);
 
   return (
     <Show when={state()} keyed>
@@ -89,7 +100,8 @@ const ServiceModal: Component = () => {
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
           <div
             class="modal-backdrop modal-backdrop-viewport service-modal-backdrop"
-            onClick={close}
+            onPointerDown={backdropDismiss.onPointerDown}
+            onClick={backdropDismiss.onClick}
           >
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -16,6 +16,7 @@ import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
 import { getSubject, token } from "./lib/auth";
 import { autoAwayDebounceValue, loadAutoAwayDebounce, saveAutoAwayDebounce } from "./lib/autoAway";
+import { createBackdropDismiss } from "./lib/backdropDismiss";
 import { type ChannelKey, decodeChannelKey } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
 import {
@@ -1084,12 +1085,26 @@ const SettingsDrawer: Component<Props> = (props) => {
     </header>
   );
 
+  // issue 1982 — the scrim dismisses on the press it began, not on any click
+  // that happens to land on it. A bare watch-family verb reaches
+  // `requestOpenSettings` with no `await` ahead of it, Shell's tick effect runs
+  // `setSettingsOpen(true)` in the same turn, and `.settings-drawer-backdrop.open`
+  // takes `pointer-events: auto` with NO transition — so a tap on send arms this
+  // scrim under the finger and the tap's own synthesised click hit-tests onto
+  // it, closing the drawer inside the gesture that opened it. Same defect and
+  // same cure as issue 1831 on BanlistModal and ModeModal; this is the first
+  // site reached through `requestOpenSettings` rather than an `open*Modal`.
+  // See lib/backdropDismiss.ts. `props.onClose` is read through an arrow so the
+  // dismiss always calls the CURRENT prop, never the one captured at mount.
+  const backdropDismiss = createBackdropDismiss(() => props.onClose());
+
   return (
     <>
       <div
         class="settings-drawer-backdrop"
         classList={{ open: props.open }}
-        onClick={props.onClose}
+        onPointerDown={backdropDismiss.onPointerDown}
+        onClick={backdropDismiss.onClick}
         aria-hidden="true"
         data-testid="settings-drawer-backdrop"
       />

--- a/cicchetto/src/UmodeModal.tsx
+++ b/cicchetto/src/UmodeModal.tsx
@@ -1,4 +1,5 @@
 import { type Component, For, Show } from "solid-js";
+import { createBackdropDismiss } from "./lib/backdropDismiss";
 import { networkIdBySlug } from "./lib/networks";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { pushChannelUmode } from "./lib/socket";
@@ -76,6 +77,14 @@ const UmodeModal: Component = () => {
   // #232 shared Esc-to-close (topmost-first, focus-independent).
   createOverlayLock(() => umodeModalState() !== null, ".umode-modal", closeUmodeModal);
 
+  // issue 1982 — the scrim dismisses on the press it began, not on any click
+  // that happens to land on it. Both openers (bare `/umode`, `/mode <ownnick>`)
+  // reach `openUmodeModal` with no `await` ahead of them, so a tap on send
+  // mounts this backdrop under the finger and the tap's own synthesised click
+  // hit-tests onto it. Same defect and same cure as issue 1831 on BanlistModal
+  // and ModeModal — see lib/backdropDismiss.ts.
+  const backdropDismiss = createBackdropDismiss(closeUmodeModal);
+
   return (
     <Show when={target()} keyed>
       {(t) => (
@@ -83,7 +92,8 @@ const UmodeModal: Component = () => {
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
         <div
           class="modal-backdrop modal-backdrop-viewport mode-modal-backdrop"
-          onClick={closeUmodeModal}
+          onPointerDown={backdropDismiss.onPointerDown}
+          onClick={backdropDismiss.onClick}
         >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div

--- a/cicchetto/src/__tests__/ServiceModal.test.tsx
+++ b/cicchetto/src/__tests__/ServiceModal.test.tsx
@@ -202,4 +202,49 @@ describe("ServiceModal (#290)", () => {
     fireEvent.click(screen.getByLabelText("close"));
     expect(screen.queryByTestId("service-modal")).toBeNull();
   });
+
+  // issue 1982 — the last of the five compose-reachable overlays to still
+  // dismiss on a bare click. `serviceModalCommand` calls `openServiceModal`
+  // FIRST and only then awaits `sendBodyLines` — an ordering #1518 pinned as
+  // load-bearing (the high-water mark must be taken before the POST), so the
+  // scrim provably exists before the tap's compat mouse events are dispatched.
+  // The cure therefore has to sit on the scrim; moving the `await` ahead of the
+  // open would trade this bug for #1518's.
+  describe("backdrop dismiss is armed by the press, not by the click (issue 1982)", () => {
+    const backdropIn = (container: HTMLElement): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(".service-modal-backdrop");
+      if (el === null) throw new Error("no service backdrop rendered");
+      return el;
+    };
+
+    it("ignores a click the backdrop never received a pointerdown for", () => {
+      openServiceModal("svc-press-a", "NickServ");
+      const { container } = render(() => <ServiceModal />);
+
+      fireEvent.click(backdropIn(container));
+
+      expect(screen.queryByTestId("service-modal")).not.toBeNull();
+    });
+
+    it("still dismisses on a press and release that both land on the backdrop", () => {
+      openServiceModal("svc-press-b", "NickServ");
+      const { container } = render(() => <ServiceModal />);
+
+      const backdrop = backdropIn(container);
+      fireEvent.pointerDown(backdrop);
+      fireEvent.click(backdrop);
+
+      expect(screen.queryByTestId("service-modal")).toBeNull();
+    });
+
+    it("a press that starts INSIDE the dialog does not dismiss on release", () => {
+      openServiceModal("svc-press-c", "NickServ");
+      const { container } = render(() => <ServiceModal />);
+
+      fireEvent.pointerDown(screen.getByTestId("service-modal"));
+      fireEvent.click(backdropIn(container));
+
+      expect(screen.queryByTestId("service-modal")).not.toBeNull();
+    });
+  });
 });

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -384,12 +384,51 @@ describe("SettingsDrawer", () => {
     expect(screen.queryByTestId("quit-irc-btn")).toBeNull();
   });
 
-  it("backdrop click fires onClose", () => {
-    const onClose = vi.fn();
-    wrap(true, onClose);
-    const backdrop = screen.getByTestId("settings-drawer-backdrop");
-    fireEvent.click(backdrop);
-    expect(onClose).toHaveBeenCalled();
+  // issue 1982 — the drawer is the THIRD site of the issue 1831 class, and the
+  // first one reached through `requestOpenSettings` rather than through an
+  // `open*Modal`. A bare watch-family verb (`/notify`, `/alias`, …) reaches
+  // `requestOpenSettings` with no `await` ahead of it, so Shell's tick effect
+  // has already run `setSettingsOpen(true)` — and `.settings-drawer-backdrop.open`
+  // takes `pointer-events: auto` with no transition — by the time the tap's
+  // compat mouse events are hit-tested. They hit-test against the NEW layout,
+  // the click lands on the backdrop, and the dismiss fires in the gesture that
+  // opened the drawer. Symptom as reported: the draft clears and nothing opens.
+  //
+  // This case used to read "backdrop click fires onClose" and asserted a bare
+  // click, which is the defect written down as a requirement: it is exactly the
+  // click a press-armed dismiss must ignore. Replaced by the trio below rather
+  // than deleted — the dismiss itself must keep working.
+  describe("backdrop dismiss is armed by the press, not by the click (issue 1982)", () => {
+    const backdrop = (): HTMLElement => screen.getByTestId("settings-drawer-backdrop");
+
+    it("ignores a click the backdrop never received a pointerdown for", () => {
+      const onClose = vi.fn();
+      wrap(true, onClose);
+
+      fireEvent.click(backdrop());
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("still dismisses on a press and release that both land on the backdrop", () => {
+      const onClose = vi.fn();
+      wrap(true, onClose);
+
+      fireEvent.pointerDown(backdrop());
+      fireEvent.click(backdrop());
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("a press that starts INSIDE the drawer does not dismiss on release", () => {
+      const onClose = vi.fn();
+      wrap(true, onClose);
+
+      fireEvent.pointerDown(screen.getByRole("dialog", { name: /settings/i }));
+      fireEvent.click(backdrop());
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
   });
 
   it("open=true gives the drawer the .open class", () => {

--- a/cicchetto/src/__tests__/UmodeModal.test.tsx
+++ b/cicchetto/src/__tests__/UmodeModal.test.tsx
@@ -101,6 +101,54 @@ describe("UmodeModal", () => {
     expect(vendor.getAttribute("aria-disabled")).toBe("true");
   });
 
+  // issue 1982 — the same defect issue 1831 cured on BanlistModal and
+  // ModeModal, on the sibling it did not reach. `umodeViewCommand` (bare
+  // `/umode`) and `umodeTargetViewCommand` (`/mode <ownnick>`) both call
+  // `openUmodeModal` with no `await` ahead of it, so the scrim is mounted while
+  // the finger is still down and the tap's synthesised click lands on it.
+  // Nothing about this arm is umode-specific: it is the shared cure applied to
+  // the third of five compose-reachable overlays.
+  describe("backdrop dismiss is armed by the press, not by the click (issue 1982)", () => {
+    const backdropIn = (container: HTMLElement): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(".mode-modal-backdrop");
+      if (el === null) throw new Error("no umode backdrop rendered");
+      return el;
+    };
+
+    it("ignores a click the backdrop never received a pointerdown for", () => {
+      mockUmodes[1] = [];
+      openUmodeModal("bahamut");
+      const { container, queryByTestId } = render(() => <UmodeModal />);
+
+      fireEvent.click(backdropIn(container));
+
+      expect(queryByTestId("umode-modal")).not.toBeNull();
+    });
+
+    it("still dismisses on a press and release that both land on the backdrop", () => {
+      mockUmodes[1] = [];
+      openUmodeModal("bahamut");
+      const { container, queryByTestId } = render(() => <UmodeModal />);
+
+      const backdrop = backdropIn(container);
+      fireEvent.pointerDown(backdrop);
+      fireEvent.click(backdrop);
+
+      expect(queryByTestId("umode-modal")).toBeNull();
+    });
+
+    it("a press that starts INSIDE the dialog does not dismiss on release", () => {
+      mockUmodes[1] = [];
+      openUmodeModal("bahamut");
+      const { container, getByTestId, queryByTestId } = render(() => <UmodeModal />);
+
+      fireEvent.pointerDown(getByTestId("umode-modal"));
+      fireEvent.click(backdropIn(container));
+
+      expect(queryByTestId("umode-modal")).not.toBeNull();
+    });
+  });
+
   it("renders only the server-advertised umodes when the server sent a set (#249)", () => {
     // The server advertised only +i (invisible) and +x (masked host); the
     // modal renders exactly those, NOT the full static table.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48239,3 +48239,165 @@ _Deploy: **HOT** on all three substrates — measured via
 `Preflight.classify_paths/2` over the changed paths: `{:hot, []}` for `:docker`,
 `:jail` and `:linux`. Positive control: `VERSION` answers
 `{:cold, [version: ["VERSION"]]}` on jail and linux._
+<!-- entry #1982 -->
+
+---
+
+## 2026-09-07 — #1982: the same tap, and the other three scrims
+
+A user on a Samsung phone reported that a bare `/notify` sent with the compose
+SEND BUTTON clears the draft and opens nothing, while the same verb sent with
+the keyboard's Enter opens the settings drawer as designed. That is issue 1831,
+again, on an overlay 1831 did not reach.
+
+### What was measured, and it is the whole point of the slice
+
+The mechanism was already established and is not re-litigated here: a command
+that reaches its opener with no `await` ahead of it mounts a full-region scrim
+while the finger is still down; a touch's compat mouse events are synthesised
+after the touch ends and hit-tested against the layout as it stands THEN, so
+the click lands on the scrim and a dismiss-on-any-click fires inside the
+gesture that opened the overlay. `lib/backdropDismiss.ts` carries that
+reasoning and the cure.
+
+What had never been written down is the SET. Grepping every overlay opener
+referenced from `lib/commands/` and `lib/compose.ts` closes it at five:
+
+| opener | overlay | state before this entry |
+|---|---|---|
+| `openBanlistModal` | BanlistModal | cured by #1831 |
+| `openModeModal` | ModeModal | cured by #1831 |
+| `openUmodeModal` | UmodeModal | **defective** |
+| `openServiceModal` | ServiceModal | **defective** |
+| `requestOpenSettings` | SettingsDrawer | **defective** — reported as #1982 |
+
+#1831 cured two of five. The remaining three carried the identical defect for
+anyone who tapped instead of pressing Enter, and #1982 is simply the first of
+them a user happened to hit. All three are confirmed synchronous: `openSettings
+Command` and `umodeViewCommand` call their opener as the first statement, and
+`serviceModalCommand` opens FIRST and awaits `sendBodyLines` after — an
+ordering #1518 pinned as load-bearing, so that one cannot be defused by moving
+the await instead.
+
+The drawer differs from the four modals in one respect worth recording: it is
+the only site reached through a signal rather than an `open*Modal`. The verb
+bumps `settingsOpenTick`, Shell's effect runs `setSettingsOpen(true)` in the
+same turn, and `.settings-drawer-backdrop.open` takes `pointer-events: auto`
+with NO transition of its own (`themes/default.css`) while the opacity fade is
+200 ms. So the drawer opened and closed without ever painting — which is
+exactly the reported "nothing happens", and is why no overlay appeared in the
+reporter's frame-by-frame.
+
+### Why the cure is #1831's helper, and not either candidate in the issue body
+
+The issue proposed widening the send button's #925 click swallow to a
+document-level one-shot capture listener, or holding a freshly-opened
+backdrop's `pointer-events` off until its transition starts. Both were
+declined, and the reasons are not stylistic.
+
+The document-level swallow deletes nothing; it moves the orphan click's victim.
+It also defends only overlays opened by that ONE button, when the property
+wanted is about the scrim: an overlay that appears under a finger mid-gesture
+must not be dismissed by that gesture, whoever opened it. The `pointer-events`
+delay is worse on its own terms — it makes correctness depend on a transition
+race, and #1059 already ruled on precisely that shape for the twin problem on
+the button ("deferring the guard by a frame makes the guard timing-dependent,
+which is the shape of the bug, not of its remedy"). A press-armed dismiss is
+structural: a backdrop that never received the pointerdown beginning the
+interaction cannot be dismissed by its click, whatever the timing.
+
+So the cure is three call sites of an existing helper and no new mechanism.
+That is also the honest reading of "fix the class, not the example": the class
+was already fixed once, and what #1982 exposes is a migration that stopped at
+two of five.
+
+### The oracle
+
+Unit, on the three components' own suites — the two arms that encode the cure
+fail before it, the arm that encodes the PRESERVED dismiss passes on both
+sides, which is what makes the red discriminating rather than merely red:
+
+| tree | `SettingsDrawer` + `UmodeModal` + `ServiceModal` |
+|---|---|
+| pre-cure | 6 failed / 139 passed, rc 1 |
+| cured | 145 passed / 0 failed, rc 0 |
+
+`SettingsDrawer.test.tsx` had a case named "backdrop click fires onClose" that
+asserted a BARE click dismisses. That is the defect written down as a
+requirement — the exact click a press-armed dismiss must ignore. It was
+replaced by the press-armed trio, not deleted: the dismiss itself must keep
+working, and two of the three new cases exist to prove it does.
+
+`e2e/tests/issue1982-tap-send-overlay-survives.spec.ts` puts the platform half
+of the question to an engine, `@touch` and only `@touch`: `chromium-pixel-touch`
+is the sole project whose `tap()` produces the compat mouse events a real tap
+produces, and a `@webkit` twin would pass without touching the defect. Two
+verbs through two parsers onto two sub-pages — `/notify` (as reported) and
+`/alias`, which is not in the watch family and is parsed by `parseAlias` — each
+with an Enter control alongside its tap, because one verb would only have shown
+that one string had been patched. Against the pre-cure tree both taps fail and
+both Enters pass (2 failed / 2 passed, rc 1); with the cure the four are green.
+
+### The false green that had to be thrown away
+
+The first draft of that spec used `/umode` → UmodeModal as its second arm,
+which would have been the stronger claim: a different command module, a
+different opener, a different scrim. It PASSED against the pre-cure tree — an
+arm that cannot fail, which is worth less than no arm at all. A document-level
+capture probe on that same tree says why, and the reason is geometry rather
+than mechanism:
+
+    /notify   pointerdown -> polygon                          (the send glyph)
+              click       -> div.settings-drawer-backdrop.open
+              drawer.open=0        the defect, on an engine
+
+    /umode    pointerdown -> polygon
+              click       -> div.mode-modal-body              (the DIALOG)
+              umode-modal=1        survives
+
+On a Pixel 7 the umode toggle list is tall enough that the centred dialog
+covers the point the send button occupied, so the synthesised click never
+reaches a scrim: the dialog's own `stopPropagation` eats it first. UmodeModal
+is still defective by construction — its scrim dismissed on a bare click, and a
+network advertising few umodes yields a short dialog that leaves the scrim
+exposed — but that is not reproducible at this viewport, and the arm was
+deleted rather than kept as decoration. The probe output is quoted in the spec
+header so the next reader does not spend a stack cycle rediscovering it.
+
+Worth stating plainly because it nearly shipped: the arm was green, on the
+right project, exercising the right verb, against code that still had the bug.
+Only running it against the MUTANT exposed it. A spec that has never been shown
+to fail has not been shown to test anything.
+
+### What this does not claim
+
+Only ONE of the three cured sites has engine evidence. SettingsDrawer was
+measured red-then-green on `chromium-pixel-touch`; UmodeModal cannot be
+reproduced at that viewport (above) and ServiceModal cannot be driven there at
+all, since a bare `/ns` needs services this testnet does not run. Both are
+cured on the strength of being the same construction — a scrim dismissing on a
+bare click, reached synchronously from the compose line — and both carry unit
+arms, but neither has been shown to fail on an engine. Curing them anyway is a
+deliberate call: leaving two of five uncured is precisely the half-migration
+that produced this issue eight months after #1831.
+
+The engine is Blink with `isMobile` + `hasTouch`. The reported device runs
+Chrome, the same engine family — a closer match than #1831 had, whose report
+was Android Firefox — but this is still not "Android coverage".
+
+The eighteen other backdrops in cic are out of scope and are NOT asserted safe
+by omission. The argument for leaving them is that an overlay opened from an
+`onClick` handler activates AT the click, so no orphan click exists to be
+retargeted; that argument is reasoning, not measurement. The context menu is
+the one adjacent case where it was not even attempted: it opens from
+`contextmenu` (long-press), a gesture whose trailing-click behaviour was not
+measured here.
+
+The keyboard staying up over the opened drawer was reported in the same session
+and is split out as issue 1983; nothing here addresses it.
+
+_Deploy: cic bundle only — every changed source file is under `cicchetto/`,
+plus this entry. `Preflight.classify_paths/2` was deliberately NOT run: it
+needs the shared `_build` and the COMPILE lane was held by another worker, and
+a classification quoted without running it would be a guess wearing a
+measurement's clothes._


### PR DESCRIPTION
Addresses issue 1982.

On Android a bare watch-family verb sent with the compose **send button**
cleared the draft and opened nothing; the same verb sent with **Enter** opened
the settings drawer as designed.

## What it actually is

Not a new bug — **issue 1831, unfinished.** The cure already exists
(`cicchetto/src/lib/backdropDismiss.ts`, "dismiss armed by the PRESS, not by
the click") and 1831 applied it to two overlays out of five.

Grepping every opener referenced from `lib/commands/` and `lib/compose.ts`
closes the compose-reachable set:

| opener | overlay | before |
|---|---|---|
| `openBanlistModal` | BanlistModal | cured by 1831 |
| `openModeModal` | ModeModal | cured by 1831 |
| `openUmodeModal` | UmodeModal | **defective** |
| `openServiceModal` | ServiceModal | **defective** |
| `requestOpenSettings` | SettingsDrawer | **defective** — the report |

All three confirmed synchronous. `serviceModalCommand` opens FIRST and awaits
`sendBodyLines` after — an ordering #1518 pinned as load-bearing, so it cannot
be defused by moving the await.

The drawer is the only site reached through a signal rather than an
`open*Modal`, and `.settings-drawer-backdrop.open` takes `pointer-events: auto`
with **no transition** while the opacity fade is 200 ms — so it opened and
closed without ever painting. That is precisely the reporter's "nothing
happens".

## Why this cure and not the two the issue proposed

Both declined. A document-level click swallow on the send button deletes
nothing — it moves the orphan click's victim — and defends only overlays opened
by that one button, when the property wanted belongs to the scrim. Holding the
backdrop's `pointer-events` off until its transition starts makes correctness
depend on a race, which #1059 already ruled is "the shape of the bug, not of
its remedy". A press-armed dismiss is structural.

Result: three call sites of an existing helper, no new mechanism.

## Oracle

**Unit** (the three components' suites): **6 failed / 139 passed, rc 1**
pre-cure → **145 passed / 0 failed, rc 0** cured. The arm encoding the
*preserved* dismiss passes on both sides, which is what makes the red
discriminating.

**e2e**, `@touch` only (`chromium-pixel-touch` is the sole project whose
`tap()` produces the compat mouse events a real tap produces; a `@webkit` twin
would pass without touching the defect):

| tree | result |
|---|---|
| pre-cure | 2 failed (both TAP arms) / 2 passed (both ENTER controls), rc 1 |
| cured | 4 passed |

**Full `integration.sh` on the cured head: 947 passed, 2 failed, 1 skipped
(37.8 m).** The two reds are `issue1807-credits-rain` and `issue248-lusers`:
zero file overlap with this branch, iso-rerun of exactly those two gave
**2 passed, rc 0**, and neither touches a scrim.

Positive control worth naming: **six existing specs (10 tests) dismiss an
overlay by clicking its backdrop, and all ten stayed green** — Playwright's
`.click()` carries its own `pointerdown`, so the press-armed dismiss still
fires. `issue232-modal-esc` covers `.mode-modal-backdrop` directly.

## A false green that was thrown away

The spec's second arm was originally `/umode` → UmodeModal, the stronger claim.
**It passed against the pre-cure tree.** A document-level capture probe says
why, and it is geometry rather than mechanism:

```
/notify   click -> div.settings-drawer-backdrop.open    drawer.open=0    RED
/umode    click -> div.mode-modal-body                  umode-modal=1    green
```

On a Pixel 7 the umode toggle list is tall enough that the centred dialog
covers the send button's position, and its own `stopPropagation` eats the click
before any scrim sees it. The arm was deleted and the probe output quoted in
the spec header. The second verb is now `/alias` — different parser, different
sub-page, and it does fail pre-cure.

## What this does not claim

- Engine evidence covers **one** of the three cured sites. UmodeModal is not
  reproducible at that viewport (above); ServiceModal cannot be driven at all
  (`/ns` needs services this testnet does not run). Both are cured on being the
  same construction, with unit arms only.
- The engine is Blink with `isMobile` + `hasTouch`. The reported device runs
  Chrome — same family, closer than 1831 had — but this is not Android coverage.
- The other eighteen backdrops are argued safe (an overlay opened from an
  `onClick` activates AT the click, so no orphan exists), not measured safe. The
  context menu's long-press was not measured at all.
- `Preflight.classify_paths/2` was not run: it needs the shared `_build` and the
  COMPILE lane was held elsewhere. Every changed source file is under
  `cicchetto/`.
- The keyboard staying up over the opened drawer is split out as issue 1983 and
  is untouched here.