### PR TITLE
cicchetto: a visibility-return is a resume, so it must not move the reader (issue 2032)

### DIFF
--- a/cicchetto/e2e/tests/issue2032-visibility-return-preserve-position.spec.ts
+++ b/cicchetto/e2e/tests/issue2032-visibility-return-preserve-position.spec.ts
@@ -1,0 +1,290 @@
+// issue 2032 — returning from an EXTERNAL link must leave the reader exactly
+// where they were, even when an unread divider renders on the return.
+//
+// Reported: tapping a link that leaves the app (external browser / another tab)
+// and coming back moves the reader off the position they were reading at.
+// Desktop AND mobile, long-standing. Modals are unaffected — they never hide the
+// document, so the pane holds position through `overlay-freeze` (a different
+// writer).
+//
+// ## What this file adds that issue535-visibility-return-preserve-scroll.spec.ts
+// ## could not catch
+//
+// #535 shipped `"marker-or-preserve"`, a mode that PRESERVES only when NO
+// divider renders — with a divider present it `scrollIntoView`s it, i.e. it
+// moves the reader. Its own spec pinned that as the contract ("return lands ON
+// the divider"), so the whole divider-present half of the space was green by
+// construction. The discriminating case is therefore the one with a divider
+// PRESENT on the return; without one the code already preserves and any test is
+// vacuous.
+//
+// Two writers move the reader on a visibility-return, and BOTH must be held:
+//
+//   1. the divider JUMP — `scrollToActivation` reads the `unread-marker` node
+//      for `"marker-or-preserve"` exactly as it does for a deliberate switch;
+//   2. the divider RE-LATCH — the visibility arm re-pointed `markerCursorId` at
+//      the LIVE read cursor, which recomputes `rows()`; `<For>` is keyed by
+//      reference and every row is a fresh object, so the DOM list is recreated
+//      and scrollTop collapses to 0. Today that reset is MASKED by writer 1
+//      landing somewhere immediately after it.
+//
+// The test below exercises BOTH: the reader reads DOWNWARD past the frozen
+// divider, which arms the input-gated scroll-settle (`SCROLL_SETTLE_DEBOUNCE_MS`
+// = 500) and advances the LIVE cursor past the divider — so on return the
+// re-latch has somewhere new to point. Removing only writer 1 leaves the reader
+// at scrollTop 0; removing only writer 2 leaves them on the divider. The
+// contract holds only when both are gone.
+//
+// ## Contract
+//
+// A visibility-return is a RESUME, not a window change: it preserves the
+// reader's scroll position and leaves the frozen divider where it was. Only a
+// DELIBERATE activation (switch / cold-mount) lands on the divider — guarded by
+// the second test here, and more fully by scroll-on-window-switch.spec.ts
+// ("SWITCH into channel-with-unreads", "fresh focus / cold-mount") which this
+// file deliberately does not restate.
+//
+// ## Oracle
+//
+// scrollTop in RAW PIXELS against a sub-pixel epsilon — NOT
+// `SCROLL_BOTTOM_THRESHOLD_PX`. That constant is a product threshold for
+// classifying follow INTENT (50px, deliberately generous); reusing it as a
+// tolerance would swallow any defect smaller than the band. The defect here is
+// a viewport-scale jump, but the epsilon is sized to the MEASUREMENT, not to the
+// defect, so the spec stays honest if the jump ever shrinks.
+//
+// ## Fixture shape (matches issue535 / scroll-on-window-switch / cp14-b1)
+//
+// The 200 DB-seeded rows on `(specUser, bahamut-test, #spec-wN)` plus an 800×300
+// viewport so the 50-row REST page overflows — without overflow "not at the
+// tail" is vacuous. The per-spec subject (sha1 of the title path) owns its own
+// cursor, so no afterAll restore is needed.
+
+import type { Page } from "@playwright/test";
+import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+const REST_PAGE_SIZE = 50;
+
+// Sub-pixel measurement epsilon. Deliberately NOT SCROLL_BOTTOM_THRESHOLD_PX
+// (50) — see the "Oracle" note above.
+const SCROLL_EPS_PX = 2;
+
+// Clear of LOAD_MORE_THRESHOLD_PX (200) so paging older rows in never churns
+// the buffer under the assertions.
+const CLEAR_OF_TAIL_PX = 200;
+
+// ScrollbackPane.SCROLL_SETTLE_DEBOUNCE_MS = 500 (not exported; kept in lockstep
+// the same way issue535 mirrors SCROLL_BOTTOM_THRESHOLD_PX). The settle POST is
+// what advances the LIVE cursor past the frozen divider — the whole premise of
+// the re-latch case — so the wait must clear it with margin.
+const SCROLL_SETTLE_WAIT_MS = 900;
+
+async function scrollbackGeometry(
+  page: Page,
+): Promise<{ scrollTop: number; scrollHeight: number; clientHeight: number }> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
+  });
+}
+
+async function distanceFromBottom(page: Page): Promise<number> {
+  const g = await scrollbackGeometry(page);
+  return g.scrollHeight - g.scrollTop - g.clientHeight;
+}
+
+// The divider's offset from the top of the scroll container's VIEWPORT.
+// ~0 → the reader is parked on it (block:"start"); negative → the reader has
+// read PAST it and it is above the fold.
+async function markerViewportOffset(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
+    const m = document.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    if (!m) throw new Error("unread-marker not rendered");
+    return m.getBoundingClientRect().top - el.getBoundingClientRect().top;
+  });
+}
+
+// WHERE the frozen divider sits in the row list, independent of scroll. The
+// re-latch MOVES it; the freeze contract on a resume must not. Index among the
+// container's element children is stable under a tail append (the async
+// `refreshScrollback` co-trigger), which a pixel offset is not.
+async function markerRowIndex(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    const kids = Array.from(el.children);
+    const idx = kids.findIndex((c) => c.getAttribute("data-testid") === "unread-marker");
+    if (idx < 0) throw new Error("unread-marker not among scrollback children");
+    return idx;
+  });
+}
+
+// A REAL Chromium wheel gesture. Required twice over: `onScroll` only flips the
+// follow state on a genuine gesture, and the cursor scroll-settle is gated on a
+// recent INPUT event (`INPUT_EVENT_RECENCY_MS`) — a synthetic scroll event is
+// deliberately gated out (BUGHUNT-2), so it would never advance the cursor and
+// the re-latch premise would silently not hold. Same idiom as issue535.
+async function wheelBy(page: Page, deltaY: number): Promise<void> {
+  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
+  if (!box) throw new Error("scrollback bounding box null");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, deltaY);
+}
+
+// Flip document visibility deterministically. documentVisibility.ts reads BOTH
+// `document.visibilityState` AND `document.hasFocus()`, so both are overridden;
+// the production listeners' events are dispatched so the Solid signal updates.
+// Identical idiom to issue535 / freshness-on-activation.
+async function setTabHidden(page: Page, hidden: boolean): Promise<void> {
+  await page.evaluate((isHidden) => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => (isHidden ? "hidden" : "visible"),
+    });
+    Object.defineProperty(document, "hasFocus", {
+      configurable: true,
+      value: () => !isHidden,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event(isHidden ? "blur" : "focus"));
+  }, hidden);
+  await page.waitForTimeout(150);
+}
+
+// Seed a cursor `back` rows from the tail so an unread divider injects, then log
+// in and land on the channel. Returns nothing — callers assert their own
+// preconditions off the live DOM.
+async function seedCursorAndOpen(page: Page, back: number): Promise<void> {
+  const vjt = specUser();
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
+  expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  const cursorRow = page0[back];
+  if (!cursorRow) throw new Error(`seeded page too short for a cursor ${back} rows back`);
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect
+    .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+}
+
+test.describe("issue 2032 — a visibility-return resumes, it does not re-activate", () => {
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  test("reader who read PAST the divider: returning preserves scrollTop and leaves the divider frozen", async ({
+    page,
+  }) => {
+    // 45 rows of unread puts the divider near the TOP of the 50-row REST page,
+    // leaving room to read a long way DOWN past it without reaching the tail.
+    await seedCursorAndOpen(page, 45);
+
+    const marker = page.locator('[data-testid="unread-marker"]');
+    await expect(marker).toHaveCount(1);
+
+    // PREMISE 1 (and the #168 contract): the deliberate activation that opened
+    // this window landed ON the divider. If this ever stops holding, the case
+    // below is not the one this file claims to test and must die here rather
+    // than pass for the wrong reason.
+    const g0 = await scrollbackGeometry(page);
+    expect(g0.scrollHeight).toBeGreaterThan(g0.clientHeight);
+    // Poll the LANDING itself (the activation scroll settles inside a rAF×2),
+    // not a bound the pre-landing state would also satisfy.
+    await expect
+      .poll(async () => await markerViewportOffset(page), { timeout: 10_000 })
+      .toBeLessThan(g0.clientHeight / 2);
+    expect(await markerViewportOffset(page)).toBeGreaterThanOrEqual(-5);
+
+    // PREMISE 2: there is enough unread content BELOW the divider to read into
+    // without landing at the tail. Measured, not assumed — a shorter buffer
+    // would make the scroll-down below a no-op.
+    const room = await distanceFromBottom(page);
+    expect(room).toBeGreaterThan(2 * CLEAR_OF_TAIL_PX);
+
+    // The reader reads DOWNWARD through the unread run — a real wheel gesture,
+    // sized from the MEASURED room so it never depends on a row height. Half the
+    // remaining distance keeps them clear of the tail.
+    await wheelBy(page, Math.floor(room / 2));
+    await expect.poll(async () => await distanceFromBottom(page)).toBeGreaterThan(CLEAR_OF_TAIL_PX);
+
+    // Let the input-gated scroll-settle fire: it POSTs the visible-tail id and
+    // advances the LIVE read cursor PAST the frozen divider. This is what gives
+    // the visibility re-latch a new place to point.
+    await page.waitForTimeout(SCROLL_SETTLE_WAIT_MS);
+
+    // PREMISE 3: the reader is now BELOW the divider (it is above the fold) and
+    // the divider has NOT moved while they read — the freeze contract. Both are
+    // what make the re-latch on return observable.
+    expect(await markerViewportOffset(page)).toBeLessThan(0);
+    const beforeIndex = await markerRowIndex(page);
+    const before = await scrollbackGeometry(page);
+    expect(before.scrollTop).toBeGreaterThan(CLEAR_OF_TAIL_PX);
+
+    // Tap the link, leave the app, come back.
+    await setTabHidden(page, true);
+    await setTabHidden(page, false);
+    // Generous enough to contain the visibility effect's rAF×2 AND the async
+    // refreshScrollback append that can follow it.
+    await page.waitForTimeout(700);
+
+    // CONTRACT: the reader is exactly where they left off.
+    //
+    // RED pre-cure, two ways at once: the re-latch recomputes `rows()` and the
+    // ref-keyed `<For>` drops scrollTop to 0, then the divider jump lands the
+    // reader on the re-latched divider — neither is `before.scrollTop`.
+    const after = await scrollbackGeometry(page);
+    expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(SCROLL_EPS_PX);
+
+    // Not tail-snapped (the #535 regression) and not stranded at the top (the
+    // <For> recreation), stated as outcomes in their own right so a failure
+    // names WHICH way the reader was moved.
+    expect(after.scrollHeight - after.scrollTop - after.clientHeight).toBeGreaterThan(
+      CLEAR_OF_TAIL_PX,
+    );
+    expect(after.scrollTop).toBeGreaterThan(CLEAR_OF_TAIL_PX);
+
+    // The frozen divider stayed frozen: a resume is not a focus acquisition, so
+    // it does not re-latch to the live cursor.
+    await expect(marker).toHaveCount(1);
+    expect(await markerRowIndex(page)).toBe(beforeIndex);
+    expect(await markerViewportOffset(page)).toBeLessThan(0);
+  });
+
+  test("a DELIBERATE activation still lands on the divider (#168 must not regress)", async ({
+    page,
+  }) => {
+    // The cure narrows the divider query in `scrollToActivation` to the
+    // deliberate modes only. This is the guard that the narrowing did not take
+    // the deliberate arm with it. The pure window-SWITCH arm of the same mode is
+    // guarded by scroll-on-window-switch.spec.ts ("SWITCH into
+    // channel-with-unreads") and is not restated here.
+    await seedCursorAndOpen(page, 25);
+
+    const marker = page.locator('[data-testid="unread-marker"]');
+    await expect(marker).toHaveCount(1);
+    await expect(marker).toBeInViewport();
+
+    // Landed ON it (block:"start" → at/near the top of the viewport), not at the
+    // tail. The pane must overflow, or "did not land at the tail" is vacuous.
+    const g = await scrollbackGeometry(page);
+    expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
+    await expect
+      .poll(async () => await markerViewportOffset(page), { timeout: 10_000 })
+      .toBeLessThan(g.clientHeight / 2);
+    expect(await markerViewportOffset(page)).toBeGreaterThanOrEqual(-5);
+  });
+});

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -17,10 +17,15 @@
 // re-anchor already uses (ScrollbackPane onMount, ~:1495):
 //   * atBottom() true  → follow-live reader → keep "tail-only" (#46 resume
 //     family). Guarded by the third test below (must NOT regress).
-//   * atBottom() false → the reader deliberately left the tail → land on the
-//     re-latched unread divider if one renders, else preserve their scrollTop.
-//     NEVER tail-snap (owner ruling 2026-07-29: the only legitimate jump to the
-//     bottom is the operator's own send in the active window).
+//   * atBottom() false → the reader deliberately left the tail → preserve their
+//     scrollTop. NEVER tail-snap (owner ruling 2026-07-29: the only legitimate
+//     jump to the bottom is the operator's own send in the active window).
+//
+// ⚠️ AMENDED by issue 2032. #535 shipped that second arm as "land on the
+// re-latched unread divider if one renders, else preserve" — the divider half
+// was a defect (it moves a reader who asked for nothing) and has been removed
+// along with the re-latch that fed it. The mode is now `preserve-only`. The
+// second test below was rewritten accordingly; the other three are unchanged.
 //
 // This is the "resume ≠ switch" family, one-shot, no latch — the marker branch
 // stays scoped by the explicit `atBottom()` condition, so #168's collapse of
@@ -184,7 +189,18 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0);
   });
 
-  test("scrolled-up reader, unread divider present: return lands ON the divider, never tail-snaps", async ({
+  // ⚠️ REWRITTEN by issue 2032. This case used to assert "return lands ON the
+  // divider" — i.e. it PINNED the defect 2032 reports. #535 put
+  // `marker-or-preserve` in the divider query on the reading that a re-latched
+  // divider always sits at the reader's own position, so landing on it WAS
+  // landing where they were; the hide-edge cursor write is forward-only (#233),
+  // so that does not hold for a reader parked above the live cursor. The mode is
+  // now `preserve-only` and the contract below is the one 2032 settled: a
+  // visibility-return preserves, divider or no divider. The divider landing that
+  // used to be asserted here belongs to DELIBERATE activation only — see
+  // issue2032-visibility-return-preserve-position.spec.ts and
+  // scroll-on-window-switch.spec.ts.
+  test("scrolled-up reader, unread divider present: return preserves scrollTop, never jumps to the divider", async ({
     page,
   }) => {
     const vjt = specUser();
@@ -215,30 +231,29 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
     await wheelBy(page, -400);
     await expect.poll(async () => await distanceFromBottom(page)).toBeGreaterThan(200);
+    const before = await scrollbackGeometry(page);
 
     // Leave the app and come back.
     await setTabHidden(page, true);
     await setTabHidden(page, false);
     await page.waitForTimeout(700);
 
-    // Contract: return lands the reader ON the re-latched unread divider —
-    // "the messages still to be read" — NOT at the tail. The marker is
-    // on-screen in the upper region (block:"start"); distance-to-bottom is
-    // ABOVE threshold. RED pre-fix: the tail snap pushed the divider off the
-    // top and distance collapsed to <= threshold.
+    // Contract (issue 2032): the reader is exactly where they were. A divider
+    // renders — that is the whole point of this case — and it must NOT be a
+    // scroll anchor on a resume. RED against the #535 code, which
+    // `scrollIntoView`d the divider and moved the reader off their position.
+    //
+    // Raw pixels against a sub-pixel epsilon, NOT SCROLL_BOTTOM_THRESHOLD_PX:
+    // that constant is a 50px product band for classifying follow INTENT, and
+    // reusing it as a tolerance would let a sub-band jump pass.
+    const after = await scrollbackGeometry(page);
+    expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(2);
+
+    // Still a divider, still above the reader, still not at the tail.
     await expect(marker).toHaveCount(1);
-    await expect(marker).toBeInViewport();
     await expect
       .poll(async () => await distanceFromBottom(page))
       .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
-    const markerOffset = await page.evaluate(() => {
-      const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
-      const m = document.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;
-      if (!el || !m) throw new Error("scrollback/marker not found");
-      return m.getBoundingClientRect().top - el.getBoundingClientRect().top;
-    });
-    expect(markerOffset).toBeGreaterThanOrEqual(-5);
-    expect(markerOffset).toBeLessThan(g.clientHeight / 2);
   });
 
   test("follow-live reader (at the tail): return still snaps to the newest row (#46 preserved)", async ({

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -78,6 +78,26 @@ async function distanceFromBottom(page: Page): Promise<number> {
   return g.scrollHeight - g.scrollTop - g.clientHeight;
 }
 
+// `page.mouse.wheel` DISPATCHES the gesture and returns; it does not wait for
+// the resulting scroll to finish. A `before` snapshot taken while the glide is
+// still running makes any later comparison measure the tail of OUR OWN gesture
+// rather than the product's behaviour — measured: it read a 400px "jump" on a
+// -400 wheel. Wait for scrollTop to stop moving before pinning a baseline.
+async function waitForScrollSettled(page: Page): Promise<void> {
+  let last = Number.NaN;
+  await expect
+    .poll(
+      async () => {
+        const { scrollTop } = await scrollbackGeometry(page);
+        const stable = scrollTop === last;
+        last = scrollTop;
+        return stable;
+      },
+      { timeout: 5_000, intervals: [100] },
+    )
+    .toBe(true);
+}
+
 // A REAL Chromium wheel gesture over the scrollback — the ONLY way to flip
 // `atBottom` false: onScroll gates the false-flip on `st < lastScrollTop`
 // (a genuine upward scroll), and the settle/loadMore paths gate on a real
@@ -231,6 +251,7 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     expect(g.scrollHeight).toBeGreaterThan(g.clientHeight);
     await wheelBy(page, -400);
     await expect.poll(async () => await distanceFromBottom(page)).toBeGreaterThan(200);
+    await waitForScrollSettled(page);
     const before = await scrollbackGeometry(page);
 
     // Leave the app and come back.

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -138,8 +138,9 @@ import WhowasCard from "./WhowasCard";
 //
 // FREEZE CONTRACT (2026-06-08): the divider derives from a FROZEN snapshot
 // of the cursor (`markerCursorId`), NOT the live value — it does not move
-// while the operator reads. It re-latches on focus acquisition
-// (channel-switch, visibility-return). The live cursor advances + POSTs to
+// while the operator reads. It re-latches on focus ACQUISITION (channel-switch,
+// cold-mount, own send) — but NOT on a visibility-return, which is a resume
+// (issue 2032). The live cursor advances + POSTs to
 // the server on settle events (scroll-settle, focus-leave, blur, send) via
 // setCursorIfAdvances / setReadCursor; see the markerCursorId signal doc
 // below for the full contract.
@@ -1411,9 +1412,12 @@ const ScrollbackPane: Component<Props> = (props) => {
   // snapshot, NOT the live `getReadCursor`, so a mid-view cursor advance
   // (own scroll-settle echo OR cross-device `read_cursor_set`) does not
   // yank the divider under the operator's eyes while they read. Re-latched
-  // to the live cursor on every focus acquisition — channel-switch (key
-  // effect) and tab/app visibility-return (option b) — so the divider
-  // settles to the new position when the operator steps away and back.
+  // to the live cursor on every focus ACQUISITION — channel-switch (key
+  // effect), cold-mount, and an own send — so the divider settles to the new
+  // position when the operator genuinely changes window. A tab/app
+  // visibility-return does NOT re-latch (issue 2032, reversing the former
+  // "option (b)"): a resume must leave the reader, and the divider they were
+  // reading against, exactly where they were.
   // `null` = not yet latched / no cursor known (cold-load pre-hydration);
   // the cold-latch effect below picks up the first non-null cursor,
   // mirroring the sessionTopId cold-mount latch. The live signal map stays
@@ -2397,9 +2401,9 @@ const ScrollbackPane: Component<Props> = (props) => {
   //      re-opened (the effect below tracks `isDocumentVisible` false→true).
   //      GATED on the follow-state at hide time (#535), no latch: resume ≠
   //      switch (#46). followMode() true → "tail-only" (the reader was following
-  //      live). followMode() false → "marker-or-preserve" (the reader had
-  //      deliberately scrolled up; land on the divider or hold their scrollTop
-  //      — NEVER tail-snap them).
+  //      live). followMode() false → "preserve-only" (the reader had
+  //      deliberately scrolled up; hold their scrollTop — never tail-snap them,
+  //      and since issue 2032 never divider-snap them either).
   //
   // Single source of truth for the DOM read/scroll mechanics: any future
   // activation trigger plugs into `scrollToActivation` and picks its mode.
@@ -2431,22 +2435,28 @@ const ScrollbackPane: Component<Props> = (props) => {
   //     visibility-return. Never the divider; `followMode`/`atBottomNow=true`; no
   //     latch (the length-effect's `followMode` tail-follow already re-establishes
   //     the tail).
-  //   * "marker-or-preserve" — the scrolled-up arm of visibility-return (#535).
-  //     Same marker DOM read as "marker-or-tail", but when NO divider renders it
-  //     PRESERVES the reader's scrollTop instead of tailing. It is safe to skip
-  //     the scroll then: the re-latch (`setMarkerCursorId`) only recomputes
-  //     `rows()` — which resets scrollTop to 0 via the ref-keyed `<For>` — when
-  //     it MOVES the cursor, and a moved cursor still below the tail always
-  //     renders a divider, so "no marker" means the re-latch left scrollTop
-  //     untouched. The sibling `refreshScrollback` (fired one line before this)
-  //     is an ASYNC co-trigger that CAN recompute `rows()` later by appending
-  //     rows missed while hidden, but a TAIL append preserves a scrolled-up
-  //     reader's position (the length-effect's `followMode` gate does nothing +
-  //     browser scroll anchoring holds the viewport) — empirically pinned by the
-  //     #535 "messages missed while hidden" e2e case, not just asserted here. No
-  //     latch (one-shot resume). Owner ruling 2026-07-29 (#535): the only
-  //     legitimate jump-to-bottom is the operator's own send in the active
-  //     window; every other trigger preserves position or lands on the divider.
+  //   * "preserve-only" — the scrolled-up arm of visibility-return (#535, then
+  //     issue 2032). Writes NOTHING: no tail, no divider. It does not read the
+  //     marker node at all, and its sibling arm no longer re-latches
+  //     `markerCursorId`, so `rows()` is not recomputed and the ref-keyed
+  //     `<For>` never recreates the list — scrollTop is untouched by
+  //     construction rather than by luck. The sibling `refreshScrollback` (fired
+  //     one line before this) is an ASYNC co-trigger that CAN recompute `rows()`
+  //     later by appending rows missed while hidden, but a TAIL append preserves
+  //     a scrolled-up reader's position (the length-effect's `followMode` gate
+  //     does nothing + browser scroll anchoring holds the viewport) —
+  //     empirically pinned by the #535 "messages missed while hidden" e2e case,
+  //     not just asserted here. No latch (one-shot resume).
+  //
+  //     ⚠️ This REVERSES the second half of #535 (DESIGN_NOTES 2026-07-30).
+  //     That entry read vjt's ruling — "l'unico caso in cui scrolliamo to bottom
+  //     è quando si scrive un messaggio nella finestra attiva" — as "everything
+  //     else preserves the reader's position OR LANDS ON THE DIVIDER", and put
+  //     this mode in the divider query on that authority. vjt's words constrain
+  //     scroll-to-BOTTOM only; the divider clause was the entry's own gloss, and
+  //     it made the mode's name a lie. issue 2032 is the owner ruling that
+  //     settles it: a visibility-return is a RESUME, and only a DELIBERATE
+  //     window change lands on the divider (#168, 2026-07-03).
   // Post-send / live-append stay at the BOTTOM via the length-effect: the send
   // ARMS `followMode` (#608 STEP 5, clearing the marker latch first) and the
   // applier tail-follows the echo when it mounts. The divider still RENDERS at
@@ -2463,7 +2473,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // pre-paint, so the intermediate scrollTop=0 is never painted — no hide
   // needed, and toggling `activating` on every rows change would itself flicker.
   const scrollToActivation = (
-    mode: "marker-or-tail" | "tail-only" | "marker-or-preserve",
+    mode: "marker-or-tail" | "tail-only" | "preserve-only",
     withHide: boolean,
   ): void => {
     if (!listRef) return;
@@ -2525,15 +2535,24 @@ const ScrollbackPane: Component<Props> = (props) => {
           if (withHide) setActivating(false);
           return;
         }
-        // #168 regression fix — the channel-SWITCH trigger jumps to the
-        // RENDERED frozen unread divider when one exists; every other trigger
-        // (cold-mount, visibility-return, resize) lands at the tail. Read the
-        // marker's DOM node the `rows()` memo already injected (same
-        // data-testid the render emits) — do NOT recompute the cursor
-        // geometry a second way. Its ABSENCE (fully-read channel, or a cold
-        // switch whose rows haven't landed) naturally falls to the tail.
+        // #168 + issue 2032 — the DELIBERATE activations (channel-SWITCH and
+        // cold-mount, both "marker-or-tail") jump to the RENDERED frozen unread
+        // divider when one exists. Every RESUME does not: "tail-only" (resize,
+        // follow-live return) goes to the tail, "preserve-only" (scrolled-up
+        // return) goes nowhere. Read the marker's DOM node the `rows()` memo
+        // already injected (same data-testid the render emits) — do NOT recompute
+        // the cursor geometry a second way. Its ABSENCE (fully-read channel, or a
+        // cold switch whose rows haven't landed) naturally falls to the tail.
+        //
+        // The comment this replaces asserted the OPPOSITE of the code: it said
+        // "every other trigger (cold-mount, visibility-return, resize) lands at
+        // the tail". Neither clause was true — cold-mount has been a marker
+        // activation since #168's own 2026-07-03b completion, and
+        // visibility-return's scrolled-up arm was IN this query, which is exactly
+        // the defect issue 2032 reported. Routing is what ships; the comment had
+        // been stale for two releases.
         const marker =
-          mode === "marker-or-tail" || mode === "marker-or-preserve"
+          mode === "marker-or-tail"
             ? (listRef.querySelector('[data-testid="unread-marker"]') as HTMLElement | null)
             : null;
         if (marker?.scrollIntoView) {
@@ -2548,16 +2567,27 @@ const ScrollbackPane: Component<Props> = (props) => {
           const near = distance <= SCROLL_BOTTOM_THRESHOLD_PX;
           setFollowMode(near);
           setAtBottomNow(near);
-        } else if (mode === "marker-or-preserve") {
-          // #535 — scrolled-up visibility-return with NO divider to land on
-          // (e.g. a fully-read channel the reader paged up into). The re-latch
-          // left `markerCursorId` — hence this synchronous `rows()`, hence
-          // scrollTop — untouched. PRESERVE the reader's position: do NOT
-          // tail-snap, and leave `followMode`/`atBottomNow` false (they are
-          // still parked above the tail). Nothing to scroll here. (A later async
-          // `refreshScrollback` append can still recompute `rows()`, but a tail
-          // append preserves a scrolled-up viewport — guarded by the #535 gap
-          // e2e case.)
+        } else if (mode === "preserve-only") {
+          // #535 + issue 2032 — the scrolled-up arm of visibility-return.
+          // PRESERVE the reader's position UNCONDITIONALLY: do not tail-snap, do
+          // not jump to a divider, and leave `followMode`/`atBottomNow` false
+          // (they are still parked above the tail). Nothing to scroll here.
+          //
+          // #535 shipped this branch reachable ONLY when no divider rendered, on
+          // the reasoning that the sibling re-latch had by then moved the divider
+          // ONTO the reader's own position, so landing on it WAS landing where
+          // they were. That reasoning holds only while the hide-edge cursor write
+          // reaches the reader's row, and `setCursorIfAdvances` is forward-only
+          // (#233): a reader parked ABOVE the live cursor leaves it untouched, so
+          // the divider sits somewhere else and `scrollIntoView` moves them.
+          // issue 2032 removed BOTH halves — this mode no longer reads the
+          // divider node, and the visibility arm no longer re-latches — so
+          // `rows()` is not recomputed and scrollTop is genuinely untouched
+          // rather than incidentally so.
+          //
+          // A later async `refreshScrollback` append can still recompute `rows()`,
+          // but a tail append preserves a scrolled-up viewport — guarded by the
+          // #535 gap e2e case.
         } else {
           const tail = listRef.lastElementChild as HTMLElement | null;
           if (tail?.scrollIntoView) {
@@ -2570,7 +2600,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         }
         // #981 — every branch above ran INSIDE the rAF×2, i.e. against settled
         // layout: the marker branch read the distance-to-tail, the else branch
-        // placed the pane AT the tail, and `marker-or-preserve` deliberately
+        // placed the pane AT the tail, and `preserve-only` deliberately
         // left the reader where they were (above the tail). All three are
         // answers about THIS window's geometry, so the suppression may act on
         // `atBottomNow` from here on. The early returns above are not: they
@@ -2752,17 +2782,27 @@ const ScrollbackPane: Component<Props> = (props) => {
   // false→true (clearBadgesForWindow); this effect owns the scroll
   // settle AND the freeze-contract bottom-boundary re-latch.
   //
-  // Top/bottom boundaries diverge on visibility-return (deliberate, see
-  // the markerCursorId / sessionTopId doc comments):
+  // Both frozen boundaries are PRESERVED on visibility-return (issue 2032;
+  // see the markerCursorId / sessionTopId doc comments):
   //   * sessionTopId (TOP) is PRESERVED — a brief tab-blur is not
   //     "leaving the window"; messages that arrived while hidden stay
   //     live-read, no fresh marker. (Re-latching it would mis-classify
   //     them.)
-  //   * markerCursorId (BOTTOM) is RE-LATCHED to the live cursor —
-  //     option (b): a step-away-and-back settles the divider to wherever
-  //     the cursor reached while frozen. The re-latch runs BEFORE
-  //     scrollToActivation so the activation scroll sees the updated
-  //     marker state.
+  //   * markerCursorId (BOTTOM) is PRESERVED TOO, since issue 2032. It used
+  //     to be RE-LATCHED to the live cursor here — freeze-contract "option
+  //     (b)", a step-away-and-back settling the divider to wherever the
+  //     cursor reached. Two measured consequences killed it. (1) It
+  //     MATERIALISES a divider that was not on screen before the app switch,
+  //     which the reader never asked for. (2) A re-latch that MOVES the
+  //     cursor recomputes `rows()`, and every row is a fresh object under a
+  //     ref-keyed `<For>`, so the whole list is recreated and scrollTop
+  //     collapses to 0 — a reset the old divider jump happened to paper over
+  //     by scrolling somewhere immediately afterwards. Remove the jump alone
+  //     and the reader lands at the TOP of the buffer, which is worse than
+  //     the bug being fixed. A resume is not a focus acquisition, so the
+  //     honest fix is that neither boundary moves: the divider stays frozen
+  //     exactly where the reader left it. It still re-latches on a deliberate
+  //     switch, on cold-mount and on an own send.
   //
   // `prev === undefined` guards the initial-mount run (signal owns
   // the prev sentinel pattern; mirrors selection.ts's identical guard
@@ -2789,7 +2829,6 @@ const ScrollbackPane: Component<Props> = (props) => {
         // (Shell.tsx `<Match>`), so `props` is always a real /messages
         // channel — no synthetic-window 404.
         void refreshScrollback(props.networkSlug, props.channelName);
-        setMarkerCursorId(getReadCursor(props.networkSlug, props.channelName));
         // #535 — gate the resume scroll on the follow-state that was in effect
         // when the document hid. `followMode()` (#608: the follow INTENT, not
         // the geometric `atBottomNow`) turns false ONLY on a real operator
@@ -2800,14 +2839,16 @@ const ScrollbackPane: Component<Props> = (props) => {
         // marker jump (#168, 2026-07-03).
         //   * followMode() true  → the reader was following live → TAIL (#46).
         //   * followMode() false → the reader deliberately scrolled up mid-backlog
-        //     → land on the re-latched divider if one renders, else PRESERVE
-        //     their scrollTop. NEVER tail-snap them (the pre-#535 bug: the
-        //     unconditional "tail-only" here dropped a mid-backlog reader at the
-        //     tail on every return from an external link).
+        //     → PRESERVE their scrollTop, full stop. NEVER tail-snap them (the
+        //     pre-#535 bug: the unconditional "tail-only" here dropped a
+        //     mid-backlog reader at the tail on every return from an external
+        //     link) and never divider-snap them either (issue 2032: #535's
+        //     replacement traded the tail yank for a divider yank, which is the
+        //     same class of defect pointing the other way).
         if (followMode()) {
           applyActivation("tail-only", true);
         } else {
-          applyActivation("marker-or-preserve", true);
+          applyActivation("preserve-only", true);
         }
       }
     }),
@@ -2886,9 +2927,10 @@ const ScrollbackPane: Component<Props> = (props) => {
   // No false→true arm HERE — the hide edge is this effect's whole job. The
   // return edge is owned by the #887 read-at-the-tail arm below, which reaches
   // the same door under a geometry gate this one does not need. (The DISPLAY
-  // snapshot is re-latched on focus-regain by the sibling activation effect
-  // above — freeze contract option (b) — by re-reading the cursor, not
-  // advancing it; that stays true whichever arm advances it.)
+  // snapshot is NOT re-latched on focus-regain — issue 2032 removed the sibling
+  // activation effect's re-read, so the divider this arm's cursor write feeds
+  // only moves on a genuine focus acquisition. This arm still advances the LIVE
+  // cursor on hide, which is a different axis and unchanged.)
   //
   // `prev === undefined` guards the initial-mount run (mirrors the
   // sibling effect's identical guard).
@@ -3470,23 +3512,22 @@ const ScrollbackPane: Component<Props> = (props) => {
   // resolves precedence and logs the decision. Behaviour-IDENTICAL to the
   // pre-STEP-3 direct calls: `scrollToActivation` already bails on
   // `isOverlayFrozen()` (= overlay-freeze precedence) and still owns the
-  // marker-or-tail / tail-only / marker-or-preserve write mechanics + the #130
+  // marker-or-tail / tail-only / preserve-only write mechanics + the #130
   // flicker hide (`withHide`) + the follow/geometry signals — this only moves the
   // DECISION into the pure `resolveIntent` core, making `scrollToActivation` an
   // applier-internal write routine (reached ONLY here and from
   // `dispatchScrollWrite`'s marker-activation case).
   //
   // The activation kind maps by mode: "tail-only" is the tail-follow intent
-  // (resize resume + the follow-live visibility arm); "marker-or-tail" /
-  // "marker-or-preserve" are marker-activation (jump to the rendered divider, or
-  // tail/preserve when none). The intent is UNCONDITIONAL per mode — NOT gated on
+  // (resize resume + the follow-live visibility arm); "marker-or-tail" and
+  // "preserve-only" are marker-activation. The intent is UNCONDITIONAL per mode — NOT gated on
   // the marker latch — because a direct `scrollToActivation` always ran when not
   // frozen; gating it would be a behaviour change. When overlay-freeze outranks
   // the activation intent we skip the delegate: `scrollToActivation`'s own frozen
   // bail produced the identical no-op, so no activation authority moves a covered
   // pane (the #219 / #219-general freeze), and the decision is now logged.
   const applyActivation = (
-    mode: "marker-or-tail" | "tail-only" | "marker-or-preserve",
+    mode: "marker-or-tail" | "tail-only" | "preserve-only",
     withHide: boolean,
   ): void => {
     if (!listRef) return;
@@ -3496,6 +3537,14 @@ const ScrollbackPane: Component<Props> = (props) => {
       intents.push({ kind: "overlay-freeze", key: k, lifetime: "sticky" });
     }
     intents.push({
+      // issue 2032 — "preserve-only" keeps declaring `marker-activation` even
+      // though it writes nothing. The kind is a PRECEDENCE CLASS, not a
+      // description of the write, and this one must outrank `tail-follow`
+      // (rank 4) or a concurrent tail-follow would snap the resuming reader to
+      // the tail — precisely the #535 defect. `prepend-preserve`, the only
+      // other preserve-shaped kind, sits BELOW tail-follow and would reinstate
+      // it. No new kind was minted: the union + PRECEDENCE array are shared
+      // with the whole applier, so widening them is a separate change.
       kind: mode === "tail-only" ? "tail-follow" : "marker-activation",
       key: k,
       lifetime: "sticky",

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -3281,7 +3281,7 @@ describe("ScrollbackPane", () => {
     // `applyReadCursorSet` boundary (same wire bytes), so the freeze is
     // uniform: cross-device reads reflect on the next refocus, not
     // mid-stare. Accepted tradeoff (vjt: "consistency").
-    it("Bug A (revised): bare cursor advance keeps the marker frozen; refocus releases it", async () => {
+    it("Bug A (revised): bare cursor advance keeps the marker frozen; so does a visibility-return; an own send releases it", async () => {
       const { applyReadCursorSet } = await import("../lib/readCursor");
       const proto = fixture[0];
       if (!proto) throw new Error("fixture[0] missing");
@@ -3304,11 +3304,24 @@ describe("ScrollbackPane", () => {
       // FROZEN: marker unchanged despite the live cursor reaching sessionTopId.
       expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
 
-      // Refocus (tab/app visibility-return) re-latches the marker baseline
-      // to the live cursor → cursor caught up to sessionTopId → marker gone.
+      // issue 2032 — a tab/app visibility-return is a RESUME, not a focus
+      // acquisition, so it does NOT re-latch: the divider still reads its
+      // frozen count after a full hide→show cycle.
+      //
+      // This block used to assert the divider VANISHED here (freeze-contract
+      // "option (b)"). That is the behaviour 2032 reversed: re-latching
+      // materialises a divider move the reader never asked for, and the
+      // `rows()` recompute it triggers recreates the ref-keyed `<For>` list,
+      // collapsing their scrollTop to 0.
       setDocVisible(false);
       await new Promise((r) => queueMicrotask(() => r(undefined)));
       setDocVisible(true);
+      await new Promise((r) => queueMicrotask(() => r(undefined)));
+      expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
+
+      // An own send IS an explicit caught-up acquisition and still releases it
+      // (the live cursor already reached sessionTopId above).
+      pushOwnSend("freenode #grappa");
       await waitFor(() => {
         expect(screen.queryByTestId("unread-marker")).toBeNull();
       });
@@ -3337,7 +3350,12 @@ describe("ScrollbackPane", () => {
       expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
     });
 
-    it("marker re-latches to the advanced cursor on visibility-return (option b)", async () => {
+    // issue 2032 — the INVERSE of what this case used to pin. It was
+    // "marker re-latches to the advanced cursor on visibility-return (option
+    // b)"; the owner ruling on 2032 made a visibility-return a RESUME, so the
+    // frozen divider must survive it untouched. A deliberate switch, a
+    // cold-mount and an own send still re-latch — covered by their own cases.
+    it("marker does NOT re-latch on visibility-return — a resume is not a focus acquisition", async () => {
       const { applyReadCursorSet } = await import("../lib/readCursor");
       const proto = fixture[0];
       if (!proto) throw new Error("fixture[0] missing");
@@ -3358,14 +3376,15 @@ describe("ScrollbackPane", () => {
       await new Promise((r) => queueMicrotask(() => r(undefined)));
       expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
 
-      // Step away + back: divider re-latches to the live cursor (62) → only
-      // id 63 remains in (62, 63] → "1 unread".
+      // Step away + back. Pre-2032 the divider re-latched to the live cursor
+      // (62) and collapsed to "1 unread" — moving under a reader who only
+      // stepped away. It must now hold at "4 unread": same rows, same frozen
+      // boundary, nothing moved.
       setDocVisible(false);
       await new Promise((r) => queueMicrotask(() => r(undefined)));
       setDocVisible(true);
-      await waitFor(() => {
-        expect(screen.getByTestId("unread-marker")).toHaveTextContent("1 unread");
-      });
+      await new Promise((r) => queueMicrotask(() => r(undefined)));
+      expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
     });
 
     // Send-relatch (2026-06-09, vjt prod report): a focused OWN send must
@@ -3622,16 +3641,17 @@ describe("ScrollbackPane", () => {
 
       // FREEZE CONTRACT (2026-06-08): a bare cursor advance no longer removes
       // the divider — it's frozen. The divider row unmounts when a FOCUS
-      // acquisition re-latches the frozen boundary past the unread block.
-      // Advance the live cursor, then drive ONE visibility-return: that
-      // re-latches markerCursorId=53 → divider unmounts. (Yield between
-      // transitions so SolidJS flushes the false state — effect captures
-      // prev=false — before we flip back to true; otherwise both writes
-      // batch and the effect's prev=undefined guard returns early.)
+      // ACQUISITION re-latches the frozen boundary past the unread block.
+      // Advance the live cursor, then drive an OWN SEND: that re-latches
+      // markerCursorId=53 → divider unmounts.
+      //
+      // issue 2032 — this used to drive a visibility-return instead. A resume
+      // no longer re-latches, so it can no longer remove the divider; the
+      // property under test here is the #168 display-only one (removal leaves
+      // the pane following the tail), not which trigger does the removing, so
+      // the trigger was swapped for one that still qualifies.
       applyReadCursorSet("freenode", "#grappa", 53);
-      setDocVisible(false);
-      await new Promise((r) => queueMicrotask(() => r(undefined)));
-      setDocVisible(true);
+      pushOwnSend("freenode #grappa");
       await waitFor(() => {
         expect(screen.queryByTestId("unread-marker")).toBeNull();
       });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,88 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2032 -->
+
+---
+
+## 2026-09-10 — issue 2032: a visibility-return is a resume, and #535's divider half is reversed
+
+Reported: tapping a link that leaves the app and coming back moves the reader
+off the position they were reading at. Desktop and mobile, long-standing.
+Modals are unaffected — they never hide the document, so the pane holds
+position through `overlay-freeze`, a different writer.
+
+**Two writers moved the reader, not one, and the second is the one that makes
+the obvious fix wrong.**
+
+1. **The divider JUMP.** `scrollToActivation` read the `unread-marker` node for
+   `"marker-or-preserve"` — the scrolled-up arm of visibility-return — in the
+   SAME query as the deliberate-switch mode, and `scrollIntoView`d it. So the
+   mode preserved only when NO divider rendered. With one present it moved the
+   reader, which is the opposite of its name.
+2. **The divider RE-LATCH.** The visibility arm re-pointed `markerCursorId` at
+   the live read cursor. When that MOVES the cursor it recomputes `rows()`, and
+   every row is a fresh object literal under a `<For>` keyed by reference, so
+   the whole DOM list is recreated and **scrollTop collapses to 0**.
+
+Writer 2 is masked by writer 1: the jump lands somewhere immediately after the
+reset, so nobody sees the zero. **Remove the jump alone and the reader is
+dropped at the TOP of the buffer — strictly worse than the reported bug.** The
+cure removes both. `"marker-or-preserve"` is renamed `"preserve-only"`, which
+is now the truth rather than an aspiration.
+
+**This REVERSES the second half of #535 (2026-07-30), deliberately.** That entry
+recorded vjt's ruling verbatim — *"non dobbiamo sminchiare lo scroll, come regola
+generale. l'unico caso in cui scrolliamo to bottom è quando si scrive un
+messaggio nella finestra attiva"* — and then glossed it as "everything else
+preserves the reader's position **or lands on the unread divider**". vjt's words
+constrain scroll-to-BOTTOM only; the divider clause was the entry's own
+extension, and it is what authorised putting a resume mode into the divider
+query. #535's reasoning for why that was harmless: the hide-edge cursor write
+parks the cursor at the reader's own row, so the re-latched divider IS their
+position. **That holds only while the write lands.** `setCursorIfAdvances` is
+forward-only (#233), so a reader parked ABOVE the live cursor leaves it
+untouched and the divider sits somewhere else entirely. The invariant that
+survives is #168's (2026-07-03): only a DELIBERATE window change lands on the
+divider.
+
+**The freeze contract loses "option (b)".** `markerCursorId` no longer
+re-latches on visibility-return. It still re-latches on a deliberate switch, on
+cold-mount and on an own send — all genuine focus acquisitions. A resume is not
+one, and the divider a reader was reading against must not move under them.
+
+**The comment at the divider query asserted the opposite of the code** — *"the
+channel-SWITCH trigger jumps to the RENDERED frozen unread divider when one
+exists; every other trigger (cold-mount, visibility-return, resize) lands at the
+tail"*. Both clauses were false: cold-mount became a marker activation in #168's
+own 2026-07-03b completion, and visibility-return's scrolled-up arm was in the
+query. Fixed in the same commit as the cure, per the standing rule.
+
+**`"preserve-only"` still declares the `marker-activation` intent kind**, and
+that is deliberate. The kind is a PRECEDENCE CLASS, not a description of the
+write: it must outrank `tail-follow` (rank 4) or a concurrent tail-follow snaps
+the resuming reader to the tail, which is the #535 defect returning.
+`prepend-preserve`, the only other preserve-shaped kind, sits BELOW `tail-follow`
+and would reinstate it. Minting a new kind means widening the union and the
+PRECEDENCE array shared by the whole applier — a separate change with its own
+blast radius.
+
+**Tests that pinned the old behaviour were rewritten, not deleted.**
+`issue535-visibility-return-preserve-scroll.spec.ts`'s second case asserted
+"return lands ON the divider" — it pinned this defect, and was green by
+construction over the entire divider-present half of the space. Three unit cases
+in `ScrollbackPane.test.tsx` pinned the re-latch, one of them named "(option
+b)". The #168 display-only case kept its property and swapped its trigger from a
+visibility-return to an own send, since a resume can no longer remove a divider.
+New coverage: `issue2032-visibility-return-preserve-position.spec.ts`, whose
+discriminating case has the reader read DOWNWARD past the frozen divider so the
+input-gated scroll-settle advances the live cursor — giving the re-latch
+somewhere new to point, which is what separates writer 2 from writer 1.
+
+_Client-only. No wire change, no protocol bump, no migration._
+
+_Not asserted: the reported direction. The report says "backwards"; every path
+this analysis can construct from the code yanks the reader FORWARD by roughly a
+viewport, or to scrollTop 0 when the divider is absent on return. The backward
+variant was not reproduced, and the cure does not depend on it — the contract
+asserted is preservation, which is direction-agnostic and covers all three._

--- a/test/grappa_web/controllers/messages_limit_mirror_test.exs
+++ b/test/grappa_web/controllers/messages_limit_mirror_test.exs
@@ -4,8 +4,8 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   limits, and until this file nothing compared a copy with its original.
 
   `@default_limit` (the unconfigured-client page size) is re-declared as
-  `REST_PAGE_SIZE` in 14 specs; `@max_http_limit` (the boundary ceiling)
-  as `MAX_HTTP_LIMIT` in 5. Nineteen numbers kept in lockstep by hand,
+  `REST_PAGE_SIZE` in 15 specs; `@max_http_limit` (the boundary ceiling)
+  as `MAX_HTTP_LIMIT` in 5. Twenty numbers kept in lockstep by hand,
   with no witness: change the attribute and every spec keeps asserting
   the old page size, silently, because a Playwright spec seeds its own
   fixture and never asks the server what its default is.
@@ -59,7 +59,7 @@ defmodule GrappaWeb.MessagesLimitMirrorTest do
   # to the state #1646 measured. Landing either means changing the number
   # here, which is the moment someone reads this.
   @mirrors [
-    {"REST_PAGE_SIZE", "default_limit", 14},
+    {"REST_PAGE_SIZE", "default_limit", 15},
     {"MAX_HTTP_LIMIT", "max_http_limit", 5}
   ]
 


### PR DESCRIPTION
Addresses issue 2032 (referenced without a closing keyword on purpose —
the owner closes it after verifying on device).

Returning from an external link moved the reader off the position they were
reading at. The contract this branch establishes: **a visibility-return is a
RESUME, not a window change.** It preserves the reader's scroll position and
leaves the frozen unread divider where it was. Only a DELIBERATE activation
(switch / cold-mount) lands on the divider — that is #168 (2026-07-03) and it
is unchanged.

## 1. There were TWO writers, and curing only the obvious one makes it worse

The issue named the divider jump. It is real, but it is not alone:

1. **The JUMP.** `scrollToActivation` read the `unread-marker` node for
   `"marker-or-preserve"` — the scrolled-up arm of visibility-return — in the
   *same query* as the deliberate-switch mode, and `scrollIntoView`d it. The
   mode preserved only when NO divider rendered, which made its name a
   promise the code did not keep.
2. **The RE-LATCH.** The visibility arm re-pointed `markerCursorId` at the
   live read cursor. When that MOVES the cursor it recomputes `rows()`, and
   every row is a fresh object literal under a `<For>` keyed by reference —
   so the whole DOM list is recreated and **scrollTop collapses to 0**.

Writer 1 *masks* writer 2 by landing somewhere immediately after the reset.
**Remove the jump alone and the reader is dropped at the TOP of the buffer**,
which is strictly worse than the reported bug. Both are removed here. The
mode is renamed `"preserve-only"`, which is now a description rather than an
aspiration.

This reverses the second half of #535 (DESIGN_NOTES 2026-07-30). That entry
recorded the owner's ruling on scroll-to-BOTTOM verbatim and then glossed it
as "everything else preserves the reader's position **or lands on the unread
divider**"; the divider clause was the gloss, not the ruling, and it is what
authorised putting a resume mode into the divider query. #535's argument for
why the jump was harmless — the hide-edge write parks the cursor on the
reader's own row, so the re-latched divider IS their position — holds only
while that write lands. `setCursorIfAdvances` is forward-only (#233), so a
reader parked ABOVE the live cursor leaves it untouched and the divider sits
somewhere else entirely.

The comment above the divider query asserted the opposite of the code
("cold-mount, visibility-return, resize … lands at the tail"). Both clauses
were false. Corrected in the same commit as the cure.

## 2. Half of this cure is invisible to the unit tests

Mutation testing, both halves, restore proven each time:

| mutant | unit suite | e2e (scoped) |
|---|---|---|
| A — restore the re-latch | **rc=1**, 2 named cases fall | (covered by unit) |
| B — put `preserve-only` back in the divider query | **rc=0, 6921 passed — nothing falls** | **rc=1**, 2 cases fall |

**Mutant B is caught by nothing but the e2e.** jsdom reports
`clientHeight === 0`, so the divider jump has no geometry to be observed
through and every unit assertion stays green on the mutated build. That is
why this branch carries a real browser case and does not lean on the unit
suite for that half.

Evidence, read from the Playwright artifact rather than from the code:

* **RED pre-cure** (spec commit, cure absent): 2 failed / 4 passed. Only the
  two divider-PRESENT cases fall; the #168 deliberate-activation guard and
  the three divider-absent cases stay green, so the red is discriminating
  and not vacuous. `error-context.md`: `Expected: <= 2`, `Received: 187`
  (new spec) and `189` (rewritten #535 case) — roughly two-thirds of a
  viewport.
* **GREEN post-cure**: 6 passed.
* **Mutant B**: 2 failed / 4 passed, exactly the two divider-present cases;
  restored tree byte-identical to the green commit (`git status --porcelain`
  and `git diff HEAD` both empty).

The oracle is raw pixels against a 2px epsilon, deliberately **not**
`SCROLL_BOTTOM_THRESHOLD_PX`: that 50px constant classifies follow INTENT and
is generous by design, so reusing it as a tolerance would swallow any jump
smaller than the band.

## 3. What is NOT claimed: the direction in the title

The title says the reader is yanked **back**. **This branch does not assert
that.** Every path derivable from the code moves the reader **forward** by
roughly a viewport (the divider re-latches BELOW them, and
`scrollIntoView({block: "start"})` puts it at the top), or to `scrollTop` 0
when no divider renders on the return. The measured displacements above,
187px and 189px, are forward. The backward variant was not reproduced.

The cure does not depend on resolving this: the asserted contract is
**preservation**, which is direction-agnostic and covers a forward jump, a
backward jump and a collapse to zero alike.

## Tests that pinned the defect were rewritten, not deleted

* `issue535-visibility-return-preserve-scroll.spec.ts` case 2 asserted
  *"return lands ON the divider"*. It pinned this defect, which is why the
  entire divider-present half of the space read green for two releases.
* Three unit cases in `ScrollbackPane.test.tsx` pinned the re-latch, one of
  them named *"(option b)"*. Two now assert the frozen divider survives a
  return. The #168 display-only case keeps its property and swaps its trigger
  to an own send, since a resume can no longer remove a divider.

## Scope notes

* `"preserve-only"` still declares the `marker-activation` intent KIND. The
  kind is a PRECEDENCE CLASS, not a description of the write, and it must
  outrank `tail-follow` or a concurrent tail-follow re-creates the #535 tail
  snap. `prepend-preserve` sits BELOW `tail-follow` and would reinstate it.
  Minting a new kind widens the union and PRECEDENCE array shared by the
  whole applier — a separate change.
* One commit here is a TEST fix, not a product fix: `page.mouse.wheel`
  dispatches the gesture and returns without waiting for the scroll to
  finish, so the rewritten case pinned its baseline mid-glide and reported a
  400px "jump" that was exactly the test's own -400 wheel. Replaced with a
  stability barrier rather than a sleep.

## Verification

* `bun run check` — 5 stages, 0 failed
* `bun run test` — 342 files, 6921 tests
* scoped e2e (chromium) — RED → GREEN → mutant B, as tabled above
* `design-notes-gate.sh` — run AFTER the commit; marker unique against the
  current tip of `main`, checked with a positive control

Client-only: no wire change, no protocol bump, no migration.

**Not run locally:** the full `integration.sh` suite (the lane was contended;
CI covers it here) and any iOS/mobile device pass — the report covers desktop
and mobile, this ran on chromium only.
