### PR TITLE
test(issue 1767): quarantine the LockWatch flake, and say what it costs

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48609,3 +48609,95 @@ v10/v11 shape (REST endpoints sit outside the generated schema), but the 422
 moved, `ErrorTokensDriftTest` went red, and this paragraph had already
 written the bump off before either spoke. `min_protocol_version` stays 1:
 no pre-v14 bundle knows `/ignore`, so none can earn the token._
+<!-- entry #1767c -->
+
+---
+
+## 2026-09-07 — #1767c: the LockWatch flake is quarantined at MODULE scope, and that is a real hole
+
+`test/grappa/repo/lock_watch_test.exs` is excluded from CI by default. vjt's
+ruling on issue 1767, 2026-09-07: *"se abbiamo un flake test disattiviamo e
+apriamo issue per fixarlo"*. **Issue 1767 stays OPEN** — it is where the cure
+will be built. This entry records the quarantine, which is the immediate action
+and explicitly not the diagnosis.
+
+The trigger, from the orchestrator's sightings register (`.orchestrate/
+flake-1767-lockwatch-sightings.md`, kept on the Pi — read by them, not by me,
+so it is attributed and not claimed): six reds in forty minutes on one evening,
+five distinct carriers inside this module plus one in `JoinSeedCostTest`; one
+carrier reproduced in isolation at 38 tests against a clean `origin/main`; one
+test green and red on the SAME sha.
+
+### Where the exclusion lives, and why it cannot live in `config/test.exs`
+
+The tag is `@moduletag :flaky` on the test module; the exclusion is
+`ExUnit.start(capture_log: true, exclude: [:flaky])` in
+`test/test_helper.exs`. That placement is not a preference. The same file
+already documents the incident that settles it: **`ExUnit.start/1` opts
+override `config :ex_unit` SILENTLY**, and on 2026-05-13 the CP25
+shared-singleton fix shipped INERT for ~12 hours because a `max_cases: 2` in
+`ExUnit.start/1` quietly beat the `max_cases: 1` in the config. An exclusion
+written config-side would have been the next thing to ship inert, and it would
+have looked exactly like a working one.
+
+Getting back in is `scripts/test.sh --include flaky <path>`. Mix configures the
+CLI `--include` before requiring `test_helper.exs`, and `:include` is a
+different key from the `:exclude` set here, so the `ExUnit.start/1` call does
+not clobber it — measured below rather than reasoned about, since reasoning is
+what produced the twelve inert hours.
+
+### The four measurements
+
+All on this branch, in the container, `scripts/test.sh`:
+
+* **Module size / baseline.** Unmodified tree: `38 tests, 0 failures` in 11.5s.
+  Green on that run — the flake is intermittent by construction, which is why a
+  single green proves nothing and is not offered as proof of anything.
+* **NEGATIVE.** Default run of the file: header `Excluding tags: [:flaky]`,
+  then `0 tests, 0 failures (38 excluded)`. The exclusion is live and its reach
+  is exactly the 38.
+* **POSITIVE.** `--include flaky` on the same file: **38 tests actually ran**,
+  150.8s. `--include` beats the exclude. This run did more than count: it
+  reproduced the quarantined phenomenon — `1 failure`,
+  `lock_roles/0 names the same holders and waiters inspect_lock/0 does`,
+  `** (ExUnit.TimeoutError) test timed out after 60000ms`. Same class as the
+  register's sightings, on the first attempt after tagging.
+* **SUITE DELTA.** Full suite before: `8 doctests, 65 properties, 7164 tests,
+  0 failures` (155.3s). After: `8 doctests, 65 properties, 7126 tests, 0
+  failures (38 excluded)` (141.7s). 7164 − 7126 = **38**, exactly the module,
+  with the doctest and property figures unmoved. Nothing but this module left
+  CI. Both runs green, so the delta is a clean subtraction and not a red
+  cutting a run short.
+* **NON-COLLATERAL.** `git grep ':flaky' -- test/ config/` returned **0 hits**
+  before this change (positive control alongside: `@moduletag` in
+  `lock_watch_test.exs` = 1 hit, so the grep was alive). The tag has exactly one
+  carrier; a second one is a decision, not housekeeping.
+
+### 🔴 The price, stated rather than buried
+
+`@moduletag` quarantines the **whole module**, not the tests that actually
+flake. From here on **a GENUINE `LockWatch` regression lands unobserved in
+CI** — the holder/waiter attribution (#1420), the unattributed-queue arm
+(#1687), the NIF cohort (#1901), the closing bracket (#1888), the episode
+instant, the boot-time priming of the logger module cache (#1715), the barrier
+budget (#1747) and the filmer (#1767) all stop being defended. That is the cost
+the ruling accepts in exchange for not losing unrelated PRs a night to somebody
+else's flake, and it is a cost, not a claim that the module stopped mattering.
+
+Module scope rather than five per-test tags is deliberate for a second reason:
+the carrier set is not closed. Five carriers are known; pinning today's five
+would go stale on the sixth while reading, to anyone glancing at CI, like
+coverage.
+
+### What this entry does NOT claim
+
+* Not a diagnosis and not a cure. Nothing here explains the flake; #1767b's
+  measurements remain the state of the art and issue 1767 remains open.
+* Not that the phenomenon is confined to this module. `JoinSeedCostTest`
+  carried a red the same night per the register; it is deliberately NOT tagged
+  by this slice.
+* Not that `--include` is the only door back in — `--only flaky` was never
+  measured here.
+
+_Deploy: **test-only** — no production module, no migration, no `VERSION` bump,
+no cic bundle, no wire change._

--- a/test/grappa/repo/lock_watch_test.exs
+++ b/test/grappa/repo/lock_watch_test.exs
@@ -70,6 +70,26 @@ defmodule Grappa.Repo.LockWatchTest do
   @moduletag timeout: @test_timeout_ms
   @waiter_budget_ms @test_timeout_ms * 2
 
+  # 🔴 QUARANTINED, NOT FIXED (issue 1767, vjt's ruling 2026-09-07).
+  #
+  # Six reds in forty minutes on one evening, five distinct carriers in this
+  # file, one of them reproduced in isolation and one green and red on the SAME
+  # sha. The ruling is the standing one for a flake — take it out of CI and keep
+  # the issue open for the cure — so this tag is the immediate action and NOT
+  # the diagnosis. Excluded by default in `test/test_helper.exs`, which is where
+  # the exclusion has to live: `ExUnit.start/1` opts override `config :ex_unit`
+  # SILENTLY, and this repo already paid ~12 hours of an inert fix for that.
+  # Run it with `scripts/test.sh --include flaky <path>`.
+  #
+  # ⚠️ THE PRICE, stated because it is real: `@moduletag` quarantines the WHOLE
+  # module, not the tests that actually flake. Every claim in this file — the
+  # holder/waiter attribution, the NIF cohort, the closing bracket, the filmer —
+  # stops being defended in CI from here on, so a GENUINE `LockWatch` regression
+  # now lands unobserved. That is the cost the ruling accepts to stop six
+  # unrelated PRs a night dying on somebody else's flake; it is not a claim that
+  # the module is unimportant. Lifting the tag is part of closing issue 1767.
+  @moduletag :flaky
+
   # 🔴 THE BARRIER IS A THIRD CLOCK, AND IT HAS TO BE ORDERED TOO (#1747).
   #
   # `await_until/2` used to count 300 ATTEMPTS, which is not a budget in

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -15,7 +15,18 @@
 # overruns the `busy_timeout` window with cascading "Database busy"
 # errors. The `max_cases: 1` config solves both the singleton class AND
 # the sqlite-busy class with one knob.
-ExUnit.start(capture_log: true)
+#
+# `exclude: [:flaky]` is the quarantine door (issue 1767, vjt's ruling
+# 2026-09-07: a flake comes out of CI and the issue stays open for the cure).
+# It lives HERE and not in `config/test.exs` for the very reason documented
+# above — `ExUnit.start/1` wins over `config :ex_unit`, so a config-side
+# exclusion would be the next thing to ship inert. A tagged module still runs
+# on demand: `scripts/test.sh --include flaky <path>` (CLI `--include` is
+# configured before this file is required and is a different key, so it is not
+# clobbered by the line below). Today the tag has exactly one carrier,
+# `test/grappa/repo/lock_watch_test.exs`; adding a second one is a decision,
+# not housekeeping.
+ExUnit.start(capture_log: true, exclude: [:flaky])
 Ecto.Adapters.SQL.Sandbox.mode(Grappa.Repo, :manual)
 
 # #594 — the cross-process BusyRetry fault table, created ONCE here so it is


### PR DESCRIPTION
Quarantines the flaky `Grappa.Repo.LockWatchTest` so it stops taking
unrelated PRs down with it. **This is the immediate action, not the cure —
issue 1767 must stay OPEN**, it is where the fix will be built.

Per vjt's ruling on issue 1767 (2026-09-07): *"se abbiamo un flake test
disattiviamo e apriamo issue per fixarlo"*.

## What changed

- `test/grappa/repo/lock_watch_test.exs`: `@moduletag :flaky`.
- `test/test_helper.exs`: `ExUnit.start(capture_log: true, exclude: [:flaky])`.
- `docs/DESIGN_NOTES.md`: entry 1767c.

The exclusion lives in `ExUnit.start/1` and **not** in `config/test.exs`. That
is the load-bearing detail: `test_helper.exs` already documents a measured
incident where `ExUnit.start/1` opts silently overrode `config :ex_unit` and a
fix shipped inert for ~12 hours. A config-side exclusion would have been the
next thing to ship inert, and it would have looked exactly like a working one.

## Measurements (local, containerised, `scripts/test.sh`)

| control | result |
|---|---|
| NEGATIVE — default run of the file | `Excluding tags: [:flaky]` → `0 tests, 0 failures (38 excluded)` |
| POSITIVE — `--include flaky` on the same file | **38 tests actually ran** (150.8s) — the CLI flag beats the exclude |
| SUITE before | `8 doctests, 65 properties, 7164 tests, 0 failures` (155.3s) |
| SUITE after | `8 doctests, 65 properties, 7126 tests, 0 failures (38 excluded)` (141.7s) |
| DELTA | 7164 − 7126 = **38**, exactly the module; doctests and properties unmoved; both runs green |
| NON-COLLATERAL | `git grep ':flaky' -- test/ config/` = **0 hits** before this change (positive control: `@moduletag` in `lock_watch_test.exs` = 1 hit, so the grep was alive) |

The positive control did more than count: it reproduced the quarantined
phenomenon on the first attempt — `lock_roles/0 names the same holders and
waiters inspect_lock/0 does` died on `ExUnit.TimeoutError` after 60000ms.

Other local gates: `mix format --check-formatted` rc=0, `mix credo --strict`
rc=0 (no issues), `scripts/design-notes-gate.sh origin/main` rc=0
(*1 new entry heading, separator and marker present*).

## The price, stated rather than buried

`@moduletag` quarantines the **WHOLE module**, not just the tests that flake.
From here on **a genuine `LockWatch` regression lands unobserved in CI** — the
holder/waiter attribution, the unattributed-queue arm, the NIF cohort, the
closing bracket, the episode instant, the boot-time logger-cache priming, the
barrier budget and the filmer all stop being defended. That is the cost the
ruling accepts; it is written into both the tag comment and the DESIGN_NOTES
entry so nobody rediscovers it as a surprise.

Module scope rather than five per-test tags is deliberate: the carrier set is
not closed at five, and per-test tags would go stale on the sixth while reading
like coverage from the outside.

## Not claimed

- No diagnosis and no cure. Issue 1767 stays open.
- Not that the phenomenon is confined to this module — `JoinSeedCostTest`
  carried a red the same night per the orchestrator's sightings register, and
  is deliberately **not** tagged by this slice.
- `--only flaky` was never measured; only `--include`.

_Deploy: **test-only** — no production module, no migration, no `VERSION` bump,
no cic bundle, no wire change._
