### PR TITLE
test(issue 1988): cross the router -> interpreter boundary the cure did not

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48401,3 +48401,67 @@ plus this entry. `Preflight.classify_paths/2` was deliberately NOT run: it
 needs the shared `_build` and the COMPILE lane was held by another worker, and
 a classification quoted without running it would be a guess wearing a
 measurement's clothes._
+<!-- entry #1988b -->
+
+---
+
+## 2026-09-07 — #1988b: pinning an effect's shape at the producer does not prove the interpreter accepts it
+
+The #1988 P0 — an inbound `/ctcp <victim> USERINFO` killing the victim's session —
+is cured in `9adc65ee3` (v1.5.3). This entry is not about the defect. It is about
+why the defect survived a suite that already covered all four of its sites.
+
+`Session.Server.apply_effects/2` is the interpreter of the effect grammar
+`EventRouter` produces. It has one clause per effect shape and deliberately NO
+catch-all, so an out-of-grammar tuple is a `function_clause` crash rather than a
+silent drop. That is the right posture, and its price is that the grammar is
+checked at RUNTIME, only for the shapes some test actually drives.
+
+Every test that covered the four broken sites asserted the tuple that
+`EventRouter.route/2` RETURNS. Such a test type-checks the producer against
+itself and is green for any shape the producer is free to emit — including one
+no clause of the interpreter can match. The defect never lived in either module;
+it lived in the JUNCTION, and nothing in the suite crossed it. So a test that
+pins arity at the producer is worth having (it stops those four sites
+regressing) and it is structurally incapable of catching the class.
+
+`test/grappa/session/ctcp_reply_effect_test.exs` is the other half: it feeds a
+real line into a real `Session.Server` over a real socket and asserts the answer
+reached the wire. Two-sided against the shipped cure — intact: 4 tests, 0
+failures; the four sites reverted to the 2-tuple in a local tree: 4 tests, 4
+failures, every one `no function clause matching in
+Grappa.Session.Server.apply_effects/2`.
+
+### The assertion that is easy to get wrong
+
+It asserts the pid is the SAME pid, not merely that a session is alive.
+`Session.Server` is `:transient`, so a crash is followed immediately by a
+supervisor restart under a NEW pid re-registering the same key: a liveness check
+on a re-looked-up pid goes green milliseconds after the crash it exists to
+catch. The wire assertion carries the same weight from the other side — a dead
+session sends nothing, so `{:error, :tcp_closed}` on the waiter IS the crash,
+observed from outside the VM's supervision.
+
+### The rest of the class, measured
+
+The class is "a producer whose arity the single interpreter clause cannot
+match", and it was enumerated rather than grepped: parse every `apply_effects`
+clause head into `atom -> accepted arity` (34 atoms), then scan all 337 modules
+under `lib/` for balanced `{:atom, ...}` tuples. Comments and `@doc` heredocs
+must be stripped first — the first pass reported 12 hits and 8 were abbreviated
+tuples in prose, which read exactly like code. The answer over all of `lib/` is
+that the four cured sites were the only real ones; the remaining hits are
+documentation, plus `session_log.ex`'s `GenServer.cast(__MODULE__, {:persist,
+metadata})`, an unrelated protocol colliding on the atom alone.
+
+One test-side straggler is fixed here: `event_router_property_test.exs`'s
+`:reply` arm still carried the 2-tuple, so the file's own "Mirror the FULL
+union" contract was false. Measured before touching it: DEAD, not a latent red —
+`string(:ascii)` cannot generate the `\x01` of a CTCP body and
+`show_peer_profiles` is hardcoded false in all three state generators, so no
+`:reply` producer is reachable from that generator and the property suite was
+green either way. It would have begun flunking on its own `other ->` clause the
+day a generator turned that flag on.
+
+_Deploy: **test-only** — no production module, no migration, no `VERSION` bump,
+no cic bundle, no wire change._

--- a/test/grappa/session/ctcp_reply_effect_test.exs
+++ b/test/grappa/session/ctcp_reply_effect_test.exs
@@ -1,0 +1,205 @@
+defmodule Grappa.Session.CtcpReplyEffectTest do
+  @moduledoc """
+  Issue 1988 — the `:reply` effect JUNCTION between `Session.EventRouter`
+  (the producer) and `Session.Server.apply_effects/2` (the consumer).
+
+  `apply_effects/2` has exactly one `:reply` clause and it takes the
+  3-tuple `{:reply, line, origin}` the effect grammar declares (#1390
+  slice 6). Four producers still emitted the pre-#1390 2-tuple
+  `{:reply, line}`, and there is no catch-all `apply_effects` clause — so
+  each of them killed the session GenServer with `function_clause`. An
+  inbound `/ctcp <victim> USERINFO` from any user on the network was
+  enough, with no opt-in and no authentication on the victim's side.
+
+  ## Why these tests drive the real session and not `EventRouter.route/2`
+
+  `event_router_test.exs` already covered all four sites, and every one of
+  those tests passed while production died three times in one evening.
+  They assert the CONTENT of the tuple the producer returns, in isolation,
+  so they type-check the producer against itself: the defect lives in the
+  junction, where a shape the producer is free to emit meets a consumer
+  that cannot match it. A test that can stay green while the session dies
+  is a mirror, not a test.
+
+  So each test here feeds a real line into a real `Session.Server` over a
+  real TCP socket (`Grappa.IRCServer`, the in-process fake ircd — never a
+  `:gen_tcp` mock) and then asserts the two things the isolation tests
+  structurally cannot see:
+
+    * the answer actually reached the wire, and
+    * the session pid that was serving before the CTCP is the SAME pid,
+      still alive, afterwards.
+
+  The pid identity half matters as much as the liveness half: `Session.Server`
+  is `:transient`, so a crash is followed by a supervisor restart under a
+  NEW pid that re-registers the same key. `Process.alive?/1` on a
+  re-looked-up pid would therefore go green a few milliseconds after the
+  very crash it is meant to catch.
+
+  `async: false` because `Grappa.SessionRegistry`, `Grappa.SessionSupervisor`
+  and `Grappa.PubSub` are singletons — same reason as `server_test.exs`.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{IRCServer, Session}
+  alias Grappa.Networks.{Credentials, SessionPlan}
+
+  # The nick `credential_fixture/3` gives the session, and therefore the
+  # nick the fake ircd must welcome and a peer must address.
+  @nick "grappa-test"
+
+  # One budget for every wire wait in this file. The fake ircd is
+  # in-process over loopback; a second is three orders of magnitude of
+  # headroom, and spelling it once keeps the file from re-deciding it per
+  # call site the way #1397 found thirteen copies doing.
+  @wire_timeout 1_000
+
+  # A real 1x1 transparent PNG. `Credentials.set_avatar/3` runs the bytes
+  # through `Grappa.Uploads` and its fail-closed `MetadataStrip`, so a
+  # placeholder string would be rejected and the arrange step would fail
+  # for a reason that has nothing to do with what is under test.
+  @png Base.decode64!(
+         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+       )
+
+  describe "inbound CTCP queries survive the :reply effect junction (issue 1988)" do
+    test "an inbound CTCP USERINFO is answered and does NOT kill the session" do
+      # The reported P0, end to end: `/ctcp grappa-test USERINFO` from a
+      # stranger. No profile is configured, which is the weakest case for
+      # the victim and still a legitimate answer — an empty USERINFO
+      # string means "nothing configured", so a reply is emitted and the
+      # crash is reached.
+      {server, pid} = connected_session([])
+
+      IRCServer.feed(server, ":alice!u@h PRIVMSG #{@nick} :\x01USERINFO\x01\r\n")
+
+      assert {:ok, line} =
+               IRCServer.wait_for_line(
+                 server,
+                 &String.starts_with?(&1, "NOTICE alice :\x01USERINFO"),
+                 @wire_timeout
+               )
+
+      assert line =~ "USERINFO"
+      assert_same_session_alive(pid)
+    end
+
+    test "an inbound CTCP AVATAR is answered and does NOT kill the session" do
+      # The AVATAR arm only replies when an avatar is SET (an unset avatar
+      # is deliberately silent), so this test must arrange one or the
+      # producer returns `[]`, the junction is never reached, and the test
+      # goes green for the wrong reason. Measured while writing it: seeding
+      # the plan with `:restored_avatar_url` does NOT work, because
+      # `Session.Server.init/1` re-resolves the plan through the injected
+      # `refresh_plan` closure and merges the FRESH plan OVER the opts —
+      # the DB wins, and the DB said nil. So the avatar is set the way
+      # production sets it, on the credential, before the plan is resolved.
+      {server, pid} = connected_session(avatar: true)
+
+      IRCServer.feed(server, ":alice!u@h PRIVMSG #{@nick} :\x01AVATAR\x01\r\n")
+
+      assert {:ok, line} =
+               IRCServer.wait_for_line(
+                 server,
+                 &String.starts_with?(&1, "NOTICE alice :\x01AVATAR"),
+                 @wire_timeout
+               )
+
+      assert line =~ "/uploads/"
+      assert_same_session_alive(pid)
+    end
+  end
+
+  describe "outbound peer-profile queries survive the same junction (issue 1988)" do
+    test "the outbound peer USERINFO query does NOT kill the session" do
+      # The `show_peer_profiles` opt-in half. A peer JOINing a channel we
+      # are in is the "first seen this session" moment that fires the lazy
+      # CTCP query — so this path needs no inbound CTCP at all, and a
+      # victim who never receives one is still exposed by it.
+      {server, pid} = connected_session(show_peer_profiles: true)
+
+      IRCServer.feed(server, ":alice!u@h JOIN #grappa\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(String.trim_trailing(&1) == "PRIVMSG alice :\x01USERINFO\x01"),
+                 @wire_timeout
+               )
+
+      assert_same_session_alive(pid)
+    end
+
+    test "the outbound peer AVATAR query does NOT kill the session" do
+      # Sibling of the above: `maybe_query_peer_profile/2` fires BOTH
+      # halves off the same JOIN, and each half emitted its own 2-tuple.
+      # Asserted separately so a regression in one is not masked by the
+      # other still being on the wire.
+      {server, pid} = connected_session(show_peer_profiles: true)
+
+      IRCServer.feed(server, ":alice!u@h JOIN #grappa\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(String.trim_trailing(&1) == "PRIVMSG alice :\x01AVATAR\x01"),
+                 @wire_timeout
+               )
+
+      assert_same_session_alive(pid)
+    end
+  end
+
+  # Boots a registered session against a fresh fake ircd and returns
+  # `{server, pid}`.
+  #
+  #   * `:avatar` — set a real avatar on the credential first, through
+  #     `Credentials.set_avatar/3` (a real `Grappa.Uploads` row on the
+  #     test storage root), so the resolved plan carries a real URL.
+  #   * `:show_peer_profiles` — the M2 opt-in. Injected as a plan key
+  #     rather than a `user_settings` row because `Session.start_session/3`
+  #     reads it with `Map.put_new_lazy/3` precisely so a caller can
+  #     supply it, and unlike `:restored_avatar_url` it is NOT a plan key
+  #     the `refresh_plan` re-resolve overwrites.
+  defp connected_session(opts) do
+    {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", @nick))
+
+    user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+
+    {network, _} =
+      network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")
+
+    _ = credential_fixture(user, network, %{})
+
+    if Keyword.get(opts, :avatar, false) do
+      {:ok, _} = Credentials.set_avatar(Credentials.get_credential!(user, network), @png, "image/png")
+    end
+
+    {:ok, resolved} = SessionPlan.resolve(Credentials.get_credential!(user, network))
+
+    plan =
+      case Keyword.fetch(opts, :show_peer_profiles) do
+        {:ok, value} -> Map.put(resolved, :show_peer_profiles, value)
+        :error -> resolved
+      end
+
+    subject = {:user, user.id}
+
+    {:ok, pid} = Session.start_session(subject, network.id, plan)
+
+    on_exit(fn -> Session.stop_session(subject, network.id) end)
+
+    :ok = IRCServer.await_handshake(server, @wire_timeout)
+
+    {server, pid}
+  end
+
+  # The session that answered must be the session that was asked. See the
+  # moduledoc: a `:transient` child is restarted under a new pid, so
+  # liveness alone is not evidence that nothing crashed.
+  defp assert_same_session_alive(pid) do
+    assert Process.alive?(pid)
+  end
+end

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -105,10 +105,23 @@ defmodule Grappa.Session.EventRouterPropertyTest do
           assert is_integer(attrs.server_time)
           assert is_map(attrs.meta)
 
-        {:reply, line} ->
+        {:reply, line, origin} ->
           # iodata is binary | improper-list-of-bytes; we accept any
           # binary as the lowest-cost shape check.
           assert is_binary(IO.iodata_to_binary(line))
+          # issue 1988 — this arm still carried the pre-#1390 2-tuple after
+          # the interpreter had moved to `{:reply, iodata(), origin()}`, so it
+          # said something false about the grammar it exists to mirror (see
+          # the "Mirror the FULL union" note below). Measured before changing
+          # it: DEAD, not a live red — `string(:ascii)` cannot produce the
+          # `\x01` of a CTCP body, and `show_peer_profiles` is hardcoded false
+          # in all three state generators, so neither producer of a `:reply`
+          # is reachable from here and the suite was green either way. It
+          # would have started flunking on the `other ->` clause the day a
+          # generator turned that flag on. The tag is asserted against the
+          # CLOSED `origin()` set for the same reason the #279 and #878 arms
+          # assert a class: `is_atom/1` would certify nothing.
+          assert origin in [:event_router_reply, :ghost_recovery, :recover_identity]
 
         {:topic_changed, channel, entry} ->
           assert is_binary(channel)


### PR DESCRIPTION
Test-only. The P0 in issue 1988 is already cured upstream by `9adc65ee3`
(v1.5.3, in production). **This PR touches nothing under `lib/`** and does not
re-propose, re-litigate or "improve" that cure.

No closing keyword anywhere: issue 1988 is already closed, and I am not
reopening-and-reclosing it.

## Why a test lands after the fix

The cure's own commit message says it: *"nothing in the suite crossed the
router->interpreter boundary"*.

`Session.Server.apply_effects/2` is the interpreter of the effect grammar
`EventRouter` produces. It has one clause per shape and deliberately no
catch-all, so an out-of-grammar tuple is a `function_clause` crash. That is the
right posture; its price is that the grammar is enforced at runtime, only for
shapes some test actually drives.

All four broken sites were already covered. Every one of those tests asserted
the tuple `EventRouter.route/2` **returns** — i.e. they pin arity at the
PRODUCER and type-check it against itself. They stay green for any shape the
producer is free to emit, including one no clause of the interpreter can match.
The defect lived in neither module. It lived in the junction, and that is how
four green tests sat over a P0 that killed sessions in production.

The two are complementary, not duplicates:

* the producer-side pin (shipped with the cure) stops **those four sites**
  regressing;
* this one stops the **class** returning from a fifth producer, because it fails
  whenever the session actually dies.

## What the test does

Each of the four paths — inbound CTCP USERINFO, inbound CTCP AVATAR, and the two
outbound `show_peer_profiles` peer queries — is driven through a real
`Session.Server` over a real socket with `Grappa.IRCServer`, never a `:gen_tcp`
mock. Two assertions an isolation test structurally cannot make:

1. the answer **reached the wire**;
2. the pid serving before the CTCP is the **same pid** after it.

**Same-pid is load-bearing, not decoration.** `Session.Server` is `:transient`,
so a crash is followed immediately by a supervisor restart under a NEW pid that
re-registers the same key. A liveness check on a re-looked-up pid therefore goes
green milliseconds after the very crash it exists to catch. The wire assertion
carries the same weight from the other side: a dead session sends nothing, so
`{:error, :tcp_closed}` on the waiter *is* the crash, observed from outside the
VM's supervision.

## Two-sided measurement, against the SHIPPED cure

Not against my own — I had written a fix before vjt's landed, and it is
discarded. Both runs are against `origin/main`:

**Positive** — cure intact:

```
4 tests, 0 failures      rc=0
function_clause on apply_effects: 0
```

**Negative** — the four sites reverted to the 2-tuple in a local, uncommitted
tree, then restored:

```
4 tests, 4 failures      rc=2
function_clause on apply_effects/2: 4
all four waiters: {:error, :tcp_closed}
```

```
** (FunctionClauseError) no function clause matching in
   Grappa.Session.Server.apply_effects/2
   (grappa) lib/grappa/session/server.ex:5468
   ... Grappa.Session.Server.delegate/2
```

A green without that expected red would not show the test is looking at
anything.

## Second change: a dead arm that misstated the grammar

`event_router_property_test.exs`'s `:reply` arm still carried the pre-#1390
2-tuple, making the file's own *"Mirror the FULL union"* contract false.

Measured before touching it, and the finding is **smaller** than it first
looked: the arm is **DEAD, not a latent red**. `string(:ascii)` cannot generate
the `\x01` of a CTCP body, and `show_peer_profiles` is hardcoded `false` in all
three state generators, so no `:reply` producer is reachable from that
generator — the property suite is green either way (10 properties, 0 failures).
It would have begun flunking on its own `other ->` clause the day a generator
turned that flag on.

## The class, enumerated rather than grepped

Parse every `apply_effects` clause head into `atom -> accepted arity` (34
atoms), then scan all 337 modules under `lib/` for balanced `{:atom, ...}`
tuples and report every arity the interpreter cannot accept. Comments and
`@doc`/`@moduledoc` heredocs must be stripped first — the first pass reported 12
hits and 8 were abbreviated tuples in prose, which read exactly like code.

**No fifth site.** The four cured ones were the only real mismatches in `lib/`.
The residue is documentation, plus `session_log.ex`'s
`GenServer.cast(__MODULE__, {:persist, metadata})` — an unrelated protocol
colliding on the atom alone, matched by its own `handle_cast` one line below.

## Gates

| gate | result |
| --- | --- |
| `mix compile --warnings-as-errors` | green |
| `mix format --check-formatted` | green |
| `mix credo --strict` | green |
| `deps.audit` / `sobelow` / `doctor` | green |
| `mix test` | 8 doctests, 65 properties, **7164 tests, 1 failure** — see below |
| `mix dialyzer` | `Total errors: 0` |
| `mix docs` | green |
| `mix grappa.wire_pin --check` | `wire shape and protocol 13 agree` |
| `design-notes-gate.sh` | `1 new entry heading(s), separator and marker present` |

`protocol_version` is untouched and the pin agrees: this PR adds no wire shape.

## 🔴 The one failure is pre-existing on `main`, and I could not clear it

`Grappa.Repo.LockWatchTest` — *"a writer the seam DOES know is counted as such,
not as an unseen one"* (`test/grappa/repo/lock_watch_test.exs:536`) —
`ExUnit.TimeoutError` after 60000 ms.

Attribution, measured rather than assumed:

* reproduces **in isolation** on this branch (38 tests, 1 failure), so it is not
  an artefact of full-suite load, and my one `async: false` file is not shifting
  it;
* reproduces **on a pristine `origin/main` tree** with `git status --porcelain`
  empty, my three files parked outside the worktree.

So it is not this branch's. It is in the #1420/#1715 write-lock timing area,
which this PR does not touch: the module carries `@moduletag timeout: 60_000`
while the writers it starts block on real SQLite lock waits. I am flagging it
rather than fixing it — it is a separate slice and not mine to scope.

## What I did NOT verify

* I did not read the four cured sites' behaviour on production, only in tests.
* I did not measure whether this failure also occurs in CI or is specific to
  this host.
* I did not review PR #1984, which touches the same two files; the rebase
  interaction is a guess, not a measurement.
* The class scan covers `lib/` only — not `test/`, not `scripts/`.
