### PR TITLE
scrollback: finish the tail write at the scroller's own bottom (issue 2031)

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -821,6 +821,79 @@ export async function scrollbackDistanceFromBottom(page: Page): Promise<number |
   });
 }
 
+// Issue 2031 — where one scrollback row sits relative to the pane that clips
+// it, and to the compose below.
+//
+// 🔴 The reason this exists rather than `distanceFromBottom <= 50` or
+// `toBeInViewport()`, which are the two assertions already in the tree and
+// which BOTH pass while the reported defect is on screen:
+//
+//   * `scrollbackDistanceFromBottom` is the pane's distance from its own tail,
+//     and `SCROLL_BOTTOM_THRESHOLD_PX` declares 50px of that to be "at the
+//     tail". A message row is shorter than 50px, so a row can be entirely
+//     below the fold inside a pane that every existing assertion calls tailed.
+//     That tolerance is the thing under accusation; an assertion cannot be
+//     written in terms of it.
+//   * `toBeInViewport()` defaults to `ratio: 0`, i.e. ANY non-empty
+//     intersection. A row showing one pixel passes it. It also measures
+//     against the browser viewport rather than against the scroller, so it
+//     cannot speak about a row clipped by the pane at all.
+//
+// So the reading is the row's box against the PANE's box, in CSS pixels, and
+// it is returned rather than asserted: the caller owns the tolerance, and the
+// numbers are what make a failure legible.
+//
+// `composeTopPx` / `hiddenBehindComposePx` are here to DISCRIMINATE two
+// mechanisms that produce the same complaint ("the line is hidden under the
+// compose"), because the cure is different for each and the report cannot tell
+// them apart:
+//   (a) SCROLL — the pane is short of its own tail, so the row is below the
+//       pane's own bottom edge: `overflowBelowPx > 0`.
+//   (b) LAYOUT — the pane is genuinely at its tail and the row is inside the
+//       pane's box, but the painted pane extends under the compose, so the row
+//       is covered: `overflowBelowPx <= 0` while `hiddenBehindComposePx > 0`.
+// (b) is not hypothetical: `themes/default.css` records exactly it on iOS
+// WebKit ("last messages hide behind BottomBar", UX-6 bucket D v2), cured
+// there with `min-height: 0`. A spec that only knew (a) would misattribute it.
+export type RowClearance = {
+  readonly rowTopPx: number;
+  readonly rowBottomPx: number;
+  readonly paneTopPx: number;
+  readonly paneBottomPx: number;
+  // Positive ⇒ that many CSS px of the row are past the pane's bottom edge.
+  readonly overflowBelowPx: number;
+  // Positive ⇒ that many CSS px of the row are above the pane's top edge.
+  readonly overflowAbovePx: number;
+  // The pane's own distance from its tail, for cross-reading against the
+  // threshold that is under accusation.
+  readonly distanceFromBottomPx: number;
+  // `null` when no compose is mounted (a read-only window).
+  readonly composeTopPx: number | null;
+  readonly hiddenBehindComposePx: number | null;
+};
+
+export async function rowClearance(row: Locator): Promise<RowClearance> {
+  return await row.evaluate((el) => {
+    const pane = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
+    if (!pane) throw new Error("rowClearance: scrollback container not found");
+    const r = el.getBoundingClientRect();
+    const p = pane.getBoundingClientRect();
+    const compose = document.querySelector(".compose-box") as HTMLElement | null;
+    const composeTop = compose ? compose.getBoundingClientRect().top : null;
+    return {
+      rowTopPx: r.top,
+      rowBottomPx: r.bottom,
+      paneTopPx: p.top,
+      paneBottomPx: p.bottom,
+      overflowBelowPx: r.bottom - p.bottom,
+      overflowAbovePx: p.top - r.top,
+      distanceFromBottomPx: pane.scrollHeight - pane.scrollTop - pane.clientHeight,
+      composeTopPx: composeTop,
+      hiddenBehindComposePx: composeTop === null ? null : r.bottom - composeTop,
+    };
+  });
+}
+
 // #237 — the on-JOIN inline topic line. NOT a `scrollback-line` (it is a
 // presentational, non-message row derived from the topic store — no server
 // message id, so it never enters the unread/cursor math). Its own testid

--- a/cicchetto/e2e/fixtures/scrollWriteProbe.ts
+++ b/cicchetto/e2e/fixtures/scrollWriteProbe.ts
@@ -1,0 +1,166 @@
+// The scrollback scroll-write spy, extracted from
+// `issue625-single-send-scroll-jump.spec.ts` when issue 2031 needed the same
+// instrument.
+//
+// It answers a question no position sampler can: WHO WROTE, and WHEN. #625's
+// defect is a second `scrollIntoView` landing ~0.5s after the send, and a
+// recorder of positions cannot tell a delayed write apart from a delayed
+// layout — both show up as "the number changed late". So this wraps the two
+// doors a scroll write can come through (`Element.prototype.scrollIntoView`
+// and the `scrollTop` setter) and timestamps each one.
+//
+// It is a FIXTURE and not a copy in each spec because two specs now assert
+// against the same recording, and a second copy is how the two drift into
+// disagreeing about what a write is. The page-context globals are namespaced
+// away from any one issue number for the same reason.
+//
+// Page-context only: nothing here changes production behaviour. The wrap is
+// installed on the live page and never restored — each spec gets a fresh page,
+// so there is nothing to leak into.
+
+import type { Page } from "@playwright/test";
+
+// One geometry reading of the scrollback container.
+export type ScrollSample = {
+  readonly t: number;
+  readonly top: number;
+  readonly height: number;
+  readonly client: number;
+};
+
+// One observed scroll write, with the position it found the pane at.
+export type ScrollWrite = {
+  readonly t: number;
+  readonly kind: string;
+  readonly detail: string;
+  readonly before: number;
+};
+
+export type ScrollProbeReading = {
+  readonly samples: readonly ScrollSample[];
+  readonly writes: readonly ScrollWrite[];
+};
+
+// Distance from the tail for one sample. The raw float, like
+// `scrollbackDistanceFromBottom` — the caller owns the rounding, because the
+// caller owns the threshold it is compared against.
+export function distanceOf(s: ScrollSample): number {
+  return s.height - s.top - s.client;
+}
+
+// The writes that landed more than `graceMs` after the FIRST one.
+//
+// Measured from the first write and not from probe-install on purpose: the
+// send's own latency (the CDP round-trip plus the WS echo) floats the
+// legitimate write's absolute timestamp, so an absolute cutoff false-REDs on a
+// slow run. The defect IS the gap between two writes, so the gap is what is
+// measured.
+export function delayedWrites(
+  writes: readonly ScrollWrite[],
+  graceMs: number,
+): readonly ScrollWrite[] {
+  const first = writes[0];
+  if (first === undefined) return [];
+  return writes.filter((w) => w.t - first.t > graceMs);
+}
+
+// Install the sampler + write spy on the scrollback container. Call BEFORE the
+// action under test.
+//
+// The sampler records on every native `scroll` event AND on a rAF tick: a
+// programmatic write that lands between two scroll events is invisible to the
+// event alone, and that write is exactly the one under accusation.
+export async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
+  await page.evaluate((windowMsArg) => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollWriteProbe: scrollback container not found");
+    type Sample = { t: number; top: number; height: number; client: number };
+    type WriteEvent = { t: number; kind: string; detail: string; before: number };
+    const w = window as unknown as {
+      __scrollProbeSamples: Sample[];
+      __scrollProbeWrites: WriteEvent[];
+    };
+    w.__scrollProbeSamples = [];
+    w.__scrollProbeWrites = [];
+    const t0 = performance.now();
+    const now = () => performance.now() - t0;
+
+    // Read through the PROTOTYPE descriptor, not `el.scrollTop`: the own
+    // property installed below would otherwise make the spy read itself.
+    const desc = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+    const getTop = () => (desc?.get ? (desc.get.call(el) as number) : el.scrollTop);
+
+    if (desc?.get && desc?.set) {
+      Object.defineProperty(el, "scrollTop", {
+        configurable: true,
+        get() {
+          return desc.get?.call(this);
+        },
+        set(v: number) {
+          w.__scrollProbeWrites.push({
+            t: Math.round(now()),
+            kind: "scrollTop=",
+            detail: String(Math.round(v)),
+            before: Math.round(getTop()),
+          });
+          desc.set?.call(this, v);
+        },
+      });
+    }
+
+    const rawSIV = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
+      // Only writes that move THIS scroller count — `scrollIntoView` on a node
+      // elsewhere in the document is somebody else's business.
+      if (this === el || el.contains(this as Node)) {
+        w.__scrollProbeWrites.push({
+          t: Math.round(now()),
+          kind: "scrollIntoView",
+          detail: JSON.stringify(arg ?? null),
+          before: Math.round(getTop()),
+        });
+      }
+      return rawSIV.call(this, arg as ScrollIntoViewOptions);
+    };
+
+    const sample = () => {
+      w.__scrollProbeSamples.push({
+        t: Math.round(now()),
+        top: Math.round(getTop()),
+        height: el.scrollHeight,
+        client: el.clientHeight,
+      });
+    };
+    sample();
+    el.addEventListener("scroll", sample, { passive: true });
+    const loop = () => {
+      sample();
+      if (now() < windowMsArg) requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+  }, windowMs);
+}
+
+// Read the recording back and print it. On a failure this dump is the whole
+// story: `writes` names every write and its timestamp (a delayed double-scroll
+// shows as a second entry ~0.5s in), `topChanges` is the compressed scrollTop
+// timeline with only the frames where the position actually moved.
+export async function dumpScrollProbe(page: Page, tag: string): Promise<ScrollProbeReading> {
+  const samples = await page.evaluate(
+    () => (window as unknown as { __scrollProbeSamples: ScrollSample[] }).__scrollProbeSamples,
+  );
+  const writes = await page.evaluate(
+    () => (window as unknown as { __scrollProbeWrites: ScrollWrite[] }).__scrollProbeWrites,
+  );
+  const compact: Array<{ t: number; top: number; d: number }> = [];
+  let prevTop = Number.NaN;
+  for (const s of samples) {
+    if (s.top !== prevTop) {
+      compact.push({ t: s.t, top: s.top, d: Math.round(distanceOf(s)) });
+      prevTop = s.top;
+    }
+  }
+  console.log(`[scroll-probe ${tag}] writes=${JSON.stringify(writes)}`);
+  console.log(`[scroll-probe ${tag}] topChanges=${JSON.stringify(compact)}`);
+  return { samples, writes };
+}

--- a/cicchetto/e2e/tests/issue2031-send-with-marker-row-clipped.spec.ts
+++ b/cicchetto/e2e/tests/issue2031-send-with-marker-row-clipped.spec.ts
@@ -1,0 +1,261 @@
+// Issue 2031 — sending with the `── XX unread messages ──` marker on screen
+// leaves the just-sent row CLIPPED at the bottom of the scrollback.
+//
+// ## Why this spec exists next to issue625, which already sends with a marker
+//
+// `issue625-single-send-scroll-jump.spec.ts` second case builds the SAME
+// shape — mid-page cursor, marker rendered, send from history — and it is
+// green. So the defect does not live in what that spec asserts; it lives in
+// the gap between those assertions and "the reader can see what they sent".
+// Both of its visibility assertions pass with the row mostly off-screen:
+//
+//   * `distance-to-tail <= SCROLL_BOTTOM_THRESHOLD_PX` is 50px of declared
+//     slack, and a message row is shorter than that. A pane every existing
+//     assertion calls "at the tail" can hold a whole row below the fold.
+//   * `toBeInViewport()` defaults to `ratio: 0` — ANY non-empty intersection
+//     passes, so a row showing one pixel is "in viewport". It also measures
+//     against the browser viewport, not the scroller, so it cannot describe a
+//     row the pane itself clips.
+//
+// This spec asserts the row's BOX against the PANE's BOX (`rowClearance`), and
+// that is the whole point: the 50px tolerance is the thing under accusation,
+// so the assertion may not be written in terms of it.
+//
+// ## The second face, from the report
+//
+// vjt's comment adds: when the row sits slightly off, "after a moment it
+// shifts by a few pixels on its own". That is a scroll write landing AFTER the
+// send settled, which is #625's own signature, so it is asserted here too —
+// on the reported platform, which #625 never runs on.
+//
+// ## What this actually measured, before any cure existed
+//
+// Nine runs on the untouched tree (`--repeat-each 3`), and the terminal state
+// is two-valued:
+//
+//   webkit-iphone-15   3/3   distanceFromBottom = 7   overflowBelow = +0.203
+//   chromium           2/3   distanceFromBottom = 7   overflowBelow = +0.359
+//   chromium           1/3   distanceFromBottom = 0   overflowBelow = -6.640
+//
+// So the pane does NOT stop inside the 50px slack by a wide margin — it stops
+// SEVEN pixels short of its own tail, which is the extent of the scroller's
+// own `padding-bottom`. `scrollIntoView({ block: "end" })` brings the row's
+// bottom to the pane's bottom EDGE and leaves that padding unscrolled; the row
+// then sits flush, with zero clearance and a fraction of a pixel cut off. The
+// remaining 7px is never corrected, because 7 <= 50 makes the #625 fail-safe
+// read the pane as "at the tail" and skip its write.
+//
+// That is the issue's own candidate mechanism, now MEASURED rather than
+// inherited — with one correction to it: the marker collapse is not what
+// leaves the pane short. `scrollIntoView`'s padding blind spot is.
+//
+// The report's SECOND face did NOT reproduce. Every one of the nine runs
+// recorded exactly ONE scroll write, so nothing moved the pane after the send
+// settled and assertion (b) below is green on the untouched tree. It is
+// asserted anyway: it is the invariant #625 bought, this is the first spec to
+// state it on webkit, and a cure that reintroduced a delayed write would
+// otherwise land unnoticed. A green there is a guard, not a reproduction.
+//
+// ## Platform
+//
+// Reported from iPhone, and not a regression. On webkit the shortfall is
+// DETERMINISTIC (3/3); on chromium it is 2/3, so the desktop case is expected
+// to be an unreliable red before the cure and a solid green after. Both are
+// kept: the defect is geometry rather than engine, and that is worth pinning
+// on both rather than assuming.
+//
+// ## Two hypotheses this spec falsified — kept because a dead end that is
+// ## written down is not walked twice
+//
+// 1. THE SOFT KEYBOARD IS NOT INVOLVED. A third case sent with
+//    `visualViewport` shrunk to 300px the way issue253 stubs it, and produced
+//    numbers IDENTICAL to its keyboard-less twin to the third decimal
+//    (distance 7, overflow +0.203, 3/3). The case and its fixture were removed
+//    rather than kept green-and-meaningless.
+// 2. THE LAYOUT MECHANISM IS NOT THIS ONE. `themes/default.css` records "last
+//    messages hide behind BottomBar" on iOS WebKit (UX-6 bucket D v2), which
+//    is the same complaint from a different cause — a pane painted past its
+//    own box. Measured, `composeTopPx` equals `paneBottomPx` exactly on both
+//    engines, so nothing is painted under the compose and that cure is not the
+//    one needed here. `rowClearance` still reports the field, so the next
+//    reader can tell the two apart instead of re-deriving it.
+
+import type { Page } from "@playwright/test";
+import {
+  composeSend,
+  loginAs,
+  rowClearance,
+  scrollbackDistanceFromBottom,
+  scrollbackLines,
+  selectChannel,
+  waitForScrollbackRefreshed,
+} from "../fixtures/cicchettoPage";
+import { fetchScrollbackPage, setReadCursorToId } from "../fixtures/grappaApi";
+import { delayedWrites, dumpScrollProbe, installScrollProbe } from "../fixtures/scrollWriteProbe";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Mirror of `lib/scrollThresholds.ts` SCROLL_BOTTOM_THRESHOLD_PX — used ONLY
+// to build the precondition (the pane parked in history is more than this from
+// the tail) and to cross-read a failure. Never as the visibility assertion:
+// that is the tolerance under accusation.
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+// REST default page size (Grappa.Web.MessagesController.@default_limit).
+const REST_PAGE_SIZE = 50;
+
+// 🔴 ZERO, and the first draft of this spec got it wrong at 1px.
+//
+// A 1px "sub-pixel slack" was written in defensively, and MEASURED over nine
+// runs it swallowed the defect whole: the clipped state overflows the pane's
+// bottom edge by +0.203px (webkit) / +0.359px (chromium), so the spec passed
+// while photographing exactly what it was written to catch.
+//
+// Zero is not a knife edge here, which is the reason it is safe. The two
+// states are ~7px apart and neither is near the boundary:
+//   correct   distanceFromBottom = 0, overflowBelow = -6.64 … -7.44  (clear)
+//   defective distanceFromBottom = 7, overflowBelow = +0.20 … +0.36  (clipped)
+// There is no sub-pixel path from -6.6 to +0.2, so rounding cannot flip the
+// verdict; only the shortfall can.
+const SUBPIXEL_TOLERANCE_PX = 0;
+
+// Must outlast every #608 deferred writer: SETTLE_MAX_FRAMES (30) ≈ 0.5s,
+// SCROLL_SETTLE_DEBOUNCE_MS = 500, PRESENCE_CURSOR_SETTLE_MS = 500. Same
+// window issue625 samples over, for the same reason.
+const SAMPLE_WINDOW_MS = 2500;
+
+// A send's ONE legitimate tail-follow fires at frame 0 of its poll; the
+// delayed one lands SETTLE_MAX_FRAMES ≈ 0.5s later. Measured from the first
+// observed write, never from probe-install — see `delayedWrites`.
+const SETTLE_GRACE_MS = 300;
+
+// Park the reader in history with the unread marker rendered, then assert the
+// marker is REALLY on screen — the issue's precondition is "with the marker
+// visible", and a marker that exists below the fold is a different scenario.
+async function parkOnVisibleMarker(page: Page): Promise<void> {
+  const vjt = specUser();
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+  const page0 = await fetchScrollbackPage(vjt.token, NETWORK_SLUG, CHANNEL);
+  expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  const cursorRow = page0[25];
+  if (!cursorRow) throw new Error("seeded page too short for cursor placement");
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
+
+  await expect
+    .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+
+  const marker = page.locator('[data-testid="unread-marker"]');
+  await expect(marker).toHaveCount(1);
+  // ON SCREEN, not merely present: the report's trigger is a visible marker.
+  await expect(marker).toBeInViewport();
+
+  // Parked in history: the pane is above the fold when the send happens.
+  await expect
+    .poll(async () => (await scrollbackDistanceFromBottom(page)) ?? 0, { timeout: 10_000 })
+    .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+}
+
+// The body of both cases. Kept as one function because the two differ ONLY in
+// the engine they run on, and a copy would let them drift into testing
+// different things on the two platforms — which is the one comparison the
+// pair exists to make.
+async function sendWithMarkerAndAssertVisible(page: Page, tag: string): Promise<void> {
+  await parkOnVisibleMarker(page);
+
+  await installScrollProbe(page, SAMPLE_WINDOW_MS);
+  const body = `i2031 ${tag} ${Date.now()}`;
+  await composeSend(page, body);
+
+  const sentLine = scrollbackLines(page).filter({ hasText: body });
+  await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+
+  // VACUITY GUARD. The scenario is "a send that collapses a visible marker",
+  // and the marker collapse is the follow-on rows change the candidate
+  // mechanism turns on. If the re-latch never ran, the run under test never
+  // happened and a green below would mean nothing. `lastOwnSend` fires after
+  // the POST resolves, so this is also the barrier that the send CONFIRMED.
+  await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0, {
+    timeout: 10_000,
+  });
+
+  // Let every deferred writer land before reading the terminal geometry.
+  await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
+
+  const { samples, writes } = await dumpScrollProbe(page, tag);
+  expect(samples.length).toBeGreaterThan(10);
+
+  // ── (a) the sent row is FULLY visible in the pane that clips it ──────────
+  const clearance = await rowClearance(sentLine);
+  console.log(`[#2031 ${tag}] clearance=${JSON.stringify(clearance)}`);
+  expect(
+    clearance.overflowBelowPx,
+    `the sent row is clipped at the pane's bottom edge. ` +
+      `overflowBelow=${clearance.overflowBelowPx.toFixed(1)}px, ` +
+      `distanceFromBottom=${clearance.distanceFromBottomPx.toFixed(1)}px ` +
+      `(threshold ${SCROLL_BOTTOM_THRESHOLD_PX}), ` +
+      `hiddenBehindCompose=${clearance.hiddenBehindComposePx?.toFixed(1) ?? "n/a"}px. ` +
+      `overflowBelow>0 ⇒ SCROLL (pane short of its tail); ` +
+      `overflowBelow<=0 with hiddenBehindCompose>0 ⇒ LAYOUT (pane painted under the compose).`,
+  ).toBeLessThanOrEqual(SUBPIXEL_TOLERANCE_PX);
+
+  // The same row must not be covered by the compose either — the LAYOUT face
+  // of the identical complaint, which the pane-box comparison alone cannot see.
+  //
+  // ⚠️ Today this is DEGENERATE and says nothing the assertion above did not:
+  // measured, `composeTopPx === paneBottomPx` exactly on both engines (the two
+  // are flush flex siblings), so `hiddenBehindCompose` equals `overflowBelow`
+  // to the bit. It earns its place only in the state it exists to catch — a
+  // pane painted PAST its own box, where `composeTop < paneBottom` and the two
+  // numbers separate. Stated rather than dropped: a reader who finds two
+  // assertions agreeing on every run deserves to know which one is load-bearing
+  // now and which is a tripwire for later.
+  if (clearance.hiddenBehindComposePx !== null) {
+    expect(
+      clearance.hiddenBehindComposePx,
+      `the sent row is inside the pane but painted under the compose: ` +
+        `rowBottom=${clearance.rowBottomPx.toFixed(1)}, composeTop=${clearance.composeTopPx?.toFixed(1)}`,
+    ).toBeLessThanOrEqual(SUBPIXEL_TOLERANCE_PX);
+  }
+
+  // ── (b) nothing writes scroll after the send settled ─────────────────────
+  // The report's second face: "after a moment it shifts by a few pixels on its
+  // own". Same invariant #625 pins on chromium; asserted here on the reported
+  // platform too.
+  expect(
+    writes.length,
+    `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    delayedWrites(writes, SETTLE_GRACE_MS),
+    `scroll write(s) landed after the send settled: ${JSON.stringify(writes)}`,
+  ).toEqual([]);
+}
+
+test.describe("issue 2031 — a send with the unread marker on screen (desktop)", () => {
+  // Tiny viewport so the seeded buffer overflows and the geometry is real —
+  // the same 800×300 issue580 / issue625 use.
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  test("the sent row lands fully inside the pane, and nothing scrolls after", async ({ page }) => {
+    await sendWithMarkerAndAssertVisible(page, "desktop");
+  });
+});
+
+test.describe("issue 2031 — a send with the unread marker on screen (iPhone)", () => {
+  // No `test.use({ viewport })` here on purpose: the `webkit-iphone-15`
+  // project's device descriptor owns the viewport, and overriding it would
+  // throw away the fidelity that makes this the reported platform's case.
+  test("@webkit the sent row lands fully inside the pane, and nothing scrolls after", async ({
+    page,
+  }) => {
+    await sendWithMarkerAndAssertVisible(page, "iphone");
+  });
+});

--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -29,7 +29,6 @@
 // Harness mirrors issue580 (DB-seeded 200-row #spec-wN; tiny 800×300 viewport so
 // the buffer overflows and scroll geometry is measurable).
 
-import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -43,6 +42,12 @@ import {
   restoreReadCursorToTail,
   setReadCursorToId,
 } from "../fixtures/grappaApi";
+import {
+  delayedWrites,
+  distanceOf,
+  dumpScrollProbe,
+  installScrollProbe,
+} from "../fixtures/scrollWriteProbe";
 import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, specNick, specUser, test } from "../fixtures/test";
 
@@ -68,114 +73,9 @@ const SAMPLE_WINDOW_MS = 2500;
 // false-RED on a slow run. The defect IS the ~0.5s gap between two writes.
 const SETTLE_GRACE_MS = 300;
 
-// The delayed double-scroll: any container scroll write that lands more than the
-// grace window AFTER the send's first (legitimate) tail-follow write.
-function delayedWrites(writes: readonly WriteEvent[]): WriteEvent[] {
-  if (writes.length === 0) return [];
-  const first = writes[0] as WriteEvent;
-  return writes.filter((w) => w.t - first.t > SETTLE_GRACE_MS);
-}
-
-type Sample = { t: number; top: number; height: number; client: number };
-type WriteEvent = { t: number; kind: string; detail: string; before: number };
-
-// Install an in-page sampler + a scroll-write spy on the scrollback container,
-// BEFORE the send. The sampler records the geometry on every native `scroll`
-// event AND on a rAF tick (to catch a programmatic write that lands between
-// scroll events), for SAMPLE_WINDOW_MS. The spy wraps `scrollIntoView` + the
-// `scrollTop` setter (page-context only — no production behaviour changes).
-async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
-  await page.evaluate((windowMsArg) => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) throw new Error("scrollback container not found for probe");
-    type Sample = { t: number; top: number; height: number; client: number };
-    type WriteEvent = { t: number; kind: string; detail: string; before: number };
-    const w = window as unknown as { __i625samples: Sample[]; __i625writes: WriteEvent[] };
-    w.__i625samples = [];
-    w.__i625writes = [];
-    const t0 = performance.now();
-    const now = () => performance.now() - t0;
-
-    const desc = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
-    const getTop = () => (desc?.get ? (desc.get.call(el) as number) : el.scrollTop);
-
-    if (desc?.get && desc?.set) {
-      Object.defineProperty(el, "scrollTop", {
-        configurable: true,
-        get() {
-          return desc.get?.call(this);
-        },
-        set(v: number) {
-          w.__i625writes.push({
-            t: Math.round(now()),
-            kind: "scrollTop=",
-            detail: String(Math.round(v)),
-            before: Math.round(getTop()),
-          });
-          desc.set?.call(this, v);
-        },
-      });
-    }
-
-    const rawSIV = Element.prototype.scrollIntoView;
-    Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
-      if (this === el || el.contains(this as Node)) {
-        w.__i625writes.push({
-          t: Math.round(now()),
-          kind: "scrollIntoView",
-          detail: JSON.stringify(arg ?? null),
-          before: Math.round(getTop()),
-        });
-      }
-      return rawSIV.call(this, arg as ScrollIntoViewOptions);
-    };
-
-    const sample = () => {
-      w.__i625samples.push({
-        t: Math.round(now()),
-        top: Math.round(getTop()),
-        height: el.scrollHeight,
-        client: el.clientHeight,
-      });
-    };
-    sample();
-    el.addEventListener("scroll", sample, { passive: true });
-    const loop = () => {
-      sample();
-      if (now() < windowMsArg) requestAnimationFrame(loop);
-    };
-    requestAnimationFrame(loop);
-  }, windowMs);
-}
-
-// On failure this dump is the whole story: `writes` names every container scroll
-// write + its timestamp (the delayed double-scroll shows as a second entry ~0.5s
-// in), `topChanges` is the compressed scrollTop timeline.
-async function dumpEvidence(
-  page: Page,
-  tag: string,
-): Promise<{ samples: Sample[]; writes: WriteEvent[] }> {
-  const samples = await page.evaluate(
-    () => (window as unknown as { __i625samples: Sample[] }).__i625samples,
-  );
-  const writes = await page.evaluate(
-    () => (window as unknown as { __i625writes: WriteEvent[] }).__i625writes,
-  );
-  const dist = (s: Sample) => Math.round(s.height - s.top - s.client);
-  const compact: Array<{ t: number; top: number; d: number }> = [];
-  let prevTop = Number.NaN;
-  for (const s of samples) {
-    if (s.top !== prevTop) {
-      compact.push({ t: s.t, top: s.top, d: dist(s) });
-      prevTop = s.top;
-    }
-  }
-  console.log(`[#625 ${tag}] writes=${JSON.stringify(writes)}`);
-  console.log(`[#625 ${tag}] topChanges=${JSON.stringify(compact)}`);
-  return { samples, writes };
-}
-
-const distOf = (s: Sample) => s.height - s.top - s.client;
+// The sampler + scroll-write spy moved to `fixtures/scrollWriteProbe.ts` when
+// issue 2031 needed the same instrument — one recorder, so the two specs
+// cannot drift into disagreeing about what counts as a write.
 
 test.describe("issue #625 — a single send must not jump the pane up before settling", () => {
   test.use({ viewport: { width: 800, height: 300 } });
@@ -204,7 +104,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
     await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
     await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
 
-    const { samples, writes } = await dumpEvidence(page, "at-tail");
+    const { samples, writes } = await dumpScrollProbe(page, "at-tail");
     expect(samples.length).toBeGreaterThan(10);
 
     // #625 CORE — no DELAYED second scroll write. A single send performs ONE
@@ -214,14 +114,14 @@ test.describe("issue #625 — a single send must not jump the pane up before set
       writes.length,
       `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
     ).toBeGreaterThanOrEqual(1);
-    const late = delayedWrites(writes);
+    const late = delayedWrites(writes, SETTLE_GRACE_MS);
     expect(
       late,
       `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`,
     ).toEqual([]);
 
     // Visible-symptom guard: following a send, the pane never travels UP.
-    const maxDist = Math.max(...samples.map(distOf));
+    const maxDist = Math.max(...samples.map(distanceOf));
     expect(maxDist).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });
@@ -261,7 +161,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
     await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
     await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
 
-    const { samples, writes } = await dumpEvidence(page, "from-history");
+    const { samples, writes } = await dumpScrollProbe(page, "from-history");
     expect(samples.length).toBeGreaterThan(10);
 
     // #625 CORE — same invariant as the at-tail case: a single send must not fire
@@ -271,7 +171,7 @@ test.describe("issue #625 — a single send must not jump the pane up before set
       writes.length,
       `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
     ).toBeGreaterThanOrEqual(1);
-    const late = delayedWrites(writes);
+    const late = delayedWrites(writes, SETTLE_GRACE_MS);
     expect(
       late,
       `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`,
@@ -279,10 +179,10 @@ test.describe("issue #625 — a single send must not jump the pane up before set
 
     // #608: a send follows the tail unconditionally → the pane reaches the bottom.
     // Once there, it STAYS (a delayed writer would drag it back UP).
-    const firstAtTail = samples.findIndex((s) => distOf(s) <= SCROLL_BOTTOM_THRESHOLD_PX);
+    const firstAtTail = samples.findIndex((s) => distanceOf(s) <= SCROLL_BOTTOM_THRESHOLD_PX);
     expect(firstAtTail).toBeGreaterThanOrEqual(0);
     const afterSettle = samples.slice(firstAtTail);
-    const maxAfterSettle = Math.max(...afterSettle.map(distOf));
+    const maxAfterSettle = Math.max(...afterSettle.map(distanceOf));
     expect(maxAfterSettle).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -417,6 +417,50 @@ const readMentionGeom = (listRef: HTMLDivElement): ScrollbackLineGeom[] => {
   return out;
 };
 
+// THE tail write, shared by the three appliers that mean "put the pane at the
+// tail": activation's no-marker branch, the settle-wait's tail-follow, and the
+// operator tail. One function because those three were three VERBATIM copies of
+// the same five lines (measured: one md5 once indentation is stripped), so the
+// defect below had to be found three times and fixed three times.
+//
+// Two steps, and both are load-bearing:
+//
+//  1. The native walk. UX-8(a3) chose `lastElementChild.scrollIntoView` over
+//     `scrollTop = scrollHeight` math because the browser scrolls the container
+//     from the element's real box — layout-aware even while scrollHeight
+//     bookkeeping is mid-update (the channel-back path: a cached window whose
+//     scrollback store reload races the key-effect even after rAF×2). It also
+//     walks scrollable ANCESTORS, which the setter does not. Both kept: this is
+//     the step that must NOT be traded away, and trading it away is exactly what
+//     "just use the setter, it reaches the real tail" would have done.
+//
+//  2. #2031 — but that walk aligns the ROW's bottom with the scrollport's bottom
+//     EDGE, and that is not the tail. `.scrollback` carries
+//     `padding: 0.5rem 1rem`, so the scroller's own 8px of bottom padding is
+//     left unscrolled: the row lands FLUSH against the edge with a fraction of a
+//     pixel clipped. Nothing repairs it afterwards, because ~7px is well inside
+//     `SCROLL_BOTTOM_THRESHOLD_PX` and so every "am I at the tail" reader — the
+//     #625 fail-safe included — answers yes and skips its write. Finish the job
+//     against the scroller's own maximum.
+//
+// The maximum is spelled `scrollHeight - clientHeight` rather than leaning on
+// the browser to clamp `scrollTop = scrollHeight`, which is the call #1121
+// already made for `restoreTo`: a number that has to be clamped before it is
+// true cannot be measured against.
+//
+// The top-up only ever scrolls DOWN, and that guard is step 1's insurance rather
+// than generic caution — a stale `scrollHeight` is the precise condition the
+// native walk exists to survive, so writing a stale maximum over a good walk
+// would undo it. `max <= scrollTop` means the read cannot be trusted (or we are
+// already there) and the walk stands. Down-only also keeps `followMode` out of
+// it: the pane leaves the tail only when scrollTop DECREASES (the #168 guard).
+const scrollToTail = (list: HTMLDivElement): void => {
+  const tail = list.lastElementChild as HTMLElement | null;
+  tail?.scrollIntoView?.({ block: "end" });
+  const max = list.scrollHeight - list.clientHeight;
+  if (max > list.scrollTop) list.scrollTop = max;
+};
+
 // Wire-shape source-of-truth: the server's `Grappa.Scrollback.Message.kind()`
 // enum is the canonical producer (lib/grappa/scrollback/message.ex).
 // `MessageKind` mirrors it; this switch must stay exhaustive over the
@@ -2503,13 +2547,14 @@ const ScrollbackPane: Component<Props> = (props) => {
     // skip — the length-effect below catches the bottom-snap on the
     // first non-empty length transition.
     //
-    // UX-8(a3): `lastElementChild?.scrollIntoView` is more reliable than
-    // `scrollTop = scrollHeight` math — the browser walks the element's
-    // box and scrolls its container natively, which is layout-aware even
-    // when scrollHeight bookkeeping is mid-update (channel-back path:
+    // UX-8(a3): the tail write is `scrollToTail`, and the reason it walks the
+    // element's box instead of doing `scrollTop = scrollHeight` math lives with
+    // it — the browser scrolls the container natively, which is layout-aware
+    // even when scrollHeight bookkeeping is mid-update (channel-back path:
     // query → #bofh cached, scrollback store reload races key-effect even
-    // after rAF×2). Fallback scrollHeight write is preserved if scrollback
-    // is empty (no element to scroll into view).
+    // after rAF×2). That property is exactly why #2031 COMPLETED that write
+    // rather than swapping it for the setter, which would have reached the true
+    // tail and lost the walk.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         // #130 — reveal in EVERY exit path so the pane is never stranded
@@ -2559,12 +2604,7 @@ const ScrollbackPane: Component<Props> = (props) => {
           // append preserves a scrolled-up viewport — guarded by the #535 gap
           // e2e case.)
         } else {
-          const tail = listRef.lastElementChild as HTMLElement | null;
-          if (tail?.scrollIntoView) {
-            tail.scrollIntoView({ block: "end" });
-          } else {
-            listRef.scrollTop = listRef.scrollHeight;
-          }
+          scrollToTail(listRef);
           setFollowMode(true);
           setAtBottomNow(true);
         }
@@ -3177,11 +3217,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         const atTail =
           currScrollHeight - listRef.scrollTop - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX;
         if (settled || !atTail) {
-          if (tail?.scrollIntoView) {
-            tail.scrollIntoView({ block: "end" });
-          } else {
-            listRef.scrollTop = listRef.scrollHeight;
-          }
+          scrollToTail(listRef);
         }
         lastTailScrollHeight = listRef.scrollHeight;
         return;
@@ -3265,12 +3301,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         // needed. Re-arm follow + geometry, exactly as the former scrollToBottom()
         // helper did; running SYNC keeps the caller's post-scroll
         // `lastFullyVisibleRowId` read on the pinned tail.
-        const tail = listRef.lastElementChild as HTMLElement | null;
-        if (tail?.scrollIntoView) {
-          tail.scrollIntoView({ block: "end" });
-        } else {
-          listRef.scrollTop = listRef.scrollHeight;
-        }
+        scrollToTail(listRef);
         setFollowMode(true);
         setAtBottomNow(true);
         return;

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -2545,6 +2545,83 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #2031 — the tail write's SECOND step, which has no other coverage anywhere.
+  //
+  // `scrollIntoView({block:"end"})` aligns the tail ROW's bottom with the
+  // scrollport's bottom EDGE and leaves the scroller's own `padding-bottom`
+  // unscrolled, so the pane stops ~7px short of its tail and the just-sent row
+  // sits flush against the edge with a fraction of a pixel clipped. The cure
+  // finishes the write against `scrollHeight - clientHeight`.
+  //
+  // Why this belongs in jsdom and not only in the e2e: the e2e measures the
+  // OUTCOME in a real layout, but it cannot construct the one input that makes
+  // the down-only guard matter — a `scrollHeight` read that is STALE, which is
+  // the UX-8(a3) condition the native walk exists to survive. Here that input is
+  // just a `defineProperty`. Without these two, the guard is an untested branch.
+  //
+  // The whole jsdom suite is otherwise blind to the top-up: `scrollHeight` and
+  // `clientHeight` both default to 0, so `max` is 0 and the write never fires
+  // unless a test defines geometry BEFORE the tail write — measured, which is
+  // why the W6 loadMore-preserve block above (which defines its geometry after
+  // `render`) is untouched by this change.
+  describe("#2031 — the tail write finishes at the scroller's own maximum", () => {
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+    beforeEach(() => {
+      // jsdom has no `scrollIntoView`. Stub it to a NO-OP so the assertion below
+      // measures the top-up alone: in a real engine the walk would already have
+      // moved the pane most of the way, and what is under test is the remainder.
+      origScrollIntoView = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = vi.fn();
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+
+    const geometry = (list: HTMLDivElement, scrollHeight: number, scrollTop: number): void => {
+      Object.defineProperty(list, "scrollHeight", { value: scrollHeight, configurable: true });
+      Object.defineProperty(list, "clientHeight", { value: 300, configurable: true });
+      Object.defineProperty(list, "scrollTop", {
+        value: scrollTop,
+        writable: true,
+        configurable: true,
+      });
+    };
+
+    it("tops the pane up to scrollHeight - clientHeight, not to the tail row's edge", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3));
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      // A pane parked above the tail, with a real extent. 1000 - 300 = 700.
+      geometry(list, 1000, 120);
+
+      // The operator tail — the same `scrollToBottomGesture` the floating button
+      // invokes, and the shortest path to the shared write.
+      requestScrollToBottom();
+      await Promise.resolve();
+
+      expect(list.scrollTop).toBe(700);
+    });
+
+    it("never scrolls UP: a stale, too-small maximum leaves the native walk's position alone", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3));
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      // The UX-8(a3) shape: `scrollHeight` reads SMALLER than where the pane
+      // actually is, because the bookkeeping is mid-update. max = 700 < 900.
+      // Writing that maximum would drag the reader 200px back UP and undo the
+      // very walk the first step performed — and, since the pane leaves the tail
+      // only when scrollTop DECREASES (#168), it would also drop followMode.
+      geometry(list, 1000, 900);
+
+      requestScrollToBottom();
+      await Promise.resolve();
+
+      expect(list.scrollTop).toBe(900);
+    });
+  });
+
   // #608 STEP 6 (RED-GREEN behaviour change) — the tail-follow write waits for a
   // MEASURED settle (isSettled: the appended content's extent has GROWN vs the
   // last tail AND the new tail row has a laid-out box) before scrolling, instead
@@ -5074,7 +5151,15 @@ describe("ScrollbackPane", () => {
       // queueMicrotask delays the DOM read+write; wait for it to flush.
       await new Promise((r) => queueMicrotask(() => r(undefined)));
 
-      // No marker → routine takes the scrollTop branch, not scrollIntoView.
+      // No marker → the routine's tail path, which since #2031 is the shared
+      // `scrollToTail` and no longer an inline `scrollTop = scrollHeight` branch.
+      //
+      // ⚠️ What this assertion actually pins is WEAKER than the title says, and
+      // it pre-dates #2031: `scrollToActivation` defers into rAF×2 while this
+      // waits ONE microtask, so a green here means "nothing has been written
+      // YET" rather than "the tail path was taken instead of the marker's".
+      // Named rather than rewritten — correcting it is a change to what this
+      // test measures, and it does not ride in on #2031's back.
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
       // atBottom branch sets atBottom=true → scroll-to-bottom button hidden.
       expect(screen.queryByTestId("scroll-to-bottom")).toBeNull();

--- a/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
+++ b/cicchetto/src/__tests__/e2eConstantMirrors.test.ts
@@ -161,8 +161,10 @@ const MIRRORS: readonly Mirror[] = [
   },
 
   // The scroll-edge pair (#1646 slice 2). `SCROLL_BOTTOM_THRESHOLD_PX` is the
-  // most-copied constant in the tree by a wide margin — 20 declarations, one
-  // per spec that has to decide "is this pane at its tail".
+  // most-copied constant in the tree by a wide margin — one declaration per
+  // spec that has to decide "is this pane at its tail". The count is the list
+  // below and is deliberately not restated in prose: it grows with every such
+  // spec, and a number here would be wrong by the next one.
   ...[
     "e2e/fixtures/scrollGesture.test.ts",
     "e2e/tests/bug7-ios-own-msg-visible.spec.ts",
@@ -172,6 +174,7 @@ const MIRRORS: readonly Mirror[] = [
     "e2e/tests/issue1121-overlay-close-tail-reader.spec.ts",
     "e2e/tests/issue168-scroll-authority.spec.ts",
     "e2e/tests/issue196-preview-scroll-live-arrival.spec.ts",
+    "e2e/tests/issue2031-send-with-marker-row-clipped.spec.ts",
     "e2e/tests/issue243-tap-active-scroll-bottom.spec.ts",
     "e2e/tests/issue253-kbd-resize-scroll-preserve.spec.ts",
     "e2e/tests/issue280-button-coexist.spec.ts",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,202 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2031 -->
+
+---
+
+## 2026-09-10 — #2031: a send stops one padding short of the tail, and the obvious cure was a regression
+
+Reported from an iPhone: send while the `── N unread messages ──` divider is on
+screen and the just-sent line comes out clipped at the bottom of the scrollback.
+The issue's own guess named the `SCROLL_BOTTOM_THRESHOLD_PX` slack — 50px of
+declared "close enough to the tail", which is wider than a message row, so a
+pane every assertion in the codebase calls "at the tail" can hold a whole row
+below the fold.
+
+That guess is right about the mechanism it enables and wrong about the distance.
+Measured over nine runs on the untouched tree, the terminal state has exactly
+two values: `distanceFromBottom = 7` with the row overflowing the pane's bottom
+edge by +0.203px (`webkit-iphone-15`, 3/3 — deterministic on the reported
+platform) or +0.359px (chromium, 2/3), against `distanceFromBottom = 0` and
+−6.640px on the one healthy chromium run. The pane does not stop somewhere
+inside 50px of slack. It stops SEVEN pixels short, and seven is the scroller's
+own `padding-bottom` (`.scrollback { padding: 0.5rem 1rem }`).
+
+`scrollIntoView({ block: "end" })` aligns the tail ROW's bottom box with the
+scrollport's bottom EDGE. The scroller's padding sits below that row inside the
+scrollable extent, so it is simply never scrolled: the row lands flush against
+the edge with no breathing room and a fraction of a pixel cut. Nothing repairs
+it afterwards, because 7 ≤ 50 makes every "am I at the tail" reader answer yes —
+the #625 fail-safe included, which then skips its write for exactly the reason
+#625 taught it to.
+
+So the divider is not what leaves the pane short. Its collapse is the follow-on
+rows change that produces the poll whose correction gets suppressed; the
+shortfall itself is the padding blind spot, and it is there on every send. The
+divider is what makes it visible.
+
+### Two cures were refused, and a third refusal is the entry
+
+Lowering `SCROLL_BOTTOM_THRESHOLD_PX` is not available: that number is the
+definition of "at the tail" for the whole product — the scroll-to-bottom button,
+the `followMode` re-arm, the read-cursor advance, the badge suppression in
+`readingAtTail.ts`. Four unrelated behaviours moved to repair one scroll write.
+
+Changing the #625 fail-safe's PREDICATE — comparing against the tail row's box
+instead of the fixed slack — treats the symptom. The fail-safe did not misjudge
+anything; it was asked to patch a write that should have been correct.
+
+The third is the one worth recording, because it was the obvious move and it
+would have been a REGRESSION. The write's two branches read as interchangeable:
+
+```
+if (tail?.scrollIntoView) { tail.scrollIntoView({ block: "end" }); }
+else { listRef.scrollTop = listRef.scrollHeight; }
+```
+
+and the `else` branch reaches the real tail, so swapping them is a one-line fix
+that measures correct on this issue. The branches are not alternatives. UX-8(a3)
+chose the native walk over the `scrollHeight` math from a measured incident: the
+browser scrolls the container from the element's real box, which stays
+layout-aware while `scrollHeight` bookkeeping is mid-update — the channel-back
+path, where a cached window's store reload races the key-effect even after
+rAF×2. The setter has no such property, and it does not walk scrollable
+ANCESTORS either. The `else` branch is the fallback for having no element (and,
+incidentally, the jsdom path, where `Element.prototype.scrollIntoView` does not
+exist).
+
+Trading the walk for the setter therefore trades a measured 7px clip for the
+re-opening of a measured page-scale defect, on a path this issue's spec does not
+cover. So the write is COMPLETED rather than replaced:
+
+```
+const tail = list.lastElementChild as HTMLElement | null;
+tail?.scrollIntoView?.({ block: "end" });
+const max = list.scrollHeight - list.clientHeight;
+if (max > list.scrollTop) list.scrollTop = max;
+```
+
+The maximum is spelled `scrollHeight - clientHeight` rather than left to the
+browser clamping `scrollTop = scrollHeight` — the same call #1121 made two
+screens down for `restoreTo`, for the reason written there: *a number that has
+to be clamped before it is true cannot be measured against*. The shape of this
+cure was already reasoned out elsewhere in the same file; the pre-existing
+`else` branch is the part that leans on clamping.
+
+The top-up only ever scrolls DOWN, and that guard is the walk's insurance rather
+than defensive habit. A stale `scrollHeight` is the precise condition step 1
+exists to survive, so writing a stale maximum over a good walk would undo it;
+`max <= scrollTop` means the read cannot be trusted (or the pane is already
+there) and the walk stands. Down-only also keeps `followMode` out of it — the
+pane leaves the tail only when `scrollTop` DECREASES (#168).
+
+### Three sites, and "verbatim" was measured rather than eyeballed
+
+The same five lines appear three times: `scrollToActivation`'s no-marker branch,
+`tailFollowWhenSettled`, and `dispatchScrollWrite`'s operator-tail. All three
+target `lastElementChild` of the same `.scrollback` node with the same padding
+and all three mean "put the pane at the tail". Only the middle one was measured
+defective; the other two are cured BY CONSTRUCTION, and that phrase is worth
+something only if "verbatim" is a measurement.
+
+It is: stripping leading indentation and nothing else, the three write cores
+share one md5 and the three `const tail` bindings share another. Controls in
+both directions — an independent block from the same file (the marker write,
+`block: "start"`) differs; a one-byte mutant (`"end"` → `"enD"`) differs; and
+the normaliser is shown not to have gutted the content (five lines, tokens
+intact), because three empty files would also share an md5. The raw blocks are
+NOT identical — two sit at ten spaces of indentation and one at eight — so the
+identity is post-normalisation and is stated that way.
+
+The set is CLOSED, which is what "all three" actually rests on: `block: "end"`
+occurs exactly three times in non-test `cicchetto/src`, and
+`scrollTop = …scrollHeight` at those three `else` branches plus two comments.
+There is no fourth site left behind.
+
+### The spec that photographed the defect and called it green
+
+The first draft of `issue2031-send-with-marker-row-clipped.spec.ts` carried a
+1px "sub-pixel" tolerance and passed. That thread swallowed the defect whole:
+the clipped state overflows by +0.203px, so the spec measured exactly what it
+was written to catch and reported ok. The tolerance is ZERO, and zero is safe
+here precisely because it is not a knife edge — the two states are ~7px apart
+(−6.64 against +0.20) with no sub-pixel path between them.
+
+Two hypotheses were falsified on the way, recorded so the dead ends are not
+walked twice. The soft keyboard is not involved: a third case with
+`visualViewport` shrunk to 300px the way issue253 stubs it produced numbers
+identical to its keyboard-less twin to the third decimal. The CSS layout
+mechanism `themes/default.css` records for iOS WebKit ("last messages hide
+behind BottomBar", UX-6 bucket D v2) is excluded: `composeTop` equals
+`paneBottom` exactly on both engines, so nothing is painted under the compose.
+The case and the fixture that served only the dead hypothesis were REMOVED
+rather than left green and meaningless; `rowClearance` still reports the field
+so the next reader can tell the two failure shapes apart.
+
+### What the runs actually said
+
+RED on the untouched tree, both projects, and the artefact was read rather than
+the reason deduced: `Expected: <= 0 / Received: 0.203125` on
+`webkit-iphone-15`, `0.359375` on chromium, both at `distanceFromBottom = 7`.
+GREEN after the cure: `−6.640625 / d=0` (chromium) and `−6.796875 / d=0`
+(webkit) — the terminal state the untouched tree had produced once by itself on
+its healthy chromium run. The write probe shows the predicted shape: two writes
+in the SAME tick (`scrollIntoView`, then `scrollTop=1415` from `before:1408`),
+which is why #625's gap-based `delayedWrites` is unmoved by a second door
+opening.
+
+#625 is green on both its cases after the cure — the control that the
+double-scroll it killed has not come back, not a bonus. `scroll-on-window-switch`
+is green on all four, and its first test is the guard on the UX-8(a3)
+channel-back path this cure deliberately does not re-open. That guard's
+granularity is worth naming: it asserts `scrollHeight - scrollTop - clientHeight
+<= 50` — the very slack this issue accuses — so it can see a page-scale
+regression and cannot see seven pixels. Right instrument for that job, blind to
+this one. Both it and #625 run on `chromium` only (neither carries `@webkit` or
+`@touch`), which is why this issue's spec adds a `@webkit` case rather than
+trusting the desktop projection.
+
+The mutant flipped the guard (`max > scrollTop` → `max <`), which disables the
+top-up and inverts its direction at once. It killed the two new jsdom guards and
+NOTHING else (expected 120 to be 700; expected 700 to be 900 — the second is the
+guard dragging a reader 200px back up), and it killed the e2e on both projects
+with numbers bit-identical to the pre-cure red. Restore was proven rather than
+assumed: mutate → dirty → `git checkout --` → porcelain empty → the eight
+scoped e2e green again.
+
+### The jsdom suite is blind to this write, which is why two guards ride in
+
+Under jsdom `scrollHeight` and `clientHeight` both default to 0, so `max` is 0
+and the top-up never fires unless a test defines geometry BEFORE the tail write.
+The 6922-test suite therefore says nothing about the two new lines — measured,
+not assumed: a prediction that the W6 loadMore-preserve block would break was
+WRONG, and the reason is exactly this. That block defines its geometry after
+`render`, so at mount `max` is 0 and there is nothing to top up; what protects
+it is the zero geometry, not the `scrollIntoView` stub its comment credits.
+
+So two guards were added where the coverage was: one pins the top-up (700 from
+a 1000/300 pane), one pins the down-only branch (a stale maximum of 700 must
+leave a pane at 900 alone). The e2e cannot construct the second one's input —
+a stale `scrollHeight` read is a `defineProperty` in jsdom and not reachable
+from a real layout — so the guard would otherwise be an untested branch.
+
+_Not asserted: that what the reporter saw has been reproduced. They describe a
+line substantially hidden; the measurement here is 0.203px of clip — the same
+mechanism at its minimum amplitude, not the same amplitude. What makes those
+seven pixels into many more on that device is not known and is not guessed at._
+
+_Not asserted: that the report's second face — "after a moment it shifts by a
+few pixels on its own" — is cured, or absent. It did NOT reproduce: all nine
+runs recorded exactly one scroll write. The spec asserts it anyway, as the
+invariant #625 bought, stated on webkit for the first time; a green there is a
+guard, not a reproduction._
+
+_Not asserted: that UX-8(a3) is still true today. It is a measured incident
+written into the file by someone else, and it is PRESERVED rather than
+re-tested — preserving it does not require re-measuring it, removing it would
+have._
+
+_Not asserted: that the two other call sites were measured. They were not. They
+are cured by construction from the md5 identity above and carry no e2e of their
+own. Only scoped e2e was run here; the full-suite ship gate is CI's._


### PR DESCRIPTION
Reported (issue 2031): sending with the `── N unread messages ──` divider on
screen leaves the just-sent line clipped at the bottom of the scrollback, on
iPhone.

## What it actually is

`scrollIntoView({ block: "end" })` aligns the tail ROW's bottom box with the
scrollport's bottom EDGE. `.scrollback` carries `padding: 0.5rem 1rem`, so the
scroller's own 8px of bottom padding is left unscrolled: the pane stops **seven
pixels short of its tail** and the row lands flush against the edge with a
fraction of a pixel cut off. Nothing repairs it afterwards, because
`7 <= SCROLL_BOTTOM_THRESHOLD_PX` makes every "am I at the tail" reader answer
yes — the #625 fail-safe included — and it skips its write.

Nine runs on the untouched tree, two-valued terminal state:

| project | runs | distanceFromBottom | overflowBelow |
|---|---|---|---|
| `webkit-iphone-15` | 3/3 | 7 | **+0.203** |
| chromium | 2/3 | 7 | **+0.359** |
| chromium | 1/3 | 0 | −6.640 |

The issue's own candidate (the 50px slack being wider than a row) is right about
the mechanism it *enables* and wrong about the distance. And the divider is not
what leaves the pane short — its collapse is the follow-on rows change whose
correction gets suppressed. The shortfall is the padding blind spot, present on
every send.

## The cure, and the one-line version of it that would have been a regression

🔴 **This is the part worth reviewing.** The write's two branches read as
interchangeable, and the `else` branch reaches the real tail:

```ts
if (tail?.scrollIntoView) { tail.scrollIntoView({ block: "end" }); }
else { listRef.scrollTop = listRef.scrollHeight; }
```

Swapping them is a one-line change that measures correct on this issue. **It
would have re-opened a bigger defect.** `ScrollbackPane.tsx:2506` (UX-8(a3))
records why the native walk was chosen over the `scrollHeight` math: the browser
scrolls the container from the element's real box, which stays layout-aware
while `scrollHeight` bookkeeping is mid-update — the channel-back path, a cached
window whose store reload races the key-effect even after rAF×2. The setter has
no such property and does not walk scrollable ANCESTORS. So the write is
**completed, not replaced**:

```ts
const tail = list.lastElementChild as HTMLElement | null;
tail?.scrollIntoView?.({ block: "end" });
const max = list.scrollHeight - list.clientHeight;
if (max > list.scrollTop) list.scrollTop = max;
```

**The shape is already reasoned out in this same file.** `#1121` at
`ScrollbackPane.tsx:3402-3406` spells the bottom of the scroll range as
`scrollHeight - clientHeight` rather than leaning on the browser clamping
`scrollTop = scrollHeight`, *"a number that has to be clamped before it is true
cannot be measured against"*. The pre-existing `else` branch is the part that
leans on clamping; this brings the tail write in line with the file's own
stated preference.

The top-up only ever scrolls **down**. That guard is the walk's insurance, not
habit: a stale `scrollHeight` is the precise condition step 1 exists to survive,
so writing a stale maximum over a good walk would undo it. Down-only also keeps
`followMode` out of it — the pane leaves the tail only when `scrollTop`
DECREASES (#168, `:3754-3766`).

## Scope: one function, three call sites — and only one of them was measured

The five lines appeared verbatim in `scrollToActivation`'s no-marker branch, in
`tailFollowWhenSettled`, and in `dispatchScrollWrite`'s operator-tail.
"Verbatim" is **measured, not eyeballed**: stripping leading indentation and
nothing else, the three write cores share one md5 and the three `const tail`
bindings share another. Controls both ways — an independent block from the same
file (the marker write, `block: "start"`) differs; a one-byte mutant
(`"end"` → `"enD"`) differs; and the normaliser is shown not to have gutted the
content, because three empty files would also share an md5. The raw blocks are
**not** identical (ten spaces of indentation versus eight), so the identity is
post-normalisation and is stated that way.

The set is **closed**: `block: "end"` occurs exactly three times in non-test
`cicchetto/src`; `scrollTop = …scrollHeight` at those three `else` branches plus
two comments. No fourth site left behind.

**Stated plainly: only `tailFollowWhenSettled` was measured defective. The other
two are cured by construction and carry no e2e of their own.**

## Two jsdom guards, because nothing else covers the top-up

Under jsdom `scrollHeight` and `clientHeight` both default to 0, so `max` is 0
and the top-up never fires unless a test defines geometry first — the 6922-test
suite says nothing about the new lines. Measured, not assumed: I **predicted the
W6 loadMore-preserve block would break and I was wrong**, and this is why. It
defines its geometry after `render`, so at mount there is nothing to top up;
what protects it is the zero geometry, not the `scrollIntoView` stub its comment
credits.

So the guards were added where the coverage was: one pins the top-up, one pins
the down-only branch. The e2e cannot construct the second one's input — a stale
`scrollHeight` read is a `defineProperty` in jsdom, not reachable from a real
layout — so it would otherwise be an untested branch.

## What ran

| gate | result |
|---|---|
| **RED**, untouched tree | 2 failed, both projects. `Expected <= 0 / Received 0.203125` (webkit), `0.359375` (chromium). Read from `error-context.md`, not deduced. |
| e2e `issue 2031` after | ✅ `−6.640 / d=0` (chromium), `−6.797 / d=0` (webkit) — the state the untouched tree produced once by itself |
| e2e `issue #625` | ✅ both cases — the control that the double-scroll has not come back |
| e2e `scroll-on-window-switch` | ✅ 4/4 — the UX-8(a3) channel-back path is not re-opened |
| `bun run check` | ✅ rc=0, 5 stages |
| `bun run test` | ✅ rc=0, 342 files / 6924 tests |
| `design-notes-gate.sh` | ✅ post-commit, "1 new entry heading" (not the empty "nothing to check") |

**Mutant, with proven restore.** Flipping the guard (`max >` → `max <`) disables
the top-up and inverts its direction at once. It killed the two new jsdom guards
and **nothing else** (`expected 120 to be 700`; `expected 700 to be 900` — the
second is the guard dragging a reader 200px back up), and it killed the e2e on
both projects with numbers **bit-identical** to the pre-cure red. Then mutate →
dirty → `git checkout --` → porcelain **empty** → the eight scoped e2e green
again.

The write probe shows the predicted mechanism: two writes in the **same tick**
(`scrollIntoView`, then `scrollTop=1415` from `before:1408`), which is why
#625's gap-based `delayedWrites` is unmoved by a second door opening.

## Two things about the spec itself

**The first draft of this spec was GREEN.** It carried 1px of "sub-pixel"
tolerance, and that thread swallowed the defect whole: the clipped state
overflows by +0.203px. The spec photographed exactly what it was written to
catch and reported ok. I found it and said so. The tolerance is now **zero**,
and zero is safe here precisely because it is not a knife edge — the two states
are ~7px apart (−6.64 against +0.20), with no sub-pixel path between them.

**Two of my own hypotheses fell, measured.** The soft keyboard is irrelevant: a
third case with `visualViewport` shrunk to 300px the way issue253 stubs it gave
numbers identical to its keyboard-less twin to the third decimal. The CSS layout
mechanism (`themes/default.css`, "last messages hide behind BottomBar", UX-6
bucket D v2) is excluded: `composeTop == paneBottom` exactly on both engines. I
**removed** the case and the fixture that served only the dead hypothesis rather
than keep a green test that proves nothing; `rowClearance` still reports the
field so the next reader can tell the two failure shapes apart.

## What I am not claiming

- **Not** that the reporter's experience was reproduced. They describe a line
  substantially hidden; this measures 0.203px of clip — the same mechanism at
  its minimum amplitude, not the same amplitude. What makes seven pixels into
  many more on that device is not known and is not guessed at.
- **Not** that the report's second face ("after a moment it shifts by a few
  pixels on its own") is cured or absent. It **did not reproduce** — all nine
  runs recorded exactly one scroll write. The spec asserts it anyway, as the
  invariant #625 bought, stated on webkit for the first time. **A green there is
  a guard, not a reproduction.**
- **Not** that UX-8(a3) is still true today. It is someone else's measured
  incident, **preserved** rather than re-tested — preserving it needs no
  re-measurement, removing it would have.
- **Not** that `scroll-on-window-switch` can see this defect. It asserts against
  the same 50px slack this issue accuses, so it sees page-scale and not seven
  pixels. Right instrument for the regression it guards, blind to this one.
  Both it and #625 run on `chromium` only — neither carries `@webkit`/`@touch` —
  which is why this spec adds a `@webkit` case rather than trusting the desktop
  projection.
- **Only scoped e2e was run here.** The full-suite ship gate is CI's.
- One pre-existing staleness is **named, not repaired**:
  `ScrollbackPane.test.tsx:5051`'s title claims a branch was taken, but the test
  waits one microtask while `scrollToActivation` defers into rAF×2, so it only
  proves "nothing written yet". That predates this work and does not ride in on
  its back.
