### PR TITLE
cic(topic): eight lines the box actually has, and an Enter that sets (issue 2035)

### DIFF
--- a/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
+++ b/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
@@ -1,0 +1,234 @@
+// issue 2035 — the topic edit box opens EIGHT text lines tall, and Enter sets
+// the topic instead of inserting a line break.
+//
+// Both halves of the issue, and both need a real engine for a different
+// reason:
+//
+//   (1) HEIGHT is geometry. jsdom has no layout engine, so vitest can only
+//       pin the `rows={8}` ATTRIBUTE (it does — TopicBar.test.tsx); whether
+//       eight LINES of text actually fit in the rendered box is a question
+//       only a browser answers. It is also the exact question the issue got
+//       wrong on paper: the old `min-height: 4.5em` was read as 4.5 / 1.25 =
+//       3.6 lines, but `* { box-sizing: border-box }` makes that figure
+//       include the padding and the border, so it rendered 3.0 — "solo tre
+//       righe", as reported — and the `10em` the issue derived for "8 lines"
+//       would have rendered 7.4 the same way. This spec measures the box
+//       instead of trusting arithmetic: content height ÷ computed
+//       line-height, which is drift-proof against both properties moving.
+//
+//   (2) ENTER's key handling is unit-covered (the preventDefault and the
+//       Shift+Enter pairing are jsdom's, per #974's every-Enter-sends rule),
+//       but what reaches the WIRE is not. Here an in-channel peer witnesses
+//       the real `TOPIC #chan :<flattened>`, which proves in one action both
+//       that Enter went through the send door and that the flatten SURVIVED
+//       the reversal: the draft is seeded via `fill()` — the paste-shaped
+//       route newlines still take now that Enter no longer types one — and a
+//       body with a raw \r/\n is rejected upstream (:invalid_line), so an
+//       unflattened submit never resolves the witness.
+//
+// The Enter behaviour REVERSES #263's documented decision ("Enter in the
+// textarea must stay a newline"). It is reversed because the product owner
+// ruled the asserted behaviour wrong, not because it was awkward to test —
+// and the premise was weak anyway, since the flatten spends the newline
+// before the send door regardless.
+//
+// 🔴 What this spec must NOT do: grow an Escape case. #232 makes the shared
+// overlay stack the single Esc authority and `issue263-topic-modal-edit.spec
+// .ts:114-124` already proves the edit-aware branch in a real browser with
+// the textarea focused. vjt confirmed Esc works (2026-09-10); that spec stays
+// untouched.
+//
+// Channel: a fresh per-run one, founded by vjt so he is chanop and the ✏️ is
+// offered past the default +t — the same reason `issue263-topic-modal-edit`
+// does it, and the same reason it does not mutate the shared autojoin
+// channel's topic (seed-expansion cascade hazard). PARTed in `finally`.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: a CSS layout
+// contract plus a topic send both users take through the same door —
+// registered vjt suffices, no visitor twin.
+
+import type { Locator, Page } from "@playwright/test";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, specNick, specUser, test } from "../fixtures/test";
+
+// The decided line count (vjt, 2026-09-10: "8 o 10", low end taken for the
+// phone viewport). It is the SAME number `rows={8}` carries in TopicBar.tsx —
+// stated once here so a future re-ruling has one place to move on this side.
+// NOT a #1646 mirror and deliberately not in that table: a mirror is a
+// production INPUT hand-copied into a fixture, where drift goes silently
+// green. This is the spec's ORACLE — production moving to ten turns this red,
+// which is the whole point of writing it down.
+const WANTED_TEXT_LINES = 8;
+
+type EditorGeometry = {
+  rows: number;
+  fontSizePx: number;
+  lineHeightPx: number;
+  paddingTopPx: number;
+  paddingBottomPx: number;
+  borderTopPx: number;
+  borderBottomPx: number;
+  // clientHeight excludes the border and INCLUDES the padding — the content
+  // box is what the text actually gets, and it is what "eight lines" is
+  // about. Subtracting them here is the whole correction the issue needed.
+  clientHeightPx: number;
+  contentHeightPx: number;
+  textLines: number;
+};
+
+async function measureEditor(editor: Locator): Promise<EditorGeometry> {
+  return await editor.evaluate((el) => {
+    const ta = el as HTMLTextAreaElement;
+    const cs = getComputedStyle(ta);
+    const num = (v: string): number => Math.round(Number.parseFloat(v) * 100) / 100;
+    const paddingTopPx = num(cs.paddingTop);
+    const paddingBottomPx = num(cs.paddingBottom);
+    const lineHeightPx = num(cs.lineHeight);
+    const contentHeightPx =
+      Math.round((ta.clientHeight - paddingTopPx - paddingBottomPx) * 100) / 100;
+    return {
+      rows: ta.rows,
+      fontSizePx: num(cs.fontSize),
+      lineHeightPx,
+      paddingTopPx,
+      paddingBottomPx,
+      borderTopPx: num(cs.borderTopWidth),
+      borderBottomPx: num(cs.borderBottomWidth),
+      clientHeightPx: ta.clientHeight,
+      contentHeightPx,
+      textLines: Math.round((contentHeightPx / lineHeightPx) * 100) / 100,
+    };
+  });
+}
+
+// Found a fresh channel, select it, and open the modal in EDIT mode. Returns
+// the editor locator. The retry absorbs the members/modes seed race (the op
+// sigil is not cached the instant the JOIN lands, so the ✏️ is not yet
+// rendered) — same shape as issue263-topic-modal-edit.
+async function openEditor(page: Page, channel: string): Promise<Locator> {
+  await composeSend(page, `/join ${channel}`);
+  await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 10_000 });
+  await selectChannel(page, NETWORK_SLUG, channel, { ownNick: specNick() });
+
+  const strip = page.locator('[data-testid="topic-strip"]');
+  const modal = page.locator(".topic-modal");
+  const editToggle = page.locator('[data-testid="topic-modal-edit"]');
+
+  await expect(async () => {
+    if (!(await modal.isVisible().catch(() => false))) {
+      await strip.click();
+    }
+    await expect(modal).toBeVisible({ timeout: 1_000 });
+    await expect(editToggle).toBeVisible({ timeout: 1_000 });
+  }).toPass({ timeout: 20_000 });
+
+  await editToggle.click();
+  const editor = page.locator('[data-testid="topic-modal-editor"]');
+  await expect(editor).toBeVisible();
+  return editor;
+}
+
+test.describe("issue 2035 topic editor: eight lines, Enter sets", () => {
+  test("the editor opens eight text lines tall, and Enter sends the flattened topic upstream", async ({
+    page,
+  }, testInfo) => {
+    const vjt = specUser();
+    const channel = `#e2e2035-${crypto.randomUUID().slice(0, 8)}`;
+    const line1 = `enter sets ${crypto.randomUUID().slice(0, 6)}`;
+    const multiline = `${line1}\nsecond line`;
+    const flattened = `${line1} second line`;
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+    const peer = await IrcPeer.connect({ nick: `e2e2035-${crypto.randomUUID().slice(0, 4)}` });
+    try {
+      const editor = await openEditor(page, channel);
+      await peer.join(channel);
+
+      // (1) HEIGHT — measured, not asserted from the stylesheet.
+      const geometry = await measureEditor(editor);
+      console.log(`[issue2035 desktop] ${JSON.stringify(geometry)}`);
+      await testInfo.attach("issue2035-editor-geometry-desktop", {
+        body: JSON.stringify(geometry, null, 2),
+        contentType: "application/json",
+      });
+      expect(geometry.rows, JSON.stringify(geometry)).toBe(WANTED_TEXT_LINES);
+      // Eight, not "at least eight": the low end of vjt's 8-or-10 was picked
+      // deliberately for the phone, so a silent drift UP is as wrong as down.
+      expect(geometry.textLines, JSON.stringify(geometry)).toBeGreaterThan(WANTED_TEXT_LINES - 0.1);
+      expect(geometry.textLines, JSON.stringify(geometry)).toBeLessThan(WANTED_TEXT_LINES + 0.1);
+
+      // (2) ENTER — `fill` seeds the newline the way a PASTE does (Enter no
+      // longer types one); `locator.press` focuses the box itself before the
+      // key, so the send door under test is the editor's own keydown and
+      // nothing else. The peer witness resolves ONLY on the flattened line.
+      await editor.fill(multiline);
+      const witnessed = peer.waitForTopic(channel, flattened);
+      await editor.press("Enter");
+      await witnessed;
+
+      // Enter took the same door ✅ takes, so it inherits the #263
+      // save-closes contract and the no-optimistic-write rule: the bar
+      // repaints only from the server's relayed topic_changed.
+      await expect(page.locator(".topic-modal")).toHaveCount(0, { timeout: 10_000 });
+      await expect(page.locator(".topic-bar-topic")).toContainText(flattened, { timeout: 10_000 });
+    } finally {
+      await peer.disconnect("e2e2035 done");
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
+
+  // The mobile-fit measurement the issue explicitly did NOT make ("no
+  // measurement of how the taller box lays out on any real viewport"). The
+  // failure it guards is the operator-visible one: a modal that is
+  // `position: fixed; top: 4rem` with no max-height and no scroller can push
+  // its own ✅ off the bottom of a phone, and the taller editor is the thing
+  // that would do it. @webkit is the reporter's platform family; @touch is
+  // the orthogonal Blink-mobile opt-in per the config's tag rules.
+  //
+  // 🔴 What this does NOT measure: the SOFT KEYBOARD. Focusing the editor on
+  // a real phone shrinks the visual viewport by roughly half, and Playwright
+  // raises no keyboard — so this proves the layout viewport fits, which is
+  // strictly weaker than "reachable while typing".
+  test("@webkit @touch on a phone viewport the modal — ✅ included — stays on screen", async ({
+    page,
+  }, testInfo) => {
+    const vjt = specUser();
+    const channel = `#e2e2035m-${crypto.randomUUID().slice(0, 8)}`;
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: specNick() });
+
+    try {
+      const editor = await openEditor(page, channel);
+      const geometry = await measureEditor(editor);
+
+      const fit = await page.locator(".topic-modal").evaluate((modal) => {
+        const box = modal.getBoundingClientRect();
+        const round = (n: number): number => Math.round(n * 10) / 10;
+        return {
+          viewportHeight: window.innerHeight,
+          modalTop: round(box.top),
+          modalBottom: round(box.bottom),
+          modalHeight: round(box.height),
+          slackBelow: round(window.innerHeight - box.bottom),
+        };
+      });
+      console.log(`[issue2035 phone] ${JSON.stringify({ ...geometry, ...fit })}`);
+      await testInfo.attach("issue2035-modal-fit-phone", {
+        body: JSON.stringify({ ...geometry, ...fit }, null, 2),
+        contentType: "application/json",
+      });
+
+      expect(geometry.textLines, JSON.stringify(geometry)).toBeGreaterThan(WANTED_TEXT_LINES - 0.2);
+      expect(fit.modalBottom, JSON.stringify(fit)).toBeLessThanOrEqual(fit.viewportHeight);
+      await expect(page.locator('[data-testid="topic-modal-save"]')).toBeInViewport();
+    } finally {
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
+});

--- a/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
+++ b/cicchetto/e2e/tests/issue2035-topic-editor-height.spec.ts
@@ -17,7 +17,8 @@
 //       line-height, which is drift-proof against both properties moving.
 //
 //   (2) ENTER's key handling is unit-covered (the preventDefault and the
-//       Shift+Enter pairing are jsdom's, per #974's every-Enter-sends rule),
+//       Shift+Enter pairing are jsdom's — the chord is RULED, vjt 2026-09-10,
+//       and agrees with #974's every-Enter-sends rule one surface over),
 //       but what reaches the WIRE is not. Here an in-channel peer witnesses
 //       the real `TOPIC #chan :<flattened>`, which proves in one action both
 //       that Enter went through the send door and that the flatten SURVIVED
@@ -71,10 +72,16 @@ type EditorGeometry = {
   paddingBottomPx: number;
   borderTopPx: number;
   borderBottomPx: number;
-  // clientHeight excludes the border and INCLUDES the padding — the content
-  // box is what the text actually gets, and it is what "eight lines" is
-  // about. Subtracting them here is the whole correction the issue needed.
+  // The BORDER box, fractional. `clientHeight` was the obvious reader and is
+  // the wrong one: it is an INTEGER, so it rounded 148.4 to 148 and reported
+  // 7.98 lines for a box that holds exactly eight — a measurement artefact
+  // arriving as a near miss, which is the one shape a height pin must not
+  // have. `getBoundingClientRect` keeps the subpixels.
+  borderBoxHeightPx: number;
   clientHeightPx: number;
+  // What the TEXT gets: border box less padding less border. Doing that
+  // subtraction is the whole correction the issue needed, since
+  // `* { box-sizing: border-box }` means neither is free.
   contentHeightPx: number;
   textLines: number;
 };
@@ -83,23 +90,29 @@ async function measureEditor(editor: Locator): Promise<EditorGeometry> {
   return await editor.evaluate((el) => {
     const ta = el as HTMLTextAreaElement;
     const cs = getComputedStyle(ta);
-    const num = (v: string): number => Math.round(Number.parseFloat(v) * 100) / 100;
+    const round = (n: number): number => Math.round(n * 100) / 100;
+    const num = (v: string): number => round(Number.parseFloat(v));
     const paddingTopPx = num(cs.paddingTop);
     const paddingBottomPx = num(cs.paddingBottom);
+    const borderTopPx = num(cs.borderTopWidth);
+    const borderBottomPx = num(cs.borderBottomWidth);
     const lineHeightPx = num(cs.lineHeight);
-    const contentHeightPx =
-      Math.round((ta.clientHeight - paddingTopPx - paddingBottomPx) * 100) / 100;
+    const borderBoxHeightPx = round(ta.getBoundingClientRect().height);
+    const contentHeightPx = round(
+      borderBoxHeightPx - paddingTopPx - paddingBottomPx - borderTopPx - borderBottomPx,
+    );
     return {
       rows: ta.rows,
       fontSizePx: num(cs.fontSize),
       lineHeightPx,
       paddingTopPx,
       paddingBottomPx,
-      borderTopPx: num(cs.borderTopWidth),
-      borderBottomPx: num(cs.borderBottomWidth),
+      borderTopPx,
+      borderBottomPx,
+      borderBoxHeightPx,
       clientHeightPx: ta.clientHeight,
       contentHeightPx,
-      textLines: Math.round((contentHeightPx / lineHeightPx) * 100) / 100,
+      textLines: round(contentHeightPx / lineHeightPx),
     };
   });
 }

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -39,7 +39,8 @@ import PaneTopBar, { PaneTopBarRailOpener } from "./PaneTopBar";
 // modal shows a ✏️ toggle. ✏️ swaps the topic text for a multi-line
 // <textarea> + ❌ cancel + ✅ save; the ✏️ disappears. ❌ cancel DISCARDS the
 // draft, reverts to read-only, brings the ✏️ back, and KEEPS the modal open.
-// ✅ save flattens newlines → submits via the EXISTING send doors (postTopic
+// ✅ save — or Enter inside the textarea, issue 2035 — flattens newlines →
+// submits via the EXISTING send doors (postTopic
 // REST for a non-empty set, pushChannelTopicClear WS verb for an empty clear —
 // one-feature-every-door, the same doors the `/topic` slashes use) and CLOSES
 // the modal on success. A server reject surfaces inline (S21 no-false-success)
@@ -54,6 +55,8 @@ import PaneTopBar, { PaneTopBarRailOpener } from "./PaneTopBar";
 // → :invalid_line). The <textarea> is a display/editing affordance only —
 // `flattenTopicNewlines` collapses every newline run to one space on submit
 // BEFORE the send door, so a multi-line edit reaches upstream as one line.
+// Still true after issue 2035 stopped Enter from inserting one: a PASTE
+// carries newlines in, and the flatten is what spends them.
 //
 // UX-4 bucket L (2026-05-19): the settings cog AND the left channel-
 // sidebar hamburger moved out of TopicBar into the cluster-wide
@@ -242,6 +245,35 @@ const TopicBar: Component<Props> = (props) => {
     }
   };
 
+  // issue 2035 — Enter SETS the topic. This REVERSES the #263 decision that
+  // used to be recorded a few lines down ("Enter in the textarea must stay a
+  // newline, save is the ✅ button only"): the product owner ruled the
+  // asserted behaviour wrong. The premise was weak besides — an IRC topic is
+  // ONE wire line, and `flattenTopicNewlines` spends every newline BEFORE the
+  // send door, so the break Enter bought was worth exactly one space and could
+  // never reach the wire as a break.
+  //
+  // EVERY Enter submits, modifier or not — #974, vjt's 2026-08-07 ruling on
+  // `ComposeBox`, the sibling surface with the same one-wire-line domain: a
+  // Shift+Enter that refuses also EATS the keystroke, and on his device the
+  // modifier arms itself on presses he never meant as Shift+Enter, so the send
+  // silently does not happen. Same operator, same chord, same answer here
+  // rather than a second semantics for it.
+  //
+  // 🔴 Escape is NOT handled here and must never be: #232 makes the shared
+  // overlay stack the SINGLE Esc authority (it deleted every per-dialog
+  // handler), and this modal's edit-aware close verb already lives on it —
+  // see `createOverlayLock` below. An element-level keydown for Enter is
+  // allowed to exist; one that grows an Escape branch is a second authority.
+  //
+  // `preventDefault` is what stops the textarea inserting its own break; the
+  // flatten STAYS regardless, because a PASTE still carries newlines in.
+  const onEditorKeyDown = (e: KeyboardEvent): void => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    void submitEdit();
+  };
+
   // #71 INC-2 — the per-channel presence-filter toggle (👁/🙈, #222) MOVED OUT
   // of the topic bar into the right-rail RailActions drawer (channel-gated). Q2
   // ruling: "one design" wants that toggle in the rail drawer on both form
@@ -264,10 +296,9 @@ const TopicBar: Component<Props> = (props) => {
   // `cancelEdit` (revert the draft, stay open, ✏️ back — the #263 cancel
   // contract), NOT `closeModal`. A naive `closeModal` here would tear down the
   // draft, violating #263. In read-only, Esc runs `closeModal` (the same verb
-  // the × / backdrop use). No element-level keydown on the textarea — the
-  // shared stack is the single ESC authority (#232 deleted all per-dialog
-  // handlers), and Enter in the textarea must stay a newline (save is the ✅
-  // button only), the flatten collapses it on submit.
+  // the × / backdrop use). The textarea's own keydown (issue 2035, above)
+  // handles Enter and NOTHING else — this stack remains the single ESC
+  // authority (#232 deleted all per-dialog handlers).
   createOverlayLock(
     () => modalState() === "open",
     ".topic-modal",
@@ -446,21 +477,28 @@ const TopicBar: Component<Props> = (props) => {
               }
             >
               {/* #263 — multi-line editor. IRC topics are one wire line, so
-                  newlines are flattened on submit (see submitEdit). NO
-                  Enter-to-submit: Enter inserts a newline; ✅ is the only save.
-                  NO element-level Esc handler — the shared #232 overlay stack
+                  newlines are flattened on submit (see submitEdit); a paste is
+                  the route they still arrive by. Enter SETS the topic (issue
+                  2035 — see onEditorKeyDown), ✅ is the other door. NO
+                  element-level Esc handler — the shared #232 overlay stack
                   owns Esc (edit-aware onEscape → cancelEdit). Seeded with the
-                  raw topic. */}
+                  raw topic.
+                  `rows` is the height knob (issue 2035): the platform's own
+                  "how many text lines", which tracks font-size + line-height
+                  by itself. See `.topic-modal-editor` for the min-height it
+                  replaced and the arithmetic that one got wrong. */}
               <textarea
                 class="topic-modal-editor"
                 data-testid="topic-modal-editor"
                 aria-label="edit topic"
                 placeholder="Set a topic…"
+                rows={8}
                 value={draft()}
                 ref={(el) => {
                   editorRef = el;
                 }}
                 onInput={(e) => setDraft(e.currentTarget.value)}
+                onKeyDown={onEditorKeyDown}
               />
               {/* #263 — inline submit-error surface (S21 no-false-success). */}
               <Show when={editError()}>

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -253,12 +253,18 @@ const TopicBar: Component<Props> = (props) => {
   // send door, so the break Enter bought was worth exactly one space and could
   // never reach the wire as a break.
   //
-  // EVERY Enter submits, modifier or not — #974, vjt's 2026-08-07 ruling on
-  // `ComposeBox`, the sibling surface with the same one-wire-line domain: a
-  // Shift+Enter that refuses also EATS the keystroke, and on his device the
-  // modifier arms itself on presses he never meant as Shift+Enter, so the send
-  // silently does not happen. Same operator, same chord, same answer here
-  // rather than a second semantics for it.
+  // EVERY Enter submits, modifier or not. The issue left Shift+Enter
+  // explicitly unruled; vjt then ruled it FOR THIS SURFACE — "anche
+  // shift-invio setta il topic" (2026-09-10, his words on #grappa, relayed
+  // in session; not observed on IRC by the author of this line).
+  //
+  // It agrees with #974, which is why the code predates the ruling rather
+  // than waiting on it: that is vjt's 2026-08-07 ruling on `ComposeBox`, the
+  // sibling surface with the same one-wire-line domain, reversing his own
+  // day-old split because a Shift+Enter that refuses also EATS the keystroke,
+  // and on his device the modifier arms itself on presses he never meant as
+  // Shift+Enter — so the send silently does not happen. One chord, one
+  // semantics, across both surfaces.
   //
   // 🔴 Escape is NOT handled here and must never be: #232 makes the shared
   // overlay stack the SINGLE Esc authority (it deleted every per-dialog

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -476,6 +476,100 @@ describe("TopicBar", () => {
       expect(screen.queryByTestId("topic-modal-editor")).toBeNull();
       expect(screen.getByTestId("topic-modal-edit")).toBeInTheDocument();
     });
+
+    // issue 2035 — Enter SETS the topic. This REVERSES #263's own decision
+    // ("Enter in the textarea must stay a newline, save is the ✅ button
+    // only"): vjt ruled the asserted behaviour wrong, and the premise it
+    // rested on was weak anyway — `flattenTopicNewlines` spends every newline
+    // BEFORE the send door, so the line break Enter bought could never reach
+    // the wire as anything but a space.
+    describe("Enter sets the topic (issue 2035)", () => {
+      it("Enter submits the FLATTENED draft through the same door ✅ uses, and closes", async () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        // A draft that already CARRIES newlines (a paste — the route that
+        // survives Enter no longer inserting one). The flatten must still run.
+        fireEvent.input(editor, { target: { value: "line one\nline two" } });
+        fireEvent.keyDown(editor, { key: "Enter" });
+        expect(postTopicMock).toHaveBeenCalledWith(
+          "tok-test",
+          "freenode",
+          "#italia",
+          "line one line two",
+        );
+        await settle();
+        expect(screen.queryByRole("dialog")).toBeNull();
+      });
+
+      it("Enter is preventDefault'd, so the textarea never inserts the line break", () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "one line" } });
+        // fireEvent returns false when the event was cancelled. jsdom does not
+        // insert the break itself, so the cancellation IS the observable.
+        expect(fireEvent.keyDown(editor, { key: "Enter" })).toBe(false);
+      });
+
+      it("Shift+Enter sets the topic too — EVERY Enter sends (#974)", () => {
+        // Not invented here: #974 is vjt's 2026-08-07 ruling on the SIBLING
+        // surface (ComposeBox), reversing his own day-old split. A Shift+Enter
+        // that refuses also EATS the keystroke, and on his device the modifier
+        // arms itself on presses he never meant as Shift+Enter — so the
+        // message silently does not go. Same operator, same device, same
+        // one-wire-line domain: the topic editor answers it the same way
+        // rather than growing a second semantics for the same chord.
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "shifted" } });
+        expect(fireEvent.keyDown(editor, { key: "Enter", shiftKey: true })).toBe(false);
+        expect(postTopicMock).toHaveBeenCalledWith("tok-test", "freenode", "#italia", "shifted");
+      });
+
+      // #232 guardrail — the new element-level keydown may exist, but it must
+      // NOT become a second ESC authority. The isolation is that `keybindings`
+      // (the ONE global keydown listener, which drives the shared overlay
+      // stack) is never installed in this file, so the element handler is the
+      // only thing an Escape can reach here: an Escape branch smuggled into it
+      // kills the draft right here, and nothing else can.
+      //
+      // 🔴 The event MUST bubble. Solid DELEGATES `onKeyDown` to the document
+      // root, so a `bubbles: false` dispatch never reaches the handler at all
+      // and this test passes with the smuggled branch in place — measured, it
+      // is how the first version of it survived its own mutant.
+      it("the editor's keydown ignores Escape — the shared stack keeps that authority", () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        const editor = screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement;
+        fireEvent.input(editor, { target: { value: "still here" } });
+        expect(fireEvent.keyDown(editor, { key: "Escape" })).toBe(true);
+        expect((screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement).value).toBe(
+          "still here",
+        );
+        // Still EDITING — no revert, no close.
+        expect(screen.queryByTestId("topic-modal-edit")).toBeNull();
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // issue 2035 height half. `rows` is the production knob — the platform's
+      // own "how many text lines", which tracks font-size and line-height by
+      // itself, where the `min-height` it replaces had to restate both and got
+      // the arithmetic wrong (see the CSS comment). jsdom has no layout, so
+      // this pins the ATTRIBUTE only; the rendered pixels are measured in
+      // e2e/tests/issue2035-topic-editor-height.spec.ts.
+      it("the editor opens eight text lines tall", () => {
+        withTopic("Old topic");
+        render(() => <TopicBar {...baseProps()} />);
+        enterEdit();
+        expect((screen.getByTestId("topic-modal-editor") as HTMLTextAreaElement).rows).toBe(8);
+      });
+    });
   });
 
   // #219-general — the topic modal COVERS the ScrollbackPane (fixed

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -514,14 +514,15 @@ describe("TopicBar", () => {
         expect(fireEvent.keyDown(editor, { key: "Enter" })).toBe(false);
       });
 
-      it("Shift+Enter sets the topic too — EVERY Enter sends (#974)", () => {
-        // Not invented here: #974 is vjt's 2026-08-07 ruling on the SIBLING
-        // surface (ComposeBox), reversing his own day-old split. A Shift+Enter
-        // that refuses also EATS the keystroke, and on his device the modifier
-        // arms itself on presses he never meant as Shift+Enter — so the
-        // message silently does not go. Same operator, same device, same
-        // one-wire-line domain: the topic editor answers it the same way
-        // rather than growing a second semantics for the same chord.
+      it("Shift+Enter sets the topic too — EVERY Enter sends", () => {
+        // RULED, not derived. The issue left this chord open; vjt settled it
+        // for this surface — "anche shift-invio setta il topic" (2026-09-10,
+        // relayed in session). It agrees with #974, his 2026-08-07 ruling on
+        // the SIBLING surface (ComposeBox), which reversed his own day-old
+        // split: a Shift+Enter that refuses also EATS the keystroke, and on
+        // his device the modifier arms itself on presses he never meant as
+        // Shift+Enter — so the message silently does not go. One chord, one
+        // semantics, on both surfaces.
         withTopic("Old topic");
         render(() => <TopicBar {...baseProps()} />);
         enterEdit();

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3204,10 +3204,23 @@ html.resize-dragging * {
    the #74 inline-strip <input>); editing happens here, inside the modal, in a
    roomy multi-line <textarea>. IRC topics are one wire line — newlines are
    flattened on submit (TopicBar.submitEdit); the textarea is a display-only
-   affordance. */
+   affordance.
+
+   issue 2035 — the height is `rows={8}` on the element now (TopicBar.tsx),
+   NOT a min-height here, and that is the whole cure rather than a bigger
+   number. The `min-height: 4.5em` this replaces was read as 4.5 / 1.25 = 3.6
+   text lines, and it never was: `* { box-sizing: border-box }` makes that
+   figure include the 0.6rem vertical padding and the 2px border, so at the
+   14px root it left 52.6px of content over a 17.5px line box — 3.0 lines,
+   which is exactly the "solo tre righe" the issue was filed about. Carrying
+   the same mistake forward, the 10em quoted for "8 lines" would have rendered
+   7.4. `rows` is the platform's own line count: it tracks font-size and
+   line-height by itself and cannot drift from them, so there is no arithmetic
+   left to get wrong. `resize: vertical` STAYS — an operator who wants more
+   drags. Below, the global form-control `min-height: var(--tap-min)` is the
+   only floor a drag meets, which is the tap-target one and correct. */
 .topic-modal-editor {
   width: 100%;
-  min-height: 4.5em;
   box-sizing: border-box;
   resize: vertical;
   background: var(--bg);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50402,3 +50402,103 @@ issue specifies. Both are small, localised changes if the answers differ.
 _Not asserted: that the pref reaches every surface has been measured through
 the chokepoint (one parse caller, zero palette consumers elsewhere), not by
 exercising all twelve in a browser. The e2e covers one channel-pane line._
+<!-- entry #2035 -->
+
+---
+
+## 2026-09-10 — #2035: eight lines the box actually has, and an Enter that sets
+
+Two asks from dogfood, and they turned out to be different kinds of thing: one
+is a reversed decision, the other is an arithmetic bug that had been sitting in
+a comment-free stylesheet since #263.
+
+### Enter sets the topic — a reversal, on a ruling
+
+`TopicBar.tsx` used to carry this, in as many words: *"Enter in the textarea
+must stay a newline (save is the ✅ button only), the flatten collapses it on
+submit."* That is now false, and the reason it is false is that the product
+owner ruled the asserted behaviour wrong. Recording the reason matters more
+than recording the change: the decision was not flaky, not awkward to test, and
+not inconvenient — it was a product call, and it was reversed by the only
+person who can reverse one.
+
+It is worth adding that the premise it rested on was weak. An IRC topic is ONE
+wire line; the server rejects a body carrying `\r`/`\n` outright
+(`Identifier.safe_line_token?` → `:invalid_line`), and `flattenTopicNewlines`
+collapses every newline run to a single space BEFORE the send door. So the line
+break Enter bought was worth exactly one space and could never reach the wire
+as a break. The decision was defending a cosmetic that the next function call
+spent.
+
+**Shift+Enter was NOT ruled**, and the issue says so. It is answered here by
+#974 rather than by invention: vjt's 2026-08-07 ruling on `ComposeBox` — the
+sibling surface, same operator, same one-wire-line domain — reversed his own
+day-old split with the measurement that *a Shift+Enter that refuses also EATS
+the keystroke*, and that on his device the modifier arms itself on presses he
+never meant as Shift+Enter, so the send silently does not happen. Growing a
+second semantics for the same chord on a second surface is exactly the
+"whatever pattern is closest gets propagated" failure CLAUDE.md warns about, so
+the topic editor answers the chord the way the composer does: every Enter
+sends, modifier or not.
+
+Two guardrails, both held. The new element-level `keydown` handles `Enter` and
+returns on everything else — it is **not** a second ESC authority, which #232
+made the shared overlay stack's alone, and whose edit-aware branch already has
+real-browser coverage in `issue263-topic-modal-edit.spec.ts`. And **the flatten
+stays**: Enter no longer types a newline, but a PASTE still carries them in,
+which is now the route it exists for.
+
+### Three lines were not a preference — they were `box-sizing`
+
+The issue asked for eight lines and derived `min-height: 10em` from
+`4.5em / 1.25 = 3.6 lines`. Both halves of that arithmetic are wrong in the
+same way, and the wrongness is measurable rather than arguable.
+
+`* { box-sizing: border-box }` is global in `default.css`, and `html` sets
+`font-size: var(--font-size)`, so at the 14px root a `min-height` is a BORDER
+box: it swallows the editor's `0.3rem` vertical padding on each side and its
+1px borders before the text sees a pixel. The old `4.5em` = 63px therefore left
+`63 − 8.4 − 2 = 52.6px` of content over a `1.25 × 14 = 17.5px` line box —
+**3.0 lines, not 3.6**. Which is precisely the *"mo è solo tre righe"* that was
+reported: the operator counted correctly and the stylesheet's arithmetic did
+not. Carried forward unchanged, the `10em` quoted for "8 lines" would have
+rendered **7.4**.
+
+The cure is not a bigger number. `rows={8}` on the element is the platform's
+own line count: it tracks `font-size` and `line-height` by itself, cannot
+disagree with them, and leaves no coupled arithmetic for the next reader to get
+wrong — the `min-height` is deleted rather than corrected. `resize: vertical`
+stays, so an operator who wants more drags; the only floor a drag now meets is
+the global form-control `min-height: var(--tap-min)`, which is the tap-target
+one and correct.
+
+### Where each half is proven, and one test that lied
+
+The split is forced by the tooling. jsdom has no layout engine, so vitest pins
+the `rows` ATTRIBUTE, the `preventDefault`, the Shift+Enter pairing and the
+Esc-guardrail; `e2e/tests/issue2035-topic-editor-height.spec.ts` measures the
+rendered box (content height ÷ computed line-height, drift-proof against both
+properties moving) and witnesses the real `TOPIC #chan :<flattened>` from an
+in-channel peer after a keyboard `Enter`.
+
+🔴 **A Solid element handler cannot be probed with a non-bubbling event.** The
+first version of the Esc guardrail dispatched `keydown` with `bubbles: false`,
+reasoning that this isolated the element handler from the shared stack. It
+passed — and it also passed with an `Escape` branch deliberately smuggled into
+the handler, which is how it was caught: Solid DELEGATES `onKeyDown` to the
+document root, so a non-bubbling dispatch reaches no handler at all and the
+test asserted nothing. The isolation that does work is structural: `keybindings`
+(the one global keydown listener) is never installed in that test file, so a
+normally-bubbling Escape can only reach the element handler. The mutant dies
+now. The general rule is worth more than the fix — **a "the handler ignores X"
+test must be shown to fail when the handler stops ignoring X**, because the
+event never arriving looks exactly like the event being ignored.
+
+_Not asserted. The phone measurement is against the LAYOUT viewport (iPhone 15
+and Pixel 7 descriptors): Playwright raises no soft keyboard, and focusing the
+editor on a real phone roughly halves the visual viewport, so "the modal fits
+above the fold" is strictly weaker than "the ✅ is reachable while typing".
+Neither is the IME case covered: like `ComposeBox` before it, this handler has
+no `isComposing` guard, so an Enter that confirms a candidate mid-composition
+submits. That is a shared gap of the two surfaces and wants one issue over both,
+not a divergence introduced on one of them here._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -50430,16 +50430,20 @@ break Enter bought was worth exactly one space and could never reach the wire
 as a break. The decision was defending a cosmetic that the next function call
 spent.
 
-**Shift+Enter was NOT ruled**, and the issue says so. It is answered here by
-#974 rather than by invention: vjt's 2026-08-07 ruling on `ComposeBox` — the
-sibling surface, same operator, same one-wire-line domain — reversed his own
-day-old split with the measurement that *a Shift+Enter that refuses also EATS
-the keystroke*, and that on his device the modifier arms itself on presses he
-never meant as Shift+Enter, so the send silently does not happen. Growing a
-second semantics for the same chord on a second surface is exactly the
-"whatever pattern is closest gets propagated" failure CLAUDE.md warns about, so
-the topic editor answers the chord the way the composer does: every Enter
-sends, modifier or not.
+**Shift+Enter was left unruled by the issue, and is RULED now**: *"anche
+shift-invio setta il topic"* — vjt, 2026-09-10, his words on #grappa relayed in
+session rather than read off IRC by the implementer, which is worth stating
+because it is the provenance of the whole slice.
+
+The code predates the ruling and did not have to guess, because #974 already
+answered the same question one surface over: vjt's 2026-08-07 ruling on
+`ComposeBox` — same operator, same device, same one-wire-line domain — reversed
+his own day-old split with the measurement that *a Shift+Enter that refuses
+also EATS the keystroke*, and that on his device the modifier arms itself on
+presses he never meant as Shift+Enter, so the send silently does not happen.
+Growing a second semantics for the same chord on a second surface is exactly
+the "whatever pattern is closest gets propagated" failure CLAUDE.md warns
+about. One chord, one semantics: every Enter sends, modifier or not, on both.
 
 Two guardrails, both held. The new element-level `keydown` handles `Enter` and
 returns on everything else — it is **not** a second ESC authority, which #232


### PR DESCRIPTION
Two dogfood asks on the topic modal (issue 2035): the edit box opens three
lines tall, and Enter inserts a newline instead of setting the topic. Section 3
of the issue (Esc cancels) is **already implemented and confirmed working by
vjt** — nothing was built there and `issue263-topic-modal-edit.spec.ts` is
untouched.

## Provenance of the rulings in this PR

Both product decisions below reached me **relayed**: vjt's words, passed on by
the orchestrator in session. I did not read them on IRC myself. Stating it
because the whole slice rests on them.

- **Height:** eight lines ("8 o 10", low end taken for the phone viewport).
- **Shift+Enter:** *"anche shift-invio setta il topic"* — 2026-09-10. The issue
  left this chord explicitly unruled; it is **RULED for this surface** now, not
  inferred by me.

## 🔴 This reverses a documented decision

`TopicBar.tsx` carried the opposite in as many words:

> No element-level keydown on the textarea — the shared stack is the single ESC
> authority (#232 deleted all per-dialog handlers), and **Enter in the textarea
> must stay a newline** (save is the ✅ button only), the flatten collapses it
> on submit.

That decision is reversed because **the product owner ruled the asserted
behaviour wrong**. Not because it was flaky, not because it was awkward to
test, not because it was inconvenient to keep — a product call, reversed by the
only person who can reverse one.

Worth adding that the premise was weak, which is why the reversal is reasonable
rather than a whim: an IRC topic is ONE wire line, the server rejects a body
carrying `\r`/`\n` outright (`Identifier.safe_line_token?` → `:invalid_line`),
and `flattenTopicNewlines` collapses every newline run to a single space
*before* the send door. The line break Enter bought was worth exactly one space
and could never reach the wire as a break.

### Shift+Enter

Every Enter sends, modifier or not. The implementation predates the ruling and
did not have to guess, because **#974** already answered the same question one
surface over: vjt's 2026-08-07 ruling on `ComposeBox` — same operator, same
device, same one-wire-line domain — reversed his own day-old split with the
measurement that *a Shift+Enter that refuses also EATS the keystroke*, and that
on his device the modifier arms itself on presses he never meant as that chord.
The 2026-09-10 ruling now settles it here directly. One chord, one semantics,
on both surfaces.

### Both guardrails held

1. **Not a second ESC authority.** The new element-level `keydown` handles
   `Enter` and returns on everything else. #232's shared overlay stack keeps
   Esc, and its edit-aware branch is unchanged.
2. **The flatten stays.** Enter no longer types a newline, but a PASTE still
   carries them in — which is now the route the flatten exists for. The e2e
   seeds the draft through exactly that route.

## The height was an arithmetic bug, not a preference

The issue derived `min-height: 10em` for eight lines from `4.5em / 1.25 = 3.6`.
Both halves are wrong the same way, and it is measurable rather than arguable.

`* { box-sizing: border-box }` is global in `default.css` and `html` sets
`font-size: var(--font-size)`, so a `min-height` is a BORDER box — it swallows
the editor's padding and border before the text sees a pixel:

| | measured |
|---|---|
| old `min-height: 4.5em` @ 14px root | 63px border box |
| less `0.3rem` padding ×2, `1px` border ×2 | 52.6px of content |
| over a `1.25 × 14` line box | **3.0 lines — not 3.6** |

Which is exactly the *"mo è solo tre righe"* that was reported: the operator
counted correctly, the stylesheet's arithmetic did not. Carried forward
unchanged, the `10em` quoted for "eight" would have rendered **7.4**.

**So the cure is not a bigger number.** `rows={8}` on the element is the
platform's own line count: it tracks `font-size` and `line-height` by itself,
cannot disagree with them, and leaves no coupled arithmetic for the next reader
to get wrong. The `min-height` is deleted rather than corrected.
`resize: vertical` stays; the only floor a drag now meets is the global
form-control `min-height: var(--tap-min)`, which is the tap-target one.

### Measured, in a real browser

`textLines` = content height ÷ computed line-height, so it stays true if either
property moves.

| project | rows | line box | content | **text lines** | modal | viewport | slack below |
|---|---|---|---|---|---|---|---|
| chromium (desktop) | 8 | 17.5px | 139.98px | **8.00** | — | — | — |
| chromium-pixel-touch (Pixel 7) | 8 | 17.5px | 139.98px | **8.00** | 56 → 297.6 (241.6px) | 839 | 541.4px |
| webkit-iphone-15 | 8 | 17.5px | 139.98px | **8.00** | 56 → 297.6 (241.6px) | 659 | 361.4px |

The phone rows are the measurement the issue explicitly declined to make. The
modal is `position: fixed; top: 4rem` with no max-height and no scroller, so a
taller editor is precisely the thing that could push its own ✅ off the bottom
— it does not, with 361px to spare on an iPhone 15.

**Arithmetic on top of that measurement, not itself a measurement:** an iOS
portrait keyboard is roughly 290–340px, which would leave ~320–370px of visual
viewport. The modal bottom sits at 297.6px, so it still lands inside — but ten
lines instead of eight adds 2 × 17.5 = 35px and puts it at 332.6px, i.e. at or
past the edge of that band. That is a quantified argument for taking the low
end, and it is arithmetic, not something I raised a keyboard to see.

## Tests

**New, 5 in vitest + 2 in Playwright (3 project runs).**

jsdom pins what jsdom can see: Enter submits the FLATTENED draft through the
same door ✅ uses; Enter is `preventDefault`'d; Shift+Enter submits too; the
handler ignores Escape; `rows === 8`. The e2e measures the rendered box and
witnesses the real `TOPIC #chan :<flattened>` from an in-channel peer after a
keyboard Enter — one action proving both the new door and the surviving
flatten, since an unflattened body is rejected upstream and the witness would
never resolve.

**Mutation control, restoration proven byte-identical after each:**

| mutant | result |
|---|---|
| drop `e.preventDefault()` | 2 red |
| `rows={8}` → `rows={3}` | 1 red |
| smuggle an `Escape` branch into the handler | **survived at first — see below**, 1 red after the fix |
| gate Enter on `!e.shiftKey` | 1 red |

🔴 **The Esc-guardrail test was vacuous and the mutant is what caught it.** Its
first version dispatched `keydown` with `bubbles: false`, reasoning that this
isolated the element handler from the shared stack. It passed — and it passed
with the Escape branch deliberately smuggled in, because **Solid DELEGATES
`onKeyDown` to the document root**, so a non-bubbling dispatch reaches no
handler at all. The isolation that works is structural: `keybindings` (the one
global keydown listener) is never installed in that test file. The general rule
is recorded in DESIGN_NOTES because it outlives this file: a *"the handler
ignores X"* test must be shown to fail when the handler stops ignoring X, since
an event that never arrives looks exactly like an event being ignored.

## Gates

| gate | result |
|---|---|
| `bun.sh run check` | rc=0 — 5 stages, 0 failed |
| `bun.sh run test` | rc=0 — **342 files / 6926 tests** (baseline 6921, +5) |
| `integration.sh --grep "issue 2035"` | rc=0 — 3 passed |
| `design-notes-gate.sh` | rc=0 — 1 entry, separator and marker present |

Two earlier full-vitest runs were red with 3 hook timeouts under the load of a
concurrent dependency install; both files went green on isolated rerun and the
final full run is green. Recorded rather than dropped.

## What this does NOT claim

- **The phone numbers are the LAYOUT viewport.** Playwright raises no soft
  keyboard, so "the modal fits above the fold" is strictly weaker than "the ✅
  is reachable while typing". The keyboard arithmetic above is arithmetic.
- **The IME case is not covered, and the gap is shared.** This handler has no
  `isComposing` guard — neither does `ComposeBox`'s Enter — so an Enter that
  confirms a candidate mid-composition submits. I deliberately did NOT add a
  guard on one surface only: that would be the divergence this PR argues
  against everywhere else. It is filed over both surfaces as
  [issue 2041](https://github.com/vjt/grappa-irc/issues/2041), and is a
  declared gap of this PR rather than something it introduces — the behaviour
  predates it on the composer and arrives unchanged on the topic editor.
- **`scripts/integration.sh` was run scoped, not whole.** A scoped `--grep`
  pass proves one spec green while the suite may be red; the full suite is the
  ship gate and it is not mine to declare.
- **Nothing about `#2036` / `#2038`.** No file overlap with either beyond
  `docs/DESIGN_NOTES.md` (union-merged, unique `<!-- entry -->` marker, gate
  green).
