### PR TITLE
skill(orchestrate): the submodule trip is not the norm — and its cause is measured

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -335,17 +335,48 @@ is DELETE-then-write, never append-only:
   **"remove NUDO, e riportami rc e output testuale"**: con `--force` la prova sparisce e resta solo
   la tua parola contro una status line. **Se la status line del pane e la tua misura si
   contraddicono, quell'`rc` è l'arbitro: chiedilo PRIMA di dichiarare che non si è perso niente.**
-  🔴🔴 **MA NON LEGGERE L'INVERSO: `rc=128` NON VUOL DIRE "SPORCA". CI SONO ALMENO DUE CAUSE, E LA
-  SECONDA È LA NORMA IN QUESTO REPO** — falsificata da w2 **40 minuti** dopo che avevo scritto la
-  regola: `fatal: working trees containing submodules cannot be moved or removed`, su una worktree
+  🔴🔴 **MA NON LEGGERE L'INVERSO: `rc=128` NON VUOL DIRE "SPORCA". CI SONO ALMENO DUE CAUSE** —
+  falsificata da w2 **40 minuti** dopo che avevo scritto la regola:
+  `fatal: working trees containing submodules cannot be moved or removed`, su una worktree
   **PULITA** (`porcelain` vuoto anche con `--ignore-submodules=none`, con controllo positivo che
   stampa ` M cicchetto/e2e/infra` sul repo principale). ⇒ **`rc=128` obbliga a LEGGERE IL TESTO**:
   *"contains modified or untracked files"* = sporca, **fermati**; *"containing submodules"* = il trip
-  già documentato in CLAUDE.md, dove `--force` è lecito **solo dopo** aver provato pulizia E
+  documentato in CLAUDE.md, dove `--force` è lecito **solo dopo** aver provato pulizia E
   atterraggio. 🪞 **Perché la mia prova non l'aveva vista: il repo usa-e-getta NON AVEVA
   SOTTOMODULI**, cioè non somigliava a quello vero. **Un meccanismo provato su un modello che manca
   della feature decisiva è provato per metà** — e la metà mancante è esattamente quella che si
   incontra sul campo.
+  🔴🔴 **CORREZIONE A ME STESSA (w1, 2026-09-07): AVEVO SCRITTO CHE IL RAMO SUBMODULE È «LA NORMA IN
+  QUESTO REPO». NON LO È — IL TRIP CAPITA MA NON È GARANTITO.** Due worktree consecutive, stessa
+  macchina, stesso repo, stessa sera: `w2-1988` → `rc=128 fatal: working trees containing submodules
+  cannot be moved or removed`; `w2-1767` → **`rc=0`, output vuoto, rimossa senza `--force`**.
+  🥇 **E LA CAUSA È MISURATA, NON IPOTIZZATA — È L'`--init`, NON LA PRESENZA DEL SUBMODULE
+  NELL'INDEX (w1, 2026-09-08, esperimento a due bracci su worktree usa-e-getta mie, git 2.50.1).**
+  `w2-1877`, il terzo `rc=0` che avevo a memoria, **non esiste più: quel caso singolo è
+  irriproducibile** — perciò ho misurato il MECCANISMO al suo posto. Due worktree `--detach` da
+  `origin/main`, identiche in tutto (stesso HEAD, `porcelain` 0 righe con `--ignore-submodules=none`,
+  con pos ctrl ` M cicchetto/e2e/infra` sul checkout principale), **unica variabile un
+  `git submodule update --init cicchetto/e2e/infra`**. Predizioni scritte PRIMA, entrambe tornate:
+  - **A, submodule NON inizializzati** → `remove` NUDO **`rc=0`, output vuoto**, worktree rimossa.
+  - **B, un submodule inizializzato** (11 file) → `remove` NUDO **`rc=128`
+    `fatal: working trees containing submodules cannot be moved or removed`**, worktree RESTA.
+  ⇒ **Il rifiuto segue l'inizializzazione, non la dichiarazione in `.gitmodules`** (che è identica
+  nei due bracci): con lo stesso index, la stessa pulizia e lo stesso commit, l'esito si ribalta
+  sull'`--init` e su nient'altro. 🔎 E la variabile varia davvero sul campo: sulle 18 worktree vive di
+  voyager, **11 hanno almeno un submodule inizializzato e 7 nessuno** (`.gitmodules` ne dichiara
+  **tre** — `cicchetto/e2e/infra`, `vendor/bats-core`, `frontends/shottino/vendor/libdatachannel` —,
+  e il terzo non è inizializzato in nessuna). **Non misurato, e resta tale:** se BASTI un submodule
+  qualsiasi o se il numero conti (il braccio B ne aveva uno solo), e quale sia il predicato esatto
+  dentro git. ⚠️ *Nota di riproducibilità:* l'`--init` locale vuole
+  `-c protocol.file.allow=always` (default `never` per i submodule dopo CVE-2022-39253), altrimenti
+  muore con `fatal: transport 'file' not allowed` e **il braccio B non si arma affatto**.
+  🥇 **Conseguenza operativa, ed è il motivo per cui la riga andava corretta invece di lasciarla
+  passare per pignoleria: si prova SEMPRE il `remove` NUDO per primo, sperando nell'`rc=0`.** Scritta
+  come "norma", quella riga fa **aspettare** il rifiuto e invita a prendere `--force` per abitudine —
+  cioè esattamente la mossa che il resto della sezione vieta, e che cancella la prova migliore che
+  esista. Se il trip non è garantito, allora **quell'`rc=0` è disponibile più spesso di quanto il
+  file lasciasse credere**. **`--force` solo dopo aver LETTO il testo dell'rc=128, e solo sul ramo
+  submodule**; sul ramo *"contains modified or untracked files"* ci si FERMA, invariato.
   🥇 **E la worker che incontra il caso NON previsto dal tuo ordine, ragiona, agisce e lo DICHIARA
   con le misure, ha fatto la cosa giusta: dillo.** (Aveva verificato pulizia *e* `--is-ancestor`
   contro `origin/main`, con lo strumento reso discriminante — contro il main LOCALE stantio risponde
@@ -1442,6 +1473,15 @@ DN di main, **entrambi rc=1**) + l'**aritmetica PREDETTA PRIMA** (`2704015 + 590
 misurato `2709917`). ⇒ **Nei brief chiedi «porta un controllo che DISCRIMINA su QUESTA forma»**, e
 accetta che la forma decida quale controllo e' quello vivo. *Un controllo negativo che non puo'
 fallire e' un controllo che non c'e'.*
+🔴 **E LA META' SPECULARE, MISURATA IL 2026-09-07: ANCHE IL CONTROLLO **POSITIVO** PUO' ESSERE MORTO
+— e allora il negativo non prova NIENTE.** Per stabilire che un *"upstream vuoto"* discriminasse, la
+worker aveva pescato come positivo **un ramo che l'upstream non ce l'ha nemmeno lui**: due vuoti
+identici, letti come "il comando funziona e la risposta e' vuota". Rifatto pescando il positivo dal
+mondo — `git config --get-regexp 'branch\..*\.merge'`, **75 rami configurati**, e il suo non fra
+quelli — il vuoto e' diventato un vuoto VERO. 🥇 **Il positivo non si sceglie perche' *dovrebbe*
+rispondere SI: si sceglie DIMOSTRANDO che risponde SI**, e la dimostrazione sta nella stessa cattura
+del negativo, non in un'altra sessione e non nella tua testa. *Un controllo positivo che non puo'
+riuscire e' un controllo che non c'e' — esattamente come il negativo che non puo' fallire.*
 🔴 **`_Deploy:` NON E' UN CHECK, e' INERTE** — non citarlo, o dichiaralo inerte.
 ⚠️ Il gate "forma al confine" e' **VACUO** quando il merge non tocca `DESIGN_NOTES`: **dichiaralo vacuo.**
 🥇 **Un FF PURO (`ahead=N behind=0`, ref PATCH-ato via `gh api`) rende la ricetta vacua PER COSTRUZIONE** —


### PR DESCRIPTION
## What this corrects

`.claude/skills/orchestrate/SKILL.md` (WORKTREE HYGIENE) stated that the
`containing submodules` refusal of a bare `git worktree remove` is **"LA NORMA
IN QUESTO REPO"**. That is wrong, and it was falsified the same evening it was
written — two consecutive worktrees, same machine, same repo:

| worktree | bare `git worktree remove` |
|---|---|
| `w2-1988` | `rc=128` `fatal: working trees containing submodules cannot be moved or removed` |
| `w2-1767` | **`rc=0`, empty output**, removed without `--force` |

**Why this is not pedantry.** Written as a norm, that line makes a worker
*expect* the refusal and reach for `--force` out of habit — precisely the move
the rest of the section forbids. The file already establishes that a bare
`rc=0` **is itself** the proof the worktree was clean. If the trip is not
guaranteed, that proof is available more often than the text let on, and it is
always preferable to forcing.

## The cause is measured, not hypothesised

The first draft of this change wrote the cause as a hypothesis. It has since
been measured with a **two-arm experiment** on throwaway worktrees I created
myself (git 2.50.1). Both predictions were written down *before* running.

Two `--detach` worktrees from `origin/main`, identical in everything — same
HEAD, `git status --porcelain -uall --ignore-submodules=none` = 0 lines on both
(with a live positive control printing ` M cicchetto/e2e/infra` on the main
checkout). **The only variable: `git submodule update --init cicchetto/e2e/infra`.**

| arm | submodules | prediction | measured |
|---|---|---|---|
| **A** | none initialised | `rc=0` | OK — `rc=0`, empty output, removed |
| **B** | one initialised (11 files) | `rc=128` `containing submodules` | OK — `rc=128` `fatal: working trees containing submodules cannot be moved or removed`, worktree stayed |

=> **The refusal follows submodule INITIALISATION, not the `.gitmodules`
declaration** — which is byte-identical in both arms. Same index, same
cleanliness, same commit; the outcome flips on the `--init` and nothing else.

Field context, also measured: of the 18 live worktrees on this host, **11 have
at least one submodule initialised and 7 have none** — so the variable really
does vary in practice. (`.gitmodules` declares three: `cicchetto/e2e/infra`,
`vendor/bats-core`, `frontends/shottino/vendor/libdatachannel`; the third is
initialised in none of them.)

Arm B was cleaned up with `--force` — my own throwaway tree — and the cleanup
was verified: 0 probe worktrees, 0 probe directories, 0 probe branches, each
negative paired with a live positive control, and all 18 pre-existing worktrees
untouched and still registered.

### What I deliberately did NOT claim

- **`w2-1877`.** A third bare `rc=0` existed in my notes from 2026-08-30. That
  worktree is gone, so the case is **irreproducible**; rather than downgrade it
  to "a written precedent" and ask the reader to trust a note, the mechanism
  measurement replaces it. It is not cited as evidence.
- **Whether ONE submodule suffices, or the count matters.** Arm B had exactly
  one. Not tested.
- **git's exact internal predicate.** Not read; the behaviour is measured from
  the outside only.
- **A correlation between init-state and remove-outcome across the live
  worktrees.** Establishing it would require removing other sessions' worktrees.
  Not done, and not to be done.

## Also in this slice

The mirror of a rule this file already carries. It says *"a negative control
that cannot fail is a control that isn't there."* The **positive** control can
be dead the same way: to prove that "empty upstream" discriminated, a worker
picked as its positive a branch that has no upstream either — two identical
blanks read as a working probe. Redone against
`git config --get-regexp 'branch\..*\.merge'` (**75** branches configured, its
own not among them), the blank became a real blank. The rule added: *a positive
control is chosen by DEMONSTRATING it answers yes, in the same capture as the
negative.*

## Scope and gates

- **Docs only** — one markdown file, +44/-4. No code path, no `_build`, no
  docker, so **no lane was needed**.
- **`.claude/` is not ungated, but the gating is by PATH.**
  `test/scripts/*.bats` reads `.claude/skills/orchestrate/lib/*.sh` —
  **`SKILL.md` it never reads.** Measured: 0 references to `SKILL.md`, 2 to
  `lib/`, so the grep that found nothing was alive. This PR therefore cannot
  turn `bats` red — that is a statement about the path, not a claim that
  `.claude/` is inert.
- **No DESIGN_NOTES entry**: this is a skill rule, not a project decision. The
  union-rebase ritual is **vacuous by construction** here — the branch
  contributes 0 lines to `DESIGN_NOTES.md`, so there is nothing to eat and
  nothing to resurrect. Pinned anyway: contribution `+44/-4` identical before
  and after the rebase.
- Rebased onto `origin/main` immediately before opening (base `7d43fc7f1`,
  ahead 1 / behind 0). Those 4 new commits touch 8 files; **none is this one**.
- No closing keyword — there is no issue.