### PR TITLE
cicchetto: per-user setting to strip mIRC formatting on render

### DIFF
--- a/cicchetto/e2e/tests/issue2029-strip-mirc-formatting.spec.ts
+++ b/cicchetto/e2e/tests/issue2029-strip-mirc-formatting.spec.ts
@@ -1,0 +1,111 @@
+// #2029 — the per-viewer "strip mIRC formatting" preference, asserted on the
+// VISIBLE OUTCOME rather than on the toggle's existence.
+//
+// Requested by `morph` (Azzurra staff) after a channel filled with heavily
+// coloured bot output. Deliberately NOT channel mode `+c`: that is an
+// operator's channel-wide policy and it REJECTS the message, costing the
+// reader the words along with the colours. This strips on RENDER, per viewer.
+//
+// ## What this spec is FOR, and why vitest is not enough
+//
+// The unit tests pin the parser projection and the chokepoint's class/style
+// output in jsdom, which is blind to CSS. Two claims need a real engine and a
+// real server, and they are the two the issue actually makes:
+//
+//   1. the colour a reader SEES goes away — asserted as a computed CSS colour
+//      on the rendered run, not as the absence of a class name;
+//   2. it goes away and comes back **without a reconnect and without a
+//      refetch** — so the message is put on screen ONCE, before the toggle is
+//      ever touched, and the same on-screen line is re-read after each flip.
+//      No reload, no rejoin, no second PRIVMSG. That is the whole contract:
+//      the raw line is untouched on the wire and in scrollback, and only its
+//      projection changes.
+//
+// The toggle also round-trips to the server (it is the fifth #449 synced
+// display pref), so the flip exercised here is the production path — signal +
+// localStorage + PUT — not a test-only seam.
+
+import {
+  closeSettings,
+  loginAs,
+  openSettingsSection,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const TEST_CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// \x034 = mIRC palette red (#ff0000 → rgb(255, 0, 0)), closed by \x03.
+const RED = "rgb(255, 0, 0)";
+
+async function setStripToggle(page: Parameters<typeof loginAs>[0], on: boolean): Promise<void> {
+  await openSettingsSection(page, "display");
+  const toggle = page.getByTestId("strip-formatting-toggle");
+  await expect(toggle).toBeVisible({ timeout: 5_000 });
+  if (on) await toggle.check();
+  else await toggle.uncheck();
+  await expect(toggle).toBeChecked({ checked: on });
+  await closeSettings(page);
+}
+
+test("#2029: a coloured line goes flat and comes back, with no reconnect", async ({ page }) => {
+  const vjt = specUser();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, TEST_CHANNEL, { awaitWsReady: false });
+
+  // Live per-channel WS gate (same rationale as the sibling mIRC specs).
+  await expect(page.locator(".members-pane li", { hasText: specNick() })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const sid = crypto.randomUUID().slice(0, 6);
+  const redTag = `red-${sid}`;
+  const boldTag = `bold-${sid}`;
+  const plainTag = `plain-${sid}`;
+
+  const peer = await IrcPeer.connect({ nick: `strippeer-${sid}` });
+  try {
+    await peer.join(TEST_CHANNEL);
+    // One line carrying a colour, a bold, and an untouched tail — so the
+    // assertions can tell "formatting removed" from "text eaten".
+    peer.privmsg(TEST_CHANNEL, `\x034${redTag}\x03 \x02${boldTag}\x02 ${plainTag}`);
+
+    const lines = scrollbackLines(page);
+
+    // ---- 1. DEFAULT OFF: the colours are there. This is also the negative
+    // control for everything below — without it, a spec that never rendered
+    // the formatting in the first place would "pass" the strip assertions.
+    await expect(lines.locator(".scrollback-mirc-bold", { hasText: boldTag })).toHaveCount(1, {
+      timeout: 10_000,
+    });
+    await expect(page.getByText(redTag, { exact: true })).toHaveCSS("color", RED);
+
+    // ---- 2. TURN IT ON. Nothing is reloaded, rejoined or re-sent: the same
+    // line that is already on screen has to change.
+    await setStripToggle(page, true);
+
+    await expect(lines.locator(".scrollback-mirc-bold", { hasText: boldTag })).toHaveCount(0, {
+      timeout: 10_000,
+    });
+    // The colour is gone as PAINT, not merely as a class: the run now inherits
+    // the surrounding text colour, so it is no longer red.
+    await expect(page.getByText(redTag, { exact: true })).not.toHaveCSS("color", RED);
+    // …and the reader lost nothing but the decoration. All three words remain.
+    await expect(lines.filter({ hasText: redTag })).toContainText(boldTag);
+    await expect(lines.filter({ hasText: redTag })).toContainText(plainTag);
+
+    // ---- 3. TURN IT BACK OFF. "Toggling it back must restore colours without
+    // a reconnect" — again on the same on-screen line, with no refetch.
+    await setStripToggle(page, false);
+
+    await expect(lines.locator(".scrollback-mirc-bold", { hasText: boldTag })).toHaveCount(1, {
+      timeout: 10_000,
+    });
+    await expect(page.getByText(redTag, { exact: true })).toHaveCSS("color", RED);
+  } finally {
+    await peer.disconnect("done");
+  }
+});

--- a/cicchetto/src/MircText.tsx
+++ b/cicchetto/src/MircText.tsx
@@ -4,9 +4,10 @@ import { splitEmphasis } from "./lib/emphasisMarkers";
 import { linkify } from "./lib/linkify";
 import { classifyMediaLink, sameHostHref } from "./lib/mediaLink";
 import { openMediaViewer } from "./lib/mediaViewer";
-import { parseMircFormat, type Run } from "./lib/mircFormat";
+import { mircPlainRuns, parseMircFormat, type Run } from "./lib/mircFormat";
 import { maybeEscapePwaClick } from "./lib/platform";
 import { serverSettings } from "./lib/serverSettings";
+import { getStripFormatting } from "./lib/stripFormatting";
 
 // Shared mIRC-formatting renderer. Extracted from ScrollbackPane (#125) so
 // the channel-directory topic reuses the SAME typed-formatting render path
@@ -291,7 +292,20 @@ export const MircBody: Component<{
   // linkPolicy / emphasis — a per-surface handler, not a reactive signal.
   onChannelClick?: (channel: string) => void;
 }> = (props) => {
-  const runs = (): Run[] => parseMircFormat(props.body);
+  // #2029 — THE chokepoint. `parseMircFormat` has exactly one production
+  // render caller (this line), and colour resolution never leaves
+  // `mircFormat.ts`, so every mIRC-formatted surface in cic — 39 `<MircBody>`
+  // call sites across 12 files, nine of which the issue never names — honours
+  // the strip preference by funnelling through here. Per-surface opt-in was
+  // never on the table: "if a surface renders colour, it must honour the
+  // strip", and enumerating them is how such a list rots.
+  //
+  // A TRACKED read of the signal, inside the same accessor that already
+  // re-runs on `props.body`: toggling re-renders every open pane with no
+  // reconnect and no refetch, because the raw body is untouched and only its
+  // projection changed. That is the issue's own contract, not a nicety.
+  const runs = (): Run[] =>
+    getStripFormatting() ? mircPlainRuns(props.body) : parseMircFormat(props.body);
   // Default "navigate" is the genuine config default — correct
   // production behavior for every non-tappable-surface consumer.
   //

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -29,6 +29,7 @@ import { CREDITS_LABEL, openCreditsModal } from "./lib/creditsModal";
 import {
   syncedSetColoredNicklist,
   syncedSetShowBottomBar,
+  syncedSetStripFormatting,
   syncedSetTimeFormat,
 } from "./lib/displayPrefs";
 import { formatDuration } from "./lib/duration";
@@ -70,6 +71,7 @@ import { selectedChannel } from "./lib/selection";
 import { consumePendingSettingsPage, type SettingsSubPage } from "./lib/settingsNav";
 import { isShareableSubject, openShareModal, SHARE_SESSION_LABEL } from "./lib/shareModal";
 import { getShowBottomBar } from "./lib/showBottomBar";
+import { getStripFormatting } from "./lib/stripFormatting";
 import { getTimeFormat, type TimeFormatKey } from "./lib/timeFormat";
 import { activeHost } from "./lib/uploadHost";
 import {
@@ -270,6 +272,13 @@ const SettingsDrawer: Component<Props> = (props) => {
   // own setter stays local-only on purpose.
   const onShowBottomBarChange = (e: Event) => {
     syncedSetShowBottomBar((e.currentTarget as HTMLInputElement).checked);
+  };
+
+  // #2029 — same shape as the row above: `getStripFormatting()` IS the module
+  // signal, so no drawer-local mirror, and the write goes through the
+  // coordinator (the single PUT authority for the #449 synced prefs).
+  const onStripFormattingChange = (e: Event) => {
+    syncedSetStripFormatting((e.currentTarget as HTMLInputElement).checked);
   };
 
   // #986 — the `onDetach` / `onQuit` handlers moved to RailActions with
@@ -2243,6 +2252,26 @@ const SettingsDrawer: Component<Props> = (props) => {
                   show colored nicklist
                 </label>
 
+                {/* #2029 — strip mIRC formatting on render. OFF by default:
+                  colours keep working as they do today and this is the opt-in.
+                  Requested by `morph` (Azzurra staff) after a channel filled
+                  with heavily coloured bot output. Deliberately NOT channel
+                  mode `+c`, which is an operator's channel-wide policy and
+                  REJECTS the message — costing the reader the words as well as
+                  the colours. This strips on RENDER only: the raw line is
+                  untouched on the wire and in scrollback, so turning it back
+                  off restores the colours with no reconnect. Sits next to the
+                  nicklist row because both are colour-rendering prefs. */}
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={getStripFormatting()}
+                    onChange={onStripFormattingChange}
+                    data-testid="strip-formatting-toggle"
+                  />
+                  strip colours and formatting from messages
+                </label>
+
                 {/* #1766 — the mobile window bar (BottomBar), ON by default:
                   an opt-OUT, never a default change. #174's ruling stands
                   ("the bottom bar must NOT be deleted, it stays opt-in from
@@ -2277,16 +2306,20 @@ const SettingsDrawer: Component<Props> = (props) => {
                 </label>
 
                 {/* The one thing the merge HIDES, said out loud rather than
-                  inherited: these rows do not persist alike. Two are #449
-                  server-backed and converge across every device on the
+                  inherited: these rows do not persist alike. All but one are
+                  #449 server-backed and converge across every device on the
                   account; the jump button is per-DEVICE localStorage, and
                   deliberately so — #914's complaint was about a viewport, not
-                  an account. Under one legend three identical-looking rows
-                  would otherwise behave differently on a second device with
-                  nothing on screen to say why. */}
+                  an account. Under one legend, identical-looking rows would
+                  otherwise behave differently on a second device with nothing
+                  on screen to say why. Phrased by BEHAVIOUR rather than by
+                  position ("the first two" until #2029 added a third synced
+                  row): a blurb that counts its neighbours is wrong the next
+                  time one arrives, silently, because nothing type-checks a
+                  sentence. */}
                 <p class="settings-section-blurb" data-testid="display-checkboxes-hint">
-                  The first two follow your account onto every device you use. The jump button is
-                  remembered on this device only.
+                  Only the jump button is remembered on this device alone — the rest follow your
+                  account onto every device you use.
                 </p>
               </fieldset>
             </section>

--- a/cicchetto/src/__tests__/MircText.test.tsx
+++ b/cicchetto/src/__tests__/MircText.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@solidjs/testing-library";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setStripFormatting } from "../lib/stripFormatting";
 import { MircBody } from "../MircText";
 
 // #220 — per-surface link-vs-surface event routing.
@@ -237,5 +238,95 @@ describe("MircText channel affordance (#648)", () => {
     const { container } = render(() => <MircBody body="join #chan" emphasis />);
     expect(container.querySelector(".channel-clickable")).toBeNull();
     expect(container.textContent).toBe("join #chan");
+  });
+});
+
+// #2029 — the strip preference, asserted where it actually acts. `MircBody` is
+// the ONE chokepoint: `parseMircFormat` has a single production render caller,
+// and colour resolution never leaves `mircFormat.ts`. So these tests stand in
+// for all 39 `<MircBody>` call sites across 12 files — the surfaces the issue
+// names AND the nine it does not.
+describe("MircText strip-formatting preference (#2029)", () => {
+  // Bold + red + a plain tail: one attribute the CLASS carries, one the inline
+  // STYLE carries, and text on both sides so a strip that ate characters shows.
+  const COLOURED = "\x02\x034alert\x03\x02 and calm";
+
+  beforeEach(() => setStripFormatting(false));
+  afterEach(() => setStripFormatting(false));
+
+  it("OFF (the default): the colours and the bold still render", () => {
+    const { container } = render(() => <MircBody body={COLOURED} />);
+
+    expect(container.querySelector(".scrollback-mirc-bold")).not.toBeNull();
+    const styled = container.querySelector("span[style]") as HTMLElement;
+    expect(styled.style.color).not.toBe("");
+    expect(container.textContent).toBe("alert and calm");
+  });
+
+  it("ON: the same body renders with NO formatting class and NO colour", () => {
+    setStripFormatting(true);
+    const { container } = render(() => <MircBody body={COLOURED} />);
+
+    expect(container.querySelector(".scrollback-mirc-bold")).toBeNull();
+    expect(container.querySelector(".scrollback-mirc-italic")).toBeNull();
+    expect(container.querySelector(".scrollback-mirc-underline")).toBeNull();
+    expect(container.querySelector(".scrollback-mirc-strikethrough")).toBeNull();
+    expect(container.querySelector(".scrollback-mirc-monospace")).toBeNull();
+    expect(container.querySelector(".scrollback-mirc-reverse")).toBeNull();
+    for (const span of container.querySelectorAll("span")) {
+      expect((span as HTMLElement).style.color).toBe("");
+      expect((span as HTMLElement).style.backgroundColor).toBe("");
+    }
+  });
+
+  // The half that is easy to lose: stripping must cost the reader NOTHING but
+  // the decoration. `+c` rejects the message; this must not.
+  it("ON: every visible character survives — the words arrive, they arrive plain", () => {
+    setStripFormatting(true);
+    const { container } = render(() => <MircBody body={COLOURED} />);
+    expect(container.textContent).toBe("alert and calm");
+  });
+
+  // THE issue's own contract: "toggling it back must restore colours without a
+  // reconnect". Nothing re-renders here and no body is re-fetched — the signal
+  // flips under a MOUNTED tree and the DOM has to follow. A `localStorage`
+  // read at the chokepoint passes both tests above and fails this one.
+  it("toggles LIVE under a mounted pane, both ways, with no re-render and no refetch", async () => {
+    const { container } = render(() => <MircBody body={COLOURED} />);
+    expect(container.querySelector(".scrollback-mirc-bold")).not.toBeNull();
+
+    setStripFormatting(true);
+    await Promise.resolve();
+    expect(container.querySelector(".scrollback-mirc-bold")).toBeNull();
+    expect(container.textContent).toBe("alert and calm");
+
+    setStripFormatting(false);
+    await Promise.resolve();
+    expect(container.querySelector(".scrollback-mirc-bold")).not.toBeNull();
+    const restyled = container.querySelector("span[style]") as HTMLElement;
+    expect(restyled.style.color).not.toBe("");
+    expect(container.textContent).toBe("alert and calm");
+  });
+
+  // #455's emphasis layer is cic's own markup over PLAIN text, not an mIRC
+  // control code. The issue asks for the control codes to go; taking the
+  // emphasis layer with them would be scope the reader never asked for.
+  it("ON: does not disturb the #455 emphasis layer, which is not a control code", () => {
+    setStripFormatting(true);
+    const { container } = render(() => <MircBody body="a *bold* word" emphasis />);
+    expect(container.querySelector(".scrollback-mirc-bold")).not.toBeNull();
+    expect(container.textContent).toBe("a *bold* word");
+  });
+
+  // Links are structure, not decoration. A stripped body must still linkify.
+  it("ON: a URL is still rendered as an anchor", () => {
+    setStripFormatting(true);
+    // Braces, not a bare attribute string: `"\x03"` inside JSX attribute
+    // quotes is a literal backslash, so the body would carry no control byte
+    // at all and the test would pass on nothing.
+    const { container } = render(() => <MircBody body={"\x0312see https://example.com/x"} />);
+    const link = container.querySelector(".scrollback-link") as HTMLAnchorElement;
+    expect(link).not.toBeNull();
+    expect(link.href).toBe("https://example.com/x");
   });
 });

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -572,13 +572,24 @@ describe("SettingsDrawer display options — one fieldset for the checkboxes (#1
     expect(screen.getByTestId("hide-next-active-toggle")).toBeInTheDocument();
   });
 
-  // The merge hides something the three legends used to keep apart: these rows
-  // do NOT persist alike. Colored nicklist and the window bar are server-synced
-  // across devices; hide-next-active is per-device localStorage (#914, and
-  // deliberately so — its complaint was a viewport). Under one legend three
-  // identical-looking rows behave differently on a second device, so the
-  // fieldset says which is which instead of inheriting the ambiguity.
-  it("says out loud that one of the three rows is per-device", () => {
+  // #2029 — the strip row lands in the same fieldset, and it is SYNCED: the
+  // complaint behind it (a channel full of coloured bot output) is a property
+  // of the account, identical on every device, which is #1766's own criterion
+  // for choosing synced over per-device.
+  it("renders the strip-formatting toggle in the display fieldset", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+    expect(screen.getByTestId("strip-formatting-toggle")).toBeInTheDocument();
+  });
+
+  // The merge hides something the legends used to keep apart: these rows do
+  // NOT persist alike. Colored nicklist, the window bar and the strip toggle
+  // are server-synced across devices; hide-next-active is per-device
+  // localStorage (#914, and deliberately so — its complaint was a viewport).
+  // Under one legend, identical-looking rows behave differently on a second
+  // device, so the fieldset says which is which instead of inheriting the
+  // ambiguity.
+  it("says out loud that one of the rows is per-device", () => {
     wrap(true);
     openSub("display-settings-entry");
     const blurb = screen.getByTestId("display-checkboxes-hint");

--- a/cicchetto/src/__tests__/displayPrefs.test.ts
+++ b/cicchetto/src/__tests__/displayPrefs.test.ts
@@ -10,6 +10,7 @@ import {
   syncedSetChannelPresencePref,
   syncedSetColoredNicklist,
   syncedSetShowBottomBar,
+  syncedSetStripFormatting,
   syncedSetTimeFormat,
 } from "../lib/displayPrefs";
 import {
@@ -19,6 +20,7 @@ import {
 } from "../lib/presenceFilter";
 import { loadInitialScrollback, purgeScrollback } from "../lib/scrollback";
 import { getShowBottomBar, setShowBottomBar } from "../lib/showBottomBar";
+import { getStripFormatting, setStripFormatting } from "../lib/stripFormatting";
 import { getTimeFormat, setTimeFormat } from "../lib/timeFormat";
 import type { DisplayPrefs } from "../lib/userSettings";
 
@@ -53,6 +55,7 @@ function resetLocal(): void {
   setColoredNicklist(false);
   replacePresencePrefs({});
   setShowBottomBar(true);
+  setStripFormatting(false);
   setToken(null);
 }
 
@@ -85,17 +88,19 @@ afterEach(() => {
 });
 
 describe("buildWireMap", () => {
-  it("reads the four module getters into the wire shape", () => {
+  it("reads the five module getters into the wire shape", () => {
     setTimeFormat("hm");
     setColoredNicklist(true);
     replacePresencePrefs({ [KEY_A]: "hide" });
     setShowBottomBar(false);
+    setStripFormatting(true);
 
     expect(buildWireMap()).toEqual({
       time_format: "hm",
       colored_nicklist: true,
       presence_filter: { [KEY_A]: "hide" },
       show_bottom_bar: false,
+      strip_formatting: true,
     });
   });
 
@@ -105,18 +110,57 @@ describe("buildWireMap", () => {
 });
 
 describe("applyServerPrefs", () => {
-  it("distributes server prefs into the four local setters", () => {
+  it("distributes server prefs into the five local setters", () => {
     applyServerPrefs({
       time_format: "hm",
       colored_nicklist: true,
       presence_filter: { [KEY_A]: "hide" },
       show_bottom_bar: false,
+      strip_formatting: true,
     });
 
     expect(getTimeFormat()).toBe("hm");
     expect(getColoredNicklist()).toBe(true);
     expect(getChannelPresencePref(KEY_A)).toBe("hide");
     expect(getShowBottomBar()).toBe(false);
+    expect(getStripFormatting()).toBe(true);
+  });
+
+  // #2029 — the same skew as #1766's, one key later, and the direction that
+  // bites is the SAME one: `--cic` can ship this bundle ahead of the server,
+  // so a server predating the fifth key answers four. A full-replace apply
+  // that passed the absent value through would write `undefined` into the
+  // owner module.
+  it("an absent strip_formatting (older server) takes the default, not undefined", () => {
+    setStripFormatting(true);
+
+    applyServerPrefs({
+      time_format: "hms",
+      colored_nicklist: false,
+      presence_filter: {},
+      show_bottom_bar: true,
+    });
+
+    expect(getStripFormatting()).toBe(false);
+  });
+
+  // `??` and not `||`, and here the trap is sharper than #1766's: `false` is
+  // this pref's DEFAULT, so under `||` a server-sent `false` would coalesce
+  // to the default too — which happens to be the same value, hiding the bug
+  // until the day the default flips. Asserted against a local `true` so the
+  // apply has something to overwrite.
+  it("a server-sent false OVERWRITES a local true (the coalesce is ??, not ||)", () => {
+    setStripFormatting(true);
+
+    applyServerPrefs({
+      time_format: "hms",
+      colored_nicklist: false,
+      presence_filter: {},
+      show_bottom_bar: true,
+      strip_formatting: false,
+    });
+
+    expect(getStripFormatting()).toBe(false);
   });
 
   // #1766 — the skew this bundle can be deployed INTO. `--cic` ships the
@@ -205,11 +249,13 @@ describe("mountDisplayPrefsSync — login reconcile", () => {
     // Local state the operator built on this device — must survive + push up.
     // #1766 — the fourth pref joins the seed-up with a NON-default value, so
     // "the key is in the body" cannot pass by accident: a coordinator that
-    // forgot to read the owner module would push `true` here.
+    // forgot to read the owner module would push `true` here. #2029's fifth
+    // key follows the same rule, inverted (its default is `false`).
     setTimeFormat("hm");
     setColoredNicklist(true);
     replacePresencePrefs({ [KEY_A]: "hide" });
     setShowBottomBar(false);
+    setStripFormatting(true);
 
     const serverDefaults: DisplayPrefs = {
       time_format: "hms",
@@ -245,6 +291,7 @@ describe("mountDisplayPrefsSync — login reconcile", () => {
         colored_nicklist: true,
         presence_filter: { [KEY_A]: "hide" },
         show_bottom_bar: false,
+        strip_formatting: true,
       },
     });
 
@@ -252,6 +299,7 @@ describe("mountDisplayPrefsSync — login reconcile", () => {
     expect(getTimeFormat()).toBe("hm");
     expect(getColoredNicklist()).toBe(true);
     expect(getShowBottomBar()).toBe(false);
+    expect(getStripFormatting()).toBe(true);
     dispose();
   });
 
@@ -319,6 +367,7 @@ describe("syncedSet* — optimistic local + full-map PUT", () => {
         colored_nicklist: true,
         presence_filter: { [KEY_A]: "hide" },
         show_bottom_bar: true,
+        strip_formatting: false,
       },
     });
   });
@@ -356,6 +405,44 @@ describe("syncedSet* — optimistic local + full-map PUT", () => {
     expect(init.method).toBe("PUT");
     expect(JSON.parse(init.body as string).display_prefs.show_bottom_bar).toBe(false);
   });
+
+  it("syncedSetStripFormatting sets local and PUTs the full wire map", async () => {
+    setToken(TOKEN);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ display_prefs: buildWireMap(), persisted: true }), {
+        status: 200,
+      }),
+    );
+
+    syncedSetStripFormatting(true);
+    await flush();
+
+    expect(getStripFormatting()).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/me/settings/display-prefs");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string).display_prefs.strip_formatting).toBe(true);
+  });
+
+  // The failure mode a fifth key invites, and the one no per-key test catches:
+  // forget `buildWireMap` and the pref still applies locally, still persists
+  // locally, and is silently reset to the server's default by the NEXT
+  // unrelated toggle — because the PUT is a full-map replace.
+  it("a sibling's PUT carries strip_formatting too (the full map, not a diff)", async () => {
+    setToken(TOKEN);
+    setStripFormatting(true);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ display_prefs: buildWireMap(), persisted: true }), {
+        status: 200,
+      }),
+    );
+
+    syncedSetColoredNicklist(true);
+    await flush();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).display_prefs.strip_formatting).toBe(true);
+  });
 });
 
 // S1 (review) — clear-on-logout so a shared browser / visitor→user upgrade can
@@ -369,6 +456,7 @@ describe("mountDisplayPrefsSync — clear-on-logout (no cross-account bleed)", (
     colored_nicklist: false,
     presence_filter: {},
     show_bottom_bar: true,
+    strip_formatting: false,
   };
 
   // Phase-mutable fetch stub: the GET body changes across A-login / B-login.
@@ -383,10 +471,15 @@ describe("mountDisplayPrefsSync — clear-on-logout (no cross-account bleed)", (
   }
 
   it("resets local prefs to defaults on logout", async () => {
+    // #2029 — A's residual carries the strip pref ON, so the clear-on-logout
+    // and the never-seed-a-prior-subject guarantees are exercised for the
+    // fifth key too. A default-valued residual would be indistinguishable
+    // from a cleared one and would assert nothing.
     const aPrefs = {
       time_format: "hm",
       colored_nicklist: true,
       presence_filter: { [KEY_A]: "hide" },
+      strip_formatting: true,
     };
     getBody = { display_prefs: aPrefs, persisted: true };
     installPhaseFetch();
@@ -400,6 +493,7 @@ describe("mountDisplayPrefsSync — clear-on-logout (no cross-account bleed)", (
     setToken(TOKEN); // A logs in — server wins, A's prefs applied locally
     await flush();
     expect(getTimeFormat()).toBe("hm");
+    expect(getStripFormatting()).toBe(true);
 
     setToken(null); // A logs out
     await flush();
@@ -407,14 +501,20 @@ describe("mountDisplayPrefsSync — clear-on-logout (no cross-account bleed)", (
     expect(getTimeFormat()).toBe("hms");
     expect(getColoredNicklist()).toBe(false);
     expect(getAllPresencePrefs()).toEqual({});
+    expect(getStripFormatting()).toBe(false);
     dispose();
   });
 
   it("does NOT seed a prior subject's prefs into a never-persisted next login", async () => {
+    // #2029 — A's residual carries the strip pref ON, so the clear-on-logout
+    // and the never-seed-a-prior-subject guarantees are exercised for the
+    // fifth key too. A default-valued residual would be indistinguishable
+    // from a cleared one and would assert nothing.
     const aPrefs = {
       time_format: "hm",
       colored_nicklist: true,
       presence_filter: { [KEY_A]: "hide" },
+      strip_formatting: true,
     };
     getBody = { display_prefs: aPrefs, persisted: true };
     const fetchMock = installPhaseFetch();

--- a/cicchetto/src/__tests__/mircFormat.test.ts
+++ b/cicchetto/src/__tests__/mircFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { MIRC_PALETTE, parseMircFormat } from "../lib/mircFormat";
+import { MIRC_PALETTE, mircPlainRuns, parseMircFormat } from "../lib/mircFormat";
 
 // mIRC text formatting parser. Pinned at the per-Run output level: the
 // test asserts the structure of the runs (text + flag set + resolved
@@ -218,5 +218,78 @@ describe("parseMircFormat", () => {
       expect(MIRC_PALETTE[0]).toBe("#ffffff");
       expect(MIRC_PALETTE[1]).toBe("#000000");
     });
+  });
+});
+
+// #2029 — the render-side projection of the SAME parse: run structure kept,
+// every formatting attribute cleared. This is what `MircBody` swaps in when
+// the reader has the strip preference on, so what it preserves and what it
+// drops IS the feature.
+describe("mircPlainRuns", () => {
+  // The body carries the whole control set the issue enumerates: colour,
+  // hex colour, bold, italic, underline, strikethrough, monospace, reverse,
+  // reset. If one of them survived as an attribute, this fails.
+  const EVERYTHING =
+    "\x02bold\x02 \x1ditalic\x1d \x1funder\x1f \x1estrike\x1e " +
+    "\x11mono\x11 \x16rev\x16 \x034red\x03 \x04ff8800hex\x04 \x0fplain";
+
+  it("keeps the visible text byte-for-byte, the same text the styled parse yields", () => {
+    // Not a hardcoded expectation: the styled parse is the reference, so this
+    // cannot drift into asserting a text the renderer never produces.
+    const styled = parseMircFormat(EVERYTHING)
+      .map((r) => r.text)
+      .join("");
+    expect(
+      mircPlainRuns(EVERYTHING)
+        .map((r) => r.text)
+        .join(""),
+    ).toBe(styled);
+  });
+
+  it("clears every formatting attribute on every run", () => {
+    const runs = mircPlainRuns(EVERYTHING);
+    expect(runs.length).toBeGreaterThan(1); // the body really does split
+    for (const run of runs) {
+      expect(run.bold).toBe(false);
+      expect(run.italic).toBe(false);
+      expect(run.underline).toBe(false);
+      expect(run.strikethrough).toBe(false);
+      expect(run.monospace).toBe(false);
+      expect(run.reverse).toBe(false);
+      expect(run.fg).toBeUndefined();
+      expect(run.bg).toBeUndefined();
+    }
+  });
+
+  // The control that proves the fixture is not vacuous: the STYLED parse of
+  // the same body must carry the attributes this strips. Without it, a body
+  // that happened to be plain would make the block above pass on nothing.
+  it("NEGATIVE CONTROL: the styled parse of the same body DOES carry attributes", () => {
+    const styled = parseMircFormat(EVERYTHING);
+    expect(styled.some((r) => r.bold)).toBe(true);
+    expect(styled.some((r) => r.italic)).toBe(true);
+    expect(styled.some((r) => r.underline)).toBe(true);
+    expect(styled.some((r) => r.strikethrough)).toBe(true);
+    expect(styled.some((r) => r.monospace)).toBe(true);
+    expect(styled.some((r) => r.reverse)).toBe(true);
+    expect(styled.some((r) => r.fg !== undefined)).toBe(true);
+  });
+
+  // Pins the ruling that the runs are NOT merged. Merging would repair a URL
+  // split by a colour code — a real improvement, and a behaviour change that
+  // does not belong to an issue about removing colours.
+  it("does NOT merge the runs — same boundaries as the styled parse", () => {
+    const styled = parseMircFormat(EVERYTHING);
+    const plain = mircPlainRuns(EVERYTHING);
+    expect(plain).toHaveLength(styled.length);
+    expect(plain.map((r) => r.text)).toEqual(styled.map((r) => r.text));
+  });
+
+  it("leaves a body with no control bytes exactly as the styled parse leaves it", () => {
+    expect(mircPlainRuns("hello world")).toEqual(parseMircFormat("hello world"));
+  });
+
+  it("yields no runs for an empty body (the zero-run contract MircBody relies on)", () => {
+    expect(mircPlainRuns("")).toEqual([]);
   });
 });

--- a/cicchetto/src/__tests__/stripFormatting.test.ts
+++ b/cicchetto/src/__tests__/stripFormatting.test.ts
@@ -1,0 +1,86 @@
+import { createEffect, createRoot } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #2029 — "strip mIRC formatting" display preference. Boolean, OFF by default:
+// colours render exactly as they do today until a reader opts out of them.
+//
+// It takes colorNicklist.ts's SHAPE (module-singleton signal + localStorage
+// write-through) because the flag is read at RENDER time by `MircBody`, and
+// its POSTURE (one of the #449 server-backed prefs, PUT by `displayPrefs.ts`)
+// because the complaint behind it — a channel full of coloured bot output — is
+// account-scoped, not viewport-scoped like #914's per-device sibling.
+//
+// The default is OFF, so `v === "true"` carries both jobs (parse the stored
+// value, and fall back to the default on garbage) — the coincidence
+// showBottomBar.ts had to break with an inverted default. Pinned anyway: it is
+// a coincidence, not a design, and the next default flip needs it stated.
+
+describe("stripFormatting module", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  describe("getStripFormatting()", () => {
+    it("defaults to FALSE when localStorage is empty — colours keep rendering", async () => {
+      const { getStripFormatting } = await import("../lib/stripFormatting");
+      expect(getStripFormatting()).toBe(false);
+    });
+
+    it("returns true when localStorage holds 'true'", async () => {
+      localStorage.setItem("cicchetto.stripFormatting", "true");
+      const { getStripFormatting } = await import("../lib/stripFormatting");
+      expect(getStripFormatting()).toBe(true);
+    });
+
+    it("returns false when localStorage holds 'false'", async () => {
+      localStorage.setItem("cicchetto.stripFormatting", "false");
+      const { getStripFormatting } = await import("../lib/stripFormatting");
+      expect(getStripFormatting()).toBe(false);
+    });
+
+    it("falls back to FALSE when localStorage holds an unparseable value", async () => {
+      localStorage.setItem("cicchetto.stripFormatting", "1");
+      const { getStripFormatting } = await import("../lib/stripFormatting");
+      expect(getStripFormatting()).toBe(false);
+    });
+  });
+
+  describe("setStripFormatting()", () => {
+    it("persists 'true' to localStorage when stripping", async () => {
+      const { setStripFormatting } = await import("../lib/stripFormatting");
+      setStripFormatting(true);
+      expect(localStorage.getItem("cicchetto.stripFormatting")).toBe("true");
+    });
+
+    it("persists 'false' to localStorage when not stripping", async () => {
+      const { setStripFormatting } = await import("../lib/stripFormatting");
+      setStripFormatting(false);
+      expect(localStorage.getItem("cicchetto.stripFormatting")).toBe("false");
+    });
+
+    // The assertion that constrains the SHAPE, and the one the issue's own
+    // wording depends on. A plain `localStorage.getItem` getter passes every
+    // test above — including a set-then-get round trip — while leaving every
+    // OPEN pane rendering its old colours until a reload. "Toggling it back
+    // must restore colours without a reconnect" is only true of a TRACKED
+    // read: the effect must re-run.
+    it("re-runs a tracked read, so an open pane re-renders on toggle", async () => {
+      const { getStripFormatting, setStripFormatting } = await import("../lib/stripFormatting");
+      const seen: boolean[] = [];
+      createRoot(() => {
+        createEffect(() => seen.push(getStripFormatting()));
+      });
+      await Promise.resolve();
+      expect(seen).toEqual([false]);
+
+      setStripFormatting(true);
+      await Promise.resolve();
+      expect(seen).toEqual([false, true]);
+
+      setStripFormatting(false);
+      await Promise.resolve();
+      expect(seen).toEqual([false, true, false]);
+    });
+  });
+});

--- a/cicchetto/src/lib/displayPrefs.ts
+++ b/cicchetto/src/lib/displayPrefs.ts
@@ -11,6 +11,7 @@ import {
 } from "./presenceFilter";
 import { loadInitialScrollback, purgeScrollback } from "./scrollback";
 import { getShowBottomBar, setShowBottomBar } from "./showBottomBar";
+import { getStripFormatting, setStripFormatting } from "./stripFormatting";
 import { getTimeFormat, setTimeFormat, type TimeFormatKey } from "./timeFormat";
 import { type DisplayPrefs, getDisplayPrefs, putDisplayPrefs } from "./userSettings";
 
@@ -22,10 +23,14 @@ import { type DisplayPrefs, getDisplayPrefs, putDisplayPrefs } from "./userSetti
 // localStorage cache (the FOUC-free boot mirror); this coordinator adds the
 // server round-trip on top.
 //
-// #1766 added a FOURTH owner module (`showBottomBar.ts`) on exactly that shape.
-// Every function below that names the wire map has to grow with it — the
-// default baseline, `buildWireMap`, `applyServerPrefs` and a `syncedSet*` — and
-// the server's `default_display_prefs/0` is the authority for the default.
+// #1766 added a FOURTH owner module (`showBottomBar.ts`) on exactly that shape,
+// and #2029 a FIFTH (`stripFormatting.ts`). Every function below that names the
+// wire map has to grow with it — the default baseline, `buildWireMap`,
+// `applyServerPrefs` and a `syncedSet*` — and the server's
+// `default_display_prefs/0` is the authority for the default. Four touch points
+// per key, none of them optional: miss the baseline and logout leaves a
+// residual pref, miss `buildWireMap` and every PUT silently resets the key to
+// the server's default.
 //
 // ## The THEME sync shape, not the notification-prefs shape
 //
@@ -60,6 +65,7 @@ const DEFAULT_DISPLAY_PREFS: Required<DisplayPrefs> = {
   colored_nicklist: false,
   presence_filter: {},
   show_bottom_bar: true,
+  strip_formatting: false,
 };
 
 // #449 (issue222 regression fix) — the "unconfirmed local write" marker.
@@ -91,20 +97,22 @@ function hasUnsyncedWrite(): boolean {
   return localStorage.getItem(UNSYNCED_KEY) === "1";
 }
 
-// Read the four owner modules into the wire shape (the seed-up + every PUT
-// body). Pure snapshot; no reactivity intended. `show_bottom_bar` is OPTIONAL
-// on the type (a pre-#1766 server omits it on the way IN) but always populated
-// here — cic is the writer, and it knows the key.
+// Read the five owner modules into the wire shape (the seed-up + every PUT
+// body). Pure snapshot; no reactivity intended. `show_bottom_bar` (#1766) and
+// `strip_formatting` (#2029) are OPTIONAL on the type (an older server omits
+// them on the way IN) but always populated here — cic is the writer, and it
+// knows the keys.
 export function buildWireMap(): Required<DisplayPrefs> {
   return {
     time_format: getTimeFormat(),
     colored_nicklist: getColoredNicklist(),
     presence_filter: getAllPresencePrefs(),
     show_bottom_bar: getShowBottomBar(),
+    strip_formatting: getStripFormatting(),
   };
 }
 
-// Distribute a server-authoritative payload into the four owner modules'
+// Distribute a server-authoritative payload into the five owner modules'
 // LOCAL setters (write-through to signal + localStorage). No re-PUT — this is
 // the server-wins apply path only. The presence map is a full replace so unset
 // channels stay unset.
@@ -120,6 +128,13 @@ export function applyServerPrefs(prefs: DisplayPrefs): void {
   setColoredNicklist(prefs.colored_nicklist);
   replacePresencePrefs(prefs.presence_filter);
   setShowBottomBar(prefs.show_bottom_bar ?? DEFAULT_DISPLAY_PREFS.show_bottom_bar);
+  // #2029 — coalesced for the same reason, in the same direction: this bundle
+  // can ship AHEAD of the server (`--cic`), and a full-replace apply that
+  // passed the absent value through would write `undefined` into the owner
+  // module. `??` and not `||`: a server-sent `false` is a real preference —
+  // here it is even the DEFAULT one, so `||` would make the pref impossible to
+  // turn back off from a second device.
+  setStripFormatting(prefs.strip_formatting ?? DEFAULT_DISPLAY_PREFS.strip_formatting);
 }
 
 // Reactive server sync — re-runs on every `token()` change (registered inside a
@@ -216,6 +231,11 @@ export function syncedSetColoredNicklist(on: boolean): void {
 
 export function syncedSetShowBottomBar(on: boolean): void {
   setShowBottomBar(on);
+  pushDisplayPrefs();
+}
+
+export function syncedSetStripFormatting(on: boolean): void {
+  setStripFormatting(on);
   pushDisplayPrefs();
 }
 

--- a/cicchetto/src/lib/mircFormat.ts
+++ b/cicchetto/src/lib/mircFormat.ts
@@ -332,13 +332,47 @@ export function parseMircFormat(body: string): Run[] {
 // the runs already carry exactly the printable text with the control bytes
 // consumed. Used for plain-text-only DOM surfaces that cannot render
 // formatting — e.g. an element's `title` tooltip attribute, where leaking
-// the raw `\x02`/`\x03` bytes would show as garbage. This is NOT a render
-// strip (the visible body always routes through `MircBody`); it is the
-// canonical projection for attribute surfaces that are plain text by nature.
+// the raw `\x02`/`\x03` bytes would show as garbage: the canonical
+// projection for attribute surfaces that are plain text by nature.
+//
+// This used to add "and it is NOT a render strip — the visible body always
+// routes through `MircBody`". #2029 made that false, so it is gone rather
+// than left to mislead: there IS a render strip now, it is opt-in per
+// viewer, and it is `mircPlainRuns` below. This one still has no render
+// caller — a STRING cannot carry the run boundaries the renderer needs.
 export function mircPlainText(body: string): string {
   let out = "";
   for (const run of parseMircFormat(body)) out += run.text;
   return out;
+}
+
+// #2029 — the same de-formatting, projected for the RENDERER instead of for a
+// string attribute: the run STRUCTURE survives, every formatting attribute is
+// cleared. `MircBody` swaps `parseMircFormat` for this when the reader has the
+// strip preference on, which is what makes the toggle reach all twelve
+// mIRC-rendering surfaces from one place.
+//
+// NOT a second stripper, and the distinction is load-bearing: the control
+// bytes are removed by `parseMircFormat` — the one parser, the same one the
+// styled render and `mircPlainText` both go through — and this only drops the
+// attributes it decoded. A new scanner over `\x03`/`\x02` here would be the
+// second implementation of the rule that CLAUDE.md forbids.
+//
+// The runs are deliberately NOT merged into one. Merging would repair a URL
+// that a colour code splits mid-link (linkify runs per-run), which is a real
+// improvement and a BEHAVIOUR CHANGE that has nothing to do with removing
+// colours — it does not ride in on this issue's back. Same text, same
+// boundaries, no attributes.
+export function mircPlainRuns(body: string): Run[] {
+  return parseMircFormat(body).map((run) => ({
+    text: run.text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    monospace: false,
+    reverse: false,
+  }));
 }
 
 function isDigit(charCode: number): boolean {

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -145,7 +145,17 @@ let _socket: Socket | null = null;
 // designed — `protocol_test.exs` went red at the commit that moved
 // `@protocol_version` (the `invalid_mask` token) without this line, so the
 // two moved together instead of this file lagging for another three weeks.
-export const CLIENT_PROTOCOL_VERSION = 14;
+//
+// 14 → 15 (#2029): the second, and the pin earned its keep twice over. The
+// `display_prefs` object grew a fifth key (`strip_formatting`) and `wire_pin
+// --check` could NOT see it — its digest does not span hand-written
+// `*_json.ex` views, so it answered "wire shape and protocol 14 agree" at rc=0
+// on a real shape change. `protocol_test.exs` is what went red for the missing
+// half of the bump, which makes it the ONLY automatic guard on this pair for
+// any payload the codegen does not cover. `MIN_SERVER_PROTOCOL_VERSION` stays
+// at 9, correctly: the new key is absent-tolerant in both directions, so this
+// bundle still serves a v9 server — the two axes behaving as designed.
+export const CLIENT_PROTOCOL_VERSION = 15;
 
 // #193 — force the correct WS scheme from the page origin, absolutely.
 //

--- a/cicchetto/src/lib/stripFormatting.ts
+++ b/cicchetto/src/lib/stripFormatting.ts
@@ -1,0 +1,67 @@
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
+
+// #2029 — "strip mIRC formatting" display preference. Boolean, OFF by
+// default: colours keep rendering exactly as they do today, and a reader opts
+// into flat text.
+//
+// Requested by `morph` (Azzurra staff) after a channel filled up with heavily
+// coloured bot output. The obvious neighbour is channel mode `+c`, and it is
+// NOT this: `+c` is a channel-wide policy an operator sets, and it REJECTS the
+// message at the server, so the reader loses the words along with the colours.
+// This is per-viewer and strips on RENDER — the words still arrive, they just
+// arrive plain. That is also why the raw line is untouched on the wire and in
+// scrollback: toggling back restores the colours with no reconnect, because
+// nothing was ever thrown away.
+//
+// ## SYNCED, on #1766's criterion rather than a coin toss
+//
+// This takes colorNicklist.ts's SHAPE and its POSTURE: one of the #449
+// server-backed display prefs, coordinated by `displayPrefs.ts` over
+// `GET/PUT /me/settings/display-prefs`. #914's `hideNextActive` sits in the
+// same settings fieldset and is deliberately per-DEVICE, so the divergence
+// needs a reason. #1766 already fixed which one: a per-device toggle is right
+// when the complaint is about a VIEWPORT, and wrong when it is about the
+// ACCOUNT. A channel full of coloured bot output is identical on the phone and
+// on the desktop — the account axis — and the pref's nearest neighbour by
+// shape, `colored_nicklist`, is synced for that same reason. Two adjacent
+// checkboxes that persist differently is the surprise this avoids.
+//
+// localStorage is the boot/offline cache for a FOUC-free first paint, not the
+// source of truth: the server wins on login, or is seeded up once when it has
+// never persisted. `setStripFormatting` stays LOCAL-only (signal +
+// localStorage write-through); the coordinator's `syncedSetStripFormatting`
+// adds the PUT.
+//
+// ## Why a signal
+//
+// Same argument as colorNicklist.ts: the flag is read at RENDER time, by
+// `MircBody` — the ONE chokepoint every mIRC-formatted surface funnels
+// through. A bare `localStorage.getItem` there would never re-run, so an open
+// pane would keep its colours until a reload, and "without a reconnect" is
+// half of what this issue asks for.
+
+const STORAGE_KEY = "cicchetto.stripFormatting";
+const DEFAULT_ON = false;
+
+function readStored(): boolean {
+  const v = localStorage.getItem(STORAGE_KEY);
+  return v === null ? DEFAULT_ON : v === "true";
+}
+
+// Module-singleton signal seeded from storage. createRoot anchors it for the
+// app lifetime (same shape as colorNicklist.ts) — the preference is
+// identity-agnostic, so no token-rotation reset arm is needed.
+const { current, setCurrent } = moduleRoot(() => {
+  const [current, setCurrent] = createSignal<boolean>(readStored());
+  return { current, setCurrent };
+});
+
+export function getStripFormatting(): boolean {
+  return current();
+}
+
+export function setStripFormatting(on: boolean): void {
+  localStorage.setItem(STORAGE_KEY, on ? "true" : "false");
+  setCurrent(on);
+}

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -345,6 +345,12 @@ export type DisplayPrefs = {
   // skew the server tolerates on the PUT. Absent ⇒ the default, exactly like
   // `persisted?` below. `buildWireMap()` always populates it.
   show_bottom_bar?: boolean;
+  // #2029 — OPTIONAL for exactly the reason above, and now the reason is a
+  // pattern rather than one key's quirk: every key added after the shape first
+  // shipped is absent-tolerant in BOTH directions, so a bundle and a server
+  // that disagree about the shape degrade instead of breaking. Absent ⇒ the
+  // default (strip OFF, colours render). `buildWireMap()` always populates it.
+  strip_formatting?: boolean;
 };
 
 export type DisplayPrefsResponse = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50334,6 +50334,17 @@ CI will not catch its absence.** Widening the digest's coverage is a change
 the pin deliberately cannot tell apart from a shape change, so it is not
 smuggled in here either.
 
+**Which gate DID hold, and it is not the one you would name.** The bump has a
+second half — cic's `CLIENT_PROTOCOL_VERSION` (socket.ts), what the bundle
+SPEAKS — and this branch shipped the server half without it. #1973's
+`protocol_test.exs` is what went red: *"cicchetto declares
+CLIENT_PROTOCOL_VERSION = 14 while the server speaks 15"*. So on a payload the
+codegen does not cover, that pin is the ONLY automatic guard on the pair, and
+it was carrying the whole change alone. Worth knowing in the order the failure
+arrives: `wire_pin` is silent, `protocol_test` is not. (cic's OTHER constant,
+`MIN_SERVER_PROTOCOL_VERSION`, correctly stays at 9 — it says what cic
+REQUIRES, and the new key is absent-tolerant.)
+
 ### One chokepoint, twelve surfaces, and why the issue's list was not used
 
 The issue enumerates *"channel and query panes, notices, quit/part reasons,

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50265,3 +50265,129 @@ refusal tests and nothing else.
 
 _Client-only. No wire change, no protocol bump, no migration. The verification
 that matters is vjt's, on device, with the flag on._
+<!-- entry #2029 -->
+
+---
+
+## 2026-09-09 — #2029: stripping mIRC formatting on render, and a gate that stayed silent twice
+
+`morph` (Azzurra staff) asked for a setting that renders messages with the
+mIRC control codes REMOVED, after a channel filled up with heavily coloured
+bot output. The neighbour to rule out first is channel mode `+c`, and it is a
+different thing on both axes: it is an operator's channel-wide policy rather
+than a per-viewer preference, and it REJECTS the message, so the reader loses
+the words along with the colours. This strips on RENDER — the words still
+arrive, they just arrive plain. Default OFF.
+
+### The issue said "client-side"; the codebase said otherwise, and the codebase won
+
+The issue's Scope section opens *"Setting lives client-side in cicchetto, per
+user, persisted with the other display preferences"*. The last five words are
+the ones that decide it, and they point at `display_prefs` — which has been
+SERVER-backed since #449 (`GET/PUT /me/settings/display-prefs`,
+`UserSettings.default_display_prefs/0` the authority). So the sentence is
+self-contradicting: persisting it *with the other display preferences* is
+exactly what makes it not client-side. Issue text is DATA about a defect, not
+an instruction about the fix.
+
+That does not settle it by itself, because a local-only class genuinely
+exists: `fontSize.ts` is localStorage with a stated reason (*"cic owns mobile
+UX; no server-side persistence, no wire bleed"*). The criterion for choosing
+between them was already fixed by #1766 and is not re-litigated here: a
+per-DEVICE toggle is right when the complaint is about a **viewport** (#914's
+`hide_next_active`, a fixed overlay on a phone), and wrong when it is about
+the **account**. A channel full of coloured bot output is identical on the
+phone and on the desktop. Reinforcing rather than deciding: the pref's nearest
+neighbour BY SHAPE — `colored_nicklist`, a boolean colour-rendering toggle —
+sits in the same settings fieldset and is synced, and two adjacent checkboxes
+that persist differently is a promise the interface should not break.
+
+### 🔴 The pin did not force the bump, and this is the SECOND carrier to prove it
+
+`Grappa.Protocol.version/0` moves 14 → 15, under #1393d: `display_prefs` is a
+client-facing REST payload and its shape changed, which is enough on its own.
+`@min_protocol_version` stays at 1, and cic's `MIN_SERVER_PROTOCOL_VERSION`
+stays at 9 — the key is absent-tolerant in BOTH directions
+(`fetch_optional_display_bool/3` server-side, `?? DEFAULT_DISPLAY_PREFS`
+client-side), so a bundle carrying it degrades against an older server instead
+of breaking.
+
+#1766 recorded that `mix grappa.wire_pin --check` *"did not force this and
+could not"*. That was its measurement of its own case; this is a fresh one, on
+this branch, and it agrees:
+
+* with `strip_formatting` ALREADY added to `Grappa.UserSettings` and the
+  version still reading **14**, the gate answered
+  `priv/wire/shape.pin: wire shape and protocol 14 agree.` at **rc=0**;
+* `--update` after the bump rewrote **one line**, `protocol_version 14 → 15`.
+  The digest is byte-identical before and after:
+  `sha256:f3c18a4c920e1bbf97d9fa7af80d1970fb3bbe47ef6e062d7f6f92817b4bf3c0`.
+
+One occurrence is an anecdote about `UserSettingsJSON`; two independent keys
+entering through the same hand-written `*_json.ex` and both passing green make
+it a property of the DETECTOR — the digest spans the codegen artefacts, whose
+sources are `lib/grappa/**/*wire.ex` plus a hand-kept list of web envelopes,
+and no hand-written JSON view is on it (the same silence #1679 hit with
+`BootJSON`). Consequence to carry forward rather than rediscover: **for a
+payload rendered by a hand-written `*_json.ex`, the bump is a manual act and
+CI will not catch its absence.** Widening the digest's coverage is a change
+the pin deliberately cannot tell apart from a shape change, so it is not
+smuggled in here either.
+
+### One chokepoint, twelve surfaces, and why the issue's list was not used
+
+The issue enumerates *"channel and query panes, notices, quit/part reasons,
+informational output"* and cites #142/#175. The set was derived from the code
+instead, and it is bigger: **39 `<MircBody>` call sites across 12 files**, of
+which **nine are surfaces the issue never names** (WhoisCard, WhowasCard,
+WhoModal, DirectoryPane topics, LinksModal, ServiceModal, ServerReplyModal,
+ServerInfoCard, RegistrationWizardModal).
+
+None of them were touched. `parseMircFormat` has exactly **one** production
+render caller — `MircText.tsx`'s `MircBody` — and `MIRC_PALETTE` has **zero**
+consumers outside `mircFormat.ts`, so colour resolution cannot leave the
+parser. One line at that chokepoint reaches every surface, including the nine.
+That is also the answer to *"if a surface renders colour, it must honour the
+strip"*: honoured by construction, not by a list that would rot the next time
+a card learns to render a body.
+
+### `mircPlainRuns`, and why it is not a second stripper
+
+`mircPlainText` (#142) already existed and already strips — for STRING
+surfaces (a `title` attribute), and it is the client twin of #1908's
+match-side strip. It could not be reused verbatim: a string cannot carry the
+run boundaries the renderer needs. `mircPlainRuns` is its render-side sibling
+— same input, same one parser, run structure kept, attributes cleared. The
+control bytes are still removed by `parseMircFormat` and nowhere else; what is
+new is only the projection. A fresh scanner over `\x03`/`\x02` here would have
+been the second implementation of the rule, and that is the thing forbidden.
+
+**The runs are deliberately NOT merged.** Merging them would repair a URL that
+a colour code splits mid-link (linkify runs per-run) — a real improvement, and
+a behaviour change with nothing to do with removing colours. It does not ride
+in on this issue's back; if it is worth having it is worth its own issue.
+
+### Two smaller things that would have rotted
+
+`mircPlainText`'s comment said *"This is NOT a render strip (the visible body
+always routes through `MircBody`)"*. #2029 makes that false, so it is
+rewritten in the same commit rather than left to mislead a future reader into
+thinking no render strip exists.
+
+The display fieldset's blurb read *"The first two follow your account onto
+every device you use"*. A third synced row makes it wrong, and nothing
+type-checks a sentence — so it is rephrased by BEHAVIOUR (*"Only the jump
+button is remembered on this device alone — the rest follow your account"*),
+which the next added row cannot falsify.
+
+### Open, and shipped anyway
+
+Two product questions were put to vjt and are unanswered at merge: whether the
+strip should also apply to one's OWN outgoing messages, and whether OFF is the
+right default. What shipped: the strip acts at the chokepoint, which makes the
+first a "yes, everything visible" at no cost, and the default is OFF as the
+issue specifies. Both are small, localised changes if the answers differ.
+
+_Not asserted: that the pref reaches every surface has been measured through
+the chokepoint (one parse caller, zero palette consumers elsewhere), not by
+exercising all twelve in a browser. The e2e covers one channel-pane line._

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -298,7 +298,30 @@ defmodule Grappa.Protocol do
   # @min_protocol_version stays at 1: no bundle predating v14 knows the
   # `/ignore` verb, so none can send the request that earns the new token —
   # the only frame an old client could fail to read is one it cannot cause.
-  @protocol_version 14
+  #
+  # v15 (#2029) — `display_prefs` grows a FIFTH key, `strip_formatting`: the
+  # per-viewer opt-in that renders message bodies with the mIRC control codes
+  # stripped. Same carrier as v6's `show_bottom_bar`, same reason it counts:
+  # `display_prefs` is a client-facing REST payload and its shape changed,
+  # which under the #1393d ruling is enough on its own.
+  #
+  # 🔴 `mix grappa.wire_pin --check` DID NOT force this bump, and the run is
+  # on the record rather than inherited from v6: with the key already added to
+  # `Grappa.UserSettings` and this number still reading 14, the gate answered
+  # `wire shape and protocol 14 agree.` at rc=0. The digest spans the codegen
+  # artefacts, whose sources are `lib/grappa/**/*wire.ex` plus a hand-kept
+  # list of web envelopes, and `GrappaWeb.UserSettingsJSON` is on neither —
+  # the same silence #1679 hit with `BootJSON`. v6 recorded that as a gap in
+  # the DETECTOR; a second carrier hitting it identically makes it a property
+  # of every hand-written `*_json.ex`, so the bump here is a deliberate manual
+  # act and the next one will be too, until the digest's coverage widens.
+  #
+  # @min_protocol_version stays at 1, and deliberately: the key is absent-
+  # tolerant in BOTH directions (`fetch_optional_display_bool/3` server-side,
+  # `?? DEFAULT_DISPLAY_PREFS` client-side), so a bundle carrying it degrades
+  # against an older server instead of breaking. cic's own
+  # MIN_SERVER_PROTOCOL_VERSION does not move for the same reason.
+  @protocol_version 15
   @min_protocol_version 1
 
   @doc "The protocol version the server currently speaks."
@@ -309,7 +332,7 @@ defmodule Grappa.Protocol do
   # alongside `@protocol_version`; the spec doubles as the bump tripwire,
   # and now that the bump is routine the tripwire is what keeps it from
   # being done half-way.
-  @spec version() :: 14
+  @spec version() :: 15
   def version, do: @protocol_version
 
   @doc """

--- a/lib/grappa/protocol.ex
+++ b/lib/grappa/protocol.ex
@@ -319,8 +319,14 @@ defmodule Grappa.Protocol do
   # @min_protocol_version stays at 1, and deliberately: the key is absent-
   # tolerant in BOTH directions (`fetch_optional_display_bool/3` server-side,
   # `?? DEFAULT_DISPLAY_PREFS` client-side), so a bundle carrying it degrades
-  # against an older server instead of breaking. cic's own
+  # against an older server instead of breaking. cic's
   # MIN_SERVER_PROTOCOL_VERSION does not move for the same reason.
+  #
+  # cic's OTHER constant does: `CLIENT_PROTOCOL_VERSION` (socket.ts) moves
+  # 14 → 15 in lockstep, because it says what cic SPEAKS rather than what it
+  # requires. #1973's `protocol_test.exs` pin is what caught the half-done bump
+  # here — and with `wire_pin --check` blind to this payload, that pin was the
+  # ONLY automatic guard standing on this change.
   @protocol_version 15
   @min_protocol_version 1
 

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -236,7 +236,8 @@ defmodule Grappa.UserSettings do
           time_format: String.t(),
           colored_nicklist: boolean(),
           presence_filter: %{String.t() => String.t()},
-          show_bottom_bar: boolean()
+          show_bottom_bar: boolean(),
+          strip_formatting: boolean()
         }
 
   @notification_prefs_key "notification_prefs"
@@ -1571,13 +1572,21 @@ defmodule Grappa.UserSettings do
   @doc """
   Default display preferences applied when a subject has no row OR the
   `"display_prefs"` key is absent: `"hms"` timestamps, monochrome nicklist,
-  an empty presence-filter map (every channel follows the size default), and
-  the mobile window bar SHOWN (#1766 is an opt-out, never a default change).
+  an empty presence-filter map (every channel follows the size default),
+  the mobile window bar SHOWN (#1766 is an opt-out, never a default change),
+  and mIRC formatting RENDERED (#2029 is an opt-in: colours keep working as
+  they do today until a reader asks for them to stop).
   """
   @dialyzer {:nowarn_function, default_display_prefs: 0}
   @spec default_display_prefs() :: display_prefs()
   def default_display_prefs do
-    %{time_format: "hms", colored_nicklist: false, presence_filter: %{}, show_bottom_bar: true}
+    %{
+      time_format: "hms",
+      colored_nicklist: false,
+      presence_filter: %{},
+      show_bottom_bar: true,
+      strip_formatting: false
+    }
   end
 
   @doc """
@@ -1634,9 +1643,10 @@ defmodule Grappa.UserSettings do
 
     * `time_format` ∈ #{inspect(@display_time_formats)}.
     * `colored_nicklist` is a boolean.
-    * `show_bottom_bar` is a boolean IF PRESENT; an absent key takes the
-      default (#1766). Every other key 422s when missing, and that asymmetry
-      is deliberate — see `fetch_optional_display_bool/3`.
+    * `show_bottom_bar` (#1766) and `strip_formatting` (#2029) are booleans
+      IF PRESENT; an absent key takes the default. The two keys added since
+      the shape first shipped are exactly the two that tolerate absence, and
+      that asymmetry is deliberate — see `fetch_optional_display_bool/3`.
     * `presence_filter` is a `%{channel_key => "show" | "hide"}` map. Any
       other value (a boolean, a third state) is REJECTED — the tri-state's
       unset is the ABSENCE of a key, never a stored value, so the server
@@ -2268,7 +2278,8 @@ defmodule Grappa.UserSettings do
       time_format: read_display_time_format(stored),
       colored_nicklist: read_display_bool(stored, :colored_nicklist, false),
       presence_filter: read_presence_filter(stored),
-      show_bottom_bar: read_display_bool(stored, :show_bottom_bar, true)
+      show_bottom_bar: read_display_bool(stored, :show_bottom_bar, true),
+      strip_formatting: read_display_bool(stored, :strip_formatting, false)
     }
   end
 
@@ -2304,13 +2315,15 @@ defmodule Grappa.UserSettings do
     with {:ok, tf} <- fetch_display_time_format(prefs),
          {:ok, cn} <- fetch_display_bool(prefs, :colored_nicklist),
          {:ok, pf} <- fetch_presence_filter(prefs),
-         {:ok, sbb} <- fetch_optional_display_bool(prefs, :show_bottom_bar, true) do
+         {:ok, sbb} <- fetch_optional_display_bool(prefs, :show_bottom_bar, true),
+         {:ok, sf} <- fetch_optional_display_bool(prefs, :strip_formatting, false) do
       {:ok,
        %{
          "time_format" => tf,
          "colored_nicklist" => cn,
          "presence_filter" => pf,
-         "show_bottom_bar" => sbb
+         "show_bottom_bar" => sbb,
+         "strip_formatting" => sf
        }}
     else
       {:error, message} -> {:error, display_prefs_changeset_error(message, subject)}
@@ -2348,6 +2361,11 @@ defmodule Grappa.UserSettings do
   # documented full-replace path into a per-key read-modify-write that the
   # NEXT added key would have to remember too. The window is one bundle
   # reload wide and it self-heals; the drift would not.
+  #
+  # #2029 IS that next key, and its arrival is what turns the paragraph above
+  # from a prediction into a rule: every key added after the shape shipped
+  # enters through here, and a new one that reaches for `fetch_display_bool/2`
+  # instead would 422 every PUT from every bundle that predates it.
   defp fetch_optional_display_bool(prefs, key, default) when is_atom(key) do
     if display_has_key?(prefs, key) do
       fetch_display_bool(prefs, key)

--- a/priv/wire/shape.pin
+++ b/priv/wire/shape.pin
@@ -9,5 +9,5 @@
 # This line states the COVERAGE on purpose: widening or narrowing what
 # the digest spans is not a wire-shape change, the gate cannot tell one
 # from the other, and reading the pin is the only place a review sees it.
-protocol_version = 14
+protocol_version = 15
 shape_digest = sha256:f3c18a4c920e1bbf97d9fa7af80d1970fb3bbe47ef6e062d7f6f92817b4bf3c0

--- a/test/grappa/user_settings_display_prefs_test.exs
+++ b/test/grappa/user_settings_display_prefs_test.exs
@@ -490,8 +490,10 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       user = user_fixture()
 
       older_body =
-        valid_wire(%{"time_format" => "hm", "colored_nicklist" => true})
-        |> Map.delete("strip_formatting")
+        Map.delete(
+          valid_wire(%{"time_format" => "hm", "colored_nicklist" => true}),
+          "strip_formatting"
+        )
 
       assert {:ok, _} = UserSettings.put_display_prefs({:user, user.id}, older_body)
 

--- a/test/grappa/user_settings_display_prefs_test.exs
+++ b/test/grappa/user_settings_display_prefs_test.exs
@@ -5,9 +5,9 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
   account converges its UI across devices (report: desktop toggle didn't
   reach the iOS PWA because the prefs were localStorage-only).
 
-  The four prefs: `time_format` (`"hms" | "hm"`, #217), `colored_nicklist`
-  (boolean, #443), `presence_filter` (a per-channel tri-state map, #222), and
-  `show_bottom_bar` (boolean, #1766).
+  The five prefs: `time_format` (`"hms" | "hm"`, #217), `colored_nicklist`
+  (boolean, #443), `presence_filter` (a per-channel tri-state map, #222),
+  `show_bottom_bar` (boolean, #1766), and `strip_formatting` (boolean, 2029).
 
   ## The tri-state invariant (NON-NEGOTIABLE)
 
@@ -41,7 +41,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
         "time_format" => "hms",
         "colored_nicklist" => false,
         "presence_filter" => %{},
-        "show_bottom_bar" => true
+        "show_bottom_bar" => true,
+        "strip_formatting" => false
       },
       overrides
     )
@@ -59,7 +60,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                time_format: "hms",
                colored_nicklist: false,
                presence_filter: %{},
-               show_bottom_bar: true
+               show_bottom_bar: true,
+               strip_formatting: false
              }
     end
 
@@ -72,7 +74,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                time_format: "hms",
                colored_nicklist: false,
                presence_filter: %{},
-               show_bottom_bar: true
+               show_bottom_bar: true,
+               strip_formatting: false
              }
     end
 
@@ -91,7 +94,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                time_format: "hm",
                colored_nicklist: false,
                presence_filter: %{},
-               show_bottom_bar: true
+               show_bottom_bar: true,
+               strip_formatting: false
              }
     end
 
@@ -107,7 +111,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                time_format: "hms",
                colored_nicklist: false,
                presence_filter: %{},
-               show_bottom_bar: true
+               show_bottom_bar: true,
+               strip_formatting: false
              }
     end
   end
@@ -166,7 +171,7 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
   # ---------------------------------------------------------------------------
 
   describe "put_display_prefs/2 — round-trip" do
-    test "persists all four prefs and reads them back" do
+    test "persists all five prefs and reads them back" do
       user = user_fixture()
 
       body =
@@ -182,7 +187,8 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
                time_format: "hm",
                colored_nicklist: true,
                presence_filter: %{"libera #bofh" => "hide", "libera #cat" => "show"},
-               show_bottom_bar: true
+               show_bottom_bar: true,
+               strip_formatting: false
              }
     end
 
@@ -424,6 +430,120 @@ defmodule Grappa.UserSettingsDisplayPrefsTest do
       |> Repo.update!()
 
       assert UserSettings.get_display_prefs({:user, user.id}).show_bottom_bar == true
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # strip_formatting (#2029) — the FIFTH key, and the proof the fourth's
+  # tolerance was a pattern rather than a one-off
+  # ---------------------------------------------------------------------------
+  #
+  # Requested by `morph` (Azzurra staff) after a channel filled with heavily
+  # coloured bot output: render incoming messages with the mIRC control codes
+  # STRIPPED. Not `+c`, which is a channel-wide operator policy that REJECTS
+  # the message and so costs the reader the text along with the colours.
+  #
+  # The pref is server-backed rather than a localStorage flag, on #1766's own
+  # criterion: a per-DEVICE toggle is right when the complaint is about a
+  # VIEWPORT (#914's `hide_next_active`), and wrong when it is about the
+  # ACCOUNT. A channel full of coloured bot output is identical on the phone
+  # and on the desktop, so this is the account axis — and its nearest
+  # neighbour by shape, `colored_nicklist`, is synced for the same reason.
+  #
+  # `fetch_optional_display_bool/3` is what makes the fifth key free: #1766
+  # wrote it for the fourth and said in as many words that the NEXT added key
+  # would have to remember it too. This block is that key remembering.
+
+  describe "strip_formatting (#2029)" do
+    test "defaults to false — colours keep rendering as they do today" do
+      assert UserSettings.default_display_prefs().strip_formatting == false
+
+      assert UserSettings.get_display_prefs({:user, Ecto.UUID.generate()}).strip_formatting ==
+               false
+    end
+
+    test "round-trips true" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               UserSettings.put_display_prefs(
+                 {:user, user.id},
+                 valid_wire(%{"strip_formatting" => true})
+               )
+
+      assert UserSettings.get_display_prefs({:user, user.id}).strip_formatting == true
+    end
+
+    test "a PUT from a client predating the key is ACCEPTED, and reads as the default" do
+      user = user_fixture()
+      older_body = Map.delete(valid_wire(), "strip_formatting")
+
+      assert {:ok, _} = UserSettings.put_display_prefs({:user, user.id}, older_body)
+      assert UserSettings.get_display_prefs({:user, user.id}).strip_formatting == false
+    end
+
+    # The other half of the skew, and the one that would silently break the
+    # PREVIOUS four keys: a bundle that predates this one sends four keys, and
+    # a mandatory fifth would 422 its every display write — the operator's
+    # time-format and nicklist toggles would quietly stop persisting.
+    test "a four-key PUT still persists the keys it DID send" do
+      user = user_fixture()
+
+      older_body =
+        valid_wire(%{"time_format" => "hm", "colored_nicklist" => true})
+        |> Map.delete("strip_formatting")
+
+      assert {:ok, _} = UserSettings.put_display_prefs({:user, user.id}, older_body)
+
+      prefs = UserSettings.get_display_prefs({:user, user.id})
+      assert prefs.time_format == "hm"
+      assert prefs.colored_nicklist == true
+    end
+
+    test "rejects a non-boolean strip_formatting — absent is tolerated, garbage is not" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               UserSettings.put_display_prefs(
+                 {:user, user.id},
+                 valid_wire(%{"strip_formatting" => "yes"})
+               )
+
+      assert cs.errors[:display_prefs]
+    end
+
+    test "accepts an atom key too (parity with the sibling booleans)" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               UserSettings.put_display_prefs({:user, user.id}, %{
+                 time_format: "hms",
+                 colored_nicklist: false,
+                 presence_filter: %{},
+                 show_bottom_bar: true,
+                 strip_formatting: true
+               })
+
+      assert UserSettings.get_display_prefs({:user, user.id}).strip_formatting == true
+    end
+
+    test "a stored blob predating the key reads false, not nil" do
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+
+      settings
+      |> Settings.changeset(%{
+        data:
+          Map.put(settings.data, "display_prefs", %{
+            "time_format" => "hm",
+            "colored_nicklist" => true,
+            "presence_filter" => %{},
+            "show_bottom_bar" => true
+          })
+      })
+      |> Repo.update!()
+
+      assert UserSettings.get_display_prefs({:user, user.id}).strip_formatting == false
     end
   end
 

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -665,9 +665,9 @@ defmodule GrappaWeb.UserSettingsControllerTest do
   # ===========================================================================
   # display_prefs (#449) — server-backed display preferences, so one account
   # converges its UI across devices. Wrapped-envelope endpoint mirroring
-  # aliases; full-map PUT, no PATCH/diff. Four prefs: time_format,
-  # colored_nicklist, presence_filter (per-channel tri-state map), and
-  # show_bottom_bar (#1766).
+  # aliases; full-map PUT, no PATCH/diff. Five prefs: time_format,
+  # colored_nicklist, presence_filter (per-channel tri-state map),
+  # show_bottom_bar (#1766), and strip_formatting (#2029).
   #
   # A/B-INDEPENDENT core: font-size (Fork A, escalated to vjt) and the
   # client-side seed-up-once migration (Fork B) are NOT exercised here.
@@ -679,7 +679,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       "time_format" => "hms",
       "colored_nicklist" => false,
       "presence_filter" => %{},
-      "show_bottom_bar" => true
+      "show_bottom_bar" => true,
+      "strip_formatting" => false
     }
   end
 
@@ -734,7 +735,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
                "time_format" => "hm",
                "colored_nicklist" => true,
                "presence_filter" => %{"libera #bofh" => "hide"},
-               "show_bottom_bar" => true
+               "show_bottom_bar" => true,
+               "strip_formatting" => false
              }
     end
 
@@ -807,6 +809,31 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
       assert %{"display_prefs" => returned} = json_response(conn, 200)
       assert returned["show_bottom_bar"] == true
+    end
+
+    # #2029 — the fifth key through the HTTP door. `true` is the non-default
+    # side here (the strip ships OFF), so a payload that carried the key and
+    # normalised it away would pass every other test in this block.
+    test "200 + round-trips strip_formatting: true", %{conn: conn, user: user} do
+      body = %{"display_prefs" => Map.put(default_display_prefs_wire(), "strip_formatting", true)}
+
+      conn = put(conn, "/me/settings/display-prefs", body)
+
+      assert %{"display_prefs" => returned} = json_response(conn, 200)
+      assert returned["strip_formatting"] == true
+      assert UserSettings.get_display_prefs({:user, user.id}).strip_formatting == true
+    end
+
+    # The same tolerance the fourth key bought, exercised for the fifth: a
+    # bundle that predates this one keeps PUTting four keys and must not start
+    # 422ing — that would silently break its OTHER display toggles.
+    test "200 for a four-key body (no strip_formatting)", %{conn: conn} do
+      body = %{"display_prefs" => Map.delete(default_display_prefs_wire(), "strip_formatting")}
+
+      conn = put(conn, "/me/settings/display-prefs", body)
+
+      assert %{"display_prefs" => returned} = json_response(conn, 200)
+      assert returned["strip_formatting"] == false
     end
 
     test "PUT response carries persisted:true", %{conn: conn} do


### PR DESCRIPTION
## What

A per-viewer display preference that renders message bodies with the mIRC
formatting control codes **stripped**. Requested on IRC by `morph` (Azzurra
staff) after a channel filled up with heavily coloured bot output. Default
**OFF** — colours keep rendering exactly as they do today.

Deliberately not channel mode `+c`: that is an operator's channel-wide policy
and it **rejects** the message, costing the reader the words along with the
colours. This strips on **render**, so the words still arrive — they just
arrive plain. The raw line is untouched on the wire and in scrollback, which
is what makes turning it back off restore the colours with no reconnect.

## 🪞 The issue says "client-side". The code said otherwise, and the code won

Issue 2029's Scope section opens with *"Setting lives client-side in
cicchetto, per user, persisted with the other display preferences"* — and
those two halves contradict each other. The other display preferences have
been **server-backed since #449** (`GET/PUT /me/settings/display-prefs`,
`UserSettings.default_display_prefs/0` the authority), so persisting it *with
them* is precisely what makes it not client-side.

Issue text is **data about a defect, not an instruction about the fix**. The
measurement that settles it, three lines of source:

- `cicchetto/src/lib/displayPrefs.ts:15` — imports `getDisplayPrefs` / `putDisplayPrefs`
- `cicchetto/src/lib/userSettings.ts:356` — `GET /me/settings/display-prefs`
- `lib/grappa/protocol.ex:120` — *"v6 (#1766) adds `show_bottom_bar` to the `display_prefs` object"*

A local-only class does genuinely exist (`fontSize.ts`, localStorage, with a
stated reason). The criterion for choosing between the two was already fixed
by #1766 and is applied rather than invented here: **per-device when the
complaint is about a viewport** (#914's `hide_next_active`), **synced when it
is about the account**. A channel full of coloured bot output looks identical
on the phone and on the desktop. Reinforcing, not deciding: the pref's nearest
neighbour by shape — `colored_nicklist`, a boolean colour-rendering toggle —
sits in the same settings fieldset and is synced.

## 🔴 Protocol 14 → 15, and the gate that did not ask for it

`display_prefs` is a client-facing REST payload and its shape changed, which
under the #1393d ruling is enough on its own.

**The bump is a manual act, and this branch measured why.** With
`strip_formatting` already added to `Grappa.UserSettings` and the version still
reading 14:

```
priv/wire/shape.pin: wire shape and protocol 14 agree.      rc=0
```

`--update` after the bump rewrote exactly one line, `protocol_version 14 → 15`,
leaving the digest byte-identical
(`sha256:f3c18a4c920e1bbf97d9fa7af80d1970fb3bbe47ef6e062d7f6f92817b4bf3c0`).

#1766 recorded the same silence for the fourth key and called it a gap in the
detector. Two independent keys entering through the same hand-written
`*_json.ex` and both passing green make it a **property of the detector**: the
digest spans the codegen artefacts, and no hand-written JSON view is in its
coverage (the same silence #1679 hit with `BootJSON`). Widening that coverage
is a change the pin cannot distinguish from a shape change, so it is not
smuggled in here.

`min_protocol_version` stays at 1 and cic's `MIN_SERVER_PROTOCOL_VERSION` stays
at 9 — the key is absent-tolerant in **both** directions
(`fetch_optional_display_bool/3` server-side, `?? DEFAULT_DISPLAY_PREFS`
client-side), so a bundle carrying it degrades against an older server rather
than breaking.

**Which gate actually held.** The bump has a second half — cic's
`CLIENT_PROTOCOL_VERSION` (what the bundle *speaks*) — and this branch first
shipped the server half without it. #1973's `protocol_test.exs` went red and
said so by name. With `wire_pin` blind to this payload, **that pin was the only
automatic guard standing on this change**, and it caught the missing half. The
order the failures arrive in is worth knowing: `wire_pin` silent,
`protocol_test` loud.

## One chokepoint, twelve surfaces

The issue lists the surfaces to cover; that list is prose, so the set was
derived from the code. **Measured: 39 `<MircBody>` call sites across 12
files**, nine of them surfaces the issue never names — `WhoisCard`,
`WhowasCard`, `WhoModal`, `DirectoryPane` topics, `LinksModal`,
`ServiceModal`, `ServerReplyModal`, `ServerInfoCard`,
`RegistrationWizardModal`.

**None of the twelve were touched.** `parseMircFormat` has exactly **one**
production render caller (`MircBody`) and `MIRC_PALETTE` has **zero** consumers
outside `mircFormat.ts`, so colour resolution cannot leave the parser. One line
there reaches every surface. That is what makes *"if a surface renders colour,
it must honour the strip"* true by construction instead of by a list that rots.

## Reuse: one tool, and one twin left alone

`mircPlainText` (#142) already strips — for **string** surfaces (a `title`
attribute) — and it is the client twin of #1908's match-side strip. It could
not be called at the chokepoint: a string cannot carry the run boundaries the
renderer needs. `mircPlainRuns` is its render-side sibling: same input, **same
one parser**, run structure kept, attributes cleared. The control bytes are
still removed by `parseMircFormat` and nowhere else, so this is not a second
stripper.

The **client and server** strippers (`mircFormat.ts` / `Grappa.IRC.MircFormat`)
are deliberately left as two implementations in two languages — consciously
twinned, like `nickEquals` / `canonical_target`. This is a render change; it
touches the client one only, and forcing a cross-language reuse would not hold.

**The runs are deliberately NOT merged.** Merging would repair a URL that a
colour code splits mid-link (linkify runs per-run) — a real improvement, and a
behaviour change with nothing to do with removing colours. A test pins the
boundaries so a future merge has to be a deliberate act.

## Two product questions are open, and this says what shipped meanwhile

Put to vjt, **not yet answered**:

1. whether the strip should also apply to one's **own outgoing** messages;
2. whether **OFF** is the right default.

What shipped in the meantime: the strip acts at the chokepoint, which makes (1)
a *"yes, everything visible"* at no extra cost, and the default is **OFF** as
the issue specifies. Both are small, localised changes if the answers differ.

## Tests

- **vitest** — the parser projection (with a negative control proving the
  fixture is not vacuous), the owner module (including the **tracked read**,
  the one assertion a `localStorage.getItem` implementation fails), both
  directions of the wire skew, and the chokepoint's rendered output.
- **e2e** (`issue2029-strip-mirc-formatting.spec.ts`) — asserts the **visible
  outcome** in a real engine: a coloured line is put on screen **once**, then
  the toggle is flipped and the **same on-screen line** is re-read. No reload,
  no rejoin, no second PRIVMSG. The default-OFF arm doubles as the negative
  control, and an untouched tail word distinguishes *formatting removed* from
  *text eaten*.
- **Mutation-tested.** Two mutants, two distinct kill sets — see the branch
  report for the exact names.

## Not claimed

That the pref reaches all twelve surfaces is established **through the
chokepoint** (one parse caller, zero palette consumers elsewhere), not by
exercising all twelve in a browser. The e2e covers one channel-pane line.

## Gates

| gate | result |
|---|---|
| `scripts/check.sh` | rc=0 — 8 doctests, 65 properties, 7237 tests, 0 failures |
| `scripts/bun.sh run test` | rc=0 — 342 files, 6921 tests |
| `scripts/bun.sh run check` | rc=0 — biome + tsc, 5/5 |
| `scripts/design-notes-gate.sh` | rc=0, re-run alone on the final tree |
| `scripts/integration.sh` (**full**, 964 specs) | rc=1 — **962 passed / 1 skipped / 1 failed** |

Every rc above was read from a file, never from a wrapper's exit code — the
background-task notification for the integration run reported `exit code 0`
while the run's own `rc` file held `1`.

**The one red is issue 2026, and it is not this branch.** The failing case is
`issue1964-upload-confirm-preview.spec.ts:97`, whose video-decode witness polls
`MEDIA_ERR_SRC_NOT_SUPPORTED` (`Expected: 0 / Received: 4`) for the full 5 s —
a host-specific red already filed as a separate defect, born on `main` in
`106ae53b0` a day before this branch existed.

Two measurements were added rather than assumed:

- **deterministic, not a flake** — an iso-rerun of that single case on this
  branch reproduced it, rc=1.
- **a base control** — the same case, run from a detached worktree at the merge
  base `b1c585e49` with **none** of this branch's code, fails with the
  **byte-identical** signature. That control is what attributes the red to the
  base rather than to the diff; the filed defect did not yet carry one.

`scripts/check.sh` started after `96c6a5f5f`; the prose-only DESIGN_NOTES edit
in `21f43d064` landed while it ran, which is why the design-notes gate was
re-run on its own against the final tree. The code check.sh covered is final.
