### PR TITLE
fix(2004): ask whether the client /64 changed before taking the write lock

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49344,3 +49344,102 @@ across the whole window. #340 rejected deferral; there is none here.
 _Deploy: **COLD** — `config/runtime.exs` is read at boot, and the release lib
 directory is unchanged only for hot-reloadable modules. `BEGIN IMMEDIATE`
 (#524) is untouched and out of scope._
+<!-- entry #2004 -->
+
+---
+
+## 2026-09-08 — 2004: the client-source sample stops taking the writer lock to write nothing
+
+`Grappa.Vhosts.record_client_source/2` fires on every client connect and puts
+one key — the subject's last-known client `/64` — into the shared
+`user_settings.data` blob. It did so unconditionally. Between two reconnects of
+the same client that key is normally IDENTICAL, so the write transaction opened,
+took SQLite's single-writer `RESERVED`, and committed a change nobody made. In
+w1's review of the 2026-09-08 stall episodes, **21 of 29** trace to this call.
+
+### The guard belongs OUTSIDE the transaction, and that placement is the fix
+
+`UserSettings.put_last_client_prefix64/2` routes through the one write path,
+`update_data/2` = `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fun) end)`.
+So `BEGIN IMMEDIATE` takes the lock **before** anything can know the value is
+unchanged. Asking "has it changed?" inside the transaction would shorten the
+hold; asking it outside removes the transaction outright on reconnect churn.
+`UserSettings.get_last_client_prefix64/1` already existed, so the comparison
+cost nothing to buy.
+
+**Measured, and it is more than the issue claimed.** The issue and its follow-up
+comment describe a SELECT and a COMMIT around an UPDATE Ecto declines to emit.
+The query telemetry captured in `Grappa.VhostsClientSourceWriteTest` shows the
+unchanged path emitting, verbatim, a bare `begin` and then
+
+```
+INSERT INTO "user_settings" (…) ON CONFLICT (user_id) WHERE user_id IS NOT NULL DO NOTHING RETURNING "id"
+```
+
+— the row init inside `get_or_init!/1`. The UPDATE is indeed absent, but a WRITE
+statement runs regardless: the lock was not merely taken for a no-op, it was
+taken and then written through. The correction strengthens the case rather than
+weakening it, which is why it is recorded here instead of quietly dropped.
+
+### Why the guard sits in `Vhosts` and not in the setter
+
+`UserSettings.get_last_client_prefix64/1`'s own doc calls the key **"a dumb
+string store"** and delegates interpretation to `Vhosts`. A skip-if-unchanged
+rule is a policy about a SAMPLE — "this reading is best-effort and redundant
+between reconnects" — and that policy belongs to the domain that owns the
+sample. Putting it in the setter would also have created a per-key exception
+inside a module whose other setters have none, which is the half-migrated shape
+CLAUDE.md warns propagates itself.
+
+The `#1375` one-write-path invariant is untouched: when the value DOES change,
+the write still goes through `update_data/2`, still holding read and write in
+one transaction. `Grappa.UserSettingsConcurrencyTest` calls the setter directly
+and so still exercises it.
+
+### 🔴 The recursion trap, worth naming because the issue's wording invites it
+
+The guard must read `UserSettings.get_last_client_prefix64/1` — **never**
+`Vhosts.last_client_prefix64/1`. The latter falls back to
+`last_known_client_key/1` (#647), which calls straight back into
+`record_client_source/2`: a guard spelled with it recurses without end. The
+issue says only "`get_last_client_prefix64/1` already exists", and the two
+modules' functions are one word apart.
+
+### It skips the WRITE, never the VALUE
+
+The guard fires only when the store ALREADY holds exactly what the call would
+have written, so mode 2 (#543) reads the same key either way and no session is
+newly HELD with `:no_client_source`. The three callers enumerated in
+`GrappaWeb.UserSocket.detach_client_source_capture/2` are safe by that same
+token: the detached WS capture is the churn this targets; `Visitors.Login`
+(#645) needs the sample PERSISTED before it spawns the anchor session, and a
+skip means it already is; `last_known_client_key/1` (#647) runs only when
+nothing is stored, so it never skips and pays one extra SELECT on a path walked
+once per subject. A value stored in another spelling compares unequal and is
+rewritten — the guard self-heals rather than pinning bad data.
+
+### 🔴 Not a cure for the stall, and the beneficiary has moved
+
+This removes THIS possession of the lock. **Why a holder sits in `RESERVED` for
+tens of seconds is still unmeasured**, inside the NIF (#1687); the OS-level
+route (`procstat -kk` on the dirty thread at the next stall) has not been taken.
+Do not read the guard as a diagnosis.
+
+⚠️ vjt has decided **Postgres for this instance; SQLite stays for
+self-hosters.** That does not invalidate the work — it moves who benefits, and
+the priority with it. Judging this against prod would be the wrong yardstick.
+
+### What the test can and cannot prove
+
+The tests assert on the write STATEMENTS, because the captured frame is a bare
+`begin` with no `IMMEDIATE` in it: they cannot tell
+`Repo.immediate_transaction/1` apart from a plain `Repo.transaction/1`, and
+`Grappa.UserSettingsConcurrencyTest` already measured that the distinction is
+invisible under the Sandbox. A green proves the writer lock is never REACHED —
+nothing about how the acquisition is spelled. Two of the five cases guard the
+other direction (the value stays readable after a skip; a genuinely roamed
+prefix still writes), because a guard that skipped the VALUE would break mode 2
+silently.
+
+_Code + docs. No wire change, no protocol bump. Deploy: hot — one context
+module, no supervision-tree or schema change._

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -580,6 +580,10 @@ defmodule Grappa.Vhosts do
   `last_client_prefix64/1` when no client is attached then — the #543
   mode-2 (`static_mapping_with_reservations`) "last-known /64" fallback.
 
+  Writes ONLY when the derived key differs from the stored one, so a
+  reconnect from the same network opens no write transaction at all
+  (2004). The stored value is unaffected either way.
+
   Always returns `:ok`: a capture failure must never fail the client
   connect. A persist error (e.g. the subject row vanished mid-connect)
   is best-effort but LOGGED, never silently swallowed (CLAUDE.md
@@ -589,6 +593,54 @@ defmodule Grappa.Vhosts do
   def record_client_source({_, _} = subject, remote_ip) do
     hex = Base.encode16(SourceMapping.client_key(remote_ip))
 
+    if hex == UserSettings.get_last_client_prefix64(subject) do
+      :ok
+    else
+      persist_client_source(subject, hex)
+    end
+  end
+
+  # 2004 — the "has it changed?" question is asked OUTSIDE the write
+  # transaction, and that placement IS the fix rather than a detail of it.
+  # `UserSettings.put_last_client_prefix64/2` routes through `update_data/2`
+  # = `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fun) end)`, so
+  # `BEGIN IMMEDIATE` takes SQLite's single writer lock BEFORE anything can
+  # know there is nothing to write. Ecto then declines to emit the UPDATE
+  # for an unchanged changeset — but the row init inside still issues an
+  # `INSERT … ON CONFLICT DO NOTHING` (measured, not inferred: it shows up
+  # in the query telemetry `Grappa.VhostsClientSourceWriteTest` captures),
+  # and the lock was taken regardless. Between two reconnects of the same
+  # client the `/64` is normally IDENTICAL, so on reconnect churn the
+  # transaction now DISAPPEARS instead of merely getting shorter.
+  #
+  # 🔴 Reads `UserSettings.get_last_client_prefix64/1`, NEVER this module's
+  # own `last_client_prefix64/1`: the latter falls back to
+  # `last_known_client_key/1`, which calls straight back into here — the
+  # guard would recurse without end. The raw store read is the correct
+  # compare anyway, because `hex` is precisely what gets STORED.
+  #
+  # It skips the WRITE, never the VALUE. The guard fires only when the store
+  # ALREADY holds exactly what this call would have written, so mode 2's
+  # `last_client_prefix64/1` (#543) reads the same key either way and no
+  # session is newly HELD with `:no_client_source`. The two ordering-critical
+  # callers named in `GrappaWeb.UserSocket.detach_client_source_capture/2`
+  # are safe by that same token: `Visitors.Login` (#645) needs the sample
+  # PERSISTED before it spawns the anchor session, and a skip means it
+  # already is; `last_known_client_key/1` (#647) runs only when nothing is
+  # stored, so it never skips and pays one extra SELECT on a path walked
+  # once per subject.
+  #
+  # A value stored in some other spelling (lowercase base16, or the garbage
+  # a miscoded writer left — `last_client_prefix64/1` tolerates both) simply
+  # compares unequal and is rewritten: the guard self-heals rather than
+  # pinning a bad value in place.
+  #
+  # 🔴 This is NOT a cure for the write-lock stall. It removes THIS
+  # possession of the lock. WHY a holder sits in `RESERVED` for tens of
+  # seconds is still unmeasured, inside the NIF (#1687) — the guard is not a
+  # diagnosis and must not be read as one.
+  @spec persist_client_source(Subject.t(), String.t()) :: :ok
+  defp persist_client_source(subject, hex) do
     case UserSettings.put_last_client_prefix64(subject, hex) do
       {:ok, _} ->
         :ok

--- a/test/grappa/vhosts_client_source_write_test.exs
+++ b/test/grappa/vhosts_client_source_write_test.exs
@@ -1,0 +1,161 @@
+defmodule Grappa.VhostsClientSourceWriteTest do
+  @moduledoc """
+  2004 — `Vhosts.record_client_source/2` must not take SQLite's single
+  writer lock for a sample it is not going to change.
+
+  The capture fires on EVERY client connect and writes one key into the
+  shared `user_settings.data` blob. Between two reconnects of the same
+  client that key is normally IDENTICAL, and the put is unconditional, so
+  the write transaction opens, takes `RESERVED`, discovers the changeset is
+  empty and commits nothing. The lock is acquired before anyone knows there
+  is anything to write.
+
+  ## What is measured
+
+  Ecto's per-query telemetry (`[:grappa, :repo, :query]`, the event
+  `Grappa.DbLatency` already folds) runs its handlers SYNCHRONOUSLY in the
+  process that issued the query — the same seam
+  `Grappa.UserSettingsConcurrencyTest` uses to interleave two writers. The
+  capture below is therefore exact, not a poll and not a sleep.
+
+  ## What the Sandbox cannot buy, stated up front
+
+  These tests assert on the write STATEMENTS the transaction carries, not on
+  the `BEGIN IMMEDIATE` spelling of the frame around them, and that is a
+  limit rather than a preference: under the Sandbox every transaction is
+  nested and every mode is a `SAVEPOINT` — measured, and written down in
+  `Grappa.UserSettingsConcurrencyTest`'s moduledoc. So a green here proves
+  the writer lock is not REACHED; it does not re-prove how
+  `Grappa.Repo.immediate_transaction/1` spells the acquisition.
+
+  It also does not prove anything about the stall the sample was found in.
+  Removing this holder removes THIS possession of the lock — why a holder
+  sits in `RESERVED` for tens of seconds is a separate, still-unmeasured
+  question inside the NIF.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Vhosts
+  alias Grappa.Vhosts.SourceMapping
+
+  # Statements that mutate, plus the transaction frame that would carry them.
+  # Either one appearing is the defect: the frame takes `RESERVED` up front,
+  # and the `INSERT ... ON CONFLICT DO NOTHING` that `get_or_init!/1` issues
+  # is a write even on the connect where it changes nothing.
+  @write_statements ~w(INSERT UPDATE DELETE BEGIN SAVEPOINT RELEASE)
+
+  # Every Ecto query emitted IN THIS PROCESS while `fun` runs, in order.
+  # Handlers run in the emitting process, so `Process.put/2` is the whole
+  # accumulator — no agent, no message passing, nothing to race.
+  defp capture_queries(fun) do
+    key = {__MODULE__, make_ref()}
+    test_pid = self()
+    Process.put(key, [])
+
+    :telemetry.attach(
+      key,
+      [:grappa, :repo, :query],
+      # `:telemetry` handler args: event, measurements, metadata, config.
+      fn _, _, meta, _ ->
+        if self() == test_pid do
+          Process.put(key, [meta[:query] | Process.get(key, [])])
+        end
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(key)
+    end
+
+    key |> Process.get([]) |> Enum.reverse()
+  end
+
+  defp writes(queries) do
+    Enum.filter(queries, fn q ->
+      upcased = String.upcase(q || "")
+      Enum.any?(@write_statements, &String.starts_with?(upcased, &1))
+    end)
+  end
+
+  defp assert_no_writes(queries) do
+    assert writes(queries) == [],
+           "expected the repeat capture to issue no write statement, got:\n  " <>
+             Enum.join(writes(queries), "\n  ")
+  end
+
+  describe "record_client_source/2 — the writer lock is not taken for an unchanged sample" do
+    setup do
+      user = user_fixture()
+      subject = {:user, user.id}
+      ip = {0x2001, 0xDB8, 1, 2, 3, 4, 5, 6}
+
+      :ok = Vhosts.record_client_source(subject, ip)
+
+      %{subject: subject, ip: ip}
+    end
+
+    test "a repeat capture of the same client prefix writes nothing at all", ctx do
+      queries = capture_queries(fn -> assert :ok = Vhosts.record_client_source(ctx.subject, ctx.ip) end)
+
+      assert_no_writes(queries)
+    end
+
+    test "a different address inside the SAME /64 is the same sample, so it writes nothing", ctx do
+      # The interface id is dropped (RFC 8981), so a client that rotated its
+      # temporary address has not moved: the stored key is already correct.
+      roamed_interface_id = {0x2001, 0xDB8, 1, 2, 0xDEAD, 0xBEEF, 0xCAFE, 1}
+
+      assert SourceMapping.client_key(roamed_interface_id) == SourceMapping.client_key(ctx.ip)
+
+      queries =
+        capture_queries(fn ->
+          assert :ok = Vhosts.record_client_source(ctx.subject, roamed_interface_id)
+        end)
+
+      assert_no_writes(queries)
+    end
+
+    # The guard skips the WRITE, never the VALUE — mode 2 (#543) reads this
+    # sample when no client is attached, and a subject without one is HELD
+    # with `:no_client_source` instead of egressing from a shared pool.
+    test "the skipped capture leaves the value readable, unchanged", ctx do
+      assert :ok = Vhosts.record_client_source(ctx.subject, ctx.ip)
+
+      assert Vhosts.last_client_prefix64(ctx.subject) == SourceMapping.client_key(ctx.ip)
+    end
+
+    test "a genuinely roamed prefix still writes, and the new value wins", ctx do
+      roamed = {0x2001, 0xDB8, 99, 99, 1, 2, 3, 4}
+      refute SourceMapping.client_key(roamed) == SourceMapping.client_key(ctx.ip)
+
+      queries = capture_queries(fn -> assert :ok = Vhosts.record_client_source(ctx.subject, roamed) end)
+
+      assert writes(queries) != [],
+             "a changed sample must still be persisted, but no write statement was issued"
+
+      assert Vhosts.last_client_prefix64(ctx.subject) == SourceMapping.client_key(roamed)
+    end
+  end
+
+  describe "record_client_source/2 — the first capture is unaffected" do
+    test "a subject with nothing recorded still writes, and the read-back is the production key" do
+      user = user_fixture()
+      subject = {:user, user.id}
+      ip = {203, 0, 113, 7}
+
+      assert Vhosts.last_client_prefix64(subject) == nil
+
+      queries = capture_queries(fn -> assert :ok = Vhosts.record_client_source(subject, ip) end)
+
+      assert writes(queries) != [],
+             "the first capture for a subject must persist, but no write statement was issued"
+
+      assert Vhosts.last_client_prefix64(subject) == SourceMapping.client_key(ip)
+    end
+  end
+end

--- a/test/grappa/vhosts_client_source_write_test.exs
+++ b/test/grappa/vhosts_client_source_write_test.exs
@@ -20,13 +20,20 @@ defmodule Grappa.VhostsClientSourceWriteTest do
 
   ## What the Sandbox cannot buy, stated up front
 
-  These tests assert on the write STATEMENTS the transaction carries, not on
-  the `BEGIN IMMEDIATE` spelling of the frame around them, and that is a
-  limit rather than a preference: under the Sandbox every transaction is
-  nested and every mode is a `SAVEPOINT` — measured, and written down in
-  `Grappa.UserSettingsConcurrencyTest`'s moduledoc. So a green here proves
-  the writer lock is not REACHED; it does not re-prove how
-  `Grappa.Repo.immediate_transaction/1` spells the acquisition.
+  What the capture actually sees on the failing path, verbatim, is a bare
+  `begin` followed by the `INSERT … ON CONFLICT DO NOTHING` that
+  `get_or_init!/1` issues to init the row. So the frame IS observable here —
+  but the word `IMMEDIATE` is not in it, and these tests therefore cannot
+  tell `Grappa.Repo.immediate_transaction/1` apart from a plain
+  `Repo.transaction/1`. A green proves the writer lock is never REACHED; it
+  does not re-prove how the acquisition is spelled. (`Grappa.Repo`'s own
+  moduledoc owns that spelling, and `Grappa.UserSettingsConcurrencyTest`
+  measured that the distinction is invisible under the Sandbox.)
+
+  The INSERT is worth naming on its own: an unchanged sample emits no
+  UPDATE, because Ecto declines an empty changeset — but the row init inside
+  the transaction is a WRITE statement that runs anyway. The lock is not
+  merely taken for a no-op, it is taken and then written through.
 
   It also does not prove anything about the stall the sample was found in.
   Removing this holder removes THIS possession of the lock — why a holder


### PR DESCRIPTION
Addresses issue 2004.

`Grappa.Vhosts.record_client_source/2` fires on every client connect and puts the subject's last-known client `/64` into the shared `user_settings.data` blob. It did so **unconditionally**. Between two reconnects of the same client that key is normally identical, so the write transaction opened, took SQLite's single-writer `RESERVED`, and committed a change nobody made.

## The guard goes OUTSIDE the transaction

That placement is the fix rather than a detail of it. `UserSettings.put_last_client_prefix64/2` routes through the one write path, `update_data/2` = `Repo.BusyRetry.run(fn -> Repo.immediate_transaction(fun) end)` — so `BEGIN IMMEDIATE` takes the lock **before** anything can know the value is unchanged. Asking "has it changed?" inside would shorten the hold; asking it outside removes the transaction outright on reconnect churn. `UserSettings.get_last_client_prefix64/1` already existed, so the comparison cost nothing to buy.

## Measured, and it is more than the issue claimed

The issue and its follow-up comment describe a SELECT and a COMMIT around an UPDATE that Ecto declines to emit. The query telemetry captured by the new test shows the unchanged path emitting, verbatim, a bare `begin` **and**:

```
INSERT INTO "user_settings" (…) ON CONFLICT (user_id) WHERE user_id IS NOT NULL DO NOTHING RETURNING "id"
```

— the row init inside `get_or_init!/1`. The UPDATE is absent as described, but a **write statement runs regardless**: the lock was not merely taken for a no-op, it was taken and then written through. The correction strengthens the case; it is recorded rather than quietly dropped.

## 🔴 This is not a proven cure for the stall

It removes **this** possession of the lock. **Why a holder sits in `RESERVED` for tens of seconds is still unmeasured**, inside the NIF (#1687) — the OS-level route (`procstat -kk` on the dirty thread at the next stall) has not been taken. Nothing here should be read as a diagnosis.

## ⚠️ The beneficiary has moved

vjt has decided **Postgres for this instance; SQLite stays for self-hosters.** That does not invalidate the work — it changes who it is for, and the priority with it. Judging this against prod would be the wrong yardstick.

## Why the guard sits in `Vhosts` and not in the setter

`UserSettings.get_last_client_prefix64/1`'s own doc calls the key **"a dumb string store"** and delegates interpretation to `Vhosts`. A skip-if-unchanged rule is policy about a *sample*, and it belongs to the domain that owns the sample. Putting it in the setter would also have created a per-key exception inside a module whose other setters have none — the half-migrated shape CLAUDE.md warns propagates itself.

The #1375 one-write-path invariant is untouched: when the value **does** change, the write still goes through `update_data/2`, still holding read and write in one transaction. `Grappa.UserSettingsConcurrencyTest` calls the setter directly and still exercises it.

## 🔴 A recursion trap the issue's wording invites

The guard must read `UserSettings.get_last_client_prefix64/1` — **never** this module's own `last_client_prefix64/1`. The latter falls back to `last_known_client_key/1` (#647), which calls straight back into `record_client_source/2`: a guard spelled with it recurses without end. The issue says only "`get_last_client_prefix64/1` already exists", and the two modules' functions are one word apart.

## It skips the WRITE, never the VALUE

The guard fires only when the store **already holds exactly** what the call would have written, so mode 2 (#543) reads the same key either way and no session is newly HELD with `:no_client_source`. The three callers enumerated in `GrappaWeb.UserSocket.detach_client_source_capture/2` are safe by the same token:

- the detached WS capture is the churn this targets;
- `Visitors.Login` (#645) needs the sample PERSISTED before it spawns the anchor session — a skip means it already is;
- `last_known_client_key/1` (#647) runs only when nothing is stored, so it never skips, and pays one extra SELECT on a path walked once per subject.

A value stored in another spelling compares unequal and is rewritten: the guard self-heals rather than pinning bad data.

## Tests, and what they cannot prove

Test first: `test(2004)` fails on its own commit, on the two accusing cases, with the three guard-rail cases already green.

The assertions are on the write STATEMENTS, not on the frame's spelling, and that is a limit rather than a preference: the captured frame is a bare `begin` with no `IMMEDIATE` in it, so these tests cannot tell `Repo.immediate_transaction/1` apart from a plain `Repo.transaction/1`. A green proves the writer lock is never **reached** — nothing about how the acquisition is spelled.

Two of the five cases guard the other direction, deliberately: the value stays readable after a skip, and a genuinely roamed prefix still writes. A guard that skipped the VALUE would break mode 2 in silence.

## Gates

Run on this branch, rebased onto `origin/main` (`e9bc2ed05`) **before** gating, so the green attests this work against current main rather than the base it forked from:

| gate | result |
|---|---|
| `scripts/check.sh` | **rc=0** |
| ExUnit | 7198 tests, **0 failures** (8 doctests, 65 properties) |
| Dialyzer | **Total errors: 0** — passed successfully |
| Credo | `6831 mods/funs, found no issues.` |
| Sobelow | 28 findings, **all Low Confidence** — zero at Medium or above |
| bats | **756 ok, 0 not ok** |
| wire pin | `wireTypes.ts` / `wireSchema.ts` in sync — no wire change, no protocol bump |

`docs/DESIGN_NOTES.md`: marker `<!-- entry #2004 -->` verified absent from `origin/main`'s tip (with a positive control alongside, so the zero is not a dead regex); line/byte arithmetic predicted **before** appending and matched exactly (49196+99 = 49295 lines, 2880456+5326 = 2885782 bytes); numstat `99 0`, zero deletions; boundary shape read on the real file. The gate reports `1 new entry heading(s), separator and marker present.` and was mutation-validated (removing the separator and removing the marker each turn it red).

Deploy: **hot** — one context module, no supervision-tree, schema, or wire change.
