### PR TITLE
cicchetto: a parked network leaves the sidebar, and the cold load stops orphaning its windows

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -143,7 +143,7 @@ async function seedAuthLocalStorage(page: Page, token: string, subjectJson: stri
 export async function loginAs(
   page: Page,
   vjt: SeededUser,
-  opts: { noNetworks?: boolean } = {},
+  opts: { noSidebarNetworks?: boolean } = {},
 ): Promise<void> {
   await seedAuthLocalStorage(page, vjt.token, vjt.subjectJson);
   await page.goto("/");
@@ -159,19 +159,27 @@ export async function loginAs(
   // OR-style selector would be more brittle than a viewport-
   // conditioned one.
   //
-  // UX-7-C (2026-05-22) — `noNetworks: true` opt-in for users with
-  // NO networks bound (M-7 seeded admin-vjt has no credentials). The
-  // per-network-header selector waits forever in that case; switch
-  // to the registered home pane placeholder ("No networks bound")
-  // which is the post-/me steady-state render for empty-networks
-  // accounts. Opt-in rather than OR-selector because the
-  // `.home-pane-registered` element can RACE in front of the network
-  // section for normal bound users (homeData resolves off /me alone;
-  // network sidebar/bottom-bar wait for /networks + /channels) —
-  // weakening the post-loginAs invariant from "shell fully populated"
-  // to "DOM has homepane scaffolding". Callers that immediately
-  // interact with sidebar/bottom-bar windows would race.
-  if (opts.noNetworks === true) {
+  // UX-7-C (2026-05-22) — opt-in for accounts that will render NO network
+  // row, where the per-network-header selector waits forever; switch to the
+  // registered home pane, which is the post-/me steady state for them. Opt-in
+  // rather than OR-selector because `.home-pane-registered` can RACE in front
+  // of the network section for normal bound users (homeData resolves off /me
+  // alone; network sidebar/bottom-bar wait for /networks + /channels) —
+  // weakening the post-loginAs invariant from "shell fully populated" to "DOM
+  // has homepane scaffolding". Callers that immediately interact with
+  // sidebar/bottom-bar windows would race, so pass this ONLY when the spec
+  // stays on the home pane.
+  //
+  // issue 1985 — named `noSidebarNetworks`, not `noNetworks`, because there
+  // are now TWO ways to get here and the old name is false for the second.
+  // UX-7-C's case is "the account has no credential bound at all" (M-7's
+  // admin-vjt). The new one is "every network the account HAS is `parked`",
+  // which since issue 1985 draws no sidebar row either — the network exists,
+  // it is simply not a window right now, and `$home` is where it lives (with
+  // its [Reconnect] chip). The gate never cared which of the two it was: what
+  // it selects on is whether a network header will ever appear, so the name
+  // says that and one opt covers both.
+  if (opts.noSidebarNetworks === true) {
     await expect(page.locator(".home-pane-registered").first()).toBeVisible({
       timeout: SHELL_READY_TIMEOUT_MS,
     });
@@ -209,7 +217,7 @@ export async function loginAs(
 // Deliberately NOT `loginAs`, though the seeding half is now literally
 // the same call. The seeded admin (`admin-vjt`) has NO networks bound,
 // so `loginAs`'s per-network-header selector never resolves for it;
-// reaching it would mean `noNetworks: true`, whose own comment above
+// reaching it would mean `noSidebarNetworks: true`, whose own comment above
 // calls that a weakening of the post-login invariant. Adopting
 // `loginAs` would also buy `waitForUserTopicReady`, which none of the
 // twenty specs needs today — none of them composes `/join` — and which

--- a/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
@@ -28,18 +28,21 @@
 //      surfaces connection_state=parked → selection.ts:287-316 fires
 //      → selection jumps to Home.
 //   3. Assert: selection is Home, HomePane renders the parked network
-//      card (slug + nick + reason + Reconnect button). Sidebar still
-//      shows the network section with `.sidebar-network-greyed`
-//      (rows remain visible — operator can re-navigate to view
-//      scrollback; greyed-cascade visual is intact).
+//      card (slug + nick + reason + Reconnect button). The sidebar
+//      network section is GONE, and its channel rows with it.
 //   4. Operator clicks `[Reconnect bahamut-test]` on the Home card
 //      (mirrors the same patchNetwork verb /connect would invoke).
 //      Server-side: Networks.connect → eager SpawnOrchestrator → DB
 //      flip + broadcast. Cic-side: networkBySlug.connection_state =
 //      connected → home card re-renders as connected.
-//   5. Assert: sidebar network section ungreys; SEED_CHANNEL row
-//      ungreys after autojoin (typed events flow through subscribe.ts
-//      as before).
+//   5. Assert: the sidebar network section is BACK (not greyed);
+//      SEED_CHANNEL row returns un-greyed after autojoin (typed events
+//      flow through subscribe.ts as before).
+//
+// issue 1985 (2026-09-10) — steps 3 and 5 were rewritten from
+// "stays, greyed" to "leaves, comes back". The spec is not being
+// relaxed: the product owner ruled the previously asserted behaviour
+// wrong. See the in-body comment at the disappearance assertion.
 //
 // Why click Reconnect instead of typing `/connect`: from Home, there
 // IS no ComposeBox — the only way to issue `/connect` from the Home
@@ -125,24 +128,31 @@ test("CP19 T32 — /disconnect parks network + redirects to Home; Reconnect ungr
   const reconnectBtn = parkedCard.getByRole("button", { name: `Reconnect ${NETWORK_SLUG}` });
   await expect(reconnectBtn).toBeEnabled();
 
-  // Sidebar network section gains .sidebar-network-greyed. The
-  // cascading CSS rule (.sidebar-network-section.sidebar-network-
-  // greyed li .sidebar-window-btn) paints channel rows muted+italic
-  // via the network derivation overlay. Operator can still see + re-
-  // navigate to scrollback for the parked channels; the greyed visual
-  // is the cue "this network is parked, no live messages."
-  await expect(networkSection).toHaveClass(/sidebar-network-greyed/, { timeout: 10_000 });
-
-  // Tooltip on the network header carries the reason text. Implemented
-  // as a `title=` attr (zero-bundle-cost; design pass deferred a
-  // richer tooltip).
+  // issue 1985 — THE SIDEBAR SECTION LEAVES. It used to gain
+  // `.sidebar-network-greyed` and stay, and this spec asserted that, with a
+  // comment calling the greyed row the cue "this network is parked, no live
+  // messages" and the operator's way back to the parked channels' scrollback.
   //
-  // UX-5 BH (2026-05-19): legacy `<h3>` per-network header was dropped
-  // in UX-4 bucket C; the `title` attr now lives on
-  // `.sidebar-network-header .sidebar-channel-name` (Sidebar.tsx
-  // L319-326).
-  const networkHeader = networkSection.locator(".sidebar-network-header .sidebar-channel-name");
-  await expect(networkHeader).toHaveAttribute("title", PARK_REASON, { timeout: 5_000 });
+  // That assertion changed because THE PRODUCT OWNER RULED THE ASSERTED
+  // BEHAVIOUR WRONG — not because it was flaky, and not to make this spec
+  // pass. vjt, 2026-09-07: *"sparisce se è disconnected (parked)"*, and on
+  // 2026-09-10 that the parked window's history is reachable from the
+  // ARCHIVE, which is what replaces the greyed row as the way back. A
+  // parked network and every row under it leave the sidebar and come back on
+  // reconnect. `failed` still greys in place; the asymmetry is deliberate.
+  //
+  // The whole section goes, so the reason tooltip that used to sit on the
+  // network header (`.sidebar-network-header .sidebar-channel-name`,
+  // `title=`) has no host any more. The reason is NOT lost to the operator —
+  // it is asserted above on the Home card's `.home-pane-network-reason`,
+  // which is now its only surface.
+  await expect(networkSection).toHaveCount(0, { timeout: 10_000 });
+
+  // The channel rows go with it — they render inside that section, so this
+  // is the same disappearance seen one level down rather than a second
+  // claim. Asserted because "the network header is gone" and "the operator
+  // has no parked channel row" are what a reader will want separated.
+  await expect(channelRow).toHaveCount(0);
 
   // Operator unparks via the Home card's Reconnect chip. Server-side:
   // Networks.connect → eager SpawnOrchestrator → DB flip + broadcast.
@@ -151,23 +161,32 @@ test("CP19 T32 — /disconnect parks network + redirects to Home; Reconnect ungr
   // as a connected row.
   await reconnectBtn.click();
 
-  // Sidebar network section ungreys on the user-topic event (sub-
-  // second).
-  await expect(networkSection).not.toHaveClass(/sidebar-network-greyed/, { timeout: 10_000 });
+  // issue 1985 — the section COMES BACK, which is the other half of the
+  // ruling and the half a disappearance-only assertion would let rot: "and
+  // come back when it reconnects". Was: ungreys in place.
+  await expect(networkSection).toHaveCount(1, { timeout: 10_000 });
+  await expect(networkSection).not.toHaveClass(/sidebar-network-greyed/);
 
   // Parked card flips off the Home pane (the network re-renders as
   // a connected `home-pane-network-row-connected` row, not parked).
   await expect(parkedCard).toHaveCount(0, { timeout: 10_000 });
 
-  // Tooltip is gone (or empty) once the network is connected — the
-  // derivation only attaches a `title=` when the network is in a
-  // greyed state; when connected, the helper returns undefined and
-  // Solid removes the attribute.
-  await expect(networkHeader).not.toHaveAttribute("title", PARK_REASON);
+  // The reason tooltip does not come back either: the derivation only
+  // attaches a `title=` in a greyed state, and a reconnected network is not
+  // one. Re-derived from the returned section rather than the pre-park
+  // locator, which pointed at a node that has since been unmounted.
+  await expect(
+    networkSection.locator(".sidebar-network-header .sidebar-channel-name"),
+  ).not.toHaveAttribute("title", PARK_REASON);
 
-  // Channel row ungreys post-autojoin: SpawnOrchestrator spawns a
-  // fresh Session.Server, the autojoin loop re-JOINs SEED_CHANNEL,
-  // and the typed window-state event flows through subscribe.ts as
-  // before.
-  await expect(channelRow.locator(".sidebar-window-greyed")).toHaveCount(0, { timeout: 15_000 });
+  // Channel row RETURNS post-autojoin, un-greyed: SpawnOrchestrator spawns a
+  // fresh Session.Server, the autojoin loop re-JOINs SEED_CHANNEL, and the
+  // typed window-state event flows through subscribe.ts as before.
+  //
+  // Both halves are asserted since issue 1985. `toHaveCount(0)` on the greyed
+  // child alone is satisfied by a row that never came back at all — it was a
+  // fair assertion while the row could only ever be present-and-greyed, and
+  // it is a hole now that disappearance is a real state.
+  await expect(channelRow).toHaveCount(1, { timeout: 15_000 });
+  await expect(channelRow.locator(".sidebar-window-greyed")).toHaveCount(0);
 });

--- a/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
@@ -81,7 +81,23 @@ test.afterEach(async () => {
   await settleNetworkAutojoin(vjt.token, NETWORK_SLUG, SEED_CHANNEL, specNick());
 });
 
-test("CP19 T32 — /disconnect parks network + redirects to Home; Reconnect ungreys + autojoin restores channel", async ({
+// The title says LEAVES/RETURNS, not "ungreys": under issue 1985 the section
+// disappears rather than greying, and the old title asserted in prose what the
+// body no longer asserts in code. A test title is read as documentation by
+// everyone who never opens the body.
+//
+// It also carries NO regex metacharacter, and that is deliberate. `--grep` is
+// a REGEX, so the previous title could not select itself: it contained
+// `network + redirects`, where `+` quantifies the preceding SPACE, so the
+// pattern demanded two spaces the title does not have. Measured with the JS
+// RegExp engine Playwright uses — `new RegExp(oldTitle).test(oldTitle)` is
+// FALSE, while it is TRUE for this one. A handle that cannot match its own
+// test collects zero tests, and zero tests reports as green.
+//
+// The short, safe handle is `--grep "CP19 T32"`: it is unique among e2e titles
+// (the other CP19 T32 mentions are cic source comments and vitest describes,
+// which Playwright never collects).
+test("CP19 T32 — /disconnect parks network and redirects to Home; the sidebar section leaves and returns un-greyed on Reconnect", async ({
   page,
 }) => {
   const vjt = specUser();

--- a/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
@@ -16,30 +16,43 @@
 // the multi-second connect + SASL + register window against the real bahamut
 // testnet, then clears on 001.
 //
-// issue 1985 (2026-09-10) — THE DRIVER'S PRECONDITION CHANGED, and the
-// change is here because the product owner ruled the old one wrong, not
-// because this spec was flaky and not to make it pass. This comment used to
-// read "sidebar network header stays visible + greyed", i.e. the badge had a
-// host for the whole park. Under vjt's ruling a parked network LEAVES the
-// sidebar, so during the park there is no row and the badge cannot render.
+// issue 1985 (2026-09-10) — THIS SPEC NOW ASSERTS THE OPPOSITE OUTCOME, and
+// the change is here because THE PRODUCT OWNER RULED THE ASSERTED BEHAVIOUR
+// WRONG — NOT because the spec was flaky, and NOT to make it pass.
 //
-// What makes the badge observable anyway is an ORDERING, and the spec now
-// asserts it instead of assuming it: the reconnect PATCH spawns FIRST and
-// commits `:connected` only on spawn success (`NetworksController`'s U-0
-// ordering), and `Session.start_session/3` returns as soon as the GenServer
-// starts — it does not wait for registration. So the DB flip and its
-// `connection_state_changed` broadcast land within milliseconds, the network
-// returns to the sidebar, and the `connecting` flag set moments earlier is
-// still true because it only clears on 001, seconds later. The badge
-// therefore surfaces on the RETURNED row.
+// It used to assert the badge SHOWS during a park→Reconnect cycle, which
+// worked because the parked network kept a greyed sidebar row for the badge
+// to live on. Under vjt's ruling a parked network LEAVES the sidebar
+// entirely, and the badge has exactly one render site — inside the
+// per-network `<For>` in `Sidebar.tsx`. No row, no host, no badge.
 //
-// If that ever stops holding, this spec fails at the named assertion below
-// rather than at a latch that times out for an unstated reason — and the
-// failure is then evidence for the open question of where a parked network
-// shows that it is coming back, which is vjt's to answer.
+// vjt was asked precisely this and answered (2026-09-10, ⚠️ RELAYED into the
+// authoring session, not read on IRC by its author): *"ci si riconnette da
+// HOME"*, *"non SERVE nient'ALTRO"*. So the badge is NOT to be given a new
+// home, the button is NOT to be taught a progress state, and this spec must
+// stop demanding a badge the product deliberately no longer shows.
 //
-// This exercises exactly the #100 reconnect path end-to-end: a session
-// that is not currently connected coming back up, surfaced to the user.
+// AN EARLIER REVISION OF THIS COMMENT WAS WRONG AND IS CORRECTED HERE RATHER
+// THAN QUIETLY DROPPED. It argued the badge would surface anyway on an
+// ORDERING: the reconnect PATCH spawns first and commits `:connected` on
+// spawn success, `Session.start_session/3` returns at GenServer start rather
+// than at registration, so the row returns in milliseconds while `connecting`
+// (which clears only on 001) is still set. MEASURED: the ordering half is
+// TRUE — the section does come back, and this spec still asserts that — but
+// the conclusion drawn from it was FALSE. The badge never entered the DOM in
+// three consecutive runs; at timeout the page showed the network back and
+// fully registered (`+ix`, unread counts). Whatever the flag's timing, the
+// operator sees no badge, and that is what gets asserted.
+//
+// ⚠️ COVERAGE LOST, STATED PLAINLY. This was the ONLY e2e spec asserting the
+// badge RENDERS (the two other specs naming it only borrow its cleanup
+// ritual). Re-aimed this way, no e2e test covers the badge appearing at all —
+// including on a spontaneous link drop, where the row is present and the
+// badge presumably still works. That path was never covered here either (this
+// spec always drove through a park), so nothing that WAS covered is being
+// dropped silently; but the badge's render is now unguarded end-to-end. Its
+// machinery keeps unit coverage in `userTopic.test.ts` (the
+// `connection_progress` → `setReconnecting` dispatch); the RENDER has none.
 //
 // CLEANUP: afterEach reconnects the network (best-effort) and polls
 // GET /channels until autojoin restores #spec-wN — same discipline as
@@ -83,7 +96,11 @@ test.afterEach(async () => {
   }
 });
 
-test("#100 — reconnecting badge shows while a parked network reconnects, then clears on connect", async ({
+// Title carries no regex metacharacter on purpose: `--grep` is a REGEX, and a
+// title that cannot match itself collects zero tests, which reports as green.
+// Short handle: `--grep "#100 — reconnecting badge"`. Plain `#100` is NOT
+// safe — it is a prefix of #1004, #1061 and others.
+test("#100 — reconnecting badge has no surface while a parked network reconnects, and the network returns anyway", async ({
   page,
 }) => {
   const vjt = specUser();
@@ -118,14 +135,13 @@ test("#100 — reconnecting badge shows while a parked network reconnects, then 
   const reconnectBtn = parkedCard.getByRole("button", { name: `Reconnect ${NETWORK_SLUG}` });
   await expect(reconnectBtn).toBeEnabled();
 
-  // Install a MutationObserver latch BEFORE triggering the reconnect. The
-  // "reconnecting…" badge is inherently transient — it shows on `connecting`
-  // and clears on `001`, a window that can be sub-second on a healthy
-  // testnet. Racing `toBeVisible` against that flash is flaky by
-  // construction; the observer catches the badge the instant it enters the
-  // DOM regardless of how briefly it lives, latching a window flag we then
-  // await. This asserts the real outcome (the badge DID surface on the
-  // reconnect) deterministically.
+  // The SAME MutationObserver latch as before the ruling, doing the same job
+  // in the opposite direction. It watches the WHOLE document — not the
+  // network section — and flips the instant a badge enters the DOM anywhere,
+  // however briefly. Before the ruling that made a transient appearance
+  // provable without racing it; now it makes a NON-appearance provable, which
+  // a polled `toHaveCount(0)` never could: a sub-second flash between two
+  // polls would pass an assertion that claims the badge never showed.
   await page.evaluate(() => {
     const w = window as unknown as { __cic_reconnectBadgeSeen?: boolean };
     w.__cic_reconnectBadgeSeen = false;
@@ -148,31 +164,34 @@ test("#100 — reconnecting badge shows while a parked network reconnects, then 
   // connect + SASL + register window.
   await reconnectBtn.click();
 
-  // issue 1985 — the network must come BACK before the badge can render, and
-  // that return is the ordering this spec now depends on (spawn-then-commit,
-  // with the commit not waiting for registration). Asserted before the latch
-  // so a failure says WHICH link broke: no section back = the ordering
-  // changed; section back but no badge = the badge itself.
+  // The network comes BACK. Asserted FIRST, and it is what keeps the
+  // no-badge assertion below from being vacuous: an absence proves nothing on
+  // a client that never reconnected at all. The ordering behind the return is
+  // real and still worth naming — spawn-then-commit, `Session.start_session/3`
+  // returning at GenServer start rather than at registration — so the row is
+  // back long before 001.
   await expect(networkSection).toHaveCount(1, { timeout: 20_000 });
 
-  // The latch flips true the moment the badge enters the DOM — proves the
-  // transient "reconnecting…" badge surfaced on the reconnect.
-  await page.waitForFunction(
-    () =>
-      (window as unknown as { __cic_reconnectBadgeSeen?: boolean }).__cic_reconnectBadgeSeen ===
-      true,
-    undefined,
-    { timeout: 20_000 },
-  );
-
-  // On 001 RPL_WELCOME the server broadcasts `connected` → badge clears.
-  // Steady-state assertion (deterministic, not a flash).
-  await expect(reconnectingBadge).toHaveCount(0, { timeout: 20_000 });
-
-  // Sanity: the network actually came back — the channel row RETURNS and is
-  // un-greyed after autojoin (proves the reconnect completed, not just that
-  // the badge vanished). Both halves since issue 1985: the greyed-child count
-  // alone is also satisfied by a row that never came back.
+  // Reconnect fully completed: the channel row RETURNS un-greyed after
+  // autojoin. This closes the observation window — everything the badge could
+  // possibly have had to say has now been said.
   await expect(channelRow).toHaveCount(1, { timeout: 15_000 });
   await expect(channelRow.locator(".sidebar-window-greyed")).toHaveCount(0);
+
+  // THE RULED OUTCOME: across the whole window just closed — from before the
+  // Reconnect click to a fully restored network — the badge never existed
+  // anywhere in the document. Not "is absent now", which a flash would
+  // satisfy: never appeared, once, at any moment.
+  //
+  // The badge is not broken and is not being worked around. It renders in one
+  // place, inside the per-network row, and a parked network has no row — the
+  // accepted collateral of the ruling, asserted here so it stays a decision
+  // and does not quietly become a regression nobody notices.
+  const badgeEverSeen = await page.evaluate(
+    () => (window as unknown as { __cic_reconnectBadgeSeen?: boolean }).__cic_reconnectBadgeSeen,
+  );
+  expect(badgeEverSeen).toBe(false);
+
+  // Steady state agrees with the latch, from the other direction.
+  await expect(reconnectingBadge).toHaveCount(0);
 });

--- a/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
@@ -10,13 +10,33 @@
 // (which stays :connected through a transient reconnect); the badge is
 // an ephemeral overlay cic mirrors, never originates.
 //
-// Driver: the proven park→Reconnect cycle. `/disconnect` parks the
-// network (selection redirects to Home, sidebar network header stays
-// visible + greyed). Clicking the Home Reconnect chip fires
-// Networks.connect → eager SpawnOrchestrator → a fresh Session.Server
-// whose do_start_client broadcasts `connecting` — so the badge appears
-// on the network-header row during the multi-second connect + SASL +
-// register window against the real bahamut testnet, then clears on 001.
+// Driver: the proven park→Reconnect cycle. Clicking the Home Reconnect chip
+// fires Networks.connect → eager SpawnOrchestrator → a fresh Session.Server
+// whose do_start_client broadcasts `connecting` — so the badge shows during
+// the multi-second connect + SASL + register window against the real bahamut
+// testnet, then clears on 001.
+//
+// issue 1985 (2026-09-10) — THE DRIVER'S PRECONDITION CHANGED, and the
+// change is here because the product owner ruled the old one wrong, not
+// because this spec was flaky and not to make it pass. This comment used to
+// read "sidebar network header stays visible + greyed", i.e. the badge had a
+// host for the whole park. Under vjt's ruling a parked network LEAVES the
+// sidebar, so during the park there is no row and the badge cannot render.
+//
+// What makes the badge observable anyway is an ORDERING, and the spec now
+// asserts it instead of assuming it: the reconnect PATCH spawns FIRST and
+// commits `:connected` only on spawn success (`NetworksController`'s U-0
+// ordering), and `Session.start_session/3` returns as soon as the GenServer
+// starts — it does not wait for registration. So the DB flip and its
+// `connection_state_changed` broadcast land within milliseconds, the network
+// returns to the sidebar, and the `connecting` flag set moments earlier is
+// still true because it only clears on 001, seconds later. The badge
+// therefore surfaces on the RETURNED row.
+//
+// If that ever stops holding, this spec fails at the named assertion below
+// rather than at a latch that times out for an unstated reason — and the
+// failure is then evidence for the open question of where a parked network
+// shows that it is coming back, which is vjt's to answer.
 //
 // This exercises exactly the #100 reconnect path end-to-end: a session
 // that is not currently connected coming back up, surfaced to the user.
@@ -81,10 +101,15 @@ test("#100 — reconnecting badge shows while a parked network reconnects, then 
   // Baseline: connected → no reconnecting badge.
   await expect(reconnectingBadge).toHaveCount(0);
 
-  // Park the network. Selection redirects to Home; the sidebar network
-  // header row stays rendered (greyed), so the badge has a home to
-  // appear on when the reconnect fires.
+  // Park the network. Selection redirects to Home and — issue 1985 — the
+  // sidebar network section LEAVES, taking the badge's host with it.
   await composeSend(page, `/disconnect ${NETWORK_SLUG} ${PARK_REASON}`, { expectUnmount: true });
+
+  // The disappearance is asserted here rather than left as background: it is
+  // the precondition that makes the rest of this spec a real test of the
+  // ordering. Without it, a badge seen later could be a badge that never
+  // went away.
+  await expect(networkSection).toHaveCount(0, { timeout: 10_000 });
 
   const parkedCard = page.locator(".home-pane-network-row-parked", {
     has: page.locator(".home-pane-network-slug", { hasText: NETWORK_SLUG }),
@@ -123,6 +148,13 @@ test("#100 — reconnecting badge shows while a parked network reconnects, then 
   // connect + SASL + register window.
   await reconnectBtn.click();
 
+  // issue 1985 — the network must come BACK before the badge can render, and
+  // that return is the ordering this spec now depends on (spawn-then-commit,
+  // with the commit not waiting for registration). Asserted before the latch
+  // so a failure says WHICH link broke: no section back = the ordering
+  // changed; section back but no badge = the badge itself.
+  await expect(networkSection).toHaveCount(1, { timeout: 20_000 });
+
   // The latch flips true the moment the badge enters the DOM — proves the
   // transient "reconnecting…" badge surfaced on the reconnect.
   await page.waitForFunction(
@@ -137,8 +169,10 @@ test("#100 — reconnecting badge shows while a parked network reconnects, then 
   // Steady-state assertion (deterministic, not a flash).
   await expect(reconnectingBadge).toHaveCount(0, { timeout: 20_000 });
 
-  // Sanity: the network actually came back — channel row ungreys after
-  // autojoin (proves the reconnect completed, not just that the badge
-  // vanished).
-  await expect(channelRow.locator(".sidebar-window-greyed")).toHaveCount(0, { timeout: 15_000 });
+  // Sanity: the network actually came back — the channel row RETURNS and is
+  // un-greyed after autojoin (proves the reconnect completed, not just that
+  // the badge vanished). Both halves since issue 1985: the greyed-child count
+  // alone is also satisfied by a row that never came back.
+  await expect(channelRow).toHaveCount(1, { timeout: 15_000 });
+  await expect(channelRow.locator(".sidebar-window-greyed")).toHaveCount(0);
 });

--- a/cicchetto/e2e/tests/issue481-user-accretion.spec.ts
+++ b/cicchetto/e2e/tests/issue481-user-accretion.spec.ts
@@ -52,9 +52,9 @@ test.describe("#481 user self-serve accretion", () => {
   test("a USER one-taps an available network from home and it connects live", async ({ page }) => {
     const user = getSeededAccreteUser();
     // accr481 holds NO network → home renders the self-serve empty state
-    // (noNetworks: true waits on the registered home pane, not a sidebar
+    // (noSidebarNetworks: true waits on the registered home pane, not a sidebar
     // network header that does not exist yet).
-    await loginAs(page, user, { noNetworks: true });
+    await loginAs(page, user, { noSidebarNetworks: true });
 
     // #481 — the self-serve "available to connect" section renders for a
     // USER now (it was visibly present only for visitors before).

--- a/cicchetto/e2e/tests/issue630-flood-protection.spec.ts
+++ b/cicchetto/e2e/tests/issue630-flood-protection.spec.ts
@@ -64,12 +64,12 @@ test("sustained inbound flood 429s then severs the web session; a second subject
 
   // Flooder — a live, authenticated cicchetto page on the DEDICATED
   // sacrificial victim (NEVER vjt: the sever revokes this bearer) with an
-  // open WS. `noNetworks: true` — the victim is bind-less (no live
+  // open WS. `noSidebarNetworks: true` — the victim is bind-less (no live
   // Session.Server → invisible to the /admin/sessions leak canary, no
   // user-cap slot), so loginAs gates on the registered empty-home pane +
   // the user-topic subscribe (which delivers the sever event → banner),
   // not a network header that never renders.
-  await loginAs(page, getSeededFloodVictim(), { noNetworks: true });
+  await loginAs(page, getSeededFloodVictim(), { noSidebarNetworks: true });
 
   // Capture the flood bearer BEFORE the sever (cic clears localStorage on
   // logout) so we can prove the OLD credential is refused afterwards.

--- a/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
@@ -523,7 +523,7 @@ test("@webkit @touch UX-4-Z cluster — case-fix + home + sidebar collapse + clo
     // logic above relies on vjt being seeded).
     const adminPage = await context.newPage();
     const admin = getSeededAdmin();
-    await loginAs(adminPage, admin, { noNetworks: true });
+    await loginAs(adminPage, admin, { noSidebarNetworks: true });
     // #71 INC-2 — settings reachable for the home selection (bucket L). On
     // mobile the door is the ☰ rail opener; assert it, then reach settings via
     // the rail helper (admin-on-home case).

--- a/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
@@ -115,7 +115,17 @@ test("UX-5 BR — Home pane [Reconnect] chip reconnects a parked network", async
   });
 
   // Cic lands on HomePane post-login (UX-4 bucket B selection default).
-  await loginAs(page, vjt);
+  //
+  // issue 1985 — `noSidebarNetworks` because the PATCH above parked the only
+  // network this user has, and a parked network no longer draws a sidebar
+  // row. `loginAs`'s default gate waits on `.sidebar-network-header`, which
+  // for this account can now never appear: not a flake, a shell-ready proxy
+  // that stopped describing this state. The weaker home-pane gate is the
+  // right one HERE — everything below reads `.home-pane-*` or goes to REST,
+  // and nothing touches the sidebar, which is the race the opt's comment
+  // warns about. `waitForUserTopicReady` still runs inside that branch, so
+  // the WS barrier the chip click depends on is unchanged.
+  await loginAs(page, vjt, { noSidebarNetworks: true });
   const homePane = page.locator(".home-pane-registered");
   await expect(homePane).toBeVisible({ timeout: 10_000 });
 
@@ -240,7 +250,10 @@ test("UX-5 BR — chip surfaces friendly error inline when cap is exceeded", asy
   });
   await adminPatchCaps(admin.token, NETWORK_SLUG, { max_concurrent_user_sessions: 0 });
 
-  await loginAs(page, vjt);
+  // issue 1985 — same reason as the arm above: the only network is parked, so
+  // no sidebar header will appear and the default shell-ready gate cannot
+  // fire. This arm never leaves the home pane either.
+  await loginAs(page, vjt, { noSidebarNetworks: true });
   const homePane = page.locator(".home-pane-registered");
   await expect(homePane).toBeVisible({ timeout: 10_000 });
 

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -38,6 +38,7 @@ import { install, registerHandlers, uninstall } from "./lib/keybindings";
 import { loadLastFocused } from "./lib/lastFocusedChannel";
 import { mentionsBundleBySlug } from "./lib/mentionsWindow";
 import { openMembersPanel, toggleMembersPanel } from "./lib/mobilePanel";
+import { isNetworkParked } from "./lib/networkParked";
 import { channelsBySlug, isAdmin, networkBySlug, networks, user } from "./lib/networks";
 import { nickEquals } from "./lib/nickEquals";
 import { createOverlayLock, overlayCount } from "./lib/overlayScrollLock";
@@ -498,6 +499,8 @@ const Shell: Component = () => {
   // Issue #35 (2026-06-01) — before defaulting to `$home`, restore the
   // last focused channel/query/server window from localStorage
   // (`lib/lastFocusedChannel.ts`). Validity gate:
+  //   * any kind → its network must not be `parked` (issue 1985 — a parked
+  //     network has no sidebar row to point at the restored pane).
   //   * channel → must appear in `channelsBySlug()[slug]`.
   //   * query   → must appear in `queryWindowsByNetwork()[net.id]`.
   //   * server  → its network must be live in `networkBySlug(slug)`.
@@ -559,6 +562,40 @@ const Shell: Component = () => {
     }
 
     const slug = saved.networkSlug;
+    // issue 1985 — a parked network has no sidebar row, so restoring a window
+    // under it would leave a pane the sidebar cannot point at. vjt's ruling
+    // (2026-09-08): redirect to home.
+    //
+    // The gate belongs HERE, in the restore's existing validity check, and not
+    // in selection.ts's bucket-D park redirect. Bucket D is transition-only on
+    // purpose (`prev === undefined` skips the first observation), and a cold
+    // load is exactly where there IS no previous value to transition from —
+    // which is why the disappearance left an orphan pane at reload while the
+    // live park path was already covered. Widening bucket D to fire on a
+    // non-transition would make every boot re-decide the selection for every
+    // network; one clause in the gate that already asks "is the saved window
+    // still somewhere the operator can be" is the same question, asked once.
+    //
+    // TERMINAL, like the no-saved-window branch above and unlike the
+    // provisional `$home` below: the ruling says redirect to home, and a
+    // non-latching gate would keep re-attempting on every resource update and
+    // yank focus off home the moment the operator hit [Reconnect] on `$home`.
+    // Landing home and staying there is what was asked for.
+    //
+    // `parked` only — NOT "any non-connected state". A `failed` network keeps
+    // its greyed sidebar row, so its saved window still has somewhere to be
+    // and must still restore.
+    if (isNetworkParked(networkBySlug(slug))) {
+      if (sel === null) {
+        setSelectedChannel({
+          networkSlug: HOME_WINDOW_SLUG,
+          channelName: HOME_WINDOW_NAME,
+          kind: "home",
+        });
+      }
+      coldLoadDone = true;
+      return;
+    }
     let restored = false;
     if (saved.kind === "channel") {
       const list = cbs[slug] ?? [];

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -1,9 +1,11 @@
 import { type Component, For, Show } from "solid-js";
 import CloseButton from "./CloseButton";
+import type { Network } from "./lib/api";
 import { ownNickForNetwork } from "./lib/api";
 import { awayByNetwork } from "./lib/awayStatus";
 import { channelKey } from "./lib/channelKey";
 import { mentionsBundleBySlug } from "./lib/mentionsWindow";
+import { isNetworkParked } from "./lib/networkParked";
 import { channelsBySlug, isAdmin, networkBySlug, networks, user } from "./lib/networks";
 import { navPseudoChannelsForNetwork } from "./lib/pseudoChannels";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
@@ -94,7 +96,15 @@ import WindowBadges from "./WindowBadges";
 // compose box on every network that blinks. The state is still visible:
 // HomePane routes anything that is not `connected` to the disconnected
 // row, which renders the word AND `connection_state_reason`.
-const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
+//
+// issue 1985 — `parked` is no longer in this set either, and for the
+// opposite reason: it does not need greying because it does not RENDER.
+// A parked network leaves the sidebar entirely (`isNetworkParked`, the
+// shared predicate in lib/networks.ts), so the only network state that can
+// still reach the cascade below is `failed`. Leaving `parked` here would be
+// a second, unreachable statement of the parked policy, and the next reader
+// would take it for the live one.
+const NETWORK_GREYED_STATES = new Set(["failed"]);
 
 // #96 — a row's state, spoken. Every non-live sidebar row is rendered muted +
 // italic and NOTHING else: a screen reader gets no signal at all, and the
@@ -146,6 +156,22 @@ const Sidebar: Component<Props> = (props) => {
   };
 
   const isNetworkGreyed = (slug: string): boolean => networkGreyedState(slug) !== null;
+
+  // issue 1985 — the networks the sidebar actually draws. A parked network is
+  // dropped here, at the ONE loop, rather than by each row branch deciding for
+  // itself: the header, the channels, the queries and the pseudo-rows are all
+  // rendered inside it, so removing the network removes all four by
+  // construction and none of them can be forgotten later.
+  //
+  // The `<Show>` around the loop deliberately still counts the RAW list. It
+  // answers "does this operator have any network bound at all", and its
+  // fallback says "no networks" — a truthful sentence about zero networks and
+  // a lie about two parked ones. With every network parked the sidebar draws
+  // the home row and nothing else, which is the honest rendering of the
+  // ruling: the networks are still there, `$home` still lists them with their
+  // [Reconnect] chip, they are just not windows right now.
+  const visibleNetworks = (): Network[] =>
+    (networks() ?? []).filter((network) => !isNetworkParked(network));
 
   // Network cascade wins over the per-window state deliberately: when the
   // credential is parked, EVERY row under it is unreachable regardless of
@@ -276,7 +302,7 @@ const Sidebar: Component<Props> = (props) => {
         when={(networks()?.length ?? 0) > 0}
         fallback={<p class="muted sidebar-empty">no networks</p>}
       >
-        <For each={networks()}>
+        <For each={visibleNetworks()}>
           {(network) => (
             <>
               {/* #96 — the per-network <ul> is the grouping the sidebar draws

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -158,6 +158,14 @@ const channelsHolder = vi.hoisted(() => {
   };
 });
 
+// issue 1985 — the network `networkBySlug("freenode")` resolves to during a
+// cold load. `null` (the default) reproduces the pre-1985 mock, which returned
+// `undefined` for every slug. Plain holder, not a signal: the restore gate
+// latches on the first pass, so no test needs it to notify mid-render.
+const networkHolder = vi.hoisted(() => ({
+  value: null as { kind: string; id: number; slug: string; connection_state: string } | null,
+}));
+
 vi.mock("@solidjs/router", () => ({
   useNavigate: () => vi.fn(),
 }));
@@ -177,7 +185,12 @@ vi.mock("../lib/networks", () => ({
     const u = userHolder.current;
     return u?.kind === "user" && u.is_admin === true;
   },
-  networkBySlug: () => undefined,
+  // issue 1985 — the cold-load restore gate asks whether the saved window's
+  // network is parked. Default `undefined` keeps every pre-1985 test on the
+  // behaviour it was written against (no network → not parked → restore
+  // proceeds); the 1985 tests opt in by setting the holder.
+  networkBySlug: (slug: string) =>
+    slug === "freenode" ? (networkHolder.value ?? undefined) : undefined,
 }));
 
 // #606 — RailContext's query context auto-fetches WHOIS on select via
@@ -489,6 +502,8 @@ beforeEach(async () => {
   userHolder.current = { kind: "user", id: "u1", name: "vjt", is_admin: false, inserted_at: "x" };
   // UX-4 bucket M default — no token unless a test opts in.
   tokenHolder.value = null;
+  // issue 1985 default — no resolvable network, i.e. the pre-1985 mock.
+  networkHolder.value = null;
 });
 
 describe("Shell — three-pane integration", () => {
@@ -637,6 +652,95 @@ describe("Shell — three-pane integration", () => {
 
     // Reactive restore overrides the provisional $home → #b is selected.
     // (A decide-once arm would have disarmed after $home and never fire this.)
+    await waitFor(() => {
+      expect(selectionState.setSelectedChannelMock).toHaveBeenCalledWith({
+        networkSlug: "freenode",
+        channelName: "#b",
+        kind: "channel",
+      });
+    });
+  });
+
+  it("issue 1985 — a saved window under a PARKED network lands on home, not on the window", async () => {
+    // The orphan the disappearance would otherwise leave: bucket D's park
+    // redirect in selection.ts is transition-only (`prev === undefined` skips
+    // the first observation), and a cold load has no previous value to
+    // transition from — so nothing walked the selection back, and the pane
+    // would have rendered a window the sidebar no longer draws a row for.
+    // vjt's ruling (2026-09-08): redirect to home.
+    networkHolder.value = { kind: "user", id: 1, slug: "freenode", connection_state: "parked" };
+    saveLastFocused("u1", {
+      networkSlug: "freenode",
+      channelName: "#b",
+      kind: "channel",
+    });
+
+    render(() => <Shell />);
+
+    await waitFor(() => {
+      expect(selectionState.setSelectedChannelMock).toHaveBeenCalledWith({
+        networkSlug: "$home",
+        channelName: "$home",
+        kind: "home",
+      });
+    });
+    // #b IS in channelsBySlug — the restore would have fired without the gate,
+    // which is what makes this an assertion about the gate and not about a
+    // missing channel.
+    expect(selectionState.setSelectedChannelMock).not.toHaveBeenCalledWith({
+      networkSlug: "freenode",
+      channelName: "#b",
+      kind: "channel",
+    });
+  });
+
+  it("issue 1985 — home is TERMINAL: the network reconnecting does not yank focus back", async () => {
+    // The gate latches instead of re-attempting. A non-latching gate would
+    // re-run on the next resource update and pull the operator off home the
+    // moment they hit [Reconnect] on `$home` — a delayed jump nobody asked
+    // for, and not what "redirect to home" says.
+    networkHolder.value = { kind: "user", id: 1, slug: "freenode", connection_state: "parked" };
+    saveLastFocused("u1", {
+      networkSlug: "freenode",
+      channelName: "#b",
+      kind: "channel",
+    });
+
+    render(() => <Shell />);
+    await waitFor(() => {
+      expect(selectionState.setSelectedChannelMock).toHaveBeenCalledWith({
+        networkSlug: "$home",
+        channelName: "$home",
+        kind: "home",
+      });
+    });
+
+    // The network comes back and the channel list refetches.
+    networkHolder.value = { kind: "user", id: 1, slug: "freenode", connection_state: "connected" };
+    channelsHolder.current = { freenode: [{ name: "#b", joined: true, source: "autojoin" }] };
+    await Promise.resolve();
+
+    expect(selectionState.setSelectedChannelMock).not.toHaveBeenCalledWith({
+      networkSlug: "freenode",
+      channelName: "#b",
+      kind: "channel",
+    });
+  });
+
+  it("issue 1985 — a saved window under a FAILED network still restores (parked only)", async () => {
+    // The mutation in the other direction. A failed network keeps its greyed
+    // sidebar row, so its saved window still has somewhere to be — the ruling
+    // is about `parked`, and generalising it to "any non-connected state"
+    // would silently take `failed` and `failing` with it.
+    networkHolder.value = { kind: "user", id: 1, slug: "freenode", connection_state: "failed" };
+    saveLastFocused("u1", {
+      networkSlug: "freenode",
+      channelName: "#b",
+      kind: "channel",
+    });
+
+    render(() => <Shell />);
+
     await waitFor(() => {
       expect(selectionState.setSelectedChannelMock).toHaveBeenCalledWith({
         networkSlug: "freenode",

--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let mockNetworkConnectionState: Record<string, string | undefined> = {};
 let mockNetworkConnectionReason: Record<string, string | null | undefined> = {};
+// issue 1985 — the hide narrows on `kind` before it reads
+// `connection_state`, so proving the narrow needs a network that is NOT a
+// user network. Mutable here rather than a second entry in the `networks()`
+// array: an extra network would add rows to every other test in this file.
+let mockNetworkKind: Record<string, string | undefined> = {};
 // UX-4 bucket N — mutable holder so individual tests can flip the
 // admin gate on/off. `isAdmin()` in Sidebar drives the new admin row
 // visibility; default false to keep pre-N tests unchanged.
@@ -35,7 +40,9 @@ vi.mock("../lib/networks", () => ({
       // Tests here exercise the user branch — visitors don't have a
       // connection_state to grey out, so the visitor variant is
       // covered by an explicit absence test below.
-      kind: "user",
+      get kind() {
+        return mockNetworkKind.freenode ?? "user";
+      },
       id: 1,
       slug: "freenode",
       nick: "vjt",
@@ -60,7 +67,7 @@ vi.mock("../lib/networks", () => ({
   networkBySlug: (slug: string) => {
     if (slug !== "freenode") return undefined;
     return {
-      kind: "user",
+      kind: mockNetworkKind.freenode ?? "user",
       id: 1,
       slug: "freenode",
       nick: "vjt",
@@ -236,6 +243,7 @@ beforeEach(() => {
   mockWindowState = {};
   mockNetworkConnectionState = {};
   mockNetworkConnectionReason = {};
+  mockNetworkKind = {};
   mockAwayByNetwork = {};
   mockMentionsBundles = {};
   mockSelectedChannel = null;
@@ -567,27 +575,26 @@ describe("Sidebar", () => {
   });
 
   // CP19 T32 parked-window — per-network derivation overlay. When the
-  // network's credential `connection_state ∈ {parked, failed}`, the
-  // network header gets `.sidebar-network-greyed` AND every channel/
-  // query row under it derives as greyed regardless of its individual
-  // `windowStateByChannel` entry. Source: `networkBySlug[slug]` (refreshed
-  // via the user-topic `connection_state_changed` event arm in
-  // `userTopic.ts`). Per CLAUDE.md "Don't duplicate state — derive it"
-  // — the cascade is one conditional in `isGreyed`, not a parallel state
-  // map. Symmetric on `:failed` (server-side terminal failure).
+  // network's credential `connection_state == failed`, the network header
+  // gets `.sidebar-network-greyed` AND every channel/query row under it
+  // derives as greyed regardless of its individual `windowStateByChannel`
+  // entry. Source: `networkBySlug[slug]` (refreshed via the user-topic
+  // `connection_state_changed` event arm in `userTopic.ts`). Per CLAUDE.md
+  // "Don't duplicate state — derive it" — the cascade is one conditional in
+  // `isGreyed`, not a parallel state map.
+  //
+  // issue 1985 — `parked` USED to cascade here too, and every assertion in
+  // this block was written against it. It no longer reaches the cascade at
+  // all: a parked network leaves the sidebar, so there is no header to grey
+  // and no row to cascade onto. The rules this block protects are unchanged
+  // and are now stated on `failed`, the one state that still renders greyed
+  // in place. The disappearance itself lives in its own block below.
   //
   // UX-5 BH (2026-05-19): the legacy `<section class="sidebar-network">`
   // wrapper was killed; the per-network `<ul>` now carries
   // `.sidebar-network-section` + the `.sidebar-network-greyed` class.
   // `.closest("section")` is replaced by `.closest(".sidebar-network-section")`.
-  describe("CP19 T32 — per-network parked/failed derivation overlay", () => {
-    it("network header gets .sidebar-network-greyed when connection_state=parked", () => {
-      mockNetworkConnectionState = { freenode: "parked" };
-      render(() => <Sidebar />);
-      const header = screen.getByText("freenode").closest(".sidebar-network-section");
-      expect(header?.classList.contains("sidebar-network-greyed")).toBe(true);
-    });
-
+  describe("CP19 T32 — per-network failed derivation overlay", () => {
     it("network header gets .sidebar-network-greyed when connection_state=failed", () => {
       mockNetworkConnectionState = { freenode: "failed" };
       render(() => <Sidebar />);
@@ -602,12 +609,14 @@ describe("Sidebar", () => {
       expect(header?.classList.contains("sidebar-network-greyed")).toBe(false);
     });
 
-    it("channel rows cascade greyed when network is parked, even if window state is joined", () => {
+    it("channel rows cascade greyed when network is failed, even if window state is joined", () => {
       // Critical derivation rule: stale `windowStateByChannel` entries
-      // (which retain the pre-park values until the GenServer is dead +
-      // a reconnect re-emits) MUST NOT win over the network-level park.
-      // If they did, /disconnect would leave channels visually live.
-      mockNetworkConnectionState = { freenode: "parked" };
+      // (which retain the pre-failure values until the GenServer is dead +
+      // a reconnect re-emits) MUST NOT win over the network-level state.
+      // If they did, a failed network would leave channels visually live.
+      // Stated on `failed` since issue 1985 — a parked network no longer
+      // draws the rows this rule is about.
+      mockNetworkConnectionState = { freenode: "failed" };
       mockWindowState = { "freenode #italia": "joined" };
       render(() => <Sidebar />);
       const li = screen.getByText("#italia").closest("li");
@@ -624,8 +633,8 @@ describe("Sidebar", () => {
       expect(btn?.classList.contains("sidebar-window-greyed")).toBe(true);
     });
 
-    it("query rows cascade greyed when network is parked", () => {
-      mockNetworkConnectionState = { freenode: "parked" };
+    it("query rows cascade greyed when network is failed", () => {
+      mockNetworkConnectionState = { freenode: "failed" };
       render(() => <Sidebar />);
       const li = screen.getByText("alice").closest("li");
       const btn = li?.querySelector(".sidebar-window-btn");
@@ -650,12 +659,12 @@ describe("Sidebar", () => {
       ).toBe(false);
     });
 
-    it("network header tooltip carries the connection_state_reason when parked", () => {
-      mockNetworkConnectionState = { freenode: "parked" };
-      mockNetworkConnectionReason = { freenode: "testing parked state" };
+    it("network header tooltip carries the connection_state_reason when failed", () => {
+      mockNetworkConnectionState = { freenode: "failed" };
+      mockNetworkConnectionReason = { freenode: "testing failed state" };
       render(() => <Sidebar />);
       const h3 = screen.getByText("freenode");
-      expect(h3.getAttribute("title")).toBe("testing parked state");
+      expect(h3.getAttribute("title")).toBe("testing failed state");
     });
 
     it("network header tooltip is absent when connected (no reason to show)", () => {
@@ -664,6 +673,97 @@ describe("Sidebar", () => {
       render(() => <Sidebar />);
       const h3 = screen.getByText("freenode");
       expect(h3.getAttribute("title")).toBeNull();
+    });
+  });
+
+  // issue 1985 — a parked network LEAVES the sidebar. vjt's ruling
+  // (2026-09-07, option 1 of the issue): "sparisce se è disconnected
+  // (parked)" — the network and every row under it are gone while
+  // `connection_state == parked`, and come back when it reconnects. No
+  // collapsed section, no parked area (option 2 dropped; #450 stays separate).
+  //
+  // `failed` is the deliberate asymmetry and the block above still owns it: a
+  // failure is something the operator must SEE, so a failed network keeps its
+  // greyed row in place. Every test here that names `parked` has a `failed`
+  // twin asserting the opposite outcome — the pair is what makes this a
+  // measurement of the rule rather than of the filter's existence.
+  describe("issue 1985 — a parked network leaves the sidebar", () => {
+    it("draws no section at all for a parked network", () => {
+      mockNetworkConnectionState = { freenode: "parked" };
+      const { container } = render(() => <Sidebar />);
+      expect(container.querySelector(".sidebar-network-section")).toBeNull();
+      expect(screen.queryByText("freenode")).toBeNull();
+    });
+
+    it("takes the channel rows down with it", () => {
+      mockNetworkConnectionState = { freenode: "parked" };
+      render(() => <Sidebar />);
+      expect(screen.queryByText("#italia")).toBeNull();
+      expect(screen.queryByText("#azzurra")).toBeNull();
+      expect(screen.queryByText("#bnc")).toBeNull();
+    });
+
+    it("takes the query rows down with it", () => {
+      mockNetworkConnectionState = { freenode: "parked" };
+      render(() => <Sidebar />);
+      expect(screen.queryByText("alice")).toBeNull();
+    });
+
+    it("takes a synthetic pseudo-row down with it (a row that is NOT in channelsBySlug)", () => {
+      // The pseudo-row branch projects from `windowStateByChannel`, a store
+      // the network filter never consults. Dropping the whole network at the
+      // ONE loop is what takes this fourth row class with it; a per-branch
+      // filter would have had to remember this one.
+      mockNetworkConnectionState = { freenode: "parked" };
+      mockWindowState = { "freenode #invite-only": "failed" };
+      render(() => <Sidebar />);
+      expect(screen.queryByText("#invite-only")).toBeNull();
+    });
+
+    it("a FAILED network keeps its section — the asymmetry is the product decision", () => {
+      mockNetworkConnectionState = { freenode: "failed" };
+      const { container } = render(() => <Sidebar />);
+      expect(container.querySelector(".sidebar-network-section")).not.toBeNull();
+      expect(screen.getByText("freenode")).toBeInTheDocument();
+      expect(screen.getByText("#italia")).toBeInTheDocument();
+    });
+
+    it("a CONNECTED network keeps its section", () => {
+      mockNetworkConnectionState = { freenode: "connected" };
+      const { container } = render(() => <Sidebar />);
+      expect(container.querySelector(".sidebar-network-section")).not.toBeNull();
+      expect(screen.getByText("#italia")).toBeInTheDocument();
+    });
+
+    it("a FAILING network keeps its section (#1675 — it is retrying on its own)", () => {
+      // Guards the ruling against being generalised to "any non-connected
+      // state": #1675 put `failing` deliberately outside the greyed set, and
+      // it is outside the hidden set for the same reason.
+      mockNetworkConnectionState = { freenode: "failing" };
+      const { container } = render(() => <Sidebar />);
+      expect(container.querySelector(".sidebar-network-section")).not.toBeNull();
+    });
+
+    it("a VISITOR network is never hidden — the predicate narrows on kind first", () => {
+      // A visitor has no credential row to park, so `connection_state` is not
+      // part of its wire shape at all. The value is planted here anyway: if
+      // the narrow were dropped, this network would vanish, and that is
+      // exactly the regression the narrow exists to prevent.
+      mockNetworkKind = { freenode: "visitor" };
+      mockNetworkConnectionState = { freenode: "parked" };
+      const { container } = render(() => <Sidebar />);
+      expect(container.querySelector(".sidebar-network-section")).not.toBeNull();
+      expect(screen.getByText("freenode")).toBeInTheDocument();
+    });
+
+    it("does NOT claim 'no networks' when the only network is parked", () => {
+      // The `<Show>` guard still counts the RAW list on purpose. "no networks"
+      // is a sentence about zero networks bound; saying it while one is parked
+      // would be a fast path describing what it DID instead of what it
+      // OBSERVED (CLAUDE.md log honesty). The sidebar draws home and stops.
+      mockNetworkConnectionState = { freenode: "parked" };
+      const { container } = render(() => <Sidebar />);
+      expect(container.querySelector(".sidebar-empty")).toBeNull();
     });
   });
 
@@ -1177,17 +1277,20 @@ describe("Sidebar", () => {
       expect(screen.getByRole("button", { name: /^#new\s*\(pending\)/ })).toBeInTheDocument();
     });
 
-    it("a parked NETWORK speaks the cascade on the header AND on every row under it", () => {
-      mockNetworkConnectionState = { freenode: "parked" };
+    it("a failed NETWORK speaks the cascade on the header AND on every row under it", () => {
+      // Stated on `failed` since issue 1985: a parked network draws no rows,
+      // so there is nothing left for it to speak. The cascade itself is
+      // unchanged.
+      mockNetworkConnectionState = { freenode: "failed" };
       render(() => <Sidebar />);
-      expect(screen.getByRole("button", { name: /^freenode\s*\(parked\)/ })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /^#italia\s*\(parked\)/ })).toBeInTheDocument();
-      // The DM row derives from the same cascade — a parked network takes the
+      expect(screen.getByRole("button", { name: /^freenode\s*\(failed\)/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^#italia\s*\(failed\)/ })).toBeInTheDocument();
+      // The DM row derives from the same cascade — a failed network takes the
       // query windows down with it.
-      expect(screen.getByRole("button", { name: /^alice\s*\(parked\)/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^alice\s*\(failed\)/ })).toBeInTheDocument();
     });
 
-    it("the network cascade OUTRANKS a row's own state (parked network, invited window)", () => {
+    it("the network cascade OUTRANKS a row's own state (failed network, invited window)", () => {
       mockNetworkConnectionState = { freenode: "failed" };
       mockWindowState = { "freenode #italia": "invited" };
       render(() => <Sidebar />);

--- a/cicchetto/src/__tests__/archive.test.ts
+++ b/cicchetto/src/__tests__/archive.test.ts
@@ -22,6 +22,10 @@ vi.mock("../lib/networks", () => ({
   // through this map, so the mock has to carry it.
   networkIdBySlug: () => undefined,
   channelsBySlug: () => ({}),
+  // issue 1985 — `navDrawsNetwork` resolves the network here to ask whether
+  // it is parked. Unresolved is not parked, so the default keeps every case
+  // below on the pre-1985 subtraction; the parked case mocks it explicitly.
+  networkBySlug: () => undefined,
 }));
 
 vi.mock("../lib/queryWindows", () => ({
@@ -188,6 +192,10 @@ describe("archive.visibleArchiveForNetwork", () => {
 
   it("filters out archive channels currently in channelsBySlug for the slug", async () => {
     vi.doMock("../lib/networks", () => ({
+      // issue 1985 — a network the store cannot resolve is not parked, so
+      // `navDrawsNetwork` says the nav draws it and the subtraction below is
+      // the pre-1985 one. These cases are all about that subtraction.
+      networkBySlug: () => undefined,
       channelsBySlug: () => ({
         freenode: [{ name: "#sniffo", joined: true, source: "joined" }],
       }),
@@ -215,6 +223,10 @@ describe("archive.visibleArchiveForNetwork", () => {
 
   it("filters out archive queries currently in queryWindowsByNetwork for the network", async () => {
     vi.doMock("../lib/networks", () => ({
+      // issue 1985 — a network the store cannot resolve is not parked, so
+      // `navDrawsNetwork` says the nav draws it and the subtraction below is
+      // the pre-1985 one. These cases are all about that subtraction.
+      networkBySlug: () => undefined,
       channelsBySlug: () => ({ freenode: [] }),
     }));
     vi.doMock("../lib/queryWindows", () => ({
@@ -247,6 +259,10 @@ describe("archive.visibleArchiveForNetwork", () => {
   // under ASCII casemapping (`normalizeNick`, A-Z only) so the active window releases it.
   it("filters out an archived query whose casing folds to an active window (#372)", async () => {
     vi.doMock("../lib/networks", () => ({
+      // issue 1985 — a network the store cannot resolve is not parked, so
+      // `navDrawsNetwork` says the nav draws it and the subtraction below is
+      // the pre-1985 one. These cases are all about that subtraction.
+      networkBySlug: () => undefined,
       channelsBySlug: () => ({ freenode: [] }),
     }));
     vi.doMock("../lib/queryWindows", () => ({
@@ -282,6 +298,10 @@ describe("archive.visibleArchiveForNetwork", () => {
   // windowState key → this filter releases → archive shows the row.
   it("filters out archive entries whose target is in windowStateByChannel for the slug", async () => {
     vi.doMock("../lib/networks", () => ({
+      // issue 1985 — a network the store cannot resolve is not parked, so
+      // `navDrawsNetwork` says the nav draws it and the subtraction below is
+      // the pre-1985 one. These cases are all about that subtraction.
+      networkBySlug: () => undefined,
       channelsBySlug: () => ({ freenode: [] }),
     }));
     vi.doMock("../lib/queryWindows", () => ({
@@ -324,6 +344,10 @@ describe("archive.visibleArchiveForNetwork", () => {
   // renders 0 for the whole assert window).
   it("does NOT hide an archived channel whose windowState is a stale :joined (re-PART transient)", async () => {
     vi.doMock("../lib/networks", () => ({
+      // issue 1985 — a network the store cannot resolve is not parked, so
+      // `navDrawsNetwork` says the nav draws it and the subtraction below is
+      // the pre-1985 one. These cases are all about that subtraction.
+      networkBySlug: () => undefined,
       // channels_changed already dropped #bofh from the live set.
       channelsBySlug: () => ({ freenode: [] }),
     }));
@@ -356,6 +380,10 @@ describe("archive.visibleArchiveForNetwork", () => {
   // by slug via decodeChannelKey.
   it("does NOT filter when the windowStateByChannel key belongs to a different slug", async () => {
     vi.doMock("../lib/networks", () => ({
+      // issue 1985 — a network the store cannot resolve is not parked, so
+      // `navDrawsNetwork` says the nav draws it and the subtraction below is
+      // the pre-1985 one. These cases are all about that subtraction.
+      networkBySlug: () => undefined,
       channelsBySlug: () => ({ freenode: [] }),
     }));
     vi.doMock("../lib/queryWindows", () => ({
@@ -381,6 +409,78 @@ describe("archive.visibleArchiveForNetwork", () => {
   it("returns empty array when the slug has never been loaded", async () => {
     const archive = await import("../lib/archive");
     expect(archive.visibleArchiveForNetwork("unloaded", 99)).toEqual([]);
+  });
+
+  // issue 1985 — a PARKED network draws no sidebar row of ANY kind (the ONE
+  // `<For>` in `Sidebar.tsx` drops the whole network), so this filter must
+  // subtract nothing for it: the archive is the only surface its windows have
+  // left, and that is what vjt's ruling ("the history is reachable from the
+  // archive") rests on.
+  //
+  // The channel leg is NOT hypothetical and it is not the pseudo-row leg.
+  // `GET /networks/:slug/channels` returns the union of the credential's
+  // AUTOJOIN list and the live session's channels (`ChannelsController.index`
+  // → `Networks.merge_channel_sources/2`); a parked network has no session, so
+  // the union is exactly the autojoin list, with `joined: false`. That list
+  // lands in `channelsBySlug` and this filter subtracts it. Before the sidebar
+  // filter those rows were drawn (greyed) — after it, subtracting them leaves
+  // one window and ZERO surfaces.
+  it("subtracts NOTHING for a parked network — its autojoin channels keep their archive row", async () => {
+    vi.doMock("../lib/networks", () => ({
+      networkIdBySlug: () => undefined,
+      // What the REST channel list returns for a parked network: the autojoin
+      // set, never joined because there is no session to join it.
+      channelsBySlug: () => ({ freenode: [{ name: "#autojoin", joined: false }] }),
+      networkBySlug: (slug: string) =>
+        slug === "freenode" ? { kind: "user", id: 1, slug, connection_state: "parked" } : undefined,
+    }));
+    vi.doMock("../lib/queryWindows", () => ({ queryWindowsByNetwork: () => ({}) }));
+    vi.doMock("../lib/windowState", () => ({
+      windowStateByChannel: () => ({ "freenode #kicked-from": "kicked" }),
+    }));
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.listArchive).mockResolvedValue([
+      { target: "#autojoin", kind: "channel", last_activity: 300 },
+      { target: "#kicked-from", kind: "channel", last_activity: 200 },
+    ]);
+
+    const archive = await import("../lib/archive");
+    await archive.loadArchive("freenode");
+
+    expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
+      { target: "#autojoin", kind: "channel", last_activity: 300 },
+      { target: "#kicked-from", kind: "channel", last_activity: 200 },
+    ]);
+  });
+
+  // The control that keeps the release narrow: a FAILED network keeps its
+  // greyed sidebar row, so its live rows are still drawn and must still be
+  // subtracted. If this one ever turns, the parked release has been widened
+  // into "any non-connected state" — the generalisation networkParked.ts
+  // exists to refuse.
+  it("still subtracts a FAILED network's live channels (its greyed row is drawn)", async () => {
+    vi.doMock("../lib/networks", () => ({
+      networkIdBySlug: () => undefined,
+      channelsBySlug: () => ({ freenode: [{ name: "#autojoin", joined: false }] }),
+      networkBySlug: (slug: string) =>
+        slug === "freenode" ? { kind: "user", id: 1, slug, connection_state: "failed" } : undefined,
+    }));
+    vi.doMock("../lib/queryWindows", () => ({ queryWindowsByNetwork: () => ({}) }));
+    vi.doMock("../lib/windowState", () => ({ windowStateByChannel: () => ({}) }));
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.listArchive).mockResolvedValue([
+      { target: "#autojoin", kind: "channel", last_activity: 300 },
+      { target: "#old-chan", kind: "channel", last_activity: 100 },
+    ]);
+
+    const archive = await import("../lib/archive");
+    await archive.loadArchive("freenode");
+
+    expect(archive.visibleArchiveForNetwork("freenode", 1)).toEqual([
+      { target: "#old-chan", kind: "channel", last_activity: 100 },
+    ]);
   });
 });
 

--- a/cicchetto/src/__tests__/networkParked.test.ts
+++ b/cicchetto/src/__tests__/networkParked.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { Network } from "../lib/api";
+import { isNetworkParked } from "../lib/networkParked";
+
+// issue 1985 — the predicate the ruling is written in. Both the Sidebar and
+// Shell suites mock `lib/networks` wholesale (it is a resource singleton), so
+// this is the one place the rule itself is measured rather than a call site's
+// wiring to it.
+//
+// The `as unknown as Network` casts are the point of the file, not a
+// shortcut: the closed set of `connection_state` values is
+// `[connected, parked, failing, failed]` (CLAUDE.md, #1675), and the
+// interesting inputs are the four states plus a visitor — a shape the
+// discriminated union deliberately gives no `connection_state` at all. Naming
+// each state through the type would only let the compiler restate what it
+// already knows; what needs proving is which of them the predicate says yes
+// to.
+const userNet = (connection_state: string): Network =>
+  ({
+    kind: "user",
+    id: 1,
+    slug: "azzurra",
+    nick: "vjt",
+    connection_state,
+    connection_state_reason: null,
+    connection_state_changed_at: null,
+    inserted_at: "",
+    updated_at: "",
+  }) as unknown as Network;
+
+describe("issue 1985 — isNetworkParked", () => {
+  it("says yes to a parked user network", () => {
+    expect(isNetworkParked(userNet("parked"))).toBe(true);
+  });
+
+  // The three negatives are the whole asymmetry, one assertion each. A
+  // generalisation to "any non-connected state" would turn two of them.
+  it("says no to connected", () => {
+    expect(isNetworkParked(userNet("connected"))).toBe(false);
+  });
+
+  it("says no to failed — a failure stays greyed in place for the operator to see", () => {
+    expect(isNetworkParked(userNet("failed"))).toBe(false);
+  });
+
+  it("says no to failing — #1675, it is retrying on its own", () => {
+    expect(isNetworkParked(userNet("failing"))).toBe(false);
+  });
+
+  it("says no to a VISITOR network even when the field reads parked", () => {
+    // A visitor has no credential row to park, so the real wire shape carries
+    // no `connection_state`. The value is planted anyway: if the `kind` narrow
+    // were dropped, a visitor network would start disappearing from the
+    // sidebar, and this is the input that catches it.
+    const visitor = {
+      kind: "visitor",
+      id: 2,
+      slug: "azzurra",
+      nick: "guest",
+      connection_state: "parked",
+    } as unknown as Network;
+    expect(isNetworkParked(visitor)).toBe(false);
+  });
+
+  it("says no to an absent network", () => {
+    // Shell's cold-load gate calls this with `networkBySlug(slug)`, which is
+    // `undefined` for a slug that is no longer bound. Not parked — the saved
+    // window is unrestorable for a different reason, and the branches below
+    // the gate are the ones that must decide it.
+    expect(isNetworkParked(undefined)).toBe(false);
+  });
+});

--- a/cicchetto/src/__tests__/pseudoChannels.test.ts
+++ b/cicchetto/src/__tests__/pseudoChannels.test.ts
@@ -23,6 +23,11 @@ const state = vi.hoisted(() => ({
   cbs: undefined as Record<string, { name: string; joined: boolean }[]> | undefined,
   qw: {} as Record<number, { targetNick: string }[]>,
   mobile: false,
+  // issue 1985 — the network's own state, read through the REAL
+  // `isNetworkParked`: this suite mocks `lib/networks` (a resource
+  // singleton) but never the predicate, so the rule under test is the
+  // shipped one and not a mirror of itself.
+  connectionState: "connected" as string,
 }));
 
 vi.mock("../lib/windowState", () => ({ windowStateByChannel: () => state.ws }));
@@ -31,6 +36,10 @@ vi.mock("../lib/networks", () => ({
   // through this map, so the mock has to carry it.
   networkIdBySlug: () => undefined,
   channelsBySlug: () => state.cbs,
+  networkBySlug: (slug: string) =>
+    slug === "freenode"
+      ? { kind: "user", id: 1, slug, connection_state: state.connectionState }
+      : undefined,
 }));
 vi.mock("../lib/queryWindows", () => ({ queryWindowsByNetwork: () => state.qw }));
 // The form factor is an environment boundary (matchMedia); mocking the
@@ -45,6 +54,7 @@ beforeEach(() => {
   state.cbs = {};
   state.qw = {};
   state.mobile = false;
+  state.connectionState = "connected";
 });
 
 describe("pseudoChannelsForNetwork", () => {
@@ -156,5 +166,37 @@ describe("navPseudoChannelsForNetwork", () => {
     state.ws = { [channelKey("freenode", "#invited")]: "invited" };
     state.mobile = true;
     expect(navPseudoChannelsForNetwork("freenode", 1)).toEqual([]);
+  });
+
+  // issue 1985 — the same #402 rule against the new surface map. A parked
+  // network is dropped at the ONE `<For>` in `Sidebar.tsx`, so the desktop nav
+  // draws none of its rows — pseudo-rows included, since they render INSIDE
+  // that loop. The archive subtracts what this function returns, so leaving
+  // the projection intact here would subtract rows nothing draws: one window,
+  // ZERO surfaces, which is exactly the bug #402 was filed for.
+  it("draws nothing for a parked network — the Sidebar no longer renders it at all", () => {
+    everyDrawnState();
+    state.mobile = false;
+    state.connectionState = "parked";
+    expect(navPseudoChannelsForNetwork("freenode", 1)).toEqual([]);
+  });
+
+  // The asymmetry is the product decision (CLAUDE.md #1675 / networkParked.ts):
+  // a FAILED network keeps its greyed row in place, so its pseudo-rows are
+  // still drawn and must still be subtracted. A "any non-connected state"
+  // generalisation would silently turn this one.
+  it("still draws a FAILED network's rows — that network keeps its greyed row", () => {
+    everyDrawnState();
+    state.mobile = false;
+    state.connectionState = "failed";
+    expect(navPseudoChannelsForNetwork("freenode", 1)).toHaveLength(4);
+  });
+
+  // Same for `failing` (#1675): it is retrying on its own and has a way back.
+  it("still draws a FAILING network's rows", () => {
+    everyDrawnState();
+    state.mobile = false;
+    state.connectionState = "failing";
+    expect(navPseudoChannelsForNetwork("freenode", 1)).toHaveLength(4);
   });
 });

--- a/cicchetto/src/lib/archive.ts
+++ b/cicchetto/src/lib/archive.ts
@@ -5,7 +5,7 @@ import { identityScopedStore } from "./identityScopedStore";
 import { casemappingForNetwork } from "./isupport";
 import { channelsBySlug } from "./networks";
 import { normalizeNick } from "./nickEquals";
-import { navPseudoChannelsForNetwork } from "./pseudoChannels";
+import { navDrawsNetwork, navPseudoChannelsForNetwork } from "./pseudoChannels";
 import { queryWindowsByNetwork } from "./queryWindows";
 
 // Per-network archive store. Source-of-truth for cic's per-network
@@ -153,6 +153,23 @@ export const setArchiveModalOpen = exports_.setArchiveModalOpen;
 export function visibleArchiveForNetwork(slug: string, networkId: number): ArchiveEntry[] {
   const entries = archivedBySlug()[slug] ?? [];
   if (entries.length === 0) return entries;
+  // issue 1985 — the premise stated above, applied whole: subtract what the
+  // nav draws. A parked network is dropped at the ONE `<For>` in the desktop
+  // Sidebar, so the nav draws NONE of its rows and the correct subtraction is
+  // the empty set — for its live channels too, not just its pseudo-rows.
+  //
+  // Measured, because the channel leg reads like it could not happen:
+  // `GET /networks/:slug/channels` unions the credential's AUTOJOIN list with
+  // the live session's channels (`ChannelsController.index` →
+  // `Networks.merge_channel_sources/2`), and a parked network has no session —
+  // so `channelsBySlug` still carries every autojoin channel, at
+  // `joined: false`. Subtracting those while no sidebar row draws them hid
+  // exactly the history vjt's ruling says the archive is the door to.
+  //
+  // The predicate is `navDrawsNetwork` and not a local `isNetworkParked`
+  // call: the form-factor half (mobile still draws these rows) belongs with
+  // the rest of the nav reconciliation, not copied in here.
+  if (!navDrawsNetwork(slug)) return entries;
   // #372: fold every comparison key with `normalizeNick` — the single client
   // mirror of the server fold. A service that replied as `DebugServ` archives
   // under that casing while the open window is `debugserv`; a raw `Set.has`

--- a/cicchetto/src/lib/networkParked.ts
+++ b/cicchetto/src/lib/networkParked.ts
@@ -1,0 +1,33 @@
+import type { Network } from "./api";
+
+// issue 1985 — the ONE statement of "this network is not in the UI right now".
+//
+// vjt's ruling (2026-09-07, option 1 of the issue): while a network is
+// `parked` it and every row under it LEAVE the sidebar, and come back when it
+// reconnects. Two callers derive from this predicate and they must never
+// disagree — the Sidebar's `<For>` (which rows to draw) and Shell's cold-load
+// restore gate (whether the saved window is still somewhere the operator can
+// be). A second copy of the string in either place is how the pane and the
+// sidebar drift into showing different worlds.
+//
+// `failed` is deliberately NOT here and must not be added: a failed network
+// stays greyed IN PLACE because the operator has to see a failure and act on
+// it (`Sidebar.tsx` NETWORK_GREYED_STATES). `failing` is not here either, for
+// #1675's reason — it is retrying on its own and has a way back. The
+// asymmetry between the three states is the product decision, not an
+// oversight, and a future "any non-connected state" generalisation would
+// silently take all three.
+//
+// Its OWN module, not a function inside `lib/networks.ts`, for a testing
+// reason that is also a design one: `networks.ts` is a resource singleton
+// (createResource over the bearer), so every suite that touches it replaces
+// it wholesale with `vi.mock`. A predicate living there would be mocked
+// alongside the resources at every call site and could only ever be tested
+// through a mirror of itself. Here it is pure, importable, and the suites
+// that mock `networks.ts` run the REAL rule.
+//
+// Narrows on `kind` first: only a UserNetwork carries `connection_state`, so
+// a visitor network can never be parked and can never be hidden.
+export function isNetworkParked(net: Network | undefined): boolean {
+  return net?.kind === "user" && net.connection_state === "parked";
+}

--- a/cicchetto/src/lib/pseudoChannels.ts
+++ b/cicchetto/src/lib/pseudoChannels.ts
@@ -1,5 +1,6 @@
 import { type ChannelKey, decodeChannelKey } from "./channelKey";
-import { channelsBySlug } from "./networks";
+import { isNetworkParked } from "./networkParked";
+import { channelsBySlug, networkBySlug } from "./networks";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { isMobile } from "./theme";
 import { type WindowState, windowStateByChannel } from "./windowState";
@@ -115,5 +116,40 @@ export function pseudoChannelsForNetwork(slug: string, networkId: number): Pseud
 // two cannot disagree.
 export function navPseudoChannelsForNetwork(slug: string, networkId: number): PseudoRow[] {
   if (isMobile()) return [];
+  // issue 1985 — a parked network draws no pseudo-row either, because it
+  // draws no row at all. See `navDrawsNetwork` below.
+  if (!navDrawsNetwork(slug)) return [];
   return pseudoChannelsForNetwork(slug, networkId);
+}
+
+// issue 1985 — does the nav of THIS form factor draw ANY row for this network?
+//
+// #402 answered "which ROWS does the nav draw" and the archive subtracts
+// exactly that. The parked ruling asks the question one level up: the desktop
+// Sidebar drops a parked network at its ONE `<For>`, and the header, the
+// channels, the queries and the pseudo-rows all render INSIDE that loop, so
+// the whole network stops being drawn — not a subset of its rows. A filter
+// that keeps subtracting them then leaves one window with ZERO surfaces,
+// which is #402's bug with a bigger blast radius.
+//
+// It lives HERE, next to `navPseudoChannelsForNetwork`, because this module's
+// job is precisely reconciling "which nav exists" with "what it draws", and
+// the archive already consumes that reconciliation. A copy of the rule in
+// `archive.ts` would be a second statement of the parked policy — the thing
+// `lib/networkParked.ts` was extracted to prevent.
+//
+// MOBILE IS TRUE, and it is measured rather than assumed: `BottomBar.tsx`
+// iterates the RAW `networks()` store and renders each network's channels and
+// queries with no state filter of its own (`:138`, `:174`, `:215`), so on a
+// phone a parked network's rows are still on screen and the archive must
+// still subtract them. The sidebar filter this issue adds is desktop-only.
+// (The pseudo-row leg is separately empty on mobile since #902 — that is the
+// early return above, a different question with the same answer here.)
+//
+// `failed` and `failing` draw normally: a failed network keeps its greyed row
+// so the operator must see it, and a failing one is retrying on its own
+// (#1675). The asymmetry is the product decision — `lib/networkParked.ts`.
+export function navDrawsNetwork(slug: string): boolean {
+  if (isMobile()) return true;
+  return !isNetworkParked(networkBySlug(slug));
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50995,17 +50995,62 @@ returns its entries unfiltered when the nav draws nothing. It does NOT live in
 statement of the parked policy plus a copy of the form-factor rule, and
 `lib/networkParked.ts` exists to stop the first.
 
-**Queries are the leg that stays broken, and it cannot be closed here.**
-`ArchiveController.build_active_keyset/3` composes the live session channels
-(empty when parked) with `open_query_targets/2`, which reads
-`QueryWindows.list_for_subject/1` — a DB read with no session gate. So a
-parked network's DM windows are excluded from the archive response by the
-SERVER while the desktop sidebar no longer draws them either: one window, zero
-surfaces, and no client-side filter can put back a row the server never sent.
-The asymmetry is the bug — the same controller's own moduledoc says everything
-with rows qualifies when no session is live, and its channel leg honours that
-while its query leg does not. Closing it is a server change (and this slice
-claims none), so it is written down here and carried to vjt rather than taken.
+**Queries were the third leg, and they ARE closed — with a server change this
+entry first said the slice would not make.** `build_active_keyset/3` composed
+the live session channels (empty when parked) with `open_query_targets/2`,
+which reads `QueryWindows.list_for_subject/1` — a DB read with no session
+gate. So a parked network's DM windows were excluded from the archive response
+by the SERVER while the desktop sidebar no longer drew them either: one
+window, zero surfaces, and no client-side filter can put back a row the server
+never sent.
+
+It was handed up rather than taken, and the call came back to take it, on a
+reason worth recording because it is the general rule and not a preference:
+**the asymmetry is pre-existing, but this slice is what turns it into a live
+hole, so shipping the first two legs without it ships a measured regression.**
+It is also not a product decision — it aligns `build_active_keyset/3` with the
+promise the module already makes in words (*"everything with rows qualifies
+for the archive when no session is live"*), which its channel arm kept and its
+query arm did not. Now one `case` over the session lookup answers for both
+arms, so there is a single place saying what an absent session means and they
+cannot drift apart again.
+
+The pair of tests is the point: without a session an open query window no
+longer hides its DM, and WITH a live session it still does. The second is the
+control — the fix must not become "the archive never subtracts queries", since
+while a session is live that window is one the operator can actually be in.
+
+### The two contract specs, and why a spec may be rewritten
+
+`cp15-b6-parked-disconnect-reconnect` and `issue100-reconnecting-badge`
+asserted the PRE-ruling contract: a parked network stays in the sidebar,
+greyed and navigable, and the reconnecting badge has that greyed row to appear
+on. They were left red for a while precisely because rewriting an assertion to
+make a branch pass is how a suite stops being evidence.
+
+**The bar they clear is the only one that licenses it: the product owner ruled
+the asserted behaviour wrong.** Not flaky, not slow, not inconvenient. The
+rewrite is written down in each spec at the assertion that changed, in those
+terms, so a later reader cannot mistake it for a relaxation. cp15-b6 now
+asserts the disappearance AND the return — a disappearance-only spec goes
+green on a sidebar that never recovers.
+
+`issue100` keeps its subject and gains the precondition it used to assume.
+Under the ruling the badge's host is absent for the whole park, so what makes
+the badge observable at all is an ORDERING: the reconnect PATCH spawns FIRST
+and commits `:connected` only on spawn success (`NetworksController`'s U-0
+ordering), and `Session.start_session/3` returns when the GenServer starts,
+not when the link registers — so the row is back within milliseconds while the
+`connecting` flag, which clears only on 001, is still set. The spec asserts
+that ordering now (section gone while parked, section back before the badge
+latch) instead of letting it be the unstated reason a latch fires or times
+out. If it ever stops holding, the failure names the broken link and becomes
+evidence for the badge question below rather than a mystery.
+
+Both specs also stopped reading `toHaveCount(0)` on the greyed child as proof
+a row is healthy: that assertion is satisfied by a row which never came back.
+It was fair while present-and-greyed was the only possible state, and it is a
+hole now that disappearance is real.
 
 ### Limits, stated
 
@@ -51044,5 +51089,8 @@ hosted the badge for exactly that window. Moving the badge, disabling the
 button for longer, or teaching `$home` the progress signal are all product
 calls; none is taken here.
 
-_Code + tests. No wire change, no protocol bump, no server change. Deploy:
-cic bundle only._
+_Code + tests. No wire change and no protocol bump — the archive response
+shape is untouched, only which entries qualify for it. It is NO LONGER cic
+bundle only: `ArchiveController` changed, so the deploy is cic bundle PLUS the
+server. One module body, no `VERSION` bump and no migration, so the server
+half is hot-reloadable; the preflight decides._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50874,18 +50874,29 @@ reconnect. Option 2 is dropped; #450 (collapsible network groups) stays a
 separate concern. When the cold-load orphan below was put to him on
 2026-09-08, the answer was equally flat: *"redirigi a home"*.
 
-**Q2 is an INFERENCE, and confirmation is still pending.** Choosing the
-redirect implies that the one door for re-reading a parked window's history
-dies — `selection.ts`'s bucket-D redirect is transition-only precisely so an
-operator can navigate BACK to a parked window, and with no row and no restore
-there is nothing left to navigate back to. That question was written in the
-same line as Q1 and the ruling did not address it in words, so it is being
-treated as accepted collateral by the session that relayed it, not as
-something vjt said. **What holds the loss up is that the network itself does
-not become invisible:** `$home` still renders a parked network as a
-disconnected row with its `connection_state_reason` and a `[Reconnect]` chip
-(`HomePane.tsx:438,463`). If a dedicated door for a parked network's history
-is wanted, that is a NEW issue, not a piece of this one.
+**Q2 was flagged as an inference and is now RULED, and the ruling reverses
+what this entry first said.** Choosing the redirect looked like it killed the
+one door for re-reading a parked window's history — `selection.ts`'s bucket-D
+redirect is transition-only precisely so an operator can navigate BACK to a
+parked window, and with no row and no restore there is nothing left to
+navigate back to. That collateral was recorded here as accepted-but-unspoken.
+It is not accepted: on 2026-09-10 vjt answered *"the history is reachable
+from the archive"* (relayed in session, not read on IRC by the author of this
+entry), and on 09-09 that reading the history of a parked network is deferred
+to SEARCH rather than to a dedicated re-entry door. **So nothing is lost and
+this paragraph's earlier claim that something was is FALSE.** The archive is
+the door, and it is reachable while parked: `ArchiveModal` iterates the RAW
+`networks()` store (`:174`), not the sidebar's filtered list, and the archive
+launcher renders unconditionally (`RailActions.tsx:525-533`).
+
+**But the door only opened once this slice made it open, and that is the
+substance of the fix below.** Naming the archive as the surface turns
+`archive.ts`'s subtraction into a load-bearing part of the ruling rather than
+a detail: the filter removes what the nav draws, and a parked network's nav
+draws nothing. Measured on this branch before the cure — a parked network
+whose archive holds an autojoin channel and a kicked pseudo-row rendered
+**zero** rows in the modal, both swallowed. Half of that was invisible to the
+issue's own reading of the code (see "The hole the ruling exposed").
 
 **`failed` is out of scope and the asymmetry is deliberate.** A failed network
 keeps its greyed row IN PLACE: a failure is something the operator must see
@@ -50946,6 +50957,56 @@ alongside the resources at every call site and could only ever be tested
 through a mirror of itself. Extracted, it is measured directly and the Sidebar
 and Shell suites run the real rule.
 
+### The hole the ruling exposed, and where the cure goes
+
+`visibleArchiveForNetwork` subtracts three sets — the live channels, the live
+queries, and the pseudo-rows — on the premise #402 wrote down: *a nav renders
+what it subtracts*. Dropping a whole network from the Sidebar's `<For>` breaks
+that premise wholesale, and the archive kept subtracting. Three legs, and only
+one of them was predicted:
+
+**Pseudo-rows (predicted).** `navPseudoChannelsForNetwork` returned the
+projection unconditionally on desktop, so `pending` / `failed` / `kicked` /
+`parked` windows under a parked network were subtracted from the archive while
+no sidebar row drew them: one window, ZERO surfaces — #402's bug, one level up.
+
+**Live channels (NOT predicted, and read as safe until it was measured).**
+`GET /networks/:slug/channels` returns the union of the credential's AUTOJOIN
+list and the live session's channels (`ChannelsController.index` →
+`Networks.merge_channel_sources/2`). A parked network has no session, so
+`Session.list_channels/2` answers `{:error, :no_session}` → `[]` and the union
+is exactly the autojoin list, at `joined: false`. Those rows sit in
+`channelsBySlug`, the archive subtracts them, and the sidebar no longer draws
+them. The server, meanwhile, PUTS them in the archive precisely because the
+session is gone: `ArchiveController`'s `active_keyset` is empty without one —
+*"everything with rows qualifies for the archive when no session is live"*.
+So the two sides disagreed, and the operator's own autojoin channels were the
+casualty. This is the leg that makes the cure worth more than a tidy-up.
+
+**The cure is `navDrawsNetwork(slug)` in `lib/pseudoChannels.ts`**, one level
+above `navPseudoChannelsForNetwork`: does the nav of THIS form factor draw ANY
+row for this network. Desktop answers `!isNetworkParked(...)`; **mobile answers
+YES**, measured rather than assumed — `BottomBar.tsx` iterates the raw
+`networks()` store and renders each network's channels and queries with no
+state filter (`:138`, `:174`, `:215`), so on a phone those rows are still on
+screen and must still be subtracted. The archive consumes the one answer and
+returns its entries unfiltered when the nav draws nothing. It does NOT live in
+`archive.ts` as a local `isNetworkParked` call: that would be a second
+statement of the parked policy plus a copy of the form-factor rule, and
+`lib/networkParked.ts` exists to stop the first.
+
+**Queries are the leg that stays broken, and it cannot be closed here.**
+`ArchiveController.build_active_keyset/3` composes the live session channels
+(empty when parked) with `open_query_targets/2`, which reads
+`QueryWindows.list_for_subject/1` — a DB read with no session gate. So a
+parked network's DM windows are excluded from the archive response by the
+SERVER while the desktop sidebar no longer draws them either: one window, zero
+surfaces, and no client-side filter can put back a row the server never sent.
+The asymmetry is the bug — the same controller's own moduledoc says everything
+with rows qualifies when no session is live, and its channel leg honours that
+while its query leg does not. Closing it is a server change (and this slice
+claims none), so it is written down here and carried to vjt rather than taken.
+
 ### Limits, stated
 
 **Not device-verified.** The gates here are jsdom + the pure predicate; the
@@ -50966,6 +51027,22 @@ to prevent.
 and was left alone deliberately.** It is what makes any residual parked window
 readable but not writable, and it is a different question (can I type here)
 from the one this slice answers (is there a row).
+
+**The `reconnecting…` badge has nowhere to live during the transition, and
+that question is OPEN — measured here, not answered.** #100's badge renders
+inside the per-network `<For>` (`Sidebar.tsx:378-380`) off
+`reconnectingByNetwork`, which the server drives with `connection_progress`
+(`connecting` on the attempt, `connected` on 001). `connection_state` stays
+`parked` for that whole window — it is operator intent, and the badge is
+deliberately NOT that state. So the badge fires while its host row does not
+exist. What the operator actually sees between clicking `[Reconnect]` on
+`$home` and 001: the button relabels to `Reconnecting…` only while
+`reconnector.pending()` — the awaited PATCH — then returns to `Reconnect` with
+the state word still reading `parked` and no badge anywhere, while the
+upstream link is in fact coming up. Before this slice the greyed sidebar row
+hosted the badge for exactly that window. Moving the badge, disabling the
+button for longer, or teaching `$home` the progress signal are all product
+calls; none is taken here.
 
 _Code + tests. No wire change, no protocol bump, no server change. Deploy:
 cic bundle only._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50853,3 +50853,119 @@ Neither is the IME case covered: like `ComposeBox` before it, this handler has
 no `isComposing` guard, so an Enter that confirms a candidate mid-composition
 submits. That is a shared gap of the two surfaces and wants one issue over both,
 not a divergence introduced on one of them here._
+<!-- entry #1985 -->
+
+---
+
+## 2026-09-09 — #1985: a parked network leaves the sidebar, and the cold load is where the disappearance bites
+
+An operator with two parked networks carries two rows that cannot be acted
+upon: every channel under them is unreachable, selecting one bounces to home,
+and on mobile they push live channels below the fold. vjt, on `#grappa`:
+*"they don't serve any purpose there"*.
+
+### The ruling, and what is NOT a ruling
+
+**Q1 is verbatim.** The issue offered two shapes — hard disappearance vs a
+collapsed/on-demand section — and vjt chose the first on 2026-09-07:
+*"sparisce se è disconnected (parked)"*. While `connection_state == parked`
+the network and every row under it leave the sidebar and come back on
+reconnect. Option 2 is dropped; #450 (collapsible network groups) stays a
+separate concern. When the cold-load orphan below was put to him on
+2026-09-08, the answer was equally flat: *"redirigi a home"*.
+
+**Q2 is an INFERENCE, and confirmation is still pending.** Choosing the
+redirect implies that the one door for re-reading a parked window's history
+dies — `selection.ts`'s bucket-D redirect is transition-only precisely so an
+operator can navigate BACK to a parked window, and with no row and no restore
+there is nothing left to navigate back to. That question was written in the
+same line as Q1 and the ruling did not address it in words, so it is being
+treated as accepted collateral by the session that relayed it, not as
+something vjt said. **What holds the loss up is that the network itself does
+not become invisible:** `$home` still renders a parked network as a
+disconnected row with its `connection_state_reason` and a `[Reconnect]` chip
+(`HomePane.tsx:438,463`). If a dedicated door for a parked network's history
+is wanted, that is a NEW issue, not a piece of this one.
+
+**`failed` is out of scope and the asymmetry is deliberate.** A failed network
+keeps its greyed row IN PLACE: a failure is something the operator must see
+and act on. `failing` stays outside both sets for #1675's reason — it is
+retrying on its own and has a way back. Three states, three treatments, and a
+future generalisation to "any non-connected state" would silently take all
+three.
+
+### The cold load is the part the issue did not know about
+
+The live park path was already covered and is not what broke. `selection.ts`'s
+bucket-D effect redirects to home when a network the operator is looking at
+transitions INTO `parked`, and it is transition-only by design:
+`lastConnectionState` starts empty and `prev === undefined` skips the first
+observation.
+
+A cold load is exactly the case with no previous value to transition from. So
+on a reload nothing walks the selection back, while #35's restore hands the
+saved window straight back — and for `kind: "server"` its gate is only "the
+network still exists", with `connection_state` deliberately not consulted
+(`selection.ts:296-303` spells out why). Before this change that was harmless:
+the row sat there greyed and the operator read history. After the
+disappearance it is a pane the sidebar draws no row for.
+
+Cured in the restore's EXISTING validity gate rather than by widening bucket
+D. Bucket D firing on a non-transition would make every boot re-decide the
+selection for every network; the restore gate already asks "is the saved
+window still somewhere the operator can be", and this is one more clause in
+that same question. The gate is TERMINAL, unlike the provisional `$home` below
+it — a non-latching gate would re-attempt on every resource update and pull
+focus off home the moment the operator hit `[Reconnect]`, which is a delayed
+jump nobody asked for.
+
+### Where the filter goes, and what it takes with it
+
+One filter, at the ONE `<For>` over networks in `Sidebar.tsx`. The header, the
+channels, the queries and the synthetic pseudo-rows all render inside that
+loop, so dropping the network drops all four by construction. The fourth is
+the one that argues for the placement: pseudo-rows project from
+`windowStateByChannel`, a store no network-level filter would think to
+consult, so a per-branch filter would have left them behind.
+
+`parked` comes OUT of `NETWORK_GREYED_STATES`, which now reads `["failed"]`.
+Not tidying — the set answers "which network states grey the section", and
+parked can no longer reach that cascade because it no longer renders. Two
+statements of one policy is how the next reader picks the wrong one.
+
+The `<Show>` guard around the loop still counts the RAW list. Its fallback
+says "no networks", which is true of zero networks bound and false of two
+parked ones; with everything parked the sidebar draws the home row and stops.
+That is the honest rendering, and it needs no new string.
+
+The predicate is its own module (`lib/networkParked.ts`) rather than a
+function in `lib/networks.ts`, for a testing reason that is also a design one.
+`networks.ts` is a resource singleton, so every suite that touches it replaces
+it wholesale with `vi.mock`; a predicate living there would be mocked
+alongside the resources at every call site and could only ever be tested
+through a mirror of itself. Extracted, it is measured directly and the Sidebar
+and Shell suites run the real rule.
+
+### Limits, stated
+
+**Not device-verified.** The gates here are jsdom + the pure predicate; the
+mutation was run in both directions (disabling the filter reds exactly the
+disappearance assertions while the failed / failing / visitor /
+no-empty-claim controls stay green, and disabling the predicate reds those
+plus its own). Whether the sidebar READS right with two parked networks on a
+phone is dogfood.
+
+**BottomBar is untouched, and that is a scope call, not an oversight.** The
+mobile strip is a separate `<For each={networks()}>` in `BottomBar.tsx` with
+no greying of its own, so a parked network still shows there. The ruling names
+the sidebar; the issue's own motivation cites the mobile fold. The question
+was raised and not answered, and widening on a guess is what the ruling exists
+to prevent.
+
+**`ComposeBox.tsx` keeps its own `NETWORK_GREYED_STATES = {parked, failed}`
+and was left alone deliberately.** It is what makes any residual parked window
+readable but not writable, and it is a different question (can I type here)
+from the one this slice answers (is there a row).
+
+_Code + tests. No wire change, no protocol bump, no server change. Deploy:
+cic bundle only._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -51073,21 +51073,36 @@ and was left alone deliberately.** It is what makes any residual parked window
 readable but not writable, and it is a different question (can I type here)
 from the one this slice answers (is there a row).
 
-**The `reconnecting…` badge has nowhere to live during the transition, and
-that question is OPEN — measured here, not answered.** #100's badge renders
-inside the per-network `<For>` (`Sidebar.tsx:378-380`) off
-`reconnectingByNetwork`, which the server drives with `connection_progress`
-(`connecting` on the attempt, `connected` on 001). `connection_state` stays
-`parked` for that whole window — it is operator intent, and the badge is
-deliberately NOT that state. So the badge fires while its host row does not
-exist. What the operator actually sees between clicking `[Reconnect]` on
-`$home` and 001: the button relabels to `Reconnecting…` only while
+**The `reconnecting…` badge has nowhere to live during the transition, and on
+2026-09-10 vjt ruled that nothing is to be built to give it one.** The words on
+`#grappa` at 14:59 Rome (12:59Z) were *"ci si riconnette da HOME"* and *"non
+SERVE nient'ALTRO"*. ⚠️ **Provenance: RELAYED into this session from the ircbot
+session, not read on IRC by this entry's author** — the same posture as the
+archive ruling above, and it is recorded as relayed rather than quoted as
+first-hand. So none of the three candidates is built: no badge grafted onto
+`$home`, no state machine holding `[Reconnect]` disabled longer, no teaching
+`$home` the progress signal. A parked network's row leaves the sidebar and
+reconnecting is `$home`'s business. This EXTENDS the 2026-09-08 *"redirect to
+home"* ruling rather than competing with it, and the cold-load restore gate in
+`Shell.tsx` is untouched by it.
+
+What was measured before the ruling landed still describes today's behaviour —
+it is simply no longer a question. The #100 badge renders inside the
+per-network `<For>` (`Sidebar.tsx:378-380`) off `reconnectingByNetwork`, which
+the server drives with `connection_progress` (`connecting` on the attempt,
+`connected` on 001). `connection_state` stays `parked` for that whole window —
+it is operator intent, and the badge is deliberately NOT that state. So the
+badge fires while its host row does not exist.
+
+**Observed, and placed OUT OF SCOPE by that same ruling — written down so the
+next reader does not re-discover it as new.** Between clicking `[Reconnect]` on
+`$home` and 001, the button relabels to `Reconnecting…` only while
 `reconnector.pending()` — the awaited PATCH — then returns to `Reconnect` with
-the state word still reading `parked` and no badge anywhere, while the
-upstream link is in fact coming up. Before this slice the greyed sidebar row
-hosted the badge for exactly that window. Moving the badge, disabling the
-button for longer, or teaching `$home` the progress signal are all product
-calls; none is taken here.
+the state word still reading `parked` and no badge anywhere, while the upstream
+link is in fact coming up. Before this slice the greyed sidebar row hosted the
+badge for exactly that window. It is a second-order effect of the ruling, it is
+deliberately NOT filed as an issue, and it is not cured: *"non serve
+nient'altro"*.
 
 _Code + tests. No wire change and no protocol bump — the archive response
 shape is untouched, only which entries qualify for it. It is NO LONGER cic

--- a/lib/grappa_web/controllers/archive_controller.ex
+++ b/lib/grappa_web/controllers/archive_controller.ex
@@ -220,21 +220,36 @@ defmodule GrappaWeb.ArchiveController do
   # Active keyset = currently-joined channels (live Session state) +
   # currently-open query windows (persisted, subject-scoped per V1's
   # XOR FK shape — both users and visitors get a row).
+  #
+  # NO LIVE SESSION MEANS AN EMPTY KEYSET, QUERY WINDOWS INCLUDED (issue
+  # 1985). This module's own doc has always promised it — *"an absent session
+  # simply means an empty `active_keyset`, which is the correct semantic
+  # (everything with rows qualifies for the archive when no session is
+  # live)"* — but only the channel arm delivered it: `Session.list_channels/2`
+  # goes quiet on `:no_session` while `open_query_targets/2` is a DB read that
+  # answers the same whether a session exists or not. So a parked network's
+  # DMs were withheld from the archive by this function.
+  #
+  # Harmless while cic drew a greyed row for a parked network. Not harmless
+  # since issue 1985 dropped parked networks from the sidebar: the DM then
+  # had no sidebar row AND no archive row — one window, ZERO surfaces — and
+  # no client-side filter can restore an entry the server never sent. The
+  # asymmetry was the bug; the channel arm was right.
+  #
+  # Written as one `case` over the session lookup rather than an empty-list
+  # fallback plus a separate query read, so the two arms cannot drift apart
+  # again: there is now exactly one place that says what an absent session
+  # means here.
   @spec build_active_keyset(
           {:user, User.t()} | {:visitor, Visitor.t()},
           Grappa.Scrollback.subject(),
           integer()
         ) :: MapSet.t(String.t())
   defp build_active_keyset(subject, session_subject, network_id) do
-    channels =
-      case Session.list_channels(session_subject, network_id) do
-        {:ok, list} -> list
-        {:error, :no_session} -> []
-      end
-
-    queries = open_query_targets(subject, network_id)
-
-    MapSet.new(channels ++ queries)
+    case Session.list_channels(session_subject, network_id) do
+      {:ok, channels} -> MapSet.new(channels ++ open_query_targets(subject, network_id))
+      {:error, :no_session} -> MapSet.new()
+    end
   end
 
   @spec open_query_targets({:user, User.t()} | {:visitor, Visitor.t()}, integer()) ::

--- a/lib/grappa_web/controllers/archive_controller.ex
+++ b/lib/grappa_web/controllers/archive_controller.ex
@@ -236,20 +236,35 @@ defmodule GrappaWeb.ArchiveController do
   # no client-side filter can restore an entry the server never sent. The
   # asymmetry was the bug; the channel arm was right.
   #
-  # Written as one `case` over the session lookup rather than an empty-list
-  # fallback plus a separate query read, so the two arms cannot drift apart
-  # again: there is now exactly one place that says what an absent session
-  # means here.
+  # Written as ONE `case` over the session lookup — both sources answered by
+  # the same arm — rather than a channels-only fallback plus a separate query
+  # read, so the two cannot drift apart again: there is exactly one place here
+  # that says what an absent session means.
+  #
+  # The `case` yields the TARGET LIST and the MapSet is built once, after it.
+  # That is a dialyzer constraint, not a style choice, and reverting it to a
+  # `MapSet.new(...)` per arm reopens two errors — measured, both directions:
+  # `MapSet.t/1` is OPAQUE, and a MapSet built from a statically-empty list
+  # collapses to the concrete `%MapSet{map: %{}}` in the success typing (it is
+  # the empty LITERAL, not the arity — `MapSet.new()` and `MapSet.new([])` are
+  # red alike). Joined with the other arm the return is then no longer purely
+  # opaque, so the `@spec` below reads as `contract_with_opaque`, and handing
+  # the value to `Scrollback.list_archive/3` — which specs the opaque type —
+  # reads as `call_without_opaque`. One construction site from a list dialyzer
+  # cannot fold to a constant keeps the opacity intact.
   @spec build_active_keyset(
           {:user, User.t()} | {:visitor, Visitor.t()},
           Grappa.Scrollback.subject(),
           integer()
         ) :: MapSet.t(String.t())
   defp build_active_keyset(subject, session_subject, network_id) do
-    case Session.list_channels(session_subject, network_id) do
-      {:ok, channels} -> MapSet.new(channels ++ open_query_targets(subject, network_id))
-      {:error, :no_session} -> MapSet.new()
-    end
+    active_targets =
+      case Session.list_channels(session_subject, network_id) do
+        {:ok, channels} -> channels ++ open_query_targets(subject, network_id)
+        {:error, :no_session} -> []
+      end
+
+    MapSet.new(active_targets)
   end
 
   @spec open_query_targets({:user, User.t()} | {:visitor, Visitor.t()}, integer()) ::

--- a/test/grappa_web/controllers/archive_controller_test.exs
+++ b/test/grappa_web/controllers/archive_controller_test.exs
@@ -26,8 +26,9 @@ defmodule GrappaWeb.ArchiveControllerTest do
 
   import Grappa.AuthFixtures
 
+  alias Grappa.IRCServer
   alias Grappa.PubSub.Topic
-  alias Grappa.Scrollback
+  alias Grappa.{QueryWindows, Scrollback}
 
   # #1404 — read the SAME config keys `GrappaWeb.ArchiveController` reads,
   # rather than an accessor on the controller: an accessor returning a
@@ -46,10 +47,11 @@ defmodule GrappaWeb.ArchiveControllerTest do
 
   defp seed_archive_rows(user, net) do
     # Two channels (#a, #b) + one DM target (vjt-peer) + $server.
-    # No live session running for any test → active_keyset will be
-    # empty per Session.list_channels/2 returning {:error, :no_session},
-    # so all four targets land in the query result and only $server is
-    # filtered out by list_archive.
+    # No live session in MOST tests → active_keyset is empty per
+    # Session.list_channels/2 returning {:error, :no_session}, so all four
+    # targets land in the query result and only $server is filtered out by
+    # list_archive. The one exception is the live-session control added for
+    # issue 1985, which spawns a session against a fake ircd on purpose.
     {:ok, _} =
       Scrollback.persist_event(%{
         user_id: user.id,
@@ -126,6 +128,63 @@ defmodule GrappaWeb.ArchiveControllerTest do
                  %{"target" => "#a", "kind" => "channel", "last_activity" => 100}
                ]
              }
+    end
+
+    # issue 1985 — an OPEN query window must NOT keep its DM out of the
+    # archive when there is no live session.
+    #
+    # The keyset composed the live session's channels with a DB read of the
+    # open query windows, and only the channel half went quiet without a
+    # session. So a parked network's DM was excluded from the archive while
+    # cic's sidebar (which drops a parked network entirely, issue 1985) drew
+    # no row for it either: one window, ZERO surfaces, and no client-side
+    # filter can restore a row the server never sent.
+    #
+    # The promise this restores is the controller's own, in its moduledoc:
+    # "an absent session simply means an empty `active_keyset`, which is the
+    # correct semantic (everything with rows qualifies for the archive when
+    # no session is live)". The channel arm honoured it; the query arm did
+    # not. The exclusion is right while a session IS live — that is the
+    # sibling test below.
+    test "an open query window does NOT hide its DM when no session is live",
+         %{conn: conn, vjt: vjt} do
+      net = net_with_credential(vjt)
+      :ok = seed_archive_rows(vjt, net)
+
+      {:ok, _} = QueryWindows.open({:user, vjt.id}, net.id, "vjt-peer", vjt.name)
+
+      conn = get(conn, "/networks/#{net.slug}/archive")
+
+      targets = Enum.map(json_response(conn, 200)["archive"], & &1["target"])
+      assert "vjt-peer" in targets
+    end
+
+    # The control for the test above, and the one that keeps the fix from
+    # becoming "the archive never subtracts queries". With a LIVE session an
+    # open query window is a window the operator can already be in, so it
+    # must still be excluded — this is the only test in the file that runs a
+    # session, which is why it pays for the fake ircd.
+    test "an open query window DOES hide its DM while a session is live",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
+      slug = "az-#{System.unique_integer([:positive])}"
+      {net, _} = network_with_server(port: port, slug: slug)
+      _ = credential_fixture(vjt, net, %{nick: "grappa-test"})
+      :ok = seed_archive_rows(vjt, net)
+
+      {:ok, _} = QueryWindows.open({:user, vjt.id}, net.id, "vjt-peer", vjt.name)
+
+      _pid = start_session_for(vjt, net)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      conn = get(conn, "/networks/#{slug}/archive")
+
+      targets = Enum.map(json_response(conn, 200)["archive"], & &1["target"])
+      refute "vjt-peer" in targets
+      # The channels are still archived — the session joined nothing, so the
+      # exclusion above is the query window's doing and not a live channel's.
+      assert "#a" in targets
+      assert "#b" in targets
     end
 
     test "returns empty archive when network has no scrollback rows",

--- a/test/grappa_web/controllers/archive_controller_test.exs
+++ b/test/grappa_web/controllers/archive_controller_test.exs
@@ -166,7 +166,14 @@ defmodule GrappaWeb.ArchiveControllerTest do
     # session, which is why it pays for the fake ircd.
     test "an open query window DOES hide its DM while a session is live",
          %{conn: conn, vjt: vjt} do
-      {server, port} = IRCServer.start_server(IRCServer.welcome_handler(":irc", "grappa-test"))
+      # The fake ircd stays SILENT (`passthrough_handler`, no 001) on purpose.
+      # All this test needs is a session PROCESS — `Session.list_channels/2`
+      # answers from its state, registration or not. Send a welcome and the
+      # session registers, then autojoins the fixture's `#sniffo` on a socket
+      # this test is about to tear down: an intermittent `:tcp_closed` crash
+      # in the log, green run and all. A silent ircd absorbs the connect and
+      # nothing else happens.
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       slug = "az-#{System.unique_integer([:positive])}"
       {net, _} = network_with_server(port: port, slug: slug)
       _ = credential_fixture(vjt, net, %{nick: "grappa-test"})
@@ -175,6 +182,8 @@ defmodule GrappaWeb.ArchiveControllerTest do
       {:ok, _} = QueryWindows.open({:user, vjt.id}, net.id, "vjt-peer", vjt.name)
 
       _pid = start_session_for(vjt, net)
+      # Handshake awaited so the socket is up before the read — the session is
+      # live either way, but a half-open connect is not a state worth racing.
       :ok = IRCServer.await_handshake(server, 1_000)
 
       conn = get(conn, "/networks/#{slug}/archive")

--- a/test/grappa_web/controllers/archive_controller_test.exs
+++ b/test/grappa_web/controllers/archive_controller_test.exs
@@ -181,7 +181,7 @@ defmodule GrappaWeb.ArchiveControllerTest do
 
       {:ok, _} = QueryWindows.open({:user, vjt.id}, net.id, "vjt-peer", vjt.name)
 
-      _pid = start_session_for(vjt, net)
+      _ = start_session_for(vjt, net)
       # Handshake awaited so the socket is up before the read — the session is
       # live either way, but a half-open connect is not a state worth racing.
       :ok = IRCServer.await_handshake(server, 1_000)


### PR DESCRIPTION
Implements the ruling on issue 1985 (hard disappearance, option 1), the cold-load redirect vjt ruled on while this was being built, and — new in this push — the archive hole that ruling exposed.

**Rebased onto `8ed1ef3d8`** (the four-way union landed while this sat). The previous red was taken on a base 63 commits behind and says nothing about this tree; it has been re-derived from zero rather than rerun, because a rerun reuses the old merge ref.

## What changes

While a network's `connection_state == parked`, the network and every row under it **leave the sidebar**, and come back when it reconnects. No collapsed section, no parked area — option 2 was dropped and issue 450 stays a separate concern.

`failed` is untouched and stays **greyed in place**: a failure is something the operator must see and act on. `failing` stays outside both sets for issue 1675's reason — it is retrying on its own. The asymmetry between the three states is the product decision, not an oversight.

## The inference is now RULED, and the ruling reversed it

The entry flagged one thing as inferred rather than laundering it into a decision: that the disappearance killed the only door back to a parked window's history. **vjt answered — the history is reachable from the archive** — with reading a parked network's history deferred to SEARCH rather than to a dedicated re-entry door.

⚠️ **Provenance: vjt's words reached this session RELAYED, not read on IRC by its author.** Stated that way in DESIGN_NOTES too.

So nothing is lost, and the paragraph that said something was is now marked FALSE in place rather than quietly deleted — the reversal is the record. The door is genuinely reachable while parked, verified by reading rather than running: `ArchiveModal` iterates the RAW `networks()` store (`:174`), not the sidebar's filtered list, and the archive launcher renders unconditionally (`RailActions.tsx:525-533`).

## …and naming the archive as THE surface exposed a hole. Three legs, one predicted

`visibleArchiveForNetwork` subtracts the live channels, the live queries and the pseudo-rows, on the premise issue 402 wrote down: *a nav renders what it subtracts*. Dropping a whole network from the Sidebar's one `<For>` breaks that premise wholesale.

**Measured before the cure, in vitest**: a parked network holding an autojoin channel and a kicked pseudo-row rendered **ZERO** archive rows. Both swallowed.

- **Pseudo-rows — predicted.** `navPseudoChannelsForNetwork` returned the projection unconditionally on desktop.
- **Live channels — NOT predicted, and read as safe until measured.** `GET /networks/:slug/channels` returns the union of the credential's AUTOJOIN list and the live session's channels (`ChannelsController.index` → `Networks.merge_channel_sources/2`). A parked network has no session, so the union is exactly the autojoin list, at `joined: false` — sitting in `channelsBySlug` for the filter to subtract. The server had put those very rows in the archive *because* the session was gone (an absent session means an empty `active_keyset`: *"everything with rows qualifies for the archive when no session is live"*). The two sides disagreed and the operator's own autojoin channels paid.
- **Queries — CURED, with the server change this PR originally declined.** `ArchiveController.build_active_keyset/3` composed the live channels (empty when parked) with `open_query_targets/2`, a DB read of the open query windows with **no session gate**. So a parked network's DM windows were excluded from the archive by the SERVER while the desktop sidebar no longer drew them: one window, zero surfaces, and no client filter can restore a row that never arrived. It was handed up rather than taken; the call came back to take it, because **the asymmetry is pre-existing but THIS slice is what turns it into a live hole, so shipping the first two legs without it ships a measured regression**. It is also not a product call: it aligns the function with the promise the module already makes in words, which its channel arm kept and its query arm did not. Now one `case` over the session lookup answers for both arms.

## The cure

`navDrawsNetwork(slug)` in `lib/pseudoChannels.ts`, one level above the row projections: does the nav of THIS form factor draw ANY row for this network. Desktop answers `!isNetworkParked(...)`.

**Mobile answers YES, and that is measured, not assumed:** `BottomBar.tsx` iterates the raw `networks()` store and renders each network's channels and queries with no state filter of its own (`:138`, `:174`, `:215`), so on a phone those rows are still on screen and must still be subtracted. The sidebar filter this issue adds is desktop-only.

It does **not** live in `archive.ts` as a local `isNetworkParked` call: that would be a second statement of the parked policy plus a copy of the form-factor rule, and `lib/networkParked.ts` was extracted precisely to stop the first.

`failed` and `failing` keep drawing, **asserted rather than left implicit** — if those controls ever turn, the parked release has been widened into "any non-connected state", the generalisation that predicate exists to refuse.

## Shape

- `lib/grappa_web/controllers/archive_controller.ex` — the ONLY server change: an absent session empties the whole keyset, query windows included. One `case`, so there is a single place saying what "no session" means and the two arms cannot drift apart again. **This PR is therefore no longer cic-bundle-only**: one module body, no `VERSION` bump and no migration, so the server half is hot-reloadable.
- `lib/networkParked.ts` — the one statement of the rule. Its own module rather than a function in `lib/networks.ts` for a testing reason that is also a design one: `networks.ts` is a resource singleton every suite replaces wholesale with `vi.mock`, so a predicate living there could only ever be tested through a mirror of itself.
- `lib/pseudoChannels.ts` — `navDrawsNetwork`, and `navPseudoChannelsForNetwork` short-circuits through it.
- `lib/archive.ts` — consumes that one answer; subtracts nothing when the nav draws nothing.
- `Sidebar.tsx` — the filter at the ONE `<For>` over networks. Header, channels, queries and pseudo-rows all render inside it, so dropping the network drops all four by construction.
- `NETWORK_GREYED_STATES` narrows to `["failed"]` — parked can no longer reach that cascade, and two statements of one policy is how the next reader picks the wrong one.
- `Shell.tsx` — one clause in the cold-load restore gate, TERMINAL rather than provisional: a non-latching gate would yank focus off home the moment the operator hit `[Reconnect]`.

## Gates, on the rebased tree

- `bun.sh run check` — **5/5 green** (lock drift, test location, biome, tsc src, tsc e2e).
- `bun.sh run test` — **343 files / 6968 tests green**.
- `scripts/design-notes-gate.sh` — green; marker `<!-- entry #1985 -->` re-checked for uniqueness against the CURRENT `origin/main` tip, not the base this branched from.
- `scripts/union-rebase.sh` — the DESIGN_NOTES contribution came through the rebase two-sided intact (+116 / −0, unchanged in both directions).
- `mix compile --force --warnings-as-errors` (test env) — clean, Boundary included.
- `archive_controller_test.exs` — **16 tests, 0 failures**.
- **RED → GREEN watched for both cic legs**, which is their mutation evidence: parked returned its 4 pseudo-rows before the cure and `[]` after; the archive returned `[]` before and both rows after. The `failed` controls passed throughout.
- **Mutation on the server leg, run explicitly**: putting the query targets back into the keyset without a session turns **exactly one** test red — the new no-session one — while the live-session control stays green. Restored by checksum, tree verified clean, re-run green.
- The heavy gate (`check.sh`: format, credo, sobelow, dialyzer, full suite) is **deliberately left to CI** rather than run twice while the lane is contended.

## The two contract specs are re-aimed, and here is the only reason that licenses it

`cp15-b6-parked-disconnect-reconnect` and `issue100-reconnecting-badge` asserted the **pre-ruling** contract: a parked network stays in the sidebar, greyed and navigable, and the reconnecting badge has that greyed row to appear on.

> **The specs change because the product owner ruled the asserted behaviour wrong — NOT because they were flaky, and NOT to make them pass.**

That sentence is in each spec at the assertion that changed, so a later reader cannot mistake the rewrite for a relaxation. Nothing was weakened: no timeout raised, no assert deleted, no rerun bought.

- **cp15-b6** now asserts the network section is GONE while parked (and its channel rows with it) and **BACK** after Reconnect. The "comes back" half is asserted deliberately — a disappearance-only spec goes green on a sidebar that never recovers. The reason tooltip loses the header that hosted it; the reason itself is still asserted on the Home card, now its only surface.
- **issue100** now asserts the OPPOSITE outcome: the badge has **no surface** during a park→Reconnect, and the network returns anyway. An earlier revision of this PR argued the badge would still surface on an ordering (spawn-then-commit, row back in milliseconds while `connecting` is still set). **Measured: the ordering half is TRUE — the section does come back, and the spec still asserts it — and the conclusion drawn from it was FALSE.** The badge never entered the DOM. That is corrected here rather than dropped.
- Both stop reading `toHaveCount(0)` on the greyed child as proof a row is healthy: that passes for a row which never came back. Present **and** un-greyed, separately.

### Attribution for the issue100 rewrite was measured, not argued

| where | result |
|---|---|
| merge base `8ed1ef3d8` | **GREEN**, 1.3s |
| this branch | **RED 3/3**, ~21.8s, identical `TimeoutError` each run |

Not a flake and not pre-existing. The cause is structural: the badge has exactly **one** render site, inside the per-network `<For>`, and this branch filters parked networks out of that loop. The base kept a greyed row for the whole park, so the badge had a host. No row, no host, no badge. The badge's own machinery is untouched by this branch (empty diff on `reconnectingStatus.ts`), so nothing else can account for it.

**That makes the lost badge accepted collateral of the ruling, not an incident** — and "repairing" it would mean building for the badge, which the ruling forbids. The same licence applies as to the other two specs:

> **The spec changes because the product owner ruled the asserted behaviour wrong — NOT because it was flaky, and NOT to make it pass.**

⚠️ **Coverage lost, stated rather than buried.** issue100 was the ONLY e2e spec asserting the badge RENDERS (the two other specs naming it merely borrow its cleanup ritual). Re-aimed, no e2e covers the badge appearing at all — including on a spontaneous link drop, where the row is present and it presumably still works. That path was never covered here either (this spec always drove through a park), so nothing that WAS covered is dropped silently; but the render is now unguarded end-to-end. The dispatch keeps unit coverage in `userTopic.test.ts`; the render has none.

### Mutation: owed in the last revision, now PAID

- **cp15-b6** — baseline GREEN. With `visibleNetworks` stripped of its filter (the exact pre-1985 regression) the spec goes **RED at the named disappearance assert** (`toHaveCount(0)`, Expected 0 / Received 1). Not decoration. Mutant reverted and verified four ways (md5, `cmp`, empty `git status`, diff gone).
- **issue100** — the same mutant cannot redden its "section BACK" assert, and no mutant on that function can: that assert and the spec's own baseline are the SAME production predicate, so a mutant hiding connected networks kills the baseline first. Stated up front rather than discovered, and a green there is **not** evidence of decoration.

⚠️ Both were run **scoped** (`--grep`). A scoped green is not the ship gate — the full `scripts/integration.sh` still has to pass before merge (incident #268).

## Ruled: nothing is built for the `reconnecting…` badge

This section asked an open question in an earlier revision. It is answered. vjt, on `#grappa` 2026-09-10 at 14:59 Rome (12:59Z): *"ci si riconnette da HOME"* — *"non SERVE nient'ALTRO"*.

⚠️ **Provenance: RELAYED into this session, not read on IRC by this PR's author** — same posture as the archive ruling above, and stated as relayed rather than quoted first-hand.

So none of the three candidates is built: no badge grafted onto `$home`, no state machine holding `[Reconnect]` disabled longer, no teaching `$home` the progress signal. A parked network's row leaves the sidebar and reconnecting is `$home`'s business. This **extends** the 2026-09-08 *"redirect to home"* ruling rather than competing with it, and the cold-load restore gate in `Shell.tsx` is untouched by it.

The measurement taken before the ruling landed still describes today's behaviour — it is simply no longer a question. The badge of issue 100 renders inside the per-network `<For>` (`Sidebar.tsx:378-380`) off `reconnectingByNetwork`, which the server drives with `connection_progress` (`connecting` on the attempt, `connected` on 001). `connection_state` stays `parked` for that entire window by design — it is operator intent, and the badge is deliberately not that state. **So the badge fires while its host row does not exist.**

**Observed, and placed out of scope by that same ruling — recorded so the next reader does not re-discover it as new.** Between clicking `[Reconnect]` on `$home` and 001, the button relabels to `Reconnecting…` only while the awaited PATCH is in flight, then returns to `Reconnect` with the state word still reading `parked` and no badge anywhere — while the upstream link is in fact coming up. Before this slice the greyed sidebar row hosted the badge for exactly that window. It is a second-order effect of the ruling, deliberately **not** filed as an issue and not cured: *"non serve nient'altro"*.

This PR moves no badge code: on `<merge-base>..HEAD` the added lines naming `reconnecting|badge` are **0** in `Shell.tsx`, `Sidebar.tsx`, `lib/networkParked.ts`, `lib/pseudoChannels.ts` and `lib/archive.ts` — every mention lives in the issue-100 spec and in DESIGN_NOTES (positive control: `parked` = 139 added lines, so the grep was alive).

## Limits, stated

- **Not device-verified.** jsdom + a pure predicate. Whether the sidebar reads right with two parked networks on a phone is dogfood.
- **`BottomBar` is untouched** — a scope call, not an oversight, and now a measured input to the cure rather than a loose end: it is exactly why the mobile arm of `navDrawsNetwork` answers yes.
- **`ComposeBox.tsx` keeps its own `{parked, failed}` set**, deliberately: "can I type here" is a different question from "is there a row".
- **This slice is out of the 1.5.4 cut** (release scope, vjt's). `v1.5.5` was cut on `e7677913b` while this round was in flight; this branch is 1 commit behind that tip and still MERGEABLE, and the DESIGN_NOTES marker was re-checked for uniqueness against the NEW tip (0 hits, positive control 341).
- **The `reconnecting…` badge was not moved** — and by the 2026-09-10 ruling it is not to be. See the ruling section above; the measured second-order effect is recorded there as out of scope, not as a loose end.
