### PR TITLE
union: compose the root restart budget with the SQLite contention ladder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,9 +106,19 @@ VAPID_PRIVATE_KEY=
 # RELEASE_COOKIE=
 
 # ─── Optional in prod (sensible defaults applied) ─────────────────────────────
-# Ecto pool size. Defaults to 10. Sqlite is single-writer; raising pool size
-# helps read concurrency, not write throughput.
-POOL_SIZE=10
+# Ecto pool size. Defaults to 5. SQLite is single-writer, so this buys READ
+# concurrency only — raising it does nothing for write throughput.
+#
+# Do not raise it past the BEAM's dirty-IO scheduler count (10 unless you set
+# +SDio; see below). Every SQLite call runs inside a dirty-IO NIF, so the pool
+# is also the number of dirty-IO schedulers the database alone can occupy, and
+# at parity a saturated pool can starve work that has no database in it.
+# grappa warns at boot if this relation is lost.
+#
+# NOTE: when the pool is exhausted, DBConnection's own error message suggests
+# "Increasing the pool_size". On SQLite that advice is backwards — the writer
+# ceiling is the single file lock, not the pool.
+POOL_SIZE=5
 
 # Phoenix HTTP listener port. Defaults to 4000.
 #
@@ -180,7 +190,19 @@ LOG_LEVEL=info
 # EXTRA_CHECK_ORIGINS=https://192.168.53.12:3000,https://irc.example.org
 
 # BEAM resource caps (see bin/start.sh). Unset → defaults applied
-# (GRAPPA_MAX_USERS=100, GRAPPA_DIRTY_SCHEDULERS=$(nproc)).
+# (GRAPPA_MAX_USERS=100, GRAPPA_DIRTY_SCHEDULERS=max(nproc, 10)).
+#
+# GRAPPA_DIRTY_SCHEDULERS sets BOTH +SDcpu and +SDio. The floor of 10 is not
+# decoration: ERTS defaults +SDio to a FIXED 10 whatever the machine has
+# (measured — a 6-CPU node answers 10, and so does the same node booted with
+# +S 16:16), so dropping below it takes capacity AWAY from the default rather
+# than trimming waste. Since every SQLite call — reads included — runs inside
+# a dirty-IO NIF, that count is the ceiling POOL_SIZE above must stay under.
+#
+# Raising it buys reserve while a writer is parked on the file lock; it buys
+# NO extra write throughput, because SQLite has exactly one writer. Measured
+# on a healthy prod node, the dirty-IO run queue was non-empty in 1 sample out
+# of 400 — at steady state these threads are not the constraint.
 # GRAPPA_MAX_USERS=100
 # GRAPPA_DIRTY_SCHEDULERS=
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -96,7 +96,7 @@ services:
       CIC_DIST_ROOT: ${CIC_DIST_ROOT:-/app/runtime/cicchetto-dist}
       # Literal defaults, NOT the empty-default form used above: an empty
       # string reaches String.to_integer/1 and crashes at boot (#369 X1).
-      POOL_SIZE: ${POOL_SIZE:-10}
+      POOL_SIZE: ${POOL_SIZE:-5}
       # PORT is NOT SUPPORTED on this substrate (#1409 D-S6): this line is
       # the only Docker-side consumer. The container side of the publish
       # above, the healthcheck below, the Dockerfile probe, and the deploy

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -26,17 +26,26 @@ config :grappa, Grappa.Repo,
   # could only have been answered at HALF the production pool and then
   # extrapolated, which is the one move the investigation is not allowed.
   #
-  # The default is `5`, so an unset environment is byte-for-byte the
-  # behaviour that shipped before this line. What it buys is the ability to
-  # take the SAME reading at two pool sizes: if the saturation point tracks
-  # the pool, the mechanism is the pool; if it does not, the hypothesis is
-  # dead and that is a result. A lever that only ever reads one value cannot
-  # tell those two apart.
+  # The default is `5`, and the lever is still the point: it buys the
+  # ability to take the SAME reading at two pool sizes, which is what
+  # tells "the mechanism is the pool" apart from "the hypothesis is dead".
+  #
+  # 🔴 What has CHANGED since #1759c wrote the paragraph above: prod no
+  # longer runs `10`, it runs this same `5` (see `config/runtime.exs` for
+  # the dirty-IO reserve argument). So the "HALF the production pool"
+  # objection no longer applies — the e2e stack now exercises the
+  # production pool size, not half of it. Read that paragraph as history.
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
-  # CP24 cluster `post-cr-review` bucket B, persistence/S2: mirror prod's
-  # 30s busy_timeout so iex sessions + integration scripts hit the same
-  # "database is locked" cushion as prod. Default ~2s otherwise.
-  busy_timeout: 30_000,
+  # Mirror prod's contention ladder — the WHOLE ladder, not one rung of
+  # it — so iex sessions, integration scripts and the e2e stack (which
+  # runs `MIX_ENV: dev`) hit the timings prod hits. See the long comment
+  # in `config/runtime.exs`: the four numbers only make sense together,
+  # and mirroring `busy_timeout` alone is how dev came to sit at 30_000
+  # against an inherited 50ms queue target.
+  busy_timeout: 300,
+  timeout: 15_000,
+  queue_target: 1_500,
+  queue_interval: 5_000,
   # REV-B / C3 (2026-05-22 codebase review): pin PRAGMAs in lockstep
   # with config/runtime.exs and config/test.exs. See runtime.exs for
   # the full rationale — dep major-version default flip would silently

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -299,26 +299,141 @@ if config_env() == :prod do
 
   config :grappa, Grappa.Repo,
     database: database_path,
-    # SQLite is single-writer at the file level. `pool_size: 10` is a
-    # READ-concurrency cap — every connection in the pool can serve a
-    # SELECT in parallel under WAL (`journal_mode: :wal` below). Writes
-    # always serialize at the file lock regardless of pool size; the
-    # `busy_timeout` below is what gives them a wait-for-the-writer-
-    # ahead budget. Lower than 10 starves cic's per-(user, network)
-    # query fan-out under multi-tab load; higher would mostly idle.
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    # CP24 cluster `post-cr-review` bucket B, persistence/S2: SQLite's
-    # default `busy_timeout` is ~2s. With `pool_size: 10` + WAL +
-    # single-writer file lock, transient contention from concurrent
-    # writes (Bootstrap spawning N sessions, channel-mode batches,
-    # last_joined_channels writes) cascades into `database is locked`
-    # exceptions before the writer ahead releases. The CP23 S4 e2e
-    # flake (`cp15-b6-kicked` + `m9-cicchetto-part-x-click` retries on
-    # `Database busy`) was a direct symptom. 30_000ms mirrors
-    # `config/test.exs` which has carried this value since the Sandbox
-    # cascading-busy investigation. Read concurrency stays uncapped;
-    # this only delays the write-side raise, not block reads.
-    busy_timeout: 30_000,
+    # ── The contention ladder ────────────────────────────────────────
+    #
+    # Four numbers govern one contended write, and they are NOT four
+    # independent defaults: each layer is supposed to hand the fault to
+    # the layer above it, so they only make sense read together.
+    #
+    #     busy_timeout          300ms   in-NIF wait for the file lock
+    #     busy_retry budget   1_500ms   BEAM-side ride-out (config/config.exs)
+    #     queue_target        1_500ms   pool queue tolerance (CoDel drops at 2x)
+    #     timeout            15_000ms   the caller's own deadline
+    #
+    # Before this was chosen as a ladder it ran 30_000 / 1_500 / 50 /
+    # 15_000 — inverted at every rung, and only two of the four had ever
+    # been chosen at all. What that cost is recorded in DESIGN_NOTES;
+    # the short version is that the app-level retry engine could never
+    # take a second attempt, and the pool shed requests (each one a lost
+    # message) a hundred times sooner than the ride-out above it needed.
+    #
+    # SQLite is single-writer at the file level, so `pool_size` buys READ
+    # concurrency under WAL (`journal_mode: :wal` below) and nothing on
+    # the write side — writes serialize at the file lock whatever the
+    # pool size is.
+    #
+    # 5 is a TUNING CHOICE argued between two bounds, not a measurement.
+    # UPPER: every exqlite call runs inside a dirty-IO NIF, so the pool
+    # is also the number of dirty-IO schedulers the Repo alone can hold —
+    # and at the old `10` that equalled the ERTS default dirty-IO count
+    # exactly, i.e. a saturated pool could occupy every one of them and
+    # stall work with no database in it at all (#1715). That ceiling is
+    # NOT hardware-derived: ERTS defaults `+SDio` to 10 whatever the core
+    # count (measured: `+S 16:16` still answers 10), and the substrates
+    # that exec the release directly set no `+SDio`, so 10 is the floor
+    # everywhere and a constant below it needs no `nproc`. 5 leaves half.
+    # LOWER: the read fan-out has to fit. NOT MEASURED at any pool size —
+    # `config/dev.exs`'s #1759c comment says so outright, and the former
+    # claim here that "lower than 10 starves cic's fan-out" carried no
+    # measurement either. What IS exercised is 5: the whole e2e stack
+    # runs `MIX_ENV: dev`, whose pool has been 5 all along.
+    # `Grappa.Repo.check_dirty_io_reserve/2` reports at boot if either
+    # side of that relation moves — including via GRAPPA_DIRTY_SCHEDULERS.
+    #
+    # ⚠️ The reserve is a STALL-TIME argument, not a throughput one, and
+    # the difference is measured. At steady state the dirty-IO run queue
+    # on prod is non-empty in 1 sample out of 400 at 50ms, maximum depth
+    # 1 — the ten threads are nowhere near the bottleneck when the node
+    # is healthy. What makes them scarce is a holder PARKED inside the
+    # NIF: every exqlite entry point is `ERL_NIF_DIRTY_JOB_IO_BOUND`,
+    # reads included, so a stalled writer occupies one of the ten for the
+    # whole hold, and three consecutive holders were observed nailing
+    # 3/10 during one prod episode. Occupancy DURING a stall is still
+    # unmeasured. So this rung buys headroom for the bad minute, and
+    # claims nothing about the good hour.
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
+    # The in-NIF wait, and it is deliberately SHORT.
+    #
+    # exqlite's busy handler sleeps INSIDE a `ERL_NIF_DIRTY_JOB_IO_BOUND`
+    # NIF, so every millisecond of `busy_timeout` is a dirty-IO scheduler
+    # held by a process doing nothing (#1715 measures what queues behind
+    # that: every `persistent_term` write and every module load in the
+    # VM, for the length of the wait). The cure is not a longer wait, it
+    # is to wait in the BEAM instead — `Grappa.Repo.BusyRetry`, which
+    # already exists and was unreachable at the old value.
+    #
+    # 300ms is a TUNING CHOICE argued between two bounds.
+    # UPPER: it must be a fraction of the 1_500ms retry budget or the
+    # loop degenerates to a single attempt — `BusyRetry`'s own moduledoc
+    # names that as a documented defect (#1421: at 30_000 the first
+    # attempt has already overshot the deadline when it returns, so the
+    # linear backoff never runs). With `backoff_ms: 25` (x attempt,
+    # capped 200) a per-attempt cost of ~300ms yields four to five
+    # attempts inside the unchanged budget, so the caller-visible wait
+    # stays ~1.5s and no other rung has to move.
+    # LOWER: it must exceed a HEALTHY hold or ordinary writes retry for
+    # nothing. That distribution is NOT MEASURED, and neither instrument
+    # we have can supply it — `LockWatch` reports only holds above its
+    # 2_000ms stall threshold (it sees the tail, never the body) and
+    # Ecto's per-query telemetry is completion-driven, so it measures the
+    # victim rather than the holder. This bound is therefore argued from
+    # above and open from below; a slow bulk write (an archive purge, a
+    # `NickMigration` sweep) is the case to watch.
+    #
+    # This also SHRINKS the window in which an insert can outlive its FK
+    # parent — the #340 rejection — from one 30_000ms attempt to a
+    # ~1_500ms budget, because every retry is synchronous in the caller's
+    # own process. Nothing here defers, spools or hands off a write.
+    #
+    # 🔴 WHAT THIS IS NOT: a cure for the 31s stalls. `busy_timeout`
+    # governs who WAITS; the stalls are a single holder's POSSESSION
+    # (`LockWatch`'s `held_ms` is measured from inside the transaction
+    # fun, so it is possession and not queueing). Shortening the wait
+    # bounds the BLAST RADIUS and makes the failure visible sooner; it
+    # does not shorten one hold by a millisecond, and #1420's mechanism
+    # remains unestablished. Do not read this rung as a fix for it.
+    busy_timeout: 300,
+    # The caller's own deadline, PINNED at the value that was already in
+    # force. Ecto's default is 15_000 (`Ecto.Repo.Supervisor`'s
+    # `@defaults`, merged in before `Grappa.Repo.init/2` ever sees the
+    # config), so this line changes nothing today — same argument as
+    # `synchronous` / `foreign_keys` below (REV-B/C3): a default that is
+    # right by accident is one dep major-version flip from moving under
+    # prod with no diff. It matters more here because this number is half
+    # of a PAIR: the DB-side wait was chosen and the caller-side deadline
+    # it should have been chosen against never was, which is how they
+    # came to sit at 30_000 against 15_000, the caller giving up first.
+    # When it fires DBConnection DESTROYS the connection rather than
+    # failing the call (`ConnectionPool.handle_info({:timeout, …})` →
+    # `Holder.handle_disconnect/2`), so it is the outer bound of the
+    # ladder and nothing below it should ever reach it.
+    timeout: 15_000,
+    # The pool queue's CoDel tolerance. Unset, DBConnection defaults to
+    # 50ms / 2_000ms — never chosen here, and `queue_target` is not a
+    # latency knob: it is the threshold that turns burst latency into
+    # DROPPED REQUESTS (`ConnectionPool.drop/2` raises the
+    # `DBConnection.ConnectionError` that `Session.Persistor` reports as
+    # `scrollback row dropped: persistence unavailable` — a message that
+    # is neither stored nor delivered). At 50ms the queue began shedding
+    # after ~100ms of sustained delay, an order of magnitude before the
+    # 1_500ms ride-out above it had finished trying.
+    #
+    # The constraint that sets it: the queue must not drop a request
+    # before the retry ladder above it has had its turn. So it is the
+    # retry budget, and CoDel's doubling puts the first drop at ~3s of
+    # SUSTAINED saturation — long enough that the ladder completes,
+    # short enough that CoDel still does its job of refusing work before
+    # it reaches the DB. `queue_interval` is the observation window over
+    # which sustained slowness doubles the target; at 5_000 it spans
+    # several full ladders before adapting, where the 2_000 default was
+    # barely longer than one. `config/test.exs` already had to choose
+    # both for CI (5_000 / 30_000) — the defaults were found inadequate
+    # once already, in the only env where anyone had looked.
+    #
+    # NOT MEASURED: the healthy checkout-delay distribution. Both bounds
+    # here are argued from the ladder, not from a reading.
+    queue_target: 1_500,
+    queue_interval: 5_000,
     journal_mode: :wal,
     cache_size: -64_000,
     temp_store: :memory,

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,20 @@ config :grappa, Grappa.Repo,
   # true still works — Sandbox owns the conn per test; concurrency
   # comes from interleaved checkouts, not concurrent file writes.
   pool_size: 1,
+  # 🔴 This env deliberately does NOT mirror the production contention
+  # ladder (`config/runtime.exs`), and the reason is `pool_size: 1` right
+  # above: the Sandbox serialises checkouts per test, so there is no
+  # cross-connection file-lock contention for a short `busy_timeout` to
+  # convert into retries. Keeping the generous value here is what makes a
+  # slow CI runner queue rather than fail. The suites that DO exercise
+  # contention build their own repo with explicit timings and never read
+  # this block — `Grappa.Repo.BusyRetryBudgetReachTest` and
+  # `Grappa.Repo.CheckoutDeadlineReachTest`.
   busy_timeout: 30_000,
+  # Pinned in lockstep with runtime.exs / dev.exs (REV-B/C3 reasoning):
+  # Ecto's own default is this value, so it changes nothing and cannot be
+  # moved out from under us by a dep bump.
+  timeout: 15_000,
   # REV-B / C3 (2026-05-22 codebase review): pin PRAGMAs in lockstep
   # with config/runtime.exs and config/dev.exs. See runtime.exs for
   # the full rationale — dep major-version default flip would silently
@@ -23,7 +36,7 @@ config :grappa, Grappa.Repo,
   foreign_keys: :on,
   # CI runner is slower than local dev (single-vCPU + coveralls
   # instrumentation overhead). Default DBConnection queue_target=50ms /
-  # queue_interval=1000ms triggers `queue_timeout` on Sandbox checkout
+  # queue_interval=2000ms triggers `queue_timeout` on Sandbox checkout
   # under sustained load even though the conn would have become
   # available shortly. Bumped both to give CI headroom; the cap is
   # still bounded so genuine deadlocks surface as failures rather

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49101,3 +49101,153 @@ assert.
 _Deploy: **COLD** — server modules changed (`ISupport`, `EventRouter`,
 `Identifier`, `Session.Server`) plus the cic bundle. No wire change, no
 protocol bump._
+<!-- entry #2001-w2-defaults -->
+
+---
+
+## 2026-09-08 — #2001 (w2 slice): the contention ladder, chosen as a ladder
+
+**Provenance.** vjt asked for "default sani per gli altri utenti" and then
+"cambia i timeout, e se possiamo aumentare o render tunabili gli io thread
+aumentiamoli su prod" — the first relayed by the ircbot, the second reaching
+the orchestrator directly in session. The motive is his and it is explicit:
+someone installing the `.deb` must not inherit numbers born in CI.
+
+### The fact that opened it
+
+`config/runtime.exs` said, in its own comment, that production's
+`busy_timeout` of `30_000` *"mirrors `config/test.exs`"*. Production was
+running the test suite's number, and the file admitted it.
+
+Pulling that thread produced the real finding: the four numbers governing a
+contended write are not four defaults, they are a **ladder**, and each rung is
+supposed to hand the fault to the rung above it. Measured, three of the four
+had never been chosen at all:
+
+| rung | was | chosen? | now |
+|---|---|---|---|
+| `busy_timeout` | 30 000 | yes — for `:test` | **300** |
+| `busy_retry.budget_ms` | 1 500 | yes (#336's ~1s window) | 1 500, unchanged |
+| `queue_target` / `queue_interval` | 50 / 2 000 | **no** — DBConnection defaults | **1 500 / 5 000** |
+| `:timeout` | 15 000 | **no** — Ecto's default | 15 000, now **pinned** |
+| `pool_size` | 10 | yes | **5** |
+
+Read top to bottom it was inverted at every rung, and two of the consequences
+were already written down in our own source as defects:
+
+* **The retry engine could not take a second attempt.**
+  `Grappa.Repo.BusyRetry`'s moduledoc said so (#1421): at `30_000` against a
+  `1_500` budget *"the loop makes EXACTLY ONE attempt and the linear backoff
+  below never runs."* We had built a retry ladder and set a timeout that
+  guaranteed it never climbed.
+* **`queue_target: 50` decided message loss.** `ConnectionPool.drop/2` is what
+  raises the `ConnectionError` that `Session.Persistor` reports as a dropped
+  scrollback row — and delivery is downstream of the insert, so a dropped row
+  is a message never delivered either. The threshold that governs that was a
+  library default nobody had looked at.
+
+The cure for the first is deliberately taken from the other side of #1421's
+pricing: **not by growing the budget, but by shrinking the wait the budget has
+to cover.** The caller-visible bound therefore does not move (~1.5s), and the
+engine becomes reachable for the first time. `BusyRetryBudgetReachTest` already
+measured both regimes against a real held write lock; production now runs in
+the arm that test proves works, rather than in a predicted one.
+
+### The invariant that is not a number: `pool_size` < dirty-IO floor
+
+The question vjt's brief forced was whether the pool should be tied to CPU
+cores or to the dirty-IO scheduler count. **Neither.**
+
+Cores have no claim: measured, ERTS does not derive `+SDio` from them — a
+6-CPU prod node reports 10, and the same node booted `+S 16:16` still reports
+10, so the default is FIXED at 10 and not `max(S, 10)`. (`dirty_cpu` does track
+the schedulers, which is the control that makes the reading mean something.)
+
+Tying it to dirty-IO is worse than it sounds, because **that is what we already
+had, by accident**: `pool_size 10 == dirty_io 10`. Every exqlite entry point is
+`ERL_NIF_DIRTY_JOB_IO_BOUND` — reads included — so a writer parked on the file
+lock occupies one of the ten for the whole hold, and at parity the Repo alone
+can occupy all of them. #1715 already documents what queues behind that
+occupancy. An equality is the degenerate case of a coupling, not a design.
+
+So the shape is a **relation with a reserve**, and the elegant part is that the
+thing to stay under is itself hardware-independent: 10 is the floor on every
+substrate we ship (ERTS gives 10; the Docker entrypoint gives `max(nproc, 10)`).
+A constant below it is correct on a 1-core VPS and a 64-core box alike, with no
+`nproc` call. `5` is half.
+
+Because it is a relation and not a number, it is **checked at boot** rather
+than commented: `Grappa.Repo.check_dirty_io_reserve/2` compares the two and
+warns naming both. That is not decoration — `GRAPPA_DIRTY_SCHEDULERS` applies
+its floor of 10 only when UNSET, so an operator who sets it explicitly (which
+`bin/start.sh`'s own comment encourages, calling 10 "wasteful on a 4-core
+host") can invert the relation silently. It warns rather than raises: the
+reserve being gone is the posture production shipped, so raising would refuse
+to boot the deployments this exists to inform.
+
+### The dirty-IO threads: tunable yes, raised by default NO
+
+vjt asked to raise them on prod. **We are declining the raise and keeping the
+tunability**, and the argument is a measurement rather than a preference.
+
+Sampled read-only on the live prod node, `run_queue_lengths_all` over 400
+samples at 50ms: the dirty-IO run queue was non-empty in **1 sample out of
+400**, maximum depth **1**. At steady state the ten threads are nowhere near
+the constraint. What makes them scarce is a holder parked inside the NIF —
+three consecutive holders were observed nailing 3/10 during one episode — so
+`+SDio` is **insurance against head-of-line during a stall, not throughput**.
+And `pool_size 10 → 5` lowers that same pressure on its own, from the cheap
+side: a smaller pool costs nothing, while each extra dirty-IO scheduler is an
+OS thread with its own allocator carriers on machines that may have two cores.
+
+⚠️ Limit of that measurement, stated rather than glossed: it was taken **at
+steady state on a healthy node**. Occupancy DURING a stall remains unmeasured.
+
+Tunability turned out to already exist and to be undocumented: `ERL_ZFLAGS` is
+honoured by erlexec on every release substrate, the jail's rc.d exports every
+`^[A-Z_]` name in its env file, and systemd loads the same file via
+`EnvironmentFile`. So the deliverable was documentation, not machinery — and
+that also resolved the separate lie in the same files, which advertised
+`GRAPPA_MAX_USERS` / `GRAPPA_DIRTY_SCHEDULERS` as knobs on two substrates where
+nothing reads them (they are read only by the two CONTAINER entrypoints). The
+knobs' absence there is deliberate and documented in `docs/OPERATIONS.md`; the
+advertisement was not.
+
+### 🔴 What this is NOT
+
+**It is not a cure for the 31s stalls, and no part of it should be read as
+one.** `busy_timeout` governs who WAITS; the stalls are a single holder's
+POSSESSION (`LockWatch`'s `held_ms` is taken from inside the transaction fun,
+so it measures possession, not queueing). Shortening the wait bounds the blast
+radius and surfaces the failure sooner; it does not shorten one hold by a
+millisecond. #1420's mechanism remains unestablished, five candidates are dead
+there, and this entry adds no sixth.
+
+### What is NOT measured, and should set these numbers one day
+
+The **healthy write-lock hold-time distribution**. It is what should fix
+`busy_timeout`, and neither instrument we own can produce it: `LockWatch`
+reports only holds above its 2 000ms stall threshold, so it sees the tail and
+never the body, and Ecto's per-query telemetry is completion-driven and
+therefore measures the victim rather than the holder. `300` is consequently
+argued from ABOVE (a fraction of the retry budget, so the loop gets four to
+five attempts) and open from BELOW. A slow bulk write — an archive purge, a
+`NickMigration` sweep — is the case to watch. Likewise unmeasured: the healthy
+checkout-delay distribution behind `queue_target`, and read fan-out at any pool
+size (`config/dev.exs`'s #1759c comment already said so, and the former claim
+in `runtime.exs` that "lower than 10 starves cic's fan-out" carried no
+measurement either — it has been retired rather than reworded).
+
+### #340 is honoured, not sidestepped
+
+A timeout change moves when an insert lands, so it owes the #340 answer. It
+**narrows** the exposure: the dominant term today is one attempt bounded by
+`busy_timeout` = 30 000ms, and it becomes a ~1 500ms budget — a 20× smaller
+window against a `Visitors.Reaper` that sweeps every 60s. Structurally, every
+retry is synchronous in the caller's own process, so nothing is deferred,
+spooled or handed off, and the caller's stack holds the FK parent's liveness
+across the whole window. #340 rejected deferral; there is none here.
+
+_Deploy: **COLD** — `config/runtime.exs` is read at boot, and the release lib
+directory is unchanged only for hot-reloadable modules. `BEGIN IMMEDIATE`
+(#524) is untouched and out of scope._

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -3287,6 +3287,32 @@ consumers too, and these caps are THIS image's concern. That is the
 same reasoning the boot-time migration switch below uses for living in
 the entrypoint rather than in `Grappa.Application`.
 
+**Corollary for the substrates with no entrypoint — the jail, the `.deb`
+and the `.rpm`.** Because the caps live in the entrypoint,
+`GRAPPA_MAX_USERS` and `GRAPPA_DIRTY_SCHEDULERS` are read by NOTHING on
+those substrates: rc.d and the systemd unit exec the release directly.
+That is the intended consequence of the paragraph above, not a gap. **The
+lever that does work there is `ERL_ZFLAGS` itself**, and it needs no code:
+the jail's rc.d sources its env file and exports every `^[A-Z_]` name in
+it, systemd loads the same file via `EnvironmentFile`, and `erlexec`
+appends the value to the release's boot flags. Both
+`grappa.env.example`s document it, with `+SDio` as the flag worth knowing.
+
+**Sizing `+SDio`, and what it does not buy.** Every exqlite call — reads
+included — runs inside an `ERL_NIF_DIRTY_JOB_IO_BOUND` NIF, so a writer
+waiting on SQLite's file lock occupies a dirty-IO scheduler for the whole
+wait. ERTS fixes the default at **10 regardless of CPU count** (measured:
+a 6-CPU node reports 10, and so does the same node booted `+S 16:16`),
+which is why `pool_size` is a constant chosen below 10 rather than derived
+from the hardware, and why `Grappa.Repo.check_dirty_io_reserve/2` warns at
+boot when that relation is lost. ⚠️ Raising `+SDio` buys **reserve while a
+writer is parked**, never write throughput — SQLite has exactly one writer
+— and it does not shorten a stall. Measured read-only on a healthy prod
+node, the dirty-IO run queue was non-empty in 1 sample out of 400 (max
+depth 1): at steady state these threads are not the constraint, so the
+default is usually the right answer, most of all on a small VPS where each
+one is an OS thread with its own allocator carriers.
+
 **The `/data` ownership split.** On a fresh anonymous `/data` volume
 Docker inherits the image's `grappa` ownership, so the entrypoint's
 `mkdir -p` succeeds; a root-owned BIND mount is the operator's to

--- a/infra/freebsd/grappa.env.example
+++ b/infra/freebsd/grappa.env.example
@@ -65,8 +65,12 @@ PORT=4000
 # to PHX_HOST only; escape-hatch for raw-IP / secondary vhost. Unset = none.
 # EXTRA_CHECK_ORIGINS=https://irc.example.org
 
-# Sqlite pool size (read concurrency). Defaults to 10 if unset.
-POOL_SIZE=10
+# Sqlite pool size (read concurrency). Defaults to 5 if unset. SQLite has one
+# writer, so this buys reads only. Keep it BELOW the BEAM's dirty-IO scheduler
+# count (10 by default here — see the ERL_ZFLAGS note below): every SQLite call
+# runs inside a dirty-IO NIF, so at parity a saturated pool can occupy every
+# one of them. grappa warns at boot if that relation is lost.
+POOL_SIZE=5
 
 # Logger level: debug | info | notice | warning | error
 LOG_LEVEL=info
@@ -86,6 +90,32 @@ GRAPPA_OUTBOUND_V6_POOL=2001:db8::1,2001:db8::2
 # GRAPPA_CAPTCHA_SITE_KEY=
 # GRAPPA_CAPTCHA_SECRET=
 
-# ── BEAM resource caps (optional) ──────────────────────────────────────────
-# GRAPPA_MAX_USERS=100
-# GRAPPA_DIRTY_SCHEDULERS=
+# ── BEAM boot flags (optional) ─────────────────────────────────────────────
+#
+# 🔴 GRAPPA_MAX_USERS and GRAPPA_DIRTY_SCHEDULERS DO NOT WORK HERE, and used
+# to be listed as if they did. They are read only by the two CONTAINER
+# entrypoints (bin/start.sh, infra/docker/release-entrypoint.sh); this
+# substrate execs the release directly from rc.d, with no entrypoint in the
+# path. That is deliberate, not an oversight — the caps those knobs set cure
+# a Docker-specific inherited NOFILE, and docs/OPERATIONS.md explains why they
+# are not baked into a rel/vm.args that would travel here.
+#
+# The lever that DOES work on this substrate is ERL_ZFLAGS: rc.d sources this
+# file and exports every ^[A-Z_] name in it, and erlexec appends ERL_ZFLAGS to
+# the release's boot flags. Unset, the BEAM boots on ERTS defaults.
+#
+# The flag worth knowing about is +SDio, the dirty-IO scheduler count, because
+# EVERY SQLite call — reads included — runs inside a dirty-IO NIF, and a writer
+# waiting on the file lock occupies one of those threads for the whole wait.
+# ERTS defaults it to a FIXED 10 regardless of CPU count (measured: unchanged
+# at 6 CPUs and at +S 16:16), so POOL_SIZE above must stay under 10 unless you
+# raise this.
+#
+# ⚠️ Raising it buys RESERVE while a writer is parked — it does NOT buy write
+# throughput, because SQLite has exactly one writer, and it does not shorten a
+# stall. Measured on a healthy prod node, the dirty-IO run queue was non-empty
+# in 1 sample out of 400: at steady state these threads are not the constraint.
+# Each one is an OS thread with its own allocator carriers, so on a small VPS
+# the default is usually the right answer.
+#
+# ERL_ZFLAGS=+SDio 16

--- a/infra/linux/grappa.env.example
+++ b/infra/linux/grappa.env.example
@@ -66,8 +66,12 @@ PORT=4000
 # to PHX_HOST only; escape-hatch for raw-IP / secondary vhost. Unset = none.
 # EXTRA_CHECK_ORIGINS=https://irc.example.org
 
-# Sqlite pool size (read concurrency). Defaults to 10 if unset.
-POOL_SIZE=10
+# Sqlite pool size (read concurrency). Defaults to 5 if unset. SQLite has one
+# writer, so this buys reads only. Keep it BELOW the BEAM's dirty-IO scheduler
+# count (10 by default here — see the ERL_ZFLAGS note below): every SQLite call
+# runs inside a dirty-IO NIF, so at parity a saturated pool can occupy every
+# one of them. grappa warns at boot if that relation is lost.
+POOL_SIZE=5
 
 # Logger level: debug | info | notice | warning | error
 # On this substrate, logs go to `journalctl -u grappa`, not a file
@@ -80,9 +84,36 @@ LOG_LEVEL=info
 # GRAPPA_CAPTCHA_SITE_KEY=
 # GRAPPA_CAPTCHA_SECRET=
 
-# ── BEAM resource caps (optional) ──────────────────────────────────────────
-# GRAPPA_MAX_USERS=100
-# GRAPPA_DIRTY_SCHEDULERS=
+# ── BEAM boot flags (optional) ─────────────────────────────────────────────
+#
+# 🔴 GRAPPA_MAX_USERS and GRAPPA_DIRTY_SCHEDULERS DO NOT WORK HERE, and used
+# to be listed as if they did. They are read only by the two CONTAINER
+# entrypoints (bin/start.sh, infra/docker/release-entrypoint.sh); this
+# substrate runs the release under systemd (Type=exec, ExecStart=bin/grappa
+# start), with no entrypoint in the path. That is deliberate, not an
+# oversight — the caps those knobs set cure a Docker-specific inherited
+# NOFILE, and docs/OPERATIONS.md explains why they are not baked into a
+# rel/vm.args that would travel here.
+#
+# The lever that DOES work on this substrate is ERL_ZFLAGS: systemd loads this
+# file via EnvironmentFile, and erlexec appends ERL_ZFLAGS to the release's
+# boot flags. Unset, the BEAM boots on ERTS defaults.
+#
+# The flag worth knowing about is +SDio, the dirty-IO scheduler count, because
+# EVERY SQLite call — reads included — runs inside a dirty-IO NIF, and a writer
+# waiting on the file lock occupies one of those threads for the whole wait.
+# ERTS defaults it to a FIXED 10 regardless of CPU count (measured: unchanged
+# at 6 CPUs and at +S 16:16), so POOL_SIZE above must stay under 10 unless you
+# raise this.
+#
+# ⚠️ Raising it buys RESERVE while a writer is parked — it does NOT buy write
+# throughput, because SQLite has exactly one writer, and it does not shorten a
+# stall. Measured on a healthy prod node, the dirty-IO run queue was non-empty
+# in 1 sample out of 400: at steady state these threads are not the constraint.
+# Each one is an OS thread with its own allocator carriers, so on a small VPS
+# the default is usually the right answer.
+#
+# ERL_ZFLAGS=+SDio 16
 
 # NOTE: GRAPPA_OUTBOUND_V6_POOL (present in infra/freebsd/grappa.env.example)
 # is intentionally NOT listed here — config/runtime.exs no longer reads

--- a/infra/packaging/grappa.env.example
+++ b/infra/packaging/grappa.env.example
@@ -56,8 +56,24 @@ CIC_DIST_ROOT=/usr/share/grappa/cicchetto-dist
 # PHX_HOST only; escape-hatch for raw-IP / secondary vhost.
 # EXTRA_CHECK_ORIGINS=https://irc.example.org
 #
-# Sqlite read-concurrency pool (defaults to 10).
-# POOL_SIZE=10
+# Sqlite read-concurrency pool (defaults to 5). SQLite has one writer, so this
+# buys reads only. Keep it BELOW the BEAM's dirty-IO scheduler count (10 by
+# default — see ERL_ZFLAGS below): every SQLite call runs inside a dirty-IO
+# NIF, so at parity a saturated pool can occupy every one of them. grappa
+# warns at boot if that relation is lost.
+# POOL_SIZE=5
+#
+# BEAM boot flags. This package runs the release under systemd with no
+# container entrypoint, so GRAPPA_MAX_USERS / GRAPPA_DIRTY_SCHEDULERS (the
+# Docker knobs) are NOT read here; ERL_ZFLAGS is the lever that is, and
+# systemd loads this file via EnvironmentFile. +SDio sets the dirty-IO
+# scheduler count, which ERTS fixes at 10 regardless of CPU count.
+#
+# ⚠️ Raising it buys reserve while a writer is parked on the file lock, NOT
+# write throughput (SQLite has one writer) and not a shorter stall. Each is an
+# OS thread with its own allocator carriers; on a small VPS the default is
+# usually right.
+# ERL_ZFLAGS=+SDio 16
 #
 # Logger level: debug | info | notice | warning | error. Logs go to
 # `journalctl -u grappa` (Type=exec foreground).

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -471,9 +471,7 @@ defmodule Grappa.Application do
           # on :start_bootstrap so test boots empty.
         ] ++ bootstrap_child()
 
-    opts = [strategy: :one_for_one, name: Grappa.Supervisor]
-
-    case Supervisor.start_link(children, opts) do
+    case Supervisor.start_link(children, root_supervisor_opts()) do
       {:ok, _} = result ->
         # H26 (review 2026-05-22): flip the substrate-readiness flag
         # so `/healthz` returns 200 (vs the default 503-on-not-ready).
@@ -519,6 +517,71 @@ defmodule Grappa.Application do
       other ->
         other
     end
+  end
+
+  # max_restarts: 60, max_seconds: 60 — the ROOT supervisor ran on OTP's
+  # DEFAULT 3-in-5s until 2026-09-08, which is a default and never was a
+  # decision: `SessionSupervisor` twenty lines up carries an argued
+  # 10_000/60, so the silence here read as "considered" when it was
+  # "never considered".
+  #
+  # 🔴 Measured on the m42 jail, two node deaths inside half an hour:
+  #
+  #   20:36:31.150–.472    4 children in   322 ms  (Visitors/Uploads/Avatars
+  #                                                 Reaper + AdminEvents)
+  #   21:06:38.979–40.053  5 children in 1_070 ms  (of which Bootstrap x3)
+  #
+  # Neither burst is N independent faults. It is ONE correlated degradation
+  # — the SQLite pool saturating — arriving at every Repo-reading singleton
+  # at once, and three of those inside 5s is the whole budget. The tree has
+  # ~31 top-level children and most of them touch the Repo, so the default
+  # made "the DB is briefly busy" and "kill the node" the same event.
+  #
+  # Where the two numbers come from:
+  #
+  #   max_seconds: 60 — twice `busy_timeout` (30_000, every env), i.e. the
+  #     window has to be able to CONTAIN one saturation episode. A window
+  #     shorter than the stall splits one degradation across two budgets and
+  #     measures nothing.
+  #   max_restarts: 60 — ~2 full sweeps of the ~31-child tree: every
+  #     top-level singleton may die TWICE inside one degradation and the node
+  #     lives. The measured peak is 5, so this clears it 12x over.
+  #
+  # Deliberately NOT the sibling's 10_000/60. Under `SessionSupervisor` the
+  # children are homogeneous, ephemeral, and restarting IS the recovery
+  # mechanism (upstream reconnect), so a huge budget buys tolerance for the
+  # normal case. Here the children are heterogeneous infrastructure
+  # singletons and a restart is an ANOMALY. 10_000/60 is ~167 restarts/s
+  # sustained: it would make the root effectively immortal and delete the
+  # signal this supervisor exists to produce.
+  #
+  # What must STILL kill the node, on purpose: a non-transient fault — an
+  # Endpoint that cannot bind, a Vault with the wrong key, a Repo that
+  # cannot open the file, or any child in a tight crash-loop. 60-in-60 is
+  # 1 restart/s sustained, so a tight loop trips it in well under a minute
+  # and the node exits where rc.d can see it. A node that restart-loops
+  # forever while looking alive is strictly WORSE for an operator than one
+  # that dies.
+  #
+  # ⚠️ What this does NOT cure, stated so nobody reads it as fixed: death 2
+  # above. `Grappa.Bootstrap` is `use Task, restart: :transient` and re-runs
+  # its credential READ on every restart, so it re-enters the saturated pool
+  # immediately — measured at ~2.8 restarts/s, which exhausts 60-in-60 in
+  # ~21s, well inside a 31s stall. That is a child that does not degrade,
+  # not a budget that is too small, and raising the budget to cover it would
+  # be buying the immortality rejected two paragraphs up. The cure is the
+  # `{:error, :db_unavailable}` verb already used in 45 files under `lib/`
+  # (`Accounts.Reaper` is the in-house model: "sweep dropped, retrying next
+  # tick"), and it is a SEPARATE slice.
+  @doc """
+  Options for the ROOT supervisor (`Grappa.Supervisor`).
+
+  Public so the restart budget is testable against the running shape rather
+  than restated in a test — see `test/grappa/application_root_supervisor_limits_test.exs`.
+  """
+  @spec root_supervisor_opts() :: [Supervisor.option()]
+  def root_supervisor_opts do
+    [strategy: :one_for_one, name: Grappa.Supervisor, max_restarts: 60, max_seconds: 60]
   end
 
   # Bootstrap is opt-in via the `:start_bootstrap` flag (true in dev/prod,

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -519,7 +519,7 @@ defmodule Grappa.Application do
     end
   end
 
-  # max_restarts: 60, max_seconds: 60 — the ROOT supervisor ran on OTP's
+  # max_restarts: 80, max_seconds: 120 — the ROOT supervisor ran on OTP's
   # DEFAULT 3-in-5s until 2026-09-08, which is a default and never was a
   # decision: `SessionSupervisor` twenty lines up carries an argued
   # 10_000/60, so the silence here read as "considered" when it was
@@ -537,15 +537,37 @@ defmodule Grappa.Application do
   # ~31 top-level children and most of them touch the Repo, so the default
   # made "the DB is briefly busy" and "kill the node" the same event.
   #
-  # Where the two numbers come from:
+  # Where the two numbers come from — anchored to MEASURED HOLD DURATIONS,
+  # deliberately not to `busy_timeout`:
   #
-  #   max_seconds: 60 — twice `busy_timeout` (30_000, every env), i.e. the
-  #     window has to be able to CONTAIN one saturation episode. A window
-  #     shorter than the stall splits one degradation across two budgets and
-  #     measures nothing.
-  #   max_restarts: 60 — ~2 full sweeps of the ~31-child tree: every
-  #     top-level singleton may die TWICE inside one degradation and the node
-  #     lives. The measured peak is 5, so this clears it 12x over.
+  #   max_seconds: 120 — the window must be able to CONTAIN one saturation
+  #     episode, because a window shorter than the episode counts a
+  #     fragment: the budget then means "restarts per arbitrary slice"
+  #     rather than "restarts per degradation". The 29 stalls logged on
+  #     2026-09-08 fall in three tight clusters — 22 at 31_060–31_457 ms,
+  #     6 at 62_604–62_810 ms, 1 at 94_055 ms — i.e. ratios 1:2:3 off a
+  #     ~31 s unit, so the long ones are two and three units back to back.
+  #     120 s contains the 94 s worst case with margin.
+  #   max_restarts: 80 — worst legitimate case is every top-level child
+  #     dying once per tick for the whole window: the periodic children run
+  #     a 60 s cadence (`reaper_interval_ms/0`) and `init/1` re-arms the
+  #     timer rather than re-querying, so a 120 s window gives each of the
+  #     ~31 children TWO chances to die: ~62. The budget must sit ABOVE
+  #     that, and 80 leaves room for roughly nine more children before the
+  #     derivation needs revisiting. The measured burst peak is 5, so this
+  #     clears it 16x over.
+  #
+  # 🔴 Why NOT `busy_timeout`, which an earlier draft of this comment used:
+  # `busy_timeout` bounds how long a WAITER blocks before giving up. What
+  # this window has to span is the HOLD — how long the winner keeps
+  # RESERVED — and the two are causally unrelated. `LockWatch`'s
+  # `acquired/0` is the first statement inside the transaction fun, which
+  # `DBConnection` only reaches after `BEGIN IMMEDIATE` returns `{:ok, _}`,
+  # so the logged `held_ms` is possession and never queueing. That the two
+  # numbers resembled each other (30 s vs 31 s) was coincidence, and it is
+  # about to stop being one: `busy_timeout` is moving to ~300 ms, under
+  # which the old formula would have produced `max_seconds: 0.6` — which is
+  # the clearest possible proof the relation was never there.
   #
   # Deliberately NOT the sibling's 10_000/60. Under `SessionSupervisor` the
   # children are homogeneous, ephemeral, and restarting IS the recovery
@@ -557,8 +579,8 @@ defmodule Grappa.Application do
   #
   # What must STILL kill the node, on purpose: a non-transient fault — an
   # Endpoint that cannot bind, a Vault with the wrong key, a Repo that
-  # cannot open the file, or any child in a tight crash-loop. 60-in-60 is
-  # 1 restart/s sustained, so a tight loop trips it in well under a minute
+  # cannot open the file, or any child in a tight crash-loop. A tight loop
+  # spends the budget at its own rate, not the window's, so it still trips
   # and the node exits where rc.d can see it. A node that restart-loops
   # forever while looking alive is strictly WORSE for an operator than one
   # that dies.
@@ -566,9 +588,9 @@ defmodule Grappa.Application do
   # ⚠️ What this does NOT cure, stated so nobody reads it as fixed: death 2
   # above. `Grappa.Bootstrap` is `use Task, restart: :transient` and re-runs
   # its credential READ on every restart, so it re-enters the saturated pool
-  # immediately — measured at ~2.8 restarts/s, which exhausts 60-in-60 in
-  # ~21s, well inside a 31s stall. That is a child that does not degrade,
-  # not a budget that is too small, and raising the budget to cover it would
+  # immediately — measured at ~2.8 restarts/s, which exhausts 80 restarts in
+  # ~29s, well inside the 31s hold that causes it. That is a child that does
+  # not degrade, not a budget that is too small, and raising it to cover this would
   # be buying the immortality rejected two paragraphs up. The cure is the
   # `{:error, :db_unavailable}` verb already used in 45 files under `lib/`
   # (`Accounts.Reaper` is the in-house model: "sweep dropped, retrying next
@@ -581,7 +603,7 @@ defmodule Grappa.Application do
   """
   @spec root_supervisor_opts() :: [Supervisor.option()]
   def root_supervisor_opts do
-    [strategy: :one_for_one, name: Grappa.Supervisor, max_restarts: 60, max_seconds: 60]
+    [strategy: :one_for_one, name: Grappa.Supervisor, max_restarts: 80, max_seconds: 120]
   end
 
   # Bootstrap is opt-in via the `:start_bootstrap` flag (true in dev/prod,

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -15,9 +15,9 @@ defmodule Grappa.Repo do
     otp_app: :grappa,
     adapter: Ecto.Adapters.SQLite3
 
-  require Logger
-
   alias Grappa.Repo.LockWatch
+
+  require Logger
 
   # #506 — pre-switch the database to WAL on a SINGLE connection before the pool
   # (or `mix ecto.migrate`'s ≥2 Ecto.Migrator connections) open.

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -15,6 +15,8 @@ defmodule Grappa.Repo do
     otp_app: :grappa,
     adapter: Ecto.Adapters.SQLite3
 
+  require Logger
+
   alias Grappa.Repo.LockWatch
 
   # #506 — pre-switch the database to WAL on a SINGLE connection before the pool
@@ -41,10 +43,69 @@ defmodule Grappa.Repo do
   @impl Ecto.Repo
   def init(context, config) do
     if context == :supervisor do
+      check_dirty_io_reserve(config, :erlang.system_info(:dirty_io_schedulers))
       {:ok, prepare_database!(config)}
     else
       {:ok, config}
     end
+  end
+
+  @doc """
+  Reports, at pool start, when `pool_size` leaves no dirty-IO reserve.
+
+  `@spec check_dirty_io_reserve(keyword(), pos_integer()) :: :ok` — always
+  `:ok`; the only effect is a `Logger.warning` when the reserve is gone.
+
+  ## Why the two numbers have to be compared at all
+
+  Every exqlite call runs inside a `ERL_NIF_DIRTY_JOB_IO_BOUND` NIF, in the
+  CALLING process, and a writer waiting on SQLite's file lock sleeps INSIDE
+  that NIF for up to `busy_timeout` — occupying a dirty-IO scheduler for
+  the whole wait while doing no work. So `pool_size` is not only a
+  connection count: it is the number of dirty-IO schedulers the Repo alone
+  can hold at once. When it reaches the scheduler count, a saturated pool
+  can occupy every one of them, and #1715 already measures what queues
+  behind that occupancy — every `persistent_term` write and every module
+  load in the VM, for the length of the wait.
+
+  ## Why a check and not a well-chosen constant
+
+  The two numbers come from different worlds and neither side can see the
+  other. `pool_size` is ours (`POOL_SIZE`, `config/runtime.exs`); the
+  dirty-IO count is the BEAM's, it is **not** derived from the hardware,
+  and on the substrates that exec the release directly — the FreeBSD jail,
+  the packaged systemd host — nothing in this repo sets `+SDio`, so it is
+  whatever ERTS defaults to. A constant that is correct today is correct
+  only until either side moves, and `GRAPPA_DIRTY_SCHEDULERS` lets an
+  operator move the BEAM side with no floor applied when it is set
+  explicitly (`bin/start.sh` floors only the UNSET case).
+
+  ## Why it warns rather than raises
+
+  The reserve being gone is the posture production ships today, so raising
+  would refuse to boot the very deployments this is meant to inform. The
+  operator must SEE it; the node must still run — and the line names both
+  numbers because whoever reads it in `journalctl` has neither the config
+  nor a running shell.
+  """
+  @spec check_dirty_io_reserve(keyword(), pos_integer()) :: :ok
+  def check_dirty_io_reserve(config, dirty_io_schedulers) do
+    pool_size = Keyword.fetch!(config, :pool_size)
+
+    if pool_size >= dirty_io_schedulers do
+      Logger.warning(
+        "Grappa.Repo: pool_size=#{pool_size} leaves no dirty-IO reserve — this BEAM has " <>
+          "#{dirty_io_schedulers} dirty-IO scheduler(s). Every SQLite call runs inside a " <>
+          "dirty-IO NIF, and a writer waiting on the file lock occupies its scheduler for " <>
+          "the whole wait, so a saturated pool can occupy all of them and stall work that " <>
+          "has nothing to do with the database (see #1715). Lower POOL_SIZE below " <>
+          "#{dirty_io_schedulers}, or raise the dirty-IO count (+SDio). NOTE: DBConnection's " <>
+          "own pool-exhaustion error advises RAISING pool_size — that advice does not hold " <>
+          "here, because the ceiling is the scheduler count and not the pool."
+      )
+    end
+
+    :ok
   end
 
   # Everything that must happen on ONE serial connection, before the pool (or

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -87,25 +87,42 @@ defmodule Grappa.Repo do
   operator must SEE it; the node must still run — and the line names both
   numbers because whoever reads it in `journalctl` has neither the config
   nor a running shell.
+
+  A config that states no `:pool_size` is silent for the same reason. That
+  number is not ours to invent here: what matters is the size the pool
+  actually opens, and its default belongs to DBConnection. Every env this
+  repo ships states it outright (`config/runtime.exs`, `dev.exs` and
+  `test.exs` all set `pool_size:` with a literal default), so an absent key
+  means a caller building a config by hand — a WAL unit test, a one-off
+  tool — for which there is nothing to compare. Raising there would make
+  this check DECIDE whether the Repo may start, which is precisely what it
+  must not do.
   """
   @spec check_dirty_io_reserve(keyword(), pos_integer()) :: :ok
   def check_dirty_io_reserve(config, dirty_io_schedulers) do
-    pool_size = Keyword.fetch!(config, :pool_size)
+    case Keyword.fetch(config, :pool_size) do
+      {:ok, pool_size} when pool_size >= dirty_io_schedulers ->
+        warn_no_reserve(pool_size, dirty_io_schedulers)
 
-    if pool_size >= dirty_io_schedulers do
-      Logger.warning(
-        "Grappa.Repo: pool_size=#{pool_size} leaves no dirty-IO reserve — this BEAM has " <>
-          "#{dirty_io_schedulers} dirty-IO scheduler(s). Every SQLite call runs inside a " <>
-          "dirty-IO NIF, and a writer waiting on the file lock occupies its scheduler for " <>
-          "the whole wait, so a saturated pool can occupy all of them and stall work that " <>
-          "has nothing to do with the database (see #1715). Lower POOL_SIZE below " <>
-          "#{dirty_io_schedulers}, or raise the dirty-IO count (+SDio). NOTE: DBConnection's " <>
-          "own pool-exhaustion error advises RAISING pool_size — that advice does not hold " <>
-          "here, because the ceiling is the scheduler count and not the pool."
-      )
+      # Two different silences, deliberately one arm: a reserve that is
+      # intact, and a config that states no pool size at all.
+      _ ->
+        :ok
     end
+  end
 
-    :ok
+  @spec warn_no_reserve(pos_integer(), pos_integer()) :: :ok
+  defp warn_no_reserve(pool_size, dirty_io_schedulers) do
+    Logger.warning(
+      "Grappa.Repo: pool_size=#{pool_size} leaves no dirty-IO reserve — this BEAM has " <>
+        "#{dirty_io_schedulers} dirty-IO scheduler(s). Every SQLite call runs inside a " <>
+        "dirty-IO NIF, and a writer waiting on the file lock occupies its scheduler for " <>
+        "the whole wait, so a saturated pool can occupy all of them and stall work that " <>
+        "has nothing to do with the database (see #1715). Lower POOL_SIZE below " <>
+        "#{dirty_io_schedulers}, or raise the dirty-IO count (+SDio). NOTE: DBConnection's " <>
+        "own pool-exhaustion error advises RAISING pool_size — that advice does not hold " <>
+        "here, because the ceiling is the scheduler count and not the pool."
+    )
   end
 
   # Everything that must happen on ONE serial connection, before the pool (or

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -63,23 +63,31 @@ defmodule Grappa.Repo.BusyRetry do
       `config/config.exs` sizes it against "the ~1s pool-saturation window the
       #336 incident measured".
     * a write-lock `busy_locked` fault raises only once SQLite's
-      `busy_timeout` has expired — 30_000ms in every env, 20x the budget. The
-      first attempt has therefore already overshot the deadline by the time it
-      returns, so the loop makes EXACTLY ONE attempt and the linear backoff
-      below never runs.
-    * an `:interrupted` fault (#1657) shares that second regime, and saying
-      so is the point. It is raised when DBConnection's own `:timeout`
-      (15_000ms by default, 10x the budget) cancels the statement, so the
-      first attempt has ALREADY overshot by the time it returns and the loop
-      makes exactly one attempt here too. 🔴 So do not read #1657's
-      reclassification as "the row now gets retried" — in the live topology
-      it does not. What changed is that a pool-induced cancellation stops
-      being reported as CORRUPTION: it degrades to `{:error, :db_unavailable}`
-      (a 503 on a stateless web write, an honest drop in `Scrollback`)
-      instead of re-raising as a 500, and it is countable as its own state.
-      Making the budget actually REACH this regime is the same
-      re-dimensioning question #1421 prices, and it is not this module's to
-      take unilaterally.
+      `busy_timeout` has expired. **This regime CHANGED when the contention
+      ladder was chosen as a ladder**: `busy_timeout` was `30_000` in every
+      env — 20x the budget, so the first attempt had already overshot the
+      deadline by the time it returned and the loop made EXACTLY ONE attempt
+      with the linear backoff below never running. It is now `300` in prod
+      and dev (`config/runtime.exs`, `config/dev.exs`), a fifth of the
+      budget, which puts this topology INSIDE the budget for the first time:
+      four to five attempts, backoff included. That is not a prediction —
+      `Grappa.Repo.BusyRetryBudgetReachTest` measures both regimes against a
+      real held write lock, and the below-budget arm is the one prod now
+      runs in.
+    * an `:interrupted` fault (#1657) does NOT follow it, and saying so is
+      the point. It is raised when DBConnection's own `:timeout` (15_000ms,
+      10x the budget) cancels the statement, so the first attempt has
+      ALREADY overshot by the time it returns and the loop makes exactly one
+      attempt here. 🔴 So do not read #1657's reclassification as "the row
+      now gets retried" — in this topology it does not. What changed is that
+      a pool-induced cancellation stops being reported as CORRUPTION: it
+      degrades to `{:error, :db_unavailable}` (a 503 on a stateless web
+      write, an honest drop in `Scrollback`) instead of re-raising as a 500,
+      and it is countable as its own state. That is BY DESIGN in the ladder
+      rather than an oversight: `:timeout` is the ladder's OUTER bound, the
+      rung nothing below it should ever reach, so a fault that only appears
+      when it fires is by construction past the point where riding it out
+      makes sense.
 
   A third topology WOULD fall inside the budget — a deferred read->write
   upgrade raises an immediate `SQLITE_BUSY` that `busy_timeout` does not cover
@@ -87,11 +95,13 @@ defmodule Grappa.Repo.BusyRetry do
   `Grappa.Repo.immediate_transaction/1`, statically enforced by
   `Grappa.Repo.TransactionModeGateTest` (#1374).
 
-  The second regime is a DOCUMENTED LIMITATION rather than a wiring slip: one
-  number was dimensioned for one topology and later reused for another.
-  Re-dimensioning it changes retry behaviour under contention — #1420's
-  contested axis, and not this module's decision to take. What IS this
-  module's to take is to stop describing a bound it does not have, which is
+  The `busy_locked` regime WAS a documented limitation of exactly that shape —
+  one number dimensioned for one topology and later reused for another — and
+  the re-dimensioning #1421 priced has now been taken, from the other side:
+  not by growing the budget, but by shrinking the wait the budget has to
+  cover, so the caller-visible bound is unchanged while the engine becomes
+  reachable. The `:interrupted` regime is unchanged and deliberate (above).
+  Either way this module still describes only the bound it HAS, which is
   why the terminal line below reports the wait it OBSERVED and never the
   budget it was handed. Measured in
   `Grappa.Repo.BusyRetryBudgetReachTest`; the options are priced in #1421.

--- a/test/grappa/application_root_supervisor_limits_test.exs
+++ b/test/grappa/application_root_supervisor_limits_test.exs
@@ -1,0 +1,169 @@
+defmodule Grappa.ApplicationRootSupervisorLimitsTest do
+  # The root supervisor's restart budget, pinned from BOTH sides.
+  #
+  # `Grappa.Supervisor` used to start with no `max_restarts`/`max_seconds`,
+  # i.e. OTP's default 3-in-5s — a default, never a decision. The sibling
+  # `SessionSupervisor` two lines above carries an argued 10_000/60, so the
+  # absence here read as "considered and left alone" when it was
+  # "never considered".
+  #
+  # Measured on the m42 jail, 2026-09-08, two node deaths in half an hour:
+  #
+  #   20:36:31.150–.472   4 top-level children in   322 ms  (three Reapers + AdminEvents)
+  #   21:06:38.979–40.053 5 top-level children in 1_070 ms  (of which Bootstrap x3)
+  #
+  # Both bursts are ONE correlated degradation — the SQLite pool saturating —
+  # arriving at several Repo-reading singletons at once. Three of them inside
+  # 5s is enough to take the node down, and that is what happened.
+  #
+  # The two tests below are a PAIR and neither is redundant:
+  #
+  #   1. the budget must ABSORB a correlated burst — else the fix cures nothing;
+  #   2. the budget must still GIVE UP — else the fix trades a node that dies
+  #      loudly for a node that restart-loops forever while looking alive,
+  #      which is strictly worse for an operator (rc.d sees a live service).
+  #
+  # Test 2 is the one that stops a future "just raise it to 10_000" from
+  # sailing through green: copying the SessionSupervisor's budget here would
+  # make the root effectively immortal (~167 restarts/s sustained).
+  use ExUnit.Case, async: true
+
+  # The measured worst correlated burst (5 children in 1.07s). The budget has
+  # to sit ABOVE this or it does not cure the incident it was written for.
+  @measured_correlated_burst 5
+
+  # A restart takes microseconds here, so a burst is delivered well inside any
+  # sane `max_seconds`; the deadline only guards against a wedged supervisor.
+  @await_ms 2_000
+
+  describe "the root supervisor's restart budget" do
+    test "declares an explicit budget rather than inheriting OTP's 3-in-5s default" do
+      opts = Grappa.Application.root_supervisor_opts()
+
+      assert Keyword.fetch!(opts, :strategy) == :one_for_one
+
+      assert is_integer(Keyword.get(opts, :max_restarts)),
+             "the root supervisor must state its restart budget: an absent max_restarts " <>
+               "silently means 3-in-5s, which a correlated degradation clears trivially"
+
+      assert is_integer(Keyword.get(opts, :max_seconds))
+    end
+
+    test "absorbs the measured correlated burst of #{@measured_correlated_burst} child deaths" do
+      Process.flag(:trap_exit, true)
+      sup = start_probe_supervisor(@measured_correlated_burst)
+
+      for id <- 1..@measured_correlated_burst do
+        kill_and_await_restart(sup, id)
+      end
+
+      assert Process.alive?(sup),
+             "the root supervisor gave up after #{@measured_correlated_burst} correlated " <>
+               "child deaths — this is the 2026-09-08 node death, unfixed"
+
+      assert length(Supervisor.which_children(sup)) == @measured_correlated_burst
+    end
+
+    test "still gives up on a child that exceeds the budget, so a wedged node dies loudly" do
+      Process.flag(:trap_exit, true)
+      budget = Keyword.fetch!(Grappa.Application.root_supervisor_opts(), :max_restarts)
+
+      sup = start_probe_supervisor(1)
+      ref = Process.monitor(sup)
+
+      # One child, killed until the supervisor gives up: the shape of a
+      # genuine crash-loop (bad config, unbindable port, a boot read that
+      # cannot succeed), not of a transient degradation. Each kill WAITS for
+      # the restart, so the kills and the restarts are one-to-one — killing
+      # a pid the supervisor has not replaced yet costs no budget at all.
+      kills = kill_until_supervisor_gives_up(sup, 1, budget + 1)
+
+      assert_receive {:DOWN, ^ref, :process, ^sup, _reason},
+                     @await_ms,
+                     "the root supervisor absorbed #{kills} restarts of a single child: " <>
+                       "the budget is no longer a protection, it is an infinite loop"
+    end
+  end
+
+  # --- probe supervisor -------------------------------------------------
+  #
+  # Runs the PRODUCTION opts (only the registered name is swapped, so the
+  # probe cannot collide with the real tree) over trivial children. What is
+  # under test is the budget, not the children.
+
+  defp start_probe_supervisor(child_count) do
+    probe_name = :"#{__MODULE__}.Probe.#{System.unique_integer([:positive])}"
+    opts = Keyword.replace!(Grappa.Application.root_supervisor_opts(), :name, probe_name)
+
+    children =
+      for id <- 1..child_count do
+        Supervisor.child_spec({Agent, fn -> id end}, id: id)
+      end
+
+    # Linked to the test process, so it dies with the test — no on_exit stop,
+    # which would race that same teardown and exit `:shutdown`.
+    {:ok, sup} = Supervisor.start_link(children, opts)
+    sup
+  end
+
+  defp kill_and_await_restart(sup, id) do
+    case kill_and_settle(sup, id) do
+      {:restarted, pid} -> pid
+      :supervisor_gave_up -> flunk("supervisor died while awaiting the restart of child #{id}")
+      :timeout -> flunk("child #{id} was not restarted within #{@await_ms}ms")
+    end
+  end
+
+  defp kill_until_supervisor_gives_up(sup, id, max_kills) do
+    Enum.reduce_while(1..max_kills, 0, fn n, _ ->
+      case kill_and_settle(sup, id) do
+        {:restarted, _} -> {:cont, n}
+        :supervisor_gave_up -> {:halt, n}
+        :timeout -> {:halt, n}
+      end
+    end)
+  end
+
+  # Kills the child and returns only once the supervisor has SETTLED: either
+  # it replaced the child (one restart spent) or it exhausted its budget.
+  defp kill_and_settle(sup, id) do
+    case child_pid(sup, id) do
+      old when is_pid(old) ->
+        Process.exit(old, :kill)
+        await_settle(sup, id, old, System.monotonic_time(:millisecond) + @await_ms)
+
+      _ ->
+        :supervisor_gave_up
+    end
+  end
+
+  defp await_settle(sup, id, old, deadline) do
+    cond do
+      not Process.alive?(sup) ->
+        :supervisor_gave_up
+
+      System.monotonic_time(:millisecond) > deadline ->
+        :timeout
+
+      true ->
+        case child_pid(sup, id) do
+          pid when is_pid(pid) and pid != old -> {:restarted, pid}
+          _ -> await_settle(sup, id, old, deadline)
+        end
+    end
+  end
+
+  defp child_pid(sup, id) do
+    sup
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn
+      {^id, pid, _, _} -> pid
+      _ -> nil
+    end)
+  rescue
+    # `which_children` on a supervisor that just exited.
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+end

--- a/test/grappa/config/repo_caller_deadline_pin_test.exs
+++ b/test/grappa/config/repo_caller_deadline_pin_test.exs
@@ -1,0 +1,92 @@
+defmodule Grappa.Config.RepoCallerDeadlinePinTest do
+  @moduledoc """
+  `:timeout` — the DBConnection caller deadline — must be CHOSEN, in every
+  env, not inherited from Ecto.
+
+  ## Why a pin, when the value does not change
+
+  Pinning it is byte-for-byte the behaviour that shipped before: Ecto's
+  own default is `15_000` (`Ecto.Repo.Supervisor`'s `@defaults`, merged
+  into the config BEFORE `Grappa.Repo.init/2` ever sees it). That is
+  exactly the argument `config/runtime.exs` already makes for pinning
+  `synchronous` and `foreign_keys` (REV-B/C3): a default that is "right by
+  accident" is one dep major-version flip away from moving under prod with
+  no diff, no log line, and no migration.
+
+  It carries extra weight here because this number is half of a PAIR. The
+  DB-side wait (`busy_timeout`, 30_000) was chosen; the caller-side
+  deadline it should have been chosen against never was, and that is how
+  the two came to sit at 30_000 against 15_000 — the caller giving up
+  first, and DBConnection DESTROYING the connection when it does
+  (`ConnectionPool.handle_info({:timeout, …})` → `Holder.handle_disconnect/2`),
+  not merely failing the call. Whether those two numbers are the RIGHT
+  pair is a separate, open question; this pin only ensures both are
+  answers rather than one answer and one accident.
+
+  ## Why the file and not the runtime config
+
+  `Grappa.Repo.config()` cannot tell the two apart: an inherited `15_000`
+  and a written `15_000` are the same keyword list by the time anything
+  can read it. Only the source distinguishes "chosen" from "defaulted", so
+  the source is what this reads — the same reason
+  `Grappa.Config.EnvRegistryDriftTest` parses files rather than state.
+  """
+
+  use ExUnit.Case, async: true
+
+  @configs ~w(config/runtime.exs config/dev.exs config/test.exs)
+
+  defp read!(path), do: File.read!(Path.expand(path, File.cwd!()))
+
+  # Lines whose TRIMMED form starts with the given key, so `busy_timeout:`
+  # never answers for `timeout:`.
+  defp assignments(source, key) do
+    source
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.filter(&String.starts_with?(&1, key <> ":"))
+  end
+
+  describe "derivation self-check (guards against a vacuously-green pin)" do
+    test "the scanner finds real content in every config it pins" do
+      # Positive control: `busy_timeout` is present in all three today and
+      # is not what this file is about. If the scanner broke, this fails
+      # before the pin below can pass by reading nothing.
+      for path <- @configs do
+        assert length(assignments(read!(path), "busy_timeout")) == 1,
+               "#{path}: scanner found no busy_timeout — the pin below would be vacuous"
+      end
+    end
+
+    test "the matcher does not let busy_timeout answer for timeout" do
+      # Negative control on the matcher itself, not on the repo.
+      assert assignments("  busy_timeout: 30_000,", "timeout") == []
+      assert assignments("  timeout: 15_000,", "timeout") == ["timeout: 15_000,"]
+    end
+  end
+
+  describe "the caller deadline is written down, in every env" do
+    test "each config sets :timeout exactly once, explicitly" do
+      for path <- @configs do
+        found = assignments(read!(path), "timeout")
+
+        assert length(found) == 1,
+               "#{path}: expected exactly one explicit `timeout:` in the Grappa.Repo " <>
+                 "config, found #{inspect(found)}. An unset :timeout silently inherits " <>
+                 "Ecto's default — see this module's docs."
+      end
+    end
+
+    test "and sets it to the value that was already in force" do
+      # The pin is about the number being CHOSEN, not about changing it.
+      # Moving it is a behaviour change and belongs to the open question
+      # about the whole ladder, not to this pin.
+      for path <- @configs do
+        [line] = assignments(read!(path), "timeout")
+
+        assert String.starts_with?(line, "timeout: 15_000"),
+               "#{path}: expected the pin to carry the value already in force, got #{line}"
+      end
+    end
+  end
+end

--- a/test/grappa/config/substrate_beam_knob_honesty_test.exs
+++ b/test/grappa/config/substrate_beam_knob_honesty_test.exs
@@ -61,13 +61,19 @@ defmodule Grappa.Config.SubstrateBeamKnobHonestyTest do
 
   defp read!(path), do: File.read!(Path.expand(path, File.cwd!()))
 
+  # Every line, stripped of indentation and of a leading comment marker, so
+  # a commented knob reads the same as a live one — the whole point being
+  # that a commented assignment exists to be uncommented.
+  defp normalized_lines(source) do
+    source
+    |> String.split("\n")
+    |> Enum.map(fn line -> line |> String.trim() |> String.trim_leading("#") |> String.trim() end)
+  end
+
   # `FOO=`, with or without a leading comment marker and whitespace.
   defp assignment_lines(source, var) do
     source
-    |> String.split("\n")
-    |> Enum.map(&String.trim/1)
-    |> Enum.map(&String.trim_leading(&1, "#"))
-    |> Enum.map(&String.trim/1)
+    |> normalized_lines()
     |> Enum.filter(&String.starts_with?(&1, var <> "="))
   end
 
@@ -163,12 +169,13 @@ defmodule Grappa.Config.SubstrateBeamKnobHonestyTest do
       ]
 
       for path <- surfaces do
+        # NOT `assignment_lines/2`: compose.yaml spells it `POOL_SIZE: ${…}`,
+        # a YAML key rather than a shell assignment, and it is one of the
+        # surfaces that must agree.
         stated =
-          read!(path)
-          |> String.split("\n")
-          |> Enum.map(&String.trim/1)
-          |> Enum.map(&String.trim_leading(&1, "#"))
-          |> Enum.map(&String.trim/1)
+          path
+          |> read!()
+          |> normalized_lines()
           |> Enum.filter(&String.starts_with?(&1, "POOL_SIZE"))
 
         assert stated != [], "#{path}: POOL_SIZE vanished — matcher broken or surface gone"

--- a/test/grappa/config/substrate_beam_knob_honesty_test.exs
+++ b/test/grappa/config/substrate_beam_knob_honesty_test.exs
@@ -1,0 +1,196 @@
+defmodule Grappa.Config.SubstrateBeamKnobHonestyTest do
+  @moduledoc """
+  An operator env-example may only advertise knobs that its OWN substrate
+  reads.
+
+  ## The drift this pins
+
+  `GRAPPA_MAX_USERS` and `GRAPPA_DIRTY_SCHEDULERS` are read by exactly two
+  files — `bin/start.sh` (dev compose, `mix phx.server`) and
+  `infra/docker/release-entrypoint.sh` (the published release image) —
+  which turn them into `+Q`/`+P`/`+SDcpu`/`+SDio`. Both are CONTAINER
+  entrypoints.
+
+  The FreeBSD jail (`infra/freebsd/rc.d/grappa`) and the packaged systemd
+  host (`infra/packaging/grappa.service`) exec the release directly;
+  `infra/release/grappa.sh` and `infra/packaging/grappa-wrapper.sh` set no
+  BEAM flags at all. So on those two substrates the variables are read by
+  nothing — and both example files nevertheless listed them under a
+  "BEAM resource caps" heading, in the one file a self-hoster is told to
+  edit.
+
+  ## What is NOT wrong here, measured before asserting
+
+  The absence of the caps themselves on those substrates is DELIBERATE and
+  documented: `docs/OPERATIONS.md` § `release-entrypoint.sh` explains that
+  a baked `rel/vm.args` "would ship inside the release and so change the
+  jail, `.deb` and `.rpm` consumers too, and these caps are THIS image's
+  concern" — they cure a Docker-specific inherited `NOFILE`. This pin is
+  therefore about the ADVERTISEMENT, not about the missing flags. Wiring
+  the knobs into those substrates would contradict a standing decision;
+  listing them there contradicts reality. Only the second is a defect.
+
+  ## Assignment form, not mention
+
+  The examples may — and should — NAME the variables in prose to explain
+  why they do nothing locally. What they must not carry is an assignment
+  line, commented or not, because a commented assignment exists to be
+  uncommented.
+
+  ## And the other half: the lever that DOES work must be there
+
+  Removing a dead knob without offering the live one would leave the
+  substrate with no documented way to size its BEAM at all, which is a
+  different lie by omission. `ERL_ZFLAGS` is that lever on both release
+  substrates — the jail's rc.d sources this file and exports every
+  `^[A-Z_]` name in it, systemd loads it via `EnvironmentFile`, and
+  erlexec appends `ERL_ZFLAGS` to the release's boot flags. So the pin has
+  two sides: no assignment for the knob that does nothing, and a documented
+  `ERL_ZFLAGS` for the one that does.
+  """
+
+  use ExUnit.Case, async: true
+
+  @container_only ~w(GRAPPA_MAX_USERS GRAPPA_DIRTY_SCHEDULERS)
+
+  # Substrates whose start path is the release itself, no entrypoint.
+  @release_examples ~w(infra/freebsd/grappa.env.example infra/linux/grappa.env.example)
+
+  # The Docker operator file, where the same names are legitimate.
+  @docker_example ".env.example"
+
+  defp read!(path), do: File.read!(Path.expand(path, File.cwd!()))
+
+  # `FOO=`, with or without a leading comment marker and whitespace.
+  defp assignment_lines(source, var) do
+    source
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.map(&String.trim_leading(&1, "#"))
+    |> Enum.map(&String.trim/1)
+    |> Enum.filter(&String.starts_with?(&1, var <> "="))
+  end
+
+  describe "derivation self-check (guards against a vacuously-green pin)" do
+    test "the matcher finds the assignments where they legitimately live" do
+      # Positive control: if this stops finding them in the Docker example,
+      # the matcher is broken and the refutations below prove nothing.
+      for var <- @container_only do
+        assert assignment_lines(read!(@docker_example), var) != [],
+               "#{@docker_example}: expected #{var} to be documented here — " <>
+                 "matcher may be broken, which would make this whole file vacuous"
+      end
+    end
+
+    test "the matcher distinguishes an assignment from a mention" do
+      assert assignment_lines("# GRAPPA_MAX_USERS=100", "GRAPPA_MAX_USERS") == [
+               "GRAPPA_MAX_USERS=100"
+             ]
+
+      assert assignment_lines("GRAPPA_MAX_USERS=100", "GRAPPA_MAX_USERS") == [
+               "GRAPPA_MAX_USERS=100"
+             ]
+
+      assert assignment_lines("# GRAPPA_MAX_USERS is read only by bin/start.sh", "GRAPPA_MAX_USERS") ==
+               []
+    end
+
+    test "the substrates under test really do exec the release directly" do
+      # The premise of the whole file. If someone later adds an entrypoint
+      # that reads these, this test fails and the pin below should go.
+      refute read!("infra/packaging/grappa.service") =~ "ERL_ZFLAGS"
+      refute read!("infra/release/grappa.sh") =~ "ERL_ZFLAGS"
+      refute read!("infra/packaging/grappa-wrapper.sh") =~ "ERL_ZFLAGS"
+      refute read!("infra/freebsd/rc.d/grappa") =~ "ERL_ZFLAGS"
+
+      # ...and that the two that DO read them still do.
+      assert read!("bin/start.sh") =~ "+SDio"
+      assert read!("infra/docker/release-entrypoint.sh") =~ "+SDio"
+    end
+  end
+
+  describe "release substrates do not advertise container-only knobs" do
+    test "no assignment line for a variable the substrate cannot read" do
+      for path <- @release_examples, var <- @container_only do
+        assert assignment_lines(read!(path), var) == [],
+               "#{path} offers `#{var}=` as an operator knob, but nothing on this " <>
+                 "substrate reads it: the release is exec'd directly, with no entrypoint. " <>
+                 "Explain it in prose instead of offering an assignment."
+      end
+    end
+  end
+
+  describe "release substrates document the lever that DOES work" do
+    test "each offers ERL_ZFLAGS, with +SDio named" do
+      for path <- @release_examples do
+        source = read!(path)
+
+        assert assignment_lines(source, "ERL_ZFLAGS") != [],
+               "#{path} removes the container-only knobs but offers no working " <>
+                 "alternative — the substrate is left with no documented way to size " <>
+                 "its BEAM at all."
+
+        assert source =~ "+SDio",
+               "#{path}: ERL_ZFLAGS is offered without naming the flag that matters " <>
+                 "for a SQLite pool — see this module's docs."
+      end
+    end
+
+    test "and say what raising it does NOT buy" do
+      # The measured trap: more dirty-IO threads buy reserve while a
+      # writer is parked, never write throughput — SQLite has one writer.
+      # An operator who reads this as a throughput knob will raise it and
+      # conclude grappa is slow.
+      for path <- @release_examples do
+        assert read!(path) =~ "one writer",
+               "#{path}: +SDio is documented without the single-writer caveat"
+      end
+    end
+  end
+
+  describe "the pool default agrees across every surface that states it" do
+    test "no surface still advertises the pre-reserve default" do
+      # The drift the 2026-07-20 architecture review named: one env var
+      # declared in up to seven places with nothing checking agreement.
+      # POOL_SIZE moved, so every surface that names a value must move
+      # with it or the operator reads a number the app does not use.
+      surfaces = [
+        ".env.example",
+        "compose.yaml",
+        "infra/freebsd/grappa.env.example",
+        "infra/linux/grappa.env.example",
+        "infra/packaging/grappa.env.example"
+      ]
+
+      for path <- surfaces do
+        stated =
+          read!(path)
+          |> String.split("\n")
+          |> Enum.map(&String.trim/1)
+          |> Enum.map(&String.trim_leading(&1, "#"))
+          |> Enum.map(&String.trim/1)
+          |> Enum.filter(&String.starts_with?(&1, "POOL_SIZE"))
+
+        assert stated != [], "#{path}: POOL_SIZE vanished — matcher broken or surface gone"
+
+        refute Enum.any?(stated, &String.contains?(&1, "10")),
+               "#{path} still states the old pool default: #{inspect(stated)}"
+      end
+    end
+  end
+
+  describe "the Docker example states the default it actually gets" do
+    test "the dirty-scheduler default is documented with its floor" do
+      # `bin/start.sh` floors the default at 10 (`if [ "$d" -lt 10 ]`), so
+      # a bare `$(nproc)` under-states it on every host with fewer than 10
+      # CPUs — which is most of them, and all of the small ones this file
+      # is written for.
+      source = read!(@docker_example)
+
+      refute source =~ "GRAPPA_DIRTY_SCHEDULERS=$(nproc)",
+             ".env.example documents the pre-floor default; bin/start.sh applies max(nproc, 10)"
+
+      assert source =~ "max(nproc, 10)"
+    end
+  end
+end

--- a/test/grappa/repo/checkout_deadline_reach_test.exs
+++ b/test/grappa/repo/checkout_deadline_reach_test.exs
@@ -5,8 +5,8 @@ defmodule Grappa.Repo.CheckoutDeadlineReachTest do
 
   ## Why the question is load-bearing
 
-  Production stacks THREE waits on one write, and nothing had ever
-  checked them against each other:
+  Production stacks THREE waits on one write, and when this file was
+  written nothing had ever checked them against each other:
 
       busy_retry budget   1_500ms   config/config.exs
       checkout deadline  15_000ms   Ecto's default `:timeout`, not overridden anywhere
@@ -17,16 +17,32 @@ defmodule Grappa.Repo.CheckoutDeadlineReachTest do
   kind, `:interrupted`, and named its cause: the checkout deadline
   firing, which disconnects the holder (`db_connection`'s
   `ConnectionPool.handle_info({:timeout, …})` → `Holder.handle_disconnect/2`)
-  and cancels the statement. That deadline sits BETWEEN the other two
-  numbers, so which one governs is not a detail.
+  and cancels the statement. That deadline sat BETWEEN the other two
+  numbers, so which one governed was not a detail.
+
+  🔴 **That stack is now HISTORY, and this file is part of why.** The four
+  numbers were subsequently chosen together as a ladder, and both ends
+  moved: `busy_timeout` is `300` and the checkout deadline is pinned
+  explicitly at `15_000` (with `queue_target` chosen at `1_500` alongside).
+  So in production today the deadline is no longer the middle number — it
+  is the OUTER bound, fifty times the DB-side wait, and the ordering this
+  file was written to disambiguate is no longer ambiguous there.
+
+  The file keeps its value for two reasons and is not deleted: the
+  measurement below is what established that the caller sees `busy_locked`
+  under EITHER ordering (so the ladder could be re-ordered without changing
+  how faults are named), and it remains the guard that says so if either
+  number moves again.
 
   ## Method
 
   ONE independent variable per test: **which of the two numbers is
   smaller.** Same engine, same real held write lock, same statement; the
   verdict is named by production's own `BusyRetry.classify/1`, never by a
-  literal here. Magnitudes are scaled down with the RATIO preserved
-  (production is 15_000 : 30_000, i.e. 1:2; this runs 300 : 600) — the
+  literal here. Magnitudes are scaled down with the RATIO preserved as it
+  stood when the reading was taken (production was then 15_000 : 30_000,
+  i.e. 1:2; this runs 300 : 600 — and note the ladder has since inverted
+  that ratio in prod, which is the point of the note above) — the
   same methodology `Grappa.Repo.BusyRetryBudgetReachTest` justifies for
   the budget, and it keeps the file under two seconds.
 

--- a/test/grappa/repo/dirty_io_reserve_test.exs
+++ b/test/grappa/repo/dirty_io_reserve_test.exs
@@ -1,0 +1,105 @@
+defmodule Grappa.Repo.DirtyIoReserveTest do
+  @moduledoc """
+  The boot-time pool-vs-dirty-IO reserve check.
+
+  ## What it guards, and why a constant cannot
+
+  Every SQLite call in this app runs inside a `ERL_NIF_DIRTY_JOB_IO_BOUND`
+  NIF (exqlite), and a writer waiting on the file lock sleeps INSIDE that
+  NIF — so it occupies a dirty-IO scheduler for the whole wait without
+  doing any work. If `pool_size` reaches the dirty-IO scheduler count, a
+  saturated pool can occupy every one of them and starve the rest of the
+  node.
+
+  The two numbers come from different worlds and neither can see the
+  other: `pool_size` is ours (`config/runtime.exs`, `POOL_SIZE`), while the
+  dirty-IO count is the BEAM's and is NOT derived from the hardware —
+  ERTS's default does not follow the core count, and on the substrates
+  that exec the release directly (the FreeBSD jail, the `.deb`/systemd
+  host) nothing in this repo sets `+SDio` at all. A constant chosen today
+  is therefore right only until somebody moves either side, and
+  `GRAPPA_DIRTY_SCHEDULERS` lets an operator move the BEAM side with no
+  floor applied. Hence a CHECK rather than a bigger comment.
+
+  ## Both arms, on purpose
+
+  A warning that cannot stay silent is not a check — it is a banner. The
+  silent arm is what makes the firing arm evidence, so both are asserted
+  here, and the scheduler count is a PARAMETER rather than a
+  `system_info/1` read so neither arm depends on the host running the
+  suite.
+  """
+
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  describe "check_dirty_io_reserve/2 fires when the reserve is gone" do
+    test "warns when pool_size EQUALS the dirty-IO scheduler count" do
+      log = capture_log(fn -> Grappa.Repo.check_dirty_io_reserve([pool_size: 10], 10) end)
+
+      assert log =~ "dirty-IO"
+      # Both numbers must be nameable from the line alone — an operator
+      # reading it in journalctl has neither config nor a running IEx.
+      assert log =~ "pool_size=10"
+      assert log =~ "10 dirty-IO scheduler"
+    end
+
+    test "warns when pool_size EXCEEDS the dirty-IO scheduler count" do
+      log = capture_log(fn -> Grappa.Repo.check_dirty_io_reserve([pool_size: 16], 10) end)
+
+      assert log =~ "pool_size=16"
+      assert log =~ "10 dirty-IO scheduler"
+    end
+
+    test "names the counter-advice, because the pool's own error contradicts it" do
+      # DBConnection's pool-exhaustion message advises "Increasing the
+      # pool_size", which is the opposite of what helps here. That advice
+      # is the first thing an operator meets at 3 a.m., so the warning has
+      # to answer it in place rather than leave the two to disagree.
+      log = capture_log(fn -> Grappa.Repo.check_dirty_io_reserve([pool_size: 10], 10) end)
+
+      assert log =~ "POOL_SIZE"
+      assert log =~ "+SDio"
+    end
+  end
+
+  describe "check_dirty_io_reserve/2 stays silent when a reserve exists" do
+    test "says nothing when pool_size is below the dirty-IO scheduler count" do
+      log = capture_log(fn -> Grappa.Repo.check_dirty_io_reserve([pool_size: 5], 10) end)
+
+      refute log =~ "dirty-IO"
+    end
+
+    test "says nothing one short of the ceiling — the boundary is `>=`, not `>`" do
+      log = capture_log(fn -> Grappa.Repo.check_dirty_io_reserve([pool_size: 9], 10) end)
+
+      refute log =~ "dirty-IO"
+    end
+
+    test "the suite's own configuration is in the silent arm" do
+      # config/test.exs runs pool_size: 1. If this ever fires, every other
+      # test in the suite starts carrying an unrelated warning in its
+      # captured log, which is how a check becomes noise nobody reads.
+      pool_size = Keyword.fetch!(Grappa.Repo.config(), :pool_size)
+
+      log = capture_log(fn -> Grappa.Repo.check_dirty_io_reserve([pool_size: pool_size], 10) end)
+
+      refute log =~ "dirty-IO"
+    end
+  end
+
+  describe "returns :ok either way" do
+    test "the check reports, it never decides" do
+      # Deliberately NOT a raise. The reserve being gone is the shipped
+      # production posture today (pool_size 10 against an ERTS default of
+      # 10 dirty-IO schedulers), so refusing to boot on it would refuse to
+      # boot production. The operator must SEE it; the node must still run.
+      assert capture_log(fn ->
+               assert Grappa.Repo.check_dirty_io_reserve([pool_size: 10], 10) == :ok
+             end) =~ "dirty-IO"
+
+      assert Grappa.Repo.check_dirty_io_reserve([pool_size: 1], 10) == :ok
+    end
+  end
+end

--- a/test/grappa/repo/dirty_io_reserve_test.exs
+++ b/test/grappa/repo/dirty_io_reserve_test.exs
@@ -77,6 +77,17 @@ defmodule Grappa.Repo.DirtyIoReserveTest do
       refute log =~ "dirty-IO"
     end
 
+    test "says nothing when the config does not state a pool size at all" do
+      # `init/2` is called with whatever config it is handed, and a caller that
+      # builds one by hand — the WAL unit tests, a one-off tool — has no reason
+      # to carry a pool size. Raising there would make this check DECIDE
+      # whether the Repo may start, which is exactly what it must not do.
+      log = capture_log(fn -> Grappa.Repo.check_dirty_io_reserve([database: ":memory:"], 10) end)
+
+      refute log =~ "dirty-IO"
+      assert Grappa.Repo.check_dirty_io_reserve([database: ":memory:"], 10) == :ok
+    end
+
     test "the suite's own configuration is in the silent arm" do
       # config/test.exs runs pool_size: 1. If this ever fires, every other
       # test in the suite starts carrying an unrelated warning in its


### PR DESCRIPTION
Union of **PR 2005** (w1 — root supervisor restart budget) and **PR 2008**
(w2 — SQLite contention ladder + dirty-IO reserve check), built by MERGE onto
`e9bc2ed05`. Neither branch is rebased, and neither should be merged
separately: this branch is the one that gets a CI run.

## Why a union and not two rebases in a row

**The composed run is the honest gate — neither green attests the PAIR.**
PR 2005 gives the root supervisor a restart budget (`max_restarts 80 /
max_seconds 120`) derived from measured holds. PR 2008 changes `pool_size`
and `busy_timeout` and adds a boot-time check *inside* `Repo.init/2` — and
`Grappa.Repo` is a child of that root. During PR 2008's own gate a
`KeyError :pool_size` was found living in exactly that `init/2`, visible only
once something actually exercised it. The question "does the node still boot,
and does the root budget still behave the way it was argued" is answered by
neither branch alone.

Two smaller reasons. Serialised, it costs two full CI cycles, because PR 2008
goes back to conflicting the moment PR 2005 lands. And both heads stay
**ancestors** of this branch, so GitHub marks both of them merged on their
own — no closing by hand, no authorship lost.

**Why merge and not rebase PR 2008.** A rebase rewrites its shas, so
`ef5c44d04` would stop being an ancestor and GitHub would no longer mark that
PR merged — the same defect a cherry-pick has, plus it takes the other
branch's authorship with it. Measured before choosing: the rebased head
`64b9259` does not contain `ef5c44d04` (different trees, `639dac5` vs
`ddb9764`), so that path was rejected and the two REMOTE heads were merged
instead. The locally rebased branch is unused and unpublished.

## What was measured, against a prediction written first

The arithmetic was written down **before** the merge and then checked.

| term | predicted | measured |
|---|---|---|
| `DESIGN_NOTES.md` bytes | 2880456 + 0 + 8520 = **2888976** | 2888976 |
| `DESIGN_NOTES.md` lines | 49196 + 0 + 150 = **49346** | 49346 |
| entry markers | 325 + 0 + 1 = **326** | 326 |
| numstat vs main | 18 files, **+1260 / -79** | 18 files, +1260 / -79 |
| `DESIGN_NOTES.md` numstat | **150 / 0** | 150 / 0 |

- **Whole-file byte compare**: the union's `DESIGN_NOTES.md` is byte-identical
  to `main's copy ++ PR 2008's 150-line tail`. That subsumes the tail-eating
  failure mode, which a numstat check cannot see.
- **Prefix compare**: the first 2880456 bytes equal main's copy exactly.
- **Boundary shape, read on the real file**: end of the preceding entry /
  marker with no blank line before it / blank / `---` / blank / `## `.
- **Marker uniqueness**, exact whole-line match against the new tip: 1 in this
  file, 0 in main's; no duplicate markers anywhere. Positive control: main
  does carry the marker of its own last entry.
- `scripts/design-notes-gate.sh` → `rc=0`.
- **Ancestry**: both PR heads are ancestors of `9c77a99`. Negative control
  from the world: the unpublished rebased head is not.

## Three corrections to the plan this branch was built from

1. **PR 2005 does not touch `DESIGN_NOTES.md` at all.** Its copy is
   byte-identical to main's — measured, 0 bytes of tail. The union was framed
   as "two append-only branches", and only one of them appends.
2. **Markers therefore rise by 1, not 2.** Stated so nobody reads a correct
   count as a lost entry.
3. **The two branches share no file** — PR 2005 touches
   `lib/grappa/application.ex` and one new test; PR 2008 touches 16 files,
   none of them those. Intersection empty, with a positive control (a set
   intersected with itself returns its 16). So the "verify both directions on
   non-union files" check is **vacuous here**, and is reported as vacuous
   rather than dressed up as a pass.

**One check that IS constructible, and it comes from the world:** GitHub
marked PR 2008 `CONFLICTING` against this same main. GitHub does not apply
`.gitattributes merge=union` on its merge ref, so that verdict is the negative
control showing these two sides genuinely collide without the driver — the
union here is doing work, not passing through.

## The two isolated gates, kept as controls

Neither is thrown away; each attests one side alone, and if this branch goes
red the red is attributable to the COMPOSITION.

- **PR 2008, 2026-09-08, full `scripts/check.sh` at `ef5c44d04`, `rc=0`**
  (read from the rc file, not the wrapper's exit code, which reported `0` for
  two red runs): credo clean, ExUnit `7213 tests, 0 failures`, dialyzer
  `Total errors: 0`, sobelow, `deps.audit` clean, bats `756 ok / 0 not ok`,
  wire pin in sync. Measured **before** this merge, so it describes that slice
  in isolation.
- **PR 2005, 2026-09-08**: its own CI, in isolation, on `6b1caf436`.

No local gate was run on this branch: the CI on this PR is the gate.
