### PR TITLE
cic(quote): quote the author a bridge relayed, not the bridge (issue 2033)

### DIFF
--- a/cicchetto/src/__tests__/addQuote.test.ts
+++ b/cicchetto/src/__tests__/addQuote.test.ts
@@ -255,3 +255,62 @@ describe("addQuoteToCompose", () => {
     expect(document.activeElement).toBe(ta);
   });
 });
+
+// issue 2033 — the same relay defect at the second door. An archived quote that
+// names `Gazzurbo` credits a bot forever, and by the time the quote is recalled
+// the channel context that would have explained it is gone.
+//
+// vjt's ruling 4: `!addquote` STRIPS ONLY — no `@`. An archive addresses
+// nobody, so it takes no mention; the wrapped author stays wrapped and only the
+// outer relay nick goes. Detection itself is shared with Reply, one predicate,
+// so the two doors cannot disagree about what a relay looks like.
+describe("addQuoteCommand — a bridged message is archived under its AUTHOR (issue 2033)", () => {
+  it("drops the relay's nick and keeps the author wrapped", () => {
+    expect(addQuoteCommand(msg({ sender: "Gazzurbo", body: "<THREADelli> ciao mondo" }))).toBe(
+      "!addquote <THREADelli> ciao mondo",
+    );
+  });
+
+  // The divergence from Reply is the POINT of ruling 4, so it is asserted as a
+  // difference rather than as two independent literals: an implementation that
+  // shared the mention would archive `@THREADelli` and pass a strip-only check
+  // that merely looked for the author's name.
+  it("takes no mention, where Reply takes one", () => {
+    const relayed = msg({ sender: "Gazzurbo", body: "<THREADelli> ciao" });
+    expect(addQuoteCommand(relayed)).not.toContain("@");
+    expect(replyQuote(relayed)).toContain("@THREADelli");
+  });
+
+  it("leaves an unbridged row exactly as it was", () => {
+    expect(addQuoteCommand(msg({}))).toBe("!addquote <vjt> ciao mondo");
+  });
+
+  it("refuses a head that is not nick-shaped", () => {
+    expect(addQuoteCommand(msg({ body: "<3 you" }))).toBe("!addquote <vjt> <3 you");
+  });
+
+  // Same #1126 carve-out Reply makes, and the reason it exists lives on THIS
+  // side: rendering `* Gazzurbo <THREADelli> waves` as `<THREADelli> waves`
+  // would archive an action as something the person SAID.
+  it("never reads an ACTION as bridged — #1126 outranks the heuristic", () => {
+    expect(
+      addQuoteCommand(
+        msg({ kind: "action", sender: "Gazzurbo", body: "\x01ACTION <THREADelli> waves\x01" }),
+      ),
+    ).toBe("!addquote * Gazzurbo <THREADelli> waves");
+  });
+
+  it("refuses a body that is only the wrapping", () => {
+    expect(addQuoteCommand(msg({ sender: "Gazzurbo", body: "<THREADelli> " }))).toBeNull();
+  });
+
+  // The accumulating door (#1356) shares the payload builder, so it inherits
+  // the strip. Pinned because it is a SECOND call site of `attributionHead`,
+  // and a fix applied only to `addQuoteCommand` would leave it behind.
+  it("strips the relay when accumulating a second payload too", () => {
+    mountCompose();
+    addQuoteToCompose(msg({ sender: "ska", body: "primo" }), NET, CHAN);
+    addQuoteToCompose(msg({ id: 2, sender: "Gazzurbo", body: "<THREADelli> secondo" }), NET, CHAN);
+    expect(getDraft(KEY)).toBe("!addquote <ska> primo <THREADelli> secondo");
+  });
+});

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -494,3 +494,108 @@ describe("replyToMessage", () => {
     expect(getDraft(KEY)).toBe("<a> primo << ciao<b> secondo << ");
   });
 });
+
+// issue 2033 — a BRIDGE relays somebody else's words under its own IRC nick and
+// wraps the real author into the body:
+//
+//   <Gazzurbo> <THREADelli> ne parlavamo in un talk...
+//
+// `msg.sender` is then the RELAY, not the speaker. Quoting it names a bot and
+// buries the person being answered, and the far side receives three
+// attributions deep (`<vjt> <Gazzurbo> <THREADelli> …`).
+//
+// vjt's rulings (2026-09-10, relayed in the issue): detection is the head shape
+// ALONE — no configured relay list — and reply re-emits the recovered author as
+// `@nick`, a real mention on the far side, because this bridge relays the
+// Telegram USERNAME and not the display name.
+describe("replyQuote — a bridged message quotes its AUTHOR, not the relay (issue 2033)", () => {
+  it("drops the relay's nick and mentions the wrapped author", () => {
+    expect(
+      replyQuote(msg({ sender: "Gazzurbo", body: "<THREADelli> ne parlavamo in un talk" })),
+    ).toBe("@THREADelli ne parlavamo in un talk << ");
+  });
+
+  // The `@` is what makes the far side notify the person. Asserted apart from
+  // the shape above: an implementation that recovered the author but left it
+  // wrapped would pass a `toContain("THREADelli")` and still notify nobody.
+  it("leaves the relay's nick nowhere in the quote", () => {
+    const quote = replyQuote(msg({ sender: "Gazzurbo", body: "<THREADelli> ciao" })) ?? "";
+    expect(quote).toBe("@THREADelli ciao << ");
+    expect(quote).not.toContain("Gazzurbo");
+    expect(quote).not.toContain("<THREADelli>");
+  });
+
+  // The ACCEPTED LIMITATION, pinned as an assertion rather than left to be
+  // rediscovered as a bug report (vjt's ruling 1). Detection is structural, so
+  // a human writing `<foo> bar` IS read as a relay — and the cost is not a
+  // stray `@`: `alice`, the actual speaker, is DROPPED. Priced in knowingly.
+  it("misreads a human who writes `<foo> bar` — and drops her, knowingly", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<foo> bar" }))).toBe("@foo bar << ");
+  });
+
+  // The other half of the same ruling: what is NOT nick-shaped is not a relay.
+  // These are the shapes that keep ordinary prose out of the heuristic.
+  it("refuses a head that is not nick-shaped", () => {
+    expect(replyQuote(msg({ body: "<3 you" }))).toBe("<vjt> <3 you << ");
+    expect(replyQuote(msg({ body: "<two words> a" }))).toBe("<vjt> <two words> a << ");
+    expect(replyQuote(msg({ body: "<nospace>x" }))).toBe("<vjt> <nospace>x << ");
+  });
+
+  // The head must be at position 0, exactly as #1123 requires of a previous
+  // quote: mid-string, the leading text is the sender's own words.
+  it("refuses a wrapping that is not at the head of the body", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "guarda <bob> ciao" }))).toBe(
+      "<alice> guarda <bob> ciao << ",
+    );
+  });
+
+  // A relay line with nothing past the wrapping is nobody saying anything.
+  it("refuses a body that is only the wrapping", () => {
+    expect(replyQuote(msg({ sender: "Gazzurbo", body: "<THREADelli> " }))).toBeNull();
+  });
+
+  // vjt's ruling 5: the cap is measured on the body AFTER the relay head comes
+  // off — the head is not what overflows, the same reading #1235 already made
+  // for the nick. Discriminating by construction: `<THREADelli> ` is 13 chars
+  // and the body is 95, so the pre-cure string is 108 (capped, ellipsis) and
+  // the cured one is 95 (whole).
+  it("measures the 100-char cap on the body left AFTER the relay head", () => {
+    const words = "x".repeat(95);
+    const quote = replyQuote(msg({ sender: "Gazzurbo", body: `<THREADelli> ${words}` })) ?? "";
+    expect(quote).toBe(`@THREADelli ${words} << `);
+    expect(quote).not.toContain(REPLY_QUOTE_ELLIPSIS);
+  });
+
+  it("still caps a bridged body that overflows on its own", () => {
+    const words = "y".repeat(REPLY_QUOTE_BODY_LIMIT + 5);
+    const quote = replyQuote(msg({ sender: "Gazzurbo", body: `<THREADelli> ${words}` })) ?? "";
+    expect(quote).toBe(
+      `@THREADelli ${"y".repeat(REPLY_QUOTE_BODY_LIMIT)}${REPLY_QUOTE_ELLIPSIS}${REPLY_QUOTE_TAIL}`,
+    );
+  });
+
+  // NOT ruled, and decided here rather than left ambiguous: an ACTION row is
+  // never read as bridged. #1126 forbids rendering an action as speech, and
+  // `!addquote` — which shares this detection — would emit exactly that
+  // (`<THREADelli> waves` for something nobody said). No transcript of an
+  // action-shaped relay exists, so this falls back to today's behaviour, the
+  // same bounded silence rulings 1 and 3 already accept.
+  it("never reads an ACTION as bridged — #1126 outranks the heuristic", () => {
+    expect(
+      replyQuote(
+        msg({ kind: "action", sender: "Gazzurbo", body: "\x01ACTION <THREADelli> waves\x01" }),
+      ),
+    ).toBe("* Gazzurbo <THREADelli> waves << ");
+  });
+
+  // The ORDER of the two peels is forced, not free. #1123's cut runs FIRST: a
+  // plain reply body (`<bob> original<< answer`) opens with a nick wrapping
+  // too, so peeling the relay first would recover `bob` — who is being QUOTED,
+  // not speaking — and strand `original<< answer` past a cut that no longer
+  // matches. This is the test that fails if the two are swapped.
+  it("peels a previous quote BEFORE looking for a relay head", () => {
+    expect(replyQuote(msg({ sender: "alice", body: "<bob> original<< answer" }))).toBe(
+      "<alice> answer << ",
+    );
+  });
+});

--- a/cicchetto/src/lib/addQuote.ts
+++ b/cicchetto/src/lib/addQuote.ts
@@ -31,9 +31,15 @@ export const ADDQUOTE_COMMAND = "!addquote ";
 // that is the predictable shape, not the exception to it: each is the line the
 // scrollback showed. `attributionHead` is shared with `replyQuote` so the two
 // doors cannot drift.
+//
+// issue 2033 — `"wrapped"` is where this door parts from Reply's, and only
+// here: a bridged row is archived under the author the relay wrapped, spelled
+// as the scrollback spelled them. It takes NO `@` (vjt's ruling 4) because an
+// archive addresses nobody — a mention notifies a person, and there is no
+// person reading a quote database.
 export function addQuoteCommand(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
-  return body === null ? null : `${ADDQUOTE_COMMAND}${attributionHead(msg)} ${body}`;
+  return body === null ? null : `${ADDQUOTE_COMMAND}${attributionHead(msg, "wrapped")} ${body}`;
 }
 
 // #1356 — ONE verb, N payloads. What a long-press adds to THIS draft: the whole
@@ -59,7 +65,7 @@ export function addQuoteCommand(msg: ScrollbackMessage): string | null {
 export function addQuoteAppendText(draft: string, msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
-  const payload = `${attributionHead(msg)} ${body}`;
+  const payload = `${attributionHead(msg, "wrapped")} ${body}`;
   if (!draft.includes(ADDQUOTE_COMMAND)) return `${ADDQUOTE_COMMAND}${payload}`;
   return draft.endsWith(" ") ? payload : ` ${payload}`;
 }

--- a/cicchetto/src/lib/quotableBody.ts
+++ b/cicchetto/src/lib/quotableBody.ts
@@ -15,6 +15,11 @@ import { mircPlainText } from "./mircFormat";
 // around this, `addQuoteCommand` puts `!addquote ` in front of it. The
 // ATTRIBUTION is not: since #1264 both doors head the quote the same way, so
 // `attributionHead` lives here with the body it heads.
+//
+// issue 2033 added the one axis on which the two heads DIFFER — a bridge relay
+// is mentioned by Reply and left wrapped by the archive — as a parameter and
+// not a fork, because WHO spoke is the same question at both doors and only
+// how to spell them changes.
 
 // #1123 — the nick charset, mirrored from the server's
 // `Grappa.IRC.Identifier` `@nick_regex` (RFC 2812 §2.3.1: first char is
@@ -40,6 +45,59 @@ function withoutPreviousQuote(body: string): string {
   return body.replace(PREVIOUS_QUOTE, "").trim();
 }
 
+// issue 2033 — a BRIDGE relays somebody else's words under its own IRC nick and
+// wraps the real author into the body: `<Gazzurbo> <THREADelli> ne parlavamo…`.
+// `msg.sender` is then the RELAY. Quoting it names a bot, buries the person
+// being answered, and reaches the far side three attributions deep.
+//
+// Detection is the head shape ALONE — vjt's ruling (2026-09-10): no configured
+// relay list, no gating on anything else. `(?: |$)` rather than a bare space
+// because the body arrives `.trim()`ed, so a relay line whose author said
+// nothing (`<THREADelli> `) has already lost the space that would anchor it;
+// the same idiom `PREVIOUS_QUOTE` uses for its own tail.
+const BRIDGE_RELAY_HEAD = new RegExp(`^<(${NICK})>(?: |$)`);
+
+// How a RECOVERED author is spelled. The two doors diverge here and nowhere
+// else (vjt's ruling 4): a reply MENTIONS them, because `@nick` is what makes
+// the far side notify a person; an archive addresses nobody and so keeps them
+// WRAPPED, exactly as the scrollback rendered them.
+export type RelayedAuthorStyle = "mention" | "wrapped";
+
+// Who spoke, and what is left of what they said. One pass, because the head
+// the caller emits and the head the body sheds are the same finding — asking
+// the question twice is how the two doors would come to disagree about what a
+// relay looks like.
+//
+// THE ORDER OF THE TWO PEELS IS FORCED, not a preference. #1123's cut runs
+// FIRST: a plain reply body (`<bob> original<< answer`) opens with a nick
+// wrapping too, so looking for a relay first would recover `bob` — who is being
+// QUOTED, not speaking — and strand the rest past a cut that no longer matches.
+//
+// An ACTION is never read as bridged, and that is a decision the rulings did
+// not cover: #1126 forbids rendering an action as speech, and `!addquote`
+// shares this detection, so it would archive `<THREADelli> waves` as something
+// nobody said. No transcript of an action-shaped relay exists; this falls back
+// to today's behaviour, the same bounded silence rulings 1 and 3 accept.
+function attributed(msg: ScrollbackMessage): { author: string | null; body: string } {
+  // #1126 — an action's stored body is the raw `\x01ACTION …\x01` wire form.
+  // Unwrap it FIRST, with the same helper the render layer uses, so the quote
+  // holds the text the operator actually saw. `mircPlainText` deliberately
+  // leaves \x01 alone (its call sites need the envelope to round-trip), so
+  // stripping there would have been the wrong door.
+  const raw = msg.kind === "action" ? stripCtcpAction(msg.body) : (msg.body ?? "");
+  // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
+  // operator is quoting what they SEE, and a control byte round-tripped through
+  // compose would be re-sent as formatting they never chose.
+  // #1123 — the body being quoted may itself be a reply, carrying its own
+  // quote plus the `<< ` tail. Left in, every hop drags the whole history
+  // forward and the line actually being answered ends up buried mid-string.
+  const body = withoutPreviousQuote(mircPlainText(raw).trim());
+  if (msg.kind === "action") return { author: null, body };
+  const relay = BRIDGE_RELAY_HEAD.exec(body);
+  if (relay === null) return { author: null, body };
+  return { author: relay[1] ?? null, body: body.slice(relay[0].length).trim() };
+}
+
 // #1688 — the same question asked of a COMPOSE DRAFT rather than of a wire
 // body: does this string already open with a quote WE emitted?
 //
@@ -59,21 +117,11 @@ export function startsWithReplyQuote(text: string): boolean {
 export function quotableBody(msg: ScrollbackMessage): string | null {
   if (!isContentKind(msg.kind)) return null;
   if (msg.sender === "") return null;
-  // #1126 — an action's stored body is the raw `\x01ACTION …\x01` wire form.
-  // Unwrap it FIRST, with the same helper the render layer uses, so the quote
-  // holds the text the operator actually saw. `mircPlainText` deliberately
-  // leaves \x01 alone (its call sites need the envelope to round-trip), so
-  // stripping there would have been the wrong door.
-  const raw = msg.kind === "action" ? stripCtcpAction(msg.body) : (msg.body ?? "");
-  // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
-  // operator is quoting what they SEE, and a control byte round-tripped through
-  // compose would be re-sent as formatting they never chose.
-  // #1123 — the body being quoted may itself be a reply, carrying its own
-  // quote plus the `<< ` tail. Left in, every hop drags the whole history
-  // forward and the line actually being answered ends up buried mid-string.
-  // Dropping it can empty the body: a sender whose message was nothing but a
-  // quote said nothing to quote back.
-  const body = withoutPreviousQuote(mircPlainText(raw).trim());
+  // Dropping the previous quote — or the relay head (issue 2033) — can empty
+  // the body: a sender whose message was nothing but a quote said nothing to
+  // quote back, and a relay line with nothing past the wrapping is nobody
+  // saying anything.
+  const { body } = attributed(msg);
   return body === "" ? null : body;
 }
 
@@ -86,6 +134,13 @@ export function quotableBody(msg: ScrollbackMessage): string | null {
 // what the operator READ. Shared rather than written twice because the two
 // doors are now one rule, and a copy would let the next kind be added to one of
 // them only.
-export function attributionHead(msg: ScrollbackMessage): string {
+//
+// issue 2033 — when the row turns out to be a BRIDGE relay, the head names the
+// author the relay wrapped instead of the relay itself, spelled per `style`.
+// This stayed one function on purpose: the two doors differ by that parameter
+// and by nothing else, so neither can drift on WHAT a relay is.
+export function attributionHead(msg: ScrollbackMessage, style: RelayedAuthorStyle): string {
+  const { author } = attributed(msg);
+  if (author !== null) return style === "mention" ? `@${author}` : `<${author}>`;
   return msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
 }

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -49,7 +49,14 @@ export function replyQuote(msg: ScrollbackMessage): string | null {
   const body = quotableBody(msg);
   if (body === null) return null;
   // #1126's heads, shared with `!addquote` since #1264 — see `attributionHead`.
-  return `${attributionHead(msg)} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
+  //
+  // issue 2033 — `"mention"`: when the row is a bridge relay, the recovered
+  // author is emitted as `@nick`, which is what makes the far side notify them
+  // (vjt measured that his bridge relays the USERNAME, not the display name).
+  // The cap then falls on a body that has already shed the relay head, because
+  // `quotableBody` took it off — ruling 5, and the same reading #1235 made for
+  // the nick: the head is not what overflows.
+  return `${attributionHead(msg, "mention")} ${capQuotedBody(body)}${REPLY_QUOTE_TAIL}`;
 }
 
 // The marker and its trailing space — the part of the tail a second reply takes

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,66 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2033 -->
+
+---
+
+## 2026-09-10 — #2033: quoting the author a bridge relayed, not the bridge
+
+A bridge bot relays somebody else's words under its OWN IRC nick and wraps the
+real author into the body — `<Gazzurbo> <THREADelli> ne parlavamo…`. `msg.sender`
+is therefore the RELAY, so both quote doors credited a bot: Reply put
+`<Gazzurbo> <THREADelli> body << ` on the wire, arriving three attributions deep
+and addressing the author as plain text (notifying nobody), and `!addquote`
+archived that misattribution permanently, into a database where the channel
+context that would explain it no longer exists.
+
+### What vjt ruled (2026-09-10, relayed into the issue — not observed on IRC)
+
+Detection is the head shape ALONE: no configured relay list, no second gate. The
+false positive is priced in. `@name` does produce a real mention because this
+bridge relays the Telegram USERNAME, not the display name — which also settles
+the charset worry the issue raised, since a username is `[A-Za-z0-9_]` and the
+existing RFC 2812 `NICK` admits that in full. `!addquote` is in scope but takes
+STRIP ONLY, no `@`: an archive addresses nobody. The cap is measured on the body
+after the head comes off.
+
+### The limitation is a dropped speaker, not a stray `@`
+
+Worth restating because the cheap reading understates it. A human writing
+`<foo> bar` is read as a relay, and the cure then drops `alice` — the actual
+speaker — and answers `@foo`, who does not exist. Accepted knowingly, and pinned
+as an assertion in `replyQuote.test.ts` so it is a recorded decision rather than
+a bug report somebody files in six months.
+
+### Two decisions the rulings did not cover
+
+**An ACTION is never read as bridged.** #1126 forbids rendering an action as
+speech, and detection is SHARED with `!addquote`, which would otherwise archive
+`<THREADelli> waves` as something nobody said. No transcript of an action-shaped
+relay exists, so this falls back to today's behaviour — the same bounded,
+deliberate silence the accepted limitations already carry. The cost is that a
+genuinely action-shaped bridge stays unfixed; the alternative was inventing a
+shape for a case with no evidence behind it.
+
+**The order of the two peels is FORCED, not a preference.** #1123's
+previous-quote cut must run FIRST. A plain reply body (`<bob> original<< answer`)
+opens with a nick wrapping too, so looking for a relay first recovers `bob` — who
+is being QUOTED, not speaking — and strands the remainder past a cut that no
+longer matches. Measured, not argued: swapping the two kills 14 tests, 13 of them
+pre-existing #1123 guards. The consequence is a real gap, stated rather than
+hidden — a bridge relaying a line that was ITSELF a reply loses its author,
+because #1123's greedy cut consumes the relay head on its way to the tail.
+
+### Shape
+
+`attributionHead/1` became `attributionHead/2`, gaining a `RelayedAuthorStyle`
+(`"mention" | "wrapped"`). One shared site, one predicate, one parameter — a
+fork would let the two doors disagree about what a relay IS, which is the
+failure `quotableBody`'s own header warns about. The 100-char cap needed no edit
+to satisfy ruling 5: it has always been measured on what `quotableBody` returns,
+and that is now the body with the head already gone.
+
+_Not asserted: that `<nick> ` is the only bridged shape in the wild. One
+transcript exists, from one bridge, and no survey was made. Verified on chromium
+via vitest only — no real bridge, no Telegram, no device._


### PR DESCRIPTION
Closes nothing automatically — this is issue 2033, left open for the orchestrator.

## What was wrong

A bridge bot relays somebody else's words under its OWN IRC nick and wraps the real author into the body:

```
<+Gazzurbo> <THREADelli> ne parlavamo in un talk che telegram ha il vizio di non taggare...
```

`msg.sender` is the RELAY, so both quote doors credited a bot. Reply put `<Gazzurbo> <THREADelli> body << ` on the wire — arriving on the far side three attributions deep, with the actual author addressed as plain text and therefore notified by nobody. `!addquote` archived the same misattribution *permanently*, into a database where the channel context that would explain it is already gone.

## Provenance of the rulings — RELAYED, not observed

The four open questions in the issue were answered by vjt **in session** and relayed into the issue by the orchestrator. I did not see them on IRC. Everything below rests on that comment, not on my own observation, and one of them (`@name` produces a real mention because the bridge relays the USERNAME, not the display name) is a fact about a bridge I have never touched.

## What it does

Detection is the head shape **alone** — no configured relay list, no second gate. `attributionHead/1` became `attributionHead/2` and gained a `RelayedAuthorStyle`:

| | today | after |
|---|---|---|
| reply | `<Gazzurbo> <THREADelli> body << ` | `@THREADelli body << ` |
| `!addquote` | `<Gazzurbo> <THREADelli> body` | `<THREADelli> body` |

One shared site, one predicate, one parameter. A fork would let the two doors disagree about what a relay *is*, which is the exact failure `quotableBody`'s own header warns about.

The 100-char cap needed **no edit** to satisfy ruling 5: it has always been measured on what `quotableBody` returns, and that is now the body with the head already off.

## 🔴 The accepted limitation costs a SPEAKER, not a stray `@`

Stated plainly because the cheap reading understates it, and because it is a decision rather than an oversight. A human who writes `<foo> bar` is read as a relay. `alice` — the **actual speaker** — is then **dropped**, and the reply addresses `@foo`, who does not exist. Ruling 1 accepts this on exactly that understanding. It is pinned as an assertion in `replyQuote.test.ts`, not left to be re-filed as a bug in six months.

A bridge that relays *display names* is simply never detected and falls back to today's behaviour: bounded, silent, deliberate.

## Two decisions the rulings did NOT cover

I made both inside the slice and am flagging them rather than burying them.

**1. An ACTION is never read as bridged.** #1126 forbids rendering an action as speech, and this detection is *shared* with `!addquote` — which would otherwise archive `<THREADelli> waves` as something nobody said. No transcript of an action-shaped relay exists. Cost: a genuinely action-shaped bridge stays unfixed. The alternative was inventing a shape for a case with no evidence behind it.

**2. The order of the two peels is FORCED.** #1123's previous-quote cut must run first: a plain reply body (`<bob> original<< answer`) opens with a nick wrapping too, so looking for a relay first recovers `bob` — who is being *quoted*, not speaking. Measured, not argued: swapping them kills 14 tests, 13 of them pre-existing #1123 guards. **The gap this leaves, stated rather than hidden:** a bridged line that was *itself* a reply loses its author, because #1123's greedy cut eats the relay head on its way to the tail.

## Gates

| gate | result |
|---|---|
| `bun.sh run test` (full) | **6938 passed / 342 files**, rc=0 |
| `bun.sh run check` | **5 stages, 0 failed** (lock drift, test location, biome, tsc src, tsc e2e) |
| `design-notes-gate.sh` | `1 new entry heading(s), separator and marker present` |

TDD, red first: the 17 new tests were written before the cure and **10 failed** — exactly the 10 that assert the new behaviour. The other 7 pin the *unchanged* behaviour and were green on main already, so they are genuine negative controls rather than tautologies that light up with the fix.

### Mutation testing (scoped baseline 90/90 green; restore proven by empty `git diff` each time)

| mutant | tests killed |
|---|---|
| detection returns no author | 8 |
| the head is not stripped from the body | 9 |
| **the two peels swapped** | **14** (13 pre-existing #1123 guards) |
| the ACTION gate removed | 2 |
| reply emits `wrapped` instead of `mention` | 6 |

All five killed; tree restored to `a7abbb42a`, 90/90 green.

## 🔴 What I refuse to assert

- **That `@THREADelli` notifies anyone.** The whole value of the mention rests on vjt's ruling 2, relayed. I have not touched a bridge, a Telegram client, or a transcript beyond the one pasted in the issue.
- **That `<nick> ` is the only bridged shape in the wild.** One transcript, one bridge, no survey. matterbridge/teleirc/znc are unexamined.
- **That this holds anywhere but chromium/jsdom.** vitest only. No real bridge, no device, no e2e.
- **That the detection has no false positive I have not thought of.** I pinned the one the ruling names. The heuristic is structural and I did not enumerate the space of human sentences that open with a nick-shaped wrapping.

## Not run, and why

`scripts/integration.sh` and any e2e. **I am not requesting the stack lane and my reasoning is that an e2e would buy little here:** this slice is pure string transformation, with no geometry, no timing and no race, and the compose-box door is already exercised in jsdom by the pre-existing `replyToMessage` / `addQuoteToCompose` tests — including the accumulating `#1356` path, which I pinned as a second call site. The orchestrator's call if he disagrees.
