### PR TITLE
fix(2024): send an inbound CTCP query through the #546 door, minting no tab

### DIFF
--- a/cicchetto/e2e/tests/issue2024-ctcp-query-no-minted-tab.spec.ts
+++ b/cicchetto/e2e/tests/issue2024-ctcp-query-no-minted-tab.spec.ts
@@ -1,0 +1,115 @@
+// issue 2024 — a stranger's CTCP probe must not hand the operator a tab.
+//
+// The defect was server-side routing: a DM-targeted CTCP query persisted at
+// `channel = own_nick`, which set `dm_with = sender`, and the auto-open keys
+// on `dm_with || channel`. So anyone who asked the bouncer for a VERSION
+// string minted a query window with somebody the operator had never talked
+// to. vjt ruled the row belongs in the network window (the #546 door).
+//
+// WHY THIS SPEC EXISTS ON TOP OF THE UNIT + INTEGRATION COVERAGE. Those two
+// prove the routing KEY and the absence of a `query_windows` row. Neither
+// proves the thing the operator actually reported, which is a TAB. The
+// sidebar is projected from `windowStateByChannel` fed by the user topic, so
+// "no row in the table" and "no tab on the screen" are two claims with a
+// whole client between them. This asserts the second one, in a browser,
+// against a real peer on the real testnet ircd.
+//
+// THE ABSENCE IS A MEASUREMENT, NOT AN EMPTY READ (#1336's rule), and it is
+// guarded twice:
+//   1. the tab is only looked for AFTER the visibility row has provably
+//      landed — so the probe was routed, not merely still in flight;
+//   2. the locator is positive-controlled on the same page against a window
+//      that MUST be there. A `toHaveCount(0)` from a selector that matches
+//      nothing anywhere is a green that proves the selector is broken.
+//
+// NOT claimed: anything about the reply the bouncer sends back. That it
+// answers a VERSION query is #391's contract and has its own coverage; this
+// spec is about where the INBOUND half lands.
+
+import { loginAs, scrollbackLine, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { fetchAllMessagesAsc } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specLiveNick, specUser, test } from "../fixtures/test";
+
+// The CTCP framing byte. Built from a char code rather than written as an
+// escape so the wire shape survives any lint that rewrites string escapes.
+const DELIM = String.fromCharCode(1);
+
+// The synthetic network window. Same literal `SERVER_WINDOW_NAME` the
+// production tag carries; `sidebarWindow` maps its legacy aliases onto it.
+// A COPY, not an import: the runner mounts `cicchetto/e2e` alone at `/work`,
+// so `src/lib/windowKinds` is not resolvable here. #1646's mirror table holds
+// the two in lockstep — this name is pinned in `e2eConstantMirrors.test.ts`,
+// and changing either side alone turns that test red.
+const SERVER_WINDOW = "$server";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// The server-emitted visibility row. Prefix only: the version suffix is
+// `Grappa.Version.current/0`, which changes on every release cut, and
+// pinning it here would rot the spec on a tag rather than on a defect.
+const ROW_PREFIX = "CTCP VERSION query → grappa";
+
+// 60s — peer registration on the mesh plus login, select, and one round
+// trip. The budget is for the ircd hops, not for settling.
+test.setTimeout(60_000);
+
+test("2024 — an inbound CTCP query lands in the network window and mints no tab", async ({
+  page,
+}) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: await specLiveNick() });
+
+  // POSITIVE CONTROL for the locator, taken BEFORE the claim so a broken
+  // selector cannot be mistaken for a missing tab. The channel just selected
+  // must be findable by exactly the helper the claim uses.
+  await expect(
+    sidebarWindow(page, NETWORK_SLUG, CHANNEL),
+    "the sidebar locator finds nothing at all — the absence below would be vacuous",
+  ).toHaveCount(1);
+
+  const peer = await IrcPeer.connect({ nick: "ctcpprobe2024" });
+
+  try {
+    // The probe. A CTCP query IS a PRIVMSG whose body is delimiter-wrapped,
+    // so this is the ordinary send verb — no new fixture seam is needed, and
+    // adding one would have been a shared-fixture edit that buys nothing.
+    peer.privmsg(await specLiveNick(), `${DELIM}VERSION${DELIM}`);
+
+    // BARRIER + DESTINATION, in one act. Polling the network window's own
+    // scrollback proves the probe was routed AND proves where it went. Read
+    // over REST rather than off the screen because the two claims that
+    // follow are about the DOM, and a barrier that shares their failure mode
+    // cannot witness them.
+    await expect
+      .poll(
+        async () => {
+          const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, SERVER_WINDOW);
+          // `body` is nullable on the wire (presence rows carry none), so
+          // the guard is part of the predicate rather than an assertion —
+          // a null body is simply not the row being waited for.
+          return rows.some((r) => (r.body ?? "").startsWith(ROW_PREFIX));
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+
+    // THE CLAIM. No tab for the stranger — not greyed, not unread, absent.
+    await expect(
+      sidebarWindow(page, NETWORK_SLUG, peer.nick),
+      "a CTCP probe from a stranger minted a query tab",
+    ).toHaveCount(0);
+
+    // …and the row is READABLE where it was sent, which is the other half of
+    // the ruling: routed to the network window, not routed to nowhere.
+    // Dropping it silently would also have produced no tab.
+    await sidebarWindow(page, NETWORK_SLUG, SERVER_WINDOW).click();
+    await expect(scrollbackLine(page, "notice", new RegExp(ROW_PREFIX))).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    await peer.disconnect("2024 done");
+  }
+});

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -101,6 +101,19 @@ const MIRRORS: readonly Mirror[] = [
     production: SERVER_WINDOW_NAME,
     origin: "SERVER_WINDOW_NAME (src/lib/windowKinds.ts)",
   },
+  // issue 2024 — the CTCP-query spec asserts the visibility row lands in the
+  // network window, so `$server` IS the fact under test and copying it is not
+  // an option to be talked out of: the e2e runner mounts `cicchetto/e2e` alone
+  // at `/work` (`compose.yaml`, `- .:/work`), so `../../src/lib/windowKinds`
+  // does not exist at runtime and an import of the VALUE cannot resolve. A
+  // pinned copy is the mechanism; KNOWN_UNPINNED would be a lie, because this
+  // value is not a question.
+  {
+    file: "e2e/tests/issue2024-ctcp-query-no-minted-tab.spec.ts",
+    name: "SERVER_WINDOW",
+    production: SERVER_WINDOW_NAME,
+    origin: "SERVER_WINDOW_NAME (src/lib/windowKinds.ts)",
+  },
   {
     file: "e2e/tests/m12-motd-server-window-routes-notice.spec.ts",
     name: "SERVER_CHANNEL",

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -890,10 +890,21 @@ moduleRoot(() => {
             // #546 narrowed WHAT reaches this arm, without changing it: a
             // peer's own NOTICE no longer lands at `channel == ownNick` at
             // all (it routes to `$server`, or to the peer's own topic when
-            // that query is already open). What still arrives here is the
-            // server-emitted CTCP-query visibility row above. No cic edit
-            // was needed for #546 precisely because this is a renderer —
-            // the routing it mirrors moved underneath it.
+            // that query is already open). No cic edit was needed for #546
+            // precisely because this is a renderer — the routing it
+            // mirrors moved underneath it.
+            //
+            // issue 2024 narrowed it AGAIN, and took away the one example
+            // the paragraph above used to end on ("what still arrives here
+            // is the server-emitted CTCP-query visibility row"). It does
+            // not: an inbound CTCP query now goes through the same #546
+            // door, so its visibility row lands on `$server` or in the
+            // already-open query, never at `channel == ownNick`. No cic
+            // edit was needed for that either, for the same reason.
+            // ⚠️ NOT claimed: that this arm is now unreachable. Its full
+            // input set was not enumerated, so it stays — a renderer arm
+            // that fires on nothing costs nothing, and deleting one whose
+            // inputs you have not measured is how a class goes silent.
             //
             // sender !== ownNick guard: don't route our OWN outbound NOTICEs
             // (they ride the topic too as fan-out echo). Service-to-self

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50045,3 +50045,104 @@ because the gate was not run before pushing.
 
 _Test fixture only. No wire change, no protocol bump, no supervision-tree or
 schema change. Deploy: nothing — the change is in a bats fixture._
+<!-- entry #2024 -->
+
+---
+
+## 2026-09-09 — #2024: the probe that handed a stranger a tab, and the fourth arm nobody counted
+
+An inbound CTCP query MINTED the sender's query window. A DM-targeted query
+resolved its routing key to `state.nick`, which made `build_persist/6` set
+`dm_with = sender` (`Scrollback.dm_peer/4` returns the sender when the target
+IS us), and `Session.Server.maybe_open_query_window/2` keys on
+`dm_with || channel`. So anyone who asked the bouncer for a VERSION string
+left a tab open with somebody the operator had never talked to. **What the
+receiver paid was not a wire line, it was a window** — the asymmetry the #546
+door exists to remove for NOTICE.
+
+**The ruling, and its provenance.** vjt on `#grappa`, 08:45 Europe/Rome,
+verbatim `<< network`, answering "does an inbound CTCP query in a DM go to the
+network window (the #546 door), or does it keep minting the peer's query
+window?". Recorded on issue 2024 as comment `5597364131`. I did not see it —
+reading IRC is closed to me; it reached me relayed and I verified it against
+the issue before building. The issue deliberately carried no `status:` label
+until the ruling landed, because flipping this reverses a contract that a test
+was written to pin.
+
+### The cure is ONE call, and it calls the existing door
+
+`ctcp_query_channel/3` replaces four inline copies of the same three lines. It
+calls `open_query_or_server/2` — the #546 door itself — rather than restating
+"open query → that query, else `$server`". A second copy of the rule would be
+a boundary violation and not a cure: the two would drift, and the reason this
+arm was broken at all is that the rule lived in one branch while the traffic
+arrived on another.
+
+The CHANNEL-targeted branch is untouched, and is the negative control in the
+tests: a channel CTCP keeps the channel key, takes no `dm_with`, and minted
+nothing before or after. It is exercised on BOTH sides of the open-window
+predicate, because the door must not reach that branch at all — if it did, an
+open query with a peer would drag a channel row into her window.
+
+### 🔴 FOUR arms, not three — the issue's own enumeration was short
+
+The issue measured three (`VERSION`, `USERINFO`, `AVATAR`). `ctcp_ping_reply/4`
+is a fourth, computing the identical key with the identical consequence, and it
+is included. Two reasons, and the second is the load-bearing one. Curing three
+of four identical sites would leave one inline copy of the rule beside the
+shared helper — the half-migration that makes the next reader copy whichever
+pattern is closer. And the tree ALREADY holds "CTCP is protocol, not
+conversation" for PING on the *reply* direction: `route_non_channel_notice/3`'s
+CTCP short-circuit names a PING round trip in its own comment. Curing the query
+direction is the symmetric half of a rule the codebase had already accepted.
+
+The fourth arm surfaced from the RED run, not from reading: exactly four
+existing assertions flipped to `left: "vjt"`, one per arm.
+
+### Three doors now, and the split is not the one the names suggest
+
+`open_query_or_server/2` used to document "two doors, deliberately asymmetric"
+— NOTICE for every nick sender, PRIVMSG for services only. There are three now,
+and the axis is **conversation vs control surface**, not NOTICE vs PRIVMSG:
+
+* NOTICE — every nick sender. Announcement, not conversation.
+* CTCP QUERY — every nick sender. A probe is a control surface, and it arrives
+  as a PRIVMSG, which is exactly why it walked past the door for so long.
+* PRIVMSG — services senders ONLY. A peer's ordinary DM still opens the
+  conversation; it is the one arm of the three that still mints.
+
+### The issue's "not measured", measured
+
+Whether a peer's `USERINFO` probe and its `AVATAR` sibling minted ONE window or
+TWO: **one**. All four arms computed the same key from the same inputs, so
+`dm_with` was the same nick and `QueryWindows.open/4` is keyed on it. Evidence
+is the pre-cure assertion set — four arms, four `channel == "vjt"`, one key.
+Post-cure the count is zero, asserted end-to-end by inspecting the whole
+`list_for_subject/1` map rather than a per-nick boolean, so the failure message
+carries the count the question was about.
+
+### What is NOT claimed
+
+* **No e2e.** The visible outcome ("no tab appears from a stranger") wants a
+  peer sending a DM-targeted CTCP, and the e2e harness drives cic against a
+  fixture API rather than a peer on a real ircd. Rather than write a spec that
+  asserts nothing, the coverage is stated: unit at the classifier for all four
+  arms plus both controls, integration through a real `IRCServer` for the
+  window count. The felt outcome stays dogfood.
+* **That the cic arm is now dead.** `subscribe.ts`'s own-nick NOTICE branch
+  documented the CTCP-query visibility row as the last thing still reaching it
+  after #546. It no longer does. Its comment is corrected; the arm is NOT
+  removed, because its full input set was not enumerated and deleting a
+  renderer arm whose inputs you have not measured is how a class goes silent.
+* **Anything about the sender side.** The fan-out (`maybe_query_peer_profile/2`
+  on JOIN + 353) is rate limited per SENDER (`{subject, network_id}`), which
+  bounds one session's outbound and says nothing about the aggregate one
+  receiver takes from N sessions. That is a different slice and was not
+  redesigned here. The `LucentW` Excess Flood kill on Libera is ONE sighting,
+  unreproduced and untied to this path; it is not a cause and was not built on.
+* **Whether USERINFO/AVATAR replies should be surfaced at all.** A product call
+  nobody has made. Each still mints a visibility row; the ruling does not touch
+  it.
+
+_Test-only + routing. No wire change, no protocol bump, no migration.
+Deploy: ordinary._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50123,12 +50123,24 @@ carries the count the question was about.
 
 ### What is NOT claimed
 
-* **No e2e.** The visible outcome ("no tab appears from a stranger") wants a
-  peer sending a DM-targeted CTCP, and the e2e harness drives cic against a
-  fixture API rather than a peer on a real ircd. Rather than write a spec that
-  asserts nothing, the coverage is stated: unit at the classifier for all four
-  arms plus both controls, integration through a real `IRCServer` for the
-  window count. The felt outcome stays dogfood.
+* **The e2e is written but NOT YET RUN.** It needs the exclusive stack lane,
+  which is the orchestrator's to allocate; the result is reported separately
+  and this entry does not pre-date it green.
+
+  🔎 It nearly was not written at all. The draft of this very bullet read "no
+  e2e — the harness drives cic against a fixture API rather than a peer on a
+  real ircd". **Measured, that premise is false**: the stack runs a real
+  grappa against the testnet ircd, `IrcPeer.connect` gives a real peer, and a
+  CTCP query is a PRIVMSG whose body is delimiter-wrapped, so the ordinary
+  send verb carries it and no shared-fixture seam was needed. A declaration
+  of "cannot be covered" is a measurement like any other, and this one would
+  have been wrong — the lesson is worth more than the spec.
+
+  It exists because the unit and integration layers prove the routing key and
+  the absent `query_windows` row, and neither proves the thing reported: a
+  TAB. The sidebar is projected from `windowStateByChannel` off the user
+  topic, so "no row in the table" and "no tab on the screen" are two claims
+  with a whole client between them.
 * **That the cic arm is now dead.** `subscribe.ts`'s own-nick NOTICE branch
   documented the CTCP-query visibility row as the last thing still reaching it
   after #546. It no longer does. Its comment is corrected; the arm is NOT

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -581,31 +581,20 @@ defmodule Grappa.Session.EventRouter do
         version = Grappa.Version.current()
         reply = "NOTICE #{sender} :\x01VERSION grappa #{version}\x01"
 
-        # Persist the inbound query so cic surfaces it. Routing rule
-        # mirrors how a real inbound PRIVMSG would land: a private CTCP
-        # query (target == own_nick) persists on the own-nick topic —
-        # that's where cic's dm-listener observes inbound DM-shaped
-        # traffic and re-keys it onto the sender's window. The window
-        # itself is minted SERVER-side (#422): `build_persist/6` sets
-        # `dm_with = sender` via `Scrollback.dm_peer/4`, and
-        # `Session.Server.maybe_open_query_window/2` keys on
-        # `dm_with || channel`. Persisting at channel = sender instead
-        # would land the broadcast on a topic cic isn't subscribed to
-        # until that window already exists.
-        # Channel-targeted CTCP keeps target as channel (no re-key).
+        # Persist the inbound query so cic surfaces it. Where it lands is
+        # `ctcp_query_channel/3` — the ONE routing rule the four CTCP
+        # query arms share; see it for the whole argument.
         #
-        # #546 does NOT reach this arm: it reverses the NOTICE door
-        # (`route_non_channel_notice/3`), and a CTCP query arrives as a
-        # PRIVMSG. So this visibility row still opens the peer's window —
-        # the issue predicted it would go quiet, and it does not. Pinned
-        # by a `server_test.exs` case rather than left to be re-derived.
-        # #537 — `canonical_target/1` (fold at every identifier boundary)
-        # so a DM CTCP target (a peer nick) folds into a canonical window
-        # KEY; the sigil-gated form left it raw-cased.
-        dm_channel =
-          if nick_eq?(target, state.nick),
-            do: state.nick,
-            else: Identifier.canonical_target(target, casemapping(state))
+        # issue 2024 rewrote what used to stand here. This arm read: "a
+        # private CTCP query persists on the own-nick topic […] #546 does
+        # NOT reach this arm […] so this visibility row still opens the
+        # peer's window." Accurate then, and exactly the defect: the
+        # minting was a documented consequence nobody had ruled on. vjt
+        # ruled it (`<< network`), so the arm now goes through the #546
+        # door and a probe from a stranger mints nothing.
+        # Channel-targeted CTCP still keeps target as channel (no re-key),
+        # with #537's fold applied to the key — that half is unchanged.
+        dm_channel = ctcp_query_channel(target, sender, state)
 
         notice_body = "CTCP VERSION query → grappa #{version}"
         # sender_meta/1, not %{}: this row's sender is a peer nick off a real
@@ -3126,11 +3115,18 @@ defmodule Grappa.Session.EventRouter do
   # routed here. That is the whole mechanism by which a notice stops
   # spawning windows: routing, not a second carve-out at the open site.
   #
-  # Two doors, deliberately asymmetric:
+  # THREE doors, deliberately asymmetric — the third arrived with issue
+  # 2024, and the asymmetry is the point: the split is conversation vs
+  # control surface, not NOTICE vs PRIVMSG.
   #   * NOTICE (`route_non_channel_notice_non_chanserv/3`) — EVERY nick
   #     sender. A notice is announcement, not conversation.
-  #   * PRIVMSG (`privmsg_default/3`) — services senders ONLY. A peer's DM
-  #     still opens the conversation; that is what a DM is for.
+  #   * CTCP QUERY (`ctcp_query_channel/3`) — EVERY nick sender. A probe
+  #     is a control surface, and it arrives as a PRIVMSG, which is why
+  #     it walked past this door until somebody was handed a tab by a
+  #     stranger who only asked for a VERSION string.
+  #   * PRIVMSG (`privmsg_default/3`) — services senders ONLY. A peer's
+  #     ordinary DM still opens the conversation; that is what a DM is
+  #     for, and it is the one arm of the three that still mints.
   #
   # The open-window fact is a per-(subject, network) DB read. EventRouter
   # is a pure classifier ("No Repo"), so the lookup is injected as the
@@ -3163,6 +3159,41 @@ defmodule Grappa.Session.EventRouter do
     if open?.(state.subject, state.network_id, sender),
       do: sender,
       else: "$server"
+  end
+
+  # The window an inbound CTCP QUERY's visibility row lands in — the ONE
+  # place the four answering arms (VERSION, PING, USERINFO, AVATAR) get
+  # that key. It used to be four inline copies of the same three lines.
+  #
+  # issue 2024 — a DM-targeted query resolved to `state.nick`, which made
+  # `build_persist/6` set `dm_with = sender` (`Scrollback.dm_peer/4`
+  # returns the sender when the target IS us), and
+  # `Session.Server.maybe_open_query_window/2` keys on `dm_with ||
+  # channel`. So a stranger who probed the bouncer MINTED a tab with
+  # somebody the operator never talked to — the receiver paid a window for
+  # a wire line they did not ask for. vjt's ruling on #grappa was `<<
+  # network`: the `#546` door wins here too.
+  #
+  # It CALLS that door (`open_query_or_server/2`) rather than restating
+  # it. A second copy of "open query → that query, else `$server`" is a
+  # boundary violation, not a cure: the two would drift, and the reason
+  # this arm was broken in the first place is that the rule lived in one
+  # branch and the traffic arrived on another.
+  #
+  # The CHANNEL-targeted branch is deliberately untouched. A channel CTCP
+  # keeps the channel key, takes no `dm_with`, and minted nothing before
+  # or after — routing it through the peer-window door would drag a
+  # channel row into a query.
+  #
+  # NOT the same as the NOTICE short-circuit above it: that one sends
+  # CTCP-framed REPLIES to `$server` unconditionally, open window or not,
+  # because a reply is protocol we asked for. This is the QUERY direction,
+  # and an open conversation still claims it.
+  @spec ctcp_query_channel(String.t(), String.t(), state()) :: String.t()
+  defp ctcp_query_channel(target, sender, state) do
+    if nick_eq?(target, state.nick),
+      do: open_query_or_server(sender, state),
+      else: Identifier.canonical_target(target, casemapping(state))
   end
 
   @spec chanserv_bracket_match(String.t(), String.t()) :: {String.t(), String.t()} | nil
@@ -3213,10 +3244,7 @@ defmodule Grappa.Session.EventRouter do
         :none -> "NOTICE #{sender} :\x01PING\x01"
       end
 
-    dm_channel =
-      if nick_eq?(target, state.nick),
-        do: state.nick,
-        else: Identifier.canonical_target(target, casemapping(state))
+    dm_channel = ctcp_query_channel(target, sender, state)
 
     # Same as the VERSION row above: a real peer nick, so the key belongs.
     {state2, persist_eff} =
@@ -3250,10 +3278,7 @@ defmodule Grappa.Session.EventRouter do
     info = userinfo_text(state.profile)
     reply = "NOTICE #{sender} :\x01USERINFO #{info}\x01"
 
-    dm_channel =
-      if nick_eq?(target, state.nick),
-        do: state.nick,
-        else: Identifier.canonical_target(target, casemapping(state))
+    dm_channel = ctcp_query_channel(target, sender, state)
 
     {state2, persist_eff} =
       build_persist(
@@ -3289,10 +3314,7 @@ defmodule Grappa.Session.EventRouter do
     sender = Message.sender_nick(msg)
     reply = "NOTICE #{sender} :\x01AVATAR #{state.avatar_url}\x01"
 
-    dm_channel =
-      if nick_eq?(target, state.nick),
-        do: state.nick,
-        else: Identifier.canonical_target(target, casemapping(state))
+    dm_channel = ctcp_query_channel(target, sender, state)
 
     {state2, persist_eff} =
       build_persist(

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -36,6 +36,18 @@ defmodule Grappa.Session.EventRouterTest do
   # longer has, which is the whole thing the bundle is supposed to make visible.
   defp deps(open?), do: %Deps{query_window_open?: open?}
 
+  # issue 2024 — the four arms that answer an inbound CTCP query package
+  # their visibility row in TWO different shapes: VERSION and PING pair it
+  # INSIDE an `:auto_reply` (one budget buys the outbound line and the row
+  # together, #1404), while USERINFO and AVATAR emit it alongside a plain
+  # `:reply`. The routing key is the same question in both shapes, so the
+  # shapes are unwrapped here instead of forking the shared test body in
+  # two. Deliberately total over exactly those two: a third shape arriving
+  # later raises `FunctionClauseError` at the assertion rather than
+  # skipping the arm in silence.
+  defp ctcp_persist([{:auto_reply, _, {:persist, _, _} = persist}]), do: persist
+  defp ctcp_persist([{:reply, _, :event_router_reply}, {:persist, _, _} = persist]), do: persist
+
   defp base_state(overrides \\ %{}) do
     Map.merge(
       %{
@@ -562,15 +574,14 @@ defmodule Grappa.Session.EventRouterTest do
       assert IO.iodata_to_binary(line) ==
                "NOTICE alice :\x01VERSION grappa #{version}\x01"
 
-      # Persist effect: visible row routed via the own-nick topic so
-      # cic's dm-listener arm (CP23 NOTICE auto-open) re-keys onto
-      # the sender's window. Persisting at channel = sender directly
-      # bypasses the dm-listener and silently drops the broadcast on
-      # the floor unless the peer's window is already open. channel
-      # = own_nick (the target the peer addressed) is the same shape
-      # an inbound PRIVMSG from the peer would land at — same routing,
-      # one less special case.
-      assert attrs.channel == "vjt"
+      # Persist effect: the visibility row goes through the `#546` door
+      # (issue 2024). It used to persist at `channel = own_nick` so cic's
+      # dm-listener re-keyed it onto the sender's window — which is
+      # precisely how a stranger's probe minted a tab. With no query open
+      # the row lands on `$server`; the arms' shared behaviour is pinned
+      # by the four-arm block below, and this line keeps the VERSION arm's
+      # own answer honest.
+      assert attrs.channel == "$server"
       assert attrs.sender == "alice"
       assert attrs.body == "CTCP VERSION query → grappa #{version}"
     end
@@ -596,7 +607,9 @@ defmodule Grappa.Session.EventRouterTest do
       assert IO.iodata_to_binary(line) ==
                "NOTICE alice :\x01USERINFO Age=30; Gender=X; Location=Italy; Languages=it, en; here for the vibes\x01"
 
-      assert attrs.channel == "vjt"
+      # issue 2024 — through the `#546` door, like every other CTCP query
+      # arm. No open query with alice here, so the row lands on `$server`.
+      assert attrs.channel == "$server"
       assert attrs.sender == "alice"
 
       assert attrs.body ==
@@ -671,7 +684,8 @@ defmodule Grappa.Session.EventRouterTest do
       assert IO.iodata_to_binary(line) ==
                "NOTICE alice :\x01AVATAR https://grappa.example/uploads/abc123.png\x01"
 
-      assert attrs.channel == "vjt"
+      # issue 2024 — through the `#546` door, like every other CTCP query arm.
+      assert attrs.channel == "$server"
       assert attrs.sender == "alice"
       assert attrs.body == "CTCP AVATAR query → https://grappa.example/uploads/abc123.png"
     end
@@ -683,6 +697,95 @@ defmodule Grappa.Session.EventRouterTest do
       m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
 
       assert {:cont, ^state, []} = EventRouter.route(m, state)
+    end
+
+    # issue 2024 — an inbound CTCP QUERY used to MINT the sender's window.
+    # A DM-shaped query persisted at `channel = own_nick`, `build_persist/6`
+    # set `dm_with = sender` off that key, and
+    # `Session.Server.maybe_open_query_window/2` keys on `dm_with ||
+    # channel` — so a stranger probing the bouncer opened a tab with
+    # somebody the operator never talked to. The `#546` door already
+    # answers this for NOTICE ("open query → that query, else `$server`,
+    # never auto-open") and vjt ruled the same answer here: `<< network`.
+    #
+    # 🔴 FOUR arms, not the three the issue enumerated. `ctcp_ping_reply/4`
+    # computes the identical key and was missed by the issue's own grep;
+    # it is included because leaving it would keep one inline copy of the
+    # rule beside a shared helper, which is the half-migration CLAUDE.md
+    # forbids — and because the tree ALREADY holds "CTCP is protocol, not
+    # conversation" for PING on the reply direction
+    # (`route_non_channel_notice/3`'s CTCP short-circuit names it).
+    #
+    # The oracle is `dm_with == nil`, not merely the channel. `dm_with` is
+    # what the auto-open PREFERS, so a row that moved to `$server` while
+    # keeping a peer in `dm_with` would still mint a window — asserting
+    # the channel alone would pass on exactly that bug. Same oracle the
+    # CTCP-framed NOTICE test below uses.
+    #
+    # Driven off ONE list on purpose: the cure is one shared helper, so
+    # the proof that it reaches every arm belongs in one body. Each arm's
+    # own reply text stays asserted by its own test above.
+    for {verb, overrides} <- [
+          {"VERSION", %{}},
+          {"PING 1753776000123", %{}},
+          {"USERINFO", %{profile: %{age: nil, gender: nil, location: nil, languages: nil, custom: nil}}},
+          {"AVATAR", %{avatar_url: "https://grappa.example/uploads/abc123.png"}}
+        ] do
+      test "2024 a DM-targeted CTCP #{verb} query routes to $server and mints nothing" do
+        state = base_state(unquote(Macro.escape(overrides)))
+
+        body = <<0x01>> <> unquote(verb) <> <<0x01>>
+        m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
+
+        assert {:cont, _, effects} = EventRouter.route(m, state)
+        assert {:persist, :notice, attrs} = ctcp_persist(effects)
+
+        assert attrs.channel == "$server"
+        assert attrs.dm_with == nil
+        assert attrs.sender == "alice"
+      end
+    end
+
+    # The other half of the door, and the reason this is a REUSE and not a
+    # hardcoded `$server`: with a query already open the row belongs in
+    # THAT conversation. A cure that always answered `$server` would pass
+    # every test above and fail this one.
+    test "2024 a DM-targeted CTCP query lands in the ALREADY-OPEN query, not $server" do
+      state = base_state(%{deps: deps(fn _, _, _ -> true end)})
+
+      body = <<0x01, "VERSION", 0x01>>
+      m = msg(:privmsg, ["vjt", body], {:nick, "alice", "u", "h"})
+
+      assert {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:persist, :notice, attrs} = ctcp_persist(effects)
+
+      # `channel = sender` with `dm_with: nil` is exactly the shape the
+      # NOTICE door produces post-#546 for an open window: the auto-open
+      # keys on the channel, finds the window already there, and the
+      # re-open is a no-op.
+      assert attrs.channel == "alice"
+      assert attrs.dm_with == nil
+    end
+
+    # NEGATIVE CONTROL — the channel-targeted branch is untouched. It took
+    # the `else` arm before and takes it now: the channel stays the key,
+    # `dm_with` stays nil, and it minted nothing either way. Exercised on
+    # BOTH sides of the open-window predicate, because the door must not
+    # reach this branch at all — if it did, an open query with `alice`
+    # would drag a #italia row into her window.
+    test "2024 a CHANNEL-targeted CTCP query keeps the channel key, open query or not" do
+      for open? <- [true, false] do
+        state = base_state(%{deps: deps(fn _, _, _ -> open? end)})
+
+        body = <<0x01, "VERSION", 0x01>>
+        m = msg(:privmsg, ["#italia", body], {:nick, "alice", "u", "h"})
+
+        assert {:cont, _, effects} = EventRouter.route(m, state)
+        assert {:persist, :notice, attrs} = ctcp_persist(effects)
+
+        assert attrs.channel == "#italia", "open?=#{open?} moved a channel-targeted row"
+        assert attrs.dm_with == nil
+      end
     end
 
     test "a CTCP-framed NOTICE lands on $server and mints no query window" do
@@ -895,10 +998,11 @@ defmodule Grappa.Session.EventRouterTest do
 
       assert IO.iodata_to_binary(line) == "NOTICE alice :\x01PING 1753776000123\x01"
 
-      # Same routing as VERSION: the DM-shaped query persists on the
-      # own-nick topic so the row reaches a client that has no window
-      # with this peer open yet.
-      assert attrs.channel == "vjt"
+      # Same routing as VERSION, and issue 2024 moved BOTH: a DM-shaped
+      # CTCP query goes through the `#546` door. PING is the arm the
+      # issue's own enumeration missed — it computed the identical key
+      # and minted the identical window.
+      assert attrs.channel == "$server"
       assert attrs.sender == "alice"
       assert attrs.body == "CTCP PING query → answered"
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3106,19 +3106,36 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    # #546 regression the issue called out as the one concrete casualty: the
-    # "CTCP VERSION query → grappa X" visibility row. It does NOT ride the
-    # NOTICE door at all — it is emitted by the inbound-PRIVMSG CTCP arm,
-    # persisted at `channel = own_nick` with `dm_with = sender`, and the
-    # auto-open keys off `dm_with || channel` (#422). So it survives the
-    # reversal untouched. Pinned here because "it still works" is a claim
-    # about a path #546 does not visit, and nobody should have to re-derive
-    # that from the routing table six months from now.
-    test "#546 a peer CTCP VERSION query still opens the peer's query window" do
+    # issue 2024 — REVERSED, and the reversal is a PRODUCT call, not a
+    # flake. This case used to read "#546 a peer CTCP VERSION query still
+    # opens the peer's query window" and asserted the window was minted. It
+    # was an accurate description of the code and a correct pin of the
+    # contract as it then stood; vjt ruled that contract WRONG (`<<
+    # network` on #grappa, recorded on the issue), so the assertion is
+    # INVERTED rather than relaxed. Nothing here was weakened: the same
+    # facts are asserted, with the opposite expected answer, plus the row's
+    # destination which the old case never checked.
+    #
+    # Why it matters: `dm_with || channel` (#422) is what the auto-open
+    # keys on, so a stranger who probes the bouncer used to leave a tab
+    # open with somebody the operator never talked to. The `#546` door
+    # ("open query → that query, else `$server`, never auto-open") now
+    # covers this arm too.
+    test "#546/2024 a peer CTCP VERSION query routes to $server and opens NO query window" do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
+      # BOTH topics, and each carries one half of the claim: the row rides
+      # the per-CHANNEL topic (`$server`, its new home) while
+      # `query_windows_list` rides the USER topic. Subscribing to only one
+      # is how the first draft of this test failed — against working code.
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "$server")
+        )
 
       pid = start_session_for(user, network)
       :ok = IRCServer.await_handshake(server, 1_000)
@@ -3127,14 +3144,79 @@ defmodule Grappa.Session.ServerTest do
 
       net_id = network.id
 
+      # The row must ARRIVE before the refutes mean anything — a `refute`
+      # that races the write passes for the wrong reason. Arriving on the
+      # `$server` topic IS the destination assertion, so the barrier and
+      # the positive claim are the same `assert_receive`. The body is
+      # pinned IN THE PATTERN, not asserted after binding it: a free
+      # binding takes the first `:message` in the mailbox, whatever it is.
       assert_receive %Phoenix.Socket.Broadcast{
                        event: "event",
-                       payload: %{kind: :query_windows_list, windows: %{^net_id => entries}}
+                       payload: %{
+                         kind: :message,
+                         message: %{body: "CTCP VERSION query → grappa" <> _}
+                       }
                      },
                      2_000
 
-      assert Enum.any?(entries, &(&1.target_nick == "bob"))
-      assert QueryWindows.open?({:user, user.id}, net_id, "bob")
+      refute_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :query_windows_list}
+                     },
+                     300
+
+      refute QueryWindows.open?({:user, user.id}, net_id, "bob")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The issue's own "Not measured" line: whether a peer's USERINFO probe
+    # and its AVATAR sibling mint ONE window or TWO. Answered here by
+    # exercising two DIFFERENT arms from the same peer and counting the
+    # windows that survive — post-cure the answer is zero either way, and
+    # the count (rather than a bare `refute open?`) is what distinguishes
+    # "the cure reached both arms" from "the cure reached one and the
+    # other never fired".
+    test "2024 two different CTCP query arms from one peer mint zero windows between them" do
+      {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "$server")
+        )
+
+      pid = start_session_for(user, network)
+      :ok = IRCServer.await_handshake(server, 1_000)
+
+      IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01USERINFO\x01\r\n")
+      IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01VERSION\x01\r\n")
+
+      # Both rows must have been written before the count is meaningful.
+      # VERSION is fed LAST and the session routes in arrival order, so its
+      # row arriving is a durable witness that USERINFO's is already down.
+      # Pinned in the PATTERN: `assert_receive` returns the first message
+      # that matches, and USERINFO's row is ahead of VERSION's in the
+      # mailbox — a free `body` binding would match USERINFO and retire
+      # the barrier one row too early.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :message,
+                         message: %{body: "CTCP VERSION query → grappa" <> _}
+                       }
+                     },
+                     2_000
+
+      # `list_for_subject/1` (a map keyed by network) rather than a per-nick
+      # `open?/3`: the quantity the issue asked about is a COUNT, and
+      # inspecting the whole map puts that count in the failure message
+      # instead of collapsing it to a boolean.
+      windows = QueryWindows.list_for_subject({:user, user.id})
+
+      assert windows == %{},
+             "an inbound CTCP query minted a window: #{inspect(windows)}"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
@@ -3158,9 +3240,15 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = IRCServer.start_server(IRCServer.passthrough_handler())
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
-      # The per-channel topic, not the user topic: these rows land at
-      # `channel = own_nick` (the DM-shaped key an inbound query takes), and
-      # a `:message` broadcast rides the channel topic.
+      # The per-channel topic, not the user topic, because a `:message`
+      # broadcast rides the channel topic. The own-nick topic specifically,
+      # and issue 2024 narrowed WHY: the PING visibility rows this test
+      # counts now land on `$server` (the `#546` door), but the BARRIER
+      # below is a plain PRIVMSG marker, and a peer's ordinary DM still
+      # keys at `channel = own_nick`. That door was deliberately left where
+      # it was — a DM is a conversation, a CTCP query is a probe. The
+      # counted rows are read straight off the table, so they need no
+      # subscription at all.
       :ok =
         Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
 


### PR DESCRIPTION
## What this changes

An inbound CTCP **query** (VERSION, PING, USERINFO, AVATAR) used to mint the sender's query
window. A DM-targeted query resolved its persistence key to `state.nick`, which made
`build_persist/6` set `dm_with = sender` (`Scrollback.dm_peer/4` returns the sender when the
target IS us), and `Session.Server.maybe_open_query_window/2` keys on `dm_with || channel`.

So anyone who asked the bouncer for a VERSION string left the operator **a tab open with
somebody they had never talked to**. What the receiver paid was not a line on the wire — it
was a window.

The cure is **one function, `ctcp_query_channel/3`**, replacing **four** inline copies of the
same three lines, and it **CALLS** `open_query_or_server/2` — the #546 door itself — instead
of restating it. A second copy of "open query wins, else `$server`" would drift, and the
reason this arm was broken in the first place is that the rule lived in one branch while the
traffic arrived on another.

## Provenance of the ruling

The routing question was **not** ours to answer. It was put to vjt on `#grappa` and answered
there at **08:45 Europe/Rome**, verbatim **`<< network`**, in reply to:

> *does an inbound CTCP query in a DM go to the network window (the #546 door), or does it
> keep minting the peer's query window?*

**This reached me RELAYED, and I verified it on the issue, not on IRC** — reading IRC is
closed to me. It is recorded as issue comment `5597364131`, which is the artefact I read and
the one a reviewer should read.

## Four arms, not three

The issue enumerates three. There are **four**: `ctcp_ping_reply/4` computes the identical
key with the identical consequence and the issue does not list it. Measured twice,
independently: once by walking the call sites, once by the RED — **exactly four** pre-existing
assertions fell on `left: "vjt"`, one per arm. All four are cured, because curing three would
leave the defect reachable by a PING probe and leave a fourth copy of the rule to drift.

That same evidence answers the question the issue flagged as unmeasured: USERINFO and AVATAR
minted **ONE** window per peer, **not two** — the four arms produce the **same** key from the
same inputs, and `QueryWindows.open/4` is keyed on it.

## A reversed pin, and why that is not a weakened test

`server_test.exs` pinned the old behaviour by name:

- was: `"#546 a peer CTCP VERSION query still opens the peer's query window"`
- now: `"#546/2024 a peer CTCP VERSION query routes to $server and opens NO query window"`

**This spec changed because the product owner ruled the asserted behaviour WRONG — NOT
because it was flaky.** It is not weakened: same facts, same setup, opposite answer, **plus**
the destination of the visibility row, which the old case did not check at all. The `#546`
reference stays in the name so the lineage is greppable.

New coverage alongside it:

- `event_router_test.exs` — `"2024 a DM-targeted CTCP <verb> query routes to $server and mints
  nothing"`, parameterised over all four verbs (VERSION, PING, USERINFO, AVATAR).
- `"2024 a DM-targeted CTCP query lands in the ALREADY-OPEN query, not $server"` — an open
  conversation still claims the row; the door is not a redirect-everything.
- `"2024 a CHANNEL-targeted CTCP query keeps the channel key, open query or not"` — the
  **negative control**. It was GREEN before and GREEN after, never red, which is exactly how a
  control must behave.
- `server_test.exs` — `"2024 two different CTCP query arms from one peer mint zero windows
  between them"`.
- e2e — `cicchetto/e2e/tests/issue2024-ctcp-query-no-minted-tab.spec.ts`, a real browser
  against a real grappa and a real ircd.

The RED was **9 failures, ALL on the DM branch**; the channel control never moved.

## The third door

`open_query_or_server/2`'s doc said "two doors, deliberately asymmetric". There are **THREE**,
and the axis is **conversation vs control surface**, not NOTICE vs PRIVMSG:

- **NOTICE** (`route_non_channel_notice_non_chanserv/3`) — every nick sender.
- **CTCP QUERY** (`ctcp_query_channel/3`) — every nick sender. A probe is a control surface,
  and it arrives as a PRIVMSG, which is why it walked past the door.
- **PRIVMSG** (`privmsg_default/3`) — services senders ONLY. A peer's ordinary DM still opens
  the conversation; it is the one arm of the three that still mints.

## What I refuse to assert — please do not promote any of it to fact

- **That the cic arm is dead.** `cicchetto/src/lib/subscribe.ts` (own-nick NOTICE branch)
  documented this visibility row as the last thing still arriving there after #546. It no
  longer arrives. I corrected **only the comment**; the branch stays, because I did not
  enumerate its input set, and deleting a renderer branch whose inputs you have not measured is
  how a whole class goes quiet.
- **Nothing about the SENDER side.** The fan-out (`maybe_query_peer_profile/2` on JOIN and 353)
  is rate-limited **per sender** (`{subject, network_id}`), which does not bound the aggregate
  ONE recipient receives from N sessions. That is a different slice; it is not redesigned here.
- **The `LucentW` Excess Flood kill on Libera (02:23) is ONE sighting**, not reproduced and not
  tied to this path. It is neither a cause nor a motive for this change.
- **Whether USERINFO/AVATAR replies should be SHOWN**: a product call nobody has made, and the
  ruling does not touch it. Each still mints a visibility row; left exactly as they are.
- **A premise of my own, falsified by me.** I was about to write "e2e is impossible here, the
  harness talks to a fixture". **False**: the stack runs a REAL grappa against the testnet
  ircd, `IrcPeer.connect` gives a real peer, and a CTCP is a PRIVMSG with the body between
  delimiters. I wrote the spec and **retracted the wrong line in DESIGN_NOTES in its own
  commit** (`a06c88d5e`). If anyone cites that old line, it is withdrawn.

## Gates

| gate | result |
|---|---|
| `scripts/check.sh` (server, full) | GREEN rc=0 — ExUnit 7228 tests / 0 failures (8 doctests, 65 properties, 38 excluded); dialyzer `Total errors: 0`; credo `6852 mods/funs, no issues`; doctor `Failed Modules: 0`; sobelow ok |
| `scripts/bun.sh run check` | GREEN — 5/5 stages |
| `scripts/bun.sh run test` | GREEN — 341 files / 6881 tests |
| `scripts/design-notes-gate.sh` | GREEN — `1 new entry heading` |
| `scripts/integration.sh` (full e2e) | 961 passed / 1 skipped / **1 failed — pre-existing, see below**; `chromium` 664, `chromium-pixel-touch` 145, `webkit-iphone-15` 152 |

The new e2e spec is **GREEN**: `2024 — an inbound CTCP query lands in the network window and
mints no tab` (chromium, 855ms).

The single failure is `issue1964-upload-confirm-preview.spec.ts:97` — *"#1964 — each staged
file previews as what it actually is"* — and it is **NOT from this branch**. Evidence, not
distribution:

- An **earlier full run on the same host finished at 03:19 today with the identical failure**
  (same test, same ordinal 232, same 6.0s, same `1 failed / 1 skipped`). Every commit on this
  branch is timestamped 09:07–09:11, so that tree could not have contained them.
- The failing assertion (`HTMLVideoElement.error.code`, expected 0, got 4 =
  `MEDIA_ERR_SRC_NOT_SUPPORTED`) was introduced on main yesterday by `106ae53b0`.
- The page snapshot shows the dialog rendering correctly — all five staged rows, video and
  audio players present. The defect is in media decode, not in the UI.
- This branch touches no CSP, upload, video or blob code. The only cic runtime file it touches
  (`subscribe.ts`) is **comment-only — zero code lines changed**.
- The CSP genuinely carries `media-src 'self' blob: https:`, so a blocked `blob:` is not the
  explanation. The fixture `tiny.mp4` is H.264 (`avc1`), unchanged since June and byte-identical
  to main.

I have **not** established the root cause, and I am not guessing at one here.

Two intermediate reds were **mine, in the SETUP** (wrong topic; a pattern with a free `body`
that matched the first line in the mailbox). I made the setup deterministic — **no timeout was
raised and no assertion was weakened.**

Refs issue 2024.
