### PR TITLE
docs: correct CLAUDE.md's runtime-mode claim and withdraw its census

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -713,31 +713,59 @@ not the surrounding code.**
   is exactly what the silent regime produces.
 - **🔴 A dirty NIF parked on a SQLite write-lock wait blocks every
   `persistent_term` write and every module load in the VM, for the whole
-  wait (#1715).** The window is `busy_timeout` (`30_000` in every env
-  today) — the 133 s seen in `lock_watch_test` is that file's own
+  wait (#1715).** The window is `busy_timeout` — **per-env, and
+  `config/runtime.exs` is the SSOT: do not restate the value here, it
+  moves** — while the 133 s seen in `lock_watch_test` is that file's own
   `@waiter_budget_ms`, **never** a production number, and quoting it as
-  one is the mistake this line exists to stop. **What blocks:** *every*
+  one is the mistake this line exists to stop. For the field scale, cite
+  a DATED measurement instead of a live knob: the 29 holds logged on
+  2026-09-08 ran 31.1–94.1 s. **What blocks:** *every*
   `persistent_term:put/2` and `erase/1` — **word-sized ones too**, which
   trigger no global GC of their own but queue behind somebody else's, and
   the shipped docs do not lead you to expect that; *every* **module's
   first log line** (`logger_config:allow/2:67` **is** a put); and *every*
   **module load** — that is, every module **not yet loaded**, since an
   already-loaded one short-circuits in `code:ensure_loaded/1` and never
-  reaches the code server. ⚠️ **That is not a small set on a warm node:**
-  measured on a booted node, 2464 of 3063 modules are still cold (80 %),
-  265 of `Grappa.*` alone, because the release runs `:interactive` and its
-  `vm.args` sets no `-mode`. **The rule: a module that may log DURING a
-  write-lock wait buys its Logger cache key at boot**
-  (`LockWatch.prime_logger_module_cache/0`, #1731) — the observer whose
-  job is to report the wait is otherwise its own casualty. **Name the
+  reaches the code server.
+  **⚠️ The module-load leg does NOT reach the release, and a retracted
+  number used to say it did (#2003).** This paragraph claimed *"2464 of
+  3063 modules are still cold (80 %), 265 of `Grappa.*` alone, because
+  the release runs `:interactive` and its `vm.args` sets no `-mode`"*.
+  **The release runs `-mode embedded`** — read on the live node
+  (`RELEASE_MODE=embedded` in pid 45683's environment, `procstat -e`) and
+  derivable entirely off-prod: the repo ships no `rel/`, so the generated
+  `bin/grappa` supplies the flag from its OWN default
+  (`RELEASE_MODE="${RELEASE_MODE:-"embedded"}"`, line 31) and
+  `RELEASE_MODE` appears **0 times** anywhere in the repo. The `vm.args`
+  half was true; the conclusion drawn from it was not, because the flag
+  comes from the start script and not from the args file.
+  🔴 **The census is DELETED, not re-measured**, on three grounds: nobody
+  recorded which node produced it (an unsourced number gets cited as
+  measured by the next reader); it cannot describe this substrate
+  (`releases/<vsn>/start.script` carries **317** `Elixir.Grappa*` modules
+  inside `primLoad`, all loaded at boot under embedded); and a *correct*
+  re-measurement would still be the WRONG EVIDENCE for the rule it was
+  supporting — module residency and Logger-cache residency are different
+  axes. **A rule may not cite a number that does not measure it.**
+  **🔴 The rule STANDS, on the other leg, and never depended on `-mode`:
+  a module that may log DURING a write-lock wait buys its Logger cache
+  key at boot** (`LockWatch.prime_logger_module_cache/0`, #1731) — the
+  observer whose job is to report the wait is otherwise its own
+  casualty. Embedded mode loads CODE; it does not populate Logger's
+  per-module cache, so a preloaded module that has never logged still
+  owes its `persistent_term:put` on its first line. That leg holds on
+  every substrate. The module-load leg is live only where the node really
+  is interactive — docker/dev's `mix phx.server`, `iex -S mix` — which is
+  also the likeliest provenance of the deleted census. **Name the
   observers; never blanket-prime.** Not for cost — blanket priming
   measures sub-millisecond, five orders below the bug — but for **scope**:
   the modules that must log under contention are enumerable (they live
-  around the Repo), and 265 primed cold modules is unfalsifiable
+  around the Repo), and priming the whole tree is unfalsifiable
   maintenance that will drift (design-discipline (1) and (5)). The
   mechanism is measured in the field and **never reproduced on a bench**;
   its final causal link is **inferred**, not measured. Measurements, the
-  2×2×2 and the three retractions: DESIGN_NOTES 2026-08-24.
+  2×2×2 and the three retractions: DESIGN_NOTES 2026-08-24; the embedded
+  correction and the census retraction: DESIGN_NOTES 2026-09-08.
 - **Sandbox per test (`async: true`).** Never share sandbox across
   tests. `use Grappa.DataCase, async: true`.
 - **PubSub topic naming: `grappa:` prefix mandatory.** Topics are

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49101,3 +49101,96 @@ assert.
 _Deploy: **COLD** — server modules changed (`ISupport`, `EventRouter`,
 `Identifier`, `Session.Server`) plus the cic bundle. No wire change, no
 protocol bump._
+<!-- entry #2003 -->
+
+---
+
+## 2026-09-08 — #2003: `CLAUDE.md` said `:interactive`; the release runs `-mode embedded`, and the number that backed it is withdrawn
+
+`CLAUDE.md`'s #1715 paragraph carried four claims about the runtime it
+describes. One was false, one was unsourced, one is about to go stale under a
+slice in flight, and the rule they all propped up turns out not to have needed
+any of them.
+
+### The false one: the release is not interactive
+
+The paragraph read *"the release runs `:interactive` and its `vm.args` sets no
+`-mode`"*. The second half is true and the first does not follow from it — the
+flag is supplied by the START SCRIPT, not by the args file.
+
+Measured twice, independently:
+
+* **On the live node.** `RELEASE_MODE=embedded` read out of pid 45683's
+  *environment* with `procstat -e` (jail `grappa-new`, release 1.5.3). The
+  explicit variable, not a glance at a command line.
+* **Off-prod, from the build artefacts.** The repo ships no `rel/`, so
+  `mix release` writes Elixir's stock template, whose `vm.args` sets no `-mode`
+  and says so in a comment. The generated `bin/grappa` then supplies it with a
+  **default of its own**: `RELEASE_MODE="${RELEASE_MODE:-"embedded"}"` (line
+  31), passed as `--erl "-mode $RELEASE_MODE"` (line 85) from the shell
+  function that both `start` and `daemon` call. `RELEASE_MODE` appears **0
+  times** in the whole repo (positive control: the same grep recipe hits
+  `RELEASE_COOKIE` in 36 files), and `infra/freebsd/rc.d/grappa` reaches the
+  release through one door — `grappa_runas "daemon"` — exporting `RELEASE_TMP`,
+  `LANG`, `RUN_ERL_LOG_*` and `PATH`, and no `RELEASE_MODE`.
+
+So embedded is nobody's choice: it is the Elixir release default and the repo
+has never overridden it. Residual gap, named rather than papered over: `su -m`
+preserves the invoking environment, so a `RELEASE_MODE` exported outside the
+repo could override it — which the `procstat -e` reading rules out for the
+running node.
+
+### The unsourced one: the cold-module census is deleted, not re-measured
+
+*"2464 of 3063 modules are still cold (80 %), 265 of `Grappa.*` alone"* had no
+recorded provenance. It is removed rather than re-taken, on three grounds, and
+the third is the one that generalises:
+
+1. **Nobody recorded which node it came from.** An unsourced number is cited as
+   measured by the next reader; that is how it survived this long.
+2. **It cannot describe this substrate.** `releases/<vsn>/start.script` carries
+   **317** distinct `Elixir.Grappa*` modules among 1372 total, all inside
+   `primLoad` directives, and embedded mode loads exactly that set at boot. The
+   census was therefore almost certainly taken on a NON-release node — docker's
+   `mix phx.server` or an `iex -S mix`, where interactive genuinely is the mode.
+3. 🔴 **A correct re-measurement would still be the wrong evidence.** The number
+   counts MODULE RESIDENCY. The rule it was supporting depends on LOGGER-CACHE
+   residency. Those are different axes, and no value of the first is evidence
+   for the second. **A rule may not cite a number that does not measure it** —
+   that is the transferable lesson, and it is why re-measuring was declined even
+   though the measurement is cheap to describe.
+
+### The rule survives, and it never depended on `-mode`
+
+The priming rule (`LockWatch.prime_logger_module_cache/0`, #1731) stands
+unchanged. #1715's hazard has two legs and they part company here:
+
+* **The `persistent_term` leg is intact on every substrate.** A module's first
+  log line does a `persistent_term:put` via `logger_config:allow/2`. Embedded
+  mode loads CODE; it does not populate Logger's per-module cache. A preloaded
+  module that has never logged still owes that put. Nothing about `-mode`
+  touches this.
+* **The module-load leg does not reach the release.** Under embedded the boot
+  script has already loaded the tree, and a module outside it fails fast rather
+  than reaching the code server. That leg is live only where the node really is
+  interactive: docker/dev.
+
+So the rule was right and its stated reason was wrong — a worse failure than a
+wrong rule, because the reasoning is what the next reader reuses.
+
+### The one about to go stale: don't restate `busy_timeout`
+
+The paragraph pinned the window as *"`busy_timeout` (`30_000` in every env
+today)"*. A slice in flight moves it to ~300 ms in prod and dev, keeping 30_000
+only in `:test`, so "in every env today" stops being true.
+
+**Deliberately NOT corrected by writing the new number in.** The two changes can
+land in either order, and a file asserting a value that has not merged yet is
+the same defect mirrored. The form chosen instead: **name the SSOT and drop the
+value** (`config/runtime.exs`, per-env), and supply the field scale from a
+**dated measurement that cannot go stale** — the 29 holds logged 2026-09-08 ran
+31.1–94.1 s. A knob moves; a dated observation does not. This is the shape to
+reuse whenever `CLAUDE.md` needs to convey a magnitude that lives in config.
+
+_Docs-only. No code, no wire change, no protocol bump. Deploy: **nothing** —
+`CLAUDE.md` is instruction, not runtime._


### PR DESCRIPTION
## Provenance

Authorization **relayed via the ircbot, not seen by me in person**: vjt's go-ahead on `#grappa` at
22:07 Europe/Rome. Recording the label rather than presenting it as first-hand, so a crooked relay
costs a line in review and not a round trip.

Docs-only: `CLAUDE.md` + one `DESIGN_NOTES` entry. No code, no wire change, no protocol bump.

## Why this one is not a docs nit

`CLAUDE.md` is not documentation — it is the instruction set every session executes with zero
prior memory. A wrong line there does not sit in a corner being wrong; it gets **followed**, and
it propagates silently for months. This paragraph has been wrong since it was written.

## The four claims, and what happened to each

The #1715 paragraph carried four claims. One was false, one unsourced, one is about to go stale
under a slice already in flight, and **the rule they all propped up needed none of them**.

### 1. FALSE — the release is not `:interactive`

The text read *"the release runs `:interactive` and its `vm.args` sets no `-mode`"*. The second
half is true; the first **does not follow from it**, because the flag comes from the **start
script**, not the args file.

Measured twice, independently:

* **Live node** — `RELEASE_MODE=embedded` read out of pid 45683's *environment* with
  `procstat -e` (jail `grappa-new`, release 1.5.3). The explicit variable, not a glance at a
  command line.
* **Off-prod, from build artefacts** — the repo ships no `rel/`, so `mix release` writes Elixir's
  stock template, whose `vm.args` sets no `-mode` and says so in a comment. The generated
  `bin/grappa` then supplies it **from its own default**:
  `RELEASE_MODE="${RELEASE_MODE:-"embedded"}"` (line 31), passed as `--erl "-mode $RELEASE_MODE"`
  (line 85) by the shell function both `start` and `daemon` call. `RELEASE_MODE` appears **0
  times** in the entire repo — positive control: the same grep recipe hits `RELEASE_COOKIE` in 36
  files. `infra/freebsd/rc.d/grappa` reaches the release through one door, `grappa_runas "daemon"`,
  exporting `RELEASE_TMP`, `LANG`, `RUN_ERL_LOG_*`, `PATH` — and no `RELEASE_MODE`.

So embedded is **nobody's choice**: it is the Elixir release default and the repo has never
overridden it. Residual gap, named rather than papered over: `su -m` preserves the invoking
environment, so a `RELEASE_MODE` exported outside the repo could override it — which the
`procstat -e` reading rules out for the running node.

### 2. UNSOURCED — the cold-module census is DELETED, not re-measured

*"2464 of 3063 modules are still cold (80 %), 265 of `Grappa.*` alone"* has no recorded
provenance. Taking the explicit permission to remove rather than correct, on three grounds — and
the third is the one that generalises beyond this line:

1. **Nobody recorded which node produced it.** An unsourced number gets cited as measured by the
   next reader. That is exactly how it survived this long, and a number taken on a dev box is a
   *second* error harder to see than the first.
2. **It cannot describe this substrate.** `releases/<vsn>/start.script` carries **317** distinct
   `Elixir.Grappa*` modules among 1372 total, all inside `primLoad` directives, and embedded mode
   loads that set at boot. The census was therefore taken on a **non-release** node — docker's
   `mix phx.server` or an `iex -S mix`, where interactive genuinely is the mode.
3. 🔴 **A correct re-measurement would still be the wrong evidence.** The number counts **module
   residency**; the rule it supported depends on **Logger-cache residency**. Different axes — no
   value of the first is evidence for the second. **A rule may not cite a number that does not
   measure it.** This is why I declined to re-measure even though the measurement is easy to
   describe: it would have produced a well-sourced number that still proves nothing.

### 3. THE RULE — it stands, and it never depended on `-mode`

Answering this explicitly rather than leaving it standing by inertia. #1715's hazard has **two
legs**, and they part company here:

| leg | on the release (embedded) | on docker/dev (interactive) |
|---|---|---|
| `persistent_term` put — a module's first log line via `logger_config:allow/2` | **live** | **live** |
| module load — a not-yet-loaded module reaching the code server | **unreachable** | live |

Embedded mode loads **CODE**; it does **not** populate Logger's per-module cache. A preloaded
module that has never logged still owes its `persistent_term:put` on its first line. So the
priming rule (`LockWatch.prime_logger_module_cache/0`) is **unchanged and correct on every
substrate** — the observer whose job is to report the wait is otherwise its own casualty.

**The rule was right and its stated reason was wrong**, which is the worse of the two failures:
the reasoning is what the next reader reuses.

### 4. ABOUT TO GO STALE — `busy_timeout`, and the form chosen

The text pinned the window as *"`busy_timeout` (`30_000` in every env today)"*. A slice in flight
moves it to ~300 ms in prod and dev, keeping 30_000 only in `:test`, so *"in every env today"*
stops being true.

**Deliberately NOT fixed by writing `300` in.** The two PRs can land in either order, and a file
asserting a value that has not merged yet is the same defect mirrored. **Form chosen, and why it
holds under both landing orders:**

* **drop the value, name the SSOT** — `config/runtime.exs`, per-env. Correct whenever either PR
  lands, and correct forever after the next change too.
* **supply the magnitude from a DATED measurement instead of a live knob** — the 29 holds logged
  2026-09-08 ran 31.1–94.1 s. A knob moves; a dated observation does not.

That second half matters beyond this line: the paragraph needed a *scale* to convey the danger,
and the reflex is to reach for the config value. Reaching for a dated field measurement gives the
same scale with no expiry. It is the shape to reuse whenever `CLAUDE.md` must convey a magnitude
that lives in config.

## What I refuse to assert

- **That the module-load leg is dead on prod as a matter of observation.** It is an
  inference from embedded's documented semantics plus the 317 modules in `primLoad`. Confirming it
  needs `length(:code.all_loaded())` against the release's module list, on the live node — and
  prod is out of scope for me. The table above says *unreachable*; that word is doing inferential
  work and I am flagging it rather than hiding it.
- **What the true cold-module count is on any node.** I deleted the number; I did not replace it
  with a better one, and no reader should infer one from this PR.
- **That `-mode embedded` is deliberate.** Measured that it is the Elixir default and that the
  repo never sets it. Whether anyone ever intended it is not something the artefacts can say.
