### PR TITLE
cicchetto: preview a staged upload as what it actually is, and let Enter say yes (#1964)

### DIFF
--- a/cicchetto/e2e/tests/issue1883-picker-send-confirm.spec.ts
+++ b/cicchetto/e2e/tests/issue1883-picker-send-confirm.spec.ts
@@ -120,11 +120,13 @@ test("1883 — a removed file is not sent; the rest of the batch is", async ({ p
   await asReturningOperator(page);
 
   // Two files, one image and one document, so the row rendering is exercised
-  // on BOTH shapes: a thumbnail for the picture, name + size for the text.
+  // on BOTH shapes: a thumbnail for the picture, and (since #1964) the first
+  // lines for the text. What this spec pins is the REMOVAL, so it asserts only
+  // the thumbnail count; the per-kind previews are #1964's own spec.
   await page.locator("input[data-file-picker]").setInputFiles([png("keep.png"), txt("drop.txt")]);
 
   await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(2);
-  // The non-image row carries no picture — it is named and sized instead.
+  // The non-image row carries no PICTURE — one thumbnail, for the png.
   await expect(page.getByTestId("confirm-modal-attachment-thumb")).toHaveCount(1);
   await expect(page.getByTestId("confirm-modal-attachments")).toContainText("drop.txt");
 

--- a/cicchetto/e2e/tests/issue1964-upload-confirm-preview.spec.ts
+++ b/cicchetto/e2e/tests/issue1964-upload-confirm-preview.spec.ts
@@ -1,0 +1,160 @@
+// #1964 — the upload confirm previews the file it is asking about, and Enter
+// answers yes.
+//
+// The defect, reported from the paste path: #1883's confirm was built around
+// an image thumbnail, and every other type got `thumbnail: null` — an empty
+// box. On the paste-as-.txt door (#816) the filename is the constant
+// `paste.txt` for every paste in every window, so the dialog asked the
+// operator to authorise an upload showing a constant name, a byte count and
+// nothing else. The second half: Cancel took focus, so Enter — the key you
+// press after reading a dialog — discarded the batch.
+//
+// Why a real browser and not jsdom. Both halves are engine behaviour that a
+// DOM mock cannot witness:
+//
+//   * the previews are `blob:` object URLs handed to `<img>`, `<video>` and
+//     `<audio>`, and the prod CSP gets a vote. #1883 measured exactly this
+//     failure for `img-src` (`blockedURI: blob`, attribute intact, empty box —
+//     green in jsdom, broken on screen). `media-src` is a separate directive,
+//     so video and audio need their own witness here.
+//   * "Enter sends" is the browser turning a keypress on a focused button into
+//     a click. jsdom can assert which element has focus; only a real engine
+//     can show that the key reaches the wire.
+//
+// Parity: the dialog is subject-shape-agnostic (client-side rendering of a
+// local file, no subject in the question), so the seeded user suffices — the
+// same argument #1883 makes.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { TINY_PNG_HEX } from "../fixtures/bytes";
+import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { setUploadConfirmEnabled } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+const fixture = (name: string): Buffer =>
+  readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)));
+
+// Four lines, so the fifth is the witness for the cap: a preview that showed
+// the whole file would be a file viewer, and a 40 MB log pasted into IRC would
+// render 40 MB of DOM.
+const TEXT_BODY = "alpha one\nbeta two\ngamma three\ndelta four\nepsilon five\nzeta six\n";
+
+const png = { name: "keep.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") };
+const txt = { name: "paste.txt", mimeType: "text/plain", buffer: Buffer.from(TEXT_BODY, "utf8") };
+const pdf = {
+  name: "spec.pdf",
+  mimeType: "application/pdf",
+  buffer: Buffer.from("%PDF-1.4\n", "utf8"),
+};
+const mp4 = { name: "clip.mp4", mimeType: "video/mp4", buffer: fixture("tiny.mp4") };
+
+// The operator this issue is about: opted INTO the confirm (it is off by
+// default since #1883) and past the one-shot privacy notice, so the confirm is
+// the only thing on screen.
+async function asConfirmingOperator(page: Page): Promise<void> {
+  await setUploadConfirmEnabled(specUser().token, true);
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await page.evaluate(() =>
+    localStorage.setItem("image-upload-privacy-acknowledged:embedded", "1"),
+  );
+}
+
+test("#1964 — each staged file previews as what it actually is", async ({ page }) => {
+  await asConfirmingOperator(page);
+
+  await page.locator("input[data-file-picker]").setInputFiles([png, mp4, txt, pdf]);
+
+  const confirm = page.getByTestId("confirm-modal");
+  await expect(confirm).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(4);
+
+  // ── image: unchanged from #1883, and it must DECODE ─────────────────────
+  const thumb = page.getByTestId("confirm-modal-attachment-thumb");
+  await expect(thumb).toHaveAttribute("src", /^blob:/);
+  await expect
+    .poll(() => thumb.evaluate((el) => (el as HTMLImageElement).naturalWidth), { timeout: 5_000 })
+    .toBeGreaterThan(0);
+
+  // ── video: a frame, from the same local bytes ───────────────────────────
+  const video = page.getByTestId("confirm-modal-attachment-video");
+  await expect(video).toHaveAttribute("src", /^blob:.*#t=0\.1$/);
+  // The CSP witness, and the reason it is not `videoWidth`: decoding is the
+  // engine's own schedule (a hidden page defers it), but a `media-src` refusal
+  // is immediate and lands as MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED — the
+  // same signature `videoPolicy.ts` documents for a blocked blob:.
+  await expect
+    .poll(() => video.evaluate((el) => (el as HTMLVideoElement).error?.code ?? 0), {
+      timeout: 5_000,
+    })
+    .toBe(0);
+
+  // ── audio: for sound there is no picture, so the preview is the player ───
+  const audio = page.getByTestId("confirm-modal-attachment-audio");
+  await expect(audio).toHaveAttribute("src", /^blob:/);
+  await expect(audio).toHaveAttribute("controls", "");
+
+  // ── text: the case the issue was filed for ──────────────────────────────
+  const source = page.getByTestId("confirm-modal-attachment-source");
+  await expect(source).toContainText("alpha one");
+  await expect(source).toContainText("delta four");
+  // Capped: this is a head, not a viewer.
+  await expect(source).not.toContainText("epsilon five");
+
+  // ── pdf: still nothing, and deliberately — cic has no PDF renderer ──────
+  // One preview element per renderable row and no more: 4 rows, 4 previews,
+  // and the PDF is the one holding the placeholder.
+  await expect(page.getByTestId("confirm-modal-attachment-video")).toHaveCount(1);
+  await expect(page.getByTestId("confirm-modal-attachment-audio")).toHaveCount(1);
+  await expect(page.getByTestId("confirm-modal-attachment-source")).toHaveCount(1);
+  await expect(thumb).toHaveCount(1);
+
+  await page.getByTestId("confirm-modal-cancel").click();
+  await expect(confirm).toBeHidden({ timeout: 5_000 });
+});
+
+test("#1964 — Enter sends the batch instead of discarding it", async ({ page }) => {
+  await asConfirmingOperator(page);
+
+  await page.locator("input[data-file-picker]").setInputFiles([txt]);
+  const confirm = page.getByTestId("confirm-modal");
+  await expect(confirm).toBeVisible({ timeout: 5_000 });
+
+  // The affirmative holds focus, so the key lands on it. Asserted as well as
+  // pressed: a passing Enter with focus elsewhere (the document, a stray
+  // button) would be a different mechanism that happens to work today.
+  await expect(page.getByTestId("confirm-modal-confirm")).toBeFocused({ timeout: 5_000 });
+  await page.keyboard.press("Enter");
+
+  await expect(confirm).toBeHidden({ timeout: 5_000 });
+  // The outcome that reaches the channel, not the button that was clicked.
+  await expect(scrollbackLine(page, "privmsg", "📄").first()).toBeVisible({ timeout: 20_000 });
+});
+
+test("#1964 — Enter still answers after a row is removed", async ({ page }) => {
+  await asConfirmingOperator(page);
+
+  await page.locator("input[data-file-picker]").setInputFiles([png, txt]);
+  const confirm = page.getByTestId("confirm-modal");
+  await expect(confirm).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(2);
+
+  // Measured in a browser during #1964: the × the operator presses unmounts
+  // with its row and focus falls to <body>, so the next Enter answers NOTHING
+  // — in the one dialog where Enter is meant to send. The cure hands focus
+  // back to the request's default button.
+  await page.getByRole("button", { name: /remove keep\.png/i }).click();
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(1);
+  await expect(page.getByTestId("confirm-modal-confirm")).toBeFocused({ timeout: 5_000 });
+
+  await page.keyboard.press("Enter");
+  await expect(confirm).toBeHidden({ timeout: 5_000 });
+  await expect(scrollbackLine(page, "privmsg", "📄").first()).toBeVisible({ timeout: 20_000 });
+  // The removed file did not ride along.
+  await expect(scrollbackLine(page, "privmsg", "📸")).toHaveCount(0);
+});

--- a/cicchetto/e2e/tests/issue1964-upload-confirm-preview.spec.ts
+++ b/cicchetto/e2e/tests/issue1964-upload-confirm-preview.spec.ts
@@ -53,6 +53,35 @@ const pdf = {
 };
 const mp4 = { name: "clip.mp4", mimeType: "video/mp4", buffer: fixture("tiny.mp4") };
 
+// A 0.1 s silent 16-bit PCM mono WAV, built here rather than committed as a
+// binary: the header is 44 bytes of documented layout and the payload is
+// zeroes, so a reader can check it against the spec instead of trusting an
+// opaque blob. Silence is enough — the audio preview is a PLAYER, not a
+// waveform, so what is asserted is that the element exists and the engine
+// accepts the source.
+function silentWav(): Buffer {
+  const rate = 8000;
+  const samples = rate / 10;
+  const dataBytes = samples * 2;
+  const buf = Buffer.alloc(44 + dataBytes);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + dataBytes, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16); // PCM header size
+  buf.writeUInt16LE(1, 20); // format: PCM
+  buf.writeUInt16LE(1, 22); // channels: mono
+  buf.writeUInt32LE(rate, 24);
+  buf.writeUInt32LE(rate * 2, 28); // byte rate
+  buf.writeUInt16LE(2, 32); // block align
+  buf.writeUInt16LE(16, 34); // bits per sample
+  buf.write("data", 36);
+  buf.writeUInt32LE(dataBytes, 40);
+  return buf;
+}
+
+const wav = { name: "tone.wav", mimeType: "audio/wav", buffer: silentWav() };
+
 // The operator this issue is about: opted INTO the confirm (it is off by
 // default since #1883) and past the one-shot privacy notice, so the confirm is
 // the only thing on screen.
@@ -68,11 +97,11 @@ async function asConfirmingOperator(page: Page): Promise<void> {
 test("#1964 — each staged file previews as what it actually is", async ({ page }) => {
   await asConfirmingOperator(page);
 
-  await page.locator("input[data-file-picker]").setInputFiles([png, mp4, txt, pdf]);
+  await page.locator("input[data-file-picker]").setInputFiles([png, mp4, wav, txt, pdf]);
 
   const confirm = page.getByTestId("confirm-modal");
   await expect(confirm).toBeVisible({ timeout: 5_000 });
-  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(4);
+  await expect(page.getByTestId("confirm-modal-attachment")).toHaveCount(5);
 
   // ── image: unchanged from #1883, and it must DECODE ─────────────────────
   const thumb = page.getByTestId("confirm-modal-attachment-thumb");
@@ -107,7 +136,7 @@ test("#1964 — each staged file previews as what it actually is", async ({ page
   await expect(source).not.toContainText("epsilon five");
 
   // ── pdf: still nothing, and deliberately — cic has no PDF renderer ──────
-  // One preview element per renderable row and no more: 4 rows, 4 previews,
+  // One preview element per renderable row and no more: 5 rows, 4 previews,
   // and the PDF is the one holding the placeholder.
   await expect(page.getByTestId("confirm-modal-attachment-video")).toHaveCount(1);
   await expect(page.getByTestId("confirm-modal-attachment-audio")).toHaveCount(1);

--- a/cicchetto/e2e/tests/issue1964-upload-confirm-preview.spec.ts
+++ b/cicchetto/e2e/tests/issue1964-upload-confirm-preview.spec.ts
@@ -110,9 +110,11 @@ test("#1964 — each staged file previews as what it actually is", async ({ page
     .poll(() => thumb.evaluate((el) => (el as HTMLImageElement).naturalWidth), { timeout: 5_000 })
     .toBeGreaterThan(0);
 
-  // ── video: a frame, from the same local bytes ───────────────────────────
+  // ── video: playable, from the same local bytes ──────────────────────────
   const video = page.getByTestId("confirm-modal-attachment-video");
   await expect(video).toHaveAttribute("src", /^blob:.*#t=0\.1$/);
+  // A video is a thing that MOVES, so recognising the take means watching it.
+  await expect(video).toHaveAttribute("controls", "");
   // The CSP witness, and the reason it is not `videoWidth`: decoding is the
   // engine's own schedule (a hidden page defers it), but a `media-src` refusal
   // is immediate and lands as MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED — the
@@ -135,9 +137,14 @@ test("#1964 — each staged file previews as what it actually is", async ({ page
   // Capped: this is a head, not a viewer.
   await expect(source).not.toContainText("epsilon five");
 
-  // ── pdf: still nothing, and deliberately — cic has no PDF renderer ──────
+  // ── pdf: no preview, and it SAYS so ─────────────────────────────────────
+  // cic has no PDF renderer — the viewer has four arms and a 📄 link falls
+  // through to the browser — so this row states the limit in words instead of
+  // showing an empty box that reads as a picture which failed to load.
+  const pdfRow = page.getByTestId("confirm-modal-attachment").filter({ hasText: "spec.pdf" });
+  await expect(pdfRow).toContainText("preview not supported");
   // One preview element per renderable row and no more: 5 rows, 4 previews,
-  // and the PDF is the one holding the placeholder.
+  // and the PDF holds none of them.
   await expect(page.getByTestId("confirm-modal-attachment-video")).toHaveCount(1);
   await expect(page.getByTestId("confirm-modal-attachment-audio")).toHaveCount(1);
   await expect(page.getByTestId("confirm-modal-attachment-source")).toHaveCount(1);

--- a/cicchetto/src/ConfirmModal.tsx
+++ b/cicchetto/src/ConfirmModal.tsx
@@ -24,19 +24,25 @@ import { createOverlayLock } from "./lib/overlayScrollLock";
 // mounted once per Shell layout branch (mobile + desktop). Replaces the
 // removed #172 hold-to-close gesture.
 //
-// Cancel is the SAFE default: it takes initial focus (so a stray Enter
-// dismisses, never leaves), and backdrop-click + Esc both dismiss without
-// firing. Only the explicit affirmative button runs the carried action.
-// Structure mirrors DeleteAccountModal (backdrop-nested dialog + overlay
-// scroll-lock), the closest existing confirm-shaped modal.
+// Backdrop-click and Esc always dismiss without firing; only the explicit
+// affirmative button runs the carried action. Structure mirrors
+// DeleteAccountModal (backdrop-nested dialog + overlay scroll-lock), the
+// closest existing confirm-shaped modal.
+//
+// #1964 — which button takes INITIAL FOCUS, and therefore what a bare Enter
+// answers, is now the request's own call (`ConfirmRequest.defaultButton`).
+// #195's "Cancel is the SAFE default" still describes nine of the ten call
+// sites and the reasoning for it has not changed; the upload confirm is the
+// exception, and the argument for it lives beside that field rather than being
+// re-stated here.
 //
 // 1883 — an OPTIONAL attachment list sits between the body and the buttons,
 // for requests whose question is about FILES. It is the same chrome, not a
-// second modal: the file-upload confirm gets the same scrim, the same Esc, the
-// same Cancel-first focus order as every other confirm in cic, and cic gains
-// no new overlay to keep consistent. The rows arrive pre-formatted (see
-// ConfirmAttachment) — this component decides layout and object-URL lifetime,
-// nothing else.
+// second modal: the file-upload confirm gets the same scrim and the same Esc
+// as every other confirm in cic, and cic gains no new overlay to keep
+// consistent. The rows arrive pre-formatted (see ConfirmAttachment) — this
+// component decides layout, object-URL lifetime and how each preview kind is
+// rendered, nothing else.
 
 // One attachment row. Its OWN component so the object URL can be minted and
 // revoked by the row's lifecycle: `onCleanup` here fires when the row leaves —
@@ -69,9 +75,13 @@ const AttachmentRow: Component<{
   // Read once, not reactively: `<For>` hands each row a stable item object, so
   // a row's preview never changes under it — a re-mint would only churn URLs.
   const preview = props.item.preview;
-  const src = preview === null ? null : URL.createObjectURL(preview.blob);
-  if (src !== null) onCleanup(() => URL.revokeObjectURL(src));
   const kind = preview?.kind ?? null;
+  // No URL for a text row: it renders a `<pre>` of lines read from the Blob, so
+  // a URL there would pin the Blob for the dialog's life and be handed to
+  // nothing.
+  const src =
+    preview === null || preview.kind === "text" ? null : URL.createObjectURL(preview.blob);
+  if (src !== null) onCleanup(() => URL.revokeObjectURL(src));
 
   // Async, hence a resource: the dialog paints at once and the lines land when
   // the disk answers. A read that fails resolves to `[]` (see
@@ -109,10 +119,13 @@ const AttachmentRow: Component<{
             />
           </Match>
           <Match when={src !== null && kind === "video"}>
-            {/* No caption track and no `controls`: this is a still frame
-                standing in for a picture, so it carries nothing to operate and
-                nothing to caption. It is decorative for the same reason as the
-                image's empty alt — the filename beside it is the label. */}
+            {/* No caption track and no `controls`: a still frame standing in
+                for a picture, with nothing to operate and nothing to caption.
+                `aria-hidden` rather than the image's `alt=""` because an empty
+                alt REMOVES an `<img>` from the a11y tree while an unnamed
+                `<video>` stays in it and is announced ahead of the filename
+                that labels it. */}
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: without `controls` a <video> is not in the tab order, so hiding it traps no focus */}
             <video
               class="confirm-modal-attachment-thumb"
               data-testid="confirm-modal-attachment-video"
@@ -120,6 +133,7 @@ const AttachmentRow: Component<{
               preload="metadata"
               muted
               playsinline
+              aria-hidden="true"
             />
           </Match>
         </Switch>

--- a/cicchetto/src/ConfirmModal.tsx
+++ b/cicchetto/src/ConfirmModal.tsx
@@ -1,13 +1,4 @@
-import {
-  type Component,
-  createEffect,
-  createResource,
-  For,
-  Match,
-  onCleanup,
-  Show,
-  Switch,
-} from "solid-js";
+import { type Component, createEffect, createResource, For, onCleanup, Show } from "solid-js";
 import { readTextPreview, TEXT_PREVIEW_LINES } from "./lib/attachmentPreview";
 import {
   acceptConfirm,
@@ -55,11 +46,12 @@ import { createOverlayLock } from "./lib/overlayScrollLock";
 // media viewer's four arms (MediaViewerModal's `<Switch>`), pointed at a
 // `blob:` URL of a file that has not been uploaded yet:
 //
-//   image  an `<img>`, unchanged from #1883.
-//   video  a `<video preload="metadata">`, no controls: at 2.5rem a control bar
-//          is unusable, and the first frame is the thing being recognised. The
-//          `#t=0.1` fragment asks for a frame rather than a black poster on
-//          engines that would otherwise decode nothing until play.
+//   image  an `<img>` thumbnail in the row head, unchanged from #1883.
+//   video  a `<video controls>` on its own line: a video is a thing that moves,
+//          so recognising it means watching it, and a control bar is unusable
+//          at 2.5rem. The `#t=0.1` fragment asks for a frame rather than a
+//          black poster on engines that would otherwise decode nothing until
+//          play.
 //   audio  an `<audio controls>` on its own line, because for sound there is no
 //          picture to recognise — listening IS the preview, and it is the same
 //          element the viewer gives a clicked audio link.
@@ -95,48 +87,28 @@ const AttachmentRow: Component<{
 
   return (
     <li class="confirm-modal-attachment" data-testid="confirm-modal-attachment">
-      {/* The row's first line is the #1883 shape exactly: media box, name and
-          size, remove button. Anything taller than the box (sound, text) goes
-          UNDER it, so a mixed batch still reads as a column of like rows. */}
+      {/* The row's first line is the #1883 shape: thumbnail, name and size,
+          remove button. Only a picture fits it — every preview that needs room
+          to be OPERATED (video, sound) or read (text) goes UNDER it, so a mixed
+          batch still reads as a column of like rows rather than a ragged grid. */}
       <div class="confirm-modal-attachment-head">
-        <Switch
-          fallback={
-            <span class="confirm-modal-attachment-icon" aria-hidden="true">
-              {/* Nothing renderable — a neutral placeholder keeps the rows the
-                  same height so a mixed batch does not read as ragged. */}
-              &#9744;
-            </span>
-          }
-        >
-          <Match when={src !== null && kind === "image"}>
-            <img
-              class="confirm-modal-attachment-thumb"
-              data-testid="confirm-modal-attachment-thumb"
-              src={src ?? ""}
-              // The filename beside it is the accessible label; announcing the
-              // picture too would read the same file twice.
-              alt=""
-            />
-          </Match>
-          <Match when={src !== null && kind === "video"}>
-            {/* No caption track and no `controls`: a still frame standing in
-                for a picture, with nothing to operate and nothing to caption.
-                `aria-hidden` rather than the image's `alt=""` because an empty
-                alt REMOVES an `<img>` from the a11y tree while an unnamed
-                `<video>` stays in it and is announced ahead of the filename
-                that labels it. */}
-            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: without `controls` a <video> is not in the tab order, so hiding it traps no focus */}
-            <video
-              class="confirm-modal-attachment-thumb"
-              data-testid="confirm-modal-attachment-video"
-              src={`${src ?? ""}#t=0.1`}
-              preload="metadata"
-              muted
-              playsinline
-              aria-hidden="true"
-            />
-          </Match>
-        </Switch>
+        {/* No fallback box, deliberately. #1883 put a neutral ☐ glyph here to
+            keep rows the same height, but that glyph reads as a picture that
+            failed to load — and the rows stopped being uniform the moment a
+            preview could be a player. A row with nothing to show says
+            "preview not supported" in its detail line instead of miming a
+            broken image, and the rows that preview BELOW the head no longer
+            carry a "no picture here" glyph beside a preview that works. */}
+        <Show when={src !== null && kind === "image"}>
+          <img
+            class="confirm-modal-attachment-thumb"
+            data-testid="confirm-modal-attachment-thumb"
+            src={src ?? ""}
+            // The filename beside it is the accessible label; announcing the
+            // picture too would read the same file twice.
+            alt=""
+          />
+        </Show>
         <span class="confirm-modal-attachment-text">
           <span class="confirm-modal-attachment-name">{props.item.label}</span>
           <span class="confirm-modal-attachment-detail">{props.item.detail}</span>
@@ -153,6 +125,27 @@ const AttachmentRow: Component<{
           &times;
         </button>
       </div>
+      {/* Gabriele's ruling (2026-09-08): the video preview PLAYS. A still frame
+          answers "which clip is this" for a photo-shaped file, but a video is
+          a thing that moves — the operator checking they picked the right take
+          has to watch it. That needs `controls`, and a control bar is unusable
+          at 2.5rem, so the video leaves the head box and takes a full-width
+          block like the sound player. Same reasoning, same shape. */}
+      <Show when={src !== null && kind === "video"}>
+        {/* biome-ignore lint/a11y/useMediaCaption: a staged local upload — no caption track exists or can be authored for it */}
+        <video
+          class="confirm-modal-attachment-video"
+          data-testid="confirm-modal-attachment-video"
+          // The media fragment asks for a frame rather than a black poster on
+          // engines that would otherwise decode nothing until play.
+          src={`${src ?? ""}#t=0.1`}
+          controls
+          playsinline
+          preload="metadata"
+          // Operable, so it needs a name: "video" beside a filename is not one.
+          aria-label={`Play ${props.item.label}`}
+        />
+      </Show>
       <Show when={src !== null && kind === "audio"}>
         {/* biome-ignore lint/a11y/useMediaCaption: a staged local upload — no caption track exists or can be authored for it */}
         <audio

--- a/cicchetto/src/ConfirmModal.tsx
+++ b/cicchetto/src/ConfirmModal.tsx
@@ -1,7 +1,18 @@
-import { type Component, createEffect, For, onCleanup, Show } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createResource,
+  For,
+  Match,
+  onCleanup,
+  Show,
+  Switch,
+} from "solid-js";
+import { readTextPreview, TEXT_PREVIEW_LINES } from "./lib/attachmentPreview";
 import {
   acceptConfirm,
   type ConfirmAttachment,
+  type ConfirmRequest,
   chooseAlternative,
   confirmRequest,
   dismissConfirm,
@@ -33,78 +44,159 @@ import { createOverlayLock } from "./lib/overlayScrollLock";
 // place that knows the URL is finished with. Doing it in the store would need
 // a dismiss hook the store deliberately does not have; doing it in the caller
 // would leak on every path it forgot.
+//
+// #1964 — the preview is per KIND, not image-or-nothing. The four arms are the
+// media viewer's four arms (MediaViewerModal's `<Switch>`), pointed at a
+// `blob:` URL of a file that has not been uploaded yet:
+//
+//   image  an `<img>`, unchanged from #1883.
+//   video  a `<video preload="metadata">`, no controls: at 2.5rem a control bar
+//          is unusable, and the first frame is the thing being recognised. The
+//          `#t=0.1` fragment asks for a frame rather than a black poster on
+//          engines that would otherwise decode nothing until play.
+//   audio  an `<audio controls>` on its own line, because for sound there is no
+//          picture to recognise — listening IS the preview, and it is the same
+//          element the viewer gives a clicked audio link.
+//   text   the first lines, read from the File. This is the one arm that cannot
+//          reuse the viewer's: `TextPane` fetches through `textResource.ts`
+//          with a `Range` header, and a blob: URL does not honour Range.
+//
+// A file with no renderer (PDF, spreadsheets) keeps the neutral placeholder.
 const AttachmentRow: Component<{
   item: ConfirmAttachment;
   onRemove: (id: string) => void;
 }> = (props) => {
   // Read once, not reactively: `<For>` hands each row a stable item object, so
-  // a row's blob never changes under it — a re-mint would only churn URLs.
-  const blob = props.item.thumbnail;
-  const src = blob === null ? null : URL.createObjectURL(blob);
+  // a row's preview never changes under it — a re-mint would only churn URLs.
+  const preview = props.item.preview;
+  const src = preview === null ? null : URL.createObjectURL(preview.blob);
   if (src !== null) onCleanup(() => URL.revokeObjectURL(src));
+  const kind = preview?.kind ?? null;
+
+  // Async, hence a resource: the dialog paints at once and the lines land when
+  // the disk answers. A read that fails resolves to `[]` (see
+  // `readTextPreview`), so the row degrades to its placeholder instead of
+  // taking the modal down with it.
+  const [lines] = createResource(
+    () => (preview !== null && preview.kind === "text" ? preview.blob : undefined),
+    (blob) => readTextPreview(blob, TEXT_PREVIEW_LINES),
+  );
+  const sourceText = (): string => (lines() ?? []).join("\n");
 
   return (
     <li class="confirm-modal-attachment" data-testid="confirm-modal-attachment">
-      <Show
-        when={src}
-        fallback={
-          <span class="confirm-modal-attachment-icon" aria-hidden="true">
-            {/* No picture to show — a neutral placeholder keeps the rows the
-                same height so a mixed batch does not read as ragged. */}
-            &#9744;
-          </span>
-        }
-      >
-        {(url) => (
-          <img
-            class="confirm-modal-attachment-thumb"
-            data-testid="confirm-modal-attachment-thumb"
-            src={url()}
-            // The filename beside it is the accessible label; announcing the
-            // picture too would read the same file twice.
-            alt=""
-          />
-        )}
+      {/* The row's first line is the #1883 shape exactly: media box, name and
+          size, remove button. Anything taller than the box (sound, text) goes
+          UNDER it, so a mixed batch still reads as a column of like rows. */}
+      <div class="confirm-modal-attachment-head">
+        <Switch
+          fallback={
+            <span class="confirm-modal-attachment-icon" aria-hidden="true">
+              {/* Nothing renderable — a neutral placeholder keeps the rows the
+                  same height so a mixed batch does not read as ragged. */}
+              &#9744;
+            </span>
+          }
+        >
+          <Match when={src !== null && kind === "image"}>
+            <img
+              class="confirm-modal-attachment-thumb"
+              data-testid="confirm-modal-attachment-thumb"
+              src={src ?? ""}
+              // The filename beside it is the accessible label; announcing the
+              // picture too would read the same file twice.
+              alt=""
+            />
+          </Match>
+          <Match when={src !== null && kind === "video"}>
+            {/* No caption track and no `controls`: this is a still frame
+                standing in for a picture, so it carries nothing to operate and
+                nothing to caption. It is decorative for the same reason as the
+                image's empty alt — the filename beside it is the label. */}
+            <video
+              class="confirm-modal-attachment-thumb"
+              data-testid="confirm-modal-attachment-video"
+              src={`${src ?? ""}#t=0.1`}
+              preload="metadata"
+              muted
+              playsinline
+            />
+          </Match>
+        </Switch>
+        <span class="confirm-modal-attachment-text">
+          <span class="confirm-modal-attachment-name">{props.item.label}</span>
+          <span class="confirm-modal-attachment-detail">{props.item.detail}</span>
+        </span>
+        <button
+          type="button"
+          class="confirm-modal-attachment-remove"
+          // Named per file: three bare × buttons are indistinguishable to a
+          // screen reader, and picking the wrong one is the very mistake this
+          // dialog exists to catch.
+          aria-label={`Remove ${props.item.label}`}
+          onClick={() => props.onRemove(props.item.id)}
+        >
+          &times;
+        </button>
+      </div>
+      <Show when={src !== null && kind === "audio"}>
+        {/* biome-ignore lint/a11y/useMediaCaption: a staged local upload — no caption track exists or can be authored for it */}
+        <audio
+          class="confirm-modal-attachment-audio"
+          data-testid="confirm-modal-attachment-audio"
+          src={src ?? ""}
+          controls
+          preload="metadata"
+          // An <audio> has no accessible name of its own, and "audio" beside a
+          // filename the operator cannot hear is not one.
+          aria-label={`Play ${props.item.label}`}
+        />
       </Show>
-      <span class="confirm-modal-attachment-text">
-        <span class="confirm-modal-attachment-name">{props.item.label}</span>
-        <span class="confirm-modal-attachment-detail">{props.item.detail}</span>
-      </span>
-      <button
-        type="button"
-        class="confirm-modal-attachment-remove"
-        // Named per file: three bare × buttons are indistinguishable to a
-        // screen reader, and picking the wrong one is the very mistake this
-        // dialog exists to catch.
-        aria-label={`Remove ${props.item.label}`}
-        onClick={() => props.onRemove(props.item.id)}
-      >
-        &times;
-      </button>
+      <Show when={sourceText() !== ""}>
+        <pre class="confirm-modal-attachment-source" data-testid="confirm-modal-attachment-source">
+          {sourceText()}
+        </pre>
+      </Show>
     </li>
   );
 };
 
 const ConfirmModal: Component = () => {
   let cancelBtn: HTMLButtonElement | undefined;
+  let confirmBtn: HTMLButtonElement | undefined;
 
   // Overlay scroll-lock + #232 shared Esc-to-close. dismissConfirm is the
   // same SAFE close verb Cancel / backdrop use — Esc never fires the carried
   // action (topmost-first, focus-independent).
   createOverlayLock(() => confirmRequest() !== null, ".confirm-modal", dismissConfirm);
 
-  // Autofocus Cancel on open — the non-destructive default per #195 (a stray
-  // Enter dismisses, never confirms). Edge-triggered so a re-render with the
-  // same open value doesn't re-steal focus.
-  let wasOpen = false;
+  // Autofocus the request's own default button, which is what a bare Enter
+  // answers. #195 focused Cancel unconditionally ("a stray Enter dismisses,
+  // never confirms"); #1964 made it per-request, because the upload confirm's
+  // Cancel is the answer that loses work — see `ConfirmRequest.defaultButton`.
+  //
+  // Keyed on the REQUEST OBJECT, not on an open/closed edge. The `<Show>` is
+  // unkeyed, so a request replaced by another one never unmounts the dialog:
+  // an open-edge guard would leave focus wherever the previous question left
+  // it, and that is exactly the paste path (the guard's "Upload as .txt" door
+  // clears the store and opens the send confirm in the same tick, so the
+  // intermediate null is never observed). Identity still gives #195's other
+  // half for free — a re-render with the SAME request does not re-steal focus.
+  const focusDefault = (req: ConfirmRequest): void => {
+    const target = req.defaultButton === "confirm" ? confirmBtn : cancelBtn;
+    queueMicrotask(() => target?.focus());
+  };
+
+  let focusedRequest: ConfirmRequest | null = null;
   createEffect(() => {
-    const open = confirmRequest() !== null;
-    if (open && !wasOpen) {
-      wasOpen = true;
-      queueMicrotask(() => cancelBtn?.focus());
-    } else if (!open && wasOpen) {
-      wasOpen = false;
+    const req = confirmRequest();
+    if (req === null) {
+      focusedRequest = null;
+      return;
     }
+    if (req === focusedRequest) return;
+    focusedRequest = req;
+    focusDefault(req);
   });
 
   return (
@@ -140,7 +232,23 @@ const ConfirmModal: Component = () => {
               {(atts) => (
                 <ul class="confirm-modal-attachments" data-testid="confirm-modal-attachments">
                   <For each={atts().items()}>
-                    {(item) => <AttachmentRow item={item} onRemove={atts().onRemove} />}
+                    {(item) => (
+                      <AttachmentRow
+                        item={item}
+                        onRemove={(id) => {
+                          atts().onRemove(id);
+                          // #1964 — the × the operator just pressed unmounts
+                          // with its row, and focus falls to <body>: the next
+                          // Enter then answers NOTHING, in the one dialog
+                          // where Enter is supposed to send. Measured in the
+                          // browser, not reasoned. Hand focus back to whatever
+                          // this request calls its default, which is the same
+                          // button the keyboard had before the removal.
+                          const current = confirmRequest();
+                          if (current !== null) focusDefault(current);
+                        }}
+                      />
+                    )}
                   </For>
                 </ul>
               )}
@@ -172,6 +280,7 @@ const ConfirmModal: Component = () => {
                 )}
               </Show>
               <button
+                ref={confirmBtn}
                 type="button"
                 class="confirm-modal-confirm"
                 data-testid="confirm-modal-confirm"

--- a/cicchetto/src/ThemeGallery.tsx
+++ b/cicchetto/src/ThemeGallery.tsx
@@ -229,6 +229,7 @@ const ThemeGallery: Component<Props> = (props) => {
       onConfirm: () => void remove(theme),
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
 
   // #333 — split the merged list into "your themes" (owned copies/creates)

--- a/cicchetto/src/__tests__/ConfirmModal.test.tsx
+++ b/cicchetto/src/__tests__/ConfirmModal.test.tsx
@@ -276,6 +276,12 @@ describe("ConfirmModal (#195)", () => {
       const video = screen.getByTestId("confirm-modal-attachment-video");
       // The media fragment is what asks for a frame instead of a black poster.
       expect(video.getAttribute("src")).toMatch(/^blob:.*#t=0\.1$/);
+      // Playable, not a still: a video is a thing that moves, so checking the
+      // operator picked the right take means watching it.
+      expect(video.hasAttribute("controls")).toBe(true);
+      expect(video.getAttribute("aria-label")).toBe("Play clip.mp4");
+      // It is NOT the head thumbnail — a control bar is unusable at 2.5rem, so
+      // it takes a full-width block under the row like the sound player.
       expect(screen.queryByTestId("confirm-modal-attachment-thumb")).toBeNull();
     });
 
@@ -342,11 +348,20 @@ describe("ConfirmModal (#195)", () => {
       create.mockRestore();
     });
 
-    it("a row with nothing renderable keeps the placeholder and mints no URL", () => {
+    // The row that cannot be previewed shows NO box at all. #1883's neutral ☐
+    // glyph kept rows the same height, but it reads as a picture that failed
+    // to load — a different claim from "this type has no viewer" — and the
+    // rows stopped being uniform when audio and text previews arrived.
+    it("a row with nothing renderable shows no box at all, and mints no URL", () => {
       const create = vi.spyOn(URL, "createObjectURL");
       render(() => <ConfirmModal />);
-      withAttachments([attachment({ label: "spec.pdf", preview: null })], vi.fn());
+      withAttachments(
+        [attachment({ label: "spec.pdf", detail: "2 KB · preview not supported", preview: null })],
+        vi.fn(),
+      );
 
+      expect(screen.getByText("2 KB · preview not supported")).toBeInTheDocument();
+      expect(document.querySelector(".confirm-modal-attachment-icon")).toBeNull();
       expect(screen.queryByTestId("confirm-modal-attachment-thumb")).toBeNull();
       expect(screen.queryByTestId("confirm-modal-attachment-video")).toBeNull();
       expect(screen.queryByTestId("confirm-modal-attachment-audio")).toBeNull();

--- a/cicchetto/src/__tests__/ConfirmModal.test.tsx
+++ b/cicchetto/src/__tests__/ConfirmModal.test.tsx
@@ -33,6 +33,7 @@ describe("ConfirmModal (#195)", () => {
       onConfirm: vi.fn(),
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
     expect(screen.getByTestId("confirm-modal-body").textContent).toBe(
@@ -52,6 +53,7 @@ describe("ConfirmModal (#195)", () => {
       onConfirm,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     fireEvent.click(screen.getByTestId("confirm-modal-confirm"));
     expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -68,6 +70,7 @@ describe("ConfirmModal (#195)", () => {
       onConfirm,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     fireEvent.click(screen.getByTestId("confirm-modal-cancel"));
     expect(onConfirm).not.toHaveBeenCalled();
@@ -84,6 +87,7 @@ describe("ConfirmModal (#195)", () => {
       onConfirm,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     fireEvent.click(screen.getByTestId("confirm-modal-backdrop"));
     expect(onConfirm).not.toHaveBeenCalled();
@@ -103,6 +107,7 @@ describe("ConfirmModal (#195)", () => {
       onConfirm,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     await waitFor(() => expect(overlayEscapeDepth()).toBe(1));
     expect(runTopmostOverlayEscape()).toBe(true);
@@ -125,6 +130,7 @@ describe("ConfirmModal (#195)", () => {
         onConfirm: vi.fn(),
         alternative: null,
         attachments: null,
+        defaultButton: "cancel",
       });
       expect(screen.queryByTestId("confirm-modal-alternative")).toBeNull();
     });
@@ -140,6 +146,7 @@ describe("ConfirmModal (#195)", () => {
         onConfirm,
         alternative: { label: "Upload as .txt", onSelect },
         attachments: null,
+        defaultButton: "cancel",
       });
       const btn = screen.getByTestId("confirm-modal-alternative");
       expect(btn.textContent).toBe("Upload as .txt");
@@ -159,7 +166,7 @@ describe("ConfirmModal (#195)", () => {
       id: "a1",
       label: "cat.png",
       detail: "12 KB",
-      thumbnail: null,
+      preview: null,
       ...over,
     });
 
@@ -171,6 +178,7 @@ describe("ConfirmModal (#195)", () => {
         onConfirm: vi.fn(),
         alternative: null,
         attachments: { items: () => items, onRemove },
+        defaultButton: "confirm",
       });
     };
 
@@ -183,6 +191,7 @@ describe("ConfirmModal (#195)", () => {
         onConfirm: vi.fn(),
         alternative: null,
         attachments: null,
+        defaultButton: "cancel",
       });
       expect(screen.queryByTestId("confirm-modal-attachments")).toBeNull();
     });
@@ -201,16 +210,16 @@ describe("ConfirmModal (#195)", () => {
       expect(screen.getByText("2 KB")).toBeInTheDocument();
     });
 
-    it("renders a thumbnail for a row that carries a blob, and none for one that does not", () => {
+    it("renders a thumbnail for a row that carries a picture, and none for one that does not", () => {
       render(() => <ConfirmModal />);
       withAttachments(
         [
           attachment({
             id: "a1",
             label: "cat.png",
-            thumbnail: new Blob(["x"], { type: "image/png" }),
+            preview: { kind: "image", blob: new Blob(["x"], { type: "image/png" }) },
           }),
-          attachment({ id: "a2", label: "spec.pdf", thumbnail: null }),
+          attachment({ id: "a2", label: "spec.pdf", preview: null }),
         ],
         vi.fn(),
       );
@@ -236,7 +245,10 @@ describe("ConfirmModal (#195)", () => {
     it("revokes a row's object URL when the dialog closes", () => {
       const revoke = vi.spyOn(URL, "revokeObjectURL");
       render(() => <ConfirmModal />);
-      withAttachments([attachment({ thumbnail: new Blob(["x"], { type: "image/png" }) })], vi.fn());
+      withAttachments(
+        [attachment({ preview: { kind: "image", blob: new Blob(["x"], { type: "image/png" }) } })],
+        vi.fn(),
+      );
       const src = screen.getByTestId("confirm-modal-attachment-thumb").getAttribute("src");
       expect(src).toMatch(/^blob:/);
 
@@ -244,6 +256,177 @@ describe("ConfirmModal (#195)", () => {
 
       expect(revoke).toHaveBeenCalledWith(src);
       revoke.mockRestore();
+    });
+
+    // #1964 — the preview is per KIND. Each arm below is a different element,
+    // and the reason they are separate assertions rather than one loop is that
+    // a wrong element is exactly the defect: a `<video>` rendered as an `<img>`
+    // shows a broken-image glyph, which is what the issue reported.
+    it("renders a video frame for a video row", () => {
+      render(() => <ConfirmModal />);
+      withAttachments(
+        [
+          attachment({
+            label: "clip.mp4",
+            preview: { kind: "video", blob: new Blob(["x"], { type: "video/mp4" }) },
+          }),
+        ],
+        vi.fn(),
+      );
+      const video = screen.getByTestId("confirm-modal-attachment-video");
+      // The media fragment is what asks for a frame instead of a black poster.
+      expect(video.getAttribute("src")).toMatch(/^blob:.*#t=0\.1$/);
+      expect(screen.queryByTestId("confirm-modal-attachment-thumb")).toBeNull();
+    });
+
+    it("renders a player for an audio row — for sound, listening IS the preview", () => {
+      render(() => <ConfirmModal />);
+      withAttachments(
+        [
+          attachment({
+            label: "song.mp3",
+            preview: { kind: "audio", blob: new Blob(["x"], { type: "audio/mpeg" }) },
+          }),
+        ],
+        vi.fn(),
+      );
+      const audio = screen.getByTestId("confirm-modal-attachment-audio");
+      expect(audio.getAttribute("src")).toMatch(/^blob:/);
+      // Operable, so it needs a name of its own: "audio" beside a filename the
+      // operator cannot hear is not one.
+      expect(audio.getAttribute("aria-label")).toBe("Play song.mp3");
+    });
+
+    it("renders the first lines of a text row — the paste case the issue was filed for", async () => {
+      render(() => <ConfirmModal />);
+      withAttachments(
+        [
+          attachment({
+            label: "paste.txt",
+            preview: {
+              kind: "text",
+              blob: new Blob(["alpha\nbeta\ngamma\ndelta\nepsilon\nzeta"], {
+                type: "text/plain",
+              }),
+            },
+          }),
+        ],
+        vi.fn(),
+      );
+
+      // Read asynchronously off the Blob, so the row paints before the lines do.
+      const source = await screen.findByTestId("confirm-modal-attachment-source");
+      expect(source.textContent).toContain("alpha");
+      expect(source.textContent).toContain("delta");
+      // Capped at TEXT_PREVIEW_LINES: this is a HEAD, not the file.
+      expect(source.textContent).not.toContain("epsilon");
+    });
+
+    it("a row with nothing renderable keeps the placeholder and mints no URL", () => {
+      const create = vi.spyOn(URL, "createObjectURL");
+      render(() => <ConfirmModal />);
+      withAttachments([attachment({ label: "spec.pdf", preview: null })], vi.fn());
+
+      expect(screen.queryByTestId("confirm-modal-attachment-thumb")).toBeNull();
+      expect(screen.queryByTestId("confirm-modal-attachment-video")).toBeNull();
+      expect(screen.queryByTestId("confirm-modal-attachment-audio")).toBeNull();
+      expect(screen.queryByTestId("confirm-modal-attachment-source")).toBeNull();
+      expect(create).not.toHaveBeenCalled();
+      create.mockRestore();
+    });
+  });
+
+  // #1964 — what a bare Enter answers. #195 focused Cancel unconditionally;
+  // the upload confirm is the one dialog whose Cancel loses work, so the
+  // request now names its own default and the modal focuses that button.
+  describe("#1964 — the default button", () => {
+    const openWith = (defaultButton: "cancel" | "confirm", onConfirm: () => void): void => {
+      requestConfirm({
+        title: "Send to #a?",
+        body: "b",
+        confirmLabel: "Send",
+        onConfirm,
+        alternative: null,
+        attachments: null,
+        defaultButton,
+      });
+    };
+
+    it("focuses Cancel by default, so a stray Enter dismisses", async () => {
+      const onConfirm = vi.fn();
+      render(() => <ConfirmModal />);
+      openWith("cancel", onConfirm);
+
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByTestId("confirm-modal-cancel")),
+      );
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("focuses the affirmative when the request asks for it, so Enter sends", async () => {
+      const onConfirm = vi.fn();
+      render(() => <ConfirmModal />);
+      openWith("confirm", onConfirm);
+
+      const send = screen.getByTestId("confirm-modal-confirm");
+      await waitFor(() => expect(document.activeElement).toBe(send));
+
+      // The browser turns Enter on a focused button into a click; asserting the
+      // click is asserting the outcome that reaches the operator.
+      fireEvent.click(send);
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    // Measured in the browser during #1964, not reasoned: the × the operator
+    // presses unmounts with its row, focus falls to <body>, and the next Enter
+    // answers nothing — in the one dialog where Enter is meant to send.
+    it("hands focus back to the default button after a row is removed", async () => {
+      const items = [
+        { id: "a1", label: "one.png", detail: "1 KB", preview: null },
+        { id: "a2", label: "two.png", detail: "1 KB", preview: null },
+      ];
+      render(() => <ConfirmModal />);
+      requestConfirm({
+        title: "Send to #a?",
+        body: "b",
+        confirmLabel: "Send",
+        onConfirm: vi.fn(),
+        alternative: null,
+        attachments: {
+          items: () => items,
+          onRemove: (id: string): void => {
+            const at = items.findIndex((i) => i.id === id);
+            if (at >= 0) items.splice(at, 1);
+          },
+        },
+        defaultButton: "confirm",
+      });
+
+      const remove = screen.getByRole("button", { name: /remove one\.png/i });
+      remove.focus();
+      fireEvent.click(remove);
+
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByTestId("confirm-modal-confirm")),
+      );
+    });
+
+    // The paste path: the guard's third door clears the store and opens the
+    // send confirm in the SAME tick, so the modal never observes a closed
+    // state between them. An open/closed edge guard left focus on the old
+    // dialog's Cancel — which is the button that discards the upload.
+    it("re-focuses when one request REPLACES another without the dialog closing", async () => {
+      render(() => <ConfirmModal />);
+      openWith("cancel", vi.fn());
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByTestId("confirm-modal-cancel")),
+      );
+
+      openWith("confirm", vi.fn());
+
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByTestId("confirm-modal-confirm")),
+      );
     });
   });
 });

--- a/cicchetto/src/__tests__/ConfirmModal.test.tsx
+++ b/cicchetto/src/__tests__/ConfirmModal.test.tsx
@@ -322,6 +322,26 @@ describe("ConfirmModal (#195)", () => {
       expect(source.textContent).not.toContain("epsilon");
     });
 
+    // A text row renders a <pre> of lines read from the Blob, so a URL there
+    // would pin the Blob for the dialog's life and be handed to nothing.
+    it("mints no object URL for a text row", async () => {
+      const create = vi.spyOn(URL, "createObjectURL");
+      render(() => <ConfirmModal />);
+      withAttachments(
+        [
+          attachment({
+            label: "paste.txt",
+            preview: { kind: "text", blob: new Blob(["a\nb"], { type: "text/plain" }) },
+          }),
+        ],
+        vi.fn(),
+      );
+
+      await screen.findByTestId("confirm-modal-attachment-source");
+      expect(create).not.toHaveBeenCalled();
+      create.mockRestore();
+    });
+
     it("a row with nothing renderable keeps the placeholder and mints no URL", () => {
       const create = vi.spyOn(URL, "createObjectURL");
       render(() => <ConfirmModal />);

--- a/cicchetto/src/__tests__/attachmentPreview.test.ts
+++ b/cicchetto/src/__tests__/attachmentPreview.test.ts
@@ -68,12 +68,38 @@ describe("readTextPreview (#1964)", () => {
     expect(await readTextPreview(blob(""), TEXT_PREVIEW_LINES)).toEqual([""]);
   });
 
-  // The read is a HEAD read, so the last row of a cut is not a line the file
-  // has — and on a byte boundary it may not even be valid UTF-8. It is dropped.
+  // The read is a HEAD read, so the last row of a cut may not be a line the
+  // file has — and on a byte boundary it may not even be valid UTF-8.
   it("drops the partial last line when the file is longer than the head read", async () => {
-    const long = `first\n${"x".repeat(16 * 1024)}`;
-    const lines = await readTextPreview(long ? blob(long) : blob(""), TEXT_PREVIEW_LINES);
+    const lines = await readTextPreview(
+      blob(`first\n${"x".repeat(16 * 1024)}`),
+      TEXT_PREVIEW_LINES,
+    );
     expect(lines).toEqual(["first"]);
+  });
+
+  // …but "drop the last row" has two cases where it would show LESS than the
+  // truth, and both were live until the #1964 review.
+  //
+  // A file whose first line is longer than the head read yields exactly ONE
+  // partial row, and dropping it returns [] — an empty preview box, which is
+  // the defect this whole module exists to remove.
+  it("keeps a truncated first line rather than previewing nothing", async () => {
+    const lines = await readTextPreview(blob("z".repeat(9000)), TEXT_PREVIEW_LINES);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toHaveLength(8 * 1024);
+  });
+
+  // And a cut that lands exactly ON a line boundary leaves every row complete:
+  // splitLines has already dropped the phantom the trailing newline makes, so
+  // dropping again eats a real line. Four 2048-byte lines fill the 8 KiB head
+  // exactly, and the tail past it is what makes the read a cut.
+  it("does not eat a line when the cut lands on a line boundary", async () => {
+    const line = (c: string): string => `${c.repeat(2047)}\n`;
+    const text = `${line("a")}${line("b")}${line("c")}${line("d")}tail`;
+    const lines = await readTextPreview(blob(text), TEXT_PREVIEW_LINES);
+    expect(lines).toHaveLength(4);
+    expect(lines[3]?.startsWith("d")).toBe(true);
   });
 
   // A dialog whose job is to say something about a file must not be the thing

--- a/cicchetto/src/__tests__/attachmentPreview.test.ts
+++ b/cicchetto/src/__tests__/attachmentPreview.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { previewKindOf, readTextPreview, TEXT_PREVIEW_LINES } from "../lib/attachmentPreview";
+
+// #1964 — what a staged local file can be shown as in the upload confirm.
+//
+// The defect this covers is not "a missing feature": #1883's row answered a
+// thumbnail for images and NOTHING for every other type, and the paste path
+// (#816) names every file `paste.txt`, so the one dialog that exists to show
+// the operator what is going out showed a constant name, a byte count and an
+// empty box.
+
+describe("previewKindOf (#1964)", () => {
+  it("answers the media viewer's own kind for the three element-backed categories", () => {
+    expect(previewKindOf("image/png")).toBe("image");
+    expect(previewKindOf("image/webp")).toBe("image");
+    expect(previewKindOf("video/mp4")).toBe("video");
+    expect(previewKindOf("video/quicktime")).toBe("video");
+    expect(previewKindOf("audio/mpeg")).toBe("audio");
+    expect(previewKindOf("audio/flac")).toBe("audio");
+  });
+
+  // The `document` category is one bucket holding text AND formats with no
+  // renderer anywhere in cic. Splitting it is the whole reason this function
+  // is not just `categoryOf`.
+  it("splits the document bucket: text renders, PDF and office do not", () => {
+    expect(previewKindOf("text/plain")).toBe("text");
+    expect(previewKindOf("text/markdown")).toBe("text");
+    expect(previewKindOf("application/pdf")).toBeNull();
+    expect(previewKindOf("application/vnd.oasis.opendocument.text")).toBeNull();
+    expect(
+      previewKindOf("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+    ).toBeNull();
+  });
+
+  // #1256 — the paste path declares its encoding, so the type carries a
+  // parameter. An exact-string map would answer null for the ONE file this
+  // whole issue is about.
+  it("is parameter-tolerant, so the paste path's charset-bearing type is text", () => {
+    expect(previewKindOf("text/plain; charset=utf-8")).toBe("text");
+    expect(previewKindOf("IMAGE/PNG")).toBe("image");
+  });
+
+  it("answers null for a type the upload itself would refuse", () => {
+    expect(previewKindOf("application/octet-stream")).toBeNull();
+    expect(previewKindOf("")).toBeNull();
+  });
+});
+
+describe("readTextPreview (#1964)", () => {
+  const blob = (text: string): Blob => new Blob([text], { type: "text/plain" });
+
+  it("returns the first lines, capped", async () => {
+    const lines = await readTextPreview(blob("a\nb\nc\nd\ne\nf"), TEXT_PREVIEW_LINES);
+    expect(lines).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("handles CRLF and a file shorter than the cap", async () => {
+    expect(await readTextPreview(blob("a\r\nb"), TEXT_PREVIEW_LINES)).toEqual(["a", "b"]);
+  });
+
+  // `splitLines` drops the phantom row a trailing newline would produce, so a
+  // file ending in \n does not preview a blank last line.
+  it("does not show the phantom line of a file ending in a newline", async () => {
+    expect(await readTextPreview(blob("a\nb\n"), TEXT_PREVIEW_LINES)).toEqual(["a", "b"]);
+  });
+
+  it("an empty file previews one empty line, not a crash", async () => {
+    expect(await readTextPreview(blob(""), TEXT_PREVIEW_LINES)).toEqual([""]);
+  });
+
+  // The read is a HEAD read, so the last row of a cut is not a line the file
+  // has — and on a byte boundary it may not even be valid UTF-8. It is dropped.
+  it("drops the partial last line when the file is longer than the head read", async () => {
+    const long = `first\n${"x".repeat(16 * 1024)}`;
+    const lines = await readTextPreview(long ? blob(long) : blob(""), TEXT_PREVIEW_LINES);
+    expect(lines).toEqual(["first"]);
+  });
+
+  // A dialog whose job is to say something about a file must not be the thing
+  // that breaks when the file is unreadable (a revoked file handle, a device
+  // that went away mid-pick).
+  it("answers [] rather than throwing when the blob cannot be read", async () => {
+    const broken = {
+      size: 10,
+      slice: () => ({
+        size: 10,
+        text: () => Promise.reject(new Error("NotReadableError")),
+      }),
+    } as unknown as Blob;
+    expect(await readTextPreview(broken, TEXT_PREVIEW_LINES)).toEqual([]);
+  });
+});

--- a/cicchetto/src/__tests__/cardEscape.test.tsx
+++ b/cicchetto/src/__tests__/cardEscape.test.tsx
@@ -147,6 +147,7 @@ const leaveChannelRequest = (onConfirm: () => void): ConfirmRequest => ({
   onConfirm,
   alternative: null,
   attachments: null,
+  defaultButton: "cancel",
 });
 
 let handlers: KeybindingHandlers;

--- a/cicchetto/src/__tests__/confirmDialog.test.ts
+++ b/cicchetto/src/__tests__/confirmDialog.test.ts
@@ -24,6 +24,7 @@ describe("confirmDialog store (#195)", () => {
       onConfirm,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     expect(confirmRequest()).toMatchObject({ title: "t", body: "b", confirmLabel: "Yes" });
     expect(onConfirm).not.toHaveBeenCalled();
@@ -38,6 +39,7 @@ describe("confirmDialog store (#195)", () => {
       onConfirm,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     acceptConfirm();
     expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -53,6 +55,7 @@ describe("confirmDialog store (#195)", () => {
       onConfirm,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     dismissConfirm();
     expect(onConfirm).not.toHaveBeenCalled();
@@ -74,6 +77,7 @@ describe("confirmDialog store (#195)", () => {
       onConfirm: first,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     requestConfirm({
       title: "2",
@@ -82,6 +86,7 @@ describe("confirmDialog store (#195)", () => {
       onConfirm: second,
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     expect(confirmRequest()?.title).toBe("2");
     acceptConfirm();
@@ -108,6 +113,7 @@ describe("confirmDialog store (#195)", () => {
         onConfirm,
         alternative: alt(onSelect),
         attachments: null,
+        defaultButton: "cancel",
       });
       chooseAlternative();
       expect(onSelect).toHaveBeenCalledTimes(1);
@@ -126,6 +132,7 @@ describe("confirmDialog store (#195)", () => {
         onConfirm,
         alternative: alt(onSelect),
         attachments: null,
+        defaultButton: "cancel",
       });
       acceptConfirm();
       expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -142,6 +149,7 @@ describe("confirmDialog store (#195)", () => {
         onConfirm,
         alternative: alt(onSelect),
         attachments: null,
+        defaultButton: "cancel",
       });
       dismissConfirm();
       expect(onConfirm).not.toHaveBeenCalled();
@@ -158,6 +166,7 @@ describe("confirmDialog store (#195)", () => {
         onConfirm,
         alternative: null,
         attachments: null,
+        defaultButton: "cancel",
       });
       expect(() => chooseAlternative()).not.toThrow();
       expect(onConfirm).not.toHaveBeenCalled();

--- a/cicchetto/src/__tests__/uploadOrchestrator.test.ts
+++ b/cicchetto/src/__tests__/uploadOrchestrator.test.ts
@@ -1298,6 +1298,24 @@ describe("the confirm gate (#1883)", () => {
     expect(attachments()[2]?.preview).toBeNull();
   });
 
+  // Solid's <For> diffs by REFERENCE. A row rebuilt on every read disposes and
+  // recreates every row on any removal, which since #1964 is visible: a playing
+  // audio preview stops and resets, a text preview is re-read off disk, and
+  // both object URLs churn. Identity is the observable that pins it.
+  it("each row keeps its identity across reads and across a removal", () => {
+    ackPrivacy();
+    triggerUploads(key, slug, channel, [img("a.png"), img("b.png"), img("c.png")]);
+    const before = attachments();
+    expect(attachments()[0]).toBe(before[0]);
+
+    confirmRequest()?.attachments?.onRemove(before[1]?.id as string);
+
+    const after = attachments();
+    expect(after.map((a) => a.label)).toEqual(["a.png", "c.png"]);
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).toBe(before[2]);
+  });
+
   // The blob handed to the modal is the file itself — the row shows the
   // operator their OWN bytes, not a re-encoded copy.
   it("the preview blob is the staged file", () => {

--- a/cicchetto/src/__tests__/uploadOrchestrator.test.ts
+++ b/cicchetto/src/__tests__/uploadOrchestrator.test.ts
@@ -1280,11 +1280,31 @@ describe("the confirm gate (#1883)", () => {
     expect(attachments().every((a) => a.detail !== "")).toBe(true);
   });
 
-  it("an image carries a thumbnail source; a non-image carries none", () => {
+  // #1964 — the preview is of the file's ACTUAL type, not image-or-nothing.
+  // The text row is the case the issue was filed for: a pasted block arrives
+  // as `paste.txt`, so before this the dialog showed a constant name, a byte
+  // count and an empty box.
+  it("each staged file carries the preview kind its own type can be shown as", () => {
     ackPrivacy();
-    triggerUploads(key, slug, channel, [img("a.png"), sampleNonImage()]);
-    expect(attachments()[0]?.thumbnail).not.toBeNull();
-    expect(attachments()[1]?.thumbnail).toBeNull();
+    triggerUploads(key, slug, channel, [
+      img("a.png"),
+      sampleNonImage(),
+      new File(["%PDF-1.4"], "spec.pdf", { type: "application/pdf" }),
+    ]);
+    expect(attachments()[0]?.preview?.kind).toBe("image");
+    expect(attachments()[1]?.preview?.kind).toBe("text");
+    // Still null, and deliberately: there is no PDF renderer anywhere in cic,
+    // so this row keeps the neutral placeholder rather than gaining a viewer.
+    expect(attachments()[2]?.preview).toBeNull();
+  });
+
+  // The blob handed to the modal is the file itself — the row shows the
+  // operator their OWN bytes, not a re-encoded copy.
+  it("the preview blob is the staged file", () => {
+    ackPrivacy();
+    const file = img("a.png");
+    triggerUploads(key, slug, channel, [file]);
+    expect(attachments()[0]?.preview?.blob).toBe(file);
   });
 
   it("Send uploads exactly the picked files to the picked window", () => {

--- a/cicchetto/src/__tests__/uploadOrchestrator.test.ts
+++ b/cicchetto/src/__tests__/uploadOrchestrator.test.ts
@@ -1293,9 +1293,14 @@ describe("the confirm gate (#1883)", () => {
     ]);
     expect(attachments()[0]?.preview?.kind).toBe("image");
     expect(attachments()[1]?.preview?.kind).toBe("text");
-    // Still null, and deliberately: there is no PDF renderer anywhere in cic,
-    // so this row keeps the neutral placeholder rather than gaining a viewer.
+    // Still null, and deliberately: there is no PDF renderer anywhere in cic
+    // (the viewer has four arms and a 📄 link falls through to the browser),
+    // so this row gains no viewer — it SAYS there is no preview instead.
     expect(attachments()[2]?.preview).toBeNull();
+    expect(attachments()[2]?.detail).toContain("preview not supported");
+    // …and the rows that DO preview say nothing of the sort.
+    expect(attachments()[0]?.detail).not.toContain("preview");
+    expect(attachments()[1]?.detail).not.toContain("preview");
   });
 
   // Solid's <For> diffs by REFERENCE. A row rebuilt on every read disposes and

--- a/cicchetto/src/lib/attachmentPreview.ts
+++ b/cicchetto/src/lib/attachmentPreview.ts
@@ -1,0 +1,110 @@
+import type { MediaKind } from "./mediaLink";
+import { splitLines } from "./textResource";
+import { baseMime, categoryOf } from "./uploadCategory";
+
+// #1964 — what a STAGED LOCAL file can be shown as in the upload confirm, and
+// how to read the head of a text one.
+//
+// #1883 shipped the confirm with an image-only thumbnail, on the argument that
+// "a picture is the only preview worth showing: for every other category the
+// bytes say nothing a human can check at a glance, and the name is what
+// distinguishes contract-final.pdf from contract-draft.pdf". That argument
+// assumes a file the OPERATOR named. On the paste path (#816) the name is the
+// constant `paste.txt` for every paste in every window, so the one signal the
+// design leans on carries zero bits, and the dialog asks the operator to
+// authorise an upload they cannot see. Gabriele's ruling (2026-09-08): show the
+// preview for the file's ACTUAL type, reusing the wiring that already exists.
+//
+// ## The vocabulary is the viewer's, not a second one
+//
+// `MediaKind` ("image" | "video" | "audio" | "text") is what `mediaLink.ts`
+// classifies a clicked scrollback link into and what `MediaViewerModal`
+// switches on. A staged local file poses the same question — what element can
+// render this — so it gets the same four answers rather than a parallel set.
+// The confirm row then reuses the viewer's element shapes (an `<img>`, a muted
+// `<video>`, an `<audio controls>`, a `<pre>` of lines), which is why this maps
+// INTO `MediaKind` instead of exporting a private union.
+//
+// ## Why the map is not `categoryOf` alone
+//
+// `UploadCategory` has four members too, and three of them line up. The fourth
+// does not: `document` is one bucket holding `text/plain`, `text/markdown`,
+// PDF, ODT, ODS, DOCX and XLSX. Only the two text types have a renderer here —
+// there is no PDF or office renderer anywhere in cic, and inventing one for a
+// 2.5rem confirm row would be a new viewer, not a reuse. So `document` splits
+// on the base MIME and everything unrenderable answers `null`, which keeps the
+// existing neutral placeholder for exactly the files that have nothing to show.
+//
+// ## Not a scrollback preview
+//
+// CLAUDE.md's "IRC stays text only" bans inline rendering of media in
+// SCROLLBACK. This is a modal the operator opened by staging a file, showing a
+// file that is still on their own disk — the same slot #1883 already put an
+// image thumbnail in. Nothing here renders anything that arrived over IRC.
+
+/**
+ * What can this staged file be shown as, if anything?
+ *
+ * * `image` / `video` / `audio` — the upload category answers directly.
+ * * `text` — only `text/plain` and `text/markdown` out of the `document`
+ *   bucket; PDF and the office types have no renderer and answer `null`.
+ * * `null` — nothing to show; the row keeps its neutral placeholder.
+ *
+ * Parameter-tolerant via `baseMime`, so the paste path's
+ * `text/plain; charset=utf-8` (#1256) is recognised.
+ */
+export function previewKindOf(mime: string): MediaKind | null {
+  const category = categoryOf(mime);
+  switch (category) {
+    case "image":
+      return "image";
+    case "video":
+      return "video";
+    case "audio":
+      return "audio";
+    case "document":
+      return TEXT_MIMES.has(baseMime(mime)) ? "text" : null;
+    case null:
+      return null;
+  }
+}
+
+// The renderable slice of the `document` bucket. A Set of base MIMEs rather
+// than a suffix test on `text/`: `uploadCategory` admits exactly these two
+// text types, and a `text/*` test would claim types the upload itself refuses.
+const TEXT_MIMES: ReadonlySet<string> = new Set(["text/plain", "text/markdown"]);
+
+/** Rows shown in a confirm-row text preview. Enough to recognise a paste. */
+export const TEXT_PREVIEW_LINES = 4;
+
+// How much of the file to read for those rows. The preview is a HEAD, so the
+// read is a head too: a staged text upload may be megabytes (the document cap
+// is far above this), and `Blob.text()` on the whole of it would decode all of
+// it to show four lines. 8 KiB holds four lines of anything an operator pastes,
+// by orders of magnitude.
+const TEXT_PREVIEW_MAX_BYTES = 8 * 1024;
+
+/**
+ * Read the first `maxLines` lines of a text blob for the preview.
+ *
+ * Never throws: an unreadable blob answers `[]` and the row falls back to its
+ * placeholder. A dialog that has to say something about a file must not be the
+ * thing that breaks when the file is odd.
+ */
+export async function readTextPreview(blob: Blob, maxLines: number): Promise<string[]> {
+  const head = blob.slice(0, TEXT_PREVIEW_MAX_BYTES);
+  let text: string;
+  try {
+    text = await head.text();
+  } catch {
+    return [];
+  }
+
+  const lines = splitLines(text);
+  // A byte slice can land mid-line AND mid-codepoint (UTF-8 decode leaves a
+  // U+FFFD there), so the last row of a truncated read is not a line the file
+  // has — drop it. `splitLines` already drops the phantom row a trailing
+  // newline produces, so this only fires on a genuine cut.
+  if (head.size < blob.size) lines.pop();
+  return lines.slice(0, maxLines);
+}

--- a/cicchetto/src/lib/attachmentPreview.ts
+++ b/cicchetto/src/lib/attachmentPreview.ts
@@ -1,6 +1,11 @@
 import type { MediaKind } from "./mediaLink";
 import { splitLines } from "./textResource";
-import { baseMime, categoryOf } from "./uploadCategory";
+import {
+  baseMime,
+  categoryOf,
+  type DOCUMENT_MIMES_OFFICE,
+  type DOCUMENT_MIMES_PORTABLE,
+} from "./uploadCategory";
 
 // #1964 — what a STAGED LOCAL file can be shown as in the upload confirm, and
 // how to read the head of a text one.
@@ -62,17 +67,38 @@ export function previewKindOf(mime: string): MediaKind | null {
       return "video";
     case "audio":
       return "audio";
-    case "document":
-      return TEXT_MIMES.has(baseMime(mime)) ? "text" : null;
+    // Widened lookup, the shape `mimeExtLabel` uses: the map is keyed on the
+    // MIME unions so it cannot drift, but the caller holds a bare string.
+    case "document": {
+      const documents = DOCUMENT_PREVIEW_KIND as Readonly<Record<string, MediaKind | null>>;
+      return documents[baseMime(mime)] ?? null;
+    }
     case null:
       return null;
   }
 }
 
-// The renderable slice of the `document` bucket. A Set of base MIMEs rather
-// than a suffix test on `text/`: `uploadCategory` admits exactly these two
-// text types, and a `text/*` test would claim types the upload itself refuses.
-const TEXT_MIMES: ReadonlySet<string> = new Set(["text/plain", "text/markdown"]);
+// What each member of the `document` bucket can be shown as — and it is keyed
+// on the MIME UNIONS rather than being a set of strings, so a ninth document
+// type added to `uploadCategory` is a compile error here instead of a file
+// that silently previews as an empty box. Same discipline, and for the same
+// stated reason, as `MIME_EXT_LABEL` in that module ("so a 15th MIME added to
+// a list without a label here is a compile error").
+//
+// `null` is a decision, not an omission: cic has no PDF renderer and no office
+// renderer, and this slice reuses viewers rather than inventing them.
+const DOCUMENT_PREVIEW_KIND: Record<
+  (typeof DOCUMENT_MIMES_PORTABLE)[number] | (typeof DOCUMENT_MIMES_OFFICE)[number],
+  MediaKind | null
+> = {
+  "application/pdf": null,
+  "text/plain": "text",
+  "text/markdown": "text",
+  "application/vnd.oasis.opendocument.text": null,
+  "application/vnd.oasis.opendocument.spreadsheet": null,
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": null,
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": null,
+};
 
 /** Rows shown in a confirm-row text preview. Enough to recognise a paste. */
 export const TEXT_PREVIEW_LINES = 4;
@@ -102,9 +128,18 @@ export async function readTextPreview(blob: Blob, maxLines: number): Promise<str
 
   const lines = splitLines(text);
   // A byte slice can land mid-line AND mid-codepoint (UTF-8 decode leaves a
-  // U+FFFD there), so the last row of a truncated read is not a line the file
-  // has — drop it. `splitLines` already drops the phantom row a trailing
-  // newline produces, so this only fires on a genuine cut.
-  if (head.size < blob.size) lines.pop();
+  // U+FFFD there), so a truncated read's last row may not be a line the file
+  // has. Two guards, and each answers a case that showed the operator LESS
+  // than the truth:
+  //
+  //   * `endsWith("\n")` — a cut landing exactly on a line boundary leaves
+  //     every row complete, and `splitLines` has already dropped the phantom
+  //     row the trailing newline produces. Popping there eats a real line.
+  //   * `length > 1` — a file whose FIRST line is longer than the head read (a
+  //     minified blob renamed `.txt`, a single-line log record) yields one
+  //     partial row, and popping it returns `[]`: an empty preview box, which
+  //     is the exact defect #1964 exists to remove. A truncated first line is
+  //     worth more than nothing.
+  if (head.size < blob.size && !text.endsWith("\n") && lines.length > 1) lines.pop();
   return lines.slice(0, maxLines);
 }

--- a/cicchetto/src/lib/channelJoin.ts
+++ b/cicchetto/src/lib/channelJoin.ts
@@ -135,5 +135,6 @@ export function confirmJoinChannel(networkSlug: string, rawChannel: string): voi
     onConfirm: () => void performJoin(networkSlug, rawChannel),
     alternative: null,
     attachments: null,
+    defaultButton: "cancel",
   });
 }

--- a/cicchetto/src/lib/commands/fanout.ts
+++ b/cicchetto/src/lib/commands/fanout.ts
@@ -71,6 +71,7 @@ export const fanOutCommand: CommandHandler<"ame" | "amsg"> = async (cmd, ctx) =>
       },
       alternative: null,
       attachments: null,
+      defaultButton: "cancel",
     });
     return { ok: `/${cmd.kind}: ${targets.length} channels — confirm to send` };
   }

--- a/cicchetto/src/lib/confirmDialog.ts
+++ b/cicchetto/src/lib/confirmDialog.ts
@@ -1,4 +1,5 @@
 import { createSignal } from "solid-js";
+import type { MediaKind } from "./mediaLink";
 
 // #195 — generic confirm-dialog primitive. Replaces the #172 hold-to-close
 // gesture (removed) for destructive window actions: leaving a channel and
@@ -28,11 +29,13 @@ import { createSignal } from "solid-js";
 // 1883 added an OPTIONAL attachment list, for the same reason and on the same
 // terms: a question about FILES cannot be asked in a sentence. "Send this?" is
 // answerable only if the operator can see WHICH file, and a mis-tapped gallery
-// thumbnail is indistinguishable from the right one by name alone. The store
-// stays domain-agnostic the same way `alternative` does — it carries a
-// pre-formatted row (label, detail, an optional blob to render) and a removal
-// closure, and knows nothing about uploads, MIME categories or byte
-// formatting. The MODAL owns the object-URL lifecycle for the blob, because
+// thumbnail is indistinguishable from the right one by name alone. #1964
+// widened that row from an image-only thumbnail to a preview of whatever the
+// file actually is, and gave the request a `defaultButton` — see both fields
+// below for why each was necessary. The store stays domain-agnostic the same
+// way `alternative` does — it carries a pre-formatted row (label, detail, an
+// optional blob and the kind to render it as) and a removal closure, and knows
+// nothing about uploads, MIME categories or byte formatting. The MODAL owns the object-URL lifecycle for the blob, because
 // the row's own mount/unmount is the only thing that knows when the URL stops
 // being needed.
 
@@ -44,9 +47,26 @@ export type ConfirmAlternative = {
   onSelect: () => void;
 };
 
+// #1964 — what to render for a row, and as what.
+//
+// The KIND is the media viewer's own `MediaKind` and not a union private to
+// this store: a staged local file poses the same question a clicked scrollback
+// link does — what element can show this — so the confirm row answers it with
+// the same four words and reuses the same element shapes (an `<img>`, a muted
+// `<video>`, an `<audio controls>`, a `<pre>` of lines). The caller decides the
+// kind (`attachmentPreview.previewKindOf`); the modal owns the object URL.
+export type ConfirmPreview = {
+  kind: MediaKind;
+  // A Blob rather than a URL string so the modal can own
+  // `createObjectURL`/`revokeObjectURL` around the row's lifetime; a
+  // caller-minted URL would have to be revoked from a dismiss path this store
+  // deliberately does not expose.
+  blob: Blob;
+};
+
 // One row of the attachment list. Everything domain-shaped (the filename, the
-// byte spelling, whether this thing can be shown as a picture) is decided by
-// the CALLER and arrives here already resolved.
+// byte spelling, what this thing can be shown as) is decided by the CALLER and
+// arrives here already resolved.
 export type ConfirmAttachment = {
   // Stable identity for the row and its remove button. Filenames are NOT
   // unique — a gallery multi-select routinely yields two `IMG_0001.png`.
@@ -57,11 +77,11 @@ export type ConfirmAttachment = {
   // raw number here would put a spelling decision in a store that has no
   // business making one.
   detail: string;
-  // Non-null → render it as a thumbnail. A Blob rather than a URL string so
-  // the modal can own `createObjectURL`/`revokeObjectURL` around the row's
-  // lifetime; a caller-minted URL would have to be revoked from a dismiss path
-  // this store deliberately does not expose.
-  thumbnail: Blob | null;
+  // Non-null → render it, per its kind. `null` means nothing renderable (a
+  // PDF, a spreadsheet) and the row keeps its neutral placeholder — #1964
+  // widened this from an image-only thumbnail, it did not invent a renderer
+  // for every type.
+  preview: ConfirmPreview | null;
 };
 
 export type ConfirmAttachments = {
@@ -97,6 +117,20 @@ export type ConfirmRequest = {
   // Same explicit-`null` contract as `alternative`, and for the same reason:
   // a text-only dialog says so in its own call site.
   attachments: ConfirmAttachments | null;
+  // #1964 — which button takes focus on open, i.e. what a bare Enter answers.
+  // Explicit on every call site, like the two fields above: which key sends
+  // and which key discards must be readable at the call site, not by opening
+  // the modal.
+  //
+  // #195 made Cancel the universal default ("a stray Enter dismisses, never
+  // leaves"), and that still holds for every dialog here whose affirmative
+  // leaves a channel, drops a network, floods a room or deletes a theme. The
+  // upload confirm is the one that reads the other way (Gabriele's ruling,
+  // 2026-09-08): the operator has already picked, dropped or pasted the file,
+  // the dialog is OPT-IN and was switched on to LOOK at what is going out, and
+  // Enter — the key you press after reading — threw the staged files away.
+  // Cancel is not the safe answer there; it is the one that loses the work.
+  defaultButton: "cancel" | "confirm";
 };
 
 const [confirmRequest, setConfirmRequest] = createSignal<ConfirmRequest | null>(null);

--- a/cicchetto/src/lib/confirmDialog.ts
+++ b/cicchetto/src/lib/confirmDialog.ts
@@ -35,7 +35,10 @@ import type { MediaKind } from "./mediaLink";
 // below for why each was necessary. The store stays domain-agnostic the same
 // way `alternative` does — it carries a pre-formatted row (label, detail, an
 // optional blob and the kind to render it as) and a removal closure, and knows
-// nothing about uploads, MIME categories or byte formatting. The MODAL owns the object-URL lifecycle for the blob, because
+// nothing about uploads, MIME types or byte formatting. It does now name
+// `MediaKind`, a type-only import: that is the RENDERING vocabulary the media
+// viewer already speaks, not a domain fact about uploads, and the alternative
+// was a second four-member union meaning the same four things. The MODAL owns the object-URL lifecycle for the blob, because
 // the row's own mount/unmount is the only thing that knows when the URL stops
 // being needed.
 

--- a/cicchetto/src/lib/lifecycle.ts
+++ b/cicchetto/src/lib/lifecycle.ts
@@ -159,6 +159,7 @@ export function confirmDetach(onDone: () => void): void {
     onConfirm: () => void detach().then(onDone),
     alternative: null,
     attachments: null,
+    defaultButton: "cancel",
   });
 }
 
@@ -175,6 +176,7 @@ export function confirmQuit(onDone: () => void): void {
     onConfirm: () => void quit().then(onDone),
     alternative: null,
     attachments: null,
+    defaultButton: "cancel",
   });
 }
 

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -235,6 +235,7 @@ function routeGuardedText(
           onSelect: () => uploadPastedText(text, networkSlug, channelName),
         },
         attachments: null,
+        defaultButton: "cancel",
       });
       return;
     case "over-limit":
@@ -250,6 +251,7 @@ function routeGuardedText(
         // uploading IS the affirmative and there is nothing else to offer.
         alternative: null,
         attachments: null,
+        defaultButton: "cancel",
       });
       return;
     case "insert":

--- a/cicchetto/src/lib/uploadOrchestrator.ts
+++ b/cicchetto/src/lib/uploadOrchestrator.ts
@@ -1,4 +1,5 @@
 import { createSignal } from "solid-js";
+import { previewKindOf } from "./attachmentPreview";
 import type { ChannelKey } from "./channelKey";
 import { type ConfirmAttachment, dismissConfirm, requestConfirm } from "./confirmDialog";
 import { formatBytes } from "./formatBytes";
@@ -697,17 +698,27 @@ let nextAttachmentId = 0;
 
 type StagedFile = { id: string; file: File };
 
-// A picture is the only preview worth showing: for every other category the
-// bytes say nothing a human can check at a glance, and the name is what
-// distinguishes `contract-final.pdf` from `contract-draft.pdf`. The blob is
-// handed over raw — ConfirmModal mints and revokes the object URL, because the
-// row's unmount is the only event that knows when it stops being needed.
+// #1964 — the preview is of the file's ACTUAL type.
+//
+// This used to answer a thumbnail for images and nothing for anything else, on
+// the argument that "a picture is the only preview worth showing: for every
+// other category the bytes say nothing a human can check at a glance, and the
+// name is what distinguishes `contract-final.pdf` from `contract-draft.pdf`".
+// That reasoning assumes a name the OPERATOR chose. The paste path (#816)
+// names every file `paste.txt`, in every window, so on the one door where the
+// operator cannot possibly know what is inside, the dialog showed a byte count
+// and an empty box. `previewKindOf` decides what each staged file can be shown
+// as; a file with no renderer (PDF, office documents) still answers null and
+// keeps the placeholder. The blob is handed over raw — ConfirmModal mints and
+// revokes the object URL, because the row's unmount is the only event that
+// knows when it stops being needed.
 function toAttachment(staged: StagedFile): ConfirmAttachment {
+  const kind = previewKindOf(staged.file.type);
   return {
     id: staged.id,
     label: staged.file.name,
     detail: formatBytes(staged.file.size),
-    thumbnail: categoryOf(staged.file.type) === "image" ? staged.file : null,
+    preview: kind === null ? null : { kind, blob: staged.file },
   };
 }
 
@@ -798,6 +809,11 @@ export function triggerUploads(
       // No third door: there is no other route to "post this file here". Cancel
       // and Send are the whole question.
       alternative: null,
+      // #1964 — the one dialog in cic where Enter means yes. The files are
+      // already staged by a gesture the operator made, and this confirm is
+      // opt-in: it exists to be READ, and the key you press after reading was
+      // discarding the batch. See `ConfirmRequest.defaultButton`.
+      defaultButton: "confirm",
       attachments: {
         items: (): ConfirmAttachment[] => staged().map(toAttachment),
         onRemove: (id: string): void => {

--- a/cicchetto/src/lib/uploadOrchestrator.ts
+++ b/cicchetto/src/lib/uploadOrchestrator.ts
@@ -722,7 +722,14 @@ function toAttachment(id: string, file: File): ConfirmAttachment {
   return {
     id,
     label: file.name,
-    detail: formatBytes(file.size),
+    // Gabriele's ruling (2026-09-08): when there is no preview, SAY so. cic
+    // has no PDF or office renderer — the media viewer has four arms and a
+    // 📄 link deliberately falls through to the browser (MircText.tsx) — so a
+    // preview for those types would mean building a viewer first. The honest
+    // row is the name, the size and a plain statement; the old empty-box glyph
+    // read as a picture that failed to load, which is a different claim.
+    detail:
+      kind === null ? `${formatBytes(file.size)} · preview not supported` : formatBytes(file.size),
     preview: kind === null ? null : { kind, blob: file },
   };
 }

--- a/cicchetto/src/lib/uploadOrchestrator.ts
+++ b/cicchetto/src/lib/uploadOrchestrator.ts
@@ -696,7 +696,12 @@ async function prepareVideo(
 // of the same photo, so the id is minted here and never derived.
 let nextAttachmentId = 0;
 
-type StagedFile = { id: string; file: File };
+// The attachment is minted WITH the staged file and never recomputed. Solid's
+// `<For>` diffs by reference, so a row rebuilt on every read would dispose and
+// recreate EVERY row on any removal — which since #1964 is visible: a playing
+// audio preview stops and resets, a text preview is re-read off disk, and both
+// object URLs churn. Deriving once is also the cheaper shape.
+type StagedFile = { id: string; file: File; attachment: ConfirmAttachment };
 
 // #1964 — the preview is of the file's ACTUAL type.
 //
@@ -712,13 +717,13 @@ type StagedFile = { id: string; file: File };
 // keeps the placeholder. The blob is handed over raw — ConfirmModal mints and
 // revokes the object URL, because the row's unmount is the only event that
 // knows when it stops being needed.
-function toAttachment(staged: StagedFile): ConfirmAttachment {
-  const kind = previewKindOf(staged.file.type);
+function toAttachment(id: string, file: File): ConfirmAttachment {
+  const kind = previewKindOf(file.type);
   return {
-    id: staged.id,
-    label: staged.file.name,
-    detail: formatBytes(staged.file.size),
-    preview: kind === null ? null : { kind, blob: staged.file },
+    id,
+    label: file.name,
+    detail: formatBytes(file.size),
+    preview: kind === null ? null : { kind, blob: file },
   };
 }
 
@@ -739,7 +744,9 @@ export function triggerUploads(
   // all describe the same files.
   const normalised: StagedFile[] = rawFiles.map((raw) => {
     nextAttachmentId += 1;
-    return { id: `picked-${nextAttachmentId}`, file: normalizeUploadFile(raw) };
+    const id = `picked-${nextAttachmentId}`;
+    const file = normalizeUploadFile(raw);
+    return { id, file, attachment: toAttachment(id, file) };
   });
 
   // Everything past the privacy notice. A closure because the notice may have
@@ -815,7 +822,7 @@ export function triggerUploads(
       // discarding the batch. See `ConfirmRequest.defaultButton`.
       defaultButton: "confirm",
       attachments: {
-        items: (): ConfirmAttachment[] => staged().map(toAttachment),
+        items: (): ConfirmAttachment[] => staged().map((s) => s.attachment),
         onRemove: (id: string): void => {
           const rest = staged().filter((s) => s.id !== id);
           setStaged(rest);

--- a/cicchetto/src/lib/windowClose.ts
+++ b/cicchetto/src/lib/windowClose.ts
@@ -174,6 +174,7 @@ export function confirmLeaveChannel(networkSlug: string, channelName: string): v
     onConfirm: () => closeChannelWindow(networkSlug, channelName),
     alternative: null,
     attachments: null,
+    defaultButton: "cancel",
   });
 }
 
@@ -188,5 +189,6 @@ export function confirmDisconnectNetwork(networkSlug: string): void {
     onConfirm: () => disconnectNetwork(networkSlug),
     alternative: null,
     attachments: null,
+    defaultButton: "cancel",
   });
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5642,17 +5642,29 @@ button.topic-bar-windows-opener {
   overscroll-behavior: contain;
 }
 
+/* #1964 — a column, because a sound or a text preview is taller than the
+   2.5rem box a picture fits in. The FIRST line keeps the #1883 row shape
+   exactly (see -head below); anything taller stacks under it, so a mixed
+   batch still reads as a column of like rows rather than a ragged grid. */
 .confirm-modal-attachment {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: stretch;
   border: 1px solid var(--border);
   padding: 0.375rem;
   min-width: 0;
 }
 
-/* Fixed box for BOTH the thumbnail and its placeholder, so a mixed batch
-   (photo + pdf) keeps every row the same height and the filenames line up. */
+.confirm-modal-attachment-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+/* Fixed box for the picture, the video frame and the placeholder alike, so a
+   mixed batch (photo + pdf) keeps every row the same height and the filenames
+   line up. */
 .confirm-modal-attachment-thumb,
 .confirm-modal-attachment-icon {
   flex: 0 0 auto;
@@ -5668,6 +5680,31 @@ button.topic-bar-windows-opener {
      a letterboxed 2.5rem thumbnail of a portrait photo is a sliver. */
   object-fit: cover;
   border: 1px solid var(--border);
+}
+
+/* #1964 — sound has no picture, so the preview IS the player. Full row width
+   because a native control bar has a minimum usable size well past 2.5rem,
+   and short because it sits under a row, not in place of one. */
+.confirm-modal-attachment-audio {
+  width: 100%;
+  height: 2rem;
+  margin-top: 0.375rem;
+}
+
+/* #1964 — the head of a text file. Scrolls sideways rather than wrapping: a
+   wrapped line would misreport where the file's line breaks are, and this
+   preview exists to show what the lines ARE. */
+.confirm-modal-attachment-source {
+  margin: 0.375rem 0 0;
+  padding: 0.375rem;
+  border: 1px solid var(--border);
+  font: inherit;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  color: var(--fg);
+  white-space: pre;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
 }
 
 .confirm-modal-attachment-icon {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5662,11 +5662,10 @@ button.topic-bar-windows-opener {
   min-width: 0;
 }
 
-/* Fixed box for the picture, the video frame and the placeholder alike, so a
-   mixed batch (photo + pdf) keeps every row the same height and the filenames
-   line up. */
-.confirm-modal-attachment-thumb,
-.confirm-modal-attachment-icon {
+/* Fixed box for the picture and the video frame, so a batch of both keeps the
+   filenames lined up. #1964 dropped the matching placeholder box: a row with
+   no preview says so in words rather than holding an empty square. */
+.confirm-modal-attachment-thumb {
   flex: 0 0 auto;
   width: 2.5rem;
   height: 2.5rem;
@@ -5682,13 +5681,26 @@ button.topic-bar-windows-opener {
   border: 1px solid var(--border);
 }
 
-/* #1964 — sound has no picture, so the preview IS the player. Full row width
-   because a native control bar has a minimum usable size well past 2.5rem,
-   and short because it sits under a row, not in place of one. */
+/* #1964 — sound has no picture and a video has to be watched, so for both the
+   preview IS the player. Full row width because a native control bar has a
+   minimum usable size well past the 2.5rem thumbnail box, and each sits UNDER
+   the row head rather than in place of it. */
 .confirm-modal-attachment-audio {
   width: 100%;
   height: 2rem;
   margin-top: 0.375rem;
+}
+
+.confirm-modal-attachment-video {
+  width: 100%;
+  /* Capped so one clip cannot push the Send button off a phone screen; the
+     dialog's own 40vh attachment scroller does the rest. `contain` because a
+     preview is for recognising the take, and a cropped one can hide the very
+     thing being checked. */
+  max-height: 9rem;
+  object-fit: contain;
+  margin-top: 0.375rem;
+  background: var(--fg);
 }
 
 /* #1964 — the head of a text file. Scrolls sideways rather than wrapping: a
@@ -5705,10 +5717,6 @@ button.topic-bar-windows-opener {
   white-space: pre;
   overflow-x: auto;
   overscroll-behavior-x: contain;
-}
-
-.confirm-modal-attachment-icon {
-  color: var(--muted);
 }
 
 .confirm-modal-attachment-text {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48912,13 +48912,16 @@ line; and a file whose FIRST line is longer than the head yields one partial
 row, where dropping it returns `[]` — an empty box, the very defect this
 change removes.
 
-**Audio gets a player, not a glyph.** For sound there is no picture to
-recognise — listening IS the preview, and `<audio controls>` is what the viewer
-gives a clicked audio link. It does not fit a 2.5rem box, so the row became a
-column: the first line keeps #1883's shape exactly (media box, name, size, ×)
-and anything taller stacks under it. Video keeps the box, with
-`preload="metadata"` and a `#t=0.1` fragment to ask for a frame rather than a
-black poster.
+**Sound and video get a PLAYER, not a still.** For sound there is no picture
+to recognise — listening IS the preview, and `<audio controls>` is what the
+viewer gives a clicked audio link. Video started as a muted first frame in the
+thumbnail box; Gabriele asked for it to be playable (2026-09-08) and the reason
+holds: a video is a thing that MOVES, so checking you picked the right take
+means watching it, and a still frame answers a question only a photo has. A
+control bar is unusable at 2.5rem, so both take a full-width block and the row
+became a column — the first line keeps #1883's shape (thumbnail, name, size, ×)
+and every preview that must be operated or read stacks under it. The `#t=0.1`
+fragment stays: it asks for a frame rather than a black poster before play.
 
 ### Enter, and the reversal it required
 
@@ -48960,6 +48963,24 @@ guards, and the `MediaKind` coupling note); the other two:
   `MIME_EXT_LABEL` on the MIME unions precisely "so a 15th MIME added to a list
   without a label here is a compile error"; the preview map now does the same,
   so a ninth document type cannot silently preview as an empty box.
+
+### The row with no preview says so
+
+The first cut kept #1883's neutral ☐ glyph for a file with no renderer.
+Gabriele's ruling on seeing it (2026-09-08): that glyph reads as a picture
+that FAILED to load, which is a different claim from "this type has no
+viewer", and it was also being shown beside text and audio previews that
+work. There is no PDF or office renderer anywhere in cic — the media viewer
+has four arms, and a 📄 link deliberately falls through to the browser
+(`MircText.tsx`) — so previewing those types would mean building a viewer
+first, which this slice is not.
+
+So the unpreviewable row now carries no box at all and states the limit in
+words: name, size, `· preview not supported`. It is the CATCH-ALL, not a
+PDF special case — the picker does not pre-filter by category, so an
+arbitrary binary reaches the dialog too, and it gets the same honest row. The
+uniform-row-height argument the glyph existed for had already lapsed: audio
+and text previews are taller than any 2.5rem box.
 
 ### Not done, and why
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48862,3 +48862,90 @@ cascade, never what a browser paints.
 _Deploy: **HOT**, cic bundle only — no server change, no migration, no wire
 change, no protocol bump: nothing here leaves the client except the two REST
 calls the two buttons already made._
+<!-- entry #1964 -->
+
+---
+
+## 2026-09-08 — #1964: the confirm previews what it is asking about, and Enter means yes
+
+#1883 put a file list in the confirm dialog so "Send this?" could be answered,
+and gave the row an image thumbnail. The argument for stopping there is quoted
+in the code it justified: *"a picture is the only preview worth showing: for
+every other category the bytes say nothing a human can check at a glance, and
+the name is what distinguishes `contract-final.pdf` from `contract-draft.pdf`"*.
+
+That reasoning assumes a name the OPERATOR chose. On the paste-as-.txt door
+(#816) the name is the constant `paste.txt`, for every paste in every window,
+so on the one door where the operator cannot know what is inside, the dialog
+showed a constant name, a byte count and an empty box. Gabriele reported it
+from the paste path and ruled the fix (2026-09-08): show the preview for the
+file's ACTUAL type, reusing the wiring that already exists.
+
+### Reuse means the viewer's vocabulary, not its components
+
+`MediaViewerModal` switches on `MediaKind` (`image | video | audio | text`) and
+its image/video/audio arms are `href: string`-driven, so a `blob:` URL of a
+local file would work in them unchanged. What is NOT reusable is the component:
+it is a full-screen modal with dismiss gestures, and the confirm needs a 2.5rem
+row. So the reuse is at the level that survives — the kind vocabulary and the
+element shapes — and `ConfirmAttachment` now carries
+`preview: {kind: MediaKind, blob} | null` instead of `thumbnail: Blob | null`.
+
+`attachmentPreview.previewKindOf/1` maps a MIME to that kind, and it is NOT
+`categoryOf`: `UploadCategory` also has four members, but `document` is one
+bucket holding `text/plain`, `text/markdown`, PDF, ODT, ODS, DOCX and XLSX.
+Only the two text types have a renderer in cic, so `document` splits on the
+base MIME and everything else answers `null` and keeps the placeholder. There
+is no PDF or office renderer anywhere in the client and this slice did not
+invent one.
+
+**The text arm is the one that could not reuse the viewer**, and the reason is
+mechanical: `TextPane` reads through `textResource.ts`, which fetches with a
+`Range` header, and a blob: URL does not honour Range. So a staged text file is
+read from the File itself — `blob.slice(0, 8 KiB).text()`, head only, then
+`splitLines` (the viewer's own splitter) and the first four rows. A truncated
+read drops its last row: a byte slice can land mid-line and mid-codepoint, so
+that row is not a line the file has.
+
+**Audio gets a player, not a glyph.** For sound there is no picture to
+recognise — listening IS the preview, and `<audio controls>` is what the viewer
+gives a clicked audio link. It does not fit a 2.5rem box, so the row became a
+column: the first line keeps #1883's shape exactly (media box, name, size, ×)
+and anything taller stacks under it. Video keeps the box, with
+`preload="metadata"` and a `#t=0.1` fragment to ask for a frame rather than a
+black poster.
+
+### Enter, and the reversal it required
+
+#195 focused Cancel unconditionally, "so a stray Enter dismisses, never
+leaves". That is right for a dialog that leaves a channel, drops a network,
+floods a room or deletes a theme. It is wrong for this one: the operator has
+already picked, dropped or pasted the file, the confirm is opt-in and was
+switched on to LOOK at what is going out, and Enter — the key you press after
+reading — discarded the batch. `ConfirmRequest.defaultButton` is now explicit
+at all ten call sites; nine say `"cancel"` and the upload confirm says
+`"confirm"`.
+
+Two things fell out of implementing it, both measured in a browser rather than
+reasoned:
+
+1. **The focus effect was keyed on an open/closed EDGE**, and the `<Show>` is
+   unkeyed, so a request REPLACED by another never re-focused. That is exactly
+   the paste path: the guard's "Upload as .txt" door clears the store and opens
+   the send confirm in the same tick, so the intermediate `null` is never
+   observed. Now keyed on the request object, which also preserves #195's other
+   half (a re-render with the same request does not re-steal focus).
+2. **A row removal dropped focus to `<body>`.** The × the operator presses
+   unmounts with its row, so the next Enter answered nothing — in the one
+   dialog where Enter is supposed to send. The modal hands focus back to the
+   request's default button after a removal.
+
+### Not done, and why
+
+The constant `paste.txt` filename is untouched. With the first lines rendered,
+the dialog now says what is going out, which was the complaint; changing the
+name changes the URL peers see on IRC, and that is a separate decision from
+fixing a blind dialog.
+
+_Deploy: **HOT**, cic bundle only — no server change, no wire change, no
+protocol bump._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48904,8 +48904,13 @@ mechanical: `TextPane` reads through `textResource.ts`, which fetches with a
 `Range` header, and a blob: URL does not honour Range. So a staged text file is
 read from the File itself — `blob.slice(0, 8 KiB).text()`, head only, then
 `splitLines` (the viewer's own splitter) and the first four rows. A truncated
-read drops its last row: a byte slice can land mid-line and mid-codepoint, so
-that row is not a line the file has.
+read drops its last row, because a byte slice can land mid-line and
+mid-codepoint — but only when that row is really partial. The review found both
+exceptions: a cut landing exactly on a newline leaves every row complete (and
+`splitLines` has already dropped the phantom), so dropping again eats a real
+line; and a file whose FIRST line is longer than the head yields one partial
+row, where dropping it returns `[]` — an empty box, the very defect this
+change removes.
 
 **Audio gets a player, not a glyph.** For sound there is no picture to
 recognise — listening IS the preview, and `<audio controls>` is what the viewer
@@ -48939,6 +48944,22 @@ reasoned:
    unmounts with its row, so the next Enter answered nothing — in the one
    dialog where Enter is supposed to send. The modal hands focus back to the
    request's default button after a removal.
+
+### What the review changed
+
+An adversarial pass over the branch found no critical issue and four medium
+ones, all fixed here rather than filed. Two are recorded above (the truncation
+guards, and the `MediaKind` coupling note); the other two:
+
+* **Row identity.** `items()` minted a fresh `ConfirmAttachment` on every read,
+  and Solid's `<For>` diffs by REFERENCE — so removing one row disposed and
+  recreated every row. Invisible while the only preview was an `<img>`; visible
+  the moment one of them is a PLAYING `<audio>`, which stopped and reset to
+  zero. The attachment is now minted once, beside the staged file.
+* **The document split was a stringly `Set`.** `uploadCategory` types
+  `MIME_EXT_LABEL` on the MIME unions precisely "so a 15th MIME added to a list
+  without a label here is a compile error"; the preview map now does the same,
+  so a ninth document type cannot silently preview as an empty box.
 
 ### Not done, and why
 


### PR DESCRIPTION
Closes #1964.

## TL;DR

Fixed previews by filetype in the upload confirm — before, only images previewed and everything else showed an empty box:

- **Images** — a thumbnail of your own bytes, in the row head. Unchanged.
- **Video** — a player on its own line: `controls`, so you can watch it and check you picked the right take.
- **Audio** — a player on its own line: for sound there is nothing to look at, so listening IS the preview.
- **Text and Markdown** — the first four lines, read straight off the file.
- **PDF, office documents, anything else** — no box and no fake thumbnail. The row says `preview not supported`, because cicchetto has no renderer for those and previewing them would mean building a viewer first.

Plus: **Enter now sends** instead of discarding the batch, and it keeps working after you remove a row with ×.

## What was wrong

#1883 put a file list in the send confirm and gave the row an image thumbnail, on the argument quoted in the code it justified: *"a picture is the only preview worth showing: for every other category the bytes say nothing a human can check at a glance, and the name is what distinguishes `contract-final.pdf` from `contract-draft.pdf`"*.

That assumes a name the **operator** chose. The paste-as-.txt door (#816) names every file `paste.txt`, in every window — so on the one door where the operator cannot know what is inside, the dialog showed a constant name, a byte count and an empty box.

Second half, reported by @gmsrc while testing: **Enter discarded the batch**. #195 focused Cancel unconditionally, so the key you press after reading a dialog threw the staged files away.

## The preview is now per kind, reusing the viewer

`ConfirmAttachment` carries `preview: {kind: MediaKind, blob} | null` instead of `thumbnail: Blob | null`. The **kind vocabulary is the media viewer's own** rather than a second one: a staged local file poses the same question a clicked scrollback link does — what element can show this — so the row answers it with the same four words and reuses the same element shapes, pointed at a `blob:` URL of a file that has not been uploaded yet.

| kind | row |
|---|---|
| image | `<img>` thumbnail in the row head, unchanged from #1883 |
| video | `<video controls>` on its own line — a video is a thing that moves, so recognising the take means watching it |
| audio | `<audio controls>` on its own line — for sound there is no picture; listening IS the preview |
| text | the first four lines, read from the File |
| anything else | no box, and the row SAYS `· preview not supported` |

Three boundaries worth stating, because each one is a place the reuse stops:

- **`previewKindOf` is not `categoryOf`.** `document` is one bucket holding text, PDF, ODT, ODS, DOCX and XLSX, and only text has a renderer in cic. The map is keyed on the MIME unions (the discipline `MIME_EXT_LABEL` already states in that module), so a ninth document type is a compile error rather than a file that silently previews as an empty box.
- **The text arm cannot reuse the viewer's.** `TextPane` fetches through `textResource.ts` with a `Range` header and blob URLs do not honour Range. So text is read from the File — head only, 8 KiB — and split with the viewer's own `splitLines`.
- **No preview means the row says so.** There is no PDF or office renderer anywhere in cic (the viewer has four arms, and a 📄 link deliberately falls through to the browser), so previewing those would mean building a viewer first. #1883's neutral ☐ glyph is gone: it reads as a picture that FAILED to load, which is a different claim, and it was also being shown beside text and audio previews that work. This is the catch-all — the picker does not pre-filter by category, so an arbitrary binary reaches the dialog and gets the same honest row.

## Enter

`ConfirmRequest.defaultButton` is explicit at all ten call sites. Nine say `"cancel"` and keep #195's reasoning, which is right for a dialog that leaves a channel, drops a network, floods a room or deletes a theme. The upload confirm says `"confirm"`: the files are already staged by a gesture the operator made, the dialog is opt-in and exists to be READ, and Enter is the key you press after reading.

Two defects fell out of implementing it, both **measured in a browser rather than reasoned**:

1. The focus effect was keyed on an open/closed **edge**, and the `<Show>` is unkeyed, so a request REPLACED by another never re-focused. That is exactly the paste path: the guard's "Upload as .txt" door clears the store and opens the send confirm in the same tick, so the intermediate `null` is never observed.
2. A row removal dropped focus to `<body>`, so the next Enter answered nothing — in the one dialog where Enter is supposed to send.

## Review

An adversarial pass found no critical or high issue and four medium, all fixed in `251c2dc0` rather than filed:

- `readTextPreview` could preview **nothing**: it dropped the last row of any cut read, so a file whose first line exceeds the 8 KiB head returned `[]` — the very empty box this issue removes. A cut landing exactly on a newline also ate a real line. Both guarded and pinned.
- **Every row remounted on any removal**: `items()` minted fresh objects and Solid's `<For>` diffs by reference. Invisible with an `<img>`; visible the moment one preview is a PLAYING `<audio>`, which stopped and reset. Minted once now.
- The document split was a stringly `Set` (above).
- The module header still said "Cancel is the SAFE default: it takes initial focus" — false as of the previous commit, in the file a future session reads first.

## Gates

- types + lint: 5/5.
- unit: full suite in WSL, 338/340 files; the two reds (`compose`, `subscribe`) pass in isolation — the known local cross-file pollution, green in CI.
- e2e `issue1964-upload-confirm-preview`: 3/3. The previews are `blob:` URLs and the prod CSP gets a vote — #1883 measured `img-src` refusing one — and `media-src` is a separate directive, so video and audio needed a real engine as witness.
- Manually verified end to end on the dev stack by @gmsrc: all four previews, the playable video, the honest unsupported row, and Enter sending after a row removal.

Deploy: **HOT**, cic bundle only — no server change, no wire change, no protocol bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDCsdiDSVDJQSaqM4Yjoht

