### PR TITLE
cic: anchor the context menu's far corner under the finger on touch (issue 2014)

### DIFF
--- a/cicchetto/e2e/tests/issue2014-context-menu-touch-anchor.spec.ts
+++ b/cicchetto/e2e/tests/issue2014-context-menu-touch-anchor.spec.ts
@@ -1,0 +1,250 @@
+// issue 2014 — on iOS the long-press message menu opened DOWN-AND-RIGHT of the
+// touch point, so the hand that opened it covered it. The ask, in the
+// reporter's words, is that the menu's BOTTOM-RIGHT CORNER sit on the press
+// point: the menu opens up-and-left, out from under the thumb. On a mouse the
+// native down-and-right convention stands, unchanged.
+//
+// WHY THIS SPEC EXISTS AT ALL — the issue says the suite cannot host the
+// gesture, and that is FALSE, measured: `issue1067-swipe-reply-message-menu`
+// has synthesized a real touchstart → wall-clock hold → touchend since #1067,
+// and its header records that `hasTouch: true` puts Chromium's primary pointer
+// at COARSE. Both halves of what this needs were already in the repo. The
+// citation that fed the issue is about `webkit-iphone-15`'s `tap()`, which is a
+// different engine and a different verb.
+//
+// THE EXPERIMENT, and it is three tests because the fix has two claims:
+//   1. the reported path — coarse pointer, long-press, message row;
+//   2+3. the GATE, isolated. Same door (a synthetic `contextmenu`), same
+//        surface (the members-pane nick menu), ONE variable changed: the
+//        pointer. Coarse answers bottom-right, fine answers top-left. Without
+//        the pair, test 1 alone leaves "maybe it is the DOOR that decides"
+//        standing, which is exactly the design decision worth pinning — the
+//        anchor is keyed on the pointing device, not on which door opened.
+//   2+3 also carry the SCOPE: vjt ruled "tutta la shell" (2026-09-09 00:24Z),
+//   so the nick menu — a different host of the same shell, which passes no
+//   anchor of its own — must inherit the same answer as the message menu.
+//
+// EVERY test asserts an ANTI-HOLLOW PRECONDITION first (the #487 sibling's
+// pattern): that at the chosen point the menu would have fitted on BOTH sides
+// of both axes. Without it the assertion is satisfiable by a viewport-collision
+// FLIP, and flip-vs-anchor is precisely the confusion the issue names — from a
+// screenshot near an edge the two are indistinguishable. The point is the
+// viewport centre and the viewports are roomy for the same reason: a
+// deterministic setup, not a tolerance.
+//
+// ⚠️ LIMITS, and they are the reason this is not the whole proof. ⚠️
+// Chromium is not iOS. `env(safe-area-inset-*)` is {0,0,0,0} on every engine in
+// this suite, so the safe-area interval degenerates to the viewport and nothing
+// here exercises the notch or the home indicator — that arithmetic is unit
+// work (src/__tests__/menuPosition.test.ts, which carries the iPhone 15 insets)
+// and the FELT result is vjt's on-device dogfood. What this file proves is the
+// ANCHOR and its GATE against a real layout engine. It says nothing about
+// iOS-specific placement, and must not be read as saying it.
+//
+// The touch synthesizer below is a THIRD copy of the one in
+// `issue1067-swipe-reply-message-menu` and `issue1413-hold-press-feedback`.
+// Left local, matching its neighbours, rather than extracted here: hoisting it
+// into a fixture would rewrite two specs this change has no business touching.
+import type { Page } from "@playwright/test";
+import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+test.setTimeout(90_000);
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Comfortably above LONG_PRESS_MS (500) so the hold classification is
+// deterministic under load; setTimeout never fires early. Same value, same
+// reason, as the #1067 spec.
+const HOLD_MS = 700;
+
+// Roomy on purpose. The centre of a 1024×800 box leaves ~500px of slack on
+// each side of both axes, which is what makes the both-anchors-fit
+// precondition hold with margin instead of by luck — and `hasTouch: true` is
+// what puts the pointer at coarse, NOT the viewport size.
+const TOUCH_VIEWPORT = { width: 1024, height: 800 };
+const MOUSE_VIEWPORT = { width: 1280, height: 800 };
+
+// Date.now() suffix + a per-test tag: the e2e sqlite scrollback survives
+// KEEP_STACK=1 re-runs and is shared by the tests in this file, so an untagged
+// module-level body would match twice and die of Playwright strict mode.
+const bodyFor = (tag: string): string => `2014 ${tag} target ${Date.now()}`;
+
+type Point = { x: number; y: number };
+
+function viewportCentre(page: Page): Point {
+  const vp = page.viewportSize();
+  if (!vp) throw new Error("no viewport size");
+  return { x: Math.round(vp.width / 2), y: Math.round(vp.height / 2) };
+}
+
+async function menuGeometry(page: Page) {
+  return await page.evaluate(() => {
+    const menu = document.querySelector(".context-menu");
+    if (!(menu instanceof HTMLElement)) throw new Error("context menu not rendered");
+    const m = menu.getBoundingClientRect();
+    return {
+      top: m.top,
+      left: m.left,
+      right: m.right,
+      bottom: m.bottom,
+      width: m.width,
+      height: m.height,
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+      coarsePointer: window.matchMedia("(pointer: coarse)").matches,
+    };
+  });
+}
+
+type Geometry = Awaited<ReturnType<typeof menuGeometry>>;
+
+// The anti-hollow precondition. Both anchors have to be POSSIBLE at this point,
+// or the corner assertion that follows proves nothing: near an edge the
+// collision flip produces the far corner all by itself, under either
+// preference, and the test would go green on a reverted fix.
+function expectBothAnchorsWouldFit(g: Geometry, at: Point): void {
+  expect(g.width).toBeGreaterThan(0);
+  expect(g.height).toBeGreaterThan(0);
+  expect(at.x - g.width).toBeGreaterThanOrEqual(0);
+  expect(at.x + g.width).toBeLessThanOrEqual(g.innerWidth);
+  expect(at.y - g.height).toBeGreaterThanOrEqual(0);
+  expect(at.y + g.height).toBeLessThanOrEqual(g.innerHeight);
+}
+
+async function seedChannel(page: Page): Promise<void> {
+  await loginAs(page, specUser());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+}
+
+async function seedRow(page: Page, tag: string): Promise<string> {
+  await seedChannel(page);
+  const body = bodyFor(tag);
+  await composeSend(page, body);
+  await expect(scrollbackLine(page, "privmsg", body)).toBeVisible({ timeout: 5_000 });
+  return body;
+}
+
+// touchstart → real wall-clock hold → touchend, with no movement: the press.
+// Dispatched in-page ON the row, so it reaches the production listener by
+// bubbling to `.scrollback` exactly as a finger does; the coordinates ride on
+// the Touch and are what `bindMessageGestures` hands the menu as its `at`.
+async function longPressRow(page: Page, body: string, at: Point, holdMs: number): Promise<void> {
+  await page.evaluate(
+    async ({ body: text, at: point, holdMs: ms }) => {
+      const rows = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-testid="scrollback-line"]'),
+      );
+      const row = rows.find((r) => r.textContent?.includes(text));
+      if (row === undefined) throw new Error(`no scrollback row containing ${text}`);
+      const mk = () =>
+        new Touch({ identifier: 1, target: row, clientX: point.x, clientY: point.y });
+      const fire = (type: "touchstart" | "touchend"): void => {
+        const t = mk();
+        const active = type === "touchend" ? [] : [t];
+        row.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches: active,
+            targetTouches: active,
+            changedTouches: [t],
+          }),
+        );
+      };
+      fire("touchstart");
+      await new Promise((r) => setTimeout(r, ms));
+      fire("touchend");
+    },
+    { body, at, holdMs },
+  );
+  await expect(page.locator(".context-menu")).toBeVisible({ timeout: 5_000 });
+}
+
+// The other door, on the other host: a synthetic `contextmenu` on the first
+// members-pane nick. Same shape as the #487 spec's opener — the handler reads
+// the coordinates off the event, not off the element box, so the press point is
+// ours to choose.
+async function contextMenuOnNick(page: Page, at: Point): Promise<void> {
+  await expect(page.locator(".members-pane .member-name").first()).toBeVisible({ timeout: 5_000 });
+  await page.evaluate((point) => {
+    const btn = document.querySelector(".members-pane .member-name");
+    if (!(btn instanceof HTMLElement)) throw new Error("no .member-name button in members-pane");
+    btn.dispatchEvent(
+      new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: point.x,
+        clientY: point.y,
+      }),
+    );
+  }, at);
+  await expect(page.locator(".context-menu")).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("issue 2014 — coarse pointer anchors the menu's bottom-right corner", () => {
+  test.use({ viewport: TOUCH_VIEWPORT, hasTouch: true });
+
+  test("a long-press puts the message menu's bottom-right corner on the press point", async ({
+    page,
+  }) => {
+    const body = await seedRow(page, "longpress");
+    const at = viewportCentre(page);
+
+    await longPressRow(page, body, at, HOLD_MS);
+    const g = await menuGeometry(page);
+
+    // The harness premise, asserted rather than assumed: `hasTouch` is what
+    // puts this project on the coarse branch, and if that ever stops being
+    // true this file would silently be testing the mouse behaviour twice.
+    expect(g.coarsePointer).toBe(true);
+    expectBothAnchorsWouldFit(g, at);
+
+    expect(g.right).toBeCloseTo(at.x, 0);
+    expect(g.bottom).toBeCloseTo(at.y, 0);
+    // The discriminant, stated rather than left implicit: the NEAR corner is
+    // where the defect put it, and it must not be there any more.
+    expect(g.left).toBeLessThan(at.x);
+    expect(g.top).toBeLessThan(at.y);
+  });
+
+  test("the nick menu inherits it from the shell, passing no anchor of its own", async ({
+    page,
+  }) => {
+    await seedChannel(page);
+    const at = viewportCentre(page);
+
+    await contextMenuOnNick(page, at);
+    const g = await menuGeometry(page);
+
+    expect(g.coarsePointer).toBe(true);
+    expectBothAnchorsWouldFit(g, at);
+
+    expect(g.right).toBeCloseTo(at.x, 0);
+    expect(g.bottom).toBeCloseTo(at.y, 0);
+  });
+});
+
+test.describe("issue 2014 — a fine pointer keeps the native down-and-right menu", () => {
+  test.use({ viewport: MOUSE_VIEWPORT, hasTouch: false });
+
+  test("the same nick menu, same door, opens from the click when the pointer is a mouse", async ({
+    page,
+  }) => {
+    await seedChannel(page);
+    const at = viewportCentre(page);
+
+    await contextMenuOnNick(page, at);
+    const g = await menuGeometry(page);
+
+    // The one variable. Everything else in this test is the test above.
+    expect(g.coarsePointer).toBe(false);
+    expectBothAnchorsWouldFit(g, at);
+
+    expect(g.left).toBeCloseTo(at.x, 0);
+    expect(g.top).toBeCloseTo(at.y, 0);
+    expect(g.right).toBeGreaterThan(at.x);
+    expect(g.bottom).toBeGreaterThan(at.y);
+  });
+});

--- a/cicchetto/src/ContextMenu.tsx
+++ b/cicchetto/src/ContextMenu.tsx
@@ -1,7 +1,8 @@
 import { type Component, createEffect, createSignal, For, on, Show } from "solid-js";
 import { Portal } from "solid-js/web";
-import { computeMenuPosition } from "./lib/menuPosition";
+import { computeMenuPosition, type MenuAnchor } from "./lib/menuPosition";
 import { createOverlayEscape } from "./lib/overlayScrollLock";
+import { isCoarsePointer } from "./lib/platform";
 
 // The context-menu SHELL: portal, backdrop, Escape, and the measured
 // flip/clamp placement. Extracted from `UserContextMenu` when #1067 needed a
@@ -21,6 +22,21 @@ import { createOverlayEscape } from "./lib/overlayScrollLock";
 // proven in the Playwright e2e (issue487-context-menu-viewport-clamp.spec.ts)
 // since jsdom gives no real viewport dimensions. Opacity-gated until measured
 // so the pre-measure frame never flashes off-screen.
+//
+// #2014 — WHICH CORNER lands on the press point is decided HERE, once, off
+// `isCoarsePointer()`: on a touch device the menu's bottom-right corner goes on
+// the press point so it opens up-and-left, out from under the hand that opened
+// it; under a mouse it keeps the native down-and-right. Reported on iOS against
+// the long-press message menu, and vjt ruled the scope "tutta la shell"
+// (2026-09-09 00:24Z) — so no host passes an anchor and none can drift: the
+// nick menu and the admin verb menu inherit the same answer from the module
+// that already owns placement.
+//
+// The flip/clamp above is UNCHANGED and is not what this touches. From a
+// screenshot the two are indistinguishable, which is the trap the issue names:
+// near the far edges the flip already produces the wanted geometry, so the
+// defect was only ever which side we PREFER. One parameter on the existing
+// primitive, not a second placement mechanism beside it.
 //
 // #949 — "inside the viewport" was the LAYOUT viewport, whose origin under
 // `viewport-fit=cover` is the physical top of the display. #913 fixed the same
@@ -159,6 +175,7 @@ const ContextMenu: Component<Props> = (props) => {
     if (!menuRef || !safeAreaRef) return;
     const rect = menuRef.getBoundingClientRect();
     const safe = safeAreaRef.getBoundingClientRect();
+    const anchor: MenuAnchor = isCoarsePointer() ? "bottom-right" : "top-left";
     setPlacement(
       computeMenuPosition({
         clickX,
@@ -179,6 +196,10 @@ const ContextMenu: Component<Props> = (props) => {
         // no inset (every desktop browser, every engine in the e2e suite) this
         // is exactly {0, w, h, 0} and the placement is bit-identical to #487's.
         safeArea: { top: safe.top, right: safe.right, bottom: safe.bottom, left: safe.left },
+        // #2014 — read HERE, next to the other two live environment reads, and
+        // for the same reason: it is measured at the moment the menu opens, off
+        // the device rather than off anything a caller passed down.
+        anchor,
       }),
     );
     setPlaced(true);

--- a/cicchetto/src/__tests__/menuPosition.test.ts
+++ b/cicchetto/src/__tests__/menuPosition.test.ts
@@ -10,12 +10,15 @@ import { computeMenuPosition, placeAxis, spaceAbove } from "../lib/menuPosition"
 // flip/clamp arithmetic.
 //
 // placeAxis is the 1D primitive applied independently to X and Y, over a
-// half-open interval [start, end) rather than [0, viewport):
+// half-open interval [start, end) rather than [0, viewport), with a PREFERRED
+// side (#2014). With `prefer: "after"` — the #487 behaviour, unchanged:
 //   * fits after the click         → keep the click coord (open down/right)
 //   * overflows the far edge        → FLIP before the click (open up/left,
 //                                     pointer stays on the menu edge)
 //   * flip would underflow `start`  → CLAMP to the last fully-visible coord
 //   * menu bigger than the interval → pin to `start` (CSS max-height + scroll)
+// `prefer: "before"` is the mirror of the first three, and NOT of the fourth —
+// see the oversize test below, and the comment on `placeAxis` itself.
 //
 // #949 — the interval used to be hardcoded to [0, viewport). Zero is the
 // LAYOUT viewport origin, which under `viewport-fit=cover` (index.html) is the
@@ -26,28 +29,28 @@ import { computeMenuPosition, placeAxis, spaceAbove } from "../lib/menuPosition"
 
 describe("placeAxis (1D flip/clamp primitive)", () => {
   it("keeps the click coord when the menu fits after it", () => {
-    expect(placeAxis(100, 120, 0, 1000)).toBe(100);
+    expect(placeAxis(100, 120, 0, 1000, "after")).toBe(100);
   });
 
   it("flips before the click point when the menu overflows the far edge", () => {
     // click 950, menu 120, end 1000 → 1070 > 1000 → flip: 950 - 120
-    expect(placeAxis(950, 120, 0, 1000)).toBe(830);
+    expect(placeAxis(950, 120, 0, 1000, "after")).toBe(830);
   });
 
   it("keeps a click that lands exactly at the far edge", () => {
     // click 880, menu 120, end 1000 → 880 + 120 == 1000 → fits, no flip
-    expect(placeAxis(880, 120, 0, 1000)).toBe(880);
+    expect(placeAxis(880, 120, 0, 1000, "after")).toBe(880);
   });
 
   it("clamps to fully-visible when a flip would underflow the interval start", () => {
     // click 100, menu 180, [0,200) → overflow (280>200) AND menu fits
     // (180<200); flip 100-180=-80 < 0 → clamp to end-size = 20
-    expect(placeAxis(100, 180, 0, 200)).toBe(20);
+    expect(placeAxis(100, 180, 0, 200, "after")).toBe(20);
   });
 
   it("pins to the interval start when the menu is bigger than the interval", () => {
-    expect(placeAxis(150, 300, 0, 200)).toBe(0);
-    expect(placeAxis(150, 200, 0, 200)).toBe(0); // equal counts as oversized
+    expect(placeAxis(150, 300, 0, 200, "after")).toBe(0);
+    expect(placeAxis(150, 200, 0, 200, "after")).toBe(0); // equal counts as oversized
   });
 
   // #949 — the four cases above with a non-zero `start` / a pulled-in `end`.
@@ -59,28 +62,90 @@ describe("placeAxis (1D flip/clamp primitive)", () => {
     // notched iPhone the first row rendered behind the status bar and the
     // menu's own overflow scroll could not bring it back — the box itself
     // starts inside the occluded strip.
-    expect(placeAxis(150, 900, 59, 818)).toBe(59);
+    expect(placeAxis(150, 900, 59, 818, "after")).toBe(59);
   });
 
   it("clamps a flip against the safe start, not against zero", () => {
     // The [0,200) clamp case above, shifted into a safe [59, 259): click 100,
     // menu 180 → 280 > 259 → flip to -80, which is below the safe START, so we
     // clamp. The last FULLY VISIBLE origin is end-size = 79, not 20.
-    expect(placeAxis(100, 180, 59, 259)).toBe(79);
+    expect(placeAxis(100, 180, 59, 259, "after")).toBe(79);
   });
 
   it("flips against the safe end, not against the physical bottom", () => {
     // click 800, menu 120, safe [59, 818): 800+120=920 > 818 → flip to 680.
     // Against the physical bottom (852) it would have "fitted" at 800 and the
     // tail would have run under the home indicator.
-    expect(placeAxis(800, 120, 59, 818)).toBe(680);
+    expect(placeAxis(800, 120, 59, 818, "after")).toBe(680);
   });
 
   it("never returns a coordinate before the safe start, even for a click inside the inset", () => {
     // A press can land inside the LEFT inset in landscape (iOS does not
     // swallow touches there the way it does under the status bar), and the
     // menu would then open from a column the display corner is eating.
-    expect(placeAxis(10, 120, 59, 818)).toBe(59);
+    expect(placeAxis(10, 120, 59, 818, "after")).toBe(59);
+  });
+});
+
+// #2014 — the mirrored preference. On a touch device the menu must open
+// up-and-left of the finger, so the box's FAR edge is what lands on the press
+// point. Same three collision branches, taken from the other side.
+describe('placeAxis (prefer: "before")', () => {
+  it("puts the far edge on the click when the menu fits before it", () => {
+    // click 500, menu 120 → box [380, 500): its END is the press point.
+    expect(placeAxis(500, 120, 0, 1000, "before")).toBe(380);
+  });
+
+  it("keeps a click that lands exactly one menu from the interval start", () => {
+    expect(placeAxis(120, 120, 0, 1000, "before")).toBe(0);
+  });
+
+  it("flips AFTER the click when the menu would underflow the interval start", () => {
+    // click 100, menu 120 → 100-120 = -20 < 0 → flip: the box opens from the
+    // press point instead, which is the #487 placement arrived at backwards.
+    expect(placeAxis(100, 120, 0, 1000, "before")).toBe(100);
+  });
+
+  it("clamps to the interval start when the menu fits on neither side", () => {
+    // click 100, menu 180, [0,200): before → -80 (underflows), after → 280
+    // (overflows). The clamp goes toward the PREFERRED side, which is `start` —
+    // the mirror of the "after" clamp landing on `end - size`.
+    expect(placeAxis(100, 180, 0, 200, "before")).toBe(0);
+  });
+
+  it("never lands before the safe start when the flip is taken", () => {
+    // click 40 sits INSIDE a 59px top inset. before → -80, so we flip; the
+    // flipped coord is the raw click, and 40 is still occluded. This is the one
+    // guard the "after" branch does not need (its own fit arm carries the
+    // `Math.max`), so it is the one a mirror written by symmetry drops.
+    expect(placeAxis(40, 120, 59, 818, "before")).toBe(59);
+  });
+
+  it("never lands past the safe end for a click inside the trailing inset", () => {
+    // click 830 is below the 818 safe bottom (the home-indicator strip). The
+    // far edge goes on the safe END, not on the occluded press point.
+    expect(placeAxis(830, 120, 59, 818, "before")).toBe(698);
+  });
+
+  it("pins an oversized menu to the interval START, exactly like the other side", () => {
+    // 🔴 THE ASYMMETRY. Every other branch mirrors; this one must NOT. The
+    // fallback for a menu taller than its interval is the CSS `max-height` +
+    // `overflow-y: auto` pair, and that box grows DOWN from `top` / RIGHT from
+    // `left` — so the origin has to be the near edge whichever corner was
+    // preferred. Mirrored to `end - size` it would put the menu's HEAD above
+    // `start`, i.e. behind the status bar on a notched iPhone, with the
+    // overflow scroll unable to bring it back (the #913 defect at this door).
+    expect(placeAxis(150, 300, 0, 200, "before")).toBe(0);
+    expect(placeAxis(150, 200, 0, 200, "before")).toBe(0);
+    expect(placeAxis(150, 900, 59, 818, "before")).toBe(59);
+  });
+
+  it("answers differently from the same call preferring the other side", () => {
+    // The mutation guard: one input, both sides, two answers. Without this a
+    // `prefer` that is read and thrown away passes every test above that
+    // happens to agree.
+    expect(placeAxis(500, 120, 0, 1000, "before")).not.toBe(placeAxis(500, 120, 0, 1000, "after"));
+    expect(placeAxis(500, 120, 0, 1000, "after")).toBe(500);
   });
 });
 
@@ -106,6 +171,7 @@ describe("computeMenuPosition (both axes)", () => {
         viewportWidth: 1280,
         viewportHeight: 720,
         safeArea: noInset(1280, 720),
+        anchor: "top-left",
       }),
     ).toEqual({ left: 100, top: 200 });
   });
@@ -119,6 +185,7 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 1280,
       viewportHeight: 720,
       safeArea: noInset(1280, 720),
+      anchor: "top-left",
     });
     expect(p.top).toBe(500); // 700 - 200
     expect(p.left).toBe(100); // X fits — unchanged
@@ -133,6 +200,7 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 1280,
       viewportHeight: 720,
       safeArea: noInset(1280, 720),
+      anchor: "top-left",
     });
     expect(p.left).toBe(1150); // 1270 - 120
     expect(p.top).toBe(100);
@@ -148,6 +216,7 @@ describe("computeMenuPosition (both axes)", () => {
         viewportWidth: 1280,
         viewportHeight: 720,
         safeArea: noInset(1280, 720),
+        anchor: "top-left",
       }),
     ).toEqual({ left: 1156, top: 516 });
   });
@@ -162,6 +231,7 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 390,
       viewportHeight: 180,
       safeArea: noInset(390, 180),
+      anchor: "top-left",
     });
     expect(p.top).toBe(0);
   });
@@ -180,6 +250,7 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 393,
       viewportHeight: 852,
       safeArea: iphone15Portrait,
+      anchor: "top-left",
     });
     expect(p.top).toBe(59);
   });
@@ -196,6 +267,7 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 393,
       viewportHeight: 852,
       safeArea: iphone15Portrait,
+      anchor: "top-left",
     });
     expect(p.top).toBe(680);
   });
@@ -211,6 +283,7 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 852,
       viewportHeight: 393,
       safeArea: { top: 0, right: 793, bottom: 372, left: 59 },
+      anchor: "top-left",
     });
     // 700 + 200 = 900 > 793 → flip to 500. Against the physical width (852)
     // it would have "fitted" at 700 and run under the rounded corner.
@@ -232,6 +305,7 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 393,
       viewportHeight: 516, // keyboard up: 852 - ~336
       safeArea: iphone15Portrait, // bottom still 818, the keyboard is not an inset
+      anchor: "top-left",
     });
     // 400 + 120 = 520 > 516 → flip to 280. Trusting the 818 safe bottom would
     // have left the menu under the keyboard — the #487 symptom.
@@ -249,8 +323,99 @@ describe("computeMenuPosition (both axes)", () => {
       viewportWidth: 393,
       viewportHeight: 516,
       safeArea: iphone15Portrait,
+      anchor: "top-left",
     });
     expect(p.top).toBe(59);
+  });
+
+  // #2014 — `anchor` names WHICH CORNER of the menu lands on the press point,
+  // and it drives both axes at once: "bottom-right" is the touch placement vjt
+  // measured as missing on iOS, where the menu has to open up-and-left so the
+  // hand that opened it is not sitting on top of it.
+  it("puts the bottom-right corner on the press point when the menu fits", () => {
+    expect(
+      computeMenuPosition({
+        clickX: 300,
+        clickY: 400,
+        menuWidth: 120,
+        menuHeight: 200,
+        viewportWidth: 1280,
+        viewportHeight: 720,
+        safeArea: noInset(1280, 720),
+        anchor: "bottom-right",
+      }),
+    ).toEqual({ left: 180, top: 200 });
+  });
+
+  it("opens down-and-right near the top-left corner, where up-and-left will not fit", () => {
+    // Both axes underflow, so both flip — and the result is bit-identical to
+    // what "top-left" would have produced. The collision logic is the SAME
+    // logic (#487's), read from the other side; there is no second mechanism.
+    expect(
+      computeMenuPosition({
+        clickX: 50,
+        clickY: 100,
+        menuWidth: 120,
+        menuHeight: 200,
+        viewportWidth: 1280,
+        viewportHeight: 720,
+        safeArea: noInset(1280, 720),
+        anchor: "bottom-right",
+      }),
+    ).toEqual({ left: 50, top: 100 });
+  });
+
+  it("keeps a flipped touch menu out of the status-bar inset", () => {
+    // A press at y=40 is inside the 59px top inset. Y cannot go up-and-left, so
+    // it flips down — and must start at the SAFE top, not at the occluded
+    // press point.
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 40,
+      menuWidth: 200,
+      menuHeight: 120,
+      viewportWidth: 393,
+      viewportHeight: 852,
+      safeArea: iphone15Portrait,
+      anchor: "bottom-right",
+    });
+    expect(p.top).toBe(59);
+  });
+
+  it("still pins an oversized touch menu to the safe TOP, not to the safe bottom", () => {
+    // The asymmetry again, at the 2D door: the CSS overflow fallback grows down
+    // from `top`, so the anchor preference does not reach this branch.
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 400,
+      menuWidth: 200,
+      menuHeight: 900,
+      viewportWidth: 393,
+      viewportHeight: 852,
+      safeArea: iphone15Portrait,
+      anchor: "bottom-right",
+    });
+    expect(p.top).toBe(59);
+  });
+
+  it("answers differently from the same measurement anchored top-left", () => {
+    const measurement = {
+      clickX: 300,
+      clickY: 400,
+      menuWidth: 120,
+      menuHeight: 200,
+      viewportWidth: 1280,
+      viewportHeight: 720,
+      safeArea: noInset(1280, 720),
+    };
+    expect(computeMenuPosition({ ...measurement, anchor: "top-left" })).toEqual({
+      left: 300,
+      top: 400,
+    });
+    expect(computeMenuPosition({ ...measurement, anchor: "bottom-right" })).toEqual({
+      left: 180,
+      top: 200,
+    });
   });
 });
 

--- a/cicchetto/src/__tests__/platform.test.ts
+++ b/cicchetto/src/__tests__/platform.test.ts
@@ -19,6 +19,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   escapePwaHref,
+  isCoarsePointer,
   isStandalonePwa,
   maybeEscapePwaClick,
   safariEscapeHref,
@@ -51,6 +52,30 @@ describe("isStandalonePwa", () => {
 
   it("survives environments without matchMedia at all (jsdom)", () => {
     expect(isStandalonePwa()).toBe(false);
+  });
+});
+
+// #2014 — the probe the context-menu anchor reads: on a coarse primary pointer
+// the menu opens up-and-left so the finger that opened it is not on top of it.
+// The VISIBLE placement is a Playwright matter (jsdom's zero-sized rects
+// collapse both anchors onto the same coordinate — see menuPosition.ts on why
+// that seam is pure); what is pinnable here is the probe and its degrade.
+describe("isCoarsePointer", () => {
+  it("is true when the primary pointer is coarse (touch device)", () => {
+    stubMatchMedia(true);
+    expect(isCoarsePointer()).toBe(true);
+  });
+
+  it("is false when the primary pointer is fine (mouse)", () => {
+    stubMatchMedia(false);
+    expect(isCoarsePointer()).toBe(false);
+  });
+
+  it("degrades to the mouse behaviour where matchMedia is absent", () => {
+    // The `sidebarWidths.ts` convention — absent means "not in the tier".
+    // Degrading the other way would hand every jsdom component test, and any
+    // engine without the query, the touch anchor.
+    expect(isCoarsePointer()).toBe(false);
   });
 });
 

--- a/cicchetto/src/lib/menuPosition.ts
+++ b/cicchetto/src/lib/menuPosition.ts
@@ -6,7 +6,8 @@
 // so a jsdom placement test would be hollow — hence the seam.
 //
 // placeAxis is the 1D primitive, applied independently to X and Y, over the
-// half-open interval [start, end):
+// half-open interval [start, end), with a PREFERRED side. With
+// `prefer: "after"`:
 //   * fits after the click          → keep the click coord (menu opens down/right)
 //   * overflows the far edge         → FLIP before the click (menu opens up/left),
 //                                      keeping the pointer on the menu edge like a
@@ -15,6 +16,16 @@
 //                                      slides off the cursor but stays whole)
 //   * menu bigger than the interval  → pin to `start` and let the CSS max-height +
 //                                      overflow-y:auto scroll the overflow
+//
+// #2014 — `prefer` exists because the preferred SIDE was the defect, not the
+// collision handling. On iOS the long-press menu opened down-and-right of the
+// finger and the hand that opened it covered it; the ask is that the menu's far
+// corner sit on the press point instead. From a screenshot that is
+// indistinguishable from a viewport-collision flip, which is why it is worth
+// saying plainly: the flip is already CORRECT, and near the far edges it
+// already produces the wanted geometry. Only the preference is wrong — hence
+// one parameter on the existing primitive, and NOT a second placement
+// mechanism beside it.
 //
 // #949 — that interval used to be hardcoded [0, viewport). Under
 // `viewport-fit=cover` (index.html) 0 is the PHYSICAL top of the display, so
@@ -28,6 +39,17 @@
 
 export type SafeArea = { top: number; right: number; bottom: number; left: number };
 
+// Which side of the press point the box PREFERS, on one axis. 1D on purpose:
+// "top-left" means nothing to the X axis, and a 2D word in here would be the
+// leak that lets the axes stop being independent.
+export type AxisSide = "after" | "before";
+
+// #2014 — which CORNER of the menu lands on the press point. The 2D word, and
+// the one a call site should be reading: it drives BOTH axes, because the
+// corner is the thing the operator sees. `computeMenuPosition` is the single
+// place that maps it onto the per-axis `AxisSide`.
+export type MenuAnchor = "top-left" | "bottom-right";
+
 export type MenuMeasurement = {
   clickX: number;
   clickY: number;
@@ -36,15 +58,45 @@ export type MenuMeasurement = {
   viewportWidth: number;
   viewportHeight: number;
   safeArea: SafeArea;
+  anchor: MenuAnchor;
 };
 
 export type MenuPlacement = { left: number; top: number };
 
-export function placeAxis(click: number, size: number, start: number, end: number): number {
+export function placeAxis(
+  click: number,
+  size: number,
+  start: number,
+  end: number,
+  prefer: AxisSide,
+): number {
+  // 🔴 THE ONE BRANCH THAT DOES NOT MIRROR, and the one a reader "tidying up
+  // for symmetry" will break. A menu bigger than its interval falls back to the
+  // CSS `max-height` + `overflow-y: auto` pair, and THAT box grows down from
+  // `top` / right from `left` — so its origin must be the near edge whichever
+  // corner was preferred. Mirrored to `end - size` it would put the menu's HEAD
+  // above `start`: behind the status bar on a notched iPhone, with the overflow
+  // scroll unable to bring it back, which is the #913 defect re-entered here.
+  // Derived from the fallback's growth direction, NOT measured on a device —
+  // what a device would add is how bad it looks, not whether it happens.
   if (size >= end - start) return start;
-  if (click + size <= end) return Math.max(click, start);
-  const flipped = click - size;
-  return flipped >= start ? flipped : end - size;
+  if (prefer === "after") {
+    if (click + size <= end) return Math.max(click, start);
+    const flipped = click - size;
+    return flipped >= start ? flipped : end - size;
+  }
+  // The mirror of the three collision branches above. The clamps swap sides
+  // too: "after" gives up on `end - size`, "before" gives up on `start` —
+  // each toward the side it wanted.
+  const before = Math.min(click, end) - size;
+  if (before >= start) return before;
+  // `Math.max` here and not on the branch above: a press can land INSIDE the
+  // leading inset, and this arm's flipped coord is the raw click, so without
+  // the clamp the box would open from an occluded column. The "after" fit arm
+  // already carries the same guard for the same press — the asymmetry is in
+  // which arm needs it, not in the policy.
+  const after = Math.max(click, start);
+  return after + size <= end ? after : start;
 }
 
 // The two bounds come from different places and both can bite:
@@ -60,18 +112,24 @@ export function placeAxis(click: number, size: number, start: number, end: numbe
 // holds for this non-scrolling, non-zoomable app shell. A pinch-zoomed page
 // would need the offsets added in; the pre-#949 code made the same assumption.
 export function computeMenuPosition(m: MenuMeasurement): MenuPlacement {
+  // The corner → per-axis translation, in one place. "bottom-right" is
+  // `before` on BOTH axes: the box's far edge on the press point is what makes
+  // it open up-and-left of the finger.
+  const prefer: AxisSide = m.anchor === "bottom-right" ? "before" : "after";
   return {
     left: placeAxis(
       m.clickX,
       m.menuWidth,
       m.safeArea.left,
       Math.min(m.viewportWidth, m.safeArea.right),
+      prefer,
     ),
     top: placeAxis(
       m.clickY,
       m.menuHeight,
       m.safeArea.top,
       Math.min(m.viewportHeight, m.safeArea.bottom),
+      prefer,
     ),
   };
 }

--- a/cicchetto/src/lib/platform.ts
+++ b/cicchetto/src/lib/platform.ts
@@ -65,6 +65,33 @@ export function isStandalonePwa(): boolean {
   return (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
 }
 
+// #2014 — is the PRIMARY pointing device a finger? The context-menu anchor
+// asks, because a menu that opens down-and-right of a finger is covered by the
+// hand that opened it, while down-and-right is the native convention under a
+// mouse.
+//
+// `(pointer: coarse)` and NOT `isIos()` above, and the precedent is #1869's:
+// default.css moved the whole selection/callout policy off `html.is-ios` onto
+// exactly this query because it *"keys on the actual pointing device rather
+// than a UA sniff"*. Same shape of decision, same query — a second, disagreeing
+// notion of "is this touch" is the drift that issue is a record of. iOS reports
+// coarse, so the platform the defect was measured on is covered.
+//
+// KNOWN AND ACCEPTED: `pointer` describes the PRIMARY pointer only, so a hybrid
+// whose primary is touch gives its occasional mouse the touch anchor. That is
+// the same trade #1869 took, and the alternative — deciding per EVENT at each
+// door — buys precision the doors cannot keep: the message menu has two of them
+// (touch and `contextmenu`) reaching one opener, and they would then disagree
+// about the same press.
+//
+// Read live, like `isStandalonePwa` above: cheap, and a menu opening is exactly
+// when the answer matters. Absent `matchMedia` means "not in the tier" — the
+// `sidebarWidths.ts` convention — which lands jsdom on the mouse behaviour.
+export function isCoarsePointer(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia("(pointer: coarse)").matches;
+}
+
 // iOS-standalone escape hatch for same-origin links (media viewer
 // dogfood bug, 2026-06-11): in-scope navigation ignores target=_blank,
 // so a same-origin anchor can NEVER leave the PWA by itself. The

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49542,3 +49542,122 @@ Across all 326 markers there are three findings and all three are same-commit:
 zero false positives observed, and no reachable case constructed. Should one
 ever turn up, the honest cure is to read the lines the branch ADDS rather than
 the file — a larger change than this gap justified today.
+<!-- entry #2014 -->
+
+---
+
+## 2026-09-09 — #2014: the flip was never the bug, the preferred side was
+
+On iOS the long-press message menu opened **down-and-right of the touch
+point**, so the hand that opened it covered it. vjt measured it on an iPhone
+with cicchetto installed as a PWA, against staging `1.5.3-def8cb2ac`. The ask:
+the menu's **bottom-right corner sits on the press point**, so it opens
+up-and-left, out from under the thumb.
+
+### One defect, not two, and the code says so
+
+The issue lists two things as **not measured** — whether the placement is also
+wrong with the keyboard UP, and whether it changes near the viewport EDGES —
+and warns that an anchor bug and a viewport-collision flip look identical from
+one screenshot. Both were answerable by reading `lib/menuPosition.ts`, and the
+answers are what made the cure small.
+
+**Keyboard up:** `ContextMenu` feeds `computeMenuPosition` the VISUAL viewport,
+which does shrink with the keyboard. But the fit arm returns `click` whether or
+not the keyboard is up; what the keyboard moves is the FLIP THRESHOLD, not the
+anchor. One defect, at one door.
+
+**Edges:** near the far edge `placeAxis` already FLIPS, and a flip puts the
+box's far edge on the press point — which is the geometry being asked for. In
+the bottom-right corner the menu already rendered exactly as vjt wants it.
+**So the flip is not the defect: it is the discriminant the issue was asking
+for.** What was wrong was only which side we PREFER. That is why this is one
+parameter on the existing primitive — `placeAxis(click, size, start, end,
+prefer)` — and not a second placement mechanism beside the first.
+
+`prefer` is REQUIRED, with no default. A default picks an anchor on behalf of a
+caller that never thought about one, which is the shape of the bug being fixed.
+
+### The one branch that must not mirror
+
+Three of the four branches mirror cleanly. The fourth does not: a menu bigger
+than its interval still pins to `start` under BOTH preferences, because the
+fallback it hands off to is the CSS `max-height` + `overflow-y: auto` pair, and
+that box grows DOWN from `top` / RIGHT from `left`. Mirrored to `end - size` it
+would put the menu's HEAD above `start` — behind the status bar on a notched
+iPhone, with the overflow scroll unable to bring it back, which is the #913
+defect re-entered at this door. Derived from the fallback's growth direction,
+not measured on a device; what a device would add is how bad it looks, not
+whether it happens. Commented where it lives, because "make the mirror
+symmetric" is a tidy-up somebody will attempt.
+
+A second, smaller asymmetry sits in the guards: the `before` arm needs a
+`Math.max(click, start)` on its FLIP where the `after` arm carries the
+equivalent on its FIT. A press can land inside the leading inset, and each
+preference meets that press in a different arm. The asymmetry is in which arm
+needs the guard, not in the policy.
+
+### The gate is the POINTER, not the door
+
+`(pointer: coarse)`, read once in `ContextMenu` — the module that already owns
+placement — via a new `isCoarsePointer()` in `lib/platform.ts`. The precedent
+is #1869's, verbatim: `default.css` moved the whole selection/callout policy
+off `html.is-ios` onto exactly this query because it *"keys on the actual
+pointing device rather than a UA sniff"*. A second, disagreeing notion of "is
+this touch" is the drift that issue is a record of.
+
+The rejected alternative was deciding per EVENT at each door, which sounds
+more precise and is not: the message menu has TWO doors reaching one opener
+(`bindMessageGestures`'s hold and `bindMessageContextMenu`'s `contextmenu`,
+both landing on `openMenuForRow`), so a per-event anchor lets them disagree
+about the same press, last writer winning. Accepted cost, identical in kind to
+the one #1869 already took: `pointer` describes the PRIMARY pointer, so a
+hybrid whose primary is touch gives its occasional mouse the touch anchor.
+
+**Scope is vjt's ruling** (`#grappa`, 2026-09-09 00:24Z, relayed): *"tutta la
+shell"* — every menu on the shared shell, so no host passes an anchor and none
+can drift. The nick menu and the admin verb menu inherit it. On a fine pointer
+NOTHING moves: the desktop right-click keeps the native down-and-right.
+
+### The premise that said this could not be tested
+
+The issue states the e2e suite cannot host the gesture, citing
+`webkit-iphone-15`'s `tap()`. **False, and both halves of the refutation were
+already in the repo:** `issue1067-swipe-reply-message-menu.spec.ts` has
+synthesized a real touchstart → wall-clock hold → touchend since #1067, and its
+own header records that `hasTouch: true` puts Chromium's primary pointer at
+COARSE. The citation is about a different engine and a different verb.
+
+So `issue2014-context-menu-touch-anchor.spec.ts` runs three tests: the reported
+path (coarse, long-press, message row), and a PAIR that isolates the gate —
+same door, same surface, one variable changed, the pointer. The pair is what
+keeps "maybe the DOOR decides" from standing, and it doubles as the scope proof,
+since the nick menu passes no anchor of its own and can only have got its
+answer from the shell.
+
+Every test asserts an anti-hollow precondition first: that at the chosen point
+the menu would have fitted on BOTH sides of both axes. Without it a collision
+flip satisfies the corner assertion by itself and the spec goes green against a
+reverted fix — the very confusion the issue names.
+
+**Declared limit.** Chromium is not iOS, and every engine in the suite reports
+`env(safe-area-inset-*)` as `{0,0,0,0}`, so nothing in that file exercises the
+notch or the home indicator; the inset arithmetic is unit work
+(`menuPosition.test.ts` carries the iPhone 15 numbers) and the FELT result stays
+vjt's on-device dogfood.
+
+### An inference left standing, and how to kill it
+
+Not chased in this slice, and not a second mechanism: since #1869 a scrollback
+row computes `user-select: none` standing on a coarse pointer, and Blink fires
+`contextmenu` on a long-press over non-selectable content. If that holds, an
+Android long-press already opens the menu TWICE today — invisibly, because both
+doors pass the same point. It is an INFERENCE: no browser launches on the
+machine this was written on, and it was never reproduced.
+
+**What would falsify it, in thirty seconds on any Android:** open the console,
+`addEventListener('contextmenu', e => console.log('ctx', e.clientX, e.clientY),
+true)` on `document`, then long-press a message row. No line logged ⇒ the
+inference is dead and the doors never race. A line logged ⇒ it is real, and
+worth its own issue. The pointer-keyed gate above makes it harmless either way:
+both doors read the same pointer and cannot disagree.


### PR DESCRIPTION
Addresses issue 2014.

On iOS the long-press message menu opened **down-and-right of the touch point**, so the hand that opened it covered it. Reported by vjt from an iPhone with cicchetto installed as a PWA, against staging `1.5.3-def8cb2ac`.

## The reading that made the cure small

The flip was never the bug.

`placeAxis` has four branches and three of them are collision handling. Near the far edge it already **flips**, and a flip puts the box's far edge on the press point — which is exactly the geometry being asked for. In the bottom-right corner the menu already rendered the way it was wanted. So the flip is not the defect: **it is the discriminant the issue was asking for.** What was wrong was only which side we *prefer*.

That is why this is one parameter on the existing primitive — `placeAxis(click, size, start, end, prefer)` — and not a second placement mechanism beside the first.

The issue lists two things as **not measured**, and both were answerable by reading the code rather than by guessing:

* **Keyboard up.** `ContextMenu` feeds the placement the *visual* viewport, which does shrink with the keyboard. But the fit arm returns `click` either way: the keyboard moves the flip **threshold**, not the anchor. One defect, not two.
* **Near the edges.** Already correct, as above.

`prefer` is **required, with no default**. A default picks an anchor on behalf of a caller that never thought about one, which is the shape of the bug being repaired.

### The one branch that must not mirror

An oversized menu still pins to `start` under **both** preferences. The fallback it hands off to is the CSS `max-height` + `overflow-y: auto` pair, and that box grows *down* from `top` / *right* from `left`, so its origin must be the near edge whichever corner was preferred. Mirrored to `end - size` it would put the menu's head above `start` — behind the status bar on a notched iPhone, with the overflow scroll unable to bring it back, which is the #913 defect re-entered at this door.

A second, smaller asymmetry sits in the guards: the `before` arm needs a `Math.max(click, start)` on its **flip** where the `after` arm carries the equivalent on its **fit**. A press can land inside the leading inset, and each preference meets that press in a different arm. Both asymmetries are commented where they live, because "make the mirror symmetric" is a tidy-up somebody will attempt.

## The ruling being executed, and the fence around it

vjt, `#grappa`, 2026-09-09 00:24Z (relayed to me, not read by me):

* **Scope — "tutta la shell":** every menu on the shared `ContextMenu`. One predicate in the module that already owns placement, so **no host passes an anchor and none can drift**. `MessageContextMenu`, `UserContextMenu` and `AdminSessionsTab` are byte-identical to before.
* **Anchor — "angolo in basso a dx sotto il dito":** the menu's bottom-right corner sits on the press point.

Explicitly **not** widened:

* The gate stays `(pointer: coarse)`. The ruling says *which menus*, not *which devices*. **On a fine pointer nothing moves** — the desktop right-click keeps the native down-and-right convention.
* Nothing else was uniformised "for consistency". One thing I noticed and deliberately did **not** touch: the touch synthesizer in the new spec is a third copy of the one in `issue1067-swipe-reply-message-menu` and `issue1413-hold-press-feedback`. Left local, matching its neighbours, and declared in the file header — hoisting it into a fixture would rewrite two specs this change has no business touching.

### Why the pointer and not the door

Deciding per **event** at each door sounds more precise and is not: the message menu has *two* doors reaching one opener (`bindMessageGestures`'s hold and `bindMessageContextMenu`'s `contextmenu`, both landing on `openMenuForRow`), so a per-event anchor lets them disagree about the same press, last writer winning. The precedent is #1869's, verbatim: `default.css` moved the whole selection/callout policy off `html.is-ios` onto exactly this query because it *"keys on the actual pointing device rather than a UA sniff"*.

Accepted cost, identical in kind to the one #1869 already took: `pointer` describes the *primary* pointer, so a hybrid whose primary is touch gives its occasional mouse the touch anchor.

## The premise that said this could not be tested

The issue states the e2e suite cannot host the gesture, citing `webkit-iphone-15`'s `tap()`. **That is false, and both halves of the refutation were already in the repo:** `issue1067-swipe-reply-message-menu.spec.ts` has synthesized a real touchstart → wall-clock hold → touchend since #1067, and its own header records that `hasTouch: true` puts Chromium's primary pointer at COARSE. The citation is about a different engine and a different verb.

Three tests, because the change makes two claims:

1. the reported path — coarse pointer, long-press, message row, bottom-right corner on the press point;
2. and 3. the **gate, isolated**: same door, same surface, one variable changed, the pointer. Without the pair, test 1 alone leaves "maybe the *door* decides" standing. The pair doubles as the scope proof, since the nick menu passes no anchor of its own and can only have got its answer from the shell.

Every test asserts an **anti-hollow precondition** first: that at the chosen point the menu would have fitted on **both** sides of both axes. Without it a collision flip satisfies the corner assertion by itself and the spec goes green against a reverted change — the very confusion the issue names. Test 1 also asserts its own harness premise (`(pointer: coarse)` really is on), so if `hasTouch` ever stops implying coarse the file goes red instead of quietly testing the mouse twice.

## What I am refusing to claim

* **The e2e proves the ANGLE and its gate, and nothing iOS-specific.** Chromium is not iOS, and every engine in the suite reports `env(safe-area-inset-*)` as `{0,0,0,0}`, so nothing in that file exercises the notch or the home indicator. The inset arithmetic is unit work (`menuPosition.test.ts` carries the iPhone 15 numbers) and the felt result on a real device stays vjt's dogfood.
* **The oversize asymmetry is derived, not measured.** It comes from the CSS fallback's growth direction; I have no iOS device. What a device would add is how bad it looks, not whether it happens.
* **The Android double-open is an INFERENCE, labelled as one** in `DESIGN_NOTES` and not chased here. Since #1869 a scrollback row computes `user-select: none` standing on a coarse pointer, and Blink fires `contextmenu` on a long-press over non-selectable content; if that holds, an Android long-press already opens the menu twice today — invisibly, because both doors pass the same point. No browser launches on the machine this was written on and it was never reproduced. The entry carries the console one-liner that kills it in thirty seconds on any Android. The pointer-keyed gate makes it harmless either way: both doors read the same pointer and cannot disagree.

## Gates

| Gate | Result |
| --- | --- |
| `bun.sh run test` (cic unit) | **green — 341 files / 6881 tests** |
| `bun.sh run check` | **green — 5/5 stages** (lock drift, test location, biome, tsc src, tsc e2e) |
| `scripts/design-notes-gate.sh` | **green** — 1 new entry, separator and marker present (re-run *after* the commit; run before it, it answers "nothing to check", which is an empty green) |
| `scripts/integration.sh` (full, no `--grep`) | **rc=1 — 1 failed / 1 skipped / 957 passed, 36.2m** |

Per project: `chromium` 662 passed / 1 failed · `chromium-pixel-touch` 144 passed / 0 failed · `webkit-iphone-15` 151 passed / 0 failed. The three new tests pass on `chromium` (they are untagged, and that project's `grepInvert: /@webkit|@touch/` means untagged specs run only there; the per-describe `test.use` supplies the pointer).

### The one red, and why it is not this branch's

`232 [chromium] › tests/issue1964-upload-confirm-preview.spec.ts:97:1 (6.0s)` — *"each staged file previews as what it actually is"*.

Already on record in `.orchestrate/red-issue1964-local-vs-ci-2026-09-08.md`, where this run is logged as sighting 2. Not re-derived by me; the load-bearing facts recorded there are that the spec is **green in CI and red locally on the same SHA**, and that there is a **red baseline on bare `origin/main`** in a detached worktree carrying nobody's lines — so no branch is implicated, including this one. Disjoint by subject as well as by file: this change is context-menu placement, that spec is upload preview. The 6.0s duration is exactly the register's local class. No cascade this run: `cp15-b6-part-archive-rejoin` and `ux-z-cluster-journey`, which fell by ordering in sighting 1, are green here. The mechanism is recorded as **unknown**, and I am not asserting one.

**Nothing was weakened, widened, disabled, re-run for a greener answer, or skipped to get this result.** No timeout was raised, no assertion loosened, and `issue1964-upload-confirm-preview.spec.ts` was not touched. The red stands and is declared.

## Notes for the merger

* **Do not merge before the 02:30Z cold deploy.** The jail pulls `origin/main` with `--ff-only` and is not pinned to the tag, so a merge now puts code into production that was never in a release.
* No wire change, no protocol bump, no schema change, no supervision-tree change. Client-only.
