### PR TITLE
cicchetto: a /credits verb, so the end titles are one verb deep (#1958)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Typed in cicchetto's compose box, parsed client-side, dispatched to REST or IRC.
 | `/notify <nick>…` · `/watch <nick>…` | Watch nicks for presence (online/offline dots + toasts); bare opens the **watch lists** settings section |
 | `/hilight <pattern>` · `/dehilight <pattern>` | Add / remove a highlight keyword (alias `/highlight`); bare opens the **watch lists** settings section |
 | `/alias <name> <expansion>` · `/unalias <name>` | Define / remove your own slash-command alias (`/alias wii whois $1 $1` → `/wii foo` runs `/whois foo foo`). `$1`..`$9` positional, `$N-` the Nth arg and everything after it (`/alias k kick $1 $2-`), `$*` all args; with no placeholder the rest is appended. Server-synced per user; builtins can't be shadowed. Bare `/alias` opens the **aliases** settings section, where existing aliases are also editable in place (rename + change expansion) |
+| `/credits` | Roll the end titles — the same modal as the **credits** entry at the bottom of the settings drawer, one verb deep instead of three taps |
 | `/connect <network>` | Unpark + respawn a network |
 | `/disconnect [network] [reason]` | Park one network (persists across reboots until `/connect`) |
 | `/reconnect [network] [reason]` | Bounce one network — park, then unpark, in that order (irssi's `RECONNECT`). The one-command form of `/disconnect` + `/connect`, and the way to re-roll a vhost (the source address is picked per connect). Bare form targets the active window's network; the reason travels as the upstream QUIT |

--- a/cicchetto/e2e/tests/issue1958-credits-verb.spec.ts
+++ b/cicchetto/e2e/tests/issue1958-credits-verb.spec.ts
@@ -1,0 +1,58 @@
+// #1958 — `/credits` opens the end titles one verb deep, instead of menu →
+// settings → scroll to the bottom of the drawer.
+//
+// The unit layer (slashCommands.test.ts, compose.test.ts) pins the parse and
+// the dispatch against a MOCKED `openCreditsModal`; what it cannot see is that
+// the signal the verb flips is the one the mounted modal listens to. This spec
+// drives the VISIBLE outcome against the real bundle: the verb, typed into the
+// compose box of a channel window, paints the same modal the drawer's
+// `credits` entry does — and the drawer entry itself still works afterwards
+// (the issue's second open question: the verb is a shortcut, not a
+// replacement).
+//
+// SCOPE. The roll's CONTENT (sha, date, contributors) is #1773's spec, not
+// this one's; here the title alone proves the modal is up. Subject-shape
+// agnostic (the verb resolves no network and puts nothing on the wire), so
+// registered vjt suffices — the same parity argument as #1773.
+
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  openSettingsDrawer,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("#1958 — /credits opens the end-titles modal, and the drawer entry still does too", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  const modal = page.getByTestId("credits-modal");
+  await expect(modal).toHaveCount(0);
+
+  // ── the verb ────────────────────────────────────────────────────────────
+  await composeSend(page, "/credits");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  // Text, never geometry: the roll is a CSS animation (see #1773).
+  await expect(page.getByTestId("credits-title")).toHaveText("GRAPPA IRC");
+  // A silent success: the draft is gone and nothing was printed as an error.
+  await expect(composeTextarea(page)).toHaveValue("");
+  await expect(page.locator(".compose-box-error")).toHaveCount(0);
+
+  await page.getByTestId("credits-close").click();
+  await expect(modal).toHaveCount(0);
+
+  // ── the drawer entry stays ──────────────────────────────────────────────
+  await openSettingsDrawer(page);
+  await page.getByTestId("credits-entry").click();
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("credits-title")).toHaveText("GRAPPA IRC");
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -139,6 +139,18 @@ vi.mock("../lib/aliasList", () => ({
 // sub-page. The real module just bumps a signal: nothing throws, so the arm
 // reported `{ok: true}` with no trace, which is a silent success no mutant
 // could reach. Mocked here so the requested SECTION becomes observable.
+// #1958 — /credits flips the credits modal's open signal. Same argument as
+// settingsNav above: the real module only bumps a signal, so the arm would
+// report `{ok: true}` with no trace. Mocked so the open becomes observable.
+vi.mock("../lib/creditsModal", () => ({
+  CREDITS_LABEL: "credits",
+  creditsModalOpen: vi.fn(() => false),
+  openCreditsModal: vi.fn(),
+  closeCreditsModal: vi.fn(),
+  creditsMuted: vi.fn(() => false),
+  toggleCreditsMuted: vi.fn(),
+}));
+
 vi.mock("../lib/settingsNav", () => ({
   requestOpenSettings: vi.fn(),
   requestSettingsPage: vi.fn(),
@@ -5080,6 +5092,25 @@ describe("compose submit — info verbs (TODO stubs)", () => {
   });
 });
 
+// #1958 — /credits is a UI deep-link like the bare watch-family verbs: it
+// opens the end-titles modal, prints nothing, touches no REST and no socket.
+describe("compose submit — /credits (#1958)", () => {
+  it("/credits opens the credits modal and clears the draft, silently", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const credits = await import("../lib/creditsModal");
+    const sb = await import("../lib/scrollback");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/credits");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(credits.openCreditsModal).toHaveBeenCalledTimes(1);
+    expect(sb.sendMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
+    expect(compose.getDraft(k)).toBe("");
+  });
+});
+
 // #356 — watch-family dispatch: keyword highlight (/hilight add, /dehilight
 // del, /highlight alias) + presence (/notify, /watch alias) as classic-IRC
 // irssi-direct verbs; a bare form opens the watch-lists settings section
@@ -5691,6 +5722,7 @@ const DISPATCH_CASE_LABELS = [
   "notify",
   "np",
   "op",
+  "open-credits",
   "open-settings",
   "oper",
   "part",
@@ -5812,6 +5844,7 @@ const DISPATCH_DRAFTS: ReadonlyArray<{ kind: SlashCommand["kind"]; draft: string
   { kind: "alias-define", draft: "/alias hi /msg bob $*" },
   { kind: "unalias", draft: "/unalias hi" },
   { kind: "open-settings", draft: "/watch" },
+  { kind: "open-credits", draft: "/credits" },
   { kind: "service-modal", draft: "/ns" },
   { kind: "error", draft: "/nosuchverb" },
 ];
@@ -5824,6 +5857,7 @@ const MOCKED_SEAM_MODULES = [
   "../lib/api",
   "../lib/banlistModal",
   "../lib/channelDirectory",
+  "../lib/creditsModal",
   "../lib/members",
   "../lib/mentionsWindow",
   "../lib/modeModal",
@@ -5907,12 +5941,12 @@ describe("#1396 — dispatch characterization over every arm", () => {
       misparsed,
     }).toMatchInlineSnapshot(`
       {
-        "arms": 63,
+        "arms": 64,
         "armsWithNoDraft": [],
         "draftsNamingNoArm": [],
         "duplicated": [],
         "misparsed": [],
-        "rows": 63,
+        "rows": 64,
       }
     `);
   });
@@ -6357,6 +6391,16 @@ describe("#1396 — dispatch characterization over every arm", () => {
             "ok": true,
           },
         },
+        "open-credits": {
+          "effects": [
+            "aliasList.aliases()",
+            "creditsModal.openCreditsModal()",
+            "networks.networkIdBySlug("freenode")",
+          ],
+          "result": {
+            "ok": true,
+          },
+        },
         "open-settings": {
           "effects": [
             "aliasList.aliases()",
@@ -6715,7 +6759,7 @@ describe("#1396 — dispatch characterization over every arm", () => {
           "aliasList.aliases()",
           "networks.networkIdBySlug("freenode")",
         ],
-        "arms": 63,
+        "arms": 64,
         "indistinguishablePairs": [
           [
             "ame",

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1184,6 +1184,24 @@ describe("parseSlash — keyword highlight (/hilight, /highlight alias, /dehilig
   });
 });
 
+// #1958 — /credits: the end titles, one verb deep. No arguments, no wire.
+describe("parseSlash — /credits (#1958)", () => {
+  it("bare /credits → open-credits", () => {
+    expect(parseSlash("/credits")).toEqual({ kind: "open-credits" });
+  });
+
+  it("trailing text is ignored, like the rest of the no-arg family", () => {
+    expect(parseSlash("/credits please")).toEqual({ kind: "open-credits" });
+    expect(parseSlash("/CREDITS")).toEqual({ kind: "open-credits" });
+  });
+
+  // The issue's first open question, answered: /credits is NOT on the
+  // non-shadowable deny list, so a user alias takes precedence over it.
+  it("a user alias may shadow /credits", () => {
+    expect(parseSlash("/credits", { credits: "np" })).toEqual({ kind: "np" });
+  });
+});
+
 describe("parseSlash — /lusers (P-0d, args #579)", () => {
   it("parses bare /lusers (no mask, no server)", () => {
     expect(parseSlash("/lusers")).toEqual({ kind: "lusers", mask: null, server: null });

--- a/cicchetto/src/lib/commands/local.ts
+++ b/cicchetto/src/lib/commands/local.ts
@@ -1,9 +1,10 @@
 import { addAlias, delAlias } from "../aliasList";
+import { openCreditsModal } from "../creditsModal";
 import { requestOpenSettings } from "../settingsNav";
 import type { CommandHandler } from "./context";
 
 /**
- * The arms that reach no network: two client-side stores, one UI deep-link,
+ * The arms that reach no network: two client-side stores, two UI deep-links,
  * and the parser's own failure arriving as a pseudo-verb. None of them resolves
  * a network id or puts a frame on the wire, which is why none of them reads
  * anything off the context record.
@@ -17,6 +18,18 @@ import type { CommandHandler } from "./context";
  */
 export const openSettingsCommand: CommandHandler<"open-settings"> = async (cmd) => {
   requestOpenSettings(cmd.section);
+  return { ok: true };
+};
+
+/**
+ * #1958 — `/credits` opens the end titles: the same `openCreditsModal` the
+ * settings drawer's last entry calls, one verb deep instead of menu → settings
+ * → scroll to the bottom. The drawer entry stays — the verb is a shortcut, the
+ * drawer is where people find the things they cannot name. Opening the modal
+ * IS the feedback, so this is a silent success.
+ */
+export const openCreditsCommand: CommandHandler<"open-credits"> = async () => {
+  openCreditsModal();
   return { ok: true };
 };
 

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -11,6 +11,7 @@ import { watchlistCommand } from "./commands/highlight";
 import {
   aliasDefineCommand,
   errorCommand,
+  openCreditsCommand,
   openSettingsCommand,
   unaliasCommand,
 } from "./commands/local";
@@ -1147,6 +1148,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         }
         case "open-settings": {
           result = await openSettingsCommand(cmd, ctx);
+          break;
+        }
+        case "open-credits": {
+          result = await openCreditsCommand(cmd, ctx);
           break;
         }
         case "quote": {

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -99,6 +99,10 @@ import { DEFAULT_CHANTYPES, isChannelName } from "./chantypes";
 // A bare form of any of them yields {kind: "open-settings"} (the unified
 // watch-lists section); compose.ts routes add/del over the existing
 // server round-trips and opens the settings drawer for the bare case.
+//
+// #1958 — `/credits` → {kind: "open-credits"}: the end-titles modal, the
+// same UI deep-link shape as the bare watch-family verbs (no network, no
+// wire). Shadowable by a user alias.
 
 export type SlashCommand =
   | { kind: "empty" }
@@ -239,6 +243,11 @@ export type SlashCommand =
   // bare-verb deep-links; it must stay assignable to settingsNav's
   // SettingsSubPage.
   | { kind: "open-settings"; section: "watchlists" | "aliases" | "ignores" }
+  // #1958 — a bare `/credits` opens the end titles: the same modal the
+  // settings drawer's last entry opens, one verb deep instead of three taps.
+  // It carries nothing — the modal is a module-singleton signal and the verb
+  // takes no arguments; trailing text is ignored, the no-arg family's posture.
+  | { kind: "open-credits" }
   // #385 — user-defined command aliases. `/alias <name> <expansion>` defines
   // one, `/unalias <name>` removes one. The define carries the parsed name +
   // expansion; compose.ts round-trips them through the aliasList store.
@@ -951,6 +960,12 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   hilight: (verb, rest) => parseHilight(verb, rest),
   dehilight: (verb, rest) => parseDehilight(verb, rest),
   highlight: (verb, rest) => parseHilight(verb, rest),
+
+  // #1958 — /credits: the end titles. A UI deep-link like a bare /hilight,
+  // resolving no network and putting nothing on the wire. Shadowable by a
+  // user alias like every verb but /alias + /unalias (Gabriele's ruling on
+  // the issue: nothing argues it must join the deny list).
+  credits: (_verb, _rest) => ({ kind: "open-credits" }),
 
   // Issue #20 — services shortcuts. Each one rewrites to a {kind: "msg"}
   // command targeting the canonical ServiceNick. Empty body → error (no

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48701,3 +48701,46 @@ coverage.
 
 _Deploy: **test-only** — no production module, no migration, no `VERSION` bump,
 no cic bundle, no wire change._
+<!-- entry #1958 -->
+
+---
+
+## 2026-09-07 — #1958: /credits, one verb deep
+
+The end titles (#1773) opened from exactly one place: the last entry of the
+settings drawer, three taps down — menu, settings, scroll to the bottom — for
+the one screen in cicchetto people stop to read. A `/credits` verb now opens
+the same modal from the compose box.
+
+### Shape: a UI deep-link, like a bare /hilight
+
+The parser gains `{kind: "open-credits"}`, carrying nothing: the modal is a
+module-singleton signal (`lib/creditsModal.ts`) and the verb takes no
+arguments, so trailing text is ignored, the no-arg family's posture. The
+handler sits in `lib/commands/local.ts` beside `openSettingsCommand`, the
+existing precedent for an arm that resolves no network id and puts no frame on
+the wire; its body is the `openCreditsModal()` the drawer entry already calls.
+Opening the modal IS the feedback, so it is a silent `{ok: true}` and the draft
+clears. The modal itself is untouched — one opener signal, two doors.
+
+### The issue's two open questions, answered on the issue (Gabriele)
+
+1. **Shadowable.** `/credits` does NOT join `NON_SHADOWABLE_VERBS` (`alias` /
+   `unalias`, the command-side repair surface). Nothing argues an alias over
+   the end titles needs a deny; a unit test pins that an alias wins.
+2. **The drawer entry stays.** The verb is a shortcut, not a replacement — the
+   drawer is where people find the things they cannot name. The e2e spec
+   opens the modal both ways in one run.
+
+### What each gate proves
+
+The unit layer (`slashCommands.test.ts`, `compose.test.ts`) pins the parse and
+the dispatch — the #1396 characterization net gained an arm, with
+`../lib/creditsModal` as a mocked seam so the open is observable rather than a
+silent `{ok: true}`. What a mock cannot see is that the signal the verb flips
+is the one the MOUNTED modal listens to; `e2e/tests/issue1958-credits-verb.spec.ts`
+types the verb into a channel window against the real bundle and asserts the
+modal's title, then closes it and opens it again from the drawer.
+
+_Deploy: **HOT**, cic bundle only — no server change, no wire change, no
+protocol bump: the verb never leaves the client._


### PR DESCRIPTION
Closes #1958.

## What

A `/credits` slash command that opens the end-titles modal (#1773) — one verb deep instead of menu → settings → scroll to the bottom of the drawer.

## Shape

The three hooks the issue measured, and nothing else:

- `slashCommands.ts` — `credits` in `DISPATCH`, yielding `{kind: "open-credits"}`. Carries nothing: the modal is a module-singleton signal and the verb takes no arguments (trailing text is ignored, the no-arg family's posture).
- `commands/local.ts` — `openCreditsCommand`, beside `openSettingsCommand`: resolves no network id, puts no frame on the wire, body is the `openCreditsModal()` the drawer entry already calls. Opening the modal IS the feedback: silent `{ok: true}`, draft cleared.
- `compose.ts` — the dispatcher arm.

The modal itself is untouched.

## The two open questions, as answered on the issue

1. **Shadowable.** Not added to `NON_SHADOWABLE_VERBS`; a unit test pins that a user alias wins over `/credits`.
2. **The drawer entry stays.** The e2e spec opens the modal both ways in one run.

## Tests

- `slashCommands.test.ts`: bare, trailing text, case, alias shadowing.
- `compose.test.ts`: the dispatch (modal opened once, nothing sent, draft cleared) + the #1396 characterization net gains the arm, with `../lib/creditsModal` as a mocked seam so the open is an observable effect rather than a silent ok.
- `e2e/tests/issue1958-credits-verb.spec.ts`: types the verb into a channel window against the real bundle, asserts the modal title, closes it, opens it again from the drawer entry. Scoped run: 1 passed. Full `scripts/integration.sh` run noted below.

## Docs

README verb table row; DESIGN_NOTES entry `#1958`. Deploy: HOT, cic bundle only — no server change, no wire change, no protocol bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDCsdiDSVDJQSaqM4Yjoht
