### PR TITLE
ci: boot both published architectures and name the harness failures (issue 2018)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1377,7 +1377,7 @@ jobs:
           provenance: false
 
   smoke:
-    name: deploy + probe the release image (amd64)
+    name: deploy + probe the release image (${{ matrix.arch }})
     needs: [docker]
     # Exactly the docker job's trigger set, all three shapes: a real tag and a
     # repair (probe what was just PUBLISHED) or a docker_validation dry-run
@@ -1389,8 +1389,75 @@ jobs:
     # proves the deb job alone and must not build images nobody asked for. The
     # docker_validation arm is untouched — asking for both dry-runs at once is
     # contradictory but harmless, since neither publishes anything.
+    #
+    # ── RELEASE-ONLY IS DELIBERATE, and this is the statement of why (#2018) ──
+    #
+    # This job never runs on plain main, which means no run on main could have
+    # caught the v1.5.4 red, and that reads like a gap until the subject is
+    # named. THE SUBJECT OF THIS GATE IS THE PUBLISHED IMAGE. Before the tag
+    # there is no published image to probe: release-only here is arithmetic, not
+    # a cadence anybody chose, and moving it earlier would mean probing a
+    # different artefact while calling it the same one.
+    #
+    # What main CAN rot is the RECIPE, and the recipe is not uncovered — it is
+    # held by gates that need no container and therefore already run on every
+    # PR: test/infra/base_image_digest_pin_test.bats (#103),
+    # test/infra/toolchain_pin_test.bats (#1408 D-S10), the ABI floor proved at
+    # build time by infra/docker/assert-abi-lockstep.sh, and the ~50 suites in
+    # test/infra/ that exercise the deploy scripts with `docker` stubbed.
+    #
+    # A `schedule:` for the `docker_validation` dry-run was considered and
+    # REFUSED (vjt's ruling, 2026-09-09): a cron red has no owner, nobody is on
+    # duty at the hour it fires, and a signal nobody reads is indistinguishable
+    # from a signal that is not there. There is no `schedule:` anywhere in this
+    # repository, and that is a decision rather than an omission.
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_validation) || (github.event_name == 'workflow_dispatch' && !inputs.docker_validation && !inputs.deb_validation && inputs.tag != '') }}
-    runs-on: ubuntu-latest
+    # ── BOTH published architectures are BOOTED, not just built (#2018) ──────
+    #
+    # The docker job publishes `linux/amd64,linux/arm64`. Until #2018 this job
+    # ran on `ubuntu-latest` alone and its name said `(amd64)`, with the posture
+    # written out as "amd64 only: the arm64 leg is proven by the build".
+    #
+    # Measured, and it is why that posture fell: EVERY job in every workflow in
+    # this repository was `ubuntu-latest`, so no arm64 binary had ever been
+    # EXECUTED here by anything. `assert-abi-lockstep.sh` does gate arm64 at
+    # build time — it runs per-platform and fails the build unless the runtime
+    # stage's musl and openssl SONAME majors match what the build stage linked —
+    # but linking is not starting. For an arm64 puller of ghcr.io/<owner>/grappa
+    # the first process ever to run the image was a user's, on every release
+    # that has ever shipped. That is structural rather than intermittent, and
+    # `ubuntu-24.04-arm` is a free GitHub-hosted runner on a public repository,
+    # so closing it costs nothing but this block.
+    #
+    # `fail-fast: false` is LOAD-BEARING and is not a softening: without it, an
+    # amd64 failure CANCELS the arm64 leg, and the cancelled leg is exactly the
+    # reading that would have been worth having. Two independent runner
+    # substrates probing one artefact is the only cross-check this gate has ever
+    # had against a failure that belongs to the machine rather than to the image
+    # — "amd64 red while arm64 is green on the same run" is a sentence nobody
+    # could write before this.
+    #
+    # THE DRY-RUN KEEPS ONE LEG, deliberately (vjt's ruling, 2026-09-09). A
+    # `docker_validation` dispatch re-exports an amd64 image from the gha build
+    # cache; giving it an arm64 leg would mean standing up a SECOND cache for a
+    # path that nothing fires automatically (there is no `schedule:` anywhere in
+    # this repo) — maintenance that drifts with nobody watching it. So the
+    # matrix is one leg on the dry-run and two on the paths that publish, which
+    # is where the coverage is owed. Better light and stated than complete and
+    # never exercised; if a cadence ever exists, this is the line to revisit.
+    #
+    # Note for whoever wires branch protection: the amd64 check-run keeps its
+    # EXACT name, `deploy + probe the release image (amd64)`, because `name:`
+    # is spelled with the matrix value rather than left to the default suffix.
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(
+          (github.event_name == 'workflow_dispatch' && inputs.docker_validation)
+          && '[{"arch":"amd64","runner":"ubuntu-latest"}]'
+          || '[{"arch":"amd64","runner":"ubuntu-latest"},{"arch":"arm64","runner":"ubuntu-24.04-arm"}]'
+          ) }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: read

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49542,3 +49542,137 @@ Across all 326 markers there are three findings and all three are same-commit:
 zero false positives observed, and no reachable case constructed. Should one
 ever turn up, the honest cure is to read the lines the branch ADDS rather than
 the file — a larger change than this gap justified today.
+<!-- entry #2018 -->
+
+---
+
+## 2026-09-09 — #2018: the release-image gate boots both published arches, and names the red it cannot explain
+
+On the `v1.5.4` release commit (`b68373237`) the job `deploy + probe the release
+image (amd64)` died at the first BEAM invocation — `sys_sigaltstack(): Internal
+error: Failed to set alternate signal stack`, exit 139 — before any migration
+line. A rerun of the SAME commit and the SAME image on a different runner
+instance came back green in 71 s (run `34293606005`, attempt 2); the failing
+attempt had died ~2 s into the step. **Same bytes, opposite verdict.** The
+mechanism is still unmeasured and this entry does not claim otherwise.
+
+### What was refused, and why it is the larger half of the decision
+
+The issue asked to "make the probe run somewhere it can actually boot the image
+(or make the sandbox difference explicit and asserted)". Both branches were
+declined.
+
+There is no second substrate: production is the FreeBSD jail and it has no
+docker at all (`grep -rln 'docker|ghcr' infra/freebsd/` → nothing), a
+self-hosted runner would be a third production substrate, and self-hosters are
+field evidence rather than a gate — nobody fires them and nobody reads their
+verdict. The `uname -m` of the two who answered CTCP VERSION was asked for and
+never arrived, so even "the image boots on real hosts" is true of an unknown
+architecture.
+
+Asserting the sandbox difference is worse than useless: nobody has measured what
+that difference IS, so the assertion would encode a guess and would stay green
+in exactly the case where the guess is wrong. "`sigaltstack` smells of seccomp"
+is a smell, not a measurement, and the issue's own "Not measured" section says
+so.
+
+And the premise moved underneath the request. The rerun shows the failure is
+**not deterministic across runner instances**, and a different PLACE does not
+cure non-determinism — it relocates it.
+
+### What shipped instead
+
+**Both published architectures are now BOOTED.** The docker job publishes
+`linux/amd64,linux/arm64`; the smoke job ran on `ubuntu-latest` alone and said
+so out loud ("amd64 only: the arm64 leg is proven by the build"). Measured, and
+it is why that posture fell: **every job in every workflow in this repository
+was `ubuntu-latest`** (12 of 12, across `ci.yml`, `integration.yml`,
+`release.yml`), so no arm64 binary had ever been EXECUTED here by anything.
+`assert-abi-lockstep.sh` does gate arm64 at build time, per-platform — but it
+proves the runtime stage can LINK the release, not that the VM STARTS. For an
+arm64 puller the first process ever to run the image was a user's, on every
+release that has ever shipped. That is structural, not intermittent.
+`ubuntu-24.04-arm` is free on a public repository, so the cure is a matrix and
+nothing else; the driver is untouched, because `docker pull` resolves the
+multi-arch manifest for whatever host it lands on, candidate and upgrade fixture
+alike.
+
+`fail-fast: false` is load-bearing rather than a softening: without it an amd64
+failure CANCELS the arm64 leg, and that cancelled leg is precisely the reading
+worth having. Two independent runner substrates probing one artefact is the only
+cross-check this gate has ever had against a failure belonging to the machine —
+"amd64 red while arm64 is green on the same run" is a sentence nobody could
+write before.
+
+**The runner's facts are captured on EVERY run, green included.** This is the
+part that is easy to get backwards. What the v1.5.4 incident lacks is not only
+the red sample — it is the GREEN one. An `ImageOS`, a `_SC_MINSIGSTKSZ`, a set
+of XSAVE feature flags cannot be read as anomalous by anyone who has never seen
+what they look like on a run where the image boots. Facts only on failure
+produce a sample of one class and nothing to hold it against, so the capture is
+unconditional and the failure branch adds only the NAME. Every reader is
+best-effort and prints `unavailable` rather than exiting: the block that
+describes the run must never be able to fail it.
+
+**A failure carrying the ERTS-startup signature is NAMED, not forgiven.** The
+run stays red — no retry, no `continue-on-error`, no downgrade. What is added is
+the distinction that cost a night: a VM that never started and an image that is
+genuinely broken used to arrive identically, as "the job is red". The pattern
+matches the MESSAGE the VM printed, deliberately, rather than a cause: a match
+on seccomp or on a CPU feature would be the encoded guess refused above.
+
+**Release-only is now stated as deliberate.** The subject of this gate is the
+PUBLISHED image, and before the tag there is none — release-only is arithmetic,
+not a cadence anyone chose. What main can rot is the RECIPE, and the recipe is
+already held by gates that need no container: `base_image_digest_pin_test.bats`
+(#103), `toolchain_pin_test.bats` (#1408 D-S10), the build-time ABI floor, and
+the ~50 suites in `test/infra/`.
+
+A `schedule:` for the `docker_validation` dry-run was considered and refused
+(vjt's ruling): a cron red has no owner, nobody is on duty at the hour it fires,
+and a signal nobody reads is indistinguishable from a signal that is not there.
+There is no `schedule:` anywhere in this repository and that is a decision. For
+the same reason the dry-run keeps ONE leg: an arm64 leg there would mean a
+second gha cache for a path nothing fires automatically.
+
+### A claim withdrawn before it was published, recorded so nobody re-derives it
+
+The first draft of the issue comment carried a second finding: that
+`Dockerfile.release` leaves `elixir:1.19-otp-28-alpine` and `alpine:3.24` on
+floating tags, so the published image is not a pure function of the source tree.
+The observation is literally true and the framing was wrong, which is worse.
+Both are excluded **by name** from the #103 digest-pin gate with the argument
+written there: the Elixir tag "carries the pin" and is held to `.tool-versions`
+on the minor line and the OTP major by `toolchain_pin_test.bats`, while the
+alpine floor is left floating on purpose so security patches keep flowing, with
+`assert-abi-lockstep.sh` proving compatibility instead of freezing bytes. It is
+a decision with two gates over it, not a gap. The lesson is the ordinary one:
+the gate that would contradict a finding is usually already in `test/`, and
+reading it costs less than publishing the finding.
+
+### 🔴 What this does NOT cure — say it before someone reads a cure into it
+
+**The non-determinism is untouched and its mechanism remains unknown.** This
+gate produced red and then green on byte-identical input, which means it can lie
+in BOTH directions, and the direction that hurts is the false GREEN: the absence
+of the failure is not by itself evidence that the image boots. What shipped here
+cures the CECITY (an arm64 half nobody had ever executed) and the LEGIBILITY (a
+red nobody could classify). Neither of those is the flip.
+
+The honest expectation is narrower and worth writing down: the next occurrence
+arrives with the runner's facts attached and a comparison class to hold them
+against, which is the measurement nobody has been able to make so far. That is
+an instrument, not a diagnosis.
+
+A BEAM preflight — the cheapest possible VM start, run first, to attribute
+before six minutes of deploy — was designed and then dropped from this slice.
+It could not be exercised anywhere available (the honest proof is a
+`docker_validation` dispatch, and the local substrate is macOS/arm64 while the
+phenomenon is linux/amd64), and an untested new invocation in the release path
+is a new way for every release to go red in exchange for attribution the
+classifier already delivers a few minutes later. It is worth doing once
+something can run it.
+
+_CI + driver + docs. No wire change, no protocol bump, no supervision-tree or
+schema change. Deploy: nothing to deploy — the change is in `release.yml` and
+the smoke driver, both of which run only in CI._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -49650,6 +49650,31 @@ a decision with two gates over it, not a gap. The lesson is the ordinary one:
 the gate that would contradict a finding is usually already in `test/`, and
 reading it costs less than publishing the finding.
 
+The version that SURVIVES the contradiction is narrower, and it took measuring
+the two gates rather than accepting that they cover the ground. They cover a
+different axis each, and neither is drift-over-time.
+`assert-abi-lockstep.sh` takes its eight arguments from ONE build — the `b_*`
+values out of `/tmp/abi-manifest`, written by that build's build stage
+(`Dockerfile.release:108-119`), the `r_*` values live from the same build's
+runtime stage (`:172-180`) — touches no network, and names no earlier build. It
+is a same-build coherence gate, so two stages moving TOGETHER to a newer alpine
+patch keep it green by construction, which is the intended behaviour rather than
+a hole. `toolchain_pin_test.bats` touches no network either; it reads files, and
+holds `.tool-versions` (`elixir 1.19.5-otp-28`, `erlang 28.5`) against the
+Dockerfile tag to minor-line and OTP-major precision, with its own moduledoc
+calling the Elixir PATCH floating underneath "real and deliberate".
+
+So neither gate reads the bytes that were pulled and neither compares two builds
+made at different times — nor should they. The consequence is what belongs to
+#2018: **if a drifted base ever produces an image that does not start, the only
+thing in this repository that finds out is the release-image smoke job.** It is
+not one check among several on the published container; it is the sole
+consequence-detector for a recipe the project has deliberately chosen to let
+move. That is why a blind spot in it costs more than its size suggests, and it
+is an argument FOR this gate rather than for pinning anything — a digest on
+`alpine:3.24` is argued in `base_image_digest_pin_test.bats` as the wrong move,
+because it would freeze security patches.
+
 ### 🔴 What this does NOT cure — say it before someone reads a cure into it
 
 **The non-determinism is untouched and its mechanism remains unknown.** This

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -174,10 +174,17 @@ runner_facts() {
     printf 'runner arch      : %s\n' "${RUNNER_ARCH:-unset}"
     # The alternate-signal-stack minimum the C library reports. The ERTS call
     # that died on v1.5.4 is `sigaltstack(2)`, whose EINVAL arm is about a size
-    # below the kernel's minimum — so these two numbers are the ones a reader
-    # would want, and nobody has ever recorded them for this job.
-    for k in _SC_SIGSTKSZ _SC_MINSIGSTKSZ _SC_PAGESIZE; do
-        printf '%-17s: %s\n' "$k" "$(getconf "$k" 2>/dev/null || echo unavailable)"
+    # below the kernel's minimum — so these are the numbers a reader would want,
+    # and nobody has ever recorded them for this job.
+    #
+    # BARE NAMES, not the `_SC_` spelling, and this is measured rather than
+    # stylistic: `getconf _SC_PAGESIZE` answers "no such configuration
+    # parameter" while `getconf PAGESIZE` answers 16384. Written the other way
+    # every line here would have printed `unavailable` on Linux too — a blind
+    # diagnostic wearing the same face as an honest one, on precisely the
+    # number this block exists to record.
+    for k in SIGSTKSZ MINSIGSTKSZ PAGESIZE; do
+        printf '%-17s: %s\n' "$k" "$(getconf "$k" 2>/dev/null || echo 'not exposed by getconf')"
     done
     if [ -r /proc/cpuinfo ]; then
         # The size of the signal frame the kernel must fit scales with the
@@ -185,9 +192,15 @@ runner_facts() {
         # decorative. One line, deduplicated — not 96 identical core stanzas.
         printf 'cpu model        : %s\n' \
             "$(awk -F': ' '/^model name/ {print $2; exit}' /proc/cpuinfo)"
-        printf 'cpu xsave flags  : %s\n' \
-            "$(awk -F': ' '/^flags/ {print $2; exit}' /proc/cpuinfo \
-               | tr ' ' '\n' | grep -E '^(avx512|amx|xsave|osxsave)' | sort -u | tr '\n' ' ')"
+        # `|| true` then a `:-none` default, because an empty reading here is
+        # AMBIGUOUS in the way this whole block exists to avoid: `grep` exits 1
+        # when the CPU simply has none of these flags, which is a fact worth
+        # printing, and a bare blank would read identically to a reader that
+        # broke. arm64 has no `flags` line at all and lands in the same arm.
+        xsave_flags="$(awk -F': ' '/^flags/ {print $2; exit}' /proc/cpuinfo \
+               | tr ' ' '\n' | grep -E '^(avx512|amx|xsave|osxsave)' \
+               | sort -u | tr '\n' ' ' || true)"
+        printf 'cpu xsave flags  : %s\n' "${xsave_flags:-none reported}"
     else
         printf 'cpu              : unavailable (no /proc/cpuinfo)\n'
     fi

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -50,8 +50,13 @@
 # the first one that fails dumps the container log and exits non-zero.
 #
 # What this does NOT cover, deliberately:
-#   * one arch only — whatever the host runs. The arm64 leg of a multi-arch
-#     manifest is proven by the build, not by this.
+#   * ONE arch per invocation — whatever the host runs. That is unchanged; what
+#     changed with #2018 is who invokes it: release.yml runs this driver on BOTH
+#     published architectures (a matrix over an amd64 and an arm64 runner), so
+#     the manifest's arm64 half is now BOOTED rather than merely built. Nothing
+#     here is arch-aware and nothing needs to be — `docker pull` resolves the
+#     multi-arch manifest for the host it lands on, for the candidate and for
+#     the upgrade fixture alike.
 #   * no IRC: no upstream connect, no SASL, no scrollback. Those are
 #     scripts/integration.sh's job, against the SOURCE image.
 #   * no TLS front door, no reverse proxy, no real PHX_HOST — the box is
@@ -131,17 +136,118 @@ docker image inspect "$GRAPPA_PREVIOUS_IMAGE" >/dev/null 2>&1 \
 
 SMOKE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/grappa-smoke.XXXXXX")"
 
+# Everything this run captured that could carry a harness failure, appended to
+# as the run proceeds. `teardown` reads it to NAME the failure (see below).
+CAPTURED="$SMOKE_HOME/captured.log"
+: > "$CAPTURED"
+
+# The signature of an ERTS that never got off the ground — #2018. It is
+# deliberately about the VM's own startup and nothing else: `sys_sigaltstack`
+# is the one measured on the v1.5.4 release run, and the two companions are the
+# same class (an "Internal error" from sys/unix, and the exit status a SIGSEGV
+# leaves behind) rather than a widening to "the boot failed".
+#
+# 🔴 THIS MATCHES A SYMPTOM, NOT A CAUSE. Why it is worded that way: the
+# mechanism behind the v1.5.4 red is UNKNOWN — nobody has measured why that
+# runner instance could not set an alternate signal stack, and the rerun on the
+# same bytes came back green, so the phenomenon is not deterministic across
+# runner instances. An assertion about seccomp, or about a CPU feature, would
+# encode a guess; a match on the message the VM actually printed does not.
+HARNESS_SIGNATURE='sys_sigaltstack|Failed to set alternate signal stack|Internal error: .*sys/unix'
+
+# runner_facts — what this run's SUBSTRATE was, printed UNCONDITIONALLY.
+#
+# Not a failure branch, and that is the whole point (#2018). What is missing
+# after the v1.5.4 incident is not only the red sample: it is the GREEN one. A
+# fact about the runner cannot be read as anomalous by anyone who has never
+# seen what the runner looks like on a run where the image boots — so the
+# comparison class has to be collected on the ordinary path, on purpose, or the
+# next failure produces a sample of one class and nothing to hold it against.
+#
+# Every reader is best-effort and says so when a source is absent: this block
+# must never be able to fail the run it is describing. A missing `/proc` on a
+# non-Linux host prints `unavailable`, it does not exit.
+runner_facts() {
+    printf '\n===== runner facts (captured on EVERY run, green included — #2018) =====\n'
+    printf 'uname            : %s\n' "$(uname -a 2>/dev/null || echo unavailable)"
+    printf 'runner image     : %s / %s\n' "${ImageOS:-unset}" "${ImageVersion:-unset}"
+    printf 'runner arch      : %s\n' "${RUNNER_ARCH:-unset}"
+    # The alternate-signal-stack minimum the C library reports. The ERTS call
+    # that died on v1.5.4 is `sigaltstack(2)`, whose EINVAL arm is about a size
+    # below the kernel's minimum — so these two numbers are the ones a reader
+    # would want, and nobody has ever recorded them for this job.
+    for k in _SC_SIGSTKSZ _SC_MINSIGSTKSZ _SC_PAGESIZE; do
+        printf '%-17s: %s\n' "$k" "$(getconf "$k" 2>/dev/null || echo unavailable)"
+    done
+    if [ -r /proc/cpuinfo ]; then
+        # The size of the signal frame the kernel must fit scales with the
+        # XSAVE state, so the CPU's feature flags are pertinent rather than
+        # decorative. One line, deduplicated — not 96 identical core stanzas.
+        printf 'cpu model        : %s\n' \
+            "$(awk -F': ' '/^model name/ {print $2; exit}' /proc/cpuinfo)"
+        printf 'cpu xsave flags  : %s\n' \
+            "$(awk -F': ' '/^flags/ {print $2; exit}' /proc/cpuinfo \
+               | tr ' ' '\n' | grep -E '^(avx512|amx|xsave|osxsave)' | sort -u | tr '\n' ' ')"
+    else
+        printf 'cpu              : unavailable (no /proc/cpuinfo)\n'
+    fi
+    printf 'docker           : %s\n' "$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unavailable)"
+    printf 'seccomp          : %s\n' \
+        "$(docker info --format '{{range .SecurityOptions}}{{.}} {{end}}' 2>/dev/null || echo unavailable)"
+    printf '=========================================================================\n\n'
+}
+
+# classify_failure — on a non-zero exit, say WHAT KIND of red this is.
+#
+# It does NOT forgive anything and it does not change the exit status: the run
+# stays red, loudly. What it adds is the one thing the v1.5.4 triage did not
+# have — a name. Today a VM that never started and an image that is genuinely
+# broken arrive identically, as "the job is red", and telling them apart cost a
+# night.
+classify_failure() {
+    grep -Eq "$HARNESS_SIGNATURE" "$CAPTURED" 2>/dev/null || return 0
+    cat >&2 <<'BANNER'
+
+xx  HARNESS FAILURE, NOT THE IMAGE (#2018)
+xx
+xx  The captured output carries the signature of a BEAM that never started —
+xx  the VM died inside its own startup, before any application code ran. That
+xx  is a property of the machine this job landed on, not of the artefact under
+xx  test: the same signature was seen on the v1.5.4 release run and a rerun of
+xx  the SAME commit and the SAME image, on a different runner instance, came
+xx  back green.
+xx
+xx  This run STAYS RED on purpose. It is not downgraded, not retried and not
+xx  excused: the image is published, and a smoke test that cannot stop anything
+xx  is the silently-passing smoke test this file exists to refuse.
+xx
+xx  What to do: read the `runner facts` block at the top of this log, compare it
+xx  against the same block on a GREEN run, and put the difference on #2018 —
+xx  the mechanism is still UNMEASURED, and that comparison is the measurement
+xx  nobody has been able to make so far.
+
+BANNER
+}
+
 teardown() {
     status=$?
     if [ "$status" -ne 0 ]; then
         # The server half of the failure: a probe that failed on the HTTP side
         # says nothing about why. 200 lines, not 30.
+        #
+        # `tee -a` into $CAPTURED as well as stderr: a BEAM that dies in its own
+        # startup does so INSIDE a container, so the container's log is one of
+        # the places the #2018 signature can land, and classify_failure below
+        # has to be able to see it.
         for c in "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE"; do
             if docker inspect "$c" >/dev/null 2>&1; then
                 printf '\n----- docker logs %s (tail 200) -----\n' "$c" >&2
-                docker logs --tail 200 "$c" >&2 || true
+                docker logs --tail 200 "$c" 2>&1 | tee -a "$CAPTURED" >&2 || true
             fi
         done
+        # LAST, so it reads everything this run captured and lands at the very
+        # bottom of the log — where a human scrolling a red job looks first.
+        classify_failure
     fi
     docker rm -f "$BOX" "$BARE" "$UP_OLD" "$UP_NEW" "$HOSTILE" >/dev/null 2>&1 || true
     docker volume rm "$BOX_VOLUME" "$BARE_VOLUME" "$UP_VOLUME" "$HOSTILE_VOLUME" "$HOSTILE_APP_VOLUME" >/dev/null 2>&1 || true
@@ -149,6 +255,10 @@ teardown() {
     exit "$status"
 }
 trap teardown EXIT
+
+# Before anything is attempted, and on every run whatever its outcome — see the
+# function's own comment for why the GREEN sample is the one that was missing.
+runner_facts | tee -a "$CAPTURED"
 
 # A crashed earlier run leaves the box behind, and `install` refuses to run
 # onto an existing container. Clear the dedicated names before, not just after.
@@ -196,7 +306,7 @@ GRAPPA_DATA_VOLUME="$BOX_VOLUME" \
 GRAPPA_PUBLISH="$PUBLISH" \
 GRAPPA_IMAGE="$GRAPPA_IMAGE" \
 PHX_HOST=localhost \
-    sh "$REPO_ROOT/infra/docker/get.sh" install
+    sh "$REPO_ROOT/infra/docker/get.sh" install 2>&1 | tee -a "$CAPTURED"
 
 # ---- probe 1: the SPA the box serves can actually boot ---------------------
 #

--- a/scripts/smoke-release-image.sh
+++ b/scripts/smoke-release-image.sh
@@ -153,7 +153,12 @@ CAPTURED="$SMOKE_HOME/captured.log"
 # same bytes came back green, so the phenomenon is not deterministic across
 # runner instances. An assertion about seccomp, or about a CPU feature, would
 # encode a guess; a match on the message the VM actually printed does not.
-HARNESS_SIGNATURE='sys_sigaltstack|Failed to set alternate signal stack|Internal error: .*sys/unix'
+#
+# The third alternative is ordered the way ERTS actually prints, which is not
+# the way it reads: the format is `<file>:<line>:<func>(): Internal error: <msg>`,
+# so the path comes BEFORE the words "Internal error" and a pattern written the
+# other way round would never have matched the very line it was drawn from.
+HARNESS_SIGNATURE='sys_sigaltstack|Failed to set alternate signal stack|sys/unix/.*Internal error'
 
 # runner_facts — what this run's SUBSTRATE was, printed UNCONDITIONALLY.
 #
@@ -197,6 +202,7 @@ runner_facts() {
         # when the CPU simply has none of these flags, which is a fact worth
         # printing, and a bare blank would read identically to a reader that
         # broke. arm64 has no `flags` line at all and lands in the same arm.
+        local xsave_flags
         xsave_flags="$(awk -F': ' '/^flags/ {print $2; exit}' /proc/cpuinfo \
                | tr ' ' '\n' | grep -E '^(avx512|amx|xsave|osxsave)' \
                | sort -u | tr '\n' ' ' || true)"
@@ -271,7 +277,12 @@ trap teardown EXIT
 
 # Before anything is attempted, and on every run whatever its outcome — see the
 # function's own comment for why the GREEN sample is the one that was missing.
-runner_facts | tee -a "$CAPTURED"
+# `|| true` is the contract stated in the function, made real rather than
+# merely promised: under `set -euo pipefail` a non-zero anywhere in there would
+# abort the run, and a block whose whole job is to DESCRIBE the run must not be
+# able to end it. Its readers already degrade individually; this covers the
+# pipeline too.
+runner_facts | tee -a "$CAPTURED" || true
 
 # A crashed earlier run leaves the box behind, and `install` refuses to run
 # onto an existing container. Clear the dedicated names before, not just after.


### PR DESCRIPTION
Refs issue 2018. This PR does **not** close it — see the last section for why.

## What this does

Three changes to the release-image gate, shipped together on purpose.

**1. Both published architectures are BOOTED, not just built.** The docker job
publishes `linux/amd64,linux/arm64`; the smoke job ran on `ubuntu-latest` alone
and said so out loud — *"amd64 only: the arm64 leg is proven by the build"*.

Measured, and it is why that posture falls: **every job in every workflow in
this repository was `ubuntu-latest`** — 12 of 12 across `ci.yml`,
`integration.yml` and `release.yml` — so no arm64 binary had ever been EXECUTED
here by anything. `infra/docker/assert-abi-lockstep.sh` does gate arm64 at build
time, per-platform, but it proves the runtime stage can **link** the release,
not that the VM **starts**. For an arm64 puller of `ghcr.io/<owner>/grappa` the
first process ever to run the image was a user's, on every release that has ever
shipped. That is structural, not intermittent, and `ubuntu-24.04-arm` is free on
a public repository — the cure is a matrix and nothing else. The driver is
unchanged: `docker pull` resolves the multi-arch manifest for whatever host it
lands on, candidate and upgrade fixture alike.

The amd64 check-run **keeps its exact name**, `deploy + probe the release image
(amd64)`, because `name:` is spelled with the matrix value rather than left to
the default suffix.

`fail-fast: false` is load-bearing and is not a softening: without it an amd64
failure CANCELS the arm64 leg, and that cancelled leg is exactly the reading
worth having.

**2. The runner's facts are captured on every run — green included.** This is
the half that is easy to get backwards. What the `v1.5.4` incident lacks is not
only the red sample, it is the **green** one: an `ImageOS`, a `MINSIGSTKSZ`, a
set of XSAVE flags cannot be read as anomalous by anyone who has never seen them
on a run where the image boots. Facts only on failure produce a sample of one
class and nothing to hold it against.

**3. A failure carrying the ERTS-startup signature is NAMED, not forgiven.** No
retry, no `continue-on-error`, no downgrade, exit status untouched. What is added
is the distinction that cost a night: a VM that never started and an image that
is genuinely broken used to arrive identically, as "the job is red".

Plus: release-only is now **stated as deliberate**. The subject of this gate is
the published image, and before the tag there is none — that is arithmetic, not
a cadence anyone chose.

## What was refused

- **The issue's first ask, as written** ("run the probe somewhere it can actually
  boot the image, or make the sandbox difference explicit and asserted"). There
  is no second substrate — production is the FreeBSD jail and has no docker, a
  self-hosted runner would be a third production substrate, and self-hosters are
  field evidence rather than a gate. Asserting the sandbox difference is worse:
  nobody has measured what that difference **is**, so the assertion would encode
  a guess and stay green in exactly the case the guess is wrong.
- **A `schedule:`** for the `docker_validation` dry-run — a cron red has no
  owner. There is no `schedule:` anywhere in this repo and that stays a decision.
- **Retries, `continue-on-error`, wider timeouts, dgoss-as-cure.**
- **A BEAM preflight.** Designed, then dropped: it cannot be exercised anywhere
  available, and an untested new invocation in the release path is a new way for
  every release to go red, in exchange for attribution the classifier already
  delivers minutes later.

## 🔴 What this does NOT cure — please do not read a cure into it

**The non-determinism is untouched and its mechanism remains unknown.** This gate
produced red and then green on byte-identical input, which means it can lie in
**both** directions, and the direction that hurts is the false green: the absence
of the failure is not by itself evidence that the image boots.

What ships here cures the **blindness** (an arm64 half nobody had ever executed)
and the **legibility** (a red nobody could classify). Neither of those is the
flip. The honest expectation is an instrument, not a diagnosis: the next
occurrence arrives with the runner's facts attached and a comparison class to
hold them against — which is the measurement nobody has been able to make so far.

## Cost accepted explicitly

Two runner substrates means two chances to trip over an environmental flake. With
these checks blocking, **the `v1.5.4` release would have stopped**. That is
accepted: the artefact is published, and a smoke test that cannot stop anything
is the silently-passing smoke test this driver exists to refuse. The human loop
is the one already used — rerun the job, and withdraw if it is still broken — and
a considered rerun on a **named** red costs a minute, where a triage on a mute
red cost a night.

## A claim withdrawn before it was published

An earlier draft carried a second finding: that `Dockerfile.release` leaves
`elixir:1.19-otp-28-alpine` and `alpine:3.24` on floating tags, so the published
image is not a pure function of the source tree. Literally true, wrongly framed.
Both are excluded **by name** from the #103 digest-pin gate with the argument
written there — the Elixir tag "carries the pin" and is held to `.tool-versions`
by `toolchain_pin_test.bats`, and the alpine floor floats on purpose so security
patches keep flowing, with `assert-abi-lockstep.sh` proving compatibility rather
than freezing bytes. A decision with two gates over it, not a gap. Recorded in
DESIGN_NOTES so nobody spends the same hour.

## Verification

| gate | result |
|---|---|
| `scripts/bats.sh test/infra/` (~50 suites, 588 cases) | **rc=0**, 0 failures |
| `shellcheck -x scripts/smoke-release-image.sh` | **rc=0** |
| `scripts/design-notes-gate.sh` (and against `origin/main`) | **rc=0** — *"1 new entry heading(s), separator and marker present"*, i.e. it saw the entry rather than answering "nothing to check" |
| workflow YAML parses; the conditional matrix folds to one line | verified |
| harness signature: real `v1.5.4` line matches; third alternative matches alone; `Ecto.MigrationError` does **not** | verified — the negative control is the one that matters, since a classifier mislabelling a real image break as "harness" would excuse the failure this gate exists to catch |
| `runner_facts` on a substrate with no `/proc` | exits 0, degrades to `unavailable` |

**Not verified, and it needs a runner:** the Linux output shape of the facts
block, the arm64 leg actually running, and the classifier firing on a real
failure. The honest proof of all three is a `docker_validation` dispatch.

## Notes

- The DESIGN_NOTES arithmetic was predicted before the append (+134 / −0) and
  matched exactly. On a pure append the "deletions zero" half of the two-sided
  check is a **tautology** and proves nothing; the additions half and the
  boundary shape read on the file are the parts that carry weight.
- #2018 is deliberately **not** closed by this PR: the issue's own question — why
  that runner instance failed — is still unanswered, and this changes what the
  gate can see rather than answering it.
