### PR TITLE
test(2007): characterize the background unread badge on three engines

### DIFF
--- a/cicchetto/e2e/tests/issue2007-plain-msg-background-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue2007-plain-msg-background-badge.spec.ts
@@ -21,11 +21,23 @@
 //
 // The body carries NO mention of the operator's nick and no highlight token:
 // the mention path is server-owned (`window_counts.mentions`) and masks the
-// defect — that is exactly what invalidated the reporter's first round.
+// defect — that is exactly what invalidated the reporter's own first round.
 // `assertMessagePersisted` runs BEFORE the badge assertion so that a red
 // separates "the server never got the line" (harness fault) from "the server
 // has it and the badge is still absent" (the defect).
+//
+// TWO ENTRIES, ONE BODY. The reporter is on a mobile PWA, and the badge is a
+// DIFFERENT element there — `sidebarMessageBadge` resolves
+// `.bottom-bar-msg-unread` under a mobile viewport and `.sidebar-msg-unread`
+// otherwise. A desktop-only green therefore says nothing about the platform
+// the defect was reported on. The tags are how a spec reaches the mobile
+// projects (`@touch` → chromium-pixel-touch, `@webkit` → webkit-iphone-15),
+// and they are EXCLUSIVE: `chromium` carries `grepInvert: /@webkit|@touch/`,
+// so tagging the one entry would have MOVED it off the desktop rather than
+// widened it. Hence a tagged entry and an untagged one over a shared body —
+// three projects, no second copy of the scenario to drift.
 
+import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -37,20 +49,19 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
-const PEER_NICK = "i2007-peer";
 // The BACKGROUND window — the one whose badge is under test.
 const BACKGROUND_CHANNEL = AUTOJOIN_CHANNELS[0];
 // A plain line: no operator nick, no highlight token, nothing that could
 // route down the server-owned mention path and mask the count.
 const MESSAGE_BODY = "issue2007: plain line into a backgrounded window";
 
-test("issue 2007 — plain PRIVMSG to a background channel bumps its msg-unread badge while parked on ANOTHER real channel", async ({
-  page,
-}) => {
+// `variant` keeps the per-run channel and the peer nick disjoint between the
+// desktop and mobile entries: the projects can run concurrently against the
+// one shared testnet, and two peers on one nick would collide upstream.
+async function backgroundBadgeScenario(page: Page, variant: string): Promise<void> {
   const vjt = specUser();
-  // Fresh per-run channel so parallel workers never share it, and so parking
-  // here cannot collide with the autojoin channel under test.
-  const parkChannel = `#i2007park-${Date.now()}`;
+  const parkChannel = `#i2007${variant}-${Date.now()}`;
+  const peerNick = `i2007-${variant}`;
 
   await loginAs(page, vjt);
 
@@ -65,7 +76,7 @@ test("issue 2007 — plain PRIVMSG to a background channel bumps its msg-unread 
     await composeSend(page, `/join ${parkChannel}`);
     await selectChannel(page, NETWORK_SLUG, parkChannel, { ownNick: specNick() });
 
-    const peer = await IrcPeer.connect({ nick: PEER_NICK });
+    const peer = await IrcPeer.connect({ nick: peerNick });
     try {
       await peer.join(BACKGROUND_CHANNEL);
       peer.privmsg(BACKGROUND_CHANNEL, MESSAGE_BODY);
@@ -91,4 +102,16 @@ test("issue 2007 — plain PRIVMSG to a background channel bumps its msg-unread 
   } finally {
     await composeSend(page, `/part ${parkChannel}`).catch(() => {});
   }
+}
+
+test("issue 2007 — plain PRIVMSG to a background channel bumps its msg-unread badge while parked on ANOTHER real channel", async ({
+  page,
+}) => {
+  await backgroundBadgeScenario(page, "d");
+});
+
+test("@webkit @touch issue 2007 — the same background badge holds on the mobile layouts, where the badge is a different element", async ({
+  page,
+}) => {
+  await backgroundBadgeScenario(page, "m");
 });

--- a/cicchetto/e2e/tests/issue2007-plain-msg-background-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue2007-plain-msg-background-badge.spec.ts
@@ -1,0 +1,94 @@
+// issue 2007 — a PLAIN PRIVMSG into a BACKGROUND channel window raises no
+// msg-unread badge, reported from the deployed mobile PWA and reproduced by
+// vjt on `#sbiffo` twice on 2026-09-08.
+//
+// This spec exists to answer ONE question the field report cannot: does the
+// defect reproduce at all under the harness, and if so on which side of the
+// fork — the live append, or the count derived from it.
+//
+// WHY IT IS NOT THE M2 SPEC, WHICH IS GREEN.
+// `m2-irssi-to-chan-defocused` already asserts "peer PRIVMSG to a defocused
+// channel bumps msg-unread by exactly 1", and it passes. It therefore proves
+// the mechanism works in ONE configuration, and the field report says there is
+// a configuration where it does not. The single deliberate delta here is WHERE
+// THE OPERATOR IS PARKED: M2 defocuses onto the `Server` pseudo-window,
+// explicitly chosen there to avoid "the JOIN-self auto-focus path" — i.e. M2
+// avoids, by construction, the very thing every real operator does, which is
+// sit on ANOTHER REAL CHANNEL. The reporter was on a real window. Everything
+// else — plain body, foreign sender, one message, badge assertion — is held
+// identical to M2 on purpose, so a red here is attributable to that delta and
+// to nothing else.
+//
+// The body carries NO mention of the operator's nick and no highlight token:
+// the mention path is server-owned (`window_counts.mentions`) and masks the
+// defect — that is exactly what invalidated the reporter's first round.
+// `assertMessagePersisted` runs BEFORE the badge assertion so that a red
+// separates "the server never got the line" (harness fault) from "the server
+// has it and the badge is still absent" (the defect).
+
+import {
+  composeSend,
+  loginAs,
+  selectChannel,
+  sidebarMessageBadge,
+} from "../fixtures/cicchettoPage";
+import { assertMessagePersisted } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const PEER_NICK = "i2007-peer";
+// The BACKGROUND window — the one whose badge is under test.
+const BACKGROUND_CHANNEL = AUTOJOIN_CHANNELS[0];
+// A plain line: no operator nick, no highlight token, nothing that could
+// route down the server-owned mention path and mask the count.
+const MESSAGE_BODY = "issue2007: plain line into a backgrounded window";
+
+test("issue 2007 — plain PRIVMSG to a background channel bumps its msg-unread badge while parked on ANOTHER real channel", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  // Fresh per-run channel so parallel workers never share it, and so parking
+  // here cannot collide with the autojoin channel under test.
+  const parkChannel = `#i2007park-${Date.now()}`;
+
+  await loginAs(page, vjt);
+
+  // Visit the BACKGROUND channel first, with the WS-ready sync: the peer's
+  // PRIVMSG must not race the per-channel subscribe (M2's note), and the
+  // window must be locally hydrated — a hydrated key is the one whose count
+  // comes from local scrollback rather than the server seed.
+  await selectChannel(page, NETWORK_SLUG, BACKGROUND_CHANNEL, { ownNick: specNick() });
+
+  try {
+    // Park on ANOTHER REAL CHANNEL — the delta from M2.
+    await composeSend(page, `/join ${parkChannel}`);
+    await selectChannel(page, NETWORK_SLUG, parkChannel, { ownNick: specNick() });
+
+    const peer = await IrcPeer.connect({ nick: PEER_NICK });
+    try {
+      await peer.join(BACKGROUND_CHANNEL);
+      peer.privmsg(BACKGROUND_CHANNEL, MESSAGE_BODY);
+
+      // Server-side truth first: if this fails the harness never delivered the
+      // line and the badge assertion below would be meaningless.
+      await assertMessagePersisted({
+        token: vjt.token,
+        networkSlug: NETWORK_SLUG,
+        channel: BACKGROUND_CHANNEL,
+        sender: peer.nick,
+        body: MESSAGE_BODY,
+      });
+
+      // The reported defect: no badge at all. Asserting the exact text "1"
+      // (M2's BUG 6 contract) keeps a double-bump from reading as a pass.
+      await expect(sidebarMessageBadge(page, NETWORK_SLUG, BACKGROUND_CHANNEL)).toHaveText("1", {
+        timeout: 5_000,
+      });
+    } finally {
+      await peer.disconnect("issue2007 done");
+    }
+  } finally {
+    await composeSend(page, `/part ${parkChannel}`).catch(() => {});
+  }
+});


### PR DESCRIPTION
## What this is

Characterization, not a cure. **There is no cause here, and no fix.** The
field report for issue 2007 says a plain PRIVMSG into a background window
raises no unread badge; this branch went looking for that defect under the
e2e harness, did not find it on any engine the harness has, and pins the
working behaviour on all three on the way out.

Two commits, one new spec file, no production code touched.

## Why the existing green spec was not enough

`m2-irssi-to-chan-defocused` already asserts "peer PRIVMSG to a defocused
channel bumps msg-unread by exactly 1", and it is green. So the mechanism
works in one configuration while the report describes another. M2's own
comment says which one it holds still: it defocuses onto the `Server`
pseudo-window, chosen there to avoid "the JOIN-self auto-focus path". That is
sound for a spec about focus, and it means the covered configuration is the
one no operator is ever in — every real operator parks on another real
window. The reporter did.

So the new spec moves exactly that one variable and holds everything else
identical to M2: plain body, foreign sender, one message, same exact-"1"
badge assertion. The body carries no operator nick and no highlight token on
purpose — the mention count is server-owned and masks the defect, which is
what invalidated the reporter's own first round.

## What was measured

One cold stack, summary read rather than the exit code:

| project | entry | result |
|---|---|---|
| `chromium` | issue 2007, desktop | pass |
| `chromium-pixel-touch` | issue 2007, mobile layouts | pass |
| `webkit-iphone-15` | issue 2007, mobile layouts | pass |

The badge was present and read exactly `1` in every one.

### The fork in the report, resolved in every configuration measured

The report's own shortlist opens on a fork it could not settle: was the row
appended live while the window sat in the background, or did it only arrive
when the window was selected? Those are two different bugs in two different
files.

A badge reading `1` settles it. The messages count is derived from local
scrollback rows past the read cursor, so a badge at 1 means the row was in
the local store while the window was backgrounded. **Under these conditions
it is neither the subscribe/append path nor the count.** Both worked.

The green also excludes one more thing for free: had the parking failed and
the operator still been sitting on the target window at its tail, the
read-at-the-tail suppression would have zeroed the count and the spec would
be red. It is not, so the window really was backgrounded.

## Why the mobile greens are readable — the positive control

The badge is a **different element** on mobile: `sidebarMessageBadge`
resolves `.bottom-bar-msg-unread` under a mobile viewport and
`.sidebar-msg-unread` otherwise. A green there is worth nothing until that
assertion has been shown capable of going red on those projects — otherwise
it is indistinguishable from an assertion pointed at an element that does not
exist.

So the run carried a temporary sibling spec asserting a messages badge on a
window that has none. It went **red on both mobile projects**, byte-identical:

```
Locator: … .locator('.bottom-bar-msg-unread')
Expected: "1"
Error: element(s) not found
```

That proves the mobile fixture resolves the mobile selector and that the
assertion can fail there. The control was deleted once read: a test whose
contract is to fail cannot live in the suite.

## Shape of the spec, and why it is two entries over one body

The tags are how a spec reaches the mobile projects (`@touch` →
chromium-pixel-touch, `@webkit` → webkit-iphone-15) and they are
**exclusive**: `chromium` carries `grepInvert: /@webkit|@touch/`. Tagging the
single entry would have *moved* the scenario off the desktop rather than
widening it — trading one blind platform for another. A second file would
have been the same scenario twice, free to drift. Hence one shared body and
two entries; `variant` disjoins the per-run channel and the peer nick so the
projects may run concurrently against the one shared testnet without two
peers colliding on a nick upstream.

## What "not reproduced" does and does not mean

Stated per engine, with what each one is **not**:

* **`chromium`** — Desktop Chrome. Not a mobile layout at all.
* **`chromium-pixel-touch`** — a Pixel 7 device descriptor: chromium with
  `isMobile` + `hasTouch`. **Not an Android WebView, and not Firefox
  Android.**
* **`webkit-iphone-15`** — Playwright's webkit project. **Not a real
  iPhone**: no installed PWA, no `navigator.standalone`, no Safari iOS, no
  operating-system background/freeze/resume cycle.

The report is from an **installed mobile PWA**. None of the three exercises
that.

## What remains unmeasured

The installed-PWA zone: service worker, `navigator.standalone`, and the
OS-driven freeze/resume cycle. Playwright does not exercise it by
construction, so more runs here would produce further greens that say
nothing. The honest next step is a probe on a real device.

Two things live in that unmeasured zone and are worth naming for whoever
takes it: the PWA-renders-nothing-until-a-tab-switch behaviour (issue 1667,
which the reporter excluded for the right reason — here the line rendered
immediately and only the count was missing), and the per-channel
pause/resume mechanism (`rejoinWithPresence`, driven "from a timer and from a
selection effect"). **Both are a reading of the source, not a measurement.**
They are pointers for the next investigator, not findings, and nothing in
this branch tests either.

Refs issue 2007.
