### PR TITLE
test: name unused reply payload _ to satisfy credo --strict

### DIFF
--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -623,7 +623,7 @@ defmodule Grappa.Session.EventRouterTest do
         assert {:cont, _, effects} = EventRouter.route(m, state)
 
         for effect <- effects, elem(effect, 0) == :reply do
-          assert {:reply, _line, origin} = effect
+          assert {:reply, _, origin} = effect
           assert origin in [:event_router_reply, :ghost_recovery, :recover_identity]
         end
       end


### PR DESCRIPTION
`ci` on `main` is red after the 1.5.3 hotfix merge: run 34156667446, step **Credo (strict)**, single consistency issue —

```
[C] Unused variables should be named consistently. It seems your strategy is
    to name them anonymously (ie. `_`) but `_line` does not follow that convention.
    test/grappa/session/event_router_test.exs:626:27
```

Introduced by my own commit `9adc65ee3` (PR #1989). One-character fix: `_line` → `_`. No behaviour change, prod 1.5.3 is unaffected.
