### PR TITLE
fix(1988): tag every CTCP reply with its origin, the arity apply_effects takes

### DIFF
--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -3218,7 +3218,7 @@ defmodule Grappa.Session.EventRouter do
         sender_meta(msg)
       )
 
-    {:cont, state2, [{:reply, reply}, persist_eff]}
+    {:cont, state2, [{:reply, reply, :event_router_reply}, persist_eff]}
   end
 
   # M3a — KVIrc-era CTCP AVATAR: unlike USERINFO, an UNSET avatar gets
@@ -3257,7 +3257,7 @@ defmodule Grappa.Session.EventRouter do
         sender_meta(msg)
       )
 
-    {:cont, state2, [{:reply, reply}, persist_eff]}
+    {:cont, state2, [{:reply, reply, :event_router_reply}, persist_eff]}
   end
 
   # Composes the KVIrc-shaped `Age=…; Gender=…; Location=…; Languages=…;
@@ -3469,7 +3469,7 @@ defmodule Grappa.Session.EventRouter do
       :ok ->
         existing = Map.get(cache, nick_key, %{})
         new_cache = Map.put(cache, nick_key, Map.put(existing, :gender, nil))
-        {%{state | peer_profile_cache: new_cache}, [{:reply, "PRIVMSG #{nick} :\x01USERINFO\x01"}]}
+        {%{state | peer_profile_cache: new_cache}, [{:reply, "PRIVMSG #{nick} :\x01USERINFO\x01", :event_router_reply}]}
 
       {:error, :rate_limited} ->
         {state, []}
@@ -3514,7 +3514,7 @@ defmodule Grappa.Session.EventRouter do
       :ok ->
         existing = Map.get(cache, nick_key, %{})
         new_cache = Map.put(cache, nick_key, Map.put(existing, :avatar_slug, nil))
-        {%{state | peer_profile_cache: new_cache}, [{:reply, "PRIVMSG #{nick} :\x01AVATAR\x01"}]}
+        {%{state | peer_profile_cache: new_cache}, [{:reply, "PRIVMSG #{nick} :\x01AVATAR\x01", :event_router_reply}]}
 
       {:error, :rate_limited} ->
         {state, []}

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -590,7 +590,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "USERINFO", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, _, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, _, [{:reply, line, :event_router_reply}, {:persist, :notice, attrs}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) ==
@@ -603,6 +603,32 @@ defmodule Grappa.Session.EventRouterTest do
                "CTCP USERINFO query → Age=30; Gender=X; Location=Italy; Languages=it, en; here for the vibes"
     end
 
+    # #1988 — every CTCP path emitted a 2-tuple `{:reply, line}` while
+    # `Session.Server.apply_effects/2` has had a single 3-arity `:reply`
+    # clause since #1390 slice 6. The router tests asserted the 2-tuple, so
+    # CI stayed green while an inbound CTCP USERINFO/AVATAR from ANY nick
+    # killed the victim's session GenServer with a `function_clause` and
+    # dropped their socket. Pin the arity here, at the producer, for every
+    # CTCP path at once: a `:reply` effect that is not `{:reply, line,
+    # origin}` is not routable, whatever it says.
+    test "every CTCP reply effect carries an origin (#1988 — apply_effects takes only the 3-tuple)" do
+      state =
+        base_state(%{
+          avatar_url: "https://grappa.example/uploads/abc123.png",
+          profile: %{age: 30, gender: :nonbinary, location: "Italy", languages: "it, en", custom: nil}
+        })
+
+      for ctcp <- ["USERINFO", "AVATAR"] do
+        m = msg(:privmsg, ["vjt", <<0x01>> <> ctcp <> <<0x01>>], {:nick, "alice", "u", "h"})
+        assert {:cont, _, effects} = EventRouter.route(m, state)
+
+        for effect <- effects, elem(effect, 0) == :reply do
+          assert {:reply, _line, origin} = effect
+          assert origin in [:event_router_reply, :ghost_recovery, :recover_identity]
+        end
+      end
+    end
+
     test "PRIVMSG carrying CTCP USERINFO query still replies (empty) when no profile is configured" do
       state =
         base_state(%{
@@ -612,7 +638,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "USERINFO", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, _, [{:reply, line}, {:persist, :notice, _}]} =
+      assert {:cont, _, [{:reply, line, :event_router_reply}, {:persist, :notice, _}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) == "NOTICE alice :\x01USERINFO \x01"
@@ -628,7 +654,7 @@ defmodule Grappa.Session.EventRouterTest do
         body = <<0x01, "USERINFO", 0x01>>
         m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-        assert {:cont, _, [{:reply, line}, _]} = EventRouter.route(m, state)
+        assert {:cont, _, [{:reply, line, :event_router_reply}, _]} = EventRouter.route(m, state)
         assert IO.iodata_to_binary(line) == "NOTICE alice :\x01USERINFO Gender=#{letter}\x01"
       end
     end
@@ -639,7 +665,7 @@ defmodule Grappa.Session.EventRouterTest do
       body = <<0x01, "AVATAR", 0x01>>
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
-      assert {:cont, _, [{:reply, line}, {:persist, :notice, attrs}]} =
+      assert {:cont, _, [{:reply, line, :event_router_reply}, {:persist, :notice, attrs}]} =
                EventRouter.route(m, state)
 
       assert IO.iodata_to_binary(line) ==
@@ -2277,10 +2303,10 @@ defmodule Grappa.Session.EventRouterTest do
 
       assert {:cont, new_state, effects} = EventRouter.route(m, state)
 
-      assert Enum.any?(effects, &match?({:reply, "PRIVMSG alice :\x01USERINFO\x01"}, &1))
+      assert Enum.any?(effects, &match?({:reply, "PRIVMSG alice :\x01USERINFO\x01", :event_router_reply}, &1))
       # M3b — the AVATAR query is a second, independent lazy query fired
       # alongside USERINFO for the same "first seen this session" nick.
-      assert Enum.any?(effects, &match?({:reply, "PRIVMSG alice :\x01AVATAR\x01"}, &1))
+      assert Enum.any?(effects, &match?({:reply, "PRIVMSG alice :\x01AVATAR\x01", :event_router_reply}, &1))
       # Marked eagerly so a second sighting this session never re-queries.
       assert new_state.peer_profile_cache == %{"alice" => %{gender: nil, avatar_slug: nil}}
     end
@@ -2290,7 +2316,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:join, ["#italia"], {:nick, "alice", "u", "h"})
 
       assert {:cont, new_state, effects} = EventRouter.route(m, state)
-      refute Enum.any?(effects, &match?({:reply, _}, &1))
+      refute Enum.any?(effects, &match?({:reply, _, _}, &1))
       assert new_state.peer_profile_cache == %{}
     end
 
@@ -2309,7 +2335,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:join, ["#italia"], {:nick, "alice", "u", "h"})
 
       assert {:cont, new_state, effects} = EventRouter.route(m, state)
-      refute Enum.any?(effects, &match?({:reply, _}, &1))
+      refute Enum.any?(effects, &match?({:reply, _, _}, &1))
       # Untouched — a real answer isn't clobbered by a re-trigger no-op.
       assert new_state.peer_profile_cache == %{"alice" => %{gender: :female, avatar_slug: "existingslug"}}
     end
@@ -2319,7 +2345,7 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:join, ["#italia"], {:nick, "vjt", "u", "h"})
 
       assert {:cont, new_state, effects} = EventRouter.route(m, state)
-      refute Enum.any?(effects, &match?({:reply, _}, &1))
+      refute Enum.any?(effects, &match?({:reply, _, _}, &1))
       assert new_state.peer_profile_cache == %{}
     end
   end


### PR DESCRIPTION
Closes #1988. Prod is down; this is the whole fix.

## The defect

`Session.Server.apply_effects/2` has had a single `:reply` clause since #1390 slice 6 (`71e4296af`, v1.3.0) and it matches the 3-tuple `{:reply, line, origin}` (`server.ex:6198`). Four CTCP producers still emitted the pre-#1390 2-tuple:

- `event_router.ex:3221` — CTCP USERINFO reply
- `event_router.ex:3260` — CTCP AVATAR reply
- `event_router.ex:3472` — USERINFO query toward a peer (`show_peer_profiles`)
- `event_router.ex:3517` — AVATAR query toward a peer (same opt-in)

An inbound `\x01USERINFO\x01` from **any** nick, with no opt-in on the victim's side, therefore raised `function_clause` in `apply_effects`, killed the session GenServer and dropped the socket. The ircd logged it as `Read/Dead Error: Input/output error`, which is why it read as a network fault. Reproduced three times in prod today; `runtime/log/erlang.log.8` 21:22:22 carries the trace.

Armed by `5db2c96ea` (29/8) so it is present in **v1.5.0, v1.5.1 and v1.5.2**. `:auto_reply` producers (VERSION, PING) were never affected — they carry their own arm.

## The fix

The four sites now emit `{:reply, line, :event_router_reply}`, the origin the `origin()` type already declares for router-built replies.

## Why CI was green

The router tests asserted the same 2-tuple, and nothing in the suite crossed the router-to-interpreter boundary. Assertions updated, plus one regression test that pins the arity for every CTCP path at once, so an uninterpretable `:reply` fails at the producer instead of in production.

`scripts/mix.sh --env=test test test/grappa/session/event_router_test.exs` gives 453 tests, 0 failures.
