### PR TITLE
session: derive the membership sigil set from the network's PREFIX (issue 1999)

### DIFF
--- a/cicchetto/e2e/tests/issue1999-namreply-sigil-peel.spec.ts
+++ b/cicchetto/e2e/tests/issue1999-namreply-sigil-peel.spec.ts
@@ -1,0 +1,138 @@
+// issue 1999 — a 353 RPL_NAMREPLY sigil must be PEELED off the nick, and the
+// peeled set must come from the network's own 005 PREFIX.
+//
+// The defect, reported on #grappa by Kerd: `split_mode_prefix` matched a
+// hardcoded `@ % +`, so on a network advertising founder/admin a `~nick`
+// token fell through unchanged and the sigil became part of the members-map
+// KEY. Clicking that nick opened a query against `~nick` — a nick that does
+// not exist — and the user could not write in it.
+//
+// ⚠️ WHAT THIS SPEC CANNOT COVER, AND WHY — read before trusting it as
+// coverage of the reported case. Neither ircd in the testnet can advertise a
+// PREFIX-rich network, so `~` and `&` are NOT reachable end to end here.
+// Measured on the live stack rather than assumed:
+//
+//   * bahamut leaf (`bahamut-test`) → `PREFIX=(ohv)@%+`
+//   * solanum (`azzurra2-solanum`)  → `PREFIX=(ov)@+`, and its
+//     reference.conf carries no `use_owner`/`use_admin`/`use_halfop` knob —
+//     solanum has no founder/admin channel modes to enable.
+//
+// So the rich case is covered where it CAN be measured: server-side by
+// `Session.ServerTest`'s "a PREFIX-rich network" case, which drives a real
+// `005 PREFIX=(qaohv)~&@%+` through the fake ircd, plus the `ISupport`,
+// `EventRouter` and `Identifier` unit cases; client-side by the `sigilRank`,
+// `memberSigil`, `members` and `MembersPane` unit cases, which seed the
+// isupport store with the rich table. A spec that claimed the browser had
+// seen a founder would be claiming a measurement nobody took.
+//
+// What this DOES buy, on the sigils the testnet does advertise: the peel was
+// rewritten from a compile-time guard clause into a run derived from 005, and
+// this is the only place that rewrite is exercised against a real ircd, a
+// real 353, and the real render — `@` and `%` must still peel, the nick text
+// must be BARE, and the click must still address the real nick. That is a
+// regression guard for the refactor, deliberately not a demonstration of the
+// bug being fixed.
+//
+// Shape — the ORDER is load-bearing:
+//   1. an op peer founds a fresh per-run channel (the founder auto-ops, @)
+//   2. a second peer joins and the op peer gives it `+h` (%)
+//   3. ONLY THEN does cic join — so the sigils reach it inside the 353,
+//      which is the `split_mode_prefix` door. Joining first would deliver
+//      them through the MODE walker instead, a different code path that has
+//      been PREFIX-aware since #216, and the spec would prove nothing.
+//
+// This spec is green on the base too — the peel of `@`/`%` worked before the
+// refactor — so it was FALSIFIED rather than trusted: with `member_sigils/1`
+// stubbed to `[]` on an otherwise unchanged tree, the run goes rc=1 on the
+// positive control ("element(s) not found" for `.nick-prefix`), because the
+// unpeeled `@nick` keys the member and carries no grade. The exact
+// `.nick-text` assertion below bites on the same break for the same reason.
+// A green that was never shown to be capable of red is not evidence.
+//
+// Platform note: the peel is server-side and the render is a members-pane
+// text node — no touch, viewport or engine dependency, so desktop chromium
+// IS the defect's own platform rather than a proxy for it.
+//
+// Parity matrix: UI shape contract, subject-shape-agnostic. Registered seed
+// (vjt + autojoin) suffices.
+
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.setTimeout(120_000);
+
+test("issue 1999 — a 353 sigil peels off the nick; the click addresses the real nick", async ({
+  page,
+}) => {
+  // Per-run unique channel + peer nicks: module-level constants make a spec
+  // un-`--repeat-each`-able (a second pass re-founds a channel it already
+  // parted and races a 433 on the peer nicks).
+  const suffix = crypto.randomUUID().slice(0, 5);
+  const channel = `#s1999-${suffix}`;
+  const opNick = `o1999${suffix}`;
+  const halfNick = `h1999${suffix}`;
+
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  // Focus the autojoin channel first to confirm login + WS-ready and mount
+  // the compose box before issuing the /join (issue240 boot order — after
+  // login cic lands on Home, which renders no ComposeBox).
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+  const opPeer = await IrcPeer.connect({ nick: opNick });
+  let halfPeer: IrcPeer | null = null;
+  try {
+    // The founding JOINer auto-ops on the testnet leaf (NO_CHANOPS_WHEN_SPLIT
+    // undef'd), so this peer holds @ and can grant +h below.
+    await opPeer.join(channel);
+
+    halfPeer = await IrcPeer.connect({ nick: halfNick });
+    await halfPeer.join(channel);
+    await opPeer.mode(channel, "+h", halfNick);
+
+    // Both grades are in place BEFORE cic joins, so they arrive in the 353.
+    await composeSend(page, `/join ${channel}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+    const opRow = page.locator(".members-pane .member-name", { hasText: opNick });
+    const halfRow = page.locator(".members-pane .member-name", { hasText: halfNick });
+
+    // POSITIVE CONTROL — the grades really did survive the 353, so the
+    // assertions below are reading a peeled token rather than an empty pane.
+    // Without this, "the nick text is bare" would pass on a plain member.
+    await expect(opRow.locator(".nick-prefix")).toHaveText("@", { timeout: 15_000 });
+    await expect(halfRow.locator(".nick-prefix")).toHaveText("%", { timeout: 15_000 });
+
+    // THE PEEL: the sigil lives in its own span and the nick text is the BARE
+    // nick. Pre-fix, an unrecognised sigil stayed glued and this node read
+    // `~nick`; `toHaveText` is exact, so a glued sigil fails here.
+    await expect(opRow.locator(".nick-text")).toHaveText(opNick);
+    await expect(halfRow.locator(".nick-text")).toHaveText(halfNick);
+
+    // THE RANK: op above halfop above the plain operator, from the advertised
+    // order rather than a hardcoded ladder. `member_sort_tier` used not to
+    // rank `%` at all, which put a halfop in the plain tier.
+    const rendered = await page.locator(".members-pane li .nick-text").allTextContents();
+    expect(rendered.indexOf(opNick)).toBeGreaterThanOrEqual(0);
+    expect(rendered.indexOf(opNick)).toBeLessThan(rendered.indexOf(halfNick));
+    expect(rendered.indexOf(halfNick)).toBeLessThan(rendered.indexOf(specNick()));
+
+    // THE REPORTED SYMPTOM: clicking a sigil-bearing nick opens a query
+    // against the real nick. A glued sigil opened `@nick` instead — a nick
+    // the ircd has never heard of, so the window could not be written in.
+    await expect(sidebarWindow(page, NETWORK_SLUG, opNick)).toHaveCount(0);
+    await opRow.click();
+    await expect(sidebarWindow(page, NETWORK_SLUG, opNick)).toHaveCount(1, { timeout: 15_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, `@${opNick}`)).toHaveCount(0);
+  } finally {
+    if (halfPeer) await halfPeer.disconnect("issue1999 done");
+    await opPeer.disconnect("issue1999 done");
+    // `/join` persists the channel into vjt's autojoin set; PART restores
+    // pre-test state. Idempotent — swallow 404 if the test bailed early.
+    await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+  }
+});

--- a/cicchetto/src/MembersPane.tsx
+++ b/cicchetto/src/MembersPane.tsx
@@ -1,5 +1,6 @@
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { ownNickForNetwork } from "./lib/api";
+import { sigilRankForSlug } from "./lib/casemapping";
 import { channelKey } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
 import { casemappingForNetwork } from "./lib/isupport";
@@ -60,12 +61,23 @@ export type Props = {
   onMemberSelect?: () => void;
 };
 
-const tierClass = (modes: string[]): string => {
-  if (modes.includes("@")) return "member-op";
-  if (modes.includes("%")) return "member-halfop";
-  if (modes.includes("+")) return "member-voiced";
-  return "member-plain";
+// The `<li>` tier class. Retained for the sortMembers contract and for
+// reviewer-facing diagnosis (see themes/default.css) — the per-tier colour
+// cascade moved onto the prefix span in BC2.
+//
+// issue 1999 — keyed off the member's rendered SIGIL rather than a
+// hardcoded `@ % +` scan, so the class always agrees with the glyph beside
+// it. The theme names only the three classic grades; a sigil outside that
+// set gets `member-plain`, the same deliberate stop `prefixClass` takes in
+// NickText, since no stylesheet in `themes/` answers for it yet.
+const CLASSIC_TIER_CLASS: Record<string, string> = {
+  "@": "member-op",
+  "%": "member-halfop",
+  "+": "member-voiced",
 };
+
+const tierClass = (modes: string[], rank: readonly string[]): string =>
+  CLASSIC_TIER_CLASS[memberSigil(modes, rank)] ?? "member-plain";
 
 // Translate member modes to the NickText prefix glyph contract.
 // memberSigil/1 returns " " for plain (column-alignment in the
@@ -76,8 +88,8 @@ const tierClass = (modes: string[]): string => {
 // span (the `@` / `%` / `+` chars are wider than a space anyway, so
 // the pre-existing alignment was approximate; per-mode color makes
 // the tier obvious without the padding).
-const sigilToPrefix = (modes: string[]): PrefixGlyph => {
-  const sigil = memberSigil(modes);
+const sigilToPrefix = (modes: string[], rank: readonly string[]): PrefixGlyph => {
+  const sigil = memberSigil(modes, rank);
   return sigil === " " ? "" : sigil;
 };
 
@@ -102,16 +114,23 @@ type MenuFor = { nick: string; x: number; y: number } | null;
 
 const MembersPane: Component<Props> = (props) => {
   const key = () => channelKey(props.networkSlug, props.channelName);
-  // UX-4 bucket J: render order is op > halfop > voice > plain, alpha
-  // within tier (case-insensitive per RFC 2812 §2.2). `sortMembers/1`
-  // owns the rule; MembersPane is the sole consumer today but the
-  // helper sits in lib/members.ts alongside the data store so the
+  // issue 1999 — the network's advertised sigil run, highest rank first.
+  // Drives BOTH the sort tier and the rendered glyph, so the order of the
+  // pane and the sigil on each row can never disagree. Reactive: a 005
+  // arriving after the pane mounted re-ranks it.
+  const rank = createMemo((): string[] => sigilRankForSlug(props.networkSlug));
+  // UX-4 bucket J: render order is highest advertised grade first, plain
+  // last, alpha within tier (case-insensitive per RFC 2812 §2.2).
+  // `sortMembers/2` owns the rule; MembersPane is the sole consumer today
+  // but the helper sits in lib/members.ts alongside the data store so the
   // sort contract co-locates with the source-of-truth shape.
   // `createMemo` caches the sorted array reference across reactive
-  // reads — only re-sorts when `membersByChannel` or `key()` actually
-  // changes (i.e. once per WS event burst per channel, not once per
-  // For-each iteration).
-  const list = createMemo((): MemberEntry[] => sortMembers(membersByChannel()[key()] ?? []));
+  // reads — only re-sorts when `membersByChannel`, `key()` or the rank
+  // actually change (i.e. once per WS event burst per channel, not once
+  // per For-each iteration).
+  const list = createMemo((): MemberEntry[] =>
+    sortMembers(membersByChannel()[key()] ?? [], rank()),
+  );
   const state = (): string | undefined => windowStateByChannel()[key()];
 
   // C5.1: context menu state — which nick was right-clicked + screen coords.
@@ -191,7 +210,7 @@ const MembersPane: Component<Props> = (props) => {
           <ul>
             <For each={list()}>
               {(m) => (
-                <li class={tierClass(m.modes)}>
+                <li class={tierClass(m.modes, rank())}>
                   <button
                     type="button"
                     class="member-name"
@@ -205,7 +224,7 @@ const MembersPane: Component<Props> = (props) => {
                         open list live on toggle. */}
                     <NickText
                       nick={m.nick}
-                      prefix={sigilToPrefix(m.modes)}
+                      prefix={sigilToPrefix(m.modes, rank())}
                       noColor={!getColoredNicklist()}
                     />
                     {/* M2 — gender badge, text content (not CSS ::before)

--- a/cicchetto/src/NamesModal.tsx
+++ b/cicchetto/src/NamesModal.tsx
@@ -1,4 +1,5 @@
 import { type Component, For, Show } from "solid-js";
+import { prefixForSlug, sigilRankForSlug } from "./lib/casemapping";
 import { memberSigil } from "./lib/memberSigil";
 import type { MemberEntry } from "./lib/memberTypes";
 import { dismissNamesModal, namesModalBySlug } from "./lib/namesModal";
@@ -25,25 +26,40 @@ import NickText, { type PrefixGlyph } from "./NickText";
 // exact MembersPane left-click verb pair). Dismiss via ×, Esc, or
 // backdrop. Ephemeral — dismissing just drops the store entry.
 
-// Section buckets in irssi precedence order. A member lands in the
-// highest tier it holds (an op who is also voiced shows under
-// Operators). Predicates are mutually exclusive by the not-higher
-// guards, so each member appears in exactly one section.
-const SECTIONS: { label: string; inTier: (modes: string[]) => boolean }[] = [
-  { label: "Operators", inTier: (m) => m.includes("@") },
-  { label: "Halfops", inTier: (m) => !m.includes("@") && m.includes("%") },
-  { label: "Voices", inTier: (m) => !m.includes("@") && !m.includes("%") && m.includes("+") },
-  {
-    label: "Users",
-    inTier: (m) => !m.includes("@") && !m.includes("%") && !m.includes("+"),
-  },
-];
+// issue 1999 — the section ladder used to be this hardcoded array of four
+// mutually-exclusive `@ % +` predicates, so on a PREFIX-rich network a
+// founder fell through every guard and was listed under "Users". Sections
+// are now GENERATED, one per sigil the network advertised, in the order it
+// advertised them (`sigilRankForSlug`), plus the trailing plain bucket. A
+// member lands in the section of their HIGHEST-ranked sigil, which
+// `memberSigil` already decides — bucketing by its answer makes the
+// sections exclusive by construction rather than by hand-written
+// not-higher guards.
+//
+// The LABELS are a display vocabulary this modal owns, keyed by mode
+// letter. That is the same split `channelModes.MEMBERSHIP_MODE_NAMES`
+// makes and for the same reason: the SET and the RANK are the network's
+// and must never be hardcoded, but a Title-Case plural heading is cic's
+// own copy, and it differs from the lowercase singular that prose surface
+// wants ("delivered to ops and voice only"). A letter nobody named renders
+// as `mode +<letter>` — the same generic shape `modeDescription` uses.
+const SECTION_LABELS: Record<string, string> = {
+  q: "Founders",
+  a: "Admins",
+  o: "Operators",
+  h: "Halfops",
+  v: "Voices",
+};
+
+const PLAIN_SECTION_LABEL = "Users";
+
+const sectionLabel = (letter: string): string => SECTION_LABELS[letter] ?? `mode +${letter}`;
 
 // modes → NickText prefix glyph. memberSigil returns " " for plain;
-// NickText's PrefixGlyph union treats plain as "" (no leading-space
-// span). Same translation MembersPane's `sigilToPrefix` does.
-const toPrefix = (modes: string[]): PrefixGlyph => {
-  const sigil = memberSigil(modes);
+// NickText treats plain as "" (no leading-space span). Same translation
+// MembersPane's `sigilToPrefix` does.
+const toPrefix = (modes: string[], rank: readonly string[]): PrefixGlyph => {
+  const sigil = memberSigil(modes, rank);
   return sigil === " " ? "" : sigil;
 };
 
@@ -83,11 +99,25 @@ const NamesModal: Component = () => {
   return (
     <Show when={bundle()} keyed>
       {(b) => {
-        const sections = (): { label: string; members: MemberEntry[] }[] =>
-          SECTIONS.map((s) => ({
-            label: s.label,
-            members: b.members.filter((m) => s.inTier(m.modes)),
-          })).filter((s) => s.members.length > 0);
+        const rank = (): string[] => sigilRankForSlug(b.network);
+        const prefixMap = (): Record<string, string> => prefixForSlug(b.network);
+        // One bucket per advertised sigil, rank order, then plain. The label
+        // is looked up by the sigil's mode LETTER, reverse-resolved through
+        // the network's own PREFIX map — never by the sigil character, which
+        // means nothing without the network that advertised it.
+        const sections = (): { label: string; members: MemberEntry[] }[] => {
+          const run = rank();
+          const letters = prefixMap();
+          const buckets = run.map((sigil) => ({
+            label: sectionLabel(Object.keys(letters).find((l) => letters[l] === sigil) ?? sigil),
+            members: b.members.filter((m) => memberSigil(m.modes, run) === sigil),
+          }));
+          buckets.push({
+            label: PLAIN_SECTION_LABEL,
+            members: b.members.filter((m) => memberSigil(m.modes, run) === " "),
+          });
+          return buckets.filter((s) => s.members.length > 0);
+        };
         const total = (): number => b.members.length;
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
@@ -132,7 +162,7 @@ const NamesModal: Component = () => {
                                 class="names-modal-nick"
                                 onClick={() => onNickClick(b.network, m.nick)}
                               >
-                                <NickText nick={m.nick} prefix={toPrefix(m.modes)} />
+                                <NickText nick={m.nick} prefix={toPrefix(m.modes, rank())} />
                               </button>
                             </li>
                           )}

--- a/cicchetto/src/NickText.tsx
+++ b/cicchetto/src/NickText.tsx
@@ -33,7 +33,13 @@ import { nickColorVar } from "./lib/nickColor";
 // pre-existing CSS layout rules still apply. The `.nick` baseline is
 // always present.
 
-export type PrefixGlyph = "@" | "%" | "+" | "";
+// issue 1999 — this was the closed union `"@" | "%" | "+" | ""`, which is
+// the SAME hardcoded triple `memberSigil` and `tierRank` carried, expressed
+// as a type. The membership set is per-network (005 PREFIX), so the glyph
+// can be any advertised sigil — `~` founder and `&` admin most commonly.
+// `""` still means "no glyph"; the empty-string check in the component is
+// the contract, not the union.
+export type PrefixGlyph = string;
 
 export type NickTextProps = {
   nick: string;
@@ -53,18 +59,22 @@ export type NickTextProps = {
   noColor?: boolean;
 };
 
-const prefixClass = (prefix: PrefixGlyph): string => {
-  switch (prefix) {
-    case "@":
-      return "nick-prefix nick-prefix-op";
-    case "%":
-      return "nick-prefix nick-prefix-halfop";
-    case "+":
-      return "nick-prefix nick-prefix-voiced";
-    default:
-      return "nick-prefix";
-  }
+// The theme carries a colour token for the three classic grades only
+// (`--mode-op` / `--mode-halfop` / `--mode-voiced`). A sigil outside that
+// set — `~`, `&`, or anything else a network advertises — renders bold on
+// the inherited `--fg` via the bare `.nick-prefix` baseline. That is a
+// deliberate stop, not an oversight: inventing a hue per sigil is a theme
+// decision, and every theme in `themes/` would have to answer it. The glyph
+// itself is what disambiguates the grade, and it is now rendered at all —
+// which is the fix (issue 1999). Adding `--mode-founder`/`--mode-admin` is
+// a follow-up with a design owner, not a guess made here.
+const CLASSIC_PREFIX_CLASS: Record<string, string> = {
+  "@": "nick-prefix nick-prefix-op",
+  "%": "nick-prefix nick-prefix-halfop",
+  "+": "nick-prefix nick-prefix-voiced",
 };
+
+const prefixClass = (prefix: PrefixGlyph): string => CLASSIC_PREFIX_CLASS[prefix] ?? "nick-prefix";
 
 const NickText: Component<NickTextProps> = (props) => {
   const cls = () => (props.extraClass ? `nick ${props.extraClass}` : "nick");

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -12,7 +12,7 @@ import {
 } from "solid-js";
 import LusersCard from "./LusersCard";
 import { isContentKind, ownNickForNetwork, type ScrollbackMessage } from "./lib/api";
-import { casemappingForSlug } from "./lib/casemapping";
+import { casemappingForSlug, sigilRankForSlug } from "./lib/casemapping";
 import { acceptInvite, confirmJoinChannel } from "./lib/channelJoin";
 import { channelKey, decodeChannelKey } from "./lib/channelKey";
 import { statusmsgDescription } from "./lib/channelModes";
@@ -755,7 +755,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
     if (!msg.channel) return "";
     const casemapping = casemappingForSlug(handlers.networkSlug);
     if (isContentKind(msg.kind) && nickEquals(nick, msg.sender, casemapping)) {
-      return snapshotSenderPrefix(msg.meta);
+      return snapshotSenderPrefix(msg.meta, sigilRankForSlug(handlers.networkSlug));
     }
     return "";
   };

--- a/cicchetto/src/WhoModal.tsx
+++ b/cicchetto/src/WhoModal.tsx
@@ -1,7 +1,8 @@
 import { type Component, For, Show } from "solid-js";
 import type { WhoUser } from "./lib/api";
-import { casemappingForSlug } from "./lib/casemapping";
+import { casemappingForSlug, prefixForSlug, sigilRankForSlug } from "./lib/casemapping";
 import { channelKey } from "./lib/channelKey";
+import { membershipLevelName } from "./lib/channelModes";
 import { memberSigil } from "./lib/memberSigil";
 import { membersByChannel } from "./lib/members";
 import { networks } from "./lib/networks";
@@ -51,14 +52,20 @@ import NickText, { type PrefixGlyph } from "./NickText";
 // when no roster snapshot exists (`WHO` on a non-joined channel,
 // `WHO <nick|mask>`) do we fall back to the token's trailing glyph, where a
 // lone `%` reads as halfop (#272 option 2). See `resolveWhoRow`.
-type Membership = "@" | "%" | "+";
+// issue 1999 — was the closed union `"@" | "%" | "+"`. A membership sigil is
+// whatever the network's 005 PREFIX advertises, so on a `(qaohv)~&@%+`
+// network `~` and `&` are memberships too: the old union made `H~` an
+// "unknown" flag chip and dropped the founder's glyph from the row.
+type Membership = string;
 
 type WhoFlagChip = { label: string; cssMod: string };
 
-// The status chars grappa enumerates; any other byte is surfaced raw so no
-// wire information is silently dropped (bahamut can emit flags grappa never
-// enumerated — the server relays the field verbatim).
-const KNOWN_WHO_FLAGS = new Set(["H", "G", "*", "S", "@", "%", "+"]);
+// The STRUCTURAL status chars grappa enumerates. The membership sigils are
+// NOT listed here (issue 1999): they are per-network and get unioned in from
+// the advertised run at parse time. Any byte in neither set is surfaced raw
+// so no wire information is silently dropped (bahamut can emit flags grappa
+// never enumerated — the server relays the field verbatim).
+const STRUCTURAL_WHO_FLAGS = ["H", "G", "*", "S"];
 
 // Structural (non-membership) attributes of a WHO row's flags token.
 type WhoFlags = {
@@ -71,7 +78,7 @@ type WhoFlags = {
   unknown: string[];
 };
 
-const isMembership = (ch: string): ch is Membership => ch === "@" || ch === "%" || ch === "+";
+const isMembership = (ch: string, rank: readonly string[]): boolean => rank.includes(ch);
 
 // Parse the raw 352 flags token per the bahamut grammar `[H|G] [*|%] [S]
 // [@|%|+]`. Channel membership is read as the TRAILING status glyph — bahamut
@@ -82,15 +89,16 @@ const isMembership = (ch: string): ch is Membership => ch === "@" || ch === "%" 
 // glyph (the glyph is still the last char). Invisibility is NOT decided here —
 // it is `%`-count-reconciled against the roster-resolved membership in
 // `resolveWhoRow`, because a lone `%` is undecidable (halfop vs +i) without it.
-const parseWhoFlags = (raw: string): WhoFlags => {
+const parseWhoFlags = (raw: string, rank: readonly string[]): WhoFlags => {
   const chars = [...raw];
   const last = chars[chars.length - 1];
+  const known = new Set([...STRUCTURAL_WHO_FLAGS, ...rank]);
   return {
     away: chars[0] === "G" ? "gone" : "here",
     oper: chars.includes("*"),
     secure: chars.includes("S"),
-    membership: last !== undefined && isMembership(last) ? last : null,
-    unknown: chars.filter((ch) => !KNOWN_WHO_FLAGS.has(ch)),
+    membership: last !== undefined && isMembership(last, rank) ? last : null,
+    unknown: chars.filter((ch) => !known.has(ch)),
   };
 };
 
@@ -110,20 +118,33 @@ const rosterMembership = (
   slug: string,
   channel: string,
   nick: string,
+  rank: readonly string[],
 ): Membership | null | undefined => {
   const list = membersByChannel()[channelKey(slug, channel)];
   if (list === undefined) return undefined;
   const member = list.find((m) => nickEquals(m.nick, nick, casemappingForSlug(slug)));
   if (member === undefined) return undefined;
-  const sigil = memberSigil(member.modes);
+  const sigil = memberSigil(member.modes, rank);
   return sigil === " " ? null : sigil;
 };
 
-const MEMBERSHIP_CHIP: Record<Membership, WhoFlagChip> = {
+// The three classic grades keep their long-standing labels and their own
+// chip colours. A sigil outside that set is NAMED through the network's own
+// PREFIX map (`membershipLevelName` — `q` → "founder", and `mode +<letter>`
+// for a letter nobody named) and rendered on the base chip style, since no
+// theme carries a colour for it. Naming the level beats surfacing a raw `~`
+// as an "unknown" flag, which is what the closed union used to do.
+const CLASSIC_MEMBERSHIP_CHIP: Record<string, WhoFlagChip> = {
   "@": { label: "chanop", cssMod: "chanop" },
   "%": { label: "halfop", cssMod: "halfop" },
   "+": { label: "voice", cssMod: "voice" },
 };
+
+const membershipChip = (sigil: Membership, prefix: Record<string, string>): WhoFlagChip =>
+  CLASSIC_MEMBERSHIP_CHIP[sigil] ?? {
+    label: membershipLevelName(sigil, prefix),
+    cssMod: "membership",
+  };
 
 // A fully-resolved WHO row: membership resolved against the roster, and
 // invisibility (umode +i) reconciled with it.
@@ -154,8 +175,12 @@ type ResolvedWhoRow = {
 // the irreducible residual (a rosterless oper-view +i *plain* member, `H%`,
 // reads as halfop) is documented in DESIGN_NOTES; the roster path covers the
 // reported/common case.
-const resolveWhoRow = (modes: string, rosterM: Membership | null | undefined): ResolvedWhoRow => {
-  const flags = parseWhoFlags(modes);
+const resolveWhoRow = (
+  modes: string,
+  rosterM: Membership | null | undefined,
+  rank: readonly string[],
+): ResolvedWhoRow => {
+  const flags = parseWhoFlags(modes, rank);
   const membership = rosterM === undefined ? flags.membership : rosterM;
   const percentCount = [...modes].filter((ch) => ch === "%").length;
   return {
@@ -171,14 +196,14 @@ const resolveWhoRow = (modes: string, rosterM: Membership | null | undefined): R
 // #176/#272 — decode a resolved WHO row into human-labeled, per-flag styled
 // chips. Labels + colors are cic-owned display strings — NOT mIRC codes — so
 // they render as CSS chips, never through MircBody.
-const whoChips = (row: ResolvedWhoRow): WhoFlagChip[] => {
+const whoChips = (row: ResolvedWhoRow, prefix: Record<string, string>): WhoFlagChip[] => {
   const chips: WhoFlagChip[] = [
     row.away === "gone" ? { label: "gone", cssMod: "gone" } : { label: "here", cssMod: "here" },
   ];
   if (row.oper) chips.push({ label: "ircop", cssMod: "ircop" });
   if (row.invisible) chips.push({ label: "invisible", cssMod: "invisible" });
   if (row.secure) chips.push({ label: "secure", cssMod: "secure" });
-  if (row.membership !== null) chips.push(MEMBERSHIP_CHIP[row.membership]);
+  if (row.membership !== null) chips.push(membershipChip(row.membership, prefix));
   for (const ch of row.unknown) chips.push({ label: ch, cssMod: "unknown" });
   return chips;
 };
@@ -219,6 +244,12 @@ const WhoModal: Component = () => {
   return (
     <Show when={bundle()} keyed>
       {(b) => {
+        // issue 1999 — the network's advertised membership run + its
+        // letter↔sigil map. Getters, not snapshots: a 005 landing while the
+        // ephemeral modal is open re-decodes the rows, the same reason
+        // `resolved` reads the roster as a getter below.
+        const rank = (): string[] => sigilRankForSlug(b.network);
+        const prefixMap = (): Record<string, string> => prefixForSlug(b.network);
         const total = (): number => b.users.length;
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
@@ -262,7 +293,11 @@ const WhoModal: Component = () => {
                       // stays correct if the roster updates while the ephemeral
                       // modal is open.
                       const resolved = (): ResolvedWhoRow =>
-                        resolveWhoRow(u.modes, rosterMembership(b.network, u.channel, u.nick));
+                        resolveWhoRow(
+                          u.modes,
+                          rosterMembership(b.network, u.channel, u.nick, rank()),
+                          rank(),
+                        );
                       return (
                         <li class="who-modal-row" data-testid="who-modal-row">
                           <div class="who-modal-line who-modal-line-head">
@@ -280,7 +315,7 @@ const WhoModal: Component = () => {
                               labels colored per flag via CSS — NOT mIRC codes,
                               so they do NOT route through MircBody. */}
                             <span class="who-modal-flags">
-                              <For each={whoChips(resolved())}>
+                              <For each={whoChips(resolved(), prefixMap())}>
                                 {(chip) => (
                                   <span
                                     class={`who-modal-flag-tag who-modal-flag-tag-${chip.cssMod}`}

--- a/cicchetto/src/__tests__/MembersPane.test.tsx
+++ b/cicchetto/src/__tests__/MembersPane.test.tsx
@@ -85,8 +85,32 @@ vi.mock("../lib/colorNicklist", () => ({
 
 import MembersPane from "../MembersPane";
 
-beforeEach(() => {
+// issue 1999 — "the network is unresolved" is a STATE for the whole
+// duration of a test, not a property of ONE call. The two cases below used
+// `mockReturnValueOnce([])`, which pins a CALL INDEX instead: the moment
+// MembersPane made one more `networks()` call during render than it used
+// to (the `sigilRankForSlug` hop the advertised-rank memo needs), the empty
+// array was consumed by the render and the click handler saw the seeded
+// network — so the test failed while the production behaviour it asserts
+// was intact. Measured: with the rank memo, `networks()` is called once by
+// render and once by the click; with that one path stubbed, zero and once.
+//
+// `unresolveNetworks()` sets the state and `beforeEach` restores the seed,
+// so the assertion no longer depends on how many times the component reads
+// the store. Curing the SETUP, never the assert.
+const SEEDED_NETWORKS = [
+  { id: 1, slug: "freenode", nick: "vjt", inserted_at: "x", updated_at: "y" },
+];
+
+const unresolveNetworks = async (): Promise<void> => {
+  const { networks } = await import("../lib/networks");
+  vi.mocked(networks).mockReturnValue([] as never);
+};
+
+beforeEach(async () => {
   vi.clearAllMocks();
+  const { networks } = await import("../lib/networks");
+  vi.mocked(networks).mockReturnValue(SEEDED_NETWORKS as never);
   mockMembers = {};
   mockWindowState = {};
   coloredHolder.current = false;
@@ -115,6 +139,44 @@ describe("MembersPane", () => {
     // `@vjt` / `+alice` above.
     expect(plain?.textContent).toContain("bob");
     expect(plain?.textContent).not.toContain(" bob");
+  });
+
+  it("renders a PREFIX-rich roster: founder on top, its sigil drawn (issue 1999)", async () => {
+    // The pane's half of the reported defect. Pre-fix, `~founder` reached
+    // cic with the sigil glued to the nick (server side) AND, once that was
+    // peeled, `memberSigil`/`tierRank` still knew only `@ % +`: the founder
+    // rendered with no glyph, in `member-plain`, at the BOTTOM of the list.
+    //
+    // The rank is seeded through the real store + the real `slug → id` hop,
+    // not stubbed, so this also covers `sigilRankForSlug` finding the
+    // network the mock declares.
+    const { seedIsupport, DEFAULT_ISUPPORT } = await import("../lib/isupport");
+    seedIsupport(1, {
+      ...DEFAULT_ISUPPORT,
+      prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      prefixOrder: ["q", "a", "o", "h", "v"],
+    });
+
+    mockWindowState = { "freenode #italia": "joined" };
+    mockMembers = {
+      "freenode #italia": [
+        { nick: "zed", modes: [] },
+        { nick: "opper", modes: ["@"] },
+        { nick: "boss", modes: ["~"] },
+        { nick: "admin", modes: ["&"] },
+      ],
+    };
+
+    render(() => <MembersPane networkSlug="freenode" channelName="#italia" />);
+
+    const rows = [...document.querySelectorAll(".members-pane li")];
+    expect(rows.map((li) => li.textContent)).toEqual(["~boss", "&admin", "@opper", "zed"]);
+
+    // The theme names only the three classic grades, so `~`/`&` land on
+    // `member-plain` by design (NickText's `prefixClass` takes the same
+    // stop). The GLYPH is what carries the grade, and it is drawn — which
+    // is the fix. A colour token for founder/admin is a theme decision.
+    expect(document.querySelector(".member-op")?.textContent).toBe("@opper");
   });
 
   it("renders the count in the heading when state=joined + non-empty list", () => {
@@ -234,8 +296,7 @@ describe("MembersPane", () => {
   });
 
   it("onMemberSelect is NOT called when network is unresolved (early-return short-circuits the side-effect chain)", async () => {
-    const { networks } = await import("../lib/networks");
-    vi.mocked(networks).mockReturnValueOnce([] as never);
+    await unresolveNetworks();
     mockWindowState = { "freenode #italia": "joined" };
     mockMembers = { "freenode #italia": [{ nick: "alice", modes: [] }] };
     const onMemberSelect = vi.fn();
@@ -250,12 +311,7 @@ describe("MembersPane", () => {
   });
 
   it("left-click is a no-op when network is unresolved (race: list arrives before networks)", async () => {
-    const { networks } = await import("../lib/networks");
-    // Cast: the mock factory above types `networks` as a `vi.fn(() => [...])`
-    // with the seed array's literal type; an empty replacement on a single
-    // call needs the matching shape. `as []` widens the empty literal
-    // appropriately for the once-call.
-    vi.mocked(networks).mockReturnValueOnce([] as never);
+    await unresolveNetworks();
     const qw = await import("../lib/queryWindows");
     const sel = await import("../lib/selection");
     mockWindowState = { "freenode #italia": "joined" };

--- a/cicchetto/src/__tests__/isupport.test.ts
+++ b/cicchetto/src/__tests__/isupport.test.ts
@@ -15,6 +15,8 @@ import {
   isupportEntryFromWire,
   isupportForNetwork,
   seedIsupport,
+  sigilRank,
+  sigilRankForNetwork,
 } from "../lib/isupport";
 import { nickEquals } from "../lib/nickEquals";
 import { narrowIsupportChanged } from "../lib/wireNarrow";
@@ -243,5 +245,72 @@ describe("isupport → nick fold composition (#1861)", () => {
 
     seedIsupport(53, isupportEntryFromWire(narrowed));
     expect(casemappingForNetwork(53)).toBe("ascii");
+  });
+});
+
+describe("isupport → membership sigil rank (issue 1999)", () => {
+  it("DEFAULT_ISUPPORT's rank is the bahamut/Azzurra run, highest first", () => {
+    expect(sigilRank(DEFAULT_ISUPPORT)).toEqual(["@", "%", "+"]);
+  });
+
+  it("a PREFIX-rich network ranks founder and admin ABOVE op", () => {
+    // The client twin of `Grappa.Session.ISupport.sigils/1`. Every surface
+    // that renders or orders a membership sigil reads this run instead of
+    // the `@ % +` triple `memberSigil` and `tierRank` used to hardcode.
+    const entry: IsupportEntry = {
+      ...DEFAULT_ISUPPORT,
+      prefix: { q: "~", a: "&", o: "@", h: "%", v: "+" },
+      prefixOrder: ["q", "a", "o", "h", "v"],
+    };
+
+    expect(sigilRank(entry)).toEqual(["~", "&", "@", "%", "+"]);
+  });
+
+  it("the rank is NOT the map's value order", () => {
+    // The guard `editorSigils` earned the hard way (#1302): the map crosses
+    // the wire as a JSON object whose key order is the server runtime's —
+    // alphabetical by mode letter — which on `(qaohv)` puts `o` in the
+    // MIDDLE. Reading rank off the map is the defect, not the shortcut.
+    const entry: IsupportEntry = {
+      ...DEFAULT_ISUPPORT,
+      prefix: { a: "&", h: "%", o: "@", q: "~", v: "+" },
+      prefixOrder: ["q", "a", "o", "h", "v"],
+    };
+
+    expect(Object.values(entry.prefix)).not.toEqual(sigilRank(entry));
+    expect(sigilRank(entry)).toEqual(["~", "&", "@", "%", "+"]);
+  });
+
+  it("an EMPTY prefixOrder falls back to the default run, never to []", () => {
+    // A server predating #1302 publishes no order at all. `[]` would read as
+    // "this network has no membership levels", which would silently disable
+    // every sigil and flatten the pane — strictly worse than assuming the
+    // bahamut run every production network advertises anyway. Same posture
+    // `editorSigils` takes for an order it cannot resolve.
+    const entry: IsupportEntry = { ...DEFAULT_ISUPPORT, prefixOrder: [] };
+
+    expect(sigilRank(entry)).toEqual(["@", "%", "+"]);
+  });
+
+  it("a letter the map cannot resolve is skipped, not rendered as undefined", () => {
+    const entry: IsupportEntry = {
+      ...DEFAULT_ISUPPORT,
+      prefix: { o: "@", v: "+" },
+      prefixOrder: ["o", "q", "v"],
+    };
+
+    expect(sigilRank(entry)).toEqual(["@", "+"]);
+  });
+
+  it("sigilRankForNetwork resolves a seeded network, and defaults for an unseeded one", () => {
+    seedIsupport(1999, {
+      ...DEFAULT_ISUPPORT,
+      prefix: { q: "~", o: "@", v: "+" },
+      prefixOrder: ["q", "o", "v"],
+    });
+
+    expect(sigilRankForNetwork(1999)).toEqual(["~", "@", "+"]);
+    expect(sigilRankForNetwork(19_991)).toEqual(["@", "%", "+"]);
+    expect(sigilRankForNetwork(null)).toEqual(["@", "%", "+"]);
   });
 });

--- a/cicchetto/src/__tests__/memberSigil.test.ts
+++ b/cicchetto/src/__tests__/memberSigil.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+// issue 1999 — `memberSigil` used to hardcode `@ > % > +`. Once the server
+// stopped gluing sigils to nicks (`ISupport.sigils/1` drives the 353 peel),
+// a founder's `["~"]` matched none of the three branches and fell through to
+// the plain arm: drawn with no sigil, indistinguishable from a lurker.
+//
+// The rank now comes from the network's own PREFIX, via `sigilRank`. These
+// cases pin the pure function; the store hop (`sigilRankForNetwork` /
+// `sigilRankForSlug`) is covered in isupport.test.ts and casemapping.test.ts.
+
+import { DEFAULT_ISUPPORT, sigilRank } from "../lib/isupport";
+import { memberSigil } from "../lib/memberSigil";
+
+const BAHAMUT = sigilRank(DEFAULT_ISUPPORT);
+const RICH = ["~", "&", "@", "%", "+"];
+
+describe("memberSigil", () => {
+  it("renders the single sigil a member holds", () => {
+    expect(memberSigil(["@"], BAHAMUT)).toBe("@");
+    expect(memberSigil(["%"], BAHAMUT)).toBe("%");
+    expect(memberSigil(["+"], BAHAMUT)).toBe("+");
+  });
+
+  it("renders a space for a plain member — the column-alignment contract", () => {
+    // Not `""`: the members pane is a monospace column and the space keeps
+    // plain rows aligned with their sigil-bearing siblings. The `→ ""`
+    // translation for NickText happens at the call sites.
+    expect(memberSigil([], BAHAMUT)).toBe(" ");
+  });
+
+  it("picks the HIGHEST-ranked sigil a member holds", () => {
+    expect(memberSigil(["+", "@"], BAHAMUT)).toBe("@");
+    expect(memberSigil(["+", "%"], BAHAMUT)).toBe("%");
+  });
+
+  it("ranks founder and admin above op on a PREFIX-rich network", () => {
+    // The reported case. `~` used to fall through to the plain arm.
+    expect(memberSigil(["~"], RICH)).toBe("~");
+    expect(memberSigil(["&"], RICH)).toBe("&");
+    expect(memberSigil(["@", "~"], RICH)).toBe("~");
+    expect(memberSigil(["+", "&"], RICH)).toBe("&");
+  });
+
+  it("takes rank from the RUN, not from the modes array's own order", () => {
+    // A member accumulates sigils in whatever order MODE lines arrived; the
+    // server prepends. Order in the array carries no rank information.
+    expect(memberSigil(["@", "&", "+"], RICH)).toBe("&");
+    expect(memberSigil(["+", "&", "@"], RICH)).toBe("&");
+  });
+
+  it("a sigil the network never advertised is not a grade", () => {
+    // On a `(ov)@+` network a stray `~` names no level cic could describe,
+    // so the member reads as plain rather than being handed an invented
+    // glyph. Same posture `membershipLevelName` takes for an unknown sigil.
+    expect(memberSigil(["~"], ["@", "+"])).toBe(" ");
+  });
+
+  it("an empty rank run yields plain rather than throwing", () => {
+    expect(memberSigil(["@"], [])).toBe(" ");
+  });
+});

--- a/cicchetto/src/__tests__/members.test.ts
+++ b/cicchetto/src/__tests__/members.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
+import { DEFAULT_ISUPPORT, sigilRank } from "../lib/isupport";
 
 vi.mock("../lib/api", () => ({
   setOn401Handler: vi.fn(),
@@ -382,6 +383,8 @@ describe("members.applyPresenceEvent", () => {
   });
 });
 
+const BAHAMUT = sigilRank(DEFAULT_ISUPPORT);
+
 describe("members.sortMembers (bucket J)", () => {
   it("orders by tier: op > halfop > voice > plain", async () => {
     const { sortMembers } = await import("../lib/members");
@@ -391,7 +394,7 @@ describe("members.sortMembers (bucket J)", () => {
       { nick: "op", modes: ["@"] },
       { nick: "halfop", modes: ["%"] },
     ];
-    const sorted = sortMembers(input);
+    const sorted = sortMembers(input, BAHAMUT);
     expect(sorted.map((m) => m.nick)).toEqual(["op", "halfop", "voice", "plain"]);
   });
 
@@ -402,7 +405,7 @@ describe("members.sortMembers (bucket J)", () => {
       { nick: "Alice", modes: [] },
       { nick: "bob", modes: [] },
     ];
-    const sorted = sortMembers(input);
+    const sorted = sortMembers(input, BAHAMUT);
     expect(sorted.map((m) => m.nick)).toEqual(["Alice", "bob", "carol"]);
   });
 
@@ -413,7 +416,7 @@ describe("members.sortMembers (bucket J)", () => {
       { nick: "alice", modes: ["@"] },
       { nick: "Bob", modes: ["@"] },
     ];
-    const sorted = sortMembers(input);
+    const sorted = sortMembers(input, BAHAMUT);
     expect(sorted.map((m) => m.nick)).toEqual(["alice", "Bob", "Zoe"]);
   });
 
@@ -429,7 +432,7 @@ describe("members.sortMembers (bucket J)", () => {
       { nick: "opZ", modes: ["@"] },
       { nick: "halfopA", modes: ["%"] },
     ];
-    const sorted = sortMembers(input);
+    const sorted = sortMembers(input, BAHAMUT);
     expect(sorted.map((m) => m.nick)).toEqual([
       "opA",
       "opZ",
@@ -448,14 +451,14 @@ describe("members.sortMembers (bucket J)", () => {
       { nick: "b", modes: [] },
       { nick: "a", modes: ["@"] },
     ];
-    const sorted = sortMembers(input);
+    const sorted = sortMembers(input, BAHAMUT);
     expect(sorted).not.toBe(input);
     expect(input.map((m) => m.nick)).toEqual(["b", "a"]);
   });
 
   it("empty input returns empty array", async () => {
     const { sortMembers } = await import("../lib/members");
-    expect(sortMembers([])).toEqual([]);
+    expect(sortMembers([], BAHAMUT)).toEqual([]);
   });
 
   it("a member with multiple modes ([@, +]) ranks by highest tier (op)", async () => {
@@ -467,7 +470,70 @@ describe("members.sortMembers (bucket J)", () => {
       { nick: "opvoiced", modes: ["@", "+"] },
       { nick: "voiced", modes: ["+"] },
     ];
-    const sorted = sortMembers(input);
+    const sorted = sortMembers(input, BAHAMUT);
     expect(sorted.map((m) => m.nick)).toEqual(["opvoiced", "voiced", "plain"]);
+  });
+});
+
+describe("members.sortMembers rank comes from the network's PREFIX (issue 1999)", () => {
+  const RICH = ["~", "&", "@", "%", "+"];
+
+  it("founder and admin sort ABOVE op", async () => {
+    // The issue's third acceptance criterion. `tierRank` knew `@ % +` only,
+    // so `~` and `&` fell through to the plain tier and a channel's founder
+    // was rendered at the BOTTOM of the pane, below every lurker.
+    const { sortMembers } = await import("../lib/members");
+    const input = [
+      { nick: "plain", modes: [] },
+      { nick: "op", modes: ["@"] },
+      { nick: "founder", modes: ["~"] },
+      { nick: "voice", modes: ["+"] },
+      { nick: "admin", modes: ["&"] },
+      { nick: "halfop", modes: ["%"] },
+    ];
+
+    expect(sortMembers(input, RICH).map((m) => m.nick)).toEqual([
+      "founder",
+      "admin",
+      "op",
+      "halfop",
+      "voice",
+      "plain",
+    ]);
+  });
+
+  it("rank is the RUN's, so the same roster orders differently per network", async () => {
+    // Two networks, one roster, two truths — which is the whole reason rank
+    // cannot be a module constant. On a network that never advertised `~`
+    // the founder is not a grade at all and sorts alphabetically as plain.
+    const { sortMembers } = await import("../lib/members");
+    const input = [
+      { nick: "zed", modes: ["@"] },
+      { nick: "founder", modes: ["~"] },
+    ];
+
+    expect(sortMembers(input, RICH).map((m) => m.nick)).toEqual(["founder", "zed"]);
+    expect(sortMembers(input, ["@", "+"]).map((m) => m.nick)).toEqual(["zed", "founder"]);
+  });
+
+  it("alpha tie-break still applies within a rich tier", async () => {
+    const { sortMembers } = await import("../lib/members");
+    const input = [
+      { nick: "Zoe", modes: ["~"] },
+      { nick: "alice", modes: ["~"] },
+      { nick: "Bob", modes: ["~"] },
+    ];
+
+    expect(sortMembers(input, RICH).map((m) => m.nick)).toEqual(["alice", "Bob", "Zoe"]);
+  });
+
+  it("an empty rank run flattens to pure alpha rather than throwing", async () => {
+    const { sortMembers } = await import("../lib/members");
+    const input = [
+      { nick: "b", modes: ["@"] },
+      { nick: "a", modes: [] },
+    ];
+
+    expect(sortMembers(input, []).map((m) => m.nick)).toEqual(["a", "b"]);
   });
 });

--- a/cicchetto/src/__tests__/nickColor.test.ts
+++ b/cicchetto/src/__tests__/nickColor.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_ISUPPORT, sigilRank } from "../lib/isupport";
 import {
   NICK_PALETTE_SIZE,
   nickColorIndex,
@@ -150,20 +151,44 @@ describe("nickColorVar", () => {
 });
 
 describe("snapshotSenderPrefix (#25)", () => {
+  // issue 1999 — the accepted set is the network's advertised run, not a
+  // hardcoded triple. `BAHAMUT` comes from production code rather than a
+  // literal so the seed cannot drift out from under these cases.
+  const BAHAMUT = sigilRank(DEFAULT_ISUPPORT);
+  const RICH = ["~", "&", "@", "%", "+"];
+
   it("returns the snapshotted glyph from meta.sender_prefix", () => {
-    expect(snapshotSenderPrefix({ sender_prefix: "@" })).toBe("@");
-    expect(snapshotSenderPrefix({ sender_prefix: "%" })).toBe("%");
-    expect(snapshotSenderPrefix({ sender_prefix: "+" })).toBe("+");
+    expect(snapshotSenderPrefix({ sender_prefix: "@" }, BAHAMUT)).toBe("@");
+    expect(snapshotSenderPrefix({ sender_prefix: "%" }, BAHAMUT)).toBe("%");
+    expect(snapshotSenderPrefix({ sender_prefix: "+" }, BAHAMUT)).toBe("+");
   });
 
   it("returns '' when the key is absent (plain sender / pre-#25 row)", () => {
-    expect(snapshotSenderPrefix({})).toBe("");
-    expect(snapshotSenderPrefix({ new_nick: "x" })).toBe("");
+    expect(snapshotSenderPrefix({}, BAHAMUT)).toBe("");
+    expect(snapshotSenderPrefix({ new_nick: "x" }, BAHAMUT)).toBe("");
   });
 
-  it("returns '' for a malformed / non-glyph value (never a live guess)", () => {
-    expect(snapshotSenderPrefix({ sender_prefix: "~" })).toBe("");
-    expect(snapshotSenderPrefix({ sender_prefix: 1 })).toBe("");
-    expect(snapshotSenderPrefix({ sender_prefix: null })).toBe("");
+  it("returns '' for a malformed / non-string value (never a live guess)", () => {
+    expect(snapshotSenderPrefix({ sender_prefix: 1 }, BAHAMUT)).toBe("");
+    expect(snapshotSenderPrefix({ sender_prefix: null }, BAHAMUT)).toBe("");
+    expect(snapshotSenderPrefix({ sender_prefix: ["@"] }, BAHAMUT)).toBe("");
+  });
+
+  it("renders a founder's snapshot on a network that advertises it", () => {
+    // The server writes whichever sigil the 005 PREFIX named
+    // (`Identifier.member_prefix/2`). Dropping `~` here left a founder's
+    // scrollback rows looking like a plain member's — the members-pane
+    // defect, one surface over.
+    expect(snapshotSenderPrefix({ sender_prefix: "~" }, RICH)).toBe("~");
+    expect(snapshotSenderPrefix({ sender_prefix: "&" }, RICH)).toBe("&");
+  });
+
+  it("still drops a sigil THIS network never advertised", () => {
+    // Not a passthrough: `meta.sender_prefix` is `term()` on the wire, so a
+    // row from an old backup or a future server can carry anything, and an
+    // unvalidated value would reach the DOM as a glyph. On bahamut `~` names
+    // no grade, so it renders as none.
+    expect(snapshotSenderPrefix({ sender_prefix: "~" }, BAHAMUT)).toBe("");
+    expect(snapshotSenderPrefix({ sender_prefix: "!" }, RICH)).toBe("");
   });
 });

--- a/cicchetto/src/lib/casemapping.ts
+++ b/cicchetto/src/lib/casemapping.ts
@@ -13,7 +13,12 @@
 // wireTypes) and keeps the pure fold in `nickEquals.ts` free of the
 // solid-js resource graph.
 
-import { type Casemapping, casemappingForNetwork } from "./isupport";
+import {
+  type Casemapping,
+  casemappingForNetwork,
+  prefixForNetwork,
+  sigilRankForNetwork,
+} from "./isupport";
 import { networkIdBySlug } from "./networks";
 
 /**
@@ -27,3 +32,28 @@ import { networkIdBySlug } from "./networks";
  */
 export const casemappingForSlug = (slug: string): Casemapping =>
   casemappingForNetwork(networkIdBySlug(slug) ?? null);
+
+/**
+ * The membership sigils the network behind `slug` advertised, highest rank
+ * first (issue 1999), or the bahamut/Azzurra run when the slug names no
+ * known network.
+ *
+ * Lives here for exactly the reason `casemappingForSlug` does: `isupport.ts`
+ * keys 005 facts by network ID, most of cic is keyed by slug, and this is
+ * the module that already owns the `slug → id` hop. Putting it in
+ * `isupport.ts` would drag `networks.ts` into that store and cost it its
+ * leaf status.
+ */
+export const sigilRankForSlug = (slug: string): string[] =>
+  sigilRankForNetwork(networkIdBySlug(slug) ?? null);
+
+/**
+ * The membership letter→sigil map the network behind `slug` advertised, or
+ * the bahamut/Azzurra default. The third resident of this slug→id hop.
+ *
+ * Safe for lookups in either direction (that is what NamesModal's section
+ * labels need: sigil → letter, to name the level). NOT safe as an order —
+ * use `sigilRankForSlug` for that. `prefixForNetwork` says why.
+ */
+export const prefixForSlug = (slug: string): Record<string, string> =>
+  prefixForNetwork(networkIdBySlug(slug) ?? null);

--- a/cicchetto/src/lib/channelModes.ts
+++ b/cicchetto/src/lib/channelModes.ts
@@ -225,7 +225,7 @@ const MEMBERSHIP_MODE_NAMES: Record<string, string> = {
  * A reverse lookup on PREFIX is safe; reading RANK out of it is NOT — the
  * map crosses the wire alphabetical by mode letter (see `editorSigils`).
  */
-function membershipLevelName(sigil: string, prefix: Record<string, string>): string {
+export function membershipLevelName(sigil: string, prefix: Record<string, string>): string {
   const letter = Object.keys(prefix).find((l) => prefix[l] === sigil);
   if (letter === undefined) return sigil;
   return MEMBERSHIP_MODE_NAMES[letter] ?? `mode +${letter}`;

--- a/cicchetto/src/lib/isupport.ts
+++ b/cicchetto/src/lib/isupport.ts
@@ -197,6 +197,50 @@ export function prefixForNetwork(networkId: number | null): Record<string, strin
 }
 
 /**
+ * The membership SIGILS this network advertised, HIGHEST RANK FIRST —
+ * `["~", "&", "@", "%", "+"]` on `PREFIX=(qaohv)~&@%+`. The client twin of
+ * `Grappa.Session.ISupport.sigils/1`, and the ONE place a surface that
+ * renders or orders a membership sigil may read the set from.
+ *
+ * issue 1999 — `memberSigil` and `tierRank` each carried their own `@ % +`
+ * copy of this. Once the server stopped gluing sigils to nicks, a founder's
+ * `["~"]` matched neither: drawn without a sigil, and sorted to the BOTTOM
+ * of the members pane.
+ *
+ * Rank is `prefixOrder`'s, never the map's — `Object.values` comes back
+ * alphabetical BY MODE LETTER, which on `(qaohv)` puts `o` in the MIDDLE
+ * (the mis-rank #1302 found in `editorSigils`). An EMPTY order — a server
+ * predating that field — falls back to the bahamut run rather than to `[]`:
+ * `[]` would read as "this network has no membership levels" and silently
+ * flatten every pane, which is strictly worse than assuming the run every
+ * production network advertises anyway. A letter the map cannot resolve is
+ * skipped rather than emitted as `undefined`.
+ */
+export function sigilRank(entry: IsupportEntry): string[] {
+  const resolve = (e: IsupportEntry): string[] => {
+    const out: string[] = [];
+    for (const letter of e.prefixOrder) {
+      const sigil = e.prefix[letter];
+      if (sigil !== undefined) out.push(sigil);
+    }
+    return out;
+  };
+
+  const run = resolve(entry);
+  return run.length > 0 ? run : resolve(DEFAULT_ISUPPORT);
+}
+
+/**
+ * `sigilRank` for a network id, or the bahamut/Azzurra run for an unseeded
+ * network / a null id. Sibling of `prefixForNetwork` — the per-fact
+ * accessor, so a caller that needs the rank does not carry the whole entry.
+ */
+export function sigilRankForNetwork(networkId: number | null): string[] {
+  if (networkId === null) return sigilRank(DEFAULT_ISUPPORT);
+  return sigilRank(isupportForNetwork(networkId));
+}
+
+/**
  * How this network folds identifiers (#1861), or the bahamut/Azzurra
  * default `"ascii"` for an unseeded network / a null id. Sibling of
  * `chantypesForNetwork` — the store-reading half of the nick fold, whose

--- a/cicchetto/src/lib/memberSigil.ts
+++ b/cicchetto/src/lib/memberSigil.ts
@@ -1,12 +1,28 @@
-// Returns the rendered prefix sigil for a member, given their mode list:
-// "@" for op, "%" for halfop, "+" for voiced, " " (single space) for
-// plain — the space keeps columns aligned with @/%/+-prefixed siblings
-// in monospace rendering.
+// Returns the rendered prefix sigil for a member, given their mode list and
+// the network's advertised sigil rank: the HIGHEST-ranked sigil they hold,
+// or " " (single space) for plain — the space keeps columns aligned with
+// sigil-bearing siblings in monospace rendering.
 //
 // Lifted from `ScrollbackPane.tsx`'s former module-private `memberSigil`
 // helper so the same sigil derivation is reused by MembersPane (right
 // pane) AND ScrollbackPane (sender prefix in scrollback rows). Per
 // CLAUDE.md "implement once, reuse everywhere".
+//
+// issue 1999 — `rank` used to be a hardcoded `@ > % > +` ladder inside this
+// function. Once the server stopped gluing sigils to nicks (see
+// `Grappa.Session.ISupport.sigils/1`, which drives the 353 peel), a
+// founder's `["~"]` matched none of the three branches and fell through to
+// the plain arm: drawn with no sigil, indistinguishable from a lurker. The
+// rank is now the network's own, from `sigilRank`/`sigilRankForNetwork`,
+// and it is a PARAMETER rather than a store read so this stays a pure
+// function with no edge to the solid-js resource graph (same shape as
+// `editorSigils`, which takes the whole entry).
+//
+// Rank is the RUN's, never the modes array's: a member accumulates sigils
+// in whatever order MODE lines arrived, so their position carries no rank.
+// A sigil the network never advertised is NOT a grade — the member reads as
+// plain rather than being handed an invented glyph, the same posture
+// `membershipLevelName` takes for an unadvertised sigil.
 //
 // IMPORTANT: this is the DOM-text representation. The previous
 // MembersPane implementation rendered the prefix via CSS `::before
@@ -16,9 +32,5 @@
 // `feedback_css_block_button_wraps_inline_prefix` for the regression
 // post-mortem.
 
-export const memberSigil = (modes: string[]): "@" | "%" | "+" | " " => {
-  if (modes.includes("@")) return "@";
-  if (modes.includes("%")) return "%";
-  if (modes.includes("+")) return "+";
-  return " ";
-};
+export const memberSigil = (modes: readonly string[], rank: readonly string[]): string =>
+  rank.find((sigil) => modes.includes(sigil)) ?? " ";

--- a/cicchetto/src/lib/members.ts
+++ b/cicchetto/src/lib/members.ts
@@ -136,26 +136,34 @@ export const applyPresenceEvent = exports_.applyPresenceEvent;
 export const seedFromTest = exports_.seedFromTest;
 
 // UX-4 bucket J (2026-05-19) — tier rank for MembersPane sort order.
-// Mirrors the sigil precedence in `memberSigil.ts`: op (@) outranks
-// halfop (%), halfop outranks voice (+), voice outranks plain. Lower
-// rank value = higher position (op = 0 on top).
+// The tier IS the index into the network's advertised sigil run (highest
+// rank first, from `sigilRank`), so lower value = higher position. Plain
+// takes `rank.length`, one past every real index whatever the run's size.
 //
-// Server-side `Grappa.Session.EventRouter.@user_mode_prefixes` is the
-// allowed set of per-user modes (o/h/v); any other prefix on a member's
-// `modes` array would mean wire contract drift, so this fn doesn't
-// need a defensive fallback for unknown prefixes — the entry falls
-// through to plain (rank 3) on its own.
-const tierRank = (modes: readonly string[]): 0 | 1 | 2 | 3 => {
-  if (modes.includes("@")) return 0;
-  if (modes.includes("%")) return 1;
-  if (modes.includes("+")) return 2;
-  return 3;
+// issue 1999 — this used to be a hardcoded `@ > % > +` ladder, and the
+// comment here claimed the server only ever admits `o/h/v`. #216 had
+// already made that false: the membership set is per-network, from the 005
+// PREFIX. Consequence once the server stopped gluing sigils to nicks — a
+// founder's `["~"]` matched no branch, fell to plain, and the channel's
+// founder rendered at the BOTTOM of the pane, below every lurker.
+//
+// A sigil the network never advertised is not a grade: `findIndex` misses
+// and the member falls to plain, the same posture `memberSigil` takes.
+const tierRank = (modes: readonly string[], rank: readonly string[]): number => {
+  const tier = rank.findIndex((sigil) => modes.includes(sigil));
+  return tier === -1 ? rank.length : tier;
 };
 
 /**
- * Returns a new array with members sorted by tier (op > halfop > voice
- * > plain) and case-insensitive alpha within each tier. Pure — does
- * not mutate the input.
+ * Returns a new array with members sorted by advertised grade (highest
+ * first, plain last) and case-insensitive alpha within each tier. Pure —
+ * does not mutate the input.
+ *
+ * `rank` is the network's sigil run — `sigilRankForSlug(slug)` at the
+ * render site. Passed in rather than read from the store so this stays a
+ * pure function; it is required rather than defaulted because a wrong
+ * default here silently reorders someone's pane (CLAUDE.md: no default
+ * arguments, they create silent degradation paths).
  *
  * Used by MembersPane to keep the right-pane order stable across MODE
  * events: `+o alice` moves alice to the top, `-o alice` drops her
@@ -167,9 +175,9 @@ const tierRank = (modes: readonly string[]): 0 | 1 | 2 | 3 => {
  * Alpha tie-breaker is case-insensitive per RFC 2812 §2.2 — IRC nicks
  * are case-insensitive, so sort order MUST match.
  */
-export const sortMembers = (members: ChannelMembers): ChannelMembers =>
+export const sortMembers = (members: ChannelMembers, rank: readonly string[]): ChannelMembers =>
   [...members].sort((a, b) => {
-    const rankDiff = tierRank(a.modes) - tierRank(b.modes);
+    const rankDiff = tierRank(a.modes, rank) - tierRank(b.modes, rank);
     if (rankDiff !== 0) return rankDiff;
     return a.nick.toLowerCase().localeCompare(b.nick.toLowerCase());
   });

--- a/cicchetto/src/lib/nickColor.ts
+++ b/cicchetto/src/lib/nickColor.ts
@@ -72,9 +72,9 @@ import { asciiFold } from "./nickEquals";
 //
 // ## Scrollback sender prefix
 //
-// Members-pane nicks carry the CURRENT prefix via `memberSigil` (op `@`,
-// halfop `%`, voiced `+`, plain ` `), and that pane is the only surface
-// where a live grade belongs — "now" is genuinely its subject.
+// Members-pane nicks carry the CURRENT prefix via `memberSigil` (the
+// network's highest advertised grade, plain ` `), and that pane is the only
+// surface where a live grade belongs — "now" is genuinely its subject.
 //
 // A scrollback row is not. It is a RECORD of a past event, so the only
 // glyph it may show is `snapshotSenderPrefix` below: the grade the SERVER
@@ -131,7 +131,22 @@ export const nickColorVar = (nick: string): string => `var(--nick-color-${nickCo
 // before #25 landed — so cic never falls back to a live-derived guess
 // (which is exactly the bug). `meta` is the untyped wire bag, so the
 // value is validated against the three glyphs here.
-export const snapshotSenderPrefix = (meta: Record<string, unknown>): "@" | "%" | "+" | "" => {
+// issue 1999 — the accepted set is the network's advertised run, not the
+// `@ % +` triple this used to test against. The server snapshots whichever
+// sigil the 005 PREFIX named (`Identifier.member_prefix/2`), so on a
+// PREFIX-rich network a founder's rows carried `~` and this dropped it: the
+// row rendered as a plain sender, which is the same defect the members pane
+// had, one surface over.
+//
+// Still a WHITELIST rather than a passthrough: `meta.sender_prefix` is
+// `term()` on the wire, so a row restored from an old backup or written by a
+// future server can carry anything, and an unvalidated value would go
+// straight into the DOM as a glyph. A sigil this network does not advertise
+// names no grade cic could render, so it degrades to no glyph.
+export const snapshotSenderPrefix = (
+  meta: Record<string, unknown>,
+  rank: readonly string[],
+): string => {
   const p = meta.sender_prefix;
-  return p === "@" || p === "%" || p === "+" ? p : "";
+  return typeof p === "string" && rank.includes(p) ? p : "";
 };

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -48991,3 +48991,113 @@ fixing a blind dialog.
 
 _Deploy: **HOT**, cic bundle only — no server change, no wire change, no
 protocol bump._
+<!-- entry #1999 -->
+
+---
+
+## 2026-09-08 — #1999: the membership sigil set is the network's, in six places
+
+A user on #grappa (Kerd) reported that clicking a nick in the members pane
+opened a query against `~nick` — a nick that does not exist, so nothing could
+be written in the window. The issue named one cause,
+`EventRouter.split_mode_prefix/1`, which matched a hardcoded `?@ ?% ?+`: a 353
+RPL_NAMREPLY token like `~nick` missed every clause, fell through the
+fallback unchanged, and the sigil became the `state.members` KEY.
+
+That diagnosis was correct and incomplete. Grepping the CLASS rather than the
+reported symptom found the same hardcoded triple in five more places, three of
+them server-side and none named in the issue:
+
+* `Identifier.member_prefix/1` held `["@", "%", "+"]` as a module constant, so
+  `Enum.find` returned nil for a `["~"]` member and a founder's content rows
+  were persisted with NO `meta.sender_prefix`. That one is permanent by
+  design: #25 SNAPSHOTS the grade at persist time precisely so a later MODE
+  cannot re-prefix history, so every row already written keeps the omission.
+* `Session.Server.member_sort_tier/1` knew `@` and `+` only. It did not rank
+  bahamut's OWN halfop — a `%` member sorted into the plain tier — and that
+  survived unseen because cic re-sorts the pane with a tier function of its
+  own. The server order is visible in `GET /members` and in the
+  `names_reply`/`members_seeded` payloads, not in the pane.
+* cic's `memberSigil`, `members.tierRank`, `NamesModal`'s four hand-written
+  not-higher predicates, `WhoModal`'s `Membership` union, `MembersPane`'s
+  `tierClass` and `nickColor.snapshotSenderPrefix` each carried a copy.
+
+### What the fix is
+
+One accessor per side. `ISupport.sigils/1` and cic's `sigilRank` return the
+advertised run, HIGHEST RANK FIRST, composed from `prefix_order` + the lookup
+map — not stored as a third field, because a stored copy is a parallel
+structure that needs housekeeping and will drift. Rank comes from
+`prefix_order` and never from the map: `Map.values/1` / `Object.values` come
+back alphabetical BY MODE LETTER, which on `(qaohv)` puts `o` in the MIDDLE.
+That is the same mis-rank #1302 found in `editorSigils`, and #1302's docstring
+is the reason this was written correctly the first time here.
+
+Deriving the SET rather than widening the literal to `~&@%+` is what makes the
+inverse safe. On a `(ov)@+` network a leading `~` is not a membership sigil,
+and peeling it would silently address a DIFFERENT nick. Unknown stays unknown,
+everywhere: an unadvertised sigil is not a grade for the sort, not a grade for
+the snapshot, and not a glyph for the render.
+
+The peel is GREEDY, and that is a deliberate decoupling rather than support
+for a feature we do not have. `multi-prefix` is not in grappa's CAP REQ, so
+upstream sends the single highest sigil and the run is length 1 in production
+— but a nick can never BEGIN with a sigil (RFC 2812 §2.3.1 `special` is
+`[ ] \ ` _ ^ { | }`, which excludes every PREFIX char), so peeling the whole
+run is unambiguous. Writing it greedily keeps `split_mode_prefix/2` correct
+independently of a CAP decision made in `IRC.AuthFsm`, instead of silently
+keying on `&nick` the day that changes.
+
+### No wire change, and it was measured
+
+`mix grappa.wire_pin --check` answers "wire shape and protocol 14 agree" and
+`gen_wire_types --check` reports in sync after the change. The domain of
+`modes` widened; its SHAPE did not, and `meta.sender_prefix` is `term()` in
+the typespec, appearing in `wireTypes.ts` only as a key NAME. `modes` is
+already `string[]` there, so an old bundle receiving `["~"]` degrades — no
+glyph, plain tier — rather than rejecting the payload. Everything cic needs
+(`prefix`, `prefix_order`) has crossed the wire since #1302. Recorded because
+the #1393d rule bumps on every shape change including additive ones, so "no
+bump" has to be an answer somebody measured, not an omission.
+
+### Two limits taken knowingly
+
+**No colour for a new sigil.** `NickText.prefixClass` and `MembersPane`'s
+`tierClass` keep their three classic branches and fall back to the bare
+`.nick-prefix` baseline / `member-plain`. The theme carries `--mode-op`,
+`--mode-halfop` and `--mode-voiced` and nothing else; inventing a hue per
+sigil is a design decision every theme in `themes/` would have to answer.
+The glyph is what carries the grade, and it is now drawn at all — which was
+the defect. `--mode-founder`/`--mode-admin` wants a design owner.
+
+**The e2e cannot reach the reported case.** Measured on the live stack rather
+than assumed: the bahamut leaf advertises `PREFIX=(ohv)@%+`, solanum
+advertises `PREFIX=(ov)@+`, and solanum's reference.conf carries no
+`use_owner`/`use_admin`/`use_halfop` knob — it has no founder/admin channel
+modes to enable. So `~` and `&` are covered where they CAN be measured:
+server-side by a `list_members` case that drives a real
+`005 PREFIX=(qaohv)~&@%+` through the fake ircd, client-side by unit cases
+that seed the isupport store with the same table. The e2e that DOES exist
+guards the rewrite at the one door nothing else guarded — a real ircd, a real
+353, the real render — and states its own limit in its header. Lifting it
+means adding an ircd that advertises founder/admin as a testnet service,
+which argues against #221's deliberate move from a hand-rolled bahamut mock
+to a real solanum, and is its own slice.
+
+### The test that broke, and why it was the test
+
+Two `MembersPane` cases asserting "the network is unresolved" used
+`mockReturnValueOnce([])`, which pins a CALL INDEX rather than a state. The
+rank memo adds one `networks()` read at render, so the empty array was
+consumed before the click handler ran and both cases failed while the
+production behaviour they assert was intact. Measured both ways before
+touching anything: 1 call after render / 2 after click with the memo, 0 / 1
+with that single path stubbed. Cured in the SETUP — a scoped
+`mockReturnValue` restored by `beforeEach` — never in the assert. General
+rule: `mockReturnValueOnce` on a function the component calls an
+implementation-dependent number of times encodes a call count nobody meant to
+assert.
+
+_Deploy: **COLD** — server modules changed (`ISupport`, `EventRouter`,
+`Identifier`, `Session.Server`) plus the cic bundle. No wire change, no
+protocol bump._

--- a/lib/grappa/irc/identifier.ex
+++ b/lib/grappa/irc/identifier.ex
@@ -764,25 +764,34 @@ defmodule Grappa.IRC.Identifier do
 
   def server_sender?(_), do: false
 
-  # Channel-membership sigil precedence: op > halfop > voice. Mirrors
-  # cic's `memberSigil` (@ > % > +) so server snapshot and client render
-  # agree on which glyph a multi-moded member shows.
-  @member_prefix_precedence ["@", "%", "+"]
-
   @doc """
-  The highest-precedence membership sigil (`@`/`%`/`+`) in a member's
-  mode-sigil list, or `nil` for a plain member / empty list / non-list.
+  The highest-ranked membership sigil in a member's mode-sigil list, or
+  `nil` for a plain member / empty list / non-list / a list carrying no
+  sigil this network advertised.
 
   `state.members[channel][nick]` stores sigils (`["@"]`, `["@", "+"]`,
   `[]`); this reduces them to the single glyph cic shows. Used at
   scrollback-persist time to SNAPSHOT a content row's sender grade into
   `meta.sender_prefix`, so a later MODE change can't retroactively
   re-prefix historical lines (#25).
+
+  `precedence` is the network's advertised sigil run, HIGHEST RANK FIRST —
+  `Grappa.Session.ISupport.sigils/1` at both call sites. issue 1999: this
+  used to be a module constant `["@", "%", "+"]`, so on a network
+  advertising founder/admin an `Enum.find` over it returned `nil` for a
+  `["~"]` member and their rows were persisted with NO grade at all, then
+  rendered as a plain user's forever after (the snapshot is the point —
+  it is never recomputed). The run is passed in rather than read here so
+  this module stays a pure identifier module with no edge to the
+  per-network capability table.
+
+  Rank is the RUN's, never the argument list's: a member holding
+  `["@", "&"]` is an admin, whatever order the sigils accumulated in.
   """
-  @spec member_prefix(term()) :: String.t() | nil
-  def member_prefix(sigils) when is_list(sigils) do
-    Enum.find(@member_prefix_precedence, &(&1 in sigils))
+  @spec member_prefix(term(), [String.t()]) :: String.t() | nil
+  def member_prefix(sigils, precedence) when is_list(sigils) and is_list(precedence) do
+    Enum.find(precedence, &(&1 in sigils))
   end
 
-  def member_prefix(_), do: nil
+  def member_prefix(_, precedence) when is_list(precedence), do: nil
 end

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -67,14 +67,14 @@ defmodule Grappa.Scrollback.Meta do
 
   ## Per-kind expected shapes
 
-      :privmsg | :action | :topic   →  %{} OR %{sender_prefix: "@" | "%" | "+"}
+      :privmsg | :action | :topic   →  %{} OR %{sender_prefix: <membership sigil>}
                                                                  (#25: content rows on a channel
                                                                   snapshot the sender's grade glyph
                                                                   at SEND time so a later MODE change
                                                                   can't retroactively re-prefix them;
                                                                   absent for plain senders / DMs /
                                                                   $server. :topic carries %{}.)
-      :notice                       →  %{} OR %{sender_prefix: "@" | "%" | "+"}
+      :notice                       →  %{} OR %{sender_prefix: <membership sigil>}
                                     OR %{numeric: 1..999, severity: :ok | :error,
                                          raw_params: [String.t()]}
                                                                  (server numerics route to :notice

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1134,7 +1134,8 @@ defmodule Grappa.Session.EventRouter do
     {members, newly_seen_nicks} =
       case Map.fetch(state.members, channel) do
         {:ok, existing} ->
-          new_entries = Map.new(tokens, &split_mode_prefix/1)
+          sigils = member_sigils(state)
+          new_entries = Map.new(tokens, &split_mode_prefix(&1, sigils))
           # M2 — nicks this 353 line introduces that we did NOT already
           # know about in this channel's roster. Only meaningful in this
           # branch (an ephemeral /names on an unjoined channel below
@@ -3871,12 +3872,44 @@ defmodule Grappa.Session.EventRouter do
 
   defp toggle_mode(modes, prefix, :remove), do: List.delete(modes, prefix)
 
-  @spec split_mode_prefix(String.t()) :: {String.t(), [String.t()]}
-  defp split_mode_prefix(<<prefix, rest::binary>>) when prefix in [?@, ?%, ?+] do
-    {rest, [<<prefix>>]}
+  # Peel the membership sigils off a 353 RPL_NAMREPLY `[prefix]nick` token,
+  # returning `{bare_nick, sigils_in_arrival_order}`.
+  #
+  # issue 1999 — `sigils` is the network's OWN advertised run
+  # (`ISupport.sigils/1`), NOT the `?@ ?% ?+` guard this used to carry. On a
+  # network advertising founder/admin (`PREFIX=(qaohv)~&@%+`) a `~nick` token
+  # matched no clause and fell through unchanged, so the sigil stayed GLUED
+  # to the nick and became the `state.members` KEY: every consumer downstream
+  # — members pane, click-to-query, right-click > query — then addressed
+  # `~nick`, which does not exist, and the operator could not write in the
+  # window that opened. Same #216 posture the two MODE walkers already hold;
+  # the 353 path was the one left behind.
+  #
+  # Deriving the SET (rather than widening the literal to `~&@%+`) is what
+  # makes the inverse safe too: on a `(ov)@+` network a leading `~` is not a
+  # membership sigil, and peeling it would silently address a DIFFERENT nick.
+  #
+  # GREEDY on purpose. `multi-prefix` is not in grappa's CAP REQ today, so
+  # upstream sends only the highest sigil and the run is length 1 in
+  # production — but a nick can never BEGIN with a sigil (RFC 2812 §2.3.1
+  # `special` is `[ ] \ ` _ ^ { | }`, which excludes every PREFIX char), so
+  # peeling the whole advertised run is unambiguous and costs nothing. That
+  # keeps this function's correctness independent of a CAP decision made in
+  # `IRC.AuthFsm`, instead of silently keying on `&nick` the day it changes.
+  @spec split_mode_prefix(String.t(), [String.t()]) :: {String.t(), [String.t()]}
+  defp split_mode_prefix(token, sigils), do: split_mode_prefix(token, sigils, [])
+
+  defp split_mode_prefix(<<sigil::utf8, rest::binary>> = token, sigils, acc) do
+    grapheme = <<sigil::utf8>>
+
+    if grapheme in sigils do
+      split_mode_prefix(rest, sigils, [grapheme | acc])
+    else
+      {token, Enum.reverse(acc)}
+    end
   end
 
-  defp split_mode_prefix(nick), do: {nick, []}
+  defp split_mode_prefix(token, _, acc), do: {token, Enum.reverse(acc)}
 
   @spec build_persist(
           state(),
@@ -4069,18 +4102,24 @@ defmodule Grappa.Session.EventRouter do
     {state, {:persist, kind, attrs}}
   end
 
-  # #25: snapshot the sender's channel grade (@/%/+) onto a content row
-  # so a later MODE change can't retroactively re-prefix it. Only for
-  # content kinds on a real (sigil-prefixed) channel where the sender is
-  # a tracked member with a non-plain grade. Plain members, DM (nick)
-  # windows, and the synthetic "$server" window get no key — cic renders
-  # no glyph for an absent `meta.sender_prefix` (also the back-compat
-  # path for rows persisted before this landed).
+  # #25: snapshot the sender's channel grade onto a content row so a later
+  # MODE change can't retroactively re-prefix it. Only for content kinds on
+  # a real (sigil-prefixed) channel where the sender is a tracked member
+  # with a non-plain grade. Plain members, DM (nick) windows, and the
+  # synthetic "$server" window get no key — cic renders no glyph for an
+  # absent `meta.sender_prefix` (also the back-compat path for rows
+  # persisted before this landed).
+  #
+  # issue 1999 — the grade resolves against THIS network's advertised rank,
+  # not a hardcoded `@ % +` precedence: a founder's rows used to snapshot no
+  # grade at all, and the snapshot is one-shot by design, so the omission
+  # was permanent for every row already written.
   @spec put_sender_prefix(map(), map(), atom(), String.t(), String.t()) :: map()
   defp put_sender_prefix(meta, state, kind, channel, sender) when kind in @content_kinds do
     with true <- channel_shaped?(channel),
          sigils when is_list(sigils) <- get_in(state.members, [channel, sender]),
-         prefix when is_binary(prefix) <- Identifier.member_prefix(sigils) do
+         prefix when is_binary(prefix) <-
+           Identifier.member_prefix(sigils, member_sigils(state)) do
       Map.put(meta, :sender_prefix, prefix)
     else
       _ -> meta
@@ -4130,6 +4169,14 @@ defmodule Grappa.Session.EventRouter do
   @spec casemapping(state()) :: Identifier.casemapping()
   defp casemapping(state),
     do: ISupport.casemapping(Map.get(state, :isupport, ISupport.default()))
+
+  # The network's membership sigils, highest rank first (issue 1999). Same
+  # `Map.get` hot-reload shape as `casemapping/1` above, and the same reason:
+  # a live state seeded before `:isupport` existed must degrade to bahamut
+  # rather than raise mid-353.
+  @spec member_sigils(state()) :: [String.t()]
+  defp member_sigils(state),
+    do: ISupport.sigils(Map.get(state, :isupport, ISupport.default()))
 
   # Empty baseline entry returned when a channel_modes entry doesn't exist yet
   # (e.g. when a MODE arrives before 324 RPL_CHANNELMODEIS).
@@ -5102,7 +5149,7 @@ defmodule Grappa.Session.EventRouter do
   #     bare JOIN seeds members but never opens a names modal).
   #   - entry exists: `[{:names_reply, channel, roster, reply_to}]`. `roster` is
   #     the arrival-order `[{nick, modes}]` list — each accumulated
-  #     `[prefix]nick` token split via `split_mode_prefix/1`. The
+  #     `[prefix]nick` token split via `split_mode_prefix/2`. The
   #     mIRC-tier sort + wire projection happen in
   #     `Session.Server.apply_effects/2` (where `member_sort_tier/1`
   #     lives), exactly as the `members_seeded` arm does. `channel` is
@@ -5120,7 +5167,8 @@ defmodule Grappa.Session.EventRouter do
       {:ok, accum} ->
         next_state = %{state | names_pending: Map.delete(pending, chan_key)}
         target_display = Map.get(accum, :target_display, channel)
-        roster = accum |> Map.get(:names, []) |> Enum.map(&split_mode_prefix/1)
+        sigils = member_sigils(state)
+        roster = accum |> Map.get(:names, []) |> Enum.map(&split_mode_prefix(&1, sigils))
         {next_state, [{:names_reply, target_display, roster, Map.get(accum, :reply_to)}]}
     end
   end

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -3970,7 +3970,7 @@ defmodule Grappa.Session.EventRouter do
   # guessing one — an absent key is the documented back-compat path.
   defp sender_meta(%Message{}), do: %{}
 
-  # #25: content kinds whose sender shows an irssi-style @/%/+ glyph. The
+  # #25: content kinds whose sender shows an irssi-style grade glyph. The
   # glyph must reflect the sender's grade AT SEND TIME, not their current
   # grade — so it's snapshotted into meta here, not derived live by cic.
   # S17 — derived from the schema SSOT (`Message` here is the IRC parser

--- a/lib/grappa/session/isupport.ex
+++ b/lib/grappa/session/isupport.ex
@@ -361,6 +361,48 @@ defmodule Grappa.Session.ISupport do
   def default_prefix_order, do: @default_prefix_order
 
   @doc """
+  The membership SIGILS this network advertised, HIGHEST RANK FIRST —
+  `["~", "&", "@", "%", "+"]` on `PREFIX=(qaohv)~&@%+`, `["@", "%", "+"]`
+  pre-005. The rank-ordered projection of the same token `prefix/1` holds
+  as a lookup map and `prefix_order/1` as mode letters.
+
+  This is the source every consumer that needs the SET or the PRECEDENCE
+  of membership sigils must read (issue 1999). Three sites used to carry
+  their own `@ % +` copy of it and each was wrong in its own way on a
+  PREFIX-rich network: `EventRouter.split_mode_prefix/2` left a `~` glued
+  to the nick it prefixed (so the members map keyed a nick that does not
+  exist — the reported defect), `Identifier.member_prefix/2` snapshot no
+  grade at all for a founder, and `Session.Server.member_sort_tier/2`
+  sorted founder and admin into the PLAIN tier at the bottom of the pane.
+
+  Composed from the two accessors rather than stored as a third field:
+  a stored copy is a parallel structure needing housekeeping, and
+  `prefix_order/1` already carries the only fact the map cannot
+  (`Map.values/1` comes back alphabetical BY LETTER, which on `(qaohv)`
+  puts `o` in the MIDDLE — the mis-rank #1302 fixed in cic's
+  `editorSigils`). Both reads are `Map.get`-defaulted, so a live
+  `Session.Server` state seeded before either field existed degrades to
+  the bahamut run instead of raising — and, crucially, never to `[]`,
+  which would disable sigil stripping altogether. A letter the map cannot
+  resolve is SKIPPED rather than emitted as `nil`; the two projections
+  come from one parse and cannot disagree today, but a total accessor
+  does not depend on that.
+  """
+  @spec sigils(t()) :: [String.t()]
+  def sigils(isupport) when is_map(isupport) do
+    prefix = Map.get(isupport, :prefix, @default_prefix)
+
+    isupport
+    |> prefix_order()
+    |> Enum.flat_map(fn letter ->
+      case Map.fetch(prefix, letter) do
+        {:ok, sigil} -> [sigil]
+        :error -> []
+      end
+    end)
+  end
+
+  @doc """
   The advertised STATUSMSG membership sigils for this network — the set a
   message target may be prefixed with to reach only members at-or-above
   that status (`@#chan` ops, `+#chan` voice). Read via `Map.get` (not

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2544,6 +2544,8 @@ defmodule Grappa.Session.Server do
       # M2 — same gender merge as the `members_seeded` broadcast
       # (apply_effects), so `GET /members` and the WS event never
       # disagree on the badge.
+      sigils = session_member_sigils(state)
+
       members =
         state.members
         |> Map.get(channel, %{})
@@ -2551,7 +2553,7 @@ defmodule Grappa.Session.Server do
           gender = Map.get(state.peer_profile_cache, fold_key(state, nick), %{})[:gender]
           %{nick: nick, modes: modes, gender: gender}
         end)
-        |> Enum.sort_by(&{member_sort_tier(&1.modes), &1.nick})
+        |> Enum.sort_by(&{member_sort_tier(&1.modes, sigils), &1.nick})
 
       {:reply, {:ok, members}, state}
     else
@@ -3984,6 +3986,14 @@ defmodule Grappa.Session.Server do
   defp session_casemapping(state),
     do: ISupport.casemapping(Map.get(state, :isupport, ISupport.default()))
 
+  # The network's membership sigils, highest rank first (issue 1999) — the
+  # ONE source both the grade snapshot and the roster sort read. Same
+  # `Map.get` hot-reload shape as `session_casemapping/1`, and the twin of
+  # `EventRouter.member_sigils/1` on the inbound side.
+  @spec session_member_sigils(t()) :: [String.t()]
+  defp session_member_sigils(state),
+    do: ISupport.sigils(Map.get(state, :isupport, ISupport.default()))
+
   # M3b — the authenticated, same-origin serving path a browser fetches
   # a cached peer avatar from — NEVER the raw third-party URL the peer's
   # CTCP AVATAR reply carried. Relative (no `base_url()` needed, unlike
@@ -4259,16 +4269,20 @@ defmodule Grappa.Session.Server do
     end
   end
 
-  # #25: the operator's own channel grade for an outbound content row,
-  # as `%{sender_prefix: "@" | "%" | "+"}` or `%{}` (DM target / plain /
-  # untracked). `key` is ALREADY the network-folded channel window key
-  # (`fold_key/2`, #537) — the same key EventRouter's members map is
-  # keyed under — so the lookup hits directly, no re-fold.
+  # #25: the operator's own channel grade for an outbound content row, as
+  # `%{sender_prefix: <sigil>}` or `%{}` (DM target / plain / untracked).
+  # `key` is ALREADY the network-folded channel window key (`fold_key/2`,
+  # #537) — the same key EventRouter's members map is keyed under — so the
+  # lookup hits directly, no re-fold.
+  #
+  # issue 1999 — the precedence run is the network's, matching the inbound
+  # twin `EventRouter.put_sender_prefix/5`. An operator who is founder on a
+  # PREFIX-rich network used to see their OWN lines rendered plain.
   @spec own_sender_prefix_meta(t(), String.t()) :: map()
   defp own_sender_prefix_meta(state, key) do
     sigils = get_in(state.members, [key, state.nick]) || []
 
-    case Identifier.member_prefix(sigils) do
+    case Identifier.member_prefix(sigils, session_member_sigils(state)) do
       nil -> %{}
       prefix -> %{sender_prefix: prefix}
     end
@@ -5723,13 +5737,15 @@ defmodule Grappa.Session.Server do
     # M2 — merge in the cached peer gender (nil when never queried/
     # answered, e.g. `show_peer_profiles` off) so `Wire.member/1`'s
     # `:gender` key is populated straight from state, no extra fetch.
+    sigils = session_member_sigils(state)
+
     members =
       members_map
       |> Enum.map(fn {nick, modes} ->
         gender = Map.get(state.peer_profile_cache, fold_key(state, nick), %{})[:gender]
         %{nick: nick, modes: modes, gender: gender}
       end)
-      |> Enum.sort_by(&{member_sort_tier(&1.modes), &1.nick})
+      |> Enum.sort_by(&{member_sort_tier(&1.modes, sigils), &1.nick})
 
     # CP24 bucket E web/S8: mark channel as NAMES-seeded so
     # `list_members/3` discriminates `{:ok, :uninitialized}` (pre-NAMES)
@@ -5757,13 +5773,15 @@ defmodule Grappa.Session.Server do
   defp apply_effects([{:names_reply, channel, roster, reply_to} | rest], state) do
     # M2 — same gender merge as :members_seeded/list_members above: one
     # roster shape, one badge source, no parallel view left un-merged.
+    sigils = session_member_sigils(state)
+
     members =
       roster
       |> Enum.map(fn {nick, modes} ->
         gender = Map.get(state.peer_profile_cache, fold_key(state, nick), %{})[:gender]
         %{nick: nick, modes: modes, gender: gender}
       end)
-      |> Enum.sort_by(&{member_sort_tier(&1.modes), &1.nick})
+      |> Enum.sort_by(&{member_sort_tier(&1.modes, sigils), &1.nick})
 
     :ok =
       Broadcaster.to_requester(
@@ -7029,13 +7047,28 @@ defmodule Grappa.Session.Server do
     :ok = ChannelDirectory.ingest(state.subject, state.network_id, rows)
   end
 
-  # mIRC sort: ops (@) → voiced (+) → plain (no prefix). Within tier,
+  # mIRC sort: highest advertised grade first, plain last. Within tier,
   # alphabetical by nick (caller `Enum.sort_by` does the secondary).
-  defp member_sort_tier(modes) do
-    cond do
-      "@" in modes -> 0
-      "+" in modes -> 1
-      true -> 2
+  #
+  # issue 1999 — `sigils` is the network's advertised run, highest rank
+  # first (`ISupport.sigils/1`), and the tier is that run's INDEX. The
+  # hardcoded `cond` this replaces knew `@` and `+` only: it did not rank
+  # bahamut's own halfop (a `%` member sorted into the plain tier, which
+  # only ever looked right because cic re-sorts with a tier fn of its own),
+  # and on a PREFIX-rich network it dropped founder and admin to the BOTTOM
+  # of the pane — the exact inversion the issue reports as its third
+  # acceptance criterion.
+  #
+  # A sigil the network never advertised is not a grade: `Enum.find_index`
+  # misses and the member falls to the plain tier, the same posture
+  # `Identifier.member_prefix/2` takes for an unknown sigil. Plain sorts
+  # last by taking `length(sigils)`, which is one past every real index
+  # whatever the run's size.
+  @spec member_sort_tier([String.t()], [String.t()]) :: non_neg_integer()
+  defp member_sort_tier(modes, sigils) do
+    case Enum.find_index(sigils, &(&1 in modes)) do
+      nil -> length(sigils)
+      tier -> tier
     end
   end
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4225,7 +4225,7 @@ defmodule Grappa.Session.Server do
           kind: kind,
           sender: state.nick,
           body: fragment,
-          # #25: snapshot the operator's own channel-grade glyph (@/%/+)
+          # #25: snapshot the operator's own channel-grade glyph
           # so a later MODE change can't retroactively re-prefix their
           # own outbound lines. Mirror of EventRouter.put_sender_prefix
           # for the inbound side; nil → %{} for DM targets / plain grade.

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -925,22 +925,51 @@ defmodule Grappa.IRC.IdentifierTest do
     end
   end
 
-  describe "member_prefix/1 (#25 grade-snapshot helper)" do
+  describe "member_prefix/2 (#25 grade-snapshot helper)" do
+    # The precedence run is the CALLER's — `ISupport.sigils/1` on the server,
+    # which is `["@", "%", "+"]` on bahamut/Azzurra. Passed in rather than
+    # read here so `Identifier` stays a pure identifier module with no edge
+    # to the per-network capability table (issue 1999).
+    @bahamut ["@", "%", "+"]
+
     test "returns the highest-precedence sigil (@ > % > +)" do
-      assert Identifier.member_prefix(["@"]) == "@"
-      assert Identifier.member_prefix(["%"]) == "%"
-      assert Identifier.member_prefix(["+"]) == "+"
-      assert Identifier.member_prefix(["+", "@"]) == "@"
-      assert Identifier.member_prefix(["+", "%"]) == "%"
+      assert Identifier.member_prefix(["@"], @bahamut) == "@"
+      assert Identifier.member_prefix(["%"], @bahamut) == "%"
+      assert Identifier.member_prefix(["+"], @bahamut) == "+"
+      assert Identifier.member_prefix(["+", "@"], @bahamut) == "@"
+      assert Identifier.member_prefix(["+", "%"], @bahamut) == "%"
+    end
+
+    test "precedence follows the RUN it is given, not a hardcoded triple" do
+      # issue 1999 — this used to hold a module constant `["@", "%", "+"]`, so
+      # a founder's rows were snapshot with NO `meta.sender_prefix` at all
+      # (`Enum.find` over a run that does not contain `~` returns nil) and
+      # cic rendered them as a plain user's. Ranking must come from the
+      # network's own PREFIX order, the same source the MODE walkers read.
+      rich = ["~", "&", "@", "%", "+"]
+
+      assert Identifier.member_prefix(["~"], rich) == "~"
+      assert Identifier.member_prefix(["@", "~"], rich) == "~"
+      assert Identifier.member_prefix(["+", "&"], rich) == "&"
+      # Order is the RUN's, not the argument's: a founder listed after an op
+      # still outranks the op.
+      assert Identifier.member_prefix(["@", "&", "+"], rich) == "&"
+    end
+
+    test "a sigil the run does not carry is not a grade" do
+      # The inverse: on a `(ov)@+` network a stray `~` names no level cic
+      # could describe, so the row gets no snapshot rather than a glyph the
+      # network never advertised.
+      assert Identifier.member_prefix(["~"], ["@", "+"]) == nil
     end
 
     test "returns nil for a plain member (empty list)" do
-      assert Identifier.member_prefix([]) == nil
+      assert Identifier.member_prefix([], @bahamut) == nil
     end
 
     test "returns nil for non-list input" do
-      assert Identifier.member_prefix(nil) == nil
-      assert Identifier.member_prefix("@") == nil
+      assert Identifier.member_prefix(nil, @bahamut) == nil
+      assert Identifier.member_prefix("@", @bahamut) == nil
     end
   end
 

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -4048,7 +4048,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       # `:server 353 vjt = #italia :@op_user +voiced_user %halfop_user plain_user`
       # — UX-4 bucket J: halfop `%` prefix is now stripped via the same
-      # `split_mode_prefix/1` path as `@` and `+`.
+      # `split_mode_prefix/2` path as `@` and `+`.
       m =
         msg(
           {:numeric, 353},
@@ -4065,6 +4065,97 @@ defmodule Grappa.Session.EventRouterTest do
                "halfop_user" => ["%"],
                "plain_user" => []
              }
+    end
+
+    test "353 strips the sigils state.isupport PREFIX advertises, not a hardcoded @%+ triple" do
+      # issue 1999 (reported on #grappa by Kerd) — the bug this closes. The
+      # split knew `@ % +` only, so on a network advertising founder/admin a
+      # `~nick` token missed every clause and fell through UNCHANGED: the
+      # sigil stayed GLUED to the nick and became the members-map KEY. Every
+      # consumer downstream then addressed `~nick` — a nick that does not
+      # exist — so click-to-query opened a window nobody could write in.
+      #
+      # This is the same #216 posture the two MODE walkers already hold (see
+      # "membership modes come from state.isupport PREFIX" above): one 005,
+      # one table, no second hardcoded copy of it.
+      isupport =
+        ISupport.merge_isupport(
+          ["s", "PREFIX=(qaohv)~&@%+", "CHANMODES=beI,k,l,imnpst"],
+          ISupport.default()
+        )
+
+      state = base_state(%{members: %{"#italia" => %{"vjt" => []}}, isupport: isupport})
+
+      m =
+        msg(
+          {:numeric, 353},
+          ["vjt", "=", "#italia", "~founder &admin @op %halfop +voiced plain"],
+          {:server, "irc.example.net"}
+        )
+
+      assert {:cont, new_state, _} = EventRouter.route(m, state)
+
+      assert new_state.members["#italia"] == %{
+               "vjt" => [],
+               "founder" => ["~"],
+               "admin" => ["&"],
+               "op" => ["@"],
+               "halfop" => ["%"],
+               "voiced" => ["+"],
+               "plain" => []
+             }
+    end
+
+    test "353 leaves a sigil the network did NOT advertise glued, rather than guessing" do
+      # The inverse guard, and the reason this derives a SET instead of
+      # widening the hardcoded one to `~&@%+`: on a network whose PREFIX is
+      # `(ov)@+`, a leading `~` is not a membership sigil at all. Stripping it
+      # would invent a grade the ircd never granted and, worse, silently
+      # address a DIFFERENT nick. Unknown stays unknown — the same posture
+      # `membershipLevelName` takes client-side for an unadvertised sigil.
+      isupport =
+        ISupport.merge_isupport(["s", "PREFIX=(ov)@+"], ISupport.default())
+
+      state = base_state(%{members: %{"#italia" => %{"vjt" => []}}, isupport: isupport})
+
+      m =
+        msg(
+          {:numeric, 353},
+          ["vjt", "=", "#italia", "~weird @op"],
+          {:server, "irc.example.net"}
+        )
+
+      assert {:cont, new_state, _} = EventRouter.route(m, state)
+
+      assert new_state.members["#italia"] == %{
+               "vjt" => [],
+               "~weird" => [],
+               "op" => ["@"]
+             }
+    end
+
+    test "353 peels EVERY leading advertised sigil, not just the first" do
+      # `multi-prefix` is not in grappa's CAP REQ today, so upstream sends the
+      # single highest sigil and this run is length 1 in production. The split
+      # is greedy anyway so that its correctness does not depend on a CAP
+      # decision made in another module: a nick can never BEGIN with a sigil
+      # (RFC 2812 §2.3.1 `special` excludes `~ & @ % +`), so peeling the whole
+      # advertised run is unambiguous. If `multi-prefix` is ever requested,
+      # this path is already right instead of silently keying on `&nick`.
+      isupport =
+        ISupport.merge_isupport(["s", "PREFIX=(qaohv)~&@%+"], ISupport.default())
+
+      state = base_state(%{members: %{"#italia" => %{"vjt" => []}}, isupport: isupport})
+
+      m =
+        msg(
+          {:numeric, 353},
+          ["vjt", "=", "#italia", "~&@boss"],
+          {:server, "irc.example.net"}
+        )
+
+      assert {:cont, new_state, _} = EventRouter.route(m, state)
+      assert new_state.members["#italia"]["boss"] == ["~", "&", "@"]
     end
 
     test "353 against an UNTRACKED channel does NOT create a phantom members entry (CP22 B-names gate)" do
@@ -6725,6 +6816,42 @@ defmodule Grappa.Session.EventRouterTest do
       # Arrival-order, prefix-split {nick, modes} tuples. The mIRC-tier
       # sort happens in server.ex apply_effects, NOT here.
       assert roster == [{"alice", ["@"]}, {"bob", ["+"]}, {"carol", []}]
+    end
+
+    test "366 splits the drained roster on the ADVERTISED sigils too (issue 1999)" do
+      # The second `split_mode_prefix` call site, and it is a distinct door:
+      # the /names drain runs for a channel the operator need not be joined
+      # to, so it never passes through the state.members merge above. A fix
+      # applied to one door only would leave NamesModal addressing `~nick`
+      # while MembersPane addressed `nick` — two spellings of one person,
+      # from one 353.
+      isupport =
+        ISupport.merge_isupport(["s", "PREFIX=(qaohv)~&@%+"], ISupport.default())
+
+      state =
+        base_state(%{
+          members: %{},
+          isupport: isupport,
+          names_pending: %{
+            "#bofh" => %{
+              target_display: "#bofh",
+              names: ["~founder", "&admin", "@alice", "carol"]
+            }
+          }
+        })
+
+      m = msg({:numeric, 366}, ["vjt", "#bofh", "End of /NAMES list"], {:server, "irc.test.org"})
+
+      {:cont, _, effects} = EventRouter.route(m, state)
+
+      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", roster, nil}] = effects
+
+      assert roster == [
+               {"founder", ["~"]},
+               {"admin", ["&"]},
+               {"alice", ["@"]},
+               {"carol", []}
+             ]
     end
 
     test "366 produces the SAME names_reply whether or not the target is joined (uniform, #140)" do

--- a/test/grappa/session/isupport_test.exs
+++ b/test/grappa/session/isupport_test.exs
@@ -218,6 +218,53 @@ defmodule Grappa.Session.ISupportTest do
     end
   end
 
+  describe "sigils/1" do
+    test "pre-005 default is the bahamut/Azzurra sigil run, highest rank first" do
+      assert ISupport.sigils(ISupport.default()) == ["@", "%", "+"]
+    end
+
+    test "a PREFIX-rich network yields its whole sigil run in ADVERTISED order" do
+      # issue 1999 — the set every membership-sigil consumer must derive from,
+      # instead of the `@ % +` triple three call sites hardcoded. The order is
+      # `prefix_order`'s, i.e. the 005's, so index 0 is genuinely the top rank.
+      isupport =
+        ISupport.merge_isupport(["grappa-test", "PREFIX=(qaohv)~&@%+"], ISupport.default())
+
+      assert ISupport.sigils(isupport) == ["~", "&", "@", "%", "+"]
+    end
+
+    test "the run is NOT the map's value order" do
+      # The sibling guard to `prefix_order/1`'s own: `Map.values/1` on a small
+      # map comes back alphabetical BY LETTER, which on `(qaohv)` puts `o`
+      # (`@`) in the middle — the exact mis-rank #1302 fixed in `editorSigils`.
+      # Deriving the run from the map instead of the order would reintroduce it.
+      isupport =
+        ISupport.merge_isupport(["grappa-test", "PREFIX=(qaohv)~&@%+"], ISupport.default())
+
+      refute ISupport.sigils(isupport) == Map.values(isupport.prefix)
+    end
+
+    test "a table predating either field reads the defaults instead of raising" do
+      # Same hot-reload contract as `prefix_order/1` and `statusmsg/1`: a live
+      # Session.Server state seeded before these fields existed, read after the
+      # new module loads, must DEGRADE to bahamut rather than KeyError — and
+      # must not degrade to `[]`, which would disable sigil stripping entirely.
+      legacy = Map.drop(ISupport.default(), [:prefix_order, :prefix])
+
+      assert ISupport.sigils(legacy) == ["@", "%", "+"]
+    end
+
+    test "a letter with no sigil in the map is skipped, not rendered as nil" do
+      # The two projections come from one parse and cannot disagree today, but
+      # the accessor is total by construction rather than by that invariant:
+      # a half-written table drops the orphan letter instead of emitting a nil
+      # that would then be compared against a binary downstream.
+      orphan = %{ISupport.default() | prefix_order: ["o", "q", "v"]}
+
+      assert ISupport.sigils(orphan) == ["@", "+"]
+    end
+  end
+
   describe "takes_param?/3 type-C sign sensitivity" do
     test "type C consumes a param on + but not on -" do
       # l is the canonical type-C mode (+l 42 sets a limit; -l clears it

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -6848,6 +6848,61 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "a PREFIX-rich network: bare nicks, advertised sigils, founder above op (issue 1999)" do
+      # The end-to-end server assertion for issue 1999, across all three
+      # hardcoded sites at once, because they are only separable on paper:
+      #
+      #   1. `split_mode_prefix` — `~founder` must key as `founder`. This is
+      #      the reported defect: with the sigil glued on, click-to-query
+      #      addressed a nick that does not exist.
+      #   2. `ISupport.sigils/1` — the run comes from THIS network's 005.
+      #   3. `member_sort_tier` — rank is the advertised order, so founder
+      #      and admin sort ABOVE op. The old tier fn knew `@` and `+` only:
+      #      it did not even rank bahamut's own halfop, so `~`/`&` landed in
+      #      the plain tier at the BOTTOM of the pane.
+      handler = IRCServer.welcome_handler(":irc", "grappa-test")
+
+      {server, port} = IRCServer.start_server(handler)
+
+      {user, network, _} =
+        setup_user_and_network(port, %{autojoin_channels: ["#test"]})
+
+      pid = start_session_for(user, network)
+
+      :ok = IRCServer.await_handshake(server, 1_000)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      IRCServer.feed(
+        server,
+        ":irc 005 grappa-test PREFIX=(qaohv)~&@%+ :are supported by this server\r\n"
+      )
+
+      IRCServer.feed(server, ":grappa-test!u@h JOIN :#test\r\n")
+
+      IRCServer.feed(
+        server,
+        ":irc 353 grappa-test = #test :@op_a ~founder plain_a &admin %halfop +voice_a\r\n"
+      )
+
+      IRCServer.feed(server, ":irc 366 grappa-test #test :End\r\n")
+      IRCServer.feed(server, "PING :flush\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+      assert {:ok, members} = Session.list_members({:user, user.id}, network.id, "#test")
+
+      assert members == [
+               %{nick: "founder", modes: ["~"], gender: nil},
+               %{nick: "admin", modes: ["&"], gender: nil},
+               %{nick: "op_a", modes: ["@"], gender: nil},
+               %{nick: "halfop", modes: ["%"], gender: nil},
+               %{nick: "voice_a", modes: ["+"], gender: nil},
+               %{nick: "grappa-test", modes: [], gender: nil},
+               %{nick: "plain_a", modes: [], gender: nil}
+             ]
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "no session for (user, network) returns {:error, :no_session}" do
       assert {:error, :no_session} =
                Session.list_members({:user, Ecto.UUID.generate()}, 999_999_999, "#test")


### PR DESCRIPTION
The orchestrator owns the merge and the issue; this PR links neither.

Addresses the defect reported by Kerd on the #grappa channel, filed as issue 1999: on a
network whose PREFIX carries sigils beyond `@ % +`, clicking a nick in the
members pane opened a query against `~nick` — a nick that does not exist, so
the window could not be written in.

## What the issue got right, and what it missed

The named cause is real. `EventRouter.split_mode_prefix/1` matched a hardcoded
`?@ ?% ?+`, so a `~nick` token in 353 RPL_NAMREPLY missed every clause, fell
through the fallback unchanged, and the sigil became the `state.members` KEY.

Grepping the CLASS rather than the reported symptom found **six** copies of that
triple, three of them server-side and none named in the issue:

| site | consequence on a PREFIX-rich network |
|---|---|
| `EventRouter.split_mode_prefix/1` | the reported defect — sigil glued to the nick |
| `Identifier.member_prefix/1` | a founder's rows persisted with NO `meta.sender_prefix`, **permanently** (#25 snapshots at persist time and never recomputes) |
| `Session.Server.member_sort_tier/1` | founder/admin sorted to the BOTTOM — and it never ranked bahamut's OWN halfop, hidden only because cic re-sorts the pane |
| `memberSigil` / `members.tierRank` | no glyph, plain tier |
| `NamesModal` SECTIONS / `WhoModal` `Membership` / `MembersPane` `tierClass` | founder bucketed under "Users"; `H~` surfaced as an "unknown" WHO flag |
| `nickColor.snapshotSenderPrefix` | dropped a `~` the server had snapshot |

## The fix

One accessor per side — `ISupport.sigils/1` and cic's `sigilRank` — returning the
advertised run, highest rank first, composed from `prefix_order` + the lookup map.
Rank never comes from the map: `Map.values`/`Object.values` come back alphabetical
BY MODE LETTER, which on `(qaohv)` puts `o` in the MIDDLE — the mis-rank #1302
found in `editorSigils`.

Deriving the SET rather than widening the literal to `~&@%+` is what makes the
inverse safe: on a `(ov)@+` network a leading `~` is not a membership sigil, and
peeling it would silently address a DIFFERENT nick.

The peel is greedy on purpose. `multi-prefix` is not in grappa's CAP REQ, so the
run is length 1 in production — but a nick can never BEGIN with a sigil (RFC 2812
§2.3.1 `special` excludes every PREFIX char), so peeling the whole run costs
nothing and keeps this correct independently of a CAP decision made in
`IRC.AuthFsm`.

## No wire change — measured, not assumed

`mix grappa.wire_pin --check` → *"wire shape and protocol 14 agree"*;
`gen_wire_types --check` → in sync. The DOMAIN of `modes` widened, its SHAPE did
not, and `meta.sender_prefix` is `term()` in the typespec (a key NAME only in
`wireTypes.ts`). `modes` is already `string[]`, so an old bundle receiving `["~"]`
degrades — no glyph, plain tier — rather than rejecting. Recorded because #1393d
bumps on every shape change including additive ones, so "no bump" has to be an
answer somebody measured.

## Two limits, stated rather than papered over

**No colour for a new sigil.** The theme carries `--mode-op`, `--mode-halfop`,
`--mode-voiced` and nothing else, so `~`/`&` render bold on the inherited `--fg`
and land on `member-plain`. The glyph carries the grade and is now drawn at all,
which was the defect; a hue per sigil is a design decision every theme in
`themes/` would have to answer.

**The e2e cannot reach the reported case.** Measured on the live stack, not
guessed: the bahamut leaf answers `PREFIX=(ohv)@%+`, solanum answers
`PREFIX=(ov)@+`, and solanum's `reference.conf` carries no
`use_owner`/`use_admin`/`use_halfop` knob at all. So `~`/`&` are covered where they
CAN be measured — a `list_members` case driving a real `005 PREFIX=(qaohv)~&@%+`
through the fake ircd, plus cic unit cases seeding the same table. The e2e that
does exist guards the rewrite at the one door nothing else guarded (real ircd,
real 353, real render) and states its own limit in its header. It is green on the
base too, so it was **falsified**: with `member_sigils/1` stubbed to `[]` the run
goes rc=1 on the positive control, then green again once restored.

## Gates

* `scripts/check.sh` → **rc=0** — credo 0 issues, deps.audit clean, sobelow, doctor,
  **7193 tests / 0 failures**, wireTypes + wireSchema in sync, wire_pin agrees.
* `scripts/bun.sh run check` → **rc=0** (5 stages, 0 failed).
* `scripts/bun.sh run test` → **rc=0** — 341 files, **6865 tests, 0 failures**.
* `scripts/integration.sh` (FULL) → 952 passed, 1 skipped, **3 failed**, and all
  three are attributed:
  * `cp15-b6-part-archive-rejoin` — **green in iso-rerun** (cascade).
  * `ux-z-cluster-journey` (webkit-iphone-15) — **green in iso-rerun** (cascade).
  * `issue1964-upload-confirm-preview:97` — **red on bare `origin/main`
    (b3a9178f4) too**, byte-identical assertion (`MediaError` code 4 vs expected
    0, a `<video>` blob preview). Measured in a throwaway detached worktree at
    the base, which was then removed. Not from this branch; topically and
    file-wise disjoint from it.

A follow-up worth its own issue: the two `MembersPane` cases that broke asserted a
STATE with `mockReturnValueOnce`, which pins a CALL INDEX — they failed while the
production behaviour was intact. Cured in the setup here, but the pattern is
likely elsewhere in the suite.
