### PR TITLE
cic/iOS: refuse a menu activation from the gesture that opened it, and name the door on device

### DIFF
--- a/cicchetto/src/ContextMenu.tsx
+++ b/cicchetto/src/ContextMenu.tsx
@@ -1,5 +1,16 @@
-import { type Component, createEffect, createSignal, For, on, Show } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  For,
+  on,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
 import { Portal } from "solid-js/web";
+import { isDiagEnabled } from "./DiagFloat";
+import { diagPush } from "./lib/diagLog";
 import { computeMenuPosition, type MenuAnchor } from "./lib/menuPosition";
 import { createOverlayEscape } from "./lib/overlayScrollLock";
 import { isCoarsePointer } from "./lib/platform";
@@ -101,9 +112,76 @@ const ContextMenu: Component<Props> = (props) => {
   // UIKit as a page pan while the menu itself — `position: fixed` — stayed put
   // and the content slid out from under it. The stylesheet half (backdrop
   // claims the stream, menu re-opens its own pan) is in `default.css`.
+  // issue 1956 — the menu must not be closed, and no item fired, by the very
+  // gesture that OPENED it.
+  //
+  // On iOS a long-press opens this menu 500ms into a touch that is STILL DOWN,
+  // and `.context-menu-backdrop` (`position: fixed; inset: 0`) lands under the
+  // finger. When that finger lifts, WebKit synthesizes mousemove/mousedown/
+  // mouseup/click at the touch point; the click hit-tests the backdrop and
+  // closes the menu before it can be read. `lib/messageGestures` tries to
+  // swallow that release with `preventDefault` on the touchend, but that is
+  // conditional on `e.cancelable`, and on device it is failing — keyboard-down
+  // only, three sightings, prod 1.5.4-c911f7cc.
+  //
+  // The guard is CAUSAL, not a timeout: the opening gesture's `pointerdown`
+  // fired BEFORE this component existed, so a menu is born DISARMED and the
+  // click synthesized from that same gesture finds no arm. Every genuine
+  // interaction — a tap outside, a tap on an item, a mouse click — begins with a
+  // fresh `pointerdown`, which arms it.
+  //
+  // 🔴 It MUST arm on `pointerdown`, NEVER on `mousedown`: the synthesized
+  // mousedown PRECEDES the click inside the same release, so arming there would
+  // arm exactly the click this exists to refuse — a no-op that reads as applied.
+  // `touchstart` is the fallback for an engine without Pointer Events.
+  //
+  // Why it is here and not in the long-press binder: the defect is not "the
+  // scrollback's gesture leaks", it is "a menu can be actioned by the gesture
+  // that opened it", which is true of every door this shell has (the #1115
+  // desktop `contextmenu` door, and the nick + admin menus that share it).
+  // Fixing it at the opener would leave the other doors open.
+  const [armed, setArmed] = createSignal(false);
+  onMount(() => {
+    const arm = (): void => {
+      setArmed(true);
+    };
+    // Capture, so a handler that stops propagation cannot starve the arm.
+    document.addEventListener("pointerdown", arm, { capture: true });
+    document.addEventListener("touchstart", arm, { capture: true, passive: true });
+    onCleanup(() => {
+      document.removeEventListener("pointerdown", arm, { capture: true });
+      document.removeEventListener("touchstart", arm, { capture: true });
+    });
+  });
+
+  // issue 1956, the diagnosis half — WHICH door closed the menu. The reported
+  // symptom cannot say, and the two candidates want different cures: a release
+  // WebKit refused to let us cancel, or a close arriving through another door.
+  // Gated like every other diag line (keepKeyboard:200-205); a no-op with the
+  // flag off.
+  const reportAndClose = (door: string): void => {
+    if (isDiagEnabled()) diagPush(`menu: close via ${door}`);
+    props.onClose();
+  };
+
+  // May this menu act on a pointer event? It logs its OWN refusal, and that is
+  // load-bearing rather than tidy: once the guard is in, a menu that correctly
+  // stays put is SILENT, and silence cannot tell "the click was refused" from
+  // "no click ever arrived" — which is exactly the pair the on-device
+  // diagnosis has to separate. Without this line the cure blinds the
+  // instrument that says which candidate it closed.
+  const mayAct = (door: string): boolean => {
+    if (armed()) return true;
+    if (isDiagEnabled()) diagPush(`menu: REFUSED ${door} (no fresh press since open)`);
+    return false;
+  };
+
+  // Escape is deliberately OUTSIDE the guard: a way out that is always
+  // available must not depend on having pressed something first, and no
+  // synthesized touch sequence can produce a keydown.
   createOverlayEscape(
     () => true,
-    () => props.onClose(),
+    () => reportAndClose("escape"),
   );
 
   // #1192 — the drill-down level, held as an INDEX into `props.items` rather
@@ -137,19 +215,34 @@ const ContextMenu: Component<Props> = (props) => {
   createEffect(
     on(
       () => [props.position.x, props.position.y],
-      () => setDrilledIndex(null),
+      () => {
+        setDrilledIndex(null);
+        // issue 1956 — and the arm resets for the same reason: a reused
+        // instance would otherwise carry the PREVIOUS interaction's press into
+        // the new open, and the second menu would be born armed against the
+        // gesture that opened it. A fresh mount needs no reset (the signal
+        // starts false); this covers only the value→value reuse.
+        setArmed(false);
+      },
       { defer: true },
     ),
   );
 
   const handleItemClick = (item: ContextMenuItem, index: number): void => {
     if (!item.enabled) return;
+    // issue 1956 — the same refusal the backdrop takes, and it sits BEFORE the
+    // action on purpose. #2014 puts the menu's bottom-right corner ON the press
+    // point, so the item nearest the finger is a pixel from the synthesized
+    // click: unguarded, a gesture the operator meant only as "open the menu"
+    // could FIRE a verb (Copy, Reply, !addquote, Select…). Refusing after the
+    // action would close the barn door.
+    if (!mayAct(`item:${item.label}`)) return;
     if ("submenu" in item) {
       setDrilledIndex(index);
       return;
     }
     item.action();
-    props.onClose();
+    reportAndClose(`item:${item.label}`);
   };
 
   let menuRef: HTMLDivElement | undefined;
@@ -223,7 +316,9 @@ const ContextMenu: Component<Props> = (props) => {
         type="button"
         class="context-menu-backdrop"
         aria-label="Close menu"
-        onClick={props.onClose}
+        onClick={() => {
+          if (mayAct("backdrop")) reportAndClose("backdrop");
+        }}
       />
       <div
         ref={menuRef}

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -10,6 +10,7 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { isDiagEnabled } from "./DiagFloat";
 import LusersCard from "./LusersCard";
 import { isContentKind, ownNickForNetwork, type ScrollbackMessage } from "./lib/api";
 import { casemappingForSlug, sigilRankForSlug } from "./lib/casemapping";
@@ -27,6 +28,7 @@ import {
 import { isChannelName } from "./lib/chantypes";
 import { type CommandOutputEntry, commandOutputByWindow } from "./lib/commandOutput";
 import { stripCtcpAction } from "./lib/ctcpAction";
+import { diagPush } from "./lib/diagLog";
 import { isDocumentVisible } from "./lib/documentVisibility";
 import { highlightPatterns } from "./lib/highlightList";
 import { type InviteAckEntry, inviteAckBySlug } from "./lib/inviteAck";
@@ -41,7 +43,7 @@ import {
 } from "./lib/mentionScroll";
 import { bindMessageContextMenu } from "./lib/messageContextMenu";
 import { bindMessageGestures } from "./lib/messageGestures";
-import { closeMessageMenu, openMessageMenu } from "./lib/messageMenu";
+import { closeMessageMenu, messageMenu, openMessageMenu } from "./lib/messageMenu";
 import { networkIdBySlug, networks, user } from "./lib/networks";
 import { snapshotSenderPrefix } from "./lib/nickColor";
 import { nickEquals } from "./lib/nickEquals";
@@ -2198,7 +2200,18 @@ const ScrollbackPane: Component<Props> = (props) => {
     }
     // A menu left open over a row this pane is about to destroy would float
     // above the next channel, still holding a detached element.
-    onCleanup(closeMessageMenu);
+    //
+    // issue 1956 — the FOURTH door to a closed menu, and the only one outside
+    // `ContextMenu`. It is named in the diag so the on-device log can tell a
+    // menu that vanished under the finger from one the pane tore down; the
+    // guard on the read keeps the line honest (log honesty: state what was
+    // OBSERVED, so a channel switch with no menu up says nothing at all).
+    onCleanup(() => {
+      if (messageMenu() !== null && isDiagEnabled()) {
+        diagPush("menu: close via unmount (pane cleanup)");
+      }
+      closeMessageMenu();
+    });
 
     // #285 — ResizeObserver on the scroll container so the gate follows REAL
     // container geometry, not just discrete events. It fires on ANY container

--- a/cicchetto/src/__tests__/ContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/ContextMenu.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import ContextMenu, { type ContextMenuItem } from "../ContextMenu";
+import { setDiagEnabled } from "../DiagFloat";
+import { diagLog } from "../lib/diagLog";
+import { runTopmostOverlayEscape } from "../lib/overlayScrollLock";
+import { pressAndClick } from "./helpers/pointerEvents";
 
 // #949 — the WIRING half of the safe-area clamp. The arithmetic is pinned as a
 // pure fn (lib/menuPosition.test.ts) and the stylesheet rules at source level
@@ -126,7 +130,7 @@ describe("ContextMenu safe-area placement (#949)", () => {
     // Now the taller level. 700 + 400 overflows too, and the flip lands at 300 —
     // a value only a RE-measurement can produce.
     height = 400;
-    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
     expect(menuEl.style.top).toBe("300px");
   });
 
@@ -162,7 +166,7 @@ describe("ContextMenu drill-down (#1192)", () => {
     const onClose = vi.fn();
     render(() => <ContextMenu items={NESTED} position={{ x: 10, y: 10 }} onClose={onClose} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
 
     // The group row is a NAVIGATION, not an invocation: closing here would make
     // the six verbs unreachable.
@@ -174,8 +178,8 @@ describe("ContextMenu drill-down (#1192)", () => {
     const onClose = vi.fn();
     render(() => <ContextMenu items={NESTED} position={{ x: 10, y: 10 }} onClose={onClose} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
-    fireEvent.click(screen.getByRole("button", { name: /^version$/i }));
+    pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    pressAndClick(screen.getByRole("button", { name: /^version$/i }));
 
     expect(VERSION_ACTION).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -185,8 +189,8 @@ describe("ContextMenu drill-down (#1192)", () => {
     const onClose = vi.fn();
     render(() => <ContextMenu items={NESTED} position={{ x: 10, y: 10 }} onClose={onClose} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
-    fireEvent.click(screen.getByRole("button", { name: /^‹ ctcp$/i }));
+    pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    pressAndClick(screen.getByRole("button", { name: /^‹ ctcp$/i }));
 
     expect(labels()).toEqual(["whois", "ctcp ▸", "query"]);
     expect(onClose).not.toHaveBeenCalled();
@@ -201,11 +205,173 @@ describe("ContextMenu drill-down (#1192)", () => {
     const [position, setPosition] = createSignal({ x: 10, y: 10 });
     render(() => <ContextMenu items={NESTED} position={position()} onClose={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+    pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
     expect(labels()).toEqual(["‹ ctcp", "VERSION", "TIME"]);
 
     setPosition({ x: 400, y: 400 });
 
     expect(labels()).toEqual(["whois", "ctcp ▸", "query"]);
+  });
+});
+
+// issue 1956 — the menu refuses a pointer activation until it has seen a press
+// that BEGAN after it opened.
+//
+// The defect: on iOS the long-press menu opens 500ms into a touch that is STILL
+// DOWN, and `.context-menu-backdrop` (fixed, inset 0) lands under the finger.
+// When the finger lifts, WebKit synthesizes a click at the touch point; it
+// hit-tests the backdrop and closes the menu before it can be read — reported
+// three times, keyboard-down only, prod 1.5.4-c911f7cc. `lib/messageGestures`
+// tries to swallow that release, but only `if (e.cancelable)`.
+//
+// The guard is causal, not timed: the opening gesture's `pointerdown` fired
+// before this component existed, so the menu is born disarmed. These are the
+// tests that fail if it is ever removed — every other menu test now presses
+// first (helpers/pointerEvents), so this block is the only one that can tell.
+//
+// What jsdom does NOT prove: that WebKit synthesizes that click at all, or that
+// it is what vjt is seeing. That is the on-device half, and the diag lines in
+// the same change are what will answer it.
+describe("issue 1956 — activation needs a press that began after the menu opened", () => {
+  it("refuses a bare click on the backdrop — the shape of the synthesized one", () => {
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /close menu/i }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes on a backdrop click that a fresh press preceded", () => {
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    pressAndClick(screen.getByRole("button", { name: /close menu/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a bare click on an ITEM, and does not run its action", () => {
+    // #2014 puts the menu's bottom-right corner ON the press point, so the item
+    // nearest the finger is a pixel from the synthesized click: unguarded, the
+    // gesture that only meant "open the menu" would FIRE a verb.
+    const action = vi.fn();
+    const onClose = vi.fn();
+    render(() => (
+      <ContextMenu
+        items={[{ label: "whois", enabled: true, action }]}
+        position={{ x: 10, y: 10 }}
+        onClose={onClose}
+      />
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: /^whois$/i }));
+
+    expect(action).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("runs an item action once a fresh press preceded the click", () => {
+    const action = vi.fn();
+    const onClose = vi.fn();
+    render(() => (
+      <ContextMenu
+        items={[{ label: "whois", enabled: true, action }]}
+        position={{ x: 10, y: 10 }}
+        onClose={onClose}
+      />
+    ));
+
+    pressAndClick(screen.getByRole("button", { name: /^whois$/i }));
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets Escape out with no press at all — the guard is pointer-only", () => {
+    // A way out that is always available must not depend on having pressed
+    // something first, and no synthesized touch sequence produces a keydown.
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    expect(runTopmostOverlayEscape()).toBe(true);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-disarms when the same instance is re-opened at new coordinates", () => {
+    // The two call sites reuse this instance across a value→value change. A
+    // press made against the FIRST menu must not arm the second one, or the
+    // reused instance walks straight back into the defect.
+    const [position, setPosition] = createSignal({ x: 10, y: 10 });
+    const onClose = vi.fn();
+    render(() => <ContextMenu items={ITEMS} position={position()} onClose={onClose} />);
+
+    document.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    setPosition({ x: 400, y: 400 });
+    fireEvent.click(screen.getByRole("button", { name: /close menu/i }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// issue 1956, the diagnosis half — and the reason the guard logs its OWN
+// refusal rather than just returning.
+//
+// Once the cure is in, a menu that correctly stays put is SILENT, and silence
+// cannot tell "the synthesized click arrived and was refused" from "no click
+// ever arrived". Those are exactly the two candidates the on-device round has
+// to separate, so the cure would blind the instrument that says which one it
+// closed. These pin that it does not.
+describe("issue 1956 — the on-device diag names the door", () => {
+  afterEach(() => {
+    setDiagEnabled(false);
+  });
+
+  it("names the refused door, so a menu that stays up is not silent", () => {
+    setDiagEnabled(true);
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /close menu/i }));
+
+    expect(diagLog()[0]).toContain("REFUSED backdrop");
+  });
+
+  it("names the door that actually closed it", () => {
+    setDiagEnabled(true);
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+
+    pressAndClick(screen.getByRole("button", { name: /close menu/i }));
+
+    expect(diagLog()[0]).toContain("close via backdrop");
+  });
+
+  it("distinguishes an item from the backdrop, and names WHICH item", () => {
+    setDiagEnabled(true);
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+
+    pressAndClick(screen.getByRole("button", { name: /^whois$/i }));
+
+    expect(diagLog()[0]).toContain("close via item:whois");
+  });
+
+  it("names Escape too, so the keyboard exit is not mistaken for a vanish", () => {
+    setDiagEnabled(true);
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+
+    runTopmostOverlayEscape();
+
+    expect(diagLog()[0]).toContain("close via escape");
+  });
+
+  it("costs nothing with the flag off — neither door pushes a line", () => {
+    setDiagEnabled(false);
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+    const before = diagLog();
+
+    fireEvent.click(screen.getByRole("button", { name: /close menu/i })); // refused
+    pressAndClick(screen.getByRole("button", { name: /close menu/i })); // closed
+
+    expect(diagLog()).toBe(before);
   });
 });

--- a/cicchetto/src/__tests__/MessageContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/MessageContextMenu.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { render, screen } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ScrollbackMessage } from "../lib/api";
 import { channelKey } from "../lib/channelKey";
 import { getDraft, setDraft } from "../lib/compose";
 import { closeMessageMenu, openMessageMenu, SELECTING_CLASS } from "../lib/messageMenu";
 import MessageContextMenu from "../MessageContextMenu";
+import { pressAndClick } from "./helpers/pointerEvents";
 
 // #1106 — the ORDERING half of "Select… installs no visible selection while the
 // compose keyboard is open".
@@ -90,7 +91,7 @@ describe("Select… with the compose keyboard up", () => {
       delivered.push(window.getSelection()?.toString() ?? "");
     });
 
-    fireEvent.click(screen.getByText("Select…"));
+    pressAndClick(screen.getByText("Select…"));
     expect(document.querySelectorAll(".context-menu")).toHaveLength(0);
 
     await settle();
@@ -154,7 +155,7 @@ describe("the !addquote item", () => {
     mountCompose();
     render(() => <MessageContextMenu />);
     openOver(scrollbackRow("12:34 <vjt> ciao"), { body: "ciao mondo" });
-    fireEvent.click(screen.getByText("!addquote"));
+    pressAndClick(screen.getByText("!addquote"));
     expect(getDraft(KEY)).toBe("!addquote <vjt> ciao mondo");
   });
 

--- a/cicchetto/src/__tests__/UserContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/UserContextMenu.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { render, screen } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { pressAndClick } from "./helpers/pointerEvents";
 
 // C5.1 — UserContextMenu: right-click submenu on member nick.
 //
@@ -145,43 +146,43 @@ describe("UserContextMenu", () => {
   describe("actions dispatch to correct socket helpers (ownModes = [@])", () => {
     it("Op button calls pushChannelOp with networkId, channel, [nick]", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^op$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^op$/i }));
       expect(mockPushChannelOp).toHaveBeenCalledWith(42, "#grappa", ["alice"]);
     });
 
     it("Deop button calls pushChannelDeop", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^deop$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^deop$/i }));
       expect(mockPushChannelDeop).toHaveBeenCalledWith(42, "#grappa", ["alice"]);
     });
 
     it("Voice button calls pushChannelVoice", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^voice$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^voice$/i }));
       expect(mockPushChannelVoice).toHaveBeenCalledWith(42, "#grappa", ["alice"]);
     });
 
     it("Devoice button calls pushChannelDevoice", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^devoice$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^devoice$/i }));
       expect(mockPushChannelDevoice).toHaveBeenCalledWith(42, "#grappa", ["alice"]);
     });
 
     it("Kick button calls pushChannelKick with empty reason", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^kick$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^kick$/i }));
       expect(mockPushChannelKick).toHaveBeenCalledWith(42, "#grappa", "alice", "");
     });
 
     it("Ban button calls pushChannelBan with nick!*@* fallback mask", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^ban$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^ban$/i }));
       expect(mockPushChannelBan).toHaveBeenCalledWith(42, "#grappa", "alice!*@*");
     });
 
     it("Query button calls openQueryWindowState and setSelectedChannel", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^query$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^query$/i }));
       expect(mockOpenQueryWindowState).toHaveBeenCalledWith(42, "alice", expect.any(String));
       expect(mockSetSelectedChannel).toHaveBeenCalledWith({
         networkSlug: "freenode",
@@ -192,7 +193,7 @@ describe("UserContextMenu", () => {
 
     it("CTCP drills into the six verbs instead of acting", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
 
       // The whole point of the group: six verbs behind ONE row, so the nick
       // menu does not grow to fourteen.
@@ -207,8 +208,8 @@ describe("UserContextMenu", () => {
     it("a CTCP verb dispatches against the SOURCE window, with no invented args", async () => {
       vi.spyOn(Date, "now").mockReturnValue(1706743200000);
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
-      fireEvent.click(screen.getByRole("button", { name: /^version$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^version$/i }));
 
       // `sourceChannel` is the window the operator is looking at (#640) and the
       // recipient travels separately — the probe must not mint a query tab.
@@ -232,8 +233,8 @@ describe("UserContextMenu", () => {
       // the drift #1192 moved the ordering into the seam to prevent.
       vi.spyOn(Date, "now").mockReturnValue(1706743200000);
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^ctcp ▸$/i }));
-      fireEvent.click(screen.getByRole("button", { name: /^ping$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^ctcp ▸$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^ping$/i }));
 
       expect(mockSendCtcpQuery).toHaveBeenCalledWith({
         networkSlug: "freenode",
@@ -249,7 +250,7 @@ describe("UserContextMenu", () => {
 
     it("WHOIS button calls pushWhois with networkId and nick (server null)", async () => {
       render(() => <UserContextMenu {...baseProps} ownModes={["@"]} />);
-      fireEvent.click(screen.getByRole("button", { name: /^whois$/i }));
+      pressAndClick(screen.getByRole("button", { name: /^whois$/i }));
       // #198 — context-menu WHOIS is single-nick: null target-server.
       expect(mockPushWhois).toHaveBeenCalledWith(42, "alice", null);
     });
@@ -261,7 +262,7 @@ describe("UserContextMenu", () => {
       render(() => <UserContextMenu {...baseProps} onClose={onClose} />);
       const backdrop = document.querySelector(".context-menu-backdrop");
       expect(backdrop).toBeInTheDocument();
-      if (backdrop) fireEvent.click(backdrop);
+      if (backdrop) pressAndClick(backdrop);
       expect(onClose).toHaveBeenCalled();
     });
 

--- a/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
+++ b/cicchetto/src/__tests__/adminSessionsActionsMenu.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { render, screen } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AdminCredential, AdminNetwork, AdminVisitor } from "../lib/api";
+import { pressAndClick } from "./helpers/pointerEvents";
 
 // #1157 — the dictated column 4: on a phone the row's verbs "collapse
 // into ONE button with a dropdown" (vjt, 2026-08-09). Desktop keeps them
@@ -159,7 +160,7 @@ describe("#1157 — column 4 collapses on a phone", () => {
     await mountWith({ credentials: [userCredential()] });
     await screen.findByTestId(`admin-session-row-${USER_KEY}`);
 
-    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+    pressAndClick(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
 
     const menu = screen.getByRole("menu");
     expect(menu.textContent).toContain("Disconnect");
@@ -172,8 +173,8 @@ describe("#1157 — column 4 collapses on a phone", () => {
     await mountWith({ credentials: [userCredential()] });
     await screen.findByTestId(`admin-session-row-${USER_KEY}`);
 
-    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
-    fireEvent.click(screen.getByText("Terminate"));
+    pressAndClick(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+    pressAndClick(screen.getByText("Terminate"));
 
     const api = await import("../lib/api");
     // The destructive verb has NOT fired: the menu replaces the arm step,
@@ -190,9 +191,9 @@ describe("#1157 — column 4 collapses on a phone", () => {
     await mountWith({ credentials: [userCredential()] });
     await screen.findByTestId(`admin-session-row-${USER_KEY}`);
 
-    fireEvent.click(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
-    fireEvent.click(screen.getByText("Terminate"));
-    fireEvent.click(screen.getByTestId(`admin-session-actions-cancel-${USER_KEY}`));
+    pressAndClick(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`));
+    pressAndClick(screen.getByText("Terminate"));
+    pressAndClick(screen.getByTestId(`admin-session-actions-cancel-${USER_KEY}`));
 
     expect(screen.queryByTestId(`admin-session-terminate-${USER_KEY}`)).toBeNull();
     expect(screen.getByTestId(`admin-session-actions-menu-${USER_KEY}`)).toBeTruthy();

--- a/cicchetto/src/__tests__/helpers/pointerEvents.ts
+++ b/cicchetto/src/__tests__/helpers/pointerEvents.ts
@@ -1,0 +1,28 @@
+import { fireEvent } from "@solidjs/testing-library";
+
+// issue 1956 — `ContextMenu` refuses a pointer activation until it has seen a
+// press that BEGAN after it opened. On iOS the long-press menu opens 500ms into
+// a touch that is still down, and the click WebKit synthesizes when that finger
+// lifts lands on the menu's own full-viewport backdrop: without the guard it
+// closes the menu, or fires the item nearest the finger, before either can be
+// read.
+//
+// This helper is NOT a way past that guard. `fireEvent.click` dispatches a bare
+// `click`, which no browser ever produces — a real activation is always
+// preceded by a `pointerdown`. So a test that means "the operator picked this
+// item" has to say it the way the platform says it, or it is asserting against
+// a DOM sequence that cannot occur. The helper makes the simulation FAITHFUL;
+// the guard is what changed, and the contract with it.
+//
+// The refusal has its own direct coverage (`ContextMenu.test.tsx`, the
+// "issue 1956" block): a bare click with no press must NOT act, and that is the
+// test which fails if the guard is ever removed. These call sites assert the
+// other half — that a real press-then-click still works, on every door and
+// every menu that shares this shell.
+//
+// A plain `Event` rather than a `PointerEvent`: jsdom ships no PointerEvent
+// constructor, and the guard reads nothing off the event but its arrival.
+export function pressAndClick(el: Element): void {
+  el.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+  fireEvent.click(el);
+}

--- a/cicchetto/src/__tests__/helpers/touchEvents.ts
+++ b/cicchetto/src/__tests__/helpers/touchEvents.ts
@@ -10,15 +10,44 @@
 
 export type TouchPoint = { clientX: number; clientY: number };
 
-export function fireTouch(el: HTMLElement, type: string, ...points: TouchPoint[]): Event {
-  const ev = new Event(type, { bubbles: true, cancelable: true });
+// The ONE dispatcher the three wrappers below share. Extracted when issue 1956
+// needed a NON-cancelable touchend: a third near-copy of the same nine lines is
+// how the `touches` / `changedTouches` shaping drifts between them, and the
+// shaping is the part every gesture listener actually reads.
+function dispatchTouch(
+  el: HTMLElement,
+  type: string,
+  init: { cancelable: boolean; timeStamp?: number },
+  points: TouchPoint[],
+): Event {
+  const ev = new Event(type, { bubbles: true, cancelable: init.cancelable });
   const list = points as unknown as TouchList;
   Object.defineProperty(ev, "touches", {
     value: type === "touchend" ? ([] as unknown as TouchList) : list,
   });
   Object.defineProperty(ev, "changedTouches", { value: list });
+  if (init.timeStamp !== undefined) {
+    Object.defineProperty(ev, "timeStamp", { value: init.timeStamp });
+  }
   el.dispatchEvent(ev);
   return ev;
+}
+
+export function fireTouch(el: HTMLElement, type: string, ...points: TouchPoint[]): Event {
+  return dispatchTouch(el, type, { cancelable: true }, points);
+}
+
+// issue 1956 — a touch the browser will NOT let a listener cancel. WebKit hands
+// these out once it has decided the gesture is its own, and `preventDefault` on
+// one is SILENT: no throw, no `defaultPrevented`, so a shield built on it reads
+// applied while doing nothing. Candidate A of the iOS long-press-menu diagnosis
+// is exactly that shape, which is why the suite has to be able to spell it.
+export function fireTouchUncancelable(
+  el: HTMLElement,
+  type: string,
+  ...points: TouchPoint[]
+): Event {
+  return dispatchTouch(el, type, { cancelable: false }, points);
 }
 
 // Same, with a chosen `timeStamp` — for gestures whose decision reads the clock
@@ -34,15 +63,7 @@ export function fireTouchAt(
   timeStamp: number,
   ...points: TouchPoint[]
 ): Event {
-  const ev = new Event(type, { bubbles: true, cancelable: true });
-  const list = points as unknown as TouchList;
-  Object.defineProperty(ev, "touches", {
-    value: type === "touchend" ? ([] as unknown as TouchList) : list,
-  });
-  Object.defineProperty(ev, "changedTouches", { value: list });
-  Object.defineProperty(ev, "timeStamp", { value: timeStamp });
-  el.dispatchEvent(ev);
-  return ev;
+  return dispatchTouch(el, type, { cancelable: true, timeStamp }, points);
 }
 
 // One full edge swipe: start → two moves → end. The intermediate moves are what

--- a/cicchetto/src/__tests__/messageGestures.test.ts
+++ b/cicchetto/src/__tests__/messageGestures.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { setDiagEnabled } from "../DiagFloat";
+import { diagLog } from "../lib/diagLog";
 import { LONG_PRESS_MS } from "../lib/keepKeyboard";
 import {
   bindMessageGestures,
@@ -10,7 +12,7 @@ import {
   SWIPING_CLASS,
 } from "../lib/messageGestures";
 import { disarmMessageSelection, SELECTING_CLASS } from "../lib/messageMenu";
-import { fireTouch } from "./helpers/touchEvents";
+import { fireTouch, fireTouchUncancelable } from "./helpers/touchEvents";
 
 // #1067 — the scrollback's ONE touch-gesture owner: a left→right swipe on a
 // message row fills the compose box with a quote, a stationary hold opens the
@@ -268,6 +270,64 @@ describe("bindMessageGestures — long press = message menu", () => {
     const end = fireTouch(body, "touchend", { clientX: CENTER_X, clientY: 300 });
     expect(onReply).not.toHaveBeenCalled();
     expect(end.defaultPrevented).toBe(true);
+  });
+
+  // issue 1956 — the shield above is the ONE thing standing between the release
+  // of a hold and a synthesized click onto the menu's own backdrop, and it is
+  // conditional on `e.cancelable`. On a non-cancelable touchend `preventDefault`
+  // is silent — no throw, no `defaultPrevented` — so the shield reads applied
+  // while doing nothing, and nothing off-device can say which of the two vjt's
+  // iPhone hands it. These pin the INSTRUMENT that will answer that: the line
+  // must carry the value OBSERVED, both ways, and must cost nothing with the
+  // flag off.
+  //
+  // `diagLog` is a module-level ring with no reset (deliberately: a reset export
+  // would be test-only API on a production module), so every assertion here
+  // reads the NEWEST entry — diagPush prepends — or compares the whole array
+  // across the action. That is leak-proof under any test order.
+  describe("issue 1956 — the cancelable of the release after a hold", () => {
+    afterEach(() => {
+      setDiagEnabled(false);
+    });
+
+    function holdThenRelease(uncancelable: boolean): Event {
+      fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+      const fire = uncancelable ? fireTouchUncancelable : fireTouch;
+      return fire(body, "touchend", { clientX: CENTER_X, clientY: 300 });
+    }
+
+    it("records cancelable=true when the release can be cancelled", () => {
+      setDiagEnabled(true);
+      const end = holdThenRelease(false);
+      expect(diagLog()[0]).toContain("cancelable=true");
+      // The shield really did fire — the line is not describing a hypothetical.
+      expect(end.defaultPrevented).toBe(true);
+    });
+
+    it("records cancelable=false — and shows the shield is then a silent no-op", () => {
+      setDiagEnabled(true);
+      const end = holdThenRelease(true);
+      expect(diagLog()[0]).toContain("cancelable=false");
+      // THE point of the whole instrument: preventDefault left no trace, so
+      // this line is the only evidence the release went unshielded.
+      expect(end.defaultPrevented).toBe(false);
+    });
+
+    it("pushes nothing with the diag flag off", () => {
+      setDiagEnabled(false);
+      const before = diagLog();
+      holdThenRelease(false);
+      expect(diagLog()).toBe(before);
+    });
+
+    it("pushes nothing on a release that was never a hold", () => {
+      setDiagEnabled(true);
+      const before = diagLog();
+      fireTouch(body, "touchstart", { clientX: CENTER_X, clientY: 300 });
+      fireTouch(body, "touchend", { clientX: CENTER_X, clientY: 300 });
+      expect(diagLog()).toBe(before);
+    });
   });
 
   it("does not arm on an inline control inside the row", () => {

--- a/cicchetto/src/lib/messageGestures.ts
+++ b/cicchetto/src/lib/messageGestures.ts
@@ -25,6 +25,8 @@
 // Returns a disposer the caller wraps in `onCleanup` (Solid does NOT re-invoke
 // a function ref with undefined at unmount the way React does — #308 landmine
 // 3 — so cleanup is explicit).
+import { isDiagEnabled } from "../DiagFloat";
+import { diagPush } from "./diagLog";
 import { LONG_PRESS_MS, SELECTABLE_TEXT_EXCLUDE } from "./keepKeyboard";
 import { disarmMessageSelection } from "./messageMenu";
 import { type Point, swipeDirection } from "./swipe";
@@ -220,6 +222,22 @@ export function bindMessageGestures(el: HTMLElement, params: MessageGestureParam
     // backdrop and close it the instant it appeared.
     if (held) {
       held = false;
+      // issue 1956 — the one fact this shield's failure hinges on, and the one
+      // nothing off-device can supply. `preventDefault` on a NON-cancelable
+      // event is SILENT: no throw, and `defaultPrevented` stays false, so the
+      // shield reads applied while doing nothing. Pushed BEFORE the call so the
+      // line records what was OBSERVED, never what was attempted.
+      //
+      // What it decides: the menu vanishes on iOS only with the keyboard down,
+      // and the only focus-dependent branch anywhere on this path is
+      // keepKeyboard's `handleMouseDown` bail — which cancels a focus shift,
+      // NOT a click (the whole of UX-3 depends on the click surviving it). So
+      // the popular reading is falsified and two candidates remain: a release
+      // WebKit refuses to let us cancel (this line answers it), or a close
+      // arriving through some other door (the menu's own line answers that).
+      if (isDiagEnabled()) {
+        diagPush(`menu: touchend after hold cancelable=${e.cancelable}`);
+      }
       if (e.cancelable) e.preventDefault();
       release();
       return;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50158,3 +50158,110 @@ carries the count the question was about.
 
 _Test-only + routing. No wire change, no protocol bump, no migration.
 Deploy: ordinary._
+<!-- entry #1956 -->
+
+---
+
+## 2026-09-09 — issue 1956: the long-press menu that vanishes with the keyboard down — what the source CAN decide, and what it cannot
+
+Reported three times on iOS, most recently against **production `1.5.4-c911f7cc`**
+(the sha this work branched from, so the code read here IS the code that
+misbehaves). The discriminator has been stable across all three: with a compose
+field focused there is no problem; with the keyboard down, a finger held STILL
+makes the menu dismiss itself, while a movement that produces vertical scroll
+leaves it up. #2014's anchoring cure is already live and is not this.
+
+### What the source decides
+
+**The class of focus-dependent branches is CLOSED, and it has one member.**
+Enumerating every `document.activeElement` / `isTextEntry` read in `cicchetto/src`
+gives six production sites; five are off this path (`Shell.tsx` tab-complete,
+`AdminDebugTab` display, `globalPaste`, `mediaViewer`, and `messageMenu.ts`'s
+`selectMessageText`, which only runs once the menu is already open). The sixth,
+`keepKeyboard.ts:182`, is the only one the long-press gesture can reach. So the
+issue's "candidate to check first" is not a starting point — it is the only
+door, by enumeration.
+
+**The menu has exactly three pointer/key doors and one lifecycle door**:
+`.context-menu-backdrop`'s `onClick`, an item's `onClick`, `createOverlayEscape`,
+and `ScrollbackPane`'s `onCleanup`. `ContextMenu` binds no touch or pointer
+listener of its own, so every pointer-driven close is a `click`.
+
+### What the source REFUTES
+
+The natural reading — *keepKeyboard's `preventDefault` suppresses the synthesized
+click with the keyboard up, and with it down the click closes the menu* — **is
+false**, and the shipped code is what falsifies it. `preventDefault` on a
+mousedown cancels the focus shift and the selection-drag start; it does not
+cancel the click. If it did, every chrome control in the app would be dead to a
+tap while the compose box holds focus, because that same always-fire
+`preventDefault` covers them all. UX-3 has shipped since 2026-06-11 and they
+work; `keepKeyboard`'s own moduledoc states it outright ("The click still fires
+… the tapped element's onClick still runs").
+
+So the focus discriminator's mechanism is **not determinable from the source**.
+Two candidates survive:
+
+* **A** — the real shield, `messageGestures.onEnd`'s `if (e.cancelable)
+  e.preventDefault()`, is a silent no-op because WebKit hands out a
+  non-cancelable touchend. `preventDefault` on one throws nothing and leaves
+  `defaultPrevented` false, so the shield reads applied while doing nothing.
+* **B** — the shield holds and the close arrives through another door (with
+  #2014 the menu's bottom-right corner sits ON the press point, so an item is a
+  pixel from the synthesized click).
+
+**Open tension, deliberately unresolved.** `keepKeyboard.ts:188-191` asserts that
+"on real iOS a long-press synthesizes NO mousedown at all". If true, candidate A
+is impossible by construction. That assertion is reasoning, not a measurement —
+the comment uses it to justify a branch it calls a cross-platform net. It is
+used here in neither direction. **If the diag below prints `cancelable=false`
+with the keyboard down, that comment is falsified and must be corrected in the
+same round**: a module comment is a claim about the present.
+
+### What ships, and why both halves
+
+**The diag** names the two facts nothing off-device can supply: the `cancelable`
+of the release after a hold, and WHICH door closed the menu. Gated on
+`isDiagEnabled()` like `keepKeyboard:200-205`; a no-op with the flag off.
+
+**The cure** is focus-INDEPENDENT, which is the point: it is correct under A and
+under B, so it does not wait on a measurement it cannot take. *The menu refuses
+any pointer activation until it has seen a press that BEGAN after it opened.*
+Causal, not timed — the opening gesture's `pointerdown` fired before the
+component existed, so the menu is born disarmed and the click synthesized from
+that same gesture finds no arm, while every genuine interaction starts with a
+fresh one.
+
+🔴 **It must arm on `pointerdown`, never on `mousedown`.** The synthesized
+mousedown PRECEDES the click inside the same release: arming there would arm
+exactly the click this refuses — a no-op that reads as applied. Escape stays
+outside the guard; a way out that is always available must not require a prior
+press.
+
+It lives in the shared shell rather than in the long-press binder because the
+defect is not "the scrollback's gesture leaks" but "a menu can be actioned by
+the gesture that opened it", which is true of every door the shell has — the
+#1115 desktop door and the nick and admin menus included. vjt ruled the scope,
+including the vitest churn (relayed, not seen first-hand).
+
+### The guard would have blinded the diagnosis, so it logs its own refusal
+
+Once the cure is in, a menu that correctly stays put is **silent**, and silence
+cannot separate "the click arrived and was refused" from "no click ever
+arrived" — which is precisely the pair the on-device round has to settle. The
+refusal therefore emits its own line. Without it the cure would have closed the
+defect while destroying the instrument that says WHICH candidate it closed, and
+whether a third remains.
+
+### Cost measured, not estimated
+
+`fireEvent.click` dispatches a bare `click`, which no browser produces, so the
+guard reddened **4** test files and 21 tests — not the 5 files predicted;
+`RailContext` is a different component and has zero `fireEvent.click`. They are
+updated to press first (`helpers/pointerEvents.pressAndClick`), which makes the
+simulation faithful rather than compliant, and the refusal keeps its own direct
+coverage. Verified by mutation: neutering the guard reds exactly the three
+refusal tests and nothing else.
+
+_Client-only. No wire change, no protocol bump, no migration. The verification
+that matters is vjt's, on device, with the flag on._


### PR DESCRIPTION
Addresses issue 1956 — the long-press message menu that does not stay open on iOS with the compose keyboard down. Two halves ship together: an on-device diagnosis, and a cure that does not depend on it.

## Provenance of the two rulings

- **"il problema del context menu on press che scompare a tastiera chiusa se non si scrolla verticalmente (ios) è ancora presente. fix it"** — vjt, 2026-09-09 16:49 Europe/Rome. **Relayed from the ircbot session, then verified on the issue by the orchestrator; not seen first-hand by either of us.** The comment is signed `vjt` because the Pi pushes with his token — that field is not evidence; the queued label was.
- **Scope approval for the cure** (shared chrome plus the vitest churn), 17:06 Rome. **Relayed, not verified on an artefact** — it arrived in channel, not on an issue.

## What was measured, and on what

Branched from `origin/main` at `c911f7ccd`, which **is** the sha production runs (`1.5.4-c911f7cc`, read from `/api/config`). The code read here is the code that misbehaves.

**The class of focus-dependent branches is closed, and it has one member.** Enumerating every `document.activeElement` / `isTextEntry` read in `cicchetto/src` gives six production sites. Five are off this path — `Shell.tsx` tab-complete, `AdminDebugTab` display, `globalPaste`, `mediaViewer`, and `messageMenu.ts`'s `selectMessageText` (which only runs once the menu is already open). The sixth, `keepKeyboard.ts:182`, is the only one the long-press can reach. The issue's "candidate to check first" is not a starting point: it is the only door.

**The menu has three pointer/key doors and one lifecycle door** — backdrop `onClick`, item `onClick`, `createOverlayEscape`, and `ScrollbackPane`'s `onCleanup`. `ContextMenu` binds no touch or pointer listener of its own, so every pointer-driven close is a `click`.

## What the source refutes

The natural reading — *keepKeyboard's `preventDefault` suppresses the synthesized click with the keyboard up, and with it down the click closes the menu* — is **false**, and the shipped code falsifies it. `preventDefault` on a mousedown cancels the focus shift and the selection-drag start, not the click. If it cancelled the click, every chrome control would be dead to a tap while the compose box holds focus, because that same always-fire `preventDefault` covers them all. UX-3 has shipped since 2026-06-11 and they work; `keepKeyboard`'s own moduledoc says so outright.

So the mechanism of the focus discriminator is **not determinable from the source**. Two candidates survive, and the diag is what separates them:

- **A** — the real shield, `messageGestures.onEnd`'s `if (e.cancelable) e.preventDefault()`, is a silent no-op because WebKit hands out a non-cancelable touchend.
- **B** — the shield holds and the close arrives through another door. With the bottom-right anchoring already live, the menu's corner sits ON the press point, so an item is a pixel from the synthesized click.

## Open tension, deliberately unresolved

`keepKeyboard.ts:188-191` asserts that "on real iOS a long-press synthesizes NO mousedown at all". If true, candidate A is impossible by construction. That assertion is reasoning, not a measurement — the comment uses it to justify a branch it itself calls a cross-platform net. It is used here in neither direction. **If the diag prints `cancelable=false` with the keyboard down, that comment is falsified and gets corrected in the same round**: a module comment is a claim about the present.

## The cure

*The menu refuses any pointer activation until it has seen a press that BEGAN after it opened.*

Causal, not timed: the opening gesture's `pointerdown` fired before the component existed, so the menu is born disarmed and the click synthesized from that same gesture finds no arm. Every genuine interaction starts with a fresh one.

⚠️ It **must** arm on `pointerdown`, never on `mousedown` — the synthesized mousedown precedes the click inside the same release, so arming there would arm exactly the click this refuses, producing a no-op that reads as applied. Escape stays outside the guard.

It lives in the shared shell, not in the long-press binder, because the defect is not "the scrollback's gesture leaks" but "a menu can be actioned by the gesture that opened it" — true of every door the shell has, the desktop `contextmenu` door and the nick and admin menus included.

**The guard would have blinded the diagnosis, so it logs its own refusal.** Once the cure is in, a menu that correctly stays put is silent, and silence cannot separate "the click arrived and was refused" from "no click ever arrived" — exactly the pair the on-device round has to settle.

## Cost, measured rather than estimated

The guard reddened **4** test files and 21 tests, not the 5 predicted (`RailContext` is a different component and has zero `fireEvent.click`). They press before clicking now, via `helpers/pointerEvents.pressAndClick` — a bare `click` is a sequence no browser produces, so this makes the simulation faithful rather than compliant. The refusal keeps its own direct coverage.

**Mutation-tested:** neutering the guard reds exactly the three refusal tests and nothing else. The three positive-path tests stay green under the mutant, correctly — they do not test the refusal.

## Gates

| gate | rc |
|---|---|
| `bun.sh run check` (lock drift, test location, biome, tsc src, tsc e2e) | **0** — 5 stages, 0 failed |
| `bun.sh run test` (vitest) | **0** — 341 files, 6897 tests |
| `scripts/design-notes-gate.sh` | **0** — 1 new entry, separator and marker present |

## What this does NOT claim

- **The mechanism of the focus discriminator is not established.** The class was closed and the obvious reading refuted; what that one gate actually buys on this path is not visible from the source, and it is not guessed here.
- **Nothing was measured on a device.** Both WebKit-dependent links are inferred.
- **No e2e spec accompanies this, and none can.** No Playwright engine hosts the gesture, `webkit-iphone-15` included, so no red test could exist for it. No timeout was raised and no assertion weakened, because no existing spec was touched.
- **jsdom does not prove that WebKit synthesizes that click at all** — only that if it arrives, the menu now refuses it.

The verification that matters is vjt's, on device, with `cic_diag` on.
