### PR TITLE
test(2022): cure main's red — the jail-deploy fixture needs the second lib the script sources

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50005,3 +50005,43 @@ _Deploy scripts, infra comments and docs. No wire change, no protocol bump, no
 supervision-tree or schema change. Deploy: the changed files are the deploy
 machinery itself — the value they now carry is the one tonight's deploy was
 already run with by hand._
+<!-- entry #2022b -->
+
+---
+
+## 2026-09-09 — #2022b: adding a second `source` to a deploy script breaks a fixture that names its libs by hand
+
+#2022 gave `infra/freebsd/deploy.sh` a second sourced lib. Main went red
+immediately: 35 `not ok`, all in `test/infra/deploy_jail_test.bats`, each
+failing at its FIRST assertion.
+
+That fixture builds a throwaway repo and copies in, **by name**, the libs the
+script sources. It had one such line. With the second lib absent, `set -eu`
+kills the script at the source — `deploy.sh: line 46: …/lib/bastille_jail.sh:
+No such file or directory`, rc=1 — before a single assertion runs.
+
+Two things are worth keeping, and neither is "remember to copy the file".
+
+**The fixture is a hand-maintained mirror of a source list, and nothing
+derives one from the other.** Six fixtures across docker, linux and the jail
+follow the same one-`cp`-per-lib shape; it is consistent, and it is a mirror
+that will drift again the next time a deploy script gains a source line. The
+cure here follows the convention rather than inventing a second one — but a
+reader adding a `.` to any deploy script should know the fixture is the other
+half of that edit.
+
+**bats reports the symptom thirty-five times and the cause zero times.** The
+CI log carries 35 assertion failures and not one line of the script's stderr;
+`No such file or directory` appears nowhere in it. The failure is legible only
+by running the suite, or by running the script from a sandbox by hand — which
+is how the mechanism here was established rather than guessed, together with
+the control that proves it: with the lib present the script runs past line 46
+into `git pull`, i.e. fails somewhere else entirely. That control is what ruled
+out the rival reading, that `SCRIPT_DIR` was resolving to the wrong place.
+
+Process note, recorded because the cost was real: `scripts/check.sh` already
+runs `scripts/bats.sh`. The red did not escape a gap in the gates — it escaped
+because the gate was not run before pushing.
+
+_Test fixture only. No wire change, no protocol bump, no supervision-tree or
+schema change. Deploy: nothing — the change is in a bats fixture._

--- a/test/infra/deploy_jail_test.bats
+++ b/test/infra/deploy_jail_test.bats
@@ -35,6 +35,14 @@ setup() {
     # exist in the throwaway clone for the script to run — committed so
     # pulls stay clean. Assertions below are UNCHANGED by the extraction.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    # …and the jail NAME (#2022), sourced BEFORE the operator hints that quote
+    # it. Absent, `set -eu` kills the script on line 46 with `No such file or
+    # directory` and every case below fails at its first assertion, with the
+    # cause nowhere in the bats output — which is exactly how it reached main.
+    # One cp per lib the script sources is the shape the docker and linux
+    # fixtures already use; it is a hand-kept mirror of the source list, and
+    # this is the second entry it has ever had.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/bastille_jail.sh" "$UPSTREAM/infra/lib/bastille_jail.sh"
     echo wrapper > "$UPSTREAM/infra/freebsd/bin/grappa-source-alias"
     # jail_*.sh delegates → recorders. Committed so pulls stay clean.
     for stub in jail_cic_build.sh jail_release.sh jail_install_rcd.sh jail_install_source_alias.sh jail_beam_wait.sh; do


### PR DESCRIPTION
Cures the red on `main` left by issue 2022's slice. Deliberately no auto-close
keyword — the issue's lifecycle is the orchestrator's call.

## ⚠️ Read this before triaging the CI on this PR

**`main` is red right now** (`eeaf8eaed`, run 34305326246). This PR is the cure.
Until it lands, any CI here that reruns against a merge with main inherits that
red — **it is not a new failure and it is not yours**. The signal to read is
this branch's own `test + lint + audit` job.

## What broke

35 `not ok`, every one in `test/infra/deploy_jail_test.bats`, each failing at its
**first** assertion. ExUnit was clean (0 failures across 7221 tests) — it was
never Elixir.

That fixture builds a throwaway repo and copies in, **by name**, the libs the
script sources. It had exactly one such line, for `deploy_common.sh`. Issue 2022
gave `infra/freebsd/deploy.sh` a second source, `infra/lib/bastille_jail.sh`, so
inside the fixture the script dies before any assertion runs.

## Mechanism — measured, not inferred

Two reproductions:

1. **Locally, the same red:** `scripts/bats.sh test/infra/deploy_jail_test.bats`
   → 35 `not ok`, same file, `rc=1`.
2. **Directly, the cause:** the real script run from a sandbox holding only
   `deploy_common.sh`:

   ```
   deploy.sh: line 46: .../infra/freebsd/../lib/bastille_jail.sh: No such file or directory
   rc=1
   ```

   …and the **control**, with `bastille_jail.sh` present: the script runs *past*
   line 46 into `git pull` and fails somewhere else entirely.

That control is what rules out the rival reading — that `SCRIPT_DIR` resolved to
the wrong place. The path in the error is exactly the intended one; the file
simply was not there.

## The cure, and what it deliberately is not

One `cp`, so the source is **reachable**. It is *not* re-hardcoding the literal
in two places: the whole point of issue 2022 is that the restart hint and the
`JAIL` variable come from one source, and splitting them again to satisfy a
fixture would undo the fix to keep the test green.

One `cp` per sourced lib is the shape the docker and linux fixtures already use
(six of them), so this follows the house convention rather than inventing a
second one.

## Worth knowing, because it will recur

- That fixture is a **hand-maintained mirror** of the script's source list, with
  nothing deriving one from the other. A new `.` line in any deploy script is
  half an edit; the fixture is the other half.
- **bats printed the symptom 35 times and the cause zero times.** `No such file
  or directory` appears nowhere in the CI log — only 35 assertion failures. You
  reach the cause by running the suite, or the script, yourself.
- No new meta-gate was added for this. A checker that derives each fixture's
  `cp` list from its script's `source` lines is a parallel structure needing its
  own housekeeping, for a mirror that has broken once.

## Verification

| gate | result |
|---|---|
| `scripts/bats.sh test/infra/` on this branch | **593 ok, 0 not ok, rc=0** |
| the same suite before the fix | 35 `not ok`, rc=1 — reproduced locally |
| `scripts/design-notes-gate.sh` | rc=0 — *"1 new entry heading(s), separator and marker present"* |

`rc` values are read from the run's own log file, not from a wrapper's exit
status.

## Process note

`scripts/check.sh` already runs `scripts/bats.sh`. This red did not escape a gap
in the gates — it escaped because the gate was not run before pushing. Recorded
in the DESIGN_NOTES entry rather than left as folklore.
