### PR TITLE
cic(issue 1993): group the general settings page by scope, apply identity + password with one button

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -1061,6 +1061,29 @@ export async function settleNetworkAutojoin(
   }
 }
 
+// Set the per-network nick through `PATCH /networks/:slug/identity` — the
+// SAME subject-agnostic door the settings identity editor drives.
+//
+// Shared because both callers need it for the same reason and not by
+// coincidence: a spec that changes the nick through the UI has to put the
+// provisioned one back before the #1152 teardown guard reads the live value,
+// so this is the restore half of every apply-and-restore identity spec.
+// (Lifted out of issue476's private copy when issue 1993 needed the second.)
+export async function setNetworkIdentityNick(
+  token: string,
+  slug: string,
+  nick: string,
+): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/networks/${slug}/identity`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ nick }),
+  });
+  if (!res.ok) {
+    throw new Error(`setNetworkIdentityNick: ${slug}=${nick} → ${res.status} ${await res.text()}`);
+  }
+}
+
 // #498 — self-serve accretion (`POST /session/networks`). Binds + spawns
 // the visitor_enabled `slug` for the authenticated subject, anon
 // (`auth_method: :none`), with the account name as the default nick. `204`

--- a/cicchetto/e2e/tests/issue1993-general-subpage-scope.spec.ts
+++ b/cicchetto/e2e/tests/issue1993-general-subpage-scope.spec.ts
@@ -1,0 +1,144 @@
+// issue 1993 — the general settings sub-page, regrouped by SCOPE and applied
+// with ONE button.
+//
+// What the unit tests cannot reach, and why this spec exists: the merged
+// apply's whole point is that it writes through TWO endpoints that each
+// BOUNCE the upstream session, and a jsdom test can only prove the calls were
+// made. Here the identity leg is witnessed where it actually lands — the
+// subject re-registers upstream under the new nick and reappears in the
+// channel's member list — while the password leg is witnessed by the only
+// readback a write-only secret has: the field clears, which happens solely on
+// a 200 from `PUT /networks/:slug/password`.
+//
+// TWO networks, on purpose. The selector this issue lifts out of the identity
+// card renders only when the subject holds more than one (#497: a one-option
+// picker is noise), so a single-network subject cannot show the defect this
+// page rework is about — the picker being buried inside one of the four cards
+// it governs. `accreteNetwork` binds azzurra2 (a different ircd, so the two
+// sessions cannot collide on nick) and the spec then drives the picker to
+// choose which network the apply targets.
+//
+// Nick discipline (#1152): the spec CHANGES the per-spec subject's nick, so
+// the teardown nick guard would read a live nick the spec never addressed.
+// The finally restores the provisioned nick before the guard runs — the same
+// apply-and-restore issue476 uses, and load-bearing rather than tidy.
+//
+// Runs on chromium desktop (untagged): the drawer renders directly, and every
+// server-side witness is over REST, so nothing here is layout-dependent.
+
+import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
+import {
+  accreteNetwork,
+  setNetworkIdentityNick,
+  settleNetworkAutojoin,
+} from "../fixtures/grappaApi";
+import { ACCRETE_NETWORK_SLUG, AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// An accrete + spawn, a live identity apply (reconnect + autojoin) and a
+// restore-and-reconnect in the finally — three upstream round trips.
+test.setTimeout(150_000);
+
+test("issue 1993 — the general page groups what the selector governs, and one apply saves identity + password", async ({
+  page,
+}) => {
+  const user = specUser();
+  const channel = AUTOJOIN_CHANNELS[0];
+  if (!channel) throw new Error("issue1993: AUTOJOIN_CHANNELS is empty — seed contract broken");
+  // Collision-free on bahamut-test, and inside NICKLEN.
+  const newNick = `n1993${Date.now() % 100000}`;
+  const nickServPassword = "issue1993-nickserv-not-secret";
+
+  try {
+    // ── GATE: the subject is live under its provisioned nick, on TWO nets ──
+    await settleNetworkAutojoin(user.token, NETWORK_SLUG, channel, specNick());
+    await accreteNetwork(user.token, ACCRETE_NETWORK_SLUG);
+
+    await loginAs(page, user);
+    const general = await openSettingsSection(page, "general");
+
+    // ── (1) the selector is OUT of the card and ABOVE the group it governs ──
+    const group = general.getByTestId("settings-network-scope");
+    const select = group.getByTestId("settings-identity-network-select");
+    await expect(select).toBeVisible({ timeout: 10_000 });
+    // The burial this issue reports: the picker used to live INSIDE the
+    // identity card, which is one of the four things it decides the scope of.
+    await expect(
+      general.locator(
+        "[data-testid='settings-section-identity'] [data-testid='settings-identity-network-select']",
+      ),
+    ).toHaveCount(0);
+    await expect(group.getByTestId("settings-section-identity")).toBeVisible();
+
+    // …and the ACCOUNT-scoped knobs stayed out of it. Both halves matter: a
+    // group that swallowed everything would say nothing.
+    await expect(general.getByTestId("auto-away-select")).toBeVisible();
+    await expect(group.getByTestId("auto-away-select")).toHaveCount(0);
+    await expect(group.getByTestId("upload-ttl-select")).toHaveCount(0);
+
+    // ── (3) the write-once fields are one tap deeper now ──
+    await expect(general.getByTestId("settings-section-profile")).toHaveCount(0);
+    await expect(general.getByTestId("settings-section-avatar")).toHaveCount(0);
+    await expect(general.getByTestId("show-peer-profiles-toggle")).toHaveCount(0);
+
+    // ── (2) ONE apply over identity + the NickServ password ──
+    // Drive the lifted picker to choose the target explicitly rather than
+    // inheriting whatever the focused network happens to be.
+    await select.selectOption(NETWORK_SLUG);
+    await expect(page.locator("#settings-nick")).toHaveValue(specNick(), { timeout: 10_000 });
+
+    const password = page.locator("#settings-network-password");
+    // The secret is edited HERE now, inside the identity card, under the name
+    // of the thing it identifies with.
+    await expect(general.getByLabel(/nickserv password/i)).toHaveCount(1);
+    // …and the rival save button it used to carry is gone.
+    await expect(general.getByTestId("settings-password-apply")).toHaveCount(0);
+
+    await page.locator("#settings-nick").fill(newNick);
+    await password.fill(nickServPassword);
+
+    const applyBtn = general.getByTestId("settings-identity-apply");
+    await applyBtn.click(); // arm
+    await applyBtn.click(); // confirm
+
+    // HEADLINE 1 — the password reached the server. A write-only value has
+    // exactly one readback: the field is cleared by the success path and by
+    // nothing else, so an empty input after an apply IS the 200.
+    await expect(password).toHaveValue("", { timeout: 30_000 });
+    await expect(general.getByTestId("settings-identity-ok")).toBeVisible({ timeout: 30_000 });
+    await expect(general.getByTestId("settings-password-error")).toHaveCount(0);
+    await expect(general.getByTestId("settings-identity-error")).toHaveCount(0);
+
+    // HEADLINE 2 — the identity reached UPSTREAM, from the same single
+    // gesture: the session bounced, re-registered under the new nick and
+    // rejoined the channel, which is where the member list can see it.
+    await settleNetworkAutojoin(user.token, NETWORK_SLUG, channel, newNick);
+
+    // ── (3, continued) the profile door, and where back goes ──
+    // Tapped directly rather than through `openSettingsSection`: this row IS
+    // what the assertion is about, and it is not on the index the helper
+    // drives — reaching it through the helper would be circular.
+    await general.getByTestId("profile-settings-entry").click();
+    const profile = page.getByTestId("profile-subpage");
+    await expect(profile.getByTestId("settings-section-profile")).toBeVisible();
+    await expect(profile.getByTestId("settings-section-avatar")).toBeVisible();
+    await expect(profile.getByTestId("show-peer-profiles-toggle")).toBeVisible();
+    // The opt-in is account-wide and must NOT sit under a group claiming a
+    // network (issue 1993 point 4 — making it per-network — is deliberately
+    // not in this slice).
+    await expect(
+      profile.getByTestId("settings-network-scope").getByTestId("show-peer-profiles-toggle"),
+    ).toHaveCount(0);
+
+    await profile.getByTestId("profile-back").click();
+    await expect(page.getByTestId("general-subpage")).toBeVisible();
+    // Back returns to GENERAL, not two levels out to the index.
+    await expect(page.getByTestId("themes-settings-entry")).toHaveCount(0);
+  } finally {
+    // Restore the provisioned nick before the #1152 teardown guard reads the
+    // live one. Swallowed: a cleanup hiccup must not mask the assertions.
+    await setNetworkIdentityNick(user.token, NETWORK_SLUG, specNick())
+      .then(() => settleNetworkAutojoin(user.token, NETWORK_SLUG, channel, specNick()))
+      .catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
@@ -26,7 +26,11 @@
 // pure form-logic + live-upstream-effect proof.
 
 import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import {
+  GRAPPA_BASE_URL,
+  patchNetworkConnectionState,
+  setNetworkIdentityNick,
+} from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -43,20 +47,6 @@ async function getNetworks(token: string): Promise<NetRow[]> {
   });
   if (!res.ok) throw new Error(`getNetworks: ${res.status} ${await res.text()}`);
   return (await res.json()) as NetRow[];
-}
-
-// Set the per-network nick via the subject-agnostic door
-// `PATCH /networks/:slug/identity` — the SAME door cic's editor drives. Used
-// by the finally to restore the seeded baseline nick.
-async function setNetworkNick(token: string, slug: string, nick: string): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/networks/${slug}/identity`, {
-    method: "PATCH",
-    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-    body: JSON.stringify({ nick }),
-  });
-  if (!res.ok) {
-    throw new Error(`setNetworkNick: ${slug}=${nick} → ${res.status} ${await res.text()}`);
-  }
 }
 
 // Poll GET /networks until `slug` reaches `state` (or throw). Gates on the
@@ -186,7 +176,7 @@ test("issue #476 — a USER edits its per-network identity in settings and it ap
     // resetSubject (wrapped-test teardown) does NOT touch the nick, so this
     // is the only restore. Swallow errors: a cleanup hiccup must not mask
     // the test's own assertion outcome.
-    await setNetworkNick(vjt.token, NETWORK_SLUG, specNick())
+    await setNetworkIdentityNick(vjt.token, NETWORK_SLUG, specNick())
       .then(() => waitForNetworkNick(vjt.token, NETWORK_SLUG, specNick()))
       .then(() => waitForOwnNickInMembers(vjt.token, NETWORK_SLUG, channel, specNick()))
       .catch(() => {});

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -307,14 +307,19 @@ const SettingsDrawer: Component<Props> = (props) => {
   const [realnameText, setRealnameText] = createSignal("");
   const [identitySaving, setIdentitySaving] = createSignal(false);
   const [identityError, setIdentityError] = createSignal<string | null>(null);
-  const [identitySaved, setIdentitySaved] = createSignal(false);
+  // issue 1993 — what the ONE apply did, as a closed set rather than a
+  // boolean: "unchanged" is a real outcome now that the button no longer
+  // bounces a card nobody edited, and a silent no-op after two taps reads as
+  // a broken button.
+  const [applyResult, setApplyResult] = createSignal<"applied" | "unchanged" | null>(null);
   // Two-tap arm for the apply button (parent owns the flag per
   // InlineConfirmButton's contract) — the reconnect is disruptive
   // (session bounces), so it arms rather than firing on the first tap. #986
   // retired the settings copies of this control for the LIFECYCLE verbs only
   // — as a per-row apply gate it is unchanged, here and at its ~20 other
-  // call sites.
-  const [identityArmed, setIdentityArmed] = createSignal(false);
+  // call sites. issue 1993 renamed it off `identity`: it now arms the
+  // password write too.
+  const [applyArmed, setApplyArmed] = createSignal(false);
 
   // KVIrc-style CTCP USERINFO profile (age/gender/location/languages/a free
   // custom field). Targets the SAME selected network the identity editor
@@ -338,16 +343,21 @@ const SettingsDrawer: Component<Props> = (props) => {
   const [avatarUploading, setAvatarUploading] = createSignal(false);
   const [avatarError, setAvatarError] = createSignal<string | null>(null);
 
-  // #124 — the per-network PASSWORD field. Its own signals and its own save,
-  // NOT folded into the identity form above: the password is write-only and
-  // leave-blank-to-keep, while the identity fields round-trip and treat a
-  // blank as "clear to default". One Save over both would make an untouched
-  // password field indistinguishable from "clear my password".
+  // #124 — the per-network PASSWORD field: write-only, leave-blank-to-keep.
+  //
+  // issue 1993 folded its SAVE into the identity apply above, reversing what
+  // #124 wrote here ("NOT folded into the identity form … one Save over both
+  // would make an untouched password field indistinguishable from 'clear my
+  // password'"). That objection is answered rather than overruled: the
+  // blank-keeps rule lives in `onApply` on the PASSWORD leg, which simply
+  // does not call the endpoint for `""`, so a blank still cannot clear
+  // anything. What made two buttons wrong is that both bounce the session,
+  // so a user changing nick AND password paid two reconnects for one
+  // intention. The signals stay separate because the two CALLS are separate
+  // (distinct endpoints, distinct failures); only the gesture merged.
   const [passwordText, setPasswordText] = createSignal("");
   const [passwordSaving, setPasswordSaving] = createSignal(false);
   const [passwordError, setPasswordError] = createSignal<string | null>(null);
-  const [passwordSaved, setPasswordSaved] = createSignal(false);
-  const [passwordArmed, setPasswordArmed] = createSignal(false);
 
   // Default the editor's target ONCE per open-session: the currently-focused
   // network (if it resolves to one of the subject's rows), else the first
@@ -377,8 +387,13 @@ const SettingsDrawer: Component<Props> = (props) => {
       setNickText(net.nick);
       setIdentText(net.ident ?? "");
       setRealnameText(net.realname ?? "");
-      setIdentityArmed(false);
-      setIdentitySaved(false);
+      // issue 1993 — a typed password belongs to the network it was typed
+      // FOR. The field now shares the identity card's target, so carrying it
+      // across a switch would write one network's secret to another.
+      setPasswordText("");
+      setPasswordError(null);
+      setApplyArmed(false);
+      setApplyResult(null);
       setIdentityError(null);
       setProfileAge(net.age ?? "");
       setProfileGender(net.gender ?? "");
@@ -448,57 +463,95 @@ const SettingsDrawer: Component<Props> = (props) => {
     }
   };
 
-  const onSaveIdentity = async () => {
-    setIdentityArmed(false);
-    setIdentityError(null);
-    setIdentitySaved(false);
+  // Whether the three identity shadows still say what the server row says.
+  // The apply skips an unchanged identity, so this is what decides whether
+  // the PATCH (and its reconnect) happens at all.
+  const identityDirty = (): boolean => {
     const net = selectedIdentityNetwork();
-    if (!net) return;
-    setIdentitySaving(true);
-    try {
-      // Send all three fields; blank ident/realname clears back to the
-      // server default (ident → nick, realname → the subject default). Empty
-      // string is a legitimate "unset" intent here — the settings editor is
-      // the canonical edit surface, so it owns the full value including
-      // clear. Nick is required (the credential can't be nickless).
-      await updateIdentity(net.slug, {
-        nick: nickText(),
-        ident: identText(),
-        realname: realnameText(),
-      });
-      setIdentitySaved(true);
-    } catch (err) {
-      setIdentityError(
-        err instanceof ApiError ? friendlyApiError(err) : "Couldn't apply identity. Try again.",
-      );
-    } finally {
-      setIdentitySaving(false);
-    }
+    if (!net) return false;
+    return (
+      nickText() !== net.nick ||
+      identText() !== (net.ident ?? "") ||
+      realnameText() !== (net.realname ?? "")
+    );
   };
 
-  const onSavePassword = async () => {
-    setPasswordArmed(false);
+  // issue 1993 — ONE apply over two endpoints. `PUT /password` and
+  // `PATCH /identity` are distinct calls (see the signals above) and BOTH
+  // live-apply by bouncing the upstream session, which is what made two
+  // buttons the wrong shape: the user's intention is "apply my changes to
+  // this network", not "reconnect once per field group".
+  //
+  // 🔴 It cannot be ONE bounce when BOTH changed, and pretending otherwise
+  // would be the lie: each endpoint reconnects server-side, so two writes
+  // are two reconnect requests back to back. What this DOES guarantee is
+  // that the merge never costs MORE than the two buttons it replaced — each
+  // leg is skipped unless it has something to write, so the single-axis
+  // cases (the common ones) are exactly one bounce, and an untouched card is
+  // zero. A genuinely single bounce needs a combined server verb; that is a
+  // server-side scope change and deliberately not in this slice.
+  //
+  // Password FIRST, and fail-fast on its refusal: a rejected secret (too
+  // short, services would refuse it) must not cost a reconnect for the half
+  // of the gesture that would have worked, leaving the operator to guess
+  // which half landed.
+  const onApply = async () => {
+    setApplyArmed(false);
+    setIdentityError(null);
     setPasswordError(null);
-    setPasswordSaved(false);
+    setApplyResult(null);
     const net = selectedIdentityNetwork();
     if (!net) return;
+
+    let applied = false;
+
     // Leave-blank-to-keep lives HERE: an empty input is "I did not touch
     // this", never "clear my password". The server 400s a blank precisely so
     // this can never be an accident.
     const pw = passwordText();
-    if (pw === "") return;
-    setPasswordSaving(true);
-    try {
-      await updateNetworkPassword(net.slug, pw);
-      setPasswordText("");
-      setPasswordSaved(true);
-    } catch (err) {
-      setPasswordError(
-        err instanceof ApiError ? friendlyApiError(err) : "Couldn't save the password. Try again.",
-      );
-    } finally {
-      setPasswordSaving(false);
+    if (pw !== "") {
+      setPasswordSaving(true);
+      try {
+        await updateNetworkPassword(net.slug, pw);
+        setPasswordText("");
+        applied = true;
+      } catch (err) {
+        setPasswordError(
+          err instanceof ApiError
+            ? friendlyApiError(err)
+            : "Couldn't save the password. Try again.",
+        );
+        return;
+      } finally {
+        setPasswordSaving(false);
+      }
     }
+
+    if (identityDirty()) {
+      setIdentitySaving(true);
+      try {
+        // Send all three fields; blank ident/realname clears back to the
+        // server default (ident → nick, realname → the subject default). Empty
+        // string is a legitimate "unset" intent here — the settings editor is
+        // the canonical edit surface, so it owns the full value including
+        // clear. Nick is required (the credential can't be nickless).
+        await updateIdentity(net.slug, {
+          nick: nickText(),
+          ident: identText(),
+          realname: realnameText(),
+        });
+        applied = true;
+      } catch (err) {
+        setIdentityError(
+          err instanceof ApiError ? friendlyApiError(err) : "Couldn't apply identity. Try again.",
+        );
+        return;
+      } finally {
+        setIdentitySaving(false);
+      }
+    }
+
+    setApplyResult(applied ? "applied" : "unchanged");
   };
 
   // The drawer stays mounted across open/close (CSS .open toggle, not a
@@ -515,9 +568,14 @@ const SettingsDrawer: Component<Props> = (props) => {
       // stale "applied"/error banner. Reset the seed latch + selected target
       // so the next open re-defaults to the (now-current) focused network and
       // re-seeds the fields from its /networks row.
-      setIdentityArmed(false);
-      setIdentitySaved(false);
+      setApplyArmed(false);
+      setApplyResult(null);
       setIdentityError(null);
+      // issue 1993 — the password rides the same apply, so it clears with
+      // the rest of the transient state: a secret typed but not applied must
+      // not sit in the DOM waiting for the next person to open the drawer.
+      setPasswordText("");
+      setPasswordError(null);
       setIdentitySeeded(false);
       setSelectedIdentitySlug(null);
       // #282 — clear a stale reconnect error so a reopened drawer that
@@ -1067,23 +1125,58 @@ const SettingsDrawer: Component<Props> = (props) => {
     return parts.join(" and ");
   };
 
-  // #460 — shared back-header for the INLINE sub-pages (general / display /
-  // push), mirroring the AliasSettings / WatchlistsSettings convention so
-  // every sub-page presents one consistent "‹ back" affordance. Local (not a
-  // component) so it stays inside the signal scope without prop threading.
-  const subpageHeader = (title: string, backTestId: string) => (
+  // #460 — shared back-header for the INLINE sub-pages (general / profile /
+  // display / push), mirroring the AliasSettings / WatchlistsSettings
+  // convention so every sub-page presents one consistent "‹ back" affordance.
+  // Local (not a component) so it stays inside the signal scope without prop
+  // threading.
+  //
+  // issue 1993 — `backTo` is an explicit parameter, not a default of "main":
+  // the profile page is entered from GENERAL, so a hard-coded "main" would
+  // drop the user two levels for one tap of back. Passed at every call site
+  // (CLAUDE.md: no defaulted arguments — a default here is exactly the silent
+  // wrong-target path).
+  const subpageHeader = (title: string, backTestId: string, backTo: SettingsSubPage) => (
     <header class="settings-subpage-header">
       <button
         type="button"
         class="settings-back"
         data-testid={backTestId}
         aria-label="back to settings"
-        onClick={() => setSettingsPage("main")}
+        onClick={() => setSettingsPage(backTo)}
       >
         ‹ back
       </button>
       <h3>{title}</h3>
     </header>
+  );
+
+  // issue 1993 — the picker that decides WHICH network the cards below are
+  // keyed to. Lifted out of the identity card (where #497 left it) so it sits
+  // at the top of the network-scoped group instead of inside one of the four
+  // things it governs. Shared by the general and profile pages: those two are
+  // mutually exclusive `<Show>` blocks, so `id="settings-identity-network"`
+  // is still unique in the DOM, and both read the SAME signal — switching on
+  // one page is already switched on the other.
+  //
+  // Still hidden on a single network (#497's ruling, unchanged: a one-option
+  // picker is noise, and the group's own heading says the scope).
+  const networkScopePicker = () => (
+    <Show when={identityNetworks().length > 1}>
+      <label for="settings-identity-network">Network</label>
+      {/* Lock the target while an apply is in flight — the save captured a
+          specific network; switching mid-reconnect would surface its result
+          banner under the wrong row. */}
+      <select
+        id="settings-identity-network"
+        data-testid="settings-identity-network-select"
+        disabled={identitySaving() || passwordSaving()}
+        value={selectedIdentityNetwork()?.slug ?? ""}
+        onChange={(e) => setSelectedIdentitySlug(e.currentTarget.value)}
+      >
+        <For each={identityNetworks()}>{(net) => <option value={net.slug}>{net.slug}</option>}</For>
+      </select>
+    </Show>
   );
 
   // issue 1982 — the scrim dismisses on the press it began, not on any click
@@ -1460,354 +1553,173 @@ const SettingsDrawer: Component<Props> = (props) => {
           <TotpSettings onBack={() => setSettingsPage("main")} />
         </Show>
 
-        {/* #460 — general sub-page: upload retention (host-gated) + visitor
-            identity (visitor-gated). Both blocks moved VERBATIM from the old
-            flat main page. */}
+        {/* #460 — general sub-page. issue 1993 reshaped it: the NETWORK-scoped
+            block (the selector, then the identity + NickServ-password card,
+            then the door to the profile page) comes FIRST as one visibly
+            grouped unit, and the ACCOUNT-scoped knobs (upload retention,
+            auto-away) follow it. Before the rework the two scopes were
+            interleaved and the selector governing half of them was buried
+            inside one of the four cards it governs. */}
         <Show when={settingsPage() === "general"}>
           <section class="settings-subpage general-subpage" data-testid="general-subpage">
-            {subpageHeader("general", "general-back")}
+            {subpageHeader("general", "general-back", "main")}
 
             {/* #476 / #478 — per-network identity editor, both subjects. It
               targets the SELECTED network row (focused-network default), with a
               picker when the subject holds more than one — the retired lowest-id
-              anchor is gone. Saving PATCHes /networks/:slug/identity which
+              anchor is gone. Applying PATCHes /networks/:slug/identity which
               live-applies via internal reconnect (the session bounces +
-              rejoins). The confirm-armed save communicates the reconnect cost;
+              rejoins). The confirm-armed apply communicates the reconnect cost;
               a 422 renders inline. Gated on hasNetworks() — you can't edit
-              identity for a network you don't hold. */}
-            {/* #335 — identity sits inside a titled .settings-section card. */}
+              identity for a network you don't hold, and an empty group would
+              claim a scope that has no members. */}
             <Show when={hasNetworks()}>
-              <div
-                class="settings-section settings-section-card"
-                data-testid="settings-section-identity"
-              >
-                <h4 class="settings-section-heading">identity</h4>
-                <div class="settings-identity" data-testid="settings-identity">
-                  {/* #497 — the network this identity edits. Shown ONLY when
-                      the subject holds more than one network: a one-option
-                      picker is noise (a single network is the common visitor
-                      case), so the whole Network row is hidden there — the
-                      nick/realname/ident fields self-evidently target the sole
-                      network. The `for` always associates with the rendered
-                      <select> now (no dangling-label a11y branch). */}
-                  <Show when={identityNetworks().length > 1}>
-                    <label for="settings-identity-network">Network</label>
-                    {/* Lock the target while an apply is in flight — the save
-                        captured a specific network; switching mid-reconnect
-                        would surface its result banner under the wrong row. */}
-                    <select
-                      id="settings-identity-network"
-                      data-testid="settings-identity-network-select"
-                      disabled={identitySaving()}
-                      value={selectedIdentityNetwork()?.slug ?? ""}
-                      onChange={(e) => setSelectedIdentitySlug(e.currentTarget.value)}
-                    >
-                      <For each={identityNetworks()}>
-                        {(net) => <option value={net.slug}>{net.slug}</option>}
-                      </For>
-                    </select>
-                  </Show>
+              <section class="settings-network-scope" data-testid="settings-network-scope">
+                {/* The heading names the SCOPE, not the network: #497 hides
+                    the picker on a single network, so on that (common) path
+                    this line is the only thing saying what the cards below
+                    are keyed to. */}
+                <h4 class="settings-section-heading">per-network</h4>
+                {networkScopePicker()}
 
-                  <label for="settings-nick">Nick</label>
-                  <input
-                    id="settings-nick"
-                    type="text"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    value={nickText()}
-                    onInput={(e) => setNickText(e.currentTarget.value)}
-                  />
+                {/* #335 — identity sits inside a titled .settings-section card. */}
+                <div
+                  class="settings-section settings-section-card"
+                  data-testid="settings-section-identity"
+                >
+                  <h4 class="settings-section-heading">identity</h4>
+                  <div class="settings-identity" data-testid="settings-identity">
+                    <label for="settings-nick">Nick</label>
+                    <input
+                      id="settings-nick"
+                      type="text"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      value={nickText()}
+                      onInput={(e) => setNickText(e.currentTarget.value)}
+                    />
 
-                  <label for="settings-realname">Real name</label>
-                  <input
-                    id="settings-realname"
-                    type="text"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    value={realnameText()}
-                    onInput={(e) => setRealnameText(e.currentTarget.value)}
-                  />
+                    <label for="settings-realname">Real name</label>
+                    <input
+                      id="settings-realname"
+                      type="text"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      value={realnameText()}
+                      onInput={(e) => setRealnameText(e.currentTarget.value)}
+                    />
 
-                  <label for="settings-ident">Ident</label>
-                  <input
-                    id="settings-ident"
-                    type="text"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    value={identText()}
-                    onInput={(e) => setIdentText(e.currentTarget.value)}
-                  />
-                  <p class="settings-identity-hint">
-                    Applying reconnects your session — you'll briefly drop and rejoin your channels.
-                  </p>
+                    <label for="settings-ident">Ident</label>
+                    <input
+                      id="settings-ident"
+                      type="text"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      value={identText()}
+                      onInput={(e) => setIdentText(e.currentTarget.value)}
+                    />
 
-                  <InlineConfirmButton
-                    idleLabel={identitySaving() ? "applying…" : "apply identity"}
-                    confirmLabel="apply — this reconnects"
-                    testId="settings-identity-apply"
-                    armed={identityArmed()}
-                    onArm={() => setIdentityArmed(true)}
-                    onConfirm={() => {
-                      void onSaveIdentity();
-                    }}
-                  />
-
-                  <Show when={identityError()}>
-                    {(msg) => (
-                      <p
-                        role="alert"
-                        class="settings-identity-error"
-                        data-testid="settings-identity-error"
-                      >
-                        {msg()}
-                      </p>
-                    )}
-                  </Show>
-                  <Show when={identitySaved()}>
-                    <p class="settings-identity-ok" data-testid="settings-identity-ok">
-                      Identity applied.
+                    {/* #124 — THE one place this secret is editable: it is the
+                      credential password, the value `$nickserv_pass` expands
+                      to, and for a visitor the credential you log into grappa
+                      with. issue 1993 moved it INTO this card and renamed it:
+                      "Network password" reads as the server PASS (#1044's
+                      distinct secret, which has its own door), and what this
+                      writes is what identifies you to NickServ. */}
+                    <label for="settings-network-password">NickServ password</label>
+                    <input
+                      id="settings-network-password"
+                      type="password"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      placeholder="leave blank to keep"
+                      value={passwordText()}
+                      data-testid="settings-network-password-input"
+                      onInput={(e) => {
+                        setPasswordText(e.currentTarget.value);
+                        setApplyResult(null);
+                      }}
+                    />
+                    <p class="settings-identity-hint">
+                      A blank password keeps the stored one, and applying reconnects your session.
                     </p>
-                  </Show>
+
+                    <InlineConfirmButton
+                      idleLabel={identitySaving() || passwordSaving() ? "applying…" : "apply"}
+                      confirmLabel="apply — this reconnects"
+                      testId="settings-identity-apply"
+                      armed={applyArmed()}
+                      onArm={() => setApplyArmed(true)}
+                      onConfirm={() => {
+                        void onApply();
+                      }}
+                    />
+
+                    {/* Two calls, two failures: which door refused is the
+                        first thing the operator needs, so the banners stay
+                        separate even though the gesture merged. */}
+                    <Show when={passwordError()}>
+                      {(msg) => (
+                        <p
+                          role="alert"
+                          class="settings-identity-error"
+                          data-testid="settings-password-error"
+                        >
+                          {msg()}
+                        </p>
+                      )}
+                    </Show>
+                    <Show when={identityError()}>
+                      {(msg) => (
+                        <p
+                          role="alert"
+                          class="settings-identity-error"
+                          data-testid="settings-identity-error"
+                        >
+                          {msg()}
+                        </p>
+                      )}
+                    </Show>
+                    <Show when={applyResult()}>
+                      {(result) => (
+                        <p class="settings-identity-ok" data-testid="settings-identity-ok">
+                          {result() === "applied" ? "Applied." : "No changes to apply."}
+                        </p>
+                      )}
+                    </Show>
+                  </div>
                 </div>
-              </div>
-
-              {/* KVIrc-style CTCP USERINFO profile (age/gender/location/
-                languages/a free custom field), per network — targets the
-                same selected network the identity card above does. Unlike
-                identity, saving does NOT reconnect: these fields never ride
-                the IRC handshake, they only feed the server's CTCP
-                USERINFO auto-reply — so a plain save, no two-tap confirm. */}
-              <div
-                class="settings-section settings-section-card"
-                data-testid="settings-section-profile"
-              >
-                <h4 class="settings-section-heading">profile</h4>
-                <div class="settings-identity" data-testid="settings-profile">
-                  <label for="settings-profile-age">Age</label>
-                  <input
-                    id="settings-profile-age"
-                    type="text"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    value={profileAge()}
-                    onInput={(e) => setProfileAge(e.currentTarget.value)}
-                  />
-
-                  <label for="settings-profile-gender">Gender</label>
-                  <select
-                    id="settings-profile-gender"
-                    data-testid="settings-profile-gender"
-                    value={profileGender()}
-                    onChange={(e) => setProfileGender(e.currentTarget.value)}
-                  >
-                    <option value="">unset</option>
-                    <option value="male">male</option>
-                    <option value="female">female</option>
-                    <option value="nonbinary">non-binary</option>
-                  </select>
-
-                  <label for="settings-profile-location">Location</label>
-                  <input
-                    id="settings-profile-location"
-                    type="text"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    value={profileLocation()}
-                    onInput={(e) => setProfileLocation(e.currentTarget.value)}
-                  />
-
-                  <label for="settings-profile-languages">Languages</label>
-                  <input
-                    id="settings-profile-languages"
-                    type="text"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    value={profileLanguages()}
-                    onInput={(e) => setProfileLanguages(e.currentTarget.value)}
-                  />
-
-                  <label for="settings-profile-custom">Custom</label>
-                  <input
-                    id="settings-profile-custom"
-                    type="text"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    value={profileCustom()}
-                    onInput={(e) => setProfileCustom(e.currentTarget.value)}
-                  />
-                  <p class="settings-identity-hint">
-                    Shown to anyone who sends you a CTCP USERINFO query. Leave a field blank to
-                    clear it.
-                  </p>
-
-                  <button
-                    type="button"
-                    class="settings-identity-apply"
-                    data-testid="settings-profile-apply"
-                    disabled={profileSaving()}
-                    onClick={() => void onSaveProfile()}
-                  >
-                    {profileSaving() ? "saving…" : "save profile"}
-                  </button>
-
-                  <Show when={profileError()}>
-                    {(msg) => (
-                      <p
-                        role="alert"
-                        class="settings-identity-error"
-                        data-testid="settings-profile-error"
-                      >
-                        {msg()}
-                      </p>
-                    )}
-                  </Show>
-                  <Show when={profileSaved()}>
-                    <p class="settings-identity-ok" data-testid="settings-profile-ok">
-                      Profile saved.
-                    </p>
-                  </Show>
-                </div>
-              </div>
-
-              {/* M3a — the own avatar, per network. A permanent, self-hosted
-                upload (same `Grappa.Uploads` pipeline as any other embedded
-                upload, just `expires_at: nil`), served over CTCP AVATAR to
-                whoever asks and — once M3b lands — rendered in peers' WHOIS
-                cards. Never bounces the connection, like /profile above. */}
-              <div
-                class="settings-section settings-section-card"
-                data-testid="settings-section-avatar"
-              >
-                <h4 class="settings-section-heading">avatar</h4>
-                <div class="settings-identity" data-testid="settings-avatar">
-                  <Show when={selectedIdentityNetwork()?.avatar_url}>
-                    {(url) => (
-                      <img
-                        src={url()}
-                        alt="Current avatar"
-                        class="settings-avatar-preview"
-                        width={64}
-                        height={64}
-                      />
-                    )}
-                  </Show>
-
-                  <input
-                    type="file"
-                    accept="image/png,image/jpeg,image/gif,image/webp"
-                    data-testid="settings-avatar-file"
-                    disabled={avatarUploading()}
-                    onChange={(e) => {
-                      const file = e.currentTarget.files?.[0];
-                      e.currentTarget.value = "";
-                      if (file) void onUploadAvatar(file);
-                    }}
-                  />
-                  <p class="settings-identity-hint">
-                    Shown to anyone who sends you a CTCP AVATAR query.
-                  </p>
-
-                  <Show when={selectedIdentityNetwork()?.avatar_url}>
-                    <button
-                      type="button"
-                      class="settings-identity-apply"
-                      data-testid="settings-avatar-remove"
-                      disabled={avatarUploading()}
-                      onClick={() => void onDeleteAvatar()}
-                    >
-                      remove avatar
-                    </button>
-                  </Show>
-
-                  <Show when={avatarUploading()}>
-                    <p class="settings-identity-hint" data-testid="settings-avatar-uploading">
-                      uploading…
-                    </p>
-                  </Show>
-                  <Show when={avatarError()}>
-                    {(msg) => (
-                      <p
-                        role="alert"
-                        class="settings-identity-error"
-                        data-testid="settings-avatar-error"
-                      >
-                        {msg()}
-                      </p>
-                    )}
-                  </Show>
-                </div>
-              </div>
-
-              {/* #124 — the per-network password. THE one place this secret is
-                editable: it is the credential password, the value
-                `$nickserv_pass` expands to, and for a visitor the credential
-                you log into grappa with. The perform editor's rival field is
-                gone — two editable homes for one secret was the split brain
-                this cures. Targets the same network the identity card above
-                does, so the picker there governs both. */}
-              <div
-                class="settings-section settings-section-card"
-                data-testid="settings-section-password"
-              >
-                <h4 class="settings-section-heading">password</h4>
-                <div class="settings-identity" data-testid="settings-password">
-                  <label for="settings-network-password">Network password</label>
-                  <input
-                    id="settings-network-password"
-                    type="password"
-                    autocapitalize="none"
-                    autocorrect="off"
-                    spellcheck={false}
-                    placeholder="type a new password (leave blank to keep)"
-                    value={passwordText()}
-                    data-testid="settings-network-password-input"
-                    onInput={(e) => {
-                      setPasswordText(e.currentTarget.value);
-                      setPasswordSaved(false);
-                    }}
-                  />
-                  <p class="settings-identity-hint">
-                    Your NickServ password for this network. Saving reconnects your session so it
-                    can identify with the new value — you'll briefly drop and rejoin your channels.
-                  </p>
-
-                  <InlineConfirmButton
-                    idleLabel={passwordSaving() ? "saving…" : "save password"}
-                    confirmLabel="save — this reconnects"
-                    testId="settings-password-apply"
-                    armed={passwordArmed()}
-                    onArm={() => setPasswordArmed(true)}
-                    onConfirm={() => {
-                      void onSavePassword();
-                    }}
-                  />
-
-                  <Show when={passwordError()}>
-                    {(msg) => (
-                      <p
-                        role="alert"
-                        class="settings-identity-error"
-                        data-testid="settings-password-error"
-                      >
-                        {msg()}
-                      </p>
-                    )}
-                  </Show>
-                  <Show when={passwordSaved()}>
-                    <p class="settings-identity-ok" data-testid="settings-password-ok">
-                      Password saved.
-                    </p>
-                  </Show>
-                </div>
-              </div>
+              </section>
             </Show>
+
+            {/* issue 1993 — profile, avatar and the peer-profiles opt-in are
+                many fields for something set once, so they moved behind this
+                row into their own sub-page (the drawer's existing sub-page
+                mechanism, not a new disclosure idiom). UNGATED on networks,
+                and OUTSIDE the group above, because the page it opens also
+                carries the ACCOUNT-scoped opt-in: gating the door on a
+                network would strand that control for a subject holding
+                none. */}
+            <button
+              type="button"
+              class="settings-nav-row"
+              data-testid="profile-settings-entry"
+              onClick={() => setSettingsPage("profile")}
+            >
+              <span class="settings-nav-row-text">
+                <span class="settings-nav-row-label">profile</span>
+                <span class="settings-nav-row-subtitle">
+                  your CTCP USERINFO fields and avatar, and whether to ask other people for theirs
+                </span>
+              </span>
+              <span class="settings-nav-row-chevron" aria-hidden="true">
+                ›
+              </span>
+            </button>
 
             {/* #497 — upload retention moved BELOW identity: identity is what a
               user looks for; upload duration is a rarely-touched knob.
@@ -1843,15 +1755,18 @@ const SettingsDrawer: Component<Props> = (props) => {
                   </select>
                 </label>
                 {/* #462 — the select alone answers none of the three questions
-                    it raises. The third one is the load-bearing one: the TTL is
-                    read at UPLOAD time (uploadOrchestrator picks the host token
-                    when it posts the file), so this is not a retention setting
-                    over a library — it applies to the next upload and cannot
-                    reach back to the last one. */}
+                    it raises, and the third is load-bearing: the TTL is read at
+                    UPLOAD time (uploadOrchestrator picks the host token when it
+                    posts the file), so this is not a retention setting over a
+                    library — it applies to the next upload and cannot reach
+                    back to the last one. issue 1993 cut the paragraph to one
+                    line; all three facts survive the cut, which is the point —
+                    the copy pass was about LENGTH, not about dropping what
+                    #462 measured a user cannot guess. */}
                 <p class="settings-section-blurb" data-testid="upload-ttl-hint">
-                  The image host deletes an upload when its time is up. This is your own preference
-                  over the site default, and it applies to uploads you make from now on — files you
-                  have already uploaded keep the duration they were sent with.
+                  Your preference over the site default: the host deletes each new upload when its
+                  time is up, and files you have already uploaded keep the duration they were sent
+                  with.
                 </p>
                 <Show when={uploadTtlSavingError() !== null}>
                   <p class="upload-ttl-error" role="alert" data-testid="upload-ttl-error">
@@ -1882,8 +1797,8 @@ const SettingsDrawer: Component<Props> = (props) => {
                     this is a setting is that the confirm was friction for the
                     operators who did not want it. */}
                 <p class="settings-section-blurb" data-testid="upload-confirm-hint">
-                  Off by default. When on, every file you pick, drop, paste or share to Grappa shows
-                  a preview and waits for you to confirm before it is uploaded and its link posted.
+                  Off by default; when on, every file you pick, drop, paste or share to Grappa waits
+                  for you to confirm before it is uploaded and its link posted.
                 </p>
                 <Show when={uploadConfirmSavingError() !== null}>
                   <p class="upload-ttl-error" role="alert" data-testid="upload-confirm-error">
@@ -1914,7 +1829,12 @@ const SettingsDrawer: Component<Props> = (props) => {
                   fieldsets up: the <label> stays as the row's flex box, the
                   name moves onto the control. NOT the <legend> instead — a
                   legend names the GROUP, and a screen reader landing on the
-                  select would still be told nothing. */}
+                  select would still be told nothing.
+
+                  issue 1993 (5) — that leftover <label> is a flex ROW, so the
+                  select inside it was sized by its own option text. The width
+                  rule lives in the sheet, on the class both bare-label
+                  fieldsets share; the markup here is unchanged. */}
               <label>
                 <select
                   aria-label="auto-away delay"
@@ -1954,9 +1874,8 @@ const SettingsDrawer: Component<Props> = (props) => {
                 </label>
               </Show>
               <p class="settings-section-blurb" data-testid="auto-away-hint">
-                When every device of yours is closed or in the background, the bouncer waits this
-                long and then tells the network you are away. It stays connected either way — this
-                only changes what other people see. Pick "never" to keep the away flag off entirely.
+                How long after your last device closes before the bouncer tells the network you are
+                away — it stays connected either way, and "never" keeps the flag off entirely.
               </p>
               <Show when={autoAwaySavingError() !== null}>
                 <p class="auto-away-error" role="alert" data-testid="auto-away-error">
@@ -1964,11 +1883,202 @@ const SettingsDrawer: Component<Props> = (props) => {
                 </p>
               </Show>
             </fieldset>
+          </section>
+        </Show>
+
+        {/* issue 1993 — profile sub-page, entered from the general page (its
+            back button returns THERE, not to the index). Two scopes on one
+            page, kept visibly apart: the CTCP USERINFO fields + the avatar are
+            per-network and sit under the same picker the identity card uses,
+            while the peer-profiles opt-in is account-wide and sits outside the
+            group. The issue floats making that opt-in network-scoped too;
+            that is a server-side change and deliberately NOT in this slice, so
+            the layout states today's truth rather than anticipating it. */}
+        <Show when={settingsPage() === "profile"}>
+          <section class="settings-subpage profile-subpage" data-testid="profile-subpage">
+            {subpageHeader("profile", "profile-back", "general")}
+
+            <Show when={hasNetworks()}>
+              <section class="settings-network-scope" data-testid="settings-network-scope">
+                <h4 class="settings-section-heading">per-network</h4>
+                {networkScopePicker()}
+
+                {/* KVIrc-style CTCP USERINFO profile (age/gender/location/
+                  languages/a free custom field), per network — targets the
+                  same selected network the identity card does. Unlike
+                  identity, saving does NOT reconnect: these fields never ride
+                  the IRC handshake, they only feed the server's CTCP
+                  USERINFO auto-reply — so a plain save, no two-tap confirm,
+                  and no reason to share the identity card's apply. */}
+                <div
+                  class="settings-section settings-section-card"
+                  data-testid="settings-section-profile"
+                >
+                  <h4 class="settings-section-heading">profile</h4>
+                  <div class="settings-identity" data-testid="settings-profile">
+                    <label for="settings-profile-age">Age</label>
+                    <input
+                      id="settings-profile-age"
+                      type="text"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      value={profileAge()}
+                      onInput={(e) => setProfileAge(e.currentTarget.value)}
+                    />
+
+                    <label for="settings-profile-gender">Gender</label>
+                    <select
+                      id="settings-profile-gender"
+                      data-testid="settings-profile-gender"
+                      value={profileGender()}
+                      onChange={(e) => setProfileGender(e.currentTarget.value)}
+                    >
+                      <option value="">unset</option>
+                      <option value="male">male</option>
+                      <option value="female">female</option>
+                      <option value="nonbinary">non-binary</option>
+                    </select>
+
+                    <label for="settings-profile-location">Location</label>
+                    <input
+                      id="settings-profile-location"
+                      type="text"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      value={profileLocation()}
+                      onInput={(e) => setProfileLocation(e.currentTarget.value)}
+                    />
+
+                    <label for="settings-profile-languages">Languages</label>
+                    <input
+                      id="settings-profile-languages"
+                      type="text"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      value={profileLanguages()}
+                      onInput={(e) => setProfileLanguages(e.currentTarget.value)}
+                    />
+
+                    <label for="settings-profile-custom">Custom</label>
+                    <input
+                      id="settings-profile-custom"
+                      type="text"
+                      autocapitalize="none"
+                      autocorrect="off"
+                      spellcheck={false}
+                      value={profileCustom()}
+                      onInput={(e) => setProfileCustom(e.currentTarget.value)}
+                    />
+                    <p class="settings-identity-hint">
+                      Answered to a CTCP USERINFO query, and a blank field clears it.
+                    </p>
+
+                    <button
+                      type="button"
+                      class="settings-identity-apply"
+                      data-testid="settings-profile-apply"
+                      disabled={profileSaving()}
+                      onClick={() => void onSaveProfile()}
+                    >
+                      {profileSaving() ? "saving…" : "save profile"}
+                    </button>
+
+                    <Show when={profileError()}>
+                      {(msg) => (
+                        <p
+                          role="alert"
+                          class="settings-identity-error"
+                          data-testid="settings-profile-error"
+                        >
+                          {msg()}
+                        </p>
+                      )}
+                    </Show>
+                    <Show when={profileSaved()}>
+                      <p class="settings-identity-ok" data-testid="settings-profile-ok">
+                        Profile saved.
+                      </p>
+                    </Show>
+                  </div>
+                </div>
+
+                {/* M3a — the own avatar, per network. A permanent, self-hosted
+                  upload (same `Grappa.Uploads` pipeline as any other embedded
+                  upload, just `expires_at: nil`), served over CTCP AVATAR to
+                  whoever asks and rendered in peers' WHOIS cards. Never
+                  bounces the connection, like /profile above. */}
+                <div
+                  class="settings-section settings-section-card"
+                  data-testid="settings-section-avatar"
+                >
+                  <h4 class="settings-section-heading">avatar</h4>
+                  <div class="settings-identity" data-testid="settings-avatar">
+                    <Show when={selectedIdentityNetwork()?.avatar_url}>
+                      {(url) => (
+                        <img
+                          src={url()}
+                          alt="Current avatar"
+                          class="settings-avatar-preview"
+                          width={64}
+                          height={64}
+                        />
+                      )}
+                    </Show>
+
+                    <input
+                      type="file"
+                      accept="image/png,image/jpeg,image/gif,image/webp"
+                      data-testid="settings-avatar-file"
+                      disabled={avatarUploading()}
+                      onChange={(e) => {
+                        const file = e.currentTarget.files?.[0];
+                        e.currentTarget.value = "";
+                        if (file) void onUploadAvatar(file);
+                      }}
+                    />
+                    <p class="settings-identity-hint">Answered to a CTCP AVATAR query.</p>
+
+                    <Show when={selectedIdentityNetwork()?.avatar_url}>
+                      <button
+                        type="button"
+                        class="settings-identity-apply"
+                        data-testid="settings-avatar-remove"
+                        disabled={avatarUploading()}
+                        onClick={() => void onDeleteAvatar()}
+                      >
+                        remove avatar
+                      </button>
+                    </Show>
+
+                    <Show when={avatarUploading()}>
+                      <p class="settings-identity-hint" data-testid="settings-avatar-uploading">
+                        uploading…
+                      </p>
+                    </Show>
+                    <Show when={avatarError()}>
+                      {(msg) => (
+                        <p
+                          role="alert"
+                          class="settings-identity-error"
+                          data-testid="settings-avatar-error"
+                        >
+                          {msg()}
+                        </p>
+                      )}
+                    </Show>
+                  </div>
+                </div>
+              </section>
+            </Show>
 
             {/* M2 — opt-in to grappa querying other people's CTCP USERINFO
                 profile (the member-list gender badge's source). Off by
                 default: nobody gets an outbound CTCP query from this
-                bouncer just for existing in a shared channel. */}
+                bouncer just for existing in a shared channel. ACCOUNT-wide,
+                so it sits outside the per-network group above. */}
             <fieldset class="show-peer-profiles-fieldset">
               <legend>peer profiles</legend>
               <label>
@@ -1983,10 +2093,8 @@ const SettingsDrawer: Component<Props> = (props) => {
                 show other people's profile info (gender badge)
               </label>
               <p class="settings-section-blurb" data-testid="show-peer-profiles-hint">
-                When on, grappa asks other users' clients for their public CTCP USERINFO profile the
-                first time you see them in a channel, and shows a gender badge next to their name
-                when they answer. This sends a small extra message to each new person you meet — off
-                by default.
+                Off by default; when on, grappa asks each new person's client for their public
+                profile and shows a gender badge when they answer.
               </p>
               <Show when={showPeerProfilesSavingError() !== null}>
                 <p
@@ -2005,7 +2113,7 @@ const SettingsDrawer: Component<Props> = (props) => {
             colored-nicklist toggle (#443 section moved VERBATIM). */}
         <Show when={settingsPage() === "display"}>
           <section class="settings-subpage display-subpage" data-testid="display-subpage">
-            {subpageHeader("display", "display-back")}
+            {subpageHeader("display", "display-back", "main")}
 
             {/* #299 — the legacy auto/mirc-light/irssi-dark radio selector was
                 removed. It is superseded by the #75 theme gallery (a themes
@@ -2189,7 +2297,7 @@ const SettingsDrawer: Component<Props> = (props) => {
             prefs + device list). Moved VERBATIM from the old flat main page. */}
         <Show when={settingsPage() === "push"}>
           <section class="settings-subpage push-subpage" data-testid="push-subpage">
-            {subpageHeader("notifications", "push-back")}
+            {subpageHeader("notifications", "push-back", "main")}
 
             <fieldset class="notifications-fieldset">
               <legend>notifications</legend>

--- a/cicchetto/src/VhostSettingsPage.tsx
+++ b/cicchetto/src/VhostSettingsPage.tsx
@@ -54,7 +54,9 @@ const VhostSettingsPage: Component<Props> = (props) => {
   // #282 — local two-tap arm for the Reconnect footer button. The sub-page
   // unmounts on ‹ back (it's a `<Show>` branch in SettingsDrawer), so this
   // ephemeral flag auto-resets on leave — no drawer-side disarm needed
-  // (unlike the always-mounted `quitArmed`/`identityArmed`).
+  // (unlike the always-mounted `applyArmed` in SettingsDrawer, which the
+  // drawer's close effect has to disarm by hand; `quitArmed` left with the
+  // lifecycle verbs in #986).
   const [reconnectArmed, setReconnectArmed] = createSignal(false);
   const customizeOn = (): boolean => {
     const o = override();

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -79,6 +79,12 @@ vi.mock("../lib/api", () => ({
     realname: "Real Name",
     auth_method: "none",
   }),
+  // issue 1993 — the NickServ password rides the SAME apply button as
+  // identity now, so a merged apply reaches `lib/lifecycle`'s
+  // `updateNetworkPassword` → `api.putNetworkPassword`. This mock lists its
+  // exports explicitly: without the entry the first merged apply dies on
+  // "No putNetworkPassword export is defined on the mock".
+  putNetworkPassword: vi.fn().mockResolvedValue(undefined),
   // The drawer imports ApiError for the identity-save catch (instanceof
   // narrowing). A minimal class stand-in keeps the import resolvable.
   ApiError: class ApiError extends Error {},
@@ -1948,12 +1954,17 @@ describe("SettingsDrawer (#476/#478 — per-network identity, both subjects)", (
     expect((screen.getByLabelText(/real name/i) as HTMLInputElement).value).toBe("Real B");
 
     // Apply PATCHes the SELECTED network's slug (libera), not the first.
+    // issue 1993 — the merged apply only calls an endpoint whose value CHANGED
+    // (one gesture must not cost more reconnects than the two buttons it
+    // replaced), so the edit below is what makes this apply reach the wire at
+    // all. What it proves is unchanged: the PATCH carries `libera`.
+    fireEvent.input(nick, { target: { value: "nick-b2" } });
     const applyBtn = screen.getByTestId("settings-identity-apply");
     fireEvent.click(applyBtn);
     fireEvent.click(applyBtn);
     await waitFor(() => {
       expect(api.updateNetworkIdentity).toHaveBeenCalledWith("test-bearer", "libera", {
-        nick: "nick-b",
+        nick: "nick-b2",
         ident: "id-b",
         realname: "Real B",
       });
@@ -2206,5 +2217,279 @@ describe("SettingsDrawer — auto-away debounce (#348)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("auto-away-error")).toHaveTextContent("out_of_range");
     });
+  });
+});
+
+// issue 1993 — the general sub-page rework. Three axes, all of them about
+// what the page SAYS about itself: the network-scoped block is grouped under
+// the selector that governs it (1); identity and the NickServ password apply
+// as ONE gesture (2); the write-once profile fields left for a sub-page (3).
+// The copy pass (6) is guarded as a shape rule, not as a string pin.
+describe("SettingsDrawer (issue 1993 — general sub-page rework)", () => {
+  const userMe = {
+    kind: "user" as const,
+    id: "u1",
+    name: "alice",
+    is_admin: false,
+    inserted_at: "2026-06-29T00:00:00Z",
+  };
+
+  const netRow = (id: number, slug: string, nick: string) => ({
+    kind: "user" as const,
+    id,
+    slug,
+    nick,
+    ident: "grp" as string | null,
+    realname: "Real Name" as string | null,
+    connection_state: "connected" as const,
+    connection_state_reason: null as string | null,
+    connection_state_changed_at: null as string | null,
+    inserted_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  });
+
+  const seedUser = (rows: ReturnType<typeof netRow>[]) => {
+    meHolder.current = userMe;
+    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
+    networksHolder.current = rows;
+  };
+
+  const openGeneral = () => {
+    wrap(true);
+    openSub("general-settings-entry");
+  };
+
+  // ── (1) the selector governs a VISIBLE group ──────────────────────────
+  it("lifts the network selector out of the identity card, above the group it governs", () => {
+    seedUser([netRow(1, "azzurra", "nick-a"), netRow(2, "libera", "nick-b")]);
+    openGeneral();
+
+    const group = screen.getByTestId("settings-network-scope");
+    const select = screen.getByTestId("settings-identity-network-select");
+    const identity = screen.getByTestId("settings-section-identity");
+
+    // The selector is IN the group and NO LONGER inside the identity card —
+    // the burial this issue reports.
+    expect(group.contains(select)).toBe(true);
+    expect(identity.contains(select)).toBe(false);
+    // …and it precedes the card whose scope it decides.
+    expect(
+      select.compareDocumentPosition(identity) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(group.contains(identity)).toBe(true);
+  });
+
+  it("keeps the one-option picker hidden (#497) and still groups the card", () => {
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    // #497's ruling survives the regroup: a single network renders no picker.
+    expect(screen.queryByTestId("settings-identity-network-select")).toBeNull();
+    const group = screen.getByTestId("settings-network-scope");
+    expect(group.contains(screen.getByTestId("settings-section-identity"))).toBe(true);
+  });
+
+  it("leaves the account-scoped knobs OUTSIDE the network-scoped group", () => {
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    const group = screen.getByTestId("settings-network-scope");
+    expect(group.contains(screen.getByTestId("upload-ttl-select"))).toBe(false);
+    expect(group.contains(screen.getByTestId("auto-away-select"))).toBe(false);
+  });
+
+  // ── (2) one apply for identity + NickServ password ────────────────────
+  it("moves the password into the identity card under its real name, with no save button of its own", () => {
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    const identity = screen.getByTestId("settings-section-identity");
+    const pw = screen.getByTestId("settings-network-password-input");
+    expect(identity.contains(pw)).toBe(true);
+    // "Network password" was the wrong name for a NickServ secret.
+    expect(screen.getByLabelText(/nickserv password/i)).toBe(pw);
+    // The rival apply is gone — one button, one confirm.
+    expect(screen.queryByTestId("settings-password-apply")).toBeNull();
+    expect(screen.queryByTestId("settings-section-password")).toBeNull();
+  });
+
+  it("applies identity AND password from the single apply", async () => {
+    const api = await import("../lib/api");
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    fireEvent.input(screen.getByLabelText(/^nick$/i), { target: { value: "nick-a2" } });
+    const pw = screen.getByTestId("settings-network-password-input") as HTMLInputElement;
+    fireEvent.input(pw, { target: { value: "s3cret" } });
+
+    const applyBtn = screen.getByTestId("settings-identity-apply");
+    fireEvent.click(applyBtn); // arm
+    fireEvent.click(applyBtn); // confirm
+
+    await waitFor(() => {
+      expect(api.putNetworkPassword).toHaveBeenCalledWith("test-bearer", "azzurra", "s3cret");
+    });
+    await waitFor(() => {
+      expect(api.updateNetworkIdentity).toHaveBeenCalledWith("test-bearer", "azzurra", {
+        nick: "nick-a2",
+        ident: "grp",
+        realname: "Real Name",
+      });
+    });
+    // The field clears on a stored secret — the only readback a write-only
+    // value can offer.
+    await waitFor(() => expect(pw.value).toBe(""));
+  });
+
+  it("never sends a blank password (leave-blank-to-keep survives the merge)", async () => {
+    const api = await import("../lib/api");
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    fireEvent.input(screen.getByLabelText(/^nick$/i), { target: { value: "nick-a2" } });
+    const applyBtn = screen.getByTestId("settings-identity-apply");
+    fireEvent.click(applyBtn);
+    fireEvent.click(applyBtn);
+
+    await waitFor(() => expect(api.updateNetworkIdentity).toHaveBeenCalledTimes(1));
+    expect(api.putNetworkPassword).not.toHaveBeenCalled();
+  });
+
+  it("does not re-apply an untouched identity just because a password was typed", async () => {
+    const api = await import("../lib/api");
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    fireEvent.input(screen.getByTestId("settings-network-password-input"), {
+      target: { value: "s3cret" },
+    });
+    const applyBtn = screen.getByTestId("settings-identity-apply");
+    fireEvent.click(applyBtn);
+    fireEvent.click(applyBtn);
+
+    await waitFor(() => expect(api.putNetworkPassword).toHaveBeenCalledTimes(1));
+    // One reconnect, not two: the identity door is not knocked on for a
+    // value that did not change.
+    expect(api.updateNetworkIdentity).not.toHaveBeenCalled();
+  });
+
+  it("a refused password aborts the apply before the identity reconnect", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.putNetworkPassword).mockRejectedValueOnce(new Error("too short"));
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    fireEvent.input(screen.getByLabelText(/^nick$/i), { target: { value: "nick-a2" } });
+    fireEvent.input(screen.getByTestId("settings-network-password-input"), {
+      target: { value: "x" },
+    });
+    const applyBtn = screen.getByTestId("settings-identity-apply");
+    fireEvent.click(applyBtn);
+    fireEvent.click(applyBtn);
+
+    await waitFor(() => expect(screen.getByTestId("settings-password-error")).toBeInTheDocument());
+    // Fail fast: bouncing the session for the half of the gesture that DID
+    // work would leave the operator guessing which half landed.
+    expect(api.updateNetworkIdentity).not.toHaveBeenCalled();
+  });
+
+  it("says nothing was applied instead of bouncing an unchanged card", async () => {
+    const api = await import("../lib/api");
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    const applyBtn = screen.getByTestId("settings-identity-apply");
+    fireEvent.click(applyBtn);
+    fireEvent.click(applyBtn);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("settings-identity-ok")).toHaveTextContent(/no changes/i),
+    );
+    expect(api.updateNetworkIdentity).not.toHaveBeenCalled();
+    expect(api.putNetworkPassword).not.toHaveBeenCalled();
+  });
+
+  // ── (3) profile / avatar / peer-profiles behind a sub-page ────────────
+  it("moves profile, avatar and the peer-profiles opt-in off the general page", () => {
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    expect(screen.queryByTestId("settings-section-profile")).toBeNull();
+    expect(screen.queryByTestId("settings-section-avatar")).toBeNull();
+    expect(screen.queryByTestId("show-peer-profiles-toggle")).toBeNull();
+    expect(screen.getByTestId("profile-settings-entry")).toBeInTheDocument();
+  });
+
+  it("the profile row opens the sub-page; back returns to general, not to the index", () => {
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+
+    fireEvent.click(screen.getByTestId("profile-settings-entry"));
+    expect(screen.getByTestId("profile-subpage")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-section-profile")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-section-avatar")).toBeInTheDocument();
+    expect(screen.getByTestId("show-peer-profiles-toggle")).toBeInTheDocument();
+    // The general page is replaced while the sub-page is up.
+    expect(screen.queryByTestId("settings-section-identity")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("profile-back"));
+    expect(screen.getByTestId("general-subpage")).toBeInTheDocument();
+    expect(screen.queryByTestId("profile-subpage")).toBeNull();
+    // …and NOT the index: the row that opened it lives one level in.
+    expect(screen.queryByTestId("themes-settings-entry")).toBeNull();
+  });
+
+  it("the sub-page carries the same network scope its cards are keyed to", () => {
+    seedUser([netRow(1, "azzurra", "nick-a"), netRow(2, "libera", "nick-b")]);
+    openGeneral();
+    fireEvent.click(screen.getByTestId("profile-settings-entry"));
+
+    const group = screen.getByTestId("settings-network-scope");
+    const select = screen.getByTestId("settings-identity-network-select");
+    expect(group.contains(select)).toBe(true);
+    expect(group.contains(screen.getByTestId("settings-section-profile"))).toBe(true);
+    expect(group.contains(screen.getByTestId("settings-section-avatar"))).toBe(true);
+    // The opt-in is ACCOUNT-scoped (issue 1993 point 4 is NOT in this slice),
+    // so it must not sit inside a group that claims a network.
+    expect(group.contains(screen.getByTestId("show-peer-profiles-toggle"))).toBe(false);
+  });
+
+  it("keeps the account-scoped opt-in reachable with no networks at all", () => {
+    meHolder.current = userMe;
+    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
+    networksHolder.current = [];
+    openGeneral();
+
+    fireEvent.click(screen.getByTestId("profile-settings-entry"));
+    expect(screen.getByTestId("show-peer-profiles-toggle")).toBeInTheDocument();
+    // Nothing network-scoped to show, so no group claiming one.
+    expect(screen.queryByTestId("settings-network-scope")).toBeNull();
+  });
+
+  // ── (6) the blurbs ────────────────────────────────────────────────────
+  // A length pin would rot on the first reword; what the issue asks for is a
+  // SHAPE — one sentence per control. Counting terminators is the objective
+  // form of "one short line", and it fails the 2-3 sentence paragraphs the
+  // issue measured without freezing a single word of the replacement.
+  it.each([
+    ["general", "general-subpage", "general-settings-entry"],
+    ["profile", "profile-subpage", "profile-settings-entry"],
+  ])("every %s blurb is one sentence", (_name, pageTestId, entryTestId) => {
+    seedUser([netRow(1, "azzurra", "nick-a")]);
+    openGeneral();
+    if (entryTestId === "profile-settings-entry") {
+      fireEvent.click(screen.getByTestId(entryTestId));
+    }
+    const page = screen.getByTestId(pageTestId);
+    const blurbs = Array.from(
+      page.querySelectorAll(".settings-section-blurb, .settings-identity-hint"),
+    );
+    expect(blurbs.length).toBeGreaterThan(0);
+    for (const blurb of blurbs) {
+      const text = (blurb.textContent ?? "").trim();
+      expect(text.length).toBeGreaterThan(0);
+      const sentences = (text.match(/\./g) ?? []).length;
+      expect(sentences, `too many sentences in: ${text}`).toBeLessThanOrEqual(1);
+    }
   });
 });

--- a/cicchetto/src/__tests__/settingsControlSizing.test.ts
+++ b/cicchetto/src/__tests__/settingsControlSizing.test.ts
@@ -100,6 +100,22 @@ describe("#462 — every remaining drawer control clears the tap floor", () => {
   });
 });
 
+// issue 1993 (5) — `.settings-drawer label` is a flex ROW, so a <select> that
+// is the label's whole content is a flex item sized by its own text: the
+// auto-away picker rendered at option width inside a full-width fieldset.
+// Neither `.auto-away-fieldset` nor `.upload-ttl-fieldset` had a rule at all.
+// The guard is on the CLASS — a bare-label wrapper is the #1227/#1766 shape
+// (the visible text was dropped, the label stayed as the box), and BOTH
+// fieldsets that wear it are covered by one rule. The notifications mute
+// picker is deliberately NOT in it: its label still carries visible text that
+// shares the row.
+describe("issue 1993 — a select alone in its label fills the row", () => {
+  it("stretches the bare-label pickers instead of leaving them at content width", () => {
+    const body = ruleBody(":where(.upload-ttl-fieldset, .auto-away-fieldset) > label > select");
+    expect(body).toMatch(/width:\s*100%/);
+  });
+});
+
 describe("#462 — the identity editor has a layout", () => {
   it("stacks the label/field pairs", () => {
     const body = ruleBody(".settings-identity");

--- a/cicchetto/src/lib/settingsNav.ts
+++ b/cicchetto/src/lib/settingsNav.ts
@@ -45,9 +45,17 @@ import { createSignal } from "solid-js";
 // blocks in SettingsDrawer (their signals live in its body) rather than
 // separate components, but they share the same `settingsPage` routing + the
 // deep-link machinery below, so they belong in this union.
+// issue 1993 — "profile" is the first NESTED sub-page: its nav row lives on
+// the general page, not on the main index, and its back button returns to
+// general. The routing needs nothing new for that — the signal is flat and
+// the back target is a parameter now — but a deep-link straight to "profile"
+// therefore lands somewhere the index cannot reach in one tap. Nothing does
+// that today; a future launcher that wants to should send the user to
+// "general" unless it means to strand them one level in.
 export type SettingsSubPage =
   | "main"
   | "general"
+  | "profile"
   | "security"
   | "display"
   | "vhost"

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -10217,6 +10217,32 @@ button.topic-bar-windows-opener {
   width: 100%;
 }
 
+/* issue 1993 — the NETWORK-scoped block of the general + profile sub-pages.
+ * The cards inside are keyed to whatever the picker at its top selects, and
+ * before this the only thing saying so was the picker's own position INSIDE
+ * one of them. A left rule + inset is the lightest thing that reads as "these
+ * belong together and to that selector": the cards keep their own borders, so
+ * a second box around them would be chrome on chrome. */
+.settings-network-scope {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding-left: 0.6rem;
+  border-left: 2px solid var(--border);
+}
+
+/* issue 1993 (5) — `.settings-drawer label` is a flex ROW, so a <select> that
+ * is its label's whole content is a flex item at its own content width: the
+ * auto-away picker rendered at option width inside a full-width fieldset, and
+ * neither fieldset had a rule at all. On the CLASS, not the instance — the
+ * bare-label wrapper is the #1227/#1766 shape (visible text dropped, label
+ * kept as the box) and both fieldsets wearing it want the same answer. The
+ * notifications mute picker is deliberately excluded: its label still carries
+ * visible text sharing the row, so stretching the select would squeeze it. */
+:where(.upload-ttl-fieldset, .auto-away-fieldset) > label > select {
+  width: 100%;
+}
+
 .settings-subpage {
   display: flex;
   flex-direction: column;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48744,3 +48744,121 @@ modal's title, then closes it and opens it again from the drawer.
 
 _Deploy: **HOT**, cic bundle only — no server change, no wire change, no
 protocol bump: the verb never leaves the client._
+<!-- entry #1993 -->
+
+---
+
+## 2026-09-08 — #1993: the general settings page, grouped by what governs it
+
+The general sub-page had grown by accretion. Network-scoped and account-scoped
+controls were interleaved, and the `<select>` deciding WHICH network four of
+them target sat buried inside one of those four — the identity card. Nothing
+above the fold said the identity/profile/avatar/password block was per-network
+at all. What follows is the set of rulings the reshaping needed; the mechanics
+are in the diff.
+
+### Scope is a GROUP, and on the common path the heading is its only witness
+
+The picker is lifted to the top of a `.settings-network-scope` group holding
+exactly what it governs; the account-scoped knobs (upload retention, auto-away)
+stay outside. The heading naming the scope is not decoration, and that is the
+load-bearing half: **#497 stands** — a one-option picker is noise, so a subject
+with a single network never sees the selector at all — which means on the common
+path the heading is the ONLY thing on screen saying what those cards are keyed
+to. Membership asserted on one side proves nothing (a group that swallowed the
+whole page would satisfy it), so the tests assert it two-sided: the identity
+card INSIDE, auto-away and upload retention OUTSIDE.
+
+### One gesture, two endpoints: a CEILING, not a single bounce
+
+Identity and the NickServ password now apply with one button. They remain two
+endpoints — `PATCH /identity` and `PUT /password` fail differently, so the
+signals and the error banners stay separate — and each leg is skipped unless it
+has something to write (`identityDirty()`, password `!== ""`). The password leg
+goes FIRST and fails fast: a refused secret must not buy a reconnect for the
+half of the gesture that would have worked.
+
+**#124's objection is ANSWERED, not overruled.** It refused an earlier fold
+because an untouched password field would be indistinguishable from *clear my
+password*. Leave-blank-to-keep now lives on the password LEG rather than on a
+button of its own: the empty field is never sent, so it cannot mean *clear*. The
+objection was about a semantic the fold destroyed; that semantic survives in a
+different place, which is why the fold became admissible — the ruling was not
+outvoted, its premise stopped holding.
+
+**What the merge guarantees is a CEILING: never MORE reconnects than the two
+buttons it replaces.** A single-axis change costs exactly one bounce; an
+untouched card costs none. It does NOT guarantee ONE bounce when both axes are
+dirty, and that is measured rather than assumed — `identity/2` and
+`update_password/2` BOTH call `live_apply_identity/3`
+(`lib/grappa_web/controllers/networks_controller.ex`), so two writes are two
+reconnect requests. A genuinely single bounce needs a COMBINED SERVER VERB,
+which is a server-side scope change and not this slice. cic cannot manufacture
+one: the only client-side way to spend a single bounce is to withhold a write,
+and withholding a write is originating state.
+
+Renamed while there: "Network password" reads as the server PASS (#1044's
+separate secret, with its own door). This field writes what identifies you to
+NickServ, so that is now what it says.
+
+### Sub-page, not disclosure
+
+Profile, avatar and the peer-profiles opt-in — many fields for something set
+once — moved behind a nav row into their own sub-page. **Chosen over a
+checkbox-driven disclosure because the drawer already HAS sub-pages**: a
+disclosure would mint a second in-drawer navigation idiom for the same job, and
+a second idiom for one job is the accretion this issue exists to undo.
+`subpageHeader` takes its back target as an explicit parameter now, with no
+default — profile is entered from general and must return there, and a defaulted
+back target is precisely the silent-degradation path a wrong return would take.
+
+The door is UNGATED on networks and sits OUTSIDE the per-network group, on
+purpose: the profile page also carries the ACCOUNT-scoped peer-profiles opt-in,
+so gating the door on holding a network would strand a control that has nothing
+to do with networks. "profile" is also the first NESTED sub-page — reachable in
+one tap from general, never from the index — which the flat routing signal
+supports unchanged, but which a future deep link should respect rather than
+stranding someone a level in.
+
+### Point 4 is NOT decided here
+
+Making `show_peer_profiles` network-scoped is deliberately left out. It is a
+server-side scope change that the issue itself files as an open design question,
+and the layout states TODAY's truth — account-wide, outside the per-network
+group — rather than pre-positioning for a ruling nobody has made. If the ruling
+lands the other way the control moves INTO the group, and this paragraph is what
+the current placement meant, not an argument for keeping it.
+
+### A length pass may not drop what a user cannot guess
+
+The blurbs are cut to one sentence each. #462's three facts about upload
+retention all survive INSIDE that one sentence: that pass was about LENGTH, and
+brevity is not licence to drop what a user provably cannot derive from the
+control in front of them. The guard is a SHAPE rule — at most one sentence
+terminator per blurb, over the general and profile pages — not a string pin. A
+string pin would rot on the next reword and teach the next reader to delete the
+guard instead of the prose.
+
+### The select-sizing rule, and exactly what its guard proves
+
+`:where(.upload-ttl-fieldset, .auto-away-fieldset) > label > select { width:
+100% }`. Both fieldsets wear the #1227/#1766 shape — the visible label text was
+dropped and the `<label>` stayed as the flex ROW — which left the select sized
+by its own option text inside a full-width fieldset; neither fieldset carried a
+rule at all. One rule on the class both share. The notifications mute picker is
+deliberately excluded: its label still carries visible text sharing the row. The
+guard reads the CSS SOURCE (`ruleBody`), so it proves what is ASKED of the
+cascade, never what a browser paints.
+
+### What this entry does NOT claim
+
+* Not that the merged apply is ONE reconnect. It is at most two, and exactly two
+  when both axes are dirty — measured on the controller, above.
+* Not that the select sizing was observed in a real browser. The guard is on the
+  source rule; no rendered width was measured anywhere in this slice.
+* Not a ruling on point 4, and not a claim that outside-the-group is where
+  `show_peer_profiles` BELONGS — only that it is where it currently is.
+
+_Deploy: **HOT**, cic bundle only — no server change, no migration, no wire
+change, no protocol bump: nothing here leaves the client except the two REST
+calls the two buttons already made._


### PR DESCRIPTION
Reworks the **general** settings sub-page for issue 1993: points 1, 2, 3, 5 and 6. Point 4 is deliberately out — see below.

The page had grown by accretion. Network-scoped and account-scoped controls were interleaved, and the `<select>` deciding WHICH network four of them target sat buried inside one of those four (the identity card). Nothing above the fold said the identity/profile/avatar/password block was per-network at all.

## What changed

**1 — Scope is a group.** The network picker is lifted out of the identity card to the top of a `.settings-network-scope` group holding exactly what it governs, with a heading naming the scope. The account-scoped knobs (upload retention, auto-away) stay outside it. #497 stands — a one-option picker is noise, so a single-network subject never sees the selector — which means on the common path the heading is the ONLY thing on screen saying what those cards are keyed to. The tests assert membership two-sided: identity card INSIDE, auto-away and upload retention OUTSIDE (a group that swallowed the page would satisfy a one-sided assertion and say nothing).

**2 — Identity + NickServ password apply with ONE button.** Still two endpoints (`PATCH /identity`, `PUT /password` fail differently, so signals and error banners stay separate), but one gesture. The password leg goes first and fails fast; each leg is skipped unless it has something to write. `settings-password-apply` and `settings-section-password` no longer exist. The field is renamed to "NickServ password" — "Network password" reads as the server PASS (#1044's separate secret with its own door).

#124's objection to folding these ("an untouched password field would be indistinguishable from *clear my password*") is **answered, not overruled**: leave-blank-to-keep now lives on the password LEG, which never calls the endpoint for `""`, so the empty field cannot mean *clear*. The ruling was not outvoted; its premise stopped holding.

**3 — Profile, avatar and the peer-profiles opt-in moved to their own sub-page** (`profile`), entered from a nav row on general and returning there. `subpageHeader` now takes its back target as an explicit third parameter, no default.

**5 — The auto-away and upload-retention `<select>`s fill their row.** Both wear the #1227/#1766 shape (visible label text dropped, `<label>` left as the flex row), which left the select sized by its own option text; neither fieldset had a CSS rule at all. One rule on the class both share. The notifications mute picker is deliberately excluded — its label still carries visible text sharing the row.

**6 — Blurbs cut to one sentence each.** #462's three facts about upload retention all survive inside that one sentence: that pass was about LENGTH, not about dropping what a user provably cannot guess. The guard is a SHAPE rule (at most one sentence terminator per blurb, on general + profile), not a string pin — a string pin rots on the next reword.

## Choices declared

**Point 3 — sub-page, not a checkbox disclosure.** The drawer already HAS sub-pages (`general` is itself one), so a disclosure would mint a second in-drawer navigation idiom for the same job — and a second idiom for one job is the accretion this issue exists to undo. The profile door is UNGATED on networks and sits OUTSIDE the per-network group on purpose: the page also carries the ACCOUNT-scoped peer-profiles opt-in, so gating the door on holding a network would strand a control that has nothing to do with networks.

**Point 4 — `show_peer_profiles` stays account-scoped. Left out on purpose.** Making it network-scoped is a SERVER-side scope change, and the issue itself files it as "a design question, not a settled decision". The layout here states today's truth (account-wide, outside the per-network group) rather than pre-positioning for a ruling nobody has made.

## The limit, measured

**The merged button's guarantee is a CEILING — never MORE reconnects than the two buttons it replaces — not a single bounce.** A single-axis change costs exactly one bounce and an untouched card costs none, but when identity AND password are both dirty it is TWO: `identity/2` and `update_password/2` both call `live_apply_identity/3` (`lib/grappa_web/controllers/networks_controller.ex`), so two writes are two reconnect requests. A genuinely single bounce needs a combined server verb — server-side scope, not this slice. cic cannot manufacture one: the only client-side way to spend a single bounce is to withhold a write, and withholding a write is originating state.

## Gates

- `scripts/bun.sh run check` — 5 stages, 0 failed.
- `scripts/bun.sh run test` — 339 files, **6822** tests passed (pre-change baseline on this same tree: 6806; delta +16).
- `scripts/integration.sh` — **FULL** suite (not a scoped `--grep`), 37.6m: **949 passed, 1 skipped, 2 failed**. Per project: chromium 655 ✓ / 1 ✘, chromium-pixel-touch 143 ✓ / 1 ✘, webkit-iphone-15 151 ✓ / 0 ✘. The new spec ran and passed: `✓ 232 [chromium] › issue1993-general-subpage-scope.spec.ts:42:1 (2.4s)`.
- Collection oracle: `playwright test --list` reports **951 tests in 441 files** on the base and **952 in 442** on this branch — the +1 is `e2e/tests/issue1993-general-subpage-scope.spec.ts`, so the new spec was collected and not silently skipped. 949 + 1 skipped + 2 failed = 952, so the whole collection reached a worker.

### The two reds are environmental, measured

`issue290-services-modal` (chromium) and `ux-5-bv-mobile-keyboard-react` (chromium-pixel-touch), neither touched by this branch. Both died the same way, per the saved `error-context.md`: a 10s `toBeVisible` on a *network header* element — `.sidebar-network-header` and `.bottom-bar-network-header`, the desktop/mobile pair the shared login helper waits on (`e2e/fixtures/cicchettoPage.ts:182`) — with the page snapshot still on the boot splash, `fetching networks...` unresolved, "no networks".

The ux-5-bv one names CSS in its title and this branch touches CSS, so it was treated as guilty until falsified. It is not: (a) the assertion that failed is in `loginAs`, before the test's first CSS read, so `readDeclaredHeight(".shell-members", "height")` never ran; (b) the CSS delta here is **+26 / −0** — two brand-new rules, `.settings-network-scope` and `:where(.upload-ttl-fieldset, .auto-away-fieldset) > label > select`, no deletions and no selector overlap, while `readDeclaredHeight` matches on exact selector text; (c) the sibling test in the SAME file that reads `.settings-drawer` — the drawer this PR actually reworks — passed in the same run, on the same project.

Both land inside a stall window on the server side. The #1429 gap census for the run: `grappa-test` GAP **32.7s** at 23:26:30→23:27:03 and GAP **33.1s** at 23:43:24→23:43:57, with `nginx-test` silent across the same two windows (22.5s / 22.7s) — and the two failure screenshots are stamped 23:26:40 and 23:43:34, one inside each. The census also flags the #1420 shape on `grappa-test` for this run: `db30=7 lockheld=2 lockstall_resolved=7 lockstall_unattributed=3 lockstall_nif=10`.

Iso-rerun on this exact HEAD, both specs, `--repeat-each 3`: **9 passed (41.8s), 0 failed** — chromium ×3, chromium-pixel-touch ×3, webkit-iphone-15 ×3. Non-reproducible on the tree under review.

The e2e spec drives TWO networks on purpose, not for coverage: #497 hides the picker above a single network, so a single-network subject cannot exhibit the defect this rework is about. It then witnesses both legs where a jsdom test cannot reach — the identity leg by the subject re-registering upstream and reappearing in the member list, the password leg by the field clearing, which is the only readback a write-only secret has.

## Not claimed

- Not one reconnect when both axes change — two, measured above.
- Point 5 is guarded on the CSS SOURCE (`ruleBody`), which proves what is asked of the cascade, not what a browser paints. No rendered width was measured.
- No ruling on point 4.
