### PR TITLE
fix(app): give the root supervisor a restart budget it can defend

### DIFF
--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -471,9 +471,7 @@ defmodule Grappa.Application do
           # on :start_bootstrap so test boots empty.
         ] ++ bootstrap_child()
 
-    opts = [strategy: :one_for_one, name: Grappa.Supervisor]
-
-    case Supervisor.start_link(children, opts) do
+    case Supervisor.start_link(children, root_supervisor_opts()) do
       {:ok, _} = result ->
         # H26 (review 2026-05-22): flip the substrate-readiness flag
         # so `/healthz` returns 200 (vs the default 503-on-not-ready).
@@ -519,6 +517,71 @@ defmodule Grappa.Application do
       other ->
         other
     end
+  end
+
+  # max_restarts: 60, max_seconds: 60 — the ROOT supervisor ran on OTP's
+  # DEFAULT 3-in-5s until 2026-09-08, which is a default and never was a
+  # decision: `SessionSupervisor` twenty lines up carries an argued
+  # 10_000/60, so the silence here read as "considered" when it was
+  # "never considered".
+  #
+  # 🔴 Measured on the m42 jail, two node deaths inside half an hour:
+  #
+  #   20:36:31.150–.472    4 children in   322 ms  (Visitors/Uploads/Avatars
+  #                                                 Reaper + AdminEvents)
+  #   21:06:38.979–40.053  5 children in 1_070 ms  (of which Bootstrap x3)
+  #
+  # Neither burst is N independent faults. It is ONE correlated degradation
+  # — the SQLite pool saturating — arriving at every Repo-reading singleton
+  # at once, and three of those inside 5s is the whole budget. The tree has
+  # ~31 top-level children and most of them touch the Repo, so the default
+  # made "the DB is briefly busy" and "kill the node" the same event.
+  #
+  # Where the two numbers come from:
+  #
+  #   max_seconds: 60 — twice `busy_timeout` (30_000, every env), i.e. the
+  #     window has to be able to CONTAIN one saturation episode. A window
+  #     shorter than the stall splits one degradation across two budgets and
+  #     measures nothing.
+  #   max_restarts: 60 — ~2 full sweeps of the ~31-child tree: every
+  #     top-level singleton may die TWICE inside one degradation and the node
+  #     lives. The measured peak is 5, so this clears it 12x over.
+  #
+  # Deliberately NOT the sibling's 10_000/60. Under `SessionSupervisor` the
+  # children are homogeneous, ephemeral, and restarting IS the recovery
+  # mechanism (upstream reconnect), so a huge budget buys tolerance for the
+  # normal case. Here the children are heterogeneous infrastructure
+  # singletons and a restart is an ANOMALY. 10_000/60 is ~167 restarts/s
+  # sustained: it would make the root effectively immortal and delete the
+  # signal this supervisor exists to produce.
+  #
+  # What must STILL kill the node, on purpose: a non-transient fault — an
+  # Endpoint that cannot bind, a Vault with the wrong key, a Repo that
+  # cannot open the file, or any child in a tight crash-loop. 60-in-60 is
+  # 1 restart/s sustained, so a tight loop trips it in well under a minute
+  # and the node exits where rc.d can see it. A node that restart-loops
+  # forever while looking alive is strictly WORSE for an operator than one
+  # that dies.
+  #
+  # ⚠️ What this does NOT cure, stated so nobody reads it as fixed: death 2
+  # above. `Grappa.Bootstrap` is `use Task, restart: :transient` and re-runs
+  # its credential READ on every restart, so it re-enters the saturated pool
+  # immediately — measured at ~2.8 restarts/s, which exhausts 60-in-60 in
+  # ~21s, well inside a 31s stall. That is a child that does not degrade,
+  # not a budget that is too small, and raising the budget to cover it would
+  # be buying the immortality rejected two paragraphs up. The cure is the
+  # `{:error, :db_unavailable}` verb already used in 45 files under `lib/`
+  # (`Accounts.Reaper` is the in-house model: "sweep dropped, retrying next
+  # tick"), and it is a SEPARATE slice.
+  @doc """
+  Options for the ROOT supervisor (`Grappa.Supervisor`).
+
+  Public so the restart budget is testable against the running shape rather
+  than restated in a test — see `test/grappa/application_root_supervisor_limits_test.exs`.
+  """
+  @spec root_supervisor_opts() :: [Supervisor.option()]
+  def root_supervisor_opts do
+    [strategy: :one_for_one, name: Grappa.Supervisor, max_restarts: 60, max_seconds: 60]
   end
 
   # Bootstrap is opt-in via the `:start_bootstrap` flag (true in dev/prod,

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -519,7 +519,7 @@ defmodule Grappa.Application do
     end
   end
 
-  # max_restarts: 60, max_seconds: 60 — the ROOT supervisor ran on OTP's
+  # max_restarts: 80, max_seconds: 120 — the ROOT supervisor ran on OTP's
   # DEFAULT 3-in-5s until 2026-09-08, which is a default and never was a
   # decision: `SessionSupervisor` twenty lines up carries an argued
   # 10_000/60, so the silence here read as "considered" when it was
@@ -537,15 +537,37 @@ defmodule Grappa.Application do
   # ~31 top-level children and most of them touch the Repo, so the default
   # made "the DB is briefly busy" and "kill the node" the same event.
   #
-  # Where the two numbers come from:
+  # Where the two numbers come from — anchored to MEASURED HOLD DURATIONS,
+  # deliberately not to `busy_timeout`:
   #
-  #   max_seconds: 60 — twice `busy_timeout` (30_000, every env), i.e. the
-  #     window has to be able to CONTAIN one saturation episode. A window
-  #     shorter than the stall splits one degradation across two budgets and
-  #     measures nothing.
-  #   max_restarts: 60 — ~2 full sweeps of the ~31-child tree: every
-  #     top-level singleton may die TWICE inside one degradation and the node
-  #     lives. The measured peak is 5, so this clears it 12x over.
+  #   max_seconds: 120 — the window must be able to CONTAIN one saturation
+  #     episode, because a window shorter than the episode counts a
+  #     fragment: the budget then means "restarts per arbitrary slice"
+  #     rather than "restarts per degradation". The 29 stalls logged on
+  #     2026-09-08 fall in three tight clusters — 22 at 31_060–31_457 ms,
+  #     6 at 62_604–62_810 ms, 1 at 94_055 ms — i.e. ratios 1:2:3 off a
+  #     ~31 s unit, so the long ones are two and three units back to back.
+  #     120 s contains the 94 s worst case with margin.
+  #   max_restarts: 80 — worst legitimate case is every top-level child
+  #     dying once per tick for the whole window: the periodic children run
+  #     a 60 s cadence (`reaper_interval_ms/0`) and `init/1` re-arms the
+  #     timer rather than re-querying, so a 120 s window gives each of the
+  #     ~31 children TWO chances to die: ~62. The budget must sit ABOVE
+  #     that, and 80 leaves room for roughly nine more children before the
+  #     derivation needs revisiting. The measured burst peak is 5, so this
+  #     clears it 16x over.
+  #
+  # 🔴 Why NOT `busy_timeout`, which an earlier draft of this comment used:
+  # `busy_timeout` bounds how long a WAITER blocks before giving up. What
+  # this window has to span is the HOLD — how long the winner keeps
+  # RESERVED — and the two are causally unrelated. `LockWatch`'s
+  # `acquired/0` is the first statement inside the transaction fun, which
+  # `DBConnection` only reaches after `BEGIN IMMEDIATE` returns `{:ok, _}`,
+  # so the logged `held_ms` is possession and never queueing. That the two
+  # numbers resembled each other (30 s vs 31 s) was coincidence, and it is
+  # about to stop being one: `busy_timeout` is moving to ~300 ms, under
+  # which the old formula would have produced `max_seconds: 0.6` — which is
+  # the clearest possible proof the relation was never there.
   #
   # Deliberately NOT the sibling's 10_000/60. Under `SessionSupervisor` the
   # children are homogeneous, ephemeral, and restarting IS the recovery
@@ -557,8 +579,8 @@ defmodule Grappa.Application do
   #
   # What must STILL kill the node, on purpose: a non-transient fault — an
   # Endpoint that cannot bind, a Vault with the wrong key, a Repo that
-  # cannot open the file, or any child in a tight crash-loop. 60-in-60 is
-  # 1 restart/s sustained, so a tight loop trips it in well under a minute
+  # cannot open the file, or any child in a tight crash-loop. A tight loop
+  # spends the budget at its own rate, not the window's, so it still trips
   # and the node exits where rc.d can see it. A node that restart-loops
   # forever while looking alive is strictly WORSE for an operator than one
   # that dies.
@@ -566,9 +588,9 @@ defmodule Grappa.Application do
   # ⚠️ What this does NOT cure, stated so nobody reads it as fixed: death 2
   # above. `Grappa.Bootstrap` is `use Task, restart: :transient` and re-runs
   # its credential READ on every restart, so it re-enters the saturated pool
-  # immediately — measured at ~2.8 restarts/s, which exhausts 60-in-60 in
-  # ~21s, well inside a 31s stall. That is a child that does not degrade,
-  # not a budget that is too small, and raising the budget to cover it would
+  # immediately — measured at ~2.8 restarts/s, which exhausts 80 restarts in
+  # ~29s, well inside the 31s hold that causes it. That is a child that does
+  # not degrade, not a budget that is too small, and raising it to cover this would
   # be buying the immortality rejected two paragraphs up. The cure is the
   # `{:error, :db_unavailable}` verb already used in 45 files under `lib/`
   # (`Accounts.Reaper` is the in-house model: "sweep dropped, retrying next
@@ -581,7 +603,7 @@ defmodule Grappa.Application do
   """
   @spec root_supervisor_opts() :: [Supervisor.option()]
   def root_supervisor_opts do
-    [strategy: :one_for_one, name: Grappa.Supervisor, max_restarts: 60, max_seconds: 60]
+    [strategy: :one_for_one, name: Grappa.Supervisor, max_restarts: 80, max_seconds: 120]
   end
 
   # Bootstrap is opt-in via the `:start_bootstrap` flag (true in dev/prod,

--- a/test/grappa/application_root_supervisor_limits_test.exs
+++ b/test/grappa/application_root_supervisor_limits_test.exs
@@ -1,0 +1,169 @@
+defmodule Grappa.ApplicationRootSupervisorLimitsTest do
+  # The root supervisor's restart budget, pinned from BOTH sides.
+  #
+  # `Grappa.Supervisor` used to start with no `max_restarts`/`max_seconds`,
+  # i.e. OTP's default 3-in-5s — a default, never a decision. The sibling
+  # `SessionSupervisor` two lines above carries an argued 10_000/60, so the
+  # absence here read as "considered and left alone" when it was
+  # "never considered".
+  #
+  # Measured on the m42 jail, 2026-09-08, two node deaths in half an hour:
+  #
+  #   20:36:31.150–.472   4 top-level children in   322 ms  (three Reapers + AdminEvents)
+  #   21:06:38.979–40.053 5 top-level children in 1_070 ms  (of which Bootstrap x3)
+  #
+  # Both bursts are ONE correlated degradation — the SQLite pool saturating —
+  # arriving at several Repo-reading singletons at once. Three of them inside
+  # 5s is enough to take the node down, and that is what happened.
+  #
+  # The two tests below are a PAIR and neither is redundant:
+  #
+  #   1. the budget must ABSORB a correlated burst — else the fix cures nothing;
+  #   2. the budget must still GIVE UP — else the fix trades a node that dies
+  #      loudly for a node that restart-loops forever while looking alive,
+  #      which is strictly worse for an operator (rc.d sees a live service).
+  #
+  # Test 2 is the one that stops a future "just raise it to 10_000" from
+  # sailing through green: copying the SessionSupervisor's budget here would
+  # make the root effectively immortal (~167 restarts/s sustained).
+  use ExUnit.Case, async: true
+
+  # The measured worst correlated burst (5 children in 1.07s). The budget has
+  # to sit ABOVE this or it does not cure the incident it was written for.
+  @measured_correlated_burst 5
+
+  # A restart takes microseconds here, so a burst is delivered well inside any
+  # sane `max_seconds`; the deadline only guards against a wedged supervisor.
+  @await_ms 2_000
+
+  describe "the root supervisor's restart budget" do
+    test "declares an explicit budget rather than inheriting OTP's 3-in-5s default" do
+      opts = Grappa.Application.root_supervisor_opts()
+
+      assert Keyword.fetch!(opts, :strategy) == :one_for_one
+
+      assert is_integer(Keyword.get(opts, :max_restarts)),
+             "the root supervisor must state its restart budget: an absent max_restarts " <>
+               "silently means 3-in-5s, which a correlated degradation clears trivially"
+
+      assert is_integer(Keyword.get(opts, :max_seconds))
+    end
+
+    test "absorbs the measured correlated burst of #{@measured_correlated_burst} child deaths" do
+      Process.flag(:trap_exit, true)
+      sup = start_probe_supervisor(@measured_correlated_burst)
+
+      for id <- 1..@measured_correlated_burst do
+        kill_and_await_restart(sup, id)
+      end
+
+      assert Process.alive?(sup),
+             "the root supervisor gave up after #{@measured_correlated_burst} correlated " <>
+               "child deaths — this is the 2026-09-08 node death, unfixed"
+
+      assert length(Supervisor.which_children(sup)) == @measured_correlated_burst
+    end
+
+    test "still gives up on a child that exceeds the budget, so a wedged node dies loudly" do
+      Process.flag(:trap_exit, true)
+      budget = Keyword.fetch!(Grappa.Application.root_supervisor_opts(), :max_restarts)
+
+      sup = start_probe_supervisor(1)
+      ref = Process.monitor(sup)
+
+      # One child, killed until the supervisor gives up: the shape of a
+      # genuine crash-loop (bad config, unbindable port, a boot read that
+      # cannot succeed), not of a transient degradation. Each kill WAITS for
+      # the restart, so the kills and the restarts are one-to-one — killing
+      # a pid the supervisor has not replaced yet costs no budget at all.
+      kills = kill_until_supervisor_gives_up(sup, 1, budget + 1)
+
+      assert_receive {:DOWN, ^ref, :process, ^sup, _reason},
+                     @await_ms,
+                     "the root supervisor absorbed #{kills} restarts of a single child: " <>
+                       "the budget is no longer a protection, it is an infinite loop"
+    end
+  end
+
+  # --- probe supervisor -------------------------------------------------
+  #
+  # Runs the PRODUCTION opts (only the registered name is swapped, so the
+  # probe cannot collide with the real tree) over trivial children. What is
+  # under test is the budget, not the children.
+
+  defp start_probe_supervisor(child_count) do
+    probe_name = :"#{__MODULE__}.Probe.#{System.unique_integer([:positive])}"
+    opts = Keyword.replace!(Grappa.Application.root_supervisor_opts(), :name, probe_name)
+
+    children =
+      for id <- 1..child_count do
+        Supervisor.child_spec({Agent, fn -> id end}, id: id)
+      end
+
+    # Linked to the test process, so it dies with the test — no on_exit stop,
+    # which would race that same teardown and exit `:shutdown`.
+    {:ok, sup} = Supervisor.start_link(children, opts)
+    sup
+  end
+
+  defp kill_and_await_restart(sup, id) do
+    case kill_and_settle(sup, id) do
+      {:restarted, pid} -> pid
+      :supervisor_gave_up -> flunk("supervisor died while awaiting the restart of child #{id}")
+      :timeout -> flunk("child #{id} was not restarted within #{@await_ms}ms")
+    end
+  end
+
+  defp kill_until_supervisor_gives_up(sup, id, max_kills) do
+    Enum.reduce_while(1..max_kills, 0, fn n, _ ->
+      case kill_and_settle(sup, id) do
+        {:restarted, _} -> {:cont, n}
+        :supervisor_gave_up -> {:halt, n}
+        :timeout -> {:halt, n}
+      end
+    end)
+  end
+
+  # Kills the child and returns only once the supervisor has SETTLED: either
+  # it replaced the child (one restart spent) or it exhausted its budget.
+  defp kill_and_settle(sup, id) do
+    case child_pid(sup, id) do
+      old when is_pid(old) ->
+        Process.exit(old, :kill)
+        await_settle(sup, id, old, System.monotonic_time(:millisecond) + @await_ms)
+
+      _ ->
+        :supervisor_gave_up
+    end
+  end
+
+  defp await_settle(sup, id, old, deadline) do
+    cond do
+      not Process.alive?(sup) ->
+        :supervisor_gave_up
+
+      System.monotonic_time(:millisecond) > deadline ->
+        :timeout
+
+      true ->
+        case child_pid(sup, id) do
+          pid when is_pid(pid) and pid != old -> {:restarted, pid}
+          _ -> await_settle(sup, id, old, deadline)
+        end
+    end
+  end
+
+  defp child_pid(sup, id) do
+    sup
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn
+      {^id, pid, _, _} -> pid
+      _ -> nil
+    end)
+  rescue
+    # `which_children` on a supervisor that just exited.
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+end


### PR DESCRIPTION
## Provenance

Authorization **relayed via the ircbot, not seen by me in person**: vjt gave the go-ahead on
`#grappa` at 22:01 Europe/Rome with three lines — "si vai", "fixa il supervisor tree config", "e
prendi i dati che servono". Recording it in this shape deliberately: if the relay is crooked it
surfaces in review and costs a line, not a round trip.

The evidence behind the numbers comes from an architecture review of tonight's two node deaths on
the m42 jail. That review is **not published here** — it contains a DoS recipe and this repo is
public. It is with the orchestrator.

## What this changes

One thing: `Grappa.Supervisor` — the **root** supervisor — started with no `max_restarts` /
`max_seconds`, i.e. OTP's default **3-in-5s**. It now declares **80 restarts in 120 s**.

The default was never a decision. `SessionSupervisor`, twenty lines above in the same list,
carries an argued `10_000 / 60` with a why-comment; the silence at the root read as "considered
and left alone" when it was "never considered".

## Why it matters — measured, m42 jail, 2026-09-08

Two node deaths inside half an hour:

| death | window | top-level children lost |
|---|---|---|
| 1 | `20:36:31.150 – .472` | **4 in 322 ms** — Visitors / Uploads / Avatars Reaper + AdminEvents |
| 2 | `21:06:38.979 – 21:06:40.053` | **5 in 1 070 ms** — of which `Bootstrap` ×3 |

Neither burst is N independent faults. It is **one** correlated degradation — the SQLite pool
saturating — arriving at every Repo-reading singleton at once. The tree has ~31 top-level children
and most of them touch the Repo, so under the default "the DB is briefly busy" and "kill the node"
were the same event. Node down at `20:36:34.990` and `21:07:21.759`.

## The two numbers, derived (not copied) — anchored to measured HOLDS

Against the two questions that decide them:

**1. How many top-level children can legitimately die together in a transient degradation?**
Measured burst peak is 5. The worst *legitimate* case is larger: every periodic child dying once
per tick for the whole window. The periodic children run a 60 s cadence and `init/1` re-arms the
timer rather than re-querying, so a 120 s window gives each of the ~31 children **two** chances to
die: **~62**. The budget must sit above that — **`max_restarts: 80`**, which leaves room for
roughly nine more children before the derivation needs revisiting, and clears the measured peak
16×.

**`max_seconds: 120`** because the window must be able to **contain one saturation episode**: a
window shorter than the episode counts a *fragment*, and the budget then means "restarts per
arbitrary slice" rather than "restarts per degradation". The 29 stalls logged 2026-09-08 fall in
three tight clusters — **22 at 31 060–31 457 ms, 6 at 62 604–62 810 ms, 1 at 94 055 ms** — i.e.
ratios 1:2:3 off a ~31 s unit, so the long ones are two and three units back to back. 120 s
contains the 94 s worst case with margin.

🔴 **An earlier revision of this PR anchored `max_seconds` to `2× busy_timeout`. That was wrong
twice, and the second reason is the one that matters.** The shallow one: `busy_timeout` is moving
to ~300 ms, so the comment would have gone stale under a slice already in flight. The load-bearing
one: **it was anchored to the wrong quantity.** `busy_timeout` bounds how long a **waiter** blocks
before giving up; what this window must span is the **hold** — how long the winner keeps
`RESERVED` — and the two are causally unrelated. `LockWatch`'s `acquired/0` is the first statement
inside the transaction fun, which `DBConnection` only reaches after `BEGIN IMMEDIATE` returns
`{:ok, _}` (read in the deps, documented at `lock_watch.ex:40`), so the logged `held_ms` is
**possession, never queueing**. The two numbers resembling each other (30 s vs 31 s) was
coincidence — and under the incoming 300 ms the old formula would have produced
`max_seconds: 0.6`, which is the clearest possible proof the relation was never there.

**2. What must this stop protecting — i.e. what should still kill the node?**
A **non-transient** fault: an Endpoint that cannot bind, a Vault with the wrong key, a Repo that
cannot open the file, or any child in a tight crash-loop. A tight loop spends the budget at **its
own rate, not the window's**, so it still trips: `Bootstrap`'s measured ~2.8 restarts/s spends 80
in ~29 s, inside the very 31 s hold that causes it. **A node that restart-loops forever while
looking alive is strictly worse for an operator than one that dies.**

**Why NOT the sibling's `10_000/60`, asked explicitly.** Under `SessionSupervisor` the children are
homogeneous, ephemeral, and restarting *is* the recovery mechanism (upstream reconnect) — a huge
budget buys tolerance for the normal case. At the root the children are heterogeneous
infrastructure singletons and a restart is an **anomaly**. `10_000/60` is ~167 restarts/s
sustained: it would make the root effectively immortal and delete the signal this supervisor
exists to produce. Copying it for symmetry would have been the wrong move.

## Scope calls, declared rather than left implicit

**`Bootstrap` is NOT in this slice, and this fix does not cure death 2.** Stating it plainly so
nobody reads the incident as closed. `Grappa.Bootstrap` is `use Task, restart: :transient` and
re-runs its credential READ on every restart, so it re-enters the saturated pool immediately —
measured at ~2.8 restarts/s, which exhausts the 80-restart budget in ~29 s, well inside the 31 s
hold that causes it. That is a
child that does not degrade, **not a budget that is too small**, and raising the budget to cover
it would buy exactly the immortality rejected above. It is a separate slice because it is a design
decision (what should boot do when the credential read cannot succeed — retry with backoff? start
web-only? the log-honesty rule bites here), not a config change.

**`Accounts.Reaper` is the in-house model, and it beats the supervisor as a cure.** It degrades
correctly today — `Accounts.delete_expired_sessions/0` returns `{:error, :db_unavailable}` and the
reaper logs *"sweep dropped, retrying next tick"* and carries on. That verb already exists in **45
files** under `lib/`. So, contradicting the framing I was given: the root cause of death 1 is
**children that crash on an expected, recurring condition**, and the durable cure is to make the
other three reapers degrade the same way. This PR is still worth landing on its own terms — the
root supervisor's budget is a structural fragility independent of who trips it, and 3-in-5s at the
root of a ~31-child tree is indefensible regardless — but it is the *consequence* half, not the
*cause* half.

## TDD — the red, then the green

Red first, before the fix (with the seam in place returning today's option list):

```
1) test ... absorbs the measured correlated burst of 5 child deaths
   supervisor died while awaiting the restart of child 4
2) test ... still gives up on a child that exceeds the budget
   ** (KeyError) key :max_restarts not found in:
       [strategy: :one_for_one, name: Grappa.Supervisor]
3) test ... declares an explicit budget rather than inheriting OTP's 3-in-5s default
   the root supervisor must state its restart budget: an absent max_restarts silently
   means 3-in-5s, which a correlated degradation clears trivially

3 tests, 3 failures
```

**"supervisor died while awaiting the restart of child 4"** is the production death reproduced in
vitro: the fourth restart inside 5 s is the whole default budget.

Green after:

```
3 tests, 0 failures
```

The two behavioural tests are a **pair** and neither is redundant: one asserts the budget
**absorbs** a correlated burst (else the fix cures nothing), the other asserts it still **gives
up** (else the fix trades a node that dies loudly for one that loops forever). The second is what
stops a future "just raise it to 10_000" from sailing through green.

The test reads the budget from `Grappa.Application.root_supervisor_opts/0` — the production
options, only the registered name swapped — rather than restating the numbers, so the two cannot
drift apart.

## Gates

`scripts/check.sh` green (format + credo strict + dialyzer + sobelow + full suite). Two files
touched: `lib/grappa/application.ex`, `test/grappa/application_root_supervisor_limits_test.exs`.

## What I refuse to assert

- That this fixes tonight's outage. It fixes **death 1** and the general class; death 2 needs the
  `Bootstrap` slice above.
- That 80/120 is optimal. It is *derived* — a window that contains the longest measured hold,
  a budget above the worst legitimate case inside it — and
  the derivation is in the code comment so the next person can argue with the reasoning rather
  than guess at the number.
- Anything about *why* the SQLite holder sits in `RESERVED` for 31 s. Out of scope here.
