### PR TITLE
test(e2e): wait for the PART echo before deleting archive state

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -877,6 +877,44 @@ export async function partChannel(
   }
 }
 
+// The PART-side twin of `listChannelNames`' lesson (#793): the DELETE only
+// ASKS. `partChannel` returns as soon as the bouncer has dropped the channel
+// from its own state — the sidebar tab vanishes on that alone — but the
+// upstream PART is still in flight, and the ECHO comes back a full second
+// later on a connection that spent its penalty budget on connect + autojoin
+// (measured on CI: `headroom_s=-1.155`, PART sent → echo ingested in 1.002 s
+// and 1.003 s across two runs).
+//
+// Ingesting that echo WRITES a `:part` row into the channel's scrollback, and
+// the archive is derived from scrollback. So a spec that deletes the archive
+// entry inside that window sees the row DELETED AND RECREATED with a fresh
+// `last_activity` — not "failing to disappear". Nothing removes the new row
+// afterwards, so a bigger timeout buys a slower red: measured, the assertion
+// polled 9 times over 5 s and saw `1` every time, losing the race by 13 ms
+// and 8 ms on two runs of `ux-2-mobile-archive`.
+//
+// Await this after `partChannel` and before anything that deletes archive
+// state or asserts an ABSENCE. Asserting the entry is PRESENT needs no
+// barrier — the echo can only recreate it, never remove it.
+//
+// Distinct from calling `assertMessagePersisted` directly, which m9 does:
+// there the persisted PART row is the CLAIM under test, here it is a setup
+// barrier. Same verb, different job, hence the name.
+export async function awaitPartEcho(
+  token: string,
+  networkSlug: string,
+  channel: string,
+  nick: string,
+): Promise<void> {
+  await assertMessagePersisted({
+    token,
+    networkSlug,
+    channel,
+    sender: nick,
+    kind: "part",
+  });
+}
+
 // #1038 — the stored mute key: the network slug, a space, and the channel or
 // DM peer.
 //

--- a/cicchetto/e2e/tests/ux-1-archive-delete.spec.ts
+++ b/cicchetto/e2e/tests/ux-1-archive-delete.spec.ts
@@ -35,7 +35,7 @@ import {
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { joinChannel, partChannel } from "../fixtures/grappaApi";
+import { awaitPartEcho, joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -61,6 +61,10 @@ test("UX-1 — × on archive entry confirms + deletes scrollback permanently", a
   // PART so the channel moves into archive.
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, { timeout: 5_000 });
+
+  // Barrier before the delete: a late PART echo recreates the archive entry
+  // AND puts a row back in the scrollback this spec later asserts is empty.
+  await awaitPartEcho(vjt.token, NETWORK_SLUG, CHANNEL, specNick());
 
   // Open the grouped ArchiveModal — the ONE archive surface post-#473,
   // replacing the retired desktop Sidebar `<details class="sidebar-archive">`.

--- a/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
+++ b/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
@@ -40,7 +40,7 @@ import {
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { joinChannel, partChannel } from "../fixtures/grappaApi";
+import { awaitPartEcho, joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -67,6 +67,11 @@ test("@webkit @touch UX-2 — rail archive opens the grouped modal + delete drop
   // selection-gated), so no server-tab dance is needed to surface it.
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).not.toBeVisible({ timeout: 10_000 });
+
+  // The sidebar going away proves the bouncer dropped the channel, NOT that
+  // the upstream echo landed — and the echo writes a `:part` row that
+  // recreates the archive entry the delete below is about to remove.
+  await awaitPartEcho(vjt.token, NETWORK_SLUG, CHANNEL, specNick());
 
   // openArchive (mobile) opens the rail drawer then taps
   // mobile-panel-archive → the grouped ArchiveModal. The header is

--- a/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
@@ -49,7 +49,7 @@ import {
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { joinChannel, partChannel } from "../fixtures/grappaApi";
+import { awaitPartEcho, joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -119,6 +119,11 @@ test("@webkit @touch UX-Z cluster — Dynamic Island clearance + RailActions arc
   // PART seed channel so the UX-2 archive-button arm has an archived
   // entry to render in the modal.
   await partChannel(vjt.token, NETWORK_SLUG, CHANNEL);
+
+  // Barrier before the archive arm below deletes the entry: a late PART echo
+  // recreates it, and also repopulates the scrollback this journey later
+  // asserts is empty.
+  await awaitPartEcho(vjt.token, NETWORK_SLUG, CHANNEL, specNick());
 
   // ── UX-2 — archive opened via the always-on RailActions button (#473) ──
   //

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49542,3 +49542,89 @@ Across all 326 markers there are three findings and all three are same-commit:
 zero false positives observed, and no reachable case constructed. Should one
 ever turn up, the honest cure is to read the lines the branch ADDS rather than
 the file — a larger change than this gap justified today.
+<!-- entry #2017 -->
+
+---
+
+## 2026-09-09 — #2017: the archive row that was deleted and recreated
+
+`ux-2-mobile-archive:54` failed three times reading "the deleted archive row
+does not disappear". It disappears. It is deleted and then RECREATED, and the
+recreating write is the spec's own PART coming back from upstream. Recorded
+because the symptom points at the wrong layer and cost three sightings before
+anyone read the timestamps.
+
+### The mechanism
+
+Server log and Playwright trace of run 34285217206, both failing attempts,
+agreeing to the millisecond: the archive DELETE commits (`204 in 4ms`,
+`DELETE FROM "messages" ... "#spec-w0"`), and 7 ms later the session process —
+logged with no `request_id`, so not an HTTP call — inserts a `:part` row for
+that channel. The archive is derived from scrollback, so the entry returns
+carrying exactly that row's `server_time` as its new `last_activity`. The
+re-fetch 7 ms later reads it back.
+
+The echo is late because the connection spent its penalty budget on connect
+plus autojoin: the PART send logs `headroom_s=-1.155`, and PART-sent to
+echo-ingested measured **1.002 s** and **1.003 s** across the two attempts,
+while the spec reaches its delete tap at ~989 ms. The margin was **13 ms** and
+**8 ms** — a deterministic mechanism with a photo-finish outcome, which is why
+it wore the costume of a flake.
+
+### Why the timeout was never the knob
+
+Nothing removes the new row until the `afterEach` JOIN five seconds later, so
+a larger budget buys a slower red — the assertion had already polled nine
+times and seen `1` every time. Every DB operation in the window is
+sub-millisecond to low-single-digit (`db=0.1ms`…`2.6ms`, `queue=0.1ms`): there
+is no lock wait here and nothing a storage-side timeout could reach. The one
+delay that decides the test is IRC fake-lag, on the far side of the socket
+from SQLite.
+
+### The cure, and its shape
+
+`awaitPartEcho` is the PART-side twin of the lesson `listChannelNames` already
+carried for JOIN (#793): the request only ASKS. It delegates to
+`assertMessagePersisted` with `kind: "part"`, which `m9-cicchetto-part-x-click`
+already used — the verb existed; what did not exist was a name for using it as
+a SETUP BARRIER rather than as a claim. That distinction is the whole reason
+for the wrapper, and it is why m9's direct call was left alone.
+
+Applied to all three specs that DELETE archive state (`ux-1-archive-delete`,
+`ux-2-mobile-archive`, `ux-z-cluster-journey`), not only the one that went red:
+identical shape, and the two journey specs additionally assert the scrollback
+is empty afterwards, which the same stray row breaks. **The direction matters
+and is the reason the blast radius stops there:** specs asserting the entry is
+PRESENT need no barrier, because a late echo can only recreate an entry, never
+remove one.
+
+### Proved by mutation, both directions
+
+A three-arm throwaway probe on the real stack, contract deliberately mixed so
+that three greens would indict the probe rather than bless the cure. Arm A (no
+barrier, delete driven over the API so it lands ~8 ms after the PART instead of
+the UI's ~990 ms) FAILED as required, on `not.toContain` with
+`archive after echo = ["#spec-w0"]`. Arm B (with barrier) passed, the archive
+still empty 2 s later. Arm C (barrier on a nick that never parted) FAILED on
+the 5 s ceiling — without it, a barrier matching anything would also be green.
+
+**Arm B's number is the evidence the barrier observes rather than sleeps:** it
+reported 2016 ms at a 100 ms poll granularity, i.e. the fake-lag as it actually
+was on that stack — twice the 1.002 s measured in CI. A disguised sleep prints
+its own constant on every substrate.
+
+Driving arm A's delete over the API rather than the UI is what made the red
+reproducible: at 13 ms of margin the UI path is a coin toss, and a negative
+control you cannot summon is not a control.
+
+### Left open, deliberately
+
+Whether the server SHOULD let an in-flight echo repopulate a just-emptied
+archive entry is a product question, escalated rather than answered here. The
+barrier holds under either ruling — it waits for an event that happens in both
+worlds. Worth carrying forward: on a real network that window is WIDER than the
+1 s measured on the testnet, not narrower, so the same race is reachable by a
+user who parts, opens archive, and deletes.
+
+_Test-only. No wire change, no protocol bump, no production code touched.
+Deploy: nothing to deploy._


### PR DESCRIPTION
`ux-2-mobile-archive:54` has gone red three times with what reads as "the
deleted archive row does not disappear". It disappears. It is deleted and
then **recreated**, and the write that recreates it is the spec's own PART
coming back from upstream.

## The mechanism, measured

From the server log and the Playwright trace of run 34285217206, both
failing attempts, agreeing to the millisecond:

| t | event |
|---|---|
| `10.102` | `command=PART` sent upstream, **`headroom_s=-1.155`** — the connection is in penalty debt |
| `11.091` | archive `DELETE` |
| `11.097` | `DELETE FROM "messages" ... "#spec-w0"` → `204 in 4ms` |
| `11.104` | `INSERT ... :part ... server_time 1788907271103` — pid with **no `request_id`**, i.e. the session process ingesting the echo |
| `11.111` | `GET /archive` → the entry is back, `last_activity: 1788907271103` |

That last number is the inserted row's `server_time` exactly. The archive is
derived from scrollback, so the echo repopulates it.

PART sent → echo ingested took **1.002 s** and **1.003 s** on the two runs;
the spec reaches its delete tap at ~989 ms. The margin is **13 ms** and
**8 ms**.

Raising the timeout could not have helped: nothing removes the new row until
the `afterEach` JOIN five seconds later, and the assertion already polled
nine times and saw `1` every time. The non-deterministic thing was the
**setup** — `partChannel` returns when the bouncer has dropped the channel,
which is not when the echo has landed.

## The cure

`awaitPartEcho` is the PART-side twin of the lesson `listChannelNames`
already carries for JOIN (issue 793): the request only asks. It delegates to
`assertMessagePersisted` with `kind: "part"`, which
`m9-cicchetto-part-x-click` already uses — the verb existed, only a name for
using it as a setup barrier rather than as a claim did not.

Applied to all three specs that delete archive state, not only the one that
went red: `ux-1-archive-delete`, `ux-2-mobile-archive`,
`ux-z-cluster-journey` have the identical shape, and the two journey specs
additionally assert the scrollback is empty afterwards — which the same
stray `:part` row breaks. Specs that assert the entry is **present** are
untouched: a late echo can only recreate the entry, never remove it.

## Proved by mutation, both directions

A three-arm throwaway probe, run on the real stack against
`chromium-pixel-touch`, then deleted. Its contract was deliberately mixed —
if all three had gone green, the probe was broken, not the cure working.

| arm | contract | result |
|---|---|---|
| **A** — no barrier; delete driven over the API so it lands ~8 ms after the PART instead of the UI's ~990 ms | must **FAIL** | ✘ `archive after echo = ["#spec-w0"]`, failing on `expect(targets).not.toContain(...)` |
| **B** — with the barrier | must **PASS** | ✓ barrier observed the echo after **2016 ms**; archive `[]` still 2 s later |
| **C** — barrier on a nick that never parted | must **FAIL** | ✘ `assertMessagePersisted: timeout after 5000ms — sender=nick-that-never-parted` |

`2 failed, 1 passed` — exactly the contract.

**A green CI run is NOT the proof, and should not be read as one.** This
spec failed 3 of 4 runs before the barrier, so a single pass is equally
consistent with luck — a 13 ms margin wins sometimes. The evidence is the
two-directional mutation above: red **on demand** without the barrier,
green with it. CI is the confirmation, not the proof.

**The negative direction is demonstrated, not argued:** arm A produces the
red on demand. Driving the delete over the API rather than the UI is what
makes it deterministic — the UI path loses by 13 ms, which is not
reproducible; the API path puts the echo ~2 s inside the window.

**Arm B's 2016 ms is an observation, not a sleep.** The barrier polls at
100 ms, so the figure is the ircd's fake-lag as it actually was on this
stack — twice the 1.002 s measured in CI. A disguised sleep would have
printed its own constant on every substrate. Arm C is what makes arm B's
green worth anything: without it, a barrier that matches everything would
also be green.

## The cured specs, on the stack

```
✓ [chromium]             ux-1-archive-delete.spec.ts:51
✓ [chromium-pixel-touch] ux-2-mobile-archive.spec.ts:54
✓ [chromium-pixel-touch] ux-z-cluster-journey.spec.ts:64
✓ [webkit-iphone-15]     ux-2-mobile-archive.spec.ts:54
✓ [webkit-iphone-15]     ux-z-cluster-journey.spec.ts:64
5 passed
```

Plus `bun run check` 5/5 and vitest 341 files / 6865 tests green.

## Out of scope, deliberately

Whether the server *should* let an in-flight echo repopulate a just-emptied
archive entry is a product question. It is escalated and not decided here,
and this barrier holds under either answer — it waits for an event that
happens in both worlds. Worth noting the window is **wider** on a real
network than the 1 s measured here, not narrower.

Separately: the main checkout's `node_modules` is 22 packages adrift from
`bun.lock`. Reconciled in this worktree only; main left as it is. Reported
out of band, not touched in this slice.
