### PR TITLE
fix(2011): see the blank line the four-line window cannot

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49443,3 +49443,102 @@ silently.
 
 _Code + docs. No wire change, no protocol bump. Deploy: hot — one context
 module, no supervision-tree or schema change._
+<!-- entry #2011 -->
+
+---
+
+## 2026-09-09 — #2011: the marker is the FIRST appended line, and the four-line window could not see the blank that says otherwise
+
+`scripts/design-notes-gate.sh` keeps four lines of history above every added
+entry heading and asserts the canonical shape — blank / `---` / blank / marker.
+A blank line ahead of the marker pushes it to the fifth line, outside the
+window, so the four lines the gate inspects still spell exactly the canonical
+shape and it answers green. Found while validating the gate BY MUTATION: of
+three mutants, a removed separator and a removed marker both came back `rc=1`,
+and the stray blank did not.
+
+A COVERAGE gap, then, not a broken check — which is why the cure is a fifth
+line of history plus one more arm, and not a new regex on the four that were
+already being read.
+
+### Why a stray blank is not a style nit
+
+The marker defeats `merge=union` by making the FIRST appended line DIFFER
+between two branches, leaving the driver no identical prefix to align as a
+common addition. A blank ahead of it hands that prefix straight back, and a
+blank is the most collidable line there is: it is what every entry in the
+legacy separator-first shape opens with — most of this file's history — and
+what every other blank-led entry opens with too.
+
+Measured on the scratch repo the bats suite builds, one row per configuration
+of the other side. Every row reports `rc=0` with zero deletions:
+
+| this branch | the other side | lines lost |
+|---|---|---|
+| canonical | canonical | 0 |
+| blank-led | canonical | 0 |
+| canonical | legacy, no marker | 0 |
+| **blank-led** | **legacy, no marker** | **1** |
+| **blank-led** | **blank-led** | **1** |
+
+Rows 3 and 4 are the whole finding. The same pair that #1271's
+incremental-adoption case proves is SAFE for a canonical entry loses a line the
+moment that entry is blank-led — so the blank is precisely what disarms the
+protection the marker exists to give. One line, not three; `CLAUDE.md` already
+said as much in prose, and nothing asserted it.
+
+And the line the driver eats IS that blank, so what it leaves behind reads
+canonical with nothing left to find. The window is therefore BEFORE the rebase
+and cannot be moved after it — the same posture #1428 arrived at, by a
+different road. The new oracle case asserts that post-rebase green on purpose,
+so that nobody later tidies the check into a position where it is blind.
+
+### The cure, and a guard nobody would have tested
+
+`p5`, a fifth line of history, and a third arm reported as its own finding with
+its own message. The other two are untouched: a stray blank means the separator
+IS present and the marker IS present, and reporting either of those would send
+an author editing a correct line.
+
+The arm is guarded on `FNR > 5`. awk history variables start unset and read as
+blank, so an entry whose marker is line 1 of a file would otherwise be reported
+for a blank nobody wrote. Measured: with that guard deleted the suite stayed
+16/16 — live code no test defended, the same class of hole being cured here —
+so it now carries its own case, and deleting the guard turns that one case red
+and nothing else. The cure itself is validated the same way in the other
+direction: removed, only the blank case goes red.
+
+### The debt this leaves standing, named rather than ticketed
+
+Three entries already on main carry a blank ahead of their marker: `#1261`
+(line 16494), `#201` (16717) and `#1883c` (45652). `git blame` puts the blank
+and the marker in the SAME commit for all three, so the blank was added by the
+entry's own branch — not one of them is a previous entry's trailing line. Out
+of 326 markers in the corpus that is 0.92 %. The four archive files
+(`docs/design_notes/2026-0[4-7].md`) carry 0 markers at all: they predate the
+convention.
+
+They stay, on three grounds. The damage happened at their own rebase and
+removing the blank now does not undo it. A dated entry in this file is HISTORY,
+and rewriting one destroys the evidence that the shape ever existed. And the
+gate is diff-scoped: it judges only what a branch ADDS, and those three have
+been in the base for weeks. No separate issue either — a ticket for three blank
+lines nobody sees is a mechanism heavier than the problem.
+
+Measured, so that "nobody goes red today" is a fact and not an argument:
+against `origin/main~20` the gate judges 10 real entries at `rc=0`, against
+`~50` it judges 19 at `rc=0`, and the first blank finding appears only at
+`~100` — three of them by `~800`. ⚠️ The red at those depths is NOT this cure's.
+The UNFIXED script answers `rc=1` at the same depths, on SEPARATOR, and that
+was established by running both scripts side by side against the same bases,
+not inferred from an exit code that happened to match.
+
+### Stated limit
+
+The check reads the resulting FILE, not the diff. A blank belonging to the
+PREVIOUS entry's tail would therefore be charged to the new author, even though
+a blank already sitting in the base collides with nothing and costs no line.
+Across all 326 markers there are three findings and all three are same-commit:
+zero false positives observed, and no reachable case constructed. Should one
+ever turn up, the honest cure is to read the lines the branch ADDS rather than
+the file — a larger change than this gap justified today.

--- a/scripts/design-notes-gate.sh
+++ b/scripts/design-notes-gate.sh
@@ -51,6 +51,18 @@
 #      deletions, and takes FOUR lines — one MORE than carrying no marker at
 #      all, because the duplicated marker collapses together with the separator
 #      block it was added to protect.
+#   4. the marker is the FIRST appended line, with nothing above it — not even
+#      a blank. Check 2 cannot see this and never could: it reads the four
+#      lines above the heading, the marker is the fourth of them, so a stray
+#      blank sits at the fifth and those four still spell the canonical shape.
+#      Green, measured (issue 2011). A blank is the most collidable first line
+#      there is — every entry in the legacy shape opens with one — so a
+#      blank-led marker hands the driver back exactly the identical prefix the
+#      marker exists to destroy. Against a legacy entry the branch then loses
+#      one line, rc=0, zero deletions; and the line lost IS that blank, so the
+#      entry reads canonical afterwards with nothing left to find. That is why
+#      this is a coverage gap cured by a fifth line of history, and why the
+#      only window for it is BEFORE the rebase.
 #
 # THE REFERENCE FOR CHECK 3 IS THE BASE REF'S TIP, NOT THE MERGE BASE. This is
 # the whole finding and it is easy to undo by tidying: the colliding entry
@@ -111,14 +123,16 @@ fi
 # text, not an entry.
 findings="$(awk '
 NR == FNR { want[$0] = 1; next }
-/^(```|~~~)/ { fence = !fence; p4 = p3; p3 = p2; p2 = p1; p1 = $0; next }
+/^(```|~~~)/ { fence = !fence; p5 = p4; p4 = p3; p3 = p2; p2 = p1; p1 = $0; next }
 !fence && /^## / && ($0 in want) {
     if (!(p1 == "" && p2 == "---"))
         printf "%d\tSEPARATOR\t%s\n", FNR, $0
     else if (p3 != "" || p4 !~ /^<!-- entry .+ -->$/)
         printf "%d\tMARKER\t%s\n", FNR, $0
+    else if (FNR > 5 && p5 == "")
+        printf "%d\tBLANK\t%s\n", FNR, $0
 }
-{ p4 = p3; p3 = p2; p2 = p1; p1 = $0 }
+{ p5 = p4; p4 = p3; p3 = p2; p2 = p1; p1 = $0 }
 ' <(printf '%s\n' "$added") "$FILE")"
 
 status=0
@@ -147,6 +161,23 @@ if [ -n "$marker_findings" ]; then
 		printf 'line, in this exact shape:\n\n'
 		printf '    <!-- entry #1271 -->\n    <blank>\n    ---\n    <blank>\n    ## 2026-08-13 — #1271: ...\n\n'
 		printf 'It is what leaves the merge machinery no identical prefix to collapse.\n'
+	} >&2
+fi
+
+blank_findings="$(printf '%s\n' "$findings" | grep -F "	BLANK	" || true)"
+if [ -n "$blank_findings" ]; then
+	status=1
+	{
+		printf 'design-notes-gate: entry marker(s) with a blank line ahead of them:\n'
+		printf '%s\n' "$blank_findings"
+		printf '\nThe marker is the FIRST appended line, with nothing before it.\n'
+		printf 'A blank ahead of it is the identical prefix all over again — a\n'
+		printf 'blank collides with every entry in the legacy separator-first\n'
+		printf 'shape, which is most of this file, and with every other blank-led\n'
+		printf 'entry. Measured: the driver emits it once and the branch loses a\n'
+		printf 'line, rc=0 and zero deletions. The line it eats IS that blank, so\n'
+		printf 'the entry then reads canonical and nothing is left to find — which\n'
+		printf 'is why this is checked here and cannot be checked after a rebase.\n'
 	} >&2
 fi
 

--- a/test/scripts/design_notes_gate_test.bats
+++ b/test/scripts/design_notes_gate_test.bats
@@ -27,17 +27,23 @@ setup() {
     REAL_REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
 }
 
-# Append one entry, in the shipped shape. The marker — when present — is the
-# FIRST appended line, with no blank before it: measured, that shape loses
-# nothing at all (8 additions before the rebase, 8 after), whereas putting a
-# blank line ahead of the marker still costs that blank (9 → 8). A convention
-# that routinely shrinks the diff by one line would poison the very numstat
-# comparison this whole class is detected by.
+# Append one entry. The marker — when present — is the FIRST appended line,
+# with no blank before it: measured on this fixture, that shape loses nothing
+# at all (7 additions before the rebase, 7 after) against EITHER shape of the
+# other side. A blank ahead of the marker is `lead=blank`, and what it costs
+# depends on what the other branch appended: nothing against a markered entry,
+# but ONE line against an entry in the legacy shape, which is most of the
+# file's history. A convention that shrinks the diff by one line in some
+# configurations and not others would poison the very numstat comparison this
+# whole class is detected by.
 #
 # The marker tag is separate from the heading tag so a case can hand two
 # entries the SAME marker, which is how the copy-paste is reproduced.
 append_entry() {
-    local tag="$1" marker="$2"
+    local tag="$1" marker="$2" lead="$3"
+    if [ "$lead" = blank ]; then
+        printf '\n' >> docs/DESIGN_NOTES.md
+    fi
     if [ "$marker" != no ]; then
         printf '<!-- entry #%s -->\n' "$marker" >> docs/DESIGN_NOTES.md
     fi
@@ -48,8 +54,13 @@ append_entry() {
 # A scratch repo with `merge=union` on the log, one entry already in the base,
 # and one appended on each of `main` and `feat`. Leaves `feat` checked out,
 # NOT yet rebased, so each case controls what happens next.
+#
+# The third argument is the shape of `feat`'s own entry — `no` for the shipped
+# one, `blank` for a stray blank line ahead of the marker. It is spelled at
+# every call site rather than defaulted: which cases feed the gate a malformed
+# entry is exactly what a reader needs to see without scrolling up.
 scratch() {
-    local feat_marker="$1" main_marker="$2"
+    local feat_marker="$1" main_marker="$2" feat_lead="$3"
     REPO="$BATS_TEST_TMPDIR/repo"
     rm -rf "$REPO"
     mkdir -p "$REPO/docs" "$REPO/scripts"
@@ -67,11 +78,11 @@ scratch() {
     git commit -qm base
     git branch feat
 
-    append_entry C "$main_marker"
+    append_entry C "$main_marker" no
     git commit -qam 'main C'
 
     git checkout -q feat
-    append_entry B "$feat_marker"
+    append_entry B "$feat_marker" "$feat_lead"
     git commit -qam 'feat B'
 }
 
@@ -83,7 +94,7 @@ contribution() {
 # ── The oracle: the gate fails on what the driver actually produces ──────────
 
 @test "the gate FAILS on a separator the union driver just ate (#1271)" {
-    scratch no no
+    scratch no no no
 
     local add_before add_after del_after
     add_before="$(contribution 1)"
@@ -107,7 +118,7 @@ contribution() {
 }
 
 @test "with a marker on both sides, nothing is eaten and the gate passes (#1271)" {
-    scratch B C
+    scratch B C no
 
     local add_before add_after
     add_before="$(contribution 1)"
@@ -129,7 +140,7 @@ contribution() {
     # EITHER entry carries a marker, so no flag day and no sweep of old
     # entries. Measured on the side that would otherwise lose its separator —
     # `feat` here carries none.
-    scratch no C
+    scratch no C no
 
     local add_before add_after
     add_before="$(contribution 1)"
@@ -155,7 +166,7 @@ contribution() {
     # missing marker is an author who did not know the convention. Reporting
     # them as one would send the next reader looking for a rebase that never
     # happened.
-    scratch no no
+    scratch no no no
 
     # No rebase: `feat` is well formed apart from the marker.
     run scripts/design-notes-gate.sh main
@@ -169,7 +180,7 @@ contribution() {
     # bug — one line WORSE than before, because the marker collapses with the
     # separator block it was added to protect. Measured, not assumed: this is
     # why the gate has to check uniqueness and not merely presence.
-    scratch C C
+    scratch C C no
 
     local add_before add_after
     add_before="$(contribution 1)"
@@ -191,7 +202,7 @@ contribution() {
     # entries are perfectly well formed, and the NEXT concurrent rebase is the
     # one that pays. This is the only case that isolates the uniqueness check —
     # once the collapse has happened there is a single marker left to count.
-    scratch B C
+    scratch B C no
     printf '<!-- entry #B -->\n\n---\n\n## 2026-01-03 — entry D\n\nbody D\n' \
         >> docs/DESIGN_NOTES.md
     git commit -qam 'feat D, template copied from B'
@@ -218,7 +229,7 @@ contribution() {
     # This case also PINS the reference. The collision does not exist at the
     # merge base — only at the base REF's tip — so a check written against the
     # merge base measures nothing and this case goes red.
-    scratch C C
+    scratch C C no
 
     run scripts/design-notes-gate.sh main
     [ "$status" -eq 1 ]
@@ -232,7 +243,7 @@ contribution() {
     # takes FOUR lines — one more than carrying no marker at all, because the
     # duplicated marker collapses together with the separator block it was
     # added to protect.
-    scratch C C
+    scratch C C no
 
     local add_before add_after del_after
     add_before="$(contribution 1)"
@@ -251,7 +262,80 @@ contribution() {
     # The negative control for the two cases above: same shape, distinct
     # markers, no rebase. Without it, a check that simply failed every branch
     # carrying a marker would satisfy them both.
-    scratch B C
+    scratch B C no
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 0 ]
+}
+
+# ── The marker's own precondition: it is the FIRST appended line (2011) ──────
+#
+# The marker defeats `merge=union` by making the first appended line DIFFER
+# between the two branches. A blank ahead of it hands the machinery back the
+# most collidable line there is: a blank collides with every entry appended in
+# the legacy shape — `\n---\n\n## ` — which is most of this file's history, and
+# with every other blank-led entry.
+#
+# The four-line window above the heading cannot see that. The marker still sits
+# at p4 and the shape those four lines spell is still exactly canonical, so the
+# stray blank is at p5, outside. A COVERAGE gap, not a broken check — which is
+# why the cure is a fifth line of history and not a new regex.
+
+@test "a blank ahead of the marker is rejected BEFORE the rebase (2011)" {
+    scratch B C blank
+
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"blank line"* ]]
+    [[ "$output" == *"entry B"* ]]
+
+    # Neither of the other two findings: the separator is there and so is the
+    # marker. Reporting either would send the author editing a correct line.
+    refute grep -q "NOT preceded by" <<<"$output"
+    refute grep -q "no <!-- entry ... --> marker line" <<<"$output"
+}
+
+@test "left ungated, the driver eats that blank and the pin goes quiet (2011)" {
+    # What the check above stands in front of, measured rather than argued.
+    # `main` carries no marker here — the legacy shape, and the configuration
+    # the incremental-adoption case above proves is SAFE for a canonical entry.
+    # Blank-led, that same pair loses a line: the blank is not a nit, it is
+    # what disarms the protection the marker exists to give.
+    scratch B no blank
+
+    local add_before add_after del_after
+    add_before="$(contribution 1)"
+
+    run git rebase main
+    [ "$status" -eq 0 ]
+
+    add_after="$(contribution 1)"
+    del_after="$(contribution 2)"
+
+    [ "$del_after" -eq 0 ]
+    [ "$add_after" -eq $((add_before - 1)) ]
+
+    # And the pre-rebase window is the ONLY one. The line the driver ate IS the
+    # offending blank, so what it leaves behind is a canonical entry with
+    # nothing left to find. A check moved after the rebase reports green on
+    # every occurrence of this, which is the shape of a guard that arrives late.
+    run scripts/design-notes-gate.sh main
+    [ "$status" -eq 0 ]
+}
+
+@test "the first entry in a file has nothing above it, and that is no finding (2011)" {
+    # The negative control for the case above, and the one place where "the
+    # line above the marker" does not exist. awk's history variables start
+    # unset, which reads as blank — so without a guard on the fifth line this
+    # well formed entry is reported for a blank nobody wrote. Measured: with
+    # the guard deleted the two cases above stay green and only this one goes
+    # red, which is the whole reason it is here.
+    scratch B C no
+
+    # feat's entry becomes the entire file, putting its marker on line 1.
+    printf '<!-- entry #E -->\n\n---\n\n## 2026-01-04 — entry E\n\nbody E\n' \
+        > docs/DESIGN_NOTES.md
+    git commit -qam 'feat E, and the file now begins with it'
 
     run scripts/design-notes-gate.sh main
     [ "$status" -eq 0 ]
@@ -263,7 +347,7 @@ contribution() {
     # The reachable version of this is a shallow CI checkout, where origin/main
     # simply is not there. Passing would report a green gate that looked at
     # nothing — the exact shape of every guard that fails open.
-    scratch B C
+    scratch B C no
 
     run scripts/design-notes-gate.sh no/such/ref
     [ "$status" -eq 1 ]
@@ -272,7 +356,7 @@ contribution() {
 }
 
 @test "a branch that adds no entry says so, rather than claiming a check" {
-    scratch B C
+    scratch B C no
     git checkout -q main
 
     run scripts/design-notes-gate.sh main
@@ -284,7 +368,7 @@ contribution() {
     # Entries quote shell and markdown constantly. Reading a fenced `## ` as a
     # heading would fail a perfectly well-formed entry and teach the next
     # author to stop quoting.
-    scratch B C
+    scratch B C no
     printf '\n```\n## 2026-01-02 — entry B\n```\n' >> docs/DESIGN_NOTES.md
     git commit -qam 'feat B gains a fenced sample of its own heading'
     git rebase -q main


### PR DESCRIPTION
## The gap

`scripts/design-notes-gate.sh` keeps four lines of history above each added
entry heading and asserts the canonical shape: blank / `---` / blank / marker.
A blank line **ahead of the marker** pushes it to the fifth line, outside the
window, so the four lines the gate inspects still spell exactly the canonical
shape and it reports green.

That is a **coverage** gap, not a broken check, so the cure is a fifth line of
history and one more arm — not a new regex.

## Why a stray blank is not a style nit

The marker defeats `merge=union` by making the FIRST appended line **differ**
between two branches, leaving no identical prefix for the driver to align as a
common addition. A blank ahead of it hands that prefix straight back: a blank
is what every entry in the legacy separator-first shape opens with — most of
this file's history — and what every other blank-led entry opens with too.

Measured on the suite's scratch repo, one row per configuration of the other
side. Every one of them reports `rc=0` and zero deletions:

| this branch | the other side | lines lost |
|---|---|---|
| canonical | canonical | 0 |
| **blank-led** | canonical | 0 |
| canonical | legacy, no marker | 0 |
| **blank-led** | **legacy, no marker** | **1** |
| **blank-led** | **blank-led** | **1** |

Row 3 against row 4 is the finding: the same pair that the incremental-adoption
case proves is SAFE for a canonical entry loses a line once the entry is
blank-led. The blank is precisely what disarms the protection the marker exists
to give.

And the line the driver eats **is that blank**, so afterwards the entry reads
canonical with nothing left to find. The window is therefore before the rebase
and cannot be moved after it — the new oracle case asserts that post-rebase
green on purpose, so nobody "tidies" the check into a place where it is blind.

## The cure

`p5` — a fifth line of history — plus a third arm, reported as its own finding
with its own message. The other two findings are untouched: a stray blank means
the separator is present and so is the marker, and reporting either of those
would send an author editing a correct line.

The arm is guarded on `FNR > 5`. awk history variables start unset and read as
blank, so an entry whose marker is line 1 of the file would otherwise be
reported for a blank nobody wrote.

## Tests

`test/scripts/design_notes_gate_test.bats`, 16 cases, all green.

Three are new, and the two negative controls this class needs were already
there (an eaten separator and an absent marker each `rc=1`), so they are cited
rather than duplicated:

1. a blank ahead of the marker is rejected BEFORE the rebase — **the red one**;
2. left ungated, the driver eats that blank and the pin goes quiet — the
   oracle: a real `git rebase`, one line lost, `rc=0`, zero deletions, and the
   post-rebase gate green;
3. the first entry in a file has nothing above it, and that is no finding — the
   guard's own case.

`scratch()` and `append_entry()` gained a third argument for the shape of the
branch's entry. It is spelled at all 12 call sites rather than defaulted: which
cases feed the gate a malformed entry is what a reader needs to see without
scrolling up.

**Mutation-validated in both directions.** With the cure removed, case 1 goes
red and nothing else. With the `FNR > 5` guard removed, case 3 goes red and
nothing else — measured, because before it was written that guard was live code
no test defended, which is the same class of hole being cured here.

## Measured against real history

Ran the fixed gate against widening ranges of `origin/main`, and against the
unfixed script at the same depths to attribute every red:

| base | entries judged | result |
|---|---|---|
| `origin/main~20` | 10 | `rc=0` |
| `origin/main~50` | 19 | `rc=0` |
| `origin/main~100` | — | `rc=1`, and the unfixed gate is **also** `rc=1` here, on `SEPARATOR` |

Three entries already on `main` do carry a blank ahead of their marker:
`#1261` (line 16494), `#201` (16717), `#1883c` (45652). `git blame` puts the
blank and the marker in the SAME commit for all three, so the blank was added
by the entry's own branch — these are real, not the previous entry's trailing
line. Out of **326 markers** in the corpus that is **0.92 %**; the four archive
files carry 0 markers, predating the convention.

**None of that turns a branch red today**: the gate is diff-scoped, so it judges
only what a branch ADDS, and those three have been in the base for weeks.

**They stay, by ruling**, and the reasoning is recorded in the entry rather than
in a ticket. The damage happened at their own rebase and removing the blank now
does not undo it; a dated entry in this file is history, and rewriting one
destroys the evidence that the shape ever existed; and the gate being
diff-scoped means nobody is looking at them. A separate issue for three blank
lines nobody sees would be a mechanism heavier than the problem.

## Stated limit

The check reads the resulting FILE, not the diff, so a blank belonging to the
PREVIOUS entry's tail would be attributed to the new author. Measured across all
326 markers there are three findings and all three are same-commit: zero false
positives observed, and no reachable case constructed.

## The entry, and the gate it has to pass

`docs/DESIGN_NOTES.md` gains the entry carrying every number above — the debt
named in the log instead of in a ticket, and the limit stated out loud.

It has to survive the check being repaired here, so that was measured rather
than assumed:

- arithmetic **predicted before the append** — 2888976 + 5323 = **2894299**
  bytes, 49346 + 99 = **49445** lines, marker on line **49347**, i.e. the first
  appended line — and every figure matched;
- boundary shape read ON the file: prose full stop / marker with nothing ahead
  of it / blank / `---` / blank / `## `;
- marker unique against the tip of `origin/main` as it stands NOW (absent, with
  a positive control counting the 326 markers the tip does carry);
- the gate run **after** the commit, answering `1 new entry heading(s),
  separator and marker present.` A run with the entry uncommitted answers
  "adds no entry heading" and passes; that empty green is not evidence and is
  not being used as any;
- and the judgement is not vacuous: inserting one blank ahead of this entry's
  own marker, on the real file, turns the gate `rc=1` with a `BLANK` finding
  naming this very heading. Reverted, and the tree is back to the byte.

## Not in this PR

- The three historical entries themselves — left standing, see above.
- `CLAUDE.md`, untouched.

## What CI runs here: four checks, and four is the whole set

Not a truncated nine. `ci.yml` carries no `paths:` filter and exactly four jobs
— `test`, `shottino`, `dialyzer`, `cicchetto` — so all four run. `integration.yml`
IS paths-filtered and none of the three files touched here matches it:
`scripts/design-notes-gate.sh` is not one of the three scripts named in that
list (`integration.sh`, `testnet.sh`, `_lib.sh`), and `test/**` does not appear
in it at all. Verified with a positive control on the matcher —
`lib/grappa/vhosts.ex` does match `lib/**`. So integration does not fire on this
PR, and will not fire on `main` at the merge either. `release.yml` is
tag-triggered and out of the picture.

## Gates

- `scripts/bats.sh test/scripts/design_notes_gate_test.bats` — `rc=0`, 16/16.
- `scripts/shellcheck.sh` — `rc=0` across 83 scripts. The first run was red on
  an `SC2016` this branch introduced; the baseline was clean and is clean again.
- `scripts/design-notes-gate.sh` post-commit — `rc=0`, on the line quoted above.

Refs: issue 2011.
